### PR TITLE
feat(dispatch): group drag-move, slot-click create and schedule copy/paste

### DIFF
--- a/apps/web/src/components/calendar/core/use-calendar-clipboard.ts
+++ b/apps/web/src/components/calendar/core/use-calendar-clipboard.ts
@@ -1,0 +1,156 @@
+// apps/web/src/components/calendar/core/use-calendar-clipboard.ts
+//
+// Generic clipboard state machine shared by every `EventCalendar` consumer that offers visit
+// copy/paste (plan `37c-calendar-create-copy-paste.md` §4/§8) — extracted in Phase 6 from the
+// dispatch board's `use-board-clipboard.ts` (the board now wraps this) so the schedule surface
+// gets the same hovered-slot ref, Cmd+C/Cmd+V keybindings, and paste-dialog target state without
+// duplicating them. `canCopy`/`canPaste` are separate gates (not one `canEdit`) because the
+// schedule surface's copy is open to everyone while paste stays admin/owner-only (every dispatch
+// write is `dispatchAdminProcedure`) — the board happens to gate both the same way.
+
+'use client'
+
+import type { HoveredSlot } from '@auxx/ui/components/event-calendar'
+import { useHotkey } from '@tanstack/react-hotkeys'
+import { useCallback, useRef, useState } from 'react'
+import { toRecordId } from '~/components/resources'
+import { type CopiedVisitItem, useClipboardCopy, useClipboardItems } from './clipboard-store'
+
+/** Where a paste lands — the consumer-local mirror of `HoveredSlot` (day + fractional hours +
+ * resource column), built either from the live hover ref (Cmd+V) or a right-click snapshot
+ * (context menu "Paste here"). `time`/`resourceId` are absent for a day-only target (month view,
+ * or no cell ever hovered — falls back to the consumer's current anchor date). */
+export interface PasteAnchor {
+  day: Date
+  time?: number
+  resourceId?: string
+}
+
+/** The minimal shape `useCalendarClipboard` needs off a consumer's own event type to build a
+ * `CopiedVisitItem` — every visit-backed calendar event (the board's `DispatchVisitEvent`,
+ * schedule's `VisitEvent` once it carries `workOrderId`) satisfies this structurally; no adapter
+ * type is needed at the call site. */
+export interface ClipboardVisitEvent {
+  id: string
+  workOrderId: string
+  title: string
+  start: Date
+  end: Date
+  assigneeUserId: string | null
+}
+
+export interface UseCalendarClipboardOptions<E extends ClipboardVisitEvent> {
+  /** The consumer's own pastable (visit) events, already narrowed to whatever subset is
+   * copy-eligible — schedule pre-filters `sourceId === 'visits'` out of its mixed
+   * visits/meetings/tasks feed before calling in; the board's events are all visits already. */
+  events: E[]
+  selectedIds: string[]
+  /** The consumer's current anchor date — the Cmd+V fallback target when nothing's been
+   * hovered yet (plan 37c §5, item 5 / board's `boardDate`). */
+  anchorDate: Date
+  /** `work-orders` resource's entityDefinitionId — needed to turn an event's `workOrderId` (an
+   * `EntityInstance` id) into the `RecordId` `dispatch.pasteVisits` wants. `undefined` while
+   * resources are still loading; copy/paste stay inert until it resolves. */
+  workOrderDefId: string | undefined
+  /** Whether this user may copy — everyone on schedule, admin/owner-gated (same as `canPaste`)
+   * on the board. */
+  canCopy: boolean
+  /** Whether this user may paste — admin/owner only wherever visit writes are gated. */
+  canPaste: boolean
+}
+
+/**
+ * Owns the hovered-slot ref a grid feeds via `EventCalendar`'s `hoveredSlotRef` prop, the
+ * Cmd+C/Cmd+V keybindings, and the paste-options dialog's open/target state. Copy/context-menu
+ * targeting (WHICH ids to copy) stays with the caller — this hook only exposes the primitives
+ * (`copyIds`, `openPasteDialogAt`) they call into.
+ */
+export function useCalendarClipboard<E extends ClipboardVisitEvent>({
+  events,
+  selectedIds,
+  anchorDate,
+  workOrderDefId,
+  canCopy,
+  canPaste,
+}: UseCalendarClipboardOptions<E>) {
+  const clipboardItems = useClipboardItems()
+  const copyToClipboard = useClipboardCopy()
+  const hoveredSlotRef = useRef<HoveredSlot | null>(null)
+  const [pasteTarget, setPasteTarget] = useState<PasteAnchor | null>(null)
+
+  const copyIds = useCallback(
+    (ids: string[]) => {
+      if (!canCopy || !workOrderDefId || ids.length === 0) return
+      const idSet = new Set(ids)
+      const picked = events.filter((e) => idSet.has(e.id))
+      if (picked.length === 0) return
+      const items: CopiedVisitItem[] = picked.map((e) => ({
+        kind: 'visit',
+        visitId: e.id,
+        workOrderRecordId: toRecordId(workOrderDefId, e.workOrderId),
+        title: e.title,
+        start: e.start,
+        end: e.end,
+        assigneeUserId: e.assigneeUserId,
+      }))
+      copyToClipboard(items)
+    },
+    [events, copyToClipboard, workOrderDefId, canCopy]
+  )
+
+  const copySelection = useCallback(() => copyIds(selectedIds), [copyIds, selectedIds])
+
+  const openPasteDialogAt = useCallback(
+    (target: PasteAnchor | null) => {
+      if (!canPaste || !clipboardItems) return
+      setPasteTarget(target ?? { day: anchorDate })
+    },
+    [canPaste, clipboardItems, anchorDate]
+  )
+
+  const openPasteDialogAtHoveredSlot = useCallback(() => {
+    const slot = hoveredSlotRef.current
+    openPasteDialogAt(
+      slot ? { day: slot.date, time: slot.time, resourceId: slot.resourceId } : null
+    )
+  }, [openPasteDialogAt])
+
+  const closePasteDialog = useCallback(() => setPasteTarget(null), [])
+
+  // Cmd/Ctrl+C — copies the current selection. `ignoreInputs: true` mirrors the workflow
+  // canvas's own Mod+V precedent (`use-workflow-shortcuts.ts`): Ctrl/Meta combos default to
+  // FIRING inside text inputs (`@tanstack/hotkeys`'s per-key default), which would hijack a
+  // dispatcher's native copy while editing a title/note field. A non-empty text selection is
+  // also left alone — the user is copying text, not events.
+  useHotkey(
+    'Mod+C',
+    () => {
+      if (!canCopy || selectedIds.length === 0) return
+      if (typeof window !== 'undefined' && window.getSelection()?.toString()) return
+      copySelection()
+    },
+    { ignoreInputs: true, enabled: canCopy }
+  )
+
+  // Cmd/Ctrl+V — opens the paste-options dialog anchored at the hovered slot (plan 37c §5, H).
+  useHotkey(
+    'Mod+V',
+    () => {
+      if (!canPaste || !clipboardItems) return
+      openPasteDialogAtHoveredSlot()
+    },
+    { ignoreInputs: true, enabled: canPaste }
+  )
+
+  return {
+    hoveredSlotRef,
+    clipboardItems,
+    hasClipboard: clipboardItems !== null,
+    copyIds,
+    copySelection,
+    pasteTarget,
+    openPasteDialogAt,
+    openPasteDialogAtHoveredSlot,
+    closePasteDialog,
+  }
+}

--- a/apps/web/src/components/calendar/sources/visits-source.tsx
+++ b/apps/web/src/components/calendar/sources/visits-source.tsx
@@ -19,9 +19,12 @@ type MyVisit = RouterOutputs['dispatch']['myVisits'][number]
 /** Emerald-500 — the visits source's default toggle-dot/chip color (decision D: color is per-surface). */
 const VISITS_COLOR = '#10b981'
 
-/** A `dispatch.myVisits` row mapped onto the shared event shape. */
+/** A `dispatch.myVisits` row mapped onto the shared event shape. `workOrderId` (plan 37c §8,
+ * Phase 6) is the `EntityInstance` id the copy handler needs to build a `RecordId` via
+ * `toRecordId(workOrderDefId, workOrderId)` — the same conversion the board does at copy time. */
 export interface VisitEvent extends SourcedEvent {
   status: MyVisit['status']
+  workOrderId: string
 }
 
 /**
@@ -76,6 +79,7 @@ export const visitsSource: CalendarSource<VisitEvent> = {
           color: VISITS_COLOR,
           sourceId: 'visits',
           status: visit.status,
+          workOrderId: visit.workOrder.id,
         })),
       [query.data]
     )

--- a/apps/web/src/components/calendar/ui/paste-visits-dialog.tsx
+++ b/apps/web/src/components/calendar/ui/paste-visits-dialog.tsx
@@ -1,4 +1,8 @@
-// apps/web/src/components/dispatch/ui/board/paste-visits-dialog.tsx
+// apps/web/src/components/calendar/ui/paste-visits-dialog.tsx
+//
+// Paste-options dialog (plan 37c §4.3) — moved here in Phase 6 (§8) so both the dispatch board
+// and the schedule surface can share one dialog instead of duplicating it; the board keeps
+// importing it from this shared location.
 
 'use client'
 
@@ -20,27 +24,41 @@ import { format } from 'date-fns'
 import { useEffect, useMemo, useState } from 'react'
 import { computePasteTimes, hoursToDate } from '~/components/calendar/core/clipboard-offset'
 import type { CopiedVisitItem } from '~/components/calendar/core/clipboard-store'
+import type { PasteAnchor } from '~/components/calendar/core/use-calendar-clipboard'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
-import type { PasteAnchor } from './hooks/use-board-clipboard'
-import type { useBoardMutations } from './hooks/use-board-mutations'
-import type { BoardWorker } from './types'
-import { UNASSIGNED_RESOURCE_ID } from './types'
+import type { api } from '~/trpc/react'
+
+/** The synthetic "Unassigned" resource-column id — mirrors `board/types.ts`'s
+ * `UNASSIGNED_RESOURCE_ID`, duplicated here (not imported) so this shared dialog doesn't reach
+ * into the dispatch feature tree for one string constant. A paste target whose `resourceId`
+ * equals this is treated the same as no resource column at all (no retarget option). */
+const UNASSIGNED_RESOURCE_ID = 'unassigned'
+
+/** Minimal worker shape the "assign all to <worker>" retarget option needs — duck-typed so any
+ * consumer's own worker list (the board's richer `BoardWorker`) satisfies it structurally without
+ * this shared dialog importing a feature-specific type. */
+export interface PasteWorkerOption {
+  userId: string
+  user?: { name: string | null; email: string | null } | null
+}
 
 export interface PasteVisitsDialogProps {
-  /** `null` = closed. Set by `use-board-clipboard.ts`'s Cmd+V handler or the context menu's
-   * "Paste here" — always the anchor at the moment the paste was invoked. */
+  /** `null` = closed. Set by a clipboard hook's Cmd+V handler or a context menu's "Paste here" —
+   * always the anchor at the moment the paste was invoked. */
   target: PasteAnchor | null
   onOpenChange: (open: boolean) => void
   items: CopiedVisitItem[]
-  workers: BoardWorker[]
-  pasteVisits: ReturnType<typeof useBoardMutations>['pasteVisits']
+  /** Worker rows the retarget option can offer — empty when the surface has no per-worker
+   * columns at all (schedule's week/day/month views never do, so it always passes `[]`). */
+  workers: PasteWorkerOption[]
+  pasteVisits: ReturnType<typeof api.dispatch.pasteVisits.useMutation>
 }
 
 type AssigneeMode = 'keep' | 'clear' | 'assign'
 type TimesMode = 'keep' | 'slot'
 
-function workerLabel(worker: BoardWorker): string {
+function workerLabel(worker: PasteWorkerOption): string {
   return worker.user?.name ?? worker.user?.email ?? 'Worker'
 }
 

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -26,6 +26,7 @@ import type { ExistingVisitForOverlap } from '../schedule-popover'
 import type { PasteAnchor } from './hooks/use-board-clipboard'
 import type { useBoardMutations } from './hooks/use-board-mutations'
 import { useTimelineHourWindow } from './hooks/use-timeline-hour-window'
+import { type SlotClickTarget, SlotCreatePopover } from './slot-create-popover'
 import type { BoardResourceInput, BoardViewMode, DispatchVisitEvent } from './types'
 import { isPastVisitEvent } from './utils'
 import { VisitChipContent, VisitChipMonthContent } from './visit-chip-content'
@@ -251,6 +252,21 @@ export function BoardCalendarGrid({
   // selection-targeted. Resolved once per `contextmenu` event, not re-derived on render.
   const [menuTarget, setMenuTarget] = useState<BoardMenuTarget | null>(null)
 
+  // Slot-click create (plan 37c §7) — `onSlotClick` carries no mouse event, so the click's
+  // viewport position (for the popover's virtual anchor) is captured separately: an
+  // `onClickCapture` on the wrapper fires BEFORE the cell's own `onClick` (capture phase runs
+  // top-down ahead of the bubble-phase target handler that calls `onSlotClick`), so by the time
+  // `handleSlotClick` reads this ref it already holds the position of the click that triggered
+  // it — same synchronous-ordering trick `handleContextMenu` below uses for its own target.
+  const lastPointerPosRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const handlePointerCapture = useCallback((e: React.MouseEvent) => {
+    lastPointerPosRef.current = { x: e.clientX, y: e.clientY }
+  }, [])
+  const [slotClickTarget, setSlotClickTarget] = useState<SlotClickTarget | null>(null)
+  const handleSlotClick = useCallback((startTime: Date, resourceId?: string) => {
+    setSlotClickTarget({ startTime, resourceId, anchor: lastPointerPosRef.current })
+  }, [])
+
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
       const chipEl = (e.target as HTMLElement).closest?.('[data-event-id]')
@@ -306,6 +322,7 @@ export function BoardCalendarGrid({
       onSelectionChange={onSelectionChange}
       onEventClick={handleEventClick}
       onEventResize={canEdit && view !== 'month' ? onEventResize : undefined}
+      onSlotClick={canEdit ? handleSlotClick : undefined}
       hideToolbar
       isNonWorkingDay={isNonWorkingDay}
       hoveredSlotRef={hoveredSlotRef}
@@ -318,31 +335,44 @@ export function BoardCalendarGrid({
   if (!canEdit) return calendar
 
   return (
-    <ContextMenu
-      onOpenChange={(open) => {
-        if (!open) setMenuTarget(null)
-      }}>
-      {/* `display: contents` keeps this wrapper out of the flex layout — `EventCalendar`'s own
-       * root (className='flex-1' above) still lands as the direct flex child its parent row
-       * (`dispatch-board.tsx`'s `flex flex-1 overflow-hidden`) expects. */}
-      <ContextMenuTrigger asChild>
-        <div className='contents' onContextMenu={handleContextMenu}>
-          {calendar}
-        </div>
-      </ContextMenuTrigger>
-      <ContextMenuContent className='w-48'>
-        {menuTarget?.type === 'chip' ? (
-          <ContextMenuItem onSelect={handleCopyFromMenu}>
-            <Copy /> Copy
-            <ContextMenuShortcut>⌘C</ContextMenuShortcut>
-          </ContextMenuItem>
-        ) : (
-          <ContextMenuItem disabled={!hasClipboard} onSelect={handlePasteFromMenu}>
-            <ClipboardPaste /> Paste here
-            <ContextMenuShortcut>⌘V</ContextMenuShortcut>
-          </ContextMenuItem>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
+    <>
+      <ContextMenu
+        onOpenChange={(open) => {
+          if (!open) setMenuTarget(null)
+        }}>
+        {/* `display: contents` keeps this wrapper out of the flex layout — `EventCalendar`'s own
+         * root (className='flex-1' above) still lands as the direct flex child its parent row
+         * (`dispatch-board.tsx`'s `flex flex-1 overflow-hidden`) expects. */}
+        <ContextMenuTrigger asChild>
+          <div
+            className='contents'
+            onContextMenu={handleContextMenu}
+            onClickCapture={handlePointerCapture}>
+            {calendar}
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent className='w-48'>
+          {menuTarget?.type === 'chip' ? (
+            <ContextMenuItem onSelect={handleCopyFromMenu}>
+              <Copy /> Copy
+              <ContextMenuShortcut>⌘C</ContextMenuShortcut>
+            </ContextMenuItem>
+          ) : (
+            <ContextMenuItem disabled={!hasClipboard} onSelect={handlePasteFromMenu}>
+              <ClipboardPaste /> Paste here
+              <ContextMenuShortcut>⌘V</ContextMenuShortcut>
+            </ContextMenuItem>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+      <SlotCreatePopover
+        target={slotClickTarget}
+        onOpenChange={(open) => {
+          if (!open) setSlotClickTarget(null)
+        }}
+        onSelectionChange={onSelectionChange}
+        mutations={mutations}
+      />
+    </>
   )
 }

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -12,6 +12,7 @@ import { addMinutes } from 'date-fns'
 import { Lock } from 'lucide-react'
 import { parseAsString, useQueryStates } from 'nuqs'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { PasteVisitsDialog } from '~/components/calendar/ui/paste-visits-dialog'
 import { renderAppDragGhost } from '~/components/global/app-drag-overlay'
 import { EmptyState } from '~/components/global/empty-state'
 import { RecordDrawer } from '~/components/records/record-drawer'
@@ -29,13 +30,13 @@ import { BoardBulkBar } from './board-bulk-bar'
 import { BoardCalendarGrid } from './board-calendar-grid'
 import { BoardToolbar } from './board-toolbar'
 import { EventDockPanel } from './event-dock-panel'
+import { computeGroupDragUpdates } from './group-drag'
 import { useAvailabilityShading } from './hooks/use-availability-shading'
 import { useBoardBulkRunner } from './hooks/use-board-bulk-runner'
 import { useBoardClipboard } from './hooks/use-board-clipboard'
 import { useBoardData } from './hooks/use-board-data'
 import { useBoardMutations } from './hooks/use-board-mutations'
 import { useBoardRealtime } from './hooks/use-board-realtime'
-import { PasteVisitsDialog } from './paste-visits-dialog'
 import type { DispatchVisitEvent } from './types'
 import { UNASSIGNED_RESOURCE_ID } from './types'
 import { computeOverlappingVisitIds } from './utils'
@@ -105,6 +106,9 @@ export function DispatchBoard() {
   })
 
   const overlappingIds = useMemo(() => computeOverlappingVisitIds(data.events), [data.events])
+  // Group drag-move (plan 37c §6) — looked up by id so `handleEventDrop` can find every OTHER
+  // selected visit's own start/end without re-deriving it from the drop event.
+  const eventsById = useMemo(() => new Map(data.events.map((e) => [e.id, e])), [data.events])
 
   const [activeVisitId, setActiveVisitId] = useState<string | null>(null)
   // Multi-selection (plan 37c §3) — independent of `activeVisitId` ("which popover is open"):
@@ -219,7 +223,13 @@ export function DispatchBoard() {
   )
 
   const handleEventDrop = useCallback(
-    (event: DispatchVisitEvent, newStart: Date, newEnd: Date, resourceId?: string) => {
+    (
+      event: DispatchVisitEvent,
+      newStart: Date,
+      newEnd: Date,
+      resourceId?: string,
+      groupIds?: string[]
+    ) => {
       if (data.view === 'month') return
       const assigneeUserId =
         resourceId !== undefined
@@ -233,8 +243,47 @@ export function DispatchBoard() {
         endTime: newEnd,
         assigneeUserId,
       })
+
+      // Group drag-move (plan 37c §6) — `groupIds` (from the generic layer's selection-aware
+      // drag data) is only ever length > 1 when the dragged chip was part of a multi-selection.
+      // Every OTHER selected visit shifts by the same delta; assignee is carried to them ONLY
+      // when the drop actually changed the dragged chip's own worker column (`resourceId`
+      // differs from its OWN original `resourceId` — every resource/day/timeline column always
+      // reports SOME `resourceId`, even the one the chip started in, so this is the only correct
+      // "did the row change" test). Committed through the same §5.2 sequential-loop runner the
+      // bulk bar uses — no confirm (the drag itself is the intent), no new endpoint.
+      if (groupIds && groupIds.length > 1) {
+        const rowChanged = resourceId !== undefined && resourceId !== event.resourceId
+        const updates = computeGroupDragUpdates(
+          event.id,
+          new Date(event.start),
+          newStart,
+          groupIds,
+          eventsById,
+          rowChanged ? assigneeUserId : undefined
+        )
+        if (updates.length > 0) {
+          const updatesByVisitId = new Map(updates.map((u) => [u.visitId, u]))
+          void bulkRunner.run(
+            Array.from(updatesByVisitId.keys()),
+            (visitId) => {
+              const update = updatesByVisitId.get(visitId)!
+              return mutations.scheduleVisit.mutateAsync({
+                visitId,
+                startTime: update.startTime,
+                endTime: update.endTime,
+                assigneeUserId: update.assigneeUserId,
+              })
+            },
+            {
+              failureTitle: 'Some visits could not be moved',
+              failureNoun: 'visits',
+            }
+          )
+        }
+      }
     },
-    [data.view, mutations.scheduleVisit]
+    [data.view, mutations.scheduleVisit, eventsById, bulkRunner]
   )
 
   const handleEventResize = useCallback(

--- a/apps/web/src/components/dispatch/ui/board/group-drag.test.ts
+++ b/apps/web/src/components/dispatch/ui/board/group-drag.test.ts
@@ -1,0 +1,142 @@
+// apps/web/src/components/dispatch/ui/board/group-drag.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { computeGroupDragUpdates } from './group-drag'
+import type { DispatchVisitEvent } from './types'
+
+function visit(overrides: Partial<DispatchVisitEvent> & { id: string }): DispatchVisitEvent {
+  return {
+    id: overrides.id,
+    title: overrides.title ?? 'Job',
+    start: overrides.start ?? new Date(2024, 0, 1, 9, 0),
+    end: overrides.end ?? new Date(2024, 0, 1, 10, 0),
+    workOrderId: overrides.workOrderId ?? 'wo-1',
+    assigneeUserId: overrides.assigneeUserId ?? null,
+    resourceId: overrides.resourceId ?? 'worker-a',
+    status: overrides.status ?? 'scheduled',
+    dispatchedAt: overrides.dispatchedAt ?? null,
+    recurrenceRuleId: overrides.recurrenceRuleId ?? null,
+    workOrder: overrides.workOrder ?? undefined,
+    timeConfirmedAt: overrides.timeConfirmedAt ?? null,
+    timezone: overrides.timezone ?? 'UTC',
+    durationMinutes: overrides.durationMinutes ?? 60,
+    ...overrides,
+  } as DispatchVisitEvent
+}
+
+describe('computeGroupDragUpdates', () => {
+  it('shifts every other selected visit by the dragged chip’s delta, preserving relative offsets', () => {
+    const dragged = visit({ id: 'dragged', start: new Date(2024, 0, 1, 9, 0) })
+    const other1 = visit({
+      id: 'other-1',
+      start: new Date(2024, 0, 1, 11, 0),
+      end: new Date(2024, 0, 1, 11, 30),
+    })
+    const other2 = visit({
+      id: 'other-2',
+      start: new Date(2024, 0, 3, 13, 0), // 2 days later than the dragged chip
+      end: new Date(2024, 0, 3, 14, 0),
+    })
+    const eventsById = new Map([
+      [dragged.id, dragged],
+      [other1.id, other1],
+      [other2.id, other2],
+    ])
+
+    // Dragged chip moved +1 day, +2 hours (from 9:00 Jan 1 to 11:00 Jan 2).
+    const newStart = new Date(2024, 0, 2, 11, 0)
+    const updates = computeGroupDragUpdates(
+      dragged.id,
+      new Date(dragged.start),
+      newStart,
+      ['dragged', 'other-1', 'other-2'],
+      eventsById,
+      undefined
+    )
+
+    const byId = new Map(updates.map((u) => [u.visitId, u]))
+    expect(byId.has('dragged')).toBe(false) // caller handles the dragged chip itself
+
+    const u1 = byId.get('other-1')!
+    expect(u1.startTime).toEqual(new Date(2024, 0, 2, 13, 0))
+    expect(u1.endTime).toEqual(new Date(2024, 0, 2, 13, 30))
+
+    const u2 = byId.get('other-2')!
+    expect(u2.startTime).toEqual(new Date(2024, 0, 4, 15, 0))
+    expect(u2.endTime).toEqual(new Date(2024, 0, 4, 16, 0))
+  })
+
+  it('omits assigneeUserId (untouched) when the caller passes undefined — no row change', () => {
+    const dragged = visit({ id: 'dragged' })
+    const other = visit({ id: 'other', assigneeUserId: 'worker-b', resourceId: 'worker-b' })
+    const eventsById = new Map([
+      [dragged.id, dragged],
+      [other.id, other],
+    ])
+
+    const updates = computeGroupDragUpdates(
+      'dragged',
+      new Date(dragged.start),
+      new Date(2024, 0, 1, 10, 0),
+      ['dragged', 'other'],
+      eventsById,
+      undefined
+    )
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0]!.assigneeUserId).toBeUndefined()
+    expect('assigneeUserId' in updates[0]!).toBe(true)
+  })
+
+  it('carries the resolved worker (including null for unassigned) to every other visit when the row changed', () => {
+    const dragged = visit({ id: 'dragged' })
+    const other = visit({ id: 'other' })
+    const eventsById = new Map([
+      [dragged.id, dragged],
+      [other.id, other],
+    ])
+
+    const updates = computeGroupDragUpdates(
+      'dragged',
+      new Date(dragged.start),
+      new Date(2024, 0, 1, 10, 0),
+      ['dragged', 'other'],
+      eventsById,
+      null // dropped on the Unassigned column
+    )
+
+    expect(updates[0]!.assigneeUserId).toBeNull()
+  })
+
+  it('skips a selected id that has fallen out of the fetched events window', () => {
+    const dragged = visit({ id: 'dragged' })
+    const eventsById = new Map([[dragged.id, dragged]])
+
+    const updates = computeGroupDragUpdates(
+      'dragged',
+      new Date(dragged.start),
+      new Date(2024, 0, 1, 10, 0),
+      ['dragged', 'missing'],
+      eventsById,
+      undefined
+    )
+
+    expect(updates).toEqual([])
+  })
+
+  it('returns an empty array when the group is just the dragged chip', () => {
+    const dragged = visit({ id: 'dragged' })
+    const eventsById = new Map([[dragged.id, dragged]])
+
+    const updates = computeGroupDragUpdates(
+      'dragged',
+      new Date(dragged.start),
+      new Date(2024, 0, 1, 10, 0),
+      ['dragged'],
+      eventsById,
+      undefined
+    )
+
+    expect(updates).toEqual([])
+  })
+})

--- a/apps/web/src/components/dispatch/ui/board/group-drag.ts
+++ b/apps/web/src/components/dispatch/ui/board/group-drag.ts
@@ -1,0 +1,55 @@
+// apps/web/src/components/dispatch/ui/board/group-drag.ts
+//
+// Pure delta math for group drag-move (plan `37c-calendar-create-copy-paste.md` §6). No React,
+// no store reads — `computeGroupDragUpdates` is unit-tested directly (`group-drag.test.ts`).
+
+import type { DispatchVisitEvent } from './types'
+
+/** One non-dragged selected visit's commit — mirrors `dispatch.scheduleVisit`'s input shape.
+ * `assigneeUserId: undefined` means "omit the key" (the scheduleVisit gotcha, plan 37c §2.5):
+ * `undefined` must never be conflated with `null` (explicitly unassigned). */
+export interface GroupDragUpdate {
+  visitId: string
+  startTime: Date
+  endTime: Date
+  assigneeUserId?: string | null
+}
+
+/**
+ * §6: every OTHER selected visit shifts by the SAME delta the dragged chip moved (relative
+ * offsets preserved) via plain millisecond arithmetic on each visit's own `start`/`end` — this
+ * also covers a month-view whole-day drag for free (a day's worth of milliseconds shifts the
+ * date, not just the time-of-day). Assignee is carried ONLY when `groupAssigneeUserId` is
+ * anything other than `undefined` — the caller resolves that once (comparing the drop's
+ * resolved worker against the dragged chip's OWN original resource column) so every row here
+ * gets identical assignee semantics: all-or-nothing, never a per-row guess.
+ *
+ * Returns one row per id in `groupIds` EXCLUDING `draggedEventId` — the caller already has its
+ * own `scheduleVisit` call for the chip dnd-kit actually dragged.
+ */
+export function computeGroupDragUpdates(
+  draggedEventId: string,
+  originalStart: Date,
+  newStart: Date,
+  groupIds: string[],
+  eventsById: ReadonlyMap<string, DispatchVisitEvent>,
+  groupAssigneeUserId: string | null | undefined
+): GroupDragUpdate[] {
+  const deltaMs = newStart.getTime() - originalStart.getTime()
+  const updates: GroupDragUpdate[] = []
+
+  for (const id of groupIds) {
+    if (id === draggedEventId) continue
+    const event = eventsById.get(id)
+    if (!event) continue // Selected id no longer in the fetched window — skip, don't guess.
+
+    updates.push({
+      visitId: id,
+      startTime: new Date(new Date(event.start).getTime() + deltaMs),
+      endTime: new Date(new Date(event.end).getTime() + deltaMs),
+      assigneeUserId: groupAssigneeUserId,
+    })
+  }
+
+  return updates
+}

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-clipboard.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-clipboard.ts
@@ -2,26 +2,16 @@
 
 'use client'
 
-import type { HoveredSlot } from '@auxx/ui/components/event-calendar'
-import { useHotkey } from '@tanstack/react-hotkeys'
-import { useCallback, useRef, useState } from 'react'
 import {
-  type CopiedVisitItem,
-  useClipboardCopy,
-  useClipboardItems,
-} from '~/components/calendar/core/clipboard-store'
-import { toRecordId } from '~/components/resources'
+  type PasteAnchor,
+  useCalendarClipboard,
+} from '~/components/calendar/core/use-calendar-clipboard'
 import type { DispatchVisitEvent } from '../types'
 
-/** Where a paste lands — the board-local mirror of `HoveredSlot` (day + fractional hours +
- * resource column), built either from the live hover ref (Cmd+V) or a right-click snapshot
- * (context menu "Paste here"). `time`/`resourceId` are absent for a day-only target (month
- * view, or no cell ever hovered — falls back to the board's current anchor date). */
-export interface PasteAnchor {
-  day: Date
-  time?: number
-  resourceId?: string
-}
+/** Re-exported so board files keep importing the anchor type from this hook (the generic
+ * primitive it wraps lives in `~/components/calendar/core/use-calendar-clipboard`, plan 37c §8's
+ * Phase 6 extraction — schedule's clipboard hook consumes the same type). */
+export type { PasteAnchor }
 
 interface UseBoardClipboardOptions {
   events: DispatchVisitEvent[]
@@ -38,11 +28,11 @@ interface UseBoardClipboardOptions {
 }
 
 /**
- * Board clipboard state machine (plan 37c §4, board-only per Phase 3's scope): owns the
- * hovered-slot ref `board-calendar-grid.tsx` feeds into `EventCalendar`, the Cmd+C/Cmd+V
- * keybindings, and the paste-options dialog's open/target state. Copy/context-menu targeting
- * stay in `board-calendar-grid.tsx` (it already owns selection + chip DOM); this hook only
- * exposes the primitives (`copyIds`, `openPasteDialogAt`) they call into.
+ * Board clipboard state machine (plan 37c §4, board-only per Phase 3's scope): a thin wrapper
+ * over the generic `useCalendarClipboard` (Phase 6 extraction) — the board gates copy AND paste
+ * on the same `canEdit` (schedule's Phase 6 hook gates them separately). Copy/context-menu
+ * targeting stay in `board-calendar-grid.tsx` (it already owns selection + chip DOM); this hook
+ * only exposes the primitives (`copyIds`, `openPasteDialogAt`) they call into.
  */
 export function useBoardClipboard({
   events,
@@ -51,84 +41,12 @@ export function useBoardClipboard({
   workOrderDefId,
   canEdit,
 }: UseBoardClipboardOptions) {
-  const clipboardItems = useClipboardItems()
-  const copyToClipboard = useClipboardCopy()
-  const hoveredSlotRef = useRef<HoveredSlot | null>(null)
-  const [pasteTarget, setPasteTarget] = useState<PasteAnchor | null>(null)
-
-  const copyIds = useCallback(
-    (ids: string[]) => {
-      if (!canEdit || !workOrderDefId || ids.length === 0) return
-      const idSet = new Set(ids)
-      const picked = events.filter((e) => idSet.has(e.id))
-      if (picked.length === 0) return
-      const items: CopiedVisitItem[] = picked.map((e) => ({
-        kind: 'visit',
-        visitId: e.id,
-        workOrderRecordId: toRecordId(workOrderDefId, e.workOrderId),
-        title: e.title,
-        start: e.start,
-        end: e.end,
-        assigneeUserId: e.assigneeUserId,
-      }))
-      copyToClipboard(items)
-    },
-    [events, copyToClipboard, workOrderDefId, canEdit]
-  )
-
-  const copySelection = useCallback(() => copyIds(selectedVisitIds), [copyIds, selectedVisitIds])
-
-  const openPasteDialogAt = useCallback(
-    (target: PasteAnchor | null) => {
-      if (!canEdit || !clipboardItems) return
-      setPasteTarget(target ?? { day: boardDate })
-    },
-    [canEdit, clipboardItems, boardDate]
-  )
-
-  const openPasteDialogAtHoveredSlot = useCallback(() => {
-    const slot = hoveredSlotRef.current
-    openPasteDialogAt(
-      slot ? { day: slot.date, time: slot.time, resourceId: slot.resourceId } : null
-    )
-  }, [openPasteDialogAt])
-
-  const closePasteDialog = useCallback(() => setPasteTarget(null), [])
-
-  // Cmd/Ctrl+C — copies the current selection. `ignoreInputs: true` mirrors the workflow
-  // canvas's own Mod+V precedent (`use-workflow-shortcuts.ts`): Ctrl/Meta combos default to
-  // FIRING inside text inputs (`@tanstack/hotkeys`'s per-key default), which would hijack a
-  // dispatcher's native copy while editing a title/note field. A non-empty text selection is
-  // also left alone — the user is copying text, not events.
-  useHotkey(
-    'Mod+C',
-    () => {
-      if (!canEdit || selectedVisitIds.length === 0) return
-      if (typeof window !== 'undefined' && window.getSelection()?.toString()) return
-      copySelection()
-    },
-    { ignoreInputs: true, enabled: canEdit }
-  )
-
-  // Cmd/Ctrl+V — opens the paste-options dialog anchored at the hovered slot (plan 37c §5, H).
-  useHotkey(
-    'Mod+V',
-    () => {
-      if (!canEdit || !clipboardItems) return
-      openPasteDialogAtHoveredSlot()
-    },
-    { ignoreInputs: true, enabled: canEdit }
-  )
-
-  return {
-    hoveredSlotRef,
-    clipboardItems,
-    hasClipboard: clipboardItems !== null,
-    copyIds,
-    copySelection,
-    pasteTarget,
-    openPasteDialogAt,
-    openPasteDialogAtHoveredSlot,
-    closePasteDialog,
-  }
+  return useCalendarClipboard({
+    events,
+    selectedIds: selectedVisitIds,
+    anchorDate: boardDate,
+    workOrderDefId,
+    canCopy: canEdit,
+    canPaste: canEdit,
+  })
 }

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
@@ -8,8 +8,28 @@ import { useCallback } from 'react'
 import { parseRecordId, type RecordId } from '~/components/resources'
 import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
-import type { BoardResult, BoardVisit } from '../types'
+import type { BoardResult, BoardVisit, BoardWorkOrder } from '../types'
 import type { DateRange } from './use-board-data'
+
+/** `dispatch.addVisit`'s per-call input, post-coercion — same `unknown`-widening gotcha as
+ * `pasteVisits`'s `PasteVisitVars` above (`z.coerce.date()` + the recordId schema cast widen
+ * every field to `unknown` on the client-side mutation-variables type). Scoped to this
+ * optimistic patch only. */
+interface AddVisitVars {
+  workOrderRecordId: RecordId
+  startTime?: Date
+  endTime?: Date
+  assigneeUserId?: string | null
+}
+
+/** `dispatch.createWorkOrder`'s per-call input, post-coercion — same widening gotcha. */
+interface CreateWorkOrderVars {
+  contactRecordId: RecordId
+  title?: string
+  startTime: Date
+  endTime: Date
+  assigneeUserId?: string | null
+}
 
 /** `dispatch.pasteVisits`'s per-item input, post-coercion — `z.coerce.date()` (and the
  * `recordIdSchema` cast) make the CLIENT-side mutation-variables type widen every field to
@@ -242,6 +262,113 @@ export function useBoardMutations(range: DateRange) {
     onSettled: settle,
   })
 
+  // Plan 37c §7, item 2 — slot-click create's "Visit for existing job" path: the existing
+  // `dispatch.addVisit` endpoint (unchanged), wrapped with the board's own optimistic temp-row
+  // patch (the `pasteVisits` recipe above, singular) so the new visit's chip appears instantly.
+  // The target work order already exists in the cache, so (unlike `createWorkOrder` below) no
+  // synthetic `BoardWorkOrder` entry is needed — the title/number resolve immediately.
+  const addVisit = api.dispatch.addVisit.useMutation({
+    onMutate: async (rawVars) => {
+      await utils.dispatch.getBoard.cancel(range)
+      const vars = rawVars as AddVisitVars
+      const previous = utils.dispatch.getBoard.getData(range)
+      if (previous && vars.startTime && vars.endTime) {
+        const now = new Date()
+        const tempVisit: BoardVisit = {
+          id: generateId('temp-visit'),
+          organizationId: organizationId ?? '',
+          workOrderId: parseRecordId(vars.workOrderRecordId).entityInstanceId,
+          assigneeUserId: vars.assigneeUserId ?? null,
+          startTime: vars.startTime,
+          endTime: vars.endTime,
+          timezone: 'UTC',
+          status: 'scheduled',
+          routeOrder: null,
+          latitude: null,
+          longitude: null,
+          geocodedAt: null,
+          dispatchedAt: null,
+          timeConfirmedAt: now,
+          durationMinutes: Math.round((vars.endTime.getTime() - vars.startTime.getTime()) / 60_000),
+          recurrenceRuleId: null,
+          occurrenceDate: null,
+          isDetached: false,
+          createdAt: now,
+          updatedAt: now,
+        }
+        utils.dispatch.getBoard.setData(range, {
+          ...previous,
+          visits: [...previous.visits, tempVisit],
+        })
+      }
+      return { previous }
+    },
+    onError: (error, _vars, ctx) => {
+      rollback(ctx?.previous)
+      toastError({ title: 'Error adding visit', description: error.message })
+    },
+    onSettled: settle,
+  })
+
+  // Plan 37c §7, item 1 — slot-click create's "New job" path. Unlike every other board
+  // mutation, the work order itself doesn't exist in the cache yet either — the optimistic
+  // patch inserts a synthetic `BoardWorkOrder` (client-known title, `number: null`) ALONGSIDE
+  // the temp visit row (the `pasteVisits` recipe), so the chip renders the real title instead of
+  // `visitToEvent`'s no-work-order fallback for the brief window before the settle invalidate
+  // swaps in the real (numbered) work order.
+  const createWorkOrder = api.dispatch.createWorkOrder.useMutation({
+    onMutate: async (rawVars) => {
+      await utils.dispatch.getBoard.cancel(range)
+      const vars = rawVars as CreateWorkOrderVars
+      const previous = utils.dispatch.getBoard.getData(range)
+      if (previous) {
+        const now = new Date()
+        const tempWorkOrderId = generateId('temp-work-order')
+        const tempWorkOrder: BoardWorkOrder = {
+          id: tempWorkOrderId,
+          displayName: vars.title?.trim() || 'New job',
+          number: null,
+          status: 'new',
+          contactId: vars.contactRecordId,
+          contactDisplayName: null,
+        }
+        const tempVisit: BoardVisit = {
+          id: generateId('temp-visit'),
+          organizationId: organizationId ?? '',
+          workOrderId: tempWorkOrderId,
+          assigneeUserId: vars.assigneeUserId ?? null,
+          startTime: vars.startTime,
+          endTime: vars.endTime,
+          timezone: 'UTC',
+          status: 'scheduled',
+          routeOrder: null,
+          latitude: null,
+          longitude: null,
+          geocodedAt: null,
+          dispatchedAt: null,
+          timeConfirmedAt: now,
+          durationMinutes: Math.round((vars.endTime.getTime() - vars.startTime.getTime()) / 60_000),
+          recurrenceRuleId: null,
+          occurrenceDate: null,
+          isDetached: false,
+          createdAt: now,
+          updatedAt: now,
+        }
+        utils.dispatch.getBoard.setData(range, {
+          ...previous,
+          workOrders: [...previous.workOrders, tempWorkOrder],
+          visits: [...previous.visits, tempVisit],
+        })
+      }
+      return { previous }
+    },
+    onError: (error, _vars, ctx) => {
+      rollback(ctx?.previous)
+      toastError({ title: 'Error creating work order', description: error.message })
+    },
+    onSettled: settle,
+  })
+
   return {
     scheduleVisit,
     assignVisit,
@@ -251,5 +378,7 @@ export function useBoardMutations(range: DateRange) {
     applyToSeries,
     cancelVisitFollowing,
     pasteVisits,
+    addVisit,
+    createWorkOrder,
   }
 }

--- a/apps/web/src/components/dispatch/ui/board/slot-create-assignee-picker.tsx
+++ b/apps/web/src/components/dispatch/ui/board/slot-create-assignee-picker.tsx
@@ -1,0 +1,94 @@
+// apps/web/src/components/dispatch/ui/board/slot-create-assignee-picker.tsx
+
+'use client'
+
+import { getActorRawId, toActorId } from '@auxx/types/actor'
+import { Command, CommandGroup, CommandItem, CommandList } from '@auxx/ui/components/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { UserX } from 'lucide-react'
+import { useState } from 'react'
+import { ActorPickerContent } from '~/components/pickers/actor-picker/actor-picker-content'
+import { useActors } from '~/components/resources/hooks/use-actor'
+import { PickerTrigger } from '~/components/ui/picker-trigger'
+import { useWorkerActorExcludes } from '../shared/use-worker-actor-excludes'
+
+export interface SlotCreateAssigneePickerProps {
+  /** `null` = unassigned. */
+  value: string | null
+  onChange: (userId: string | null) => void
+  disabled?: boolean
+}
+
+/**
+ * Single-select, worker-filtered assignee field for the slot-create popover (plan 37c §7) — the
+ * same `ActorPickerContent` + `useWorkerActorExcludes` recipe `AssigneeRow`
+ * (`../shared/assignee-row.tsx`) and the bulk bar's `BoardAssignPicker` already use, minus both
+ * components' own coupling (`AssigneeRow` requires a `SeriesScopeProvider` ancestor for its
+ * commit gate; `BoardAssignPicker` is shaped for `ActionBar`'s `anchorRef` picker contract) that
+ * this plain create-form field — a local `useState`, no commit gate — doesn't need.
+ */
+export function SlotCreateAssigneePicker({
+  value,
+  onChange,
+  disabled,
+}: SlotCreateAssigneePickerProps) {
+  const [open, setOpen] = useState(false)
+  const excludeIds = useWorkerActorExcludes()
+  const assigneeActorId = value ? toActorId('user', value) : null
+  const hydrated = useActors(assigneeActorId ? [assigneeActorId] : [])
+  const assigneeActor = assigneeActorId ? hydrated.get(assigneeActorId) : undefined
+  const label = assigneeActor?.name ?? 'Worker'
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <PickerTrigger
+          open={open}
+          disabled={disabled}
+          hasValue={!!value}
+          placeholder='Unassigned'
+          showClear={!!value}
+          onClear={(e) => {
+            e.stopPropagation()
+            onChange(null)
+          }}>
+          {label}
+        </PickerTrigger>
+      </PopoverTrigger>
+      <PopoverContent className='w-72 p-0' align='start'>
+        <Command shouldFilter={false} className='rounded-lg rounded-b-none'>
+          <CommandList>
+            <CommandGroup>
+              <CommandItem
+                onSelect={() => {
+                  onChange(null)
+                  setOpen(false)
+                }}
+                className='flex items-center gap-2'>
+                <UserX className='size-4 text-muted-foreground' />
+                Unassigned
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+        {/* Plain divider, not `CommandSeparator` — same reason as `board-assign-picker.tsx`: two
+         * independent `Command` roots stacked (the static "Unassigned" row, then the searchable
+         * `ActorPickerContent` worker list). */}
+        <div className='h-px bg-border/50 dark:bg-[#323842]/80' />
+        <ActorPickerContent
+          value={[]}
+          onChange={() => {}}
+          target='user'
+          multi={false}
+          disabled={disabled}
+          excludeIds={excludeIds}
+          onSelectSingle={(actorId) => {
+            onChange(getActorRawId(actorId))
+            setOpen(false)
+          }}
+          placeholder='Search workers...'
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/board/slot-create-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/slot-create-popover.tsx
@@ -1,0 +1,304 @@
+// apps/web/src/components/dispatch/ui/board/slot-create-popover.tsx
+
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { addMinutes } from 'date-fns'
+import { useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { type RecordId, useResource } from '~/components/resources'
+import { MultiRelationInput } from '~/components/shared/multi-relation-input'
+import type { useBoardMutations } from './hooks/use-board-mutations'
+import { SlotCreateAssigneePicker } from './slot-create-assignee-picker'
+import { UNASSIGNED_RESOURCE_ID } from './types'
+
+/** The board's slot-click target (plan 37c §7) — the clicked cell's start/resource (from the
+ * grid's `onSlotClick`) plus the click's viewport position, captured separately (`onSlotClick`
+ * carries no mouse event) so the popover can anchor at the exact spot instead of the board's
+ * current view. `null` = closed. */
+export interface SlotClickTarget {
+  startTime: Date
+  resourceId?: string
+  anchor: { x: number; y: number }
+}
+
+type SlotCreateTab = 'new' | 'existing'
+
+const DEFAULT_DURATION_MINUTES = 60
+
+interface TimeAssigneeFieldsProps {
+  startTime: Date
+  onStartTimeChange: (date: Date) => void
+  durationMinutes: number
+  onDurationChange: (minutes: number) => void
+  assigneeUserId: string | null
+  onAssigneeChange: (userId: string | null) => void
+  disabled: boolean
+}
+
+/** Start/Duration/Assignee — identical on both tabs (the slot's time and worker prefill don't
+ * depend on which path creates the visit), factored out so the two `TabsContent` panels only
+ * differ in their subject picker (contact vs. work order) and submit action. */
+function TimeAssigneeFields({
+  startTime,
+  onStartTimeChange,
+  durationMinutes,
+  onDurationChange,
+  assigneeUserId,
+  onAssigneeChange,
+  disabled,
+}: TimeAssigneeFieldsProps) {
+  return (
+    <>
+      <FieldPanelRow title='Start'>
+        <FieldInputAdapter
+          fieldType={FieldType.DATETIME}
+          value={startTime.toISOString()}
+          onChange={(val) => {
+            if (val) onStartTimeChange(new Date(val as string))
+          }}
+          disabled={disabled}
+        />
+      </FieldPanelRow>
+      <FieldPanelRow title='Duration'>
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
+          value={durationMinutes}
+          onChange={(val) =>
+            onDurationChange(typeof val === 'number' ? val : DEFAULT_DURATION_MINUTES)
+          }
+          placeholder='60'
+          disabled={disabled}
+        />
+      </FieldPanelRow>
+      <FieldPanelRow title='Assignee'>
+        <SlotCreateAssigneePicker
+          value={assigneeUserId}
+          onChange={onAssigneeChange}
+          disabled={disabled}
+        />
+      </FieldPanelRow>
+    </>
+  )
+}
+
+export interface SlotCreatePopoverProps {
+  target: SlotClickTarget | null
+  onOpenChange: (open: boolean) => void
+  /** Selects the newly created/added visit's chip (the board's `selectedVisitIds` setter) —
+   * fired from `onSuccess`, matching the plan's "select after settle" wording (the optimistic
+   * temp row above has no real id to select yet). */
+  onSelectionChange: (ids: string[]) => void
+  mutations: Pick<ReturnType<typeof useBoardMutations>, 'createWorkOrder' | 'addVisit'>
+}
+
+/**
+ * Slot-click create popover (plan 37c §7) — opened by `BoardCalendarGrid`'s `onSlotClick`
+ * (fires only when the selection is empty, §3.2). Anchored at the click's viewport position via
+ * an invisible virtual anchor (`PopoverAnchor asChild` around a zero-size `position: fixed`
+ * span) rather than a real chip element — the grid's `onSlotClick` carries no DOM node/mouse
+ * event to anchor to the way `EventPopover`'s chip anchor does (`board-calendar-grid.tsx`
+ * captures the click position separately, in an `onClickCapture` ahead of the cell's own
+ * `onClick`, and hands it down as `target.anchor`).
+ *
+ * Two paths (decision D): **New job** builds a work order from a contact + optional title
+ * (`dispatch.createWorkOrder`); **Existing job** finds a work order and adds a visit to it
+ * (`dispatch.addVisit`, unchanged). Both share the same Start/Duration/Assignee fields,
+ * prefilled from the clicked slot.
+ */
+export function SlotCreatePopover({
+  target,
+  onOpenChange,
+  onSelectionChange,
+  mutations,
+}: SlotCreatePopoverProps) {
+  const { resource: contactResource } = useResource('contacts')
+  const { resource: workOrderResource } = useResource('work-orders')
+
+  const [tab, setTab] = useState<SlotCreateTab>('new')
+  const [contactRecordId, setContactRecordId] = useState<RecordId | null>(null)
+  const [workOrderRecordId, setWorkOrderRecordId] = useState<RecordId | null>(null)
+  const [title, setTitle] = useState('')
+  const [startTime, setStartTime] = useState<Date>(() => target?.startTime ?? new Date())
+  const [durationMinutes, setDurationMinutes] = useState(DEFAULT_DURATION_MINUTES)
+  const [assigneeUserId, setAssigneeUserId] = useState<string | null>(null)
+
+  // Re-seed every time a NEW slot is clicked — never while already open for the current target
+  // (the `PasteVisitsDialog` reset-on-target-change precedent). Assignee prefills from the
+  // clicked resource column (day/timeline); week/month never pass a `resourceId`, so this
+  // naturally lands `null` there without a view-specific branch.
+  useEffect(() => {
+    if (!target) return
+    setTab('new')
+    setContactRecordId(null)
+    setWorkOrderRecordId(null)
+    setTitle('')
+    setStartTime(target.startTime)
+    setDurationMinutes(DEFAULT_DURATION_MINUTES)
+    setAssigneeUserId(
+      target.resourceId && target.resourceId !== UNASSIGNED_RESOURCE_ID ? target.resourceId : null
+    )
+  }, [target])
+
+  const isPending = mutations.createWorkOrder.isPending || mutations.addVisit.isPending
+
+  const handleCreateJob = () => {
+    if (!contactRecordId) return
+    const endTime = addMinutes(startTime, durationMinutes)
+    mutations.createWorkOrder.mutate(
+      { contactRecordId, title: title.trim() || undefined, startTime, endTime, assigneeUserId },
+      {
+        onSuccess: (result) => {
+          onSelectionChange([result.visitId])
+          onOpenChange(false)
+        },
+      }
+    )
+  }
+
+  const handleAddVisit = () => {
+    if (!workOrderRecordId) return
+    const endTime = addMinutes(startTime, durationMinutes)
+    mutations.addVisit.mutate(
+      { workOrderRecordId, startTime, endTime, assigneeUserId },
+      {
+        onSuccess: (visit) => {
+          onSelectionChange([visit.id])
+          onOpenChange(false)
+        },
+      }
+    )
+  }
+
+  return (
+    <Popover
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) onOpenChange(false)
+      }}>
+      <PopoverAnchor asChild>
+        <span
+          aria-hidden
+          style={{
+            position: 'fixed',
+            left: target?.anchor.x ?? 0,
+            top: target?.anchor.y ?? 0,
+            width: 0,
+            height: 0,
+            pointerEvents: 'none',
+          }}
+        />
+      </PopoverAnchor>
+      <PopoverContent
+        side='right'
+        align='start'
+        sideOffset={8}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        className='w-96 rounded-3xl shadow-xl'>
+        {target && (
+          <Tabs value={tab} onValueChange={(v) => setTab(v as SlotCreateTab)}>
+            <TabsList variant='outline' className='w-full justify-start'>
+              <TabsTrigger value='new' variant='outline'>
+                New job
+              </TabsTrigger>
+              <TabsTrigger value='existing' variant='outline'>
+                Existing job
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value='new' className='space-y-3 pt-3'>
+              <FieldPanel
+                orientation='responsive'
+                breakpoint='md'
+                resizeId='slot-create-form'
+                defaultLabelWidth={80}
+                className='p-0'>
+                <FieldPanelRow title='Contact' isRequired>
+                  <MultiRelationInput
+                    entityDefinitionId={contactResource?.id}
+                    value={contactRecordId ? [contactRecordId] : []}
+                    onChange={(ids) => setContactRecordId(ids[0] ?? null)}
+                    multi={false}
+                    placeholder='Select a contact'
+                    disabled={isPending}
+                  />
+                </FieldPanelRow>
+                <FieldPanelRow title='Title'>
+                  <FieldInputAdapter
+                    fieldType={FieldType.TEXT}
+                    value={title}
+                    onChange={(val) => setTitle((val as string) ?? '')}
+                    placeholder='Defaults to the contact name'
+                    disabled={isPending}
+                  />
+                </FieldPanelRow>
+                <TimeAssigneeFields
+                  startTime={startTime}
+                  onStartTimeChange={setStartTime}
+                  durationMinutes={durationMinutes}
+                  onDurationChange={setDurationMinutes}
+                  assigneeUserId={assigneeUserId}
+                  onAssigneeChange={setAssigneeUserId}
+                  disabled={isPending}
+                />
+              </FieldPanel>
+              <Button
+                className='w-full'
+                size='sm'
+                variant='outline'
+                onClick={handleCreateJob}
+                loading={mutations.createWorkOrder.isPending}
+                loadingText='Creating...'
+                disabled={!contactRecordId || isPending}>
+                Create job
+              </Button>
+            </TabsContent>
+
+            <TabsContent value='existing' className='space-y-3 pt-3'>
+              <FieldPanel
+                orientation='responsive'
+                breakpoint='md'
+                resizeId='slot-create-form'
+                defaultLabelWidth={80}
+                className='p-0'>
+                <FieldPanelRow title='Job' isRequired>
+                  <MultiRelationInput
+                    entityDefinitionId={workOrderResource?.id}
+                    value={workOrderRecordId ? [workOrderRecordId] : []}
+                    onChange={(ids) => setWorkOrderRecordId(ids[0] ?? null)}
+                    multi={false}
+                    placeholder='Search jobs...'
+                    disabled={isPending}
+                  />
+                </FieldPanelRow>
+                <TimeAssigneeFields
+                  startTime={startTime}
+                  onStartTimeChange={setStartTime}
+                  durationMinutes={durationMinutes}
+                  onDurationChange={setDurationMinutes}
+                  assigneeUserId={assigneeUserId}
+                  onAssigneeChange={setAssigneeUserId}
+                  disabled={isPending}
+                />
+              </FieldPanel>
+              <Button
+                className='w-full'
+                size='sm'
+                variant='outline'
+                onClick={handleAddVisit}
+                loading={mutations.addVisit.isPending}
+                loadingText='Adding...'
+                disabled={!workOrderRecordId || isPending}>
+                Add visit
+              </Button>
+            </TabsContent>
+          </Tabs>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/schedule/ui/schedule-calendar.tsx
+++ b/apps/web/src/components/schedule/ui/schedule-calendar.tsx
@@ -5,8 +5,11 @@
 // `EventCalendar` grid, sourced from the `visits`/`meetings` calendar-source registry (plan
 // 01-source-registry-refactor.md). No drag-move/resize/create (decision I′ — the schedule grid
 // is display-only; scheduling stays the dispatch board's job) — `onEventClick` is the only
-// interaction, dispatched by `event.sourceId` to the click targets `schedule-page.tsx` owns
-// (decision D′).
+// click-through interaction, dispatched by `event.sourceId` to the click targets
+// `schedule-page.tsx` owns (decision D′). Phase 6 (plan `37c-calendar-create-copy-paste.md` §8)
+// adds the second layer on top of that: multi-select (free from the grid's generic selection
+// engine) and visit copy/paste — copy is open to everyone, paste is admin/owner-gated because
+// every dispatch write is `dispatchAdminProcedure`.
 
 'use client'
 
@@ -17,17 +20,26 @@ import {
   type RenderEventContext,
 } from '@auxx/ui/components/event-calendar'
 import { ModuleSidebar } from '@auxx/ui/components/module-sidebar'
-import { useMemo } from 'react'
+import { toastError } from '@auxx/ui/components/toast'
+import { useMemo, useState } from 'react'
 import { hiddenIdsForGroup } from '~/components/calendar/core/source-visibility'
 import type { CalendarSource, SourcedEvent } from '~/components/calendar/core/types'
+import { useCalendarClipboard } from '~/components/calendar/core/use-calendar-clipboard'
 import type { CalendarRangeView, DateRange } from '~/components/calendar/core/use-calendar-range'
 import { meetingsSource } from '~/components/calendar/sources/meetings-source'
 import type { TaskEvent } from '~/components/calendar/sources/tasks-source'
 import { tasksSource } from '~/components/calendar/sources/tasks-source'
-import { visitsSource } from '~/components/calendar/sources/visits-source'
+import { type VisitEvent, visitsSource } from '~/components/calendar/sources/visits-source'
 import { MiniCalendarSection } from '~/components/calendar/ui/mini-calendar-section'
+import {
+  PasteVisitsDialog,
+  type PasteWorkerOption,
+} from '~/components/calendar/ui/paste-visits-dialog'
 import { SourceToggleGroup } from '~/components/calendar/ui/source-toggle-group'
+import { useResource } from '~/components/resources'
 import { useSettings } from '~/hooks/use-settings'
+import { useUser } from '~/hooks/use-user'
+import { api } from '~/trpc/react'
 import { useScheduleSidebarStore } from '../stores/schedule-sidebar-store'
 
 /** Sidebar group id for the visits/meetings source toggle rows. */
@@ -36,6 +48,11 @@ const KINDS_GROUP = 'kinds'
 /** Stable empty default — an inline `[]` would recreate `EventCalendar`'s `selectedIdSet` every
  * render whenever nothing is selected. */
 const EmptySelection: string[] = []
+
+/** The paste dialog's worker-retarget list — always empty on schedule (no per-worker resource
+ * columns exist on this grid, so the "assign all to <worker>" option never applies); a stable
+ * reference so `PasteVisitsDialog`'s memo doesn't recompute every render. */
+const EmptyWorkers: PasteWorkerOption[] = []
 
 /**
  * Module-level static source list — hook rules require a page's source list never change
@@ -74,7 +91,12 @@ interface ScheduleCalendarProps {
   onVisitClick: (visitId: string) => void
   onMeetingClick: (meetingId: string) => void
   onTaskClick: (task: TaskEvent['task']) => void
-  /** Event id whose detail drawer/sheet is open — draws the in-color selection ring. */
+  /** Event id whose detail drawer/sheet is open — only used to SEED the initial multi-selection
+   * (below) so switching from list view with something already open still shows a ring on
+   * mount; once mounted, selection is purely gesture-driven (plan 37c §8) and no longer
+   * resynced from this prop (a plain click already keeps the two in lockstep — the grid's
+   * selection engine calls `onSelectionChange([id])` on the very same click that opens the
+   * drawer via `onEventClick`). */
   selectedEventId?: string | null
 }
 
@@ -102,6 +124,18 @@ export function ScheduleCalendar({
   const toggleHidden = useScheduleSidebarStore((s) => s.toggleHidden)
 
   const hiddenIds = hiddenIdsForGroup(hidden, KINDS_GROUP)
+
+  // Multi-selection (plan 37c §8) — grid-internal gesture layer (cmd/shift/marquee/day-grab/
+  // Escape) comes free from `EventCalendar`'s generic selection engine; this is just the
+  // controlled state it reads/writes. Seeded (not resynced) from `selectedEventId` — see the
+  // prop's doc comment.
+  const [selectedEventIds, setSelectedEventIds] = useState<string[]>(() =>
+    selectedEventId ? [selectedEventId] : []
+  )
+
+  const { isAdminOrOwner, userId } = useUser()
+  const { resource: workOrderResource } = useResource('work-orders')
+  const utils = api.useUtils()
 
   const { getSetting } = useSettings({ scope: 'GENERAL' })
   const weekStart = (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
@@ -133,12 +167,64 @@ export function ScheduleCalendar({
     SOURCE_BY_ID[event.sourceId]?.renderEvent(event, ctx) ?? null
 
   // Plain-click-only (plan 37c §3.2 — the grid never calls this on a modifier-click), so
-  // behavior here is unchanged; multi-selection/copy-paste for this surface is a later phase.
+  // behavior here is unchanged from before multi-selection/copy-paste landed.
   const handleEventClick = (event: SourcedEvent, _e: React.MouseEvent) => {
     if (event.sourceId === 'visits') onVisitClick(event.id)
     else if (event.sourceId === 'meetings') onMeetingClick(event.id)
     else if (event.sourceId === 'tasks') onTaskClick((event as TaskEvent).task)
   }
+
+  // Copy (plan 37c §8): enabled for everyone, but only `sourceId === 'visits'` events are
+  // clipboard-eligible — meetings/tasks have no work order to paste onto, so they're narrowed
+  // out here rather than filtered a second time inside `useCalendarClipboard`. `workOrderId`
+  // comes straight off `VisitEvent` (added alongside this phase); `assigneeUserId` isn't part of
+  // the source's payload at all — `dispatch.myVisits` only ever returns the signed-in worker's
+  // OWN visits, so it's always the current user, no need to round-trip it through the query.
+  const visitClipboardEvents = useMemo(
+    () =>
+      events
+        .filter((event): event is VisitEvent => event.sourceId === 'visits')
+        .map((event) => ({
+          id: event.id,
+          workOrderId: event.workOrderId,
+          title: event.title,
+          start: event.start,
+          end: event.end,
+          assigneeUserId: userId,
+        })),
+    [events, userId]
+  )
+
+  const clipboard = useCalendarClipboard({
+    events: visitClipboardEvents,
+    selectedIds: selectedEventIds,
+    anchorDate: date,
+    workOrderDefId: workOrderResource?.id,
+    canCopy: true,
+    // Paste is admin/owner-only (every dispatch write is `dispatchAdminProcedure`) — non-admins
+    // get no Cmd+V, no dialog, no affordance at all (plan 37c §8, derived decision).
+    canPaste: isAdminOrOwner,
+  })
+
+  // No optimistic cache patch here (unlike the board's `use-board-mutations.ts` `pasteVisits`) —
+  // this surface has no local cache shape to patch against; `dispatch.myVisits` invalidate on
+  // settle is enough. It can't rely on the realtime `dispatch:visit-changed` broadcast alone: the
+  // acting client's own socket id is excluded from its own broadcast (the board's optimistic
+  // patch is what stands in for it there), and paste is only ever invoked BY this same client.
+  const pasteVisits = api.dispatch.pasteVisits.useMutation({
+    onSuccess: (result) => {
+      if (result.failures.length > 0) {
+        toastError({
+          title: 'Some visits could not be pasted',
+          description: `${result.failures.length} of ${result.created.length + result.failures.length} visits failed to paste`,
+        })
+      }
+    },
+    onError: (error) => toastError({ title: 'Error pasting visits', description: error.message }),
+    onSettled: () => {
+      void utils.dispatch.myVisits.invalidate()
+    },
+  })
 
   // The grid's keyboard shortcuts (`EventCalendar`'s M/W/D/A) can emit 'agenda'/'resource' too —
   // this shell only ever offers day/week/month, so filter those out before forwarding.
@@ -179,11 +265,24 @@ export function ScheduleCalendar({
         events={events}
         renderEvent={renderEvent}
         onEventClick={handleEventClick}
-        selectedEventIds={selectedEventId ? [selectedEventId] : EmptySelection}
+        selectedEventIds={selectedEventIds.length > 0 ? selectedEventIds : EmptySelection}
+        onSelectionChange={setSelectedEventIds}
+        hoveredSlotRef={clipboard.hoveredSlotRef}
         weekStartsOn={weekStartsOn}
         hideToolbar
         className='flex-1'
       />
+      {isAdminOrOwner && (
+        <PasteVisitsDialog
+          target={clipboard.pasteTarget}
+          onOpenChange={(open) => {
+            if (!open) clipboard.closePasteDialog()
+          }}
+          items={clipboard.clipboardItems ?? []}
+          workers={EmptyWorkers}
+          pasteVisits={pasteVisits}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -13,6 +13,7 @@ import {
   closeMyVisit,
   convertRequestToWorkOrder,
   createQcItemTemplate,
+  createWorkOrder,
   createWorkOrderFromTicket,
   deleteQcItemTemplate,
   dispatchVisit,
@@ -416,6 +417,32 @@ export const dispatchRouter = createTRPCRouter({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         workOrderInstanceId: entityInstanceId,
+        startTime: input.startTime,
+        endTime: input.endTime,
+        assigneeUserId: input.assigneeUserId,
+        excludeSocketId: excludeSocketId(ctx),
+      })
+    }),
+
+  // Plan 37c §7 — slot-click create's "New job" path: builds a minimal work order from a
+  // contact + title + slot times (not a conversion — see `createFromTicket`/`convertToWorkOrder`
+  // above for the source-copying flows). Admin-gated like the rest of visit machinery (§B).
+  createWorkOrder: dispatchAdminProcedure
+    .input(
+      z.object({
+        contactRecordId: recordIdSchema,
+        title: z.string().optional(),
+        startTime: z.coerce.date(),
+        endTime: z.coerce.date(),
+        assigneeUserId: z.string().nullable().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return createWorkOrder({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        contactRecordId: input.contactRecordId,
+        title: input.title,
         startTime: input.startTime,
         endTime: input.endTime,
         assigneeUserId: input.assigneeUserId,

--- a/apps/worker/scripts/verify-dispatch-create-work-order.ts
+++ b/apps/worker/scripts/verify-dispatch-create-work-order.ts
@@ -1,0 +1,337 @@
+// apps/worker/scripts/verify-dispatch-create-work-order.ts
+/**
+ * `createWorkOrder` verification (plans/dispatch/37c-calendar-create-copy-paste.md §7/§9 Phase
+ * 5). Exercises the REAL write path `createWorkOrder`
+ * (packages/lib/src/dispatch/create-work-order.ts) — the §2.5-corrected mechanism where
+ * `handler.create('work_order', ...)` does NOT itself schedule anything; a field-change hook
+ * (`ensureVisitOnWorkOrderCreate`, keyed off the first `work_order_number` write) auto-creates
+ * one UNSCHEDULED visit synchronously inside that call, and `createWorkOrder` has to look that
+ * row up (it isn't returned) before `scheduleVisit`-ing it with the slot's times/assignee. This
+ * script's job is checking that hand-off, not `scheduleVisit`/`handler.create` themselves:
+ *
+ * - The work order lands with the right title and a contact link; `work_order_status` rolls up
+ *   to `'scheduled'` (not `'new'`) because `createWorkOrder` schedules the visit in the same call.
+ * - Exactly ONE visit exists on the new work order (the hook's row, found and scheduled in
+ *   place — never a second stray insert) and it carries the given times + assignee.
+ * - Title omitted/blank → falls back to the contact's `EntityInstance.displayName`.
+ * - `assigneeUserId` omitted → the visit lands unassigned (`null`), same as every other
+ *   fresh-row contract in this codebase (`addVisit`/`pasteVisits`).
+ *
+ * Work orders + their contacts are created via `UnifiedCrudHandler.create` (M1 hooks), prefixed
+ * "[create-wo-verify]", and deleted at the end — `WorkOrderVisit.workOrderId` cascades on
+ * `EntityInstance` delete (the `verify-dispatch-paste-visits.ts` precedent). No
+ * dispatch/notification/money path is touched (fresh rows never carry a prior `dispatchedAt`),
+ * so no queue pausing is needed.
+ *
+ * Timing: the dev org has no `OperatingHours` row so the org resolves to 'UTC' (asserted as a
+ * precondition, the `verify-dispatch-series-end.ts`/`verify-dispatch-paste-visits.ts`
+ * precedent); all times here are plain UTC.
+ *
+ * Run (from repo root) under the worker runtime:
+ *   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
+ *     scripts/verify-dispatch-create-work-order.ts
+ */
+
+import { database } from '@auxx/database'
+import { getOrgCache } from '@auxx/lib/cache'
+import { createWorkOrder } from '@auxx/lib/dispatch'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+
+/** Pulls the EntityInstance id back out of a `entityDefId:entityInstanceId` RecordId string
+ * without pulling in `@auxx/types` (not a worker dependency — the `verify-money-*.ts`
+ * precedent). */
+function instanceIdOf(recordId: string): string {
+  return recordId.split(':')[1]!
+}
+
+let pass = 0
+let fail = 0
+function check(name: string, ok: boolean, detail?: unknown) {
+  if (ok) {
+    pass++
+    console.log(`  ✅ ${name}`)
+  } else {
+    fail++
+    console.log(`  ❌ ${name}`, detail ?? '')
+  }
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+function addDaysToIso(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00.000Z`)
+  d.setUTCDate(d.getUTCDate() + days)
+  return isoDate(d)
+}
+/** A UTC start/end pair `daysFromNow` at a fixed hour, `durationMinutes` long. */
+function slot(daysFromNow: number, hour: number, durationMinutes = 60) {
+  const start = new Date(`${addDaysToIso(isoDate(new Date()), daysFromNow)}T00:00:00.000Z`)
+  start.setUTCHours(hour, 0, 0, 0)
+  const end = new Date(start.getTime() + durationMinutes * 60_000)
+  return { startTime: start, endTime: end }
+}
+
+async function getVisitsSorted(workOrderInstanceId: string) {
+  return database.query.WorkOrderVisit.findMany({
+    where: (t, { eq }) => eq(t.workOrderId, workOrderInstanceId),
+    orderBy: (t, { asc }) => [asc(t.startTime)],
+  })
+}
+
+/** Reads the `work_order_contact` relationship value back off the created work order — a raw
+ * `FieldValue` row read (`relatedEntityId` is the RELATIONSHIP storage column) rather than the
+ * `FieldValueService`/`getFieldValues` route, so this script doesn't need `@auxx/types`'
+ * `TypedFieldValue` shape (not a worker dependency — the `verify-money-*.ts` precedent). */
+async function getContactLinkInstanceId(
+  organizationId: string,
+  workOrderInstanceId: string
+): Promise<string | undefined> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['work_order_contact'] as const)
+  if (!cf.work_order_contact) return undefined
+  const row = await database.query.FieldValue.findFirst({
+    where: (t, { and, eq }) =>
+      and(
+        eq(t.organizationId, organizationId),
+        eq(t.entityId, workOrderInstanceId),
+        eq(t.fieldId, cf.work_order_contact!.id)
+      ),
+    columns: { relatedEntityId: true },
+  })
+  return row?.relatedEntityId ?? undefined
+}
+
+/** Reads `work_order_status` back (the SINGLE_SELECT `optionId` storage column) — confirms the
+ * create landed at the expected `'new'`. */
+async function getStatus(
+  organizationId: string,
+  workOrderInstanceId: string
+): Promise<string | undefined> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['work_order_status'] as const)
+  if (!cf.work_order_status) return undefined
+  const row = await database.query.FieldValue.findFirst({
+    where: (t, { and, eq }) =>
+      and(
+        eq(t.organizationId, organizationId),
+        eq(t.entityId, workOrderInstanceId),
+        eq(t.fieldId, cf.work_order_status!.id)
+      ),
+    columns: { optionId: true },
+  })
+  return row?.optionId ?? undefined
+}
+
+async function main() {
+  const user = await database.query.User.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.email, 'm4rkuskk@gmail.com'),
+  })
+  if (!user) throw new Error('Dev user not found')
+  const organizationId = 'u45w22ft66ymiaa19ohs7m9f' // Marki Corp (primary dev org)
+  const userId = user.id
+  console.log(`Org ${organizationId}, user ${userId}`)
+
+  const opHours = await database.query.OperatingHours.findFirst({
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.subjectType, 'organization')),
+    columns: { timezone: true },
+  })
+  if (opHours?.timezone && opHours.timezone !== 'UTC') {
+    throw new Error(`Expected dev org timezone 'UTC', got '${opHours.timezone}'`)
+  }
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const createdRecordIds: string[] = []
+
+  try {
+    // ══════════════════════════════════════════════════════════════════════
+    // 1. Full create: explicit title + assignee — WO fields, contact link, exactly ONE
+    //    visit, scheduled with the given times/assignee.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('1: full create — explicit title + assignee')
+    const contact1 = await handler.create('contact', {
+      first_name: '[create-wo-verify]',
+      last_name: 'ContactOne',
+    })
+    createdRecordIds.push(contact1.recordId)
+
+    const item1 = slot(5, 9)
+    const result1 = await createWorkOrder({
+      organizationId,
+      userId,
+      contactRecordId: contact1.recordId,
+      title: '[create-wo-verify] custom job title',
+      startTime: item1.startTime,
+      endTime: item1.endTime,
+      assigneeUserId: userId,
+    })
+    createdRecordIds.push(result1.workOrderRecordId)
+
+    const wo1InstanceId = instanceIdOf(result1.workOrderRecordId)
+    const wo1Instance = await database.query.EntityInstance.findFirst({
+      where: (t, { and, eq }) => and(eq(t.id, wo1InstanceId), eq(t.organizationId, organizationId)),
+      columns: { displayName: true },
+    })
+    check(
+      'work order title matches the given title',
+      wo1Instance?.displayName === '[create-wo-verify] custom job title',
+      wo1Instance?.displayName
+    )
+    // `handler.create` lands `work_order_status: 'new'`, but `createWorkOrder` immediately
+    // `scheduleVisit`s the hook-created visit in the same call — `scheduleVisit`'s own roll-up
+    // (`lifecycle.ts`'s forward-only guard, trigger `'scheduled'`) advances the work order to
+    // `'scheduled'` right away, same as every other schedule action (drag from backlog, etc.).
+    // A slot-click create never observably rests at `'new'`.
+    check(
+      'work order status rolls up to "scheduled" (the visit was scheduled in the same call)',
+      (await getStatus(organizationId, wo1InstanceId)) === 'scheduled'
+    )
+    check(
+      'work order contact link points at the given contact',
+      (await getContactLinkInstanceId(organizationId, wo1InstanceId)) === contact1.instance.id
+    )
+
+    const visits1 = await getVisitsSorted(wo1InstanceId)
+    check('exactly ONE visit exists on the new work order', visits1.length === 1, visits1.length)
+    const visit1 = visits1[0]
+    check('the returned visitId matches the actual row', visit1?.id === result1.visitId)
+    check(
+      'visit is scheduled with the given times',
+      visit1?.startTime?.getTime() === item1.startTime.getTime() &&
+        visit1?.endTime?.getTime() === item1.endTime.getTime(),
+      visit1
+    )
+    check('visit status is "scheduled"', visit1?.status === 'scheduled')
+    check('visit assignee matches the given userId', visit1?.assigneeUserId === userId)
+    check(
+      'visit is rule-less (a from-scratch job, never a series)',
+      visit1?.recurrenceRuleId === null && visit1?.occurrenceDate === null
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 2. Title omitted → falls back to the contact's displayName.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('2: title omitted → falls back to contact displayName')
+    const contact2 = await handler.create('contact', {
+      first_name: '[create-wo-verify]',
+      last_name: 'FallbackTitle',
+    })
+    createdRecordIds.push(contact2.recordId)
+    const contact2Instance = await database.query.EntityInstance.findFirst({
+      where: (t, { and, eq }) =>
+        and(eq(t.id, contact2.instance.id), eq(t.organizationId, organizationId)),
+      columns: { displayName: true },
+    })
+    check(
+      'setup: contact has a populated displayName',
+      typeof contact2Instance?.displayName === 'string' && contact2Instance.displayName.length > 0,
+      contact2Instance?.displayName
+    )
+
+    const item2 = slot(6, 10)
+    const result2 = await createWorkOrder({
+      organizationId,
+      userId,
+      contactRecordId: contact2.recordId,
+      startTime: item2.startTime,
+      endTime: item2.endTime,
+    })
+    createdRecordIds.push(result2.workOrderRecordId)
+
+    const wo2InstanceId = instanceIdOf(result2.workOrderRecordId)
+    const wo2Instance = await database.query.EntityInstance.findFirst({
+      where: (t, { and, eq }) => and(eq(t.id, wo2InstanceId), eq(t.organizationId, organizationId)),
+      columns: { displayName: true },
+    })
+    check(
+      'work order title falls back to the contact displayName',
+      wo2Instance?.displayName === contact2Instance?.displayName,
+      { woTitle: wo2Instance?.displayName, contactDisplayName: contact2Instance?.displayName }
+    )
+    const visits2 = await getVisitsSorted(wo2InstanceId)
+    check('exactly ONE visit exists', visits2.length === 1, visits2.length)
+
+    // Blank (whitespace-only) title is treated the same as omitted.
+    console.log('2b: blank title also falls back to contact displayName')
+    const item2b = slot(6, 13)
+    const result2b = await createWorkOrder({
+      organizationId,
+      userId,
+      contactRecordId: contact2.recordId,
+      title: '   ',
+      startTime: item2b.startTime,
+      endTime: item2b.endTime,
+    })
+    createdRecordIds.push(result2b.workOrderRecordId)
+    const wo2bInstance = await database.query.EntityInstance.findFirst({
+      where: (t, { and, eq }) =>
+        and(
+          eq(t.id, instanceIdOf(result2b.workOrderRecordId)),
+          eq(t.organizationId, organizationId)
+        ),
+      columns: { displayName: true },
+    })
+    check(
+      'blank title falls back to the contact displayName too',
+      wo2bInstance?.displayName === contact2Instance?.displayName,
+      wo2bInstance?.displayName
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 3. assigneeUserId omitted → the visit lands unassigned.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('3: assigneeUserId omitted → unassigned')
+    const contact3 = await handler.create('contact', {
+      first_name: '[create-wo-verify]',
+      last_name: 'Unassigned',
+    })
+    createdRecordIds.push(contact3.recordId)
+
+    const item3 = slot(7, 14)
+    const result3 = await createWorkOrder({
+      organizationId,
+      userId,
+      contactRecordId: contact3.recordId,
+      title: '[create-wo-verify] unassigned job',
+      startTime: item3.startTime,
+      endTime: item3.endTime,
+      // assigneeUserId intentionally omitted
+    })
+    createdRecordIds.push(result3.workOrderRecordId)
+
+    const wo3InstanceId = instanceIdOf(result3.workOrderRecordId)
+    const visits3 = await getVisitsSorted(wo3InstanceId)
+    check('exactly ONE visit exists', visits3.length === 1, visits3.length)
+    check(
+      'omitted assigneeUserId: visit lands unassigned',
+      visits3[0]?.assigneeUserId === null,
+      visits3[0]?.assigneeUserId
+    )
+    check(
+      'visit still carries the given times despite no assignee',
+      visits3[0]?.startTime?.getTime() === item3.startTime.getTime() &&
+        visits3[0]?.endTime?.getTime() === item3.endTime.getTime()
+    )
+  } finally {
+    console.log(`Cleanup: deleting ${createdRecordIds.length} verify records`)
+    for (const recordId of createdRecordIds.reverse()) {
+      try {
+        await handler.delete(recordId as never)
+      } catch (err) {
+        console.log(`  cleanup failed for ${recordId}:`, err instanceof Error ? err.message : err)
+      }
+    }
+  }
+
+  console.log(`\n${pass}/${pass + fail} passed`)
+  process.exit(fail > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/dispatch/create-work-order.ts
+++ b/packages/lib/src/dispatch/create-work-order.ts
@@ -1,0 +1,87 @@
+// packages/lib/src/dispatch/create-work-order.ts
+//
+// Slot-click create's server write (plans/dispatch/37c-calendar-create-copy-paste.md §7, §2.5
+// correction). Unlike `convert-to-work-order.ts`/`create-from-ticket.ts` (which copy fields off
+// an existing source record), this is the "build a work order from nothing" path — a mini
+// contact + title + time form, not a conversion.
+
+import { database, schema } from '@auxx/database'
+import { parseRecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { NotFoundError } from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud'
+import type { CreateWorkOrderInput, CreateWorkOrderResult } from './types'
+import { scheduleVisit } from './visit-mutations'
+
+/**
+ * Create a work order from the board's slot-click "New job" popover (§7). **Mechanism
+ * (§2.5 correction)**: neither this function nor `handler.create` calls
+ * `ensureVisitForWorkOrder` directly — the field-change hook `ensureVisitOnWorkOrderCreate`
+ * (`visit-hooks.ts`) auto-creates exactly ONE unscheduled visit the instant `work_order_number`
+ * first lands, and that hook fires (and is awaited) synchronously inside `handler.create`
+ * (`setValueWithBuiltIn`'s post-write hook chain), so by the time `create` resolves the row
+ * already exists. This function looks that row up (it isn't returned synchronously) and then
+ * `scheduleVisit`s it with the slot's times/assignee — the same call every other visit-create
+ * flow ends at (mirror, roll-up, sequence enrollment, broadcast).
+ *
+ * `work_order_job_type` is left at its schema default (`'one_off'`) — this is always a
+ * from-scratch job, never a conversion, so (unlike `convertRequestToWorkOrder`) there's nothing
+ * to explain about not setting it; it's just never touched.
+ *
+ * @param input - organizationId, userId (acting user), contactRecordId, optional title (falls
+ * back to the contact's displayName), the slot's startTime/endTime, optional assigneeUserId.
+ * @returns The new work order's RecordId and the id of the visit that was scheduled onto it.
+ */
+export async function createWorkOrder(input: CreateWorkOrderInput): Promise<CreateWorkOrderResult> {
+  const { organizationId, userId, contactRecordId, startTime, endTime, assigneeUserId } = input
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  let title = input.title?.trim()
+  if (!title) {
+    const { entityInstanceId: contactInstanceId } = parseRecordId(contactRecordId)
+    const contact = await database.query.EntityInstance.findFirst({
+      where: and(
+        eq(schema.EntityInstance.id, contactInstanceId),
+        eq(schema.EntityInstance.organizationId, organizationId)
+      ),
+      columns: { displayName: true },
+    })
+    title = contact?.displayName || 'New job'
+  }
+
+  const values: Record<string, unknown> = {
+    work_order_title: title,
+    work_order_status: 'new',
+    work_order_contact: contactRecordId,
+  }
+
+  // Events ON (user-triggered, no skipEvents): timeline + realtime `record:created` + the
+  // §F.4a number pre-hook + the visit auto-create hook all fire from this call — by the time it
+  // resolves, the hook-created visit row below already exists.
+  const created = await handler.create('work_order', values)
+
+  const visit = await database.query.WorkOrderVisit.findFirst({
+    where: and(
+      eq(schema.WorkOrderVisit.organizationId, organizationId),
+      eq(schema.WorkOrderVisit.workOrderId, created.instance.id)
+    ),
+  })
+  if (!visit) {
+    // Defensive only — `ensureVisitOnWorkOrderCreate` guarantees exactly one row per work-order
+    // create; a miss here means the hook chain didn't run, which is a bug elsewhere, not a
+    // recoverable input error.
+    throw new NotFoundError('Work order created without its auto-created visit')
+  }
+
+  const scheduled = await scheduleVisit({
+    organizationId,
+    userId,
+    visitId: visit.id,
+    startTime,
+    endTime,
+    assigneeUserId,
+    excludeSocketId: input.excludeSocketId,
+  })
+
+  return { workOrderRecordId: created.recordId, visitId: scheduled.id }
+}

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -9,6 +9,7 @@ export type { VisitChangedPayload } from './broadcast'
 export { publishVisitChanged } from './broadcast'
 export { convertRequestToWorkOrder } from './convert-to-work-order'
 export { createWorkOrderFromTicket } from './create-from-ticket'
+export { createWorkOrder } from './create-work-order'
 export type { LifecycleTrigger } from './lifecycle'
 export { rollUpWorkOrderStatus } from './lifecycle'
 export { mirrorVisitOntoWorkOrder } from './mirror'
@@ -114,6 +115,8 @@ export type {
   AssignVisitInput,
   ConvertRequestToWorkOrderInput,
   CreateFromTicketInput,
+  CreateWorkOrderInput,
+  CreateWorkOrderResult,
   DispatchVisitInput,
   RestoreVisitInput,
   ScheduleVisitInput,

--- a/packages/lib/src/dispatch/types.ts
+++ b/packages/lib/src/dispatch/types.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/dispatch/types.ts
 
+import type { RecordId } from '@auxx/types/resource'
+
 /** Input for {@link createWorkOrderFromTicket} — the SECONDARY intake path (01 §8). */
 export interface CreateFromTicketInput {
   organizationId: string
@@ -14,6 +16,27 @@ export interface ConvertRequestToWorkOrderInput {
   userId: string
   /** EntityInstance id of the source service request (not the RecordId). */
   requestInstanceId: string
+}
+
+/** Input for {@link createWorkOrder} — the slot-click create flow (plan 37c §7): the board's
+ * "New job" path, building a work order from nothing (not a conversion). */
+export interface CreateWorkOrderInput {
+  organizationId: string
+  userId: string
+  /** RecordId of the contact this job is for. */
+  contactRecordId: RecordId
+  /** Falls back to the contact's `EntityInstance.displayName` when omitted/blank. */
+  title?: string
+  startTime: Date
+  endTime: Date
+  assigneeUserId?: string | null
+  excludeSocketId?: string
+}
+
+/** Output of {@link createWorkOrder}. */
+export interface CreateWorkOrderResult {
+  workOrderRecordId: RecordId
+  visitId: string
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
+++ b/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
@@ -40,6 +40,14 @@ interface CalendarDndContextValue<T extends EventCalendarItem = EventCalendarIte
   eventHeight: number | null
   /** Chip width (px) of the drag source — set only for horizontal (timeline) chips. */
   eventWidth: number | null
+  /**
+   * Group drag-move (plan `37c-calendar-create-copy-paste.md` §6) — the full set of ids moving
+   * together (including the drag source), non-null only when the dragged chip was part of a
+   * multi-selection (size > 1) at drag start. `DraggableEvent` reads this to dim every OTHER
+   * selected chip while the drag is in flight; the `DragOverlay` ghost reads its size for the
+   * "×N" count badge.
+   */
+  activeGroupIds: Set<string> | null
 }
 
 const CalendarDndContext = createContext<CalendarDndContextValue>({
@@ -52,6 +60,7 @@ const CalendarDndContext = createContext<CalendarDndContextValue>({
   currentResourceId: null,
   eventHeight: null,
   eventWidth: null,
+  activeGroupIds: null,
 })
 
 export const useCalendarDnd = () => useContext(CalendarDndContext)
@@ -63,8 +72,19 @@ interface CalendarDndProviderProps<T extends EventCalendarItem = EventCalendarIt
    * droppable cells (move = reschedule/reassign). The calendar itself never
    * mutates — this is the only place a write happens, and it's the
    * consumer's job to call their own mutation.
+   *
+   * `groupIds` (plan 37c §6) — present (length > 1) only when the dragged chip was part of a
+   * multi-selection: every id in the selection, INCLUDING the dragged one, so the consumer's
+   * write semantics (delta math, worker blast-radius) live entirely on their side — dnd-kit
+   * itself only ever drags the one chip.
    */
-  onEventDrop?: (event: T, newStart: Date, newEnd: Date, resourceId?: string) => void
+  onEventDrop?: (
+    event: T,
+    newStart: Date,
+    newEnd: Date,
+    resourceId?: string,
+    groupIds?: string[]
+  ) => void
   /**
    * Escape hatch for composition: fires on every drag end regardless of
    * whether the dragged item is a calendar event. Mount `CalendarDndProvider`
@@ -99,6 +119,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
   const [eventHeight, setEventHeight] = useState<number | null>(null)
   const [eventWidth, setEventWidth] = useState<number | null>(null)
   const [foreignActive, setForeignActive] = useState<Active | null>(null)
+  const [activeGroupIds, setActiveGroupIds] = useState<Set<string> | null>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -128,7 +149,17 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event
     const data = active.data.current as
-      | { event?: T; view?: DraggableView; height?: number; width?: number }
+      | {
+          event?: T
+          view?: DraggableView
+          height?: number
+          width?: number
+          /** See `DraggableEvent` — reads the REAL selection engine (this provider may be
+           * mounted ambiently, above the calendar's own `CalendarSelectionProvider`, so it can't
+           * read that context itself) and, as a side effect, collapses the selection to just
+           * this chip when it's dragged from outside it. */
+          onGroupDragStart?: () => string[] | null
+        }
       | undefined
     if (!data?.event) {
       setForeignActive(active)
@@ -142,6 +173,8 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     setCurrentTime(new Date(data.event.start))
     setEventHeight(data.height ?? null)
     setEventWidth(data.width ?? null)
+    const groupIds = data.onGroupDragStart?.() ?? null
+    setActiveGroupIds(groupIds && groupIds.length > 1 ? new Set(groupIds) : null)
   }
 
   const handleDragOver = (event: DragOverEvent) => {
@@ -190,6 +223,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     setEventHeight(null)
     setEventWidth(null)
     setForeignActive(null)
+    setActiveGroupIds(null)
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -222,7 +256,13 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
         const newEnd = addMinutes(newStart, durationMinutes)
 
         if (newStart.getTime() !== originalStart.getTime()) {
-          onEventDrop?.(calendarEvent, newStart, newEnd, overData.resourceId)
+          onEventDrop?.(
+            calendarEvent,
+            newStart,
+            newEnd,
+            overData.resourceId,
+            activeGroupIds ? Array.from(activeGroupIds) : undefined
+          )
         }
       }
     }
@@ -249,6 +289,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
           currentResourceId,
           eventHeight,
           eventWidth,
+          activeGroupIds,
         }}>
         {children}
 
@@ -277,6 +318,14 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
                 currentTime={currentTime || undefined}
                 renderEvent={renderEvent}
               />
+              {/* Group drag-move count badge (plan 37c §6) — only when the drag source was part
+                  of a multi-selection; makes the "every selected visit moves together, and gets
+                  the target worker if the row changed" blast radius visible mid-drag. */}
+              {activeGroupIds && activeGroupIds.size > 1 && (
+                <div className='bg-primary text-primary-foreground absolute -top-2 -right-2 z-50 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] font-semibold shadow'>
+                  ×{activeGroupIds.size}
+                </div>
+              )}
               {/* Live snapped landing time (plan 35 §3) — month drags are whole-day, no pill. */}
               {activeView !== 'month' && currentTime && (
                 <div className='absolute top-full left-0 mt-1'>

--- a/packages/ui/src/components/event-calendar/draggable-event.tsx
+++ b/packages/ui/src/components/event-calendar/draggable-event.tsx
@@ -59,7 +59,7 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
   orientation = 'y',
   cellSize,
 }: DraggableEventProps<T>) {
-  const { activeId, hasDropHandler } = useCalendarDnd()
+  const { activeId, hasDropHandler, activeGroupIds } = useCalendarDnd()
   const selection = useCalendarSelection()
   const elementRef = useRef<HTMLDivElement>(null)
   const [dragHandlePosition, setDragHandlePosition] = useState<{ x: number; y: number } | null>(
@@ -81,6 +81,22 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
       dragHandlePosition,
       isFirstDay,
       isLastDay,
+      // Group drag-move (plan 37c §6) — called once from `CalendarDndProvider.handleDragStart`,
+      // which may be mounted ABOVE this chip's own `CalendarSelectionProvider` (an ambient
+      // provider composed by the consumer, e.g. dispatch's board — see that provider's doc
+      // comment) and so can't read the real selection engine via context itself; this chip
+      // already holds the real engine (`useCalendarSelection()` above), so the closure carries
+      // it across. Returns every selected id (this chip included) when it's dragged as part of
+      // a multi-selection (size > 1); as a side effect, dragging a chip OUTSIDE the current
+      // selection collapses the selection to just this chip first (mirrors a plain click).
+      onGroupDragStart: (): string[] | null => {
+        const selected = selection.getSelectedIds()
+        if (!selected.has(event.id)) {
+          selection.emitSelection(new Set([event.id]))
+          return null
+        }
+        return selected.size > 1 ? Array.from(selected) : null
+      },
     },
   })
 
@@ -115,6 +131,12 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
   // DragOverlay copy is the "moving" one — so we neither hide the origin nor apply the
   // pointer `transform` to it (that would make the origin chase the cursor as a second ghost).
   const isDragSource = isDragging || activeId === `${event.id}-${view}`
+
+  // Group drag-move (plan 37c §6) — every OTHER selected chip dims while the group is in
+  // flight, so the "these ids are moving together" blast radius reads clearly against the
+  // count badge on the ghost. The drag source itself is excluded (it already renders via the
+  // DragOverlay above, and `isDragSource` keeps its origin solid per the comment above).
+  const isGroupMoving = Boolean(activeGroupIds?.has(event.id)) && !isDragSource
 
   const effectiveSize =
     isResizing && previewSize !== null ? previewSize : orientation === 'x' ? width : height
@@ -155,7 +177,11 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
       }}
       data-event-id={event.id}
       style={style}
-      className={cn('group/event touch-none', canResize && 'relative')}>
+      className={cn(
+        'group/event touch-none',
+        canResize && 'relative',
+        isGroupMoving && 'pointer-events-none opacity-50'
+      )}>
       <EventItem
         event={event}
         view={view as CalendarView}

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -152,8 +152,17 @@ export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarI
    * "what's hovered right now" for a Cmd+V paste anchor or a right-click menu without owning a
    * selection engine of its own. Ref-only, never causes a re-render. */
   hoveredSlotRef?: React.MutableRefObject<HoveredSlot | null>
-  /** The calendar never mutates — every write (move or resize) round-trips through these. */
-  onEventDrop?: (event: T, newStart: Date, newEnd: Date, resourceId?: string) => void
+  /**
+   * The calendar never mutates — every write (move or resize) round-trips through these.
+   * `groupIds` (plan 37c §6) — see `CalendarDndProvider`'s `onEventDrop` doc.
+   */
+  onEventDrop?: (
+    event: T,
+    newStart: Date,
+    newEnd: Date,
+    resourceId?: string,
+    groupIds?: string[]
+  ) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   /** Hide the built-in date-nav/view-switcher header when the consumer brings their own toolbar chrome. */
   hideToolbar?: boolean


### PR DESCRIPTION
## Summary

Phases 4–6 of `plans/dispatch/37c-calendar-create-copy-paste.md` (phases 0–3 shipped in #1257).

### Phase 4 — group drag-move (board)
- Dragging a chip that belongs to a multi-selection moves the whole selection: the drag ghost gets a `×N` count badge, the other selected chips dim while the drag is in flight.
- On drop, every selected visit shifts by the same delta (pure helper `group-drag.ts`, unit-tested); the target worker is applied to **all** selected visits only when the drop actually changed the dragged chip's own column.
- Commits through the existing §5.2 bulk-runner loop over `scheduleVisit` — no new endpoints, no confirm (the drag is the intent). Dragging an unselected chip collapses the selection to it; resize stays per-chip; backlog drops stay single-visit.

### Phase 5 — slot-click create (board)
- Empty-slot click opens `SlotCreatePopover` (virtual-anchor popover at the click position) with two paths: **New job** (contact + optional title → new `dispatch.createWorkOrder`) and **Existing job** (work-order picker → existing `dispatch.addVisit`). Time and worker prefill from the clicked slot.
- `createWorkOrder` (lib `create-work-order.ts`, `dispatchAdminProcedure`) follows the §2.5-corrected mechanism: `handler.create('work_order', …)` → look up the hook-created unscheduled visit → `scheduleVisit` it with the slot times. Optimistic temp work-order + visit rows on the board; the new chip is selected on success.

### Phase 6 — schedule surface
- `/app/schedule` gains multi-select (free from the shared selection engine) and visit copy/paste: copy for everyone (`sourceId === 'visits'` only), paste admin/owner-gated with no affordance for others.
- Clipboard hook extracted to `calendar/core/use-calendar-clipboard.ts`; the board hook is now a thin wrapper. `PasteVisitsDialog` moved to `calendar/ui/` and shared. Clipboard interop works both directions between board and schedule.

## Verification
- `apps/worker/scripts/verify-dispatch-create-work-order.ts`: **16/16** against the dev DB (WO fields + contact link, exactly-one-visit invariant, scheduled times/assignee, title fallback to contact displayName, omitted assignee → unassigned).
- `group-drag.test.ts` + `clipboard-offset.test.ts`: **10/10**.
- Scoped typecheck clean for every touched file in `packages/ui`, `packages/lib`, `apps/web` (baseline errors excluded); biome clean.
- **Pending**: browser gesture pass (group drag across days/worker rows, month day-delta, slot-create prefills in all four views, schedule gestures + non-admin paste gating, cross-surface paste realtime).

## Notes for review
- Known accepted edge: dragging one of a multi-selection onto the backlog still shows the ×N badge/dim during the gesture, but only the dragged visit unschedules (backlog stays single-visit per plan).
- Month-view slot-create prefills midnight rather than an org day-start default — time inputs are visible/editable; can follow up if it annoys.
- Schedule copy hardcodes `assigneeUserId` to the viewer since `dispatch.myVisits` is worker-scoped by session (verified in the router).