### PR TITLE
fix(dispatch): board shading for worker/team rows, cross-column drag & timeline rail polish

### DIFF
--- a/apps/web/src/components/calendar/ui/mini-calendar-section.tsx
+++ b/apps/web/src/components/calendar/ui/mini-calendar-section.tsx
@@ -45,7 +45,7 @@ export function MiniCalendarSection({
 }: MiniCalendarSectionProps) {
   const band = view === 'week' ? { from: date, to: addDays(date, 6) } : visibleRange
   return (
-    <div className='border-sidebar-border border-b'>
+    <div className='border-sidebar-border border-b pb-2'>
       <MiniMonthCalendar
         selected={date}
         onSelect={onDateChange}

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -413,6 +413,10 @@ export function BoardCalendarGrid({
     } else {
       startTime.setHours(DefaultStartHour, 0, 0, 0)
     }
+    // The popover survives the context menu's close-time focus churn via `onFocusOutside`
+    // preventDefault in `SlotCreatePopover` (Radix restores focus to <body> a tick after the menu
+    // unmounts, which would otherwise instantly dismiss the freshly-opened popover), so this can
+    // open synchronously.
     setSlotClickTarget({
       startTime,
       endTime: addMinutes(startTime, 60),

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -99,17 +99,20 @@ export function DispatchBoard() {
   // same value for the month-anchor reducer) and reused here for the toolbar/grid/sidebar.
   const weekStartsOn = data.weekStartsOn
 
-  // Availability is a per-PERSON concept (a schedule belongs to a `User`, not a board column) —
-  // team rows have no `userId` and are excluded here, not remapped to `worker.id`.
-  const workerUserIds = useMemo(
-    () => data.workers.flatMap((w) => (w.userId ? [w.userId] : [])),
+  // Availability is a per-PERSON concept (a schedule belongs to a `User`, not a board column), so
+  // we pass BOTH ids: `userId` to look the schedule up by, and the worker `id` to tag the resulting
+  // background band with (the shading hook keys the band on the column id, not the user). Teams have
+  // no `userId` (no per-team schedule model) — they pass through as `null` and the hook falls them
+  // back to org hours so their row isn't left reading as available 24/7.
+  const shadingWorkers = useMemo(
+    () => data.workers.map((w) => ({ id: w.id, userId: w.userId ?? null })),
     [data.workers]
   )
   const { backgroundEvents, isNonWorkingDay } = useAvailabilityShading({
     view: data.view,
     range: data.range,
     fetchWindow: data.fetchWindow,
-    workerUserIds,
+    workers: shadingWorkers,
   })
 
   const overlappingIds = useMemo(() => computeOverlappingVisitIds(data.events), [data.events])

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-availability-shading.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-availability-shading.ts
@@ -37,12 +37,22 @@ export function useAvailabilityShading({
   view,
   range,
   fetchWindow: fetchWindowRange,
-  workerUserIds,
+  workers,
 }: {
   view: BoardViewMode
   range: DateRange
   fetchWindow: DateRange
-  workerUserIds: string[]
+  /**
+   * Worker column id ↔ user id. Availability is per-PERSON (a schedule belongs to a `User`), so we
+   * fetch it by `userId`; but the emitted background band must carry the WORKER id, because that's
+   * the resource-column id chips and shading are matched on (`use-board-data.ts` keys columns by
+   * `worker.id`). Keying the band by `userId` — as this once did — meant it never matched any
+   * column, so worker rows silently showed no off-hours shading (only Unassigned, keyed by the
+   * literal `UNASSIGNED_RESOURCE_ID`, lined up). Team rows have `userId: null` — there is no
+   * per-team schedule model, so they fall back to the ORG hours (same source as Unassigned)
+   * instead of reading as available 24/7.
+   */
+  workers: Array<{ id: string; userId: string | null }>
 }): {
   backgroundEvents: BackgroundEvent[]
   isNonWorkingDay: (date: Date) => boolean
@@ -81,15 +91,18 @@ export function useAvailabilityShading({
       { key: ORG_KEY, subject: { type: 'organization' } },
     ]
     if (view === 'day' || view === 'timeline') {
-      for (const userId of workerUserIds) {
+      for (const worker of workers) {
+        // Teams (`userId: null`) have no personal schedule — they reuse the always-present ORG
+        // subject, so nothing extra to fetch for them here.
+        if (!worker.userId) continue
         list.push({
-          key: workerKey(userId),
-          subject: { type: 'worker', userId },
+          key: workerKey(worker.userId),
+          subject: { type: 'worker', userId: worker.userId },
         })
       }
     }
     return list
-  }, [view, workerUserIds])
+  }, [view, workers])
 
   useResolvedDaysForSubjects(
     subjectList.map(({ subject }) => subject),
@@ -111,9 +124,12 @@ export function useAvailabilityShading({
 
   const backgroundEvents = useMemo(() => {
     if (view === 'day' || view === 'timeline') {
-      const events = workerUserIds.flatMap((userId) =>
-        visibleDays(workerKey(userId)).flatMap((day) =>
-          offHoursBackgroundEvents(new Date(`${day.date}T00:00:00`), day.ranges, userId)
+      // Band carries the WORKER id (the resource-column id), while availability is looked up by the
+      // worker's `userId` — see the `workers` prop doc for why the two must not be conflated. Teams
+      // (`userId: null`) read the ORG schedule so their row shades to org hours instead of 24/7.
+      const events = workers.flatMap((worker) =>
+        visibleDays(worker.userId ? workerKey(worker.userId) : ORG_KEY).flatMap((day) =>
+          offHoursBackgroundEvents(new Date(`${day.date}T00:00:00`), day.ranges, worker.id)
         )
       )
       const unassigned = visibleDays(ORG_KEY).flatMap((day) =>
@@ -131,7 +147,7 @@ export function useAvailabilityShading({
       )
     }
     return []
-  }, [view, workerUserIds, visibleDays])
+  }, [view, workers, visibleDays])
 
   // Non-working-day tint (month view): a resolved day wins (exception-aware); otherwise fall back to
   // the weekly baseline so weekends paint from the get-go. `getDay()` is 0=Sun, matching the server.

--- a/apps/web/src/components/dispatch/ui/board/slot-create-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/slot-create-popover.tsx
@@ -213,6 +213,11 @@ export function SlotCreatePopover({
         align='start'
         sideOffset={8}
         onOpenAutoFocus={(e) => e.preventDefault()}
+        // Opened from the right-click context menu: as that menu unmounts, Radix restores focus
+        // (landing on <body>) a tick AFTER this popover opens, and that focus-outside would
+        // otherwise instantly dismiss it (the "flash at 0,0 then vanish" bug). Ignoring focus-outside
+        // dismissal keeps it open; outside-CLICK (`onPointerDownOutside`) and Escape still close it.
+        onFocusOutside={(e) => e.preventDefault()}
         className='w-96 rounded-3xl shadow-xl'>
         {target && (
           <Tabs value={tab} onValueChange={(v) => setTab(v as SlotCreateTab)}>

--- a/apps/web/src/components/dispatch/ui/schedule-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-popover.tsx
@@ -249,72 +249,74 @@ export function SchedulePopoverContent({
         hideAll: isPast,
       }}
       className={className}>
-      <EventDateTimeSection
-        start={startTime}
-        end={endTime}
-        warnings={hints}
-        renderTimeEditor={(props) => <InlineEventTimePicker {...props} />}
-        onChange={handleDateTimeChange}
-        // Plan 30 §D.1 — series visits never go back to the backlog (server rejects it too);
-        // the clear-date toggle is a series visit's disguised unschedule affordance, so hide it
-        // once `recurrenceRuleId` is set. Reschedule (this same card's date/time picker) and
-        // Skip (Status card, elsewhere) are the only exception verbs.
-        onDateToggle={
-          isDraft || recurrenceRuleId || !visitId
-            ? undefined
-            : (enabled) => {
-                if (!enabled) unscheduleVisit.mutate({ visitId })
-              }
-        }
-      />
-      <AssigneeRow value={assigneeWorkerId} onChange={handleAssigneeChange} />
-      {workOrderRecordId && (
-        <EventRepeatSection
-          label={editor.repeatLabel}
-          detail={
-            // Plan 30 §F.4 — a rule-less visit on an already-recurring work order can't pick up
-            // a cadence of its own (one rule per job); the hint explains why the row is locked.
-            editor.repeatLocked
-              ? 'This job already repeats — this is an extra visit.'
-              : editor.repeatMode === 'custom'
-                ? (editor.recurrenceSummary ?? undefined)
-                : undefined
+      <div className='space-y-2'>
+        <EventDateTimeSection
+          start={startTime}
+          end={endTime}
+          warnings={hints}
+          renderTimeEditor={(props) => <InlineEventTimePicker {...props} />}
+          onChange={handleDateTimeChange}
+          // Plan 30 §D.1 — series visits never go back to the backlog (server rejects it too);
+          // the clear-date toggle is a series visit's disguised unschedule affordance, so hide it
+          // once `recurrenceRuleId` is set. Reschedule (this same card's date/time picker) and
+          // Skip (Status card, elsewhere) are the only exception verbs.
+          onDateToggle={
+            isDraft || recurrenceRuleId || !visitId
+              ? undefined
+              : (enabled) => {
+                  if (!enabled) unscheduleVisit.mutate({ visitId })
+                }
           }
-          disabled={editor.repeatLocked}
-          renderEditor={(close) => (
-            <RepeatEditor
-              editor={editor}
-              // Draft mode has no Save — the staged Repeat commits with the Schedule button.
-              saving={setRecurrence.isPending}
-              onSave={
-                isDraft
-                  ? undefined
-                  : () => {
-                      commitRecurrence()
-                      close()
-                    }
-              }
-            />
-          )}
-          onOpenChange={(open) => {
-            // Non-draft close-without-save = discard (Save cleared `repeatsTouched` already);
-            // draft mode keeps its staged edits for the Schedule commit.
-            if (!open && !isDraft && editor.repeatsTouched) editor.resetToRule()
-          }}
         />
-      )}
-      {isDraft && (
-        <EventPopoverFooter>
-          <Button
-            size='sm'
-            className='w-full'
-            loading={scheduleVisit.isPending || addVisit.isPending || setRecurrence.isPending}
-            disabled={!canSave}
-            onClick={handleSchedule}>
-            Schedule
-          </Button>
-        </EventPopoverFooter>
-      )}
+        <AssigneeRow value={assigneeWorkerId} onChange={handleAssigneeChange} />
+        {workOrderRecordId && (
+          <EventRepeatSection
+            label={editor.repeatLabel}
+            detail={
+              // Plan 30 §F.4 — a rule-less visit on an already-recurring work order can't pick up
+              // a cadence of its own (one rule per job); the hint explains why the row is locked.
+              editor.repeatLocked
+                ? 'This job already repeats — this is an extra visit.'
+                : editor.repeatMode === 'custom'
+                  ? (editor.recurrenceSummary ?? undefined)
+                  : undefined
+            }
+            disabled={editor.repeatLocked}
+            renderEditor={(close) => (
+              <RepeatEditor
+                editor={editor}
+                // Draft mode has no Save — the staged Repeat commits with the Schedule button.
+                saving={setRecurrence.isPending}
+                onSave={
+                  isDraft
+                    ? undefined
+                    : () => {
+                        commitRecurrence()
+                        close()
+                      }
+                }
+              />
+            )}
+            onOpenChange={(open) => {
+              // Non-draft close-without-save = discard (Save cleared `repeatsTouched` already);
+              // draft mode keeps its staged edits for the Schedule commit.
+              if (!open && !isDraft && editor.repeatsTouched) editor.resetToRule()
+            }}
+          />
+        )}
+        {isDraft && (
+          <EventPopoverFooter>
+            <Button
+              size='sm'
+              className='w-full'
+              loading={scheduleVisit.isPending || addVisit.isPending || setRecurrence.isPending}
+              disabled={!canSave}
+              onClick={handleSchedule}>
+              Schedule
+            </Button>
+          </EventPopoverFooter>
+        )}
+      </div>
     </EventPopoverBody>
   )
 }

--- a/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
@@ -144,7 +144,7 @@ export function DispatchSidebar({
     <ModuleSidebar
       open={open}
       onOpenChange={setOpen}
-      className='py-0 [&_[data-sidebar=content]]:pt-0!'
+      className='py-0 [&_[data-sidebar=content]]:pt-0! [&_[data-sidebar=content]]:pe-0!'
       footer={
         /* Plan 30 §B.1 — "Show canceled" pinned footer toggle. Default off (canceled/skipped
          * visits hidden from the board + mini-calendar day markers). Rooted in a `<div>` (not

--- a/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
+++ b/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
@@ -256,7 +256,15 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
         const durationMinutes = differenceInMinutes(originalEnd, originalStart)
         const newEnd = addMinutes(newStart, durationMinutes)
 
-        if (newStart.getTime() !== originalStart.getTime()) {
+        // Commit when EITHER the start time OR the resource column changed. In resource/day/timeline
+        // views (one row per assignee), dropping a chip onto a different worker at the SAME time
+        // slot is a pure reassignment — `newStart` is unchanged, so a time-only guard swallowed it
+        // silently. Every column always reports a `resourceId` (even the source's own), so the
+        // undefined check just skips views with no resource lane (plain week/month).
+        const resourceChanged =
+          overData.resourceId !== undefined && overData.resourceId !== calendarEvent.resourceId
+
+        if (newStart.getTime() !== originalStart.getTime() || resourceChanged) {
           onEventDrop?.(
             calendarEvent,
             newStart,

--- a/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
@@ -185,8 +185,11 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
 }: HorizontalTimelineViewProps<T>) {
   const selection = useCalendarSelection()
   const scrollRef = useRef<HTMLDivElement>(null)
+  // The non-scrolling view root — carries the `--tl-*` CSS vars (so the single full-height rail
+  // handle, a sibling of the scroll area, can read `--tl-rail-width`) and is the positioning
+  // context for that handle.
+  const rootRef = useRef<HTMLDivElement>(null)
   const [snapEnabled, setSnapEnabled] = useState(true)
-  const [viewportHeight, setViewportHeight] = useState(0)
 
   // Controlled-or-internal zoom/rail state — web passes the persisted store values; standalone
   // usage still gets working gestures.
@@ -236,7 +239,7 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   commitCallbacksRef.current = { onHourWidthChange, onRailWidthChange, onLaneHeightChange }
 
   const applyCssVars = useCallback(() => {
-    const el = scrollRef.current
+    const el = rootRef.current
     if (!el) return
     const liveHourWidth = zoomGestureRef.current?.hourWidth ?? geoRef.current.hourWidth
     const liveRailWidth = railGestureRef.current?.width ?? geoRef.current.railWidth
@@ -280,8 +283,6 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
     const applySize = () => {
       const avail = Math.max(1, el.clientWidth - railWidth)
       setSnapEnabled(dayWidth <= avail)
-      // Body min-height: the row/day grid stretches to fill the viewport even with few workers.
-      setViewportHeight(el.clientHeight)
     }
     applySize()
     const observer = new ResizeObserver(applySize)
@@ -749,11 +750,14 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   const rowHeightExpr = (ri: number) =>
     `calc(${rowLaneCounts[ri] ?? 1} * var(--tl-lane-height) + ${TimelineRowPadding}px)`
   const headerHeight = DateLabelHeight + HourTickHeight
-  // The body (rows + day sections + their vertical day borders) fills at least the visible
-  // viewport below the header — the grid never stops short above empty screen space.
+  // The body (rows + day sections + their vertical day borders) fills at least the viewport below
+  // the header — the grid never stops short above empty screen space. Uses CSS `100%` (against the
+  // scroll viewport) rather than the JS-measured `viewportHeight`, so it's correct on the very
+  // first paint after a refresh — `viewportHeight` starts at 0 and only fills after a measure pass,
+  // which was the "gutter not full height for a beat" flash.
   const bodyHeightExpr = `max(calc(${totalLanes} * var(--tl-lane-height) + ${
     resources.length * TimelineRowPadding
-  }px), ${Math.max(0, viewportHeight - headerHeight)}px)`
+  }px), calc(100% - ${headerHeight}px))`
 
   // ── current time: 60s-interval state, window-relative (NOT `useCurrentTimeIndicator`'s 24h-%
   // math — this view's x-axis is `hourWindow`, not the full day). The effect has an empty
@@ -784,23 +788,24 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
     `translateX(calc(var(--tl-rail-width) + ${index} * var(--tl-day-width) + var(--tl-zoom-comp, 0px)))`
 
   return (
-    <div data-slot='horizontal-timeline-view' className='flex min-h-0 flex-1 flex-col'>
-      <div
-        ref={scrollRef}
-        onScroll={handleScroll}
-        className='min-h-0 flex-1 overflow-auto'
-        style={
-          {
-            // Committed geometry — the always-run layout effect re-asserts live gesture values
-            // on top of these pre-paint (see `applyCssVars`).
-            '--tl-day-width': `${dayWidth}px`,
-            '--tl-rail-width': `${railWidth}px`,
-            '--tl-lane-height': `${laneHeight}px`,
-            '--tl-zoom-comp': '0px',
-          } as CSSProperties
-        }>
+    <div
+      ref={rootRef}
+      data-slot='horizontal-timeline-view'
+      className='relative flex min-h-0 flex-1 flex-col'
+      style={
+        {
+          // Committed geometry — the always-run layout effect re-asserts live gesture values
+          // on top of these pre-paint (see `applyCssVars`). Lives on the root so both the scroll
+          // content (descendants) and the sibling rail handle can read the vars.
+          '--tl-day-width': `${dayWidth}px`,
+          '--tl-rail-width': `${railWidth}px`,
+          '--tl-lane-height': `${laneHeight}px`,
+          '--tl-zoom-comp': '0px',
+        } as CSSProperties
+      }>
+      <div ref={scrollRef} onScroll={handleScroll} className='min-h-0 flex-1 overflow-auto'>
         <div
-          className='relative'
+          className='relative flex flex-col'
           style={{
             width: `calc(var(--tl-rail-width) + ${dayCount} * var(--tl-day-width))`,
             minHeight: `calc(${headerHeight}px + ${bodyHeightExpr})`,
@@ -814,11 +819,6 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
               className='bg-background text-muted-foreground/70 sticky left-0 z-10 flex items-center justify-center text-sm'
               style={{ width: 'var(--tl-rail-width)', height: headerHeight }}>
               <span className='max-[479px]:sr-only'>{format(new Date(), 'O')}</span>
-              {/* Rail-width drag handle (corner segment) — one continuous strip with the rail's. */}
-              <div
-                {...railResizeHandleProps}
-                className='hover:bg-border/70 absolute inset-y-0 right-0 z-20 w-[5px] cursor-col-resize touch-none select-none'
-              />
               <StickyRailShadow />
             </div>
 
@@ -924,41 +924,38 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
             })}
           </div>
 
-          {/* Sticky-left worker rail — pinned left only (no `top`: it scrolls vertically with
-              the rows below; its flow position already starts below the sticky header). */}
+          {/* Sticky-left worker rail — pinned left only (no `top`: it scrolls vertically with the
+              rows below; its flow position already starts below the sticky header). `flex-1` makes
+              it fill the flex-col container's full height (measurement-free — no `viewportHeight`),
+              so its `bg-background` never stops short of the bottom on refresh or across zoom. */}
           <div
-            className='bg-background sticky left-0 z-20'
+            className='bg-background sticky left-0 z-20 flex-1'
             style={{ width: 'var(--tl-rail-width)' }}>
-            <div className='relative' style={{ height: bodyHeightExpr }}>
-              {resources.map((resource, ri) => (
-                <div
-                  key={resource.id}
-                  className='border-border/70 text-muted-foreground/80 absolute right-0 left-0 flex items-center border-b px-2 text-sm'
-                  style={{
-                    top: rowTopExpr(ri),
-                    height: rowHeightExpr(ri),
-                  }}>
-                  {resource.header ?? resource.label}
-                  {/* Lane-height drag handle — the row's bottom border (plan 43). Any row's
-                      border rescales the global lane height; double-click resets. */}
-                  <div
-                    onPointerDown={(e) => beginLaneResize(e, ri)}
-                    onPointerMove={moveLaneResize}
-                    onPointerUp={endLaneResize}
-                    onPointerCancel={endLaneResize}
-                    onDoubleClick={resetLaneHeight}
-                    data-marquee-ignore
-                    className='hover:bg-border/70 absolute inset-x-0 -bottom-[2px] z-20 h-[5px] cursor-row-resize touch-none select-none'
-                  />
-                </div>
-              ))}
-              {/* Rail-width drag handle (body segment). */}
+            {resources.map((resource, ri) => (
               <div
-                {...railResizeHandleProps}
-                className='hover:bg-border/70 absolute inset-y-0 right-0 z-20 w-[5px] cursor-col-resize touch-none select-none'
-              />
-              <StickyRailShadow />
-            </div>
+                key={resource.id}
+                className='border-border/70 text-muted-foreground/80 absolute right-0 left-0 flex items-center border-b px-2 text-sm'
+                style={{
+                  top: rowTopExpr(ri),
+                  height: rowHeightExpr(ri),
+                }}>
+                {resource.header ?? resource.label}
+                {/* Lane-height drag handle — the row's bottom border (plan 43). Any row's
+                    border rescales the global lane height; double-click resets. */}
+                <div
+                  onPointerDown={(e) => beginLaneResize(e, ri)}
+                  onPointerMove={moveLaneResize}
+                  onPointerUp={endLaneResize}
+                  onPointerCancel={endLaneResize}
+                  onDoubleClick={resetLaneHeight}
+                  data-marquee-ignore
+                  className='hover:bg-border/70 absolute inset-x-0 -bottom-[2px] z-20 h-[5px] cursor-row-resize touch-none select-none'
+                />
+              </div>
+            ))}
+            {/* Right-edge rail shadow — anchors to the flex-1 gutter directly (its `inset-y-0`
+                needs a real parent height; an inner `h-full` wrapper collapsed to 0 under flex). */}
+            <StickyRailShadow />
           </div>
 
           {virtualItems.map((v) => (
@@ -987,6 +984,19 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
             />
           ))}
         </div>
+      </div>
+
+      {/* Single full-height rail-width handle — lives in the non-scrolling root at the rail's right
+          edge (`left: var(--tl-rail-width)`). The rail is sticky-pinned, so its right edge is always
+          at that x regardless of horizontal scroll; a fixed handle here stays aligned while spanning
+          the FULL height (header included) as one hover target. Regular border hairline at rest,
+          `bg-info` (and slightly thicker) on hover to signal it drags. `-translate-x-full` keeps the
+          grab strip inside the rail (off the day grid); the visible line sits on the seam. */}
+      <div
+        {...railResizeHandleProps}
+        className='group absolute inset-y-0 z-40 w-[6px] -translate-x-full cursor-col-resize touch-none select-none'
+        style={{ left: 'var(--tl-rail-width)' }}>
+        <div className='bg-border/70 absolute inset-y-0 right-0 w-px transition-all group-hover:w-[2px] group-hover:bg-info' />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

A batch of dispatch board & calendar timeline fixes.

- **Availability shading** — off-hours bands are now tagged with the worker **column id** (not `userId`), so worker rows actually shade to their off-hours. Team rows (no per-team schedule) fall back to **org hours** instead of reading as available 24/7.
- **Cross-column drag** — dropping a chip onto a different worker column at the **same time slot** now commits as a reassignment (previously swallowed by a time-only guard in `CalendarDndProvider`).
- **Slot-create popover** — survives the right-click context menu's close-time focus churn via `onFocusOutside` preventDefault (fixes the "flash at 0,0 then vanish" bug). Outside-click and Escape still close it.
- **Timeline rail** — single full-height rail-width drag handle in the non-scrolling root; body/rail height now uses CSS `100%` rather than a JS-measured viewport height, so the gutter is full-height on first paint (no measurement flash).
- **Spacing polish** — schedule popover section spacing, mini-calendar bottom padding, sidebar content padding-end.

## Test plan

- [ ] Day/timeline view: worker rows show off-hours shading; team rows shade to org hours
- [ ] Drag a visit onto a different worker at the same time → reassigns
- [ ] Right-click a slot → create popover opens and stays open
- [ ] Refresh timeline view → rail gutter is full-height immediately; rail-width handle drags