### PR TITLE
fix(permissions): gate datasets ui on l2 area + fix realtime nav update

### DIFF
--- a/apps/web/src/app/(protected)/app/datasets/page.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/page.tsx
@@ -2,7 +2,7 @@
 
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
 import {
@@ -26,6 +26,7 @@ import {
 } from '~/components/datasets'
 import { EmptyState } from '~/components/global/empty-state'
 import { ListSelectionProvider } from '~/components/list-selection'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 /**
@@ -48,7 +49,9 @@ function DatasetsPageContent() {
 
         {/* Filters + Datasets Content */}
         <ListSelectionProvider>
-          <ListPageScroll toolbar={<DatasetsFilterBar />}>
+          <ListPageScroll
+            toolbar={<DatasetsFilterBar />}
+            bodyClassName='flex-1 flex flex-col min-h-0'>
             {isLoading ? (
               <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
                 {[...Array(8)].map((_, i) => (
@@ -75,6 +78,7 @@ function DatasetsPageContent() {
  */
 export default function DatasetsPage() {
   const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
 
   if (!hasAccess(FeatureKey.datasets)) {
     return (
@@ -89,6 +93,29 @@ export default function DatasetsPage() {
             icon={Lock}
             title='Datasets Not Available'
             description='Upgrade your plan to use datasets.'
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  // Layer-2 permission gate: the member holds the plan but not `datasets.view`.
+  // Without this the page mounts DatasetsProvider, whose getOrganizationStats
+  // query 403s server-side.
+  if (!can(PermissionKey.datasetsView)) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Datasets' href='/app/datasets' />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            icon={Lock}
+            title='No Access to Datasets'
+            description="You don't have permission to view datasets. Ask an admin for access."
             button={<div className='h-12' />}
           />
         </MainPageContent>

--- a/apps/web/src/components/datasets/create-dataset-button.tsx
+++ b/apps/web/src/components/datasets/create-dataset-button.tsx
@@ -2,11 +2,12 @@
 
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { Database, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { CreateDatasetDialog } from './create-dataset-dialog'
 import { useDatasets } from './datasets-provider'
@@ -21,9 +22,16 @@ export function CreateDatasetButton({
 } = {}) {
   const [limitDialogOpen, setLimitDialogOpen] = useState(false)
   const { isAtLimit, getLimit } = useFeatureFlags()
+  const { can } = useAccess()
   const { stats } = useDatasets()
   const atLimit = isAtLimit(FeatureKey.datasetsLimit, stats?.total ?? 0)
   const datasetLimit = getLimit(FeatureKey.datasetsLimit)
+
+  // Creating a dataset requires the `datasets` Full rung (`datasets.manage`);
+  // Read/Edit members can browse and contribute but not create.
+  if (!can(PermissionKey.datasetsManage)) {
+    return null
+  }
 
   if (atLimit) {
     return (

--- a/apps/web/src/components/global/sidebar/nav-main.tsx
+++ b/apps/web/src/components/global/sidebar/nav-main.tsx
@@ -10,6 +10,7 @@ import {
 } from '@auxx/ui/components/sidebar'
 import { usePathname } from 'next/navigation'
 import type * as React from 'react'
+import { useMemo } from 'react'
 import type { SidebarProps } from '~/constants/menu'
 import { useUser } from '~/hooks/use-user'
 import { useAccess } from '~/providers/capabilities-provider'
@@ -25,6 +26,18 @@ type Props = {
   /** Optional per-item action renderers, keyed by item id */
   itemActions?: Record<string, () => React.ReactNode>
 }
+
+function getUrl(url: string, parentSlug?: string, childSlug?: string) {
+  let fullUrl = `${url}`
+  if (parentSlug) {
+    fullUrl += `/${parentSlug}`
+  }
+  if (childSlug) {
+    fullUrl += `/${childSlug}`
+  }
+  return fullUrl
+}
+
 export function NavMain({ menu, itemActions }: Props) {
   const pathname = usePathname()
   const { getGroupOpen, toggleGroup } = useSidebarStateContext()
@@ -38,55 +51,39 @@ export function NavMain({ menu, itemActions }: Props) {
     toggleGroup('configurations')
   }
 
-  function getUrl(url: string, parentSlug?: string, childSlug?: string) {
-    let fullUrl = `${url}`
-    if (parentSlug) {
-      fullUrl += `/${parentSlug}`
-    }
-    if (childSlug) {
-      fullUrl += `/${childSlug}`
-    }
-    return fullUrl
-  }
+  // Filter items by feature access + Layer-2 capability (and admin-only gates)
+  // then compute URLs — into NEW objects, never mutating the shared `menu.items`
+  // (the module-level `SIDEBAR_MENU`, also read by the command palette). Mutating
+  // it would permanently prune entries: once an item is filtered out it could
+  // never reappear when a realtime permission change re-grants access. Memoized
+  // on the gate identities, which change exactly when capabilities/features do.
+  const menuItems = useMemo(() => {
+    return menu.items
+      .filter((item) => !item.featureKey || hasAccess(item.featureKey))
+      .filter((item) => !item.permissionKey || can(item.permissionKey))
+      .filter((item) => !item.adminOnly || isAdminOrOwner)
+      .map((item) => {
+        const subItems = item.items
+          ?.filter((sub) => !sub.featureKey || hasAccess(sub.featureKey))
+          .filter((sub) => !sub.permissionKey || can(sub.permissionKey))
+          .filter((sub) => !sub.adminOnly || isAdminOrOwner)
+          .map((sub) => ({
+            ...sub,
+            url: item.skipParentSlug
+              ? getUrl(menu.route, undefined, sub.slug)
+              : getUrl(menu.route, item.slug, sub.slug),
+          }))
 
-  // Filter items by feature access + Layer-2 capability (and admin-only gates
-  // for top-level entries). The capability check collapses a field seat's
-  // sidebar to just their granted surfaces automatically.
-  const filteredItems = menu.items
-    .filter((item) => !item.featureKey || hasAccess(item.featureKey))
-    .filter((item) => !item.permissionKey || can(item.permissionKey))
-    .filter((item) => !item.adminOnly || isAdminOrOwner)
-    .map((item) => ({
-      ...item,
-      items: item.items
-        ?.filter((sub) => !sub.featureKey || hasAccess(sub.featureKey))
-        .filter((sub) => !sub.permissionKey || can(sub.permissionKey))
-        .filter((sub) => !sub.adminOnly || isAdminOrOwner),
-    }))
-    .filter((item) => !item.items || item.items.length > 0)
-
-  // Process menu.items URLs
-  menu.items = filteredItems.map((item) => {
-    if (item.items && item.items.length > 0) {
-      item.items = item.items.map((subItem) => {
-        if (item.skipParentSlug) {
-          // Parent has skipParentSlug flag - skip parent slug for all children
-          subItem.url = getUrl(menu.route, undefined, subItem.slug)
-        } else {
-          subItem.url = getUrl(menu.route, item.slug, subItem.slug)
+        if (subItems && subItems.length > 0) {
+          // Explicit `url` on the entry wins (navigable group homes like
+          // /app/dispatch); else fall back to the first child. preventNavigation
+          // still decides whether clicking the row navigates at all.
+          return { ...item, items: subItems, url: item.url ?? subItems[0].url }
         }
-        return subItem
+        return { ...item, items: subItems, url: getUrl(menu.route, item.slug) }
       })
-
-      // Handle parent URL — an explicit `url` on the menu entry wins (navigable group
-      // homes like /app/dispatch); otherwise fall back to the first child for consistency.
-      // preventNavigation still decides whether clicking the row navigates at all.
-      item.url = item.url ?? item.items[0].url
-    } else {
-      item.url = getUrl(menu.route, item.slug)
-    }
-    return item
-  })
+      .filter((item) => !item.items || item.items.length > 0)
+  }, [menu, can, hasAccess, isAdminOrOwner])
 
   function isActive(item: SidebarProps) {
     if (item.items?.length) {
@@ -114,7 +111,7 @@ export function NavMain({ menu, itemActions }: Props) {
       />
       <SidebarGroupCollapse open={isOpen}>
         <SidebarMenu>
-          {menu.items.map((item) => (
+          {menuItems.map((item) => (
             <div key={item.id}>
               {item.items?.length ? (
                 <CollapsibleSidebarSection

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -193,6 +193,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
         slug: 'datasets',
         icon: <Database />,
         featureKey: 'datasets',
+        permissionKey: 'datasets.view',
       },
       {
         id: 'kb',

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -23,11 +23,18 @@ import { SEAT_CEILINGS } from './seat-policy'
  */
 
 /**
- * Mail/messaging infrastructure def slugs — visibility governed OUTSIDE the
- * records area (the mail visibility system), so record-level view/edit gates
- * pass them through. Keyed by entity slug; the caller resolves the def to its
- * slug before checking. (Moved here from `capability-set.ts` so the client can
- * apply the same carve-out.)
+ * Def slugs whose visibility is governed OUTSIDE the records area, so record-level
+ * view/edit gates pass them through:
+ * - **Mail/messaging infrastructure** (`inbox`…`sequence`) — the mail visibility
+ *   system.
+ * - **Instance-access resources** (`dataset`) — their own L2 area + per-instance
+ *   `ResourceAccess` grants, disjoint from type-level def enforcement (plan 11
+ *   §0.6). Nothing calls `canViewEntity('dataset')`, so this is inert for
+ *   enforcement; it keeps the client mirror `NON_RECORD_ENTITY_SLUGS` in
+ *   `resources/registry/types.ts` consistent (that set hides datasets from the
+ *   entity-def Access grid).
+ *
+ * Keyed by entity slug; the caller resolves the def to its slug before checking.
  */
 export const NON_RECORD_DEF_SLUGS: ReadonlySet<string> = new Set([
   'inbox',
@@ -36,6 +43,7 @@ export const NON_RECORD_DEF_SLUGS: ReadonlySet<string> = new Set([
   'message',
   'snippet',
   'sequence',
+  'dataset',
 ])
 
 /**

--- a/packages/lib/src/resources/registry/types.ts
+++ b/packages/lib/src/resources/registry/types.ts
@@ -106,11 +106,17 @@ export function isCustomResource(resource: Resource): resource is CustomResource
 }
 
 /**
- * Mail/messaging-infrastructure entity slugs whose visibility is governed OUTSIDE
- * the records area (their `ResourceAccess` rows carry mail-sharing semantics, not
- * def restriction). Client-safe mirror of the server-side `NON_RECORD_DEF_SLUGS`
- * in `permissions/capabilities/capability-set.ts` — kept in sync by hand. The
- * entity-def Access UI (capability layer v2 phase 3) is hidden for these.
+ * Entity slugs whose visibility is governed OUTSIDE the records area, so they are
+ * hidden from the entity-def Access UI (capability layer v2 phase 3):
+ * - **Mail/messaging infra** (`inbox`…`sequence`) — their `ResourceAccess` rows
+ *   carry mail-sharing semantics, not def restriction.
+ * - **Instance-access resources** (`dataset`) — governed by their own L2 area +
+ *   per-instance `ResourceAccess` grants (the Share card), disjoint from
+ *   type-level def enforcement (plan 08 §0.6 / 11 §0.6). A def-access grid row
+ *   for these would be a phantom control that writes rows nothing reads.
+ *
+ * Client-safe mirror of the server-side `NON_RECORD_DEF_SLUGS` in
+ * `permissions/capabilities/entity-access.ts` — kept in sync by hand.
  */
 export const NON_RECORD_ENTITY_SLUGS: ReadonlySet<string> = new Set([
   'inbox',
@@ -119,6 +125,7 @@ export const NON_RECORD_ENTITY_SLUGS: ReadonlySet<string> = new Set([
   'message',
   'snippet',
   'sequence',
+  'dataset',
 ])
 
 /**


### PR DESCRIPTION
## Problem

Datasets shipped an L2 \`datasets\` area (None/Read/Edit/Full) enforced by the router, but the **client UI was never gated on it** (plan #11 step 5, "Still open"). A member set to \`datasets = None\` still saw:

- the **Datasets sidebar item**,
- the **Create Dataset button**,
- and hit a hard **\`dataset.getOrganizationStats\` 403** when the page mounted its provider.

Separately, \`dataset\` also appeared as a row in the **entity-def Access grid** (type-level \`ResourceAccess\`), because it's a system \`ModelType\` not excluded from that grid — a **phantom control**: those rows are disjoint from the instance-access mechanism the dataset router reads (plan 08/11 §0.6), so setting them did nothing.

And when permissions changed over **realtime**, the sidebar item didn't update.

## Fixes

### Datasets gating (commit 1)
- \`menu.tsx\`: add \`permissionKey: 'datasets.view'\` to the nav item (matches connectors/files).
- \`datasets/page.tsx\`: Layer-2 \`datasets.view\` page guard (mirrors the connectors page) — the provider/\`getOrganizationStats\` no longer mount without access, killing the 403. Also centers the empty state via \`bodyClassName='flex-1 flex flex-col min-h-0'\`.
- \`create-dataset-button.tsx\`: hidden unless \`datasets.manage\` (create = Full rung).
- \`NON_RECORD_ENTITY_SLUGS\` (client) + \`NON_RECORD_DEF_SLUGS\` (server): add \`'dataset'\` so it drops out of the entity-def Access grid and the dataset custom-fields "Permissions" tab.

### Realtime nav update (commit 2)
\`nav-main.tsx\` reassigned \`menu.items\` (the shared module-level \`SIDEBAR_MENU\`, also read by the command palette) and mutated item objects in place. Once an item failed a gate it was pruned from the source **permanently**, so a \`capabilities:changed\` event that re-granted access could never restore it. Replaced with a **memoized, non-mutating** derivation, recomputed only when \`can\`/\`hasAccess\`/\`isAdminOrOwner\` identities change (i.e. exactly when access changes) — also fewer recomputes than the previous every-render mutation.

## Notes
- Backend enforcement was already correct; these are client-side degrade + a shared-state mutation bug.
- No schema changes. No new deps.