### PR TITLE
feat(permissions): enforce settings-admin areas at the router layer

### DIFF
--- a/apps/web/src/server/api/routers/aiIntegration.ts
+++ b/apps/web/src/server/api/routers/aiIntegration.ts
@@ -22,11 +22,17 @@ import {
 } from '@auxx/lib/ai'
 import { ModelType, ProviderType } from '@auxx/lib/ai/providers/types'
 import { onCacheEvent } from '@auxx/lib/cache'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
 import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { adminProcedure, createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
+import {
+  createTRPCRouter,
+  notDemo,
+  permissionProcedure,
+  protectedProcedure,
+} from '~/server/api/trpc'
 
 export const aiIntegrationRouter = createTRPCRouter({
   /**
@@ -62,7 +68,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Toggle model enabled state for organization
    */
-  toggleModel: adminProcedure
+  toggleModel: permissionProcedure(PermissionKey.aiConfigManage)
     .input(z.object({ provider: z.string(), model: z.string(), enabled: z.boolean() }))
     .use(notDemo('configure AI models'))
     .mutation(async ({ input, ctx }) => {
@@ -94,7 +100,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Update model parameter configuration
    */
-  updateModelConfig: adminProcedure
+  updateModelConfig: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({ provider: z.string(), model: z.string(), config: z.record(z.string(), z.any()) })
     )
@@ -150,7 +156,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Save provider configuration with dynamic credentials
    */
-  saveProviderConfiguration: adminProcedure
+  saveProviderConfiguration: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({
         provider: z.string(),
@@ -223,7 +229,7 @@ export const aiIntegrationRouter = createTRPCRouter({
    * Remove custom provider credentials (preserves system quota)
    * Clears credentials and switches to SYSTEM mode
    */
-  deleteProviderConfiguration: adminProcedure
+  deleteProviderConfiguration: permissionProcedure(PermissionKey.aiConfigManage)
     .input(z.object({ provider: z.string() }))
     .use(notDemo('delete AI providers'))
     .mutation(async ({ input, ctx }) => {
@@ -257,7 +263,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Test provider credentials (replaces aiModel.retest)
    */
-  testProviderCredentials: adminProcedure
+  testProviderCredentials: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({ provider: z.string(), credentials: z.record(z.string(), z.any()).optional() })
     )
@@ -294,7 +300,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Set provider as default (replaces aiModel.makeDefault)
    */
-  setDefaultProvider: adminProcedure
+  setDefaultProvider: permissionProcedure(PermissionKey.aiConfigManage)
     .input(z.object({ provider: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const { userId, organizationId } = ctx.session
@@ -331,7 +337,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Make one of a provider's BYO keys the org-level default (used when a model has no pool).
    */
-  setDefaultProviderKey: adminProcedure
+  setDefaultProviderKey: permissionProcedure(PermissionKey.aiConfigManage)
     .input(z.object({ provider: z.string(), credentialId: z.string() }))
     .use(notDemo('set default AI key'))
     .mutation(async ({ input, ctx }) => {
@@ -407,7 +413,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Save custom model configuration (handles both create and update)
    */
-  saveCustomModel: adminProcedure
+  saveCustomModel: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({
         provider: z.string(),
@@ -500,7 +506,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Delete custom model configuration
    */
-  deleteCustomModel: adminProcedure
+  deleteCustomModel: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({
         provider: z.string(),
@@ -560,7 +566,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Set a system default model for a specific model type
    */
-  setSystemModelDefault: adminProcedure
+  setSystemModelDefault: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({
         modelType: z.enum(ModelType),
@@ -585,7 +591,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Remove a system default model for a specific model type
    */
-  removeSystemModelDefault: adminProcedure
+  removeSystemModelDefault: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({
         modelType: z.enum(ModelType),
@@ -645,7 +651,7 @@ export const aiIntegrationRouter = createTRPCRouter({
   /**
    * Switch provider type preference (system vs custom)
    */
-  switchProviderType: adminProcedure
+  switchProviderType: permissionProcedure(PermissionKey.aiConfigManage)
     .input(
       z.object({
         provider: z.string(),

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -15,7 +15,7 @@ import { getCachedAppBySlug, getOrgCache, onCacheEvent } from '@auxx/lib/cache'
 import { mintClientCredentialToken } from '@auxx/lib/connections'
 import { resolveConnectorConfigOptions } from '@auxx/lib/data-connectors'
 import { isAdminOrOwner } from '@auxx/lib/members'
-import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { resolveQuickActionOptions } from '@auxx/lib/quick-actions'
 import { createScopedLogger } from '@auxx/logger'
 import {
@@ -36,7 +36,12 @@ import {
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { adminProcedure, createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
+import {
+  createTRPCRouter,
+  notDemo,
+  permissionProcedure,
+  protectedProcedure,
+} from '~/server/api/trpc'
 
 const logger = createScopedLogger('trpc-apps')
 
@@ -231,7 +236,7 @@ export const appsRouter = createTRPCRouter({
   /**
    * Install an app (requires ADMIN or OWNER role)
    */
-  install: adminProcedure
+  install: permissionProcedure(PermissionKey.integrationsManage)
     .input(
       z
         .object({
@@ -301,7 +306,7 @@ export const appsRouter = createTRPCRouter({
   /**
    * Uninstall an app (requires ADMIN or OWNER role)
    */
-  uninstall: adminProcedure
+  uninstall: permissionProcedure(PermissionKey.integrationsManage)
     .input(
       z
         .object({
@@ -612,7 +617,7 @@ export const appsRouter = createTRPCRouter({
    * Make an org-scoped connection the primary one record actions use when an app has more than
    * one connection — by method or by account (§4a). Org decision → admin only.
    */
-  setDefaultConnection: adminProcedure
+  setDefaultConnection: permissionProcedure(PermissionKey.integrationsManage)
     .input(z.object({ connectionId: z.string() }))
     .use(notDemo('change the primary connection'))
     .mutation(async ({ ctx, input }) => {
@@ -826,7 +831,7 @@ export const appsRouter = createTRPCRouter({
    * Save app settings (from form submission)
    * Validates on server-side before persisting
    */
-  saveSettings: adminProcedure
+  saveSettings: permissionProcedure(PermissionKey.integrationsManage)
     .input(
       z.object({
         appSlug: z.string(),

--- a/apps/web/src/server/api/routers/audit-log.ts
+++ b/apps/web/src/server/api/routers/audit-log.ts
@@ -9,10 +9,11 @@ import {
   listAllAuditEvents,
   listAuditEvents,
 } from '@auxx/lib/audit-log'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { adminProcedure, createTRPCRouter, superAdminProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, permissionProcedure, superAdminProcedure } from '~/server/api/trpc'
 
 const categoryEnum = z.enum(AUDIT_CATEGORIES as unknown as [string, ...string[]])
 const visibilityEnum = z.enum(AUDIT_VISIBILITIES as unknown as [string, ...string[]])
@@ -30,22 +31,24 @@ const listInput = z.object({
 
 export const auditLogRouter = createTRPCRouter({
   /** Org-scoped, customer-visible activity feed (admin/owner only). */
-  list: adminProcedure.input(listInput).query(async ({ ctx, input }) => {
-    const result = await listAuditEvents({
-      organizationId: ctx.session.organizationId,
-      category: input.category as never,
-      actorId: input.actorId,
-      action: input.action,
-      from: input.from,
-      to: input.to,
-      limit: input.limit,
-      cursor: input.cursor,
-    })
-    if (result.isErr()) {
-      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: result.error.message })
-    }
-    return result.value
-  }),
+  list: permissionProcedure(PermissionKey.auditLogView)
+    .input(listInput)
+    .query(async ({ ctx, input }) => {
+      const result = await listAuditEvents({
+        organizationId: ctx.session.organizationId,
+        category: input.category as never,
+        actorId: input.actorId,
+        action: input.action,
+        from: input.from,
+        to: input.to,
+        limit: input.limit,
+        cursor: input.cursor,
+      })
+      if (result.isErr()) {
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: result.error.message })
+      }
+      return result.value
+    }),
 
   /** Cross-org view incl. internal + platform-level rows (super-admin only). */
   listAll: superAdminProcedure
@@ -74,7 +77,7 @@ export const auditLogRouter = createTRPCRouter({
     }),
 
   /** Export the current org's audit rows (admin/owner) — CSV or NDJSON. */
-  export: adminProcedure
+  export: permissionProcedure(PermissionKey.auditLogView)
     .input(
       z.object({
         format: z.enum(['csv', 'ndjson']).optional(),

--- a/apps/web/src/server/api/routers/billing.ts
+++ b/apps/web/src/server/api/routers/billing.ts
@@ -11,16 +11,22 @@ import { isSelfHosted } from '@auxx/deployment'
 import { getAppCache, getOrgCache, onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { BadRequestError } from '@auxx/lib/errors'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { and, desc, eq, isNull, lt } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
+import {
+  createTRPCRouter,
+  notDemo,
+  permissionProcedure,
+  protectedProcedure,
+} from '~/server/api/trpc'
 
 const logger = createScopedLogger('billing-router')
 
-/** Blocks all billing procedures in self-hosted mode */
+/** Cloud-only, member-readable billing procedures (view plan, invoices, etc.). */
 const cloudOnlyProcedure = protectedProcedure.use(async ({ next }) => {
   if (isSelfHosted()) {
     throw new TRPCError({
@@ -30,6 +36,24 @@ const cloudOnlyProcedure = protectedProcedure.use(async ({ next }) => {
   }
   return next()
 })
+
+/**
+ * Cloud-only billing WRITES — additionally require the `billing.manage`
+ * capability. Reads stay open to any member; only state-changing billing ops
+ * (plan changes, payment methods, billing address, portal access) are gated so
+ * a member with `billing` = Read can view but not mutate.
+ */
+const manageBillingProcedure = permissionProcedure(PermissionKey.billingManage).use(
+  async ({ next }) => {
+    if (isSelfHosted()) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Billing is not available in self-hosted mode',
+      })
+    }
+    return next()
+  }
+)
 
 /** Read the cached subscription for the current org, or null */
 async function getCachedSubscription(orgId: string) {
@@ -308,7 +332,7 @@ export const billingRouter = createTRPCRouter({
     }),
 
   // Upgrade/change subscription
-  upgradeSubscription: cloudOnlyProcedure
+  upgradeSubscription: manageBillingProcedure
     .input(
       z.object({
         planName: z.string(),
@@ -351,7 +375,7 @@ export const billingRouter = createTRPCRouter({
     }),
 
   // Cancel subscription
-  cancelSubscription: cloudOnlyProcedure
+  cancelSubscription: manageBillingProcedure
     .use(notDemo('manage billing'))
     .mutation(async ({ ctx }) => {
       try {
@@ -387,7 +411,7 @@ export const billingRouter = createTRPCRouter({
     }),
 
   // Restore canceled subscription
-  restoreSubscription: cloudOnlyProcedure
+  restoreSubscription: manageBillingProcedure
     .use(notDemo('manage billing'))
     .mutation(async ({ ctx }) => {
       try {
@@ -414,7 +438,7 @@ export const billingRouter = createTRPCRouter({
     }),
 
   // Create billing portal session
-  createBillingPortal: cloudOnlyProcedure
+  createBillingPortal: manageBillingProcedure
     .input(
       z.object({
         returnUrl: z.string(),
@@ -489,7 +513,7 @@ export const billingRouter = createTRPCRouter({
   }),
 
   // Update billing address in Stripe (cached stripeCustomerId)
-  updateBillingAddress: cloudOnlyProcedure
+  updateBillingAddress: manageBillingProcedure
     .input(
       z.object({
         email: z.string().email(),
@@ -586,7 +610,7 @@ export const billingRouter = createTRPCRouter({
   }),
 
   // Create setup intent for adding payment method (cached stripeCustomerId)
-  createSetupIntent: cloudOnlyProcedure.mutation(async ({ ctx }) => {
+  createSetupIntent: manageBillingProcedure.mutation(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
       if (!organizationId) {
@@ -612,7 +636,7 @@ export const billingRouter = createTRPCRouter({
   }),
 
   // Set default payment method (cached stripeCustomerId)
-  setDefaultPaymentMethod: cloudOnlyProcedure
+  setDefaultPaymentMethod: manageBillingProcedure
     .input(z.object({ paymentMethodId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       try {
@@ -651,7 +675,7 @@ export const billingRouter = createTRPCRouter({
     }),
 
   // Delete payment method
-  deletePaymentMethod: cloudOnlyProcedure
+  deletePaymentMethod: manageBillingProcedure
     .input(z.object({ paymentMethodId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       try {
@@ -690,7 +714,7 @@ export const billingRouter = createTRPCRouter({
     }),
 
   // Update subscription directly (without Stripe Checkout)
-  updateSubscriptionDirect: cloudOnlyProcedure
+  updateSubscriptionDirect: manageBillingProcedure
     .input(
       z.object({
         planName: z.string(),
@@ -729,7 +753,7 @@ export const billingRouter = createTRPCRouter({
     }),
 
   // Cancel scheduled plan change (cached read, DB write)
-  cancelScheduledChange: cloudOnlyProcedure.mutation(async ({ ctx }) => {
+  cancelScheduledChange: manageBillingProcedure.mutation(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
       if (!organizationId) {

--- a/apps/web/src/server/api/routers/mcp.ts
+++ b/apps/web/src/server/api/routers/mcp.ts
@@ -23,20 +23,22 @@ import { buildCreateOAuthAppUrl } from '@auxx/lib/ai/mcp/templates/client'
 import { getOrgCache } from '@auxx/lib/cache'
 import { RateLimitError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
-import { FeaturePermissionService } from '@auxx/lib/permissions'
+import { FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { z } from 'zod'
-import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
 
 const logger = createScopedLogger('mcp-router')
 
-/** adminProcedure + the `mcp` feature gate — guards every MCP mutation. */
-const mcpAdminProcedure = adminProcedure.use(async ({ ctx, next }) => {
-  await new FeaturePermissionService().requireAccess(ctx.session.organizationId, FeatureKey.mcp)
-  return next()
-})
+/** integrations capability + the `mcp` feature gate — guards every MCP mutation. */
+const mcpAdminProcedure = permissionProcedure(PermissionKey.integrationsManage).use(
+  async ({ ctx, next }) => {
+    await new FeaturePermissionService().requireAccess(ctx.session.organizationId, FeatureKey.mcp)
+    return next()
+  }
+)
 
 /**
  * Fetch the connection-definition data the detail page + edit dialog need: connection-variable

--- a/apps/web/src/server/api/routers/record-rules.ts
+++ b/apps/web/src/server/api/routers/record-rules.ts
@@ -6,6 +6,7 @@
 import type { Database } from '@auxx/database'
 import { getCachedCustomFields, onCacheEvent } from '@auxx/lib/cache'
 import { ForbiddenError } from '@auxx/lib/errors'
+import { PermissionKey } from '@auxx/lib/permissions'
 import {
   createRecordRule,
   deleteRecordRule,
@@ -23,7 +24,7 @@ import {
 import { SIGNAL_KIND_LIST } from '@auxx/lib/signals'
 import { assertWorkflowAppNotSystemOwned } from '@auxx/lib/workflows'
 import { z } from 'zod'
-import { adminProcedure, createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, permissionProcedure, protectedProcedure } from '~/server/api/trpc'
 
 /** Managed rules (inventory-source setup, …) are edit/delete-locked; only `enabled` toggles. */
 async function assertNotManaged(
@@ -156,30 +157,32 @@ export const recordRulesRouter = createTRPCRouter({
       listRecordRuleRuns(ctx.db, ctx.session.organizationId, input.ruleId, input.limit)
     ),
 
-  create: adminProcedure.input(ruleInputSchema).mutation(async ({ ctx, input }) => {
-    const organizationId = ctx.session.organizationId
-    await assertActionsWorkflowsAccessible(ctx.db, organizationId, input.actions)
-    const fieldId = await normalizeFieldRef(organizationId, input)
-    const rule = await createRecordRule(
-      ctx.db,
-      organizationId,
-      {
-        entityDefinitionId: input.entityDefinitionId,
-        fieldId,
-        name: input.name,
-        on: input.on,
-        signalKind: input.signalKind ?? null,
-        condition: input.condition,
-        actions: input.actions as RecordRuleAction[],
-        enabled: input.enabled,
-      },
-      ctx.session.userId
-    )
-    await onCacheEvent('record-rule.changed', { orgId: organizationId })
-    return rule
-  }),
+  create: permissionProcedure(PermissionKey.automationRulesManage)
+    .input(ruleInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const organizationId = ctx.session.organizationId
+      await assertActionsWorkflowsAccessible(ctx.db, organizationId, input.actions)
+      const fieldId = await normalizeFieldRef(organizationId, input)
+      const rule = await createRecordRule(
+        ctx.db,
+        organizationId,
+        {
+          entityDefinitionId: input.entityDefinitionId,
+          fieldId,
+          name: input.name,
+          on: input.on,
+          signalKind: input.signalKind ?? null,
+          condition: input.condition,
+          actions: input.actions as RecordRuleAction[],
+          enabled: input.enabled,
+        },
+        ctx.session.userId
+      )
+      await onCacheEvent('record-rule.changed', { orgId: organizationId })
+      return rule
+    }),
 
-  update: adminProcedure
+  update: permissionProcedure(PermissionKey.automationRulesManage)
     .input(ruleInputSchema.partial().extend({ ruleId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.organizationId
@@ -206,7 +209,7 @@ export const recordRulesRouter = createTRPCRouter({
     }),
 
   /** Quick enable/disable without touching the rest of the rule. */
-  setEnabled: adminProcedure
+  setEnabled: permissionProcedure(PermissionKey.automationRulesManage)
     .input(z.object({ ruleId: z.string().min(1), enabled: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.organizationId
@@ -217,7 +220,7 @@ export const recordRulesRouter = createTRPCRouter({
       return rule
     }),
 
-  delete: adminProcedure
+  delete: permissionProcedure(PermissionKey.automationRulesManage)
     .input(z.object({ ruleId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.organizationId

--- a/apps/web/src/server/api/routers/webhook-endpoint.ts
+++ b/apps/web/src/server/api/routers/webhook-endpoint.ts
@@ -4,6 +4,7 @@
 // table; `create`/`rotateSecret` return the minted secret in plaintext ONCE, every read masks it.
 // All logic lives in the `@auxx/lib/webhooks/webhook-endpoint` service (Drizzle, thrown AuxxErrors).
 
+import { PermissionKey } from '@auxx/lib/permissions'
 import {
   getWebhookEndpointTemplate,
   listWebhookEndpointTemplates,
@@ -17,7 +18,7 @@ import {
   updateWebhookEndpoint,
 } from '@auxx/lib/webhooks/webhook-endpoint'
 import { z } from 'zod'
-import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
 
 const verificationSchema = z.enum(['none', 'token', 'hmac', 'stripe'])
 const signatureEncodingSchema = z.enum(['hex', 'base64'])
@@ -50,7 +51,7 @@ export const webhookEndpointRouter = createTRPCRouter({
     .input(z.object({ id: z.string().min(1) }))
     .query(({ ctx, input }) => getWebhookEndpoint(ctx.db, ctx.session.organizationId, input.id)),
 
-  create: adminProcedure
+  create: permissionProcedure(PermissionKey.integrationsManage)
     .input(
       z.object({
         name: z.string().min(1, 'Name is required'),
@@ -72,7 +73,7 @@ export const webhookEndpointRouter = createTRPCRouter({
       })
     ),
 
-  update: adminProcedure
+  update: permissionProcedure(PermissionKey.integrationsManage)
     .input(
       z.object({
         id: z.string().min(1),
@@ -90,14 +91,14 @@ export const webhookEndpointRouter = createTRPCRouter({
       return updateWebhookEndpoint(ctx.db, ctx.session.organizationId, id, patch)
     }),
 
-  rotateSecret: adminProcedure
+  rotateSecret: permissionProcedure(PermissionKey.integrationsManage)
     // `secret` is the replacement `whsec_…` for stripe endpoints; token/hmac mint a fresh one.
     .input(z.object({ id: z.string().min(1), secret: z.string().optional() }))
     .mutation(({ ctx, input }) =>
       rotateWebhookEndpointSecret(ctx.db, ctx.session.organizationId, input.id, input.secret)
     ),
 
-  delete: adminProcedure
+  delete: permissionProcedure(PermissionKey.integrationsManage)
     .input(z.object({ id: z.string().min(1) }))
     .mutation(({ ctx, input }) =>
       deleteWebhookEndpoint(ctx.db, ctx.session.organizationId, input.id)

--- a/apps/web/src/server/api/routers/webhook.ts
+++ b/apps/web/src/server/api/routers/webhook.ts
@@ -1,8 +1,8 @@
-import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { WebhookService } from '@auxx/lib/webhooks'
 import { WEBHOOK_EVENT_TYPES } from '@auxx/lib/webhooks/types'
 import { z } from 'zod'
-import { adminProcedure, createTRPCRouter, notDemo, protectedProcedure } from '../trpc'
+import { createTRPCRouter, notDemo, permissionProcedure, protectedProcedure } from '../trpc'
 
 // Create a zod schema for validating event types
 const eventTypeSchema = z.enum([...(Object.values(WEBHOOK_EVENT_TYPES) as [string, ...string[]])])
@@ -27,7 +27,7 @@ export const webhookRouters = createTRPCRouter({
     return result.value
   }),
 
-  create: adminProcedure
+  create: permissionProcedure(PermissionKey.integrationsManage)
     .input(
       z.object({
         name: z.string().min(1, 'Name is required'),
@@ -49,7 +49,7 @@ export const webhookRouters = createTRPCRouter({
       return result.unwrap()
     }),
 
-  update: adminProcedure
+  update: permissionProcedure(PermissionKey.integrationsManage)
     .input(
       z.object({
         id: z.string(),
@@ -80,26 +80,28 @@ export const webhookRouters = createTRPCRouter({
       return result.unwrap()
     }),
 
-  delete: adminProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
-    const { organizationId } = ctx.session
+  delete: permissionProcedure(PermissionKey.integrationsManage)
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
 
-    const service = new WebhookService(organizationId, ctx.db)
+      const service = new WebhookService(organizationId, ctx.db)
 
-    // First verify the webhook belongs to the organization
-    const webhookResult = await service.byId({ id: input.id, organizationId })
+      // First verify the webhook belongs to the organization
+      const webhookResult = await service.byId({ id: input.id, organizationId })
 
-    if (!webhookResult.ok) {
-      throw webhookResult.error
-    }
+      if (!webhookResult.ok) {
+        throw webhookResult.error
+      }
 
-    const result = await service.deleteWebhook({ id: input.id })
+      const result = await service.deleteWebhook({ id: input.id })
 
-    if (!result.ok) {
-      throw result.error
-    }
-  }),
+      if (!result.ok) {
+        throw result.error
+      }
+    }),
 
-  test: adminProcedure
+  test: permissionProcedure(PermissionKey.integrationsManage)
     .input(z.object({ url: z.string().url('Must be a valid URL') }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -193,7 +193,6 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     label: 'Manage AI Config',
     description: 'Configure AI models and Kopilot organization defaults.',
     group: 'AI',
-    featureKey: FeatureKey.kopilot,
   },
 
   // ── Automation (rules) ──
@@ -416,7 +415,6 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
     description: 'Configure AI models and Kopilot organization defaults.',
     group: 'AI',
     rungs: [{ level: Level.Full, keys: [PermissionKey.aiConfigManage] }],
-    featureKey: FeatureKey.kopilot,
   },
   [Area.automationRules]: {
     area: Area.automationRules,


### PR DESCRIPTION
## What

The enforcement half of the settings-admin areas (follow-up to #1298). #1298 gated the **UI** (nav + page guards); this wires the backing tRPC routers from coarse `adminProcedure` to the leveled `permissionProcedure(<key>)`, so a granted non-admin actually reaches these endpoints. Admins still bypass — they hold every key via `ROLE_DEFAULTS`.

## Routers migrated

| Router | Endpoints | Key |
|---|---|---|
| `aiIntegration.ts` | 12 config **mutations** (every `.query` read stayed `protectedProcedure`) | `aiConfig.manage` |
| `record-rules.ts` | 4 mutations (`create`/`update`/`setEnabled`/`delete`) | `automationRules.manage` |
| `audit-log.ts` | `list`, `export` | `auditLog.view` |
| `apps.ts` | 4 (`install`/`uninstall`/`setDefaultConnection`/`saveSettings`) | `integrations.manage` |
| `webhook.ts` | 4 | `integrations.manage` |
| `webhook-endpoint.ts` | 4 | `integrations.manage` |
| `mcp.ts` | `mcpAdminProcedure` base (feeds 9 mutations) | `integrations.manage` |

Existing inline feature gates (`mcp`, `webhooks`, `unverifiedApps`) preserved, so no plan behavior changed there.

## Billing — closes a pre-existing hole

`billing.ts` was `protectedProcedure` (via `cloudOnlyProcedure`) throughout with **no admin check anywhere** — any authenticated member could call `upgradeSubscription` / `cancelSubscription` / `deletePaymentMethod` / `createBillingPortal` etc. directly through the API; only the UI page was admin-gated. Added `manageBillingProcedure` (= `permissionProcedure(billing.manage)` + the cloud guard) on the **10 state-changing writes**. All reads stay open, and `calculateSubscriptionPreview` (price preview) + `syncShopifyStatus` (idempotent status refresh that fires on page load) stay open so a `billing = Read` member can view without erroring.

## Registry

Dropped `featureKey: FeatureKey.kopilot` from the `aiConfig` area + flat key. `permissionProcedure` enforces a key's `featureKey` as a plan-AND, and AI-model config must not newly require the Kopilot plan (models power agents/workflows too, and `adminProcedure` imposed no plan gate).

## Deferred

- **Members** — `member.ts` mutations enforce admin inside `MemberService` (`isAdminOrOwner`), so making `members.manage` grantable needs a coordinated service-layer change, not just the procedure swap. Left untouched; tracked as its own follow-up.
- **Kopilot org-defaults** — no dedicated admin-gated router exists for the `settings/kopilot` page's writes (they aren't in a scoped router), so they weren't gated here. Worth locating (likely org-settings) as a follow-up.

## Not touched

`data-connectors.ts` (the `connectors` area isn't built yet), Tags/Inboxes/Import/Custom-Fields routers (deferred settings screens), and all `protectedProcedure`/`superAdminProcedure` endpoints.

## Test

- Per-package `tsc --noEmit` (web + lib): no new errors on any changed line (baselines are broken; verified by grepping the migrated files — remaining hits are pre-existing, e.g. `billing.ts` `ownerEmail` exists on `main` at the same body).
- `biome check` clean.