### PR TITLE
feat(permissions): agent permission gating (runtime principal model)

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -11,6 +11,7 @@ import {
   createCallModel,
   enqueueAgentJob,
   flattenMessagesForModelSwitch,
+  resolveAgentRunCapabilities,
   subscribeToAgentEvents,
   withAgentRunLog,
 } from '@auxx/lib/ai/agent-framework'
@@ -43,7 +44,12 @@ import { createMcpCapabilities } from '@auxx/lib/ai/mcp'
 import { getCachedAgentById } from '@auxx/lib/cache'
 import { ForbiddenError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
-import { FeatureKey, FeaturePermissionService, getCapabilities } from '@auxx/lib/permissions'
+import {
+  type CapabilityView,
+  FeatureKey,
+  FeaturePermissionService,
+  getCapabilities,
+} from '@auxx/lib/permissions'
 import { docToText } from '@auxx/lib/tiptap'
 import { createScopedLogger } from '@auxx/logger'
 import {
@@ -563,10 +569,30 @@ async function runInProcessPath(params: {
     : Promise.resolve(null)
 
   // Build domain config with capabilities. `userId` is the logged-in member, so
-  // resolve entity-def read enforcement (v2 §3) once per turn and share it across
-  // every tool. Autonomous/visitor/workflow agents build deps without this and
-  // stay unrestricted.
-  const capabilities = await getCapabilities(userId, organizationId)
+  // resolve read/write enforcement (v2 §3) once per turn and share it across
+  // every tool AND the prompt-side catalogs (§3.4).
+  //
+  // Plain Kopilot and the builder are the human alone (§0.11) — no agent
+  // principal is involved. A turn targeting a defined agent additionally
+  // intersects with that agent's profile (or its run-as delegate), so an agent
+  // restriction clamps the turn even though a human is driving it (§0.5).
+  // Dormant while every agent sits at the all-Full default. A broken run-as
+  // delegation throws `AgentRunAsUnavailableError`, which the caller's catch
+  // surfaces as a normal `turn-error`.
+  const humanCapabilities = await getCapabilities(userId, organizationId)
+  let capabilities: CapabilityView = humanCapabilities
+  if (agentId && !isBuilder) {
+    const cachedAgent = await getCachedAgentById(organizationId, agentId)
+    if (cachedAgent) {
+      capabilities =
+        (await resolveAgentRunCapabilities({
+          agent: cachedAgent,
+          organizationId,
+          invokerUserId: userId,
+        })) ?? humanCapabilities
+    }
+  }
+
   const getToolDeps = createToolDepsFactory({
     organizationId,
     userId,
@@ -716,6 +742,8 @@ async function runInProcessPath(params: {
     surface: 'builder',
     audience: 'member',
     triggerContext,
+    // Prompt-side catalog filtering (§3.4) — the same view the tools enforce with.
+    capabilities,
   })
 
   // Create LLM adapter

--- a/apps/web/src/components/agents/constant.ts
+++ b/apps/web/src/components/agents/constant.ts
@@ -11,5 +11,6 @@ export const AGENT_TABS = [
   'restrictions',
   'knowledge',
   'triggers',
+  'permissions',
 ] as const
 export type AgentTab = (typeof AGENT_TABS)[number]

--- a/apps/web/src/components/agents/hooks/use-agent-mutations.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-mutations.ts
@@ -26,6 +26,12 @@ interface UpdateAgentInput {
   archivedAt?: Date | null
   /** Persona Tiptap doc (`{ type: 'doc', content: [...] }`). */
   prompt?: Record<string, unknown>
+  /**
+   * Run-as delegation (capability layer v2 §0.6) — a member's user id makes
+   * every run resolve that member's capabilities; `null` clears it. Server
+   * rejects anything but an ACTIVE `userType:'USER'` member.
+   */
+  runAsUserId?: string | null
 }
 
 interface UseAgentMutationsResult {
@@ -115,7 +121,8 @@ export function useAgentMutations(): UseAgentMutationsResult {
         patch.description === undefined &&
         patch.modelId === undefined &&
         patch.mentionable === undefined &&
-        patch.archivedAt === undefined
+        patch.archivedAt === undefined &&
+        patch.runAsUserId === undefined
 
       if (isPromptOnly) {
         // Mirror the server-side reconciler client-side, optimistically. The
@@ -192,6 +199,8 @@ export function useAgentMutations(): UseAgentMutationsResult {
       if (patch.modelId !== undefined) detailPatch.modelId = patch.modelId
       if (patch.mentionable !== undefined) detailPatch.mentionable = patch.mentionable
       if (patch.archivedAt !== undefined) detailPatch.archivedAt = patch.archivedAt
+      // Run-as isn't surfaced in the list/store, only on the detail view.
+      if (patch.runAsUserId !== undefined) detailPatch.runAsUserId = patch.runAsUserId
       // Behavior-field edits (prompt/modelId) flip the dirty pill when a
       // published baseline exists; identity edits (name/slug/description) don't.
       const behaviorChanged = patch.prompt !== undefined || patch.modelId !== undefined

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -19,6 +19,7 @@ import {
   Clock,
   FileText,
   ListChecks,
+  Lock,
   Plug,
   Plus,
   ShieldCheck,
@@ -41,6 +42,7 @@ import type { AgentDetail } from '../../store/agent-store'
 import type { AutosaveState } from '../shared/autosave-indicator'
 import { AgentGuideDialog } from './agent-guide-dialog'
 import { AgentHero } from './agent-hero'
+import { AgentPermissionsSection } from './agent-permissions-section'
 import { BindingsSection } from './bindings/bindings-section'
 import { KnowledgeSectionContent } from './knowledge/knowledge-section-content'
 import { PersonaEditor } from './prompt/persona-editor'
@@ -54,6 +56,7 @@ const SECTION_ICONS: Record<AgentTab, React.ComponentType<{ className?: string }
   knowledge: BookOpen,
   procedures: ListChecks,
   triggers: Zap,
+  permissions: Lock,
 }
 
 const SECTION_LABELS: Record<AgentTab, string> = {
@@ -63,6 +66,7 @@ const SECTION_LABELS: Record<AgentTab, string> = {
   knowledge: 'Knowledge',
   procedures: 'Procedures',
   triggers: 'Triggers',
+  permissions: 'Permissions',
 }
 
 // The tab strip lives in <NavStackBar>, OUTSIDE/above the ScrollArea viewport, so the
@@ -307,6 +311,10 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
                     </Section>
                   </div>
                 ) : null}
+
+                <div ref={assignRef('permissions')}>
+                  <AgentPermissionsSection agent={agent} />
+                </div>
 
                 {/* Spacer so the last section can scroll up to the activation line. */}
                 <div className='h-[40vh]' />

--- a/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
@@ -1,0 +1,186 @@
+// apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { EmptySection, Section } from '@auxx/ui/components/section'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { Globe, Lock, UserCog } from 'lucide-react'
+import { useMemo } from 'react'
+import { UpgradeBanner } from '~/components/banner/upgrade-banner'
+import { SettingsSection } from '~/components/global/settings-page'
+import { getInitials } from '~/components/members/utils'
+import { GranteeDefAccessSection } from '~/components/permissions/ui/grantee-def-access-section'
+import { GranteeLevelsSection } from '~/components/permissions/ui/grantee-levels-section'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
+import { useAgentMutations } from '../../hooks/use-agent-mutations'
+import type { AgentDetail } from '../../store/agent-store'
+
+/** Select sentinel for "no delegation" — `runAsUserId = null`. */
+const OWN_PERMISSIONS = '__own__'
+
+/**
+ * The agent builder's **Permissions** tab (capability layer v2 §4.2): the
+ * grantee view transposed onto an agent, plus the run-as selector.
+ *
+ * Three stacked surfaces, in order:
+ * 1. **Run as** — optional delegation. While set, the agent resolves the chosen
+ *    member's capabilities at run time instead of its own profile, so the two
+ *    grids below are shown read-only with a note (§0.6).
+ * 2. **Access levels** — the Layer-2 area grid keyed by the agent's backing
+ *    `userId`, in `agent` mode: agents compose by SET over an all-Full base, so
+ *    an unset area is **Full** ("Default"), and `None` is the rung that locks an
+ *    area down (§0.2/§0.3). Nothing here elevates — this surface only restricts.
+ * 3. **Record access** — the Layer-3 per-record-type overlay on the same
+ *    grantee, whose "Default" resolves to the def's workspace baseline when one
+ *    is configured, else the agent's Records level (Full unless lowered above).
+ *
+ * **Editing is OWNER/ADMIN-only** (§0.9) — `agents.manage` does not confer
+ * permission governance. In practice the whole agent detail page is already
+ * hard-gated on `isAdminOrOwner`, so a non-admin never reaches this component;
+ * the check is kept explicit so loosening the page gate can't silently hand a
+ * non-admin the grants editor. Grant writes additionally require the
+ * `granularPermissions` plan feature (`setGranteeLevels` enforces it), so
+ * without it the grids render read-only behind an upgrade banner rather than
+ * 500ing on save.
+ */
+export function AgentPermissionsSection({ agent }: { agent: AgentDetail }) {
+  const { hasAccess } = useFeatureFlags()
+  const { isAdminOrOwner } = useUser()
+  const { updateAgent, isUpdating } = useAgentMutations()
+
+  const hasGranularPermissions = hasAccess(FeatureKey.granularPermissions)
+  /** Run-as is an agent field, not a grant — it needs no plan feature. */
+  const canEditRunAs = isAdminOrOwner
+  const isDelegated = agent.runAsUserId != null
+  /** Grants are editable for admins on a plan with granular permissions… */
+  const canEditGrants = isAdminOrOwner && hasGranularPermissions && !isDelegated
+
+  const { data: memberData } = api.member.all.useQuery()
+  // `member.all` already hard-filters to `userType: 'USER'`, so agents can
+  // never appear here; ACTIVE is the remaining run-as requirement (§0.6).
+  const members = useMemo(
+    () => (memberData?.members ?? []).filter((m) => m.status === 'ACTIVE'),
+    [memberData]
+  )
+  const runAsMember = members.find((m) => m.userId === agent.runAsUserId)
+  const runAsName = runAsMember?.user.name || runAsMember?.user.email || 'another member'
+
+  const handleRunAsChange = (value: string) => {
+    void updateAgent(agent.id, {
+      runAsUserId: value === OWN_PERMISSIONS ? null : value,
+    })
+  }
+
+  return (
+    <Section
+      title='Permissions'
+      icon={<Lock className='size-4' />}
+      initialOpen
+      collapsible={false}
+      description='What this agent can reach when it runs. Agents start with full access — this tab is where you restrict it.'>
+      <div className='space-y-6'>
+        {agent.kind === 'chat' && (
+          <Alert variant='warning'>
+            <Globe className='size-4' />
+            <AlertDescription>
+              This agent is public-facing — consider restricting what it can access.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {!hasGranularPermissions && (
+          <UpgradeBanner
+            title='Upgrade to restrict agents'
+            description='Granular permissions let you scope what an agent can read and change across the workspace and per record type.'
+          />
+        )}
+
+        <SettingsSection
+          icon={UserCog}
+          title='Run as'
+          description="By default an agent runs with its own permissions, set below. Point it at a member instead and every run resolves that member's access — the agent still acts as itself in history and attribution.">
+          <div className='flex flex-col gap-2'>
+            <Select
+              value={agent.runAsUserId ?? OWN_PERMISSIONS}
+              onValueChange={handleRunAsChange}
+              disabled={!canEditRunAs || isUpdating}>
+              <SelectTrigger size='sm' className='w-full max-w-96'>
+                <SelectValue placeholder='Own permissions (default)' />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={OWN_PERMISSIONS} textValue='Own permissions (default)'>
+                  <div className='flex flex-col items-start'>
+                    <span>Own permissions (default)</span>
+                    <span className='text-muted-foreground text-xs'>
+                      Uses this agent&apos;s own profile
+                    </span>
+                  </div>
+                </SelectItem>
+                {members.map((member) => {
+                  const label = member.user.name || member.user.email || 'Unnamed member'
+                  return (
+                    <SelectItem key={member.userId} value={member.userId} textValue={label}>
+                      <div className='flex items-center gap-2'>
+                        <Avatar className='size-5 rounded-full'>
+                          {member.user.image && (
+                            <AvatarImage src={member.user.image} alt={member.user.name ?? ''} />
+                          )}
+                          <AvatarFallback className='text-[10px]'>
+                            {getInitials(member.user.name, member.user.email)}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span>{label}</span>
+                      </div>
+                    </SelectItem>
+                  )
+                })}
+              </SelectContent>
+            </Select>
+            {isDelegated && (
+              <p className='text-xs text-muted-foreground'>
+                This agent acts with {runAsName}&apos;s permissions. Its own profile below is kept
+                but not used — clear the delegation to edit it. Runs fail if that member is
+                deactivated or removed.
+              </p>
+            )}
+          </div>
+        </SettingsSection>
+
+        {agent.userId ? (
+          <>
+            <GranteeLevelsSection
+              mode='agent'
+              granteeKind='user'
+              granteeId={agent.userId}
+              canEdit={canEditGrants}
+            />
+            <GranteeDefAccessSection
+              principal='agent'
+              granteeKind='user'
+              granteeId={agent.userId}
+              canEdit={canEditGrants}
+            />
+          </>
+        ) : (
+          // Pre-`completeAgentSetup` drafts have no backing User, so there is no
+          // grantee to write grants against yet.
+          <EmptySection
+            icon={<Lock />}
+            title='Permissions unavailable'
+            description='This agent is still being set up. Finish setup to give it a workspace identity, then restrict what it can access here.'
+          />
+        )}
+      </div>
+    </Section>
+  )
+}

--- a/apps/web/src/components/permissions/hooks/use-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-def-access.ts
@@ -135,6 +135,10 @@ export function useDefAccess(entityDefinitionId: string | undefined) {
         .map((r) => ({ granteeId: r.granteeId, permission: r.permission })),
     [rows]
   )
+  // NOTE: `user` rows carry BOTH humans and agents — an agent grant is a `user`
+  // row keyed on the agent's backing `User.id` (agent plan §4.1), so consumers
+  // that render an Agents section must partition this list against the org's
+  // agent user ids (see `def-access-section.tsx`).
   const userGrants = useMemo<DefAccessGrant[]>(
     () =>
       rows

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
@@ -13,6 +13,16 @@ import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permissio
 /** The grantee axis this section edits: an individual member or a team. */
 export type GranteeKind = 'user' | 'group'
 
+/**
+ * How the grantee's Layer-2 Records level composes — which decides what an
+ * unconfigured def falls through to:
+ * - `member` (default) — human/team: own override → org policy → role default.
+ * - `agent` — an AGENT grantee (`userType:'AGENT'`), which composes by SET over
+ *   an all-Full base (capability layer v2 §0.2/§0.3): no org policy, no group
+ *   tier, so an unset Records area is **Full**, not the member baseline.
+ */
+export type GranteePrincipal = 'member' | 'agent'
+
 const GRANTEE_TYPE: Record<GranteeKind, ResourceGranteeType> = {
   user: ResourceGranteeType.user,
   group: ResourceGranteeType.group,
@@ -61,7 +71,11 @@ export interface GranteeDefAccessRow {
  * doesn't silently become restricted and lock every other member out. Selecting
  * Inherit (revoke) never touches the baseline. Errors surface via `toastError`.
  */
-export function useGranteeDefAccess(granteeKind: GranteeKind, granteeId: string) {
+export function useGranteeDefAccess(
+  granteeKind: GranteeKind,
+  granteeId: string,
+  principal: GranteePrincipal = 'member'
+) {
   const utils = api.useUtils()
   const { resources, isLoading: resourcesLoading } = useResources()
   const granteeType = GRANTEE_TYPE[granteeKind]
@@ -78,12 +92,15 @@ export function useGranteeDefAccess(granteeKind: GranteeKind, granteeId: string)
   const recordsPermission = useMemo<ResourcePermission>(() => {
     const persisted = granteeKind === 'group' ? groupGrants : userGrants
     const own = persisted.find((g) => g.granteeId === granteeId)?.levels?.[Area.records]
+    // An agent has no baseline to fall back on — absent means Full (§0.2/§0.3).
     const level =
-      own ?? effectiveBaseline[Area.records] ?? roleDefaults?.[Area.records] ?? Level.None
+      principal === 'agent'
+        ? (own ?? Level.Full)
+        : (own ?? effectiveBaseline[Area.records] ?? roleDefaults?.[Area.records] ?? Level.None)
     // `levelToPermission` maps `Level.None` to `undefined` ("no permission");
     // for display we want the `none` marker so the picker can name it.
     return levelToPermission(level) ?? ResourcePermission.none
-  }, [granteeKind, granteeId, groupGrants, userGrants, effectiveBaseline, roleDefaults])
+  }, [granteeKind, granteeId, principal, groupGrants, userGrants, effectiveBaseline, roleDefaults])
 
   const rowsQuery = api.resourceAccess.allTypeAccess.useQuery(undefined, { staleTime: 30_000 })
 

--- a/apps/web/src/components/permissions/ui/access-level-select.tsx
+++ b/apps/web/src/components/permissions/ui/access-level-select.tsx
@@ -60,6 +60,12 @@ interface AccessLevelSelectProps {
    * legible without a separate label.
    */
   inheritedLevel?: ResourcePermission
+  /**
+   * Name for the `Inherit` option. AGENT grantees pass `'Default'` — they
+   * compose by SET over an all-Full base, so there is no baseline to inherit
+   * FROM and "Inherit" would misdescribe the state (capability layer v2 §0.2).
+   */
+  inheritLabelText?: string
   disabled?: boolean
   size?: 'xs' | 'sm' | 'default'
   variant?: 'default' | 'transparent'
@@ -86,6 +92,7 @@ export function AccessLevelSelect({
   includeInherit = false,
   onInherit,
   inheritedLevel,
+  inheritLabelText = INHERIT_LABEL.label,
   disabled = false,
   size = 'sm',
   variant = 'default',
@@ -98,8 +105,8 @@ export function AccessLevelSelect({
     const safeValue = value && levels.includes(value) ? value : INHERIT
     const inheritLabel =
       inheritedLevel !== undefined
-        ? `Inherit · ${ACCESS_LEVEL_LABELS[inheritedLevel].label}`
-        : INHERIT_LABEL.label
+        ? `${inheritLabelText} · ${ACCESS_LEVEL_LABELS[inheritedLevel].label}`
+        : inheritLabelText
     return (
       <Select
         value={safeValue}

--- a/apps/web/src/components/permissions/ui/def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/def-access-section.tsx
@@ -4,7 +4,7 @@
 import { ResourceGranteeType, type ResourcePermission } from '@auxx/database/enums'
 import type { Resource } from '@auxx/lib/resources/client'
 import { FeatureKey } from '@auxx/lib/types'
-import { type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
+import { type ActorId, getActorRawId, isAgentActor, toActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -12,6 +12,7 @@ import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import {
   AlertTriangle,
+  Bot,
   Folder,
   Plus,
   RotateCcw,
@@ -20,11 +21,15 @@ import {
   User,
   type Users,
 } from 'lucide-react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { UpgradeBanner } from '~/components/banner/upgrade-banner'
 import { Tooltip } from '~/components/global/tooltip'
 import { ActorPicker } from '~/components/pickers/actor-picker'
-import { useActor } from '~/components/resources/hooks/use-actor'
+import {
+  useActor,
+  useActorLoading,
+  useAvailableActors,
+} from '~/components/resources/hooks/use-actor'
 import { ActorAvatar } from '~/components/resources/ui/actor-badge'
 import { useUser } from '~/hooks/use-user'
 import { useAccess } from '~/providers/capabilities-provider'
@@ -32,16 +37,32 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { type DefAccessGrant, useDefAccess } from '../hooks/use-def-access'
 import { AccessLevelSelect } from './access-level-select'
 
-type GranteeKind = 'group' | 'user'
+/**
+ * The three grantee axes the Access tab renders. `agent` is NOT a storage
+ * grantee type — an agent grant is a `user` row keyed on the agent's backing
+ * `User.id` (agent plan §4.1); the kind only selects the copy, the picker
+ * target, and the ActorId prefix used for display.
+ */
+type GranteeKind = 'group' | 'user' | 'agent'
 
 const GRANTEE_COPY: Record<
   GranteeKind,
-  { title: string; add: string; remove: string; empty: string; icon: typeof Users }
+  {
+    title: string
+    add: string
+    remove: string
+    emptyTitle: string
+    empty: string
+    icon: typeof Users
+    /** Tooltip next to the section title (shown once the list is non-empty). */
+    description?: string
+  }
 > = {
   group: {
     title: 'Teams',
     add: 'Add team',
     remove: 'Remove team',
+    emptyTitle: 'No teams yet',
     empty: 'Grant a team access to these records.',
     icon: Folder,
   },
@@ -49,15 +70,26 @@ const GRANTEE_COPY: Record<
     title: 'Individual members',
     add: 'Add member',
     remove: 'Remove member',
+    emptyTitle: 'No members yet',
     empty: 'Grant an individual member access to these records.',
     icon: User,
+  },
+  agent: {
+    title: 'Agents',
+    add: 'Add agent',
+    remove: 'Remove agent',
+    emptyTitle: 'No agents yet',
+    empty: 'Agents inherit their own base access. Grant or restrict this object per agent.',
+    icon: Bot,
+    description: 'Agents inherit their own base access. Grant or restrict this object per agent.',
   },
 }
 
 /**
  * The entity-def **Access** surface (capability layer v2 phase 3): a workspace
- * baseline ("Default for all members"), raise-only **team** grants, and
- * **individual member** grants — modeled on Attio's object-permissions screen.
+ * baseline ("Default for all members"), raise-only **team** grants,
+ * **individual member** grants, and per-**agent** grants (agent plan §4.1) —
+ * modeled on Attio's object-permissions screen.
  *
  * Composition is baseline-floor + raise-only-grants, so adding a team/member
  * never locks others out; only Workspace access = No Access restricts
@@ -86,7 +118,61 @@ export function DefAccessSection({ resource }: { resource: Resource }) {
     isIgnored,
   } = useDefAccess(resource.entityDefinitionId)
 
-  if (isLoading) {
+  // Agents are org members backed by a synthetic User row, so their def grants
+  // are `user`-type rows keyed on `AgentActor.userId` — indistinguishable from a
+  // human grant in the stored rows. The actor store (hydrated org-wide by
+  // `ResourceProvider` with `target: 'all'`) is the only place both ids live, so
+  // it drives BOTH directions of the id seam:
+  //   - write: picked `agent:<Agent.id>` → the agent's `User.id` (the grantee).
+  //   - read:  a granted `User.id` → `agent:<Agent.id>` (the display ActorId —
+  //     `useActor('user:<agentUserId>')` resolves to NOT-FOUND, since the batch
+  //     resolver keys results by the canonical `agent:` ActorId).
+  const agentActors = useAvailableActors({ target: 'agent' })
+  const actorsLoading = useActorLoading()
+  const { agentUserIdByActorId, agentActorIdByUserId } = useMemo(() => {
+    const byActorId = new Map<ActorId, string>()
+    const byUserId = new Map<string, ActorId>()
+    for (const actor of agentActors) {
+      if (!isAgentActor(actor) || !actor.userId) continue
+      byActorId.set(actor.actorId, actor.userId)
+      byUserId.set(actor.userId, actor.actorId)
+    }
+    return { agentUserIdByActorId: byActorId, agentActorIdByUserId: byUserId }
+  }, [agentActors])
+
+  // Partition the `user` rows: a grantee that maps to a known agent belongs to
+  // the Agents section and must not double-render under Individual members.
+  const { memberGrants, agentGrants } = useMemo(() => {
+    const members: DefAccessGrant[] = []
+    const agents: DefAccessGrant[] = []
+    for (const grant of userGrants) {
+      if (agentActorIdByUserId.has(grant.granteeId)) agents.push(grant)
+      else members.push(grant)
+    }
+    return { memberGrants: members, agentGrants: agents }
+  }, [userGrants, agentActorIdByUserId])
+
+  /** Picked `agent:<Agent.id>` → grant on the agent's backing `User.id`. */
+  const addAgents = useCallback(
+    (nextActorIds: ActorId[]) => {
+      const present = new Set(agentGrants.map((g) => g.granteeId))
+      for (const actorId of nextActorIds) {
+        const agentUserId = agentUserIdByActorId.get(actorId)
+        // No `getActorRawId` here — that yields the `Agent.id`, which would
+        // write a grant row no composition path can ever match.
+        if (!agentUserId || present.has(agentUserId)) continue
+        addGrant(ResourceGranteeType.user, agentUserId)
+      }
+    },
+    [addGrant, agentGrants, agentUserIdByActorId]
+  )
+
+  const resolveAgentActorId = useCallback(
+    (granteeUserId: string) => agentActorIdByUserId.get(granteeUserId),
+    [agentActorIdByUserId]
+  )
+
+  if (isLoading || actorsLoading) {
     return (
       <div className='space-y-2 p-3 sm:p-6'>
         <Skeleton className='h-16 w-full rounded-lg' />
@@ -148,14 +234,29 @@ export function DefAccessSection({ resource }: { resource: Resource }) {
 
       <GranteeAccessBlock
         kind='user'
-        grants={userGrants}
+        grants={memberGrants}
         baselineLevel={baselineLevel}
         canEdit={canEdit}
         isIgnored={isIgnored}
-        onAdd={(actorIds) => addActors(actorIds, userGrants, ResourceGranteeType.user, addGrant)}
+        onAdd={(actorIds) => addActors(actorIds, memberGrants, ResourceGranteeType.user, addGrant)}
         onChange={(granteeId, level) => setGrant(ResourceGranteeType.user, granteeId, level)}
         onRemove={(granteeId) => removeGrant(ResourceGranteeType.user, granteeId)}
       />
+
+      {/* Agents (plan §4.1) — hidden entirely for orgs with no agents. */}
+      {agentActorIdByUserId.size > 0 && (
+        <GranteeAccessBlock
+          kind='agent'
+          grants={agentGrants}
+          baselineLevel={baselineLevel}
+          canEdit={canEdit}
+          isIgnored={isIgnored}
+          resolveActorId={resolveAgentActorId}
+          onAdd={addAgents}
+          onChange={(granteeId, level) => setGrant(ResourceGranteeType.user, granteeId, level)}
+          onRemove={(granteeId) => removeGrant(ResourceGranteeType.user, granteeId)}
+        />
+      )}
     </div>
   )
 }
@@ -178,13 +279,14 @@ function addActors(
   }
 }
 
-/** One grantee-kind block (Teams or Individual members): add button + row list. */
+/** One grantee-kind block (Teams, Individual members or Agents): add button + row list. */
 function GranteeAccessBlock({
   kind,
   grants,
   baselineLevel,
   canEdit,
   isIgnored,
+  resolveActorId,
   onAdd,
   onChange,
   onRemove,
@@ -194,16 +296,29 @@ function GranteeAccessBlock({
   baselineLevel: ResourcePermission
   canEdit: boolean
   isIgnored: (permission: ResourcePermission) => boolean
+  /**
+   * Map a stored `granteeId` to the ActorId used for display. Defaults to
+   * `<kind>:<granteeId>`; the Agents block overrides it because its rows store
+   * the agent's `User.id` while the actor system addresses agents by `Agent.id`.
+   */
+  resolveActorId?: (granteeId: string) => ActorId | undefined
   onAdd: (actorIds: ActorId[]) => void
   onChange: (granteeId: string, level: ResourcePermission) => void
   onRemove: (granteeId: string) => void
 }) {
   const copy = GRANTEE_COPY[kind]
-  const actorIds = useMemo(() => grants.map((g) => toActorId(kind, g.granteeId)), [grants, kind])
+  const actorIds = useMemo(
+    () =>
+      grants
+        .map((g) => resolveActorId?.(g.granteeId) ?? toActorId(kind, g.granteeId))
+        .filter((id): id is ActorId => !!id),
+    [grants, kind, resolveActorId]
+  )
 
   return (
     <Section
       title={copy.title}
+      description={copy.description}
       icon={<copy.icon className='size-4' />}
       className='[&_[data-slot=section]]:p-0! [&_[data-slot=section]]:border-b-0!'
       collapsible={false}
@@ -225,7 +340,7 @@ function GranteeAccessBlock({
         <EmptySection
           orientation='horizontal'
           icon={<copy.icon className='size-5' />}
-          title={`No ${kind === 'group' ? 'teams' : 'members'} yet`}
+          title={copy.emptyTitle}
           description={copy.empty}
         />
       ) : (
@@ -234,6 +349,7 @@ function GranteeAccessBlock({
             <GranteeRow
               key={grant.granteeId}
               kind={kind}
+              actorId={resolveActorId?.(grant.granteeId) ?? toActorId(kind, grant.granteeId)}
               grant={grant}
               ignored={isIgnored(grant.permission)}
               baselineLevel={baselineLevel}
@@ -251,6 +367,7 @@ function GranteeAccessBlock({
 /** A single grantee row: avatar + resolved name + level select + remove. */
 function GranteeRow({
   kind,
+  actorId,
   grant,
   ignored,
   baselineLevel,
@@ -259,6 +376,8 @@ function GranteeRow({
   onRemove,
 }: {
   kind: GranteeKind
+  /** Display ActorId — for agents this is `agent:<Agent.id>`, not the grantee id. */
+  actorId: ActorId
   grant: DefAccessGrant
   ignored: boolean
   baselineLevel: ResourcePermission
@@ -267,7 +386,6 @@ function GranteeRow({
   onRemove: () => void
 }) {
   const { userId } = useUser()
-  const actorId = useMemo(() => toActorId(kind, grant.granteeId), [kind, grant.granteeId])
   const { actor, isLoading, isNotFound } = useActor({ actorId })
   const base = isNotFound
     ? 'Unknown'
@@ -287,6 +405,17 @@ function GranteeRow({
       }
       actions={
         <>
+          {/* The "ignored" flag is as true for agents as for humans: an agent's
+              all-Full base (agent plan §0.3) is an AREA-level default, but any
+              type row makes the def restricted, and `defAccess` then resolves to
+              the HIGHEST row matching the grantee — and the `role:org_member`
+              baseline row matches agents too (they are ACTIVE members;
+              `compute-user-capabilities.ts` applies no `userType` filter to the
+              ResourceAccess grantee union). So a grant at or below the baseline
+              lifts nothing for an agent either. Note a `none` baseline never
+              trips this — `PERMISSION_RANK` puts every positive grant above it,
+              which is exactly the restricted-def case where the grant is the
+              load-bearing one. */}
           {ignored && (
             <Tooltip
               content={`Ignored — this grant is at or below the workspace baseline (${baselineLevel}).`}>

--- a/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
@@ -16,6 +16,7 @@ import { Tooltip } from '~/components/global/tooltip'
 import {
   type GranteeDefAccessRow,
   type GranteeKind,
+  type GranteePrincipal,
   useGranteeDefAccess,
 } from '../hooks/use-grantee-def-access'
 import { AccessLevelSelect } from './access-level-select'
@@ -30,6 +31,13 @@ const COPY: Record<GranteeKind, { description: string }> = {
       'Access to individual record types. Each row shows what this team gets by default; pick a level to override it for that type.',
   },
 }
+
+/**
+ * Agent copy. An agent's default per type is Full unless its Records area was
+ * lowered above, or the type itself is restricted workspace-wide.
+ */
+const AGENT_DESCRIPTION =
+  'Access to individual record types. Each row shows what this agent gets by default — pick a level to override it for that type.'
 
 /**
  * The grantee-centric entity-def **Access** section (capability layer v2
@@ -50,12 +58,18 @@ export function GranteeDefAccessSection({
   granteeKind,
   granteeId,
   canEdit,
+  principal = 'member',
 }: {
   granteeKind: GranteeKind
   granteeId: string
   canEdit: boolean
+  /**
+   * `agent` switches the "Inherit" fall-through to the agent SET-semantics
+   * default (Full) and the copy with it — see {@link GranteePrincipal}.
+   */
+  principal?: GranteePrincipal
 }) {
-  const { isLoading, rows, setLevel } = useGranteeDefAccess(granteeKind, granteeId)
+  const { isLoading, rows, setLevel } = useGranteeDefAccess(granteeKind, granteeId, principal)
 
   const [search, setSearch] = useState('')
   const [overridesOnly, setOverridesOnly] = useState(false)
@@ -78,7 +92,7 @@ export function GranteeDefAccessSection({
     <SettingsSection
       icon={ShieldCheck}
       title='Record access'
-      description={COPY[granteeKind].description}>
+      description={principal === 'agent' ? AGENT_DESCRIPTION : COPY[granteeKind].description}>
       {isLoading ? (
         <div className='border p-1 rounded-xl space-y-1'>
           <Skeleton className='h-9 w-full rounded-lg' />
@@ -122,6 +136,7 @@ export function GranteeDefAccessSection({
                   key={row.resource.entityDefinitionId}
                   row={row}
                   canEdit={canEdit}
+                  principal={principal}
                   onChange={(level) => setLevel(row.resource.entityDefinitionId, level)}
                 />
               ))}
@@ -137,10 +152,12 @@ export function GranteeDefAccessSection({
 function DefAccessRow({
   row,
   canEdit,
+  principal,
   onChange,
 }: {
   row: GranteeDefAccessRow
   canEdit: boolean
+  principal: GranteePrincipal
   onChange: (level: Parameters<ReturnType<typeof useGranteeDefAccess>['setLevel']>[1]) => void
 }) {
   const { resource, isLockedDown, grantLevel, inheritedLevel, isNoEffect } = row
@@ -178,6 +195,7 @@ function DefAccessRow({
             value={grantLevel}
             includeInherit
             inheritedLevel={inheritedLevel}
+            inheritLabelText={principal === 'agent' ? 'Default' : undefined}
             onInherit={() => onChange('inherit')}
             onChange={(level) => onChange(level)}
             disabled={!canEdit}

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
@@ -21,6 +21,13 @@ const COPY: Record<GranteeKind, { description: string }> = {
 }
 
 /**
+ * Agent copy. Agents compose by SET over an all-Full base — no baseline, no
+ * inheritance — so the surface is a restriction editor, not an elevation one.
+ */
+const AGENT_DESCRIPTION =
+  'What this agent can reach when it runs. An area you leave on Default gives the agent full access — set a lower level (or None) to restrict it.'
+
+/**
  * The Layer-2 (per-area None/Read/Edit/Full) override editor for a single grantee
  * — a member or a team — surfaced on their detail page's Permissions tab. Reuses
  * the org-wide {@link usePermissionGrants} store and renders one grantee's sparse
@@ -29,15 +36,26 @@ const COPY: Record<GranteeKind, { description: string }> = {
  * (raise-only enforced server-side; an override that lifts nothing is flagged
  * "ignored"). Sits above the Layer-3 Record-access grid, which overrides the
  * Records area per record type.
+ *
+ * `mode='agent'` retargets the same store at an AGENT grantee (the agent's
+ * backing `userId`, still a `user`-type grant row): the grid switches to
+ * SET-semantics — unset ⇒ **Full**, `None` is a real rung, nothing is "ignored"
+ * — per capability layer v2 §0.2/§0.3. The write path is identical either way,
+ * and it is what keeps the two states apart: an unset area OMITS its key from
+ * the saved map (compose falls through to Full), while `None` writes an explicit
+ * `Level.None` (kept server-side for AGENT grantees, stripped for humans).
  */
 export function GranteeLevelsSection({
   granteeKind,
   granteeId,
   canEdit,
+  mode = 'override',
 }: {
   granteeKind: GranteeKind
   granteeId: string
   canEdit: boolean
+  /** `override` — a member/team grant; `agent` — an agent's own profile. */
+  mode?: 'override' | 'agent'
 }) {
   const { isLoading, roleDefaults, effectiveBaseline, groupGrants, userGrants, save } =
     usePermissionGrants()
@@ -47,6 +65,10 @@ export function GranteeLevelsSection({
 
   const handleChange = (area: Area, level: Level | undefined) => {
     const next = { ...values }
+    // `undefined` DELETES the key (no grant → the grantee's fall-through: the
+    // baseline for a member, Full for an agent); an explicit level — including
+    // `Level.None`, which is `0` and must not be conflated with absent — is
+    // stored as-is.
     if (level === undefined) delete next[area]
     else next[area] = level
     save(granteeKind, granteeId, next)
@@ -56,7 +78,7 @@ export function GranteeLevelsSection({
     <SettingsSection
       icon={SlidersHorizontal}
       title='Access levels'
-      description={COPY[granteeKind].description}>
+      description={mode === 'agent' ? AGENT_DESCRIPTION : COPY[granteeKind].description}>
       {isLoading || !roleDefaults ? (
         <div className='space-y-2'>
           <Skeleton className='h-16 w-full rounded-lg' />
@@ -64,7 +86,7 @@ export function GranteeLevelsSection({
         </div>
       ) : (
         <LeveledAreaGrid
-          mode='override'
+          mode={mode}
           values={values}
           roleDefaults={roleDefaults}
           baseline={effectiveBaseline}

--- a/apps/web/src/components/permissions/ui/level-control.tsx
+++ b/apps/web/src/components/permissions/ui/level-control.tsx
@@ -32,6 +32,16 @@ interface LevelControlProps {
   /** Emits the new explicit level, or `undefined` to reset the area to inherited. */
   onChange: (level: Level | undefined) => void
   disabled?: boolean
+  /**
+   * Muted text rendered beside the control while nothing explicit is stored —
+   * how a caller names the fall-through. Agent grantees pass `'Default'` so an
+   * unset area reads "Default · Full" (set-semantics: absent ⇒ Full) instead of
+   * silently looking identical to an explicit Full. Omitted for the member
+   * surfaces, where the reset button alone marks the explicit state.
+   */
+  unsetHint?: string
+  /** Tooltip on the reset button. Defaults to the inherit wording. */
+  resetTooltip?: string
 }
 
 /**
@@ -42,7 +52,9 @@ interface LevelControlProps {
  * button appears once an explicit level is set. Every rung stays selectable —
  * the raise-only rule for overrides is enforced server-side (an override at or
  * below the baseline is composed away), and surfaced in the UI as an "ignored"
- * warning rather than a disabled rung.
+ * warning rather than a disabled rung. For AGENT grantees (set-semantics, no
+ * inheritance) the caller passes `unsetHint` so the unset state is legible as a
+ * default rather than an inherited value.
  */
 export function LevelControl({
   area,
@@ -51,6 +63,8 @@ export function LevelControl({
   ignored = false,
   onChange,
   disabled = false,
+  unsetHint,
+  resetTooltip = 'Reset to inherited',
 }: LevelControlProps) {
   const levels = useMemo<Level[]>(
     () => [Level.None, ...area.rungs.map((r) => r.level)],
@@ -67,12 +81,22 @@ export function LevelControl({
           aria-hidden={!ignored}
         />
       </Tooltip>
-      <Tooltip content='Reset to inherited'>
+      {unsetHint !== undefined && (
+        <span
+          className={cn(
+            'text-xs text-muted-foreground whitespace-nowrap',
+            isExplicit && 'invisible'
+          )}
+          aria-hidden={isExplicit}>
+          {unsetHint}
+        </span>
+      )}
+      <Tooltip content={resetTooltip}>
         <Button
           type='button'
           size='icon-sm'
           variant='ghost'
-          aria-label='Reset to inherited'
+          aria-label={resetTooltip}
           disabled={disabled || !isExplicit}
           className={cn('size-6 text-muted-foreground', !isExplicit && 'invisible')}
           onClick={() => onChange(undefined)}>

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/permissions/ui/leveled-area-grid.tsx
 'use client'
 
-import { AREA_ORDER, type Area, type Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
+import { AREA_ORDER, type Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { ButtonSwitch } from '@auxx/ui/components/button-switch'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
@@ -49,9 +49,13 @@ interface LeveledAreaGridProps {
   baseline?: Partial<Record<Area, Level>>
   /**
    * `baseline` — the org-wide member baseline (raise or lower from role default);
-   * `override` — a group/user grant that can only raise above the baseline.
+   * `override` — a group/user grant that can only raise above the baseline;
+   * `agent` — an AGENT grantee's own profile: SET-semantics over an all-Full
+   * base (capability layer v2 §0.2/§0.3), so every area falls through to
+   * **Full** rather than to any baseline, nothing is ever "ignored", and `None`
+   * is the meaningful rung (the only way to lock an area down for an agent).
    */
-  mode: 'baseline' | 'override'
+  mode: 'baseline' | 'override' | 'agent'
   onChange: (area: Area, level: Level | undefined) => void
   disabled?: boolean
   /**
@@ -90,8 +94,11 @@ const AREA_GROUPS: Array<{ group: string; areas: Area[] }> = (() => {
  * Automation, …). `adminOnly` areas are never shown — they're not grantable below
  * ADMIN. In `override` mode each area inherits from the member baseline (and is
  * raise-only, enforced server-side); in `baseline` mode it inherits from the role
- * default. Every rung is selectable in both modes — an override that doesn't lift
- * the baseline is composed away and flagged as "ignored" on the grantee.
+ * default; in `agent` mode there is no inheritance at all — an unset area IS Full
+ * (§0.3), so it renders as a "Default" fall-through to Full. Every rung is
+ * selectable in every mode — an override that doesn't lift the baseline is
+ * composed away and flagged as "ignored" on the grantee (member surfaces only;
+ * for an agent a `None` genuinely lowers, so nothing is ever ignored).
  *
  * An area may also nest child rows via `renderChildren` (the member baseline
  * supplies per-def workspace baselines under Records). Children are collapsed by
@@ -151,7 +158,7 @@ export function LeveledAreaGrid({
           placeholder='Search areas...'
         />
         <ButtonSwitch
-          label='Overrides only'
+          label={mode === 'agent' ? 'Restrictions only' : 'Overrides only'}
           checked={overridesOnly}
           onCheckedChange={setOverridesOnly}
           disabled={disabled}
@@ -173,10 +180,14 @@ export function LeveledAreaGrid({
               {rows.map(({ area, children, autoOpen }) => {
                 const meta = PERMISSION_AREAS[area]
                 const value = values[area]
+                // Agent profiles compose by SET over an all-Full base — an unset
+                // area IS Full, there is nothing to inherit from (§0.2/§0.3).
                 const inherited =
-                  mode === 'override'
-                    ? (baseline?.[area] ?? roleDefaults[area])
-                    : roleDefaults[area]
+                  mode === 'agent'
+                    ? Level.Full
+                    : mode === 'override'
+                      ? (baseline?.[area] ?? roleDefaults[area])
+                      : roleDefaults[area]
                 const isOpen = openAreas[area] ?? autoOpen
                 return (
                   <TreeRow
@@ -197,6 +208,10 @@ export function LeveledAreaGrid({
                         value={value}
                         inherited={inherited}
                         ignored={mode === 'override' && value !== undefined && value <= inherited}
+                        unsetHint={mode === 'agent' ? 'Default' : undefined}
+                        resetTooltip={
+                          mode === 'agent' ? 'Clear — back to full access' : 'Reset to inherited'
+                        }
                         onChange={(level) => onChange(area, level)}
                         disabled={disabled}
                       />

--- a/apps/web/src/server/api/routers/agent.ts
+++ b/apps/web/src/server/api/routers/agent.ts
@@ -198,6 +198,13 @@ export const agentRouter = createTRPCRouter({
         appAccounts: z
           .record(z.string().min(1), z.object({ credId: z.string().min(1) }).nullable())
           .optional(),
+        /**
+         * Run-as delegation (capability layer v2 §0.6). A user id makes every
+         * run resolve capabilities from that member instead of the agent's own
+         * profile; `null` clears it; omit to leave unchanged. The service
+         * validates the target is an ACTIVE `userType:'USER'` member.
+         */
+        runAsUserId: z.string().nullable().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -226,6 +233,7 @@ export const agentRouter = createTRPCRouter({
       if (patch.mentionable !== undefined) updatePayload.mentionable = patch.mentionable
       if (patch.archivedAt !== undefined) updatePayload.archivedAt = patch.archivedAt
       if (patch.appAccounts !== undefined) updatePayload.appAccounts = patch.appAccounts
+      if (patch.runAsUserId !== undefined) updatePayload.runAsUserId = patch.runAsUserId
 
       // Exclude the writer's own socket from the `agent:updated` broadcast so
       // the persona editor's autosave doesn't echo back and remount over the

--- a/packages/lib/src/agents/agent-service.ts
+++ b/packages/lib/src/agents/agent-service.ts
@@ -13,7 +13,13 @@ import {
 import { createScopedLogger } from '@auxx/logger'
 import { generateId } from '@auxx/utils'
 import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm'
-import { getAllCachedAgents, getCachedAgentById, getCachedAgents, onCacheEvent } from '../cache'
+import {
+  getAllCachedAgents,
+  getCachedAgentById,
+  getCachedAgents,
+  getCachedMembers,
+  onCacheEvent,
+} from '../cache'
 import { BadRequestError, ForbiddenError } from '../errors'
 import { getRealtimeService, publishAgentUpdated } from '../realtime'
 import { publishAgentTx } from './agent-version-service'
@@ -235,6 +241,15 @@ export interface UpdateAgentInput {
    * plans/kopilot/apps/agent-credentials.md §5.5.
    */
   appAccounts?: Record<string, AppAccountBinding | null>
+  /**
+   * **Run-as delegation** (capability layer v2 §0.6). When non-null, every run
+   * of this agent resolves its capabilities from that user instead of the
+   * agent's own permission profile; `null` clears the delegation. The engine
+   * identity (session `userId`, authorship, realtime attribution) is unchanged
+   * either way. Must be an ACTIVE `userType: 'USER'` member of the org —
+   * rejected with `BadRequestError` otherwise. Omit to leave untouched.
+   */
+  runAsUserId?: string | null
 }
 
 /**
@@ -273,6 +288,13 @@ export async function updateAgent(
   // cred owned by createdById). Done before the tx so we fail fast.
   if (input.appAccounts !== undefined) {
     await validateAppAccountBindings(agentId, organizationId, input.appAccounts, db)
+  }
+
+  // Run-as delegation must point at an ACTIVE human member — a delegation to a
+  // non-member / deactivated / non-human principal would fail every run at
+  // `resolveAgentRunCapabilities` (§0.6), so reject it at the write instead.
+  if (input.runAsUserId != null) {
+    await assertRunAsCandidate(organizationId, input.runAsUserId)
   }
 
   await db.transaction(async (tx) => {
@@ -662,6 +684,12 @@ export interface AgentSummary {
   id: string
   /** `null` while the agent is a draft (pre-`completeAgentSetup`). */
   userId: string | null
+  /**
+   * Optional run-as delegation — every run resolves its capabilities from this
+   * user instead of the agent's own profile. `null` = own profile (the default).
+   * See plans/permissions/v2/14-agent-permissions.md §0.6.
+   */
+  runAsUserId: string | null
   createdById: string
   /** `null` until the builder writes a real one via `update_agent_identity`. */
   name: string | null
@@ -696,6 +724,7 @@ export async function listAgents(
 function toAgentSummary(a: {
   id: string
   userId: string | null
+  runAsUserId: string | null
   createdById: string
   name: string | null
   slug: string
@@ -712,6 +741,7 @@ function toAgentSummary(a: {
   return {
     id: a.id,
     userId: a.userId,
+    runAsUserId: a.runAsUserId,
     createdById: a.createdById,
     name: a.name && a.name.length > 0 ? a.name : null,
     slug: a.slug,
@@ -837,6 +867,27 @@ export async function isAgentSlugTaken(
  */
 export async function agentExistsInOrg(organizationId: string, agentId: string): Promise<boolean> {
   return (await getCachedAgentById(organizationId, agentId)) !== null
+}
+
+/**
+ * Verify a proposed `runAsUserId` is an ACTIVE, human (`userType: 'USER'`)
+ * member of the org — the same predicate `resolveAgentRunCapabilities` asserts
+ * at run time (capability layer v2 §0.6). Reads the `members` org cache.
+ *
+ * @throws {BadRequestError} when the user is not a member, not ACTIVE, or is an
+ * agent/system principal.
+ */
+async function assertRunAsCandidate(organizationId: string, runAsUserId: string): Promise<void> {
+  const member = (await getCachedMembers(organizationId)).find((m) => m.userId === runAsUserId)
+  if (!member) {
+    throw new BadRequestError('The run-as user must be a member of this organization.')
+  }
+  if (member.status !== 'ACTIVE') {
+    throw new BadRequestError('The run-as user must be an active member of this organization.')
+  }
+  if (member.user?.userType !== 'USER') {
+    throw new BadRequestError('An agent can only run as a human member, not another agent.')
+  }
 }
 
 /**

--- a/packages/lib/src/ai/agent-framework/__tests__/agent-run-capabilities.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/agent-run-capabilities.test.ts
@@ -1,0 +1,208 @@
+// packages/lib/src/ai/agent-framework/__tests__/agent-run-capabilities.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
+
+interface FakeMember {
+  userId: string
+  status: string
+  role: string
+  user: { userType: string } | null
+}
+
+const members: FakeMember[] = []
+vi.mock('../../../cache/org-cache-helpers', () => ({
+  getCachedMembers: async () => members,
+}))
+
+const capsByUser = new Map<string, CapabilityView>()
+const getCapabilitiesSpy = vi.fn(async (userId: string, _orgId: string) => {
+  const hit = capsByUser.get(userId)
+  if (!hit) throw new Error(`no fake capabilities registered for ${userId}`)
+  return hit
+})
+vi.mock('../../../permissions/capabilities/get-capabilities', () => ({
+  getCapabilities: (userId: string, orgId: string) => getCapabilitiesSpy(userId, orgId),
+}))
+
+import { AgentRunAsUnavailableError, resolveAgentRunCapabilities } from '../agent-run-capabilities'
+
+/** Minimal CapabilityView stub — only the gates these tests exercise are real. */
+function fakeCaps(viewable: string[]): CapabilityView {
+  const set = new Set(viewable)
+  return {
+    can: (k) => set.has(k),
+    has: (k) => set.has(k),
+    assert: () => {},
+    canWriteEntity: (id) => set.has(id),
+    assertWriteEntity: () => {},
+    canEditEntity: (id) => set.has(id),
+    assertEditEntity: () => {},
+    filterEditableDefIds: (ids) => ids.filter((id) => set.has(id)),
+    canViewEntity: (id) => set.has(id),
+    assertViewEntity: () => {},
+    filterViewableDefIds: (ids) => ids.filter((id) => set.has(id)),
+    viewAccessFor: () => undefined,
+    canAdministerDef: () => false,
+    assertAdministerDef: () => {},
+    canViewInstance: (_k, id) => set.has(id),
+    canEditInstance: (_k, id) => set.has(id),
+    canAdminInstance: () => false,
+    assertViewInstance: () => {},
+    assertEditInstance: () => {},
+    assertAdminInstance: () => {},
+  } as CapabilityView
+}
+
+const ORG = 'org-1'
+
+beforeEach(() => {
+  members.length = 0
+  capsByUser.clear()
+  getCapabilitiesSpy.mockClear()
+})
+
+describe('resolveAgentRunCapabilities', () => {
+  it('returns undefined when the agent has no backing user (pre-setup draft)', async () => {
+    const caps = await resolveAgentRunCapabilities({
+      agent: { userId: null, runAsUserId: null },
+      organizationId: ORG,
+    })
+    expect(caps).toBeUndefined()
+    expect(getCapabilitiesSpy).not.toHaveBeenCalled()
+  })
+
+  it('resolves the agent profile when no run-as is set', async () => {
+    const agentCaps = fakeCaps(['def-a'])
+    capsByUser.set('agent-user', agentCaps)
+
+    const caps = await resolveAgentRunCapabilities({
+      agent: { userId: 'agent-user', runAsUserId: null },
+      organizationId: ORG,
+    })
+
+    expect(caps).toBe(agentCaps)
+    expect(getCapabilitiesSpy).toHaveBeenCalledWith('agent-user', ORG)
+  })
+
+  it('resolves the delegate when run-as points at an ACTIVE human member', async () => {
+    members.push({ userId: 'human-1', status: 'ACTIVE', role: 'USER', user: { userType: 'USER' } })
+    const delegateCaps = fakeCaps(['def-a', 'def-b'])
+    capsByUser.set('human-1', delegateCaps)
+    capsByUser.set('agent-user', fakeCaps([]))
+
+    const caps = await resolveAgentRunCapabilities({
+      agent: { userId: 'agent-user', runAsUserId: 'human-1' },
+      organizationId: ORG,
+    })
+
+    expect(caps).toBe(delegateCaps)
+    // The agent's own profile is never resolved when run-as is set.
+    expect(getCapabilitiesSpy).toHaveBeenCalledTimes(1)
+    expect(getCapabilitiesSpy).toHaveBeenCalledWith('human-1', ORG)
+  })
+
+  it('throws when the run-as user is not a member at all', async () => {
+    capsByUser.set('agent-user', fakeCaps(['def-a']))
+
+    await expect(
+      resolveAgentRunCapabilities({
+        agent: { userId: 'agent-user', runAsUserId: 'ghost', id: 'ag_1', name: 'Triage Bot' },
+        organizationId: ORG,
+      })
+    ).rejects.toBeInstanceOf(AgentRunAsUnavailableError)
+  })
+
+  it('throws when the run-as member is inactive — never falls back to the agent profile', async () => {
+    members.push({
+      userId: 'human-1',
+      status: 'DEACTIVATED',
+      role: 'USER',
+      user: { userType: 'USER' },
+    })
+    capsByUser.set('agent-user', fakeCaps(['def-a']))
+    capsByUser.set('human-1', fakeCaps([]))
+
+    const promise = resolveAgentRunCapabilities({
+      agent: { userId: 'agent-user', runAsUserId: 'human-1', name: 'Triage Bot' },
+      organizationId: ORG,
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(AgentRunAsUnavailableError)
+    await expect(promise).rejects.toThrow(/Triage Bot/)
+    expect(getCapabilitiesSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when the run-as user is not human (agent/system principal)', async () => {
+    members.push({ userId: 'bot-2', status: 'ACTIVE', role: 'USER', user: { userType: 'AGENT' } })
+    capsByUser.set('agent-user', fakeCaps(['def-a']))
+    capsByUser.set('bot-2', fakeCaps(['def-a', 'def-b']))
+
+    await expect(
+      resolveAgentRunCapabilities({
+        agent: { userId: 'agent-user', runAsUserId: 'bot-2' },
+        organizationId: ORG,
+      })
+    ).rejects.toBeInstanceOf(AgentRunAsUnavailableError)
+  })
+
+  it('intersects with the invoker when a human triggered the run', async () => {
+    capsByUser.set('agent-user', fakeCaps(['def-a', 'def-b']))
+    capsByUser.set('human-1', fakeCaps(['def-b', 'def-c']))
+
+    const caps = await resolveAgentRunCapabilities({
+      agent: { userId: 'agent-user', runAsUserId: null },
+      organizationId: ORG,
+      invokerUserId: 'human-1',
+    })
+
+    expect(caps?.canViewEntity('def-a')).toBe(false)
+    expect(caps?.canViewEntity('def-b')).toBe(true)
+    expect(caps?.canViewEntity('def-c')).toBe(false)
+    expect(caps?.filterViewableDefIds(['def-a', 'def-b', 'def-c'])).toEqual(['def-b'])
+  })
+
+  it('intersects the DELEGATE (not the agent) with the invoker when run-as is set', async () => {
+    members.push({ userId: 'human-1', status: 'ACTIVE', role: 'USER', user: { userType: 'USER' } })
+    capsByUser.set('agent-user', fakeCaps(['def-a', 'def-b', 'def-c']))
+    capsByUser.set('human-1', fakeCaps(['def-a']))
+    capsByUser.set('human-2', fakeCaps(['def-a', 'def-b']))
+
+    const caps = await resolveAgentRunCapabilities({
+      agent: { userId: 'agent-user', runAsUserId: 'human-1' },
+      organizationId: ORG,
+      invokerUserId: 'human-2',
+    })
+
+    expect(caps?.canViewEntity('def-a')).toBe(true)
+    expect(caps?.canViewEntity('def-b')).toBe(false)
+  })
+
+  it('short-circuits (no wrapper) when the invoker IS the capability source', async () => {
+    const agentCaps = fakeCaps(['def-a'])
+    capsByUser.set('agent-user', agentCaps)
+
+    const caps = await resolveAgentRunCapabilities({
+      agent: { userId: 'agent-user', runAsUserId: null },
+      organizationId: ORG,
+      invokerUserId: 'agent-user',
+    })
+
+    expect(caps).toBe(agentCaps)
+    expect(getCapabilitiesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a null invoker (autonomous run) — agent profile alone', async () => {
+    const agentCaps = fakeCaps(['def-a'])
+    capsByUser.set('agent-user', agentCaps)
+
+    const caps = await resolveAgentRunCapabilities({
+      agent: { userId: 'agent-user', runAsUserId: null },
+      organizationId: ORG,
+      invokerUserId: null,
+    })
+
+    expect(caps).toBe(agentCaps)
+    expect(getCapabilitiesSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/ai/agent-framework/agent-run-capabilities.ts
+++ b/packages/lib/src/ai/agent-framework/agent-run-capabilities.ts
@@ -1,0 +1,115 @@
+// packages/lib/src/ai/agent-framework/agent-run-capabilities.ts
+
+import { getCachedMembers } from '../../cache/org-cache-helpers'
+import { UnprocessableEntityError } from '../../errors'
+import {
+  type CapabilityView,
+  intersectCapabilities,
+} from '../../permissions/capabilities/capability-view'
+import { getCapabilities } from '../../permissions/capabilities/get-capabilities'
+
+/**
+ * The agent fields {@link resolveAgentRunCapabilities} needs — structurally
+ * satisfied by `CachedAgent`, the `Agent` row, and test fixtures alike.
+ */
+export interface AgentRunPrincipal {
+  /** The agent's own synthetic User; `null` while setup is incomplete. */
+  userId: string | null
+  /** Optional run-as delegation — resolves capabilities from this user instead. */
+  runAsUserId: string | null
+  /** Only used to make the run-as failure message actionable. */
+  id?: string
+  /** Only used to make the run-as failure message actionable. */
+  name?: string | null
+}
+
+/**
+ * Thrown when an agent's `runAsUserId` no longer points at an ACTIVE human
+ * member of the org (deleted, deactivated, or re-pointed at an agent/system
+ * user). The run is **stopped** rather than silently falling back to the
+ * agent's own profile — a silently-widened agent is worse than a stopped one
+ * (capability layer v2 §0.6). Surfaces as a 422 through the standard
+ * `AuxxError` mapping, and lands in the run log with a message naming both
+ * the agent and the missing user so an admin can re-point the delegation.
+ */
+export class AgentRunAsUnavailableError extends UnprocessableEntityError {}
+
+/**
+ * Resolve the {@link CapabilityView} an agent run executes under
+ * (capability layer v2 §3.1).
+ *
+ * ```
+ * sourceUserId = agent.runAsUserId ?? agent.userId
+ * caps         = getCapabilities(sourceUserId, organizationId)
+ * caps         = invokerUserId ? min(caps, getCapabilities(invokerUserId)) : caps
+ * ```
+ *
+ * - **Run-as** (`agent.runAsUserId`) replaces the capability *source only* —
+ *   the engine identity (session `userId`, authorship, realtime attribution)
+ *   stays `agent.userId` in every case, so audit trails remain honest (§0.1).
+ *   The delegate must be an ACTIVE `userType: 'USER'` member; otherwise this
+ *   throws {@link AgentRunAsUnavailableError} (§0.6 — never a silent fallback).
+ * - **Invoker intersection** applies to human-triggered runs (mention,
+ *   assignment, interactive DM): a mention can never read data through an agent
+ *   that the mentioner couldn't read themselves (§0.5). Schedule / event / app /
+ *   webhook / visitor runs pass no `invokerUserId` and use the agent profile
+ *   alone. Passing the source user as the invoker short-circuits to the same
+ *   view (no wrapper) via `intersectCapabilities`.
+ *
+ * Returns `undefined` when the agent has no backing User yet (pre-setup draft):
+ * there is no principal to resolve, so callers keep today's unrestricted
+ * behavior rather than inventing one.
+ */
+export async function resolveAgentRunCapabilities(params: {
+  agent: AgentRunPrincipal
+  organizationId: string
+  /** The human who triggered this run, when there is one. */
+  invokerUserId?: string | null
+}): Promise<CapabilityView | undefined> {
+  const { agent, organizationId, invokerUserId } = params
+
+  // Pre-setup draft: no synthetic User exists, so there is no principal to
+  // resolve. Not an error — the caller simply stays unrestricted, as today.
+  if (!agent.userId) return undefined
+
+  if (agent.runAsUserId) {
+    await assertActiveHumanMember(agent, agent.runAsUserId, organizationId)
+  }
+
+  const sourceUserId = agent.runAsUserId ?? agent.userId
+  const caps = await getCapabilities(sourceUserId, organizationId)
+
+  if (!invokerUserId || invokerUserId === sourceUserId) return caps
+
+  return intersectCapabilities(caps, await getCapabilities(invokerUserId, organizationId))
+}
+
+/**
+ * Assert the run-as delegate is an ACTIVE human member of the org, reading the
+ * `members` org cache (zero DB round-trips on a warm cache).
+ */
+async function assertActiveHumanMember(
+  agent: AgentRunPrincipal,
+  runAsUserId: string,
+  organizationId: string
+): Promise<void> {
+  const members = await getCachedMembers(organizationId)
+  const member = members.find((m) => m.userId === runAsUserId)
+  const label = agent.name ? `"${agent.name}"` : (agent.id ?? 'unknown')
+
+  if (!member) {
+    throw new AgentRunAsUnavailableError(
+      `Agent ${label} is configured to run as user ${runAsUserId}, who is not a member of this organization. Update the agent's run-as user to let it run again.`
+    )
+  }
+  if (member.status !== 'ACTIVE') {
+    throw new AgentRunAsUnavailableError(
+      `Agent ${label} is configured to run as user ${runAsUserId}, whose membership is ${member.status}. Reactivate that member or update the agent's run-as user to let it run again.`
+    )
+  }
+  if (member.user?.userType !== 'USER') {
+    throw new AgentRunAsUnavailableError(
+      `Agent ${label} is configured to run as user ${runAsUserId}, who is not a human member. Update the agent's run-as user to let it run again.`
+    )
+  }
+}

--- a/packages/lib/src/ai/agent-framework/effective-runtime.ts
+++ b/packages/lib/src/ai/agent-framework/effective-runtime.ts
@@ -15,6 +15,7 @@ import {
 } from '../../agents/bindings'
 import type { AgentSurface } from '../../agents/client'
 import { PROCEDURE_CONTROL_TOOLS } from '../../agents/procedures'
+import type { CapabilityView } from '../../permissions/capabilities/capability-view'
 import {
   type CapabilityRegistry,
   createAppCapabilities,
@@ -87,6 +88,14 @@ export interface BuildEffectiveAgentRuntimeArgs {
    * are preserved by the wrapper, so binding clamps and schema digests are invariant.
    */
   wrapTools?: (tools: AgentToolDefinition[]) => AgentToolDefinition[]
+  /**
+   * The capability view this run executes under, resolved once by
+   * `resolveAgentRunCapabilities` (capability layer v2 §3.1). Threaded into
+   * BOTH the tool deps (read/write gates) and the domain config (prompt-side
+   * catalog filtering, §3.4). Omit to keep today's unrestricted behavior —
+   * master-Kopilot job runs (no agent) and pre-setup drafts have no principal.
+   */
+  capabilities?: CapabilityView
 }
 
 /**
@@ -163,9 +172,17 @@ export async function buildAgentCapabilityRegistry(args: {
   sessionId: string
   agentId: string | null
   signal?: AbortSignal
+  /** Read/write enforcement for this run (§3.1). Omit → unrestricted, as today. */
+  capabilities?: CapabilityView
 }): Promise<CapabilityRegistry> {
-  const { organizationId, userId, sessionId, agentId, signal } = args
-  const getToolDeps = createToolDepsFactory({ organizationId, userId, sessionId, signal })
+  const { organizationId, userId, sessionId, agentId, signal, capabilities } = args
+  const getToolDeps = createToolDepsFactory({
+    organizationId,
+    userId,
+    sessionId,
+    signal,
+    capabilities,
+  })
 
   const registry = createCapabilityRegistry()
   registry.register(createEntityCapabilities(getToolDeps))
@@ -220,6 +237,7 @@ export async function buildEffectiveAgentRuntime(
     sessionId,
     agentId,
     signal,
+    capabilities: args.capabilities,
   })
 
   const agentConfig = await resolveAgentConfig(organizationId, agentId, undefined, { source })
@@ -267,6 +285,9 @@ export async function buildEffectiveAgentRuntime(
     surface,
     audience,
     triggerContext: args.triggerContext,
+    // Prompt-side catalog filtering (§3.4) — the entity/KB catalogs the model is
+    // handed are narrowed to what this run may actually read.
+    capabilities: args.capabilities,
     // Long-running plans (≥30 steps × ~1–2 LLM rounds each) need headroom past
     // the framework's small-loop default.
     maxIterations: 30,

--- a/packages/lib/src/ai/agent-framework/enqueue-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/enqueue-agent-job.ts
@@ -43,6 +43,15 @@ export interface AgentJobPayload {
    * context from `session.agentTriggerId` regardless.
    */
   triggerKind?: 'dm'
+  /**
+   * The human who triggered this run; the run's capabilities are intersected
+   * with theirs (capability layer v2 §0.5), so a mention can never read data
+   * through an agent that the mentioner couldn't read themselves. Unset for
+   * schedule/event/app/webhook runs — those use the agent profile alone.
+   *
+   * Never the run's identity: the engine still runs as `userId` (the agent).
+   */
+  invokerUserId?: string | null
 }
 
 /**

--- a/packages/lib/src/ai/agent-framework/index.ts
+++ b/packages/lib/src/ai/agent-framework/index.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/ai/agent-framework/index.ts
 
+export type { AgentRunPrincipal } from './agent-run-capabilities'
+export { AgentRunAsUnavailableError, resolveAgentRunCapabilities } from './agent-run-capabilities'
 export { BUILDER_MODEL } from './builder-model'
 export type { ContextManagerConfig } from './context-manager'
 export {

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -17,6 +17,7 @@ import { buildInstructionReferenceResolver } from '../kopilot/prompts/resolve-in
 import type { TriggerContext, TriggerKind } from '../kopilot/prompts/trigger-context'
 import type { UsageTrackingRequest } from '../orchestrator/types'
 import { UsageTrackingService } from '../usage/usage-tracking-service'
+import { resolveAgentRunCapabilities } from './agent-run-capabilities'
 import { KopilotContextStore, readContextSlice } from './context'
 import { type AgentRuntimeDomain, buildEffectiveAgentRuntime } from './effective-runtime'
 import { AgentEngine } from './engine'
@@ -94,6 +95,19 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   const procedures = agent?.procedures ?? []
   const hasProcedures = procedures.length > 0
 
+  // Capability layer v2 §3.1: the run's read/write enforcement — the agent's own
+  // profile (or its run-as delegate), intersected with the invoking human on
+  // mention/assignment/DM runs. Master Kopilot job runs (`agentId === null`) have
+  // no agent principal, so they stay `undefined` (unrestricted, as today).
+  // A broken run-as delegation throws here and fails the run loudly (§0.6).
+  const capabilities = agent
+    ? await resolveAgentRunCapabilities({
+        agent,
+        organizationId,
+        invokerUserId: data.invokerUserId,
+      })
+    : undefined
+
   // 1b. Resolve trigger context for autonomous runs. The trigger row is
   // re-fetched (not passed via the job payload) so operator edits to
   // `instructions` between enqueue and execution are picked up.
@@ -123,6 +137,7 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
     hasProcedures,
     page,
     triggerContext,
+    capabilities,
   })
   const { domainConfig, agentConfig } = runtime
 

--- a/packages/lib/src/ai/kopilot/agents/agent.ts
+++ b/packages/lib/src/ai/kopilot/agents/agent.ts
@@ -11,6 +11,7 @@ import {
   getCachedMembersByUserIds,
   getCachedResources,
 } from '../../../cache/org-cache-helpers'
+import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
 import type {
   AgentDefinition,
   AgentDeps,
@@ -59,6 +60,16 @@ export interface CreateKopilotAgentOptions {
    * (master or user agent) leave this undefined.
    */
   triggerContext?: TriggerContext
+  /**
+   * The turn's resolved read enforcement (capability layer v2 §3.4). Filters
+   * the org-wide catalogs hydrated into the system prompt — the prompt-side
+   * twin of the client's `useViewableResources`. Undefined ⇒ no filtering, so
+   * un-threaded callers render exactly today's prompt.
+   *
+   * Named apart from {@link CreateKopilotAgentOptions.capabilities}, which is
+   * the human-readable capability *description* list.
+   */
+  recordAccess?: CapabilityView
 }
 
 /**
@@ -80,6 +91,7 @@ export function createKopilotAgent(
     surface,
     audience,
     triggerContext,
+    recordAccess,
   } = options
 
   const agentTools: AgentToolDefinition[] = tools
@@ -111,8 +123,15 @@ export function createKopilotAgent(
           }),
         ])
 
+      // Def-level read enforcement, prompt-side (capability layer v2 §3.4): the
+      // catalog must not advertise defs the tools would deny — the twin of the
+      // client's `useViewableResources`. No `recordAccess` ⇒ unfiltered, as today.
       const entityCatalog = resources
-        .filter((r) => r.isVisible !== false)
+        .filter(
+          (r) =>
+            r.isVisible !== false &&
+            (!recordAccess || recordAccess.canViewEntity(r.entityDefinitionId ?? r.id))
+        )
         .map((r) => ({
           apiSlug: r.apiSlug,
           label: r.label,
@@ -147,6 +166,7 @@ export function createKopilotAgent(
         triggerContext,
         instructionsReferences,
         procedureStep,
+        recordAccess,
       })
 
       // Full conversation for tool-loop continuity. Each persisted assistant

--- a/packages/lib/src/ai/kopilot/capabilities/create-deps.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/create-deps.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/create-deps.ts
 
 import { database } from '@auxx/database'
-import type { CapabilitySet } from '../../../permissions/capabilities/capability-set'
+import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
 import type { SessionContext } from '../types'
 import type { GetToolDeps, ToolDeps } from './types'
 
@@ -17,11 +17,21 @@ export function createToolDepsFactory(params: {
   /** UI session context from the current request body. Read by tools that need active-record ids. */
   sessionContext?: SessionContext
   /**
-   * Pre-resolved read enforcement (v2 §3). Pass ONLY for interactive turns where
-   * the acting user is a real org member; omit for autonomous/visitor/workflow
-   * turns (they stay unrestricted). Resolved once and shared by every tool call.
+   * Pre-resolved read/write enforcement (v2 §3), resolved once and shared by
+   * every tool call in the turn.
+   *
+   * As of capability layer v2 §3.2 every agent path threads this: interactive
+   * Kopilot (`intersectCapabilities(agentCaps, humanCaps)`), worker agent jobs
+   * and visitor chat (both via `resolveAgentRunCapabilities`).
+   *
+   * The `!capabilities → unrestricted` fallback inside the tools now survives
+   * **solely for the workflow AI node** (`workflow-engine/nodes/action-nodes/
+   * ai-v2.ts`), which is explicitly out of scope until workflows become
+   * permission principals of their own (§0.8) — plus master-Kopilot job runs and
+   * pre-setup drafts, which have no principal to resolve. Do not remove the
+   * fallback, and do not add new callers that rely on it.
    */
-  capabilities?: CapabilitySet
+  capabilities?: CapabilityView
 }): GetToolDeps {
   return (): ToolDeps => ({
     db: database,

--- a/packages/lib/src/ai/kopilot/capabilities/entities/enrich-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/enrich-entity-fields.ts
@@ -10,7 +10,7 @@ import { getCachedResource } from '../../../../cache/org-cache-helpers'
 import { rowsToTypedValues } from '../../../../field-values/field-value-helpers'
 import { formatToDisplayValue, formatToRawValue } from '../../../../field-values/formatter'
 import type { FieldValueRow } from '../../../../field-values/types'
-import type { CapabilitySet } from '../../../../permissions/capabilities/capability-set'
+import type { CapabilityView } from '../../../../permissions/capabilities/capability-view'
 import { RecordPickerService } from '../../../../resources/picker'
 import { isCustomResourceId } from '../../../../resources/registry/types'
 import { isRecordId } from '../../../../resources/resource-id'
@@ -37,7 +37,7 @@ export async function enrichEntitiesWithFieldValues(params: {
   db: Database
   entities: Array<{ recordId: string; entityDefinitionId: string; entityInstanceId: string }>
   /** Read enforcement (§3): gates per-def groups + relationship-target resolution. */
-  capabilities?: CapabilitySet
+  capabilities?: CapabilityView
 }): Promise<Map<string, Record<string, EnrichedField>>> {
   const { organizationId, userId, db, entities, capabilities } = params
   const result = new Map<string, Record<string, EnrichedField>>()

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
@@ -1,0 +1,136 @@
+// packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
+//
+// Permissions v2 §3.3 (Phase C1): `bulk_update_entity` bypasses
+// `UnifiedCrudHandler` and writes straight through `FieldValueService`, so it
+// carries its own copy of the handler's `assertEditDistinctDefs` — one
+// `assertEditEntity` per DISTINCT def among the recordIds. Absent capabilities
+// (the un-threaded workflow AI node) must behave byte-for-byte as before.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const setBulkValuesSpy = vi.fn()
+
+vi.mock('../../../../../../cache/org-cache-helpers', () => ({
+  // `null` ⇒ the tool skips field-key validation and actor resolution, which
+  // keeps this test focused on the capability gate.
+  findCachedResource: vi.fn(async () => null),
+}))
+
+vi.mock('../../../../../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    async setBulkValues(args: unknown) {
+      return setBulkValuesSpy(args)
+    }
+  },
+}))
+
+import { ForbiddenError } from '../../../../../../errors'
+import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../../agent-framework/types'
+import { createBulkUpdateEntityTool } from '../bulk-update-entity'
+
+/** All-permissive `CapabilityView`; override just the gate under test. */
+function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  const yes = () => true
+  const noop = () => {}
+  return {
+    can: yes,
+    has: yes,
+    assert: noop,
+    canWriteEntity: yes,
+    assertWriteEntity: noop,
+    canEditEntity: yes,
+    assertEditEntity: noop,
+    filterEditableDefIds: (ids: string[]) => ids,
+    canViewEntity: yes,
+    assertViewEntity: noop,
+    filterViewableDefIds: (ids: string[]) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: yes,
+    assertAdministerDef: noop,
+    canViewInstance: yes,
+    canEditInstance: yes,
+    canAdminInstance: yes,
+    assertViewInstance: noop,
+    assertEditInstance: noop,
+    assertAdminInstance: noop,
+    ...overrides,
+  }
+}
+
+/** Records every def id the tool asserted on, in call order. */
+function makeRecordingCapabilities(deniedDefIds: string[] = []) {
+  const asserted: string[] = []
+  const capabilities = makeCapabilities({
+    canEditEntity: (defId: string) => !deniedDefIds.includes(defId),
+    assertEditEntity: (defId: string) => {
+      asserted.push(defId)
+      if (deniedDefIds.includes(defId)) {
+        throw new ForbiddenError("You don't have permission to edit records.")
+      }
+    },
+  })
+  return { capabilities, asserted }
+}
+
+function runTool(recordIds: string[], capabilities?: CapabilityView) {
+  const tool = createBulkUpdateEntityTool(() => ({ db: {}, capabilities }) as never)
+  const ctx = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+  return tool.execute(
+    { recordIds, values: [{ fieldId: 'ticket_status', value: 'COMPLETED' }] },
+    ctx
+  ) as Promise<AgentToolResult>
+}
+
+beforeEach(() => {
+  setBulkValuesSpy.mockReset()
+  setBulkValuesSpy.mockResolvedValue({ count: 2 })
+})
+
+describe('bulk_update_entity — write enforcement', () => {
+  it('without capabilities, writes as before with no gating', async () => {
+    const result = await runTool(['def_a:i_1', 'def_b:i_2'], undefined)
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ total: 2, approved: 2, updated: 2 })
+    expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('asserts once per DISTINCT def, not once per record', async () => {
+    const { capabilities, asserted } = makeRecordingCapabilities()
+
+    const result = await runTool(['def_a:i_1', 'def_a:i_2', 'def_b:i_3', 'def_a:i_4'], capabilities)
+
+    expect(result.success).toBe(true)
+    expect(asserted).toEqual(['def_a', 'def_b'])
+    expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws ForbiddenError before any write when one def is not editable', async () => {
+    const { capabilities } = makeRecordingCapabilities(['def_b'])
+
+    await expect(runTool(['def_a:i_1', 'def_b:i_2'], capabilities)).rejects.toBeInstanceOf(
+      ForbiddenError
+    )
+    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+  })
+
+  it('gates the APPROVED subset, not the originally requested ids', async () => {
+    const { capabilities, asserted } = makeRecordingCapabilities(['def_b'])
+
+    // `def_b` was requested but not approved, so it must not be asserted on.
+    const tool = createBulkUpdateEntityTool(() => ({ db: {}, capabilities }) as never)
+    const result = (await tool.execute(
+      {
+        recordIds: ['def_a:i_1', 'def_b:i_2'],
+        _approvedRecordIds: ['def_a:i_1'],
+        values: [{ fieldId: 'ticket_status', value: 'COMPLETED' }],
+      },
+      { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+    )) as AgentToolResult
+
+    expect(result.success).toBe(true)
+    expect(asserted).toEqual(['def_a'])
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/create-entity-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/create-entity-capabilities.test.ts
@@ -1,0 +1,138 @@
+// packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/create-entity-capabilities.test.ts
+//
+// Permissions v2 §3.3 (Phase C1): `create_entity` must hand its resolved
+// `CapabilityView` to `UnifiedCrudHandler`, whose `create` asserts
+// `canEditEntity`. Absent capabilities (the un-threaded workflow AI node) must
+// behave byte-for-byte as before.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createSpy = vi.fn()
+const constructedOptions: Array<{ capabilities?: CapabilityView } | undefined> = []
+
+vi.mock('../../../../../../cache/org-cache-helpers', () => ({
+  findCachedResource: vi.fn(async () => ({
+    id: 'contact',
+    entityDefinitionId: 'def_contact',
+    label: 'Contact',
+    fields: [],
+  })),
+  getCachedResources: vi.fn(async () => []),
+}))
+
+vi.mock('../field-label-helpers', () => ({
+  validateFieldKeys: () => ({ unknownKeys: [], validIds: ['name'] }),
+  formatUnknownFieldsError: () => 'unknown fields',
+  resolveFieldLabels: (_r: unknown, ids: string[]) => ids,
+}))
+
+vi.mock('../resolve-actor-values', () => ({
+  resolveActorValues: async (values: Record<string, unknown>) => ({ values, errors: [] }),
+  formatActorResolutionError: () => 'actor error',
+}))
+
+// Stand-in for the real handler that reproduces the one line under test:
+// `create` asserts `assertEditEntity` when capabilities were threaded in.
+vi.mock('../../../../../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    private readonly capabilities?: CapabilityView
+    constructor(
+      _org: string,
+      _user: string,
+      _db: unknown,
+      _def: unknown,
+      options?: { capabilities?: CapabilityView }
+    ) {
+      constructedOptions.push(options)
+      this.capabilities = options?.capabilities
+    }
+    async create(entityDefinitionId: string, values: Record<string, unknown>) {
+      this.capabilities?.assertEditEntity(entityDefinitionId)
+      return createSpy(entityDefinitionId, values)
+    }
+  },
+}))
+
+import { ForbiddenError } from '../../../../../../errors'
+import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../../agent-framework/types'
+import { createCreateEntityTool } from '../create-entity'
+
+/** All-permissive `CapabilityView`; override just the gate under test. */
+function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  const yes = () => true
+  const noop = () => {}
+  return {
+    can: yes,
+    has: yes,
+    assert: noop,
+    canWriteEntity: yes,
+    assertWriteEntity: noop,
+    canEditEntity: yes,
+    assertEditEntity: noop,
+    filterEditableDefIds: (ids: string[]) => ids,
+    canViewEntity: yes,
+    assertViewEntity: noop,
+    filterViewableDefIds: (ids: string[]) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: yes,
+    assertAdministerDef: noop,
+    canViewInstance: yes,
+    canEditInstance: yes,
+    canAdminInstance: yes,
+    assertViewInstance: noop,
+    assertEditInstance: noop,
+    assertAdminInstance: noop,
+    ...overrides,
+  }
+}
+
+function runTool(capabilities?: CapabilityView) {
+  const tool = createCreateEntityTool(() => ({ db: {}, capabilities }) as never)
+  const ctx = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+  return tool.execute(
+    { entityDefinitionId: 'contact', values: { name: 'Ada' } },
+    ctx
+  ) as Promise<AgentToolResult>
+}
+
+beforeEach(() => {
+  createSpy.mockReset()
+  createSpy.mockResolvedValue({ recordId: 'def_contact:i_1' })
+  constructedOptions.length = 0
+})
+
+describe('create_entity — write enforcement', () => {
+  it('without capabilities, creates as before and passes none to the handler', async () => {
+    const result = await runTool(undefined)
+
+    expect(result.success).toBe(true)
+    expect(result.output).toEqual({ recordId: 'def_contact:i_1' })
+    expect(createSpy).toHaveBeenCalledWith('def_contact', { name: 'Ada' })
+    expect(constructedOptions).toHaveLength(1)
+    expect(constructedOptions[0]?.capabilities).toBeUndefined()
+  })
+
+  it('threads the capability view into the handler options', async () => {
+    const capabilities = makeCapabilities()
+    await runTool(capabilities)
+
+    expect(constructedOptions[0]?.capabilities).toBe(capabilities)
+  })
+
+  it('surfaces the ForbiddenError as a tool error when the def is not editable', async () => {
+    const capabilities = makeCapabilities({
+      canEditEntity: () => false,
+      assertEditEntity: () => {
+        throw new ForbiddenError("You don't have permission to edit records.")
+      },
+    })
+
+    const result = await runTool(capabilities)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("don't have permission")
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod'
 import { findCachedResource } from '../../../../../cache/org-cache-helpers'
 import { FieldValueService } from '../../../../../field-values/field-value-service'
-import { getDefinitionId } from '../../../../../resources/resource-id'
+import { getDefinitionId, type RecordId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArrayArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
@@ -108,7 +108,7 @@ Example (ids match list_entity_fields output):
       }
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const allRecordIds = args.recordIds as string[]
       const values = args.values as Array<{ fieldId: string; value: unknown }>
 
@@ -132,6 +132,21 @@ Example (ids match list_entity_fields output):
           output: null,
           error:
             'No field values provided. Call list_entity_fields first to discover fields, then pass them in the "values" array.',
+        }
+      }
+
+      // Write enforcement (permissions v2 §3.3). This tool bypasses
+      // `UnifiedCrudHandler` and writes straight through `FieldValueService`,
+      // so it carries its own copy of the handler's `assertEditDistinctDefs`:
+      // one `assertEditEntity` per DISTINCT def among the recordIds, in-memory,
+      // before any DB work. Absent capabilities ⇒ unrestricted, as before.
+      if (capabilities) {
+        const seenDefIds = new Set<string>()
+        for (const recordId of recordIds) {
+          const entityDefinitionId = getDefinitionId(recordId as RecordId)
+          if (seenDefIds.has(entityDefinitionId)) continue
+          seenDefIds.add(entityDefinitionId)
+          capabilities.assertEditEntity(entityDefinitionId)
         }
       }
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
@@ -101,7 +101,7 @@ Example (ids match list_entity_fields output):
       return { ok: true, args: { ...args, entityDefinitionId: entityDefinitionId.value } }
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const key = args.entityDefinitionId as string
 
       // The LLM may nest field values under `values` or flatten them at the top level.
@@ -156,7 +156,16 @@ Example (ids match list_entity_fields output):
         }
       }
 
-      const handler = new UnifiedCrudHandler(agentDeps.organizationId, agentDeps.userId, db)
+      // Write enforcement (permissions v2 §3.3): the handler asserts
+      // `canEditEntity` on `create`. Absent capabilities (workflow AI node) ⇒
+      // unrestricted, exactly as before.
+      const handler = new UnifiedCrudHandler(
+        agentDeps.organizationId,
+        agentDeps.userId,
+        db,
+        undefined,
+        { capabilities }
+      )
 
       try {
         const result = await handler.create(entityDefId, actorResolution.values)

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
@@ -84,7 +84,7 @@ Example (ids match list_entity_fields output):
       }
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const recordId = args.recordId as string
 
       // The LLM may nest field values under `values` or flatten them at the top level.
@@ -130,7 +130,16 @@ Example (ids match list_entity_fields output):
         resolvedValues = actorResolution.values
       }
 
-      const handler = new UnifiedCrudHandler(agentDeps.organizationId, agentDeps.userId, db)
+      // Write enforcement (permissions v2 §3.3): the handler asserts
+      // `canEditEntity` on `update`. Absent capabilities (workflow AI node) ⇒
+      // unrestricted, exactly as before.
+      const handler = new UnifiedCrudHandler(
+        agentDeps.organizationId,
+        agentDeps.userId,
+        db,
+        undefined,
+        { capabilities }
+      )
 
       try {
         await handler.update(recordId, resolvedValues)

--- a/packages/lib/src/ai/kopilot/capabilities/kb/kb-access.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/kb-access.ts
@@ -1,0 +1,26 @@
+// packages/lib/src/ai/kopilot/capabilities/kb/kb-access.ts
+
+import type { CapabilityView } from '../../../../permissions/capabilities/capability-view'
+
+/**
+ * Instance-access READ gate for KB tools (permissions v2 §3.3).
+ *
+ * Reads keep the **silent-filter** semantics humans get: a KB the principal
+ * can't view is reported as "not found" / dropped from a list, never as a 403.
+ * (Write gates are the opposite — they `assertEditInstance` and throw, so the
+ * model can explain the denial.)
+ *
+ * `capabilities === undefined` ⇒ unrestricted (the workflow AI node is the one
+ * remaining un-threaded caller), so behavior is byte-for-byte unchanged there.
+ *
+ * @param capabilities Resolved capability view for the turn, if any.
+ * @param knowledgeBaseId The KB instance the caller is trying to read.
+ */
+export function canViewKb(
+  capabilities: CapabilityView | undefined,
+  knowledgeBaseId: string | null | undefined
+): boolean {
+  if (!capabilities) return true
+  if (!knowledgeBaseId) return true
+  return capabilities.canViewInstance('kb', knowledgeBaseId)
+}

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/write-helpers-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/write-helpers-capabilities.test.ts
@@ -1,0 +1,146 @@
+// packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/write-helpers-capabilities.test.ts
+//
+// Permissions v2 §3.3 (Phase C2): `runBlockCrudOp` is the single choke point for
+// every KB write tool (insert_blocks / replace_block / delete_blocks /
+// move_blocks, plus runMarkdownReplace via runPatchSequence), so the
+// `assertEditInstance('kb', …)` gate lives there — before the snapshot, the lock
+// and the patch. Absent capabilities ⇒ unrestricted, exactly as before.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const captureSnapshotSpy = vi.fn()
+const updateArticleDraftSpy = vi.fn()
+
+vi.mock('../../../../../../kb/kopilot-snapshot', () => ({
+  readKopilotSnapshot: vi.fn(async () => undefined),
+  captureKopilotSnapshot: (...args: unknown[]) => captureSnapshotSpy(...args),
+}))
+
+vi.mock('../../../../../../kb/realtime', () => ({
+  publishKbArticleEvent: vi.fn(async () => {}),
+}))
+
+vi.mock('../../../../../../kb/kb-service', () => ({
+  KBService: class {
+    async updateArticleDraft(...args: unknown[]) {
+      return updateArticleDraftSpy(...args)
+    }
+  },
+}))
+
+import { ForbiddenError } from '../../../../../../errors'
+import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import type { AgentDeps } from '../../../../../agent-framework/types'
+import type { ToolDeps } from '../../../types'
+import { runBlockCrudOp } from '../write-helpers'
+
+const KB_ID = 'kb_home'
+const ARTICLE_ID = 'art_1'
+
+/** All-permissive `CapabilityView`; override just the gate under test. */
+function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  const yes = () => true
+  const noop = () => {}
+  return {
+    can: yes,
+    has: yes,
+    assert: noop,
+    canWriteEntity: yes,
+    assertWriteEntity: noop,
+    canEditEntity: yes,
+    assertEditEntity: noop,
+    filterEditableDefIds: (ids: string[]) => ids,
+    canViewEntity: yes,
+    assertViewEntity: noop,
+    filterViewableDefIds: (ids: string[]) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: yes,
+    assertAdministerDef: noop,
+    canViewInstance: yes,
+    canEditInstance: yes,
+    canAdminInstance: yes,
+    assertViewInstance: noop,
+    assertEditInstance: noop,
+    assertAdminInstance: noop,
+    ...overrides,
+  }
+}
+
+function makeToolDeps(capabilities?: CapabilityView): ToolDeps {
+  return {
+    db: {
+      query: {
+        Article: {
+          findFirst: async () => ({
+            id: ARTICLE_ID,
+            homeKnowledgeBaseId: KB_ID,
+            draftRevision: {
+              contentJson: [{ type: 'block', attrs: { id: 'b1', blockType: 'text' }, content: [] }],
+            },
+          }),
+        },
+      },
+    },
+    organizationId: 'org_1',
+    userId: 'u_1',
+    sessionId: 's_1',
+    sessionContext: {
+      references: [{ kind: 'article', id: ARTICLE_ID, origin: 'mention' }],
+    },
+    capabilities,
+  } as unknown as ToolDeps
+}
+
+const agentDeps = {
+  organizationId: 'org_1',
+  userId: 'u_1',
+  sessionId: 's_1',
+  turnId: 't_1',
+} as AgentDeps
+
+function run(capabilities?: CapabilityView) {
+  return runBlockCrudOp({
+    agentDeps,
+    toolDeps: makeToolDeps(capabilities),
+    patch: { op: 'delete', blockIds: ['b1'] },
+    opIndex: 0,
+  })
+}
+
+beforeEach(() => {
+  captureSnapshotSpy.mockReset()
+  updateArticleDraftSpy.mockReset()
+})
+
+describe('runBlockCrudOp — KB instance-access write gate', () => {
+  it('without capabilities, applies the op as before', async () => {
+    const result = await run(undefined)
+
+    expect(result.ok).toBe(true)
+    expect(updateArticleDraftSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('with an editable KB, applies the op', async () => {
+    const result = await run(makeCapabilities())
+
+    expect(result.ok).toBe(true)
+    expect(updateArticleDraftSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws ForbiddenError before the snapshot/lock when the KB is not editable', async () => {
+    const seen: Array<[string, string]> = []
+    const capabilities = makeCapabilities({
+      canEditInstance: () => false,
+      assertEditInstance: (key, instanceId) => {
+        seen.push([key, instanceId])
+        throw new ForbiddenError("You don't have permission to edit this.")
+      },
+    })
+
+    await expect(run(capabilities)).rejects.toBeInstanceOf(ForbiddenError)
+    expect(seen).toEqual([['kb', KB_ID]])
+    // Nothing was captured, locked, or persisted.
+    expect(captureSnapshotSpy).not.toHaveBeenCalled()
+    expect(updateArticleDraftSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article-section.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article-section.ts
@@ -8,6 +8,7 @@ import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { findRef } from '../../../context-refs'
 import type { GetToolDeps } from '../../types'
+import { canViewKb } from '../kb-access'
 
 /**
  * Reads a contiguous section of an article between two heading anchors
@@ -48,7 +49,7 @@ export function createGetArticleSectionTool(getDeps: GetToolDeps): AgentToolDefi
       return { ok: true, args: { ...args, headingText: h.value } }
     },
     execute: async (args, agentDeps) => {
-      const { db, sessionContext } = getDeps()
+      const { db, sessionContext, capabilities } = getDeps()
       const articleId = findRef(sessionContext, 'article')?.id
       if (!articleId) {
         return {
@@ -65,7 +66,14 @@ export function createGetArticleSectionTool(getDeps: GetToolDeps): AgentToolDefi
         ),
         with: { draftRevision: true },
       })
-      if (!article || !article.draftRevision) {
+      // The active-article ref is client-supplied, so re-check instance access
+      // here (permissions v2 §3.3). Silent filter — a KB the caller can't view
+      // reads as "not found", never a 403.
+      if (
+        !article ||
+        !article.draftRevision ||
+        !canViewKb(capabilities, article.homeKnowledgeBaseId)
+      ) {
         return { success: false, output: null, error: 'article not found' }
       }
       const content = (article.draftRevision.contentJson as ArticleNodeJSON[] | null) ?? []

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article.ts
@@ -5,6 +5,7 @@ import { parseArticleIdArg, parseStringArg } from '../../../../agent-framework/t
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { findRef } from '../../../context-refs'
 import type { GetToolDeps } from '../../types'
+import { canViewKb } from '../kb-access'
 import { buildActiveArticleSnapshot } from '../snapshot-pipeline'
 
 /**
@@ -95,7 +96,7 @@ export function createGetArticleTool(getDeps: GetToolDeps): AgentToolDefinition 
       return warnings.length > 0 ? { ok: true, args: out, warnings } : { ok: true, args: out }
     },
     execute: async (args, agentDeps) => {
-      const { db, sessionContext } = getDeps()
+      const { db, sessionContext, capabilities } = getDeps()
       const explicitId = args.articleId as string | undefined
       const slug = args.slug as string | undefined
       const knowledgeBaseId =
@@ -109,7 +110,7 @@ export function createGetArticleTool(getDeps: GetToolDeps): AgentToolDefinition 
           organizationId: agentDeps.organizationId,
           articleId,
         })
-        if (!snapshot) {
+        if (!snapshot || !canViewKb(capabilities, snapshot.knowledgeBaseId)) {
           return { success: false, output: null, error: `article "${articleId}" not found` }
         }
         return { success: true, output: snapshot }
@@ -132,7 +133,7 @@ export function createGetArticleTool(getDeps: GetToolDeps): AgentToolDefinition 
             organizationId: agentDeps.organizationId,
             articleId: article.id,
           })
-          if (!snapshot) {
+          if (!snapshot || !canViewKb(capabilities, snapshot.knowledgeBaseId)) {
             return { success: false, output: null, error: `article "${slug}" not found` }
           }
           return { success: true, output: snapshot }

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/list-articles.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/list-articles.ts
@@ -10,6 +10,7 @@ import { parseArticleIdArrayArg, parseStringArg } from '../../../../agent-framew
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { findRef } from '../../../context-refs'
 import type { GetToolDeps } from '../../types'
+import { canViewKb } from '../kb-access'
 
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
@@ -111,7 +112,7 @@ export function createListArticlesTool(getDeps: GetToolDeps): AgentToolDefinitio
       return { ok: true, args: out }
     },
     execute: async (args, agentDeps) => {
-      const { db, sessionContext } = getDeps()
+      const { db, sessionContext, capabilities } = getDeps()
       const requestedKb = args.knowledgeBaseId as string | undefined
       const activeKb = findRef(sessionContext, 'kb')?.id
       const scopeKbId: string | undefined = requestedKb ?? activeKb
@@ -132,7 +133,13 @@ export function createListArticlesTool(getDeps: GetToolDeps): AgentToolDefinitio
         getCachedEntityDefId(agentDeps.organizationId, 'article'),
       ])
 
-      let filtered = all
+      // Instance-access read gate (permissions v2 §3.3) — silent filter, so a
+      // restricted KB's articles simply don't appear (and don't count toward
+      // `total`), the same thing a human sees. Runs before the other filters so
+      // no unviewable row can survive any of them.
+      let filtered = capabilities
+        ? all.filter((a) => canViewKb(capabilities, a.knowledgeBaseId))
+        : all
       if (idFilter && idFilter.length > 0) {
         const idSet = new Set(idFilter)
         filtered = filtered.filter((a) => idSet.has(a.id))

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/resolve-block-by-heading.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/resolve-block-by-heading.ts
@@ -7,6 +7,7 @@ import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { findRef } from '../../../context-refs'
 import type { GetToolDeps } from '../../types'
+import { canViewKb } from '../kb-access'
 
 /**
  * Resolves a heading's text → block id. Useful when the agent is
@@ -43,7 +44,7 @@ export function createResolveBlockByHeadingTool(getDeps: GetToolDeps): AgentTool
       return { ok: true, args: { ...args, headingText: h.value } }
     },
     execute: async (args, agentDeps) => {
-      const { db, sessionContext } = getDeps()
+      const { db, sessionContext, capabilities } = getDeps()
       const articleId = findRef(sessionContext, 'article')?.id
       if (!articleId) {
         return { success: false, output: null, error: 'no active article' }
@@ -55,7 +56,14 @@ export function createResolveBlockByHeadingTool(getDeps: GetToolDeps): AgentTool
         ),
         with: { draftRevision: true },
       })
-      if (!article || !article.draftRevision) {
+      // The active-article ref is client-supplied, so re-check instance access
+      // here (permissions v2 §3.3). Silent filter — a KB the caller can't view
+      // reads as "not found", never a 403.
+      if (
+        !article ||
+        !article.draftRevision ||
+        !canViewKb(capabilities, article.homeKnowledgeBaseId)
+      ) {
         return { success: false, output: null, error: 'article not found' }
       }
       const content = (article.draftRevision.contentJson as ArticleNodeJSON[] | null) ?? []

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/write-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/write-helpers.ts
@@ -160,6 +160,15 @@ export async function runBlockCrudOp(args: {
     return { ok: false, error: 'article not found' }
   }
   const knowledgeBaseId = article.homeKnowledgeBaseId
+
+  // Instance-access write gate (permissions v2 §3.3): every KB write tool
+  // (`insert_blocks` / `replace_block` / `delete_blocks` / `move_blocks`, and
+  // `runMarkdownReplace` via `runPatchSequence`) funnels through here, so the
+  // assert lives at this single choke point — before the snapshot, the lock and
+  // the patch. Throws `ForbiddenError`, which the query loop surfaces as a tool
+  // error. Absent capabilities (workflow AI node) ⇒ unrestricted, as before.
+  toolDeps.capabilities?.assertEditInstance('kb', knowledgeBaseId)
+
   const draftJson = (article.draftRevision.contentJson as ArticleNodeJSON[] | null) ?? []
   const preHash = computeArticleJsonHash(draftJson)
 

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-capabilities.test.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-capabilities.test.ts
+//
+// Permissions v2 §3.3 (Phase C3): the searchable dataset set is filtered by
+// instance access — KB-backed datasets by `canViewInstance('kb', kbId)`,
+// standalone RAG datasets by `canViewInstance('dataset', id)`. Silent filter:
+// an empty set is a normal empty result, never a 403. Absent capabilities ⇒
+// unrestricted AND zero extra queries (the un-threaded workflow AI node must
+// issue exactly the same SQL it does today).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const searchSpy = vi.fn()
+vi.mock('../../../../../../datasets/services/search.service', () => ({
+  SearchService: { search: (...args: unknown[]) => searchSpy(...args) },
+}))
+
+import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../../agent-framework/types'
+import { createSearchKnowledgeTool } from '../search-knowledge'
+
+const KB_DATASET = 'ds_kb'
+const RAG_DATASET = 'ds_rag'
+const KB_ID = 'kb_1'
+
+/**
+ * Fake drizzle handle, discriminated by the SELECTed column set rather than by
+ * table identity — the `schema.*` objects are dual-loaded under Vitest, so
+ * `table === schema.X` is not reliable here (same reason the two pre-existing
+ * `search-knowledge.test.ts` cases fail at HEAD).
+ *
+ *  - `{ id, datasetId }` → the KB id ↔ datasetId map read by the access filter.
+ *  - `{ id }`            → the Dataset list (one KB-backed, one standalone RAG).
+ *
+ * `queries` records every `.from()` so we can prove the no-capabilities path
+ * issues no extra roundtrip.
+ */
+function makeFakeDb(queries: string[]) {
+  return {
+    select: (cols?: Record<string, unknown>) => ({
+      from: () => {
+        const isKbMap = Boolean(cols && 'id' in cols && 'datasetId' in cols)
+        queries.push(isKbMap ? 'kb-map' : 'datasets')
+        const rows = isKbMap
+          ? [{ id: KB_ID, datasetId: KB_DATASET }]
+          : [{ id: KB_DATASET }, { id: RAG_DATASET }]
+        return { where: () => Promise.resolve(rows) }
+      },
+    }),
+  }
+}
+
+/** All-permissive `CapabilityView`; override just the gate under test. */
+function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  const yes = () => true
+  const noop = () => {}
+  return {
+    can: yes,
+    has: yes,
+    assert: noop,
+    canWriteEntity: yes,
+    assertWriteEntity: noop,
+    canEditEntity: yes,
+    assertEditEntity: noop,
+    filterEditableDefIds: (ids: string[]) => ids,
+    canViewEntity: yes,
+    assertViewEntity: noop,
+    filterViewableDefIds: (ids: string[]) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: yes,
+    assertAdministerDef: noop,
+    canViewInstance: yes,
+    canEditInstance: yes,
+    canAdminInstance: yes,
+    assertViewInstance: noop,
+    assertEditInstance: noop,
+    assertAdminInstance: noop,
+    ...overrides,
+  }
+}
+
+function runTool(db: unknown, capabilities?: CapabilityView) {
+  const tool = createSearchKnowledgeTool(() => ({ db, capabilities }) as never)
+  const ctx = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+  return tool.execute({ query: 'how do I cancel', source: 'rag' }, ctx) as Promise<AgentToolResult>
+}
+
+/** The `datasetIds` actually handed to `SearchService.search`. */
+function searchedDatasetIds(): string[] | undefined {
+  const args = searchSpy.mock.calls[0]?.[0] as { datasetIds?: string[] } | undefined
+  return args?.datasetIds
+}
+
+beforeEach(() => {
+  searchSpy.mockReset()
+  searchSpy.mockResolvedValue({ results: [], total: 0, metrics: {} })
+})
+
+describe('search_knowledge — instance-access scope', () => {
+  it('without capabilities, searches every resolved dataset and adds no queries', async () => {
+    const queries: string[] = []
+    await runTool(makeFakeDb(queries), undefined)
+
+    expect(searchSpy).toHaveBeenCalledTimes(1)
+    expect(searchedDatasetIds()).toEqual([KB_DATASET, RAG_DATASET])
+    // Exactly one query — the dataset resolution. No access-filter roundtrip.
+    expect(queries).toEqual(['datasets'])
+  })
+
+  it('drops a KB-backed dataset whose KB is not viewable', async () => {
+    const capabilities = makeCapabilities({
+      canViewInstance: (key, instanceId) => !(key === 'kb' && instanceId === KB_ID),
+    })
+    await runTool(makeFakeDb([]), capabilities)
+
+    expect(searchSpy).toHaveBeenCalledTimes(1)
+    expect(searchedDatasetIds()).toEqual([RAG_DATASET])
+  })
+
+  it('drops a standalone RAG dataset that is not viewable', async () => {
+    const capabilities = makeCapabilities({
+      canViewInstance: (key, instanceId) => !(key === 'dataset' && instanceId === RAG_DATASET),
+    })
+    await runTool(makeFakeDb([]), capabilities)
+
+    expect(searchSpy).toHaveBeenCalledTimes(1)
+    expect(searchedDatasetIds()).toEqual([KB_DATASET])
+  })
+
+  it('returns the normal empty result (no throw) when everything is filtered out', async () => {
+    const capabilities = makeCapabilities({ canViewInstance: () => false })
+    const result = await runTool(makeFakeDb([]), capabilities)
+
+    expect(result.success).toBe(true)
+    expect(result.output).toEqual({
+      results: [],
+      count: 0,
+      message: 'No accessible datasets for this query',
+    })
+    expect(searchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -4,6 +4,7 @@ import { schema } from '@auxx/database'
 import { and, eq, inArray, isNotNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { SearchService } from '../../../../../datasets/services/search.service'
+import type { CapabilityView } from '../../../../../permissions/capabilities/capability-view'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { takeSample } from '../../../digests'
@@ -163,7 +164,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
       return { ok: true, args: { ...args, query: query.value } }
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const query = args.query as string
       const requestedSource = ((args.source as Source) ?? 'both') as Source
       const knowledgeBaseId = args.knowledgeBaseId as string | undefined
@@ -189,6 +190,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
           knowledgeBaseId,
           requestedDatasetIds,
           publicOnly: isChat,
+          capabilities,
         })
 
         if (datasetIds.length === 0) {
@@ -335,6 +337,37 @@ async function resolveDatasetIds(args: {
   requestedDatasetIds?: string[]
   /** Chat clamp — restrict managed datasets to PUBLIC knowledge bases. */
   publicOnly?: boolean
+  /** Resolved instance-access gate for the turn; absent ⇒ unrestricted. */
+  capabilities?: CapabilityView
+}): Promise<string[]> {
+  const {
+    db,
+    organizationId,
+    source,
+    knowledgeBaseId,
+    requestedDatasetIds,
+    publicOnly,
+    capabilities,
+  } = args
+
+  const ids = await collectDatasetIds({
+    db,
+    organizationId,
+    source,
+    knowledgeBaseId,
+    requestedDatasetIds,
+    publicOnly,
+  })
+  return filterAccessibleDatasetIds(db, organizationId, ids, capabilities)
+}
+
+async function collectDatasetIds(args: {
+  db: import('@auxx/database').Database
+  organizationId: string
+  source: Source
+  knowledgeBaseId?: string
+  requestedDatasetIds?: string[]
+  publicOnly?: boolean
 }): Promise<string[]> {
   const { db, organizationId, source, knowledgeBaseId, requestedDatasetIds, publicOnly } = args
 
@@ -374,6 +407,47 @@ async function resolveDatasetIds(args: {
       .then((rows) => rows.map((r) => r.id)),
   ])
   return [...new Set([...kb, ...rag])]
+}
+
+/**
+ * Instance-access read gate for the searchable set (permissions v2 §3.3, doc-11
+ * "Read = use in search/agents"). Every branch above funnels through here, so a
+ * dataset the principal can't view — or a managed dataset whose backing KB the
+ * principal can't view — never reaches `SearchService`.
+ *
+ * A KB-backed dataset is governed by its **KB** instance grant (that's the
+ * container an admin actually shares); only standalone RAG datasets fall back
+ * to the `dataset` key. Silent filter: an empty result is a normal empty search,
+ * never a 403.
+ *
+ * Zero extra I/O when `capabilities` is absent — the whole function
+ * short-circuits, so the un-threaded workflow AI node issues exactly the same
+ * queries it does today.
+ */
+async function filterAccessibleDatasetIds(
+  db: import('@auxx/database').Database,
+  organizationId: string,
+  datasetIds: string[],
+  capabilities?: CapabilityView
+): Promise<string[]> {
+  if (!capabilities || datasetIds.length === 0) return datasetIds
+
+  const kbRows = await db
+    .select({ id: schema.KnowledgeBase.id, datasetId: schema.KnowledgeBase.datasetId })
+    .from(schema.KnowledgeBase)
+    .where(eq(schema.KnowledgeBase.organizationId, organizationId))
+
+  const kbIdByDatasetId = new Map<string, string>()
+  for (const row of kbRows) {
+    if (row.datasetId) kbIdByDatasetId.set(row.datasetId, row.id)
+  }
+
+  return datasetIds.filter((datasetId) => {
+    const kbId = kbIdByDatasetId.get(datasetId)
+    return kbId
+      ? capabilities.canViewInstance('kb', kbId)
+      : capabilities.canViewInstance('dataset', datasetId)
+  })
 }
 
 async function collectManagedDatasetIds(

--- a/packages/lib/src/ai/kopilot/capabilities/learned/tools/upsert-learned-article.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/learned/tools/upsert-learned-article.ts
@@ -171,11 +171,16 @@ export function createUpsertLearnedArticleTool(getDeps: GetToolDeps): AgentToolD
       }
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const { organizationId, userId } = agentDeps
       const ctx = { db, organizationId }
 
       const { kb, categoryIds } = await ensureLearnedKb(ctx)
+
+      // Instance-access write gate (permissions v2 §3.3): the learned KB is a
+      // real KnowledgeBase, so writing AI memory needs Edit on that instance.
+      // Throws `ForbiddenError`; absent capabilities ⇒ unrestricted, as before.
+      capabilities?.assertEditInstance('kb', kb.id)
 
       const title = args.title as string
       const description = args.description as string

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/create-record-view.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/create-record-view.ts
@@ -33,12 +33,24 @@ Example: { name: "Open tickets", filters: [{ field: "status", operator: "is", va
         return { success: false, output: null, error: 'View name must be 50 characters or fewer.' }
       }
 
-      const { db, sessionContext } = getDeps()
+      const { db, sessionContext, capabilities } = getDeps()
       const target = await resolveRecordViewTarget(sessionContext, agentDeps.organizationId)
       if ('error' in target) {
         return { success: false, output: null, error: target.error }
       }
       const { resource, entityDefinitionId, tableId } = target
+
+      // Human parity (permissions v2 §3.3): the tRPC path gates view authoring on
+      // effective Read of the def (`tableView.create` → `assertViewAccess`), so the
+      // agent path must too — otherwise an agent restricted off a def could still
+      // author views on it. Absent capabilities ⇒ unrestricted, as before.
+      if (entityDefinitionId && capabilities && !capabilities.canViewEntity(entityDefinitionId)) {
+        return {
+          success: false,
+          output: null,
+          error: "You don't have permission to view these records.",
+        }
+      }
 
       const spec: ViewSpec = readViewSpec(args)
       const built = buildViewConfig(spec, resource, entityDefinitionId)

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/update-record-view.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/update-record-view.ts
@@ -42,12 +42,23 @@ Example: { viewId: "abc123", filters: [{ field: "status", operator: "is", value:
         return { success: false, output: null, error: 'View name must be 50 characters or fewer.' }
       }
 
-      const { db, sessionContext } = getDeps()
+      const { db, sessionContext, capabilities } = getDeps()
       const target = await resolveRecordViewTarget(sessionContext, agentDeps.organizationId)
       if ('error' in target) {
         return { success: false, output: null, error: target.error }
       }
       const { resource, entityDefinitionId, tableId } = target
+
+      // Human parity (permissions v2 §3.3): the tRPC path gates view authoring on
+      // effective Read of the def (`tableView.update` → `assertViewAccess`), so the
+      // agent path must too. Absent capabilities ⇒ unrestricted, as before.
+      if (entityDefinitionId && capabilities && !capabilities.canViewEntity(entityDefinitionId)) {
+        return {
+          success: false,
+          output: null,
+          error: "You don't have permission to view these records.",
+        }
+      }
 
       const spec: ViewSpec = readViewSpec(args)
       const built = buildViewConfigPatch(spec, resource, entityDefinitionId)

--- a/packages/lib/src/ai/kopilot/capabilities/types.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/types.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/types.ts
 
 import type { Database } from '@auxx/database'
-import type { CapabilitySet } from '../../../permissions/capabilities/capability-set'
+import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
 import type { AgentDeps, AgentToolDefinition } from '../../agent-framework/types'
 import type { SessionContext } from '../types'
 
@@ -20,7 +20,7 @@ export interface ToolDeps extends AgentDeps {
    * **absent for autonomous/visitor/workflow turns**, which stay unrestricted.
    * Entity tools that read records gate each def through `canViewEntity`.
    */
-  capabilities?: CapabilitySet
+  capabilities?: CapabilityView
 }
 
 /** Factory function that provides ToolDeps at execution time */

--- a/packages/lib/src/ai/kopilot/domain-config.ts
+++ b/packages/lib/src/ai/kopilot/domain-config.ts
@@ -4,6 +4,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { ResolvedAgentConfig } from '../../agents'
 import type { AgentSurface } from '../../agents/client'
 import { PROCEDURE_SLICE_KEY } from '../../agents/procedures/persist'
+import type { CapabilityView } from '../../permissions/capabilities/capability-view'
 import { CONTEXT_SLICE_KEY, readContextSlice } from '../agent-framework/context'
 import type {
   AgentDomainConfig,
@@ -69,6 +70,17 @@ export interface KopilotDomainConfigOptions {
    * prompt. Chat runs leave this undefined.
    */
   triggerContext?: TriggerContext
+  /**
+   * The turn's resolved read enforcement, used **prompt-side** (capability
+   * layer v2 §3.4): the entity catalog and the member-audience KB catalog the
+   * model is handed are narrowed to what this principal may actually read, so
+   * the system prompt stops leaking the existence (and KB article titles +
+   * descriptions) of data the tools would deny.
+   *
+   * Same object the tool deps get. Omit → no filtering, byte-identical prompt
+   * to today (workflow AI node, tests, any un-threaded caller).
+   */
+  capabilities?: CapabilityView
 }
 
 /**
@@ -93,6 +105,9 @@ export function createKopilotDomainConfig(
     surface,
     audience,
     triggerContext,
+    // Aliased: `capabilities` below is the string[] of capability *descriptions*
+    // rendered into the prompt — a different thing from the access gate.
+    capabilities: recordAccess,
   } = options
 
   // Cheap same-provider sibling for low-stakes internal LLM tasks (procedure
@@ -137,6 +152,7 @@ export function createKopilotDomainConfig(
     surface,
     audience,
     triggerContext,
+    recordAccess,
   })
 
   return {

--- a/packages/lib/src/ai/kopilot/prompts/__tests__/build-kopilot-prompt.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/__tests__/build-kopilot-prompt.test.ts
@@ -2,6 +2,9 @@
 
 import { describe, expect, it } from 'vitest'
 import type { ResolvedAgentConfig } from '../../../../agents'
+import type { KbCatalogEntry } from '../../../../kb/catalog/kb-catalog'
+import type { CapabilityView } from '../../../../permissions/capabilities/capability-view'
+import type { AgentToolDefinition } from '../../../agent-framework/types'
 import {
   fixtureCapabilities,
   fixtureCurrentUser,
@@ -157,5 +160,124 @@ describe('buildKopilotPrompt', () => {
     expect(out.indexOf('## Run mode')).toBeLessThan(out.indexOf('## Trigger instructions'))
     expect(out.indexOf('## Trigger instructions')).toBeLessThan(out.indexOf('## Acting as'))
     expect(out.indexOf('## Acting as')).toBeLessThan(out.indexOf('## Trigger fired'))
+  })
+})
+
+// ── Prompt-side catalog filtering (capability layer v2 §3.4) ──
+
+const kbFixture: KbCatalogEntry[] = [
+  {
+    id: 'kb_public',
+    name: 'Customer Help Center',
+    description: null,
+    kind: 'standard',
+    visibility: 'PUBLIC',
+    articles: [
+      {
+        id: 'a_1',
+        title: 'Refund policy',
+        description: 'How refunds work.',
+        kind: 'page',
+        depth: 0,
+      },
+    ],
+  },
+  {
+    id: 'kb_internal',
+    name: 'Internal Runbooks',
+    description: null,
+    kind: 'standard',
+    visibility: 'INTERNAL',
+    articles: [
+      {
+        id: 'a_2',
+        title: 'Escalation ladder',
+        description: 'Who to page at 3am.',
+        kind: 'page',
+        depth: 0,
+      },
+    ],
+  },
+]
+
+const knowledgeTools: AgentToolDefinition[] = [
+  ...fixtureTools,
+  {
+    name: 'get_article',
+    displayName: 'Get article',
+    description: 'Read a KB article.',
+    parameters: {},
+    execute: async () => ({ ok: true, value: null }) as never,
+  } as AgentToolDefinition,
+]
+
+/** CapabilityView stub — only the two gates the catalog sections consult are real. */
+function restrictedTo(defIds: string[], kbIds: string[]): CapabilityView {
+  const defs = new Set(defIds)
+  const kbs = new Set(kbIds)
+  return {
+    can: () => true,
+    has: () => true,
+    assert: () => {},
+    canWriteEntity: () => true,
+    assertWriteEntity: () => {},
+    canEditEntity: (id: string) => defs.has(id),
+    assertEditEntity: () => {},
+    filterEditableDefIds: (ids: string[]) => ids.filter((id) => defs.has(id)),
+    canViewEntity: (id: string) => defs.has(id),
+    assertViewEntity: () => {},
+    filterViewableDefIds: (ids: string[]) => ids.filter((id) => defs.has(id)),
+    viewAccessFor: () => undefined,
+    canAdministerDef: () => false,
+    assertAdministerDef: () => {},
+    canViewInstance: (_kind: string, id: string) => kbs.has(id),
+    canEditInstance: (_kind: string, id: string) => kbs.has(id),
+    canAdminInstance: () => false,
+    assertViewInstance: () => {},
+    assertEditInstance: () => {},
+    assertAdminInstance: () => {},
+  } as unknown as CapabilityView
+}
+
+describe('buildKopilotPrompt — recordAccess filtering (v2 §3.4)', () => {
+  const knowledgeArgs = { ...baseArgs, tools: knowledgeTools, kbCatalog: kbFixture }
+
+  it('undefined recordAccess renders exactly today’s prompt', () => {
+    const before = buildKopilotPrompt({ ...knowledgeArgs })
+    const after = buildKopilotPrompt({ ...knowledgeArgs, recordAccess: undefined })
+    expect(after).toBe(before)
+    expect(after).toContain('Internal Runbooks')
+    expect(after).toContain('Escalation ladder')
+  })
+
+  it('drops a KB the principal cannot view from the member-audience catalog', () => {
+    const out = buildKopilotPrompt({
+      ...knowledgeArgs,
+      recordAccess: restrictedTo(['def_contacts', 'def_companies'], ['kb_public']),
+    })
+    expect(out).toContain('Customer Help Center')
+    expect(out).toContain('Refund policy')
+    expect(out).not.toContain('Internal Runbooks')
+    expect(out).not.toContain('Escalation ladder')
+    expect(out).not.toContain('Who to page at 3am')
+  })
+
+  it('drops the whole Knowledge Catalog section when no KB survives', () => {
+    const out = buildKopilotPrompt({
+      ...knowledgeArgs,
+      recordAccess: restrictedTo(['def_contacts'], []),
+    })
+    expect(out).not.toContain('## Knowledge Catalog')
+  })
+
+  it('leaves the entity catalog alone — it is filtered upstream at hydration', () => {
+    // `entityCatalog` arrives pre-filtered from `createKopilotAgent`; the prompt
+    // builder must not double-filter (and must not drop entries when it can't).
+    const out = buildKopilotPrompt({
+      ...knowledgeArgs,
+      recordAccess: restrictedTo(['def_contacts'], ['kb_public']),
+    })
+    expect(out).toContain('**Contact**')
+    expect(out).toContain('**Company**')
   })
 })

--- a/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
@@ -5,6 +5,7 @@ import type { ResolvedAgentConfig } from '../../../agents'
 import type { AgentSurface } from '../../../agents/client'
 import type { IntegrationCatalogEntry } from '../../../cache/integration-catalog'
 import type { KbCatalogEntry } from '../../../kb/catalog/kb-catalog'
+import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
 import type { AgentToolDefinition } from '../../agent-framework/types'
 import type { KopilotDomainState } from '../types'
 import { SYSTEM_PROMPT_SECTIONS } from './sections/registry'
@@ -64,6 +65,18 @@ export interface BuildKopilotPromptArgs {
    * active; unset on free-form turns so `agentProcedureStep` renders `null`.
    */
   procedureStep?: ProcedureStepInput
+  /**
+   * The turn's resolved read enforcement (capability layer v2 §3.4). Sections
+   * that render org-wide catalogs consult it so the prompt can't advertise
+   * data the tools would deny — today the member-audience KB catalog
+   * (`canViewInstance('kb', id)`); the entity catalog is filtered upstream at
+   * hydration.
+   *
+   * Named apart from {@link BuildKopilotPromptArgs.capabilities}, which is the
+   * `string[]` of human-readable capability *descriptions*. Undefined ⇒ no
+   * filtering, byte-identical output to today.
+   */
+  recordAccess?: CapabilityView
 }
 
 /**
@@ -157,6 +170,7 @@ function buildPromptCtx(args: BuildKopilotPromptArgs): PromptCtx {
     instructionsReferences: args.instructionsReferences,
     triggerContext: args.triggerContext,
     procedureStep: args.procedureStep,
+    recordAccess: args.recordAccess,
   }
 }
 

--- a/packages/lib/src/ai/kopilot/prompts/sections/kb-catalog.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/kb-catalog.ts
@@ -9,6 +9,11 @@ import { ALL_MODES, type PromptSection } from './types'
  * (`get_article`) instead of leaning on chunk-level embedding search.
  * Customer-facing runs only see PUBLIC KBs — mirrors the `search_knowledge`
  * dataset clamp. See plans/kb/knowledge-retrieval-plan.md.
+ *
+ * Member-audience runs are additionally gated per KB by `ctx.recordAccess`
+ * (capability layer v2 §3.4). Without it the catalog handed a member the full
+ * ToC — titles plus body-derived descriptions — of every INTERNAL KB, including
+ * ones they hold no instance grant on.
  */
 export const kbCatalog: PromptSection = {
   id: 'kb-catalog',
@@ -19,9 +24,11 @@ export const kbCatalog: PromptSection = {
     const hasGetArticle = ctx.toolNames.has('get_article')
     // Without a way to read or search knowledge, the catalog is dead weight.
     if (!hasGetArticle && !ctx.toolNames.has('search_knowledge')) return null
+    const recordAccess = ctx.recordAccess
     return renderKbCatalog(ctx.kbCatalog, {
       publicOnly: ctx.audience === 'customer',
       hasGetArticle,
+      canViewKb: recordAccess ? (kbId) => recordAccess.canViewInstance('kb', kbId) : undefined,
     })
   },
 }

--- a/packages/lib/src/ai/kopilot/prompts/sections/types.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/types.ts
@@ -4,6 +4,7 @@ import type { ResolvedAgentConfig } from '../../../../agents'
 import type { AgentSurface } from '../../../../agents/client'
 import type { IntegrationCatalogEntry } from '../../../../cache/integration-catalog'
 import type { KbCatalogEntry } from '../../../../kb/catalog/kb-catalog'
+import type { CapabilityView } from '../../../../permissions/capabilities/capability-view'
 import type { AgentToolDefinition } from '../../../agent-framework/types'
 import type { KopilotDomainState } from '../../types'
 import type { CurrentUserInfo, EntityCatalogEntry } from '../shared-types'
@@ -101,6 +102,15 @@ export interface PromptCtx {
   readonly triggerContext: TriggerContext | undefined
   // Procedure stepper (Phase 3) — set by Phase 4 only while a frame is active.
   readonly procedureStep?: ProcedureStepInput
+  /**
+   * The turn's resolved read enforcement (capability layer v2 §3.4). Sections
+   * rendering org-wide catalogs filter by it so the prompt can't advertise data
+   * the tools would deny. Undefined ⇒ no filtering (today's output).
+   *
+   * Distinct from {@link PromptCtx.capabilities} — that is the `string[]` of
+   * human-readable capability descriptions.
+   */
+  readonly recordAccess?: CapabilityView
 }
 
 export interface PromptSection {

--- a/packages/lib/src/cache/accessor-map.ts
+++ b/packages/lib/src/cache/accessor-map.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/cache/accessor-map.ts
 
-import type { CustomFieldEntity, OrganizationRole, SeatType } from '@auxx/database/types'
+import type { CustomFieldEntity } from '@auxx/database/types'
 import type { Inbox } from '../inboxes/types'
 import type { Overage } from '../permissions/overage-detection-service'
 import type { FeatureMapObject } from '../permissions/types'
@@ -13,7 +13,12 @@ import type {
   RecordAccessor,
   ScalarAccessor,
 } from './accessors'
-import type { CachedSubscription, DehydratedOrgProfile, OrgMemberInfo } from './org-cache-keys'
+import type {
+  CachedSubscription,
+  DehydratedOrgProfile,
+  MemberRoleEntry,
+  OrgMemberInfo,
+} from './org-cache-keys'
 import type { CachedWorkflowApp } from './providers/workflow-apps-provider'
 
 /**
@@ -30,7 +35,7 @@ export interface OrgCacheAccessorMap {
   // Record-shaped
   entityDefs: RecordAccessor<string>
   entityDefSlugs: RecordAccessor<string>
-  memberRoleMap: RecordAccessor<{ role: OrganizationRole; seatType: SeatType }>
+  memberRoleMap: RecordAccessor<MemberRoleEntry>
   channelProviders: RecordAccessor<string>
   features: ScalarAccessor<FeatureMapObject>
 

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -92,6 +92,7 @@ export type {
   CachedSubscription,
   CachedSystemModelDefault,
   DehydratedOrgProfile,
+  MemberRoleEntry,
   OrgCacheDataMap,
   OrgCacheKeyName,
   OrgMemberInfo,

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -21,6 +21,7 @@ import type {
   OrganizationMemberInfo,
   OrganizationRole,
   SeatType,
+  UserType,
 } from '@auxx/database/types'
 import type { CompiledProcedure, TriggerExample } from '../agents/procedures/types'
 import type { ToolCategory } from '../ai/agent-framework/types'
@@ -47,6 +48,20 @@ export interface OrgMemberInfo extends OrganizationMemberInfo {
     image: string | null
     userType: string
   } | null
+}
+
+/**
+ * One entry of the `memberRoleMap` cache — the hot, per-user membership facts
+ * every permission path needs without touching the DB.
+ *
+ * `userType` carries the principal kind (`USER` | `SYSTEM` | `AGENT`) so
+ * capability composition can branch on agents (SET-semantics over an all-Full
+ * base, capability layer v2 §0.2) with no extra read.
+ */
+export interface MemberRoleEntry {
+  role: OrganizationRole
+  seatType: SeatType
+  userType: UserType
 }
 
 /** Dehydrated subscription shape (client-safe, serializable) */
@@ -176,6 +191,14 @@ export interface CachedAgent {
    * plans/kopilot/agents/dm/option-d-defer-user-plan.md.
    */
   userId: string | null
+  /**
+   * Optional **run-as delegation** — when set, every run of this agent resolves
+   * its capabilities from THIS user instead of the agent's own profile. The
+   * engine identity stays `userId`. See
+   * plans/permissions/v2/14-agent-permissions.md §0.6 and
+   * `resolveAgentRunCapabilities`.
+   */
+  runAsUserId: string | null
   createdById: string
   /** `null` while the builder hasn't named the agent yet. */
   name: string | null
@@ -492,7 +515,7 @@ export interface OrgCacheDataMap {
 
   // Membership & permissions
   members: OrgMemberInfo[]
-  memberRoleMap: Record<string, { role: OrganizationRole; seatType: SeatType }>
+  memberRoleMap: Record<string, MemberRoleEntry>
   hasPermissionGrants: boolean // whether the org has ANY PermissionGrant rows (composition fast path)
   restrictedEntityDefIds: string[] // entity defs with ≥1 type-level ResourceAccess grant (read-path enforcement §0)
   restrictedInstanceIds: string[] // instance ids with ≥1 instance-access ResourceAccess row (§1.3)
@@ -549,7 +572,8 @@ export const ORG_CACHE_KEY_CONFIG: Record<
 
   // Membership & permissions (24h TTL, invalidated on member events)
   members: { prefix: 'org:members', ttlSeconds: ONE_DAY },
-  memberRoleMap: { prefix: 'org:member-roles:v2', ttlSeconds: ONE_DAY },
+  // v3: + userType (agent capability composition, capability layer v2 §1).
+  memberRoleMap: { prefix: 'org:member-roles:v3', ttlSeconds: ONE_DAY },
   hasPermissionGrants: { prefix: 'org:has-permission-grants', ttlSeconds: ONE_DAY },
   restrictedEntityDefIds: { prefix: 'org:restricted-entity-def-ids', ttlSeconds: ONE_DAY },
   restrictedInstanceIds: { prefix: 'org:restricted-instance-ids', ttlSeconds: ONE_DAY },
@@ -563,7 +587,10 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   groups: { prefix: 'org:groups', ttlSeconds: ONE_DAY },
   groupMembers: { prefix: 'org:group-members', ttlSeconds: ONE_DAY },
   // Read per CRUD event by agent-trigger dispatch — same rationale as workflowApps.
-  agents: { prefix: 'org:agents', ttlSeconds: ONE_DAY, localTtlMs: 5_000 },
+  // v2: + runAsUserId (agent run-as delegation, capability layer v2 §3.1 —
+  // `resolveAgentRunCapabilities` reads it off the cached agent, so a stale
+  // blob would silently resolve the agent's own profile). Bump on shape changes.
+  agents: { prefix: 'org:agents:v2', ttlSeconds: ONE_DAY, localTtlMs: 5_000 },
   // v5: defaultLens/status normalized to scalars (were SINGLE_SELECT arrays —
   // poisoned strict lens comparisons). v4: + ownerUserId (§11 personal
   // accounts). v3: + isPersonal. v2: + defaultLens (mail-permissions §2.2).

--- a/packages/lib/src/cache/providers/agents-provider.ts
+++ b/packages/lib/src/cache/providers/agents-provider.ts
@@ -37,6 +37,7 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
         .select({
           id: schema.Agent.id,
           userId: schema.Agent.userId,
+          runAsUserId: schema.Agent.runAsUserId,
           createdById: schema.Agent.createdById,
           slug: schema.Agent.slug,
           description: schema.Agent.description,
@@ -209,6 +210,7 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
         return {
           id: row.id,
           userId: row.userId,
+          runAsUserId: row.runAsUserId ?? null,
           createdById: row.createdById,
           name,
           slug: row.slug,

--- a/packages/lib/src/cache/providers/members-provider.ts
+++ b/packages/lib/src/cache/providers/members-provider.ts
@@ -1,9 +1,9 @@
 // packages/lib/src/cache/providers/members-provider.ts
 
 import { schema } from '@auxx/database'
-import type { OrganizationRole, SeatType } from '@auxx/database/types'
+import type { UserType } from '@auxx/database/types'
 import { eq } from 'drizzle-orm'
-import type { OrgMemberInfo } from '../org-cache-keys'
+import type { MemberRoleEntry, OrgMemberInfo } from '../org-cache-keys'
 import type { CacheProvider } from '../org-cache-provider'
 
 /** Computes all org members with joined user info */
@@ -34,15 +34,25 @@ export const membersProvider: CacheProvider<OrgMemberInfo[]> = {
   },
 }
 
-/** Derives userId → { role, seatType } map from members (computed independently for independent invalidation) */
-export const memberRoleMapProvider: CacheProvider<
-  Record<string, { role: OrganizationRole; seatType: SeatType }>
-> = {
+/**
+ * Derives `userId → { role, seatType, userType }` from members (computed
+ * independently for independent invalidation).
+ *
+ * `userType` rides along so capability composition can branch on AGENT members
+ * without a second read (`composeUserCapabilities` uses SET-semantics over an
+ * all-Full base for agents — see capability layer v2 §0.2). The `User` join is a
+ * LEFT join, so a member row with no user row falls back to `'USER'`.
+ */
+export const memberRoleMapProvider: CacheProvider<Record<string, MemberRoleEntry>> = {
   async compute(orgId, db) {
     const members = await membersProvider.compute(orgId, db)
-    const map: Record<string, { role: OrganizationRole; seatType: SeatType }> = {}
+    const map: Record<string, MemberRoleEntry> = {}
     for (const m of members) {
-      map[m.userId] = { role: m.role, seatType: m.seatType }
+      map[m.userId] = {
+        role: m.role,
+        seatType: m.seatType,
+        userType: (m.user?.userType as UserType | undefined) ?? 'USER',
+      }
     }
     return map
   },

--- a/packages/lib/src/chat/agent/build-chat-engine-config.ts
+++ b/packages/lib/src/chat/agent/build-chat-engine-config.ts
@@ -9,7 +9,12 @@ import {
 } from '../../agents/bindings'
 import { ALL_SURFACES } from '../../agents/client'
 import { PROCEDURE_CONTROL_TOOLS } from '../../agents/procedures/control-tools'
-import { type AgentEngineConfig, createCallModel, type Subject } from '../../ai/agent-framework'
+import {
+  type AgentEngineConfig,
+  createCallModel,
+  resolveAgentRunCapabilities,
+  type Subject,
+} from '../../ai/agent-framework'
 import {
   createAppCapabilities,
   createCapabilityRegistry,
@@ -20,7 +25,7 @@ import {
   createToolDepsFactory,
 } from '../../ai/kopilot'
 import { ModelType } from '../../ai/providers/types'
-import { getCachedDefaultModel } from '../../cache/org-cache-helpers'
+import { getCachedAgentById, getCachedDefaultModel } from '../../cache/org-cache-helpers'
 import { createHandoffTool } from './tools/handoff'
 
 /** Split a `provider:model` string; null when unset / malformed. */
@@ -105,11 +110,21 @@ export async function buildChatEngineConfig(
     }
   }
 
+  // Capability layer v2 §3.1/§3.2: a visitor turn runs on the agent's own
+  // profile (or its run-as delegate) with NO invoker intersection — the visitor
+  // is not an org member and has no capabilities to intersect with. A broken
+  // run-as delegation throws and fails the turn loudly rather than widening it.
+  const cachedAgent = await getCachedAgentById(organizationId, agentId)
+  const capabilities = cachedAgent
+    ? await resolveAgentRunCapabilities({ agent: cachedAgent, organizationId })
+    : undefined
+
   const getToolDeps = createToolDepsFactory({
     organizationId,
     userId: agentUserId,
     sessionId,
     signal,
+    capabilities,
   })
 
   const registry = createCapabilityRegistry()
@@ -171,6 +186,8 @@ export async function buildChatEngineConfig(
     // chat ALWAYS serves a customer, so we never consult `agent.kind` here.
     surface: 'chat',
     audience: 'customer',
+    // Prompt-side catalog filtering (§3.4) — same view the tools enforce with.
+    capabilities,
     // No `triggerContext` — chat is not an AgentTrigger run; it stays
     // `runMode: 'interactive'` (the visitor is in the loop). The surface/audience
     // gates do the customer-facing work the trigger envelope used to.

--- a/packages/lib/src/jobs/agent/app-trigger-dispatch-job.ts
+++ b/packages/lib/src/jobs/agent/app-trigger-dispatch-job.ts
@@ -95,6 +95,10 @@ export async function dispatchAppTriggerToAgents(ctx: JobContext<AgentAppTrigger
     const filter = (match.config as { filter?: Record<string, unknown> } | null)?.filter
     if (!matchesFilter(filter, triggerData)) continue
 
+    // Fan-out only — `executeAgentAppTrigger` (app-trigger-job.ts) owns the
+    // `enqueueAgentJob` call and deliberately passes no `invokerUserId`: an app
+    // payload has no human in the loop, so the run uses the agent's own
+    // capability profile alone (capability layer v2 §0.5).
     await queue.add('executeAgentAppTrigger', {
       agentTriggerId: match.triggerId,
       agentId: match.agentId,

--- a/packages/lib/src/jobs/agent/app-trigger-job.ts
+++ b/packages/lib/src/jobs/agent/app-trigger-job.ts
@@ -112,6 +112,9 @@ export async function executeAgentAppTrigger(ctx: JobContext<AgentAppTriggerJobD
     agentTriggerId,
     approvalMode: 'auto',
     modelId: agent.modelId ?? undefined,
+    // No `invokerUserId`: an app/webhook payload has no human in the loop, so
+    // the run uses the agent's own capability profile alone (capability layer
+    // v2 §0.5). This is also the executor for webhook-endpoint dispatch.
   })
 
   logger.info('Enqueued autonomous app-trigger run', {

--- a/packages/lib/src/jobs/agent/assignment-trigger-job.ts
+++ b/packages/lib/src/jobs/agent/assignment-trigger-job.ts
@@ -15,14 +15,24 @@ export interface AgentAssignmentTriggerJobData {
   organizationId: string
   /** Canonical RecordId of the assigned ticket/thread (e.g. `ticket:abc`). */
   threadRecordId: string | null
-  /** User that performed the assignment — becomes runAsUser for user-scope tools. */
+  /**
+   * User that performed the assignment. The **intersection bound** on the run's
+   * capabilities (capability layer v2 §0.5) — never a run-as user. Nullable:
+   * a system-driven assignment carries none, and the run then uses the agent
+   * profile alone.
+   */
   assignerUserId: string | null
   firedAt: string
 }
 
 /**
  * Fires when an agent is assigned to a ticket via `ticket:assignee:added`.
- * The agent owns the session; the assigner is recorded in trigger context.
+ *
+ * The agent owns the run in every recorded sense — session row, engine
+ * identity, authorship. The assigner (`assignerUserId`) rides along as
+ * `invokerUserId`, so the run's effective permissions are
+ * `min(agentProfile, assigner)` and the agent can't read through an assignment
+ * what the assigner couldn't read themselves (capability layer v2 §0.5).
  */
 export async function executeAgentAssignmentTrigger(
   ctx: JobContext<AgentAssignmentTriggerJobData>
@@ -86,6 +96,9 @@ export async function executeAgentAssignmentTrigger(
     agentTriggerId,
     approvalMode: 'auto',
     modelId: agent.modelId ?? undefined,
+    // Human-triggered run — clamp capabilities to the assigner's (§0.5). Null
+    // (system assignment) leaves the agent profile alone.
+    invokerUserId: assignerUserId,
   })
 
   logger.info('Enqueued autonomous assignment-trigger run', {

--- a/packages/lib/src/jobs/agent/event-trigger-job.ts
+++ b/packages/lib/src/jobs/agent/event-trigger-job.ts
@@ -82,6 +82,10 @@ export async function executeAgentEventTrigger(ctx: JobContext<AgentEventTrigger
     agentTriggerId,
     approvalMode: 'auto',
     modelId: agent.modelId ?? undefined,
+    // No `invokerUserId` — deliberately NOT the editor whose change fired this
+    // event. Record rules are side effects; scoping them per-editor would make
+    // trigger behavior nondeterministic. Agent profile alone (capability layer
+    // v2 §0.5).
   })
 
   logger.info('Enqueued autonomous event-trigger run', {

--- a/packages/lib/src/jobs/agent/mention-trigger-job.ts
+++ b/packages/lib/src/jobs/agent/mention-trigger-job.ts
@@ -22,9 +22,15 @@ export interface AgentMentionTriggerJobData {
 }
 
 /**
- * Fires when an agent is referenced in a comment. The mentioner (`mentionerUserId`)
- * becomes the run-as user — user-scope tools resolve via their credentials —
- * while the agent itself still owns the session row (`userId` below).
+ * Fires when an agent is referenced in a comment.
+ *
+ * The agent owns the run in every sense that is recorded: the session row, the
+ * engine identity, and authorship are all `agent.userId`. The mentioner
+ * (`mentionerUserId`) is the **intersection bound** on the run's capabilities —
+ * it rides along as `invokerUserId` so the effective permissions are
+ * `min(agentProfile, mentioner)`, and the agent can never read something through
+ * a mention that the mentioner couldn't read themselves (capability layer v2
+ * §0.5). It is not a run-as user and never changes who the run "is".
  */
 export async function executeAgentMentionTrigger(ctx: JobContext<AgentMentionTriggerJobData>) {
   const job = ctx.job
@@ -100,6 +106,8 @@ export async function executeAgentMentionTrigger(ctx: JobContext<AgentMentionTri
     agentTriggerId,
     approvalMode: 'auto',
     modelId: agent.modelId ?? undefined,
+    // Human-triggered run — clamp capabilities to the mentioner's (§0.5).
+    invokerUserId: mentionerUserId,
   })
 
   logger.info('Enqueued autonomous mention-trigger run', {

--- a/packages/lib/src/jobs/agent/scheduled-trigger-job.ts
+++ b/packages/lib/src/jobs/agent/scheduled-trigger-job.ts
@@ -86,6 +86,8 @@ export async function executeAgentScheduledTrigger(ctx: JobContext<AgentSchedule
     agentTriggerId,
     approvalMode: 'auto',
     modelId: agent.modelId ?? undefined,
+    // No `invokerUserId`: a schedule has no human trigger, so the run uses the
+    // agent's own capability profile alone (capability layer v2 §0.5).
   })
 
   logger.info('Enqueued autonomous scheduled-trigger run', {

--- a/packages/lib/src/jobs/agent/webhook-endpoint-dispatch-job.ts
+++ b/packages/lib/src/jobs/agent/webhook-endpoint-dispatch-job.ts
@@ -75,6 +75,10 @@ export async function dispatchWebhookEndpointToAgents(
     const filter = (match.config as { filter?: Record<string, unknown> } | null)?.filter
     if (!matchesFilter(filter, triggerData)) continue
 
+    // Fan-out only — `executeAgentAppTrigger` (app-trigger-job.ts) owns the
+    // `enqueueAgentJob` call and deliberately passes no `invokerUserId`: a
+    // webhook payload has no human in the loop, so the run uses the agent's own
+    // capability profile alone (capability layer v2 §0.5).
     await queue.add('executeAgentAppTrigger', {
       agentTriggerId: match.triggerId,
       agentId: match.agentId,

--- a/packages/lib/src/kb/catalog/__tests__/kb-catalog.test.ts
+++ b/packages/lib/src/kb/catalog/__tests__/kb-catalog.test.ts
@@ -142,6 +142,26 @@ describe('renderKbCatalog', () => {
     expect(out).not.toContain('[p42]')
   })
 
+  it('drops KBs the principal cannot view (capability layer v2 §3.4)', () => {
+    const out = renderKbCatalog(catalog, {
+      publicOnly: false,
+      canViewKb: (id) => id === 'kb1',
+    })
+    expect(out).toContain('### Help Center')
+    expect(out).not.toContain('Internal Playbook')
+    expect(out).not.toContain('Escalations')
+  })
+
+  it('returns null when no KB survives the view gate', () => {
+    expect(renderKbCatalog(catalog, { publicOnly: false, canViewKb: () => false })).toBeNull()
+  })
+
+  it('omitting canViewKb is a no-op', () => {
+    expect(renderKbCatalog(catalog, { publicOnly: false, canViewKb: undefined })).toBe(
+      renderKbCatalog(catalog, { publicOnly: false })
+    )
+  })
+
   it('adapts the read hint when get_article is unavailable', () => {
     const withTool = renderKbCatalog(catalog, { publicOnly: false, hasGetArticle: true })
     const withoutTool = renderKbCatalog(catalog, { publicOnly: false, hasGetArticle: false })

--- a/packages/lib/src/kb/catalog/render-kb-catalog.ts
+++ b/packages/lib/src/kb/catalog/render-kb-catalog.ts
@@ -13,6 +13,14 @@ export interface RenderKbCatalogOptions {
   maxChars?: number
   /** Whether the run has `get_article` — drives the "how to read one" line. */
   hasGetArticle?: boolean
+  /**
+   * Per-instance read gate for the member audience (capability layer v2 §3.4).
+   * Applied on top of {@link RenderKbCatalogOptions.publicOnly}: a KB the
+   * principal can't VIEW is dropped entirely, so its article titles and
+   * body-derived descriptions never reach the model. Omit ⇒ no gating (today's
+   * output) — the workflow AI node and any un-threaded caller.
+   */
+  canViewKb?: (kbId: string) => boolean
 }
 
 const DEFAULT_MAX_CHARS = 8_000
@@ -27,10 +35,13 @@ export function renderKbCatalog(
   catalog: readonly KbCatalogEntry[],
   options: RenderKbCatalogOptions
 ): string | null {
-  const { publicOnly, maxChars = DEFAULT_MAX_CHARS, hasGetArticle = true } = options
+  const { publicOnly, maxChars = DEFAULT_MAX_CHARS, hasGetArticle = true, canViewKb } = options
 
   const kbs = catalog.filter(
-    (kb) => kb.articles.length > 0 && (!publicOnly || kb.visibility === 'PUBLIC')
+    (kb) =>
+      kb.articles.length > 0 &&
+      (!publicOnly || kb.visibility === 'PUBLIC') &&
+      (!canViewKb || canViewKb(kb.id))
   )
   if (kbs.length === 0) return null
 

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -4,6 +4,7 @@ import { ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { ForbiddenError } from '../../errors'
 import { satisfiesPermission } from '../../resource-access/constants'
+import type { CapabilityView } from './capability-view'
 import {
   type ClientCapabilities,
   canAdministerRecord,
@@ -35,7 +36,7 @@ export type DefIdToSlug = (entityDefId: string) => string
  * lookup — no guard issues its own fetch. This is a plain value object, not a
  * DB model, so it may carry behavior.
  */
-export class CapabilitySet {
+export class CapabilitySet implements CapabilityView {
   /**
    * @param keys       Materialized capability verbs the member holds (already seat-clamped).
    * @param defAccess  Highest type-level ResourceAccess permission per entity definition

--- a/packages/lib/src/permissions/capabilities/capability-view.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-view.test.ts
@@ -1,0 +1,251 @@
+// packages/lib/src/permissions/capabilities/capability-view.test.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import { describe, expect, it, vi } from 'vitest'
+import { ForbiddenError } from '../../errors'
+import type { CapabilityView } from './capability-view'
+import { intersectCapabilities, MinCapabilitySet } from './capability-view'
+import type { InstanceAccessKey } from './instance-access'
+import type { PermissionKey } from './registry'
+
+/**
+ * `MinCapabilitySet` is the intersection used for human-triggered agent runs
+ * (v2 §2): `min(agentProfile, invoker)`. These tests exercise it against
+ * hand-built stub views so the semantics are isolated from `CapabilitySet`'s
+ * own composition math.
+ */
+
+type Stub = {
+  keys?: PermissionKey[]
+  view?: string[]
+  edit?: string[]
+  write?: string[]
+  admin?: string[]
+  access?: Record<string, ResourcePermission>
+  instances?: string[]
+  label?: string
+}
+
+/** A minimal {@link CapabilityView} whose gates are plain allow-lists. */
+function stub(opts: Stub): CapabilityView {
+  const has = (list: string[] | undefined, id: string) => (list ?? []).includes(id)
+  const deny = (): never => {
+    throw new ForbiddenError(`denied by ${opts.label ?? 'stub'}`)
+  }
+  const self: CapabilityView = {
+    can: (key) => (opts.keys ?? []).includes(key),
+    has: (key) => (opts.keys ?? []).includes(key),
+    assert: (key) => {
+      if (!self.can(key)) deny()
+    },
+    canWriteEntity: (id) => has(opts.write, id),
+    assertWriteEntity: (id) => {
+      if (!self.canWriteEntity(id)) deny()
+    },
+    canEditEntity: (id) => has(opts.edit, id),
+    assertEditEntity: (id) => {
+      if (!self.canEditEntity(id)) deny()
+    },
+    filterEditableDefIds: (ids) => ids.filter((id) => self.canEditEntity(id)),
+    canViewEntity: (id) => has(opts.view, id),
+    assertViewEntity: (id) => {
+      if (!self.canViewEntity(id)) deny()
+    },
+    filterViewableDefIds: (ids) => ids.filter((id) => self.canViewEntity(id)),
+    viewAccessFor: (id) => opts.access?.[id],
+    canAdministerDef: (id) => has(opts.admin, id),
+    assertAdministerDef: (id) => {
+      if (!self.canAdministerDef(id)) deny()
+    },
+    canViewInstance: (_key, id) => has(opts.instances, id),
+    canEditInstance: (_key, id) => has(opts.instances, id),
+    canAdminInstance: (_key, id) => has(opts.instances, id),
+    assertViewInstance: (key, id) => {
+      if (!self.canViewInstance(key, id)) deny()
+    },
+    assertEditInstance: (key, id) => {
+      if (!self.canEditInstance(key, id)) deny()
+    },
+    assertAdminInstance: (key, id) => {
+      if (!self.canAdminInstance(key, id)) deny()
+    },
+  }
+  return self
+}
+
+const KEY_A = 'records.view' as PermissionKey
+const KEY_B = 'records.edit' as PermissionKey
+const DATASET = 'dataset' as InstanceAccessKey
+
+describe('MinCapabilitySet — boolean gates are AND', () => {
+  it('a gate passes only when BOTH sides pass', () => {
+    const a = stub({ keys: [KEY_A, KEY_B], view: ['def_1', 'def_2'], edit: ['def_1'] })
+    const b = stub({ keys: [KEY_A], view: ['def_2', 'def_3'], edit: ['def_1', 'def_2'] })
+    const min = new MinCapabilitySet(a, b)
+
+    expect(min.can(KEY_A)).toBe(true)
+    expect(min.can(KEY_B)).toBe(false) // only a
+    expect(min.has(KEY_B)).toBe(false)
+
+    expect(min.canViewEntity('def_2')).toBe(true)
+    expect(min.canViewEntity('def_1')).toBe(false) // only a
+    expect(min.canViewEntity('def_3')).toBe(false) // only b
+    expect(min.canEditEntity('def_1')).toBe(true)
+    expect(min.canEditEntity('def_2')).toBe(false)
+  })
+
+  it('an all-permissive side (the admin-bypass case) cannot lift a restricted side', () => {
+    // `a` mimics an ADMIN invoker: every gate true. `b` mimics a locked-down agent.
+    const admin: CapabilityView = new Proxy(stub({}), {
+      get(_t, prop) {
+        if (typeof prop === 'string' && prop.startsWith('can')) return () => true
+        if (typeof prop === 'string' && prop.startsWith('assert')) return () => undefined
+        if (prop === 'viewAccessFor') return () => 'admin' as ResourcePermission
+        if (prop === 'filterViewableDefIds' || prop === 'filterEditableDefIds')
+          return (ids: string[]) => ids
+        return () => true
+      },
+    })
+    const agent = stub({ view: ['def_ok'], label: 'agent' })
+
+    const min = new MinCapabilitySet(admin, agent)
+    expect(min.canViewEntity('def_ok')).toBe(true)
+    expect(min.canViewEntity('def_secret')).toBe(false)
+    // ...and the reverse ordering behaves identically.
+    expect(new MinCapabilitySet(agent, admin).canViewEntity('def_secret')).toBe(false)
+  })
+
+  it('instance gates AND across both sides', () => {
+    const a = stub({ instances: ['ds_1', 'ds_2'] })
+    const b = stub({ instances: ['ds_2'] })
+    const min = new MinCapabilitySet(a, b)
+    expect(min.canViewInstance(DATASET, 'ds_2')).toBe(true)
+    expect(min.canEditInstance(DATASET, 'ds_1')).toBe(false)
+    expect(min.canAdminInstance(DATASET, 'ds_1')).toBe(false)
+  })
+
+  it('canWriteEntity / canAdministerDef AND across both sides', () => {
+    const a = stub({ write: ['def_1'], admin: ['def_1', 'def_2'] })
+    const b = stub({ write: ['def_1', 'def_2'], admin: ['def_2'] })
+    const min = new MinCapabilitySet(a, b)
+    expect(min.canWriteEntity('def_1')).toBe(true)
+    expect(min.canWriteEntity('def_2')).toBe(false)
+    expect(min.canAdministerDef('def_2')).toBe(true)
+    expect(min.canAdministerDef('def_1')).toBe(false)
+  })
+})
+
+describe('MinCapabilitySet.viewAccessFor — level min', () => {
+  it('returns the LOWER of the two by PERMISSION_RANK, either ordering', () => {
+    const a = stub({ access: { def_1: 'admin', def_2: 'view' } })
+    const b = stub({ access: { def_1: 'edit', def_2: 'admin' } })
+    expect(new MinCapabilitySet(a, b).viewAccessFor('def_1')).toBe('edit')
+    expect(new MinCapabilitySet(b, a).viewAccessFor('def_1')).toBe('edit')
+    expect(new MinCapabilitySet(a, b).viewAccessFor('def_2')).toBe('view')
+  })
+
+  it('is undefined when EITHER side has no type-level grant', () => {
+    const a = stub({ access: { def_1: 'admin' } })
+    const b = stub({ access: {} })
+    expect(new MinCapabilitySet(a, b).viewAccessFor('def_1')).toBeUndefined()
+    expect(new MinCapabilitySet(b, a).viewAccessFor('def_1')).toBeUndefined()
+  })
+
+  it("keeps an explicit 'none' row (it is a real, lowest-rank level)", () => {
+    const a = stub({ access: { def_1: 'none' } })
+    const b = stub({ access: { def_1: 'admin' } })
+    expect(new MinCapabilitySet(a, b).viewAccessFor('def_1')).toBe('none')
+  })
+})
+
+describe('MinCapabilitySet filters — intersection', () => {
+  it('filterViewableDefIds keeps only ids both sides allow, preserving order', () => {
+    const a = stub({ view: ['def_1', 'def_2', 'def_3'] })
+    const b = stub({ view: ['def_3', 'def_2'] })
+    expect(new MinCapabilitySet(a, b).filterViewableDefIds(['def_1', 'def_2', 'def_3'])).toEqual([
+      'def_2',
+      'def_3',
+    ])
+  })
+
+  it('filterEditableDefIds keeps only ids both sides allow', () => {
+    const a = stub({ edit: ['def_1', 'def_2'] })
+    const b = stub({ edit: ['def_2', 'def_9'] })
+    expect(new MinCapabilitySet(a, b).filterEditableDefIds(['def_1', 'def_2', 'def_9'])).toEqual([
+      'def_2',
+    ])
+  })
+
+  it('returns an empty array when the sides are disjoint', () => {
+    const a = stub({ view: ['def_1'] })
+    const b = stub({ view: ['def_2'] })
+    expect(new MinCapabilitySet(a, b).filterViewableDefIds(['def_1', 'def_2'])).toEqual([])
+  })
+})
+
+describe('MinCapabilitySet assert* — delegates to BOTH sides', () => {
+  it("throws from the FIRST failing side with that side's own message", () => {
+    const a = stub({ view: [], label: 'a' })
+    const b = stub({ view: [], label: 'b' })
+    expect(() => new MinCapabilitySet(a, b).assertViewEntity('def_1')).toThrow('denied by a')
+    expect(() => new MinCapabilitySet(b, a).assertViewEntity('def_1')).toThrow('denied by b')
+  })
+
+  it('throws from `b` when only `b` denies (and `a` was still consulted)', () => {
+    const a = stub({ edit: ['def_1'], label: 'a' })
+    const b = stub({ edit: [], label: 'b' })
+    const aAssert = vi.spyOn(a, 'assertEditEntity')
+    expect(() => new MinCapabilitySet(a, b).assertEditEntity('def_1')).toThrow('denied by b')
+    expect(aAssert).toHaveBeenCalledWith('def_1')
+  })
+
+  it('does not throw when both sides allow, and calls both', () => {
+    const a = stub({ keys: [KEY_A], label: 'a' })
+    const b = stub({ keys: [KEY_A], label: 'b' })
+    const aAssert = vi.spyOn(a, 'assert')
+    const bAssert = vi.spyOn(b, 'assert')
+    expect(() => new MinCapabilitySet(a, b).assert(KEY_A)).not.toThrow()
+    expect(aAssert).toHaveBeenCalledTimes(1)
+    expect(bAssert).toHaveBeenCalledTimes(1)
+  })
+
+  it('every assert* surface delegates (write / administer / instance)', () => {
+    const permissive = stub({
+      write: ['def_1'],
+      admin: ['def_1'],
+      instances: ['ds_1'],
+      label: 'p',
+    })
+    const restrictive = stub({ label: 'r' })
+    const min = new MinCapabilitySet(permissive, restrictive)
+    expect(() => min.assertWriteEntity('def_1')).toThrow('denied by r')
+    expect(() => min.assertAdministerDef('def_1')).toThrow('denied by r')
+    expect(() => min.assertViewInstance(DATASET, 'ds_1')).toThrow('denied by r')
+    expect(() => min.assertEditInstance(DATASET, 'ds_1')).toThrow('denied by r')
+    expect(() => min.assertAdminInstance(DATASET, 'ds_1')).toThrow('denied by r')
+  })
+})
+
+describe('intersectCapabilities', () => {
+  it('short-circuits to the same object when a === b', () => {
+    const a = stub({ view: ['def_1'] })
+    expect(intersectCapabilities(a, a)).toBe(a)
+  })
+
+  it('wraps in a MinCapabilitySet when the sides differ', () => {
+    const a = stub({ view: ['def_1', 'def_2'] })
+    const b = stub({ view: ['def_2'] })
+    const composed = intersectCapabilities(a, b)
+    expect(composed).toBeInstanceOf(MinCapabilitySet)
+    expect(composed.canViewEntity('def_1')).toBe(false)
+    expect(composed.canViewEntity('def_2')).toBe(true)
+  })
+
+  it('composes associatively for three sides', () => {
+    const a = stub({ view: ['def_1', 'def_2', 'def_3'] })
+    const b = stub({ view: ['def_2', 'def_3'] })
+    const c = stub({ view: ['def_3'] })
+    const composed = intersectCapabilities(intersectCapabilities(a, b), c)
+    expect(composed.filterViewableDefIds(['def_1', 'def_2', 'def_3'])).toEqual(['def_3'])
+  })
+})

--- a/packages/lib/src/permissions/capabilities/capability-view.ts
+++ b/packages/lib/src/permissions/capabilities/capability-view.ts
@@ -1,0 +1,214 @@
+// packages/lib/src/permissions/capabilities/capability-view.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import { PERMISSION_RANK } from './compose-user-capabilities'
+import type { InstanceAccessKey } from './instance-access'
+import type { PermissionKey } from './registry'
+
+/**
+ * The public **gate surface** of a resolved capability set (capability layer
+ * v2 §2) — every read/write/instance check an enforcement point may call,
+ * with none of the construction or serialization detail.
+ *
+ * Extracted so a gate can be satisfied by something other than a single member's
+ * {@link import('./capability-set').CapabilitySet} — specifically
+ * {@link MinCapabilitySet}, the intersection used for human-triggered agent runs.
+ * Everything downstream of a gate (tool deps, the CRUD handler, the record
+ * picker) is typed to this interface; only callers that *serialize* a capability
+ * set to the client (`toClientCapabilities`) or branch on the member's `role`
+ * keep a concrete `CapabilitySet`.
+ *
+ * Every member is **zero I/O** — in-memory Set/map lookups only.
+ */
+export interface CapabilityView {
+  /** O(1) — whether the principal holds `key`. */
+  can(key: PermissionKey): boolean
+  /** Alias for {@link CapabilityView.can}. */
+  has(key: PermissionKey): boolean
+  /** Throwing form of {@link CapabilityView.can} (403). */
+  assert(key: PermissionKey): void
+
+  /** Coarse Layer-2 write verb for a def (mail-infra + dedicated write keys). */
+  canWriteEntity(entityDefId: string): boolean
+  /** Throwing form of {@link CapabilityView.canWriteEntity} (403). */
+  assertWriteEntity(entityDefId: string): void
+
+  /** Whether the principal may create/update/delete records of the def. */
+  canEditEntity(entityDefId: string): boolean
+  /** Throwing form of {@link CapabilityView.canEditEntity} (403). */
+  assertEditEntity(entityDefId: string): void
+  /** Filter RecordId-def forms down to the editable ones. */
+  filterEditableDefIds(entityDefIds: string[]): string[]
+
+  /** Whether the principal may read records of the def. */
+  canViewEntity(entityDefId: string): boolean
+  /** Throwing form of {@link CapabilityView.canViewEntity} (403). */
+  assertViewEntity(entityDefId: string): void
+  /** Filter RecordId-def forms down to the viewable ones. */
+  filterViewableDefIds(entityDefIds: string[]): string[]
+
+  /** Highest type-level ResourceAccess permission for the def, or `undefined`. */
+  viewAccessFor(entityDefId: string): ResourcePermission | undefined
+
+  /** Whether the principal may administer the definition itself (Full rung). */
+  canAdministerDef(entityDefId: string): boolean
+  /** Throwing form of {@link CapabilityView.canAdministerDef} (403). */
+  assertAdministerDef(entityDefId: string): void
+
+  /** Whether the principal may VIEW an instance-access resource instance. */
+  canViewInstance(key: InstanceAccessKey, instanceId: string): boolean
+  /** Whether the principal may EDIT an instance-access resource instance. */
+  canEditInstance(key: InstanceAccessKey, instanceId: string): boolean
+  /** Whether the principal may ADMINISTER an instance-access resource instance. */
+  canAdminInstance(key: InstanceAccessKey, instanceId: string): boolean
+  /** Throwing form of {@link CapabilityView.canViewInstance} (403). */
+  assertViewInstance(key: InstanceAccessKey, instanceId: string): void
+  /** Throwing form of {@link CapabilityView.canEditInstance} (403). */
+  assertEditInstance(key: InstanceAccessKey, instanceId: string): void
+  /** Throwing form of {@link CapabilityView.canAdminInstance} (403). */
+  assertAdminInstance(key: InstanceAccessKey, instanceId: string): void
+}
+
+/**
+ * The pointwise **intersection** of two capability views (capability layer v2 §2):
+ * every boolean gate is `a && b`, every level is the lower of the two, every
+ * filter is the intersection of both filters.
+ *
+ * Used for human-triggered agent runs (mention / assignment / interactive DM):
+ * effective capabilities = `min(agentProfile, invoker)`, so a mention can never
+ * read data through an agent that the mentioner couldn't read themselves
+ * (confused-deputy closed, §0.5).
+ *
+ * Two properties worth stating explicitly:
+ *
+ * - **Admin bypass composes for free.** `CapabilitySet` short-circuits OWNER/ADMIN
+ *   to `true`/`admin` internally, so an ADMIN invoker contributes `true` on every
+ *   gate — which by `&&` cannot override a restricted agent's `false`. The
+ *   converse holds too: an all-Full agent profile cannot lift a restricted human.
+ *   Neither side needs to know the other's role.
+ * - **`assert*` calls BOTH sides**, in `a`-then-`b` order, so the first failing
+ *   side throws its own `ForbiddenError` with its own message. There is no merged
+ *   error type, and no side is silently skipped once the other passes.
+ *
+ * Blob merging is deliberately NOT how this is computed: effective levels depend
+ * on each set's own base + restricted-def/instance context, so only the resolved
+ * gates can be safely intersected.
+ */
+export class MinCapabilitySet implements CapabilityView {
+  /**
+   * @param a First view (asserts fire from this side first).
+   * @param b Second view.
+   */
+  constructor(
+    private readonly a: CapabilityView,
+    private readonly b: CapabilityView
+  ) {}
+
+  can(key: PermissionKey): boolean {
+    return this.a.can(key) && this.b.can(key)
+  }
+
+  has(key: PermissionKey): boolean {
+    return this.a.has(key) && this.b.has(key)
+  }
+
+  assert(key: PermissionKey): void {
+    this.a.assert(key)
+    this.b.assert(key)
+  }
+
+  canWriteEntity(entityDefId: string): boolean {
+    return this.a.canWriteEntity(entityDefId) && this.b.canWriteEntity(entityDefId)
+  }
+
+  assertWriteEntity(entityDefId: string): void {
+    this.a.assertWriteEntity(entityDefId)
+    this.b.assertWriteEntity(entityDefId)
+  }
+
+  canEditEntity(entityDefId: string): boolean {
+    return this.a.canEditEntity(entityDefId) && this.b.canEditEntity(entityDefId)
+  }
+
+  assertEditEntity(entityDefId: string): void {
+    this.a.assertEditEntity(entityDefId)
+    this.b.assertEditEntity(entityDefId)
+  }
+
+  filterEditableDefIds(entityDefIds: string[]): string[] {
+    return entityDefIds.filter((id) => this.canEditEntity(id))
+  }
+
+  canViewEntity(entityDefId: string): boolean {
+    return this.a.canViewEntity(entityDefId) && this.b.canViewEntity(entityDefId)
+  }
+
+  assertViewEntity(entityDefId: string): void {
+    this.a.assertViewEntity(entityDefId)
+    this.b.assertViewEntity(entityDefId)
+  }
+
+  filterViewableDefIds(entityDefIds: string[]): string[] {
+    return entityDefIds.filter((id) => this.canViewEntity(id))
+  }
+
+  /**
+   * The LOWER of the two type-level permissions by {@link PERMISSION_RANK}.
+   * `undefined` (no type-level grant at all) is the absorbing value: if either
+   * side has no grant, the intersection has none.
+   */
+  viewAccessFor(entityDefId: string): ResourcePermission | undefined {
+    const left = this.a.viewAccessFor(entityDefId)
+    if (left === undefined) return undefined
+    const right = this.b.viewAccessFor(entityDefId)
+    if (right === undefined) return undefined
+    return PERMISSION_RANK[left] <= PERMISSION_RANK[right] ? left : right
+  }
+
+  canAdministerDef(entityDefId: string): boolean {
+    return this.a.canAdministerDef(entityDefId) && this.b.canAdministerDef(entityDefId)
+  }
+
+  assertAdministerDef(entityDefId: string): void {
+    this.a.assertAdministerDef(entityDefId)
+    this.b.assertAdministerDef(entityDefId)
+  }
+
+  canViewInstance(key: InstanceAccessKey, instanceId: string): boolean {
+    return this.a.canViewInstance(key, instanceId) && this.b.canViewInstance(key, instanceId)
+  }
+
+  canEditInstance(key: InstanceAccessKey, instanceId: string): boolean {
+    return this.a.canEditInstance(key, instanceId) && this.b.canEditInstance(key, instanceId)
+  }
+
+  canAdminInstance(key: InstanceAccessKey, instanceId: string): boolean {
+    return this.a.canAdminInstance(key, instanceId) && this.b.canAdminInstance(key, instanceId)
+  }
+
+  assertViewInstance(key: InstanceAccessKey, instanceId: string): void {
+    this.a.assertViewInstance(key, instanceId)
+    this.b.assertViewInstance(key, instanceId)
+  }
+
+  assertEditInstance(key: InstanceAccessKey, instanceId: string): void {
+    this.a.assertEditInstance(key, instanceId)
+    this.b.assertEditInstance(key, instanceId)
+  }
+
+  assertAdminInstance(key: InstanceAccessKey, instanceId: string): void {
+    this.a.assertAdminInstance(key, instanceId)
+    this.b.assertAdminInstance(key, instanceId)
+  }
+}
+
+/**
+ * Compose two capability views into their intersection (capability layer v2 §2).
+ *
+ * Returns `a` unchanged when both sides are the same object — the common case
+ * for an agent whose run-as user IS the invoker, and for any path that resolves
+ * one set and passes it twice. Otherwise wraps in a {@link MinCapabilitySet}.
+ */
+export function intersectCapabilities(a: CapabilityView, b: CapabilityView): CapabilityView {
+  return a === b ? a : new MinCapabilitySet(a, b)
+}

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -2,8 +2,8 @@
 
 import { describe, expect, it } from 'vitest'
 import { composeUserCapabilities } from './compose-user-capabilities'
-import { Area, Level, PermissionKey } from './registry'
-import { effectiveDefault, WORKER_SEAT_KEYS } from './seat-policy'
+import { Area, Level, PERMISSION_AREAS, PermissionKey } from './registry'
+import { ALL_KEYS, effectiveDefault, WORKER_SEAT_KEYS } from './seat-policy'
 
 const sorted = (keys: PermissionKey[]) => [...keys].sort()
 
@@ -191,6 +191,32 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     expect(caps.keys).toEqual([])
   })
 
+  it('human composition is byte-for-byte unchanged when userType is passed explicitly', () => {
+    // Every human userType must produce EXACTLY the legacy (no-userType) result.
+    const legacy = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      orgPolicyLevels: { [Area.records]: Level.Read },
+      groupLevels: [{ [Area.records]: Level.Full, [Area.workflows]: Level.None }],
+      userLevels: { [Area.knowledgeBase]: Level.Full },
+      typeAccessRows: [{ entityDefinitionId: 'def_a', permission: 'edit' }],
+      instanceAccessRows: [{ entityInstanceId: 'inst_a', permission: 'none' }],
+    })
+    for (const userType of ['USER', 'SYSTEM'] as const) {
+      const withType = composeUserCapabilities({
+        role: 'USER',
+        seatType: 'full',
+        userType,
+        orgPolicyLevels: { [Area.records]: Level.Read },
+        groupLevels: [{ [Area.records]: Level.Full, [Area.workflows]: Level.None }],
+        userLevels: { [Area.knowledgeBase]: Level.Full },
+        typeAccessRows: [{ entityDefinitionId: 'def_a', permission: 'edit' }],
+        instanceAccessRows: [{ entityInstanceId: 'inst_a', permission: 'none' }],
+      })
+      expect(withType).toEqual(legacy)
+    }
+  })
+
   it('is JSON-serializable (cache round-trip)', () => {
     const caps = composeUserCapabilities({
       role: 'ADMIN',
@@ -198,5 +224,129 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
       typeAccessRows: [{ entityDefinitionId: 'def_a', permission: 'edit' }],
     })
     expect(JSON.parse(JSON.stringify(caps))).toEqual(caps)
+  })
+})
+
+/** Every PermissionKey the `records` area can confer (any rung). */
+const RECORDS_KEYS = PERMISSION_AREAS[Area.records].rungs.flatMap((r) => r.keys)
+
+describe('composeUserCapabilities — AGENT branch (SET-semantics over all-Full, §0.2/§0.3)', () => {
+  it('(a) an agent with no grants holds every key (all-Full base)', () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      typeAccessRows: [],
+    })
+    expect(sorted(caps.keys)).toEqual(sorted(ALL_KEYS))
+    // Explicitly: the human USER default would NOT include these.
+    expect(caps.keys).toContain(PermissionKey.settingsManage)
+    expect(caps.keys).toContain(PermissionKey.recordsDelete)
+  })
+
+  it('(b) an explicit { records: None } user grant LOWERS records, leaving everything else Full', () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      userLevels: { [Area.records]: Level.None },
+      typeAccessRows: [],
+    })
+    for (const key of RECORDS_KEYS) expect(caps.keys).not.toContain(key)
+    // Every other key survives.
+    const expected = ALL_KEYS.filter((k) => !RECORDS_KEYS.includes(k))
+    expect(sorted(caps.keys)).toEqual(sorted(expected))
+  })
+
+  it('(b2) an explicit intermediate level SETS (does not raise) — records: Read keeps only the Read rung', () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      userLevels: { [Area.records]: Level.Read },
+      typeAccessRows: [],
+    })
+    expect(caps.keys).toContain(PermissionKey.recordsView)
+    expect(caps.keys).not.toContain(PermissionKey.recordsEdit)
+    expect(caps.keys).not.toContain(PermissionKey.recordsDelete)
+  })
+
+  it('(c) an org_member policy clamping records to None does NOT reach an agent', () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      orgPolicyLevels: { [Area.records]: Level.None, [Area.workflows]: Level.Read },
+      typeAccessRows: [],
+    })
+    expect(sorted(caps.keys)).toEqual(sorted(ALL_KEYS))
+    expect(caps.keys).toContain(PermissionKey.recordsDelete)
+  })
+
+  it('(d) group levels are ignored for agents (neither raise nor lower)', () => {
+    const lowering = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      groupLevels: [{ [Area.records]: Level.None }, { [Area.knowledgeBase]: Level.Read }],
+      typeAccessRows: [],
+    })
+    expect(sorted(lowering.keys)).toEqual(sorted(ALL_KEYS))
+
+    // A group can't rescue an area the agent's own grant set to None either.
+    const restricted = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      userLevels: { [Area.records]: Level.None },
+      groupLevels: [{ [Area.records]: Level.Full }],
+      typeAccessRows: [],
+    })
+    expect(restricted.keys).not.toContain(PermissionKey.recordsView)
+  })
+
+  it('still fails closed for an agent with no OrganizationMember row', () => {
+    const caps = composeUserCapabilities({
+      role: undefined,
+      seatType: 'full',
+      userType: 'AGENT',
+      typeAccessRows: [],
+    })
+    expect(caps.keys).toEqual([])
+  })
+
+  it('the seat ceiling still clamps last (worker seat wins over the all-Full base)', () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'worker',
+      userType: 'AGENT',
+      typeAccessRows: [],
+    })
+    expect(sorted(caps.keys)).toEqual(sorted(WORKER_SEAT_KEYS))
+  })
+
+  it('defAccess / instanceAccess compose exactly as they do for humans', () => {
+    const rows = {
+      typeAccessRows: [
+        { entityDefinitionId: 'def_a', permission: 'view' as const },
+        { entityDefinitionId: 'def_a', permission: 'admin' as const },
+        { entityDefinitionId: 'def_locked', permission: 'none' as const },
+      ],
+      instanceAccessRows: [
+        { entityInstanceId: 'inst_a', permission: 'none' as const },
+        { entityInstanceId: 'inst_b', permission: 'edit' as const },
+      ],
+    }
+    const agent = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      ...rows,
+    })
+    const human = composeUserCapabilities({ role: 'USER', seatType: 'full', ...rows })
+    expect(agent.defAccess).toEqual(human.defAccess)
+    expect(agent.instanceAccess).toEqual(human.instanceAccess)
+    expect(agent.defAccess).toEqual({ def_a: 'admin' })
+    expect(agent.instanceAccess).toEqual({ inst_a: 'none', inst_b: 'edit' })
   })
 })

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
 
 import type { ResourcePermission } from '@auxx/database/enums'
-import type { OrganizationRole, SeatType } from '@auxx/database/types'
+import type { OrganizationRole, SeatType, UserType } from '@auxx/database/types'
 import {
   type Area,
   buildAreaLevels,
@@ -59,11 +59,19 @@ export const PERMISSION_RANK: Record<ResourcePermission, number> = {
  * an area absent from the policy stays at the code default (not None). Areas
  * expand to their key set (union) = the resolved PermissionKey[]. An undefined
  * role (non-member) fails closed to an empty set.
+ *
+ * **AGENT grantees take a different branch** — see {@link composeAgentLevels}.
  */
 export function composeUserCapabilities(input: {
   /** From the cached memberRoleMap; undefined when not a member (→ no access). */
   role: OrganizationRole | undefined
   seatType: SeatType
+  /**
+   * Principal kind from the cached memberRoleMap. `'AGENT'` selects the
+   * set-semantics branch ({@link composeAgentLevels}); everything else composes
+   * with the human raise-only model. Defaults to `'USER'`.
+   */
+  userType?: UserType
   /** Sparse levels on the `role:org_member` policy grant (per-area override, L4). */
   orgPolicyLevels?: Partial<Record<Area, Level>>
   /** Sparse levels on each of the member's group grants (raise-only, L3). */
@@ -77,6 +85,7 @@ export function composeUserCapabilities(input: {
   const {
     role,
     seatType,
+    userType = 'USER',
     orgPolicyLevels,
     groupLevels,
     userLevels,
@@ -113,8 +122,18 @@ export function composeUserCapabilities(input: {
   // Fail closed: a non-member holds no capabilities.
   if (!role) return { keys: [], defAccess, instanceAccess }
 
-  const isAdmin = role === 'OWNER' || role === 'ADMIN'
   const ceiling = SEAT_CEILINGS[seatType]
+
+  // AGENT principals compose by SET, not by raise (§0.2) — separate branch.
+  if (userType === 'AGENT') {
+    return {
+      keys: expandLevelsToKeys(composeAgentLevels(userLevels, ceiling)),
+      defAccess,
+      instanceAccess,
+    }
+  }
+
+  const isAdmin = role === 'OWNER' || role === 'ADMIN'
   const userDefault = ROLE_DEFAULTS.USER
 
   const resolved = buildAreaLevels((area) => {
@@ -135,4 +154,43 @@ export function composeUserCapabilities(input: {
   })
 
   return { keys: expandLevelsToKeys(resolved), defAccess, instanceAccess }
+}
+
+/**
+ * Level resolution for `userType: 'AGENT'` principals (capability layer v2 §0.2/§0.3):
+ *
+ * ```
+ *   base  = Level.Full for every area                 // §0.3 default-Full
+ *   level = userLevels[a] ?? base                     // SET, not max — an explicit None LOWERS
+ *   level = min(level, SEAT_CEILINGS[seatType][a])    // seat clamp still last (no-op at 'full')
+ * ```
+ *
+ * **Why SET and not the human raise-only model:**
+ * - Agents are managed **individually** (one Permissions tab per agent). Raise-only
+ *   composition can only lift a baseline, so it literally cannot express "lock
+ *   THIS agent down" — the whole point of the surface. Set-semantics can.
+ * - The `role:org_member` org policy and group tiers are **skipped**. An org policy
+ *   is a lever aimed at humans (seats, headcount, org-wide posture); silently
+ *   clamping every agent with it would break automations an admin never touched.
+ *   Agents also aren't group members in any product sense (§6 deferred).
+ * - The all-Full base keeps enforcement **dormant** until an admin restricts an
+ *   agent: no grant rows ⇒ every area Full ⇒ every check passes, so orgs that
+ *   never open the tab see zero behavior change.
+ *
+ * The seat clamp survives because it is a billing invariant, not a policy lever —
+ * agent member rows are seat-exempt and fall back to `seatType: 'full'`, whose
+ * ceiling is Full everywhere, so in practice this is a no-op.
+ *
+ * `defAccess` / `instanceAccess` are NOT touched here: per-def and per-instance
+ * `ResourceAccess` grants compose exactly as they do for humans (most-specific-wins
+ * downstream in `CapabilitySet`).
+ */
+function composeAgentLevels(
+  userLevels: Partial<Record<Area, Level>> | undefined,
+  ceiling: Record<Area, Level>
+): Record<Area, Level> {
+  return buildAreaLevels((area) => {
+    const level = userLevels?.[area] ?? Level.Full
+    return Math.min(level, ceiling[area]) as Level
+  })
 }

--- a/packages/lib/src/permissions/capabilities/compute-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compute-user-capabilities.ts
@@ -34,12 +34,16 @@ export async function computeUserCapabilities(
   const entry = roleMap[userId]
   const role = entry?.role
   const seatType = entry?.seatType ?? 'full'
+  // Principal kind rides the same cached entry — no extra read. `'AGENT'` selects
+  // the set-semantics branch in `composeUserCapabilities` (v2 §0.2).
+  const userType = entry?.userType ?? 'USER'
 
   // Non-member: fail closed without touching the DB.
   if (!role)
     return composeUserCapabilities({
       role: undefined,
       seatType,
+      userType,
       typeAccessRows: [],
       instanceAccessRows: [],
     })
@@ -151,6 +155,7 @@ export async function computeUserCapabilities(
   return composeUserCapabilities({
     role,
     seatType,
+    userType,
     orgPolicyLevels,
     groupLevels,
     userLevels,

--- a/packages/lib/src/permissions/capabilities/grant-service.test.ts
+++ b/packages/lib/src/permissions/capabilities/grant-service.test.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/permissions/capabilities/grant-service.test.ts
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it, vi } from 'vitest'
+
+const roleMap: Record<string, { role: string; seatType: string; userType: string }> = {
+  u_human: { role: 'USER', seatType: 'full', userType: 'USER' },
+  u_agent: { role: 'USER', seatType: 'full', userType: 'AGENT' },
+}
+
+// The cache barrel is only used here for `onCacheEvent` + the memberRoleMap read;
+// mocking it keeps the heavy cache/redis deps out of the test.
+vi.mock('../../cache', () => ({
+  onCacheEvent: vi.fn(async () => {}),
+  getOrgCache: () => ({ get: vi.fn(async () => roleMap) }),
+}))
+vi.mock('../../dehydration/cache', () => ({
+  DehydrationCacheService: class {
+    async invalidateUser() {}
+    async invalidateOrganization() {}
+  },
+}))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishCapabilitiesChanged: vi.fn(async () => {}),
+}))
+vi.mock('../feature-permission-service', () => ({
+  FeaturePermissionService: class {
+    async requireAccess() {}
+  },
+}))
+
+import { setGranteeLevels } from './grant-service'
+import { Area, Level } from './registry'
+
+const ORG = 'org_1'
+
+/**
+ * Minimal chainable drizzle stub covering only the shapes `setGranteeLevels`
+ * touches; captures the `levels` payload that reaches the upsert.
+ */
+function fakeDb(sink: { levels?: Record<string, number> }): Database {
+  const db = {
+    insert: () => ({
+      values: (row: { levels: Record<string, number> }) => {
+        sink.levels = row.levels
+        return {
+          onConflictDoUpdate: () => ({ returning: async () => [row] }),
+        }
+      },
+    }),
+  }
+  return db as unknown as Database
+}
+
+describe('setGranteeLevels — Level.None storability (v2 §1)', () => {
+  it('KEEPS Level.None for an AGENT user grantee (the only way to lock an area down)', async () => {
+    const sink: { levels?: Record<string, number> } = {}
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_agent',
+      grantedById: 'u_admin',
+      levels: { [Area.records]: Level.None, [Area.knowledgeBase]: Level.Read },
+      db: fakeDb(sink),
+    })
+    expect(sink.levels).toEqual({
+      [Area.records]: Level.None,
+      [Area.knowledgeBase]: Level.Read,
+    })
+  })
+
+  it('STRIPS Level.None for a human user grantee (raise-only ⇒ inert noise)', async () => {
+    const sink: { levels?: Record<string, number> } = {}
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_human',
+      grantedById: 'u_admin',
+      levels: { [Area.records]: Level.None, [Area.knowledgeBase]: Level.Read },
+      db: fakeDb(sink),
+    })
+    expect(sink.levels).toEqual({ [Area.knowledgeBase]: Level.Read })
+  })
+
+  it('STRIPS Level.None for a group grantee', async () => {
+    const sink: { levels?: Record<string, number> } = {}
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'group',
+      granteeId: 'grp_1',
+      grantedById: 'u_admin',
+      levels: { [Area.records]: Level.None, [Area.workflows]: Level.Full },
+      db: fakeDb(sink),
+    })
+    expect(sink.levels).toEqual({ [Area.workflows]: Level.Full })
+  })
+
+  it('KEEPS Level.None for the org_member policy (the one downward lever)', async () => {
+    // `composeUserCapabilities` reads `orgPolicyLevels[a] ?? ROLE_DEFAULTS.USER[a]`,
+    // so a stored None genuinely zeroes the area for every non-admin member.
+    // Stripping it here would silently widen the workspace baseline back to Full.
+    const sink: { levels?: Record<string, number> } = {}
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'role',
+      granteeId: 'org_member',
+      grantedById: 'u_admin',
+      levels: { [Area.records]: Level.Read, [Area.workflows]: Level.None },
+      db: fakeDb(sink),
+    })
+    expect(sink.levels).toEqual({
+      [Area.records]: Level.Read,
+      [Area.workflows]: Level.None,
+    })
+  })
+
+  it('treats an unknown user grantee (no member row) as a human and strips None', async () => {
+    const sink: { levels?: Record<string, number> } = {}
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_ghost',
+      grantedById: 'u_admin',
+      levels: { [Area.records]: Level.None },
+      db: fakeDb(sink),
+    })
+    expect(sink.levels).toEqual({})
+  })
+})

--- a/packages/lib/src/permissions/capabilities/grant-service.ts
+++ b/packages/lib/src/permissions/capabilities/grant-service.ts
@@ -3,7 +3,7 @@
 import { type Database, database, type PermissionGrantEntity, schema } from '@auxx/database'
 import { generateId } from '@auxx/utils'
 import { and, eq } from 'drizzle-orm'
-import { onCacheEvent } from '../../cache'
+import { getOrgCache, onCacheEvent } from '../../cache'
 import { DehydrationCacheService } from '../../dehydration/cache'
 import { ForbiddenError } from '../../errors'
 import { FeaturePermissionService } from '../feature-permission-service'
@@ -48,6 +48,50 @@ function assertGrantableLevels(levels: Partial<Record<Area, Level>>): void {
       )
     }
   }
+}
+
+/**
+ * Drop `Level.None` area entries for grantees whose tier composes **raise-only**,
+ * where a stored `None` can never lower anything and is therefore inert noise
+ * that makes the grid read as a denial it does not produce (§0.2).
+ *
+ * Kept (`None` is load-bearing) for exactly two grantee kinds:
+ *  - **`role:org_member`** — the org policy is the one DOWNWARD lever
+ *    (`base = orgPolicyLevels[a] ?? ROLE_DEFAULTS.USER[a]`, so a stored `None`
+ *    genuinely zeroes the area for every non-admin member).
+ *  - **`user` grantees whose `User.userType` is `'AGENT'`** — agents compose by
+ *    SET (`level = userLevels[a] ?? Full`), so `None` is the only way to express
+ *    "this agent has no access to this area".
+ *
+ * Stripped for human `user` grantees and all `group` grantees: both tiers are
+ * `max(base, grant)`, so `None` is a no-op there.
+ */
+function stripInertNoneLevels(
+  levels: Partial<Record<Area, Level>>,
+  keepNone: boolean
+): Partial<Record<Area, Level>> {
+  if (keepNone) return levels
+  const out: Partial<Record<Area, Level>> = {}
+  for (const area of Object.keys(levels) as Area[]) {
+    const level = levels[area]
+    if (level === undefined || level === Level.None) continue
+    out[area] = level
+  }
+  return out
+}
+
+/**
+ * Whether `Level.None` entries are meaningful for this grantee — see
+ * {@link stripInertNoneLevels}. The AGENT check resolves the grantee's
+ * `User.userType` from the cached `memberRoleMap` (zero extra DB round-trip);
+ * a grantee with no member row is treated as a human (fail closed to the
+ * stricter, raise-only interpretation).
+ */
+async function granteeKeepsNoneLevels(grantee: GranteeRef): Promise<boolean> {
+  if (grantee.granteeType === 'role') return grantee.granteeId === 'org_member'
+  if (grantee.granteeType !== 'user') return false
+  const roleMap = await getOrgCache().get(grantee.organizationId, 'memberRoleMap')
+  return roleMap[grantee.granteeId]?.userType === 'AGENT'
 }
 
 /** Enterprise gate — writing override grants requires the plan feature (§2.H/§8). */
@@ -97,6 +141,10 @@ async function emitGrantChanged(grantee: GranteeRef): Promise<void> {
  * upserts the single grantee row. Only the areas present in `levels` are stored;
  * absent areas fall through to the code default at compose time. Passing `{}`
  * writes an empty override row; prefer {@link clearGranteeLevels} to remove it.
+ *
+ * `Level.None` entries are stripped for grantees whose tier composes raise-only
+ * (human users, groups) and kept for the `role:org_member` policy and AGENT user
+ * grantees — see {@link stripInertNoneLevels}.
  */
 export async function setGranteeLevels(
   input: GranteeRef & {
@@ -108,8 +156,12 @@ export async function setGranteeLevels(
   const { organizationId, granteeType, granteeId, grantedById } = input
   const db = input.db ?? database
 
-  const levels = parseAreaLevels(input.levels)
-  assertGrantableLevels(levels)
+  const parsed = parseAreaLevels(input.levels)
+  assertGrantableLevels(parsed)
+  const levels = stripInertNoneLevels(
+    parsed,
+    await granteeKeepsNoneLevels({ organizationId, granteeType, granteeId })
+  )
   await requireGranularPermissions(db, organizationId)
 
   const [row] = await db

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -2,6 +2,11 @@
 
 export { CapabilitySet, type DefIdToSlug } from './capability-set'
 export {
+  type CapabilityView,
+  intersectCapabilities,
+  MinCapabilitySet,
+} from './capability-view'
+export {
   composeUserCapabilities,
   type UserCapabilities,
 } from './compose-user-capabilities'

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -1,5 +1,10 @@
 export { CapabilitySet, type DefIdToSlug } from './capabilities/capability-set'
 export {
+  type CapabilityView,
+  intersectCapabilities,
+  MinCapabilitySet,
+} from './capabilities/capability-view'
+export {
   composeUserCapabilities,
   type UserCapabilities,
 } from './capabilities/compose-user-capabilities'

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -20,7 +20,7 @@ import { FieldValueService } from '../../field-values'
 import { normalizeForLookup } from '../../field-values/normalize-for-lookup'
 import { typedColumnMatch } from '../../field-values/typed-column-match'
 import { upsertRecordIdentity } from '../../identity'
-import type { CapabilitySet } from '../../permissions/capabilities/capability-set'
+import type { CapabilityView } from '../../permissions/capabilities/capability-view'
 import { getOrCreateSnapshot, getSnapshotChunk, invalidateSnapshots } from '../../snapshot'
 import { getCommonHooks, getSystemHooks } from '../hooks'
 import { RecordPickerService } from '../picker'
@@ -178,14 +178,14 @@ export interface UnifiedCrudHandlerOptions {
    */
   bypassFieldGuards?: ReadonlySet<SystemAttribute>
   /**
-   * Request-scoped {@link CapabilitySet} for entity-def enforcement. Present ⇒
+   * Request-scoped {@link CapabilityView} for entity-def enforcement. Present ⇒
    * read methods gate each def through `canViewEntity` (v2 §2) AND mutation
    * methods gate through `assertEditEntity` (v2 phase 4 §2). **Absent ⇒ no
    * enforcement** — so internal/system callers (seeders, workers, record-rules)
    * stay unrestricted with no change. Request paths must thread `ctx.capabilities`
    * (resolved once via `capabilityProcedure`).
    */
-  capabilities?: CapabilitySet
+  capabilities?: CapabilityView
 }
 
 export class UnifiedCrudHandler {
@@ -193,7 +193,7 @@ export class UnifiedCrudHandler {
   private db: Database
   private bypassFieldGuards: ReadonlySet<SystemAttribute>
   /** Request-scoped read enforcement; undefined for internal/system callers. */
-  private capabilities?: CapabilitySet
+  private capabilities?: CapabilityView
 
   constructor(
     private organizationId: string,
@@ -1112,7 +1112,7 @@ export class UnifiedCrudHandler {
    */
   async updateValues(instanceId: string, values: Record<string, unknown>) {
     // Only the instanceId is known here, so resolve its def to enforce — but
-    // solely when a request-scoped CapabilitySet is present (internal callers
+    // solely when a request-scoped CapabilityView is present (internal callers
     // skip the extra lookup entirely).
     if (this.capabilities) {
       const instance = await getEntityInstance({

--- a/packages/lib/src/resources/picker/record-picker-service.ts
+++ b/packages/lib/src/resources/picker/record-picker-service.ts
@@ -6,7 +6,7 @@ import { isEntityDefinitionType, type RecordId } from '@auxx/types/resource'
 import { and, asc, desc, eq, ilike, inArray, or, type SQL, sql } from 'drizzle-orm'
 import { getCachedEntityDefId, getCachedResource, getOrgCache } from '../../cache'
 import { getRecordIdentitiesForRecords } from '../../identity'
-import type { CapabilitySet } from '../../permissions/capabilities/capability-set'
+import type { CapabilityView } from '../../permissions/capabilities/capability-view'
 import {
   type CustomResource,
   isCustomResource,
@@ -60,13 +60,13 @@ export class RecordPickerService {
   private userId?: string
   private cache: RecordPickerCacheService
   /** Request-scoped read enforcement (§2.2); undefined for internal callers. */
-  private capabilities?: CapabilitySet
+  private capabilities?: CapabilityView
 
   constructor(
     organizationId: string,
     userId: string | undefined,
     db: Database,
-    capabilities?: CapabilitySet
+    capabilities?: CapabilityView
   ) {
     this.db = db
     this.organizationId = organizationId


### PR DESCRIPTION
Implements [`plans/permissions/v2/14-agent-permissions.md`](plans/permissions/v2/14-agent-permissions.md).

Every agent run — scheduled, event, app-trigger, mention, assignment, DM, visitor chat — now executes with a real `CapabilitySet`, enforced by the **same** read/write/instance gates humans get, instead of the previous split where only interactive Kopilot turns were gated and every autonomous path ran unrestricted.

**Enforcement is dormant at the all-Full default.** New and existing agents have no grant rows → every check passes → nothing changes until an admin restricts an agent.

## What's in it

**§1 Composition** — agents compose by SET over an all-Full base (`level[area] = userGrant[area] ?? Full`). Org-policy and group tiers are skipped (an org policy aimed at humans must not silently clamp automations; raise-only composition literally cannot express "lock this one agent down"). Seat clamp still applied last. `userType` rides the existing `memberRoleMap` entry, so composition costs no extra read.

**§2 Intersection** — `CapabilityView` extracted as the public gate surface; `MinCapabilitySet` + `intersectCapabilities` compose two views pointwise (`&&` on gates, `min` on levels, intersection on filters). `CapabilitySet implements CapabilityView` so drift is compile-checked. Admin bypass composes for free: an ADMIN invoker's `true` can't override a restricted agent's `false`.

**§3 Threading** — `resolveAgentRunCapabilities` resolves run-as (`AgentRunAsUnavailableError` if the delegate stops being an active human — never a silent fallback to the agent profile) and intersects with the invoker on mention / assignment / interactive-DM runs. Schedule / event / app / webhook / visitor runs use the agent profile alone. Write asserts added at the CRUD choke points and KB `runBlockCrudOp`; `search_knowledge` filters its dataset set by instance access; the prompt-side entity and KB catalogs are filtered so the model stops being handed the full ToC (titles + body-derived descriptions) of INTERNAL KBs it can't read.

**§4 UI** — an **Agents** section on the entity-def Access tab, and a **Permissions** tab in the agent builder (area grid + record access + run-as selector). Both admin-only.

## Deliberate behavior change

Def restrictions now reach agents. An org that already restricted a def will see agents lose access to it until granted — the new Agents section on the Access tab is the one-click fix. **Worth a release note.**

## Plan open items resolved

| # | Resolution |
|---|---|
| 1 | `parseAreaLevels` already round-trips `Level.None`; `setGranteeLevels` now keeps it for AGENT grantees (and for `role:org_member`, the org's only downward lever) and strips it for humans/groups where it's inert |
| 2 | The assignment event payload already carries `assignerUserId` — wired as the intersection bound |
| 3 | Cache was at `v4`, bumped to `v5` (landed with #1322) |
| 5 | The KB tools reached by `applyContextDefaults` ref pre-fill now re-check instance access on both read and write |

## Verification

- `packages/lib` + `apps/web` typecheck: zero new errors. Every hit in a touched file sits on an untouched line (pre-existing `RecordId` branding, `noUncheckedIndexedAccess`, `AgentDomainConfig` generic invariance, `services/dist` TS6305).
- Tests: 602 passed / 22 failed. All 22 are in six files that fail at HEAD (`context-store` ×16, `search-knowledge` ×2, `caller-preamble`, `agent-procedure-step`, `wire-format-conversion`, `query-loop-validation`). ~45 new tests, all passing.
- Biome clean across all 74 files.
- **Not verified: anything visual or runtime.** The local dev server was unresponsive, so neither new UI surface has been rendered in a browser and the grant math hasn't been exercised against a real DB — only against stubs.

## Known limitations / follow-ups

- **Per-def "No Access" for a single agent is not expressible.** `composeUserCapabilities` skips `permission === 'none'` rows when building `defAccess`, so a grantee-level `none` is a no-op by design. Restricting one agent from one def requires lowering its whole Records area or restricting the def workspace-wide. Pre-existing model limitation, but the new tab's framing invites the attempt.
- **Agents get `Full` on the admin-only areas** (settings/billing/members/permissions) from the all-Full base — inert today (no agent path reads those keys) and what §0.3 specifies, but it's authority no human grant could obtain.
- **Latent pre-existing bug found while auditing §3.4:** `transformToolInput` ignores the tool name, so `applyContextDefaults` injects `threadId`/`articleId`/`knowledgeBaseId` into *every* tool call, including app/MCP bridge tools declaring `additionalProperties: false`. For `upsert_learned_article` this can silently turn "create a memory" into "update article X". Not addressed here.
- Workflows stay out of scope (§0.8) — the `!capabilities → unrestricted` fallback in `create-deps` survives solely for the workflow AI node, and is commented as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
