### PR TITLE
fix(dispatch): full-height calendar gutter, header scroll shadow & worker row avatars

### DIFF
--- a/apps/web/src/components/calendar/ui/source-toggle-group.tsx
+++ b/apps/web/src/components/calendar/ui/source-toggle-group.tsx
@@ -9,7 +9,7 @@ import {
   SidebarMenuItem,
 } from '@auxx/ui/components/sidebar'
 import { cn } from '@auxx/ui/lib/utils'
-import { Eye, EyeOff } from 'lucide-react'
+import { EyeOff } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
@@ -23,6 +23,12 @@ interface SourceToggleRowProps {
   color?: string
   visible: boolean
   onToggle: () => void
+  /** Leading visual. Defaults to a small color dot; pass a richer node (e.g. a `VisualIcon`
+   * avatar/glyph for dispatch workers) to override it. */
+  icon?: ReactNode
+  /** Extra classes on the row (e.g. a muted tint for a synthetic row). Merged before the
+   * hidden-state dim, so hiding still wins. */
+  className?: string
 }
 
 /**
@@ -32,26 +38,39 @@ interface SourceToggleRowProps {
  * bespoke groups (e.g. dispatch's `WorkersGroup`, which needs worker avatars) can reuse the
  * row without adopting `SourceToggleGroup`'s generic list rendering.
  */
-export function SourceToggleRow({ id, label, color, visible, onToggle }: SourceToggleRowProps) {
+export function SourceToggleRow({
+  id,
+  label,
+  color,
+  visible,
+  onToggle,
+  icon,
+  className,
+}: SourceToggleRowProps) {
   return (
     <SidebarMenuItem>
       <SidebarItem
         id={id}
         name={label}
         onClick={onToggle}
-        className={cn(!visible && 'text-muted-foreground/70')}
+        className={cn(className, !visible && 'text-muted-foreground/70')}
         icon={
-          <span
-            className='size-2 shrink-0 rounded-full'
-            style={{ backgroundColor: color ?? DEFAULT_TOGGLE_COLOR }}
-          />
+          icon ?? (
+            <span
+              className='size-2 shrink-0 rounded-full'
+              style={{ backgroundColor: color ?? DEFAULT_TOGGLE_COLOR }}
+            />
+          )
         }
         end={
-          visible ? (
-            <EyeOff className='hidden size-3.5 text-muted-foreground group-hover/menu-item:block' />
-          ) : (
-            <Eye className='size-3.5 text-muted-foreground opacity-60' />
-          )
+          <EyeOff
+            className={cn(
+              'size-3.5 text-muted-foreground',
+              // Visible: eye-off only reveals on hover (click to hide). Hidden: eye-off stays
+              // put as the persistent hidden-state indicator (click to show).
+              visible ? 'hidden group-hover/menu-item:block' : 'opacity-60'
+            )}
+          />
         }
       />
     </SidebarMenuItem>

--- a/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
@@ -8,18 +8,19 @@ import { SidebarGroup, SidebarGroupCollapse, SidebarMenu } from '@auxx/ui/compon
 import { cn } from '@auxx/ui/lib/utils'
 import { useDndContext, useDroppable } from '@dnd-kit/core'
 import { UserPlus } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 import { SourceToggleRow } from '~/components/calendar/ui/source-toggle-group'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
+import { VisualIcon } from '~/components/icons/ui/visual-icon'
 import { type BoardWorker, UNASSIGNED_RESOURCE_ID } from '../board/types'
-import { DEFAULT_WORKER_COLOR, UNASSIGNED_COLOR, workerDisplayName } from '../board/utils'
+import { workerDisplayName } from '../board/utils'
 import { WorkerDialog } from '../worker-dialog'
 
 interface WorkersGroupProps {
   workers: BoardWorker[]
   /** Per-worker `OPTION_COLORS` entry, keyed by `DispatchWorker.id` (`use-board-data.ts`'s
-   * `colorByWorkerId` — the stored `SelectOptionColor` id resolved to its palette entry; this
-   * row's dot reads `.hex`, since several palette ids can't render directly as a CSS color). */
+   * `colorByWorkerId` — the stored `SelectOptionColor` id resolved to its palette entry). The
+   * row's `VisualIcon` fallback reads `.id` (the palette id) to tint the photoless avatar glyph. */
   colorByWorkerId: Map<string, OptionColor>
   hiddenWorkerIds: string[]
   onToggleWorker: (workerId: string) => void
@@ -41,18 +42,20 @@ function DroppableWorkerRow({
   id,
   dropAssigneeWorkerId,
   label,
-  color,
+  icon,
   visible,
   onToggle,
   mode,
+  className,
 }: {
   id: string
   dropAssigneeWorkerId: string | null
   label: string
-  color: string
+  icon: ReactNode
   visible: boolean
   onToggle: () => void
   mode?: 'map' | 'calendar'
+  className?: string
 }) {
   const { active } = useDndContext()
   const isCompatibleDrag =
@@ -79,7 +82,14 @@ function DroppableWorkerRow({
           isOver &&
           'bg-primary/20 outline-primary/80 ring-2 ring-inset ring-primary/60'
       )}>
-      <SourceToggleRow id={id} label={label} color={color} visible={visible} onToggle={onToggle} />
+      <SourceToggleRow
+        id={id}
+        label={label}
+        icon={icon}
+        visible={visible}
+        onToggle={onToggle}
+        className={className}
+      />
     </div>
   )
 }
@@ -132,27 +142,47 @@ export function WorkersGroup({
       />
       <SidebarGroupCollapse open={open}>
         <SidebarMenu>
+          <DroppableWorkerRow
+            id={UNASSIGNED_RESOURCE_ID}
+            dropAssigneeWorkerId={null}
+            label='Unassigned'
+            icon={
+              <VisualIcon
+                fallbackIconId='user-x'
+                fallbackColor='gray'
+                size='sm'
+                inverse
+                frameClassName='-ms-0.5 inset-shadow-xs inset-shadow-black/20'
+              />
+            }
+            className='text-primary-400'
+            visible={!hidden.has(UNASSIGNED_RESOURCE_ID)}
+            onToggle={() => onToggleWorker(UNASSIGNED_RESOURCE_ID)}
+            mode={mode}
+          />
           {workers.map((worker) => (
             <DroppableWorkerRow
               key={worker.id}
               id={worker.id}
               dropAssigneeWorkerId={worker.id}
               label={workerDisplayName(worker)}
-              color={colorByWorkerId.get(worker.id)?.hex ?? DEFAULT_WORKER_COLOR}
+              icon={
+                <VisualIcon
+                  value={worker.user?.image}
+                  fallbackIconId={worker.type === 'team' ? 'users' : 'user'}
+                  fallbackColor={colorByWorkerId.get(worker.id)?.id ?? 'indigo'}
+                  size='sm'
+                  inverse
+                  imageFallback
+                  fit='cover'
+                  frameClassName='-ms-0.5 inset-shadow-xs inset-shadow-black/20'
+                />
+              }
               visible={!hidden.has(worker.id)}
               onToggle={() => onToggleWorker(worker.id)}
               mode={mode}
             />
           ))}
-          <DroppableWorkerRow
-            id={UNASSIGNED_RESOURCE_ID}
-            dropAssigneeWorkerId={null}
-            label='Unassigned'
-            color={UNASSIGNED_COLOR}
-            visible={!hidden.has(UNASSIGNED_RESOURCE_ID)}
-            onToggle={() => onToggleWorker(UNASSIGNED_RESOURCE_ID)}
-            mode={mode}
-          />
         </SidebarMenu>
       </SidebarGroupCollapse>
       <WorkerDialog open={addOpen} onOpenChange={setAddOpen} workerId={null} />

--- a/packages/ui/src/components/event-calendar/background-events.tsx
+++ b/packages/ui/src/components/event-calendar/background-events.tsx
@@ -46,7 +46,7 @@ export function BackgroundEventsLayer({
   // Vertical (`'y'`) grids offset every segment's `top` by the visible window's first hour — the
   // grid no longer starts at 00:00 when the board crops to working hours. `'x'` (timeline) takes
   // its window via explicit props instead.
-  const { start: gridStartHour } = useHourWindow()
+  const { start: gridStartHour, end: gridEndHour } = useHourWindow()
   const dayEvents = events.filter((bg) => {
     if (bg.resourceId !== undefined && bg.resourceId !== resourceId) return false
     if (bg.date !== undefined && !isSameDay(bg.date, day)) return false
@@ -99,8 +99,14 @@ export function BackgroundEventsLayer({
         const end = new Date(bg.end)
         const startHour = isSameDay(day, start) ? getHours(start) + getMinutes(start) / 60 : 0
         const endHour = isSameDay(day, end) ? getHours(end) + getMinutes(end) / 60 : 24
-        const top = (startHour - gridStartHour) * cellHeight
-        const height = (endHour - startHour) * cellHeight
+        // Clamp to the visible hour window (mirrors the `'x'` branch) — an unclamped segment
+        // running past the window's last hour overflows the grid and stretches the scroll area
+        // below the gutter/rail shadow.
+        const clampedStart = Math.min(Math.max(startHour, gridStartHour), gridEndHour)
+        const clampedEnd = Math.min(Math.max(endHour, gridStartHour), gridEndHour)
+        if (clampedEnd <= clampedStart) return null
+        const top = (clampedStart - gridStartHour) * cellHeight
+        const height = (clampedEnd - clampedStart) * cellHeight
 
         return (
           <div

--- a/packages/ui/src/components/event-calendar/header-scroll-shadow.tsx
+++ b/packages/ui/src/components/event-calendar/header-scroll-shadow.tsx
@@ -1,0 +1,27 @@
+// packages/ui/src/components/event-calendar/header-scroll-shadow.tsx
+
+'use client'
+
+/**
+ * Soft drop shadow hanging below a calendar view's sticky header, visible only once the grid is
+ * scrolled down — the sidebar ScrollArea's top-fade recipe, minus the hairline (the headers keep
+ * their own always-on `border-b`). Renders inside the sticky header at `top-full`, so it spans the
+ * full content width — hour gutter / worker rail included — and rides above the z-20 sticky rails.
+ *
+ * Visibility is driven by a `data-scrolled-y` attribute on the scroll container (which must carry
+ * `group/grid-scroll`), mirrored render-free from `scrollTop` via `syncScrolledY` in the view's
+ * scroll handler.
+ */
+export function HeaderScrollShadow() {
+  return (
+    <div
+      aria-hidden
+      className='pointer-events-none absolute inset-x-0 top-full h-2 bg-gradient-to-b from-black/10 to-transparent opacity-0 transition-opacity duration-150 ease-out group-data-[scrolled-y]/grid-scroll:opacity-100'
+    />
+  )
+}
+
+/** Mirrors `scrollTop > 0` onto the scroll element as `data-scrolled-y` — call on every scroll. */
+export function syncScrolledY(el: HTMLElement) {
+  el.toggleAttribute('data-scrolled-y', el.scrollTop > 0)
+}

--- a/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
@@ -29,6 +29,7 @@ import {
   TimelineRailWidthMin,
   TimelineRowPadding,
 } from './constants'
+import { HeaderScrollShadow, syncScrolledY } from './header-scroll-shadow'
 import { useDayStream } from './hooks/use-day-stream'
 import { useCalendarSelection } from './selection/calendar-selection-context'
 import { StickyRailShadow } from './sticky-rail-shadow'
@@ -358,6 +359,7 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   // the snap-scroll but still emit the (rounded) leftmost day.
   const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const handleScroll = useCallback(() => {
+    if (scrollRef.current) syncScrolledY(scrollRef.current)
     clearTimeout(settleTimeoutRef.current)
     settleTimeoutRef.current = setTimeout(() => {
       if (programmaticScrollRef.current) return
@@ -803,7 +805,10 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
           '--tl-zoom-comp': '0px',
         } as CSSProperties
       }>
-      <div ref={scrollRef} onScroll={handleScroll} className='min-h-0 flex-1 overflow-auto'>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className='group/grid-scroll min-h-0 flex-1 overflow-auto'>
         <div
           className='relative flex flex-col'
           style={{
@@ -922,6 +927,8 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
                 </div>
               )
             })}
+
+            <HeaderScrollShadow />
           </div>
 
           {/* Sticky-left worker rail — pinned left only (no `top`: it scrolls vertically with the

--- a/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { EventGap, EventHeight, GridHeaderHeight, WeekCellsHeight } from './constants'
 import { DayResourceGroup } from './day-resource-group'
 import { EventItem } from './event-item'
+import { HeaderScrollShadow, syncScrolledY } from './header-scroll-shadow'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
 import { useDayStream } from './hooks/use-day-stream'
 import { HourGutter } from './hour-gutter'
@@ -223,6 +224,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
   // viewport we skip the snap-scroll but still emit the (rounded) leftmost day.
   const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const handleScroll = useCallback(() => {
+    if (scrollRef.current) syncScrolledY(scrollRef.current)
     clearTimeout(settleTimeoutRef.current)
     settleTimeoutRef.current = setTimeout(() => {
       if (programmaticScrollRef.current) return
@@ -304,7 +306,14 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
 
   return (
     <div data-slot='resource-timeline-view' className='flex min-h-0 flex-1 flex-col'>
-      <div ref={scrollRef} onScroll={handleScroll} className='min-h-0 flex-1 overflow-auto'>
+      {/* `bg-background` lives on the scroll container (not the gutter): its height is always the
+          viewport (`flex-1`), zoom-independent, so the white sidebar fills full height and can never
+          collapse. The gutter keeps its own `bg-background` only to occlude horizontally-scrolled
+          day columns behind the sticky hour labels. */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className='group/grid-scroll bg-background min-h-0 flex-1 overflow-auto'>
         <div
           className='relative'
           style={{
@@ -315,10 +324,13 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
           <div
             className='bg-background/80 border-border/70 sticky top-0 z-30 border-b backdrop-blur-md'
             style={{ height: headerHeight }}>
-            {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip. */}
+            {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip.
+                Width comes from the SAME responsive class as `HourGutter` (not the JS-measured
+                `gutterWidth` state, which starts at a wrong 48 guess) so corner + gutter body
+                agree on the first paint — no width flash on refresh. */}
             <div
-              className='bg-background sticky left-0 z-10 flex flex-col'
-              style={{ width: gutterWidth, height: headerHeight }}>
+              className='bg-background sticky left-0 z-10 flex w-12 flex-col sm:w-14'
+              style={{ height: headerHeight }}>
               <div
                 className='text-muted-foreground/70 flex items-center justify-center text-sm'
                 style={{ height: DateLabelHeight + WorkerHeaderHeight }}>
@@ -459,10 +471,14 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
                 </div>
               )
             })}
+
+            <HeaderScrollShadow />
           </div>
 
           {/* Sticky hour gutter — pinned left only (no `top`: it scrolls vertically with the
-              hour grid; its flow position already starts below the sticky header). */}
+              hour grid; its flow position already starts below the sticky header). Opaque
+              `bg-background` occludes horizontally-scrolled day columns; full-height white below the
+              grid comes from the scroll container, not this element's height. */}
           <div ref={gutterRef} className='bg-background sticky left-0 z-20 w-fit'>
             <HourGutter
               hours={hours}

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import { EventGap, EventHeight, GridHeaderHeight, WeekCellsHeight } from './constants'
 import { EventItem } from './event-item'
+import { HeaderScrollShadow, syncScrolledY } from './header-scroll-shadow'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
 import { useDayStream } from './hooks/use-day-stream'
 import { HourGutter } from './hour-gutter'
@@ -196,6 +197,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
   // otherwise a pure vertical (time-axis) scroll would yank the view sideways.
   const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const handleScroll = useCallback(() => {
+    if (scrollRef.current) syncScrolledY(scrollRef.current)
     clearTimeout(settleTimeoutRef.current)
     settleTimeoutRef.current = setTimeout(() => {
       if (programmaticScrollRef.current) return
@@ -270,7 +272,14 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
 
   return (
     <div data-slot='week-view' className='flex min-h-0 flex-1 flex-col'>
-      <div ref={scrollRef} onScroll={handleScroll} className='min-h-0 flex-1 overflow-auto'>
+      {/* `bg-background` lives on the scroll container (not the gutter): its height is always the
+          viewport (`flex-1`), zoom-independent, so the white sidebar fills full height and can never
+          collapse. The gutter keeps its own `bg-background` only to occlude horizontally-scrolled
+          day columns behind the sticky hour labels. */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className='group/grid-scroll bg-background min-h-0 flex-1 overflow-auto'>
         <div
           className='relative'
           style={{
@@ -281,10 +290,13 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
           <div
             className='bg-background/80 border-border/70 sticky top-0 z-30 border-b backdrop-blur-md'
             style={{ height: headerHeight }}>
-            {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip. */}
+            {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip.
+                Width comes from the SAME responsive class as `HourGutter` (not the JS-measured
+                `gutterWidth` state, which starts at a wrong 48 guess) so corner + gutter body
+                agree on the first paint — no width flash on refresh. */}
             <div
-              className='bg-background sticky left-0 z-10 flex flex-col'
-              style={{ width: gutterWidth, height: headerHeight }}>
+              className='bg-background sticky left-0 z-10 flex w-12 flex-col sm:w-14'
+              style={{ height: headerHeight }}>
               <div
                 className='text-muted-foreground/70 flex items-center justify-center text-sm'
                 style={{ height: HeaderLabelHeight }}>
@@ -389,10 +401,14 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
                 </div>
               )
             })}
+
+            <HeaderScrollShadow />
           </div>
 
           {/* Sticky hour gutter — pinned left only (no `top`: it must scroll vertically with
-              the hour grid; its flow position already starts below the sticky header). */}
+              the hour grid; its flow position already starts below the sticky header). Opaque
+              `bg-background` occludes horizontally-scrolled day columns; full-height white below the
+              grid comes from the scroll container, not this element's height. */}
           <div ref={gutterRef} className='bg-background sticky left-0 z-20 w-fit'>
             <HourGutter
               hours={hours}


### PR DESCRIPTION
## Summary

Follow-on polish/fixes to plan 46 (calendar bugfixes) across the dispatch board calendar.

### Gutter/rail shadow stopped short when scrolling below the grid (day/week)

The vertical (`'y'`) branch of `BackgroundEventsLayer` offset off-hours shading bands by the hour window's start but never clamped to its end — with the board cropped to working hours, a band running to midnight rendered ~300px past the grid bottom. Those absolute bands stretched the scroll container's scrollable overflow, so scrolling into that zone showed shaded columns with no gutter white and no `StickyRailShadow`. Now clamped to `[windowStart, windowEnd]`, mirroring the `'x'` (timeline) branch — which is why timeline was unaffected.

Also: `bg-background` moved onto the day/week scroll containers (viewport-height, zoom-independent), and the header corner takes its width from the same responsive class as `HourGutter` so corner + gutter agree on first paint.

### Header scroll shadow (day/week/timeline)

New `HeaderScrollShadow`: a soft 8px gradient hanging below the sticky header (all-day lane / hour ticks), fading in only once the grid is scrolled down — the sidebar ScrollArea's top-fade recipe, minus the hairline (headers keep their always-on `border-b`). Renders inside the sticky header at `top-full`, so it spans the full content width — hour gutter / worker rail included — and sits above the z-20 rails. Visibility is mirrored render-free from `scrollTop` onto a `data-scrolled-y` attribute in each view's existing `onScroll` (no React state, no re-renders).

### Sidebar workers group: avatars instead of color dots

Worker rows render `VisualIcon` (photo, or a palette-tinted glyph — team/user/unassigned variants) instead of the small color dot; Unassigned moved to the top of the list; hidden rows keep a persistent eye-off indicator. `SourceToggleRow` gains `icon`/`className` overrides for this.

## Test plan

- [x] Day + week: scroll below the viewport height — gutter stays white, rail shadow runs full height, off-hours shading ends at the grid bottom (`scrollHeight === contentHeight` verified via CDP)
- [x] Day/week/timeline: header shadow fades in on scroll down, disappears at `scrollTop === 0`, continuous across gutter + grid
- [x] Biome clean