### PR TITLE
fix(money): keep remaining default line rows after editing one

### DIFF
--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -664,9 +664,13 @@ export function LineBuilder({
    */
   const createDraft = useCallback(
     async (draftId: string, overrides: LinePatch = {}) => {
-      // The first real edit promotes an initial loading placeholder to a normal
-      // draft, so an arriving persisted list cannot remove the user's work.
-      initialDraftIdsRef.current.delete(draftId)
+      // The first real edit retires the whole initial-placeholder concept: the
+      // edited draft materializes into a real record, and the remaining seeded
+      // rows demote to ordinary empty drafts instead of being cleared as stale
+      // placeholders. Clearing the WHOLE set (not just this id) is what keeps
+      // the other default rows on screen after you fill one in — placeholder
+      // replacement only ever runs before the user has touched anything.
+      initialDraftIdsRef.current.clear()
       if (creatingDraftIdsRef.current.has(draftId)) {
         mutateDrafts((prev) =>
           prev.map((d) => (d.draftId === draftId ? { ...d, ...overrides } : d))


### PR DESCRIPTION
## Problem

The line builder seeds three empty default rows on an editable document. Editing any one of them made the **other two disappear**.

## Cause

The three default rows are local "initial placeholder" drafts, tracked in `initialDraftIdsRef`. Editing one calls `createDraft`, which materializes it into a real record — flipping `displayRecords.length` to `1`. That flip trips the placeholder-cleanup path (`visibleDrafts` filter + effect at `line-builder.tsx:418/423`), which is keyed only on "a real record now exists" and can't tell "user edited a placeholder" apart from "persisted rows loaded from the server." So it cleared the two still-untouched placeholders.

## Fix

On the first edit, retire the whole initial-placeholder concept by clearing the entire `initialDraftIdsRef` set (not just the edited id). The remaining seeded rows demote to ordinary empty drafts and stay on screen. Placeholder replacement still runs for its intended case — server rows arriving before the user has touched anything.

Untouched empty drafts still never persist (they vanish on unmount), so no blank lines are saved.