### PR TITLE
feat(permissions): restricted record drawer for field seats

### DIFF
--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -3,6 +3,7 @@
 
 import type { DrawerTabCardDefinition, Resource } from '@auxx/lib/resources/client'
 import { getEntityDrawerConfig, parseRecordId } from '@auxx/lib/resources/client'
+import { COMMUNICATION_TIMELINE_EVENT_TYPES } from '@auxx/lib/timeline/client'
 import type { RecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
@@ -56,9 +57,10 @@ import {
   useDehydratedUser,
 } from '~/providers/dehydrated-state-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useRecordDrawerReadOnly } from '../records/use-record-drawer-read-only'
 import { ThreadVisitCard } from './cards/thread-visit-card'
 import { DrawerCardActionsProvider } from './drawer-card-actions'
-import { getTabCardComponent, getTabComponent } from './drawer-tab-registry'
+import { getTabCardComponent, getTabComponent, isRestrictedDrawerTab } from './drawer-tab-registry'
 
 interface BaseEntityDrawerProps {
   /** RecordId in format "entityDefinitionId:entityInstanceId" */
@@ -91,6 +93,13 @@ interface BaseEntityDrawerProps {
   minWidth?: number
   /** Optional maxWidth for dockable drawer */
   maxWidth?: number
+  /**
+   * Restricted (read-only) mode — fields become non-editable, communication
+   * panels/tabs and edit affordances hide (§11.4). Defaults to the current
+   * member's derived read-only state when omitted, so drawers opened directly
+   * (contact/dispatch) are also restricted for field seats.
+   */
+  readOnly?: boolean
 }
 
 /**
@@ -145,6 +154,8 @@ interface DrawerRecordFrameProps {
   /** Host card content (person card, entity card, etc.) — rendered only when `isBase`. */
   cardContent?: React.ReactNode
   focusComposerTrigger?: number
+  /** Restricted (read-only) mode — threaded uniformly into every frame (§11.4). */
+  readOnly: boolean
 }
 
 /**
@@ -162,6 +173,7 @@ function DrawerRecordFrame({
   entityTypeOverride,
   cardContent,
   focusComposerTrigger = 0,
+  readOnly,
 }: DrawerRecordFrameProps) {
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' })
   const { hasAccess } = useFeatureFlags()
@@ -174,8 +186,11 @@ function DrawerRecordFrame({
   // Get resource metadata
   const { resource } = useResource(entityDefinitionId)
 
-  // Get record data
-  const { record } = useRecord({
+  // Get record data. `isNotFound` covers a drill/peek into a record the server
+  // denies for an out-of-scope field seat (`recordsViewLinked` row scope) — the
+  // batch fetch omits it, so we render a graceful "unavailable" state instead of
+  // an endless skeleton (§11.4, deliverable #5).
+  const { record, isNotFound, hasLoadedOnce } = useRecord({
     recordId,
     enabled: true,
   })
@@ -230,9 +245,12 @@ function DrawerRecordFrame({
       { value: 'comments', label: 'Comments', icon: MessagesSquare },
       { value: 'tasks', label: 'Tasks', icon: ListTodo },
     ]
+      // Restricted mode drops the communication/comment tabs (§11.4).
+      .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType ?? '', tab.value))
 
     const additionalTabs = drawerConfig.additionalTabs
       .filter((tab) => !tab.featureGate || hasAccess(tab.featureGate))
+      .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType ?? '', tab.value))
       .map((tab) => ({
         value: tab.value,
         label: tab.label,
@@ -241,7 +259,7 @@ function DrawerRecordFrame({
 
     // Overview first, then entity-specific tabs, then the shared timeline/comments/tasks tabs
     return [overviewTab, ...additionalTabs, ...trailingTabs]
-  }, [drawerConfig, hasAccess])
+  }, [drawerConfig, hasAccess, readOnly, entityType])
 
   // Tab order persistence
   const tabOrderStorageKey = React.useMemo(() => {
@@ -295,6 +313,18 @@ function DrawerRecordFrame({
 
   if (!drawerConfig || !entityType) return null
 
+  // Restricted drill/peek into an out-of-scope record: the server denied the
+  // fetch (row scope), so show a graceful message rather than an endless
+  // skeleton. Gated on `readOnly` so full members keep byte-identical behavior
+  // for genuinely deleted records (deliverable #5).
+  if (readOnly && hasLoadedOnce && isNotFound) {
+    return (
+      <div className='flex flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground'>
+        This record isn’t available with your current access.
+      </div>
+    )
+  }
+
   // The existing tabbed overview body — rendered verbatim whether or not this
   // entityType has drill panels, so it becomes the root NavStackPanel's
   // content when it does (byte-identical render otherwise).
@@ -327,6 +357,7 @@ function DrawerRecordFrame({
                   entityInstanceId={entityInstanceId}
                   recordId={recordId}
                   record={record}
+                  readOnly={readOnly}
                 />
                 <Section
                   title='Details'
@@ -334,7 +365,7 @@ function DrawerRecordFrame({
                   initialOpen
                   collapsible={false}
                   icon={<HouseIcon className='size-4' />}>
-                  <EntityFields recordId={recordId} />
+                  <EntityFields recordId={recordId} readOnly={readOnly} canEdit={!readOnly} />
                 </Section>
                 {/* Context card: visit facts when opened over a chat thread */}
                 <ThreadVisitCard
@@ -348,6 +379,7 @@ function DrawerRecordFrame({
                   entityInstanceId={entityInstanceId}
                   recordId={recordId}
                   record={record}
+                  readOnly={readOnly}
                 />
               </ScrollArea>
             </TabsContent>
@@ -355,16 +387,24 @@ function DrawerRecordFrame({
             <TabsContent value='timeline' className='w-full h-full mt-0'>
               <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
                 <div className='p-3 flex-1 flex-col flex'>
-                  <TimelineTab recordId={recordId} />
+                  <TimelineTab
+                    recordId={recordId}
+                    excludeEventTypes={readOnly ? COMMUNICATION_TIMELINE_EVENT_TYPES : undefined}
+                  />
                 </div>
               </ScrollArea>
             </TabsContent>
 
-            <TabsContent value='comments' className='w-full h-full mt-0'>
-              <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
-                <DrawerComments recordId={recordId} focusComposerTrigger={focusComposerTrigger} />
-              </ScrollArea>
-            </TabsContent>
+            {/* Comments tab is dropped from the tab bar in restricted mode; keep
+                its content unmounted too so a stale `?tab=comments` deep link
+                can't surface it. */}
+            {!readOnly && (
+              <TabsContent value='comments' className='w-full h-full mt-0'>
+                <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
+                  <DrawerComments recordId={recordId} focusComposerTrigger={focusComposerTrigger} />
+                </ScrollArea>
+              </TabsContent>
+            )}
 
             <TabsContent value='tasks' className='w-full h-full mt-0'>
               <TasksSection recordId={recordId} />
@@ -373,6 +413,7 @@ function DrawerRecordFrame({
             {/* Dynamic tabs from registry */}
             {drawerConfig.additionalTabs
               .filter((tab) => !tab.featureGate || hasAccess(tab.featureGate))
+              .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType, tab.value))
               .map((tab) => (
                 <TabsContent key={tab.value} value={tab.value} className='w-full'>
                   <LazyTabComponent
@@ -459,7 +500,16 @@ export function BaseEntityDrawer({
   onWidthChange,
   minWidth = 400,
   maxWidth = 800,
+  readOnly: readOnlyProp,
 }: BaseEntityDrawerProps) {
+  // Restricted (read-only) mode — the explicit prop from `RecordDrawer` wins;
+  // fall back to the member's derived state so drawers opened directly (contact,
+  // dispatch board) are restricted for field seats too (§11.4). One derivation
+  // for the whole frame stack: every `DrawerRecordFrame` (base + peek/drill)
+  // gets the same flag, so a drilled record is read-only just like its parent.
+  const derivedReadOnly = useRecordDrawerReadOnly()
+  const readOnly = readOnlyProp ?? derivedReadOnly
+
   // Cross-record peek stack — `frames = [recordId, ...peek]`. Called
   // unconditionally (recordId may be null while the drawer is closed).
   const peek = useRecordPeekStack(recordId)
@@ -566,7 +616,7 @@ export function BaseEntityDrawer({
         actions={
           <>
             {isBaseTop && headerActions}
-            <AppRecordActions recordId={top} recordType={topEntityType} compact />
+            {!readOnly && <AppRecordActions recordId={top} recordType={topEntityType} compact />}
             {!isBaseTop && topRecordLink && (
               <Tooltip content='Open full page'>
                 <Button variant='ghost' size='icon-xs' onClick={() => router.push(topRecordLink)}>
@@ -607,6 +657,7 @@ export function BaseEntityDrawer({
                   entityTypeOverride={entityTypeOverride}
                   cardContent={cardContent}
                   focusComposerTrigger={focusComposerTrigger}
+                  readOnly={readOnly}
                 />
               </NavStackPanel>
             ))}
@@ -667,6 +718,7 @@ function TabCards({
   entityInstanceId,
   recordId,
   record,
+  readOnly,
 }: {
   tab: string
   position: 'before' | 'after'
@@ -675,8 +727,12 @@ function TabCards({
   entityInstanceId: string
   recordId: RecordId
   record?: Record<string, unknown>
+  readOnly?: boolean
 }) {
-  const cards = drawerConfig.tabCards?.[tab]?.filter((c) => (c.position ?? 'after') === position)
+  const cards = drawerConfig.tabCards?.[tab]
+    ?.filter((c) => (c.position ?? 'after') === position)
+    // Restricted mode drops communication overview cards (e.g. work_order:communications).
+    .filter((c) => !readOnly || !isRestrictedDrawerTab(entityType, c.value))
   if (!cards?.length) return null
 
   return (

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -188,6 +188,31 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
 }
 
 /**
+ * Drawer tab / overview-card values hidden in the restricted (read-only) drawer
+ * — the customer-communication surfaces a field seat must never see on a linked
+ * record (§11.4). Matched by either the bare tab/card value (`comments`) or the
+ * qualified `entityType:value` form (`contact:conversations`). Tabs/cards NOT in
+ * this set are unaffected, so full-member drawers stay byte-identical.
+ */
+const RESTRICTED_HIDDEN_DRAWER_TABS = new Set<string>([
+  'comments',
+  'contact:conversations',
+  'work_order:communications',
+])
+
+/**
+ * Whether a drawer tab or overview card is hidden in restricted (read-only) mode.
+ * @param entityType - The frame's entity type (e.g. `contact`, `work_order`)
+ * @param value - The tab or card value (e.g. `comments`, `conversations`)
+ */
+export function isRestrictedDrawerTab(entityType: string, value: string): boolean {
+  return (
+    RESTRICTED_HIDDEN_DRAWER_TABS.has(value) ||
+    RESTRICTED_HIDDEN_DRAWER_TABS.has(`${entityType}:${value}`)
+  )
+}
+
+/**
  * Get tab component loader for entityType and tab value
  * @returns Component loader or undefined if not found
  */

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -45,6 +45,7 @@ import { ManualTriggerButton } from '~/components/workflow/manual-trigger-button
 import { useConfirm } from '~/hooks/use-confirm'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useDockStore } from '~/stores/dock-store'
+import { useRecordDrawerReadOnly } from './use-record-drawer-read-only'
 
 /** Props for RecordDrawer */
 interface RecordDrawerProps {
@@ -76,6 +77,12 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   const isDocked = useEffectiveDockState()
   const dockedWidth = useDockStore((state) => state.dockedWidth)
   const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+
+  // Restricted (read-only) mode for field seats — computed once here (the drawer
+  // root) and threaded into BaseEntityDrawer + used to gate every write
+  // affordance in this header. Full members (`records.edit`) get `false`, so the
+  // drawer is byte-identical to before (§11.4).
+  const readOnly = useRecordDrawerReadOnly()
 
   // Parse recordId to get components
   const { entityDefinitionId, entityInstanceId } = recordId
@@ -187,7 +194,22 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   // Confirm dialog for delete
   const [confirm, ConfirmDialog] = useConfirm()
 
-  const actions = drawerConfig?.actions
+  // In restricted mode every mutating action is forced off — this collapses
+  // `hasMoreActions` and the standalone delete button below, matching the
+  // read-only fields (§11.4, deliverable #4).
+  const actions = React.useMemo(() => {
+    const base = drawerConfig?.actions
+    if (!readOnly) return base
+    return {
+      ...base,
+      enableEdit: false,
+      enableRename: false,
+      enableArchive: false,
+      enableLink: false,
+      enableMerge: false,
+      enableDelete: false,
+    }
+  }, [drawerConfig?.actions, readOnly])
 
   /** Handle close */
   const handleClose = React.useCallback(() => {
@@ -267,6 +289,7 @@ export const RecordDrawer = React.memo(function RecordDrawer({
         onWidthChange={setDockedWidth}
         minWidth={400}
         maxWidth={800}
+        readOnly={readOnly}
         focusComposerTrigger={focusComposerTrigger}
         onClose={handleClose}
         headerIcon={
@@ -279,8 +302,10 @@ export const RecordDrawer = React.memo(function RecordDrawer({
         headerTitle={resource?.label || 'Record'}
         headerActions={
           <>
-            {/* Entity-specific header actions (compose for contacts, reply for tickets, etc.) */}
-            {entityType &&
+            {/* Entity-specific header actions (compose for contacts, reply for
+                tickets, etc.) — write affordances, hidden in restricted mode. */}
+            {!readOnly &&
+              entityType &&
               headerActionComponents.map((Action, i) => (
                 <Action
                   key={i}
@@ -293,14 +318,16 @@ export const RecordDrawer = React.memo(function RecordDrawer({
                 />
               ))}
 
-            {/* Run workflow */}
-            <ManualTriggerButton
-              recordId={recordId}
-              buttonVariant='ghost'
-              buttonSize='icon-xs'
-              buttonClassName='rounded-full'
-              tooltipContent='Run workflow'
-            />
+            {/* Run workflow — hidden in restricted mode (a mutating trigger). */}
+            {!readOnly && (
+              <ManualTriggerButton
+                recordId={recordId}
+                buttonVariant='ghost'
+                buttonSize='icon-xs'
+                buttonClassName='rounded-full'
+                tooltipContent='Run workflow'
+              />
+            )}
 
             {/* More actions dropdown */}
             {hasMoreActions && (
@@ -409,7 +436,7 @@ export const RecordDrawer = React.memo(function RecordDrawer({
         }
         cardContent={
           <div className='flex gap-3 py-2 px-3 flex-row items-center justify-start border-b'>
-            {avatarField && recordId && avatarFieldDef?.fieldType === 'FILE' ? (
+            {avatarField && recordId && avatarFieldDef?.fieldType === 'FILE' && !readOnly ? (
               <AvatarUploadIcon
                 recordId={recordId}
                 avatarUrl={cachedRecord?.avatarUrl as string}

--- a/apps/web/src/components/records/use-record-drawer-read-only.ts
+++ b/apps/web/src/components/records/use-record-drawer-read-only.ts
@@ -1,0 +1,20 @@
+// apps/web/src/components/records/use-record-drawer-read-only.ts
+'use client'
+
+import { PermissionKey } from '@auxx/lib/permissions/client'
+import { useAccess } from '~/providers/capabilities-provider'
+
+/**
+ * Single source of truth for the record drawer's restricted (read-only) mode.
+ *
+ * A member is read-only in the drawer when they cannot edit CRM records — i.e.
+ * a field ("worker") seat that has `records.viewLinked` but not `records.edit`
+ * (the worker ceiling zeroes the `records` area). Full members — anyone with
+ * `records.edit` — get `false`, so the drawer stays exactly as before (§11.4,
+ * §2.K). Compute once near the drawer root and thread the boolean down; never
+ * call `useAccess()` in leaf drawer components.
+ */
+export function useRecordDrawerReadOnly(): boolean {
+  const { can } = useAccess()
+  return !can(PermissionKey.recordsEdit)
+}

--- a/apps/web/src/components/timeline/timeline-tab.tsx
+++ b/apps/web/src/components/timeline/timeline-tab.tsx
@@ -20,6 +20,11 @@ interface TimelineTabProps {
   emptyTitle?: string
   /** Optional: custom empty state description */
   emptyDescription?: React.ReactNode
+  /**
+   * Optional: event types to exclude server-side (e.g. the restricted
+   * drawer hides communication/comment events for field seats).
+   */
+  excludeEventTypes?: string[]
 }
 
 /** Empty state configuration per system entity type */
@@ -98,6 +103,7 @@ export function TimelineTab({
   isGroupingDisabled = false,
   emptyTitle,
   emptyDescription,
+  excludeEventTypes,
 }: TimelineTabProps) {
   // Normalize incoming recordId to canonical `<entityDefinitionId>:<instanceId>`
   // form so legacy `toRecordId('contact', id)` callers still hit the correct
@@ -111,6 +117,7 @@ export function TimelineTab({
         recordId: normalizedRecordId,
         limit,
         isGroupingDisabled,
+        eventTypeExcludeFilter: excludeEventTypes,
       },
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/apps/web/src/server/api/routers/timeline.ts
+++ b/apps/web/src/server/api/routers/timeline.ts
@@ -24,6 +24,7 @@ export const timelineRouter = createTRPCRouter({
         isGroupingDisabled: z.boolean().optional().default(false),
         actorFilter: z.array(z.string()).optional(),
         eventTypeFilter: z.array(z.string()).optional(),
+        eventTypeExcludeFilter: z.array(z.string()).optional(),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -70,6 +71,7 @@ export const timelineRouter = createTRPCRouter({
           isGroupingDisabled: input.isGroupingDisabled,
           actorFilter: input.actorFilter,
           eventTypeFilter: input.eventTypeFilter,
+          eventTypeExcludeFilter: input.eventTypeExcludeFilter,
         })
       } catch (error: any) {
         if (error instanceof TRPCError) throw error

--- a/packages/lib/src/timeline/client.ts
+++ b/packages/lib/src/timeline/client.ts
@@ -2,6 +2,7 @@
 // Client-safe timeline exports (no server dependencies)
 
 export {
+  COMMUNICATION_TIMELINE_EVENT_TYPES,
   ContactEventType,
   EntityInstanceEventType,
   SYSTEM_ENTITY_TYPES,

--- a/packages/lib/src/timeline/event-types.ts
+++ b/packages/lib/src/timeline/event-types.ts
@@ -137,6 +137,29 @@ export enum ThreadEventType {
   MERGED_FROM = 'thread:merged_from',
 }
 
+/**
+ * Communication / comment timeline event types — emails, thread messages,
+ * replies, and notes across contact / ticket / custom entities. The restricted
+ * record drawer (field-seat read-only mode) excludes these so a field seat never
+ * sees customer-communication history on a linked record.
+ */
+export const COMMUNICATION_TIMELINE_EVENT_TYPES: string[] = [
+  ContactEventType.EMAIL_RECEIVED,
+  ContactEventType.EMAIL_SENT,
+  ContactEventType.NOTE_ADDED,
+  ContactEventType.NOTE_UPDATED,
+  ContactEventType.NOTE_DELETED,
+  TicketEventType.MESSAGE_RECEIVED,
+  TicketEventType.MESSAGE_SENT,
+  TicketEventType.REPLY_SENT,
+  TicketEventType.NOTE_ADDED,
+  TicketEventType.NOTE_UPDATED,
+  TicketEventType.NOTE_DELETED,
+  EntityInstanceEventType.NOTE_ADDED,
+  EntityInstanceEventType.NOTE_UPDATED,
+  EntityInstanceEventType.NOTE_DELETED,
+]
+
 /** All timeline event types (expandable for other entities) */
 export type TimelineEventType =
   | ContactEventType

--- a/packages/lib/src/timeline/index.ts
+++ b/packages/lib/src/timeline/index.ts
@@ -2,6 +2,7 @@
 
 export { ContactTimelineTracker } from './contact-timeline-tracker'
 export {
+  COMMUNICATION_TIMELINE_EVENT_TYPES,
   ContactEventType,
   EntityInstanceEventType,
   SYSTEM_ENTITY_TYPES,

--- a/packages/lib/src/timeline/timeline-service.ts
+++ b/packages/lib/src/timeline/timeline-service.ts
@@ -110,6 +110,7 @@ export class TimelineService {
       isGroupingDisabled = false,
       actorFilter,
       eventTypeFilter,
+      eventTypeExcludeFilter,
     } = input
 
     // Decode cursor if provided
@@ -124,6 +125,7 @@ export class TimelineService {
       limit,
       actorFilter,
       eventTypeFilter,
+      eventTypeExcludeFilter,
     })
 
     if (result.isErr()) {

--- a/packages/lib/src/timeline/types.ts
+++ b/packages/lib/src/timeline/types.ts
@@ -110,7 +110,8 @@ export interface TimelineQueryInput {
   limit?: number
   isGroupingDisabled?: boolean
   actorFilter?: string[] // Filter by actor IDs
-  eventTypeFilter?: TimelineEventType[] // Filter by event types
+  eventTypeFilter?: TimelineEventType[] // Filter by event types (inclusion)
+  eventTypeExcludeFilter?: TimelineEventType[] // Exclude event types (e.g. restricted drawer)
 }
 
 /** Timeline query result */

--- a/packages/services/src/timeline/get-timeline.ts
+++ b/packages/services/src/timeline/get-timeline.ts
@@ -3,7 +3,7 @@
 import { database, schema } from '@auxx/database'
 import type { TimelineEventEntity } from '@auxx/database/types'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
-import { and, desc, eq, inArray, lt, or } from 'drizzle-orm'
+import { and, desc, eq, inArray, lt, notInArray, or } from 'drizzle-orm'
 import { ok } from 'neverthrow'
 import { fromDatabase } from '../shared/utils'
 
@@ -25,6 +25,8 @@ export interface GetTimelineEventsInput {
   limit?: number
   actorFilter?: string[]
   eventTypeFilter?: string[]
+  /** Exclude these event types (e.g. communication/comment events in the restricted drawer). */
+  eventTypeExcludeFilter?: string[]
 }
 
 /**
@@ -51,7 +53,15 @@ export interface GetTimelineEventsOutput {
  * @returns Result with timeline events and pagination info
  */
 export async function getTimelineEvents(input: GetTimelineEventsInput) {
-  const { organizationId, recordId, cursor, limit = 100, actorFilter, eventTypeFilter } = input
+  const {
+    organizationId,
+    recordId,
+    cursor,
+    limit = 100,
+    actorFilter,
+    eventTypeFilter,
+    eventTypeExcludeFilter,
+  } = input
 
   // Parse recordId to get components
   const { entityDefinitionId: entityType, entityInstanceId: entityId } = parseRecordId(recordId)
@@ -83,6 +93,10 @@ export async function getTimelineEvents(input: GetTimelineEventsInput) {
 
   if (eventTypeFilter && eventTypeFilter.length > 0) {
     conditions.push(inArray(schema.TimelineEvent.eventType, eventTypeFilter))
+  }
+
+  if (eventTypeExcludeFilter && eventTypeExcludeFilter.length > 0) {
+    conditions.push(notInArray(schema.TimelineEvent.eventType, eventTypeExcludeFilter))
   }
 
   // Fetch events with one extra to check for more


### PR DESCRIPTION
## What

**Phase 4b** of the leveled capability layer — a field ("worker") seat can **open** a linked record's drawer but only **read** it (§11.4, decision §2.K: reuse the full drawer in a restricted mode, not a second read-only surface).

The whole feature keys off **one rule** — `useRecordDrawerReadOnly() = !can('records.edit')` — computed once at the drawer root and threaded down as a boolean. Anyone with `records.edit` (every full member) gets `readOnly=false`, so the drawer is **byte-identical to before**.

## What restricted mode changes (field seats only)

- **Fields** render read-only (`EntityFields readOnly/canEdit`); header rename, compose/reply, run-workflow, avatar upload, `AppRecordActions`, and every `drawerConfig.actions.enable*` (Edit/Rename/Archive/Link/Merge/Delete) are off.
- **Communication surfaces hidden** — `comments`, `contact:conversations`, `work_order:communications` — via a `RESTRICTED_HIDDEN_DRAWER_TABS` set. The comments `TabsContent` is unmounted too, so a stale `?tab=comments` deep link can't surface it.
- **Timeline** excludes `COMMUNICATION_TIMELINE_EVENT_TYPES` via a new `eventTypeExcludeFilter` (`notInArray`) threaded router → lib → services (the existing filter was inclusion-only).
- **Peek/drill** frames inherit read-only from the one flag; an out-of-scope drill the server denies (the `recordsViewLinked` row scope) renders a graceful "not available" state instead of an endless skeleton.

## Deliberate scoping calls (flagged for review)

- **Drill panels stay editable.** A field seat legitimately edits visit reports (`dispatchVisitReports`) inside a work-order's drill panels — only CRM fields and cross-record peek frames go read-only. Threading the CRM `records.edit` flag into drill panels would wrongly disable that.
- **Tab gating via a set, not a fake `permissionKey`.** The three hidden surfaces are heterogeneous (trailing tab / additional tab / overview card) with no natural capability key; their real driver is the read-only flag.
- **`comment.create` guard not added.** It's a plain `protectedProcedure` and there's no `comments.*` registry key yet — that's a registry decision for the phase-6 enforcement sweep, not a drive-by. The client already hides the comments tab, so a field seat has no UI path to it.

## Verification

- Full-member path verified reduces to the prior code (`readOnly=false` → actions memo returns the untouched config, every `!readOnly` guard renders everything, filters are no-ops).
- Per-package typecheck: **zero new errors** in touched files. The 7 remaining errors (DockableDrawer optional-prop mismatch at base-entity-drawer:605-607, `useFieldValue`/`formatToDisplayValue` at record-drawer:138-172) are pre-existing — confirmed byte-identical to origin/main, just line-shifted.