### PR TITLE
feat(permissions): gate record-write affordances on canEditEntity

### DIFF
--- a/apps/web/src/components/detail-view/components/detail-view-actions.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react'
 import { MergeDialog } from '~/components/merge'
 import { AddToSequenceDialog } from '~/components/sequences/ui/add-to-sequence-dialog'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import type { DetailViewActionsProps } from '../types'
 import { AppRecordActions } from './app-record-actions'
@@ -25,6 +26,11 @@ export function DetailViewActions({
 }: DetailViewActionsProps) {
   const { hasAccess } = useFeatureFlags()
   const sequencesEnabled = hasAccess(FeatureKey.sequences)
+
+  // Per-def write gate (Layer 2 × Layer 3, `edit` floor) — merge/archive/delete/
+  // spam are all record writes, so hide them for a member below Edit on this def.
+  const { canEditEntity } = useAccess()
+  const canEdit = recordId ? canEditEntity(parseRecordId(recordId).entityDefinitionId) : false
   const [confirm, ConfirmDialog] = useConfirm()
   const [isGroupDialogOpen, setIsGroupDialogOpen] = useState(false)
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false)
@@ -95,7 +101,7 @@ export function DetailViewActions({
           </Button>
         )}
 
-        {actions.enableMerge && (
+        {actions.enableMerge && canEdit && (
           <Button variant='outline' size='sm' onClick={() => setMergeDialogOpen(true)}>
             <Merge /> Merge
           </Button>
@@ -113,19 +119,19 @@ export function DetailViewActions({
           </Button>
         )}
 
-        {actions.enableArchive && !isArchived && (
+        {actions.enableArchive && canEdit && !isArchived && (
           <Button variant='outline' size='sm' onClick={handleArchive}>
             <Archive /> Archive
           </Button>
         )}
 
-        {actions.enableSpam && !isSpam && (
+        {actions.enableSpam && canEdit && !isSpam && (
           <Button variant='destructive' size='sm' onClick={handleSpam}>
             <Ban /> Spam
           </Button>
         )}
 
-        {actions.enableDelete && (
+        {actions.enableDelete && canEdit && (
           <Button variant='destructive' size='sm' onClick={handleDelete}>
             <Trash2 /> Delete
           </Button>

--- a/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
@@ -146,12 +146,21 @@ function SelectableTableCellInner<TData>({
 
   const handleDoubleClick = useCallback(
     (e: React.MouseEvent) => {
-      if (!cellSelectionConfig?.enabled || isSystemColumn || !isUpdatable) return
+      if (!cellSelectionConfig?.enabled || cellSelectionConfig.readOnly || isSystemColumn) return
+      if (!isUpdatable) return
       if (!cellRef.current?.contains(e.target as Node)) return
       e.stopPropagation()
       setEditingCell({ rowId, columnId })
     },
-    [cellSelectionConfig?.enabled, isSystemColumn, isUpdatable, rowId, columnId, setEditingCell]
+    [
+      cellSelectionConfig?.enabled,
+      cellSelectionConfig?.readOnly,
+      isSystemColumn,
+      isUpdatable,
+      rowId,
+      columnId,
+      setEditingCell,
+    ]
   )
 
   /** Keyboard navigation handled centrally in useCellNavigation; only handle local edit-shortcuts */
@@ -163,7 +172,7 @@ function SelectableTableCellInner<TData>({
       if (!cellRef.current?.contains(e.target as Node)) return
       switch (e.key) {
         case 'Enter':
-          if (!isUpdatable) return
+          if (!isUpdatable || cellSelectionConfig?.readOnly) return
           e.preventDefault()
           setEditingCell({ rowId, columnId })
           break
@@ -173,7 +182,16 @@ function SelectableTableCellInner<TData>({
           break
       }
     },
-    [isActive, isEditing, isUpdatable, rowId, columnId, setEditingCell, setActiveCell]
+    [
+      isActive,
+      isEditing,
+      isUpdatable,
+      cellSelectionConfig?.readOnly,
+      rowId,
+      columnId,
+      setEditingCell,
+      setActiveCell,
+    ]
   )
 
   const handleCloseEditor = useCallback(() => {

--- a/apps/web/src/components/dynamic-table/components/selection-overlay.tsx
+++ b/apps/web/src/components/dynamic-table/components/selection-overlay.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCellSelectionConfig } from '../context/cell-selection-context'
 import { useTableConfig } from '../context/table-config-context'
 import { useSelectionStore } from '../stores/selection-store'
 import type { CellRange } from '../types'
@@ -154,6 +155,7 @@ function PositionedBox({
  */
 export function SelectionOverlay({ scrollContainerRef }: SelectionOverlayProps) {
   const { tableId } = useTableConfig()
+  const cellSelectionConfig = useCellSelectionConfig()
   const range = useSelectionStore((s) => s.tables[tableId]?.range ?? null)
   const fillDrag = useSelectionStore((s) => s.tables[tableId]?.fillDrag ?? null)
   const copyHighlight = useSelectionStore((s) => s.tables[tableId]?.copyHighlight ?? null)
@@ -181,7 +183,7 @@ export function SelectionOverlay({ scrollContainerRef }: SelectionOverlayProps) 
         <PositionedBox rect={rangeRect} className={overlayClassName} dataSlot='selection-overlay'>
           {/* Single-cell case is owned by ExpandableCell so the handle follows
               an expanded cell's actual right edge instead of the cell rect. */}
-          {!isEditing && !fillDrag && !single && <FillHandle />}
+          {!isEditing && !fillDrag && !single && !cellSelectionConfig?.readOnly && <FillHandle />}
         </PositionedBox>
       )}
 

--- a/apps/web/src/components/dynamic-table/dynamic-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-view.tsx
@@ -120,6 +120,7 @@ function DynamicViewInner<TData extends object>({
     table,
     tableId,
     enabled: cellSelectionConfig?.enabled ?? false,
+    readOnly: cellSelectionConfig?.readOnly,
     scrollContainerRef,
   })
 

--- a/apps/web/src/components/dynamic-table/hooks/use-cell-clipboard.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-cell-clipboard.ts
@@ -183,7 +183,7 @@ export function useCellClipboard({
   }, [config, tableId, indexer])
 
   const handleDelete = useCallback(async () => {
-    if (!config?.clearCells) return
+    if (!config?.clearCells || config.readOnly) return
     const range = useSelectionStore.getState().getRange(tableId)
     if (!range) return
 
@@ -235,7 +235,7 @@ export function useCellClipboard({
 
   const handlePaste = useCallback(
     async (e: ClipboardEvent) => {
-      if (!config?.saveCells) return
+      if (!config?.saveCells || config.readOnly) return
       const range = useSelectionStore.getState().getRange(tableId)
       if (!range) return
 

--- a/apps/web/src/components/dynamic-table/hooks/use-cell-navigation.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-cell-navigation.ts
@@ -12,6 +12,8 @@ interface UseCellNavigationOptions<TData> {
   table: Table<TData>
   tableId: string
   enabled: boolean
+  /** Read-only degrade — arrow/tab/copy navigation stays on, Enter-to-edit off. */
+  readOnly?: boolean
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
@@ -26,6 +28,7 @@ export function useCellNavigation<TData>({
   table,
   tableId,
   enabled,
+  readOnly,
   scrollContainerRef,
 }: UseCellNavigationOptions<TData>) {
   /** Track last known position for resuming navigation after Escape clears */
@@ -178,7 +181,7 @@ export function useCellNavigation<TData>({
           }
           break
         case 'Enter':
-          if (!currentRange) return
+          if (!currentRange || readOnly) return
           e.preventDefault()
           store.setEditingCell(tableId, focusAddr)
           return
@@ -219,7 +222,7 @@ export function useCellNavigation<TData>({
       }
       scrollCellIntoView(newRow.id, newCol.id, direction)
     },
-    [table, tableId, editingCell, enabled, scrollCellIntoView]
+    [table, tableId, editingCell, enabled, readOnly, scrollCellIntoView]
   )
 
   useEffect(() => {

--- a/apps/web/src/components/dynamic-table/hooks/use-fill-drag.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-fill-drag.ts
@@ -145,7 +145,7 @@ export function useFillDrag({
   const commitFill = useCallback(
     async (preview: CellRange, source: CellRange) => {
       const cfg = configRef.current
-      if (!cfg?.saveCells) return
+      if (!cfg?.saveCells || cfg.readOnly) return
 
       const idx = indexerRef.current
       const previewB = rangeBounds(preview)

--- a/apps/web/src/components/dynamic-table/types.ts
+++ b/apps/web/src/components/dynamic-table/types.ts
@@ -98,6 +98,15 @@ export interface CopyCellPayload {
 export interface CellSelectionConfig {
   /** Enable cell selection mode */
   enabled: boolean
+  /**
+   * Read-only degrade — selection + copy stay on, but every WRITE path is
+   * disabled: inline/popover edit triggers, paste, range clear, and fill/AI.
+   * Set per-def from the member's `canEditEntity` gate (Layer 2 × Layer 3), so a
+   * Read-only grantee can still browse/copy a restricted def's records without
+   * click-then-403. Checked only at write *entry points* (all event-driven), so
+   * it adds no per-cell render cost. The server enforces regardless.
+   */
+  readOnly?: boolean
   /** Get field definition for a column (for FieldInput) */
   getFieldDefinition?: (columnId: string) => ResourceField | null
   /** Get cell value for editing */

--- a/apps/web/src/components/merge/merge-dialog.tsx
+++ b/apps/web/src/components/merge/merge-dialog.tsx
@@ -16,6 +16,7 @@ import { Kbd } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRecords, useResource } from '~/components/resources'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { MergePreviewPanel } from './merge-preview-panel'
 import { MergeSourcePanel } from './merge-source-panel'
@@ -56,6 +57,12 @@ export function MergeDialog({
   // Get resource definition for label and fields
   const { resource } = useResource(entityDefinitionId ?? '')
 
+  // Per-def write gate (Layer 2 × Layer 3) — merge is a record write (`edit`
+  // floor). Central guard covering every merge trigger (records view, ticket
+  // row actions, detail view). The server enforces regardless.
+  const { canEditEntity } = useAccess()
+  const canEdit = entityDefinitionId ? canEditEntity(entityDefinitionId) : false
+
   // State: target and sources (sources = everything except target)
   const [targetRecordId, setTargetRecordId] = useState<RecordId>(
     () => initialTargetId ?? baseRecordIds[0]
@@ -63,7 +70,6 @@ export function MergeDialog({
   const [sourceRecordIds, setSourceRecordIds] = useState<RecordId[]>(() =>
     baseRecordIds.filter((id) => id !== (initialTargetId ?? baseRecordIds[0]))
   )
-  console.log('MergeDialog sourceRecordIds:', sourceRecordIds, targetRecordId)
   // Fetch all records for display
   const allRecordIds = useMemo(
     () => [targetRecordId, ...sourceRecordIds].filter(Boolean),
@@ -132,7 +138,7 @@ export function MergeDialog({
 
   /** Execute merge */
   const handleMerge = () => {
-    if (sourceRecordIds.length === 0 || !targetRecordId) return
+    if (sourceRecordIds.length === 0 || !targetRecordId || !canEdit) return
 
     mergeMutation.mutate({
       targetRecordId,
@@ -141,7 +147,7 @@ export function MergeDialog({
   }
 
   const resourceLabel = resource?.label ?? 'Record'
-  const canMerge = sourceRecordIds.length > 0 && targetRecordId
+  const canMerge = sourceRecordIds.length > 0 && targetRecordId && canEdit
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -117,12 +117,14 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
   const entityDefinitionId = resource?.id
   const createHotkey = getCreateHotkey(resource?.apiSlug)
 
-  // Per-def write gate (Layer 2 × Layer 3) — hides the Create affordances for a
-  // member who can view but not edit this def (Read-only grantee / field seat).
-  // The server enforces regardless; this just avoids a click-then-403. Keyed by
+  // Per-def write gate (Layer 2 × Layer 3) — the single `edit`-floor predicate
+  // that governs every record write on this def (create/update/delete/archive/
+  // merge all sit at the same floor, §0.1). Hides those affordances for a member
+  // who can view but not edit this def (Read-only grantee / field seat). The
+  // server enforces regardless; this just avoids a click-then-403. Keyed by
   // `entityDefinitionId` (the defAccess keyspace), not `resource.id`.
   const { canEditEntity } = useAccess()
-  const canCreate = resource ? canEditEntity(resource.entityDefinitionId) : false
+  const canEdit = resource ? canEditEntity(resource.entityDefinitionId) : false
 
   // Imperative handle into DynamicResourceView for refresh + field-value reads
   // (paste/fill needs getValue from the inner syncer).
@@ -278,10 +280,12 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
           resourceFieldId={primaryResourceFieldId}
           rowId={row.id}
           onTitleClick={() => handleOpenDrawer(row)}>
-          <DropdownMenuItem onClick={() => handleOpenEditDialog(row)}>
-            <SquarePen />
-            Edit
-          </DropdownMenuItem>
+          {canEdit && (
+            <DropdownMenuItem onClick={() => handleOpenEditDialog(row)}>
+              <SquarePen />
+              Edit
+            </DropdownMenuItem>
+          )}
           {resource && resourceHasDetailPage(resource) && (
             <DropdownMenuItem
               onClick={() => {
@@ -299,19 +303,24 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
               entityInstanceId: row.id,
             }}
           />
-          <DropdownMenuItem onClick={() => handleArchive(row.id)}>
-            <Archive />
-            Archive
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem variant='destructive' onClick={() => handleDelete(row.id)}>
-            <Trash2 />
-            Delete
-          </DropdownMenuItem>
+          {canEdit && (
+            <>
+              <DropdownMenuItem onClick={() => handleArchive(row.id)}>
+                <Archive />
+                Archive
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant='destructive' onClick={() => handleDelete(row.id)}>
+                <Trash2 />
+                Delete
+              </DropdownMenuItem>
+            </>
+          )}
         </PrimaryFieldCell>
       )
     },
     [
+      canEdit,
       entityDefinitionId,
       primaryResourceFieldId,
       resource,
@@ -339,15 +348,20 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
           setIsWorkflowDialogOpen(true)
         },
       },
-      {
-        label: 'Merge',
-        icon: Combine,
-        variant: 'outline' as const,
-        action: (rows: EntityRow[]) => {
-          setSelectedRowIds(new Set(rows.map((r) => r.id)))
-          setIsMergeDialogOpen(true)
-        },
-      },
+      // Merge is a record write (edit floor) — only for editable defs.
+      ...(canEdit
+        ? [
+            {
+              label: 'Merge',
+              icon: Combine,
+              variant: 'outline' as const,
+              action: (rows: EntityRow[]) => {
+                setSelectedRowIds(new Set(rows.map((r) => r.id)))
+                setIsMergeDialogOpen(true)
+              },
+            },
+          ]
+        : []),
       // Sequences plan §17 — contacts are the only enrollable recipient type.
       ...(isContactResource && sequencesEnabled
         ? [
@@ -362,15 +376,20 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
             },
           ]
         : []),
-      {
-        label: 'Edit',
-        icon: SquarePen,
-        variant: 'outline' as const,
-        action: (rows: EntityRow[]) => {
-          setSelectedRowIds(new Set(rows.map((r) => r.id)))
-          setIsBulkUpdateDialogOpen(true)
-        },
-      },
+      // Bulk edit / archive / delete — record writes, gated on the edit floor.
+      ...(canEdit
+        ? [
+            {
+              label: 'Edit',
+              icon: SquarePen,
+              variant: 'outline' as const,
+              action: (rows: EntityRow[]) => {
+                setSelectedRowIds(new Set(rows.map((r) => r.id)))
+                setIsBulkUpdateDialogOpen(true)
+              },
+            },
+          ]
+        : []),
       {
         label: 'Print…',
         icon: Printer,
@@ -383,20 +402,31 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
           setIsPrintWizardOpen(true)
         },
       },
-      {
-        label: 'Archive',
-        icon: Archive,
-        variant: 'outline' as const,
-        action: (rows: EntityRow[]) => handleBulkArchive(rows),
-      },
-      {
-        label: 'Delete',
-        icon: Trash2,
-        variant: 'destructive' as const,
-        action: (rows: EntityRow[]) => handleBulkDelete(rows),
-      },
+      ...(canEdit
+        ? [
+            {
+              label: 'Archive',
+              icon: Archive,
+              variant: 'outline' as const,
+              action: (rows: EntityRow[]) => handleBulkArchive(rows),
+            },
+            {
+              label: 'Delete',
+              icon: Trash2,
+              variant: 'destructive' as const,
+              action: (rows: EntityRow[]) => handleBulkDelete(rows),
+            },
+          ]
+        : []),
     ],
-    [handleBulkArchive, handleBulkDelete, isContactResource, sequencesEnabled, entityDefinitionId]
+    [
+      canEdit,
+      handleBulkArchive,
+      handleBulkDelete,
+      isContactResource,
+      sequencesEnabled,
+      entityDefinitionId,
+    ]
   )
 
   const { saveBulkMultipleFields } = useSaveFieldValue()
@@ -423,6 +453,9 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
 
     return {
       enabled: true,
+      // Read-only degrade for members below Edit on this def — keeps selection +
+      // copy, disables every inline write path (server enforces regardless).
+      readOnly: !canEdit,
       getFieldDefinition: resolveField,
       getCellValue: (rowId: string, columnId: string) => {
         if (columnId.startsWith('_')) return undefined
@@ -687,7 +720,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
         return { skipped }
       },
     }
-  }, [entityDefinitionId, fieldMap, saveBulkMultipleFields, runAiBulkGenerate])
+  }, [entityDefinitionId, fieldMap, saveBulkMultipleFields, runAiBulkGenerate, canEdit])
 
   const renderSearchBar = useCallback(
     () =>
@@ -704,12 +737,12 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
           icon={Database}
           title={`No ${resource?.plural?.toLowerCase() ?? 'records'} found`}
           description={
-            canCreate
+            canEdit
               ? `Create your first ${resource?.label?.toLowerCase() ?? 'record'}`
               : `No ${resource?.plural?.toLowerCase() ?? 'records'} to show`
           }
           button={
-            canCreate ? (
+            canEdit ? (
               <Button size='sm' variant='outline' onClick={() => setIsCreateDialogOpen(true)}>
                 <Plus />
                 Create {resource?.label ?? 'Record'}
@@ -725,7 +758,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
         />
       </div>
     ),
-    [resource?.plural, resource?.label, createHotkey, setIsCreateDialogOpen, canCreate]
+    [resource?.plural, resource?.label, createHotkey, setIsCreateDialogOpen, canEdit]
   )
 
   // Memoized element — passing a fresh `<EmptyStateComponent />` inline made the
@@ -782,7 +815,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
       dockedPanels={dockedPanels}
       onRowSelectionChange={handleRowSelectionChange}
       onAddNew={
-        canCreate
+        canEdit
           ? (presetValues) => {
               setCreatePresetValues(presetValues)
               setIsCreateDialogOpen(true)
@@ -791,7 +824,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
       }
       entityLabel={resource.label}
       onCardClick={handleOpenDrawer}
-      onAddCard={canCreate ? () => setIsCreateDialogOpen(true) : undefined}
+      onAddCard={canEdit ? () => setIsCreateDialogOpen(true) : undefined}
       selectedKanbanCardIds={selectedKanbanCardIds}
       onSelectedKanbanCardIdsChange={setSelectedKanbanCardIds}
       importHref={`${resolvedBasePath}/import`}
@@ -821,13 +854,15 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
           kind='table'
           label={resource.plural}
           entityDefinitionId={entityDefinitionId}>
-          <CommandAction
-            label={`Create ${resource.label}`}
-            icon={resource.icon ?? 'plus'}
-            keywords='create new add record'
-            priority={10}
-            perform={() => useCommandPaletteStore.getState().openCreate(entityDefinitionId)}
-          />
+          {canEdit && (
+            <CommandAction
+              label={`Create ${resource.label}`}
+              icon={resource.icon ?? 'plus'}
+              keywords='create new add record'
+              priority={10}
+              perform={() => useCommandPaletteStore.getState().openCreate(entityDefinitionId)}
+            />
+          )}
           <CommandAction
             label='Create field'
             icon='columns'
@@ -855,7 +890,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
                 priority={9}
                 perform={() => setIsWorkflowDialogOpen(true)}
               />
-              {selectionCount >= 2 && (
+              {canEdit && selectionCount >= 2 && (
                 <CommandAction
                   label='Merge'
                   subtitle={`${selectionCount} selected`}
@@ -865,30 +900,34 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
                   perform={() => setIsMergeDialogOpen(true)}
                 />
               )}
-              <CommandAction
-                label='Edit'
-                subtitle={`${selectionCount} selected`}
-                icon='edit'
-                keywords='edit bulk update fields'
-                priority={7}
-                perform={() => setIsBulkUpdateDialogOpen(true)}
-              />
-              <CommandAction
-                label='Archive'
-                subtitle={`${selectionCount} selected`}
-                icon='archive'
-                keywords='archive bulk'
-                priority={6}
-                perform={() => handleBulkArchive(selectedRows())}
-              />
-              <CommandAction
-                label='Delete'
-                subtitle={`${selectionCount} selected`}
-                icon='trash'
-                keywords='delete remove bulk'
-                priority={5}
-                perform={() => handleBulkDelete(selectedRows())}
-              />
+              {canEdit && (
+                <>
+                  <CommandAction
+                    label='Edit'
+                    subtitle={`${selectionCount} selected`}
+                    icon='edit'
+                    keywords='edit bulk update fields'
+                    priority={7}
+                    perform={() => setIsBulkUpdateDialogOpen(true)}
+                  />
+                  <CommandAction
+                    label='Archive'
+                    subtitle={`${selectionCount} selected`}
+                    icon='archive'
+                    keywords='archive bulk'
+                    priority={6}
+                    perform={() => handleBulkArchive(selectedRows())}
+                  />
+                  <CommandAction
+                    label='Delete'
+                    subtitle={`${selectionCount} selected`}
+                    icon='trash'
+                    keywords='delete remove bulk'
+                    priority={5}
+                    perform={() => handleBulkDelete(selectedRows())}
+                  />
+                </>
+              )}
             </>
           )}
         </CommandContext>
@@ -896,7 +935,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
 
       <MainPageAction>
         {pageActions}
-        {canCreate && (
+        {canEdit && (
           <Button size='sm' className='h-7 rounded-lg' onClick={() => setIsCreateDialogOpen(true)}>
             <Plus className='size-4' />
             Create {resource.label}

--- a/apps/web/src/components/tickets/ticket-row-actions.tsx
+++ b/apps/web/src/components/tickets/ticket-row-actions.tsx
@@ -34,7 +34,7 @@ export function TicketRowActions({ recordId, status, priority, onActionComplete 
   const { save } = useSaveSystemValues(recordId)
   const [mergeOpen, setMergeOpen] = useState(false)
 
-  const { handleDelete, ConfirmDeleteDialog } = useEntityInstanceOperations({
+  const { canEdit, handleDelete, ConfirmDeleteDialog } = useEntityInstanceOperations({
     entityDefinitionId,
     resourceLabel: 'Ticket',
     resourcePlural: 'Tickets',
@@ -49,6 +49,10 @@ export function TicketRowActions({ recordId, status, priority, onActionComplete 
 
   // Hide dropdown for merged tickets
   if (status === 'MERGED') return null
+
+  // Every action here (status/priority change, merge, delete) is a record write
+  // on the `ticket` def — hide the whole menu for a member below Edit on tickets.
+  if (!canEdit) return null
 
   const handleStatusChange = (newStatus: string) => {
     save({ ticket_status: newStatus })

--- a/apps/web/src/hooks/use-entity-instance-operations.tsx
+++ b/apps/web/src/hooks/use-entity-instance-operations.tsx
@@ -7,6 +7,7 @@ import { useCallback } from 'react'
 import type { EntityRow } from '~/app/(protected)/app/custom/[slug]/_components/types'
 import { useRecordStore } from '~/components/resources/store/record-store'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 
 /**
@@ -47,6 +48,12 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
     onClearSelection,
     onRefetch,
   } = options
+
+  // Per-def write gate (Layer 2 × Layer 3, `edit` floor) — archive/delete are
+  // record writes, so grantees below Edit on this def must not see the
+  // affordances. The server enforces regardless; this just avoids click-then-403.
+  const { canEditEntity } = useAccess()
+  const canEdit = entityDefinitionId ? canEditEntity(entityDefinitionId) : false
 
   // Confirm dialogs
   const [confirmDelete, ConfirmDeleteDialog] = useConfirm()
@@ -243,6 +250,9 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
   )
 
   return {
+    /** Per-def `edit`-floor gate — hide archive/delete affordances when false. */
+    canEdit,
+
     // Single instance operations
     handleArchive,
     handleDelete,


### PR DESCRIPTION
## Summary

Finishes **Phase 4 §11.2** of the leveled record model (`plans/permissions/v2/`). The write path is already enforced server-side (#1290); this closes the last **client-side** gap so write affordances hide/disable per-def for members below **Edit** — a Read-only grantee never clicks into a 403.

Every affordance is gated on the single **`canEditEntity(def)`** edit-floor predicate (create/update/delete/archive/merge all share it, §0.1).

## Affordances gated
- **Records view** — row dropdown (Edit/Archive/Delete), bulk bar (Merge/Edit/Archive/Delete), command-palette write actions, create buttons/empty-state (`canCreate` → unified `canEdit`).
- **Tickets** — the whole row-actions menu (status/priority change, merge, delete are all writes) hides below Edit.
- **Detail view** — Merge/Archive/Delete/Spam buttons.
- **Merge dialog** — self-guards *every* merge trigger (records, tickets, detail view, drawer) in one place; also drops a stray `console.log`.
- The record **drawer** was already gated via `readOnly = !canEditEntity` (#1291) — no change.

## Inline table editing (read-only degrade)
New **`CellSelectionConfig.readOnly`** flag (set from `!canEditEntity`) as the single source of truth. **Selection + Cmd+C copy stay on**; every write path is off: double-click/Enter edit (per-cell **and** range-nav), paste, range clear, fill/AI-fill, and the fill handle.

### Performance (up to ~5000 cells rendered)
- `readOnly` is checked **only at write entry points**, all event-driven — never in render.
- The one hot-path component (`selectable-table-cell.tsx`, ×5000) reads `readOnly` off the `cellSelectionConfig` it **already** subscribes to — no new hook/subscription.
- Config object identity stays **stable** (`canEdit` added to its `useMemo` deps; changes only on a permission change), so a normal render never rebuilds the config or re-renders the grid.

## Verification
- **Typecheck (web):** type-clean — the only surfaced errors are pre-existing baseline issues on untouched code (`ExtendedColumnDef` generics, missing `ColumnFormatting`/`ViewConfig` types, the `readValue`/relationship region). None reference the new gating.
- **Biome:** errors-only lint passes (one pre-existing conditional-hook warning, not in this change).
- Server enforces all these writes regardless; this PR is UX-only (avoids click-then-403).

## Notes
- Also makes README "What's next" item #1 (ticket read-gating) moot-adjacent: tickets already flow through the gated record path after #1300.
- Follow-ups still open per the plan: Phase 4 §9 def-administration (`Full`), agent write tools (§7 open item #1).