### PR TITLE
feat(permissions): enforce def-level write path (records, field values, tickets)

### DIFF
--- a/apps/web/src/components/permissions/hooks/use-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-def-access.ts
@@ -52,9 +52,12 @@ const DEFAULT_GRANTEE_LEVEL: ResourcePermission = ResourcePermission.admin
  * - **Reset**: `resetToDefault()` clears every row, returning the def to the
  *   dormant/unrestricted state.
  *
- * Writes are optimistic; the `resource-access.type.changed` realtime event
- * re-composes affected members' capabilities, and the query invalidates on
- * settle to reconcile. Errors surface via `toastError`.
+ * Writes are optimistic; the query invalidates on settle to reconcile, and the
+ * write also fires `publishCapabilitiesChanged` (phase 4 §10) so OTHER members'
+ * open sessions get nudged to re-fetch. Note the client `CapabilitiesProvider`
+ * currently consumes only `caps.keys` (not `defAccess`), so that live nudge only
+ * takes visible effect once a client surface reads def-access live (§8 nav
+ * catalog, §11.1 per-def write affordances). Errors surface via `toastError`.
  */
 export function useDefAccess(entityDefinitionId: string | undefined) {
   const utils = api.useUtils()

--- a/apps/web/src/server/api/routers/fieldValue.ts
+++ b/apps/web/src/server/api/routers/fieldValue.ts
@@ -1,12 +1,14 @@
 // apps/web/src/server/api/routers/fieldValue.ts
 
+import { schema } from '@auxx/database'
 import { FieldValueService } from '@auxx/lib/field-values'
 import type { FieldReference } from '@auxx/types/field'
 import { fieldIdSchema, resourceFieldIdSchema } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, recordIdSchema } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
-import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+import { capabilityProcedure, createTRPCRouter } from '../trpc'
 
 /** Schema for FieldReference - either ResourceFieldId or FieldPath */
 const fieldReferenceSchema = z.union([
@@ -54,10 +56,10 @@ export const fieldValueRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // Layer-2 write guard (§11.4): the required key is per-entity (recordsEdit, or
-      // dispatch.board.manage for work orders) — an in-memory Set lookup, no extra I/O.
+      // Write enforcement (phase 4 §3.2): def-aware edit gate (Layer 2 × Layer 3,
+      // most-specific-wins) — in-memory, no extra I/O. Throws ForbiddenError (403).
       const { entityDefinitionId } = parseRecordId(input.recordId as RecordId)
-      ctx.capabilities.assertWriteEntity(entityDefinitionId)
+      ctx.capabilities.assertEditEntity(entityDefinitionId)
 
       const service = new FieldValueService(
         ctx.session.organizationId,
@@ -123,12 +125,12 @@ export const fieldValueRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // Layer-2 write guard (§11.4): assert per DISTINCT entity def in the batch — zero extra
-      // I/O beyond the recordId parse the service already does, in-memory Set lookups only.
+      // Write enforcement (phase 4 §3.2): assert the def-aware edit gate per DISTINCT
+      // entity def in the batch — in-memory Set lookups only, no extra I/O.
       const distinctDefIds = new Set(
         input.recordIds.map((id) => parseRecordId(id as RecordId).entityDefinitionId)
       )
-      for (const defId of distinctDefIds) ctx.capabilities.assertWriteEntity(defId)
+      for (const defId of distinctDefIds) ctx.capabilities.assertEditEntity(defId)
 
       const service = new FieldValueService(
         ctx.session.organizationId,
@@ -158,9 +160,9 @@ export const fieldValueRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // Layer-2 write guard (§11.4): clearing a field value is a write to that entity.
+      // Write enforcement (phase 4 §3.2): clearing a field value is an edit to that def.
       const { entityDefinitionId } = parseRecordId(input.recordId as RecordId)
-      ctx.capabilities.assertWriteEntity(entityDefinitionId)
+      ctx.capabilities.assertEditEntity(entityDefinitionId)
 
       const service = new FieldValueService(
         ctx.session.organizationId,
@@ -211,7 +213,7 @@ export const fieldValueRouter = createTRPCRouter({
    * Add value to multi-value field (MULTI_SELECT, TAGS, etc.)
    * Expects recordId in RecordId format.
    */
-  add: protectedProcedure
+  add: capabilityProcedure
     .input(
       z.object({
         recordId: z.string(), // RecordId format
@@ -224,6 +226,10 @@ export const fieldValueRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Write enforcement (phase 4 §3.2): appending a multi-value is an edit.
+      const { entityDefinitionId } = parseRecordId(input.recordId as RecordId)
+      ctx.capabilities.assertEditEntity(entityDefinitionId)
+
       const service = new FieldValueService(
         ctx.session.organizationId,
         ctx.session.user.id,
@@ -242,9 +248,22 @@ export const fieldValueRouter = createTRPCRouter({
   /**
    * Remove value from multi-value field
    */
-  remove: protectedProcedure
+  remove: capabilityProcedure
     .input(z.object({ valueId: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      // `remove` carries only the value's id, so resolve its def to enforce the
+      // write gate (phase 4 §3.2). A missing row is a no-op removal — skip the gate.
+      const [row] = await ctx.db
+        .select({ entityDefinitionId: schema.FieldValue.entityDefinitionId })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.id, input.valueId),
+            eq(schema.FieldValue.organizationId, ctx.session.organizationId)
+          )
+        )
+      if (row) ctx.capabilities.assertEditEntity(row.entityDefinitionId)
+
       const service = new FieldValueService(
         ctx.session.organizationId,
         ctx.session.user.id,

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -458,13 +458,17 @@ export const recordRouter = createTRPCRouter({
   /**
    * Create a new entity instance with optional field values
    */
-  create: protectedProcedure.input(createInputSchema).mutation(async ({ ctx, input }) => {
+  create: capabilityProcedure.input(createInputSchema).mutation(async ({ ctx, input }) => {
     const { organizationId, user } = ctx.session
 
     try {
-      const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+      const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+        capabilities: ctx.capabilities,
+      })
       return await handler.create(input.entityDefinitionId, input.values ?? {})
     } catch (error: any) {
+      // Let def-level ForbiddenError (403) and other AuxxErrors reach the middleware.
+      if (isAuxxError(error)) throw error
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: `Failed to create record: ${error.message}`,
@@ -484,9 +488,11 @@ export const recordRouter = createTRPCRouter({
    * the uncommitted instances. All-or-nothing is approximated instead: a
    * mid-loop failure deletes the rows already created, then rethrows.
    */
-  createMany: protectedProcedure.input(createManyInputSchema).mutation(async ({ ctx, input }) => {
+  createMany: capabilityProcedure.input(createManyInputSchema).mutation(async ({ ctx, input }) => {
     const { organizationId, user } = ctx.session
-    const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+    const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+      capabilities: ctx.capabilities,
+    })
     const created: Array<Pick<CreateEntityResult, 'recordId' | 'instance'>> = []
 
     try {
@@ -505,6 +511,8 @@ export const recordRouter = createTRPCRouter({
           // Leave the orphan; the original error below is what the user sees.
         }
       }
+      // A def-level 403 on the very first row leaves `created` empty — surface it.
+      if (isAuxxError(error)) throw error
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: `Failed to create records: ${error.message}`,
@@ -515,13 +523,16 @@ export const recordRouter = createTRPCRouter({
   /**
    * Update entity instance field values
    */
-  update: protectedProcedure.input(updateInputSchema).mutation(async ({ ctx, input }) => {
+  update: capabilityProcedure.input(updateInputSchema).mutation(async ({ ctx, input }) => {
     const { organizationId, user } = ctx.session
 
     try {
-      const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+      const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+        capabilities: ctx.capabilities,
+      })
       return await handler.update(input.recordId, input.values, input.modes)
     } catch (error: any) {
+      if (isAuxxError(error)) throw error
       if (error.message?.includes('not found')) {
         throw new TRPCError({
           code: 'NOT_FOUND',
@@ -538,15 +549,18 @@ export const recordRouter = createTRPCRouter({
   /**
    * Archive entity instance (soft delete)
    */
-  archive: protectedProcedure
+  archive: capabilityProcedure
     .input(z.object({ recordId: recordIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, user } = ctx.session
 
       try {
-        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+          capabilities: ctx.capabilities,
+        })
         return await handler.archive(input.recordId)
       } catch (error: any) {
+        if (isAuxxError(error)) throw error
         if (error.message?.includes('not found')) {
           throw new TRPCError({
             code: 'NOT_FOUND',
@@ -563,15 +577,18 @@ export const recordRouter = createTRPCRouter({
   /**
    * Restore archived entity instance
    */
-  restore: protectedProcedure
+  restore: capabilityProcedure
     .input(z.object({ recordId: recordIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, user } = ctx.session
 
       try {
-        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+          capabilities: ctx.capabilities,
+        })
         return await handler.restore(input.recordId)
       } catch (error: any) {
+        if (isAuxxError(error)) throw error
         if (error.message?.includes('not found')) {
           throw new TRPCError({
             code: 'NOT_FOUND',
@@ -596,7 +613,9 @@ export const recordRouter = createTRPCRouter({
       ctx.capabilities.assert(PermissionKey.recordsDelete)
 
       try {
-        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+          capabilities: ctx.capabilities,
+        })
         await handler.delete(input.recordId)
         return { success: true }
       } catch (error: any) {
@@ -621,15 +640,18 @@ export const recordRouter = createTRPCRouter({
   /**
    * Bulk archive entity instances
    */
-  bulkArchive: protectedProcedure
+  bulkArchive: capabilityProcedure
     .input(z.object({ recordIds: z.array(recordIdSchema).min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, user } = ctx.session
 
       try {
-        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+          capabilities: ctx.capabilities,
+        })
         return await handler.bulkArchive(input.recordIds)
       } catch (error: any) {
+        if (isAuxxError(error)) throw error
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: `Failed to bulk archive records: ${error.message}`,
@@ -648,7 +670,9 @@ export const recordRouter = createTRPCRouter({
       ctx.capabilities.assert(PermissionKey.recordsDelete)
 
       try {
-        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+          capabilities: ctx.capabilities,
+        })
         // NOTE on friendly messages here: the invoice pre-delete hook's admin-gate /
         // succeeded-charges guard throws `BadRequestError` with an already-friendly message
         // (e.g. "Remove recorded payments before deleting this invoice") — `bulkDeleteEntities`
@@ -675,6 +699,7 @@ export const recordRouter = createTRPCRouter({
         return result
       } catch (error: any) {
         if (error instanceof TRPCError) throw error
+        if (isAuxxError(error)) throw error
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: `Failed to bulk delete records: ${error.message}`,
@@ -699,10 +724,13 @@ export const recordRouter = createTRPCRouter({
       ctx.capabilities.assert(PermissionKey.recordsDelete)
 
       try {
-        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+        const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+          capabilities: ctx.capabilities,
+        })
         return await handler.merge(input.targetRecordId, input.sourceRecordIds)
       } catch (error: any) {
         if (error instanceof TRPCError) throw error
+        if (isAuxxError(error)) throw error
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: `Failed to merge records: ${error.message}`,

--- a/apps/web/src/server/api/routers/ticket.ts
+++ b/apps/web/src/server/api/routers/ticket.ts
@@ -3,6 +3,7 @@
 import { schema } from '@auxx/database'
 import { TicketPriority, TicketStatus, TicketType } from '@auxx/database/enums'
 import { publisher } from '@auxx/lib/events'
+import { PermissionKey } from '@auxx/lib/permissions'
 import {
   addRelation,
   deleteMultipleTickets,
@@ -15,7 +16,18 @@ import {
 } from '@auxx/lib/tickets'
 import { eq } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '../trpc'
+import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+
+/**
+ * Tickets are governed by the RECORDS area (capability layer v2 phase 4). The
+ * ticket entity has no dedicated write key, so `assertEditEntity('ticket')`
+ * resolves to `records.edit` for an unrestricted ticket def, or the ticket def's
+ * own grant when an admin restricts it via the Access tab (most-specific-wins).
+ * Writes flow through `ticketService`, NOT `UnifiedCrudHandler`, so enforcement
+ * lives here at the router. Destructive ops additionally assert the coarse
+ * `records.delete` verb, mirroring `record.ts`.
+ */
+const TICKET_ENTITY = 'ticket'
 
 /**
  * Simplified input schema for tickets with JSON-based type data
@@ -42,9 +54,10 @@ const ticketInputSchema = z.object({
  */
 export const ticketRouter = createTRPCRouter({
   // Create ticket
-  create: protectedProcedure
+  create: capabilityProcedure
     .input(ticketInputSchema.omit({ id: true }))
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
       return await ticketService.createTicket({
         ...input,
@@ -54,9 +67,10 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Update ticket
-  update: protectedProcedure
+  update: capabilityProcedure
     .input(ticketInputSchema.partial().required({ id: true }))
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
       return await ticketService.updateTicket({
         ...input,
@@ -138,16 +152,18 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Delete ticket
-  deleteTicket: protectedProcedure
+  deleteTicket: capabilityProcedure
     .input(z.object({ ticketId: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assert(PermissionKey.recordsDelete)
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
       await ticketService.deleteTicket(input.ticketId, organizationId, userId)
       return { success: true }
     }),
 
   // Update ticket status
-  updateStatus: protectedProcedure
+  updateStatus: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -155,14 +171,16 @@ export const ticketRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
       return await ticketService.updateTicketStatus(input.id, input.status, organizationId, userId)
     }),
 
   // Update ticket assignments
-  updateAssignment: protectedProcedure
+  updateAssignment: capabilityProcedure
     .input(z.object({ ticketId: z.string(), agentIds: z.array(z.string()) }))
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
       return await ticketService.updateTicketAssignments(
         input.ticketId,
@@ -173,7 +191,7 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Update ticket priority
-  updatePriority: protectedProcedure
+  updatePriority: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -181,6 +199,7 @@ export const ticketRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
 
       const ticket = await ticketService.updateTicket({
@@ -251,7 +270,7 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Update multiple tickets' status
-  updateMultipleStatus: protectedProcedure
+  updateMultipleStatus: capabilityProcedure
     .input(
       z.object({
         ticketIds: z.array(z.string()),
@@ -259,6 +278,7 @@ export const ticketRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { ticketIds, status } = input
       const { organizationId, userId } = ctx.session
 
@@ -273,7 +293,7 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Update multiple tickets' priority
-  updateMultiplePriority: protectedProcedure
+  updateMultiplePriority: capabilityProcedure
     .input(
       z.object({
         ticketIds: z.array(z.string()),
@@ -281,6 +301,7 @@ export const ticketRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { ticketIds, priority } = input
       const { organizationId, userId } = ctx.session
 
@@ -295,9 +316,10 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Update multiple tickets' assignments
-  updateMultipleAssignments: protectedProcedure
+  updateMultipleAssignments: capabilityProcedure
     .input(z.object({ ticketIds: z.array(z.string()), agentIds: z.array(z.string()) }))
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { ticketIds, agentIds } = input
       const { organizationId, userId } = ctx.session
 
@@ -312,9 +334,11 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Delete multiple tickets
-  deleteMultipleTickets: protectedProcedure
+  deleteMultipleTickets: capabilityProcedure
     .input(z.object({ ticketIds: z.array(z.string()) }))
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assert(PermissionKey.recordsDelete)
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { ticketIds } = input
       const { organizationId, userId } = ctx.session
 
@@ -325,9 +349,13 @@ export const ticketRouter = createTRPCRouter({
       })
     }),
 
-  mergeTickets: protectedProcedure
+  mergeTickets: capabilityProcedure
     .input(z.object({ primaryTicketId: z.string(), ticketsToMergeIds: z.array(z.string()) }))
     .mutation(async ({ ctx, input }) => {
+      // Merge permanently removes the source tickets — gate on the delete verb
+      // (mirrors record.merge) plus the records-area edit gate.
+      ctx.capabilities.assert(PermissionKey.recordsDelete)
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { primaryTicketId, ticketsToMergeIds } = input
       const { organizationId, userId } = ctx.session
 
@@ -345,7 +373,7 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Add a relation between tickets
-  addRelation: protectedProcedure
+  addRelation: capabilityProcedure
     .input(
       z.object({
         ticketId: z.string(),
@@ -354,6 +382,7 @@ export const ticketRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
       const { ticketId, relatedTicketId, relation } = input
 
@@ -367,9 +396,10 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   // Remove a relation between tickets
-  removeRelation: protectedProcedure
+  removeRelation: capabilityProcedure
     .input(z.object({ relationId: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditEntity(TICKET_ENTITY)
       const { organizationId, userId } = ctx.session
       const { relationId } = input
 

--- a/packages/lib/src/permissions/capabilities/capability-set-edit.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-edit.test.ts
@@ -1,0 +1,170 @@
+// packages/lib/src/permissions/capabilities/capability-set-edit.test.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import type { SeatType } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { CapabilitySet } from './capability-set'
+import { PermissionKey } from './registry'
+
+/**
+ * Write-path enforcement (v2 phase 4 §1): `canEditEntity`/`effectiveRecordLevel`
+ * combine the Layer-2 base records rung with the Layer-3 per-def grant under
+ * most-specific-wins (v1.5 §5.1, revised) — an explicit def grant REPLACES base.
+ * The `edit` floor covers create/update/delete/merge (§0.1).
+ */
+
+const defIdToDefinitionId = (id: string) =>
+  id === 'invoice' || id === 'invoices' ? 'invoice-def' : id
+
+const build = (opts: {
+  keys?: PermissionKey[]
+  defAccess?: Record<string, ResourcePermission>
+  restricted?: string[]
+  role?: 'OWNER' | 'ADMIN' | 'USER'
+  seatType?: SeatType
+}) =>
+  new CapabilitySet(
+    new Set(opts.keys ?? [PermissionKey.recordsView, PermissionKey.recordsEdit]),
+    opts.defAccess ?? {},
+    opts.role ?? 'USER',
+    opts.seatType ?? 'full',
+    // Resolve mail-infra slugs so isMailInfraDef matches; everything else identity.
+    (id) => id,
+    new Set(opts.restricted ?? []),
+    defIdToDefinitionId
+  )
+
+const READ_ONLY = [PermissionKey.recordsView]
+const READ_WRITE = [PermissionKey.recordsView, PermissionKey.recordsEdit]
+
+describe('CapabilitySet.canEditEntity (most-specific-wins, edit floor)', () => {
+  it('base Read + def Full grant → editable (raise)', () => {
+    const caps = build({
+      keys: READ_ONLY,
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+    })
+    expect(caps.canEditEntity('invoice-def')).toBe(true)
+  })
+
+  it('base Read + def Edit grant → editable (raise)', () => {
+    const caps = build({
+      keys: READ_ONLY,
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'edit' },
+    })
+    expect(caps.canEditEntity('invoice-def')).toBe(true)
+  })
+
+  it('base Full + def Read grant → not editable but viewable (restrict)', () => {
+    const caps = build({
+      keys: READ_WRITE,
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'view' },
+    })
+    expect(caps.canEditEntity('invoice-def')).toBe(false)
+    expect(caps.canViewEntity('invoice-def')).toBe(true)
+  })
+
+  it('base None + def Full grant → editable (row 5)', () => {
+    const caps = build({
+      keys: [],
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+    })
+    expect(caps.canEditEntity('invoice-def')).toBe(true)
+    expect(caps.canViewEntity('invoice-def')).toBe(true)
+  })
+
+  it('unrestricted def → effectiveRecordLevel == base (verb governs)', () => {
+    // Read-write base can edit an unrestricted def…
+    expect(build({ keys: READ_WRITE }).canEditEntity('contact-def')).toBe(true)
+    // …read-only base cannot.
+    expect(build({ keys: READ_ONLY }).canEditEntity('contact-def')).toBe(false)
+  })
+
+  it('restricted def, not a grantee (baseline none) → both false', () => {
+    const caps = build({ keys: READ_WRITE, restricted: ['invoice-def'], defAccess: {} })
+    expect(caps.canEditEntity('invoice-def')).toBe(false)
+    expect(caps.canViewEntity('invoice-def')).toBe(false)
+  })
+
+  it('OWNER/ADMIN → editable regardless of grant', () => {
+    const admin = build({ role: 'ADMIN', keys: [], restricted: ['invoice-def'], defAccess: {} })
+    expect(admin.canEditEntity('invoice-def')).toBe(true)
+    const owner = build({ role: 'OWNER', keys: [], restricted: ['invoice-def'], defAccess: {} })
+    expect(owner.canEditEntity('invoice-def')).toBe(true)
+  })
+
+  it('worker seat (records ceiling None) → not editable even at def grant admin', () => {
+    const worker = build({
+      seatType: 'worker',
+      keys: [PermissionKey.recordsViewLinked],
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+    })
+    expect(worker.canEditEntity('invoice-def')).toBe(false)
+    // …but can still VIEW linked rows of the granted def (field-seat carve-out).
+    expect(worker.canViewEntity('invoice-def')).toBe(true)
+  })
+
+  it('mail-infra def bypasses to the verb gate (canWriteEntity)', () => {
+    // Has records.edit → can write signatures (mail-infra) even when restricted.
+    const withVerb = build({ keys: READ_WRITE, restricted: ['signature'] })
+    expect(withVerb.canEditEntity('signature')).toBe(true)
+    // No records.edit → the verb gate denies it.
+    const noVerb = build({ keys: READ_ONLY })
+    expect(noVerb.canEditEntity('signature')).toBe(false)
+  })
+
+  it('dedicated-write-key def (work_order) bypasses to its dispatch key', () => {
+    // work_order → dispatch.board.manage (ENTITY_WRITE_KEYS), NOT the records area.
+    // A dispatch manager holding board.manage but only Read on records can edit it…
+    const dispatcher = new CapabilitySet(
+      new Set([PermissionKey.recordsView, PermissionKey.dispatchBoardManage]),
+      {},
+      'USER',
+      'full'
+    )
+    expect(dispatcher.canEditEntity('work_order')).toBe(true)
+    // …while a records-editor WITHOUT board.manage cannot (records level is irrelevant).
+    const recordsEditor = new CapabilitySet(new Set(READ_WRITE), {}, 'USER', 'full')
+    expect(recordsEditor.canEditEntity('work_order')).toBe(false)
+  })
+})
+
+describe('CapabilitySet.assertEditEntity', () => {
+  it('throws for a restricted def the member cannot edit', () => {
+    const caps = build({
+      keys: READ_ONLY,
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'view' },
+    })
+    expect(() => caps.assertEditEntity('invoice-def')).toThrow()
+  })
+
+  it('does not throw for an editable def', () => {
+    const caps = build({
+      keys: READ_ONLY,
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'edit' },
+    })
+    expect(() => caps.assertEditEntity('invoice-def')).not.toThrow()
+  })
+})
+
+describe('CapabilitySet.filterEditableDefIds', () => {
+  it('keeps editable defs, drops the rest (pure in-memory)', () => {
+    const caps = build({
+      keys: READ_WRITE,
+      restricted: ['invoice-def', 'salary-def'],
+      defAccess: { 'invoice-def': 'edit' },
+    })
+    // contact-def unrestricted (base edit) → kept; invoice granted edit → kept;
+    // salary restricted, not a grantee → dropped.
+    expect(caps.filterEditableDefIds(['contact-def', 'invoice-def', 'salary-def'])).toEqual([
+      'contact-def',
+      'invoice-def',
+    ])
+  })
+})

--- a/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
@@ -52,13 +52,16 @@ describe('CapabilitySet.canViewEntity (absent = unrestricted)', () => {
     expect(caps.canViewEntity('invoice-def')).toBe(false)
   })
 
-  it('denies everything when records.view is absent, even for a grantee', () => {
+  it('most-specific-wins: a def grant lets a base-None member view that def', () => {
+    // v1.5 §5.1 (revised): an explicit per-def grant REPLACES the base records
+    // verb, so a grantee sees the restricted def even with no base records.view.
     const caps = build({
       hasView: false,
       restricted: ['invoice-def'],
       defAccess: { 'invoice-def': 'view' },
     })
-    expect(caps.canViewEntity('invoice-def')).toBe(false)
+    expect(caps.canViewEntity('invoice-def')).toBe(true)
+    // But an UNRESTRICTED def still falls back to base (None here) → denied.
     expect(caps.canViewEntity('anything')).toBe(false)
   })
 
@@ -113,13 +116,15 @@ describe('CapabilitySet.canViewEntity (absent = unrestricted)', () => {
     expect(admin.canViewEntity('invoice-def')).toBe(true)
   })
 
-  it('OWNER/ADMIN bypass the noun layer but not the verb', () => {
+  it('OWNER/ADMIN bypass both layers (effectiveRecordLevel → admin)', () => {
     const admin = build({ role: 'ADMIN', restricted: ['invoice-def'], defAccess: {} })
     expect(admin.canViewEntity('invoice-def')).toBe(true)
     const owner = build({ role: 'OWNER', restricted: ['invoice-def'], defAccess: {} })
     expect(owner.canViewEntity('invoice-def')).toBe(true)
+    // Under most-specific-wins OWNER/ADMIN resolve to `admin` regardless of the
+    // base verb — in practice they always hold records.view (role default Full).
     const adminNoVerb = build({ role: 'ADMIN', hasView: false, restricted: ['invoice-def'] })
-    expect(adminNoVerb.canViewEntity('invoice-def')).toBe(false)
+    expect(adminNoVerb.canViewEntity('invoice-def')).toBe(true)
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -1,10 +1,11 @@
 // packages/lib/src/permissions/capabilities/capability-set.ts
 
-import type { ResourcePermission } from '@auxx/database/enums'
+import { ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { ForbiddenError } from '../../errors'
-import { PERMISSION_REGISTRY_MAP, PermissionKey } from './registry'
-import { ENTITY_WRITE_KEYS } from './seat-policy'
+import { satisfiesPermission } from '../../resource-access/constants'
+import { Area, Level, PERMISSION_REGISTRY_MAP, PermissionKey } from './registry'
+import { ENTITY_WRITE_KEYS, SEAT_CEILINGS } from './seat-policy'
 
 /**
  * Resolves the definition part of a RecordId (a system slug like `work_order`,
@@ -95,6 +96,9 @@ export class CapabilitySet {
    * RecordId-def part → entity slug (in memory) → the required key via
    * {@link ENTITY_WRITE_KEYS} (default {@link PermissionKey.recordsEdit}), then
    * a Set lookup. Zero I/O.
+   *
+   * This is the coarse Layer-2 verb gate. Def-aware write enforcement (Layer 2 ×
+   * Layer 3) is {@link canEditEntity}; mail-infra defs fall back to this verb.
    */
   canWriteEntity(entityDefId: string): boolean {
     return this.keys.has(this.writeKeyFor(entityDefId))
@@ -106,40 +110,120 @@ export class CapabilitySet {
   }
 
   /**
-   * Whether the member may VIEW records of the given definition (v2 §0). Two
-   * layers combined by `min`:
-   * - **Layer 2 (the verb):** must hold {@link PermissionKey.recordsView} — or
-   *   {@link PermissionKey.recordsViewLinked} (field seats), whose reads are
-   *   narrowed to their linked rows by the row-scoped read path, not per def.
-   * - **Layer 3 (the noun):** if the def carries a type-level grant for *anyone*
-   *   (it's in `restrictedDefIds`), the member must be a grantee (present in
-   *   their `defAccess`). A def with NO type-level grant is unrestricted —
-   *   **absent = visible to all**. OWNER/ADMIN bypass this layer: restricting a
-   *   def scopes members, never the admins who administer it.
+   * The member's base records rung (Layer 2), derived from the already
+   * seat-clamped key set (v2 §1). Record data collapses to read vs write
+   * (decision §0.1 — `edit` covers create/update/delete); the coarse
+   * `records.delete`/`import` verbs stay org-wide keys, not a per-def rung.
+   * `undefined` = No Access. Note {@link PermissionKey.recordsViewLinked} (field
+   * seats) is NOT a base rung — its narrowed view is a {@link canViewEntity}
+   * carve-out, never a write rung.
+   */
+  private baseRecordsLevel(): ResourcePermission | undefined {
+    if (this.keys.has(PermissionKey.recordsEdit)) return ResourcePermission.edit
+    if (this.keys.has(PermissionKey.recordsView)) return ResourcePermission.view
+    return undefined
+  }
+
+  /**
+   * Layer 2 × Layer 3, most-specific-wins (v1.5 §5.1, revised 2026-07-23). The
+   * member's effective record permission for a def, or `undefined` (= No Access).
+   * Zero I/O.
+   *  - OWNER/ADMIN → `admin` (bypass — administer restrictions, never self-lock).
+   *  - restricted def → the member's own type-level grant REPLACES base
+   *    (`undefined` when they're not a grantee → locked out).
+   *  - unrestricted def → base records level fills in.
+   *  - seat ceiling clamps last: a worker's records ceiling is None → `undefined`.
+   */
+  private effectiveRecordLevel(entityDefId: string): ResourcePermission | undefined {
+    if (this.role === 'OWNER' || this.role === 'ADMIN') return ResourcePermission.admin
+    const defId = this.defIdToDefinitionId(entityDefId)
+    const chosen = this.restrictedDefIds.has(defId)
+      ? this.defAccess[defId] // explicit per-def setting replaces base
+      : this.baseRecordsLevel() // unset def → base fills in
+    if (chosen === undefined) return undefined
+    // Records seat ceiling is Full (full seat) or None (worker) — no intermediate rung.
+    if (SEAT_CEILINGS[this.seatType][Area.records] === Level.None) return undefined
+    return chosen
+  }
+
+  /**
+   * Whether the member may create/update/delete/merge records of the given def —
+   * the `edit` floor (§0.1). Two carve-outs bypass most-specific-wins and keep
+   * the existing verb gate ({@link canWriteEntity}), because their write
+   * authority lives OUTSIDE the records area:
+   *  - **mail-infra defs** (signatures/snippets/etc. — governed by mail keys),
+   *  - **defs with a dedicated write key** ({@link ENTITY_WRITE_KEYS}, e.g.
+   *    `work_order` → `dispatch.board.manage`). Gating these on the records level
+   *    would wrongly block a dispatch manager (who holds `board.manage` but may be
+   *    Read-only on records) or wrongly admit a records-editor lacking the
+   *    dispatch key (open item #4 — dispatch authority kept as-is).
+   * Zero I/O.
+   */
+  canEditEntity(entityDefId: string): boolean {
+    if (this.isMailInfraDef(entityDefId) || this.hasDedicatedWriteKey(entityDefId)) {
+      return this.canWriteEntity(entityDefId)
+    }
+    const level = this.effectiveRecordLevel(entityDefId)
+    return level !== undefined && satisfiesPermission(level, ResourcePermission.edit)
+  }
+
+  /** {@link canEditEntity} as a throwing guard (403). */
+  assertEditEntity(entityDefId: string): void {
+    if (this.canEditEntity(entityDefId)) return
+    throw new ForbiddenError("You don't have permission to edit these records.")
+  }
+
+  /**
+   * Filter a set of RecordId-def forms down to the editable ones (§1). Pure
+   * in-memory — the multi-def write enforcement primitive; NEVER a per-row query.
+   */
+  filterEditableDefIds(entityDefIds: string[]): string[] {
+    return entityDefIds.filter((id) => this.canEditEntity(id))
+  }
+
+  /**
+   * Whether the member may VIEW records of the given definition (v2 §0/§1),
+   * re-expressed to most-specific-wins so read and write agree (§0.2):
+   * `effectiveRecordLevel(def)` must satisfy `view`. This means an explicit
+   * per-def grant REPLACES the base records verb — a member with base None but a
+   * def grant of Read/Edit/Full *can* view that def (v1.5 §5.1, revised).
    *
-   * Mail/messaging infrastructure defs ({@link NON_RECORD_DEF_SLUGS}) bypass
-   * both layers — their visibility is governed by the mail visibility system.
+   * Two carve-outs survive the re-expression:
+   * - **Mail/messaging infrastructure defs** ({@link NON_RECORD_DEF_SLUGS})
+   *   bypass entirely — visibility governed by the mail visibility system.
+   * - **Field seats** ({@link PermissionKey.recordsViewLinked}) grant view of
+   *   their LINKED rows (narrowed by the row-scoped read path, not per def); this
+   *   verb is not a base rung, so it's applied here. A restricted def still needs
+   *   a grant even for a field seat.
+   *
+   * OWNER/ADMIN bypass the noun layer (`effectiveRecordLevel` → `admin`):
+   * restricting a def scopes members, never the admins who administer it.
    *
    * The argument may be any RecordId-def form (slug, apiSlug, id); it is
    * normalized to the canonical `entityDefinitionId` keyspace first. Zero I/O.
    */
   canViewEntity(entityDefId: string): boolean {
-    if (
+    if (this.isMailInfraDef(entityDefId)) return true
+    const level = this.effectiveRecordLevel(entityDefId)
+    if (level !== undefined && satisfiesPermission(level, ResourcePermission.view)) return true
+    // Field-seat carve-out: recordsViewLinked doesn't flow through base rungs.
+    if (this.keys.has(PermissionKey.recordsViewLinked)) {
+      const defId = this.defIdToDefinitionId(entityDefId)
+      if (!this.restrictedDefIds.has(defId)) return true
+      return this.defAccess[defId] !== undefined
+    }
+    return false
+  }
+
+  /**
+   * Mail/messaging infrastructure def check ({@link NON_RECORD_DEF_SLUGS}),
+   * matched on both the raw def-part and its resolved entity slug.
+   */
+  private isMailInfraDef(entityDefId: string): boolean {
+    return (
       NON_RECORD_DEF_SLUGS.has(entityDefId) ||
       NON_RECORD_DEF_SLUGS.has(this.defIdToSlug(entityDefId))
-    ) {
-      return true
-    }
-    if (
-      !this.keys.has(PermissionKey.recordsView) &&
-      !this.keys.has(PermissionKey.recordsViewLinked)
-    ) {
-      return false
-    }
-    if (this.role === 'OWNER' || this.role === 'ADMIN') return true
-    const defId = this.defIdToDefinitionId(entityDefId)
-    if (!this.restrictedDefIds.has(defId)) return true
-    return this.defAccess[defId] !== undefined
+    )
   }
 
   /** {@link canViewEntity} as a throwing guard (403). */
@@ -169,5 +253,15 @@ export class CapabilitySet {
   private writeKeyFor(entityDefId: string): PermissionKey {
     const slug = this.defIdToSlug(entityDefId)
     return ENTITY_WRITE_KEYS[slug] ?? PermissionKey.recordsEdit
+  }
+
+  /**
+   * Whether the def has a dedicated write key ({@link ENTITY_WRITE_KEYS}) rather
+   * than the default {@link PermissionKey.recordsEdit} — i.e. its write authority
+   * belongs to another area (e.g. dispatch), so it bypasses the records-level
+   * edit gate in {@link canEditEntity}.
+   */
+  private hasDedicatedWriteKey(entityDefId: string): boolean {
+    return this.writeKeyFor(entityDefId) !== PermissionKey.recordsEdit
   }
 }

--- a/packages/lib/src/resource-access/resource-access-service.ts
+++ b/packages/lib/src/resource-access/resource-access-service.ts
@@ -65,6 +65,11 @@ async function emitResourceAccessChanged(
  * separate so the noisy instance-level event isn't piggybacked onto capability
  * invalidation. Call AFTER the DB write commits, in addition to the
  * instance-level emit.
+ *
+ * Also publishes `publishCapabilitiesChanged` so OTHER members' live client
+ * sessions re-compose def-access on a grant change (phase 4 §10) — the server
+ * cache bust alone leaves clients stale until a natural refetch / TTL. Mirrors
+ * {@link emitGrantChanged} in grant-service.ts.
  */
 async function emitResourceAccessTypeChanged(
   organizationId: string,
@@ -77,18 +82,24 @@ async function emitResourceAccessTypeChanged(
     else broadcast = true
   }
 
+  // Lazy import — the cache invalidation path lazily imports realtime, so this
+  // module must not statically import the realtime barrel back (import cycle).
+  const { getRealtimeService, publishCapabilitiesChanged } = await import('../realtime')
+
   if (broadcast) {
     await onCacheEvent('resource-access.type.changed', {
       orgId: organizationId,
       broadcastUserKeys: true,
     })
+    await publishCapabilitiesChanged(getRealtimeService(), { orgId: organizationId })
     return
   }
 
   await Promise.all(
-    Array.from(userIds).map((userId) =>
-      onCacheEvent('resource-access.type.changed', { orgId: organizationId, userId })
-    )
+    Array.from(userIds).map(async (userId) => {
+      await onCacheEvent('resource-access.type.changed', { orgId: organizationId, userId })
+      await publishCapabilitiesChanged(getRealtimeService(), { userId })
+    })
   )
 }
 

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -178,8 +178,9 @@ export interface UnifiedCrudHandlerOptions {
    */
   bypassFieldGuards?: ReadonlySet<SystemAttribute>
   /**
-   * Request-scoped {@link CapabilitySet} for entity-def read enforcement (v2 §2).
-   * Present ⇒ read methods gate each def through `canViewEntity`. **Absent ⇒ no
+   * Request-scoped {@link CapabilitySet} for entity-def enforcement. Present ⇒
+   * read methods gate each def through `canViewEntity` (v2 §2) AND mutation
+   * methods gate through `assertEditEntity` (v2 phase 4 §2). **Absent ⇒ no
    * enforcement** — so internal/system callers (seeders, workers, record-rules)
    * stay unrestricted with no change. Request paths must thread `ctx.capabilities`
    * (resolved once via `capabilityProcedure`).
@@ -237,6 +238,22 @@ export class UnifiedCrudHandler {
     await this.resolveEntityDefinition(entityDefinitionId)
   }
 
+  /**
+   * Write enforcement for bulk ops (§2): assert `assertEditEntity` once per
+   * DISTINCT def among the recordIds. Pure in-memory (just the recordId parse);
+   * a no-op when `capabilities` is absent (internal/system callers).
+   */
+  private assertEditDistinctDefs(recordIds: RecordId[]): void {
+    if (!this.capabilities) return
+    const seen = new Set<string>()
+    for (const recordId of recordIds) {
+      const { entityDefinitionId } = parseRecordId(recordId)
+      if (seen.has(entityDefinitionId)) continue
+      seen.add(entityDefinitionId)
+      this.capabilities.assertEditEntity(entityDefinitionId)
+    }
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // SINGLE RECORD OPERATIONS
   // ═══════════════════════════════════════════════════════════════════════════
@@ -256,6 +273,8 @@ export class UnifiedCrudHandler {
     values: Record<string, unknown>,
     options: CrudOptions = {}
   ): Promise<CreateEntityResult> {
+    // Write enforcement (§2): absent capabilities ⇒ internal caller ⇒ unrestricted.
+    this.capabilities?.assertEditEntity(entityDefinitionId)
     await this.warmCache(entityDefinitionId)
     // The `external_id` ARRAY attribute is retired (contact/company). Its writers
     // (browser extension) still send it under `values` as an array; peel it off
@@ -327,6 +346,7 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ) {
     const { entityDefinitionId } = parseRecordId(recordId)
+    this.capabilities?.assertEditEntity(entityDefinitionId)
     await this.warmCache(entityDefinitionId)
     return updateEntity(this.getMutationContext(), recordId, values, modes, options)
   }
@@ -608,6 +628,8 @@ export class UnifiedCrudHandler {
    */
   async archive(recordId: RecordId, options: CrudOptions = {}) {
     const { entityDefinitionId } = parseRecordId(recordId)
+    // Soft delete is an edit (§0.1).
+    this.capabilities?.assertEditEntity(entityDefinitionId)
     await this.warmCache(entityDefinitionId)
     return archiveEntity(this.getMutationContext(), recordId, options)
   }
@@ -620,6 +642,7 @@ export class UnifiedCrudHandler {
    */
   async restore(recordId: RecordId, options: CrudOptions = {}) {
     const { entityDefinitionId } = parseRecordId(recordId)
+    this.capabilities?.assertEditEntity(entityDefinitionId)
     await this.warmCache(entityDefinitionId)
     return restoreEntity(this.getMutationContext(), recordId, options)
   }
@@ -632,6 +655,9 @@ export class UnifiedCrudHandler {
    */
   async delete(recordId: RecordId, options: CrudOptions = {}): Promise<void> {
     const { entityDefinitionId } = parseRecordId(recordId)
+    // Record delete is a write (§0.1); the router additionally asserts the
+    // coarse `records.delete` verb (belt-and-braces Layer-2 gate).
+    this.capabilities?.assertEditEntity(entityDefinitionId)
     await this.warmCache(entityDefinitionId)
     return deleteEntity(this.getMutationContext(), recordId, options)
   }
@@ -653,6 +679,7 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ): Promise<{ created: EntityInstanceEntity[]; errors: Array<{ index: number; error: string }> }> {
     if (items.length === 0) return { created: [], errors: [] }
+    this.capabilities?.assertEditEntity(entityDefinitionId)
     await this.warmCache(entityDefinitionId)
     return bulkCreateEntities(this.getMutationContext(), entityDefinitionId, items, options)
   }
@@ -668,6 +695,7 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ): Promise<{ updated: number; errors: Array<{ recordId: RecordId; error: string }> }> {
     if (updates.length === 0) return { updated: 0, errors: [] }
+    this.assertEditDistinctDefs(updates.map((u) => u.recordId))
     const { entityDefinitionId } = parseRecordId(updates[0]!.recordId)
     await this.warmCache(entityDefinitionId)
     return bulkUpdateEntities(this.getMutationContext(), updates, options)
@@ -681,6 +709,7 @@ export class UnifiedCrudHandler {
    */
   async bulkArchive(recordIds: RecordId[], options: CrudOptions = {}): Promise<{ count: number }> {
     if (recordIds.length === 0) return { count: 0 }
+    this.assertEditDistinctDefs(recordIds)
     const { entityDefinitionId } = parseRecordId(recordIds[0]!)
     await this.warmCache(entityDefinitionId)
     return bulkArchiveEntities(this.getMutationContext(), recordIds, options)
@@ -697,6 +726,7 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ): Promise<{ count: number; errors: Array<{ recordId: RecordId; message: string }> }> {
     if (recordIds.length === 0) return { count: 0, errors: [] }
+    this.assertEditDistinctDefs(recordIds)
     const { entityDefinitionId } = parseRecordId(recordIds[0]!)
     await this.warmCache(entityDefinitionId)
     return bulkDeleteEntities(this.getMutationContext(), recordIds, options)
@@ -715,6 +745,7 @@ export class UnifiedCrudHandler {
     value: unknown
   ): Promise<{ count: number }> {
     if (recordIds.length === 0) return { count: 0 }
+    this.assertEditDistinctDefs(recordIds)
     return bulkSetFieldValue(this.getMutationContext(), recordIds, fieldId, value)
   }
 
@@ -1050,6 +1081,8 @@ export class UnifiedCrudHandler {
    * @param sourceRecordIds - RecordIds of instances to merge into target
    */
   async merge(targetRecordId: RecordId, sourceRecordIds: RecordId[]) {
+    // Merge writes the survivor and removes the sources — assert edit on every def.
+    this.assertEditDistinctDefs([targetRecordId, ...sourceRecordIds])
     return mergeEntities(this.getMutationContext(), targetRecordId, sourceRecordIds)
   }
 
@@ -1065,6 +1098,7 @@ export class UnifiedCrudHandler {
    * @param values - Field values (fieldId -> value)
    */
   async createWithValues(entityDefinitionId: string, values: Record<string, unknown>) {
+    this.capabilities?.assertEditEntity(entityDefinitionId)
     await this.warmCache(entityDefinitionId)
     return createWithValuesImpl(this.getMutationContext(), entityDefinitionId, values)
   }
@@ -1077,6 +1111,16 @@ export class UnifiedCrudHandler {
    * @param values - Field values to update (fieldId -> value)
    */
   async updateValues(instanceId: string, values: Record<string, unknown>) {
+    // Only the instanceId is known here, so resolve its def to enforce — but
+    // solely when a request-scoped CapabilitySet is present (internal callers
+    // skip the extra lookup entirely).
+    if (this.capabilities) {
+      const instance = await getEntityInstance({
+        id: instanceId,
+        organizationId: this.organizationId,
+      })
+      if (instance.isOk()) this.capabilities.assertEditEntity(instance.value.entityDefinitionId)
+    }
     return updateValuesImpl(this.getMutationContext(), instanceId, values)
   }
 


### PR DESCRIPTION
## What

Activates the **Edit** rung of the leveled permission model — **capability layer v2 phase 4** (write-path enforcement). Writes to a *restricted* entity def now require a def-level grant of `edit` or higher; unrestricted defs stay governed by the verb layer alone (**dormant** — no behavior change until a def is restricted via the Phase 3 Access tab).

Plan: `plans/permissions/v2/capability-layer-v2-phase4-writepath-enforcement.md`.

## Changes

**Primitive (`CapabilitySet`)**
- Added `effectiveRecordLevel` / `canEditEntity` / `assertEditEntity` / `filterEditableDefIds` — Layer 2 × Layer 3 combined by **most-specific-wins** (v1.5 §5.1, revised): an explicit per-def grant *replaces* the base records level.
- Re-expressed `canViewEntity` through the same rule so read and write agree (a base-None member with a def grant can now view that def).
- Two carve-outs bypass to the verb gate: **mail-infra defs**, and **defs with a dedicated write key** (`work_order → dispatch.board.manage`) — so dispatch authority is preserved end-to-end and not wrongly gated on the records area.

**Enforcement**
- `UnifiedCrudHandler`: every mutation method gates through `capabilities?.assertEditEntity(...)` (absent = internal caller = unrestricted).
- `record.ts`: promoted the six `protectedProcedure` mutations to `capabilityProcedure`, threaded `capabilities` into every write handler, and added `isAuxxError` rethrows so the 403 isn't flattened into a 500 (closes the pre-existing Layer-2 create/update hole).
- `fieldValue.ts`: upgraded write guards `assertWriteEntity → assertEditEntity` and gated the two ungated writers (`add`/`remove`).
- `ticket.ts`: tickets are **records-governed** — gated all 13 write mutations on `assertEditEntity('ticket')` (+ `records.delete` verb on destructive ops), mirroring `record.ts`. Ticket writes flow through `ticketService`, not the handler, so the gate lives at the router.

**Realtime (§10)**
- `emitResourceAccessTypeChanged` now fires `publishCapabilitiesChanged` per user / org-wide so other members' live sessions re-compose def-access; fixed the inaccurate `use-def-access.ts` comment.

## Tests
- New `capability-set-edit.test.ts` (13 cases: raise/restrict/row-5, worker seat, mail-infra, work_order dispatch bypass).
- Updated the two `canViewEntity` assertions that flip under most-specific-wins.
- Full `permissions` + `resource-access` + `crud` suites pass (102 tests).

## Notes / out of scope
- **Ticket reads** (`byId`/`all`/`list`/…) left ungated for now — read-gating tickets is Phase-2-shaped; can follow up if we want full records parity.
- Kopilot write tools, `Full`/def-administration (§9), and per-def client affordances (§11) remain deferred per the plan.