### PR TITLE
feat(permissions): connectors l2 area (none/full), loosen admin gate to connectors.manage

### DIFF
--- a/apps/web/src/app/(protected)/app/connectors/[connectorId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/connectors/[connectorId]/page.tsx
@@ -2,16 +2,20 @@
 
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import {
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
+  MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, Lock } from 'lucide-react'
 import { use } from 'react'
 import { ConnectorDetailView } from '~/components/data-connectors/ui/connector-detail-view'
+import { EmptyState } from '~/components/global/empty-state'
 import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 
 interface ConnectorDetailPageProps {
@@ -25,7 +29,30 @@ interface ConnectorDetailPageProps {
  */
 export default function ConnectorDetailPage({ params }: ConnectorDetailPageProps) {
   const { connectorId } = use(params)
-  const connector = api.dataConnector.getById.useQuery({ id: connectorId })
+  const { can } = useAccess()
+  const canManage = can(PermissionKey.connectorsManage)
+  const connector = api.dataConnector.getById.useQuery({ id: connectorId }, { enabled: canManage })
+
+  // Layer-2 permission gate: skip the (doomed) query and show a denied state.
+  if (!canManage) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            icon={Lock}
+            title='No Access to Connectors'
+            description="You don't have permission to manage connectors. Ask an admin for access."
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
 
   if (connector.isError || (!connector.isLoading && !connector.data)) {
     return (

--- a/apps/web/src/app/(protected)/app/connectors/page.tsx
+++ b/apps/web/src/app/(protected)/app/connectors/page.tsx
@@ -2,7 +2,7 @@
 
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { Kbd } from '@auxx/ui/components/kbd'
 import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
@@ -24,74 +24,108 @@ import { EmptyState } from '~/components/global/empty-state'
 import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
 import { ListSelectionProvider } from '~/components/list-selection'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 /**
  * Connectors index — the list view (card grid + "Connect a source" picker).
  * See plans/data-connectors/claude/05-frontend.md §1.
  */
-export default function ConnectorsPage() {
-  const { hasAccess } = useFeatureFlags()
+function ConnectorsPageContent() {
   const [pickerOpen, setPickerOpen] = useState(false)
   const [search, setSearch] = useState('')
-  const canConnect = hasAccess(FeatureKey.dataConnectors)
 
   // Page-local shortcut: N opens the "Connect a source" picker.
-  useHotkey('N', () => setPickerOpen(true), { enabled: canConnect })
+  useHotkey('N', () => setPickerOpen(true))
 
   return (
     <MainPage>
-      {canConnect && (
-        <CommandContext kind='page' label='Connectors'>
-          <CommandAction
-            label='Connect a source'
-            icon='plus'
-            keywords='connect source add data connector new'
-            shortcut={['N']}
-            priority={10}
-            perform={() => {
-              useCommandPaletteStore.getState().close()
-              setPickerOpen(true)
-            }}
-          />
-        </CommandContext>
-      )}
+      <CommandContext kind='page' label='Connectors'>
+        <CommandAction
+          label='Connect a source'
+          icon='plus'
+          keywords='connect source add data connector new'
+          shortcut={['N']}
+          priority={10}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            setPickerOpen(true)
+          }}
+        />
+      </CommandContext>
       <MainPageHeader
         action={
-          canConnect ? (
-            <Button size='sm' onClick={() => setPickerOpen(true)}>
-              <Plus />
-              Connect a source
-              <Kbd variant='default' size='sm'>
-                N
-              </Kbd>
-            </Button>
-          ) : undefined
+          <Button size='sm' onClick={() => setPickerOpen(true)}>
+            <Plus />
+            Connect a source
+            <Kbd variant='default' size='sm'>
+              N
+            </Kbd>
+          </Button>
         }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>
-        {canConnect ? (
-          <ListSelectionProvider>
-            <ListPageScroll
-              toolbar={<ConnectorsToolbar search={search} onSearchChange={setSearch} />}
-              bodyClassName='flex-1 flex flex-col min-h-0'>
-              <ConnectorList onConnect={() => setPickerOpen(true)} search={search} />
-            </ListPageScroll>
-            <ConnectorsBulkBar />
-          </ListSelectionProvider>
-        ) : (
+        <ListSelectionProvider>
+          <ListPageScroll
+            toolbar={<ConnectorsToolbar search={search} onSearchChange={setSearch} />}
+            bodyClassName='flex-1 flex flex-col min-h-0'>
+            <ConnectorList onConnect={() => setPickerOpen(true)} search={search} />
+          </ListPageScroll>
+          <ConnectorsBulkBar />
+        </ListSelectionProvider>
+      </MainPageContent>
+      <SourceTemplateDialog open={pickerOpen} onOpenChange={setPickerOpen} />
+    </MainPage>
+  )
+}
+
+export default function ConnectorsPage() {
+  const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
+
+  if (!hasAccess(FeatureKey.dataConnectors)) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
           <EmptyState
             icon={Lock}
             title='Connectors Not Available'
             description='Upgrade your plan to use data connectors.'
             button={<div className='h-12' />}
           />
-        )}
-      </MainPageContent>
-      <SourceTemplateDialog open={pickerOpen} onOpenChange={setPickerOpen} />
-    </MainPage>
-  )
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  // Layer-2 permission gate: the member holds the plan but not `connectors.manage`.
+  if (!can(PermissionKey.connectorsManage)) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            icon={Lock}
+            title='No Access to Connectors'
+            description="You don't have permission to manage connectors. Ask an admin for access."
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  return <ConnectorsPageContent />
 }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -207,7 +207,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
         slug: 'connectors',
         icon: <Cable />,
         featureKey: 'dataConnectors',
-        adminOnly: true,
+        permissionKey: 'connectors.manage',
       },
       {
         id: 'files',

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -1,7 +1,10 @@
 // apps/web/src/server/api/routers/data-connectors.ts
 // tRPC surface for Data Connectors (sync external structured records into the entity
-// system). Reads are protectedProcedure; all management + provisioning + setup is
-// adminProcedure (a connector provisions entity defs and binds credentials, 05 §1).
+// system). Management + provisioning + setup AND the connector reads are gated on the
+// Layer-2 `connectors.manage` capability (grantable to a non-admin data-ops member; a
+// connector provisions entity defs and binds credentials, 05 §1). The lone exception is
+// `list`, kept as `protectedProcedure` — it's a member-facing display primitive that
+// resolves connector names for the record-grid `ConnectorLockBadge`.
 // The backend engine (queue/scheduler/orchestrator/provisioning) lives in
 // @auxx/lib/data-connectors — this router is a thin, validated edge over it.
 
@@ -39,10 +42,11 @@ import {
   updateStream,
 } from '@auxx/lib/data-connectors'
 import { inferJsonSchema } from '@auxx/lib/json-schema/client'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { resourceFieldIdSchema } from '@auxx/types/field'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { adminProcedure, createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, permissionProcedure, protectedProcedure } from '~/server/api/trpc'
 
 // ── Shared zod shapes ─────────────────────────────────────────────────────────
 
@@ -202,8 +206,11 @@ const fieldMappingSchema = z.object({
 })
 
 export const dataConnectorRouter = createTRPCRouter({
-  // ── Reads (protected) ─────────────────────────────────────────────────────
+  // ── Reads (connectors.manage — except `list`) ─────────────────────────────
 
+  // Display-primitive carve-out: `list` stays open to any org member because the
+  // record-grid `ConnectorLockBadge` resolves connector names from it for
+  // connector-owned/contributing fields. Every other read is gated.
   list: protectedProcedure.query(async ({ ctx }) => {
     return listConnectors(ctx.db, ctx.session.organizationId)
   }),
@@ -214,7 +221,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * reads the `installedApps` org-cache (already projected with
    * `catalog.dataConnectors`) — no bundle eval, no extra query.
    */
-  catalog: protectedProcedure.query(async ({ ctx }) => {
+  catalog: permissionProcedure(PermissionKey.connectorsManage).query(async ({ ctx }) => {
     const installedApps = await getCachedInstalledApps(ctx.session.organizationId)
     const apps = installedApps.flatMap((app) =>
       (app.dataConnectors ?? []).map((dc) => ({
@@ -253,7 +260,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * `config._schema` placeholder. Built-ins expose the request builder, so they
    * carry no config schema.
    */
-  connectorSchema: protectedProcedure
+  connectorSchema: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       const result = await getConnector(ctx.db, ctx.session.organizationId, input.id)
@@ -286,20 +293,22 @@ export const dataConnectorRouter = createTRPCRouter({
       }
     }),
 
-  getById: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
-    const result = await getConnector(ctx.db, ctx.session.organizationId, input.id)
-    if (result.isErr()) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: result.error.message })
-    }
-    const connector = result.value
-    // Surface the template's declared connection hint (05c §8) so the connect UI
-    // can scope its picker to the provider/app the template expects — instead of
-    // the legacy "always mint an API key" path. `null` ⇒ no hint ⇒ open catalog.
-    const connectionHint = connector.templateId
-      ? (getConnectorTemplateById(connector.templateId)?.connection ?? null)
-      : null
-    return { ...connector, connectionHint }
-  }),
+  getById: permissionProcedure(PermissionKey.connectorsManage)
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const result = await getConnector(ctx.db, ctx.session.organizationId, input.id)
+      if (result.isErr()) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: result.error.message })
+      }
+      const connector = result.value
+      // Surface the template's declared connection hint (05c §8) so the connect UI
+      // can scope its picker to the provider/app the template expects — instead of
+      // the legacy "always mint an API key" path. `null` ⇒ no hint ⇒ open catalog.
+      const connectionHint = connector.templateId
+        ? (getConnectorTemplateById(connector.templateId)?.connection ?? null)
+        : null
+      return { ...connector, connectionHint }
+    }),
 
   /**
    * The OWNED record types this connector's app catalog declares (v6 —
@@ -311,7 +320,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * install `onComplete`. Empty for a non-app connector or one whose app declares no
    * owned targets. The owned def's stable identity is its `sourceKey` (== `ownedKey`).
    */
-  ownedTargets: protectedProcedure
+  ownedTargets: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       const result = await getConnector(ctx.db, ctx.session.organizationId, input.id)
@@ -346,7 +355,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * backfill view. Per-stream `recordsSeen`/`phase` come straight off the stream
    * states (the source of truth) rather than denormalized onto the run.
    */
-  getStatus: protectedProcedure
+  getStatus: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       const result = await getConnector(ctx.db, ctx.session.organizationId, input.id)
@@ -431,13 +440,13 @@ export const dataConnectorRouter = createTRPCRouter({
       }
     }),
 
-  listRuns: protectedProcedure
+  listRuns: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string(), limit: z.number().int().positive().max(200).optional() }))
     .query(async ({ ctx, input }) => {
       return listRuns(ctx.db, ctx.session.organizationId, input.id, input.limit)
     }),
 
-  listStreams: protectedProcedure
+  listStreams: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       // Authz: ensures the connector belongs to this org before listing. Each
@@ -451,7 +460,7 @@ export const dataConnectorRouter = createTRPCRouter({
 
   // ── Management (admin) ────────────────────────────────────────────────────
 
-  create: adminProcedure
+  create: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         name: z.string().min(1),
@@ -533,7 +542,7 @@ export const dataConnectorRouter = createTRPCRouter({
       })
     }),
 
-  update: adminProcedure
+  update: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z
         .object({
@@ -584,13 +593,13 @@ export const dataConnectorRouter = createTRPCRouter({
    * KEEPS them (reassigns ownership) instead of tearing them down. The detail view joins
    * these against the cached resource labels to spell out "shared → kept" in the confirm.
    */
-  sharedOwnedDefs: protectedProcedure
+  sharedOwnedDefs: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       return listSharedOwnedDefIds(ctx.db, ctx.session.organizationId, input.id)
     }),
 
-  delete: adminProcedure
+  delete: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         id: z.string(),
@@ -608,7 +617,7 @@ export const dataConnectorRouter = createTRPCRouter({
       )
     }),
 
-  syncNow: adminProcedure
+  syncNow: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         id: z.string(),
@@ -648,7 +657,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * §3.4). The connector leaves setup configured-but-idle; a later manual Sync now or a
    * scheduled fire advances it `ready → syncing → live`. Idempotent (no-op past pending).
    */
-  finishSetup: adminProcedure
+  finishSetup: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       return finishConnectorSetup(ctx.db, ctx.session.organizationId, input.id)
@@ -661,7 +670,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * when that backfill finalizes. The only place a `rebackfill`/`rebind` edit's
    * expensive re-crawl is requested.
    */
-  backfillPendingChange: adminProcedure
+  backfillPendingChange: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const result = await getConnector(ctx.db, ctx.session.organizationId, input.id)
@@ -682,7 +691,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * part of the authored source shape. Capped small. App connectors aren't wired
    * yet (phase 4) — guarded.
    */
-  sampleFetch: adminProcedure
+  sampleFetch: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         id: z.string(),
@@ -733,7 +742,7 @@ export const dataConnectorRouter = createTRPCRouter({
    * entity def's fields (read from the org cache). Returns the editable `FieldMapping`
    * entry shape; the UI drops them in as pre-checked rows the user confirms/edits.
    */
-  suggestMappings: adminProcedure
+  suggestMappings: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         id: z.string(),
@@ -780,7 +789,7 @@ export const dataConnectorRouter = createTRPCRouter({
       return { proposals }
     }),
 
-  addStream: adminProcedure
+  addStream: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         id: z.string(),
@@ -803,7 +812,7 @@ export const dataConnectorRouter = createTRPCRouter({
       return addStream(ctx.db, ctx.session.organizationId, id, rest)
     }),
 
-  setStreamSchema: adminProcedure
+  setStreamSchema: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         streamId: z.string(),
@@ -817,7 +826,7 @@ export const dataConnectorRouter = createTRPCRouter({
       return setStreamSchema(ctx.db, ctx.session.organizationId, streamId, rest)
     }),
 
-  setStreamRequestConfig: adminProcedure
+  setStreamRequestConfig: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         streamId: z.string(),
@@ -831,7 +840,7 @@ export const dataConnectorRouter = createTRPCRouter({
       return setStreamRequestConfig(ctx.db, ctx.session.organizationId, streamId, rest)
     }),
 
-  updateStream: adminProcedure
+  updateStream: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         streamId: z.string(),
@@ -844,7 +853,7 @@ export const dataConnectorRouter = createTRPCRouter({
       return updateStream(ctx.db, ctx.session.organizationId, streamId, rest)
     }),
 
-  removeStream: adminProcedure
+  removeStream: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ streamId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       return removeStream(ctx.db, ctx.session.organizationId, input.streamId)
@@ -852,7 +861,7 @@ export const dataConnectorRouter = createTRPCRouter({
 
   // ── Mapping setup (admin) ─────────────────────────────────────────────────
 
-  addMapping: adminProcedure
+  addMapping: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         dataConnectorStreamId: z.string(),
@@ -873,7 +882,7 @@ export const dataConnectorRouter = createTRPCRouter({
 
   // The single mapping write surface: any subset of a mapping's columns
   // (structural + target binding + per-field policy) in one patch.
-  updateMapping: adminProcedure
+  updateMapping: permissionProcedure(PermissionKey.connectorsManage)
     .input(
       z.object({
         mappingId: z.string(),
@@ -892,7 +901,7 @@ export const dataConnectorRouter = createTRPCRouter({
       return updateMapping(ctx.db, ctx.session.organizationId, mappingId, patch)
     }),
 
-  removeMapping: adminProcedure
+  removeMapping: permissionProcedure(PermissionKey.connectorsManage)
     .input(z.object({ mappingId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       return removeMapping(ctx.db, ctx.session.organizationId, input.mappingId)

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -45,6 +45,9 @@ export enum PermissionKey {
   // files
   filesView = 'files.view',
   filesManage = 'files.manage',
+
+  // connectors
+  connectorsManage = 'connectors.manage',
 }
 
 /** Metadata describing a single capability key. Mirrors `FeatureMetadata`. */
@@ -230,6 +233,15 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     group: 'Files',
     featureKey: FeatureKey.files,
   },
+
+  // ── Connectors ──
+  {
+    key: PermissionKey.connectorsManage,
+    label: 'Manage Connectors',
+    description: 'Create, configure, sync, and delete data connectors.',
+    group: 'Integrations',
+    featureKey: FeatureKey.dataConnectors,
+  },
 ]
 
 /** Lookup map for quick access to a key's metadata. */
@@ -288,6 +300,7 @@ export enum Area {
   automationRules = 'automationRules',
   auditLog = 'auditLog',
   files = 'files',
+  connectors = 'connectors',
 }
 
 /** A single rung of an area's ladder — the keys ADDED at (and above) `level`. */
@@ -461,6 +474,14 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
       { level: Level.Full, keys: [PermissionKey.filesManage] },
     ],
     featureKey: FeatureKey.files,
+  },
+  [Area.connectors]: {
+    area: Area.connectors,
+    label: 'Connectors',
+    description: 'Create, configure, sync, and delete data connectors.',
+    group: 'Integrations',
+    rungs: [{ level: Level.Full, keys: [PermissionKey.connectorsManage] }],
+    featureKey: FeatureKey.dataConnectors,
   },
 }
 

--- a/packages/lib/src/permissions/capabilities/seat-policy.ts
+++ b/packages/lib/src/permissions/capabilities/seat-policy.ts
@@ -56,6 +56,7 @@ const USER_ADMIN_NONE_AREAS = new Set<Area>([
   Area.aiConfig,
   Area.automationRules,
   Area.auditLog,
+  Area.connectors,
 ])
 
 /**


### PR DESCRIPTION
## Problem

Data-connector management is **admin-only** today (`data-connectors.ts` uses `adminProcedure`, the sidebar item is `adminOnly`). There's no way to hand connector setup/sync to a non-admin data-ops member without making them a full org admin.

## Solution

Introduce a Layer-2 `connectors` permission area (doc 10 §1), mirroring the shipped `files` area (#1306):

- **`registry.ts`** — new `PermissionKey.connectorsManage = 'connectors.manage'`, a `PERMISSION_REGISTRY` entry (UI group `Integrations`, linked to `FeatureKey.dataConnectors`), a new `Area.connectors`, and `PERMISSION_AREAS[Area.connectors]` with a single `Full` rung → `[connectorsManage]` (None grants nothing). Flows to the client automatically through the client-exported registry + dehydration + `myCapabilities` — no extra wiring (matches the files diff, which touched only `registry.ts` in `@auxx/lib`).
- **`data-connectors.ts`** — `adminProcedure` → `permissionProcedure(PermissionKey.connectorsManage)` on all management/setup/mutation procedures, and the previously member-open reads collapse behind the same key. **Exception:** `list` stays `protectedProcedure`.
- **`seat-policy.ts`** — `Area.connectors` added to `USER_ADMIN_NONE_AREAS` (default-OFF for the USER role, granted explicitly; OWNER/ADMIN still Full). Not a `WORKER_AREAS` surface.
- **Client** — `menu.tsx` connectors item `adminOnly: true` → `permissionKey: 'connectors.manage'` (kept under the existing Resources nav group — `Integrations` is only the registry *area group* for the Permissions editor, not a nav move). The connectors index and `[connectorId]` route pages gate on `can('connectors.manage')` with a denied empty state, and the index page's kbar `CommandAction` is gated with it.

## "Zero member-facing read callers" assumption — did NOT fully hold

Grepping `api.dataConnector.*` client callers surfaced one member-facing read: `list` is consumed by `useConnectorName` → `ConnectorLockBadge`, which renders in **record grids** (`dynamic-table` header/custom-field cells) and the record property panel (`property-row.tsx`) to label connector-owned/contributing fields. A non-admin member with records access but not `connectors.manage` sees those badges. Per the display-primitive carve-out, **`list` is kept open** (`protectedProcedure`) so the badge keeps resolving names; every other read (`catalog`, `connectorSchema`, `getById`, `ownedTargets`, `getStatus`, `listRuns`, `listStreams`, `sharedOwnedDefs`) is gated. All other callers live under `components/data-connectors/` (the connector management UI reachable only from the now-gated route).

## Verification

- Biome clean on all 6 touched files (the pre-existing `Map` lucide-import warning in `menu.tsx` is unrelated).
- Scoped `tsc --noEmit` for `@auxx/lib` and `apps/web` — no errors in any edited file, and no `Area`-exhaustiveness fallout elsewhere.