### PR TITLE
feat(permissions): comments capability + agents/comment enforcement + no-access

### DIFF
--- a/apps/web/src/components/records/entity-route-layout.tsx
+++ b/apps/web/src/components/records/entity-route-layout.tsx
@@ -2,7 +2,7 @@
 
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { getIcon } from '@auxx/ui/components/icons'
 import {
   MainPage,
@@ -13,7 +13,9 @@ import {
 import { MainPageTabs, type MainPageTabsItem } from '@auxx/ui/components/main-page-tabs'
 import { ChartColumn } from 'lucide-react'
 import type { ReactNode } from 'react'
+import { NoAccess } from '~/components/permissions/ui/no-access'
 import { useResources } from '~/components/resources'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 interface EntityRouteLayoutProps {
@@ -47,8 +49,19 @@ export function EntityRouteLayout({
 }: EntityRouteLayoutProps) {
   const { getResourceById } = useResources()
   const { hasAccess } = useFeatureFlags()
+  const { deniedBy } = useAccess()
   const resource = getResourceById(slug)
   const ResourceIcon = resource ? getIcon(resource.icon)?.icon : undefined
+
+  // Layer-2 read gate for direct-URL hits (e.g. a field seat deep-linking
+  // `/app/tickets`): tickets ride the `tickets.view` capability, every other
+  // entity list rides `records.view`. A `'permission'` denial (nothing to buy)
+  // renders the friendly NoAccess surface instead of an empty/broken shell;
+  // plan denials fall through so the existing upgrade surfaces still show.
+  const viewKey = slug === 'tickets' ? PermissionKey.ticketsView : PermissionKey.recordsView
+  if (deniedBy(viewKey) === 'permission') {
+    return <NoAccess area={resource?.plural ?? undefined} />
+  }
 
   const items: MainPageTabsItem[] = [
     {

--- a/apps/web/src/server/api/routers/agent.ts
+++ b/apps/web/src/server/api/routers/agent.ts
@@ -18,12 +18,12 @@ import {
   setAgentToolBindings,
   updateAgent as updateAgentService,
 } from '@auxx/lib/agents'
-import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { getRealtimeService, publishAgentUpdated } from '@auxx/lib/realtime'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { adminProcedure, createTRPCRouter } from '../trpc'
+import { createTRPCRouter, permissionProcedure } from '../trpc'
 import { unwrap } from '../unwrap'
 
 const logger = createScopedLogger('agent-router')
@@ -38,7 +38,7 @@ const promptSchema = z.record(z.string(), z.unknown())
  * `@auxx/lib/agents` service functions — no raw SQL lives in this router.
  */
 export const agentRouter = createTRPCRouter({
-  list: adminProcedure
+  list: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ includeArchived: z.boolean().optional() }).optional())
     .query(({ ctx, input }) =>
       listAgents(ctx.session.organizationId, {
@@ -51,7 +51,7 @@ export const agentRouter = createTRPCRouter({
    * backward compatibility with existing callers, but accepts either form —
    * the service helper checks both columns against the org agents cache.
    */
-  getById: adminProcedure
+  getById: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const detail = await getAgentDetailByIdOrSlug(ctx.session.organizationId, input.agentId)
@@ -61,7 +61,7 @@ export const agentRouter = createTRPCRouter({
       return detail
     }),
 
-  create: adminProcedure
+  create: permissionProcedure(PermissionKey.agentsManage)
     .input(
       z
         .object({
@@ -136,7 +136,7 @@ export const agentRouter = createTRPCRouter({
    * the user finishes configuration in the live tabs. The AI chat-builder
    * tool calls `completeAgentSetup` directly and keeps those gates.
    */
-  completeSetup: adminProcedure
+  completeSetup: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
@@ -151,7 +151,7 @@ export const agentRouter = createTRPCRouter({
    * agents-list "Discard draft" overflow item. Refuses to touch completed
    * agents — use the archive path for those.
    */
-  deleteDraft: adminProcedure
+  deleteDraft: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
@@ -169,7 +169,7 @@ export const agentRouter = createTRPCRouter({
    * `Agent` row and its synthetic `User`; conversation history is preserved
    * orphaned. Use `deleteDraft` only for incomplete drafts.
    */
-  delete: adminProcedure
+  delete: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const result = await deleteAgentService(input.agentId, ctx.session.organizationId)
@@ -178,7 +178,7 @@ export const agentRouter = createTRPCRouter({
       }
     }),
 
-  update: adminProcedure
+  update: permissionProcedure(PermissionKey.agentsManage)
     .input(
       z.object({
         agentId: z.string(),
@@ -235,7 +235,7 @@ export const agentRouter = createTRPCRouter({
       await updateAgentService(agentId, organizationId, updatePayload, { excludeSocketId })
     }),
 
-  checkSlug: adminProcedure
+  checkSlug: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ slug: agentSlugSchema, excludeAgentId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       const taken = await isAgentSlugTaken(ctx.session.organizationId, input.slug, {
@@ -251,7 +251,7 @@ export const agentRouter = createTRPCRouter({
    * the org agents cache. An empty map means "everything runs on author
    * defaults". See plans/chat/v8 phase-5.
    */
-  setToolBindings: adminProcedure
+  setToolBindings: permissionProcedure(PermissionKey.agentsManage)
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -291,7 +291,7 @@ export const agentRouter = createTRPCRouter({
   // plans/agents/agent-versions/build-plan.md §6.
 
   /** Snapshot the draft as a new version (or no-op republish). Human-only. */
-  publish: adminProcedure
+  publish: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1), label: z.string().max(120).optional() }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
@@ -312,7 +312,7 @@ export const agentRouter = createTRPCRouter({
     }),
 
   /** Discard draft edits — restore the active version onto the row. */
-  discardChanges: adminProcedure
+  discardChanges: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
@@ -328,7 +328,7 @@ export const agentRouter = createTRPCRouter({
     }),
 
   /** Restore-as-draft: load a past version into the draft + mark dirty. */
-  restoreVersion: adminProcedure
+  restoreVersion: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1), toVersionId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
@@ -348,7 +348,7 @@ export const agentRouter = createTRPCRouter({
     }),
 
   /** Rename a published version's label (annotation only). */
-  renameVersion: adminProcedure
+  renameVersion: permissionProcedure(PermissionKey.agentsManage)
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -374,7 +374,7 @@ export const agentRouter = createTRPCRouter({
     }),
 
   /** Published version history (newest first) with editor names. */
-  listVersions: adminProcedure
+  listVersions: permissionProcedure(PermissionKey.agentsManage)
     .input(z.object({ agentId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const rows = unwrap(

--- a/apps/web/src/server/api/routers/comment.ts
+++ b/apps/web/src/server/api/routers/comment.ts
@@ -1,6 +1,7 @@
 // server/api/routers/comment.ts
 
 import { CommentService } from '@auxx/lib/comments'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { isNonEmptyDoc } from '@auxx/lib/tiptap'
 import { createScopedLogger } from '@auxx/logger'
 import { recordIdSchema } from '@auxx/types'
@@ -8,7 +9,7 @@ import { type ActorId, toActorId } from '@auxx/types/actor'
 import { toRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, permissionProcedure, protectedProcedure } from '~/server/api/trpc'
 
 const logger = createScopedLogger('comment-router')
 
@@ -70,69 +71,73 @@ const updateCommentSchema = z.object({
 
 export const commentRouter = createTRPCRouter({
   // Create a new comment
-  create: protectedProcedure.input(createCommentSchema).mutation(async ({ ctx, input }) => {
-    try {
-      const { userId, organizationId } = ctx.session
-      const commentService = new CommentService(organizationId, userId, ctx.db)
-      const { contentJson, recordId, parentId, fileAttachments } = input
+  create: permissionProcedure(PermissionKey.commentsManage)
+    .input(createCommentSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { userId, organizationId } = ctx.session
+        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const { contentJson, recordId, parentId, fileAttachments } = input
 
-      // Create the comment
-      const comment = await commentService.createComment({
-        contentJson: contentJson as Record<string, unknown>,
-        recordId,
-        createdById: userId,
-        parentId,
-        fileAttachments,
-      })
+        // Create the comment
+        const comment = await commentService.createComment({
+          contentJson: contentJson as Record<string, unknown>,
+          recordId,
+          createdById: userId,
+          parentId,
+          fileAttachments,
+        })
 
-      return transformCommentResponse(comment)
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : 'Failed to create comment'
-      logger.error('Error creating comment', { error, input })
+        return transformCommentResponse(comment)
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Failed to create comment'
+        logger.error('Error creating comment', { error, input })
 
-      if (error instanceof TRPCError) {
-        throw error
+        if (error instanceof TRPCError) {
+          throw error
+        }
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: message,
+        })
       }
-
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: message,
-      })
-    }
-  }),
+    }),
 
   // Update a comment
-  update: protectedProcedure.input(updateCommentSchema).mutation(async ({ ctx, input }) => {
-    try {
-      const { userId, organizationId } = ctx.session
-      const commentService = new CommentService(organizationId, userId, ctx.db)
-      const { id, contentJson, fileAttachments } = input
+  update: permissionProcedure(PermissionKey.commentsManage)
+    .input(updateCommentSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { userId, organizationId } = ctx.session
+        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const { id, contentJson, fileAttachments } = input
 
-      // Update the comment
-      const updatedComment = await commentService.updateComment({
-        id,
-        contentJson: contentJson as Record<string, unknown>,
-        fileAttachments,
-      })
+        // Update the comment
+        const updatedComment = await commentService.updateComment({
+          id,
+          contentJson: contentJson as Record<string, unknown>,
+          fileAttachments,
+        })
 
-      return updatedComment
-    } catch (error: unknown) {
-      logger.error('Error updating comment', { error, input })
-      // const message = error instanceof Error ? error.message : 'Failed to update comment'
+        return updatedComment
+      } catch (error: unknown) {
+        logger.error('Error updating comment', { error, input })
+        // const message = error instanceof Error ? error.message : 'Failed to update comment'
 
-      if (error instanceof TRPCError) {
-        throw error
+        if (error instanceof TRPCError) {
+          throw error
+        }
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update comment',
+        })
       }
-
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to update comment',
-      })
-    }
-  }),
+    }),
 
   // Delete a comment
-  delete: protectedProcedure
+  delete: permissionProcedure(PermissionKey.commentsManage)
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       try {

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -27,6 +27,9 @@ export enum PermissionKey {
   workflowsManage = 'workflows.manage',
   agentsManage = 'agents.manage',
 
+  // collaboration
+  commentsManage = 'comments.manage',
+
   // dispatch
   dispatchBoardView = 'dispatch.board.view',
   dispatchBoardManage = 'dispatch.board.manage',
@@ -115,6 +118,14 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     description: 'Create and configure Kopilot agents.',
     group: 'Automation',
     featureKey: FeatureKey.agents,
+  },
+
+  // ── Collaboration ──
+  {
+    key: PermissionKey.commentsManage,
+    label: 'Manage Comments',
+    description: 'Write, edit, and delete comments on records.',
+    group: 'Collaboration',
   },
 
   // ── Dispatch ──
@@ -223,6 +234,7 @@ export enum Area {
   recordsLinked = 'recordsLinked',
   workflows = 'workflows',
   agents = 'agents',
+  comments = 'comments',
   dispatchBoard = 'dispatchBoard',
   dispatchMySchedule = 'dispatchMySchedule',
   dispatchVisitReports = 'dispatchVisitReports',
@@ -284,6 +296,10 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
     area: Area.agents,
     rungs: [{ level: Level.Full, keys: [PermissionKey.agentsManage] }],
     featureKey: FeatureKey.agents,
+  },
+  [Area.comments]: {
+    area: Area.comments,
+    rungs: [{ level: Level.Full, keys: [PermissionKey.commentsManage] }],
   },
   [Area.dispatchBoard]: {
     area: Area.dispatchBoard,


### PR DESCRIPTION
## What

**Phase 6 — the final v1 phase.** Incremental adoption of the leveled capability model on server enforcement + the no-access page. Conservative by design: only unambiguous, model-consistent migrations; admin-structural gates stay as `adminProcedure`.

## Changes

- **New `comments` capability area** (`registry.ts`) — a toggle (`comments.manage`). USER default **Full**; worker-seat ceiling **None**, so field seats can't comment on linked records (matches 4b hiding the comments tab). Derives automatically from the existing `buildAreaLevels`/`AREA_ORDER`/`WORKER_AREAS` machinery — no hand-edited defaults.
- **`comment.ts`** — `create`/`update`/`delete` moved `protectedProcedure` → `permissionProcedure(commentsManage)`. Read procedures untouched.
- **`agent.ts`** — every procedure moved `adminProcedure` → `permissionProcedure(agentsManage)`. **Behavior change (intended, confirmed):** agents becomes a member capability — every full member has `agents=Full` by the merged registry default — and gains the plan-AND on `FeatureKey.agents`. OWNER/ADMIN unaffected.
- **`entity-route-layout.tsx`** — wires the `NoAccess` page (from 4a) into the shared records/tickets layout: `deniedBy(viewKey) === 'permission'` renders a friendly no-access state instead of a crash/redirect-loop. Plan denials fall through to existing upgrade surfaces.

## Deliberately left for review (NOT migrated)

- **`settings` / `members` / `billing` routers** stay `adminProcedure`. Composition lets a group/user grant *raise* those `adminOnly` areas for a USER, so swapping to `permissionProcedure` wouldn't be behaviour-preserving — and §6 says admin-structural gates stay.
- **`comment.togglePin` / `addReaction` / `removeReaction`** — lighter interaction writes, left ungated pending a decision on whether they need the comments key.
- **`agent-procedure`/`agent-scope`/`agent-toolset`/`agent-trigger`** sub-routers — likely also `agentsManage` but not audited this pass.
- The ~100 client-side `isAdminOrOwner` UI show/hide checks — cosmetic, out of scope.

## Verification

- Composition unit test: **13/13 pass** (new area derives cleanly, kept green).
- Per-package typecheck: touched files clean; `agent.ts`'s `input ?? {}` errors are pre-existing baseline (present in HEAD, unrelated to the procedure swap).

## Follow-up note

The agents sidebar item still carries `adminOnly: true` alongside its `permissionKey` — now that agents is a member capability, that stale `adminOnly` should be dropped so the UI matches the API. Small, can ride a later cleanup.