### PR TITLE
feat(permissions): expose def-access to the client, gate record UI per def

### DIFF
--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -503,11 +503,12 @@ export function BaseEntityDrawer({
   readOnly: readOnlyProp,
 }: BaseEntityDrawerProps) {
   // Restricted (read-only) mode — the explicit prop from `RecordDrawer` wins;
-  // fall back to the member's derived state so drawers opened directly (contact,
-  // dispatch board) are restricted for field seats too (§11.4). One derivation
-  // for the whole frame stack: every `DrawerRecordFrame` (base + peek/drill)
-  // gets the same flag, so a drilled record is read-only just like its parent.
-  const derivedReadOnly = useRecordDrawerReadOnly()
+  // fall back to the member's derived per-def state so drawers opened directly
+  // (contact, dispatch board) are restricted for field seats / Read-only grantees
+  // too (§11.4). Derived from the BASE record's def: one flag for the whole frame
+  // stack, so a drilled record inherits the parent's read-only state.
+  const baseDefId = recordId ? parseRecordId(recordId).entityDefinitionId : undefined
+  const derivedReadOnly = useRecordDrawerReadOnly(baseDefId)
   const readOnly = readOnlyProp ?? derivedReadOnly
 
   // Cross-record peek stack — `frames = [recordId, ...peek]`. Called

--- a/apps/web/src/components/records/entity-route-layout.tsx
+++ b/apps/web/src/components/records/entity-route-layout.tsx
@@ -49,17 +49,20 @@ export function EntityRouteLayout({
 }: EntityRouteLayoutProps) {
   const { getResourceById } = useResources()
   const { hasAccess } = useFeatureFlags()
-  const { deniedBy } = useAccess()
+  const { deniedBy, canViewEntity } = useAccess()
   const resource = getResourceById(slug)
   const ResourceIcon = resource ? getIcon(resource.icon)?.icon : undefined
 
-  // Layer-2 read gate for direct-URL hits (e.g. a field seat deep-linking
-  // `/app/tickets`): tickets ride the `tickets.view` capability, every other
-  // entity list rides `records.view`. A `'permission'` denial (nothing to buy)
-  // renders the friendly NoAccess surface instead of an empty/broken shell;
-  // plan denials fall through so the existing upgrade surfaces still show.
-  const viewKey = slug === 'tickets' ? PermissionKey.ticketsView : PermissionKey.recordsView
-  if (deniedBy(viewKey) === 'permission') {
+  // Layer-2/3 read gate for direct-URL hits (e.g. a member deep-linking
+  // `/app/contacts` they can't see). Tickets ride the `tickets.view` capability
+  // (plan-aware verb). Every other entity list rides the per-def most-specific-
+  // wins gate (`canViewEntity`) so a def-level grant unlocks a def even when the
+  // member's base records level is None — the whole point of the leveled model.
+  if (slug === 'tickets') {
+    if (deniedBy(PermissionKey.ticketsView) === 'permission') {
+      return <NoAccess area={resource?.plural ?? undefined} />
+    }
+  } else if (resource && !canViewEntity(resource.entityDefinitionId)) {
     return <NoAccess area={resource?.plural ?? undefined} />
   }
 

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -78,16 +78,16 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   const dockedWidth = useDockStore((state) => state.dockedWidth)
   const setDockedWidth = useDockStore((state) => state.setDockedWidth)
 
-  // Restricted (read-only) mode for field seats — computed once here (the drawer
-  // root) and threaded into BaseEntityDrawer + used to gate every write
-  // affordance in this header. Full members (`records.edit`) get `false`, so the
-  // drawer is byte-identical to before (§11.4).
-  const readOnly = useRecordDrawerReadOnly()
-
   // Parse recordId to get components
   const { entityDefinitionId, entityInstanceId } = recordId
     ? parseRecordId(recordId)
     : { entityDefinitionId: '', entityInstanceId: '' }
+
+  // Restricted (read-only) mode — computed once here (the drawer root) and
+  // threaded into BaseEntityDrawer + used to gate every write affordance in this
+  // header. Per-def (`!canEditEntity`), so a Read-only grantee on this def is
+  // read-only while an Edit grantee is not; full members are unaffected (§11.4).
+  const readOnly = useRecordDrawerReadOnly(entityDefinitionId || undefined)
 
   // Get resource with fields
   const { resource } = useResource(entityDefinitionId ?? null)

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -66,6 +66,7 @@ import { AddToSequenceDialog } from '~/components/sequences/ui/add-to-sequence-d
 import { MassWorkflowTriggerDialog } from '~/components/workflow/mass-workflow-trigger-dialog'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useEntityInstanceOperations } from '~/hooks/use-entity-instance-operations'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { RecordDrawer } from './record-drawer'
 import { searchConditionsToGroup, useRecordsSearchStore } from './records-search-store'
@@ -115,6 +116,13 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
   const { resource, isLoading } = useResource(slug)
   const entityDefinitionId = resource?.id
   const createHotkey = getCreateHotkey(resource?.apiSlug)
+
+  // Per-def write gate (Layer 2 × Layer 3) — hides the Create affordances for a
+  // member who can view but not edit this def (Read-only grantee / field seat).
+  // The server enforces regardless; this just avoids a click-then-403. Keyed by
+  // `entityDefinitionId` (the defAccess keyspace), not `resource.id`.
+  const { canEditEntity } = useAccess()
+  const canCreate = resource ? canEditEntity(resource.entityDefinitionId) : false
 
   // Imperative handle into DynamicResourceView for refresh + field-value reads
   // (paste/fill needs getValue from the inner syncer).
@@ -695,23 +703,29 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
         <EmptyState
           icon={Database}
           title={`No ${resource?.plural?.toLowerCase() ?? 'records'} found`}
-          description={`Create your first ${resource?.label?.toLowerCase() ?? 'record'}`}
+          description={
+            canCreate
+              ? `Create your first ${resource?.label?.toLowerCase() ?? 'record'}`
+              : `No ${resource?.plural?.toLowerCase() ?? 'records'} to show`
+          }
           button={
-            <Button size='sm' variant='outline' onClick={() => setIsCreateDialogOpen(true)}>
-              <Plus />
-              Create {resource?.label ?? 'Record'}
-              {createHotkey && (
-                <KbdGroup variant='default' size='sm'>
-                  <Kbd>{createHotkey[0]}</Kbd>
-                  <Kbd>{createHotkey[1]}</Kbd>
-                </KbdGroup>
-              )}
-            </Button>
+            canCreate ? (
+              <Button size='sm' variant='outline' onClick={() => setIsCreateDialogOpen(true)}>
+                <Plus />
+                Create {resource?.label ?? 'Record'}
+                {createHotkey && (
+                  <KbdGroup variant='default' size='sm'>
+                    <Kbd>{createHotkey[0]}</Kbd>
+                    <Kbd>{createHotkey[1]}</Kbd>
+                  </KbdGroup>
+                )}
+              </Button>
+            ) : undefined
           }
         />
       </div>
     ),
-    [resource?.plural, resource?.label, createHotkey, setIsCreateDialogOpen]
+    [resource?.plural, resource?.label, createHotkey, setIsCreateDialogOpen, canCreate]
   )
 
   // Memoized element — passing a fresh `<EmptyStateComponent />` inline made the
@@ -767,13 +781,17 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
       emptyState={emptyStateElement}
       dockedPanels={dockedPanels}
       onRowSelectionChange={handleRowSelectionChange}
-      onAddNew={(presetValues) => {
-        setCreatePresetValues(presetValues)
-        setIsCreateDialogOpen(true)
-      }}
+      onAddNew={
+        canCreate
+          ? (presetValues) => {
+              setCreatePresetValues(presetValues)
+              setIsCreateDialogOpen(true)
+            }
+          : undefined
+      }
       entityLabel={resource.label}
       onCardClick={handleOpenDrawer}
-      onAddCard={() => setIsCreateDialogOpen(true)}
+      onAddCard={canCreate ? () => setIsCreateDialogOpen(true) : undefined}
       selectedKanbanCardIds={selectedKanbanCardIds}
       onSelectedKanbanCardIdsChange={setSelectedKanbanCardIds}
       importHref={`${resolvedBasePath}/import`}
@@ -878,16 +896,18 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
 
       <MainPageAction>
         {pageActions}
-        <Button size='sm' className='h-7 rounded-lg' onClick={() => setIsCreateDialogOpen(true)}>
-          <Plus className='size-4' />
-          Create {resource.label}
-          {createHotkey && (
-            <KbdGroup variant='default' size='sm'>
-              <Kbd>{createHotkey[0]}</Kbd>
-              <Kbd>{createHotkey[1]}</Kbd>
-            </KbdGroup>
-          )}
-        </Button>
+        {canCreate && (
+          <Button size='sm' className='h-7 rounded-lg' onClick={() => setIsCreateDialogOpen(true)}>
+            <Plus className='size-4' />
+            Create {resource.label}
+            {createHotkey && (
+              <KbdGroup variant='default' size='sm'>
+                <Kbd>{createHotkey[0]}</Kbd>
+                <Kbd>{createHotkey[1]}</Kbd>
+              </KbdGroup>
+            )}
+          </Button>
+        )}
       </MainPageAction>
 
       {mainContent}

--- a/apps/web/src/components/records/use-record-drawer-read-only.ts
+++ b/apps/web/src/components/records/use-record-drawer-read-only.ts
@@ -1,20 +1,23 @@
 // apps/web/src/components/records/use-record-drawer-read-only.ts
 'use client'
 
-import { PermissionKey } from '@auxx/lib/permissions/client'
 import { useAccess } from '~/providers/capabilities-provider'
 
 /**
  * Single source of truth for the record drawer's restricted (read-only) mode.
  *
- * A member is read-only in the drawer when they cannot edit CRM records — i.e.
- * a field ("worker") seat that has `records.viewLinked` but not `records.edit`
- * (the worker ceiling zeroes the `records` area). Full members — anyone with
- * `records.edit` — get `false`, so the drawer stays exactly as before (§11.4,
- * §2.K). Compute once near the drawer root and thread the boolean down; never
- * call `useAccess()` in leaf drawer components.
+ * A member is read-only in the drawer when they cannot edit the def's records —
+ * `!canEditEntity(entityDefinitionId)` (Layer 2 × Layer 3, most-specific-wins).
+ * This covers a field ("worker") seat (records ceiling None) AND a member who is
+ * a Read-only grantee on a restricted def, while raising a member granted Edit on
+ * a def they'd otherwise lack. Full members are unaffected. Compute once near the
+ * drawer root and thread the boolean down; never call `useAccess()` in leaves.
+ *
+ * @param entityDefinitionId The def whose records the drawer edits. When
+ *   `undefined` (def still resolving) the drawer stays editable — the server
+ *   remains the source of truth and rejects a disallowed write.
  */
-export function useRecordDrawerReadOnly(): boolean {
-  const { can } = useAccess()
-  return !can(PermissionKey.recordsEdit)
+export function useRecordDrawerReadOnly(entityDefinitionId: string | undefined): boolean {
+  const { canEditEntity } = useAccess()
+  return entityDefinitionId ? !canEditEntity(entityDefinitionId) : false
 }

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -1,8 +1,14 @@
 // apps/web/src/providers/capabilities-provider.tsx
 'use client'
 
-import type { PermissionKey } from '@auxx/lib/permissions/client'
-import { PERMISSION_REGISTRY_MAP } from '@auxx/lib/permissions/client'
+import {
+  type ClientCapabilities,
+  canEditRecord,
+  canViewRecord,
+  PERMISSION_REGISTRY_MAP,
+  type PermissionKey,
+  toResolvedRecordAccess,
+} from '@auxx/lib/permissions/client'
 import type { SubscribeHandlers } from '@auxx/lib/realtime/client'
 import { rooms } from '@auxx/lib/realtime/client'
 import type React from 'react'
@@ -14,6 +20,15 @@ import { useFeatureFlags, useOrganizationIdContext } from './feature-flag-provid
 
 /** Why a capability check failed — drives UX (§7.3). */
 export type DeniedReason = 'plan' | 'permission' | null
+
+/** Fail-closed default when no org is seeded — base None, so every gate denies. */
+const EMPTY_CAPS: ClientCapabilities = {
+  keys: [],
+  defAccess: {},
+  restrictedEntityDefIds: [],
+  role: 'USER',
+  seatType: 'full',
+}
 
 /** Shape of the capabilities context value. */
 interface CapabilitiesContextType {
@@ -28,6 +43,19 @@ interface CapabilitiesContextType {
    * hide the entry point or render read-only; `null` → access is allowed.
    */
   deniedBy: (key: PermissionKey | string) => DeniedReason
+  /**
+   * Per-def READ gate (Layer 2 × Layer 3, most-specific-wins) — mirrors the
+   * server `canViewEntity`. Pass the canonical `entityDefinitionId` (e.g.
+   * `resource.entityDefinitionId`), NOT the slug/apiSlug.
+   */
+  canViewEntity: (entityDefinitionId: string) => boolean
+  /**
+   * Per-def WRITE gate — mirrors the server `canEditEntity` for records-area
+   * defs. NOTE: dedicated-write-key defs (`work_order` → dispatch) and mail-infra
+   * defs are NOT special-cased here; the server remains the source of truth for
+   * those, so an affordance may show optimistically and get a 403 on submit.
+   */
+  canEditEntity: (entityDefinitionId: string) => boolean
   /** The current member's composed capability keys. */
   capabilities: PermissionKey[]
   isLoading: boolean
@@ -40,10 +68,10 @@ const CapabilitiesContext = createContext<CapabilitiesContextType | undefined>(u
  * state and live-merged over realtime.
  *
  * Sibling of {@link FeatureFlagProvider} — MUST mount INSIDE it so `can()` can
- * AND the plan layer via `useFeatureFlags().hasAccess`. Seeds the key set from
+ * AND the plan layer via `useFeatureFlags().hasAccess`. Seeds the snapshot from
  * the active org's dehydrated `capabilities`; on a `capabilities:changed` event
  * (user room or org events room) it refetches `permissions.myCapabilities` (a
- * cheap user-cache read) and swaps the set — menus/gates re-render automatically.
+ * cheap user-cache read) and swaps it — menus/gates re-render automatically.
  * Server enforcement never trusts this copy, so the realtime path is UX-only.
  */
 export function CapabilitiesProvider({ children }: { children: React.ReactNode }) {
@@ -56,26 +84,26 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
   // Stable signature of the dehydrated seed so the re-seed effect only fires on
   // an actual org switch (the dehydrated blob is static for a page load).
   const seedKey = useMemo(
-    () => (dehydratedCaps ? [...dehydratedCaps].join(',') : ''),
+    () => (dehydratedCaps ? JSON.stringify(dehydratedCaps) : ''),
     [dehydratedCaps]
   )
 
-  const [capKeys, setCapKeys] = useState<ReadonlySet<string>>(() => new Set(dehydratedCaps ?? []))
+  const [snapshot, setSnapshot] = useState<ClientCapabilities>(() => dehydratedCaps ?? EMPTY_CAPS)
 
   // Re-seed from dehydrated state when the active org changes.
   // biome-ignore lint/correctness/useExhaustiveDependencies: seedKey encodes dehydratedCaps
   useEffect(() => {
-    setCapKeys(new Set(dehydratedCaps ?? []))
+    setSnapshot(dehydratedCaps ?? EMPTY_CAPS)
   }, [organizationId, seedKey])
 
-  // Disabled by default — the dehydrated set is the initial source; the realtime
-  // event triggers a manual refetch, and the result swaps into local state.
+  // Disabled by default — the dehydrated snapshot is the initial source; the
+  // realtime event triggers a manual refetch, and the result swaps into state.
   const myCapabilities = api.permissions.myCapabilities.useQuery(undefined, {
     enabled: false,
   })
 
   useEffect(() => {
-    if (myCapabilities.data) setCapKeys(new Set(myCapabilities.data.keys))
+    if (myCapabilities.data) setSnapshot(myCapabilities.data)
   }, [myCapabilities.data])
 
   const refetch = myCapabilities.refetch
@@ -94,6 +122,9 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
   useRealtimeRoom(organizationId ? rooms.orgEvents(organizationId) : null, handlers)
 
   const value = useMemo<CapabilitiesContextType>(() => {
+    const capKeys = new Set<string>(snapshot.keys)
+    const resolved = toResolvedRecordAccess(snapshot)
+
     const can = (key: PermissionKey | string): boolean => {
       const meta = PERMISSION_REGISTRY_MAP.get(key as PermissionKey)
       const planOk = meta?.featureKey ? hasAccess(meta.featureKey) : true
@@ -113,17 +144,20 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
     return {
       can,
       deniedBy,
-      capabilities: [...capKeys] as PermissionKey[],
+      canViewEntity: (entityDefinitionId: string) => canViewRecord(resolved, entityDefinitionId),
+      canEditEntity: (entityDefinitionId: string) => canEditRecord(resolved, entityDefinitionId),
+      capabilities: snapshot.keys,
       isLoading: false,
     }
-  }, [capKeys, hasAccess])
+  }, [snapshot, hasAccess])
 
   return <CapabilitiesContext.Provider value={value}>{children}</CapabilitiesContext.Provider>
 }
 
 /**
  * Consume the capability context. Combines the plan (Layer 1) and member
- * capability (Layer 2) layers into one `can()` / `deniedBy()` surface.
+ * capability (Layer 2) layers into one `can()` / `deniedBy()` surface, plus the
+ * per-def `canViewEntity` / `canEditEntity` gates (Layer 3).
  */
 export function useAccess(): CapabilitiesContextType {
   const context = useContext(CapabilitiesContext)

--- a/apps/web/src/server/api/routers/permissions.ts
+++ b/apps/web/src/server/api/routers/permissions.ts
@@ -1,9 +1,9 @@
 // apps/web/src/server/api/routers/permissions.ts
 
-import { getCachedUserCapabilities } from '@auxx/lib/cache'
 import {
   type Area,
   clearGranteeLevels,
+  getCapabilities,
   Level,
   listGranteeGrants,
   ROLE_DEFAULTS,
@@ -32,10 +32,16 @@ const levelsInput = z.record(z.string(), z.coerce.number().int().min(Level.None)
  * the levels, applies the `granularPermissions` plan gate, and busts caches).
  */
 export const permissionsRouter = createTRPCRouter({
-  /** The current member's composed capability keys (for the client provider). */
+  /**
+   * The current member's composed capability snapshot for the client provider —
+   * the coarse verb `keys` PLUS the per-def access map (`defAccess` +
+   * `restrictedEntityDefIds`) and `role`/`seatType`, so the client can run the
+   * same most-specific-wins `canViewEntity`/`canEditEntity` math as the server
+   * (capability layer v2 §11.1).
+   */
   myCapabilities: protectedProcedure.query(async ({ ctx }) => {
-    const caps = await getCachedUserCapabilities(ctx.session.userId, ctx.session.organizationId)
-    return { keys: caps.keys }
+    const caps = await getCapabilities(ctx.session.userId, ctx.session.organizationId)
+    return caps.toClientCapabilities()
   }),
 
   /**

--- a/packages/lib/src/dehydration/service.ts
+++ b/packages/lib/src/dehydration/service.ts
@@ -12,8 +12,9 @@ import { configService } from '@auxx/credentials'
 import { getDeploymentMode } from '@auxx/deployment'
 import { createScopedLogger } from '@auxx/logger'
 import { execSync } from 'child_process'
-import { getCachedUserCapabilities, getOrgCache, getUserCache } from '../cache'
+import { getOrgCache, getUserCache } from '../cache'
 import type { CachedSubscription } from '../cache/org-cache-keys'
+import { getCapabilities } from '../permissions'
 import { SETTINGS_CATALOG } from '../settings'
 import type { DehydratedEnvironment, DehydratedOrganization, DehydratedState } from './types'
 
@@ -192,8 +193,9 @@ export class DehydrationService {
       ]),
       // User+org-scoped: settings
       this.userCache.getOrRecompute(userId, ['userSettings'], orgId),
-      // User+org-scoped: composed Layer-2 capability set (one cached read, no DB).
-      getCachedUserCapabilities(userId, orgId),
+      // User+org-scoped: resolved Layer-2 capability set (cache-backed, no DB) —
+      // the full CapabilitySet so the client seed carries defAccess (§11.1).
+      getCapabilities(userId, orgId),
     ])
 
     const { features, subscription, orgProfile, overages, channelProviders } = orgData
@@ -214,7 +216,7 @@ export class DehydrationService {
       demoExpiresAt: orgProfile.demoExpiresAt,
       subscription: toClientSubscription(subscription),
       features: features ?? {},
-      capabilities: capabilities.keys,
+      capabilities: capabilities.toClientCapabilities(),
       overages,
       settings: userData.userSettings,
       hasIntegrations,

--- a/packages/lib/src/dehydration/types.ts
+++ b/packages/lib/src/dehydration/types.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/dehydration/types.ts
 
-import type { PermissionKey } from '../permissions/capabilities/registry'
+import type { ClientCapabilities } from '../permissions/capabilities/entity-access'
 
 /**
  * Window global interface for dehydrated state
@@ -176,8 +176,13 @@ export interface DehydratedOrganization {
   // Feature permissions
   features: Record<string, boolean | number | '+'>
 
-  /** The ACTIVE org's composed Layer-2 capability keys for THIS user (§7.1). */
-  capabilities: PermissionKey[]
+  /**
+   * The ACTIVE org's composed Layer-2 capability snapshot for THIS user (§7.1):
+   * verb `keys` plus the per-def access map (`defAccess` +
+   * `restrictedEntityDefIds`) and `role`/`seatType`, so the client provider can
+   * run the same most-specific-wins `canViewEntity`/`canEditEntity` as the server.
+   */
+  capabilities: ClientCapabilities
 
   /** Features that exceed the current plan's limits (empty if none) */
   overages: Array<{

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -1,11 +1,17 @@
 // packages/lib/src/permissions/capabilities/capability-set.ts
 
-import { ResourcePermission } from '@auxx/database/enums'
+import type { ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { ForbiddenError } from '../../errors'
-import { satisfiesPermission } from '../../resource-access/constants'
-import { Area, Level, PERMISSION_REGISTRY_MAP, PermissionKey } from './registry'
-import { ENTITY_WRITE_KEYS, SEAT_CEILINGS } from './seat-policy'
+import {
+  type ClientCapabilities,
+  canEditRecord,
+  canViewRecord,
+  NON_RECORD_DEF_SLUGS,
+  type ResolvedRecordAccess,
+} from './entity-access'
+import { PERMISSION_REGISTRY_MAP, PermissionKey } from './registry'
+import { ENTITY_WRITE_KEYS } from './seat-policy'
 
 /**
  * Resolves the definition part of a RecordId (a system slug like `work_order`,
@@ -16,24 +22,6 @@ import { ENTITY_WRITE_KEYS, SEAT_CEILINGS } from './seat-policy'
  * the {@link PermissionKey.recordsEdit} default applies.
  */
 export type DefIdToSlug = (entityDefId: string) => string
-
-/**
- * Defs whose visibility is governed OUTSIDE the records area — mail and
- * messaging infrastructure. `canViewEntity` passes these through unconditionally:
- * the `records.view` verb must not hide them (a member with a lowered records
- * area still composes mail with signatures and inboxes), and their
- * `ResourceAccess` rows carry SHARING semantics (mail visibility, sequence/
- * snippet sharing), never def restriction. Keyed by entityType slug; membership
- * is checked on both the raw def-part and its resolved slug.
- */
-const NON_RECORD_DEF_SLUGS: ReadonlySet<string> = new Set([
-  'inbox',
-  'signature',
-  'thread',
-  'message',
-  'snippet',
-  'sequence',
-])
 
 /**
  * A resolved, request-scoped view of one member's Layer-2 capabilities (§6.1).
@@ -110,40 +98,33 @@ export class CapabilitySet {
   }
 
   /**
-   * The member's base records rung (Layer 2), derived from the already
-   * seat-clamped key set (v2 §1). Record data collapses to read vs write
-   * (decision §0.1 — `edit` covers create/update/delete); the coarse
-   * `records.delete`/`import` verbs stay org-wide keys, not a per-def rung.
-   * `undefined` = No Access. Note {@link PermissionKey.recordsViewLinked} (field
-   * seats) is NOT a base rung — its narrowed view is a {@link canViewEntity}
-   * carve-out, never a write rung.
+   * The normalized {@link ResolvedRecordAccess} view fed to the shared
+   * client-safe resolver ({@link canViewRecord} / {@link canEditRecord}). The
+   * `defAccess` / `restrictedDefIds` fields are already in the canonical
+   * `entityDefinitionId` keyspace (normalized in {@link getCapabilities}).
    */
-  private baseRecordsLevel(): ResourcePermission | undefined {
-    if (this.keys.has(PermissionKey.recordsEdit)) return ResourcePermission.edit
-    if (this.keys.has(PermissionKey.recordsView)) return ResourcePermission.view
-    return undefined
+  private resolved(): ResolvedRecordAccess {
+    return {
+      role: this.role,
+      seatType: this.seatType,
+      keys: this.keys,
+      defAccess: this.defAccess,
+      restrictedEntityDefIds: this.restrictedDefIds,
+    }
   }
 
   /**
-   * Layer 2 × Layer 3, most-specific-wins (v1.5 §5.1, revised 2026-07-23). The
-   * member's effective record permission for a def, or `undefined` (= No Access).
-   * Zero I/O.
-   *  - OWNER/ADMIN → `admin` (bypass — administer restrictions, never self-lock).
-   *  - restricted def → the member's own type-level grant REPLACES base
-   *    (`undefined` when they're not a grantee → locked out).
-   *  - unrestricted def → base records level fills in.
-   *  - seat ceiling clamps last: a worker's records ceiling is None → `undefined`.
+   * Serialize to the wire snapshot the client needs to run the SAME
+   * most-specific-wins math (dehydrated seed + `permissions.myCapabilities`).
    */
-  private effectiveRecordLevel(entityDefId: string): ResourcePermission | undefined {
-    if (this.role === 'OWNER' || this.role === 'ADMIN') return ResourcePermission.admin
-    const defId = this.defIdToDefinitionId(entityDefId)
-    const chosen = this.restrictedDefIds.has(defId)
-      ? this.defAccess[defId] // explicit per-def setting replaces base
-      : this.baseRecordsLevel() // unset def → base fills in
-    if (chosen === undefined) return undefined
-    // Records seat ceiling is Full (full seat) or None (worker) — no intermediate rung.
-    if (SEAT_CEILINGS[this.seatType][Area.records] === Level.None) return undefined
-    return chosen
+  toClientCapabilities(): ClientCapabilities {
+    return {
+      keys: [...this.keys],
+      defAccess: { ...this.defAccess },
+      restrictedEntityDefIds: [...this.restrictedDefIds],
+      role: this.role,
+      seatType: this.seatType,
+    }
   }
 
   /**
@@ -163,8 +144,7 @@ export class CapabilitySet {
     if (this.isMailInfraDef(entityDefId) || this.hasDedicatedWriteKey(entityDefId)) {
       return this.canWriteEntity(entityDefId)
     }
-    const level = this.effectiveRecordLevel(entityDefId)
-    return level !== undefined && satisfiesPermission(level, ResourcePermission.edit)
+    return canEditRecord(this.resolved(), this.defIdToDefinitionId(entityDefId))
   }
 
   /** {@link canEditEntity} as a throwing guard (403). */
@@ -204,15 +184,7 @@ export class CapabilitySet {
    */
   canViewEntity(entityDefId: string): boolean {
     if (this.isMailInfraDef(entityDefId)) return true
-    const level = this.effectiveRecordLevel(entityDefId)
-    if (level !== undefined && satisfiesPermission(level, ResourcePermission.view)) return true
-    // Field-seat carve-out: recordsViewLinked doesn't flow through base rungs.
-    if (this.keys.has(PermissionKey.recordsViewLinked)) {
-      const defId = this.defIdToDefinitionId(entityDefId)
-      if (!this.restrictedDefIds.has(defId)) return true
-      return this.defAccess[defId] !== undefined
-    }
-    return false
+    return canViewRecord(this.resolved(), this.defIdToDefinitionId(entityDefId))
   }
 
   /**

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -1,0 +1,131 @@
+// packages/lib/src/permissions/capabilities/entity-access.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import type { OrganizationRole, SeatType } from '@auxx/database/types'
+import { satisfiesPermission } from '../../resource-access/constants'
+import { Area, Level, PermissionKey } from './registry'
+import { SEAT_CEILINGS } from './seat-policy'
+
+/**
+ * Client-safe core of the leveled record-access model — the most-specific-wins
+ * math (v1.5 §5.1) extracted so the SERVER {@link import('./capability-set').CapabilitySet}
+ * and the CLIENT capabilities provider resolve def access identically and can
+ * never drift. Pure, zero I/O, no server-only deps (only enums + registry +
+ * seat-policy constants), so it is exported through `@auxx/lib/permissions/client`.
+ *
+ * All def-keyed inputs use the canonical `entityDefinitionId` keyspace — the
+ * caller normalizes any slug/apiSlug/id form first.
+ */
+
+/**
+ * Mail/messaging infrastructure def slugs — visibility governed OUTSIDE the
+ * records area (the mail visibility system), so record-level view/edit gates
+ * pass them through. Keyed by entity slug; the caller resolves the def to its
+ * slug before checking. (Moved here from `capability-set.ts` so the client can
+ * apply the same carve-out.)
+ */
+export const NON_RECORD_DEF_SLUGS: ReadonlySet<string> = new Set([
+  'inbox',
+  'signature',
+  'thread',
+  'message',
+  'snippet',
+  'sequence',
+])
+
+/**
+ * A resolved, normalized view of one member's record-access inputs — the shared
+ * argument for every function here. The server builds it from its
+ * `CapabilitySet` fields; the client from the dehydrated/refetched snapshot.
+ */
+export interface ResolvedRecordAccess {
+  role: OrganizationRole
+  seatType: SeatType
+  /** Materialized capability verbs (already seat-clamped). */
+  keys: ReadonlySet<PermissionKey>
+  /** Highest type-level grant per `entityDefinitionId` (absent = not a grantee). */
+  defAccess: Readonly<Record<string, ResourcePermission>>
+  /** Defs carrying ≥1 type-level grant for anyone (`entityDefinitionId` keyspace). */
+  restrictedEntityDefIds: ReadonlySet<string>
+}
+
+/**
+ * The member's base records rung (Layer 2) from the seat-clamped key set.
+ * `edit` covers create/update/delete (§0.1); `undefined` = No Access.
+ * `recordsViewLinked` (field seats) is NOT a base rung — it's a
+ * {@link canViewRecord} carve-out.
+ */
+export function baseRecordsLevel(keys: ReadonlySet<PermissionKey>): ResourcePermission | undefined {
+  if (keys.has(PermissionKey.recordsEdit)) return ResourcePermission.edit
+  if (keys.has(PermissionKey.recordsView)) return ResourcePermission.view
+  return undefined
+}
+
+/**
+ * Layer 2 × Layer 3, most-specific-wins. The member's effective record
+ * permission for a def, or `undefined` (= No Access).
+ *  - OWNER/ADMIN → `admin` (bypass — never self-lock).
+ *  - restricted def → the member's own grant REPLACES base.
+ *  - unrestricted def → base records level fills in.
+ *  - worker seat (records ceiling None) → `undefined`.
+ */
+export function effectiveRecordLevel(
+  caps: ResolvedRecordAccess,
+  entityDefinitionId: string
+): ResourcePermission | undefined {
+  if (caps.role === 'OWNER' || caps.role === 'ADMIN') return ResourcePermission.admin
+  const chosen = caps.restrictedEntityDefIds.has(entityDefinitionId)
+    ? caps.defAccess[entityDefinitionId]
+    : baseRecordsLevel(caps.keys)
+  if (chosen === undefined) return undefined
+  if (SEAT_CEILINGS[caps.seatType][Area.records] === Level.None) return undefined
+  return chosen
+}
+
+/**
+ * Records-area VIEW gate (no mail-infra carve-out — the caller pre-checks that).
+ * `effectiveRecordLevel` satisfies `view`, OR the field-seat `recordsViewLinked`
+ * carve-out (narrowed rows; a restricted def still needs a grant).
+ */
+export function canViewRecord(caps: ResolvedRecordAccess, entityDefinitionId: string): boolean {
+  const level = effectiveRecordLevel(caps, entityDefinitionId)
+  if (level !== undefined && satisfiesPermission(level, ResourcePermission.view)) return true
+  if (caps.keys.has(PermissionKey.recordsViewLinked)) {
+    if (!caps.restrictedEntityDefIds.has(entityDefinitionId)) return true
+    return caps.defAccess[entityDefinitionId] !== undefined
+  }
+  return false
+}
+
+/**
+ * Records-area EDIT gate — `effectiveRecordLevel` satisfies the `edit` floor.
+ * (Mail-infra and dedicated-write-key defs bypass this in the caller.)
+ */
+export function canEditRecord(caps: ResolvedRecordAccess, entityDefinitionId: string): boolean {
+  const level = effectiveRecordLevel(caps, entityDefinitionId)
+  return level !== undefined && satisfiesPermission(level, ResourcePermission.edit)
+}
+
+/**
+ * Serializable snapshot of a member's record-access inputs — the wire shape sent
+ * to the client (dehydrated seed + `permissions.myCapabilities`). Arrays instead
+ * of Sets so it is JSON-safe; the client rebuilds a {@link ResolvedRecordAccess}.
+ */
+export interface ClientCapabilities {
+  keys: PermissionKey[]
+  defAccess: Record<string, ResourcePermission>
+  restrictedEntityDefIds: string[]
+  role: OrganizationRole
+  seatType: SeatType
+}
+
+/** Rebuild the Set-backed {@link ResolvedRecordAccess} from a wire snapshot. */
+export function toResolvedRecordAccess(caps: ClientCapabilities): ResolvedRecordAccess {
+  return {
+    role: caps.role,
+    seatType: caps.seatType,
+    keys: new Set(caps.keys),
+    defAccess: caps.defAccess,
+    restrictedEntityDefIds: new Set(caps.restrictedEntityDefIds),
+  }
+}

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -5,6 +5,17 @@
  */
 
 // Type-only re-exports (erased at runtime — no server deps pulled in).
+// ── Shared client-safe entity-access resolver (most-specific-wins core, used by
+//    the client capabilities provider to mirror server enforcement).
+export {
+  type ClientCapabilities,
+  canEditRecord,
+  canViewRecord,
+  effectiveRecordLevel,
+  NON_RECORD_DEF_SLUGS,
+  type ResolvedRecordAccess,
+  toResolvedRecordAccess,
+} from './capabilities/entity-access'
 export type { GranteeGrant, GrantGranteeType } from './capabilities/grant-service'
 // ── Capability registry (Layer 2) — client-safe: registry.ts only imports
 //    `FeatureKey` from `./types`, which is already client-exported above.


### PR DESCRIPTION
## What

Closes the **client** half of the leveled permission model (capability layer v2 §11.1). PR #1290 made the **server** resolve most-specific-wins correctly (base None + a def-level grant → the grant governs), but the client still gated the nav/route and write affordances on the coarse `records.view` / `records.edit` verb. So a member with **No Access** to records but a **def-level grant** (e.g. Full on `contacts`) was locked out of the UI (`<NoAccess>` on the route) even though the server would have allowed them — the exact bug hit in testing.

## Changes

**Shared resolver (no drift)**
- New `entity-access.ts` — client-safe pure module with the most-specific-wins core (`effectiveRecordLevel` / `canViewRecord` / `canEditRecord`). The server `CapabilitySet` now delegates to it and gains `toClientCapabilities()`. Exported via `@auxx/lib/permissions/client`.

**Expose def-access to the client**
- `permissions.myCapabilities` and the dehydration seed now ship the full snapshot — `keys` **+ `defAccess` + `restrictedEntityDefIds` + `role` + `seatType`** — instead of keys only (`DehydratedOrganization.capabilities` shape widened).
- `capabilities-provider` stores the snapshot and exposes `canViewEntity(entityDefinitionId)` / `canEditEntity(entityDefinitionId)` mirroring the server.

**UI gates**
- `entity-route-layout`: records defs gate on `canViewEntity(resource.entityDefinitionId)` — a def grant now unlocks the route even at base-None records. Tickets keep the plan-aware `tickets.view` verb.
- `records-view`: Create affordances (header button, empty state, kanban add-card) hidden behind `canEditEntity(def)`.
- `use-record-drawer-read-only`: per-def (`!canEditEntity`) instead of the global `records.edit`; the two drawer callers thread the def id.

## Scenario fixed
Member baseline = No Access to records + Full grant on `contacts` → now **sees** contacts in nav/route, gets Create buttons, and can inline-edit. A Read-only grantee sees contacts but no Create and a read-only drawer.

## Notes
- Dedicated-write-key defs (`work_order` → dispatch) and mail-infra defs are **not** special-cased on the client; the server stays source of truth, so a rare optimistic affordance degrades to a 403 toast.
- Server `CapabilitySet` refactor is covered by the existing 26 unit tests; full permissions + resource-access + dehydration suites pass (100 tests).

Follow-ups still open (per plan §8/§11): nav catalog filter (§8), global-create filter, merge/bulk affordances, and the ticket read-gating decision.