### PR TITLE
fix(trpc): surface AuxxError messages + gate table-view create-field on def-admin

### DIFF
--- a/apps/web/src/components/dynamic-table/components/add-column-button.tsx
+++ b/apps/web/src/components/dynamic-table/components/add-column-button.tsx
@@ -10,6 +10,7 @@ import { Plus } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { CustomFieldDialog } from '~/components/custom-fields/ui/custom-field-dialog'
 import { Tooltip } from '~/components/global/tooltip'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useTableConfig } from '../context/table-config-context'
 import { useSetColumnOrder, useSetColumnVisibility } from '../stores/store-actions'
 import { useColumnOrder, useColumnVisibility } from '../stores/store-selectors'
@@ -31,6 +32,11 @@ export function AddColumnButton() {
   const columnOrder = useColumnOrder(tableId)
   const setColumnVisibility = useSetColumnVisibility(tableId)
   const setColumnOrder = useSetColumnOrder(tableId)
+
+  // Creating a field is def-administration (Full/admin, server-gated in #1303);
+  // adding existing fields as columns stays open. Hide "Create field" below that.
+  const { canAdministerDef } = useAccess()
+  const canCreateField = entityDefinitionId ? canAdministerDef(entityDefinitionId) : false
 
   const handleCreateFieldClick = useCallback(() => {
     setIsOpen(false)
@@ -59,7 +65,7 @@ export function AddColumnButton() {
             <Command shouldFilter={false}>
               <CommandBreadcrumb rootLabel='Add column' />
               <AddColumnStack
-                onCreateField={handleCreateFieldClick}
+                onCreateField={canCreateField ? handleCreateFieldClick : undefined}
                 onFieldAdded={handleFieldAdded}
               />
             </Command>
@@ -67,7 +73,7 @@ export function AddColumnButton() {
         </PopoverContent>
       </Popover>
 
-      {isFieldDialogOpen && entityDefinitionId && (
+      {isFieldDialogOpen && entityDefinitionId && canCreateField && (
         <CustomFieldDialog
           open={isFieldDialogOpen}
           onOpenChange={setIsFieldDialogOpen}

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/add-column-stack.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/add-column-stack.tsx
@@ -44,7 +44,12 @@ export type ColumnNavigationItem = AddColumnNavigationItem | FieldPickerNavigati
  * what ColumnManager wants (go back to the root "visible columns" list).
  */
 interface AddColumnStackProps {
-  onCreateField: () => void
+  /**
+   * Opens the "Create field" flow. Def-administration (Full/admin) — omitted by
+   * callers for members below that rung, which hides the create-field affordance
+   * (adding EXISTING fields as columns stays open to any view author).
+   */
+  onCreateField?: () => void
   onFieldAdded?: () => void
 }
 
@@ -169,7 +174,7 @@ export function AddColumnStack({ onCreateField, onFieldAdded }: AddColumnStackPr
 export function LegacyAddColumnStack<TData = any>({
   onCreateField,
 }: {
-  onCreateField: () => void
+  onCreateField?: () => void
 }) {
   const { tableId, entityDefinitionId } = useTableConfig()
   const { table } = useTableInstance<TData>()
@@ -265,8 +270,9 @@ export function LegacyAddColumnStack<TData = any>({
           </CommandGroup>
         )}
 
-        {/* Create Field Button - only show if entity definition exists */}
-        {entityDefinitionId && (
+        {/* Create Field Button — def-admin only (onCreateField is omitted for
+            members below the Full/admin rung; see AddColumnStackProps). */}
+        {entityDefinitionId && onCreateField && (
           <>
             {filteredColumns.length > 0 && <CommandSeparator />}
             <CommandGroup>

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/column-manager.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/column-manager.tsx
@@ -32,6 +32,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { CustomFieldDialog } from '~/components/custom-fields/ui/custom-field-dialog'
 import { Tooltip } from '~/components/global/tooltip'
 import { useFields } from '~/components/resources/hooks/use-field'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useTableConfig } from '../../context/table-config-context'
 import { useTableInstance } from '../../context/table-instance-context'
 import {
@@ -324,7 +325,7 @@ function ColumnOptionsDropdown<TData = any>({
 /**
  * ColumnManagerContent - Router for navigation stacks
  */
-function ColumnManagerContent<TData = any>({ onCreateField }: { onCreateField: () => void }) {
+function ColumnManagerContent<TData = any>({ onCreateField }: { onCreateField?: () => void }) {
   const { current } = useCommandNavigation<ColumnNavigationItem>()
 
   // Check if we're in "add column" mode or drilling into a relationship
@@ -353,6 +354,12 @@ export function ColumnManager<TData = any>() {
   const setColumnVisibility = useSetColumnVisibility(tableId)
   const setColumnOrder = useSetColumnOrder(tableId)
 
+  // Creating a field mutates the def (customField.create) — a def-administration
+  // op, gated on the Full/admin rung (server: #1303). Adding EXISTING fields as
+  // columns is ordinary view authoring and stays open to any member.
+  const { canAdministerDef } = useAccess()
+  const canCreateField = entityDefinitionId ? canAdministerDef(entityDefinitionId) : false
+
   // Handler to open field dialog and close popover
   const handleCreateFieldClick = useCallback(() => {
     setIsOpen(false) // Close popover
@@ -380,14 +387,16 @@ export function ColumnManager<TData = any>() {
           <CommandNavigation<ColumnNavigationItem>>
             <Command shouldFilter={false}>
               <CommandBreadcrumb rootLabel='Columns' />
-              <ColumnManagerContent<TData> onCreateField={handleCreateFieldClick} />
+              <ColumnManagerContent<TData>
+                onCreateField={canCreateField ? handleCreateFieldClick : undefined}
+              />
             </Command>
           </CommandNavigation>
         </PopoverContent>
       </Popover>
 
       {/* Custom Field Dialog */}
-      {isFieldDialogOpen && entityDefinitionId && (
+      {isFieldDialogOpen && entityDefinitionId && canCreateField && (
         <CustomFieldDialog
           open={isFieldDialogOpen}
           onOpenChange={setIsFieldDialogOpen}

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -231,22 +231,28 @@ export const isAuxxError = (error: unknown): error is AuxxError =>
     AUXX_ERROR_NAMES.has(error.name))
 
 /**
- * Middleware that catches AuxxError instances thrown by service-layer code
- * and re-throws them as proper TRPCErrors with the correct error code.
+ * Middleware that surfaces AuxxError instances thrown by resolver/service code
+ * as proper TRPCErrors with the correct HTTP-derived code + message.
+ *
+ * IMPORTANT — tRPC v11 semantics: middleware `next()` RESOLVES with
+ * `{ ok: false, error }` for a downstream throw; it does NOT reject. So a
+ * `try/catch` around `next()` never fires for a resolver-thrown error (this used
+ * to be a `try/catch` and silently did nothing — every AuxxError got masked as a
+ * generic 500 by `errorFormatter`). tRPC has already wrapped the throw as
+ * `INTERNAL_SERVER_ERROR` with the original preserved on `.cause`; we detect that
+ * and re-throw with the real code + message so the client sees it.
  */
 const auxxErrorMiddleware = t.middleware(async ({ next }) => {
-  try {
-    return await next()
-  } catch (error) {
-    if (isAuxxError(error)) {
-      throw new TRPCError({
-        code: HTTP_TO_TRPC[error.statusCode] ?? 'INTERNAL_SERVER_ERROR',
-        message: error.message,
-        cause: error,
-      })
-    }
-    throw error
+  const result = await next()
+  if (!result.ok && isAuxxError(result.error.cause)) {
+    const cause = result.error.cause
+    throw new TRPCError({
+      code: HTTP_TO_TRPC[cause.statusCode] ?? 'INTERNAL_SERVER_ERROR',
+      message: cause.message,
+      cause,
+    })
   }
+  return result
 })
 
 /**


### PR DESCRIPTION
Two related fixes surfaced while gating the table-view **Create field** affordance.

## 1. tRPC AuxxError surfacing (systemic bug)

`auxxErrorMiddleware` wrapped `next()` in a `try/catch`, but in **tRPC v11 middleware `next()` RESOLVES with `{ ok: false, error }` for a downstream throw — it does not reject**. So the `catch` never fired, and every AuxxError thrown from a resolver/service was silently masked as a generic **"Internal server error"** by `errorFormatter`'s `INTERNAL_SERVER_ERROR` branch.

Flow (confirmed against `@trpc/server@11.10.0` internals):
1. Resolver throws e.g. `ForbiddenError` (403).
2. tRPC's `callRecursive` catches it → `getTRPCErrorFromUnknown` wraps as `TRPCError{ code: 'INTERNAL_SERVER_ERROR', cause: <AuxxError> }`.
3. `auxxErrorMiddleware`'s `catch` never runs (next resolved, didn't throw) → passes through.
4. `errorFormatter` masks the message → client toast shows "Internal server error".

**Fix:** inspect the resolved result and re-throw when `result.error.cause` is an AuxxError, mapping `statusCode → TRPC code` and preserving the message. This corrects **every** AuxxError surface across the app (permission 403s, 404s, validation, etc.), not just create-field.

## 2. Table-view "Create field" gating

Creating a field mutates the def (`customField.create`, server-gated on def-admin in #1303). The client affordance was still shown to non-def-admins. Gated on the #1305 `canAdministerDef` helper across both entry points:

- **Column manager** popover ("Create field" at the bottom of Add column).
- **Header "+" button** popover.

Adding **existing** fields as columns stays open to any view author; only field *creation* is gated. Threaded `onCreateField` as optional through `AddColumnStack` → `FieldPickerInnerContent` / `LegacyAddColumnStack` so omitting it hides the button; the `CustomFieldDialog` render is also guarded (defense-in-depth).

## Verification
- Typecheck (`apps/web`): clean on all four changed files (only pre-existing baseline errors remain).
- Biome: clean.
- Manual: def-admin sees "Create field"; non-def-admin doesn't; a raw 403 from `customField.create` now surfaces its real message in the toast instead of "Internal server error".