### PR TITLE
feat(dispatch): surgical visit cache patches instead of invalidate/refetch

### DIFF
--- a/apps/web/src/components/calendar/sources/visits-source.tsx
+++ b/apps/web/src/components/calendar/sources/visits-source.tsx
@@ -8,9 +8,16 @@
 
 'use client'
 
+import { useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useCallback, useMemo } from 'react'
 import type { CalendarSource, SourcedEvent } from '~/components/calendar/core/types'
+import {
+  applyVisitToCaches,
+  rewrapVisitDates,
+  type VisitChangedPayload,
+} from '~/components/dispatch/visit-cache'
+import { useUser } from '~/hooks/use-user'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api, type RouterOutputs } from '~/trpc/react'
 
@@ -60,12 +67,30 @@ export const visitsSource: CalendarSource<VisitEvent> = {
     )
 
     const utils = api.useUtils()
+    const queryClient = useQueryClient()
+    const { userId } = useUser()
+
+    // Plan 39 §Phase-2: a `kind: 'row'` broadcast rewraps its wire-string dates and patches every
+    // cached `myVisits` window via `applyVisitToCaches` instead of invalidating. `kind: 'bulk'`
+    // and any old-shape/malformed payload fall back to the pre-Phase-2 scoped invalidate.
     const onEvent = useCallback(
-      (event: string) => {
+      (event: string, payload: unknown) => {
         if (event !== 'dispatch:visit-changed') return
+        const p = payload as VisitChangedPayload | undefined
+        if (p?.kind === 'row' && p.visit && userId) {
+          applyVisitToCaches(
+            { utils, queryClient },
+            {
+              visit: rewrapVisitDates(p.visit),
+              workOrderStatus: p.workOrderStatus,
+              viewerUserId: userId,
+            }
+          )
+          return
+        }
         void utils.dispatch.myVisits.invalidate({ from: range.from, to: range.to })
       },
-      [utils, range.from, range.to]
+      [utils, queryClient, userId, range.from, range.to]
     )
     useOrgChannel({ onEvent })
 

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -45,7 +45,8 @@ import { VisitChipContent } from './visit-chip-content'
 /**
  * The dispatch board (07-m2-build.md §D.2) — the `/app/dispatch` module home. Day view is
  * `resources` mode (workers + a first "Unassigned" column); week shows every worker
- * color-coded; month is display-only. All writes funnel through `dispatch.scheduleVisit`
+ * color-coded; month drags are whole-day moves (time-of-day preserved, no resize — 37c §6
+ * revised M2a's display-only month). All writes funnel through `dispatch.scheduleVisit`
  * (drag/resize/backlog-drop) or the chip popover's status/dispatch mutations.
  *
  * `boardMode === 'map'` (09-route-planner.md §A) swaps the calendar grid for `RoutePlannerView`.
@@ -230,7 +231,9 @@ export function DispatchBoard() {
       resourceId?: string,
       groupIds?: string[]
     ) => {
-      if (data.view === 'month') return
+      // Month drops commit too (37c §6 revised M2a's display-only month): the dnd layer builds
+      // `newStart` from the target day with the visit's original time-of-day and duration
+      // preserved, and month cells carry no `resourceId`, so the assignee stays untouched.
       const assigneeUserId =
         resourceId !== undefined
           ? resourceId === UNASSIGNED_RESOURCE_ID
@@ -283,7 +286,7 @@ export function DispatchBoard() {
         }
       }
     },
-    [data.view, mutations.scheduleVisit, eventsById, bulkRunner]
+    [mutations.scheduleVisit, eventsById, bulkRunner]
   )
 
   const handleEventResize = useCallback(

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
@@ -4,7 +4,9 @@
 
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
+import { applyVisitToCaches } from '~/components/dispatch/visit-cache'
 import { parseRecordId, type RecordId } from '~/components/resources'
 import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
@@ -46,15 +48,45 @@ interface PasteVisitVars {
 
 /**
  * All visit-mutating writes the board makes, each with an optimistic patch of the
- * `dispatch.getBoard` cache (snapshot → patch → rollback-on-error → invalidate-on-settle —
- * the `use-task-completion.ts` recipe adapted to `setQueriesData`-style cache surgery).
+ * `dispatch.getBoard` cache (snapshot → patch → rollback-on-error). Plan
+ * `dispatch/39-visit-cache-sync.md` §Phase-1: single-row mutations (`scheduleVisit`,
+ * `assignVisit`, `unscheduleVisit`, `setVisitStatus`, `dispatchVisit`, `addVisit`,
+ * `createWorkOrder`) reconcile on success via `applyResponse` (`visit-cache.ts`'s
+ * `applyVisitToCaches`) instead of invalidating on settle — it patches every cached `getBoard`
+ * window (not just this hook's own `range`) plus `listVisits`/`myVisits` if open in this tab, so
+ * e.g. a drawer's Schedule section stays in sync with a board drag in the SAME tab. Batch/series
+ * ops (`applyToSeries`, `cancelVisitFollowing`, `pasteVisits`) keep the old settle-invalidate —
+ * one mutation can touch an unbounded row set, so a single-row response can't describe it.
  * Realtime echo suppression is free (the acting client's socket id travels on the mutation
  * header automatically — `apps/web/src/trpc/react.tsx`), so no extra bookkeeping is needed
  * here beyond the local optimistic patch.
  */
 export function useBoardMutations(range: DateRange) {
   const utils = api.useUtils()
-  const { organizationId } = useUser()
+  const queryClient = useQueryClient()
+  const { organizationId, userId } = useUser()
+
+  // Plan 39 §Phase-1 — the acting tab's single write path: feed every single-row mutation's own
+  // response into `applyVisitToCaches` instead of invalidating `getBoard`/`getVisitDayMarkers` on
+  // settle. `viewerUserId` (this tab's signed-in user) only matters if a `myVisits` cache happens
+  // to be open in the same tab — harmless to pass unconditionally.
+  const applyResponse = useCallback(
+    (
+      visit: BoardVisit & { workOrderStatus?: string },
+      staleIds?: { removeStaleVisitId?: string; removeStaleWorkOrderId?: string }
+    ) => {
+      applyVisitToCaches(
+        { utils, queryClient },
+        {
+          visit,
+          workOrderStatus: visit.workOrderStatus,
+          viewerUserId: userId ?? undefined,
+          ...staleIds,
+        }
+      )
+    },
+    [utils, queryClient, userId]
+  )
 
   const patchVisit = useCallback(
     (visitId: string, patch: Partial<BoardVisit>): BoardResult | undefined => {
@@ -77,6 +109,9 @@ export function useBoardMutations(range: DateRange) {
     [range, utils]
   )
 
+  // Blanket invalidate — kept ONLY for the batch/series mutations below (`applyToSeries`,
+  // `cancelVisitFollowing`, `pasteVisits`); every single-row mutation uses `applyResponse`
+  // instead (plan 39 §Phase-1).
   const settle = useCallback(() => {
     void utils.dispatch.getBoard.invalidate()
     // v3 sidebar plan §1.4 — keep the mini-calendar's day-marker dots fresh alongside the board.
@@ -104,7 +139,7 @@ export function useBoardMutations(range: DateRange) {
         description: error.message,
       })
     },
-    onSettled: settle,
+    onSuccess: (visit) => applyResponse(visit),
   })
 
   const assignVisit = api.dispatch.assignVisit.useMutation({
@@ -119,7 +154,9 @@ export function useBoardMutations(range: DateRange) {
         description: error.message,
       })
     },
-    onSettled: settle,
+    // No `workOrderStatus` on this response — `assignVisit` has no roll-up rule of its own
+    // (`visit-mutations.ts`'s doc comment).
+    onSuccess: (visit) => applyResponse(visit),
   })
 
   const unscheduleVisit = api.dispatch.unscheduleVisit.useMutation({
@@ -136,7 +173,7 @@ export function useBoardMutations(range: DateRange) {
         description: error.message,
       })
     },
-    onSettled: settle,
+    onSuccess: (visit) => applyResponse(visit),
   })
 
   const setVisitStatus = api.dispatch.setVisitStatus.useMutation({
@@ -151,7 +188,7 @@ export function useBoardMutations(range: DateRange) {
         description: error.message,
       })
     },
-    onSettled: settle,
+    onSuccess: (visit) => applyResponse(visit),
   })
 
   const dispatchVisit = api.dispatch.dispatchVisit.useMutation({
@@ -168,7 +205,7 @@ export function useBoardMutations(range: DateRange) {
         description: error.message,
       })
     },
-    onSettled: settle,
+    onSuccess: (visit) => applyResponse(visit),
   })
 
   // Series-wide edits ('following'/'all' scope) touch rows beyond this visit — no optimistic
@@ -272,10 +309,11 @@ export function useBoardMutations(range: DateRange) {
       await utils.dispatch.getBoard.cancel(range)
       const vars = rawVars as AddVisitVars
       const previous = utils.dispatch.getBoard.getData(range)
+      const tempVisitId = generateId('temp-visit')
       if (previous && vars.startTime && vars.endTime) {
         const now = new Date()
         const tempVisit: BoardVisit = {
-          id: generateId('temp-visit'),
+          id: tempVisitId,
           organizationId: organizationId ?? '',
           workOrderId: parseRecordId(vars.workOrderRecordId).entityInstanceId,
           assigneeUserId: vars.assigneeUserId ?? null,
@@ -301,29 +339,34 @@ export function useBoardMutations(range: DateRange) {
           visits: [...previous.visits, tempVisit],
         })
       }
-      return { previous }
+      return { previous, tempVisitId }
     },
     onError: (error, _vars, ctx) => {
       rollback(ctx?.previous)
       toastError({ title: 'Error adding visit', description: error.message })
     },
-    onSettled: settle,
+    // Response apply also purges the optimistic temp row (`ctx.tempVisitId`) — otherwise the
+    // real row lands ALONGSIDE the placeholder instead of replacing it (ids never match).
+    onSuccess: (visit, _vars, ctx) =>
+      applyResponse(visit, { removeStaleVisitId: ctx?.tempVisitId }),
   })
 
   // Plan 37c §7, item 1 — slot-click create's "New job" path. Unlike every other board
   // mutation, the work order itself doesn't exist in the cache yet either — the optimistic
   // patch inserts a synthetic `BoardWorkOrder` (client-known title, `number: null`) ALONGSIDE
   // the temp visit row (the `pasteVisits` recipe), so the chip renders the real title instead of
-  // `visitToEvent`'s no-work-order fallback for the brief window before the settle invalidate
-  // swaps in the real (numbered) work order.
+  // `visitToEvent`'s no-work-order fallback for the brief window before the response apply swaps
+  // in the real (numbered) work order (plan 39 §Phase-1 — `removeStaleWorkOrderId`/
+  // `removeStaleVisitId` purge the placeholders so the real row replaces rather than duplicates).
   const createWorkOrder = api.dispatch.createWorkOrder.useMutation({
     onMutate: async (rawVars) => {
       await utils.dispatch.getBoard.cancel(range)
       const vars = rawVars as CreateWorkOrderVars
       const previous = utils.dispatch.getBoard.getData(range)
+      const tempWorkOrderId = generateId('temp-work-order')
+      const tempVisitId = generateId('temp-visit')
       if (previous) {
         const now = new Date()
-        const tempWorkOrderId = generateId('temp-work-order')
         const tempWorkOrder: BoardWorkOrder = {
           id: tempWorkOrderId,
           displayName: vars.title?.trim() || 'New job',
@@ -333,7 +376,7 @@ export function useBoardMutations(range: DateRange) {
           contactDisplayName: null,
         }
         const tempVisit: BoardVisit = {
-          id: generateId('temp-visit'),
+          id: tempVisitId,
           organizationId: organizationId ?? '',
           workOrderId: tempWorkOrderId,
           assigneeUserId: vars.assigneeUserId ?? null,
@@ -360,13 +403,19 @@ export function useBoardMutations(range: DateRange) {
           visits: [...previous.visits, tempVisit],
         })
       }
-      return { previous }
+      return { previous, tempWorkOrderId, tempVisitId }
     },
     onError: (error, _vars, ctx) => {
       rollback(ctx?.previous)
       toastError({ title: 'Error creating work order', description: error.message })
     },
-    onSettled: settle,
+    // Response apply also purges the optimistic temp visit + work order (ids never match the
+    // server's real ones) — otherwise they'd land ALONGSIDE the real row instead of replacing it.
+    onSuccess: (result, _vars, ctx) =>
+      applyResponse(
+        { ...result.visit, workOrderStatus: result.workOrderStatus },
+        { removeStaleVisitId: ctx?.tempVisitId, removeStaleWorkOrderId: ctx?.tempWorkOrderId }
+      ),
   })
 
   return {

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-realtime.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-realtime.ts
@@ -2,28 +2,54 @@
 
 'use client'
 
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
+import {
+  applyVisitToCaches,
+  rewrapVisitDates,
+  type VisitChangedPayload,
+} from '~/components/dispatch/visit-cache'
+import { useUser } from '~/hooks/use-user'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api } from '~/trpc/react'
 
 /**
- * Live board updates (07 §D.5, the `use-eval-cases-realtime.ts` recipe): any
- * `dispatch:visit-changed` broadcast for the org invalidates every cached `dispatch.getBoard`
- * range. The acting client's own writes are excluded server-side via the
- * `x-realtime-socket-id` header (attached globally by the tRPC client link), so this never
- * double-patches the tab that made the change — only other tabs/users refetch.
+ * Live board updates (07 §D.5, the `use-eval-cases-realtime.ts` recipe). Plan
+ * `dispatch/39-visit-cache-sync.md` §Phase-2: a `kind: 'row'` broadcast (every single-row
+ * mutation) rewraps its wire-string dates and patches every cached `dispatch.getBoard` range
+ * via `applyVisitToCaches` instead of invalidating — `applyVisitToCaches` already scoped-
+ * invalidates `getVisitDayMarkers` itself, so this never double-invalidates on that path.
+ * `kind: 'bulk'` (recurrence regeneration, pause/resume, series-end) and any old-shape/
+ * malformed payload fall back to the pre-Phase-2 blanket invalidate. The acting client's own
+ * writes are excluded server-side via the `x-realtime-socket-id` header (attached globally by
+ * the tRPC client link), so this never double-patches the tab that made the change — only
+ * other tabs/users hear it at all.
  */
 export function useBoardRealtime() {
   const utils = api.useUtils()
+  const queryClient = useQueryClient()
+  const { userId } = useUser()
 
   const onEvent = useCallback(
-    (event: string) => {
+    (event: string, payload: unknown) => {
       if (event !== 'dispatch:visit-changed') return
+      const p = payload as VisitChangedPayload | undefined
+      if (p?.kind === 'row' && p.visit) {
+        applyVisitToCaches(
+          { utils, queryClient },
+          {
+            visit: rewrapVisitDates(p.visit),
+            workOrderStatus: p.workOrderStatus,
+            viewerUserId: userId ?? undefined,
+          }
+        )
+        return
+      }
       void utils.dispatch.getBoard.invalidate()
       // v3 sidebar plan §1.4 — the mini-calendar's day-marker dots follow the same broadcast.
       void utils.dispatch.getVisitDayMarkers.invalidate()
     },
-    [utils]
+    [utils, queryClient, userId]
   )
 
   useOrgChannel({ onEvent })

--- a/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
@@ -103,6 +103,9 @@ export function VisitPopoverContent({
     recurrenceRuleId: event.recurrenceRuleId,
   })
 
+  // Rule mutations are bulk-shaped (an unbounded row set, not one visit) — this settle-invalidate
+  // stays as-is rather than converting to `applyVisitToCaches` (plan `dispatch/39-visit-cache-
+  // sync.md` §2.4 "what this deliberately is NOT" / the batch-rule carve-out).
   const setRecurrence = api.dispatch.setRecurrence.useMutation({
     onError: (error) =>
       toastError({ title: 'Error saving recurrence', description: error.message }),

--- a/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
@@ -4,7 +4,13 @@
 
 import { getInstanceId, type RecordId } from '@auxx/types/resource'
 import { toastError } from '@auxx/ui/components/toast'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo } from 'react'
+import {
+  applyVisitToCaches,
+  rewrapVisitDates,
+  type VisitChangedPayload,
+} from '~/components/dispatch/visit-cache'
 import { useUser } from '~/hooks/use-user'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api, type RouterOutputs } from '~/trpc/react'
@@ -22,9 +28,10 @@ export type JobVisit = RouterOutputs['dispatch']['listVisits'][number]
  * the server enforces it too (`dispatchAdminProcedure`).
  */
 export function useJobVisits(workOrderRecordId: RecordId) {
-  const { isAdminOrOwner } = useUser()
+  const { isAdminOrOwner, userId } = useUser()
   const canEdit = isAdminOrOwner
   const utils = api.useUtils()
+  const queryClient = useQueryClient()
   const workOrderInstanceId = getInstanceId(workOrderRecordId)
 
   const query = api.dispatch.listVisits.useQuery({ workOrderRecordId })
@@ -37,14 +44,40 @@ export function useJobVisits(workOrderRecordId: RecordId) {
     void utils.dispatch.getRecurrence.invalidate({ workOrderRecordId })
   }, [utils, workOrderRecordId])
 
+  // Plan 39 §Phase-1 — feed each single-row mutation's own response into `applyVisitToCaches`
+  // instead of invalidating `listVisits` (this closes the reported bug: dragging a chip on the
+  // board left THIS drawer's Schedule section stale, since the acting tab's own realtime echo
+  // is server-suppressed and nothing else was feeding this cache). Patches every cache that can
+  // hold the visit (`getBoard`/`listVisits`/`myVisits`), not just this hook's own query.
+  const applyResponse = useCallback(
+    (visit: RouterOutputs['dispatch']['scheduleVisit']) => {
+      applyVisitToCaches(
+        { utils, queryClient },
+        { visit, workOrderStatus: visit.workOrderStatus, viewerUserId: userId ?? undefined }
+      )
+    },
+    [utils, queryClient, userId]
+  )
+
+  // Plan 39 §Phase-2: a `kind: 'row'` broadcast rewraps its wire-string dates and applies
+  // through the SAME `applyResponse` a mutation's own success response uses — global-cache-safe
+  // and cheap (upsert-by-id), so it's applied unconditionally rather than gated on
+  // `workOrderInstanceId` first (`applyVisitToCaches`'s own `listVisits` loop already scopes the
+  // write to caches whose `workOrderRecordId` resolves to `visit.workOrderId`). `kind: 'bulk'`
+  // (recurrence regeneration, pause/resume, series-end) and any old-shape/malformed payload keep
+  // the pre-Phase-2 `workOrderId`-filtered invalidate as the fallback.
   const onEvent = useCallback(
     (event: string, payload: unknown) => {
       if (event !== 'dispatch:visit-changed') return
-      const p = payload as { workOrderId?: string } | undefined
+      const p = payload as VisitChangedPayload | undefined
+      if (p?.kind === 'row' && p.visit) {
+        applyResponse({ ...rewrapVisitDates(p.visit), workOrderStatus: p.workOrderStatus })
+        return
+      }
       if (p?.workOrderId !== workOrderInstanceId) return
       invalidate()
     },
-    [workOrderInstanceId, invalidate]
+    [workOrderInstanceId, invalidate, applyResponse]
   )
   useOrgChannel({ onEvent })
 
@@ -56,28 +89,46 @@ export function useJobVisits(workOrderRecordId: RecordId) {
 
   const scheduleVisit = api.dispatch.scheduleVisit.useMutation({
     onError: onErrorToast('Error scheduling visit'),
-    onSuccess: invalidate,
+    onSuccess: applyResponse,
   })
   const unscheduleVisit = api.dispatch.unscheduleVisit.useMutation({
     onError: onErrorToast('Error unscheduling visit'),
-    onSuccess: invalidate,
+    onSuccess: applyResponse,
   })
   const setVisitStatus = api.dispatch.setVisitStatus.useMutation({
     onError: onErrorToast('Error updating visit status'),
-    onSuccess: invalidate,
+    onSuccess: applyResponse,
   })
   const dispatchVisit = api.dispatch.dispatchVisit.useMutation({
     onError: onErrorToast('Error dispatching visit'),
-    onSuccess: invalidate,
+    onSuccess: applyResponse,
   })
   // Plan 30 §A.5 — bring a canceled/skipped visit back to `scheduled` in place (never a new time).
   // (Add-visit creation lives in `SchedulePopover`'s CREATE mode, not here — the picker commits
   // `dispatch.addVisit` itself.)
   const restoreVisit = api.dispatch.restoreVisit.useMutation({
     onError: onErrorToast('Error restoring visit'),
-    onSuccess: invalidate,
+    onSuccess: (visit, variables) => {
+      applyResponse(visit)
+      // Plan 36 §A.2 / plan 39 §Phase-1 audit finding: `resumeSeries` also clears the rule
+      // pattern's `until` and regenerates the tail — a rule-level write the returned visit row
+      // carries no signal of. Keep this one targeted invalidate for that case only; every other
+      // restore (`resumeSeries` false/omitted) is fully covered by `applyResponse`.
+      // Other tabs (plan 39 §Phase-2): the lib side (`restoreVisit`, `visit-mutations.ts`)
+      // publishes a SECOND `kind: 'bulk'` broadcast for this rule-level write — either
+      // `materializeVisits`'s own (when it regenerates the tail) or an explicit one (paused
+      // engagements, which skip regeneration) — on top of this mutation's `kind: 'row'` one. The
+      // `onEvent` bulk-fallback above catches it and invalidates `listVisits`/`getRecurrence`
+      // there too, so a resume-series in tab A refreshes both tab B's series summary AND its
+      // regenerated visit list. No extra plumbing needed here.
+      if (variables.resumeSeries) {
+        void utils.dispatch.getRecurrence.invalidate({ workOrderRecordId })
+      }
+    },
   })
-  // "Skip this and future visits" — tombstones the target and ends its series there.
+  // "Skip this and future visits" — tombstones the target and ends its series there. Bulk/series
+  // op (plan 39 §Phase-1) — a single visit response can't describe the later siblings it also
+  // tombstones, so this keeps the full `invalidate` (`listVisits` + `getRecurrence`).
   const cancelVisitFollowing = api.dispatch.cancelVisitFollowing.useMutation({
     onError: onErrorToast('Error skipping visits'),
     onSuccess: invalidate,

--- a/apps/web/src/components/dispatch/visit-cache.test.ts
+++ b/apps/web/src/components/dispatch/visit-cache.test.ts
@@ -1,0 +1,311 @@
+// apps/web/src/components/dispatch/visit-cache.test.ts
+//
+// Unit coverage for the pure per-cache patch functions in `visit-cache.ts` (plan
+// `dispatch/39-visit-cache-sync.md` §Phase-1) — no React Query, no QueryClient; just the
+// window/merge/sort logic `applyVisitToCaches` wires into the cache.
+
+import { describe, expect, it } from 'vitest'
+import type { RouterOutputs } from '~/trpc/react'
+import type { BoardResult, BoardVisit, BoardWorkOrder } from './ui/board/types'
+import type { JobVisit } from './ui/job-schedule/use-job-visits'
+import {
+  applyBoardPatch,
+  applyMyVisitsPatch,
+  isScheduledWithinWindow,
+  mergeJobVisits,
+  patchBoardVisits,
+  rewrapVisitDates,
+  type SerializedVisitRow,
+  sortByStartTimeAscNullsLast,
+} from './visit-cache'
+
+type MyVisitRow = RouterOutputs['dispatch']['myVisits'][number]
+
+const WINDOW = { from: new Date('2026-07-20T00:00:00Z'), to: new Date('2026-07-27T00:00:00Z') }
+
+function visit(overrides: Partial<BoardVisit> & { id: string }): BoardVisit {
+  return {
+    id: overrides.id,
+    organizationId: 'org-1',
+    workOrderId: overrides.workOrderId ?? 'wo-1',
+    assigneeUserId: overrides.assigneeUserId ?? null,
+    startTime: overrides.startTime ?? new Date('2026-07-21T09:00:00Z'),
+    endTime: overrides.endTime ?? new Date('2026-07-21T10:00:00Z'),
+    timezone: overrides.timezone ?? 'UTC',
+    status: overrides.status ?? 'scheduled',
+    routeOrder: overrides.routeOrder ?? null,
+    latitude: overrides.latitude ?? null,
+    longitude: overrides.longitude ?? null,
+    geocodedAt: overrides.geocodedAt ?? null,
+    dispatchedAt: overrides.dispatchedAt ?? null,
+    timeConfirmedAt: overrides.timeConfirmedAt ?? null,
+    durationMinutes: overrides.durationMinutes ?? 60,
+    recurrenceRuleId: overrides.recurrenceRuleId ?? null,
+    occurrenceDate: overrides.occurrenceDate ?? null,
+    isDetached: overrides.isDetached ?? false,
+    createdAt: overrides.createdAt ?? new Date('2026-07-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-07-01T00:00:00Z'),
+    ...overrides,
+  } as BoardVisit
+}
+
+function workOrder(overrides: Partial<BoardWorkOrder> & { id: string }): BoardWorkOrder {
+  return {
+    id: overrides.id,
+    displayName: overrides.displayName ?? 'Job',
+    number: overrides.number ?? 'WO-1',
+    status: overrides.status ?? 'scheduled',
+    contactId: overrides.contactId ?? null,
+    contactDisplayName: overrides.contactDisplayName ?? null,
+  }
+}
+
+function jobVisit(overrides: Partial<JobVisit> & { id: string }): JobVisit {
+  return {
+    ...visit(overrides),
+    invoiceState: overrides.invoiceState ?? 'uninvoiced',
+    invoiceCount: overrides.invoiceCount ?? 0,
+    invoiceId: overrides.invoiceId,
+  } as JobVisit
+}
+
+function myVisit(overrides: Partial<MyVisitRow> & { id: string }): MyVisitRow {
+  return {
+    id: overrides.id,
+    status: overrides.status ?? 'scheduled',
+    startTime: overrides.startTime ?? new Date('2026-07-21T09:00:00Z'),
+    endTime: overrides.endTime ?? new Date('2026-07-21T10:00:00Z'),
+    timezone: overrides.timezone ?? 'UTC',
+    workOrder: overrides.workOrder ?? { id: 'wo-1', displayName: 'Job', number: 'WO-1' },
+  } as MyVisitRow
+}
+
+describe('isScheduledWithinWindow', () => {
+  it('is false for an unscheduled (null startTime) visit', () => {
+    expect(isScheduledWithinWindow(null, WINDOW)).toBe(false)
+  })
+
+  it('is true for a startTime inside the window', () => {
+    expect(isScheduledWithinWindow(new Date('2026-07-21T09:00:00Z'), WINDOW)).toBe(true)
+  })
+
+  it('is false for a startTime outside the window', () => {
+    expect(isScheduledWithinWindow(new Date('2026-08-01T09:00:00Z'), WINDOW)).toBe(false)
+  })
+})
+
+describe('patchBoardVisits', () => {
+  it('upserts an existing visit that is still in-window', () => {
+    const v1 = visit({ id: 'v1', status: 'scheduled' })
+    const patched = visit({ id: 'v1', status: 'en_route' })
+    const next = patchBoardVisits([v1], patched, WINDOW)
+    expect(next).toHaveLength(1)
+    expect(next[0]?.status).toBe('en_route')
+  })
+
+  it('inserts a new in-window visit not previously cached', () => {
+    const v1 = visit({ id: 'v1' })
+    const created = visit({ id: 'v2' })
+    const next = patchBoardVisits([v1], created, WINDOW)
+    expect(next.map((v) => v.id).sort()).toEqual(['v1', 'v2'])
+  })
+
+  it('removes a visit that moved out of the window', () => {
+    const v1 = visit({ id: 'v1', startTime: new Date('2026-07-21T09:00:00Z') })
+    const moved = visit({ id: 'v1', startTime: new Date('2026-08-15T09:00:00Z') })
+    const next = patchBoardVisits([v1], moved, WINDOW)
+    expect(next).toHaveLength(0)
+  })
+
+  it('removes a visit that was unscheduled back to the backlog rail', () => {
+    const v1 = visit({ id: 'v1', startTime: new Date('2026-07-21T09:00:00Z') })
+    const unscheduled = visit({ id: 'v1', startTime: null, endTime: null })
+    const next = patchBoardVisits([v1], unscheduled, WINDOW)
+    expect(next).toHaveLength(0)
+  })
+})
+
+describe('applyBoardPatch', () => {
+  it('patches the matching workOrders[] entry status when workOrderStatus is given', () => {
+    const board: BoardResult = {
+      workers: [],
+      visits: [visit({ id: 'v1', workOrderId: 'wo-1' })],
+      workOrders: [workOrder({ id: 'wo-1', status: 'new' })],
+    }
+    const changed = visit({ id: 'v1', workOrderId: 'wo-1', status: 'en_route' })
+    const { board: next, needsInvalidate } = applyBoardPatch(board, changed, 'in_progress', WINDOW)
+    expect(needsInvalidate).toBe(false)
+    expect(next.workOrders[0]?.status).toBe('in_progress')
+    expect(next.visits[0]?.status).toBe('en_route')
+  })
+
+  it('flags needsInvalidate when the visit is in-window but its work order is unknown', () => {
+    const board: BoardResult = { workers: [], visits: [], workOrders: [] }
+    const created = visit({ id: 'v1', workOrderId: 'wo-never-seen' })
+    const { needsInvalidate } = applyBoardPatch(board, created, undefined, WINDOW)
+    expect(needsInvalidate).toBe(true)
+  })
+
+  it('never flags needsInvalidate for an out-of-window visit', () => {
+    const board: BoardResult = { workers: [], visits: [], workOrders: [] }
+    const outOfWindow = visit({ id: 'v1', startTime: new Date('2026-09-01T09:00:00Z') })
+    const { needsInvalidate } = applyBoardPatch(board, outOfWindow, 'scheduled', WINDOW)
+    expect(needsInvalidate).toBe(false)
+  })
+})
+
+describe('mergeJobVisits', () => {
+  it('preserves invoice enrichment fields on an update', () => {
+    const existing = jobVisit({
+      id: 'v1',
+      status: 'scheduled',
+      invoiceState: 'drafted',
+      invoiceCount: 1,
+      invoiceId: 'inv-1',
+    })
+    const changed = visit({ id: 'v1', status: 'done' })
+    const [row] = mergeJobVisits([existing], changed)
+    expect(row?.status).toBe('done')
+    expect(row?.invoiceState).toBe('drafted')
+    expect(row?.invoiceCount).toBe(1)
+    expect(row?.invoiceId).toBe('inv-1')
+  })
+
+  it('inserts a new row at the enrichment zero-state', () => {
+    const created = visit({ id: 'v2' })
+    const [row] = mergeJobVisits([], created)
+    expect(row?.invoiceState).toBe('uninvoiced')
+    expect(row?.invoiceCount).toBe(0)
+    expect(row?.invoiceId).toBeUndefined()
+  })
+
+  it('re-sorts ascending by startTime with unscheduled rows last', () => {
+    const later = jobVisit({ id: 'later', startTime: new Date('2026-07-22T09:00:00Z') })
+    const unscheduled = jobVisit({ id: 'unscheduled', startTime: null, endTime: null })
+    const earlier = visit({ id: 'earlier', startTime: new Date('2026-07-21T09:00:00Z') })
+    const next = mergeJobVisits([later, unscheduled], earlier)
+    expect(next.map((r) => r.id)).toEqual(['earlier', 'later', 'unscheduled'])
+  })
+})
+
+describe('applyMyVisitsPatch', () => {
+  const viewerUserId = 'user-1'
+
+  it('removes a row when the visit was reassigned away from the viewer', () => {
+    const existing = myVisit({ id: 'v1' })
+    const reassigned = visit({ id: 'v1', assigneeUserId: 'someone-else' })
+    const { rows, needsInvalidate } = applyMyVisitsPatch(
+      [existing],
+      reassigned,
+      viewerUserId,
+      WINDOW
+    )
+    expect(rows).toHaveLength(0)
+    expect(needsInvalidate).toBe(false)
+  })
+
+  it('removes a row when the visit left the cached window', () => {
+    const existing = myVisit({ id: 'v1' })
+    const moved = visit({
+      id: 'v1',
+      assigneeUserId: viewerUserId,
+      startTime: new Date('2026-09-01T09:00:00Z'),
+    })
+    const { rows } = applyMyVisitsPatch([existing], moved, viewerUserId, WINDOW)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('removes a row when the visit was unscheduled', () => {
+    const existing = myVisit({ id: 'v1' })
+    const unscheduled = visit({
+      id: 'v1',
+      assigneeUserId: viewerUserId,
+      startTime: null,
+      endTime: null,
+    })
+    const { rows } = applyMyVisitsPatch([existing], unscheduled, viewerUserId, WINDOW)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('updates in place while preserving the workOrder join', () => {
+    const existing = myVisit({
+      id: 'v1',
+      status: 'scheduled',
+      workOrder: { id: 'wo-1', displayName: 'Fix the sink', number: 'WO-42' },
+    })
+    const changed = visit({
+      id: 'v1',
+      assigneeUserId: viewerUserId,
+      status: 'en_route',
+      startTime: new Date('2026-07-22T11:00:00Z'),
+      endTime: new Date('2026-07-22T12:00:00Z'),
+    })
+    const { rows, needsInvalidate } = applyMyVisitsPatch([existing], changed, viewerUserId, WINDOW)
+    expect(needsInvalidate).toBe(false)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.status).toBe('en_route')
+    expect(rows[0]?.startTime).toEqual(new Date('2026-07-22T11:00:00Z'))
+    expect(rows[0]?.workOrder).toEqual({ id: 'wo-1', displayName: 'Fix the sink', number: 'WO-42' })
+  })
+
+  it('flags needsInvalidate when the visit should now appear but has no cached row', () => {
+    const created = visit({ id: 'v1', assigneeUserId: viewerUserId })
+    const { rows, needsInvalidate } = applyMyVisitsPatch([], created, viewerUserId, WINDOW)
+    expect(rows).toHaveLength(0)
+    expect(needsInvalidate).toBe(true)
+  })
+})
+
+describe('rewrapVisitDates', () => {
+  it('round-trips every date field through JSON (the realtime wire shape) back to Date objects', () => {
+    const row = visit({
+      id: 'v1',
+      startTime: new Date('2026-07-21T09:00:00.000Z'),
+      endTime: new Date('2026-07-21T10:00:00.000Z'),
+      geocodedAt: new Date('2026-07-20T00:00:00.000Z'),
+      dispatchedAt: new Date('2026-07-21T08:00:00.000Z'),
+      timeConfirmedAt: new Date('2026-07-19T00:00:00.000Z'),
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-02T00:00:00.000Z'),
+    })
+
+    // `JSON.parse(JSON.stringify(...))` is exactly what the wire does to a `Date` (`toJSON`
+    // serializes it to an ISO string) — the same transform a Pusher-protocol JSON payload puts
+    // the row through, no SuperJSON involved.
+    const wire = JSON.parse(JSON.stringify(row)) as SerializedVisitRow
+    expect(typeof wire.startTime).toBe('string')
+    expect(typeof wire.createdAt).toBe('string')
+
+    const rewrapped = rewrapVisitDates(wire)
+    expect(rewrapped).toEqual(row)
+  })
+
+  it('keeps null date fields null (never `new Date(null)`)', () => {
+    const row = visit({
+      id: 'v1',
+      startTime: null,
+      endTime: null,
+      geocodedAt: null,
+      dispatchedAt: null,
+      timeConfirmedAt: null,
+    })
+    const wire = JSON.parse(JSON.stringify(row)) as SerializedVisitRow
+    const rewrapped = rewrapVisitDates(wire)
+    expect(rewrapped.startTime).toBeNull()
+    expect(rewrapped.endTime).toBeNull()
+    expect(rewrapped.geocodedAt).toBeNull()
+    expect(rewrapped.dispatchedAt).toBeNull()
+    expect(rewrapped.timeConfirmedAt).toBeNull()
+  })
+})
+
+describe('sortByStartTimeAscNullsLast', () => {
+  it('sorts ascending with nulls last', () => {
+    const rows = [
+      { id: 'b', startTime: null },
+      { id: 'a', startTime: new Date('2026-07-21T09:00:00Z') },
+      { id: 'c', startTime: new Date('2026-07-20T09:00:00Z') },
+    ]
+    expect(sortByStartTimeAscNullsLast(rows).map((r) => r.id)).toEqual(['c', 'a', 'b'])
+  })
+})

--- a/apps/web/src/components/dispatch/visit-cache.ts
+++ b/apps/web/src/components/dispatch/visit-cache.ts
@@ -1,0 +1,368 @@
+// apps/web/src/components/dispatch/visit-cache.ts
+//
+// Plan `dispatch/39-visit-cache-sync.md` §Phase-1 — the one write path that patches every
+// visit-holding React Query cache from a mutation response (Phase 2 reuses it for a fattened
+// realtime payload). Board chip drag → work-order drawer Schedule section going stale in the
+// SAME tab was the reported bug; this closes it by feeding `applyVisitToCaches` off each
+// single-row mutation's own response instead of invalidating/refetching a list.
+//
+// Pure per-cache patch functions are exported standalone (no React Query import) so
+// `visit-cache.test.ts` can exercise the window/merge/sort logic without a QueryClient.
+//
+// §Phase-2 — `VisitChangedPayload`/`SerializedVisitRow` below are a hand-copied CLIENT mirror of
+// `packages/lib/src/dispatch/broadcast.ts`'s types (the `board/types.ts` `VISIT_STATUS_VALUES`
+// precedent): that lib module has no `/client` export subpath (server-only deps upstream), so
+// importing the real type would pull the whole server barrel into client code (the CLAUDE.md
+// client/server import rule). Keep both copies in sync by hand if the wire shape changes.
+
+import { getInstanceId, type RecordId } from '@auxx/types/resource'
+import type { QueryClient } from '@tanstack/react-query'
+import { getQueryKey } from '@trpc/react-query'
+import { api, type RouterOutputs } from '~/trpc/react'
+import type { BoardResult, BoardVisit, BoardWorkOrder } from './ui/board/types'
+import type { JobVisit } from './ui/job-schedule/use-job-visits'
+
+type MyVisitRow = RouterOutputs['dispatch']['myVisits'][number]
+
+// ════════════════════════════════════════════════════════════════════════════
+// Realtime wire shape — client mirror of `packages/lib/src/dispatch/broadcast.ts` (see the
+// file-header note on why this is hand-copied, not imported).
+// ════════════════════════════════════════════════════════════════════════════
+
+/** `WorkOrderVisit` date columns that arrive as ISO strings on the realtime wire (Pusher-
+ * protocol JSON, no SuperJSON on this channel) — mirrors `broadcast.ts`'s `VisitDateKey`.
+ * `occurrenceDate` is deliberately NOT here: it's a Drizzle `date()` column, already a plain
+ * `YYYY-MM-DD` string on `BoardVisit` itself. */
+type VisitDateKey =
+  | 'startTime'
+  | 'endTime'
+  | 'geocodedAt'
+  | 'dispatchedAt'
+  | 'timeConfirmedAt'
+  | 'createdAt'
+  | 'updatedAt'
+
+/** The composed `WorkOrderVisit` row as it travels over the wire — every `VisitDateKey` field
+ * downgraded to its ISO-string wire representation (`createdAt`/`updatedAt` are DB `NOT NULL`,
+ * so they stay non-null strings; the rest stay nullable). Mirrors `broadcast.ts`'s
+ * `SerializedVisitRow`, defined against `BoardVisit` instead of the server row type. */
+export type SerializedVisitRow = Omit<BoardVisit, VisitDateKey> & {
+  startTime: string | null
+  endTime: string | null
+  geocodedAt: string | null
+  dispatchedAt: string | null
+  timeConfirmedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+/** `dispatch:visit-changed` payload — client mirror of `broadcast.ts`'s `VisitChangedPayload`.
+ * `kind: 'row'` carries the composed value (`visit`, dates as wire strings) plus whatever
+ * roll-up ran (`workOrderStatus`); `kind: 'bulk'` (recurrence regeneration, pause/resume,
+ * series-end) and any old-shape/malformed payload carry neither — realtime handlers fall back
+ * to their pre-Phase-2 scoped invalidate in that case. */
+export interface VisitChangedPayload {
+  visitId: string
+  workOrderId: string
+  kind: 'row' | 'bulk'
+  visit?: SerializedVisitRow
+  workOrderStatus?: string
+}
+
+/** `SerializedVisitRow` → `BoardVisit` — rewrap every wire-string date field back to a real
+ * `Date` (nulls stay null) before handing a realtime payload's row to `applyVisitToCaches`,
+ * which is typed (and tested) against the SuperJSON'd `BoardVisit` shape every other cache
+ * write already uses. */
+export function rewrapVisitDates(row: SerializedVisitRow): BoardVisit {
+  return {
+    ...row,
+    startTime: row.startTime ? new Date(row.startTime) : null,
+    endTime: row.endTime ? new Date(row.endTime) : null,
+    geocodedAt: row.geocodedAt ? new Date(row.geocodedAt) : null,
+    dispatchedAt: row.dispatchedAt ? new Date(row.dispatchedAt) : null,
+    timeConfirmedAt: row.timeConfirmedAt ? new Date(row.timeConfirmedAt) : null,
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+  } as BoardVisit
+}
+
+/** A cache window — `getBoard`/`myVisits` are both keyed `{from, to}`. */
+export interface VisitWindow {
+  from: Date
+  to: Date
+}
+
+/**
+ * `visit.startTime` falling inside `window` is the client-side proxy for "this cache's window
+ * should show this visit" — `null` (unscheduled/backlog) is never in-window. Mirrors the
+ * inclusive `gte(endTime, from) && lte(startTime, to)` overlap `getBoard` itself queries with,
+ * approximated to a startTime-only check (visits run hours, never window-length, so the
+ * approximation never disagrees with the server in practice); `myVisits`/`getVisitDayMarkers`
+ * query `[from, to)` server-side, which this errs inclusive of at the `to` edge — a chip stays
+ * visible one patch past its true boundary until the next real fetch corrects it, harmless.
+ */
+export function isScheduledWithinWindow(
+  startTime: Date | null | undefined,
+  window: VisitWindow
+): boolean {
+  if (!startTime) return false
+  const t = startTime.getTime()
+  return t >= window.from.getTime() && t <= window.to.getTime()
+}
+
+/** Sort ascending by `startTime`, nulls last — the `listVisits`/`getBoard` server convention
+ * (`ORDER BY startTime ASC NULLS LAST`). */
+export function sortByStartTimeAscNullsLast<T extends { startTime: Date | null }>(
+  rows: readonly T[]
+): T[] {
+  return [...rows].sort((a, b) => {
+    if (a.startTime === null) return b.startTime === null ? 0 : 1
+    if (b.startTime === null) return -1
+    return a.startTime.getTime() - b.startTime.getTime()
+  })
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// getBoard — every cached fetch window (day/timeline scrolling keeps many alive at once).
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Upsert-or-remove `visit` in one window's cached `visits[]` — in-window → replace (existing
+ * id) or append (new id); out-of-window → drop it. Covers both "moved out of range" and
+ * "unscheduled back to the backlog rail" (backlog visits have `startTime: null`, which is never
+ * in-window for any real window, so an unscheduled visit simply falls out everywhere it used to
+ * render). */
+export function patchBoardVisits(
+  visits: readonly BoardVisit[],
+  visit: BoardVisit,
+  window: VisitWindow
+): BoardVisit[] {
+  const inWindow = isScheduledWithinWindow(visit.startTime, window)
+  const exists = visits.some((v) => v.id === visit.id)
+
+  if (inWindow) {
+    return exists ? visits.map((v) => (v.id === visit.id ? visit : v)) : [...visits, visit]
+  }
+  return exists ? visits.filter((v) => v.id !== visit.id) : [...visits]
+}
+
+export interface BoardPatchResult {
+  board: BoardResult
+  /** The visit belongs in this window but its work order has never been seen there — a
+   * `BoardWorkOrder` summary (title/number/contact) can't be fabricated client-side, it's a
+   * server-side `FieldValue` read. The caller falls back to a scoped `getBoard.invalidate` for
+   * just this one window. */
+  needsInvalidate: boolean
+}
+
+/** One cached `getBoard` window's patch — `visits[]` always gets the upsert/remove treatment;
+ * `workOrders[]` only when the visit's own work order is already known there (an existing job;
+ * `workOrderStatus` patches its `status` in place). */
+export function applyBoardPatch(
+  board: BoardResult,
+  visit: BoardVisit,
+  workOrderStatus: string | undefined,
+  window: VisitWindow
+): BoardPatchResult {
+  const visits = patchBoardVisits(board.visits, visit, window)
+
+  if (!isScheduledWithinWindow(visit.startTime, window)) {
+    return { board: { ...board, visits }, needsInvalidate: false }
+  }
+
+  const hasWorkOrder = board.workOrders.some((wo) => wo.id === visit.workOrderId)
+  if (!hasWorkOrder) {
+    return { board: { ...board, visits }, needsInvalidate: true }
+  }
+
+  const workOrders: BoardWorkOrder[] =
+    workOrderStatus === undefined
+      ? board.workOrders
+      : board.workOrders.map((wo) =>
+          wo.id === visit.workOrderId ? { ...wo, status: workOrderStatus } : wo
+        )
+
+  return { board: { ...board, visits, workOrders }, needsInvalidate: false }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// listVisits — one work order's Schedule section, keyed `{workOrderRecordId}`.
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Merge-by-id into a `listVisits` cache, preserving the invoice-allocation enrichment fields
+ * the router joins in (`invoiceState`/`invoiceCount`/`invoiceId` — never present on the raw
+ * mutation-response row): the existing row spreads first, the changed scalar fields overwrite on
+ * top, so enrichment survives untouched. A new id (e.g. `addVisit`) inserts at the enrichment's
+ * zero-state (`uninvoiced`, count 0) — a brand-new row can't have been invoiced yet. Re-sorts
+ * after patch (`startTime ASC NULLS LAST`, the router's own order). */
+export function mergeJobVisits(rows: readonly JobVisit[], visit: BoardVisit): JobVisit[] {
+  const idx = rows.findIndex((r) => r.id === visit.id)
+  const next: JobVisit[] =
+    idx === -1
+      ? [
+          ...rows,
+          { ...visit, invoiceState: 'uninvoiced' as const, invoiceCount: 0, invoiceId: undefined },
+        ]
+      : rows.map((r, i) => (i === idx ? { ...r, ...visit } : r))
+  return sortByStartTimeAscNullsLast(next)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// myVisits — the signed-in worker's own Schedule page, keyed `{from,to}`.
+// ════════════════════════════════════════════════════════════════════════════
+
+export interface MyVisitsPatchResult {
+  rows: MyVisitRow[]
+  /** The visit now belongs in this window+viewer but never had a row here (e.g. freshly
+   * (re)assigned to this worker) — a `MyVisitListItem` can't be fabricated client-side, it needs
+   * the `workOrder.displayName`/`number` join the mutation response doesn't carry. The caller
+   * falls back to a scoped `myVisits.invalidate` for just this one window. */
+  needsInvalidate: boolean
+}
+
+/** Decide + apply one cached `myVisits` window's patch. Rows are implicitly scoped to the
+ * viewer server-side (no `assigneeUserId` field on the row itself) — a visit stays present only
+ * while it's BOTH assigned to `viewerUserId` AND scheduled inside `window`; anything else
+ * (reassigned away, unscheduled, dragged out of range) removes it. `status` never gates removal
+ * on its own — `listMyVisits` keeps canceled rows visible (no status filter server-side). */
+export function applyMyVisitsPatch(
+  rows: readonly MyVisitRow[],
+  visit: BoardVisit,
+  viewerUserId: string,
+  window: VisitWindow
+): MyVisitsPatchResult {
+  const idx = rows.findIndex((r) => r.id === visit.id)
+  const shouldBePresent =
+    visit.assigneeUserId === viewerUserId && isScheduledWithinWindow(visit.startTime, window)
+
+  if (!shouldBePresent) {
+    return {
+      rows: idx === -1 ? [...rows] : rows.filter((r) => r.id !== visit.id),
+      needsInvalidate: false,
+    }
+  }
+  if (idx === -1) {
+    return { rows: [...rows], needsInvalidate: true }
+  }
+
+  const existing = rows[idx]!
+  const updated: MyVisitRow = {
+    ...existing,
+    status: visit.status as MyVisitRow['status'],
+    startTime: visit.startTime as Date,
+    endTime: visit.endTime as Date,
+    timezone: visit.timezone,
+  }
+  return {
+    rows: sortByStartTimeAscNullsLast(rows.map((r, i) => (i === idx ? updated : r))),
+    needsInvalidate: false,
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// The one write path — wires the pure functions above into React Query's cache.
+// ════════════════════════════════════════════════════════════════════════════
+
+/** What a successful single-row visit mutation hands `applyVisitToCaches`. `visit` is the raw
+ * `WorkOrderVisit` row the mutation returned (SuperJSON — dates already real `Date` objects, no
+ * rewrap needed). `workOrderStatus` is present whenever the mutation's roll-up ran server-side
+ * (absent for `assignVisit`, which has no roll-up rule of its own — see
+ * `apps/web/src/server/api/routers/dispatch.ts`'s `withWorkOrderStatus`). `viewerUserId` gates
+ * the `myVisits` patch only — omit it to skip that cache entirely (a call site that hasn't
+ * threaded the signed-in user's id through). */
+export interface VisitCachePatch {
+  visit: BoardVisit
+  workOrderStatus?: string
+  viewerUserId?: string
+  /** Slot-create's optimistic placeholder cleanup (`addVisit`/`createWorkOrder` — `use-board-
+   * mutations.ts`): `onMutate` there inserts a client-generated temp row (`generateId`) before
+   * the server assigns real ids. Pass its id here so the `getBoard` patch removes the
+   * placeholder instead of leaving it duplicated alongside the real row `patch.visit` carries. */
+  removeStaleVisitId?: string
+  /** Same idea, for `createWorkOrder`'s synthetic `BoardWorkOrder` placeholder. */
+  removeStaleWorkOrderId?: string
+}
+
+/**
+ * The live handles `applyVisitToCaches` needs. `utils` (`api.useUtils()`) drives the scoped
+ * invalidate fallbacks; `queryClient` (`useQueryClient()`) drives the raw multi-key reads/
+ * writes — tRPC v11's typed `utils.dispatch.<proc>.setQueriesData` updater callback has no way
+ * to see which cached key it's patching (verified against `@trpc/react-query`'s
+ * `createUtilityFunctions.ts`/`utilsProxy.ts`: the `Updater<TData, TData>` it forwards to
+ * `queryClient.setQueriesData` takes the old data only, never the query key), and window-aware
+ * patching needs the window bounds baked into each `getBoard`/`myVisits` query key — so this
+ * reads/writes the cache directly via the raw `QueryClient` instead.
+ */
+export interface ApplyVisitToCachesCtx {
+  utils: ReturnType<typeof api.useUtils>
+  queryClient: QueryClient
+}
+
+function windowInput(queryKey: readonly unknown[]): VisitWindow | undefined {
+  return (queryKey[1] as { input?: VisitWindow } | undefined)?.input
+}
+
+function listVisitsInput(
+  queryKey: readonly unknown[]
+): { workOrderRecordId: RecordId } | undefined {
+  return (queryKey[1] as { input?: { workOrderRecordId: RecordId } } | undefined)?.input
+}
+
+/**
+ * Surgically patch every cache that can hold `patch.visit` — `getBoard` (every cached window),
+ * `listVisits` (this work order's cache, if open), `myVisits` (every cached window, only when
+ * `viewerUserId` is given) — from one mutation response. Idempotent by construction (upsert-by-
+ * id), so re-applying the same row twice (an optimistic patch, then the response apply, then a
+ * future Phase-2 broadcast apply) is harmless. `getVisitDayMarkers` is the one deliberate
+ * exception: a scoped invalidate, not a patch (plan 39 §2.1 judgment call — the mini-calendar
+ * dots are a tiny read and correctness math (count per day per worker, across the
+ * `includeCanceled` variant) isn't worth hand-maintaining for a query this cheap).
+ */
+export function applyVisitToCaches(ctx: ApplyVisitToCachesCtx, patch: VisitCachePatch): void {
+  const { utils, queryClient } = ctx
+  const { visit, workOrderStatus, viewerUserId, removeStaleVisitId, removeStaleWorkOrderId } = patch
+
+  const boardKey = getQueryKey(api.dispatch.getBoard, undefined, 'query')
+  for (const query of queryClient.getQueryCache().findAll({ queryKey: boardKey })) {
+    const window = windowInput(query.queryKey)
+    let old = query.state.data as BoardResult | undefined
+    if (!window || !old) continue
+    if (removeStaleVisitId || removeStaleWorkOrderId) {
+      old = {
+        ...old,
+        visits: removeStaleVisitId
+          ? old.visits.filter((v) => v.id !== removeStaleVisitId)
+          : old.visits,
+        workOrders: removeStaleWorkOrderId
+          ? old.workOrders.filter((wo) => wo.id !== removeStaleWorkOrderId)
+          : old.workOrders,
+      }
+    }
+    const { board, needsInvalidate } = applyBoardPatch(old, visit, workOrderStatus, window)
+    queryClient.setQueryData(query.queryKey, board)
+    if (needsInvalidate) void utils.dispatch.getBoard.invalidate(window)
+  }
+
+  const listVisitsKey = getQueryKey(api.dispatch.listVisits, undefined, 'query')
+  for (const query of queryClient.getQueryCache().findAll({ queryKey: listVisitsKey })) {
+    const input = listVisitsInput(query.queryKey)
+    const old = query.state.data as JobVisit[] | undefined
+    if (!input || !old) continue
+    if (getInstanceId(input.workOrderRecordId) !== visit.workOrderId) continue
+    queryClient.setQueryData(query.queryKey, mergeJobVisits(old, visit))
+  }
+
+  if (viewerUserId) {
+    const myVisitsKey = getQueryKey(api.dispatch.myVisits, undefined, 'query')
+    for (const query of queryClient.getQueryCache().findAll({ queryKey: myVisitsKey })) {
+      const window = windowInput(query.queryKey)
+      const old = query.state.data as MyVisitRow[] | undefined
+      if (!window || !old) continue
+      const { rows, needsInvalidate } = applyMyVisitsPatch(old, visit, viewerUserId, window)
+      queryClient.setQueryData(query.queryKey, rows)
+      if (needsInvalidate) void utils.dispatch.myVisits.invalidate(window)
+    }
+  }
+
+  // Pragmatic scoped invalidate (see the doc comment above) — cheap, rare, deliberately unpatched.
+  void utils.dispatch.getVisitDayMarkers.invalidate()
+}

--- a/apps/web/src/components/schedule/hooks/use-my-schedule.ts
+++ b/apps/web/src/components/schedule/hooks/use-my-schedule.ts
@@ -9,9 +9,16 @@
 
 'use client'
 
+import { useQueryClient } from '@tanstack/react-query'
 import { addWeeks, format, startOfDay } from 'date-fns'
 import { useCallback, useMemo } from 'react'
 import { visitTitle } from '~/components/calendar/sources/visits-source'
+import {
+  applyVisitToCaches,
+  rewrapVisitDates,
+  type VisitChangedPayload,
+} from '~/components/dispatch/visit-cache'
+import { useUser } from '~/hooks/use-user'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api, type RouterOutputs } from '~/trpc/react'
 
@@ -62,12 +69,31 @@ export function useMySchedule() {
   const meetingsQuery = api.calendar.myMeetings.useQuery({ from, to })
 
   const utils = api.useUtils()
+  const queryClient = useQueryClient()
+  const { userId } = useUser()
+
+  // Plan 39 §Phase-2: a `kind: 'row'` broadcast rewraps its wire-string dates and patches every
+  // cached `myVisits` window via `applyVisitToCaches` (scoped internally to `viewerUserId`)
+  // instead of invalidating. `kind: 'bulk'` and any old-shape/malformed payload fall back to the
+  // pre-Phase-2 scoped invalidate.
   const onEvent = useCallback(
-    (event: string) => {
+    (event: string, payload: unknown) => {
       if (event !== 'dispatch:visit-changed') return
+      const p = payload as VisitChangedPayload | undefined
+      if (p?.kind === 'row' && p.visit && userId) {
+        applyVisitToCaches(
+          { utils, queryClient },
+          {
+            visit: rewrapVisitDates(p.visit),
+            workOrderStatus: p.workOrderStatus,
+            viewerUserId: userId,
+          }
+        )
+        return
+      }
       void utils.dispatch.myVisits.invalidate({ from, to })
     },
-    [utils, from, to]
+    [utils, queryClient, userId, from, to]
   )
   useOrgChannel({ onEvent })
 

--- a/apps/web/src/components/schedule/ui/schedule-calendar.tsx
+++ b/apps/web/src/components/schedule/ui/schedule-calendar.tsx
@@ -211,6 +211,10 @@ export function ScheduleCalendar({
   // settle is enough. It can't rely on the realtime `dispatch:visit-changed` broadcast alone: the
   // acting client's own socket id is excluded from its own broadcast (the board's optimistic
   // patch is what stands in for it there), and paste is only ever invoked BY this same client.
+  // Plan `dispatch/39-visit-cache-sync.md` §Phase-1's batch-op rule: `pasteVisits` is the one
+  // deliberate multi-row mutation (N new work orders' worth of rows in one round trip) — no
+  // single-row response protocol fits, so this keeps the settle-invalidate rather than adopting
+  // `applyVisitToCaches`.
   const pasteVisits = api.dispatch.pasteVisits.useMutation({
     onSuccess: (result) => {
       if (result.failures.length > 0) {

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -23,6 +23,7 @@ import {
   getRouteGeometryForWorker,
   getRoutePlannerBoard,
   getVisitDayMarkers,
+  getWorkOrderStatus,
   listDispatchWorkers,
   listMyVisitQcItems,
   listMyVisits,
@@ -84,6 +85,24 @@ const dispatchAdminProcedure = dispatchProcedure.use(async ({ ctx, next }) => {
 /** Echo-suppression convention (07 §B.4, the `agent.ts:234` precedent). */
 function excludeSocketId(ctx: { headers: Headers }): string | undefined {
   return ctx.headers.get('x-realtime-socket-id') ?? undefined
+}
+
+/** Roll-up sync (plan 39 `dispatch/39-visit-cache-sync.md` §Phase-1): the work-order status
+ * roll-up (`rollUpWorkOrderStatus`, `lifecycle.ts`) runs inside the mutation but its result is
+ * otherwise discarded — this is the one read-back, merged onto the returned visit row so the
+ * acting tab's cache patch (`applyVisitToCaches`) can reconcile board/drawer chip status without
+ * a second round trip. Skipped for `assignVisit` (no roll-up rule of its own) and `pasteVisits`
+ * (multi-work-order, out of scope for a single merged status). */
+async function withWorkOrderStatus<T extends { workOrderId: string }>(
+  ctx: { session: { organizationId: string; user: { id: string } } },
+  visit: T
+): Promise<T & { workOrderStatus: string | undefined }> {
+  const workOrderStatus = await getWorkOrderStatus(
+    ctx.session.organizationId,
+    ctx.session.user.id,
+    visit.workOrderId
+  )
+  return { ...visit, workOrderStatus }
 }
 
 const addressStructSchema = z.object({
@@ -182,7 +201,7 @@ export const dispatchRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      return scheduleVisit({
+      const visit = await scheduleVisit({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         visitId: input.visitId,
@@ -193,6 +212,7 @@ export const dispatchRouter = createTRPCRouter({
         timeWriteKind: input.timeWriteKind,
         excludeSocketId: excludeSocketId(ctx),
       })
+      return withWorkOrderStatus(ctx, visit)
     }),
   assignVisit: dispatchAdminProcedure
     .input(z.object({ visitId: z.string(), assigneeUserId: z.string().nullable() }))
@@ -208,23 +228,25 @@ export const dispatchRouter = createTRPCRouter({
   unscheduleVisit: dispatchAdminProcedure
     .input(z.object({ visitId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return unscheduleVisit({
+      const visit = await unscheduleVisit({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         visitId: input.visitId,
         excludeSocketId: excludeSocketId(ctx),
       })
+      return withWorkOrderStatus(ctx, visit)
     }),
   setVisitStatus: dispatchAdminProcedure
     .input(z.object({ visitId: z.string(), status: z.enum(VISIT_STATUS_VALUES) }))
     .mutation(async ({ ctx, input }) => {
-      return setVisitStatus({
+      const visit = await setVisitStatus({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         visitId: input.visitId,
         status: input.status,
         excludeSocketId: excludeSocketId(ctx),
       })
+      return withWorkOrderStatus(ctx, visit)
     }),
   // "Skip this and future visits" — tombstones the target occurrence AND ends its series
   // there (`until` stamp + later-scheduled-row cleanup). Single-row cancels keep going
@@ -243,12 +265,13 @@ export const dispatchRouter = createTRPCRouter({
   dispatchVisit: dispatchAdminProcedure
     .input(z.object({ visitId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return dispatchVisit({
+      const visit = await dispatchVisit({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         visitId: input.visitId,
         excludeSocketId: excludeSocketId(ctx),
       })
+      return withWorkOrderStatus(ctx, visit)
     }),
   // Plan 30 §A.1 — bring a canceled visit back to `scheduled` IN PLACE (never a new time).
   // `resumeSeries` (plan 36 §A.2): on the series boundary visit only, also clears the
@@ -256,13 +279,14 @@ export const dispatchRouter = createTRPCRouter({
   restoreVisit: dispatchAdminProcedure
     .input(z.object({ visitId: z.string(), resumeSeries: z.boolean().optional() }))
     .mutation(async ({ ctx, input }) => {
-      return restoreVisit({
+      const visit = await restoreVisit({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         visitId: input.visitId,
         resumeSeries: input.resumeSeries,
         excludeSocketId: excludeSocketId(ctx),
       })
+      return withWorkOrderStatus(ctx, visit)
     }),
 
   // §B.6 — the board's single read. Members read it (read-only board interactions).
@@ -413,7 +437,7 @@ export const dispatchRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { entityInstanceId } = parseRecordId(input.workOrderRecordId)
-      return addVisit({
+      const visit = await addVisit({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         workOrderInstanceId: entityInstanceId,
@@ -422,6 +446,7 @@ export const dispatchRouter = createTRPCRouter({
         assigneeUserId: input.assigneeUserId,
         excludeSocketId: excludeSocketId(ctx),
       })
+      return withWorkOrderStatus(ctx, visit)
     }),
 
   // Plan 37c §7 — slot-click create's "New job" path: builds a minimal work order from a
@@ -438,7 +463,7 @@ export const dispatchRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      return createWorkOrder({
+      const result = await createWorkOrder({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         contactRecordId: input.contactRecordId,
@@ -448,6 +473,12 @@ export const dispatchRouter = createTRPCRouter({
         assigneeUserId: input.assigneeUserId,
         excludeSocketId: excludeSocketId(ctx),
       })
+      const workOrderStatus = await getWorkOrderStatus(
+        ctx.session.organizationId,
+        ctx.session.user.id,
+        result.visit.workOrderId
+      )
+      return { ...result, workOrderStatus }
     }),
 
   // Plan 37c §4.4 — copy/paste's one deliberate batch mutation: N new rule-less, scheduled
@@ -491,7 +522,9 @@ export const dispatchRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const { entityInstanceId } = parseRecordId(input.workOrderRecordId)
       const visits = await listVisitsForWorkOrder(ctx.session.organizationId, entityInstanceId)
-      if (visits.length === 0) return visits
+      // `[]`, not `visits` — returning the bare rows here made the output type a union of
+      // bare|enriched row arrays, which broke `JobVisit` consumers (plan 39 `mergeJobVisits`).
+      if (visits.length === 0) return []
 
       const allocations = await ctx.db
         .select({

--- a/packages/lib/src/dispatch/broadcast.ts
+++ b/packages/lib/src/dispatch/broadcast.ts
@@ -1,21 +1,94 @@
 // packages/lib/src/dispatch/broadcast.ts
 //
-// Realtime (07 §B.4) — the `publish-helpers.ts` recipe. Slim ids-only payload; clients
-// patch/refetch their board range query (04-ui §D.5) rather than trusting the wire payload.
+// Realtime (07 §B.4) — the `publish-helpers.ts` recipe. Plan `dispatch/39-visit-cache-sync.md`
+// §Phase-2: the payload now carries the composed visit row (+ work-order roll-up status) for
+// single-row mutations, so other tabs can surgically patch their caches
+// (`apps/web/src/components/dispatch/visit-cache.ts`'s `applyVisitToCaches`) instead of
+// refetching a whole list. Bulk/series ops (recurrence regeneration, pause/resume, series-end)
+// can't carry a row — they send `kind: 'bulk'` and clients keep invalidating for those.
 
+import type { schema } from '@auxx/database'
 import { getRealtimeService, rooms } from '../realtime'
 
-/** Slim `dispatch:visit-changed` payload — ids only, clients refetch. */
+type WorkOrderVisitRow = typeof schema.WorkOrderVisit.$inferSelect
+
+/**
+ * `WorkOrderVisit` columns that travel over the realtime wire as ISO strings (Pusher-protocol
+ * JSON both directions — no SuperJSON on this channel, unlike tRPC). Every consumer must
+ * rewrap these with `new Date(...)` before writing into a React Query cache typed against the
+ * SuperJSON'd tRPC row shape. `occurrenceDate` is deliberately NOT in this list — it's a
+ * Drizzle `date()` column (mode: default), already a plain `YYYY-MM-DD` string on the row
+ * itself server-side, so it needs no rewrap.
+ */
+type VisitDateKey =
+  | 'startTime'
+  | 'endTime'
+  | 'geocodedAt'
+  | 'dispatchedAt'
+  | 'timeConfirmedAt'
+  | 'createdAt'
+  | 'updatedAt'
+
+/** The composed `WorkOrderVisit` row as it travels over the wire — every `VisitDateKey` column
+ * downgraded to its ISO-string wire representation (`createdAt`/`updatedAt` are DB `NOT NULL`,
+ * so they stay non-null strings; the rest stay nullable). Client-side mirror:
+ * `apps/web/src/components/dispatch/visit-cache.ts`'s `SerializedVisitRow` — this module has no
+ * `/client` export subpath (server-only deps upstream), so the client copies this type by hand
+ * (the `board/types.ts` `VISIT_STATUS_VALUES` precedent) rather than importing it. Keep both in
+ * sync by hand if this shape changes. */
+export type SerializedVisitRow = Omit<WorkOrderVisitRow, VisitDateKey> & {
+  startTime: string | null
+  endTime: string | null
+  geocodedAt: string | null
+  dispatchedAt: string | null
+  timeConfirmedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+/** `WorkOrderVisitRow` → `SerializedVisitRow` — the one write side of the wire-date contract
+ * above. Used by `afterVisitWrite` (`visit-mutations.ts`) right before publishing. */
+export function serializeVisitRow(visit: WorkOrderVisitRow): SerializedVisitRow {
+  return {
+    ...visit,
+    startTime: visit.startTime?.toISOString() ?? null,
+    endTime: visit.endTime?.toISOString() ?? null,
+    geocodedAt: visit.geocodedAt?.toISOString() ?? null,
+    dispatchedAt: visit.dispatchedAt?.toISOString() ?? null,
+    timeConfirmedAt: visit.timeConfirmedAt?.toISOString() ?? null,
+    createdAt: visit.createdAt.toISOString(),
+    updatedAt: visit.updatedAt.toISOString(),
+  }
+}
+
+/**
+ * `dispatch:visit-changed` payload. `visitId`/`workOrderId` are kept at the top level
+ * unconditionally (compat: every consumer keys off `workOrderId` today, including `kind:
+ * 'bulk'` publishers below that fake `visitId` with a rule id since no single row exists).
+ *
+ * - `kind: 'row'` — a single-row mutation (`afterVisitWrite`); `visit` carries the composed
+ *   value (project rule: a value-less realtime publish is a no-op — always publish the
+ *   composed value) and `workOrderStatus` carries the roll-up result when one ran
+ *   (`rollUpWorkOrderStatus` — absent for `assignVisit`/`setVisitDuration`, which have no
+ *   roll-up rule of their own, and for the recurring-engagement early-return).
+ * - `kind: 'bulk'` — recurrence regeneration, pause/resume, series-end, auto-end: ops that can
+ *   touch an unbounded row set. No `visit` — clients fall back to their scoped invalidate.
+ */
 export interface VisitChangedPayload {
   visitId: string
   workOrderId: string
+  kind: 'row' | 'bulk'
+  visit?: SerializedVisitRow
+  workOrderStatus?: string
 }
 
 /**
  * Publish `dispatch:visit-changed` on the org presence channel. Echo-suppression
  * convention: tRPC mutations read `x-realtime-socket-id` off the request and pass it as
  * `excludeSocketId`; engine/worker-origin writes omit it so every open tab refreshes.
- * Fire-and-forget — a Pusher hiccup must never fail the underlying visit mutation.
+ * Fire-and-forget — a Pusher hiccup must never fail the underlying visit mutation. Size: one
+ * visit row + status is well under the realtime service's payload cap (100KB,
+ * docs/realtime-architecture-guide.md).
  */
 export async function publishVisitChanged(
   organizationId: string,

--- a/packages/lib/src/dispatch/create-work-order.ts
+++ b/packages/lib/src/dispatch/create-work-order.ts
@@ -30,7 +30,8 @@ import { scheduleVisit } from './visit-mutations'
  *
  * @param input - organizationId, userId (acting user), contactRecordId, optional title (falls
  * back to the contact's displayName), the slot's startTime/endTime, optional assigneeUserId.
- * @returns The new work order's RecordId and the id of the visit that was scheduled onto it.
+ * @returns The new work order's RecordId, the id of the visit that was scheduled onto it, and
+ * the scheduled visit row itself (plan 39 §Phase-1 — feeds the acting tab's cache patch).
  */
 export async function createWorkOrder(input: CreateWorkOrderInput): Promise<CreateWorkOrderResult> {
   const { organizationId, userId, contactRecordId, startTime, endTime, assigneeUserId } = input
@@ -83,5 +84,5 @@ export async function createWorkOrder(input: CreateWorkOrderInput): Promise<Crea
     excludeSocketId: input.excludeSocketId,
   })
 
-  return { workOrderRecordId: created.recordId, visitId: scheduled.id }
+  return { workOrderRecordId: created.recordId, visitId: scheduled.id, visit: scheduled }
 }

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -5,8 +5,8 @@
 
 export type { BoardResult, BoardWorkOrder, GetBoardRange, VisitDayMarker } from './board'
 export { getBoard, getVisitDayMarkers, listVisitsForWorkOrder } from './board'
-export type { VisitChangedPayload } from './broadcast'
-export { publishVisitChanged } from './broadcast'
+export type { SerializedVisitRow, VisitChangedPayload } from './broadcast'
+export { publishVisitChanged, serializeVisitRow } from './broadcast'
 export { convertRequestToWorkOrder } from './convert-to-work-order'
 export { createWorkOrderFromTicket } from './create-from-ticket'
 export { createWorkOrder } from './create-work-order'

--- a/packages/lib/src/dispatch/lifecycle.ts
+++ b/packages/lib/src/dispatch/lifecycle.ts
@@ -49,19 +49,26 @@ const RESET_TRIGGERS: ReadonlySet<LifecycleTrigger> = new Set(['canceled', 'unsc
  * plain `FieldValueService` — the `convertRequestToWorkOrder` pre-hook-bypass precedent —
  * so manual dispatcher status edits stay allowed and no guard fights this write.
  * Transitions only move FORWARD from the current status, except the cancel/unschedule reset.
+ *
+ * Returns the status actually left on the work order after the call — the plan
+ * `dispatch/39-visit-cache-sync.md` §Phase-2 widen so `afterVisitWrite` can put it straight on
+ * the realtime broadcast instead of a second read-back: the `targetStatus` when the roll-up
+ * wrote it, the already-loaded current status when the forward-only guard blocked the write,
+ * `undefined` when no roll-up ran at all (no `work_order_status` field, or the recurring
+ * engagement early-return — engagement-level status is never visit-mirrored).
  */
 export async function rollUpWorkOrderStatus(
   organizationId: string,
   userId: string,
   workOrderId: string,
   trigger: LifecycleTrigger
-): Promise<void> {
+): Promise<string | undefined> {
   const targetStatus = TRIGGER_TARGET_STATUS[trigger]
   const cf = await getOrgCache()
     .from(organizationId, 'customFields')
     .bySystemAttributes(['work_order_status', 'work_order_job_type'] as const)
   const statusField = cf.work_order_status
-  if (!statusField) return
+  if (!statusField) return undefined
 
   // Resolve the type-slug to the real `entityDefinitionId` UUID — the field-change hook
   // dispatch inside `setValuesForEntity` looks up the resource by `entityDefinitionId` via
@@ -85,7 +92,7 @@ export async function rollUpWorkOrderStatus(
     })
     const jobTypeFirst = Array.isArray(jobTypeTyped) ? jobTypeTyped[0] : jobTypeTyped
     const jobType = jobTypeFirst ? (extractValue(jobTypeFirst) as string) : undefined
-    if (jobType === 'recurring') return
+    if (jobType === 'recurring') return undefined
   }
 
   if (!RESET_TRIGGERS.has(trigger)) {
@@ -95,11 +102,12 @@ export async function rollUpWorkOrderStatus(
     const current = currentFirst ? (extractValue(currentFirst) as string) : undefined
     const currentRank = current !== undefined ? (STATUS_RANK[current] ?? -1) : -1
     const targetRank = STATUS_RANK[targetStatus] ?? -1
-    if (targetRank <= currentRank) return // forward-only guard
+    if (targetRank <= currentRank) return current // forward-only guard blocked — unchanged
   }
 
   await fieldValueService.setValuesForEntity({
     recordId,
     values: [{ fieldId: statusField.id, value: targetStatus }],
   })
+  return targetStatus
 }

--- a/packages/lib/src/dispatch/recurring/engagement-actions.ts
+++ b/packages/lib/src/dispatch/recurring/engagement-actions.ts
@@ -119,7 +119,9 @@ async function writeEngagementStatus(
 }
 
 /** Mirror + broadcast once (07 §B.3/§B.4) — used by pause/end, which don't otherwise run
- * `materializeVisits` (resume does, and that already mirrors + broadcasts). */
+ * `materializeVisits` (resume does, and that already mirrors + broadcasts). `kind: 'bulk'` —
+ * an engagement-level (pause/end) write, no single visit row describes it; `visitId` is the
+ * RULE id (plan 39 §2.3). */
 async function mirrorAndBroadcast(
   rule: RecurrenceRuleRow,
   userId: string,
@@ -128,7 +130,7 @@ async function mirrorAndBroadcast(
   await mirrorVisitOntoWorkOrder(rule.organizationId, userId, rule.subjectId)
   await publishVisitChanged(
     rule.organizationId,
-    { visitId: rule.id, workOrderId: rule.subjectId },
+    { visitId: rule.id, workOrderId: rule.subjectId, kind: 'bulk' },
     { excludeSocketId }
   )
 }

--- a/packages/lib/src/dispatch/recurring/materialize.ts
+++ b/packages/lib/src/dispatch/recurring/materialize.ts
@@ -176,9 +176,12 @@ export async function materializeVisits(
 
   const userId = opts.userId ?? (await systemActorUserId(rule.organizationId))
   await mirrorVisitOntoWorkOrder(rule.organizationId, userId, rule.subjectId)
+  // `kind: 'bulk'` — materialization can insert/update an unbounded run of occurrences; no
+  // single row describes it. `visitId` here is the RULE id (there is no one visit), kept only
+  // for the top-level shape every consumer still keys `workOrderId` off (plan 39 §2.3).
   await publishVisitChanged(
     rule.organizationId,
-    { visitId: rule.id, workOrderId: rule.subjectId },
+    { visitId: rule.id, workOrderId: rule.subjectId, kind: 'bulk' },
     { excludeSocketId: opts.excludeSocketId }
   )
 }
@@ -246,7 +249,13 @@ export async function maybeEndExhaustedEngagement(rule: RecurrenceRuleRow): Prom
     values: [{ fieldId: cf.work_order_status.id, value: 'ended' }],
   })
   await mirrorVisitOntoWorkOrder(rule.organizationId, userId, rule.subjectId)
-  await publishVisitChanged(rule.organizationId, { visitId: rule.id, workOrderId: rule.subjectId })
+  // `kind: 'bulk'` — an engagement-level status write, not a visit row; `visitId` is the RULE
+  // id (plan 39 §2.3, the `materializeVisits` precedent above).
+  await publishVisitChanged(rule.organizationId, {
+    visitId: rule.id,
+    workOrderId: rule.subjectId,
+    kind: 'bulk',
+  })
 }
 
 /**

--- a/packages/lib/src/dispatch/recurring/rule-mutations.ts
+++ b/packages/lib/src/dispatch/recurring/rule-mutations.ts
@@ -466,11 +466,13 @@ export async function setSeriesEnd(input: SetSeriesEndInput): Promise<Recurrence
 
   if (status === 'paused') {
     // Pause already deleted the future rows — never regenerate them here (resume owns that).
-    // Mirror + broadcast directly so other tabs still refresh the rule state.
+    // Mirror + broadcast directly so other tabs still refresh the rule state. `kind: 'bulk'` —
+    // a rule-level (tombstone) write, no single visit row describes it; `visitId` is the RULE
+    // id (plan 39 §2.3).
     await mirrorVisitOntoWorkOrder(organizationId, userId, rule.subjectId)
     await publishVisitChanged(
       organizationId,
-      { visitId: rule.id, workOrderId: rule.subjectId },
+      { visitId: rule.id, workOrderId: rule.subjectId, kind: 'bulk' },
       { excludeSocketId }
     )
   } else {

--- a/packages/lib/src/dispatch/types.ts
+++ b/packages/lib/src/dispatch/types.ts
@@ -1,6 +1,9 @@
 // packages/lib/src/dispatch/types.ts
 
+import type { schema } from '@auxx/database'
 import type { RecordId } from '@auxx/types/resource'
+
+type WorkOrderVisitRow = typeof schema.WorkOrderVisit.$inferSelect
 
 /** Input for {@link createWorkOrderFromTicket} — the SECONDARY intake path (01 §8). */
 export interface CreateFromTicketInput {
@@ -37,6 +40,10 @@ export interface CreateWorkOrderInput {
 export interface CreateWorkOrderResult {
   workOrderRecordId: RecordId
   visitId: string
+  /** The scheduled visit row (plan 39 §Phase-1) — lets the acting-tab cache patch
+   * (`applyVisitToCaches`) reconcile every visit-holding cache off this one response instead
+   * of a second round trip. */
+  visit: WorkOrderVisitRow
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/lib/src/dispatch/visit-mutations.ts
+++ b/packages/lib/src/dispatch/visit-mutations.ts
@@ -18,7 +18,7 @@ import {
   onVisitCompleted,
 } from '../sequences/hooks'
 import { reanchorSequenceRuns } from '../sequences/reanchor'
-import { publishVisitChanged } from './broadcast'
+import { publishVisitChanged, serializeVisitRow } from './broadcast'
 import { type LifecycleTrigger, rollUpWorkOrderStatus } from './lifecycle'
 import { mirrorVisitOntoWorkOrder } from './mirror'
 // Direct module import (not the ./recurring barrel) — the barrel pulls engagement-actions,
@@ -79,18 +79,33 @@ export async function ensureVisitForWorkOrder(
  * `trigger` is omitted — e.g. `assignVisit`, which has no roll-up rule of its own), then
  * broadcast the change. Exported standalone so the M2c engine's rolling-window
  * materializer can reuse it after a bulk visit write.
+ *
+ * Plan `dispatch/39-visit-cache-sync.md` §Phase-2: the broadcast carries the composed row
+ * (`kind: 'row'`) plus whatever `rollUpWorkOrderStatus` left on the work order, so other tabs
+ * can patch their caches (`applyVisitToCaches`) instead of refetching a list.
  */
 export async function afterVisitWrite(
   visit: WorkOrderVisitRow,
   opts: { userId: string; trigger?: LifecycleTrigger; excludeSocketId?: string }
 ): Promise<void> {
   await mirrorVisitOntoWorkOrder(visit.organizationId, opts.userId, visit.workOrderId)
-  if (opts.trigger) {
-    await rollUpWorkOrderStatus(visit.organizationId, opts.userId, visit.workOrderId, opts.trigger)
-  }
+  const workOrderStatus = opts.trigger
+    ? await rollUpWorkOrderStatus(
+        visit.organizationId,
+        opts.userId,
+        visit.workOrderId,
+        opts.trigger
+      )
+    : undefined
   await publishVisitChanged(
     visit.organizationId,
-    { visitId: visit.id, workOrderId: visit.workOrderId },
+    {
+      visitId: visit.id,
+      workOrderId: visit.workOrderId,
+      kind: 'row',
+      visit: serializeVisitRow(visit),
+      workOrderStatus,
+    },
     { excludeSocketId: opts.excludeSocketId }
   )
 }
@@ -300,7 +315,22 @@ export async function restoreVisit(input: RestoreVisitInput): Promise<WorkOrderV
       .returning()
     const status = await getWorkOrderStatus(organizationId, userId, existing.workOrderId)
     if (updatedRule && status !== 'paused') {
+      // `materializeVisits` broadcasts its own `kind: 'bulk'` event unconditionally at the end
+      // (plan 39 §Phase-2) — that's the signal other tabs need to refresh the regenerated tail
+      // + series summary on top of the `kind: 'row'` visit-restore broadcast just above, so no
+      // extra publish is needed here.
       await materializeVisits(updatedRule, { userId, excludeSocketId })
+    } else if (updatedRule) {
+      // Paused engagement: no `materializeVisits` call (pause owns deletion, resume only
+      // regenerates once un-paused), so nothing else broadcasts the rule write above. The
+      // `kind: 'row'` visit-restore broadcast can't signal a rule-level `until` change — publish
+      // a second, explicit `kind: 'bulk'` event so other tabs' `getRecurrence` cache doesn't go
+      // stale (plan 39 §Phase-2, the restoreVisit(resumeSeries) broadcast decision).
+      await publishVisitChanged(
+        organizationId,
+        { visitId: updatedRule.id, workOrderId: existing.workOrderId, kind: 'bulk' },
+        { excludeSocketId }
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

Plan 39 (`plans/dispatch/39-visit-cache-sync.md`), phases 1–2, plus the month-view drag fix as its own commit.

**The bug**: move a visit on the dispatch board and the work-order drawer's Schedule section in the **same tab** stays stale — visits live in four React Query caches (`getBoard`, `listVisits`, `myVisits`, `getVisitDayMarkers`) bridged only by an ids-only realtime broadcast that excludes the acting tab's socket. Other tabs also paid a full list refetch per event.

### Phase 1 — acting tab (fixes the bug)
- New `applyVisitToCaches()` (`apps/web/src/components/dispatch/visit-cache.ts`): one write path that upserts/removes the changed row across **every** cached `getBoard`/`myVisits` window (day/timeline scrolling keeps many alive), merges-by-id into `listVisits` preserving the invoice-allocation enrichment (re-sorted `startTime ASC NULLS LAST`), and patches work-order roll-up status on board summaries. Scoped invalidate remains only where a row can't be fabricated client-side (never-seen work order in a window; `myVisits` insert needs a displayName/number join). Pure patch functions unit-tested (21 tests).
- Single-row mutations now feed the apply from their own responses; the router merges `workOrderStatus` onto returned rows (`withWorkOrderStatus` via `getWorkOrderStatus`); `CreateWorkOrderResult` widened to carry the scheduled visit row.
- Duplicate-chip fix found during wiring: `addVisit`/`createWorkOrder`'s optimistic temp rows are purged before the real row lands (client temp ids never match server ids).

### Phase 2 — other tabs
- `dispatch:visit-changed` now carries the composed serialized row + roll-up status (`kind: 'row'`); `rollUpWorkOrderStatus` widened `void → string | undefined` (advanced / guard-blocked-current / no-op).
- Realtime handlers (board, drawer, schedule ×2) rewrap wire-string dates and apply instead of invalidating; bulk/series publishers (materialize, pause/resume, series-end) send `kind: 'bulk'` and keep the invalidate fallback, as do malformed/old-shape payloads.
- `restoreVisit(resumeSeries)` on a **paused** engagement publishes an explicit bulk event (nothing else broadcasts that rule write); non-paused resume rides `materializeVisits`' own broadcast.

### Also fixed in passing
- `listVisits` empty-case early return produced a bare/enriched **union** output type — now returns `[]` so `JobVisit` is a single shape (this was a live `tsc` error in `mergeJobVisits`).
- **Month-view drags now commit** (first commit): stale M2A display-only guard in `handleEventDrop` silently discarded every month drop; the dnd layer already computed them correctly and 37c §6 specs them.

## Verification
- `visit-cache.test.ts` 21/21 (31/31 with group-drag + clipboard-offset suites)
- `verify-dispatch-create-work-order.ts` 16/16 against dev DB (return-shape widen safe)
- `verify-dispatch-recurring.ts` 58/59 — the 1 failure is a pre-existing assertion/behavior mismatch from #1250 (`maybeEndExhaustedEngagement` flips status before the assertion), confirmed unrelated by diff
- Scoped typechecks clean for every touched file in `apps/web` + `packages/lib`; biome clean
- **Pending**: two-tab browser pass (move in tab A → tab B board/drawer/schedule update with zero refetch in the network tab; same-tab drawer updates on board move)

## Notes for review
- Echo suppression unchanged — acting tab covered by response-apply, other tabs by the fat payload; `applyVisitToCaches` is idempotent (upsert-by-id) so overlap is harmless.
- Wire types are hand-mirrored client-side in `visit-cache.ts` (no `/client` subpath for `@auxx/lib/dispatch`; `board/types.ts` precedent) — flagged in both files' comments.
- `getVisitDayMarkers` stays on scoped invalidate by design (tiny query, per-day count math not worth hand-maintaining).