### PR TITLE
feat(connections): pre-insert connection-identify hook for dedup

### DIFF
--- a/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
@@ -40,6 +40,7 @@ function renderPopupTerminationPage(payload: {
   credId?: string | null
   appId?: string | null
   error?: string | null
+  matchedExisting?: boolean
   originOfOpener: string
 }): NextResponse {
   const message = {
@@ -48,6 +49,7 @@ function renderPopupTerminationPage(payload: {
     credId: payload.credId ?? null,
     appId: payload.appId ?? null,
     error: payload.error ?? null,
+    matchedExisting: payload.matchedExisting ?? false,
   }
   const serializedMessage = JSON.stringify(message).replace(/</g, '\\u003c')
   const serializedOrigin = JSON.stringify(payload.originOfOpener).replace(/</g, '\\u003c')
@@ -374,19 +376,23 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       throw result.error
     }
 
+    const { credentialId, matchedExisting } = result.value
+
     logger.info('App connection created successfully', {
       appId,
       slug,
       installationId: metadata.installationId,
       global: metadata.global,
-      credentialId: result.value,
+      credentialId,
+      matchedExisting,
     })
 
     if (isPopup) {
       const popupResponse = renderPopupTerminationPage({
         ok: true,
-        credId: result.value,
+        credId: credentialId,
         appId: metadata.appId,
+        matchedExisting,
         originOfOpener,
       })
       popupResponse.cookies.delete('oauth_return_to')
@@ -395,7 +401,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     // Redirect back — use returnTo from state if available, else default to app connections page
     const successPath = metadata.returnTo || `/app/settings/apps/installed/${slug}/connections`
-    const redirectUrl = buildRedirectUrl(successPath, { oauth_success: 'true' })
+    const redirectUrl = buildRedirectUrl(successPath, {
+      oauth_success: 'true',
+      // A silent identity dedup update-in-place — the return hook toasts "already connected".
+      ...(matchedExisting && { already_connected: 'true' }),
+    })
     const response = NextResponse.redirect(redirectUrl)
     response.cookies.delete('oauth_return_to')
     return response

--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import type { ConnectionVariable } from '@auxx/database'
-import { toastError } from '@auxx/ui/components/toast'
+import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { type ReactNode, useCallback, useMemo, useState } from 'react'
 import { ConnectionDetailDialog } from '~/components/connections/ui/connection-detail-dialog'
 import type { DetailMethod } from '~/components/connections/ui/connection-detail-page'
@@ -11,6 +11,13 @@ import { useOAuthPopup } from '~/hooks/use-oauth-popup'
 import { api, type RouterOutputs } from '~/trpc/react'
 
 type Scope = 'user' | 'organization'
+
+/**
+ * Shown when a connect deduped onto an existing provider identity and updated it in place instead
+ * of minting a duplicate (see `saveAppConnection`'s `connection-identify` dedup). Kept consistent
+ * across all three delivery paths — popup, redirect, secret.
+ */
+const ALREADY_CONNECTED_MESSAGE = 'Already connected — reconnected the existing connection.'
 
 /**
  * The connection owner — an installed **app** (routes through `/api/apps/[slug]/oauth2/*` +
@@ -205,12 +212,15 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
 
   // Secret-save success/error are shared across the app and platform mutations. `args` is read
   // through the latest render (React Query stores option callbacks in a ref), so it stays current.
-  const onSecretSaved = (credId: string | null) => {
+  const onSecretSaved = (credId: string | null, matchedExisting = false) => {
     setFormOpen(false)
     if (args) invalidateForOwner(args.target.owner)
     if (credId) {
       setLastConnectedCredId(credId)
       if (args) onConnected?.(credId, args)
+    }
+    if (matchedExisting) {
+      toastSuccess({ title: 'Already connected', description: ALREADY_CONNECTED_MESSAGE })
     }
     setArgs(null)
   }
@@ -220,10 +230,11 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
   }
 
   const saveAppSecret = api.apps.saveSecretConnection.useMutation({
-    onSuccess: (data) => onSecretSaved(data?.credentialId ?? null),
+    onSuccess: (data) => onSecretSaved(data?.credentialId ?? null, data?.matchedExisting ?? false),
     onError: onSecretError,
   })
   const savePlatformSecret = api.connections.save.useMutation({
+    // Platform (non-app) secret saves don't run the identity dedup — no `matchedExisting` flag.
     onSuccess: (data) => onSecretSaved(data?.credentialId ?? null),
     onError: onSecretError,
   })
@@ -278,13 +289,16 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         fallbackUrl,
         channelName: 'oauth-app-connect',
         verify: a.verify ?? buildConnectionVerify(utils, a),
-        onDone: (ok, credId) => {
+        onDone: (ok, credId, matchedExisting) => {
           invalidateForOwner(owner)
           setArgs(null)
           const resolvedId = credId ?? (ok ? (a.connectionId ?? null) : null)
           if (ok && resolvedId) {
             setLastConnectedCredId(resolvedId)
             onConnected?.(resolvedId, a)
+          }
+          if (ok && matchedExisting) {
+            toastSuccess({ title: 'Already connected', description: ALREADY_CONNECTED_MESSAGE })
           }
           // A failure toasts in the core; a cancel/timeout settles silently. Either way the popup's
           // `pending` flips false, so the caller's disabled state recovers.

--- a/apps/web/src/components/apps/hooks/use-oauth-return.ts
+++ b/apps/web/src/components/apps/hooks/use-oauth-return.ts
@@ -23,15 +23,24 @@ export function useOAuthReturn() {
   const oauthSuccess = searchParams.get('oauth_success')
   const oauthError = searchParams.get('oauth_error')
   const oauthErrorMessage = searchParams.get('oauth_error_message')
+  // Set by the OAuth callback when the connect deduped onto an existing identity (update-in-place).
+  const alreadyConnected = searchParams.get('already_connected')
 
   useEffect(() => {
     if (!oauthSuccess && !oauthError) return
 
     if (oauthSuccess === 'true') {
-      toastSuccess({
-        title: 'Connection Successful',
-        description: 'Your app has been connected successfully!',
-      })
+      toastSuccess(
+        alreadyConnected === 'true'
+          ? {
+              title: 'Already connected',
+              description: 'Already connected — reconnected the existing connection.',
+            }
+          : {
+              title: 'Connection Successful',
+              description: 'Your app has been connected successfully!',
+            }
+      )
       void utils.apps.listConnections.invalidate()
       void utils.apps.listInstalled.invalidate()
       // Channel reconnects (Gmail/Outlook) ride the same return path — refresh their list so a
@@ -51,11 +60,12 @@ export function useOAuthReturn() {
     params.delete('oauth_success')
     params.delete('oauth_error')
     params.delete('oauth_error_message')
+    params.delete('already_connected')
 
     const remaining = params.toString()
     const cleanUrl = remaining
       ? `${window.location.pathname}?${remaining}`
       : window.location.pathname
     router.replace(cleanUrl)
-  }, [oauthSuccess, oauthError, oauthErrorMessage, router, searchParams, utils])
+  }, [oauthSuccess, oauthError, oauthErrorMessage, alreadyConnected, router, searchParams, utils])
 }

--- a/apps/web/src/hooks/use-oauth-popup.ts
+++ b/apps/web/src/hooks/use-oauth-popup.ts
@@ -10,6 +10,8 @@ interface OAuthDonePayload {
   ok: boolean
   credId?: string | null
   error?: string | null
+  /** True when the connect matched an existing identity and updated it in place (no new row). */
+  matchedExisting?: boolean
 }
 
 export interface OpenOAuthPopupOptions {
@@ -21,8 +23,11 @@ export interface OpenOAuthPopupOptions {
   channelName: string
   /** `window.open` target name (defaults to `auxx-oauth`). */
   windowName?: string
-  /** Settled exactly once: `ok` + the connected credId when known. */
-  onDone: (ok: boolean, credId?: string | null) => void
+  /**
+   * Settled exactly once: `ok` + the connected credId when known. `matchedExisting` is true when
+   * the connect deduped onto an existing identity (update-in-place) — the caller toasts it.
+   */
+  onDone: (ok: boolean, credId?: string | null, matchedExisting?: boolean) => void
   /**
    * Authoritative success backstop, polled every {@link verifyIntervalMs}. Resolve to a credId
    * (or `true`) once the connect is observed server-side; `null`/`false` while still pending.
@@ -107,7 +112,7 @@ export function useOAuthPopup() {
         ok: boolean,
         credId?: string | null,
         error?: string | null,
-        opts?: { closePopup?: boolean }
+        opts?: { closePopup?: boolean; matchedExisting?: boolean }
       ) => {
         if (settled) return
         settled = true
@@ -122,14 +127,17 @@ export function useOAuthPopup() {
         if (!ok && error) {
           toastError({ title: 'Failed to connect', description: error })
         }
-        onDone(ok, credId ?? null)
+        onDone(ok, credId ?? null, opts?.matchedExisting ?? false)
       }
 
       const handleDone = (payload: OAuthDonePayload) => {
         finish(
           payload.ok,
           payload.credId,
-          payload.ok ? undefined : payload.error || 'Connection failed'
+          payload.ok ? undefined : payload.error || 'Connection failed',
+          {
+            matchedExisting: payload.matchedExisting ?? false,
+          }
         )
       }
 

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -590,11 +590,13 @@ export const appsRouter = createTRPCRouter({
         })
       }
 
+      const { credentialId, matchedExisting } = result.value
+
       // Connection test for the no-browser `client-credentials` grant: mint once now so a bad
       // client id/secret surfaces immediately rather than on first runtime use. The minted token
       // is cached on the credential for reuse.
       if (def.connectionType === 'client-credentials') {
-        const minted = await mintClientCredentialToken(result.value, organizationId)
+        const minted = await mintClientCredentialToken(credentialId, organizationId)
         if (!minted.success) {
           throw new TRPCError({
             code: 'BAD_REQUEST',
@@ -603,7 +605,7 @@ export const appsRouter = createTRPCRouter({
         }
       }
 
-      return { success: true, credentialId: result.value }
+      return { success: true, credentialId, matchedExisting }
     }),
 
   /**

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -252,7 +252,7 @@ export const shopifyRouter = createTRPCRouter({
       }
       // The credential id for the claimed shop (reconnected or freshly inserted). Used to
       // flip the primary connection to this shop whenever we establish a Shopify anchor.
-      const claimedCredentialId = saveResult.value
+      const claimedCredentialId = saveResult.value.credentialId
 
       await redis.del(claimKey)
       cookieStore.delete(CLAIM_COOKIE_NAME)

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -351,6 +351,10 @@ export interface CatalogPayload {
   fields?: CatalogAppField[]
   /** App-declared data connectors (optional — older catalogs omit it). */
   dataConnectors?: CatalogDataConnector[]
+  /** Ids of app-side event handlers this deployment declares, e.g.
+   *  'connection-added', 'connection-identify'. Missing/older catalogs omit it →
+   *  treat as []. */
+  events?: string[]
 }
 
 /** Drizzle table for AppDeployment */

--- a/packages/lib/src/apps/connections/__tests__/save-app-connection.test.ts
+++ b/packages/lib/src/apps/connections/__tests__/save-app-connection.test.ts
@@ -14,7 +14,9 @@ const recordRefreshSuccess = vi.fn()
 const mergeSecretFields = vi.fn()
 const mergeSecrets = vi.fn()
 const getCredential = vi.fn()
+const listCredentials = vi.fn()
 const triggerAppEvent = vi.fn()
+const findFirstAppInstallation = vi.fn()
 
 vi.mock('@auxx/credentials/store', () => ({
   insertCredential: (input: unknown) => insertCredential(input),
@@ -24,7 +26,18 @@ vi.mock('@auxx/credentials/store', () => ({
   mergeSecretFields: (...args: unknown[]) => mergeSecretFields(...args),
   mergeSecrets: (...args: unknown[]) => mergeSecrets(...args),
   getCredential: (...args: unknown[]) => getCredential(...args),
-  listCredentials: async () => ok([]),
+  listCredentials: (input: unknown) => listCredentials(input),
+}))
+
+// loadDeclaredEvents reads the active deployment's catalog to gate connection-identify.
+vi.mock('@auxx/database', () => ({
+  database: {
+    query: {
+      AppInstallation: {
+        findFirst: (...args: unknown[]) => findFirstAppInstallation(...args),
+      },
+    },
+  },
 }))
 
 vi.mock('@auxx/services/app-connections', () => ({
@@ -68,7 +81,10 @@ beforeEach(() => {
   getCredential
     .mockReset()
     .mockResolvedValue(ok({ metadata: { connectionVariables: { account_number: 'acc-1' } } }))
+  listCredentials.mockReset().mockResolvedValue(ok([]))
   triggerAppEvent.mockReset().mockResolvedValue(ok({ result: undefined }))
+  // Default: no declared events → identify gate off → today's plain-insert behavior.
+  findFirstAppInstallation.mockReset().mockResolvedValue(undefined)
 })
 
 describe('saveAppConnection — secret/plain split', () => {
@@ -78,7 +94,7 @@ describe('saveAppConnection — secret/plain split', () => {
       metadata: { connectionVariables: { account_number: 'acc-1' } },
     })
 
-    expect(res._unsafeUnwrap()).toBe('cred-1')
+    expect(res._unsafeUnwrap()).toEqual({ credentialId: 'cred-1', matchedExisting: false })
     const inserted = insertCredential.mock.calls[0]![0] as {
       secrets: Record<string, unknown>
       metadata: Record<string, unknown>
@@ -173,5 +189,136 @@ describe('saveAppConnection — secret/plain split', () => {
     }
     expect(event.payload.connection.fields).toBeUndefined()
     expect(event.payload.connection.value).toBe('sk')
+  })
+})
+
+describe('saveAppConnection — connection-identify dedup', () => {
+  // Gate on: active deployment declares the connection-identify handler.
+  const withIdentifyHook = () =>
+    findFirstAppInstallation.mockResolvedValue({
+      currentDeployment: { catalog: { events: ['connection-identify'] } },
+    })
+
+  // triggerAppEvent serves the identify call with `identifier`; every other event
+  // (connection-added) resolves to the neutral `{ result: undefined }`.
+  const identifyReturns = (identifier: string | undefined) =>
+    triggerAppEvent.mockImplementation((input: { eventType: string }) =>
+      Promise.resolve(
+        input.eventType === 'connection-identify'
+          ? ok({ result: identifier === undefined ? {} : { identifier } })
+          : ok({ result: undefined })
+      )
+    )
+
+  it('app WITHOUT the hook inserts on every connect (no dedup)', async () => {
+    // Default findFirst → no catalog events → gate off.
+    await saveAppConnection(...ARGS, { accessToken: 'tok-a', metadata: { realmId: 'r1' } })
+    await saveAppConnection(...ARGS, { accessToken: 'tok-b', metadata: { realmId: 'r1' } })
+
+    expect(insertCredential).toHaveBeenCalledTimes(2)
+    // No identify hook → no in-place update.
+    expect(rotateSecrets).not.toHaveBeenCalled()
+    // No connection-identify event was ever fired.
+    const identifyCalls = triggerAppEvent.mock.calls.filter(
+      (c) => (c[0] as { eventType: string }).eventType === 'connection-identify'
+    )
+    expect(identifyCalls).toHaveLength(0)
+  })
+
+  it('same identifier updates the existing row in place (no insert, no connection-added)', async () => {
+    withIdentifyHook()
+    identifyReturns('realm-1')
+    // A row with this identity already exists in scope.
+    listCredentials.mockResolvedValue(
+      ok([{ id: 'cred-existing', metadata: { __identity: 'realm-1' } }])
+    )
+
+    const res = await saveAppConnection(...ARGS, {
+      accessToken: 'fresh-tok',
+      metadata: { realmId: 'realm-1' },
+    })
+
+    expect(res._unsafeUnwrap()).toEqual({ credentialId: 'cred-existing', matchedExisting: true })
+    // Update in place — tokens rotated, breaker reset, no new row.
+    expect(insertCredential).not.toHaveBeenCalled()
+    expect(rotateSecrets).toHaveBeenCalledWith(
+      'cred-existing',
+      'org-1',
+      expect.objectContaining({ accessToken: 'fresh-tok' }),
+      { expiresAt: null }
+    )
+    expect(recordRefreshSuccess).toHaveBeenCalledWith('cred-existing', 'org-1', { expiresAt: null })
+    // __identity survives the metadata replacement so future connects keep matching.
+    expect(updateCredential).toHaveBeenCalledWith('cred-existing', 'org-1', {
+      metadata: expect.objectContaining({ __identity: 'realm-1' }),
+    })
+    // connection-added must NOT re-fire — setup already ran for this account.
+    const addedCalls = triggerAppEvent.mock.calls.filter(
+      (c) => (c[0] as { eventType: string }).eventType === 'connection-added'
+    )
+    expect(addedCalls).toHaveLength(0)
+  })
+
+  it('different identifier inserts a new row and persists __identity', async () => {
+    withIdentifyHook()
+    identifyReturns('realm-2')
+    // Existing row carries a different identity → no match.
+    listCredentials.mockResolvedValue(
+      ok([{ id: 'cred-existing', metadata: { __identity: 'realm-1' } }])
+    )
+
+    const res = await saveAppConnection(...ARGS, {
+      accessToken: 'tok',
+      metadata: { realmId: 'realm-2' },
+    })
+
+    expect(res._unsafeUnwrap()).toEqual({ credentialId: 'cred-1', matchedExisting: false })
+    expect(insertCredential).toHaveBeenCalledTimes(1)
+    const inserted = insertCredential.mock.calls[0]![0] as { metadata: Record<string, unknown> }
+    expect(inserted.metadata.__identity).toBe('realm-2')
+    // connection-added fires for a genuinely new connection.
+    const addedCalls = triggerAppEvent.mock.calls.filter(
+      (c) => (c[0] as { eventType: string }).eventType === 'connection-added'
+    )
+    expect(addedCalls).toHaveLength(1)
+  })
+
+  it('empty identifier falls back to a plain insert (no __identity stored)', async () => {
+    withIdentifyHook()
+    identifyReturns('') // handler opts out of dedup for this connect
+    listCredentials.mockResolvedValue(ok([]))
+
+    const res = await saveAppConnection(...ARGS, {
+      accessToken: 'tok',
+      metadata: { realmId: '' },
+    })
+
+    expect(res._unsafeUnwrap()).toEqual({ credentialId: 'cred-1', matchedExisting: false })
+    expect(insertCredential).toHaveBeenCalledTimes(1)
+    const inserted = insertCredential.mock.calls[0]![0] as { metadata: Record<string, unknown> }
+    expect(inserted.metadata.__identity).toBeUndefined()
+  })
+
+  it('same identifier in a different scope stays a separate row (scope isolation)', async () => {
+    withIdentifyHook()
+    identifyReturns('realm-1')
+    // The identity match query is scoped by userId — an org-scoped row (userId: null)
+    // carrying this identity is invisible to a user-scoped connect.
+    listCredentials.mockImplementation((input: { userId: string | null }) =>
+      Promise.resolve(
+        input.userId === null
+          ? ok([{ id: 'cred-org', metadata: { __identity: 'realm-1' }, isDefault: true }])
+          : ok([])
+      )
+    )
+
+    // User-scoped connect (createdById 'user-1', userId 'user-1').
+    const res = await saveAppConnection('app-1', 'inst-1', 'FedEx', 'org-1', 'user-1', 'user-1', {
+      accessToken: 'tok',
+      metadata: { realmId: 'realm-1' },
+    })
+
+    expect(res._unsafeUnwrap()).toEqual({ credentialId: 'cred-1', matchedExisting: false })
+    expect(insertCredential).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/lib/src/apps/connections/save-app-connection.ts
+++ b/packages/lib/src/apps/connections/save-app-connection.ts
@@ -7,6 +7,7 @@ import {
   rotateSecrets,
   updateCredential,
 } from '@auxx/credentials/store'
+import { database } from '@auxx/database'
 import {
   logger,
   mergeConnectionVariables,
@@ -41,18 +42,27 @@ function pickSecrets(data: {
 /**
  * Save app connection (OAuth callback or manual secret)
  *
- * Creates or updates an app connection with encrypted credentials. This function implements
- * an upsert pattern - it will update an existing connection if one exists for the same
- * app/organization/user combination, or create a new one if not.
+ * Persists an app connection with encrypted credentials. There are three distinct paths:
  *
- * The function handles two primary use cases:
- * 1. OAuth2 flow completion: Saves access_token, refresh_token, and expiry from OAuth callback
- * 2. Manual secret entry: Saves API keys or secrets entered directly by the user
+ * 1. **Explicit reconnect** (`options.connectionId` given) — rotates the tokens/secrets of that
+ *    specific credential and resets its refresh circuit breaker. No new row, no
+ *    `connection-added` event.
+ * 2. **Identity dedup** (fresh connect, app declares a `connection-identify` handler) — the
+ *    handler returns a stable provider identity (realm id, workspace id, account email). If an
+ *    existing connection in the same visibility scope already carries that identity
+ *    (`metadata.__identity`), it is updated in place (same as an explicit reconnect) instead of
+ *    creating a duplicate. Returns `matchedExisting: true` so callers can toast.
+ * 3. **Fresh insert** (fresh connect, no identity match or no handler) — inserts a new
+ *    credential and fires the `connection-added` app event so the app can run its setup
+ *    (register webhooks, resolve a `{ label }`, etc.).
+ *
+ * The function handles two credential shapes:
+ * - OAuth2 flow completion: access_token, refresh_token, and expiry from an OAuth callback
+ * - Manual secret entry: API keys or secrets entered directly by the user
  *
  * Secret credential data is encrypted via the credential store (insertCredential/rotateSecrets)
- * before being stored; non-secret data goes in plaintext `metadata`. The function also triggers
- * a 'connection-added' app event
- * (for new connections) to notify any registered event handlers in the app.
+ * before being stored; non-secret data (including the reserved `metadata.__identity` dedup key)
+ * goes in plaintext `metadata`.
  *
  * Connection scoping:
  * - If userId is null: Creates an organization-scoped connection (shared across all users)
@@ -82,9 +92,12 @@ function pickSecrets(data: {
  * @param {Record<string, any>} [connectionData.metadata] - Additional metadata like scopes,
  *                                                          token type, user info, etc.
  *
- * @returns {Promise<Result<string, Error>>}
+ * @returns {Promise<Result<{ credentialId: string; matchedExisting: boolean }, Error>>}
  *          A Result containing either:
- *          - Success: The credential ID (string) of the created or updated connection
+ *          - Success: `{ credentialId, matchedExisting }` — the credential ID of the
+ *            created/updated connection, and whether it matched an existing connection by
+ *            provider identity (`true`) rather than being freshly inserted (`false`). An
+ *            explicit reconnect returns `matchedExisting: false` (it is not a silent dedup).
  *          - Error: Database error or CONNECTION_CREATE_FAILED if creation fails
  *
  * @example
@@ -191,58 +204,108 @@ export async function saveAppConnection(
   if (options?.connectionId) {
     logger.info('Reconnecting existing app connection:', { credentialId: options.connectionId })
 
-    const expiresAt = connectionData.expiresAt ? new Date(connectionData.expiresAt) : null
-
-    // OAuth mint (the callback route) carries fresh tokens and legitimately replaces everything;
-    // a manual secret edit carries only secretFields/secret + plain vars and must MERGE so editing
-    // one field never wipes the stored secret or drops a plain var the user didn't re-supply.
-    const isOAuthMint =
-      connectionData.accessToken !== undefined || connectionData.refreshToken !== undefined
-
-    if (isOAuthMint) {
-      const rotated = await rotateSecrets(options.connectionId, organizationId, secrets, {
-        expiresAt,
-      })
-      if (rotated.isErr()) {
-        return err(rotated.error)
-      }
-
-      // Refresh the plaintext companion metadata alongside the rotated secrets.
-      const metaUpdated = await updateCredential(options.connectionId, organizationId, { metadata })
-      if (metaUpdated.isErr()) {
-        return err(metaUpdated.error)
-      }
-    } else {
-      const reconnected = await mergeManualConnectionEdit(options.connectionId, organizationId, {
-        secretFields: connectionData.secretFields,
-        secret: connectionData.secret,
-        plainVariables: (metadata.connectionVariables ?? {}) as Record<string, unknown>,
-      })
-      if (reconnected.isErr()) {
-        return err(reconnected.error)
-      }
-    }
-
-    // A successful re-auth clears any open refresh circuit breaker. Without this the
-    // connection keeps surfacing as "expired" (consecutiveRefreshFailures >= threshold)
-    // even though it now holds a fresh token — recordRefreshSuccess resets the breaker
-    // and stamps lastRefreshAt alongside the already-rotated expiry.
-    const breakerReset = await recordRefreshSuccess(options.connectionId, organizationId, {
-      expiresAt,
-    })
-    if (breakerReset.isErr()) {
-      return err(breakerReset.error)
+    const updated = await updateExistingConnection(
+      options.connectionId,
+      organizationId,
+      connectionData
+    )
+    if (updated.isErr()) {
+      return err(updated.error)
     }
 
     // No app-field provisioning here — connector sync setup runs the authoritative
     // reconcile (create/drift/orphan) and parks visibly on any error, so a field the
     // catalog gained since this connection was created self-heals on the next sync.
     logger.info('Successfully reconnected app connection:', { credentialId: options.connectionId })
-    return ok(options.connectionId)
+    // An explicit reconnect is not a silent identity dedup — matchedExisting is false.
+    return ok({ credentialId: options.connectionId, matchedExisting: false })
   }
 
   // Create new connection with auto-generated label
   logger.info('Creating new app connection')
+
+  // Identity dedup (fresh connect): if this app declares a `connection-identify` handler,
+  // ask it for the freshly minted connection's stable provider identity BEFORE inserting.
+  // A pre-insert match updates the existing row in place instead of minting a duplicate —
+  // no new row, no `connection-added` re-fire (setup already ran for that account). The gate
+  // reads the active deployment's catalog (same source triggerAppEvent uses); a missing
+  // catalog or list means today's behavior — a plain insert.
+  const declaredEvents = await loadDeclaredEvents(appInstallationId)
+  if (declaredEvents.includes('connection-identify')) {
+    const identifyType: 'oauth2-code' | 'secret' = connectionData.accessToken
+      ? 'oauth2-code'
+      : 'secret'
+    // Token is already in hand — no persistence yet, so no `id` is sent to identify.
+    const identifyValue = connectionData.accessToken || connectionData.secret || ''
+    const identifyFields = mergeConnectionVariables(metadata, {
+      fields: connectionData.secretFields,
+    })
+
+    const identifyResult = await triggerAppEvent({
+      appInstallationId,
+      eventType: 'connection-identify',
+      payload: {
+        connection: {
+          type: identifyType,
+          value: identifyValue,
+          ...(Object.keys(identifyFields).length > 0 && { fields: identifyFields }),
+          metadata: safeSerializeMetadata(connectionData.metadata),
+        },
+      },
+    })
+
+    if (identifyResult.isErr()) {
+      // A failing/absent identify handler must never block the connect — fall through to
+      // a plain insert (store nothing to match on).
+      logger.error('connection-identify handler failed; proceeding without dedup', {
+        appInstallationId,
+        error: identifyResult.error.message,
+      })
+    } else {
+      const handlerResult = identifyResult.value.result
+      const identifier =
+        handlerResult && typeof handlerResult === 'object' && 'identifier' in handlerResult
+          ? String((handlerResult as { identifier?: unknown }).identifier ?? '').trim()
+          : ''
+
+      // Empty identifier → app opted out of dedup for this connect → plain insert.
+      if (identifier) {
+        // Persist the identity on plaintext metadata so future connects (and this insert)
+        // can match it. Mutating `metadata` here also updates `connectionData.metadata`
+        // when the caller supplied one; otherwise link them so the update path below (which
+        // recomputes metadata from connectionData) persists `__identity` too.
+        metadata.__identity = identifier
+        connectionData.metadata = metadata
+
+        // Same visibility scope as dedupeLabel — (appId, appInstallationId, userId). Org- and
+        // user-scoped rows are disjoint, so a personal and a workspace connection with the same
+        // identity stay two distinct rows.
+        const existing = await listCredentials({
+          organizationId,
+          kind: 'app',
+          appId,
+          appInstallationId,
+          userId,
+        })
+        const match = existing.isOk()
+          ? existing.value.find((row) => row.metadata?.__identity === identifier)
+          : undefined
+
+        if (match) {
+          const updated = await updateExistingConnection(match.id, organizationId, connectionData)
+          if (updated.isErr()) {
+            return err(updated.error)
+          }
+          logger.info('Matched existing connection by identity — updated in place', {
+            credentialId: match.id,
+            appInstallationId,
+          })
+          // Keep the matched row's isDefault flag; no new row, no connection-added.
+          return ok({ credentialId: match.id, matchedExisting: true })
+        }
+      }
+    }
+  }
 
   // Generate the initial label. Defaults to the app name, deduped within this
   // connection's own visibility scope (see dedupeLabel). An app's
@@ -375,7 +438,93 @@ export async function saveAppConnection(
     }
   }
 
-  return ok(created.id)
+  return ok({ credentialId: created.id, matchedExisting: false })
+}
+
+/**
+ * Update an existing connection's stored credentials in place — used by both the explicit
+ * reconnect path (`options.connectionId`) and the identity-dedup match path. Rotates the
+ * tokens/secrets and resets the refresh circuit breaker. Deliberately does NOT fire a
+ * `connection-added` event: the account's setup (webhooks, label) already exists.
+ */
+async function updateExistingConnection(
+  connectionId: string,
+  organizationId: string,
+  connectionData: {
+    accessToken?: string
+    refreshToken?: string
+    expiresAt?: string
+    secret?: string
+    secretFields?: Record<string, string>
+    metadata?: Record<string, any>
+  }
+) {
+  const secrets = pickSecrets(connectionData)
+  const metadata = (connectionData.metadata ?? {}) as Record<string, unknown>
+  const expiresAt = connectionData.expiresAt ? new Date(connectionData.expiresAt) : null
+
+  // OAuth mint (the callback route) carries fresh tokens and legitimately replaces everything;
+  // a manual secret edit carries only secretFields/secret + plain vars and must MERGE so editing
+  // one field never wipes the stored secret or drops a plain var the user didn't re-supply.
+  const isOAuthMint =
+    connectionData.accessToken !== undefined || connectionData.refreshToken !== undefined
+
+  if (isOAuthMint) {
+    const rotated = await rotateSecrets(connectionId, organizationId, secrets, { expiresAt })
+    if (rotated.isErr()) {
+      return err(rotated.error)
+    }
+
+    // Refresh the plaintext companion metadata alongside the rotated secrets.
+    const metaUpdated = await updateCredential(connectionId, organizationId, { metadata })
+    if (metaUpdated.isErr()) {
+      return err(metaUpdated.error)
+    }
+  } else {
+    const reconnected = await mergeManualConnectionEdit(connectionId, organizationId, {
+      secretFields: connectionData.secretFields,
+      secret: connectionData.secret,
+      plainVariables: (metadata.connectionVariables ?? {}) as Record<string, unknown>,
+    })
+    if (reconnected.isErr()) {
+      return err(reconnected.error)
+    }
+  }
+
+  // A successful re-auth clears any open refresh circuit breaker. Without this the
+  // connection keeps surfacing as "expired" (consecutiveRefreshFailures >= threshold)
+  // even though it now holds a fresh token — recordRefreshSuccess resets the breaker
+  // and stamps lastRefreshAt alongside the already-rotated expiry.
+  const breakerReset = await recordRefreshSuccess(connectionId, organizationId, { expiresAt })
+  if (breakerReset.isErr()) {
+    return err(breakerReset.error)
+  }
+
+  return ok(undefined)
+}
+
+/**
+ * Ids of app-side event handlers the installation's active deployment declares (e.g.
+ * `connection-identify`). Read from the deployment catalog — the same source
+ * `triggerAppEvent` uses. A missing installation / deployment / catalog / list yields `[]`,
+ * so the caller falls back to today's behavior (no identify hook).
+ */
+async function loadDeclaredEvents(appInstallationId: string): Promise<string[]> {
+  try {
+    const installation = await database.query.AppInstallation.findFirst({
+      where: (inst, { eq }) => eq(inst.id, appInstallationId),
+      with: {
+        currentDeployment: { columns: { catalog: true } },
+      },
+    })
+    return installation?.currentDeployment?.catalog?.events ?? []
+  } catch (error) {
+    logger.error('Failed to load declared events for connection-identify gate', {
+      appInstallationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return []
+  }
 }
 
 /**

--- a/packages/lib/src/apps/events.ts
+++ b/packages/lib/src/apps/events.ts
@@ -36,12 +36,21 @@ export type AppEventError =
  * Connection data for event payload
  */
 export interface EventConnectionData {
-  /** Unique identifier for the connection */
-  id: string
+  /**
+   * Unique identifier for the connection. Present for post-insert events
+   * (`connection-added`/`connection-removed`); omitted for the pre-insert
+   * `connection-identify` event, where nothing is persisted yet.
+   */
+  id?: string
   /** Type of connection authentication */
   type: 'oauth2-code' | 'secret'
   /** The connection credential value (access token, API key, etc.) */
   value: string
+  /**
+   * Merged connection variables (plain + secret-flagged) so handlers can read
+   * user-defined connection vars. Secrets win on key collision.
+   */
+  fields?: Record<string, string>
   /** Optional metadata associated with the connection */
   metadata?: Record<string, unknown>
 }
@@ -54,7 +63,7 @@ export interface EventConnectionData {
  */
 export async function triggerAppEvent(params: {
   appInstallationId: string
-  eventType: 'connection-added' | 'connection-removed'
+  eventType: 'connection-added' | 'connection-removed' | 'connection-identify'
   payload: {
     connection?: EventConnectionData
   }

--- a/packages/sdk/src/build/server/generate-server-entry.ts
+++ b/packages/sdk/src/build/server/generate-server-entry.ts
@@ -58,7 +58,7 @@ type LogFunction = (message: string) => void
  * // Find webhook modules
  * const webhooks = await findServerFunctionModules('/app/webhooks', 'webhook')
  */
-async function findServerFunctionModules(cwd: string, pattern: string) {
+export async function findServerFunctionModules(cwd: string, pattern: string) {
   try {
     return complete(await glob(`**/*.${pattern}.{js,ts}`, { nodir: true, cwd }))
   } catch (error) {

--- a/packages/sdk/src/server/connections.ts
+++ b/packages/sdk/src/server/connections.ts
@@ -63,6 +63,52 @@ export interface ConnectionAddedResult {
 }
 
 /**
+ * Connection view passed to `connection-identify` — pre-insert, so no `id`
+ * (nothing is persisted yet; the freshly minted credential value + metadata are
+ * handed to the handler before any DB write).
+ */
+export type IdentifyConnection = Omit<Connection, 'id'>
+
+/**
+ * Result an app's `connection-identify` event handler returns so the platform
+ * can dedupe a fresh connect against existing connections in the same scope.
+ *
+ * The handler lives at `src/events/connection-identify.event.ts` and is a
+ * **pure, side-effect-free, PRE-insert** hook. It runs *before* the credential
+ * is written, receives the freshly minted credential value + metadata (no
+ * `connection.id`, nothing persisted yet), and returns a stable provider
+ * identity string for dedup — a realm id, workspace id, account email, etc.
+ *
+ * The handler MAY read the provider (e.g. `GET /me`) to derive the identity, but
+ * MUST NOT mutate provider state (no webhook registration, no writes). All
+ * setup + webhook side effects stay in `connection-added`, which runs *after*
+ * insert only for genuinely new connections. When the returned `identifier`
+ * matches an existing connection the platform updates that row in place (rotates
+ * tokens) and does NOT re-fire `connection-added`.
+ *
+ * @example
+ * // src/events/connection-identify.event.ts
+ * import type {
+ *   IdentifyConnection,
+ *   ConnectionIdentifyResult,
+ * } from '@auxx/sdk/server'
+ *
+ * export default async function connectionIdentify(
+ *   { connection }: { connection: IdentifyConnection },
+ * ): Promise<ConnectionIdentifyResult> {
+ *   // Metadata-derived (QuickBooks): realmId rides the OAuth callback.
+ *   const realmId = connection.metadata?.realmId as string | undefined
+ *   return realmId ? { identifier: realmId } : {}
+ *   // API-derived: call `GET /me` with connection.value, return { identifier: me.email }.
+ * }
+ */
+export interface ConnectionIdentifyResult {
+  /** Stable provider identity for dedup — realm id, workspace id, account email.
+   *  Omit/empty to skip dedup for this connect. */
+  identifier?: string
+}
+
+/**
  * Error thrown when connection is not found.
  * Platform catches this and prompts user to authenticate.
  */

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -4,8 +4,9 @@ import * as esbuild from 'esbuild'
 import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
+import { findServerFunctionModules } from '../build/server/generate-server-entry.js'
 import { HIDDEN_AUXX_DIRECTORY } from '../constants/hidden-auxx-directory.js'
-import { complete, errored, type Result } from '../errors.js'
+import { complete, errored, isErrored, type Result } from '../errors.js'
 import type {
   ActionInputHint,
   AgentSurface,
@@ -299,6 +300,10 @@ export interface CatalogPayload {
   fields?: CatalogAppField[]
   /** App-declared data connectors (optional — older catalogs omit it). */
   dataConnectors?: CatalogDataConnector[]
+  /** Ids of app-side event handlers this deployment declares, e.g.
+   *  'connection-added', 'connection-identify'. Missing/older catalogs omit it →
+   *  treat as []. */
+  events?: string[]
 }
 
 export type CompileAndExtractCatalogError =
@@ -795,6 +800,17 @@ export async function compileAndExtractCatalog(): Promise<
     })
   }
 
+  // Declared event handlers — files under the events dir (`src/events` by
+  // convention). Not part of the projected `app` literal, so scan the filesystem
+  // the same way the server-entry generator does: `*.event.{js,ts}` → strip the
+  // suffix to the handler id (e.g. 'connection-identify'). A missing events dir
+  // is not an error — treat as no declared events.
+  const eventsDirAbsolute = path.join(srcDirAbsolute, 'events')
+  const eventModulesResult = await findServerFunctionModules(eventsDirAbsolute, 'event')
+  const eventIds = isErrored(eventModulesResult)
+    ? []
+    : eventModulesResult.value.map((p) => p.replace(/\.event\.(js|ts)$/, ''))
+
   const catalog: CatalogPayload = {
     tools: cataloguedTools,
     triggers: cataloguedTriggers,
@@ -811,6 +827,7 @@ export async function compileAndExtractCatalog(): Promise<
     actions: cataloguedActions,
     fields: cataloguedFields,
     dataConnectors: cataloguedDataConnectors,
+    events: eventIds,
   }
 
   // Roundtrip-serializable check — catches non-serializable values left on


### PR DESCRIPTION
## What

Re-connecting the same provider identity (e.g. QuickBooks re-completing Intuit SSO silently) currently mints a **duplicate** credential. This adds a pure, side-effect-free **pre-insert** app event, `connection-identify`, that returns a stable identity string; the platform runs it *before* `insertCredential`, dedupes on it, and updates the existing connection in place instead of creating a duplicate.

Implements `plans/connections/connection-identity-dedup.md` (plan is gitignored/local).

## Changes (platform)

- **SDK** (`packages/sdk/src/server/connections.ts`) — `IdentifyConnection` (`Omit<Connection,'id'>`) + `ConnectionIdentifyResult` types and the `connection-identify.event.ts` convention docs.
- **Catalog `events` list** — `events?: string[]` on both `CatalogPayload` defs (`compile-and-extract-catalog.ts`, `app-deployment.ts`); extractor emits declared event ids via the shared `findServerFunctionModules`. Type-only change on an existing `jsonb` column — **no migration**.
- **`triggerAppEvent`** (`packages/lib/src/apps/events.ts`) — eventType widened to include `connection-identify`; typed optional `fields` on `EventConnectionData`.
- **`saveAppConnection`** — extracted `updateExistingConnection` (rotates tokens, resets breaker, no `connection-added` re-fire) reused by explicit-reconnect and identity-match paths; pre-insert identify + dedup (gated on `catalog.events.includes('connection-identify')`, scoped like `dedupeLabel`); return shape now `{ credentialId, matchedExisting }`.
- **Callers + toast** — 3 callers adopt `.credentialId`; `matchedExisting` threaded through popup message, `&already_connected=true` redirect, and the secret mutation → *"Already connected — reconnected the existing connection."*

## App hooks

App-side `connection-identify.event.ts` files live in the separate `auxxai-apps` repo (separate PR) and are **not yet redeployed** — a hook only fires once its app's catalog carries `connection-identify`.

## Tests

`save-app-connection.test.ts` — 11 cases green (no-hook dupes; same-identifier update-in-place; different-identifier insert; empty→insert; scope isolation). Per-package typecheck clean on all touched files (pre-existing baseline errors excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)