### PR TITLE
feat(permissions): def administration (Full) enforcement

### DIFF
--- a/apps/web/src/server/api/routers/customField.ts
+++ b/apps/web/src/server/api/routers/customField.ts
@@ -9,11 +9,11 @@ import {
   relationshipOptionsSchema,
   richReferencePromptSchema,
 } from '@auxx/types/custom-field'
-import { fieldIdSchema, resourceFieldIdSchema } from '@auxx/types/field'
+import { fieldIdSchema, parseResourceFieldId, resourceFieldIdSchema } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '../audit-context'
-import { createTRPCRouter, protectedProcedure } from '../trpc'
+import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
 export const customFieldRouter = createTRPCRouter({
   /**
@@ -54,7 +54,7 @@ export const customFieldRouter = createTRPCRouter({
    * Create a new custom field.
    * For RELATIONSHIP type, pass relationship options to auto-create inverse field.
    */
-  create: protectedProcedure
+  create: capabilityProcedure
     .input(
       z.object({
         name: z.string(),
@@ -76,6 +76,9 @@ export const customFieldRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Def administration (§9.1): managing a def's fields requires `Full`/`admin`
+      // on that def (OWNER/ADMIN or an explicit `admin` type-grant).
+      ctx.capabilities.assertAdministerDef(input.entityDefinitionId)
       const { organizationId, userId } = ctx.session
       const service = new CustomFieldService(organizationId, userId, ctx.db)
       const created = await service.createField(input)
@@ -96,7 +99,7 @@ export const customFieldRouter = createTRPCRouter({
   /**
    * Update a custom field
    */
-  update: protectedProcedure
+  update: capabilityProcedure
     .input(
       z.object({
         resourceFieldId: resourceFieldIdSchema,
@@ -120,6 +123,11 @@ export const customFieldRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Def administration (§9.1): the def is encoded in the resourceFieldId
+      // (`{def}:{field}`); require `Full`/`admin` on it.
+      ctx.capabilities.assertAdministerDef(
+        parseResourceFieldId(input.resourceFieldId).entityDefinitionId
+      )
       const { organizationId, userId } = ctx.session
       const service = new CustomFieldService(organizationId, userId, ctx.db)
       const updated = await service.updateField(input)
@@ -135,9 +143,13 @@ export const customFieldRouter = createTRPCRouter({
   /**
    * Delete a custom field
    */
-  delete: protectedProcedure
+  delete: capabilityProcedure
     .input(z.object({ resourceFieldId: resourceFieldIdSchema }))
     .mutation(async ({ ctx, input }) => {
+      // Def administration (§9.1): require `Full`/`admin` on the field's def.
+      ctx.capabilities.assertAdministerDef(
+        parseResourceFieldId(input.resourceFieldId).entityDefinitionId
+      )
       const { organizationId, userId } = ctx.session
       const service = new CustomFieldService(organizationId, userId, ctx.db)
       const deleted = await service.deleteField(input.resourceFieldId)

--- a/apps/web/src/server/api/routers/entityDefinition.ts
+++ b/apps/web/src/server/api/routers/entityDefinition.ts
@@ -18,7 +18,7 @@ import { checkSlugExists } from '@auxx/services/entity-definitions'
 import { and, count, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '../audit-context'
-import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
 export const entityDefinitionRouter = createTRPCRouter({
   /**
@@ -128,8 +128,12 @@ export const entityDefinitionRouter = createTRPCRouter({
   /**
    * Update an entity definition
    * Only allows updating: icon, singular, plural, archivedAt
+   *
+   * Def administration (§9.1): requires `Full`/`admin` on this def — OWNER/ADMIN
+   * or an explicit `admin` type-grant. Was `protectedProcedure` (any member could
+   * rename/re-icon any def); this closes that hole.
    */
-  update: protectedProcedure
+  update: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -137,6 +141,7 @@ export const entityDefinitionRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertAdministerDef(input.id)
       const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
       const updated = await service.update(input.id, input.data)
       await recordAuditFromCtx(ctx, {
@@ -149,51 +154,62 @@ export const entityDefinitionRouter = createTRPCRouter({
     }),
 
   /**
-   * Archive an entity definition (soft delete). Admin/owner only — removing an
-   * entity type (even reversibly) is an org-wide destructive action.
+   * Archive an entity definition (soft delete). Def administration (§9.1):
+   * OWNER/ADMIN or a def-`admin` grantee of this def (full delegation).
    */
-  archive: adminProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
-    const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
-    const archived = await service.archive(input.id)
-    await recordAuditFromCtx(ctx, {
-      category: 'settings',
-      action: 'entityDef.archived',
-      targetType: 'EntityDefinition',
-      targetId: input.id,
-    })
-    return archived
-  }),
+  archive: capabilityProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertAdministerDef(input.id)
+      const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
+      const archived = await service.archive(input.id)
+      await recordAuditFromCtx(ctx, {
+        category: 'settings',
+        action: 'entityDef.archived',
+        targetType: 'EntityDefinition',
+        targetId: input.id,
+      })
+      return archived
+    }),
 
   /**
-   * Restore an archived entity definition. Admin/owner only (pairs with archive).
+   * Restore an archived entity definition (pairs with archive). Def
+   * administration (§9.1): OWNER/ADMIN or a def-`admin` grantee of this def.
    */
-  restore: adminProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
-    const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
-    const restored = await service.restore(input.id)
-    await recordAuditFromCtx(ctx, {
-      category: 'settings',
-      action: 'entityDef.restored',
-      targetType: 'EntityDefinition',
-      targetId: input.id,
-    })
-    return restored
-  }),
+  restore: capabilityProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertAdministerDef(input.id)
+      const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
+      const restored = await service.restore(input.id)
+      await recordAuditFromCtx(ctx, {
+        category: 'settings',
+        action: 'entityDef.restored',
+        targetType: 'EntityDefinition',
+        targetId: input.id,
+      })
+      return restored
+    }),
 
   /**
    * Permanently delete an entity definition (with relationship + connector
-   * teardown). Admin/owner only — this is irreversible and org-wide.
+   * teardown) — irreversible and org-wide. Def administration (§9.1): OWNER/ADMIN
+   * or a def-`admin` grantee of this def (full delegation, user decision 2026-07-23).
    */
-  delete: adminProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
-    const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
-    const deleted = await service.delete(input.id)
-    await recordAuditFromCtx(ctx, {
-      category: 'settings',
-      action: 'entityDef.deleted',
-      targetType: 'EntityDefinition',
-      targetId: input.id,
-    })
-    return deleted
-  }),
+  delete: capabilityProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertAdministerDef(input.id)
+      const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
+      const deleted = await service.delete(input.id)
+      await recordAuditFromCtx(ctx, {
+        category: 'settings',
+        action: 'entityDef.deleted',
+        targetType: 'EntityDefinition',
+        targetId: input.id,
+      })
+      return deleted
+    }),
 
   /**
    * List all available entity templates (lightweight, no field details)

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -2,6 +2,7 @@
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import { isAdminOrOwner } from '@auxx/lib/members'
+import { getCapabilities } from '@auxx/lib/permissions'
 import type { ResourceAccessContext } from '@auxx/lib/resource-access'
 import {
   assertCanManageMailSharing,
@@ -44,10 +45,15 @@ function toContext(ctx: {
 /**
  * Authorization for TYPE-level (def-wide) ResourceAccess reads/writes. Mail-infra
  * defs keep their mail-sharing authorization (inbox managers etc.); every other
- * def — the entity-def Access UI surface (capability layer v2 phase 3) — is
- * strictly admin/owner-only. Enforced at the endpoint independently of the page's
- * role guard (defense in depth: a non-admin must not self-grant def access via a
- * raw call).
+ * def — the entity-def Access UI surface (capability layer v2 phase 3) — requires
+ * **def administration** on that exact def: OWNER/ADMIN, or a def-`admin` grantee
+ * of this def (§9.1/§9.2 — delegating the Access tab). Enforced at the endpoint
+ * independently of the page's role guard (defense in depth: a non-admin must not
+ * self-grant def access via a raw call).
+ *
+ * `canAdministerDef` is scoped to the exact `entityDefinitionId`, so a def-`admin`
+ * grantee can only manage the Access tab of the def(s) they administer — never
+ * another def, and never an org-level permission (§9.3 self-escalation guard).
  */
 async function assertCanManageTypeAccess(
   ctx: { db: any; session: { organizationId: string; userId: string } },
@@ -57,11 +63,11 @@ async function assertCanManageTypeAccess(
     await assertCanManageMailTypeAccess(toContext(ctx), entityDefinitionId)
     return
   }
-  const allowed = await isAdminOrOwner(ctx.session.organizationId, ctx.session.userId)
-  if (!allowed) {
+  const capabilities = await getCapabilities(ctx.session.userId, ctx.session.organizationId)
+  if (!capabilities.canAdministerDef(entityDefinitionId)) {
     throw new TRPCError({
       code: 'FORBIDDEN',
-      message: 'You must be an admin or owner to manage type-level access',
+      message: 'You must be able to administer this entity to manage its type-level access',
     })
   }
 }

--- a/packages/lib/src/permissions/capabilities/capability-set-administer.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-administer.test.ts
@@ -1,0 +1,117 @@
+// packages/lib/src/permissions/capabilities/capability-set-administer.test.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import type { SeatType } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { CapabilitySet } from './capability-set'
+import { PermissionKey } from './registry'
+
+/**
+ * Def-administration enforcement (v2 phase 4 §9.1): `canAdministerDef` gates the
+ * `Full`/`admin` rung — managing a def's fields, its access, its metadata, and
+ * deleting the def. Unlike record writes, it does NOT flow from the base records
+ * level: only an explicit `admin` type-grant (or OWNER/ADMIN) confers it.
+ */
+
+const defIdToDefinitionId = (id: string) =>
+  id === 'invoice' || id === 'invoices' ? 'invoice-def' : id
+
+const build = (opts: {
+  keys?: PermissionKey[]
+  defAccess?: Record<string, ResourcePermission>
+  restricted?: string[]
+  role?: 'OWNER' | 'ADMIN' | 'USER'
+  seatType?: SeatType
+}) =>
+  new CapabilitySet(
+    new Set(opts.keys ?? [PermissionKey.recordsView, PermissionKey.recordsEdit]),
+    opts.defAccess ?? {},
+    opts.role ?? 'USER',
+    opts.seatType ?? 'full',
+    (id) => id,
+    new Set(opts.restricted ?? []),
+    defIdToDefinitionId
+  )
+
+const READ_WRITE = [PermissionKey.recordsView, PermissionKey.recordsEdit]
+
+describe('CapabilitySet.canAdministerDef (Full/admin rung, §9.1)', () => {
+  it('explicit def `admin` grant → can administer', () => {
+    const caps = build({
+      keys: [],
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+    })
+    expect(caps.canAdministerDef('invoice-def')).toBe(true)
+    // slug form resolves to the same canonical def.
+    expect(caps.canAdministerDef('invoice')).toBe(true)
+  })
+
+  it('base Full (records.edit) does NOT confer def-admin — it edits records, not defs', () => {
+    // Unrestricted def, read-write base: can edit records but never administer.
+    expect(build({ keys: READ_WRITE }).canAdministerDef('contact-def')).toBe(false)
+  })
+
+  it('explicit def `edit` / `view` grant → cannot administer', () => {
+    expect(
+      build({
+        restricted: ['invoice-def'],
+        defAccess: { 'invoice-def': 'edit' },
+      }).canAdministerDef('invoice-def')
+    ).toBe(false)
+    expect(
+      build({
+        restricted: ['invoice-def'],
+        defAccess: { 'invoice-def': 'view' },
+      }).canAdministerDef('invoice-def')
+    ).toBe(false)
+  })
+
+  it('OWNER/ADMIN → can administer any def regardless of grant', () => {
+    expect(build({ role: 'ADMIN', keys: [], defAccess: {} }).canAdministerDef('invoice-def')).toBe(
+      true
+    )
+    expect(build({ role: 'OWNER', keys: [], defAccess: {} }).canAdministerDef('invoice-def')).toBe(
+      true
+    )
+  })
+
+  it('worker seat (records ceiling None) → never administers, even at def grant admin', () => {
+    const worker = build({
+      seatType: 'worker',
+      keys: [PermissionKey.recordsViewLinked],
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+    })
+    expect(worker.canAdministerDef('invoice-def')).toBe(false)
+  })
+
+  it('scoped to the exact def — an `admin` grant on one def does not administer another', () => {
+    const caps = build({
+      restricted: ['invoice-def', 'salary-def'],
+      defAccess: { 'invoice-def': 'admin' },
+    })
+    expect(caps.canAdministerDef('invoice-def')).toBe(true)
+    expect(caps.canAdministerDef('salary-def')).toBe(false)
+    expect(caps.canAdministerDef('contact-def')).toBe(false)
+  })
+})
+
+describe('CapabilitySet.assertAdministerDef', () => {
+  it('throws when the member cannot administer the def', () => {
+    const caps = build({
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'edit' },
+    })
+    expect(() => caps.assertAdministerDef('invoice-def')).toThrow()
+  })
+
+  it('does not throw for a def-`admin` grantee', () => {
+    const caps = build({
+      keys: [],
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+    })
+    expect(() => caps.assertAdministerDef('invoice-def')).not.toThrow()
+  })
+})

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -5,6 +5,7 @@ import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { ForbiddenError } from '../../errors'
 import {
   type ClientCapabilities,
+  canAdministerRecord,
   canEditRecord,
   canViewRecord,
   NON_RECORD_DEF_SLUGS,
@@ -219,6 +220,26 @@ export class CapabilitySet {
    */
   viewAccessFor(entityDefId: string): ResourcePermission | undefined {
     return this.defAccess[this.defIdToDefinitionId(entityDefId)]
+  }
+
+  /**
+   * Whether the member may ADMINISTER the definition itself (§9.1) — manage its
+   * fields, its access (the Access tab), its metadata, and delete/archive the
+   * def. The `Full`/`admin` rung: a scoped delegation of org-admin for one def.
+   *
+   * Unlike {@link canEditEntity}, this does NOT flow from the base records level
+   * — only an explicit `admin` type-grant (or OWNER/ADMIN) confers it. Worker
+   * seats never administer. Scoped to the exact def, so a def-admin grantee can
+   * only administer the def(s) they were granted (self-escalation guard). Zero I/O.
+   */
+  canAdministerDef(entityDefId: string): boolean {
+    return canAdministerRecord(this.resolved(), this.defIdToDefinitionId(entityDefId))
+  }
+
+  /** {@link canAdministerDef} as a throwing guard (403). */
+  assertAdministerDef(entityDefId: string): void {
+    if (this.canAdministerDef(entityDefId)) return
+    throw new ForbiddenError("You don't have permission to administer this definition.")
   }
 
   /** The capability key required to write the given RecordId-def part. */

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -107,6 +107,27 @@ export function canEditRecord(caps: ResolvedRecordAccess, entityDefinitionId: st
 }
 
 /**
+ * Def-ADMINISTRATION gate (§9.1) — whether the member may administer the
+ * DEFINITION itself: manage its fields, its access (the Access tab), its
+ * metadata (name/icon/description), and delete/archive the def. This is the
+ * `admin`/`Full` rung — a scoped delegation of org-admin for one def.
+ *
+ * Unlike {@link canViewRecord}/{@link canEditRecord}, def administration does
+ * NOT flow from the base records level: a base `Full` member edits *records*,
+ * never *definitions*. Only an explicit type-level grant of exactly `admin`
+ * (or OWNER/ADMIN) confers it — so it reads the RAW `defAccess` grant, not
+ * `effectiveRecordLevel`. Worker seats (records ceiling None) never administer.
+ */
+export function canAdministerRecord(
+  caps: ResolvedRecordAccess,
+  entityDefinitionId: string
+): boolean {
+  if (caps.role === 'OWNER' || caps.role === 'ADMIN') return true
+  if (SEAT_CEILINGS[caps.seatType][Area.records] === Level.None) return false
+  return caps.defAccess[entityDefinitionId] === ResourcePermission.admin
+}
+
+/**
  * Serializable snapshot of a member's record-access inputs — the wire shape sent
  * to the client (dehydrated seed + `permissions.myCapabilities`). Arrays instead
  * of Sets so it is JSON-safe; the client rebuilds a {@link ResolvedRecordAccess}.


### PR DESCRIPTION
## What

Enforces the **Full/admin def rung** (perms v2 [doc 04 §9](plans/permissions/v2/04-writepath-enforcement.md)). A def-`admin` grantee — not just an org admin — can now administer a single entity definition: manage its fields, its Access tab, its metadata, and delete/archive the def. This is a scoped delegation of org-admin for that one def, and unblocks table-view gating (#7, which depends on `canAdministerDef`).

## The primitive

`canAdministerDef(defId)` / `assertAdministerDef(defId)` on `CapabilitySet`, backed by client-safe `canAdministerRecord()` in `entity-access.ts`:

- `OWNER/ADMIN` **or** an explicit **raw** `admin` type-grant on that def.
- Worker-seat clamped (a field seat never administers).
- Does **NOT** flow from the base records level — base `Full` edits *records*, never *definitions*. So it reads the raw `defAccess` grant, not `effectiveRecordLevel`.
- Scoped to the exact def → the §9.3 self-escalation guard (a def-admin can only administer the def(s) they were granted).

## Router re-gates

| Surface | Before | After |
|---|---|---|
| `entityDefinition.update` | `protectedProcedure` (ungated — **any member could rename/re-icon any def**) | `capabilityProcedure` + `assertAdministerDef` |
| `entityDefinition.archive/restore/delete` | `adminProcedure` | def-admin (full delegation) |
| `customField.create/update/delete` | `protectedProcedure` | `assertAdministerDef` (update/delete parse the def from `resourceFieldId`) |
| `resourceAccess` type-access guard | org-admin-only | def-admin of that exact def (mail carve-out kept; `allTypeAccess` stays admin-only) |

Closes the `entityDefinition.update` hole as a side effect (same spirit as #1290 closing the `record.create` hole).

## Decision

Delete/archive-the-def is **fully delegated** to def-`admin` grantees (per owner decision 2026-07-23) rather than held at org-admin.

## Scope / follow-ons

- **Server-only enforcement; UI degrades** — matches the Phase-4 stance. A client `canAdministerDef` helper (mirroring #1291's `canEditEntity`) is a small follow-on and is the prerequisite for #7 table-view gating.

## Test plan

- [x] 8 new unit tests for `canAdministerDef`/`assertAdministerDef` (base Full ≠ def-admin; explicit `admin` grant confers; OWNER/ADMIN bypass; worker never; per-def scope). 21/21 pass in the edit+administer suites.
- [x] Typecheck (lib + web) — no new errors on changed files.