### PR TITLE
feat(permissions): agent knowledge scope (retrieval scope, not access)

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -1,7 +1,12 @@
 // apps/web/src/app/api/kopilot/stream/route.ts
 
 import { database as db } from '@auxx/database'
-import { buildDmTriggerContext, filterToolsByToolsets, resolveAgentConfig } from '@auxx/lib/agents'
+import {
+  buildDmTriggerContext,
+  filterToolsByToolsets,
+  resolveAgentConfig,
+  resolveAgentKnowledgeScope,
+} from '@auxx/lib/agents'
 import { type UsageTrackingRequest, UsageTrackingService } from '@auxx/lib/ai'
 import {
   AgentEngine,
@@ -593,6 +598,39 @@ async function runInProcessPath(params: {
     }
   }
 
+  // Builder sessions run as master Kopilot with the agents-builder persona
+  // addition — the target agent is the subject of editing (passed via the
+  // `agent` active reference), not the persona to adopt. Passing its real
+  // agentConfig would render two competing "You are X." personas.
+  // Draft test-runs (build-plan §4.2): the agent Chat tab may request the
+  // unpublished draft view, but only for admins (agent-edit permission) and never
+  // for master/builder sessions. Per-request — nothing here is persisted.
+  //
+  // Hoisted above the tool-deps factory (was resolved further down, right
+  // before the domain config) so this single `resolveAgentConfig` call can
+  // also feed the knowledge-scope resolution below — one source of truth for
+  // both the tool deps' read gate and the prompt-side catalog filter.
+  let agentConfigSource: 'active' | 'draft' = 'active'
+  if (params.useDraft && !isBuilder && agentId) {
+    const isAdmin = await isAdminOrOwner(organizationId, userId, db)
+    if (isAdmin) agentConfigSource = 'draft'
+  }
+  const agentConfig = await resolveAgentConfig(organizationId, isBuilder ? null : agentId, db, {
+    source: agentConfigSource,
+  })
+
+  // Resolve once per turn (§1.1) — shared by the tool deps (read gate) below
+  // and the domain config (prompt-side catalog filtering) further down.
+  // Builder sessions resolve `agentConfig` off the master sentinel (`[]`
+  // knowledge), so this naturally comes back `null` (unrestricted) for the
+  // builder Kopilot even though a real `agentId` is in scope for the session.
+  const knowledgeScope = await resolveAgentKnowledgeScope({
+    db,
+    organizationId,
+    entries: agentConfig.knowledge,
+    capabilities,
+  })
+
   const getToolDeps = createToolDepsFactory({
     organizationId,
     userId,
@@ -600,6 +638,7 @@ async function runInProcessPath(params: {
     signal: request.signal,
     sessionContext: { ...(context ?? {}), page },
     capabilities,
+    knowledgeScope,
   })
 
   const registry = createCapabilityRegistry()
@@ -705,21 +744,6 @@ async function runInProcessPath(params: {
     }
   }
 
-  // Builder sessions run as master Kopilot with the agents-builder persona
-  // addition — the target agent is the subject of editing (passed via the
-  // `agent` active reference), not the persona to adopt. Passing its real
-  // agentConfig would render two competing "You are X." personas.
-  // Draft test-runs (build-plan §4.2): the agent Chat tab may request the
-  // unpublished draft view, but only for admins (agent-edit permission) and never
-  // for master/builder sessions. Per-request — nothing here is persisted.
-  let agentConfigSource: 'active' | 'draft' = 'active'
-  if (params.useDraft && !isBuilder && agentId) {
-    const isAdmin = await isAdminOrOwner(organizationId, userId, db)
-    if (isAdmin) agentConfigSource = 'draft'
-  }
-  const agentConfig = await resolveAgentConfig(organizationId, isBuilder ? null : agentId, db, {
-    source: agentConfigSource,
-  })
   const resolvedPage = page ?? '__none__'
   // Pre-filter tools by the agent's enabled toolsets before handing them to
   // the domain config. Master sessions pass through untouched. Future filter
@@ -744,6 +768,11 @@ async function runInProcessPath(params: {
     triggerContext,
     // Prompt-side catalog filtering (§3.4) — the same view the tools enforce with.
     capabilities,
+    // The agent's retrieval scope (§1.1) — narrows the Knowledge Catalog to
+    // what this agent may actually search. `null` for builder sessions (which
+    // resolve `agentConfig` off the master sentinel, not the edited agent) and
+    // for master Kopilot, matching today's unrestricted behavior.
+    knowledgeScope,
   })
 
   // Create LLM adapter

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -261,10 +261,11 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
 
                 <div ref={assignRef('knowledge')}>
                   <Section
-                    title='Knowledge'
+                    title='Knowledge sources'
                     icon={<BookOpen className='size-4' />}
                     className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
                     initialOpen
+                    description='Narrows what this agent searches. Leave empty to search all org knowledge. Access is controlled in Permissions.'
                     collapsible={false}>
                     <KnowledgeSectionContent agent={agent} onAutosaveChange={onAutosaveChange} />
                   </Section>

--- a/apps/web/src/components/agents/ui/detail/knowledge/__tests__/derive-scope-mode.test.ts
+++ b/apps/web/src/components/agents/ui/detail/knowledge/__tests__/derive-scope-mode.test.ts
@@ -4,23 +4,13 @@ import { describe, expect, it } from 'vitest'
 import { deriveEffectiveMode } from '../derive-scope-mode'
 
 type AgentScopes = Parameters<typeof deriveEffectiveMode>[0]
+type KnowledgeEntry = AgentScopes[number]
 
 function row(
-  entityDefinitionId: string,
-  entityInstanceId: string | null,
+  recordId: string,
   mode: 'include_descendants' | 'include_one' | 'exclude'
-): AgentScopes[number] {
-  return {
-    id: `r-${entityDefinitionId}-${entityInstanceId ?? 'def'}`,
-    agentId: 'agent-1',
-    organizationId: 'org-1',
-    entityDefinitionId,
-    entityInstanceId,
-    mode,
-    source: 'manual',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  } as AgentScopes[number]
+): KnowledgeEntry {
+  return { recordId, mode, source: 'manual' }
 }
 
 describe('deriveEffectiveMode', () => {
@@ -34,31 +24,31 @@ describe('deriveEffectiveMode', () => {
   })
 
   it('inherits include_descendants from KB ancestor when no own row', () => {
-    const scopes = [row('kb', 'A', 'include_descendants')]
+    const scopes = [row(kbA, 'include_descendants')]
     expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
       'inherited_include_descendants'
     )
   })
 
   it('inherits exclude from KB ancestor when no own row', () => {
-    const scopes = [row('kb', 'A', 'exclude')]
+    const scopes = [row(kbA, 'exclude')]
     expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
       'inherited_exclude'
     )
   })
 
   it('own include_one wins over ancestor exclude', () => {
-    const scopes = [row('kb', 'A', 'exclude'), row('article', 'X', 'include_one')]
+    const scopes = [row(kbA, 'exclude'), row(articleX, 'include_one')]
     expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe('include_one')
   })
 
   it('own exclude wins over ancestor include_descendants', () => {
-    const scopes = [row('kb', 'A', 'include_descendants'), row('article', 'X', 'exclude')]
+    const scopes = [row(kbA, 'include_descendants'), row(articleX, 'exclude')]
     expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe('exclude')
   })
 
   it('nearest article ancestor exclude wins over no own row', () => {
-    const scopes = [row('article', 'P', 'exclude')]
+    const scopes = [row(articleParent, 'exclude')]
     // P is the parent, A is the KB further up.
     expect(deriveEffectiveMode(scopes, articleY, { ancestorRecordIds: [articleParent, kbA] })).toBe(
       'inherited_exclude'
@@ -66,7 +56,7 @@ describe('deriveEffectiveMode', () => {
   })
 
   it('nearest ancestor include_descendants beats more-distant exclude', () => {
-    const scopes = [row('kb', 'A', 'exclude'), row('article', 'P', 'include_descendants')]
+    const scopes = [row(kbA, 'exclude'), row(articleParent, 'include_descendants')]
     expect(deriveEffectiveMode(scopes, articleY, { ancestorRecordIds: [articleParent, kbA] })).toBe(
       'inherited_include_descendants'
     )
@@ -74,28 +64,32 @@ describe('deriveEffectiveMode', () => {
 
   it('ancestor include_one does NOT inherit to descendants', () => {
     // include_one is "this one record only" — descendants stay none.
-    const scopes = [row('article', 'P', 'include_one')]
+    const scopes = [row(articleParent, 'include_one')]
     expect(deriveEffectiveMode(scopes, articleY, { ancestorRecordIds: [articleParent] })).toBe(
       'none'
     )
   })
 
+  // The definition-level fallback is resource-agnostic. These two cases use a
+  // bare `article` row to exercise it against an article target — reachable in
+  // stored data, though no longer writable: `isKnowledgeScopeRecordId` accepts
+  // a bare row only for `kb`/`dataset` (the depth-0 container rows).
   it('falls through to definition-level rule when no ancestor matches', () => {
-    const scopes = [row('article', null, 'include_descendants')]
+    const scopes = [row('article', 'include_descendants')]
     expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
       'inherited_include_descendants'
     )
   })
 
   it('ancestor rule wins over definition-level rule', () => {
-    const scopes = [row('article', null, 'exclude'), row('kb', 'A', 'include_descendants')]
+    const scopes = [row('article', 'exclude'), row(kbA, 'include_descendants')]
     expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
       'inherited_include_descendants'
     )
   })
 
   it('works without ancestors arg (back-compat for depth-0 callers)', () => {
-    const scopes = [row('kb', 'A', 'include_descendants')]
+    const scopes = [row(kbA, 'include_descendants')]
     expect(deriveEffectiveMode(scopes, kbA)).toBe('include_descendants')
   })
 })

--- a/apps/web/src/components/agents/ui/detail/knowledge/flat-record-list.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/flat-record-list.tsx
@@ -24,9 +24,10 @@ interface FlatRecordListProps {
 }
 
 /**
- * Renders the records an admin has *explicitly added* (scope row or pin) for
- * one resource type — never the full corpus. An "+ Add" row at the bottom
- * opens `RecordPicker` to attach more.
+ * Renders the datasets an admin has *explicitly added* (scope row or pin) —
+ * never the full corpus. The only resource type that reaches this component
+ * is `dataset` (`kb` has its own `KbBranch` with article-level picking). An
+ * "+ Add" row at the bottom opens `RecordPicker` to attach more.
  */
 export function FlatRecordList({
   resource,
@@ -59,9 +60,9 @@ export function FlatRecordList({
 }
 
 /**
- * Knowledge-entry record ids scoped to one resource type. Definition-level
- * entries (no `:instanceId` suffix) are excluded — those are owned by the
- * depth-0 container row.
+ * Knowledge-entry record ids scoped to the `dataset` resource type.
+ * Definition-level entries (no `:instanceId` suffix) are excluded — those
+ * are owned by the depth-0 container row.
  */
 function useAddedRecordIds(entityDefinitionId: string, agent: AgentDetail): string[] {
   return useMemo(() => {

--- a/apps/web/src/components/agents/ui/detail/knowledge/knowledge-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/knowledge-section-content.tsx
@@ -10,18 +10,13 @@ import { ResourceTypeBranch } from './resource-type-branch'
 import { useScopeMutations } from './use-scope-mutations'
 
 /**
- * Depth-0 ordering for system resources. `article` is omitted intentionally —
- * articles render under their owning KB (see `KbBranch`).
+ * Depth-0 ordering for the resource types that remain valid retrieval scope
+ * targets. `article` is omitted intentionally — articles render under their
+ * owning KB (see `KbBranch`). Entity records (contacts, tickets, etc.) are
+ * no longer scope targets here — access to them is governed by the
+ * Permissions tab.
  */
-const SYSTEM_ORDER: ReadonlyArray<string> = [
-  'kb',
-  'contact',
-  'company',
-  'ticket',
-  'dataset',
-  'meeting',
-  'part',
-]
+const SYSTEM_ORDER: ReadonlyArray<string> = ['kb', 'dataset']
 
 interface KnowledgeSectionContentProps {
   agent: AgentDetail
@@ -29,9 +24,11 @@ interface KnowledgeSectionContentProps {
 }
 
 /**
- * Knowledge tab body: a unified scope tree with one branch per resource
- * type, each expanding to its records. Pinned state shows inline via the
- * star icon on every row — no separate pinned block.
+ * Knowledge tab body: a retrieval-scope tree over knowledge bases and
+ * datasets. Narrowing scope here limits what the agent searches — it does
+ * not grant or restrict access; that's the Permissions tab's job. Pinned
+ * state shows inline via the star icon on every row — no separate pinned
+ * block.
  */
 export function KnowledgeSectionContent({ agent, onAutosaveChange }: KnowledgeSectionContentProps) {
   const handleSavingChange = useCallback(
@@ -41,17 +38,13 @@ export function KnowledgeSectionContent({ agent, onAutosaveChange }: KnowledgeSe
     [onAutosaveChange]
   )
 
-  const { resources, customResources, isLoading } = useResources()
+  const { resources, isLoading } = useResources()
   const mutations = useScopeMutations(agent.id, agent.slug, handleSavingChange)
 
   const orderedTypes = useMemo<Resource[]>(() => {
     const byId = new Map(resources.map((r) => [r.id, r]))
-    const system = SYSTEM_ORDER.map((id) => byId.get(id)).filter((r): r is Resource => !!r)
-    const visibleCustom = customResources
-      .filter((r) => r.isVisible !== false)
-      .sort((a, b) => a.plural.localeCompare(b.plural))
-    return [...system, ...visibleCustom]
-  }, [resources, customResources])
+    return SYSTEM_ORDER.map((id) => byId.get(id)).filter((r): r is Resource => !!r)
+  }, [resources])
 
   if (isLoading && orderedTypes.length === 0) {
     return <p className='text-sm text-muted-foreground py-2'>Loading resources…</p>
@@ -60,7 +53,7 @@ export function KnowledgeSectionContent({ agent, onAutosaveChange }: KnowledgeSe
   if (orderedTypes.length === 0) {
     return (
       <p className='text-sm text-muted-foreground py-2'>
-        No resources available yet. Set up a knowledge base or entity to scope this agent.
+        No knowledge bases or datasets available yet. Set one up to scope this agent's retrieval.
       </p>
     )
   }

--- a/apps/web/src/components/agents/ui/detail/knowledge/resource-type-branch.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/resource-type-branch.tsx
@@ -23,14 +23,15 @@ interface ResourceTypeBranchProps {
 /**
  * Resource types whose `include_descendants` mode is meaningful — picking one
  * via the "+ Add" picker should default to "Whole" rather than "Container
- * only" because granting access to descendants is the common case.
+ * only" because scoping in descendants is the common case. Only `kb` reaches
+ * this component with descendants (articles); `dataset` has none.
  */
 const HAS_DESCENDANTS = new Set<string>(['kb'])
 
 /**
- * Depth-0 row for one resource type (e.g. "Contacts", "Knowledge bases").
- * The row owns a definition-level scope + pin (recordId = resource.id with
- * no instance suffix). Expanding reveals only the records the admin has
+ * Depth-0 row for one knowledge-source type (`kb` or `dataset`). The row
+ * owns a definition-level scope + pin (recordId = resource.id with no
+ * instance suffix). Expanding reveals only the records the admin has
  * explicitly added (via picker), never the full corpus.
  */
 export function ResourceTypeBranch({ resource, agent, mutations }: ResourceTypeBranchProps) {
@@ -71,6 +72,8 @@ export function ResourceTypeBranch({ resource, agent, mutations }: ResourceTypeB
       {resource.id === 'kb' ? (
         <KbBranch agent={agent} mutations={mutations} depth={1} />
       ) : (
+        // Only 'dataset' reaches this branch — the only other resource in
+        // SYSTEM_ORDER (see knowledge-section-content.tsx).
         <FlatRecordList
           resource={resource}
           agent={agent}

--- a/apps/web/src/server/api/routers/agent-scope.ts
+++ b/apps/web/src/server/api/routers/agent-scope.ts
@@ -2,6 +2,7 @@
 
 import {
   agentExistsInOrg,
+  isKnowledgeScopeRecordId,
   removeAgentScopeRow,
   ScopeRowImmutableError,
   upsertAgentScopeRow,
@@ -15,6 +16,11 @@ const logger = createScopedLogger('agent-scope-router')
 
 const scopeModeSchema = z.enum(['include_descendants', 'include_one', 'exclude'])
 const recordIdSchema = z.string().min(1).max(180)
+/** `upsertRow` targets a knowledge source; `removeRow` stays unrestricted so a
+ * stale entity-record row from the deleted include system can still be cleared. */
+const knowledgeScopeRecordIdSchema = recordIdSchema.refine(isKnowledgeScopeRecordId, {
+  message: 'recordId must target a knowledge source (kb, article, or dataset)',
+})
 
 async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
   if (!(await agentExistsInOrg(organizationId, agentId))) {
@@ -33,7 +39,10 @@ function mapServiceError(err: unknown): TRPCError {
 }
 
 /**
- * Per-agent knowledge entry mutations. Reads come from `agent.getById.knowledge`.
+ * Per-agent knowledge-source scope mutations — which KBs, articles and
+ * datasets the agent's retrieval scope includes/excludes. This is not an
+ * access-control surface; record/entity permissions are configured
+ * separately (doc 14). Reads come from `agent.getById.knowledge`.
  * Mention-sourced entries are owned by the prompt reconciler and are rejected
  * here; admin edits write `manual`.
  */
@@ -42,7 +51,7 @@ export const agentScopeRouter = createTRPCRouter({
     .input(
       z.object({
         agentId: z.string(),
-        recordId: recordIdSchema,
+        recordId: knowledgeScopeRecordIdSchema,
         mode: scopeModeSchema,
       })
     )

--- a/packages/lib/src/agents/__tests__/knowledge-scope.test.ts
+++ b/packages/lib/src/agents/__tests__/knowledge-scope.test.ts
@@ -1,0 +1,201 @@
+// packages/lib/src/agents/__tests__/knowledge-scope.test.ts
+
+import type { KnowledgeEntry } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import {
+  filterKnowledgeScopeEntries,
+  isKnowledgeScopeRecordId,
+  parseAgentKnowledgeScope,
+  parseKnowledgeScopeRecordId,
+  scopeHasIncludes,
+} from '../knowledge-scope'
+
+function entry(
+  recordId: string,
+  mode: KnowledgeEntry['mode'] = 'include_one',
+  source: KnowledgeEntry['source'] = 'manual'
+): KnowledgeEntry {
+  return { recordId, mode, source }
+}
+
+describe('isKnowledgeScopeRecordId / parseKnowledgeScopeRecordId', () => {
+  it.each(['kb', 'kb:x', 'article:x', 'dataset', 'dataset:x'])('accepts %s', (recordId) => {
+    expect(isKnowledgeScopeRecordId(recordId)).toBe(true)
+  })
+
+  it.each([
+    'contact',
+    'contact:x',
+    'ticket:x',
+    'entity:contact',
+    'kb:',
+    '',
+  ])('rejects %s', (recordId) => {
+    expect(isKnowledgeScopeRecordId(recordId)).toBe(false)
+  })
+
+  it('parses a bare definition-level prefix with a null instanceId', () => {
+    expect(parseKnowledgeScopeRecordId('kb')).toEqual({ prefix: 'kb', instanceId: null })
+    expect(parseKnowledgeScopeRecordId('dataset')).toEqual({
+      prefix: 'dataset',
+      instanceId: null,
+    })
+  })
+
+  it('parses an instance-level id into prefix + instanceId', () => {
+    expect(parseKnowledgeScopeRecordId('kb:abc')).toEqual({ prefix: 'kb', instanceId: 'abc' })
+    expect(parseKnowledgeScopeRecordId('article:def')).toEqual({
+      prefix: 'article',
+      instanceId: 'def',
+    })
+    expect(parseKnowledgeScopeRecordId('dataset:ghi')).toEqual({
+      prefix: 'dataset',
+      instanceId: 'ghi',
+    })
+  })
+
+  it('rejects a bare "article" — only kb and dataset have a definition level', () => {
+    // A bare `article` row would mean "every article in the org", which a bare
+    // `kb` row already says. Articles are always instance-level.
+    expect(parseKnowledgeScopeRecordId('article')).toBeNull()
+    expect(isKnowledgeScopeRecordId('article')).toBe(false)
+  })
+
+  it('rejects an empty instanceId after the colon', () => {
+    expect(parseKnowledgeScopeRecordId('kb:')).toBeNull()
+  })
+
+  it('rejects prefixes outside the knowledge-scope set', () => {
+    expect(parseKnowledgeScopeRecordId('contact:abc')).toBeNull()
+    expect(parseKnowledgeScopeRecordId('entity:contact')).toBeNull()
+    expect(parseKnowledgeScopeRecordId('ticket:abc')).toBeNull()
+  })
+})
+
+describe('filterKnowledgeScopeEntries', () => {
+  it('returns [] for null/undefined/empty input', () => {
+    expect(filterKnowledgeScopeEntries(null)).toEqual([])
+    expect(filterKnowledgeScopeEntries(undefined)).toEqual([])
+    expect(filterKnowledgeScopeEntries([])).toEqual([])
+  })
+
+  it('drops entity-record rows left over from the deleted include system', () => {
+    const rows = [entry('kb:abc'), entry('contact:xyz'), entry('ticket:123'), entry('article:def')]
+    expect(filterKnowledgeScopeEntries(rows)).toEqual([entry('kb:abc'), entry('article:def')])
+  })
+
+  it('keeps only knowledge-scope rows when the list is entity-only', () => {
+    expect(filterKnowledgeScopeEntries([entry('contact:xyz'), entry('entity:contact')])).toEqual([])
+  })
+})
+
+describe('parseAgentKnowledgeScope', () => {
+  it('returns null for an empty list', () => {
+    expect(parseAgentKnowledgeScope([])).toBeNull()
+    expect(parseAgentKnowledgeScope(null)).toBeNull()
+    expect(parseAgentKnowledgeScope(undefined)).toBeNull()
+  })
+
+  it('returns null when every row is an entity-record leftover', () => {
+    expect(parseAgentKnowledgeScope([entry('contact:xyz'), entry('ticket:123')])).toBeNull()
+  })
+
+  it('buckets definition-level include/exclude rows', () => {
+    const scope = parseAgentKnowledgeScope([
+      entry('kb', 'include_one', 'manual'),
+      entry('dataset', 'exclude', 'manual'),
+    ])
+    expect(scope).toMatchObject({ allKbs: 'include', allDatasets: 'exclude' })
+  })
+
+  it('buckets instance-level kb and dataset rows by direction', () => {
+    const scope = parseAgentKnowledgeScope([
+      entry('kb:abc', 'include_one', 'manual'),
+      entry('kb:excluded', 'exclude', 'manual'),
+      entry('dataset:def', 'include_one', 'manual'),
+      entry('dataset:excluded', 'exclude', 'manual'),
+    ])
+    expect(scope).toMatchObject({
+      kbIds: ['abc'],
+      excludedKbIds: ['excluded'],
+      datasetIds: ['def'],
+      excludedDatasetIds: ['excluded'],
+    })
+  })
+
+  it('buckets article include_one vs include_descendants separately', () => {
+    const scope = parseAgentKnowledgeScope([
+      entry('article:one', 'include_one', 'manual'),
+      entry('article:tree', 'include_descendants', 'manual'),
+    ])
+    expect(scope).toMatchObject({
+      articleIds: ['one'],
+      articleTreeIds: ['tree'],
+    })
+  })
+
+  it('buckets an excluded article regardless of its mode (exclude always covers the subtree)', () => {
+    const scope = parseAgentKnowledgeScope([
+      entry('article:excluded', 'exclude', 'manual'),
+      entry('article:excluded-tree', 'exclude', 'manual'),
+    ])
+    expect(scope?.excludedArticleIds.sort()).toEqual(['excluded', 'excluded-tree'])
+    expect(scope?.articleIds).toEqual([])
+    expect(scope?.articleTreeIds).toEqual([])
+  })
+
+  it('is a no-op for a bare "article" row — no definition-level article bucket exists', () => {
+    const scope = parseAgentKnowledgeScope([
+      entry('article', 'include_one', 'manual'),
+      entry('kb:abc', 'include_one', 'manual'),
+    ])
+    expect(scope).toMatchObject({ kbIds: ['abc'] })
+    expect(scope?.articleIds).toEqual([])
+    expect(scope?.articleTreeIds).toEqual([])
+  })
+
+  it('ignores interleaved entity-record rows while bucketing the rest', () => {
+    const scope = parseAgentKnowledgeScope([
+      entry('contact:xyz', 'include_one', 'manual'),
+      entry('kb:abc', 'include_one', 'manual'),
+      entry('ticket:123', 'exclude', 'manual'),
+    ])
+    expect(scope).toMatchObject({ kbIds: ['abc'] })
+  })
+})
+
+describe('scopeHasIncludes', () => {
+  const empty = parseAgentKnowledgeScope([]) // null — build a base manually instead
+  const base = {
+    allKbs: null,
+    allDatasets: null,
+    kbIds: [] as string[],
+    articleIds: [] as string[],
+    articleTreeIds: [] as string[],
+    datasetIds: [] as string[],
+    excludedKbIds: [] as string[],
+    excludedArticleIds: [] as string[],
+    excludedDatasetIds: [] as string[],
+  }
+
+  it('is false for an all-null/empty scope', () => {
+    expect(scopeHasIncludes(base)).toBe(false)
+    expect(empty).toBeNull()
+  })
+
+  it('is false when only excludes are present (excludes carve out of an org-wide default)', () => {
+    expect(scopeHasIncludes({ ...base, allKbs: 'exclude', excludedKbIds: ['abc'] })).toBe(false)
+  })
+
+  it('is true for a definition-level include', () => {
+    expect(scopeHasIncludes({ ...base, allKbs: 'include' })).toBe(true)
+    expect(scopeHasIncludes({ ...base, allDatasets: 'include' })).toBe(true)
+  })
+
+  it('is true when any instance-level include list is non-empty', () => {
+    expect(scopeHasIncludes({ ...base, kbIds: ['abc'] })).toBe(true)
+    expect(scopeHasIncludes({ ...base, articleIds: ['abc'] })).toBe(true)
+    expect(scopeHasIncludes({ ...base, articleTreeIds: ['abc'] })).toBe(true)
+    expect(scopeHasIncludes({ ...base, datasetIds: ['abc'] })).toBe(true)
+  })
+})

--- a/packages/lib/src/agents/__tests__/prompt-mention-reconciler.test.ts
+++ b/packages/lib/src/agents/__tests__/prompt-mention-reconciler.test.ts
@@ -127,10 +127,10 @@ describe('walkPromptDoc', () => {
 
   it('collects record RecordIds for known prefixes', () => {
     const result = walkPromptDoc(
-      doc(paragraph(reference('article:abc'), reference('entity:def'), reference('ticket:ghi'))),
+      doc(paragraph(reference('article:abc'), reference('kb:def'), reference('dataset:ghi'))),
       TOOL_CATALOG
     )
-    expect([...result.recordIds].sort()).toEqual(['article:abc', 'entity:def', 'ticket:ghi'])
+    expect([...result.recordIds].sort()).toEqual(['article:abc', 'dataset:ghi', 'kb:def'])
   })
 
   it('ignores unknown prefixes and malformed ids', () => {
@@ -146,6 +146,17 @@ describe('walkPromptDoc', () => {
       TOOL_CATALOG
     )
     expect(result.toolsetLocks.size).toBe(0)
+    expect(result.recordIds.size).toBe(0)
+  })
+
+  it('ignores entity-record chips (ticket/meeting/entity) — permissions own those now', () => {
+    // These prefixes used to reconcile into Agent.knowledge alongside kb/article/
+    // dataset; that job moved to the permission layer (doc 14), so a mention here
+    // is just a prompt token — no knowledge row is written.
+    const result = walkPromptDoc(
+      doc(paragraph(reference('ticket:abc'), reference('meeting:def'), reference('entity:ghi'))),
+      TOOL_CATALOG
+    )
     expect(result.recordIds.size).toBe(0)
   })
 

--- a/packages/lib/src/agents/__tests__/resolve-knowledge-scope.test.ts
+++ b/packages/lib/src/agents/__tests__/resolve-knowledge-scope.test.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/agents/__tests__/resolve-knowledge-scope.test.ts
+
+import type { KnowledgeEntry } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { parseAgentKnowledgeScope, scopeHasIncludes } from '../knowledge-scope'
+import { selectScopedSources } from '../resolve-knowledge-scope'
+
+function entry(recordId: string, mode: KnowledgeEntry['mode']): KnowledgeEntry {
+  return { recordId, mode, source: 'manual' }
+}
+
+const KB_IDS = ['kb1', 'kb2', 'kb3']
+const RAG_IDS = ['ds1', 'ds2']
+
+/**
+ * Drive the precedence core the way `resolveAgentKnowledgeScope` does, so the
+ * cases read as "these scope rows produce these sources".
+ */
+function select(
+  rows: KnowledgeEntry[],
+  opts: {
+    kbIdsWithScopedArticles?: string[]
+    viewableKbIds?: string[]
+    viewableDatasetIds?: string[]
+  } = {}
+) {
+  const scope = parseAgentKnowledgeScope(rows)
+  if (!scope) throw new Error('expected a scope — the caller should pass scope rows')
+
+  const capabilities =
+    opts.viewableKbIds || opts.viewableDatasetIds
+      ? ({
+          canViewInstance: (key: string, id: string) =>
+            key === 'kb'
+              ? (opts.viewableKbIds ?? KB_IDS).includes(id)
+              : (opts.viewableDatasetIds ?? RAG_IDS).includes(id),
+          // Only `canViewInstance` is read by the core under test.
+        } as never)
+      : undefined
+
+  const out = selectScopedSources({
+    scope,
+    hasIncludes: scopeHasIncludes(scope),
+    kbIds: KB_IDS,
+    ragDatasetIds: RAG_IDS,
+    kbIdsWithScopedArticles: new Set(opts.kbIdsWithScopedArticles ?? []),
+    capabilities,
+  })
+  return {
+    included: [...out.includedKbIds].sort(),
+    partial: [...out.partialKbIds].sort(),
+    datasets: [...out.includedDatasetIds].sort(),
+  }
+}
+
+describe('selectScopedSources', () => {
+  it('treats any include mode on a KB as the whole KB', () => {
+    // Mentions write `include_one` for a `kb:` chip; the builder writes
+    // `include_descendants`. Both mean "this KB's content".
+    expect(select([entry('kb:kb1', 'include_one')]).included).toEqual(['kb1'])
+    expect(select([entry('kb:kb1', 'include_descendants')]).included).toEqual(['kb1'])
+  })
+
+  it('an allowlist scope omits everything not named', () => {
+    const out = select([entry('kb:kb1', 'include_descendants')])
+    expect(out.included).toEqual(['kb1'])
+    expect(out.partial).toEqual([])
+    // Naming a KB does not drag the RAG datasets along.
+    expect(out.datasets).toEqual([])
+  })
+
+  it('an exclude-only scope starts org-wide and carves out', () => {
+    const out = select([entry('kb:kb2', 'exclude')])
+    expect(out.included).toEqual(['kb1', 'kb3'])
+    expect(out.datasets).toEqual(['ds1', 'ds2'])
+  })
+
+  it('honours the definition-level rows for kb and dataset', () => {
+    const allKbs = select([entry('kb', 'include_descendants')])
+    expect(allKbs.included).toEqual(KB_IDS)
+    expect(allKbs.datasets).toEqual([])
+
+    const allDatasets = select([entry('dataset', 'include_descendants')])
+    expect(allDatasets.included).toEqual([])
+    expect(allDatasets.datasets).toEqual(RAG_IDS)
+  })
+
+  it('lets a specific KB row override the definition-level row (most-specific-wins)', () => {
+    const out = select([entry('kb', 'exclude'), entry('kb:kb2', 'include_descendants')])
+    expect(out.included).toEqual(['kb2'])
+  })
+
+  it('marks a KB partial when it only contributes individually scoped articles', () => {
+    const out = select([entry('article:a1', 'include_one')], { kbIdsWithScopedArticles: ['kb3'] })
+    expect(out.included).toEqual([])
+    // kb3's dataset still has to be searchable, or the article post-filter has
+    // nothing to narrow.
+    expect(out.partial).toEqual(['kb3'])
+  })
+
+  it('an included article outranks the exclusion of its KB', () => {
+    const out = select([entry('kb:kb1', 'exclude'), entry('article:a1', 'include_one')], {
+      kbIdsWithScopedArticles: ['kb1'],
+    })
+    expect(out.included).toEqual([])
+    expect(out.partial).toEqual(['kb1'])
+  })
+
+  it('a whole-KB include beats the same KB being partial', () => {
+    const out = select([entry('kb:kb1', 'include_descendants')], {
+      kbIdsWithScopedArticles: ['kb1'],
+    })
+    expect(out.included).toEqual(['kb1'])
+    expect(out.partial).toEqual([])
+  })
+
+  it('drops sources the capability view cannot see (§0.4 — narrow, never widen)', () => {
+    const out = select(
+      [entry('kb', 'include_descendants'), entry('dataset', 'include_descendants')],
+      {
+        viewableKbIds: ['kb2'],
+        viewableDatasetIds: ['ds1'],
+      }
+    )
+    expect(out.included).toEqual(['kb2'])
+    expect(out.datasets).toEqual(['ds1'])
+  })
+
+  it('drops a partial KB the capability view cannot see', () => {
+    const out = select([entry('article:a1', 'include_one')], {
+      kbIdsWithScopedArticles: ['kb1'],
+      viewableKbIds: ['kb2'],
+    })
+    expect(out.partial).toEqual([])
+  })
+
+  it('silently drops dangling ids rather than failing', () => {
+    // `kb:gone` no longer exists in the org, so nothing matches it.
+    const out = select([entry('kb:gone', 'include_descendants')])
+    expect(out.included).toEqual([])
+    expect(out.partial).toEqual([])
+    expect(out.datasets).toEqual([])
+  })
+})

--- a/packages/lib/src/agents/agent-scope-service.ts
+++ b/packages/lib/src/agents/agent-scope-service.ts
@@ -10,7 +10,20 @@ import {
 import { createScopedLogger } from '@auxx/logger'
 import { eq, sql } from 'drizzle-orm'
 import { onCacheEvent } from '../cache'
+import { BadRequestError } from '../errors'
 import { getRealtimeService, publishAgentUpdated } from '../realtime'
+import { isKnowledgeScopeRecordId } from './knowledge-scope'
+
+// CRUD for `Agent.knowledge` — the agent's **knowledge-source retrieval
+// scope**: which knowledge bases, articles and datasets `search_knowledge`
+// and the prompt's Knowledge Catalog draw from by default.
+//
+// This is NOT an access-control mechanism. Whether an agent (or the human
+// running it) may read a given record is governed entirely by the permission
+// layer (per-def / per-instance grants, doc 14,
+// plans/permissions/v2/15-agent-knowledge-scope.md §0). Every `recordId`
+// written here must target a knowledge source — see `isKnowledgeScopeRecordId`
+// — so the two systems never get re-conflated.
 
 const logger = createScopedLogger('agent-scope-service')
 
@@ -24,7 +37,7 @@ export type AgentScopeMode = 'include_descendants' | 'include_one' | 'exclude'
 
 export interface AgentScopeUpsertInput {
   agentId: string
-  /** `${entityDefinitionId}:${entityInstanceId}` or `${entityDefinitionId}` for definition-level. */
+  /** `kb:<id>`, `article:<id>`, `dataset:<id>`, or a bare `kb`/`dataset` for definition-level. */
   recordId: string
   mode: AgentScopeMode
 }
@@ -42,10 +55,6 @@ function findScopeEntry(
   return { idx, entry: idx >= 0 ? entries[idx] : undefined }
 }
 
-function recordMatchesScopeRow(recordId: string, row: { recordId: string }): boolean {
-  return row.recordId === recordId
-}
-
 async function loadKnowledgeForUpdate(tx: Transaction, agentId: string): Promise<KnowledgeEntry[]> {
   const [row] = await tx
     .select({ knowledge: schema.Agent.knowledge })
@@ -58,15 +67,23 @@ async function loadKnowledgeForUpdate(tx: Transaction, agentId: string): Promise
 }
 
 /**
- * Upsert one knowledge entry. Inserts default to `source='manual'`; existing
- * `manual` rows are mutated in place; `mention` rows are immutable from this
- * call site (the prompt reconciler owns them).
+ * Upsert one knowledge-source scope row. Inserts default to `source='manual'`;
+ * existing `manual` rows are mutated in place; `mention` rows are immutable
+ * from this call site (the prompt reconciler owns them).
+ *
+ * @throws {BadRequestError} when `input.recordId` isn't a knowledge source
+ *   (`kb` / `article` / `dataset`, see {@link isKnowledgeScopeRecordId}).
  */
 export async function upsertAgentScopeRow(
   organizationId: string,
   input: AgentScopeUpsertInput,
   db: Database = defaultDb as Database
 ): Promise<void> {
+  if (!isKnowledgeScopeRecordId(input.recordId)) {
+    throw new BadRequestError(
+      `recordId must target a knowledge source (kb, article, or dataset): "${input.recordId}"`
+    )
+  }
   await db.transaction(async (tx) => {
     const current = await loadKnowledgeForUpdate(tx, input.agentId)
     const { idx, entry } = findScopeEntry(current, input.recordId)
@@ -96,9 +113,11 @@ export async function upsertAgentScopeRow(
 }
 
 /**
- * Remove a knowledge entry. Mention-sourced entries reject with an error —
- * those are managed by the prompt reconciler. Removing a non-existent entry
- * is a no-op.
+ * Remove a knowledge-source scope row. Mention-sourced entries reject with an
+ * error — those are managed by the prompt reconciler. Removing a
+ * non-existent entry is a no-op. No `recordId` validation here on purpose:
+ * removing a stale entity-record row left over from the deleted include
+ * system must keep working.
  */
 export async function removeAgentScopeRow(
   organizationId: string,
@@ -128,12 +147,16 @@ export async function removeAgentScopeRow(
 }
 
 /**
- * Replace the agent's full set of manual knowledge entries in one
+ * Replace the agent's full set of manual knowledge-source scope rows in one
  * transaction. Diff semantics:
  * - entries in `inputs` but not in the agent → insert (`source='manual'`)
  * - entries in both → update mode (and promote to `manual` if not already)
  * - entries on the agent but not in `inputs` → delete UNLESS `source='mention'`
  *   (mention entries are owned by the prompt reconciler and are preserved)
+ *
+ * @throws {BadRequestError} when any `inputs[].recordId` isn't a knowledge
+ *   source (`kb` / `article` / `dataset`). Validated up front, before the
+ *   transaction opens, so a bad row in a large batch never touches the DB.
  */
 export async function batchSetAgentResourceScopes(
   organizationId: string,
@@ -141,6 +164,14 @@ export async function batchSetAgentResourceScopes(
   inputs: Array<{ recordId: string; mode: AgentScopeMode }>,
   db: Database = defaultDb as Database
 ): Promise<{ applied: number }> {
+  for (const { recordId } of inputs) {
+    if (!isKnowledgeScopeRecordId(recordId)) {
+      throw new BadRequestError(
+        `recordId must target a knowledge source (kb, article, or dataset): "${recordId}"`
+      )
+    }
+  }
+
   const desired = new Map(inputs.map((row) => [row.recordId, row.mode]))
 
   await db.transaction(async (tx) => {
@@ -199,5 +230,3 @@ export class ScopeRowImmutableError extends Error {
     this.name = 'ScopeRowImmutableError'
   }
 }
-
-export { recordMatchesScopeRow }

--- a/packages/lib/src/agents/index.ts
+++ b/packages/lib/src/agents/index.ts
@@ -10,7 +10,6 @@ export {
   type AgentScopeRemoveInput,
   type AgentScopeUpsertInput,
   batchSetAgentResourceScopes,
-  recordMatchesScopeRow,
   removeAgentScopeRow,
   ScopeRowImmutableError,
   upsertAgentScopeRow,
@@ -77,6 +76,16 @@ export { BUILTIN_APP, BUILTIN_TOOLSETS, getBuiltinToolset } from './builtin-app'
 export { BUILTIN_DEFAULT_TOOLSETS, resolveDefaultToolsets } from './default-toolsets'
 export { filterToolsByToolsets } from './filter-tools'
 export {
+  type AgentKnowledgeScope,
+  filterKnowledgeScopeEntries,
+  isKnowledgeScopeRecordId,
+  KNOWLEDGE_SCOPE_PREFIXES,
+  type KnowledgeScopePrefix,
+  parseAgentKnowledgeScope,
+  parseKnowledgeScopeRecordId,
+  scopeHasIncludes,
+} from './knowledge-scope'
+export {
   type KnowledgeEntry,
   type KnowledgeMode,
   type KnowledgeSource,
@@ -92,6 +101,10 @@ export {
   walkPromptDocs,
 } from './prompt-mention-reconciler'
 export { type ResolvedAgentConfig, resolveAgentConfig } from './resolve-agent-config'
+export {
+  type ResolvedKnowledgeScope,
+  resolveAgentKnowledgeScope,
+} from './resolve-knowledge-scope'
 export {
   type SetAgentToolBindingsInput,
   setAgentToolBindings,

--- a/packages/lib/src/agents/knowledge-scope.ts
+++ b/packages/lib/src/agents/knowledge-scope.ts
@@ -1,0 +1,166 @@
+// packages/lib/src/agents/knowledge-scope.ts
+
+import type { KnowledgeEntry } from '@auxx/database'
+
+/**
+ * Resource-id prefixes a knowledge-scope row may target.
+ *
+ * `Agent.knowledge` used to double as an entity-record include list; that job
+ * moved to the permission layer (per-def / per-instance grants, doc 14), and
+ * this column is now purely a **retrieval scope**: which knowledge sources
+ * `search_knowledge` and the prompt's Knowledge Catalog look at by default.
+ * See plans/permissions/v2/15-agent-knowledge-scope.md §0.
+ */
+export const KNOWLEDGE_SCOPE_PREFIXES = ['kb', 'article', 'dataset'] as const
+
+export type KnowledgeScopePrefix = (typeof KNOWLEDGE_SCOPE_PREFIXES)[number]
+
+const PREFIX_SET = new Set<string>(KNOWLEDGE_SCOPE_PREFIXES)
+
+/**
+ * Prefixes that also work as a bare, definition-level row meaning "every one of
+ * these". Articles are excluded: a bare `article` row would mean "every article
+ * in the org", which a bare `kb` row already says.
+ */
+const DEFINITION_LEVEL_PREFIXES = new Set<string>(['kb', 'dataset'])
+
+/**
+ * Split a scope `recordId` into its resource prefix and instance id.
+ * `kb` → definition-level ("all knowledge bases"); `kb:abc` → one KB.
+ * Returns `null` for anything outside {@link KNOWLEDGE_SCOPE_PREFIXES}.
+ */
+export function parseKnowledgeScopeRecordId(
+  recordId: string
+): { prefix: KnowledgeScopePrefix; instanceId: string | null } | null {
+  const colon = recordId.indexOf(':')
+  if (colon === -1) {
+    return DEFINITION_LEVEL_PREFIXES.has(recordId)
+      ? { prefix: recordId as KnowledgeScopePrefix, instanceId: null }
+      : null
+  }
+  const prefix = recordId.slice(0, colon)
+  const instanceId = recordId.slice(colon + 1)
+  if (!PREFIX_SET.has(prefix) || instanceId.length === 0) return null
+  return { prefix: prefix as KnowledgeScopePrefix, instanceId }
+}
+
+/**
+ * Whether `recordId` is a valid knowledge-scope target. The single validation
+ * predicate shared by the `agentScope` router, the scope service, and the
+ * agents-builder LLM tool, so all three reject the same ids.
+ */
+export function isKnowledgeScopeRecordId(recordId: string): boolean {
+  return parseKnowledgeScopeRecordId(recordId) !== null
+}
+
+/**
+ * Drop entries whose `recordId` is not a knowledge source.
+ *
+ * Read-time defence (§0.6): `AgentVersion` snapshots are immutable and older
+ * ones still carry entity-record rows from the deleted include system. Every
+ * runtime consumer funnels through here, so those rows are inert without
+ * rewriting history.
+ */
+export function filterKnowledgeScopeEntries(
+  entries: readonly KnowledgeEntry[] | null | undefined
+): KnowledgeEntry[] {
+  if (!entries || entries.length === 0) return []
+  return entries.filter((e) => isKnowledgeScopeRecordId(e.recordId))
+}
+
+/**
+ * The knowledge-scope rows of an agent, bucketed by target and direction.
+ * Purely structural — ids are not validated against the org here (that happens
+ * in `resolveAgentKnowledgeScope`, which also drops dangling ones).
+ */
+export interface AgentKnowledgeScope {
+  /** Definition-level `kb` row — the default for KBs with no row of their own. */
+  allKbs: 'include' | 'exclude' | null
+  /** Definition-level `dataset` row. */
+  allDatasets: 'include' | 'exclude' | null
+  /** KBs included whole. Any include mode on a KB means its entire content. */
+  kbIds: string[]
+  /** Articles included on their own (`include_one`) — no descendants. */
+  articleIds: string[]
+  /** Articles included with their subtree (`include_descendants`). */
+  articleTreeIds: string[]
+  /** Standalone RAG datasets included. */
+  datasetIds: string[]
+  excludedKbIds: string[]
+  /** Excluded articles. Exclusion always covers the subtree (mirrors the UI). */
+  excludedArticleIds: string[]
+  excludedDatasetIds: string[]
+}
+
+/**
+ * Bucket an agent's knowledge rows into an {@link AgentKnowledgeScope}.
+ *
+ * Returns `null` when the agent has no knowledge-source rows at all — the
+ * unrestricted default (§0.3: empty scope = all org knowledge). Entity-record
+ * rows left over from the old include system are ignored, so an agent carrying
+ * only those is still unrestricted.
+ *
+ * Pure — safe to call from client code.
+ */
+export function parseAgentKnowledgeScope(
+  entries: readonly KnowledgeEntry[] | null | undefined
+): AgentKnowledgeScope | null {
+  const rows = filterKnowledgeScopeEntries(entries)
+  if (rows.length === 0) return null
+
+  const scope: AgentKnowledgeScope = {
+    allKbs: null,
+    allDatasets: null,
+    kbIds: [],
+    articleIds: [],
+    articleTreeIds: [],
+    datasetIds: [],
+    excludedKbIds: [],
+    excludedArticleIds: [],
+    excludedDatasetIds: [],
+  }
+
+  for (const row of rows) {
+    const parsed = parseKnowledgeScopeRecordId(row.recordId)
+    if (!parsed) continue
+    const { prefix, instanceId } = parsed
+    const isExclude = row.mode === 'exclude'
+
+    if (instanceId === null) {
+      const direction = isExclude ? 'exclude' : 'include'
+      if (prefix === 'kb') scope.allKbs = direction
+      else if (prefix === 'dataset') scope.allDatasets = direction
+      continue
+    }
+
+    if (prefix === 'kb') {
+      ;(isExclude ? scope.excludedKbIds : scope.kbIds).push(instanceId)
+    } else if (prefix === 'dataset') {
+      ;(isExclude ? scope.excludedDatasetIds : scope.datasetIds).push(instanceId)
+    } else if (isExclude) {
+      scope.excludedArticleIds.push(instanceId)
+    } else if (row.mode === 'include_descendants') {
+      scope.articleTreeIds.push(instanceId)
+    } else {
+      scope.articleIds.push(instanceId)
+    }
+  }
+
+  return scope
+}
+
+/**
+ * Whether the scope names anything to include. When it doesn't (exclude rows
+ * only), the searchable set starts org-wide and the excludes carve out of it
+ * (§0.3).
+ */
+export function scopeHasIncludes(scope: AgentKnowledgeScope): boolean {
+  return (
+    scope.allKbs === 'include' ||
+    scope.allDatasets === 'include' ||
+    scope.kbIds.length > 0 ||
+    scope.articleIds.length > 0 ||
+    scope.articleTreeIds.length > 0 ||
+    scope.datasetIds.length > 0
+  )
+}

--- a/packages/lib/src/agents/prompt-mention-reconciler.ts
+++ b/packages/lib/src/agents/prompt-mention-reconciler.ts
@@ -55,20 +55,27 @@ interface WalkedPrompt {
    * atomic rule). `toolset:<slug>` chips always resolve to `'*'`.
    */
   toolsetLocks: Map<string, WalkedToolsetLock>
-  /** RecordIds referenced by record chips (`article:<id>`, `entity:<id>`, …). */
+  /** RecordIds referenced by knowledge-source chips (`article:<id>`, `kb:<id>`, `dataset:<id>`). */
   recordIds: Set<string>
 }
 
 /**
- * Tiptap inline `reference` node prefixes that point at records (not at
- * tools/people/etc.). Anything matching one of these prefixes gets reconciled
- * into `Agent.knowledge`. Tool chips use the `tool:` prefix and reconcile into
- * `Agent.toolsets` instead.
+ * Tiptap inline `reference` node prefixes that point at knowledge sources
+ * (not at tools/people/entity records/etc.). Anything matching one of these
+ * prefixes gets reconciled into `Agent.knowledge` — mentioning a KB, article,
+ * or dataset in the persona prompt joins it to the agent's retrieval scope,
+ * which is the whole point of the feature. Tool chips use the `tool:` prefix
+ * and reconcile into `Agent.toolsets` instead.
+ *
+ * Mentioning a `ticket:`/`meeting:`/`entity:` record is just a prompt token —
+ * `resolve-instruction-references.ts` renders the bare id inline — and no
+ * longer writes a knowledge row; whether the agent may read that record is
+ * the permission layer's job (doc 14), not this reconciler's.
  *
  * Kept conservative on purpose — unknown prefixes are ignored so that adding a
  * new reference kind never inadvertently writes a knowledge row.
  */
-const RECORD_PREFIXES = new Set<string>(['article', 'kb', 'ticket', 'dataset', 'meeting', 'entity'])
+const RECORD_PREFIXES = new Set<string>(['article', 'kb', 'dataset'])
 
 function addLock(
   locks: Map<string, WalkedToolsetLock>,
@@ -92,9 +99,12 @@ function addLock(
 /**
  * Walk a Tiptap prompt doc, returning the resolved toolset locks (via
  * `tool:<name>` / `toolset:<slug>` chips resolved against `toolCatalog`) and
- * the set of record RecordIds (via `article:<id>` / `entity:<id>` / … chips).
+ * the set of knowledge-source RecordIds (via `article:<id>` / `kb:<id>` /
+ * `dataset:<id>` chips).
  *
- * Unknown chips are silently dropped. Pure function — does not mutate input.
+ * Unknown chips are silently dropped — including `ticket:`/`meeting:`/
+ * `entity:` record chips, which are prompt-only tokens with no knowledge-scope
+ * effect. Pure function — does not mutate input.
  */
 export function walkPromptDoc(
   prompt: Record<string, unknown>,

--- a/packages/lib/src/agents/resolve-agent-config.ts
+++ b/packages/lib/src/agents/resolve-agent-config.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/agents/resolve-agent-config.ts
 
-import type { AgentKind, Database } from '@auxx/database'
+import type { AgentKind, Database, KnowledgeEntry } from '@auxx/database'
 import { database as defaultDb, schema } from '@auxx/database'
 import { and, eq } from 'drizzle-orm'
 import { loadMasterKopilotSettings } from '../ai/kopilot/load-master-settings'
@@ -58,6 +58,15 @@ export interface ResolvedAgentConfig {
   toolRestrictions: ToolBindingMap
   /** Per-agent / per-master override. null = inherit org/system default. */
   modelId: string | null
+  /**
+   * The agent's retrieval scope (plans/permissions/v2/15-agent-knowledge-scope.md
+   * §1.1): raw `Agent.knowledge` rows, resolved via `resolveAgentKnowledgeScope`
+   * into the concrete datasets/articles `search_knowledge` and the prompt's
+   * Knowledge Catalog may look at. `[]` = unrestricted, org-wide knowledge —
+   * today's behavior, and the default for master Kopilot (which has no
+   * knowledge scope of its own).
+   */
+  knowledge: KnowledgeEntry[]
 }
 
 /**
@@ -96,6 +105,7 @@ export async function resolveAgentConfig(
       appAccounts: master.appAccounts,
       toolRestrictions: {},
       modelId: master.modelId,
+      knowledge: [],
     }
   }
 
@@ -110,6 +120,7 @@ export async function resolveAgentConfig(
   let behavior = {
     prompt: agent.prompt as Record<string, unknown>,
     toolsets: agent.toolsets,
+    knowledge: agent.knowledge,
     appAccounts: agent.appAccounts ?? {},
     toolRestrictions: (agent.toolRestrictions ?? {}) as ToolBindingMap,
     modelId: agent.modelId,
@@ -119,6 +130,7 @@ export async function resolveAgentConfig(
       .select({
         prompt: schema.Agent.prompt,
         toolsets: schema.Agent.toolsets,
+        knowledge: schema.Agent.knowledge,
         appAccounts: schema.Agent.appAccounts,
         toolRestrictions: schema.Agent.toolRestrictions,
         modelId: schema.Agent.modelId,
@@ -130,6 +142,7 @@ export async function resolveAgentConfig(
       behavior = {
         prompt: (row.prompt ?? {}) as Record<string, unknown>,
         toolsets: row.toolsets ?? [],
+        knowledge: row.knowledge ?? [],
         appAccounts: row.appAccounts ?? {},
         toolRestrictions: (row.toolRestrictions ?? {}) as ToolBindingMap,
         modelId: row.modelId ?? null,
@@ -165,6 +178,7 @@ export async function resolveAgentConfig(
     // it to a `VarRef`.
     toolRestrictions: behavior.toolRestrictions,
     modelId: behavior.modelId,
+    knowledge: behavior.knowledge,
   }
 }
 

--- a/packages/lib/src/agents/resolve-knowledge-scope.ts
+++ b/packages/lib/src/agents/resolve-knowledge-scope.ts
@@ -1,0 +1,420 @@
+// packages/lib/src/agents/resolve-knowledge-scope.ts
+
+import { type Database, type KnowledgeEntry, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNotNull } from 'drizzle-orm'
+import type { CapabilityView } from '../permissions/capabilities/capability-view'
+import {
+  type AgentKnowledgeScope,
+  parseAgentKnowledgeScope,
+  scopeHasIncludes,
+} from './knowledge-scope'
+
+const logger = createScopedLogger('agent-knowledge-scope')
+
+/**
+ * An agent's knowledge scope resolved against the org: concrete dataset ids to
+ * search plus the article-level narrowing the segment post-filter applies.
+ *
+ * `null` (not this type) means unrestricted — see
+ * {@link resolveAgentKnowledgeScope}.
+ */
+export interface ResolvedKnowledgeScope {
+  /**
+   * Datasets the scope permits. `search_knowledge` intersects its own resolved
+   * dataset set with this one — the scope narrows, it never adds a dataset the
+   * LLM args or the visitor clamp excluded.
+   */
+  datasetIds: ReadonlySet<string>
+  /**
+   * KBs whose entire content is in scope, including the hidden KBs that back
+   * linked knowledge sources federated into them. A segment from one of these
+   * passes the article filter regardless of its `articleId`.
+   */
+  fullKbIds: ReadonlySet<string>
+  /**
+   * Articles in scope on their own, because their KB is only partially
+   * included. Segments from a partially-included KB survive only if their
+   * `articleId` is in here.
+   */
+  articleIds: ReadonlySet<string>
+  /** Articles excluded outright — dropped even inside a fully-included KB. */
+  excludedArticleIds: ReadonlySet<string>
+}
+
+interface ResolveArgs {
+  db: Database
+  organizationId: string
+  /** Raw `Agent.knowledge` — entity rows from the old include system are ignored. */
+  entries: readonly KnowledgeEntry[] | null | undefined
+  /**
+   * Doc-14 capability view for the run. When present the scope is intersected
+   * with it (§0.4 — narrow, never widen): a scoped KB or dataset the principal
+   * cannot view is dropped. Absent ⇒ no intersection, as on the un-threaded
+   * workflow AI node.
+   */
+  capabilities?: CapabilityView
+}
+
+/**
+ * Resolve an agent's knowledge rows into the concrete set of datasets and
+ * articles its retrieval may touch.
+ *
+ * Returns `null` when the agent has no knowledge-source rows — the org-wide
+ * default, and the signal for consumers to skip scope work entirely.
+ *
+ * Dangling ids (a KB or dataset that has since been deleted) are dropped
+ * silently: resolution walks the org's live rows, so a stale id simply never
+ * matches. An agent whose only include rows are dangling therefore resolves to
+ * an empty scope — nothing in scope, rather than a silent widening back to
+ * org-wide.
+ */
+export async function resolveAgentKnowledgeScope(
+  args: ResolveArgs
+): Promise<ResolvedKnowledgeScope | null> {
+  const scope = parseAgentKnowledgeScope(args.entries)
+  if (!scope) return null
+
+  const { db, organizationId, capabilities } = args
+
+  const [kbRows, ragRows] = await Promise.all([
+    db
+      .select({ id: schema.KnowledgeBase.id, datasetId: schema.KnowledgeBase.datasetId })
+      .from(schema.KnowledgeBase)
+      .where(eq(schema.KnowledgeBase.organizationId, organizationId)),
+    db
+      .select({ id: schema.Dataset.id })
+      .from(schema.Dataset)
+      .where(
+        and(eq(schema.Dataset.organizationId, organizationId), eq(schema.Dataset.isManaged, false))
+      ),
+  ])
+
+  const hasIncludes = scopeHasIncludes(scope)
+  const kbIdSet = new Set(kbRows.map((r) => r.id))
+
+  // Articles first: a KB that isn't included whole but contributes articles is
+  // still "partially in scope", and its dataset must be searchable for the
+  // article post-filter to have anything to filter.
+  const articles = await resolveArticleScope(db, organizationId, scope, kbIdSet)
+
+  const { includedKbIds, partialKbIds, includedDatasetIds } = selectScopedSources({
+    scope,
+    hasIncludes,
+    kbIds: [...kbIdSet],
+    ragDatasetIds: ragRows.map((r) => r.id),
+    kbIdsWithScopedArticles: articles.kbIdsWithScopedArticles,
+    capabilities,
+  })
+
+  // Federate: a source linked into a scoped KB embeds its content in its own
+  // hidden KB's dataset, so those datasets — and those KB ids, which is what
+  // the segments carry — belong to the scoped KB's content.
+  const searchableKbIds = new Set([...includedKbIds, ...partialKbIds])
+  const federated = await resolveFederatedKbs(db, organizationId, searchableKbIds)
+
+  const datasetIdByKbId = new Map<string, string>()
+  for (const kb of kbRows) {
+    if (kb.datasetId) datasetIdByKbId.set(kb.id, kb.datasetId)
+  }
+
+  const datasetIds = new Set<string>(includedDatasetIds)
+  for (const kbId of searchableKbIds) {
+    const dsId = datasetIdByKbId.get(kbId)
+    if (dsId) datasetIds.add(dsId)
+  }
+  for (const fed of federated.datasetIds) datasetIds.add(fed)
+
+  // A federated KB's segments carry the *hidden* KB's id, so a fully-included
+  // parent must vouch for them too, or the article filter would drop them all.
+  const fullKbIds = new Set(includedKbIds)
+  for (const [parentKbId, ownedKbIds] of federated.ownedKbIdsByParent) {
+    if (!includedKbIds.has(parentKbId)) continue
+    for (const owned of ownedKbIds) fullKbIds.add(owned)
+  }
+
+  if (hasIncludes && datasetIds.size === 0) {
+    logger.warn('Agent knowledge scope resolved to nothing searchable', {
+      organizationId,
+      scopedKbIds: scope.kbIds.length,
+      scopedDatasetIds: scope.datasetIds.length,
+      scopedArticleIds: scope.articleIds.length + scope.articleTreeIds.length,
+    })
+  }
+
+  return {
+    datasetIds,
+    fullKbIds,
+    articleIds: articles.articleIds,
+    excludedArticleIds: articles.excludedArticleIds,
+  }
+}
+
+/**
+ * The precedence core: decide which KBs and RAG datasets a scope reaches,
+ * given the org's live ids. Pure — extracted from
+ * {@link resolveAgentKnowledgeScope} so the resolution rules can be tested
+ * without a database.
+ *
+ * - `includedKbIds` — in scope whole.
+ * - `partialKbIds` — not in scope whole, but carrying individually scoped
+ *   articles, so their dataset must still be searchable for the article
+ *   post-filter to have anything to narrow.
+ * - `includedDatasetIds` — standalone RAG datasets in scope.
+ *
+ * Capabilities are applied here (§0.4) so a source the principal cannot view
+ * can never reach the returned sets.
+ */
+export function selectScopedSources(args: {
+  scope: AgentKnowledgeScope
+  hasIncludes: boolean
+  kbIds: readonly string[]
+  ragDatasetIds: readonly string[]
+  kbIdsWithScopedArticles: ReadonlySet<string>
+  capabilities?: CapabilityView
+}): {
+  includedKbIds: Set<string>
+  partialKbIds: Set<string>
+  includedDatasetIds: Set<string>
+} {
+  const { scope, hasIncludes, kbIds, ragDatasetIds, kbIdsWithScopedArticles, capabilities } = args
+
+  const includedKbIds = new Set<string>()
+  const partialKbIds = new Set<string>()
+  for (const kbId of kbIds) {
+    if (kbLevel(scope, kbId, hasIncludes) === 'include') includedKbIds.add(kbId)
+    // Most-specific-wins: an explicitly included article outranks the exclusion
+    // of its KB, so an excluded KB still goes in as *partial* when it carries
+    // one. `kbIdsWithScopedArticles` is computed after article exclusions, so a
+    // KB with nothing individually scoped contributes nothing here.
+    else if (kbIdsWithScopedArticles.has(kbId)) partialKbIds.add(kbId)
+  }
+
+  const includedDatasetIds = new Set<string>()
+  for (const datasetId of ragDatasetIds) {
+    if (datasetLevel(scope, datasetId, hasIncludes) === 'include') {
+      includedDatasetIds.add(datasetId)
+    }
+  }
+
+  // §0.4 — intersect with the run's capabilities. A KB-backed dataset is
+  // governed by its KB grant (the container an admin actually shares), matching
+  // `filterAccessibleDatasetIds` in search-knowledge.ts.
+  if (capabilities) {
+    for (const id of includedKbIds) {
+      if (!capabilities.canViewInstance('kb', id)) includedKbIds.delete(id)
+    }
+    for (const id of partialKbIds) {
+      if (!capabilities.canViewInstance('kb', id)) partialKbIds.delete(id)
+    }
+    for (const id of includedDatasetIds) {
+      if (!capabilities.canViewInstance('dataset', id)) includedDatasetIds.delete(id)
+    }
+  }
+
+  return { includedKbIds, partialKbIds, includedDatasetIds }
+}
+
+type ScopeLevel = 'include' | 'exclude' | 'omit'
+
+/**
+ * Most-specific-wins, mirroring the builder tree's `deriveEffectiveMode`: the
+ * KB's own row beats the definition-level `kb` row, which beats the default.
+ * The default is "omit" once anything is explicitly included (an allow-list),
+ * and "include" when the scope only carves things out.
+ */
+function kbLevel(scope: AgentKnowledgeScope, kbId: string, hasIncludes: boolean): ScopeLevel {
+  if (scope.kbIds.includes(kbId)) return 'include'
+  if (scope.excludedKbIds.includes(kbId)) return 'exclude'
+  if (scope.allKbs) return scope.allKbs
+  return hasIncludes ? 'omit' : 'include'
+}
+
+function datasetLevel(
+  scope: AgentKnowledgeScope,
+  datasetId: string,
+  hasIncludes: boolean
+): ScopeLevel {
+  if (scope.datasetIds.includes(datasetId)) return 'include'
+  if (scope.excludedDatasetIds.includes(datasetId)) return 'exclude'
+  if (scope.allDatasets) return scope.allDatasets
+  return hasIncludes ? 'omit' : 'include'
+}
+
+interface ArticleScope {
+  articleIds: Set<string>
+  excludedArticleIds: Set<string>
+  /** KBs contributing at least one individually-scoped article. */
+  kbIdsWithScopedArticles: Set<string>
+}
+
+/**
+ * Expand the article rows through the placement tree. `include_descendants`
+ * carries to the subtree; `include_one` does not; exclusion always does — the
+ * same inheritance the builder tree shows.
+ */
+async function resolveArticleScope(
+  db: Database,
+  organizationId: string,
+  scope: AgentKnowledgeScope,
+  orgKbIds: ReadonlySet<string>
+): Promise<ArticleScope> {
+  const empty: ArticleScope = {
+    articleIds: new Set(),
+    excludedArticleIds: new Set(),
+    kbIdsWithScopedArticles: new Set(),
+  }
+
+  const seedIds = [
+    ...new Set([...scope.articleIds, ...scope.articleTreeIds, ...scope.excludedArticleIds]),
+  ]
+  if (seedIds.length === 0) return empty
+
+  const seedPlacements = await db
+    .select({
+      knowledgeBaseId: schema.ArticlePlacement.knowledgeBaseId,
+    })
+    .from(schema.ArticlePlacement)
+    .where(
+      and(
+        eq(schema.ArticlePlacement.organizationId, organizationId),
+        inArray(schema.ArticlePlacement.articleId, seedIds)
+      )
+    )
+
+  const kbIds = [
+    ...new Set(seedPlacements.map((p) => p.knowledgeBaseId).filter((id) => orgKbIds.has(id))),
+  ]
+  if (kbIds.length === 0) return empty
+
+  // One pass over the placements of every KB the seeds live in — enough to walk
+  // parent → child without a recursive query.
+  const placements = await db
+    .select({
+      id: schema.ArticlePlacement.id,
+      articleId: schema.ArticlePlacement.articleId,
+      parentId: schema.ArticlePlacement.parentId,
+      knowledgeBaseId: schema.ArticlePlacement.knowledgeBaseId,
+    })
+    .from(schema.ArticlePlacement)
+    .where(
+      and(
+        eq(schema.ArticlePlacement.organizationId, organizationId),
+        inArray(schema.ArticlePlacement.knowledgeBaseId, kbIds)
+      )
+    )
+
+  const childrenByParent = new Map<string, typeof placements>()
+  const placementsByArticle = new Map<string, typeof placements>()
+  for (const p of placements) {
+    if (p.parentId) {
+      const arr = childrenByParent.get(p.parentId) ?? []
+      arr.push(p)
+      childrenByParent.set(p.parentId, arr)
+    }
+    const byArticle = placementsByArticle.get(p.articleId) ?? []
+    byArticle.push(p)
+    placementsByArticle.set(p.articleId, byArticle)
+  }
+
+  const collectSubtree = (articleIds: readonly string[]): Set<string> => {
+    const out = new Set<string>()
+    const queue: string[] = []
+    for (const articleId of articleIds) {
+      for (const p of placementsByArticle.get(articleId) ?? []) queue.push(p.id)
+      out.add(articleId)
+    }
+    const seenPlacements = new Set<string>(queue)
+    while (queue.length > 0) {
+      const placementId = queue.pop() as string
+      for (const child of childrenByParent.get(placementId) ?? []) {
+        out.add(child.articleId)
+        if (seenPlacements.has(child.id)) continue
+        seenPlacements.add(child.id)
+        queue.push(child.id)
+      }
+    }
+    return out
+  }
+
+  const articleIds = new Set<string>(scope.articleIds)
+  for (const id of collectSubtree(scope.articleTreeIds)) articleIds.add(id)
+  const excludedArticleIds = collectSubtree(scope.excludedArticleIds)
+  for (const id of excludedArticleIds) articleIds.delete(id)
+
+  const kbIdsWithScopedArticles = new Set<string>()
+  for (const articleId of articleIds) {
+    for (const p of placementsByArticle.get(articleId) ?? []) {
+      kbIdsWithScopedArticles.add(p.knowledgeBaseId)
+    }
+  }
+
+  return { articleIds, excludedArticleIds, kbIdsWithScopedArticles }
+}
+
+/**
+ * Datasets + owned KB ids of the knowledge sources linked into `kbIds`. Mirrors
+ * the federation branch of `collectManagedDatasetIds` — search stays embed-once,
+ * so a scoped KB has to bring its linked sources' datasets along.
+ */
+async function resolveFederatedKbs(
+  db: Database,
+  organizationId: string,
+  kbIds: ReadonlySet<string>
+): Promise<{ datasetIds: Set<string>; ownedKbIdsByParent: Map<string, string[]> }> {
+  const result = { datasetIds: new Set<string>(), ownedKbIdsByParent: new Map<string, string[]>() }
+  if (kbIds.size === 0) return result
+
+  const linkRows = await db
+    .selectDistinct({
+      knowledgeBaseId: schema.ArticlePlacement.knowledgeBaseId,
+      sourceId: schema.ArticlePlacement.linkedFromSourceId,
+    })
+    .from(schema.ArticlePlacement)
+    .where(
+      and(
+        eq(schema.ArticlePlacement.organizationId, organizationId),
+        inArray(schema.ArticlePlacement.knowledgeBaseId, [...kbIds]),
+        isNotNull(schema.ArticlePlacement.linkedFromSourceId)
+      )
+    )
+  if (linkRows.length === 0) return result
+
+  const sourceIds = [
+    ...new Set(linkRows.map((r) => r.sourceId).filter((id): id is string => Boolean(id))),
+  ]
+  const sources = await db
+    .select({
+      id: schema.KnowledgeSource.id,
+      ownedKnowledgeBaseId: schema.KnowledgeSource.ownedKnowledgeBaseId,
+    })
+    .from(schema.KnowledgeSource)
+    .where(
+      and(
+        inArray(schema.KnowledgeSource.id, sourceIds),
+        eq(schema.KnowledgeSource.organizationId, organizationId)
+      )
+    )
+
+  const ownedKbIdBySource = new Map(sources.map((s) => [s.id, s.ownedKnowledgeBaseId]))
+  for (const row of linkRows) {
+    const ownedKbId = row.sourceId ? ownedKbIdBySource.get(row.sourceId) : undefined
+    if (!ownedKbId) continue
+    const arr = result.ownedKbIdsByParent.get(row.knowledgeBaseId) ?? []
+    arr.push(ownedKbId)
+    result.ownedKbIdsByParent.set(row.knowledgeBaseId, arr)
+  }
+
+  const ownedKbIds = [...new Set(sources.map((s) => s.ownedKnowledgeBaseId).filter(Boolean))]
+  if (ownedKbIds.length === 0) return result
+
+  const ownedKbs = await db
+    .select({ datasetId: schema.KnowledgeBase.datasetId })
+    .from(schema.KnowledgeBase)
+    .where(inArray(schema.KnowledgeBase.id, ownedKbIds))
+  for (const kb of ownedKbs) {
+    if (kb.datasetId) result.datasetIds.add(kb.datasetId)
+  }
+
+  return result
+}

--- a/packages/lib/src/ai/agent-framework/effective-runtime.ts
+++ b/packages/lib/src/ai/agent-framework/effective-runtime.ts
@@ -7,6 +7,7 @@
 // divergent second copy (plans/evals/phase-1-agent-simulation.md §1.4,
 // conventions.md §5).
 
+import { database } from '@auxx/database'
 import { filterToolsByToolsets, type ResolvedAgentConfig, resolveAgentConfig } from '../../agents'
 import {
   buildApplyBindings,
@@ -15,6 +16,10 @@ import {
 } from '../../agents/bindings'
 import type { AgentSurface } from '../../agents/client'
 import { PROCEDURE_CONTROL_TOOLS } from '../../agents/procedures'
+import {
+  type ResolvedKnowledgeScope,
+  resolveAgentKnowledgeScope,
+} from '../../agents/resolve-knowledge-scope'
 import type { CapabilityView } from '../../permissions/capabilities/capability-view'
 import {
   type CapabilityRegistry,
@@ -174,14 +179,21 @@ export async function buildAgentCapabilityRegistry(args: {
   signal?: AbortSignal
   /** Read/write enforcement for this run (§3.1). Omit → unrestricted, as today. */
   capabilities?: CapabilityView
+  /**
+   * The running agent's resolved retrieval scope (§1.1). Optional — the eval
+   * mock validator calls this builder without one, and callers with no scope
+   * to thread keep today's unrestricted behavior.
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }): Promise<CapabilityRegistry> {
-  const { organizationId, userId, sessionId, agentId, signal, capabilities } = args
+  const { organizationId, userId, sessionId, agentId, signal, capabilities, knowledgeScope } = args
   const getToolDeps = createToolDepsFactory({
     organizationId,
     userId,
     sessionId,
     signal,
     capabilities,
+    knowledgeScope,
   })
 
   const registry = createCapabilityRegistry()
@@ -231,6 +243,18 @@ export async function buildEffectiveAgentRuntime(
     source,
   })
 
+  const agentConfig = await resolveAgentConfig(organizationId, agentId, undefined, { source })
+
+  // Resolve once per turn (§1.1) — shared by both the tool deps (read gate)
+  // and the domain config (prompt-side catalog filtering). `null` entries
+  // (master Kopilot) resolve to `null` = unrestricted, matching today.
+  const knowledgeScope = await resolveAgentKnowledgeScope({
+    db: database,
+    organizationId,
+    entries: agentConfig.knowledge,
+    capabilities: args.capabilities,
+  })
+
   const registry = await buildAgentCapabilityRegistry({
     organizationId,
     userId,
@@ -238,9 +262,9 @@ export async function buildEffectiveAgentRuntime(
     agentId,
     signal,
     capabilities: args.capabilities,
+    knowledgeScope,
   })
 
-  const agentConfig = await resolveAgentConfig(organizationId, agentId, undefined, { source })
   const resolvedPage = args.page ?? '__none__'
   const filteredTools = filterToolsByToolsets(registry.getTools(resolvedPage), agentConfig)
   // Mount procedure-control tools when this agent has procedures — inert without
@@ -288,6 +312,9 @@ export async function buildEffectiveAgentRuntime(
     // Prompt-side catalog filtering (§3.4) — the entity/KB catalogs the model is
     // handed are narrowed to what this run may actually read.
     capabilities: args.capabilities,
+    // The agent's retrieval scope (§1.1) — narrows the Knowledge Catalog the
+    // prompt renders to what this agent may actually search.
+    knowledgeScope,
     // Long-running plans (≥30 steps × ~1–2 LLM rounds each) need headroom past
     // the framework's small-loop default.
     maxIterations: 30,

--- a/packages/lib/src/ai/kopilot/agents/agent.ts
+++ b/packages/lib/src/ai/kopilot/agents/agent.ts
@@ -5,6 +5,7 @@ import { toActorId } from '@auxx/types/actor'
 import { getOrgToolCatalog, getOrgToolsetCatalog, type ResolvedAgentConfig } from '../../../agents'
 import type { AgentSurface } from '../../../agents/client'
 import { PROCEDURE_STEP_KEY } from '../../../agents/procedures/persist'
+import type { ResolvedKnowledgeScope } from '../../../agents/resolve-knowledge-scope'
 import { getCachedIntegrationCatalog } from '../../../cache/integration-catalog'
 import {
   getCachedKbCatalog,
@@ -70,6 +71,13 @@ export interface CreateKopilotAgentOptions {
    * the human-readable capability *description* list.
    */
   recordAccess?: CapabilityView
+  /**
+   * The running agent's resolved retrieval scope (capability layer v2 §1.1).
+   * Forwarded into `buildKopilotPromptSerialized` so the Knowledge Catalog
+   * section can narrow to what this agent may actually search. Absent/null ⇒
+   * unrestricted, org-wide knowledge — today's behavior.
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }
 
 /**
@@ -92,6 +100,7 @@ export function createKopilotAgent(
     audience,
     triggerContext,
     recordAccess,
+    knowledgeScope,
   } = options
 
   const agentTools: AgentToolDefinition[] = tools
@@ -167,6 +176,7 @@ export function createKopilotAgent(
         instructionsReferences,
         procedureStep,
         recordAccess,
+        knowledgeScope,
       })
 
       // Full conversation for tool-loop continuity. Each persisted assistant

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
@@ -4,7 +4,7 @@ import {
   type AgentScopeMode,
   batchSetAgentResourceScopes,
 } from '../../../../../agents/agent-scope-service'
-import { findCachedResource } from '../../../../../cache/org-cache-helpers'
+import { isKnowledgeScopeRecordId } from '../../../../../agents/knowledge-scope'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { findRef } from '../../../context-refs'
 import type { GetToolDeps } from '../../types'
@@ -15,9 +15,13 @@ const RECORD_ID_MIN = 1
 const RECORD_ID_MAX = 180
 
 /**
- * Replace the agent's resource-scope rows. Pass the full desired set; rows in
- * the DB that aren't in `scopes` are deleted (unless they're mention-sourced,
- * which the prompt reconciler owns).
+ * Narrow (or widen) which knowledge bases, articles and datasets the agent
+ * searches by default — its **retrieval scope**, not an access-control list.
+ * Pass the full desired set; rows in the DB that aren't in `scopes` are
+ * deleted (unless they're mention-sourced, which the prompt reconciler owns).
+ *
+ * Permissions (who/what the agent may read) are configured separately — this
+ * tool only shapes what `search_knowledge` and the Knowledge Catalog look at.
  */
 export function createSetAgentResourceScopeTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -25,18 +29,25 @@ export function createSetAgentResourceScopeTool(getDeps: GetToolDeps): AgentTool
     displayName: 'Set agent resource scope',
     // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
     surfaces: ['builder'],
-    description: `Update the agent's resource-scope rows (which records / entity types it can read).
+    description: `Narrow which knowledge sources the agent searches by default (its retrieval scope) —
+for example "focus this agent on the Returns KB" or "exclude the internal-only dataset".
+
+This is NOT an access-control mechanism — permissions (who/what the agent may
+read) are configured separately. An empty scope means the agent searches all
+org knowledge; scoping only narrows the default search set.
 
 Pass the FULL desired set of scopes. Rows in the DB that aren't in this list
 are removed (mention-pinned rows are preserved).
 
 Each row:
-- recordId: \`<defId>:<instanceId>\` for one record, or just \`<defId>\` for
-  a definition-level scope (covers every record of that type).
+- recordId targets a knowledge source: \`kb:<id>\` (one knowledge base),
+  \`article:<id>\` (one article), \`dataset:<id>\` (one RAG dataset), or the
+  bare definition-level \`kb\` / \`dataset\` (covers every KB / dataset in the
+  org). Bare \`article\` is not valid — articles are always instance-level.
 - mode: include_descendants | include_one | exclude
 
-Search for record names first with \`search_entities\` / \`search_knowledge\`
-before guessing recordIds.`,
+Search for source names first with \`search_knowledge\` before guessing
+recordIds.`,
     parameters: {
       type: 'object',
       properties: {
@@ -50,7 +61,8 @@ before guessing recordIds.`,
                 type: 'string',
                 minLength: RECORD_ID_MIN,
                 maxLength: RECORD_ID_MAX,
-                description: '`<defId>:<instanceId>` or `<defId>` for definition-level',
+                description:
+                  'Knowledge source id: `kb:<id>`, `article:<id>`, `dataset:<id>`, or bare `kb`/`dataset` for definition-level',
               },
               mode: { type: 'string', enum: VALID_MODES },
             },
@@ -97,14 +109,11 @@ before guessing recordIds.`,
             error: `mode must be one of: ${VALID_MODES.join(', ')}`,
           }
         }
-        const colon = row.recordId.indexOf(':')
-        const entityDefinitionId = colon === -1 ? row.recordId : row.recordId.slice(0, colon)
-        const def = await findCachedResource(agentDeps.organizationId, entityDefinitionId)
-        if (!def) {
+        if (!isKnowledgeScopeRecordId(row.recordId)) {
           return {
             success: false,
             output: null,
-            error: `Unknown entityDefinitionId "${entityDefinitionId}" in recordId "${row.recordId}".`,
+            error: `recordId "${row.recordId}" must target a knowledge source: \`kb:<id>\`, \`article:<id>\`, \`dataset:<id>\`, or bare \`kb\`/\`dataset\`.`,
           }
         }
       }

--- a/packages/lib/src/ai/kopilot/capabilities/create-deps.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/create-deps.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/create-deps.ts
 
 import { database } from '@auxx/database'
+import type { ResolvedKnowledgeScope } from '../../../agents/resolve-knowledge-scope'
 import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
 import type { SessionContext } from '../types'
 import type { GetToolDeps, ToolDeps } from './types'
@@ -32,6 +33,12 @@ export function createToolDepsFactory(params: {
    * fallback, and do not add new callers that rely on it.
    */
   capabilities?: CapabilityView
+  /**
+   * The running agent's resolved retrieval scope (§1.1), resolved once and
+   * shared by every tool call in the turn. Same `null`-is-unrestricted
+   * semantics as {@link capabilities}. Absent for un-threaded callers.
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }): GetToolDeps {
   return (): ToolDeps => ({
     db: database,
@@ -41,5 +48,6 @@ export function createToolDepsFactory(params: {
     signal: params.signal,
     sessionContext: params.sessionContext ?? {},
     capabilities: params.capabilities,
+    knowledgeScope: params.knowledgeScope,
   })
 }

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-scope.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-scope.test.ts
@@ -1,0 +1,63 @@
+// packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-scope.test.ts
+//
+// Permissions v2 §1.2/1.3 (agent knowledge scope): the article-level
+// post-filter search_knowledge applies on top of the dataset-level filter,
+// so a partially-scoped KB's out-of-scope articles never surface even though
+// they share the KB's dataset with in-scope ones. Pure/DB-free — exercises
+// `isSegmentInKnowledgeScope` directly against fabricated `ResolvedKnowledgeScope`
+// values.
+
+import { describe, expect, it } from 'vitest'
+import type { ResolvedKnowledgeScope } from '../../../../../../agents/resolve-knowledge-scope'
+import { isSegmentInKnowledgeScope } from '../search-knowledge'
+
+function scope(over: Partial<ResolvedKnowledgeScope> = {}): ResolvedKnowledgeScope {
+  return {
+    datasetIds: new Set(),
+    fullKbIds: new Set(),
+    articleIds: new Set(),
+    excludedArticleIds: new Set(),
+    ...over,
+  }
+}
+
+describe('isSegmentInKnowledgeScope', () => {
+  it('null/undefined scope is a no-op — always keeps', () => {
+    expect(isSegmentInKnowledgeScope({ source: 'kb', articleId: 'a1', kbId: 'kb1' }, null)).toBe(
+      true
+    )
+    expect(
+      isSegmentInKnowledgeScope({ source: 'kb', articleId: 'a1', kbId: 'kb1' }, undefined)
+    ).toBe(true)
+  })
+
+  it('always keeps a RAG segment regardless of scope', () => {
+    const s = scope({ fullKbIds: new Set(['kb_other']) })
+    expect(isSegmentInKnowledgeScope({ source: 'rag', articleId: 'a1', kbId: 'kb1' }, s)).toBe(true)
+    // Even with no metadata at all.
+    expect(isSegmentInKnowledgeScope({ source: 'rag' }, s)).toBe(true)
+  })
+
+  it('keeps a KB segment whose kbId is fully in scope', () => {
+    const s = scope({ fullKbIds: new Set(['kb1']) })
+    expect(isSegmentInKnowledgeScope({ source: 'kb', articleId: 'a1', kbId: 'kb1' }, s)).toBe(true)
+  })
+
+  it('in a partially-included KB, keeps only articles individually in scope', () => {
+    const s = scope({ articleIds: new Set(['a1']) })
+    expect(isSegmentInKnowledgeScope({ source: 'kb', articleId: 'a1', kbId: 'kb1' }, s)).toBe(true)
+    expect(isSegmentInKnowledgeScope({ source: 'kb', articleId: 'a2', kbId: 'kb1' }, s)).toBe(false)
+  })
+
+  it('drops an excluded article even inside a fully-included KB', () => {
+    const s = scope({ fullKbIds: new Set(['kb1']), excludedArticleIds: new Set(['a1']) })
+    expect(isSegmentInKnowledgeScope({ source: 'kb', articleId: 'a1', kbId: 'kb1' }, s)).toBe(false)
+    // A sibling article in the same fully-included KB still passes.
+    expect(isSegmentInKnowledgeScope({ source: 'kb', articleId: 'a2', kbId: 'kb1' }, s)).toBe(true)
+  })
+
+  it('drops a KB segment with no kbId/articleId when neither fullKbIds nor articleIds match', () => {
+    const s = scope({ fullKbIds: new Set(['kb_other']), articleIds: new Set(['a_other']) })
+    expect(isSegmentInKnowledgeScope({ source: 'kb' }, s)).toBe(false)
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -3,6 +3,7 @@
 import { schema } from '@auxx/database'
 import { and, eq, inArray, isNotNull } from 'drizzle-orm'
 import { z } from 'zod'
+import type { ResolvedKnowledgeScope } from '../../../../../agents/resolve-knowledge-scope'
 import { SearchService } from '../../../../../datasets/services/search.service'
 import type { CapabilityView } from '../../../../../permissions/capabilities/capability-view'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
@@ -59,6 +60,23 @@ type Source = 'kb' | 'rag' | 'both'
  * Unified hybrid search across KB-managed datasets (article embeddings) and
  * user-uploaded RAG datasets. The two share an embedding pipeline, so we just
  * pick the right dataset id set and let SearchService do the work.
+ *
+ * Three narrowings stack on the searchable set, in this order:
+ *  1. Visitor PUBLIC clamp (`publicOnly` / `isChat` below) — **security**. An
+ *     untrusted external caller must never reach an INTERNAL KB or any RAG
+ *     dataset, full stop.
+ *  2. Agent retrieval scope (`knowledgeScope`, permissions v2 §1.2/1.3) —
+ *     **relevance-by-design**, not a security boundary of its own: it's the
+ *     agent author's choice of which of the org's *otherwise-accessible*
+ *     knowledge this agent should draw from. Narrows `resolveDatasetIds`'
+ *     dataset set (1a) and, for KB segments, narrows further at the article
+ *     level via {@link isSegmentInKnowledgeScope} (1b) — a dataset in scope
+ *     can still hold articles the scope excludes.
+ *  3. Capability instance-access (`capabilities`, doc-14) — **security**.
+ *     Read enforcement for the acting principal; a KB/dataset the scope
+ *     allows but the principal can't view is still dropped.
+ * `null`/`undefined` `knowledgeScope` is unrestricted org-wide, exactly
+ * today's pre-scope behaviour, with no added queries.
  */
 export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -164,7 +182,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
       return { ok: true, args: { ...args, query: query.value } }
     },
     execute: async (args, agentDeps) => {
-      const { db, capabilities } = getDeps()
+      const { db, capabilities, knowledgeScope } = getDeps()
       const query = args.query as string
       const requestedSource = ((args.source as Source) ?? 'both') as Source
       const knowledgeBaseId = args.knowledgeBaseId as string | undefined
@@ -191,6 +209,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
           requestedDatasetIds,
           publicOnly: isChat,
           capabilities,
+          knowledgeScope,
         })
 
         if (datasetIds.length === 0) {
@@ -215,16 +234,19 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
           agentDeps.userId
         )
 
-        const filtered =
-          recordIds && recordIds.length > 0
-            ? response.results.filter((r) => {
-                const links = (r.segment.metadata as any)?.links as
-                  | Array<{ recordId: string }>
-                  | undefined
-                if (!links || links.length === 0) return false
-                return links.some((l) => recordIds.includes(l.recordId))
-              })
-            : response.results
+        const filtered = response.results.filter((r) => {
+          const meta = (r.segment.metadata as any) ?? {}
+          if (recordIds && recordIds.length > 0) {
+            const links = meta.links as Array<{ recordId: string }> | undefined
+            if (!links || links.length === 0) return false
+            if (!links.some((l) => recordIds.includes(l.recordId))) return false
+          }
+          // Agent retrieval scope (permissions v2 §1.2/1.3) — relevance/security
+          // narrowing stacked on top of the dataset-level filter above, needed
+          // because a partially-scoped KB's segments still share the KB's
+          // dataset with its out-of-scope siblings.
+          return isSegmentInKnowledgeScope(meta, knowledgeScope)
+        })
 
         // One result per article (KB) / document (RAG): results arrive score-
         // sorted, so the first segment seen for a source is its best passage.
@@ -329,6 +351,36 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
   }
 }
 
+/**
+ * Article-level narrowing gate for a single search result (permissions v2
+ * §1.2/1.3 — agent retrieval scope). Pure and DB-free: `scope` is already
+ * fully resolved by `resolveAgentKnowledgeScope`, so this is a plain set
+ * lookup, not a re-derivation of KB/article inclusion.
+ *
+ * `null`/`undefined` scope ⇒ unrestricted, always keep (today's behaviour).
+ * A RAG segment (`meta.source !== 'kb'`) is always kept here too — RAG has no
+ * article concept, and it's already governed by the dataset-level
+ * `datasetIds` intersection in {@link resolveDatasetIds}.
+ *
+ * Deliberate deferral (plan §4): this filters the over-fetched result set in
+ * memory rather than pushing a `searchMetadata->>'articleId'` predicate into
+ * `SearchService.search` / `searchByVectorMultiDataset`. The existing
+ * `limit * 3` over-fetch (capped 50) already leaves headroom for this
+ * post-filter; pushing the predicate into the vector query is the follow-up
+ * if scoped-article recall proves thin in practice, not part of this slice.
+ */
+export function isSegmentInKnowledgeScope(
+  meta: { source?: string; articleId?: string; kbId?: string },
+  scope: ResolvedKnowledgeScope | null | undefined
+): boolean {
+  if (!scope) return true
+  if (meta.source !== 'kb') return true
+  if (meta.articleId !== undefined && scope.excludedArticleIds.has(meta.articleId)) return false
+  if (meta.kbId !== undefined && scope.fullKbIds.has(meta.kbId)) return true
+  if (meta.articleId !== undefined && scope.articleIds.has(meta.articleId)) return true
+  return false
+}
+
 async function resolveDatasetIds(args: {
   db: import('@auxx/database').Database
   organizationId: string
@@ -339,6 +391,13 @@ async function resolveDatasetIds(args: {
   publicOnly?: boolean
   /** Resolved instance-access gate for the turn; absent ⇒ unrestricted. */
   capabilities?: CapabilityView
+  /**
+   * Agent retrieval scope (permissions v2 §1.2/1.3). Intersected with the
+   * collected dataset ids below — narrows, never adds — before the
+   * capability instance-access filter runs. `null`/`undefined` ⇒ unrestricted
+   * and zero added I/O (a plain array filter, no extra query either way).
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }): Promise<string[]> {
   const {
     db,
@@ -348,6 +407,7 @@ async function resolveDatasetIds(args: {
     requestedDatasetIds,
     publicOnly,
     capabilities,
+    knowledgeScope,
   } = args
 
   const ids = await collectDatasetIds({
@@ -358,7 +418,11 @@ async function resolveDatasetIds(args: {
     requestedDatasetIds,
     publicOnly,
   })
-  return filterAccessibleDatasetIds(db, organizationId, ids, capabilities)
+  // Cheap in-memory intersection, no I/O — runs before the capability filter's
+  // extra KB query so a scope that already narrows to nothing skips it
+  // entirely. Absent scope is a no-op pass-through.
+  const scoped = knowledgeScope ? ids.filter((id) => knowledgeScope.datasetIds.has(id)) : ids
+  return filterAccessibleDatasetIds(db, organizationId, scoped, capabilities)
 }
 
 async function collectDatasetIds(args: {

--- a/packages/lib/src/ai/kopilot/capabilities/types.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/types.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/types.ts
 
 import type { Database } from '@auxx/database'
+import type { ResolvedKnowledgeScope } from '../../../agents/resolve-knowledge-scope'
 import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
 import type { AgentDeps, AgentToolDefinition } from '../../agent-framework/types'
 import type { SessionContext } from '../types'
@@ -21,6 +22,14 @@ export interface ToolDeps extends AgentDeps {
    * Entity tools that read records gate each def through `canViewEntity`.
    */
   capabilities?: CapabilityView
+  /**
+   * The agent's resolved retrieval scope (plans/permissions/v2/15-agent-knowledge-scope.md
+   * §1.1), resolved once per turn. Present ONLY when the running agent has a
+   * non-empty `Agent.knowledge` scope; absent/null ⇒ unrestricted, org-wide
+   * knowledge — today's behavior. Read by knowledge-retrieval tools to narrow
+   * which datasets/articles they search.
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }
 
 /** Factory function that provides ToolDeps at execution time */

--- a/packages/lib/src/ai/kopilot/domain-config.ts
+++ b/packages/lib/src/ai/kopilot/domain-config.ts
@@ -4,6 +4,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { ResolvedAgentConfig } from '../../agents'
 import type { AgentSurface } from '../../agents/client'
 import { PROCEDURE_SLICE_KEY } from '../../agents/procedures/persist'
+import type { ResolvedKnowledgeScope } from '../../agents/resolve-knowledge-scope'
 import type { CapabilityView } from '../../permissions/capabilities/capability-view'
 import { CONTEXT_SLICE_KEY, readContextSlice } from '../agent-framework/context'
 import type {
@@ -81,6 +82,14 @@ export interface KopilotDomainConfigOptions {
    * to today (workflow AI node, tests, any un-threaded caller).
    */
   capabilities?: CapabilityView
+  /**
+   * The running agent's resolved retrieval scope (plans/permissions/v2/
+   * 15-agent-knowledge-scope.md §1.1), threaded into `createKopilotAgent` so
+   * the Knowledge Catalog section can narrow to what this agent may actually
+   * search. Same object the tool deps get. Absent/null ⇒ unrestricted,
+   * org-wide knowledge — today's behavior.
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }
 
 /**
@@ -108,6 +117,7 @@ export function createKopilotDomainConfig(
     // Aliased: `capabilities` below is the string[] of capability *descriptions*
     // rendered into the prompt — a different thing from the access gate.
     capabilities: recordAccess,
+    knowledgeScope,
   } = options
 
   // Cheap same-provider sibling for low-stakes internal LLM tasks (procedure
@@ -153,6 +163,7 @@ export function createKopilotDomainConfig(
     audience,
     triggerContext,
     recordAccess,
+    knowledgeScope,
   })
 
   return {

--- a/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
@@ -3,6 +3,7 @@
 import { createScopedLogger } from '@auxx/logger'
 import type { ResolvedAgentConfig } from '../../../agents'
 import type { AgentSurface } from '../../../agents/client'
+import type { ResolvedKnowledgeScope } from '../../../agents/resolve-knowledge-scope'
 import type { IntegrationCatalogEntry } from '../../../cache/integration-catalog'
 import type { KbCatalogEntry } from '../../../kb/catalog/kb-catalog'
 import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
@@ -77,6 +78,13 @@ export interface BuildKopilotPromptArgs {
    * filtering, byte-identical output to today.
    */
   recordAccess?: CapabilityView
+  /**
+   * The running agent's resolved retrieval scope (capability layer v2 §1.1).
+   * Sections rendering the Knowledge Catalog narrow it to what this agent may
+   * actually search. Absent/null ⇒ unrestricted, org-wide knowledge —
+   * byte-identical output to today.
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }
 
 /**
@@ -171,6 +179,7 @@ function buildPromptCtx(args: BuildKopilotPromptArgs): PromptCtx {
     triggerContext: args.triggerContext,
     procedureStep: args.procedureStep,
     recordAccess: args.recordAccess,
+    knowledgeScope: args.knowledgeScope,
   }
 }
 

--- a/packages/lib/src/ai/kopilot/prompts/sections/kb-catalog.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/kb-catalog.ts
@@ -14,6 +14,11 @@ import { ALL_MODES, type PromptSection } from './types'
  * (capability layer v2 §3.4). Without it the catalog handed a member the full
  * ToC — titles plus body-derived descriptions — of every INTERNAL KB, including
  * ones they hold no instance grant on.
+ *
+ * `ctx.knowledgeScope` (permissions v2 §1.2/1.3) narrows further: the agent's
+ * own retrieval scope, same allowlist `search_knowledge` enforces. Without
+ * this the catalog could advertise a KB or article the tool can't actually
+ * return.
  */
 export const kbCatalog: PromptSection = {
   id: 'kb-catalog',
@@ -29,6 +34,7 @@ export const kbCatalog: PromptSection = {
       publicOnly: ctx.audience === 'customer',
       hasGetArticle,
       canViewKb: recordAccess ? (kbId) => recordAccess.canViewInstance('kb', kbId) : undefined,
+      knowledgeScope: ctx.knowledgeScope,
     })
   },
 }

--- a/packages/lib/src/ai/kopilot/prompts/sections/types.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/types.ts
@@ -2,6 +2,7 @@
 
 import type { ResolvedAgentConfig } from '../../../../agents'
 import type { AgentSurface } from '../../../../agents/client'
+import type { ResolvedKnowledgeScope } from '../../../../agents/resolve-knowledge-scope'
 import type { IntegrationCatalogEntry } from '../../../../cache/integration-catalog'
 import type { KbCatalogEntry } from '../../../../kb/catalog/kb-catalog'
 import type { CapabilityView } from '../../../../permissions/capabilities/capability-view'
@@ -111,6 +112,12 @@ export interface PromptCtx {
    * human-readable capability descriptions.
    */
   readonly recordAccess?: CapabilityView
+  /**
+   * The running agent's resolved retrieval scope (capability layer v2 §1.1).
+   * The Knowledge Catalog section narrows to this. Absent/null ⇒
+   * unrestricted, org-wide knowledge — today's output.
+   */
+  readonly knowledgeScope?: ResolvedKnowledgeScope | null
 }
 
 export interface PromptSection {

--- a/packages/lib/src/chat/agent/build-chat-engine-config.ts
+++ b/packages/lib/src/chat/agent/build-chat-engine-config.ts
@@ -9,6 +9,7 @@ import {
 } from '../../agents/bindings'
 import { ALL_SURFACES } from '../../agents/client'
 import { PROCEDURE_CONTROL_TOOLS } from '../../agents/procedures/control-tools'
+import { resolveAgentKnowledgeScope } from '../../agents/resolve-knowledge-scope'
 import {
   type AgentEngineConfig,
   createCallModel,
@@ -119,12 +120,23 @@ export async function buildChatEngineConfig(
     ? await resolveAgentRunCapabilities({ agent: cachedAgent, organizationId })
     : undefined
 
+  // Resolve once per turn (§1.1) — shared by the tool deps (read gate) and the
+  // domain config (prompt-side catalog filtering). `[]` knowledge (no scope
+  // rows) resolves to `null` = unrestricted, matching today.
+  const knowledgeScope = await resolveAgentKnowledgeScope({
+    db,
+    organizationId,
+    entries: agentConfig.knowledge,
+    capabilities,
+  })
+
   const getToolDeps = createToolDepsFactory({
     organizationId,
     userId: agentUserId,
     sessionId,
     signal,
     capabilities,
+    knowledgeScope,
   })
 
   const registry = createCapabilityRegistry()
@@ -188,6 +200,9 @@ export async function buildChatEngineConfig(
     audience: 'customer',
     // Prompt-side catalog filtering (§3.4) — same view the tools enforce with.
     capabilities,
+    // The agent's retrieval scope (§1.1) — narrows the Knowledge Catalog to
+    // what this agent may actually search.
+    knowledgeScope,
     // No `triggerContext` — chat is not an AgentTrigger run; it stays
     // `runMode: 'interactive'` (the visitor is in the loop). The surface/audience
     // gates do the customer-facing work the trigger envelope used to.

--- a/packages/lib/src/kb/catalog/__tests__/kb-catalog.test.ts
+++ b/packages/lib/src/kb/catalog/__tests__/kb-catalog.test.ts
@@ -1,8 +1,19 @@
 // packages/lib/src/kb/catalog/__tests__/kb-catalog.test.ts
 
 import { describe, expect, it } from 'vitest'
+import type { ResolvedKnowledgeScope } from '../../../agents/resolve-knowledge-scope'
 import { buildKbCatalog, type KbCatalogSourceRow } from '../kb-catalog'
 import { renderKbCatalog } from '../render-kb-catalog'
+
+function knowledgeScope(over: Partial<ResolvedKnowledgeScope> = {}): ResolvedKnowledgeScope {
+  return {
+    datasetIds: new Set(),
+    fullKbIds: new Set(),
+    articleIds: new Set(),
+    excludedArticleIds: new Set(),
+    ...over,
+  }
+}
 
 const kb = (id: string, over: Partial<Parameters<typeof buildKbCatalog>[0][number]> = {}) => ({
   id,
@@ -167,5 +178,90 @@ describe('renderKbCatalog', () => {
     const withoutTool = renderKbCatalog(catalog, { publicOnly: false, hasGetArticle: false })
     expect(withTool).toContain('get_article')
     expect(withoutTool).not.toContain('`get_article`')
+  })
+})
+
+describe('renderKbCatalog — agent knowledge scope (permissions v2 §1.2/1.3)', () => {
+  // kb1 ("Full KB"): fully in scope — both articles survive regardless of
+  // articleIds. kb2 ("Partial KB"): only individually scoped. kb3 ("Out of
+  // scope KB"): neither full nor contributing a scoped article — dropped.
+  const scopedCatalog = buildKbCatalog(
+    [
+      kb('kb1', { name: 'Full KB' }),
+      kb('kb2', { name: 'Partial KB' }),
+      kb('kb3', { name: 'Out of scope KB' }),
+    ],
+    [
+      row({ placementId: 'p1', title: 'Full article one' }),
+      row({ placementId: 'p2', title: 'Full article two', sortOrder: 'a1' }),
+      row({ placementId: 'p3', knowledgeBaseId: 'kb2', title: 'Scoped article' }),
+      row({
+        placementId: 'p4',
+        knowledgeBaseId: 'kb2',
+        title: 'Unscoped article',
+        sortOrder: 'a1',
+      }),
+      row({ placementId: 'p5', knowledgeBaseId: 'kb3', title: 'Never in scope' }),
+    ]
+  )
+
+  it('null/undefined scope is a no-op', () => {
+    const base = renderKbCatalog(scopedCatalog, { publicOnly: false })
+    expect(renderKbCatalog(scopedCatalog, { publicOnly: false, knowledgeScope: null })).toBe(base)
+    expect(renderKbCatalog(scopedCatalog, { publicOnly: false, knowledgeScope: undefined })).toBe(
+      base
+    )
+    expect(base).toContain('Out of scope KB')
+  })
+
+  it('keeps every article of a fully-included KB', () => {
+    const out = renderKbCatalog(scopedCatalog, {
+      publicOnly: false,
+      knowledgeScope: knowledgeScope({ fullKbIds: new Set(['kb1']) }),
+    })
+    expect(out).toContain('### Full KB')
+    expect(out).toContain('Full article one')
+    expect(out).toContain('Full article two')
+  })
+
+  it('in a partially-included KB, keeps only the individually scoped article and drops the KB if none survive', () => {
+    const out = renderKbCatalog(scopedCatalog, {
+      publicOnly: false,
+      knowledgeScope: knowledgeScope({ articleIds: new Set(['art-p3']) }),
+    })
+    expect(out).toContain('### Partial KB')
+    expect(out).toContain('Scoped article')
+    expect(out).not.toContain('Unscoped article')
+    // kb1 and kb3 contribute nothing to this scope — dropped entirely.
+    expect(out).not.toContain('Full KB')
+    expect(out).not.toContain('Out of scope KB')
+  })
+
+  it('drops an excluded article even inside a fully-included KB', () => {
+    const out = renderKbCatalog(scopedCatalog, {
+      publicOnly: false,
+      knowledgeScope: knowledgeScope({
+        fullKbIds: new Set(['kb1']),
+        excludedArticleIds: new Set(['art-p1']),
+      }),
+    })
+    expect(out).toContain('### Full KB')
+    expect(out).not.toContain('Full article one')
+    expect(out).toContain('Full article two')
+  })
+
+  it('drops a KB with no surviving article', () => {
+    const out = renderKbCatalog(scopedCatalog, {
+      publicOnly: false,
+      knowledgeScope: knowledgeScope({ fullKbIds: new Set(['kb1']) }),
+    })
+    expect(out).not.toContain('Partial KB')
+    expect(out).not.toContain('Out of scope KB')
+  })
+
+  it('returns null when nothing survives the scope', () => {
+    expect(
+      renderKbCatalog(scopedCatalog, { publicOnly: false, knowledgeScope: knowledgeScope() })
+    ).toBeNull()
   })
 })

--- a/packages/lib/src/kb/catalog/render-kb-catalog.ts
+++ b/packages/lib/src/kb/catalog/render-kb-catalog.ts
@@ -1,5 +1,9 @@
 // packages/lib/src/kb/catalog/render-kb-catalog.ts
 
+// Direct relative path, not the `agents` barrel — avoids pulling the agents
+// module graph into every consumer of this file (packages/lib import-cycle
+// hygiene).
+import type { ResolvedKnowledgeScope } from '../../agents/resolve-knowledge-scope'
 import type { KbCatalogEntry } from './kb-catalog'
 
 export interface RenderKbCatalogOptions {
@@ -21,6 +25,15 @@ export interface RenderKbCatalogOptions {
    * output) — the workflow AI node and any un-threaded caller.
    */
   canViewKb?: (kbId: string) => boolean
+  /**
+   * Agent retrieval scope (permissions v2 §1.2/1.3) — the same allowlist
+   * `search_knowledge` enforces (`isSegmentInKnowledgeScope` in
+   * search-knowledge.ts). Composes with {@link publicOnly} and
+   * {@link canViewKb}, it does not replace either: a KB/article can pass both
+   * of those and still be dropped or trimmed here. `null`/`undefined` ⇒ no
+   * scope narrowing (today's output) — the org-wide default.
+   */
+  knowledgeScope?: ResolvedKnowledgeScope | null
 }
 
 const DEFAULT_MAX_CHARS = 8_000
@@ -35,14 +48,23 @@ export function renderKbCatalog(
   catalog: readonly KbCatalogEntry[],
   options: RenderKbCatalogOptions
 ): string | null {
-  const { publicOnly, maxChars = DEFAULT_MAX_CHARS, hasGetArticle = true, canViewKb } = options
+  const {
+    publicOnly,
+    maxChars = DEFAULT_MAX_CHARS,
+    hasGetArticle = true,
+    canViewKb,
+    knowledgeScope,
+  } = options
 
-  const kbs = catalog.filter(
-    (kb) =>
-      kb.articles.length > 0 &&
-      (!publicOnly || kb.visibility === 'PUBLIC') &&
-      (!canViewKb || canViewKb(kb.id))
-  )
+  const kbs = catalog
+    .map((kb) => narrowKbByScope(kb, knowledgeScope))
+    .filter((kb): kb is KbCatalogEntry => kb !== null)
+    .filter(
+      (kb) =>
+        kb.articles.length > 0 &&
+        (!publicOnly || kb.visibility === 'PUBLIC') &&
+        (!canViewKb || canViewKb(kb.id))
+    )
   if (kbs.length === 0) return null
 
   const readHint = hasGetArticle
@@ -69,6 +91,37 @@ export function renderKbCatalog(
     ),
   ].join('\n')
   return compact
+}
+
+/**
+ * Narrow one catalog KB to the agent retrieval scope (permissions v2
+ * §1.2/1.3). Pure and DB-free — `scope` is already fully resolved by
+ * `resolveAgentKnowledgeScope`, so this is plain set membership, not a
+ * re-derivation of KB/article inclusion.
+ *
+ * - `null`/`undefined` scope ⇒ no-op, returns `kb` unchanged.
+ * - Whole-KB kept as-is if `kb.id` is in `fullKbIds`, OR at least one of its
+ *   own articles is in `articleIds` (a partially-included KB). Otherwise the
+ *   KB is dropped entirely (returns `null`).
+ * - Within a kept, non-full KB, only articles in `articleIds` survive.
+ * - In any kept KB (full or partial), articles in `excludedArticleIds` are
+ *   always dropped — an excluded article never renders even inside an
+ *   otherwise fully-included KB. A full KB whose every article ends up
+ *   excluded is left with an empty `articles` array; the caller's existing
+ *   `articles.length > 0` filter drops it same as any other empty KB.
+ */
+function narrowKbByScope(
+  kb: KbCatalogEntry,
+  scope: ResolvedKnowledgeScope | null | undefined
+): KbCatalogEntry | null {
+  if (!scope) return kb
+  const isFullKb = scope.fullKbIds.has(kb.id)
+  const kept = isFullKb || kb.articles.some((a) => scope.articleIds.has(a.id))
+  if (!kept) return null
+  const articles = kb.articles.filter(
+    (a) => !scope.excludedArticleIds.has(a.id) && (isFullKb || scope.articleIds.has(a.id))
+  )
+  return articles.length === kb.articles.length ? kb : { ...kb, articles }
 }
 
 function renderKb(kb: KbCatalogEntry): string {


### PR DESCRIPTION
Implements [`plans/permissions/v2/15-agent-knowledge-scope.md`] — the companion to doc 14 (#1323). All four §3 steps in one pass.

## The finding this closes

`Agent.knowledge` was **write-only**. The builder UI, the `agentScope` router, the prompt/procedure mention reconcilers and the `set_agent_resource_scope` LLM tool all wrote it; versioning snapshotted and hashed it; the org cache projected it — and **no execution path read it** (`ResolvedAgentConfig` had no `knowledge` field, `recordMatchesScopeRow` had zero callers). So the click-to-include system was UI plus bookkeeping with zero runtime effect.

One concern per system now:

| Concern | Owner |
|---|---|
| What an agent **may** read (security) | doc-14 permissions — per-def / per-instance grants |
| What `search_knowledge` retrieves **by default** (relevance) | this PR — the slimmed "Knowledge sources" scope |

## What changed

**Deletion.** Entity-record includes are gone — access to records is the permission layer's job. `RECORD_PREFIXES` → `['article','kb','dataset']`, `SYSTEM_ORDER` → `['kb','dataset']`, custom-resource branch dropped, section renamed **Knowledge sources** with copy pointing at Permissions. One shared `isKnowledgeScopeRecordId` guards all three write paths (router zod, scope service, builder LLM tool); `removeRow` stays unvalidated on purpose so stale rows can still be cleared. Dead `recordMatchesScopeRow` deleted.

**Threading.** `ResolvedAgentConfig.knowledge` added (with the draft overlay), and `knowledgeScope` threaded beside `capabilities` on all three rails — `effective-runtime` (covers every worker trigger + evals), `build-chat-engine-config`, and the SSE route. In the SSE route `resolveAgentConfig` is **hoisted** above the deps factory so one call feeds both the tool gate and the prompt; this was required, not cosmetic — that call carries the `{source:'draft'}` builder override, which deriving from `cachedAgent` would have silently ignored.

**Enforcement.** New `resolveAgentKnowledgeScope` resolves rows once per turn into `{datasetIds, fullKbIds, articleIds, excludedArticleIds}`:
- dataset-id intersection at `resolveDatasetIds` (narrows, never unions — LLM `knowledgeBaseId`/`datasetIds` args still only narrow *within* scope)
- `articleId` post-filter via `isSegmentInKnowledgeScope`, at the same site as the existing `recordIds` filter
- `renderKbCatalog` filters against the **same** allowlist, so the prompt can't advertise an article the tool won't return
- `scope ∩ capabilities` (§0.4), under the unchanged visitor PUBLIC clamp

## Semantics worth reviewing

Settled during implementation, all mirroring the builder tree's `deriveEffectiveMode` so UI and runtime agree:

- **Empty scope = all org knowledge** (unchanged default). `null` from the resolver means unrestricted, and the consumers short-circuit with zero added I/O.
- **Any include mode on a `kb:` row means the whole KB** — mentions write `include_one` for a `kb:` chip while the builder writes `include_descendants`; "the KB row but not its articles" isn't a meaningful retrieval scope.
- **Articles inherit like the tree**: `include_descendants` carries to the subtree, `include_one` does not, exclusion always does. Expansion walks `ArticlePlacement.parentId` (the tree lives on the placement, not the article) in two bounded queries.
- **Most-specific-wins across levels**: a `kb:<id>` row beats the bare `kb` row, and an explicitly included article outranks the exclusion of its KB — that KB becomes *partial*, so its dataset stays searchable for the article filter to narrow. (This was a bug in my first pass; it has a regression test.)
- **Federation expands both ways**: a scoped KB brings its linked sources' datasets along, *and* the hidden source KB ids join `fullKbIds` — their segments carry the hidden KB's `kbId`, so without that the article post-filter would drop every federated hit.

## Deviations from the plan

- **No `DataMigration`** (§0.6) and **no stale-source badge** (§5.2) — both dropped by owner call: no production surface uses agents yet, and the read-time `filterKnowledgeScopeEntries` already makes leftover entity rows inert. The §5.3 prod scan was skipped for the same reason.
- **A scope whose every include row is dangling resolves to *empty*, not org-wide.** §5.2's "never blocks search" is honoured as "never throws"; widening back to org-wide would contradict §0.4's narrow-never-widen rule. Logged as a warning.
- **Bare `article` rows rejected** — definition-level rows exist only for `kb`/`dataset`, the two depth-0 container rows the builder actually writes.
- **`set_agent_resource_scope` keeps its name** — renaming would churn stored agent configs for no behavioural gain; only validation and description changed.

## Testing

157 new/updated assertions, all passing. The precedence core is extracted as the pure, exported `selectScopedSources` so the resolution rules are testable without a DB (11 cases: allowlist vs denylist, definition-level rows, partial KBs, article-outranks-KB-exclusion, capability intersection, dangling ids). Plus `isSegmentInKnowledgeScope`, `renderKbCatalog` scope narrowing, the pure `knowledge-scope` helpers, and the dropped mention prefixes.

Also **fixed a pre-existing red test**: `derive-scope-mode.test.ts` was ~9/11 failing because its fixtures still built the old `AgentResourceScope` table shape after the flat-`recordId` refactor.

Scoped typechecks are clean for every touched file (`packages/lib` and `apps/web` both carry large pre-existing baselines, so these were verified by grepping for the changed filenames, not by exit code).

## Known limitation — please read

`search_knowledge` / `get_article` are **not registered on the worker or visitor-chat paths at all** (`createKnowledgeCapabilities`/`createKbReadCapabilities` are missing from `buildAgentCapabilityRegistry` and `build-chat-engine-config`), so the KB catalog section self-suppresses there too. Scope is threaded through those paths regardless and activates the moment the tools are registered — but today it only bites on the interactive / approvals / workflow rails.

Closing that has two unequal halves, and one is a **latent leak**: `get_article`/`list_articles` gate only on the *agent's* capability view, with no PUBLIC/INTERNAL clamp and no published check, so registering them on visitor chat as-is would let a visitor pull an INTERNAL KB's unpublished draft by id. `search_knowledge` on chat is safe (it self-clamps on `subject`), as is the worker path. Full analysis in the plan doc §6.3; not touched here.