### PR TITLE
fix(dev): stabilize local servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,7 +384,10 @@ peak observed for web).
 ### Rules
 
 - **Do NOT run a whole-repo `tsc`.** Scope it per-package as shown above.
-- **Do NOT stop or restart the dev server.**
+- **Never `kill` a single `turbo dev` task.** Turbo treats a dying persistent
+  task as fatal and tears down the whole run (`ELIFECYCLE` cascading across
+  every package). To run one app, restart with
+  `pnpm exec turbo dev --filter=@auxx/web`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,10 @@ peak observed for web).
 ### Rules
 
 - **Do NOT run a whole-repo `tsc`.** Scope it per-package as shown above.
-- **Do NOT stop or restart the dev server.**
+- **Never `kill` a single `turbo dev` task.** Turbo treats a dying persistent
+  task as fatal and tears down the whole run (`ELIFECYCLE` cascading across
+  every package). To run one app, restart with
+  `pnpm exec turbo dev --filter=@auxx/web`.
 
 ---
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --conditions source --env-file ../../.env --env-file .env --import tsx/esm --watch src/index.ts",
+    "dev": "tsx watch --conditions=source --env-file=../../.env --env-file=.env src/index.ts",
     "build": "tsdown",
     "build:platform-runtime": "NODE_ENV=development tsx build-platform-runtime.ts",
     "dev:platform-runtime": "NODE_ENV=development tsx build-platform-runtime.ts --watch --include ../../packages/sdk/src --include ../../packages/sdk/lib",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -36,6 +36,7 @@ const nextConfig = {
     '@auxx/workflow-nodes',
   ],
   experimental: {
+    // Keep Turbopack's incremental dev state across server restarts.
     turbopackFileSystemCacheForDev: true,
     // Persists Turbopack's incremental state in .next/cache across production
     // builds. Only pays off where .next/cache survives between builds (local
@@ -43,7 +44,6 @@ const nextConfig = {
     // plans/docker/web-image-build-speed.md). Hosted CI runners start empty,
     // so there it just writes an unused cache.
     turbopackFileSystemCacheForBuild: true,
-    webpackMemoryOptimizations: true,
   },
   poweredByHeader: false,
   reactStrictMode: true,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit",
     "build:opennext": "open-next build",
     "check:opennext": "pnpm run build:opennext",
-    "dev": "next dev --turbopack",
+    "dev": "NODE_OPTIONS='--max-old-space-size=12288' next dev --turbopack",
     "clean": "rm -rf .next .open-next .turbo node_modules *.tsbuildinfo",
     "preview": "next build --turbopack && next start",
     "start": "PORT=3000 node .next/standalone/apps/web/server.js",


### PR DESCRIPTION
## Summary

- replace the API native Node watcher with tsx watch to prevent the reproducible EMFILE crash from terminating the Turbo dev stack
- raise the web dev server old-space ceiling and keep Turbopack filesystem caching enabled for development and builds
- remove the webpack-only memory flag and document safe Turbo dev-task restart behavior

## Verification

- direct Biome check passed for the three changed code/config files
- commit hooks passed
- verified web, build, kb, docs, homepage, API, and platform-runtime watchers running concurrently with the worker active
- verified API source-change restart and healthy responses from web and API
- user confirmed contacts and agents navigation loads quickly again

## Known existing issue

- pnpm --filter @auxx/api typecheck remains red with broad pre-existing source and missing project-output errors unrelated to these package-script/config changes