### PR TITLE
fix(permissions): gate create affordances on empty states + dataset uploads

### DIFF
--- a/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-empty-state.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-empty-state.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-empty-state.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { FileText, Plus, Search, Workflow } from 'lucide-react'
 import { useState } from 'react'
@@ -8,6 +9,7 @@ import { EmptyState } from '~/components/global/empty-state'
 import { WorkflowFormDialog } from '~/components/workflow/dialogs/workflow-form-dialog'
 import { WorkflowTemplateDialog } from '~/components/workflow/dialogs/workflow-template-dialog'
 import { useOrganization } from '~/hooks/use-organization'
+import { useAccess } from '~/providers/capabilities-provider'
 
 interface WorkflowsEmptyStateProps {
   searchQuery?: string
@@ -21,6 +23,8 @@ export function WorkflowsEmptyState({
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showTemplateDialog, setShowTemplateDialog] = useState(false)
   const organization = useOrganization()
+  const { can } = useAccess()
+  const canCreate = can(PermissionKey.workflowsManage)
   const hasFilters = searchQuery || selectedTriggerType
 
   if (hasFilters) {
@@ -52,24 +56,28 @@ export function WorkflowsEmptyState({
         title='Workflows'
         description={
           <div className='max-w-[250px]'>
-            No workflows yet! Create your first workflow to get started.
+            {canCreate
+              ? 'No workflows yet! Create your first workflow to get started.'
+              : 'No workflows yet. Ask an admin to set one up.'}
           </div>
         }
         button={
-          <div className='flex items-center gap-2'>
-            <Button
-              type='button'
-              size='sm'
-              variant='outline'
-              onClick={() => setShowCreateDialog(true)}>
-              <Plus />
-              Create Workflow
-            </Button>
-            <Button type='button' size='sm' onClick={() => setShowTemplateDialog(true)}>
-              <FileText />
-              Browse Templates
-            </Button>
-          </div>
+          canCreate ? (
+            <div className='flex items-center gap-2'>
+              <Button
+                type='button'
+                size='sm'
+                variant='outline'
+                onClick={() => setShowCreateDialog(true)}>
+                <Plus />
+                Create Workflow
+              </Button>
+              <Button type='button' size='sm' onClick={() => setShowTemplateDialog(true)}>
+                <FileText />
+                Browse Templates
+              </Button>
+            </div>
+          ) : undefined
         }
       />
       <WorkflowFormDialog

--- a/apps/web/src/components/agents/ui/list/agents-empty-state.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-empty-state.tsx
@@ -1,9 +1,11 @@
 // apps/web/src/components/agents/ui/list/agents-empty-state.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { Bot } from 'lucide-react'
 import { EmptyState } from '~/components/global/empty-state'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useAgentSearch } from '../../hooks/use-agent-search'
 import { CreateAgentButton } from './create-agent-button'
 
@@ -14,13 +16,19 @@ interface AgentsEmptyStateProps {
 
 export function AgentsEmptyState({ isFirstRun }: AgentsEmptyStateProps) {
   const { setSearch } = useAgentSearch()
+  const { can } = useAccess()
+  const canCreate = can(PermissionKey.agentsManage)
   if (isFirstRun) {
     return (
       <EmptyState
         icon={Bot}
         title='No agents yet'
-        description='Create an agent to delegate work to AI.'
-        button={<CreateAgentButton />}
+        description={
+          canCreate
+            ? 'Create an agent to delegate work to AI.'
+            : 'No agents have been set up yet. Ask an admin to create one.'
+        }
+        button={canCreate ? <CreateAgentButton /> : undefined}
       />
     )
   }

--- a/apps/web/src/components/agents/ui/list/create-agent-button.tsx
+++ b/apps/web/src/components/agents/ui/list/create-agent-button.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/agents/ui/list/create-agent-button.tsx
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { AnimatedGradientText } from '@auxx/ui/components/animated-gradient-text'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -16,6 +16,7 @@ import { Bot, LayoutTemplate, MessageCircle, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useState } from 'react'
 import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
 import { useAgentStore } from '../../store/agent-store'
@@ -41,6 +42,7 @@ export function CreateAgentButton() {
   )
   const atLimit = isAtLimit(FeatureKey.agentsLimit, agentCount)
   const agentLimit = getLimit(FeatureKey.agentsLimit)
+  const { can } = useAccess()
 
   const isBusy = isCreating || isRedirecting
 
@@ -64,6 +66,9 @@ export function CreateAgentButton() {
     setTemplateKind(kind)
     setTemplateDialogOpen(true)
   }, [])
+
+  // Members without the agents Full rung can't create — hide the trigger.
+  if (!can(PermissionKey.agentsManage)) return null
 
   // No allowance on the current plan — gate creation behind an upgrade prompt.
   if (atLimit) {

--- a/apps/web/src/components/datasets/datasets-empty-state.tsx
+++ b/apps/web/src/components/datasets/datasets-empty-state.tsx
@@ -3,8 +3,10 @@
 'use client'
 
 import type { DatasetStatus } from '@auxx/lib/datasets'
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Database } from 'lucide-react'
 import { EmptyState } from '~/components/global/empty-state'
+import { useAccess } from '~/providers/capabilities-provider'
 import { CreateDatasetButton } from './create-dataset-button'
 
 interface DatasetsEmptyStateProps {
@@ -16,6 +18,8 @@ interface DatasetsEmptyStateProps {
  * Empty state component for when no datasets are found
  */
 export function DatasetsEmptyState({ searchQuery, selectedStatus }: DatasetsEmptyStateProps) {
+  const { can } = useAccess()
+  const canCreate = can(PermissionKey.datasetsManage)
   const hasFilters = searchQuery || selectedStatus !== 'all'
 
   if (hasFilters) {
@@ -28,12 +32,18 @@ export function DatasetsEmptyState({ searchQuery, selectedStatus }: DatasetsEmpt
     )
   }
 
+  // Members without the create (Full) rung can't add datasets — don't invite
+  // them to. The Create button already self-hides on the same gate.
   return (
     <EmptyState
       icon={Database}
       title='No datasets yet'
-      description='Create your first dataset to get started with knowledge management.'
-      button={<CreateDatasetButton variant='outline' />}
+      description={
+        canCreate
+          ? 'Create your first dataset to get started with knowledge management.'
+          : 'No datasets have been shared with you yet. Ask an admin to add one or share one with you.'
+      }
+      button={canCreate ? <CreateDatasetButton variant='outline' /> : undefined}
     />
   )
 }

--- a/apps/web/src/components/datasets/documents/document-management.tsx
+++ b/apps/web/src/components/datasets/documents/document-management.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/datasets/documents/document-management.tsx
 'use client'
 import type { DocumentEntity as Document } from '@auxx/database/types'
+import { toRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { toastError, toastInfo, toastSuccess } from '@auxx/ui/components/toast'
 import { CircleDot, CircleSlash, FileText, Plus, Trash2 } from 'lucide-react'
@@ -11,6 +12,7 @@ import { useFileUpload } from '~/components/file-upload/hooks/use-file-upload'
 import { FileDropZone } from '~/components/files/file-drop-zone'
 import { EmptyState } from '~/components/global/empty-state'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { useDocumentProcessing } from '../hooks/use-document-processing'
 import { createDocumentColumns } from './document-columns'
@@ -46,6 +48,11 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
   const [detailDrawerOpen, setDetailDrawerOpen] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [confirm, ConfirmDialog] = useConfirm()
+
+  // Uploading documents is a Write on this dataset (per-instance, mirrors the
+  // `document.batchProcess` router gate) — hide the upload affordances otherwise.
+  const { canEditInstance } = useAccess()
+  const canUpload = canEditInstance(toRecordId('dataset', datasetId))
 
   // Get utils for cache invalidation
   const utils = api.useUtils()
@@ -325,7 +332,7 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
     <FileDropZone
       onFilesDropped={handleDocumentsDropped}
       currentFolderName={dataset?.name || 'Dataset'}
-      disabled={isDocumentsLoading || isUploading || isUploadActive}>
+      disabled={isDocumentsLoading || isUploading || isUploadActive || !canUpload}>
       {/* Dynamic Table */}
       <DynamicTable<Document>
         tableId='dataset-documents'
@@ -342,7 +349,7 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
         onRefresh={refetch}
         searchPlaceholder='Search documents...'
         searchKeys={['filename', 'title', 'mimeType']}
-        onAddNew={() => setUploadDialogOpen(true)}
+        onAddNew={canUpload ? () => setUploadDialogOpen(true) : undefined}
         customFilter={
           <DocumentFilterBar
             filterValue={documentFilter}
@@ -358,10 +365,12 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
             description={
               documentFilter !== 'all'
                 ? 'Try adjusting your filters to find documents.'
-                : 'Upload your first documents to get started with this dataset.'
+                : canUpload
+                  ? 'Upload your first documents to get started with this dataset.'
+                  : "This dataset has no documents yet. You don't have permission to add files here."
             }
             button={
-              documentFilter === 'all' ? (
+              documentFilter === 'all' && canUpload ? (
                 <Button onClick={() => setUploadDialogOpen(true)} variant='outline'>
                   <Plus />
                   Upload Documents


### PR DESCRIPTION
## Summary
- Workflows, agents, and datasets empty states now hide the "Create" button and show read-only copy when the viewer lacks the relevant `*.manage` permission (`workflowsManage`, `agentsManage`, `datasetsManage`).
- `CreateAgentButton` self-hides entirely for members without `agentsManage`.
- Dataset document management now gates uploads (drop zone, "add new", empty-state button) on per-instance edit access (`canEditInstance`) rather than just loading/upload state, mirroring the `document.batchProcess` router-side gate.

## Test plan
- [ ] As a member without `agentsManage`/`workflowsManage`/`datasetsManage`, confirm empty states show read-only copy and no create button.
- [ ] As an admin/full-access member, confirm create flows still work unchanged.
- [ ] As a member with only Read access on a shared dataset, confirm upload affordances are hidden on the documents empty state and drop zone.
- [ ] `pnpm --filter @auxx/web typecheck` and `pnpm lint:changed` pass.