### PR TITLE
feat(permissions): redact relationship values pointing at non-viewable defs

### DIFF
--- a/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
+++ b/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
@@ -8,8 +8,10 @@ import {
   formatToDisplayValue,
   formatToRawValue,
   getInstanceId,
+  getRelationshipRedactedCount,
   type NumberFieldOptions,
   type PhoneFieldOptions,
+  type RecordId,
 } from '@auxx/lib/field-values/client'
 import { type ActorId, isActorId, toActorId } from '@auxx/types/actor'
 import { Badge } from '@auxx/ui/components/badge'
@@ -19,7 +21,7 @@ import { CheckSquare } from 'lucide-react'
 import { useMemo } from 'react'
 import { FileIcon } from '~/components/files/utils/file-icon'
 import { VisualIcon } from '~/components/icons/ui/visual-icon'
-import { ActorBadge, RecordBadge } from '~/components/resources/ui'
+import { ActorBadge, RecordBadge, RestrictedRelationshipChip } from '~/components/resources/ui'
 import { ItemsCellView } from '~/components/ui/items-list-view'
 import { TagsCellView } from '~/components/ui/tags-view'
 import { api } from '~/trpc/react'
@@ -54,20 +56,31 @@ function RelationshipCellContent({
 }) {
   // Extract RecordIds from value using centralized utility
   const recordIds = useMemo(() => extractRelationshipRecordIds(value), [value])
+  // Redaction count (v2 Phase 5 §2) — referenced records the member can't view.
+  const redactedCount = useMemo(() => getRelationshipRedactedCount(value), [value])
 
-  // Map recordIds to simple items for ItemsCellView
-  const items = recordIds.map((recordId) => ({
-    id: getInstanceId(recordId),
-    recordId, // Pass the full RecordId to renderItem
-  }))
+  // Map recordIds to simple items for ItemsCellView, then append the redaction
+  // marker so a `🔒 N restricted` chip renders in the same flow.
+  const items: Array<{ id: string; recordId: RecordId | null; redactedCount?: number }> =
+    recordIds.map((recordId) => ({
+      id: getInstanceId(recordId),
+      recordId, // Pass the full RecordId to renderItem
+    }))
+  if (redactedCount > 0) {
+    items.push({ id: '__redacted__', recordId: null, redactedCount })
+  }
 
   return (
     <ItemsCellView
       items={items}
       isLoading={false} // RecordBadge handles individual loading states
-      renderItem={(item) => (
-        <RecordBadge recordId={item.recordId} link hoverCard={!disableNestedHoverCard} />
-      )}
+      renderItem={(item) =>
+        item.redactedCount ? (
+          <RestrictedRelationshipChip count={item.redactedCount} />
+        ) : (
+          <RecordBadge recordId={item.recordId} link hoverCard={!disableNestedHoverCard} />
+        )
+      }
       maxDisplay={3}
     />
   )

--- a/apps/web/src/components/fields/displays/display-relationship.tsx
+++ b/apps/web/src/components/fields/displays/display-relationship.tsx
@@ -1,17 +1,22 @@
 // apps/web/src/components/fields/displays/display-relationship.tsx
 
-import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import {
+  extractRelationshipRecordIds,
+  getRelationshipRedactedCount,
+} from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import { useMemo } from 'react'
 import { useRelationship } from '~/components/resources'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { RestrictedRelationshipChip } from '~/components/resources/ui/restricted-relationship-chip'
 import { type ItemsListItem, ItemsListView } from '~/components/ui/items-list-view'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 
-/** Relationship item for ItemsListView */
+/** Relationship item for ItemsListView (recordId null = redaction marker). */
 interface RelationshipItem extends ItemsListItem {
-  recordId: RecordId
+  recordId: RecordId | null
+  redactedCount?: number
 }
 
 /**
@@ -24,17 +29,23 @@ export function DisplayRelationship() {
 
   // Extract RecordIds using centralized utility
   const recordIds = useMemo(() => extractRelationshipRecordIds(value), [value])
+  // Redaction count (v2 Phase 5 §2) — referenced records the member can't view.
+  const redactedCount = useMemo(() => getRelationshipRedactedCount(value), [value])
 
   // Hydrate items via global store for copy text
   const { items } = useRelationship(recordIds)
 
-  // Build relationship items for ItemsListView
+  // Build relationship items for ItemsListView, appending the redaction marker.
   const relationshipItems = useMemo<RelationshipItem[]>(() => {
-    return recordIds.map((recordId) => ({
+    const built: RelationshipItem[] = recordIds.map((recordId) => ({
       id: recordId,
       recordId,
     }))
-  }, [recordIds])
+    if (redactedCount > 0) {
+      built.push({ id: '__redacted__', recordId: null, redactedCount })
+    }
+    return built
+  }, [recordIds, redactedCount])
 
   // Build display names for copy value
   const copyText = items
@@ -47,7 +58,16 @@ export function DisplayRelationship() {
       <ItemsListView
         items={relationshipItems}
         emptyContent={<span className='text-muted-foreground'>-</span>}
-        renderItem={(item) => <RecordBadge recordId={item.recordId} />}
+        renderItem={(item) => {
+          // ItemsListView widens items to `T | string | number`; ours are always
+          // RelationshipItem objects — narrow before reading fields.
+          if (typeof item !== 'object') return null
+          return item.redactedCount ? (
+            <RestrictedRelationshipChip count={item.redactedCount} />
+          ) : (
+            <RecordBadge recordId={item.recordId} />
+          )
+        }}
       />
     </DisplayWrapper>
   )

--- a/apps/web/src/components/fields/inputs/relationship-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/relationship-input-field.tsx
@@ -3,6 +3,7 @@
 import {
   extractRelationshipRecordIds,
   getInstanceId,
+  getRelationshipRedactedCount,
   parseRecordId,
   type RecordId,
 } from '@auxx/lib/field-values/client'
@@ -18,6 +19,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { RecordPickerContent } from '~/components/pickers/record-picker'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { getRelationshipStoreState, toRecordId, useResource } from '~/components/resources'
+import { RecordBadge, RestrictedRelationshipChip } from '~/components/resources/ui'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { useFieldNavigationOptional } from '../field-navigation-context'
 import { usePropertyContext } from '../property-provider'
@@ -34,6 +37,7 @@ import { usePropertyContext } from '../property-provider'
 export function RelationshipInputField() {
   const { value, field, commitValue, onBeforeClose, recordId } = usePropertyContext()
   const nav = useFieldNavigationOptional()
+  const { canViewEntity } = useAccess()
 
   const relationship = field.options?.relationship as RelationshipConfig | undefined
   const isSingleSelect = isSingleRelationship(relationship?.relationshipType)
@@ -226,6 +230,26 @@ export function RelationshipInputField() {
 
   if (!relatedEntityDefinitionId) {
     return <span className='text-muted-foreground p-2'>Invalid relationship config</span>
+  }
+
+  // Read-only when the member can't view the target def (v2 Phase 5 §4): the
+  // record picker's search is gated to empty (nothing to pick) and the current
+  // targets are redacted (nothing to identify or remove), so editing is
+  // meaningless. Render the current value display-only instead of the picker.
+  if (!canViewEntity(relatedEntityDefinitionId)) {
+    const redactedCount = getRelationshipRedactedCount(value)
+    const visibleRecordIds = extractRelationshipRecordIds(value)
+    return (
+      <div className='flex flex-wrap items-center gap-1 p-2'>
+        {visibleRecordIds.map((rid) => (
+          <RecordBadge key={rid} recordId={rid} />
+        ))}
+        {redactedCount > 0 && <RestrictedRelationshipChip count={redactedCount} />}
+        {visibleRecordIds.length === 0 && redactedCount === 0 && (
+          <span className='text-muted-foreground'>-</span>
+        )}
+      </div>
+    )
   }
 
   return (

--- a/apps/web/src/components/resources/ui/index.ts
+++ b/apps/web/src/components/resources/ui/index.ts
@@ -11,4 +11,5 @@ export {
 export { RecordHoverCard } from './record-hover-card'
 export { RecordHoverCardField } from './record-hover-card-field'
 export { RecordIcon } from './record-icon'
+export { RestrictedRelationshipChip } from './restricted-relationship-chip'
 export { TicketBadge } from './ticket-badge'

--- a/apps/web/src/components/resources/ui/restricted-relationship-chip.tsx
+++ b/apps/web/src/components/resources/ui/restricted-relationship-chip.tsx
@@ -1,0 +1,38 @@
+// apps/web/src/components/resources/ui/restricted-relationship-chip.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { Lock } from 'lucide-react'
+
+/**
+ * Non-interactive chip standing in for relationship targets the member can't
+ * view (capability layer v2 Phase 5 §2/§3). Their recordIds are stripped
+ * server-side; only the count survives. Deliberately distinct from
+ * `RecordBadge`'s "Unknown" (genuinely not-found/deleted) — this is `no access`,
+ * not `missing` — and carries no link or hover card (there is nothing the member
+ * is allowed to see).
+ *
+ * @param count - Number of referenced records the member can't view.
+ */
+export function RestrictedRelationshipChip({
+  count,
+  className,
+}: {
+  count: number
+  className?: string
+}) {
+  return (
+    <span
+      data-slot='restricted-relationship-chip'
+      aria-label={`${count} restricted`}
+      className={cn(
+        'flex h-5 items-center gap-1 rounded-[5px] px-1.5 text-sm',
+        'cursor-default select-none ring-1 ring-neutral-300 bg-neutral-100 text-neutral-500',
+        'dark:bg-muted dark:text-neutral-400 dark:ring-neutral-800',
+        className
+      )}>
+      <Lock className='size-3 flex-shrink-0' />
+      <span className='truncate'>{count} restricted</span>
+    </span>
+  )
+}

--- a/packages/lib/src/field-values/client.ts
+++ b/packages/lib/src/field-values/client.ts
@@ -51,6 +51,7 @@ export {
   extractRelationshipRecordIds,
   getDefinitionId,
   getInstanceId,
+  getRelationshipRedactedCount,
   isMultiRelationship,
   isRecordId,
   isSingleRelationship,

--- a/packages/lib/src/field-values/converters/relationship.ts
+++ b/packages/lib/src/field-values/converters/relationship.ts
@@ -86,9 +86,20 @@ export const relationshipConverter: FieldValueConverter = {
   /**
    * Convert to raw value (returns the RecordId).
    */
-  toRawValue(value: TypedFieldValue | TypedFieldValueInput | unknown): RelationshipRawValue | null {
+  toRawValue(
+    value: TypedFieldValue | TypedFieldValueInput | unknown
+  ): RelationshipRawValue | { redactedCount: number } | null {
     if (value === null || value === undefined) {
       return null
+    }
+
+    // Redaction marker (v2 Phase 5 §2) — preserve the count through the table
+    // path (formatToRawValue maps each element through here). It survives as
+    // `{ redactedCount }` for the cell renderer. Must precede the recordId
+    // branch below because a marker's recordId is empty.
+    if (typeof value === 'object' && value !== null && 'redactedCount' in value) {
+      const count = (value as { redactedCount?: number }).redactedCount
+      if (typeof count === 'number' && count > 0) return { redactedCount: count }
     }
 
     // Internal format { type: 'relationship', recordId }

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -575,10 +575,49 @@ async function fetchFieldValueResults(
 
     const fieldOptions = fieldOptionsMap.get(fieldId)
     const isMulti = isArrayReturnFieldType(fieldType, fieldOptions)
-    const typedValues = fieldRows.map((row) =>
+
+    // Read enforcement (v2 Phase 5 §2) — a relationship pointing at a def the
+    // member can't view still returns its target recordIds, which the UI can't
+    // hydrate (that path is gated) so they render as broken "Unknown" chips and
+    // leak the referenced ids. Strip the non-viewable referenced rows here, at
+    // the authoritative server value read, so the ids never reach the client.
+    // System-table FK relationships (e.g. thread.inbox) never reach this
+    // FieldValue path — they resolve via the system resolvers and are governed
+    // by mail visibility — so only entity-def relationships are affected.
+    let effectiveRows: typeof fieldRows = fieldRows
+    if (fieldType === FieldTypeEnum.RELATIONSHIP && ctx.capabilities) {
+      const caps = ctx.capabilities
+      effectiveRows = fieldRows.filter(
+        (row) => !row.relatedEntityDefinitionId || caps.canViewEntity(row.relatedEntityDefinitionId)
+      )
+    }
+
+    const typedValues = effectiveRows.map((row) =>
       rowToTypedValue(row as unknown as FieldValueRow, fieldType)
     )
-    const value = isMulti ? typedValues : typedValues[0]!
+
+    // Carry the redaction count (v2 Phase 5 §2) as a trailing marker element so
+    // the renderer can show a `🔒 N restricted` chip. The marker has an empty
+    // recordId → `extractRelationshipRecordIds` skips it (never keyed/hydrated);
+    // only the count survives. redactedCount is 0 for every non-relationship
+    // group (effectiveRows === fieldRows) and when nothing was stripped.
+    const redactedCount = fieldRows.length - effectiveRows.length
+    if (redactedCount > 0) {
+      const base = fieldRows[0]! as unknown as FieldValueRow
+      typedValues.push({
+        id: `${base.id}:redacted`,
+        entityId: base.entityId,
+        fieldId: base.fieldId,
+        sortKey: base.sortKey,
+        createdAt: base.createdAt,
+        updatedAt: base.updatedAt,
+        type: 'relationship',
+        recordId: '' as RecordId,
+        redactedCount,
+      })
+    }
+
+    const value = isMulti ? typedValues : (typedValues[0] ?? null)
 
     // AI marker lives on a single row per (entity, field). Multi-value fields
     // don't carry AI markers today — take the first row's marker for safety.

--- a/packages/lib/src/field-values/index.ts
+++ b/packages/lib/src/field-values/index.ts
@@ -131,6 +131,7 @@ export {
   extractRelationshipRecordIds,
   getDefinitionId,
   getInstanceId,
+  getRelationshipRedactedCount,
   isMultiRelationship,
   isRecordId,
   isRelationshipFieldValue,

--- a/packages/lib/src/field-values/relationship-field.ts
+++ b/packages/lib/src/field-values/relationship-field.ts
@@ -87,6 +87,33 @@ export function extractRelationshipRecordIds(value: unknown): RecordId[] {
   return []
 }
 
+/**
+ * Read the redaction count from a relationship value (capability layer v2 Phase
+ * 5 §2). Returns the number of referenced records the member can't view — their
+ * ids are stripped server-side and replaced by one trailing marker element
+ * carrying `redactedCount`. Returns 0 when there is no redaction.
+ *
+ * Shape-agnostic: works on the raw `RecordId[]` the table cell receives (after
+ * `formatToRawValue`, the marker survives as `{ redactedCount }`) AND on the
+ * `TypedFieldValue[]` the detail view receives (the marker is a relationship
+ * value with an empty `recordId` and `redactedCount`).
+ *
+ * @example
+ * const count = getRelationshipRedactedCount(value)
+ * if (count > 0) render(<RestrictedRelationshipChip count={count} />)
+ */
+export function getRelationshipRedactedCount(value: unknown): number {
+  if (!value) return 0
+  const items = Array.isArray(value) ? value : [value]
+  for (const item of items) {
+    if (item && typeof item === 'object' && 'redactedCount' in item) {
+      const count = (item as { redactedCount?: unknown }).redactedCount
+      if (typeof count === 'number' && count > 0) return count
+    }
+  }
+  return 0
+}
+
 // Re-export from resource-id for convenience
 export {
   getDefinitionId,

--- a/packages/types/field-value/index.ts
+++ b/packages/types/field-value/index.ts
@@ -157,6 +157,15 @@ export interface RelationshipFieldValue extends BaseFieldValue {
   recordId: RecordId
   /** Denormalized for display */
   displayName?: string
+  /**
+   * Redaction marker (capability layer v2 Phase 5 §2). When set, this is NOT a
+   * real referenced record but a synthetic trailing element standing in for
+   * `redactedCount` referenced records the member can't view — their ids are
+   * stripped server-side and never reach the client. `recordId` is empty on a
+   * marker, so `extractRelationshipRecordIds` skips it; the renderers detect the
+   * marker and render a `🔒 N restricted` chip. Absent on real records.
+   */
+  redactedCount?: number
 }
 
 /** Actor value for ACTOR fields - references a user, group, or agent */


### PR DESCRIPTION
## What

Capability layer **v2 Phase 5 (partial)** — the relationship-value redaction half of read-side visibility (`plans/permissions/v2/05-readside-visibility.md` §2/§3/§4).

Closes a read-side leak: a relationship on a def you *can* view (contact) pointing at a def you *can't* (ticket) still returned the target recordIds. The hydrate path is gated, so the UI rendered them as broken **"Unknown"** chips — leaking the count and looking broken.

## Changes

- **§2 server redaction** (`field-value-queries.ts`) — at the authoritative value read (`fetchFieldValueResults`), referenced rows whose target def the member can't view are stripped, so their ids **never reach the client**. The count rides out as one trailing **marker element** (empty recordId, `redactedCount`). Absent caps ⇒ no partition (internal callers unaffected); mail-infra FK relationships never hit this path.
- **marker plumbing** — `redactedCount?` on `RelationshipFieldValue`; shape-agnostic `getRelationshipRedactedCount()` helper (works on the raw `RecordId[]` the table gets *and* the `TypedFieldValue[]` the detail gets); `relationshipConverter.toRawValue` preserves the marker through `formatToRawValue` (the table path). **`extractRelationshipRecordIds` is untouched** — it already skips the marker, so all existing consumers + keying/hydration operate on real recordIds only.
- **§3 renderers** — new `RestrictedRelationshipChip` (🔒 + "N restricted", non-interactive, distinct from "Unknown"), rendered in both the table cell and the detail/drawer displays.
- **§4 read-only input** — the relationship input goes display-only when the target def is non-viewable.

## Behavior

**Dormant until a def is actually restricted** via the Phase 3 access UI — no change for anyone otherwise.

## Not in this PR

- Phase 5 **§1 catalog display filtering** (`viewableResources` selector + repointing the ~7 enumerating surfaces) — a separate, independent follow-on.
- Known minor gap: the strip covers **direct** relationship fields (the documented `contact→tickets` leak); a path *ending* in a relationship-to-restricted-def isn't stripped (paths traversing *through* restricted defs are already dropped at `batchGetValues`).

## Testing

- `tsc` clean for all touched files (remaining errors in `cell-renderers`/`relationship-input-field` are pre-existing baseline errors outside the edits).
- Biome clean.