### PR TITLE
fix(dispatch): keep month view on the snapped row after scroll settles

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/utils.ts
+++ b/apps/web/src/components/dispatch/ui/board/utils.ts
@@ -169,7 +169,17 @@ export function withPreservedDayOfMonth(
   weekStartsOn: WeekStartIndex
 ): Date {
   const viewedMonth = startOfMonth(endOfWeek(next, { weekStartsOn }))
-  return setDayOfMonth(viewedMonth, Math.min(prev.getDate(), getDaysInMonth(viewedMonth)))
+  const candidate = setDayOfMonth(
+    viewedMonth,
+    Math.min(prev.getDate(), getDaysInMonth(viewedMonth))
+  )
+  // A late-month day whose week ends in the NEXT month would itself "view" that next month
+  // and re-anchor the stream a month ahead of where the user settled — clamp to the last
+  // day whose week still ends inside the viewed month.
+  if (viewedMonthStart(candidate, weekStartsOn).getTime() === viewedMonth.getTime()) {
+    return candidate
+  }
+  return subDays(startOfWeek(candidate, { weekStartsOn }), 1)
 }
 
 /** Only visits with both `startTime`/`endTime` render on the grid. */

--- a/packages/ui/src/components/event-calendar/month-view.tsx
+++ b/packages/ui/src/components/event-calendar/month-view.tsx
@@ -324,16 +324,23 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
   const programmaticScrollRef = useRef(false)
   const currentDateRef = useRef(currentDate)
   currentDateRef.current = currentDate
-  // Set when a scroll-settle emits onDateChange — that date echoing back as the
-  // `currentDate` prop must NOT re-scroll (the user is already looking at it).
-  const lastEmittedDateRef = useRef<number | null>(null)
+  // Set when a scroll-settle emits onDateChange — the consumer may echo a TRANSFORMED
+  // date back as `currentDate` (the dispatch board preserves the anchor's day-of-month),
+  // so the echo is matched by its resolved target row, not exact timestamp. Any echo
+  // resolving to the settled viewed month must NOT re-scroll (the user is already
+  // looking at it); genuine external navigation lands on a different target row.
+  const lastEmittedTargetIndexRef = useRef<number | null>(null)
 
   // Rows are fixed-height, so the target offset is exact math — scrolling directly
   // (instead of virtualizer.scrollToIndex) sidesteps its measurement-cache staleness.
   const lastRowHeightRef = useRef(rowHeight)
   useLayoutEffect(() => {
     const rowHeightChanged = lastRowHeightRef.current !== rowHeight
-    if (!rowHeightChanged && lastEmittedDateRef.current === currentDateRef.current.getTime()) return
+    const isEmitEcho = lastEmittedTargetIndexRef.current === targetIndex
+    // Consume the marker either way — after this change, a later navigation back to the
+    // same month is external and must scroll again.
+    lastEmittedTargetIndexRef.current = null
+    if (!rowHeightChanged && isEmitEcho) return
     const el = scrollRef.current
     if (!el) return
     lastRowHeightRef.current = rowHeight
@@ -377,11 +384,13 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
       }
       const topLeft = weekStartAt(snapIndex)
       if (!isSameDay(topLeft, currentDateRef.current)) {
-        lastEmittedDateRef.current = topLeft.getTime()
+        lastEmittedTargetIndexRef.current = weekIndexOf(
+          startOfMonth(endOfWeek(topLeft, { weekStartsOn }))
+        )
         onDateChange?.(topLeft)
       }
     }, 160)
-  }, [rowHeight, weekCount, weekStartAt, onDateChange])
+  }, [rowHeight, weekCount, weekStartAt, weekIndexOf, weekStartsOn, onDateChange])
 
   useEffect(
     () => () => {


### PR DESCRIPTION
## Problem

In the month view, a bigger swipe would settle and snap to a week row, then immediately jump again to the row containing the 1st of the month. Slow scrolls within a month didn't trigger it.

## Cause

A handshake mismatch between the month stream and the dispatch board's anchor transform:

- On scroll-settle, `MonthView` emits the snapped row's top-left day and guards the echo by **exact timestamp**.
- The board's `setDate` doesn't echo that date back — `withPreservedDayOfMonth` keeps the previous anchor's day-of-month inside the newly viewed month, producing a different timestamp.
- When the swipe crossed into a new month, `targetIndex` changed, the scroll effect re-ran, the timestamp guard failed, and the view programmatically scrolled to the first-of-month row. Small scrolls stayed in the same viewed month, so the effect never re-ran — hence fast-only.

## Fix

- **month-view.tsx**: guard the echo by the emitted date's resolved target row (`weekIndexOf(startOfMonth(endOfWeek(topLeft)))`) instead of exact timestamp. Any consumer-transformed echo landing in the same viewed month is a no-op; genuine external navigation (toolbar, mini calendar) still scrolls. The marker is consumed on first evaluation so later navigation back to the same month scrolls again.
- **board/utils.ts**: clamp `withPreservedDayOfMonth` — a late-month day whose week ends in the next month (e.g. Feb 28 2026 → week ends Mar 1) would itself "view" that next month and re-anchor the stream a month ahead. Clamp to the last day whose week still ends inside the viewed month.

## Verification

- `biome check` clean on both files.
- Scoped typechecks: zero errors in the two changed files (remaining `@auxx/ui` / `apps/web` errors are pre-existing baselines).