### PR TITLE
feat(dispatch): qc photo captions, office capture and printable visit report

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -3,6 +3,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { toActorId } from '@auxx/types/actor'
+import { getFileRefDownloadUrl, toFileRef } from '@auxx/types/file-ref'
 import { type RecordId, toRecordId } from '@auxx/types/resource'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Badge } from '@auxx/ui/components/badge'
@@ -14,6 +15,7 @@ import { format } from 'date-fns'
 import {
   CalendarClock,
   CircleDollarSign,
+  Printer,
   ReceiptText,
   RotateCcw,
   Send,
@@ -75,6 +77,12 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
   const setVisitDuration = api.dispatch.setVisitDuration.useMutation({
     onError: (error) => toastError({ title: 'Error saving duration', description: error.message }),
     onSuccess: refresh,
+  })
+  const getVisitReportPdf = api.dispatch.getVisitReportPdf.useMutation({
+    onSuccess: (data) =>
+      window.open(getFileRefDownloadUrl(toFileRef('asset', data.assetId)), '_blank'),
+    onError: (error) =>
+      toastError({ title: 'Error rendering visit report', description: error.message }),
   })
   const utils = api.useUtils()
   const addExtrasToContract = api.money.addVisitExtrasToContract.useMutation({
@@ -281,8 +289,19 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
           </FieldPanelRow>
         </FieldPanel>
 
-        {/* Per-visit proof of work — the worker's captured QC checklist (notes + photos),
-            read-only dispatcher-side. Authoring stays on the worker surface's Notes tab. */}
+        {/* Per-visit proof of work — the worker's captured QC checklist (checks + notes are
+            worker attestations; photos are office-editable, 37d §4). "Print report" renders the
+            per-visit Visit report PDF on demand (37d §5). */}
+        <div className='flex justify-end'>
+          <Button
+            variant='outline'
+            size='sm'
+            loading={getVisitReportPdf.isPending}
+            loadingText='Rendering...'
+            onClick={() => getVisitReportPdf.mutate({ visitId: visit.id })}>
+            <Printer /> Print report
+          </Button>
+        </div>
         <VisitProofOfWork visitId={visit.id} />
 
         <div className='flex items-center justify-between gap-3 rounded-xl border bg-primary-100 p-3'>

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-proof-of-work.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-proof-of-work.tsx
@@ -1,10 +1,11 @@
 // apps/web/src/components/dispatch/ui/job-schedule/visit-proof-of-work.tsx
 //
-// The visit-detail panel's proof-of-work block (plan 17 Part A) — the dispatcher's READ-ONLY
-// view of what the worker captured on the visit's quality checklist (per-item notes + photos,
-// authored on the worker surface's Notes tab). Backed by `dispatch.listVisitQcItems`, which is
-// org-scoped and non-materializing: an untouched visit shows the empty state, it never authors
-// checklist rows. Reviewing is the dispatcher's role; authoring stays worker-side by design.
+// The visit-detail panel's proof-of-work block (plan 17 Part A) — the dispatcher's view of what
+// the worker captured on the visit's quality checklist. Checks and per-item notes stay READ-ONLY
+// (worker attestations); PHOTOS are editable here (37d §4 office capture) via the org-scoped
+// `*Visit*` mutations, so a dispatcher can add/caption/remove proof-of-work photos. Backed by
+// `dispatch.listVisitQcItems`, which is org-scoped and non-materializing: an untouched visit
+// shows the empty state (no checklist rows to attach photos to yet — v1 hangs photos off items).
 //
 // Layout mirrors the billing blocks: a `TuckedLabel` header the content tucks into, with
 // `EmptySection` covering the loading + empty states.
@@ -12,10 +13,11 @@
 'use client'
 
 import { EmptySection } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
 import { TREE_SECONDARY_NOTRUNCATE } from '@auxx/ui/components/tree-row'
 import { TuckedSection } from '@auxx/ui/components/tucked-label'
 import { ClipboardList } from 'lucide-react'
-import { QcItemDisplay } from '~/components/schedule/ui/qc/qc-item-display'
+import { QcItemDisplay, type QcItemPhotoEditing } from '~/components/schedule/ui/qc/qc-item-display'
 import { api } from '~/trpc/react'
 
 interface VisitProofOfWorkProps {
@@ -23,7 +25,29 @@ interface VisitProofOfWorkProps {
 }
 
 export function VisitProofOfWork({ visitId }: VisitProofOfWorkProps) {
+  const utils = api.useUtils()
   const { data, isLoading } = api.dispatch.listVisitQcItems.useQuery({ visitId })
+
+  const invalidate = () => utils.dispatch.listVisitQcItems.invalidate({ visitId })
+  const addPhoto = api.dispatch.addVisitQcItemPhoto.useMutation({
+    onSuccess: invalidate,
+    onError: (error) => toastError({ title: 'Error attaching photo', description: error.message }),
+  })
+  const removePhoto = api.dispatch.removeVisitQcItemPhoto.useMutation({
+    onSuccess: invalidate,
+    onError: (error) => toastError({ title: 'Error removing photo', description: error.message }),
+  })
+  const setCaption = api.dispatch.setVisitQcItemPhotoCaption.useMutation({
+    onSuccess: invalidate,
+    onError: (error) => toastError({ title: 'Error saving caption', description: error.message }),
+  })
+
+  const photoEditing: QcItemPhotoEditing = {
+    onAddPhoto: (itemId, assetId) => addPhoto.mutate({ itemId, assetId }),
+    onRemovePhoto: (itemId, attachmentId) => removePhoto.mutate({ itemId, attachmentId }),
+    onSetCaption: (itemId, attachmentId, caption) =>
+      setCaption.mutate({ itemId, attachmentId, caption }),
+  }
 
   const items = data?.items ?? []
 
@@ -45,7 +69,7 @@ export function VisitProofOfWork({ visitId }: VisitProofOfWorkProps) {
       ) : (
         <div className={`rounded-xl border bg-primary-50 p-2 ${TREE_SECONDARY_NOTRUNCATE}`}>
           {items.map((item) => (
-            <QcItemDisplay key={item.id} item={item} />
+            <QcItemDisplay key={item.id} item={item} photoEditing={photoEditing} />
           ))}
         </div>
       )}

--- a/apps/web/src/components/pickers/photo-tile-editor.tsx
+++ b/apps/web/src/components/pickers/photo-tile-editor.tsx
@@ -24,6 +24,9 @@ interface PhotoTileEditorProps {
   name: string
   caption?: string
   internal?: boolean
+  /** Show the internal/customer visibility toggle (37b quote photos). QC photos have no
+   * internal split (37d), so they render caption-only via `showInternal={false}`. */
+  showInternal?: boolean
   onSave: (patch: { caption?: string; internal?: boolean }) => Promise<void> | void
   onRemove: () => void
 }
@@ -42,6 +45,7 @@ export function PhotoTileEditor({
   name,
   caption,
   internal,
+  showInternal = true,
   onSave,
   onRemove,
 }: PhotoTileEditorProps) {
@@ -62,7 +66,10 @@ export function PhotoTileEditor({
     setIsSaving(true)
     try {
       const trimmed = captionDraft.trim()
-      await onSave({ caption: trimmed ? trimmed : undefined, internal: internalDraft })
+      await onSave({
+        caption: trimmed ? trimmed : undefined,
+        ...(showInternal ? { internal: internalDraft } : {}),
+      })
       setOpen(false)
     } finally {
       setIsSaving(false)
@@ -77,7 +84,11 @@ export function PhotoTileEditor({
         className='flex flex-col gap-4 sm:max-w-sm'>
         <SheetHeader>
           <SheetTitle className='truncate'>{name}</SheetTitle>
-          <SheetDescription>Add a caption or hide this photo from the customer.</SheetDescription>
+          <SheetDescription>
+            {showInternal
+              ? 'Add a caption or hide this photo from the customer.'
+              : 'Add a caption.'}
+          </SheetDescription>
         </SheetHeader>
 
         <div className='flex flex-col gap-1.5'>
@@ -91,13 +102,15 @@ export function PhotoTileEditor({
           />
         </div>
 
-        <div className='flex items-center justify-between rounded-md border p-3'>
-          <div className='flex flex-col gap-0.5'>
-            <span className='text-sm font-medium'>Internal</span>
-            <span className='text-xs text-muted-foreground'>Hidden from customer</span>
+        {showInternal && (
+          <div className='flex items-center justify-between rounded-md border p-3'>
+            <div className='flex flex-col gap-0.5'>
+              <span className='text-sm font-medium'>Internal</span>
+              <span className='text-xs text-muted-foreground'>Hidden from customer</span>
+            </div>
+            <Switch checked={internalDraft} onCheckedChange={setInternalDraft} />
           </div>
-          <Switch checked={internalDraft} onCheckedChange={setInternalDraft} />
-        </div>
+        )}
 
         <SheetFooter className='mt-auto flex-row justify-between sm:justify-between'>
           <Button

--- a/apps/web/src/components/schedule/ui/qc/qc-item-display.tsx
+++ b/apps/web/src/components/schedule/ui/qc/qc-item-display.tsx
@@ -1,11 +1,11 @@
 // apps/web/src/components/schedule/ui/qc/qc-item-display.tsx
 //
-// Read-only presentation of one quality-check row — the dispatcher-side counterpart of
-// `QcItemRow` (plan 17 Part A). Deliberately a SIBLING, not a shared base: the worker row is
-// wired to the assignee-guarded `my*` mutations (checkbox, note textarea, photo add/remove),
-// and threading all of that through props would bloat both. This renders the same TreeRow
-// shape with a static check glyph, and expands (only when there's anything to show) into the
-// note as static text + the photo strip without remove/camera controls.
+// The dispatcher-side counterpart of `QcItemRow` (plan 17 Part A). Deliberately a SIBLING, not a
+// shared base: the worker row is wired to the assignee-guarded `my*` mutations for the checkbox
+// and note; those stay worker attestations and render read-only here. Photos are the exception —
+// with `photoEditing` supplied (office capture, 37d §4) the row hosts the shared, editable
+// `QcPhotoStrip` wired to the org-scoped `*Visit*` mutations, so a dispatcher can add/caption/
+// remove photos from the proof-of-work panel. Without it, photos render as static thumbnails.
 
 'use client'
 
@@ -15,6 +15,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Circle, CircleCheck, Image as ImageIcon, MessageSquare } from 'lucide-react'
 import { useState } from 'react'
 import { AttachmentThumbnail } from '~/components/files/utils/attachment-thumbnail'
+import { QcPhotoStrip } from './qc-photo-strip'
 
 /** The display slice of a checklist item — both `listMyVisitQcItems` and the dispatcher's
  * `listVisitQcItems` rows satisfy it. */
@@ -24,20 +25,30 @@ export interface QcItemDisplayData {
   isRequired: boolean
   note: string | null
   checkedAt: Date | null
-  photos: { attachmentId: string; assetId: string | null }[]
+  photos: { attachmentId: string; assetId: string | null; caption: string | null }[]
+}
+
+/** Office photo-editing handlers (37d §4) — supplied by the proof-of-work panel to make the
+ * photo strip editable while checks/notes stay read-only. */
+export interface QcItemPhotoEditing {
+  onAddPhoto: (itemId: string, assetId: string) => void
+  onRemovePhoto: (itemId: string, attachmentId: string) => void
+  onSetCaption: (itemId: string, attachmentId: string, caption: string | null) => void
 }
 
 interface QcItemDisplayProps {
   item: QcItemDisplayData
+  photoEditing?: QcItemPhotoEditing
 }
 
-export function QcItemDisplay({ item }: QcItemDisplayProps) {
+export function QcItemDisplay({ item, photoEditing }: QcItemDisplayProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   const isChecked = !!item.checkedAt
   const hasNote = !!item.note
   const hasPhotos = item.photos.length > 0
-  const expandable = hasNote || hasPhotos
+  // With office editing on, the row must open even when empty so a photo can be added.
+  const expandable = hasNote || hasPhotos || !!photoEditing
 
   return (
     <TreeRow
@@ -59,7 +70,7 @@ export function QcItemDisplay({ item }: QcItemDisplayProps) {
         ) : undefined
       }
       actions={
-        expandable ? (
+        hasNote || hasPhotos ? (
           <div className='flex items-center gap-1.5 text-muted-foreground'>
             {hasNote && <MessageSquare className='size-3.5' />}
             {hasPhotos && (
@@ -77,16 +88,35 @@ export function QcItemDisplay({ item }: QcItemDisplayProps) {
       {expandable && (
         <div className='flex flex-col gap-2 py-2 pl-9 pr-2'>
           {hasNote && <p className='whitespace-pre-wrap text-sm'>{item.note}</p>}
-          {hasPhotos && (
-            <div className='flex flex-wrap items-center gap-2'>
-              {item.photos.map((photo) => (
-                <AttachmentThumbnail
-                  key={photo.attachmentId}
-                  attachmentId={photo.attachmentId}
-                  alt={item.title}
-                />
-              ))}
-            </div>
+          {photoEditing ? (
+            <QcPhotoStrip
+              itemId={item.id}
+              itemTitle={item.title}
+              photos={item.photos}
+              onAddPhoto={(assetId) => photoEditing.onAddPhoto(item.id, assetId)}
+              onRemovePhoto={(attachmentId) => photoEditing.onRemovePhoto(item.id, attachmentId)}
+              onSetCaption={(attachmentId, caption) =>
+                photoEditing.onSetCaption(item.id, attachmentId, caption)
+              }
+            />
+          ) : (
+            hasPhotos && (
+              <div className='flex flex-wrap items-start gap-2'>
+                {item.photos.map((photo) => (
+                  <div key={photo.attachmentId} className='w-12'>
+                    <AttachmentThumbnail
+                      attachmentId={photo.attachmentId}
+                      alt={photo.caption ?? item.title}
+                    />
+                    {photo.caption && (
+                      <p className='mt-0.5 line-clamp-1 text-[10px] text-muted-foreground'>
+                        {photo.caption}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )
           )}
         </div>
       )}

--- a/apps/web/src/components/schedule/ui/qc/qc-item-row.tsx
+++ b/apps/web/src/components/schedule/ui/qc/qc-item-row.tsx
@@ -14,11 +14,10 @@ import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Camera, Image as ImageIcon, Loader2, MessageSquare, X } from 'lucide-react'
+import { Image as ImageIcon, MessageSquare } from 'lucide-react'
 import { useRef, useState } from 'react'
-import { useFileUpload } from '~/components/file-upload/hooks/use-file-upload'
-import { AttachmentThumbnail } from '~/components/files/utils/attachment-thumbnail'
 import { api, type RouterOutputs } from '~/trpc/react'
+import { QcPhotoStrip } from './qc-photo-strip'
 
 type MyVisitQcItem = RouterOutputs['dispatch']['listMyVisitQcItems']['items'][number]
 
@@ -31,7 +30,6 @@ export function QcItemRow({ visitId, item }: QcItemRowProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [noteDraft, setNoteDraft] = useState(item.note ?? '')
   const savedNoteRef = useRef(item.note ?? '')
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const utils = api.useUtils()
 
@@ -73,39 +71,15 @@ export function QcItemRow({ visitId, item }: QcItemRowProps) {
     onError: (error) => toastError({ title: 'Error removing photo', description: error.message }),
   })
 
-  const fileUpload = useFileUpload({
-    entityType: 'visit_qc_item',
-    entityId: item.id,
-    onComplete: (results) => {
-      const result = results.results[0]
-      if (result?.success && result.metadata?.assetId) {
-        addPhoto.mutate({ itemId: item.id, assetId: result.metadata.assetId })
-      } else if (result?.error) {
-        toastError({ title: 'Error uploading photo', description: result.error })
-      }
-    },
-    onError: (error) => toastError({ title: 'Error uploading photo', description: error }),
+  const setCaption = api.dispatch.setMyQcItemPhotoCaption.useMutation({
+    onSuccess: () => utils.dispatch.listMyVisitQcItems.invalidate({ visitId }),
+    onError: (error) => toastError({ title: 'Error saving caption', description: error.message }),
   })
 
   const handleNoteBlur = () => {
     if (noteDraft === savedNoteRef.current) return
     savedNoteRef.current = noteDraft
     setNote.mutate({ itemId: item.id, note: noteDraft.trim() ? noteDraft : null })
-  }
-
-  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(event.target.files ?? [])
-    event.target.value = ''
-    if (files.length === 0) return
-    try {
-      await fileUpload.addFiles(files)
-      await fileUpload.startUpload()
-    } catch (error) {
-      toastError({
-        title: 'Error uploading photo',
-        description: error instanceof Error ? error.message : 'Upload failed',
-      })
-    }
   }
 
   const isChecked = !!item.checkedAt
@@ -162,45 +136,16 @@ export function QcItemRow({ visitId, item }: QcItemRowProps) {
           rows={2}
           className='text-sm'
         />
-        <div className='flex flex-wrap items-center gap-2'>
-          {item.photos.map((photo) => (
-            <div key={photo.attachmentId} className='relative'>
-              <AttachmentThumbnail attachmentId={photo.attachmentId} alt={item.title} />
-              <button
-                type='button'
-                onClick={() =>
-                  removePhoto.mutate({ itemId: item.id, attachmentId: photo.attachmentId })
-                }
-                disabled={removePhoto.isPending}
-                aria-label='Remove photo'
-                className='absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-destructive text-destructive-foreground'>
-                <X className='size-2.5' />
-              </button>
-            </div>
-          ))}
-          <button
-            type='button'
-            onClick={() => fileInputRef.current?.click()}
-            disabled={fileUpload.isUploading}
-            aria-label='Add photo'
-            className='flex size-12 items-center justify-center rounded-md border border-dashed text-muted-foreground hover:bg-accent/50'>
-            {fileUpload.isUploading ? (
-              <Loader2 className='size-4 animate-spin' />
-            ) : (
-              <Camera className='size-4' />
-            )}
-          </button>
-          {/* First repo-wide `capture=` usage — one attribute on the input `useFileUpload`
-              feeds; opens the device camera directly on mobile instead of the file picker. */}
-          <input
-            ref={fileInputRef}
-            type='file'
-            accept='image/*'
-            capture='environment'
-            className='hidden'
-            onChange={handleFileChange}
-          />
-        </div>
+        <QcPhotoStrip
+          itemId={item.id}
+          itemTitle={item.title}
+          photos={item.photos}
+          onAddPhoto={(assetId) => addPhoto.mutate({ itemId: item.id, assetId })}
+          onRemovePhoto={(attachmentId) => removePhoto.mutate({ itemId: item.id, attachmentId })}
+          onSetCaption={(attachmentId, caption) =>
+            setCaption.mutate({ itemId: item.id, attachmentId, caption })
+          }
+        />
       </div>
     </TreeRow>
   )

--- a/apps/web/src/components/schedule/ui/qc/qc-photo-strip.tsx
+++ b/apps/web/src/components/schedule/ui/qc/qc-photo-strip.tsx
@@ -1,0 +1,126 @@
+// apps/web/src/components/schedule/ui/qc/qc-photo-strip.tsx
+//
+// The shared QC checklist-item photo strip (37d §3) — one component for BOTH the worker surface
+// (`qc-item-row.tsx`, assignee-guarded `addMy*`/`removeMy*`/`setMy*` mutations) and the office
+// proof-of-work panel (`qc-item-display.tsx`, org-scoped `addVisit*`/`removeVisit*`/`setVisit*`
+// mutations). Upload is identical on both (camera-capture `useFileUpload` on
+// `entityType='visit_qc_item'`); the parent injects which mutation runs on the resulting assetId
+// plus the caption/remove handlers, so the tile UI is written once. QC photos have no
+// internal/customer split (37d), so the tile editor renders caption-only (`showInternal={false}`).
+
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { Camera, Loader2 } from 'lucide-react'
+import { useRef } from 'react'
+import { useFileUpload } from '~/components/file-upload/hooks/use-file-upload'
+import { AttachmentThumbnail } from '~/components/files/utils/attachment-thumbnail'
+import { PhotoTileEditor } from '~/components/pickers/photo-tile-editor'
+
+/** One photo tile's data — mirrors `MyVisitQcItemPhoto`. */
+export interface QcStripPhoto {
+  attachmentId: string
+  assetId: string | null
+  caption: string | null
+}
+
+interface QcPhotoStripProps {
+  itemId: string
+  itemTitle: string
+  photos: QcStripPhoto[]
+  /** Attach the uploaded `MediaAsset` to the item (worker vs office mutation, injected). */
+  onAddPhoto: (assetId: string) => void
+  onRemovePhoto: (attachmentId: string) => void
+  onSetCaption: (attachmentId: string, caption: string | null) => void
+}
+
+export function QcPhotoStrip({
+  itemId,
+  itemTitle,
+  photos,
+  onAddPhoto,
+  onRemovePhoto,
+  onSetCaption,
+}: QcPhotoStripProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const fileUpload = useFileUpload({
+    entityType: 'visit_qc_item',
+    entityId: itemId,
+    onComplete: (results) => {
+      const result = results.results[0]
+      if (result?.success && result.metadata?.assetId) {
+        onAddPhoto(result.metadata.assetId)
+      } else if (result?.error) {
+        toastError({ title: 'Error uploading photo', description: result.error })
+      }
+    },
+    onError: (error) => toastError({ title: 'Error uploading photo', description: error }),
+  })
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? [])
+    event.target.value = ''
+    if (files.length === 0) return
+    try {
+      await fileUpload.addFiles(files)
+      await fileUpload.startUpload()
+    } catch (error) {
+      toastError({
+        title: 'Error uploading photo',
+        description: error instanceof Error ? error.message : 'Upload failed',
+      })
+    }
+  }
+
+  return (
+    <div className='flex flex-wrap items-start gap-2'>
+      {photos.map((photo) => (
+        <PhotoTileEditor
+          key={photo.attachmentId}
+          trigger={
+            <button type='button' className='block w-12 text-left'>
+              <AttachmentThumbnail
+                attachmentId={photo.attachmentId}
+                alt={photo.caption ?? itemTitle}
+              />
+              {photo.caption && (
+                <p className='mt-0.5 line-clamp-1 text-[10px] text-muted-foreground'>
+                  {photo.caption}
+                </p>
+              )}
+            </button>
+          }
+          name={itemTitle}
+          caption={photo.caption ?? undefined}
+          showInternal={false}
+          onSave={(patch) => onSetCaption(photo.attachmentId, patch.caption ?? null)}
+          onRemove={() => onRemovePhoto(photo.attachmentId)}
+        />
+      ))}
+      <button
+        type='button'
+        onClick={() => fileInputRef.current?.click()}
+        disabled={fileUpload.isUploading}
+        aria-label='Add photo'
+        className='flex size-12 items-center justify-center rounded-md border border-dashed text-muted-foreground hover:bg-accent/50'>
+        {fileUpload.isUploading ? (
+          <Loader2 className='size-4 animate-spin' />
+        ) : (
+          <Camera className='size-4' />
+        )}
+      </button>
+      {/* `capture='environment'` opens the device camera directly on mobile — harmless on
+          desktop (falls back to the file picker), useful when a dispatcher opens the panel on a
+          phone. */}
+      <input
+        ref={fileInputRef}
+        type='file'
+        accept='image/*'
+        capture='environment'
+        className='hidden'
+        onChange={handleFileChange}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -6,6 +6,7 @@ import {
   addMyAdhocQcItem,
   addMyQcItemPhoto,
   addVisit,
+  addVisitQcItemPhoto,
   advanceMyVisit,
   applyRouteTimes,
   assignVisit,
@@ -34,16 +35,20 @@ import {
   pauseEngagement,
   removeDispatchWorker,
   removeMyQcItemPhoto,
+  removeVisitQcItemPhoto,
+  renderVisitReportToAsset,
   reorderQcItemTemplates,
   restoreVisit,
   resumeEngagement,
   scheduleVisit,
   setMyQcItemChecked,
   setMyQcItemNote,
+  setMyQcItemPhotoCaption,
   setRecurrenceRule,
   setRouteOrder,
   setSeriesEnd,
   setVisitDuration,
+  setVisitQcItemPhotoCaption,
   setVisitStatus,
   setWorkerActive,
   unscheduleVisit,
@@ -695,6 +700,39 @@ export const dispatchRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       return listVisitQcItems(ctx.session.organizationId, input.visitId)
     }),
+  // 37d §2 — office (dispatcher) photo capture: org-scoped, NO assignee guard, so any dispatch
+  // admin can document a visit's checklist from the proof-of-work panel. Admin-gated to match the
+  // `listVisitQcItems` read this panel is built on. Checks/notes stay worker attestations.
+  addVisitQcItemPhoto: dispatchAdminProcedure
+    .input(z.object({ itemId: z.string(), assetId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      return addVisitQcItemPhoto(ctx.session.organizationId, ctx.session.user.id, input)
+    }),
+  removeVisitQcItemPhoto: dispatchAdminProcedure
+    .input(z.object({ itemId: z.string(), attachmentId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await removeVisitQcItemPhoto(ctx.session.organizationId, ctx.session.user.id, input)
+      return { success: true }
+    }),
+  setVisitQcItemPhotoCaption: dispatchAdminProcedure
+    .input(
+      z.object({ itemId: z.string(), attachmentId: z.string(), caption: z.string().nullable() })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await setVisitQcItemPhotoCaption(ctx.session.organizationId, ctx.session.user.id, input)
+      return { success: true }
+    }),
+  // 37d §5 — render the per-visit "Visit report" PDF on demand (visits aren't FieldValue-backed
+  // entities, so no pointer cache) and return the short-lived asset id to open via the file proxy.
+  getVisitReportPdf: dispatchAdminProcedure
+    .input(z.object({ visitId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      return renderVisitReportToAsset({
+        organizationId: ctx.session.organizationId,
+        actorId: ctx.session.user.id,
+        visitId: input.visitId,
+      })
+    }),
 
   // 08-worker-surface.md §5 — the worker-scoped checklist path. Member-level (not admin-gated):
   // the row-level assignee guard lives in the lib layer (`loadOwnVisit`/`loadOwnQcItem`), so
@@ -728,6 +766,14 @@ export const dispatchRouter = createTRPCRouter({
     .input(z.object({ itemId: z.string(), attachmentId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       await removeMyQcItemPhoto(ctx.session.organizationId, ctx.session.user.id, input)
+      return { success: true }
+    }),
+  setMyQcItemPhotoCaption: dispatchProcedure
+    .input(
+      z.object({ itemId: z.string(), attachmentId: z.string(), caption: z.string().nullable() })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await setMyQcItemPhotoCaption(ctx.session.organizationId, ctx.session.user.id, input)
       return { success: true }
     }),
 

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -42,28 +42,35 @@ export { pasteVisits } from './paste-visits'
 export type {
   AddMyAdhocQcItemInput,
   AddMyQcItemPhotoInput,
+  AddVisitQcItemPhotoInput,
   CreateQcItemTemplateInput,
   ListMyVisitQcItemsResult,
   MyVisitQcItem,
   MyVisitQcItemPhoto,
   RemoveMyQcItemPhotoInput,
+  RemoveVisitQcItemPhotoInput,
   ReorderQcItemTemplateUpdate,
   SetMyQcItemCheckedInput,
   SetMyQcItemNoteInput,
+  SetQcItemPhotoCaptionInput,
   UpdateQcItemTemplateInput,
 } from './qc'
 export {
   addMyAdhocQcItem,
   addMyQcItemPhoto,
+  addVisitQcItemPhoto,
   createQcItemTemplate,
   deleteQcItemTemplate,
   listMyVisitQcItems,
   listQcItemTemplates,
   listVisitQcItems,
   removeMyQcItemPhoto,
+  removeVisitQcItemPhoto,
   reorderQcItemTemplates,
   setMyQcItemChecked,
   setMyQcItemNote,
+  setMyQcItemPhotoCaption,
+  setVisitQcItemPhotoCaption,
   updateQcItemTemplate,
 } from './qc'
 export type {
@@ -138,6 +145,14 @@ export {
   setVisitStatus,
   unscheduleVisit,
 } from './visit-mutations'
+export type {
+  VisitReportChecklistItem,
+  VisitReportPayload,
+  VisitReportPhoto,
+} from './visit-report/payload'
+export { buildVisitReportPayload } from './visit-report/payload'
+export type { RenderVisitReportResult } from './visit-report/render'
+export { renderVisitReportPdf, renderVisitReportToAsset } from './visit-report/render'
 export type {
   NotifyVisitCanceledInput,
   NotifyVisitReassignedInput,

--- a/packages/lib/src/dispatch/qc.ts
+++ b/packages/lib/src/dispatch/qc.ts
@@ -166,6 +166,24 @@ export async function reorderQcItemTemplates(
 // ════════════════════════════════════════════════════════════════════════════
 
 /**
+ * Load a `VisitQcItem` scoped to the org — no assignee guard. Backs the office (dispatcher)
+ * photo mutations, which are org-scoped: any dispatch member may document a visit's checklist,
+ * not only its assigned worker (37d decision 3). `loadOwnQcItem` layers the assignee guard on top.
+ *
+ * @throws {NotFoundError} when the item doesn't exist in this org.
+ */
+async function loadQcItemInOrg(organizationId: string, itemId: string): Promise<VisitQcItemRow> {
+  const item = await database.query.VisitQcItem.findFirst({
+    where: and(
+      eq(schema.VisitQcItem.id, itemId),
+      eq(schema.VisitQcItem.organizationId, organizationId)
+    ),
+  })
+  if (!item) throw new NotFoundError('Quality check item not found')
+  return item
+}
+
+/**
  * Load a `VisitQcItem` scoped to the org, then guard its parent visit via `loadOwnVisit` — every
  * item-id worker fn below uses this so a worker can only touch checklist rows on their own visit.
  *
@@ -177,21 +195,17 @@ async function loadOwnQcItem(
   userId: string,
   itemId: string
 ): Promise<VisitQcItemRow> {
-  const item = await database.query.VisitQcItem.findFirst({
-    where: and(
-      eq(schema.VisitQcItem.id, itemId),
-      eq(schema.VisitQcItem.organizationId, organizationId)
-    ),
-  })
-  if (!item) throw new NotFoundError('Quality check item not found')
+  const item = await loadQcItemInOrg(organizationId, itemId)
   await loadOwnVisit(organizationId, userId, item.visitId)
   return item
 }
 
-/** One photo attached to a `VisitQcItem`, projected for the worker UI. */
+/** One photo attached to a `VisitQcItem`, projected for the worker + office UI. */
 export interface MyVisitQcItemPhoto {
   attachmentId: string
   assetId: string | null
+  /** Optional free-text caption (37d §2), stored on `Attachment.caption`. */
+  caption: string | null
 }
 
 /** One row of `listMyVisitQcItems`'s materialized checklist. */
@@ -202,6 +216,8 @@ export interface MyVisitQcItem {
   isRequired: boolean
   note: string | null
   checkedAt: Date | null
+  /** Who checked the item (null when unchecked) — surfaced on the visit report (37d §5). */
+  checkedByUserId: string | null
   sortOrder: number
   photos: MyVisitQcItemPhoto[]
 }
@@ -224,6 +240,7 @@ async function getPhotosByItemId(
       attachmentId: schema.Attachment.id,
       entityId: schema.Attachment.entityId,
       assetId: schema.Attachment.assetId,
+      caption: schema.Attachment.caption,
     })
     .from(schema.Attachment)
     .where(
@@ -233,10 +250,11 @@ async function getPhotosByItemId(
         inArray(schema.Attachment.entityId, itemIds)
       )
     )
+    .orderBy(asc(schema.Attachment.sort), asc(schema.Attachment.createdAt))
 
   for (const row of rows) {
     const photos = result.get(row.entityId) ?? []
-    photos.push({ attachmentId: row.attachmentId, assetId: row.assetId })
+    photos.push({ attachmentId: row.attachmentId, assetId: row.assetId, caption: row.caption })
     result.set(row.entityId, photos)
   }
   return result
@@ -271,6 +289,7 @@ async function readVisitQcItems(
       isRequired: item.isRequired,
       note: item.note,
       checkedAt: item.checkedAt,
+      checkedByUserId: item.checkedByUserId,
       sortOrder: item.sortOrder,
       photos: photosByItemId.get(item.id) ?? [],
     })),
@@ -421,27 +440,82 @@ export async function addMyAdhocQcItem(
   return created
 }
 
+// ─── Shared photo bodies (guard already applied by the public fns) ──────────────
+// The worker (`*My*`) and office (`*Visit*`) fns differ ONLY in their item-load guard
+// (`loadOwnQcItem` vs `loadQcItemInOrg`, 37d §2); everything past the guard is identical, so
+// it lives here once and takes a pre-resolved `itemId`.
+
+/** Attach an already-uploaded `MediaAsset` (see `useFileUpload`) to a checklist item. */
+async function attachQcItemPhoto(
+  organizationId: string,
+  userId: string,
+  itemId: string,
+  assetId: string
+): Promise<MyVisitQcItemPhoto> {
+  const attachment = await new AttachmentService(organizationId, userId).create({
+    entityType: 'visit_qc_item',
+    entityId: itemId,
+    assetId,
+  })
+  return { attachmentId: attachment.id, assetId: attachment.assetId, caption: attachment.caption }
+}
+
+/** Resolve an attachment and assert it belongs to the given checklist item, or throw. */
+async function loadQcItemPhoto(
+  organizationId: string,
+  itemId: string,
+  attachmentId: string
+): Promise<void> {
+  const attachment = await database.query.Attachment.findFirst({
+    where: and(
+      eq(schema.Attachment.id, attachmentId),
+      eq(schema.Attachment.organizationId, organizationId)
+    ),
+  })
+  if (!attachment || attachment.entityType !== 'visit_qc_item' || attachment.entityId !== itemId) {
+    throw new NotFoundError('Photo not found on this quality check item')
+  }
+}
+
+/** Detach a photo from a checklist item. */
+async function detachQcItemPhoto(
+  organizationId: string,
+  userId: string,
+  itemId: string,
+  attachmentId: string
+): Promise<void> {
+  await loadQcItemPhoto(organizationId, itemId, attachmentId)
+  await new AttachmentService(organizationId, userId).delete(attachmentId)
+}
+
+/** Set (or clear, `caption: null`) a photo's caption. */
+async function updateQcItemPhotoCaption(
+  organizationId: string,
+  userId: string,
+  itemId: string,
+  attachmentId: string,
+  caption: string | null
+): Promise<void> {
+  await loadQcItemPhoto(organizationId, itemId, attachmentId)
+  await new AttachmentService(organizationId, userId).update(attachmentId, { caption })
+}
+
+// ─── Worker (assignee-guarded) photo mutations ──────────────────────────────────
+
 /** Input for {@link addMyQcItemPhoto}. */
 export interface AddMyQcItemPhotoInput {
   itemId: string
   assetId: string
 }
 
-/** Attach an already-uploaded `MediaAsset` (see `useFileUpload`) to a checklist item. */
+/** Attach an already-uploaded `MediaAsset` (see `useFileUpload`) to the worker's own checklist item. */
 export async function addMyQcItemPhoto(
   organizationId: string,
   userId: string,
   input: AddMyQcItemPhotoInput
 ): Promise<MyVisitQcItemPhoto> {
   await loadOwnQcItem(organizationId, userId, input.itemId)
-
-  const attachment = await new AttachmentService(organizationId, userId).create({
-    entityType: 'visit_qc_item',
-    entityId: input.itemId,
-    assetId: input.assetId,
-  })
-
-  return { attachmentId: attachment.id, assetId: attachment.assetId }
+  return attachQcItemPhoto(organizationId, userId, input.itemId, input.assetId)
 }
 
 /** Input for {@link removeMyQcItemPhoto}. */
@@ -451,7 +525,7 @@ export interface RemoveMyQcItemPhotoInput {
 }
 
 /**
- * Detach a photo from a checklist item.
+ * Detach a photo from the worker's own checklist item.
  *
  * @throws {NotFoundError} when the attachment doesn't exist, or belongs to a different item/org.
  */
@@ -461,20 +535,81 @@ export async function removeMyQcItemPhoto(
   input: RemoveMyQcItemPhotoInput
 ): Promise<void> {
   await loadOwnQcItem(organizationId, userId, input.itemId)
+  await detachQcItemPhoto(organizationId, userId, input.itemId, input.attachmentId)
+}
 
-  const attachment = await database.query.Attachment.findFirst({
-    where: and(
-      eq(schema.Attachment.id, input.attachmentId),
-      eq(schema.Attachment.organizationId, organizationId)
-    ),
-  })
-  if (
-    !attachment ||
-    attachment.entityType !== 'visit_qc_item' ||
-    attachment.entityId !== input.itemId
-  ) {
-    throw new NotFoundError('Photo not found on this quality check item')
-  }
+/** Input for {@link setMyQcItemPhotoCaption} / {@link setVisitQcItemPhotoCaption}. */
+export interface SetQcItemPhotoCaptionInput {
+  itemId: string
+  attachmentId: string
+  /** `null` clears the caption. */
+  caption: string | null
+}
 
-  await new AttachmentService(organizationId, userId).delete(input.attachmentId)
+/** Set/clear the caption on a photo of the worker's own checklist item (37d §2). */
+export async function setMyQcItemPhotoCaption(
+  organizationId: string,
+  userId: string,
+  input: SetQcItemPhotoCaptionInput
+): Promise<void> {
+  await loadOwnQcItem(organizationId, userId, input.itemId)
+  await updateQcItemPhotoCaption(
+    organizationId,
+    userId,
+    input.itemId,
+    input.attachmentId,
+    input.caption
+  )
+}
+
+// ─── Office (org-scoped, no assignee guard) photo mutations — 37d §2 ─────────────
+// Any dispatch member may add/caption/remove a visit's QC photos from the proof-of-work panel,
+// not just the assigned worker. Checks and per-item notes stay worker attestations (untouched).
+
+/** Input for {@link addVisitQcItemPhoto}. */
+export interface AddVisitQcItemPhotoInput {
+  itemId: string
+  assetId: string
+}
+
+/** Office: attach an already-uploaded `MediaAsset` to any org checklist item. */
+export async function addVisitQcItemPhoto(
+  organizationId: string,
+  userId: string,
+  input: AddVisitQcItemPhotoInput
+): Promise<MyVisitQcItemPhoto> {
+  await loadQcItemInOrg(organizationId, input.itemId)
+  return attachQcItemPhoto(organizationId, userId, input.itemId, input.assetId)
+}
+
+/** Input for {@link removeVisitQcItemPhoto}. */
+export interface RemoveVisitQcItemPhotoInput {
+  itemId: string
+  attachmentId: string
+}
+
+/** Office: detach a photo from any org checklist item. */
+export async function removeVisitQcItemPhoto(
+  organizationId: string,
+  userId: string,
+  input: RemoveVisitQcItemPhotoInput
+): Promise<void> {
+  await loadQcItemInOrg(organizationId, input.itemId)
+  await detachQcItemPhoto(organizationId, userId, input.itemId, input.attachmentId)
+}
+
+/** Office: set/clear the caption on a photo of any org checklist item. */
+export async function setVisitQcItemPhotoCaption(
+  organizationId: string,
+  userId: string,
+  input: SetQcItemPhotoCaptionInput
+): Promise<void> {
+  await loadQcItemInOrg(organizationId, input.itemId)
+  await updateQcItemPhotoCaption(
+    organizationId,
+    userId,
+    input.itemId,
+    input.attachmentId,
+    input.caption
+  )
 }

--- a/packages/lib/src/dispatch/visit-report/payload.ts
+++ b/packages/lib/src/dispatch/visit-report/payload.ts
@@ -1,0 +1,188 @@
+// packages/lib/src/dispatch/visit-report/payload.ts
+//
+// Visit-report PDF payload (37d §5) — a per-visit proof-of-service document: visit header +
+// work-order context + the QC checklist (items, notes, captioned photos). Deliberately NOT part
+// of the documents registry / `DocumentPdfPayload` union: a visit is a `WorkOrderVisit` row, not
+// a FieldValue-backed EntityInstance, so it has no pointer field and can't use `ensure-pdf.ts`'s
+// pointer cache. The report renders on demand (see `./render.ts`), reusing the shared `parts.tsx`
+// PDF building blocks + `resolvePhotoRef` from the documents module.
+
+import { database, schema } from '@auxx/database'
+import type { TypedFieldValue } from '@auxx/types'
+import { extractValue } from '@auxx/types'
+import { toRecordId } from '@auxx/types/resource'
+import { type AddressStructValue, formatAddress } from '@auxx/utils/address'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
+import { loadPdfContact, type QuotePdfContact } from '../../documents/payload'
+import {
+  type ResolvedDocumentSettings,
+  resolveDocumentSettings,
+} from '../../documents/resolve-settings'
+import { NotFoundError } from '../../errors'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import { listVisitQcItems } from '../qc'
+
+/** A photo reference on the visit report — `"asset:<id>"`, resolved to bytes by `./render.ts`. */
+export interface VisitReportPhoto {
+  ref: string
+  caption?: string
+}
+
+/** One checklist row on the visit report. */
+export interface VisitReportChecklistItem {
+  title: string
+  isRequired: boolean
+  checked: boolean
+  /** ISO timestamp the item was checked, or `null`. */
+  checkedAt: string | null
+  /** Display name of whoever checked it, or `null`. */
+  checkedByName: string | null
+  note: string | null
+  photos: VisitReportPhoto[]
+}
+
+/** Everything `<VisitReportPdf>` needs to render. */
+export interface VisitReportPayload {
+  /** Needed by `./render.ts` to load the logo + photo bytes server-side. */
+  organizationId: string
+  /** ISO — the visit's scheduled date (start time, or the recurring occurrence date). */
+  visitDate: string | null
+  /** ISO scheduled window, or `null` when not yet scheduled. */
+  startTime: string | null
+  endTime: string | null
+  status: string
+  assigneeName: string | null
+  workOrderTitle: string | null
+  workOrderNumber: string | null
+  instructions: string | null
+  serviceAddress: string | null
+  contact: QuotePdfContact
+  items: VisitReportChecklistItem[]
+  settings: ResolvedDocumentSettings
+}
+
+/** Unwrap a `getFieldValues()` map entry — takes the first value if array-returned. */
+function firstTyped(
+  entry: TypedFieldValue | TypedFieldValue[] | undefined
+): TypedFieldValue | undefined {
+  if (!entry) return undefined
+  return Array.isArray(entry) ? entry[0] : entry
+}
+
+/**
+ * Build the visit-report payload for one `WorkOrderVisit` — mirrors `getMyVisitDetail`'s
+ * work-order/contact reads (`my-schedule.ts`) and reuses `listVisitQcItems` for the checklist.
+ * Assignee + per-item checker display names are resolved in one batched `User` read.
+ *
+ * @throws {NotFoundError} when the visit doesn't exist in this org.
+ */
+export async function buildVisitReportPayload(params: {
+  organizationId: string
+  userId: string
+  visitId: string
+}): Promise<VisitReportPayload> {
+  const { organizationId, userId, visitId } = params
+
+  const visit = await database.query.WorkOrderVisit.findFirst({
+    where: and(
+      eq(schema.WorkOrderVisit.id, visitId),
+      eq(schema.WorkOrderVisit.organizationId, organizationId)
+    ),
+  })
+  if (!visit) throw new NotFoundError('Visit not found')
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const cache = getOrgCache()
+  const workOrderRecordId = toRecordId('work_order', visit.workOrderId)
+
+  const [instance, cf, settings, qc] = await Promise.all([
+    database.query.EntityInstance.findFirst({
+      where: eq(schema.EntityInstance.id, visit.workOrderId),
+      columns: { displayName: true },
+    }),
+    cache
+      .from(organizationId, 'customFields')
+      .bySystemAttributes([
+        'work_order_number',
+        'work_order_description',
+        'work_order_contact',
+        'work_order_address',
+      ] as const),
+    resolveDocumentSettings(organizationId),
+    listVisitQcItems(organizationId, visitId),
+  ])
+
+  const woFieldIds = [
+    cf.work_order_number,
+    cf.work_order_description,
+    cf.work_order_contact,
+    cf.work_order_address,
+  ]
+    .filter(Boolean)
+    .map((f) => f!.id)
+  const woValues = await handler.getFieldValues(workOrderRecordId, woFieldIds)
+  const get = (f?: { id: string } | null) => (f ? firstTyped(woValues.get(f.id)) : undefined)
+
+  const numberTyped = get(cf.work_order_number)
+  const descriptionTyped = get(cf.work_order_description)
+  const contactTyped = get(cf.work_order_contact)
+  const addressTyped = get(cf.work_order_address)
+
+  const workOrderNumber = numberTyped ? (extractValue(numberTyped) as string) : null
+  const instructions = descriptionTyped ? (extractValue(descriptionTyped) as string) : null
+  const contactRecordId = contactTyped?.type === 'relationship' ? contactTyped.recordId : undefined
+  const domesticCountry = settings.business.address?.country
+  const serviceAddress =
+    addressTyped?.type === 'json'
+      ? formatAddress(addressTyped.value as Partial<AddressStructValue>, { domesticCountry }) ||
+        null
+      : null
+
+  const contact = await loadPdfContact(cache, handler, organizationId, contactRecordId)
+
+  // Resolve assignee + per-item checker display names in one read.
+  const userIds = new Set<string>()
+  if (visit.assigneeUserId) userIds.add(visit.assigneeUserId)
+  for (const item of qc.items) if (item.checkedByUserId) userIds.add(item.checkedByUserId)
+  const nameById = new Map<string, string>()
+  if (userIds.size > 0) {
+    const users = await database.query.User.findMany({
+      where: inArray(schema.User.id, [...userIds]),
+      columns: { id: true, name: true },
+    })
+    for (const u of users) nameById.set(u.id, u.name ?? '')
+  }
+
+  const items: VisitReportChecklistItem[] = qc.items.map((item) => ({
+    title: item.title,
+    isRequired: item.isRequired,
+    checked: !!item.checkedAt,
+    checkedAt: item.checkedAt ? item.checkedAt.toISOString() : null,
+    checkedByName: item.checkedByUserId ? nameById.get(item.checkedByUserId) || null : null,
+    note: item.note,
+    photos: item.photos
+      .filter((p) => p.assetId)
+      .map((p) =>
+        p.caption
+          ? { ref: `asset:${p.assetId}`, caption: p.caption }
+          : { ref: `asset:${p.assetId}` }
+      ),
+  }))
+
+  return {
+    organizationId,
+    visitDate: visit.startTime ? visit.startTime.toISOString() : (visit.occurrenceDate ?? null),
+    startTime: visit.startTime ? visit.startTime.toISOString() : null,
+    endTime: visit.endTime ? visit.endTime.toISOString() : null,
+    status: visit.status,
+    assigneeName: visit.assigneeUserId ? nameById.get(visit.assigneeUserId) || null : null,
+    workOrderTitle: instance?.displayName ?? null,
+    workOrderNumber,
+    instructions,
+    serviceAddress,
+    contact,
+    items,
+    settings,
+  }
+}

--- a/packages/lib/src/dispatch/visit-report/render.ts
+++ b/packages/lib/src/dispatch/visit-report/render.ts
@@ -1,0 +1,118 @@
+// packages/lib/src/dispatch/visit-report/render.ts
+//
+// On-demand render of a visit report to a short-lived `MediaAsset` (37d §5) — the visit analog of
+// `documents/preview-pdf.ts`. Visits aren't FieldValue-backed entities, so there's no pointer/
+// content-hash cache (unlike quote/invoice `ensure-pdf.ts`): every call renders fresh and uploads
+// a ~1h asset the caller opens via the shared `/api/files/download/asset:<id>` proxy. Reuses the
+// documents module's `resolvePhotoRef` (downscale/transcode) so photo bytes match the PDF path.
+
+import { database as db, schema } from '@auxx/database'
+import type { DocumentProps } from '@react-pdf/renderer'
+import { renderToBuffer } from '@react-pdf/renderer'
+import { eq } from 'drizzle-orm'
+import type { ReactElement } from 'react'
+import { createElement } from 'react'
+import { resolvePhotoRef } from '../../documents/render'
+import { MediaAssetService } from '../../files/core/media-asset-service'
+import { createStorageManager } from '../../files/storage/storage-manager'
+import { buildVisitReportPayload, type VisitReportPayload } from './payload'
+import { VisitReportPdf } from './visit-report-pdf'
+
+/** A rendered report lives an hour — long enough to open in a new tab, short enough not to pile up. */
+const REPORT_ASSET_TTL_MS = 60 * 60 * 1000
+
+/** Resolve every photo ref on the report's checklist items to downscaled JPEG bytes, keyed by
+ * ref. A ref that fails to resolve is simply absent — the PDF skips it silently. */
+async function resolveReportPhotoBytes(payload: VisitReportPayload): Promise<Map<string, Buffer>> {
+  const refs = new Set<string>()
+  for (const item of payload.items) {
+    for (const photo of item.photos) refs.add(photo.ref)
+  }
+  if (refs.size === 0) return new Map()
+
+  const resolved = await Promise.all(
+    Array.from(refs).map(
+      async (ref) => [ref, await resolvePhotoRef(payload.organizationId, ref)] as const
+    )
+  )
+  const photoBytes = new Map<string, Buffer>()
+  for (const [ref, bytes] of resolved) {
+    if (bytes) photoBytes.set(ref, bytes)
+  }
+  return photoBytes
+}
+
+/** Render a visit-report payload to a PDF buffer — loads the org logo bytes server-side (missing
+ * logo renders without one, same fail-soft contract as the quote/invoice renderer). */
+export async function renderVisitReportPdf(payload: VisitReportPayload): Promise<Buffer> {
+  const logoAssetId = payload.settings.branding.logo?.assetId
+  let logoBytes: Buffer | null = null
+  if (logoAssetId) {
+    try {
+      logoBytes = await new MediaAssetService(payload.organizationId).getContent(logoAssetId)
+    } catch {
+      logoBytes = null
+    }
+  }
+
+  const photoBytes = await resolveReportPhotoBytes(payload)
+  const element = createElement(VisitReportPdf, { payload, logoBytes, photoBytes })
+  return renderToBuffer(element as unknown as ReactElement<DocumentProps>)
+}
+
+/** Result of {@link renderVisitReportToAsset}. */
+export interface RenderVisitReportResult {
+  assetId: string
+  fileName: string
+}
+
+/**
+ * Build + render one visit's report and upload it as a short-lived (`expiresAt` ~1h) `MediaAsset`,
+ * returning its id for the caller to open via the file-download proxy. Mirrors
+ * `documents/preview-pdf.ts`.
+ */
+export async function renderVisitReportToAsset(params: {
+  organizationId: string
+  actorId: string
+  visitId: string
+}): Promise<RenderVisitReportResult> {
+  const { organizationId, actorId, visitId } = params
+
+  const payload = await buildVisitReportPayload({ organizationId, userId: actorId, visitId })
+  const buffer = await renderVisitReportPdf(payload)
+
+  const fileName = `visit-report-${payload.workOrderNumber || visitId}.pdf`
+  const storageManager = createStorageManager(organizationId)
+  const storageKey = `documents/${organizationId}/visit-report/${visitId}.pdf`
+  const storageLocation = await storageManager.uploadContent({
+    provider: 'S3',
+    key: storageKey,
+    content: buffer,
+    mimeType: 'application/pdf',
+    size: buffer.length,
+    visibility: 'PRIVATE',
+    organizationId,
+  })
+
+  const mediaAssetService = new MediaAssetService(organizationId, actorId, db)
+  const { asset } = await mediaAssetService.createWithVersion(
+    {
+      kind: 'DOCUMENT',
+      purpose: 'PREVIEW',
+      name: fileName,
+      mimeType: 'application/pdf',
+      size: BigInt(buffer.length),
+      isPrivate: true,
+      organizationId,
+      createdById: actorId,
+    },
+    storageLocation.id
+  )
+
+  await db
+    .update(schema.MediaAsset)
+    .set({ expiresAt: new Date(Date.now() + REPORT_ASSET_TTL_MS) })
+    .where(eq(schema.MediaAsset.id, asset.id))
+
+  return { assetId: asset.id, fileName }
+}

--- a/packages/lib/src/dispatch/visit-report/visit-report-pdf.tsx
+++ b/packages/lib/src/dispatch/visit-report/visit-report-pdf.tsx
@@ -1,0 +1,155 @@
+// packages/lib/src/dispatch/visit-report/visit-report-pdf.tsx
+// @jsxRuntime automatic
+// @jsxImportSource react
+//
+// The visit-report PDF template (37d §5) — a proof-of-service document. Composes the shared
+// document `parts.tsx` header/branding/footer with a QC checklist section (item, checked-by/at,
+// note, captioned photos). Every QC photo renders (no internal/customer split, 37d).
+
+import { Document, Image, Page, Text, View } from '@react-pdf/renderer'
+import {
+  BillingPartyBlock,
+  DocumentFooter,
+  DocumentHeader,
+  formatDocDate,
+} from '../../documents/pdf/parts'
+import { createDocumentStyles, pageSizeFor } from '../../documents/pdf/theme'
+import type { VisitReportChecklistItem, VisitReportPayload, VisitReportPhoto } from './payload'
+
+/** Human label for a visit status (`WorkOrderVisit.status`). */
+const STATUS_LABEL: Record<string, string> = {
+  scheduled: 'Scheduled',
+  en_route: 'En route',
+  on_site: 'On site',
+  done: 'Done',
+  canceled: 'Canceled',
+}
+
+export function VisitReportPdf(props: {
+  payload: VisitReportPayload
+  logoBytes?: Buffer | null
+  photoBytes?: Map<string, Buffer>
+}) {
+  const { payload, logoBytes, photoBytes } = props
+  const { settings } = payload
+  const styles = createDocumentStyles(settings)
+  const dateFormat = settings.branding.dateFormat
+
+  const windowLine =
+    payload.startTime && payload.endTime
+      ? `${formatDocDate(payload.startTime, 'p')} – ${formatDocDate(payload.endTime, 'p')}`
+      : payload.startTime
+        ? formatDocDate(payload.startTime, 'p')
+        : 'Not scheduled'
+
+  const metaRows: Array<{ label: string; value: string }> = [
+    { label: 'Status', value: STATUS_LABEL[payload.status] ?? payload.status },
+    { label: 'Time', value: windowLine },
+  ]
+  if (payload.assigneeName) metaRows.push({ label: 'Assignee', value: payload.assigneeName })
+  if (payload.serviceAddress)
+    metaRows.push({ label: 'Service address', value: payload.serviceAddress })
+
+  return (
+    <Document
+      title={`Visit report${payload.workOrderNumber ? ` — ${payload.workOrderNumber}` : ''}`}>
+      <Page size={pageSizeFor(settings.branding.paperSize)} style={styles.page} wrap>
+        <DocumentHeader
+          styles={styles}
+          documentLabel='Visit report'
+          number={payload.workOrderTitle || payload.workOrderNumber || ''}
+          issuedAt={payload.visitDate ?? ''}
+          dateFormat={dateFormat}
+          logoBytes={logoBytes}
+        />
+
+        <BillingPartyBlock styles={styles} business={settings.business} contact={payload.contact} />
+
+        {/* Visit meta — status/time/assignee/address as label→value rows. */}
+        <View style={{ marginBottom: 12, flexDirection: 'row', flexWrap: 'wrap' }}>
+          {metaRows.map((row) => (
+            <View key={row.label} style={{ width: '50%', marginBottom: 6 }}>
+              <Text style={styles.label}>{row.label}</Text>
+              <Text style={styles.value}>{row.value}</Text>
+            </View>
+          ))}
+        </View>
+
+        {payload.instructions ? (
+          <View style={{ marginBottom: 12 }}>
+            <Text style={styles.label}>Instructions</Text>
+            <Text style={styles.value}>{payload.instructions}</Text>
+          </View>
+        ) : null}
+
+        <Text style={[styles.label, { marginBottom: 6 }]}>Quality checklist</Text>
+        {payload.items.length === 0 ? (
+          <Text style={styles.value}>No checklist items recorded for this visit.</Text>
+        ) : (
+          payload.items.map((item, i) => (
+            <ChecklistRow
+              key={i}
+              styles={styles}
+              item={item}
+              dateFormat={dateFormat}
+              photoBytes={photoBytes}
+            />
+          ))
+        )}
+
+        <DocumentFooter styles={styles} text={settings.quote.footerText} />
+      </Page>
+    </Document>
+  )
+}
+
+type Styles = ReturnType<typeof createDocumentStyles>
+
+function ChecklistRow(props: {
+  styles: Styles
+  item: VisitReportChecklistItem
+  dateFormat: string
+  photoBytes?: Map<string, Buffer>
+}) {
+  const { styles, item, dateFormat, photoBytes } = props
+  const resolved = (item.photos ?? [])
+    .map((p) => ({ ...p, bytes: photoBytes?.get(p.ref) }))
+    .filter((p): p is VisitReportPhoto & { bytes: Buffer } => p.bytes !== undefined)
+
+  const checkGlyph = item.checked ? '☑' : '☐' // ballot box with/without check
+  const checkedLine = item.checked
+    ? [item.checkedByName, item.checkedAt ? formatDocDate(item.checkedAt, dateFormat) : null]
+        .filter(Boolean)
+        .join(' · ')
+    : null
+
+  return (
+    <View style={{ marginBottom: 10 }} wrap={false}>
+      <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
+        <Text style={[styles.value, { marginRight: 6 }]}>{checkGlyph}</Text>
+        <View style={{ flex: 1 }}>
+          <Text style={[styles.value, styles.bold]}>
+            {item.title}
+            {item.isRequired ? '  (required)' : ''}
+          </Text>
+          {checkedLine ? (
+            <Text style={[styles.label, { textTransform: 'none', marginTop: 1 }]}>
+              Checked · {checkedLine}
+            </Text>
+          ) : null}
+          {item.note ? <Text style={[styles.value, { marginTop: 2 }]}>{item.note}</Text> : null}
+          {resolved.length > 0 ? (
+            <View style={styles.lineThumbRow}>
+              {resolved.map((photo, j) => (
+                <View key={j} style={styles.lineThumbWrap}>
+                  <Image style={styles.lineThumb} src={photo.bytes} />
+                  {photo.caption ? <Text style={styles.photoCaption}>{photo.caption}</Text> : null}
+                </View>
+              ))}
+            </View>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  )
+}

--- a/packages/lib/src/files/core/types.ts
+++ b/packages/lib/src/files/core/types.ts
@@ -128,7 +128,8 @@ export interface CreateAttachmentRequest {
 export interface UpdateAttachmentRequest {
   role?: AttachmentRole
   title?: string
-  caption?: string
+  /** `null` clears the caption; `undefined` leaves it unchanged. */
+  caption?: string | null
   sort?: number
   fileVersionId?: string
   assetVersionId?: string


### PR DESCRIPTION
Implements **plan 37d** (QC photo captions, office capture & printable visit report).

## Phase 1 — Captions (no migration)
- `MyVisitQcItemPhoto` carries `caption`; `getPhotosByItemId` selects it (sort-ordered).
- Worker `setMyQcItemPhotoCaption` mutation.
- Shared `qc-photo-strip.tsx` (camera upload + caption tile editor); `PhotoTileEditor` gained a `showInternal` prop (QC is caption-only).
- `Attachment.caption` was already fully wired through `AttachmentService` — **no schema change**.

## Phase 2 — Office capture
- Org-scoped `addVisitQcItemPhoto` / `removeVisitQcItemPhoto` / `setVisitQcItemPhotoCaption` (no assignee guard).
- The dispatcher proof-of-work panel is now photo-editable (checks/notes stay worker attestations).

## Phase 3 — Visit report PDF (on-demand)
- `dispatch/visit-report/`: payload builder + `VisitReportPdf` (reuses the shared `documents/pdf/parts.tsx` blocks) + on-demand render into a ~1h `MediaAsset`.
- `dispatch.getVisitReportPdf` mutation + a "Print report" button on the visit detail panel.

## Deviations from the plan (both forced by the real code)
1. **Office mutations are on `dispatchAdminProcedure`, not `dispatchProcedure`** — matching the actual gating of the `listVisitQcItems` read they back (the plan's leverage map was wrong). Resolves the plan's open question #2.
2. **The visit report is a standalone on-demand render, not a documents-registry FieldValue-pointer type.** A visit is a `WorkOrderVisit` row, not a FieldValue-backed EntityInstance (the `visit` registry entity is a read-only `dbColumn`/`computed` projection), so `ensure-pdf.ts`'s pointer cache can't apply. Renders fresh like `documents/preview-pdf.ts`. No migration, no pointer field, no `DocumentPdfPayload` union change.

## `isInternal` dropped
Per discussion, QC photos have no internal/customer split in v1 — the report shows every photo. Add the flag (cheap additive boolean) only if a split is ever requested.

## Verification
- Changed files type-check clean (only pre-existing baseline errors remain) and pass biome.
- **Not yet run in-app** — the PDF's visual layout is untested against a real render.