### PR TITLE
feat(permissions): cross-link group members and member teams to detail pages

### DIFF
--- a/apps/web/src/components/groups/ui/group-members-section.tsx
+++ b/apps/web/src/components/groups/ui/group-members-section.tsx
@@ -10,6 +10,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { Plus, Trash2, UsersRound } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
 import { ActorPicker } from '~/components/pickers/actor-picker'
@@ -19,6 +20,7 @@ import { getInitials } from '../utils'
 
 /** User members of a group, with add (ActorPicker) + per-row remove. */
 export function GroupMembersSection({ groupId }: { groupId: string }) {
+  const router = useRouter()
   const [confirm, ConfirmDialog] = useConfirm()
 
   const { data: members, isLoading } = useGroupMembers(groupId)
@@ -105,6 +107,7 @@ export function GroupMembersSection({ groupId }: { groupId: string }) {
             renderRow={(m) => (
               <TreeRow
                 rowClassName='bg-primary-50 hover:bg-primary-100'
+                onDrill={() => router.push(`/app/settings/members/${m.memberRefId}`)}
                 icon={
                   <Avatar className='size-6'>
                     <AvatarImage src={m.user?.image || undefined} alt={m.user?.name || ''} />

--- a/apps/web/src/components/members/ui/member-teams-section.tsx
+++ b/apps/web/src/components/members/ui/member-teams-section.tsx
@@ -9,6 +9,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { Plus, Trash2, UsersRound } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
 import { getGroupMetadata, useGroupMutations, useGroupsForUser } from '~/components/groups'
@@ -19,6 +20,7 @@ import type { Member } from '../types'
 
 /** Teams (groups) a member belongs to, with add + remove. */
 export function MemberTeamsSection({ member }: { member: Member }) {
+  const router = useRouter()
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
 
@@ -108,6 +110,7 @@ export function MemberTeamsSection({ member }: { member: Member }) {
               return (
                 <TreeRow
                   rowClassName='bg-primary-50 hover:bg-primary-100 '
+                  onDrill={() => router.push(`/app/settings/groups/${g.id}`)}
                   icon={<span className='text-sm'>{meta.icon || '👥'}</span>}
                   title={g.displayName}
                   secondary={meta.visibility === 'private' ? 'Private' : undefined}


### PR DESCRIPTION
Follow-on to the group detail view (#1284) and member detail view (#1283). Adds row-click cross-navigation between the two detail pages.

## What's new
- **Group detail → Members section**: clicking a member row drills into the member detail view (`settings/members/[userId]`).
- **Member detail → Teams section**: clicking a team row drills into the group detail view (`settings/groups/[groupId]`).

Both use `TreeRow`'s `onDrill`, which makes the whole row clickable and renders a trailing `ChevronRight` affordance. The per-row remove (trash) button keeps working — it's wrapped in a `stopPropagation` handler, so clicking it doesn't also navigate.

## Verification
- `apps/web` tsc — clean for both touched files.
- `pnpm lint` — clean (lint-staged ran on commit).
- Manual: from a group, click a member → member detail; from a member, click a team → group detail; trash button still removes without navigating.