### PR TITLE
Gate dispatch records by dispatch access

### DIFF
--- a/apps/web/src/app/(protected)/app/dispatch/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/layout.tsx
@@ -10,7 +10,10 @@ import {
 } from '@auxx/ui/components/main-page'
 import { MainPageTabs } from '@auxx/ui/components/main-page-tabs'
 import { CalendarDays, Settings } from 'lucide-react'
+import { usePathname } from 'next/navigation'
 import { DispatchSetupWizardGate } from '~/components/dispatch/ui/setup-wizard/setup-wizard-gate'
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
+import { useAccess } from '~/providers/capabilities-provider'
 
 /**
  * Module header for `/app/dispatch/*` — Board · Settings tabs via
@@ -18,6 +21,8 @@ import { DispatchSetupWizardGate } from '~/components/dispatch/ui/setup-wizard/s
  * `router.push` on select).
  */
 function DispatchLayoutHeader() {
+  const { can } = useAccess()
+
   return (
     <MainPageHeader className='justify-start'>
       <MainPageBreadcrumb>
@@ -38,6 +43,7 @@ function DispatchLayoutHeader() {
             icon: <Settings />,
             href: '/app/dispatch/settings',
             tooltip: 'Settings',
+            hidden: !can('dispatch.board.manage'),
           },
         ]}
       />
@@ -54,11 +60,17 @@ function DispatchLayoutHeader() {
  * route tree; it renders nothing until its own gating conditions are met.
  */
 export default function DispatchLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const isSettings = pathname.startsWith('/app/dispatch/settings')
+  const permissionKey = isSettings ? 'dispatch.board.manage' : 'dispatch.board.view'
+
   return (
-    <MainPage>
-      <DispatchLayoutHeader />
-      {children}
-      <DispatchSetupWizardGate />
-    </MainPage>
+    <CapabilityPageGuard permissionKey={permissionKey} area='Dispatch'>
+      <MainPage>
+        <DispatchLayoutHeader />
+        {children}
+        <DispatchSetupWizardGate />
+      </MainPage>
+    </CapabilityPageGuard>
   )
 }

--- a/apps/web/src/app/(protected)/app/invoices/layout.tsx
+++ b/apps/web/src/app/(protected)/app/invoices/layout.tsx
@@ -9,6 +9,7 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { usePathname } from 'next/navigation'
+import { RecordRouteGuard } from '~/components/records'
 import { useResource } from '~/components/resources'
 
 type Props = { children: React.ReactNode; modal: React.ReactNode }
@@ -28,24 +29,24 @@ export default function InvoicesLayout({ children, modal }: Props) {
   const { resource } = useResource('invoices')
   const isDetailOrSpecialPage = pathname !== BASE_PATH
 
-  if (isDetailOrSpecialPage) {
-    return (
-      <>
-        {children}
-        {modal}
-      </>
-    )
-  }
-
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title={resource?.plural ?? 'Invoices'} href={BASE_PATH} />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      {children}
-      {modal}
-    </MainPage>
+    <RecordRouteGuard slug='invoices'>
+      {isDetailOrSpecialPage ? (
+        <>
+          {children}
+          {modal}
+        </>
+      ) : (
+        <MainPage>
+          <MainPageHeader>
+            <MainPageBreadcrumb>
+              <MainPageBreadcrumbItem title={resource?.plural ?? 'Invoices'} href={BASE_PATH} />
+            </MainPageBreadcrumb>
+          </MainPageHeader>
+          {children}
+          {modal}
+        </MainPage>
+      )}
+    </RecordRouteGuard>
   )
 }

--- a/apps/web/src/app/(protected)/app/quotes/layout.tsx
+++ b/apps/web/src/app/(protected)/app/quotes/layout.tsx
@@ -9,6 +9,7 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { usePathname } from 'next/navigation'
+import { RecordRouteGuard } from '~/components/records'
 import { useResource } from '~/components/resources'
 
 type Props = { children: React.ReactNode; modal: React.ReactNode }
@@ -27,24 +28,24 @@ export default function QuotesLayout({ children, modal }: Props) {
   const { resource } = useResource('quotes')
   const isDetailOrSpecialPage = pathname !== BASE_PATH
 
-  if (isDetailOrSpecialPage) {
-    return (
-      <>
-        {children}
-        {modal}
-      </>
-    )
-  }
-
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title={resource?.plural ?? 'Quotes'} href={BASE_PATH} />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      {children}
-      {modal}
-    </MainPage>
+    <RecordRouteGuard slug='quotes'>
+      {isDetailOrSpecialPage ? (
+        <>
+          {children}
+          {modal}
+        </>
+      ) : (
+        <MainPage>
+          <MainPageHeader>
+            <MainPageBreadcrumb>
+              <MainPageBreadcrumbItem title={resource?.plural ?? 'Quotes'} href={BASE_PATH} />
+            </MainPageBreadcrumb>
+          </MainPageHeader>
+          {children}
+          {modal}
+        </MainPage>
+      )}
+    </RecordRouteGuard>
   )
 }

--- a/apps/web/src/app/(protected)/app/service-requests/layout.tsx
+++ b/apps/web/src/app/(protected)/app/service-requests/layout.tsx
@@ -9,6 +9,7 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { usePathname } from 'next/navigation'
+import { RecordRouteGuard } from '~/components/records'
 import { useResource } from '~/components/resources'
 
 const BASE_PATH = '/app/service-requests'
@@ -25,18 +26,23 @@ export default function ServiceRequestsLayout({ children }: { children: React.Re
   const { resource } = useResource('service-requests')
   const isDetailOrSpecialPage = pathname !== BASE_PATH
 
-  if (isDetailOrSpecialPage) {
-    return <>{children}</>
-  }
-
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title={resource?.plural ?? 'Service Requests'} href={BASE_PATH} />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      {children}
-    </MainPage>
+    <RecordRouteGuard slug='service-requests'>
+      {isDetailOrSpecialPage ? (
+        children
+      ) : (
+        <MainPage>
+          <MainPageHeader>
+            <MainPageBreadcrumb>
+              <MainPageBreadcrumbItem
+                title={resource?.plural ?? 'Service Requests'}
+                href={BASE_PATH}
+              />
+            </MainPageBreadcrumb>
+          </MainPageHeader>
+          {children}
+        </MainPage>
+      )}
+    </RecordRouteGuard>
   )
 }

--- a/apps/web/src/app/(protected)/app/work-orders/layout.tsx
+++ b/apps/web/src/app/(protected)/app/work-orders/layout.tsx
@@ -9,6 +9,7 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { usePathname } from 'next/navigation'
+import { RecordRouteGuard } from '~/components/records'
 import { useResource } from '~/components/resources'
 
 const BASE_PATH = '/app/work-orders'
@@ -25,18 +26,20 @@ export default function WorkOrdersLayout({ children }: { children: React.ReactNo
   const { resource } = useResource('work-orders')
   const isDetailOrSpecialPage = pathname !== BASE_PATH
 
-  if (isDetailOrSpecialPage) {
-    return <>{children}</>
-  }
-
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title={resource?.plural ?? 'Work Orders'} href={BASE_PATH} />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      {children}
-    </MainPage>
+    <RecordRouteGuard slug='work-orders'>
+      {isDetailOrSpecialPage ? (
+        children
+      ) : (
+        <MainPage>
+          <MainPageHeader>
+            <MainPageBreadcrumb>
+              <MainPageBreadcrumbItem title={resource?.plural ?? 'Work Orders'} href={BASE_PATH} />
+            </MainPageBreadcrumb>
+          </MainPageHeader>
+          {children}
+        </MainPage>
+      )}
+    </RecordRouteGuard>
   )
 }

--- a/apps/web/src/components/detail-view/detail-view.tsx
+++ b/apps/web/src/components/detail-view/detail-view.tsx
@@ -13,10 +13,12 @@ import {
 } from '@auxx/ui/components/main-page'
 import { PanelRight } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { NoAccess } from '~/components/permissions/ui/no-access'
 import { getRecordDrillPanels } from '~/components/records/record-drill-panels'
-import { toRecordId, useRecord, useResourceProperty } from '~/components/resources'
+import { toRecordId, useRecord, useResource, useResourceProperty } from '~/components/resources'
 import { useIsMobile } from '~/hooks/use-mobile'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { DetailViewActions } from './components/detail-view-actions'
 import { DetailViewMainTabs } from './detail-view-main-tabs'
@@ -31,6 +33,9 @@ import type { DetailViewProps } from './types'
  * Works for all entity types (system and custom) using registry-based configuration
  */
 export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: DetailViewProps) {
+  const { resource, isLoading: resourceLoading } = useResource(apiSlug)
+  const { can, canViewEntity } = useAccess()
+
   // Get resource properties including id (entityDefinitionId) and entityType
   const resourceProps = useResourceProperty(apiSlug, [
     'id', // entityDefinitionId
@@ -48,9 +53,13 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
 
   // Build recordId with the actual entityDefinitionId
   const recordId = toRecordId(entityDefinitionId, instanceId)
+  const canViewDefinition = resource ? canViewEntity(resource.entityDefinitionId) : !resourceLoading
 
   // Get record data
-  const { record, isLoading, isNotFound, hasLoadedOnce } = useRecord({ recordId, enabled: true })
+  const { record, isLoading, isNotFound, hasLoadedOnce } = useRecord({
+    recordId,
+    enabled: !resourceLoading && canViewDefinition,
+  })
 
   // Get config from registry based on entityType
   const config = getDetailViewConfig(entityType)
@@ -87,10 +96,45 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
 
   const backUrl = backUrlOverride ?? defaultBackUrl
 
+  // Filter once at the detail-view boundary so the tab strip, rendered
+  // sections, active-tab fallback, and lazy query owners all consume the same
+  // list. This also handles a hidden default or a denied `?tab=` deep link.
+  const visibleMainTabs = useMemo(
+    () => config.mainTabs.filter((tab) => !tab.permissionKey || can(tab.permissionKey)),
+    [config.mainTabs, can]
+  )
+  const requestedMainTab = mainTab ?? config.defaultTab ?? 'overview'
+  const activeMainTab = visibleMainTabs.some((tab) => tab.value === requestedMainTab)
+    ? requestedMainTab
+    : (visibleMainTabs[0]?.value ?? requestedMainTab)
+  const visibleConfig = useMemo(
+    () => ({ ...config, mainTabs: visibleMainTabs, defaultTab: activeMainTab }),
+    [config, visibleMainTabs, activeMainTab]
+  )
+  const visibleDrillPanels = useMemo(
+    () =>
+      getRecordDrillPanels(entityType).filter(
+        (panel) => !panel.permissionKey || can(panel.permissionKey)
+      ),
+    [entityType, can]
+  )
+
+  useEffect(() => {
+    if (mainTab !== activeMainTab) void setMainTab(activeMainTab)
+  }, [activeMainTab, mainTab, setMainTab])
+
   // Loading state — on first load the recordId is built with the apiSlug
   // fallback until `resource.list` hydrates, so "no record yet" (no fetch
   // attempt completed for the current id) must show the skeleton, not the
   // not-found screen.
+  if (resourceLoading) {
+    return <DetailViewSkeleton label={label} backUrl={backUrl} />
+  }
+
+  if (!canViewDefinition) {
+    return <NoAccess area={plural ?? label} backHref={backUrl} />
+  }
+
   if (isLoading || (!record && !hasLoadedOnce)) {
     return <DetailViewSkeleton label={label} backUrl={backUrl} />
   }
@@ -158,18 +202,18 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
           <DetailViewSections
             recordId={recordId}
             entityType={entityType}
-            config={config}
-            activeTab={mainTab ?? config.defaultTab ?? 'overview'}
+            config={visibleConfig}
+            activeTab={activeMainTab}
             onTabChange={setMainTab}
             record={record}
-            drillPanels={getRecordDrillPanels(entityType)}
+            drillPanels={visibleDrillPanels}
           />
         ) : (
           <DetailViewMainTabs
             recordId={recordId}
             entityType={entityType}
-            config={config}
-            activeTab={mainTab ?? config.defaultTab ?? 'overview'}
+            config={visibleConfig}
+            activeTab={activeMainTab}
             onTabChange={setMainTab}
             record={record}
           />

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -178,6 +178,7 @@ function DrawerRecordFrame({
 }: DrawerRecordFrameProps) {
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' })
   const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
   const organizationId = useDehydratedOrganizationId()
   const user = useDehydratedUser()
 
@@ -207,8 +208,13 @@ function DrawerRecordFrame({
   // (contacts, invoices, …), which keeps the render tree below byte-identical
   // to before this feature existed.
   const drillPanels = React.useMemo(
-    () => (entityType ? getRecordDrillPanels(entityType) : []),
-    [entityType]
+    () =>
+      entityType
+        ? getRecordDrillPanels(entityType).filter(
+            (panel) => !panel.permissionKey || can(panel.permissionKey)
+          )
+        : [],
+    [entityType, can]
   )
 
   // Shared two-level record drill (dispatch v4/02) — same `panel`/`item` nuqs

--- a/apps/web/src/components/global/capability-page-guard.tsx
+++ b/apps/web/src/components/global/capability-page-guard.tsx
@@ -2,25 +2,44 @@
 'use client'
 
 import { usePathname, useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { type ReactNode, useEffect } from 'react'
+import { NoAccess } from '~/components/permissions/ui/no-access'
 import { useAccess } from '~/providers/capabilities-provider'
 
+interface CapabilityPageGuardProps {
+  permissionKey: string
+  /**
+   * When provided, the guard owns the protected subtree and prevents it from
+   * mounting while denied. Existing marker-style callers without children keep
+   * the legacy redirect behavior.
+   */
+  children?: ReactNode
+  /** Friendly area name for the inline denied surface. */
+  area?: string
+}
+
 /**
- * Drop-in guard for capability-gated settings pages: redirects members who do
- * NOT hold `permissionKey` to /access-denied. The capability-check twin of
- * {@link AdminPageGuard} — ADMIN/OWNER hold every key via `ROLE_DEFAULTS`, so
- * they pass, while a granted non-admin is let through. Renders nothing.
+ * Drop-in guard for capability-gated pages. Marker-style usage redirects denied
+ * members to `/access-denied`; wrapper usage prevents protected children from
+ * mounting and renders {@link NoAccess}. ADMIN/OWNER hold every key via
+ * `ROLE_DEFAULTS`, while a granted non-admin is let through.
  */
-export function CapabilityPageGuard({ permissionKey }: { permissionKey: string }) {
+export function CapabilityPageGuard({ permissionKey, children, area }: CapabilityPageGuardProps) {
   const router = useRouter()
   const pathname = usePathname()
   const { can, isLoading } = useAccess()
 
   useEffect(() => {
+    if (children !== undefined) return
     // Skip for auth pages (mirrors useUser's role-guard bail-out).
     if (pathname === '/login' || pathname === '/register' || pathname === '/forgot-password') return
     if (!isLoading && !can(permissionKey)) router.push('/access-denied')
-  }, [can, isLoading, permissionKey, pathname, router])
+  }, [can, children, isLoading, permissionKey, pathname, router])
 
+  if (children !== undefined) {
+    if (isLoading) return null
+    if (!can(permissionKey)) return <NoAccess area={area} />
+    return children
+  }
   return null
 }

--- a/apps/web/src/components/money/billing/batch-invoice-action.tsx
+++ b/apps/web/src/components/money/billing/batch-invoice-action.tsx
@@ -9,10 +9,14 @@
 import { Button } from '@auxx/ui/components/button'
 import { ReceiptText } from 'lucide-react'
 import { useState } from 'react'
+import { useAccess } from '~/providers/capabilities-provider'
 import { BillingActionDialog } from './billing-action-dialog'
 
 export function BatchInvoiceAction() {
   const [open, setOpen] = useState(false)
+  const { can } = useAccess()
+
+  if (!can('dispatch.board.manage')) return null
 
   return (
     <>

--- a/apps/web/src/components/permissions/hooks/use-def-baselines.ts
+++ b/apps/web/src/components/permissions/hooks/use-def-baselines.ts
@@ -2,7 +2,13 @@
 'use client'
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
-import { Area, Level, levelToPermission } from '@auxx/lib/permissions/client'
+import {
+  Area,
+  ENTITY_BASE_AREAS,
+  Level,
+  levelToRecordBasePermission,
+  PERMISSION_AREAS,
+} from '@auxx/lib/permissions/client'
 import { isAccessManageable, type Resource } from '@auxx/lib/resources/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
@@ -15,15 +21,16 @@ export interface DefBaselineRow {
   resource: Resource
   /**
    * The def's persisted `role:org_member` permission, or `undefined` when no row
-   * exists — the def falls through to the Records area level (= "Inherit").
+   * exists — the def falls through to its mapped Layer-2 base (= "Inherit").
    */
   baselineLevel: ResourcePermission | undefined
   /**
-   * What an unconfigured def resolves to: the member baseline's Records rung
-   * mapped to a record permission. Rendered inline on the Inherit option, so the
-   * child always names the level the parent row directly above it is set to.
+   * What an unconfigured def resolves to: its base area's member-baseline rung
+   * mapped to a record permission. Rendered inline on the Inherit option.
    */
   inheritedLevel: ResourcePermission
+  /** Source-aware label for defs whose base comes from another Layer-2 area. */
+  inheritLabelText?: string
   /** Baseline explicitly `none` → the def is restricted (hidden unless granted). */
   isLockedDown: boolean
 }
@@ -52,15 +59,18 @@ export function useDefBaselines() {
   const { isLoading: grantsLoading, roleDefaults, baseline } = usePermissionGrants()
 
   /**
-   * The parent Records rung as a record permission — the member baseline's own
-   * level if stored, else the USER role default. This must follow the parent
-   * row, not a constant: it is rendered directly beneath it.
+   * Every area that supplies a record base, mapped to the record permission
+   * vocabulary. The normal case is Records; feature-backed defs use their own
+   * area (currently Dispatch board).
    */
-  const recordsPermission = useMemo<ResourcePermission>(() => {
-    const level = baseline[Area.records] ?? roleDefaults?.[Area.records] ?? Level.None
-    // `levelToPermission` maps `Level.None` to `undefined` ("no permission");
-    // for display we want the `none` marker so the picker can name it.
-    return levelToPermission(level) ?? ResourcePermission.none
+  const inheritedPermissionByArea = useMemo(() => {
+    const permissions = new Map<Area, ResourcePermission>()
+    const baseAreas = new Set<Area>([Area.records, ...Object.values(ENTITY_BASE_AREAS)])
+    for (const area of baseAreas) {
+      const level = baseline[area] ?? roleDefaults?.[area] ?? Level.None
+      permissions.set(area, levelToRecordBasePermission(level) ?? ResourcePermission.none)
+    }
+    return permissions
   }, [baseline, roleDefaults])
 
   const rowsQuery = api.resourceAccess.allTypeAccess.useQuery(undefined, { staleTime: 30_000 })
@@ -135,15 +145,20 @@ export function useDefBaselines() {
         .filter(isAccessManageable)
         .map((resource) => {
           const baselineLevel = baselineByDef.get(resource.entityDefinitionId)
+          const baseArea = ENTITY_BASE_AREAS[resource.entityType ?? ''] ?? Area.records
           return {
             resource,
             baselineLevel,
-            inheritedLevel: recordsPermission,
+            inheritedLevel: inheritedPermissionByArea.get(baseArea) ?? ResourcePermission.none,
+            inheritLabelText:
+              baseArea === Area.records
+                ? undefined
+                : `Inherit · ${PERMISSION_AREAS[baseArea].label}`,
             isLockedDown: baselineLevel === ResourcePermission.none,
           }
         })
         .sort((a, b) => a.resource.plural.localeCompare(b.resource.plural)),
-    [resources, baselineByDef, recordsPermission]
+    [resources, baselineByDef, inheritedPermissionByArea]
   )
 
   /**

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
@@ -2,7 +2,14 @@
 'use client'
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
-import { Area, Level, levelToPermission, PERMISSION_RANK } from '@auxx/lib/permissions/client'
+import {
+  Area,
+  ENTITY_BASE_AREAS,
+  Level,
+  levelToRecordBasePermission,
+  PERMISSION_AREAS,
+  PERMISSION_RANK,
+} from '@auxx/lib/permissions/client'
 import { isAccessManageable, type Resource } from '@auxx/lib/resources/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
@@ -14,7 +21,7 @@ import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permissio
 export type GranteeKind = 'user' | 'group'
 
 /**
- * How the grantee's Layer-2 Records level composes — which decides what an
+ * How the grantee's Layer-2 area levels compose — which decides what an
  * unconfigured def falls through to:
  * - `member` (default) — human/team: own override → org policy → role default.
  * - `agent` — an AGENT grantee (`userType:'AGENT'`), which composes by SET over
@@ -28,17 +35,10 @@ const GRANTEE_TYPE: Record<GranteeKind, ResourceGranteeType> = {
   group: ResourceGranteeType.group,
 }
 
-/**
- * The workspace baseline an unconfigured def defaults to (and first-touch
- * persists) — everyone's default access. Must match `use-def-access`'s
- * `DEFAULT_BASELINE_LEVEL` so the two surfaces agree.
- */
-const DEFAULT_BASELINE_LEVEL: ResourcePermission = ResourcePermission.edit
-
 /** One def's row in the grantee-centric Access grid. */
 export interface GranteeDefAccessRow {
   resource: Resource
-  /** The def's `role:org_member` baseline, or the default when unconfigured. */
+  /** The def's `role:org_member` baseline, or its base-area default when unconfigured. */
   baselineLevel: ResourcePermission
   /** Baseline = No Access → non-grantees are locked out ("Restricted"). */
   isLockedDown: boolean
@@ -47,9 +47,11 @@ export interface GranteeDefAccessRow {
   /**
    * What the grantee gets WITHOUT an explicit grant here — the resolved "Inherit"
    * value: the def's workspace baseline if configured, else the grantee's general
-   * Records level. Displayed in the picker's Inherit option.
+   * mapped Layer-2 base area. Displayed in the picker's Inherit option.
    */
   inheritedLevel: ResourcePermission
+  /** Source-aware label when an unconfigured def inherits another L2 area. */
+  inheritLabelText?: string
   /** Explicit grant that lifts nothing above the baseline → does nothing. */
   isNoEffect: boolean
 }
@@ -80,8 +82,8 @@ export function useGranteeDefAccess(
   const { resources, isLoading: resourcesLoading } = useResources()
   const granteeType = GRANTEE_TYPE[granteeKind]
 
-  // The grantee's Layer-2 Records level — what unconfigured (non-restricted) defs
-  // inherit. Own override → effective member baseline → role default.
+  // The grantee's Layer-2 levels — what unconfigured (non-restricted) defs
+  // inherit from their mapped base area. Own override → member baseline → role default.
   const {
     isLoading: grantsLoading,
     roleDefaults,
@@ -89,18 +91,29 @@ export function useGranteeDefAccess(
     groupGrants,
     userGrants,
   } = usePermissionGrants()
-  const recordsPermission = useMemo<ResourcePermission>(() => {
+  const ownAreaLevels = useMemo(() => {
     const persisted = granteeKind === 'group' ? groupGrants : userGrants
-    const own = persisted.find((g) => g.granteeId === granteeId)?.levels?.[Area.records]
-    // An agent has no baseline to fall back on — absent means Full (§0.2/§0.3).
-    const level =
-      principal === 'agent'
-        ? (own ?? Level.Full)
-        : (own ?? effectiveBaseline[Area.records] ?? roleDefaults?.[Area.records] ?? Level.None)
-    // `levelToPermission` maps `Level.None` to `undefined` ("no permission");
-    // for display we want the `none` marker so the picker can name it.
-    return levelToPermission(level) ?? ResourcePermission.none
-  }, [granteeKind, granteeId, principal, groupGrants, userGrants, effectiveBaseline, roleDefaults])
+    return persisted.find((g) => g.granteeId === granteeId)?.levels ?? {}
+  }, [granteeKind, granteeId, groupGrants, userGrants])
+
+  const targetBasePermission = useCallback(
+    (area: Area): ResourcePermission => {
+      const level =
+        principal === 'agent'
+          ? (ownAreaLevels[area] ?? Level.Full)
+          : (ownAreaLevels[area] ?? effectiveBaseline[area] ?? roleDefaults?.[area] ?? Level.None)
+      return levelToRecordBasePermission(level) ?? ResourcePermission.none
+    },
+    [principal, ownAreaLevels, effectiveBaseline, roleDefaults]
+  )
+
+  const workspaceBasePermission = useCallback(
+    (area: Area): ResourcePermission => {
+      const level = effectiveBaseline[area] ?? roleDefaults?.[area] ?? Level.None
+      return levelToRecordBasePermission(level) ?? ResourcePermission.none
+    },
+    [effectiveBaseline, roleDefaults]
+  )
 
   const rowsQuery = api.resourceAccess.allTypeAccess.useQuery(undefined, { staleTime: 30_000 })
 
@@ -189,24 +202,38 @@ export function useGranteeDefAccess(
       .filter(isAccessManageable)
       .map((resource) => {
         const configuredBaseline = baselineByDef.get(resource.entityDefinitionId)
-        const baselineLevel = configuredBaseline ?? DEFAULT_BASELINE_LEVEL
+        const baseArea = ENTITY_BASE_AREAS[resource.entityType ?? ''] ?? Area.records
+        const baselineLevel = configuredBaseline ?? workspaceBasePermission(baseArea)
         const grantLevel = grantByDef.get(resource.entityDefinitionId)
         // Configured def → inherit its workspace baseline; unconfigured → the
         // grantee's general Records level.
-        const inheritedLevel = configuredBaseline ?? recordsPermission
+        const inheritedLevel = configuredBaseline ?? targetBasePermission(baseArea)
         return {
           resource,
           baselineLevel,
           isLockedDown: baselineLevel === ResourcePermission.none,
           grantLevel,
           inheritedLevel,
+          inheritLabelText:
+            configuredBaseline !== undefined || baseArea === Area.records
+              ? undefined
+              : `${principal === 'agent' ? 'Default' : 'Inherit'} · ${
+                  PERMISSION_AREAS[baseArea].label
+                }`,
           isNoEffect:
             grantLevel !== undefined &&
             PERMISSION_RANK[grantLevel] <= PERMISSION_RANK[baselineLevel],
         }
       })
       .sort((a, b) => a.resource.plural.localeCompare(b.resource.plural))
-  }, [resources, baselineByDef, grantByDef, recordsPermission])
+  }, [
+    resources,
+    baselineByDef,
+    grantByDef,
+    principal,
+    targetBasePermission,
+    workspaceBasePermission,
+  ])
 
   /**
    * Set this grantee's level for a def. `'inherit'` revokes the explicit row;
@@ -221,23 +248,35 @@ export function useGranteeDefAccess(
       }
       // First-touch: keep everyone at the default while this grantee is raised.
       if (!baselineByDef.has(entityDefinitionId)) {
+        const resource = resources.find((item) => item.entityDefinitionId === entityDefinitionId)
+        const baseArea = ENTITY_BASE_AREAS[resource?.entityType ?? ''] ?? Area.records
+        const defaultBaseline = workspaceBasePermission(baseArea)
         patchLocal(
           entityDefinitionId,
           ResourceGranteeType.role,
           MEMBER_BASELINE_GRANTEE_ID,
-          DEFAULT_BASELINE_LEVEL
+          defaultBaseline
         )
         grantType.mutate({
           entityDefinitionId,
           granteeType: ResourceGranteeType.role,
           granteeId: MEMBER_BASELINE_GRANTEE_ID,
-          permission: DEFAULT_BASELINE_LEVEL,
+          permission: defaultBaseline,
         })
       }
       patchLocal(entityDefinitionId, granteeType, granteeId, level)
       grantType.mutate({ entityDefinitionId, granteeType, granteeId, permission: level })
     },
-    [baselineByDef, granteeType, granteeId, grantType, revokeType, patchLocal]
+    [
+      baselineByDef,
+      resources,
+      workspaceBasePermission,
+      granteeType,
+      granteeId,
+      grantType,
+      revokeType,
+      patchLocal,
+    ]
   )
 
   return {

--- a/apps/web/src/components/permissions/ui/def-baseline-rows.tsx
+++ b/apps/web/src/components/permissions/ui/def-baseline-rows.tsx
@@ -85,6 +85,7 @@ export function DefBaselineRows({
               includeInherit
               includeNone
               inheritedLevel={row.inheritedLevel}
+              inheritLabelText={row.inheritLabelText}
               onInherit={() => onChange(row.resource.entityDefinitionId, 'inherit')}
               onChange={(level) => onChange(row.resource.entityDefinitionId, level)}
               disabled={disabled}

--- a/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
@@ -160,7 +160,7 @@ function DefAccessRow({
   principal: GranteePrincipal
   onChange: (level: Parameters<ReturnType<typeof useGranteeDefAccess>['setLevel']>[1]) => void
 }) {
-  const { resource, isLockedDown, grantLevel, inheritedLevel, isNoEffect } = row
+  const { resource, isLockedDown, grantLevel, inheritedLevel, inheritLabelText, isNoEffect } = row
   const isOverridden = grantLevel !== undefined
   return (
     <TreeRow
@@ -195,7 +195,7 @@ function DefAccessRow({
             value={grantLevel}
             includeInherit
             inheritedLevel={inheritedLevel}
-            inheritLabelText={principal === 'agent' ? 'Default' : undefined}
+            inheritLabelText={inheritLabelText ?? (principal === 'agent' ? 'Default' : undefined)}
             onInherit={() => onChange('inherit')}
             onChange={(level) => onChange(level)}
             disabled={!canEdit}

--- a/apps/web/src/components/records/entity-route-layout.tsx
+++ b/apps/web/src/components/records/entity-route-layout.tsx
@@ -13,10 +13,9 @@ import {
 import { MainPageTabs, type MainPageTabsItem } from '@auxx/ui/components/main-page-tabs'
 import { ChartColumn } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { NoAccess } from '~/components/permissions/ui/no-access'
 import { useResources } from '~/components/resources'
-import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { RecordRouteGuard } from './record-route-guard'
 
 interface EntityRouteLayoutProps {
   /** Resource slug (entityDefinitionId or apiSlug), resolved via `useResources()`. */
@@ -49,18 +48,8 @@ export function EntityRouteLayout({
 }: EntityRouteLayoutProps) {
   const { getResourceById } = useResources()
   const { hasAccess } = useFeatureFlags()
-  const { canViewEntity } = useAccess()
   const resource = getResourceById(slug)
   const ResourceIcon = resource ? getIcon(resource.icon)?.icon : undefined
-
-  // Layer-2/3 read gate for direct-URL hits (e.g. a member deep-linking
-  // `/app/contacts` they can't see). Every entity list — tickets included —
-  // rides the per-def most-specific-wins gate (`canViewEntity`) so a def-level
-  // grant unlocks a def even when the member's base records level is None — the
-  // whole point of the leveled model. Tickets are just another entity def.
-  if (resource && !canViewEntity(resource.entityDefinitionId)) {
-    return <NoAccess area={resource?.plural ?? undefined} />
-  }
 
   const items: MainPageTabsItem[] = [
     {
@@ -80,14 +69,16 @@ export function EntityRouteLayout({
   ]
 
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title={resource?.plural ?? '...'} href={basePath} />
-        </MainPageBreadcrumb>
-        <MainPageTabs items={items} />
-      </MainPageHeader>
-      {children}
-    </MainPage>
+    <RecordRouteGuard slug={slug}>
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title={resource?.plural ?? '...'} href={basePath} />
+          </MainPageBreadcrumb>
+          <MainPageTabs items={items} />
+        </MainPageHeader>
+        {children}
+      </MainPage>
+    </RecordRouteGuard>
   )
 }

--- a/apps/web/src/components/records/index.ts
+++ b/apps/web/src/components/records/index.ts
@@ -2,4 +2,5 @@
 
 export { EntityRouteLayout } from './entity-route-layout'
 export { RecordDrawer } from './record-drawer'
+export { RecordRouteGuard } from './record-route-guard'
 export { type EntityRow, RecordsView } from './records-view'

--- a/apps/web/src/components/records/record-drill-panels.tsx
+++ b/apps/web/src/components/records/record-drill-panels.tsx
@@ -45,6 +45,8 @@ export interface RecordDrillContext {
 export interface RecordDrillPanel {
   /** Panel key. Activated when the `panel` query param equals this value. */
   value: string
+  /** Capability required to mount this query-owning drill panel. */
+  permissionKey?: string
   /** `NavStackBar` content while this panel (or its item level) is on top. */
   bar?: React.ReactNode | ((ctx: RecordDrillContext) => React.ReactNode)
   /** List-level (or single) panel body. */
@@ -95,6 +97,7 @@ const RECORD_DRILL_PANELS: Record<string, RecordDrillPanel[]> = {
   work_order: [
     {
       value: 'visits',
+      permissionKey: 'dispatch.board.view',
       bar: (ctx: RecordDrillContext) => <DrillBackBar title={ctx.itemId ? 'Visit' : 'Visits'} />,
       render: (ctx) => <VisitsListPanel {...ctx} />,
       renderItem: (ctx) => <VisitDetailPanel {...ctx} />,
@@ -104,6 +107,7 @@ const RECORD_DRILL_PANELS: Record<string, RecordDrillPanel[]> = {
       // and drill straight in): `render` reads the drilled invoice off ctx.itemId,
       // so `open('invoices', recordId)` always lands a two-level stack.
       value: 'invoices',
+      permissionKey: 'dispatch.board.view',
       bar: (ctx: RecordDrillContext) => <InvoiceDrillBar itemId={ctx.itemId} />,
       render: (ctx) => <InvoiceDetailPanel {...ctx} />,
     },

--- a/apps/web/src/components/records/record-route-guard.tsx
+++ b/apps/web/src/components/records/record-route-guard.tsx
@@ -1,0 +1,30 @@
+// apps/web/src/components/records/record-route-guard.tsx
+'use client'
+
+import type { ReactNode } from 'react'
+import { NoAccess } from '~/components/permissions/ui/no-access'
+import { useResource } from '~/components/resources'
+import { useAccess } from '~/providers/capabilities-provider'
+
+interface RecordRouteGuardProps {
+  /** Resource slug, definition ID, or system type understood by `useResource`. */
+  slug: string
+  children: ReactNode
+}
+
+/**
+ * Prevents a record route from mounting its query-owning children until the
+ * resource is resolved, then renders an honest permission-denied surface when
+ * the member cannot view that definition.
+ */
+export function RecordRouteGuard({ slug, children }: RecordRouteGuardProps) {
+  const { resource, isLoading } = useResource(slug)
+  const { canViewEntity } = useAccess()
+
+  if (isLoading) return null
+  if (resource && !canViewEntity(resource.entityDefinitionId)) {
+    return <NoAccess area={resource.plural} />
+  }
+
+  return children
+}

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -56,10 +56,9 @@ interface CapabilitiesContextType {
    */
   canViewEntity: (entityDefinitionId: string) => boolean
   /**
-   * Per-def WRITE gate — mirrors the server `canEditEntity` for records-area
-   * defs. NOTE: dedicated-write-key defs (`work_order` → dispatch) and mail-infra
-   * defs are NOT special-cased here; the server remains the source of truth for
-   * those, so an affordance may show optimistically and get a 403 on submit.
+   * Per-def WRITE gate — mirrors the server `canEditEntity`, including
+   * server-computed base overrides for feature-backed definitions such as work
+   * orders. Mail-infrastructure defs remain governed by their own feature UI.
    */
   canEditEntity: (entityDefinitionId: string) => boolean
   /**

--- a/apps/web/src/trpc/query-client.ts
+++ b/apps/web/src/trpc/query-client.ts
@@ -1,3 +1,5 @@
+// apps/web/src/trpc/query-client.ts
+
 import { defaultShouldDehydrateQuery, MutationCache, QueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import SuperJSON from 'superjson'
@@ -33,6 +35,14 @@ export const createQueryClient = () =>
         // With SSR, we usually want to set some default staleTime
         // above 0 to avoid refetching immediately on the client
         staleTime: 30 * 1000,
+        retry: (failureCount, error) => {
+          const data = (error as any)?.data
+          const status =
+            data?.httpStatus ??
+            (data?.code === 'FORBIDDEN' ? 403 : data?.code === 'UNAUTHORIZED' ? 401 : undefined)
+          if (status === 401 || status === 403) return false
+          return failureCount < 3
+        },
       },
       dehydrate: {
         serializeData: SuperJSON.serialize,

--- a/packages/lib/src/dehydration/cache.ts
+++ b/packages/lib/src/dehydration/cache.ts
@@ -9,7 +9,9 @@ import type { DehydratedState } from './types'
  */
 export class DehydrationCacheService extends BaseCacheService {
   constructor() {
-    super('dehydrated', 300) // 5 minute TTL
+    // v2 includes feature-area-derived per-def record bases in capabilities.
+    // Namespace the cache so pre-v2 snapshots cannot fail open for their TTL.
+    super('dehydrated:v2', 300) // 5 minute TTL
   }
 
   /**

--- a/packages/lib/src/permissions/capabilities/capability-set-edit.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-edit.test.ts
@@ -22,6 +22,7 @@ const build = (opts: {
   restricted?: string[]
   role?: 'OWNER' | 'ADMIN' | 'USER'
   seatType?: SeatType
+  defBaseOverrides?: Record<string, ResourcePermission | null>
 }) =>
   new CapabilitySet(
     new Set(opts.keys ?? [PermissionKey.recordsView, PermissionKey.recordsEdit]),
@@ -31,7 +32,10 @@ const build = (opts: {
     // Resolve mail-infra slugs so isMailInfraDef matches; everything else identity.
     (id) => id,
     new Set(opts.restricted ?? []),
-    defIdToDefinitionId
+    defIdToDefinitionId,
+    {},
+    new Set(),
+    opts.defBaseOverrides ?? {}
   )
 
 const READ_ONLY = [PermissionKey.recordsView]
@@ -117,19 +121,28 @@ describe('CapabilitySet.canEditEntity (most-specific-wins, edit floor)', () => {
     expect(noVerb.canEditEntity('signature')).toBe(false)
   })
 
-  it('dedicated-write-key def (work_order) bypasses to its dispatch key', () => {
-    // work_order → dispatch.board.manage (ENTITY_WRITE_KEYS), NOT the records area.
-    // A dispatch manager holding board.manage but only Read on records can edit it…
-    const dispatcher = new CapabilitySet(
-      new Set([PermissionKey.recordsView, PermissionKey.dispatchBoardManage]),
-      {},
-      'USER',
-      'full'
-    )
+  it('feature-backed defs use their derived base for def-aware editing', () => {
+    const dispatcher = build({
+      keys: [PermissionKey.dispatchBoardView, PermissionKey.dispatchBoardManage],
+      defBaseOverrides: { work_order: 'edit' },
+    })
     expect(dispatcher.canEditEntity('work_order')).toBe(true)
-    // …while a records-editor WITHOUT board.manage cannot (records level is irrelevant).
-    const recordsEditor = new CapabilitySet(new Set(READ_WRITE), {}, 'USER', 'full')
+
+    const recordsEditor = build({
+      keys: READ_WRITE,
+      defBaseOverrides: { work_order: null },
+    })
     expect(recordsEditor.canEditEntity('work_order')).toBe(false)
+  })
+
+  it('keeps coarse dispatch write keys aligned across all dispatch record faces', () => {
+    const dispatcher = build({ keys: [PermissionKey.dispatchBoardManage] })
+    const recordsEditor = build({ keys: READ_WRITE })
+
+    for (const slug of ['work_order', 'service_request', 'quote', 'invoice']) {
+      expect(dispatcher.canWriteEntity(slug)).toBe(true)
+      expect(recordsEditor.canWriteEntity(slug)).toBe(false)
+    }
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
@@ -3,6 +3,7 @@
 import type { ResourcePermission } from '@auxx/database/enums'
 import { describe, expect, it } from 'vitest'
 import { CapabilitySet } from './capability-set'
+import { canViewRecord, toResolvedRecordAccess } from './entity-access'
 import { PermissionKey } from './registry'
 
 /**
@@ -23,6 +24,7 @@ const build = (opts: {
   restricted?: string[]
   role?: 'OWNER' | 'ADMIN' | 'USER'
   seatType?: 'full' | 'worker'
+  defBaseOverrides?: Record<string, ResourcePermission | null>
 }) =>
   new CapabilitySet(
     new Set(opts.keys ?? (opts.hasView === false ? [] : [PermissionKey.recordsView])),
@@ -31,10 +33,63 @@ const build = (opts: {
     opts.seatType ?? 'full',
     (id) => id,
     new Set(opts.restricted ?? []),
-    defIdToDefinitionId
+    defIdToDefinitionId,
+    {},
+    new Set(),
+    opts.defBaseOverrides ?? {}
   )
 
 describe('CapabilitySet.canViewEntity (absent = unrestricted)', () => {
+  it('uses a feature-area-derived base for dispatch record definitions', () => {
+    const recordsEditorWithoutDispatch = build({
+      keys: [PermissionKey.recordsView, PermissionKey.recordsEdit],
+      defBaseOverrides: { 'work-order-def': null },
+    })
+    expect(recordsEditorWithoutDispatch.canViewEntity('work-order-def')).toBe(false)
+
+    const dispatchReaderWithoutRecords = build({
+      keys: [PermissionKey.dispatchBoardView],
+      defBaseOverrides: { 'work-order-def': 'view' },
+    })
+    expect(dispatchReaderWithoutRecords.canViewEntity('work-order-def')).toBe(true)
+    expect(dispatchReaderWithoutRecords.canEditEntity('work-order-def')).toBe(false)
+
+    const dispatchManagerWithoutRecords = build({
+      keys: [PermissionKey.dispatchBoardView, PermissionKey.dispatchBoardManage],
+      defBaseOverrides: { 'work-order-def': 'edit' },
+    })
+    expect(dispatchManagerWithoutRecords.canViewEntity('work-order-def')).toBe(true)
+    expect(dispatchManagerWithoutRecords.canEditEntity('work-order-def')).toBe(true)
+  })
+
+  it('lets an explicit def grant replace a closed feature-area base', () => {
+    const caps = build({
+      keys: [PermissionKey.recordsView, PermissionKey.recordsEdit],
+      restricted: ['work-order-def'],
+      defAccess: { 'work-order-def': 'view' },
+      defBaseOverrides: { 'work-order-def': null },
+    })
+    expect(caps.canViewEntity('work-order-def')).toBe(true)
+    expect(caps.canEditEntity('work-order-def')).toBe(false)
+  })
+
+  it('keeps the worker linked-record carve-out with a closed dispatch base', () => {
+    const caps = build({
+      keys: [PermissionKey.dispatchMySchedule, PermissionKey.recordsViewLinked],
+      seatType: 'worker',
+      defBaseOverrides: { 'work-order-def': null },
+    })
+    expect(caps.canViewEntity('work-order-def')).toBe(true)
+    expect(caps.canEditEntity('work-order-def')).toBe(false)
+  })
+
+  it('serializes derived bases for the client resolver', () => {
+    const caps = build({ defBaseOverrides: { 'work-order-def': null } })
+    const snapshot = caps.toClientCapabilities()
+    expect(snapshot.defBaseOverrides).toEqual({ 'work-order-def': null })
+    expect(canViewRecord(toResolvedRecordAccess(snapshot), 'work-order-def')).toBe(false)
+  })
+
   it('a def with NO type-level grant is visible to everyone with records.view', () => {
     const caps = build({ restricted: ['other-def'] })
     expect(caps.canViewEntity('invoice-def')).toBe(true)

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -60,6 +60,9 @@ export class CapabilitySet implements CapabilityView {
    *                   instance-access row for *anyone*. An instance NOT in this
    *                   set has no explicit row → falls back to its area's base L2
    *                   level (for `baselineAtCreate: false` resources).
+   * @param defBaseOverrides Per-def record base for defs whose base comes from
+   *                   another Layer-2 area. Canonical `entityDefinitionId`
+   *                   keys; `null` means that area is closed.
    */
   constructor(
     private readonly keys: ReadonlySet<PermissionKey>,
@@ -70,7 +73,8 @@ export class CapabilitySet implements CapabilityView {
     private readonly restrictedDefIds: ReadonlySet<string> = new Set(),
     private readonly defIdToDefinitionId: DefIdToSlug = (id) => id,
     private readonly instanceAccess: Readonly<Record<string, ResourcePermission>> = {},
-    private readonly restrictedInstanceIds: ReadonlySet<string> = new Set()
+    private readonly restrictedInstanceIds: ReadonlySet<string> = new Set(),
+    private readonly defBaseOverrides: Readonly<Record<string, ResourcePermission | null>> = {}
   ) {}
 
   /** O(1) Set lookup — whether the member holds `key`. */
@@ -124,6 +128,7 @@ export class CapabilitySet implements CapabilityView {
       keys: this.keys,
       defAccess: this.defAccess,
       restrictedEntityDefIds: this.restrictedDefIds,
+      defBaseOverrides: this.defBaseOverrides,
     }
   }
 
@@ -136,6 +141,7 @@ export class CapabilitySet implements CapabilityView {
       keys: [...this.keys],
       defAccess: { ...this.defAccess },
       restrictedEntityDefIds: [...this.restrictedDefIds],
+      defBaseOverrides: { ...this.defBaseOverrides },
       role: this.role,
       seatType: this.seatType,
       instanceAccess: { ...this.instanceAccess },
@@ -146,20 +152,14 @@ export class CapabilitySet implements CapabilityView {
   /**
    * Whether the member may create/update/delete/merge records of the given def —
    * the `edit` floor (§0.1). Two carve-outs bypass most-specific-wins and keep
-   * the existing verb gate ({@link canWriteEntity}), because their write
-   * authority lives OUTSIDE the records area:
-   *  - **mail-infra defs** (signatures/snippets/etc. — governed by mail keys),
-   *  - **defs with a dedicated write key** ({@link ENTITY_WRITE_KEYS}, e.g.
-   *    `work_order` → `dispatch.board.manage`). Gating these on the records level
-   *    would wrongly block a dispatch manager (who holds `board.manage` but may be
-   *    Read-only on records) or wrongly admit a records-editor lacking the
-   *    dispatch key (open item #4 — dispatch authority kept as-is).
+   * the existing verb gate ({@link canWriteEntity}) for mail-infrastructure defs
+   * (signatures/snippets/etc. — governed by mail keys). Feature-backed record
+   * defs use `defBaseOverrides`, so server and client apply the same derived base
+   * and the same per-def override semantics.
    * Zero I/O.
    */
   canEditEntity(entityDefId: string): boolean {
-    if (this.isMailInfraDef(entityDefId) || this.hasDedicatedWriteKey(entityDefId)) {
-      return this.canWriteEntity(entityDefId)
-    }
+    if (this.isMailInfraDef(entityDefId)) return this.canWriteEntity(entityDefId)
     return canEditRecord(this.resolved(), this.defIdToDefinitionId(entityDefId))
   }
 
@@ -318,15 +318,5 @@ export class CapabilitySet implements CapabilityView {
   private writeKeyFor(entityDefId: string): PermissionKey {
     const slug = this.defIdToSlug(entityDefId)
     return ENTITY_WRITE_KEYS[slug] ?? PermissionKey.recordsEdit
-  }
-
-  /**
-   * Whether the def has a dedicated write key ({@link ENTITY_WRITE_KEYS}) rather
-   * than the default {@link PermissionKey.recordsEdit} — i.e. its write authority
-   * belongs to another area (e.g. dispatch), so it bypasses the records-level
-   * edit gate in {@link canEditEntity}.
-   */
-  private hasDedicatedWriteKey(entityDefId: string): boolean {
-    return this.writeKeyFor(entityDefId) !== PermissionKey.recordsEdit
   }
 }

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -67,6 +67,12 @@ export interface ResolvedRecordAccess {
   /** Defs carrying ≥1 type-level grant for anyone (`entityDefinitionId` keyspace). */
   restrictedEntityDefIds: ReadonlySet<string>
   /**
+   * Per-def record base for definitions whose base comes from another Layer-2
+   * area, keyed by canonical `entityDefinitionId`. `null` means that area's
+   * level is None; an absent key falls back to the Records area.
+   */
+  defBaseOverrides?: Readonly<Record<string, ResourcePermission | null>>
+  /**
    * Highest instance-level grant per `entityInstanceId` (CUID) for the
    * instance-access resources (datasets etc., §1.4). Explicit `'none'` rows are
    * KEPT (the per-instance downward marker). Optional — absent = `{}` (the
@@ -85,8 +91,17 @@ export interface ResolvedRecordAccess {
  * {@link canViewRecord} carve-out.
  */
 export function baseRecordsLevel(keys: ReadonlySet<PermissionKey>): ResourcePermission | undefined {
-  if (keys.has(PermissionKey.recordsEdit)) return ResourcePermission.edit
-  if (keys.has(PermissionKey.recordsView)) return ResourcePermission.view
+  return levelToRecordBasePermission(areaLevelFromKeys(keys, Area.records))
+}
+
+/**
+ * Map a Layer-2 area rung to the record-base vocabulary. `Full` deliberately
+ * maps to `edit`, not `admin`: managing a feature's records does not confer
+ * administration of their entity definition.
+ */
+export function levelToRecordBasePermission(level: Level): ResourcePermission | undefined {
+  if (level >= Level.Edit) return ResourcePermission.edit
+  if (level >= Level.Read) return ResourcePermission.view
   return undefined
 }
 
@@ -116,9 +131,13 @@ export function effectiveRecordLevel(
   entityDefinitionId: string
 ): ResourcePermission | undefined {
   if (caps.role === 'OWNER' || caps.role === 'ADMIN') return ResourcePermission.admin
+  const hasBaseOverride = Object.hasOwn(caps.defBaseOverrides ?? {}, entityDefinitionId)
+  const unrestrictedBase = hasBaseOverride
+    ? (caps.defBaseOverrides?.[entityDefinitionId] ?? undefined)
+    : baseRecordsLevel(caps.keys)
   const chosen = caps.restrictedEntityDefIds.has(entityDefinitionId)
     ? caps.defAccess[entityDefinitionId]
-    : baseRecordsLevel(caps.keys)
+    : unrestrictedBase
   if (chosen === undefined) return undefined
   if (SEAT_CEILINGS[caps.seatType][Area.records] === Level.None) return undefined
   return chosen
@@ -149,8 +168,8 @@ export function canViewRecord(caps: ResolvedRecordAccess, entityDefinitionId: st
 }
 
 /**
- * Records-area EDIT gate — `effectiveRecordLevel` satisfies the `edit` floor.
- * (Mail-infra and dedicated-write-key defs bypass this in the caller.)
+ * Record EDIT gate — `effectiveRecordLevel` satisfies the `edit` floor.
+ * Mail-infrastructure defs bypass this in the server caller.
  */
 export function canEditRecord(caps: ResolvedRecordAccess, entityDefinitionId: string): boolean {
   const level = effectiveRecordLevel(caps, entityDefinitionId)
@@ -199,6 +218,11 @@ export interface ClientCapabilities {
   keys: PermissionKey[]
   defAccess: Record<string, ResourcePermission>
   restrictedEntityDefIds: string[]
+  /**
+   * Per-def record base for definitions backed by another Layer-2 area.
+   * `null` means no access; absent definitions use the Records base.
+   */
+  defBaseOverrides?: Record<string, ResourcePermission | null>
   role: OrganizationRole
   seatType: SeatType
   /**
@@ -220,6 +244,7 @@ export function toResolvedRecordAccess(caps: ClientCapabilities): ResolvedRecord
     keys: new Set(caps.keys),
     defAccess: caps.defAccess,
     restrictedEntityDefIds: new Set(caps.restrictedEntityDefIds),
+    defBaseOverrides: caps.defBaseOverrides ?? {},
     instanceAccess: caps.instanceAccess ?? {},
     restrictedInstanceIds: new Set(caps.restrictedInstanceIds ?? []),
   }

--- a/packages/lib/src/permissions/capabilities/get-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/get-capabilities.ts
@@ -11,6 +11,9 @@ import {
 import type { Resource } from '../../resources/registry/types'
 import { CapabilitySet, type DefIdToSlug } from './capability-set'
 import { PERMISSION_RANK } from './compose-user-capabilities'
+import { levelToRecordBasePermission } from './entity-access'
+import { areaLevelFromKeys } from './registry'
+import { ENTITY_BASE_AREAS } from './seat-policy'
 
 /**
  * Build the in-memory RecordId-def → entity-slug resolver from the cached
@@ -78,6 +81,7 @@ export async function getCapabilities(
   const entry = roleMap[userId]
   const role = entry?.role ?? 'USER'
   const seatType = entry?.seatType ?? 'full'
+  const keys = new Set(caps.keys)
 
   // ResourceAccess rows are keyed inconsistently in practice — system entity
   // types by slug ('inbox'), custom defs by EntityDefinition CUID. Lookups in
@@ -94,10 +98,23 @@ export async function getCapabilities(
     }
   }
 
+  // Resolve the handful of feature-backed record defs from entity slug to the
+  // canonical definition-id keyspace once. `null` is intentional: it
+  // distinguishes an explicitly closed derived base from an absent override,
+  // which falls back to the Records area on both server and client.
+  const defBaseOverrides: Record<string, ResourcePermission | null> = {}
+  for (const resource of resources) {
+    const slug = resource.entityType ?? resource.apiSlug
+    const area = ENTITY_BASE_AREAS[slug]
+    if (!area) continue
+    defBaseOverrides[resource.entityDefinitionId] =
+      levelToRecordBasePermission(areaLevelFromKeys(keys, area)) ?? null
+  }
+
   // instanceAccess keys on the globally-unique instance CUID (Dataset.id etc.),
   // so — unlike defAccess — no keyspace normalization is needed (§1.2).
   return new CapabilitySet(
-    new Set(caps.keys),
+    keys,
     defAccess,
     role,
     seatType,
@@ -105,6 +122,7 @@ export async function getCapabilities(
     new Set(restrictedDefIds.map(toDefinitionId)),
     toDefinitionId,
     caps.instanceAccess ?? {},
-    new Set(restrictedInstanceIds)
+    new Set(restrictedInstanceIds),
+    defBaseOverrides
   )
 }

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -46,6 +46,7 @@ export {
 export { requirePermission } from './require'
 export {
   ALL_KEYS,
+  ENTITY_BASE_AREAS,
   ENTITY_WRITE_KEYS,
   effectiveDefault,
   ROLE_DEFAULTS,

--- a/packages/lib/src/permissions/capabilities/seat-policy.ts
+++ b/packages/lib/src/permissions/capabilities/seat-policy.ts
@@ -110,11 +110,32 @@ export const SEAT_CEILINGS: Record<SeatType, Record<Area, Level>> = {
 
 /**
  * Entity slug → the capability key required to WRITE that entity. Slugs absent
- * from this map default (in code) to {@link PermissionKey.recordsEdit}. Dispatch
- * work orders route to the dispatch board-manage key.
+ * from this map default (in code) to {@link PermissionKey.recordsEdit}. These
+ * dispatch record faces route writes to the dispatch board-manage key. Keep this
+ * map aligned with {@link ENTITY_BASE_AREAS}: coarse verb call sites use this
+ * map, while def-aware read/write checks use the derived record base.
  */
 export const ENTITY_WRITE_KEYS: Record<string, PermissionKey> = {
   work_order: PermissionKey.dispatchBoardManage,
+  service_request: PermissionKey.dispatchBoardManage,
+  quote: PermissionKey.dispatchBoardManage,
+  invoice: PermissionKey.dispatchBoardManage,
+}
+
+/**
+ * Entity slug → the Layer-2 area that supplies the definition's record base
+ * instead of {@link Area.records}. These definitions are the record face of a
+ * feature whose authority lives in its own area, so opening the Records area
+ * alone must not expose them. The server resolves this slug-keyed map to
+ * definition IDs before sending capabilities to the client.
+ *
+ * Read-side twin of {@link ENTITY_WRITE_KEYS}; keep both maps aligned.
+ */
+export const ENTITY_BASE_AREAS: Record<string, Area> = {
+  work_order: Area.dispatchBoard,
+  service_request: Area.dispatchBoard,
+  quote: Area.dispatchBoard,
+  invoice: Area.dispatchBoard,
 }
 
 /**

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -22,6 +22,7 @@ export {
   canViewRecord,
   effectiveRecordLevel,
   levelToPermission,
+  levelToRecordBasePermission,
   NON_RECORD_DEF_SLUGS,
   type ResolvedRecordAccess,
   toResolvedRecordAccess,
@@ -52,6 +53,7 @@ export {
   PermissionKey,
   parseAreaLevels,
 } from './capabilities/registry'
+export { ENTITY_BASE_AREAS } from './capabilities/seat-policy'
 export type { Overage } from './overage-detection-service'
 export type {
   FeatureDefinition,

--- a/packages/lib/src/resources/registry/detail-view-config-types.ts
+++ b/packages/lib/src/resources/registry/detail-view-config-types.ts
@@ -13,6 +13,8 @@ export interface MainTabDefinition {
   label: string
   /** Icon name (e.g., 'ticket', 'clock') */
   icon: string
+  /** Capability required to render the tab and mount its query-owning content. */
+  permissionKey?: string
   /**
    * Cancel the wrapping `<Section>`'s horizontal inset so the content (e.g. a
    * line-items table) spans edge-to-edge — the `sections` layout twin of the

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -106,7 +106,13 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     mainTabs: [
       // fullBleed: the line-items table spans edge-to-edge (cancels the Section's
       // px-3), matching the quote drawer/sidebar cards' `fullBleed` treatment.
-      { value: 'line-items', label: 'Line items', icon: 'receipt-text', fullBleed: false },
+      {
+        value: 'line-items',
+        label: 'Line items',
+        icon: 'receipt-text',
+        fullBleed: false,
+        permissionKey: 'dispatch.board.view',
+      },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],
@@ -134,12 +140,32 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       // Schedule carries the recurrence row, primary visit card, the upcoming
       // visit previews AND past visits behind an "N in history" disclosure
       // (drawer parity) — no standalone upcoming-visits or history section.
-      { value: 'schedule', label: 'Schedule', icon: 'calendar' },
-      { value: 'line-items', label: 'Line items', icon: 'receipt-text' },
-      { value: 'billing', label: 'Billing', icon: 'credit-card' },
+      {
+        value: 'schedule',
+        label: 'Schedule',
+        icon: 'calendar',
+        permissionKey: 'dispatch.board.view',
+      },
+      {
+        value: 'line-items',
+        label: 'Line items',
+        icon: 'receipt-text',
+        permissionKey: 'dispatch.board.view',
+      },
+      {
+        value: 'billing',
+        label: 'Billing',
+        icon: 'credit-card',
+        permissionKey: 'dispatch.board.view',
+      },
       // Client-notifications plan §4.8/Phase 4 — outbound-message timeline (sequences +
       // manual quote/invoice sends).
-      { value: 'communications', label: 'Communications', icon: 'mail' },
+      {
+        value: 'communications',
+        label: 'Communications',
+        icon: 'mail',
+        permissionKey: 'dispatch.board.view',
+      },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -110,10 +110,25 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     // from the Details panel (showInPanel:false) so they only surface here.
     tabCards: {
       overview: [
-        { value: 'schedule', label: 'Schedule', icon: 'calendar-clock' },
-        { value: 'billing', label: 'Billing', icon: 'credit-card' },
+        {
+          value: 'schedule',
+          label: 'Schedule',
+          icon: 'calendar-clock',
+          permissionKey: 'dispatch.board.view',
+        },
+        {
+          value: 'billing',
+          label: 'Billing',
+          icon: 'credit-card',
+          permissionKey: 'dispatch.board.view',
+        },
         // Client-notifications plan §4.8/Phase 4 — compact recent-communications card.
-        { value: 'communications', label: 'Communications', icon: 'mail' },
+        {
+          value: 'communications',
+          label: 'Communications',
+          icon: 'mail',
+          permissionKey: 'dispatch.board.view',
+        },
       ],
     },
   },
@@ -132,13 +147,18 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     },
     tabCards: {
       overview: [
-        { value: 'lines', label: 'Line items', fullBleed: true },
+        {
+          value: 'lines',
+          label: 'Line items',
+          fullBleed: true,
+          permissionKey: 'dispatch.board.view',
+        },
         { value: 'customer', label: 'Customer' },
         { value: 'origin', label: 'Origin' },
         { value: 'jobs', label: 'Jobs' },
         // Deposit visibility (deposit-accounting plan 16 §D.5) — the card itself renders
         // null when the quote has no deposit charge, so this stays in the list unconditionally.
-        { value: 'deposit', label: 'Deposit' },
+        { value: 'deposit', label: 'Deposit', permissionKey: 'dispatch.board.view' },
       ],
     },
   },
@@ -156,9 +176,24 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     },
     tabCards: {
       overview: [
-        { value: 'lines', label: 'Line items', fullBleed: false, icon: 'file-text' },
-        { value: 'billing-context', label: 'Billing context', icon: 'calendar-clock' },
-        { value: 'payments', label: 'Payments', icon: 'credit-card' },
+        {
+          value: 'lines',
+          label: 'Line items',
+          fullBleed: false,
+          icon: 'file-text',
+          permissionKey: 'dispatch.board.view',
+        },
+        {
+          value: 'billing-context',
+          label: 'Billing context',
+          icon: 'calendar-clock',
+        },
+        {
+          value: 'payments',
+          label: 'Payments',
+          icon: 'credit-card',
+          permissionKey: 'dispatch.board.view',
+        },
       ],
     },
   },


### PR DESCRIPTION
## Summary

- derive `work_order`, `service_request`, `quote`, and `invoice` record bases from the Dispatch board area and ship definition-ID-keyed overrides to the shared server/client resolver
- add honest route/detail denial surfaces plus capability-gated tabs, drawer cards, drill panels, dispatch settings, and batch invoicing affordances
- stop retrying 401/403 query failures, version the dehydrated capability cache, and show the correct Dispatch board inheritance source in permissions UI

## Behavior changes

- members with `dispatchBoard: None` no longer see dispatch-backed record definitions solely because Records is open
- members with `dispatchBoard: Full` and `records: None` can now view and edit those dispatch-backed records
- explicit per-definition grants still replace the derived base, OWNER/ADMIN bypass remains, and the worker linked-record carve-out is preserved

## Verification

- `pnpm exec vitest run src/permissions/capabilities/capability-set-view.test.ts src/permissions/capabilities/capability-set-edit.test.ts src/permissions/capabilities/capability-set-administer.test.ts` — 40 tests passed
- `pnpm --filter @auxx/lib build` — passed
- direct Biome check/write on all 31 touched files — completed; only pre-existing warnings remain in `base-entity-drawer.tsx`
- `git diff --check` — passed
- scoped web typecheck reported no new errors; it still reports the three existing optional-prop errors at `base-entity-drawer.tsx:613-615`