### PR TITLE
feat(permissions): grantable settings-admin areas + functional settings nav

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/activity-log/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/activity-log/page.tsx
@@ -12,11 +12,10 @@ import { useMemo, useState } from 'react'
 import type { AuditFeedFilters } from '~/components/activity-log/hooks/use-audit-feed'
 import { ActivityLogView } from '~/components/activity-log/ui/activity-log-view'
 import { AuditExportButton } from '~/components/activity-log/ui/audit-export-button'
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import SettingsPage from '~/components/global/settings-page'
-import { useUser } from '~/hooks/use-user'
 
 export default function ActivityLogPage() {
-  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
   const [category, setCategory] = useState<string>('all')
   const [dateRange, setDateRange] = useState<DateRange>(() => ({
     from: startOfDay(addDays(new Date(), -7)),
@@ -38,6 +37,7 @@ export default function ActivityLogPage() {
       description='Security & account events for your organization'
       breadcrumbs={[{ title: 'Settings', href: '/settings' }, { title: 'Account Activity' }]}
       button={<AuditExportButton scope='org' filters={filters} />}>
+      <CapabilityPageGuard permissionKey='auditLog.view' />
       <ActivityLogView
         filters={filters}
         category={category}

--- a/apps/web/src/app/(protected)/app/settings/aiModels/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/aiModels/page.tsx
@@ -1,5 +1,5 @@
 import { AiModelsList } from '~/components/ai/ui/ai-model-list'
-import { AdminPageGuard } from '~/components/global/admin-page-guard'
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import { api } from '~/trpc/server'
 
 type Props = {}
@@ -8,7 +8,7 @@ async function APIPage({}: Props) {
   const unifiedData = await api.aiIntegration.getUnifiedModelData({ includeDefaults: true })
   return (
     <>
-      <AdminPageGuard />
+      <CapabilityPageGuard permissionKey='aiConfig.manage' />
       <AiModelsList initialUnifiedData={unifiedData} />
     </>
   )

--- a/apps/web/src/app/(protected)/app/settings/kopilot/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/kopilot/page.tsx
@@ -1,18 +1,18 @@
 // apps/web/src/app/(protected)/app/settings/kopilot/page.tsx
 'use client'
 
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import SettingsPage from '~/components/global/settings-page'
-import { useUser } from '~/hooks/use-user'
 import { ModelSection } from './_components/model-section'
 import { ToolsetsSection } from './_components/toolsets-section'
 
 export default function KopilotSettingsPage() {
-  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
   return (
     <SettingsPage
       title='Kopilot'
       description='Configure the org-wide Kopilot defaults.'
       breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Kopilot' }]}>
+      <CapabilityPageGuard permissionKey='aiConfig.manage' />
       <div className='space-y-4 sm:space-y-10 p-3 sm:p-6'>
         <ModelSection />
         <ToolsetsSection />

--- a/apps/web/src/app/(protected)/app/settings/members/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/page.tsx
@@ -8,11 +8,11 @@ import { Folder, Plus, Users } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useState } from 'react'
 import { UpgradeBanner } from '~/components/banner/upgrade-banner'
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import SettingsPage from '~/components/global/settings-page'
 import { Tooltip } from '~/components/global/tooltip'
 import { GroupsTab } from '~/components/groups'
 import { MembersTab } from '~/components/members'
-import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import InviteFormPopover from './_components/invite-popover'
@@ -22,7 +22,6 @@ import InviteFormPopover from './_components/invite-popover'
  * tab strip in the sticky sub-header; the tab persists via the `?t=` query param.
  */
 export default function MembersPage() {
-  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
   const [tab, setTab] = useQueryState('t', { defaultValue: 'members' })
   const [createGroupOpen, setCreateGroupOpen] = useState(false)
 
@@ -59,6 +58,7 @@ export default function MembersPage() {
 
   return (
     <Tabs value={tab} onValueChange={setTab} className='flex h-full min-h-0 flex-1 flex-col'>
+      <CapabilityPageGuard permissionKey='members.manage' />
       <SettingsPage
         icon={<Users />}
         title='Members and Groups'

--- a/apps/web/src/app/(protected)/app/settings/plans/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/page.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Receipt } from 'lucide-react'
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
-import { AdminPageGuard } from '~/components/global/admin-page-guard'
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import {
   BillingCycleAlert,
@@ -28,7 +28,7 @@ export default function PlansPage() {
       description='Manage your subscription, plan, and payment details'
       breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Plans' }]}>
       <div className='p-3 sm:p-6 space-y-6 sm:space-y-10'>
-        <AdminPageGuard />
+        <CapabilityPageGuard permissionKey='billing.view' />
         <PlanViewTracker />
         <UpgradeConfetti />
         <DemoBillingCycleGuard>

--- a/apps/web/src/app/(protected)/app/settings/rules/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/rules/page.tsx
@@ -1,18 +1,18 @@
 // apps/web/src/app/(protected)/app/settings/rules/page.tsx
 'use client'
 
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import SettingsPage from '~/components/global/settings-page'
 import { InventorySourcesSection } from '~/components/inventory-bridge/ui/inventory-sources-section'
 import { RecordRulesSection } from '~/components/record-rules/ui/record-rules-section'
-import { useUser } from '~/hooks/use-user'
 
 export default function RulesPage() {
-  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
   return (
     <SettingsPage
       title='Rules'
       description='Automate reactions to record changes — conditions and actions on any field.'
       breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Rules' }]}>
+      <CapabilityPageGuard permissionKey='automationRules.manage' />
       <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
         <RecordRulesSection />
         <InventorySourcesSection />

--- a/apps/web/src/app/(protected)/app/settings/webhooks/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/webhooks/page.tsx
@@ -3,15 +3,14 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Lock } from 'lucide-react'
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage from '~/components/global/settings-page'
 import { WebhookEndpointsSection } from '~/components/webhooks/ui/webhook-endpoints-section'
 import { WebhooksSection } from '~/components/webhooks/ui/webhooks-section'
-import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 export default function WebhooksPage() {
-  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
   const { hasAccess } = useFeatureFlags()
 
   if (!hasAccess(FeatureKey.webhooks)) {
@@ -20,6 +19,7 @@ export default function WebhooksPage() {
         title='Webhooks'
         description='Manage webhooks to integrate with external services.'
         breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Webhooks' }]}>
+        <CapabilityPageGuard permissionKey='integrations.manage' />
         <EmptyState
           icon={Lock}
           title='Webhooks Not Available'
@@ -35,6 +35,7 @@ export default function WebhooksPage() {
       title='Webhooks'
       description='Send Auxx events to external services when something happens.'
       breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Webhooks' }]}>
+      <CapabilityPageGuard permissionKey='integrations.manage' />
       <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
         <WebhooksSection />
         <WebhookEndpointsSection />

--- a/apps/web/src/components/global/capability-page-guard.tsx
+++ b/apps/web/src/components/global/capability-page-guard.tsx
@@ -1,0 +1,26 @@
+// apps/web/src/components/global/capability-page-guard.tsx
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { useAccess } from '~/providers/capabilities-provider'
+
+/**
+ * Drop-in guard for capability-gated settings pages: redirects members who do
+ * NOT hold `permissionKey` to /access-denied. The capability-check twin of
+ * {@link AdminPageGuard} — ADMIN/OWNER hold every key via `ROLE_DEFAULTS`, so
+ * they pass, while a granted non-admin is let through. Renders nothing.
+ */
+export function CapabilityPageGuard({ permissionKey }: { permissionKey: string }) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const { can, isLoading } = useAccess()
+
+  useEffect(() => {
+    // Skip for auth pages (mirrors useUser's role-guard bail-out).
+    if (pathname === '/login' || pathname === '/register' || pathname === '/forgot-password') return
+    if (!isLoading && !can(permissionKey)) router.push('/access-denied')
+  }, [can, isLoading, permissionKey, pathname, router])
+
+  return null
+}

--- a/apps/web/src/components/global/sidebar-secondary.tsx
+++ b/apps/web/src/components/global/sidebar-secondary.tsx
@@ -7,6 +7,7 @@ import type { SidebarProps } from '~/constants/menu'
 import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
 import { useIsMobile } from '~/hooks/use-mobile'
 import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 type Props = { items: SidebarProps[]; baseUrl: string; title: string; current: string | undefined }
@@ -21,6 +22,7 @@ function SidebarSecondary({ items, baseUrl, title, current }: Props) {
   })
   const role = isAdminOrOwner ? 'ADMIN' : 'USER'
   const { hasAccess: hasFeatureAccess } = useFeatureFlags()
+  const { can } = useAccess()
 
   return (
     // <div className='flex h-full min-h-screen w-[16rem] overflow-auto border-r bg-sidebar text-sidebar-foreground'>
@@ -58,6 +60,7 @@ function SidebarSecondary({ items, baseUrl, title, current }: Props) {
                 role,
                 selfHosted,
                 hasFeatureAccess,
+                can,
                 isMobile ? () => setIsDropdownOpen(false) : undefined
               )}
             </React.Fragment>
@@ -75,6 +78,7 @@ function createSidebarGroup(
   role: 'ADMIN' | 'USER',
   selfHosted: boolean,
   hasFeatureAccess: (key: string) => boolean,
+  can: (key: string) => boolean,
   onItemClick?: () => void
 ) {
   const title = group.label
@@ -82,6 +86,10 @@ function createSidebarGroup(
   let items = selfHosted ? group.items?.filter((item) => !item.cloudOnly) : group.items
   items = items?.filter((item) => !item.featureKey || hasFeatureAccess(item.featureKey))
   items = items?.filter((item) => !item.access || item.access === role)
+  // Layer-2 capability filter — ADMIN/OWNER hold every key via ROLE_DEFAULTS, so
+  // no admin bypass is needed here; the resolved capability set already lets them
+  // through. Suppresses a group entirely once all its items are filtered out.
+  items = items?.filter((item) => !item.permissionKey || can(item.permissionKey))
   if (!items || items.length === 0) {
     return null
   }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -235,10 +235,15 @@ export const SIDEBAR_MENU: SidebarProps[] = [
   // { id: 'settings', label: 'Settings', slug: 'settings', icon: <Settings /> },
 ]
 
+// Scheme B (plans/permissions/v2/09-settings-admin-areas.md) — flat functional
+// groups replace the old role-based `Admin` bucket. A group renders if you hold
+// any capability inside it (sidebar suppresses empty groups); each item gates on
+// its own Layer-2 `permissionKey`. Groups set NO group-level `access`.
 export const SETTINGS_MENU: SidebarProps[] = [
+  // Account — personal, always visible (no gate).
   {
-    id: 'settings',
-    label: 'Settings',
+    id: 'account',
+    label: 'Account',
     type: 'header',
     items: [
       { id: 'settings-general', label: 'General', slug: 'general', icon: <Settings /> },
@@ -249,28 +254,111 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'organization',
         icon: <Building2 />,
       },
-      { id: 'settings-snippets', label: 'Snippets', slug: 'snippets', icon: <Tag /> },
-      { id: 'settings-signatures', label: 'Signatures', slug: 'signatures', icon: <Feather /> },
-
-      // {
-      //   id: 'settings-integrations',
-      //   label: 'Integrations',
-      //   slug: 'integrations',
-      //   icon: <Waypoints />,
-      // },
-
+    ],
+  },
+  // Workspace — org membership, access, billing, audit.
+  {
+    id: 'workspace',
+    label: 'Workspace',
+    type: 'header',
+    items: [
       {
-        id: 'settings-apiKeys',
-        label: 'API Keys',
-        slug: 'apiKeys',
-        icon: <ComponentIcon />,
-        featureKey: 'apiAccess',
+        id: 'settings-members',
+        label: 'Members and Groups',
+        slug: 'members',
+        icon: <Users />,
+        permissionKey: 'members.manage',
+      },
+      {
+        id: 'settings-permissions',
+        label: 'Permissions',
+        slug: 'permissions',
+        icon: <ShieldCheck />,
+        // `permissions` area stays adminOnly (granting the grant is an escalation).
+        access: 'ADMIN',
+      },
+      {
+        id: 'admin-plans',
+        label: 'Plans & Billing',
+        slug: 'plans',
+        icon: <Map />,
+        // Read is enough to SEE the billing tab.
+        permissionKey: 'billing.view',
+        cloudOnly: true,
+      },
+      {
+        id: 'settings-activity-log',
+        label: 'Account Activity',
+        slug: 'activity-log',
+        icon: <History />,
+        permissionKey: 'auditLog.view',
+      },
+    ],
+  },
+  // Data & CRM — data model + rules.
+  {
+    id: 'data-crm',
+    label: 'Data & CRM',
+    type: 'header',
+    items: [
+      {
+        id: 'admin-fields',
+        label: 'Custom Entities & Fields',
+        slug: 'custom-fields',
+        icon: <Rows3 />,
+        // TODO(perms v2 doc 09): derive from def-admin (canAdministerDef) — page
+        // lists only the defs the member administers; not yet split out.
+        access: 'ADMIN',
+      },
+      {
+        id: 'admin-tags',
+        label: 'Tags',
+        slug: 'tags',
+        icon: <Tag />,
+        // TODO(perms v2 doc 09): gets its own area later; deferred, stays admin.
+        access: 'ADMIN',
+      },
+      {
+        id: 'admin-import-history',
+        label: 'Import & Export',
+        slug: 'import-history',
+        icon: <Import />,
+        // TODO(perms v2 doc 09): gets its own area later; deferred, stays admin.
+        access: 'ADMIN',
+      },
+      {
+        id: 'admin-rules',
+        label: 'Rules',
+        slug: 'rules',
+        icon: <Zap />,
+        permissionKey: 'automationRules.manage',
+      },
+    ],
+  },
+  // AI — models + Kopilot org defaults.
+  {
+    id: 'ai',
+    label: 'AI',
+    type: 'header',
+    items: [
+      {
+        id: 'settings-aiModels',
+        label: 'AI Models',
+        slug: 'aiModels',
+        icon: <Bot />,
+        permissionKey: 'aiConfig.manage',
+      },
+      {
+        id: 'settings-kopilot',
+        label: 'Kopilot',
+        slug: 'kopilot',
+        icon: <Sparkles />,
+        permissionKey: 'aiConfig.manage',
       },
     ],
   },
   // Channels — member-visible: members connect/manage their own personal email
-  // accounts here; shared-channel actions are gated in-page. Item-level `access`
-  // is enforced by the sidebar (webhooks stays admin-only).
+  // accounts here; shared-channel actions are gated in-page. Inboxes stays admin.
   {
     id: 'channels',
     label: 'Channels',
@@ -282,11 +370,23 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'channels',
         icon: <Waypoints />,
       },
+      { id: 'settings-inboxes', label: 'Inboxes', slug: 'inbox', icon: <Inbox />, access: 'ADMIN' },
+      { id: 'settings-signatures', label: 'Signatures', slug: 'signatures', icon: <Feather /> },
+      { id: 'settings-snippets', label: 'Snippets', slug: 'snippets', icon: <Tag /> },
+    ],
+  },
+  // Integrations — apps/MCP/webhooks + connections + API keys.
+  {
+    id: 'integrations',
+    label: 'Integrations',
+    type: 'header',
+    items: [
       {
         id: 'settings-apps',
         label: 'Apps & MCP',
         slug: 'apps',
         icon: <AppWindow />,
+        permissionKey: 'integrations.manage',
       },
       {
         id: 'settings-connections',
@@ -299,121 +399,15 @@ export const SETTINGS_MENU: SidebarProps[] = [
         label: 'Webhooks',
         slug: 'webhooks',
         icon: <Webhook />,
-        access: 'ADMIN',
+        permissionKey: 'integrations.manage',
         featureKey: 'webhooks',
       },
-
-      // {
-      //   id: 'settings-chat',
-      //   label: 'Chat',
-      //   slug: 'chat',
-      //   icon: <MessageSquare />,
-      // },
-
-      // {
-      //   id: 'integrations-email',
-      //   label: 'Email Setup',
-      //   slug: 'email',
-      //   icon: <Mails />,
-      // },
-
-      // {
-      //   id: 'integrations-google',
-      //   label: 'Google',
-      //   slug: 'google',
-      //   icon: <GoogleIcon />,
-      // },
-    ],
-  },
-  // Admin
-  {
-    id: 'admin',
-    label: 'Admin',
-    type: 'header',
-    access: 'ADMIN',
-    items: [
       {
-        id: 'settings-members',
-        label: 'Members and Groups',
-        slug: 'members',
-        icon: <Users />,
-        access: 'ADMIN',
-      },
-      {
-        id: 'settings-permissions',
-        label: 'Permissions',
-        slug: 'permissions',
-        icon: <ShieldCheck />,
-        access: 'ADMIN',
-      },
-      { id: 'settings-inboxes', label: 'Inboxes', slug: 'inbox', icon: <Inbox />, access: 'ADMIN' },
-
-      // {
-      //   id: 'admin-appearance',
-      //   label: 'Appearance',
-      //   slug: 'admin-appearance',
-      //   icon: <CircleAlert />,
-      //   access: 'ADMIN',
-      // },
-
-      // {
-      //   id: 'admin-notifications',
-      //   label: 'Notifications',
-      //   slug: 'admin-notifications',
-      //   icon: <MessagesSquare />,
-      //   access: 'ADMIN',
-      // },
-      {
-        id: 'settings-aiModels',
-        label: 'AI Models',
-        slug: 'aiModels',
-        icon: <Bot />,
-        access: 'ADMIN',
-      },
-      {
-        id: 'settings-kopilot',
-        label: 'Kopilot',
-        slug: 'kopilot',
-        icon: <Sparkles />,
-        access: 'ADMIN',
-      },
-
-      {
-        id: 'admin-fields',
-        label: 'Custom Entities & Fields',
-        slug: 'custom-fields',
-        icon: <Rows3 />,
-        access: 'ADMIN',
-      },
-      {
-        id: 'admin-rules',
-        label: 'Rules',
-        slug: 'rules',
-        icon: <Zap />,
-        access: 'ADMIN',
-      },
-      {
-        id: 'settings-activity-log',
-        label: 'Account Activity',
-        slug: 'activity-log',
-        icon: <History />,
-        access: 'ADMIN',
-      },
-      { id: 'admin-tags', label: 'Tags', slug: 'tags', icon: <Tag />, access: 'ADMIN' },
-      {
-        id: 'admin-import-history',
-        label: 'Import & Export',
-        slug: 'import-history',
-        icon: <Import />,
-        access: 'ADMIN',
-      },
-      {
-        id: 'admin-plans',
-        label: 'Plans & Billing',
-        slug: 'plans',
-        icon: <Map />,
-        access: 'ADMIN',
-        cloudOnly: true,
+        id: 'settings-apiKeys',
+        label: 'API Keys',
+        slug: 'apiKeys',
+        icon: <ComponentIcon />,
+        featureKey: 'apiAccess',
       },
     ],
   },

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -33,9 +33,14 @@ export enum PermissionKey {
 
   // org administration
   settingsManage = 'settings.manage',
+  billingView = 'billing.view',
   billingManage = 'billing.manage',
   membersManage = 'members.manage',
   permissionsManage = 'permissions.manage',
+  integrationsManage = 'integrations.manage',
+  aiConfigManage = 'aiConfig.manage',
+  automationRulesManage = 'automationRules.manage',
+  auditLogView = 'auditLog.view',
 }
 
 /** Metadata describing a single capability key. Mirrors `FeatureMetadata`. */
@@ -148,18 +153,22 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     adminOnly: true,
   },
   {
+    key: PermissionKey.billingView,
+    label: 'View Billing',
+    description: 'View the plan, usage, and invoices.',
+    group: 'Organization',
+  },
+  {
     key: PermissionKey.billingManage,
     label: 'Manage Billing',
     description: 'View and change the plan, seats, and billing.',
     group: 'Organization',
-    adminOnly: true,
   },
   {
     key: PermissionKey.membersManage,
     label: 'Manage Members',
     description: 'Invite, remove, and change roles/seats of members.',
     group: 'Organization',
-    adminOnly: true,
   },
   {
     key: PermissionKey.permissionsManage,
@@ -168,6 +177,39 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     group: 'Organization',
     featureKey: FeatureKey.granularPermissions,
     adminOnly: true,
+  },
+
+  // ── Integrations ──
+  {
+    key: PermissionKey.integrationsManage,
+    label: 'Manage Integrations',
+    description: 'Install and configure apps, MCP servers, and webhooks.',
+    group: 'Integrations',
+  },
+
+  // ── AI ──
+  {
+    key: PermissionKey.aiConfigManage,
+    label: 'Manage AI Config',
+    description: 'Configure AI models and Kopilot organization defaults.',
+    group: 'AI',
+    featureKey: FeatureKey.kopilot,
+  },
+
+  // ── Automation (rules) ──
+  {
+    key: PermissionKey.automationRulesManage,
+    label: 'Manage Rules',
+    description: 'Create, edit, and delete record automation rules.',
+    group: 'Automation',
+  },
+
+  // ── Organization (audit) ──
+  {
+    key: PermissionKey.auditLogView,
+    label: 'View Account Activity',
+    description: 'View the organization audit log.',
+    group: 'Organization',
   },
 ]
 
@@ -222,6 +264,10 @@ export enum Area {
   billing = 'billing',
   members = 'members',
   permissions = 'permissions',
+  integrations = 'integrations',
+  aiConfig = 'aiConfig',
+  automationRules = 'automationRules',
+  auditLog = 'auditLog',
 }
 
 /** A single rung of an area's ladder — the keys ADDED at (and above) `level`. */
@@ -334,10 +380,12 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
   [Area.billing]: {
     area: Area.billing,
     label: 'Billing',
-    description: 'View and change the plan, seats, and billing.',
+    description: 'View the plan and invoices, or change the plan, seats, and payment method.',
     group: 'Organization',
-    rungs: [{ level: Level.Full, keys: [PermissionKey.billingManage] }],
-    adminOnly: true,
+    rungs: [
+      { level: Level.Read, keys: [PermissionKey.billingView] },
+      { level: Level.Full, keys: [PermissionKey.billingManage] },
+    ],
   },
   [Area.members]: {
     area: Area.members,
@@ -345,7 +393,6 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
     description: 'Invite, remove, and change roles and seats of members.',
     group: 'Organization',
     rungs: [{ level: Level.Full, keys: [PermissionKey.membersManage] }],
-    adminOnly: true,
   },
   [Area.permissions]: {
     area: Area.permissions,
@@ -355,6 +402,35 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
     rungs: [{ level: Level.Full, keys: [PermissionKey.permissionsManage] }],
     adminOnly: true,
     featureKey: FeatureKey.granularPermissions,
+  },
+  [Area.integrations]: {
+    area: Area.integrations,
+    label: 'Integrations',
+    description: 'Install and configure apps, MCP servers, and webhooks.',
+    group: 'Integrations',
+    rungs: [{ level: Level.Full, keys: [PermissionKey.integrationsManage] }],
+  },
+  [Area.aiConfig]: {
+    area: Area.aiConfig,
+    label: 'AI configuration',
+    description: 'Configure AI models and Kopilot organization defaults.',
+    group: 'AI',
+    rungs: [{ level: Level.Full, keys: [PermissionKey.aiConfigManage] }],
+    featureKey: FeatureKey.kopilot,
+  },
+  [Area.automationRules]: {
+    area: Area.automationRules,
+    label: 'Rules',
+    description: 'Create, edit, and delete record automation rules.',
+    group: 'Automation',
+    rungs: [{ level: Level.Full, keys: [PermissionKey.automationRulesManage] }],
+  },
+  [Area.auditLog]: {
+    area: Area.auditLog,
+    label: 'Account activity',
+    description: 'View the organization audit log.',
+    group: 'Organization',
+    rungs: [{ level: Level.Read, keys: [PermissionKey.auditLogView] }],
   },
 }
 

--- a/packages/lib/src/permissions/capabilities/seat-policy.ts
+++ b/packages/lib/src/permissions/capabilities/seat-policy.ts
@@ -1,14 +1,7 @@
 // packages/lib/src/permissions/capabilities/seat-policy.ts
 
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
-import {
-  Area,
-  buildAreaLevels,
-  expandLevelsToKeys,
-  Level,
-  PERMISSION_AREAS,
-  PermissionKey,
-} from './registry'
+import { Area, buildAreaLevels, expandLevelsToKeys, Level, PermissionKey } from './registry'
 
 /**
  * Role defaults + seat ceilings live IN CODE (not the DB), now expressed as
@@ -47,14 +40,33 @@ export const WORKER_SEAT_KEYS: PermissionKey[] = [
 ]
 
 /**
+ * Org-administration areas whose USER default is `None` (delegated, not
+ * default-on). Two are `adminOnly` (never grantable below ADMIN); the rest are
+ * grantable but still OFF by default — a member gets them only via an explicit
+ * grant. This is the source of truth for the USER baseline, NOT `adminOnly`,
+ * because dropping `adminOnly` (to make an area grantable) must NOT flip its
+ * USER default to Full (that would auto-hand every member billing/members).
+ */
+const USER_ADMIN_NONE_AREAS = new Set<Area>([
+  Area.settings,
+  Area.permissions,
+  Area.billing,
+  Area.members,
+  Area.integrations,
+  Area.aiConfig,
+  Area.automationRules,
+  Area.auditLog,
+])
+
+/**
  * What each role gets out of the box, per area (before grants + seat clamp).
  * OWNER/ADMIN short-circuit to Full anyway; USER is Full everywhere except the
- * `adminOnly` areas (settings/billing/members/permissions), which are `None`.
+ * org-administration areas in {@link USER_ADMIN_NONE_AREAS}, which are `None`.
  */
 export const ROLE_DEFAULTS: Record<OrganizationRole, Record<Area, Level>> = {
   OWNER: ALL_FULL,
   ADMIN: ALL_FULL,
-  USER: buildAreaLevels((area) => (PERMISSION_AREAS[area].adminOnly ? Level.None : Level.Full)),
+  USER: buildAreaLevels((area) => (USER_ADMIN_NONE_AREAS.has(area) ? Level.None : Level.Full)),
 }
 
 /**


### PR DESCRIPTION
## What

Breaks the binary admin gate on settings screens (v2 permissions, plan doc 09). Splits the coarse `settings` mega-area into a trimmed set of **grantable Layer-2 areas**, and regroups the settings nav functionally so it's no longer a role-based `Admin` bucket.

A non-admin member can now be granted *just* billing, *just* the rules page, etc. — without becoming a full admin.

## Areas (registry)

- **New areas:** `integrations` (Apps/MCP + Webhooks), `aiConfig` (AI Models + Kopilot, gated on `FeatureKey.kopilot`), `automationRules` (Rules), `auditLog` (Read-only — Account Activity).
- **`billing`:** now `None/Read/Full` (Read = see plan/usage/invoices; Full = change it); `adminOnly` dropped.
- **`members`:** `adminOnly` dropped (grantable to a non-admin).
- **`permissions`:** unchanged — stays `adminOnly` (escalation vector).

### ⚠️ Correctness: USER seat default

Dropping `adminOnly` would otherwise make `ROLE_DEFAULTS.USER` (Full-for-most) hand every member Full billing/member-management. The USER baseline is now driven by an explicit `USER_ADMIN_NONE_AREAS` set (None for all six org-admin areas) instead of the `adminOnly` flag. Verified `effectiveDefault('USER','full')` holds none of the six admin keys; ADMIN holds all; worker holds none. Existing permission tests pass.

## Nav (Scheme B)

`SETTINGS_MENU` regrouped into **Account / Workspace / Data & CRM / AI / Channels / Integrations** — the role-based `Admin` group is gone. Kept today's single-tier sidebar rendering (no new nesting).

- Gated items carry `permissionKey`; `sidebar-secondary.tsx` filters items via `useAccess().can(key)` and auto-hides a group once all its items are filtered out. No admin bypass needed — ADMIN/OWNER hold every key via `ROLE_DEFAULTS`.
- Seven settings pages swap `requireRoles`/`AdminPageGuard` for a new `CapabilityPageGuard` (plans→`billing.view`, members→`members.manage`, aiModels/kopilot→`aiConfig.manage`, rules→`automationRules.manage`, activity-log→`auditLog.view`, webhooks→`integrations.manage`).
- **Deferred (stay admin-gated):** Custom Fields (→ def-admin-derived later), Tags, Import & Export, Inboxes.

## Not in this PR (intentionally deferred)

- **Router enforcement** — the `adminProcedure → permissionProcedure` migration on the backing routers (`aiIntegration`, `record-rules`, `audit-log`, `apps`/`webhook`, billing, member). This PR gates the **UI**; the routers still use `adminProcedure`, so nothing is under-secured. That's the natural follow-up PR.

## Test

- Per-package `tsc --noEmit` (lib + web) clean on touched files.
- `biome check` clean.
- 93 `src/permissions` tests pass (incl. USER/ADMIN/worker default assertions).