### PR TITLE
feat(permissions): buttonswitch ui component + search/overrides filters

### DIFF
--- a/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
@@ -2,12 +2,15 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
 import { EntityIcon } from '@auxx/ui/components/icons'
+import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { Lock, ShieldCheck } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
 import { Tooltip } from '~/components/global/tooltip'
 import {
@@ -54,6 +57,23 @@ export function GranteeDefAccessSection({
 }) {
   const { isLoading, rows, setLevel } = useGranteeDefAccess(granteeKind, granteeId)
 
+  const [search, setSearch] = useState('')
+  const [overridesOnly, setOverridesOnly] = useState(false)
+
+  const query = search.trim().toLowerCase()
+
+  /** Rows narrowed by the search query and the "overrides only" toggle. */
+  const filteredRows = useMemo(
+    () =>
+      rows.filter((row) => {
+        if (overridesOnly && row.grantLevel === undefined) return false
+        if (!query) return true
+        const { plural, label } = row.resource
+        return plural.toLowerCase().includes(query) || label.toLowerCase().includes(query)
+      }),
+    [rows, query, overridesOnly]
+  )
+
   return (
     <SettingsSection
       icon={ShieldCheck}
@@ -67,20 +87,46 @@ export function GranteeDefAccessSection({
         </div>
       ) : rows.length === 0 ? (
         <EmptySection
+          orientation='horizontal'
           icon={<ShieldCheck />}
           title='No record types'
           description='There are no record types to configure access for yet.'
         />
       ) : (
-        <div className='border p-1 rounded-xl flex flex-col gap-1'>
-          {rows.map((row) => (
-            <DefAccessRow
-              key={row.resource.entityDefinitionId}
-              row={row}
-              canEdit={canEdit}
-              onChange={(level) => setLevel(row.resource.entityDefinitionId, level)}
+        <div className='flex flex-col gap-3'>
+          <div className='flex items-center gap-2'>
+            <InputSearch
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder='Search record types...'
             />
-          ))}
+            <ButtonSwitch
+              label='Overrides only'
+              checked={overridesOnly}
+              onCheckedChange={setOverridesOnly}
+              disabled={!canEdit}
+            />
+          </div>
+
+          {filteredRows.length === 0 ? (
+            <EmptySection
+              orientation='horizontal'
+              icon={<ShieldCheck />}
+              title='No matches'
+              description='No record types match your search.'
+            />
+          ) : (
+            <div className='border p-1 rounded-xl flex flex-col gap-1'>
+              {filteredRows.map((row) => (
+                <DefAccessRow
+                  key={row.resource.entityDefinitionId}
+                  row={row}
+                  canEdit={canEdit}
+                  onChange={(level) => setLevel(row.resource.entityDefinitionId, level)}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </SettingsSection>

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -2,7 +2,10 @@
 'use client'
 
 import { AREA_ORDER, type Area, type Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
+import { InputSearch } from '@auxx/ui/components/input-search'
 import { TreeRow } from '@auxx/ui/components/tree-row'
+import { useMemo, useState } from 'react'
 import { LevelControl } from './level-control'
 
 interface LeveledAreaGridProps {
@@ -57,37 +60,82 @@ export function LeveledAreaGrid({
   onChange,
   disabled = false,
 }: LeveledAreaGridProps) {
+  const [search, setSearch] = useState('')
+  const [overridesOnly, setOverridesOnly] = useState(false)
+
+  const query = search.trim().toLowerCase()
+
+  /** Groups with their areas narrowed by the search query and the "overrides only" toggle. */
+  const filteredGroups = useMemo(
+    () =>
+      AREA_GROUPS.map(({ group, areas }) => ({
+        group,
+        areas: areas.filter((area) => {
+          if (overridesOnly && values[area] === undefined) return false
+          if (!query) return true
+          const meta = PERMISSION_AREAS[area]
+          return (
+            meta.label.toLowerCase().includes(query) ||
+            meta.description.toLowerCase().includes(query)
+          )
+        }),
+      })).filter(({ areas }) => areas.length > 0),
+    [query, overridesOnly, values]
+  )
+
   return (
-    <div className='flex flex-col gap-4'>
-      {AREA_GROUPS.map(({ group, areas }) => (
-        <div key={group} className='flex flex-col gap-0.5'>
-          <span className='px-1 text-xs font-semibold uppercase text-primary-600'>{group}</span>
-          {areas.map((area) => {
-            const meta = PERMISSION_AREAS[area]
-            const value = values[area]
-            const inherited =
-              mode === 'override' ? (baseline?.[area] ?? roleDefaults[area]) : roleDefaults[area]
-            return (
-              <TreeRow
-                rowClassName='bg-primary-50 hover:bg-primary-100'
-                key={area}
-                title={meta.label}
-                description={meta.description}
-                trailing={
-                  <LevelControl
-                    area={meta}
-                    value={value}
-                    inherited={inherited}
-                    ignored={mode === 'override' && value !== undefined && value <= inherited}
-                    onChange={(level) => onChange(area, level)}
-                    disabled={disabled}
+    <div className='flex flex-col gap-3'>
+      <div className='flex items-center gap-2'>
+        <InputSearch
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder='Search areas...'
+        />
+        <ButtonSwitch
+          label='Overrides only'
+          checked={overridesOnly}
+          onCheckedChange={setOverridesOnly}
+          disabled={disabled}
+        />
+      </div>
+
+      {filteredGroups.length === 0 ? (
+        <p className='px-1 py-6 text-center text-xs text-muted-foreground'>No areas match.</p>
+      ) : (
+        <div className='flex flex-col gap-4'>
+          {filteredGroups.map(({ group, areas }) => (
+            <div key={group} className='flex flex-col gap-0.5'>
+              <span className='px-1 text-xs font-semibold uppercase text-primary-600'>{group}</span>
+              {areas.map((area) => {
+                const meta = PERMISSION_AREAS[area]
+                const value = values[area]
+                const inherited =
+                  mode === 'override'
+                    ? (baseline?.[area] ?? roleDefaults[area])
+                    : roleDefaults[area]
+                return (
+                  <TreeRow
+                    rowClassName='bg-primary-50 hover:bg-primary-100'
+                    key={area}
+                    title={meta.label}
+                    description={meta.description}
+                    trailing={
+                      <LevelControl
+                        area={meta}
+                        value={value}
+                        inherited={inherited}
+                        ignored={mode === 'override' && value !== undefined && value <= inherited}
+                        onChange={(level) => onChange(area, level)}
+                        disabled={disabled}
+                      />
+                    }
                   />
-                }
-              />
-            )
-          })}
+                )
+              })}
+            </div>
+          ))}
         </div>
-      ))}
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/tasks/ui/task-filter-bar.tsx
+++ b/apps/web/src/components/tasks/ui/task-filter-bar.tsx
@@ -5,10 +5,10 @@
 import type { TaskSortConfig } from '@auxx/lib/tasks/client'
 import { TASK_FILTER_FIELDS } from '@auxx/lib/tasks/client'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button, buttonVariants } from '@auxx/ui/components/button'
+import { Button } from '@auxx/ui/components/button'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
 import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import { Switch } from '@auxx/ui/components/switch'
 import { Filter, X, Zap } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import {
@@ -211,34 +211,18 @@ export function TaskFilterBar({
 
       {/* Show Snoozed / Show Completed Toggles */}
       <ListToolbarGroup align='end'>
-        <label
-          className={buttonVariants({
-            variant: 'ghost',
-            size: 'sm',
-            className: `gap-2 ${disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer'}`,
-          })}>
-          <span className='text-muted-foreground text-xs'>Show snoozed</span>
-          <Switch
-            size='sm'
-            checked={includeSnoozed}
-            onCheckedChange={onIncludeSnoozedChange}
-            disabled={disabled}
-          />
-        </label>
-        <label
-          className={buttonVariants({
-            variant: 'ghost',
-            size: 'sm',
-            className: `gap-2 ${disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer'}`,
-          })}>
-          <span className='text-muted-foreground text-xs'>Show completed</span>
-          <Switch
-            size='sm'
-            checked={includeCompleted}
-            onCheckedChange={onIncludeCompletedChange}
-            disabled={disabled}
-          />
-        </label>
+        <ButtonSwitch
+          label='Show snoozed'
+          checked={includeSnoozed}
+          onCheckedChange={onIncludeSnoozedChange}
+          disabled={disabled}
+        />
+        <ButtonSwitch
+          label='Show completed'
+          checked={includeCompleted}
+          onCheckedChange={onIncludeCompletedChange}
+          disabled={disabled}
+        />
       </ListToolbarGroup>
     </ListToolbar>
   )

--- a/packages/ui/src/components/button-switch.tsx
+++ b/packages/ui/src/components/button-switch.tsx
@@ -1,0 +1,63 @@
+// apps/web/src/components/ui/button-switch.tsx
+'use client'
+
+import { buttonVariants } from '@auxx/ui/components/button'
+import { Switch, type SwitchProps } from '@auxx/ui/components/switch'
+import { cn } from '@auxx/ui/lib/utils'
+import type { VariantProps } from 'class-variance-authority'
+
+/** Button styling that can be merged over the defaults (`variant: 'ghost'`, matched `size`). */
+type ButtonVariantProps = VariantProps<typeof buttonVariants>
+
+export interface ButtonSwitchProps {
+  /** Text shown to the left of the switch. */
+  label: string
+  /** Controlled checked state. */
+  checked: boolean
+  /** Fired when the switch is toggled. */
+  onCheckedChange: (value: boolean) => void
+  /** Disables the label + switch and dims it. */
+  disabled?: boolean
+  /** Drives both the {@link Switch} and the wrapping button size. Defaults to `sm`. */
+  size?: SwitchProps['size']
+  /** Extra classes on the wrapping label. */
+  className?: string
+  /** `buttonVariants` overrides merged over the defaults (e.g. a different `variant`). */
+  buttonProps?: ButtonVariantProps
+}
+
+/**
+ * A button-styled `<label>` wrapping a caption and a {@link Switch} — the compact
+ * toolbar toggle used for "Show snoozed", "Overrides only", etc. Clicking anywhere
+ * on the label flips the switch. Defaults to a ghost button whose size tracks the
+ * switch; pass `buttonProps` to merge over those defaults.
+ */
+function ButtonSwitch({
+  label,
+  checked,
+  onCheckedChange,
+  disabled = false,
+  size = 'sm',
+  className,
+  buttonProps,
+}: ButtonSwitchProps) {
+  return (
+    <label
+      className={buttonVariants({
+        variant: 'ghost',
+        size,
+        ...buttonProps,
+        className: cn(
+          'gap-2',
+          disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer',
+          className
+        ),
+      })}>
+      <span className='text-muted-foreground text-xs'>{label}</span>
+      <Switch size={size} checked={checked} onCheckedChange={onCheckedChange} disabled={disabled} />
+    </label>
+  )
+}
+ButtonSwitch.displayName = 'ButtonSwitch'
+
+export { ButtonSwitch }


### PR DESCRIPTION
## What

Adds a reusable **`ButtonSwitch`** UI component and applies **search + an "Overrides only" toggle** to the two grantee permissions surfaces.

### `@auxx/ui/components/button-switch` (new)
Extracts the ghost-button-styled `<label>` + `Switch` toggle pattern (previously hand-rolled in `task-filter-bar` and elsewhere) into one component.
- `size` drives **both** the `Switch` and the wrapping button (defaults to `sm`).
- `buttonProps` (`VariantProps<typeof buttonVariants>`) is merged over the defaults (`variant: 'ghost'`, matched `size`) so callers can swap `variant`/`size`.

### `leveled-area-grid.tsx`
- `InputSearch` filtering areas by `label` + `description`.
- `ButtonSwitch` **"Overrides only"** — hides areas with no explicit stored value. Empty groups drop; a "No areas match." line shows when nothing matches.

### `grantee-def-access-section.tsx`
- `InputSearch` filtering record types by `plural` + `label`.
- `ButtonSwitch` **"Overrides only"** — hides rows with no explicit grant.
- Both empty states rendered as `EmptySection orientation='horizontal'`.

### `task-filter-bar.tsx`
- Refactored the two hand-rolled label+Switch toggles ("Show snoozed" / "Show completed") to use the new `ButtonSwitch`.

## Notes
- `Resource` has no `description` field, so the def-access search matches `plural` + `label` only (record types carry no description text).

## Verification
- `@auxx/ui` typecheck: no `button-switch` errors.
- `apps/web` typecheck: `leveled-area-grid`, `grantee-def-access-section`, `button-switch` clean. Pre-existing `ConditionSystemConfig` baseline errors in `task-filter-bar` are untouched by this change.
- Biome: clean.