### PR TITLE
fix(permissions): gate command-palette actions on layer-2 access

### DIFF
--- a/apps/web/src/components/kbar/actions/create.ts
+++ b/apps/web/src/components/kbar/actions/create.ts
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { useCreateEntityStore } from '~/components/global-create/create-entity-store'
 import { SYSTEM_CREATE_HOTKEYS } from '~/components/global-create/system-hotkeys'
 import { useViewableResources } from '~/components/resources/hooks/use-viewable-resources'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useCommandPaletteStore } from '../store'
 import type { PaletteAction } from '../types'
 
@@ -16,10 +17,13 @@ import type { PaletteAction } from '../types'
  */
 export function useCreateActions(): PaletteAction[] {
   const { resources } = useViewableResources()
+  const { canEditEntity } = useAccess()
 
   return useMemo<PaletteAction[]>(() => {
+    // Creating a record is a write — gate on the per-def Edit rung, not just
+    // viewability (a Read-only member sees the def but can't create in it).
     return resources
-      .filter((r) => r.isVisible)
+      .filter((r) => r.isVisible && canEditEntity(r.entityDefinitionId))
       .map((r) => ({
         id: `create.${r.id}`,
         label: `Create ${r.label}`,
@@ -30,7 +34,7 @@ export function useCreateActions(): PaletteAction[] {
         // Inside the palette, render the create form as a step (Phase 3).
         perform: () => useCommandPaletteStore.getState().openCreate(r.id),
       }))
-  }, [resources])
+  }, [resources, canEditEntity])
 }
 
 /**

--- a/apps/web/src/components/kbar/actions/launchers.ts
+++ b/apps/web/src/components/kbar/actions/launchers.ts
@@ -4,6 +4,7 @@
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
 import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useCommandPaletteStore } from '../store'
 import type { PaletteAction } from '../types'
@@ -22,6 +23,7 @@ import type { PaletteAction } from '../types'
 export function useLauncherActions(): PaletteAction[] {
   const router = useRouter()
   const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
   const { isAdminOrOwner } = useUser()
 
   return useMemo<PaletteAction[]>(() => {
@@ -91,7 +93,9 @@ export function useLauncherActions(): PaletteAction[] {
       })
     }
 
-    if (hasAccess('datasets')) {
+    // Creating a dataset is the `datasets` Full rung (`datasets.manage`) — mirrors
+    // CreateDatasetButton; Read/Edit members can browse but not create.
+    if (hasAccess('datasets') && can('datasets.manage')) {
       actions.push({
         id: 'create.dataset',
         label: 'Create Dataset',
@@ -131,5 +135,5 @@ export function useLauncherActions(): PaletteAction[] {
     }
 
     return actions
-  }, [hasAccess, isAdminOrOwner, router])
+  }, [hasAccess, can, isAdminOrOwner, router])
 }

--- a/apps/web/src/components/kbar/actions/navigation.ts
+++ b/apps/web/src/components/kbar/actions/navigation.ts
@@ -3,7 +3,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo } from 'react'
-import { useUser } from '~/hooks/use-user'
+import { useViewableResources } from '~/components/resources/hooks/use-viewable-resources'
 import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { SHORTCUTS } from '../shortcuts'
@@ -20,7 +20,13 @@ export function useNavigationActions(): PaletteAction[] {
   const router = useRouter()
   const { hasAccess } = useFeatureFlags()
   const { can } = useAccess()
-  const { isAdminOrOwner } = useUser()
+  // Per-def read gate for the core-record destinations, mirroring the sidebar
+  // (which lists only viewable defs, #1296). Keyed by `apiSlug`.
+  const { resources: viewableResources, isLoading: resourcesLoading } = useViewableResources()
+  const viewableSlugs = useMemo(
+    () => new Set(viewableResources.map((r) => r.apiSlug)),
+    [viewableResources]
+  )
 
   const nav = useCallback(
     (path: string) => {
@@ -66,7 +72,7 @@ export function useNavigationActions(): PaletteAction[] {
       })
     }
 
-    if (hasAccess('agents') && isAdminOrOwner) {
+    if (hasAccess('agents') && can('agents.manage')) {
       actions.push({
         id: 'nav.agents',
         label: 'Agents',
@@ -191,8 +197,13 @@ export function useNavigationActions(): PaletteAction[] {
     )
 
     // ── Records ──────────────────────────────────────────────────────────
-    actions.push(
-      {
+    // Per-def view gate: show a core-record destination only when its def is
+    // viewable (or while the catalog is still loading, so core nav never flickers
+    // out). Keyed by `apiSlug`; mirrors the sidebar's viewable-defs filter.
+    const recordVisible = (apiSlug: string) => resourcesLoading || viewableSlugs.has(apiSlug)
+
+    if (recordVisible('contacts')) {
+      actions.push({
         id: 'nav.contacts',
         label: 'Contacts',
         subtitle: 'View your contacts',
@@ -200,8 +211,10 @@ export function useNavigationActions(): PaletteAction[] {
         keywords: 'contacts people',
         shortcut: SHORTCUTS['nav.contacts'],
         perform: () => nav('/contacts'),
-      },
-      {
+      })
+    }
+    if (recordVisible('companies')) {
+      actions.push({
         id: 'nav.companies',
         label: 'Companies',
         subtitle: 'View your companies',
@@ -209,8 +222,10 @@ export function useNavigationActions(): PaletteAction[] {
         keywords: 'companies organizations accounts',
         shortcut: SHORTCUTS['nav.companies'],
         perform: () => nav('/companies'),
-      },
-      {
+      })
+    }
+    if (recordVisible('parts')) {
+      actions.push({
         id: 'nav.parts',
         label: 'Parts',
         subtitle: 'View your parts inventory',
@@ -218,50 +233,55 @@ export function useNavigationActions(): PaletteAction[] {
         keywords: 'parts inventory manufacturing',
         shortcut: SHORTCUTS['nav.parts'],
         perform: () => nav('/parts'),
-      },
-      {
-        id: 'nav.tickets',
-        label: 'Tickets',
-        subtitle: 'View your tickets',
-        icon: 'ticket',
-        keywords: 'tickets support',
-        shortcut: SHORTCUTS['nav.tickets'],
-        perform: () => nav('/tickets/list'),
-      },
-      {
-        id: 'nav.tickets.filter',
-        label: 'Tickets · Filter',
-        icon: 'filter',
-        keywords: 'tickets filter',
-        perform: () => nav('/tickets/list?filter=true'),
-      },
-      {
-        id: 'nav.tickets.dashboard',
-        label: 'Tickets · Dashboard',
-        icon: 'layout-dashboard',
-        keywords: 'tickets dashboard',
-        perform: () => nav('/tickets/dashboard'),
-      },
-      {
-        id: 'nav.tickets.settings',
-        label: 'Tickets · Settings',
-        icon: 'settings',
-        keywords: 'tickets settings',
-        perform: () => nav('/tickets/settings'),
-      },
-      {
-        id: 'nav.tasks',
-        label: 'Tasks',
-        subtitle: 'View your tasks',
-        icon: 'list-checks',
-        keywords: 'tasks to-do',
-        shortcut: SHORTCUTS['nav.tasks'],
-        perform: () => nav('/tasks'),
-      }
-    )
+      })
+    }
+    if (recordVisible('tickets')) {
+      actions.push(
+        {
+          id: 'nav.tickets',
+          label: 'Tickets',
+          subtitle: 'View your tickets',
+          icon: 'ticket',
+          keywords: 'tickets support',
+          shortcut: SHORTCUTS['nav.tickets'],
+          perform: () => nav('/tickets/list'),
+        },
+        {
+          id: 'nav.tickets.filter',
+          label: 'Tickets · Filter',
+          icon: 'filter',
+          keywords: 'tickets filter',
+          perform: () => nav('/tickets/list?filter=true'),
+        },
+        {
+          id: 'nav.tickets.dashboard',
+          label: 'Tickets · Dashboard',
+          icon: 'layout-dashboard',
+          keywords: 'tickets dashboard',
+          perform: () => nav('/tickets/dashboard'),
+        },
+        {
+          id: 'nav.tickets.settings',
+          label: 'Tickets · Settings',
+          icon: 'settings',
+          keywords: 'tickets settings',
+          perform: () => nav('/tickets/settings'),
+        }
+      )
+    }
+    // Tasks is a core destination with no per-area/def gate (matches the sidebar).
+    actions.push({
+      id: 'nav.tasks',
+      label: 'Tasks',
+      subtitle: 'View your tasks',
+      icon: 'list-checks',
+      keywords: 'tasks to-do',
+      shortcut: SHORTCUTS['nav.tasks'],
+      perform: () => nav('/tasks'),
+    })
 
     // ── Feature-gated destinations ───────────────────────────────────────
-    if (hasAccess('dispatch')) {
+    if (hasAccess('dispatch') && can('dispatch.mySchedule')) {
       actions.push({
         id: 'nav.schedule',
         label: 'Schedule',
@@ -271,7 +291,7 @@ export function useNavigationActions(): PaletteAction[] {
         perform: () => nav('/schedule'),
       })
     }
-    if (hasAccess('workflows')) {
+    if (hasAccess('workflows') && can('workflows.manage')) {
       actions.push({
         id: 'nav.workflows',
         label: 'Workflows',
@@ -282,7 +302,7 @@ export function useNavigationActions(): PaletteAction[] {
         perform: () => nav('/workflows'),
       })
     }
-    if (hasAccess('knowledgeBase')) {
+    if (hasAccess('knowledgeBase') && can('knowledgeBase.view')) {
       actions.push({
         id: 'nav.kb',
         label: 'Knowledge Bases',
@@ -293,7 +313,7 @@ export function useNavigationActions(): PaletteAction[] {
         perform: () => nav('/kb'),
       })
     }
-    if (hasAccess('datasets')) {
+    if (hasAccess('datasets') && can('datasets.view')) {
       actions.push({
         id: 'nav.datasets',
         label: 'Datasets',
@@ -316,5 +336,5 @@ export function useNavigationActions(): PaletteAction[] {
       })
     }
     return actions
-  }, [hasAccess, can, isAdminOrOwner, nav])
+  }, [hasAccess, can, nav, viewableSlugs, resourcesLoading])
 }


### PR DESCRIPTION
## Problem

The cmd+k command palette gated its nav/create actions on the **Layer-1 feature flag only** (does the org have the feature) and never on the member's **Layer-2 area level** (`can(permissionKey)`). So a member without knowledge-base / dataset access still saw those destinations — and "Create X" showed for defs a member can only read. This is the same gap the sidebar already closed in #1296; the palette is a hand-maintained parallel list that drifted.

## Changes

**`navigation.ts`** — each destination now also checks the `permissionKey` its `SIDEBAR_MENU` counterpart already declares:
- `kb` → `knowledgeBase.view` · `datasets` → `datasets.view` · `workflows` → `workflows.manage` · `schedule` → `dispatch.mySchedule` · `agents` → `agents.manage` (replacing the loose `isAdminOrOwner`, which the declared key generalizes).
- **Core-record destinations** (`contacts`/`companies`/`parts`/`tickets`) now gate on per-def **view** access via `useViewableResources()` (keyed by `apiSlug`, confirmed against `ModelTypeMeta`), mirroring the sidebar. Guarded with the catalog-loading flag so core nav never flickers out during hydration. `tasks` stays ungated (no gate in the sidebar either).

**`create.ts`** — "Create \<entity\>" actions filtered on `isVisible` (view) only; a Read-only member saw "Create Contact". Now also requires `canEditEntity(def)` — creating a record is a write.

**`launchers.ts`** — `create.dataset` gated only on the feature; now also `can('datasets.manage')` (create = Full), matching `CreateDatasetButton`.

## Scope notes
- `dashboards` and `calls` nav stay feature-only — their Layer-2 areas aren't built yet (slice #13 / doc 10 §2).
- `create.invite` left as `isAdminOrOwner` — that's the safe (non-over-exposing) direction; moving it to `members.manage` would *expand* access and belongs with a members-delegation change.

## Test plan
- [ ] Member at `knowledgeBase = None` / `datasets = None`: KB/Datasets no longer appear in cmd+k nav or create.
- [ ] Member with Read-only on a def: "Create \<that def\>" is absent from the palette; the def still appears under nav (view).
- [ ] Member with a restricted (non-viewable) def: it's absent from palette nav, matching the sidebar.
- [ ] Admin/owner: full palette unchanged.
- [ ] Cold load: opening cmd+k mid-hydration still shows Contacts/Tickets (no flicker), then filters once the catalog loads.