### PR TITLE
feat(printing): tree-row content page with shared sortable primitives

### DIFF
--- a/apps/web/src/components/dispatch/ui/quality-check-tree-row.tsx
+++ b/apps/web/src/components/dispatch/ui/quality-check-tree-row.tsx
@@ -4,11 +4,9 @@
 
 import { Badge } from '@auxx/ui/components/badge'
 import { Switch } from '@auxx/ui/components/switch'
-import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { SortableTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, Trash2 } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 import type { RouterOutputs } from '~/trpc/react'
 
 export type QcItemTemplateRow = RouterOutputs['dispatch']['listQcTemplates'][number]
@@ -24,10 +22,10 @@ interface QualityCheckTreeRowProps {
 
 /**
  * One QC template row in the settings tree list (08-worker-surface.md §5), styled to match the
- * Products & Services lists — draggable via dnd-kit `useSortable` (the drag handle doubles as the
- * row's leading icon); selecting it opens the FieldPanel editor. Trailing actions mirror
- * products-list.tsx: a destructive delete button (already-materialized visit checklists keep
- * their snapshot rows) and the active/inactive `Switch`.
+ * Products & Services lists — a `SortableTreeRow` (hover-revealed drag grip in the leading slot);
+ * selecting it opens the FieldPanel editor. Trailing actions mirror products-list.tsx: a
+ * destructive delete button (already-materialized visit checklists keep their snapshot rows)
+ * and the active/inactive `Switch`.
  */
 export function QualityCheckTreeRow({
   template,
@@ -37,56 +35,39 @@ export function QualityCheckTreeRow({
   onDelete,
   isPending,
 }: QualityCheckTreeRowProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: template.id,
-  })
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    zIndex: isDragging ? 10 : undefined,
-    opacity: isDragging ? 0.8 : 1,
-  }
-
   return (
-    <div ref={setNodeRef} style={style}>
-      <TreeRow
-        icon={
-          <span {...attributes} {...listeners} className='cursor-grab touch-none'>
-            <GripVertical className='size-4' />
+    <SortableTreeRow
+      id={template.id}
+      isOpen={isSelected}
+      onToggleOpen={onSelect}
+      rowClassName={cn(
+        'bg-primary-100/50 hover:bg-primary-100',
+        isSelected && 'bg-primary-100 ring-1 ring-primary-200',
+        !template.isActive && 'opacity-60'
+      )}
+      title={<span className='text-sm'>{template.title}</span>}
+      secondary={
+        template.isRequired ? (
+          <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+            <Badge variant='secondary' size='xs'>
+              Required
+            </Badge>
           </span>
-        }
-        isOpen={isSelected}
-        onToggleOpen={onSelect}
-        rowClassName={cn(
-          'bg-primary-100/50 hover:bg-primary-100',
-          isSelected && 'bg-primary-100 ring-1 ring-primary-200',
-          !template.isActive && 'opacity-60'
-        )}
-        title={<span className='text-sm'>{template.title}</span>}
-        secondary={
-          template.isRequired ? (
-            <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
-              <Badge variant='secondary' size='xs'>
-                Required
-              </Badge>
-            </span>
-          ) : undefined
-        }
-        actions={
-          <div className='flex items-center gap-1'>
-            <TreeRowButton tooltipText='Delete check' variant='destructive' onClick={onDelete}>
-              <Trash2 />
-            </TreeRowButton>
-            <Switch
-              size='xs'
-              checked={template.isActive}
-              onCheckedChange={onToggleActive}
-              disabled={isPending}
-            />
-          </div>
-        }
-      />
-    </div>
+        ) : undefined
+      }
+      actions={
+        <div className='flex items-center gap-1'>
+          <TreeRowButton tooltipText='Delete check' variant='destructive' onClick={onDelete}>
+            <Trash2 />
+          </TreeRowButton>
+          <Switch
+            size='xs'
+            checked={template.isActive}
+            onCheckedChange={onToggleActive}
+            disabled={isPending}
+          />
+        </div>
+      }
+    />
   )
 }

--- a/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
+++ b/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
@@ -6,26 +6,11 @@ import { FieldType } from '@auxx/database/enums'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { SortableList } from '@auxx/ui/components/sortable'
 import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils'
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core'
-import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
 import { Lock, Plus } from 'lucide-react'
 import { useRef, useState } from 'react'
 import type { QcItemTemplateRow } from '~/components/dispatch/ui/quality-check-tree-row'
@@ -155,21 +140,14 @@ export function QualityChecksPage() {
   const selected = orderedTemplates.find((t) => t.id === selectedId) ?? null
   const isDraftSelected = draft !== null && selectedId === draft.draftId
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  )
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = orderedTemplates.findIndex((t) => t.id === active.id)
-    const newIndex = orderedTemplates.findIndex((t) => t.id === over.id)
-    if (oldIndex === -1 || newIndex === -1) return
-
-    // The draft (if any) never enters `orderedTemplates` — it's local state rendered as a
-    // trailing row outside the sortable list — so it can never appear in this payload.
-    const reordered = arrayMove(orderedTemplates, oldIndex, newIndex)
+  // The draft (if any) never enters `orderedTemplates` — it's local state rendered as a
+  // trailing row outside the sortable list — so it can never appear in this payload.
+  const handleReorder = (ids: string[]) => {
+    const byId = new Map(orderedTemplates.map((t) => [t.id, t]))
+    const reordered = ids
+      .map((id) => byId.get(id))
+      .filter((t): t is QcItemTemplateRow => t !== undefined)
+    if (reordered.length !== orderedTemplates.length) return
     setOrderOverride(reordered)
     reorderTemplates.mutate(reordered.map((t, i) => ({ id: t.id, sortOrder: i })))
   }
@@ -372,27 +350,19 @@ export function QualityChecksPage() {
             ) : (
               <div className='flex flex-col gap-0.5'>
                 {orderedTemplates.length > 0 && (
-                  <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                    modifiers={[restrictToVerticalAxis]}>
-                    <SortableContext
-                      items={orderedTemplates.map((t) => t.id)}
-                      strategy={verticalListSortingStrategy}>
-                      {orderedTemplates.map((template) => (
-                        <QualityCheckTreeRow
-                          key={template.id}
-                          template={template}
-                          isSelected={selectedId === template.id}
-                          onSelect={() => selectRow(template.id)}
-                          onToggleActive={() => handleToggleActive(template)}
-                          onDelete={() => handleDelete(template)}
-                          isPending={updateTemplate.isPending}
-                        />
-                      ))}
-                    </SortableContext>
-                  </DndContext>
+                  <SortableList items={orderedTemplates.map((t) => t.id)} onReorder={handleReorder}>
+                    {orderedTemplates.map((template) => (
+                      <QualityCheckTreeRow
+                        key={template.id}
+                        template={template}
+                        isSelected={selectedId === template.id}
+                        onSelect={() => selectRow(template.id)}
+                        onToggleActive={() => handleToggleActive(template)}
+                        onDelete={() => handleDelete(template)}
+                        isPending={updateTemplate.isPending}
+                      />
+                    ))}
+                  </SortableList>
                 )}
 
                 {draft && !draft.recordId && (

--- a/apps/web/src/components/print/hooks/use-print-columns.ts
+++ b/apps/web/src/components/print/hooks/use-print-columns.ts
@@ -3,30 +3,48 @@
 'use client'
 
 import type { ExportColumn } from '@auxx/lib/export/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import {
+  type FieldReference,
+  isFieldPath,
+  isResourceFieldId,
+  type ResourceFieldId,
+} from '@auxx/types/field'
 import { useCallback, useMemo, useState } from 'react'
 import { useExportColumns } from '~/components/data-export/hooks/use-export-columns'
+import { useFields } from '~/components/resources/hooks/use-field'
 
-/** Stable identity for an `ExportColumn` — `fieldRef` is a string or a path (string[]). */
+/** Stable identity for a `FieldReference` — a direct id or a joined path. */
+export function refKey(ref: FieldReference): string {
+  return Array.isArray(ref) ? ref.join('.') : ref
+}
+
+/** Stable identity for an `ExportColumn`. */
 export function columnKey(column: ExportColumn): string {
-  return Array.isArray(column.fieldRef) ? column.fieldRef.join('.') : column.fieldRef
+  return refKey(column.fieldRef)
 }
 
 export interface UsePrintColumnsResult {
-  /** Selected columns, in print order. */
+  /** Selected columns, in print order — labels resolved (path hops joined with ›). */
   selected: ExportColumn[]
-  /** Remaining columns available to add (view + all fields, minus selected). */
-  available: ExportColumn[]
-  addColumn: (column: ExportColumn) => void
+  /** Direct refs already selected — the field picker's exclude list. */
+  excludeFields: ResourceFieldId[]
+  /** Per-hop resolved fields — for breadcrumb labels and field-type icons. */
+  hopFields: Map<string, ResourceField>
+  /** Add a field-picker selection (direct or drilled path). No-op if already selected. */
+  addField: (ref: FieldReference) => void
   removeColumn: (column: ExportColumn) => void
-  /** Reorder `selected` — receives the full new key order (see `CommandSortable`). */
+  /** Reorder `selected` — receives the full new key order (see `SortableList`). */
   reorder: (keys: string[]) => void
 }
 
 /**
- * Print wizard "Content" page column state (list style). Seeded from
- * {@link useExportColumns} exactly like the CSV export flow — `viewColumns` preselected,
- * `allColumns` the addable pool — with local add/remove/reorder for the drag-to-reorder
- * picker (`PrintColumnPicker`).
+ * Print wizard "Content" page column state (list/detail styles). Seeded from
+ * {@link useExportColumns} exactly like the CSV export flow — `viewColumns` preselected —
+ * but open-ended: any `FieldReference` the field picker produces (including drilled
+ * relationship paths) can be added. Labels prefer what the table already resolved
+ * (per-view overrides); refs the view doesn't know fall back to field metadata,
+ * resolved per hop via `useFields` (columns-row.tsx recipe).
  */
 export function usePrintColumns(
   tableId: string,
@@ -34,41 +52,75 @@ export function usePrintColumns(
 ): UsePrintColumnsResult {
   const { viewColumns, allColumns } = useExportColumns(tableId, entityDefinitionId)
 
-  // Union of both pools, keyed for lookup — `viewColumns` can include relationship-path
-  // columns `allColumns` doesn't carry (it's direct entity fields only).
-  const pool = useMemo(() => {
-    const map = new Map<string, ExportColumn>()
+  // Labels the table already resolved — view label overrides win over field metadata.
+  const knownLabels = useMemo(() => {
+    const map = new Map<string, string>()
     for (const column of [...viewColumns, ...allColumns]) {
-      if (!map.has(columnKey(column))) map.set(columnKey(column), column)
+      if (!map.has(columnKey(column))) map.set(columnKey(column), column.label)
     }
     return map
   }, [viewColumns, allColumns])
 
-  const [selectedKeys, setSelectedKeys] = useState<string[]>(() => viewColumns.map(columnKey))
-
-  const selected = useMemo(
-    () => selectedKeys.map((key) => pool.get(key)).filter((c): c is ExportColumn => c != null),
-    [selectedKeys, pool]
+  const [selectedRefs, setSelectedRefs] = useState<FieldReference[]>(() =>
+    viewColumns.map((c) => c.fieldRef)
   )
 
-  const available = useMemo(
-    () => Array.from(pool.values()).filter((c) => !selectedKeys.includes(columnKey(c))),
-    [pool, selectedKeys]
+  // Every hop of every selected ref in one shallow-compared subscription, so newly
+  // drilled paths (and their breadcrumb segments/icons) resolve without per-row hooks.
+  const allHops = useMemo(() => {
+    const seen = new Set<ResourceFieldId>()
+    for (const ref of selectedRefs) {
+      for (const hop of isFieldPath(ref) ? ref : [ref]) {
+        if (isResourceFieldId(hop)) seen.add(hop)
+      }
+    }
+    return [...seen]
+  }, [selectedRefs])
+  const hopFieldList = useFields(allHops)
+  const hopFields = useMemo(() => {
+    const map = new Map<string, ResourceField>()
+    allHops.forEach((hop, i) => {
+      const field = hopFieldList[i]
+      if (field) map.set(hop, field)
+    })
+    return map
+  }, [allHops, hopFieldList])
+
+  const selected = useMemo<ExportColumn[]>(
+    () =>
+      selectedRefs.map((ref) => ({
+        label:
+          knownLabels.get(refKey(ref)) ??
+          (isFieldPath(ref)
+            ? ref.map((hop) => hopFields.get(hop)?.label ?? hop).join(' › ')
+            : (hopFields.get(ref)?.label ?? ref)),
+        fieldRef: ref,
+      })),
+    [selectedRefs, knownLabels, hopFields]
   )
 
-  const addColumn = useCallback((column: ExportColumn) => {
-    setSelectedKeys((prev) =>
-      prev.includes(columnKey(column)) ? prev : [...prev, columnKey(column)]
-    )
+  const excludeFields = useMemo(
+    () => selectedRefs.filter((ref): ref is ResourceFieldId => !isFieldPath(ref)),
+    [selectedRefs]
+  )
+
+  const addField = useCallback((ref: FieldReference) => {
+    setSelectedRefs((prev) => (prev.some((r) => refKey(r) === refKey(ref)) ? prev : [...prev, ref]))
   }, [])
 
   const removeColumn = useCallback((column: ExportColumn) => {
-    setSelectedKeys((prev) => prev.filter((key) => key !== columnKey(column)))
+    setSelectedRefs((prev) => prev.filter((ref) => refKey(ref) !== columnKey(column)))
   }, [])
 
   const reorder = useCallback((keys: string[]) => {
-    setSelectedKeys(keys)
+    setSelectedRefs((prev) => {
+      const byKey = new Map(prev.map((ref) => [refKey(ref), ref] as const))
+      const next = keys
+        .map((key) => byKey.get(key))
+        .filter((ref): ref is FieldReference => ref !== undefined)
+      return next.length === prev.length ? next : prev
+    })
   }, [])
 
-  return { selected, available, addColumn, removeColumn, reorder }
+  return { selected, excludeFields, hopFields, addField, removeColumn, reorder }
 }

--- a/apps/web/src/components/print/ui/print-column-picker.tsx
+++ b/apps/web/src/components/print/ui/print-column-picker.tsx
@@ -2,87 +2,148 @@
 
 'use client'
 
-import type { PrintStyle } from '@auxx/lib/export/client'
-import {
-  Command,
-  CommandCheckboxItem,
-  CommandDescription,
-  CommandGroup,
-  CommandList,
-  CommandSeparator,
-  CommandSortable,
-  CommandSortableItem,
-} from '@auxx/ui/components/command'
-import { X } from 'lucide-react'
+import type { FieldType } from '@auxx/database/types'
+import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
+import type { ExportColumn, PrintStyle } from '@auxx/lib/export/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { mapBaseTypeToFieldType } from '@auxx/lib/workflow-engine/client'
+import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
+import { isFieldPath } from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { EmptySection } from '@auxx/ui/components/section'
+import { type BreadcrumbSegment, SmartBreadcrumb } from '@auxx/ui/components/smart-breadcrumb'
+import { SortableList } from '@auxx/ui/components/sortable'
+import { SortableTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Plus, Trash2 } from 'lucide-react'
+import { useMemo } from 'react'
+import { FieldPicker } from '~/components/pickers/field-picker'
+import { useResourceProperty } from '~/components/resources'
 import { columnKey, type UsePrintColumnsResult } from '../hooks/use-print-columns'
 
 interface PrintColumnPickerProps {
   columns: UsePrintColumnsResult
-  /** List calls the picked entries "Columns"; detail calls the exact same entries "Fields"
+  entityDefinitionId: string
+  /** List calls the picked entries "columns"; detail calls the exact same entries "fields"
    * (the label/value blocks on each record's sheet) — same picker, different word. */
   style: PrintStyle
 }
 
 /**
- * Print wizard "Content" page — the column/field picker `usePrintColumns` drives, reused
- * as-is by both the `list` style (table columns) and the `detail` style (label/value field
- * blocks) since the underlying selection semantics are identical (`viewColumns` preselected,
- * `allColumns` addable, drag to reorder). Selected entries are drag-reorderable
- * (`CommandSortable`), removable; the remaining pool is addable via a checkbox. Mirrors
- * `column-manager.tsx`'s sortable-list idiom.
+ * Print wizard "Content" page — the column/field list `usePrintColumns` drives, shared by the
+ * `list` style (table columns) and the `detail` style (label/value field blocks). Selected
+ * entries render as `SortableTreeRow`s (hover grip to reorder, hover `Trash2` to remove;
+ * drilled paths as breadcrumbs); "Add" opens the regular `FieldPicker` popover with search +
+ * relationship drill-down, staying open for multi-add.
  */
-export function PrintColumnPicker({ columns, style }: PrintColumnPickerProps) {
-  const { selected, available, addColumn, removeColumn, reorder } = columns
-  const noun = style === 'detail' ? 'Fields' : 'Columns'
+export function PrintColumnPicker({ columns, entityDefinitionId, style }: PrintColumnPickerProps) {
+  const { selected, excludeFields, hopFields, addField, removeColumn, reorder } = columns
+  const noun = style === 'detail' ? 'field' : 'column'
 
   return (
-    <Command shouldFilter={false} className='p-0'>
-      <CommandList scrollAreaClassName='max-h-[360px]'>
-        <CommandGroup heading={`${noun} (${selected.length})`}>
-          {selected.length === 0 ? (
-            <CommandDescription>
-              No {noun.toLowerCase()} selected — add at least one below.
-            </CommandDescription>
-          ) : (
-            <CommandSortable items={selected.map(columnKey)} onReorder={reorder}>
-              {selected.map((column) => (
-                <CommandSortableItem
-                  key={columnKey(column)}
-                  id={columnKey(column)}
-                  className='py-0 pe-0.5'>
-                  <span className='min-w-0 flex-1 truncate'>{column.label}</span>
-                  <button
-                    type='button'
-                    aria-label={`Remove ${column.label}`}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      removeColumn(column)
-                    }}
-                    className='flex size-6.5 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-accent'>
-                    <X className='size-3.5' />
-                  </button>
-                </CommandSortableItem>
-              ))}
-            </CommandSortable>
-          )}
-        </CommandGroup>
+    <div className='flex flex-col gap-1'>
+      {selected.length === 0 ? (
+        <EmptySection
+          title={`No ${noun}s selected`}
+          description='Add at least one below to print.'
+        />
+      ) : (
+        <SortableList items={selected.map(columnKey)} onReorder={reorder} className='gap-0.5'>
+          {selected.map((column) => (
+            <PrintColumnRow
+              key={columnKey(column)}
+              column={column}
+              hopFields={hopFields}
+              noun={noun}
+              onRemove={() => removeColumn(column)}
+            />
+          ))}
+        </SortableList>
+      )}
 
-        {available.length > 0 && (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading={`Add ${style === 'detail' ? 'field' : 'column'}`}>
-              {available.map((column) => (
-                <CommandCheckboxItem
-                  key={columnKey(column)}
-                  checked={false}
-                  onCheckedChange={() => addColumn(column)}>
-                  <span className='min-w-0 flex-1 truncate'>{column.label}</span>
-                </CommandCheckboxItem>
-              ))}
-            </CommandGroup>
-          </>
-        )}
-      </CommandList>
-    </Command>
+      <FieldPicker
+        entityDefinitionId={entityDefinitionId}
+        excludeFields={excludeFields}
+        mode='single'
+        closeOnSelect={false}
+        onSelect={addField}
+        searchPlaceholder={`Search ${noun}s…`}
+        trigger={
+          <Button variant='ghost' size='sm' className='justify-start text-muted-foreground'>
+            <Plus />
+            Add {noun}
+          </Button>
+        }
+      />
+    </div>
   )
+}
+
+/** One selected column: leaf-field type icon, label (breadcrumb for paths), hover remove. */
+function PrintColumnRow({
+  column,
+  hopFields,
+  noun,
+  onRemove,
+}: {
+  column: ExportColumn
+  hopFields: Map<string, ResourceField>
+  noun: string
+  onRemove: () => void
+}) {
+  // A path column's icon/type comes from its LEAF hop — that's the field whose value prints.
+  const leafHop = isFieldPath(column.fieldRef)
+    ? column.fieldRef[column.fieldRef.length - 1]!
+    : column.fieldRef
+  const field = hopFields.get(leafHop)
+
+  return (
+    <SortableTreeRow
+      id={columnKey(column)}
+      rowClassName='bg-primary-100 hover:bg-muted/50'
+      icon={<ColumnFieldIcon field={field} />}
+      title={
+        isFieldPath(column.fieldRef) ? (
+          <SmartBreadcrumb
+            segments={column.fieldRef.map(
+              (hop): BreadcrumbSegment => ({ id: hop, label: hopFields.get(hop)?.label ?? hop })
+            )}
+            mode='display'
+            size='sm'
+          />
+        ) : (
+          column.label
+        )
+      }
+      actions={
+        <TreeRowButton variant='destructive' tooltipText={`Remove ${noun}`} onClick={onRemove}>
+          <Trash2 />
+        </TreeRowButton>
+      }
+    />
+  )
+}
+
+/**
+ * Field-type icon matching the field picker's rows (field-item.tsx): relationship fields show
+ * the target resource's icon, everything else the fieldType icon from `fieldTypeOptions`.
+ */
+function ColumnFieldIcon({ field }: { field: ResourceField | undefined }) {
+  const relatedEntityDefinitionId = useMemo(() => {
+    if (!field?.relationship) return null
+    return getRelatedEntityDefinitionId(field.relationship as RelationshipConfig)
+  }, [field?.relationship])
+  const targetResourceProps = useResourceProperty(relatedEntityDefinitionId, ['icon', 'color'])
+
+  if (field?.relationship && targetResourceProps) {
+    return (
+      <EntityIcon iconId={targetResourceProps.icon} color={targetResourceProps.color} size='xs' />
+    )
+  }
+
+  const effectiveFieldType =
+    (field?.fieldType as FieldType) ||
+    (field?.type ? mapBaseTypeToFieldType(field.type as never) : undefined)
+  const iconId = (effectiveFieldType && fieldTypeOptions[effectiveFieldType]?.iconId) ?? 'circle'
+  return <EntityIcon iconId={iconId} size='xs' className='text-muted-foreground' />
 }

--- a/apps/web/src/components/print/ui/print-wizard-dialog.tsx
+++ b/apps/web/src/components/print/ui/print-wizard-dialog.tsx
@@ -249,7 +249,11 @@ export function PrintWizardDialog({
                 />
               ) : (
                 <div className='p-3'>
-                  <PrintColumnPicker columns={columns} style={style} />
+                  <PrintColumnPicker
+                    columns={columns}
+                    entityDefinitionId={entityDefinitionId}
+                    style={style}
+                  />
                 </div>
               )}
             </DialogNavPage>

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -12,27 +12,12 @@ import {
 } from '@auxx/ui/components/dialog'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { SortableList } from '@auxx/ui/components/sortable'
 import { Switch } from '@auxx/ui/components/switch'
 import { TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import { ScrollArea as BaseScrollArea } from '@base-ui-components/react/scroll-area'
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core'
-import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
+import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Command as CommandPrimitive } from 'cmdk'
 import {
@@ -862,52 +847,10 @@ interface CommandSortableProps {
 /**
  * CommandSortable component.
  * Wrapper that provides drag-and-drop sorting for CommandSortableItem children.
+ * Thin alias over the shared {@link SortableList} container.
  */
-function CommandSortable({
-  items,
-  onReorder,
-  disabled = false,
-  children,
-  className,
-}: CommandSortableProps) {
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 5 },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  )
-
-  const handleDragEnd = React.useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event
-      if (over && active.id !== over.id) {
-        const oldIndex = items.indexOf(String(active.id))
-        const newIndex = items.indexOf(String(over.id))
-        if (oldIndex !== -1 && newIndex !== -1) {
-          onReorder(arrayMove(items, oldIndex, newIndex))
-        }
-      }
-    },
-    [items, onReorder]
-  )
-
-  if (disabled) {
-    return <div className={className}>{children}</div>
-  }
-
-  return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      modifiers={[restrictToVerticalAxis]}
-      onDragEnd={handleDragEnd}>
-      <SortableContext items={items} strategy={verticalListSortingStrategy}>
-        <div className={className}>{children}</div>
-      </SortableContext>
-    </DndContext>
-  )
+function CommandSortable(props: CommandSortableProps) {
+  return <SortableList {...props} />
 }
 
 /**

--- a/packages/ui/src/components/sortable.tsx
+++ b/packages/ui/src/components/sortable.tsx
@@ -1,0 +1,87 @@
+// packages/ui/src/components/sortable.tsx
+'use client'
+
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import * as React from 'react'
+
+export interface SortableListProps {
+  /** Item IDs in current order. */
+  items: string[]
+  /** Called with the full new ID order after a drop. */
+  onReorder: (newItems: string[]) => void
+  /** Disable sorting interactions (renders a plain container). */
+  disabled?: boolean
+  /** Rows — each must register itself via `useSortable` with an id from `items`. */
+  children: React.ReactNode
+  /** Additional class name for the container. */
+  className?: string
+}
+
+/**
+ * Shared vertical drag-sort container: `DndContext` + `SortableContext` with
+ * pointer/keyboard sensors, vertical-axis restriction, and `arrayMove` →
+ * `onReorder`. Rows own their `useSortable` registration — see
+ * `CommandSortableItem` (command.tsx) and `SortableTreeRow` (tree-row.tsx).
+ * Flat sibling reordering only — no cross-parent drops.
+ */
+export function SortableList({
+  items,
+  onReorder,
+  disabled = false,
+  children,
+  className,
+}: SortableListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  )
+
+  const handleDragEnd = React.useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (over && active.id !== over.id) {
+        const oldIndex = items.indexOf(String(active.id))
+        const newIndex = items.indexOf(String(over.id))
+        if (oldIndex !== -1 && newIndex !== -1) {
+          onReorder(arrayMove(items, oldIndex, newIndex))
+        }
+      }
+    },
+    [items, onReorder]
+  )
+
+  if (disabled) {
+    return <div className={className}>{children}</div>
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis]}
+      onDragEnd={handleDragEnd}>
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        <div className={className}>{children}</div>
+      </SortableContext>
+    </DndContext>
+  )
+}

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -4,8 +4,10 @@
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SimpleTooltip, TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, GripVertical } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import React from 'react'
 
@@ -341,6 +343,72 @@ export function TreeRow({
       line={line}>
       {children}
     </BaseTreeRow>
+  )
+}
+
+export interface SortableTreeRowProps extends TreeRowProps {
+  /** Unique sortable id — must appear in the parent `SortableList`'s `items`. */
+  id: string
+  /** Disable dragging for this row (renders a plain TreeRow, no grip). */
+  sortDisabled?: boolean
+}
+
+/**
+ * Drag-sortable {@link TreeRow} for use inside a `SortableList`
+ * (`@auxx/ui/components/sortable`). Registers with dnd-kit via `useSortable`;
+ * the grip handle is hover-revealed in the leading slot — a row without an
+ * `icon` fades the grip into the empty slot, a row with one cross-fades
+ * icon → grip (mirroring `chevronOnHover`). Flat sibling reordering only.
+ */
+export function SortableTreeRow({
+  id,
+  sortDisabled = false,
+  icon,
+  ...props
+}: SortableTreeRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled: sortDisabled,
+  })
+
+  if (sortDisabled) return <TreeRow icon={icon} {...props} />
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+    opacity: isDragging ? 0.8 : 1,
+  }
+
+  const grip = (
+    <span className='relative flex items-center justify-center'>
+      {icon !== undefined && (
+        <span
+          className={cn(
+            'flex items-center justify-center transition-opacity',
+            isDragging ? 'opacity-0' : 'group-hover/tree-row:opacity-0'
+          )}>
+          {icon}
+        </span>
+      )}
+      <span
+        {...attributes}
+        {...listeners}
+        onClick={stopPropagation}
+        className={cn(
+          'cursor-grab touch-none transition-opacity',
+          icon !== undefined && 'absolute inset-0 flex items-center justify-center',
+          isDragging ? 'opacity-100' : 'opacity-0 group-hover/tree-row:opacity-100'
+        )}>
+        <GripVertical className='size-4' />
+      </span>
+    </span>
+  )
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <TreeRow icon={grip} {...props} />
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Redesigns the print wizard's Content page (from #1253) and extracts reusable sortable primitives along the way.

### `@auxx/ui` primitives
- **New `SortableList`** (`components/sortable.tsx`): the vertical drag-sort container (DndContext + sensors + vertical-axis restriction + `arrayMove` → `onReorder`), extracted from `CommandSortable` — which is now a one-line alias over it.
- **New `SortableTreeRow`** (`components/tree-row.tsx`): a drag-sortable `TreeRow` for use inside `SortableList`. The grip is hover-revealed in the leading slot — rows without an `icon` fade it into the empty slot, rows with one cross-fade icon → grip (mirroring `chevronOnHover`). Flat sibling reordering only.

### Migration
- Dispatch **Quality Checks** page + row drop their hand-rolled dnd-kit setup (~60 lines) for `SortableList`/`SortableTreeRow`; the grip there is now hover-revealed too.

### Print wizard Content page (list/detail styles)
- Selected columns render as `SortableTreeRow`s: field-type icon (relationship fields show the target resource icon, matching `FieldItem`), breadcrumbs for drilled paths, hover-revealed destructive remove.
- "Add column/field" opens the regular `FieldPicker` popover — search + relationship drill-down, already-selected fields excluded, stays open for multi-add.
- Empty state uses `EmptySection`.
- `usePrintColumns` is now `FieldReference`-based, so drilled relationship paths flow to the export as `FieldPath` (already supported by the CSV/PDF backend). Labels prefer the view's resolved labels, falling back to field metadata via one shared `useFields` subscription.

## Test plan
- [ ] Print wizard (list + detail styles): reorder via hover grip, remove via hover trash, add direct + drilled fields, verify PDF columns/labels
- [ ] Dispatch Settings → Quality Checks: reorder, select, toggle, delete still work; grip appears on row hover
- [ ] Kanban/calendar view settings + dashboard columns row (CommandSortable consumers) still drag-sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)