### PR TITLE
fix(permissions): govern tickets as an entity def, not a standalone area

### DIFF
--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -42,7 +42,7 @@ const AREA_GROUPS: Array<{ group: string; areas: Area[] }> = (() => {
 
 /**
  * The shared leveled surface: every grantable area rendered as a labelled row
- * with its {@link LevelControl}, grouped by registry group (Tickets, Records,
+ * with its {@link LevelControl}, grouped by registry group (Records,
  * Automation, …). `adminOnly` areas are never shown — they're not grantable below
  * ADMIN. In `override` mode each area inherits from the member baseline (and is
  * raise-only, enforced server-side); in `baseline` mode it inherits from the role

--- a/apps/web/src/components/records/entity-route-layout.tsx
+++ b/apps/web/src/components/records/entity-route-layout.tsx
@@ -2,7 +2,7 @@
 
 'use client'
 
-import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import { getIcon } from '@auxx/ui/components/icons'
 import {
   MainPage,
@@ -49,20 +49,16 @@ export function EntityRouteLayout({
 }: EntityRouteLayoutProps) {
   const { getResourceById } = useResources()
   const { hasAccess } = useFeatureFlags()
-  const { deniedBy, canViewEntity } = useAccess()
+  const { canViewEntity } = useAccess()
   const resource = getResourceById(slug)
   const ResourceIcon = resource ? getIcon(resource.icon)?.icon : undefined
 
   // Layer-2/3 read gate for direct-URL hits (e.g. a member deep-linking
-  // `/app/contacts` they can't see). Tickets ride the `tickets.view` capability
-  // (plan-aware verb). Every other entity list rides the per-def most-specific-
-  // wins gate (`canViewEntity`) so a def-level grant unlocks a def even when the
-  // member's base records level is None — the whole point of the leveled model.
-  if (slug === 'tickets') {
-    if (deniedBy(PermissionKey.ticketsView) === 'permission') {
-      return <NoAccess area={resource?.plural ?? undefined} />
-    }
-  } else if (resource && !canViewEntity(resource.entityDefinitionId)) {
+  // `/app/contacts` they can't see). Every entity list — tickets included —
+  // rides the per-def most-specific-wins gate (`canViewEntity`) so a def-level
+  // grant unlocks a def even when the member's base records level is None — the
+  // whole point of the leveled model. Tickets are just another entity def.
+  if (resource && !canViewEntity(resource.entityDefinitionId)) {
     return <NoAccess area={resource?.plural ?? undefined} />
   }
 

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -25,10 +25,9 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     expect(caps.keys).not.toContain(PermissionKey.billingManage)
     expect(caps.keys).not.toContain(PermissionKey.membersManage)
     expect(caps.keys).not.toContain(PermissionKey.permissionsManage)
-    // A full USER holds full records (view/edit/delete/import) and tickets.
+    // A full USER holds full records (view/edit/delete/import).
     expect(caps.keys).toContain(PermissionKey.recordsDelete)
     expect(caps.keys).toContain(PermissionKey.recordsImport)
-    expect(caps.keys).toContain(PermissionKey.ticketsReply)
   })
 
   it("a worker seat's effective default is exactly WORKER_SEAT_KEYS", () => {
@@ -36,7 +35,7 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     expect(sorted(caps.keys)).toEqual(sorted(WORKER_SEAT_KEYS))
   })
 
-  it('org policy falls through PER AREA: sets records=Read, leaves tickets at USER default', () => {
+  it('org policy falls through PER AREA: sets records=Read, leaves workflows at USER default', () => {
     const caps = composeUserCapabilities({
       role: 'USER',
       seatType: 'full',
@@ -48,10 +47,7 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     expect(caps.keys).toContain(PermissionKey.recordsView)
     expect(caps.keys).not.toContain(PermissionKey.recordsEdit)
     expect(caps.keys).not.toContain(PermissionKey.recordsDelete)
-    // tickets is UNSET in the policy → falls through to the USER default (Full), NOT None.
-    expect(caps.keys).toContain(PermissionKey.ticketsView)
-    expect(caps.keys).toContain(PermissionKey.ticketsReply)
-    // Other unset areas also keep the USER default.
+    // workflows is UNSET in the policy → falls through to the USER default, NOT None.
     expect(caps.keys).toContain(PermissionKey.workflowsManage)
   })
 
@@ -70,7 +66,7 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     const caps = composeUserCapabilities({
       role: 'ADMIN',
       seatType: 'full',
-      orgPolicyLevels: { [Area.records]: Level.None, [Area.tickets]: Level.None },
+      orgPolicyLevels: { [Area.records]: Level.None, [Area.workflows]: Level.None },
       typeAccessRows: [],
     })
     expect(caps.keys).toContain(PermissionKey.recordsDelete)
@@ -113,7 +109,6 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
       groupLevels: [
         {
           [Area.records]: Level.Full,
-          [Area.tickets]: Level.Full,
           [Area.settings]: Level.Full,
           [Area.dispatchBoard]: Level.Full,
         },

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -7,14 +7,9 @@ import { FeatureKey } from '../types'
  *
  * These are NOT per-field/per-record (that's Layer 3 ResourceAccess). Keys are
  * forever-ish once orgs configure grants against them — start coarse, split
- * later only when a real org needs it. See
- * plans/permissions/capability-layer-and-worker-seat.md §4.
+ * later only when a real org needs it. See plans/permissions/v2/README.md.
  */
 export enum PermissionKey {
-  // mail / tickets
-  ticketsView = 'tickets.view',
-  ticketsReply = 'tickets.reply',
-
   // records / CRM
   recordsView = 'records.view',
   recordsEdit = 'records.edit',
@@ -58,20 +53,6 @@ export interface PermissionMetadata {
 
 /** Single source of truth for all capability keys, labels, groups, and plan links. */
 export const PERMISSION_REGISTRY: PermissionMetadata[] = [
-  // ── Tickets ──
-  {
-    key: PermissionKey.ticketsView,
-    label: 'View Tickets',
-    description: 'See conversations and tickets in accessible inboxes.',
-    group: 'Tickets',
-  },
-  {
-    key: PermissionKey.ticketsReply,
-    label: 'Reply to Tickets',
-    description: 'Send replies and notes on tickets.',
-    group: 'Tickets',
-  },
-
   // ── Records ──
   {
     key: PermissionKey.recordsView,
@@ -229,7 +210,6 @@ export enum Level {
 
 /** Coarse capability area slugs — the level ladder is defined per area. */
 export enum Area {
-  tickets = 'tickets',
   records = 'records',
   recordsLinked = 'recordsLinked',
   workflows = 'workflows',
@@ -271,19 +251,10 @@ export interface AreaMetadata {
 /**
  * Single source of truth for the area→level→keys expansion (§3 table). Toggle
  * areas list a lone `Full` rung; hybrid areas (`dispatchBoard`) simply skip the
- * `Edit` rung. `tickets` has no `Full`/manage key yet (§9.1) so `Full == Edit`.
+ * `Edit` rung. Tickets are governed as an entity def (per-def ResourceAccess on
+ * the `ticket` def, `records` area), not a standalone area.
  */
 export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
-  [Area.tickets]: {
-    area: Area.tickets,
-    label: 'Tickets',
-    description: 'View conversations and reply to tickets.',
-    group: 'Tickets',
-    rungs: [
-      { level: Level.Read, keys: [PermissionKey.ticketsView] },
-      { level: Level.Edit, keys: [PermissionKey.ticketsReply] },
-    ],
-  },
   [Area.records]: {
     area: Area.records,
     label: 'Records',

--- a/packages/ui/src/components/kb/layout/kb-layout.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout.tsx
@@ -41,6 +41,13 @@ interface KBLayoutProps<T extends KBSidebarArticle> {
   onArticleClick?: (articleId: string) => void
   /** When true, drops the `min-h-screen` so the layout sizes to its content (used when embedded inside the admin editor preview). */
   embedded?: boolean
+  /**
+   * Whether the theme provider syncs `data-kb-mode` from the `kb-mode-{id}`
+   * cookie before paint. Defaults to `!embedded` — embedded previews pin the
+   * mode via `mode`, so the pre-paint script is both unwanted and inert (React
+   * never executes client-inserted `<script>` tags).
+   */
+  syncModeFromCookie?: boolean
   /** When true, the `<main>` element owns vertical scroll instead of the document. Required in admin previews where document scroll is unavailable. */
   mainScroll?: boolean
   /** Notified when the in-tree mode toggle flips. Used by apps/web preview to keep its override in sync with cookie writes. */
@@ -59,6 +66,7 @@ export function KBLayout<T extends KBSidebarArticle>({
   embedded = false,
   mainScroll = false,
   onModeChange,
+  syncModeFromCookie,
   children,
 }: KBLayoutProps<T>) {
   const headerNav = parseNavigation(kb.headerNavigation)
@@ -72,7 +80,10 @@ export function KBLayout<T extends KBSidebarArticle>({
       : 'default'
 
   return (
-    <KBThemeProvider kb={kb} mode={effectiveMode}>
+    <KBThemeProvider
+      kb={kb}
+      mode={effectiveMode}
+      syncModeFromCookie={syncModeFromCookie ?? !embedded}>
       <div
         data-slot='kb-layout'
         className={cn(


### PR DESCRIPTION
## Summary
- Tickets previously had their own `Area.tickets`/`PermissionKey.ticketsView`/`ticketsReply` capability path that ran in parallel with the per-def `canViewEntity` gate every other entity list uses — a def-level grant on the `ticket` entity def couldn't unlock it if the coarse `tickets` area was set to `None`.
- Removes the standalone tickets area/keys from the capability registry and the leveled-area grid UI, and routes `EntityRouteLayout` for `tickets` through the same per-def most-specific-wins `canViewEntity` gate as every other entity list.
- Updates `compose-user-capabilities.test.ts` to drop ticket-specific assertions accordingly.
- Adds a `syncModeFromCookie` prop to `KBLayout` so consumers with an externally-pinned mode (e.g. the embedded admin preview) can skip the pre-paint cookie-sync script, which is inert there anyway since React never executes client-inserted `<script>` tags.

## Test plan
- [ ] `pnpm --filter @auxx/lib test compose-user-capabilities`
- [ ] Manually verify a member with `records` area at `None` but a def-level grant on `ticket` can still view tickets
- [ ] Manually verify the embedded KB admin preview still renders in the correct mode