### PR TITLE
feat(permissions): grantee override list with selectable levels and ignored warning

### DIFF
--- a/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
@@ -4,10 +4,11 @@
 import type { Area, Level } from '@auxx/lib/permissions/client'
 import { type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
-import { EmptySection } from '@auxx/ui/components/section'
+import { EmptySection, Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Folder, Plus, Trash2, Users } from 'lucide-react'
+import { Folder, Plus, SlidersHorizontal, Trash2, Users } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useActor } from '~/components/resources/hooks/use-actor'
@@ -17,25 +18,44 @@ import { LeveledAreaGrid } from './leveled-area-grid'
 
 type OverrideType = 'group' | 'user'
 
-const COPY: Record<OverrideType, { add: string; empty: string; icon: typeof Users }> = {
+const COPY: Record<
+  OverrideType,
+  { add: string; list: string; remove: string; empty: string; icon: typeof Users }
+> = {
   group: {
     add: 'Add group',
+    list: 'Groups',
+    remove: 'Remove group',
     empty: 'Grant a group more access than the member baseline.',
     icon: Folder,
   },
   user: {
     add: 'Add member',
+    list: 'Members',
+    remove: 'Remove member',
     empty: 'Grant one member more access than the baseline or their groups.',
     icon: Users,
   },
 }
 
+/** Resolve a grantee's display name from the actor cache (falls back to email / Unknown). */
+function useGranteeName(granteeType: OverrideType, granteeId: string) {
+  const actorId = useMemo(() => toActorId(granteeType, granteeId), [granteeType, granteeId])
+  const { actor, isLoading, isNotFound } = useActor({ actorId })
+  const name = isNotFound
+    ? 'Unknown'
+    : actor?.name || (actor?.type === 'user' && actor?.email) || 'Unknown'
+  return { actor, isLoading, isNotFound, name }
+}
+
 /**
- * The raise-only override surface for one grantee kind (groups or users). Each
- * grantee gets a card with the full leveled grid, floored at the member baseline
- * — overrides can only *raise* access (Camp-1, v1.5 §L3). Clearing every raised
- * area removes the grant row. New grantees are added via the actor picker and
- * persist on their first raised area.
+ * The raise-only override surface for one grantee kind (groups or users). A
+ * `TreeRow` list of grantees on top; selecting one reveals its full leveled grid
+ * below. Every rung is selectable, but overrides only *raise* above the member
+ * baseline — the raise-only rule is enforced server-side (Camp-1, v1.5 §L3), and
+ * an override that lifts nothing is flagged "ignored" on the grantee. Clearing
+ * every raised area leaves the row selectable but empty; the delete action
+ * removes the grant. New grantees are added via the actor picker.
  */
 export function GranteeOverridesTab({
   granteeType,
@@ -51,6 +71,7 @@ export function GranteeOverridesTab({
 
   // Grantees picked but not yet raised on any area (no row persisted yet).
   const [pendingIds, setPendingIds] = useState<string[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
 
   const rows = useMemo(() => {
     const ids = new Set(persisted.map((g) => g.granteeId))
@@ -59,10 +80,16 @@ export function GranteeOverridesTab({
 
   const actorIds = useMemo(() => rows.map((id) => toActorId(granteeType, id)), [rows, granteeType])
 
+  // Fall back to the first row when the selection is empty or was removed.
+  const selectedGranteeId = selectedId && rows.includes(selectedId) ? selectedId : (rows[0] ?? null)
+
   const handleAdd = (nextActorIds: ActorId[]) => {
     const existing = new Set(rows)
     const added = nextActorIds.map(getActorRawId).filter((id) => !existing.has(id))
-    if (added.length > 0) setPendingIds((prev) => [...prev, ...added])
+    if (added.length > 0) {
+      setPendingIds((prev) => [...prev, ...added])
+      setSelectedId(added[0])
+    }
   }
 
   const handleChange = (granteeId: string, area: Area, level: Level | undefined) => {
@@ -79,6 +106,7 @@ export function GranteeOverridesTab({
   const handleRemove = (granteeId: string) => {
     remove(granteeType, granteeId)
     setPendingIds((prev) => prev.filter((id) => id !== granteeId))
+    if (selectedId === granteeId) setSelectedId(null)
   }
 
   if (isLoading || !roleDefaults) {
@@ -91,50 +119,124 @@ export function GranteeOverridesTab({
   }
 
   return (
-    <div className='flex flex-col gap-3 p-3 sm:p-6'>
-      <div className='flex items-center justify-between'>
-        <p className='max-w-2xl text-sm text-muted-foreground'>{copy.empty}</p>
-        <ActorPicker
-          value={actorIds}
-          onChange={handleAdd}
-          target={granteeType}
-          multi
-          excludeIds={actorIds}
-          disabled={disabled}>
-          <Button variant='outline' size='sm' disabled={disabled}>
-            <Plus />
-            {copy.add}
-          </Button>
-        </ActorPicker>
-      </div>
+    <div className='flex flex-col p-3 sm:p-6'>
+      <p className='mb-3 max-w-2xl text-sm text-muted-foreground'>{copy.empty}</p>
 
-      {rows.length === 0 ? (
-        <EmptySection
-          icon={<copy.icon className='size-5' />}
-          title='No overrides yet'
-          description={copy.empty}
+      {/* Grantee list */}
+      <Section
+        title={copy.list}
+        icon={<copy.icon className='size-4' />}
+        collapsible={false}
+        actions={
+          <ActorPicker
+            value={actorIds}
+            onChange={handleAdd}
+            target={granteeType}
+            multi
+            excludeIds={actorIds}
+            disabled={disabled}>
+            <Button variant='ghost' size='xs' disabled={disabled}>
+              <Plus />
+              {copy.add}
+            </Button>
+          </ActorPicker>
+        }>
+        {rows.length === 0 ? (
+          <EmptySection
+            icon={<copy.icon className='size-5' />}
+            title='No overrides yet'
+            description={copy.empty}
+          />
+        ) : (
+          <div className='flex flex-col gap-0.5'>
+            {rows.map((granteeId) => (
+              <GranteeListRow
+                key={granteeId}
+                granteeType={granteeType}
+                granteeId={granteeId}
+                selected={granteeId === selectedGranteeId}
+                disabled={disabled}
+                onSelect={() => setSelectedId(granteeId)}
+                onRemove={() => handleRemove(granteeId)}
+              />
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* Selected grantee's leveled grid */}
+      {selectedGranteeId ? (
+        <GranteeAccessDetail
+          key={selectedGranteeId}
+          granteeType={granteeType}
+          granteeId={selectedGranteeId}
+          values={persisted.find((g) => g.granteeId === selectedGranteeId)?.levels ?? {}}
+          roleDefaults={roleDefaults}
+          baseline={effectiveBaseline}
+          disabled={disabled}
+          onChange={(area, level) => handleChange(selectedGranteeId, area, level)}
         />
       ) : (
-        rows.map((granteeId) => (
-          <GranteeOverrideCard
-            key={granteeId}
-            granteeType={granteeType}
-            granteeId={granteeId}
-            values={persisted.find((g) => g.granteeId === granteeId)?.levels ?? {}}
-            roleDefaults={roleDefaults}
-            baseline={effectiveBaseline}
-            disabled={disabled}
-            onChange={(area, level) => handleChange(granteeId, area, level)}
-            onRemove={() => handleRemove(granteeId)}
+        <Section title='Access' icon={<SlidersHorizontal className='size-4' />} collapsible={false}>
+          <EmptySection
+            icon={<SlidersHorizontal className='size-5' />}
+            title={`No ${granteeType === 'group' ? 'group' : 'member'} selected`}
+            description={`Add ${granteeType === 'group' ? 'a group' : 'a member'} above to grant more access.`}
           />
-        ))
+        </Section>
       )}
     </div>
   )
 }
 
-/** A single grantee's override card — resolved actor header + its leveled grid. */
-function GranteeOverrideCard({
+/** A single grantee row in the list — avatar + resolved name, selectable, hover-delete. */
+function GranteeListRow({
+  granteeType,
+  granteeId,
+  selected,
+  disabled,
+  onSelect,
+  onRemove,
+}: {
+  granteeType: OverrideType
+  granteeId: string
+  selected: boolean
+  disabled: boolean
+  onSelect: () => void
+  onRemove: () => void
+}) {
+  const { actor, isLoading, isNotFound, name } = useGranteeName(granteeType, granteeId)
+
+  return (
+    <TreeRow
+      icon={<ActorAvatar type={actor?.type ?? granteeType} avatarUrl={actor?.avatarUrl} />}
+      isOpen={selected}
+      onToggleOpen={onSelect}
+      rowClassName={
+        selected ? 'bg-primary-150 hover:bg-primary-150' : 'bg-primary-50 hover:bg-primary-100'
+      }
+      title={
+        isLoading && !actor ? (
+          <Skeleton className='h-4 w-24 rounded-full' />
+        ) : (
+          <span className={cn('truncate', isNotFound && 'text-muted-foreground')}>{name}</span>
+        )
+      }
+      actions={
+        <TreeRowButton
+          variant='destructive'
+          tooltipText={COPY[granteeType].remove}
+          disabled={disabled}
+          onClick={onRemove}>
+          <Trash2 />
+        </TreeRowButton>
+      }
+    />
+  )
+}
+
+/** The selected grantee's leveled grid, headed by its resolved name. */
+function GranteeAccessDetail({
   granteeType,
   granteeId,
   values,
@@ -142,7 +244,6 @@ function GranteeOverrideCard({
   baseline,
   disabled,
   onChange,
-  onRemove,
 }: {
   granteeType: OverrideType
   granteeId: string
@@ -151,38 +252,14 @@ function GranteeOverrideCard({
   baseline: Partial<Record<Area, Level>>
   disabled: boolean
   onChange: (area: Area, level: Level | undefined) => void
-  onRemove: () => void
 }) {
-  const actorId = useMemo(() => toActorId(granteeType, granteeId), [granteeType, granteeId])
-  const { actor, isLoading, isNotFound } = useActor({ actorId })
-  const name = isNotFound
-    ? 'Unknown'
-    : actor?.name || (actor?.type === 'user' && actor?.email) || 'Unknown'
+  const { name } = useGranteeName(granteeType, granteeId)
 
   return (
-    <div className='flex flex-col gap-3 rounded-lg border p-3'>
-      <div className='flex items-center justify-between'>
-        <div className='flex min-w-0 items-center gap-2'>
-          <ActorAvatar type={actor?.type ?? granteeType} avatarUrl={actor?.avatarUrl} />
-          {isLoading && !actor ? (
-            <Skeleton className='h-4 w-24 rounded-full' />
-          ) : (
-            <span
-              className={cn('truncate text-sm font-medium', isNotFound && 'text-muted-foreground')}>
-              {name}
-            </span>
-          )}
-        </div>
-        <Button
-          variant='ghost'
-          size='icon-sm'
-          className='text-muted-foreground hover:text-destructive'
-          aria-label='Remove override'
-          disabled={disabled}
-          onClick={onRemove}>
-          <Trash2 />
-        </Button>
-      </div>
+    <Section
+      title={`Access · ${name}`}
+      icon={<SlidersHorizontal className='size-4' />}
+      collapsible={false}>
       <LeveledAreaGrid
         mode='override'
         values={values}
@@ -191,6 +268,6 @@ function GranteeOverrideCard({
         onChange={onChange}
         disabled={disabled}
       />
-    </div>
+    </Section>
   )
 }

--- a/apps/web/src/components/permissions/ui/level-control.tsx
+++ b/apps/web/src/components/permissions/ui/level-control.tsx
@@ -5,7 +5,7 @@ import { type AreaMetadata, Level } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { cn } from '@auxx/ui/lib/utils'
-import { Undo2 } from 'lucide-react'
+import { AlertTriangle, Undo2 } from 'lucide-react'
 import { useMemo } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 
@@ -25,11 +25,10 @@ interface LevelControlProps {
   /** The level this area falls through to when unset (role default or member baseline). */
   inherited: Level
   /**
-   * Raise-only floor (override mode): levels at or below this are disabled, so an
-   * override can only *raise* above the baseline. Omit for the baseline surface,
-   * where any level (including a deliberate `None`) is selectable.
+   * Override mode: the explicit level lifts nothing above the baseline, so the
+   * server composes it away. Renders an "ignored" warning next to the selector.
    */
-  floor?: Level
+  ignored?: boolean
   /** Emits the new explicit level, or `undefined` to reset the area to inherited. */
   onChange: (level: Level | undefined) => void
   disabled?: boolean
@@ -40,14 +39,16 @@ interface LevelControlProps {
  * per rung the area offers (`None` + each ladder rung — so `records` shows
  * None/Read/Edit/Full while a toggle area shows None/Full). Shows the effective
  * level (`value ?? inherited`); while inherited it renders muted, and a reset
- * button appears once an explicit level is set. In override mode, rungs at or
- * below `floor` are disabled (raise-only).
+ * button appears once an explicit level is set. Every rung stays selectable —
+ * the raise-only rule for overrides is enforced server-side (an override at or
+ * below the baseline is composed away), and surfaced in the UI as an "ignored"
+ * warning rather than a disabled rung.
  */
 export function LevelControl({
   area,
   value,
   inherited,
-  floor,
+  ignored = false,
   onChange,
   disabled = false,
 }: LevelControlProps) {
@@ -60,22 +61,12 @@ export function LevelControl({
 
   return (
     <div className='flex items-center gap-1'>
-      <RadioTab
-        value={String(effective)}
-        onValueChange={(v) => onChange(Number(v) as Level)}
-        size='sm'
-        className={cn(!isExplicit && 'opacity-60')}>
-        {levels.map((level) => (
-          <RadioTabItem
-            key={level}
-            value={String(level)}
-            size='sm'
-            disabled={disabled || (floor !== undefined && level <= floor)}
-            className='min-w-0 px-2.5'>
-            {LEVEL_LABELS[level]}
-          </RadioTabItem>
-        ))}
-      </RadioTab>
+      <Tooltip content='This override is ignored — the member baseline already grants this level of access.'>
+        <AlertTriangle
+          className={cn('size-3.5 text-amber-500', !ignored && 'invisible')}
+          aria-hidden={!ignored}
+        />
+      </Tooltip>
       <Tooltip content='Reset to inherited'>
         <Button
           type='button'
@@ -83,11 +74,28 @@ export function LevelControl({
           variant='ghost'
           aria-label='Reset to inherited'
           disabled={disabled || !isExplicit}
-          className={cn('text-muted-foreground', !isExplicit && 'invisible')}
+          className={cn('size-6 text-muted-foreground', !isExplicit && 'invisible')}
           onClick={() => onChange(undefined)}>
           <Undo2 />
         </Button>
       </Tooltip>
+      <RadioTab
+        value={String(effective)}
+        onValueChange={(v) => onChange(Number(v) as Level)}
+        size='xs'
+        radioGroupClassName='after:rounded-full'
+        className={cn('rounded-full', !isExplicit && 'opacity-60')}>
+        {levels.map((level) => (
+          <RadioTabItem
+            key={level}
+            value={String(level)}
+            size='xs'
+            disabled={disabled}
+            className='h-full w-auto min-w-0 rounded-full px-2.5'>
+            {LEVEL_LABELS[level]}
+          </RadioTabItem>
+        ))}
+      </RadioTab>
     </div>
   )
 }

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -13,7 +13,7 @@ interface LeveledAreaGridProps {
   roleDefaults: Record<Area, Level>
   /**
    * Override mode: the effective member baseline per area. Each area inherits from
-   * (and is raise-only floored at) this instead of the raw role default.
+   * this instead of the raw role default; overrides only take effect above it.
    */
   baseline?: Partial<Record<Area, Level>>
   /**
@@ -45,9 +45,10 @@ const AREA_GROUPS: Array<{ group: string; areas: Area[] }> = (() => {
  * The shared leveled surface: every grantable area rendered as a labelled row
  * with its {@link LevelControl}, grouped by registry group (Tickets, Records,
  * Automation, …). `adminOnly` areas are never shown — they're not grantable below
- * ADMIN. In `override` mode each area inherits from the member baseline and is
- * raise-only; in `baseline` mode it inherits from the role default and is freely
- * settable (including a deliberate `None`).
+ * ADMIN. In `override` mode each area inherits from the member baseline (and is
+ * raise-only, enforced server-side); in `baseline` mode it inherits from the role
+ * default. Every rung is selectable in both modes — an override that doesn't lift
+ * the baseline is composed away and flagged as "ignored" on the grantee.
  */
 export function LeveledAreaGrid({
   values,
@@ -82,7 +83,11 @@ export function LeveledAreaGrid({
                     area={meta}
                     value={values[area]}
                     inherited={inherited}
-                    floor={mode === 'override' ? inherited : undefined}
+                    ignored={
+                      mode === 'override' &&
+                      values[area] !== undefined &&
+                      (values[area] as Level) <= inherited
+                    }
                     onChange={(level) => onChange(area, level)}
                     disabled={disabled}
                   />


### PR DESCRIPTION
## Summary

Reworks the group/member permission override surface on the Permissions settings page.

- **List + detail layout** — replaces the wall of stacked override cards with a `TreeRow` list of groups/members; selecting one reveals its leveled grid below (mirrors the webhook-topics page). Selected row highlights `bg-primary-150`.
- **Compact level control** — the per-area radio tabs are now `xs` pill segments, and the reset (undo) button moved to the left of the radio group.
- **Selectable rungs + ignored warning** — dropped the raise-only *UI floor* that was hard-disabling every rung (the member baseline defaults to `Full` everywhere, so nothing was clickable). Every rung is now selectable; raise-only is still enforced server-side via `max`-composition (`compose-user-capabilities.ts`), and an override that lifts nothing above the baseline shows a per-area amber "ignored" warning.

## Why

With the baseline at `Full` by default, the old raise-only floor made the entire override grid cursor-forbidden. Since the server composes overrides with `max(base, group, user)`, an at-or-below-baseline selection can never lower access — so a permissive grid + a per-area "ignored" hint is both safe and clearer.

## Test plan

- [ ] Group/Member overrides tab: list renders, selecting a row swaps the grid below
- [ ] Levels are selectable; setting a level ≤ baseline shows the ignored warning on that area; raising above baseline clears it
- [ ] Reset button clears an area back to inherited