### PR TITLE
fix(permissions): bump userCapabilities cache to v2 (new-area rollout invalidation)

### DIFF
--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -104,5 +104,11 @@ export const USER_CACHE_KEY_CONFIG: Record<
   // v2: inboxLens values normalized to scalar lenses (cached entries built
   // from the pre-v5 `inboxes` shape carried SINGLE_SELECT arrays).
   userMailVisibility: { prefix: 'user:mail-visibility:v2', ttlSeconds: ONE_DAY },
-  userCapabilities: { prefix: 'user:capabilities:v1', ttlSeconds: ONE_DAY },
+  // v2: instance-access slice (#1313) added the `instanceAccess` field + the
+  // `datasets` L2 area/keys. Pre-#1313 blobs lack the datasets area entirely, so
+  // their expanded key set is missing `datasets.*` (even admins 403 on
+  // `datasets.view`). Bump to abandon every stale blob → recompute on next read.
+  // NOTE: bump this whenever the registry's area/key set or the UserCapabilities
+  // shape changes, so a rollout can't leave members on a stale key set.
+  userCapabilities: { prefix: 'user:capabilities:v2', ttlSeconds: ONE_DAY },
 }


### PR DESCRIPTION
## What

Bumps the `userCapabilities` cache prefix `user:capabilities:v1 → v2`.

## Why

#1313 added the `datasets` L2 area + keys and the `instanceAccess` field to the `UserCapabilities` shape. A capability blob cached under `v1` **before** that deploy has no `datasets` level, so its expanded key set is missing `datasets.*` — and because the coarse `assert(key)` gate has **no OWNER/ADMIN bypass** (unlike `assertViewInstance`), even admins get a 403 on e.g. `dataset.getOrganizationStats` (`assert(datasets.view)`).

The org-cache flush doesn't fix this: `userCapabilities` is a **user-tier** key (`user:capabilities:*`), not org-tier (`org:*`), so `flushOrganization` never touches it. Without a version bump the stale blob persists for up to the 1-day TTL — meaning every real admin would 403 on the new area for up to a day after `datasets` ships.

## Fix

Bumping the prefix abandons every stale `v1` blob on deploy; each member recomputes on next read (fresh compute includes `datasets.*` for everyone via the Read default / Full ceiling). Matches the existing `userMailVisibility:v2` precedent in the same file. Added a note to bump this whenever the registry's area/key set or the `UserCapabilities` shape changes, so future new-area rollouts don't repeat the gap.

## Testing

- One-line prefix change; no logic touched.
- Verified in dev: flushing `user:capabilities:*` resolved the admin 403 (recompute picks up `datasets.view`); the running server already emits `v2` keys after the change.