### PR TITLE
feat(dispatch): scouting photos on quotes, lines & invoices with pdf and public rendering

### DIFF
--- a/apps/web/src/app/(public)/pay/[token]/photo/[ref]/route.ts
+++ b/apps/web/src/app/(public)/pay/[token]/photo/[ref]/route.ts
@@ -1,0 +1,46 @@
+// apps/web/src/app/(public)/pay/[token]/photo/[ref]/route.ts
+
+import { resolvePhotoRef } from '@auxx/lib/documents'
+import { getPublicInvoicePayload, resolveInvoiceByPublicToken } from '@auxx/lib/money'
+import { NextResponse } from 'next/server'
+
+/**
+ * GET /pay/:token/photo/:ref — public by design (plan 37b §6), the byte source behind the
+ * pay page's line thumbnails and header "Photos" gallery. Direct mirror of the quote page's
+ * `/quote/[token]/photo/[ref]` route — see its doc comment for the full IDOR-guard rationale.
+ * No `acceptancePageEnabled`-equivalent master switch on the invoice side (the pay page has
+ * none either), so the only gates here are the token and the payload allow-list.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; ref: string }> }
+) {
+  const { token, ref: encodedRef } = await params
+  const ref = decodeURIComponent(encodedRef)
+
+  const resolved = await resolveInvoiceByPublicToken(token)
+  if (!resolved) return photoNotFound()
+
+  const payload = await getPublicInvoicePayload(token)
+  if (!payload) return photoNotFound()
+
+  const allowed =
+    payload.photos.some((photo) => photo.ref === ref) ||
+    payload.lines.some((line) => (line.photos ?? []).some((photo) => photo.ref === ref))
+  if (!allowed) return photoNotFound()
+
+  const bytes = await resolvePhotoRef(resolved.organizationId, ref)
+  if (!bytes) return photoNotFound()
+
+  return new NextResponse(new Uint8Array(bytes), {
+    headers: {
+      'Content-Type': 'image/jpeg',
+      'Cache-Control': 'private, max-age=3600',
+      'Content-Length': bytes.length.toString(),
+    },
+  })
+}
+
+function photoNotFound() {
+  return NextResponse.json({ error: 'Photo not found' }, { status: 404 })
+}

--- a/apps/web/src/app/(public)/quote/[token]/photo/[ref]/route.ts
+++ b/apps/web/src/app/(public)/quote/[token]/photo/[ref]/route.ts
@@ -1,0 +1,54 @@
+// apps/web/src/app/(public)/quote/[token]/photo/[ref]/route.ts
+
+import { resolvePhotoRef } from '@auxx/lib/documents'
+import { getPublicQuotePayload, resolveQuoteByPublicToken } from '@auxx/lib/money'
+import { NextResponse } from 'next/server'
+
+/**
+ * GET /quote/:token/photo/:ref — public by design (plan 37b §6), the byte source behind the
+ * quote page's line thumbnails and header "Photos" gallery. The public page has no session,
+ * so a photo ref (`"asset:<id>"` | `"file:<id>"`) isn't otherwise fetchable.
+ *
+ * IDOR guard: resolves the token, rebuilds this quote's public payload (already
+ * internal-filtered by `buildQuotePdfPayload`'s `extractPhotos`), and serves `ref` ONLY if it
+ * appears in that payload's header `photos` or one of its `lines[].photos` — a valid token can
+ * never be used to fetch an arbitrary asset/file id off the URL alone. 404s on an unknown
+ * token, a disabled acceptance page, an unlisted ref, or a broken/missing asset — same
+ * "don't leak which case" posture as the sibling `pdf/route.ts`.
+ *
+ * Streams the same sharp-downscaled JPEG bytes the PDF embeds (`resolvePhotoRef`, ≤1200px,
+ * q80) — the public page never needs multi-MB camera originals.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; ref: string }> }
+) {
+  const { token, ref: encodedRef } = await params
+  const ref = decodeURIComponent(encodedRef)
+
+  const resolved = await resolveQuoteByPublicToken(token)
+  if (!resolved) return photoNotFound()
+
+  const payload = await getPublicQuotePayload(token)
+  if (!payload || !payload.acceptancePageEnabled) return photoNotFound()
+
+  const allowed =
+    payload.photos.some((photo) => photo.ref === ref) ||
+    payload.lines.some((line) => (line.photos ?? []).some((photo) => photo.ref === ref))
+  if (!allowed) return photoNotFound()
+
+  const bytes = await resolvePhotoRef(resolved.organizationId, ref)
+  if (!bytes) return photoNotFound()
+
+  return new NextResponse(new Uint8Array(bytes), {
+    headers: {
+      'Content-Type': 'image/jpeg',
+      'Cache-Control': 'private, max-age=3600',
+      'Content-Length': bytes.length.toString(),
+    },
+  })
+}
+
+function photoNotFound() {
+  return NextResponse.json({ error: 'Photo not found' }, { status: 404 })
+}

--- a/apps/web/src/components/fields/displays/display-file.tsx
+++ b/apps/web/src/components/fields/displays/display-file.tsx
@@ -1,7 +1,10 @@
 // apps/web/src/components/fields/displays/display-file.tsx
 
+import type { FileValue } from '@auxx/lib/field-values/client'
+import { type FileRef, getFileRefDownloadUrl } from '@auxx/types/file-ref'
 import { Badge } from '@auxx/ui/components/badge'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { EyeOff } from 'lucide-react'
 import { useMemo } from 'react'
 import { FileIcon } from '~/components/files/utils/file-icon'
 import { type ItemsListItem, ItemsListView } from '~/components/ui/items-list-view'
@@ -9,25 +12,31 @@ import { api } from '~/trpc/react'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 
-/** File item for ItemsListView */
+/** File item for ItemsListView — carries caption/internal through from the FILE envelope
+ * (`{ ref, caption?, internal? }`, plans/dispatch/37b-scouting-quote-photos.md §2). */
 interface DisplayFileItem extends ItemsListItem {
+  ref: string
   name: string
   mimeType: string
+  caption?: string
+  internal?: boolean
 }
 
 /**
  * DisplayFile component
  * Renders file references in read-only mode.
- * value is now an array of { ref: "asset:xxx" } objects (FILE is in ARRAY_RETURN_FIELD_TYPES).
+ * value is now an array of { ref: "asset:xxx", caption?, internal? } objects (FILE is in
+ * ARRAY_RETURN_FIELD_TYPES).
  */
 export function DisplayFile() {
   const { value } = useFieldContext()
 
-  // Extract refs from multi-value array
-  const refs = useMemo(() => {
+  // Extract refs + envelope metadata from the multi-value array
+  const envelopes = useMemo(() => {
     if (!Array.isArray(value)) return []
-    return value.filter((v: any) => v?.ref).map((v: any) => v.ref as string)
+    return (value as FileValue[]).filter((v) => v?.ref)
   }, [value])
+  const refs = useMemo(() => envelopes.map((v) => v.ref), [envelopes])
 
   const { data: fileDetails, isLoading } = api.file.resolveFileRefs.useQuery(
     { refs },
@@ -36,12 +45,16 @@ export function DisplayFile() {
   // Build file items for ItemsListView
   const fileItems = useMemo<DisplayFileItem[]>(() => {
     if (!fileDetails) return []
+    const envelopeMap = new Map(envelopes.map((v) => [v.ref, v]))
     return fileDetails.map((detail) => ({
       id: detail.ref,
+      ref: detail.ref,
       name: detail.name,
       mimeType: detail.mimeType || 'application/octet-stream',
+      caption: envelopeMap.get(detail.ref)?.caption,
+      internal: envelopeMap.get(detail.ref)?.internal,
     }))
-  }, [fileDetails])
+  }, [fileDetails, envelopes])
 
   if (isLoading && refs.length > 0) {
     return (
@@ -66,13 +79,56 @@ export function DisplayFile() {
     <DisplayWrapper>
       <ItemsListView
         items={fileItems}
-        renderItem={(item) => (
-          <Badge variant='pill' shape='tag' className='flex items-center gap-1.5'>
-            <FileIcon mimeType={item.mimeType} className='size-4 flex shrink-0 text-gray-500' />
-            <span>{item.name}</span>
-          </Badge>
-        )}
+        renderItem={(itemValue) => {
+          // `ItemsListView` also supports primitive items (see its doc comment); FILE
+          // fields always pass full `DisplayFileItem` objects.
+          const item = itemValue as DisplayFileItem
+          return item.mimeType.startsWith('image/') ? (
+            <PhotoThumbnail item={item} />
+          ) : (
+            <span className='inline-flex items-center gap-1'>
+              <Badge variant='pill' shape='tag' className='flex items-center gap-1.5'>
+                <FileIcon mimeType={item.mimeType} className='size-4 flex shrink-0 text-gray-500' />
+                <span>{item.name}</span>
+                {item.caption && <span className='text-muted-foreground'>· {item.caption}</span>}
+              </Badge>
+              {item.internal && (
+                <Badge variant='secondary' size='xs' className='gap-1'>
+                  <EyeOff className='size-3' />
+                  Internal
+                </Badge>
+              )}
+            </span>
+          )
+        }}
       />
     </DisplayWrapper>
+  )
+}
+
+/** Thumbnail + caption fine print for an image photo, with an "Internal" corner badge
+ * when the photo is hidden from the customer. */
+function PhotoThumbnail({ item }: { item: DisplayFileItem }) {
+  return (
+    <div className='flex w-16 flex-col gap-0.5' title={item.name}>
+      <div className='relative size-16 shrink-0 overflow-hidden rounded-md ring-1 ring-neutral-300 dark:ring-neutral-800'>
+        <img
+          src={getFileRefDownloadUrl(item.ref as FileRef)}
+          alt={item.caption || item.name}
+          className='size-full object-cover'
+          loading='lazy'
+        />
+        {item.internal && (
+          <span
+            title='Internal — hidden from customer'
+            className='absolute right-0.5 top-0.5 flex size-4 items-center justify-center rounded-full bg-background/90 text-muted-foreground ring-1 ring-neutral-300 dark:ring-neutral-800'>
+            <EyeOff className='size-2.5' />
+          </span>
+        )}
+      </div>
+      {item.caption && (
+        <span className='truncate text-[11px] text-muted-foreground'>{item.caption}</span>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/fields/inputs/file-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/file-input-field.tsx
@@ -21,9 +21,12 @@ export function FileInputField() {
     uploadingFiles,
     canAddMore,
     remainingSlots,
+    supportsCameraCapture,
     openNativeFilePicker,
+    openCameraCapture,
     handleBrowseFilesSelected,
     removeFile,
+    updatePhotoMeta,
     browseOpen,
     setBrowseOpen,
   } = useFieldFileUpload({ recordId, fieldRef: field.id, fileOptions })
@@ -37,6 +40,8 @@ export function FileInputField() {
         onUpload={openNativeFilePicker}
         onBrowse={() => setBrowseOpen(true)}
         onRemove={removeFile}
+        onTakePhoto={supportsCameraCapture ? openCameraCapture : undefined}
+        onUpdateMeta={updatePhotoMeta}
       />
       {browseOpen && (
         <FileSelectDialog

--- a/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
+++ b/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
 'use client'
 
+import type { FileValue } from '@auxx/lib/field-values/client'
 import type { FileTypeCategory } from '@auxx/lib/files/client'
 import { getMimePatternsForCategories } from '@auxx/lib/files/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
@@ -14,6 +15,7 @@ import type { FileOptions } from '~/components/custom-fields/ui/file-options-edi
 import type { FileState } from '~/components/file-upload/stores'
 import { useUploadStore } from '~/components/file-upload/stores'
 import type { FileItem } from '~/components/files/files-store'
+import { convertHeicFiles } from '~/components/files/utils/convert-heic'
 import {
   buildFieldValueKey,
   useFieldValueStore,
@@ -306,6 +308,13 @@ interface UseFieldFileUploadOptions {
   fileOptions: FileOptions
 }
 
+/** Patch applied to one photo's envelope by the tile editor. */
+export interface PhotoMetaPatch {
+  /** `undefined` clears the caption. */
+  caption?: string
+  internal?: boolean
+}
+
 interface UseFieldFileUploadReturn {
   displayFiles: Array<{
     id: string // fieldValueId — for removal
@@ -313,6 +322,10 @@ interface UseFieldFileUploadReturn {
     name: string
     mimeType: string | null
     size: number | null
+    /** Caption from the FILE envelope (`{ ref, caption?, internal? }`). */
+    caption?: string
+    /** When true, the photo is internal-only (stripped from customer-facing payloads). */
+    internal?: boolean
   }>
   uploadingFiles: UploadingFile[]
   isUploading: boolean
@@ -334,9 +347,23 @@ interface UseFieldFileUploadReturn {
    * existing value).
    */
   remainingSlots: number
+  /** True when the field is images-only (`allowedFileTypes` is exactly `['image']`) —
+   * gates the camera-capture affordance (37b-scouting-quote-photos.md §4/§8). */
+  supportsCameraCapture: boolean
   openNativeFilePicker: () => void
+  /** Same picker, opened with `capture='environment'` so mobile browsers default to the
+   * device camera instead of the file/photo chooser. */
+  openCameraCapture: () => void
   handleBrowseFilesSelected: (files: FileItem[]) => Promise<void>
   removeFile: (fieldValueId: string) => Promise<void>
+  /**
+   * Edit a photo's caption/internal flag. Composes the FULL envelope array from the
+   * freshest store state and writes it via `fieldValue.set` (mode 'set') — the only
+   * sanctioned edit path (plans/dispatch/37b-scouting-quote-photos.md §2). Never
+   * edit via remove+add: `add` dedups on the bare `{ ref }` shape and would duplicate
+   * an already-captioned row.
+   */
+  updatePhotoMeta: (fieldValueId: string, patch: PhotoMetaPatch) => Promise<void>
   browseOpen: boolean
   setBrowseOpen: (open: boolean) => void
 }
@@ -344,6 +371,10 @@ interface UseFieldFileUploadReturn {
 // Stable empty array references
 const EMPTY_UPLOADING: UploadingFile[] = []
 const EMPTY_ARRAY: TypedFieldValue[] = []
+
+// Concrete (non-wildcard) accept list for images-only FILE fields — deliberately omits
+// `image/heic`/`image/heif`. See `openPicker`'s doc comment in the hook below for why.
+const IMAGE_ONLY_ACCEPT = 'image/jpeg,image/png,image/webp,image/gif,image/bmp'
 
 // =============================================================================
 // HELPERS
@@ -404,15 +435,24 @@ export function useFieldFileUpload({
     })
   )
 
-  // Extract file refs from typed values
+  // Extract file refs from typed values — carries caption/internal through from the
+  // envelope (`{ ref, caption?, internal? }`), additive on top of the original `{ ref }`
+  // shape (plans/dispatch/37b-scouting-quote-photos.md §2).
   const fileRefs = useMemo(
     () =>
       typedValues
         .filter((tv) => tv.type === 'json' && (tv as JsonFieldValue).value?.ref)
         .map((tv) => {
-          const ref = (tv as JsonFieldValue).value.ref as string
-          const { sourceType, id } = parseFileRef(ref)
-          return { fieldValueId: tv.id, ref, sourceType, id }
+          const value = (tv as JsonFieldValue).value as unknown as FileValue
+          const { sourceType, id } = parseFileRef(value.ref)
+          return {
+            fieldValueId: tv.id,
+            ref: value.ref,
+            sourceType,
+            id,
+            caption: value.caption,
+            internal: value.internal,
+          }
         }),
     [typedValues]
   )
@@ -437,6 +477,8 @@ export function useFieldFileUpload({
           name: detail?.name ?? 'Unknown file',
           mimeType: detail?.mimeType ?? null,
           size: detail?.size ?? null,
+          caption: fr.caption,
+          internal: fr.internal,
         }
       })
       .filter((f) => f.name !== 'Unknown file' || fileDetails.length < fileRefs.length)
@@ -532,103 +574,146 @@ export function useFieldFileUpload({
   // allows 1 (replace); multi-file uses the strict remaining count.
   const effectiveSlots = fileOptions.allowMultiple ? remainingSlots : 1
 
+  // Images-only field (37b-scouting-quote-photos.md §1/§4/§8: `quote_photos` /
+  // `line_item_photos` / `invoice_photos` are `allowedFileTypes: ['image']`) — gates the
+  // camera-capture affordance.
+  const isImagesOnly =
+    fileOptions.allowedFileTypes?.length === 1 && fileOptions.allowedFileTypes[0] === 'image'
+
   /**
-   * Open native file picker. Registers completion handler BEFORE opening dialog.
-   * For single-file fields, always opens — upload replaces any existing value.
+   * Open the native file picker, optionally requesting camera capture.
+   *
+   * `capture` is deliberately combined with a concrete (non-wildcard) image MIME list
+   * rather than `getMimePatternsForCategories`'s `'image/*'` — that constraint is what
+   * makes iOS Safari transcode a HEIC capture/pick to JPEG itself before handing the
+   * file back (the 'image' category excludes `.heic`, `file-type-constants.ts:9-18`).
+   * `convertHeicFiles` below is the client-side backstop for whatever slips through.
+   * Registers the completion handler BEFORE opening the dialog. For single-file fields,
+   * always opens — upload replaces any existing value.
    */
-  const openNativeFilePicker = useCallback(async () => {
-    if (!canOpenPicker) return
+  const openPicker = useCallback(
+    async (capture?: 'environment') => {
+      if (!canOpenPicker) return
 
-    try {
-      // Create upload session in store
-      const store = useUploadStore.getState()
-      const sessionId = await store.createSessionWithGuard(uploaderId, {
-        entityType: 'CUSTOM_FIELD',
-        entityId: `field-${fieldRef}`,
-        behaviorConfig: {
-          allowMultiple: fileOptions.allowMultiple,
-          autoStart: false,
-        },
-        metadata: { fieldId: fieldRef },
-      })
+      try {
+        // Create upload session in store
+        const store = useUploadStore.getState()
+        const sessionId = await store.createSessionWithGuard(uploaderId, {
+          entityType: 'CUSTOM_FIELD',
+          entityId: `field-${fieldRef}`,
+          behaviorConfig: {
+            allowMultiple: fileOptions.allowMultiple,
+            autoStart: false,
+          },
+          metadata: { fieldId: fieldRef },
+        })
 
-      // Register or update completion handler (deduplicate)
-      const existing = completionHandlers.get(uploaderId)
-      if (!existing || Date.now() - existing.registeredAt >= 60_000) {
-        completionHandlers.set(uploaderId, {
-          recordId,
-          fieldRef,
-          storeKey,
-          allowMultiple: fileOptions.allowMultiple,
-          registeredAt: Date.now(),
+        // Register or update completion handler (deduplicate)
+        const existing = completionHandlers.get(uploaderId)
+        if (!existing || Date.now() - existing.registeredAt >= 60_000) {
+          completionHandlers.set(uploaderId, {
+            recordId,
+            fieldRef,
+            storeKey,
+            allowMultiple: fileOptions.allowMultiple,
+            registeredAt: Date.now(),
+          })
+        }
+
+        // Build accept string for file input. Images-only fields use a concrete list
+        // (no `image/heic`) instead of the `'image/*'` wildcard — see doc comment above.
+        const acceptTypes = isImagesOnly
+          ? IMAGE_ONLY_ACCEPT
+          : fileOptions.allowedFileTypes
+            ? getMimePatternsForCategories(fileOptions.allowedFileTypes as FileTypeCategory[]).join(
+                ','
+              )
+            : undefined
+
+        // Create detached native file input (survives React unmount)
+        const input = document.createElement('input')
+        input.type = 'file'
+        if (acceptTypes) input.accept = acceptTypes
+        if (capture) input.capture = capture
+        input.multiple = fileOptions.allowMultiple && effectiveSlots > 1
+        input.style.display = 'none'
+        document.body.appendChild(input)
+
+        input.onchange = async () => {
+          const rawFiles = Array.from(input.files ?? [])
+          document.body.removeChild(input)
+
+          if (rawFiles.length === 0) return
+
+          // Backstop transcode for any HEIC/HEIF that slipped past the accept-list
+          // constraint above (see `convert-heic.ts`).
+          const files = isImagesOnly ? await convertHeicFiles(rawFiles) : rawFiles
+
+          // Optimistic avatar preview: show the locally-selected image instantly
+          // via a blob URL. `handleUploadCompletion` swaps to a stable download
+          // URL on server success, or rolls back on failure.
+          if (isAvatarField(recordId, fieldRef) && files[0]) {
+            const blobUrl = URL.createObjectURL(files[0])
+            const { priorAvatarUrl } = optimisticallyWriteAvatar(recordId, blobUrl)
+            pendingAvatarByKey.set(uploaderId, {
+              recordId,
+              priorAvatarUrl,
+              blobUrl,
+            })
+          }
+
+          try {
+            const storeNow = useUploadStore.getState()
+            const addResult = await storeNow.addFilesWithValidation(files, uploaderId, {
+              maxFiles: effectiveSlots,
+            })
+            if (addResult.validationErrors.length > 0) {
+              console.error('[useFieldFileUpload] validation errors:', addResult.validationErrors)
+            }
+
+            await storeNow.startUploadForSession(sessionId)
+          } catch (err) {
+            console.error('[useFieldFileUpload] upload error:', err)
+            // Upload failed to start — rollback optimistic avatar.
+            const pending = pendingAvatarByKey.get(uploaderId)
+            if (pending) {
+              const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId as RecordId)
+              useRecordStore.getState().updateRecord(entityDefinitionId, entityInstanceId, {
+                avatarUrl: pending.priorAvatarUrl,
+              })
+              if (pending.blobUrl) scheduleBlobRevoke(pending.blobUrl, 0)
+              pendingAvatarByKey.delete(uploaderId)
+            }
+          }
+        }
+
+        input.click()
+      } catch (error) {
+        toastError({
+          title: 'Upload failed',
+          description: error instanceof Error ? error.message : 'Unknown error',
         })
       }
+    },
+    [
+      canOpenPicker,
+      uploaderId,
+      fieldRef,
+      recordId,
+      storeKey,
+      effectiveSlots,
+      fileOptions,
+      isImagesOnly,
+    ]
+  )
 
-      // Build accept string for file input
-      const acceptTypes = fileOptions.allowedFileTypes
-        ? getMimePatternsForCategories(fileOptions.allowedFileTypes as FileTypeCategory[]).join(',')
-        : undefined
+  const openNativeFilePicker = useCallback(() => {
+    void openPicker()
+  }, [openPicker])
 
-      // Create detached native file input (survives React unmount)
-      const input = document.createElement('input')
-      input.type = 'file'
-      if (acceptTypes) input.accept = acceptTypes
-      input.multiple = fileOptions.allowMultiple && effectiveSlots > 1
-      input.style.display = 'none'
-      document.body.appendChild(input)
-
-      input.onchange = async () => {
-        const files = Array.from(input.files ?? [])
-        document.body.removeChild(input)
-
-        if (files.length === 0) return
-
-        // Optimistic avatar preview: show the locally-selected image instantly
-        // via a blob URL. `handleUploadCompletion` swaps to a stable download
-        // URL on server success, or rolls back on failure.
-        if (isAvatarField(recordId, fieldRef) && files[0]) {
-          const blobUrl = URL.createObjectURL(files[0])
-          const { priorAvatarUrl } = optimisticallyWriteAvatar(recordId, blobUrl)
-          pendingAvatarByKey.set(uploaderId, {
-            recordId,
-            priorAvatarUrl,
-            blobUrl,
-          })
-        }
-
-        try {
-          const storeNow = useUploadStore.getState()
-          const addResult = await storeNow.addFilesWithValidation(files, uploaderId, {
-            maxFiles: effectiveSlots,
-          })
-          if (addResult.validationErrors.length > 0) {
-            console.error('[useFieldFileUpload] validation errors:', addResult.validationErrors)
-          }
-
-          await storeNow.startUploadForSession(sessionId)
-        } catch (err) {
-          console.error('[useFieldFileUpload] upload error:', err)
-          // Upload failed to start — rollback optimistic avatar.
-          const pending = pendingAvatarByKey.get(uploaderId)
-          if (pending) {
-            const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId as RecordId)
-            useRecordStore.getState().updateRecord(entityDefinitionId, entityInstanceId, {
-              avatarUrl: pending.priorAvatarUrl,
-            })
-            if (pending.blobUrl) scheduleBlobRevoke(pending.blobUrl, 0)
-            pendingAvatarByKey.delete(uploaderId)
-          }
-        }
-      }
-
-      input.click()
-    } catch (error) {
-      toastError({
-        title: 'Upload failed',
-        description: error instanceof Error ? error.message : 'Unknown error',
-      })
-    }
-  }, [canOpenPicker, uploaderId, fieldRef, recordId, storeKey, effectiveSlots, fileOptions])
+  const openCameraCapture = useCallback(() => {
+    void openPicker('environment')
+  }, [openPicker])
 
   /**
    * Handle files selected from FileSelectDialog. Routes through the shared
@@ -703,6 +788,55 @@ export function useFieldFileUpload({
     [removeValue, recordId, fieldRef, storeKey]
   )
 
+  /**
+   * Edit one photo's caption/internal flag (tile editor save). Builds the full envelope
+   * array from the freshest store state at call time — not from the `typedValues`
+   * closure — to minimize clobbering a concurrent upload's `add`
+   * (plans/dispatch/37b-scouting-quote-photos.md §2 concurrency caveat, accepted for v1).
+   */
+  const updatePhotoMeta = useCallback(
+    async (fieldValueId: string, patch: PhotoMetaPatch) => {
+      const fvStore = useFieldValueStore.getState()
+      const current = fvStore.values[storeKey]
+      const currentArr = (
+        Array.isArray(current) ? current : current ? [current] : []
+      ) as TypedFieldValue[]
+
+      const envelopes: FileValue[] = currentArr
+        .filter(
+          (tv): tv is JsonFieldValue =>
+            tv.type === 'json' && !!(tv.value as unknown as FileValue)?.ref
+        )
+        .map((tv) => {
+          const value = tv.value as unknown as FileValue
+          if (tv.id !== fieldValueId) {
+            return { ref: value.ref, caption: value.caption, internal: value.internal }
+          }
+          return {
+            ref: value.ref,
+            caption: patch.caption,
+            internal: patch.internal,
+          }
+        })
+
+      try {
+        const result = await vanillaApi.fieldValue.set.mutate({
+          recordId,
+          fieldId: fieldRef,
+          value: envelopes,
+        })
+        fvStore.setValue(storeKey, (result?.values ?? []) as TypedFieldValue[])
+      } catch (error) {
+        toastError({
+          title: 'Failed to save photo details',
+          description: error instanceof Error ? error.message : 'Unknown error',
+        })
+        throw error
+      }
+    },
+    [recordId, fieldRef, storeKey]
+  )
+
   return {
     displayFiles,
     uploadingFiles,
@@ -710,9 +844,12 @@ export function useFieldFileUpload({
     canAddMore,
     canAppend,
     remainingSlots: effectiveSlots,
+    supportsCameraCapture: isImagesOnly,
     openNativeFilePicker,
+    openCameraCapture,
     handleBrowseFilesSelected,
     removeFile,
+    updatePhotoMeta,
     browseOpen,
     setBrowseOpen,
   }

--- a/apps/web/src/components/files/utils/convert-heic.ts
+++ b/apps/web/src/components/files/utils/convert-heic.ts
@@ -1,0 +1,63 @@
+// apps/web/src/components/files/utils/convert-heic.ts
+
+/**
+ * Best-effort client-side HEIC/HEIF → JPEG re-encode (37b-scouting-quote-photos.md §4).
+ *
+ * The 'image' file category excludes HEIC (`packages/lib/src/files/file-type-constants.ts`
+ * `IMAGE_EXTENSIONS`), so a HEIC photo must become JPEG before it reaches an images-only
+ * FILE field. The primary defense is a constrained `accept` list on the file input (no
+ * `image/heic` in the list — see `use-field-file-upload.ts`), which makes iOS Safari
+ * transcode HEIC → JPEG itself at selection/capture time in most cases. This module is
+ * the backstop for whatever slips through that (older iOS, browsers that hand back a
+ * `.heic` file despite the accept list).
+ *
+ * `createImageBitmap` + `<canvas>` can only decode HEIC in Safari (the only engine with
+ * native HEIC image support) — that's the exact case we need to cover, and it needs no
+ * new dependency. Everywhere else `createImageBitmap` throws on a HEIC blob and this
+ * quietly returns the original file, so existing server-side validation still rejects it
+ * the same as before this module existed.
+ */
+
+const HEIC_EXTENSION_PATTERN = /\.(heic|heif)$/i
+
+/** True when a `File` is (or looks like) HEIC/HEIF — by MIME type or filename extension,
+ * since some devices hand over a `.heic` file with an empty/generic `mimeType`. */
+export function isHeicFile(file: File): boolean {
+  const type = file.type.toLowerCase()
+  if (type === 'image/heic' || type === 'image/heif') return true
+  return HEIC_EXTENSION_PATTERN.test(file.name)
+}
+
+/** Re-encode a single HEIC/HEIF file to JPEG via canvas. Returns the original file
+ * untouched if it isn't HEIC, or if this browser can't decode HEIC client-side. */
+export async function convertHeicToJpeg(file: File): Promise<File> {
+  if (!isHeicFile(file)) return file
+
+  try {
+    const bitmap = await createImageBitmap(file)
+    const canvas = document.createElement('canvas')
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return file
+
+    ctx.drawImage(bitmap, 0, 0)
+    bitmap.close()
+
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob((b) => resolve(b), 'image/jpeg', 0.9)
+    )
+    if (!blob) return file
+
+    const newName = file.name.replace(HEIC_EXTENSION_PATTERN, '.jpg')
+    return new File([blob], newName, { type: 'image/jpeg', lastModified: Date.now() })
+  } catch {
+    // Can't decode HEIC client-side outside Safari — leave untouched.
+    return file
+  }
+}
+
+/** Run `convertHeicToJpeg` over a file list — only HEIC/HEIF entries are re-encoded. */
+export async function convertHeicFiles(files: File[]): Promise<File[]> {
+  return Promise.all(files.map(convertHeicToJpeg))
+}

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -211,6 +211,13 @@ export function LineBuilder({
       color: o.color,
     }))
   }, [lineItemFields])
+  // Field def for the photo chip (line-photo-chip.tsx, plan 37b §4) — `null` on a
+  // pre-migration org that hasn't picked up the `line_item.photos` registry field yet,
+  // in which case `LineRow` renders no chip at all.
+  const photosField = useMemo(
+    () => lineItemFields.find((f) => f.key === 'photos') ?? null,
+    [lineItemFields]
+  )
   // Catalog data is shared by every row picker. Editable builders preload it
   // once so opening a picker or resolving a product group never starts a fetch.
   const catalogEnabled = !!entityDefinitionId && !readOnly
@@ -1137,6 +1144,7 @@ export function LineBuilder({
                       rowIndex={row.rowIndex}
                       entityDefinitionId={entityDefinitionId}
                       categoryOptions={categoryOptions}
+                      photosField={photosField}
                       readOnly={readOnly}
                       currencyCode={currencyCode}
                       documentType={documentType}

--- a/apps/web/src/components/money/ui/line-builder/line-photo-chip.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-photo-chip.tsx
@@ -1,0 +1,72 @@
+// apps/web/src/components/money/ui/line-builder/line-photo-chip.tsx
+
+'use client'
+
+// Per-line scouting-photo affordance (plans/dispatch/37b-scouting-quote-photos.md §4) —
+// `line_item` has no generic detail-dialog surface, so this small camera/count chip is
+// the line's only entry point for photos. Reuses the existing generic FILE input
+// (`FileInputField`, get-input-component.tsx:70) as-is, bound to this line instance's
+// `line_item_photos` field through the same `PropertyProvider` context every other field
+// input reads from — no bespoke upload/remove logic lives here. Rendered only for real
+// (persisted) line rows: a phantom draft has no EntityInstance yet, so there is nowhere
+// to attach a FieldValue row until the line's first commit.
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Camera } from 'lucide-react'
+import { FileInputField } from '~/components/fields/inputs/file-input-field'
+import { PropertyProvider } from '~/components/fields/property-provider'
+import type { RecordId } from '~/components/resources'
+
+export function LinePhotoChip({
+  recordId,
+  field,
+  photoCount,
+  readOnly,
+}: {
+  recordId: RecordId
+  field: ResourceField
+  photoCount: number
+  readOnly: boolean
+}) {
+  // Read-only surfaces (the invoice gather preview, an already-invoiced line
+  // builder, …) show a static count badge only — `FileInputField` has no
+  // read-only mode of its own (upload/remove always live), so opening it here
+  // would silently defeat the surface's read-only contract.
+  if (readOnly) {
+    if (photoCount === 0) return null
+    return (
+      <span className='inline-flex shrink-0 items-center gap-0.5 px-1 text-muted-foreground'>
+        <Camera className='size-3.5' />
+        <span className='text-[10px] tabular-nums'>{photoCount}</span>
+      </span>
+    )
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <TreeRowButton
+          persistent={photoCount > 0}
+          tabIndex={-1}
+          tooltipText={
+            photoCount > 0 ? `${photoCount} photo${photoCount === 1 ? '' : 's'}` : 'Add photos'
+          }
+          onMouseDown={(e) => e.preventDefault()}>
+          <Camera />
+          {photoCount > 0 && <span className='ml-0.5 text-[10px] tabular-nums'>{photoCount}</span>}
+        </TreeRowButton>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='w-80' onOpenAutoFocus={(e) => e.preventDefault()}>
+        <PropertyProvider
+          field={field}
+          recordId={recordId}
+          providerId={`line-photos-${recordId}`}
+          readOnly={false}>
+          <FileInputField />
+        </PropertyProvider>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -30,6 +30,7 @@ import {
   type LineItemUnit,
   parseQuantityWithUnit,
 } from '@auxx/lib/money/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
 import { AutosizeTextarea } from '@auxx/ui/components/autosize-textarea'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Checkbox } from '@auxx/ui/components/checkbox'
@@ -68,6 +69,7 @@ import { type RecordId, type RecordMeta, toRecordId } from '~/components/resourc
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { catalogItemToLinePatch } from './catalog-group-resolver'
 import { CatalogPicker } from './catalog-picker'
+import { LinePhotoChip } from './line-photo-chip'
 import {
   BASE_LINE_SYSTEM_ATTRIBUTES,
   DEFAULT_LINE_VALUES,
@@ -461,6 +463,7 @@ function LineNameCellView({
   onCommitDescription,
   onCommitCategory,
   onDelete,
+  photoChip,
 }: {
   name: string
   description: string | null
@@ -489,6 +492,11 @@ function LineNameCellView({
   onCommitCategory: (value: string | null) => void
   /** Delete this line (real record or draft). */
   onDelete: () => void
+  /**
+   * Scouting-photo chip (line-photo-chip.tsx, plan 37b §4) — `undefined` on a
+   * phantom draft row (no `EntityInstance` to attach photos to yet).
+   */
+  photoChip?: ReactNode
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -637,6 +645,7 @@ function LineNameCellView({
         </span>
         {stateBadges}
         {description && <TooltipExplanation text={description} />}
+        {photoChip}
       </div>
     )
   }
@@ -734,6 +743,9 @@ function LineNameCellView({
           <AlignLeft />
         </TreeRowButton>
       )}
+
+      {/* Scouting-photo chip (plan 37b §4) — undefined on draft rows. */}
+      {!focused && photoChip}
 
       {/* The `⋯` menu — always the cell's LAST flex child so its slot is
           stable whether the cell is at rest or editing (React keeps it
@@ -1044,6 +1056,7 @@ export function LineRow({
   rowIndex,
   entityDefinitionId,
   categoryOptions,
+  photosField,
   readOnly,
   currencyCode,
   documentType,
@@ -1059,6 +1072,9 @@ export function LineRow({
   rowIndex: number
   entityDefinitionId: string
   categoryOptions: CategoryOption[]
+  /** `line_item.photos` field def (plan 37b §4) — `null` skips the photo chip
+   * entirely (pre-migration org). */
+  photosField: ResourceField | null
   readOnly: boolean
   currencyCode: string
   documentType: 'quote' | 'work_order' | 'invoice'
@@ -1075,6 +1091,9 @@ export function LineRow({
   const systemAttributes = isQuote ? QUOTE_LINE_SYSTEM_ATTRIBUTES : BASE_LINE_SYSTEM_ATTRIBUTES
   const { values } = useSystemValues(recordId, systemAttributes, { autoFetch: false })
   const line = lineValuesFromSystemValues(values, isQuote)
+  // FILE is array-return (plan 37b §3) — `line_item_photos` reads back as an array of
+  // `{ ref, caption?, internal? }` envelopes (or is absent/empty when there are none).
+  const photoCount = Array.isArray(values.line_item_photos) ? values.line_item_photos.length : 0
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: record.id,
     disabled: readOnly,
@@ -1116,6 +1135,16 @@ export function LineRow({
             onCommitDescription={(description) => onUpdateLine(recordId, { description })}
             onCommitCategory={(category) => onUpdateLine(recordId, { category })}
             onDelete={() => deleteLine(record.id)}
+            photoChip={
+              photosField ? (
+                <LinePhotoChip
+                  recordId={recordId}
+                  field={photosField}
+                  photoCount={photoCount}
+                  readOnly={readOnly}
+                />
+              ) : undefined
+            }
           />
         }
         qty={

--- a/apps/web/src/components/money/ui/line-builder/line-values.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-values.ts
@@ -52,6 +52,12 @@ export const BASE_LINE_SYSTEM_ATTRIBUTES = [
   'line_item_qty',
   'line_item_unit',
   'line_item_unit_price',
+  // Not part of `LineValues`/`linePatchToFieldValues` — the photo chip
+  // (line-photo-chip.tsx) reads/writes this field directly via
+  // `PropertyProvider`/`FileInputField`, not the semantic patch path. Riding
+  // along in the same prefetch batch just gives the chip its count for free
+  // (plan 37b §4).
+  'line_item_photos',
 ]
 
 /** Quote-only selection fields appended to the base row values. */

--- a/apps/web/src/components/money/ui/public-document/photo-gallery.tsx
+++ b/apps/web/src/components/money/ui/public-document/photo-gallery.tsx
@@ -1,0 +1,108 @@
+// apps/web/src/components/money/ui/public-document/photo-gallery.tsx
+'use client'
+
+// Shared photo thumbnails + lightbox for public documents (plan 37b §6) — used both for a
+// line's small inline thumbnails and the document's header-level "Photos" gallery grid.
+// Thumbnails/lightbox images point at the token-scoped `/quote/[token]/photo/[ref]` or
+// `/pay/[token]/photo/[ref]` route (the public page has no session, so refs aren't otherwise
+// fetchable); `photoBasePath` is that route's base (`/quote/{token}/photo` or
+// `/pay/{token}/photo}`), with each photo's `ref` percent-encoded onto it (refs contain a
+// `:`, e.g. `asset:abc123`). Decoupled from `@auxx/lib`'s payload types on purpose (only
+// `ref`/`caption`) so this client component never statically imports a server-only module.
+
+import { Dialog, DialogContent, DialogTitle } from '@auxx/ui/components/dialog'
+import { cn } from '@auxx/ui/lib/utils'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+
+export interface PublicDocumentPhoto {
+  ref: string
+  caption?: string
+}
+
+interface PhotoGalleryProps {
+  photos: PublicDocumentPhoto[]
+  /** Base path of the token-scoped photo route, e.g. `/quote/{token}/photo`. */
+  photoBasePath: string
+  /** `sm` = small inline thumbnails under a line row; `md` = the header gallery grid. */
+  size?: 'sm' | 'md'
+  className?: string
+}
+
+function photoUrl(basePath: string, ref: string): string {
+  return `${basePath}/${encodeURIComponent(ref)}`
+}
+
+/** Captioned photo thumbnails that open a simple prev/next lightbox dialog on click. Renders
+ * nothing when `photos` is empty, so callers can render it unconditionally. */
+export function PhotoGallery({ photos, photoBasePath, size = 'md', className }: PhotoGalleryProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+
+  if (photos.length === 0) return null
+
+  const active = openIndex !== null ? photos[openIndex] : undefined
+  const step = (delta: number) =>
+    setOpenIndex((i) => (i === null ? i : (i + delta + photos.length) % photos.length))
+
+  return (
+    <>
+      <div className={cn('flex flex-wrap gap-2', size === 'sm' ? 'mt-1.5' : 'mt-3', className)}>
+        {photos.map((photo, i) => (
+          <button
+            key={photo.ref}
+            type='button'
+            onClick={() => setOpenIndex(i)}
+            className={cn(
+              'shrink-0 overflow-hidden rounded-md border border-white/10 bg-white/5 transition hover:border-white/30',
+              size === 'sm' ? 'size-14' : 'size-24 sm:size-28'
+            )}>
+            <img
+              src={photoUrl(photoBasePath, photo.ref)}
+              alt={photo.caption ?? ''}
+              loading='lazy'
+              className='h-full w-full object-cover'
+            />
+          </button>
+        ))}
+      </div>
+
+      <Dialog open={openIndex !== null} onOpenChange={(open) => !open && setOpenIndex(null)}>
+        <DialogContent size='xl' innerClassName='items-center'>
+          <DialogTitle className='sr-only'>{active?.caption || 'Photo'}</DialogTitle>
+          {active ? (
+            <div className='flex flex-col items-center gap-3'>
+              <div className='relative flex w-full items-center justify-center'>
+                {photos.length > 1 ? (
+                  <button
+                    type='button'
+                    aria-label='Previous photo'
+                    onClick={() => step(-1)}
+                    className='-translate-y-1/2 absolute left-1 top-1/2 flex size-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70'>
+                    <ChevronLeft className='size-4' />
+                  </button>
+                ) : null}
+                <img
+                  src={photoUrl(photoBasePath, active.ref)}
+                  alt={active.caption ?? ''}
+                  className='max-h-[70vh] max-w-full rounded-md object-contain'
+                />
+                {photos.length > 1 ? (
+                  <button
+                    type='button'
+                    aria-label='Next photo'
+                    onClick={() => step(1)}
+                    className='-translate-y-1/2 absolute right-1 top-1/2 flex size-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70'>
+                    <ChevronRight className='size-4' />
+                  </button>
+                ) : null}
+              </div>
+              {active.caption ? (
+                <p className='text-center text-muted-foreground text-sm'>{active.caption}</p>
+              ) : null}
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/web/src/components/money/ui/public-document/public-document-line-items.tsx
+++ b/apps/web/src/components/money/ui/public-document/public-document-line-items.tsx
@@ -6,7 +6,10 @@
 // (`public-quote/quote-lines-with-selection.tsx`, money plan 18 §4) instead of this component.
 
 import { formatLineItemUnit, type LineItemUnit } from '@auxx/lib/money/client'
+import { cn } from '@auxx/ui/lib/utils'
+import { Fragment } from 'react'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PhotoGallery } from './photo-gallery'
 
 /** One rendered line — decoupled from `@auxx/lib/money`'s payload types on purpose so this
  * presentational component never needs a server-only import. */
@@ -17,11 +20,16 @@ export interface PublicDocumentLine {
   unit?: LineItemUnit | null
   unitPrice: number | null
   lineTotal: number | null
+  /** Site photos captured for this line (plan 37b §6) — already internal-filtered. */
+  photos?: { ref: string; caption?: string }[]
 }
 
 interface PublicDocumentLineItemsProps {
   lines: PublicDocumentLine[]
   currency: string
+  /** Base path of the token-scoped photo route (`/pay/{token}/photo`, plan 37b §6) — each
+   * line's thumbnails point here. */
+  photoBasePath: string
 }
 
 /** Formats a quantity without trailing zeros, up to 3 decimal places (`2.375`, `5`, `12`) —
@@ -30,7 +38,11 @@ function formatQty(qty: number): string {
   return String(Number(qty.toFixed(3)))
 }
 
-export function PublicDocumentLineItems({ lines, currency }: PublicDocumentLineItemsProps) {
+export function PublicDocumentLineItems({
+  lines,
+  currency,
+  photoBasePath,
+}: PublicDocumentLineItemsProps) {
   return (
     <div className='mt-6 overflow-x-auto'>
       <table className='w-full text-sm'>
@@ -45,21 +57,39 @@ export function PublicDocumentLineItems({ lines, currency }: PublicDocumentLineI
         <tbody>
           {lines.map((line, i) => {
             const unitSuffix = formatLineItemUnit(line.unit, 'document')
+            const hasPhotos = !!line.photos?.length
             return (
-              <tr key={i} className='border-white/10 border-b text-white/80 last:border-0'>
-                <td className='py-2 pr-2'>{line.name}</td>
-                <td className='py-2 text-right tabular-nums'>
-                  {unitSuffix ? `${formatQty(line.qty)} ${unitSuffix}` : formatQty(line.qty)}
-                </td>
-                <td className='py-2 text-right tabular-nums'>
-                  {unitSuffix && line.unitPrice !== null
-                    ? `${formatCurrency(line.unitPrice, currency)}/${unitSuffix}`
-                    : formatCurrency(line.unitPrice, currency)}
-                </td>
-                <td className='py-2 text-right tabular-nums'>
-                  {formatCurrency(line.lineTotal, currency)}
-                </td>
-              </tr>
+              <Fragment key={i}>
+                <tr
+                  className={cn(
+                    'border-white/10 border-b text-white/80 last:border-0',
+                    hasPhotos && 'border-b-0'
+                  )}>
+                  <td className='py-2 pr-2'>{line.name}</td>
+                  <td className='py-2 text-right tabular-nums'>
+                    {unitSuffix ? `${formatQty(line.qty)} ${unitSuffix}` : formatQty(line.qty)}
+                  </td>
+                  <td className='py-2 text-right tabular-nums'>
+                    {unitSuffix && line.unitPrice !== null
+                      ? `${formatCurrency(line.unitPrice, currency)}/${unitSuffix}`
+                      : formatCurrency(line.unitPrice, currency)}
+                  </td>
+                  <td className='py-2 text-right tabular-nums'>
+                    {formatCurrency(line.lineTotal, currency)}
+                  </td>
+                </tr>
+                {hasPhotos ? (
+                  <tr className='border-white/10 border-b last:border-0'>
+                    <td colSpan={4} className='pb-3'>
+                      <PhotoGallery
+                        photos={line.photos ?? []}
+                        photoBasePath={photoBasePath}
+                        size='sm'
+                      />
+                    </td>
+                  </tr>
+                ) : null}
+              </Fragment>
             )
           })}
         </tbody>

--- a/apps/web/src/components/money/ui/public-invoice/public-invoice-document.tsx
+++ b/apps/web/src/components/money/ui/public-invoice/public-invoice-document.tsx
@@ -13,6 +13,7 @@ import { Button } from '@auxx/ui/components/button'
 import { Card } from '@auxx/ui/components/card'
 import { Loader2 } from 'lucide-react'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PhotoGallery } from '~/components/money/ui/public-document/photo-gallery'
 import {
   PublicDocumentContact,
   PublicDocumentHeader,
@@ -43,6 +44,7 @@ export function PublicInvoiceDocument({
     dueDate,
     contact,
     lines,
+    photos,
     subtotal,
     discountAmount,
     taxName,
@@ -91,7 +93,18 @@ export function PublicInvoiceDocument({
 
         <PublicDocumentContact label='Billed to' name={contact.name} email={contact.email} />
 
-        <PublicDocumentLineItems lines={lines} currency={currency} />
+        <PublicDocumentLineItems
+          lines={lines}
+          currency={currency}
+          photoBasePath={`/pay/${token}/photo`}
+        />
+
+        {photos.length > 0 ? (
+          <div className='mt-6 border-white/10 border-t pt-4'>
+            <p className='text-white/50 text-xs uppercase tracking-wide'>Photos</p>
+            <PhotoGallery photos={photos} photoBasePath={`/pay/${token}/photo`} size='md' />
+          </div>
+        ) : null}
 
         <PublicDocumentTotals
           currency={currency}

--- a/apps/web/src/components/money/ui/public-quote/public-quote-document.tsx
+++ b/apps/web/src/components/money/ui/public-quote/public-quote-document.tsx
@@ -13,6 +13,7 @@ import { Card } from '@auxx/ui/components/card'
 import { Download, Loader2 } from 'lucide-react'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 import { formatDocumentDate } from '~/components/money/ui/public-document/format'
+import { PhotoGallery } from '~/components/money/ui/public-document/photo-gallery'
 import {
   PublicDocumentContact,
   PublicDocumentHeader,
@@ -46,6 +47,7 @@ export function PublicQuoteDocument({ token, payload, state, message }: PublicQu
     terms,
     contact,
     lines,
+    photos,
     discountType,
     discountValue,
     taxName,
@@ -102,7 +104,15 @@ export function PublicQuoteDocument({ token, payload, state, message }: PublicQu
           taxName={taxName}
           taxRate={taxRate}
           readOnly={!showAcceptDecline}
+          photoBasePath={`/quote/${token}/photo`}
         />
+
+        {photos.length > 0 ? (
+          <div className='mt-6 border-white/10 border-t pt-4'>
+            <p className='text-white/50 text-xs uppercase tracking-wide'>Photos</p>
+            <PhotoGallery photos={photos} photoBasePath={`/quote/${token}/photo`} size='md' />
+          </div>
+        ) : null}
 
         {terms ? (
           <div className='mt-6 border-white/10 border-t pt-4'>

--- a/apps/web/src/components/money/ui/public-quote/quote-lines-with-selection.tsx
+++ b/apps/web/src/components/money/ui/public-quote/quote-lines-with-selection.tsx
@@ -18,8 +18,9 @@ import {
   type LineItemUnit,
 } from '@auxx/lib/money/client'
 import { cn } from '@auxx/ui/lib/utils'
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PhotoGallery } from '~/components/money/ui/public-document/photo-gallery'
 import { PublicDocumentTotals } from '~/components/money/ui/public-document/public-document-totals'
 
 /** One quote line as the public page needs it — decoupled from `@auxx/lib/money`'s payload
@@ -35,6 +36,8 @@ export interface QuoteSelectionLine {
   optional: boolean
   /** Seller's pre-accept default (checked = "included unless removed", money plan 18 decision 2). */
   optionalSelected: boolean
+  /** Site photos captured for this line (plan 37b §6) — already internal-filtered. */
+  photos?: { ref: string; caption?: string }[]
 }
 
 interface QuoteLinesWithSelectionProps {
@@ -48,6 +51,9 @@ interface QuoteLinesWithSelectionProps {
    * declined, expired, or still being revised) — selections are locked at accept (decision 3),
    * so there's nothing left to toggle and no accept form in the DOM to submit into anyway. */
   readOnly?: boolean
+  /** Base path of the token-scoped photo route (`/quote/{token}/photo`, plan 37b §6) — each
+   * line's thumbnails point here. */
+  photoBasePath: string
 }
 
 /** Formats a quantity without trailing zeros, up to 3 decimal places (`2.375`, `5`, `12`) —
@@ -64,6 +70,7 @@ export function QuoteLinesWithSelection({
   taxName,
   taxRate,
   readOnly = false,
+  photoBasePath,
 }: QuoteLinesWithSelectionProps) {
   // Page-local selection state, seeded from each optional line's seller default. Keyed by line
   // instance id — untouched (required) lines never enter this map.
@@ -110,53 +117,67 @@ export function QuoteLinesWithSelection({
             {lines.map((line) => {
               const unitSuffix = formatLineItemUnit(line.unit, 'document')
               const checked = isChecked(line)
+              const hasPhotos = !!line.photos?.length
               return (
-                <tr
-                  key={line.lineInstanceId}
-                  className={cn(
-                    'border-white/10 border-b last:border-0',
-                    line.optional ? 'text-white/60' : 'text-white/80'
-                  )}>
-                  <td className='py-2 pr-2'>
-                    <div className='flex items-start gap-2'>
-                      {line.optional ? (
-                        <input
-                          type='checkbox'
-                          name='selectedLineIds'
-                          value={line.lineInstanceId}
-                          form='accept-form'
-                          checked={checked}
-                          disabled={readOnly}
-                          onChange={() => toggle(line.lineInstanceId)}
-                          aria-label={`Include ${line.name}`}
-                          className='mt-0.5 h-4 w-4 shrink-0 rounded-sm border border-white/30 bg-transparent accent-white disabled:opacity-50'
-                        />
-                      ) : null}
-                      <div>
-                        <span>{line.name}</span>
+                <Fragment key={line.lineInstanceId}>
+                  <tr
+                    className={cn(
+                      'border-white/10 border-b last:border-0',
+                      line.optional ? 'text-white/60' : 'text-white/80',
+                      hasPhotos && 'border-b-0'
+                    )}>
+                    <td className='py-2 pr-2'>
+                      <div className='flex items-start gap-2'>
                         {line.optional ? (
-                          <span className='ml-2 inline-flex items-center gap-1 align-middle text-[10px] text-white/40 uppercase tracking-wide'>
-                            <span className='rounded-full border border-white/20 px-1.5 py-0.5'>
-                              Optional
-                            </span>
-                            {line.optionalSelected ? '(recommended)' : '(add-on)'}
-                          </span>
+                          <input
+                            type='checkbox'
+                            name='selectedLineIds'
+                            value={line.lineInstanceId}
+                            form='accept-form'
+                            checked={checked}
+                            disabled={readOnly}
+                            onChange={() => toggle(line.lineInstanceId)}
+                            aria-label={`Include ${line.name}`}
+                            className='mt-0.5 h-4 w-4 shrink-0 rounded-sm border border-white/30 bg-transparent accent-white disabled:opacity-50'
+                          />
                         ) : null}
+                        <div>
+                          <span>{line.name}</span>
+                          {line.optional ? (
+                            <span className='ml-2 inline-flex items-center gap-1 align-middle text-[10px] text-white/40 uppercase tracking-wide'>
+                              <span className='rounded-full border border-white/20 px-1.5 py-0.5'>
+                                Optional
+                              </span>
+                              {line.optionalSelected ? '(recommended)' : '(add-on)'}
+                            </span>
+                          ) : null}
+                        </div>
                       </div>
-                    </div>
-                  </td>
-                  <td className='py-2 text-right tabular-nums'>
-                    {unitSuffix ? `${formatQty(line.qty)} ${unitSuffix}` : formatQty(line.qty)}
-                  </td>
-                  <td className='py-2 text-right tabular-nums'>
-                    {unitSuffix && line.unitPrice !== null
-                      ? `${formatCurrency(line.unitPrice, currency)}/${unitSuffix}`
-                      : formatCurrency(line.unitPrice, currency)}
-                  </td>
-                  <td className='py-2 text-right tabular-nums'>
-                    {formatCurrency(line.lineTotal, currency)}
-                  </td>
-                </tr>
+                    </td>
+                    <td className='py-2 text-right tabular-nums'>
+                      {unitSuffix ? `${formatQty(line.qty)} ${unitSuffix}` : formatQty(line.qty)}
+                    </td>
+                    <td className='py-2 text-right tabular-nums'>
+                      {unitSuffix && line.unitPrice !== null
+                        ? `${formatCurrency(line.unitPrice, currency)}/${unitSuffix}`
+                        : formatCurrency(line.unitPrice, currency)}
+                    </td>
+                    <td className='py-2 text-right tabular-nums'>
+                      {formatCurrency(line.lineTotal, currency)}
+                    </td>
+                  </tr>
+                  {hasPhotos ? (
+                    <tr className='border-white/10 border-b last:border-0'>
+                      <td colSpan={4} className='pb-3'>
+                        <PhotoGallery
+                          photos={line.photos ?? []}
+                          photoBasePath={photoBasePath}
+                          size='sm'
+                        />
+                      </td>
+                    </tr>
+                  ) : null}
+                </Fragment>
               )
             })}
           </tbody>

--- a/apps/web/src/components/pickers/file-picker.tsx
+++ b/apps/web/src/components/pickers/file-picker.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { type FileRef, getFileRefDownloadUrl } from '@auxx/types/file-ref'
+import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
   Command,
@@ -12,19 +13,25 @@ import {
   CommandPlaceholder,
   CommandSeparator,
 } from '@auxx/ui/components/command'
-import { formatBytes } from '@auxx/utils/file'
-import { Download, File, FolderOpen, Trash2, Upload } from 'lucide-react'
+import { Camera, Download, EyeOff, File, FolderOpen, Pencil, Trash2, Upload } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import type { UploadingFile } from '~/components/fields/inputs/hooks/use-field-file-upload'
+import { PhotoTileEditor } from './photo-tile-editor'
+
+interface FilePickerFile {
+  id: string // fieldValueId — passed to onRemove
+  ref: FileRef
+  name: string
+  mimeType: string | null
+  size: number | null
+  /** Caption from the FILE envelope (37b-scouting-quote-photos.md §2). */
+  caption?: string
+  /** When true, the photo is internal-only. */
+  internal?: boolean
+}
 
 interface FilePickerProps {
-  files: Array<{
-    id: string // fieldValueId — passed to onRemove
-    ref: FileRef
-    name: string
-    mimeType: string | null
-    size: number | null
-  }>
+  files: FilePickerFile[]
   uploadingFiles: UploadingFile[]
   canAddMore: boolean
   onUpload: () => void
@@ -32,6 +39,15 @@ interface FilePickerProps {
   onRemove: (fieldValueId: string) => void
   onDownload?: (ref: FileRef) => void
   placeholder?: string
+  /** Opens the file picker with `capture='environment'`. Shown as a "Take photo" action
+   * alongside "Upload file" when provided — additive, backward compatible. */
+  onTakePhoto?: () => void
+  /** Saves a photo's caption/internal flag via `fieldValue.set` (mode 'set'). Renders an
+   * edit affordance on each tile when provided — additive, backward compatible. */
+  onUpdateMeta?: (
+    fieldValueId: string,
+    patch: { caption?: string; internal?: boolean }
+  ) => Promise<void>
 }
 
 export function FilePicker({
@@ -41,6 +57,8 @@ export function FilePicker({
   onUpload,
   onBrowse,
   onRemove,
+  onTakePhoto,
+  onUpdateMeta,
   placeholder = 'Search files...',
 }: FilePickerProps) {
   const [search, setSearch] = useState('')
@@ -69,8 +87,11 @@ export function FilePicker({
                 name={file.name}
                 mimeType={file.mimeType}
                 size={file.size}
+                caption={file.caption}
+                internal={file.internal}
                 downloadUrl={getFileRefDownloadUrl(file.ref)}
                 onRemove={() => onRemove(file.id)}
+                onUpdateMeta={onUpdateMeta ? (patch) => onUpdateMeta(file.id, patch) : undefined}
               />
             ))}
 
@@ -96,6 +117,12 @@ export function FilePicker({
         <CommandGroup>
           {canAddMore ? (
             <>
+              {onTakePhoto && (
+                <CommandItem onSelect={onTakePhoto}>
+                  <Camera className='size-4' />
+                  Take photo
+                </CommandItem>
+              )}
               <CommandItem onSelect={onUpload}>
                 <Upload className='size-4' />
                 Upload file
@@ -118,10 +145,13 @@ interface FileItemRowProps {
   name: string
   mimeType?: string | null
   size?: number | null
+  caption?: string
+  internal?: boolean
   progress?: number
   status?: string
   downloadUrl?: string
   onRemove?: () => void
+  onUpdateMeta?: (patch: { caption?: string; internal?: boolean }) => Promise<void>
   value: string
   key?: string
 }
@@ -130,13 +160,23 @@ function FileItemRow({
   name,
   mimeType,
   size,
+  caption,
+  internal,
   progress,
   status,
   downloadUrl,
   onRemove,
+  onUpdateMeta,
   ...commandItemProps
 }: FileItemRowProps) {
   const isUploading = status === 'uploading' || status === 'processing'
+  const isImage = !!mimeType?.startsWith('image/') && !!downloadUrl
+
+  const icon = isImage ? (
+    <img src={downloadUrl} alt='' className='size-6 shrink-0 rounded object-cover' loading='lazy' />
+  ) : (
+    <File className='size-4 shrink-0 text-muted-foreground' />
+  )
 
   return (
     <CommandItem
@@ -144,8 +184,17 @@ function FileItemRow({
       disabled={isUploading}
       className='group/file relative overflow-hidden'>
       <div className='flex min-w-0 flex-1 items-center gap-2'>
-        <File className='size-4 shrink-0 text-muted-foreground' />
-        <span className='truncate text-sm'>{name}</span>
+        {icon}
+        <div className='flex min-w-0 flex-col'>
+          <span className='truncate text-sm'>{name}</span>
+          {caption && <span className='truncate text-xs text-muted-foreground'>{caption}</span>}
+        </div>
+        {internal && (
+          <Badge variant='secondary' size='xs' className='shrink-0 gap-1'>
+            <EyeOff className='size-3' />
+            Internal
+          </Badge>
+        )}
         {isUploading && progress != null && (
           <span className='ml-auto tabular-nums text-xs text-muted-foreground'>
             {Math.round(progress)}%
@@ -154,10 +203,28 @@ function FileItemRow({
       </div>
       {!isUploading && (downloadUrl || onRemove) && (
         <div
-          style={{ '--btn-width': '50px' } as React.CSSProperties}
+          style={{ '--btn-width': '74px' } as React.CSSProperties}
           className='absolute inset-y-0 right-0 flex items-center translate-x-[calc(var(--btn-width)+8px)] group-hover/file:translate-x-0 transition-transform duration-200 ease-out'>
           <div className='w-4 h-full bg-gradient-to-r from-transparent to-accent/50 dark:to-[#404754]/50 transition-opacity duration-200' />
           <div className='flex items-center gap-0.5 bg-accent/50 dark:bg-[#404754]/50 pr-0.5'>
+            {onUpdateMeta && (
+              <PhotoTileEditor
+                trigger={
+                  <Button
+                    variant='ghost'
+                    size='icon-xs'
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label='Edit photo details'>
+                    <Pencil />
+                  </Button>
+                }
+                name={name}
+                caption={caption}
+                internal={internal}
+                onSave={onUpdateMeta}
+                onRemove={() => onRemove?.()}
+              />
+            )}
             {downloadUrl && (
               <Button variant='ghost' size='icon-xs' asChild>
                 <a href={downloadUrl} download onClick={(e) => e.stopPropagation()}>

--- a/apps/web/src/components/pickers/photo-tile-editor.tsx
+++ b/apps/web/src/components/pickers/photo-tile-editor.tsx
@@ -1,0 +1,120 @@
+// apps/web/src/components/pickers/photo-tile-editor.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Label } from '@auxx/ui/components/label'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@auxx/ui/components/sheet'
+import { Switch } from '@auxx/ui/components/switch'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { Trash2 } from 'lucide-react'
+import { type ReactNode, useEffect, useState } from 'react'
+import { useIsMobile } from '~/hooks/use-mobile'
+
+interface PhotoTileEditorProps {
+  /** Element that opens the editor — usually the photo thumbnail itself. */
+  trigger: ReactNode
+  name: string
+  caption?: string
+  internal?: boolean
+  onSave: (patch: { caption?: string; internal?: boolean }) => Promise<void> | void
+  onRemove: () => void
+}
+
+/**
+ * Caption + "Internal" + Remove editor for one photo tile (37b-scouting-quote-photos.md
+ * §2 tile UI). Opens as a `Sheet` — a side panel on desktop, a bottom sheet on mobile
+ * (camera-capture-friendly) — rather than a nested `Popover`: the FILE input already
+ * lives inside a field-row `Popover` (`FieldInput`), and `file-input-field.tsx`'s
+ * `FilePicker` is explicitly built to avoid Popover-in-Popover; `FileSelectDialog`
+ * already proves Dialog-in-Popover is the safe nesting here, and `Sheet` is built on the
+ * same Dialog primitive.
+ */
+export function PhotoTileEditor({
+  trigger,
+  name,
+  caption,
+  internal,
+  onSave,
+  onRemove,
+}: PhotoTileEditorProps) {
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useState(false)
+  const [captionDraft, setCaptionDraft] = useState(caption ?? '')
+  const [internalDraft, setInternalDraft] = useState(internal ?? false)
+  const [isSaving, setIsSaving] = useState(false)
+
+  // Reset the draft from the freshest props every time the sheet opens.
+  useEffect(() => {
+    if (!open) return
+    setCaptionDraft(caption ?? '')
+    setInternalDraft(internal ?? false)
+  }, [open, caption, internal])
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      const trimmed = captionDraft.trim()
+      await onSave({ caption: trimmed ? trimmed : undefined, internal: internalDraft })
+      setOpen(false)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>{trigger}</SheetTrigger>
+      <SheetContent
+        side={isMobile ? 'bottom' : 'right'}
+        className='flex flex-col gap-4 sm:max-w-sm'>
+        <SheetHeader>
+          <SheetTitle className='truncate'>{name}</SheetTitle>
+          <SheetDescription>Add a caption or hide this photo from the customer.</SheetDescription>
+        </SheetHeader>
+
+        <div className='flex flex-col gap-1.5'>
+          <Label htmlFor='photo-tile-caption'>Caption</Label>
+          <Textarea
+            id='photo-tile-caption'
+            value={captionDraft}
+            onChange={(e) => setCaptionDraft(e.target.value)}
+            placeholder='Add a caption…'
+            rows={2}
+          />
+        </div>
+
+        <div className='flex items-center justify-between rounded-md border p-3'>
+          <div className='flex flex-col gap-0.5'>
+            <span className='text-sm font-medium'>Internal</span>
+            <span className='text-xs text-muted-foreground'>Hidden from customer</span>
+          </div>
+          <Switch checked={internalDraft} onCheckedChange={setInternalDraft} />
+        </div>
+
+        <SheetFooter className='mt-auto flex-row justify-between sm:justify-between'>
+          <Button
+            type='button'
+            variant='destructive-hover'
+            onClick={() => {
+              setOpen(false)
+              onRemove()
+            }}>
+            <Trash2 />
+            Remove
+          </Button>
+          <Button type='button' loading={isSaving} loadingText='Saving...' onClick={handleSave}>
+            Save
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/packages/lib/src/documents/index.ts
+++ b/packages/lib/src/documents/index.ts
@@ -23,6 +23,7 @@ export {
   type InvoicePdfPayload,
   type InvoicePdfPaymentRow,
   loadPdfContact,
+  type PdfPhotoRef,
   type QuotePdfContact,
   type QuotePdfLineItem,
   type QuotePdfPayload,
@@ -35,7 +36,7 @@ export {
   listDocumentTypes,
   type RegisteredDocumentType,
 } from './registry'
-export { type RenderDocumentPdfOptions, renderDocumentPdf } from './render'
+export { type RenderDocumentPdfOptions, renderDocumentPdf, resolvePhotoRef } from './render'
 export {
   type DocumentBrandingSettings,
   type DocumentBusinessSettings,

--- a/packages/lib/src/documents/payload.ts
+++ b/packages/lib/src/documents/payload.ts
@@ -8,6 +8,7 @@ import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { stableHash } from '@auxx/utils/hash'
 import { getOrgCache } from '../cache'
 import type { ConditionGroup } from '../conditions'
+import type { FileValue } from '../field-values/converters'
 import { formatToDisplayValue } from '../field-values/formatter'
 import type { TypedFieldValueResult } from '../field-values/types'
 import { getPaymentAccount } from '../money/payments/account-state'
@@ -19,6 +20,15 @@ import type { LineItemUnit } from '../money/units'
 import { UnifiedCrudHandler } from '../resources/crud'
 import type { ResolvedDocumentSettings } from './resolve-settings'
 import { resolveDocumentSettings } from './resolve-settings'
+
+/** A customer-safe photo reference on a PDF payload (plan 37b §5) — `internal: true` rows
+ * are dropped at `extractPhotos` build time, so this shape never carries that flag; PDF,
+ * email, and public-page payloads all read this same filtered shape. */
+export interface PdfPhotoRef {
+  /** `"asset:<id>"` or `"file:<id>"` — resolved to bytes by `render.ts`'s photo resolver. */
+  ref: string
+  caption?: string
+}
 
 /** One rendered line on the quote PDF's line-item table. */
 export interface QuotePdfLineItem {
@@ -41,6 +51,9 @@ export interface QuotePdfLineItem {
   optional: boolean
   /** Current selection state — meaningful only when `optional` is true. */
   optionalSelected: boolean
+  /** Site photos captured for this line (plan 37b §5), `line_item_photos`, in FieldValue
+   * `sortKey` order. Internal-only photos are already filtered out (never present here). */
+  photos?: PdfPhotoRef[]
 }
 
 /** Billing-party display fields — no street address on `contact` today (city/region/country only). */
@@ -89,6 +102,9 @@ export interface QuotePdfPayload {
   /** Integer cents. */
   total: number
   settings: ResolvedDocumentSettings
+  /** Header-level site photos (plan 37b §5), `quote_photos`, in FieldValue `sortKey` order.
+   * Internal-only photos are already filtered out (never present here). */
+  photos?: PdfPhotoRef[]
 }
 
 /** One payment-history row on the invoice PDF (money MI1 build spec §H.1) — a succeeded
@@ -151,6 +167,10 @@ export interface InvoicePdfPayload {
    * naturally busts the cached render. */
   payLink: string | null
   settings: ResolvedDocumentSettings
+  /** Header-level photos (plan 37b §5), `invoice_photos`, in FieldValue `sortKey` order. No
+   * auto-copy from `quote_photos` (decision 7) — office attaches directly. Internal-only
+   * photos are already filtered out (never present here). */
+  photos?: PdfPhotoRef[]
 }
 
 /** The render/content-hash dispatch union — `render.ts` and `ensure-pdf.ts` branch on
@@ -163,6 +183,27 @@ function firstTyped(
 ): TypedFieldValue | undefined {
   if (!entry) return undefined
   return Array.isArray(entry) ? entry[0] : entry
+}
+
+/**
+ * Extract a payload-safe photo list from a batched FILE field-value read (plan 37b §5) —
+ * `getValues`/`batchGetValues` already order FILE's multiple rows by `FieldValue.sortKey`
+ * (`field-value-queries.ts`), so this preserves capture order as-is. Drops `internal: true`
+ * rows here — the single server-side choke point that keeps internal photos out of every
+ * downstream consumer (PDF, email, and — once wired — the public quote/pay pages, since
+ * `PublicQuoteLine`/`PublicInvoiceLine` = `QuotePdfLineItem`).
+ */
+function extractPhotos(entry: TypedFieldValue | TypedFieldValue[] | undefined): PdfPhotoRef[] {
+  if (!entry) return []
+  const rows = Array.isArray(entry) ? entry : [entry]
+  const photos: PdfPhotoRef[] = []
+  for (const row of rows) {
+    if (row.type !== 'json' || !row.value) continue
+    const file = row.value as unknown as FileValue
+    if (!file.ref || file.internal === true) continue
+    photos.push(file.caption ? { ref: file.ref, caption: file.caption } : { ref: file.ref })
+  }
+  return photos
 }
 
 /**
@@ -286,6 +327,7 @@ async function loadPdfLines(
       'line_item_taxable',
       'line_item_optional',
       'line_item_optional_selected',
+      'line_item_photos',
     ] as const)
 
   const { ids: lineInstanceIds } = await handler.listFiltered({
@@ -306,6 +348,7 @@ async function loadPdfLines(
     lineCf.line_item_taxable,
     lineCf.line_item_optional,
     lineCf.line_item_optional_selected,
+    lineCf.line_item_photos,
   ]
     .filter(Boolean)
     .map((f) => f!.id)
@@ -325,6 +368,7 @@ async function loadPdfLines(
     const taxableTyped = getLine(lineCf.line_item_taxable)
     const optionalTyped = getLine(lineCf.line_item_optional)
     const optionalSelectedTyped = getLine(lineCf.line_item_optional_selected)
+    const photosEntry = lineCf.line_item_photos ? values.get(lineCf.line_item_photos.id) : undefined
 
     lines.push({
       lineInstanceId,
@@ -339,6 +383,7 @@ async function loadPdfLines(
       optionalSelected: optionalSelectedTyped
         ? (extractValue(optionalSelectedTyped) as boolean)
         : true,
+      photos: extractPhotos(photosEntry),
     })
   }
 
@@ -386,6 +431,7 @@ export async function buildQuotePdfPayload(params: {
       'quote_discount_type',
       'quote_discount_value',
       'quote_contact',
+      'quote_photos',
     ] as const)
 
   const quoteFieldIds = [
@@ -399,6 +445,7 @@ export async function buildQuotePdfPayload(params: {
     cf.quote_discount_type,
     cf.quote_discount_value,
     cf.quote_contact,
+    cf.quote_photos,
   ]
     .filter(Boolean)
     .map((f) => f!.id)
@@ -426,6 +473,7 @@ export async function buildQuotePdfPayload(params: {
   const discountType = discountTypeTyped ? (extractValue(discountTypeTyped) as DiscountType) : null
   const discountValue = discountValueTyped ? (extractValue(discountValueTyped) as number) : null
   const contactRecordId = contactTyped?.type === 'relationship' ? contactTyped.recordId : undefined
+  const photos = extractPhotos(cf.quote_photos ? quoteValues.get(cf.quote_photos.id) : undefined)
 
   // ─── Contact display fields (billing party block) ──────────────────────────
   const contact = await loadPdfContact(cache, handler, organizationId, contactRecordId)
@@ -481,6 +529,7 @@ export async function buildQuotePdfPayload(params: {
     taxTotal: totals.taxTotal,
     total: totals.total,
     settings,
+    photos,
   }
 
   return { payload, hash: stableHash(payload) }
@@ -527,6 +576,7 @@ export async function buildInvoicePdfPayload(params: {
       'invoice_contact',
       'invoice_amount_paid',
       'invoice_balance',
+      'invoice_photos',
     ] as const)
 
   const invoiceFieldIds = [
@@ -542,6 +592,7 @@ export async function buildInvoicePdfPayload(params: {
     cf.invoice_contact,
     cf.invoice_amount_paid,
     cf.invoice_balance,
+    cf.invoice_photos,
   ]
     .filter(Boolean)
     .map((f) => f!.id)
@@ -573,6 +624,9 @@ export async function buildInvoicePdfPayload(params: {
   const discountType = discountTypeTyped ? (extractValue(discountTypeTyped) as DiscountType) : null
   const discountValue = discountValueTyped ? (extractValue(discountValueTyped) as number) : null
   const contactRecordId = contactTyped?.type === 'relationship' ? contactTyped.recordId : undefined
+  const photos = extractPhotos(
+    cf.invoice_photos ? invoiceValues.get(cf.invoice_photos.id) : undefined
+  )
 
   // ─── Contact display fields (billing party block) ──────────────────────────
   const contact = await loadPdfContact(cache, handler, organizationId, contactRecordId)
@@ -665,6 +719,7 @@ export async function buildInvoicePdfPayload(params: {
     payments,
     payLink,
     settings,
+    photos,
   }
 
   return { payload, hash: stableHash(payload) }

--- a/packages/lib/src/documents/pdf/invoice-pdf.tsx
+++ b/packages/lib/src/documents/pdf/invoice-pdf.tsx
@@ -11,6 +11,7 @@ import {
   DocumentHeader,
   formatDocDate,
   LineItemsTable,
+  PhotoGrid,
   TotalsBlock,
 } from './parts'
 import { createDocumentStyles, pageSizeFor } from './theme'
@@ -65,10 +66,12 @@ function PaymentHistoryBlock(props: {
 export function InvoicePdf(props: {
   payload: InvoicePdfPayload
   logoBytes?: Buffer | null
+  /** Resolved photo bytes keyed by ref (plan 37b §5) — see `render.ts`'s photo resolver. */
+  photoBytes?: Map<string, Buffer>
   /** Batch-print copy label (P4) — see `DocumentHeader`'s `copyLabel`. */
   copyLabel?: string
 }) {
-  const { payload, logoBytes, copyLabel } = props
+  const { payload, logoBytes, photoBytes, copyLabel } = props
   const { settings } = payload
   const styles = createDocumentStyles(settings)
   const currencyCode = settings.currency
@@ -97,7 +100,12 @@ export function InvoicePdf(props: {
           lineDisplay={settings.invoice.lineDisplay}
           showDescriptions={settings.invoice.showDescriptions}
           currencyCode={currencyCode}
+          photoBytes={photoBytes}
         />
+
+        {photoBytes ? (
+          <PhotoGrid styles={styles} photos={payload.photos ?? []} photoBytes={photoBytes} />
+        ) : null}
 
         <TotalsBlock
           styles={styles}

--- a/packages/lib/src/documents/pdf/parts.tsx
+++ b/packages/lib/src/documents/pdf/parts.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from '@auxx/utils/currency'
 import { Image, Text, View } from '@react-pdf/renderer'
 import { format } from 'date-fns'
 import { formatLineItemUnit, type LineItemUnit } from '../../money/units'
+import type { PdfPhotoRef } from '../payload'
 import type { DocumentBusinessSettings } from '../resolve-settings'
 import type { createDocumentStyles } from './theme'
 
@@ -149,6 +150,75 @@ export interface DocumentLineRow {
    * optional line as "Optional · included" in the main list (money plan 18 §7). Absent on
    * every other row (invoice lines, deselected add-ons rendered in their own block). */
   tag?: string | null
+  /** Site photos captured for this line (plan 37b §5) — rendered as a wrapping row of small
+   * captioned thumbnails under the description when `photoBytes` resolved at least one ref. */
+  photos?: PdfPhotoRef[]
+}
+
+/** Drops photo refs with no resolved bytes — `photoBytes` only ever contains refs `render.ts`
+ * successfully fetched + downscaled, so a ref with no entry means a missing/deleted asset or
+ * a failed downscale (plan 37b §5); every photo component skips it silently rather than
+ * rendering a broken image. */
+function resolvedPhotos(
+  photos: PdfPhotoRef[],
+  photoBytes: Map<string, Buffer>
+): Array<PdfPhotoRef & { bytes: Buffer }> {
+  return photos
+    .map((p) => ({ ...p, bytes: photoBytes.get(p.ref) }))
+    .filter((p): p is PdfPhotoRef & { bytes: Buffer } => p.bytes !== undefined)
+}
+
+/**
+ * Wrapping row of captioned thumbnails — shared by `LineItemsTable`'s per-line strip
+ * (~110pt) and `PhotoGrid`'s header-level 2-up gallery via different sizing styles (plan
+ * 37b §5). Caller must have already filtered to resolved photos.
+ */
+function PhotoThumbs(props: {
+  photos: Array<PdfPhotoRef & { bytes: Buffer }>
+  rowStyle: Styles[keyof Styles]
+  wrapStyle: Styles[keyof Styles]
+  imageStyle: Styles[keyof Styles]
+  captionStyle: Styles[keyof Styles]
+}) {
+  const { photos, rowStyle, wrapStyle, imageStyle, captionStyle } = props
+  return (
+    <View style={rowStyle}>
+      {photos.map((photo, i) => (
+        <View key={i} style={wrapStyle}>
+          <Image style={imageStyle} src={photo.bytes} />
+          {photo.caption ? <Text style={captionStyle}>{photo.caption}</Text> : null}
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/**
+ * Header-level "Photos" gallery — a 2-up captioned grid rendered after the line table for a
+ * document's own `photos` (quote's `quote_photos` / invoice's `invoice_photos`, plan 37b §5).
+ * Renders nothing when there are no photos, or none resolved to bytes.
+ */
+export function PhotoGrid(props: {
+  styles: Styles
+  photos: PdfPhotoRef[]
+  photoBytes: Map<string, Buffer>
+}) {
+  const { styles, photos, photoBytes } = props
+  const resolved = resolvedPhotos(photos, photoBytes)
+  if (resolved.length === 0) return null
+
+  return (
+    <View style={styles.photoSection}>
+      <Text style={[styles.label, { marginBottom: 6 }]}>Photos</Text>
+      <PhotoThumbs
+        photos={resolved}
+        rowStyle={styles.photoGridRow}
+        wrapStyle={styles.photoGridCell}
+        imageStyle={styles.photoGridImage}
+        captionStyle={styles.photoCaption}
+      />
+    </View>
+  )
 }
 
 /** Formats a quantity without trailing zeros, up to 3 decimal places (`2.375`, `5`, `12`) —
@@ -192,8 +262,11 @@ export function LineItemsTable(props: {
   lineDisplay: 'full' | 'amount_only'
   showDescriptions: boolean
   currencyCode: string
+  /** Resolved photo bytes keyed by ref (plan 37b §5) — omit/empty renders exactly as before
+   * (no thumbnail row under any line). */
+  photoBytes?: Map<string, Buffer>
 }) {
-  const { styles, lines, lineDisplay, showDescriptions, currencyCode } = props
+  const { styles, lines, lineDisplay, showDescriptions, currencyCode, photoBytes } = props
   const full = lineDisplay === 'full'
 
   return (
@@ -204,24 +277,38 @@ export function LineItemsTable(props: {
         {full ? <Text style={[styles.colUnitPrice, styles.label]}>Unit price</Text> : null}
         <Text style={[styles.colAmount, styles.label]}>Amount</Text>
       </View>
-      {lines.map((line, i) => (
-        <View key={i} style={styles.tableRow}>
-          <View style={styles.colDescription}>
-            <Text style={styles.lineName}>{line.name}</Text>
-            {line.tag ? <Text style={styles.lineTag}>{line.tag}</Text> : null}
-            {showDescriptions && line.description ? (
-              <Text style={styles.lineDescription}>{line.description}</Text>
+      {lines.map((line, i) => {
+        const linePhotos = photoBytes ? resolvedPhotos(line.photos ?? [], photoBytes) : []
+        return (
+          <View key={i} style={styles.tableRow}>
+            <View style={styles.colDescription}>
+              <Text style={styles.lineName}>{line.name}</Text>
+              {line.tag ? <Text style={styles.lineTag}>{line.tag}</Text> : null}
+              {showDescriptions && line.description ? (
+                <Text style={styles.lineDescription}>{line.description}</Text>
+              ) : null}
+              {linePhotos.length > 0 ? (
+                <PhotoThumbs
+                  photos={linePhotos}
+                  rowStyle={styles.lineThumbRow}
+                  wrapStyle={styles.lineThumbWrap}
+                  imageStyle={styles.lineThumb}
+                  captionStyle={styles.photoCaption}
+                />
+              ) : null}
+            </View>
+            {full ? (
+              <Text style={styles.colQty}>{formatDocQtyCell(line.qty, line.unit)}</Text>
             ) : null}
+            {full ? (
+              <Text style={styles.colUnitPrice}>
+                {formatDocUnitPriceCell(line.unitPrice, line.unit, currencyCode)}
+              </Text>
+            ) : null}
+            <Text style={styles.colAmount}>{formatCurrency(line.lineTotal, { currencyCode })}</Text>
           </View>
-          {full ? <Text style={styles.colQty}>{formatDocQtyCell(line.qty, line.unit)}</Text> : null}
-          {full ? (
-            <Text style={styles.colUnitPrice}>
-              {formatDocUnitPriceCell(line.unitPrice, line.unit, currencyCode)}
-            </Text>
-          ) : null}
-          <Text style={styles.colAmount}>{formatCurrency(line.lineTotal, { currencyCode })}</Text>
-        </View>
-      ))}
+        )
+      })}
     </View>
   )
 }

--- a/packages/lib/src/documents/pdf/quote-pdf.tsx
+++ b/packages/lib/src/documents/pdf/quote-pdf.tsx
@@ -10,6 +10,7 @@ import {
   DocumentHeader,
   type DocumentLineRow,
   LineItemsTable,
+  PhotoGrid,
   TotalsBlock,
 } from './parts'
 import { createDocumentStyles, pageSizeFor } from './theme'
@@ -31,10 +32,12 @@ import { createDocumentStyles, pageSizeFor } from './theme'
 export function QuotePdf(props: {
   payload: QuotePdfPayload
   logoBytes?: Buffer | null
+  /** Resolved photo bytes keyed by ref (plan 37b §5) — see `render.ts`'s photo resolver. */
+  photoBytes?: Map<string, Buffer>
   /** Batch-print copy label (P4) — see `DocumentHeader`'s `copyLabel`. */
   copyLabel?: string
 }) {
-  const { payload, logoBytes, copyLabel } = props
+  const { payload, logoBytes, photoBytes, copyLabel } = props
   const { settings } = payload
   const styles = createDocumentStyles(settings)
   const currencyCode = settings.currency
@@ -49,6 +52,7 @@ export function QuotePdf(props: {
       unit: line.unit,
       unitPrice: line.unitPrice,
       lineTotal: line.lineTotal,
+      photos: line.photos,
     }
     if (line.optional && !line.optionalSelected) {
       addOnLines.push(row)
@@ -85,6 +89,7 @@ export function QuotePdf(props: {
           lineDisplay={settings.quote.lineDisplay}
           showDescriptions={settings.quote.showDescriptions}
           currencyCode={currencyCode}
+          photoBytes={photoBytes}
         />
 
         {addOnLines.length > 0 ? (
@@ -96,12 +101,17 @@ export function QuotePdf(props: {
               lineDisplay={settings.quote.lineDisplay}
               showDescriptions={settings.quote.showDescriptions}
               currencyCode={currencyCode}
+              photoBytes={photoBytes}
             />
             <Text style={[styles.value, { marginTop: 6, fontSize: 8, color: '#6b7280' }]}>
               These add-ons aren&apos;t included in the total above — they can be added on the
               online quote page.
             </Text>
           </View>
+        ) : null}
+
+        {photoBytes ? (
+          <PhotoGrid styles={styles} photos={payload.photos ?? []} photoBytes={photoBytes} />
         ) : null}
 
         <TotalsBlock

--- a/packages/lib/src/documents/pdf/theme.ts
+++ b/packages/lib/src/documents/pdf/theme.ts
@@ -116,5 +116,16 @@ export function createDocumentStyles(settings: ResolvedDocumentSettings) {
       paddingTop: 8,
     },
     terms: { marginTop: 20, fontSize: 8, color: '#6b7280' },
+    // ─── Photos (plan 37b §5) ──────────────────────────────────────────────────
+    /** Wrapping row of small thumbnails under a line's description. */
+    lineThumbRow: { flexDirection: 'row', flexWrap: 'wrap', marginTop: 6 },
+    lineThumbWrap: { width: 110, marginRight: 8, marginBottom: 8 },
+    lineThumb: { width: 110, height: 78, objectFit: 'cover', borderRadius: 3 },
+    photoCaption: { fontSize: 7, color: '#6b7280', marginTop: 2 },
+    photoSection: { marginTop: 20 },
+    /** 2-up grid for header-level ("Photos" section) photos. */
+    photoGridRow: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between' },
+    photoGridCell: { width: '48%', marginBottom: 14 },
+    photoGridImage: { width: '100%', height: 160, objectFit: 'cover', borderRadius: 3 },
   })
 }

--- a/packages/lib/src/documents/registry.ts
+++ b/packages/lib/src/documents/registry.ts
@@ -35,7 +35,15 @@ export interface RegisteredDocumentType {
    * batch print runs (P4) — "Office Copy" for the office copy, `undefined` for the customer
    * copy and every single-document render (`ensure-pdf.ts`, `preview-pdf.ts`).
    */
-  Pdf: ComponentType<{ payload: DocumentPdfPayload; logoBytes?: Buffer | null; copyLabel?: string }>
+  Pdf: ComponentType<{
+    payload: DocumentPdfPayload
+    logoBytes?: Buffer | null
+    /** Resolved+downscaled bytes for every payload photo ref that resolved successfully,
+     * keyed by ref (plan 37b §5) — a ref with no entry means resolution failed and the
+     * component must skip it silently, same contract as `logoBytes`. */
+    photoBytes?: Map<string, Buffer>
+    copyLabel?: string
+  }>
   /** Wizard extras this type contributes (P4 — empty today, see `./client.ts`). */
   printOptions?: PrintOptionField[]
 }

--- a/packages/lib/src/documents/render.ts
+++ b/packages/lib/src/documents/render.ts
@@ -4,9 +4,107 @@ import type { DocumentProps } from '@react-pdf/renderer'
 import { renderToBuffer } from '@react-pdf/renderer'
 import type { ReactElement } from 'react'
 import { createElement } from 'react'
+import { FileService } from '../files/core/file-service'
 import { MediaAssetService } from '../files/core/media-asset-service'
+import { THUMBNAIL_LIMITS } from '../files/core/thumbnail-types'
 import type { DocumentPdfPayload } from './payload'
 import { getDocumentType } from './registry'
+
+/** Longest-edge cap (points→px, effectively pixels here) for embedded photo bytes (plan 37b
+ * §5) — a 12-photo quote at full camera resolution would otherwise balloon the PDF to tens
+ * of MB. 1200px is comfortably above what a ~110pt line thumbnail or a half-page 2-up grid
+ * cell ever needs at print resolution. */
+const PHOTO_MAX_DIMENSION = 1200
+
+/** JPEG quality for embedded photos — react-pdf only embeds JPEG/PNG, so every source format
+ * (including already-JPEG originals) is re-encoded here; 80 keeps file size down without
+ * visible banding at thumbnail/gallery sizes. */
+const PHOTO_JPEG_QUALITY = 80
+
+/**
+ * Downscale + transcode one photo's raw bytes to a PDF-embeddable JPEG (plan 37b §5). Mirrors
+ * the resize/encode shape of `files/core/image-processing.ts`'s `processImage`, but as a
+ * one-off (no thumbnail preset/DB row) since these bytes are only ever embedded inline in a
+ * rendered PDF buffer, never stored.
+ */
+async function downscalePhotoForPdf(buffer: Buffer): Promise<Buffer> {
+  const sharp = (await import('sharp')).default
+  return sharp(buffer, { limitInputPixels: THUMBNAIL_LIMITS.maxInputPixels, failOn: 'warning' })
+    .rotate() // auto-orient by EXIF before resizing, same as the thumbnail pipeline
+    .resize(PHOTO_MAX_DIMENSION, PHOTO_MAX_DIMENSION, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: PHOTO_JPEG_QUALITY, progressive: true, mozjpeg: true })
+    .toBuffer()
+}
+
+/**
+ * Resolve one payload photo ref (`"asset:<id>"` | `"file:<id>"`) to downscaled JPEG bytes.
+ * `asset:` refs are `MediaAsset` rows (uploaded via the FILE field's asset-upload path);
+ * `file:` refs are `FolderFile` rows (picked from the file manager) — both services implement
+ * the same `ContentAccessible.getContent(id) => Buffer` shape (`files/core/mixins`), so the
+ * only branch is which service to construct. Returns `null` on any failure (deleted asset,
+ * unreadable image, transient storage error) — callers skip the ref silently, same fail-soft
+ * contract as the logo above.
+ *
+ * Exported (plan 37b §6) for the public `/quote/[token]/photo/[ref]` and
+ * `/pay/[token]/photo/[ref]` route handlers — same downscale-on-read behavior the PDF gets,
+ * so the public pages never stream multi-MB originals. Callers MUST only invoke this after
+ * verifying the ref appears in that document's own (already internal-filtered) payload — this
+ * function itself has no allow-list, it resolves any well-formed ref for the given org.
+ */
+export async function resolvePhotoRef(organizationId: string, ref: string): Promise<Buffer | null> {
+  try {
+    const colonIdx = ref.indexOf(':')
+    if (colonIdx === -1) return null
+    const kind = ref.slice(0, colonIdx)
+    const id = ref.slice(colonIdx + 1)
+
+    let raw: Buffer
+    if (kind === 'asset') {
+      raw = await new MediaAssetService(organizationId).getContent(id)
+    } else if (kind === 'file') {
+      raw = await new FileService(organizationId).getContent(id)
+    } else {
+      return null
+    }
+
+    return await downscalePhotoForPdf(raw)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve every photo ref referenced by a document payload (header-level `photos` + each
+ * line's `photos`) to downscaled JPEG bytes, keyed by ref (plan 37b §5). Refs repeat when the
+ * same asset appears on multiple lines (e.g. a copied line) or is somehow duplicated — the
+ * `Set` dedupes so each unique ref is only fetched/downscaled once. Counts are small (≤10
+ * header + ≤10 per line) so an unbounded `Promise.all` is fine; a ref that fails to resolve
+ * is simply absent from the returned map, and every PDF photo component skips refs with no
+ * entry (same missing/broken-ref contract as the logo).
+ */
+async function resolvePayloadPhotoBytes(payload: DocumentPdfPayload): Promise<Map<string, Buffer>> {
+  const refs = new Set<string>()
+  for (const photo of payload.photos ?? []) refs.add(photo.ref)
+  for (const line of payload.lines) {
+    for (const photo of line.photos ?? []) refs.add(photo.ref)
+  }
+  if (refs.size === 0) return new Map()
+
+  const resolved = await Promise.all(
+    Array.from(refs).map(
+      async (ref) => [ref, await resolvePhotoRef(payload.organizationId, ref)] as const
+    )
+  )
+
+  const photoBytes = new Map<string, Buffer>()
+  for (const [ref, bytes] of resolved) {
+    if (bytes) photoBytes.set(ref, bytes)
+  }
+  return photoBytes
+}
 
 /** Options accepted by {@link renderDocumentPdf} beyond the payload itself. */
 export interface RenderDocumentPdfOptions {
@@ -41,6 +139,8 @@ export async function renderDocumentPdf(
     }
   }
 
+  const photoBytes = await resolvePayloadPhotoBytes(payload)
+
   const documentType = getDocumentType(payload.documentType)
   if (!documentType) {
     throw new Error(`Unregistered document type: ${payload.documentType}`)
@@ -52,6 +152,7 @@ export async function renderDocumentPdf(
   const element = createElement(documentType.Pdf, {
     payload,
     logoBytes,
+    photoBytes,
     copyLabel: options?.copyLabel,
   })
   return renderToBuffer(element as unknown as ReactElement<DocumentProps>)

--- a/packages/lib/src/field-values/__tests__/file-ref-identity.test.ts
+++ b/packages/lib/src/field-values/__tests__/file-ref-identity.test.ts
@@ -1,0 +1,215 @@
+// packages/lib/src/field-values/__tests__/file-ref-identity.test.ts
+
+import { toRecordId } from '@auxx/types/resource'
+
+// See batched-realtime-publish.test.ts for why these two barrels are mocked
+// this way (leaf-module mock to dodge an import-cycle gotcha; '../../cache'
+// wholesale since only getOrgCache is reached on this path).
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+  getCachedResource: vi.fn(),
+  getOrgCache: vi.fn(),
+}))
+
+import { getOrgCache } from '../../cache'
+import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
+import { createFieldValueContext, type FieldValueContext } from '../field-value-helpers'
+import { addValues, removeValues } from '../field-value-mutations'
+import type { FieldValueRow } from '../types'
+
+const mockedGetOrgCache = getOrgCache as unknown as ReturnType<typeof vi.fn>
+const mockedPublish = publishFieldValueUpdates as unknown as ReturnType<typeof vi.fn>
+
+// Minimal CustomField-shaped fixture for the FILE `photos` field. `entityDefinitionId:
+// null` keeps `getField`'s `entityDefinition` null, so `maybeUpdateDisplayValue`
+// short-circuits (`if (!entityDef) return`) — untested here, out of scope.
+const FIELD_PHOTOS = {
+  id: 'field-photos',
+  type: 'FILE',
+  options: {},
+  entityDefinitionId: null,
+  entityType: null,
+  isUnique: false,
+  systemAttribute: null,
+}
+
+const recordId = toRecordId('quote', 'inst-1')
+
+/**
+ * Chainable fake `Database`. Drizzle's `schema.*` column refs are undefined
+ * under this repo's vitest setup (project memory), so — same as
+ * batched-realtime-publish.test.ts — no assertion here depends on `.where()`
+ * actually filtering; the fake ignores its arguments and this suite drives
+ * behavior entirely through what `.orderBy()` / `.returning()` are seeded to
+ * return.
+ */
+function makeFakeDb(existingRows: FieldValueRow[]) {
+  let idSeq = 0
+  let pendingValues: any[] = []
+  const chain: any = {}
+  Object.assign(chain, {
+    transaction: async (fn: (tx: any) => Promise<any>) => fn(chain),
+    execute: async () => undefined, // pg_advisory_xact_lock
+    delete: () => chain,
+    where: () => chain,
+    insert: () => chain,
+    values: (rows: any) => {
+      pendingValues = Array.isArray(rows) ? rows : [rows]
+      return chain
+    },
+    onConflictDoUpdate: () => chain,
+    returning: () =>
+      Promise.resolve(
+        pendingValues.map((row) => ({
+          id: `fv-new-${idSeq++}`,
+          createdAt: '2026-07-21T00:00:00.000Z',
+          updatedAt: '2026-07-21T00:00:00.000Z',
+          ...row,
+        }))
+      ),
+    select: () => chain,
+    from: () => chain,
+    orderBy: () => Promise.resolve(existingRows),
+    update: () => chain,
+    set: () => chain,
+  })
+  return chain
+}
+
+function makeCtx(db: any): FieldValueContext {
+  return createFieldValueContext('org-1', undefined, db, 'socket-abc')
+}
+
+function photoRow(overrides: Partial<FieldValueRow>): FieldValueRow {
+  return {
+    id: 'fv-existing',
+    entityId: 'inst-1',
+    entityDefinitionId: 'quote',
+    fieldId: 'field-photos',
+    organizationId: 'org-1',
+    valueText: null,
+    valueNumber: null,
+    valueBoolean: null,
+    valueDate: null,
+    valueJson: null,
+    optionId: null,
+    relatedEntityId: null,
+    relatedEntityDefinitionId: null,
+    actorId: null,
+    sortKey: 'a0',
+    createdAt: '2026-07-20T00:00:00.000Z',
+    updatedAt: '2026-07-20T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockedGetOrgCache.mockReset()
+  mockedPublish.mockReset()
+  mockedPublish.mockResolvedValue(undefined)
+  mockedGetOrgCache.mockReturnValue({
+    all: async () => ({}),
+    from: () => ({
+      all: async () => ({}),
+      byId: async (id: string) => (id === 'field-photos' ? FIELD_PHOTOS : undefined),
+    }),
+  })
+})
+
+describe('addValues — FILE identity is `.ref`, not whole-envelope equality', () => {
+  it('dedupes a bare { ref } re-add against an existing captioned row for the same file', async () => {
+    const existing = photoRow({
+      valueJson: { ref: 'asset:1', caption: 'Front porch', internal: false },
+    })
+    const db = makeFakeDb([existing])
+    const ctx = makeCtx(db)
+
+    const result = await addValues(ctx, {
+      recordId,
+      fieldId: 'field-photos',
+      // Re-adding the same file bare (as the upload path always does) plus one
+      // genuinely new file.
+      values: [{ ref: 'asset:1' }, { ref: 'asset:2' }],
+    })
+
+    // Only the new file was inserted — the captioned row was not duplicated.
+    expect(result).toHaveLength(2)
+    const byRef = new Map(result.map((r: any) => [r.value.ref, r]))
+    expect(byRef.get('asset:1')?.value).toEqual({
+      ref: 'asset:1',
+      caption: 'Front porch',
+      internal: false,
+    })
+    expect(byRef.get('asset:2')?.value).toEqual({ ref: 'asset:2' })
+    expect(byRef.get('asset:1')?.id).toBe('fv-existing')
+  })
+
+  it('dedupes two identical bare refs within the same add call', async () => {
+    const db = makeFakeDb([])
+    const ctx = makeCtx(db)
+
+    const result = await addValues(ctx, {
+      recordId,
+      fieldId: 'field-photos',
+      values: [{ ref: 'asset:3' }, { ref: 'asset:3' }],
+    })
+
+    expect(result).toHaveLength(1)
+    expect((result[0] as any).value).toEqual({ ref: 'asset:3' })
+  })
+})
+
+describe('removeValues — FILE identity is `.ref`, not whole-envelope equality', () => {
+  it('does not throw when removing a bare { ref } that matches a captioned row', async () => {
+    const existing = photoRow({
+      valueJson: { ref: 'asset:1', caption: 'Front porch', internal: true },
+    })
+    const db = makeFakeDb([existing])
+    const ctx = makeCtx(db)
+
+    await expect(
+      removeValues(ctx, {
+        recordId,
+        fieldId: 'field-photos',
+        values: [{ ref: 'asset:1' }],
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('builds a ref-scoped where clause distinct from whole-envelope equality for FILE', async () => {
+    const existing = photoRow({
+      valueJson: { ref: 'asset:1', caption: 'Front porch', internal: true },
+    })
+    const db = makeFakeDb([existing])
+    const whereArgs: any[] = []
+    db.where = (arg: any) => {
+      whereArgs.push(arg)
+      return db
+    }
+    const ctx = makeCtx(db)
+
+    await removeValues(ctx, {
+      recordId,
+      fieldId: 'field-photos',
+      values: [{ ref: 'asset:1' }], // bare — would NOT equal the captioned row's
+      // whole valueJson via old-style jsonb equality.
+    })
+
+    // First `.where()` call is the DELETE's; a second follows from the
+    // post-delete `getValue()` read (unrelated — plain entity/field/org
+    // equality, no valueJson match at all).
+    expect(whereArgs.length).toBeGreaterThanOrEqual(1)
+    const rendered = JSON.stringify(whereArgs[0])
+    // The `inArray(valueJson->>'ref', ['asset:1'])` clause carries the raw
+    // `->>'ref'` SQL fragment and the bare ref as its bound param — proof the
+    // match is ref-scoped, not a whole-object jsonb equality check (which
+    // would instead carry the JSON.stringify'd `{"ref":"asset:1"}` string).
+    expect(rendered).toContain("->>'ref'")
+    expect(rendered).toContain('asset:1')
+    expect(rendered).not.toContain('caption')
+  })
+})

--- a/packages/lib/src/field-values/client.ts
+++ b/packages/lib/src/field-values/client.ts
@@ -16,7 +16,7 @@ export {
   validateCalcExpression,
 } from '@auxx/utils/calc-expression'
 // Converters (for direct access if needed)
-export { converters } from './converters'
+export { converters, type FileValue } from './converters'
 
 // Re-export relationship type guards from converter (centralized location)
 export {

--- a/packages/lib/src/field-values/converters/index.ts
+++ b/packages/lib/src/field-values/converters/index.ts
@@ -66,7 +66,7 @@ import { actorConverter } from './actor'
 import { booleanConverter } from './boolean'
 import { calcConverter } from './calc'
 import { dateConverter } from './date'
-import { fileConverter, jsonConverter, nameConverter } from './json'
+import { type FileValue, fileConverter, jsonConverter, nameConverter } from './json'
 import { currencyConverter, numberConverter } from './number'
 import { phoneConverter } from './phone'
 import { relationshipConverter } from './relationship'
@@ -138,3 +138,4 @@ export {
   calcConverter,
   actorConverter,
 }
+export type { FileValue }

--- a/packages/lib/src/field-values/converters/json.ts
+++ b/packages/lib/src/field-values/converters/json.ts
@@ -236,10 +236,19 @@ export const nameConverter: FieldValueConverter = {
 }
 
 /**
- * FILE field value structure — one file reference per FieldValue row.
+ * FILE field value envelope — one file reference per FieldValue row, stored as the
+ * row's whole `valueJson`. `caption`/`internal` are additive on top of the original
+ * `{ ref }` shape (plans/dispatch/37b-scouting-quote-photos.md §2): existing bare
+ * `{ ref }` rows keep working, and every reader that only needs `.ref` is unaffected.
  */
 export interface FileValue {
-  ref: string // "asset:id" or "file:id"
+  /** "asset:<id>" or "file:<id>" */
+  ref: string
+  /** Optional caption rendered under the photo thumbnail. */
+  caption?: string
+  /** When true, the photo is internal-only — stripped server-side before it reaches
+   * customer-facing payloads (PDF, email, public quote/pay pages). */
+  internal?: boolean
 }
 
 const FILE_REF_PATTERN = /^(asset|file):.+/

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/field-values/field-value-mutations.ts
 
 import { type Database, schema } from '@auxx/database'
+import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import {
@@ -1189,20 +1190,48 @@ export async function removeRelationValuesBulk(
  * Serialize an existing row's value column into the same string shape
  * `typedColumnMatch` returns — lets us dedup new inputs against existing
  * rows with a plain Set lookup.
+ *
+ * FILE identity special-case: FILE rows store `{ ref, caption?, internal? }`
+ * in `valueJson`. Whole-object string equality would treat a bare `{ ref }`
+ * upload-add as distinct from an already-captioned `{ ref, caption }` row for
+ * the same file, duplicating it. FILE dedup keys on `.ref` alone instead —
+ * every other `valueJson` field type (ADDRESS_STRUCT, NAME, JSON) keeps
+ * whole-object comparison.
  */
-function serializeRowMatch(row: FieldValueRow, column: TypedColumnMatch['column']): string | null {
+function serializeRowMatch(
+  row: FieldValueRow,
+  column: TypedColumnMatch['column'],
+  fieldType?: FieldType
+): string | null {
   const raw = (row as unknown as Record<string, unknown>)[column]
   if (raw === null || raw === undefined) return null
-  if (column === 'valueJson') return JSON.stringify(raw)
+  if (column === 'valueJson') {
+    if (fieldType === FieldTypeEnum.FILE) {
+      const ref = (raw as { ref?: unknown }).ref
+      if (typeof ref === 'string') return ref
+    }
+    return JSON.stringify(raw)
+  }
   if (column === 'valueBoolean') return String(raw)
   if (column === 'valueNumber') return String(raw)
   return String(raw)
 }
 
-/** Convert a TypedColumnMatch value to its string form for Set-based dedup. */
-function matchKey(m: TypedColumnMatch): string {
+/**
+ * Convert a TypedColumnMatch value to its string form for Set-based dedup.
+ * See `serializeRowMatch` for the FILE `.ref`-identity special-case.
+ */
+function matchKey(m: TypedColumnMatch, fieldType?: FieldType): string {
   if (m.column === 'valueBoolean') return String(m.value)
   if (m.column === 'valueNumber') return String(m.value)
+  if (m.column === 'valueJson' && fieldType === FieldTypeEnum.FILE) {
+    try {
+      const parsed = JSON.parse(m.value) as { ref?: unknown }
+      if (typeof parsed.ref === 'string') return parsed.ref
+    } catch {
+      // Fall through to whole-string compare below.
+    }
+  }
   return String(m.value)
 }
 
@@ -1337,7 +1366,7 @@ export async function addValues(
 
     const seen = new Set<string>()
     for (const row of existingRows) {
-      const k = serializeRowMatch(row, column)
+      const k = serializeRowMatch(row, column, fieldType)
       if (k !== null) seen.add(k)
     }
 
@@ -1345,7 +1374,7 @@ export async function addValues(
     const survivors: TypedFieldValueInput[] = []
     const surviving = new Set<string>()
     for (let i = 0; i < typedInputs.length; i++) {
-      const key = matchKey(matches[i]!)
+      const key = matchKey(matches[i]!, fieldType)
       if (seen.has(key) || surviving.has(key)) continue
       surviving.add(key)
       survivors.push(typedInputs[i]!)
@@ -1450,7 +1479,6 @@ export async function removeValues(
   if (matches.length === 0) return
 
   const column = matches[0]!.column
-  const matchValues = matches.map((m) => m.value)
 
   // Group by column to guard against mixed types (shouldn't happen — one
   // field = one type — but fail safely if it does).
@@ -1460,6 +1488,31 @@ export async function removeValues(
     )
   }
 
+  // FILE identity is `.ref` (see `serializeRowMatch`) — match on the extracted
+  // ref via `valueJson->>'ref'` instead of whole-envelope jsonb equality, so a
+  // remove call passing a bare `{ ref }` still finds a captioned/internal-flagged
+  // row for that same file.
+  const valueMatchClause =
+    fieldType === FieldTypeEnum.FILE && column === 'valueJson'
+      ? (() => {
+          const refs = matches
+            .map((m) => {
+              // `column === 'valueJson'` (checked above) guarantees `m.value`
+              // is the stringified JSON envelope for every match here.
+              try {
+                const parsed = JSON.parse(m.value as string) as { ref?: unknown }
+                return typeof parsed.ref === 'string' ? parsed.ref : null
+              } catch {
+                return null
+              }
+            })
+            .filter((ref): ref is string => ref !== null)
+          return refs.length > 0 ? inArray(sql`${schema.FieldValue.valueJson}->>'ref'`, refs) : null
+        })()
+      : buildMatchInClause(column, matches.map((m) => m.value) as any)
+
+  if (valueMatchClause === null) return
+
   await ctx.db
     .delete(schema.FieldValue)
     .where(
@@ -1467,7 +1520,7 @@ export async function removeValues(
         eq(schema.FieldValue.entityId, entityInstanceId),
         eq(schema.FieldValue.fieldId, fieldId),
         eq(schema.FieldValue.organizationId, ctx.organizationId),
-        buildMatchInClause(column, matchValues as any)
+        valueMatchClause
       )
     )
 
@@ -1590,7 +1643,7 @@ export async function addValuesBulk(
       oldRowsByEntity.set(entityId, existing)
       const seen = new Set<string>()
       for (const row of existing) {
-        const k = serializeRowMatch(row, column)
+        const k = serializeRowMatch(row, column, fieldType)
         if (k !== null) seen.add(k)
       }
 
@@ -1600,7 +1653,7 @@ export async function addValuesBulk(
       const localSeen = new Set<string>()
       const insertedTyped: TypedFieldValueInput[] = []
       for (let i = 0; i < typedInputs.length; i++) {
-        const key = matchKey(matches[i]!)
+        const key = matchKey(matches[i]!, fieldType)
         if (seen.has(key) || localSeen.has(key)) {
           skippedCount++
           continue

--- a/packages/lib/src/field-values/field-value-validator.ts
+++ b/packages/lib/src/field-values/field-value-validator.ts
@@ -152,9 +152,14 @@ export const fieldValueSchemas = {
       message: 'ADDRESS_STRUCT requires at least one address field',
     }),
 
-  // FILE JSON: { ref } — one file reference per FieldValue row ("asset:id" or "file:id")
+  // FILE JSON: { ref, caption?, internal? } — one file reference per FieldValue row
+  // ("asset:id" or "file:id"). `caption`/`internal` are additive (plans/dispatch/
+  // 37b-scouting-quote-photos.md §2) — kept here so a future caller doesn't strip
+  // them; `validateFileJson` has no callers today.
   fileJson: z.object({
     ref: z.string().regex(/^(asset|file):.+/),
+    caption: z.string().optional(),
+    internal: z.boolean().optional(),
   }),
 
   // Generic JSON fallback

--- a/packages/lib/src/field-values/index.ts
+++ b/packages/lib/src/field-values/index.ts
@@ -27,6 +27,7 @@ export {
   converters,
   currencyConverter,
   dateConverter,
+  type FileValue,
   fileConverter,
   jsonConverter,
   nameConverter,

--- a/packages/lib/src/money/convert-quote.ts
+++ b/packages/lib/src/money/convert-quote.ts
@@ -9,6 +9,7 @@ import { toRecordId } from '@auxx/types/resource'
 import { and, eq, isNull } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
+import type { FileValue } from '../field-values/converters'
 import { FieldValueService } from '../field-values/field-value-service'
 import { extractRelationshipRecordIds } from '../field-values/relationship-field'
 import { getRealtimeService, publishFieldValueUpdates } from '../realtime'
@@ -28,6 +29,22 @@ function firstTyped(
 ): TypedFieldValue | undefined {
   if (!entry) return undefined
   return Array.isArray(entry) ? entry[0] : entry
+}
+
+/**
+ * Unwrap a `getFieldValues()` map entry for a FILE field into its raw `{ ref, caption?,
+ * internal? }` envelopes — one per photo (FILE is `MULTI_VALUE_FIELD_TYPES`, plans/dispatch/
+ * 37b-scouting-quote-photos.md §3). Unlike {@link firstTyped}, this keeps every row: FILE
+ * always reads back as an array, but stays defensive (`Array.isArray`) in case a caller ever
+ * passes a bare single `TypedFieldValue`. Only `type: 'json'` rows are kept — the shape FILE
+ * values are stored as.
+ */
+function fileEnvelopes(entry: TypedFieldValue | TypedFieldValue[] | undefined): FileValue[] {
+  if (!entry) return []
+  const list = Array.isArray(entry) ? entry : [entry]
+  return list
+    .filter((v): v is Extract<TypedFieldValue, { type: 'json' }> => v.type === 'json')
+    .map((v) => v.value as unknown as FileValue)
 }
 
 /**
@@ -231,6 +248,7 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
       'line_item_optional',
       'line_item_optional_selected',
       'line_item_source_line',
+      'line_item_photos',
     ] as const)
 
   const { ids: lineInstanceIds } = await handler.listFiltered({
@@ -268,6 +286,7 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     lineCf.line_item_catalog_item,
     lineCf.line_item_optional,
     lineCf.line_item_optional_selected,
+    lineCf.line_item_photos,
   ]
     .filter(Boolean)
     .map((f) => f!.id)
@@ -290,6 +309,9 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     const catalogItemTyped = get(lineCf.line_item_catalog_item)
     const optionalTyped = get(lineCf.line_item_optional)
     const optionalSelectedTyped = get(lineCf.line_item_optional_selected)
+    const photos = lineCf.line_item_photos
+      ? fileEnvelopes(values.get(lineCf.line_item_photos.id))
+      : []
 
     // Deselected option (plan 18 §6, decision 5) — stays on the quote only, never becomes work.
     const optional = optionalTyped ? (extractValue(optionalTyped) as boolean) : false
@@ -312,6 +334,14 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
       line_item_discount: discountTyped ? extractValue(discountTyped) : undefined,
       line_item_sort_order: sortOrderTyped ? extractValue(sortOrderTyped) : undefined,
       line_item_work_order: workOrderRecordId,
+      // FILE is multi-row (MULTI_VALUE_FIELD_TYPES) — pass the raw envelope array through
+      // as-is. `setFieldValues`' default 'set' mode → `setValuesForEntity` →
+      // `validateAndConvertValue` detects the array + FILE's multi-value type and converts
+      // each element via `fileConverter.toTypedInput` individually, so `setValueWithType`
+      // DELETE+INSERTs one FieldValue row per photo (full `{ ref, caption?, internal? }`
+      // envelope preserved) — never a single row holding a jsonb array. Copies are by
+      // `.ref` (same MediaAsset), so no asset duplication (plan 37b §3).
+      line_item_photos: photos.length > 0 ? photos : undefined,
     }
     if (catalogItemTyped?.type === 'relationship') {
       copyValues.line_item_catalog_item = catalogItemTyped.recordId

--- a/packages/lib/src/money/gather.ts
+++ b/packages/lib/src/money/gather.ts
@@ -9,6 +9,7 @@ import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
+import type { FileValue } from '../field-values/converters'
 import { FieldValueService } from '../field-values/field-value-service'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { getOrganizationSetting } from '../settings/settings-service'
@@ -36,6 +37,19 @@ function firstTyped(
 ): TypedFieldValue | undefined {
   if (!entry) return undefined
   return Array.isArray(entry) ? entry[0] : entry
+}
+
+/**
+ * Unwrap a `getFieldValues()` map entry for a FILE field into its raw `{ ref, caption?,
+ * internal? }` envelopes — one per photo (FILE is `MULTI_VALUE_FIELD_TYPES`, plans/dispatch/
+ * 37b-scouting-quote-photos.md §3). Unlike {@link firstTyped}, this keeps every row.
+ */
+function fileEnvelopes(entry: TypedFieldValue | TypedFieldValue[] | undefined): FileValue[] {
+  if (!entry) return []
+  const list = Array.isArray(entry) ? entry : [entry]
+  return list
+    .filter((v): v is Extract<TypedFieldValue, { type: 'json' }> => v.type === 'json')
+    .map((v) => v.value as unknown as FileValue)
 }
 
 const LINE_ROW_ATTRS = [
@@ -68,6 +82,7 @@ export const LINE_COPY_ATTRS = [
   'line_item_catalog_item',
   'line_item_work_order',
   'line_item_invoice',
+  'line_item_photos',
 ] as const
 
 /**
@@ -358,6 +373,9 @@ export async function copyLineOntoInvoice(input: {
   const discountTyped = get(lineCf.line_item_discount)
   const sortOrderTyped = get(lineCf.line_item_sort_order)
   const catalogItemTyped = get(lineCf.line_item_catalog_item)
+  const photos = lineCf.line_item_photos
+    ? fileEnvelopes(values.get(lineCf.line_item_photos.id))
+    : []
 
   // No `line_item_work_order`, no `line_item_quote` on copies (§B.3 invariant). Units flow to
   // invoices (plan 13 §6); optionality does not — invoice/work-order lines never carry it.
@@ -373,6 +391,11 @@ export async function copyLineOntoInvoice(input: {
     line_item_discount: discountTyped ? extractValue(discountTyped) : undefined,
     line_item_sort_order: sortOrderTyped ? extractValue(sortOrderTyped) : undefined,
     line_item_invoice: invoiceRecordId,
+    // FILE is multi-row (MULTI_VALUE_FIELD_TYPES) — pass the raw envelope array through
+    // as-is; `setFieldValues`' default 'set' mode writes one FieldValue row per photo (full
+    // `{ ref, caption?, internal? }` envelope), never a single jsonb-array row. Copies are
+    // by `.ref` — same MediaAsset, no duplication (plan 37b §3).
+    line_item_photos: photos.length > 0 ? photos : undefined,
     ...extraValues,
   }
   if (catalogItemTyped?.type === 'relationship') {

--- a/packages/lib/src/money/public-token.ts
+++ b/packages/lib/src/money/public-token.ts
@@ -12,6 +12,7 @@ import type {
   DiscountType,
   DocumentBrandingSettings,
   DocumentBusinessSettings,
+  PdfPhotoRef,
   QuotePdfContact,
   QuotePdfLineItem,
 } from '../documents/payload'
@@ -170,6 +171,9 @@ export interface PublicInvoicePayload {
   terms: string | null
   contact: QuotePdfContact
   lines: PublicInvoiceLine[]
+  /** Header-level photos (plan 37b §6), `invoice_photos` — already internal-filtered by
+   * `buildInvoicePdfPayload`. Backs the "Photos" gallery section on the public pay page. */
+  photos: PdfPhotoRef[]
   /** Integer cents. */
   subtotal: number
   discountType: DiscountType | null
@@ -270,6 +274,7 @@ export async function getPublicInvoicePayload(token: string): Promise<PublicInvo
     terms: payload.terms,
     contact: payload.contact,
     lines: payload.lines,
+    photos: payload.photos ?? [],
     subtotal: payload.subtotal,
     discountType: payload.discountType,
     discountValue: payload.discountValue,

--- a/packages/lib/src/money/quote-public-token.ts
+++ b/packages/lib/src/money/quote-public-token.ts
@@ -12,6 +12,7 @@ import type {
   DiscountType,
   DocumentBrandingSettings,
   DocumentBusinessSettings,
+  PdfPhotoRef,
   QuotePdfContact,
   QuotePdfLineItem,
 } from '../documents/payload'
@@ -161,6 +162,9 @@ export interface PublicQuotePayload {
   terms: string | null
   contact: QuotePdfContact
   lines: PublicQuoteLine[]
+  /** Header-level site photos (plan 37b §6), `quote_photos` — already internal-filtered by
+   * `buildQuotePdfPayload`. Backs the "Photos" gallery section on the public quote page. */
+  photos: PdfPhotoRef[]
   /** Integer cents. */
   subtotal: number
   discountType: DiscountType | null
@@ -314,6 +318,7 @@ export async function getPublicQuotePayload(token: string): Promise<PublicQuoteP
     terms: payload.terms,
     contact: payload.contact,
     lines: payload.lines,
+    photos: payload.photos ?? [],
     subtotal: payload.subtotal,
     discountType: payload.discountType,
     discountValue: payload.discountValue,

--- a/packages/lib/src/resources/registry/resources/invoice-fields.ts
+++ b/packages/lib/src/resources/registry/resources/invoice-fields.ts
@@ -468,6 +468,31 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     description: 'Customer-facing terms (plain text, PDF-friendly)',
   },
 
+  photos: {
+    id: toFieldId('photos'),
+    key: 'photos',
+    label: 'Photos',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'invoice_photos',
+    systemSortOrder: 'aH1',
+    nullable: true,
+    options: {
+      file: { allowMultiple: true, allowedFileTypes: ['image'], maxFiles: 10 },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Photos attached directly to this invoice (plan 37b scouting build spec) — no ' +
+      'auto-copy from quote_photos',
+  },
+
   pdfAsset: {
     id: toFieldId('pdfAsset'),
     key: 'pdfAsset',

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -469,6 +469,31 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     description: 'Parent invoice relation for invoice-owned snapshot lines only',
   },
 
+  photos: {
+    id: toFieldId('photos'),
+    key: 'photos',
+    label: 'Photos',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'line_item_photos',
+    systemSortOrder: 'b1a',
+    nullable: true,
+    options: {
+      file: { allowMultiple: true, allowedFileTypes: ['image'], maxFiles: 10 },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Line-level scouting photos (plan 37b build spec) — surfaced via the line-builder ' +
+      'photo chip, not a generic dialog',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/resources/registry/resources/quote-fields.ts
+++ b/packages/lib/src/resources/registry/resources/quote-fields.ts
@@ -481,6 +481,29 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     description: 'Customer-facing terms (plain text, PDF-friendly)',
   },
 
+  photos: {
+    id: toFieldId('photos'),
+    key: 'photos',
+    label: 'Photos',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'quote_photos',
+    systemSortOrder: 'aH1',
+    nullable: true,
+    options: {
+      file: { allowMultiple: true, allowedFileTypes: ['image'], maxFiles: 10 },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Site photos captured for this quote (plan 37b scouting build spec)',
+  },
+
   pdfAsset: {
     id: toFieldId('pdfAsset'),
     key: 'pdfAsset',

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -290,6 +290,7 @@ export const SYSTEM_ATTRIBUTES = [
   'quote_decline_reason',
   'quote_deposit_type',
   'quote_deposit_value',
+  'quote_photos', // scouting/quote photos gallery (plan 37b §1)
 
   // ─── Line Item fields ──────────────────────────────────────────
   'line_item_name',
@@ -310,6 +311,7 @@ export const SYSTEM_ATTRIBUTES = [
   'line_item_quote',
   'line_item_work_order',
   'line_item_invoice',
+  'line_item_photos', // scouting/line-level photos (plan 37b §1)
 
   // ─── Catalog Item fields ────────────────────────────────────────
   'catalog_item_name',
@@ -359,6 +361,7 @@ export const SYSTEM_ATTRIBUTES = [
   'invoice_progress_percent',
   'invoice_installment_name',
   'invoice_public_token',
+  'invoice_photos', // scouting/invoice photos gallery, parity with quote_photos (plan 37b §1)
   'invoice_line_items', // inverse of line_item_invoice
   'invoice_payments', // inverse of payment_invoice
 


### PR DESCRIPTION
Implements `plans/dispatch/37b-scouting-quote-photos.md` (37 §C — Calvin's flow: visit a home, take photos, attach them to the quote the customer receives). All 4 phases.

## What's in here

**Fields (registry only, no migration)**
- Three system `FieldType.FILE` fields: `quote_photos`, `line_item_photos`, `invoice_photos` — images-only (`allowedFileTypes: ['image']`), multi-file, max 10. Plus the matching `SYSTEM_ATTRIBUTES` entries in `@auxx/types`.

**Caption + internal envelope**
- FILE `valueJson` envelope extended additively: `{ ref, caption?, internal? }` (`FileValue`, client-safe export).
- FILE identity is now `.ref` in the multi-value primitives: `addValues`/`addValuesBulk` dedup and `removeValues` matching key on `valueJson->>'ref'` instead of whole-object equality — re-adding an already-captioned file no longer duplicates, remove-by-value finds captioned rows. All other valueJson types (ADDRESS_STRUCT, NAME, JSON) unchanged. 4 new unit tests (fault-injection-verified).
- Photo tile editor (Sheet): caption input + "Internal — hidden from customer" switch + remove. Saves by composing the full envelope array from freshest store state via `fieldValue.set` (never remove+add).

**Capture**
- Images-only FILE fields get a "Take photo" action (`capture='environment'`). HEIC handled by constraining the accept list to `image/jpeg,png,webp,...` (makes iOS Safari transcode at selection) plus a dependency-free canvas re-encode backstop (`convert-heic.ts`).

**Lines + propagation**
- Per-line photo chip in the line builder (popover wrapping the generic `FileInputField` via `PropertyProvider`); count rides the existing batched prefetch.
- `line_item_photos` added to the quote→WO funnel (`convert-quote.ts`) and `LINE_COPY_ATTRS`/`copyLineOntoInvoice` (`gather.ts`) — covers all four WO→invoice builders. Copies are by ref (no asset duplication), one FieldValue row per photo, caption/internal preserved.

**PDF rendering**
- `QuotePdfLineItem.photos` + top-level payload `photos`; **internal photos are stripped server-side in one choke point** (`extractPhotos()` in `payload.ts`) so they never reach PDFs, email, or public pages.
- `resolvePhotoRef` resolves `asset:`/`file:` refs to bytes, sharp-downscaled to ≤1200px JPEG q80; broken refs skip silently. Shared `PhotoGrid`/thumbnail parts render line thumbnails under descriptions and a 2-up "Photos" section after the line table on both quote + invoice PDFs. `stableHash` picks up photo changes for free (pointer-based regeneration).

**Public viewers**
- Token-scoped routes `/quote/[token]/photo/[ref]` and `/pay/[token]/photo/[ref]`: token validated like the sibling pdf routes, then the ref is served **only if present in that document's (already internal-filtered) payload** — no IDOR by guessing asset ids. Streams downscaled JPEG with cache headers.
- Public quote + pay pages: captioned thumbnails under lines, "Photos" gallery, lightbox with prev/next.

## Verification
- 28/28 field-values tests pass (4 new).
- Scoped typechecks: zero new errors in touched files (lib + web), verified against baseline.
- Cross-agent integration review traced all seams end-to-end (registry→UI options path, tRPC set-path envelope survival, copy-funnel preservation, payload internal-stripping, PDF byte-map lookups, non-FILE dedup regression, client/server import hygiene) — no findings.

## Out of scope (per plan)
Scouting entity, auto-copying quote-level photos to invoices, photos in email bodies, request-level photos, print-wizard "include photos" toggle.