### PR TITLE
feat(dispatch): calendar multi-select, bulk actions and visit copy/paste

### DIFF
--- a/apps/web/src/components/calendar/core/clipboard-offset.test.ts
+++ b/apps/web/src/components/calendar/core/clipboard-offset.test.ts
@@ -1,0 +1,121 @@
+// apps/web/src/components/calendar/core/clipboard-offset.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { computePasteTimes } from './clipboard-offset'
+import type { CopiedVisitItem } from './clipboard-store'
+
+function item(overrides: Partial<CopiedVisitItem> & { start: Date; end: Date }): CopiedVisitItem {
+  return {
+    kind: 'visit',
+    visitId: overrides.visitId ?? 'visit-1',
+    workOrderRecordId: overrides.workOrderRecordId ?? 'work-order:wo-1',
+    title: overrides.title ?? 'Job',
+    assigneeUserId: overrides.assigneeUserId ?? null,
+    ...overrides,
+  }
+}
+
+describe('computePasteTimes', () => {
+  it('preserves multi-day relative structure (Mon+Wed pasted on Thu -> Thu+Sat)', () => {
+    // 2024-01-01 is a Monday; 2024-01-03 a Wednesday; 2024-01-04 a Thursday.
+    const monday = item({
+      visitId: 'mon',
+      start: new Date(2024, 0, 1, 9, 0),
+      end: new Date(2024, 0, 1, 10, 0),
+    })
+    const wednesday = item({
+      visitId: 'wed',
+      start: new Date(2024, 0, 3, 13, 30),
+      end: new Date(2024, 0, 3, 14, 30),
+    })
+
+    const results = computePasteTimes(
+      [monday, wednesday],
+      { day: new Date(2024, 0, 4) }, // Thursday
+      { startAtSlot: false }
+    )
+
+    const byId = new Map(results.map((r) => [r.item.visitId, r]))
+    const monResult = byId.get('mon')!
+    const wedResult = byId.get('wed')!
+
+    // Mon -> Thu (Jan 4), Wed -> Sat (Jan 6) — the +3 day delta from the earliest item.
+    expect(monResult.startTime).toEqual(new Date(2024, 0, 4, 9, 0))
+    expect(monResult.endTime).toEqual(new Date(2024, 0, 4, 10, 0))
+    expect(wedResult.startTime).toEqual(new Date(2024, 0, 6, 13, 30))
+    expect(wedResult.endTime).toEqual(new Date(2024, 0, 6, 14, 30))
+  })
+
+  it('preserves each item duration', () => {
+    const shortVisit = item({
+      visitId: 'short',
+      start: new Date(2024, 0, 1, 9, 0),
+      end: new Date(2024, 0, 1, 9, 45),
+    })
+    const longVisit = item({
+      visitId: 'long',
+      start: new Date(2024, 0, 1, 12, 0),
+      end: new Date(2024, 0, 1, 14, 0),
+    })
+
+    const results = computePasteTimes(
+      [shortVisit, longVisit],
+      { day: new Date(2024, 0, 10) },
+      { startAtSlot: false }
+    )
+
+    for (const result of results) {
+      const original = result.item.visitId === 'short' ? shortVisit : longVisit
+      const originalDuration = original.end.getTime() - original.start.getTime()
+      const pastedDuration = result.endTime.getTime() - result.startTime.getTime()
+      expect(pastedDuration).toBe(originalDuration)
+    }
+  })
+
+  it('shifts every item so the earliest starts at the clicked slot time, keeping relative offsets', () => {
+    const first = item({
+      visitId: 'first',
+      start: new Date(2024, 0, 1, 9, 0),
+      end: new Date(2024, 0, 1, 10, 0),
+    })
+    const second = item({
+      visitId: 'second',
+      start: new Date(2024, 0, 1, 11, 0), // 2h after `first`'s start
+      end: new Date(2024, 0, 1, 11, 30),
+    })
+
+    const results = computePasteTimes(
+      [first, second],
+      { day: new Date(2024, 0, 5), time: new Date(2024, 0, 5, 14, 0) },
+      { startAtSlot: true }
+    )
+
+    const byId = new Map(results.map((r) => [r.item.visitId, r]))
+    const firstResult = byId.get('first')!
+    const secondResult = byId.get('second')!
+
+    // Earliest item lands exactly on the slot time.
+    expect(firstResult.startTime).toEqual(new Date(2024, 0, 5, 14, 0))
+    // The second item keeps its original 2h offset from the first.
+    expect(secondResult.startTime).toEqual(new Date(2024, 0, 5, 16, 0))
+    // Durations stay intact under the extra shift too.
+    expect(firstResult.endTime.getTime() - firstResult.startTime.getTime()).toBe(60 * 60_000)
+    expect(secondResult.endTime.getTime() - secondResult.startTime.getTime()).toBe(30 * 60_000)
+  })
+
+  it('ignores startAtSlot when the target carries no time (month-view / day-only paste)', () => {
+    const visit = item({
+      visitId: 'v',
+      start: new Date(2024, 0, 1, 9, 0),
+      end: new Date(2024, 0, 1, 10, 0),
+    })
+
+    const results = computePasteTimes([visit], { day: new Date(2024, 0, 8) }, { startAtSlot: true })
+
+    expect(results[0]!.startTime).toEqual(new Date(2024, 0, 8, 9, 0))
+  })
+
+  it('returns an empty array for an empty clipboard', () => {
+    expect(computePasteTimes([], { day: new Date() }, { startAtSlot: false })).toEqual([])
+  })
+})

--- a/apps/web/src/components/calendar/core/clipboard-offset.ts
+++ b/apps/web/src/components/calendar/core/clipboard-offset.ts
@@ -1,0 +1,98 @@
+// apps/web/src/components/calendar/core/clipboard-offset.ts
+//
+// Pure paste-anchor offset math (plan `37c-calendar-create-copy-paste.md` §4.2). No React, no
+// store reads — `computePasteTimes` is unit-tested directly (`clipboard-offset.test.ts`).
+
+import {
+  addDays,
+  addMinutes,
+  differenceInCalendarDays,
+  differenceInMinutes,
+  set,
+  startOfDay,
+} from 'date-fns'
+import type { CopiedVisitItem } from './clipboard-store'
+
+/** Where a paste lands. `time` is only present for a timed-slot target (right-clicked/hovered
+ * a week/day/timeline cell); a month-view or day-only target omits it. */
+export interface PasteTarget {
+  day: Date
+  time?: Date
+}
+
+export interface PasteTimesOptions {
+  /** §4.3 "start at clicked slot" toggle — only meaningful (and only ever passed `true`) when
+   * `target.time` is set; timed slots only. */
+  startAtSlot: boolean
+}
+
+/** One item's computed paste time, paired back with the source item it came from (callers zip
+ * this against `item.visitId`/`item.workOrderRecordId` for the mutation payload). */
+export interface PasteTimeResult {
+  item: CopiedVisitItem
+  startTime: Date
+  endTime: Date
+}
+
+/** Fractional-hours (`HoveredSlot.time`'s convention — e.g. `9.25` for 9:15) → a `Date` on the
+ * given day, hour/minute-precision. Pure conversion helper shared by anything that needs to
+ * turn a hovered/right-clicked slot into a `PasteTarget.time`. */
+export function hoursToDate(day: Date, hours: number): Date {
+  const wholeHours = Math.floor(hours)
+  const minutes = Math.round((hours - wholeHours) * 60)
+  return set(day, { hours: wholeHours, minutes, seconds: 0, milliseconds: 0 })
+}
+
+/**
+ * §4.2's offset math: anchor day = start-of-day of the EARLIEST copied item (by `start`); every
+ * item shifts by the same `dayDelta` (target day − anchor day, in calendar days) via
+ * `date-fns#addDays` — NOT millisecond arithmetic, so a paste across a DST boundary keeps each
+ * item's wall-clock time-of-day instead of drifting by an hour. Relative day structure and
+ * durations both fall out of applying one delta to every item's `start`/`end`: a copied Mon+Wed
+ * pair pasted on a Thursday becomes Thu+Sat.
+ *
+ * When `opts.startAtSlot` and `target.time` are both set, an additional shift is layered on top
+ * (also via `date-fns#addMinutes`, so it composes with the day shift instead of re-deriving from
+ * scratch): the EARLIEST item's start moves onto the slot's hour/minute, and every item — the
+ * earliest included — carries the same extra delta, so relative offsets between items survive.
+ *
+ * Order of the returned array mirrors `items` (not chronological) — callers zip it back against
+ * the original list for a preview table or a mutation payload.
+ */
+export function computePasteTimes(
+  items: CopiedVisitItem[],
+  target: PasteTarget,
+  opts: PasteTimesOptions
+): PasteTimeResult[] {
+  if (items.length === 0) return []
+
+  let anchorItem = items[0]!
+  for (const item of items) {
+    if (item.start.getTime() < anchorItem.start.getTime()) anchorItem = item
+  }
+  const anchorDay = startOfDay(anchorItem.start)
+  const targetDay = startOfDay(target.day)
+  const dayDelta = differenceInCalendarDays(targetDay, anchorDay)
+
+  let extraMinutes = 0
+  if (opts.startAtSlot && target.time) {
+    const shiftedAnchorStart = addDays(anchorItem.start, dayDelta)
+    const desiredAnchorStart = set(shiftedAnchorStart, {
+      hours: target.time.getHours(),
+      minutes: target.time.getMinutes(),
+      seconds: target.time.getSeconds(),
+      milliseconds: 0,
+    })
+    extraMinutes = differenceInMinutes(desiredAnchorStart, shiftedAnchorStart)
+  }
+
+  return items.map((item) => {
+    const dayShiftedStart = addDays(item.start, dayDelta)
+    const dayShiftedEnd = addDays(item.end, dayDelta)
+    return {
+      item,
+      startTime: extraMinutes !== 0 ? addMinutes(dayShiftedStart, extraMinutes) : dayShiftedStart,
+      endTime: extraMinutes !== 0 ? addMinutes(dayShiftedEnd, extraMinutes) : dayShiftedEnd,
+    }
+  })
+}

--- a/apps/web/src/components/calendar/core/clipboard-store.ts
+++ b/apps/web/src/components/calendar/core/clipboard-store.ts
@@ -1,0 +1,55 @@
+// apps/web/src/components/calendar/core/clipboard-store.ts
+
+import { create } from 'zustand'
+
+/** One copied visit (plan `37c-calendar-create-copy-paste.md` §4.1) — a kind-discriminated
+ * union when more clipboard kinds land (schedule's meetings/tasks stay non-pastable v1, so
+ * `'visit'` is the only member today). */
+export interface CopiedVisitItem {
+  kind: 'visit'
+  visitId: string
+  /** Full `RecordId` (def + instance) of the work order this visit belongs to — what
+   * `dispatch.pasteVisits` wants on the wire. Resolve from a `DispatchVisitEvent.workOrderId`
+   * (an `EntityInstance` id, `board/types.ts`) via `toRecordId(workOrderDefId, workOrderId)`
+   * at copy time, not paste time — the clipboard is source-agnostic once filled. */
+  workOrderRecordId: string
+  title: string
+  start: Date
+  end: Date
+  assigneeUserId: string | null
+}
+
+interface CalendarClipboard {
+  /** `null` = empty clipboard (nothing copied yet this session). */
+  items: CopiedVisitItem[] | null
+  copy: (items: CopiedVisitItem[]) => void
+  clear: () => void
+}
+
+/**
+ * One global, unpersisted clipboard (plan 37c §4.1) — a plain module-level zustand store (not
+ * `localStorage`-backed, cleared on page reload) so copy-on-one-surface → paste-on-another
+ * works for free (board today; the schedule surface lands in Phase 6). Consumers must read via
+ * the selector hooks below, never destructure the whole store (repo Zustand convention).
+ */
+const useCalendarClipboardStore = create<CalendarClipboard>((set) => ({
+  items: null,
+  copy: (items) => set({ items }),
+  clear: () => set({ items: null }),
+}))
+
+/** The current clipboard contents, or `null` if nothing's copied. */
+export function useClipboardItems(): CopiedVisitItem[] | null {
+  return useCalendarClipboardStore((s) => s.items)
+}
+
+/** Replace the clipboard wholesale — a fresh copy always overwrites, never appends. */
+export function useClipboardCopy(): (items: CopiedVisitItem[]) => void {
+  return useCalendarClipboardStore((s) => s.copy)
+}
+
+/** Not called by the paste flow itself (repeat pastes are allowed, plan 37c §4.3) — available
+ * for a future explicit "clear clipboard" affordance. */
+export function useClipboardClear(): () => void {
+  return useCalendarClipboardStore((s) => s.clear)
+}

--- a/apps/web/src/components/dispatch/ui/board/board-assign-picker.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-assign-picker.tsx
@@ -1,0 +1,95 @@
+// apps/web/src/components/dispatch/ui/board/board-assign-picker.tsx
+
+'use client'
+
+import { getActorRawId } from '@auxx/types/actor'
+import type { PickerComponentProps } from '@auxx/ui/components/action-bar'
+import { Command, CommandGroup, CommandItem, CommandList } from '@auxx/ui/components/command'
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContentDialogAware,
+  PopoverTrigger,
+} from '@auxx/ui/components/popover'
+import { UserX } from 'lucide-react'
+import { type RefObject, useState } from 'react'
+import { ActorPickerContent } from '~/components/pickers/actor-picker/actor-picker-content'
+import { useWorkerActorExcludes } from '../shared/use-worker-actor-excludes'
+
+interface BoardAssignPickerProps extends PickerComponentProps {
+  /** `null` = the "Unassigned" row. */
+  onSelect: (userId: string | null) => void
+}
+
+/**
+ * The bulk bar's "Assign to…" action popover (plan 37c §5.1). Reuses the same worker-filtered
+ * `ActorPickerContent` the single-visit assignee row uses (`AssigneeRow` in
+ * `../shared/assignee-row.tsx`, via `useWorkerActorExcludes`) — just single-select, with an
+ * "Unassigned" row prepended (not part of `ActorPickerContent`'s vocabulary) and no
+ * series-scope gate: bulk assignee changes are always "this visit" (documented, §5.2).
+ */
+export function BoardAssignPicker({
+  children,
+  anchorRef,
+  open,
+  onOpenChange,
+  disabled,
+  onSelect,
+}: BoardAssignPickerProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+  const isOpen = open ?? internalOpen
+  const excludeIds = useWorkerActorExcludes()
+
+  const setOpen = (next: boolean) => {
+    if (open === undefined) setInternalOpen(next)
+    onOpenChange?.(next)
+  }
+
+  return (
+    <Popover open={isOpen} onOpenChange={setOpen}>
+      {anchorRef ? (
+        // Radix's `virtualRef` wants `RefObject<Measurable>` (non-nullable); `anchorRef` comes
+        // in via `PickerComponentProps` as `RefObject<HTMLElement | null>` — same mismatch
+        // pre-existing in every other `ActionBar` picker (`actor-picker.tsx`, `tag-picker.tsx`).
+        <PopoverAnchor virtualRef={anchorRef as RefObject<HTMLElement>} />
+      ) : (
+        <PopoverTrigger asChild>{children}</PopoverTrigger>
+      )}
+      <PopoverContentDialogAware className='w-72 p-0' align='end'>
+        <Command shouldFilter={false} className='rounded-lg rounded-b-none'>
+          <CommandList>
+            <CommandGroup>
+              <CommandItem
+                onSelect={() => {
+                  onSelect(null)
+                  setOpen(false)
+                }}
+                className='flex items-center gap-2'>
+                <UserX className='size-4 text-muted-foreground' />
+                Unassigned
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+        {/* Plain divider, not `CommandSeparator` — that primitive requires living inside the
+         * SAME `Command` root (cmdk context), and this popover deliberately stacks two
+         * independent `Command` trees (the static "Unassigned" row, then the searchable
+         * `ActorPickerContent` worker list below it). */}
+        <div className='h-px bg-border/50 dark:bg-[#323842]/80' />
+        <ActorPickerContent
+          value={[]}
+          onChange={() => {}}
+          target='user'
+          multi={false}
+          disabled={disabled}
+          excludeIds={excludeIds}
+          onSelectSingle={(actorId) => {
+            onSelect(getActorRawId(actorId))
+            setOpen(false)
+          }}
+          placeholder='Search workers...'
+        />
+      </PopoverContentDialogAware>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/board/board-bulk-bar.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-bulk-bar.tsx
@@ -1,0 +1,173 @@
+// apps/web/src/components/dispatch/ui/board/board-bulk-bar.tsx
+
+'use client'
+
+import {
+  ActionBar,
+  type ActionBarAction,
+  type PickerComponentProps,
+} from '@auxx/ui/components/action-bar'
+import { useHotkey } from '@tanstack/react-hotkeys'
+import { Ban, Copy, Inbox, Send, UserCog } from 'lucide-react'
+import type { ComponentType } from 'react'
+import { useCallback } from 'react'
+import { BoardAssignPicker } from './board-assign-picker'
+import type { useBoardBulkRunner } from './hooks/use-board-bulk-runner'
+import type { useBoardMutations } from './hooks/use-board-mutations'
+
+interface BoardBulkBarProps {
+  selectedVisitIds: string[]
+  mutations: ReturnType<typeof useBoardMutations>
+  bulkRunner: ReturnType<typeof useBoardBulkRunner>
+  onClearSelection: () => void
+  /** Plan 37c §5.1's Copy action — `use-board-clipboard.ts`'s `copySelection` (also what
+   * Cmd+C runs; the hook owns that keybinding, this button is just a visible affordance for
+   * the same action, not a second registration). */
+  onCopySelection: () => void
+}
+
+const noun = (n: number) => `${n} visit${n === 1 ? '' : 's'}`
+
+/**
+ * The board's floating bulk-action bar (plan 37c §5.1) — mounted unconditionally by
+ * `dispatch-board.tsx` (only while `canEdit`, member boards never render it) so the
+ * Delete/Backspace hotkey below stays live at a single-visit selection too, even though the
+ * visible `ActionBar` itself only opens at 2+ (a plain single click keeps today's
+ * chip+popover behavior, no bar noise). Every action is a sequential loop
+ * (`useBoardBulkRunner`) over the SAME single-visit mutations `use-board-mutations.ts`
+ * already exposes — no new endpoints, no series-scope chooser (bulk = "this visit" edits).
+ */
+export function BoardBulkBar({
+  selectedVisitIds,
+  mutations,
+  bulkRunner,
+  onClearSelection,
+  onCopySelection,
+}: BoardBulkBarProps) {
+  const { run, isRunning, ConfirmDialog } = bulkRunner
+  const count = selectedVisitIds.length
+  const hasSelection = count > 0
+  const open = count >= 2
+
+  const handleAssign = useCallback(
+    (assigneeUserId: string | null) => {
+      void run(
+        selectedVisitIds,
+        (visitId) => mutations.assignVisit.mutateAsync({ visitId, assigneeUserId }),
+        {
+          failureTitle: 'Some visits could not be assigned',
+          failureNoun: 'visits',
+        }
+      )
+    },
+    [run, selectedVisitIds, mutations.assignVisit]
+  )
+
+  const handleDispatch = useCallback(() => {
+    void run(selectedVisitIds, (visitId) => mutations.dispatchVisit.mutateAsync({ visitId }), {
+      failureTitle: 'Some visits could not be dispatched',
+      failureNoun: 'visits',
+    })
+  }, [run, selectedVisitIds, mutations.dispatchVisit])
+
+  const handleMoveToBacklog = useCallback(() => {
+    void run(selectedVisitIds, (visitId) => mutations.unscheduleVisit.mutateAsync({ visitId }), {
+      failureTitle: 'Some visits could not be moved to the backlog',
+      failureNoun: 'visits',
+      onDone: onClearSelection,
+    })
+  }, [run, selectedVisitIds, mutations.unscheduleVisit, onClearSelection])
+
+  const handleCancel = useCallback(() => {
+    void run(
+      selectedVisitIds,
+      (visitId) => mutations.setVisitStatus.mutateAsync({ visitId, status: 'canceled' }),
+      {
+        confirm: {
+          title: `Cancel ${noun(selectedVisitIds.length)}?`,
+          description: 'This cannot be undone.',
+          confirmText: 'Cancel visits',
+          destructive: true,
+        },
+        failureTitle: 'Some visits could not be canceled',
+        failureNoun: 'visits',
+        onDone: onClearSelection,
+      }
+    )
+  }, [run, selectedVisitIds, mutations.setVisitStatus, onClearSelection])
+
+  // Delete/Backspace → the same bulk-cancel confirm flow, for ANY non-empty selection (not
+  // just when the bar itself is visible at 2+) — mirrors a single chip's popover Cancel
+  // button, just keyboard-driven. `ignoreInputs` defaults `true` for single keys
+  // (`@tanstack/hotkeys`), so focus in a text input/textarea/contenteditable already
+  // suppresses this — the same guard `event-calendar.tsx`'s own Escape handler hand-rolls.
+  useHotkey('Delete', handleCancel, { enabled: hasSelection && !isRunning })
+  useHotkey('Backspace', handleCancel, { enabled: hasSelection && !isRunning })
+
+  const actions: ActionBarAction[] = [
+    {
+      id: 'copy',
+      label: 'Copy',
+      icon: Copy,
+      onClick: onCopySelection,
+      disabled: isRunning,
+      shortcut: '⌘C',
+      tooltip: 'Copy selected visits',
+    },
+    {
+      id: 'assign',
+      label: 'Assign to…',
+      icon: UserCog,
+      disabled: isRunning,
+      tooltip: 'Assign selected visits to a worker',
+      picker: {
+        // `ActionBarAction['picker']['component']` is typed as `ComponentType<PickerComponentProps>`
+        // only — every consumer with a custom required prop needs this same cast (the mail
+        // toolbar's `ActorPicker`/`TagPicker`/`RecordPicker` usage has the identical pre-existing
+        // mismatch at `bulk-action-toolbar.tsx:323`, just uncast there).
+        component: BoardAssignPicker as ComponentType<PickerComponentProps>,
+        props: { onSelect: handleAssign },
+      },
+    },
+    {
+      id: 'dispatch',
+      label: 'Dispatch',
+      icon: Send,
+      onClick: handleDispatch,
+      disabled: isRunning,
+      tooltip: 'Notify assignees for selected visits',
+    },
+    {
+      id: 'backlog',
+      label: 'Move to backlog',
+      icon: Inbox,
+      onClick: handleMoveToBacklog,
+      disabled: isRunning,
+      tooltip: 'Unschedule selected visits back to the backlog',
+    },
+    {
+      id: 'cancel',
+      label: 'Cancel',
+      icon: Ban,
+      onClick: handleCancel,
+      disabled: isRunning,
+      variant: 'destructive',
+      shortcut: 'Del',
+      tooltip: 'Cancel selected visits',
+    },
+  ]
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ActionBar
+        open={open}
+        onOpenChange={(next) => !next && onClearSelection()}
+        selectedCount={count}
+        selectedLabel='selected'
+        actions={actions}
+        showClose
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -4,16 +4,26 @@
 
 import type { RecordId } from '@auxx/lib/resources/client'
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuShortcut,
+  ContextMenuTrigger,
+} from '@auxx/ui/components/context-menu'
+import {
   type BackgroundEvent,
   type CalendarResource,
   EventCalendar,
   EventPopover,
+  type HoveredSlot,
   type RenderEventContext,
 } from '@auxx/ui/components/event-calendar'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { ClipboardPaste, Copy } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
 import { useTimelineViewStore } from '../../stores/timeline-view-store'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
+import type { PasteAnchor } from './hooks/use-board-clipboard'
 import type { useBoardMutations } from './hooks/use-board-mutations'
 import { useTimelineHourWindow } from './hooks/use-timeline-hour-window'
 import type { BoardResourceInput, BoardViewMode, DispatchVisitEvent } from './types'
@@ -21,6 +31,13 @@ import { isPastVisitEvent } from './utils'
 import { VisitChipContent, VisitChipMonthContent } from './visit-chip-content'
 import { VisitPopoverContent } from './visit-popover'
 import { WorkerColumnHeader } from './worker-column-header'
+
+/** The board's right-click menu target (plan 37c §5.3) — resolved once per `contextmenu`
+ * event from `e.target.closest('[data-event-id]')` (chips self-tag that attribute in
+ * `draggable-event.tsx`/`agenda-view.tsx`); anything else is treated as empty-space. */
+type BoardMenuTarget =
+  | { type: 'chip'; visitId: string }
+  | { type: 'slot'; slot: HoveredSlot | null }
 
 interface BoardCalendarGridProps {
   date: Date
@@ -36,6 +53,15 @@ interface BoardCalendarGridProps {
   existingVisits: ExistingVisitForOverlap[]
   activeVisitId: string | null
   onActiveVisitChange: (visitId: string | null) => void
+  /** Multi-selection (plan 37c §3) — the grid's ring rendering + gestures; independent of
+   * `activeVisitId`, which stays the "which popover is open" concern. */
+  selectedEventIds: string[]
+  onSelectionChange: (ids: string[]) => void
+  /** Plan 37c §5.2 — visit ids the bulk bar's runner currently has in flight; dims their
+   * chips so a running bulk action reads as busy (the optimistic cache patches from
+   * `use-board-mutations.ts` already give the instant settle, this is just the "still
+   * working" affordance while the loop is mid-flight). */
+  pendingVisitIds?: Set<string>
   onRangeChange: (from: Date, to: Date) => void
   onEventResize: (event: DispatchVisitEvent, newStart: Date, newEnd: Date) => void
   onOpenRecord: (recordId: RecordId, drill?: { panel?: string; item?: string }) => void
@@ -44,6 +70,18 @@ interface BoardCalendarGridProps {
    * click routes to the panel instead of opening the floating `EventPopover`, so this suppresses
    * that popover entirely and renders a plain click target for the chip. */
   isDockOpen?: boolean
+  /** Plan 37c §4/§5 — threaded straight into `EventCalendar`; `use-board-clipboard.ts` owns the
+   * ref and reads it for the Cmd+V paste anchor. Also what the right-click menu's "Paste here"
+   * snapshots at click time. */
+  hoveredSlotRef?: React.MutableRefObject<HoveredSlot | null>
+  /** Whether the clipboard has anything copied — disables "Paste here" in the context menu. */
+  hasClipboard?: boolean
+  /** Copies the given visit ids (`use-board-clipboard.ts`'s `copyIds`) — the grid decides WHICH
+   * ids (selection-aware for the context menu's Copy item), the hook just writes the clipboard. */
+  onCopyIds?: (ids: string[]) => void
+  /** Opens the paste-options dialog anchored at the given target (`null` = fall back to the
+   * board's current date, no time) — the context menu's "Paste here". */
+  onPasteAt?: (target: PasteAnchor | null) => void
 }
 
 /**
@@ -67,11 +105,18 @@ export function BoardCalendarGrid({
   existingVisits,
   activeVisitId,
   onActiveVisitChange,
+  selectedEventIds,
+  onSelectionChange,
+  pendingVisitIds,
   onRangeChange,
   onEventResize,
   onOpenRecord,
   isNonWorkingDay,
   isDockOpen,
+  hoveredSlotRef,
+  hasClipboard,
+  onCopyIds,
+  onPasteAt,
 }: BoardCalendarGridProps) {
   const setEventDockOpen = useDispatchSidebarStore((s) => s.setEventDockOpen)
   // Docking transfers the currently controlled popover into the panel. Radix may report the
@@ -84,18 +129,32 @@ export function BoardCalendarGrid({
 
   const renderEvent = useCallback(
     (event: DispatchVisitEvent, ctx: RenderEventContext) => {
-      const chip =
+      const chipContent =
         ctx.view === 'month' ? (
           <VisitChipMonthContent event={event} />
         ) : (
           <VisitChipContent event={event} isOverlapping={overlappingIds.has(event.id)} />
         )
+      // Bulk-runner pending-dim (plan 37c §5.2) — no interaction while a bulk action is
+      // mid-flight for this visit; the optimistic cache patch handles the instant settle.
+      const chip = pendingVisitIds?.has(event.id) ? (
+        <div className='opacity-50 pointer-events-none'>{chipContent}</div>
+      ) : (
+        chipContent
+      )
 
       // Sticky mode (plan 21 decision #3): docked, so route the click straight into the
-      // panel — no floating popover, and no per-event popover state to manage here.
+      // panel — no floating popover, and no per-event popover state to manage here. Guarded
+      // against modifier-clicks (plan 37c §3.2) — cmd/ctrl/shift-click manages the selection
+      // only, via the grid's own gesture handling; it must not also flip the docked panel.
       if (isDockOpen) {
         return (
-          <div className='h-full w-full' onClick={() => onActiveVisitChange(event.id)}>
+          <div
+            className='h-full w-full'
+            onClick={(e) => {
+              if (e.metaKey || e.ctrlKey || e.shiftKey) return
+              onActiveVisitChange(event.id)
+            }}>
             {chip}
           </div>
         )
@@ -141,6 +200,7 @@ export function BoardCalendarGrid({
       activeVisitId,
       onActiveVisitChange,
       overlappingIds,
+      pendingVisitIds,
       canEdit,
       mutations,
       existingVisits,
@@ -150,8 +210,10 @@ export function BoardCalendarGrid({
     ]
   )
 
+  // Grid never calls this on a modifier-click (plan 37c §3.2) — behavior is unchanged from
+  // before multi-selection, just carrying the mouse event through the new signature.
   const handleEventClick = useCallback(
-    (event: DispatchVisitEvent) => onActiveVisitChange(event.id),
+    (event: DispatchVisitEvent, _e: React.MouseEvent) => onActiveVisitChange(event.id),
     [onActiveVisitChange]
   )
 
@@ -185,7 +247,43 @@ export function BoardCalendarGrid({
     [resources]
   )
 
-  return (
+  // Right-click menu (plan 37c §5.3) — spatial-target-only, the bulk bar owns everything
+  // selection-targeted. Resolved once per `contextmenu` event, not re-derived on render.
+  const [menuTarget, setMenuTarget] = useState<BoardMenuTarget | null>(null)
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      const chipEl = (e.target as HTMLElement).closest?.('[data-event-id]')
+      const visitId = chipEl?.getAttribute('data-event-id')
+      setMenuTarget(
+        visitId
+          ? { type: 'chip', visitId }
+          : { type: 'slot', slot: hoveredSlotRef?.current ?? null }
+      )
+    },
+    [hoveredSlotRef]
+  )
+
+  // Right-click a chip outside the current selection → select just it, then copy (§5.3);
+  // right-click one already in the selection → copy the whole selection, mirroring Cmd+C.
+  const handleCopyFromMenu = useCallback(() => {
+    if (menuTarget?.type !== 'chip') return
+    const { visitId } = menuTarget
+    if (selectedEventIds.includes(visitId)) {
+      onCopyIds?.(selectedEventIds)
+    } else {
+      onSelectionChange([visitId])
+      onCopyIds?.([visitId])
+    }
+  }, [menuTarget, selectedEventIds, onSelectionChange, onCopyIds])
+
+  const handlePasteFromMenu = useCallback(() => {
+    if (menuTarget?.type !== 'slot') return
+    const { slot } = menuTarget
+    onPasteAt?.(slot ? { day: slot.date, time: slot.time, resourceId: slot.resourceId } : null)
+  }, [menuTarget, onPasteAt])
+
+  const calendar = (
     <EventCalendar<DispatchVisitEvent>
       date={date}
       view={calendarView}
@@ -204,12 +302,47 @@ export function BoardCalendarGrid({
       backgroundEvents={backgroundEvents}
       events={events}
       renderEvent={renderEvent}
-      selectedEventId={activeVisitId}
+      selectedEventIds={selectedEventIds}
+      onSelectionChange={onSelectionChange}
       onEventClick={handleEventClick}
       onEventResize={canEdit && view !== 'month' ? onEventResize : undefined}
       hideToolbar
       isNonWorkingDay={isNonWorkingDay}
+      hoveredSlotRef={hoveredSlotRef}
       className='flex-1'
     />
+  )
+
+  // Copy/paste's right-click affordance is admin-gated like every other write path (plan 37c
+  // derived decision) — members get the plain calendar, no `ContextMenu` wrapper at all.
+  if (!canEdit) return calendar
+
+  return (
+    <ContextMenu
+      onOpenChange={(open) => {
+        if (!open) setMenuTarget(null)
+      }}>
+      {/* `display: contents` keeps this wrapper out of the flex layout — `EventCalendar`'s own
+       * root (className='flex-1' above) still lands as the direct flex child its parent row
+       * (`dispatch-board.tsx`'s `flex flex-1 overflow-hidden`) expects. */}
+      <ContextMenuTrigger asChild>
+        <div className='contents' onContextMenu={handleContextMenu}>
+          {calendar}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className='w-48'>
+        {menuTarget?.type === 'chip' ? (
+          <ContextMenuItem onSelect={handleCopyFromMenu}>
+            <Copy /> Copy
+            <ContextMenuShortcut>⌘C</ContextMenuShortcut>
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem disabled={!hasClipboard} onSelect={handlePasteFromMenu}>
+            <ClipboardPaste /> Paste here
+            <ContextMenuShortcut>⌘V</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -25,13 +25,17 @@ import { PlannerDndProvider } from '../route-planner/planner-dnd-provider'
 import { RoutePlannerView } from '../route-planner/route-planner-view'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import { DispatchSidebar } from '../sidebar/dispatch-sidebar'
+import { BoardBulkBar } from './board-bulk-bar'
 import { BoardCalendarGrid } from './board-calendar-grid'
 import { BoardToolbar } from './board-toolbar'
 import { EventDockPanel } from './event-dock-panel'
 import { useAvailabilityShading } from './hooks/use-availability-shading'
+import { useBoardBulkRunner } from './hooks/use-board-bulk-runner'
+import { useBoardClipboard } from './hooks/use-board-clipboard'
 import { useBoardData } from './hooks/use-board-data'
 import { useBoardMutations } from './hooks/use-board-mutations'
 import { useBoardRealtime } from './hooks/use-board-realtime'
+import { PasteVisitsDialog } from './paste-visits-dialog'
 import type { DispatchVisitEvent } from './types'
 import { UNASSIGNED_RESOURCE_ID } from './types'
 import { computeOverlappingVisitIds } from './utils'
@@ -103,6 +107,16 @@ export function DispatchBoard() {
   const overlappingIds = useMemo(() => computeOverlappingVisitIds(data.events), [data.events])
 
   const [activeVisitId, setActiveVisitId] = useState<string | null>(null)
+  // Multi-selection (plan 37c §3) — independent of `activeVisitId` ("which popover is open"):
+  // a plain click sets both (the grid fires `onSelectionChange` AND `onEventClick`), a
+  // cmd/shift-click only ever touches this.
+  const [selectedVisitIds, setSelectedVisitIds] = useState<string[]>([])
+  const clearSelection = useCallback(() => setSelectedVisitIds([]), [])
+
+  // Board-local bulk runner (plan 37c §5.2) — one instance shared by the bulk bar (which
+  // drives `run()`) and the grid (which dims `pendingVisitIds` chips), so both read the same
+  // in-flight set.
+  const bulkRunner = useBoardBulkRunner()
 
   // Dockable event panel (plan 21) — a board-scoped push column, separate from the page-level
   // `useDockedPanels` dock further below that drives the record drawer; this
@@ -132,6 +146,24 @@ export function DispatchBoard() {
     item: parseAsString,
   })
   const drawerRecordId = recordParam && isRecordId(recordParam) ? recordParam : null
+
+  // Clipboard + paste (plan 37c §4/§5, Phase 3, board only) — Cmd+C/Cmd+V keybindings, the
+  // hovered-slot ref `BoardCalendarGrid` feeds into `EventCalendar`, and the paste-options
+  // dialog's open/target state. `workOrderResource?.id` (the `work-orders` def id) is what
+  // turns a copied `DispatchVisitEvent.workOrderId` (an `EntityInstance` id) into the
+  // `RecordId` `dispatch.pasteVisits` wants — copy stays inert until resources have loaded.
+  // Gated off in map mode too (`!isMap`) — the calendar grid (and its selection) isn't even
+  // mounted there, so a stray Cmd+C/Cmd+V shouldn't silently act on a stale selection or pop
+  // the paste dialog open after switching back to the calendar.
+  const clipboard = useBoardClipboard({
+    events: data.events,
+    selectedVisitIds,
+    boardDate: data.date,
+    workOrderDefId: workOrderResource?.id,
+    canEdit: canEdit && data.boardMode !== 'map',
+  })
+  const pasteItems = useMemo(() => clipboard.clipboardItems ?? [], [clipboard.clipboardItems])
+
   const handleSelectVisit = useCallback(
     (sel: { workOrderId: string; visitId: string }) => {
       if (!workOrderResource) return
@@ -379,16 +411,43 @@ export function DispatchBoard() {
                 existingVisits={existingVisits}
                 activeVisitId={activeVisitId}
                 onActiveVisitChange={setActiveVisitId}
+                selectedEventIds={selectedVisitIds}
+                onSelectionChange={setSelectedVisitIds}
+                pendingVisitIds={bulkRunner.pendingVisitIds}
                 onRangeChange={data.handleRangeChange}
                 onEventResize={handleEventResize}
                 onOpenRecord={handleOpenRecord}
                 isNonWorkingDay={isNonWorkingDay}
                 isDockOpen={isEventDockOpen}
+                hoveredSlotRef={clipboard.hoveredSlotRef}
+                hasClipboard={clipboard.hasClipboard}
+                onCopyIds={clipboard.copyIds}
+                onPasteAt={clipboard.openPasteDialogAt}
               />
             </div>
           </CalendarDndProvider>
         )}
       </div>
+      {!isMap && canEdit && (
+        <PasteVisitsDialog
+          target={clipboard.pasteTarget}
+          onOpenChange={(open) => {
+            if (!open) clipboard.closePasteDialog()
+          }}
+          items={pasteItems}
+          workers={data.workers}
+          pasteVisits={mutations.pasteVisits}
+        />
+      )}
+      {!isMap && canEdit && (
+        <BoardBulkBar
+          selectedVisitIds={selectedVisitIds}
+          onCopySelection={clipboard.copySelection}
+          mutations={mutations}
+          bulkRunner={bulkRunner}
+          onClearSelection={clearSelection}
+        />
+      )}
       {overlays}
     </MainPageContent>
   )

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-bulk-runner.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-bulk-runner.ts
@@ -1,0 +1,89 @@
+// apps/web/src/components/dispatch/ui/board/hooks/use-board-bulk-runner.ts
+
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
+
+interface ConfirmSpec {
+  /** Confirm dialog title, e.g. `Cancel 7 visits?`. */
+  title: string
+  /** Confirm dialog body. */
+  description?: string
+  /** Confirm button label. Default `Confirm`. */
+  confirmText?: string
+  /** Style the confirm as destructive (red). Default `true`. */
+  destructive?: boolean
+}
+
+interface RunOptions {
+  /** Confirm gate up front — omit for non-destructive actions (Assign, Dispatch) that don't
+   * want one; the loop starts immediately. */
+  confirm?: ConfirmSpec
+  /** Toast title shown when one or more items fail. */
+  failureTitle?: string
+  /** Noun used in the summary toast, e.g. "3 of 12 visits skipped". Default `items`. */
+  failureNoun?: string
+  /** Runs once after the loop settles (e.g. clear the selection). */
+  onDone?: () => void
+}
+
+/**
+ * Board-local mirror of `list-selection/use-bulk-runner.ts` (plan 37c §5.2): one optional
+ * `useConfirm` gate up front, then a **sequential** loop over the per-item async mutation,
+ * collecting failures into a single summary toast. Deliberately drops the list-selection
+ * store coupling (`addPending`/`removePending`/`setPendingLabel` drive `ListCard` blur
+ * overlays that don't exist on calendar chips) — instead it exposes `pendingVisitIds`, the
+ * set of ids currently mid-flight, so the board can dim their chips directly.
+ */
+export function useBoardBulkRunner() {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const [isRunning, setIsRunning] = useState(false)
+  const [pendingVisitIds, setPendingVisitIds] = useState<Set<string>>(new Set())
+
+  const run = useCallback(
+    async (ids: string[], perItem: (id: string) => Promise<unknown>, opts: RunOptions = {}) => {
+      if (ids.length === 0) return
+      if (opts.confirm) {
+        const confirmed = await confirm({
+          title: opts.confirm.title,
+          description: opts.confirm.description,
+          confirmText: opts.confirm.confirmText ?? 'Confirm',
+          cancelText: 'Cancel',
+          destructive: opts.confirm.destructive ?? true,
+        })
+        if (!confirmed) return
+      }
+
+      setIsRunning(true)
+      let failures = 0
+      for (const id of ids) {
+        setPendingVisitIds((prev) => new Set(prev).add(id))
+        try {
+          await perItem(id)
+        } catch {
+          failures++
+        } finally {
+          setPendingVisitIds((prev) => {
+            const next = new Set(prev)
+            next.delete(id)
+            return next
+          })
+        }
+      }
+      setIsRunning(false)
+
+      if (failures > 0) {
+        toastError({
+          title: opts.failureTitle ?? 'Some items could not be processed',
+          description: `${failures} of ${ids.length} ${opts.failureNoun ?? 'items'} skipped`,
+        })
+      }
+      opts.onDone?.()
+    },
+    [confirm]
+  )
+
+  return { ConfirmDialog, run, isRunning, pendingVisitIds }
+}

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-clipboard.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-clipboard.ts
@@ -1,0 +1,134 @@
+// apps/web/src/components/dispatch/ui/board/hooks/use-board-clipboard.ts
+
+'use client'
+
+import type { HoveredSlot } from '@auxx/ui/components/event-calendar'
+import { useHotkey } from '@tanstack/react-hotkeys'
+import { useCallback, useRef, useState } from 'react'
+import {
+  type CopiedVisitItem,
+  useClipboardCopy,
+  useClipboardItems,
+} from '~/components/calendar/core/clipboard-store'
+import { toRecordId } from '~/components/resources'
+import type { DispatchVisitEvent } from '../types'
+
+/** Where a paste lands — the board-local mirror of `HoveredSlot` (day + fractional hours +
+ * resource column), built either from the live hover ref (Cmd+V) or a right-click snapshot
+ * (context menu "Paste here"). `time`/`resourceId` are absent for a day-only target (month
+ * view, or no cell ever hovered — falls back to the board's current anchor date). */
+export interface PasteAnchor {
+  day: Date
+  time?: number
+  resourceId?: string
+}
+
+interface UseBoardClipboardOptions {
+  events: DispatchVisitEvent[]
+  selectedVisitIds: string[]
+  /** Board's current anchor date (`useBoardData().date`) — the Cmd+V fallback target when
+   * nothing's been hovered yet (plan 37c §5, item 5). */
+  boardDate: Date
+  /** `work-orders` resource's entityDefinitionId — needed to turn a
+   * `DispatchVisitEvent.workOrderId` (an `EntityInstance` id) into the `RecordId`
+   * `dispatch.pasteVisits` wants. `undefined` while resources are still loading; copy/paste
+   * stay inert until it resolves. */
+  workOrderDefId: string | undefined
+  canEdit: boolean
+}
+
+/**
+ * Board clipboard state machine (plan 37c §4, board-only per Phase 3's scope): owns the
+ * hovered-slot ref `board-calendar-grid.tsx` feeds into `EventCalendar`, the Cmd+C/Cmd+V
+ * keybindings, and the paste-options dialog's open/target state. Copy/context-menu targeting
+ * stay in `board-calendar-grid.tsx` (it already owns selection + chip DOM); this hook only
+ * exposes the primitives (`copyIds`, `openPasteDialogAt`) they call into.
+ */
+export function useBoardClipboard({
+  events,
+  selectedVisitIds,
+  boardDate,
+  workOrderDefId,
+  canEdit,
+}: UseBoardClipboardOptions) {
+  const clipboardItems = useClipboardItems()
+  const copyToClipboard = useClipboardCopy()
+  const hoveredSlotRef = useRef<HoveredSlot | null>(null)
+  const [pasteTarget, setPasteTarget] = useState<PasteAnchor | null>(null)
+
+  const copyIds = useCallback(
+    (ids: string[]) => {
+      if (!canEdit || !workOrderDefId || ids.length === 0) return
+      const idSet = new Set(ids)
+      const picked = events.filter((e) => idSet.has(e.id))
+      if (picked.length === 0) return
+      const items: CopiedVisitItem[] = picked.map((e) => ({
+        kind: 'visit',
+        visitId: e.id,
+        workOrderRecordId: toRecordId(workOrderDefId, e.workOrderId),
+        title: e.title,
+        start: e.start,
+        end: e.end,
+        assigneeUserId: e.assigneeUserId,
+      }))
+      copyToClipboard(items)
+    },
+    [events, copyToClipboard, workOrderDefId, canEdit]
+  )
+
+  const copySelection = useCallback(() => copyIds(selectedVisitIds), [copyIds, selectedVisitIds])
+
+  const openPasteDialogAt = useCallback(
+    (target: PasteAnchor | null) => {
+      if (!canEdit || !clipboardItems) return
+      setPasteTarget(target ?? { day: boardDate })
+    },
+    [canEdit, clipboardItems, boardDate]
+  )
+
+  const openPasteDialogAtHoveredSlot = useCallback(() => {
+    const slot = hoveredSlotRef.current
+    openPasteDialogAt(
+      slot ? { day: slot.date, time: slot.time, resourceId: slot.resourceId } : null
+    )
+  }, [openPasteDialogAt])
+
+  const closePasteDialog = useCallback(() => setPasteTarget(null), [])
+
+  // Cmd/Ctrl+C — copies the current selection. `ignoreInputs: true` mirrors the workflow
+  // canvas's own Mod+V precedent (`use-workflow-shortcuts.ts`): Ctrl/Meta combos default to
+  // FIRING inside text inputs (`@tanstack/hotkeys`'s per-key default), which would hijack a
+  // dispatcher's native copy while editing a title/note field. A non-empty text selection is
+  // also left alone — the user is copying text, not events.
+  useHotkey(
+    'Mod+C',
+    () => {
+      if (!canEdit || selectedVisitIds.length === 0) return
+      if (typeof window !== 'undefined' && window.getSelection()?.toString()) return
+      copySelection()
+    },
+    { ignoreInputs: true, enabled: canEdit }
+  )
+
+  // Cmd/Ctrl+V — opens the paste-options dialog anchored at the hovered slot (plan 37c §5, H).
+  useHotkey(
+    'Mod+V',
+    () => {
+      if (!canEdit || !clipboardItems) return
+      openPasteDialogAtHoveredSlot()
+    },
+    { ignoreInputs: true, enabled: canEdit }
+  )
+
+  return {
+    hoveredSlotRef,
+    clipboardItems,
+    hasClipboard: clipboardItems !== null,
+    copyIds,
+    copySelection,
+    pasteTarget,
+    openPasteDialogAt,
+    openPasteDialogAtHoveredSlot,
+    closePasteDialog,
+  }
+}

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
@@ -3,10 +3,26 @@
 'use client'
 
 import { toastError } from '@auxx/ui/components/toast'
+import { generateId } from '@auxx/utils'
 import { useCallback } from 'react'
+import { parseRecordId, type RecordId } from '~/components/resources'
+import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
 import type { BoardResult, BoardVisit } from '../types'
 import type { DateRange } from './use-board-data'
+
+/** `dispatch.pasteVisits`'s per-item input, post-coercion — `z.coerce.date()` (and the
+ * `recordIdSchema` cast) make the CLIENT-side mutation-variables type widen every field to
+ * `unknown` (tRPC infers `.mutate()`'s param type from the schema's pre-parse input, not its
+ * parsed output); this is what actually lands in `vars.items` at runtime. `scheduleVisit`'s own
+ * `onMutate` above has the identical pre-existing `unknown` gap for the same reason — this cast
+ * is scoped to the paste-visits temp-row builder only. */
+interface PasteVisitVars {
+  workOrderRecordId: RecordId
+  startTime: Date
+  endTime: Date
+  assigneeUserId?: string | null
+}
 
 /**
  * All visit-mutating writes the board makes, each with an optimistic patch of the
@@ -18,6 +34,7 @@ import type { DateRange } from './use-board-data'
  */
 export function useBoardMutations(range: DateRange) {
   const utils = api.useUtils()
+  const { organizationId } = useUser()
 
   const patchVisit = useCallback(
     (visitId: string, patch: Partial<BoardVisit>): BoardResult | undefined => {
@@ -64,6 +81,21 @@ export function useBoardMutations(range: DateRange) {
       rollback(ctx?.previous)
       toastError({
         title: 'Error scheduling visit',
+        description: error.message,
+      })
+    },
+    onSettled: settle,
+  })
+
+  const assignVisit = api.dispatch.assignVisit.useMutation({
+    onMutate: async (vars) => {
+      await utils.dispatch.getBoard.cancel(range)
+      return { previous: patchVisit(vars.visitId, { assigneeUserId: vars.assigneeUserId }) }
+    },
+    onError: (error, _vars, ctx) => {
+      rollback(ctx?.previous)
+      toastError({
+        title: 'Error assigning visit',
         description: error.message,
       })
     },
@@ -149,12 +181,75 @@ export function useBoardMutations(range: DateRange) {
     onSettled: settle,
   })
 
+  // Copy/paste's one batch mutation (plan 37c §4.4/§5, item 5) — a single round trip that
+  // creates N new rule-less, scheduled visits. Optimistic patch INSERTS temp rows (not the
+  // patch-in-place recipe every other mutation above uses) so the pasted chips render
+  // instantly; `generateId` (not the server's cuid2) keeps temp ids visually distinct and
+  // collision-free until the settle invalidate swaps them for the real rows. No per-item
+  // rollback on partial failure — the whole optimistic batch reverts together on a hard
+  // error, and the settle invalidate always repaints the true state regardless.
+  const pasteVisits = api.dispatch.pasteVisits.useMutation({
+    onMutate: async (vars) => {
+      await utils.dispatch.getBoard.cancel(range)
+      const previous = utils.dispatch.getBoard.getData(range)
+      if (previous) {
+        const now = new Date()
+        const items = vars.items as PasteVisitVars[]
+        const tempVisits: BoardVisit[] = items.map((item) => ({
+          id: generateId('temp-visit'),
+          organizationId: organizationId ?? '',
+          workOrderId: parseRecordId(item.workOrderRecordId).entityInstanceId,
+          assigneeUserId: item.assigneeUserId ?? null,
+          startTime: item.startTime,
+          endTime: item.endTime,
+          timezone: 'UTC',
+          status: 'scheduled',
+          routeOrder: null,
+          latitude: null,
+          longitude: null,
+          geocodedAt: null,
+          dispatchedAt: null,
+          timeConfirmedAt: now,
+          durationMinutes: Math.round((item.endTime.getTime() - item.startTime.getTime()) / 60_000),
+          recurrenceRuleId: null,
+          occurrenceDate: null,
+          isDetached: false,
+          createdAt: now,
+          updatedAt: now,
+        }))
+        utils.dispatch.getBoard.setData(range, {
+          ...previous,
+          visits: [...previous.visits, ...tempVisits],
+        })
+      }
+      return { previous }
+    },
+    onError: (error, _vars, ctx) => {
+      rollback(ctx?.previous)
+      toastError({
+        title: 'Error pasting visits',
+        description: error.message,
+      })
+    },
+    onSuccess: (result) => {
+      if (result.failures.length > 0) {
+        toastError({
+          title: 'Some visits could not be pasted',
+          description: `${result.failures.length} of ${result.created.length + result.failures.length} visits failed to paste`,
+        })
+      }
+    },
+    onSettled: settle,
+  })
+
   return {
     scheduleVisit,
+    assignVisit,
     unscheduleVisit,
     setVisitStatus,
     dispatchVisit,
     applyToSeries,
     cancelVisitFollowing,
+    pasteVisits,
   }
 }

--- a/apps/web/src/components/dispatch/ui/board/paste-visits-dialog.tsx
+++ b/apps/web/src/components/dispatch/ui/board/paste-visits-dialog.tsx
@@ -1,0 +1,236 @@
+// apps/web/src/components/dispatch/ui/board/paste-visits-dialog.tsx
+
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
+import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import { format } from 'date-fns'
+import { useEffect, useMemo, useState } from 'react'
+import { computePasteTimes, hoursToDate } from '~/components/calendar/core/clipboard-offset'
+import type { CopiedVisitItem } from '~/components/calendar/core/clipboard-store'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import type { PasteAnchor } from './hooks/use-board-clipboard'
+import type { useBoardMutations } from './hooks/use-board-mutations'
+import type { BoardWorker } from './types'
+import { UNASSIGNED_RESOURCE_ID } from './types'
+
+export interface PasteVisitsDialogProps {
+  /** `null` = closed. Set by `use-board-clipboard.ts`'s Cmd+V handler or the context menu's
+   * "Paste here" — always the anchor at the moment the paste was invoked. */
+  target: PasteAnchor | null
+  onOpenChange: (open: boolean) => void
+  items: CopiedVisitItem[]
+  workers: BoardWorker[]
+  pasteVisits: ReturnType<typeof useBoardMutations>['pasteVisits']
+}
+
+type AssigneeMode = 'keep' | 'clear' | 'assign'
+type TimesMode = 'keep' | 'slot'
+
+function workerLabel(worker: BoardWorker): string {
+  return worker.user?.name ?? worker.user?.email ?? 'Worker'
+}
+
+/**
+ * Paste-options dialog (plan 37c §4.3) — the confirm for BOTH invocation routes (Cmd+V and the
+ * context menu's "Paste here"). One `Dialog` + `FieldPanel`, modeled on the route planner's
+ * `ApplyTimesDialog` (live preview list + one editable field + a single confirm mutation).
+ * `dispatch.pasteVisits` is the one deliberate batch endpoint (§4.4) — this dialog's confirm is
+ * its only caller.
+ */
+export function PasteVisitsDialog({
+  target,
+  onOpenChange,
+  items,
+  workers,
+  pasteVisits,
+}: PasteVisitsDialogProps) {
+  const open = target !== null
+
+  const [targetDay, setTargetDay] = useState<Date>(() => target?.day ?? new Date())
+  const [assigneeMode, setAssigneeMode] = useState<AssigneeMode>('keep')
+  const [timesMode, setTimesMode] = useState<TimesMode>('keep')
+
+  // Re-seed every time the dialog opens for a NEW target — never while it's open (an option
+  // toggle shouldn't stomp the dispatcher's own edits mid-dialog). Options reset to their
+  // defaults too, so a stale "assign all to <worker>" from a previous open can't silently
+  // apply to a different target.
+  useEffect(() => {
+    if (target) {
+      setTargetDay(target.day)
+      setAssigneeMode('keep')
+      setTimesMode('keep')
+    }
+  }, [target])
+
+  // The retarget option (§4.3) only exists when the target slot carries a real worker row —
+  // week/month views and the synthetic "Unassigned" column never offer it.
+  const targetWorker = useMemo(
+    () =>
+      target?.resourceId && target.resourceId !== UNASSIGNED_RESOURCE_ID
+        ? (workers.find((w) => w.userId === target.resourceId) ?? null)
+        : null,
+    [target?.resourceId, workers]
+  )
+  const hasSlotTime = target?.time !== undefined
+
+  const results = useMemo(() => {
+    if (!target) return []
+    const slotTime =
+      timesMode === 'slot' && target.time !== undefined
+        ? hoursToDate(targetDay, target.time)
+        : undefined
+    return computePasteTimes(
+      items,
+      { day: targetDay, time: slotTime },
+      {
+        startAtSlot: timesMode === 'slot' && slotTime !== undefined,
+      }
+    )
+  }, [items, target, targetDay, timesMode])
+
+  const handleConfirm = () => {
+    if (results.length === 0) return
+    pasteVisits.mutate(
+      {
+        items: results.map((r) => ({
+          workOrderRecordId: r.item.workOrderRecordId,
+          startTime: r.startTime,
+          endTime: r.endTime,
+          assigneeUserId:
+            assigneeMode === 'keep'
+              ? r.item.assigneeUserId
+              : assigneeMode === 'clear'
+                ? null
+                : (targetWorker?.userId ?? null),
+        })),
+      },
+      {
+        onSuccess: () => onOpenChange(false),
+        onError: (error) =>
+          toastError({ title: 'Error pasting visits', description: error.message }),
+      }
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc'>
+        <DialogHeader>
+          <DialogTitle>
+            Paste {items.length} visit{items.length === 1 ? '' : 's'}
+          </DialogTitle>
+          <DialogDescription>
+            Creates a new visit on the same work order for each copied item — never moves or clones
+            the original.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='space-y-4'>
+          <FieldPanel className='p-0' breakpoint='md'>
+            <FieldPanelRow title='Target date'>
+              <FieldInputAdapter
+                fieldType={FieldType.DATE}
+                value={targetDay.toISOString()}
+                onChange={(val) => {
+                  if (val) setTargetDay(new Date(val as string))
+                }}
+                disabled={pasteVisits.isPending}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+
+          <div className='space-y-1.5'>
+            <span className='text-xs text-muted-foreground'>Times</span>
+            <RadioGroup
+              value={timesMode}
+              onValueChange={(v) => setTimesMode(v as TimesMode)}
+              className='gap-1.5'>
+              <label className='flex items-center gap-2 text-sm'>
+                <RadioGroupItem value='keep' size='sm' /> Keep original times
+              </label>
+              <label
+                className={cn(
+                  'flex items-center gap-2 text-sm',
+                  !hasSlotTime && 'text-muted-foreground'
+                )}>
+                <RadioGroupItem value='slot' size='sm' disabled={!hasSlotTime} /> Start at clicked
+                slot
+              </label>
+            </RadioGroup>
+          </div>
+
+          <div className='space-y-1.5'>
+            <span className='text-xs text-muted-foreground'>Assignee</span>
+            <RadioGroup
+              value={assigneeMode}
+              onValueChange={(v) => setAssigneeMode(v as AssigneeMode)}
+              className='gap-1.5'>
+              <label className='flex items-center gap-2 text-sm'>
+                <RadioGroupItem value='keep' size='sm' /> Keep original assignee
+              </label>
+              <label className='flex items-center gap-2 text-sm'>
+                <RadioGroupItem value='clear' size='sm' /> Clear (unassigned)
+              </label>
+              {targetWorker && (
+                <label className='flex items-center gap-2 text-sm'>
+                  <RadioGroupItem value='assign' size='sm' /> Assign all to{' '}
+                  {workerLabel(targetWorker)}
+                </label>
+              )}
+            </RadioGroup>
+          </div>
+
+          <div className='max-h-72 space-y-1.5 overflow-y-auto rounded-2xl border py-2 px-3'>
+            {results.length === 0 ? (
+              <p className='text-muted-foreground px-1 py-2 text-xs'>Nothing to paste.</p>
+            ) : (
+              results.map((r) => (
+                <div key={r.item.visitId} className='flex items-center gap-2 text-xs'>
+                  <span className='min-w-0 flex-1 truncate'>{r.item.title}</span>
+                  <span className='shrink-0 text-muted-foreground'>
+                    {format(r.item.start, 'MMM d, p')} → {format(r.startTime, 'MMM d, p')}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={pasteVisits.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            variant='outline'
+            size='sm'
+            loading={pasteVisits.isPending}
+            loadingText='Pasting...'
+            disabled={results.length === 0}
+            data-dialog-submit>
+            Paste <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
@@ -44,9 +44,10 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
 
   const { upcoming, history } = splitJobVisits(visits)
   // The primary card's target visit — also the recurring engine's "next-upcoming visit"
-  // (06-recurring-engine.md §6): one-off has exactly one, so this stays jobType-agnostic.
-  // Never falls back into history (plan 30 §G.2) — no upcoming visits is an empty state,
-  // not a "next visit" mislabel on a done/canceled row.
+  // (06-recurring-engine.md §6): a one-off job can carry extra visits too (`addVisit`'s
+  // deliberate exception, plan 37c decision B), so this just picks the earliest upcoming
+  // one and stays jobType-agnostic. Never falls back into history (plan 30 §G.2) — no
+  // upcoming visits is an empty state, not a "next visit" mislabel on a done/canceled row.
   const primaryVisit = upcoming[0]
   // The primary visit already renders as the card — preview only the visits after it.
   const laterUpcoming = upcoming.slice(1)

--- a/apps/web/src/components/dispatch/ui/schedule-work-order-action.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-work-order-action.tsx
@@ -3,7 +3,7 @@
 
 // Work-order drawer header action (dispatch M2 build spec §F.4, the
 // create-quote-action/create-invoice-action precedent): mounts the schedule
-// control (#7, `SchedulePopover`) targeting the job's next/only visit.
+// control (#7, `SchedulePopover`) targeting the job's next visit.
 // Admin-only client-side (`dispatch-board.tsx`'s `isAdminOrOwner` pattern) —
 // scheduling mutations are admin-gated server-side too (`dispatchAdminProcedure`).
 // `<div><Tooltip><Button/></Tooltip></div>` as the popover trigger is the

--- a/apps/web/src/components/dynamic-table/components/calendar/calendar-view-body.tsx
+++ b/apps/web/src/components/dynamic-table/components/calendar/calendar-view-body.tsx
@@ -112,7 +112,7 @@ export function CalendarViewBody() {
         onViewChange={() => {}}
         onRangeChange={handleRangeChange}
         events={events}
-        onEventClick={(event) => onCardClick?.({ id: event.id })}
+        onEventClick={(event, _e) => onCardClick?.({ id: event.id })}
         onEventDrop={handleEventDrop}
         onSlotClick={handleSlotClick}
         hideToolbar

--- a/apps/web/src/components/schedule/ui/schedule-calendar.tsx
+++ b/apps/web/src/components/schedule/ui/schedule-calendar.tsx
@@ -33,6 +33,10 @@ import { useScheduleSidebarStore } from '../stores/schedule-sidebar-store'
 /** Sidebar group id for the visits/meetings source toggle rows. */
 const KINDS_GROUP = 'kinds'
 
+/** Stable empty default — an inline `[]` would recreate `EventCalendar`'s `selectedIdSet` every
+ * render whenever nothing is selected. */
+const EmptySelection: string[] = []
+
 /**
  * Module-level static source list — hook rules require a page's source list never change
  * across renders (plan 01 §3.1), so this lives outside the component.
@@ -128,7 +132,9 @@ export function ScheduleCalendar({
   const renderEvent = (event: SourcedEvent, ctx: RenderEventContext) =>
     SOURCE_BY_ID[event.sourceId]?.renderEvent(event, ctx) ?? null
 
-  const handleEventClick = (event: SourcedEvent) => {
+  // Plain-click-only (plan 37c §3.2 — the grid never calls this on a modifier-click), so
+  // behavior here is unchanged; multi-selection/copy-paste for this surface is a later phase.
+  const handleEventClick = (event: SourcedEvent, _e: React.MouseEvent) => {
     if (event.sourceId === 'visits') onVisitClick(event.id)
     else if (event.sourceId === 'meetings') onMeetingClick(event.id)
     else if (event.sourceId === 'tasks') onTaskClick((event as TaskEvent).task)
@@ -173,7 +179,7 @@ export function ScheduleCalendar({
         events={events}
         renderEvent={renderEvent}
         onEventClick={handleEventClick}
-        selectedEventId={selectedEventId}
+        selectedEventIds={selectedEventId ? [selectedEventId] : EmptySelection}
         weekStartsOn={weekStartsOn}
         hideToolbar
         className='flex-1'

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -28,6 +28,7 @@ import {
   listQcItemTemplates,
   listVisitQcItems,
   listVisitsForWorkOrder,
+  pasteVisits,
   pauseEngagement,
   removeDispatchWorker,
   removeMyQcItemPhoto,
@@ -420,6 +421,41 @@ export const dispatchRouter = createTRPCRouter({
         assigneeUserId: input.assigneeUserId,
         excludeSocketId: excludeSocketId(ctx),
       })
+    }),
+
+  // Plan 37c §4.4 — copy/paste's one deliberate batch mutation: N new rule-less, scheduled
+  // visits in a single round trip (the paste-options dialog's confirm). Thin delegation to
+  // `pasteVisits` (a sequential loop over `addVisit`, no transaction — partial success is
+  // expected and reported back per item). Admin-gated like the rest of visit machinery (§B).
+  pasteVisits: dispatchAdminProcedure
+    .input(
+      z.object({
+        items: z
+          .array(
+            z.object({
+              workOrderRecordId: recordIdSchema,
+              startTime: z.coerce.date(),
+              endTime: z.coerce.date(),
+              assigneeUserId: z.string().nullable().optional(),
+            })
+          )
+          .min(1)
+          .max(200),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const result = await pasteVisits({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        items: input.items.map((item) => ({
+          workOrderInstanceId: parseRecordId(item.workOrderRecordId).entityInstanceId,
+          startTime: item.startTime,
+          endTime: item.endTime,
+          assigneeUserId: item.assigneeUserId,
+        })),
+        excludeSocketId: excludeSocketId(ctx),
+      })
+      return result
     }),
 
   // §F.3 (M2b job view) — visits for one work order, oldest-scheduled-first.

--- a/apps/worker/scripts/verify-dispatch-paste-visits.ts
+++ b/apps/worker/scripts/verify-dispatch-paste-visits.ts
@@ -1,0 +1,298 @@
+// apps/worker/scripts/verify-dispatch-paste-visits.ts
+/**
+ * `pasteVisits` verification (plans/dispatch/37c-calendar-create-copy-paste.md §4.4/§9 Phase
+ * 3). Exercises the REAL write path `pasteVisits` (packages/lib/src/dispatch/paste-visits.ts),
+ * a sequential loop over the existing `addVisit` primitive — no new scheduling logic, so this
+ * script's job is checking the BATCH contract `addVisit` itself doesn't have:
+ *
+ * - Invariant B (decision B): a one-off work order (which already carries its auto-created
+ *   first visit, `ensureVisitOnWorkOrderCreate`) gains a SECOND visit via paste without the
+ *   server blocking it.
+ * - A pasted copy of a series visit's time lands as a plain rule-less clone
+ *   (`recurrenceRuleId: null`, `occurrenceDate: null`) on the same work order — a paste is a
+ *   manual clone, never a detachment of the series itself.
+ * - Per-item assignee semantics: retarget (explicit userId), clear (explicit `null`), and the
+ *   omitted-key case (nothing to "keep" on a brand-new row, so it lands unassigned — same
+ *   contract `addVisit`/`scheduleVisit` already have for a fresh insert).
+ * - Partial failure: one bogus `workOrderInstanceId` among valid items lands in `failures` at
+ *   its own index; every other item still commits (no transaction, no all-or-nothing).
+ *
+ * Work orders are created via `UnifiedCrudHandler.create` (M1 hooks), prefixed
+ * "[paste-visits-verify]", and deleted at the end — `WorkOrderVisit.workOrderId` AND
+ * `RecurrenceRule.subjectId` cascade on `EntityInstance` delete (the
+ * `verify-dispatch-series-end.ts` precedent). No dispatch/notification/money path is touched
+ * (fresh rows never carry a prior `dispatchedAt`, so `scheduleVisit`'s reschedule-notice guard
+ * never fires), so no queue pausing is needed.
+ *
+ * Timing: the dev org has no `OperatingHours` row so the org resolves to 'UTC' (asserted as a
+ * precondition, the `verify-dispatch-series-end.ts` precedent); all times here are plain UTC.
+ *
+ * Run (from repo root) under the worker runtime:
+ *   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
+ *     scripts/verify-dispatch-paste-visits.ts
+ */
+
+import { database } from '@auxx/database'
+import { pasteVisits, setRecurrenceRule } from '@auxx/lib/dispatch'
+import type { RecurrencePattern } from '@auxx/lib/recurrence'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+
+let pass = 0
+let fail = 0
+function check(name: string, ok: boolean, detail?: unknown) {
+  if (ok) {
+    pass++
+    console.log(`  ✅ ${name}`)
+  } else {
+    fail++
+    console.log(`  ❌ ${name}`, detail ?? '')
+  }
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+function addDaysToIso(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00.000Z`)
+  d.setUTCDate(d.getUTCDate() + days)
+  return isoDate(d)
+}
+function weekdayOfIso(iso: string): number {
+  return new Date(`${iso}T00:00:00.000Z`).getUTCDay()
+}
+/** A UTC start/end pair `daysFromNow` at a fixed hour, `durationMinutes` long. */
+function slot(daysFromNow: number, hour: number, durationMinutes = 60) {
+  const start = new Date(`${addDaysToIso(isoDate(new Date()), daysFromNow)}T00:00:00.000Z`)
+  start.setUTCHours(hour, 0, 0, 0)
+  const end = new Date(start.getTime() + durationMinutes * 60_000)
+  return { startTime: start, endTime: end }
+}
+
+async function getVisitsSorted(workOrderInstanceId: string) {
+  return database.query.WorkOrderVisit.findMany({
+    where: (t, { eq }) => eq(t.workOrderId, workOrderInstanceId),
+    orderBy: (t, { asc }) => [asc(t.occurrenceDate), asc(t.startTime)],
+  })
+}
+
+async function main() {
+  const user = await database.query.User.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.email, 'm4rkuskk@gmail.com'),
+  })
+  if (!user) throw new Error('Dev user not found')
+  const organizationId = 'u45w22ft66ymiaa19ohs7m9f' // Marki Corp (primary dev org)
+  const userId = user.id
+  console.log(`Org ${organizationId}, user ${userId}`)
+
+  const opHours = await database.query.OperatingHours.findFirst({
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.subjectType, 'organization')),
+    columns: { timezone: true },
+  })
+  if (opHours?.timezone && opHours.timezone !== 'UTC') {
+    throw new Error(`Expected dev org timezone 'UTC', got '${opHours.timezone}'`)
+  }
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const createdRecordIds: string[] = []
+
+  try {
+    // ══════════════════════════════════════════════════════════════════════
+    // 1. Invariant B — a one-off work order (already carries its auto-created first visit)
+    //    gains a second visit via paste.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('1: one-off work order gains a 2nd visit via paste (invariant B)')
+    const wo1 = await handler.create('work_order', {
+      work_order_title: '[paste-visits-verify] one-off invariant B',
+    })
+    createdRecordIds.push(wo1.recordId)
+    const before1 = await getVisitsSorted(wo1.instance.id)
+    check('setup: work order auto-creates exactly 1 visit', before1.length === 1, before1.length)
+
+    const item1 = slot(5, 9)
+    const result1 = await pasteVisits({
+      organizationId,
+      userId,
+      items: [{ workOrderInstanceId: wo1.instance.id, ...item1 }],
+    })
+    check(
+      'paste onto a one-off WO: 1 created, 0 failures',
+      result1.created.length === 1 && result1.failures.length === 0,
+      result1
+    )
+    const after1 = await getVisitsSorted(wo1.instance.id)
+    check(
+      'one-off WO now carries 2 visits (extra visit allowed)',
+      after1.length === 2,
+      after1.length
+    )
+    const pasted1 = after1.find((v) => v.id === result1.created[0]?.id)
+    check(
+      'pasted visit is a plain rule-less row, scheduled',
+      pasted1?.recurrenceRuleId === null &&
+        pasted1?.occurrenceDate === null &&
+        pasted1?.status === 'scheduled',
+      pasted1
+    )
+    check(
+      'pasted visit times match the item',
+      pasted1?.startTime?.getTime() === item1.startTime.getTime() &&
+        pasted1?.endTime?.getTime() === item1.endTime.getTime()
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 2. Pasting a copy of a series visit produces a plain rule-less clone on the same WO.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('2: paste of a series visit → plain rule-less clone')
+    const todayIso = isoDate(new Date())
+    const anchorIso = addDaysToIso(todayIso, 3)
+    const weekday = weekdayOfIso(anchorIso)
+    const wo2 = await handler.create('work_order', {
+      work_order_title: '[paste-visits-verify] series clone',
+    })
+    createdRecordIds.push(wo2.recordId)
+    const weekly: RecurrencePattern = { frequency: 'weekly', interval: 1, weekdays: [weekday] }
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo2.instance.id,
+      pattern: weekly,
+      template: { startMinute: 600, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: anchorIso,
+    })
+    const seriesRows = (await getVisitsSorted(wo2.instance.id)).filter((r) => r.recurrenceRuleId)
+    check(
+      'setup: series materialized at least 1 occurrence',
+      seriesRows.length >= 1,
+      seriesRows.length
+    )
+    const sourceOccurrence = seriesRows[0]!
+    check(
+      'setup: source occurrence carries series identity',
+      sourceOccurrence.recurrenceRuleId !== null && sourceOccurrence.occurrenceDate !== null
+    )
+
+    // Copy the occurrence's time onto a NEW slot on the same day (avoids colliding with the
+    // template row itself; invariant B allows the overlap regardless).
+    const cloneStart = new Date(sourceOccurrence.startTime!.getTime() + 2 * 60 * 60_000)
+    const cloneEnd = new Date(sourceOccurrence.endTime!.getTime() + 2 * 60 * 60_000)
+    const result2 = await pasteVisits({
+      organizationId,
+      userId,
+      items: [{ workOrderInstanceId: wo2.instance.id, startTime: cloneStart, endTime: cloneEnd }],
+    })
+    check(
+      'paste of series-visit time: 1 created, 0 failures',
+      result2.created.length === 1 && result2.failures.length === 0,
+      result2
+    )
+    const clone2 = result2.created[0]
+    check(
+      'clone is rule-less (recurrenceRuleId/occurrenceDate null) — a manual clone, not a detachment',
+      clone2?.recurrenceRuleId === null && clone2?.occurrenceDate === null,
+      clone2
+    )
+    check('clone lands on the same work order', clone2?.workOrderId === wo2.instance.id)
+    check('clone is scheduled', clone2?.status === 'scheduled')
+    check(
+      'original series occurrence untouched (still carries its series identity)',
+      (await getVisitsSorted(wo2.instance.id)).find((r) => r.id === sourceOccurrence.id)
+        ?.recurrenceRuleId === sourceOccurrence.recurrenceRuleId
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 3. Assignee semantics: retarget (explicit userId) / clear (explicit null) / omitted key
+    //    (nothing to "keep" on a brand-new row — lands unassigned, same as `addVisit` today).
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('3: assignee semantics — retarget / clear / omitted')
+    const wo3 = await handler.create('work_order', {
+      work_order_title: '[paste-visits-verify] assignee semantics',
+    })
+    createdRecordIds.push(wo3.recordId)
+    const retargetSlot = slot(6, 9)
+    const clearSlot = slot(6, 11)
+    const omittedSlot = slot(6, 13)
+    const result3 = await pasteVisits({
+      organizationId,
+      userId,
+      items: [
+        { workOrderInstanceId: wo3.instance.id, ...retargetSlot, assigneeUserId: userId },
+        { workOrderInstanceId: wo3.instance.id, ...clearSlot, assigneeUserId: null },
+        { workOrderInstanceId: wo3.instance.id, ...omittedSlot },
+      ],
+    })
+    check(
+      'assignee-semantics batch: 3 created, 0 failures',
+      result3.created.length === 3 && result3.failures.length === 0,
+      result3
+    )
+    check(
+      'retarget: assigneeUserId set to the given userId',
+      result3.created[0]?.assigneeUserId === userId
+    )
+    check('clear: assigneeUserId explicitly null', result3.created[1]?.assigneeUserId === null)
+    check(
+      'omitted key: fresh row lands unassigned (nothing to keep)',
+      result3.created[2]?.assigneeUserId === null
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 4. Partial failure: a bogus workOrderInstanceId among valid items lands in `failures` at
+    //    its own index; the other items still commit.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('4: partial failure — bogus item alongside valid items')
+    const wo4 = await handler.create('work_order', {
+      work_order_title: '[paste-visits-verify] partial failure',
+    })
+    createdRecordIds.push(wo4.recordId)
+    const validSlotA = slot(7, 9)
+    const validSlotB = slot(7, 11)
+    const result4 = await pasteVisits({
+      organizationId,
+      userId,
+      items: [
+        { workOrderInstanceId: wo4.instance.id, ...validSlotA },
+        { workOrderInstanceId: 'this-work-order-does-not-exist', ...slot(7, 10) },
+        { workOrderInstanceId: wo4.instance.id, ...validSlotB },
+      ],
+    })
+    check('partial failure: 2 created', result4.created.length === 2, result4)
+    check('partial failure: exactly 1 failure', result4.failures.length === 1, result4.failures)
+    check(
+      'partial failure: failure is at index 1',
+      result4.failures[0]?.index === 1,
+      result4.failures
+    )
+    check(
+      'partial failure: failure carries a message',
+      typeof result4.failures[0]?.message === 'string' && result4.failures[0]!.message.length > 0,
+      result4.failures[0]
+    )
+    check(
+      'partial failure: the two valid items landed on the work order',
+      // `status: 'scheduled'` alone doesn't distinguish these — the auto-created initial visit
+      // is ALSO 'scheduled' despite carrying no time (`ensureVisitForWorkOrder`'s default).
+      // `startTime` is what actually flips on a real schedule write.
+      (await getVisitsSorted(wo4.instance.id)).filter((v) => v.startTime !== null).length === 2
+    )
+  } finally {
+    console.log(`Cleanup: deleting ${createdRecordIds.length} verify records`)
+    for (const recordId of createdRecordIds.reverse()) {
+      try {
+        await handler.delete(recordId as never)
+      } catch (err) {
+        console.log(`  cleanup failed for ${recordId}:`, err instanceof Error ? err.message : err)
+      }
+    }
+  }
+
+  console.log(`\n${pass}/${pass + fail} passed`)
+  process.exit(fail > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -32,6 +32,13 @@ export {
 } from './my-schedule'
 export { dispatchVisit, getWorkOrderLabel } from './notify'
 export type {
+  PasteVisitItem,
+  PasteVisitsFailure,
+  PasteVisitsInput,
+  PasteVisitsResult,
+} from './paste-visits'
+export { pasteVisits } from './paste-visits'
+export type {
   AddMyAdhocQcItemInput,
   AddMyQcItemPhotoInput,
   CreateQcItemTemplateInput,

--- a/packages/lib/src/dispatch/paste-visits.ts
+++ b/packages/lib/src/dispatch/paste-visits.ts
@@ -1,0 +1,94 @@
+// packages/lib/src/dispatch/paste-visits.ts
+//
+// Copy/paste's server write (plans/dispatch/37c-calendar-create-copy-paste.md §4.4). The ONE
+// deliberate batch endpoint in dispatch (§5.2's client-loop convention covers everything
+// else) — the paste-options dialog is the confirm, so a single round trip has to return the
+// created+failed summary the dialog reports.
+
+import type { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { addVisit } from './visit-mutations'
+
+type WorkOrderVisitRow = typeof schema.WorkOrderVisit.$inferSelect
+
+const logger = createScopedLogger('dispatch:paste-visits')
+
+/** One pasted visit — a target work order + the slot it lands on (§4.2 offset math already
+ * applied client-side) + assignee intent (§4.3: omit to leave the fresh row unassigned,
+ * `null` to explicitly clear, a userId to retarget). */
+export interface PasteVisitItem {
+  /** EntityInstance id of the work order (not the RecordId). */
+  workOrderInstanceId: string
+  startTime: Date
+  endTime: Date
+  assigneeUserId?: string | null
+}
+
+/** Input for {@link pasteVisits}. */
+export interface PasteVisitsInput {
+  organizationId: string
+  userId: string
+  items: PasteVisitItem[]
+  /** Realtime echo-suppression — the acting client's own socket id (07 §B.4). */
+  excludeSocketId?: string
+}
+
+/** One item's failure, keyed by its position in {@link PasteVisitsInput.items} so the client
+ * can map it back to the row it pasted. */
+export interface PasteVisitsFailure {
+  index: number
+  message: string
+}
+
+/** Result of {@link pasteVisits} — partial success is expected, not an error. */
+export interface PasteVisitsResult {
+  created: WorkOrderVisitRow[]
+  failures: PasteVisitsFailure[]
+}
+
+/**
+ * Paste N visits (§4.4) — a sequential loop over {@link addVisit}, the existing paste
+ * primitive: it always inserts a new rule-less row (`recurrenceRuleId: null`,
+ * `occurrenceDate: null` — a paste is a manual clone, even of a series visit) and, since every
+ * item here carries `startTime`/`endTime`, commits through `scheduleVisit` in the same call so
+ * each row gets full scheduling semantics (mirror, status roll-up, sequence enrollment,
+ * realtime broadcast) — landing at `status: 'scheduled'` without this function forcing it.
+ *
+ * Deliberately NOT wrapped in a DB transaction (plan 31 §D): the pool-scoped field-change hooks
+ * `addVisit`/`scheduleVisit` trigger would go blind inside one. Items are independent rows, so
+ * partial success is acceptable — a bad item (e.g. a stale `workOrderInstanceId`) is collected
+ * as a failure and the rest still land; there's nothing to compensate/roll back.
+ */
+export async function pasteVisits(input: PasteVisitsInput): Promise<PasteVisitsResult> {
+  const { organizationId, userId, items, excludeSocketId } = input
+
+  const created: WorkOrderVisitRow[] = []
+  const failures: PasteVisitsFailure[] = []
+
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index]
+    if (!item) continue
+    try {
+      const visit = await addVisit({
+        organizationId,
+        userId,
+        workOrderInstanceId: item.workOrderInstanceId,
+        startTime: item.startTime,
+        endTime: item.endTime,
+        assigneeUserId: item.assigneeUserId,
+        excludeSocketId,
+      })
+      created.push(visit)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.warn('Failed to paste visit', {
+        error,
+        index,
+        workOrderInstanceId: item.workOrderInstanceId,
+      })
+      failures.push({ index, message })
+    }
+  }
+
+  return { created, failures }
+}

--- a/packages/ui/src/components/event-calendar/agenda-view.tsx
+++ b/packages/ui/src/components/event-calendar/agenda-view.tsx
@@ -8,16 +8,17 @@ import { useMemo } from 'react'
 
 import { AgendaDaysToShow } from './constants'
 import { EventItem } from './event-item'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 import type { EventCalendarItem, RenderEvent } from './types'
 import { getAgendaEventsForDay } from './utils'
 
 interface AgendaViewProps<T extends EventCalendarItem = EventCalendarItem> {
   currentDate: Date
   events: T[]
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
 }
 
 export function AgendaView<T extends EventCalendarItem = EventCalendarItem>({
@@ -25,15 +26,16 @@ export function AgendaView<T extends EventCalendarItem = EventCalendarItem>({
   events,
   onEventSelect,
   renderEvent,
-  selectedEventId,
+  selectedIds,
 }: AgendaViewProps<T>) {
+  const selection = useCalendarSelection()
   const days = useMemo(() => {
     return Array.from({ length: AgendaDaysToShow }, (_, i) => addDays(new Date(currentDate), i))
   }, [currentDate])
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   const hasEvents = days.some((day) => getAgendaEventsForDay(events, day).length > 0)
@@ -61,16 +63,25 @@ export function AgendaView<T extends EventCalendarItem = EventCalendarItem>({
                 {format(day, 'd MMM, EEEE')}
               </span>
               <div className='mt-6 space-y-2'>
-                {/* Site 1/1: agenda card. */}
+                {/* Site 1/1: agenda card. Agenda bypasses `DraggableEvent` (no drag/resize here),
+                    so it registers into the marquee's chip registry itself — selection rendering
+                    only, agenda is a plain list with no spatial marquee. */}
                 {dayEvents.map((event) => (
-                  <EventItem
+                  <div
                     key={event.id}
-                    event={event}
-                    view='agenda'
-                    onClick={(e) => handleEventClick(event, e)}
-                    isSelected={event.id === selectedEventId}
-                    renderEvent={renderEvent}
-                  />
+                    ref={(node) => {
+                      if (node) selection.registerChip(event.id, node)
+                      return () => selection.unregisterChip(event.id)
+                    }}
+                    data-event-id={event.id}>
+                    <EventItem
+                      event={event}
+                      view='agenda'
+                      onClick={(e) => handleEventClick(event, e)}
+                      isSelected={selectedIds?.has(event.id) ?? false}
+                      renderEvent={renderEvent}
+                    />
+                  </div>
                 ))}
               </div>
             </div>

--- a/packages/ui/src/components/event-calendar/day-resource-group.tsx
+++ b/packages/ui/src/components/event-calendar/day-resource-group.tsx
@@ -31,12 +31,12 @@ interface DayResourceGroupProps<T extends EventCalendarItem = EventCalendarItem>
   hours: Date[]
   events: T[]
   backgroundEvents: BackgroundEvent[]
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date, resourceId: string) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Current-time line position (% of the hour grid) — shared math, rendered only when `isToday(day)`. */
   currentTimePosition: number
   /** Px-per-hour of the timed grid — the zoomable vertical scale (scroll-stable; changes only on zoom). */
@@ -71,7 +71,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
   onSlotClick,
   onEventResize,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   currentTimePosition,
   hourHeight,
 }: DayResourceGroupProps<T>) {
@@ -89,7 +89,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   return (
@@ -142,7 +142,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
                     onResize={onEventResize}
                     cellSize={hourHeight}
                     renderEvent={renderEvent}
-                    isSelected={p.event.id === selectedEventId}
+                    isSelected={selectedIds?.has(p.event.id) ?? false}
                   />
                 </div>
               </div>

--- a/packages/ui/src/components/event-calendar/day-view.tsx
+++ b/packages/ui/src/components/event-calendar/day-view.tsx
@@ -16,27 +16,50 @@ import { EventItem } from './event-item'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
 import { HourGutter } from './hour-gutter'
 import { positionEventsForDay } from './position-events'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 import type { BackgroundEvent, EventCalendarItem, RenderEvent } from './types'
-import { isMultiDayEvent } from './utils'
+import { getAllEventsForDay, isMultiDayEvent } from './utils'
 
 interface DayViewProps<T extends EventCalendarItem = EventCalendarItem> {
   currentDate: Date
   events: T[]
   backgroundEvents?: BackgroundEvent[]
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Px-per-hour of the timed grid — the zoomable vertical scale. Defaults to `WeekCellsHeight`. */
   hourHeight?: number
 }
 
-/** Big date header — day + month bold, year regular, weekday name below. */
-export function DayViewHeader({ currentDate }: { currentDate: Date }) {
+/**
+ * Big date header — day + month bold, year regular, weekday name below. Also the day-grab
+ * target for plain (non-resource) day view: cmd/ctrl+click toggles every event on `currentDate`
+ * into the selection (§3.2) — resource/timeline day views grab from their own in-stream date
+ * labels instead (they render one per visible day, this header only ever shows one).
+ */
+export function DayViewHeader<T extends EventCalendarItem = EventCalendarItem>({
+  currentDate,
+  events,
+}: {
+  currentDate: Date
+  /** Omit when this header isn't paired with a plain day view's event list (e.g. resource/timeline
+   * pass their own date labels through instead) — the header then renders without day-grab. */
+  events?: T[]
+}) {
+  const selection = useCalendarSelection()
   return (
-    <div className='px-2 py-3 sm:px-4'>
+    <div
+      className='px-2 py-3 sm:px-4'
+      onClick={(e) =>
+        events &&
+        selection.handleDayGrab(
+          getAllEventsForDay(events, currentDate).map((ev) => ev.id),
+          e
+        )
+      }>
       <div className='text-2xl font-bold'>
         {format(currentDate, 'd MMMM')}{' '}
         <span className='font-normal'>{format(currentDate, 'yyyy')}</span>
@@ -54,7 +77,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
   onSlotClick,
   onEventResize,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   hourHeight = WeekCellsHeight,
 }: DayViewProps<T>) {
   const hours = useMemo(() => {
@@ -99,7 +122,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   const showAllDaySection = allDayEvents.length > 0
@@ -131,7 +154,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
                     allDayLane
                     isFirstDay={isFirstDay}
                     isLastDay={isLastDay}
-                    isSelected={event.id === selectedEventId}
+                    isSelected={selectedIds?.has(event.id) ?? false}
                     renderEvent={renderEvent}>
                     <div>{event.title}</div>
                   </EventItem>
@@ -181,7 +204,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
                   onResize={onEventResize}
                   cellSize={hourHeight}
                   renderEvent={renderEvent}
-                  isSelected={positioned.event.id === selectedEventId}
+                  isSelected={selectedIds?.has(positioned.event.id) ?? false}
                 />
               </div>
             </div>

--- a/packages/ui/src/components/event-calendar/draggable-event.tsx
+++ b/packages/ui/src/components/event-calendar/draggable-event.tsx
@@ -12,6 +12,7 @@ import { useCalendarDnd } from './calendar-dnd-context'
 import { TimelineHourWidth, WeekCellsHeight } from './constants'
 import { EventItem } from './event-item'
 import { useEventResize } from './hooks/use-event-resize'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 import { TimeRangePill } from './time-range-pill'
 import type { CalendarView, EventCalendarItem, RenderEvent } from './types'
 
@@ -59,6 +60,7 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
   cellSize,
 }: DraggableEventProps<T>) {
   const { activeId, hasDropHandler } = useCalendarDnd()
+  const selection = useCalendarSelection()
   const elementRef = useRef<HTMLDivElement>(null)
   const [dragHandlePosition, setDragHandlePosition] = useState<{ x: number; y: number } | null>(
     null
@@ -145,7 +147,13 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
       ref={(node) => {
         setNodeRef(node)
         elementRef.current = node
+        // Self-registers into the marquee's hit-test registry (React 19 callback-ref cleanup —
+        // runs before the next call or on unmount, so a re-render's re-invocation never leaves a
+        // stale entry behind).
+        if (node) selection.registerChip(event.id, node)
+        return () => selection.unregisterChip(event.id)
       }}
+      data-event-id={event.id}
       style={style}
       className={cn('group/event touch-none', canResize && 'relative')}>
       <EventItem
@@ -170,11 +178,13 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
             {/* Invisible left drag zone — resizes the start time. */}
             <div
               {...getResizeHandleProps('start')}
+              data-marquee-ignore
               className='absolute inset-y-0 left-0 w-2 cursor-ew-resize touch-none'
             />
             {/* Invisible right drag zone — resizes the end time. */}
             <div
               {...getResizeHandleProps('end')}
+              data-marquee-ignore
               className='absolute inset-y-0 right-0 w-2 cursor-ew-resize touch-none'
             />
           </>
@@ -183,11 +193,13 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
             {/* Invisible top drag zone — resizes the start time. */}
             <div
               {...getResizeHandleProps('start')}
+              data-marquee-ignore
               className='absolute inset-x-0 top-0 h-2 cursor-ns-resize touch-none'
             />
             {/* Invisible bottom drag zone — resizes the end time. */}
             <div
               {...getResizeHandleProps('end')}
+              data-marquee-ignore
               className='absolute inset-x-0 bottom-0 h-2 cursor-ns-resize touch-none'
             />
           </>

--- a/packages/ui/src/components/event-calendar/droppable-cell.tsx
+++ b/packages/ui/src/components/event-calendar/droppable-cell.tsx
@@ -6,6 +6,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { useDroppable } from '@dnd-kit/core'
 
 import { useCalendarDnd } from './calendar-dnd-context'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 
 interface DroppableCellProps {
   id: string
@@ -16,7 +17,7 @@ interface DroppableCellProps {
   resourceId?: string
   children?: React.ReactNode
   className?: string
-  onClick?: () => void
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void
 }
 
 export function DroppableCell({
@@ -29,6 +30,7 @@ export function DroppableCell({
   onClick,
 }: DroppableCellProps) {
   const { activeEvent } = useCalendarDnd()
+  const { reportHoveredSlot } = useCalendarSelection()
 
   const { setNodeRef, isOver } = useDroppable({
     id,
@@ -39,6 +41,7 @@ export function DroppableCell({
     <div
       ref={setNodeRef}
       onClick={onClick}
+      onPointerEnter={() => reportHoveredSlot({ date, time, resourceId })}
       className={cn(
         'data-dragging:bg-accent flex h-full flex-col overflow-hidden px-0.5 py-1 sm:px-1',
         className

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -57,6 +57,12 @@ import { DayView, DayViewHeader } from './day-view'
 import { HorizontalTimelineView } from './horizontal-timeline-view'
 import { MonthView } from './month-view'
 import { ResourceTimelineView } from './resource-timeline-view'
+import {
+  CalendarSelectionProvider,
+  type HoveredSlot,
+  useCalendarSelectionEngine,
+} from './selection/calendar-selection-context'
+import { MarqueeOverlay } from './selection/marquee-overlay'
 import type {
   BackgroundEvent,
   CalendarResource,
@@ -69,6 +75,10 @@ import { WeekView } from './week-view'
 
 /** Module-level default — an inline `{}` default would break `TimelineDaySection`'s memo every render. */
 const DefaultHourWindow: TimelineHourWindow = { start: StartHour, end: EndHour }
+
+/** Module-level default — an inline `[]` default would recompute `selectedIdSet` (and the
+ * selection engine's live snapshot) every render for consumers that don't control selection. */
+const EmptySelectedEventIds: string[] = []
 
 const clampHourHeight = (px: number) =>
   Math.min(WeekCellsHeightMax, Math.max(WeekCellsHeightMin, px))
@@ -125,10 +135,23 @@ export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarI
   onGridHourHeightChange?: (px: number) => void
   backgroundEvents?: BackgroundEvent[]
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (its detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
-  onEventClick?: (event: T) => void
+  /** Controlled multi-selection (plan `37c-calendar-create-copy-paste.md` §3) — the grid
+   * interprets every selection gesture (plain/cmd/shift-click, marquee, day-grab, Escape) and
+   * reports the result here; the consumer owns the actual state. Selected chips draw the
+   * in-color ring. */
+  selectedEventIds?: string[]
+  /** Fires whenever a selection gesture changes the set — always the full replacement set. */
+  onSelectionChange?: (ids: string[]) => void
+  /** Fires on a PLAIN chip click only (no modifier) — cmd/ctrl/shift-clicks manage selection
+   * instead and never call this, so a popover/drawer wired here never opens on a modifier-click.
+   * Carries the mouse event so a consumer can read further modifiers if it needs to. */
+  onEventClick?: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date, resourceId?: string) => void
+  /** Plan 37c §4 — when provided, every hovered-slot report (pointer-enter on a day/time cell)
+   * also lands here, mirroring the selection engine's own internal ref. Lets a consumer read
+   * "what's hovered right now" for a Cmd+V paste anchor or a right-click menu without owning a
+   * selection engine of its own. Ref-only, never causes a re-render. */
+  hoveredSlotRef?: React.MutableRefObject<HoveredSlot | null>
   /** The calendar never mutates — every write (move or resize) round-trips through these. */
   onEventDrop?: (event: T, newStart: Date, newEnd: Date, resourceId?: string) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
@@ -165,7 +188,8 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   onGridHourHeightChange,
   backgroundEvents,
   renderEvent,
-  selectedEventId,
+  selectedEventIds = EmptySelectedEventIds,
+  onSelectionChange,
   onEventClick,
   onSlotClick,
   onEventDrop,
@@ -173,7 +197,20 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   hideToolbar,
   isNonWorkingDay,
   className,
+  hoveredSlotRef,
 }: EventCalendarProps<T>) {
+  // Memoized once here (not per-view) — every view flips its `isSelected` check from id-equality
+  // to `selectedIds.has(event.id)` against this single Set.
+  const selectedIdSet = useMemo(() => new Set(selectedEventIds), [selectedEventIds])
+  // Built once (see `useCalendarSelectionEngine`'s doc comment) so both this component's own
+  // gesture handlers below AND the provider it renders further down share the same instance.
+  const selectionEngine = useCalendarSelectionEngine(
+    events,
+    selectedIdSet,
+    onSelectionChange,
+    hoveredSlotRef
+  )
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (
@@ -184,13 +221,18 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
         return
       }
 
+      if (e.key === 'Escape' && selectedIdSet.size > 0) {
+        selectionEngine.clearSelection()
+        return
+      }
+
       const match = VIEW_OPTIONS.find((o) => o.shortcut.toLowerCase() === e.key.toLowerCase())
       if (match) onViewChange(match.value)
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [onViewChange])
+  }, [onViewChange, selectedIdSet, selectionEngine])
 
   // Month view is a continuous week stream (see MonthView): the "viewed month" is the month
   // of the anchor date's week END, and month nav lands on the target month's top-left cell.
@@ -219,16 +261,26 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
     else onDateChange(new Date())
   }
 
-  const handleEventSelect = (event: T) => onEventClick?.(event)
+  // Central gesture interpretation (§3.2) — every view's chip `onClick` funnels here through
+  // `onEventSelect`, passing its raw mouse event through instead of branching modifiers itself.
+  // `onEventClick` (the popover/drawer hook) only fires for a genuinely plain click.
+  const handleEventSelect = (event: T, e: React.MouseEvent) => {
+    const isPlainClick = selectionEngine.handleChipClick(event.id, e)
+    if (isPlainClick) onEventClick?.(event, e)
+  }
 
   const handleSlotClick = (startTime: Date, resourceId?: string) => {
-    const minutes = startTime.getMinutes()
-    const remainder = minutes % 15
-    if (remainder !== 0) {
-      startTime.setMinutes(remainder < 7.5 ? minutes - remainder : minutes + (15 - remainder))
-      startTime.setSeconds(0, 0)
-    }
-    onSlotClick?.(startTime, resourceId)
+    // "Click away to deselect": a non-empty selection swallows this click entirely — it must
+    // never also open a slot-create affordance. An empty selection falls through unchanged.
+    selectionEngine.handleEmptyClick(() => {
+      const minutes = startTime.getMinutes()
+      const remainder = minutes % 15
+      if (remainder !== 0) {
+        startTime.setMinutes(remainder < 7.5 ? minutes - remainder : minutes + (15 - remainder))
+        startTime.setSeconds(0, 0)
+      }
+      onSlotClick?.(startTime, resourceId)
+    })
   }
 
   const [rangeFrom, rangeTo] = useMemo<[Date, Date]>(() => {
@@ -269,7 +321,10 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
         : `${format(start, 'MMM')} - ${format(end, 'MMM yyyy')}`
     }
     if (view === 'day' || view === 'resource' || view === 'timeline') {
-      return <DayViewHeader currentDate={date} />
+      // Day-grab (§3.2) only wires here for the plain 'day' view — resource/timeline render
+      // their own per-day date labels in-stream (possibly several visible at once) and grab
+      // from those instead, so this shared title stays a non-interactive header for them.
+      return <DayViewHeader currentDate={date} events={view === 'day' ? events : undefined} />
     }
     if (view === 'agenda') {
       const start = date
@@ -279,7 +334,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
         : `${format(start, 'MMM')} - ${format(end, 'MMM yyyy')}`
     }
     return format(date, 'MMMM yyyy')
-  }, [date, view, weekStartsOn])
+  }, [date, view, weekStartsOn, events])
 
   const dndContext = useCalendarDnd()
   const withinAmbientProvider = dndContext.isCalendarDndContext
@@ -534,7 +589,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             onEventSelect={handleEventSelect}
             onSlotClick={handleSlotClick}
             renderEvent={renderEvent}
-            selectedEventId={selectedEventId}
+            selectedIds={selectedIdSet}
             onDateChange={onDateChange}
             onVisibleRangeChange={onRangeChange}
             isNonWorkingDay={isNonWorkingDay}
@@ -550,7 +605,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             onSlotClick={handleSlotClick}
             onEventResize={onEventResize}
             renderEvent={renderEvent}
-            selectedEventId={selectedEventId}
+            selectedIds={selectedIdSet}
             onDateChange={onDateChange}
             onVisibleRangeChange={onRangeChange}
             hourHeight={effectiveGridHourHeight}
@@ -565,7 +620,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             onSlotClick={handleSlotClick}
             onEventResize={onEventResize}
             renderEvent={renderEvent}
-            selectedEventId={selectedEventId}
+            selectedIds={selectedIdSet}
             hourHeight={effectiveGridHourHeight}
           />
         )}
@@ -582,7 +637,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
               onSlotClick={handleSlotClick}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
-              selectedEventId={selectedEventId}
+              selectedIds={selectedIdSet}
               onDateChange={onDateChange}
               onVisibleRangeChange={onRangeChange}
               hourHeight={effectiveGridHourHeight}
@@ -602,9 +657,10 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
               railWidth={timelineRailWidth}
               onRailWidthChange={onTimelineRailWidthChange}
               onEventSelect={handleEventSelect}
+              onSlotClick={handleSlotClick}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
-              selectedEventId={selectedEventId}
+              selectedIds={selectedIdSet}
               onDateChange={onDateChange}
               onVisibleRangeChange={onRangeChange}
             />
@@ -615,7 +671,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             events={events}
             onEventSelect={handleEventSelect}
             renderEvent={renderEvent}
-            selectedEventId={selectedEventId}
+            selectedIds={selectedIdSet}
           />
         )}
       </div>
@@ -641,13 +697,16 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
           '--grid-all-day-padding-top': `${GridAllDayPaddingTop}px`,
         } as CSSProperties
       }>
-      {withinAmbientProvider ? (
-        body
-      ) : (
-        <CalendarDndProvider onEventDrop={onEventDrop} renderEvent={renderEvent}>
-          {body}
-        </CalendarDndProvider>
-      )}
+      <CalendarSelectionProvider engine={selectionEngine}>
+        {withinAmbientProvider ? (
+          body
+        ) : (
+          <CalendarDndProvider onEventDrop={onEventDrop} renderEvent={renderEvent}>
+            {body}
+          </CalendarDndProvider>
+        )}
+        <MarqueeOverlay containerRef={viewContainerRef} engine={selectionEngine} />
+      </CalendarSelectionProvider>
     </div>
   )
 }

--- a/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
@@ -37,6 +37,7 @@ import {
   TimelineRailWidthMax,
   TimelineRailWidthMin,
 } from './constants'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 import { StickyRailShadow } from './sticky-rail-shadow'
 import { type DayLaneAssignment, TimelineDaySection } from './timeline-day-section'
 import type {
@@ -112,11 +113,14 @@ interface HorizontalTimelineViewProps<T extends EventCalendarItem = EventCalenda
    * Omit for internal state. Drags report commits via `onRailWidthChange`. */
   railWidth?: number
   onRailWidthChange?: (px: number) => void
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
+  /** Fires when a quarter-hour cell is clicked (§7 slot-create; also the empty-space clear-first
+   * ordering the shared `onSlotClick` handler already enforces). */
+  onSlotClick?: (startTime: Date, resourceId?: string) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Fires when a user scroll settles on a new leftmost day. */
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) day window — consumers fetch this. */
@@ -159,12 +163,14 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   railWidth: railWidthProp,
   onRailWidthChange,
   onEventSelect,
+  onSlotClick,
   onEventResize,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   onDateChange,
   onVisibleRangeChange,
 }: HorizontalTimelineViewProps<T>) {
+  const selection = useCalendarSelection()
   const scrollRef = useRef<HTMLDivElement>(null)
   const [snapEnabled, setSnapEnabled] = useState(true)
   const [viewportHeight, setViewportHeight] = useState(0)
@@ -567,6 +573,9 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
     onPointerUp: endRailResize,
     onPointerCancel: endRailResize,
     onDoubleClick: resetRail,
+    // Landmine for the marquee's pointerdown guard — a class-based selector here would be
+    // fragile against the two render sites (corner + body segments) below.
+    'data-marquee-ignore': true,
   }
 
   // ── visible window → consumer fetch range ────────────────────────────────
@@ -727,6 +736,14 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
               return (
                 <div
                   key={`label-${v.key}`}
+                  // Cmd/ctrl+click the day header grabs the whole day's events into the
+                  // selection (§3.2), across every worker row.
+                  onClick={(e) =>
+                    selection.handleDayGrab(
+                      getAllEventsForDay(events, day).map((ev) => ev.id),
+                      e
+                    )
+                  }
                   className='text-muted-foreground/80 border-border/70 absolute flex items-center justify-center gap-1.5 border-l text-sm'
                   style={{
                     top: 0,
@@ -791,6 +808,7 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
                       onPointerUp={endBorderZoom}
                       onPointerCancel={endBorderZoom}
                       onDoubleClick={() => resetZoom(v.index, hourIndex)}
+                      data-marquee-ignore
                       className='absolute inset-y-0 z-10 w-[7px] cursor-ew-resize touch-none select-none'
                       style={{ left: `calc(${(hourIndex / windowHours) * 100}% - 3px)` }}
                     />
@@ -855,9 +873,10 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
               bodyHeight={bodyHeight}
               laneMapsByResource={laneMapsByResource}
               onEventSelect={onEventSelect}
+              onSlotClick={onSlotClick}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
-              selectedEventId={selectedEventId}
+              selectedIds={selectedIds}
               nowPosition={nowPosition}
             />
           ))}

--- a/packages/ui/src/components/event-calendar/index.ts
+++ b/packages/ui/src/components/event-calendar/index.ts
@@ -60,6 +60,8 @@ export { MonthView } from './month-view'
 // Positioning util (day/week/resource share this — see position-events.ts)
 export { type PositionedEvent, positionEventsForDay } from './position-events'
 export { ResourceTimelineView } from './resource-timeline-view'
+// Selection (plan 37c) — the hovered-slot shape consumers thread into `hoveredSlotRef`.
+export type { HoveredSlot } from './selection/calendar-selection-context'
 export { TimeRangePill } from './time-range-pill'
 // Types
 export type {

--- a/packages/ui/src/components/event-calendar/month-view.tsx
+++ b/packages/ui/src/components/event-calendar/month-view.tsx
@@ -29,6 +29,7 @@ import {
 import { DraggableEvent } from './draggable-event'
 import { DroppableCell } from './droppable-cell'
 import { EventItem } from './event-item'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 import type { EventCalendarItem, RenderEvent } from './types'
 import { getAllEventsForDay, getEventsForDay, getSpanningEventsForDay, sortEvents } from './utils'
 
@@ -45,11 +46,11 @@ interface MonthWeekRowProps<T extends EventCalendarItem = EventCalendarItem> {
   slotCount: number
   events: T[]
   weekStartAt: (index: number) => Date
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   isNonWorkingDay?: (date: Date) => boolean
 }
 
@@ -68,14 +69,15 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
   onEventSelect,
   onSlotClick,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   isNonWorkingDay,
 }: MonthWeekRowProps<T>) {
   const weekStart = weekStartAt(index)
+  const selection = useCalendarSelection()
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   return (
@@ -107,12 +109,23 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
             <DroppableCell
               id={cellId}
               date={day}
-              onClick={() => {
+              onClick={(e) => {
+                // Cmd/ctrl+click the cell (background or date label — the whole cell shares one
+                // click target) grabs the whole day's events into the selection (§3.2) instead
+                // of starting a slot-create click.
+                if (
+                  selection.handleDayGrab(
+                    allEvents.map((ev) => ev.id),
+                    e
+                  )
+                ) {
+                  return
+                }
                 const startTime = new Date(day)
                 startTime.setHours(DefaultStartHour, 0, 0)
                 onSlotClick?.(startTime)
               }}>
-              <div className='mt-1 flex items-center gap-1'>
+              <div className='mt-1 flex select-none items-center gap-1'>
                 {isFirstOfMonth && (
                   <span className='text-sm font-semibold'>{format(day, 'MMM')}</span>
                 )}
@@ -142,7 +155,7 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
                         view='month'
                         isFirstDay={isFirstDay}
                         isLastDay={isLastDay}
-                        isSelected={event.id === selectedEventId}
+                        isSelected={selectedIds?.has(event.id) ?? false}
                         renderEvent={renderEvent}>
                         <div className='invisible' aria-hidden={true}>
                           {!event.allDay && <span>{format(new Date(event.start), 'h:mm')} </span>}
@@ -160,7 +173,7 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
                       onClick={(e) => handleEventClick(event, e)}
                       isFirstDay={isFirstDay}
                       isLastDay={isLastDay}
-                      isSelected={event.id === selectedEventId}
+                      isSelected={selectedIds?.has(event.id) ?? false}
                       renderEvent={renderEvent}
                     />
                   )
@@ -193,7 +206,7 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
                               view='month'
                               isFirstDay={isSameDay(day, new Date(event.start))}
                               isLastDay={isSameDay(day, new Date(event.end))}
-                              isSelected={event.id === selectedEventId}
+                              isSelected={selectedIds?.has(event.id) ?? false}
                               renderEvent={renderEvent}
                             />
                           ))}
@@ -218,11 +231,11 @@ interface MonthViewProps<T extends EventCalendarItem = EventCalendarItem> {
   currentDate: Date
   events: T[]
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Fires when a user scroll settles on a new month — with the stream's top-left day. */
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) week window — consumers fetch this. */
@@ -246,7 +259,7 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
   onEventSelect,
   onSlotClick,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   onDateChange,
   onVisibleRangeChange,
   isNonWorkingDay,
@@ -461,7 +474,7 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
               onEventSelect={onEventSelect}
               onSlotClick={onSlotClick}
               renderEvent={renderEvent}
-              selectedEventId={selectedEventId}
+              selectedIds={selectedIds}
               isNonWorkingDay={isNonWorkingDay}
             />
           ))}

--- a/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
@@ -30,6 +30,7 @@ import { DayResourceGroup } from './day-resource-group'
 import { EventItem } from './event-item'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
 import { HourGutter } from './hour-gutter'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 import { StickyRailShadow } from './sticky-rail-shadow'
 import type { BackgroundEvent, CalendarResource, EventCalendarItem, RenderEvent } from './types'
 import { getAllEventsForDay, isMultiDayEvent } from './utils'
@@ -62,12 +63,12 @@ interface ResourceTimelineViewProps<T extends EventCalendarItem = EventCalendarI
   backgroundEvents?: BackgroundEvent[]
   /** How many days to aim for across the viewport — 1 (Day mode) or e.g. 3 (Timeline mode). */
   desiredDays?: number
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date, resourceId: string) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Fires when a user scroll settles on a new leftmost day. */
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) day window — consumers fetch this. */
@@ -103,11 +104,12 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
   onSlotClick,
   onEventResize,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   onDateChange,
   onVisibleRangeChange,
   hourHeight = WeekCellsHeight,
 }: ResourceTimelineViewProps<T>) {
+  const selection = useCalendarSelection()
   const scrollRef = useRef<HTMLDivElement>(null)
   const gutterRef = useRef<HTMLDivElement>(null)
   const [dayWidth, setDayWidth] = useState(480)
@@ -152,7 +154,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   const virtualizer = useVirtualizer({
@@ -353,6 +355,14 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
               return (
                 <div
                   key={`label-${v.key}`}
+                  // Cmd/ctrl+click the day header grabs the whole day's events into the
+                  // selection (§3.2), across every worker column.
+                  onClick={(e) =>
+                    selection.handleDayGrab(
+                      getAllEventsForDay(events, day).map((ev) => ev.id),
+                      e
+                    )
+                  }
                   className='text-muted-foreground/80 border-border/70 absolute flex items-center justify-center gap-1.5 border-l text-sm'
                   style={{
                     top: 0,
@@ -442,7 +452,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
                               allDayLane
                               isFirstDay={isFirstDay}
                               isLastDay={isLastDay}
-                              isSelected={event.id === selectedEventId}
+                              isSelected={selectedIds?.has(event.id) ?? false}
                               renderEvent={renderEvent}>
                               <div
                                 className={cn('truncate', !isFirstDay && 'invisible')}
@@ -490,7 +500,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
               onSlotClick={onSlotClick}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
-              selectedEventId={selectedEventId}
+              selectedIds={selectedIds}
               currentTimePosition={currentTimePosition}
               hourHeight={hourHeight}
             />

--- a/packages/ui/src/components/event-calendar/selection/calendar-selection-context.tsx
+++ b/packages/ui/src/components/event-calendar/selection/calendar-selection-context.tsx
@@ -1,0 +1,278 @@
+// packages/ui/src/components/event-calendar/selection/calendar-selection-context.tsx
+
+'use client'
+
+import { createContext, type ReactNode, useContext, useRef } from 'react'
+import type { EventCalendarItem } from '../types'
+
+/** The slot last hovered by the pointer — feeds paste-anchor/context-menu targeting (later
+ * phases). Ref-only, never a re-render (see `reportHoveredSlot`). */
+export interface HoveredSlot {
+  date: Date
+  time?: number
+  resourceId?: string
+}
+
+/** The subset of a DOM/pointer event `handleChipClick`/`handleDayGrab` read — both a React
+ * `MouseEvent` and a raw `PointerEvent` satisfy this, so the engine works from either. */
+interface ModifierEvent {
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey?: boolean
+  preventDefault?: () => void
+  stopPropagation?: () => void
+}
+
+/**
+ * The generic multi-selection engine for one `EventCalendar` mount (plan
+ * `37c-calendar-create-copy-paste.md` §3) — one stable object per calendar instance holding the
+ * selection anchor, the chip DOM registry (for marquee hit-testing), and the hovered-slot ref,
+ * plus the gesture-interpretation functions every view/chip calls into instead of branching
+ * modifier keys itself. Selection STATE is NOT owned here — `selectedIds` is a live snapshot of
+ * the consumer's controlled `selectedEventIds` prop; every mutator ends by calling
+ * `emitSelection`/`onSelectionChange`, never by writing local state.
+ */
+export interface CalendarSelectionEngine {
+  hoveredSlotRef: React.MutableRefObject<HoveredSlot | null>
+  /** Pointer-enter feed for the hovered slot — ref-only, zero re-renders. */
+  reportHoveredSlot: (slot: HoveredSlot) => void
+  /** Chips self-register their DOM element on mount (`draggable-event.tsx`, agenda's chip) so
+   * the marquee can hit-test their client rects without a React re-render per frame. */
+  registerChip: (id: string, element: HTMLElement) => void
+  unregisterChip: (id: string) => void
+  getChipRegistry: () => Map<string, HTMLElement>
+  /** Live snapshot of the controlled `selectedEventIds` prop, for callers (the marquee) that
+   * need to read it outside a render (inside a rAF-throttled pointer handler). */
+  getSelectedIds: () => ReadonlySet<string>
+  /** Replaces the selection wholesale — the marquee's per-frame commit. */
+  emitSelection: (ids: Set<string>) => void
+  /** Clears the selection and resets the shift-range anchor (Escape, click-away). */
+  clearSelection: () => void
+  /** Marks a marquee release so the very next `handleEmptyClick` swallows the synthetic click
+   * the browser fires on release instead of treating it as a plain empty-space click. */
+  markMarqueeReleased: () => void
+  /**
+   * Central click-gesture interpretation for a chip (§3.2): plain click replaces the selection
+   * and moves the anchor; cmd/ctrl+click toggles membership; shift+click extends a chronological
+   * range from the anchor (cmd+shift unions it into the existing selection). Returns `true` only
+   * for a plain click — callers use that to decide whether to also fire `onEventClick`
+   * (cmd/shift clicks manage selection only, never open a popover/drawer).
+   */
+  handleChipClick: (id: string, e: ModifierEvent) => boolean
+  /**
+   * Click on empty grid space: a non-empty selection is cleared and the click is swallowed
+   * (never reaches `onEmpty`, i.e. never opens a slot-create affordance); an empty selection
+   * forwards to `onEmpty` unchanged. Also swallows the synthetic click that follows a marquee
+   * release (`markMarqueeReleased`).
+   */
+  handleEmptyClick: (onEmpty: () => void) => void
+  /**
+   * Cmd/ctrl+click a day (month cell/date label, or a week/day/timeline day header): toggles
+   * every id in `dayEventIds` into the selection — all-selected clears them, otherwise unions
+   * them in. No-ops (returns `false`) without a held modifier, so callers can fall through to
+   * whatever else that click target does.
+   */
+  handleDayGrab: (dayEventIds: string[], e: ModifierEvent) => boolean
+}
+
+function noop() {}
+
+/** Default context value — only used if a consumer reads `useCalendarSelection` outside an
+ * `EventCalendar` mount (defensive; `EventCalendar` always provides a real engine). */
+const DefaultEngine: CalendarSelectionEngine = {
+  hoveredSlotRef: { current: null },
+  reportHoveredSlot: noop,
+  registerChip: noop,
+  unregisterChip: noop,
+  getChipRegistry: () => new Map(),
+  getSelectedIds: () => new Set(),
+  emitSelection: noop,
+  clearSelection: noop,
+  markMarqueeReleased: noop,
+  handleChipClick: () => true,
+  handleEmptyClick: (onEmpty) => onEmpty(),
+  handleDayGrab: () => false,
+}
+
+const CalendarSelectionContext = createContext<CalendarSelectionEngine>(DefaultEngine)
+
+/** Reads the current calendar's selection engine — chips, droppable cells, and day headers call
+ * this to register/report/grab without threading selection props through every view. */
+export function useCalendarSelection(): CalendarSelectionEngine {
+  return useContext(CalendarSelectionContext)
+}
+
+/**
+ * Builds the selection engine for one `EventCalendar` mount. Called directly by
+ * `EventCalendarInner` (not by `CalendarSelectionProvider`) so the shell's own
+ * `handleEventSelect`/`handleSlotClick` can call the SAME engine instance its descendants read
+ * via context — a component can't consume a context it renders below itself, so the engine has
+ * to be created above the provider, then handed to it.
+ *
+ * The returned object's identity is stable for the component's lifetime (built once via a lazy
+ * ref) — every live input (`events`, `selectedIds`, `onSelectionChange`) is threaded through
+ * refs instead, so context consumers never re-render merely because the engine "changed".
+ */
+export function useCalendarSelectionEngine<T extends EventCalendarItem>(
+  events: T[],
+  selectedIds: ReadonlySet<string>,
+  onSelectionChange?: (ids: string[]) => void,
+  /** Plan 37c §4 — an optional consumer-owned ref that mirrors every hovered-slot report
+   * alongside the engine's own internal one. Lets the paste anchor live OUTSIDE the calendar
+   * (a board-level Cmd+V handler, a right-click menu) without threading hover state through
+   * `onSelectionChange`-shaped props. Written in the same call as the internal ref — never a
+   * re-render on its own. */
+  externalHoveredSlotRef?: React.MutableRefObject<HoveredSlot | null>
+): CalendarSelectionEngine {
+  const selectedIdsRef = useRef(selectedIds)
+  selectedIdsRef.current = selectedIds
+  const onSelectionChangeRef = useRef(onSelectionChange)
+  onSelectionChangeRef.current = onSelectionChange
+  const externalHoveredSlotRefRef = useRef(externalHoveredSlotRef)
+  externalHoveredSlotRefRef.current = externalHoveredSlotRef
+  const anchorIdRef = useRef<string | null>(null)
+  const registryRef = useRef<Map<string, HTMLElement>>(new Map())
+  const hoveredSlotRef = useRef<HoveredSlot | null>(null)
+  const marqueeSuppressRef = useRef(false)
+
+  // Sorted-by-start once per `events` identity change — shift-range needs a stable chronological
+  // order, and re-sorting inside every click handler would be wasteful for large event lists.
+  const sortedCacheRef = useRef<{ events: T[]; sorted: EventCalendarItem[] }>({
+    events,
+    sorted: [],
+  })
+  if (sortedCacheRef.current.events !== events) {
+    sortedCacheRef.current = {
+      events,
+      sorted: [...events].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()),
+    }
+  }
+  const sortedEventsRef = useRef<EventCalendarItem[]>(sortedCacheRef.current.sorted)
+  sortedEventsRef.current = sortedCacheRef.current.sorted
+
+  const engineRef = useRef<CalendarSelectionEngine | null>(null)
+  if (!engineRef.current) {
+    const emit = (next: Set<string>) => onSelectionChangeRef.current?.(Array.from(next))
+
+    engineRef.current = {
+      hoveredSlotRef,
+      reportHoveredSlot: (slot) => {
+        hoveredSlotRef.current = slot
+        if (externalHoveredSlotRefRef.current) externalHoveredSlotRefRef.current.current = slot
+      },
+      registerChip: (id, element) => {
+        registryRef.current.set(id, element)
+      },
+      unregisterChip: (id) => {
+        registryRef.current.delete(id)
+      },
+      getChipRegistry: () => registryRef.current,
+      getSelectedIds: () => selectedIdsRef.current,
+      emitSelection: emit,
+      clearSelection: () => {
+        anchorIdRef.current = null
+        emit(new Set())
+      },
+      markMarqueeReleased: () => {
+        marqueeSuppressRef.current = true
+        // The synthetic click a release produces dispatches before timers run, so this disarms
+        // the swallow immediately after that click's window — a release over a chip or outside
+        // the grid (whose click never reaches `handleEmptyClick`) can't leave the flag armed to
+        // eat the NEXT legitimate empty-space click.
+        setTimeout(() => {
+          marqueeSuppressRef.current = false
+        }, 0)
+      },
+      handleChipClick: (id, e) => {
+        const isMeta = e.metaKey || e.ctrlKey
+        const isShift = Boolean(e.shiftKey)
+        const current = selectedIdsRef.current
+
+        if (isShift) {
+          // Prevents the browser's native text-selection drag artifact shift-click can trigger.
+          e.preventDefault?.()
+          const anchor = anchorIdRef.current
+          const sorted = sortedEventsRef.current
+          const anchorIndex = anchor ? sorted.findIndex((ev) => ev.id === anchor) : -1
+          const clickedIndex = sorted.findIndex((ev) => ev.id === id)
+          const rangeIds =
+            anchorIndex === -1 || clickedIndex === -1
+              ? [id]
+              : sorted
+                  .slice(
+                    Math.min(anchorIndex, clickedIndex),
+                    Math.max(anchorIndex, clickedIndex) + 1
+                  )
+                  .map((ev) => ev.id)
+          const next = isMeta ? new Set(current) : new Set<string>()
+          for (const rangeId of rangeIds) next.add(rangeId)
+          // Finder semantics: the anchor stays put across repeated shift-clicks so the range
+          // always measures from the FIRST click, not the last.
+          if (!anchor) anchorIdRef.current = id
+          emit(next)
+          return false
+        }
+
+        if (isMeta) {
+          const next = new Set(current)
+          if (next.has(id)) next.delete(id)
+          else next.add(id)
+          anchorIdRef.current = id
+          emit(next)
+          return false
+        }
+
+        anchorIdRef.current = id
+        emit(new Set([id]))
+        return true
+      },
+      handleEmptyClick: (onEmpty) => {
+        if (marqueeSuppressRef.current) {
+          marqueeSuppressRef.current = false
+          return
+        }
+        if (selectedIdsRef.current.size > 0) {
+          anchorIdRef.current = null
+          emit(new Set())
+          return
+        }
+        onEmpty()
+      },
+      handleDayGrab: (dayEventIds, e) => {
+        if (!(e.metaKey || e.ctrlKey)) return false
+        e.preventDefault?.()
+        e.stopPropagation?.()
+        if (dayEventIds.length === 0) return true
+        const current = selectedIdsRef.current
+        const allSelected = dayEventIds.every((id) => current.has(id))
+        const next = new Set(current)
+        for (const id of dayEventIds) {
+          if (allSelected) next.delete(id)
+          else next.add(id)
+        }
+        anchorIdRef.current = dayEventIds[dayEventIds.length - 1] ?? anchorIdRef.current
+        emit(next)
+        return true
+      },
+    }
+  }
+
+  return engineRef.current
+}
+
+/**
+ * Publishes an already-built engine (see `useCalendarSelectionEngine`) to descendants — a thin
+ * context wrapper, not the state owner, so `EventCalendarInner` can use the same engine instance
+ * for its own gesture handlers that this provider hands to the view tree below it.
+ */
+export function CalendarSelectionProvider({
+  engine,
+  children,
+}: {
+  engine: CalendarSelectionEngine
+  children: ReactNode
+}) {
+  return (
+    <CalendarSelectionContext.Provider value={engine}>{children}</CalendarSelectionContext.Provider>
+  )
+}

--- a/packages/ui/src/components/event-calendar/selection/marquee-overlay.tsx
+++ b/packages/ui/src/components/event-calendar/selection/marquee-overlay.tsx
@@ -1,0 +1,151 @@
+// packages/ui/src/components/event-calendar/selection/marquee-overlay.tsx
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { CalendarSelectionEngine } from './calendar-selection-context'
+
+interface MarqueeRect {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+/** Pixel distance a pointer must travel past `pointerdown` before a marquee gesture begins —
+ * below this the gesture resolves as a plain click (§3.2's "plain click empty space" row). */
+const MarqueeThresholdPx = 4
+
+/** Elements a marquee must never start on — chips (`data-event-id`, or any `<button>`, since
+ * every chip renders as one), the vertical-grid hour-zoom handles, and any other interactive
+ * control. Landmines whose class-based selector would be fragile (timeline zoom/rail strips,
+ * resize handles) opt out via `data-marquee-ignore` instead. */
+const MarqueeIgnoreSelector =
+  '[data-marquee-ignore], [data-event-id], [data-hour-zoom-handle], button, a, input, textarea, select, [role="button"]'
+
+interface MarqueeOverlayProps {
+  /** The view container `EventCalendar` already scopes its zoom/pan gestures to — the marquee's
+   * pointerdown delegates from the same root so it composes with those gestures for free. */
+  containerRef: React.RefObject<HTMLElement | null>
+  engine: CalendarSelectionEngine
+}
+
+/**
+ * Pointerdown-and-drag rectangle select over empty grid space (§3.2). A fixed-position overlay —
+ * chip rects come from `getBoundingClientRect`, already in viewport space, so no scroll-offset
+ * bookkeeping is needed. The hit-test runs at most once per animation frame while dragging.
+ */
+export function MarqueeOverlay({ containerRef, engine }: MarqueeOverlayProps) {
+  const [rect, setRect] = useState<MarqueeRect | null>(null)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `engine` is a stable per-mount identity (see useCalendarSelectionEngine)
+  useEffect(() => {
+    const root = containerRef.current
+    if (!root) return
+
+    let active = false
+    let startX = 0
+    let startY = 0
+    let unionBase = new Set<string>()
+    let raf = 0
+    let latest: { x: number; y: number } | null = null
+
+    const computeRect = (x: number, y: number): MarqueeRect => ({
+      left: Math.min(startX, x),
+      top: Math.min(startY, y),
+      width: Math.abs(x - startX),
+      height: Math.abs(y - startY),
+    })
+
+    const hitTest = (r: MarqueeRect) => {
+      const hits = new Set<string>()
+      const right = r.left + r.width
+      const bottom = r.top + r.height
+      for (const [id, element] of engine.getChipRegistry()) {
+        const chipRect = element.getBoundingClientRect()
+        if (
+          chipRect.left < right &&
+          chipRect.right > r.left &&
+          chipRect.top < bottom &&
+          chipRect.bottom > r.top
+        ) {
+          hits.add(id)
+        }
+      }
+      return hits
+    }
+
+    const flush = () => {
+      raf = 0
+      if (!active || !latest) return
+      const r = computeRect(latest.x, latest.y)
+      setRect(r)
+      const hits = hitTest(r)
+      const next = new Set(unionBase)
+      for (const id of hits) next.add(id)
+      engine.emitSelection(next)
+    }
+
+    const scheduleFlush = () => {
+      if (raf) return
+      raf = requestAnimationFrame(flush)
+    }
+
+    const onMove = (e: PointerEvent) => {
+      if (!active) {
+        if (Math.hypot(e.clientX - startX, e.clientY - startY) < MarqueeThresholdPx) return
+        active = true
+        // Base to union hits into — the pre-drag selection when cmd/ctrl is held at drag start,
+        // otherwise a marquee replaces the selection outright.
+        unionBase = e.metaKey || e.ctrlKey ? new Set(engine.getSelectedIds()) : new Set<string>()
+      }
+      latest = { x: e.clientX, y: e.clientY }
+      scheduleFlush()
+    }
+
+    const endGesture = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+      if (raf) cancelAnimationFrame(raf)
+      raf = 0
+      // The commit already happened progressively (each `flush` calls `emitSelection`) — release
+      // just ends the visual rectangle and, if a gesture actually occurred, arms the swallow so
+      // the browser's post-release synthetic click doesn't also fire a slot-create/deselect.
+      if (active) engine.markMarqueeReleased()
+      active = false
+      setRect(null)
+    }
+    const onUp = () => endGesture()
+
+    const onDown = (e: PointerEvent) => {
+      if (e.button !== 0) return
+      const target = e.target
+      if (target instanceof HTMLElement && target.closest(MarqueeIgnoreSelector)) return
+      startX = e.clientX
+      startY = e.clientY
+      active = false
+      window.addEventListener('pointermove', onMove)
+      window.addEventListener('pointerup', onUp)
+      window.addEventListener('pointercancel', onUp)
+    }
+
+    root.addEventListener('pointerdown', onDown)
+    return () => {
+      root.removeEventListener('pointerdown', onDown)
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [containerRef])
+
+  if (!rect) return null
+
+  return (
+    <div
+      className='pointer-events-none fixed z-40 rounded-sm border border-primary bg-primary/10'
+      style={{ left: rect.left, top: rect.top, width: rect.width, height: rect.height }}
+    />
+  )
+}

--- a/packages/ui/src/components/event-calendar/timeline-day-section.tsx
+++ b/packages/ui/src/components/event-calendar/timeline-day-section.tsx
@@ -60,11 +60,13 @@ interface TimelineDaySectionProps<T extends EventCalendarItem = EventCalendarIte
    * spans), so the outer key must include the day, not just the resource.
    */
   laneMapsByResource: Map<string, DayLaneAssignment>
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
+  /** Fires when a quarter-hour cell is clicked (§7 slot-create). */
+  onSlotClick?: (startTime: Date, resourceId?: string) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Fraction (0..1) of the hour window "now" falls at — `null` when outside the window. */
   nowPosition: number | null
 }
@@ -102,9 +104,10 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
   bodyHeight,
   laneMapsByResource,
   onEventSelect,
+  onSlotClick,
   onEventResize,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   nowPosition,
 }: TimelineDaySectionProps<T>) {
   const day = dayAt(index)
@@ -129,7 +132,7 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   return (
@@ -198,7 +201,7 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                     height={TimelineLaneHeight - LaneGap}
                     onResize={onEventResize}
                     renderEvent={renderEvent}
-                    isSelected={event.id === selectedEventId}
+                    isSelected={selectedIds?.has(event.id) ?? false}
                     isFirstDay={isFirstDay}
                     isLastDay={isLastDay}
                   />
@@ -249,7 +252,7 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                       height={TimelineLaneHeight - LaneGap}
                       onResize={onEventResize}
                       renderEvent={renderEvent}
-                      isSelected={event.id === selectedEventId}
+                      isSelected={selectedIds?.has(event.id) ?? false}
                       isFirstDay={!isClampedStart}
                       isLastDay={!isClampedEnd}
                     />
@@ -264,7 +267,9 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
               windowEndHour={windowEnd}
             />
 
-            {/* Quarter-hour droppable cells — no `onClick`, click-to-create is out of scope. */}
+            {/* Quarter-hour droppable cells — clicking one reports the already-computed
+                day/quarterHourTime/resourceId as a slot click (§7), through the same
+                clear-selection-first ordering every other view's cells share. */}
             {Array.from({ length: slotCount }, (_, slot) => {
               const quarterHourTime = windowStart + slot * 0.25
               return (
@@ -281,6 +286,13 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                     date={day}
                     time={quarterHourTime}
                     resourceId={resource.id}
+                    onClick={() => {
+                      const hours = Math.floor(quarterHourTime)
+                      const minutes = Math.round((quarterHourTime - hours) * 60)
+                      const startTime = new Date(day)
+                      startTime.setHours(hours, minutes, 0, 0)
+                      onSlotClick?.(startTime, resource.id)
+                    }}
                   />
                 </div>
               )

--- a/packages/ui/src/components/event-calendar/week-day-column.tsx
+++ b/packages/ui/src/components/event-calendar/week-day-column.tsx
@@ -30,12 +30,12 @@ interface WeekDayColumnProps<T extends EventCalendarItem = EventCalendarItem> {
   hours: Date[]
   events: T[]
   backgroundEvents: BackgroundEvent[]
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Current-time line position (% of the hour grid) — shared math, rendered only when `isToday(day)`. */
   currentTimePosition: number
   /** Px-per-hour of the timed grid — the zoomable vertical scale (scroll-stable; changes only on zoom). */
@@ -68,7 +68,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
   onSlotClick,
   onEventResize,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   currentTimePosition,
   hourHeight,
 }: WeekDayColumnProps<T>) {
@@ -89,7 +89,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   return (
@@ -127,7 +127,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
               onResize={onEventResize}
               cellSize={hourHeight}
               renderEvent={renderEvent}
-              isSelected={p.event.id === selectedEventId}
+              isSelected={selectedIds?.has(p.event.id) ?? false}
             />
           </div>
         </div>

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -30,6 +30,7 @@ import {
 import { EventItem } from './event-item'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
 import { HourGutter } from './hour-gutter'
+import { useCalendarSelection } from './selection/calendar-selection-context'
 import { StickyRailShadow } from './sticky-rail-shadow'
 import type { BackgroundEvent, EventCalendarItem, RenderEvent } from './types'
 import { getAllEventsForDay, isMultiDayEvent } from './utils'
@@ -53,12 +54,12 @@ interface WeekViewProps<T extends EventCalendarItem = EventCalendarItem> {
   events: T[]
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
   backgroundEvents?: BackgroundEvent[]
-  onEventSelect: (event: T) => void
+  onEventSelect: (event: T, e: React.MouseEvent) => void
   onSlotClick?: (startTime: Date) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
-  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
-  selectedEventId?: string | null
+  /** Selected event ids (multi-selection, §3) — draws the in-color ring on membership. */
+  selectedIds?: ReadonlySet<string>
   /** Fires when a user scroll settles on a new leftmost day. */
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) day window — consumers fetch this. */
@@ -92,11 +93,12 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
   onSlotClick,
   onEventResize,
   renderEvent,
-  selectedEventId,
+  selectedIds,
   onDateChange,
   onVisibleRangeChange,
   hourHeight = WeekCellsHeight,
 }: WeekViewProps<T>) {
+  const selection = useCalendarSelection()
   const scrollRef = useRef<HTMLDivElement>(null)
   const gutterRef = useRef<HTMLDivElement>(null)
   const [dayWidth, setDayWidth] = useState(160)
@@ -132,7 +134,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
     e.stopPropagation()
-    onEventSelect(event)
+    onEventSelect(event, e)
   }
 
   const virtualizer = useVirtualizer({
@@ -319,6 +321,14 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
               return (
                 <div
                   key={`label-${v.key}`}
+                  // Cmd/ctrl+click the day header grabs the whole day's events into the
+                  // selection (§3.2) — the label carries no other click behavior.
+                  onClick={(e) =>
+                    selection.handleDayGrab(
+                      getAllEventsForDay(events, day).map((ev) => ev.id),
+                      e
+                    )
+                  }
                   className='text-muted-foreground/80 absolute flex items-center justify-center gap-1.5 text-sm'
                   style={{
                     top: 0,
@@ -375,7 +385,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
                         allDayLane
                         isFirstDay={isFirstDay}
                         isLastDay={isLastDay}
-                        isSelected={event.id === selectedEventId}
+                        isSelected={selectedIds?.has(event.id) ?? false}
                         renderEvent={renderEvent}>
                         <div
                           className={cn('truncate', !isFirstDay && 'invisible')}
@@ -420,7 +430,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
               onSlotClick={onSlotClick}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
-              selectedEventId={selectedEventId}
+              selectedIds={selectedIds}
               currentTimePosition={currentTimePosition}
               hourHeight={hourHeight}
             />


### PR DESCRIPTION
Implements **plan 37c phases 1–3** ([plans/dispatch/37c-calendar-create-copy-paste.md](../blob/main/plans/dispatch/37c-calendar-create-copy-paste.md)). Phases 4–6 (group drag-move, slot-create popover, schedule surface) follow in separate PRs.

## Phase 1 — generic multi-selection (`@auxx/ui` event-calendar)

- Breaking prop contract: `selectedEventId` → `selectedEventIds: string[]` + `onSelectionChange`; `onEventClick` now carries the mouse event. All three consumers (board, schedule, records) updated.
- New `selection/` layer: stable per-mount selection engine (anchor, chip DOM registry, hovered-slot ref) + rAF-throttled marquee overlay.
- Gestures per §3.2: plain click (select + popover as today), cmd/ctrl+click toggle (no popover), shift+click chronological range (Finder semantics, cmd+shift unions), marquee on empty space (4px threshold, cmd unions), day-grab (cmd+click day cell/header), Escape clears, click-away clears **before** any slot-create can fire.
- Fixes the plan's discovered gap: `onSlotClick` was never wired into the horizontal timeline view.

## Phase 2 — board bulk-action bar

- `board-bulk-bar.tsx` on the shared `ActionBar`, opens at 2+ selection: **Assign to…** (ActorPicker + Unassigned), **Dispatch**, **Move to backlog**, **Cancel** (destructive, one confirm).
- Board-local bulk runner mirroring `useBulkRunner` (sequential loop, partial-failure summary toast) minus the list-store coupling; exposes `pendingVisitIds` for chip dimming. No new endpoints — loops the existing single-visit mutations; new `assignVisit` optimistic wrapper in `use-board-mutations`.
- Delete/Backspace triggers the bulk-cancel confirm at any non-empty selection.

## Phase 3 — clipboard + copy/paste

- Global unpersisted zustand clipboard; DST-safe offset math (`differenceInCalendarDays`/`addDays`) preserving relative day structure and durations — unit tested (5/5).
- Cmd+C / Cmd+V (paste anchors to the hovered slot) + right-click context menu (chip → Copy, empty cell → Paste here).
- Paste-options dialog: per-item old→new preview, assignee keep/clear/retarget (retarget only when the target is a worker row), keep times vs start-at-slot, editable target date.
- Server: `dispatch.pasteVisits` (`dispatchAdminProcedure`) — the one deliberate batch endpoint; sequential loop over `addVisit` (full scheduling semantics per row), no transaction (plan 31 §D), per-index failure reporting. Optimistic temp-row cache patch on the client.
- Pasted copies of series visits land as plain rule-less visits (`recurrenceRuleId: null`).

## Verification

- `apps/worker/scripts/verify-dispatch-paste-visits.ts` against dev DB: **21/21** (one-off gains 2nd visit, rule-less series clone, assignee keep/clear/retarget, partial failure indexing, cleanup).
- `clipboard-offset.test.ts`: 5/5.
- Browser-driven pass (Chrome DevTools) on the live dev board: all selection gestures, bulk bar + Delete-confirm, assign picker, end-to-end copy→paste (optimistic temp chip settling to the real row), schedule + records surfaces regression-checked. Zero console errors.
- Scoped typechecks: zero errors contributed by touched files in `packages/ui`, `packages/lib`, `apps/web`.

## Manual checklist before merge (feel-dependent)

- [ ] Marquee vs chip-drag coexistence (dnd-kit 8px threshold) feels right in week/day views
- [ ] Timeline view: marquee doesn't fight zoom strips / rail drag / resize handles
- [ ] Group of selected chips: popover suppression on modifier-click feels right in the sticky dock