### PR TITLE
feat(money): batch advance invoicing

### DIFF
--- a/apps/web/src/app/(protected)/app/invoices/page.tsx
+++ b/apps/web/src/app/(protected)/app/invoices/page.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/app/(protected)/app/invoices/page.tsx
 'use client'
 
+import { BatchInvoiceAction } from '~/components/money/billing/batch-invoice-action'
 import { RecordsView } from '~/components/records'
 
 /**
@@ -8,5 +9,7 @@ import { RecordsView } from '~/components/records'
  * Drawer-only (no `[invoiceId]/` detail route, money MI1 build spec §J.6).
  */
 export default function InvoicesPage() {
-  return <RecordsView slug='invoices' basePath='/app/invoices' />
+  return (
+    <RecordsView slug='invoices' basePath='/app/invoices' pageActions={<BatchInvoiceAction />} />
+  )
 }

--- a/apps/web/src/app/(protected)/app/work-orders/page.tsx
+++ b/apps/web/src/app/(protected)/app/work-orders/page.tsx
@@ -1,11 +1,18 @@
 // apps/web/src/app/(protected)/app/work-orders/page.tsx
 'use client'
 
+import { BatchInvoiceAction } from '~/components/money/billing/batch-invoice-action'
 import { RecordsView } from '~/components/records'
 
 /**
  * Work orders page — renders the shared RecordsView for the work orders resource
  */
 export default function WorkOrdersPage() {
-  return <RecordsView slug='work-orders' basePath='/app/work-orders' />
+  return (
+    <RecordsView
+      slug='work-orders'
+      basePath='/app/work-orders'
+      pageActions={<BatchInvoiceAction />}
+    />
+  )
 }

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -392,10 +392,13 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
         <BillingActionDialog
           open={billingOpen}
           onOpenChange={setBillingOpen}
-          workOrderRecordId={recordId}
-          billing={billing}
-          initialVisitIds={[visit.id]}
-          mode={billing.basis === 'fixed_contract' ? 'extra' : billingMode}
+          scope={{
+            kind: 'workOrder',
+            workOrderRecordId: recordId,
+            billing,
+            initialVisitIds: [visit.id],
+            mode: billing.basis === 'fixed_contract' ? 'extra' : billingMode,
+          }}
         />
       </div>
     </ScrollArea>

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -166,8 +166,7 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
       <BillingActionDialog
         open={actionOpen}
         onOpenChange={setActionOpen}
-        workOrderRecordId={recordId}
-        billing={billing}
+        scope={{ kind: 'workOrder', workOrderRecordId: recordId, billing }}
       />
       <BillingPlanDialog
         open={planOpen}
@@ -185,9 +184,7 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
       <BillingActionDialog
         open={extraOpen}
         onOpenChange={setExtraOpen}
-        workOrderRecordId={recordId}
-        billing={billing}
-        mode='extra'
+        scope={{ kind: 'workOrder', workOrderRecordId: recordId, billing, mode: 'extra' }}
       />
     </div>
   )

--- a/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
@@ -198,9 +198,12 @@ export function WorkOrderBillingCard({ recordId, entityInstanceId }: DrawerTabPr
       <BillingActionDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
-        workOrderRecordId={recordId}
-        billing={billing}
-        mode={action.kind === 'create_extra' ? 'extra' : 'primary'}
+        scope={{
+          kind: 'workOrder',
+          workOrderRecordId: recordId,
+          billing,
+          mode: action.kind === 'create_extra' ? 'extra' : 'primary',
+        }}
       />
     </div>
   )

--- a/apps/web/src/components/money/billing/batch-invoice-action.tsx
+++ b/apps/web/src/components/money/billing/batch-invoice-action.tsx
@@ -1,0 +1,26 @@
+// apps/web/src/components/money/billing/batch-invoice-action.tsx
+'use client'
+
+// Toolbar entry point for batch advance invoicing (plans/dispatch/37a-batch-advance-invoicing.md
+// §3, decision #4) — self-contained Button + `BillingActionDialog` in `batch` scope, owning its
+// own open state. Rendered from both `/app/invoices` and `/app/work-orders` (`RecordsView`'s
+// `pageActions` slot).
+
+import { Button } from '@auxx/ui/components/button'
+import { ReceiptText } from 'lucide-react'
+import { useState } from 'react'
+import { BillingActionDialog } from './billing-action-dialog'
+
+export function BatchInvoiceAction() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button size='sm' variant='outline' className='h-7 rounded-lg' onClick={() => setOpen(true)}>
+        <ReceiptText />
+        Batch invoice
+      </Button>
+      <BillingActionDialog open={open} onOpenChange={setOpen} scope={{ kind: 'batch' }} />
+    </>
+  )
+}

--- a/apps/web/src/components/money/billing/batch-invoice-pages.tsx
+++ b/apps/web/src/components/money/billing/batch-invoice-pages.tsx
@@ -1,0 +1,402 @@
+// apps/web/src/components/money/billing/batch-invoice-pages.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { getFieldOperators } from '@auxx/lib/resources/client'
+import type { RecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import type { DateRange } from '@auxx/ui/components/date-range-picker'
+import { DateRangePicker } from '@auxx/ui/components/date-range-picker'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Switch } from '@auxx/ui/components/switch'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
+import { addMonths, endOfMonth, isSameDay, startOfMonth } from 'date-fns'
+import { CheckCircle2, Printer, Receipt, XCircle } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { Condition, ConditionSystemConfig } from '~/components/conditions'
+import { ConditionContainer, ConditionProvider } from '~/components/conditions'
+import { ExportProgressDialog } from '~/components/data-export/ui/export-progress-dialog'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PrintWizardDialog } from '~/components/print/ui/print-wizard-dialog'
+import { useResource, useResourceFields } from '~/components/resources'
+import type { RouterOutputs } from '~/trpc/react'
+import { PreviewRow } from './billing-action-dialog'
+
+type BatchRow = RouterOutputs['money']['previewInvoiceBatch']['rows'][number]
+type BatchRunResult = RouterOutputs['money']['runInvoiceBatch']['results'][number]
+
+/** Batch amounts don't carry a currency code (plan §3 — `previewInvoiceBatch` doesn't return
+ * one); the batch scope is single-org, single-currency in v1, so this mirrors the fallback
+ * `WorkOrderBillingView.currencyCode` default used elsewhere in this dialog. */
+const BATCH_CURRENCY = 'USD'
+
+const BASIS_LABELS: Record<BatchRow['basis'], string> = {
+  fixed_contract: 'Fixed contract',
+  per_visit: 'Per visit',
+  recurring_flat: 'Recurring',
+}
+
+function countLabel(row: BatchRow): string | undefined {
+  if (row.visitCount !== undefined)
+    return `${row.visitCount} visit${row.visitCount === 1 ? '' : 's'}`
+  if (row.occurrenceCount !== undefined) {
+    return `${row.occurrenceCount} occurrence${row.occurrenceCount === 1 ? '' : 's'}`
+  }
+  return undefined
+}
+
+const EMPTY_CONDITIONS: Condition[] = []
+
+interface BatchScopePageProps {
+  range: DateRange
+  onRangeChange: (range: DateRange) => void
+  filters: ConditionGroup[]
+  onFiltersChange: (filters: ConditionGroup[]) => void
+  onCancel: () => void
+  onContinue: () => void
+}
+
+/** Batch page 1 — period + condition-builder scope (plan §3, batch page `scope`). Filters embed
+ * the shared condition system directly (no popover buffering — this is already a dialog page). */
+export function BatchScopePage({
+  range,
+  onRangeChange,
+  filters,
+  onFiltersChange,
+  onCancel,
+  onContinue,
+}: BatchScopePageProps) {
+  const { resource } = useResource('work-orders')
+  const entityDefinitionId = resource?.id
+  const { filterableFields } = useResourceFields(entityDefinitionId)
+
+  const fieldDefinitions = useMemo(
+    () =>
+      filterableFields.map((field) => ({
+        id: field.resourceFieldId ?? field.id,
+        label: field.label,
+        type: field.type,
+        fieldType: field.fieldType,
+        fieldKey: field.key,
+        operators: field.operatorOverrides || getFieldOperators(field),
+        options: field.options,
+      })),
+    [filterableFields]
+  )
+
+  const config: ConditionSystemConfig = useMemo(
+    () => ({
+      mode: 'resource',
+      entityDefinitionId: entityDefinitionId ?? '',
+      fields: fieldDefinitions,
+      allowNesting: false,
+      allowReordering: true,
+      showLogicalOperators: true,
+      showGrouping: true,
+      allowGroupNaming: false,
+      allowGroupCollapse: false,
+      allowGroupReordering: true,
+      showGroupSubtext: false,
+      defaultGroupName: 'Filter',
+      allowVarEditor: false,
+      allowConstantToggle: false,
+      allowCurrentUserPlaceholder: true,
+    }),
+    [fieldDefinitions, entityDefinitionId]
+  )
+
+  const thisMonthStart = startOfMonth(new Date())
+  const nextMonthStart = addMonths(thisMonthStart, 1)
+  const isThisMonth =
+    isSameDay(range.from, thisMonthStart) && isSameDay(range.to, endOfMonth(thisMonthStart))
+  const isNextMonth =
+    isSameDay(range.from, nextMonthStart) && isSameDay(range.to, endOfMonth(nextMonthStart))
+
+  return (
+    <>
+      <div className='space-y-4 p-4'>
+        <FieldPanel orientation='horizontal' defaultLabelWidth={100} className='p-0'>
+          <FieldPanelRow title='Period'>
+            <div className='flex flex-wrap items-center gap-2 px-2 py-1'>
+              <Button
+                type='button'
+                size='sm'
+                variant={isThisMonth ? 'secondary' : 'ghost'}
+                onClick={() =>
+                  onRangeChange({ from: thisMonthStart, to: endOfMonth(thisMonthStart) })
+                }>
+                This month
+              </Button>
+              <Button
+                type='button'
+                size='sm'
+                variant={isNextMonth ? 'secondary' : 'ghost'}
+                onClick={() =>
+                  onRangeChange({ from: nextMonthStart, to: endOfMonth(nextMonthStart) })
+                }>
+                Next month
+              </Button>
+              <DateRangePicker value={range} onChange={onRangeChange} showPresets={false} />
+            </div>
+          </FieldPanelRow>
+        </FieldPanel>
+        <div className='space-y-1.5'>
+          <p className='px-1 text-xs text-muted-foreground'>Filters</p>
+          {entityDefinitionId ? (
+            <ConditionProvider
+              conditions={EMPTY_CONDITIONS}
+              groups={filters}
+              config={config}
+              onConditionsChange={() => {}}
+              onGroupsChange={onFiltersChange}
+              getAvailableFields={() => fieldDefinitions}
+              getFieldDefinition={(id) => fieldDefinitions.find((f) => f.id === id)}>
+              <ConditionContainer
+                emptyStateText='All qualifying work orders will be included — add a filter to narrow'
+                showAddButton
+                showGrouping
+              />
+            </ConditionProvider>
+          ) : (
+            <p className='rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground'>
+              Loading work order fields…
+            </p>
+          )}
+        </div>
+      </div>
+      <DialogFooter>
+        <Button type='button' variant='ghost' size='sm' onClick={onCancel}>
+          Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+        </Button>
+        <Button variant='outline' size='sm' onClick={onContinue} data-dialog-submit>
+          Preview <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+interface BatchPreviewPageProps {
+  rows: BatchRow[]
+  isLoading: boolean
+  selectedIds: Set<RecordId>
+  onToggle: (id: RecordId, checked: boolean) => void
+  onCancel: () => void
+  onGenerate: () => void
+  canGenerate: boolean
+}
+
+/** Batch page 2 — per-work-order checkbox preview (plan §3, batch page `preview`). Excluded
+ * rows (fixed-contract, no custom schedule) render greyed with their reason, no checkbox. */
+export function BatchPreviewPage({
+  rows,
+  isLoading,
+  selectedIds,
+  onToggle,
+  onCancel,
+  onGenerate,
+  canGenerate,
+}: BatchPreviewPageProps) {
+  const includable = rows.filter((row) => !row.excludedReason)
+  const excluded = rows.filter((row) => row.excludedReason)
+  const selectedRows = includable.filter((row) => selectedIds.has(row.workOrderRecordId))
+  const selectedAmount = selectedRows.reduce((sum, row) => sum + row.amount, 0)
+
+  return (
+    <>
+      <div className='space-y-3 p-4'>
+        {!isLoading && rows.length === 0 ? (
+          <p className='rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground'>
+            No work orders have anything due in this period.
+          </p>
+        ) : (
+          <>
+            <TreeRowList
+              items={[...includable, ...excluded]}
+              getKey={(row) => row.workOrderRecordId}
+              loading={isLoading}
+              skeletonCount={4}
+              renderRow={(row) =>
+                row.excludedReason ? (
+                  <TreeRow
+                    rowClassName='opacity-60'
+                    icon={<Receipt className='size-4' />}
+                    title={<span className='text-sm'>{row.contactName ?? 'Work order'}</span>}
+                    secondary={
+                      <span className='text-xs'>
+                        {[BASIS_LABELS[row.basis], row.excludedReason].filter(Boolean).join(' · ')}
+                      </span>
+                    }
+                  />
+                ) : (
+                  <TreeRow
+                    rowClassName='hover:bg-primary-100'
+                    icon={<Receipt className='size-4' />}
+                    title={<span className='text-sm'>{row.contactName ?? 'Work order'}</span>}
+                    secondary={
+                      <span className='text-xs'>
+                        {[
+                          BASIS_LABELS[row.basis],
+                          countLabel(row),
+                          formatCurrency(row.amount, BATCH_CURRENCY),
+                        ]
+                          .filter(Boolean)
+                          .join(' · ')}
+                      </span>
+                    }
+                    trailing={
+                      <Switch
+                        size='xs'
+                        checked={selectedIds.has(row.workOrderRecordId)}
+                        onCheckedChange={(checked) => onToggle(row.workOrderRecordId, checked)}
+                      />
+                    }
+                  />
+                )
+              }
+            />
+            {!isLoading && (
+              <FieldPanel orientation='horizontal' defaultLabelWidth={170} className='p-0'>
+                <PreviewRow
+                  label='Selected'
+                  value={`${selectedRows.length} of ${includable.length}`}
+                />
+                <PreviewRow label='Total' value={formatCurrency(selectedAmount, BATCH_CURRENCY)} />
+              </FieldPanel>
+            )}
+          </>
+        )}
+      </div>
+      <DialogFooter>
+        <Button type='button' variant='ghost' size='sm' onClick={onCancel}>
+          Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+        </Button>
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={!canGenerate}
+          onClick={onGenerate}
+          data-dialog-submit>
+          Generate {selectedRows.length} draft{selectedRows.length === 1 ? '' : 's'}{' '}
+          <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+interface BatchGeneratePageProps {
+  isPending: boolean
+  results: BatchRunResult[] | undefined
+  error: string | undefined
+  rowLabelByWorkOrderId: Map<string, string>
+  invoiceEntityDefinitionId: string | undefined
+  onClose: () => void
+}
+
+/** Batch page 3 — run results (plan §3, batch page `generate`). The "Print…" handoff opens the
+ * unified print wizard pinned to the created invoices' selection scope. */
+export function BatchGeneratePage({
+  isPending,
+  results,
+  error,
+  rowLabelByWorkOrderId,
+  invoiceEntityDefinitionId,
+  onClose,
+}: BatchGeneratePageProps) {
+  const [printOpen, setPrintOpen] = useState(false)
+  const [printJobId, setPrintJobId] = useState<string | null>(null)
+  const [printProgressOpen, setPrintProgressOpen] = useState(false)
+
+  const createdRecordIds = useMemo(() => {
+    if (!results) return []
+    return results.flatMap(
+      (item) => item.invoiceRecordIds ?? (item.invoiceRecordId ? [item.invoiceRecordId] : [])
+    )
+  }, [results])
+
+  return (
+    <>
+      <div className='space-y-3 p-4'>
+        {error ? (
+          <p className='rounded-lg border border-dashed p-4 text-center text-sm text-bad-500'>
+            {error}
+          </p>
+        ) : isPending || !results ? (
+          <p className='rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground'>
+            Generating draft invoices…
+          </p>
+        ) : (
+          <>
+            <FieldPanel orientation='horizontal' defaultLabelWidth={220} className='p-0'>
+              {results.map((item) => (
+                <FieldPanelRow
+                  key={item.workOrderRecordId}
+                  title={rowLabelByWorkOrderId.get(item.workOrderRecordId) ?? 'Work order'}>
+                  <div className='flex min-h-8 items-center gap-2 px-2 text-sm'>
+                    {item.ok ? (
+                      <>
+                        <CheckCircle2 className='size-4 text-good-500' />
+                        <span className='text-muted-foreground'>Draft created</span>
+                      </>
+                    ) : (
+                      <>
+                        <XCircle className='size-4 text-bad-500' />
+                        <span className='text-bad-500'>{item.error ?? 'Failed'}</span>
+                      </>
+                    )}
+                  </div>
+                </FieldPanelRow>
+              ))}
+            </FieldPanel>
+            {createdRecordIds.length > 0 && (
+              <p className='text-xs text-muted-foreground'>
+                {createdRecordIds.length} draft{createdRecordIds.length === 1 ? '' : 's'} created on{' '}
+                <span className='font-medium'>/app/invoices</span>.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+      <DialogFooter>
+        {createdRecordIds.length > 0 && invoiceEntityDefinitionId && (
+          <Button type='button' variant='ghost' size='sm' onClick={() => setPrintOpen(true)}>
+            <Printer />
+            Print…
+          </Button>
+        )}
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={isPending || (!results && !error)}
+          onClick={onClose}
+          data-dialog-submit>
+          Done <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </DialogFooter>
+      {invoiceEntityDefinitionId && printOpen && (
+        <PrintWizardDialog
+          open={printOpen}
+          onOpenChange={setPrintOpen}
+          entityDefinitionId={invoiceEntityDefinitionId}
+          tableId={`entity-${invoiceEntityDefinitionId}`}
+          selection={{ recordIds: createdRecordIds }}
+          onCreated={(jobId) => {
+            setPrintJobId(jobId)
+            setPrintProgressOpen(true)
+          }}
+        />
+      )}
+      {printJobId && (
+        <ExportProgressDialog
+          jobId={printJobId}
+          open={printProgressOpen}
+          onOpenChange={setPrintProgressOpen}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/money/billing/billing-action-dialog.tsx
+++ b/apps/web/src/components/money/billing/billing-action-dialog.tsx
@@ -2,48 +2,78 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import type { RecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
+import type { DateRange } from '@auxx/ui/components/date-range-picker'
 import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
 import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { RadioGroup, RadioGroupItemCard } from '@auxx/ui/components/radio-group'
 import { toastError } from '@auxx/ui/components/toast'
-import { format } from 'date-fns'
+import { addMonths, endOfMonth, format, startOfMonth } from 'date-fns'
 import { CalendarClock, CircleDollarSign, Percent, ReceiptText } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { useResource } from '~/components/resources'
 import { BaseType } from '~/components/workflow/types'
 import { api } from '~/trpc/react'
-import type { WorkOrderBillingView } from './types'
+import { BatchGeneratePage, BatchPreviewPage, BatchScopePage } from './batch-invoice-pages'
+import { EMPTY_WORK_ORDER_BILLING, type WorkOrderBillingView } from './types'
 
-type Page = 'choose' | 'review'
+type Page = 'choose' | 'review' | 'scope' | 'preview' | 'generate'
 type FixedChoice = 'remaining' | 'percentage' | 'fixed' | `installment:${string}`
+
+/**
+ * Discriminated scope for the shared billing dialog (plans/dispatch/37a-batch-advance-invoicing.md
+ * §3): `workOrder` is the original single-work-order flow (basis-routed invoice creation);
+ * `batch` drives the period + filter → preview → generate advance-invoicing flow across many
+ * work orders. Every `billing.*` read below is gated on `scope.kind === 'workOrder'` — batch
+ * scope carries no `WorkOrderBillingView`.
+ */
+export type BillingDialogScope =
+  | {
+      kind: 'workOrder'
+      workOrderRecordId: RecordId
+      billing: WorkOrderBillingView
+      initialVisitIds?: string[]
+      mode?: 'primary' | 'extra'
+    }
+  | { kind: 'batch'; initialRange?: { from: Date; to: Date } }
 
 interface BillingActionDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  workOrderRecordId: RecordId
-  billing: WorkOrderBillingView
-  initialVisitIds?: string[]
-  mode?: 'primary' | 'extra'
+  scope: BillingDialogScope
 }
 
-/** Route a work order's billing basis to its explicit allocation-backed invoice command. */
-export function BillingActionDialog({
-  open,
-  onOpenChange,
-  workOrderRecordId,
-  billing,
-  initialVisitIds,
-  mode = 'primary',
-}: BillingActionDialogProps) {
-  const [page, setPage] = useState<Page>('choose')
+/** Default batch period: next calendar month (plan §3, decision "default: next calendar month"). */
+function defaultBatchRange(): DateRange {
+  const nextMonthStart = addMonths(startOfMonth(new Date()), 1)
+  return { from: nextMonthStart, to: endOfMonth(nextMonthStart) }
+}
+
+/** Route a work order's billing basis to its explicit allocation-backed invoice command, or —
+ * in batch scope — drive the period/filter → preview → generate advance-invoicing flow. */
+export function BillingActionDialog({ open, onOpenChange, scope }: BillingActionDialogProps) {
+  const isBatch = scope.kind === 'batch'
+  // Batch scope carries no `WorkOrderBillingView` — fall back to the empty placeholder so the
+  // single-work-order render tree below (never mounted while `isBatch`) can read `billing.*`
+  // unconditionally instead of threading optional chaining through every picker.
+  const billing = scope.kind === 'workOrder' ? scope.billing : EMPTY_WORK_ORDER_BILLING
+  const workOrderRecordId = scope.kind === 'workOrder' ? scope.workOrderRecordId : undefined
+  const mode = scope.kind === 'workOrder' ? (scope.mode ?? 'primary') : 'primary'
+  const initialVisitIds = scope.kind === 'workOrder' ? scope.initialVisitIds : undefined
+
+  const [page, setPage] = useState<Page>(isBatch ? 'scope' : 'choose')
   const [fixedChoice, setFixedChoice] = useState<FixedChoice>('remaining')
   const [inputValue, setInputValue] = useState<number | null>(null)
+  // Deps stay granular (not `scope` itself — call sites build it inline, so its identity churns
+  // every parent render and would reset the open dialog's page/selection mid-flow).
   const defaultVisits = useMemo(() => {
+    if (isBatch) return []
     if (initialVisitIds?.length) return initialVisitIds
     // Extra mode defaults to DONE visits' extras only — upcoming visits' staged extras are
     // opt-in (plan money/19 §2: pre-billing is deliberate, never the default).
@@ -55,19 +85,75 @@ export function BillingActionDialog({
       ]
     }
     return billing.eligibleVisits.map((visit) => visit.id)
-  }, [billing.eligibleVisits, billing.extraWork, initialVisitIds, mode])
+  }, [billing.eligibleVisits, billing.extraWork, initialVisitIds, mode, isBatch])
   const [visitIds, setVisitIds] = useState<string[]>(defaultVisits)
   const utils = api.useUtils()
 
+  // ─── Batch scope state (plan §3, batch pages) ───────────────────────────
+  const [batchRange, setBatchRange] = useState<DateRange>(
+    scope.kind === 'batch' && scope.initialRange ? scope.initialRange : defaultBatchRange()
+  )
+  const [batchFilters, setBatchFilters] = useState<ConditionGroup[]>([])
+  const [batchSelectedIds, setBatchSelectedIds] = useState<Set<RecordId>>(new Set())
+  const { resource: invoiceResource } = useResource('invoices')
+
+  const previewBatch = api.money.previewInvoiceBatch.useQuery(
+    { range: batchRange, filters: batchFilters },
+    { enabled: isBatch && page === 'preview' }
+  )
+
+  useEffect(() => {
+    if (!previewBatch.data) return
+    setBatchSelectedIds(
+      new Set(
+        previewBatch.data.rows
+          .filter((row) => !row.excludedReason)
+          .map((row) => row.workOrderRecordId)
+      )
+    )
+  }, [previewBatch.data])
+
+  const rowLabelByWorkOrderId = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const row of previewBatch.data?.rows ?? []) {
+      map.set(row.workOrderRecordId, row.contactName ?? 'Work order')
+    }
+    return map
+  }, [previewBatch.data])
+
+  const runBatch = api.money.runInvoiceBatch.useMutation({
+    onSuccess: async () => {
+      if (!invoiceResource?.id) return
+      await utils.record.listFiltered.invalidate({ entityDefinitionId: invoiceResource.id })
+    },
+    onError: (error) =>
+      toastError({ title: 'Error generating batch invoices', description: error.message }),
+  })
+
+  const submitBatch = () => {
+    setPage('generate')
+    runBatch.mutate({ range: batchRange, workOrderRecordIds: [...batchSelectedIds] })
+  }
+
+  const batchInitialRange = scope.kind === 'batch' ? scope.initialRange : undefined
+  const resetRunBatch = runBatch.reset
+
   useEffect(() => {
     if (!open) return
-    setPage('choose')
+    setPage(isBatch ? 'scope' : 'choose')
     setFixedChoice('remaining')
     setInputValue(null)
     setVisitIds(defaultVisits)
-  }, [open, defaultVisits])
+    if (isBatch) {
+      setBatchRange(batchInitialRange ?? defaultBatchRange())
+      setBatchFilters([])
+      setBatchSelectedIds(new Set())
+      resetRunBatch()
+    }
+  }, [open, defaultVisits, isBatch, batchInitialRange, resetRunBatch])
 
   const invalidate = async () => {
+    if (!workOrderRecordId) return
     await utils.money.getWorkOrderBillingState.invalidate({ workOrderRecordId })
     onOpenChange(false)
   }
@@ -119,6 +205,7 @@ export function BillingActionDialog({
         : true
 
   const submit = () => {
+    if (!workOrderRecordId) return
     if (isExtra) {
       createExtra.mutate({ workOrderRecordId, visitIds })
       return
@@ -146,117 +233,195 @@ export function BillingActionDialog({
     createFixed.mutate({ workOrderRecordId, amount: fixedAmount })
   }
 
-  const title = isExtra
-    ? 'Invoice extra work'
-    : billing.basis === 'fixed_contract'
-      ? 'Create contract invoice'
-      : billing.basis === 'per_visit'
-        ? 'Create visit invoice'
-        : 'Generate recurring charge'
+  const title = isBatch
+    ? 'Batch invoice'
+    : isExtra
+      ? 'Invoice extra work'
+      : billing.basis === 'fixed_contract'
+        ? 'Create contract invoice'
+        : billing.basis === 'per_visit'
+          ? 'Create visit invoice'
+          : 'Generate recurring charge'
+
+  const description = isBatch
+    ? 'Preview and create draft invoices for every qualifying work order in a period.'
+    : 'Review the billable work before creating an editable draft.'
+
+  const crumbs = isBatch
+    ? [
+        {
+          label: 'Period & filters',
+          onClick: page !== 'scope' ? () => setPage('scope') : undefined,
+        },
+        ...(page === 'preview' || page === 'generate'
+          ? [
+              {
+                label: 'Preview',
+                onClick: page === 'generate' ? () => setPage('preview') : undefined,
+              },
+            ]
+          : []),
+        ...(page === 'generate' ? [{ label: 'Results' }] : []),
+      ]
+    : [{ label: page === 'choose' ? chooseLabel(billing, isExtra) : 'Review' }]
+
+  const onBack = isBatch
+    ? page === 'preview'
+      ? () => setPage('scope')
+      : undefined
+    : page === 'review'
+      ? () => setPage('choose')
+      : undefined
+
+  const previewRows = previewBatch.data?.rows ?? []
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size='content' position='tc' innerClassName='p-0'>
-        <DialogNav
-          title={title}
-          description='Review the billable work before creating an editable draft.'
-          onBack={page === 'review' ? () => setPage('choose') : undefined}
-          crumbs={[{ label: page === 'choose' ? chooseLabel(billing, isExtra) : 'Review' }]}
-        />
+        <DialogNav title={title} description={description} onBack={onBack} crumbs={crumbs} />
         <DialogNavPages value={page}>
-          <DialogNavPage value='choose' size='md'>
-            <div className='space-y-4 p-4'>
-              {isExtra ? (
-                <ExtraWorkPicker billing={billing} value={visitIds} onChange={setVisitIds} />
-              ) : billing.basis === 'per_visit' ? (
-                <VisitPicker billing={billing} value={visitIds} onChange={setVisitIds} />
-              ) : billing.basis === 'fixed_contract' ? (
-                <FixedAmountPicker
-                  billing={billing}
-                  choice={fixedChoice}
-                  onChoice={setFixedChoice}
-                  inputValue={inputValue}
-                  onInputValue={setInputValue}
+          {isBatch ? (
+            <>
+              <DialogNavPage value='scope' size='md'>
+                <BatchScopePage
+                  range={batchRange}
+                  onRangeChange={setBatchRange}
+                  filters={batchFilters}
+                  onFiltersChange={setBatchFilters}
+                  onCancel={() => onOpenChange(false)}
+                  onContinue={() => setPage('preview')}
                 />
-              ) : (
-                <FieldPanel orientation='horizontal' defaultLabelWidth={160} className='p-0'>
-                  <PreviewRow
-                    label='Recurring charge'
-                    value={formatCurrency(billing.billingAmount, billing.currencyCode)}
-                  />
-                </FieldPanel>
-              )}
-            </div>
-            <DialogFooter>
-              <Button type='button' variant='ghost' size='sm' onClick={() => onOpenChange(false)}>
-                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-              </Button>
-              <Button
-                variant='outline'
-                size='sm'
-                disabled={!canContinue}
-                onClick={() => setPage('review')}
-                data-dialog-submit>
-                Review <KbdSubmit variant='outline' size='sm' />
-              </Button>
-            </DialogFooter>
-          </DialogNavPage>
-          <DialogNavPage value='review' size='md'>
-            <div className='space-y-3 p-4 text-sm'>
-              <FieldPanel orientation='horizontal' defaultLabelWidth={170} className='p-0'>
-                <PreviewRow
-                  label='Amount on this invoice'
-                  value={formatCurrency(
-                    amount ||
-                      (isExtra
-                        ? selectedExtraAmount(billing, visitIds)
-                        : selectedVisitAmount(billing, visitIds)),
-                    billing.currencyCode
-                  )}
+              </DialogNavPage>
+              <DialogNavPage value='preview' size='lg'>
+                <BatchPreviewPage
+                  rows={previewRows}
+                  isLoading={previewBatch.isLoading}
+                  selectedIds={batchSelectedIds}
+                  onToggle={(id, checked) =>
+                    setBatchSelectedIds((current) => {
+                      const next = new Set(current)
+                      if (checked) next.add(id)
+                      else next.delete(id)
+                      return next
+                    })
+                  }
+                  onCancel={() => onOpenChange(false)}
+                  onGenerate={submitBatch}
+                  canGenerate={batchSelectedIds.size > 0}
                 />
-                {billing.basis === 'fixed_contract' && !isExtra && (
-                  <>
-                    <PreviewRow
-                      label='Contract value'
-                      value={formatCurrency(billing.billingAmount, billing.currencyCode)}
+              </DialogNavPage>
+              <DialogNavPage value='generate' size='md'>
+                <BatchGeneratePage
+                  isPending={runBatch.isPending}
+                  results={runBatch.data?.results}
+                  error={runBatch.error?.message}
+                  rowLabelByWorkOrderId={rowLabelByWorkOrderId}
+                  invoiceEntityDefinitionId={invoiceResource?.id}
+                  onClose={() => onOpenChange(false)}
+                />
+              </DialogNavPage>
+            </>
+          ) : (
+            <>
+              <DialogNavPage value='choose' size='md'>
+                <div className='space-y-4 p-4'>
+                  {isExtra ? (
+                    <ExtraWorkPicker billing={billing} value={visitIds} onChange={setVisitIds} />
+                  ) : billing.basis === 'per_visit' ? (
+                    <VisitPicker billing={billing} value={visitIds} onChange={setVisitIds} />
+                  ) : billing.basis === 'fixed_contract' ? (
+                    <FixedAmountPicker
+                      billing={billing}
+                      choice={fixedChoice}
+                      onChoice={setFixedChoice}
+                      inputValue={inputValue}
+                      onInputValue={setInputValue}
                     />
+                  ) : (
+                    <FieldPanel orientation='horizontal' defaultLabelWidth={160} className='p-0'>
+                      <PreviewRow
+                        label='Recurring charge'
+                        value={formatCurrency(billing.billingAmount, billing.currencyCode)}
+                      />
+                    </FieldPanel>
+                  )}
+                </div>
+                <DialogFooter>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='sm'
+                    onClick={() => onOpenChange(false)}>
+                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    disabled={!canContinue}
+                    onClick={() => setPage('review')}
+                    data-dialog-submit>
+                    Review <KbdSubmit variant='outline' size='sm' />
+                  </Button>
+                </DialogFooter>
+              </DialogNavPage>
+              <DialogNavPage value='review' size='md'>
+                <div className='space-y-3 p-4 text-sm'>
+                  <FieldPanel orientation='horizontal' defaultLabelWidth={170} className='p-0'>
                     <PreviewRow
-                      label='Remaining after draft'
+                      label='Amount on this invoice'
                       value={formatCurrency(
-                        Math.max(0, billing.remaining - amount),
+                        amount ||
+                          (isExtra
+                            ? selectedExtraAmount(billing, visitIds)
+                            : selectedVisitAmount(billing, visitIds)),
                         billing.currencyCode
                       )}
                     />
-                  </>
-                )}
-                {(isExtra || billing.basis === 'per_visit') && (
-                  <PreviewRow label='Visits included' value={String(visitIds.length)} />
-                )}
-              </FieldPanel>
-              <p className='text-xs text-muted-foreground'>
-                Tax and document discounts are calculated when the draft is created.
-              </p>
-            </div>
-            <DialogFooter>
-              <Button
-                type='button'
-                variant='ghost'
-                size='sm'
-                onClick={() => onOpenChange(false)}
-                disabled={isPending}>
-                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-              </Button>
-              <Button
-                variant='outline'
-                size='sm'
-                loading={isPending}
-                loadingText='Creating...'
-                onClick={submit}
-                data-dialog-submit>
-                Create draft <KbdSubmit variant='outline' size='sm' />
-              </Button>
-            </DialogFooter>
-          </DialogNavPage>
+                    {billing.basis === 'fixed_contract' && !isExtra && (
+                      <>
+                        <PreviewRow
+                          label='Contract value'
+                          value={formatCurrency(billing.billingAmount, billing.currencyCode)}
+                        />
+                        <PreviewRow
+                          label='Remaining after draft'
+                          value={formatCurrency(
+                            Math.max(0, billing.remaining - amount),
+                            billing.currencyCode
+                          )}
+                        />
+                      </>
+                    )}
+                    {(isExtra || billing.basis === 'per_visit') && (
+                      <PreviewRow label='Visits included' value={String(visitIds.length)} />
+                    )}
+                  </FieldPanel>
+                  <p className='text-xs text-muted-foreground'>
+                    Tax and document discounts are calculated when the draft is created.
+                  </p>
+                </div>
+                <DialogFooter>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='sm'
+                    onClick={() => onOpenChange(false)}
+                    disabled={isPending}>
+                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    loading={isPending}
+                    loadingText='Creating...'
+                    onClick={submit}
+                    data-dialog-submit>
+                    Create draft <KbdSubmit variant='outline' size='sm' />
+                  </Button>
+                </DialogFooter>
+              </DialogNavPage>
+            </>
+          )}
         </DialogNavPages>
       </DialogContent>
     </Dialog>
@@ -496,7 +661,7 @@ function ExtraWorkPicker({
   )
 }
 
-function PreviewRow({ label, value }: { label: string; value: string }) {
+export function PreviewRow({ label, value }: { label: string; value: string }) {
   return (
     <FieldPanelRow title={label}>
       <div className='flex min-h-8 items-center justify-end px-2 font-medium tabular-nums'>

--- a/apps/web/src/components/money/billing/types.ts
+++ b/apps/web/src/components/money/billing/types.ts
@@ -91,7 +91,10 @@ export interface ContactBillingView {
   recentInvoices: BillingInvoiceRow[]
 }
 
-const EMPTY_WORK_ORDER_BILLING: WorkOrderBillingView = {
+/** Placeholder billing view for the batch dialog scope, which carries no `WorkOrderBillingView`
+ * — lets `BillingActionDialog` reuse its single-work-order render tree's derived values
+ * (never rendered in batch scope) without threading `billing?.` everywhere. */
+export const EMPTY_WORK_ORDER_BILLING: WorkOrderBillingView = {
   basis: 'per_visit',
   timing: 'as_needed',
   state: 'not_ready',

--- a/apps/web/src/components/money/ui/invoice/create-invoice-action.tsx
+++ b/apps/web/src/components/money/ui/invoice/create-invoice-action.tsx
@@ -39,9 +39,12 @@ export function CreateInvoiceAction({ recordId }: DrawerActionProps) {
       <BillingActionDialog
         open={open}
         onOpenChange={setOpen}
-        workOrderRecordId={recordId}
-        billing={billing}
-        mode={action.kind === 'create_extra' ? 'extra' : 'primary'}
+        scope={{
+          kind: 'workOrder',
+          workOrderRecordId: recordId,
+          billing,
+          mode: action.kind === 'create_extra' ? 'extra' : 'primary',
+        }}
       />
     </>
   )

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -28,6 +28,7 @@ import {
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
+import type { ReactNode } from 'react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { BulkUpdateEntityInstanceDialog } from '~/components/custom-fields/ui/bulk-update-entity-instance-dialog'
 import { ExportProgressDialog } from '~/components/data-export/ui/export-progress-dialog'
@@ -86,6 +87,10 @@ interface RecordsViewProps {
   slug: string
   /** Base URL path for breadcrumbs and import links. Defaults to /app/custom/${slug} */
   basePath?: string
+  /** Extra actions rendered in the header action slot, next to the Create button (e.g. the
+   * invoices/work-orders "Batch invoice" entry point, plan
+   * plans/dispatch/37a-batch-advance-invoicing.md §3 decision #4). */
+  pageActions?: ReactNode
 }
 
 /**
@@ -95,7 +100,7 @@ interface RecordsViewProps {
  * only `MainPageContent` + contributions (`MainPageAction` for Create) — the
  * calling route (`EntityRouteLayout`) owns `MainPage`/`MainPageHeader`.
  */
-export function RecordsView({ slug, basePath }: RecordsViewProps) {
+export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
   const resolvedBasePath = basePath ?? `/app/custom/${slug}`
   const router = useRouter()
   const { hasAccess } = useFeatureFlags()
@@ -872,6 +877,7 @@ export function RecordsView({ slug, basePath }: RecordsViewProps) {
       )}
 
       <MainPageAction>
+        {pageActions}
         <Button size='sm' className='h-7 rounded-lg' onClick={() => setIsCreateDialogOpen(true)}>
           <Plus className='size-4' />
           Create {resource.label}

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -2,6 +2,7 @@
 
 import type { PaymentTransactionEntity } from '@auxx/database'
 import { database, schema } from '@auxx/database'
+import { conditionGroupsSchema } from '@auxx/lib/conditions'
 import { renderPreviewQuotePdf } from '@auxx/lib/documents'
 import { NotFoundError } from '@auxx/lib/errors'
 import {
@@ -29,10 +30,12 @@ import {
   markInvoiceSent,
   markQuoteSent,
   prepareDocumentEmail,
+  previewInvoiceBatch,
   recomputeTotals,
   recordManualPayment,
   refundTransaction,
   reorderLines,
+  runInvoiceBatch,
   saveBillingInstallments,
   setInvoiceSchedule,
   syncAccountState,
@@ -318,6 +321,40 @@ export const moneyRouter = createTRPCRouter({
         userId: ctx.session.user.id,
         workOrderInstanceId: parseRecordId(input.workOrderRecordId).entityInstanceId,
         visitId: input.visitId,
+      })
+    ),
+
+  // ─── Batch advance invoicing (plans/dispatch/37a-batch-advance-invoicing.md) ────
+
+  previewInvoiceBatch: moneyProcedure
+    .input(
+      z.object({
+        range: z.object({ from: z.date(), to: z.date() }),
+        filters: conditionGroupsSchema,
+      })
+    )
+    .query(async ({ ctx, input }) =>
+      previewInvoiceBatch({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        range: input.range,
+        filters: input.filters,
+      })
+    ),
+
+  runInvoiceBatch: moneyProcedure
+    .input(
+      z.object({
+        range: z.object({ from: z.date(), to: z.date() }),
+        workOrderRecordIds: z.array(recordIdSchema).min(1),
+      })
+    )
+    .mutation(async ({ ctx, input }) =>
+      runInvoiceBatch({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        range: input.range,
+        workOrderRecordIds: input.workOrderRecordIds,
       })
     ),
 

--- a/packages/lib/src/money/batch-invoicing.ts
+++ b/packages/lib/src/money/batch-invoicing.ts
@@ -1,0 +1,477 @@
+// packages/lib/src/money/batch-invoicing.ts
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { and, eq, gte, inArray, lte, ne } from 'drizzle-orm'
+import type { ConditionGroup } from '../conditions'
+import { FieldValueService } from '../field-values/field-value-service'
+import { expandOccurrences, type RecurrencePattern } from '../recurrence'
+import { UnifiedCrudHandler } from '../resources/crud'
+import { createRecurringCharge, createVisitInvoice } from './billing-commands'
+import { batchReadSystemValues, computeWorkOrderBillingProjection } from './billing-projection'
+import { listUninvoicedLines } from './gather'
+import type { WorkOrderBillingBasis } from './types'
+
+const logger = createScopedLogger('money:batch-invoicing')
+
+/** Wall-clock instant window a batch operates over — the caller's concern to compute (e.g. an
+ * org-timezone month preset); this module takes `from`/`to` verbatim. */
+export interface InvoiceBatchRange {
+  from: Date
+  to: Date
+}
+
+/** One work order's outcome in a batch preview — billable (`amount`/`visitCount` or
+ * `occurrenceCount` set) or excluded (`excludedReason` set, `amount` is `0`). */
+export interface InvoiceBatchRow {
+  workOrderRecordId: RecordId
+  contactName: string | null
+  basis: WorkOrderBillingBasis
+  visitCount?: number
+  occurrenceCount?: number
+  amount: number
+  excludedReason?: string
+}
+
+export interface PreviewInvoiceBatchInput {
+  organizationId: string
+  userId: string
+  range: InvoiceBatchRange
+  filters: ConditionGroup[]
+}
+
+export interface PreviewInvoiceBatchResult {
+  rows: InvoiceBatchRow[]
+  totalCount: number
+  totalAmount: number
+}
+
+export interface RunInvoiceBatchInput {
+  organizationId: string
+  userId: string
+  range: InvoiceBatchRange
+  workOrderRecordIds: RecordId[]
+}
+
+/** One work order's outcome in a batch run. `invoiceRecordId` is the last invoice created for
+ * this work order; `invoiceRecordIds` carries every invoice created (`recurring_flat` can
+ * produce more than one when several occurrences fall due in the same range). */
+export interface InvoiceBatchItemResult {
+  workOrderRecordId: RecordId
+  ok: boolean
+  invoiceRecordId?: RecordId
+  invoiceRecordIds?: RecordId[]
+  error?: string
+}
+
+export interface RunInvoiceBatchResult {
+  results: InvoiceBatchItemResult[]
+}
+
+interface GatheredWorkOrder {
+  workOrderInstanceId: string
+  workOrderRecordId: RecordId
+  contactName: string | null
+  basis: WorkOrderBillingBasis
+  amount: number
+  visitCount?: number
+  occurrenceCount?: number
+  visitIds?: string[]
+  occurrenceDates?: string[]
+  excludedReason?: string
+}
+
+const FIXED_CONTRACT_EXCLUDED_REASON =
+  'Fixed-contract billing is not supported by the batch — use the work order billing dialog'
+const NO_SCHEDULE_EXCLUDED_REASON =
+  'Configure a custom invoice schedule before batch billing this work order'
+const NOTHING_DUE_ERROR = 'No billable visits or occurrences in this period'
+
+function toPublicRow(item: GatheredWorkOrder): InvoiceBatchRow {
+  return {
+    workOrderRecordId: item.workOrderRecordId,
+    contactName: item.contactName,
+    basis: item.basis,
+    visitCount: item.visitCount,
+    occurrenceCount: item.occurrenceCount,
+    amount: item.amount,
+    excludedReason: item.excludedReason,
+  }
+}
+
+/** Resolve work-order EntityInstance ids matching the caller's condition-system filters. */
+async function resolveWorkOrderInstanceIds(input: {
+  organizationId: string
+  userId: string
+  filters: ConditionGroup[]
+}): Promise<string[]> {
+  const handler = new UnifiedCrudHandler(input.organizationId, input.userId)
+  const { ids, total } = await handler.listFiltered({
+    entityDefinitionId: 'work_order',
+    filters: input.filters,
+    limit: 1000,
+    mode: 'oneshot',
+  })
+  if (total > ids.length) {
+    logger.warn('Invoice batch truncated to first 1000 matching work orders', {
+      organizationId: input.organizationId,
+      total,
+    })
+  }
+  return ids
+}
+
+/** Contact display name per work order, batched (one field-value read, one name lookup). */
+async function loadContactNames(input: {
+  organizationId: string
+  userId: string
+  workOrderInstanceIds: string[]
+}): Promise<Map<string, string | null>> {
+  const contactValuesById = await batchReadSystemValues({
+    service: new FieldValueService(input.organizationId, input.userId),
+    organizationId: input.organizationId,
+    entityType: 'work_order',
+    entityInstanceIds: input.workOrderInstanceIds,
+    attributes: ['work_order_contact'] as const,
+  })
+  const contactInstanceIdByWorkOrder = new Map<string, string>()
+  const contactInstanceIds = new Set<string>()
+  for (const workOrderInstanceId of input.workOrderInstanceIds) {
+    const contactValue = contactValuesById.get(workOrderInstanceId)?.get('work_order_contact')
+    if (typeof contactValue === 'string' && contactValue.includes(':')) {
+      const { entityInstanceId } = parseRecordId(contactValue as RecordId)
+      contactInstanceIdByWorkOrder.set(workOrderInstanceId, entityInstanceId)
+      contactInstanceIds.add(entityInstanceId)
+    }
+  }
+  const contactRows = contactInstanceIds.size
+    ? await database
+        .select({ id: schema.EntityInstance.id, displayName: schema.EntityInstance.displayName })
+        .from(schema.EntityInstance)
+        .where(inArray(schema.EntityInstance.id, [...contactInstanceIds]))
+    : []
+  const contactNameById = new Map(contactRows.map((row) => [row.id, row.displayName]))
+  const result = new Map<string, string | null>()
+  for (const workOrderInstanceId of input.workOrderInstanceIds) {
+    const contactInstanceId = contactInstanceIdByWorkOrder.get(workOrderInstanceId)
+    result.set(
+      workOrderInstanceId,
+      contactInstanceId ? (contactNameById.get(contactInstanceId) ?? null) : null
+    )
+  }
+  return result
+}
+
+/** Non-canceled visits overlapping `range`, minus visits already holding an active base
+ * `InvoiceVisitAllocation` — grouped by work order. Same overlap-query shape as
+ * `dispatch/board.ts`'s `getBoard` range read. */
+async function loadUninvoicedVisitsByWorkOrder(input: {
+  organizationId: string
+  range: InvoiceBatchRange
+  workOrderInstanceIds: string[]
+}): Promise<Map<string, (typeof schema.WorkOrderVisit.$inferSelect)[]>> {
+  const rangeVisits = await database.query.WorkOrderVisit.findMany({
+    where: and(
+      eq(schema.WorkOrderVisit.organizationId, input.organizationId),
+      inArray(schema.WorkOrderVisit.workOrderId, input.workOrderInstanceIds),
+      ne(schema.WorkOrderVisit.status, 'canceled'),
+      gte(schema.WorkOrderVisit.endTime, input.range.from),
+      lte(schema.WorkOrderVisit.startTime, input.range.to)
+    ),
+  })
+  const visitIds = rangeVisits.map((visit) => visit.id)
+  const activeBaseAllocations = visitIds.length
+    ? await database.query.InvoiceVisitAllocation.findMany({
+        where: and(
+          eq(schema.InvoiceVisitAllocation.organizationId, input.organizationId),
+          inArray(schema.InvoiceVisitAllocation.visitId, visitIds),
+          eq(schema.InvoiceVisitAllocation.status, 'active'),
+          eq(schema.InvoiceVisitAllocation.kind, 'base')
+        ),
+        columns: { visitId: true },
+      })
+    : []
+  const allocatedVisitIds = new Set(activeBaseAllocations.map((row) => row.visitId))
+  const visitsByWorkOrder = new Map<string, (typeof schema.WorkOrderVisit.$inferSelect)[]>()
+  for (const visit of rangeVisits) {
+    if (allocatedVisitIds.has(visit.id)) continue
+    const list = visitsByWorkOrder.get(visit.workOrderId) ?? []
+    list.push(visit)
+    visitsByWorkOrder.set(visit.workOrderId, list)
+  }
+  return visitsByWorkOrder
+}
+
+/** Custom-schedule `invoice_drafts` recurrence rules for these work orders, plus the occurrence
+ * dates already claimed by an active `InvoiceScheduleAllocation` per rule. */
+async function loadScheduleState(input: {
+  organizationId: string
+  workOrderInstanceIds: string[]
+}): Promise<{
+  ruleByWorkOrder: Map<string, typeof schema.RecurrenceRule.$inferSelect>
+  allocatedOccurrencesByRule: Map<string, Set<string>>
+}> {
+  const rules = await database.query.RecurrenceRule.findMany({
+    where: and(
+      eq(schema.RecurrenceRule.organizationId, input.organizationId),
+      eq(schema.RecurrenceRule.subjectType, 'invoice_drafts'),
+      inArray(schema.RecurrenceRule.subjectId, input.workOrderInstanceIds)
+    ),
+  })
+  const ruleByWorkOrder = new Map(rules.map((rule) => [rule.subjectId, rule]))
+  const ruleIds = rules.map((rule) => rule.id)
+  const allocations = ruleIds.length
+    ? await database.query.InvoiceScheduleAllocation.findMany({
+        where: and(
+          eq(schema.InvoiceScheduleAllocation.organizationId, input.organizationId),
+          inArray(schema.InvoiceScheduleAllocation.recurrenceRuleId, ruleIds),
+          eq(schema.InvoiceScheduleAllocation.status, 'active')
+        ),
+        columns: { recurrenceRuleId: true, occurrenceDate: true },
+      })
+    : []
+  const allocatedOccurrencesByRule = new Map<string, Set<string>>()
+  for (const row of allocations) {
+    const set = allocatedOccurrencesByRule.get(row.recurrenceRuleId) ?? new Set<string>()
+    set.add(row.occurrenceDate)
+    allocatedOccurrencesByRule.set(row.recurrenceRuleId, set)
+  }
+  return { ruleByWorkOrder, allocatedOccurrencesByRule }
+}
+
+/**
+ * Per-work-order billable candidates for `range`, shared verbatim by `previewInvoiceBatch` and
+ * `runInvoiceBatch` so the two can't drift. Work orders with nothing due in `range` (an empty
+ * uninvoiced-visit set, or a `recurring_flat` schedule with no due occurrence) are omitted
+ * entirely, not returned as excluded rows — only a genuine configuration problem (fixed-contract
+ * basis, or a `recurring_flat` work order with no `custom_schedule` rule) is.
+ */
+async function gatherInvoiceBatchWorkOrders(input: {
+  organizationId: string
+  userId: string
+  range: InvoiceBatchRange
+  workOrderInstanceIds: string[]
+}): Promise<GatheredWorkOrder[]> {
+  const { organizationId, userId, range, workOrderInstanceIds } = input
+  if (workOrderInstanceIds.length === 0) return []
+
+  const [contactNameByWorkOrder, visitsByWorkOrder, scheduleState] = await Promise.all([
+    loadContactNames({ organizationId, userId, workOrderInstanceIds }),
+    loadUninvoicedVisitsByWorkOrder({ organizationId, range, workOrderInstanceIds }),
+    loadScheduleState({ organizationId, workOrderInstanceIds }),
+  ])
+  const { ruleByWorkOrder, allocatedOccurrencesByRule } = scheduleState
+
+  const results: GatheredWorkOrder[] = []
+  for (const workOrderInstanceId of workOrderInstanceIds) {
+    const workOrderRecordId = toRecordId('work_order', workOrderInstanceId)
+    const contactName = contactNameByWorkOrder.get(workOrderInstanceId) ?? null
+    const projection = await computeWorkOrderBillingProjection({
+      organizationId,
+      userId,
+      workOrderInstanceId,
+    })
+
+    if (projection.basis === 'per_visit') {
+      const candidates = visitsByWorkOrder.get(workOrderInstanceId) ?? []
+      if (candidates.length === 0) continue
+      const candidateVisitIds = new Set(candidates.map((visit) => visit.id))
+      const uninvoicedLines = await listUninvoicedLines({
+        organizationId,
+        userId,
+        workOrderInstanceId,
+      })
+      const extrasTotal = uninvoicedLines
+        .filter(
+          (line) =>
+            line.visitId !== undefined &&
+            candidateVisitIds.has(line.visitId) &&
+            (line.lineTotal ?? 0) > 0
+        )
+        .reduce((sum, line) => sum + (line.lineTotal ?? 0), 0)
+      results.push({
+        workOrderInstanceId,
+        workOrderRecordId,
+        contactName,
+        basis: 'per_visit',
+        amount: candidates.length * projection.billingAmount + extrasTotal,
+        visitCount: candidates.length,
+        visitIds: candidates.map((visit) => visit.id),
+      })
+      continue
+    }
+
+    if (projection.basis === 'recurring_flat') {
+      const rule =
+        projection.timing === 'custom_schedule'
+          ? ruleByWorkOrder.get(workOrderInstanceId)
+          : undefined
+      if (!rule) {
+        results.push({
+          workOrderInstanceId,
+          workOrderRecordId,
+          contactName,
+          basis: 'recurring_flat',
+          amount: 0,
+          excludedReason: NO_SCHEDULE_EXCLUDED_REASON,
+        })
+        continue
+      }
+      const occurrences = expandOccurrences(rule.pattern as unknown as RecurrencePattern, {
+        anchor: rule.anchor,
+        timezone: rule.timezone,
+        from: range.from,
+        to: range.to,
+        startMinute: 0,
+      })
+      const allocatedDates = allocatedOccurrencesByRule.get(rule.id) ?? new Set<string>()
+      const dueOccurrences = occurrences.filter(
+        (occurrence) => !allocatedDates.has(occurrence.occurrenceDate)
+      )
+      if (dueOccurrences.length === 0) continue
+      results.push({
+        workOrderInstanceId,
+        workOrderRecordId,
+        contactName,
+        basis: 'recurring_flat',
+        amount: dueOccurrences.length * projection.billingAmount,
+        occurrenceCount: dueOccurrences.length,
+        occurrenceDates: dueOccurrences.map((occurrence) => occurrence.occurrenceDate),
+      })
+      continue
+    }
+
+    results.push({
+      workOrderInstanceId,
+      workOrderRecordId,
+      contactName,
+      basis: projection.basis,
+      amount: 0,
+      excludedReason: FIXED_CONTRACT_EXCLUDED_REASON,
+    })
+  }
+
+  return results
+}
+
+/**
+ * Preview which work orders a batch will invoice for `range` + `filters` (condition-system
+ * filters on the work-order entity def, resource mode) — the office's "invoice all of August"
+ * check before generating drafts. Amounts are computed by running the billing projection per
+ * work order (fine at the tens-of-work-orders scale a batch period covers; revisit if orgs grow
+ * into the hundreds).
+ */
+export async function previewInvoiceBatch(
+  input: PreviewInvoiceBatchInput
+): Promise<PreviewInvoiceBatchResult> {
+  const workOrderInstanceIds = await resolveWorkOrderInstanceIds(input)
+  const gathered = await gatherInvoiceBatchWorkOrders({ ...input, workOrderInstanceIds })
+  const rows = gathered.map(toPublicRow)
+  const billableRows = rows.filter((row) => !row.excludedReason)
+  return {
+    rows,
+    totalCount: billableRows.length,
+    totalAmount: billableRows.reduce((sum, row) => sum + row.amount, 0),
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const direct = 'code' in error ? (error as { code?: unknown }).code : undefined
+  if (direct === '23505') return true
+  const cause = 'cause' in error ? (error as { cause?: unknown }).cause : undefined
+  return Boolean(
+    cause &&
+      typeof cause === 'object' &&
+      'code' in cause &&
+      (cause as { code?: unknown }).code === '23505'
+  )
+}
+
+/**
+ * Generate draft invoices for `workOrderRecordIds` over `range` — re-derives each work order's
+ * billable visits/occurrences at run time (the same gather `previewInvoiceBatch` uses) rather
+ * than trusting client-sent visit ids. Sequential, one work order at a time; each underlying
+ * command (`createVisitInvoice` with `advance: true`, `createRecurringCharge` per due
+ * occurrence) keeps its own serializable-retry transaction — there is no cross-invoice
+ * transaction, so a failure on one work order never rolls back drafts already created for
+ * others. A unique-violation on an allocation (raced by a concurrent manual invoice) is reported
+ * as a per-item skip, not a batch failure.
+ */
+export async function runInvoiceBatch(input: RunInvoiceBatchInput): Promise<RunInvoiceBatchResult> {
+  const workOrderInstanceIds = input.workOrderRecordIds.map(
+    (recordId) => parseRecordId(recordId).entityInstanceId
+  )
+  const gathered = await gatherInvoiceBatchWorkOrders({
+    organizationId: input.organizationId,
+    userId: input.userId,
+    range: input.range,
+    workOrderInstanceIds,
+  })
+  const gatheredByWorkOrder = new Map(gathered.map((item) => [item.workOrderInstanceId, item]))
+
+  const results: InvoiceBatchItemResult[] = []
+  for (const workOrderRecordId of input.workOrderRecordIds) {
+    const { entityInstanceId: workOrderInstanceId } = parseRecordId(workOrderRecordId)
+    const item = gatheredByWorkOrder.get(workOrderInstanceId)
+    if (!item || item.excludedReason) {
+      results.push({
+        workOrderRecordId,
+        ok: false,
+        error: item?.excludedReason ?? NOTHING_DUE_ERROR,
+      })
+      continue
+    }
+    try {
+      if (item.basis === 'per_visit' && item.visitIds?.length) {
+        const invoice = await createVisitInvoice({
+          organizationId: input.organizationId,
+          userId: input.userId,
+          workOrderInstanceId,
+          visitIds: item.visitIds,
+          advance: true,
+        })
+        results.push({ workOrderRecordId, ok: true, invoiceRecordId: invoice.recordId })
+      } else if (item.basis === 'recurring_flat' && item.occurrenceDates?.length) {
+        const invoiceRecordIds: RecordId[] = []
+        for (const occurrenceDate of item.occurrenceDates) {
+          const invoice = await createRecurringCharge({
+            organizationId: input.organizationId,
+            userId: input.userId,
+            workOrderInstanceId,
+            occurrenceDate,
+          })
+          invoiceRecordIds.push(invoice.recordId)
+        }
+        results.push({
+          workOrderRecordId,
+          ok: true,
+          invoiceRecordId: invoiceRecordIds.at(-1),
+          invoiceRecordIds,
+        })
+      } else {
+        results.push({ workOrderRecordId, ok: false, error: NOTHING_DUE_ERROR })
+      }
+    } catch (error) {
+      const skipped = isUniqueViolation(error)
+      logger.warn('Batch invoice item failed', {
+        organizationId: input.organizationId,
+        workOrderInstanceId,
+        skipped,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      results.push({
+        workOrderRecordId,
+        ok: false,
+        error: skipped
+          ? 'Already invoiced by a concurrent action'
+          : error instanceof Error
+            ? error.message
+            : 'Failed to create invoice',
+      })
+    }
+  }
+  return { results }
+}

--- a/packages/lib/src/money/billing-commands.ts
+++ b/packages/lib/src/money/billing-commands.ts
@@ -3,7 +3,7 @@
 import { type Database, database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, ne } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import { FieldValueService } from '../field-values/field-value-service'
@@ -334,7 +334,8 @@ export async function createFixedContractInvoice(
   return projectCommittedInvoice({ ...input, result })
 }
 
-/** Create one allocation-backed invoice for selected completed visits. */
+/** Create one allocation-backed invoice for selected visits — `'done'` only by default, or (with
+ * `input.advance`) any non-canceled visit, for batch/advance invoicing before the work happens. */
 export async function createVisitInvoice(
   input: CreateVisitInvoiceInput
 ): Promise<CreateInvoiceFromWorkOrderResult> {
@@ -348,13 +349,17 @@ export async function createVisitInvoice(
       where: and(
         eq(schema.WorkOrderVisit.organizationId, input.organizationId),
         eq(schema.WorkOrderVisit.workOrderId, input.workOrderInstanceId),
-        eq(schema.WorkOrderVisit.status, 'done'),
+        input.advance
+          ? ne(schema.WorkOrderVisit.status, 'canceled')
+          : eq(schema.WorkOrderVisit.status, 'done'),
         inArray(schema.WorkOrderVisit.id, [...new Set(input.visitIds)])
       ),
     })
     if (visits.length !== new Set(input.visitIds).size) {
       throw new BadRequestError(
-        'Every selected visit must be completed and belong to this work order'
+        input.advance
+          ? 'Every selected visit must belong to this work order and not be canceled'
+          : 'Every selected visit must be completed and belong to this work order'
       )
     }
     const source = await getSourceLines({ ...input, db })

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -16,6 +16,17 @@ export {
   setInvoiceSchedule,
   sweepInvoiceDrafts,
 } from './auto-invoice'
+export {
+  type InvoiceBatchItemResult,
+  type InvoiceBatchRange,
+  type InvoiceBatchRow,
+  type PreviewInvoiceBatchInput,
+  type PreviewInvoiceBatchResult,
+  previewInvoiceBatch,
+  type RunInvoiceBatchInput,
+  type RunInvoiceBatchResult,
+  runInvoiceBatch,
+} from './batch-invoicing'
 export { allocateProportionally, resolveFixedInvoiceAmount } from './billing-allocation-math'
 export {
   allocateInvoiceLine,

--- a/packages/lib/src/money/types.ts
+++ b/packages/lib/src/money/types.ts
@@ -210,6 +210,10 @@ export interface CreateFixedContractInvoiceInput extends WorkOrderBillingCommand
 /** Create one invoice containing one or more completed visits. */
 export interface CreateVisitInvoiceInput extends WorkOrderBillingCommandInput {
   visitIds: string[]
+  /** When `true`, accept any non-canceled visit status instead of requiring `'done'` — the
+   * batch/advance-invoicing path (bill before the work happens). Everything downstream
+   * (allocation, line copying, `finishInvoice`) is unchanged. */
+  advance?: boolean
 }
 
 /** Create one flat-rate charge for a recurrence occurrence or a manual period. */

--- a/packages/ui/src/components/dialog-nav.tsx
+++ b/packages/ui/src/components/dialog-nav.tsx
@@ -186,9 +186,16 @@ export function DialogNavPages({ value, children, className }: DialogNavPagesPro
     if (typeof height === 'number') measuredOnce.current = true
   }, [height])
 
-  const pages = Children.toArray(children).filter(
-    isValidElement
-  ) as ReactElement<DialogNavPageProps>[]
+  // Flatten one level of fragments so callers can group pages conditionally
+  // ({cond ? <>…pages…</> : <>…pages…</>}) — Children.toArray leaves fragments
+  // intact, which would hide their pages from the value match below.
+  const pages = Children.toArray(children)
+    .flatMap((child) =>
+      isValidElement(child) && child.type === Fragment
+        ? Children.toArray((child.props as { children?: ReactNode }).children)
+        : [child]
+    )
+    .filter(isValidElement) as ReactElement<DialogNavPageProps>[]
   const active = pages.find((page) => page.props.value === value)
   const widthRem = dialogSizeRem[active?.props.size ?? 'sm']
 


### PR DESCRIPTION
## Summary

Implements plan 37a (batch advance invoicing, plan 37 §A): one office action to pick a period + filters, preview which work orders will be billed, and generate **draft** invoices for all of them before the work happens — the pest-control "invoice all of August" flow.

### Lib (`packages/lib/src/money`)
- `advance?: boolean` on `createVisitInvoice` — accepts any non-canceled visit status instead of requiring `done`; the existing `InvoiceVisitAllocation` unique index still prevents double billing.
- New `batch-invoicing.ts`: `previewInvoiceBatch` (condition-system filters on the work-order def + visit/occurrence gather, minus active allocations) and `runInvoiceBatch` (sequential per-work-order run over the existing commands, per-item results, raced allocations reported as skips). Preview and run share one gather function so they can't drift. Resolve is capped at 1000 work orders with a warning log when truncated.
- `recurring_flat` creates one draft per due occurrence in range; results carry `invoiceRecordIds[]`.

### Router
- `money.previewInvoiceBatch` (query) + `money.runInvoiceBatch` (mutation), both `moneyProcedure`, thin delegations.

### UI
- `BillingActionDialog` generalized to a discriminated `scope` prop (`workOrder` | `batch`); batch scope adds three pages: period presets + embedded condition builder → per-work-order preview (`TreeRowList`/`TreeRow` with trailing `Switch size='xs'`, excluded rows greyed with reason) → results with a "Print…" handoff into the unified print wizard (selection scope).
- New `pageActions` slot on `RecordsView`; "Batch invoice" button on `/app/invoices` and `/app/work-orders`.
- `DialogNavPages` now flattens fragment-wrapped pages (conditional page groups previously rendered an empty dialog).

### Out of scope (per plan)
Fixed-contract installments (excluded rows name the reason), cancel-after-billing handling, per-customer consolidation, send/email.

## Test plan
- [x] 273 existing money-module vitest tests pass
- [x] Scoped `tsc` clean for all touched files in `packages/lib`, `packages/ui`, `apps/web` (3 remaining errors in `batch-invoice-pages.tsx` mirror the identical pre-existing `ConditionSystemConfig` baseline errors in `table-filter-builder.tsx`)
- [ ] Manual: single-WO invoice dialog (was affected by the fragment bug), batch flow end-to-end on `/app/invoices`