### PR TITLE
feat(custom-fields): add search + hide-system toggle to entity/field lists

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/custom-fields/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/custom-fields/page.tsx
@@ -4,16 +4,27 @@
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { AnimatedGradientText } from '@auxx/ui/components/animated-gradient-text'
 import { Button } from '@auxx/ui/components/button'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
-import { Table, TableBody, TableHead, TableHeader, TableRow } from '@auxx/ui/components/table'
-import { ChevronDown, LayoutTemplate, Plus } from 'lucide-react'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
+import { EmptySection } from '@auxx/ui/components/section'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { ChevronDown, LayoutTemplate, Plus, Search } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { EntityDefinitionDialog } from '~/components/custom-fields/ui/entity-definition-dialog'
 import { EntityRow } from '~/components/custom-fields/ui/entity-row'
 import { EntityTemplateDialog } from '~/components/custom-fields/ui/entity-template-dialog'
@@ -41,11 +52,25 @@ export default function CustomFieldsPage() {
   const [limitDialogOpen, setLimitDialogOpen] = useState(false)
   const { isAtLimit, getLimit } = useFeatureFlags()
 
+  // Search + system-entity visibility (local, non-persisted list filters)
+  const [search, setSearch] = useState('')
+  const [hideSystem, setHideSystem] = useState(false)
+
   // Get all resources (system + custom) from unified registry
   const { resources, customResources, isLoading } = useResources()
   const userCreatedEntityCount = customResources?.filter((r) => !r.entityType).length ?? 0
   const atEntityLimit = isAtLimit(FeatureKey.entities, userCreatedEntityCount)
   const entityLimit = getLimit(FeatureKey.entities)
+
+  // Def-admin scoping, hidden system types, then search + "hide system" filters
+  const visibleResources = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    return resources
+      .filter((r) => !r.entityType || !HIDDEN_ENTITY_TYPES.includes(r.entityType))
+      .filter((r) => canAdministerDef(r.entityDefinitionId))
+      .filter((r) => !(hideSystem && r.entityType))
+      .filter((r) => !query || r.label.toLowerCase().includes(query))
+  }, [resources, canAdministerDef, hideSystem, search])
 
   /** Navigate to entity fields page */
   function handleRowClick(slug: string) {
@@ -74,7 +99,24 @@ export default function CustomFieldsPage() {
     <SettingsPage
       title='Custom Entities & Fields'
       description='Manage all the custom entities and fields in your organization.'
-      breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Custom Fields' }]}>
+      breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Custom Fields' }]}
+      subHeader={
+        <ListToolbar sticky={false}>
+          <InputSearch
+            value={search}
+            placeholder='Search entities...'
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <ListToolbarGroup align='end'>
+            <ButtonSwitch
+              label='Hide system entities'
+              checked={hideSystem}
+              onCheckedChange={setHideSystem}
+            />
+          </ListToolbarGroup>
+        </ListToolbar>
+      }
+      subHeaderClassName='p-0'>
       <Table>
         <TableHeader>
           <TableRow>
@@ -108,23 +150,30 @@ export default function CustomFieldsPage() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {/* All resources (system + custom) from unified registry, excluding hidden system types */}
-          {!isLoading &&
-            resources
-              .filter((r) => !r.entityType || !HIDDEN_ENTITY_TYPES.includes(r.entityType))
-              // Def-admin scoping: a member sees only the defs they administer.
-              // Admins administer every def, so their list is unchanged.
-              .filter((r) => canAdministerDef(r.entityDefinitionId))
-              .map((resource) => (
-                <EntityRow
-                  key={resource.id}
-                  label={resource.label}
-                  type={resource.entityType ? 'System' : 'Custom'}
-                  iconId={resource.icon}
-                  color={resource.color}
-                  onClick={() => handleRowClick(resource.apiSlug)}
+          {!isLoading && visibleResources.length === 0 ? (
+            <TableRow className='hover:bg-transparent'>
+              <TableCell colSpan={4} className='p-0'>
+                <EmptySection
+                  icon={<Search />}
+                  title='No entities found'
+                  description='Try a different search or turn off "Hide system entities".'
+                  className='mx-3 mt-3'
                 />
-              ))}
+              </TableCell>
+            </TableRow>
+          ) : (
+            !isLoading &&
+            visibleResources.map((resource) => (
+              <EntityRow
+                key={resource.id}
+                label={resource.label}
+                type={resource.entityType ? 'System' : 'Custom'}
+                iconId={resource.icon}
+                color={resource.color}
+                onClick={() => handleRowClick(resource.apiSlug)}
+              />
+            ))
+          )}
         </TableBody>
       </Table>
 

--- a/apps/web/src/components/custom-fields/ui/custom-fields-list.tsx
+++ b/apps/web/src/components/custom-fields/ui/custom-fields-list.tsx
@@ -4,6 +4,10 @@
 import type { Resource } from '@auxx/lib/resources/client'
 import { type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
+import { EmptySection } from '@auxx/ui/components/section'
 import { TableBody, TableHead, TableHeader, TableRow } from '@auxx/ui/components/table'
 import {
   closestCenter,
@@ -20,7 +24,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Plus, Rows3 } from 'lucide-react'
+import { Plus, Rows3, Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useCustomFieldMutations } from '~/components/custom-fields/hooks/use-custom-field-mutations'
 import { CustomFieldDialog } from '~/components/custom-fields/ui/custom-field-dialog'
@@ -43,6 +47,10 @@ export function CustomFieldsList({ resource }: CustomFieldsListProps) {
   // Dialog state
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingResourceFieldId, setEditingResourceFieldId] = useState<ResourceFieldId | null>(null)
+
+  // Search + system-field visibility (local, non-persisted list filters)
+  const [search, setSearch] = useState('')
+  const [hideSystem, setHideSystem] = useState(false)
 
   // Confirm dialog for delete
   const [confirmDelete, ConfirmDeleteDialog] = useConfirm()
@@ -68,6 +76,20 @@ export function CustomFieldsList({ resource }: CustomFieldsListProps) {
         .sort((a, b) => (a.sortOrder ?? '').localeCompare(b.sortOrder ?? '')),
     [fields]
   )
+
+  const hasFields = sortedFields.length > 0
+
+  // Apply search (name/label + description) and the "hide system fields" toggle
+  const visibleFields = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    return sortedFields.filter((field) => {
+      if (hideSystem && field.isSystem) return false
+      if (!query) return true
+      const name = (field.name ?? field.label ?? '').toLowerCase()
+      const description = (field.description ?? '').toLowerCase()
+      return name.includes(query) || description.includes(query)
+    })
+  }, [sortedFields, search, hideSystem])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
@@ -129,7 +151,24 @@ export function CustomFieldsList({ resource }: CustomFieldsListProps) {
         />
       )}
 
-      {sortedFields.length === 0 ? (
+      {hasFields && (
+        <ListToolbar>
+          <InputSearch
+            value={search}
+            placeholder='Search fields...'
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <ListToolbarGroup align='end'>
+            <ButtonSwitch
+              label='Hide system fields'
+              checked={hideSystem}
+              onCheckedChange={setHideSystem}
+            />
+          </ListToolbarGroup>
+        </ListToolbar>
+      )}
+
+      {!hasFields ? (
         <EmptyState
           icon={Rows3}
           title='No custom fields added'
@@ -148,13 +187,20 @@ export function CustomFieldsList({ resource }: CustomFieldsListProps) {
             ) : undefined
           }
         />
+      ) : visibleFields.length === 0 ? (
+        <EmptySection
+          icon={<Search />}
+          title='No fields found'
+          description='Try a different search or turn off "Hide system fields".'
+          className='mx-3 mt-3'
+        />
       ) : (
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
           modifiers={[restrictToVerticalAxis]}>
-          <table className='text-sm w-full caption-bottom border-t'>
+          <table className='text-sm w-full caption-bottom'>
             <TableHeader>
               <TableRow>
                 <TableHead className='w-[40px]'></TableHead>
@@ -179,9 +225,9 @@ export function CustomFieldsList({ resource }: CustomFieldsListProps) {
             </TableHeader>
             <TableBody>
               <SortableContext
-                items={sortedFields.map((field) => field.id)}
+                items={visibleFields.map((field) => field.id)}
                 strategy={verticalListSortingStrategy}>
-                {sortedFields.map((field) => (
+                {visibleFields.map((field) => (
                   <CustomFieldRow
                     key={field.id}
                     field={field}


### PR DESCRIPTION
## Summary
- Add a `ListToolbar` (search box + "Hide system entities" switch) to the custom entities list (`/app/settings/custom-fields`), placed in `SettingsPage`'s `subHeader`.
- Add the same pattern (search + "Hide system fields" switch) to the per-entity fields list (`CustomFieldsList`).
- Show a dedicated `EmptySection` "no results" state when search/filter excludes everything, distinct from the existing "nothing created yet" empty state.

## Test plan
- [x] `tsc --noEmit` on both changed files (apps/web) — no new errors
- [ ] Manually verify search/toggle filtering and empty states in the browser on `/app/settings/custom-fields` and an entity's fields tab