### PR TITLE
feat(dispatch): sync sent invoices to quickbooks online

### DIFF
--- a/apps/lambda/src/dev-server.ts
+++ b/apps/lambda/src/dev-server.ts
@@ -150,7 +150,7 @@ async function handleToolStreamingRequest(req: Request): Promise<Response> {
   // Mirror the caller allowlist in index.ts — Kopilot (agent), the quick-action
   // service (action), and the shared tool-backed option resolver may invoke
   // 'tool' events.
-  const TOOL_CALLERS = new Set(['kopilot', 'quick-action', 'app-tool-options'])
+  const TOOL_CALLERS = new Set(['kopilot', 'quick-action', 'app-tool-options', 'integration-sync'])
   if (authCaller && !TOOL_CALLERS.has(authCaller)) {
     return jsonError(403, 'CALLER_TYPE_DENIED', `Caller "${authCaller}" cannot invoke 'tool'`)
   }

--- a/apps/lambda/src/index.ts
+++ b/apps/lambda/src/index.ts
@@ -118,6 +118,10 @@ const CALLER_TYPE_ALLOWLIST: Record<string, string[]> = {
   // config pickers) invoke a tool through the shared `invokeAppToolForOptions`
   // core, which signs as `app-tool-options`. See packages/lib/src/apps/tool-options.ts.
   'app-tool-options': ['tool'],
+  // Platform-initiated app-tool orchestration: backend business logic driving an
+  // installed app's tools directly (QuickBooks invoice/payment sync, future outbound
+  // integration syncs). See packages/lib/src/money/quickbooks/invoke-quickbooks-tool.ts.
+  'integration-sync': ['tool'],
 }
 
 /** Maximum payload size (5 MB) */

--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -333,7 +333,7 @@ export default function IntegrationList() {
             title='Browse apps'
             description='Discover new apps to help you work better'>
             <div className='flex flex-col gap-6 justify-start w-full'>
-              <div className='sticky pt-20 -mt-20  top-0'>
+              <div className='sticky pt-20 -mt-20 top-0 z-11'>
                 <div className='grid sm:grid-cols-3 pb-4 sm:pb-0'>
                   <Input
                     placeholder='Search apps'

--- a/apps/web/src/components/global/settings-page.tsx
+++ b/apps/web/src/components/global/settings-page.tsx
@@ -118,7 +118,7 @@ export default function SettingsPage({
         </header>
       )}
 
-      <div className='sticky top-0 z-10 backdrop-blur-sm bg-background/80 rounded-tr-xl'>
+      <div className='sticky top-0 z-21 backdrop-blur-sm bg-background/80 rounded-tr-xl'>
         <div
           className={cn(
             'flex flex-col sm:flex-row sm:items-center gap-2 bg-muted/50 px-5 py-3 pe-2 sm:pe-5',

--- a/apps/web/src/components/money/ui/settings/invoicing-page.tsx
+++ b/apps/web/src/components/money/ui/settings/invoicing-page.tsx
@@ -9,6 +9,7 @@ import { FieldPanel } from '~/components/global/forms/field-panel'
 import { FormSaveBar } from '~/components/global/forms/form-save-bar'
 import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
+import { QuickbooksSettingsSection } from '~/components/money/ui/settings/quickbooks-section'
 import { SettingsFieldRow } from '~/components/settings/settings-field-row'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
@@ -62,6 +63,8 @@ const DRAFT_KEYS = [
   'documents.invoice.lineDisplay',
   'documents.invoice.showDescriptions',
   'documents.invoice.showPaymentHistory',
+  'quickbooks.syncInvoices',
+  'quickbooks.defaultIncomeAccountId',
 ] as const
 
 function InvoicingSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }[] }) {
@@ -163,6 +166,11 @@ function InvoicingSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }
             />
           </FieldPanel>
         </SettingsSection>
+
+        <QuickbooksSettingsSection
+          syncInvoices={controlled('quickbooks.syncInvoices')}
+          defaultIncomeAccountId={controlled('quickbooks.defaultIncomeAccountId')}
+        />
 
         <FormSaveBar
           dirty={dirty}

--- a/apps/web/src/components/money/ui/settings/quickbooks-section.tsx
+++ b/apps/web/src/components/money/ui/settings/quickbooks-section.tsx
@@ -1,0 +1,100 @@
+// apps/web/src/components/money/ui/settings/quickbooks-section.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Landmark } from 'lucide-react'
+import Link from 'next/link'
+import { useAppsContext } from '~/components/apps/providers/apps-context'
+import { InlineAppInstallButton } from '~/components/apps/ui/app-install-button'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { SettingsSection } from '~/components/global/settings-page'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+
+const QUICKBOOKS_APP_SLUG = 'quickbooks'
+const QUICKBOOKS_APP_DETAIL_PATH = '/app/settings/apps/quickbooks'
+
+type ControlledFieldProps = { value: unknown; onChange: (value: unknown) => void }
+
+/**
+ * QuickBooks section for the invoicing settings page (37e-quickbooks-invoice-sync.md P1).
+ * Renders one of three states, detected client-side off `useAppsContext()` — the app is
+ * never auto-installed, every state points at an explicit user action:
+ *
+ * 1. Not installed → install row (mirrors the "Required Apps" row in
+ *    `workflow-template-dialog.tsx`), title links to the app detail page.
+ * 2. Installed, no QBO connection → a "Connect QuickBooks" prompt linking to the app detail
+ *    page (connecting is a full OAuth flow, out of scope here).
+ * 3. Connected → the `quickbooks.syncInvoices` toggle + default income account input, riding
+ *    the parent page's batched draft/save.
+ */
+export function QuickbooksSettingsSection({
+  syncInvoices,
+  defaultIncomeAccountId,
+}: {
+  syncInvoices: ControlledFieldProps
+  defaultIncomeAccountId: ControlledFieldProps
+}) {
+  const { appInstallations, appConnections } = useAppsContext()
+
+  const installation = appInstallations.find((inst) => inst.app.slug === QUICKBOOKS_APP_SLUG)
+  // A connection identifies its app via `appId` (see `AppConnection` in apps-context.tsx,
+  // sourced from `listAppConnections` — `cred.appId` matched against the App table). We
+  // match on the installed app's id rather than name/slug since connections don't carry slug.
+  const isConnected = installation
+    ? appConnections.some(
+        (conn) => conn.appId === installation.app.id && conn.connectionStatus === 'connected'
+      )
+    : false
+
+  return (
+    <SettingsSection
+      icon={Landmark}
+      title='QuickBooks'
+      description='Mirror sent invoices into QuickBooks Online.'>
+      {!installation && (
+        <FieldPanel className='mt-1 p-0' resizeId='invoicing-quickbooks-settings'>
+          <FieldPanelRow
+            title='QuickBooks Online'
+            description='Install the app to enable invoice sync.'>
+            <div className='flex w-full items-center justify-between gap-2'>
+              <Link href={QUICKBOOKS_APP_DETAIL_PATH} className='text-sm hover:underline'>
+                QuickBooks
+              </Link>
+              <InlineAppInstallButton appSlug={QUICKBOOKS_APP_SLUG} />
+            </div>
+          </FieldPanelRow>
+        </FieldPanel>
+      )}
+
+      {installation && !isConnected && (
+        <FieldPanel className='mt-1 p-0' resizeId='invoicing-quickbooks-settings'>
+          <FieldPanelRow
+            title='QuickBooks Online'
+            description='Connect your QuickBooks Online company to enable invoice sync.'>
+            <Button variant='outline' size='sm' asChild>
+              <Link href={QUICKBOOKS_APP_DETAIL_PATH}>Connect QuickBooks</Link>
+            </Button>
+          </FieldPanelRow>
+        </FieldPanel>
+      )}
+
+      {installation && isConnected && (
+        <FieldPanel
+          className='mt-1 p-0'
+          resizeId='invoicing-quickbooks-settings'
+          defaultLabelWidth={220}>
+          <SettingsFieldRow
+            settingKey='quickbooks.syncInvoices'
+            title='Sync invoices to QuickBooks'
+            {...syncInvoices}
+          />
+          <SettingsFieldRow
+            settingKey='quickbooks.defaultIncomeAccountId'
+            title='Default income account'
+            {...defaultIncomeAccountId}
+          />
+        </FieldPanel>
+      )}
+    </SettingsSection>
+  )
+}

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -39,6 +39,7 @@ import {
   saveBillingInstallments,
   setInvoiceSchedule,
   syncAccountState,
+  syncInvoiceToQuickbooks,
   voidInvoice,
 } from '@auxx/lib/money'
 import { FeaturePermissionService } from '@auxx/lib/permissions'
@@ -391,6 +392,21 @@ export const moneyRouter = createTRPCRouter({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         invoiceInstanceId: entityInstanceId,
+      })
+    }),
+
+  // Manual "Sync to QuickBooks" action (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3) —
+  // calls the orchestrator directly (not via the queue) so the UI gets the result inline; the
+  // draft→sent field-change hook (`enqueueQuickbooksInvoiceSyncOnSent`) uses the same
+  // orchestrator through the queue for the automatic path.
+  syncInvoiceToQuickbooks: moneyProcedure
+    .input(z.object({ invoiceRecordId: recordIdSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const { entityInstanceId } = parseRecordId(input.invoiceRecordId)
+      return syncInvoiceToQuickbooks({
+        organizationId: ctx.session.organizationId,
+        invoiceInstanceId: entityInstanceId,
+        actorUserId: ctx.session.user.id,
       })
     }),
 

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -29,6 +29,7 @@ import { startMessageSyncWorker } from './worker-definitions/message-sync-worker
 import { startOAuth2RefreshWorker } from './worker-definitions/oauth2-refresh-worker'
 import { startPollingSyncWorker } from './worker-definitions/polling-sync-worker'
 import { startPollingTriggerWorker } from './worker-definitions/polling-trigger-worker'
+import { startQuickbooksInvoiceSyncWorker } from './worker-definitions/quickbooks-invoice-sync-worker'
 import { startRecordingBotWorker } from './worker-definitions/recording-bot-worker'
 import { startRecordingProcessingWorker } from './worker-definitions/recording-processing-worker'
 import { startScheduledTriggerWorker } from './worker-definitions/scheduled-trigger-worker'
@@ -123,6 +124,9 @@ export async function startWorkers() {
   // Quote/invoice PDF render worker (money MQ2)
   const documentPdfWorker = startDocumentPdfWorker()
 
+  // QuickBooks invoice sync worker (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
+  const quickbooksInvoiceSyncWorker = startQuickbooksInvoiceSyncWorker()
+
   const workers = [
     // defaultWorker,
     eventsWorker,
@@ -156,6 +160,7 @@ export async function startWorkers() {
     knowledgeSourceWorker,
     dataConnectorWorker,
     documentPdfWorker,
+    quickbooksInvoiceSyncWorker,
   ]
 
   return Promise.all(workers)

--- a/apps/worker/src/workers/worker-definitions/quickbooks-invoice-sync-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/quickbooks-invoice-sync-worker.ts
@@ -1,0 +1,21 @@
+// apps/worker/src/workers/worker-definitions/quickbooks-invoice-sync-worker.ts
+
+import { syncQuickbooksInvoiceJob } from '@auxx/lib/jobs'
+import { Queues } from '@auxx/lib/jobs/queues'
+import { createWorker } from '../utils/createWorker'
+
+const jobMappings = {
+  syncQuickbooksInvoice: syncQuickbooksInvoiceJob,
+}
+
+/**
+ * QuickBooks invoice sync worker (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3).
+ * Concurrency capped at 2 — each job drives a chain of outbound QBO API calls
+ * (customer/item upsert + invoice create/update), so it doesn't need thumbnail-worker levels
+ * of parallelism.
+ */
+export function startQuickbooksInvoiceSyncWorker() {
+  return createWorker(Queues.quickbooksInvoiceSyncQueue, jobMappings, {
+    concurrency: 2,
+  })
+}

--- a/packages/lib/scripts/qbo-invoice-sync-e2e.ts
+++ b/packages/lib/scripts/qbo-invoice-sync-e2e.ts
@@ -1,0 +1,86 @@
+// packages/lib/scripts/qbo-invoice-sync-e2e.ts
+//
+// Throwaway e2e driver for QuickBooks invoice sync against the DemoOrg sandbox connection
+// (plan 37e-quickbooks-invoice-sync.md, P3). Two phases so nothing writes to QBO until we've
+// picked a valid income account:
+//
+//   list                         → resolve the QB Lambda context + list sandbox income accounts
+//   sync <invoiceInstanceId> [incomeAccountId]
+//                                → optionally set the default income account, then run the
+//                                  orchestrator on one invoice and print the result
+//
+// Run (full dev must be up so the app Lambda runtime is reachable):
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/qbo-invoice-sync-e2e.ts list
+
+import { onCacheEvent } from '../src/cache'
+import { resolveQuickbooksContext } from '../src/money/quickbooks/invoke-quickbooks-tool'
+import { syncInvoiceToQuickbooks } from '../src/money/quickbooks/sync-invoice'
+import { getOrganizationSetting, updateOrganizationSetting } from '../src/settings/settings-service'
+
+const ORG = 'abgwpa1l81reht2zmwrcihfu' // DemoOrg1
+
+async function list() {
+  const resolved = await resolveQuickbooksContext({ organizationId: ORG })
+  if (!resolved.connected) {
+    console.error('❌ QuickBooks not connected for org', ORG)
+    return
+  }
+  console.log('✅ connected — realmId:', resolved.context.realmId)
+  const out = await resolved.context.callTool('list_quickbooks_accounts', {})
+  const accounts: Array<{
+    id: string
+    name: string
+    accountType: string
+    classification: string
+    active: boolean
+  }> = out.accounts ?? []
+  const income = accounts.filter((a) => a.classification === 'Revenue' && a.active)
+  console.log(`\nIncome (Revenue) accounts — ${income.length}:`)
+  for (const a of income) {
+    console.log(`  ${a.id.padEnd(6)}  ${a.name}  (${a.accountType})`)
+  }
+}
+
+async function sync(invoiceInstanceId: string, incomeAccountId?: string) {
+  if (incomeAccountId) {
+    await updateOrganizationSetting({
+      organizationId: ORG,
+      key: 'quickbooks.defaultIncomeAccountId',
+      value: incomeAccountId,
+    })
+    // The service only writes the DB; the tRPC router busts the cache separately.
+    // Replicate that here so getOrganizationSetting reads fresh (not the stale Redis snapshot).
+    await onCacheEvent('org.settings.changed', { orgId: ORG, broadcastUserKeys: true })
+    console.log('set quickbooks.defaultIncomeAccountId =', incomeAccountId)
+  }
+  const acct = await getOrganizationSetting({
+    organizationId: ORG,
+    key: 'quickbooks.defaultIncomeAccountId',
+  })
+  console.log('default income account:', acct)
+  console.log('syncing invoice', invoiceInstanceId, '...')
+  const result = await syncInvoiceToQuickbooks({ organizationId: ORG, invoiceInstanceId })
+  console.log('\nSYNC RESULT:', JSON.stringify(result, null, 2))
+}
+
+async function main() {
+  const [cmd, arg1, arg2] = process.argv.slice(2)
+  if (cmd === 'list') {
+    await list()
+  } else if (cmd === 'sync' && arg1) {
+    await sync(arg1, arg2)
+  } else {
+    console.error(
+      'usage: qbo-invoice-sync-e2e.ts list | sync <invoiceInstanceId> [incomeAccountId]'
+    )
+    process.exitCode = 1
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('SCRIPT ERROR:', err)
+    process.exit(1)
+  })

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -36,6 +36,7 @@ import {
 } from '../money/totals-hooks'
 import { handleRecordRulesOnFieldChange } from '../record-rules/hook-handler'
 import {
+  enqueueQuickbooksInvoiceSyncOnSent,
   enrollInvoiceReminderOnSent,
   enrollJobFollowUpOnCompletion,
   reanchorInvoiceOnDueDateChange,
@@ -145,10 +146,15 @@ export function registerAllHooks(): void {
   // payment-deletion paid→sent reversal does NOT re-enroll, decision #12), and re-anchor any
   // parked reminder wait when `invoice_due_date` changes (`reanchorInvoiceOnDueDateChange` —
   // required, not just an accelerator: it's the only path that can move an already-parked wait).
+  //
+  // QuickBooks invoice sync (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3):
+  // `enqueueQuickbooksInvoiceSyncOnSent` rides the same draft→sent door, enqueuing the mirror
+  // job (gated by `quickbooks.syncInvoices`) rather than syncing inline.
   registerEntityFieldChangeHooks('invoices', [
     recomputeOnInvoiceBillingChange,
     enrollInvoiceReminderOnSent,
     reanchorInvoiceOnDueDateChange,
+    enqueueQuickbooksInvoiceSyncOnSent,
     syncBillingOnInvoiceChange,
   ])
 

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -231,6 +231,11 @@ export {
   type ThreadProviderStatusSyncJobData,
   threadProviderStatusSyncJob,
 } from './messages/thread-provider-status-sync-job'
+// Money (QuickBooks invoice sync — plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
+export {
+  type SyncQuickbooksInvoiceJobData,
+  syncQuickbooksInvoiceJob,
+} from './money/sync-quickbooks-invoice-job'
 // OAuth2
 export { oauth2TokenRefreshJob } from './oauth2-refresh'
 // Polling

--- a/packages/lib/src/jobs/money/sync-quickbooks-invoice-job.ts
+++ b/packages/lib/src/jobs/money/sync-quickbooks-invoice-job.ts
@@ -1,0 +1,22 @@
+// packages/lib/src/jobs/money/sync-quickbooks-invoice-job.ts
+
+import { syncInvoiceToQuickbooks } from '../../money/quickbooks/sync-invoice'
+import type { JobContext } from '../types'
+
+/** Payload for {@link syncQuickbooksInvoiceJob}. */
+export interface SyncQuickbooksInvoiceJobData {
+  organizationId: string
+  invoiceInstanceId: string
+  actorUserId?: string
+}
+
+/**
+ * Worker job — mirrors an Auxx invoice into QuickBooks Online (plans/dispatch/
+ * 37e-quickbooks-invoice-sync.md §3, P3). Thin wrapper around
+ * {@link syncInvoiceToQuickbooks}; enqueued from the `invoice_status` draft→sent field-change
+ * hook (`sequences/field-change-hooks.ts`) and available for the manual "Sync to QuickBooks"
+ * retry action.
+ */
+export const syncQuickbooksInvoiceJob = async (ctx: JobContext<SyncQuickbooksInvoiceJobData>) => {
+  return syncInvoiceToQuickbooks(ctx.data)
+}

--- a/packages/lib/src/jobs/queues/types.ts
+++ b/packages/lib/src/jobs/queues/types.ts
@@ -59,4 +59,6 @@ export enum Queues {
   dataConnectorQueue = 'data-connector',
   // Learned-KB extraction (AI memory from resolved threads) queue
   learnedExtractionQueue = 'learned-extraction',
+  // QuickBooks invoice sync queue (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
+  quickbooksInvoiceSyncQueue = 'quickbooks-invoice-sync',
 }

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -132,6 +132,11 @@ export {
   resolveInvoiceByPublicToken,
 } from './public-token'
 export {
+  type SyncInvoiceResult,
+  type SyncInvoiceToQuickbooksInput,
+  syncInvoiceToQuickbooks,
+} from './quickbooks/sync-invoice'
+export {
   type AcceptQuoteByTokenInput,
   type AcceptQuoteByTokenResult,
   acceptQuoteByToken,

--- a/packages/lib/src/money/quickbooks/__tests__/sync-invoice.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/sync-invoice.test.ts
@@ -1,0 +1,408 @@
+// packages/lib/src/money/quickbooks/__tests__/sync-invoice.test.ts
+//
+// Unit tests for the invoice-sync orchestrator. Every collaborator (settings, the
+// QuickBooks tool-call context, the customer/item upserts, the id-map field reads/writes,
+// and the org cache / UnifiedCrudHandler) is mocked at its module boundary — no real Drizzle
+// schema/columns are touched (repo memory: drizzle columns are undefined under vitest).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getOrganizationSetting = vi.fn()
+vi.mock('../../../settings/settings-service', () => ({
+  getOrganizationSetting: (...a: unknown[]) => getOrganizationSetting(...a),
+}))
+
+const resolveQuickbooksContext = vi.fn()
+vi.mock('../invoke-quickbooks-tool', () => ({
+  resolveQuickbooksContext: (...a: unknown[]) => resolveQuickbooksContext(...a),
+}))
+
+const upsertQuickbooksCustomer = vi.fn()
+vi.mock('../upsert-customer', () => ({
+  upsertQuickbooksCustomer: (...a: unknown[]) => upsertQuickbooksCustomer(...a),
+}))
+
+const upsertQuickbooksItem = vi.fn()
+vi.mock('../upsert-item', () => ({
+  upsertQuickbooksItem: (...a: unknown[]) => upsertQuickbooksItem(...a),
+}))
+
+const readQuickbooksIdField = vi.fn()
+const writeQuickbooksIdField = vi.fn()
+vi.mock('../identity-field', () => ({
+  readQuickbooksIdField: (...a: unknown[]) => readQuickbooksIdField(...a),
+  writeQuickbooksIdField: (...a: unknown[]) => writeQuickbooksIdField(...a),
+}))
+
+const bySystemAttributes = vi.fn()
+vi.mock('../../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes }) }),
+}))
+
+const getFieldValues = vi.fn()
+const listFiltered = vi.fn()
+vi.mock('../../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    constructor(
+      public organizationId: string,
+      public userId: string
+    ) {}
+    getFieldValues(...a: unknown[]) {
+      return getFieldValues(...a)
+    }
+    listFiltered(...a: unknown[]) {
+      return listFiltered(...a)
+    }
+  },
+}))
+
+import { syncInvoiceToQuickbooks } from '../sync-invoice'
+
+const ORG_ID = 'org1'
+const INVOICE_ID = 'inv1'
+const CONTACT_ID = 'contact1'
+const LINE_ID_1 = 'line1'
+const LINE_ID_2 = 'line2'
+
+/** systemAttribute → CustomField.id, mirroring the real registry keys the orchestrator reads. */
+const FIELD_IDS: Record<string, string> = {
+  invoice_number: 'f-invoice-number',
+  invoice_due_date: 'f-invoice-due-date',
+  invoice_contact: 'f-invoice-contact',
+  first_name: 'f-first-name',
+  last_name: 'f-last-name',
+  primary_email: 'f-primary-email',
+  line_item_line_total: 'f-line-total',
+  line_item_qty: 'f-line-qty',
+  line_item_name: 'f-line-name',
+  line_item_catalog_item: 'f-line-catalog-item',
+}
+
+const CTX = {
+  organizationId: ORG_ID,
+  installationId: 'install1',
+  connectionId: 'conn1',
+  userId: 'user1',
+  callTool: vi.fn(),
+}
+
+function textValue(value: string) {
+  return { type: 'text', value }
+}
+function dateValue(value: string) {
+  return { type: 'date', value }
+}
+function numberValue(value: number) {
+  return { type: 'number', value }
+}
+function relationshipValue(recordId: string) {
+  return { type: 'relationship', recordId }
+}
+
+/** Default single-line invoice fixture: one $120 line, no catalog item. */
+function setupSingleLineFixture() {
+  listFiltered.mockResolvedValue({ ids: [LINE_ID_1], total: 1, hasMore: false, snapshotId: '' })
+
+  getFieldValues.mockImplementation(async (recordId: string) => {
+    if (recordId === `invoice:${INVOICE_ID}`) {
+      return new Map<string, unknown>([
+        [FIELD_IDS.invoice_number!, textValue('INV-001')],
+        [FIELD_IDS.invoice_due_date!, dateValue('2026-08-01')],
+        [FIELD_IDS.invoice_contact!, relationshipValue(`contact:${CONTACT_ID}`)],
+      ])
+    }
+    if (recordId === `contact:${CONTACT_ID}`) {
+      return new Map([
+        [FIELD_IDS.first_name!, textValue('Jane')],
+        [FIELD_IDS.last_name!, textValue('Doe')],
+        [FIELD_IDS.primary_email!, textValue('jane@example.com')],
+      ])
+    }
+    if (recordId === `line_item:${LINE_ID_1}`) {
+      return new Map<string, unknown>([
+        [FIELD_IDS.line_item_line_total!, numberValue(12000)],
+        [FIELD_IDS.line_item_qty!, numberValue(2)],
+        [FIELD_IDS.line_item_name!, textValue('Service Call')],
+      ])
+    }
+    return new Map()
+  })
+}
+
+beforeEach(() => {
+  getOrganizationSetting.mockReset()
+  getOrganizationSetting.mockImplementation(async ({ key }: { key: string }) => {
+    if (key === 'quickbooks.syncInvoices') return true
+    if (key === 'quickbooks.defaultIncomeAccountId') return 'acct-1'
+    return null
+  })
+
+  resolveQuickbooksContext.mockReset()
+  resolveQuickbooksContext.mockResolvedValue({ connected: true, context: CTX })
+
+  upsertQuickbooksCustomer.mockReset()
+  upsertQuickbooksCustomer.mockResolvedValue('qbo-cust-1')
+
+  upsertQuickbooksItem.mockReset()
+  upsertQuickbooksItem.mockResolvedValue('qbo-item-1')
+
+  readQuickbooksIdField.mockReset()
+  readQuickbooksIdField.mockResolvedValue(undefined)
+
+  writeQuickbooksIdField.mockReset()
+  writeQuickbooksIdField.mockResolvedValue(undefined)
+
+  bySystemAttributes.mockReset()
+  bySystemAttributes.mockImplementation(async (attrs: string[]) => {
+    const map: Record<string, { id: string } | null> = {}
+    for (const attr of attrs) map[attr] = FIELD_IDS[attr] ? { id: FIELD_IDS[attr] } : null
+    return map
+  })
+
+  getFieldValues.mockReset()
+  listFiltered.mockReset()
+  CTX.callTool.mockReset()
+})
+
+describe('syncInvoiceToQuickbooks', () => {
+  it('returns disabled when the org setting is off', async () => {
+    getOrganizationSetting.mockImplementation(async ({ key }: { key: string }) =>
+      key === 'quickbooks.syncInvoices' ? false : null
+    )
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result).toEqual({ status: 'disabled' })
+    expect(resolveQuickbooksContext).not.toHaveBeenCalled()
+  })
+
+  it('returns not_connected when the app has no usable connection', async () => {
+    resolveQuickbooksContext.mockResolvedValue({ connected: false })
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result).toEqual({ status: 'not_connected' })
+  })
+
+  it('creates a fresh invoice — upserts the customer + item, creates, writes ids back', async () => {
+    setupSingleLineFixture()
+    CTX.callTool.mockImplementation(async (toolId: string) => {
+      if (toolId === 'create_quickbooks_invoice') {
+        return { invoiceId: 'qbo-inv-1', docNumber: 'INV-001', totalAmt: 120, balance: 120 }
+      }
+      throw new Error(`unexpected tool call: ${toolId}`)
+    })
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+      actorUserId: 'actor1',
+    })
+
+    expect(result).toEqual({ status: 'synced', qboInvoiceId: 'qbo-inv-1' })
+
+    expect(upsertQuickbooksCustomer).toHaveBeenCalledWith(
+      CTX,
+      expect.objectContaining({
+        contactInstanceId: CONTACT_ID,
+        contactFields: { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' },
+      })
+    )
+    expect(upsertQuickbooksItem).toHaveBeenCalledWith(
+      CTX,
+      expect.objectContaining({ itemName: 'Service Call', defaultIncomeAccountId: 'acct-1' })
+    )
+
+    expect(CTX.callTool).toHaveBeenCalledWith(
+      'create_quickbooks_invoice',
+      expect.objectContaining({
+        customerId: 'qbo-cust-1',
+        lines: [{ itemId: 'qbo-item-1', amount: 120, quantity: 2, description: 'Service Call' }],
+        docNumber: 'INV-001',
+        dueDate: '2026-08-01',
+        billEmail: 'jane@example.com',
+      })
+    )
+    expect(CTX.callTool).not.toHaveBeenCalledWith('update_quickbooks_invoice', expect.anything())
+
+    expect(writeQuickbooksIdField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appFieldKey: 'qboInvoiceId',
+        entityType: 'invoice',
+        entityInstanceId: INVOICE_ID,
+        externalId: 'qbo-inv-1',
+      })
+    )
+  })
+
+  it('normalises a timestamptz due date to a bare YYYY-MM-DD for QBO', async () => {
+    // Auxx DATE fields extract as a full timestamp; QBO rejects anything but YYYY-MM-DD.
+    setupSingleLineFixture()
+    getFieldValues.mockImplementation(async (recordId: string) => {
+      if (recordId === `invoice:${INVOICE_ID}`) {
+        return new Map<string, unknown>([
+          [FIELD_IDS.invoice_number!, textValue('INV-003')],
+          [FIELD_IDS.invoice_due_date!, dateValue('2026-08-10 00:00:00+00')],
+          [FIELD_IDS.invoice_contact!, relationshipValue(`contact:${CONTACT_ID}`)],
+        ])
+      }
+      if (recordId === `contact:${CONTACT_ID}`) {
+        return new Map([[FIELD_IDS.primary_email!, textValue('jane@example.com')]])
+      }
+      if (recordId === `line_item:${LINE_ID_1}`) {
+        return new Map<string, unknown>([
+          [FIELD_IDS.line_item_line_total!, numberValue(12000)],
+          [FIELD_IDS.line_item_qty!, numberValue(1)],
+          [FIELD_IDS.line_item_name!, textValue('Service Call')],
+        ])
+      }
+      return new Map()
+    })
+    CTX.callTool.mockResolvedValue({ invoiceId: 'qbo-inv-3' })
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result.status).toBe('synced')
+    expect(CTX.callTool).toHaveBeenCalledWith(
+      'create_quickbooks_invoice',
+      expect.objectContaining({ dueDate: '2026-08-10' })
+    )
+  })
+
+  it('re-syncs an already-synced invoice via update, never calling create (no duplicate)', async () => {
+    setupSingleLineFixture()
+    readQuickbooksIdField.mockResolvedValue('qbo-inv-existing')
+    CTX.callTool.mockImplementation(async (toolId: string) => {
+      if (toolId === 'update_quickbooks_invoice') {
+        return { invoiceId: 'qbo-inv-existing', docNumber: 'INV-001', totalAmt: 120, balance: 120 }
+      }
+      throw new Error(`unexpected tool call: ${toolId}`)
+    })
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result).toEqual({ status: 'synced', qboInvoiceId: 'qbo-inv-existing' })
+    expect(CTX.callTool).toHaveBeenCalledWith(
+      'update_quickbooks_invoice',
+      expect.objectContaining({ invoiceId: 'qbo-inv-existing' })
+    )
+    expect(CTX.callTool).not.toHaveBeenCalledWith('create_quickbooks_invoice', expect.anything())
+  })
+
+  it('skips $0 lines entirely — they never reach the item upsert or the QBO payload', async () => {
+    listFiltered.mockResolvedValue({
+      ids: [LINE_ID_1, LINE_ID_2],
+      total: 2,
+      hasMore: false,
+      snapshotId: '',
+    })
+    getFieldValues.mockImplementation(async (recordId: string) => {
+      if (recordId === `invoice:${INVOICE_ID}`) {
+        return new Map<string, unknown>([
+          [FIELD_IDS.invoice_number!, textValue('INV-002')],
+          [FIELD_IDS.invoice_contact!, relationshipValue(`contact:${CONTACT_ID}`)],
+        ])
+      }
+      if (recordId === `contact:${CONTACT_ID}`) {
+        return new Map([[FIELD_IDS.primary_email!, textValue('jane@example.com')]])
+      }
+      if (recordId === `line_item:${LINE_ID_1}`) {
+        // Zero-dollar line (e.g. a chemical-usage record) — must be skipped.
+        return new Map([[FIELD_IDS.line_item_line_total!, numberValue(0)]])
+      }
+      if (recordId === `line_item:${LINE_ID_2}`) {
+        return new Map<string, unknown>([
+          [FIELD_IDS.line_item_line_total!, numberValue(5000)],
+          [FIELD_IDS.line_item_qty!, numberValue(1)],
+          [FIELD_IDS.line_item_name!, textValue('Billable Line')],
+        ])
+      }
+      return new Map()
+    })
+    CTX.callTool.mockResolvedValue({ invoiceId: 'qbo-inv-2' })
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result.status).toBe('synced')
+    expect(upsertQuickbooksItem).toHaveBeenCalledTimes(1)
+    expect(upsertQuickbooksItem).toHaveBeenCalledWith(
+      CTX,
+      expect.objectContaining({ itemName: 'Billable Line' })
+    )
+    expect(CTX.callTool).toHaveBeenCalledWith(
+      'create_quickbooks_invoice',
+      expect.objectContaining({
+        lines: [{ itemId: 'qbo-item-1', amount: 50, quantity: 1, description: 'Billable Line' }],
+      })
+    )
+  })
+
+  it('resolves to status: error (never throws) when a downstream step fails', async () => {
+    setupSingleLineFixture()
+    upsertQuickbooksItem.mockRejectedValue(
+      new Error('Cannot create a QuickBooks item — set a default income account first.')
+    )
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result.status).toBe('error')
+    expect(result.error).toMatch(/default income account/)
+    expect(CTX.callTool).not.toHaveBeenCalledWith('create_quickbooks_invoice', expect.anything())
+  })
+
+  it('errors when the invoice has no contact', async () => {
+    listFiltered.mockResolvedValue({ ids: [], total: 0, hasMore: false, snapshotId: '' })
+    getFieldValues.mockImplementation(async (recordId: string) => {
+      if (recordId === `invoice:${INVOICE_ID}`) return new Map()
+      return new Map()
+    })
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result.status).toBe('error')
+    expect(result.error).toMatch(/no contact/)
+  })
+
+  it('errors when every line is $0 (no billable lines to sync)', async () => {
+    listFiltered.mockResolvedValue({ ids: [LINE_ID_1], total: 1, hasMore: false, snapshotId: '' })
+    getFieldValues.mockImplementation(async (recordId: string) => {
+      if (recordId === `invoice:${INVOICE_ID}`) {
+        return new Map([[FIELD_IDS.invoice_contact!, relationshipValue(`contact:${CONTACT_ID}`)]])
+      }
+      if (recordId === `contact:${CONTACT_ID}`) return new Map()
+      if (recordId === `line_item:${LINE_ID_1}`) {
+        return new Map([[FIELD_IDS.line_item_line_total!, numberValue(0)]])
+      }
+      return new Map()
+    })
+
+    const result = await syncInvoiceToQuickbooks({
+      organizationId: ORG_ID,
+      invoiceInstanceId: INVOICE_ID,
+    })
+
+    expect(result.status).toBe('error')
+    expect(result.error).toMatch(/no billable lines/)
+  })
+})

--- a/packages/lib/src/money/quickbooks/__tests__/upsert-customer.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/upsert-customer.test.ts
@@ -1,0 +1,135 @@
+// packages/lib/src/money/quickbooks/__tests__/upsert-customer.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const readQuickbooksIdField = vi.fn()
+const writeQuickbooksIdField = vi.fn()
+vi.mock('../identity-field', () => ({
+  readQuickbooksIdField: (...a: unknown[]) => readQuickbooksIdField(...a),
+  writeQuickbooksIdField: (...a: unknown[]) => writeQuickbooksIdField(...a),
+}))
+
+import type { QuickbooksToolContext } from '../invoke-quickbooks-tool'
+import { upsertQuickbooksCustomer } from '../upsert-customer'
+
+const ORG_ID = 'org1'
+const CONTACT_ID = 'contact1'
+const handler = {} as never // opaque — only threaded through to the mocked identity-field reads
+
+function buildCtx(callTool = vi.fn()): QuickbooksToolContext {
+  return {
+    organizationId: ORG_ID,
+    installationId: 'install1',
+    connectionId: 'conn1',
+    userId: 'user1',
+    callTool,
+  }
+}
+
+beforeEach(() => {
+  readQuickbooksIdField.mockReset()
+  writeQuickbooksIdField.mockReset()
+})
+
+describe('upsertQuickbooksCustomer', () => {
+  it('returns the stored id without calling any QuickBooks tool (idempotent fast path)', async () => {
+    readQuickbooksIdField.mockResolvedValue('qbo-cust-existing')
+    const callTool = vi.fn()
+
+    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      contactInstanceId: CONTACT_ID,
+      contactFields: { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' },
+      handler,
+    })
+
+    expect(result).toBe('qbo-cust-existing')
+    expect(callTool).not.toHaveBeenCalled()
+    expect(writeQuickbooksIdField).not.toHaveBeenCalled()
+  })
+
+  it('finds by exact email and writes the id back — no create call', async () => {
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    const callTool = vi.fn().mockResolvedValue({ found: true, customer: { customerId: '99' } })
+
+    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      contactInstanceId: CONTACT_ID,
+      contactFields: { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' },
+      handler,
+    })
+
+    expect(result).toBe('99')
+    expect(callTool).toHaveBeenCalledWith('find_quickbooks_customer', { email: 'jane@example.com' })
+    expect(callTool).not.toHaveBeenCalledWith('create_quickbooks_customer', expect.anything())
+    expect(writeQuickbooksIdField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appFieldKey: 'qboCustomerId',
+        entityType: 'contact',
+        entityInstanceId: CONTACT_ID,
+        externalId: '99',
+      })
+    )
+  })
+
+  it('creates a customer when the email search misses', async () => {
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    const callTool = vi
+      .fn()
+      .mockResolvedValueOnce({ found: false, customer: null, notImportedReason: null })
+      .mockResolvedValueOnce({ customerId: '101', displayName: 'Jane Doe' })
+
+    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      contactInstanceId: CONTACT_ID,
+      contactFields: { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' },
+      handler,
+    })
+
+    expect(result).toBe('101')
+    expect(callTool).toHaveBeenNthCalledWith(
+      2,
+      'create_quickbooks_customer',
+      expect.objectContaining({
+        displayName: 'Jane Doe',
+        givenName: 'Jane',
+        familyName: 'Doe',
+        email: 'jane@example.com',
+      })
+    )
+  })
+
+  it('skips the email search and creates directly when the contact has no email', async () => {
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    const callTool = vi.fn().mockResolvedValue({ customerId: '202', displayName: 'Jane Doe' })
+
+    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      contactInstanceId: CONTACT_ID,
+      contactFields: { firstName: 'Jane', lastName: 'Doe' },
+      handler,
+    })
+
+    expect(result).toBe('202')
+    expect(callTool).toHaveBeenCalledTimes(1)
+    expect(callTool).toHaveBeenCalledWith(
+      'create_quickbooks_customer',
+      expect.objectContaining({ displayName: 'Jane Doe' })
+    )
+  })
+
+  it('throws when the contact has neither a name nor an email to create with', async () => {
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    const callTool = vi.fn()
+
+    await expect(
+      upsertQuickbooksCustomer(buildCtx(callTool), {
+        organizationId: ORG_ID,
+        contactInstanceId: CONTACT_ID,
+        contactFields: {},
+        handler,
+      })
+    ).rejects.toThrow(/no name or email/)
+    expect(callTool).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/money/quickbooks/__tests__/upsert-item.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/upsert-item.test.ts
@@ -1,0 +1,141 @@
+// packages/lib/src/money/quickbooks/__tests__/upsert-item.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const readQuickbooksIdField = vi.fn()
+const writeQuickbooksIdField = vi.fn()
+vi.mock('../identity-field', () => ({
+  readQuickbooksIdField: (...a: unknown[]) => readQuickbooksIdField(...a),
+  writeQuickbooksIdField: (...a: unknown[]) => writeQuickbooksIdField(...a),
+}))
+
+import type { QuickbooksToolContext } from '../invoke-quickbooks-tool'
+import { upsertQuickbooksItem } from '../upsert-item'
+
+const ORG_ID = 'org1'
+const CATALOG_ITEM_ID = 'catalog1'
+const handler = {} as never // opaque — only threaded through to the mocked identity-field reads
+
+function buildCtx(callTool = vi.fn()): QuickbooksToolContext {
+  return {
+    organizationId: ORG_ID,
+    installationId: 'install1',
+    connectionId: 'conn1',
+    userId: 'user1',
+    callTool,
+  }
+}
+
+beforeEach(() => {
+  readQuickbooksIdField.mockReset()
+  writeQuickbooksIdField.mockReset()
+})
+
+describe('upsertQuickbooksItem', () => {
+  it('returns the stored id for a catalog-linked line without calling any QuickBooks tool', async () => {
+    readQuickbooksIdField.mockResolvedValue('qbo-item-existing')
+    const callTool = vi.fn()
+
+    const result = await upsertQuickbooksItem(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      itemName: 'Quarterly Service',
+      catalogItemInstanceId: CATALOG_ITEM_ID,
+      defaultIncomeAccountId: 'acct-1',
+      handler,
+    })
+
+    expect(result).toBe('qbo-item-existing')
+    expect(callTool).not.toHaveBeenCalled()
+    expect(writeQuickbooksIdField).not.toHaveBeenCalled()
+  })
+
+  it('skips the stored-id check entirely for a line with no catalog item', async () => {
+    const callTool = vi.fn().mockImplementation(async (toolId: string) => {
+      if (toolId === 'list_quickbooks_items') return { items: [] }
+      if (toolId === 'create_quickbooks_item') return { itemId: '55' }
+      throw new Error(`unexpected: ${toolId}`)
+    })
+
+    const result = await upsertQuickbooksItem(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      itemName: 'Ad-hoc Line',
+      defaultIncomeAccountId: 'acct-1',
+      handler,
+    })
+
+    expect(result).toBe('55')
+    expect(readQuickbooksIdField).not.toHaveBeenCalled()
+    expect(writeQuickbooksIdField).not.toHaveBeenCalled() // no catalogItemInstanceId to write onto
+  })
+
+  it('matches an existing QBO item by case-insensitive name — no create call', async () => {
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    const callTool = vi.fn().mockImplementation(async (toolId: string) => {
+      if (toolId === 'list_quickbooks_items') {
+        return { items: [{ id: '61', name: 'quarterly service', type: 'Service' }] }
+      }
+      throw new Error(`unexpected: ${toolId}`)
+    })
+
+    const result = await upsertQuickbooksItem(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      itemName: 'Quarterly Service',
+      catalogItemInstanceId: CATALOG_ITEM_ID,
+      defaultIncomeAccountId: 'acct-1',
+      handler,
+    })
+
+    expect(result).toBe('61')
+    expect(callTool).not.toHaveBeenCalledWith('create_quickbooks_item', expect.anything())
+    expect(writeQuickbooksIdField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appFieldKey: 'qboItemId',
+        entityType: 'catalog_item',
+        entityInstanceId: CATALOG_ITEM_ID,
+        externalId: '61',
+      })
+    )
+  })
+
+  it('creates a new item against the default income account when no name match is found', async () => {
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    const callTool = vi.fn().mockImplementation(async (toolId: string) => {
+      if (toolId === 'list_quickbooks_items') return { items: [] }
+      if (toolId === 'create_quickbooks_item') return { itemId: '77' }
+      throw new Error(`unexpected: ${toolId}`)
+    })
+
+    const result = await upsertQuickbooksItem(buildCtx(callTool), {
+      organizationId: ORG_ID,
+      itemName: 'Brand New Service',
+      catalogItemInstanceId: CATALOG_ITEM_ID,
+      defaultIncomeAccountId: 'acct-1',
+      handler,
+    })
+
+    expect(result).toBe('77')
+    expect(callTool).toHaveBeenCalledWith('create_quickbooks_item', {
+      name: 'Brand New Service',
+      incomeAccountId: 'acct-1',
+    })
+  })
+
+  it('throws a clear error when a create is needed but no default income account is configured', async () => {
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    const callTool = vi.fn().mockImplementation(async (toolId: string) => {
+      if (toolId === 'list_quickbooks_items') return { items: [] }
+      throw new Error(`unexpected: ${toolId}`)
+    })
+
+    await expect(
+      upsertQuickbooksItem(buildCtx(callTool), {
+        organizationId: ORG_ID,
+        itemName: 'Brand New Service',
+        catalogItemInstanceId: CATALOG_ITEM_ID,
+        defaultIncomeAccountId: null,
+        handler,
+      })
+    ).rejects.toThrow(/default income account/)
+    expect(callTool).not.toHaveBeenCalledWith('create_quickbooks_item', expect.anything())
+  })
+})

--- a/packages/lib/src/money/quickbooks/identity-field.ts
+++ b/packages/lib/src/money/quickbooks/identity-field.ts
@@ -1,0 +1,145 @@
+// packages/lib/src/money/quickbooks/identity-field.ts
+//
+// Read/write the QuickBooks id-map fields (`qboCustomerId` / `qboItemId` / `qboInvoiceId`,
+// declared by the app as hidden, connection-scoped `identity: true` fields — see
+// auxxai-apps/apps/quickbooks/src/fields.ts). Mirrors the exact write-through
+// `writeShopifyCustomerIdField` established (`packages/lib/src/chat/shopify-identity-field.ts`):
+// `FieldValueService.setValue` writes the cell, `upsertRecordIdentity` mirrors it into
+// `RecordIdentity` so the reverse lookup (`findByIntegrationId`) and future reverse-sync
+// converge on the same cell. Shared across upsert-customer/upsert-item/sync-invoice so the
+// (appInstallationId, connectionId, appFieldKey) → CustomField resolution isn't repeated
+// three times.
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { extractValue } from '@auxx/types'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { getCachedEntityDefId } from '../../cache'
+import { FieldValueService } from '../../field-values/field-value-service'
+import { upsertRecordIdentity } from '../../identity'
+import type { UnifiedCrudHandler } from '../../resources/crud'
+
+const logger = createScopedLogger('quickbooks-identity-field')
+
+/** `RecordIdentity.source` for every id-map field this module reads/writes. */
+export const QUICKBOOKS_SOURCE = 'quickbooks'
+
+/** Resolve the connection-scoped `CustomField` the QuickBooks app provisioned for one identity key. */
+async function findAppField(params: {
+  organizationId: string
+  installationId: string
+  connectionId: string
+  appFieldKey: string
+}): Promise<{ id: string } | undefined> {
+  return database.query.CustomField.findFirst({
+    where: and(
+      eq(schema.CustomField.organizationId, params.organizationId),
+      eq(schema.CustomField.appInstallationId, params.installationId),
+      eq(schema.CustomField.connectionId, params.connectionId),
+      eq(schema.CustomField.appFieldKey, params.appFieldKey)
+    ),
+    columns: { id: true },
+  })
+}
+
+/**
+ * Read a QuickBooks id-map field's current value off a record (e.g. does this contact
+ * already have a `qboCustomerId`?). Returns `undefined` when the field isn't provisioned or
+ * has never been written — both are "no stored id, fall through to find-or-create".
+ */
+export async function readQuickbooksIdField(params: {
+  organizationId: string
+  installationId: string
+  connectionId: string
+  appFieldKey: string
+  recordId: RecordId
+  handler: UnifiedCrudHandler
+}): Promise<string | undefined> {
+  const field = await findAppField(params)
+  if (!field) return undefined
+
+  const values = await params.handler.getFieldValues(params.recordId, [field.id])
+  const entry = values.get(field.id)
+  const typed = Array.isArray(entry) ? entry[0] : entry
+  if (!typed) return undefined
+
+  const value = extractValue(typed)
+  return typeof value === 'string' && value ? value : undefined
+}
+
+/**
+ * Write a QuickBooks external id back onto a record's id-map field, then mirror it into
+ * `RecordIdentity`. Best-effort on the mirror step only — a missed `RecordIdentity` write is
+ * logged and swallowed (the reconciler is the backstop); the `FieldValueService.setValue` call
+ * itself is allowed to throw, since a failed cell write means the sync genuinely didn't
+ * complete and the caller's try/catch should surface `status: 'error'`.
+ */
+export async function writeQuickbooksIdField(params: {
+  organizationId: string
+  installationId: string
+  connectionId: string
+  appFieldKey: string
+  /** System entity type slug ('contact' | 'catalog_item' | 'invoice') — not the UUID def id. */
+  entityType: string
+  entityInstanceId: string
+  externalId: string
+  userId?: string
+}): Promise<void> {
+  const {
+    organizationId,
+    installationId,
+    connectionId,
+    appFieldKey,
+    entityType,
+    entityInstanceId,
+    externalId,
+    userId,
+  } = params
+
+  const field = await findAppField({ organizationId, installationId, connectionId, appFieldKey })
+  if (!field) {
+    logger.warn('QuickBooks id-map field not provisioned — skipping write', {
+      organizationId,
+      appFieldKey,
+    })
+    return
+  }
+
+  const service = new FieldValueService(organizationId, userId)
+  await service.setValue({
+    recordId: toRecordId(entityType, entityInstanceId),
+    fieldId: field.id,
+    value: externalId,
+  })
+
+  const entityDefId = await getCachedEntityDefId(organizationId, entityType)
+  if (!entityDefId) {
+    logger.warn('No entity definition found — skipping RecordIdentity mirror', {
+      organizationId,
+      entityType,
+    })
+    return
+  }
+
+  const mirrored = await upsertRecordIdentity({
+    organizationId,
+    entityInstanceId,
+    entityDefinitionId: entityDefId,
+    source: QUICKBOOKS_SOURCE,
+    appInstallationId: installationId,
+    connectionId,
+    appFieldKey,
+    fieldId: field.id,
+    externalId,
+  })
+  if (!mirrored.ok) {
+    logger.warn('Failed to mirror QuickBooks id into RecordIdentity', {
+      organizationId,
+      entityType,
+      entityInstanceId,
+      appFieldKey,
+      error: mirrored.error.message,
+    })
+  }
+}

--- a/packages/lib/src/money/quickbooks/invoke-quickbooks-tool.ts
+++ b/packages/lib/src/money/quickbooks/invoke-quickbooks-tool.ts
@@ -1,0 +1,177 @@
+// packages/lib/src/money/quickbooks/invoke-quickbooks-tool.ts
+//
+// Resolves the QuickBooks app installation + deployment + connection for an org ONCE, then
+// exposes a `callTool` closure that drives `invokeLambdaExecutor` — the same
+// installation → deployment → connection → Lambda chain `quick-action-executor.ts` uses for
+// quick actions (`packages/lib/src/quick-actions/quick-action-executor.ts`). Callers (the
+// invoice-sync orchestrator, and later the payment-push orchestrator) resolve this once per
+// run and reuse it across every `find_/create_/update_quickbooks_*` tool call.
+
+import { database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getCachedInstalledApps, getOrgCache } from '../../cache'
+
+const logger = createScopedLogger('quickbooks-invoke-tool')
+
+const QUICKBOOKS_APP_SLUG = 'quickbooks'
+/**
+ * Caller identity threaded through `invokeLambdaExecutor`'s HMAC signature + allowlist.
+ * A general "platform-initiated app-tool orchestration" origin — shared by invoice sync,
+ * the upcoming payment push, and any future outbound integration sync — not a per-feature
+ * caller. See `CALLER_TYPE_ALLOWLIST` in `apps/lambda/src/index.ts`.
+ */
+const CALLER = 'integration-sync'
+/** Matches the quick-action-executor's per-call Lambda timeout. */
+const TOOL_TIMEOUT_MS = 30_000
+
+/**
+ * Reusable QuickBooks Lambda-runtime handle — resolved once per sync run, then used to call
+ * as many app tools as needed without re-resolving the installation/deployment/connection
+ * chain per call.
+ */
+export interface QuickbooksToolContext {
+  organizationId: string
+  installationId: string
+  /** The resolved Credential id (org- or user-scoped) — connection-scoped `CustomField` rows key off this. */
+  connectionId: string
+  /** `actorUserId` if given, else the org's system user — used for entity reads/writes too. */
+  userId: string
+  /** `connection.metadata.realmId`, when present — informational, not required by callers. */
+  realmId?: string
+  /** Invoke one QuickBooks app tool by id, returning its unwrapped `execution_result.data`. */
+  callTool: (toolId: string, inputs: Record<string, unknown>) => Promise<any>
+}
+
+export type ResolveQuickbooksContextResult =
+  | { connected: true; context: QuickbooksToolContext }
+  | { connected: false }
+
+/**
+ * Resolve the QuickBooks app installation + deployment + connection for an org.
+ *
+ * `connected: false` covers every reason a sync can't proceed — the app isn't installed, has
+ * no active deployment, or has neither an org- nor user-scoped connection — so the caller
+ * (`syncInvoiceToQuickbooks`) can collapse all of them into `status: 'not_connected'` without
+ * branching on why.
+ */
+export async function resolveQuickbooksContext(input: {
+  organizationId: string
+  actorUserId?: string
+}): Promise<ResolveQuickbooksContextResult> {
+  const { organizationId, actorUserId } = input
+
+  const installedApps = await getCachedInstalledApps(organizationId)
+  const qbInstall = installedApps.find((a) => a.app.slug === QUICKBOOKS_APP_SLUG)
+  if (!qbInstall) return { connected: false }
+
+  const userId = actorUserId ?? (await getOrgCache().get(organizationId, 'systemUser'))
+
+  const org = await database.query.Organization.findFirst({
+    where: (t, { eq }) => eq(t.id, organizationId),
+    columns: { handle: true },
+  })
+  if (!org?.handle) {
+    logger.warn('No organization handle — cannot resolve QuickBooks deployment', {
+      organizationId,
+    })
+    return { connected: false }
+  }
+
+  // Lazy imports keep the app-runtime cluster out of this module's static graph
+  // (mirrors quick-action-executor.ts).
+  const { getInstallationDeployment } = await import(
+    '../../apps/installations/get-installation-deployment'
+  )
+  const { resolveAppConnectionForRuntime } = await import(
+    '../../apps/connections/resolve-app-connection-for-runtime'
+  )
+  const { prepareLambdaContext, invokeLambdaExecutor } = await import('../../apps/lambda')
+
+  const deploymentResult = await getInstallationDeployment({
+    installationId: qbInstall.installationId,
+    organizationHandle: org.handle,
+    appId: qbInstall.app.id,
+  })
+  if (deploymentResult.isErr()) {
+    logger.warn('Failed to resolve QuickBooks installation deployment', {
+      organizationId,
+      error: deploymentResult.error.message,
+    })
+    return { connected: false }
+  }
+  const { serverBundleSha, installation } = deploymentResult.value
+  if (!serverBundleSha) return { connected: false }
+
+  const connectionsResult = await resolveAppConnectionForRuntime({
+    appId: qbInstall.app.id,
+    organizationId,
+    userId,
+  })
+  if (connectionsResult.isErr()) {
+    logger.warn('Failed to resolve QuickBooks connection', {
+      organizationId,
+      error: connectionsResult.error.message,
+    })
+    return { connected: false }
+  }
+  const { organizationConnection, userConnection } = connectionsResult.value
+  const connection = organizationConnection ?? userConnection
+  if (!connection) return { connected: false }
+
+  const baseContext = prepareLambdaContext({
+    appId: qbInstall.app.id,
+    installationId: installation.id,
+    organizationId,
+    organizationHandle: org.handle,
+    userId,
+    userEmail: null,
+    userName: null,
+    userConnection,
+    organizationConnection,
+    // The customer/item tools call back into entities (e.g. resolving an existing
+    // auxxContactId) via the SDK's entity value-I/O — requires the `entities` scope.
+    includeEntitiesScope: true,
+  })
+
+  const callTool = async (toolId: string, inputs: Record<string, unknown>): Promise<any> => {
+    const result = await invokeLambdaExecutor({
+      caller: CALLER,
+      payload: {
+        type: 'tool',
+        serverBundleSha,
+        toolId,
+        inputs,
+        context: baseContext,
+        timeout: TOOL_TIMEOUT_MS,
+      },
+    })
+
+    if (result.isErr()) {
+      throw new Error(`QuickBooks tool ${toolId} failed: ${result.error.message}`)
+    }
+
+    const { execution_result: executionResult, metadata } = result.value
+    if (metadata?.runtime_error) {
+      throw new Error(`QuickBooks tool ${toolId} runtime error: ${metadata.runtime_error.message}`)
+    }
+    if (metadata?.validation_error) {
+      throw new Error(
+        `QuickBooks tool ${toolId} validation error: ${metadata.validation_error.message}`
+      )
+    }
+
+    return executionResult?.data ?? executionResult ?? {}
+  }
+
+  return {
+    connected: true,
+    context: {
+      organizationId,
+      installationId: installation.id,
+      connectionId: connection.id,
+      userId,
+      realmId: connection.metadata?.realmId,
+      callTool,
+    },
+  }
+}

--- a/packages/lib/src/money/quickbooks/sync-invoice.ts
+++ b/packages/lib/src/money/quickbooks/sync-invoice.ts
@@ -1,0 +1,324 @@
+// packages/lib/src/money/quickbooks/sync-invoice.ts
+//
+// Orchestrator CORE for QuickBooks invoice sync (plan 37e-quickbooks-invoice-sync.md §3, P3).
+// Mirrors an Auxx invoice into QuickBooks Online: find-or-create the customer + line items,
+// then create-or-update the invoice, keyed on the `qboInvoiceId` id-map field so re-runs
+// converge instead of duplicating. Never sends the invoice — Auxx owns delivery (decision D3).
+//
+// This module is invocation-agnostic on purpose: a separate task wires the BullMQ queue, the
+// `invoice_status: draft→sent` field-change hook, the worker, and the tRPC "Sync to QuickBooks"
+// mutation — all of them just call `syncInvoiceToQuickbooks()`.
+
+import { createScopedLogger } from '@auxx/logger'
+import { extractValue, type TypedFieldValue } from '@auxx/types'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { getOrgCache } from '../../cache'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import { getOrganizationSetting } from '../../settings/settings-service'
+import { readQuickbooksIdField, writeQuickbooksIdField } from './identity-field'
+import { resolveQuickbooksContext } from './invoke-quickbooks-tool'
+import { upsertQuickbooksCustomer } from './upsert-customer'
+import { upsertQuickbooksItem } from './upsert-item'
+
+const logger = createScopedLogger('quickbooks-sync-invoice')
+
+const QBO_INVOICE_ID_FIELD_KEY = 'qboInvoiceId'
+
+export interface SyncInvoiceToQuickbooksInput {
+  organizationId: string
+  invoiceInstanceId: string
+  /**
+   * Actor for entity reads/writes and the app connection's user-scope resolution. Falls back
+   * to the org's system user when absent — the actor-less Stripe-webhook `paid` transition is
+   * exactly why this is optional (plan §3 "Why code, not a workflow").
+   */
+  actorUserId?: string
+}
+
+export interface SyncInvoiceResult {
+  status: 'synced' | 'disabled' | 'not_connected' | 'error'
+  qboInvoiceId?: string
+  error?: string
+}
+
+/** Unwrap a `getFieldValues()` map entry — takes the first value if array-returned. */
+function firstTyped(
+  entry: TypedFieldValue | TypedFieldValue[] | undefined
+): TypedFieldValue | undefined {
+  return Array.isArray(entry) ? entry[0] : entry
+}
+
+function stringValue(entry: TypedFieldValue | TypedFieldValue[] | undefined): string | undefined {
+  const typed = firstTyped(entry)
+  if (!typed) return undefined
+  const value = extractValue(typed)
+  return typeof value === 'string' && value ? value : undefined
+}
+
+function numberValue(entry: TypedFieldValue | TypedFieldValue[] | undefined): number | undefined {
+  const typed = firstTyped(entry)
+  if (!typed) return undefined
+  const value = extractValue(typed)
+  return typeof value === 'number' ? value : undefined
+}
+
+/**
+ * QBO date fields require a bare `YYYY-MM-DD`; Auxx DATE fields extract as a full
+ * timestamp string (e.g. `2026-08-10 00:00:00+00`) or a `Date`. Normalise to the
+ * calendar date, or return undefined if it isn't a parseable date.
+ */
+function toQboDate(entry: TypedFieldValue | TypedFieldValue[] | undefined): string | undefined {
+  const typed = firstTyped(entry)
+  if (!typed) return undefined
+  const value = extractValue(typed)
+  if (value instanceof Date) return value.toISOString().slice(0, 10)
+  if (typeof value === 'string') {
+    const match = value.match(/^\d{4}-\d{2}-\d{2}/)
+    return match ? match[0] : undefined
+  }
+  return undefined
+}
+
+interface QuickbooksInvoiceLine {
+  itemId: string
+  amount: number
+  quantity?: number
+  description?: string
+}
+
+/**
+ * Mirror an Auxx invoice into QuickBooks Online (money plan 37e-quickbooks-invoice-sync.md §3).
+ *
+ * Never throws — disabled, not-connected, and every failure mid-chain (missing contact, no
+ * billable lines, missing default income account, a QBO tool error) all resolve to a typed
+ * `status` instead, so callers (a BullMQ job, a tRPC mutation) can persist the outcome without
+ * their own try/catch.
+ */
+export async function syncInvoiceToQuickbooks(
+  input: SyncInvoiceToQuickbooksInput
+): Promise<SyncInvoiceResult> {
+  const { organizationId, invoiceInstanceId, actorUserId } = input
+
+  try {
+    const syncEnabled = await getOrganizationSetting({
+      organizationId,
+      key: 'quickbooks.syncInvoices',
+    })
+    if (!syncEnabled) return { status: 'disabled' }
+
+    const resolved = await resolveQuickbooksContext({ organizationId, actorUserId })
+    if (!resolved.connected) return { status: 'not_connected' }
+    const ctx = resolved.context
+
+    const handler = new UnifiedCrudHandler(organizationId, ctx.userId)
+    const invoiceRecordId = toRecordId('invoice', invoiceInstanceId)
+    const cache = getOrgCache()
+
+    // ── 1. Invoice's own fields ──────────────────────────────────────────
+    const invoiceCf = await cache
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['invoice_number', 'invoice_due_date', 'invoice_contact'] as const)
+
+    const invoiceFieldIds = [
+      invoiceCf.invoice_number,
+      invoiceCf.invoice_due_date,
+      invoiceCf.invoice_contact,
+    ]
+      .filter(Boolean)
+      .map((f) => f!.id)
+    const invoiceValues = await handler.getFieldValues(invoiceRecordId, invoiceFieldIds)
+
+    const invoiceNumber = invoiceCf.invoice_number
+      ? stringValue(invoiceValues.get(invoiceCf.invoice_number.id))
+      : undefined
+    const dueDate = invoiceCf.invoice_due_date
+      ? toQboDate(invoiceValues.get(invoiceCf.invoice_due_date.id))
+      : undefined
+    const contactRecordIdStr = invoiceCf.invoice_contact
+      ? stringValue(invoiceValues.get(invoiceCf.invoice_contact.id))
+      : undefined
+
+    if (!contactRecordIdStr) {
+      throw new Error(`Invoice ${invoiceInstanceId} has no contact — cannot sync to QuickBooks`)
+    }
+    const { entityInstanceId: contactInstanceId } = parseRecordId(contactRecordIdStr as RecordId)
+    const contactRecordId = toRecordId('contact', contactInstanceId)
+
+    // ── 2. Contact's fields → customer upsert ────────────────────────────
+    const contactCf = await cache
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['first_name', 'last_name', 'primary_email'] as const)
+    const contactFieldIds = [contactCf.first_name, contactCf.last_name, contactCf.primary_email]
+      .filter(Boolean)
+      .map((f) => f!.id)
+    const contactValues = await handler.getFieldValues(contactRecordId, contactFieldIds)
+
+    const contactFields = {
+      firstName: contactCf.first_name
+        ? stringValue(contactValues.get(contactCf.first_name.id))
+        : undefined,
+      lastName: contactCf.last_name
+        ? stringValue(contactValues.get(contactCf.last_name.id))
+        : undefined,
+      primaryEmail: contactCf.primary_email
+        ? stringValue(contactValues.get(contactCf.primary_email.id))
+        : undefined,
+    }
+
+    const qboCustomerId = await upsertQuickbooksCustomer(ctx, {
+      organizationId,
+      contactInstanceId,
+      contactFields,
+      handler,
+    })
+
+    // ── 3. Lines → item upserts (skip $0 lines entirely) ─────────────────
+    const defaultIncomeAccountId = (await getOrganizationSetting({
+      organizationId,
+      key: 'quickbooks.defaultIncomeAccountId',
+    })) as string | null
+
+    const lineCf = await cache
+      .from(organizationId, 'customFields')
+      .bySystemAttributes([
+        'line_item_line_total',
+        'line_item_qty',
+        'line_item_name',
+        'line_item_catalog_item',
+      ] as const)
+
+    const { ids: lineInstanceIds } = await handler.listFiltered({
+      entityDefinitionId: 'line_item',
+      filters: [
+        {
+          id: 'invoice-lines',
+          logicalOperator: 'AND',
+          conditions: [
+            {
+              id: 'invoice-lines-invoice',
+              fieldId: 'line_item:invoice',
+              operator: 'is',
+              value: invoiceRecordId,
+            },
+            {
+              id: 'invoice-lines-workorder',
+              fieldId: 'line_item:workOrder',
+              operator: 'empty',
+              value: null,
+            },
+          ],
+        },
+      ],
+      limit: 1000,
+      mode: 'oneshot',
+    })
+
+    const qboLines: QuickbooksInvoiceLine[] = []
+
+    if (lineCf.line_item_line_total) {
+      const lineFieldIds = [
+        lineCf.line_item_line_total,
+        lineCf.line_item_qty,
+        lineCf.line_item_name,
+        lineCf.line_item_catalog_item,
+      ]
+        .filter(Boolean)
+        .map((f) => f!.id)
+
+      for (const lineInstanceId of lineInstanceIds) {
+        const lineRecordId = toRecordId('line_item', lineInstanceId)
+        const lineValues = await handler.getFieldValues(lineRecordId, lineFieldIds)
+
+        const lineTotalCents = numberValue(lineValues.get(lineCf.line_item_line_total.id))
+        if (!lineTotalCents || lineTotalCents <= 0) continue // §3: $0 lines skipped entirely
+
+        const qty = lineCf.line_item_qty
+          ? numberValue(lineValues.get(lineCf.line_item_qty.id))
+          : undefined
+        const lineName = lineCf.line_item_name
+          ? stringValue(lineValues.get(lineCf.line_item_name.id))
+          : undefined
+        const catalogItemRecordIdStr = lineCf.line_item_catalog_item
+          ? stringValue(lineValues.get(lineCf.line_item_catalog_item.id))
+          : undefined
+        const catalogItemInstanceId = catalogItemRecordIdStr
+          ? parseRecordId(catalogItemRecordIdStr as RecordId).entityInstanceId
+          : undefined
+
+        const itemName = lineName || 'Item'
+        const qboItemId = await upsertQuickbooksItem(ctx, {
+          organizationId,
+          itemName,
+          catalogItemInstanceId,
+          defaultIncomeAccountId,
+          handler,
+        })
+
+        qboLines.push({
+          itemId: qboItemId,
+          amount: lineTotalCents / 100,
+          quantity: qty ?? 1,
+          description: itemName,
+        })
+      }
+    }
+
+    if (qboLines.length === 0) {
+      throw new Error(`Invoice ${invoiceInstanceId} has no billable lines to sync to QuickBooks`)
+    }
+
+    // ── 4. Create-or-update the invoice (idempotency guarantee) ──────────
+    const storedQboInvoiceId = await readQuickbooksIdField({
+      organizationId,
+      installationId: ctx.installationId,
+      connectionId: ctx.connectionId,
+      appFieldKey: QBO_INVOICE_ID_FIELD_KEY,
+      recordId: invoiceRecordId,
+      handler,
+    })
+
+    const sharedFields = {
+      ...(invoiceNumber ? { docNumber: invoiceNumber } : {}),
+      ...(dueDate ? { dueDate } : {}),
+      ...(contactFields.primaryEmail ? { billEmail: contactFields.primaryEmail } : {}),
+    }
+
+    let qboInvoiceId: string
+    if (storedQboInvoiceId) {
+      const updated = await ctx.callTool('update_quickbooks_invoice', {
+        invoiceId: storedQboInvoiceId,
+        lines: qboLines,
+        ...sharedFields,
+      })
+      qboInvoiceId = String(updated.invoiceId)
+    } else {
+      const created = await ctx.callTool('create_quickbooks_invoice', {
+        customerId: qboCustomerId,
+        lines: qboLines,
+        ...sharedFields,
+      })
+      qboInvoiceId = String(created.invoiceId)
+    }
+
+    await writeQuickbooksIdField({
+      organizationId,
+      installationId: ctx.installationId,
+      connectionId: ctx.connectionId,
+      appFieldKey: QBO_INVOICE_ID_FIELD_KEY,
+      entityType: 'invoice',
+      entityInstanceId: invoiceInstanceId,
+      externalId: qboInvoiceId,
+      userId: ctx.userId,
+    })
+
+    return { status: 'synced', qboInvoiceId }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    logger.error('QuickBooks invoice sync failed', {
+      organizationId,
+      invoiceInstanceId,
+      error: message,
+    })
+    return { status: 'error', error: message }
+  }
+}

--- a/packages/lib/src/money/quickbooks/upsert-customer.ts
+++ b/packages/lib/src/money/quickbooks/upsert-customer.ts
@@ -1,0 +1,92 @@
+// packages/lib/src/money/quickbooks/upsert-customer.ts
+
+import { toRecordId } from '@auxx/types/resource'
+import type { UnifiedCrudHandler } from '../../resources/crud'
+import { readQuickbooksIdField, writeQuickbooksIdField } from './identity-field'
+import type { QuickbooksToolContext } from './invoke-quickbooks-tool'
+
+const QBO_CUSTOMER_ID_FIELD_KEY = 'qboCustomerId'
+
+export interface UpsertQuickbooksCustomerInput {
+  organizationId: string
+  contactInstanceId: string
+  contactFields: {
+    firstName?: string
+    lastName?: string
+    primaryEmail?: string
+  }
+  handler: UnifiedCrudHandler
+}
+
+/**
+ * Find-or-create the QuickBooks `Customer` mapped to an Auxx contact (money plan
+ * 37e-quickbooks-invoice-sync.md §3 step 2, decision D4). Resolution order:
+ *
+ * 1. Stored `qboCustomerId` id-map field on the contact — the fast, idempotent path.
+ * 2. `find_quickbooks_customer` by the contact's exact primary email — avoids the category's
+ *    #1 pain (Jobber: duplicate customers from name matching); only attempted when the
+ *    contact has an email.
+ * 3. `create_quickbooks_customer`.
+ *
+ * The resolved id is always written back (field + `RecordIdentity` mirror), even when found
+ * rather than created, so step 1 short-circuits on the next sync.
+ */
+export async function upsertQuickbooksCustomer(
+  ctx: QuickbooksToolContext,
+  input: UpsertQuickbooksCustomerInput
+): Promise<string> {
+  const { organizationId, contactInstanceId, contactFields, handler } = input
+  const contactRecordId = toRecordId('contact', contactInstanceId)
+
+  const stored = await readQuickbooksIdField({
+    organizationId,
+    installationId: ctx.installationId,
+    connectionId: ctx.connectionId,
+    appFieldKey: QBO_CUSTOMER_ID_FIELD_KEY,
+    recordId: contactRecordId,
+    handler,
+  })
+  if (stored) return stored
+
+  const email = contactFields.primaryEmail?.trim() || undefined
+  const displayName =
+    [contactFields.firstName, contactFields.lastName].filter(Boolean).join(' ').trim() || undefined
+
+  let qboCustomerId: string | undefined
+
+  if (email) {
+    const found = await ctx.callTool('find_quickbooks_customer', { email })
+    if (found?.found && found.customer?.customerId) {
+      qboCustomerId = String(found.customer.customerId)
+    }
+  }
+
+  if (!qboCustomerId) {
+    if (!displayName) {
+      throw new Error(
+        `Cannot create a QuickBooks customer for contact ${contactInstanceId} — it has no name ` +
+          'or email.'
+      )
+    }
+    const created = await ctx.callTool('create_quickbooks_customer', {
+      displayName,
+      ...(contactFields.firstName ? { givenName: contactFields.firstName } : {}),
+      ...(contactFields.lastName ? { familyName: contactFields.lastName } : {}),
+      ...(email ? { email } : {}),
+    })
+    qboCustomerId = String(created.customerId)
+  }
+
+  await writeQuickbooksIdField({
+    organizationId,
+    installationId: ctx.installationId,
+    connectionId: ctx.connectionId,
+    appFieldKey: QBO_CUSTOMER_ID_FIELD_KEY,
+    entityType: 'contact',
+    entityInstanceId: contactInstanceId,
+    externalId: qboCustomerId,
+    userId: ctx.userId,
+  })
+
+  return qboCustomerId
+}

--- a/packages/lib/src/money/quickbooks/upsert-item.ts
+++ b/packages/lib/src/money/quickbooks/upsert-item.ts
@@ -1,0 +1,89 @@
+// packages/lib/src/money/quickbooks/upsert-item.ts
+
+import { toRecordId } from '@auxx/types/resource'
+import type { UnifiedCrudHandler } from '../../resources/crud'
+import { readQuickbooksIdField, writeQuickbooksIdField } from './identity-field'
+import type { QuickbooksToolContext } from './invoke-quickbooks-tool'
+
+const QBO_ITEM_ID_FIELD_KEY = 'qboItemId'
+
+export interface UpsertQuickbooksItemInput {
+  organizationId: string
+  /** Line name used to create/match the QBO item — `line_item_name`, never the catalog default. */
+  itemName: string
+  /** Present when the line was picked from the catalog — enables the id-map fast path + write-back. */
+  catalogItemInstanceId?: string
+  /** `quickbooks.defaultIncomeAccountId` org setting — required only when a create is needed. */
+  defaultIncomeAccountId?: string | null
+  handler: UnifiedCrudHandler
+}
+
+/**
+ * Find-or-create the QuickBooks `Item` mapped to an invoice line (money plan
+ * 37e-quickbooks-invoice-sync.md §3 step 3, decision D5). Resolution order:
+ *
+ * 1. Stored `qboItemId` id-map field on the line's catalog item — only checked when the line
+ *    has one (ad-hoc lines with no `line_item_catalog_item` always fall through).
+ * 2. Case-insensitive name match against `list_quickbooks_items`.
+ * 3. `create_quickbooks_item` against the org's default income account — throws a clear error
+ *    (mapped to `status: 'error'` by the caller) when no default account is configured, since
+ *    QBO requires one for every Service item.
+ *
+ * Only writes the id-map field back when `catalogItemInstanceId` is given — a one-off line
+ * with no catalog item has nothing to remember the mapping on.
+ */
+export async function upsertQuickbooksItem(
+  ctx: QuickbooksToolContext,
+  input: UpsertQuickbooksItemInput
+): Promise<string> {
+  const { organizationId, itemName, catalogItemInstanceId, defaultIncomeAccountId, handler } = input
+
+  if (catalogItemInstanceId) {
+    const stored = await readQuickbooksIdField({
+      organizationId,
+      installationId: ctx.installationId,
+      connectionId: ctx.connectionId,
+      appFieldKey: QBO_ITEM_ID_FIELD_KEY,
+      recordId: toRecordId('catalog_item', catalogItemInstanceId),
+      handler,
+    })
+    if (stored) return stored
+  }
+
+  const { items } = await ctx.callTool('list_quickbooks_items', {})
+  const nameMatch = (items ?? []).find(
+    (item: { id: string; name: string }) => item.name?.toLowerCase() === itemName.toLowerCase()
+  )
+
+  let qboItemId: string
+  if (nameMatch) {
+    qboItemId = String(nameMatch.id)
+  } else {
+    if (!defaultIncomeAccountId) {
+      throw new Error(
+        `Cannot create a QuickBooks item for "${itemName}" — set a default income account under ` +
+          'Settings → Money → Invoicing → QuickBooks first.'
+      )
+    }
+    const created = await ctx.callTool('create_quickbooks_item', {
+      name: itemName,
+      incomeAccountId: defaultIncomeAccountId,
+    })
+    qboItemId = String(created.itemId)
+  }
+
+  if (catalogItemInstanceId) {
+    await writeQuickbooksIdField({
+      organizationId,
+      installationId: ctx.installationId,
+      connectionId: ctx.connectionId,
+      appFieldKey: QBO_ITEM_ID_FIELD_KEY,
+      entityType: 'catalog_item',
+      entityInstanceId: catalogItemInstanceId,
+      externalId: qboItemId,
+      userId: ctx.userId,
+    })
+  }
+
+  return qboItemId
+}

--- a/packages/lib/src/sequences/field-change-hooks.ts
+++ b/packages/lib/src/sequences/field-change-hooks.ts
@@ -8,6 +8,8 @@ import type { TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
 import { parseRecordId } from '@auxx/types/resource'
 import type { EntityFieldChangeHandler } from '../field-hooks/types'
+import { getQueue, Queues } from '../jobs/queues'
+import { getOrganizationSetting } from '../settings/settings-service'
 import { enrollInvoiceSentSequences, enrollWorkOrderCompletedSequences } from './hooks'
 import { reanchorSequenceRuns } from './reanchor'
 
@@ -63,6 +65,46 @@ export const enrollInvoiceReminderOnSent: EntityFieldChangeHandler = async (even
     await enrollInvoiceSentSequences(event.organizationId, entityInstanceId)
   } catch (error) {
     logger.error('Failed to enroll invoice:sent sequences', {
+      organizationId: event.organizationId,
+      invoiceInstanceId: entityInstanceId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * `invoice:sent` — QuickBooks mirror (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3).
+ * Same draft→sent door as {@link enrollInvoiceReminderOnSent}, enqueued rather than run inline
+ * (D8 — the queue route also covers the actor-less Stripe `paid` path elsewhere, and keeps this
+ * hook from blocking the field write on an outbound QBO API call). Gated by
+ * `quickbooks.syncInvoices` up front so the queue sees no churn when the org has the feature
+ * off. Deterministic `jobId` de-dupes rapid re-sends of the same invoice.
+ */
+export const enqueueQuickbooksInvoiceSyncOnSent: EntityFieldChangeHandler = async (event) => {
+  if (event.field.systemAttribute !== 'invoice_status') return
+  const oldStatus = extractStringValue(event.oldValue)
+  const newStatus = extractStringValue(event.newValue)
+  if (oldStatus !== 'draft' || newStatus !== 'sent') return
+
+  const { entityInstanceId } = parseRecordId(event.recordId)
+  try {
+    const syncEnabled = await getOrganizationSetting({
+      organizationId: event.organizationId,
+      key: 'quickbooks.syncInvoices',
+    })
+    if (!syncEnabled) return
+
+    await getQueue(Queues.quickbooksInvoiceSyncQueue).add(
+      'syncQuickbooksInvoice',
+      {
+        organizationId: event.organizationId,
+        invoiceInstanceId: entityInstanceId,
+        actorUserId: event.userId,
+      },
+      { jobId: `qb-invoice-sync:${entityInstanceId}` }
+    )
+  } catch (error) {
+    logger.error('Failed to enqueue QuickBooks invoice sync on invoice:sent', {
       organizationId: event.organizationId,
       invoiceInstanceId: entityInstanceId,
       error: error instanceof Error ? error.message : String(error),

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -717,6 +717,23 @@ export const SETTINGS_CATALOG = {
     defaultValue: true,
     description: 'Show payment history on invoice PDFs (MI1 consumes)',
   },
+
+  // ── QuickBooks invoice sync (plans/dispatch/37e-quickbooks-invoice-sync.md P1) ──────────
+  'quickbooks.syncInvoices': {
+    scope: 'DOCUMENTS',
+    access: 'org',
+    fieldType: 'CHECKBOX',
+    options: { variant: 'switch' },
+    defaultValue: false,
+    description: 'When on, sending an Auxx invoice mirrors it into QuickBooks Online.',
+  },
+  'quickbooks.defaultIncomeAccountId': {
+    scope: 'DOCUMENTS',
+    access: 'org',
+    fieldType: 'TEXT',
+    defaultValue: null,
+    description: 'QBO income account id used when auto-creating service items.',
+  },
 } satisfies Record<string, SettingConfig>
 
 /**

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -65,6 +65,8 @@ export type EntityRefKind =
   | 'user'
   | 'article'
   | 'thread'
+  | 'invoice'
+  | 'catalog_item'
 
 /**
  * Per-tool configuration. See plans/kopilot/apps/README.md §4.2.


### PR DESCRIPTION
## What

Mirror Auxx invoices into QuickBooks Online — P1–P3 of `plans/dispatch/37e-quickbooks-invoice-sync.md`. One-way, Auxx is source of truth. When an invoice goes `draft→sent` (or via a manual action), it upserts the customer + line items and creates/updates the QBO invoice, remembering QBO ids so it never double-bills.

## Changes

- **Id-map (P1):** hidden `identity` fields (`qboInvoiceId`/`qboCustomerId`/`qboItemId`, declared app-side) with explicit `RecordIdentity` write-through, so re-syncs converge instead of duplicating.
- **Settings (P1):** `quickbooks.syncInvoices` + `quickbooks.defaultIncomeAccountId`, and a three-state QuickBooks `SettingsSection` (not-installed → install button · installed → connect prompt · connected → toggle + income account) on the invoicing settings page.
- **Orchestrator (P3):** `syncInvoiceToQuickbooks()` — customer + item find-or-create, idempotent invoice create-or-update (**never sends** — D3), `$0` lines skipped, cents→dollars, due-date normalized to `YYYY-MM-DD`.
- **Triggers (P3):** `draft→sent` field-change hook → `quickbooksInvoiceSyncQueue` (BullMQ) → worker; plus a manual `money.syncInvoiceToQuickbooks` tRPC mutation.
- **SDK/runtime:** `EntityRefKind` gains `invoice`/`catalog_item`; a **general `integration-sync` Lambda caller** for platform-initiated app-tool orchestration (reused by the future payment push).

Companion app-side changes (the `create_quickbooks_item` tool + the identity-field declarations) are in a separate `Auxx-Ai/auxxai-apps` PR.

## Test plan

- ✅ **Live e2e against a QBO sandbox company** — list accounts → create customer+item+invoice (`qboInvoiceId 145`) → id-map written back → re-sync takes the update path, no duplicate.
- ✅ 19 unit tests (`packages/lib/src/money/quickbooks/__tests__/`) — disabled / not-connected / create / update-no-duplicate / skip-\$0 / missing-income-account / due-date normalization.

## ⚠️ Deploy note

The `apps/lambda/src/index.ts` allowlist addition (`integration-sync`) **must ship to the prod Lambda (Railway)** or every programmatic QB tool call 403s in production.

## Out of scope (follow-ups)

P4 payment push, P5 per-invoice sync-status UI + retry, P6 tax (see the plan's §7–§8).