### PR TITLE
fix(redis): dedupe concurrent client creation and share cache across scopes

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -15,6 +15,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "clean": "rm -rf dist node_modules .turbo *.tsbuildinfo",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -28,6 +29,7 @@
     "@auxx/typescript-config": "workspace:*",
     "@types/node": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/redis/src/__tests__/client.test.ts
+++ b/packages/redis/src/__tests__/client.test.ts
@@ -1,0 +1,134 @@
+// packages/redis/src/__tests__/client.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RedisClient } from '../types'
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('@auxx/credentials', () => ({
+  configService: { get: vi.fn(() => undefined) },
+}))
+
+vi.mock('../core/redis-client-factory', () => ({
+  RedisClientFactory: {
+    createClient: vi.fn(),
+    getLiveClient: vi.fn(() => undefined),
+    closeClient: vi.fn(async () => {}),
+    closeAllClients: vi.fn(async () => {}),
+  },
+}))
+
+import {
+  closeRedisConnection,
+  disconnectRedis,
+  getPublishingClient,
+  getRedisClient,
+  getSubscriptionClient,
+} from '../client'
+import { RedisClientFactory } from '../core/redis-client-factory'
+
+const fakeClient = { isAlive: () => true } as unknown as RedisClient
+
+/** The failure cooldown lives on globalThis; reset it so tests don't leak. */
+function clearCooldown() {
+  ;(globalThis as unknown as { _auxxRedisLastFailureAt?: number })._auxxRedisLastFailureAt = 0
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearCooldown()
+  vi.mocked(RedisClientFactory.createClient).mockResolvedValue(fakeClient)
+  vi.mocked(RedisClientFactory.getLiveClient).mockReturnValue(undefined)
+})
+
+describe('client accessors', () => {
+  it('routes each accessor to its own factory instance id', async () => {
+    await getRedisClient()
+    await getPublishingClient()
+    await getSubscriptionClient()
+
+    const ids = vi.mocked(RedisClientFactory.createClient).mock.calls.map(([, id]) => id)
+    expect(ids).toEqual(['main', 'publishing', 'subscription'])
+  })
+
+  it('keeps no cache of its own — every call delegates to the factory', async () => {
+    await getRedisClient()
+    await getRedisClient()
+    await getRedisClient()
+
+    // A second cache layer here would shadow the factory's and go stale
+    // independently, which is what caused duplicate connections.
+    expect(RedisClientFactory.createClient).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('getRedisClient failure handling', () => {
+  it('throws when required and the factory cannot connect', async () => {
+    vi.mocked(RedisClientFactory.createClient).mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(getRedisClient(true)).rejects.toThrow(/ECONNREFUSED/)
+  })
+
+  it('returns undefined when optional and the factory cannot connect', async () => {
+    vi.mocked(RedisClientFactory.createClient).mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(getRedisClient(false)).resolves.toBeUndefined()
+  })
+
+  it('fast-fails during the cooldown instead of retrying the connect', async () => {
+    vi.mocked(RedisClientFactory.createClient).mockRejectedValue(new Error('ECONNREFUSED'))
+    await expect(getRedisClient(false)).resolves.toBeUndefined()
+    expect(RedisClientFactory.createClient).toHaveBeenCalledTimes(1)
+
+    // Second call inside the 30s window must not pay another connect timeout.
+    await expect(getRedisClient(false)).resolves.toBeUndefined()
+    expect(RedisClientFactory.createClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the cooldown when a live client already exists', async () => {
+    vi.mocked(RedisClientFactory.createClient).mockRejectedValueOnce(new Error('ECONNREFUSED'))
+    await expect(getRedisClient(false)).resolves.toBeUndefined()
+
+    // A live client means the outage is over — the cooldown must not block it.
+    vi.mocked(RedisClientFactory.getLiveClient).mockReturnValue(fakeClient)
+    await expect(getRedisClient(false)).resolves.toBe(fakeClient)
+  })
+
+  it('clears the cooldown after a successful connect', async () => {
+    vi.mocked(RedisClientFactory.createClient).mockRejectedValueOnce(new Error('ECONNREFUSED'))
+    await expect(getRedisClient(false)).resolves.toBeUndefined()
+
+    clearCooldown()
+    await expect(getRedisClient(false)).resolves.toBe(fakeClient)
+
+    const stored = (globalThis as unknown as { _auxxRedisLastFailureAt?: number })
+      ._auxxRedisLastFailureAt
+    expect(stored).toBe(0)
+  })
+
+  it('returns null rather than throwing for optional pub/sub clients', async () => {
+    vi.mocked(RedisClientFactory.createClient).mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(getPublishingClient(false)).resolves.toBeNull()
+    await expect(getSubscriptionClient(false)).resolves.toBeNull()
+  })
+})
+
+describe('disconnect helpers', () => {
+  it('disconnectRedis closes every factory-cached client', async () => {
+    await disconnectRedis()
+    expect(RedisClientFactory.closeAllClients).toHaveBeenCalledTimes(1)
+  })
+
+  it('closeRedisConnection closes only the main client', async () => {
+    await closeRedisConnection()
+    expect(RedisClientFactory.closeClient).toHaveBeenCalledWith('main')
+  })
+})

--- a/packages/redis/src/client.ts
+++ b/packages/redis/src/client.ts
@@ -25,18 +25,22 @@ export const MESSAGE_EXPIRATION = 60 * 60 * 24 * 7
 // Session expiration in Redis (30 days in seconds)
 export const SESSION_EXPIRATION = 60 * 60 * 24 * 30
 
-// Main Redis client singleton
-let redisClient: RedisClient | null = null
-
-// Publishing Redis client singleton (separate from subscriber client)
-let publishingClient: RedisClient | null = null
-
-// Subscription Redis client singleton (separate from publishing client)
-let subscriptionClient: RedisClient | null = null
+/**
+ * The main/publishing/subscription clients are cached by `RedisClientFactory`
+ * under the instance ids below. This module deliberately keeps no client
+ * references of its own: a second cache layer here would shadow the factory's,
+ * go stale independently, and reintroduce the duplicate-connection problem it
+ * exists to prevent.
+ */
+const MAIN_INSTANCE = 'main'
+const PUBLISHING_INSTANCE = 'publishing'
+const SUBSCRIPTION_INSTANCE = 'subscription'
 
 // Connection failure cooldown — prevents retrying a 5s timeout on every call
-// during the same Lambda invocation when Redis is unreachable
-let lastConnectionFailureAt = 0
+// during the same Lambda invocation when Redis is unreachable. On globalThis
+// for the same reason the factory's caches are: module scope is duplicated
+// per Next.js server bundle, so a module-level counter wouldn't be shared.
+const globalForCooldown = globalThis as unknown as { _auxxRedisLastFailureAt?: number }
 const CONNECTION_FAILURE_COOLDOWN_MS = 30_000
 
 /**
@@ -113,8 +117,9 @@ export function getConnectionOptions(): RedisConnectionOptions {
 export async function getRedisClient(required = true): Promise<RedisClient | undefined> {
   // Fast-fail during cooldown period after a connection failure.
   // Prevents burning 5s per call when Redis is unreachable (e.g., Lambda cold start).
-  if (!redisClient && lastConnectionFailureAt > 0) {
-    const elapsed = Date.now() - lastConnectionFailureAt
+  const lastFailureAt = globalForCooldown._auxxRedisLastFailureAt ?? 0
+  if (lastFailureAt > 0 && !RedisClientFactory.getLiveClient(MAIN_INSTANCE)) {
+    const elapsed = Date.now() - lastFailureAt
     if (elapsed < CONNECTION_FAILURE_COOLDOWN_MS) {
       if (required) {
         throw new Error(
@@ -126,22 +131,13 @@ export async function getRedisClient(required = true): Promise<RedisClient | und
   }
 
   try {
-    // Drop a dead reference so we recreate. The factory does the same internally,
-    // but our module-scope variable would otherwise pin the old (closed) client.
-    if (redisClient && !redisClient.isAlive()) {
-      logger.warn('Cached main Redis client is no longer alive; recreating')
-      redisClient = null
-    }
-
-    if (!redisClient) {
-      // Use the new factory to create the client
-      redisClient = await RedisClientFactory.createClient(undefined, 'main')
-      lastConnectionFailureAt = 0 // Reset on successful connection
-    }
-
-    return redisClient
+    // The factory returns its cached client, joins an in-flight creation, or
+    // builds a new one — including dropping a dead client and reconnecting.
+    const client = await RedisClientFactory.createClient(undefined, MAIN_INSTANCE)
+    globalForCooldown._auxxRedisLastFailureAt = 0 // Reset on successful connection
+    return client
   } catch (error) {
-    lastConnectionFailureAt = Date.now()
+    globalForCooldown._auxxRedisLastFailureAt = Date.now()
     logger.error('Failed to initialize Redis client', { error: (error as Error).message })
 
     if (required) {
@@ -159,16 +155,7 @@ export async function getRedisClient(required = true): Promise<RedisClient | und
  */
 export async function getPublishingClient(required = true): Promise<RedisClient | null> {
   try {
-    if (publishingClient && !publishingClient.isAlive()) {
-      logger.warn('Cached publishing Redis client is no longer alive; recreating')
-      publishingClient = null
-    }
-    if (!publishingClient) {
-      // Use the new factory to create the publishing client
-      publishingClient = await RedisClientFactory.createClient(undefined, 'publishing')
-    }
-
-    return publishingClient
+    return await RedisClientFactory.createClient(undefined, PUBLISHING_INSTANCE)
   } catch (error) {
     logger.error('Failed to initialize Redis publishing client', {
       error: (error as Error).message,
@@ -190,16 +177,7 @@ export async function getPublishingClient(required = true): Promise<RedisClient 
  */
 export async function getSubscriptionClient(required = true): Promise<RedisClient | null> {
   try {
-    if (subscriptionClient && !subscriptionClient.isAlive()) {
-      logger.warn('Cached subscription Redis client is no longer alive; recreating')
-      subscriptionClient = null
-    }
-    if (!subscriptionClient) {
-      // Use the new factory to create the subscription client
-      subscriptionClient = await RedisClientFactory.createClient(undefined, 'subscription')
-    }
-
-    return subscriptionClient
+    return await RedisClientFactory.createClient(undefined, SUBSCRIPTION_INSTANCE)
   } catch (error) {
     logger.error('Failed to initialize Redis subscription client', {
       error: (error as Error).message,
@@ -219,54 +197,8 @@ export async function getSubscriptionClient(required = true): Promise<RedisClien
  * Disconnect Redis client (useful for serverless environments)
  */
 export async function disconnectRedis(): Promise<void> {
-  if (redisClient) {
-    try {
-      await redisClient.quit()
-      logger.info('Redis connection properly closed')
-      redisClient = null
-    } catch (err) {
-      logger.error('Error disconnecting from Redis', { error: (err as Error).message })
-      // Force disconnect if quit fails
-      if (redisClient?.disconnect) {
-        redisClient.disconnect()
-        redisClient = null
-      }
-    }
-  }
-
-  if (publishingClient) {
-    try {
-      await publishingClient.quit()
-      logger.info('Redis publishing client connection properly closed')
-      publishingClient = null
-    } catch (err) {
-      logger.error('Error disconnecting from Redis publishing client', {
-        error: (err as Error).message,
-      })
-      if (publishingClient?.disconnect) {
-        publishingClient.disconnect()
-        publishingClient = null
-      }
-    }
-  }
-
-  if (subscriptionClient) {
-    try {
-      await subscriptionClient.quit()
-      logger.info('Redis subscription client connection properly closed')
-      subscriptionClient = null
-    } catch (err) {
-      logger.error('Error disconnecting from Redis subscription client', {
-        error: (err as Error).message,
-      })
-      if (subscriptionClient?.disconnect) {
-        subscriptionClient.disconnect()
-        subscriptionClient = null
-      }
-    }
-  }
-
-  // Also close all factory clients
+  // The main, publishing, and subscription clients are all factory-cached, so
+  // this covers them along with any other instance ids.
   await RedisClientFactory.closeAllClients()
 }
 
@@ -358,15 +290,7 @@ export async function deleteRedisData(key: string, required = false): Promise<nu
  * Close Redis client (useful for testing and cleanup)
  */
 export async function closeRedisConnection(): Promise<void> {
-  if (redisClient) {
-    try {
-      await redisClient.quit()
-    } catch (error) {
-      logger.error('Error closing Redis connection', { error: (error as Error).message })
-    } finally {
-      redisClient = null
-    }
-  }
+  await RedisClientFactory.closeClient(MAIN_INSTANCE)
 }
 
 /**

--- a/packages/redis/src/core/__tests__/redis-client-factory.test.ts
+++ b/packages/redis/src/core/__tests__/redis-client-factory.test.ts
@@ -1,0 +1,239 @@
+// packages/redis/src/core/__tests__/redis-client-factory.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RedisClient } from '../../types'
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../providers/provider-detector', () => ({
+  getRedisProvider: vi.fn(() => 'hosted'),
+  validateProviderConfiguration: vi.fn(() => true),
+  getProviderCapabilities: vi.fn(() => ({ provider: 'hosted' })),
+  getConnectionOptions: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}))
+
+vi.mock('../../providers/upstash-provider', () => ({
+  createUpstashClient: vi.fn(() => makeFakeClient()),
+}))
+
+vi.mock('../../providers/ioredis-provider', () => ({
+  createIORedisClient: vi.fn(() => makeFakeClient()),
+}))
+
+import { createIORedisClient } from '../../providers/ioredis-provider'
+import { RedisClientFactory } from '../redis-client-factory'
+
+/** Controls whether the next fake client's connect() resolves immediately. */
+let connectGate: {
+  promise: Promise<void>
+  resolve: () => void
+  reject: (e: Error) => void
+} | null = null
+
+/** Every fake client built during a test, in construction order. */
+const built: FakeClient[] = []
+
+interface FakeClient extends RedisClient {
+  alive: boolean
+}
+
+function makeFakeClient(): FakeClient {
+  const client = {
+    alive: true,
+    connect: vi.fn(async () => {
+      if (connectGate) await connectGate.promise
+    }),
+    ping: vi.fn(async () => 'PONG'),
+    quit: vi.fn(async () => 'OK'),
+    disconnect: vi.fn(() => {
+      client.alive = false
+    }),
+    isAlive: vi.fn(() => client.alive),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  } as unknown as FakeClient
+
+  built.push(client)
+  return client
+}
+
+function deferred() {
+  let resolve!: () => void
+  let reject!: (e: Error) => void
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/**
+ * The factory's caches live on globalThis (so separate Next.js module scopes
+ * share one pool), which means they survive between tests. Clear them rather
+ * than reloading the module so each test starts from a cold cache.
+ */
+function clearFactoryCaches() {
+  const g = globalThis as unknown as {
+    _auxxRedisInstances?: Map<string, RedisClient>
+    _auxxRedisPending?: Map<string, Promise<RedisClient>>
+  }
+  g._auxxRedisInstances?.clear()
+  g._auxxRedisPending?.clear()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearFactoryCaches()
+  built.length = 0
+  connectGate = null
+})
+
+afterEach(() => {
+  clearFactoryCaches()
+})
+
+describe('RedisClientFactory.createClient', () => {
+  it('coalesces concurrent calls for the same instance into a single client', async () => {
+    // Hold connect() open so all four callers arrive while the first creation
+    // is still in flight — the exact shape of initCaches() constructing four
+    // cache services in one tick.
+    connectGate = deferred()
+
+    const calls = [
+      RedisClientFactory.createClient(undefined, 'main'),
+      RedisClientFactory.createClient(undefined, 'main'),
+      RedisClientFactory.createClient(undefined, 'main'),
+      RedisClientFactory.createClient(undefined, 'main'),
+    ]
+
+    connectGate.resolve()
+    const clients = await Promise.all(calls)
+
+    expect(createIORedisClient).toHaveBeenCalledTimes(1)
+    expect(new Set(clients).size).toBe(1)
+    expect(built).toHaveLength(1)
+  })
+
+  it('reuses the cached client once the first creation has settled', async () => {
+    const first = await RedisClientFactory.createClient(undefined, 'main')
+    const second = await RedisClientFactory.createClient(undefined, 'main')
+
+    expect(second).toBe(first)
+    expect(createIORedisClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps separate clients per instance id', async () => {
+    const main = await RedisClientFactory.createClient(undefined, 'main')
+    const publishing = await RedisClientFactory.createClient(undefined, 'publishing')
+
+    expect(main).not.toBe(publishing)
+    expect(createIORedisClient).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let one instance id block another from being created', async () => {
+    connectGate = deferred()
+
+    const main = RedisClientFactory.createClient(undefined, 'main')
+    const publishing = RedisClientFactory.createClient(undefined, 'publishing')
+
+    connectGate.resolve()
+    const [a, b] = await Promise.all([main, publishing])
+
+    expect(a).not.toBe(b)
+    expect(built).toHaveLength(2)
+  })
+
+  it('replaces a cached client that is no longer alive', async () => {
+    const first = (await RedisClientFactory.createClient(undefined, 'main')) as FakeClient
+    first.alive = false
+
+    const second = await RedisClientFactory.createClient(undefined, 'main')
+
+    expect(second).not.toBe(first)
+    expect(createIORedisClient).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects every concurrent caller when the shared creation fails', async () => {
+    connectGate = deferred()
+
+    const calls = [
+      RedisClientFactory.createClient(undefined, 'main'),
+      RedisClientFactory.createClient(undefined, 'main'),
+      RedisClientFactory.createClient(undefined, 'main'),
+    ]
+
+    connectGate.reject(new Error('ECONNREFUSED'))
+    const results = await Promise.allSettled(calls)
+
+    expect(results.every((r) => r.status === 'rejected')).toBe(true)
+    // One failed attempt, not one per caller.
+    expect(createIORedisClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries after a failure instead of caching the rejection', async () => {
+    connectGate = deferred()
+    const failing = RedisClientFactory.createClient(undefined, 'main')
+    connectGate.reject(new Error('ECONNREFUSED'))
+    await expect(failing).rejects.toThrow(/ECONNREFUSED/)
+
+    // A rejected creation must not stay in the in-flight map, or every later
+    // caller would inherit the same failure until process restart.
+    connectGate = null
+    const recovered = await RedisClientFactory.createClient(undefined, 'main')
+
+    expect(recovered).toBeDefined()
+    expect(createIORedisClient).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches the connected client on globalThis so other module scopes share it', async () => {
+    const client = await RedisClientFactory.createClient(undefined, 'main')
+
+    const g = globalThis as unknown as { _auxxRedisInstances?: Map<string, RedisClient> }
+    expect(g._auxxRedisInstances?.get('auto-main')).toBe(client)
+  })
+
+  it('clears the in-flight entry once a creation settles', async () => {
+    await RedisClientFactory.createClient(undefined, 'main')
+
+    const g = globalThis as unknown as { _auxxRedisPending?: Map<string, Promise<RedisClient>> }
+    expect(g._auxxRedisPending?.size).toBe(0)
+  })
+})
+
+describe('RedisClientFactory.getLiveClient', () => {
+  it('returns undefined when nothing is cached, without connecting', () => {
+    expect(RedisClientFactory.getLiveClient('main')).toBeUndefined()
+    expect(createIORedisClient).not.toHaveBeenCalled()
+  })
+
+  it('returns the cached client while it is alive', async () => {
+    const client = await RedisClientFactory.createClient(undefined, 'main')
+    expect(RedisClientFactory.getLiveClient('main')).toBe(client)
+  })
+
+  it('returns undefined for a cached client that has died', async () => {
+    const client = (await RedisClientFactory.createClient(undefined, 'main')) as FakeClient
+    client.alive = false
+
+    expect(RedisClientFactory.getLiveClient('main')).toBeUndefined()
+  })
+})
+
+describe('RedisClientFactory.closeClient', () => {
+  it('quits and evicts the client so the next call reconnects', async () => {
+    const client = await RedisClientFactory.createClient(undefined, 'main')
+
+    await RedisClientFactory.closeClient('main')
+
+    expect(client.quit).toHaveBeenCalledTimes(1)
+    const next = await RedisClientFactory.createClient(undefined, 'main')
+    expect(next).not.toBe(client)
+  })
+})

--- a/packages/redis/src/core/redis-client-factory.ts
+++ b/packages/redis/src/core/redis-client-factory.ts
@@ -39,12 +39,35 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 }
 
 /**
+ * Client caches live on `globalThis`, not in module scope.
+ *
+ * Next.js/Turbopack gives server components, route handlers, and API routes
+ * separate module scopes within the same Node process. A module-level `Map`
+ * is therefore duplicated per scope, and each fresh copy starts empty — so
+ * every scope opens its own set of connections to the same Redis. `globalThis`
+ * is process-wide and survives HMR, so all scopes share one pool.
+ * (`@auxx/lib/cache` singletons use the same approach for the same reason.)
+ */
+const globalForRedis = globalThis as unknown as {
+  _auxxRedisInstances?: Map<string, RedisClient>
+  _auxxRedisPending?: Map<string, Promise<RedisClient>>
+}
+
+/** Connected, reusable clients keyed by `<provider>-<instanceId>` */
+const instances = (globalForRedis._auxxRedisInstances ??= new Map<string, RedisClient>())
+
+/**
+ * Creations currently in flight, keyed the same way. Entries are removed as
+ * soon as the creation settles — this only coalesces concurrent callers, it
+ * never caches a result.
+ */
+const pending = (globalForRedis._auxxRedisPending ??= new Map<string, Promise<RedisClient>>())
+
+/**
  * Factory pattern for creating Redis clients
  * Provides provider-agnostic client creation with automatic capability detection
  */
 export class RedisClientFactory {
-  private static instances = new Map<string, RedisClient>()
-
   /**
    * Returns true when REDIS_PASSWORD is not set as a non-empty environment variable.
    */
@@ -85,15 +108,41 @@ export class RedisClientFactory {
     // Return existing instance if it's still alive. A previous caller may have
     // closed the connection (e.g. an SSE route calling .quit() on the shared
     // singleton); without this check we'd hand back a dead client forever.
-    const cached = RedisClientFactory.instances.get(cacheKey)
+    const cached = instances.get(cacheKey)
     if (cached) {
       if (cached.isAlive()) {
         return cached
       }
       logger.warn(`Cached Redis client ${cacheKey} is no longer alive; recreating`)
-      RedisClientFactory.instances.delete(cacheKey)
+      instances.delete(cacheKey)
     }
 
+    // Coalesce concurrent creations for the same key. `instances` is only
+    // populated after connect+ping resolve, so callers arriving during that
+    // window would all miss the cache and each build their own client — every
+    // one but the last then orphaned, holding an open socket that nothing ever
+    // closes. Four cache services constructed in one tick reliably hit this.
+    const inFlight = pending.get(cacheKey)
+    if (inFlight) {
+      return inFlight
+    }
+
+    // Must be registered before the first await so no caller can interleave.
+    const creation = RedisClientFactory.connectNewClient(cacheKey, provider).finally(() => {
+      pending.delete(cacheKey)
+    })
+    pending.set(cacheKey, creation)
+    return creation
+  }
+
+  /**
+   * Build, connect, verify, and cache a single client. Always call via
+   * `createClient` — this deliberately has no cache or dedupe of its own.
+   */
+  private static async connectNewClient(
+    cacheKey: string,
+    provider?: RedisProvider
+  ): Promise<RedisClient> {
     const detectedProvider = provider ?? getRedisProvider()
     logger.info(`Creating new Redis client instance: ${cacheKey} (provider: ${detectedProvider})`)
 
@@ -107,8 +156,8 @@ export class RedisClientFactory {
     // Eviction callback — when the underlying socket ends, drop the cached
     // reference so the next caller creates a fresh client.
     const evict = () => {
-      if (RedisClientFactory.instances.get(cacheKey) === client) {
-        RedisClientFactory.instances.delete(cacheKey)
+      if (instances.get(cacheKey) === client) {
+        instances.delete(cacheKey)
       }
     }
 
@@ -144,8 +193,18 @@ export class RedisClientFactory {
     }
 
     // Cache the instance
-    RedisClientFactory.instances.set(cacheKey, client)
+    instances.set(cacheKey, client)
     return client
+  }
+
+  /**
+   * Return the cached client for an instance id if one is connected and alive.
+   * Never creates a connection — callers use this to test for an existing
+   * client without triggering one.
+   */
+  static getLiveClient(instanceId = 'default', provider?: RedisProvider): RedisClient | undefined {
+    const client = instances.get(`${provider ?? 'auto'}-${instanceId}`)
+    return client?.isAlive() ? client : undefined
   }
 
   /**
@@ -221,23 +280,21 @@ export class RedisClientFactory {
    * Close all cached client instances
    */
   static async closeAllClients(): Promise<void> {
-    const promises = Array.from(RedisClientFactory.instances.entries()).map(
-      async ([key, client]) => {
-        try {
-          await client.quit()
-          logger.info(`Closed Redis client: ${key}`)
-        } catch (error) {
-          logger.error(`Error closing Redis client ${key}`, { error: (error as Error).message })
-          // Force disconnect if quit fails
-          if (client.disconnect) {
-            client.disconnect()
-          }
+    const promises = Array.from(instances.entries()).map(async ([key, client]) => {
+      try {
+        await client.quit()
+        logger.info(`Closed Redis client: ${key}`)
+      } catch (error) {
+        logger.error(`Error closing Redis client ${key}`, { error: (error as Error).message })
+        // Force disconnect if quit fails
+        if (client.disconnect) {
+          client.disconnect()
         }
       }
-    )
+    })
 
     await Promise.all(promises)
-    RedisClientFactory.instances.clear()
+    instances.clear()
     logger.info('All Redis client instances closed')
   }
 
@@ -246,7 +303,7 @@ export class RedisClientFactory {
    */
   static async closeClient(instanceId = 'default', provider?: RedisProvider): Promise<void> {
     const cacheKey = `${provider ?? 'auto'}-${instanceId}`
-    const client = RedisClientFactory.instances.get(cacheKey)
+    const client = instances.get(cacheKey)
 
     if (client) {
       try {
@@ -258,7 +315,7 @@ export class RedisClientFactory {
           client.disconnect()
         }
       }
-      RedisClientFactory.instances.delete(cacheKey)
+      instances.delete(cacheKey)
     }
   }
 

--- a/packages/redis/vitest.config.ts
+++ b/packages/redis/vitest.config.ts
@@ -1,0 +1,21 @@
+// packages/redis/vitest.config.ts
+
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'redis',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts', 'src/**/__tests__/**/*.ts'],
+    exclude: ['node_modules/**', 'dist/**', '**/*.config.*'],
+  },
+  resolve: {
+    alias: {
+      '@auxx/logger': path.resolve(__dirname, '../logger/src'),
+      '@auxx/config': path.resolve(__dirname, '../config/src'),
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2219,6 +2219,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/sdk:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       './packages/workflow-nodes/vitest.config.ts',
       './packages/database/vitest.config.ts',
       './packages/credentials/vitest.config.ts',
+      './packages/redis/vitest.config.ts',
       './packages/utils/vitest.config.ts',
       './packages/test-utils/vitest.config.ts',
       './packages/ui/vitest.config.ts',


### PR DESCRIPTION
## Problem

A single `/login` refresh opened **four** Redis connections. Two independent causes:

**1. Race in `RedisClientFactory.createClient`.** The cache was only populated after `connect()` + `ping()` resolved, so callers arriving during that window all missed it and each built their own client. All but the last were then orphaned — not in the cache, not referenced, never quit, and with `retryStrategy` never returning `null` they reconnect forever.

`packages/lib/src/cache/singletons.ts` `initCaches()` constructs four cache services in one synchronous tick, each firing an unawaited `getRedisClient(false)` from its constructor. That hits the race every time, on any request that resolves a session:

```
GET /login → getSession() → auth/server.ts:630 getUserCache() → initCaches() → 4× getRedisClient
```

**2. Module-scope caches.** The factory's `instances` map and the three singletons in `client.ts` lived in module scope. Turbopack gives server components, route handlers, and API routes separate module scopes, so each fresh scope started with an empty cache and opened its own set. `@auxx/lib/cache/singletons.ts` already moved to `globalThis` for exactly this reason; `@auxx/redis` never did.

Measured over 3.5h of dev: **83** `auto-main` creations vs 1 `auto-publishing`, with zero eviction/close log lines — nothing was dying and being replaced, every creation started from an already-empty cache.

## Changes

- `createClient` registers the in-flight creation promise **before** the first await; concurrent callers for the same key join it. Cleared in a `finally`, so a failed creation isn't cached and the next call retries.
- Build/connect/verify extracted to `connectNewClient()`; `createClient` is now cache-check → dedupe-check → create.
- `instances` (and the new `pending` map) moved to `globalThis`, matching the cache singletons.
- New `getLiveClient()` — returns a cached live client without ever creating one.
- `client.ts` drops its `redisClient` / `publishingClient` / `subscriptionClient` module vars. They were a second cache layer shadowing the factory's with independent staleness. All three accessors now delegate. `disconnectRedis()` → `closeAllClients()`, `closeRedisConnection()` → `closeClient('main')`.
- Failure cooldown moved to `globalThis`, tested via `getLiveClient()`.

## Tests

New vitest setup for `packages/redis` (mirrors `packages/utils`), registered in the root `vitest.config.ts` projects list. 23 tests, no real Redis required — providers are mocked and a gated `connect()` reproduces the concurrent-caller shape.

Verified the dedupe tests have teeth: temporarily disabling the `pending` lookup fails exactly `coalesces concurrent calls…` and `rejects every concurrent caller…`, and nothing else.

## Verification

After a clean `.next` + dev restart, one `/login` request:

```
1  [@auxx/web]     Creating new Redis client instance: auto-main
1  [@auxx/worker]  Creating new Redis client instance: auto-main
```

`next-server` now holds **1** connection where the burst previously produced 4.

## Scope note

This does not touch the worker's ~72 BullMQ connections. `packages/lib/src/jobs/queues/index.ts` passes `getConnectionOptions()` — a plain config object — to BullMQ, which constructs its own ioredis instances and never goes through the factory. 33 workers (each needing a dedicated blocking connection) plus 7 queues accounts for them; that's BullMQ working as designed.

`packages/redis` is **not** in CI's project list (`ci.yml` runs `--project billing --project workflow-nodes`). Add `--project redis` there if you want it gated on CI.