### PR TITLE
feat(settings): add search to the settings sidebar

### DIFF
--- a/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
@@ -114,7 +114,9 @@ export default function DispatchSettingsLayout({ children }: { children: React.R
 
   return (
     <MainPageContent>
-      <div className='flex flex-col sm:flex-row h-full flex-1 overflow-hidden'>
+      {/* `md:` must match SidebarSecondary's own breakpoint — at `sm:` the sidebar is
+          still in mobile-disclosure mode with no fixed width and collapses to a sliver. */}
+      <div className='flex flex-col md:flex-row h-full flex-1 overflow-hidden'>
         <SidebarSecondary
           items={DISPATCH_SETTINGS}
           baseUrl={baseUrl}

--- a/apps/web/src/app/(protected)/app/tickets/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/settings/layout.tsx
@@ -39,7 +39,9 @@ export default function TicketSettingsLayout({ children }: { children: React.Rea
 
   return (
     <MainPageContent>
-      <div className='flex flex-col sm:flex-row h-full flex-1 overflow-hidden'>
+      {/* `md:` must match SidebarSecondary's own breakpoint — at `sm:` the sidebar is
+          still in mobile-disclosure mode with no fixed width and collapses to a sliver. */}
+      <div className='flex flex-col md:flex-row h-full flex-1 overflow-hidden'>
         <SidebarSecondary
           items={TICKET_SETTINGS}
           baseUrl={baseUrl}

--- a/apps/web/src/components/global/sidebar-secondary-search.ts
+++ b/apps/web/src/components/global/sidebar-secondary-search.ts
@@ -1,0 +1,115 @@
+// apps/web/src/components/global/sidebar-secondary-search.ts
+import type { SidebarProps } from '~/constants/menu'
+
+/**
+ * Case- and diacritic-insensitive fold used for every haystack and the query.
+ *
+ * NFD decomposes a precomposed accent into base + combining mark, and stripping the
+ * marks returns it to a single character — so the fold is **length-preserving** for
+ * the scripts we care about. That is what lets {@link SettingsSearchResult.labelMatch}
+ * index straight into the original, unfolded label for highlighting.
+ */
+function fold(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+}
+
+/** One searchable settings page, with its haystacks folded once at index time. */
+export type SettingsSearchEntry = {
+  item: SidebarProps
+  /** Label of the header group this item sits under, for the result breadcrumb. */
+  groupLabel: string
+  href: string
+  foldedLabel: string
+  foldedGroup: string
+  foldedKeywords: string[]
+  foldedDescription: string
+}
+
+export type SettingsSearchResult = SettingsSearchEntry & {
+  score: number
+  /** `[start, end)` into the original `item.label`, or null when the hit was elsewhere. */
+  labelMatch: [number, number] | null
+}
+
+/**
+ * Match tiers, best first. Deliberately ranked substring matching rather than fuzzy
+ * scoring — across ~22 items a fuzzy matcher mostly produces noise ("gen" matching
+ * "Mana**g**e **G**roups") while substring ranking stays explainable.
+ */
+const SCORE = {
+  labelPrefix: 0,
+  labelWordPrefix: 1,
+  labelSubstring: 2,
+  keyword: 3,
+  group: 4,
+  description: 5,
+} as const
+
+/** Characters that make the next character a "word start" for tier-1 ranking. */
+const WORD_BOUNDARY = /[\s&/_-]/
+
+/**
+ * Flattens filtered menu groups into a search index.
+ *
+ * `groups` must already have come through `useSettingsMenu()` — indexing raw
+ * `SETTINGS_MENU` would surface pages the member cannot open.
+ */
+export function buildSettingsIndex(groups: SidebarProps[], baseUrl: string): SettingsSearchEntry[] {
+  return groups.flatMap((group) =>
+    (group.items ?? []).map((item) => ({
+      item,
+      groupLabel: group.label,
+      href: `${baseUrl}/${item.slug}`,
+      foldedLabel: fold(item.label),
+      foldedGroup: fold(group.label),
+      foldedKeywords: (item.keywords ?? []).map(fold),
+      foldedDescription: fold(item.description ?? ''),
+    }))
+  )
+}
+
+/** Ranks `entries` against `rawQuery`. Returns `[]` for a blank query. */
+export function searchSettings(
+  entries: SettingsSearchEntry[],
+  rawQuery: string
+): SettingsSearchResult[] {
+  const query = fold(rawQuery.trim())
+  if (!query) return []
+
+  const results: SettingsSearchResult[] = []
+
+  for (const entry of entries) {
+    const at = entry.foldedLabel.indexOf(query)
+
+    if (at === 0) {
+      results.push({ ...entry, score: SCORE.labelPrefix, labelMatch: [0, query.length] })
+      continue
+    }
+    if (at > 0) {
+      const isWordStart = WORD_BOUNDARY.test(entry.foldedLabel[at - 1] ?? '')
+      results.push({
+        ...entry,
+        score: isWordStart ? SCORE.labelWordPrefix : SCORE.labelSubstring,
+        labelMatch: [at, at + query.length],
+      })
+      continue
+    }
+    if (entry.foldedKeywords.some((keyword) => keyword.includes(query))) {
+      results.push({ ...entry, score: SCORE.keyword, labelMatch: null })
+      continue
+    }
+    if (entry.foldedGroup.includes(query)) {
+      results.push({ ...entry, score: SCORE.group, labelMatch: null })
+      continue
+    }
+    if (entry.foldedDescription.includes(query)) {
+      results.push({ ...entry, score: SCORE.description, labelMatch: null })
+    }
+  }
+
+  // Array.prototype.sort is stable, so equal scores keep menu order.
+  return results.sort((a, b) => a.score - b.score)
+}

--- a/apps/web/src/components/global/sidebar-secondary.tsx
+++ b/apps/web/src/components/global/sidebar-secondary.tsx
@@ -1,142 +1,279 @@
+// apps/web/src/components/global/sidebar-secondary.tsx
+'use client'
+
 import { Button } from '@auxx/ui/components/button'
+import { Command, CommandItem, CommandList } from '@auxx/ui/components/command'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  sidebarMenuButtonVariants,
+} from '@auxx/ui/components/sidebar'
 import { cn } from '@auxx/ui/lib/utils'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import Link from 'next/link'
-import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type React from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import type { SidebarProps } from '~/constants/menu'
-import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
-import { useIsMobile } from '~/hooks/use-mobile'
-import { useUser } from '~/hooks/use-user'
-import { useAccess } from '~/providers/capabilities-provider'
-import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useSettingsMenu } from '~/hooks/use-settings-menu'
+import {
+  buildSettingsIndex,
+  type SettingsSearchResult,
+  searchSettings,
+} from './sidebar-secondary-search'
 
 type Props = { items: SidebarProps[]; baseUrl: string; title: string; current: string | undefined }
 
-function SidebarSecondary({ items, baseUrl, title, current }: Props) {
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
-  const isMobile = useIsMobile()
-  const selfHosted = useIsSelfHosted()
+/** Below this many reachable pages the search field is more chrome than help. */
+const SEARCH_MIN_ITEMS = 8
 
-  const { isAdminOrOwner } = useUser({
-    requireOrganization: true, // Require organization membership
-  })
-  const role = isAdminOrOwner ? 'ADMIN' : 'USER'
-  const { hasAccess: hasFeatureAccess } = useFeatureFlags()
-  const { can, administersAnyDef } = useAccess()
+/**
+ * Secondary (settings) navigation column, with iOS-Settings-style search.
+ *
+ * Two render states share one `Command` root: an unfiltered grouped nav of `<Link>`
+ * rows, and — once the query is non-empty — a flat, keyboard-navigable result list.
+ * The nav rows are deliberately NOT cmdk items: keeping them plain links preserves
+ * cmd-click/middle-click and keeps `role='listbox'` off the always-visible nav.
+ */
+function SidebarSecondary({ items, baseUrl, title, current }: Props) {
+  const router = useRouter()
+  const groups = useSettingsMenu(items)
+  const [query, setQuery] = useState('')
+  // Mobile-only disclosure. Desktop ignores it via `md:` classes rather than a JS
+  // breakpoint, so there is no first-render flash and no hydration mismatch.
+  const [isOpen, setIsOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const index = useMemo(() => buildSettingsIndex(groups, baseUrl), [groups, baseUrl])
+  const results = useMemo(() => searchSettings(index, query), [index, query])
+
+  const searchable = index.length >= SEARCH_MIN_ITEMS
+  const isSearching = searchable && query.trim().length > 0
+
+  const closeMobilePanel = useCallback(() => setIsOpen(false), [])
+
+  const handleNavigate = useCallback(
+    (href: string) => {
+      router.push(href)
+      setQuery('')
+      setIsOpen(false)
+    },
+    [router]
+  )
+
+  // Focus search when the mobile panel expands. `isOpen` can only become true from
+  // the `md:hidden` toggle, so this never steals focus on desktop.
+  useEffect(() => {
+    if (isOpen) inputRef.current?.focus()
+  }, [isOpen])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      // First Escape clears the query, second blurs. Arrow keys and Enter bubble to
+      // the `Command` root, which owns selection and scroll-into-view.
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      if (query) setQuery('')
+      else inputRef.current?.blur()
+    },
+    [query]
+  )
 
   return (
-    // <div className='flex h-full min-h-screen w-[16rem] overflow-auto border-r bg-sidebar text-sidebar-foreground'>
-    <div className='flex md:w-[16rem] overflow-auto md:border-r bg-neutral-50 dark:bg-sidebar text-sidebar-foreground'>
-      <div className='flex w-full flex-col'>
-        {/* Mobile toggle button */}
-        {isMobile && (
-          <div className='sticky top-0 z-10 bg-neutral-50 dark:bg-primary-50 border-b border-neutral-200 dark:border-primary-200 p-2'>
-            <Button
-              variant='ghost'
-              className='w-full justify-between h-6 px-3'
-              onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
-              <span className='font-medium'>{title}</span>
-              {isDropdownOpen ? <ChevronUp /> : <ChevronDown />}
-            </Button>
+    <div className='flex flex-col md:h-full md:w-[16rem] md:shrink-0 md:border-r bg-neutral-50 dark:bg-sidebar text-sidebar-foreground'>
+      {/* Mobile disclosure toggle */}
+      <div className='sticky top-0 z-10 border-b border-neutral-200 dark:border-primary-200 bg-neutral-50 dark:bg-sidebar p-2 md:hidden'>
+        <Button
+          variant='ghost'
+          className='w-full justify-between h-6 px-3'
+          aria-expanded={isOpen}
+          onClick={() => setIsOpen((open) => !open)}>
+          <span className='font-medium'>{title}</span>
+          <ChevronDown className={cn('transition-transform', isOpen && 'rotate-180')} />
+        </Button>
+      </div>
+
+      <Command
+        shouldFilter={false}
+        label={title}
+        className={cn(
+          // `h-auto` cancels the Command base's `h-full`, which would fight `flex-1`.
+          'flex h-auto min-h-0 flex-1 flex-col overflow-hidden rounded-none bg-transparent',
+          'transition-[max-height] duration-300 ease-in-out',
+          // Desktop: always expanded. Mobile: driven by `isOpen`. `svh` so the
+          // software keyboard doesn't bury the results.
+          'md:max-h-none',
+          isOpen ? 'max-h-[60svh]' : 'max-h-0'
+        )}>
+        {searchable && (
+          <div className='shrink-0 p-2 pb-1'>
+            <InputSearch
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onClear={() => setQuery('')}
+              onKeyDown={handleKeyDown}
+              placeholder={`Search ${title.toLowerCase()}...`}
+              role='combobox'
+              aria-expanded={isSearching}
+              aria-label={`Search ${title.toLowerCase()}`}
+            />
           </div>
         )}
 
-        <div
-          id='dropdown'
-          className={cn(
-            'flex min-h-0 flex-1 flex-col gap-2 overflow-auto transition-all duration-300 ease-in-out',
-            // Mobile-specific classes
-            isMobile && !isDropdownOpen && 'max-h-0 overflow-hidden',
-            isMobile && isDropdownOpen && 'max-h-[70vh]',
-            // Desktop always visible
-            !isMobile && 'block'
-          )}>
-          {items.map((group) => (
-            <React.Fragment key={group.id}>
-              {createSidebarGroup(
-                group,
-                baseUrl,
-                current,
-                role,
-                selfHosted,
-                hasFeatureAccess,
-                can,
-                administersAnyDef,
-                isMobile ? () => setIsDropdownOpen(false) : undefined
-              )}
-            </React.Fragment>
-          ))}
-        </div>
-      </div>
+        {isSearching ? (
+          <SearchResults
+            results={results}
+            query={query}
+            onNavigate={handleNavigate}
+            onItemClick={closeMobilePanel}
+          />
+        ) : (
+          <ScrollArea
+            className='relative min-h-0 flex-1'
+            scrollbarClassName='w-1'
+            fadeClassName='before:bg-gradient-to-b before:from-black/10 after:bg-gradient-to-t after:from-black/10'>
+            {groups.map((group) => (
+              <SidebarNavGroup
+                key={group.id}
+                group={group}
+                baseUrl={baseUrl}
+                current={current}
+                onItemClick={closeMobilePanel}
+              />
+            ))}
+          </ScrollArea>
+        )}
+      </Command>
     </div>
   )
 }
 
-function createSidebarGroup(
-  group: SidebarProps,
-  baseUrl: string,
-  current: string | undefined,
-  role: 'ADMIN' | 'USER',
-  selfHosted: boolean,
-  hasFeatureAccess: (key: string) => boolean,
-  can: (key: string) => boolean,
-  administersAnyDef: boolean,
-  onItemClick?: () => void
-) {
-  const title = group.label
-  // Filter out cloud-only items in self-hosted mode, then by feature access and role
-  let items = selfHosted ? group.items?.filter((item) => !item.cloudOnly) : group.items
-  items = items?.filter((item) => !item.featureKey || hasFeatureAccess(item.featureKey))
-  items = items?.filter((item) => !item.access || item.access === role)
-  // Def-admin-derived items (Custom Fields, perms v2 doc 09): visible to any
-  // member administering ≥1 def, not just the org role. `administersAnyDef` is
-  // already true for OWNER/ADMIN.
-  items = items?.filter((item) => !item.requiresDefAdmin || administersAnyDef)
-  // Layer-2 capability filter — ADMIN/OWNER hold every key via ROLE_DEFAULTS, so
-  // no admin bypass is needed here; the resolved capability set already lets them
-  // through. Suppresses a group entirely once all its items are filtered out.
-  items = items?.filter((item) => !item.permissionKey || can(item.permissionKey))
-  if (!items || items.length === 0) {
-    return null
-  }
-  if (group.access && role !== group.access) {
-    return null
+/** One header group of the unfiltered nav. Plain links — never cmdk items. */
+function SidebarNavGroup({
+  group,
+  baseUrl,
+  current,
+  onItemClick,
+}: {
+  group: SidebarProps
+  baseUrl: string
+  current: string | undefined
+  onItemClick: () => void
+}) {
+  return (
+    <div className='relative flex w-full min-w-0 flex-col p-2'>
+      <div className='flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70'>
+        {group.label}
+      </div>
+      <SidebarMenu className='gap-1'>
+        {group.items?.map((item) => (
+          <SidebarMenuItem key={item.id}>
+            <SidebarMenuButton
+              asChild
+              variant='secondary'
+              size='compact'
+              isActive={item.slug === current}>
+              <Link href={`${baseUrl}/${item.slug}`} prefetch={false} onClick={onItemClick}>
+                {item.icon}
+                <span>{item.label}</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </div>
+  )
+}
+
+/**
+ * Flat result list. Rows stay real anchors so cmd-click still opens a new tab:
+ * cmdk fires `onSelect` from a custom event on Enter (never a synthetic click), while
+ * `stopPropagation` keeps its `onClick` handler out of the way of the anchor.
+ */
+function SearchResults({
+  results,
+  query,
+  onNavigate,
+  onItemClick,
+}: {
+  results: SettingsSearchResult[]
+  query: string
+  onNavigate: (href: string) => void
+  onItemClick: () => void
+}) {
+  const openPalette = useCommandPaletteStore((state) => state.openPalette)
+
+  if (results.length === 0) {
+    return (
+      <div className='flex min-h-0 flex-1 flex-col gap-2 p-3'>
+        <p className='text-sm text-muted-foreground'>
+          No settings match &ldquo;{query.trim()}&rdquo;
+        </p>
+        <Button variant='outline' size='sm' className='justify-start' onClick={openPalette}>
+          Search everything
+        </Button>
+      </div>
+    )
   }
 
   return (
-    <div className='relative flex w-full min-w-0 flex-col p-2'>
-      <div
-        className={cn(
-          'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden',
-          'ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2',
-          '[&>svg]:size-4 [&>svg]:shrink-0'
-        )}>
-        {title}
-      </div>
-      <ul className='flex w-full min-w-0 flex-col gap-1'>
-        {items.map((item) => (
-          <li className='group/menu-item relative' key={item.id}>
-            <Link
-              prefetch={false}
-              href={`${baseUrl}/${item.slug}`}
-              onClick={onItemClick}
-              data-active={item.slug == current}
-              className={cn(
-                'peer/menu-button flex h-7 w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring text-neutral-500 dark:text-sidebar-foreground',
-                'transition-[width,height,padding] hover:bg-black/5 dark:hover:bg-sidebar-accent hover:text-foreground dark:hover:text-sidebar-accent-foreground focus-visible:ring-2',
-                'active:bg-black/5 dark:active:bg-sidebar-accent active:text-foreground disabled:pointer-events-none disabled:opacity-50',
-                'group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50',
-                'data-[active=true]:bg-black/5 dark:data-[active=true]:bg-sidebar-accent dark:data-[active=true]:hover:bg-sidebar-accent data-[active=true]:text-foreground',
-                'data-[state=open]:hover:bg-black/5 data-[state=open]:hover:text-foreground ',
-                '[&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0'
-              )}>
-              {item.icon}
-              <span>{item.label}</span>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <CommandList scrollAreaClassName='min-h-0 flex-1 max-h-none' className='p-2'>
+      {results.map((result) => (
+        <CommandItem
+          key={result.item.id}
+          value={result.item.id}
+          onSelect={() => onNavigate(result.href)}
+          className={cn(
+            sidebarMenuButtonVariants({ variant: 'secondary', size: 'compact' }),
+            'h-auto min-h-7 rounded-md py-1.5',
+            'data-[selected=true]:ring-1 data-[selected=true]:ring-inset data-[selected=true]:ring-primary-300',
+            'data-[selected=true]:bg-black/5 dark:data-[selected=true]:bg-sidebar-accent'
+          )}>
+          <Link
+            href={result.href}
+            prefetch={false}
+            onClick={(event) => {
+              // Let the anchor own every click (incl. cmd/middle) — keep cmdk's
+              // onClick handler from double-navigating.
+              event.stopPropagation()
+              onItemClick()
+            }}
+            className='flex min-w-0 flex-1 items-center gap-2'>
+            {result.item.icon}
+            {/* The cva's `[&>span:last-child]:truncate` targets DIRECT span children,
+                so the label needs its own explicit `truncate` inside this wrapper. */}
+            <span className='flex min-w-0 flex-1 flex-col'>
+              <span className='truncate'>
+                <HighlightedLabel label={result.item.label} match={result.labelMatch} />
+              </span>
+              <span className='truncate text-xs text-muted-foreground'>
+                {result.item.description ?? result.groupLabel}
+              </span>
+            </span>
+          </Link>
+        </CommandItem>
+      ))}
+    </CommandList>
+  )
+}
+
+/** Bolds the matched span of a label, when the hit was in the label itself. */
+function HighlightedLabel({ label, match }: { label: string; match: [number, number] | null }) {
+  if (!match) return <>{label}</>
+  const [start, end] = match
+  return (
+    <>
+      {label.slice(0, start)}
+      <mark className='bg-transparent font-semibold text-foreground'>
+        {label.slice(start, end)}
+      </mark>
+      {label.slice(end)}
+    </>
   )
 }
 

--- a/apps/web/src/components/kbar/actions/settings.ts
+++ b/apps/web/src/components/kbar/actions/settings.ts
@@ -3,24 +3,58 @@
 
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo } from 'react'
-import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
-import { useUser } from '~/hooks/use-user'
-import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { SETTINGS_MENU } from '~/constants/menu'
+import { useSettingsMenu } from '~/hooks/use-settings-menu'
 import { SHORTCUTS } from '../shortcuts'
 import { useCommandPaletteStore } from '../store'
 import type { PaletteAction } from '../types'
 
 /**
- * Settings navigation actions, mirroring `SETTINGS_MENU`. Member-visible items
- * are always present; admin-only items appear for admins/owners; a few ride
- * feature flags. Billing keeps no chord (it lost `s,b` to Inbox settings) but
- * stays reachable via search.
+ * Palette metadata per `SETTINGS_MENU` item id: the stable action id — which keys
+ * both `SHORTCUTS` and the recents store, so it must not change — plus an icon id
+ * from the shared registry.
+ *
+ * Items missing from this map still produce an action (id `settings.<slug>`, no
+ * icon), so a new settings page is reachable from the palette the moment it lands
+ * in the menu.
+ */
+const PALETTE_META: Record<string, { id: string; icon: string }> = {
+  'settings-general': { id: 'settings.general', icon: 'settings' },
+  'settings-account': { id: 'settings.account', icon: 'circle-user' },
+  'settings-organization': { id: 'settings.organization', icon: 'building' },
+  'settings-members': { id: 'settings.members', icon: 'users' },
+  'settings-permissions': { id: 'settings.permissions', icon: 'shield-check' },
+  'admin-plans': { id: 'settings.billing', icon: 'credit-card' },
+  'settings-activity-log': { id: 'settings.activityLog', icon: 'history' },
+  'admin-fields': { id: 'settings.customFields', icon: 'text-cursor-input' },
+  'admin-tags': { id: 'settings.tags', icon: 'tag' },
+  'admin-import-history': { id: 'settings.importHistory', icon: 'download' },
+  'admin-rules': { id: 'settings.rules', icon: 'zap' },
+  'settings-aiModels': { id: 'settings.aiModels', icon: 'sparkles' },
+  'settings-kopilot': { id: 'settings.kopilot', icon: 'sparkles' },
+  'settings-channels': { id: 'settings.channels', icon: 'inbox' },
+  'settings-inboxes': { id: 'settings.inbox', icon: 'inbox' },
+  'settings-signatures': { id: 'settings.signatures', icon: 'pen-tool' },
+  'settings-snippets': { id: 'settings.snippets', icon: 'braces' },
+  'settings-apps': { id: 'settings.apps', icon: 'boxes' },
+  'settings-connections': { id: 'settings.connections', icon: 'cable' },
+  'settings-webhooks': { id: 'settings.webhooks', icon: 'webhook' },
+  'settings-apiKeys': { id: 'settings.apiKeys', icon: 'key' },
+}
+
+/**
+ * Settings navigation actions, **derived** from `SETTINGS_MENU` through
+ * `useSettingsMenu()` — the same filtered menu the settings sidebar renders.
+ *
+ * This used to be a hand-maintained mirror of the menu and had drifted: it gated on
+ * `isAdminOrOwner` where the sidebar gates on Layer-2 `permissionKey` (so a member
+ * holding `members.manage` saw "Members and Groups" in the nav but could not find it
+ * here), and it omitted Permissions, Rules and Connections entirely. Deriving keeps
+ * the two surfaces honest by construction — do not reintroduce a parallel list.
  */
 export function useSettingsActions(): PaletteAction[] {
   const router = useRouter()
-  const { hasAccess } = useFeatureFlags()
-  const { isAdminOrOwner } = useUser()
-  const selfHosted = useIsSelfHosted()
+  const groups = useSettingsMenu(SETTINGS_MENU)
 
   const goToSetting = useCallback(
     (slug: string) => {
@@ -31,171 +65,45 @@ export function useSettingsActions(): PaletteAction[] {
   )
 
   return useMemo<PaletteAction[]>(() => {
-    const actions: PaletteAction[] = [
-      {
-        id: 'settings.general',
-        label: 'General Settings',
-        icon: 'settings',
-        keywords: 'settings general',
-        shortcut: SHORTCUTS['settings.general'],
-        perform: () => goToSetting('general'),
-      },
-      {
-        id: 'settings.account',
-        label: 'My Account',
-        icon: 'circle-user',
-        keywords: 'account profile me',
-        shortcut: SHORTCUTS['settings.account'],
-        perform: () => goToSetting('account'),
-      },
-      {
-        id: 'settings.organization',
-        label: 'Organization Settings',
-        icon: 'building',
-        keywords: 'organization',
-        shortcut: SHORTCUTS['settings.organization'],
-        perform: () => goToSetting('organization'),
-      },
-      {
-        id: 'settings.snippets',
-        label: 'Snippets Settings',
-        icon: 'braces',
-        keywords: 'snippets',
-        shortcut: SHORTCUTS['settings.snippets'],
-        perform: () => goToSetting('snippets'),
-      },
-      {
-        id: 'settings.signatures',
-        label: 'Signatures Settings',
-        icon: 'pen-tool',
-        keywords: 'signatures',
-        shortcut: SHORTCUTS['settings.signatures'],
-        perform: () => goToSetting('signatures'),
-      },
-      {
-        id: 'settings.apps',
-        label: 'Apps & MCP',
-        icon: 'boxes',
-        keywords: 'apps mcp marketplace integrations',
-        shortcut: SHORTCUTS['settings.apps'],
-        perform: () => goToSetting('apps'),
-      },
-    ]
+    const actions: PaletteAction[] = groups.flatMap((group) =>
+      (group.items ?? []).flatMap((item) => {
+        if (!item.slug) return []
+        const meta = PALETTE_META[item.id]
+        const id = meta?.id ?? `settings.${item.slug}`
+        const slug = item.slug
 
-    if (hasAccess('apiAccess')) {
+        return [
+          {
+            id,
+            label: item.label,
+            subtitle: item.description,
+            icon: meta?.icon,
+            keywords: [group.label, ...(item.keywords ?? [])].join(' '),
+            shortcut: SHORTCUTS[id],
+            perform: () => goToSetting(slug),
+          },
+        ]
+      })
+    )
+
+    // `/app/settings/groups` is a live route with an `s,r` chord but is deliberately
+    // absent from the nav (groups are reached via "Members and Groups"). Derived
+    // actions can't see it, so it stays explicit — gated on the same visibility as
+    // the Members item rather than on a separate role check.
+    const canSeeMembers = groups.some((group) =>
+      group.items?.some((item) => item.id === 'settings-members')
+    )
+    if (canSeeMembers) {
       actions.push({
-        id: 'settings.apiKeys',
-        label: 'API Keys Settings',
-        icon: 'key',
-        keywords: 'api keys',
-        shortcut: SHORTCUTS['settings.apiKeys'],
-        perform: () => goToSetting('apiKeys'),
+        id: 'settings.groups',
+        label: 'Groups',
+        icon: 'layers',
+        keywords: 'groups teams',
+        shortcut: SHORTCUTS['settings.groups'],
+        perform: () => goToSetting('groups'),
       })
     }
 
-    if (isAdminOrOwner) {
-      actions.push(
-        {
-          id: 'settings.channels',
-          label: 'Channels',
-          icon: 'inbox',
-          keywords: 'channels',
-          shortcut: SHORTCUTS['settings.channels'],
-          perform: () => goToSetting('channels'),
-        },
-        {
-          id: 'settings.members',
-          label: 'Members',
-          icon: 'users',
-          keywords: 'members users',
-          shortcut: SHORTCUTS['settings.members'],
-          perform: () => goToSetting('members'),
-        },
-        {
-          id: 'settings.groups',
-          label: 'Groups',
-          icon: 'layers',
-          keywords: 'groups teams',
-          shortcut: SHORTCUTS['settings.groups'],
-          perform: () => goToSetting('groups'),
-        },
-        {
-          id: 'settings.inbox',
-          label: 'Inboxes',
-          icon: 'inbox',
-          keywords: 'inbox inboxes messages',
-          shortcut: SHORTCUTS['settings.inbox'],
-          perform: () => goToSetting('inbox'),
-        },
-        {
-          id: 'settings.aiModels',
-          label: 'AI Models',
-          icon: 'sparkles',
-          keywords: 'ai models openai gemini deepseek claude chatgpt',
-          shortcut: SHORTCUTS['settings.aiModels'],
-          perform: () => goToSetting('aiModels'),
-        },
-        {
-          id: 'settings.kopilot',
-          label: 'Kopilot Settings',
-          icon: 'sparkles',
-          keywords: 'kopilot ai assistant',
-          perform: () => goToSetting('kopilot'),
-        },
-        {
-          id: 'settings.customFields',
-          label: 'Custom Entities & Fields',
-          icon: 'text-cursor-input',
-          keywords: 'custom fields entities',
-          shortcut: SHORTCUTS['settings.customFields'],
-          perform: () => goToSetting('custom-fields'),
-        },
-        {
-          id: 'settings.activityLog',
-          label: 'Account Activity',
-          icon: 'history',
-          keywords: 'activity log audit history',
-          perform: () => goToSetting('activity-log'),
-        },
-        {
-          id: 'settings.tags',
-          label: 'Tags',
-          icon: 'tag',
-          keywords: 'tags',
-          shortcut: SHORTCUTS['settings.tags'],
-          perform: () => goToSetting('tags'),
-        },
-        {
-          id: 'settings.importHistory',
-          label: 'Import & Export',
-          icon: 'download',
-          keywords: 'import export history data transfer',
-          perform: () => goToSetting('import-history'),
-        }
-      )
-
-      if (hasAccess('webhooks')) {
-        actions.push({
-          id: 'settings.webhooks',
-          label: 'Webhooks',
-          icon: 'webhook',
-          keywords: 'webhooks',
-          shortcut: SHORTCUTS['settings.webhooks'],
-          perform: () => goToSetting('webhooks'),
-        })
-      }
-      // Billing is cloud-only and lost its `s,b` chord to Inbox settings.
-      if (!selfHosted) {
-        actions.push({
-          id: 'settings.billing',
-          label: 'Plans & Billing',
-          icon: 'credit-card',
-          keywords: 'billing plans subscription payment',
-          perform: () => goToSetting('plans'),
-        })
-      }
-    }
-
     return actions
-  }, [hasAccess, isAdminOrOwner, selfHosted, goToSetting])
+  }, [groups, goToSetting])
 }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -70,6 +70,17 @@ export type SidebarProps = {
    * only the defs the member administers.
    */
   requiresDefAdmin?: boolean
+  /**
+   * One-line supporting copy shown under the label in `SidebarSecondary`'s search
+   * results. Add it only where the label alone is ambiguous (General vs My Account vs
+   * Organization, Channels vs Inboxes, Connections vs Apps & MCP) — not to every item.
+   */
+  description?: string
+  /**
+   * Extra terms that should match this item in search but don't appear in its label,
+   * e.g. `['stripe', 'subscription']` for Plans & Billing. Matched case-insensitively.
+   */
+  keywords?: string[]
 } & FieldProps
 
 import type * as React from 'react'
@@ -263,13 +274,29 @@ export const SETTINGS_MENU: SidebarProps[] = [
     label: 'Account',
     type: 'header',
     items: [
-      { id: 'settings-general', label: 'General', slug: 'general', icon: <Settings /> },
-      { id: 'settings-account', label: 'My Account', slug: 'account', icon: <UserCog /> },
+      {
+        id: 'settings-general',
+        label: 'General',
+        slug: 'general',
+        icon: <Settings />,
+        description: 'Appearance, language and notification preferences',
+        keywords: ['theme', 'dark mode', 'language', 'timezone', 'preferences'],
+      },
+      {
+        id: 'settings-account',
+        label: 'My Account',
+        slug: 'account',
+        icon: <UserCog />,
+        description: 'Your profile, password and two-factor authentication',
+        keywords: ['profile', 'password', '2fa', 'mfa', 'passkey', 'security', 'email address'],
+      },
       {
         id: 'settings-organization',
         label: 'Organization',
         slug: 'organization',
         icon: <Building2 />,
+        description: 'Workspace name, logo and defaults',
+        keywords: ['workspace', 'company', 'logo', 'branding', 'domain'],
       },
     ],
   },
@@ -285,6 +312,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'members',
         icon: <Users />,
         permissionKey: 'members.manage',
+        keywords: ['users', 'teams', 'invite', 'seats', 'people'],
       },
       {
         id: 'settings-permissions',
@@ -293,6 +321,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         icon: <ShieldCheck />,
         // `permissions` area stays adminOnly (granting the grant is an escalation).
         access: 'ADMIN',
+        keywords: ['roles', 'access', 'sharing', 'sso', 'saml', 'policy'],
       },
       {
         id: 'admin-plans',
@@ -302,6 +331,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         // Read is enough to SEE the billing tab.
         permissionKey: 'billing.view',
         cloudOnly: true,
+        keywords: ['stripe', 'subscription', 'invoice', 'payment', 'upgrade', 'credits'],
       },
       {
         id: 'settings-activity-log',
@@ -309,6 +339,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'activity-log',
         icon: <History />,
         permissionKey: 'auditLog.view',
+        keywords: ['audit', 'log', 'history', 'events', 'security'],
       },
     ],
   },
@@ -326,6 +357,8 @@ export const SETTINGS_MENU: SidebarProps[] = [
         // Derived from def-admin (perms v2 doc 09): visible to any member who
         // administers ≥1 def; the page lists only their administered defs.
         requiresDefAdmin: true,
+        description: 'Define record types and the fields on them',
+        keywords: ['schema', 'objects', 'properties', 'attributes', 'records', 'columns'],
       },
       {
         id: 'admin-tags',
@@ -334,6 +367,8 @@ export const SETTINGS_MENU: SidebarProps[] = [
         icon: <Tag />,
         // TODO(perms v2 doc 09): gets its own area later; deferred, stays admin.
         access: 'ADMIN',
+        description: 'Shared labels applied across records and threads',
+        keywords: ['labels', 'categories'],
       },
       {
         id: 'admin-import-history',
@@ -342,6 +377,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         icon: <Import />,
         // TODO(perms v2 doc 09): gets its own area later; deferred, stays admin.
         access: 'ADMIN',
+        keywords: ['csv', 'upload', 'migration', 'backup', 'download', 'data transfer'],
       },
       {
         id: 'admin-rules',
@@ -349,6 +385,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'rules',
         icon: <Zap />,
         permissionKey: 'automationRules.manage',
+        keywords: ['automation', 'triggers', 'record rules', 'if this then that'],
       },
     ],
   },
@@ -364,6 +401,8 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'aiModels',
         icon: <Bot />,
         permissionKey: 'aiConfig.manage',
+        description: 'Providers, API keys and the default model',
+        keywords: ['openai', 'anthropic', 'claude', 'gemini', 'chatgpt', 'deepseek', 'llm', 'byo'],
       },
       {
         id: 'settings-kopilot',
@@ -371,6 +410,8 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'kopilot',
         icon: <Sparkles />,
         permissionKey: 'aiConfig.manage',
+        description: 'Org defaults for the AI assistant',
+        keywords: ['assistant', 'copilot', 'chat', 'ai'],
       },
     ],
   },
@@ -386,10 +427,32 @@ export const SETTINGS_MENU: SidebarProps[] = [
         label: 'Channels',
         slug: 'channels',
         icon: <Waypoints />,
+        description: 'Connect the accounts messages arrive on',
+        keywords: ['gmail', 'outlook', 'imap', 'smtp', 'email account', 'sms', 'whatsapp'],
       },
-      { id: 'settings-inboxes', label: 'Inboxes', slug: 'inbox', icon: <Inbox />, access: 'ADMIN' },
-      { id: 'settings-signatures', label: 'Signatures', slug: 'signatures', icon: <Feather /> },
-      { id: 'settings-snippets', label: 'Snippets', slug: 'snippets', icon: <Tag /> },
+      {
+        id: 'settings-inboxes',
+        label: 'Inboxes',
+        slug: 'inbox',
+        icon: <Inbox />,
+        access: 'ADMIN',
+        description: 'Shared queues that route those messages to your team',
+        keywords: ['shared inbox', 'routing', 'assignment', 'queue'],
+      },
+      {
+        id: 'settings-signatures',
+        label: 'Signatures',
+        slug: 'signatures',
+        icon: <Feather />,
+        keywords: ['sign off', 'footer', 'email signature'],
+      },
+      {
+        id: 'settings-snippets',
+        label: 'Snippets',
+        slug: 'snippets',
+        icon: <Tag />,
+        keywords: ['canned response', 'macro', 'template', 'saved reply'],
+      },
     ],
   },
   // Integrations — apps/MCP/webhooks + connections + API keys.
@@ -404,12 +467,16 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'apps',
         icon: <AppWindow />,
         permissionKey: 'integrations.manage',
+        description: 'Install apps and MCP servers that add capabilities',
+        keywords: ['marketplace', 'integrations', 'mcp', 'shopify', 'quickbooks', 'plugins'],
       },
       {
         id: 'settings-connections',
         label: 'Connections',
         slug: 'connections',
         icon: <Cable />,
+        description: 'Accounts those apps authenticate against',
+        keywords: ['oauth', 'credentials', 'authorize', 'linked accounts', 'reconnect'],
       },
       {
         id: 'settings-webhooks',
@@ -418,6 +485,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         icon: <Webhook />,
         permissionKey: 'integrations.manage',
         featureKey: 'webhooks',
+        keywords: ['callbacks', 'events', 'http', 'subscriptions'],
       },
       {
         id: 'settings-apiKeys',
@@ -425,6 +493,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         slug: 'apiKeys',
         icon: <ComponentIcon />,
         featureKey: 'apiAccess',
+        keywords: ['token', 'secret', 'sdk', 'rest', 'developer'],
       },
     ],
   },

--- a/apps/web/src/hooks/use-settings-menu.ts
+++ b/apps/web/src/hooks/use-settings-menu.ts
@@ -1,0 +1,50 @@
+// apps/web/src/hooks/use-settings-menu.ts
+'use client'
+
+import { useMemo } from 'react'
+import type { SidebarProps } from '~/constants/menu'
+import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
+import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+/**
+ * Applies every settings-menu visibility predicate and drops groups that end up
+ * empty. This is the single source of truth for "which settings can this member
+ * actually reach" — `SidebarSecondary` renders it, its search indexes it, and the
+ * command palette derives its settings actions from it.
+ *
+ * Anything building a settings index MUST go through this hook rather than reading
+ * `SETTINGS_MENU` directly, or it will surface pages the member 403s on.
+ *
+ * Filter order mirrors the original inline chain: self-hosted → feature flag → role
+ * → def-admin → Layer-2 capability. ADMIN/OWNER hold every capability key via
+ * ROLE_DEFAULTS, so no admin bypass is needed for `permissionKey`.
+ */
+export function useSettingsMenu(groups: SidebarProps[]): SidebarProps[] {
+  const selfHosted = useIsSelfHosted()
+  const { isAdminOrOwner } = useUser({ requireOrganization: true })
+  const { hasAccess: hasFeatureAccess } = useFeatureFlags()
+  const { can, administersAnyDef } = useAccess()
+
+  return useMemo(() => {
+    const role: 'ADMIN' | 'USER' = isAdminOrOwner ? 'ADMIN' : 'USER'
+
+    return groups.flatMap((group) => {
+      if (group.access && group.access !== role) return []
+
+      const items = (group.items ?? []).filter(
+        (item) =>
+          (!selfHosted || !item.cloudOnly) &&
+          (!item.featureKey || hasFeatureAccess(item.featureKey)) &&
+          (!item.access || item.access === role) &&
+          // Custom Fields is *derived* from def-admin, not its own Layer-2 area
+          // (perms v2 doc 09); the page lists only the defs the member administers.
+          (!item.requiresDefAdmin || administersAnyDef) &&
+          (!item.permissionKey || can(item.permissionKey))
+      )
+
+      return items.length > 0 ? [{ ...group, items }] : []
+    })
+  }, [groups, selfHosted, isAdminOrOwner, hasFeatureAccess, can, administersAnyDef])
+}

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -807,11 +807,19 @@ const sidebarMenuButtonVariants = cva(
           'border border-dashed border-primary-300 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ',
         outline:
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+        // Nested secondary panels (SidebarSecondary) sit on `bg-neutral-50` rather than
+        // `bg-sidebar`, so they need a lighter treatment than `default`: muted resting
+        // text, a black/5 wash instead of `sidebar-accent` in light mode, and no
+        // `font-medium` on the active row (the background alone carries it).
+        secondary:
+          'overflow-hidden text-neutral-500 dark:text-sidebar-foreground hover:bg-black/5 hover:text-foreground dark:hover:bg-sidebar-accent dark:hover:text-sidebar-accent-foreground active:bg-black/5 active:text-foreground dark:active:bg-sidebar-accent data-[active=true]:bg-black/5 data-[active=true]:font-normal data-[active=true]:text-foreground dark:data-[active=true]:bg-sidebar-accent dark:data-[active=true]:hover:bg-sidebar-accent data-[state=open]:hover:bg-black/5 data-[state=open]:hover:text-foreground',
       },
       size: {
         default: 'h-8 text-sm',
         sm: 'h-7 text-xs',
         lg: 'h-12 text-sm',
+        // `sm` height at `default` type scale — the SidebarSecondary row metric.
+        compact: 'h-7 text-sm',
       },
     },
     defaultVariants: { variant: 'default', size: 'default' },
@@ -1005,5 +1013,8 @@ export {
   SidebarProvider,
   SidebarSeparator,
   SidebarTrigger,
+  // Exported so secondary surfaces can apply the row styling to a non-button host
+  // (e.g. a cmdk `CommandItem`) without nesting a second interactive wrapper.
+  sidebarMenuButtonVariants,
   useSidebar,
 }


### PR DESCRIPTION
Adds an iOS-Settings-style search field to `SidebarSecondary`, and collapses the duplicated settings index that the command palette was hand-maintaining.

## Search

Typing swaps the grouped nav for a flat, keyboard-navigable result list. Ranked substring matching (label prefix > word prefix > substring > keyword > group > description) rather than fuzzy — across ~22 items a fuzzy matcher mostly produces noise (`gen` matching "Mana**g**e **G**roups").

Built on cmdk for selection/scroll-into-view, but with `InputSearch` as the input rather than `CommandInput`, whose wrapper has a hardcoded className and no prop to override it. cmdk's `onKeyDown` lives on the `Command` root, so keystrokes bubble up from any input inside it.

The unfiltered nav is **not** rendered as cmdk items — `CommandList` carries `role="listbox"`, which is wrong for an always-visible nav, and plain `<Link>` rows keep cmd-click/middle-click working. Result rows are `CommandItem`s wrapping real anchors, with `stopPropagation` so the anchor owns clicks while Enter goes through cmdk's `onSelect`.

Search hides below 8 reachable items (the tickets menu has ~6); the empty state bridges to the command palette.

## One source of truth

`useSettingsMenu()` now owns the visibility chain (`cloudOnly` → `featureKey` → role → def-admin → `permissionKey`) and feeds the sidebar, its search, and the palette.

The palette's settings actions were a hand-written mirror of `SETTINGS_MENU` and had drifted:

- gated on `isAdminOrOwner` where the sidebar gates on Layer-2 `permissionKey` — a member holding `members.manage` saw "Members and Groups" in the nav but **could not find it in the palette**
- Permissions, Rules and Connections were missing entirely

`/app/settings/groups` is a live route that is deliberately absent from the nav, so it stays an explicit action (keeping its `s,r` chord) rather than being dropped.

## Row styling

Nav rows now use `SidebarMenuButton` through a new `secondary` variant — a verbatim port of the existing settings-row colors (`text-neutral-500`, `hover:bg-black/5`, no `font-medium` on active) plus a `compact` size (`h-7 text-sm`) — instead of a copied class blob. Nothing changes visually.

Note the cva's `[&>span:last-child]:truncate` and `[&>svg]:size-4` are **direct-child** selectors, so result rows (which add a second line) state `truncate` explicitly inside their own wrapper.

## Latent bugs fixed in passing

- `tickets/settings` and `dispatch/settings` flipped to a row at `sm:` while the sidebar is `md:`, collapsing it to a sliver between 640–767px
- `useIsMobile` returns `false` on first render, so phones rendered the panel expanded then collapsed it — the disclosure is now CSS-driven and the hook is gone from this component
- `max-h-[70vh]` ignored the software keyboard; now `60svh`

## Testing

- Biome clean; `tsc --noEmit` clean for all touched files in `packages/ui` and `apps/web`
- **Not verified in a browser** — no dev server was running. Worth an eyeball on the mobile `max-h` transition and on arrow keys reaching cmdk through event bubbling.

## Known limitation

`CommandList` assigns its own list `id`, so `aria-controls` can't reliably point at it. The input gets `role="combobox"` + `aria-expanded` + `aria-label`; `aria-activedescendant` is owned by cmdk on the list.