### PR TITLE
feat(permissions): seat-class billing — worker seats + seed gap

### DIFF
--- a/packages/lib/src/members/member-service.ts
+++ b/packages/lib/src/members/member-service.ts
@@ -216,19 +216,27 @@ export class MemberService {
       })
     }
 
-    // 5. Check teammate limit BEFORE creating invitation
+    // 5. Check seat limit BEFORE creating invitation (§2.G — hard block, seat-class
+    // aware). A field (worker) seat is checked against the workerSeats limit, a full
+    // seat against teammates; each class counts only its own active members + pending
+    // invitations so the two don't cross-consume each other's bundled limits.
     const featureService = new FeaturePermissionService(this.db)
-    const memberLimit = await featureService.getLimit(organizationId, FeatureKey.teammates)
+    const isWorkerSeat = seatType === 'worker'
+    const seatLimit = await featureService.getLimit(
+      organizationId,
+      isWorkerSeat ? FeatureKey.workerSeats : FeatureKey.teammates
+    )
 
-    if (typeof memberLimit === 'number' && memberLimit >= 0) {
-      // Count active members + pending invitations
+    if (typeof seatLimit === 'number' && seatLimit >= 0) {
+      // Count active members + pending invitations OF THIS SEAT CLASS
       const [memberCount] = await this.db
         .select({ value: count() })
         .from(schema.OrganizationMember)
         .where(
           and(
             eq(schema.OrganizationMember.organizationId, organizationId),
-            eq(schema.OrganizationMember.status, 'ACTIVE')
+            eq(schema.OrganizationMember.status, 'ACTIVE'),
+            eq(schema.OrganizationMember.seatType, seatType)
           )
         )
 
@@ -239,21 +247,25 @@ export class MemberService {
           and(
             eq(schema.OrganizationInvitation.organizationId, organizationId),
             eq(schema.OrganizationInvitation.status, 'PENDING'),
+            eq(schema.OrganizationInvitation.seatType, seatType),
             gt(schema.OrganizationInvitation.expiresAt, new Date())
           )
         )
 
       const totalUsed = (memberCount?.value ?? 0) + (pendingCount?.value ?? 0)
-      if (totalUsed >= memberLimit) {
-        logger.warn('Invitation blocked: teammate limit reached', {
+      if (totalUsed >= seatLimit) {
+        logger.warn('Invitation blocked: seat limit reached', {
           organizationId,
-          limit: memberLimit,
+          seatType,
+          limit: seatLimit,
           activeMembers: memberCount?.value,
           pendingInvites: pendingCount?.value,
         })
         throw new TRPCError({
           code: 'FORBIDDEN',
-          message: `You have reached your team member limit (${memberLimit}). Upgrade your plan to add more teammates.`,
+          message: isWorkerSeat
+            ? `You have reached your field seat limit (${seatLimit}). Upgrade your plan to add more field seats.`
+            : `You have reached your team member limit (${seatLimit}). Upgrade your plan to add more teammates.`,
         })
       }
     }
@@ -656,34 +668,45 @@ export class MemberService {
       invitationId: invitation.id,
     })
     const featureService = new FeaturePermissionService(this.db)
-    // 1. Check Feature Limit BEFORE Transaction
-    const memberLimit = await featureService.getLimit(organizationId, FeatureKey.teammates)
+    // 1. Check Feature Limit BEFORE Transaction (seat-class aware §2.G — a field
+    // (worker) seat consumes a worker seat, checked against workerSeats; a full seat
+    // against teammates). Each class counts only its own active members.
+    const seatClass: SeatType = invitation.seatType === 'worker' ? 'worker' : 'full'
+    const isWorkerSeat = seatClass === 'worker'
+    const memberLimit = await featureService.getLimit(
+      organizationId,
+      isWorkerSeat ? FeatureKey.workerSeats : FeatureKey.teammates
+    )
     let activeMemberCount = 0 // Initialize count
 
     if (typeof memberLimit === 'number' && memberLimit >= 0) {
-      // Check numeric limits (including 0)
+      // Check numeric limits (including 0) — scoped to the joining seat class
       const [countRow] = await this.db
         .select({ value: count() })
         .from(schema.OrganizationMember)
         .where(
           and(
             eq(schema.OrganizationMember.organizationId, organizationId),
-            eq(schema.OrganizationMember.status, 'ACTIVE')
+            eq(schema.OrganizationMember.status, 'ACTIVE'),
+            eq(schema.OrganizationMember.seatType, seatClass)
           )
         )
 
       activeMemberCount = countRow?.value ?? 0
 
       if (activeMemberCount >= memberLimit) {
-        logger.warn('Invitation acceptance blocked by helper: Member limit reached.', {
+        logger.warn('Invitation acceptance blocked by helper: Seat limit reached.', {
           organizationId,
           acceptingUserId,
+          seatType: seatClass,
           limit: memberLimit,
           current: activeMemberCount,
         })
         throw new TRPCError({
           code: 'FORBIDDEN',
-          message: `Cannot join organization: The member limit (${memberLimit}) for the current plan has been reached.`,
+          message: isWorkerSeat
+            ? `Cannot join organization: The field seat limit (${memberLimit}) for the current plan has been reached.`
+            : `Cannot join organization: The member limit (${memberLimit}) for the current plan has been reached.`,
         })
       }
       logger.info('Helper: Member limit check passed.', {

--- a/packages/lib/src/permissions/overage-detection-service.ts
+++ b/packages/lib/src/permissions/overage-detection-service.ts
@@ -227,7 +227,8 @@ export class OverageDetectionService {
     switch (featureKey) {
       case FeatureKey.teammates: {
         // Only count human members — agents (userType='AGENT') and system users
-        // must not consume paid seats.
+        // must not consume paid seats. Full seats only: field (worker) seats are
+        // counted separately against the workerSeats limit (§8).
         const [result] = await this.db
           .select({ value: count() })
           .from(schema.OrganizationMember)
@@ -236,6 +237,25 @@ export class OverageDetectionService {
             and(
               eq(schema.OrganizationMember.organizationId, organizationId),
               eq(schema.OrganizationMember.status, 'ACTIVE'),
+              eq(schema.OrganizationMember.seatType, 'full'),
+              eq(schema.User.userType, 'USER')
+            )
+          )
+        return result?.value ?? 0
+      }
+
+      case FeatureKey.workerSeats: {
+        // Field (worker) seats only — the cheaper capability-capped member seat (§8).
+        // Mirrors the teammates count: human members, active, scoped to the org.
+        const [result] = await this.db
+          .select({ value: count() })
+          .from(schema.OrganizationMember)
+          .innerJoin(schema.User, eq(schema.User.id, schema.OrganizationMember.userId))
+          .where(
+            and(
+              eq(schema.OrganizationMember.organizationId, organizationId),
+              eq(schema.OrganizationMember.status, 'ACTIVE'),
+              eq(schema.OrganizationMember.seatType, 'worker'),
               eq(schema.User.userType, 'USER')
             )
           )

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -47,6 +47,7 @@ interface PlanDefinition {
 const STATIC_LIMITS = {
   demo: {
     teammates: 1,
+    workerSeats: 0,
     channels: 1,
     workflowsLimit: 3,
     savedViews: 10,
@@ -59,6 +60,7 @@ const STATIC_LIMITS = {
   },
   free: {
     teammates: 1,
+    workerSeats: 0,
     channels: 1,
     workflowsLimit: 3,
     savedViews: 10,
@@ -71,6 +73,7 @@ const STATIC_LIMITS = {
   },
   starter: {
     teammates: -1,
+    workerSeats: 2,
     channels: 3,
     workflowsLimit: 15,
     savedViews: 20,
@@ -83,6 +86,7 @@ const STATIC_LIMITS = {
   },
   growth: {
     teammates: -1,
+    workerSeats: 10,
     channels: -1,
     workflowsLimit: -1,
     savedViews: -1,
@@ -95,6 +99,7 @@ const STATIC_LIMITS = {
   },
   enterprise: {
     teammates: -1,
+    workerSeats: -1,
     channels: -1,
     workflowsLimit: -1,
     savedViews: -1,
@@ -129,6 +134,10 @@ const BOOLEAN_GATES = {
     mcp: false,
     dataConnectors: true,
     mailPermissions: true,
+    dashboards: false,
+    dispatch: false,
+    sequences: false,
+    granularPermissions: false,
   },
   free: {
     knowledgeBase: true,
@@ -150,6 +159,10 @@ const BOOLEAN_GATES = {
     mcp: false,
     dataConnectors: true,
     mailPermissions: false,
+    dashboards: false,
+    dispatch: false,
+    sequences: false,
+    granularPermissions: false,
   },
   starter: {
     knowledgeBase: true,
@@ -171,6 +184,10 @@ const BOOLEAN_GATES = {
     mcp: false,
     dataConnectors: true,
     mailPermissions: false,
+    dashboards: false,
+    dispatch: false,
+    sequences: false,
+    granularPermissions: false,
   },
   growth: {
     knowledgeBase: true,
@@ -192,6 +209,10 @@ const BOOLEAN_GATES = {
     mcp: false,
     dataConnectors: true,
     mailPermissions: false,
+    dashboards: true,
+    dispatch: true,
+    sequences: true,
+    granularPermissions: true,
   },
   enterprise: {
     knowledgeBase: true,
@@ -213,6 +234,10 @@ const BOOLEAN_GATES = {
     mcp: false,
     dataConnectors: true,
     mailPermissions: true,
+    dashboards: true,
+    dispatch: true,
+    sequences: true,
+    granularPermissions: true,
   },
 } as const
 


### PR DESCRIPTION
## What

**Phase 5** of the leveled capability layer — makes the field ("worker") seat a real, plan-limited seat class and stops the two seat classes from cross-consuming each other's limits.

## Changes

- **Seed** (`billing.domain.ts`): `workerSeats` per tier — **Demo 0, Free 0, Starter 2, Growth 10, Enterprise −1** (user-confirmed). Fixed the seed gap where `dispatch` / `sequences` / `dashboards` were absent from every tier's `BOOLEAN_GATES`, and added the `granularPermissions` gate.
- **Overage detection**: `teammates` now counts **full** seats only; new `workerSeats` case counts **field** seats (both active human members, org-scoped).
- **Invite + accept guards** (`member-service`): seat-class aware — a worker invite/join checks `workerSeats`, a full one `teammates`; each counts only its own class (+ pending invitations of that class), **hard-blocking at cap** (§2.G) with a class-specific message.

## ⚠️ Pricing decision needed before merge

The four boolean gates default to **Growth + Enterprise only** (Starter/Free/Demo `false`). These are placeholders:

| gate | Starter | Growth | Enterprise |
|---|---|---|---|
| `dispatch` | ❌ | ✅ | ✅ |
| `sequences` | ❌ | ✅ | ✅ |
| `dashboards` | ❌ | ✅ | ✅ |
| `granularPermissions` | ❌ | ✅ | ✅ |

**`dispatch` on Starter is the one to decide** — as gated here, Starter customers can't use dispatch. If you want it on Starter, it's a one-line seed flip. Nothing is live, so this is freely retunable.

## Verification

- Per-package typecheck: seeded file + overage service clean; `member-service` shows only the two pre-existing baseline errors (line-shifted), none from these lines.
- No Stripe/Shopify meter work (bundled model, §2.G); no re-seed run (source only).