### PR TITLE
feat(permissions): files L2 area (None/Read/Full) enforcement + UI gating

### DIFF
--- a/apps/web/src/app/(protected)/app/files/page.tsx
+++ b/apps/web/src/app/(protected)/app/files/page.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/app/(protected)/app/files/page.tsx
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -17,6 +17,7 @@ import { FileDetailDrawer } from '~/components/files/file-detail-drawer'
 import { type FileItem, useFileSystemStore } from '~/components/files/files-store'
 import { EmptyState } from '~/components/global/empty-state'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 function FilesPageContent() {
@@ -118,6 +119,7 @@ function FilesPageContent() {
 
 export default function FilesPage() {
   const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
 
   if (!hasAccess(FeatureKey.files)) {
     return (
@@ -132,6 +134,27 @@ export default function FilesPage() {
             icon={Lock}
             title='Files Not Available'
             description='Upgrade your plan to access file management.'
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  // Layer-2 permission gate: the member holds the plan but not `files.view`.
+  if (!can(PermissionKey.filesView)) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Files' href='/app/files' />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            icon={Lock}
+            title='No Access to Files'
+            description="You don't have permission to view files. Ask an admin for access."
             button={<div className='h-12' />}
           />
         </MainPageContent>

--- a/apps/web/src/components/files/file-detail-drawer.tsx
+++ b/apps/web/src/components/files/file-detail-drawer.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { CardContent, CardHeader, CardTitle } from '@auxx/ui/components/card'
@@ -38,6 +39,7 @@ import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { AttachmentPreview } from '../attachments/attachment-preview'
@@ -69,6 +71,10 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
   const isDocked = useEffectiveDockState()
   const dockedWidth = useDockStore((state) => state.dockedWidth)
   const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+
+  // Layer-2 write gate — rename/delete require `files.manage` (Full).
+  const { can } = useAccess()
+  const canManageFiles = can(PermissionKey.filesManage)
 
   const [confirm, ConfirmDialog] = useConfirm()
   const [editingName, setEditingName] = useState(file.name || '')
@@ -306,17 +312,19 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
           priority={5}
           perform={copyId}
         />
-        <CommandAction
-          label='Delete'
-          icon='trash'
-          keywords='delete remove'
-          priority={1}
-          disabled={file.isUploading}
-          perform={() => {
-            closePalette()
-            void handleDelete()
-          }}
-        />
+        {canManageFiles && (
+          <CommandAction
+            label='Delete'
+            icon='trash'
+            keywords='delete remove'
+            priority={1}
+            disabled={file.isUploading}
+            perform={() => {
+              closePalette()
+              void handleDelete()
+            }}
+          />
+        )}
       </CommandContext>
       <DockableDrawer
         open={true}
@@ -339,6 +347,7 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
                 onBlur={handleNameBlur}
                 onKeyDown={handleNameKeyDown}
                 placeholder='Enter name'
+                readOnly={!canManageFiles}
                 disabled={isRenaming || renameItem.isPending}
                 className={cn(
                   'mr-2 h-7 min-w-0 w-full appearance-none rounded-md border bg-transparent px-1 outline-none',
@@ -380,15 +389,19 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
                       <Download />
                       Download
                     </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={handleDelete}
-                      disabled={file.isUploading}
-                      variant='destructive'>
-                      <Trash2 />
-                      Delete
-                      <KeyboardShortcut shortcut='Del' />
-                    </DropdownMenuItem>
+                    {canManageFiles && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={handleDelete}
+                          disabled={file.isUploading}
+                          variant='destructive'>
+                          <Trash2 />
+                          Delete
+                          <KeyboardShortcut shortcut='Del' />
+                        </DropdownMenuItem>
+                      </>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
                 <DockToggleButton />

--- a/apps/web/src/components/files/files-management.tsx
+++ b/apps/web/src/components/files/files-management.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { Kbd } from '@auxx/ui/components/kbd'
 import { toastSuccess } from '@auxx/ui/components/toast'
@@ -24,6 +25,7 @@ import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
 import MailThreadItemDragOverlay from '~/components/mail/mail-thread-item-drag-overlay'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { CreateFolderDialog } from './create-folder-dialog'
 import { createFileColumns } from './file-columns'
 import { FileDetailDrawer } from './file-detail-drawer'
@@ -141,12 +143,17 @@ export function FilesManagement({
     return hierarchicalItems
   }, [mode, hierarchicalItems, storeItemsById.size])
 
+  // Layer-2 write gate — upload/new-folder/delete/rename/move all require
+  // `files.manage` (Full). Read members get a browse-only view.
+  const { can } = useAccess()
+  const canManageFiles = can(PermissionKey.filesManage)
+
   // Compute default values based on mode
   const isManagementMode = mode === 'management'
   const shouldShowFileDetailDrawer = allowFileDetailDrawer ?? isManagementMode
   const shouldShowHeader = showHeader ?? isManagementMode
-  const shouldShowUploadControls = showUploadControls ?? isManagementMode
-  const shouldShowBulkActions = showBulkActions ?? isManagementMode
+  const shouldShowUploadControls = (showUploadControls ?? isManagementMode) && canManageFiles
+  const shouldShowBulkActions = (showBulkActions ?? isManagementMode) && canManageFiles
 
   // console.log('foldertree', folderTree)
   // console.log('hierarchicalItems', hierarchicalItems)
@@ -348,9 +355,9 @@ export function FilesManagement({
         onNavigate: navigateToFolder,
         // onRetryUpload: retryUpload,
         // onCancelUpload: cancelUpload,
-        onDelete: handleDelete,
+        onDelete: canManageFiles ? handleDelete : undefined,
         onDownload: handleDownload,
-        onRename: handleRename,
+        onRename: canManageFiles ? handleRename : undefined,
         isMoving,
       }),
     [
@@ -361,6 +368,7 @@ export function FilesManagement({
       handleDownload,
       handleRename,
       isMoving,
+      canManageFiles,
     ]
   )
 
@@ -437,7 +445,8 @@ export function FilesManagement({
   // Drag and drop configuration
   const dragDropConfig: DragDropConfig<FileItem> = useMemo(
     () => ({
-      enabled: true,
+      // Drag-to-move is a write; disable entirely for browse-only members.
+      enabled: canManageFiles,
 
       canDrag: (item) => {
         // Don't allow dragging uploading files
@@ -556,7 +565,14 @@ export function FilesManagement({
 
       dragPreview: MailThreadItemDragOverlay,
     }),
-    [selectedItems, moveItems, getItemDescendants, computeAllowedCrumbs, currentFolderId]
+    [
+      selectedItems,
+      moveItems,
+      getItemDescendants,
+      computeAllowedCrumbs,
+      currentFolderId,
+      canManageFiles,
+    ]
   )
 
   return (
@@ -646,7 +662,7 @@ export function FilesManagement({
               onRefresh={refetchFiles}
               searchPlaceholder='Search files and folders...'
               searchKeys={['name', 'path', 'mimeType', 'ext']}
-              onAddNew={() => setUploadDialogOpen(true)}
+              onAddNew={canManageFiles ? () => setUploadDialogOpen(true) : undefined}
               dragDrop={dragDropConfig}
               customFilter={
                 <FileFilterBar
@@ -661,12 +677,18 @@ export function FilesManagement({
                   icon={FolderPlus}
                   className='mt-20'
                   title={'No files yet'}
-                  description={'Upload your first files to get started.'}
+                  description={
+                    canManageFiles
+                      ? 'Upload your first files to get started.'
+                      : 'There are no files to show.'
+                  }
                   button={
-                    <Button onClick={() => setUploadDialogOpen(true)} variant='outline'>
-                      <Upload />
-                      Upload Files
-                    </Button>
+                    canManageFiles ? (
+                      <Button onClick={() => setUploadDialogOpen(true)} variant='outline'>
+                        <Upload />
+                        Upload Files
+                      </Button>
+                    ) : undefined
                   }
                 />
               }

--- a/apps/web/src/components/files/hooks/use-filesystem.tsx
+++ b/apps/web/src/components/files/hooks/use-filesystem.tsx
@@ -2,11 +2,13 @@
 
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { keepPreviousData } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useFileUpload } from '~/components/file-upload/hooks/use-file-upload'
 import { useUploadStore } from '~/components/file-upload/stores'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { type FileItem, type FolderTreeNode, useFileSystemStore } from '../files-store'
 
@@ -68,6 +70,12 @@ export function useFilesystem() {
   const utils = api.useUtils()
   const [movingIds, setMovingIds] = useState<Set<string>>(new Set())
 
+  // Layer-2 gate: only fetch the filesystem when the member holds at least
+  // `filesView` (Read). The provider mounts at the app root, so without this a
+  // member with `files: None` would 403 on `getFileSystem` on every page load.
+  const { can } = useAccess()
+  const canViewFiles = can(PermissionKey.filesView)
+
   // Use specific selectors to avoid unnecessary re-renders
   const setFileSystemData = useFileSystemStore((state) => state.setFileSystemData)
   const getItemPath = useFileSystemStore((state) => state.getItemPath)
@@ -107,7 +115,7 @@ export function useFilesystem() {
       includeArchived: false,
     },
     {
-      enabled: true,
+      enabled: canViewFiles,
       placeholderData: keepPreviousData,
       getNextPageParam: (lastPage) => lastPage.filesNextCursor,
       refetchOnWindowFocus: false,

--- a/apps/web/src/components/kbar/actions/navigation.ts
+++ b/apps/web/src/components/kbar/actions/navigation.ts
@@ -4,6 +4,7 @@
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo } from 'react'
 import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { SHORTCUTS } from '../shortcuts'
 import { useCommandPaletteStore } from '../store'
@@ -18,6 +19,7 @@ import type { PaletteAction } from '../types'
 export function useNavigationActions(): PaletteAction[] {
   const router = useRouter()
   const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
   const { isAdminOrOwner } = useUser()
 
   const nav = useCallback(
@@ -302,7 +304,7 @@ export function useNavigationActions(): PaletteAction[] {
         perform: () => nav('/datasets'),
       })
     }
-    if (hasAccess('files')) {
+    if (hasAccess('files') && can('files.view')) {
       actions.push({
         id: 'nav.files',
         label: 'Files',
@@ -314,5 +316,5 @@ export function useNavigationActions(): PaletteAction[] {
       })
     }
     return actions
-  }, [hasAccess, isAdminOrOwner, nav])
+  }, [hasAccess, can, isAdminOrOwner, nav])
 }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -202,7 +202,14 @@ export const SIDEBAR_MENU: SidebarProps[] = [
         featureKey: 'dataConnectors',
         adminOnly: true,
       },
-      { id: 'files', label: 'Files', slug: 'files', icon: <Folder />, featureKey: 'files' },
+      {
+        id: 'files',
+        label: 'Files',
+        slug: 'files',
+        icon: <Folder />,
+        featureKey: 'files',
+        permissionKey: 'files.view',
+      },
     ],
   },
   {

--- a/apps/web/src/server/api/routers/file.ts
+++ b/apps/web/src/server/api/routers/file.ts
@@ -6,11 +6,12 @@ import {
   createFilesystemService,
   createMediaAssetService,
 } from '@auxx/lib/files'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, permissionProcedure, protectedProcedure } from '~/server/api/trpc'
 
 const logger = createScopedLogger('api/file')
 
@@ -116,241 +117,257 @@ export const fileRouter = createTRPCRouter({
   // Query Procedures
 
   /** List files in a folder with pagination and filtering */
-  list: protectedProcedure.input(listFilesSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  list: permissionProcedure(PermissionKey.filesView)
+    .input(listFilesSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const result = await fileService.listInFolder(input.folderId || null, {
-        limit: input.limit,
-        cursor: input.cursor,
-        sortBy: input.sortBy,
-        sortOrder: input.sortOrder,
-        fileTypes: input.fileTypes,
-        includeArchived: input.includeArchived,
-        search: input.search,
-      })
+      try {
+        const result = await fileService.listInFolder(input.folderId || null, {
+          limit: input.limit,
+          cursor: input.cursor,
+          sortBy: input.sortBy,
+          sortOrder: input.sortOrder,
+          fileTypes: input.fileTypes,
+          includeArchived: input.includeArchived,
+          search: input.search,
+        })
 
-      logger.info('Files listed successfully', {
-        folderId: input.folderId,
-        count: result.items.length,
-        hasNextPage: result.hasNextPage,
-        nextCursor: result.nextCursor,
-      })
+        logger.info('Files listed successfully', {
+          folderId: input.folderId,
+          count: result.items.length,
+          hasNextPage: result.hasNextPage,
+          nextCursor: result.nextCursor,
+        })
 
-      return result
-    } catch (error) {
-      logger.error('Failed to list files', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to list files',
-      })
-    }
-  }),
+        return result
+      } catch (error) {
+        logger.error('Failed to list files', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to list files',
+        })
+      }
+    }),
 
   /** Get file by ID with full relations */
-  getById: protectedProcedure.input(fileIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getById: permissionProcedure(PermissionKey.filesView)
+    .input(fileIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const file = await fileService.getById(input.fileId)
+      try {
+        const file = await fileService.getById(input.fileId)
 
-      if (!file) {
+        if (!file) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'File not found',
+          })
+        }
+
+        logger.info('File retrieved successfully', { fileId: input.fileId })
+        return file
+      } catch (error) {
+        logger.error('Failed to get file', { error, input })
+
+        if (error instanceof TRPCError) {
+          throw error
+        }
+
         throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'File not found',
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get file',
         })
       }
-
-      logger.info('File retrieved successfully', { fileId: input.fileId })
-      return file
-    } catch (error) {
-      logger.error('Failed to get file', { error, input })
-
-      if (error instanceof TRPCError) {
-        throw error
-      }
-
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get file',
-      })
-    }
-  }),
+    }),
 
   /** Search files with relevance scoring */
-  search: protectedProcedure.input(searchFilesSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  search: permissionProcedure(PermissionKey.filesView)
+    .input(searchFilesSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const results = await fileService.search(input.query, {
-        folderId: input.folderId,
-        fileTypes: input.fileTypes,
-        cursor: input.cursor,
-        limit: input.limit,
-      })
+      try {
+        const results = await fileService.search(input.query, {
+          folderId: input.folderId,
+          fileTypes: input.fileTypes,
+          cursor: input.cursor,
+          limit: input.limit,
+        })
 
-      logger.info('File search completed', {
-        query: input.query,
-        resultCount: results.items.length,
-        hasNextPage: results.hasNextPage,
-        nextCursor: results.nextCursor,
-      })
+        logger.info('File search completed', {
+          query: input.query,
+          resultCount: results.items.length,
+          hasNextPage: results.hasNextPage,
+          nextCursor: results.nextCursor,
+        })
 
-      return results
-    } catch (error) {
-      logger.error('File search failed', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Search failed',
-      })
-    }
-  }),
-
-  /** Get download URL/info for a file */
-  getDownloadInfo: protectedProcedure.input(fileIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
-
-    const fileService = createFileService(organizationId, userId)
-
-    try {
-      const downloadInfo = await fileService.getDownloadInfo(input.fileId)
-
-      if (!downloadInfo) {
+        return results
+      } catch (error) {
+        logger.error('File search failed', { error, input })
         throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'File not found or not downloadable',
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Search failed',
         })
       }
+    }),
 
-      logger.info('Download info retrieved', { fileId: input.fileId })
-      return downloadInfo
-    } catch (error) {
-      logger.error('Failed to get download info', { error, input })
+  /** Get download URL/info for a file */
+  getDownloadInfo: permissionProcedure(PermissionKey.filesView)
+    .input(fileIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-      if (error instanceof TRPCError) {
-        throw error
+      const fileService = createFileService(organizationId, userId)
+
+      try {
+        const downloadInfo = await fileService.getDownloadInfo(input.fileId)
+
+        if (!downloadInfo) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'File not found or not downloadable',
+          })
+        }
+
+        logger.info('Download info retrieved', { fileId: input.fileId })
+        return downloadInfo
+      } catch (error) {
+        logger.error('Failed to get download info', { error, input })
+
+        if (error instanceof TRPCError) {
+          throw error
+        }
+
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get download info',
+        })
       }
-
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get download info',
-      })
-    }
-  }),
+    }),
 
   /** Get all versions of a file */
-  getVersions: protectedProcedure.input(fileIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getVersions: permissionProcedure(PermissionKey.filesView)
+    .input(fileIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const versions = await fileService.getVersions(input.fileId)
+      try {
+        const versions = await fileService.getVersions(input.fileId)
 
-      logger.info('File versions retrieved', {
-        fileId: input.fileId,
-        versionCount: versions.length,
-      })
+        logger.info('File versions retrieved', {
+          fileId: input.fileId,
+          versionCount: versions.length,
+        })
 
-      return versions
-    } catch (error) {
-      logger.error('Failed to get file versions', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get versions',
-      })
-    }
-  }),
+        return versions
+      } catch (error) {
+        logger.error('Failed to get file versions', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get versions',
+        })
+      }
+    }),
 
   /** Find files by extension */
-  findByExtension: protectedProcedure.input(findByExtensionSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  findByExtension: permissionProcedure(PermissionKey.filesView)
+    .input(findByExtensionSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const files = await fileService.findByExtension(input.extensions, {
-        limit: input.limit,
-      })
+      try {
+        const files = await fileService.findByExtension(input.extensions, {
+          limit: input.limit,
+        })
 
-      logger.info('Files found by extension', {
-        extensions: input.extensions,
-        count: files.length,
-      })
+        logger.info('Files found by extension', {
+          extensions: input.extensions,
+          count: files.length,
+        })
 
-      return files
-    } catch (error) {
-      logger.error('Failed to find files by extension', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to find files',
-      })
-    }
-  }),
+        return files
+      } catch (error) {
+        logger.error('Failed to find files by extension', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to find files',
+        })
+      }
+    }),
 
   /** Find files by MIME type */
-  findByMimeType: protectedProcedure.input(findByMimeTypeSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  findByMimeType: permissionProcedure(PermissionKey.filesView)
+    .input(findByMimeTypeSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const files = await fileService.findByMimeType(input.mimeTypes, {
-        limit: input.limit,
-      })
+      try {
+        const files = await fileService.findByMimeType(input.mimeTypes, {
+          limit: input.limit,
+        })
 
-      logger.info('Files found by MIME type', {
-        mimeTypes: input.mimeTypes,
-        count: files.length,
-      })
+        logger.info('Files found by MIME type', {
+          mimeTypes: input.mimeTypes,
+          count: files.length,
+        })
 
-      return files
-    } catch (error) {
-      logger.error('Failed to find files by MIME type', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to find files',
-      })
-    }
-  }),
+        return files
+      } catch (error) {
+        logger.error('Failed to find files by MIME type', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to find files',
+        })
+      }
+    }),
 
   /** Get complete filesystem state in single call */
-  getFileSystem: protectedProcedure.input(getFileSystemSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getFileSystem: permissionProcedure(PermissionKey.filesView)
+    .input(getFileSystemSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const filesystemService = createFilesystemService(organizationId, userId)
+      const filesystemService = createFilesystemService(organizationId, userId)
 
-    try {
-      const result = await filesystemService.getCompleteFileSystem({
-        filesCursor: input.filesCursor,
-        filesLimit: input.filesLimit,
-        fileTypes: input.fileTypes,
-        includeArchived: input.includeArchived,
-        lastSync: input.lastSync,
-      })
+      try {
+        const result = await filesystemService.getCompleteFileSystem({
+          filesCursor: input.filesCursor,
+          filesLimit: input.filesLimit,
+          fileTypes: input.fileTypes,
+          includeArchived: input.includeArchived,
+          lastSync: input.lastSync,
+        })
 
-      logger.info('Complete filesystem retrieved', {
-        itemsCount: result.items.length,
-        hasMoreFiles: result.filesHasNextPage,
-        totalFiles: result.totalFiles,
-        totalFolders: result.totalFolders,
-      })
+        logger.info('Complete filesystem retrieved', {
+          itemsCount: result.items.length,
+          hasMoreFiles: result.filesHasNextPage,
+          totalFiles: result.totalFiles,
+          totalFolders: result.totalFolders,
+        })
 
-      return result
-    } catch (error) {
-      logger.error('Failed to get complete filesystem', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get filesystem',
-      })
-    }
-  }),
+        return result
+      } catch (error) {
+        logger.error('Failed to get complete filesystem', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get filesystem',
+        })
+      }
+    }),
 
   /** Get preview download reference for attachment (files or assets) */
   getAttachmentPreviewRef: protectedProcedure
@@ -492,172 +509,186 @@ export const fileRouter = createTRPCRouter({
   // Mutation Procedures
 
   /** Soft delete a file */
-  delete: protectedProcedure.input(fileIdSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  delete: permissionProcedure(PermissionKey.filesManage)
+    .input(fileIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      await fileService.delete(input.fileId)
+      try {
+        await fileService.delete(input.fileId)
 
-      logger.info('File deleted successfully', { fileId: input.fileId })
-      return { success: true }
-    } catch (error) {
-      logger.error('Failed to delete file', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to delete file',
-      })
-    }
-  }),
+        logger.info('File deleted successfully', { fileId: input.fileId })
+        return { success: true }
+      } catch (error) {
+        logger.error('Failed to delete file', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to delete file',
+        })
+      }
+    }),
 
   /** Restore a soft-deleted file */
-  restore: protectedProcedure.input(fileIdSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  restore: permissionProcedure(PermissionKey.filesManage)
+    .input(fileIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const file = await fileService.restore(input.fileId)
+      try {
+        const file = await fileService.restore(input.fileId)
 
-      logger.info('File restored successfully', { fileId: input.fileId })
-      return file
-    } catch (error) {
-      logger.error('Failed to restore file', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to restore file',
-      })
-    }
-  }),
+        logger.info('File restored successfully', { fileId: input.fileId })
+        return file
+      } catch (error) {
+        logger.error('Failed to restore file', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to restore file',
+        })
+      }
+    }),
 
   /** Archive a file */
-  archive: protectedProcedure.input(fileIdSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  archive: permissionProcedure(PermissionKey.filesManage)
+    .input(fileIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const file = await fileService.archive(input.fileId)
+      try {
+        const file = await fileService.archive(input.fileId)
 
-      logger.info('File archived successfully', { fileId: input.fileId })
-      return file
-    } catch (error) {
-      logger.error('Failed to archive file', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to archive file',
-      })
-    }
-  }),
+        logger.info('File archived successfully', { fileId: input.fileId })
+        return file
+      } catch (error) {
+        logger.error('Failed to archive file', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to archive file',
+        })
+      }
+    }),
 
   /** Move file to different folder */
-  move: protectedProcedure.input(moveFileSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  move: permissionProcedure(PermissionKey.filesManage)
+    .input(moveFileSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const file = await fileService.move(input.fileId, input.targetFolderId)
+      try {
+        const file = await fileService.move(input.fileId, input.targetFolderId)
 
-      logger.info('File moved successfully', {
-        fileId: input.fileId,
-        targetFolderId: input.targetFolderId,
-      })
+        logger.info('File moved successfully', {
+          fileId: input.fileId,
+          targetFolderId: input.targetFolderId,
+        })
 
-      return file
-    } catch (error) {
-      logger.error('Failed to move file', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to move file',
-      })
-    }
-  }),
+        return file
+      } catch (error) {
+        logger.error('Failed to move file', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to move file',
+        })
+      }
+    }),
 
   /** Rename a file */
-  rename: protectedProcedure.input(renameFileSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  rename: permissionProcedure(PermissionKey.filesManage)
+    .input(renameFileSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const file = await fileService.rename(input.fileId, input.newName)
+      try {
+        const file = await fileService.rename(input.fileId, input.newName)
 
-      logger.info('File renamed successfully', {
-        fileId: input.fileId,
-        newName: input.newName,
-      })
+        logger.info('File renamed successfully', {
+          fileId: input.fileId,
+          newName: input.newName,
+        })
 
-      return file
-    } catch (error) {
-      logger.error('Failed to rename file', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to rename file',
-      })
-    }
-  }),
+        return file
+      } catch (error) {
+        logger.error('Failed to rename file', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to rename file',
+        })
+      }
+    }),
 
   /** Copy file to different location */
-  copy: protectedProcedure.input(copyFileSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  copy: permissionProcedure(PermissionKey.filesManage)
+    .input(copyFileSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const newFile = await fileService.copy(
-        input.sourceFileId,
-        input.targetFolderId,
-        input.newName
-      )
+      try {
+        const newFile = await fileService.copy(
+          input.sourceFileId,
+          input.targetFolderId,
+          input.newName
+        )
 
-      logger.info('File copied successfully', {
-        sourceFileId: input.sourceFileId,
-        targetFolderId: input.targetFolderId,
-        newFileId: newFile.id,
-      })
+        logger.info('File copied successfully', {
+          sourceFileId: input.sourceFileId,
+          targetFolderId: input.targetFolderId,
+          newFileId: newFile.id,
+        })
 
-      return newFile
-    } catch (error) {
-      logger.error('Failed to copy file', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to copy file',
-      })
-    }
-  }),
+        return newFile
+      } catch (error) {
+        logger.error('Failed to copy file', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to copy file',
+        })
+      }
+    }),
 
   /** Create new version of file */
-  createVersion: protectedProcedure.input(createVersionSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  createVersion: permissionProcedure(PermissionKey.filesManage)
+    .input(createVersionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      const version = await fileService.createVersion(input.fileId, {
-        versionNumber: input.versionNumber,
-        comment: input.comment,
-        createdById: userId,
-      })
+      try {
+        const version = await fileService.createVersion(input.fileId, {
+          versionNumber: input.versionNumber,
+          comment: input.comment,
+          createdById: userId,
+        })
 
-      logger.info('File version created successfully', {
-        fileId: input.fileId,
-        versionId: version.id,
-      })
+        logger.info('File version created successfully', {
+          fileId: input.fileId,
+          versionId: version.id,
+        })
 
-      return version
-    } catch (error) {
-      logger.error('Failed to create file version', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to create version',
-      })
-    }
-  }),
+        return version
+      } catch (error) {
+        logger.error('Failed to create file version', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to create version',
+        })
+      }
+    }),
 
   /** Restore to specific version */
-  restoreVersion: protectedProcedure
+  restoreVersion: permissionProcedure(PermissionKey.filesManage)
     .input(restoreVersionSchema)
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
@@ -683,80 +714,86 @@ export const fileRouter = createTRPCRouter({
     }),
 
   /** Delete a specific version */
-  deleteVersion: protectedProcedure.input(restoreVersionSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  deleteVersion: permissionProcedure(PermissionKey.filesManage)
+    .input(restoreVersionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const fileService = createFileService(organizationId, userId)
+      const fileService = createFileService(organizationId, userId)
 
-    try {
-      await fileService.deleteVersion(input.versionId)
+      try {
+        await fileService.deleteVersion(input.versionId)
 
-      logger.info('File version deleted successfully', {
-        fileId: input.fileId,
-        versionId: input.versionId,
-      })
+        logger.info('File version deleted successfully', {
+          fileId: input.fileId,
+          versionId: input.versionId,
+        })
 
-      return { success: true }
-    } catch (error) {
-      logger.error('Failed to delete file version', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to delete version',
-      })
-    }
-  }),
+        return { success: true }
+      } catch (error) {
+        logger.error('Failed to delete file version', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to delete version',
+        })
+      }
+    }),
 
   /** Move multiple files and folders to a target folder */
-  moveItems: protectedProcedure.input(moveItemsSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  moveItems: permissionProcedure(PermissionKey.filesManage)
+    .input(moveItemsSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    try {
-      const fsSvc = createFilesystemService(organizationId, userId)
-      const result = await fsSvc.moveItems(input.items, input.targetFolderId, {
-        mode: 'best-effort',
-        collision: 'rename',
-        dryRun: false,
-      })
+      try {
+        const fsSvc = createFilesystemService(organizationId, userId)
+        const result = await fsSvc.moveItems(input.items, input.targetFolderId, {
+          mode: 'best-effort',
+          collision: 'rename',
+          dryRun: false,
+        })
 
-      logger.info('Bulk move completed', {
-        items: input.items.map((i) => ({ id: i.id, type: i.type })),
-        targetFolderId: input.targetFolderId,
-        moved: result.moved,
-        failed: result.failed,
-        skipped: result.skipped,
-      })
+        logger.info('Bulk move completed', {
+          items: input.items.map((i) => ({ id: i.id, type: i.type })),
+          targetFolderId: input.targetFolderId,
+          moved: result.moved,
+          failed: result.failed,
+          skipped: result.skipped,
+        })
 
-      return result
-    } catch (error) {
-      logger.error('Failed to move items', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to move items',
-      })
-    }
-  }),
+        return result
+      } catch (error) {
+        logger.error('Failed to move items', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to move items',
+        })
+      }
+    }),
 
   /** Rename a file or folder */
-  renameItem: protectedProcedure.input(renameItemSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  renameItem: permissionProcedure(PermissionKey.filesManage)
+    .input(renameItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    try {
-      const fsSvc = createFilesystemService(organizationId, userId)
-      const result = await fsSvc.renameItem(input.id, input.type, input.newName)
+      try {
+        const fsSvc = createFilesystemService(organizationId, userId)
+        const result = await fsSvc.renameItem(input.id, input.type, input.newName)
 
-      logger.info('Item renamed successfully', {
-        id: input.id,
-        type: input.type,
-        newName: input.newName,
-      })
+        logger.info('Item renamed successfully', {
+          id: input.id,
+          type: input.type,
+          newName: input.newName,
+        })
 
-      return result
-    } catch (error) {
-      logger.error('Failed to rename item', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to rename item',
-      })
-    }
-  }),
+        return result
+      } catch (error) {
+        logger.error('Failed to rename item', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to rename item',
+        })
+      }
+    }),
 })

--- a/apps/web/src/server/api/routers/folder.ts
+++ b/apps/web/src/server/api/routers/folder.ts
@@ -1,10 +1,11 @@
 // apps/web/src/server/api/routers/folder.ts
 
 import { createFolderService } from '@auxx/lib/files'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 
 const logger = createScopedLogger('api/folder')
 
@@ -65,7 +66,7 @@ export const folderRouter = createTRPCRouter({
   // Query Procedures
 
   /** Get all folders in organization */
-  list: protectedProcedure.query(async ({ ctx }) => {
+  list: permissionProcedure(PermissionKey.filesView).query(async ({ ctx }) => {
     const { organizationId, userId } = ctx.session
 
     const folderService = createFolderService(organizationId, userId)
@@ -89,39 +90,41 @@ export const folderRouter = createTRPCRouter({
   }),
 
   /** Get folder by ID with relations */
-  getById: protectedProcedure.input(folderIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getById: permissionProcedure(PermissionKey.filesView)
+    .input(folderIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.getById(input.folderId)
+      try {
+        const folder = await folderService.getById(input.folderId)
 
-      if (!folder) {
+        if (!folder) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Folder not found',
+          })
+        }
+
+        logger.info('Folder retrieved successfully', { folderId: input.folderId })
+        return folder
+      } catch (error) {
+        logger.error('Failed to get folder', { error, input })
+
+        if (error instanceof TRPCError) {
+          throw error
+        }
+
         throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Folder not found',
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get folder',
         })
       }
-
-      logger.info('Folder retrieved successfully', { folderId: input.folderId })
-      return folder
-    } catch (error) {
-      logger.error('Failed to get folder', { error, input })
-
-      if (error instanceof TRPCError) {
-        throw error
-      }
-
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get folder',
-      })
-    }
-  }),
+    }),
 
   /** Get complete folder tree */
-  getTree: protectedProcedure.query(async ({ ctx }) => {
+  getTree: permissionProcedure(PermissionKey.filesView).query(async ({ ctx }) => {
     const { organizationId, userId } = ctx.session
 
     const folderService = createFolderService(organizationId, userId)
@@ -144,417 +147,455 @@ export const folderRouter = createTRPCRouter({
   }),
 
   /** Get immediate subfolders */
-  getSubfolders: protectedProcedure.input(folderIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getSubfolders: permissionProcedure(PermissionKey.filesView)
+    .input(folderIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const subfolders = await folderService.getSubfolders(input.folderId)
+      try {
+        const subfolders = await folderService.getSubfolders(input.folderId)
 
-      logger.info('Subfolders retrieved successfully', {
-        folderId: input.folderId,
-        count: subfolders.length,
-      })
+        logger.info('Subfolders retrieved successfully', {
+          folderId: input.folderId,
+          count: subfolders.length,
+        })
 
-      return subfolders
-    } catch (error) {
-      logger.error('Failed to get subfolders', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get subfolders',
-      })
-    }
-  }),
+        return subfolders
+      } catch (error) {
+        logger.error('Failed to get subfolders', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get subfolders',
+        })
+      }
+    }),
 
   /** Get folder's ancestor chain */
-  getAncestors: protectedProcedure.input(folderIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getAncestors: permissionProcedure(PermissionKey.filesView)
+    .input(folderIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const ancestors = await folderService.getAncestors(input.folderId)
+      try {
+        const ancestors = await folderService.getAncestors(input.folderId)
 
-      logger.info('Folder ancestors retrieved successfully', {
-        folderId: input.folderId,
-        ancestorCount: ancestors.length,
-      })
+        logger.info('Folder ancestors retrieved successfully', {
+          folderId: input.folderId,
+          ancestorCount: ancestors.length,
+        })
 
-      return ancestors
-    } catch (error) {
-      logger.error('Failed to get folder ancestors', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get ancestors',
-      })
-    }
-  }),
+        return ancestors
+      } catch (error) {
+        logger.error('Failed to get folder ancestors', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get ancestors',
+        })
+      }
+    }),
 
   /** Get all descendant folders */
-  getDescendants: protectedProcedure.input(folderIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getDescendants: permissionProcedure(PermissionKey.filesView)
+    .input(folderIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const descendants = await folderService.getDescendants(input.folderId)
+      try {
+        const descendants = await folderService.getDescendants(input.folderId)
 
-      logger.info('Folder descendants retrieved successfully', {
-        folderId: input.folderId,
-        descendantCount: descendants.length,
-      })
+        logger.info('Folder descendants retrieved successfully', {
+          folderId: input.folderId,
+          descendantCount: descendants.length,
+        })
 
-      return descendants
-    } catch (error) {
-      logger.error('Failed to get folder descendants', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get descendants',
-      })
-    }
-  }),
+        return descendants
+      } catch (error) {
+        logger.error('Failed to get folder descendants', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get descendants',
+        })
+      }
+    }),
 
   /** Search folders with relevance */
-  search: protectedProcedure.input(searchFoldersSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  search: permissionProcedure(PermissionKey.filesView)
+    .input(searchFoldersSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const results = await folderService.search(input.query, {
-        parentId: input.parentId,
-        limit: input.limit,
-      })
+      try {
+        const results = await folderService.search(input.query, {
+          parentId: input.parentId,
+          limit: input.limit,
+        })
 
-      logger.info('Folder search completed', {
-        query: input.query,
-        resultCount: results.length,
-      })
+        logger.info('Folder search completed', {
+          query: input.query,
+          resultCount: results.length,
+        })
 
-      return results
-    } catch (error) {
-      logger.error('Folder search failed', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Search failed',
-      })
-    }
-  }),
+        return results
+      } catch (error) {
+        logger.error('Folder search failed', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Search failed',
+        })
+      }
+    }),
 
   /** Get folder statistics */
-  getStats: protectedProcedure.input(folderIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getStats: permissionProcedure(PermissionKey.filesView)
+    .input(folderIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const stats = await folderService.getStats(input.folderId)
+      try {
+        const stats = await folderService.getStats(input.folderId)
 
-      logger.info('Folder stats retrieved successfully', {
-        folderId: input.folderId,
-        stats,
-      })
+        logger.info('Folder stats retrieved successfully', {
+          folderId: input.folderId,
+          stats,
+        })
 
-      return stats
-    } catch (error) {
-      logger.error('Failed to get folder stats', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get stats',
-      })
-    }
-  }),
+        return stats
+      } catch (error) {
+        logger.error('Failed to get folder stats', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get stats',
+        })
+      }
+    }),
 
   /** Get folder usage analytics */
-  getUsage: protectedProcedure.input(folderIdSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  getUsage: permissionProcedure(PermissionKey.filesView)
+    .input(folderIdSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const usage = await folderService.getUsage(input.folderId)
+      try {
+        const usage = await folderService.getUsage(input.folderId)
 
-      logger.info('Folder usage retrieved successfully', {
-        folderId: input.folderId,
-        usage,
-      })
+        logger.info('Folder usage retrieved successfully', {
+          folderId: input.folderId,
+          usage,
+        })
 
-      return usage
-    } catch (error) {
-      logger.error('Failed to get folder usage', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to get usage',
-      })
-    }
-  }),
+        return usage
+      } catch (error) {
+        logger.error('Failed to get folder usage', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to get usage',
+        })
+      }
+    }),
 
   /** Validate folder name uniqueness */
-  validateName: protectedProcedure.input(validateNameSchema).query(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  validateName: permissionProcedure(PermissionKey.filesView)
+    .input(validateNameSchema)
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const isValid = await folderService.validateName(input.name, input.parentId, input.excludeId)
+      try {
+        const isValid = await folderService.validateName(
+          input.name,
+          input.parentId,
+          input.excludeId
+        )
 
-      logger.info('Folder name validation completed', {
-        name: input.name,
-        isValid,
-      })
+        logger.info('Folder name validation completed', {
+          name: input.name,
+          isValid,
+        })
 
-      return { isValid }
-    } catch (error) {
-      logger.error('Failed to validate folder name', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to validate name',
-      })
-    }
-  }),
+        return { isValid }
+      } catch (error) {
+        logger.error('Failed to validate folder name', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to validate name',
+        })
+      }
+    }),
 
   // Mutation Procedures
 
   /** Create new folder */
-  create: protectedProcedure.input(createFolderSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  create: permissionProcedure(PermissionKey.filesManage)
+    .input(createFolderSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.create({
-        name: input.name,
-        parentId: input.parentId,
-        organizationId,
-        createdById: userId,
-      })
+      try {
+        const folder = await folderService.create({
+          name: input.name,
+          parentId: input.parentId,
+          organizationId,
+          createdById: userId,
+        })
 
-      logger.info('Folder created successfully', {
-        folderId: folder.id,
-        name: input.name,
-        parentId: input.parentId,
-      })
+        logger.info('Folder created successfully', {
+          folderId: folder.id,
+          name: input.name,
+          parentId: input.parentId,
+        })
 
-      return folder
-    } catch (error) {
-      logger.error('Failed to create folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to create folder',
-      })
-    }
-  }),
+        return folder
+      } catch (error) {
+        logger.error('Failed to create folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to create folder',
+        })
+      }
+    }),
 
   /** Update folder properties */
-  update: protectedProcedure.input(updateFolderSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  update: permissionProcedure(PermissionKey.filesManage)
+    .input(updateFolderSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.update(input.folderId, {
-        name: input.name,
-        parentId: input.parentId,
-      })
+      try {
+        const folder = await folderService.update(input.folderId, {
+          name: input.name,
+          parentId: input.parentId,
+        })
 
-      logger.info('Folder updated successfully', {
-        folderId: input.folderId,
-        updates: { name: input.name, parentId: input.parentId },
-      })
+        logger.info('Folder updated successfully', {
+          folderId: input.folderId,
+          updates: { name: input.name, parentId: input.parentId },
+        })
 
-      return folder
-    } catch (error) {
-      logger.error('Failed to update folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to update folder',
-      })
-    }
-  }),
+        return folder
+      } catch (error) {
+        logger.error('Failed to update folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to update folder',
+        })
+      }
+    }),
 
   /** Soft delete folder and contents */
-  delete: protectedProcedure.input(folderIdSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  delete: permissionProcedure(PermissionKey.filesManage)
+    .input(folderIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      await folderService.delete(input.folderId)
+      try {
+        await folderService.delete(input.folderId)
 
-      logger.info('Folder deleted successfully', { folderId: input.folderId })
-      return { success: true }
-    } catch (error) {
-      logger.error('Failed to delete folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to delete folder',
-      })
-    }
-  }),
+        logger.info('Folder deleted successfully', { folderId: input.folderId })
+        return { success: true }
+      } catch (error) {
+        logger.error('Failed to delete folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to delete folder',
+        })
+      }
+    }),
 
   /** Restore soft-deleted folder */
-  restore: protectedProcedure.input(folderIdSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  restore: permissionProcedure(PermissionKey.filesManage)
+    .input(folderIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.restore(input.folderId)
+      try {
+        const folder = await folderService.restore(input.folderId)
 
-      logger.info('Folder restored successfully', { folderId: input.folderId })
-      return folder
-    } catch (error) {
-      logger.error('Failed to restore folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to restore folder',
-      })
-    }
-  }),
+        logger.info('Folder restored successfully', { folderId: input.folderId })
+        return folder
+      } catch (error) {
+        logger.error('Failed to restore folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to restore folder',
+        })
+      }
+    }),
 
   /** Permanently delete folder */
-  permanentDelete: protectedProcedure.input(folderIdSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  permanentDelete: permissionProcedure(PermissionKey.filesManage)
+    .input(folderIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      await folderService.permanentDelete(input.folderId)
+      try {
+        await folderService.permanentDelete(input.folderId)
 
-      logger.info('Folder permanently deleted', { folderId: input.folderId })
-      return { success: true }
-    } catch (error) {
-      logger.error('Failed to permanently delete folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to permanently delete folder',
-      })
-    }
-  }),
+        logger.info('Folder permanently deleted', { folderId: input.folderId })
+        return { success: true }
+      } catch (error) {
+        logger.error('Failed to permanently delete folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to permanently delete folder',
+        })
+      }
+    }),
 
   /** Move folder to new parent */
-  move: protectedProcedure.input(moveFolderSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  move: permissionProcedure(PermissionKey.filesManage)
+    .input(moveFolderSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.move(input.folderId, input.targetParentId)
+      try {
+        const folder = await folderService.move(input.folderId, input.targetParentId)
 
-      logger.info('Folder moved successfully', {
-        folderId: input.folderId,
-        targetParentId: input.targetParentId,
-      })
+        logger.info('Folder moved successfully', {
+          folderId: input.folderId,
+          targetParentId: input.targetParentId,
+        })
 
-      return folder
-    } catch (error) {
-      logger.error('Failed to move folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to move folder',
-      })
-    }
-  }),
+        return folder
+      } catch (error) {
+        logger.error('Failed to move folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to move folder',
+        })
+      }
+    }),
 
   /** Rename folder */
-  rename: protectedProcedure.input(renameFolderSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  rename: permissionProcedure(PermissionKey.filesManage)
+    .input(renameFolderSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.rename(input.folderId, input.newName)
+      try {
+        const folder = await folderService.rename(input.folderId, input.newName)
 
-      logger.info('Folder renamed successfully', {
-        folderId: input.folderId,
-        newName: input.newName,
-      })
+        logger.info('Folder renamed successfully', {
+          folderId: input.folderId,
+          newName: input.newName,
+        })
 
-      return folder
-    } catch (error) {
-      logger.error('Failed to rename folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to rename folder',
-      })
-    }
-  }),
+        return folder
+      } catch (error) {
+        logger.error('Failed to rename folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to rename folder',
+        })
+      }
+    }),
 
   /** Copy folder with all contents */
-  copy: protectedProcedure.input(copyFolderSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  copy: permissionProcedure(PermissionKey.filesManage)
+    .input(copyFolderSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const newFolder = await folderService.copy(
-        input.sourceFolderId,
-        input.targetParentId,
-        input.newName
-      )
+      try {
+        const newFolder = await folderService.copy(
+          input.sourceFolderId,
+          input.targetParentId,
+          input.newName
+        )
 
-      logger.info('Folder copied successfully', {
-        sourceFolderId: input.sourceFolderId,
-        targetParentId: input.targetParentId,
-        newFolderId: newFolder.id,
-      })
+        logger.info('Folder copied successfully', {
+          sourceFolderId: input.sourceFolderId,
+          targetParentId: input.targetParentId,
+          newFolderId: newFolder.id,
+        })
 
-      return newFolder
-    } catch (error) {
-      logger.error('Failed to copy folder', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to copy folder',
-      })
-    }
-  }),
+        return newFolder
+      } catch (error) {
+        logger.error('Failed to copy folder', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to copy folder',
+        })
+      }
+    }),
 
   /** Merge two folders */
-  merge: protectedProcedure.input(mergeFolderSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  merge: permissionProcedure(PermissionKey.filesManage)
+    .input(mergeFolderSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.merge(input.sourceFolderId, input.targetFolderId)
+      try {
+        const folder = await folderService.merge(input.sourceFolderId, input.targetFolderId)
 
-      logger.info('Folders merged successfully', {
-        sourceFolderId: input.sourceFolderId,
-        targetFolderId: input.targetFolderId,
-      })
+        logger.info('Folders merged successfully', {
+          sourceFolderId: input.sourceFolderId,
+          targetFolderId: input.targetFolderId,
+        })
 
-      return folder
-    } catch (error) {
-      logger.error('Failed to merge folders', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to merge folders',
-      })
-    }
-  }),
+        return folder
+      } catch (error) {
+        logger.error('Failed to merge folders', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to merge folders',
+        })
+      }
+    }),
 
   /** Create folder path if not exists */
-  ensurePath: protectedProcedure.input(folderPathSchema).mutation(async ({ ctx, input }) => {
-    const { organizationId, userId } = ctx.session
+  ensurePath: permissionProcedure(PermissionKey.filesManage)
+    .input(folderPathSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
 
-    const folderService = createFolderService(organizationId, userId)
+      const folderService = createFolderService(organizationId, userId)
 
-    try {
-      const folder = await folderService.ensurePath(input.path)
+      try {
+        const folder = await folderService.ensurePath(input.path)
 
-      logger.info('Folder path ensured successfully', {
-        path: input.path,
-        folderId: folder.id,
-      })
+        logger.info('Folder path ensured successfully', {
+          path: input.path,
+          folderId: folder.id,
+        })
 
-      return folder
-    } catch (error) {
-      logger.error('Failed to ensure folder path', { error, input })
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: error instanceof Error ? error.message : 'Failed to ensure path',
-      })
-    }
-  }),
+        return folder
+      } catch (error) {
+        logger.error('Failed to ensure folder path', { error, input })
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to ensure path',
+        })
+      }
+    }),
 })

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -41,6 +41,10 @@ export enum PermissionKey {
   aiConfigManage = 'aiConfig.manage',
   automationRulesManage = 'automationRules.manage',
   auditLogView = 'auditLog.view',
+
+  // files
+  filesView = 'files.view',
+  filesManage = 'files.manage',
 }
 
 /** Metadata describing a single capability key. Mirrors `FeatureMetadata`. */
@@ -210,6 +214,22 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     description: 'View the organization audit log.',
     group: 'Organization',
   },
+
+  // ── Files ──
+  {
+    key: PermissionKey.filesView,
+    label: 'View Files',
+    description: 'List, search, preview, and download files.',
+    group: 'Files',
+    featureKey: FeatureKey.files,
+  },
+  {
+    key: PermissionKey.filesManage,
+    label: 'Manage Files',
+    description: 'Delete, restore, archive, move, rename, copy, and version files and folders.',
+    group: 'Files',
+    featureKey: FeatureKey.files,
+  },
 ]
 
 /** Lookup map for quick access to a key's metadata. */
@@ -267,6 +287,7 @@ export enum Area {
   aiConfig = 'aiConfig',
   automationRules = 'automationRules',
   auditLog = 'auditLog',
+  files = 'files',
 }
 
 /** A single rung of an area's ladder — the keys ADDED at (and above) `level`. */
@@ -429,6 +450,17 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
     description: 'View the organization audit log.',
     group: 'Organization',
     rungs: [{ level: Level.Read, keys: [PermissionKey.auditLogView] }],
+  },
+  [Area.files]: {
+    area: Area.files,
+    label: 'Files',
+    description: 'Browse and download files, or manage them (delete, move, rename, version).',
+    group: 'Files',
+    rungs: [
+      { level: Level.Read, keys: [PermissionKey.filesView] },
+      { level: Level.Full, keys: [PermissionKey.filesManage] },
+    ],
+    featureKey: FeatureKey.files,
   },
 }
 


### PR DESCRIPTION
## What

Adds the **`files`** Layer-2 capability area — the first standalone new area of the permissions v2 initiative (`plans/permissions/v2/README.md` → *New areas under design*). Ladder: **None / Read / Full**, linked to `FeatureKey.files` (Layer-1).

- **Read** = browse / search / download / preview / versions
- **Full** = manage: upload, new folder, delete, restore, archive, move, rename, copy, version ops

USER role gets `files` on by default (like records); workers are clamped to None.

## Backend enforcement

**`registry.ts`** — new `filesView`/`filesManage` keys + `Area.files` ladder. `seat-policy.ts` needs no change: `buildAreaLevels` auto-resolves files → Full for USER (default-on) and None for workers.

**`file.ts` + `folder.ts`** — reads → `permissionProcedure(filesView)`, all mutations → `filesManage`. **`resolveFileRefs` + `getAttachmentPreviewRef` stay open** — they're record/message-embedded display primitives and must resolve at any level, even `None`.

## Client gating

- **`use-filesystem.tsx`** — root query `enabled: canViewFiles`. The `FilesystemProvider` mounts at the app root, so without this a `files: None` member would 403 on `getFileSystem` **on every page**. Now it degrades to an empty filesystem.
- **`menu.tsx`** — Files sidebar item gated on `permissionKey: 'files.view'`.
- **`files/page.tsx`** — Layer-2 "No Access to Files" EmptyState when the member holds the plan but not `filesView`.
- **`kbar/navigation.ts`** — Files command-palette action gated on `can('files.view')`.
- **`files-management.tsx` + `file-detail-drawer.tsx`** — upload / new-folder / bulk-delete / drag-to-move / row delete+rename gated on `can(filesManage)`; Read members get a clean browse-only view.

## Known follow-up (not in this PR)

The actual **file-upload presign transport** (`use-file-upload`) is **not** yet server-gated on `filesManage` — only the client affordances are hidden. It's shared with record-attachment and visit-photo uploads, so it needs a **context-aware** gate (enforce `filesManage` only when the target is the file library, not a record attachment). Tracked in the next-steps plan.

## Testing

- Typecheck: no new errors from any edit (pre-existing `FileService`/`noUncheckedIndexedAccess` baseline noise only).
- Enforcement is server-side (`permissionProcedure`); OWNER/ADMIN bypass via `ROLE_DEFAULTS`.