### PR TITLE
feat(permissions): datasets instance-access (l2 area + per-dataset sharing)

### DIFF
--- a/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-actions.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-actions.tsx
@@ -12,8 +12,10 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { Archive, Download, MoreHorizontal, RefreshCw, Trash2, Upload } from 'lucide-react'
+import { Archive, Download, MoreHorizontal, RefreshCw, Share2, Trash2, Upload } from 'lucide-react'
+import { useState } from 'react'
 import { useDatasetActions } from '~/components/datasets/hooks/use-dataset-actions'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { WorkflowSubMenu } from '~/components/workflow/workflow-submenu'
 import { useDatasetDetail } from './dataset-detail-provider'
 
@@ -22,6 +24,7 @@ import { useDatasetDetail } from './dataset-detail-provider'
  */
 export function DatasetActions() {
   const { dataset, setCurrentTab, refetch, setUploadDialogOpen } = useDatasetDetail()
+  const [shareOpen, setShareOpen] = useState(false)
 
   const { handleDelete, handleArchive, isDeleting, isArchiving, ConfirmDialog } = useDatasetActions(
     {
@@ -79,6 +82,10 @@ export function DatasetActions() {
     <>
       <div className='flex items-center gap-2'>
         {/* Primary Actions */}
+        <Button onClick={() => setShareOpen(true)} variant='outline' size='sm'>
+          <Share2 />
+          Share
+        </Button>
         <Button onClick={handleUpload} size='sm'>
           <Upload />
           Upload
@@ -115,6 +122,11 @@ export function DatasetActions() {
         </DropdownMenu>
       </div>
 
+      <InstanceShareDialog
+        recordId={toRecordId('dataset', dataset.id)}
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+      />
       <ConfirmDialog />
     </>
   )

--- a/apps/web/src/components/datasets/dataset-card.tsx
+++ b/apps/web/src/components/datasets/dataset-card.tsx
@@ -3,14 +3,16 @@
 'use client'
 
 import type { DatasetWithRelations } from '@auxx/lib/datasets'
+import { toRecordId } from '@auxx/types/resource'
 import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
 import { Badge } from '@auxx/ui/components/badge'
 import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ListCard, type ListCardStatusTone } from '@auxx/ui/components/list-card'
-import { Tooltip } from '@auxx/ui/components/tooltip'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { formatBytes } from '@auxx/utils'
-import { Archive, Database, Search, Settings, Trash } from 'lucide-react'
+import { Archive, Database, Lock, Search, Settings, Share2, Trash } from 'lucide-react'
+import { useState } from 'react'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import {
   useBulkMode,
@@ -19,6 +21,8 @@ import {
   useListSelection,
   usePendingLabel,
 } from '~/components/list-selection'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDatasetActions } from './hooks/use-dataset-actions'
 
 interface DatasetCardProps {
@@ -47,6 +51,9 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
   const pending = useIsPending(dataset.id)
   const pendingLabel = usePendingLabel()
   const toggle = useListSelection((s) => s.toggle)
+  const { isRestrictedInstance } = useAccess()
+  const [shareOpen, setShareOpen] = useState(false)
+  const isShared = isRestrictedInstance(dataset.id)
 
   const status = STATUS_DOT[dataset.status] ?? STATUS_DOT.ARCHIVED
   const creatorName = dataset.createdBy.name ?? dataset.createdBy.email ?? '?'
@@ -60,6 +67,11 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
   return (
     <>
       <ConfirmDialog />
+      <InstanceShareDialog
+        recordId={toRecordId('dataset', dataset.id)}
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+      />
       <ListCard
         onClick={onClick}
         ariaLabel={dataset.name}
@@ -75,18 +87,28 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
         subtitle={<LastUpdated timestamp={dataset.updatedAt} prefix='' includeSeconds={true} />}
         descriptionLines={0}
         badges={
-          <Badge variant='pill' size='sm' className='shrink-0'>
-            {dataset.documentCount} docs
-            <span className='mx-1 text-muted-foreground/60'>|</span>
-            {formatBytes(Number(dataset.totalSize))}
-          </Badge>
+          <>
+            {isShared && (
+              <SimpleTooltip content='Shared with specific access'>
+                <Badge variant='pill' size='sm' className='shrink-0'>
+                  <Lock className='size-3' />
+                  Shared
+                </Badge>
+              </SimpleTooltip>
+            )}
+            <Badge variant='pill' size='sm' className='shrink-0'>
+              {dataset.documentCount} docs
+              <span className='mx-1 text-muted-foreground/60'>|</span>
+              {formatBytes(Number(dataset.totalSize))}
+            </Badge>
+          </>
         }
         trailing={
-          <Tooltip content={`Created by ${creatorName}`}>
+          <SimpleTooltip content={`Created by ${creatorName}`}>
             <Avatar className='size-5'>
               <AvatarFallback className='text-[10px] font-medium'>{creatorInitial}</AvatarFallback>
             </Avatar>
-          </Tooltip>
+          </SimpleTooltip>
         }
         menu={
           <>
@@ -97,6 +119,10 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
             <DropdownMenuItem onClick={wrap(handleSettings)}>
               <Settings />
               Settings
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={wrap(() => setShareOpen(true))}>
+              <Share2 />
+              Share…
             </DropdownMenuItem>
             <FavoriteToggleMenuItem targetType='DATASET' targetIds={{ datasetId: dataset.id }} />
             <DropdownMenuSeparator />

--- a/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
+++ b/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react'
 import { useMailShare } from '~/components/mail-permissions/hooks/use-mail-share'
 import { AccessLevelsGuide } from '~/components/mail-permissions/ui/access-levels-guide'
 import { EnterpriseGate } from '~/components/mail-permissions/ui/enterprise-gate'
-import { GranteeList } from '~/components/mail-permissions/ui/grantee-list'
+import { MailGranteeList } from '~/components/mail-permissions/ui/mail-grantee-list'
 import { useUser } from '~/hooks/use-user'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
@@ -34,7 +34,7 @@ export function ContactSharedWithCard({ entityInstanceId }: DrawerTabProps) {
         participates in.
       </p>
       <EnterpriseGate className='w-full'>
-        <GranteeList
+        <MailGranteeList
           grants={grants}
           onGrant={grant}
           onChangeLens={changeLens}

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -21,8 +21,8 @@ import {
   MailPermissionsUpgradeDialog,
   useMailPermissionsGated,
 } from '~/components/mail-permissions/ui/enterprise-gate'
-import { GranteeList } from '~/components/mail-permissions/ui/grantee-list'
 import { LensSelect } from '~/components/mail-permissions/ui/lens-select'
+import { MailGranteeList } from '~/components/mail-permissions/ui/mail-grantee-list'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
@@ -602,7 +602,7 @@ export function InboxForm({
             </button>
           ) : (
             <>
-              <GranteeList
+              <MailGranteeList
                 grants={values.grants}
                 onGrant={updateGrant}
                 onChangeLens={updateGrant}

--- a/apps/web/src/components/inbox/inbox-members-page.tsx
+++ b/apps/web/src/components/inbox/inbox-members-page.tsx
@@ -7,7 +7,10 @@ import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
 import { Section } from '@auxx/ui/components/section'
 import { Plus, Users } from 'lucide-react'
-import { GranteeAddButton, GranteeList } from '~/components/mail-permissions/ui/grantee-list'
+import {
+  MailGranteeAddButton,
+  MailGranteeList,
+} from '~/components/mail-permissions/ui/mail-grantee-list'
 
 /** A grantee row as the form edits it (mirrors {@link InboxForm}'s FormGrant). */
 interface FormGrant {
@@ -65,16 +68,16 @@ export function InboxMembersPage({
         icon={<Users className='size-4' />}
         collapsible={false}
         actions={
-          <GranteeAddButton grants={grants} onGrant={onGrant} disabled={disabled}>
+          <MailGranteeAddButton grants={grants} onGrant={onGrant} disabled={disabled}>
             <Button variant='ghost' size='xs' disabled={disabled}>
               <Plus />
               Add
             </Button>
-          </GranteeAddButton>
+          </MailGranteeAddButton>
         }>
         {note && <p className='px-1 pb-2 text-muted-foreground text-xs'>{note}</p>}
 
-        <GranteeList
+        <MailGranteeList
           grants={grants}
           onGrant={onGrant}
           onChangeLens={onChangeLens}

--- a/apps/web/src/components/mail-permissions/ui/mail-grantee-list.tsx
+++ b/apps/web/src/components/mail-permissions/ui/mail-grantee-list.tsx
@@ -1,0 +1,86 @@
+// apps/web/src/components/mail-permissions/ui/mail-grantee-list.tsx
+'use client'
+
+import { LENS_LABELS, type LensChoice } from '@auxx/lib/permissions/visibility/client'
+import type { ActorId } from '@auxx/types/actor'
+import type { ReactNode } from 'react'
+import { GranteeAddButton, GranteeList } from '~/components/permissions/ui/grantee-list'
+import { LensSelect } from './lens-select'
+
+/**
+ * Mail-specialized {@link GranteeList} — the neutral list wired with the mail
+ * `LensSelect` picker and `LENS_LABELS`, new grantees defaulting to Full. Keeps
+ * the exact API the mail surfaces already use (`onChangeLens`, `includeManager`)
+ * so the Share card / thread popover / inbox pages behave identically after the
+ * list was lifted to a neutral home (§4, resolved open item #1).
+ */
+export function MailGranteeList({
+  grants,
+  onGrant,
+  onChangeLens,
+  onRevoke,
+  includeManager = false,
+  disabled = false,
+  emptyHint,
+  lockedActorIds,
+  hideAddButton,
+}: {
+  grants: Array<{ actorId: ActorId; choice: LensChoice }>
+  onGrant: (actorId: ActorId, choice: LensChoice) => void
+  onChangeLens: (actorId: ActorId, choice: LensChoice) => void
+  onRevoke: (actorId: ActorId) => void
+  includeManager?: boolean
+  disabled?: boolean
+  emptyHint?: string
+  lockedActorIds?: ActorId[]
+  hideAddButton?: boolean
+}) {
+  return (
+    <GranteeList<LensChoice>
+      grants={grants}
+      onGrant={onGrant}
+      onChange={onChangeLens}
+      onRevoke={onRevoke}
+      defaultChoice='full'
+      renderLockedLabel={(choice) => LENS_LABELS[choice].label}
+      renderPicker={({ value, onChange, disabled: rowDisabled }) => (
+        <LensSelect
+          value={value}
+          onChange={onChange}
+          includeManager={includeManager}
+          disabled={rowDisabled}
+          size='sm'
+          variant='transparent'
+          className='h-7 w-36'
+        />
+      )}
+      disabled={disabled}
+      emptyHint={emptyHint}
+      lockedActorIds={lockedActorIds}
+      hideAddButton={hideAddButton}
+    />
+  )
+}
+
+/** Mail-specialized {@link GranteeAddButton} — new grantees default to Full. */
+export function MailGranteeAddButton({
+  grants,
+  onGrant,
+  disabled = false,
+  children,
+}: {
+  grants: Array<{ actorId: ActorId; choice: LensChoice }>
+  onGrant: (actorId: ActorId, choice: LensChoice) => void
+  disabled?: boolean
+  children?: ReactNode
+}) {
+  return (
+    <GranteeAddButton<LensChoice>
+      grants={grants}
+      onGrant={onGrant}
+      defaultChoice='full'
+      disabled={disabled}>
+      {children}
+    </GranteeAddButton>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
+++ b/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
@@ -18,7 +18,7 @@ import { api } from '~/trpc/react'
 import { Tooltip } from '../../global/tooltip'
 import { AccessLevelsGuide } from './access-levels-guide'
 import { EnterpriseGate, useMailPermissionsGated } from './enterprise-gate'
-import { GranteeList } from './grantee-list'
+import { MailGranteeList } from './mail-grantee-list'
 
 /** A tiny stacked avatar for the share button's grantee cluster. */
 function MiniActorAvatar({ actorId }: { actorId: ActorId }) {
@@ -111,7 +111,7 @@ export function ThreadSharePopover({ threadId }: { threadId: string }) {
             <span className='font-medium text-sm'>Share conversation</span>
           </div>
           <div className='px-2 py-2'>
-            <GranteeList
+            <MailGranteeList
               grants={grants}
               onGrant={grant}
               onChangeLens={changeLens}

--- a/apps/web/src/components/permissions/hooks/use-instance-share.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-share.ts
@@ -1,0 +1,209 @@
+// apps/web/src/components/permissions/hooks/use-instance-share.ts
+'use client'
+
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import type { ResourceAccessInfo } from '@auxx/lib/resource-access'
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import type { RecordId } from '@auxx/types/resource'
+import { toastError } from '@auxx/ui/components/toast'
+import { useMemo } from 'react'
+import { api } from '~/trpc/react'
+
+/** Instance grant level — the raw Read/Write/Full ResourceAccess permission. */
+export type InstanceLevel = Exclude<ResourcePermission, 'none'>
+
+/**
+ * The workspace-baseline (`role:org_member`) state for an instance:
+ *  - `view`/`edit`/`admin` — everyone in the workspace gets at least this level;
+ *  - `'restricted'` — an explicit `'none'` marker (no org-wide access);
+ *  - `undefined` — no explicit baseline row: the instance falls back to its L2
+ *    area base level (for `baselineAtCreate: false` resources that's org-Read,
+ *    i.e. shared-with-org by default — until a first grant materializes it).
+ */
+export type WorkspaceBaseline = InstanceLevel | 'restricted' | undefined
+
+export interface InstanceShareGrant {
+  actorId: ActorId
+  choice: InstanceLevel
+}
+
+/** The fixed grantee for the workspace baseline (everyone in the org). */
+const WORKSPACE_GRANTEE = {
+  granteeType: ResourceGranteeType.role,
+  granteeId: 'org_member',
+} as const
+
+/**
+ * Sharing state + mutations for one instance-access resource instance (datasets
+ * etc.), keyed by its whole `RecordId`. The drop-in sibling of `useMailShare`,
+ * minus the mail-lens semantics — it writes the RAW instance grant
+ * (Read/Write/Full) over `resourceAccess.forInstance` (read) +
+ * `grantInstance`/`revokeInstance` (write).
+ *
+ * Workspace-baseline preservation (§4, "workspace-baseline preservation"):
+ * datasets are `baselineAtCreate: false`, so the moment an instance gains ANY
+ * explicit row every member WITHOUT their own row loses the org-wide base-Read.
+ * To avoid silently privatizing a dataset when it's first shared to one person,
+ * {@link grant} materializes a workspace baseline at Read on the first grant
+ * (unless the admin has already set an explicit baseline — incl. Restricted).
+ */
+export function useInstanceShare({
+  recordId,
+  enabled = true,
+}: {
+  recordId: RecordId
+  enabled?: boolean
+}) {
+  const utils = api.useUtils()
+
+  const { data: rows = [], isLoading } = api.resourceAccess.forInstance.useQuery(
+    { recordId },
+    { enabled: enabled && !!recordId }
+  )
+
+  const invalidate = () => utils.resourceAccess.forInstance.invalidate({ recordId })
+
+  const setRows = (updater: (rows: ResourceAccessInfo[]) => ResourceAccessInfo[]) => {
+    utils.resourceAccess.forInstance.setData({ recordId }, (prev) => updater(prev ?? []))
+  }
+
+  const optimisticRow = (
+    granteeType: ResourceGranteeType,
+    granteeId: string,
+    permission: ResourcePermission
+  ): ResourceAccessInfo => ({
+    id: `optimistic-${granteeType}-${granteeId}`,
+    entityDefinitionId: recordId.split(':')[0] ?? '',
+    entityInstanceId: recordId.split(':')[1] ?? null,
+    granteeType,
+    granteeId,
+    permission,
+    lens: null,
+    createdAt: new Date(),
+  })
+
+  const grantInstance = api.resourceAccess.grantInstance.useMutation({
+    onMutate: async (input) => {
+      await utils.resourceAccess.forInstance.cancel({ recordId })
+      const previous = utils.resourceAccess.forInstance.getData({ recordId })
+      setRows((rows) => [
+        optimisticRow(input.granteeType, input.granteeId, input.permission),
+        ...rows.filter(
+          (r) => !(r.granteeType === input.granteeType && r.granteeId === input.granteeId)
+        ),
+      ])
+      return { previous }
+    },
+    onError: (error, _input, context) => {
+      utils.resourceAccess.forInstance.setData({ recordId }, context?.previous)
+      toastError({ title: 'Error updating access', description: error.message })
+    },
+    onSettled: invalidate,
+  })
+
+  const revokeInstance = api.resourceAccess.revokeInstance.useMutation({
+    onMutate: async (input) => {
+      await utils.resourceAccess.forInstance.cancel({ recordId })
+      const previous = utils.resourceAccess.forInstance.getData({ recordId })
+      setRows((rows) =>
+        rows.filter(
+          (r) => !(r.granteeType === input.granteeType && r.granteeId === input.granteeId)
+        )
+      )
+      return { previous }
+    },
+    onError: (error, _input, context) => {
+      utils.resourceAccess.forInstance.setData({ recordId }, context?.previous)
+      toastError({ title: 'Error removing access', description: error.message })
+    },
+    onSettled: invalidate,
+  })
+
+  /** Actor-keyed user/group grants (excludes the workspace baseline row). */
+  const grants = useMemo<InstanceShareGrant[]>(
+    () =>
+      rows
+        .filter(
+          (r) =>
+            r.granteeType === ResourceGranteeType.user ||
+            r.granteeType === ResourceGranteeType.group
+        )
+        .map((r) => ({
+          actorId: toActorId(
+            r.granteeType === ResourceGranteeType.group ? 'group' : 'user',
+            r.granteeId
+          ),
+          choice: r.permission as InstanceLevel,
+        })),
+    [rows]
+  )
+
+  /** The workspace baseline (`role:org_member`) row, if one exists. */
+  const baselineRow = useMemo(
+    () =>
+      rows.find(
+        (r) =>
+          r.granteeType === WORKSPACE_GRANTEE.granteeType &&
+          r.granteeId === WORKSPACE_GRANTEE.granteeId
+      ),
+    [rows]
+  )
+
+  const baseline: WorkspaceBaseline = baselineRow
+    ? baselineRow.permission === ResourcePermission.none
+      ? 'restricted'
+      : (baselineRow.permission as InstanceLevel)
+    : undefined
+
+  const toGrantee = (actorId: ActorId) => {
+    const { type, id } = parseActorId(actorId)
+    return {
+      granteeType: type === 'group' ? ResourceGranteeType.group : ResourceGranteeType.user,
+      granteeId: id,
+    }
+  }
+
+  /**
+   * Grant or change a user/group's level (upsert). On the FIRST explicit row for
+   * a still-unshared instance, also materialize the workspace baseline at Read so
+   * the rest of the org keeps its base-level access instead of silently losing it.
+   */
+  const grant = (actorId: ActorId, choice: InstanceLevel) => {
+    if (rows.length === 0 && !baselineRow) {
+      grantInstance.mutate({
+        recordId,
+        granteeType: WORKSPACE_GRANTEE.granteeType,
+        granteeId: WORKSPACE_GRANTEE.granteeId,
+        permission: ResourcePermission.view,
+      })
+    }
+    const { granteeType, granteeId } = toGrantee(actorId)
+    grantInstance.mutate({ recordId, granteeType, granteeId, permission: choice })
+  }
+
+  const revoke = (actorId: ActorId) => {
+    const { granteeType, granteeId } = toGrantee(actorId)
+    revokeInstance.mutate({ recordId, granteeType, granteeId })
+  }
+
+  /** Set the workspace baseline. `'restricted'` writes the `'none'` marker. */
+  const setBaseline = (next: InstanceLevel | 'restricted') => {
+    grantInstance.mutate({
+      recordId,
+      granteeType: WORKSPACE_GRANTEE.granteeType,
+      granteeId: WORKSPACE_GRANTEE.granteeId,
+      permission: next === 'restricted' ? ResourcePermission.none : next,
+    })
+  }
+
+  return {
+    grants,
+    baseline,
+    isLoading,
+    grant,
+    changeLevel: grant,
+    revoke,
+    setBaseline,
+    isMutating: grantInstance.isPending || revokeInstance.isPending,
+  }
+}

--- a/apps/web/src/components/permissions/ui/grantee-list.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-list.tsx
@@ -1,8 +1,6 @@
-// apps/web/src/components/mail-permissions/ui/grantee-list.tsx
+// apps/web/src/components/permissions/ui/grantee-list.tsx
 'use client'
 
-import type { LensChoice } from '@auxx/lib/permissions/visibility/client'
-import { LENS_LABELS } from '@auxx/lib/permissions/visibility/client'
 import type { ActorId } from '@auxx/types/actor'
 import { parseActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
@@ -15,20 +13,34 @@ import { type ReactNode, useMemo } from 'react'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useActor } from '~/components/resources/hooks/use-actor'
 import { ActorAvatar } from '~/components/resources/ui/actor-badge'
-import { LensSelect } from './lens-select'
 
-export interface GranteeListProps {
-  grants: Array<{ actorId: ActorId; choice: LensChoice }>
-  onGrant: (actorId: ActorId, choice: LensChoice) => void
-  onChangeLens: (actorId: ActorId, choice: LensChoice) => void
+/**
+ * Render the level picker for one editable grantee row. The neutral list is
+ * agnostic to what "level" means — mail passes a `LensSelect`, instance-access
+ * passes a Read/Write/Full select (§4, resolved open item #1).
+ */
+export type RenderPicker<TChoice extends string> = (args: {
+  value: TChoice
+  onChange: (choice: TChoice) => void
+  disabled: boolean
+}) => ReactNode
+
+export interface GranteeListProps<TChoice extends string> {
+  grants: Array<{ actorId: ActorId; choice: TChoice }>
+  onGrant: (actorId: ActorId, choice: TChoice) => void
+  onChange: (actorId: ActorId, choice: TChoice) => void
   onRevoke: (actorId: ActorId) => void
-  /** Renders the Manager entry in each row's picker (inbox surface only). */
-  includeManager?: boolean
+  /** The level picker rendered in each editable row's actions slot. */
+  renderPicker: RenderPicker<TChoice>
+  /** The muted label shown in place of the picker for locked rows. */
+  renderLockedLabel: (choice: TChoice) => ReactNode
+  /** Level assigned to a newly picked grantee (mail: `full`; instance: `view`). */
+  defaultChoice: TChoice
   disabled?: boolean
   emptyHint?: string
   /**
    * Rows that render muted with a fixed level and no remove/change controls —
-   * the inbox creator's Manager grant, so the list never lies.
+   * e.g. the inbox creator's Manager grant, so the list never lies.
    */
   lockedActorIds?: ActorId[]
   /**
@@ -40,23 +52,28 @@ export interface GranteeListProps {
 
 /**
  * The reusable "who has access" list: one `TreeRow` per grantee — the actor's
- * avatar in the leading icon slot, their name as the title, and a `LensSelect`
- * plus hover-revealed remove in the actions slot. Capped off by a
+ * avatar in the leading icon slot, their name as the title, and a pluggable
+ * level picker plus a hover-revealed remove in the actions slot. Capped off by a
  * {@link GranteeAddButton} unless `hideAddButton` is set. Controlled and dumb —
- * persistence lives in the hosting surface's hook. New grantees default to Full
- * access.
+ * persistence lives in the hosting surface's hook.
+ *
+ * Lifted out of `mail-permissions/ui` (was mail-`LensSelect`-specific) to a
+ * neutral home with a pluggable picker so both mail and instance-access sharing
+ * share one list component with two pickers.
  */
-export function GranteeList({
+export function GranteeList<TChoice extends string>({
   grants,
   onGrant,
-  onChangeLens,
+  onChange,
   onRevoke,
-  includeManager = false,
+  renderPicker,
+  renderLockedLabel,
+  defaultChoice,
   disabled = false,
   emptyHint = 'Not shared with anyone yet.',
   lockedActorIds = [],
   hideAddButton = false,
-}: GranteeListProps) {
+}: GranteeListProps<TChoice>) {
   const locked = useMemo(() => new Set(lockedActorIds), [lockedActorIds])
 
   return (
@@ -74,37 +91,48 @@ export function GranteeList({
             actorId={actorId}
             choice={choice}
             isLocked={locked.has(actorId)}
-            includeManager={includeManager}
             disabled={disabled}
-            onChangeLens={onChangeLens}
+            renderPicker={renderPicker}
+            renderLockedLabel={renderLockedLabel}
+            onChange={onChange}
             onRevoke={onRevoke}
           />
         ))
       )}
 
-      {!hideAddButton && <GranteeAddButton grants={grants} onGrant={onGrant} disabled={disabled} />}
+      {!hideAddButton && (
+        <GranteeAddButton
+          grants={grants}
+          onGrant={onGrant}
+          defaultChoice={defaultChoice}
+          disabled={disabled}
+        />
+      )}
     </div>
   )
 }
 
 /**
  * The "Add people or groups" trigger — an `ActorPicker` that grants any newly
- * picked actor Full access. Extracted so surfaces can host it apart from the
+ * picked actor `defaultChoice`. Extracted so surfaces can host it apart from the
  * list (e.g. an inbox dialog's `Section` header `actions`). Pass `children` to
  * override the default ghost button.
  */
-export function GranteeAddButton({
+export function GranteeAddButton<TChoice extends string>({
   grants,
   onGrant,
+  defaultChoice,
   disabled = false,
   children,
-}: Pick<GranteeListProps, 'grants' | 'onGrant' | 'disabled'> & { children?: ReactNode }) {
+}: Pick<GranteeListProps<TChoice>, 'grants' | 'onGrant' | 'defaultChoice' | 'disabled'> & {
+  children?: ReactNode
+}) {
   const currentIds = useMemo(() => grants.map((g) => g.actorId), [grants])
 
   const handlePickerChange = (nextIds: ActorId[]) => {
     const existing = new Set(currentIds)
     for (const actorId of nextIds) {
-      if (!existing.has(actorId)) onGrant(actorId, 'full')
+      if (!existing.has(actorId)) onGrant(actorId, defaultChoice)
     }
   }
 
@@ -127,21 +155,23 @@ export function GranteeAddButton({
 }
 
 /** A single grantee row. Resolves the actor once for the avatar + name. */
-function GranteeRow({
+function GranteeRow<TChoice extends string>({
   actorId,
   choice,
   isLocked,
-  includeManager,
   disabled,
-  onChangeLens,
+  renderPicker,
+  renderLockedLabel,
+  onChange,
   onRevoke,
 }: {
   actorId: ActorId
-  choice: LensChoice
+  choice: TChoice
   isLocked: boolean
-  includeManager: boolean
   disabled: boolean
-  onChangeLens: (actorId: ActorId, choice: LensChoice) => void
+  renderPicker: RenderPicker<TChoice>
+  renderLockedLabel: (choice: TChoice) => ReactNode
+  onChange: (actorId: ActorId, choice: TChoice) => void
   onRevoke: (actorId: ActorId) => void
 }) {
   const { actor, isLoading, isNotFound } = useActor({ actorId })
@@ -158,18 +188,14 @@ function GranteeRow({
       rowClassName={cn('bg-primary-50 hover:bg-primary-100', isLocked && 'opacity-70')}
       actions={
         isLocked ? (
-          <span className='pr-2 text-muted-foreground text-xs'>{LENS_LABELS[choice].label}</span>
+          <span className='pr-2 text-muted-foreground text-xs'>{renderLockedLabel(choice)}</span>
         ) : (
           <>
-            <LensSelect
-              value={choice}
-              onChange={(next) => onChangeLens(actorId, next)}
-              includeManager={includeManager}
-              disabled={disabled}
-              size='sm'
-              variant='transparent'
-              className='h-7 w-36'
-            />
+            {renderPicker({
+              value: choice,
+              onChange: (next) => onChange(actorId, next),
+              disabled,
+            })}
             <TreeRowButton
               variant='destructive'
               disabled={disabled}

--- a/apps/web/src/components/permissions/ui/instance-share-card.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-card.tsx
@@ -1,0 +1,223 @@
+// apps/web/src/components/permissions/ui/instance-share-card.tsx
+'use client'
+
+import { ResourcePermission } from '@auxx/database/enums'
+import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId } from '@auxx/types/resource'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { Globe, Lock } from 'lucide-react'
+import { useCanAdminInstance } from '~/providers/capabilities-provider'
+import type { InstanceLevel, WorkspaceBaseline } from '../hooks/use-instance-share'
+import { useInstanceShare } from '../hooks/use-instance-share'
+import { GranteeList } from './grantee-list'
+import { INSTANCE_SHARE_COPY, type InstanceShareCopy } from './instance-share-copy'
+
+const LEVEL_ORDER: InstanceLevel[] = [
+  ResourcePermission.view,
+  ResourcePermission.edit,
+  ResourcePermission.admin,
+]
+
+const LEVEL_TIER: Record<InstanceLevel, string> = {
+  [ResourcePermission.view]: 'Read',
+  [ResourcePermission.edit]: 'Write',
+  [ResourcePermission.admin]: 'Full',
+}
+
+function levelHelper(copy: InstanceShareCopy, level: InstanceLevel): string {
+  if (level === ResourcePermission.edit) return copy.levels.write
+  if (level === ResourcePermission.admin) return copy.levels.full
+  return copy.levels.read
+}
+
+/** The Read / Write / Full picker for a grantee row. */
+function InstanceLevelSelect({
+  value,
+  onChange,
+  copy,
+  disabled,
+}: {
+  value: InstanceLevel
+  onChange: (value: InstanceLevel) => void
+  copy: InstanceShareCopy
+  disabled: boolean
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as InstanceLevel)} disabled={disabled}>
+      <SelectTrigger size='sm' variant='transparent' className='h-7 w-32'>
+        <SelectValue>{LEVEL_TIER[value]}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align='end' className='min-w-56'>
+        {LEVEL_ORDER.map((level) => (
+          <SelectItem key={level} value={level} textValue={LEVEL_TIER[level]}>
+            <div className='flex flex-col items-start'>
+              <span>{LEVEL_TIER[level]}</span>
+              <span className='text-muted-foreground text-xs'>{levelHelper(copy, level)}</span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+/** The workspace-baseline picker: Read / Write / Full + "No access (Restricted)". */
+function WorkspaceBaselineSelect({
+  value,
+  onChange,
+  copy,
+  disabled,
+}: {
+  value: InstanceLevel | 'restricted'
+  onChange: (value: InstanceLevel | 'restricted') => void
+  copy: InstanceShareCopy
+  disabled: boolean
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => onChange(v as InstanceLevel | 'restricted')}
+      disabled={disabled}>
+      <SelectTrigger size='sm' variant='transparent' className='h-7 w-40'>
+        <SelectValue>{value === 'restricted' ? 'Restricted' : LEVEL_TIER[value]}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align='end' className='min-w-56'>
+        {LEVEL_ORDER.map((level) => (
+          <SelectItem key={level} value={level} textValue={LEVEL_TIER[level]}>
+            <div className='flex flex-col items-start'>
+              <span>{LEVEL_TIER[level]}</span>
+              <span className='text-muted-foreground text-xs'>{levelHelper(copy, level)}</span>
+            </div>
+          </SelectItem>
+        ))}
+        <SelectSeparator />
+        <SelectItem value='restricted' textValue='No access'>
+          <div className='flex flex-col items-start'>
+            <span>No access (Restricted)</span>
+            <span className='text-muted-foreground text-xs'>Only people below and admins</span>
+          </div>
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}
+
+/**
+ * The workspace-baseline row (org-wide default). Rendered above the grantee list.
+ * When no explicit baseline row exists yet, an unshared `baselineAtCreate:false`
+ * resource is org-visible at Read — shown as Read so the admin sees the org has
+ * access, and switching to Restricted is the explicit opt-out.
+ */
+function WorkspaceBaselineRow({
+  baseline,
+  onChange,
+  copy,
+  disabled,
+}: {
+  baseline: WorkspaceBaseline
+  onChange: (value: InstanceLevel | 'restricted') => void
+  copy: InstanceShareCopy
+  disabled: boolean
+}) {
+  const restricted = baseline === 'restricted'
+  const display: InstanceLevel | 'restricted' = baseline ?? ResourcePermission.view
+
+  return (
+    <TreeRow
+      icon={
+        restricted ? (
+          <Lock className='size-4 text-muted-foreground' />
+        ) : (
+          <Globe className='size-4 text-muted-foreground' />
+        )
+      }
+      title='Everyone in the workspace'
+      rowClassName='bg-primary-50 hover:bg-primary-100'
+      actions={
+        <WorkspaceBaselineSelect
+          value={display}
+          onChange={onChange}
+          copy={copy}
+          disabled={disabled}
+        />
+      }
+    />
+  )
+}
+
+/**
+ * Generic per-instance Share card, keyed by a whole `RecordId` (§4). Mounted by
+ * every instance-access consumer (datasets now; KB / dashboards later) with a
+ * different `recordId` — nothing here is dataset-shaped except one entry in
+ * {@link INSTANCE_SHARE_COPY}.
+ *
+ * Rows: a workspace-baseline row (org-wide default, Read/Write/Full/Restricted)
+ * plus user/group grantees (Read/Write/Full). Editable to members who may
+ * administer the instance (OWNER/ADMIN or a `Full` grant); a read-only list
+ * otherwise, and hidden entirely when neither admin nor any grant exists (same
+ * affordance rule as `contact-shared-with-card.tsx`).
+ */
+export function InstanceShareCard({ recordId }: { recordId: RecordId }) {
+  const { entityDefinitionId: key } = parseRecordId(recordId)
+  const isSupported = key in INSTANCE_SHARE_COPY
+  const canAdmin = useCanAdminInstance(recordId)
+  const { grants, baseline, grant, changeLevel, revoke, setBaseline } = useInstanceShare({
+    recordId,
+    enabled: isSupported,
+  })
+
+  if (!isSupported) return null
+  const copy = INSTANCE_SHARE_COPY[key as keyof typeof INSTANCE_SHARE_COPY]
+  if (!canAdmin && grants.length === 0) return null
+
+  const restricted = baseline === 'restricted'
+
+  return (
+    <div className='space-y-2'>
+      <p className='text-muted-foreground text-xs'>
+        {restricted ? (
+          <>
+            This {copy.noun} is <span className='font-medium'>restricted</span> — only the people
+            below and admins can access it.
+          </>
+        ) : (
+          <>
+            This {copy.noun} is <span className='font-medium'>shared with the workspace</span>.{' '}
+            {copy.baselineHint}
+          </>
+        )}
+      </p>
+
+      <div className='space-y-0.5'>
+        <WorkspaceBaselineRow
+          baseline={baseline}
+          onChange={setBaseline}
+          copy={copy}
+          disabled={!canAdmin}
+        />
+      </div>
+
+      <GranteeList<InstanceLevel>
+        grants={grants}
+        onGrant={grant}
+        onChange={changeLevel}
+        onRevoke={revoke}
+        defaultChoice={ResourcePermission.view}
+        renderLockedLabel={(choice) => LEVEL_TIER[choice]}
+        renderPicker={({ value, onChange, disabled }) => (
+          <InstanceLevelSelect value={value} onChange={onChange} copy={copy} disabled={disabled} />
+        )}
+        disabled={!canAdmin}
+        emptyHint={`Not shared with anyone specific. Adjust the workspace default above to restrict this ${copy.noun}.`}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/permissions/ui/instance-share-copy.ts
+++ b/apps/web/src/components/permissions/ui/instance-share-copy.ts
@@ -1,0 +1,35 @@
+// apps/web/src/components/permissions/ui/instance-share-copy.ts
+
+import type { InstanceAccessKey } from '@auxx/lib/permissions/client'
+
+/**
+ * Per-resource UI copy for the generic {@link import('./instance-share-card').InstanceShareCard}
+ * — the client mirror of the server's `INSTANCE_ACCESS_RESOURCES`. Everything
+ * resource-specific about the Share card is DATA here, not code: adding KB /
+ * dashboards later is one entry each, no new component (§4).
+ */
+export interface InstanceShareCopy {
+  /** The resource noun, e.g. `'dataset'`. Used in inline copy. */
+  noun: string
+  /** The "everyone can use it by default" baseline line. */
+  baselineHint: string
+  /** What Read / Write / Full mean for this resource. */
+  levels: { read: string; write: string; full: string }
+}
+
+/**
+ * Copy keyed by {@link InstanceAccessKey}. Only the resources with an entry here
+ * render a Share card — an unsupported def part narrows out to `null`.
+ */
+export const INSTANCE_SHARE_COPY: Record<InstanceAccessKey, InstanceShareCopy> = {
+  dataset: {
+    noun: 'dataset',
+    baselineHint: 'Everyone in the workspace can use it in search and agents by default.',
+    levels: {
+      read: 'Use in search & agents',
+      write: 'Add & manage files',
+      full: 'Change settings',
+    },
+  },
+  // kb / dashboard added by their slices
+}

--- a/apps/web/src/components/permissions/ui/instance-share-dialog.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-dialog.tsx
@@ -1,0 +1,48 @@
+// apps/web/src/components/permissions/ui/instance-share-dialog.tsx
+'use client'
+
+import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId } from '@auxx/types/resource'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { InstanceShareCard } from './instance-share-card'
+import { INSTANCE_SHARE_COPY } from './instance-share-copy'
+
+/**
+ * The modal host for {@link InstanceShareCard} — the shared dialog every
+ * instance-access consumer (datasets now; KB / dashboards later) opens from its
+ * own trigger. Title/description derive from the resource's copy entry, so the
+ * dialog is generic over `recordId`.
+ */
+export function InstanceShareDialog({
+  recordId,
+  open,
+  onOpenChange,
+}: {
+  recordId: RecordId
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { entityDefinitionId: key } = parseRecordId(recordId)
+  const copy = INSTANCE_SHARE_COPY[key as keyof typeof INSTANCE_SHARE_COPY]
+  const noun = copy?.noun ?? 'item'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc' size='sm'>
+        <DialogHeader>
+          <DialogTitle className='capitalize'>Share {noun}</DialogTitle>
+          <DialogDescription>
+            Choose who can access this {noun} and what they can do.
+          </DialogDescription>
+        </DialogHeader>
+        {open && <InstanceShareCard recordId={recordId} />}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -4,8 +4,11 @@
 import {
   administersAnyDef,
   type ClientCapabilities,
+  canAdminInstance,
   canAdministerRecord,
+  canEditInstance,
   canEditRecord,
+  canViewInstance,
   canViewRecord,
   PERMISSION_REGISTRY_MAP,
   type PermissionKey,
@@ -13,6 +16,7 @@ import {
 } from '@auxx/lib/permissions/client'
 import type { SubscribeHandlers } from '@auxx/lib/realtime/client'
 import { rooms } from '@auxx/lib/realtime/client'
+import type { RecordId } from '@auxx/types/resource'
 import type React from 'react'
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { useRealtimeRoom } from '~/realtime/hooks'
@@ -75,6 +79,26 @@ interface CapabilitiesContextType {
    * the per-def actions; this only decides discoverability of the entry point.
    */
   administersAnyDef: boolean
+  /**
+   * Per-instance READ gate for instance-access resources (datasets etc.) —
+   * mirrors the server `CapabilitySet.canViewInstance`. Pass a whole `RecordId`
+   * (`toRecordId('dataset', id)`); returns `false` for any non-instance-access
+   * def part. Degrade-only; the server remains the source of truth.
+   */
+  canViewInstance: (recordId: RecordId) => boolean
+  /** Per-instance WRITE gate — mirrors the server `canEditInstance`. */
+  canEditInstance: (recordId: RecordId) => boolean
+  /**
+   * Per-instance ADMIN gate (`Full`) — mirrors the server `canAdminInstance`.
+   * Governs who may re-share an instance (the Share card's editable affordances).
+   */
+  canAdminInstance: (recordId: RecordId) => boolean
+  /**
+   * Whether an instance carries ≥1 explicit instance-access row (the org-wide
+   * `restrictedInstanceIds` signal, §1.3) — drives the "Shared"/🔒 badge. Pass
+   * the bare `entityInstanceId` (CUID), NOT a `RecordId`.
+   */
+  isRestrictedInstance: (instanceId: string) => boolean
   /** The current member's composed capability keys. */
   capabilities: PermissionKey[]
   isLoading: boolean
@@ -143,6 +167,7 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
   const value = useMemo<CapabilitiesContextType>(() => {
     const capKeys = new Set<string>(snapshot.keys)
     const resolved = toResolvedRecordAccess(snapshot)
+    const restrictedInstances = new Set<string>(snapshot.restrictedInstanceIds ?? [])
 
     const can = (key: PermissionKey | string): boolean => {
       const meta = PERMISSION_REGISTRY_MAP.get(key as PermissionKey)
@@ -168,6 +193,10 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
       canAdministerDef: (entityDefinitionId: string) =>
         canAdministerRecord(resolved, entityDefinitionId),
       administersAnyDef: administersAnyDef(resolved),
+      canViewInstance: (recordId: RecordId) => canViewInstance(resolved, recordId),
+      canEditInstance: (recordId: RecordId) => canEditInstance(resolved, recordId),
+      canAdminInstance: (recordId: RecordId) => canAdminInstance(resolved, recordId),
+      isRestrictedInstance: (instanceId: string) => restrictedInstances.has(instanceId),
       capabilities: snapshot.keys,
       isLoading: false,
     }
@@ -187,4 +216,14 @@ export function useAccess(): CapabilitiesContextType {
     throw new Error('useAccess must be used within a CapabilitiesProvider')
   }
   return context
+}
+
+/**
+ * Whether the current member may administer (re-share) an instance-access
+ * resource — OWNER/ADMIN or an explicit `Full` instance grant. Thin wrapper over
+ * {@link useAccess} for the Share card's affordance gate (§4). Server enforces;
+ * this only decides editability of the sharing UI.
+ */
+export function useCanAdminInstance(recordId: RecordId): boolean {
+  return useAccess().canAdminInstance(recordId)
 }

--- a/apps/web/src/server/api/routers/dataset.ts
+++ b/apps/web/src/server/api/routers/dataset.ts
@@ -8,11 +8,11 @@ import {
 } from '@auxx/database/enums'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { DatasetService } from '@auxx/lib/datasets'
-import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { and, count, eq, sum } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
 
 const logger = createScopedLogger('api/dataset')
 
@@ -83,12 +83,16 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Create a new dataset
    */
-  create: protectedProcedure.input(createDatasetSchema).mutation(async ({ ctx, input }) => {
+  create: capabilityProcedure.input(createDatasetSchema).mutation(async ({ ctx, input }) => {
     const organizationId = ctx.session.user.defaultOrganizationId
     const userId = ctx.session.user.id
     if (!organizationId) {
       throw new Error('No organization found')
     }
+
+    // L2 area gate: creating a dataset requires `datasets` Full (no instance
+    // exists yet to key on). Plan-AND with the Layer-1 feature/limit gate below.
+    ctx.capabilities.assert(PermissionKey.datasetsManage)
 
     // Feature gate: check datasets access + limit
     // Exclude managed datasets (e.g. KB-synced private datasets) — they don't count toward plan limits.
@@ -120,7 +124,7 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Get a dataset by ID
    */
-  getById: protectedProcedure
+  getById: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -132,6 +136,7 @@ export const datasetRouter = createTRPCRouter({
       if (!organizationId) {
         return null
       }
+      ctx.capabilities.assertViewInstance('dataset', input.id)
       const datasetService = new DatasetService(ctx.db)
       const dataset = await datasetService.getById(input.id, organizationId)
       if (!dataset) return null
@@ -157,13 +162,14 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Get processing status for a dataset
    */
-  getProcessingStatus: protectedProcedure
+  getProcessingStatus: capabilityProcedure
     .input(z.object({ datasetId: z.string() }))
     .query(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      ctx.capabilities.assertViewInstance('dataset', input.datasetId)
       // Get document processing statistics
       const [{ total }] = await ctx.db
         .select({ total: count() })
@@ -214,13 +220,11 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Delete a dataset
    */
-  delete: protectedProcedure
+  delete: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const organizationId = ctx.session.user.defaultOrganizationId
-      if (!organizationId) {
-        throw new Error('No organization found')
-      }
+      const organizationId = ctx.session.organizationId
+      ctx.capabilities.assertAdminInstance('dataset', input.id)
       const datasetService = new DatasetService(ctx.db)
       await datasetService.delete(input.id, organizationId)
       logger.info('Dataset deleted', { datasetId: input.id, organizationId })
@@ -230,13 +234,14 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Archive a dataset
    */
-  archive: protectedProcedure
+  archive: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      ctx.capabilities.assertAdminInstance('dataset', input.id)
       const datasetService = new DatasetService(ctx.db)
       await datasetService.update(input.id, organizationId, { status: 'INACTIVE' })
       logger.info('Dataset archived', { datasetId: input.id, organizationId })
@@ -245,7 +250,7 @@ export const datasetRouter = createTRPCRouter({
   /**
    * List datasets for the organization
    */
-  list: protectedProcedure.input(listDatasetsSchema).query(async ({ ctx, input }) => {
+  list: capabilityProcedure.input(listDatasetsSchema).query(async ({ ctx, input }) => {
     const organizationId = ctx.session.user.defaultOrganizationId
     if (!organizationId) {
       return { datasets: [], totalCount: 0, hasMore: false }
@@ -264,12 +269,18 @@ export const datasetRouter = createTRPCRouter({
       sortBy: input.sortBy,
       sortOrder: input.sortOrder,
     }
-    return await datasetService.list(organizationId, filters, pagination)
+    const result = await datasetService.list(organizationId, filters, pagination)
+    // Filter the page to datasets the member may view. With base-Read fallback
+    // (§0.1) nearly all rows pass; only explicitly-restricted datasets drop.
+    const datasets = result.datasets.filter((d: { id: string }) =>
+      ctx.capabilities.canViewInstance('dataset', d.id)
+    )
+    return { ...result, datasets }
   }),
   /**
    * Update a dataset
    */
-  update: protectedProcedure
+  update: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -281,6 +292,8 @@ export const datasetRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      // Full — updating a dataset's metadata / embedding / search settings.
+      ctx.capabilities.assertAdminInstance('dataset', input.id)
       logger.info('Updating dataset', { datasetId: input.id, organizationId })
       const datasetService = new DatasetService(ctx.db)
       const dataset = await datasetService.update(input.id, organizationId, input.data)
@@ -290,24 +303,29 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Get dataset statistics
    */
-  getStats: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
-    const organizationId = ctx.session.user.defaultOrganizationId
-    if (!organizationId) {
-      throw new Error('No organization found')
-    }
-    const datasetService = new DatasetService(ctx.db)
-    return await datasetService.getStats(input.id, organizationId)
-  }),
+  getStats: capabilityProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const organizationId = ctx.session.user.defaultOrganizationId
+      if (!organizationId) {
+        throw new Error('No organization found')
+      }
+      ctx.capabilities.assertViewInstance('dataset', input.id)
+      const datasetService = new DatasetService(ctx.db)
+      return await datasetService.getStats(input.id, organizationId)
+    }),
   /**
    * Update dataset metrics (document count, size, etc.)
    */
-  updateMetrics: protectedProcedure
+  updateMetrics: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      // Write — content-metrics churn (document count / size), not settings.
+      ctx.capabilities.assertEditInstance('dataset', input.id)
       const datasetService = new DatasetService(ctx.db)
       await datasetService.updateMetrics(input.id, organizationId)
       return { success: true }
@@ -315,11 +333,14 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Get organization-level dataset statistics
    */
-  getOrganizationStats: protectedProcedure.query(async ({ ctx }) => {
+  getOrganizationStats: capabilityProcedure.query(async ({ ctx }) => {
     const organizationId = ctx.session.user.defaultOrganizationId
     if (!organizationId) {
       throw new Error('No organization found')
     }
+    // Org-wide aggregate — no single instance to key on; gate on the coarse
+    // `datasets` area Read rung.
+    ctx.capabilities.assert(PermissionKey.datasetsView)
     // Get overall counts and stats from the database.
     // Managed datasets (KB-synced private datasets) are hidden from /app/datasets and
     // excluded here so the totals match what the user actually sees and can manage.
@@ -362,24 +383,27 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Get available embedding options for organization
    */
-  getAvailableEmbeddingOptions: protectedProcedure.query(async ({ ctx }) => {
+  getAvailableEmbeddingOptions: capabilityProcedure.query(async ({ ctx }) => {
     const organizationId = ctx.session.user.defaultOrganizationId
     if (!organizationId) {
       throw new Error('No organization found')
     }
+    // Org-wide option list — gate on the coarse `datasets` area Read rung.
+    ctx.capabilities.assert(PermissionKey.datasetsView)
     const datasetService = new DatasetService(ctx.db)
     return await datasetService.getAvailableEmbeddingOptions(organizationId)
   }),
   /**
    * Get recommended search configuration for a dataset
    */
-  getRecommendedSearchConfig: protectedProcedure
+  getRecommendedSearchConfig: capabilityProcedure
     .input(z.object({ datasetId: z.string() }))
     .query(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      ctx.capabilities.assertViewInstance('dataset', input.datasetId)
       // Get dataset info for recommendations
       const [dataset] = await ctx.db
         .select({
@@ -431,7 +455,7 @@ export const datasetRouter = createTRPCRouter({
   /**
    * Test search configuration with sample query
    */
-  testSearchConfig: protectedProcedure
+  testSearchConfig: capabilityProcedure
     .input(
       z.object({
         datasetId: z.string(),
@@ -446,6 +470,8 @@ export const datasetRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      // Full — testing embedding/search config is a settings-level operation.
+      ctx.capabilities.assertAdminInstance('dataset', input.datasetId)
       logger.info('Testing search configuration', {
         datasetId: input.datasetId,
         testQuery: input.testQuery,

--- a/apps/web/src/server/api/routers/document.ts
+++ b/apps/web/src/server/api/routers/document.ts
@@ -1,14 +1,55 @@
 // apps/web/src/server/api/routers/document.ts
 
+import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { ChunkingStrategyValues, DocumentStatus } from '@auxx/database/enums'
 import { DocumentService } from '@auxx/lib/datasets'
+import { NotFoundError } from '@auxx/lib/errors'
 import { createScopedLogger } from '@auxx/logger'
-import { and, asc, count, desc, eq, ilike, type SQL } from 'drizzle-orm'
+import { and, asc, count, desc, eq, ilike, inArray, type SQL } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
 
 const logger = createScopedLogger('api/document')
+
+/**
+ * Resolve a document to its parent `datasetId` — documents inherit their
+ * dataset's access level (doc 11 §3), so every document gate keys on the
+ * parent. Org-scoped; 404s a missing/foreign document.
+ */
+async function datasetIdForDocument(
+  db: Database,
+  documentId: string,
+  organizationId: string
+): Promise<string> {
+  const [row] = await db
+    .select({ datasetId: schema.Document.datasetId })
+    .from(schema.Document)
+    .where(
+      and(eq(schema.Document.id, documentId), eq(schema.Document.organizationId, organizationId))
+    )
+    .limit(1)
+  if (!row) throw new NotFoundError('Document not found')
+  return row.datasetId
+}
+
+/** Resolve a batch of documents to their distinct parent `datasetId`s (§3). */
+async function datasetIdsForDocuments(
+  db: Database,
+  documentIds: string[],
+  organizationId: string
+): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ datasetId: schema.Document.datasetId })
+    .from(schema.Document)
+    .where(
+      and(
+        inArray(schema.Document.id, documentIds),
+        eq(schema.Document.organizationId, organizationId)
+      )
+    )
+  return rows.map((r) => r.datasetId)
+}
 
 /** Preprocessing options schema for chunk settings */
 const chunkPreprocessingSchema = z.object({
@@ -37,11 +78,12 @@ export const documentRouter = createTRPCRouter({
   /**
    * List documents in a dataset
    */
-  list: protectedProcedure.input(listDocumentsSchema).query(async ({ ctx, input }) => {
+  list: capabilityProcedure.input(listDocumentsSchema).query(async ({ ctx, input }) => {
     const organizationId = ctx.session.user.defaultOrganizationId
     if (!organizationId) {
       return { documents: [], totalCount: 0, hasMore: false }
     }
+    ctx.capabilities.assertViewInstance('dataset', input.datasetId)
 
     const page = input.page
     const limit = input.limit
@@ -98,13 +140,15 @@ export const documentRouter = createTRPCRouter({
   /**
    * Get a document by ID
    */
-  getById: protectedProcedure
+  getById: capabilityProcedure
     .input(z.object({ documentId: z.string() }))
     .query(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         return null
       }
+      const datasetId = await datasetIdForDocument(ctx.db, input.documentId, organizationId)
+      ctx.capabilities.assertViewInstance('dataset', datasetId)
       const documentService = new DocumentService(ctx.db)
       return await documentService.getById(input.documentId, organizationId)
     }),
@@ -112,13 +156,15 @@ export const documentRouter = createTRPCRouter({
   /**
    * Delete a document
    */
-  delete: protectedProcedure
+  delete: capabilityProcedure
     .input(z.object({ documentId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      const datasetId = await datasetIdForDocument(ctx.db, input.documentId, organizationId)
+      ctx.capabilities.assertEditInstance('dataset', datasetId)
       const documentService = new DocumentService(ctx.db)
       await documentService.delete(input.documentId, organizationId)
       logger.info('Document deleted', {
@@ -131,13 +177,15 @@ export const documentRouter = createTRPCRouter({
   /**
    * Reprocess a document
    */
-  reprocess: protectedProcedure
+  reprocess: capabilityProcedure
     .input(z.object({ documentId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      const datasetId = await datasetIdForDocument(ctx.db, input.documentId, organizationId)
+      ctx.capabilities.assertEditInstance('dataset', datasetId)
       const documentService = new DocumentService(ctx.db)
       await documentService.reprocess(input.documentId, organizationId, {
         updateChunking: true,
@@ -152,20 +200,22 @@ export const documentRouter = createTRPCRouter({
   /**
    * Get document download URL
    */
-  getDownloadUrl: protectedProcedure
+  getDownloadUrl: capabilityProcedure
     .input(z.object({ documentId: z.string() }))
     .query(async ({ ctx, input }) => {
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         return null
       }
+      const datasetId = await datasetIdForDocument(ctx.db, input.documentId, organizationId)
+      ctx.capabilities.assertViewInstance('dataset', datasetId)
       const documentService = new DocumentService(ctx.db)
       return await documentService.getDownloadUrl(input.documentId, organizationId)
     }),
   /**
    * Update a document (title, status, enabled, chunkSettings)
    */
-  update: protectedProcedure
+  update: capabilityProcedure
     .input(
       z.object({
         documentId: z.string(),
@@ -181,6 +231,8 @@ export const documentRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      const datasetId = await datasetIdForDocument(ctx.db, input.documentId, organizationId)
+      ctx.capabilities.assertEditInstance('dataset', datasetId)
       const documentService = new DocumentService(ctx.db)
       const { documentId, ...data } = input
       await documentService.update(documentId, organizationId, data)
@@ -195,7 +247,7 @@ export const documentRouter = createTRPCRouter({
    * Create documents from existing files
    * Single endpoint, duplicate checking handled internally
    */
-  createFromExistingFiles: protectedProcedure
+  createFromExistingFiles: capabilityProcedure
     .input(
       z.object({
         fileSelections: z.array(
@@ -215,6 +267,8 @@ export const documentRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      // Write — adding files to the target dataset.
+      ctx.capabilities.assertEditInstance('dataset', input.datasetId)
       const documentService = new DocumentService(ctx.db)
       const results = await documentService.createFromExistingFiles(
         {
@@ -236,7 +290,7 @@ export const documentRouter = createTRPCRouter({
   /**
    * Batch process documents (enable, disable, archive, delete, reprocess)
    */
-  batchProcess: protectedProcedure
+  batchProcess: capabilityProcedure
     .input(
       z.object({
         documentIds: z.array(z.string()).min(1),
@@ -247,6 +301,11 @@ export const documentRouter = createTRPCRouter({
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
+      }
+      // Write — resolve each document to its dataset and require Edit on all.
+      const datasetIds = await datasetIdsForDocuments(ctx.db, input.documentIds, organizationId)
+      for (const datasetId of datasetIds) {
+        ctx.capabilities.assertEditInstance('dataset', datasetId)
       }
       const documentService = new DocumentService(ctx.db)
       const results = await documentService.batchProcess(organizationId, {

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -1,7 +1,9 @@
 // apps/web/src/server/api/routers/resourceAccess.ts
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { BadRequestError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
+import { getCapabilities, isInstanceAccessKey } from '@auxx/lib/permissions'
 import type { ResourceAccessContext } from '@auxx/lib/resource-access'
 import {
   assertCanManageMailSharing,
@@ -21,6 +23,7 @@ import {
   setTypeAccess,
 } from '@auxx/lib/resource-access'
 import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
@@ -68,6 +71,26 @@ async function assertCanManageTypeAccess(
   }
 }
 
+/**
+ * Authorize a per-INSTANCE sharing mutation (§1.6). If the target's def id is an
+ * instance-access resource (datasets etc.), managing its sharing requires
+ * `canAdminInstance(key, instanceId)` **or** OWNER/ADMIN — scoped to the exact
+ * `entityInstanceId` (no cross-instance escalation) — and returns `true` so the
+ * caller SKIPS the mail-sharing authorizer + feature gate. Returns `false` for
+ * generic mail targets (`contact:<id>`, `inbox:<id>`, …), which fall through to
+ * {@link assertCanManageMailSharing}.
+ */
+async function authorizeInstanceTarget(
+  ctx: { db: any; session: { organizationId: string; userId: string } },
+  recordId: string
+): Promise<boolean> {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId as RecordId)
+  if (!isInstanceAccessKey(entityDefinitionId)) return false
+  const capabilities = await getCapabilities(ctx.session.userId, ctx.session.organizationId)
+  capabilities.assertAdminInstance(entityDefinitionId, entityInstanceId)
+  return true
+}
+
 export const resourceAccessRouter = createTRPCRouter({
   /** Grant access to a specific entity instance */
   grantInstance: protectedProcedure
@@ -81,7 +104,13 @@ export const resourceAccessRouter = createTRPCRouter({
           ResourceGranteeType.role,
         ]),
         granteeId: z.string(),
+        // `none` is accepted only as the workspace-baseline (`role:org_member`)
+        // downward marker for instance-access resources (datasets etc. — §1.4):
+        // it restricts the instance without granting anyone. Mail-share targets
+        // never send it (their picker is view/manager). The compose + resolver
+        // already keep `'none'` instance rows as an explicit floor.
         permission: z.enum([
+          ResourcePermission.none,
           ResourcePermission.view,
           ResourcePermission.edit,
           ResourcePermission.admin,
@@ -92,8 +121,22 @@ export const resourceAccessRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const context = toContext(ctx)
       const recordId = input.recordId as RecordId
-      await assertCanManageMailSharing(context, recordId)
-      await assertMailSharingFeature(context, recordId, [input])
+      // `none` is the instance-access baseline lockdown marker (§1.4). The enum
+      // permits it, but it must never land on a mail-share target — reject it for
+      // any non-instance-access recordId (defense in depth; mail pickers never
+      // send it). Keeps the shared enum honest without a per-consumer schema.
+      if (
+        input.permission === ResourcePermission.none &&
+        !isInstanceAccessKey(parseRecordId(recordId).entityDefinitionId)
+      ) {
+        throw new BadRequestError(
+          'The "none" permission is only valid for instance-access resources'
+        )
+      }
+      if (!(await authorizeInstanceTarget(ctx, recordId))) {
+        await assertCanManageMailSharing(context, recordId)
+        await assertMailSharingFeature(context, recordId, [input])
+      }
       await grantInstanceAccess(context, {
         recordId,
         granteeType: input.granteeType,
@@ -175,10 +218,12 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const context = toContext(ctx)
-      await assertCanManageMailSharing(context, input.recordId as RecordId, {
-        selfRevokeGranteeId: input.granteeId,
-        selfRevokeGranteeType: input.granteeType,
-      })
+      if (!(await authorizeInstanceTarget(ctx, input.recordId))) {
+        await assertCanManageMailSharing(context, input.recordId as RecordId, {
+          selfRevokeGranteeId: input.granteeId,
+          selfRevokeGranteeType: input.granteeType,
+        })
+      }
       const revoked = await revokeInstanceAccess(context, {
         recordId: input.recordId as RecordId,
         granteeType: input.granteeType,
@@ -256,8 +301,10 @@ export const resourceAccessRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const context = toContext(ctx)
       const recordId = input.recordId as RecordId
-      await assertCanManageMailSharing(context, recordId)
-      await assertMailSharingFeature(context, recordId, input.grants)
+      if (!(await authorizeInstanceTarget(ctx, recordId))) {
+        await assertCanManageMailSharing(context, recordId)
+        await assertMailSharingFeature(context, recordId, input.grants)
+      }
       await setInstanceAccess(context, recordId, input.granteeType, input.grants)
       await recordAuditFromCtx(ctx, {
         category: 'security',

--- a/packages/lib/src/cache/accessor-map.ts
+++ b/packages/lib/src/cache/accessor-map.ts
@@ -41,6 +41,7 @@ export interface OrgCacheAccessorMap {
   systemUser: ScalarAccessor<string>
   hasPermissionGrants: ScalarAccessor<boolean>
   restrictedEntityDefIds: ScalarAccessor<string[]>
+  restrictedInstanceIds: ScalarAccessor<string[]>
   subscription: ScalarAccessor<CachedSubscription | null>
   orgProfile: ScalarAccessor<DehydratedOrgProfile>
 

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -75,6 +75,7 @@ export {
   getCachedResourceFields,
   getCachedResources,
   getCachedRestrictedEntityDefIds,
+  getCachedRestrictedInstanceIds,
   getCachedUserGroupIds,
   getEntityDefIdResolver,
   isAgentUser,

--- a/packages/lib/src/cache/invalidation-graph.ts
+++ b/packages/lib/src/cache/invalidation-graph.ts
@@ -171,6 +171,15 @@ export const INVALIDATION_GRAPH: Record<string, InvalidationMapping> = {
     user: ['userCapabilities'],
     org: ['restrictedEntityDefIds'],
   },
+  // Instance-level grant changes on an instance-access resource (datasets etc.)
+  // feed `instanceAccess` in the capability blob (per-user) AND the org-wide
+  // `restrictedInstanceIds` set (§1.5). Emitted ONLY when the target's def id ∈
+  // INSTANCE_ACCESS_RESOURCES, so generic mail-share instance traffic (which
+  // fires the noisy `resource-access.changed`) never churns these caches.
+  'resource-access.instance.changed': {
+    user: ['userCapabilities'],
+    org: ['restrictedInstanceIds'],
+  },
 
   // ── Capability grants (permissions plan §5.3) ──
   // Emitted by every PermissionGrant create/update/delete. User grants target a

--- a/packages/lib/src/cache/org-cache-helpers.ts
+++ b/packages/lib/src/cache/org-cache-helpers.ts
@@ -207,6 +207,16 @@ export async function getCachedRestrictedEntityDefIds(orgId: string): Promise<st
   return getOrgCache().get(orgId, 'restrictedEntityDefIds')
 }
 
+/**
+ * The org-wide set of instance ids carrying ≥1 instance-access `ResourceAccess`
+ * row (cached, §1.3). The "does this instance have an explicit row?" signal for
+ * the instance-access resolver — an instance NOT in this set falls back to its
+ * area's base L2 level.
+ */
+export async function getCachedRestrictedInstanceIds(orgId: string): Promise<string[]> {
+  return getOrgCache().get(orgId, 'restrictedInstanceIds')
+}
+
 // ── Group cache helpers ──
 
 /**

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -495,6 +495,7 @@ export interface OrgCacheDataMap {
   memberRoleMap: Record<string, { role: OrganizationRole; seatType: SeatType }>
   hasPermissionGrants: boolean // whether the org has ANY PermissionGrant rows (composition fast path)
   restrictedEntityDefIds: string[] // entity defs with ≥1 type-level ResourceAccess grant (read-path enforcement §0)
+  restrictedInstanceIds: string[] // instance ids with ≥1 instance-access ResourceAccess row (§1.3)
 
   // Business data
   features: FeatureMapObject
@@ -551,6 +552,7 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   memberRoleMap: { prefix: 'org:member-roles:v2', ttlSeconds: ONE_DAY },
   hasPermissionGrants: { prefix: 'org:has-permission-grants', ttlSeconds: ONE_DAY },
   restrictedEntityDefIds: { prefix: 'org:restricted-entity-def-ids', ttlSeconds: ONE_DAY },
+  restrictedInstanceIds: { prefix: 'org:restricted-instance-ids', ttlSeconds: ONE_DAY },
 
   // Business data (24h TTL, all invalidated via cache events)
   features: { prefix: 'org:features', ttlSeconds: THIRTY_DAYS },

--- a/packages/lib/src/cache/org-cache-service.ts
+++ b/packages/lib/src/cache/org-cache-service.ts
@@ -135,6 +135,7 @@ export class OrganizationCacheService {
       'features',
       'hasPermissionGrants',
       'restrictedEntityDefIds',
+      'restrictedInstanceIds',
     ]
 
     if (ARRAY_KEYS.includes(key)) {

--- a/packages/lib/src/cache/providers/restricted-instance-ids-provider.ts
+++ b/packages/lib/src/cache/providers/restricted-instance-ids-provider.ts
@@ -1,0 +1,38 @@
+// packages/lib/src/cache/providers/restricted-instance-ids-provider.ts
+
+import { schema } from '@auxx/database'
+import { and, eq, inArray, isNotNull } from 'drizzle-orm'
+import { INSTANCE_ACCESS_KEYS } from '../../permissions/capabilities/instance-access'
+import type { CacheProvider } from '../org-cache-provider'
+
+/**
+ * The org-wide set of `entityInstanceId`s that carry at least one
+ * **instance-level** `ResourceAccess` row (`entityInstanceId IS NOT NULL`) for
+ * an instance-access resource (datasets etc.), for ANY grantee (§1.3).
+ *
+ * This is the "does this instance have an explicit row?" signal the resolver
+ * uses (mirrors {@link import('./restricted-entity-def-ids-provider').restrictedEntityDefIdsProvider}
+ * at the instance level): an instance NOT in this set has no explicit grant and
+ * falls back to its area's base L2 level (for `baselineAtCreate: false`
+ * resources). Only rows keyed by an instance-access resource id count — generic
+ * mail-share instance rows (`contact:<id>` etc.) are excluded by the `IN (...)`
+ * filter, so they never enter the capability path.
+ *
+ * Invalidated by the `resource-access.instance.changed` cache event.
+ */
+export const restrictedInstanceIdsProvider: CacheProvider<string[]> = {
+  async compute(orgId, db) {
+    const rows = await db
+      .selectDistinct({ entityInstanceId: schema.ResourceAccess.entityInstanceId })
+      .from(schema.ResourceAccess)
+      .where(
+        and(
+          eq(schema.ResourceAccess.organizationId, orgId),
+          inArray(schema.ResourceAccess.entityDefinitionId, INSTANCE_ACCESS_KEYS),
+          isNotNull(schema.ResourceAccess.entityInstanceId)
+        )
+      )
+
+    return rows.map((r) => r.entityInstanceId).filter((id): id is string => id !== null)
+  },
+}

--- a/packages/lib/src/cache/register-providers.ts
+++ b/packages/lib/src/cache/register-providers.ts
@@ -36,6 +36,7 @@ import { publishedAppsProvider } from './providers/published-apps-provider'
 import { recordRulesProvider } from './providers/record-rules-provider'
 import { resourcesProvider } from './providers/resources-provider'
 import { restrictedEntityDefIdsProvider } from './providers/restricted-entity-def-ids-provider'
+import { restrictedInstanceIdsProvider } from './providers/restricted-instance-ids-provider'
 import { subscriptionProvider } from './providers/subscription-provider'
 import { systemUserProvider } from './providers/system-user-provider'
 import { userCapabilitiesProvider } from './providers/user-capabilities-provider'
@@ -68,6 +69,7 @@ export function registerAllProviders(
   orgCache.register('memberRoleMap', memberRoleMapProvider)
   orgCache.register('hasPermissionGrants', hasPermissionGrantsProvider)
   orgCache.register('restrictedEntityDefIds', restrictedEntityDefIdsProvider)
+  orgCache.register('restrictedInstanceIds', restrictedInstanceIdsProvider)
 
   // Org-scoped: business data
   orgCache.register('features', featuresProvider)

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -1,17 +1,20 @@
 // packages/lib/src/permissions/capabilities/capability-set.ts
 
-import type { ResourcePermission } from '@auxx/database/enums'
+import { ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { ForbiddenError } from '../../errors'
+import { satisfiesPermission } from '../../resource-access/constants'
 import {
   type ClientCapabilities,
   canAdministerRecord,
   canEditRecord,
   canViewRecord,
+  levelToPermission,
   NON_RECORD_DEF_SLUGS,
   type ResolvedRecordAccess,
 } from './entity-access'
-import { PERMISSION_REGISTRY_MAP, PermissionKey } from './registry'
+import { INSTANCE_ACCESS_RESOURCES, type InstanceAccessKey } from './instance-access'
+import { areaLevelFromKeys, Level, PERMISSION_REGISTRY_MAP, PermissionKey } from './registry'
 import { ENTITY_WRITE_KEYS } from './seat-policy'
 
 /**
@@ -49,6 +52,13 @@ export class CapabilitySet {
    *                   `entityDefinitionId` resolver (the keyspace of `defAccess`
    *                   / `restrictedDefIds`). Distinct from {@link defIdToSlug},
    *                   which resolves to the write-key slug.
+   * @param instanceAccess Highest instance-level ResourceAccess permission per
+   *                   `entityInstanceId` (CUID) for the instance-access resources
+   *                   (datasets etc., §1.4). Explicit `'none'` rows are kept.
+   * @param restrictedInstanceIds Org-wide set of instance ids carrying ≥1
+   *                   instance-access row for *anyone*. An instance NOT in this
+   *                   set has no explicit row → falls back to its area's base L2
+   *                   level (for `baselineAtCreate: false` resources).
    */
   constructor(
     private readonly keys: ReadonlySet<PermissionKey>,
@@ -57,7 +67,9 @@ export class CapabilitySet {
     readonly seatType: SeatType,
     private readonly defIdToSlug: DefIdToSlug = (id) => id,
     private readonly restrictedDefIds: ReadonlySet<string> = new Set(),
-    private readonly defIdToDefinitionId: DefIdToSlug = (id) => id
+    private readonly defIdToDefinitionId: DefIdToSlug = (id) => id,
+    private readonly instanceAccess: Readonly<Record<string, ResourcePermission>> = {},
+    private readonly restrictedInstanceIds: ReadonlySet<string> = new Set()
   ) {}
 
   /** O(1) Set lookup — whether the member holds `key`. */
@@ -125,6 +137,8 @@ export class CapabilitySet {
       restrictedEntityDefIds: [...this.restrictedDefIds],
       role: this.role,
       seatType: this.seatType,
+      instanceAccess: { ...this.instanceAccess },
+      restrictedInstanceIds: [...this.restrictedInstanceIds],
     }
   }
 
@@ -240,6 +254,61 @@ export class CapabilitySet {
   assertAdministerDef(entityDefId: string): void {
     if (this.canAdministerDef(entityDefId)) return
     throw new ForbiddenError("You don't have permission to administer this definition.")
+  }
+
+  /**
+   * Effective per-instance permission for an instance-access resource
+   * (most-specific-wins), or `undefined` = no access (§1.4). OWNER/ADMIN bypass
+   * to `admin`; the coarse L2 area gate must be open; an explicit instance row
+   * (incl. the workspace baseline / `'none'`) wins; otherwise fall back to the
+   * base L2 area level (for `baselineAtCreate: false` resources). Zero I/O.
+   */
+  private effectiveInstanceLevel(
+    key: InstanceAccessKey,
+    instanceId: string
+  ): ResourcePermission | undefined {
+    if (this.role === 'OWNER' || this.role === 'ADMIN') return ResourcePermission.admin
+    const cfg = INSTANCE_ACCESS_RESOURCES[key]
+    const areaLevel = areaLevelFromKeys(this.keys, cfg.area)
+    if (areaLevel === Level.None) return undefined
+    if (this.restrictedInstanceIds.has(instanceId)) return this.instanceAccess[instanceId]
+    return cfg.baselineAtCreate ? undefined : levelToPermission(areaLevel)
+  }
+
+  /** Whether the member may VIEW the instance (Read). Zero I/O. */
+  canViewInstance(key: InstanceAccessKey, instanceId: string): boolean {
+    const level = this.effectiveInstanceLevel(key, instanceId)
+    return level !== undefined && satisfiesPermission(level, ResourcePermission.view)
+  }
+
+  /** Whether the member may EDIT the instance's contents (Write). Zero I/O. */
+  canEditInstance(key: InstanceAccessKey, instanceId: string): boolean {
+    const level = this.effectiveInstanceLevel(key, instanceId)
+    return level !== undefined && satisfiesPermission(level, ResourcePermission.edit)
+  }
+
+  /** Whether the member may ADMINISTER the instance + its settings (Full). Zero I/O. */
+  canAdminInstance(key: InstanceAccessKey, instanceId: string): boolean {
+    const level = this.effectiveInstanceLevel(key, instanceId)
+    return level !== undefined && satisfiesPermission(level, ResourcePermission.admin)
+  }
+
+  /** {@link canViewInstance} as a throwing guard (403). */
+  assertViewInstance(key: InstanceAccessKey, instanceId: string): void {
+    if (this.canViewInstance(key, instanceId)) return
+    throw new ForbiddenError("You don't have permission to view this.")
+  }
+
+  /** {@link canEditInstance} as a throwing guard (403). */
+  assertEditInstance(key: InstanceAccessKey, instanceId: string): void {
+    if (this.canEditInstance(key, instanceId)) return
+    throw new ForbiddenError("You don't have permission to edit this.")
+  }
+
+  /** {@link canAdminInstance} as a throwing guard (403). */
+  assertAdminInstance(key: InstanceAccessKey, instanceId: string): void {
+    if (this.canAdminInstance(key, instanceId)) return
+    throw new ForbiddenError("You don't have permission to manage this.")
   }
 
   /** The capability key required to write the given RecordId-def part. */

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
@@ -21,6 +21,14 @@ import { ROLE_DEFAULTS, SEAT_CEILINGS } from './seat-policy'
 export interface UserCapabilities {
   keys: PermissionKey[]
   defAccess: Record<string, ResourcePermission>
+  /**
+   * Highest instance-level ResourceAccess permission per `entityInstanceId`
+   * (CUID) for the instance-access resources (datasets etc., §1.2). Keys are
+   * globally-unique instance ids, so no `resourceKey` disambiguation is needed.
+   * Unlike `defAccess`, explicit `'none'` rows are KEPT — they are the per-
+   * instance downward marker (a real grant outranks them via {@link PERMISSION_RANK}).
+   */
+  instanceAccess: Record<string, ResourcePermission>
 }
 
 /**
@@ -63,8 +71,29 @@ export function composeUserCapabilities(input: {
   /** Sparse levels on the member's direct user grant (raise-only, L3). */
   userLevels?: Partial<Record<Area, Level>>
   typeAccessRows: Array<{ entityDefinitionId: string; permission: ResourcePermission }>
+  /** Instance-level rows (entityInstanceId IS NOT NULL) for the instance-access resources. */
+  instanceAccessRows?: Array<{ entityInstanceId: string; permission: ResourcePermission }>
 }): UserCapabilities {
-  const { role, seatType, orgPolicyLevels, groupLevels, userLevels, typeAccessRows } = input
+  const {
+    role,
+    seatType,
+    orgPolicyLevels,
+    groupLevels,
+    userLevels,
+    typeAccessRows,
+    instanceAccessRows = [],
+  } = input
+
+  // instanceAccess: highest permission wins per instance. `'none'` is KEPT here
+  // (unlike defAccess) — it is the per-instance downward marker; a real grant
+  // outranks it via PERMISSION_RANK.
+  const instanceAccess: Record<string, ResourcePermission> = {}
+  for (const row of instanceAccessRows) {
+    const existing = instanceAccess[row.entityInstanceId]
+    if (!existing || PERMISSION_RANK[row.permission] > PERMISSION_RANK[existing]) {
+      instanceAccess[row.entityInstanceId] = row.permission
+    }
+  }
 
   // defAccess: highest permission wins per definition. Computed regardless of
   // role so admins carry it too (they simply also hold every capability key).
@@ -82,7 +111,7 @@ export function composeUserCapabilities(input: {
   }
 
   // Fail closed: a non-member holds no capabilities.
-  if (!role) return { keys: [], defAccess }
+  if (!role) return { keys: [], defAccess, instanceAccess }
 
   const isAdmin = role === 'OWNER' || role === 'ADMIN'
   const ceiling = SEAT_CEILINGS[seatType]
@@ -105,5 +134,5 @@ export function composeUserCapabilities(input: {
     return Math.min(raised, ceiling[area]) as Level
   })
 
-  return { keys: expandLevelsToKeys(resolved), defAccess }
+  return { keys: expandLevelsToKeys(resolved), defAccess, instanceAccess }
 }

--- a/packages/lib/src/permissions/capabilities/compute-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compute-user-capabilities.ts
@@ -3,8 +3,9 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import type { ResourcePermission } from '@auxx/database/enums'
-import { and, eq, inArray, isNull, or } from 'drizzle-orm'
+import { and, eq, inArray, isNotNull, isNull, or } from 'drizzle-orm'
 import { composeUserCapabilities, type UserCapabilities } from './compose-user-capabilities'
+import { INSTANCE_ACCESS_KEYS } from './instance-access'
 import { type Area, type Level, parseAreaLevels } from './registry'
 
 /**
@@ -35,7 +36,13 @@ export async function computeUserCapabilities(
   const seatType = entry?.seatType ?? 'full'
 
   // Non-member: fail closed without touching the DB.
-  if (!role) return composeUserCapabilities({ role: undefined, seatType, typeAccessRows: [] })
+  if (!role)
+    return composeUserCapabilities({
+      role: undefined,
+      seatType,
+      typeAccessRows: [],
+      instanceAccessRows: [],
+    })
 
   const isAdmin = role === 'OWNER' || role === 'ADMIN'
 
@@ -106,7 +113,29 @@ export async function computeUserCapabilities(
       )
     )
 
-  const [grantRows, typeAccessRows] = await Promise.all([grantRowsPromise, typeAccessPromise])
+  // Second ResourceAccess query: INSTANCE-level rows (entityInstanceId IS NOT
+  // NULL) for the instance-access resources (datasets etc., §1.2), reusing the
+  // same grantee union. Keyed on the globally-unique instance CUID alone.
+  const instanceAccessPromise = db
+    .select({
+      entityInstanceId: schema.ResourceAccess.entityInstanceId,
+      permission: schema.ResourceAccess.permission,
+    })
+    .from(schema.ResourceAccess)
+    .where(
+      and(
+        eq(schema.ResourceAccess.organizationId, organizationId),
+        inArray(schema.ResourceAccess.entityDefinitionId, INSTANCE_ACCESS_KEYS),
+        isNotNull(schema.ResourceAccess.entityInstanceId),
+        or(...accessConditions)
+      )
+    )
+
+  const [grantRows, typeAccessRows, instanceAccessRows] = await Promise.all([
+    grantRowsPromise,
+    typeAccessPromise,
+    instanceAccessPromise,
+  ])
 
   // Split the sparse-jsonb rows into the three composition tiers (§5).
   let orgPolicyLevels: Partial<Record<Area, Level>> | undefined
@@ -127,6 +156,10 @@ export async function computeUserCapabilities(
     userLevels,
     typeAccessRows: typeAccessRows as Array<{
       entityDefinitionId: string
+      permission: ResourcePermission
+    }>,
+    instanceAccessRows: instanceAccessRows as Array<{
+      entityInstanceId: string
       permission: ResourcePermission
     }>,
   })

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -3,7 +3,12 @@
 import { ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { satisfiesPermission } from '../../resource-access/constants'
-import { Area, Level, PermissionKey } from './registry'
+import {
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+  isInstanceAccessKey,
+} from './instance-access'
+import { Area, areaLevelFromKeys, Level, PermissionKey } from './registry'
 import { SEAT_CEILINGS } from './seat-policy'
 
 /**
@@ -47,6 +52,16 @@ export interface ResolvedRecordAccess {
   defAccess: Readonly<Record<string, ResourcePermission>>
   /** Defs carrying ≥1 type-level grant for anyone (`entityDefinitionId` keyspace). */
   restrictedEntityDefIds: ReadonlySet<string>
+  /**
+   * Highest instance-level grant per `entityInstanceId` (CUID) for the
+   * instance-access resources (datasets etc., §1.4). Explicit `'none'` rows are
+   * KEPT (the per-instance downward marker). Optional — absent = `{}` (the
+   * server `CapabilitySet.resolved()` view omits it; only the client instance
+   * resolver reads it, always via {@link toResolvedRecordAccess}).
+   */
+  instanceAccess?: Readonly<Record<string, ResourcePermission>>
+  /** Org-wide set of instance ids carrying ≥1 instance-access row. Optional (see above). */
+  restrictedInstanceIds?: ReadonlySet<string>
 }
 
 /**
@@ -58,6 +73,19 @@ export interface ResolvedRecordAccess {
 export function baseRecordsLevel(keys: ReadonlySet<PermissionKey>): ResourcePermission | undefined {
   if (keys.has(PermissionKey.recordsEdit)) return ResourcePermission.edit
   if (keys.has(PermissionKey.recordsView)) return ResourcePermission.view
+  return undefined
+}
+
+/**
+ * Map an L2 area {@link Level} to the {@link ResourcePermission} vocabulary the
+ * instance-access resolver speaks (Read→view · Edit→edit · Full→admin ·
+ * None→undefined). Used as the absent-instance-row fallback for
+ * `baselineAtCreate: false` resources (§1.4).
+ */
+export function levelToPermission(level: Level): ResourcePermission | undefined {
+  if (level >= Level.Full) return ResourcePermission.admin
+  if (level >= Level.Edit) return ResourcePermission.edit
+  if (level >= Level.Read) return ResourcePermission.view
   return undefined
 }
 
@@ -150,6 +178,15 @@ export interface ClientCapabilities {
   restrictedEntityDefIds: string[]
   role: OrganizationRole
   seatType: SeatType
+  /**
+   * Highest instance-level permission per `entityInstanceId` (instance-access
+   * resources — datasets etc., §1.4). Optional: carried in the dehydration seed
+   * so the client instance-access resolver (a later slice) and any server-built
+   * snapshot have it; absent = treat as `{}`.
+   */
+  instanceAccess?: Record<string, ResourcePermission>
+  /** Org-wide set of instance ids carrying ≥1 instance-access row. Optional (see above). */
+  restrictedInstanceIds?: string[]
 }
 
 /** Rebuild the Set-backed {@link ResolvedRecordAccess} from a wire snapshot. */
@@ -160,5 +197,79 @@ export function toResolvedRecordAccess(caps: ClientCapabilities): ResolvedRecord
     keys: new Set(caps.keys),
     defAccess: caps.defAccess,
     restrictedEntityDefIds: new Set(caps.restrictedEntityDefIds),
+    instanceAccess: caps.instanceAccess ?? {},
+    restrictedInstanceIds: new Set(caps.restrictedInstanceIds ?? []),
   }
+}
+
+/**
+ * Parse a `RecordId` (`entityDefinitionId:entityInstanceId`) into its parts.
+ * Local, dependency-free split (first colon) so this pure module stays
+ * client-safe without importing `@auxx/types`.
+ */
+function parseInstanceRecordId(recordId: string): { key: string; instanceId: string } {
+  const i = recordId.indexOf(':')
+  if (i === -1) return { key: recordId, instanceId: '' }
+  return { key: recordId.slice(0, i), instanceId: recordId.slice(i + 1) }
+}
+
+/**
+ * The member's effective per-instance permission for an instance-access resource
+ * (most-specific-wins) — the CLIENT mirror of
+ * {@link import('./capability-set').CapabilitySet}'s private
+ * `effectiveInstanceLevel`, kept byte-for-byte in sync so client affordances and
+ * server enforcement never drift (§1.4):
+ *  - OWNER/ADMIN → `admin` (bypass — never self-lock).
+ *  - L2 area gate closed (`None`) → `undefined`.
+ *  - explicit instance row (incl. workspace baseline / `'none'`) → wins.
+ *  - otherwise fall back to the base L2 area level (`baselineAtCreate: false`).
+ */
+function effectiveInstanceLevel(
+  caps: ResolvedRecordAccess,
+  key: InstanceAccessKey,
+  instanceId: string
+): ResourcePermission | undefined {
+  if (caps.role === 'OWNER' || caps.role === 'ADMIN') return ResourcePermission.admin
+  const cfg = INSTANCE_ACCESS_RESOURCES[key]
+  const areaLevel = areaLevelFromKeys(caps.keys, cfg.area)
+  if (areaLevel === Level.None) return undefined
+  if ((caps.restrictedInstanceIds ?? EMPTY_INSTANCE_SET).has(instanceId)) {
+    return caps.instanceAccess?.[instanceId]
+  }
+  return cfg.baselineAtCreate ? undefined : levelToPermission(areaLevel)
+}
+
+const EMPTY_INSTANCE_SET: ReadonlySet<string> = new Set()
+
+/**
+ * Instance-access VIEW gate (Read) — the client mirror of
+ * `CapabilitySet.canViewInstance`. Takes a whole `RecordId`; returns `false` for
+ * any def part that is not a registered instance-access resource. Zero I/O.
+ */
+export function canViewInstance(caps: ResolvedRecordAccess, recordId: string): boolean {
+  const { key, instanceId } = parseInstanceRecordId(recordId)
+  if (!isInstanceAccessKey(key)) return false
+  const level = effectiveInstanceLevel(caps, key, instanceId)
+  return level !== undefined && satisfiesPermission(level, ResourcePermission.view)
+}
+
+/**
+ * Instance-access EDIT gate (Write) — mirror of `CapabilitySet.canEditInstance`.
+ */
+export function canEditInstance(caps: ResolvedRecordAccess, recordId: string): boolean {
+  const { key, instanceId } = parseInstanceRecordId(recordId)
+  if (!isInstanceAccessKey(key)) return false
+  const level = effectiveInstanceLevel(caps, key, instanceId)
+  return level !== undefined && satisfiesPermission(level, ResourcePermission.edit)
+}
+
+/**
+ * Instance-access ADMIN gate (Full) — mirror of `CapabilitySet.canAdminInstance`.
+ * Governs the Share card's editable affordances (who may re-share the instance).
+ */
+export function canAdminInstance(caps: ResolvedRecordAccess, recordId: string): boolean {
+  const { key, instanceId } = parseInstanceRecordId(recordId)
+  if (!isInstanceAccessKey(key)) return false
+  const level = effectiveInstanceLevel(caps, key, instanceId)
+  return level !== undefined && satisfiesPermission(level, ResourcePermission.admin)
 }

--- a/packages/lib/src/permissions/capabilities/get-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/get-capabilities.ts
@@ -4,6 +4,7 @@ import type { ResourcePermission } from '@auxx/database/enums'
 import {
   getCachedResources,
   getCachedRestrictedEntityDefIds,
+  getCachedRestrictedInstanceIds,
   getCachedUserCapabilities,
   getOrgCache,
 } from '../../cache'
@@ -66,11 +67,12 @@ export async function getCapabilities(
   orgId: string,
   _db?: unknown
 ): Promise<CapabilitySet> {
-  const [caps, roleMap, resources, restrictedDefIds] = await Promise.all([
+  const [caps, roleMap, resources, restrictedDefIds, restrictedInstanceIds] = await Promise.all([
     getCachedUserCapabilities(userId, orgId),
     getOrgCache().get(orgId, 'memberRoleMap'),
     getCachedResources(orgId),
     getCachedRestrictedEntityDefIds(orgId),
+    getCachedRestrictedInstanceIds(orgId),
   ])
 
   const entry = roleMap[userId]
@@ -92,6 +94,8 @@ export async function getCapabilities(
     }
   }
 
+  // instanceAccess keys on the globally-unique instance CUID (Dataset.id etc.),
+  // so — unlike defAccess — no keyspace normalization is needed (§1.2).
   return new CapabilitySet(
     new Set(caps.keys),
     defAccess,
@@ -99,6 +103,8 @@ export async function getCapabilities(
     seatType,
     buildDefIdToSlug(resources),
     new Set(restrictedDefIds.map(toDefinitionId)),
-    toDefinitionId
+    toDefinitionId,
+    caps.instanceAccess ?? {},
+    new Set(restrictedInstanceIds)
   )
 }

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -15,6 +15,13 @@ export {
   getGranteeLevels,
   setGranteeLevels,
 } from './grant-service'
+export {
+  INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+  type InstanceAccessResourceConfig,
+  isInstanceAccessKey,
+} from './instance-access'
 export { resolveLinkedRecordIds } from './record-view-scope'
 export {
   AREA_ORDER,

--- a/packages/lib/src/permissions/capabilities/instance-access.ts
+++ b/packages/lib/src/permissions/capabilities/instance-access.ts
@@ -1,0 +1,39 @@
+// packages/lib/src/permissions/capabilities/instance-access.ts
+
+import { Area } from './registry'
+
+/**
+ * Per-resource declaration for instance-level access (doc 08 §1.1 / doc 11 §1.1).
+ *  - `baselineAtCreate` — whether every instance is born with a workspace
+ *    baseline row. `false` (datasets): a resource with no explicit instance rows
+ *    falls back to the member's base L2 `area` level (org-shared). `true`
+ *    (future: dashboards): no-row ⇒ no access.
+ *  - `area` — the coarse L2 capability {@link Area} that gates "may this member
+ *    touch the feature at all" AND supplies the absent-row fallback level.
+ */
+export interface InstanceAccessResourceConfig {
+  baselineAtCreate: boolean
+  area: Area
+}
+
+/**
+ * The registry of resources that use instance-level `ResourceAccess` grants
+ * (doc 11 §1.1). Keyed by the resource's non-CUID access key (a system resource
+ * id or reserved slug). Datasets is the first entry; KB / dashboards are added
+ * by later slices. Everything downstream is generic over {@link InstanceAccessKey}.
+ */
+export const INSTANCE_ACCESS_RESOURCES = {
+  // org-shared; absent instance row → base L2 `datasets` level (§0.1)
+  dataset: { baselineAtCreate: false, area: Area.datasets },
+} as const satisfies Record<string, InstanceAccessResourceConfig>
+
+/** The set of resource keys backed by instance-level access. */
+export type InstanceAccessKey = keyof typeof INSTANCE_ACCESS_RESOURCES
+
+/** All instance-access resource keys (for `IN (...)` queries and set membership). */
+export const INSTANCE_ACCESS_KEYS = Object.keys(INSTANCE_ACCESS_RESOURCES) as InstanceAccessKey[]
+
+/** Type guard — whether an arbitrary `entityDefinitionId` is an instance-access key. */
+export function isInstanceAccessKey(key: string): key is InstanceAccessKey {
+  return Object.hasOwn(INSTANCE_ACCESS_RESOURCES, key)
+}

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -48,6 +48,11 @@ export enum PermissionKey {
 
   // connectors
   connectorsManage = 'connectors.manage',
+
+  // datasets (instance-access resource — per-dataset ResourceAccess grants, §2)
+  datasetsView = 'datasets.view',
+  datasetsEdit = 'datasets.edit',
+  datasetsManage = 'datasets.manage',
 }
 
 /** Metadata describing a single capability key. Mirrors `FeatureMetadata`. */
@@ -242,6 +247,29 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     group: 'Integrations',
     featureKey: FeatureKey.dataConnectors,
   },
+
+  // ── Datasets ──
+  {
+    key: PermissionKey.datasetsView,
+    label: 'View Datasets',
+    description: 'Browse and use datasets in search and agents.',
+    group: 'Knowledge',
+    featureKey: FeatureKey.datasets,
+  },
+  {
+    key: PermissionKey.datasetsEdit,
+    label: 'Contribute to Datasets',
+    description: 'Add and manage the files inside datasets.',
+    group: 'Knowledge',
+    featureKey: FeatureKey.datasets,
+  },
+  {
+    key: PermissionKey.datasetsManage,
+    label: 'Manage Datasets',
+    description: 'Create, delete, and configure datasets and their settings.',
+    group: 'Knowledge',
+    featureKey: FeatureKey.datasets,
+  },
 ]
 
 /** Lookup map for quick access to a key's metadata. */
@@ -301,6 +329,7 @@ export enum Area {
   auditLog = 'auditLog',
   files = 'files',
   connectors = 'connectors',
+  datasets = 'datasets',
 }
 
 /** A single rung of an area's ladder — the keys ADDED at (and above) `level`. */
@@ -483,6 +512,18 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
     rungs: [{ level: Level.Full, keys: [PermissionKey.connectorsManage] }],
     featureKey: FeatureKey.dataConnectors,
   },
+  [Area.datasets]: {
+    area: Area.datasets,
+    label: 'Datasets',
+    description: 'Browse and use datasets, contribute files, or manage them and their settings.',
+    group: 'Knowledge',
+    rungs: [
+      { level: Level.Read, keys: [PermissionKey.datasetsView] },
+      { level: Level.Edit, keys: [PermissionKey.datasetsEdit] },
+      { level: Level.Full, keys: [PermissionKey.datasetsManage] },
+    ],
+    featureKey: FeatureKey.datasets,
+  },
 }
 
 /** Stable area ordering — drives every iteration over areas. */
@@ -531,4 +572,23 @@ export function expandLevelsToKeys(levels: Partial<Record<Area, Level>>): Permis
     }
   }
   return PERMISSION_KEY_ORDER.filter((key) => held.has(key))
+}
+
+/**
+ * The inverse of {@link expandLevelsToKeys} for a single area: recover the
+ * member's effective {@link Level} for `area` from an already-materialized
+ * (seat-clamped, composed) PermissionKey set. Walks the area's rungs in
+ * ascending order and returns the highest rung whose keys are all held,
+ * stopping at the first gap (rungs are cumulative, so this matches the
+ * expansion semantics). Absent rungs ⇒ {@link Level.None}. Pure, zero I/O —
+ * used by the instance-access resolver to read the coarse L2 area gate + base
+ * fallback level from a {@link import('./capability-set').CapabilitySet}.
+ */
+export function areaLevelFromKeys(keys: ReadonlySet<PermissionKey>, area: Area): Level {
+  let level = Level.None
+  for (const rung of PERMISSION_AREAS[area].rungs) {
+    if (rung.keys.every((key) => keys.has(key))) level = rung.level
+    else break
+  }
+  return level
 }

--- a/packages/lib/src/permissions/capabilities/seat-policy.ts
+++ b/packages/lib/src/permissions/capabilities/seat-policy.ts
@@ -60,14 +60,31 @@ const USER_ADMIN_NONE_AREAS = new Set<Area>([
 ])
 
 /**
+ * Areas whose USER default is `Read` (not the binary None/Full). The first such
+ * area is `datasets` (§0.2): everyone should *see and use* datasets in search
+ * and agents by default, but *contributing files* (Edit) or *changing settings*
+ * (Full) is a deliberate L2 rung bump or per-dataset instance grant. Without a
+ * Read default, per-dataset share-up grants would be meaningless (base already
+ * Full).
+ */
+const USER_READ_AREAS = new Set<Area>([Area.datasets])
+
+/**
  * What each role gets out of the box, per area (before grants + seat clamp).
  * OWNER/ADMIN short-circuit to Full anyway; USER is Full everywhere except the
- * org-administration areas in {@link USER_ADMIN_NONE_AREAS}, which are `None`.
+ * org-administration areas in {@link USER_ADMIN_NONE_AREAS} (`None`) and the
+ * {@link USER_READ_AREAS} (`Read`).
  */
 export const ROLE_DEFAULTS: Record<OrganizationRole, Record<Area, Level>> = {
   OWNER: ALL_FULL,
   ADMIN: ALL_FULL,
-  USER: buildAreaLevels((area) => (USER_ADMIN_NONE_AREAS.has(area) ? Level.None : Level.Full)),
+  USER: buildAreaLevels((area) =>
+    USER_ADMIN_NONE_AREAS.has(area)
+      ? Level.None
+      : USER_READ_AREAS.has(area)
+        ? Level.Read
+        : Level.Full
+  ),
 }
 
 /**

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -10,8 +10,11 @@
 export {
   administersAnyDef,
   type ClientCapabilities,
+  canAdminInstance,
   canAdministerRecord,
+  canEditInstance,
   canEditRecord,
+  canViewInstance,
   canViewRecord,
   effectiveRecordLevel,
   NON_RECORD_DEF_SLUGS,
@@ -19,6 +22,15 @@ export {
   toResolvedRecordAccess,
 } from './capabilities/entity-access'
 export type { GranteeGrant, GrantGranteeType } from './capabilities/grant-service'
+// ── Instance-access registry (client-safe: instance-access.ts only imports
+//    `Area` from registry.ts, already client-exported above).
+export {
+  INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+  type InstanceAccessResourceConfig,
+  isInstanceAccessKey,
+} from './capabilities/instance-access'
 // ── Capability registry (Layer 2) — client-safe: registry.ts only imports
 //    `FeatureKey` from `./types`, which is already client-exported above.
 export type { AreaMetadata, PermissionMetadata } from './capabilities/registry'

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -12,6 +12,13 @@ export {
   listGranteeGrants,
   setGranteeLevels,
 } from './capabilities/grant-service'
+export {
+  INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+  type InstanceAccessResourceConfig,
+  isInstanceAccessKey,
+} from './capabilities/instance-access'
 export { resolveLinkedRecordIds } from './capabilities/record-view-scope'
 export {
   AREA_ORDER,

--- a/packages/lib/src/resource-access/resource-access-service.ts
+++ b/packages/lib/src/resource-access/resource-access-service.ts
@@ -6,6 +6,7 @@ import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm'
 import { getCachedUserGroupIds, onCacheEvent } from '../cache'
+import { isInstanceAccessKey } from '../permissions/capabilities/instance-access'
 import { satisfiesPermission } from './constants'
 import type {
   AccessCheckResult,
@@ -104,6 +105,48 @@ async function emitResourceAccessTypeChanged(
 }
 
 /**
+ * Emit the narrow instance-level cache event that busts the `userCapabilities`
+ * `instanceAccess` map + the org-wide `restrictedInstanceIds` set after an
+ * INSTANCE-level ResourceAccess mutation whose target is an instance-access
+ * resource (datasets etc., §1.5). Same user/broadcast fan-out shape as
+ * {@link emitResourceAccessTypeChanged}; kept separate so generic mail-share
+ * instance traffic (which only fires {@link emitResourceAccessChanged}) never
+ * churns these caches. Also publishes `publishCapabilitiesChanged` so other
+ * members' live sessions re-compose (phase 4 §10). Call AFTER the write commits.
+ */
+async function emitResourceAccessInstanceChanged(
+  organizationId: string,
+  grantees: Array<{ granteeType: ResourceGranteeType; granteeId: string }>
+): Promise<void> {
+  const userIds = new Set<string>()
+  let broadcast = false
+  for (const g of grantees) {
+    if (g.granteeType === ResourceGranteeType.user) userIds.add(g.granteeId)
+    else broadcast = true
+  }
+
+  // Lazy import — the cache invalidation path lazily imports realtime, so this
+  // module must not statically import the realtime barrel back (import cycle).
+  const { getRealtimeService, publishCapabilitiesChanged } = await import('../realtime')
+
+  if (broadcast) {
+    await onCacheEvent('resource-access.instance.changed', {
+      orgId: organizationId,
+      broadcastUserKeys: true,
+    })
+    await publishCapabilitiesChanged(getRealtimeService(), { orgId: organizationId })
+    return
+  }
+
+  await Promise.all(
+    Array.from(userIds).map(async (userId) => {
+      await onCacheEvent('resource-access.instance.changed', { orgId: organizationId, userId })
+      await publishCapabilitiesChanged(getRealtimeService(), { userId })
+    })
+  )
+}
+
+/**
  * Grant access to a specific entity instance.
  */
 export async function grantInstanceAccess(
@@ -141,9 +184,11 @@ export async function grantInstanceAccess(
       },
     })
 
-  await emitResourceAccessChanged(organizationId, [
-    { granteeType: input.granteeType, granteeId: input.granteeId },
-  ])
+  const grantees = [{ granteeType: input.granteeType, granteeId: input.granteeId }]
+  await emitResourceAccessChanged(organizationId, grantees)
+  if (isInstanceAccessKey(entityDefinitionId)) {
+    await emitResourceAccessInstanceChanged(organizationId, grantees)
+  }
 }
 
 /**
@@ -210,9 +255,11 @@ export async function revokeInstanceAccess(
     .returning()
 
   if (result.length > 0) {
-    await emitResourceAccessChanged(organizationId, [
-      { granteeType: input.granteeType, granteeId: input.granteeId },
-    ])
+    const grantees = [{ granteeType: input.granteeType, granteeId: input.granteeId }]
+    await emitResourceAccessChanged(organizationId, grantees)
+    if (isInstanceAccessKey(entityDefinitionId)) {
+      await emitResourceAccessInstanceChanged(organizationId, grantees)
+    }
   }
 
   return result.length > 0
@@ -296,10 +343,11 @@ export async function setInstanceAccess(
 
   // Affected grantees = removed ∪ added (a removed grantee also loses access).
   const affected = new Set([...removed.map((r) => r.granteeId), ...grants.map((g) => g.granteeId)])
-  await emitResourceAccessChanged(
-    organizationId,
-    Array.from(affected, (granteeId) => ({ granteeType, granteeId }))
-  )
+  const grantees = Array.from(affected, (granteeId) => ({ granteeType, granteeId }))
+  await emitResourceAccessChanged(organizationId, grantees)
+  if (isInstanceAccessKey(entityDefinitionId)) {
+    await emitResourceAccessInstanceChanged(organizationId, grantees)
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Instance-access slice #1 (permissions v2, plans doc 08 §1 + §3B / doc 11): the reusable **instance-level `ResourceAccess`** mechanism — built once — with **datasets** as its first consumer. Gives per-dataset access ("Support can read the returns dataset", "data-ops manages the imports dataset") composed most-specific-wins under a coarse L2 area, OWNER/ADMIN bypass, seat ceiling as the floor.

KB and dashboards ride the same mechanism in later slices (one registry entry + one card trigger each).

## How

**§1 — shared mechanism**
- `INSTANCE_ACCESS_RESOURCES` registry (`dataset` entry only for now).
- `instanceAccess` map on the capability blob: a second `ResourceAccess` query (`entityInstanceId IS NOT NULL`), keyed on the globally-unique instance CUID; `'none'` rows kept as the per-instance floor.
- `restrictedInstanceIds` org-cache provider + event wiring.
- `CapabilitySet.canView/Edit/AdminInstance` (+ asserts) — most-specific-wins; absent row falls back to the base L2 level for `baselineAtCreate:false` resources.
- `resource-access.instance.changed` event → invalidation graph + `publishCapabilitiesChanged`.
- Instance-target sharing authorizer branch on `resourceAccess.grantInstance/revokeInstance/setInstance` (`canAdminInstance` or OWNER/ADMIN, scoped to the exact instance).

**§2 — L2 `datasets` area**
- `datasets.view/edit/manage` keys, `Area.datasets` (None/Read/Write/Full, `Knowledge` group, `FeatureKey.datasets`).
- USER default rung = **Read** (new `USER_READ_AREAS`; first non-binary USER default), worker = None.

**§3 — enforcement**
- `dataset.ts` + `document.ts` → `capabilityProcedure`; gates on `('dataset', id)`; documents inherit via `Document.datasetId` (batch resolves distinct datasets).

**§4 — share UI**
- Client instance resolver (`canView/Edit/AdminInstance`) wired through `capabilities-provider`'s `useAccess()` + `useCanAdminInstance`.
- `useInstanceShare` hook with **workspace-baseline preservation**: the first grant materializes an org-Read baseline so sharing never silently privatizes the dataset for everyone else. A "Restricted" option writes the `'none'` baseline to make it private.
- Generic `InstanceShareCard` + dialog + `INSTANCE_SHARE_COPY` (keyed by `recordId`); dataset-detail header Share button + card `⋯`/🔒 badge.
- `GranteeList` lifted to a neutral home with a pluggable picker; mail wrapped in `MailGranteeList` (behavior unchanged; all 4 mail importers updated).

**Enum note:** `grantInstance` now accepts the `'none'` baseline marker (mirrors the existing `grantType`), guarded to instance-access targets only (`BadRequestError` for mail targets).

## Testing

- Per-package `tsc --noEmit` (lib + web): no new type errors in changed files (pre-existing baselines only).
- Biome clean.
- Mail sharing path (contact card / thread popover / inbox pages) verified behavior-identical after the `GranteeList` lift.

## Notes / follow-ups

- Datasets settings-nav gating and KB/dashboards verticals are out of scope (later slices).
- `setInstance` doesn't accept `'none'` (only `grantInstance` needs it for the baseline) — consistent for now.