### PR TITLE
feat(rules): placeholder tokens in action fields + task snooze visibility

### DIFF
--- a/apps/web/src/components/record-rules/ui/action-token-input.tsx
+++ b/apps/web/src/components/record-rules/ui/action-token-input.tsx
@@ -1,0 +1,344 @@
+// apps/web/src/components/record-rules/ui/action-token-input.tsx
+
+'use client'
+
+import {
+  ACTION_TOKEN_RECORD_NAME,
+  isActionDoc,
+  isRuleActionToken,
+  legacyActionTextToDoc,
+  SIGNAL_CONTEXT_TOKENS,
+} from '@auxx/lib/record-rules/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import type { TiptapDoc } from '@auxx/lib/tiptap'
+import { fieldRefToKey } from '@auxx/types/field'
+import { Badge } from '@auxx/ui/components/badge'
+import {
+  CommandGroup,
+  CommandItem,
+  CommandNavigation,
+  useCommandNavigation,
+} from '@auxx/ui/components/command'
+import type { JSONContent } from '@tiptap/core'
+import Placeholder from '@tiptap/extension-placeholder'
+import { type Editor, EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { Braces, Radio } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  createPlaceholderNode,
+  getOpenPickerRange,
+  type InlineNodeBadgeProps,
+  InlinePickerPopover,
+  PlaceholderBadge,
+  ReferencePickerNode,
+  stableStringify,
+  stripOpenChips,
+  useActivePicker,
+} from '~/components/editor/inline-picker'
+import {
+  FieldPickerInnerContent,
+  type FieldPickerNavigationItem,
+} from '~/components/pickers/field-picker'
+
+/**
+ * A fresh empty action doc — the add-action / type-switch default for the token-bearing
+ * fields (`create-task.title`, `notify.message`, `set-field.value`). Fails every
+ * completeness check until the user types, so an untouched action stays invalid.
+ */
+export function emptyActionDoc(): TiptapDoc {
+  return { type: 'doc', content: [{ type: 'paragraph' }] }
+}
+
+/**
+ * Normalize an incoming action field value to a Tiptap doc for the editor. Docs pass
+ * through; anything else (a stray string, a raw set-field primitive) is defensively
+ * converted via `legacyActionTextToDoc`.
+ */
+function toDoc(value: unknown): TiptapDoc {
+  if (isActionDoc(value)) return value
+  if (typeof value === 'string') return legacyActionTextToDoc(value)
+  return legacyActionTextToDoc(value == null ? '' : String(value))
+}
+
+/**
+ * Chip renderer for action-token placeholder nodes. Rule-specific tokens
+ * (`record:name`, `signal:*`) render as plain labeled badges — they aren't in the
+ * shared placeholder catalog, so `PlaceholderBadge` would flag them unresolved.
+ * Everything else (field tokens) reuses `PlaceholderBadge` and gets the breadcrumb
+ * label + fallback/format popover for free.
+ */
+function ActionTokenBadge(props: InlineNodeBadgeProps) {
+  const { id, selected } = props
+  if (isRuleActionToken(id)) {
+    const label =
+      id === ACTION_TOKEN_RECORD_NAME
+        ? 'Record name'
+        : (SIGNAL_CONTEXT_TOKENS.find((t) => t.id === id)?.label ?? id)
+    return (
+      <Badge
+        variant='pill'
+        size='sm'
+        data-selected={selected || undefined}
+        className='h-5 mx-0.5 px-1.5 py-0 text-xs align-baseline inline-flex items-center'
+        title={id}>
+        {label}
+      </Badge>
+    )
+  }
+  // A signal-ish id that isn't a known token (e.g. hand-typed `signal:foo`) — flag it.
+  if (id.startsWith('signal:')) {
+    return (
+      <Badge
+        variant='destructive'
+        size='sm'
+        data-selected={selected || undefined}
+        className='h-5 mx-0.5 px-1.5 py-0 text-xs align-baseline inline-flex items-center'
+        title={id}>
+        {id}
+      </Badge>
+    )
+  }
+  return <PlaceholderBadge {...props} />
+}
+
+// Module-level extensions — no props captured, safe to share across instances.
+const placeholderNode = createPlaceholderNode((props) => <ActionTokenBadge {...props} />)
+const pickerNode = ReferencePickerNode.configure({
+  triggers: [{ char: '{', kind: 'command', allowedPrefixes: null }],
+})
+
+/** Case-insensitive substring match for the custom (non-field) picker items. */
+function matchesSearch(label: string, search: string): boolean {
+  return !search || label.toLowerCase().includes(search.toLowerCase().trim())
+}
+
+interface ActionTokenPickerProps {
+  entityDefinitionId: string
+  fields: ResourceField[]
+  isSignalRule: boolean
+  onSelect: (id: string) => void
+  onClose: () => void
+}
+
+/**
+ * Command-rooted picker body: the rule's record fields (with relationship drill-down
+ * via `FieldPickerInnerContent`), a 'Record name' token, and — on signal rules — the
+ * signal-context tokens. Field selections are emitted as placeholder ids via
+ * `fieldRefToKey`, the exact scheme `tryParsePlaceholderId` parses back.
+ */
+function ActionTokenPicker(props: ActionTokenPickerProps) {
+  return (
+    <CommandNavigation<FieldPickerNavigationItem>>
+      <ActionTokenPickerInner {...props} />
+    </CommandNavigation>
+  )
+}
+
+function ActionTokenPickerInner({
+  entityDefinitionId,
+  fields,
+  isSignalRule,
+  onSelect,
+  onClose,
+}: ActionTokenPickerProps) {
+  const { isAtRoot } = useCommandNavigation<FieldPickerNavigationItem>()
+
+  const renderRecordGroup = (search: string) => {
+    if (!matchesSearch('Record name', search)) return null
+    return (
+      <CommandGroup heading='Record'>
+        <CommandItem
+          value={ACTION_TOKEN_RECORD_NAME}
+          onSelect={() => onSelect(ACTION_TOKEN_RECORD_NAME)}>
+          <Braces className='size-4 text-muted-foreground' />
+          <span>Record name</span>
+        </CommandItem>
+      </CommandGroup>
+    )
+  }
+
+  const renderSignalGroup = (search: string) => {
+    const tokens = SIGNAL_CONTEXT_TOKENS.filter((t) => matchesSearch(t.label, search))
+    if (tokens.length === 0) return null
+    return (
+      <CommandGroup heading='Signal'>
+        {tokens.map((t) => (
+          <CommandItem key={t.id} value={t.id} onSelect={() => onSelect(t.id)}>
+            <Radio className='size-4 text-muted-foreground' />
+            <span>{t.label}</span>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    )
+  }
+
+  return (
+    <FieldPickerInnerContent
+      entityDefinitionId={entityDefinitionId}
+      fields={fields}
+      mode='single'
+      onSelect={(fieldRef) => onSelect(fieldRefToKey(fieldRef))}
+      onBackFromRoot={onClose}
+      searchPlaceholder='Search tokens...'
+      renderHeaderContent={isAtRoot ? renderRecordGroup : undefined}
+      renderAdditionalContent={isAtRoot && isSignalRule ? renderSignalGroup : undefined}
+    />
+  )
+}
+
+export interface ActionTokenInputProps {
+  /** Current field value — a Tiptap doc (strays are defensively normalized). */
+  value: unknown
+  onChange: (doc: TiptapDoc) => void
+  /** The rule's record type — roots the field tokens the picker offers. */
+  entityDefinitionId: string
+  /** The record type's fields (same list the condition builder shows). */
+  fields: ResourceField[]
+  /** Offer the signal-context tokens (only meaningful on `on === 'signal'` rules). */
+  isSignalRule: boolean
+  placeholder?: string
+}
+
+/**
+ * Single-line token input for the text-bearing rule-action fields
+ * (plans/signals/07-action-placeholders.md). Looks like a plain `FieldInputAdapter`
+ * TEXT input, but typing `{` opens an inline token picker; committed tokens render as
+ * chips and persist as `placeholder` nodes in the emitted Tiptap doc.
+ */
+export function ActionTokenInput({
+  value,
+  onChange,
+  entityDefinitionId,
+  fields,
+  isSignalRule,
+  placeholder = 'Type { to insert a field…',
+}: ActionTokenInputProps) {
+  const onChangeRef = useRef(onChange)
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  // Seed content once; later external changes flow through the reseed effect below.
+  const initialDocRef = useRef<TiptapDoc | null>(null)
+  if (initialDocRef.current === null) initialDocRef.current = toDoc(value)
+  const contentRef = useRef(stableStringify(initialDocRef.current))
+
+  const editorConfig = useMemo(
+    () => ({
+      extensions: [
+        StarterKit.configure({
+          heading: false,
+          blockquote: false,
+          bulletList: false,
+          orderedList: false,
+          listItem: false,
+          codeBlock: false,
+          horizontalRule: false,
+        }),
+        placeholderNode,
+        pickerNode,
+        Placeholder.configure({ placeholder, showOnlyWhenEditable: true }),
+      ],
+      content: initialDocRef.current as JSONContent,
+      onUpdate: ({ editor }: { editor: Editor }) => {
+        // Don't emit while the `{` picker chip is open — the transient chip would
+        // otherwise land in the value.
+        if (getOpenPickerRange(editor.state)) return
+        const next = stripOpenChips(editor.getJSON()) as TiptapDoc
+        const key = stableStringify(next)
+        if (key !== contentRef.current) {
+          contentRef.current = key
+          onChangeRef.current?.(next)
+        }
+      },
+      editorProps: {
+        attributes: {
+          class: 'text-sm focus:outline-none whitespace-nowrap overflow-x-auto',
+        },
+        // Single-line: swallow Enter so the doc never gains a paragraph. (When the
+        // picker is open, focus is in the popover, so this won't interfere.)
+        handleKeyDown: (_view: unknown, event: KeyboardEvent) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            return true
+          }
+          return false
+        },
+      },
+      immediatelyRender: false,
+      shouldRerenderOnTransaction: false,
+    }),
+    [placeholder]
+  )
+
+  const editor = useEditor(editorConfig)
+
+  // Reseed only on a genuine external change (selecting another action, a server
+  // refresh) — never echo our own onChange back (would jump the cursor).
+  useEffect(() => {
+    const doc = toDoc(value)
+    const key = stableStringify(doc)
+    if (key !== contentRef.current) {
+      contentRef.current = key
+      editor?.commands.setContent(doc as JSONContent)
+    }
+  }, [value, editor])
+
+  /** Insert a token chip, replacing the open `{` picker chip. */
+  const insertToken = useCallback(
+    (id: string) => {
+      if (!editor) return
+      const range = getOpenPickerRange(editor.state)
+      if (!range) return
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent({ type: 'placeholder', attrs: { id } })
+        .insertContent(' ')
+        .run()
+    },
+    [editor]
+  )
+
+  const closePicker = useCallback(() => {
+    editor?.commands.closeReferencePicker({ keepText: false })
+  }, [editor])
+
+  const activePicker = useActivePicker(editor)
+  const pickerOpen = !!activePicker && activePicker.trigger === '{'
+
+  return (
+    // Mirrors the FieldInputAdapter TEXT look (transparent input, min-h-8, text-sm)
+    // so the row matches its sibling inputs inside a FieldPanelRow.
+    <div className='relative flex w-full min-h-8 items-center'>
+      <EditorContent
+        editor={editor}
+        className='w-full text-sm [&_.ProseMirror]:w-full [&_.ProseMirror]:min-h-[1.25rem] [&_.ProseMirror]:outline-none [&_p]:m-0'
+      />
+      {editor && (
+        <InlinePickerPopover
+          state={{
+            isOpen: pickerOpen,
+            query: activePicker?.query ?? '',
+            range: null,
+            clientRect: activePicker?.clientRect ?? null,
+          }}
+          width={320}
+          onClose={closePicker}>
+          <ActionTokenPicker
+            entityDefinitionId={entityDefinitionId}
+            fields={fields}
+            isSignalRule={isSignalRule}
+            onSelect={(id) => {
+              insertToken(id)
+              closePicker()
+            }}
+            onClose={closePicker}
+          />
+        </InlinePickerPopover>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/record-rules/ui/create-task-action-form.tsx
+++ b/apps/web/src/components/record-rules/ui/create-task-action-form.tsx
@@ -4,11 +4,13 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { RecordRuleAction } from '@auxx/lib/record-rules/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
 import { getTaskFilterField } from '@auxx/lib/tasks/client'
 import { type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
 import type { SelectOption } from '@auxx/types/custom-field'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanelRow } from '~/components/global/forms/field-panel'
+import { ActionTokenInput } from './action-token-input'
 
 /** The `create-task` variant of `RecordRuleAction` — the only shape this form edits. */
 export type CreateTaskAction = Extract<RecordRuleAction, { type: 'create-task' }>
@@ -28,6 +30,12 @@ function first(value: unknown): string {
 interface CreateTaskActionFormProps {
   action: CreateTaskAction
   onChange: (action: CreateTaskAction) => void
+  /** The rule's record type — roots the title's field tokens. */
+  entityDefinitionId: string
+  /** The record type's fields (threaded from the actions page). */
+  fields: ResourceField[]
+  /** Offer signal-context tokens in the title (`on === 'signal'` rules). */
+  isSignalRule: boolean
 }
 
 /**
@@ -35,15 +43,23 @@ interface CreateTaskActionFormProps {
  * deadline, priority, and the reply auto-complete toggle (decision 11, v1 scope). Split out
  * of `RecordRuleActionsPage` to keep that file under the split threshold.
  */
-export function CreateTaskActionForm({ action, onChange }: CreateTaskActionFormProps) {
+export function CreateTaskActionForm({
+  action,
+  onChange,
+  entityDefinitionId,
+  fields,
+  isSignalRule,
+}: CreateTaskActionFormProps) {
   return (
     <>
-      <FieldPanelRow title='Title' isRequired description="Use {{record}} for the record's name">
-        <FieldInputAdapter
-          fieldType={FieldType.TEXT}
+      <FieldPanelRow title='Title' isRequired description='Type { to insert a field…'>
+        <ActionTokenInput
           value={action.title}
-          onChange={(v) => onChange({ ...action, title: String(v ?? '') })}
-          placeholder='e.g. Follow up with {{record}}'
+          onChange={(doc) => onChange({ ...action, title: doc })}
+          entityDefinitionId={entityDefinitionId}
+          fields={fields}
+          isSignalRule={isSignalRule}
+          placeholder='Task title'
         />
       </FieldPanelRow>
 

--- a/apps/web/src/components/record-rules/ui/record-rule-actions-page.tsx
+++ b/apps/web/src/components/record-rules/ui/record-rule-actions-page.tsx
@@ -3,10 +3,17 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import type { RecordRuleAction } from '@auxx/lib/record-rules/client'
+import { tryParsePlaceholderId } from '@auxx/lib/placeholders/client'
+import {
+  ACTION_TOKEN_RECORD_NAME,
+  actionDocToSummaryText,
+  type RecordRuleAction,
+  SIGNAL_CONTEXT_TOKENS,
+} from '@auxx/lib/record-rules/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
 import type { SelectOption } from '@auxx/types/custom-field'
+import { isFieldPath } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
@@ -16,6 +23,7 @@ import { Bell, ListTodo, PenLine, Plus, Settings2, Trash2, Workflow, Zap } from 
 import { type ReactNode, useMemo } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { ActionTokenInput, emptyActionDoc } from './action-token-input'
 import { CreateTaskActionForm } from './create-task-action-form'
 import { RecordRuleFieldRefInput } from './record-rule-field-ref-input'
 
@@ -25,7 +33,13 @@ interface WorkflowOption {
   name: string
 }
 
-const ACTION_LABELS: Record<RecordRuleAction['type'], string> = {
+/**
+ * The action shapes the rule editor edits — `native` actions are server-declared only
+ * (never accepted from the router or UI), so the editor's unions exclude them.
+ */
+export type EditableRuleAction = Exclude<RecordRuleAction, { type: 'native' }>
+
+const ACTION_LABELS: Record<EditableRuleAction['type'], string> = {
   notify: 'Notify members',
   'set-field': 'Set field',
   'enqueue-workflow': 'Run workflow',
@@ -33,13 +47,13 @@ const ACTION_LABELS: Record<RecordRuleAction['type'], string> = {
 }
 
 const ACTION_TYPE_OPTIONS: SelectOption[] = (
-  Object.keys(ACTION_LABELS) as RecordRuleAction['type'][]
+  Object.keys(ACTION_LABELS) as EditableRuleAction['type'][]
 ).map((type) => ({ value: type, label: ACTION_LABELS[type] }))
 
 /** The flush-in-a-FieldPanelRow trigger sizing shared by every action input. */
 const TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' } as const
 
-function ActionIcon({ type }: { type: RecordRuleAction['type'] }): ReactNode {
+function ActionIcon({ type }: { type: EditableRuleAction['type'] }): ReactNode {
   if (type === 'notify') return <Bell className='size-4' />
   if (type === 'set-field') return <PenLine className='size-4' />
   if (type === 'create-task') return <ListTodo className='size-4' />
@@ -52,23 +66,17 @@ function first(value: unknown): string {
   return typeof v === 'string' ? v : ''
 }
 
-/** 'true'/'false'/numeric strings become their typed values; everything else stays a string. */
-function coerceValue(raw: string): unknown {
-  if (raw === 'true') return true
-  if (raw === 'false') return false
-  if (raw.trim() !== '' && !Number.isNaN(Number(raw))) return Number(raw)
-  return raw
-}
-
 interface RecordRuleActionsPageProps {
-  actions: RecordRuleAction[]
+  actions: EditableRuleAction[]
   selectedIndex: number
   onSelectedIndexChange: (index: number) => void
   onAdd: () => void
   onRemove: (index: number) => void
-  onUpdate: (index: number, action: RecordRuleAction) => void
+  onUpdate: (index: number, action: EditableRuleAction) => void
   entityDefinitionId: string
   fields: ResourceField[]
+  /** True on `on === 'signal'` rules — offers signal-context tokens in the token inputs. */
+  isSignalRule: boolean
   workflows: WorkflowOption[]
   isEdit: boolean
   canSave: boolean
@@ -90,6 +98,7 @@ export function RecordRuleActionsPage({
   onUpdate,
   entityDefinitionId,
   fields,
+  isSignalRule,
   workflows,
   isEdit,
   canSave,
@@ -104,7 +113,19 @@ export function RecordRuleActionsPage({
     [workflows]
   )
 
-  const summarize = (action: RecordRuleAction): string => {
+  /** Token id → display label for `actionDocToSummaryText` — 'Record name', signal labels,
+   * or the field's label (root-level tokens only; drilled paths degrade to the raw id). */
+  const resolveTokenLabel = (id: string): string | undefined => {
+    if (id === ACTION_TOKEN_RECORD_NAME) return 'Record name'
+    const signalToken = SIGNAL_CONTEXT_TOKENS.find((t) => t.id === id)
+    if (signalToken) return signalToken.label
+    const parsed = tryParsePlaceholderId(id)
+    if (parsed?.kind !== 'field') return undefined
+    const terminal = isFieldPath(parsed.fieldRef) ? parsed.fieldRef.at(-1) : parsed.fieldRef
+    return fields.find((f) => f.resourceFieldId === terminal)?.label
+  }
+
+  const summarize = (action: EditableRuleAction): string => {
     if (action.type === 'notify')
       return action.userIds.length > 0
         ? `${action.userIds.length} member${action.userIds.length === 1 ? '' : 's'}`
@@ -114,7 +135,8 @@ export function RecordRuleActionsPage({
         ? (fields.find((f) => (f.systemAttribute ?? String(f.id)) === action.fieldRef)?.label ??
             action.fieldRef)
         : 'No field'
-    if (action.type === 'create-task') return action.title || 'No title'
+    if (action.type === 'create-task')
+      return actionDocToSummaryText(action.title, resolveTokenLabel) || 'No title'
     return workflows.find((w) => w.id === action.workflowAppId)?.name || 'No workflow'
   }
 
@@ -188,14 +210,23 @@ export function RecordRuleActionsPage({
                 triggerProps={TRIGGER_PROPS}
                 value={selected.type}
                 onChange={(v) => {
-                  const type = first(v) as RecordRuleAction['type']
+                  const type = first(v) as EditableRuleAction['type']
                   if (type === 'set-field')
-                    onUpdate(selectedIndex, { type: 'set-field', fieldRef: '', value: '' })
+                    onUpdate(selectedIndex, {
+                      type: 'set-field',
+                      fieldRef: '',
+                      value: emptyActionDoc(),
+                    })
                   else if (type === 'enqueue-workflow')
                     onUpdate(selectedIndex, { type: 'enqueue-workflow', workflowAppId: '' })
                   else if (type === 'create-task')
-                    onUpdate(selectedIndex, { type: 'create-task', title: '' })
-                  else onUpdate(selectedIndex, { type: 'notify', userIds: [], message: '' })
+                    onUpdate(selectedIndex, { type: 'create-task', title: emptyActionDoc() })
+                  else
+                    onUpdate(selectedIndex, {
+                      type: 'notify',
+                      userIds: [],
+                      message: emptyActionDoc(),
+                    })
                 }}
               />
             </FieldPanelRow>
@@ -217,13 +248,13 @@ export function RecordRuleActionsPage({
                     placeholder='Add members to notify'
                   />
                 </FieldPanelRow>
-                <FieldPanelRow title='Message' isRequired>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
+                <FieldPanelRow title='Message' isRequired description='Type { to insert a field…'>
+                  <ActionTokenInput
                     value={selected.message}
-                    onChange={(v) =>
-                      onUpdate(selectedIndex, { ...selected, message: String(v ?? '') })
-                    }
+                    onChange={(doc) => onUpdate(selectedIndex, { ...selected, message: doc })}
+                    entityDefinitionId={entityDefinitionId}
+                    fields={fields}
+                    isSignalRule={isSignalRule}
                     placeholder='Notification message'
                   />
                 </FieldPanelRow>
@@ -241,13 +272,13 @@ export function RecordRuleActionsPage({
                     placeholder='Field to set'
                   />
                 </FieldPanelRow>
-                <FieldPanelRow title='Value'>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
-                    value={String(selected.value ?? '')}
-                    onChange={(v) =>
-                      onUpdate(selectedIndex, { ...selected, value: coerceValue(String(v ?? '')) })
-                    }
+                <FieldPanelRow title='Value' description='Type { to insert a field…'>
+                  <ActionTokenInput
+                    value={selected.value}
+                    onChange={(doc) => onUpdate(selectedIndex, { ...selected, value: doc })}
+                    entityDefinitionId={entityDefinitionId}
+                    fields={fields}
+                    isSignalRule={isSignalRule}
                     placeholder='Value'
                   />
                 </FieldPanelRow>
@@ -273,6 +304,9 @@ export function RecordRuleActionsPage({
               <CreateTaskActionForm
                 action={selected}
                 onChange={(next) => onUpdate(selectedIndex, next)}
+                entityDefinitionId={entityDefinitionId}
+                fields={fields}
+                isSignalRule={isSignalRule}
               />
             )}
           </FieldPanel>

--- a/apps/web/src/components/record-rules/ui/record-rule-dialog.tsx
+++ b/apps/web/src/components/record-rules/ui/record-rule-dialog.tsx
@@ -4,20 +4,32 @@
 
 import type { Condition, ConditionGroup } from '@auxx/lib/conditions/client'
 import {
+  isActionDoc,
   LIFECYCLE_TRANSITIONS,
-  type RecordRuleAction,
   type RecordRuleOn,
 } from '@auxx/lib/record-rules/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { isSignalPseudoFieldId } from '@auxx/lib/signals/client'
+import { docToText, isNonEmptyDoc } from '@auxx/lib/tiptap'
 import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
 import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { toastError } from '@auxx/ui/components/toast'
 import { useEffect, useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
 import { useRecordRules } from '../hooks/use-record-rules'
-import { RecordRuleActionsPage } from './record-rule-actions-page'
+import { emptyActionDoc } from './action-token-input'
+import { type EditableRuleAction, RecordRuleActionsPage } from './record-rule-actions-page'
 import { RecordRuleConfigurePage } from './record-rule-configure-page'
+
+/**
+ * Doc-aware completeness for token-bearing action fields. `isNonEmptyDoc` alone would
+ * reject a doc whose only content is a placeholder chip (it counts text/reference/mention
+ * nodes, not `placeholder`), so a token-only doc is rescued via `docToText`, which renders
+ * placeholder nodes as `{{id}}`.
+ */
+function hasActionContent(v: unknown): boolean {
+  return isActionDoc(v) && (isNonEmptyDoc(v) || docToText(v) !== '')
+}
 
 /** Rule shape the settings list hands to the dialog (router `list` output item). */
 export interface EditableRecordRule {
@@ -86,7 +98,7 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
   const [fieldRef, setFieldRef] = useState('')
   const [signalKind, setSignalKind] = useState('')
   const [groups, setGroups] = useState<ConditionGroup[]>([])
-  const [actions, setActions] = useState<RecordRuleAction[]>([])
+  const [actions, setActions] = useState<EditableRuleAction[]>([])
   const [selectedActionIndex, setSelectedActionIndex] = useState(0)
 
   // Re-seed form state whenever the dialog opens.
@@ -100,7 +112,7 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
     setFieldRef(rule?.fieldRef ?? '')
     setSignalKind(rule?.signalKind ?? '')
     setGroups(Array.isArray(rule?.condition) ? (rule.condition as ConditionGroup[]) : [])
-    setActions(Array.isArray(rule?.actions) ? (rule.actions as RecordRuleAction[]) : [])
+    setActions(Array.isArray(rule?.actions) ? (rule.actions as EditableRuleAction[]) : [])
   }, [open, rule])
 
   const isLifecycle = LIFECYCLE_TRANSITIONS.includes(on)
@@ -144,7 +156,7 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
     }
   }
 
-  const updateAction = (index: number, next: RecordRuleAction) =>
+  const updateAction = (index: number, next: EditableRuleAction) =>
     setActions((prev) => prev.map((a, i) => (i === index ? next : a)))
   const removeAction = (index: number) =>
     setActions((prev) => {
@@ -154,7 +166,10 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
     })
   const addAction = () =>
     setActions((prev) => {
-      const next: RecordRuleAction[] = [...prev, { type: 'notify', userIds: [], message: '' }]
+      const next: EditableRuleAction[] = [
+        ...prev,
+        { type: 'notify', userIds: [], message: emptyActionDoc() },
+      ]
       setSelectedActionIndex(next.length - 1)
       return next
     })
@@ -170,10 +185,10 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
   const handleSave = async () => {
     const invalidIndex = actions.findIndex(
       (a) =>
-        (a.type === 'notify' && (a.userIds.length === 0 || a.message.trim() === '')) ||
+        (a.type === 'notify' && (a.userIds.length === 0 || !hasActionContent(a.message))) ||
         (a.type === 'set-field' && !a.fieldRef) ||
         (a.type === 'enqueue-workflow' && !a.workflowAppId) ||
-        (a.type === 'create-task' && !a.title.trim())
+        (a.type === 'create-task' && !hasActionContent(a.title))
     )
     if (invalidIndex >= 0) {
       setSelectedActionIndex(invalidIndex)
@@ -256,6 +271,7 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
               onUpdate={updateAction}
               entityDefinitionId={entityDefinitionId}
               fields={fields}
+              isSignalRule={isSignal}
               workflows={workflows}
               isEdit={!!rule}
               canSave={canSave}

--- a/apps/web/src/components/tasks/hooks/use-tasks.ts
+++ b/apps/web/src/components/tasks/hooks/use-tasks.ts
@@ -27,6 +27,8 @@ interface UseTasksOptions {
   includeCompleted?: boolean
   /** Include archived tasks */
   includeArchived?: boolean
+  /** Include snoozed tasks (excluded from open lists by default) */
+  includeSnoozed?: boolean
   /** Restrict to tasks created via these sources (e.g. the "Follow-ups" chip maps to rule/ai) */
   sources?: TaskSource[]
   /** Items per page */
@@ -71,6 +73,7 @@ export function useTasks({
   sort = DEFAULT_SORT,
   includeCompleted = false,
   includeArchived = false,
+  includeSnoozed = false,
   sources,
   limit = 50,
   enabled = true,
@@ -87,10 +90,21 @@ export function useTasks({
       search,
       includeCompleted,
       includeArchived,
+      includeSnoozed,
       sources,
       limit,
     }),
-    [recordId, assigneeIds, priority, search, includeCompleted, includeArchived, sources, limit]
+    [
+      recordId,
+      assigneeIds,
+      priority,
+      search,
+      includeCompleted,
+      includeArchived,
+      includeSnoozed,
+      sources,
+      limit,
+    ]
   )
 
   // Fetch tasks using query (not infinite for now - keeping it simple)

--- a/apps/web/src/components/tasks/ui/task-filter-bar.tsx
+++ b/apps/web/src/components/tasks/ui/task-filter-bar.tsx
@@ -35,6 +35,10 @@ interface TaskFilterBarProps {
   includeCompleted: boolean
   /** Callback when includeCompleted changes */
   onIncludeCompletedChange: (value: boolean) => void
+  /** Whether to include snoozed tasks (excluded from open lists by default) */
+  includeSnoozed: boolean
+  /** Callback when includeSnoozed changes */
+  onIncludeSnoozedChange: (value: boolean) => void
   /** Whether the "Follow-ups" chip (source in rule/ai — build plan decision 16) is active */
   followUpsOnly: boolean
   /** Callback when the "Follow-ups" chip is toggled */
@@ -54,6 +58,8 @@ export function TaskFilterBar({
   onSortChange,
   includeCompleted,
   onIncludeCompletedChange,
+  includeSnoozed,
+  onIncludeSnoozedChange,
   followUpsOnly,
   onFollowUpsOnlyChange,
   disabled = false,
@@ -203,8 +209,22 @@ export function TaskFilterBar({
         <TaskSortSelect value={sort} onChange={onSortChange} disabled={disabled} />
       </ListToolbarGroup>
 
-      {/* Show Completed Toggle */}
+      {/* Show Snoozed / Show Completed Toggles */}
       <ListToolbarGroup align='end'>
+        <label
+          className={buttonVariants({
+            variant: 'ghost',
+            size: 'sm',
+            className: `gap-2 ${disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer'}`,
+          })}>
+          <span className='text-muted-foreground text-xs'>Show snoozed</span>
+          <Switch
+            size='sm'
+            checked={includeSnoozed}
+            onCheckedChange={onIncludeSnoozedChange}
+            disabled={disabled}
+          />
+        </label>
         <label
           className={buttonVariants({
             variant: 'ghost',

--- a/apps/web/src/components/tasks/ui/task-form.tsx
+++ b/apps/web/src/components/tasks/ui/task-form.tsx
@@ -100,6 +100,8 @@ export function TaskForm({
   // "Complete on reply" toggle (build plan decision 13) — only meaningful/shown when a
   // contact is linked; see `hasContactReference` below.
   const [autoCompleteOn, setAutoCompleteOn] = useState(false)
+  // Snooze (build plan decision 10) — buffered like the other pickers, persisted on save.
+  const [snoozedUntil, setSnoozedUntil] = useState<Date | null>(null)
 
   // Does `linkedRecords` include a reference to the contact entity definition? Drives the
   // auto-complete toggle's visibility (decision 13).
@@ -198,6 +200,7 @@ export function TaskForm({
         setAssigneeActorIds(task.assignments ?? [])
         setLinkedRecords(task.references ?? [])
         setAutoCompleteOn(task.autoCompleteOn === 'contact_reply')
+        setSnoozedUntil(task.snoozedUntil ? new Date(task.snoozedUntil) : null)
       } else {
         // Create mode: start fresh
         setDeadline(undefined)
@@ -205,6 +208,7 @@ export function TaskForm({
         setAssigneeActorIds([])
         setLinkedRecords(defaultReferencedEntity ? [defaultReferencedEntity] : [])
         setAutoCompleteOn(false)
+        setSnoozedUntil(null)
       }
       // Defer editor operations using double requestAnimationFrame to ensure
       // we're outside React's render cycle and avoid flushSync errors
@@ -251,6 +255,7 @@ export function TaskForm({
     setAssigneeActorIds([])
     setLinkedRecords(defaultReferencedEntity ? [defaultReferencedEntity] : [])
     setAutoCompleteOn(false)
+    setSnoozedUntil(null)
     // Use double requestAnimationFrame to avoid flushSync errors
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
@@ -295,6 +300,7 @@ export function TaskForm({
         assigneeActorIds,
         referencedEntities: linkedRecords,
         autoCompleteOn: effectiveAutoComplete,
+        snoozedUntil: snoozedUntil ? snoozedUntil.toISOString() : null,
       }
       updateTask.mutate(input)
     }
@@ -313,6 +319,7 @@ export function TaskForm({
     assigneeActorIds,
     linkedRecords,
     effectiveAutoComplete,
+    snoozedUntil,
     createTask,
     updateTask,
     onClose,
@@ -442,7 +449,13 @@ export function TaskForm({
                 </RecordPicker>
 
                 {/* Snooze (edit mode only — build plan decision 10) */}
-                {mode === 'edit' && task && <TaskSnoozeButton task={task} />}
+                {mode === 'edit' && task && (
+                  <TaskSnoozeButton
+                    value={snoozedUntil}
+                    onChange={setSnoozedUntil}
+                    disabled={isSaving}
+                  />
+                )}
               </div>
 
               {/* Toggles (scroll with the pickers) */}

--- a/apps/web/src/components/tasks/ui/task-item.tsx
+++ b/apps/web/src/components/tasks/ui/task-item.tsx
@@ -6,6 +6,7 @@ import type { TaskWithRelations } from '@auxx/lib/tasks'
 import type { ActorId } from '@auxx/types/actor'
 import { Badge } from '@auxx/ui/components/badge'
 import { cn } from '@auxx/ui/lib/utils'
+import { AlarmClock } from 'lucide-react'
 import { ParsedText } from '~/components/editor/parsed-text'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
@@ -132,7 +133,8 @@ export function TaskItem({ task, onClick, showEntityReferences = false }: TaskIt
               )}
 
               {isSnoozedIntoFuture && (
-                <Badge variant='secondary' size='sm' className='ms-1 align-middle'>
+                <Badge variant='amber' size='sm' className='ms-1 align-middle'>
+                  <AlarmClock />
                   Snoozed until {formatTaskDeadlineDisplay(new Date(task.snoozedUntil as Date))}
                 </Badge>
               )}

--- a/apps/web/src/components/tasks/ui/task-snooze-button.tsx
+++ b/apps/web/src/components/tasks/ui/task-snooze-button.tsx
@@ -2,7 +2,6 @@
 
 'use client'
 
-import type { TaskWithRelations } from '@auxx/lib/tasks'
 import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
@@ -13,7 +12,6 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { addDays } from 'date-fns'
 import { AlarmClock } from 'lucide-react'
-import { useTaskMutations } from '../hooks/use-task-mutations'
 import { formatTaskDeadlineDisplay } from '../utils/group-tasks-by-period'
 
 /** Snooze duration presets offered by the dropdown (build plan Step 7). */
@@ -25,39 +23,40 @@ const SNOOZE_PRESETS = [
 
 /**
  * Snooze control for `TaskForm`'s footer picker cluster (edit mode only — a task must exist
- * to snooze). Excludes the task from default open lists until the chosen date (build plan
- * decision 10) via `api.task.update({ snoozedUntil })`.
+ * to snooze). Controlled like the other footer pickers: the chosen date is buffered in
+ * `TaskForm` state and only persisted on save (build plan decision 10).
  */
-export function TaskSnoozeButton({ task }: { task: TaskWithRelations }) {
-  const { updateTask } = useTaskMutations()
-
-  const snoozedUntil = task.snoozedUntil ? new Date(task.snoozedUntil) : null
-  const isSnoozed = !!snoozedUntil && snoozedUntil.getTime() > Date.now()
-
-  const setSnooze = (date: Date | null) => {
-    updateTask.mutate({ id: task.id, snoozedUntil: date ? date.toISOString() : null })
-  }
+export function TaskSnoozeButton({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: Date | null
+  onChange: (date: Date | null) => void
+  disabled?: boolean
+}) {
+  const isSnoozed = !!value && value.getTime() > Date.now()
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant='ghost' size='sm' disabled={updateTask.isPending}>
+        <Button variant='ghost' size='sm' disabled={disabled}>
           <AlarmClock />
-          {isSnoozed ? `Snoozed until ${formatTaskDeadlineDisplay(snoozedUntil)}` : 'Snooze'}
+          {isSnoozed ? `Snoozed until ${formatTaskDeadlineDisplay(value)}` : 'Snooze'}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='start'>
         {SNOOZE_PRESETS.map((preset) => (
           <DropdownMenuItem
             key={preset.label}
-            onSelect={() => setSnooze(addDays(new Date(), preset.days))}>
+            onSelect={() => onChange(addDays(new Date(), preset.days))}>
             {preset.label}
           </DropdownMenuItem>
         ))}
         {isSnoozed && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => setSnooze(null)}>Unsnooze</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onChange(null)}>Unsnooze</DropdownMenuItem>
           </>
         )}
       </DropdownMenuContent>

--- a/apps/web/src/components/tasks/ui/tasks-list.tsx
+++ b/apps/web/src/components/tasks/ui/tasks-list.tsx
@@ -33,6 +33,8 @@ interface TasksListProps {
   sort?: TaskSortConfig
   /** Include completed tasks (can be overridden by filters) */
   includeCompleted?: boolean
+  /** Include snoozed tasks (excluded from open lists by default) */
+  includeSnoozed?: boolean
   /** Restrict to tasks created via these sources (the "Follow-ups" chip — build plan decision 16) */
   sources?: TaskSource[]
   /** Callback when create button is clicked (from empty state) */
@@ -69,6 +71,7 @@ export function TasksList({
   filters,
   sort = DEFAULT_SORT,
   includeCompleted = true,
+  includeSnoozed = false,
   sources,
   onCreateClick,
   showEntityReferences = false,
@@ -86,6 +89,7 @@ export function TasksList({
     priority: filterProps.priority,
     search: filterProps.search,
     includeCompleted: filterProps.includeCompleted ?? includeCompleted,
+    includeSnoozed,
     sources,
     limit,
   })

--- a/apps/web/src/components/tasks/ui/tasks-page.tsx
+++ b/apps/web/src/components/tasks/ui/tasks-page.tsx
@@ -30,6 +30,7 @@ export function TasksPage() {
     direction: 'asc',
   })
   const [includeCompleted, setIncludeCompleted] = useState(true)
+  const [includeSnoozed, setIncludeSnoozed] = useState(false)
   // "Follow-ups" chip — build plan decision 16: rule/AI-created tasks only. Kopilot
   // chat-created tasks are user-initiated (closer to manual) and stay out of the chip.
   const [followUpsOnly, setFollowUpsOnly] = useState(false)
@@ -60,6 +61,8 @@ export function TasksPage() {
               onSortChange={setSort}
               includeCompleted={includeCompleted}
               onIncludeCompletedChange={setIncludeCompleted}
+              includeSnoozed={includeSnoozed}
+              onIncludeSnoozedChange={setIncludeSnoozed}
               followUpsOnly={followUpsOnly}
               onFollowUpsOnlyChange={setFollowUpsOnly}
             />
@@ -69,6 +72,7 @@ export function TasksPage() {
             filters={filters}
             sort={sort}
             includeCompleted={includeCompleted}
+            includeSnoozed={includeSnoozed}
             sources={followUpsOnly ? ['rule', 'ai'] : undefined}
             showEntityReferences
           />

--- a/apps/web/src/server/api/routers/record-rules.ts
+++ b/apps/web/src/server/api/routers/record-rules.ts
@@ -55,17 +55,27 @@ const signalKindSchema = z.enum(SIGNAL_KIND_LIST as [string, ...string[]])
 /** Mirrors the task router's `prioritySchema` (`apps/web/src/server/api/routers/task.ts`). */
 const taskPrioritySchema = z.enum(['low', 'medium', 'high'])
 
+/**
+ * Structural validation only for the token-bearing action fields (Tiptap docs with
+ * `placeholder` nodes — plans/signals/07-action-placeholders.md). The deep walk happens
+ * in the lib resolver at execution; mirrors `promptDocSchema` (promptTemplate router).
+ */
+const actionDocSchema = z.object({
+  type: z.literal('doc'),
+  content: z.array(z.unknown()).optional(),
+})
+
 const actionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('set-field'), fieldRef: z.string().min(1), value: z.unknown() }),
   z.object({ type: z.literal('enqueue-workflow'), workflowAppId: z.string().min(1) }),
   z.object({
     type: z.literal('notify'),
     userIds: z.array(z.string().min(1)).min(1),
-    message: z.string().min(1),
+    message: actionDocSchema,
   }),
   z.object({
     type: z.literal('create-task'),
-    title: z.string().min(1).max(500),
+    title: actionDocSchema,
     assigneeIds: z.array(z.string().min(1)).optional(),
     deadlineDays: z.number().int().positive().max(365).optional(),
     priority: taskPrioritySchema.optional(),
@@ -173,10 +183,10 @@ export const recordRulesRouter = createTRPCRouter({
     .input(ruleInputSchema.partial().extend({ ruleId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.organizationId
-      const { ruleId, fieldRef, ...rest } = input
+      const { ruleId, fieldRef, actions, ...rest } = input
       await assertNotManaged(ctx.db, organizationId, ruleId)
-      if (rest.actions) {
-        await assertActionsWorkflowsAccessible(ctx.db, organizationId, rest.actions)
+      if (actions) {
+        await assertActionsWorkflowsAccessible(ctx.db, organizationId, actions)
       }
       const fieldId =
         fieldRef !== undefined && rest.entityDefinitionId && rest.on
@@ -189,7 +199,7 @@ export const recordRulesRouter = createTRPCRouter({
       const rule = await updateRecordRule(ctx.db, organizationId, ruleId, {
         ...rest,
         ...(fieldId !== undefined && { fieldId }),
-        ...(rest.actions && { actions: rest.actions as RecordRuleAction[] }),
+        ...(actions && { actions: actions as RecordRuleAction[] }),
       })
       await onCacheEvent('record-rule.changed', { orgId: organizationId })
       return rule

--- a/packages/lib/src/events/handlers/handle-signal-record-rules.test.ts
+++ b/packages/lib/src/events/handlers/handle-signal-record-rules.test.ts
@@ -7,6 +7,7 @@
 // signals-queries) mocked; the pure pseudo-field mapper runs for real via `__test__`.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { legacyActionTextToDoc } from '../../record-rules/client'
 import type { CachedRecordRule } from '../../record-rules/types'
 
 // Everything a `vi.mock` factory below reads must be created via `vi.hoisted` — a plain
@@ -67,7 +68,7 @@ function rule(overrides: Partial<CachedRecordRule> = {}): CachedRecordRule {
     on: 'signal',
     signalKind: 'email:opened',
     condition: [],
-    actions: [{ type: 'notify', userIds: ['u1'], message: 'hi' }],
+    actions: [{ type: 'notify', userIds: ['u1'], message: legacyActionTextToDoc('hi') }],
     enabled: true,
     ...overrides,
   }
@@ -152,7 +153,14 @@ describe('handleSignalRecordRules', () => {
       entityInstanceId: 'contact_1',
       source: 'interactive',
       newValue: { signalId: 'sig_1', kind: 'email:opened', subtype: 'open' },
-      signal: { signalId: 'sig_1', kind: 'email:opened', contactEntityInstanceId: 'contact_1' },
+      // Signal context now carries subtype + ISO occurredAt for action tokens (07).
+      signal: {
+        signalId: 'sig_1',
+        kind: 'email:opened',
+        contactEntityInstanceId: 'contact_1',
+        subtype: 'open',
+        occurredAt: new Date('2026-01-01').toISOString(),
+      },
     })
     // No matched rule has conditions — the snapshot fetch is skipped entirely (hot-path).
     expect(ctx.snapshot).toBeUndefined()

--- a/packages/lib/src/events/handlers/handle-signal-record-rules.ts
+++ b/packages/lib/src/events/handlers/handle-signal-record-rules.ts
@@ -106,6 +106,8 @@ export const handleSignalRecordRules = async ({ data: event }: { data: AuxxEvent
           signalId: representative.id,
           kind: data.kind,
           contactEntityInstanceId: data.contactEntityInstanceId ?? undefined,
+          subtype: data.subtype || undefined,
+          occurredAt: toIsoOrUndefined(data.occurredAt),
         },
       }
 
@@ -118,6 +120,13 @@ export const handleSignalRecordRules = async ({ data: event }: { data: AuxxEvent
       error: error instanceof Error ? error.message : String(error),
     })
   }
+}
+
+/** Event dates cross BullMQ as strings — normalize either form to ISO, dropping invalids. */
+function toIsoOrUndefined(value: Date | string | undefined | null): string | undefined {
+  if (!value) return undefined
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
 }
 
 /**

--- a/packages/lib/src/events/handlers/handle-sync-record-rules.test.ts
+++ b/packages/lib/src/events/handlers/handle-sync-record-rules.test.ts
@@ -5,6 +5,7 @@
 // transition + condition-ref + resolver helpers run for real.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { legacyActionTextToDoc } from '../../record-rules/client'
 import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
 import type { CachedRecordRule } from '../../record-rules/types'
 
@@ -51,7 +52,7 @@ function rule(overrides: Partial<CachedRecordRule> = {}): CachedRecordRule {
     name: 'r',
     on: 'changed',
     condition: [],
-    actions: [{ type: 'notify', userIds: ['u1'], message: 'hi' }],
+    actions: [{ type: 'notify', userIds: ['u1'], message: legacyActionTextToDoc('hi') }],
     enabled: true,
     ...overrides,
   }

--- a/packages/lib/src/record-rules/actions.test.ts
+++ b/packages/lib/src/record-rules/actions.test.ts
@@ -1,11 +1,13 @@
 // packages/lib/src/record-rules/actions.test.ts
-// Executor tests for the `create-task` rule action (plans/signals/06-follow-ups-build.md
-// Step 4). Schema is a Proxy (avoids the known Drizzle-columns-undefined-under-vitest
+// Executor tests for the `create-task` / `notify` / `set-field` rule actions
+// (plans/signals/06-follow-ups-build.md Step 4 + 07-action-placeholders.md tokens).
+// Schema is a Proxy (avoids the known Drizzle-columns-undefined-under-vitest
 // gotcha — see project memory); drizzle-orm's `and`/`eq`/`gte`/`isNull`/`or` are stubbed
 // so the real query builder never runs against the fake columns — the dedupe/cooldown
 // query's actual date filtering is Postgres-side and out of scope here; these tests
 // verify the executor builds the right predicate shape and branches correctly on
-// whether the (mocked) query returns a matching row.
+// whether the (mocked) query returns a matching row. Placeholder docs run the REAL
+// pre-pass + document resolver on top of a mocked shared field lookup.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CachedRecordRule, RecordRuleFireContext } from './types'
@@ -40,6 +42,14 @@ const h = vi.hoisted(() => {
     getSystemUserForActions: vi.fn<(organizationId: string) => Promise<string>>(
       async () => 'user_system_1'
     ),
+    sendNotification: vi.fn<(input: any) => Promise<void>>(async () => undefined),
+    crudUpdate: vi.fn<(recordId: string, data: Record<string, unknown>) => Promise<void>>(
+      async () => undefined
+    ),
+    resolveFieldTokens: vi.fn<(tokens: any[], ctx: any) => Promise<Map<string, any>>>(
+      async () => new Map()
+    ),
+    formatFieldValueForText: vi.fn<(...args: any[]) => string>(() => ''),
   }
 })
 
@@ -60,8 +70,28 @@ vi.mock('../tasks', () => ({
 vi.mock('../users/system-user-service', () => ({
   SystemUserService: { getSystemUserForActions: h.getSystemUserForActions },
 }))
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ get: vi.fn(async () => ({})) }),
+  getUserCache: () => ({ get: vi.fn(async () => null) }),
+}))
+vi.mock('../placeholders/resolver', () => ({
+  resolveFieldTokens: h.resolveFieldTokens,
+  formatFieldValueForText: h.formatFieldValueForText,
+}))
+vi.mock('../notifications/notification-service', () => ({
+  NotificationService: class {
+    sendNotification = h.sendNotification
+  },
+}))
+vi.mock('../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    update = h.crudUpdate
+  },
+}))
 
+import type { TiptapDoc, TiptapNode } from '../tiptap/types'
 import { executeRuleAction } from './actions'
+import { legacyActionTextToDoc } from './client'
 
 /** One `database.select(...).from(...)` chain, resolving `.limit()` to `rows`. */
 function chain(rows: any[]) {
@@ -109,13 +139,19 @@ beforeEach(() => {
   vi.clearAllMocks()
   h.createTask.mockResolvedValue({ id: 'task_new' })
   h.getSystemUserForActions.mockResolvedValue('user_system_1')
+  h.resolveFieldTokens.mockResolvedValue(new Map())
 })
+
+/** Single-paragraph tiptap doc from inline nodes (07 action-token storage shape). */
+function actionDoc(...content: TiptapNode[]): TiptapDoc {
+  return { type: 'doc', content: [{ type: 'paragraph', content }] }
+}
 
 describe("executeRuleAction — 'create-task'", () => {
   it('skips (dedupe) when an open task from the same rule already references the record', async () => {
     stubQueries([{ id: 'task_dup' }], [])
     const result = await executeRuleAction(
-      { type: 'create-task', title: 'Follow up with {{record}}' },
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up with {{record}}') },
       rule(),
       baseCtx,
       null
@@ -130,7 +166,7 @@ describe("executeRuleAction — 'create-task'", () => {
     // predicate actually asks for a 7-day-ish cutoff.
     stubQueries([{ id: 'task_recently_completed' }], [])
     const result = await executeRuleAction(
-      { type: 'create-task', title: 'Follow up' },
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up') },
       rule(),
       baseCtx,
       null
@@ -146,7 +182,7 @@ describe("executeRuleAction — 'create-task'", () => {
   it('creates when no dedupe/cooldown match is found (e.g. prior task completed >7 days ago)', async () => {
     stubQueries([], [{ displayName: 'Jane Doe' }])
     const result = await executeRuleAction(
-      { type: 'create-task', title: 'Follow up with {{record}}' },
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up with {{record}}') },
       rule(),
       baseCtx,
       null
@@ -155,10 +191,13 @@ describe("executeRuleAction — 'create-task'", () => {
     expect(h.createTask).toHaveBeenCalledTimes(1)
   })
 
-  it('interpolates {{record}} with the fired record display name, falling back to the id', async () => {
+  it('resolves the record:name token to the display name, falling back to the id', async () => {
     stubQueries([], [{ displayName: 'Jane Doe' }])
     await executeRuleAction(
-      { type: 'create-task', title: 'Follow up with {{record}} about opens' },
+      {
+        type: 'create-task',
+        title: legacyActionTextToDoc('Follow up with {{record}} about opens'),
+      },
       rule(),
       baseCtx,
       null
@@ -168,7 +207,7 @@ describe("executeRuleAction — 'create-task'", () => {
 
     stubQueries([], [{ displayName: null }])
     await executeRuleAction(
-      { type: 'create-task', title: 'Follow up with {{record}}' },
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up with {{record}}') },
       rule(),
       baseCtx,
       null
@@ -179,7 +218,12 @@ describe("executeRuleAction — 'create-task'", () => {
 
   it('creates with the org system user as creator, source=rule, and sourceRuleId set', async () => {
     stubQueries([], [{ displayName: 'Jane Doe' }])
-    await executeRuleAction({ type: 'create-task', title: 'Follow up' }, rule(), baseCtx, null)
+    await executeRuleAction(
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up') },
+      rule(),
+      baseCtx,
+      null
+    )
 
     expect(h.getSystemUserForActions).toHaveBeenCalledWith('org_1')
     const [input, organizationId, userId] = h.createTask.mock.calls[0] as [any, string, string]
@@ -197,7 +241,7 @@ describe("executeRuleAction — 'create-task'", () => {
       signal: { signalId: 'sig_1', kind: 'email:opened', contactEntityInstanceId: 'contact_1' },
     }
     await executeRuleAction(
-      { type: 'create-task', title: 'Follow up' },
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up') },
       rule(),
       ctxWithSignal,
       null
@@ -214,7 +258,7 @@ describe("executeRuleAction — 'create-task'", () => {
       signal: { signalId: 'sig_1', kind: 'email:opened', contactEntityInstanceId: 'contact_1' },
     }
     await executeRuleAction(
-      { type: 'create-task', title: 'Follow up' },
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up') },
       rule(),
       ctxWithSignal,
       null
@@ -228,7 +272,7 @@ describe("executeRuleAction — 'create-task'", () => {
     await executeRuleAction(
       {
         type: 'create-task',
-        title: 'Follow up',
+        title: legacyActionTextToDoc('Follow up'),
         deadlineDays: 2,
         priority: 'high',
         autoCompleteOn: 'contact_reply',
@@ -247,7 +291,7 @@ describe("executeRuleAction — 'create-task'", () => {
 
   it("skips without querying anything on a 'deleted' firing", async () => {
     const result = await executeRuleAction(
-      { type: 'create-task', title: 'Follow up' },
+      { type: 'create-task', title: legacyActionTextToDoc('Follow up') },
       rule({ on: 'deleted' }),
       baseCtx,
       null
@@ -255,5 +299,170 @@ describe("executeRuleAction — 'create-task'", () => {
     expect(result).toBe('skipped')
     expect(h.select).not.toHaveBeenCalled()
     expect(h.createTask).not.toHaveBeenCalled()
+  })
+
+  it('resolves a doc title: record:name + signal tokens (07 placeholder path)', async () => {
+    stubQueries([], [{ displayName: 'Jane Doe' }])
+    const ctxWithSignal: RecordRuleFireContext = {
+      ...baseCtx,
+      signal: {
+        signalId: 'sig_1',
+        kind: 'email:opened',
+        subtype: 'sequence_step',
+        occurredAt: '2026-07-15T10:00:00.000Z',
+      },
+    }
+    await executeRuleAction(
+      {
+        type: 'create-task',
+        title: actionDoc(
+          { type: 'text', text: 'Follow up with ' },
+          { type: 'placeholder', attrs: { id: 'record:name' } },
+          { type: 'text', text: ' — ' },
+          { type: 'placeholder', attrs: { id: 'signal:kind' } }
+        ),
+      },
+      rule(),
+      ctxWithSignal,
+      null
+    )
+    const [input] = h.createTask.mock.calls[0] as [any, string, string]
+    expect(input.title).toBe('Follow up with Jane Doe — Email opened')
+  })
+
+  it('resolves field tokens in a doc title through the shared placeholder resolver', async () => {
+    stubQueries([], [{ displayName: 'Jane Doe' }])
+    h.resolveFieldTokens.mockResolvedValue(
+      new Map([
+        [
+          'def_contact:email',
+          { value: { type: 'text', value: 'jane@acme.test' }, fieldType: 'TEXT' },
+        ],
+      ])
+    )
+    h.formatFieldValueForText.mockReturnValue('jane@acme.test')
+    await executeRuleAction(
+      {
+        type: 'create-task',
+        title: actionDoc(
+          { type: 'text', text: 'Fix email ' },
+          { type: 'placeholder', attrs: { id: 'def_contact:email' } }
+        ),
+      },
+      rule(),
+      baseCtx,
+      null
+    )
+    const [input] = h.createTask.mock.calls[0] as [any, string, string]
+    expect(input.title).toBe('Fix email jane@acme.test')
+  })
+})
+
+describe("executeRuleAction — 'notify'", () => {
+  it('passes a stale plain-string message through verbatim without any context lookups', async () => {
+    h.select.mockReset()
+    const result = await executeRuleAction(
+      // Defensive guard only — the type is TiptapDoc, but stale rows may hold strings.
+      {
+        type: 'notify',
+        userIds: ['u1', 'u2'],
+        message: 'Check this record' as unknown as TiptapDoc,
+      },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(result).toBe('ok')
+    expect(h.select).not.toHaveBeenCalled()
+    expect(h.sendNotification).toHaveBeenCalledTimes(2)
+    expect(h.sendNotification.mock.calls[0]?.[0]).toMatchObject({ message: 'Check this record' })
+  })
+
+  it('flattens a doc message with record:name resolved', async () => {
+    h.select.mockReset()
+    h.select.mockImplementationOnce(() => chain([{ displayName: 'Jane Doe' }]))
+    await executeRuleAction(
+      {
+        type: 'notify',
+        userIds: ['u1'],
+        message: actionDoc(
+          { type: 'text', text: 'Heads up: ' },
+          { type: 'placeholder', attrs: { id: 'record:name' } },
+          { type: 'text', text: ' unsubscribed' }
+        ),
+      },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(h.sendNotification.mock.calls[0]?.[0]).toMatchObject({
+      message: 'Heads up: Jane Doe unsubscribed',
+    })
+  })
+})
+
+describe("executeRuleAction — 'set-field'", () => {
+  it('writes legacy raw values verbatim', async () => {
+    h.select.mockReset()
+    const result = await executeRuleAction(
+      { type: 'set-field', fieldRef: 'fld_1', value: 42 },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(result).toBe('ok')
+    expect(h.select).not.toHaveBeenCalled()
+    expect(h.crudUpdate).toHaveBeenCalledWith('def_contact:contact_1', { fld_1: 42 })
+  })
+
+  it('resolves a solo field-token doc to the RAW typed value', async () => {
+    h.select.mockReset()
+    h.select.mockImplementationOnce(() => chain([{ displayName: 'Jane Doe' }]))
+    h.resolveFieldTokens.mockResolvedValue(
+      new Map([['def_contact:score', { value: { type: 'number', value: 7 }, fieldType: 'NUMBER' }]])
+    )
+    await executeRuleAction(
+      {
+        type: 'set-field',
+        fieldRef: 'fld_score',
+        value: actionDoc({ type: 'placeholder', attrs: { id: 'def_contact:score' } }),
+      },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(h.crudUpdate).toHaveBeenCalledWith('def_contact:contact_1', { fld_score: 7 })
+  })
+
+  it('flattens a mixed doc value to a string', async () => {
+    h.select.mockReset()
+    h.select.mockImplementationOnce(() => chain([{ displayName: 'Jane Doe' }]))
+    await executeRuleAction(
+      {
+        type: 'set-field',
+        fieldRef: 'fld_note',
+        value: actionDoc(
+          { type: 'text', text: 'From ' },
+          { type: 'placeholder', attrs: { id: 'record:name' } }
+        ),
+      },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(h.crudUpdate).toHaveBeenCalledWith('def_contact:contact_1', {
+      fld_note: 'From Jane Doe',
+    })
+  })
+
+  it("skips on a 'deleted' firing", async () => {
+    const result = await executeRuleAction(
+      { type: 'set-field', fieldRef: 'fld_1', value: 1 },
+      rule({ on: 'deleted' }),
+      baseCtx,
+      null
+    )
+    expect(result).toBe('skipped')
+    expect(h.crudUpdate).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/record-rules/actions.ts
+++ b/packages/lib/src/record-rules/actions.ts
@@ -6,6 +6,8 @@
 import { createScopedLogger } from '@auxx/logger'
 import { toActorId } from '@auxx/types/actor'
 import { type RecordId, toRecordId } from '@auxx/types/resource'
+import type { TiptapDoc } from '../tiptap/types'
+import { isActionDoc } from './client'
 import type { RecordSnapshot } from './resolver'
 import type { CachedRecordRule, RecordRuleAction, RecordRuleFireContext } from './types'
 
@@ -61,6 +63,22 @@ export function __clearNativeRuleHandlers(): void {
 }
 
 /**
+ * Resolve one text-bearing action field (create-task title / notify message) — a
+ * placeholder-token doc (plans/signals/07-action-placeholders.md). Builds the token
+ * context once per call. Defensive guard: a plain string (stale seeded row) passes
+ * through verbatim without any context lookups. Lazy-imports the resolver — it reaches
+ * the placeholders/cache cluster.
+ */
+async function resolveActionTextField(
+  value: TiptapDoc | string,
+  ctx: RecordRuleFireContext
+): Promise<string> {
+  if (typeof value === 'string') return value
+  const { buildRuleTokenContext, resolveActionDocToText } = await import('./resolve-action-tokens')
+  return resolveActionDocToText(value, await buildRuleTokenContext(ctx))
+}
+
+/**
  * Execute one action. Returns the outcome status; throws on failure (the engine
  * catches and records it — continue-and-report).
  */
@@ -74,6 +92,15 @@ export async function executeRuleAction(
     case 'set-field': {
       // `deleted` firings have no record left to write onto.
       if (rule.on === 'deleted') return 'skipped'
+      // Doc-shaped values resolve placeholder tokens (a solo token keeps the raw typed
+      // value); raw static values (string/number/boolean) write verbatim.
+      let value = action.value
+      if (isActionDoc(action.value)) {
+        const { buildRuleTokenContext, resolveActionValue } = await import(
+          './resolve-action-tokens'
+        )
+        value = await resolveActionValue(action.value, await buildRuleTokenContext(ctx))
+      }
       const [{ UnifiedCrudHandler }, { SystemUserService }] = await Promise.all([
         import('../resources/crud/unified-handler'),
         import('../users/system-user-service'),
@@ -83,7 +110,7 @@ export async function executeRuleAction(
       await handler.update(toRecordId(ctx.entityDefinitionId, ctx.entityInstanceId), {
         // fieldRef may be a field row id OR a systemAttribute — the mutation-side
         // field resolution accepts both.
-        [action.fieldRef]: action.value,
+        [action.fieldRef]: value,
       })
       return 'ok'
     }
@@ -129,6 +156,8 @@ export async function executeRuleAction(
     }
 
     case 'notify': {
+      // Placeholder-token docs flatten to text (stale plain strings send verbatim).
+      const message = await resolveActionTextField(action.message, ctx)
       const { NotificationService } = await import('../notifications/notification-service')
       const notifications = new NotificationService()
       for (const userId of action.userIds) {
@@ -137,7 +166,7 @@ export async function executeRuleAction(
           userId,
           entityId: ctx.entityInstanceId,
           entityType: ctx.entityDefinitionId,
-          message: action.message,
+          message,
           organizationId: ctx.organizationId,
           data: {
             source: 'record-rule',
@@ -189,20 +218,8 @@ export async function executeRuleAction(
         return 'skipped'
       }
 
-      // `{{record}}` interpolation — the fired record's display name (denormalized
-      // `EntityInstance.displayName`), falling back to the raw id when unset.
-      const [instance] = await database
-        .select({ displayName: schema.EntityInstance.displayName })
-        .from(schema.EntityInstance)
-        .where(
-          and(
-            eq(schema.EntityInstance.id, ctx.entityInstanceId),
-            eq(schema.EntityInstance.organizationId, ctx.organizationId)
-          )
-        )
-        .limit(1)
-      const recordName = instance?.displayName || ctx.entityInstanceId
-      const title = action.title.replaceAll('{{record}}', recordName)
+      // Title resolution — placeholder-token docs flattened to text.
+      const title = await resolveActionTextField(action.title, ctx)
 
       const [{ createTaskService }, { SystemUserService }] = await Promise.all([
         import('../tasks'),

--- a/packages/lib/src/record-rules/batch.test.ts
+++ b/packages/lib/src/record-rules/batch.test.ts
@@ -4,6 +4,7 @@
 // per-record path (batch-of-1 ≡ single). Boundaries (actions, store, cache, db) mocked.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { legacyActionTextToDoc } from './client'
 import type { CachedRecordRule, RecordRuleBatchEvent } from './types'
 
 const h = vi.hoisted(() => {
@@ -43,7 +44,7 @@ function rule(overrides: Partial<CachedRecordRule> = {}): CachedRecordRule {
     name: 'r',
     on: 'changed',
     condition: [],
-    actions: [{ type: 'notify', userIds: ['u1'], message: 'hi' }],
+    actions: [{ type: 'notify', userIds: ['u1'], message: legacyActionTextToDoc('hi') }],
     enabled: true,
     ...overrides,
   }
@@ -221,7 +222,7 @@ describe('fireRecordRulesBatch — non-native (batch-of-1 ≡ single)', () => {
       id: 'life',
       fieldId: null,
       on: 'created',
-      actions: [{ type: 'notify', userIds: ['u'], message: 'm' }],
+      actions: [{ type: 'notify', userIds: ['u'], message: legacyActionTextToDoc('m') }],
     })
     await fireRecordRulesBatch([created], {
       ...baseCtx,

--- a/packages/lib/src/record-rules/client.ts
+++ b/packages/lib/src/record-rules/client.ts
@@ -1,5 +1,14 @@
 // packages/lib/src/record-rules/client.ts
-// Client-safe exports — types + pure constants only. No server dependencies.
+// Client-safe exports — types + pure constants/helpers only. No server dependencies.
+// Action-token helpers (plans/signals/07-action-placeholders.md): the three text-bearing
+// rule-action fields (`create-task.title`, `set-field.value`, `notify.message`) store
+// tiptap JSON docs with `placeholder` token nodes (`attrs: { id, fallback?, format? }` —
+// the snippet editor's node). Field tokens use the shared placeholder-id scheme
+// (`@auxx/lib/placeholders/client` `tryParsePlaceholderId`); the ids below are the
+// rule-specific additions resolved by `resolve-action-tokens.ts`.
+
+import { docToText } from '../tiptap/doc-to-text'
+import type { TiptapDoc, TiptapNode } from '../tiptap/types'
 
 export {
   type CachedRecordRule,
@@ -9,3 +18,68 @@ export {
   type RecordRuleActionOutcome,
   type RecordRuleOn,
 } from './types'
+
+/**
+ * Token id for the fired record's display name — the successor of the legacy v1
+ * `{{record}}` string interpolation.
+ */
+export const ACTION_TOKEN_RECORD_NAME = 'record:name'
+
+/**
+ * Signal-context tokens, offered only on `on: 'signal'` rules and resolved from
+ * `RecordRuleFireContext.signal` at execution.
+ */
+export const SIGNAL_CONTEXT_TOKENS: { id: string; label: string }[] = [
+  { id: 'signal:kind', label: 'Signal kind' },
+  { id: 'signal:subtype', label: 'Signal subtype' },
+  { id: 'signal:occurredAt', label: 'Signal date' },
+]
+
+/**
+ * Is `id` one of the rule-specific action tokens (`record:name` + the signal-context
+ * ids) — i.e. NOT part of the shared placeholder catalog? The web badge/picker and the
+ * server resolver's pre-pass both branch on this.
+ */
+export function isRuleActionToken(id: string): boolean {
+  return id === ACTION_TOKEN_RECORD_NAME || SIGNAL_CONTEXT_TOKENS.some((t) => t.id === id)
+}
+
+/**
+ * Is `v` a tiptap-doc-shaped action value (`{ type: 'doc' }`)? Distinguishes the 07 doc
+ * shape from legacy pre-07 plain-string (and, for set-field, raw) values.
+ */
+export function isActionDoc(v: unknown): v is TiptapDoc {
+  return typeof v === 'object' && v !== null && (v as { type?: unknown }).type === 'doc'
+}
+
+/**
+ * Convert a plain action string to the 07 doc shape: a single paragraph where each
+ * literal `{{record}}` becomes a `record:name` placeholder node and the remaining text
+ * becomes text nodes. Used by the seeds and as the UI's defensive normalizer (also a
+ * convenient doc-fixture builder in tests).
+ */
+export function legacyActionTextToDoc(text: string): TiptapDoc {
+  const content: TiptapNode[] = []
+  const parts = text.split('{{record}}')
+  parts.forEach((part, i) => {
+    if (i > 0) content.push({ type: 'placeholder', attrs: { id: ACTION_TOKEN_RECORD_NAME } })
+    if (part.length > 0) content.push({ type: 'text', text: part })
+  })
+  return {
+    type: 'doc',
+    content: [content.length > 0 ? { type: 'paragraph', content } : { type: 'paragraph' }],
+  }
+}
+
+/**
+ * Flatten an action field value to display text for UI summaries. Legacy strings pass
+ * through verbatim; docs flatten with each token rendered as `{Label}` via `resolveLabel`
+ * (falling back to `{id}` when unresolved).
+ */
+export function actionDocToSummaryText(
+  v: TiptapDoc | string,
+  resolveLabel?: (id: string) => string | undefined
+): string {
+  if (typeof v === 'string') return v
+  return docToText(v, { placeholders: (id) => `{${resolveLabel?.(id) ?? id}}` })
+}

--- a/packages/lib/src/record-rules/index.ts
+++ b/packages/lib/src/record-rules/index.ts
@@ -13,6 +13,12 @@ export {
 } from './capture-field-changes'
 export { fireRecordRules, fireRecordRulesBatch } from './engine'
 export { handleRecordRulesOnFieldChange } from './hook-handler'
+export {
+  buildRuleTokenContext,
+  type RuleTokenContext,
+  resolveActionDocToText,
+  resolveActionValue,
+} from './resolve-action-tokens'
 export { resolveFieldRefToId } from './resolve-field-ref'
 export { buildFieldKeyMap, makeSnapshotResolver, type RecordSnapshot } from './resolver'
 export {

--- a/packages/lib/src/record-rules/record-rules.test.ts
+++ b/packages/lib/src/record-rules/record-rules.test.ts
@@ -5,6 +5,7 @@
 // vitest (project memory), so the store is exercised at the function level only.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { legacyActionTextToDoc } from './client'
 import type { CachedRecordRule } from './types'
 
 const h = vi.hoisted(() => ({
@@ -39,7 +40,7 @@ function rule(overrides: Partial<CachedRecordRule> = {}): CachedRecordRule {
     name: 'Test rule',
     on: 'changed',
     condition: [],
-    actions: [{ type: 'notify', userIds: ['u1'], message: 'hi' }],
+    actions: [{ type: 'notify', userIds: ['u1'], message: legacyActionTextToDoc('hi') }],
     enabled: true,
     ...overrides,
   }
@@ -131,7 +132,7 @@ describe('fireRecordRules', () => {
   it('runs actions in order and logs an ok run', async () => {
     const r = rule({
       actions: [
-        { type: 'notify', userIds: ['u1'], message: 'first' },
+        { type: 'notify', userIds: ['u1'], message: legacyActionTextToDoc('first') },
         { type: 'set-field', fieldRef: 'fld_x', value: 1 },
       ],
     })
@@ -151,7 +152,7 @@ describe('fireRecordRules', () => {
     const r = rule({
       actions: [
         { type: 'set-field', fieldRef: 'fld_x', value: 1 },
-        { type: 'notify', userIds: ['u1'], message: 'still runs' },
+        { type: 'notify', userIds: ['u1'], message: legacyActionTextToDoc('still runs') },
       ],
     })
     await fireRecordRules([r], { ...baseCtx })

--- a/packages/lib/src/record-rules/resolve-action-tokens.test.ts
+++ b/packages/lib/src/record-rules/resolve-action-tokens.test.ts
@@ -1,0 +1,247 @@
+// packages/lib/src/record-rules/resolve-action-tokens.test.ts
+// Unit tests for the rule-action placeholder resolver (plans/signals/07-action-placeholders.md).
+// Mirrors document-resolver.test.ts's mocking: the shared field lookup
+// (`placeholders/resolver`) and the cache are mocked; the REAL
+// `resolvePlaceholdersInDocument` runs on top so pre-pass + fallback/format layering is
+// exercised end-to-end without a database.
+
+import { FieldType } from '@auxx/database/enums'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TiptapDoc, TiptapNode } from '../tiptap/types'
+import type { RuleTokenContext } from './resolve-action-tokens'
+
+const shared = vi.hoisted(() => ({
+  resolveFieldTokens: vi.fn(),
+  formatFieldValueForText: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ get: vi.fn(async () => ({})) }),
+  getUserCache: () => ({ get: vi.fn(async () => null) }),
+}))
+vi.mock('../placeholders/resolver', () => shared)
+
+import { resolveActionDocToText, resolveActionValue } from './resolve-action-tokens'
+
+/** Single-paragraph doc from inline nodes. */
+function doc(...content: TiptapNode[]): TiptapDoc {
+  return { type: 'doc', content: [{ type: 'paragraph', content }] }
+}
+
+function placeholder(id: string, attrs: Record<string, unknown> = {}): TiptapNode {
+  return { type: 'placeholder', attrs: { id, ...attrs } }
+}
+
+function text(t: string): TiptapNode {
+  return { type: 'text', text: t }
+}
+
+function ctx(overrides: Partial<RuleTokenContext> = {}): RuleTokenContext {
+  return {
+    recordName: 'Jane Doe',
+    placeholderCtx: {
+      db: {} as never,
+      organizationId: 'org_1',
+      senderUserId: 'user_sys',
+      recordIdsByRoot: new Map([['def_contact', 'def_contact:contact_1' as never]]),
+    },
+    ...overrides,
+  }
+}
+
+const signal = {
+  signalId: 'sig_1',
+  kind: 'email:opened',
+  subtype: 'sequence_step',
+  occurredAt: '2026-07-15T10:00:00.000Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  shared.resolveFieldTokens.mockResolvedValue(new Map())
+})
+
+describe('resolveActionDocToText', () => {
+  it('plain strings pass through verbatim — no interpolation (defensive guard)', async () => {
+    await expect(resolveActionDocToText('Follow up with {{record}} now', ctx())).resolves.toBe(
+      'Follow up with {{record}} now'
+    )
+    await expect(resolveActionDocToText('No tokens here', ctx())).resolves.toBe('No tokens here')
+  })
+
+  it('resolves record:name in a mixed doc', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(new Map())
+    const result = await resolveActionDocToText(
+      doc(text('Follow up with '), placeholder('record:name'), text(' about opens')),
+      ctx()
+    )
+    expect(result).toBe('Follow up with Jane Doe about opens')
+  })
+
+  it('resolves field tokens through the shared resolver, honoring format options', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(
+      new Map([
+        [
+          'def_contact:email',
+          { value: { type: 'text', value: 'jane@acme.test' }, fieldType: FieldType.TEXT },
+        ],
+      ])
+    )
+    shared.formatFieldValueForText.mockReturnValue('jane@acme.test')
+    const result = await resolveActionDocToText(
+      doc(text('Email '), placeholder('def_contact:email'), text(' bounced')),
+      ctx()
+    )
+    expect(result).toBe('Email jane@acme.test bounced')
+    expect(shared.resolveFieldTokens.mock.calls[0]?.[0]).toEqual([
+      { id: 'def_contact:email', parsed: expect.objectContaining({ kind: 'field' }) },
+    ])
+  })
+
+  it('uses the token FALLBACK when the field value is empty', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(new Map([['def_contact:email', null]]))
+    const result = await resolveActionDocToText(
+      doc(
+        text('Email '),
+        placeholder('def_contact:email', { fallback: { v: 1, t: 'TEXT', d: 'unknown address' } })
+      ),
+      ctx()
+    )
+    expect(result).toBe('Email unknown address')
+  })
+
+  it('degrades unparseable ids via their fallback (or empty) instead of throwing', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(new Map())
+    const result = await resolveActionDocToText(
+      doc(
+        text('A'),
+        placeholder('date:bogus', { fallback: { v: 1, t: 'TEXT', d: 'someday' } }),
+        text('B'),
+        placeholder('org:bogus')
+      ),
+      ctx()
+    )
+    expect(result).toBe('AsomedayB')
+  })
+
+  it('degrades to plain text when the shared resolver throws (bad root)', async () => {
+    shared.resolveFieldTokens.mockRejectedValue(new Error('no record for root'))
+    const result = await resolveActionDocToText(
+      doc(text('Hi '), placeholder('record:name'), text(', field: '), placeholder('def_x:missing')),
+      ctx()
+    )
+    // record:name was pre-passed; the failing field token flattens to ''.
+    expect(result).toBe('Hi Jane Doe, field:')
+  })
+
+  it('resolves signal tokens from ctx.signal (kind label, subtype, formatted date)', async () => {
+    const result = await resolveActionDocToText(
+      doc(
+        placeholder('signal:kind'),
+        text(' / '),
+        placeholder('signal:subtype'),
+        text(' / '),
+        placeholder('signal:occurredAt')
+      ),
+      ctx({ signal })
+    )
+    expect(result).toBe('Email opened / sequence_step / Jul 15, 2026')
+  })
+
+  it('falls back to the raw kind for unknown signal kinds', async () => {
+    const result = await resolveActionDocToText(
+      doc(placeholder('signal:kind')),
+      ctx({ signal: { ...signal, kind: 'custom:thing' } })
+    )
+    expect(result).toBe('custom:thing')
+  })
+
+  it('signal tokens resolve to fallback/empty without ctx.signal', async () => {
+    const result = await resolveActionDocToText(
+      doc(
+        text('['),
+        placeholder('signal:kind', { fallback: { v: 1, t: 'TEXT', d: 'a signal' } }),
+        placeholder('signal:occurredAt'),
+        text(']')
+      ),
+      ctx()
+    )
+    expect(result).toBe('[a signal]')
+  })
+})
+
+describe('resolveActionValue (set-field)', () => {
+  it('passes legacy non-doc values through verbatim', async () => {
+    await expect(resolveActionValue('vip', ctx())).resolves.toBe('vip')
+    await expect(resolveActionValue(42, ctx())).resolves.toBe(42)
+    await expect(resolveActionValue(true, ctx())).resolves.toBe(true)
+    expect(shared.resolveFieldTokens).not.toHaveBeenCalled()
+  })
+
+  it('a solo field token resolves to the RAW typed value (number, boolean)', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(
+      new Map([
+        [
+          'def_contact:score',
+          { value: { type: 'number', value: 42 }, fieldType: FieldType.NUMBER },
+        ],
+      ])
+    )
+    await expect(resolveActionValue(doc(placeholder('def_contact:score')), ctx())).resolves.toBe(42)
+
+    shared.resolveFieldTokens.mockResolvedValue(
+      new Map([
+        [
+          'def_contact:vip',
+          { value: { type: 'boolean', value: true }, fieldType: FieldType.CHECKBOX },
+        ],
+      ])
+    )
+    await expect(resolveActionValue(doc(placeholder('def_contact:vip')), ctx())).resolves.toBe(true)
+  })
+
+  it('a solo field token ignores surrounding whitespace-only text', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(
+      new Map([
+        ['def_contact:score', { value: { type: 'number', value: 7 }, fieldType: FieldType.NUMBER }],
+      ])
+    )
+    await expect(
+      resolveActionValue(doc(text('  '), placeholder('def_contact:score'), text(' ')), ctx())
+    ).resolves.toBe(7)
+  })
+
+  it('a solo field token with an empty value uses the fallback text', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(new Map([['def_contact:score', null]]))
+    await expect(
+      resolveActionValue(
+        doc(placeholder('def_contact:score', { fallback: { v: 1, t: 'NUMBER', d: 0 } })),
+        ctx()
+      )
+    ).resolves.toBe('0')
+  })
+
+  it('solo rule tokens resolve raw: record:name and signal:occurredAt (ISO)', async () => {
+    await expect(resolveActionValue(doc(placeholder('record:name')), ctx())).resolves.toBe(
+      'Jane Doe'
+    )
+    await expect(
+      resolveActionValue(doc(placeholder('signal:occurredAt')), ctx({ signal }))
+    ).resolves.toBe('2026-07-15T10:00:00.000Z')
+  })
+
+  it('mixed docs flatten to a string', async () => {
+    shared.resolveFieldTokens.mockResolvedValue(new Map())
+    await expect(
+      resolveActionValue(doc(text('VIP: '), placeholder('record:name')), ctx())
+    ).resolves.toBe('VIP: Jane Doe')
+  })
+
+  it('coerces token-free flattened docs to primitives (number, boolean, else string)', async () => {
+    await expect(resolveActionValue(doc(text('42')), ctx())).resolves.toBe(42)
+    await expect(resolveActionValue(doc(text('  3.5 ')), ctx())).resolves.toBe(3.5)
+    await expect(resolveActionValue(doc(text('true')), ctx())).resolves.toBe(true)
+    await expect(resolveActionValue(doc(text('false')), ctx())).resolves.toBe(false)
+    await expect(resolveActionValue(doc(text('not a number')), ctx())).resolves.toBe('not a number')
+  })
+})

--- a/packages/lib/src/record-rules/resolve-action-tokens.ts
+++ b/packages/lib/src/record-rules/resolve-action-tokens.ts
@@ -1,0 +1,264 @@
+// packages/lib/src/record-rules/resolve-action-tokens.ts
+// Resolution of `placeholder` token nodes in rule-action docs
+// (plans/signals/07-action-placeholders.md). Layering: a rule-specific pre-pass resolves
+// the tokens only this module knows (`record:name`, `signal:*` — ids the shared parser
+// can't own) plus anything unparseable, then hands the doc to the SHARED
+// `resolvePlaceholdersInDocument`, which owns field lookup, fallback, and format —
+// nothing re-implemented here.
+//
+// Heavy dependencies (db, cache, FieldValueService via the placeholders module) are
+// lazy-imported — this module is reached from actions.ts, which is reachable from the
+// field-hooks registry and must not create import cycles or break vi.mock in unit tests.
+
+import { createScopedLogger } from '@auxx/logger'
+import { extractValue } from '@auxx/types'
+import { format } from 'date-fns'
+import { decodeFallback, renderFallbackPayload } from '../placeholders/fallback-codec'
+import { tryParsePlaceholderId } from '../placeholders/path-parser'
+import type { PlaceholderResolutionContext } from '../placeholders/resolver'
+import { SIGNAL_KINDS, type SignalKindMeta } from '../signals/client'
+import { docToText } from '../tiptap/doc-to-text'
+import type { TiptapDoc, TiptapNode } from '../tiptap/types'
+import { ACTION_TOKEN_RECORD_NAME, isActionDoc, isRuleActionToken } from './client'
+import type { RecordRuleFireContext } from './types'
+
+const logger = createScopedLogger('record-rules-action-tokens')
+
+/** Everything rule-action token resolution reads, gathered once per action execution. */
+export interface RuleTokenContext {
+  /** The fired record's display name (falls back to the raw instance id). */
+  recordName: string
+  /** Shared resolver context: db, org, sender (org system user), recordIdsByRoot. */
+  placeholderCtx: PlaceholderResolutionContext
+  /** Signal-door provenance; absent on field/lifecycle firings (signal tokens → `''`). */
+  signal?: RecordRuleFireContext['signal']
+}
+
+/**
+ * Build the {@link RuleTokenContext} for one firing: the record's denormalized display
+ * name, and a `PlaceholderResolutionContext` rooted at the fired rule's def — plus the
+ * contact def root when the signal carries a distinct contact (mirroring
+ * `buildPlaceholderContextForThread`).
+ */
+export async function buildRuleTokenContext(ctx: RecordRuleFireContext): Promise<RuleTokenContext> {
+  const [{ database, schema }, { and, eq }] = await Promise.all([
+    import('@auxx/database'),
+    import('drizzle-orm'),
+  ])
+  const [instance] = await database
+    .select({ displayName: schema.EntityInstance.displayName })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.id, ctx.entityInstanceId),
+        eq(schema.EntityInstance.organizationId, ctx.organizationId)
+      )
+    )
+    .limit(1)
+  const recordName = instance?.displayName || ctx.entityInstanceId
+
+  const [{ SystemUserService }, { toRecordId }] = await Promise.all([
+    import('../users/system-user-service'),
+    import('@auxx/types/resource'),
+  ])
+  const senderUserId = await SystemUserService.getSystemUserForActions(ctx.organizationId)
+
+  const recordIdsByRoot: PlaceholderResolutionContext['recordIdsByRoot'] = new Map()
+  recordIdsByRoot.set(
+    ctx.entityDefinitionId,
+    toRecordId(ctx.entityDefinitionId, ctx.entityInstanceId)
+  )
+  const contactInstanceId = ctx.signal?.contactEntityInstanceId
+  if (contactInstanceId && contactInstanceId !== ctx.entityInstanceId) {
+    const { getOrgCache } = await import('../cache')
+    const entityDefs = await getOrgCache().get(ctx.organizationId, 'entityDefs')
+    // The fired record's root always wins — only add the contact under its own def.
+    if (entityDefs.contact && entityDefs.contact !== ctx.entityDefinitionId) {
+      recordIdsByRoot.set(entityDefs.contact, toRecordId('contact', contactInstanceId))
+    }
+  }
+
+  return {
+    recordName,
+    signal: ctx.signal,
+    placeholderCtx: {
+      db: database,
+      organizationId: ctx.organizationId,
+      senderUserId,
+      recordIdsByRoot,
+    },
+  }
+}
+
+/**
+ * Resolve a text-bearing action field (`create-task.title`, `notify.message`) to plain
+ * text. Docs go pre-pass → shared resolver → `docToText`; a shared-resolver throw
+ * degrades to the pre-passed doc with remaining tokens as `''` (one bad token must not
+ * kill the action). Defensive guard: a plain string (stale seeded row) passes through
+ * verbatim — no interpolation.
+ */
+export async function resolveActionDocToText(
+  value: TiptapDoc | string,
+  ctx: RuleTokenContext
+): Promise<string> {
+  if (typeof value === 'string') return value
+  const prepped = prePassRuleTokens(value, ctx) as TiptapDoc
+  try {
+    const { resolvePlaceholdersInDocument } = await import('../placeholders/document-resolver')
+    const resolved = await resolvePlaceholdersInDocument(prepped, ctx.placeholderCtx)
+    return docToText(resolved)
+  } catch (error) {
+    logger.warn('Rule action placeholder resolution failed — degrading to plain text', {
+      organizationId: ctx.placeholderCtx.organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return docToText(prepped, { placeholders: () => '' })
+  }
+}
+
+/**
+ * Resolve a `set-field` value. Non-docs (raw static strings/numbers/booleans) pass
+ * through verbatim. A doc whose only meaningful content is ONE placeholder node (single
+ * paragraph, whitespace-only text ignored) resolves to the RAW value, type preserved:
+ * field tokens via the shared `resolveFieldTokens` (empty + fallback → the fallback
+ * text), `record:name` → the display name, `signal:*` → its raw value (`occurredAt` as
+ * ISO string). Anything else flattens via {@link resolveActionDocToText}, then coerces
+ * the final string to a primitive (`'true'`/`'false'` → boolean, numeric → number) so a
+ * NUMBER field set to a typed `"42"` still receives a number.
+ */
+export async function resolveActionValue(value: unknown, ctx: RuleTokenContext): Promise<unknown> {
+  if (!isActionDoc(value)) return value
+  const solo = singlePlaceholderNode(value)
+  if (!solo) return coercePrimitive(await resolveActionDocToText(value, ctx))
+
+  if (isRuleActionToken(solo.id)) {
+    const raw = ruleTokenRawValue(solo.id, ctx)
+    return raw === undefined || raw === '' ? nodeFallbackText(solo.attrs) : raw
+  }
+
+  const parsed = tryParsePlaceholderId(solo.id)
+  if (parsed?.kind === 'field') {
+    try {
+      const { resolveFieldTokens } = await import('../placeholders/resolver')
+      const values = await resolveFieldTokens([{ id: solo.id, parsed }], ctx.placeholderCtx)
+      const resolved = values.get(solo.id)
+      if (!resolved) return nodeFallbackText(solo.attrs)
+      return Array.isArray(resolved.value)
+        ? resolved.value.map((v) => extractValue(v))
+        : extractValue(resolved.value)
+    } catch (error) {
+      logger.warn('Rule set-field token resolution failed — using fallback', {
+        organizationId: ctx.placeholderCtx.organizationId,
+        tokenId: solo.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return nodeFallbackText(solo.attrs)
+    }
+  }
+
+  // org/user/date tokens (and unparseable ids) have no raw form — flatten to text.
+  return coercePrimitive(await resolveActionDocToText(value, ctx))
+}
+
+/**
+ * Coerce a flattened set-field string to its primitive form (the write-side replacement
+ * for the token editor's old client-side `coerceValue`): `'true'`/`'false'` → boolean,
+ * numeric strings → number, everything else stays a string.
+ */
+function coercePrimitive(text: string): unknown {
+  const trimmed = text.trim()
+  if (trimmed === 'true') return true
+  if (trimmed === 'false') return false
+  if (trimmed !== '' && !Number.isNaN(Number(trimmed))) return Number(trimmed)
+  return text
+}
+
+// ── Pre-pass ────────────────────────────────────────────────────────────────
+
+/**
+ * Copy the doc, turning every placeholder node the SHARED resolver must not see into a
+ * text node: rule tokens (`record:name`, `signal:*`) get their resolved text, and
+ * unparseable ids degrade to their fallback/`''` — `resolvePlaceholdersInDocument`
+ * THROWS on ids `tryParsePlaceholderId` rejects, so none may reach it. Parseable shared
+ * tokens pass through untouched (fallback + format stay theirs to apply).
+ */
+function prePassRuleTokens(node: TiptapNode, ctx: RuleTokenContext): TiptapNode {
+  if (node.type === 'placeholder') {
+    const id = typeof node.attrs?.id === 'string' ? (node.attrs.id as string) : ''
+    if (id && !isRuleActionToken(id) && tryParsePlaceholderId(id)) {
+      // Shared-catalog token — leave for resolvePlaceholdersInDocument.
+      return { ...node, attrs: { ...node.attrs } }
+    }
+    const text = id && isRuleActionToken(id) ? ruleTokenText(id, ctx) : ''
+    return {
+      type: 'text',
+      text: text || nodeFallbackText(node.attrs),
+      ...(node.marks ? { marks: node.marks.map((mark) => ({ ...mark })) } : {}),
+    }
+  }
+  return {
+    ...node,
+    ...(node.attrs ? { attrs: { ...node.attrs } } : {}),
+    ...(node.marks ? { marks: node.marks.map((mark) => ({ ...mark })) } : {}),
+    ...(node.content
+      ? { content: node.content.map((child) => prePassRuleTokens(child, ctx)) }
+      : {}),
+  }
+}
+
+/** Text form of a rule-specific token (`''` when unresolvable — caller applies fallback). */
+function ruleTokenText(id: string, ctx: RuleTokenContext): string {
+  if (id === 'signal:occurredAt') {
+    const iso = ctx.signal?.occurredAt
+    if (!iso) return ''
+    const date = new Date(iso)
+    return Number.isNaN(date.getTime()) ? iso : format(date, 'MMM d, yyyy')
+  }
+  const raw = ruleTokenRawValue(id, ctx)
+  return raw === undefined ? '' : String(raw)
+}
+
+/** Raw form of a rule-specific token (set-field solo tokens; `occurredAt` stays ISO). */
+function ruleTokenRawValue(id: string, ctx: RuleTokenContext): unknown {
+  if (id === ACTION_TOKEN_RECORD_NAME) return ctx.recordName
+  if (id === 'signal:kind') {
+    const kind = ctx.signal?.kind
+    if (!kind) return undefined
+    const meta = (SIGNAL_KINDS as Record<string, SignalKindMeta | undefined>)[kind]
+    return meta?.label ?? kind
+  }
+  if (id === 'signal:subtype') return ctx.signal?.subtype
+  if (id === 'signal:occurredAt') return ctx.signal?.occurredAt
+  return undefined
+}
+
+// ── Shape helpers ───────────────────────────────────────────────────────────
+
+/**
+ * The single-token rule: exactly one paragraph whose only meaningful content is one
+ * placeholder node (whitespace-only text ignored). Returns its id + attrs, else null.
+ */
+function singlePlaceholderNode(
+  doc: TiptapDoc
+): { id: string; attrs?: Record<string, unknown> } | null {
+  const blocks = doc.content ?? []
+  if (blocks.length !== 1) return null
+  const paragraph = blocks[0]
+  if (!paragraph || paragraph.type !== 'paragraph') return null
+  const meaningful = (paragraph.content ?? []).filter(
+    (n) => !(typeof n.text === 'string' && n.text.trim() === '')
+  )
+  const only = meaningful.length === 1 ? meaningful[0] : undefined
+  if (!only || only.type !== 'placeholder') return null
+  const id = only.attrs?.id
+  return typeof id === 'string' && id.length > 0 ? { id, attrs: only.attrs } : null
+}
+
+/** Decode a node's `attrs.fallback` payload to text (same codec path as the shared
+ * document resolver's `decodePayload`); `''` when absent/undecodable. */
+function nodeFallbackText(attrs: Record<string, unknown> | undefined): string {
+  const fallback = attrs?.fallback
+  if (!fallback || typeof fallback !== 'object') return ''
+  const payload = decodeFallback(JSON.stringify(fallback))
+  return payload ? renderFallbackPayload(payload) : ''
+}

--- a/packages/lib/src/record-rules/seed-suggested-rules.ts
+++ b/packages/lib/src/record-rules/seed-suggested-rules.ts
@@ -20,6 +20,7 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import type { ConditionGroup } from '../conditions/types'
+import { legacyActionTextToDoc } from './client'
 import { assertRuleShape } from './store'
 import type { CreateTaskAction, RecordRuleAction } from './types'
 
@@ -55,7 +56,7 @@ export const SUGGESTED_RECORD_RULE_TEMPLATES: SuggestedRuleTemplate[] = [
     actions: [
       {
         type: 'create-task',
-        title: 'Review unsubscribe from {{record}}',
+        title: legacyActionTextToDoc('Review unsubscribe from {{record}}'),
       } satisfies CreateTaskAction,
     ],
   },
@@ -65,7 +66,10 @@ export const SUGGESTED_RECORD_RULE_TEMPLATES: SuggestedRuleTemplate[] = [
     signalKind: 'email:bounced',
     condition: [],
     actions: [
-      { type: 'create-task', title: 'Fix invalid email for {{record}}' } satisfies CreateTaskAction,
+      {
+        type: 'create-task',
+        title: legacyActionTextToDoc('Fix invalid email for {{record}}'),
+      } satisfies CreateTaskAction,
     ],
   },
   {
@@ -76,7 +80,7 @@ export const SUGGESTED_RECORD_RULE_TEMPLATES: SuggestedRuleTemplate[] = [
     actions: [
       {
         type: 'create-task',
-        title: 'Follow up with {{record}} — opening but not replying',
+        title: legacyActionTextToDoc('Follow up with {{record}} — opening but not replying'),
         autoCompleteOn: 'contact_reply',
         deadlineDays: 2,
       } satisfies CreateTaskAction,

--- a/packages/lib/src/record-rules/store.test.ts
+++ b/packages/lib/src/record-rules/store.test.ts
@@ -3,6 +3,7 @@
 // actions (the tRPC create/update path calls this). Pure — no DB.
 
 import { describe, expect, it } from 'vitest'
+import { legacyActionTextToDoc } from './client'
 import { assertRuleShape } from './store'
 
 const fieldRule = { fieldId: 'fld_1', on: 'changed' as const }
@@ -28,7 +29,10 @@ describe('assertRuleShape — native actions', () => {
 
   it('accepts a normal user rule', () => {
     expect(() =>
-      assertRuleShape({ ...fieldRule, actions: [{ type: 'notify', userIds: ['u'], message: 'm' }] })
+      assertRuleShape({
+        ...fieldRule,
+        actions: [{ type: 'notify', userIds: ['u'], message: legacyActionTextToDoc('m') }],
+      })
     ).not.toThrow()
   })
 
@@ -55,7 +59,7 @@ describe('assertRuleShape — native actions', () => {
 })
 
 describe('assertRuleShape — signal door (decision 4)', () => {
-  const notify = [{ type: 'notify' as const, userIds: ['u'], message: 'm' }]
+  const notify = [{ type: 'notify' as const, userIds: ['u'], message: legacyActionTextToDoc('m') }]
 
   it('accepts a signal rule with a recognized signalKind and no fieldId', () => {
     expect(() =>
@@ -99,7 +103,7 @@ describe('assertRuleShape — signal door (decision 4)', () => {
 })
 
 describe('assertRuleShape — stale signal:* conditions (decision 15)', () => {
-  const notify = [{ type: 'notify' as const, userIds: ['u'], message: 'm' }]
+  const notify = [{ type: 'notify' as const, userIds: ['u'], message: legacyActionTextToDoc('m') }]
 
   it('rejects a condition referencing a signal:* pseudo-field on a non-signal rule', () => {
     expect(() =>

--- a/packages/lib/src/record-rules/system-rules.test.ts
+++ b/packages/lib/src/record-rules/system-rules.test.ts
@@ -3,6 +3,7 @@
 // customFields / entityDefs lookups. Pure — no DB, no cache.
 
 import { afterEach, describe, expect, it } from 'vitest'
+import { legacyActionTextToDoc } from './client'
 import {
   __clearSystemRules,
   declareSystemRules,
@@ -23,7 +24,7 @@ describe('declareSystemRules — validation', () => {
           defSlug: 'vendor-parts',
           fieldRef: { systemAttribute: 'vendor_part_unit_price' },
           on: 'changed',
-          actions: [{ type: 'notify', userIds: ['u'], message: 'm' }],
+          actions: [{ type: 'notify', userIds: ['u'], message: legacyActionTextToDoc('m') }],
         },
       ])
     ).toThrow(/native/)
@@ -40,7 +41,7 @@ describe('declareSystemRules — validation', () => {
           on: 'changed',
           actions: [
             { type: 'native', handler: 'recalc' },
-            { type: 'notify', userIds: ['u'], message: 'm' },
+            { type: 'notify', userIds: ['u'], message: legacyActionTextToDoc('m') },
           ],
         },
       ])

--- a/packages/lib/src/record-rules/types.ts
+++ b/packages/lib/src/record-rules/types.ts
@@ -5,6 +5,7 @@
 
 import type { ConditionGroup } from '../conditions/types'
 import type { TaskPriority } from '../tasks/types'
+import type { TiptapDoc } from '../tiptap/types'
 
 /**
  * Transition selector. Direction semantics live on the rule, NOT in conditions.
@@ -35,6 +36,12 @@ export const LIFECYCLE_TRANSITIONS: readonly RecordRuleOn[] = ['created', 'delet
 export interface SetFieldAction {
   type: 'set-field'
   fieldRef: string
+  /**
+   * Tiptap JSON doc with `placeholder` token nodes (plans/signals/07-action-placeholders.md).
+   * A doc whose only meaningful content is a single token resolves to the RAW value (type
+   * preserved); mixed content flattens to a string. Legacy pre-07 rows carry a raw value
+   * (string/number/…), written verbatim — hence `unknown` rather than `TiptapDoc | string`.
+   */
   value: unknown
 }
 
@@ -48,7 +55,11 @@ export interface EnqueueWorkflowAction {
 export interface NotifyAction {
   type: 'notify'
   userIds: string[]
-  message: string
+  /**
+   * Tiptap JSON doc with `placeholder` token nodes, flattened to text at execution
+   * (plans/signals/07-action-placeholders.md).
+   */
+  message: TiptapDoc
 }
 
 /**
@@ -65,13 +76,16 @@ export interface NativeAction {
 /**
  * Create a follow-up task from the fired record (decision 11 — v1 scope). Registered as
  * a normal (non-native) action: immediately usable on field/lifecycle/sync/signal doors
- * alike, no `managed` gate. Dedupe + completion cooldown (decision 7) and
- * `{{record}}` title interpolation are handled by the executor (`actions.ts`).
+ * alike, no `managed` gate. Dedupe + completion cooldown (decision 7) and placeholder-
+ * token title resolution are handled by the executor (`actions.ts`).
  */
 export interface CreateTaskAction {
   type: 'create-task'
-  /** May contain the literal token `{{record}}`, replaced with the fired record's display name. */
-  title: string
+  /**
+   * Tiptap JSON doc with `placeholder` token nodes, flattened to text at execution
+   * (plans/signals/07-action-placeholders.md).
+   */
+  title: TiptapDoc
   /** Fixed assignee user ids. No record-owner strategy yet (decision 11). */
   assigneeIds?: string[]
   /** Relative deadline in days from firing time, resolved the same way `createTask` does. */
@@ -195,5 +209,9 @@ export interface RecordRuleFireContext {
     signalId: string
     kind: string
     contactEntityInstanceId?: string
+    /** The signal's `subtype` (e.g. `'sequence_step'`), for `signal:subtype` action tokens. */
+    subtype?: string
+    /** ISO timestamp the signal occurred at, for `signal:occurredAt` action tokens. */
+    occurredAt?: string
   }
 }

--- a/packages/lib/src/tiptap/doc-to-text.ts
+++ b/packages/lib/src/tiptap/doc-to-text.ts
@@ -2,7 +2,7 @@
 
 import type { TiptapNode } from './types'
 
-interface DocToTextOptions {
+export interface DocToTextOptions {
   /**
    * Optional resolver for inline `reference` nodes. Receives the `RecordId`
    * and returns the markdown text to inline (typically `[Title](recordId)`).
@@ -29,6 +29,14 @@ interface DocToTextOptions {
     subProcedures?: { id: string; name: string }[]
     codeBlocks?: { id: string; name: string }[]
   }
+  /**
+   * Optional resolver for inline `placeholder` chips (the snippet/sequence
+   * editor's token node — `attrs: { id, fallback?, format? }`, the full attrs
+   * bag is passed through). Receives the token id and returns the text to
+   * inline. When unset, the chip renders to `{{id}}` — the same form the
+   * node's own `renderText` produces.
+   */
+  placeholders?: (id: string, attrs?: Record<string, unknown>) => string
 }
 
 /**
@@ -159,6 +167,11 @@ function walkNode(
     const badge = renderStepBadge(id, options.procedureMaps)
     if (badge !== null) return badge
     return options.references ? options.references(id) : `[reference](${id})`
+  }
+  if (node.type === 'placeholder') {
+    const id = typeof node.attrs?.id === 'string' ? (node.attrs.id as string) : ''
+    if (!id) return ''
+    return options.placeholders ? options.placeholders(id, node.attrs) : `{{${id}}}`
   }
   if (node.type === 'variable-node') {
     const variableId =

--- a/packages/lib/src/tiptap/index.ts
+++ b/packages/lib/src/tiptap/index.ts
@@ -11,7 +11,7 @@
 export { collectReferenceIds } from './collect-references'
 export { collectVariableIds } from './collect-variable-ids'
 export { isNonEmptyDoc, trimTrailingEmptyParagraphs } from './doc-shape'
-export { docToText } from './doc-to-text'
+export { type DocToTextOptions, docToText } from './doc-to-text'
 export { docToHtml, htmlToDoc, stripHtml } from './html'
 export {
   appendSequenceUnsubscribeFooter,


### PR DESCRIPTION
## Summary

Two features from the signals workstream (plan 07 + snooze follow-ups):

### Placeholder tokens in rule-action fields (plans/signals/07)
- `create-task` **title**, `set-field` **value**, and `notify` **message** are now tiptap docs with placeholder tokens. Typing `{` opens a Command picker offering the record's name, the record's fields (relationship drill-down included), and — on signal rules only — signal context (kind / subtype / date).
- New `ActionTokenInput`: single-line tiptap editor (token-field ergonomics) committing the snippet system's `placeholder` nodes, so field chips reuse `PlaceholderBadge` with its **fallback** ("replacement when empty") and format popover.
- Server resolution layers a rule-specific pre-pass (`record:name`, `signal:*`) over the shared `resolvePlaceholdersInDocument` — no bespoke field/fallback/format logic. A set-field doc that is a single token resolves to the **raw typed value**; token-free doc text coerces to number/boolean (replaces the client-side `coerceValue`).
- No legacy-string support (no legacy rows exist): `{{record}}` interpolation removed; seeded suggested rules store doc titles; `RecordRuleFireContext.signal` gains `subtype`/`occurredAt`.

### Task snooze visibility + save-time snooze
- "Show snoozed" switch in the task filter bar (wires the existing `includeSnoozed` list option through `useTasks`/`TasksList`) — snoozed tasks were previously invisible with no way to surface or unsnooze them.
- Snoozed row badge is amber with the alarm-clock icon.
- `TaskSnoozeButton` is now a controlled picker: the snooze buffers in `TaskForm` state and persists on **Save** like every other task field (Cancel discards it).

## Testing
- 203 tests passing across the record-rules / placeholders / tiptap / signal-handler scopes (new resolver suite + executor token cases included).
- Scoped `tsc` on both packages: zero new errors in touched files.
- Biome clean.
- E2E dev-loop (fire a signal rule → resolved task title) not yet run.