### PR TITLE
feat(ui): shared danger-zone card, settings polish, and entity-def access

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
@@ -28,6 +28,7 @@ import {
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { AdminGate } from '~/components/global/admin-gate'
+import { DangerZone } from '~/components/global/danger-zone'
 import { SettingsSection } from '~/components/global/settings-page'
 import { InboxPicker } from '~/components/pickers/inbox-picker'
 import { toRecordId, useRecord, useResource } from '~/components/resources'
@@ -385,35 +386,25 @@ export default function IntegrationRouting({
 
       {!isForwarding && (
         <SettingsSection className='space-y-2' icon={AlertTriangle} title='Danger Zone'>
-          <div className='group flex items-center border py-2 px-3 hover:bg-destructive/2 transition-colors duration-200 rounded-2xl border-destructive/50'>
-            <div className='flex flex-col justify-between gap-4 w-full md:flex-row md:items-center'>
-              <div className='flex items-center gap-3'>
-                <div className='size-8 border border-destructive/10 bg-destructive/2 rounded-lg flex items-center justify-center group-hover:bg-destructive/5 transition-colors overflow-hidden shrink-0'>
-                  <AlertTriangle className='size-4 text-destructive' />
-                </div>
-                <div className='flex flex-col'>
-                  <span className='text-sm text-destructive'>Delete Integration</span>
-                  <span className='text-xs text-destructive/80'>
-                    Permanently delete integration and all associated messages.
-                  </span>
-                </div>
-              </div>
-              <div className='shrink-0'>
-                <AdminGate action='manage shared channels' allow={canManage}>
-                  <Button
-                    variant='destructive'
-                    onClick={handleRemoveIntegration}
-                    disabled={isRemoving}
-                    size='sm'>
-                    Delete Integration
-                  </Button>
-                </AdminGate>
-              </div>
-              <ConfirmDialog />
-            </div>
-          </div>
+          <DangerZone
+            title='Delete Integration'
+            description='Permanently delete integration and all associated messages.'
+            action={
+              <AdminGate action='manage shared channels' allow={canManage}>
+                <Button
+                  variant='destructive'
+                  onClick={handleRemoveIntegration}
+                  disabled={isRemoving}
+                  size='sm'>
+                  Delete Integration
+                </Button>
+              </AdminGate>
+            }
+          />
         </SettingsSection>
       )}
+
+      <ConfirmDialog />
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/custom-fields/[apiSlug]/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/custom-fields/[apiSlug]/page.tsx
@@ -1,7 +1,9 @@
 // apps/web/src/app/(protected)/app/settings/custom-fields/[apiSlug]/page.tsx
 'use client'
 
+import { isAccessManageable } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
+import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { Spinner } from '@auxx/ui/components/spinner'
 import { useParams } from 'next/navigation'
 import { useState } from 'react'
@@ -9,6 +11,7 @@ import { CustomFieldsList } from '~/components/custom-fields/ui/custom-fields-li
 import { EntityAppearanceEditor } from '~/components/custom-fields/ui/entity-appearance-editor'
 import { EntityDefinitionDialog } from '~/components/custom-fields/ui/entity-definition-dialog'
 import SettingsPage from '~/components/global/settings-page'
+import { DefAccessSection } from '~/components/permissions/ui/def-access-section'
 import { useResource } from '~/components/resources/hooks'
 import { useUser } from '~/hooks/use-user'
 
@@ -18,6 +21,8 @@ function CustomFieldsDetailPage() {
 
   // Dialog state
   const [dialogOpen, setDialogOpen] = useState(false)
+  // Fields vs Permissions tab (Appearance stays visible above both).
+  const [tab, setTab] = useState<'fields' | 'permissions'>('fields')
 
   // Get resource from unified registry (handles both system and custom)
   const { resource, isLoading } = useResource(apiSlug)
@@ -82,8 +87,30 @@ function CustomFieldsDetailPage() {
         {/* Appearance editor - show for all, disable for system */}
         <EntityAppearanceEditor resource={resource} disabled={!!resource.entityType} />
 
-        {/* Custom fields list */}
-        <CustomFieldsList resource={resource} />
+        {/* Fields vs Permissions — Permissions only for in-scope CRM defs */}
+        {isAccessManageable(resource) ? (
+          <>
+            <div className='px-3 pt-3 sm:px-6 pb-6'>
+              <div className='w-56'>
+                <RadioTab
+                  value={tab}
+                  onValueChange={(v) => setTab(v as 'fields' | 'permissions')}
+                  size='sm'
+                  radioGroupClassName='w-full'>
+                  <RadioTabItem value='fields'>Fields</RadioTabItem>
+                  <RadioTabItem value='permissions'>Permissions</RadioTabItem>
+                </RadioTab>
+              </div>
+            </div>
+            {tab === 'fields' ? (
+              <CustomFieldsList resource={resource} />
+            ) : (
+              <DefAccessSection resource={resource} />
+            )}
+          </>
+        ) : (
+          <CustomFieldsList resource={resource} />
+        )}
       </SettingsPage>
 
       {/* Edit entity definition dialog (custom only) */}

--- a/apps/web/src/components/channels/ui/channels-page.tsx
+++ b/apps/web/src/components/channels/ui/channels-page.tsx
@@ -4,7 +4,7 @@
 import { FeatureKey } from '@auxx/lib/types'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { Lock, Waypoints } from 'lucide-react'
+import { Ban, Lock, Waypoints } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useOAuthReturn } from '~/components/apps/hooks/use-oauth-return'
@@ -77,16 +77,26 @@ export function ChannelsPage() {
   }
 
   return (
-    <Tabs value={effectiveTab} onValueChange={handleTabChange} className='w-full'>
+    <Tabs
+      value={effectiveTab}
+      onValueChange={handleTabChange}
+      className='flex h-full min-h-0 flex-1 flex-col'>
       <SettingsPage
         title='Channels'
         description='Connect email, chat, social, and phone channels.'
         breadcrumbs={BREADCRUMBS}
-        button={
+        subHeaderClassName='p-0'
+        subHeader={
           isAdminOrOwner ? (
-            <TabsList>
-              <TabsTrigger value='channels'>Channels</TabsTrigger>
-              <TabsTrigger value='suppressions'>Suppressions</TabsTrigger>
+            <TabsList variant='outline'>
+              <TabsTrigger value='channels' variant='outline'>
+                <Waypoints />
+                Channels
+              </TabsTrigger>
+              <TabsTrigger value='suppressions' variant='outline'>
+                <Ban />
+                Suppressions
+              </TabsTrigger>
             </TabsList>
           ) : undefined
         }>
@@ -123,10 +133,8 @@ export function ChannelsPage() {
           </div>
         </TabsContent>
 
-        <TabsContent value='suppressions'>
-          <div className='p-3 sm:p-6'>
-            <SuppressionList />
-          </div>
+        <TabsContent value='suppressions' className='flex flex-1 flex-col'>
+          <SuppressionList />
         </TabsContent>
 
         <ChannelGalleryDialog open={galleryOpen} onOpenChange={setGalleryOpen} />

--- a/apps/web/src/components/channels/ui/suppression-list.tsx
+++ b/apps/web/src/components/channels/ui/suppression-list.tsx
@@ -90,11 +90,11 @@ export function SuppressionList() {
   }
 
   return (
-    <SettingsSection
-      icon={MailX}
-      title='Suppressed addresses'
-      description='Addresses sequences will never email — collected from unsubscribes, hard bounces, and manual adds. Removing an entry resubscribes the address.'>
-      <div className='space-y-3'>
+    <div className='flex flex-1 flex-col gap-4 p-3 sm:p-6'>
+      <SettingsSection
+        icon={MailX}
+        title='Suppressed addresses'
+        description='Addresses sequences will never email — collected from unsubscribes, hard bounces, and manual adds. Removing an entry resubscribes the address.'>
         <div className='flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between'>
           <InputGroup className='sm:max-w-xs'>
             <InputGroupAddon>
@@ -135,74 +135,74 @@ export function SuppressionList() {
             {addError && <p className='text-xs text-destructive'>{addError}</p>}
           </div>
         </div>
+      </SettingsSection>
 
-        {listQuery.isLoading ? (
-          <div className='flex flex-col'>
-            {[0, 1, 2].map((i) => (
-              <TreeRowSkeleton key={i} />
-            ))}
-          </div>
-        ) : rows.length === 0 ? (
-          <EmptyState
-            icon={MailX}
-            title={deferredSearch ? 'No matches' : 'No suppressed addresses'}
-            description={
-              deferredSearch
-                ? 'No suppressed addresses match your search.'
-                : 'Unsubscribes and hard bounces will show up here automatically.'
-            }
-          />
-        ) : (
-          <div className={cn('flex flex-col', TREE_SECONDARY_NOTRUNCATE)}>
-            {rows.map((row) => (
-              <TreeRow
-                key={row.id}
-                rowClassName='hover:bg-primary-100'
-                icon={<MailX className='size-4 text-muted-foreground/60' />}
-                title={<span className='font-mono text-sm'>{row.email}</span>}
-                secondary={
-                  <span className='flex items-center gap-1.5'>
-                    <Badge variant='secondary' size='sm'>
-                      {row.reason}
-                    </Badge>
-                    <span className='text-xs text-muted-foreground'>
-                      {formatRelativeTime(row.createdAt, true)}
-                    </span>
+      {listQuery.isLoading ? (
+        <div className='flex flex-col'>
+          {[0, 1, 2].map((i) => (
+            <TreeRowSkeleton key={i} />
+          ))}
+        </div>
+      ) : rows.length === 0 ? (
+        <EmptyState
+          icon={MailX}
+          title={deferredSearch ? 'No matches' : 'No suppressed addresses'}
+          description={
+            deferredSearch
+              ? 'No suppressed addresses match your search.'
+              : 'Unsubscribes and hard bounces will show up here automatically.'
+          }
+        />
+      ) : (
+        <div className={cn('flex flex-col', TREE_SECONDARY_NOTRUNCATE)}>
+          {rows.map((row) => (
+            <TreeRow
+              key={row.id}
+              rowClassName='hover:bg-primary-100'
+              icon={<MailX className='size-4 text-muted-foreground/60' />}
+              title={<span className='font-mono text-sm'>{row.email}</span>}
+              secondary={
+                <span className='flex items-center gap-1.5'>
+                  <Badge variant='secondary' size='sm'>
+                    {row.reason}
+                  </Badge>
+                  <span className='text-xs text-muted-foreground'>
+                    {formatRelativeTime(row.createdAt, true)}
                   </span>
-                }
-                actions={
-                  <>
-                    {row.contactEntityInstanceId && (
-                      <TreeRowButton
-                        tooltipText='View contact'
-                        onClick={() => router.push(`/app/contacts/${row.contactEntityInstanceId}`)}>
-                        <UserRound />
-                      </TreeRowButton>
-                    )}
+                </span>
+              }
+              actions={
+                <>
+                  {row.contactEntityInstanceId && (
                     <TreeRowButton
-                      variant='destructive'
-                      tooltipText='Remove suppression'
-                      onClick={() => void handleRemove(row)}>
-                      <Trash2 />
+                      tooltipText='View contact'
+                      onClick={() => router.push(`/app/contacts/${row.contactEntityInstanceId}`)}>
+                      <UserRound />
                     </TreeRowButton>
-                  </>
-                }
-              />
-            ))}
-            {listQuery.hasNextPage && (
-              <Button
-                variant='ghost'
-                size='xs'
-                className='mt-1 self-center text-muted-foreground'
-                loading={listQuery.isFetchingNextPage}
-                onClick={() => void listQuery.fetchNextPage()}>
-                Load more
-              </Button>
-            )}
-          </div>
-        )}
-      </div>
+                  )}
+                  <TreeRowButton
+                    variant='destructive'
+                    tooltipText='Remove suppression'
+                    onClick={() => void handleRemove(row)}>
+                    <Trash2 />
+                  </TreeRowButton>
+                </>
+              }
+            />
+          ))}
+          {listQuery.hasNextPage && (
+            <Button
+              variant='ghost'
+              size='xs'
+              className='mt-1 self-center text-muted-foreground'
+              loading={listQuery.isFetchingNextPage}
+              onClick={() => void listQuery.fetchNextPage()}>
+              Load more
+            </Button>
+          )}
+        </div>
+      )}
       <ConfirmDialog />
-    </SettingsSection>
+    </div>
   )
 }

--- a/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
@@ -27,6 +27,7 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { DangerZone } from '~/components/global/danger-zone'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
@@ -328,19 +329,23 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
           </SettingsSection>
         </div>
 
-        <div className='flex flex-wrap items-center justify-between gap-3 border-t p-3 sm:p-6'>
-          <div className='space-y-1'>
-            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-destructive'>
-              <Trash2 className='size-4' /> Danger zone
-            </div>
-            <p className='text-sm text-muted-foreground'>
-              Permanently delete this widget and disconnect it from inboxes.
-            </p>
-          </div>
-          <Button type='button' variant='destructive' size='sm' onClick={onDelete}>
-            <Trash2 className='size-4' />
-            Delete widget
-          </Button>
+        <div className='border-t p-3 sm:p-6'>
+          <SettingsSection
+            icon={Trash2}
+            title='Danger zone'
+            description='Permanently delete this widget and disconnect it from inboxes.'>
+            <DangerZone
+              icon={Trash2}
+              title='Delete widget'
+              description='Permanently delete this widget and disconnect it from inboxes.'
+              action={
+                <Button type='button' variant='destructive' size='sm' onClick={onDelete}>
+                  <Trash2 />
+                  Delete widget
+                </Button>
+              }
+            />
+          </SettingsSection>
         </div>
 
         <div className='flex justify-end gap-2 border-t px-4 py-4'>

--- a/apps/web/src/components/custom-fields/ui/custom-fields-list.tsx
+++ b/apps/web/src/components/custom-fields/ui/custom-fields-list.tsx
@@ -146,7 +146,7 @@ export function CustomFieldsList({ resource }: CustomFieldsListProps) {
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
           modifiers={[restrictToVerticalAxis]}>
-          <table className='text-sm w-full caption-bottom'>
+          <table className='text-sm w-full caption-bottom border-t'>
             <TableHeader>
               <TableRow>
                 <TableHead className='w-[40px]'></TableHead>

--- a/apps/web/src/components/custom-fields/ui/entity-appearance-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-appearance-editor.tsx
@@ -91,7 +91,7 @@ export function EntityAppearanceEditor({
   }
 
   return (
-    <div className='p-4 border-b'>
+    <div className='p-3 sm:p-6'>
       <SettingsSection className='mb-4' icon={Palette} title='Appearance'>
         {disabled && (
           <div className='text-xs text-muted-foreground italic mb-4'>

--- a/apps/web/src/components/global/danger-zone.tsx
+++ b/apps/web/src/components/global/danger-zone.tsx
@@ -1,0 +1,61 @@
+// apps/web/src/components/global/danger-zone.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { type LucideIcon, TriangleAlert } from 'lucide-react'
+import type React from 'react'
+
+interface DangerZoneProps {
+  /** Card heading, e.g. "Delete integration". */
+  title: React.ReactNode
+  /** Optional supporting copy under the card heading. */
+  description?: React.ReactNode
+  /**
+   * Action element — usually a destructive `Button` (optionally wrapped in an
+   * `AdminGate`). Sits to the right of the text on wide cards and stacks below
+   * it once the card itself gets narrow (container-query driven, so it responds
+   * to the available space rather than the viewport).
+   */
+  action: React.ReactNode
+  /** Icon shown in the card badge. Defaults to {@link TriangleAlert}. */
+  icon?: LucideIcon
+  /** Extra classes for the card wrapper. */
+  className?: string
+}
+
+/**
+ * Standardized "Danger zone" card: a destructive-outlined row with an icon
+ * badge, title, description, and an action. Used for delete/remove actions
+ * across settings and detail pages so they read the same everywhere. Wrap it in
+ * a `SettingsSection` at the call site when it needs a section header.
+ */
+export function DangerZone({
+  title,
+  description,
+  action,
+  icon: Icon = TriangleAlert,
+  className,
+}: DangerZoneProps) {
+  return (
+    <div
+      className={cn(
+        '@container group rounded-2xl border border-destructive/50 px-3 py-2 transition-colors duration-200 hover:bg-destructive/2',
+        className
+      )}>
+      <div className='flex flex-col justify-between gap-1 @md:gap-4 @md:flex-row @md:items-center'>
+        <div className='flex items-center gap-3'>
+          <div className='flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-destructive/10 bg-destructive/2 transition-colors group-hover:bg-destructive/5'>
+            <Icon className='size-4 text-destructive' />
+          </div>
+          <div className='flex flex-col'>
+            <span className='text-sm text-destructive font-bold'>{title}</span>
+            {description && <span className='text-xs text-destructive/80'>{description}</span>}
+          </div>
+        </div>
+        {/* Stacked (narrow) → line the action up with the text, not the icon badge
+            (badge size-8 + gap-3 = pl-11); inline (wide) → back to the right edge. */}
+        <div className='shrink-0 pl-11 @md:pl-0'>{action}</div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/groups/ui/group-danger-section.tsx
+++ b/apps/web/src/components/groups/ui/group-danger-section.tsx
@@ -6,6 +6,7 @@ import { Button } from '@auxx/ui/components/button'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { TriangleAlert } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { DangerZone } from '~/components/global/danger-zone'
 import { SettingsSection } from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useGroupMutations } from '../hooks'
@@ -40,21 +41,19 @@ export function GroupDangerSection({ group }: { group: EntityInstanceEntity }) {
       icon={TriangleAlert}
       title='Danger zone'
       description='Irreversible actions for this group'>
-      <div className='flex items-center justify-between gap-4 rounded-2xl border border-destructive/30 p-4'>
-        <div className='min-w-0'>
-          <p className='text-sm font-medium'>Delete this group</p>
-          <p className='text-sm text-muted-foreground'>
-            Permanently delete the group and remove all of its members.
-          </p>
-        </div>
-        <Button
-          variant='destructive'
-          onClick={handleDelete}
-          loading={deleteGroup.isPending}
-          loadingText='Deleting...'>
-          Delete group
-        </Button>
-      </div>
+      <DangerZone
+        title='Delete this group'
+        description='Permanently delete the group and remove all of its members.'
+        action={
+          <Button
+            variant='destructive'
+            onClick={handleDelete}
+            loading={deleteGroup.isPending}
+            loadingText='Deleting...'>
+            Delete group
+          </Button>
+        }
+      />
       <ConfirmDialog />
     </SettingsSection>
   )

--- a/apps/web/src/components/members/ui/member-danger-section.tsx
+++ b/apps/web/src/components/members/ui/member-danger-section.tsx
@@ -6,6 +6,7 @@ import { Button } from '@auxx/ui/components/button'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { TriangleAlert } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { DangerZone } from '~/components/global/danger-zone'
 import { SettingsSection } from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -53,21 +54,19 @@ export function MemberDangerSection({ member, viewerRole, viewerId }: MemberDang
       icon={TriangleAlert}
       title='Danger zone'
       description='Irreversible actions for this member'>
-      <div className='flex items-center justify-between gap-4 rounded-2xl border border-destructive/30 p-4'>
-        <div className='min-w-0'>
-          <p className='text-sm font-medium'>Remove from organization</p>
-          <p className='text-sm text-muted-foreground'>
-            Revoke this member's access and free their seat.
-          </p>
-        </div>
-        <Button
-          variant='destructive'
-          onClick={handleRemove}
-          loading={removeUser.isPending}
-          loadingText='Removing...'>
-          Remove member
-        </Button>
-      </div>
+      <DangerZone
+        title='Remove from organization'
+        description="Revoke this member's access and free their seat."
+        action={
+          <Button
+            variant='destructive'
+            onClick={handleRemove}
+            loading={removeUser.isPending}
+            loadingText='Removing...'>
+            Remove member
+          </Button>
+        }
+      />
       <ConfirmDialog />
     </SettingsSection>
   )

--- a/apps/web/src/components/members/ui/members-tab.tsx
+++ b/apps/web/src/components/members/ui/members-tab.tsx
@@ -13,15 +13,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from '@auxx/ui/components/empty'
 import { InputSearch } from '@auxx/ui/components/input-search'
-import type { ListCardMenuItem } from '@auxx/ui/components/list-card'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { ListCard, type ListCardMenuItem } from '@auxx/ui/components/list-card'
 import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import {
   Select,
@@ -33,6 +27,7 @@ import {
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { Copy, Send, Trash2, Users } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { EmptyState } from '~/components/global/empty-state'
 import { Tooltip } from '~/components/global/tooltip'
 import { SeatTypeSelect } from '~/components/permissions/ui/seat-type-select'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -57,15 +52,12 @@ export function MembersTab() {
   const { userId, role: currentUserRole } = useUser({ requireRoles: ['ADMIN', 'OWNER'] })
   const utils = api.useUtils()
 
-  const { data: membersData } = api.member.all.useQuery()
+  const { data: membersData, isLoading } = api.member.all.useQuery()
   const { data: pendingInvitations = [] } = api.member.invitations.useQuery()
   const members = (membersData?.members ?? []) as unknown as Member[]
 
   const [search, setSearch] = useState('')
   const [selectedMember, setSelectedMember] = useState<Member | null>(null)
-  const [selectedInvitation, setSelectedInvitation] = useState<PendingInvitation | null>(null)
-  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
-  const [isCancelInviteDialogOpen, setIsCancelInviteDialogOpen] = useState(false)
   const [isRoleDialogOpen, setIsRoleDialogOpen] = useState(false)
   const [newRole, setNewRole] = useState<OrganizationRole | null>(null)
   const [isSeatDialogOpen, setIsSeatDialogOpen] = useState(false)
@@ -81,7 +73,6 @@ export function MembersTab() {
   const removeUser = api.member.remove.useMutation({
     onSuccess: () => {
       toastSuccess({ description: 'Member removed' })
-      setIsRemoveDialogOpen(false)
       refreshMembers()
     },
     onError: (error) => toastError({ title: 'Error removing member', description: error.message }),
@@ -105,7 +96,6 @@ export function MembersTab() {
   const cancelInvite = api.member.cancelInvitation.useMutation({
     onSuccess: () => {
       toastSuccess({ description: 'Invitation cancelled' })
-      setIsCancelInviteDialogOpen(false)
       refreshMembers()
     },
     onError: (error) =>
@@ -135,9 +125,26 @@ export function MembersTab() {
     onError: (error) => toastError({ title: 'Error getting link', description: error.message }),
   })
 
-  const handleRemoveMember = async () => {
-    if (!selectedMember) return
-    await removeUser.mutateAsync({ memberId: selectedMember.userId })
+  const handleRemoveMember = async (member: Member) => {
+    const confirmed = await confirm({
+      title: 'Remove member?',
+      description: `Remove ${member.user.name || member.user.email} from this organization? They will lose all access.`,
+      confirmText: 'Remove',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) removeUser.mutate({ memberId: member.userId })
+  }
+
+  const handleCancelInvite = async (invitation: PendingInvitation) => {
+    const confirmed = await confirm({
+      title: 'Cancel invitation?',
+      description: `Cancel the invitation sent to ${invitation.email}? They will no longer be able to join using the previous link.`,
+      confirmText: 'Cancel Invitation',
+      cancelText: 'Keep',
+      destructive: true,
+    })
+    if (confirmed) cancelInvite.mutate({ invitationId: invitation.id })
   }
   const handleUpdateRole = async () => {
     if (!selectedMember || !newRole) return
@@ -224,10 +231,7 @@ export function MembersTab() {
           icon: <Trash2 />,
           destructive: true,
           disabled: cancelInvite.isPending,
-          onClick: () => {
-            setSelectedInvitation(item.data)
-            setIsCancelInviteDialogOpen(true)
-          },
+          onClick: () => handleCancelInvite(item.data),
         },
       ]
     }
@@ -268,10 +272,7 @@ export function MembersTab() {
       items.push({
         label: 'Remove Member',
         destructive: true,
-        onClick: () => {
-          setSelectedMember(member)
-          setIsRemoveDialogOpen(true)
-        },
+        onClick: () => handleRemoveMember(member),
       })
     }
     return items.length > 0 ? items : undefined
@@ -295,22 +296,20 @@ export function MembersTab() {
       </ListToolbar>
 
       <div className='p-3 sm:p-6'>
-        {filtered.length === 0 ? (
-          <div className='flex flex-1 flex-col items-center justify-center py-8'>
-            <Empty>
-              <EmptyHeader>
-                <EmptyMedia variant='icon'>
-                  <Users />
-                </EmptyMedia>
-                <EmptyTitle>No members found</EmptyTitle>
-                <EmptyDescription>
-                  {search
-                    ? 'Try adjusting your search terms'
-                    : 'Invite people to your organization'}
-                </EmptyDescription>
-              </EmptyHeader>
-            </Empty>
+        {isLoading ? (
+          <div className='space-y-2'>
+            {[...Array(6)].map((_, i) => (
+              <ListCard key={`skeleton-${i}`} loading descriptionLines={0} />
+            ))}
           </div>
+        ) : filtered.length === 0 ? (
+          <EmptyState
+            icon={Users}
+            title='No members found'
+            description={
+              search ? 'Try adjusting your search terms' : 'Invite people to your organization'
+            }
+          />
         ) : (
           <div className='space-y-2'>
             {filtered.map((item) => (
@@ -325,68 +324,9 @@ export function MembersTab() {
         )}
       </div>
 
-      {/* Remove member confirmation */}
-      <Dialog open={isRemoveDialogOpen} onOpenChange={setIsRemoveDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Remove member</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to remove{' '}
-              {selectedMember?.user.name || selectedMember?.user.email} from this organization?
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant='outline'
-              onClick={() => setIsRemoveDialogOpen(false)}
-              disabled={removeUser.isPending}>
-              Cancel
-            </Button>
-            <Button
-              variant='destructive'
-              onClick={handleRemoveMember}
-              loading={removeUser.isPending}
-              loadingText='Removing...'>
-              Remove
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Cancel invitation confirmation */}
-      <Dialog open={isCancelInviteDialogOpen} onOpenChange={setIsCancelInviteDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Cancel Invitation</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to cancel the invitation sent to{' '}
-              <strong>{selectedInvitation?.email}</strong>? They will no longer be able to join
-              using the previous link.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant='outline'
-              onClick={() => setIsCancelInviteDialogOpen(false)}
-              disabled={cancelInvite.isPending}>
-              Cancel
-            </Button>
-            <Button
-              variant='destructive'
-              onClick={() => {
-                if (selectedInvitation) cancelInvite.mutate({ invitationId: selectedInvitation.id })
-              }}
-              loading={cancelInvite.isPending}
-              loadingText='Cancelling...'>
-              Cancel Invitation
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       {/* Change role */}
       <Dialog open={isRoleDialogOpen} onOpenChange={setIsRoleDialogOpen}>
-        <DialogContent>
+        <DialogContent position='tc'>
           <DialogHeader>
             <DialogTitle>Change member role</DialogTitle>
             <DialogDescription>
@@ -444,16 +384,17 @@ export function MembersTab() {
               size='sm'
               onClick={() => setIsRoleDialogOpen(false)}
               disabled={updateRole.isPending}>
-              Cancel
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
             </Button>
             <Button
+              data-dialog-submit
               onClick={handleUpdateRole}
               size='sm'
               variant='outline'
               disabled={updateRole.isPending || !newRole || newRole === selectedMember?.role}
               loading={updateRole.isPending}
               loadingText='Updating...'>
-              Update role
+              Update role <KbdSubmit variant='outline' size='sm' />
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -461,7 +402,7 @@ export function MembersTab() {
 
       {/* Change seat type */}
       <Dialog open={isSeatDialogOpen} onOpenChange={setIsSeatDialogOpen}>
-        <DialogContent>
+        <DialogContent position='tc'>
           <DialogHeader>
             <DialogTitle>Change seat type</DialogTitle>
             <DialogDescription>
@@ -485,16 +426,17 @@ export function MembersTab() {
               size='sm'
               onClick={() => setIsSeatDialogOpen(false)}
               disabled={updateSeatType.isPending}>
-              Cancel
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
             </Button>
             <Button
+              data-dialog-submit
               onClick={handleUpdateSeatType}
               size='sm'
               variant='outline'
               disabled={updateSeatType.isPending || newSeatType === selectedMember?.seatType}
               loading={updateSeatType.isPending}
               loadingText='Updating...'>
-              Update seat
+              Update seat <KbdSubmit variant='outline' size='sm' />
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/permissions/hooks/use-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-def-access.ts
@@ -1,0 +1,257 @@
+// apps/web/src/components/permissions/hooks/use-def-access.ts
+'use client'
+
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useMemo } from 'react'
+import { api } from '~/trpc/react'
+import { MEMBER_BASELINE_GRANTEE_ID } from './use-permission-grants'
+
+/** A resolved team/member grant (grantees never carry `none`). */
+export interface DefAccessGrant {
+  granteeId: string
+  permission: ResourcePermission
+}
+
+/** Client-safe rank for the "ignored" comparison (`none` < view < edit < admin). */
+const PERMISSION_RANK: Record<ResourcePermission, number> = {
+  [ResourcePermission.none]: 0,
+  [ResourcePermission.view]: 1,
+  [ResourcePermission.edit]: 2,
+  [ResourcePermission.admin]: 3,
+}
+
+/**
+ * The workspace baseline an unconfigured def displays and persists on first
+ * touch — every member's default access to the def (matches Attio's read-write
+ * default). Set to `edit` (Read and write).
+ */
+const DEFAULT_BASELINE_LEVEL: ResourcePermission = ResourcePermission.edit
+
+/**
+ * The level a newly added team/member grant defaults to. `admin` (Full access)
+ * so a fresh grant sits above the read-write baseline and isn't instantly
+ * flagged "ignored" (mirrors Attio, where added grantees default to Full).
+ */
+const DEFAULT_GRANTEE_LEVEL: ResourcePermission = ResourcePermission.admin
+
+/**
+ * Manages the entity-def Access configuration (capability layer v2 phase 3) for
+ * one CRM def: the workspace baseline (`role:org_member`), team (`group`) grants,
+ * and individual member (`user`) grants — all stored as type-level `ResourceAccess`
+ * rows keyed by the def's `entityDefinitionId` CUID.
+ *
+ * Semantics (plan §1):
+ * - **Unconfigured** (`isConfigured=false`): no rows, def visible to everyone;
+ *   the baseline displays as the default (Read and write) and nothing is
+ *   persisted until touched.
+ * - **First-touch additive**: adding a grant while no baseline row exists ALSO
+ *   writes `role:org_member @ <default baseline>`, so everyone keeps the default
+ *   access while the grantee is raised — a new grant never silently locks others out.
+ * - **Lockdown**: only Workspace access = `none` restricts non-grantees.
+ * - **Reset**: `resetToDefault()` clears every row, returning the def to the
+ *   dormant/unrestricted state.
+ *
+ * Writes are optimistic; the `resource-access.type.changed` realtime event
+ * re-composes affected members' capabilities, and the query invalidates on
+ * settle to reconcile. Errors surface via `toastError`.
+ */
+export function useDefAccess(entityDefinitionId: string | undefined) {
+  const utils = api.useUtils()
+  const enabled = !!entityDefinitionId
+  const defId = entityDefinitionId ?? ''
+  const queryInput = useMemo(() => ({ entityDefinitionId: defId }), [defId])
+
+  const grantsQuery = api.resourceAccess.forType.useQuery(queryInput, {
+    enabled,
+    staleTime: 30_000,
+  })
+
+  const invalidate = useCallback(
+    () => utils.resourceAccess.forType.invalidate(queryInput),
+    [utils, queryInput]
+  )
+
+  /** Optimistically upsert (or, with `permission` undefined, drop) one row. */
+  const patchLocal = useCallback(
+    (granteeType: ResourceGranteeType, granteeId: string, permission?: ResourcePermission) => {
+      utils.resourceAccess.forType.setData(queryInput, (prev) => {
+        const rows = (prev ?? []).filter(
+          (r) => !(r.granteeType === granteeType && r.granteeId === granteeId)
+        )
+        if (permission) {
+          rows.unshift({
+            id: `optimistic-${granteeType}-${granteeId}`,
+            entityDefinitionId: queryInput.entityDefinitionId,
+            entityInstanceId: null,
+            granteeType,
+            granteeId,
+            permission,
+            createdAt: new Date(),
+          } as (typeof rows)[number])
+        }
+        return rows
+      })
+    },
+    [utils, queryInput]
+  )
+
+  const grantType = api.resourceAccess.grantType.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Error saving access', description: error.message })
+      void invalidate()
+    },
+    onSettled: () => void invalidate(),
+  })
+  const revokeType = api.resourceAccess.revokeType.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Error removing access', description: error.message })
+      void invalidate()
+    },
+    onSettled: () => void invalidate(),
+  })
+  const setType = api.resourceAccess.setType.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Error resetting access', description: error.message })
+      void invalidate()
+    },
+    onSettled: () => void invalidate(),
+  })
+
+  const rows = useMemo(() => grantsQuery.data ?? [], [grantsQuery.data])
+
+  const baselineRow = useMemo(
+    () =>
+      rows.find(
+        (r) =>
+          r.granteeType === ResourceGranteeType.role && r.granteeId === MEMBER_BASELINE_GRANTEE_ID
+      ),
+    [rows]
+  )
+
+  /** The persisted baseline permission, or the default (Read and write) when absent. */
+  const baselineLevel: ResourcePermission = baselineRow?.permission ?? DEFAULT_BASELINE_LEVEL
+  const isConfigured = rows.length > 0
+
+  const teamGrants = useMemo<DefAccessGrant[]>(
+    () =>
+      rows
+        .filter((r) => r.granteeType === ResourceGranteeType.group)
+        .map((r) => ({ granteeId: r.granteeId, permission: r.permission })),
+    [rows]
+  )
+  const userGrants = useMemo<DefAccessGrant[]>(
+    () =>
+      rows
+        .filter((r) => r.granteeType === ResourceGranteeType.user)
+        .map((r) => ({ granteeId: r.granteeId, permission: r.permission })),
+    [rows]
+  )
+
+  /** Persist the workspace baseline (persists `none` too — the lockdown marker). */
+  const setBaseline = useCallback(
+    (permission: ResourcePermission) => {
+      patchLocal(ResourceGranteeType.role, MEMBER_BASELINE_GRANTEE_ID, permission)
+      grantType.mutate({
+        entityDefinitionId: queryInput.entityDefinitionId,
+        granteeType: ResourceGranteeType.role,
+        granteeId: MEMBER_BASELINE_GRANTEE_ID,
+        permission,
+      })
+    },
+    [grantType, patchLocal, queryInput.entityDefinitionId]
+  )
+
+  /**
+   * Add a team/member grant. First-touch rule: if no baseline row exists yet,
+   * also persist `role:org_member @ <default baseline>` so everyone keeps the
+   * default access while the grantee is raised (additive, never exclusionary).
+   */
+  const addGrant = useCallback(
+    (
+      granteeType: ResourceGranteeType,
+      granteeId: string,
+      permission: ResourcePermission = DEFAULT_GRANTEE_LEVEL
+    ) => {
+      if (!baselineRow) {
+        patchLocal(ResourceGranteeType.role, MEMBER_BASELINE_GRANTEE_ID, DEFAULT_BASELINE_LEVEL)
+        grantType.mutate({
+          entityDefinitionId: queryInput.entityDefinitionId,
+          granteeType: ResourceGranteeType.role,
+          granteeId: MEMBER_BASELINE_GRANTEE_ID,
+          permission: DEFAULT_BASELINE_LEVEL,
+        })
+      }
+      patchLocal(granteeType, granteeId, permission)
+      grantType.mutate({
+        entityDefinitionId: queryInput.entityDefinitionId,
+        granteeType,
+        granteeId,
+        permission,
+      })
+    },
+    [baselineRow, grantType, patchLocal, queryInput.entityDefinitionId]
+  )
+
+  /** Change an existing grantee's level. */
+  const setGrant = useCallback(
+    (granteeType: ResourceGranteeType, granteeId: string, permission: ResourcePermission) => {
+      patchLocal(granteeType, granteeId, permission)
+      grantType.mutate({
+        entityDefinitionId: queryInput.entityDefinitionId,
+        granteeType,
+        granteeId,
+        permission,
+      })
+    },
+    [grantType, patchLocal, queryInput.entityDefinitionId]
+  )
+
+  /** Remove a team/member grant (the baseline row stays — everyone still views). */
+  const removeGrant = useCallback(
+    (granteeType: ResourceGranteeType, granteeId: string) => {
+      patchLocal(granteeType, granteeId)
+      revokeType.mutate({
+        entityDefinitionId: queryInput.entityDefinitionId,
+        granteeType,
+        granteeId,
+      })
+    },
+    [revokeType, patchLocal, queryInput.entityDefinitionId]
+  )
+
+  /** Clear every type row for the def → back to the dormant/unrestricted state. */
+  const resetToDefault = useCallback(() => {
+    utils.resourceAccess.forType.setData(queryInput, () => [])
+    // Clear each grantee type independently (setType replaces one type at a time).
+    for (const granteeType of [
+      ResourceGranteeType.role,
+      ResourceGranteeType.group,
+      ResourceGranteeType.user,
+    ]) {
+      setType.mutate({ entityDefinitionId: queryInput.entityDefinitionId, granteeType, grants: [] })
+    }
+  }, [setType, utils, queryInput])
+
+  /** A grant is "ignored" when it lifts nothing above the effective baseline. */
+  const isIgnored = useCallback(
+    (permission: ResourcePermission) =>
+      PERMISSION_RANK[permission] <= PERMISSION_RANK[baselineLevel],
+    [baselineLevel]
+  )
+
+  return {
+    isLoading: grantsQuery.isLoading,
+    baselineLevel,
+    isConfigured,
+    teamGrants,
+    userGrants,
+    isSaving: grantType.isPending || revokeType.isPending || setType.isPending,
+    setBaseline,
+    addGrant,
+    setGrant,
+    removeGrant,
+    resetToDefault,
+    isIgnored,
+  }
+}

--- a/apps/web/src/components/permissions/ui/access-level-select.tsx
+++ b/apps/web/src/components/permissions/ui/access-level-select.tsx
@@ -1,0 +1,84 @@
+// apps/web/src/components/permissions/ui/access-level-select.tsx
+'use client'
+
+import { ResourcePermission } from '@auxx/database/enums'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+
+/** The label + helper shown for each access level in the def-access selects. */
+export const ACCESS_LEVEL_LABELS: Record<ResourcePermission, { label: string; helper: string }> = {
+  [ResourcePermission.none]: { label: 'No Access', helper: 'Cannot see these records' },
+  [ResourcePermission.view]: { label: 'Read only', helper: 'Can view records' },
+  [ResourcePermission.edit]: { label: 'Read and write', helper: 'Can view and edit records' },
+  [ResourcePermission.admin]: { label: 'Full access', helper: 'Full access to records' },
+}
+
+/** Positive levels offered to grantee rows (removing the row is the revoke). */
+const POSITIVE_LEVELS: ResourcePermission[] = [
+  ResourcePermission.view,
+  ResourcePermission.edit,
+  ResourcePermission.admin,
+]
+
+/** All four levels, offered on the workspace baseline row (`includeNone`). */
+const ALL_LEVELS: ResourcePermission[] = [ResourcePermission.none, ...POSITIVE_LEVELS]
+
+interface AccessLevelSelectProps {
+  value: ResourcePermission
+  onChange: (value: ResourcePermission) => void
+  /** Include the `No Access` option — only the workspace baseline offers it. */
+  includeNone?: boolean
+  disabled?: boolean
+  size?: 'xs' | 'sm' | 'default'
+  variant?: 'default' | 'transparent'
+  className?: string
+}
+
+/**
+ * The access-level picker for the entity-def Access UI (capability layer v2
+ * phase 3): a `Select` over No Access / Read / Edit / Full mapping labels ⇄
+ * `ResourcePermission` (`none/view/edit/admin`). Baseline rows pass
+ * `includeNone`; grantee rows offer only the three positive levels (the remove
+ * button is the revoke). Controlled and dumb — persistence lives in the hook.
+ */
+export function AccessLevelSelect({
+  value,
+  onChange,
+  includeNone = false,
+  disabled = false,
+  size = 'sm',
+  variant = 'default',
+  className,
+}: AccessLevelSelectProps) {
+  const levels = includeNone ? ALL_LEVELS : POSITIVE_LEVELS
+  // Never feed Radix an unknown/none value on a positive-only select.
+  const safeValue = levels.includes(value) ? value : ResourcePermission.view
+
+  return (
+    <Select
+      value={safeValue}
+      onValueChange={(next) => onChange(next as ResourcePermission)}
+      disabled={disabled}>
+      <SelectTrigger size={size} variant={variant} className={className}>
+        <SelectValue placeholder='Access'>{ACCESS_LEVEL_LABELS[safeValue].label}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align='end' className='min-w-52'>
+        {levels.map((level) => (
+          <SelectItem key={level} value={level} textValue={ACCESS_LEVEL_LABELS[level].label}>
+            <div className='flex flex-col items-start'>
+              <span>{ACCESS_LEVEL_LABELS[level].label}</span>
+              <span className='text-muted-foreground text-xs'>
+                {ACCESS_LEVEL_LABELS[level].helper}
+              </span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/apps/web/src/components/permissions/ui/def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/def-access-section.tsx
@@ -1,0 +1,310 @@
+// apps/web/src/components/permissions/ui/def-access-section.tsx
+'use client'
+
+import { ResourceGranteeType, type ResourcePermission } from '@auxx/database/enums'
+import type { Resource } from '@auxx/lib/resources/client'
+import { FeatureKey } from '@auxx/lib/types'
+import { type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
+import { Button } from '@auxx/ui/components/button'
+import { EmptySection, Section } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  AlertTriangle,
+  Folder,
+  Plus,
+  RotateCcw,
+  ShieldCheck,
+  Trash2,
+  User,
+  type Users,
+} from 'lucide-react'
+import { useMemo } from 'react'
+import { UpgradeBanner } from '~/components/banner/upgrade-banner'
+import { Tooltip } from '~/components/global/tooltip'
+import { ActorPicker } from '~/components/pickers/actor-picker'
+import { useActor } from '~/components/resources/hooks/use-actor'
+import { ActorAvatar } from '~/components/resources/ui/actor-badge'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { type DefAccessGrant, useDefAccess } from '../hooks/use-def-access'
+import { AccessLevelSelect } from './access-level-select'
+
+type GranteeKind = 'group' | 'user'
+
+const GRANTEE_COPY: Record<
+  GranteeKind,
+  { title: string; add: string; remove: string; empty: string; icon: typeof Users }
+> = {
+  group: {
+    title: 'Teams',
+    add: 'Add team',
+    remove: 'Remove team',
+    empty: 'Grant a team access to these records.',
+    icon: Folder,
+  },
+  user: {
+    title: 'Individual members',
+    add: 'Add member',
+    remove: 'Remove member',
+    empty: 'Grant an individual member access to these records.',
+    icon: User,
+  },
+}
+
+/**
+ * The entity-def **Access** surface (capability layer v2 phase 3): a workspace
+ * baseline ("Default for all members"), raise-only **team** grants, and
+ * **individual member** grants — modeled on Attio's object-permissions screen.
+ *
+ * Composition is baseline-floor + raise-only-grants, so adding a team/member
+ * never locks others out; only Workspace access = No Access restricts
+ * non-grantees. Editing is gated on `granularPermissions`; admins always retain
+ * access regardless of baseline. All writes carry the def's
+ * `entityDefinitionId` CUID (never a slug).
+ */
+export function DefAccessSection({ resource }: { resource: Resource }) {
+  const { hasAccess } = useFeatureFlags()
+  const canEdit = hasAccess(FeatureKey.granularPermissions)
+  const {
+    isLoading,
+    baselineLevel,
+    isConfigured,
+    teamGrants,
+    userGrants,
+    setBaseline,
+    addGrant,
+    setGrant,
+    removeGrant,
+    resetToDefault,
+    isIgnored,
+  } = useDefAccess(resource.entityDefinitionId)
+
+  if (isLoading) {
+    return (
+      <div className='space-y-2 p-3 sm:p-6'>
+        <Skeleton className='h-16 w-full rounded-lg' />
+        <Skeleton className='h-24 w-full rounded-lg' />
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-4 p-3 sm:p-6 sm:pt-0 pt-0'>
+      {!canEdit && (
+        <UpgradeBanner
+          title='Upgrade to configure record access'
+          description='Granular permissions let you set a workspace baseline and grant teams and members access per record type.'
+        />
+      )}
+
+      {/* Workspace access */}
+      <Section
+        title='Workspace access'
+        className='[&_[data-slot=section]]:p-0! [&_[data-slot=section]]:border-b-0!'
+        icon={<ShieldCheck className='size-4' />}
+        collapsible={false}
+        actions={
+          isConfigured ? (
+            <Button variant='ghost' size='xs' disabled={!canEdit} onClick={() => resetToDefault()}>
+              <RotateCcw />
+              Reset to default
+            </Button>
+          ) : undefined
+        }>
+        <div className='flex items-center justify-between gap-4 rounded-xl border bg-primary-50 px-3 py-2.5'>
+          <div className='flex flex-col'>
+            <span className='font-medium text-sm'>Default for all members</span>
+            <span className='text-muted-foreground text-xs'>
+              The default access level for everyone. Admins always retain access.
+            </span>
+          </div>
+          <AccessLevelSelect
+            value={baselineLevel}
+            onChange={setBaseline}
+            includeNone
+            disabled={!canEdit}
+            className='h-8 w-40 shrink-0'
+          />
+        </div>
+      </Section>
+
+      <GranteeAccessBlock
+        kind='group'
+        grants={teamGrants}
+        baselineLevel={baselineLevel}
+        canEdit={canEdit}
+        isIgnored={isIgnored}
+        onAdd={(actorIds) => addActors(actorIds, teamGrants, ResourceGranteeType.group, addGrant)}
+        onChange={(granteeId, level) => setGrant(ResourceGranteeType.group, granteeId, level)}
+        onRemove={(granteeId) => removeGrant(ResourceGranteeType.group, granteeId)}
+      />
+
+      <GranteeAccessBlock
+        kind='user'
+        grants={userGrants}
+        baselineLevel={baselineLevel}
+        canEdit={canEdit}
+        isIgnored={isIgnored}
+        onAdd={(actorIds) => addActors(actorIds, userGrants, ResourceGranteeType.user, addGrant)}
+        onChange={(granteeId, level) => setGrant(ResourceGranteeType.user, granteeId, level)}
+        onRemove={(granteeId) => removeGrant(ResourceGranteeType.user, granteeId)}
+      />
+    </div>
+  )
+}
+
+/** Add every newly-picked actor as a `view` grant (skips ones already present). */
+function addActors(
+  nextActorIds: ActorId[],
+  existing: DefAccessGrant[],
+  granteeType: ResourceGranteeType,
+  addGrant: (
+    granteeType: ResourceGranteeType,
+    granteeId: string,
+    permission?: ResourcePermission
+  ) => void
+) {
+  const present = new Set(existing.map((g) => g.granteeId))
+  for (const actorId of nextActorIds) {
+    const granteeId = getActorRawId(actorId)
+    if (!present.has(granteeId)) addGrant(granteeType, granteeId)
+  }
+}
+
+/** One grantee-kind block (Teams or Individual members): add button + row list. */
+function GranteeAccessBlock({
+  kind,
+  grants,
+  baselineLevel,
+  canEdit,
+  isIgnored,
+  onAdd,
+  onChange,
+  onRemove,
+}: {
+  kind: GranteeKind
+  grants: DefAccessGrant[]
+  baselineLevel: ResourcePermission
+  canEdit: boolean
+  isIgnored: (permission: ResourcePermission) => boolean
+  onAdd: (actorIds: ActorId[]) => void
+  onChange: (granteeId: string, level: ResourcePermission) => void
+  onRemove: (granteeId: string) => void
+}) {
+  const copy = GRANTEE_COPY[kind]
+  const actorIds = useMemo(() => grants.map((g) => toActorId(kind, g.granteeId)), [grants, kind])
+
+  return (
+    <Section
+      title={copy.title}
+      icon={<copy.icon className='size-4' />}
+      className='[&_[data-slot=section]]:p-0! [&_[data-slot=section]]:border-b-0!'
+      collapsible={false}
+      actions={
+        <ActorPicker
+          value={actorIds}
+          onChange={onAdd}
+          target={kind}
+          multi
+          excludeIds={actorIds}
+          disabled={!canEdit}>
+          <Button variant='ghost' size='xs' disabled={!canEdit}>
+            <Plus />
+            {copy.add}
+          </Button>
+        </ActorPicker>
+      }>
+      {grants.length === 0 ? (
+        <EmptySection
+          orientation='horizontal'
+          icon={<copy.icon className='size-5' />}
+          title={`No ${kind === 'group' ? 'teams' : 'members'} yet`}
+          description={copy.empty}
+        />
+      ) : (
+        <div className='flex flex-col gap-0.5 border rounded-xl p-0.5'>
+          {grants.map((grant) => (
+            <GranteeRow
+              key={grant.granteeId}
+              kind={kind}
+              grant={grant}
+              ignored={isIgnored(grant.permission)}
+              baselineLevel={baselineLevel}
+              canEdit={canEdit}
+              onChange={(level) => onChange(grant.granteeId, level)}
+              onRemove={() => onRemove(grant.granteeId)}
+            />
+          ))}
+        </div>
+      )}
+    </Section>
+  )
+}
+
+/** A single grantee row: avatar + resolved name + level select + remove. */
+function GranteeRow({
+  kind,
+  grant,
+  ignored,
+  baselineLevel,
+  canEdit,
+  onChange,
+  onRemove,
+}: {
+  kind: GranteeKind
+  grant: DefAccessGrant
+  ignored: boolean
+  baselineLevel: ResourcePermission
+  canEdit: boolean
+  onChange: (level: ResourcePermission) => void
+  onRemove: () => void
+}) {
+  const { userId } = useUser()
+  const actorId = useMemo(() => toActorId(kind, grant.granteeId), [kind, grant.granteeId])
+  const { actor, isLoading, isNotFound } = useActor({ actorId })
+  const base = isNotFound
+    ? 'Unknown'
+    : actor?.name || (actor?.type === 'user' && actor?.email) || 'Unknown'
+  const name = kind === 'user' && grant.granteeId === userId ? `${base} (You)` : base
+
+  return (
+    <TreeRow
+      icon={<ActorAvatar type={actor?.type ?? kind} avatarUrl={actor?.avatarUrl} />}
+      rowClassName='bg-primary-50 hover:bg-primary-100'
+      title={
+        isLoading && !actor ? (
+          <Skeleton className='h-4 w-24 rounded-full' />
+        ) : (
+          <span className={cn('truncate', isNotFound && 'text-muted-foreground')}>{name}</span>
+        )
+      }
+      actions={
+        <>
+          {ignored && (
+            <Tooltip
+              content={`Ignored — this grant is at or below the workspace baseline (${baselineLevel}).`}>
+              <AlertTriangle className='size-4 text-amber-500' />
+            </Tooltip>
+          )}
+          <AccessLevelSelect
+            value={grant.permission}
+            onChange={onChange}
+            disabled={!canEdit}
+            size='sm'
+            variant='transparent'
+            className='h-7 w-32'
+          />
+          <TreeRowButton
+            variant='destructive'
+            tooltipText={GRANTEE_COPY[kind].remove}
+            disabled={!canEdit}
+            onClick={onRemove}>
+            <Trash2 />
+          </TreeRowButton>
+        </>
+      }
+    />
+  )
+}

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -1,6 +1,7 @@
 // apps/web/src/server/api/routers/resourceAccess.ts
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { isAdminOrOwner } from '@auxx/lib/members'
 import type { ResourceAccessContext } from '@auxx/lib/resource-access'
 import {
   assertCanManageMailSharing,
@@ -12,12 +13,14 @@ import {
   getTypeAccess,
   grantInstanceAccess,
   grantTypeAccess,
+  isMailSharingDef,
   revokeInstanceAccess,
   revokeTypeAccess,
   setInstanceAccess,
   setTypeAccess,
 } from '@auxx/lib/resource-access'
 import type { RecordId } from '@auxx/types/resource'
+import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
@@ -34,6 +37,31 @@ function toContext(ctx: {
     db: ctx.db,
     organizationId: ctx.session.organizationId,
     userId: ctx.session.userId,
+  }
+}
+
+/**
+ * Authorization for TYPE-level (def-wide) ResourceAccess reads/writes. Mail-infra
+ * defs keep their mail-sharing authorization (inbox managers etc.); every other
+ * def — the entity-def Access UI surface (capability layer v2 phase 3) — is
+ * strictly admin/owner-only. Enforced at the endpoint independently of the page's
+ * role guard (defense in depth: a non-admin must not self-grant def access via a
+ * raw call).
+ */
+async function assertCanManageTypeAccess(
+  ctx: { db: any; session: { organizationId: string; userId: string } },
+  entityDefinitionId: string
+): Promise<void> {
+  if (isMailSharingDef(entityDefinitionId)) {
+    await assertCanManageMailTypeAccess(toContext(ctx), entityDefinitionId)
+    return
+  }
+  const allowed = await isAdminOrOwner(ctx.session.organizationId, ctx.session.userId)
+  if (!allowed) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'You must be an admin or owner to manage type-level access',
+    })
   }
 }
 
@@ -86,7 +114,11 @@ export const resourceAccessRouter = createTRPCRouter({
       return { success: true }
     }),
 
-  /** Grant type-level access (all instances of an entity type) */
+  /**
+   * Grant type-level access (all instances of an entity type). `none` is
+   * accepted only for the workspace baseline (`role:org_member`) — a def
+   * lockdown marker that grants nobody (capability layer v2 phase 3).
+   */
   grantType: protectedProcedure
     .input(
       z.object({
@@ -99,6 +131,7 @@ export const resourceAccessRouter = createTRPCRouter({
         ]),
         granteeId: z.string(),
         permission: z.enum([
+          ResourcePermission.none,
           ResourcePermission.view,
           ResourcePermission.edit,
           ResourcePermission.admin,
@@ -106,7 +139,7 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await assertCanManageMailTypeAccess(toContext(ctx), input.entityDefinitionId)
+      await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
       await grantTypeAccess(toContext(ctx), input)
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -177,7 +210,7 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await assertCanManageMailTypeAccess(toContext(ctx), input.entityDefinitionId)
+      await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
       const revoked = await revokeTypeAccess(toContext(ctx), input)
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -258,7 +291,7 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await assertCanManageMailTypeAccess(toContext(ctx), input.entityDefinitionId)
+      await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
       await setTypeAccess(toContext(ctx), input.entityDefinitionId, input.granteeType, input.grants)
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -318,6 +351,9 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      // Non-mail def-access grants are admin-only to read (they reveal the org's
+      // access configuration); mail-infra defs keep their existing read surface.
+      await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
       return getTypeAccess(toContext(ctx), input.entityDefinitionId)
     }),
 })

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -1754,11 +1754,22 @@ export const ResourceGranteeType = {
   role: 'role',
 } as const
 
-/** Permission levels for resource access - hierarchical */
-export const ResourcePermissionValues = ['view', 'edit', 'admin'] as const
+/**
+ * Permission levels for resource access - hierarchical.
+ *
+ * `none` is a baseline-only marker used by the entity-def Access UI (capability
+ * layer v2 phase 3): a single `role:org_member @ none` type row marks a def
+ * restricted while granting nobody access, so only explicit team/member grants
+ * can see it. It is deliberately NOT part of the view/edit/admin hierarchy
+ * ({@link satisfiesPermission} never treats it as satisfying any requirement)
+ * and is skipped when composing `defAccess`. The column is `text()`, not a
+ * pgEnum, so extending this union needs no DB migration.
+ */
+export const ResourcePermissionValues = ['none', 'view', 'edit', 'admin'] as const
 export type ResourcePermission = (typeof ResourcePermissionValues)[number]
 
 export const ResourcePermission = {
+  none: 'none',
   view: 'view',
   edit: 'edit',
   admin: 'admin',

--- a/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
@@ -100,6 +100,19 @@ describe('CapabilitySet.canViewEntity (absent = unrestricted)', () => {
     expect(restricted.canViewEntity('inbox')).toBe(true)
   })
 
+  it("baseline 'none' + group grant: grantee sees the def, non-grantee is denied", () => {
+    // A `role:org_member @ none` baseline row flags the def restricted (present
+    // in restrictedDefIds) but composes to NO defAccess entry for a non-grantee,
+    // while a team/member grantee gets their own defAccess entry.
+    const grantee = build({ restricted: ['invoice-def'], defAccess: { 'invoice-def': 'view' } })
+    const nonGrantee = build({ restricted: ['invoice-def'], defAccess: {} })
+    expect(grantee.canViewEntity('invoice-def')).toBe(true)
+    expect(nonGrantee.canViewEntity('invoice-def')).toBe(false)
+    // Admins bypass the lockdown regardless.
+    const admin = build({ role: 'ADMIN', restricted: ['invoice-def'], defAccess: {} })
+    expect(admin.canViewEntity('invoice-def')).toBe(true)
+  })
+
   it('OWNER/ADMIN bypass the noun layer but not the verb', () => {
     const admin = build({ role: 'ADMIN', restricted: ['invoice-def'], defAccess: {} })
     expect(admin.canViewEntity('invoice-def')).toBe(true)

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -154,6 +154,38 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     expect(caps.defAccess).toEqual({ def_a: 'admin', def_b: 'edit' })
   })
 
+  it("skips a baseline 'none' row so it never seeds a defAccess entry (grants nobody)", () => {
+    // Non-grantee: only the org_member lockdown row applies → no defAccess entry,
+    // so canViewEntity denies (the def is still flagged restricted upstream).
+    const nonGrantee = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      typeAccessRows: [{ entityDefinitionId: 'def_locked', permission: 'none' }],
+    })
+    expect(nonGrantee.defAccess).toEqual({})
+
+    // Grantee: the lockdown row plus their own positive grant → only the positive
+    // level surfaces in defAccess (none is skipped, not max-composed to 0).
+    const grantee = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      typeAccessRows: [
+        { entityDefinitionId: 'def_locked', permission: 'none' },
+        { entityDefinitionId: 'def_locked', permission: 'view' },
+      ],
+    })
+    expect(grantee.defAccess).toEqual({ def_locked: 'view' })
+  })
+
+  it("a baseline 'view' row makes the def visible to everyone (grant present)", () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      typeAccessRows: [{ entityDefinitionId: 'def_open', permission: 'view' }],
+    })
+    expect(caps.defAccess).toEqual({ def_open: 'view' })
+  })
+
   it('fails closed for an undefined role (non-member): no keys', () => {
     const caps = composeUserCapabilities({
       role: undefined,

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
@@ -23,8 +23,13 @@ export interface UserCapabilities {
   defAccess: Record<string, ResourcePermission>
 }
 
-/** Hierarchy rank for picking the highest ResourceAccess permission. */
+/**
+ * Hierarchy rank for picking the highest ResourceAccess permission. `none` is
+ * the baseline lockdown marker (grants nobody) and ranks below every positive
+ * level; it is skipped entirely when building `defAccess` (see below).
+ */
 export const PERMISSION_RANK: Record<ResourcePermission, number> = {
+  none: 0,
   view: 1,
   edit: 2,
   admin: 3,
@@ -65,6 +70,11 @@ export function composeUserCapabilities(input: {
   // role so admins carry it too (they simply also hold every capability key).
   const defAccess: Record<string, ResourcePermission> = {}
   for (const row of typeAccessRows) {
+    // `none` is the baseline lockdown marker: it flags the def restricted (via
+    // `restrictedEntityDefIds`) but grants nobody, so it must NOT seed a
+    // `defAccess` entry — otherwise the `role:org_member @ none` row would make
+    // every member a grantee, defeating the lockdown.
+    if (row.permission === 'none') continue
     const existing = defAccess[row.entityDefinitionId]
     if (!existing || PERMISSION_RANK[row.permission] > PERMISSION_RANK[existing]) {
       defAccess[row.entityDefinitionId] = row.permission

--- a/packages/lib/src/resource-access/constants.test.ts
+++ b/packages/lib/src/resource-access/constants.test.ts
@@ -1,0 +1,36 @@
+// packages/lib/src/resource-access/constants.test.ts
+
+import { ResourcePermission, ResourcePermissionValues } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { PERMISSION_HIERARCHY, satisfiesPermission } from './constants'
+
+/**
+ * `ResourcePermission.none` is a baseline-only lockdown marker (capability layer
+ * v2 phase 3). It must be inert in the permission hierarchy: never satisfying a
+ * required permission, and never being satisfiable by any actual permission.
+ */
+describe('satisfiesPermission with the none marker', () => {
+  it("excludes 'none' from the hierarchy", () => {
+    expect(PERMISSION_HIERARCHY).not.toContain(ResourcePermission.none)
+    expect(PERMISSION_HIERARCHY).toEqual([
+      ResourcePermission.view,
+      ResourcePermission.edit,
+      ResourcePermission.admin,
+    ])
+  })
+
+  it("a 'none' actual never satisfies any positive required permission", () => {
+    // 'none' is only ever written as an actual (the baseline marker), never as a
+    // required level — so the meaningful invariant is against view/edit/admin.
+    const positiveLevels = ResourcePermissionValues.filter((p) => p !== ResourcePermission.none)
+    for (const required of positiveLevels) {
+      expect(satisfiesPermission(ResourcePermission.none, required)).toBe(false)
+    }
+  })
+
+  it('keeps the positive hierarchy intact (view < edit < admin)', () => {
+    expect(satisfiesPermission(ResourcePermission.admin, ResourcePermission.view)).toBe(true)
+    expect(satisfiesPermission(ResourcePermission.view, ResourcePermission.admin)).toBe(false)
+    expect(satisfiesPermission(ResourcePermission.edit, ResourcePermission.edit)).toBe(true)
+  })
+})

--- a/packages/lib/src/resource-access/constants.ts
+++ b/packages/lib/src/resource-access/constants.ts
@@ -2,7 +2,15 @@
 
 import { ResourcePermission } from '@auxx/database/enums'
 
-/** Permission hierarchy - higher index = more permissions */
+/**
+ * Permission hierarchy - higher index = more permissions.
+ *
+ * `ResourcePermission.none` is deliberately OMITTED: it is a baseline-only
+ * marker (capability layer v2 phase 3) meaning "def is restricted, grants
+ * nobody". Because {@link satisfiesPermission} does an `indexOf`, a `none`
+ * actual resolves to `-1` and therefore never satisfies any required
+ * permission — exactly the "grants nobody" semantic. Never add `none` here.
+ */
 export const PERMISSION_HIERARCHY: ResourcePermission[] = [
   ResourcePermission.view,
   ResourcePermission.edit,

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -108,10 +108,12 @@ export type {
 } from './registry/types'
 // Resource types (system + custom)
 export {
+  isAccessManageable,
   isCustomResource,
   isCustomResourceId,
   isSystemResource,
   isSystemResourceId,
+  NON_RECORD_ENTITY_SLUGS,
 } from './registry/types'
 // RecordId utilities (branded string format: entityDefinitionId:entityInstanceId)
 export {

--- a/packages/lib/src/resources/registry/types.ts
+++ b/packages/lib/src/resources/registry/types.ts
@@ -106,6 +106,35 @@ export function isCustomResource(resource: Resource): resource is CustomResource
 }
 
 /**
+ * Mail/messaging-infrastructure entity slugs whose visibility is governed OUTSIDE
+ * the records area (their `ResourceAccess` rows carry mail-sharing semantics, not
+ * def restriction). Client-safe mirror of the server-side `NON_RECORD_DEF_SLUGS`
+ * in `permissions/capabilities/capability-set.ts` — kept in sync by hand. The
+ * entity-def Access UI (capability layer v2 phase 3) is hidden for these.
+ */
+export const NON_RECORD_ENTITY_SLUGS: ReadonlySet<string> = new Set([
+  'inbox',
+  'signature',
+  'thread',
+  'message',
+  'snippet',
+  'sequence',
+])
+
+/**
+ * Whether a resource's type-level access is manageable via the entity-def Access
+ * UI: any CRM record def (system or custom) that is NOT a mail-infra def. Purely
+ * a UI-visibility gate — the server enforces admin authorization independently.
+ */
+export function isAccessManageable(resource: Resource): boolean {
+  return (
+    !NON_RECORD_ENTITY_SLUGS.has(resource.apiSlug) &&
+    !(resource.entityType != null && NON_RECORD_ENTITY_SLUGS.has(resource.entityType)) &&
+    !NON_RECORD_ENTITY_SLUGS.has(resource.id)
+  )
+}
+
+/**
  * Type guard to check if a string is a valid system TableId
  */
 export function isSystemResourceId(id: string): id is TableId {

--- a/packages/types/groups/index.ts
+++ b/packages/types/groups/index.ts
@@ -97,8 +97,14 @@ export interface GroupPermissionInfo {
 // Permission Constants
 // ============================================================================
 
-/** Permission hierarchy for level comparison */
+/**
+ * Permission hierarchy for level comparison. `none` is the baseline lockdown
+ * marker (capability layer v2 phase 3) and ranks below every positive level, so
+ * a `none` actual satisfies nothing — group sharing never writes it, but it must
+ * be present for the exhaustive `Record<ResourcePermission, number>` type.
+ */
 export const PERMISSION_HIERARCHY: Record<ResourcePermission, number> = {
+  none: 0,
   view: 1,
   edit: 2,
   admin: 3,

--- a/packages/ui/src/components/section.tsx
+++ b/packages/ui/src/components/section.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@auxx/ui/components/spinner'
 import { Switch } from '@auxx/ui/components/switch'
 import { TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
 import { ChevronRight } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import React, { useEffect, useRef, useState } from 'react'
@@ -224,12 +225,26 @@ export function Field({
   )
 }
 
+const emptySectionVariants = cva(
+  'flex rounded-lg border bg-muted/30 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      orientation: {
+        vertical:
+          'h-24 flex-col items-center justify-center px-6 text-center [&_[data-slot=empty-section-icon]]:mb-2',
+        horizontal: 'min-h-9 flex-row items-center justify-start gap-2 px-3 text-left',
+      },
+    },
+    defaultVariants: { orientation: 'vertical' },
+  }
+)
+
 /**
  * Props for EmptySection component
  */
-export interface EmptySectionProps {
+export interface EmptySectionProps extends VariantProps<typeof emptySectionVariants> {
   className?: string
-  /** Icon rendered above the title */
+  /** Icon rendered before (horizontal) or above (vertical) the title */
   icon?: React.ReactNode
   title: React.ReactNode
   description?: React.ReactNode
@@ -238,38 +253,36 @@ export interface EmptySectionProps {
 }
 
 /**
- * Empty state placeholder for a Section's body — centered icon, title, and
- * description inside a dashed/muted card. Pass `loading` to show a spinner
- * instead of the empty content.
+ * Empty state placeholder for a Section's body inside a muted card. The
+ * `vertical` orientation (default) stacks a centered icon, title, and
+ * description; `horizontal` lays them out on a single `TreeRow`-height row so
+ * swapping between empty and populated states causes no layout shift. Pass
+ * `loading` to show a spinner instead of the empty content.
  */
 export function EmptySection({
   className,
   icon,
   title,
   description,
+  orientation,
   loading = false,
 }: EmptySectionProps) {
   return (
-    <div
-      data-slot='empty-section'
-      className={cn(
-        'flex h-24 flex-col items-center justify-center rounded-lg border bg-muted/30 text-center px-6 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-        className
-      )}>
+    <div data-slot='empty-section' className={cn(emptySectionVariants({ orientation }), className)}>
       {loading ? (
         <Spinner data-slot='empty-section-spinner' className='size-5 text-muted-foreground' />
       ) : (
         <>
           {icon && (
-            <div data-slot='empty-section-icon' className='mb-2 text-muted-foreground'>
+            <div data-slot='empty-section-icon' className='text-primary-400'>
               {icon}
             </div>
           )}
-          <p data-slot='empty-section-title' className='text-sm text-muted-foreground'>
+          <p data-slot='empty-section-title' className='text-sm text-primary-500'>
             {title}
           </p>
           {description && (
-            <p data-slot='empty-section-description' className='text-xs text-muted-foreground'>
+            <p data-slot='empty-section-description' className='text-xs text-primary-400'>
               {description}
             </p>
           )}


### PR DESCRIPTION
## Summary

Two groups of changes, bundled per request.

### UI: shared danger-zone card + settings polish
- New `DangerZone` card component (`~/components/global/danger-zone.tsx`): destructive-outlined row with icon badge, title, description, and an action. Stacking is container-query driven so the action drops below the text (aligned with the text, not the icon) when the card is narrow. Callers own the `SettingsSection` wrapper.
- Adopted in: integration routing (channels), group & member danger sections, and chat-widget general settings.
- Channels settings: tabs moved into the sticky sub-header (matching the Members page); suppression list now fills height so its empty state centers.
- Members tab: `useConfirm` for remove-member and cancel-invitation (replacing hand-rolled dialogs); `position='tc'` + `Kbd`/`KbdSubmit` footer pattern on the change-role/change-seat dialogs; `ListCard` skeletons while loading; empty state via the shared `EmptyState` component.

### Permissions: entity-def access
- Entity-def **Access** surface: workspace baseline ("Default for all members") plus raise-only team and individual-member grants, with `access-level-select` and the `use-def-access` hook.
- Supporting changes across `resourceAccess` router, enums, capability composition, resource-access constants (+tests), resources client/registry types, groups types, and the `section` UI primitive.

## Notes
- The two areas were developed in parallel; committed as two separate commits within this one PR ("include all" per request).
- Not manually verified end-to-end here beyond Biome (errors-only) on the touched UI files; the permissions changes carry their own unit tests.