### PR TITLE
feat(permissions): kb instance-access (l2 area + per-kb sharing)

### DIFF
--- a/apps/web/src/app/(protected)/app/kb/page.tsx
+++ b/apps/web/src/app/(protected)/app/kb/page.tsx
@@ -1,15 +1,29 @@
 // apps/web/src/app/(protected)/app/kb/page.tsx
 
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import { KBEmptyState } from '~/components/kb/ui/dialogs/kb-empty-state'
 import { KBLandingShell } from '~/components/kb/ui/landing/kb-landing-shell'
 import { api } from '~/trpc/server'
 
 export default async function KBMain() {
+  // `kb.list` has no coarse assert — it returns a filtered/empty list for a None
+  // member, so this server call never 403s. The guard redirects a member lacking
+  // `knowledgeBase.view` to /access-denied (client-side).
   const knowledgeBases = await api.kb.list()
 
   if (!knowledgeBases || knowledgeBases.length === 0) {
-    return <KBEmptyState />
+    return (
+      <>
+        <CapabilityPageGuard permissionKey='knowledgeBase.view' />
+        <KBEmptyState />
+      </>
+    )
   }
 
-  return <KBLandingShell />
+  return (
+    <>
+      <CapabilityPageGuard permissionKey='knowledgeBase.view' />
+      <KBLandingShell />
+    </>
+  )
 }

--- a/apps/web/src/components/kb/ui/dialogs/kb-empty-state.tsx
+++ b/apps/web/src/components/kb/ui/dialogs/kb-empty-state.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/dialogs/kb-empty-state.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   MainPage,
@@ -12,12 +13,15 @@ import {
 import { Book, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useKnowledgeBaseMutations } from '../../hooks/use-knowledge-base-mutations'
 import { KnowledgeBaseDialog, type KnowledgeBaseFormValues } from './kb-knowledge-base-dialog'
 
 export function KBEmptyState() {
   const router = useRouter()
   const [showDialog, setShowDialog] = useState(false)
+  const { can } = useAccess()
+  const canCreate = can(PermissionKey.knowledgeBaseManage)
   const { createKnowledgeBase, isCreating } = useKnowledgeBaseMutations()
 
   const handleCreate = async (values: KnowledgeBaseFormValues) => {
@@ -45,13 +49,16 @@ export function KBEmptyState() {
           </div>
           <h2 className='text-xl font-semibold'>No knowledge bases yet</h2>
           <p className='mt-2 max-w-md text-sm text-muted-foreground'>
-            Create your first knowledge base to start publishing articles, FAQs, and how-to guides
-            for your customers.
+            {canCreate
+              ? 'Create your first knowledge base to start publishing articles, FAQs, and how-to guides for your customers.'
+              : 'No knowledge bases have been created yet. Ask an admin to add one.'}
           </p>
-          <Button className='mt-6' onClick={() => setShowDialog(true)} loading={isCreating}>
-            <Plus />
-            Create Knowledge Base
-          </Button>
+          {canCreate && (
+            <Button className='mt-6' onClick={() => setShowDialog(true)} loading={isCreating}>
+              <Plus />
+              Create Knowledge Base
+            </Button>
+          )}
         </div>
       </MainPageContent>
 

--- a/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
@@ -2,7 +2,9 @@
 'use client'
 
 import { mergeDraftOverLive } from '@auxx/lib/kb/client'
+import { toRecordId } from '@auxx/types/resource'
 import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
 import {
   MainPageBreadcrumb,
   MainPageBreadcrumbDropdown,
@@ -10,9 +12,10 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { MainPageTabs } from '@auxx/ui/components/main-page-tabs'
-import { Book, Cog, Layout, Sparkles } from 'lucide-react'
+import { Book, Cog, Layout, Share2, Sparkles } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { LAYOUT_TAB_ENABLED } from '../../constant'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
 import { useKBPreviewHint } from '../preview/preview-hint-context'
@@ -54,6 +57,7 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
     parseAsStringLiteral(PANEL_VALUES).withDefault('general')
   )
   const { lockSession } = useKBPreviewHint()
+  const [shareOpen, setShareOpen] = useState(false)
   const isLearned = knowledgeBase.kind === 'learned'
 
   // Once the user has reached the Articles panel they've found the answer the
@@ -72,6 +76,15 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
       action={
         isLearned ? undefined : (
           <div className='flex items-center gap-2'>
+            <Button variant='outline' size='sm' onClick={() => setShareOpen(true)}>
+              <Share2 />
+              Share
+            </Button>
+            <InstanceShareDialog
+              recordId={toRecordId('kb', knowledgeBaseId)}
+              open={shareOpen}
+              onOpenChange={setShareOpen}
+            />
             <KBPublishCluster kbId={knowledgeBaseId} />
           </div>
         )

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
@@ -7,9 +7,12 @@
 // use-draft-settings-autosave.ts) — name is staged via `updateDraftSettings`
 // and never auto-published from here, matching the rest of the app.
 
+import { toRecordId } from '@auxx/types/resource'
+import { Badge } from '@auxx/ui/components/badge'
 import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
 import { ListCard, renderBadgeChips } from '@auxx/ui/components/list-card'
-import { Book, Lock, Settings, Trash } from 'lucide-react'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { Book, Lock, Settings, Share2, Trash } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
@@ -20,7 +23,9 @@ import {
   useListSelection,
   usePendingLabel,
 } from '~/components/list-selection'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useKnowledgeBaseMutations } from '../../hooks/use-knowledge-base-mutations'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
 import {
@@ -37,6 +42,9 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
   const router = useRouter()
   const [confirm, ConfirmDialog] = useConfirm()
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
+  const { isRestrictedInstance } = useAccess()
+  const isShared = isRestrictedInstance(kb.id)
 
   const bulkMode = useBulkMode()
   const selected = useIsSelected(kb.id)
@@ -79,6 +87,11 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
   return (
     <>
       <ConfirmDialog />
+      <InstanceShareDialog
+        recordId={toRecordId('kb', kb.id)}
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+      />
       <ListCard
         href={`/app/kb/${kb.id}/editor`}
         ariaLabel={kb.name}
@@ -92,9 +105,21 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
         icon={<Book className='size-4' />}
         description={kb.description ?? undefined}
         descriptionLines={2}
-        badges={renderBadgeChips(
-          statusLabel ? [{ icon: <Lock className='size-3' />, label: statusLabel }] : []
-        )}
+        badges={
+          <>
+            {isShared && (
+              <SimpleTooltip content='Shared with specific access'>
+                <Badge variant='pill' size='sm' className='shrink-0'>
+                  <Lock className='size-3' />
+                  Shared
+                </Badge>
+              </SimpleTooltip>
+            )}
+            {renderBadgeChips(
+              statusLabel ? [{ icon: <Lock className='size-3' />, label: statusLabel }] : []
+            )}
+          </>
+        }
         menu={
           <>
             <DropdownMenuItem onClick={() => router.push(`/app/kb/${kb.id}/editor`)}>
@@ -104,6 +129,10 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
             <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
               <Settings />
               Settings
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setShareOpen(true)}>
+              <Share2 />
+              Share…
             </DropdownMenuItem>
             <FavoriteToggleMenuItem
               targetType='KNOWLEDGE_BASE'

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-list.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-list.tsx
@@ -1,11 +1,13 @@
 // apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-list.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { Library, Search } from 'lucide-react'
 import { useEffect } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { useListSelection } from '~/components/list-selection'
+import { useAccess } from '~/providers/capabilities-provider'
 import { CreateKnowledgeBaseButton } from '../landing/create-knowledge-base-button'
 import { KnowledgeBaseCard } from './knowledge-base-card'
 import { useKnowledgeBasesList } from './knowledge-bases-provider'
@@ -13,6 +15,8 @@ import { useKnowledgeBasesList } from './knowledge-bases-provider'
 export function KnowledgeBasesList() {
   const { knowledgeBases, isLoading, searchQuery } = useKnowledgeBasesList()
   const setItemIds = useListSelection((s) => s.setItemIds)
+  const { can } = useAccess()
+  const canCreate = can(PermissionKey.knowledgeBaseManage)
 
   useEffect(() => {
     setItemIds(knowledgeBases.map((kb) => kb.id))
@@ -40,8 +44,12 @@ export function KnowledgeBasesList() {
       <EmptyState
         icon={Library}
         title='No knowledge bases yet'
-        description='Create your first knowledge base to start publishing articles.'
-        button={<CreateKnowledgeBaseButton />}
+        description={
+          canCreate
+            ? 'Create your first knowledge base to start publishing articles.'
+            : 'No knowledge bases have been created yet. Ask an admin to add one.'
+        }
+        button={canCreate ? <CreateKnowledgeBaseButton /> : <div className='h-12' />}
       />
     )
   }

--- a/apps/web/src/components/kb/ui/landing/create-knowledge-base-button.tsx
+++ b/apps/web/src/components/kb/ui/landing/create-knowledge-base-button.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/kb/ui/landing/create-knowledge-base-button.tsx
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { Kbd } from '@auxx/ui/components/kbd'
 import { useHotkey } from '@tanstack/react-hotkeys'
@@ -11,6 +11,7 @@ import { useCallback, useState } from 'react'
 import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
 import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { useKnowledgeBaseMutations } from '../../hooks/use-knowledge-base-mutations'
@@ -38,6 +39,7 @@ export function CreateKnowledgeBaseButton({
   const router = useRouter()
   const [isCreateKBOpen, setIsCreateKBOpen] = useState(false)
   const [limitDialogOpen, setLimitDialogOpen] = useState(false)
+  const { can } = useAccess()
   const { createKnowledgeBase, isCreating } = useKnowledgeBaseMutations()
 
   const { isAtLimit, getLimit } = useFeatureFlags()
@@ -70,6 +72,9 @@ export function CreateKnowledgeBaseButton({
     },
     [createKnowledgeBase, router]
   )
+
+  // Members without the knowledge-base Full rung can't create — hide the trigger.
+  if (!can(PermissionKey.knowledgeBaseManage)) return null
 
   return (
     <>

--- a/apps/web/src/components/kb/ui/sources/connect-source-button.tsx
+++ b/apps/web/src/components/kb/ui/sources/connect-source-button.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/sources/connect-source-button.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
@@ -16,6 +17,7 @@ import { ClipboardPaste, FileText, Globe, Plus, ShoppingBag } from 'lucide-react
 import { useState } from 'react'
 import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
+import { useAccess } from '~/providers/capabilities-provider'
 import { CrawlWebsiteWizard } from '../editor/crawl-website-wizard'
 import { CreateKnowledgeSourceDialog } from '../editor/create-knowledge-source-dialog'
 
@@ -40,9 +42,13 @@ export function ConnectSourceButton({
 } = {}) {
   const [crawlOpen, setCrawlOpen] = useState(false)
   const [manualOpen, setManualOpen] = useState(false)
+  const { can } = useAccess()
 
   // Page-local shortcut: N opens the website crawler (the headline source).
   useHotkey('N', () => setCrawlOpen(true), { enabled: registerShortcut })
+
+  // Connecting a source contributes content — the knowledge-base Write rung.
+  if (!can(PermissionKey.knowledgeBaseEdit)) return null
 
   return (
     <>

--- a/apps/web/src/components/kb/ui/sources/sources-empty-state.tsx
+++ b/apps/web/src/components/kb/ui/sources/sources-empty-state.tsx
@@ -1,14 +1,18 @@
 // apps/web/src/components/kb/ui/sources/sources-empty-state.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Globe } from 'lucide-react'
 import { EmptyState } from '~/components/global/empty-state'
+import { useAccess } from '~/providers/capabilities-provider'
 import { ConnectSourceButton } from './connect-source-button'
 import { useSources } from './sources-provider'
 
 /** Empty state for the Sources tab — distinguishes "no matches" from "no sources yet". */
 export function SourcesEmptyState() {
   const { searchQuery, selectedStatus } = useSources()
+  const { can } = useAccess()
+  const canConnect = can(PermissionKey.knowledgeBaseEdit)
   const hasFilters = !!searchQuery || selectedStatus !== 'all'
 
   if (hasFilters) {
@@ -25,8 +29,12 @@ export function SourcesEmptyState() {
     <EmptyState
       icon={Globe}
       title='No sources yet'
-      description='Connect a website or other content source to keep a knowledge base in sync.'
-      button={<ConnectSourceButton variant='outline' />}
+      description={
+        canConnect
+          ? 'Connect a website or other content source to keep a knowledge base in sync.'
+          : 'No content sources have been connected yet. Ask an admin to add one.'
+      }
+      button={canConnect ? <ConnectSourceButton variant='outline' /> : undefined}
     />
   )
 }

--- a/apps/web/src/components/permissions/ui/instance-share-copy.ts
+++ b/apps/web/src/components/permissions/ui/instance-share-copy.ts
@@ -31,5 +31,14 @@ export const INSTANCE_SHARE_COPY: Record<InstanceAccessKey, InstanceShareCopy> =
       full: 'Change settings',
     },
   },
-  // kb / dashboard added by their slices
+  kb: {
+    noun: 'knowledge base',
+    baselineHint: 'Everyone in the workspace can read and write its articles by default.',
+    levels: {
+      read: 'Read articles',
+      write: 'Write & publish articles',
+      full: 'Manage the KB & its settings',
+    },
+  },
+  // dashboard added by its slice
 }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -201,6 +201,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
         slug: 'kb',
         icon: <BookOpen />,
         featureKey: 'knowledgeBase',
+        permissionKey: 'knowledgeBase.view',
       },
       {
         id: 'connectors',

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -1,16 +1,63 @@
 // ~/server/api/routers/kb.ts
 
+import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { ArticleStatus } from '@auxx/database/enums'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
+import { NotFoundError } from '@auxx/lib/errors'
 import { articleToMarkdown, ensureLearnedKb, KBService, linkArticlesIntoKb } from '@auxx/lib/kb'
-import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
 import { and, count, eq } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
+import { capabilityProcedure, createTRPCRouter, notDemo } from '~/server/api/trpc'
 import { fireKBRevalidate } from '~/server/lib/kb-revalidate'
+
+/**
+ * Resolve an article to its home KnowledgeBase — articles inherit their KB's
+ * access level (doc 12 §0.5), so every article gate keys on the parent KB when
+ * no explicit `knowledgeBaseId` is supplied. Org-scoped; 404s a missing/foreign
+ * article. `Article.homeKnowledgeBaseId` is `notNull`.
+ */
+async function knowledgeBaseIdForArticle(
+  db: Database,
+  articleId: string,
+  organizationId: string
+): Promise<string> {
+  const [row] = await db
+    .select({ knowledgeBaseId: schema.Article.homeKnowledgeBaseId })
+    .from(schema.Article)
+    .where(and(eq(schema.Article.id, articleId), eq(schema.Article.organizationId, organizationId)))
+    .limit(1)
+  if (!row) throw new NotFoundError('Article not found')
+  return row.knowledgeBaseId
+}
+
+/**
+ * Resolve an article revision (version) → its article → home KnowledgeBase
+ * (doc 12 §3.1). Version/rename ops carry only a `versionId`, so they gate on
+ * the owning article's KB. Org-scoped; 404s a missing/foreign revision.
+ */
+async function knowledgeBaseIdForArticleVersion(
+  db: Database,
+  versionId: string,
+  organizationId: string
+): Promise<string> {
+  const [row] = await db
+    .select({ knowledgeBaseId: schema.Article.homeKnowledgeBaseId })
+    .from(schema.ArticleRevision)
+    .innerJoin(schema.Article, eq(schema.ArticleRevision.articleId, schema.Article.id))
+    .where(
+      and(
+        eq(schema.ArticleRevision.id, versionId),
+        eq(schema.ArticleRevision.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  if (!row) throw new NotFoundError('Article version not found')
+  return row.knowledgeBaseId
+}
 
 // Live-only fields. Draftable presentation fields go through
 // `kb.updateDraftSettings`.
@@ -125,23 +172,33 @@ async function revalidateForArticle(
 }
 
 export const knowledgeBaseRouter = createTRPCRouter({
-  byId: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
+  byId: capabilityProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
+    // Read — viewing a KB and its articles.
+    ctx.capabilities.assertViewInstance('kb', input.id)
     return await getKBService(ctx).getKnowledgeBaseById(input.id)
   }),
 
-  list: protectedProcedure.query(async ({ ctx }) => {
-    return await getKBService(ctx).listKnowledgeBases()
+  list: capabilityProcedure.query(async ({ ctx }) => {
+    // No coarse assert — filter the result to KBs the member may view (base-Edit
+    // fallback per §0.2 passes every KB with no explicit row). A None member
+    // simply gets an empty list, so the server-warmed page.tsx call never 403s.
+    const kbs = await getKBService(ctx).listKnowledgeBases()
+    return kbs.filter((kb: { id: string }) => ctx.capabilities.canViewInstance('kb', kb.id))
   }),
 
   /**
    * Idempotently provision the org's AI Memory KB (kind 'learned') and return
    * its id — the entry point for the "AI Memory" card on the KB landing page.
    */
-  ensureLearnedMemory: protectedProcedure.mutation(async ({ ctx }) => {
+  ensureLearnedMemory: capabilityProcedure.mutation(async ({ ctx }) => {
     const organizationId = getUserOrganizationId(ctx.session)
     if (!organizationId) {
       throw new TRPCError({ code: 'UNAUTHORIZED', message: 'User organization context not found' })
     }
+    // Full — provisioning the org's AI Memory KB is a settings-adjacent action
+    // (doc 12 §3.1). No instance exists yet to key on, so gate on the coarse
+    // `knowledgeBase` Full rung (mirrors `create`).
+    ctx.capabilities.assert(PermissionKey.knowledgeBaseManage)
     await new FeaturePermissionService(ctx.db).requireAccess(
       organizationId,
       FeatureKey.learnedMemory
@@ -150,11 +207,14 @@ export const knowledgeBaseRouter = createTRPCRouter({
     return { id: kb.id }
   }),
 
-  create: protectedProcedure.input(kbCreateSchema).mutation(async ({ ctx, input }) => {
+  create: capabilityProcedure.input(kbCreateSchema).mutation(async ({ ctx, input }) => {
     const organizationId = getUserOrganizationId(ctx.session)
     if (!organizationId) {
       throw new TRPCError({ code: 'UNAUTHORIZED', message: 'User organization context not found' })
     }
+    // L2 area gate: creating a KB requires `knowledgeBase` Full (no instance
+    // exists yet to key on). Plan-AND with the Layer-1 feature/limit gate below.
+    ctx.capabilities.assert(PermissionKey.knowledgeBaseManage)
     await new FeaturePermissionService(ctx.db).requireAccessAndLimit(
       organizationId,
       FeatureKey.knowledgeBase,
@@ -172,9 +232,11 @@ export const knowledgeBaseRouter = createTRPCRouter({
     return result
   }),
 
-  update: protectedProcedure
+  update: capabilityProcedure
     .input(z.object({ id: z.string(), data: kbLiveFieldsSchema }))
     .mutation(async ({ ctx, input }) => {
+      // Full — updating a KB's live settings (slug/domain/visibility).
+      ctx.capabilities.assertAdminInstance('kb', input.id)
       const result = await getKBService(ctx).updateKnowledgeBase(input.id, input.data)
       void fireKBRevalidate(input.id)
       // Name/visibility feed the agent-prompt KB catalog.
@@ -182,51 +244,63 @@ export const knowledgeBaseRouter = createTRPCRouter({
       return result
     }),
 
-  updateDraftSettings: protectedProcedure
+  updateDraftSettings: capabilityProcedure
     .input(z.object({ id: z.string(), patch: kbDraftSettingsSchema }))
     .mutation(async ({ ctx, input }) => {
+      // Full — staging KB presentation settings.
+      ctx.capabilities.assertAdminInstance('kb', input.id)
       // No revalidate — draft is admin-only.
       return await getKBService(ctx).updateDraftSettings(input.id, input.patch)
     }),
 
-  publishPendingSettings: protectedProcedure
+  publishPendingSettings: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .use(notDemo('publish knowledge base settings'))
     .mutation(async ({ ctx, input }) => {
+      // Full — publishing staged KB settings.
+      ctx.capabilities.assertAdminInstance('kb', input.id)
       const result = await getKBService(ctx).publishPendingSettings(input.id)
       void fireKBRevalidate(input.id)
       return result
     }),
 
-  discardSettingsDraft: protectedProcedure
+  discardSettingsDraft: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      // Full — discarding staged KB settings.
+      ctx.capabilities.assertAdminInstance('kb', input.id)
       // No revalidate — discard never affects the public site.
       return await getKBService(ctx).discardSettingsDraft(input.id)
     }),
 
-  delete: protectedProcedure
+  delete: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      // Full — deleting a KB and all its articles.
+      ctx.capabilities.assertAdminInstance('kb', input.id)
       const result = await getKBService(ctx).deleteKnowledgeBase(input.id)
       const organizationId = getUserOrganizationId(ctx.session)
       await onCacheEvent('kb.deleted', { orgId: organizationId })
       return result
     }),
 
-  publishSite: protectedProcedure
+  publishSite: capabilityProcedure
     .input(z.object({ id: z.string(), status: z.enum(['PUBLISHED', 'UNLISTED']) }))
     .use(notDemo('publish knowledge base'))
     .mutation(async ({ ctx, input }) => {
+      // Full — turning the whole public KB site on (governance, §0.6).
+      ctx.capabilities.assertAdminInstance('kb', input.id)
       const result = await getKBService(ctx).publishKnowledgeBase(input.id, input.status)
       void fireKBRevalidate(input.id)
       return result
     }),
 
-  unpublishSite: protectedProcedure
+  unpublishSite: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .use(notDemo('unpublish knowledge base'))
     .mutation(async ({ ctx, input }) => {
+      // Full — turning the whole public KB site off (governance, §0.6).
+      ctx.capabilities.assertAdminInstance('kb', input.id)
       const result = await getKBService(ctx).unpublishKnowledgeBase(input.id)
       void fireKBRevalidate(input.id)
       return result
@@ -234,7 +308,7 @@ export const knowledgeBaseRouter = createTRPCRouter({
 
   // ─── Articles ────────────────────────────────────────────────────
 
-  getArticles: protectedProcedure
+  getArticles: capabilityProcedure
     .input(
       z.object({
         knowledgeBaseId: z.string(),
@@ -242,6 +316,8 @@ export const knowledgeBaseRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      // Read — articles inherit their KB's access level.
+      ctx.capabilities.assertViewInstance('kb', input.knowledgeBaseId)
       return await getKBService(ctx).getArticles(input.knowledgeBaseId, {
         includeUnpublished: input.includeUnpublished,
       })
@@ -249,7 +325,7 @@ export const knowledgeBaseRouter = createTRPCRouter({
 
   // Link individually-chosen `page` articles from any KB into this KB, placed under
   // `targetParentArticleId` (e.g. the active tab) or the KB root. Idempotent.
-  linkArticles: protectedProcedure
+  linkArticles: capabilityProcedure
     .input(
       z.object({
         knowledgeBaseId: z.string().min(1),
@@ -265,12 +341,14 @@ export const knowledgeBaseRouter = createTRPCRouter({
           message: 'User organization context not found',
         })
       }
+      // Write — linking articles mutates the target KB's membership.
+      ctx.capabilities.assertEditInstance('kb', input.knowledgeBaseId)
       return linkArticlesIntoKb(ctx.db, organizationId, input.knowledgeBaseId, input.articleIds, {
         targetParentArticleId: input.targetParentArticleId,
       })
     }),
 
-  getArticleById: protectedProcedure
+  getArticleById: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -279,6 +357,11 @@ export const knowledgeBaseRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      // Read — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ??
+        (await knowledgeBaseIdForArticle(ctx.db, input.id, getUserOrganizationId(ctx.session)))
+      ctx.capabilities.assertViewInstance('kb', kbId)
       return await getKBService(ctx).getArticleById(
         input.id,
         input.knowledgeBaseId,
@@ -286,16 +369,20 @@ export const knowledgeBaseRouter = createTRPCRouter({
       )
     }),
 
-  getArticleBySlug: protectedProcedure
+  getArticleBySlug: capabilityProcedure
     .input(z.object({ slug: z.string(), knowledgeBaseId: z.string() }))
     .query(async ({ ctx, input }) => {
+      // Read — articles inherit their KB's access level.
+      ctx.capabilities.assertViewInstance('kb', input.knowledgeBaseId)
       return await getKBService(ctx).getArticleBySlug(input.slug, input.knowledgeBaseId)
     }),
 
-  createArticle: protectedProcedure
+  createArticle: capabilityProcedure
     .input(z.object({ knowledgeBaseId: z.string() }).and(articleCreateSchema))
     .mutation(async ({ ctx, input }) => {
       const { knowledgeBaseId, adjacentTo, position, ...articleData } = input
+      // Write — creating an article in the target KB (article doesn't exist yet).
+      ctx.capabilities.assertEditInstance('kb', knowledgeBaseId)
       const result = await getKBService(ctx).createArticle(
         knowledgeBaseId,
         articleData as Parameters<ReturnType<typeof getKBService>['createArticle']>[1],
@@ -311,7 +398,7 @@ export const knowledgeBaseRouter = createTRPCRouter({
    * Marks the article as having unpublished changes. Public site is NOT
    * revalidated — drafts aren't public.
    */
-  updateArticleDraft: protectedProcedure
+  updateArticleDraft: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -325,6 +412,10 @@ export const knowledgeBaseRouter = createTRPCRouter({
       // the article sink writes managed drafts through the lib fn directly, so
       // this must NOT live inside KBService. Detach (managed=false) re-opens edits.
       const organizationId = getUserOrganizationId(ctx.session)
+      // Write — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ?? (await knowledgeBaseIdForArticle(ctx.db, input.id, organizationId))
+      ctx.capabilities.assertEditInstance('kb', kbId)
       const target = await ctx.db.query.Article.findFirst({
         where: and(
           eq(schema.Article.id, input.id),
@@ -350,7 +441,7 @@ export const knowledgeBaseRouter = createTRPCRouter({
   /**
    * Edit structural fields (slug/parentId/order). Live; revalidates.
    */
-  updateArticleStructure: protectedProcedure
+  updateArticleStructure: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -359,6 +450,11 @@ export const knowledgeBaseRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Write — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ??
+        (await knowledgeBaseIdForArticle(ctx.db, input.id, getUserOrganizationId(ctx.session)))
+      ctx.capabilities.assertEditInstance('kb', kbId)
       const result = await getKBService(ctx).updateArticleStructure(
         input.id,
         input.data,
@@ -368,7 +464,7 @@ export const knowledgeBaseRouter = createTRPCRouter({
       return result
     }),
 
-  publishArticle: protectedProcedure
+  publishArticle: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -379,6 +475,10 @@ export const knowledgeBaseRouter = createTRPCRouter({
     .use(notDemo('publish knowledge base articles'))
     .mutation(async ({ ctx, input }) => {
       const organizationId = getUserOrganizationId(ctx.session)
+      // Write — publishing an individual article (contributor action, §0.6).
+      const kbId =
+        input.knowledgeBaseId ?? (await knowledgeBaseIdForArticle(ctx.db, input.id, organizationId))
+      ctx.capabilities.assertEditInstance('kb', kbId)
       const featureService = new FeaturePermissionService(ctx.db)
       const articleLimit = await featureService.getLimit(
         organizationId,
@@ -416,42 +516,68 @@ export const knowledgeBaseRouter = createTRPCRouter({
       return result
     }),
 
-  unpublishArticle: protectedProcedure
+  unpublishArticle: capabilityProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
     .use(notDemo('unpublish knowledge base articles'))
     .mutation(async ({ ctx, input }) => {
-      const result = await getKBService(ctx).unpublishArticle(input.id, input.knowledgeBaseId)
       const organizationId = getUserOrganizationId(ctx.session)
+      // Write — unpublishing an individual article (contributor action, §0.6).
+      const kbId =
+        input.knowledgeBaseId ?? (await knowledgeBaseIdForArticle(ctx.db, input.id, organizationId))
+      ctx.capabilities.assertEditInstance('kb', kbId)
+      const result = await getKBService(ctx).unpublishArticle(input.id, input.knowledgeBaseId)
       await onCacheEvent('article.unpublished', { orgId: organizationId })
       await revalidateForArticle(ctx, input.knowledgeBaseId, input.id)
       return result
     }),
 
-  archiveArticle: protectedProcedure
+  archiveArticle: capabilityProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
     .use(notDemo('archive knowledge base articles'))
     .mutation(async ({ ctx, input }) => {
+      // Write — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ??
+        (await knowledgeBaseIdForArticle(ctx.db, input.id, getUserOrganizationId(ctx.session)))
+      ctx.capabilities.assertEditInstance('kb', kbId)
       const result = await getKBService(ctx).archiveArticle(input.id)
       await revalidateForArticle(ctx, input.knowledgeBaseId, input.id)
       return result
     }),
 
-  unarchiveArticle: protectedProcedure
+  unarchiveArticle: capabilityProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
+      // Write — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ??
+        (await knowledgeBaseIdForArticle(ctx.db, input.id, getUserOrganizationId(ctx.session)))
+      ctx.capabilities.assertEditInstance('kb', kbId)
       return await getKBService(ctx).unarchiveArticle(input.id)
     }),
 
-  discardArticleDraft: protectedProcedure
+  discardArticleDraft: capabilityProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
+      // Write — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ??
+        (await knowledgeBaseIdForArticle(ctx.db, input.id, getUserOrganizationId(ctx.session)))
+      ctx.capabilities.assertEditInstance('kb', kbId)
       return await getKBService(ctx).discardArticleDraft(input.id)
     }),
 
-  restoreArticleVersion: protectedProcedure
+  restoreArticleVersion: capabilityProcedure
     .input(z.object({ versionId: z.string() }))
     .use(notDemo('restore knowledge base article version'))
     .mutation(async ({ ctx, input }) => {
+      // Write — resolve version → article → home KB (§3.1).
+      const kbId = await knowledgeBaseIdForArticleVersion(
+        ctx.db,
+        input.versionId,
+        getUserOrganizationId(ctx.session)
+      )
+      ctx.capabilities.assertEditInstance('kb', kbId)
       return await getKBService(ctx).restoreArticleVersion(input.versionId, ctx.session.user.id)
     }),
 
@@ -461,10 +587,13 @@ export const knowledgeBaseRouter = createTRPCRouter({
    * pin scopes the revert to a specific turn — if a newer turn has
    * superseded it, this returns "turn_mismatch" and no-ops.
    */
-  revertKopilotTurn: protectedProcedure
+  revertKopilotTurn: capabilityProcedure
     .input(z.object({ articleId: z.string(), turnId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = getUserOrganizationId(ctx.session)
+      // Write — reviewing (undoing) a Kopilot turn's edits (§0.8).
+      const kbId = await knowledgeBaseIdForArticle(ctx.db, input.articleId, organizationId)
+      ctx.capabilities.assertEditInstance('kb', kbId)
       const { revertKopilotKbTurn } = await import(
         '@auxx/lib/ai/kopilot/capabilities/kb/tools/write-helpers'
       )
@@ -485,12 +614,15 @@ export const knowledgeBaseRouter = createTRPCRouter({
    * the post-turn banner — both the live signal and recovery-on-mount after a
    * refresh (the snapshot survives reload, the agent event does not).
    */
-  getKopilotTurnReview: protectedProcedure
+  getKopilotTurnReview: capabilityProcedure
     .input(z.object({ articleId: z.string() }))
     .query(async ({ ctx, input }) => {
       const organizationId = getUserOrganizationId(ctx.session)
-      // Snapshots are keyed by articleId alone in Redis — gate on org ownership
-      // so a guessed id can't read another org's draft content.
+      // Read — reviewing a Kopilot turn's pre-edit snapshot (§0.8). Snapshots are
+      // keyed by articleId alone in Redis, so resolve → home KB and gate Read (a
+      // guessed id can't read another org's / another KB's draft content).
+      const kbId = await knowledgeBaseIdForArticle(ctx.db, input.articleId, organizationId)
+      ctx.capabilities.assertViewInstance('kb', kbId)
       const article = await ctx.db.query.Article.findFirst({
         where: and(
           eq(schema.Article.id, input.articleId),
@@ -515,10 +647,13 @@ export const knowledgeBaseRouter = createTRPCRouter({
    * released by `finalizeKopilotKbTurn`. Turn-pinned: a stale Keep button won't
    * clobber a newer turn's snapshot.
    */
-  keepKopilotTurn: protectedProcedure
+  keepKopilotTurn: capabilityProcedure
     .input(z.object({ articleId: z.string(), turnId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = getUserOrganizationId(ctx.session)
+      // Write — committing (keeping) a Kopilot turn's edits (§0.8).
+      const kbId = await knowledgeBaseIdForArticle(ctx.db, input.articleId, organizationId)
+      ctx.capabilities.assertEditInstance('kb', kbId)
       const article = await ctx.db.query.Article.findFirst({
         where: and(
           eq(schema.Article.id, input.articleId),
@@ -539,7 +674,7 @@ export const knowledgeBaseRouter = createTRPCRouter({
       return { ok: true as const }
     }),
 
-  moveArticle: protectedProcedure
+  moveArticle: capabilityProcedure
     .input(
       z.object({
         knowledgeBaseId: z.string(),
@@ -552,12 +687,21 @@ export const knowledgeBaseRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { knowledgeBaseId, ...rest } = input
+      // Write on the KB being reorganized; if the article's home KB differs
+      // (a linked article), require Write on both (§3.3 "both KBs").
+      ctx.capabilities.assertEditInstance('kb', knowledgeBaseId)
+      const homeKbId = await knowledgeBaseIdForArticle(
+        ctx.db,
+        input.id,
+        getUserOrganizationId(ctx.session)
+      )
+      if (homeKbId !== knowledgeBaseId) ctx.capabilities.assertEditInstance('kb', homeKbId)
       const result = await getKBService(ctx).moveArticle(knowledgeBaseId, rest)
       void fireKBRevalidate(knowledgeBaseId)
       return result
     }),
 
-  updateArticlesBatch: protectedProcedure
+  updateArticlesBatch: capabilityProcedure
     .input(
       z.object({
         knowledgeBaseId: z.string(),
@@ -570,29 +714,42 @@ export const knowledgeBaseRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Write — batch article edits within the target KB.
+      ctx.capabilities.assertEditInstance('kb', input.knowledgeBaseId)
       return await getKBService(ctx).updateArticlesBatch(
         input.knowledgeBaseId,
         input.articles as Parameters<ReturnType<typeof getKBService>['updateArticlesBatch']>[1]
       )
     }),
 
-  deleteArticle: protectedProcedure
+  deleteArticle: capabilityProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
-      const result = await getKBService(ctx).deleteArticle(input.id, input.knowledgeBaseId)
       const organizationId = getUserOrganizationId(ctx.session)
+      // Write — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ?? (await knowledgeBaseIdForArticle(ctx.db, input.id, organizationId))
+      ctx.capabilities.assertEditInstance('kb', kbId)
+      const result = await getKBService(ctx).deleteArticle(input.id, input.knowledgeBaseId)
       await onCacheEvent('article.deleted', { orgId: organizationId })
       if (input.knowledgeBaseId) void fireKBRevalidate(input.knowledgeBaseId)
       return result
     }),
 
-  getArticleVersions: protectedProcedure
+  getArticleVersions: capabilityProcedure
     .input(z.object({ articleId: z.string() }))
     .query(async ({ ctx, input }) => {
+      // Read — resolve → home KB (§3.1).
+      const kbId = await knowledgeBaseIdForArticle(
+        ctx.db,
+        input.articleId,
+        getUserOrganizationId(ctx.session)
+      )
+      ctx.capabilities.assertViewInstance('kb', kbId)
       return await getKBService(ctx).getArticleVersions(input.articleId)
     }),
 
-  getArticleDiff: protectedProcedure
+  getArticleDiff: capabilityProcedure
     .input(
       z.object({
         articleId: z.string(),
@@ -602,12 +759,24 @@ export const knowledgeBaseRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      // Read — resolve → home KB (§3.1).
+      const kbId = await knowledgeBaseIdForArticle(
+        ctx.db,
+        input.articleId,
+        getUserOrganizationId(ctx.session)
+      )
+      ctx.capabilities.assertViewInstance('kb', kbId)
       return await getKBService(ctx).getArticleDiff(input.articleId, input.base, input.compare)
     }),
 
-  exportArticleMarkdown: protectedProcedure
+  exportArticleMarkdown: capabilityProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
+      // Read — gate on the placement KB if supplied, else the article's home KB.
+      const kbId =
+        input.knowledgeBaseId ??
+        (await knowledgeBaseIdForArticle(ctx.db, input.id, getUserOrganizationId(ctx.session)))
+      ctx.capabilities.assertViewInstance('kb', kbId)
       const article = await getKBService(ctx).getArticleById(input.id, input.knowledgeBaseId)
       if (article.articleKind === 'link') {
         throw new TRPCError({
@@ -626,9 +795,16 @@ export const knowledgeBaseRouter = createTRPCRouter({
       return { filename, markdown: header + markdown }
     }),
 
-  renameArticleVersion: protectedProcedure
+  renameArticleVersion: capabilityProcedure
     .input(z.object({ versionId: z.string(), label: z.string().nullish() }))
     .mutation(async ({ ctx, input }) => {
+      // Write — resolve version → article → home KB (§3.1).
+      const kbId = await knowledgeBaseIdForArticleVersion(
+        ctx.db,
+        input.versionId,
+        getUserOrganizationId(ctx.session)
+      )
+      ctx.capabilities.assertEditInstance('kb', kbId)
       await getKBService(ctx).renameArticleVersion(input.versionId, input.label ?? null)
       return { success: true }
     }),

--- a/apps/web/src/server/api/routers/knowledge-sources.ts
+++ b/apps/web/src/server/api/routers/knowledge-sources.ts
@@ -3,7 +3,10 @@
 // discovery procedures (checkUrl/getSitemapTree/findSubdomains) back the wizard, and
 // `create` accepts a website source whose config holds the crawl selection.
 
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
 import { getUserOrganizationId } from '@auxx/lib/email'
+import { ForbiddenError, NotFoundError } from '@auxx/lib/errors'
 import { detachArticleFromSource } from '@auxx/lib/kb'
 import {
   createSource,
@@ -19,9 +22,11 @@ import {
   unlinkSourceFromKb,
   updateSource,
 } from '@auxx/lib/knowledge-sources'
+import { type CapabilitySet, PermissionKey } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
+import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
 
 function requireOrgId(session: Parameters<typeof getUserOrganizationId>[0]): string {
   const organizationId = getUserOrganizationId(session)
@@ -29,6 +34,97 @@ function requireOrgId(session: Parameters<typeof getUserOrganizationId>[0]): str
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'User organization context not found' })
   }
   return organizationId
+}
+
+// ── Knowledge-source → KB(s) access resolution (doc 12 §3.3) ──────────────────
+// A source feeds one-or-more user-facing KBs (M:N). Sources have no L2 area of
+// their own; they inherit the KBs they link into:
+//   reads          → Read on ANY linked KB (link-less → creator/admin)
+//   per-link ops   → Write on THAT KB (gated inline at the call site)
+//   source-global  → Write on ALL linked KBs (link-less → creator/admin)
+
+/** The user-facing KBs a source links into (excludes its owned hidden KB). */
+async function linkedKbIds(
+  db: Database,
+  organizationId: string,
+  sourceId: string
+): Promise<string[]> {
+  const links = await listSourceLinks(db, organizationId, sourceId)
+  return links.map((k) => k.id)
+}
+
+/** A link-less source falls back to its creator or an org admin/owner. */
+function isSourceCreatorOrAdmin(
+  capabilities: CapabilitySet,
+  userId: string,
+  source: { createdById?: string | null }
+): boolean {
+  return (
+    capabilities.role === 'OWNER' ||
+    capabilities.role === 'ADMIN' ||
+    (source.createdById != null && source.createdById === userId)
+  )
+}
+
+/** Read visibility for a source: Read on ≥1 linked KB, or (link-less) creator/admin. */
+async function canReadSource(
+  db: Database,
+  capabilities: CapabilitySet,
+  userId: string,
+  organizationId: string,
+  source: { id: string; createdById?: string | null }
+): Promise<boolean> {
+  const kbIds = await linkedKbIds(db, organizationId, source.id)
+  if (kbIds.length === 0) return isSourceCreatorOrAdmin(capabilities, userId, source)
+  return kbIds.some((id) => capabilities.canViewInstance('kb', id))
+}
+
+/** Throwing read guard — resolves the source (org-scoped) then applies {@link canReadSource}. */
+async function assertCanReadSource(
+  db: Database,
+  capabilities: CapabilitySet,
+  userId: string,
+  organizationId: string,
+  sourceId: string
+): Promise<void> {
+  const source = await getSource(db, organizationId, sourceId)
+  if (await canReadSource(db, capabilities, userId, organizationId, source)) return
+  throw new ForbiddenError("You don't have permission to view this knowledge source.")
+}
+
+/**
+ * Source-global write guard: Write on ALL linked KBs (deny if any lacks it). A
+ * link-less source (freshly created, pre-sync) falls back to creator/admin.
+ */
+async function assertCanManageSource(
+  db: Database,
+  capabilities: CapabilitySet,
+  userId: string,
+  organizationId: string,
+  sourceId: string
+): Promise<void> {
+  const source = await getSource(db, organizationId, sourceId)
+  const kbIds = await linkedKbIds(db, organizationId, source.id)
+  if (kbIds.length === 0) {
+    if (isSourceCreatorOrAdmin(capabilities, userId, source)) return
+    throw new ForbiddenError("You don't have permission to manage this knowledge source.")
+  }
+  for (const id of kbIds) capabilities.assertEditInstance('kb', id)
+}
+
+/** Resolve an article to its home KB (for `detachArticle`, which carries only an articleId). */
+async function knowledgeBaseIdForArticle(
+  db: Database,
+  articleId: string,
+  organizationId: string
+): Promise<string> {
+  const [row] = await db
+    .select({ knowledgeBaseId: schema.Article.homeKnowledgeBaseId })
+    .from(schema.Article)
+    .where(and(eq(schema.Article.id, articleId), eq(schema.Article.organizationId, organizationId)))
+    .limit(1)
+  if (!row) throw new NotFoundError('Article not found')
+  return row.knowledgeBaseId
 }
 
 const manualItemSchema = z.object({
@@ -95,18 +191,44 @@ const websiteSourceSchema = z.object({
 const createSchema = z.discriminatedUnion('type', [manualSourceSchema, websiteSourceSchema])
 
 export const knowledgeSourceRouter = createTRPCRouter({
-  list: protectedProcedure.query(async ({ ctx }) => {
-    return listSources(ctx.db, requireOrgId(ctx.session))
+  list: capabilityProcedure.query(async ({ ctx }) => {
+    const organizationId = requireOrgId(ctx.session)
+    const userId = ctx.session.user.id
+    const sources = await listSources(ctx.db, organizationId)
+    // Filter to sources with ≥1 viewable linked KB (link-less → creator/admin).
+    const visible: typeof sources = []
+    for (const source of sources) {
+      if (await canReadSource(ctx.db, ctx.capabilities, userId, organizationId, source)) {
+        visible.push(source)
+      }
+    }
+    return visible
   }),
 
-  getById: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
-    return getSource(ctx.db, requireOrgId(ctx.session), input.id)
+  getById: capabilityProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
+    const organizationId = requireOrgId(ctx.session)
+    await assertCanReadSource(
+      ctx.db,
+      ctx.capabilities,
+      ctx.session.user.id,
+      organizationId,
+      input.id
+    )
+    return getSource(ctx.db, organizationId, input.id)
   }),
 
-  getStatus: protectedProcedure
+  getStatus: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      const source = await getSource(ctx.db, requireOrgId(ctx.session), input.id)
+      const organizationId = requireOrgId(ctx.session)
+      await assertCanReadSource(
+        ctx.db,
+        ctx.capabilities,
+        ctx.session.user.id,
+        organizationId,
+        input.id
+      )
+      const source = await getSource(ctx.db, organizationId, input.id)
       return {
         status: source.status,
         lastSyncedAt: source.lastSyncedAt,
@@ -115,7 +237,7 @@ export const knowledgeSourceRouter = createTRPCRouter({
       }
     }),
 
-  create: protectedProcedure.input(createSchema).mutation(async ({ ctx, input }) => {
+  create: capabilityProcedure.input(createSchema).mutation(async ({ ctx, input }) => {
     if (input.surface === 'ai-only') {
       throw new TRPCError({
         code: 'BAD_REQUEST',
@@ -123,6 +245,10 @@ export const knowledgeSourceRouter = createTRPCRouter({
       })
     }
     const organizationId = requireOrgId(ctx.session)
+    // A brand-new source names no KB (links happen post-sync from the KB side),
+    // so there's no instance to key on. Gate on the coarse source-setup
+    // capability: the member must hold `knowledgeBase.edit` (§3.3).
+    ctx.capabilities.assert(PermissionKey.knowledgeBaseEdit)
     // Linking is a post-sync, per-article action (from the KB side) — there are no
     // articles to pick until the first sync completes, so create never pre-links.
     return createSource(ctx.db, organizationId, {
@@ -136,7 +262,7 @@ export const knowledgeSourceRouter = createTRPCRouter({
     })
   }),
 
-  update: protectedProcedure
+  update: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -149,10 +275,13 @@ export const knowledgeSourceRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...patch } = input
+      const organizationId = requireOrgId(ctx.session)
+      // Source-global config change → Write on ALL linked KBs (§3.3).
+      await assertCanManageSource(ctx.db, ctx.capabilities, ctx.session.user.id, organizationId, id)
       // Selecting "Manual only" clears the cadence so the scheduler is removed.
       const scheduleConfig =
         patch.syncBehavior === 'manual' ? null : (patch.scheduleConfig ?? undefined)
-      return updateSource(ctx.db, requireOrgId(ctx.session), id, {
+      return updateSource(ctx.db, organizationId, id, {
         ...(patch.name !== undefined ? { name: patch.name } : {}),
         ...(patch.config !== undefined ? { config: patch.config } : {}),
         ...(patch.syncBehavior !== undefined ? { syncBehavior: patch.syncBehavior } : {}),
@@ -162,14 +291,22 @@ export const knowledgeSourceRouter = createTRPCRouter({
 
   // ── Linking a source's content into user-facing KBs ───────────────────────
 
-  listLinks: protectedProcedure
+  listLinks: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      return listSourceLinks(ctx.db, requireOrgId(ctx.session), input.id)
+      const organizationId = requireOrgId(ctx.session)
+      await assertCanReadSource(
+        ctx.db,
+        ctx.capabilities,
+        ctx.session.user.id,
+        organizationId,
+        input.id
+      )
+      return listSourceLinks(ctx.db, organizationId, input.id)
     }),
 
   // Remove one linked article's placement from a KB (source content untouched).
-  unlinkArticle: protectedProcedure
+  unlinkArticle: capabilityProcedure
     .input(
       z.object({
         id: z.string(),
@@ -178,6 +315,8 @@ export const knowledgeSourceRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Per-link mutation → Write on THAT KB (§3.3).
+      ctx.capabilities.assertEditInstance('kb', input.knowledgeBaseId)
       return unlinkSourceArticleFromKb(
         ctx.db,
         requireOrgId(ctx.session),
@@ -188,68 +327,112 @@ export const knowledgeSourceRouter = createTRPCRouter({
     }),
 
   // Bulk-unlink: remove ALL of a source's articles from one KB.
-  unlinkFromKnowledgeBase: protectedProcedure
+  unlinkFromKnowledgeBase: capabilityProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
+      // Per-link mutation → Write on THAT KB (§3.3).
+      ctx.capabilities.assertEditInstance('kb', input.knowledgeBaseId)
       return unlinkSourceFromKb(ctx.db, requireOrgId(ctx.session), input.id, input.knowledgeBaseId)
     }),
 
-  pause: protectedProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
-    return pauseSource(ctx.db, requireOrgId(ctx.session), input.id)
-  }),
-
-  resume: protectedProcedure
+  pause: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return resumeSource(ctx.db, requireOrgId(ctx.session), input.id)
+      const organizationId = requireOrgId(ctx.session)
+      // Source-global → Write on ALL linked KBs (§3.3).
+      await assertCanManageSource(
+        ctx.db,
+        ctx.capabilities,
+        ctx.session.user.id,
+        organizationId,
+        input.id
+      )
+      return pauseSource(ctx.db, organizationId, input.id)
+    }),
+
+  resume: capabilityProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const organizationId = requireOrgId(ctx.session)
+      // Source-global → Write on ALL linked KBs (§3.3).
+      await assertCanManageSource(
+        ctx.db,
+        ctx.capabilities,
+        ctx.session.user.id,
+        organizationId,
+        input.id
+      )
+      return resumeSource(ctx.db, organizationId, input.id)
     }),
 
   // ── Website crawler discovery (wizard backend) ────────────────────────────
   // These call the crawl provider directly — discovery happens before a source exists.
 
-  checkUrl: protectedProcedure
+  checkUrl: capabilityProcedure
     .input(z.object({ url: z.string().url() }))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      // Pre-create setup probe → source-setup capability (`knowledgeBase.edit`, §3.3).
+      ctx.capabilities.assert(PermissionKey.knowledgeBaseEdit)
       return getCrawlProvider().checkUrl(input.url)
     }),
 
-  findSubdomains: protectedProcedure
+  findSubdomains: capabilityProcedure
     .input(z.object({ url: z.string().url() }))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      // Pre-create setup probe → source-setup capability (`knowledgeBase.edit`, §3.3).
+      ctx.capabilities.assert(PermissionKey.knowledgeBaseEdit)
       const provider = getCrawlProvider()
       return provider.findSubdomains ? provider.findSubdomains(input.url) : []
     }),
 
-  getSitemapTree: protectedProcedure
+  getSitemapTree: capabilityProcedure
     .input(z.object({ url: z.string().url(), includeSubdomains: z.boolean().optional() }))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      // Pre-create setup probe → source-setup capability (`knowledgeBase.edit`, §3.3).
+      ctx.capabilities.assert(PermissionKey.knowledgeBaseEdit)
       return getCrawlProvider().getSitemapTree(input.url, {
         includeSubdomains: input.includeSubdomains,
       })
     }),
 
-  syncNow: protectedProcedure
+  syncNow: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = requireOrgId(ctx.session)
-      // Authz: ensures the source belongs to this org before enqueuing.
-      await getSource(ctx.db, organizationId, input.id)
+      // Source-global → Write on ALL linked KBs (§3.3). Also org-scopes the source.
+      await assertCanManageSource(
+        ctx.db,
+        ctx.capabilities,
+        ctx.session.user.id,
+        organizationId,
+        input.id
+      )
       await enqueueSourceSync({ sourceId: input.id, organizationId })
       return { success: true }
     }),
 
-  delete: protectedProcedure
+  delete: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return deleteSource(ctx.db, requireOrgId(ctx.session), input.id)
+      const organizationId = requireOrgId(ctx.session)
+      // Source-global → Write on ALL linked KBs (§3.3).
+      await assertCanManageSource(
+        ctx.db,
+        ctx.capabilities,
+        ctx.session.user.id,
+        organizationId,
+        input.id
+      )
+      return deleteSource(ctx.db, organizationId, input.id)
     }),
 
-  detachArticle: protectedProcedure
+  detachArticle: capabilityProcedure
     .input(z.object({ articleId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return detachArticleFromSource(
-        { db: ctx.db, organizationId: requireOrgId(ctx.session) },
-        input.articleId
-      )
+      const organizationId = requireOrgId(ctx.session)
+      // Per-link mutation → resolve the article's home KB, Write on it (§3.3).
+      const kbId = await knowledgeBaseIdForArticle(ctx.db, input.articleId, organizationId)
+      ctx.capabilities.assertEditInstance('kb', kbId)
+      return detachArticleFromSource({ db: ctx.db, organizationId }, input.articleId)
     }),
 })

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -108,7 +108,9 @@ export const USER_CACHE_KEY_CONFIG: Record<
   // `datasets` L2 area/keys. Pre-#1313 blobs lack the datasets area entirely, so
   // their expanded key set is missing `datasets.*` (even admins 403 on
   // `datasets.view`). Bump to abandon every stale blob → recompute on next read.
+  // v3: KB instance-access slice (doc 12) added the `knowledgeBase` L2 area/keys;
+  // pre-slice blobs lack them entirely (admins 403 on `knowledgeBase.view`).
   // NOTE: bump this whenever the registry's area/key set or the UserCapabilities
   // shape changes, so a rollout can't leave members on a stale key set.
-  userCapabilities: { prefix: 'user:capabilities:v2', ttlSeconds: ONE_DAY },
+  userCapabilities: { prefix: 'user:capabilities:v3', ttlSeconds: ONE_DAY },
 }

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -27,12 +27,14 @@ import { SEAT_CEILINGS } from './seat-policy'
  * view/edit gates pass them through:
  * - **Mail/messaging infrastructure** (`inbox`…`sequence`) — the mail visibility
  *   system.
- * - **Instance-access resources** (`dataset`) — their own L2 area + per-instance
- *   `ResourceAccess` grants, disjoint from type-level def enforcement (plan 11
- *   §0.6). Nothing calls `canViewEntity('dataset')`, so this is inert for
- *   enforcement; it keeps the client mirror `NON_RECORD_ENTITY_SLUGS` in
- *   `resources/registry/types.ts` consistent (that set hides datasets from the
- *   entity-def Access grid).
+ * - **Instance-access resources** (`dataset`, `kb`) — their own L2 area +
+ *   per-instance `ResourceAccess` grants, disjoint from type-level def
+ *   enforcement (plan 11 §0.6 / plan 12 §0.11). `article` inherits its KB's
+ *   grants (no per-article grants), so it is a non-record def too. Nothing calls
+ *   `canViewEntity('dataset'|'kb'|'article')`, so this is inert for enforcement;
+ *   it keeps the client mirror `NON_RECORD_ENTITY_SLUGS` in
+ *   `resources/registry/types.ts` consistent (that set hides datasets / KBs /
+ *   articles from the entity-def Access grid).
  *
  * Keyed by entity slug; the caller resolves the def to its slug before checking.
  */
@@ -44,6 +46,8 @@ export const NON_RECORD_DEF_SLUGS: ReadonlySet<string> = new Set([
   'snippet',
   'sequence',
   'dataset',
+  'kb',
+  'article',
 ])
 
 /**

--- a/packages/lib/src/permissions/capabilities/instance-access.ts
+++ b/packages/lib/src/permissions/capabilities/instance-access.ts
@@ -25,6 +25,8 @@ export interface InstanceAccessResourceConfig {
 export const INSTANCE_ACCESS_RESOURCES = {
   // org-shared; absent instance row → base L2 `datasets` level (§0.1)
   dataset: { baselineAtCreate: false, area: Area.datasets },
+  // org-shared; absent instance row → base L2 `knowledgeBase` level (doc 12 §0.2)
+  kb: { baselineAtCreate: false, area: Area.knowledgeBase },
 } as const satisfies Record<string, InstanceAccessResourceConfig>
 
 /** The set of resource keys backed by instance-level access. */

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -53,6 +53,11 @@ export enum PermissionKey {
   datasetsView = 'datasets.view',
   datasetsEdit = 'datasets.edit',
   datasetsManage = 'datasets.manage',
+
+  // knowledge bases (instance-access resource — per-KB ResourceAccess grants, doc 12 §2)
+  knowledgeBaseView = 'knowledgeBase.view',
+  knowledgeBaseEdit = 'knowledgeBase.edit',
+  knowledgeBaseManage = 'knowledgeBase.manage',
 }
 
 /** Metadata describing a single capability key. Mirrors `FeatureMetadata`. */
@@ -270,6 +275,29 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     group: 'Knowledge',
     featureKey: FeatureKey.datasets,
   },
+
+  // ── Knowledge Bases ──
+  {
+    key: PermissionKey.knowledgeBaseView,
+    label: 'View Knowledge Bases',
+    description: 'Read the articles inside knowledge bases.',
+    group: 'Knowledge',
+    featureKey: FeatureKey.knowledgeBase,
+  },
+  {
+    key: PermissionKey.knowledgeBaseEdit,
+    label: 'Write Knowledge Base Articles',
+    description: 'Write, publish, and organize the articles inside knowledge bases.',
+    group: 'Knowledge',
+    featureKey: FeatureKey.knowledgeBase,
+  },
+  {
+    key: PermissionKey.knowledgeBaseManage,
+    label: 'Manage Knowledge Bases',
+    description: 'Create, delete, and configure knowledge bases and their settings.',
+    group: 'Knowledge',
+    featureKey: FeatureKey.knowledgeBase,
+  },
 ]
 
 /** Lookup map for quick access to a key's metadata. */
@@ -330,6 +358,7 @@ export enum Area {
   files = 'files',
   connectors = 'connectors',
   datasets = 'datasets',
+  knowledgeBase = 'knowledgeBase',
 }
 
 /** A single rung of an area's ladder — the keys ADDED at (and above) `level`. */
@@ -523,6 +552,21 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
       { level: Level.Full, keys: [PermissionKey.datasetsManage] },
     ],
     featureKey: FeatureKey.datasets,
+  },
+  [Area.knowledgeBase]: {
+    area: Area.knowledgeBase,
+    label: 'Knowledge Base',
+    description:
+      'Read articles, write & publish them, or manage the knowledge base and its settings.',
+    group: 'Knowledge',
+    rungs: [
+      { level: Level.Read, keys: [PermissionKey.knowledgeBaseView] },
+      { level: Level.Edit, keys: [PermissionKey.knowledgeBaseEdit] },
+      { level: Level.Full, keys: [PermissionKey.knowledgeBaseManage] },
+    ],
+    // Layer-1 boolean access gate (types.ts:31) — NOT the plural
+    // FeatureKey.knowledgeBases (types.ts:61), which is the numeric KB-count limit.
+    featureKey: FeatureKey.knowledgeBase,
   },
 }
 

--- a/packages/lib/src/permissions/capabilities/seat-policy.ts
+++ b/packages/lib/src/permissions/capabilities/seat-policy.ts
@@ -70,10 +70,19 @@ const USER_ADMIN_NONE_AREAS = new Set<Area>([
 const USER_READ_AREAS = new Set<Area>([Area.datasets])
 
 /**
+ * Areas whose USER default is `Write`/`Edit` (not None/Read/Full). KB is
+ * collaborative content: everyone reads + authors articles by default; changing
+ * KB *settings* (Full) is a deliberate grant (doc 12 §0.3). Without an Edit
+ * default, per-KB share-up to Full would be the only per-KB lever and article
+ * authoring would need an org-wide bump.
+ */
+const USER_EDIT_AREAS = new Set<Area>([Area.knowledgeBase])
+
+/**
  * What each role gets out of the box, per area (before grants + seat clamp).
  * OWNER/ADMIN short-circuit to Full anyway; USER is Full everywhere except the
- * org-administration areas in {@link USER_ADMIN_NONE_AREAS} (`None`) and the
- * {@link USER_READ_AREAS} (`Read`).
+ * org-administration areas in {@link USER_ADMIN_NONE_AREAS} (`None`), the
+ * {@link USER_READ_AREAS} (`Read`), and the {@link USER_EDIT_AREAS} (`Edit`).
  */
 export const ROLE_DEFAULTS: Record<OrganizationRole, Record<Area, Level>> = {
   OWNER: ALL_FULL,
@@ -83,7 +92,9 @@ export const ROLE_DEFAULTS: Record<OrganizationRole, Record<Area, Level>> = {
       ? Level.None
       : USER_READ_AREAS.has(area)
         ? Level.Read
-        : Level.Full
+        : USER_EDIT_AREAS.has(area)
+          ? Level.Edit
+          : Level.Full
   ),
 }
 

--- a/packages/lib/src/resources/registry/types.ts
+++ b/packages/lib/src/resources/registry/types.ts
@@ -110,10 +110,11 @@ export function isCustomResource(resource: Resource): resource is CustomResource
  * hidden from the entity-def Access UI (capability layer v2 phase 3):
  * - **Mail/messaging infra** (`inbox`…`sequence`) — their `ResourceAccess` rows
  *   carry mail-sharing semantics, not def restriction.
- * - **Instance-access resources** (`dataset`) — governed by their own L2 area +
- *   per-instance `ResourceAccess` grants (the Share card), disjoint from
- *   type-level def enforcement (plan 08 §0.6 / 11 §0.6). A def-access grid row
- *   for these would be a phantom control that writes rows nothing reads.
+ * - **Instance-access resources** (`dataset`, `kb`) — governed by their own L2
+ *   area + per-instance `ResourceAccess` grants (the Share card), disjoint from
+ *   type-level def enforcement (plan 08 §0.6 / 11 §0.6 / 12 §0.11). `article`
+ *   inherits its KB's grants (no per-article grants). A def-access grid row for
+ *   any of these would be a phantom control that writes rows nothing reads.
  *
  * Client-safe mirror of the server-side `NON_RECORD_DEF_SLUGS` in
  * `permissions/capabilities/entity-access.ts` — kept in sync by hand.
@@ -126,6 +127,8 @@ export const NON_RECORD_ENTITY_SLUGS: ReadonlySet<string> = new Set([
   'snippet',
   'sequence',
   'dataset',
+  'kb',
+  'article',
 ])
 
 /**


### PR DESCRIPTION
## What

Instance-access **slice #2: knowledge bases** — the second consumer of the doc-11 mechanism (after datasets #1313). KB is a near-verbatim copy of datasets riding the same mechanism; no mechanism was rebuilt. Implements `plans/permissions/v2/12-instance-access-kb.md`.

## Changes

- **Registry / seat-policy** — `knowledgeBase.view/edit/manage` keys + `Area.knowledgeBase` ladder (None/Read/Write/Full); `USER_EDIT_AREAS` sets the USER default to **Write** (KB is collaborative content — everyone reads + authors articles by default; changing settings is Full). One `kb` line in `INSTANCE_ACCESS_RESOURCES` + one `INSTANCE_SHARE_COPY.kb` entry.
- **`kb.ts` enforcement** — `protectedProcedure` → `capabilityProcedure`. Article ops resolve to their placement KB (`input.knowledgeBaseId`) or the article's `homeKnowledgeBaseId`; version-only ops resolve version → `ArticleRevision` → article → home KB. Rung map per plan §3.1 (Read: browse/versions/diff/export/turn-review · Write: article authoring/publish/link/move/batch/Kopilot turn keep-revert · Full: KB settings/site publish/delete). `create` + `ensureLearnedMemory` gate the coarse `knowledgeBase.manage`.
- **`knowledge-sources.ts` enforcement** — the M:N source→KB resolution: reads = Read on **any** linked KB · source-global mutations (`update`/`pause`/`resume`/`syncNow`/`delete`) = Write on **all** linked KBs · per-link ops = Write on that KB · `detachArticle` = Write on the article's home KB · link-less source = creator or OWNER/ADMIN · `create`/probes = coarse `knowledgeBase.edit`.
- **Share UI** — reuses the generic `InstanceShareCard`: a Share button on the KB editor header + a Shared/🔒 badge and `⋯` "Share…" item on the KB card.
- **Client gating** — nav `permissionKey: 'knowledgeBase.view'`, a `CapabilityPageGuard` on `/app/kb`, create/connect affordance gates; `kb` **and** `article` added to `NON_RECORD_ENTITY_SLUGS` / `NON_RECORD_DEF_SLUGS` so they don't render a phantom Access-grid row (instance-access is disjoint from def enforcement).
- **Cache bump** — `userCapabilities` v2 → v3 (new-area rollout invalidation; without it admins 403 on `knowledgeBase.view` from stale blobs).

## Two deltas from the plan (resolved open items)

- **`ensureLearnedMemory` gates at coarse `knowledgeBase.manage` (Full), not `assertAdminInstance`** — the AI-Memory KB may not exist yet at call time, so there's no instance to key on (create-shaped). Consequence: a regular USER (default Write) can't provision AI Memory — it's a Manage/admin action. Resolves plan open item #4.
- **The link-less-source creator/admin fallback extends to source *reads*** (not just global mutations) so a freshly-created pre-sync source stays visible to its creator instead of vanishing until first sync.

## Notes

- Does **not** touch `KnowledgeBase.visibility` (PUBLIC/INTERNAL — orthogonal external-publishing axis) or the Kopilot autonomous write-tools (deferred to the Phase-4 agent-tools item). Human turn-review ops do gate now.
- Minor N+1: `knowledgeSource.list` calls `listSourceLinks` per source — fine at current source counts.

## Test plan

- [ ] USER (default): can read all KBs, author/publish articles, connect sources; cannot create/delete a KB, change KB settings, or provision AI Memory.
- [ ] Per-KB share-up to Full on one KB grants settings access to just that KB; restrict to Read/`'none'` narrows one KB.
- [ ] Member at `knowledgeBase = None`: `/app/kb` redirects to /access-denied; sidebar item hidden; `kb.list` returns empty (no 403).
- [ ] Admin: no phantom KB/article row in the entity-def Access grid.
- [ ] Source with links to KBs A+B: `syncNow`/`delete` denied unless the member has Write on both.