### PR TITLE
feat(permissions): client capability delivery + realtime merge

### DIFF
--- a/apps/web/src/app/(protected)/layout.tsx
+++ b/apps/web/src/app/(protected)/layout.tsx
@@ -6,6 +6,7 @@ import { redirect } from 'next/navigation'
 import Script from 'next/script'
 import type { ReactNode } from 'react'
 import { getSession } from '~/auth/session'
+import { CapabilitiesProvider } from '~/providers/capabilities-provider'
 import { DehydratedStateProvider } from '~/providers/dehydrated-state-provider'
 import { FeatureFlagProvider, OrganizationIdProvider } from '~/providers/feature-flag-provider'
 import { PostHogProvider } from '~/providers/posthog-provider'
@@ -73,7 +74,9 @@ export default async function ProtectedLayout({ children }: ProtectedLayoutProps
       <DehydratedStateProvider initialState={dehydratedState}>
         <OrganizationIdProvider>
           <FeatureFlagProvider>
-            <PostHogProvider>{children}</PostHogProvider>
+            <CapabilitiesProvider>
+              <PostHogProvider>{children}</PostHogProvider>
+            </CapabilitiesProvider>
           </FeatureFlagProvider>
         </OrganizationIdProvider>
       </DehydratedStateProvider>

--- a/apps/web/src/components/global/sidebar/nav-main.tsx
+++ b/apps/web/src/components/global/sidebar/nav-main.tsx
@@ -12,6 +12,7 @@ import { usePathname } from 'next/navigation'
 import type * as React from 'react'
 import type { SidebarProps } from '~/constants/menu'
 import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { CollapsibleSidebarSection } from './collapsible-sidebar-section'
 import { SidebarGroupHeader } from './sidebar-group-header'
@@ -28,6 +29,7 @@ export function NavMain({ menu, itemActions }: Props) {
   const pathname = usePathname()
   const { getGroupOpen, toggleGroup } = useSidebarStateContext()
   const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
   const { isAdminOrOwner } = useUser()
   const isOpen = getGroupOpen('configurations')
 
@@ -47,14 +49,18 @@ export function NavMain({ menu, itemActions }: Props) {
     return fullUrl
   }
 
-  // Filter items by feature access (and admin-only gates for top-level entries)
+  // Filter items by feature access + Layer-2 capability (and admin-only gates
+  // for top-level entries). The capability check collapses a field seat's
+  // sidebar to just their granted surfaces automatically.
   const filteredItems = menu.items
     .filter((item) => !item.featureKey || hasAccess(item.featureKey))
+    .filter((item) => !item.permissionKey || can(item.permissionKey))
     .filter((item) => !item.adminOnly || isAdminOrOwner)
     .map((item) => ({
       ...item,
       items: item.items
         ?.filter((sub) => !sub.featureKey || hasAccess(sub.featureKey))
+        .filter((sub) => !sub.permissionKey || can(sub.permissionKey))
         .filter((sub) => !sub.adminOnly || isAdminOrOwner),
     }))
     .filter((item) => !item.items || item.items.length > 0)

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -58,6 +58,8 @@ export type SidebarProps = {
   cloudOnly?: boolean
   /** Feature key required for this menu item to be visible */
   featureKey?: string
+  /** Layer-2 capability key required for this item to be visible (§7.3) */
+  permissionKey?: string
   /** When true, only admins/owners see this item */
   adminOnly?: boolean
 } & FieldProps
@@ -102,6 +104,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     slug: 'agents',
     icon: <Bot />,
     featureKey: 'agents',
+    permissionKey: 'agents.manage',
     adminOnly: true,
   },
   {
@@ -117,6 +120,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     slug: 'workflows',
     icon: <Zap />,
     featureKey: 'workflows',
+    permissionKey: 'workflows.manage',
   },
   { id: 'tasks', label: 'Tasks', slug: 'tasks', icon: <CheckSquare /> },
   {
@@ -125,6 +129,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     slug: 'schedule',
     icon: <CalendarClock />,
     featureKey: 'dispatch',
+    permissionKey: 'dispatch.mySchedule',
   },
   {
     id: 'dispatch',
@@ -132,6 +137,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     slug: 'dispatch',
     icon: <Truck />,
     featureKey: 'dispatch',
+    permissionKey: 'dispatch.board.view',
     skipParentSlug: true,
     // Navigable group: clicking the row opens the module home (settings until the
     // M2 board lands); the chevron toggles the sub-items independently.

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -1,0 +1,134 @@
+// apps/web/src/providers/capabilities-provider.tsx
+'use client'
+
+import type { PermissionKey } from '@auxx/lib/permissions/client'
+import { PERMISSION_REGISTRY_MAP } from '@auxx/lib/permissions/client'
+import type { SubscribeHandlers } from '@auxx/lib/realtime/client'
+import { rooms } from '@auxx/lib/realtime/client'
+import type React from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { useRealtimeRoom } from '~/realtime/hooks'
+import { api } from '~/trpc/react'
+import { useDehydratedOrganization, useDehydratedUser } from './dehydrated-state-provider'
+import { useFeatureFlags, useOrganizationIdContext } from './feature-flag-provider'
+
+/** Why a capability check failed — drives UX (§7.3). */
+export type DeniedReason = 'plan' | 'permission' | null
+
+/** Shape of the capabilities context value. */
+interface CapabilitiesContextType {
+  /**
+   * Plan-AND-capability boolean — the same formula as the server, so they
+   * cannot disagree: `hasAccess(meta.featureKey) && capabilities.has(key)`.
+   */
+  can: (key: PermissionKey | string) => boolean
+  /**
+   * Why `can(key)` is false. `'plan'` (checked first) → the org could buy it,
+   * render an upgrade surface; `'permission'` → the member has nothing to buy,
+   * hide the entry point or render read-only; `null` → access is allowed.
+   */
+  deniedBy: (key: PermissionKey | string) => DeniedReason
+  /** The current member's composed capability keys. */
+  capabilities: PermissionKey[]
+  isLoading: boolean
+}
+
+const CapabilitiesContext = createContext<CapabilitiesContextType | undefined>(undefined)
+
+/**
+ * Provides the current member's Layer-2 capability set, seeded from dehydrated
+ * state and live-merged over realtime.
+ *
+ * Sibling of {@link FeatureFlagProvider} — MUST mount INSIDE it so `can()` can
+ * AND the plan layer via `useFeatureFlags().hasAccess`. Seeds the key set from
+ * the active org's dehydrated `capabilities`; on a `capabilities:changed` event
+ * (user room or org events room) it refetches `permissions.myCapabilities` (a
+ * cheap user-cache read) and swaps the set — menus/gates re-render automatically.
+ * Server enforcement never trusts this copy, so the realtime path is UX-only.
+ */
+export function CapabilitiesProvider({ children }: { children: React.ReactNode }) {
+  const { organizationId } = useOrganizationIdContext()
+  const user = useDehydratedUser()
+  const org = useDehydratedOrganization(organizationId)
+  const { hasAccess } = useFeatureFlags()
+
+  const dehydratedCaps = org?.capabilities
+  // Stable signature of the dehydrated seed so the re-seed effect only fires on
+  // an actual org switch (the dehydrated blob is static for a page load).
+  const seedKey = useMemo(
+    () => (dehydratedCaps ? [...dehydratedCaps].join(',') : ''),
+    [dehydratedCaps]
+  )
+
+  const [capKeys, setCapKeys] = useState<ReadonlySet<string>>(() => new Set(dehydratedCaps ?? []))
+
+  // Re-seed from dehydrated state when the active org changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: seedKey encodes dehydratedCaps
+  useEffect(() => {
+    setCapKeys(new Set(dehydratedCaps ?? []))
+  }, [organizationId, seedKey])
+
+  // Disabled by default — the dehydrated set is the initial source; the realtime
+  // event triggers a manual refetch, and the result swaps into local state.
+  const myCapabilities = api.permissions.myCapabilities.useQuery(undefined, {
+    enabled: false,
+  })
+
+  useEffect(() => {
+    if (myCapabilities.data) setCapKeys(new Set(myCapabilities.data.keys))
+  }, [myCapabilities.data])
+
+  const refetch = myCapabilities.refetch
+  const handlers = useMemo<SubscribeHandlers>(
+    () => ({
+      onEvent: (event) => {
+        if (event === 'capabilities:changed') void refetch()
+      },
+    }),
+    [refetch]
+  )
+
+  // Live merge — subscribe to both the current user's room (user grants,
+  // role/seat changes) and the org events room (role/group grants fan-out).
+  useRealtimeRoom(user ? rooms.user(user.id) : null, handlers)
+  useRealtimeRoom(organizationId ? rooms.orgEvents(organizationId) : null, handlers)
+
+  const value = useMemo<CapabilitiesContextType>(() => {
+    const can = (key: PermissionKey | string): boolean => {
+      const meta = PERMISSION_REGISTRY_MAP.get(key as PermissionKey)
+      const planOk = meta?.featureKey ? hasAccess(meta.featureKey) : true
+      return planOk && capKeys.has(key)
+    }
+
+    const deniedBy = (key: PermissionKey | string): DeniedReason => {
+      const meta = PERMISSION_REGISTRY_MAP.get(key as PermissionKey)
+      const planOk = meta?.featureKey ? hasAccess(meta.featureKey) : true
+      const hasCap = capKeys.has(key)
+      if (hasCap && planOk) return null
+      // Plan first — an upgrade surface — then permission (hide / read-only).
+      if (!planOk) return 'plan'
+      return 'permission'
+    }
+
+    return {
+      can,
+      deniedBy,
+      capabilities: [...capKeys] as PermissionKey[],
+      isLoading: false,
+    }
+  }, [capKeys, hasAccess])
+
+  return <CapabilitiesContext.Provider value={value}>{children}</CapabilitiesContext.Provider>
+}
+
+/**
+ * Consume the capability context. Combines the plan (Layer 1) and member
+ * capability (Layer 2) layers into one `can()` / `deniedBy()` surface.
+ */
+export function useAccess(): CapabilitiesContextType {
+  const context = useContext(CapabilitiesContext)
+  if (context === undefined) {
+    throw new Error('useAccess must be used within a CapabilitiesProvider')
+  }
+  return context
+}

--- a/packages/lib/src/dehydration/service.ts
+++ b/packages/lib/src/dehydration/service.ts
@@ -12,7 +12,7 @@ import { configService } from '@auxx/credentials'
 import { getDeploymentMode } from '@auxx/deployment'
 import { createScopedLogger } from '@auxx/logger'
 import { execSync } from 'child_process'
-import { getOrgCache, getUserCache } from '../cache'
+import { getCachedUserCapabilities, getOrgCache, getUserCache } from '../cache'
 import type { CachedSubscription } from '../cache/org-cache-keys'
 import { SETTINGS_CATALOG } from '../settings'
 import type { DehydratedEnvironment, DehydratedOrganization, DehydratedState } from './types'
@@ -181,7 +181,7 @@ export class DehydrationService {
     userId: string,
     orgId: string
   ): Promise<DehydratedOrganization> {
-    const [orgData, userData] = await Promise.all([
+    const [orgData, userData, capabilities] = await Promise.all([
       // Org-scoped: features, subscription, profile, overages, channelProviders
       this.orgCache.getOrRecompute(orgId, [
         'features',
@@ -192,6 +192,8 @@ export class DehydrationService {
       ]),
       // User+org-scoped: settings
       this.userCache.getOrRecompute(userId, ['userSettings'], orgId),
+      // User+org-scoped: composed Layer-2 capability set (one cached read, no DB).
+      getCachedUserCapabilities(userId, orgId),
     ])
 
     const { features, subscription, orgProfile, overages, channelProviders } = orgData
@@ -212,6 +214,7 @@ export class DehydrationService {
       demoExpiresAt: orgProfile.demoExpiresAt,
       subscription: toClientSubscription(subscription),
       features: features ?? {},
+      capabilities: capabilities.keys,
       overages,
       settings: userData.userSettings,
       hasIntegrations,

--- a/packages/lib/src/dehydration/types.ts
+++ b/packages/lib/src/dehydration/types.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/dehydration/types.ts
 
+import type { PermissionKey } from '../permissions/capabilities/registry'
+
 /**
  * Window global interface for dehydrated state
  */
@@ -171,6 +173,9 @@ export interface DehydratedOrganization {
 
   // Feature permissions
   features: Record<string, boolean | number | '+'>
+
+  /** The ACTIVE org's composed Layer-2 capability keys for THIS user (§7.1). */
+  capabilities: PermissionKey[]
 
   /** Features that exceed the current plan's limits (empty if none) */
   overages: Array<{

--- a/packages/lib/src/members/member-service.ts
+++ b/packages/lib/src/members/member-service.ts
@@ -1222,6 +1222,19 @@ export class MemberService {
       })
     }
 
+    // Recompose caches + nudge the client: a role change shifts the member's
+    // composed capability set (role defaults). Mirrors the seat-type path.
+    const { onCacheEvent } = await import('../cache')
+    await onCacheEvent('member.role.changed', {
+      orgId: organizationId,
+      userId: memberToUpdateId,
+    })
+    const { DehydrationCacheService } = await import('../dehydration/cache')
+    await new DehydrationCacheService().invalidateUser(memberToUpdateId)
+    // UX-only live merge for the affected member's open clients.
+    const { getRealtimeService, publishCapabilitiesChanged } = await import('../realtime')
+    await publishCapabilitiesChanged(getRealtimeService(), { userId: memberToUpdateId })
+
     logger.info('Member role updated successfully', {
       organizationId,
       memberToUpdateId,
@@ -1297,6 +1310,9 @@ export class MemberService {
       })
       const { DehydrationCacheService } = await import('../dehydration/cache')
       await new DehydrationCacheService().invalidateUser(memberToUpdateId)
+      // UX-only live merge — the seat ceiling changed this member's composed set.
+      const { getRealtimeService, publishCapabilitiesChanged } = await import('../realtime')
+      await publishCapabilitiesChanged(getRealtimeService(), { userId: memberToUpdateId })
     }
 
     logger.info('Member seat type updated successfully', {

--- a/packages/lib/src/permissions/capabilities/grant-service.ts
+++ b/packages/lib/src/permissions/capabilities/grant-service.ts
@@ -65,6 +65,9 @@ async function requireGranularPermissions(db: Database, organizationId: string):
  */
 async function emitGrantChanged(grantee: GranteeRef): Promise<void> {
   const dehydration = new DehydrationCacheService()
+  // Lazy import — the cache invalidation path lazily imports realtime, so this
+  // module must not statically import the realtime barrel back (import cycle).
+  const { getRealtimeService, publishCapabilitiesChanged } = await import('../../realtime')
 
   if (grantee.granteeType === 'user') {
     await onCacheEvent('permission-grant.changed', {
@@ -72,6 +75,8 @@ async function emitGrantChanged(grantee: GranteeRef): Promise<void> {
       userId: grantee.granteeId,
     })
     await dehydration.invalidateUser(grantee.granteeId)
+    // UX-only live merge: nudge just that user's client to refetch.
+    await publishCapabilitiesChanged(getRealtimeService(), { userId: grantee.granteeId })
     return
   }
 
@@ -81,6 +86,8 @@ async function emitGrantChanged(grantee: GranteeRef): Promise<void> {
     broadcastUserKeys: true,
   })
   await dehydration.invalidateOrganization(grantee.organizationId)
+  // Org-wide grant → nudge every open client in the org.
+  await publishCapabilitiesChanged(getRealtimeService(), { orgId: grantee.organizationId })
 }
 
 /**

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -3,6 +3,23 @@
  * Client-safe exports for the permissions module.
  * Does not pull in server-only dependencies.
  */
+
+// ── Capability registry (Layer 2) — client-safe: registry.ts only imports
+//    `FeatureKey` from `./types`, which is already client-exported above.
+export type { AreaMetadata, PermissionMetadata } from './capabilities/registry'
+export {
+  AREA_ORDER,
+  Area,
+  buildAreaLevels,
+  expandLevelsToKeys,
+  isPermissionKey,
+  Level,
+  PERMISSION_AREAS,
+  PERMISSION_REGISTRY,
+  PERMISSION_REGISTRY_MAP,
+  PermissionKey,
+  parseAreaLevels,
+} from './capabilities/registry'
 export type { Overage } from './overage-detection-service'
 export type {
   FeatureDefinition,

--- a/packages/lib/src/realtime/index.ts
+++ b/packages/lib/src/realtime/index.ts
@@ -51,6 +51,7 @@ export { shapeMailEventForLens } from './mail-event-shaping'
 export {
   flushMailBatch,
   publishAgentUpdated,
+  publishCapabilitiesChanged,
   publishCountsChanged,
   publishDataConnectorSync,
   publishDataExportJob,

--- a/packages/lib/src/realtime/publish-helpers.ts
+++ b/packages/lib/src/realtime/publish-helpers.ts
@@ -328,6 +328,34 @@ export async function publishCountsChanged(realtimeService: RealtimeService, use
   await realtimeService.publish(rooms.user(userId), 'counts:changed', { userId }).catch(() => {})
 }
 
+/**
+ * Publish `capabilities:changed` — a signal to the client `CapabilitiesProvider`
+ * to refetch `permissions.myCapabilities` and swap its key set (permissions plan
+ * §7.2). UX-only: server enforcement never trusts the client copy, so a missed
+ * event just degrades to "stale until reload".
+ *
+ * Target a single user (`{ userId }` → their private room) when the affected
+ * member is known — e.g. a user grant or a single member's role/seat change; use
+ * the org-wide event (`{ orgId }` → the org events room) when a role/group grant
+ * can shift many members' composed sets.
+ *
+ * Fire-and-forget: errors swallowed so a Pusher hiccup never blocks the write.
+ */
+export async function publishCapabilitiesChanged(
+  realtimeService: RealtimeService,
+  target: { userId: string } | { orgId: string }
+) {
+  if ('userId' in target) {
+    await realtimeService
+      .publish(rooms.user(target.userId), 'capabilities:changed', { userId: target.userId })
+      .catch(() => {})
+    return
+  }
+  await realtimeService
+    .publish(rooms.orgEvents(target.orgId), 'capabilities:changed', { orgId: target.orgId })
+    .catch(() => {})
+}
+
 /** Publish `thread:deleted` on the inbox channels + grantee fanout. */
 export async function publishThreadDeleted(
   realtimeService: RealtimeService,


### PR DESCRIPTION
## What

**Phase 3** of the leveled capability layer (`plans/permissions/capability-layer-and-worker-seat.md` §7). The server substrate (registry, leveled composition, seat ceilings, enforcement, `permissions` router) shipped in #1275; this wires it to the client so field/worker seats render a narrowed UI and grant/role changes take effect without a reload.

## Changes

- **Client export** — `permissions/client` now re-exports the capability registry (`PermissionKey`, `Area`, `Level`, `PERMISSION_REGISTRY(_MAP)`, `PERMISSION_AREAS`, `expandLevelsToKeys`, `parseAreaLevels`, `isPermissionKey`, `buildAreaLevels`) so client code can import it without pulling the server barrel. Registry is genuinely client-safe (only depends on `FeatureKey`); no `'use client'` directive (avoids the proxy-stub trap).
- **Dehydration** — `DehydratedOrganization.capabilities` populated from `getCachedUserCapabilities` inside the existing `Promise.all` (one extra cached read, no new DB query).
- **`CapabilitiesProvider` + `useAccess()`** — `can()` / `deniedBy()` AND the plan layer (Layer 1) with the member capability set (Layer 2) using the **same formula as the server**, so they can't disagree. Seeds from dehydrated state, re-seeds on org switch, live-merges over realtime. Mounted inside `FeatureFlagProvider`.
- **Realtime push** — `publishCapabilitiesChanged` targets the user room (user grants, single-member role/seat changes) or the org events room (role/group grants); the provider subscribes to both and refetches `permissions.myCapabilities`. Lazy realtime import avoids the barrel cycle. UX-only — server enforcement never trusts the client copy.
- **`member.role.changed` emit** — the event was declared in the invalidation graph but never emitted; `updateMemberRole` now fires it (+ dehydration invalidation), so a role change actually recomposes the capability cache.
- **Menu** — items gain `permissionKey`; the sidebar renderer gates on it. Full members keep all tagged items via role defaults; field seats (ceiling-zeroed) collapse to their granted surfaces automatically.

## Verification

- Per-package typecheck (lib + web): all touched lines clean. Remaining errors in the touched files are pre-existing baseline breakage (unchanged from `main`).
- lint-staged/biome clean.

## Notes

- No new tests — phase 3 is provider/UI wiring; the composition unit tests (unchanged) still cover the model.
- Discovered a **separate pre-existing bug**: `updateMemberRole`/remove path reference undefined `updaterModel`/`removerModel`. Fixed in a follow-up PR, not here.

## Follow-up phases

4 (seat management UI + restricted drawer), 5 (billing seed + overage split — pending tier seat counts), 6 (incremental `isAdminOrOwner` migration).