### PR TITLE
feat(permissions): gate drawer and detail-view cards on a layer-2 key

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-sidebar.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sidebar.tsx
@@ -10,6 +10,7 @@ import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { getTabCardComponent } from '~/components/drawers/drawer-tab-registry'
 import EntityFields from '~/components/fields/entity-fields'
 import DrawerComments from '~/components/global/comments/drawer-comments'
+import { useAccess } from '~/providers/capabilities-provider'
 import { DetailViewCardHeader } from './components/detail-view-card-header'
 import type { DetailViewSidebarProps } from './types'
 
@@ -31,8 +32,11 @@ export function DetailViewSidebar({
   displayName,
 }: DetailViewSidebarProps) {
   const { entityInstanceId } = parseRecordId(recordId)
+  const { can } = useAccess()
   const entityType = config.entityType
-  const sidebarCards = config.sidebarCards
+  // Layer-2 capability gate — drop cards (header included) the viewer lacks the
+  // key for, mirroring the card's router procedure gate (e.g. billing → dispatch).
+  const sidebarCards = config.sidebarCards?.filter((c) => !c.permissionKey || can(c.permissionKey))
 
   const beforeCards = sidebarCards?.filter((c) => c.position === 'before') ?? []
   const afterCards = sidebarCards?.filter((c) => (c.position ?? 'after') === 'after') ?? []

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -52,6 +52,7 @@ import { useRecordLink } from '~/components/resources/utils/get-record-link'
 import { TasksSection } from '~/components/tasks/ui/tasks-section'
 import { TimelineTab } from '~/components/timeline'
 import { safeLocalStorage } from '~/lib/safe-localstorage'
+import { useAccess } from '~/providers/capabilities-provider'
 import {
   useDehydratedOrganizationId,
   useDehydratedUser,
@@ -730,10 +731,14 @@ function TabCards({
   record?: Record<string, unknown>
   readOnly?: boolean
 }) {
+  const { can } = useAccess()
   const cards = drawerConfig.tabCards?.[tab]
     ?.filter((c) => (c.position ?? 'after') === position)
     // Restricted mode drops communication overview cards (e.g. work_order:communications).
     .filter((c) => !readOnly || !isRestrictedDrawerTab(entityType, c.value))
+    // Layer-2 capability gate — hide the whole section (header included) when the
+    // viewer lacks the key, mirroring the card's router procedure gate.
+    .filter((c) => !c.permissionKey || can(c.permissionKey))
   if (!cards?.length) return null
 
   return (

--- a/apps/web/src/components/drawers/cards/contact-billing-overview-card.tsx
+++ b/apps/web/src/components/drawers/cards/contact-billing-overview-card.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/drawers/cards/contact-billing-overview-card.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { ArrowRight, ReceiptText } from 'lucide-react'
@@ -9,14 +10,25 @@ import { normalizeContactBilling } from '~/components/money/billing/types'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 import { useOpenRecord } from '~/components/records/record-drill-panels'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
 /** Allocation-backed customer billing summary shared by the contact drawer and detail sidebar. */
 export function ContactBillingOverviewCard({ recordId }: DrawerTabProps) {
+  const { can } = useAccess()
+  // Money reads are gated on `dispatch.board.view` (mirrors moneyViewProcedure) —
+  // a field seat holds neither board key, so hide the card entirely rather than
+  // firing a query that 403s.
+  const canViewBilling = can(PermissionKey.dispatchBoardView)
   const utils = api.useUtils()
-  const query = api.money.getContactBillingOverview.useQuery({ contactRecordId: recordId })
-  const { values } = useSystemValues(recordId, ['contact_billing_revision'], { autoFetch: true })
+  const query = api.money.getContactBillingOverview.useQuery(
+    { contactRecordId: recordId },
+    { enabled: canViewBilling }
+  )
+  const { values } = useSystemValues(recordId, ['contact_billing_revision'], {
+    autoFetch: canViewBilling,
+  })
   const revision = values.contact_billing_revision
   const previousRevision = useRef(revision)
   useEffect(() => {
@@ -32,6 +44,7 @@ export function ContactBillingOverviewCard({ recordId }: DrawerTabProps) {
   const billing = useMemo(() => normalizeContactBilling(query.data), [query.data])
   const openRecord = useOpenRecord()
 
+  if (!canViewBilling) return null
   if (query.isLoading) return <Skeleton className='h-24 w-full rounded-xl' />
   const empty =
     billing.balanceDue === 0 &&

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -51,7 +51,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       // this contact participates in. Admin-managed; hidden for other roles
       // unless shares already exist.
       { value: 'shared-with', label: 'Shared with' },
-      { value: 'billing', label: 'Billing' },
+      { value: 'billing', label: 'Billing', permissionKey: 'dispatch.board.view' },
     ],
   },
 

--- a/packages/lib/src/resources/registry/drawer-config-types.ts
+++ b/packages/lib/src/resources/registry/drawer-config-types.ts
@@ -42,6 +42,13 @@ export interface DrawerTabCardDefinition {
   /** Position relative to default tab content */
   position?: 'before' | 'after'
   /**
+   * Optional Layer-2 capability gate (a {@link PermissionKey} value, e.g.
+   * `dispatch.board.view`) — the whole card section (header included) is hidden
+   * when the viewer lacks the key, mirroring the router's procedure gate so no
+   * empty section renders before the query 403s.
+   */
+  permissionKey?: string
+  /**
    * Render the card edge-to-edge by cancelling the wrapping Section's horizontal
    * padding (and bottom gap). Use for full-bleed strips like the metrics grid.
    */

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -25,7 +25,14 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       enableDelete: true,
     },
     tabCards: {
-      overview: [{ value: 'billing', label: 'Billing', position: 'after' }],
+      overview: [
+        {
+          value: 'billing',
+          label: 'Billing',
+          position: 'after',
+          permissionKey: 'dispatch.board.view',
+        },
+      ],
     },
   },
 


### PR DESCRIPTION
## What

Adds an optional Layer-2 capability gate to drawer / detail-view **card** definitions. A card is hidden entirely when the viewer lacks the key — instead of rendering an empty section whose query then 403s.

## Changes

- **`drawer-config-types`** — new optional `permissionKey?` on `DrawerTabCardDefinition` (a `PermissionKey` value, e.g. `dispatch.board.view`).
- **`detail-view-sidebar` + `base-entity-drawer` (`TabCards`)** — filter cards by `can(c.permissionKey)`, dropping the whole section (header included). Composes with the existing restricted-mode filter.
- **`contact-billing-overview-card`** — gate on `dispatch.board.view` (mirrors `moneyViewProcedure`): a field seat holds no board key, so skip the query (`enabled`/`autoFetch` off) and render `null` rather than fire a request that 403s.
- **registry** (`detail-view-config` + `drawer-config`) — mark the contact **Billing** tab/card with `permissionKey: 'dispatch.board.view'`.

## Behavior

Purely additive — cards without a `permissionKey` are unaffected. Only the contact Billing card is gated so far.

## Testing

- `tsc` clean for the touched files (4 errors at touched paths confirmed pre-existing baseline: `detail-view-sidebar:153` is the dynamic `<Component>` render and `base-entity-drawer:607-609` are `<DockableDrawer>` prop mismatches — both identical unchanged code on HEAD).
- Biome clean (errors-only).