### PR TITLE
fix(printing): enable document print style by matching entity type slugs

### DIFF
--- a/apps/web/src/components/print/ui/print-column-picker.tsx
+++ b/apps/web/src/components/print/ui/print-column-picker.tsx
@@ -48,7 +48,7 @@ export function PrintColumnPicker({ columns, entityDefinitionId, style }: PrintC
           description='Add at least one below to print.'
         />
       ) : (
-        <SortableList items={selected.map(columnKey)} onReorder={reorder} className='gap-0.5'>
+        <SortableList items={selected.map(columnKey)} onReorder={reorder} className='space-y-0.5'>
           {selected.map((column) => (
             <PrintColumnRow
               key={columnKey(column)}

--- a/apps/web/src/components/print/ui/print-style-scope-page.tsx
+++ b/apps/web/src/components/print/ui/print-style-scope-page.tsx
@@ -3,7 +3,6 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import { DOCUMENT_TYPE_DESCRIPTORS } from '@auxx/lib/documents/client'
 import type { ExportType, PrintStyle } from '@auxx/lib/export/client'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
@@ -17,7 +16,9 @@ interface PrintStyleScopePageProps {
   onStyleChange: (style: PrintStyle) => void
   scope: ExportType
   onScopeChange: (scope: ExportType) => void
-  entityDefinitionId: string
+  /** Whether the entity has a registered document type (quote/invoice) — resolved by the
+   * wizard from the entity's `entityType` slug against `DOCUMENT_TYPE_DESCRIPTORS`. */
+  hasDocumentType: boolean
   /** Present only when opened from the bulk-action bar — pins scope to 'selection'. */
   selectionCount?: number
 }
@@ -35,13 +36,9 @@ export function PrintStyleScopePage({
   onStyleChange,
   scope,
   onScopeChange,
-  entityDefinitionId,
+  hasDocumentType,
   selectionCount,
 }: PrintStyleScopePageProps) {
-  const hasDocumentType = DOCUMENT_TYPE_DESCRIPTORS.some(
-    (d) => d.entityDefinitionId === entityDefinitionId
-  )
-
   const scopeOptions =
     selectionCount != null
       ? [{ value: 'selection', label: `Selected records (${selectionCount})` }]

--- a/apps/web/src/components/print/ui/print-wizard-dialog.tsx
+++ b/apps/web/src/components/print/ui/print-wizard-dialog.tsx
@@ -79,10 +79,12 @@ export function PrintWizardDialog({
 
   // The registered document type for this entity, if any (quote/invoice today) — drives
   // whether the Document style card is enabled and preselects it when entered from a
-  // quote/invoice table (plans/printing/01-unified-print.md §E page 1).
+  // quote/invoice table (plans/printing/01-unified-print.md §E page 1). Descriptors carry the
+  // entityType slug, not the per-org EntityDefinition.id, so match on `resource.entityType`.
+  const entityType = resource?.entityType
   const documentDescriptor = useMemo(
-    () => DOCUMENT_TYPE_DESCRIPTORS.find((d) => d.entityDefinitionId === entityDefinitionId),
-    [entityDefinitionId]
+    () => DOCUMENT_TYPE_DESCRIPTORS.find((d) => d.entityType === entityType),
+    [entityType]
   )
 
   const [page, setPage] = useState<WizardPage>('style-scope')
@@ -229,7 +231,7 @@ export function PrintWizardDialog({
                 onStyleChange={setStyle}
                 scope={scope}
                 onScopeChange={setScope}
-                entityDefinitionId={entityDefinitionId}
+                hasDocumentType={documentDescriptor != null}
                 selectionCount={selection?.recordIds.length}
               />
             </DialogNavPage>

--- a/packages/lib/src/documents/client.ts
+++ b/packages/lib/src/documents/client.ts
@@ -38,8 +38,10 @@ export type PrintOptionField =
 export interface DocumentTypeDescriptor {
   /** Matches `RegisteredDocumentType.id` ('quote' | 'invoice'). */
   id: string
-  /** `EntityDefinition.id` this document type renders records of. */
-  entityDefinitionId: string
+  /** `EntityDefinition.entityType` slug this document type renders records of — NOT the
+   * per-org generated `EntityDefinition.id`; callers resolve/compare via the entity's
+   * `entityType` (client `Resource.entityType`, server `requireCachedEntityDefId`). */
+  entityType: string
   /** Type-specific extras ONLY — `copies`/`collation` are CORE `document` print-config fields
    * the wizard renders for every document type; this carries the rest (invoice's `sortBy`).
    * Values land in `printConfig.document.options`. Empty for quote (P4). */
@@ -48,14 +50,14 @@ export interface DocumentTypeDescriptor {
 
 /**
  * All document types registered for "Document" print style. Single source of truth for
- * id/entityDefinitionId — the server registry (`./registry.ts`) imports this array and merges
+ * id/entityType — the server registry (`./registry.ts`) imports this array and merges
  * it with its `buildPayload`/`Pdf` wiring rather than redeclaring the ids.
  */
 export const DOCUMENT_TYPE_DESCRIPTORS: DocumentTypeDescriptor[] = [
-  { id: 'quote', entityDefinitionId: 'quote', printOptions: [] },
+  { id: 'quote', entityType: 'quote', printOptions: [] },
   {
     id: 'invoice',
-    entityDefinitionId: 'invoice',
+    entityType: 'invoice',
     printOptions: [
       {
         type: 'select',

--- a/packages/lib/src/documents/index.ts
+++ b/packages/lib/src/documents/index.ts
@@ -32,7 +32,7 @@ export {
 export { type RenderPreviewQuotePdfResult, renderPreviewQuotePdf } from './preview-pdf'
 export {
   getDocumentType,
-  getDocumentTypeByEntityDefinitionId,
+  getDocumentTypeByEntityType,
   listDocumentTypes,
   type RegisteredDocumentType,
 } from './registry'

--- a/packages/lib/src/documents/registry.ts
+++ b/packages/lib/src/documents/registry.ts
@@ -21,8 +21,9 @@ import { QuotePdf } from './pdf/quote-pdf'
 export interface RegisteredDocumentType {
   /** Matches `DocumentType` ('quote' | 'invoice') and the client descriptor's `id`. */
   id: string
-  /** `EntityDefinition.id` this document type renders records of. */
-  entityDefinitionId: string
+  /** `EntityDefinition.entityType` slug this document type renders records of — resolve to a
+   * per-org `EntityDefinition.id` via `requireCachedEntityDefId` before comparing against one. */
+  entityType: string
   /** systemAttribute of the last-rendered pdf-asset pointer field (`ensure-pdf.ts`). */
   pointerAttr: string
   buildPayload(params: {
@@ -50,7 +51,7 @@ export interface RegisteredDocumentType {
 
 /** Per-type renderer wiring — the part `./client.ts`'s descriptors can't carry (react-pdf +
  * server-only payload builders). Merged with `DOCUMENT_TYPE_DESCRIPTORS` below so
- * id/entityDefinitionId are defined exactly once. */
+ * id/entityType are defined exactly once. */
 const RENDER_ENTRIES: Array<
   Pick<RegisteredDocumentType, 'id' | 'pointerAttr' | 'buildPayload' | 'Pdf'>
 > = [
@@ -86,7 +87,7 @@ const REGISTRY: Record<string, RegisteredDocumentType> = Object.fromEntries(
     }
     const registered: RegisteredDocumentType = {
       ...entry,
-      entityDefinitionId: descriptor.entityDefinitionId,
+      entityType: descriptor.entityType,
       printOptions: descriptor.printOptions,
     }
     return [entry.id, registered]
@@ -104,11 +105,11 @@ export function listDocumentTypes(): RegisteredDocumentType[] {
 }
 
 /**
- * Look up the registered document type for an entity definition — e.g. a records-page bulk
- * action deciding whether the "Document" print style card should be enabled.
+ * Look up the registered document type for an entity's `entityType` slug — e.g. a
+ * records-page bulk action deciding whether the "Document" print style card should be enabled.
  */
-export function getDocumentTypeByEntityDefinitionId(
-  entityDefinitionId: string
+export function getDocumentTypeByEntityType(
+  entityType: string
 ): RegisteredDocumentType | undefined {
-  return listDocumentTypes().find((d) => d.entityDefinitionId === entityDefinitionId)
+  return listDocumentTypes().find((d) => d.entityType === entityType)
 }

--- a/packages/lib/src/jobs/export/print-records-job.ts
+++ b/packages/lib/src/jobs/export/print-records-job.ts
@@ -10,7 +10,7 @@ import { and, eq } from 'drizzle-orm'
 import { PDFDocument } from 'pdf-lib'
 import type { ReactElement } from 'react'
 import { createElement } from 'react'
-import { getCachedOrgProfile, getCachedResource } from '../../cache'
+import { getCachedOrgProfile, getCachedResource, requireCachedEntityDefId } from '../../cache'
 import type { ConditionGroup } from '../../conditions/types'
 import type { DocumentPdfPayload } from '../../documents/payload'
 import { formatDocDate } from '../../documents/pdf/parts'
@@ -489,9 +489,13 @@ async function renderDocumentPrint(
   if (!documentType) {
     throw new Error(`Unregistered document type: ${documentConfig.documentTypeId}`)
   }
-  if (documentType.entityDefinitionId !== job.entityDefinitionId) {
+  const documentEntityDefId = await requireCachedEntityDefId(
+    organizationId,
+    documentType.entityType
+  )
+  if (documentEntityDefId !== job.entityDefinitionId) {
     throw new Error(
-      `Document type "${documentConfig.documentTypeId}" prints "${documentType.entityDefinitionId}" ` +
+      `Document type "${documentConfig.documentTypeId}" prints "${documentType.entityType}" ` +
         `records, but this print job targets "${job.entityDefinitionId}"`
     )
   }


### PR DESCRIPTION
## Summary
- the print wizard's **Document** style card was permanently disabled (for invoice and quote tables alike): `DOCUMENT_TYPE_DESCRIPTORS` stored the entityType slugs `'quote'`/`'invoice'` in a field named `entityDefinitionId`, while the wizard compared them against the per-org **generated** `EntityDefinition.id` — the `.some()` never matched
- the worker had the same latent bug: `print-records-job.ts`'s guard compared the slug against `job.entityDefinitionId` and would have thrown on every document run once the UI was enabled

## Changes
- `documents/client.ts` + `documents/registry.ts`: rename the descriptor field `entityDefinitionId` → `entityType` (that's what the values are); `getDocumentTypeByEntityDefinitionId` → `getDocumentTypeByEntityType`
- `print-wizard-dialog.tsx`: match descriptors on `resource.entityType`; also fixes Document preselection when opening from an invoice/quote table. Passes a resolved `hasDocumentType` boolean to the style page instead of the raw id
- `print-style-scope-page.tsx`: drop the broken local descriptor lookup, take `hasDocumentType` as a prop
- `print-records-job.ts`: resolve the descriptor slug to the org's real entity definition id via `requireCachedEntityDefId` before the guard comparison

## Testing
- scoped `tsc` on `packages/lib` and `apps/web`: zero errors in touched files (one pre-existing `JobContext` baseline error in lib, present at HEAD)
- biome clean