### PR TITLE
feat(permissions): reach custom fields via def-admin, keep permissions tab admin-only

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/custom-fields/[apiSlug]/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/custom-fields/[apiSlug]/page.tsx
@@ -14,6 +14,7 @@ import SettingsPage from '~/components/global/settings-page'
 import { DefAccessSection } from '~/components/permissions/ui/def-access-section'
 import { useResource } from '~/components/resources/hooks'
 import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 
 function CustomFieldsDetailPage() {
   const params = useParams()
@@ -26,10 +27,12 @@ function CustomFieldsDetailPage() {
 
   // Get resource from unified registry (handles both system and custom)
   const { resource, isLoading } = useResource(apiSlug)
-  useUser({
-    requireOrganization: true,
-    requireRoles: ['ADMIN', 'OWNER'],
-  })
+  // Managing a def's fields is def administration (the `Full`/`admin` rung) —
+  // OWNER/ADMIN or a def-`admin` grantee (perms v2 doc 09). Gated per-def below
+  // rather than via a blanket role guard; the server enforces regardless. The
+  // **Permissions** (record access) tab is a further, OWNER/ADMIN-only step.
+  const { isAdminOrOwner } = useUser({ requireOrganization: true })
+  const { canAdministerDef } = useAccess()
 
   // Show loading state
   if (isLoading) {
@@ -67,6 +70,25 @@ function CustomFieldsDetailPage() {
     )
   }
 
+  // Per-def administration gate — a member without def-`admin` on THIS def cannot
+  // manage its fields/permissions (server enforces regardless).
+  if (!canAdministerDef(resource.entityDefinitionId)) {
+    return (
+      <SettingsPage
+        title='Access denied'
+        description="You don't have permission to manage this entity's fields."
+        breadcrumbs={[
+          { title: 'Settings', href: '/app/settings' },
+          { title: 'Custom Fields', href: '/app/settings/custom-fields' },
+          { title: resource.label },
+        ]}>
+        <div className='text-center py-12 text-muted-foreground'>
+          <p>You need administration access to “{resource.label}” to manage its fields.</p>
+        </div>
+      </SettingsPage>
+    )
+  }
+
   return (
     <>
       <SettingsPage
@@ -87,8 +109,10 @@ function CustomFieldsDetailPage() {
         {/* Appearance editor - show for all, disable for system */}
         <EntityAppearanceEditor resource={resource} disabled={!!resource.entityType} />
 
-        {/* Fields vs Permissions — Permissions only for in-scope CRM defs */}
-        {isAccessManageable(resource) ? (
+        {/* Fields vs Permissions — Permissions tab only for in-scope CRM defs
+            AND OWNER/ADMIN (record access stays admin-only; def-admins get Fields
+            only). Server enforces the access mutations regardless. */}
+        {isAccessManageable(resource) && isAdminOrOwner ? (
           <>
             <div className='px-3 pt-3 sm:px-6 pb-6'>
               <div className='w-56'>

--- a/apps/web/src/app/(protected)/app/settings/custom-fields/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/custom-fields/page.tsx
@@ -21,6 +21,7 @@ import SettingsPage from '~/components/global/settings-page'
 import { useResources } from '~/components/resources/hooks'
 import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
 import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 const BASE_URL = `/app/settings/custom-fields`
@@ -29,7 +30,11 @@ const BASE_URL = `/app/settings/custom-fields`
 const HIDDEN_ENTITY_TYPES = ['signature', 'inbox', 'entity_group', 'tag']
 
 export default function CustomFieldsPage() {
-  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
+  // Reachable by any def-admin (not just OWNER/ADMIN) — the list is filtered to
+  // the defs the member administers (perms v2 doc 09). Creating a *new* def is
+  // org-level, so the Create actions stay admin-only below.
+  const { isAdminOrOwner } = useUser({ requireOrganization: true })
+  const { canAdministerDef } = useAccess()
   const router = useRouter()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [templateDialogOpen, setTemplateDialogOpen] = useState(false)
@@ -41,14 +46,7 @@ export default function CustomFieldsPage() {
   const userCreatedEntityCount = customResources?.filter((r) => !r.entityType).length ?? 0
   const atEntityLimit = isAtLimit(FeatureKey.entities, userCreatedEntityCount)
   const entityLimit = getLimit(FeatureKey.entities)
-  console.log(
-    'CustomFieldsPage: resources',
-    userCreatedEntityCount,
-    'limit',
-    entityLimit,
-    'atLimit',
-    atEntityLimit
-  )
+
   /** Navigate to entity fields page */
   function handleRowClick(slug: string) {
     router.push(`${BASE_URL}/${slug}`)
@@ -84,26 +82,28 @@ export default function CustomFieldsPage() {
             <TableHead>Type</TableHead>
             <TableHead className='hidden sm:table-cell'>Fields</TableHead>
             <TableHead className='w-[100px]'>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button size='sm' variant='outline'>
-                    <Plus />
-                    Create
-                    <ChevronDown />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align='end'>
-                  <DropdownMenuItem onClick={handleCreateFromBlank}>
-                    <Plus /> Create Entity
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={handleCreateFromTemplate}
-                    className='data-highlighted:bg-[#ffaa40]/10'>
-                    <LayoutTemplate className='text-[#ffaa40]' />{' '}
-                    <AnimatedGradientText>Create from template</AnimatedGradientText>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              {isAdminOrOwner && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button size='sm' variant='outline'>
+                      <Plus />
+                      Create
+                      <ChevronDown />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align='end'>
+                    <DropdownMenuItem onClick={handleCreateFromBlank}>
+                      <Plus /> Create Entity
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={handleCreateFromTemplate}
+                      className='data-highlighted:bg-[#ffaa40]/10'>
+                      <LayoutTemplate className='text-[#ffaa40]' />{' '}
+                      <AnimatedGradientText>Create from template</AnimatedGradientText>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </TableHead>
           </TableRow>
         </TableHeader>
@@ -112,6 +112,9 @@ export default function CustomFieldsPage() {
           {!isLoading &&
             resources
               .filter((r) => !r.entityType || !HIDDEN_ENTITY_TYPES.includes(r.entityType))
+              // Def-admin scoping: a member sees only the defs they administer.
+              // Admins administer every def, so their list is unchanged.
+              .filter((r) => canAdministerDef(r.entityDefinitionId))
               .map((resource) => (
                 <EntityRow
                   key={resource.id}

--- a/apps/web/src/components/global/sidebar-secondary.tsx
+++ b/apps/web/src/components/global/sidebar-secondary.tsx
@@ -22,7 +22,7 @@ function SidebarSecondary({ items, baseUrl, title, current }: Props) {
   })
   const role = isAdminOrOwner ? 'ADMIN' : 'USER'
   const { hasAccess: hasFeatureAccess } = useFeatureFlags()
-  const { can } = useAccess()
+  const { can, administersAnyDef } = useAccess()
 
   return (
     // <div className='flex h-full min-h-screen w-[16rem] overflow-auto border-r bg-sidebar text-sidebar-foreground'>
@@ -61,6 +61,7 @@ function SidebarSecondary({ items, baseUrl, title, current }: Props) {
                 selfHosted,
                 hasFeatureAccess,
                 can,
+                administersAnyDef,
                 isMobile ? () => setIsDropdownOpen(false) : undefined
               )}
             </React.Fragment>
@@ -79,6 +80,7 @@ function createSidebarGroup(
   selfHosted: boolean,
   hasFeatureAccess: (key: string) => boolean,
   can: (key: string) => boolean,
+  administersAnyDef: boolean,
   onItemClick?: () => void
 ) {
   const title = group.label
@@ -86,6 +88,10 @@ function createSidebarGroup(
   let items = selfHosted ? group.items?.filter((item) => !item.cloudOnly) : group.items
   items = items?.filter((item) => !item.featureKey || hasFeatureAccess(item.featureKey))
   items = items?.filter((item) => !item.access || item.access === role)
+  // Def-admin-derived items (Custom Fields, perms v2 doc 09): visible to any
+  // member administering ≥1 def, not just the org role. `administersAnyDef` is
+  // already true for OWNER/ADMIN.
+  items = items?.filter((item) => !item.requiresDefAdmin || administersAnyDef)
   // Layer-2 capability filter — ADMIN/OWNER hold every key via ROLE_DEFAULTS, so
   // no admin bypass is needed here; the resolved capability set already lets them
   // through. Suppresses a group entirely once all its items are filtered out.

--- a/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
+++ b/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
@@ -299,10 +299,12 @@ export function EntitySidebarNav() {
             <Pencil /> Edit Entity
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem
-          onClick={() => router.push(`/app/settings/custom-fields/${entity.apiSlug}`)}>
-          <Settings /> Manage Fields
-        </DropdownMenuItem>
+        {canAdminister && (
+          <DropdownMenuItem
+            onClick={() => router.push(`/app/settings/custom-fields/${entity.apiSlug}`)}>
+            <Settings /> Manage Fields
+          </DropdownMenuItem>
+        )}
         {canRemove && <DropdownMenuSeparator />}
         {canRemove && (
           <DropdownMenuItem onClick={() => handleArchiveEntity(resource)} variant='destructive'>

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -63,6 +63,13 @@ export type SidebarProps = {
   permissionKey?: string
   /** When true, only admins/owners see this item */
   adminOnly?: boolean
+  /**
+   * When true, this item is visible to any member who administers ≥1 def
+   * (OWNER/ADMIN or a def-`admin` grantee) — Custom Fields is *derived* from
+   * def-admin, not its own Layer-2 area (perms v2 doc 09). The page itself lists
+   * only the defs the member administers.
+   */
+  requiresDefAdmin?: boolean
 } & FieldProps
 
 import type * as React from 'react'
@@ -313,9 +320,9 @@ export const SETTINGS_MENU: SidebarProps[] = [
         label: 'Custom Entities & Fields',
         slug: 'custom-fields',
         icon: <Rows3 />,
-        // TODO(perms v2 doc 09): derive from def-admin (canAdministerDef) — page
-        // lists only the defs the member administers; not yet split out.
-        access: 'ADMIN',
+        // Derived from def-admin (perms v2 doc 09): visible to any member who
+        // administers ≥1 def; the page lists only their administered defs.
+        requiresDefAdmin: true,
       },
       {
         id: 'admin-tags',

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import {
+  administersAnyDef,
   type ClientCapabilities,
   canAdministerRecord,
   canEditRecord,
@@ -67,6 +68,13 @@ interface CapabilitiesContextType {
    * degrade-only to avoid click-then-403.
    */
   canAdministerDef: (entityDefinitionId: string) => boolean
+  /**
+   * Whether the member administers ANY def — the "is there a def-admin surface
+   * for me at all" gate (e.g. showing the Custom Fields settings nav entry). True
+   * for OWNER/ADMIN or a member holding ≥1 `admin` type-grant. Server enforces
+   * the per-def actions; this only decides discoverability of the entry point.
+   */
+  administersAnyDef: boolean
   /** The current member's composed capability keys. */
   capabilities: PermissionKey[]
   isLoading: boolean
@@ -159,6 +167,7 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
       canEditEntity: (entityDefinitionId: string) => canEditRecord(resolved, entityDefinitionId),
       canAdministerDef: (entityDefinitionId: string) =>
         canAdministerRecord(resolved, entityDefinitionId),
+      administersAnyDef: administersAnyDef(resolved),
       capabilities: snapshot.keys,
       isLoading: false,
     }

--- a/apps/web/src/server/api/routers/entityDefinition.ts
+++ b/apps/web/src/server/api/routers/entityDefinition.ts
@@ -18,7 +18,7 @@ import { checkSlugExists } from '@auxx/services/entity-definitions'
 import { and, count, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '../audit-context'
-import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+import { adminProcedure, capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
 export const entityDefinitionRouter = createTRPCRouter({
   /**
@@ -91,39 +91,40 @@ export const entityDefinitionRouter = createTRPCRouter({
   /**
    * Create a new entity definition
    */
-  create: protectedProcedure
-    .input(createEntityDefinitionSchema)
-    .mutation(async ({ ctx, input }) => {
-      // Feature gate: check custom entity limit (only counts custom entities, not system ones)
-      await new FeaturePermissionService(ctx.db).requireLimit(
-        ctx.session.organizationId,
-        FeatureKey.entities,
-        async () => {
-          const [{ value }] = await ctx.db
-            .select({ value: count() })
-            .from(schema.EntityDefinition)
-            .where(
-              and(
-                eq(schema.EntityDefinition.organizationId, ctx.session.organizationId),
-                isNull(schema.EntityDefinition.entityType),
-                isNull(schema.EntityDefinition.archivedAt)
-              )
+  // Creating a NEW def is org-level (not per-def def administration), so it stays
+  // OWNER/ADMIN-only. Was `protectedProcedure` — any member could create a def
+  // (perms v2 doc 09). Editing/deleting existing defs is gated on def-`admin`.
+  create: adminProcedure.input(createEntityDefinitionSchema).mutation(async ({ ctx, input }) => {
+    // Feature gate: check custom entity limit (only counts custom entities, not system ones)
+    await new FeaturePermissionService(ctx.db).requireLimit(
+      ctx.session.organizationId,
+      FeatureKey.entities,
+      async () => {
+        const [{ value }] = await ctx.db
+          .select({ value: count() })
+          .from(schema.EntityDefinition)
+          .where(
+            and(
+              eq(schema.EntityDefinition.organizationId, ctx.session.organizationId),
+              isNull(schema.EntityDefinition.entityType),
+              isNull(schema.EntityDefinition.archivedAt)
             )
-          return value
-        }
-      )
+          )
+        return value
+      }
+    )
 
-      const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
-      const created = await service.create(input)
-      await recordAuditFromCtx(ctx, {
-        category: 'settings',
-        action: 'entityDef.created',
-        targetType: 'EntityDefinition',
-        targetId: created.id,
-        metadata: { apiSlug: input.apiSlug, singular: input.singular },
-      })
-      return created
-    }),
+    const service = new EntityDefinitionService(ctx.session.organizationId, ctx.session.user.id)
+    const created = await service.create(input)
+    await recordAuditFromCtx(ctx, {
+      category: 'settings',
+      action: 'entityDef.created',
+      targetType: 'EntityDefinition',
+      targetId: created.id,
+      metadata: { apiSlug: input.apiSlug, singular: input.singular },
+    })
+    return created
+  }),
 
   /**
    * Update an entity definition

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -2,7 +2,6 @@
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import { isAdminOrOwner } from '@auxx/lib/members'
-import { getCapabilities } from '@auxx/lib/permissions'
 import type { ResourceAccessContext } from '@auxx/lib/resource-access'
 import {
   assertCanManageMailSharing,
@@ -45,15 +44,13 @@ function toContext(ctx: {
 /**
  * Authorization for TYPE-level (def-wide) ResourceAccess reads/writes. Mail-infra
  * defs keep their mail-sharing authorization (inbox managers etc.); every other
- * def — the entity-def Access UI surface (capability layer v2 phase 3) — requires
- * **def administration** on that exact def: OWNER/ADMIN, or a def-`admin` grantee
- * of this def (§9.1/§9.2 — delegating the Access tab). Enforced at the endpoint
+ * def — the entity-def **Permissions** (Access) tab — is **OWNER/ADMIN only**.
+ *
+ * Managing record access is org-level: even a def-`admin` grantee (who can manage
+ * a def's fields/name/icon via `canAdministerDef`) may NOT set who can see/edit
+ * that def's records — that stays with admins. Enforced at the endpoint
  * independently of the page's role guard (defense in depth: a non-admin must not
  * self-grant def access via a raw call).
- *
- * `canAdministerDef` is scoped to the exact `entityDefinitionId`, so a def-`admin`
- * grantee can only manage the Access tab of the def(s) they administer — never
- * another def, and never an org-level permission (§9.3 self-escalation guard).
  */
 async function assertCanManageTypeAccess(
   ctx: { db: any; session: { organizationId: string; userId: string } },
@@ -63,11 +60,10 @@ async function assertCanManageTypeAccess(
     await assertCanManageMailTypeAccess(toContext(ctx), entityDefinitionId)
     return
   }
-  const capabilities = await getCapabilities(ctx.session.userId, ctx.session.organizationId)
-  if (!capabilities.canAdministerDef(entityDefinitionId)) {
+  if (!(await isAdminOrOwner(ctx.session.organizationId, ctx.session.userId))) {
     throw new TRPCError({
       code: 'FORBIDDEN',
-      message: 'You must be able to administer this entity to manage its type-level access',
+      message: 'You must be an admin or owner to manage record access',
     })
   }
 }

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -128,6 +128,18 @@ export function canAdministerRecord(
 }
 
 /**
+ * Whether the member administers AT LEAST ONE def — the "is there any def-admin
+ * surface for me at all" gate (e.g. showing the Custom Fields settings nav entry
+ * / listing only administered defs). OWNER/ADMIN administer every def; everyone
+ * else needs ≥1 explicit `admin` type-grant. Worker seats never administer.
+ */
+export function administersAnyDef(caps: ResolvedRecordAccess): boolean {
+  if (caps.role === 'OWNER' || caps.role === 'ADMIN') return true
+  if (SEAT_CEILINGS[caps.seatType][Area.records] === Level.None) return false
+  return Object.values(caps.defAccess).some((p) => p === ResourcePermission.admin)
+}
+
+/**
  * Serializable snapshot of a member's record-access inputs — the wire shape sent
  * to the client (dehydrated seed + `permissions.myCapabilities`). Arrays instead
  * of Sets so it is JSON-safe; the client rebuilds a {@link ResolvedRecordAccess}.

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -8,6 +8,7 @@
 // ── Shared client-safe entity-access resolver (most-specific-wins core, used by
 //    the client capabilities provider to mirror server enforcement).
 export {
+  administersAnyDef,
   type ClientCapabilities,
   canAdministerRecord,
   canEditRecord,


### PR DESCRIPTION
## Problem

Giving a member **Full** (def-\`admin\`) access on a def (e.g. tickets) did **not** let them edit that def's fields. The custom-fields settings pages still carried the pre-v2 hard guard \`useUser({ requireRoles: ['ADMIN','OWNER'] })\`, which redirects any non-admin to \`/access-denied\` — so the member was bounced before the \`canAdministerDef\`-gated field UI (#1305) could ever render. The def-admin delegation model (#1303/#1305) was wired into the *components* but never into the *page/nav entry points* (the code even flagged this with a \`TODO(perms v2 doc 09)\`).

## Changes

**Def-admin now drives Custom Fields (doc 09):**
- New client-safe \`administersAnyDef()\` helper in \`entity-access.ts\`; exposed on the capabilities provider.
- **List page** — dropped \`requireRoles\`; rows filtered to \`canAdministerDef(r.entityDefinitionId)\` (a member sees only defs they administer; admins see all); **Create** dropdown gated on \`isAdminOrOwner\`; removed a stray \`console.log\`.
- **Detail page** — dropped \`requireRoles\`; added a per-def \`canAdministerDef\` access guard.
- **Settings nav** — new \`requiresDefAdmin\` menu flag (shown when \`administersAnyDef\`) replaces the binary \`access:'ADMIN'\`, so def-admins see "Custom Entities & Fields".
- **Entity nav** — "Manage Fields" dropdown item gated on \`canAdminister\` (no click-through to access-denied).
- **Server** — \`entityDefinition.create\`: \`protectedProcedure\` → \`adminProcedure\` (creating a *new* def is org-level; closes a hole where any member could create defs).

**Record access stays admin-only (owner decision, narrows #1303):**
- The **Permissions/Access tab** renders only for OWNER/ADMIN; def-admin members get the Fields list directly.
- \`resourceAccess.assertCanManageTypeAccess\` reverts from def-\`admin\` back to OWNER/ADMIN-only for non-mail defs (mail-infra defs keep their mail-sharing authorization). Guards the \`grantType\`/\`revokeType\`/\`setAll\` writes and the \`forType\` read.

## Testing
- \`tsc --noEmit\` on \`@auxx/lib\` and \`apps/web\` — no new errors in any touched file (pre-existing baseline noise only).
- Biome clean (via lint-staged).

Plan-doc updates (README "Def-level rungs", doc 04 §9, doc 03 §3.1) are in the gitignored \`plans/\` tree, not part of this PR.