### PR TITLE
feat(sidebar): attio-style resizable sidebar with hover-peek

### DIFF
--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/layout.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/layout.tsx
@@ -94,7 +94,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='h-screen flex flex-1 flex-col w-full h-full'>
       <AddToOrgDialog open={addToOrgOpen} onOpenChange={setAddToOrgOpen} appId={app.id} />
-      <SidebarProvider>
+      <SidebarProvider resizable persistKey='build_sidebar'>
         <BuildAppSidebar user={user} accountSlug={slug} />
         <SidebarInset>
           <MainPage>

--- a/apps/build/src/app/(portal)/[slug]/settings/layout.tsx
+++ b/apps/build/src/app/(portal)/[slug]/settings/layout.tsx
@@ -35,7 +35,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <div className='h-screen flex flex-1 flex-col w-full h-full'>
-      <SidebarProvider>
+      <SidebarProvider resizable persistKey='build_sidebar'>
         <BuildAppSidebar user={user} accountSlug={slug} />
         <SidebarInset>
           <MainPage>

--- a/apps/build/src/components/build-app-sidebar.tsx
+++ b/apps/build/src/components/build-app-sidebar.tsx
@@ -1,7 +1,7 @@
 // apps/build/src/components/build-app-sidebar.tsx
 'use client'
 
-import { Sidebar, SidebarContent, SidebarHeader, SidebarRail } from '@auxx/ui/components/sidebar'
+import { Sidebar, SidebarContent, SidebarHeader } from '@auxx/ui/components/sidebar'
 import type * as React from 'react'
 import type { DehydratedBuildUser } from '~/lib/dehydration'
 import { BuildNavMain } from './build-nav-main'
@@ -18,14 +18,13 @@ type BuildAppSidebarProps = {
  */
 export function BuildAppSidebar({ user, accountSlug, ...props }: BuildAppSidebarProps) {
   return (
-    <Sidebar collapsible='icon' {...props}>
+    <Sidebar {...props}>
       <SidebarHeader>
         <BuildNavUser user={user} accountSlug={accountSlug} />
       </SidebarHeader>
       <SidebarContent className='gap-0'>
         <BuildNavMain accountSlug={accountSlug} />
       </SidebarContent>
-      <SidebarRail />
     </Sidebar>
   )
 }

--- a/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
@@ -26,6 +26,10 @@ import { useOrganizationIdContext } from '~/providers/feature-flag-provider'
 interface AppLayoutWrapperProps {
   children: ReactNode
   user: any
+  /** SSR sidebar open state from cookie — forwarded to `Dashboard`'s `SidebarProvider`. */
+  defaultSidebarOpen?: boolean
+  /** SSR sidebar width (px) from cookie — forwarded to `Dashboard`'s `SidebarProvider`. */
+  defaultSidebarWidth?: number
 }
 
 /** Helper function to check if subscription is expired */
@@ -45,7 +49,12 @@ function isTrialExpired(subscription: DehydratedOrganization['subscription']): b
 /**
  * Client wrapper that checks subscription and conditionally renders Dashboard or SubscriptionEnded
  */
-export function AppLayoutWrapper({ children, user }: AppLayoutWrapperProps) {
+export function AppLayoutWrapper({
+  children,
+  user,
+  defaultSidebarOpen,
+  defaultSidebarWidth,
+}: AppLayoutWrapperProps) {
   const organizations = useDehydratedOrganizations()
   const { organizationId: currentOrgId } = useOrganizationIdContext()
   const selfHosted = useIsSelfHosted()
@@ -85,7 +94,12 @@ export function AppLayoutWrapper({ children, user }: AppLayoutWrapperProps) {
         <ChannelProvider>
           <ThreadDataProvider>
             <ThreadActionsProvider>
-              <Dashboard user={user}>{children}</Dashboard>
+              <Dashboard
+                user={user}
+                defaultSidebarOpen={defaultSidebarOpen}
+                defaultSidebarWidth={defaultSidebarWidth}>
+                {children}
+              </Dashboard>
               <FloatingComposeRoot />
               <FloatingTaskRoot />
               <GlobalCreateRoot />

--- a/apps/web/src/app/(protected)/app/layout.tsx
+++ b/apps/web/src/app/(protected)/app/layout.tsx
@@ -1,5 +1,6 @@
 // apps/web/src/app/(protected)/app/layout.tsx
 
+import { cookies } from 'next/headers'
 import type { ReactNode } from 'react'
 import { getSession } from '~/auth/session'
 import { AppDialog } from '~/components/apps/host/app-dialog'
@@ -18,9 +19,24 @@ interface AppLayoutProps {
 export default async function AppLayout({ children }: AppLayoutProps) {
   const session = await getSession()
 
+  // Read the persisted sidebar open/width cookies here so the shell renders at the right
+  // size on first paint (no open-flash, no width-flash). Cookie names mirror the provider's
+  // `persistKey` ('sidebar_state') + its `_width` companion.
+  const cookieStore = await cookies()
+  const sidebarStateCookie = cookieStore.get('sidebar_state')?.value
+  const sidebarWidthCookie = cookieStore.get('sidebar_state_width')?.value
+  const defaultSidebarOpen = sidebarStateCookie ? sidebarStateCookie !== 'false' : undefined
+  const parsedWidth = sidebarWidthCookie ? Number.parseInt(sidebarWidthCookie, 10) : Number.NaN
+  const defaultSidebarWidth = Number.isFinite(parsedWidth) ? parsedWidth : undefined
+
   return (
     <AppsProvider>
-      <AppLayoutWrapper user={session?.user}>{children}</AppLayoutWrapper>
+      <AppLayoutWrapper
+        user={session?.user}
+        defaultSidebarOpen={defaultSidebarOpen}
+        defaultSidebarWidth={defaultSidebarWidth}>
+        {children}
+      </AppLayoutWrapper>
 
       {/* Global extension dialog renderer */}
       <AppDialog />

--- a/apps/web/src/app/admin/_components/app-sidebar.tsx
+++ b/apps/web/src/app/admin/_components/app-sidebar.tsx
@@ -7,7 +7,6 @@ import {
   SidebarFooter,
   SidebarHeader,
   SidebarMenu,
-  SidebarRail,
 } from '@auxx/ui/components/sidebar'
 import type * as React from 'react'
 import { NavUser } from '~/components/global/sidebar/nav-user'
@@ -38,7 +37,7 @@ type AdminAppSidebarProps = {
 function AdminVersionFooter() {
   const { version } = useEnv()
   return (
-    <div className='px-3 py-2 text-[11px] text-muted-foreground/60 truncate group-data-[collapsible=icon]:hidden'>
+    <div className='px-3 py-2 text-[11px] text-muted-foreground/60 truncate'>
       {version.appVersion} ({version.commit})
     </div>
   )
@@ -46,7 +45,7 @@ function AdminVersionFooter() {
 
 export function AdminAppSidebar({ user, ...props }: AdminAppSidebarProps) {
   return (
-    <Sidebar collapsible='icon' className='p-0' {...props}>
+    <Sidebar className='p-0' {...props}>
       <SidebarHeader>
         <SidebarMenu>
           <NavUser user={user} />
@@ -58,7 +57,6 @@ export function AdminAppSidebar({ user, ...props }: AdminAppSidebarProps) {
       <SidebarFooter>
         <AdminVersionFooter />
       </SidebarFooter>
-      <SidebarRail />
     </Sidebar>
   )
 }

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -3,6 +3,7 @@
 import { DehydrationService } from '@auxx/lib/dehydration'
 import { SidebarInset, SidebarProvider } from '@auxx/ui/components/sidebar'
 import type { Metadata } from 'next'
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { getSession } from '~/auth/session'
 import { DehydratedStateProvider } from '~/providers/dehydrated-state-provider'
@@ -63,12 +64,25 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     }
   }
 
+  // Admin sidebar persists its own open/width under `admin_sidebar*` cookies (independent of
+  // the main app shell) — read them here so first paint matches the persisted size.
+  const cookieStore = await cookies()
+  const openCookie = cookieStore.get('admin_sidebar')?.value
+  const widthCookie = cookieStore.get('admin_sidebar_width')?.value
+  const defaultOpen = openCookie ? openCookie !== 'false' : undefined
+  const parsedWidth = widthCookie ? Number.parseInt(widthCookie, 10) : Number.NaN
+  const defaultWidth = Number.isFinite(parsedWidth) ? parsedWidth : undefined
+
   return (
     <div className='h-screen flex flex-1 flex-col w-full h-full'>
       <DehydratedStateProvider initialState={dehydratedState}>
         <OrganizationIdProvider>
           <FeatureFlagProvider>
-            <SidebarProvider>
+            <SidebarProvider
+              resizable
+              persistKey='admin_sidebar'
+              defaultOpen={defaultOpen}
+              defaultWidth={defaultWidth}>
               <AdminAppSidebar user={user} variant='inset' />
               <SidebarInset className='p-0 m-0!'>{children}</SidebarInset>
             </SidebarProvider>

--- a/apps/web/src/components/favorites/drag-eligibility.ts
+++ b/apps/web/src/components/favorites/drag-eligibility.ts
@@ -1,0 +1,17 @@
+// apps/web/src/components/favorites/drag-eligibility.ts
+import type { Active } from '@dnd-kit/core'
+
+/**
+ * dnd-kit drag `data.current.type` values the app-shell sidebar (favorites) accepts as drops.
+ * Single source of truth shared by the drag-end router (`dashboard.tsx`) and the drag-to-peek
+ * spring-loader (`SidebarDragPeek`) so a new droppable type can't silently miss the spring-load.
+ */
+export const SIDEBAR_FAVORITE_DRAG_TYPES = ['favorite'] as const
+
+/** Whether an active drag targets the sidebar favorites. */
+export function isSidebarFavoriteDrag(active: Active | null | undefined): boolean {
+  const type = active?.data?.current?.type
+  return (
+    typeof type === 'string' && (SIDEBAR_FAVORITE_DRAG_TYPES as readonly string[]).includes(type)
+  )
+}

--- a/apps/web/src/components/favorites/ui/favorite-folder.tsx
+++ b/apps/web/src/components/favorites/ui/favorite-folder.tsx
@@ -173,9 +173,7 @@ export function FavoriteFolder({ folder, items, index }: FavoriteFolderProps) {
               />
             ) : (
               <>
-                <span className='truncate group-data-[collapsible=icon]:hidden'>
-                  {folder.title}
-                </span>
+                <span className='truncate'>{folder.title}</span>
                 <button
                   type='button'
                   data-no-toggle
@@ -184,14 +182,14 @@ export function FavoriteFolder({ folder, items, index }: FavoriteFolderProps) {
                     sidebarState.toggleSection(sectionId)
                   }}
                   onPointerDown={(e) => e.stopPropagation()}
-                  className='ml-1 inline-flex shrink-0 items-center text-muted-foreground group-data-[collapsible=icon]:hidden'>
+                  className='ml-1 inline-flex shrink-0 items-center text-muted-foreground'>
                   <CollapsibleChevron open={isOpen} />
                 </button>
               </>
             )}
           </div>
 
-          <div className='flex items-center group-data-[collapsible=icon]:hidden'>
+          <div className='flex items-center'>
             {!editing && (
               <div
                 data-no-toggle

--- a/apps/web/src/components/getting-started/ui/getting-started-group.tsx
+++ b/apps/web/src/components/getting-started/ui/getting-started-group.tsx
@@ -122,10 +122,10 @@ export function GettingStartedGroup({ checklistId, catalog, title = 'Getting sta
                   onClick={() => toggleSection(sectionId)}
                   className='group/gs relative h-7 cursor-pointer'>
                   <Rocket className='size-4' />
-                  <span className='group-data-[collapsible=icon]:hidden'>{title}</span>
+                  <span>{title}</span>
                   <CollapsibleChevron open={isOpen} className='ms-1 text-muted-foreground' />
 
-                  <div className='ms-auto flex items-center gap-1 group-data-[collapsible=icon]:hidden'>
+                  <div className='ms-auto flex items-center gap-1'>
                     <span className='text-xs text-muted-foreground'>
                       {done}/{total}
                     </span>
@@ -155,7 +155,7 @@ export function GettingStartedGroup({ checklistId, catalog, title = 'Getting sta
                 </div>
               </SidebarMenuButton>
 
-              <SidebarGroupCollapse open={isOpen} className='group-data-[collapsible=icon]:hidden'>
+              <SidebarGroupCollapse open={isOpen}>
                 <div className='px-2 pb-1.5 pt-1'>
                   <Progress value={(done / total) * 100} indicatorClassName='bg-info' />
                 </div>

--- a/apps/web/src/components/global/dashboard.tsx
+++ b/apps/web/src/components/global/dashboard.tsx
@@ -19,9 +19,11 @@ import React, { useCallback, useState } from 'react'
 import { DndStateProvider } from '~/app/context/dnd-state-context'
 import { OverageBanner } from '~/components/banner/overage-banner'
 import { DemoBanner } from '~/components/demo/demo-banner'
+import { isSidebarFavoriteDrag } from '~/components/favorites/drag-eligibility'
 import { useFavoriteDragEnd } from '~/components/favorites/hooks/use-favorite-drag-end'
 import { AppDragOverlay } from '~/components/global/app-drag-overlay'
 import AppSidebar from '~/components/global/sidebar'
+import { SidebarDragPeek } from '~/components/global/sidebar/sidebar-drag-peek'
 import { KopilotDock } from '~/components/kopilot/ui/kopilot-dock'
 import { KopilotRuntime } from '~/components/kopilot/ui/kopilot-runtime'
 import { useThreadMutation } from '~/components/threads/hooks'
@@ -31,12 +33,21 @@ import {
   useDehydratedOrganizationId,
 } from '~/providers/dehydrated-state-provider'
 
-type Props = { user?: any; children: React.ReactNode }
+type Props = {
+  user?: any
+  children: React.ReactNode
+  /** SSR-provided from the `sidebar_state` cookie so the sidebar doesn't flash open on load. */
+  defaultSidebarOpen?: boolean
+  /** SSR-provided from the `sidebar_state_width` cookie so the width doesn't flash on load. */
+  defaultSidebarWidth?: number
+}
 
 export const Dashboard = ({
   // slug,
   user,
   children,
+  defaultSidebarOpen,
+  defaultSidebarWidth,
 }: Props) => {
   const pathname = usePathname()
   const router = useRouter()
@@ -101,7 +112,7 @@ export const Dashboard = ({
         return
       }
 
-      if (activeData.type === 'favorite') {
+      if (isSidebarFavoriteDrag(active)) {
         handleFavoriteDragEnd(activeData as Parameters<typeof handleFavoriteDragEnd>[0], overData)
       }
     },
@@ -109,12 +120,13 @@ export const Dashboard = ({
   )
 
   return (
-    <SidebarProvider>
+    <SidebarProvider resizable defaultOpen={defaultSidebarOpen} defaultWidth={defaultSidebarWidth}>
       <DndContext
         sensors={sensors}
         collisionDetection={pointerWithin}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}>
+        <SidebarDragPeek />
         <DndStateProvider activeDndItem={activeDndItem}>
           <div className='flex h-screen overflow-hidden w-full'>
             <AppSidebar className='min-w-0' user={user} />

--- a/apps/web/src/components/global/sidebar-secondary.tsx
+++ b/apps/web/src/components/global/sidebar-secondary.tsx
@@ -42,7 +42,7 @@ function SidebarSecondary({ items, baseUrl, title, current }: Props) {
         <div
           id='dropdown'
           className={cn(
-            'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden transition-all duration-300 ease-in-out',
+            'flex min-h-0 flex-1 flex-col gap-2 overflow-auto transition-all duration-300 ease-in-out',
             // Mobile-specific classes
             isMobile && !isDropdownOpen && 'max-h-0 overflow-hidden',
             isMobile && isDropdownOpen && 'max-h-[70vh]',
@@ -90,12 +90,12 @@ function createSidebarGroup(
   }
 
   return (
-    <div className='relative flex w-full min-w-0 flex-col p-2 group-data-[collapsible=icon]:hidden'>
+    <div className='relative flex w-full min-w-0 flex-col p-2'>
       <div
         className={cn(
           'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden',
           'ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2',
-          'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-4 [&>svg]:shrink-0'
+          '[&>svg]:size-4 [&>svg]:shrink-0'
         )}>
         {title}
       </div>
@@ -114,7 +114,7 @@ function createSidebarGroup(
                 'group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50',
                 'data-[active=true]:bg-black/5 dark:data-[active=true]:bg-sidebar-accent dark:data-[active=true]:hover:bg-sidebar-accent data-[active=true]:text-foreground',
                 'data-[state=open]:hover:bg-black/5 data-[state=open]:hover:text-foreground ',
-                'group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0'
+                '[&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0'
               )}>
               {item.icon}
               <span>{item.label}</span>

--- a/apps/web/src/components/global/sidebar/app-footer.tsx
+++ b/apps/web/src/components/global/sidebar/app-footer.tsx
@@ -306,9 +306,7 @@ function DemoSidebarBanner() {
         }}>
         <BorderBeam />
         <Clock className='size-4 text-info' />
-        <span className='group-data-[collapsible=icon]:hidden ps-3 pe-4 tabular-nums text-info'>
-          {remaining} remaining
-        </span>
+        <span className='ps-3 pe-4 tabular-nums text-info'>{remaining} remaining</span>
       </SidebarButton>
     </div>
   )
@@ -351,7 +349,7 @@ function UpgradeButton() {
           onClick={() => setDialogOpen(true)}>
           <BorderBeam />
           <Zap className='size-4' />
-          <span className='group-data-[collapsible=icon]:hidden ps-3 pe-4'>
+          <span className='ps-3 pe-4'>
             {daysRemaining} {daysText} left on trial
           </span>
         </SidebarButton>

--- a/apps/web/src/components/global/sidebar/collapsible-sidebar-section.tsx
+++ b/apps/web/src/components/global/sidebar/collapsible-sidebar-section.tsx
@@ -149,7 +149,7 @@ function CollapsibleSidebarSectionComponent({
           )}
 
           {avatar ? avatar : icon ? <span className='[&_svg]:size-4'>{icon}</span> : null}
-          <span className='group-data-[collapsible=icon]:hidden'>{title}</span>
+          <span>{title}</span>
 
           {!isEditMode && (
             <button
@@ -159,12 +159,12 @@ function CollapsibleSidebarSectionComponent({
                 e.stopPropagation()
                 toggleOpen()
               }}
-              className='inline-flex items-center text-muted-foreground group-data-[collapsible=icon]:hidden'>
+              className='inline-flex items-center text-muted-foreground'>
               <CollapsibleChevron open={isOpen} />
             </button>
           )}
 
-          <div className='ml-auto flex items-center group-data-[collapsible=icon]:hidden'>
+          <div className='ml-auto flex items-center'>
             {typeof count === 'number' && count > 0 && (
               <span
                 className={cn(

--- a/apps/web/src/components/global/sidebar/entity-folder.tsx
+++ b/apps/web/src/components/global/sidebar/entity-folder.tsx
@@ -163,9 +163,7 @@ export function EntityFolder({
               />
             ) : (
               <>
-                <span className='truncate group-data-[collapsible=icon]:hidden'>
-                  {folder.title}
-                </span>
+                <span className='truncate'>{folder.title}</span>
                 <button
                   type='button'
                   data-no-toggle
@@ -174,7 +172,7 @@ export function EntityFolder({
                     toggleSection(sectionId)
                   }}
                   onPointerDown={(e) => e.stopPropagation()}
-                  className='ml-1 inline-flex shrink-0 items-center text-muted-foreground group-data-[collapsible=icon]:hidden'>
+                  className='ml-1 inline-flex shrink-0 items-center text-muted-foreground'>
                   <CollapsibleChevron open={isOpen} />
                 </button>
               </>
@@ -183,7 +181,7 @@ export function EntityFolder({
 
           {showMenu && !editing && (
             <div
-              className='flex items-center group-data-[collapsible=icon]:hidden'
+              className='flex items-center'
               data-no-toggle
               onClick={(e) => {
                 e.stopPropagation()

--- a/apps/web/src/components/global/sidebar/index.tsx
+++ b/apps/web/src/components/global/sidebar/index.tsx
@@ -7,7 +7,6 @@ import {
   SidebarFooter,
   SidebarHeader,
   SidebarMenu,
-  SidebarRail,
 } from '@auxx/ui/components/sidebar'
 import type * as React from 'react'
 import { GETTING_STARTED_GOALS } from '~/components/getting-started/client'
@@ -42,7 +41,7 @@ export default function AppSidebar({ user, ...props }: Prop) {
 
   return (
     <SidebarStateProvider>
-      <Sidebar collapsible='icon' {...props}>
+      <Sidebar {...props}>
         <SidebarHeader>
           <SidebarMenu>
             <NavUser user={user} />
@@ -59,7 +58,6 @@ export default function AppSidebar({ user, ...props }: Prop) {
           <GettingStartedGroup checklistId='main' catalog={GETTING_STARTED_GOALS} />
           <AppFooter />
         </SidebarFooter>
-        <SidebarRail />
       </Sidebar>
       {dialogs}
     </SidebarStateProvider>

--- a/apps/web/src/components/global/sidebar/nav-user.tsx
+++ b/apps/web/src/components/global/sidebar/nav-user.tsx
@@ -30,6 +30,7 @@ import {
   Headset,
   LogOut,
   Moon,
+  PanelLeftOpen,
   Plus,
   Shield,
   Sparkles,
@@ -66,7 +67,7 @@ type Prop = {
 }
 
 export function NavUser({ user }: Prop) {
-  const { isMobile } = useSidebar()
+  const { isMobile, peek, setOpen } = useSidebar()
   const [showNewOrgDialog, setShowNewOrgDialog] = useState(false)
   const [activeOrgId, setActiveOrgId] = useState<string | null>(null)
   const router = useRouter()
@@ -145,8 +146,8 @@ export function NavUser({ user }: Prop) {
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size='lg'
-              className='ps-1 w-auto pe-1.5  h-8 rounded-2xl ring-0 ring-ring/20  data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:pe-0'>
-              <span className='relative inline-flex shrink-0 group-data-[collapsible=icon]:mx-auto'>
+              className='ps-1 w-auto pe-1.5  h-8 rounded-2xl ring-0 ring-ring/20  data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground'>
+              <span className='relative inline-flex shrink-0'>
                 <Avatar className='size-6 rounded-full ring-1 ring-ring/20'>
                   <AvatarImage src={displayImage!} alt={displayName} />
                   <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
@@ -156,7 +157,7 @@ export function NavUser({ user }: Prop) {
                   className='absolute -bottom-0.5 -right-0.5 size-2'
                 />
               </span>
-              <div className='grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden pe-2'>
+              <div className='grid flex-1 text-left text-sm leading-tight pe-2'>
                 <span className='truncate'>{displayName}</span>
               </div>
             </SidebarMenuButton>
@@ -340,22 +341,36 @@ export function NavUser({ user }: Prop) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        {kopilotEnabled && (
-          <Tooltip content='Kopilot' shortcut={['⌘', '⇧', 'K']}>
-            <button
-              type='button'
-              className='relative shrink-0 flex items-center justify-center size-8 rounded-2xl text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors group-data-[collapsible=icon]:hidden'
-              onClick={toggleKopilot}>
-              <Sparkles className='size-4' />
-              {hasUnreadNotification && (
-                <span
-                  aria-label='Unread Kopilot notification'
-                  className='absolute right-1 top-1 size-2 rounded-full bg-primary'
-                />
-              )}
-            </button>
-          </Tooltip>
-        )}
+        <div className='flex shrink-0 items-center gap-1'>
+          {kopilotEnabled && (
+            <Tooltip content='Kopilot' shortcut={['⌘', '⇧', 'K']}>
+              <button
+                type='button'
+                className='relative shrink-0 flex items-center justify-center size-8 rounded-2xl text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors'
+                onClick={toggleKopilot}>
+                <Sparkles className='size-4' />
+                {hasUnreadNotification && (
+                  <span
+                    aria-label='Unread Kopilot notification'
+                    className='absolute right-1 top-1 size-2 rounded-full bg-primary'
+                  />
+                )}
+              </button>
+            </Tooltip>
+          )}
+          {/* Only while peeking: pin the floating sidebar open (real expand, clears the peek). */}
+          {peek && (
+            <Tooltip content='Expand sidebar' shortcut={['⌘', '.']}>
+              <button
+                type='button'
+                aria-label='Expand sidebar'
+                className='shrink-0 flex items-center justify-center size-8 rounded-2xl text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors'
+                onClick={() => setOpen(true)}>
+                <PanelLeftOpen className='size-4' />
+              </button>
+            </Tooltip>
+          )}
+        </div>
       </SidebarMenuItem>
     </>
   )

--- a/apps/web/src/components/global/sidebar/quick-actions-nav.tsx
+++ b/apps/web/src/components/global/sidebar/quick-actions-nav.tsx
@@ -21,11 +21,8 @@ export function QuickActionsNav() {
         tooltip='Quick Actions'
         className='h-7 shadow-[inset_0_0_0_1px_rgba(255,255,255,0),0_0_2px_0_rgba(28,40,64,0.18),0_1px_3px_0_rgba(24,41,75,0.04)] transition-colors hover:bg-sidebar-accent active:bg-sidebar-accent dark:shadow-[inset_0_0_0_1px_#2f3033,0_0_2px_0_#000,0_1px_3px_0_rgba(0,0,0,0.08)]'>
         <Zap />
-        <span className='group-data-[collapsible=icon]:hidden'>Quick Actions</span>
-        <KbdGroup
-          size='sm'
-          className='ml-auto group-data-[collapsible=icon]:hidden'
-          variant='outline'>
+        <span>Quick Actions</span>
+        <KbdGroup size='sm' className='ml-auto' variant='outline'>
           <Kbd shortcut='meta' />
           <Kbd>K</Kbd>
         </KbdGroup>

--- a/apps/web/src/components/global/sidebar/sidebar-drag-peek.tsx
+++ b/apps/web/src/components/global/sidebar/sidebar-drag-peek.tsx
@@ -1,0 +1,102 @@
+// apps/web/src/components/global/sidebar/sidebar-drag-peek.tsx
+'use client'
+
+import { useSidebar } from '@auxx/ui/components/sidebar'
+import { useDndMonitor } from '@dnd-kit/core'
+import { useCallback, useEffect, useRef } from 'react'
+import { isSidebarFavoriteDrag } from '~/components/favorites/drag-eligibility'
+
+/** Distance from the left screen edge (px) that arms the spring-load timer. */
+const EDGE_THRESHOLD = 48
+/** Hover-at-edge dwell (ms) before the collapsed sidebar springs open for a drop. */
+const SPRING_DELAY = 250
+/** Grace period (ms) after a drop so a successful landing is visible before the overlay closes. */
+const CLOSE_DELAY = 300
+
+/**
+ * Headless drag-to-peek spring-loader. Mounted inside the app-shell `DndContext` (and under the
+ * `SidebarProvider`), it watches for sidebar-eligible drags (favorites) and, while the sidebar
+ * is collapsed, floats the peek overlay open once the pointer dwells at the left screen edge —
+ * so the favorites droppables (kept mounted even when collapsed) can receive the drop. The
+ * sidebar stays collapsed throughout; the overlay slides away shortly after the drag ends.
+ */
+export function SidebarDragPeek() {
+  const { state, setPeek, setHoldPeek } = useSidebar()
+
+  const stateRef = useRef(state)
+  stateRef.current = state
+
+  const eligibleRef = useRef(false)
+  const sprungRef = useRef(false)
+  const pointerXRef = useRef(Number.POSITIVE_INFINITY)
+  const springTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const trackPointer = useCallback((e: PointerEvent) => {
+    pointerXRef.current = e.clientX
+  }, [])
+
+  const cancelSpring = useCallback(() => {
+    if (springTimer.current) clearTimeout(springTimer.current)
+    springTimer.current = null
+  }, [])
+
+  const endDrag = useCallback(() => {
+    document.removeEventListener('pointermove', trackPointer)
+    cancelSpring()
+    eligibleRef.current = false
+    pointerXRef.current = Number.POSITIVE_INFINITY
+    if (sprungRef.current) {
+      sprungRef.current = false
+      setHoldPeek(false)
+      // Let a successful drop land visibly before the overlay slides away.
+      if (closeTimer.current) clearTimeout(closeTimer.current)
+      closeTimer.current = setTimeout(() => {
+        closeTimer.current = null
+        setPeek(false)
+      }, CLOSE_DELAY)
+    }
+  }, [trackPointer, cancelSpring, setHoldPeek, setPeek])
+
+  useDndMonitor({
+    onDragStart(event) {
+      eligibleRef.current = isSidebarFavoriteDrag(event.active)
+      sprungRef.current = false
+      if (eligibleRef.current) {
+        document.addEventListener('pointermove', trackPointer)
+      }
+    },
+    onDragMove() {
+      if (!eligibleRef.current || sprungRef.current) return
+      if (stateRef.current !== 'collapsed') {
+        cancelSpring()
+        return
+      }
+      if (pointerXRef.current <= EDGE_THRESHOLD) {
+        if (!springTimer.current) {
+          springTimer.current = setTimeout(() => {
+            springTimer.current = null
+            sprungRef.current = true
+            setPeek(true)
+            setHoldPeek(true)
+          }, SPRING_DELAY)
+        }
+      } else {
+        cancelSpring()
+      }
+    },
+    onDragEnd: endDrag,
+    onDragCancel: endDrag,
+  })
+
+  // Safety net: drop the document listener + timers if we unmount mid-drag.
+  useEffect(() => {
+    return () => {
+      document.removeEventListener('pointermove', trackPointer)
+      if (springTimer.current) clearTimeout(springTimer.current)
+      if (closeTimer.current) clearTimeout(closeTimer.current)
+    }
+  }, [trackPointer])
+
+  return null
+}

--- a/apps/web/src/components/global/sidebar/sidebar-group-header.tsx
+++ b/apps/web/src/components/global/sidebar/sidebar-group-header.tsx
@@ -57,7 +57,7 @@ export function SidebarGroupHeader({
       data-state={isOpen || isEditMode ? 'open' : 'closed'}
       onClick={handleRowClick}
       className={cn(
-        'flex items-center justify-between h-7.5 rounded-md hover:bg-sidebar-accent group-data-[collapsible=icon]:hidden cursor-pointer',
+        'flex items-center justify-between h-7.5 rounded-md hover:bg-sidebar-accent cursor-pointer',
         popoverOpen && 'bg-sidebar-accent',
         isEditMode && !isGroupVisible && 'opacity-50'
       )}>

--- a/apps/web/src/components/global/sidebar/sidebar-item.tsx
+++ b/apps/web/src/components/global/sidebar/sidebar-item.tsx
@@ -86,7 +86,7 @@ export function SidebarItem({
         {color && !icon && (
           <div
             className={cn(
-              'mr-2 size-2 rounded-full group-data-[collapsible=icon]:hidden',
+              'mr-2 size-2 rounded-full',
               getOptionColor(color as SelectOptionColor).swatch
             )}
           />
@@ -111,13 +111,13 @@ export function SidebarItem({
                 onEditCancel?.()
               }
             }}
-            className='h-5 min-w-0 grow rounded bg-background px-1 text-sm outline-none ring-1 ring-border group-data-[collapsible=icon]:hidden'
+            className='h-5 min-w-0 grow rounded bg-background px-1 text-sm outline-none ring-1 ring-border'
           />
         ) : (
-          <span className='truncate group-data-[collapsible=icon]:hidden'>{name}</span>
+          <span className='truncate'>{name}</span>
         )}
       </div>
-      <div className='flex items-center group-data-[collapsible=icon]:hidden shrink-0'>{end}</div>
+      <div className='flex items-center shrink-0'>{end}</div>
     </>
   )
 

--- a/apps/web/src/components/global/sidebar/views-group.tsx
+++ b/apps/web/src/components/global/sidebar/views-group.tsx
@@ -233,11 +233,7 @@ export function ViewsSection({
       if (visibleViews.length === 0) {
         return (
           <SidebarMenuSubItem>
-            <SidebarMenuButton
-              variant='dashed'
-              size='sm'
-              onClick={() => setShowCreateView(true)}
-              className='group-data-[collapsible=icon]:hidden'>
+            <SidebarMenuButton variant='dashed' size='sm' onClick={() => setShowCreateView(true)}>
               Create a view
             </SidebarMenuButton>
           </SidebarMenuSubItem>
@@ -292,9 +288,7 @@ export function ViewsSection({
   const isAnyViewActive = pathname?.startsWith('/app/mail/views/')
 
   const actions = (
-    <DropdownMenuItem
-      onClick={() => setShowCreateView(true)}
-      className='group-data-[collapsible=icon]:hidden!'>
+    <DropdownMenuItem onClick={() => setShowCreateView(true)}>
       <TableProperties />
       Create view
     </DropdownMenuItem>

--- a/packages/ui/src/components/sidebar-button.tsx
+++ b/packages/ui/src/components/sidebar-button.tsx
@@ -26,13 +26,7 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
   const { isMobile, state } = useSidebar()
 
   const button = (
-    <Button
-      className={cn(
-        // Auto-transform to icon button when sidebar is collapsed
-        'group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2',
-        className
-      )}
-      {...props}>
+    <Button className={cn(className)} {...props}>
       {children}
     </Button>
   )

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -6,12 +6,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Separator } from '@auxx/ui/components/separator'
 import { Sheet, SheetContent } from '@auxx/ui/components/sheet'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@auxx/ui/components/tooltip'
+import { SimpleTooltip, type TooltipContent, TooltipProvider } from '@auxx/ui/components/tooltip'
 import { useIsMobile } from '@auxx/ui/hooks/use-mobile'
 import { cn } from '@auxx/ui/lib/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
@@ -24,9 +19,14 @@ const SIDEBAR_COOKIE_NAME = 'sidebar_state'
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = '16rem'
 const SIDEBAR_WIDTH_MOBILE = '18rem'
-// const SIDEBAR_WIDTH_ICON = '1.5rem'
-const SIDEBAR_WIDTH_ICON = '3rem'
-const SIDEBAR_KEYBOARD_SHORTCUT = 'b'
+const SIDEBAR_MIN_WIDTH = 200
+const SIDEBAR_MAX_WIDTH = 400
+const SIDEBAR_DEFAULT_WIDTH = 256
+/** Distance from the screen edge (px) the cursor must reach for a resize drag to snap collapsed. */
+const SIDEBAR_COLLAPSE_EDGE = 24
+/** Hover-intent delay (ms) before the collapsed sidebar peeks in — kept short so it feels snappy. */
+const SIDEBAR_PEEK_OPEN_DELAY = 20
+const SIDEBAR_KEYBOARD_SHORTCUT = '.'
 
 type SidebarContext = {
   state: 'expanded' | 'collapsed'
@@ -36,6 +36,34 @@ type SidebarContext = {
   setOpenMobile: (open: boolean) => void
   isMobile: boolean
   toggleSidebar: () => void
+  /** Whether this provider owns a drag-resizable width (opt-in). */
+  resizable: boolean
+  /** Current sidebar width in px (only meaningful when `resizable`). */
+  width: number
+  /** Set the live width during a drag — does NOT persist the cookie (see `persistWidth`). */
+  setWidth: (width: number) => void
+  /** Persist the given width to the `${persistKey}_width` cookie (call on drag end). */
+  persistWidth: (width: number) => void
+  minWidth: number
+  maxWidth: number
+  defaultWidth: number
+  /** True while a resize drag is in progress — containers drop their width transition. */
+  isResizing: boolean
+  setIsResizing: (resizing: boolean) => void
+  /** Whether the collapsed sidebar is floating in as a hover/drag peek overlay. */
+  peek: boolean
+  setPeek: (peek: boolean) => void
+  /** When set, the peek overlay is pinned open (used by DnD spring-loading). */
+  holdPeek: boolean
+  setHoldPeek: (hold: boolean) => void
+  /** Open the peek overlay after a short hover-intent delay. */
+  requestPeekOpen: () => void
+  /** Cancel a pending peek-open (mouse left the hot zone before it fired). */
+  cancelPeekOpen: () => void
+  /** Close the peek overlay after a short delay (no-op while `holdPeek`). */
+  requestPeekClose: () => void
+  /** Cancel a pending peek-close (mouse re-entered the overlay). */
+  cancelPeekClose: () => void
 }
 
 const SidebarContext = React.createContext<SidebarContext | null>(null)
@@ -49,6 +77,19 @@ function useSidebar() {
   return context
 }
 
+/** True on pointers that can hover (mouse/trackpad) — gates the peek hot zone off touch. */
+function useHoverCapable() {
+  const [hoverable, setHoverable] = React.useState(false)
+  React.useEffect(() => {
+    const mq = window.matchMedia('(hover: hover)')
+    setHoverable(mq.matches)
+    const onChange = () => setHoverable(mq.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+  return hoverable
+}
+
 function SidebarProvider({
   defaultOpen = true,
   open: openProp,
@@ -56,6 +97,10 @@ function SidebarProvider({
   className,
   style,
   width,
+  resizable = false,
+  minWidth = SIDEBAR_MIN_WIDTH,
+  maxWidth = SIDEBAR_MAX_WIDTH,
+  defaultWidth = SIDEBAR_DEFAULT_WIDTH,
   persistKey = SIDEBAR_COOKIE_NAME,
   keyboardShortcut = SIDEBAR_KEYBOARD_SHORTCUT,
   nested = false,
@@ -65,7 +110,20 @@ function SidebarProvider({
   defaultOpen?: boolean
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  /** Static CSS width (e.g. `'16rem'`) for non-resizable sidebars. Ignored when `resizable`. */
   width?: string
+  /**
+   * Opt into drag-to-resize. When true, `--sidebar-width` is driven by `width` state (px),
+   * a `SidebarResizeHandle` + hover-peek overlay render inside the fixed `Sidebar`, and the
+   * width is persisted to a `${persistKey}_width` cookie. Defaults to `false` (static width).
+   */
+  resizable?: boolean
+  /** Min drag width in px (default 200). */
+  minWidth?: number
+  /** Max drag width in px (default 400). */
+  maxWidth?: number
+  /** Initial/reset width in px (default 256) — pass from the `${persistKey}_width` cookie for SSR. */
+  defaultWidth?: number
   /**
    * Cookie name used to persist the open state on every `setOpen` call. Pass `false` to skip
    * the cookie write entirely (e.g. a nested module sidebar that persists state elsewhere).
@@ -76,7 +134,7 @@ function SidebarProvider({
   /**
    * Key that toggles the sidebar when held with Cmd/Ctrl. Pass `false` to skip registering
    * the `window` keydown listener (e.g. a nested module sidebar shouldn't fight the app-shell
-   * sidebar for the same shortcut). Defaults to `'b'`.
+   * sidebar for the same shortcut). Defaults to `'.'`.
    */
   keyboardShortcut?: string | false
   /**
@@ -112,6 +170,62 @@ function SidebarProvider({
     [setOpenProp, open, persistKey]
   )
 
+  // Live drag width (px). Independent of open/closed — collapsing never resets it.
+  const [width_, setWidth] = React.useState(defaultWidth)
+  const [isResizing, setIsResizing] = React.useState(false)
+  const persistWidth = React.useCallback(
+    (w: number) => {
+      if (persistKey) {
+        document.cookie = `${persistKey}_width=${Math.round(w)}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+      }
+    },
+    [persistKey]
+  )
+
+  // Hover/drag peek overlay (collapsed state, fixed variant only).
+  const [peek, setPeek] = React.useState(false)
+  const [holdPeek, setHoldPeek] = React.useState(false)
+  const holdPeekRef = React.useRef(holdPeek)
+  holdPeekRef.current = holdPeek
+  const peekOpenTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const peekCloseTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancelPeekOpen = React.useCallback(() => {
+    if (peekOpenTimer.current) clearTimeout(peekOpenTimer.current)
+    peekOpenTimer.current = null
+  }, [])
+  const cancelPeekClose = React.useCallback(() => {
+    if (peekCloseTimer.current) clearTimeout(peekCloseTimer.current)
+    peekCloseTimer.current = null
+  }, [])
+  const requestPeekOpen = React.useCallback(() => {
+    cancelPeekClose()
+    if (peekOpenTimer.current) return
+    peekOpenTimer.current = setTimeout(() => {
+      peekOpenTimer.current = null
+      setPeek(true)
+    }, SIDEBAR_PEEK_OPEN_DELAY)
+  }, [cancelPeekClose])
+  const requestPeekClose = React.useCallback(() => {
+    cancelPeekOpen()
+    if (holdPeekRef.current) return
+    if (peekCloseTimer.current) return
+    peekCloseTimer.current = setTimeout(() => {
+      peekCloseTimer.current = null
+      setPeek(false)
+    }, 150)
+  }, [cancelPeekOpen])
+
+  // Expanding always clears any peek overlay + pin.
+  React.useEffect(() => {
+    if (open) {
+      cancelPeekOpen()
+      cancelPeekClose()
+      setPeek(false)
+      setHoldPeek(false)
+    }
+  }, [open, cancelPeekOpen, cancelPeekClose])
+
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
@@ -137,9 +251,57 @@ function SidebarProvider({
   const state = open ? 'expanded' : 'collapsed'
 
   const contextValue = React.useMemo<SidebarContext>(
-    () => ({ state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar }),
-    [state, open, setOpen, isMobile, openMobile, toggleSidebar]
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      resizable,
+      width: width_,
+      setWidth,
+      persistWidth,
+      minWidth,
+      maxWidth,
+      defaultWidth,
+      isResizing,
+      setIsResizing,
+      peek,
+      setPeek,
+      holdPeek,
+      setHoldPeek,
+      requestPeekOpen,
+      cancelPeekOpen,
+      requestPeekClose,
+      cancelPeekClose,
+    }),
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      toggleSidebar,
+      resizable,
+      width_,
+      persistWidth,
+      minWidth,
+      maxWidth,
+      defaultWidth,
+      isResizing,
+      peek,
+      holdPeek,
+      requestPeekOpen,
+      cancelPeekOpen,
+      requestPeekClose,
+      cancelPeekClose,
+    ]
   )
+
+  // `--sidebar-width`: driven by drag state when resizable, otherwise the static string prop.
+  const sidebarWidth = resizable ? `${width_}px` : width || SIDEBAR_WIDTH
 
   return (
     <SidebarContext.Provider value={contextValue}>
@@ -147,8 +309,7 @@ function SidebarProvider({
         <div
           style={
             {
-              '--sidebar-width': width || SIDEBAR_WIDTH,
-              '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
+              '--sidebar-width': sidebarWidth,
               ...style,
             } as React.CSSProperties
           }
@@ -176,10 +337,21 @@ function Sidebar({
 }: React.ComponentProps<'div'> & {
   side?: 'left' | 'right'
   variant?: 'sidebar' | 'floating' | 'inset'
-  collapsible?: 'offcanvas' | 'icon' | 'none'
+  collapsible?: 'offcanvas' | 'none'
   fixed?: boolean // New prop for non-fixed sidebar
 }) {
-  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+  const {
+    isMobile,
+    state,
+    openMobile,
+    setOpenMobile,
+    resizable,
+    isResizing,
+    peek,
+    cancelPeekClose,
+    cancelPeekOpen,
+    requestPeekClose,
+  } = useSidebar()
 
   // Simple sidebar, no collapsible behavior
   if (collapsible === 'none') {
@@ -220,30 +392,52 @@ function Sidebar({
         data-state={state}
         data-collapsible={state === 'collapsed' ? collapsible : ''}
         data-variant={variant}
-        data-side={side}>
+        data-side={side}
+        data-resizing={isResizing ? '' : undefined}
+        data-peek={peek ? '' : undefined}>
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
             'relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear ',
             'group-data-[collapsible=offcanvas]:w-0',
             'group-data-[side=right]:rotate-180',
-            variant === 'floating' || variant === 'inset'
-              ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
-              : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)'
+            'group-data-[resizing]:transition-none'
           )}
         />
         <div
           className={cn(
-            'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex ',
+            // z-30 keeps the panel above page content + its sticky `z-10` headers at all times —
+            // notably while animating open from a peek, when content briefly overlaps the panel.
+            'fixed inset-y-0 z-30 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex ',
             side === 'left'
-              ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-              : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+              ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] group-data-[peek]:left-0!'
+              : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] group-data-[peek]:right-0!',
             // Adjust the padding for floating and inset variants.
             variant === 'floating' || variant === 'inset'
-              ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-              : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l ', //dark:border-neutral-900/70 border-neutral-950/20
+              ? 'p-2'
+              : 'group-data-[side=left]:border-r group-data-[side=right]:border-l ', //dark:border-neutral-900/70 border-neutral-950/20
+            // Peek overlay: float above content + sticky headers (below dialogs); slide in fast.
+            'group-data-[peek]:z-40 group-data-[peek]:shadow-xl group-data-[peek]:duration-100',
+            'group-data-[resizing]:transition-none',
             className
           )}
+          onMouseEnter={
+            resizable
+              ? () => {
+                  cancelPeekClose()
+                  cancelPeekOpen()
+                }
+              : undefined
+          }
+          // Don't auto-close the peek while a resize drag is in flight — the pointer leaves the
+          // panel bounds as the width follows it, but the user is still adjusting the width.
+          onMouseLeave={
+            resizable
+              ? () => {
+                  if (!isResizing) requestPeekClose()
+                }
+              : undefined
+          }
           {...props}>
           <div className='absolute right-0 inset-y-0 border-x border-r-white/60 dark:border-r-white/5 border-l-black/10 dark:border-l-black/50 '></div>
           <div
@@ -251,7 +445,12 @@ function Sidebar({
             className='flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm select-none'>
             {children}
           </div>
+          {/* Handle is live while expanded OR peeking, so the width can be adjusted in either
+              state. Skipped when fully collapsed (off-canvas) — there it would sit at the screen
+              edge on top of the peek hot zone. */}
+          {resizable && (peek || state === 'expanded') && <SidebarResizeHandle side={side} />}
         </div>
+        {resizable && <SidebarPeekHotZone side={side} />}
       </div>
     )
   } else {
@@ -289,46 +488,143 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
   const { toggleSidebar, state } = useSidebar()
 
   return (
-    <Button
-      data-sidebar='trigger'
-      variant='ghost'
-      size='icon'
-      className={cn(
-        'h-7 w-7',
-        state === 'expanded' ? 'cursor-w-resize' : 'cursor-e-resize',
-        className
-      )}
-      onClick={(event) => {
-        onClick?.(event)
-        toggleSidebar()
-      }}
-      {...props}>
-      <PanelLeft />
-      <span className='sr-only'>Toggle Sidebar</span>
-    </Button>
+    <SimpleTooltip
+      content={state === 'expanded' ? 'Collapse sidebar' : 'Expand sidebar'}
+      shortcut={['⌘', '.']}>
+      <Button
+        data-sidebar='trigger'
+        variant='ghost'
+        size='icon'
+        className={cn(
+          'h-7 w-7',
+          state === 'expanded' ? 'cursor-w-resize' : 'cursor-e-resize',
+          className
+        )}
+        onClick={(event) => {
+          onClick?.(event)
+          toggleSidebar()
+        }}
+        {...props}>
+        <PanelLeft />
+        <span className='sr-only'>Toggle Sidebar</span>
+      </Button>
+    </SimpleTooltip>
   )
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
-  const { toggleSidebar } = useSidebar()
+/**
+ * Attio-style drag-to-resize strip straddling the fixed sidebar's inner edge. Rendered
+ * automatically inside a `resizable` `Sidebar` — consumers don't mount it. Live-updates the
+ * provider `width` (clamped to `[minWidth, maxWidth]`), snaps to collapsed when dragged well
+ * below `minWidth`, persists the width on release, and resets to `defaultWidth` on double-click.
+ */
+function SidebarResizeHandle({ side }: { side: 'left' | 'right' }) {
+  const {
+    width,
+    setWidth,
+    persistWidth,
+    minWidth,
+    maxWidth,
+    defaultWidth,
+    setIsResizing,
+    setOpen,
+  } = useSidebar()
+
+  // Latest committed width, read at drag end for persistence (state is async).
+  const widthRef = React.useRef(width)
+  widthRef.current = width
+
+  const handleMouseDown = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      setIsResizing(true)
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+
+      const startX = e.clientX
+      const startWidth = widthRef.current
+      let collapsed = false
+
+      const cleanup = () => {
+        setIsResizing(false)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+      }
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        // Snap to collapsed only once the cursor is dragged right up to the screen edge — not
+        // merely when the width bottoms out at the minimum (Attio behavior).
+        const atEdge =
+          side === 'left'
+            ? moveEvent.clientX <= SIDEBAR_COLLAPSE_EDGE
+            : moveEvent.clientX >= window.innerWidth - SIDEBAR_COLLAPSE_EDGE
+        if (atEdge) {
+          collapsed = true
+          cleanup()
+          setOpen(false)
+          return
+        }
+
+        // Dragging toward the inner edge grows the sidebar (mirror for a right sidebar).
+        const delta = side === 'left' ? moveEvent.clientX - startX : startX - moveEvent.clientX
+        const clamped = Math.min(maxWidth, Math.max(minWidth, startWidth + delta))
+        widthRef.current = clamped
+        setWidth(clamped)
+      }
+
+      const handleMouseUp = () => {
+        cleanup()
+        // Width state keeps its last value when we snap to collapsed, so re-expanding restores it.
+        if (!collapsed) persistWidth(widthRef.current)
+      }
+
+      document.addEventListener('mousemove', handleMouseMove)
+      document.addEventListener('mouseup', handleMouseUp)
+    },
+    [side, minWidth, maxWidth, setWidth, persistWidth, setIsResizing, setOpen]
+  )
+
+  const handleDoubleClick = React.useCallback(() => {
+    widthRef.current = defaultWidth
+    setWidth(defaultWidth)
+    persistWidth(defaultWidth)
+  }, [defaultWidth, setWidth, persistWidth])
 
   return (
-    <button
-      data-sidebar='rail'
-      aria-label='Toggle Sidebar'
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title='Toggle Sidebar'
+    <div
+      role='separator'
+      aria-orientation='vertical'
+      aria-label='Resize sidebar'
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
       className={cn(
-        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
-        'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
-        '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
-        'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar',
-        '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
-        '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
-        className
-      )}
-      {...props}
+        'group/resize absolute inset-y-0 z-20 flex w-2 cursor-col-resize items-stretch justify-center',
+        side === 'left' ? 'right-0 translate-x-1/2' : 'left-0 -translate-x-1/2'
+      )}>
+      {/* Accent line on the border, revealed on hover / while dragging. */}
+      <div className='w-px bg-transparent transition-colors group-hover/resize:bg-info' />
+    </div>
+  )
+}
+
+/**
+ * Left-edge hot zone that floats the collapsed sidebar in as a peek overlay on hover. Only
+ * rendered on hover-capable pointers while the sidebar is collapsed and not already peeking.
+ */
+function SidebarPeekHotZone({ side }: { side: 'left' | 'right' }) {
+  const { state, peek, requestPeekOpen, cancelPeekOpen } = useSidebar()
+  const hoverable = useHoverCapable()
+
+  if (!hoverable || state !== 'collapsed' || peek) return null
+
+  return (
+    <div
+      aria-hidden
+      onMouseEnter={requestPeekOpen}
+      onMouseLeave={cancelPeekOpen}
+      className={cn('fixed inset-y-0 z-40 w-3', side === 'left' ? 'left-0' : 'right-0')}
     />
   )
 }
@@ -388,16 +684,11 @@ function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof S
 function SidebarContent({ className, children, ...props }: React.ComponentProps<'div'>) {
   return (
     <ScrollArea
-      className={cn(
-        'relative min-h-0 flex-1 group-data-[collapsible=icon]:overflow-x-hidden',
-        className
-      )}
+      className={cn('relative min-h-0 flex-1', className)}
       fadeClassName='before:bg-gradient-to-b before:from-black/10 before:shadow-[inset_0_1px_0_rgba(0,0,0,0.1)] after:bg-gradient-to-t after:from-black/10 after:shadow-[inset_0_-1px_0_rgba(0,0,0,0.1)]'
       scrollbarClassName='w-1'
       {...props}>
-      <div
-        data-sidebar='content'
-        className='flex flex-col gap-0.5 py-2 pe-0.5 sm:pe-2 group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:pe-0'>
+      <div data-sidebar='content' className='flex flex-col gap-0.5 py-2 pe-0.5 sm:pe-2'>
         {children}
       </div>
     </ScrollArea>
@@ -429,7 +720,6 @@ function SidebarGroupLabel({
       data-sidebar='group-label'
       className={cn(
         'flex h-6 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-        'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className
       )}
       {...props}
@@ -451,7 +741,6 @@ function SidebarGroupAction({
         'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 md:after:hidden',
-        'group-data-[collapsible=icon]:hidden',
         className
       )}
       {...props}
@@ -509,7 +798,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 group-data-[collapsible=icon]:gap-0 rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -522,7 +811,7 @@ const sidebarMenuButtonVariants = cva(
       size: {
         default: 'h-8 text-sm',
         sm: 'h-7 text-xs',
-        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+        lg: 'h-12 text-sm',
       },
     },
     defaultVariants: { variant: 'default', size: 'default' },
@@ -534,7 +823,9 @@ function SidebarMenuButton({
   isActive = false,
   variant = 'default',
   size = 'default',
-  tooltip,
+  // Accepted for call-site compatibility but no longer rendered — the collapsed-state tooltip
+  // only existed for the removed icon mode (the sidebar now slides fully off-canvas).
+  tooltip: _tooltip,
   className,
   ...props
 }: React.ComponentProps<'button'> & {
@@ -543,9 +834,8 @@ function SidebarMenuButton({
   tooltip?: string | React.ComponentProps<typeof TooltipContent>
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? SlotPrimitive.Slot : 'button'
-  const { isMobile, state } = useSidebar()
 
-  const button = (
+  return (
     <Comp
       data-sidebar='menu-button'
       data-size={size}
@@ -553,26 +843,6 @@ function SidebarMenuButton({
       className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
       {...props}
     />
-  )
-
-  if (!tooltip) {
-    return button
-  }
-
-  if (typeof tooltip === 'string') {
-    tooltip = { children: tooltip }
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent
-        side='right'
-        align='center'
-        hidden={state !== 'collapsed' || isMobile}
-        {...tooltip}
-      />
-    </Tooltip>
   )
 }
 
@@ -594,7 +864,6 @@ function SidebarMenuAction({
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
         'peer-data-[size=lg]/menu-button:top-2.5',
-        'group-data-[collapsible=icon]:hidden ',
         showOnHover &&
           'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
         className
@@ -614,7 +883,6 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) 
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
         'peer-data-[size=lg]/menu-button:top-2.5',
-        'group-data-[collapsible=icon]:hidden',
         className
       )}
       {...props}
@@ -669,7 +937,6 @@ function SidebarMenuSub({
       className={cn(
         'flex min-w-0 flex-col gap-0.5 py-0.5',
         inset && 'mx-3.5 translate-x-px border-l border-sidebar-border px-2.5',
-        'group-data-[collapsible=icon]:hidden ',
         className
       )}
       {...props}
@@ -685,7 +952,8 @@ function SidebarMenuSubButton({
   asChild = false,
   size = 'md',
   isActive,
-  tooltip,
+  // Accepted for call-site compatibility but no longer rendered (see `SidebarMenuButton`).
+  tooltip: _tooltip,
   className,
   ...props
 }: React.ComponentProps<'a'> & {
@@ -695,9 +963,8 @@ function SidebarMenuSubButton({
   tooltip?: string | React.ComponentProps<typeof TooltipContent>
 }) {
   const Comp = asChild ? SlotPrimitive.Slot : 'a'
-  const { isMobile, state } = useSidebar()
 
-  const button = (
+  return (
     <Comp
       data-sidebar='menu-sub-button'
       data-size={size}
@@ -707,31 +974,10 @@ function SidebarMenuSubButton({
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',
-        'group-data-[collapsible=icon]:hidden ',
         className
       )}
       {...props}
     />
-  )
-
-  if (!tooltip) {
-    return button
-  }
-
-  if (typeof tooltip === 'string') {
-    tooltip = { children: tooltip }
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent
-        side='right'
-        align='center'
-        hidden={state !== 'collapsed' || isMobile}
-        {...tooltip}
-      />
-    </Tooltip>
   )
 }
 
@@ -757,7 +1003,6 @@ export {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarProvider,
-  SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -307,7 +307,6 @@ export {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarProvider,
-  SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,


### PR DESCRIPTION
Overhauls the app-shell sidebar to match Attio: drag-to-resize, off-canvas collapse (icon mode removed), and a hover-peek overlay. Implements `plans/ui/sidebar/attio-style-resizable-sidebar.md`.

## What changed

**Primitive (`packages/ui/src/components/sidebar.tsx`)**
- `SidebarProvider` gains opt-in `resizable` + `minWidth`/`maxWidth`/`defaultWidth` (200/256/400), live `width` state, and `peek`/`holdPeek`. Width persists to a `${persistKey}_width` cookie on drag-end and is SSR-restored (no flash).
- New `SidebarResizeHandle` — Attio-style edge strip (`role="separator"`), live clamp, double-click reset. Drag-to-collapse now snaps closed only when the **cursor reaches the screen edge** (24px), not merely at min width.
- Hover-peek overlay floats the collapsed sidebar in from the left edge; base panel raised to `z-30` so it stays above sticky content headers during the expand animation. Handle stays usable while peeking.
- **Icon-collapsed mode removed** (`collapsible: 'offcanvas' | 'none'`); `SidebarRail`, `--sidebar-width-icon`, and all `group-data-[collapsible=icon]` classes deleted. `tooltip` prop kept accepted-but-ignored.
- Toggle shortcut moved from **Cmd+B → Cmd+.**. Header trigger + a peek-only "expand sidebar" button (right of Kopilot) get a shortcut tooltip.

**Consumers**
- Main shell: `resizable` provider fed by `sidebar_state`/`sidebar_state_width` cookies (read server-side); headless `SidebarDragPeek` spring-loads the collapsed sidebar open when dragging a favorites-eligible item to the edge, sharing an `isSidebarFavoriteDrag` helper with the drag-end router.
- Admin (`admin_sidebar`) and build portal (`build_sidebar`) made resizable with their own cookie namespaces. Settings-secondary stays static; module sidebars untouched.

## Verification
- Type-clean (`@auxx/ui`, `apps/web`, `apps/build`) and Biome-clean (only the pre-existing `noDocumentCookie` warning).
- QA'd live in dev: resize + clamp at 200/400, edge-only drag-to-collapse, Cmd+. toggle, hover-peek in/out, resize-while-peeking, expand-from-peek layering, width persistence across reload, expand button.

## Notes
- The two build-portal layouts are client components, so their width/open persist to cookies but reset on hard reload (no SSR restore) — acceptable for the internal dev portal. Main app + admin restore correctly.