### PR TITLE
feat(permissions): gate file-library upload presign on files.manage

### DIFF
--- a/apps/web/src/app/api/files/upload/sessions/route.ts
+++ b/apps/web/src/app/api/files/upload/sessions/route.ts
@@ -1,5 +1,6 @@
 // apps/web/src/app/api/files/upload/sessions/route.ts
 
+import { AuxxError } from '@auxx/lib/errors'
 import {
   createStorageManager,
   ensureProcessorsInitialized,
@@ -49,6 +50,30 @@ export async function POST(request: NextRequest) {
       return UploadErrorHandler.validationError('Invalid session request format', {
         validationErrors: validationError,
       })
+    }
+
+    // Layer-2 gate (doc 10 §0): file-library uploads require `files.manage` (Full).
+    // Record attachments, dataset docs, visit-QC photos, avatars, etc. reach this
+    // same transport but are gated by their own host surface — leave them on the
+    // plan/quota gate only. Returned explicitly so the AuxxError carries its own 403
+    // instead of being message-string-classified by the outer handler.
+    if (sessionRequest.entityType === ENTITY_TYPES.FILE) {
+      try {
+        const { requirePermission, PermissionKey } = await import('@auxx/lib/permissions')
+        await requirePermission(
+          session.user.id,
+          session.user.defaultOrganizationId,
+          PermissionKey.filesManage
+        )
+      } catch (permissionError) {
+        if (permissionError instanceof AuxxError) {
+          return NextResponse.json(
+            { error: 'FORBIDDEN', message: permissionError.message },
+            { status: permissionError.statusCode }
+          )
+        }
+        throw permissionError
+      }
     }
 
     // Storage limit check: verify org has capacity for this upload


### PR DESCRIPTION
## What

Closes the one gap #1306 left in the `files` L2 area (doc 10 §0): the client upload affordances were hidden on `filesManage`, and `file.ts`/`folder.ts` mutations were gated — but the **actual upload transport** (`use-file-upload` → presign session) was not server-gated. A determined Read member could still upload by hitting the raw presign endpoint directly.

## The fix — context-aware

`apps/web/src/app/api/files/upload/sessions/route.ts` is the single choke point (the `parts`/`complete` routes act on an already-created session). The presign path is **shared** with record-attachment and visit-report photo uploads, so a blunt `filesManage` gate would break both.

The gate branches on `entityType`:

- `entityType === FILE` (the **file library**) → now requires `files.manage` via `requirePermission(...)` (same plan-AND-capability guard as `permissionProcedure`), returning an explicit **403** from the AuxxError's `statusCode`.
- All other targets — record attachments (`TICKET`/`COMMENT`/`MESSAGE`), dataset docs (`DATASET`), visit-QC photos (`visit_qc_item`), avatars (`USER_PROFILE`), etc. — flow through untouched, gated by their own host surface.

## Verification

- Read member → `POST /api/files/upload/sessions` with `entityType:'FILE'` → **403**; with a non-`FILE` type → **200** (host gate unchanged).
- Full/manage member → `FILE` upload → **200**.
- Typecheck: no new errors (the pre-existing `provider`/`presigned.method`/`partPresignEndpoint` mismatches in this file are unrelated, shifted down by the insert). Biome clean.

Plan: `plans/permissions/v2/10-new-l2-areas.md` §0.