### PR TITLE
feat(permissions): definition ceilings, escalation guard, profile grantee sweep

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/permissions/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/permissions/page.tsx
@@ -18,6 +18,19 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
  * read-only under an upgrade banner). Three leveled surfaces: the member
  * baseline, group overrides, and per-member overrides, each writing sparse grant
  * rows through the grant service.
+ *
+ * The two `GranteeOverridesTab` mounts are `group` and `user` — the only two
+ * *override* tiers. `PermissionGrant` also carries `granteeType:'profile'` rows
+ * (doc 19 §0.1), but a profile is the composition BASE, not a raise above it, so
+ * it is not a third override tab: the Member profile is presented here as the
+ * "Member baseline" tab via `permissions-member-baseline.ts`, and the remaining
+ * profiles get their own editor.
+ *
+ * TODO(plan-19-step-7): add the **Profiles** tab (doc 19 §7) and retitle
+ * "Member baseline" to the Member-profile editor, deleting the bridge.
+ * Until then, non-`member` profile rows are read-only and surfaced nowhere on
+ * this page — `usePermissionGrants().profileGrants` is the bucket that holds
+ * them, and it is explicitly unrendered rather than silently dropped.
  */
 export default function PermissionsPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })

--- a/apps/web/src/app/(protected)/app/settings/snippets/_components/snippet-form.tsx
+++ b/apps/web/src/app/(protected)/app/settings/snippets/_components/snippet-form.tsx
@@ -21,7 +21,7 @@ import { useForm } from 'react-hook-form'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { api } from '~/trpc/react'
 import { SnippetEditor } from './snippet-editor'
-import { SnippetSharing } from './snippet-sharing'
+import { type SnippetShareInput, SnippetSharing } from './snippet-sharing'
 
 interface FormValues {
   title: string
@@ -32,11 +32,13 @@ interface FormValues {
   sharingType: SnippetSharingType
 }
 
-type ShareInput = {
-  granteeType: 'group' | 'user'
-  granteeId: string
-  permission: 'VIEW' | 'EDIT'
-}
+/**
+ * Snippet share payload. Aliased to the dialog's own type so the grantee
+ * vocabulary is declared in exactly ONE place — a second literal union here is
+ * how the two drift and a kind the dialog can emit becomes unrepresentable (or,
+ * worse, silently coerced) on the way to the router.
+ */
+type ShareInput = SnippetShareInput
 
 interface SnippetFormProps {
   snippetId?: string

--- a/apps/web/src/app/(protected)/app/settings/snippets/_components/snippet-sharing.tsx
+++ b/apps/web/src/app/(protected)/app/settings/snippets/_components/snippet-sharing.tsx
@@ -2,7 +2,7 @@
 'use client'
 import { SnippetSharingType as SnippetSharingTypeEnum } from '@auxx/database/enums'
 import type { SnippetSharingType } from '@auxx/database/types'
-import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import { type ActorId, toActorId } from '@auxx/types/actor'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -27,12 +27,37 @@ import {
 import { Plus, Trash, UserIcon, Users2Icon, UsersIcon } from 'lucide-react'
 import React from 'react'
 import { ActorPicker } from '~/components/pickers/actor-picker'
+import { tryParseActorId } from '~/components/resources/utils/actor-id'
 import { api } from '~/trpc/react'
 
+/**
+ * The grantee kinds snippet sharing supports — the exact vocabulary of
+ * `snippet.ts`'s router enum and `snippet-permissions.ts`'s resolver.
+ *
+ * `'profile'` is deliberately NOT here: snippet permissions are resolved by a
+ * user/group-only reader (19a #12) and the router rejects anything else, so
+ * offering it would ship a control that fails end-to-end. Snippet sharing is
+ * therefore explicitly **unsupported** for permission-profile grantees.
+ */
+export type SnippetGranteeType = 'group' | 'user'
+
+/** One staged/persisted snippet share, in the shape the router accepts. */
+export interface SnippetShareInput {
+  granteeType: SnippetGranteeType
+  granteeId: string
+  permission: 'VIEW' | 'EDIT'
+}
+
 interface ShareItem {
-  /** userId for members, groupId for groups */
+  /** The `granteeId` as stored — `User.id` for `user`, group instance id for `group`. */
   id: string
-  type: 'group' | 'member'
+  /**
+   * The storage grantee type, NOT a display proxy. Carrying it verbatim keeps
+   * {@link handleSave} a pass-through: the old `type === 'group' ? 'group' :
+   * 'user'` ternary had no failure branch, so any future third kind would have
+   * been written as a `user` row keyed on a non-user id.
+   */
+  type: SnippetGranteeType
   name: string
   permission: 'VIEW' | 'EDIT'
   icon?: string
@@ -42,21 +67,10 @@ interface SnippetSharingProps {
   snippetId?: string
   initialSharingType: SnippetSharingType
   /** Staged shares for a new snippet (used only when snippetId is absent) */
-  initialShares?: Array<{
-    granteeType: 'group' | 'user'
-    granteeId: string
-    permission: 'VIEW' | 'EDIT'
-  }>
+  initialShares?: SnippetShareInput[]
   open: boolean
   onOpenChange: (open: boolean) => void
-  onSave: (
-    sharingType: SnippetSharingType,
-    shares?: Array<{
-      granteeType: 'group' | 'user'
-      granteeId: string
-      permission: 'VIEW' | 'EDIT'
-    }>
-  ) => void
+  onSave: (sharingType: SnippetSharingType, shares?: SnippetShareInput[]) => void
 }
 
 export function SnippetSharing({
@@ -77,11 +91,14 @@ export function SnippetSharing({
     { enabled: !!snippetId }
   )
 
-  // Hydrate shares from a common source shape (server shares or staged shares)
+  // Hydrate shares from a common source shape (server shares or staged shares).
+  // A row whose `granteeType` is outside the snippet vocabulary is skipped
+  // rather than treated as a member — it has no name to show and its id half
+  // does not address a User row.
   const hydrateShares = React.useCallback(
     (
       shares: Array<{
-        granteeType: 'group' | 'user'
+        granteeType: string
         granteeId: string
         permission: string
       }>
@@ -100,7 +117,7 @@ export function SnippetSharing({
               permission,
             })
           }
-        } else {
+        } else if (share.granteeType === 'user') {
           // Legacy fallback: older rows may have stored member.id instead of userId
           const member = membersData?.members?.find(
             (m) => m.userId === share.granteeId || m.id === share.granteeId
@@ -108,7 +125,7 @@ export function SnippetSharing({
           if (member) {
             items.push({
               id: member.userId,
-              type: 'member',
+              type: 'user',
               name: member.user.name || member.user.email || 'Unknown',
               permission,
               icon: member.user.image || undefined,
@@ -149,20 +166,19 @@ export function SnippetSharing({
     }
   }, [open])
 
-  // Build ActorId[] for the picker from the current selection
+  // Build ActorId[] for the picker from the current selection. `item.type` is
+  // already the storage grantee type, which maps 1:1 onto the ActorId prefix.
   const pickerValue = React.useMemo<ActorId[]>(
-    () =>
-      selectedItems.map((item) => toActorId(item.type === 'member' ? 'user' : 'group', item.id)),
+    () => selectedItems.map((item) => toActorId(item.type, item.id)),
     [selectedItems]
   )
 
-  // Translate ActorPicker selection back into ShareItem[], preserving permissions for existing items
+  // Translate ActorPicker selection back into ShareItem[], preserving permissions
+  // for existing items. `tryParseActorId` never throws: `parseActorId` rejects any
+  // prefix outside its whitelist, which would have crashed this handler outright.
   const handlePickerChange = (nextIds: ActorId[]) => {
     const byActorId = new Map<string, ShareItem>(
-      selectedItems.map((item) => [
-        toActorId(item.type === 'member' ? 'user' : 'group', item.id),
-        item,
-      ])
+      selectedItems.map((item) => [toActorId(item.type, item.id), item])
     )
     const next: ShareItem[] = []
     for (const actorId of nextIds) {
@@ -171,9 +187,10 @@ export function SnippetSharing({
         next.push(existing)
         continue
       }
-      const { type, id } = parseActorId(actorId)
-      if (type === 'group') {
-        const group = groupsData?.find((g) => g.id === id)
+      const parsed = tryParseActorId(actorId)
+      if (!parsed) continue
+      if (parsed.type === 'group') {
+        const group = groupsData?.find((g) => g.id === parsed.id)
         if (!group) continue
         next.push({
           id: group.id,
@@ -181,17 +198,18 @@ export function SnippetSharing({
           name: group.displayName || 'Group',
           permission: 'VIEW',
         })
-      } else {
-        const member = membersData?.members?.find((m) => m.userId === id)
+      } else if (parsed.type === 'user') {
+        const member = membersData?.members?.find((m) => m.userId === parsed.id)
         if (!member) continue
         next.push({
           id: member.userId,
-          type: 'member',
+          type: 'user',
           name: member.user.name || member.user.email || 'Unknown',
           permission: 'VIEW',
           icon: member.user.image || undefined,
         })
       }
+      // Any other actor kind (agent, worker, …) has no snippet grantee — skipped.
     }
     setSelectedItems(next)
   }
@@ -205,10 +223,12 @@ export function SnippetSharing({
   }
 
   const handleSave = () => {
-    let shares
+    let shares: SnippetShareInput[] | undefined
     if (sharingType === SnippetSharingTypeEnum.GROUPS) {
+      // Pass-through — `item.type` IS the grantee type, so there is no ternary
+      // that could write a `user` row keyed on a non-user id.
       shares = selectedItems.map((item) => ({
-        granteeType: item.type === 'group' ? ('group' as const) : ('user' as const),
+        granteeType: item.type,
         granteeId: item.id,
         permission: item.permission,
       }))

--- a/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
+++ b/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
@@ -23,9 +23,12 @@ export function ContactSharedWithCard({ entityInstanceId }: DrawerTabProps) {
 
   // ResourceAccess keys contact grants by the fixed 'contact' slug.
   const shareRecordId = toRecordId('contact', entityInstanceId)
-  const { grants, grant, changeLens, revoke } = useMailShare({ recordId: shareRecordId })
+  const { grants, unmanageableGrants, grant, changeLens, revoke } = useMailShare({
+    recordId: shareRecordId,
+  })
 
-  if (!isAdminOrOwner && grants.length === 0) return null
+  // A grant on a kind this list can't address still means the contact IS shared.
+  if (!isAdminOrOwner && grants.length === 0 && unmanageableGrants.length === 0) return null
 
   return (
     <div className='space-y-2'>
@@ -40,6 +43,7 @@ export function ContactSharedWithCard({ entityInstanceId }: DrawerTabProps) {
           onChangeLens={changeLens}
           onRevoke={revoke}
           disabled={!isAdminOrOwner}
+          unmanageableGrants={unmanageableGrants}
           emptyHint='Not shared. Only inbox members see these conversations.'
         />
       </EnterpriseGate>

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -1,10 +1,15 @@
 // apps/web/src/components/inbox/inbox-form.tsx
 'use client'
 
-import { FieldType, ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import {
+  FieldType,
+  ResourceGranteeType,
+  ResourcePermission,
+  type SharingGranteeType,
+} from '@auxx/database/enums'
 import type { Lens, LensChoice } from '@auxx/lib/permissions/visibility/client'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
-import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import { type ActorId, toActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
 import { DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
@@ -23,6 +28,14 @@ import {
 } from '~/components/mail-permissions/ui/enterprise-gate'
 import { LensSelect } from '~/components/mail-permissions/ui/lens-select'
 import { MailGranteeList } from '~/components/mail-permissions/ui/mail-grantee-list'
+import {
+  actorIdToGrantee,
+  GRANTEE_UNSUPPORTED_MESSAGE,
+  granteeToActorId,
+  isActorGrantee,
+  type ShareGrantee,
+  type UnmanageableGrant,
+} from '~/components/permissions/utils/grantee'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
@@ -87,15 +100,35 @@ export interface InboxFormProps {
   header?: (ctx: { title: string; page: 'main' | 'members'; onBack: () => void }) => ReactNode
 }
 
-/** Map a stored ResourceAccess row to the form's grant shape. */
+/**
+ * The grantee types this form OWNS. The save path is replace-per-type
+ * (`setInstance` swaps one `granteeType` at a time), so a kind absent from this
+ * list is left untouched on save rather than wiped — which is exactly why the
+ * list must stay in lockstep with what the grantee list can render and edit.
+ * Kinds outside it (`role` — the org-wide floor, expressed as
+ * `inbox_default_lens`; `profile` — plan 19 §8.2) are disclosed to the admin via
+ * {@link unmanageableGrantsNote} instead of being silently dropped.
+ */
+const MANAGED_GRANTEE_TYPES: readonly SharingGranteeType[] = [
+  ResourceGranteeType.user,
+  ResourceGranteeType.group,
+]
+
+/**
+ * Map a stored ResourceAccess row to the form's grant shape, or `null` when the
+ * grantee kind has no ActorId representation. Never coerces an unknown kind to
+ * `user` — that produced a row keyed on the wrong table's id.
+ */
 function rowToGrant(row: {
   granteeType: string
   granteeId: string
   permission: string
   lens: string | null
-}): FormGrant {
+}): FormGrant | null {
+  const actorId = granteeToActorId(row.granteeType, row.granteeId)
+  if (!actorId) return null
   return {
-    actorId: toActorId(row.granteeType === 'group' ? 'group' : 'user', row.granteeId),
+    actorId,
     choice:
       row.permission === ResourcePermission.admin
         ? 'manager'
@@ -202,6 +235,20 @@ export function InboxForm({
     })
   }
 
+  /**
+   * Rows the grantee list can't render or edit — a `profile` grant today (plan
+   * 19 §8.2). `setInstance` replaces one `granteeType` at a time, so these rows
+   * SURVIVE this form's save; disclosing them keeps the "N people & groups"
+   * summary from reading as the complete picture.
+   */
+  const unmanageableGrants = useMemo<UnmanageableGrant[]>(
+    () =>
+      (accessRows ?? [])
+        .filter((r) => !isActorGrantee(r.granteeType) && r.granteeType !== ResourceGranteeType.role)
+        .map((r) => ({ granteeType: r.granteeType, granteeId: r.granteeId })),
+    [accessRows]
+  )
+
   // Combined snapshot for dirty checking (grants serialized for stability).
   const formSnapshot = useMemo(
     () => ({
@@ -247,7 +294,7 @@ export function InboxForm({
         const storedLens = (fieldValues.inbox_default_lens as Lens | undefined) ?? 'full'
         const accessType = storedLens === 'none' ? 'restricted' : 'anyone'
         const floorLens = (storedLens === 'none' ? 'full' : storedLens) as Exclude<Lens, 'none'>
-        const grants = accessRows.map(rowToGrant)
+        const grants = accessRows.flatMap((row) => rowToGrant(row) ?? [])
 
         initialLensRef.current = storedLens
         initialGrantsRef.current = grantsKey(grants)
@@ -350,15 +397,24 @@ export function InboxForm({
     )
   }
 
-  /** The setInstance payload for one grantee type. */
-  const grantsPayload = (allGrants: FormGrant[], type: 'user' | 'group') =>
-    allGrants
-      .filter((g) => parseActorId(g.actorId).type === type)
-      .map((g) => ({
-        granteeId: parseActorId(g.actorId).id,
-        permission: g.choice === 'manager' ? ResourcePermission.admin : ResourcePermission.view,
-        lens: g.choice === 'manager' ? undefined : g.choice,
-      }))
+  /**
+   * The `setInstance` payload for one grantee type. Resolves each form grant to
+   * its storage grantee first, so a row whose ActorId has no grantee
+   * representation is dropped from EVERY bucket instead of landing in the `user`
+   * one with an id that points at another table.
+   */
+  const grantsPayload = (allGrants: FormGrant[], type: SharingGranteeType) =>
+    allGrants.flatMap((g) => {
+      const grantee = actorIdToGrantee(g.actorId)
+      if (!grantee || grantee.granteeType !== type) return []
+      return [
+        {
+          granteeId: grantee.granteeId,
+          permission: g.choice === 'manager' ? ResourcePermission.admin : ResourcePermission.view,
+          lens: g.choice === 'manager' ? undefined : g.choice,
+        },
+      ]
+    })
 
   // Handle delete with confirmation
   const handleDelete = async () => {
@@ -402,16 +458,14 @@ export function InboxForm({
 
       if (canManageAccess && grantsKey(values.grants) !== initialGrantsRef.current) {
         try {
-          await setInstance.mutateAsync({
-            recordId,
-            granteeType: ResourceGranteeType.user,
-            grants: grantsPayload(values.grants, 'user'),
-          })
-          await setInstance.mutateAsync({
-            recordId,
-            granteeType: ResourceGranteeType.group,
-            grants: grantsPayload(values.grants, 'group'),
-          })
+          // One replace-all pass per MANAGED type. Unlisted kinds keep their rows.
+          for (const granteeType of MANAGED_GRANTEE_TYPES) {
+            await setInstance.mutateAsync({
+              recordId,
+              granteeType,
+              grants: grantsPayload(values.grants, granteeType),
+            })
+          }
         } catch {
           return // toast shown by the mutation; keep the form open
         }
@@ -435,11 +489,17 @@ export function InboxForm({
         // Additive grants — the server already added the creator's Manager row.
         const createdRecordId = toRecordId('inbox', created.id)
         for (const grant of values.grants) {
-          const { type, id } = parseActorId(grant.actorId)
+          const grantee: ShareGrantee | null = actorIdToGrantee(grant.actorId)
+          if (!grantee) {
+            toastError({
+              title: 'Some access was not saved',
+              description: GRANTEE_UNSUPPORTED_MESSAGE,
+            })
+            continue
+          }
           await grantInstance.mutateAsync({
             recordId: createdRecordId,
-            granteeType: type === 'group' ? ResourceGranteeType.group : ResourceGranteeType.user,
-            granteeId: id,
+            ...grantee,
             permission:
               grant.choice === 'manager' ? ResourcePermission.admin : ResourcePermission.view,
             lens: grant.choice === 'manager' ? undefined : grant.choice,
@@ -610,6 +670,7 @@ export function InboxForm({
                 includeManager
                 disabled={isPending}
                 lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
+                unmanageableGrants={unmanageableGrants}
                 emptyHint={membersEmptyHint}
               />
               <button
@@ -671,6 +732,7 @@ export function InboxForm({
       includeManager
       disabled={isPending}
       lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
+      unmanageableGrants={unmanageableGrants}
       emptyHint={membersEmptyHint}
       note={
         isPersonalInbox

--- a/apps/web/src/components/inbox/inbox-members-page.tsx
+++ b/apps/web/src/components/inbox/inbox-members-page.tsx
@@ -11,6 +11,7 @@ import {
   MailGranteeAddButton,
   MailGranteeList,
 } from '~/components/mail-permissions/ui/mail-grantee-list'
+import type { UnmanageableGrant } from '~/components/permissions/utils/grantee'
 
 /** A grantee row as the form edits it (mirrors {@link InboxForm}'s FormGrant). */
 interface FormGrant {
@@ -33,6 +34,8 @@ interface InboxMembersPageProps {
    * the inbox owner's locked Manager grant, so the list never lies.
    */
   lockedActorIds?: ActorId[]
+  /** Grants on a kind the list can't address (e.g. `profile`) — disclosed, not dropped. */
+  unmanageableGrants?: UnmanageableGrant[]
   /** Personal-account note rendered above the list. */
   note?: string
   /** Opens the access-levels guide. */
@@ -57,6 +60,7 @@ export function InboxMembersPage({
   disabled = false,
   emptyHint = 'Not shared with anyone yet.',
   lockedActorIds = [],
+  unmanageableGrants,
   note,
   onOpenGuide,
   onBack,
@@ -86,6 +90,7 @@ export function InboxMembersPage({
           disabled={disabled}
           emptyHint={emptyHint}
           lockedActorIds={lockedActorIds}
+          unmanageableGrants={unmanageableGrants}
           hideAddButton
         />
 

--- a/apps/web/src/components/inbox/ui/inbox-info-card.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-info-card.tsx
@@ -5,6 +5,7 @@ import { LENS_LABELS } from '@auxx/lib/permissions/visibility/client'
 import { toActorId } from '@auxx/types/actor'
 import { Badge } from '@auxx/ui/components/badge'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { granteeToActorId, unmanageableGrantsNote } from '~/components/permissions/utils/grantee'
 import { ActorStack } from '~/components/resources/ui/actor-stack'
 import type { InboxItem } from '~/components/threads/hooks/use-inbox'
 import { api } from '~/trpc/react'
@@ -81,8 +82,15 @@ export function InboxInfoCard({ inbox, loading }: { inbox?: InboxItem; loading?:
 
   if (loading || !inbox) return <InboxInfoCardSkeleton />
 
-  const actorIds = (rows ?? []).map((r) =>
-    toActorId(r.granteeType === 'group' ? 'group' : 'user', r.granteeId)
+  // `granteeToActorId` returns null for every kind with no actor — the old
+  // `r.granteeType === 'group' ? 'group' : 'user'` ternary rendered a `role`
+  // baseline or a `profile` grant as a bogus `user:<id>` avatar that resolves to
+  // "Unknown", and counted it as a person.
+  const actorIds = (rows ?? []).flatMap((r) => granteeToActorId(r.granteeType, r.granteeId) ?? [])
+  const hiddenNote = unmanageableGrantsNote(
+    (rows ?? [])
+      .filter((r) => !granteeToActorId(r.granteeType, r.granteeId) && r.granteeType !== 'role')
+      .map((r) => ({ granteeType: r.granteeType, granteeId: r.granteeId }))
   )
   // Personal inbox: ensure the owner shows even if there's no explicit grant row.
   const ownerActorId =
@@ -121,6 +129,7 @@ export function InboxInfoCard({ inbox, loading }: { inbox?: InboxItem; loading?:
               </span>
             </div>
           )}
+          {hiddenNote && <p className='text-muted-foreground text-xs'>{hiddenNote}</p>}
         </div>
       </div>
 

--- a/apps/web/src/components/mail-permissions/hooks/use-mail-share.ts
+++ b/apps/web/src/components/mail-permissions/hooks/use-mail-share.ts
@@ -4,9 +4,16 @@
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import type { LensChoice } from '@auxx/lib/permissions/visibility/client'
 import type { ResourceAccessInfo } from '@auxx/lib/resource-access'
-import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import type { ActorId } from '@auxx/types/actor'
 import { toastError } from '@auxx/ui/components/toast'
 import { useMemo } from 'react'
+import {
+  actorIdToGrantee,
+  GRANTEE_UNSUPPORTED_MESSAGE,
+  granteeToActorId,
+  isActorGrantee,
+  type UnmanageableGrant,
+} from '~/components/permissions/utils/grantee'
 import { api } from '~/trpc/react'
 
 export interface MailShareGrant {
@@ -93,54 +100,76 @@ export function useMailShare({
   /** Grants as actor-keyed lens choices (admin permission renders as Manager). */
   const grants = useMemo<MailShareGrant[]>(
     () =>
-      rows
-        .filter(
-          (r) =>
-            r.granteeType === ResourceGranteeType.user ||
-            r.granteeType === ResourceGranteeType.group
-        )
-        .map((r) => ({
-          actorId: toActorId(
-            r.granteeType === ResourceGranteeType.group ? 'group' : 'user',
-            r.granteeId
-          ),
-          choice:
-            r.permission === ResourcePermission.admin || r.permission === ResourcePermission.edit
-              ? r.permission === ResourcePermission.admin
-                ? ('manager' as const)
-                : ('full' as const)
-              : ((r.lens ?? 'full') as LensChoice),
-        })),
+      rows.flatMap((r) => {
+        const actorId = granteeToActorId(r.granteeType, r.granteeId)
+        if (!actorId) return []
+        return [
+          {
+            actorId,
+            choice:
+              r.permission === ResourcePermission.admin || r.permission === ResourcePermission.edit
+                ? r.permission === ResourcePermission.admin
+                  ? ('manager' as const)
+                  : ('full' as const)
+                : ((r.lens ?? 'full') as LensChoice),
+          },
+        ]
+      }),
     [rows]
   )
 
-  const toGrantee = (actorId: ActorId) => {
-    const { type, id } = parseActorId(actorId)
-    return {
-      granteeType: type === 'group' ? ResourceGranteeType.group : ResourceGranteeType.user,
-      granteeId: id,
-    }
-  }
+  /**
+   * Rows this surface can neither render as an actor nor revoke — a `profile`
+   * grantee today (plan 19 §8.2). Disclosed rather than dropped, so an admin is
+   * never shown an empty share list while a live grant exists server-side.
+   * The `role:org_member` floor is excluded: mail expresses it as the inbox's
+   * `inbox_default_lens`, not as a row in this list.
+   */
+  const unmanageableGrants = useMemo<UnmanageableGrant[]>(
+    () =>
+      rows
+        .filter((r) => !isActorGrantee(r.granteeType) && r.granteeType !== ResourceGranteeType.role)
+        .map((r) => ({ granteeType: r.granteeType, granteeId: r.granteeId })),
+    [rows]
+  )
 
-  /** Grant or change an actor's level (upsert semantics server-side). */
+  /**
+   * Grant or change an actor's level (upsert semantics server-side).
+   *
+   * An ActorId with no grantee representation is REFUSED, not coerced: the old
+   * `type === 'group' ? group : user` fall-through turned an `agent:`/`worker:`
+   * pick into a `user` row keyed on an `Agent.id`/`DispatchWorker.id`, which
+   * points at the wrong table and grants nobody anything.
+   */
   const grant = (actorId: ActorId, choice: LensChoice) => {
-    const { granteeType, granteeId } = toGrantee(actorId)
+    const grantee = actorIdToGrantee(actorId)
+    if (!grantee) {
+      toastError({
+        title: 'Cannot share with this actor',
+        description: GRANTEE_UNSUPPORTED_MESSAGE,
+      })
+      return
+    }
     grantInstance.mutate({
       recordId,
-      granteeType,
-      granteeId,
+      ...grantee,
       permission: choice === 'manager' ? ResourcePermission.admin : ResourcePermission.view,
       lens: choice === 'manager' ? undefined : choice,
     })
   }
 
   const revoke = (actorId: ActorId) => {
-    const { granteeType, granteeId } = toGrantee(actorId)
-    revokeInstance.mutate({ recordId, granteeType, granteeId })
+    const grantee = actorIdToGrantee(actorId)
+    if (!grantee) {
+      toastError({ title: 'Cannot remove this access', description: GRANTEE_UNSUPPORTED_MESSAGE })
+      return
+    }
+    revokeInstance.mutate({ recordId, ...grantee })
   }
 
   return {
     grants,
+    unmanageableGrants,
     isLoading,
     grant,
     changeLens: grant,

--- a/apps/web/src/components/mail-permissions/ui/mail-grantee-list.tsx
+++ b/apps/web/src/components/mail-permissions/ui/mail-grantee-list.tsx
@@ -5,6 +5,7 @@ import { LENS_LABELS, type LensChoice } from '@auxx/lib/permissions/visibility/c
 import type { ActorId } from '@auxx/types/actor'
 import type { ReactNode } from 'react'
 import { GranteeAddButton, GranteeList } from '~/components/permissions/ui/grantee-list'
+import type { UnmanageableGrant } from '~/components/permissions/utils/grantee'
 import { LensSelect } from './lens-select'
 
 /**
@@ -24,6 +25,7 @@ export function MailGranteeList({
   emptyHint,
   lockedActorIds,
   hideAddButton,
+  unmanageableGrants,
 }: {
   grants: Array<{ actorId: ActorId; choice: LensChoice }>
   onGrant: (actorId: ActorId, choice: LensChoice) => void
@@ -34,6 +36,8 @@ export function MailGranteeList({
   emptyHint?: string
   lockedActorIds?: ActorId[]
   hideAddButton?: boolean
+  /** Grants on a kind this list can't address (e.g. `profile`) — disclosed, not dropped. */
+  unmanageableGrants?: UnmanageableGrant[]
 }) {
   return (
     <GranteeList<LensChoice>
@@ -58,6 +62,7 @@ export function MailGranteeList({
       emptyHint={emptyHint}
       lockedActorIds={lockedActorIds}
       hideAddButton={hideAddButton}
+      unmanageableGrants={unmanageableGrants}
     />
   )
 }

--- a/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
+++ b/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
@@ -56,7 +56,7 @@ export function ThreadSharePopover({ threadId }: { threadId: string }) {
   const gated = useMailPermissionsGated()
 
   const recordId = toRecordId('thread', threadId)
-  const { grants, grant, changeLens, revoke } = useMailShare({ recordId })
+  const { grants, unmanageableGrants, grant, changeLens, revoke } = useMailShare({ recordId })
 
   // Inbox Managers may share without being org admins (delegation).
   const { data: inboxAccess } = api.resourceAccess.check.useQuery(
@@ -117,6 +117,7 @@ export function ThreadSharePopover({ threadId }: { threadId: string }) {
               onChangeLens={changeLens}
               onRevoke={revoke}
               disabled={!canShare || gated}
+              unmanageableGrants={unmanageableGrants}
               emptyHint='Not shared with anyone yet.'
             />
           </div>

--- a/apps/web/src/components/permissions/hooks/use-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-def-access.ts
@@ -5,10 +5,12 @@ import {
   ResourceGranteeType,
   ResourcePermission,
   type SharingGranteeType,
+  SharingGranteeTypeValues,
 } from '@auxx/database/enums'
 import { PERMISSION_RANK } from '@auxx/lib/permissions/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
+import { granteeKindLabel, type UnmanageableGrant } from '~/components/permissions/utils/grantee'
 import { api } from '~/trpc/react'
 import { MEMBER_BASELINE_GRANTEE_ID } from './use-permission-grants'
 
@@ -151,6 +153,26 @@ export function useDefAccess(entityDefinitionId: string | undefined) {
     [rows]
   )
 
+  /**
+   * Rows this tab renders in none of its three blocks — a `profile` grant today
+   * (plan 19 §8.2). They are the difference between "no one else has access" and
+   * "someone else has access you can't see", and via 19a finding 1 a single one
+   * of them keeps the def restricted org-wide, so they are disclosed rather than
+   * dropped.
+   */
+  const unmanageableGrants = useMemo<UnmanageableGrant[]>(
+    () =>
+      rows
+        .filter(
+          (r) =>
+            r.granteeType !== ResourceGranteeType.role &&
+            r.granteeType !== ResourceGranteeType.group &&
+            r.granteeType !== ResourceGranteeType.user
+        )
+        .map((r) => ({ granteeType: r.granteeType, granteeId: r.granteeId })),
+    [rows]
+  )
+
   /** Persist the workspace baseline (persists `none` too — the lockdown marker). */
   const setBaseline = useCallback(
     (permission: ResourcePermission) => {
@@ -223,18 +245,44 @@ export function useDefAccess(entityDefinitionId: string | undefined) {
     [revokeType, patchLocal, queryInput.entityDefinitionId]
   )
 
-  /** Clear every type row for the def → back to the dormant/unrestricted state. */
+  /**
+   * Clear every type row for the def → back to the dormant/unrestricted state.
+   *
+   * `setType` replaces ONE grantee type per call, so the types to clear are
+   * derived from the rows that actually exist rather than from a fixed
+   * `[role, group, user]` list. That list was the bug: a `profile` row survived
+   * the reset, and because `restricted-entity-def-ids-provider.ts` builds the
+   * restricted set **grantee-agnostically** (19a finding 1), the def stayed
+   * restricted — invisible to every non-admin — while this button reported it
+   * reset. Any surviving kind now reports itself instead of vanishing.
+   */
   const resetToDefault = useCallback(() => {
-    utils.resourceAccess.forType.setData(queryInput, () => [])
-    // Clear each grantee type independently (setType replaces one type at a time).
-    for (const granteeType of [
-      ResourceGranteeType.role,
-      ResourceGranteeType.group,
-      ResourceGranteeType.user,
-    ]) {
+    const presentTypes = [...new Set(rows.map((r) => r.granteeType))]
+    const clearable = presentTypes.filter((t): t is SharingGranteeType =>
+      SharingGranteeTypeValues.includes(t as SharingGranteeType)
+    )
+    const unclearable = presentTypes.filter(
+      (t) => !SharingGranteeTypeValues.includes(t as SharingGranteeType)
+    )
+
+    utils.resourceAccess.forType.setData(queryInput, (prev) =>
+      (prev ?? []).filter((r) => unclearable.includes(r.granteeType))
+    )
+    for (const granteeType of clearable) {
       setType.mutate({ entityDefinitionId: queryInput.entityDefinitionId, granteeType, grants: [] })
     }
-  }, [setType, utils, queryInput])
+
+    if (unclearable.length > 0) {
+      toastError({
+        title: 'Access not fully reset',
+        description: `This record type still has ${unclearable
+          .map(granteeKindLabel)
+          .join(
+            ' and '
+          )} access rows, which can’t be cleared from here. It stays restricted until they are removed.`,
+      })
+    }
+  }, [rows, setType, utils, queryInput])
 
   /** A grant is "ignored" when it lifts nothing above the effective baseline. */
   const isIgnored = useCallback(
@@ -249,6 +297,7 @@ export function useDefAccess(entityDefinitionId: string | undefined) {
     isConfigured,
     teamGrants,
     userGrants,
+    unmanageableGrants,
     isSaving: grantType.isPending || revokeType.isPending || setType.isPending,
     setBaseline,
     addGrant,

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
@@ -21,7 +21,17 @@ import { useResources } from '~/components/resources/hooks'
 import { api } from '~/trpc/react'
 import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permission-grants'
 
-/** The grantee axis this section edits: an individual member or a team. */
+/**
+ * The grantee axis this section edits: an individual member or a team.
+ *
+ * A `'profile'` kind is deliberately absent. It is not a missing tab — the
+ * grantee-centric def grid writes `ResourceAccess` rows through
+ * `resourceAccess.grantType`/`revokeType`, and profile-grantee `ResourceAccess`
+ * writes are refused at the service layer (`assertProfileGranteeSupported`) until
+ * every resolver reads them. Adding it here would ship a picker whose every
+ * selection 400s. Per-def profile access is therefore explicitly **unsupported**
+ * on this surface; it belongs to the profile-side def grid in doc 19 §7.
+ */
 export type GranteeKind = 'user' | 'group'
 
 /**
@@ -34,8 +44,12 @@ export type GranteeKind = 'user' | 'group'
  */
 export type GranteePrincipal = 'member' | 'agent'
 
-// Typed against `SharingGranteeType`, not `ResourceGranteeType`: the wider union
-// carries `'profile'`, whose ResourceAccess writes are gated until plan 19 step 9.
+/**
+ * Typed against `SharingGranteeType`, not `ResourceGranteeType`: the wider union
+ * carries `'profile'`, whose ResourceAccess writes are still refused server-side.
+ * Total over {@link GranteeKind} by construction — there is no fall-through
+ * branch that could turn an unmodelled kind into a `user` write.
+ */
 const GRANTEE_TYPE: Record<GranteeKind, SharingGranteeType> = {
   user: ResourceGranteeType.user,
   group: ResourceGranteeType.group,

--- a/apps/web/src/components/permissions/hooks/use-instance-share.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-share.ts
@@ -3,10 +3,17 @@
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import type { ResourceAccessInfo } from '@auxx/lib/resource-access'
-import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import type { ActorId } from '@auxx/types/actor'
 import type { RecordId } from '@auxx/types/resource'
 import { toastError } from '@auxx/ui/components/toast'
 import { useMemo } from 'react'
+import {
+  actorIdToGrantee,
+  GRANTEE_UNSUPPORTED_MESSAGE,
+  granteeToActorId,
+  isActorGrantee,
+  type UnmanageableGrant,
+} from '~/components/permissions/utils/grantee'
 import { api } from '~/trpc/react'
 
 /** Instance grant level — the raw Read/Write/Full ResourceAccess permission. */
@@ -122,19 +129,32 @@ export function useInstanceShare({
   /** Actor-keyed user/group grants (excludes the workspace baseline row). */
   const grants = useMemo<InstanceShareGrant[]>(
     () =>
+      rows.flatMap((r) => {
+        const actorId = granteeToActorId(r.granteeType, r.granteeId)
+        if (!actorId) return []
+        return [{ actorId, choice: r.permission as InstanceLevel }]
+      }),
+    [rows]
+  )
+
+  /**
+   * Rows this card can neither render as an actor nor revoke — a `profile`
+   * grantee today (plan 19 §8.2), any future kind tomorrow. Surfaced rather than
+   * dropped: silently filtering them told the admin "not shared with anyone"
+   * while a live grant existed server-side, so they could not see OR revoke it.
+   */
+  const unmanageableGrants = useMemo<UnmanageableGrant[]>(
+    () =>
       rows
         .filter(
           (r) =>
-            r.granteeType === ResourceGranteeType.user ||
-            r.granteeType === ResourceGranteeType.group
+            !isActorGrantee(r.granteeType) &&
+            !(
+              r.granteeType === WORKSPACE_GRANTEE.granteeType &&
+              r.granteeId === WORKSPACE_GRANTEE.granteeId
+            )
         )
-        .map((r) => ({
-          actorId: toActorId(
-            r.granteeType === ResourceGranteeType.group ? 'group' : 'user',
-            r.granteeId
-          ),
-          choice: r.permission as InstanceLevel,
-        })),
+        .map((r) => ({ granteeType: r.granteeType, granteeId: r.granteeId })),
     [rows]
   )
 
@@ -155,20 +175,25 @@ export function useInstanceShare({
       : (baselineRow.permission as InstanceLevel)
     : undefined
 
-  const toGrantee = (actorId: ActorId) => {
-    const { type, id } = parseActorId(actorId)
-    return {
-      granteeType: type === 'group' ? ResourceGranteeType.group : ResourceGranteeType.user,
-      granteeId: id,
-    }
-  }
-
   /**
    * Grant or change a user/group's level (upsert). On the FIRST explicit row for
    * a still-unshared instance, also materialize the workspace baseline at Read so
    * the rest of the org keeps its base-level access instead of silently losing it.
+   *
+   * An ActorId with no grantee representation is REFUSED, not coerced: the old
+   * `type === 'group' ? group : user` fall-through turned an `agent:`/`worker:`
+   * pick into a `user` row keyed on an `Agent.id`/`DispatchWorker.id` — a row
+   * pointing at the wrong table that no resolver matches and no admin can see.
    */
   const grant = (actorId: ActorId, choice: InstanceLevel) => {
+    const grantee = actorIdToGrantee(actorId)
+    if (!grantee) {
+      toastError({
+        title: 'Cannot share with this actor',
+        description: GRANTEE_UNSUPPORTED_MESSAGE,
+      })
+      return
+    }
     if (rows.length === 0 && !baselineRow) {
       grantInstance.mutate({
         recordId,
@@ -177,13 +202,16 @@ export function useInstanceShare({
         permission: ResourcePermission.view,
       })
     }
-    const { granteeType, granteeId } = toGrantee(actorId)
-    grantInstance.mutate({ recordId, granteeType, granteeId, permission: choice })
+    grantInstance.mutate({ recordId, ...grantee, permission: choice })
   }
 
   const revoke = (actorId: ActorId) => {
-    const { granteeType, granteeId } = toGrantee(actorId)
-    revokeInstance.mutate({ recordId, granteeType, granteeId })
+    const grantee = actorIdToGrantee(actorId)
+    if (!grantee) {
+      toastError({ title: 'Cannot remove this access', description: GRANTEE_UNSUPPORTED_MESSAGE })
+      return
+    }
+    revokeInstance.mutate({ recordId, ...grantee })
   }
 
   /** Set the workspace baseline. `'restricted'` writes the `'none'` marker. */
@@ -198,6 +226,7 @@ export function useInstanceShare({
 
   return {
     grants,
+    unmanageableGrants,
     baseline,
     isLoading,
     grant,

--- a/apps/web/src/components/permissions/hooks/use-permission-grants.ts
+++ b/apps/web/src/components/permissions/hooks/use-permission-grants.ts
@@ -104,6 +104,27 @@ export function usePermissionGrants() {
     [grants]
   )
 
+  /**
+   * Permission-profile grant rows — the area-level base for every member bound to
+   * that profile (doc 19 §0.1/§0.8). Every org has six after data migration 049.
+   *
+   * These are NOT overrides and must never be folded into {@link groupGrants} /
+   * {@link userGrants}: they compose as the base tier, not as a raise above it.
+   * Before this bucket existed the three filters simply dropped them, so the
+   * settings page silently showed nothing for the majority of an org's stored
+   * grant rows. The org's own `member` profile is NOT here — the router presents
+   * it as `role:org_member` in {@link baseline} (`permissions-member-baseline.ts`).
+   *
+   * TODO(plan-19-step-7): the Profiles editor is the surface that renders and
+   * edits these. Read-only here on purpose — `permissions.grant`'s input enum
+   * still excludes `'profile'` (see {@link save}), so exposing an editor for them
+   * from this hook would ship a control that fails at the router.
+   */
+  const profileGrants = useMemo<GranteeGrant[]>(
+    () => grants.filter((g) => g.granteeType === 'profile'),
+    [grants]
+  )
+
   /** The effective member baseline per area — role default merged with org policy. */
   const effectiveBaseline = useMemo<Partial<Record<Area, Level>>>(
     () => ({ ...(roleDefaults ?? {}), ...baseline }),
@@ -143,6 +164,7 @@ export function usePermissionGrants() {
     baseline,
     groupGrants,
     userGrants,
+    profileGrants,
     effectiveBaseline,
     isSaving: grant.isPending || revoke.isPending,
     save,

--- a/apps/web/src/components/permissions/ui/def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/def-access-section.tsx
@@ -39,6 +39,7 @@ import { useUser } from '~/hooks/use-user'
 import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { type DefAccessGrant, useDefAccess } from '../hooks/use-def-access'
+import { unmanageableGrantsNote } from '../utils/grantee'
 import { AccessLevelSelect } from './access-level-select'
 
 /**
@@ -46,6 +47,11 @@ import { AccessLevelSelect } from './access-level-select'
  * grantee type — an agent grant is a `user` row keyed on the agent's backing
  * `User.id` (agent plan §4.1); the kind only selects the copy, the picker
  * target, and the ActorId prefix used for display.
+ *
+ * A `profile` grantee is the opposite: a REAL storage kind with no actor and no
+ * `user` row behind it, so it cannot be added as a fourth block by copying the
+ * `agent` pattern — there is nothing to translate it into. Its rows are
+ * disclosed via `unmanageableGrants` and edited from step 7's Profiles page.
  */
 type GranteeKind = 'group' | 'user' | 'agent'
 
@@ -114,6 +120,7 @@ export function DefAccessSection({ resource }: { resource: Resource }) {
     isConfigured,
     teamGrants,
     userGrants,
+    unmanageableGrants,
     setBaseline,
     addGrant,
     setGrant,
@@ -121,6 +128,15 @@ export function DefAccessSection({ resource }: { resource: Resource }) {
     resetToDefault,
     isIgnored,
   } = useDefAccess(resource.entityDefinitionId)
+
+  // Rows none of the three blocks below can render (a `profile` grant today).
+  // Via 19a finding 1 a single one keeps the def restricted org-wide, so a
+  // silent drop here would leave an admin staring at a restricted def with no
+  // visible cause.
+  const hiddenGrantsNote = useMemo(
+    () => unmanageableGrantsNote(unmanageableGrants),
+    [unmanageableGrants]
+  )
 
   // Agents are org members backed by a synthetic User row, so their def grants
   // are `user`-type rows keyed on `AgentActor.userId` — indistinguishable from a
@@ -224,6 +240,12 @@ export function DefAccessSection({ resource }: { resource: Resource }) {
           />
         </div>
       </Section>
+
+      {hiddenGrantsNote && (
+        <p className='rounded-xl border border-dashed px-3 py-2 text-muted-foreground text-xs'>
+          {hiddenGrantsNote}
+        </p>
+      )}
 
       <GranteeAccessBlock
         kind='group'

--- a/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
@@ -39,6 +39,19 @@ const COPY: Record<GranteeKind, { description: string }> = {
 const AGENT_DESCRIPTION =
   'Access to individual record types. Each row shows what this agent gets by default — pick a level to override it for that type.'
 
+/** Neutral copy for a grantee kind this section does not model (e.g. `profile`). */
+const FALLBACK_DESCRIPTION =
+  'Access to individual record types. Each row shows what this grantee gets by default; pick a level to override it for that type.'
+
+/**
+ * Total copy lookup — `COPY[granteeKind].description` on an unlisted kind throws
+ * during render, and this section is the record-access half of a member/team
+ * detail page.
+ */
+function descriptionFor(granteeKind: string): string {
+  return COPY[granteeKind as GranteeKind]?.description ?? FALLBACK_DESCRIPTION
+}
+
 /**
  * The grantee-centric entity-def **Access** section (capability layer v2
  * grantee-def-access) — the transpose of the per-def Permissions tab. Lists every
@@ -92,7 +105,7 @@ export function GranteeDefAccessSection({
     <SettingsSection
       icon={ShieldCheck}
       title='Record access'
-      description={principal === 'agent' ? AGENT_DESCRIPTION : COPY[granteeKind].description}>
+      description={principal === 'agent' ? AGENT_DESCRIPTION : descriptionFor(granteeKind)}>
       {isLoading ? (
         <div className='border p-1 rounded-xl space-y-1'>
           <Skeleton className='h-9 w-full rounded-lg' />

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
@@ -20,6 +20,19 @@ const COPY: Record<GranteeKind, { description: string }> = {
   },
 }
 
+/** Neutral copy for a grantee kind this section does not model (e.g. `profile`). */
+const FALLBACK_DESCRIPTION =
+  'What this grantee can do across the workspace. Overrides only raise access above the member baseline.'
+
+/**
+ * Total copy lookup — `COPY[granteeKind].description` on an unlisted kind is a
+ * `TypeError` at render, and this section is the whole Permissions tab of a
+ * member/team detail page.
+ */
+function descriptionFor(granteeKind: string): string {
+  return COPY[granteeKind as GranteeKind]?.description ?? FALLBACK_DESCRIPTION
+}
+
 /**
  * Agent copy. Agents compose by SET over an all-Full base — no baseline, no
  * inheritance — so the surface is a restriction editor, not an elevation one.
@@ -78,7 +91,7 @@ export function GranteeLevelsSection({
     <SettingsSection
       icon={SlidersHorizontal}
       title='Access levels'
-      description={mode === 'agent' ? AGENT_DESCRIPTION : COPY[granteeKind].description}>
+      description={mode === 'agent' ? AGENT_DESCRIPTION : descriptionFor(granteeKind)}>
       {isLoading || !roleDefaults ? (
         <div className='space-y-2'>
           <Skeleton className='h-16 w-full rounded-lg' />

--- a/apps/web/src/components/permissions/ui/grantee-list.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-list.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import type { ActorId } from '@auxx/types/actor'
-import { parseActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
 import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -13,6 +12,9 @@ import { type ReactNode, useMemo } from 'react'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useActor } from '~/components/resources/hooks/use-actor'
 import { ActorAvatar } from '~/components/resources/ui/actor-badge'
+import { actorAvatarType } from '~/components/resources/utils/actor-id'
+import type { UnmanageableGrant } from '../utils/grantee'
+import { unmanageableGrantsNote } from '../utils/grantee'
 
 /**
  * Render the level picker for one editable grantee row. The neutral list is
@@ -48,6 +50,13 @@ export interface GranteeListProps<TChoice extends string> {
    * their own {@link GranteeAddButton} (e.g. the inbox dialog's Section header).
    */
   hideAddButton?: boolean
+  /**
+   * Stored grants this list cannot render as an actor row — a `profile` grantee
+   * today (plan 19 §8.2). Disclosed as a muted line beneath the rows so the list
+   * never claims "not shared with anyone" while a live grant exists server-side.
+   * Not editable here: revoking one needs a surface that can address its kind.
+   */
+  unmanageableGrants?: UnmanageableGrant[]
 }
 
 /**
@@ -73,12 +82,17 @@ export function GranteeList<TChoice extends string>({
   emptyHint = 'Not shared with anyone yet.',
   lockedActorIds = [],
   hideAddButton = false,
+  unmanageableGrants,
 }: GranteeListProps<TChoice>) {
   const locked = useMemo(() => new Set(lockedActorIds), [lockedActorIds])
+  const hiddenNote = useMemo(
+    () => unmanageableGrantsNote(unmanageableGrants ?? []),
+    [unmanageableGrants]
+  )
 
   return (
     <div className='space-y-0.5'>
-      {grants.length === 0 ? (
+      {grants.length === 0 && !hiddenNote ? (
         <EmptySection
           icon={<Users className='size-5' />}
           title='No one added yet'
@@ -99,6 +113,8 @@ export function GranteeList<TChoice extends string>({
           />
         ))
       )}
+
+      {hiddenNote && <p className='px-2 pt-1 text-muted-foreground text-xs'>{hiddenNote}</p>}
 
       {!hideAddButton && (
         <GranteeAddButton
@@ -175,7 +191,10 @@ function GranteeRow<TChoice extends string>({
   onRevoke: (actorId: ActorId) => void
 }) {
   const { actor, isLoading, isNotFound } = useActor({ actorId })
-  const type = actor?.type ?? parseActorId(actorId).type
+  // Never `parseActorId` here: it throws for any prefix outside its whitelist,
+  // and this row renders BEFORE hydration resolves — so one grant on a kind the
+  // actor system doesn't model white-screened the entire share sheet.
+  const type = actorAvatarType(actorId, actor?.type)
   const showLoading = isLoading && !actor
   const name = isNotFound
     ? 'Unknown'

--- a/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
@@ -19,23 +19,32 @@ import { useUser } from '~/hooks/use-user'
 import { usePermissionGrants } from '../hooks/use-permission-grants'
 import { LeveledAreaGrid } from './leveled-area-grid'
 
+/**
+ * The grantee kinds this tab edits.
+ *
+ * `PermissionGrant` also carries `'profile'` rows (plan 19 §0.1) — every org has
+ * six after data migration 049 — but they are NOT overrides: a profile IS the
+ * composition base, and its editor is step 7's Profiles page, not this raise-only
+ * surface. `usePermissionGrants` exposes them separately as `profileGrants`; this
+ * tab deliberately renders none of them. See {@link copyFor} for why the copy
+ * lookup is still total.
+ */
 type OverrideType = 'group' | 'user'
 
 /** Rows shown before the inline "Show N more" toggle takes over. */
 const VISIBLE_GRANTEES = 5
 
-const COPY: Record<
-  OverrideType,
-  {
-    add: string
-    list: string
-    remove: string
-    empty: string
-    search: string
-    noMatches: string
-    icon: typeof Users
-  }
-> = {
+interface OverrideCopy {
+  add: string
+  list: string
+  remove: string
+  empty: string
+  search: string
+  noMatches: string
+  icon: typeof Users
+}
+
+const COPY: Record<OverrideType, OverrideCopy> = {
   group: {
     add: 'Add group',
     list: 'Groups',
@@ -54,6 +63,27 @@ const COPY: Record<
     noMatches: 'No members match your search.',
     icon: Users,
   },
+}
+
+/** Neutral copy for a grantee kind this tab does not model. */
+const FALLBACK_COPY: OverrideCopy = {
+  add: 'Add grantee',
+  list: 'Grantees',
+  remove: 'Remove grantee',
+  empty: 'Grant more access than the member baseline.',
+  search: 'Search grantees...',
+  noMatches: 'No grantees match your search.',
+  icon: Users,
+}
+
+/**
+ * Total copy lookup. `COPY[granteeType]` was an unguarded index: widening the
+ * grantee vocabulary (plan 19's `'profile'`) turned every read of `.add`/`.icon`
+ * on the result into a `TypeError` at render, taking the whole tab down rather
+ * than showing a generic label.
+ */
+function copyFor(granteeType: string): OverrideCopy {
+  return COPY[granteeType as OverrideType] ?? FALLBACK_COPY
 }
 
 /** Resolve a grantee's display name from the actor cache (falls back to email / Unknown). */
@@ -88,7 +118,7 @@ export function GranteeOverridesTab({
   const { isLoading, roleDefaults, effectiveBaseline, groupGrants, userGrants, save, remove } =
     usePermissionGrants()
   const persisted = granteeType === 'group' ? groupGrants : userGrants
-  const copy = COPY[granteeType]
+  const copy = copyFor(granteeType)
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [search, setSearch] = useState('')
@@ -278,7 +308,7 @@ function GranteeListRow({
       actions={
         <TreeRowButton
           variant='destructive'
-          tooltipText={COPY[granteeType].remove}
+          tooltipText={copyFor(granteeType).remove}
           disabled={disabled}
           onClick={onRemove}>
           <Trash2 />

--- a/apps/web/src/components/permissions/ui/instance-share-card.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-card.tsx
@@ -169,14 +169,17 @@ export function InstanceShareCard({ recordId }: { recordId: RecordId }) {
   const { entityDefinitionId: key } = parseRecordId(recordId)
   const isSupported = key in INSTANCE_SHARE_COPY
   const canAdmin = useCanAdminInstance(recordId)
-  const { grants, baseline, grant, changeLevel, revoke, setBaseline } = useInstanceShare({
-    recordId,
-    enabled: isSupported,
-  })
+  const { grants, unmanageableGrants, baseline, grant, changeLevel, revoke, setBaseline } =
+    useInstanceShare({
+      recordId,
+      enabled: isSupported,
+    })
 
   if (!isSupported) return null
   const copy = INSTANCE_SHARE_COPY[key as keyof typeof INSTANCE_SHARE_COPY]
-  if (!canAdmin && grants.length === 0) return null
+  // A grant this card can't render still means the resource IS shared — hiding
+  // the card would leave an admin with no signal at all.
+  if (!canAdmin && grants.length === 0 && unmanageableGrants.length === 0) return null
 
   const restricted = baseline === 'restricted'
 
@@ -216,6 +219,7 @@ export function InstanceShareCard({ recordId }: { recordId: RecordId }) {
           <InstanceLevelSelect value={value} onChange={onChange} copy={copy} disabled={disabled} />
         )}
         disabled={!canAdmin}
+        unmanageableGrants={unmanageableGrants}
         emptyHint={`Not shared with anyone specific. Adjust the workspace default above to restrict this ${copy.noun}.`}
       />
     </div>

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -68,10 +68,17 @@ interface LeveledAreaGridProps {
   renderChildren?: (area: Area, filter: AreaChildFilter) => AreaChildren | undefined
 }
 
+/** The §5.3 wording for an area whose routers are still a binary admin gate. */
+const ROLE_GATED_NOTE = 'Still role-gated — admins reach this regardless.'
+
 /**
  * Grantable areas, grouped by registry `group` in area order. Excludes
  * `adminOnly` (never grantable below ADMIN) and `workerOnly` (enforced only on a
  * worker seat, so a level control here would do nothing).
+ *
+ * `roleGated` areas ARE included — they are grantable in the model (doc 19
+ * §0.25) — but render locked, because their routers are still binary
+ * `adminProcedure` checks (§5.3).
  */
 const AREA_GROUPS: Array<{ group: string; areas: Area[] }> = (() => {
   const order: string[] = []
@@ -194,7 +201,9 @@ export function LeveledAreaGrid({
                     rowClassName='bg-primary-50 hover:bg-primary-100'
                     key={area}
                     title={meta.label}
-                    description={meta.description}
+                    description={
+                      meta.roleGated ? `${meta.description} ${ROLE_GATED_NOTE}` : meta.description
+                    }
                     expandable={children !== undefined}
                     isOpen={children !== undefined ? isOpen : undefined}
                     onToggleOpen={
@@ -213,7 +222,7 @@ export function LeveledAreaGrid({
                           mode === 'agent' ? 'Clear — back to full access' : 'Reset to inherited'
                         }
                         onChange={(level) => onChange(area, level)}
-                        disabled={disabled}
+                        disabled={disabled || meta.roleGated === true}
                       />
                     }>
                     {children?.rows}

--- a/apps/web/src/components/permissions/utils/grantee.ts
+++ b/apps/web/src/components/permissions/utils/grantee.ts
@@ -1,0 +1,99 @@
+// apps/web/src/components/permissions/utils/grantee.ts
+
+import { ResourceGranteeType, type SharingGranteeType } from '@auxx/database/enums'
+import { type ActorId, toActorId } from '@auxx/types/actor'
+import { tryParseActorId } from '~/components/resources/utils/actor-id'
+
+/** A `ResourceAccess` grantee address as the sharing surfaces write it. */
+export interface ShareGrantee {
+  granteeType: SharingGranteeType
+  granteeId: string
+}
+
+/** A stored grant a sharing surface can neither render as an actor nor edit. */
+export interface UnmanageableGrant {
+  granteeType: string
+  granteeId: string
+}
+
+/**
+ * ActorId prefix → the `ResourceAccess` grantee type that stores it.
+ *
+ * Deliberately **partial**: only `user:` and `group:` have a storage kind whose
+ * id half is the same id as the ActorId's. `agent:` carries the `Agent.id` while
+ * an agent grant stores the agent's backing `User.id` (`def-access-section.tsx`
+ * owns that translation), and `worker:` carries a `DispatchWorker.id` with no
+ * grantee kind at all. The `type === 'group' ? group : user` ternaries this
+ * replaces wrote, for either of those, a row whose id half pointed at the wrong
+ * table — a corrupt ACL row no resolver can ever match and no admin can see.
+ */
+const GRANTEE_TYPE_BY_ACTOR_PREFIX: Record<string, SharingGranteeType> = {
+  user: ResourceGranteeType.user,
+  group: ResourceGranteeType.group,
+}
+
+/** The inverse: grantee type → the ActorId prefix that displays it. */
+const ACTOR_PREFIX_BY_GRANTEE_TYPE: Record<string, 'user' | 'group'> = {
+  [ResourceGranteeType.user]: 'user',
+  [ResourceGranteeType.group]: 'group',
+}
+
+/** Human copy for a grantee kind a sharing surface cannot manage. */
+const GRANTEE_KIND_LABEL: Record<string, string> = {
+  [ResourceGranteeType.profile]: 'permission profile',
+  [ResourceGranteeType.role]: 'workspace baseline',
+  [ResourceGranteeType.team]: 'team',
+  [ResourceGranteeType.group]: 'group',
+  [ResourceGranteeType.user]: 'person',
+}
+
+/** Shown when a picked actor has no grantee representation. */
+export const GRANTEE_UNSUPPORTED_MESSAGE =
+  'Only people and groups can be given access here. Agents are granted from the record type’s Access tab.'
+
+/**
+ * Resolve an ActorId to the `ResourceAccess` grantee it must be stored as, or
+ * `null` when the actor has no such representation. Callers MUST treat `null` as
+ * "refuse the write" — never as "fall back to `user`".
+ */
+export function actorIdToGrantee(actorId: ActorId | string): ShareGrantee | null {
+  const parsed = tryParseActorId(actorId)
+  if (!parsed) return null
+  const granteeType = GRANTEE_TYPE_BY_ACTOR_PREFIX[parsed.type]
+  if (!granteeType) return null
+  return { granteeType, granteeId: parsed.id }
+}
+
+/**
+ * Resolve a stored grant row to the ActorId that displays it, or `null` when the
+ * grantee kind is not an actor (`role` baselines, `profile` grants, `team`).
+ * A `null` row belongs in {@link unmanageableGrantsNote}, not in the actor list.
+ */
+export function granteeToActorId(granteeType: string, granteeId: string): ActorId | null {
+  const prefix = ACTOR_PREFIX_BY_GRANTEE_TYPE[granteeType]
+  if (!prefix || !granteeId) return null
+  return toActorId(prefix, granteeId)
+}
+
+/** Whether a stored grant row can be rendered as an actor row in a share list. */
+export function isActorGrantee(granteeType: string): boolean {
+  return granteeType in ACTOR_PREFIX_BY_GRANTEE_TYPE
+}
+
+/** `'permission profile'`, `'team'`, … — falls back to the raw kind, never blank. */
+export function granteeKindLabel(granteeType: string): string {
+  return GRANTEE_KIND_LABEL[granteeType] ?? `${granteeType} grantee`
+}
+
+/**
+ * One muted sentence naming grants this surface cannot show or revoke, so an
+ * admin is never told "not shared with anyone" while rows exist server-side.
+ * Returns `null` when there is nothing to disclose.
+ */
+export function unmanageableGrantsNote(grants: UnmanageableGrant[]): string | null {
+  if (grants.length === 0) return null
+  const kinds = [...new Set(grants.map((g) => granteeKindLabel(g.granteeType)))].sort()
+  const noun = grants.length === 1 ? 'grant' : 'grants'
+  const verb = grants.length === 1 ? 'is' : 'are'
+  return `${grants.length} ${kinds.join(' / ')} ${noun} ${verb} also in effect and can’t be changed here.`
+}

--- a/apps/web/src/components/pickers/actor-picker/actor-item.tsx
+++ b/apps/web/src/components/pickers/actor-picker/actor-item.tsx
@@ -26,6 +26,22 @@ export interface ActorItemProps {
  * Single item in the actor picker list.
  * Shows avatar, name, and badge (member count for groups) or email tooltip icon (for users).
  */
+/**
+ * Fallback glyph per actor type. Only `group` — and a *team* worker, which is a
+ * collection of people — gets the group glyph; everything else, including a kind
+ * this map doesn't list, falls back to the neutral person glyph.
+ *
+ * The `type === user|agent|system ? 'user' : 'group'` ternary this replaces made
+ * "group" the default for everything unlisted, so an individual dispatch worker
+ * (a single person) rendered with a group icon, as would any kind added later.
+ */
+const GLYPH_BY_ACTOR_TYPE: Record<string, 'user' | 'group'> = {
+  user: 'user',
+  agent: 'user',
+  system: 'user',
+  group: 'group',
+}
+
 export function ActorItem({ actor, isSelected, onToggle, multi = true }: ActorItemProps) {
   const { userId } = useUser()
   const isYou = actor.type === 'user' && !!userId && actor.actorId === toActorId('user', userId)
@@ -33,7 +49,9 @@ export function ActorItem({ actor, isSelected, onToggle, multi = true }: ActorIt
     onToggle(actor.actorId)
   }
   const iconId =
-    actor.type === 'user' || actor.type === 'agent' || actor.type === 'system' ? 'user' : 'group'
+    actor.type === 'worker' && actor.workerType === 'team'
+      ? 'group'
+      : (GLYPH_BY_ACTOR_TYPE[actor.type] ?? 'user')
 
   return (
     <CommandItem

--- a/apps/web/src/components/pickers/actor-picker/actor-picker-content.tsx
+++ b/apps/web/src/components/pickers/actor-picker/actor-picker-content.tsx
@@ -48,7 +48,20 @@ export interface ActorPickerContentProps {
   /** Called when selection changes */
   onChange: (selected: ActorId[]) => void
 
-  /** Actor target: 'user', 'group', 'agent', 'worker', 'both', or 'all' (default: 'both') */
+  /**
+   * Actor target: 'user', 'group', 'agent', 'worker', 'both', or 'all'
+   * (default: 'both').
+   *
+   * There is deliberately **no `'profile'` target.** Permission profiles are a
+   * `ResourceAccess`/`PermissionGrant` grantee kind, not actors: the actor
+   * service cannot resolve a `profile:` id to a name or avatar, and
+   * profile-grantee `ResourceAccess` writes are still refused server-side
+   * (`assertProfileGranteeSupported`, plan 19 step 9). Adding the option before
+   * both land would ship a picker entry whose every selection renders "Unknown"
+   * and then 400s on save. Every "add grantee" surface funnels through here, so
+   * profile grantees are explicitly **unsupported in all pickers** for now; doc
+   * 19 §7's Profiles editor is where profile-scoped access is authored.
+   */
   target?: 'user' | 'group' | 'agent' | 'worker' | 'both' | 'all'
 
   /**
@@ -211,15 +224,28 @@ export function ActorPickerContent({
     })
   }, [search, searchResults, storeActors, wasInitiallySelected, excludeIds])
 
-  // Group available items by type
+  /**
+   * Group available items by type. The buckets are **exhaustive**: anything the
+   * four named sections don't claim lands in `others` instead of disappearing.
+   * The previous four filters silently dropped every unbucketed kind — today the
+   * org's `system` actor, tomorrow anything the actor union gains — which made
+   * `target='all'` quietly not mean "all".
+   */
   const groupedAvailable = useMemo(() => {
-    const users = availableItems.filter((a) => a.type === 'user')
-    const agents = availableItems.filter(
-      (a) => a.type === 'agent' && (!agentFilter || agentFilter(a.actorId))
-    )
-    const groups = availableItems.filter((a) => a.type === 'group')
-    const workers = availableItems.filter((a) => a.type === 'worker')
-    return { users, agents, groups, workers }
+    const users: Actor[] = []
+    const agents: Actor[] = []
+    const groups: Actor[] = []
+    const workers: Actor[] = []
+    const others: Actor[] = []
+    for (const actor of availableItems) {
+      if (actor.type === 'user') users.push(actor)
+      else if (actor.type === 'agent') {
+        if (!agentFilter || agentFilter(actor.actorId)) agents.push(actor)
+      } else if (actor.type === 'group') groups.push(actor)
+      else if (actor.type === 'worker') workers.push(actor)
+      else others.push(actor)
+    }
+    return { users, agents, groups, workers, others }
   }, [availableItems, agentFilter])
 
   /**
@@ -267,8 +293,10 @@ export function ActorPickerContent({
     groupedAvailable.groups.length > 0
   const hasWorkersSection =
     (target === 'worker' || target === 'all') && groupedAvailable.workers.length > 0
+  // Only `all` promises everything, so only `all` renders the catch-all bucket.
+  const hasOthersSection = target === 'all' && groupedAvailable.others.length > 0
   const hasResultsSection =
-    hasUsersSection || hasAgentsSection || hasGroupsSection || hasWorkersSection
+    hasUsersSection || hasAgentsSection || hasGroupsSection || hasWorkersSection || hasOthersSection
   const showGroupHeadings = target === 'both' || target === 'all'
 
   return (
@@ -367,6 +395,22 @@ export function ActorPickerContent({
         {hasWorkersSection && (
           <CommandGroup heading={showGroupHeadings ? 'Workers' : undefined} aria-label='Workers'>
             {groupedAvailable.workers.map((actor) => (
+              <ActorItem
+                key={actor.actorId}
+                actor={actor}
+                isSelected={isSelected(actor.actorId)}
+                onToggle={handleToggle}
+                multi={multi}
+              />
+            ))}
+          </CommandGroup>
+        )}
+
+        {/* Catch-all for kinds the four sections above don't claim (e.g. the
+            org's system actor), so `target='all'` never silently omits one. */}
+        {hasOthersSection && (
+          <CommandGroup heading={showGroupHeadings ? 'Other' : undefined} aria-label='Other'>
+            {groupedAvailable.others.map((actor) => (
               <ActorItem
                 key={actor.actorId}
                 actor={actor}

--- a/apps/web/src/components/resources/hooks/use-resource-access.ts
+++ b/apps/web/src/components/resources/hooks/use-resource-access.ts
@@ -4,8 +4,9 @@
 
 import { ResourceGranteeType } from '@auxx/database/enums'
 import type { ResourceAccessInfo } from '@auxx/lib/resource-access'
-import { type ActorId, toActorId } from '@auxx/types/actor'
+import type { ActorId } from '@auxx/types/actor'
 import { useMemo } from 'react'
+import { granteeToActorId, type UnmanageableGrant } from '~/components/permissions/utils/grantee'
 import { api } from '~/trpc/react'
 
 interface UseResourceAccessOptions {
@@ -24,6 +25,13 @@ interface UseResourceAccessResult {
   groupIds: string[]
   /** User grantee IDs only */
   userIds: string[]
+  /**
+   * Grants with no ActorId representation — `role` baselines, and `profile`
+   * grants (plan 19 §8.2). Callers that show a count or an "is this shared?"
+   * affordance must consult this alongside {@link granteeActorIds}, or a live
+   * grant reads as "not shared with anyone".
+   */
+  unmanageableGrants: UnmanageableGrant[]
   /** Loading state */
   isLoading: boolean
   /** Invalidate and refetch */
@@ -44,22 +52,32 @@ export function useResourceAccess({
     { enabled: enabled && !!recordId }
   )
 
-  const { granteeActorIds, groupIds, userIds } = useMemo(() => {
+  const { granteeActorIds, groupIds, userIds, unmanageableGrants } = useMemo(() => {
     const actorIds: ActorId[] = []
     const groups: string[] = []
     const users: string[] = []
+    const unmanageable: UnmanageableGrant[] = []
 
+    // Exhaustive by construction: `granteeToActorId` returns `null` for every
+    // kind with no actor, and that branch is now an explicit `else` rather than
+    // the absent one an `if group … else if user …` chain left behind.
     for (const grant of grants) {
-      if (grant.granteeType === ResourceGranteeType.group) {
-        actorIds.push(toActorId('group', grant.granteeId))
-        groups.push(grant.granteeId)
-      } else if (grant.granteeType === ResourceGranteeType.user) {
-        actorIds.push(toActorId('user', grant.granteeId))
-        users.push(grant.granteeId)
+      const actorId = granteeToActorId(grant.granteeType, grant.granteeId)
+      if (!actorId) {
+        unmanageable.push({ granteeType: grant.granteeType, granteeId: grant.granteeId })
+        continue
       }
+      actorIds.push(actorId)
+      if (grant.granteeType === ResourceGranteeType.group) groups.push(grant.granteeId)
+      else users.push(grant.granteeId)
     }
 
-    return { granteeActorIds: actorIds, groupIds: groups, userIds: users }
+    return {
+      granteeActorIds: actorIds,
+      groupIds: groups,
+      userIds: users,
+      unmanageableGrants: unmanageable,
+    }
   }, [grants])
 
   const refetch = () => utils.resourceAccess.forInstance.invalidate({ recordId })
@@ -69,6 +87,7 @@ export function useResourceAccess({
     granteeActorIds,
     groupIds,
     userIds,
+    unmanageableGrants,
     isLoading,
     refetch,
   }

--- a/apps/web/src/components/resources/store/actor-store.ts
+++ b/apps/web/src/components/resources/store/actor-store.ts
@@ -3,11 +3,11 @@
 'use client'
 
 import type { Actor, ActorId, ActorType } from '@auxx/types/actor'
-import { parseActorId } from '@auxx/types/actor'
 import type { GroupMember } from '@auxx/types/groups'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
+import { tryParseActorId } from '../utils/actor-id'
 
 /** Batch configuration */
 const BATCH_DELAY = 50
@@ -235,14 +235,14 @@ export const useActorStore = create<ActorStoreState>()(
       removeActor: (actorId) =>
         set((state) => {
           state.actors.delete(actorId)
-          // If it's a group, also clear its members
-          try {
-            const { type, id } = parseActorId(actorId)
-            if (type === 'group') {
-              state.groupMembers.delete(id)
-            }
-          } catch {
-            // Invalid ActorId, skip
+          // If it's a group, also clear its members. Parsed with the non-throwing
+          // helper: `parseActorId` throws for any prefix outside its whitelist, so
+          // this used a bare `catch {}` — which silently swallowed genuinely
+          // malformed ids alongside merely-unmodelled ones. Now neither throws and
+          // a non-group id simply has no member cache to clear.
+          const parsed = tryParseActorId(actorId)
+          if (parsed?.type === 'group') {
+            state.groupMembers.delete(parsed.id)
           }
         }),
 

--- a/apps/web/src/components/resources/ui/actor-badge.tsx
+++ b/apps/web/src/components/resources/ui/actor-badge.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import type { ActorId, ActorType } from '@auxx/types/actor'
-import { isWorkerActor, parseActorId } from '@auxx/types/actor'
+import { isWorkerActor } from '@auxx/types/actor'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
@@ -11,6 +11,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { Bot, Cog, User, Users, X } from 'lucide-react'
 
 import { useActor } from '~/components/resources/hooks/use-actor'
+import { actorAvatarType } from '~/components/resources/utils/actor-id'
 
 /**
  * The avatar-only half of an {@link ActorBadge}: the image with a type-aware
@@ -136,8 +137,12 @@ export function ActorBadge({
 }: ActorBadgeProps) {
   const { actor, isLoading, isNotFound } = useActor({ actorId, enabled: !!actorId })
 
-  // Prefer the resolved actor type (which may be 'system'); fall back to ID prefix during load.
-  const type = actor?.type ?? (actorId ? parseActorId(actorId).type : 'user')
+  // Prefer the resolved actor type (which may be 'system'); fall back to the id
+  // prefix during load, and to the neutral person glyph for a prefix the actor
+  // system does not model (`profile:` — plan 19 §8.2 — or the filter-builder's
+  // `placeholder:currentUser` sentinel). `parseActorId` THREW for both, taking
+  // the whole render tree down instead of degrading this one badge.
+  const type = actorAvatarType(actorId, actor?.type)
 
   // Determine display name: name → email (for users) → 'Unknown'
   const displayName = isNotFound

--- a/apps/web/src/components/resources/ui/actor-stack.tsx
+++ b/apps/web/src/components/resources/ui/actor-stack.tsx
@@ -2,9 +2,9 @@
 'use client'
 
 import type { ActorId } from '@auxx/types/actor'
-import { parseActorId } from '@auxx/types/actor'
 import { cn } from '@auxx/ui/lib/utils'
 import { useActor } from '~/components/resources/hooks/use-actor'
+import { actorAvatarType } from '~/components/resources/utils/actor-id'
 import { ActorAvatar } from './actor-badge'
 
 export interface ActorStackProps {
@@ -19,7 +19,10 @@ export interface ActorStackProps {
 /** One resolved avatar (resolves type/avatarUrl from the actor store). */
 function StackAvatar({ actorId, size }: { actorId: ActorId; size: string }) {
   const { actor } = useActor({ actorId })
-  const type = actor?.type ?? parseActorId(actorId).type
+  // Same crash shape as `grantee-list`/`actor-badge`: this stack renders grantee
+  // ActorIds straight from `resourceAccess.forInstance`, so one row on a kind the
+  // actor system doesn't model threw out of `parseActorId` mid-render.
+  const type = actorAvatarType(actorId, actor?.type)
   return (
     <ActorAvatar
       type={type}

--- a/apps/web/src/components/resources/utils/actor-id.ts
+++ b/apps/web/src/components/resources/utils/actor-id.ts
@@ -1,0 +1,57 @@
+// apps/web/src/components/resources/utils/actor-id.ts
+
+import { type ActorId, type ActorType, isActorIdType } from '@auxx/types/actor'
+
+/** A split ActorId whose prefix has NOT been validated against the whitelist. */
+export interface LooseActorId {
+  /** The raw prefix. May be a kind the actor system cannot resolve. */
+  type: string
+  /** The id half — everything after the first colon. */
+  id: string
+}
+
+/**
+ * Split `<prefix>:<id>` without validating the prefix. Returns `null` for an
+ * empty, colon-less, or empty-half value. Never throws, whatever `parseActorId`
+ * does with an unknown prefix.
+ */
+export function tryParseActorId(value: string | null | undefined): LooseActorId | null {
+  if (!value) return null
+  const colon = value.indexOf(':')
+  if (colon <= 0) return null
+  const id = value.slice(colon + 1)
+  if (!id) return null
+  return { type: value.slice(0, colon), id }
+}
+
+/**
+ * The prefix narrowed to a known actor kind, or `undefined` when the value is
+ * malformed or names a kind outside `ACTOR_ID_TYPES`.
+ *
+ * The vocabulary comes from `@auxx/types/actor` rather than a local copy:
+ * duplicating that list in three places is precisely what made an unlisted
+ * prefix white-screen render paths (19a finding 5). Only the *throwing* half of
+ * that module is avoided here — `isActorIdType` is a total predicate, so a
+ * non-actor value like the `placeholder:currentUser` filter sentinel still
+ * degrades to `undefined` instead of throwing.
+ */
+export function tryActorIdType(value: string | null | undefined): ActorType | undefined {
+  const parsed = tryParseActorId(value)
+  if (!parsed) return undefined
+  return isActorIdType(parsed.type) ? parsed.type : undefined
+}
+
+/**
+ * The glyph type for an actor row: the resolved actor's own type when hydration
+ * has landed, else the id prefix, else the neutral person glyph.
+ *
+ * This is the safe replacement for `actor?.type ?? parseActorId(id).type`, which
+ * throws — during load, when the actor has not resolved yet — for any id whose
+ * prefix is outside the whitelist.
+ */
+export function actorAvatarType(
+  actorId: ActorId | string | undefined,
+  resolved?: ActorType
+): ActorType {
+  return resolved ?? tryActorIdType(actorId) ?? 'user'
+}

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -319,7 +319,9 @@ export const SETTINGS_MENU: SidebarProps[] = [
         label: 'Permissions',
         slug: 'permissions',
         icon: <ShieldCheck />,
-        // `permissions` area stays adminOnly (granting the grant is an escalation).
+        // The `permissions` area is grantable since doc 19 §0.25, but every
+        // router behind this page is still a binary `adminProcedure` (the area
+        // is `roleGated`), so the nav entry stays ADMIN-only until §5.3 piece 3.
         access: 'ADMIN',
         keywords: ['roles', 'access', 'sharing', 'sso', 'saml', 'policy'],
       },

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -34,6 +34,9 @@ const EMPTY_CAPS: ClientCapabilities = {
   restrictedEntityDefIds: [],
   role: 'USER',
   seatType: 'full',
+  // No profile is bound in the no-org case, so there is no definition ceiling to
+  // apply — every gate already denies via the empty key set.
+  ceilingDefs: null,
 }
 
 /** Shape of the capabilities context value. */

--- a/apps/web/src/server/api/grantee-schema.test.ts
+++ b/apps/web/src/server/api/grantee-schema.test.ts
@@ -1,0 +1,78 @@
+// apps/web/src/server/api/grantee-schema.test.ts
+
+import { ResourceGranteeType, ResourceGranteeTypeValues } from '@auxx/database/enums'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCachedPermissionProfiles = vi.fn()
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedPermissionProfiles: (...args: unknown[]) => getCachedPermissionProfiles(...args),
+}))
+
+import { assertProfileGranteesAuthorable, granteeTypeSchema } from './grantee-schema'
+
+const humanProfile = { id: 'p_member', name: 'Member', appliesTo: 'member' }
+const anyProfile = { id: 'p_any', name: 'Anyone', appliesTo: 'any' }
+const agentProfile = { id: 'p_agent', name: 'Chat agent', appliesTo: 'agent' }
+
+beforeEach(() => {
+  getCachedPermissionProfiles.mockReset()
+  getCachedPermissionProfiles.mockResolvedValue([humanProfile, anyProfile, agentProfile])
+})
+
+describe('granteeTypeSchema', () => {
+  it('accepts the full ResourceGranteeType vocabulary — no kind is silently missing', () => {
+    for (const value of ResourceGranteeTypeValues) {
+      expect(granteeTypeSchema.parse(value)).toBe(value)
+    }
+  })
+
+  it('accepts profile (doc 19 §0.1 / §0.28 — a profile is an additive grantee)', () => {
+    expect(granteeTypeSchema.parse(ResourceGranteeType.profile)).toBe('profile')
+  })
+
+  it('still rejects a kind outside the enum', () => {
+    expect(() => granteeTypeSchema.parse('everyone')).toThrow()
+  })
+})
+
+describe('assertProfileGranteesAuthorable', () => {
+  it('does nothing for the non-profile kinds (and costs no cache read)', async () => {
+    for (const granteeType of ['group', 'user', 'team', 'role'] as const) {
+      await expect(
+        assertProfileGranteesAuthorable('org1', granteeType, ['whatever'])
+      ).resolves.toBeUndefined()
+    }
+    expect(getCachedPermissionProfiles).not.toHaveBeenCalled()
+  })
+
+  it('allows a member-bindable profile', async () => {
+    await expect(
+      assertProfileGranteesAuthorable('org1', ResourceGranteeType.profile, ['p_member', 'p_any'])
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects an unknown profile id — the row would restrict without granting', async () => {
+    await expect(
+      assertProfileGranteesAuthorable('org1', ResourceGranteeType.profile, ['p_gone'])
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('rejects an agent profile — agents never read ResourceAccess', async () => {
+    await expect(
+      assertProfileGranteesAuthorable('org1', ResourceGranteeType.profile, ['p_agent'])
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('rejects when ANY id in a set-style batch is unauthorable', async () => {
+    await expect(
+      assertProfileGranteesAuthorable('org1', ResourceGranteeType.profile, ['p_member', 'p_agent'])
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('is a no-op for an empty grant list (the "clear all rows" call)', async () => {
+    await expect(
+      assertProfileGranteesAuthorable('org1', ResourceGranteeType.profile, [])
+    ).resolves.toBeUndefined()
+    expect(getCachedPermissionProfiles).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/server/api/grantee-schema.ts
+++ b/apps/web/src/server/api/grantee-schema.ts
@@ -1,0 +1,68 @@
+// apps/web/src/server/api/grantee-schema.ts
+
+import { ResourceGranteeType } from '@auxx/database/enums'
+import { getCachedPermissionProfiles } from '@auxx/lib/cache'
+import { BadRequestError } from '@auxx/lib/errors'
+import { z } from 'zod'
+
+/**
+ * The grantee vocabulary a `ResourceAccess` write endpoint accepts — ONE schema
+ * shared by every sharing router, instead of the eight divergent copies the tree
+ * used to carry (doc 19 §8.2 and `19a` sites 15 + 17; the copy nobody had noticed
+ * sat on `resourceAccess.setType`, which the whole def-Access UI writes through).
+ *
+ * `profile` is included. Doc 19 §0.1 keeps human per-def and shared per-instance
+ * grants as `ResourceAccess` rows, and §0.28 makes the profile selectable as an
+ * additive grantee. This is deliberately the FULL `ResourceGranteeType` and not
+ * `SharingGranteeType`: that narrower union exists so surfaces which *cannot*
+ * resolve a profile never hand one to a router — these routers now can.
+ *
+ * Writes still fail downstream until `resource-access-service.ts` drops its
+ * step-9 profile guard. That ordering is intentional, not a bug.
+ */
+export const granteeTypeSchema = z.enum([
+  ResourceGranteeType.group,
+  ResourceGranteeType.user,
+  ResourceGranteeType.team,
+  ResourceGranteeType.role,
+  ResourceGranteeType.profile,
+])
+
+/**
+ * Reject a `profile` grantee that cannot actually carry a sharing grant.
+ *
+ * Two failure modes, both silent without this check:
+ * - **Unknown id** — a row keyed on a profile that does not exist grants nobody,
+ *   yet still flips the def/instance into the grantee-agnostic *restricted* set
+ *   (`19a` finding 1), so it takes access away instead of adding it.
+ * - **An agent profile** (`appliesTo: 'agent'`) — agents resolve capabilities from
+ *   `AgentVersion.permissionPolicy` through `AgentPolicyCapabilities` and never
+ *   read `ResourceAccess` (doc 19 §0.1, §2.3). Such a row is inert: a control that
+ *   looks like it works and does nothing. Agent authority is authored on the
+ *   profile's own `agentPolicy`, never through a sharing router.
+ *
+ * Reads and revokes deliberately skip this — a row left behind by a deleted or
+ * repurposed profile must stay listable and cleanable.
+ *
+ * Costs nothing for the non-profile kinds (early return) and one org-cache hit
+ * otherwise; `profiles` is already cached for capability composition (§8.1).
+ */
+export async function assertProfileGranteesAuthorable(
+  organizationId: string,
+  granteeType: ResourceGranteeType,
+  granteeIds: string[]
+): Promise<void> {
+  if (granteeType !== ResourceGranteeType.profile || granteeIds.length === 0) return
+  const profiles = await getCachedPermissionProfiles(organizationId)
+  for (const granteeId of granteeIds) {
+    const profile = profiles.find((p) => p.id === granteeId)
+    if (!profile) {
+      throw new BadRequestError('Permission profile not found')
+    }
+    if (profile.appliesTo === 'agent') {
+      throw new BadRequestError(
+        `"${profile.name}" is an agent profile. Agent access is authored on the profile itself, not by sharing a resource with it.`
+      )
+    }
+  }
+}

--- a/apps/web/src/server/api/routers/entityGroup.ts
+++ b/apps/web/src/server/api/routers/entityGroup.ts
@@ -1,15 +1,11 @@
 // apps/web/src/server/api/routers/entityGroup.ts
 
-import {
-  GroupVisibility,
-  MemberType,
-  ResourceGranteeType,
-  ResourcePermission,
-} from '@auxx/database/enums'
+import { GroupVisibility, MemberType, ResourcePermission } from '@auxx/database/enums'
 import * as groups from '@auxx/lib/groups'
 import type { GroupContext } from '@auxx/types/groups'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '../audit-context'
+import { assertProfileGranteesAuthorable, granteeTypeSchema } from '../grantee-schema'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
 
 /**
@@ -223,12 +219,7 @@ export const entityGroupRouter = createTRPCRouter({
     .input(
       z.object({
         groupId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         granteeId: z.string(),
         permission: z.enum([
           ResourcePermission.view,
@@ -239,6 +230,9 @@ export const entityGroupRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const groupCtx = toGroupContext(ctx)
+      await assertProfileGranteesAuthorable(ctx.session.organizationId, input.granteeType, [
+        input.granteeId,
+      ])
       const result = await groups.grantPermission(groupCtx, input)
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -259,12 +253,7 @@ export const entityGroupRouter = createTRPCRouter({
     .input(
       z.object({
         groupId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         granteeId: z.string(),
       })
     )

--- a/apps/web/src/server/api/routers/permissions-member-baseline.test.ts
+++ b/apps/web/src/server/api/routers/permissions-member-baseline.test.ts
@@ -181,8 +181,12 @@ describe('the ResourceAccess baseline path is untouched', () => {
   })
 
   it('the resourceAccess router still accepts the role grantee', () => {
+    // Doc 19 step 9 collapsed the router's six copies of the grantee enum into
+    // one shared schema, so the marker now lives there — the router must still
+    // parse with it, and must still not route through the PermissionGrant bridge.
+    expect(read('server/api/grantee-schema.ts')).toContain('ResourceGranteeType.role')
     const src = read('server/api/routers/resourceAccess.ts')
-    expect(src).toContain('ResourceGranteeType.role')
+    expect(src).toContain('granteeTypeSchema')
     expect(src).not.toContain('permissions-member-baseline')
   })
 

--- a/apps/web/src/server/api/routers/permissions.ts
+++ b/apps/web/src/server/api/routers/permissions.ts
@@ -1,17 +1,22 @@
 // apps/web/src/server/api/routers/permissions.ts
 
+import { getCachedPermissionProfiles } from '@auxx/lib/cache'
 import {
   type Area,
   clearGranteeLevels,
+  createPermissionProfile,
   getCapabilities,
   Level,
   listGranteeGrants,
+  PermissionKey,
+  type ProfileCeiling,
   ROLE_DEFAULTS,
+  savePermissionProfile,
   setGranteeLevels,
 } from '@auxx/lib/permissions'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { adminProcedure, createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
 import { bridgeMemberBaselineGrants, resolveGrantGrantee } from './permissions-member-baseline'
 
 /**
@@ -34,11 +39,48 @@ const granteeType = z.enum(['role', 'group', 'user'])
  */
 const levelsInput = z.record(z.string(), z.coerce.number().int().min(Level.None).max(Level.Full))
 
+/** A profile's own intrinsic cap (§0.13/§0.14) — areas plus the def allow/deny list. */
+const ceilingInput = z
+  .object({
+    areas: levelsInput.optional(),
+    defs: z.object({ mode: z.enum(['only', 'except']), slugs: z.array(z.string()) }).nullish(),
+  })
+  .nullable()
+
+/** Profile identity chrome (§7): an icon id + colour token, or nothing. */
+const iconInput = z.object({ iconId: z.string(), color: z.string() }).nullable()
+
 /**
- * Thin write/read surface for Layer-2 capability grants — enough to exercise
- * enforcement before the v2 permissions settings page ships (§2.J). Grant/revoke
- * are admin-only and delegate to the functional grant-service (which validates
- * the levels, applies the `granularPermissions` plan gate, and busts caches).
+ * The Layer-2 gate for this router: the `permissions` area itself.
+ *
+ * Doc 19 §0.25 makes `permissions` grantable (it was `adminOnly`), which is only
+ * true if the routers behind it stop being binary `adminProcedure` checks —
+ * otherwise the area renders as a lever that does nothing. OWNER/ADMIN still pass
+ * unconditionally: they hold every key through `ROLE_DEFAULTS`, so this is strictly
+ * wider than the `adminProcedure` it replaces, never narrower.
+ *
+ * Deliberately capability-ONLY, with no `FeatureKey.granularPermissions` check:
+ * §0.26 plan-gates profile **writes** and never composition or reads. The write
+ * gate lives in `savePermissionProfile` / `createPermissionProfile` /
+ * `setGranteeLevels` (and pointedly NOT in `clearGranteeLevels` — removal only
+ * tightens, so a downgraded org must still be able to clean up). Using
+ * `permissionProcedure(permissionsManage)` here would hoist that plan check onto
+ * every read and every revoke, which is exactly the §0.26 failure mode.
+ */
+const permissionsProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  const capabilities = await getCapabilities(ctx.session.userId, ctx.session.organizationId)
+  capabilities.assert(PermissionKey.permissionsManage)
+  return next({ ctx: { capabilities } })
+})
+
+/**
+ * Thin write/read surface for Layer-2 capability grants and permission profiles.
+ * Every procedure below (except `myCapabilities`, which is every member's own
+ * snapshot) is gated on the `permissions` area via {@link permissionsProcedure};
+ * the grant/revoke pair delegates to the functional grant-service (which validates
+ * the levels, applies the `granularPermissions` plan gate, and busts caches) and
+ * the profile pair to `profiles/profile-save.ts`, which runs the §6.1 escalation
+ * guard inside its own transaction.
  *
  * TODO(plan-19-step-7): the org-wide member baseline is addressed by the shipped
  * client as `role:org_member`, a `PermissionGrant` tier step 2 deleted. Both
@@ -66,7 +108,7 @@ export const permissionsRouter = createTRPCRouter({
    * The USER role's per-area level defaults — the informational baseline the
    * settings page shows beside each editable area (what admins deviate from).
    */
-  roleDefaults: adminProcedure.query(() => ROLE_DEFAULTS.USER),
+  roleDefaults: permissionsProcedure.query(() => ROLE_DEFAULTS.USER),
 
   /**
    * Every stored grant row for the org (the member baseline + group + user
@@ -77,7 +119,7 @@ export const permissionsRouter = createTRPCRouter({
    * `role:org_member` so the shipped baseline tab reads back exactly what the
    * redirected write stored — see `permissions-member-baseline.ts`.
    */
-  listGrants: adminProcedure.query(async ({ ctx }) => {
+  listGrants: permissionsProcedure.query(async ({ ctx }) => {
     const rows = await listGranteeGrants(ctx.session.organizationId, ctx.db)
     const grants = await bridgeMemberBaselineGrants(ctx.session.organizationId, rows)
     return { grants }
@@ -89,7 +131,7 @@ export const permissionsRouter = createTRPCRouter({
    * TODO(plan-19-step-7): a `role:org_member` target is redirected onto the org's
    * `member` profile — the only tier the composer reads (§0.8).
    */
-  grant: adminProcedure
+  grant: permissionsProcedure
     .input(
       z.object({
         granteeType,
@@ -131,7 +173,7 @@ export const permissionsRouter = createTRPCRouter({
    * Remove the grant row for one grantee. A `role:org_member` target is
    * redirected the same way as {@link permissionsRouter.grant}.
    */
-  revoke: adminProcedure
+  revoke: permissionsProcedure
     .input(
       z.object({
         granteeType,
@@ -157,5 +199,120 @@ export const permissionsRouter = createTRPCRouter({
       })
 
       return { removed }
+    }),
+
+  /**
+   * Every permission profile in the org (system + custom), off the cached
+   * `profiles` projection — the same rows `computeUserCapabilities` composes from,
+   * so the editor can never show a profile the composer does not read.
+   *
+   * A READ, therefore **not** plan-gated (§0.26): a Free org must still be able to
+   * see the system profiles supplying its `ROLE_DEFAULTS`, it simply cannot edit
+   * them.
+   */
+  listProfiles: permissionsProcedure.query(async ({ ctx }) => {
+    const profiles = await getCachedPermissionProfiles(ctx.session.organizationId)
+    return { profiles }
+  }),
+
+  /**
+   * Create a custom profile. `seat` / `appliesTo` are accepted here and nowhere
+   * else — they are immutable after creation (§0.18).
+   *
+   * No escalation guard: a brand-new profile has no holders, so the §6.1
+   * resulting-state comparison is vacuous. The authority check bites on the first
+   * save that gives it content and on assignment (step 8).
+   */
+  createProfile: permissionsProcedure
+    .input(
+      z.object({
+        slug: z.string().min(1).max(64),
+        name: z.string().min(1).max(120),
+        description: z.string().max(500).nullish(),
+        icon: iconInput.optional(),
+        seat: z.enum(['full', 'worker']).optional(),
+        appliesTo: z.enum(['member', 'agent', 'any']).optional(),
+        baseLevel: z.number().int().min(Level.None).max(Level.Full).nullish(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const profile = await createPermissionProfile({
+        db: ctx.db,
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        slug: input.slug,
+        name: input.name,
+        description: input.description ?? null,
+        icon: input.icon ?? null,
+        seat: input.seat,
+        appliesTo: input.appliesTo,
+        baseLevel: input.baseLevel ?? null,
+      })
+
+      await recordAuditFromCtx(ctx, {
+        category: 'members',
+        action: 'permission.profile.created',
+        targetType: 'PermissionProfile',
+        targetId: profile.id,
+        newState: { slug: profile.slug, name: profile.name, seat: profile.seat },
+      })
+
+      return profile
+    }),
+
+  /**
+   * The ONE transactional profile save (§6.1.4) — metadata, area levels and the
+   * ceiling in a single mutation, because a save spanning several requests cannot
+   * enforce one atomic "resulting effective state" check. There is deliberately no
+   * metadata-only side door.
+   *
+   * `savePermissionProfile` owns the gates: the `granularPermissions` plan gate
+   * (writes only), cross-org ownership, `owner`-profile immutability, the
+   * OWNER/ADMIN-only rule for agent profiles, `assertGrantableLevels`, and the
+   * §6.1 escalation guard over every affected holder's post-write state.
+   */
+  saveProfile: permissionsProcedure
+    .input(
+      z.object({
+        profileId: z.string(),
+        name: z.string().min(1).max(120).optional(),
+        description: z.string().max(500).nullish(),
+        icon: iconInput.optional(),
+        levels: levelsInput.nullish(),
+        baseLevel: z.number().int().min(Level.None).max(Level.Full).nullish(),
+        ceiling: ceilingInput.optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const profile = await savePermissionProfile({
+        db: ctx.db,
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        profileId: input.profileId,
+        name: input.name,
+        description: input.description,
+        icon: input.icon,
+        // Coerced `Record<string, number>` maps; `parseAreaLevels` inside the save
+        // is the real gate (drops unknown areas, clamps each value).
+        levels: input.levels as Partial<Record<Area, Level>> | null | undefined,
+        baseLevel: input.baseLevel as Level | null | undefined,
+        ceiling: input.ceiling as ProfileCeiling | null | undefined,
+      })
+
+      await recordAuditFromCtx(ctx, {
+        category: 'members',
+        action: 'permission.profile.updated',
+        targetType: 'PermissionProfile',
+        targetId: profile.id,
+        newState: {
+          slug: profile.slug,
+          name: profile.name,
+          levels: input.levels ?? undefined,
+          baseLevel: input.baseLevel ?? undefined,
+          ceiling: input.ceiling ?? undefined,
+        },
+      })
+
+      return profile
     }),
 })

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/resourceAccess.ts
 
-import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { ResourcePermission } from '@auxx/database/enums'
 import { BadRequestError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import { getCapabilities, isInstanceAccessKey } from '@auxx/lib/permissions'
@@ -27,6 +27,7 @@ import { parseRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
+import { assertProfileGranteesAuthorable, granteeTypeSchema } from '~/server/api/grantee-schema'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
 
 /** Visibility lens on mail grants (mail-permissions §2.1). Optional everywhere. */
@@ -97,12 +98,7 @@ export const resourceAccessRouter = createTRPCRouter({
     .input(
       z.object({
         recordId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         granteeId: z.string(),
         // `none` is accepted only as the workspace-baseline (`role:org_member`)
         // downward marker for instance-access resources (datasets etc. — §1.4):
@@ -133,6 +129,9 @@ export const resourceAccessRouter = createTRPCRouter({
           'The "none" permission is only valid for instance-access resources'
         )
       }
+      await assertProfileGranteesAuthorable(ctx.session.organizationId, input.granteeType, [
+        input.granteeId,
+      ])
       if (!(await authorizeInstanceTarget(ctx, recordId))) {
         await assertCanManageMailSharing(context, recordId)
         await assertMailSharingFeature(context, recordId, [input])
@@ -169,12 +168,7 @@ export const resourceAccessRouter = createTRPCRouter({
     .input(
       z.object({
         entityDefinitionId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         granteeId: z.string(),
         permission: z.enum([
           ResourcePermission.none,
@@ -186,6 +180,9 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
+      await assertProfileGranteesAuthorable(ctx.session.organizationId, input.granteeType, [
+        input.granteeId,
+      ])
       await grantTypeAccess(toContext(ctx), input)
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -207,12 +204,7 @@ export const resourceAccessRouter = createTRPCRouter({
     .input(
       z.object({
         recordId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         granteeId: z.string(),
       })
     )
@@ -248,12 +240,7 @@ export const resourceAccessRouter = createTRPCRouter({
     .input(
       z.object({
         entityDefinitionId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         granteeId: z.string(),
       })
     )
@@ -279,12 +266,7 @@ export const resourceAccessRouter = createTRPCRouter({
     .input(
       z.object({
         recordId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         grants: z.array(
           z.object({
             granteeId: z.string(),
@@ -301,6 +283,11 @@ export const resourceAccessRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const context = toContext(ctx)
       const recordId = input.recordId as RecordId
+      await assertProfileGranteesAuthorable(
+        ctx.session.organizationId,
+        input.granteeType,
+        input.grants.map((g) => g.granteeId)
+      )
       if (!(await authorizeInstanceTarget(ctx, recordId))) {
         await assertCanManageMailSharing(context, recordId)
         await assertMailSharingFeature(context, recordId, input.grants)
@@ -322,12 +309,7 @@ export const resourceAccessRouter = createTRPCRouter({
     .input(
       z.object({
         entityDefinitionId: z.string(),
-        granteeType: z.enum([
-          ResourceGranteeType.group,
-          ResourceGranteeType.user,
-          ResourceGranteeType.team,
-          ResourceGranteeType.role,
-        ]),
+        granteeType: granteeTypeSchema,
         grants: z.array(
           z.object({
             granteeId: z.string(),
@@ -342,6 +324,11 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
+      await assertProfileGranteesAuthorable(
+        ctx.session.organizationId,
+        input.granteeType,
+        input.grants.map((g) => g.granteeId)
+      )
       await setTypeAccess(toContext(ctx), input.entityDefinitionId, input.granteeType, input.grants)
       await recordAuditFromCtx(ctx, {
         category: 'security',

--- a/apps/web/src/server/api/routers/snippet.ts
+++ b/apps/web/src/server/api/routers/snippet.ts
@@ -1,6 +1,6 @@
 // server/api/routers/snippets.ts
 
-import { SnippetSharingType } from '@auxx/database/enums'
+import { ResourceGranteeType, SnippetSharingType } from '@auxx/database/enums'
 import {
   createSnippet,
   createSnippetFolder,
@@ -10,11 +10,13 @@ import {
   incrementSnippetUsage,
   listSnippetFoldersWithCounts,
   listSnippetsForUser,
+  SNIPPET_SHARE_GRANTEE_TYPES,
   setSnippetSharing,
   updateSnippet,
   updateSnippetFolder,
 } from '@auxx/lib/snippets'
 import { z } from 'zod'
+import { assertProfileGranteesAuthorable } from '../grantee-schema'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
 
 /**
@@ -107,11 +109,14 @@ export const snippetsRouter = createTRPCRouter({
       z.object({
         snippetId: z.string(),
         sharingType: z.enum(SnippetSharingType),
-        // For CUSTOM sharing type - supports both groups and users
+        // For GROUPS sharing — the kinds the lib helper can actually store, which
+        // is the same list its per-type replace loop iterates (doc 19 §8.2 / 19a
+        // site 18). Derived from `SNIPPET_SHARE_GRANTEE_TYPES` so the schema can
+        // never drift from the writer again.
         shares: z
           .array(
             z.object({
-              granteeType: z.enum(['group', 'user']),
+              granteeType: z.enum(SNIPPET_SHARE_GRANTEE_TYPES),
               granteeId: z.string(),
               permission: z.enum(['VIEW', 'EDIT']).default('VIEW'),
             })
@@ -121,6 +126,13 @@ export const snippetsRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
+      await assertProfileGranteesAuthorable(
+        organizationId,
+        ResourceGranteeType.profile,
+        (input.shares ?? [])
+          .filter((s) => s.granteeType === ResourceGranteeType.profile)
+          .map((s) => s.granteeId)
+      )
       const result = await setSnippetSharing(
         ctx.db,
         organizationId,

--- a/packages/lib/src/actors/__tests__/actor-id.test.ts
+++ b/packages/lib/src/actors/__tests__/actor-id.test.ts
@@ -1,0 +1,81 @@
+// packages/lib/src/actors/__tests__/actor-id.test.ts
+
+import type { ActorId } from '@auxx/types/actor'
+import {
+  ACTOR_ID_TYPES,
+  getActorRawId,
+  getActorType,
+  isActorId,
+  isActorIdType,
+  parseActorId,
+  safeParseActorId,
+  toActorId,
+} from '@auxx/types/actor'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `@auxx/types` is not a vitest project, so the ActorId vocabulary is pinned from
+ * here — its nearest consumer. 19a finding 5: the whitelist used to be written out
+ * three times (the type alias plus a literal array in `parseActorId` and in
+ * `isActorId`), which is how a kind ends up type-legal but rejected at runtime.
+ */
+describe('ActorId vocabulary', () => {
+  it('covers every grantee kind the actor system addresses, including profile', () => {
+    expect([...ACTOR_ID_TYPES]).toEqual(['user', 'group', 'agent', 'worker', 'profile'])
+  })
+
+  it('round-trips every supported kind through toActorId/parseActorId', () => {
+    for (const type of ACTOR_ID_TYPES) {
+      const actorId = toActorId(type, 'abc123')
+      expect(actorId).toBe(`${type}:abc123`)
+      expect(parseActorId(actorId)).toEqual({ type, id: 'abc123' })
+      expect(safeParseActorId(actorId)).toEqual({ type, id: 'abc123' })
+      expect(isActorId(actorId)).toBe(true)
+      expect(isActorIdType(type)).toBe(true)
+      expect(getActorType(actorId)).toBe(type)
+      expect(getActorRawId(actorId)).toBe('abc123')
+    }
+  })
+
+  it('rejects a kind that is not in the vocabulary', () => {
+    expect(isActorIdType('team')).toBe(false)
+    expect(isActorIdType('role')).toBe(false)
+    expect(isActorId('team:t1')).toBe(false)
+    expect(isActorId('role:org_member')).toBe(false)
+  })
+})
+
+describe('safeParseActorId — degrade, never throw', () => {
+  // Render paths (actor-badge, grantee-list) must degrade to a generic row rather
+  // than white-screen when a grant carries a kind this build does not know.
+  const malformed = [
+    'nope:abc123', // unknown prefix — the forward-compat case
+    'abc123', // no colon
+    'user:', // empty id half
+    '', // empty string
+    null,
+    undefined,
+    42,
+    {},
+  ]
+
+  it('returns null for anything malformed or of an unknown kind', () => {
+    for (const value of malformed) {
+      expect(safeParseActorId(value)).toBeNull()
+    }
+  })
+
+  it('is the same parse as parseActorId, minus the throw', () => {
+    for (const value of malformed) {
+      expect(() => parseActorId(value as ActorId)).toThrow(/Invalid ActorId/)
+    }
+    expect(safeParseActorId('user:u1')).toEqual(parseActorId('user:u1' as ActorId))
+  })
+
+  it('splits on the FIRST colon, so an id containing a colon survives', () => {
+    expect(safeParseActorId('group:a:b')).toEqual({ type: 'group', id: 'a:b' })
+    // isActorId stays stricter on purpose — it is what rejects malformed agent
+    // tool-call arguments, where a 3-part shape is a caller bug.
+    expect(isActorId('group:a:b')).toBe(false)
+  })
+})

--- a/packages/lib/src/ai/agent-framework/index.ts
+++ b/packages/lib/src/ai/agent-framework/index.ts
@@ -31,6 +31,13 @@ export type {
 export { findOrCreateThreadSession } from './sessions/find-or-create-thread-session'
 export { executeToolCall } from './tool-bridge'
 export type { Subject, ToolContext, WorkflowToolContext } from './tool-context'
+export type {
+  AgentToolEnforcement,
+  AgentToolPermission,
+  AreaSlug,
+  UnmodeledPermissionDomain,
+} from './tool-permission'
+export { isUnenforcedToolPermission } from './tool-permission'
 
 export type {
   AgentDefinition,

--- a/packages/lib/src/ai/agent-framework/tool-permission.ts
+++ b/packages/lib/src/ai/agent-framework/tool-permission.ts
@@ -1,0 +1,139 @@
+// packages/lib/src/ai/agent-framework/tool-permission.ts
+
+import type { AgentAccessLevel } from '@auxx/database'
+import type { InstanceAccessKey } from '../../permissions/capabilities/instance-access'
+import type { Area } from '../../permissions/capabilities/registry'
+
+/**
+ * String form of the coarse Layer-2 capability {@link Area} enum, so a tool can
+ * declare `area: 'agents'` without a *runtime* import of `@auxx/lib/permissions`
+ * (this module is type-only on purpose — it must never add an import edge from a
+ * tool definition into the permissions barrel, which sits behind the
+ * realtime→cache→capabilities cycle). Still checked against the enum: a typo
+ * fails to compile.
+ */
+export type AreaSlug = `${Area}`
+
+/**
+ * Whether the requirement declared alongside it is actually asserted by the
+ * tool's `execute` **today**.
+ *
+ * - `'enforced'` — `execute` performs the check before doing the work (or
+ *   filters its output by it, which for a list tool is the same boundary).
+ * - `'unenforced'` — **KNOWN GAP**. The requirement is real; `execute` does not
+ *   check it. This is the greppable marker the audit exists for:
+ *   `grep -rn "enforcement: 'unenforced'" packages/lib/src` answers "which agent
+ *   tools are unauthorized?" without anyone re-reading a plan document. The
+ *   accompanying `note` must say why, and
+ *   `capabilities/__tests__/tool-permission-declarations.test.ts` pins the exact
+ *   set — adding one, or fixing one without delisting it, fails the suite.
+ */
+export type AgentToolEnforcement = 'enforced' | 'unenforced'
+
+type EnforcementState =
+  | { enforcement: 'enforced'; note?: string }
+  | { enforcement: 'unenforced'; note: string }
+
+/**
+ * Authorization domains that exist in the product but have **no target in the
+ * leveled permission model** (`Area` / entity definition / resource instance).
+ * A tool in one of these is not plumbing and must not be declared `'none'`.
+ *
+ * - `'mail'` — threads, drafts, tags and outbound sending. There is no `mail`
+ *   `Area`; visibility is a parallel system (`getCachedUserMailVisibility` +
+ *   `getThreadLens`, plans/permissions/v2/05-readside-visibility.md). Note that
+ *   every mail tool keys on `agentDeps.userId`, which per doc 14 §0.1 is always
+ *   the agent's own engine identity — so run-as substitution and the invoker
+ *   intersection are inert for this domain even where `enforcement` is
+ *   `'enforced'`.
+ * - `'tasks'` — the `Task` table via `TaskService`. Not an entity definition and
+ *   not an area; nothing gates it.
+ * - `'directory'` — workspace members and groups. `Area.members` exists but is a
+ *   Full-only ladder describing *managing* members; there is no read rung for a
+ *   directory lookup.
+ */
+export type UnmodeledPermissionDomain = 'mail' | 'tasks' | 'directory'
+
+/**
+ * The authorization contract of one agent tool — what its `execute` must check,
+ * and whether it actually does.
+ *
+ * **This is an audit record, not a runtime gate.** Nothing reads it to decide
+ * whether a call proceeds; the server-side assertion inside `execute` is still
+ * authoritative (plan 19 §2.4). Its job is to make the tool surface *machine
+ * checkable*: `plans/permissions/v2/19b-agent-tool-permission-audit.md` had to
+ * hand-sweep 60+ tools to discover that six agent-builder tools had no
+ * authorization at all, and that inventory started rotting the next PR. A
+ * declaration on the definition rots visibly instead.
+ *
+ * **Declare what the code does, not what it should do.** `level` on an
+ * `'enforced'` declaration names the check `execute` actually performs; on an
+ * `'unenforced'` one it names the requirement that is *missing*.
+ *
+ * **Orthogonal to G0.** Every `'enforced'` declaration describes behavior when
+ * `ToolDeps.capabilities` is present. Four runtime paths still pass
+ * `capabilities: undefined` deliberately (`workflow-engine/nodes/action-nodes/ai-v2.ts`
+ * and the three `approvals/*` runners, each carrying a `KNOWN GAP` comment), and
+ * on those paths every capability-backed check below is inert. That is a
+ * property of the call site, not of any tool, so it is not repeated per tool.
+ */
+export type AgentToolPermission =
+  /**
+   * Per entity **definition** — `canViewEntity` / `canEditEntity` /
+   * `canAdministerDef` off `ToolDeps.capabilities`. `level` maps to
+   * read → `canViewEntity`, read_write → `canEditEntity`, full →
+   * `canAdministerDef` (which has zero tool callers today — 19b G8).
+   */
+  | (EnforcementState & { target: 'definition'; level: AgentAccessLevel })
+  /**
+   * Per shared resource **instance** — `can*Instance(key, id)`. `keys` is a list
+   * because one tool may span several instance-access resource types in a single
+   * call (`search_knowledge` gates both `kb` and `dataset`).
+   */
+  | (EnforcementState & {
+      target: 'instance'
+      keys: readonly InstanceAccessKey[]
+      level: AgentAccessLevel
+    })
+  /**
+   * Coarse Layer-2 **area** — a `PermissionKey` read off the caller's own
+   * `CapabilityView` (`getCapabilities(...).can(key)`), expressed as the area +
+   * rung that key sits on.
+   */
+  | (EnforcementState & { target: 'area'; area: AreaSlug; level: AgentAccessLevel })
+  /**
+   * A real requirement in a domain the leveled model cannot name — see
+   * {@link UnmodeledPermissionDomain}. Deliberately NOT `'none'`: these tools
+   * touch workspace data, they just have no `Area` / definition / instance to
+   * bind to.
+   */
+  | (EnforcementState & {
+      target: 'unmodeled'
+      domain: UnmodeledPermissionDomain
+      level: AgentAccessLevel
+    })
+  /**
+   * An app- or MCP-backed **bridge** tool. Its effects live inside a third-party
+   * bundle or an external server, so the platform cannot classify them into a
+   * level at all. Authorization is the bridge's own model: install + toolset
+   * enablement + `requiresConnection` credential presence + `Agent.appAccounts`
+   * binding for apps; `readOnlyHint` + org-set `trusted` + the autonomous-run
+   * drop for MCP. Distinct from `'none'` so "unclassifiable" is never confused
+   * with "verified to need nothing".
+   */
+  | { target: 'bridge'; governedBy: 'app' | 'mcp'; note: string }
+  /**
+   * No authorization required — agent-loop plumbing that writes turn-local state,
+   * or a read of genuinely public data. `note` is mandatory: this is the value a
+   * careless author would reach for, so it must cost a sentence of justification.
+   */
+  | { target: 'none'; note: string }
+
+/**
+ * Whether a declaration records a known gap — a requirement the tool's `execute`
+ * does not actually assert. The one predicate the regression test and any future
+ * reporting surface should share.
+ */
+export function isUnenforcedToolPermission(permission: AgentToolPermission): boolean {
+  return 'enforcement' in permission && permission.enforcement === 'unenforced'
+}

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -7,6 +7,7 @@ import type { AgentSurface } from '../../agents/client'
 import type { Message, ModelParameters, Tool, ToolCall, UsageMetrics } from '../clients/base/types'
 import type { ContextManager } from './context/context-manager'
 import type { EvalFieldResolver, Subject, ToolContext, WorkflowToolContext } from './tool-context'
+import type { AgentToolPermission } from './tool-permission'
 
 // ===== CONTENT PARTS =====
 
@@ -373,6 +374,25 @@ export interface AgentToolDefinition {
    * gate. See plans/chat/v6/chat-tool-availability.md.
    */
   externalSafe?: boolean
+  /**
+   * The tool's authorization contract: what its `execute` must check, and
+   * whether it actually does today. See {@link AgentToolPermission}.
+   *
+   * Unlike `surfaces` / `category` / `externalSafe` — which are explicitly NOT
+   * security boundaries — this field *describes* the boundary. It is still not a
+   * runtime gate: nothing reads it to allow or deny a call, and the server-side
+   * assertion inside `execute` stays authoritative (plan 19 §2.4). It exists so
+   * the tool surface can be audited by machine instead of by hand-sweep, and so
+   * a tool that skips authorization has to say so in the PR that adds it.
+   *
+   * **Every tool registered through `ai/kopilot/capabilities/registry.ts` must
+   * declare one.** Optional on the type only because non-registry
+   * `AgentToolDefinition`s (procedure control signals, eval mock wrappers, test
+   * fixtures) construct the shape too; the registry-enumeration test in
+   * `ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts` is
+   * what makes it mandatory where it matters.
+   */
+  permission?: AgentToolPermission
   /**
    * Classifies the tool for UI visibility policy (see
    * `agents/tool-visibility.ts`). NOT a security boundary.

--- a/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
+++ b/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
@@ -88,17 +88,23 @@ function extractToolDecls(file: string): ToolDecl[] {
   // `name:` keys inside JSON Schema property descriptors (e.g. parseStringArg
   // args or zod schemas).
   const factoryRe = /return\s*\{\s*name:\s*['"]([a-z][a-z0-9_]*)['"]\s*,/g
+  const matches: Array<{ index: number; name: string }> = []
   let m: RegExpExecArray | null
   // biome-ignore lint/suspicious/noAssignInExpressions: classic regex loop
   while ((m = factoryRe.exec(src)) !== null) {
-    const name = m[1]
-    if (!name) continue
-    // Scan the next ~400 chars (within the same factory) for `toolsetSlug:`.
-    const window = src.slice(m.index, m.index + 600)
+    if (m[1]) matches.push({ index: m.index, name: m[1] })
+  }
+  for (const [i, match] of matches.entries()) {
+    // Scan from this factory's `return {` up to the NEXT factory in the file
+    // (or EOF). A fixed char budget was the old bound, but declaration blocks
+    // above `toolsetSlug` / `surfaces` — most recently `permission` (plan 19b
+    // G9) — pushed them past it, which silently reclassified a builder tool.
+    const end = matches[i + 1]?.index ?? src.length
+    const window = src.slice(match.index, end)
     const slugMatch = window.match(/\btoolsetSlug:\s*['"]([^'"]+)['"]/)
     out.push({
       file,
-      name,
+      name: match.name,
       toolsetSlug: slugMatch ? (slugMatch[1] ?? null) : null,
       builderSurface: /surfaces:\s*\[\s*['"]builder['"]\s*\]/.test(window),
     })

--- a/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
@@ -1,0 +1,273 @@
+// packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
+//
+// Plan 19 step 5 / 19b G9 — the anti-rot test for the agent tool permission audit.
+//
+// WHAT THIS PROVES
+//   1. Every tool registered through a native capability factory carries an
+//      `AgentToolPermission`. Fully static, non-negotiable: a new tool cannot
+//      reach the registry without stating its authorization contract.
+//   2. Each declaration is well-formed for its own target (an `instance` names
+//      real InstanceAccessKeys, an `area` names a real Area, an `unenforced`
+//      one carries a rationale). The type says most of this at compile time;
+//      this catches tools built at RUNTIME from external data — the app bridge
+//      and the MCP adapter — where the compiler never sees a literal.
+//   3. The known-gap set is EXACTLY pinned, both ways. A tool that starts
+//      declaring `enforcement: 'unenforced'` without being added below fails.
+//      A tool that gets FIXED and flips to `'enforced'` while still listed
+//      below also fails. That is the whole point: 19b's ranked gap list was
+//      prose in a plan document and started rotting the next PR; here it is a
+//      list the suite forces you to maintain.
+//   4. The `target: 'none'` set is pinned the same way — `'none'` is the value
+//      a careless author reaches for, so it may not grow silently.
+//
+// WHAT THIS DOES **NOT** PROVE
+//   That a declaration of `enforcement: 'enforced'` corresponds to a real
+//   assertion inside `execute`. That is not statically decidable, and a regex
+//   over the tool's source ("does it mention canViewEntity?") would manufacture
+//   confidence rather than earn it — a tool can read the capability view and
+//   ignore the answer. The honest substitute is the curated partition in (3):
+//   the enforced set is a human-reviewed claim, and the suite's job is to make
+//   any change to that claim explicit and reviewable instead of silent.
+//
+//   Behavioural proof exists for exactly one family today: the 17
+//   `agents.builder` tools, whose gate is exercised per tool in
+//   `agents-builder/tools/__tests__/agent-authoring-guard.test.ts`. Extending
+//   that pattern per domain is the way to convert claims in (3) into proofs.
+//
+// Enumeration mirrors `agent-authoring-guard.test.ts`: build the capability
+// factories, read `capability.tools`, and assert over the whole set — never per
+// file. A per-file test is exactly how six unguarded builder tools shipped.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isInstanceAccessKey } from '../../../../permissions/capabilities/instance-access'
+import { Area } from '../../../../permissions/capabilities/registry'
+import type { AgentToolDefinition } from '../../../agent-framework/types'
+import type { GetToolDeps, PageCapability } from '../types'
+
+// The agents-builder factory is the only async/IO-touching one: it reads the
+// session agent, the org toolset catalog, and the agent's procedures to decide
+// which tools to register. Stubbed to the `internal` branch so the enumeration
+// covers the FULL 17-tool set (a `chat`-kind agent registers 15).
+const { getCachedAgentById } = vi.hoisted(() => ({
+  getCachedAgentById: vi.fn(async () => ({ id: 'a1', kind: 'internal' }) as never),
+}))
+
+vi.mock('../../../../cache', () => ({
+  getCachedAgentById,
+  onCacheEvent: vi.fn(async () => {}),
+}))
+vi.mock('../../../../agents/procedures/authoring', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listAgentProceduresForAuthoring: vi.fn(async () => ({ match: () => [] })),
+}))
+vi.mock('../../../../agents/toolset-catalog', () => ({
+  getOrgToolsetCatalog: vi.fn(async () => []),
+  getOrgToolsetCatalogForSurface: vi.fn(async () => []),
+}))
+
+import { createActorCapabilities } from '../actors'
+import {
+  createAgentsBuilderCapabilities,
+  createSuggestRepliesGlobalCapability,
+} from '../agents-builder'
+import { createEntityCapabilities } from '../entities'
+import { createKbCapabilities, createKbReadCapabilities } from '../kb'
+import { createKnowledgeCapabilities } from '../knowledge'
+import { createKopilotCapabilities } from '../kopilot'
+import { createLearnedKbCapabilities } from '../learned'
+import { createMailCapabilities } from '../mail'
+import { createRecordViewCapabilities } from '../record-views'
+import { createCapabilityRegistry } from '../registry'
+import { createTaskCapabilities } from '../tasks'
+import { createNativeWorkflowCapabilities } from '../workflow'
+
+const ORG = 'org-1'
+
+// Tool factories capture `getDeps` for execute-time use only; construction never
+// calls it — except the builder factory, which reads `sessionContext` to resolve
+// the agent under edit.
+const getDeps: GetToolDeps = () =>
+  ({
+    db: {},
+    sessionContext: { page: 'agents.builder', references: [{ kind: 'agent', id: 'a1' }] },
+    organizationId: ORG,
+    userId: 'member-1',
+    sessionId: 's-1',
+    capabilities: undefined,
+  }) as never
+
+/**
+ * Every native capability factory the production registries assemble
+ * (`apps/web/.../api/kopilot/stream/route.ts`, `chat/agent/build-chat-engine-config.ts`,
+ * `ai/agent-framework/effective-runtime.ts`, the three `approvals/*` runners,
+ * `workflow-engine/nodes/action-nodes/ai-v2.ts`). App- and MCP-backed bridges are
+ * built from live org data and are covered by their own case below.
+ */
+async function collectNativeCapabilities(): Promise<PageCapability[]> {
+  return [
+    createEntityCapabilities(getDeps),
+    createMailCapabilities(getDeps),
+    createKnowledgeCapabilities(getDeps),
+    createActorCapabilities(getDeps),
+    createTaskCapabilities(getDeps),
+    createKopilotCapabilities(getDeps),
+    createKbCapabilities(getDeps),
+    createKbReadCapabilities(getDeps),
+    createLearnedKbCapabilities(getDeps),
+    createRecordViewCapabilities(getDeps),
+    createNativeWorkflowCapabilities(getDeps),
+    createSuggestRepliesGlobalCapability(getDeps),
+    await createAgentsBuilderCapabilities(getDeps, ORG),
+  ]
+}
+
+/** Flatten every registered native tool, deduped by name. */
+async function collectNativeTools(): Promise<AgentToolDefinition[]> {
+  const byName = new Map<string, AgentToolDefinition>()
+  for (const capability of await collectNativeCapabilities()) {
+    for (const tool of capability.tools) byName.set(tool.name, tool)
+  }
+  return [...byName.values()]
+}
+
+/**
+ * Tools whose declared requirement is NOT asserted by their `execute` today.
+ *
+ * This list is the machine-readable form of 19b's ranked gaps. Each entry names
+ * the gap family; the tool's own `permission.note` carries the detail.
+ *
+ * TO ADD an entry you must be adding a tool that knowingly skips authorization —
+ * say why in its `note`, and expect the reviewer to ask.
+ * TO REMOVE one, land the assertion in `execute`, flip the declaration to
+ * `enforcement: 'enforced'`, and delete the line here. The test fails if you do
+ * either half without the other.
+ */
+const KNOWN_UNENFORCED: readonly string[] = [
+  // 19b G3 — record-adjacent write, deliberately ungated to match the human
+  // comment routers (doc 14 §8.3). The four G3 *reads* were fixed; this is the pair's survivor.
+  'create_note',
+  // 19b G7 — coarse org-wide reads. Metadata-scale, no record bodies, but they
+  // turn an otherwise-`None` chat agent into a workspace directory.
+  'list_members',
+  'list_groups',
+  'list_tasks',
+  'list_table_views',
+  'list_tags',
+  // Ungated task write; no Area or definition exists to assert against.
+  'create_task',
+  // 19b G2 — mail sits outside the four-level model entirely.
+  'start_new_conversation',
+  // Role check (`isAdminOrOwner`) rather than a CapabilityView assertion, and no
+  // `canViewEntity` on the def whose org-wide default it flips.
+  'set_default_table_view',
+]
+
+/**
+ * Tools that genuinely require no authorization: agent-loop plumbing writing
+ * turn-local state, or a read of public data. Pinned so `'none'` cannot become
+ * the lazy default for a tool that actually touches workspace data.
+ */
+const NO_AUTHORIZATION_REQUIRED: readonly string[] = [
+  'plan_create',
+  'plan_update_step',
+  'assign_variable',
+  'suggest_replies',
+  'search_docs',
+]
+
+const AREA_SLUGS = new Set<string>(Object.values(Area))
+const UNMODELED_DOMAINS = new Set(['mail', 'tasks', 'directory'])
+
+describe('agent tool permission declarations — registry enumeration', () => {
+  beforeEach(() => {
+    getCachedAgentById.mockClear()
+  })
+
+  it('enumerates the full native tool surface', async () => {
+    const tools = await collectNativeTools()
+    // Guards against a broken mock silently enumerating an empty registry and
+    // making every assertion below pass vacuously.
+    expect(tools.length).toBeGreaterThanOrEqual(60)
+    expect(new Set(tools.map((t) => t.name)).size).toBe(tools.length)
+  })
+
+  it('EVERY registered native tool declares a permission', async () => {
+    const undeclared = (await collectNativeTools())
+      .filter((t) => !t.permission)
+      .map((t) => t.name)
+      .sort()
+    expect(undeclared).toEqual([])
+  })
+
+  it('every declaration is well-formed for its target', async () => {
+    for (const tool of await collectNativeTools()) {
+      const permission = tool.permission
+      if (!permission) continue
+      switch (permission.target) {
+        case 'definition':
+          expect(permission.level, tool.name).toBeTruthy()
+          break
+        case 'instance':
+          expect(permission.keys.length, tool.name).toBeGreaterThan(0)
+          for (const key of permission.keys) {
+            expect(isInstanceAccessKey(key), `${tool.name}: ${key}`).toBe(true)
+          }
+          break
+        case 'area':
+          expect(AREA_SLUGS.has(permission.area), `${tool.name}: ${permission.area}`).toBe(true)
+          break
+        case 'unmodeled':
+          expect(
+            UNMODELED_DOMAINS.has(permission.domain),
+            `${tool.name}: ${permission.domain}`
+          ).toBe(true)
+          break
+        default:
+          expect(permission.note?.length, tool.name).toBeGreaterThan(0)
+      }
+      // A gap must always explain itself — the note is what a reader gets
+      // instead of re-deriving the sweep.
+      if ('enforcement' in permission && permission.enforcement === 'unenforced') {
+        expect(permission.note.length, tool.name).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('the unenforced set is EXACTLY the curated known-gap list', async () => {
+    const declared = (await collectNativeTools())
+      .filter((t) => t.permission && 'enforcement' in t.permission)
+      .filter((t) => (t.permission as { enforcement: string }).enforcement === 'unenforced')
+      .map((t) => t.name)
+      .sort()
+    expect(declared).toEqual([...KNOWN_UNENFORCED].sort())
+  })
+
+  it('the no-authorization-required set is EXACTLY the curated plumbing list', async () => {
+    const declared = (await collectNativeTools())
+      .filter((t) => t.permission?.target === 'none')
+      .map((t) => t.name)
+      .sort()
+    expect(declared).toEqual([...NO_AUTHORIZATION_REQUIRED].sort())
+  })
+
+  it('no native tool declares itself a bridge — `bridge` is app/MCP only', async () => {
+    const bridges = (await collectNativeTools())
+      .filter((t) => t.permission?.target === 'bridge')
+      .map((t) => t.name)
+    expect(bridges).toEqual([])
+  })
+
+  it('every tool reachable through a real registry declares a permission', async () => {
+    const registry = createCapabilityRegistry()
+    for (const capability of await collectNativeCapabilities()) registry.register(capability)
+
+    const seen = new Set<string>()
+    for (const page of [...registry.getPages(), 'some.unregistered.page']) {
+      for (const tool of registry.getTools(page)) {
+        seen.add(tool.name)
+        expect(tool.permission, `${page}/${tool.name}`).toBeDefined()
+      }
+    }
+    expect(seen.size).toBeGreaterThanOrEqual(60)
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-groups.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-groups.ts
@@ -23,6 +23,13 @@ const ListGroupsOutput = z.object({
 export function createListGroupsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_groups',
+    permission: {
+      target: 'unmodeled',
+      domain: 'directory',
+      level: 'read',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP (19b G7). Returns every group org-wide INCLUDING visibility:"private" ones, with member counts. Same missing-read-rung ambiguity as list_members.',
+    },
     displayName: 'List groups',
     toolsetSlug: 'auxx:actors',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-members.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-members.ts
@@ -23,6 +23,13 @@ const ListMembersOutput = z.object({
 export function createListMembersTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_members',
+    permission: {
+      target: 'unmodeled',
+      domain: 'directory',
+      level: 'read',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP (19b G7). Returns every member’s name, email and role org-wide with no check. AMBIGUOUS requirement: Area.members is a Full-only ladder about *managing* members, so there is no read rung to bind this to — the level below is the intent, not an existing rung.',
+    },
     displayName: 'List members',
     toolsetSlug: 'auxx:actors',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
@@ -14,6 +14,13 @@ import { resolveAgentAuthoring } from './agent-authoring-guard'
 export function createCompleteAgentSetupTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'complete_agent_setup',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Complete agent setup',
     // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
     surfaces: ['builder'],

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/create-eval-case.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/create-eval-case.ts
@@ -36,6 +36,13 @@ const outputSchema = z.object({
 export function createCreateEvalCaseTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'create_eval_case',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Create simulation case',
     surfaces: ['builder'],
     requiresApproval: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-case.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-case.ts
@@ -27,6 +27,13 @@ const outputSchema = z.object({
 export function createGetEvalCaseTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_eval_case',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Read simulation case',
     surfaces: ['builder'],
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-run.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-run.ts
@@ -35,6 +35,13 @@ const outputSchema = z.object({
 export function createGetEvalRunTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_eval_run',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Read simulation run',
     surfaces: ['builder'],
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-suite-diff.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-suite-diff.ts
@@ -34,6 +34,13 @@ const outputSchema = z.object({
 export function createGetSuiteDiffTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_suite_diff',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Compare suite runs',
     surfaces: ['builder'],
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/list-eval-cases.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/list-eval-cases.ts
@@ -34,6 +34,13 @@ const outputSchema = z.object({
 export function createListEvalCasesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_eval_cases',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'List simulation cases',
     surfaces: ['builder'],
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-create.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-create.ts
@@ -36,6 +36,13 @@ const triggerExampleSchema = {
 export function createCreateProcedureTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'create_procedure',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Create procedure',
     surfaces: ['builder'],
     description: `Create a new branching procedure (a deterministic, multi-step playbook for one situation) and attach it to this agent as a DRAFT.

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-read.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-read.ts
@@ -14,6 +14,13 @@ import { resolveProcedureAuthoring } from './procedure-authoring-guard'
 export function createReadProcedureTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'read_procedure',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Read procedure',
     surfaces: ['builder'],
     description: `Read a procedure attached to this agent back as the step DSL (with stable ids), so you can change only what the user asks and re-emit via \`set_procedure_body\` using the returned \`draftContentHash\`. Code blocks and rules-mode conditions appear as read-only \`opaque\` steps — keep them exactly.`,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-set-body.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-set-body.ts
@@ -32,6 +32,13 @@ const STALE_HINT =
 export function createSetProcedureBodyTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'set_procedure_body',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Set procedure body',
     surfaces: ['builder'],
     description: `Replace a procedure's draft body with the full step DSL. To EDIT, call \`read_procedure\` first, change only the steps the user asked about (keep all others and their ids exactly — including every read-only \`opaque\` step), and re-emit the whole \`body\` with the returned \`draftContentHash\` as \`expectedDraftContentHash\`. If the tool reports a stale draft, read again and reapply. The compiler returns structured errors — fix and retry. You write a draft; the user publishes in the editor.`,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-update-criteria.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-update-criteria.ts
@@ -19,6 +19,13 @@ import { validateTriggerExamples } from './trigger-examples'
 export function createUpdateProcedureCriteriaTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_procedure_criteria',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Update procedure criteria',
     surfaces: ['builder'],
     description: `Update a procedure's name and/or selection criteria (\`whenToUse\`, \`triggerExamples\`). These drive when the procedure is selected at runtime and go live when the user publishes. To change the step flow, use \`set_procedure_body\` instead.`,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/run-eval-suite.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/run-eval-suite.ts
@@ -26,6 +26,13 @@ const outputSchema = z.object({
 export function createRunEvalSuiteTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'run_eval_suite',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Run simulation suite',
     surfaces: ['builder'],
     requiresApproval: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
@@ -20,6 +20,13 @@ const MARKDOWN_MAX_BYTES = 20_000
 export function createSetAgentPromptTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'set_agent_prompt',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Set agent prompt',
     // Builder-only meta-tool — configures another agent. Never offered on a
     // chat/internal/email agent. See plans/chat/v6/chat-tool-availability.md.

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
@@ -26,6 +26,13 @@ const RECORD_ID_MAX = 180
 export function createSetAgentResourceScopeTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'set_agent_resource_scope',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Set agent resource scope',
     // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
     surfaces: ['builder'],

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
@@ -20,6 +20,13 @@ const MAX_TOOLSETS = 50
 export function createSetAgentToolsetsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'set_agent_toolsets',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Set agent toolsets',
     // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
     surfaces: ['builder'],

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
@@ -54,6 +54,13 @@ type ParsedTrigger = ParsedScheduledTrigger | ParsedEventTrigger
 export function createSetAgentTriggersTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'set_agent_triggers',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Set agent triggers',
     // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
     surfaces: ['builder'],

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/suggest-replies.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/suggest-replies.ts
@@ -16,6 +16,10 @@ const LABEL_MAX = 80
 export function createSuggestRepliesTool(_getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'suggest_replies',
+    permission: {
+      target: 'none',
+      note: 'UI directive: renders reply chips above the composer from strings the model supplied. Reads and writes nothing.',
+    },
     displayName: 'Suggest replies',
     // Every legitimate use means "I'm done, waiting for the admin" — the chips
     // are for the client, not the model, so the call terminates the turn.

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-agent-identity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-agent-identity.ts
@@ -22,6 +22,13 @@ const DESCRIPTION_MAX = 280
 export function createUpdateAgentIdentityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_agent_identity',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Update agent identity',
     // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
     surfaces: ['builder'],

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-eval-case-mock.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-eval-case-mock.ts
@@ -53,6 +53,13 @@ function parseUpsertMocks(raw: unknown): UpsertMockArg[] | string {
 export function createUpdateEvalCaseMockTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_eval_case_mock',
+    permission: {
+      target: 'area',
+      area: 'agents',
+      level: 'full',
+      enforcement: 'enforced',
+      note: 'resolveAgentAuthoring — PermissionKey.agentsManage (the agents area’s only rung) on the caller’s own CapabilitySet, plus an org-scope check on the session agent ref. Enforcement is proven behaviourally by agents-builder/tools/__tests__/agent-authoring-guard.test.ts.',
+    },
     displayName: 'Update simulation case mocks',
     surfaces: ['builder'],
     requiresApproval: true,

--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -236,6 +236,19 @@ export async function createAppCapabilities(deps: {
 
       const buildAgentTool = (execute: AgentToolDefinition['execute']): AgentToolDefinition => ({
         name: registeredName,
+        // The platform cannot classify an app tool's effects: they run inside a
+        // third-party bundle. Gates are install + toolset enablement, the
+        // `requiresConnection` presence check above, the `Agent.appAccounts`
+        // binding, and `resolveOwnedField` on write-back — none of which map to
+        // an area / definition / instance level. Marked `bridge` (never `none`)
+        // so the audit can tell "unclassifiable" from "needs nothing". The known
+        // record-read channel is 19b G5: `includeEntitiesScope: true` below mints
+        // a token for apps/api's entity routes with no CapabilitySet on the path.
+        permission: {
+          target: 'bridge',
+          governedBy: 'app',
+          note: 'App bundle: install + toolset enablement + connection binding are the gate; requiresApproval is hard-coded false. Record reads via the entities scope are unbounded by capabilities (19b G5).',
+        },
         displayName: tool.name || registeredName,
         description: tool.description,
         parameters: tool.inputsJsonSchema,

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/list-entity-fields-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/list-entity-fields-capabilities.test.ts
@@ -1,0 +1,151 @@
+// packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/list-entity-fields-capabilities.test.ts
+//
+// Permissions v2 §3 / plan 19b gap G4: `list_entity_fields` returned the full
+// field schema (ids, types, options, relationships, flags) for ANY definition
+// with no capability check, reopening through a tool call exactly the
+// disclosure doc 14 §3.4 removed from the prompt catalog. It now requires
+// definition-level Read, and an unviewable def must be indistinguishable from
+// one that does not exist — including in the "valid apiSlugs" hint.
+
+import { describe, expect, it, vi } from 'vitest'
+
+const RESOURCES = [
+  {
+    id: 'def_contact',
+    entityDefinitionId: 'def_contact',
+    apiSlug: 'contact',
+    entityType: 'contact',
+    label: 'Contact',
+    fields: [
+      {
+        id: 'contact_name',
+        key: 'name',
+        label: 'Name',
+        fieldType: 'NAME',
+        systemAttribute: 'name',
+        isRequired: true,
+      },
+    ],
+  },
+  {
+    id: 'def_invoice',
+    entityDefinitionId: 'def_invoice',
+    apiSlug: 'invoice',
+    entityType: 'invoice',
+    label: 'Invoice',
+    fields: [
+      {
+        id: 'invoice_total',
+        key: 'total',
+        label: 'Total',
+        fieldType: 'CURRENCY',
+        systemAttribute: 'total',
+      },
+    ],
+  },
+]
+
+vi.mock('../../../../../../cache/org-cache-helpers', () => ({
+  findCachedResource: vi.fn(
+    async (_orgId: string, key: string) =>
+      RESOURCES.find((r) => r.id === key || r.entityType === key || r.apiSlug === key) ?? null
+  ),
+  getCachedResources: vi.fn(async () => RESOURCES),
+}))
+
+import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import { Level } from '../../../../../../permissions/capabilities/registry'
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../../agent-framework/types'
+import { createListEntityFieldsTool } from '../list-entity-fields'
+
+/** All-permissive `CapabilityView`; override just the gate under test. */
+function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  const yes = () => true
+  const noop = () => {}
+  return {
+    can: yes,
+    has: yes,
+    assert: noop,
+    areaLevel: () => Level.Full,
+    canWriteEntity: yes,
+    assertWriteEntity: noop,
+    canEditEntity: yes,
+    assertEditEntity: noop,
+    filterEditableDefIds: (ids: string[]) => ids,
+    canViewEntity: yes,
+    assertViewEntity: noop,
+    filterViewableDefIds: (ids: string[]) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: yes,
+    assertAdministerDef: noop,
+    canViewInstance: yes,
+    canEditInstance: yes,
+    canAdminInstance: yes,
+    assertViewInstance: noop,
+    assertEditInstance: noop,
+    assertAdminInstance: noop,
+    ...overrides,
+  }
+}
+
+/** Denies exactly one def, mirroring a published policy of `None` on it. */
+function denying(defId: string): CapabilityView {
+  return makeCapabilities({ canViewEntity: (id: string) => id !== defId })
+}
+
+function runTool(entityDefinitionId: string, capabilities?: CapabilityView) {
+  const tool = createListEntityFieldsTool(() => ({ db: {}, capabilities }) as never)
+  const ctx = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+  return tool.execute({ entityDefinitionId }, ctx) as Promise<AgentToolResult>
+}
+
+describe('list_entity_fields — read enforcement', () => {
+  it('returns the schema for a viewable definition', async () => {
+    const result = await runTool('invoice', makeCapabilities())
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ entityDefinitionId: 'def_invoice' })
+    expect((result.output as { fields: unknown[] }).fields).toHaveLength(1)
+  })
+
+  it('without capabilities, discloses the schema as before', async () => {
+    const result = await runTool('invoice', undefined)
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ entityDefinitionId: 'def_invoice' })
+  })
+
+  it('refuses an unviewable definition and leaks no field data', async () => {
+    const result = await runTool('invoice', denying('def_invoice'))
+
+    expect(result.success).toBe(false)
+    expect(result.output).toBeNull()
+    expect(result.error).toContain('not found')
+    expect(JSON.stringify(result)).not.toContain('invoice_total')
+  })
+
+  it('denial is byte-identical to an unknown slug, so existence stays hidden', async () => {
+    const capabilities = denying('def_invoice')
+
+    const denied = await runTool('invoice', capabilities)
+    const unknown = await runTool('no_such_thing', capabilities)
+
+    const suffixOf = (error: string | undefined) => error?.slice(error.indexOf('not found'))
+    expect(suffixOf(denied.error)).toBe(suffixOf(unknown.error))
+  })
+
+  it('filters the suggested apiSlug list to viewable definitions', async () => {
+    const result = await runTool('no_such_thing', denying('def_invoice'))
+
+    expect(result.error).toContain('contact')
+    expect(result.error).not.toContain('invoice')
+  })
+
+  it('without capabilities, the suggested apiSlug list is unfiltered', async () => {
+    const result = await runTool('no_such_thing', undefined)
+
+    expect(result.error).toContain('contact')
+    expect(result.error).toContain('invoice')
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/record-adjacent-reads-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/record-adjacent-reads-capabilities.test.ts
@@ -1,0 +1,291 @@
+// packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/record-adjacent-reads-capabilities.test.ts
+//
+// Permissions v2 §3 / plan 19b gap G3: `list_notes`, `list_field_changes`,
+// `list_transcripts_for_entity` and `get_transcript` each took a bare
+// `recordId` / `entityInstanceId` / `transcriptId` and ran raw org-scoped SQL,
+// so a definition published `None` still yielded its notes, field-change
+// history and meeting transcripts. Each now resolves the owning definition
+// first and gates on `canViewEntity`, the shape `get_entity_history` proves.
+//
+// Denial convention, per tool shape: the two list tools return their empty
+// success payload (matching `query_records`), the single-object getter returns
+// its ordinary not-found error. Neither confirms the target exists.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCommentsSpy = vi.fn()
+
+vi.mock('../../../../../../comments', () => ({
+  CommentService: class {
+    async getCommentsByRecordId(...args: unknown[]) {
+      return getCommentsSpy(...args)
+    }
+  },
+}))
+
+vi.mock('../../../../../../cache/org-cache-helpers', () => ({
+  getCachedMembersByUserIds: vi.fn(async () => []),
+}))
+
+import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import { Level } from '../../../../../../permissions/capabilities/registry'
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../../agent-framework/types'
+import { createGetTranscriptTool } from '../get-transcript'
+import { createListFieldChangesTool } from '../list-field-changes'
+import { createListNotesTool } from '../list-notes'
+import { createListTranscriptsForEntityTool } from '../list-transcripts-for-entity'
+
+/** All-permissive `CapabilityView`; override just the gate under test. */
+function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  const yes = () => true
+  const noop = () => {}
+  return {
+    can: yes,
+    has: yes,
+    assert: noop,
+    areaLevel: () => Level.Full,
+    canWriteEntity: yes,
+    assertWriteEntity: noop,
+    canEditEntity: yes,
+    assertEditEntity: noop,
+    filterEditableDefIds: (ids: string[]) => ids,
+    canViewEntity: yes,
+    assertViewEntity: noop,
+    filterViewableDefIds: (ids: string[]) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: yes,
+    assertAdministerDef: noop,
+    canViewInstance: yes,
+    canEditInstance: yes,
+    canAdminInstance: yes,
+    assertViewInstance: noop,
+    assertEditInstance: noop,
+    assertAdminInstance: noop,
+    ...overrides,
+  }
+}
+
+/** Denies exactly one def, mirroring a published policy of `None` on it. */
+function denying(defId: string): CapabilityView {
+  return makeCapabilities({ canViewEntity: (id: string) => id !== defId })
+}
+
+/**
+ * Thenable Drizzle-builder stub — every chained method returns itself and the
+ * chain resolves to `rows` whenever it is awaited, at whatever depth.
+ */
+function selectChain(rows: unknown[]) {
+  const chain: Record<string, unknown> = {}
+  for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit']) {
+    chain[method] = () => chain
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable query-builder mock
+  chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject)
+  return chain
+}
+
+/**
+ * Fake db: `query.EntityInstance.findFirst` answers the def lookup, `select()`
+ * shifts the next queued row set (defaulting to empty). Both are spies so a
+ * test can assert the gate short-circuited before any SQL.
+ */
+function makeDb(options: {
+  instance?: { entityDefinitionId: string } | null
+  rowSets?: unknown[][]
+}) {
+  const queue = [...(options.rowSets ?? [])]
+  const findFirst = vi.fn(async () => options.instance ?? null)
+  const select = vi.fn(() => selectChain(queue.shift() ?? []))
+  return { db: { query: { EntityInstance: { findFirst } }, select }, findFirst, select }
+}
+
+const CTX = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+
+beforeEach(() => {
+  getCommentsSpy.mockReset()
+  getCommentsSpy.mockResolvedValue([
+    { id: 'c_1', contentJson: {}, createdById: 'u_2', createdAt: new Date(), isPinned: false },
+  ])
+})
+
+describe('list_notes — read enforcement', () => {
+  function runTool(capabilities?: CapabilityView) {
+    const tool = createListNotesTool(() => ({ db: {}, capabilities }) as never)
+    return tool.execute({ recordId: 'def_invoice:i_1' }, CTX) as Promise<AgentToolResult>
+  }
+
+  it('lists notes when the definition is viewable', async () => {
+    const result = await runTool(makeCapabilities())
+
+    expect(result.success).toBe(true)
+    expect((result.output as { notes: unknown[] }).notes).toHaveLength(1)
+    expect(getCommentsSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('without capabilities, lists notes as before', async () => {
+    const result = await runTool(undefined)
+
+    expect(result.success).toBe(true)
+    expect(getCommentsSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an empty page for an unviewable definition, without reading comments', async () => {
+    const result = await runTool(denying('def_invoice'))
+
+    expect(result.success).toBe(true)
+    expect(result.output).toEqual({ notes: [], hasMore: false })
+    expect(getCommentsSpy).not.toHaveBeenCalled()
+  })
+
+  it('the denial is indistinguishable from a record that simply has no notes', async () => {
+    getCommentsSpy.mockResolvedValue([])
+    const empty = await runTool(makeCapabilities())
+    const denied = await runTool(denying('def_invoice'))
+
+    expect(denied).toEqual(empty)
+  })
+})
+
+describe('list_field_changes — read enforcement', () => {
+  function runTool(capabilities: CapabilityView | undefined, dbSetup: ReturnType<typeof makeDb>) {
+    const tool = createListFieldChangesTool(() => ({ db: dbSetup.db, capabilities }) as never)
+    return tool.execute({ entityInstanceId: 'i_1' }, CTX) as Promise<AgentToolResult>
+  }
+
+  it('reads the timeline when the definition is viewable', async () => {
+    const setup = makeDb({ instance: { entityDefinitionId: 'def_contact' } })
+
+    const result = await runTool(makeCapabilities(), setup)
+
+    expect(result.success).toBe(true)
+    expect(setup.select).toHaveBeenCalledTimes(1)
+  })
+
+  it('without capabilities, skips the lookup and reads as before', async () => {
+    const setup = makeDb({ instance: { entityDefinitionId: 'def_invoice' } })
+
+    const result = await runTool(undefined, setup)
+
+    expect(result.success).toBe(true)
+    expect(setup.findFirst).not.toHaveBeenCalled()
+    expect(setup.select).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns no changes for an unviewable definition, without touching the timeline', async () => {
+    const setup = makeDb({ instance: { entityDefinitionId: 'def_invoice' } })
+
+    const result = await runTool(denying('def_invoice'), setup)
+
+    expect(result.success).toBe(true)
+    expect(result.output).toEqual({ changes: [] })
+    expect(setup.select).not.toHaveBeenCalled()
+  })
+
+  it('an unviewable record and a non-existent one answer identically', async () => {
+    const denied = await runTool(
+      denying('def_invoice'),
+      makeDb({ instance: { entityDefinitionId: 'def_invoice' } })
+    )
+    const missing = await runTool(makeCapabilities(), makeDb({ instance: null }))
+
+    expect(denied).toEqual(missing)
+  })
+})
+
+describe('list_transcripts_for_entity — read enforcement', () => {
+  function runTool(capabilities: CapabilityView | undefined, dbSetup: ReturnType<typeof makeDb>) {
+    const tool = createListTranscriptsForEntityTool(
+      () => ({ db: dbSetup.db, capabilities }) as never
+    )
+    return tool.execute({ entityInstanceId: 'i_1' }, CTX) as Promise<AgentToolResult>
+  }
+
+  it('runs the transcript joins when the definition is viewable', async () => {
+    const setup = makeDb({ instance: { entityDefinitionId: 'def_meeting' } })
+
+    const result = await runTool(makeCapabilities(), setup)
+
+    expect(result.success).toBe(true)
+    expect(setup.select).toHaveBeenCalled()
+  })
+
+  it('without capabilities, skips the lookup and joins as before', async () => {
+    const setup = makeDb({ instance: { entityDefinitionId: 'def_invoice' } })
+
+    const result = await runTool(undefined, setup)
+
+    expect(result.success).toBe(true)
+    expect(setup.findFirst).not.toHaveBeenCalled()
+    expect(setup.select).toHaveBeenCalled()
+  })
+
+  it('returns no transcripts for an unviewable definition, without joining', async () => {
+    const setup = makeDb({ instance: { entityDefinitionId: 'def_invoice' } })
+
+    const result = await runTool(denying('def_invoice'), setup)
+
+    expect(result.success).toBe(true)
+    expect(result.output).toEqual({ transcripts: [] })
+    expect(setup.select).not.toHaveBeenCalled()
+  })
+
+  it('an unviewable record and a non-existent one answer identically', async () => {
+    const denied = await runTool(
+      denying('def_invoice'),
+      makeDb({ instance: { entityDefinitionId: 'def_invoice' } })
+    )
+    const missing = await runTool(makeCapabilities(), makeDb({ instance: null }))
+
+    expect(denied).toEqual(missing)
+  })
+})
+
+describe('get_transcript — read enforcement', () => {
+  const TRANSCRIPT_ROW = {
+    fullText: 'Alex: welcome aboard.',
+    wordCount: 4,
+    entityDefinitionId: 'def_meeting',
+  }
+
+  function runTool(capabilities: CapabilityView | undefined, rowSets: unknown[][]) {
+    const setup = makeDb({ rowSets })
+    const tool = createGetTranscriptTool(() => ({ db: setup.db, capabilities }) as never)
+    return {
+      setup,
+      result: tool.execute({ transcriptId: 't_1' }, CTX) as Promise<AgentToolResult>,
+    }
+  }
+
+  it('returns the transcript text when the meeting definition is viewable', async () => {
+    const { result } = runTool(makeCapabilities(), [[TRANSCRIPT_ROW]])
+
+    expect(await result).toMatchObject({
+      success: true,
+      output: { transcriptId: 't_1', fullText: 'Alex: welcome aboard.' },
+    })
+  })
+
+  it('without capabilities, returns the transcript as before', async () => {
+    const { result } = runTool(undefined, [[TRANSCRIPT_ROW]])
+
+    expect((await result).success).toBe(true)
+  })
+
+  it('refuses an unviewable meeting definition and leaks no transcript text', async () => {
+    const { result } = runTool(denying('def_meeting'), [[TRANSCRIPT_ROW]])
+    const resolved = await result
+
+    expect(resolved.success).toBe(false)
+    expect(resolved.output).toBeNull()
+    expect(JSON.stringify(resolved)).not.toContain('welcome aboard')
+  })
+
+  it('the denial is byte-identical to a transcript that does not exist', async () => {
+    const denied = await runTool(denying('def_meeting'), [[TRANSCRIPT_ROW]]).result
+    const missing = await runTool(makeCapabilities(), [[]]).result
+
+    expect(denied).toEqual(missing)
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
@@ -26,6 +26,12 @@ import { formatActorResolutionError, resolveActorValuesFlat } from './resolve-ac
 export function createBulkUpdateEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'bulk_update_entity',
+    permission: {
+      target: 'definition',
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'Own per-def assertEditEntity before any DB work (bypasses UnifiedCrudHandler by design).',
+    },
     displayName: 'Bulk update records',
     toolsetSlug: 'auxx:entities:write',
     outputSchema: BulkUpdateEntityOutput,

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
@@ -19,6 +19,12 @@ import { formatActorResolutionError, resolveActorValues } from './resolve-actor-
 export function createCreateEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'create_entity',
+    permission: {
+      target: 'definition',
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'UnifiedCrudHandler → assertEditEntity.',
+    },
     displayName: 'Create record',
     toolsetSlug: 'auxx:entities:write',
     outputSchema: CreateEntityOutput,

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-note.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-note.ts
@@ -22,6 +22,12 @@ const CreateNoteOutput = z.object({
 export function createCreateNoteTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'create_note',
+    permission: {
+      target: 'definition',
+      level: 'read_write',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP (19b G3). Deliberate: the human comment routers are ungated too (doc 14 §8.3), so gating only the agent path would diverge from the product. A def published None still accepts notes. Do not "fix" without the matching human-router decision.',
+    },
     displayName: 'Add note',
     toolsetSlug: 'auxx:comments:write',
     outputSchema: CreateNoteOutput,
@@ -75,6 +81,12 @@ export function createCreateNoteTool(getDeps: GetToolDeps): AgentToolDefinition 
       }
     },
     execute: async (args, agentDeps) => {
+      // KNOWN GAP (plan 19b, G3): deliberately ungated. The *human* comment
+      // routers are ungated too (doc 14 §8.3), so gating only the agent path
+      // would diverge from the surface it mirrors. The four record-adjacent
+      // READS (`list_notes`, `list_field_changes`, `get_transcript`,
+      // `list_transcripts_for_entity`) do NOT share this reasoning and are
+      // gated on `canViewEntity`. Close this together with the human routers.
       const { db } = getDeps()
       const recordId = args.recordId as string
       const content = args.content as string

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity-history.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity-history.ts
@@ -161,6 +161,12 @@ function snapshotItemToDisplay(snap: TimelineFieldChangeSnapshot): string | null
 export function createGetEntityHistoryTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_entity_history',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity on the parent instance’s def, plus a per-def filter over linked entities.',
+    },
     displayName: 'Get record history',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity.ts
@@ -28,6 +28,12 @@ const GetEntityOutput = z.object({
 export function createGetEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_entity',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity on the recordId’s def before the read.',
+    },
     displayName: 'Get record',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-transcript.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-transcript.ts
@@ -36,6 +36,12 @@ const GetTranscriptOutput = z.object({
 export function createGetTranscriptTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_transcript',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'Transcript → CallRecording → EntityInstance join then canViewEntity; not-found on denial (19b G3).',
+    },
     displayName: 'Get transcript',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',
@@ -78,21 +84,45 @@ export function createGetTranscriptTool(getDeps: GetToolDeps): AgentToolDefiniti
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const transcriptId = args.transcriptId as string
       const granularity =
         (args.granularity as 'full_text' | 'utterances' | undefined) ?? 'full_text'
       const maxTokens = (args.maxTokens as number | undefined) ?? DEFAULT_MAX_TOKENS
       const charBudget = maxTokens * CHARS_PER_TOKEN
 
-      const transcript = await db.query.Transcript.findFirst({
-        where: and(
-          eq(schema.Transcript.id, transcriptId),
-          eq(schema.Transcript.organizationId, agentDeps.organizationId)
-        ),
-      })
+      // A transcript is reachable only through its meeting record, so the join
+      // carries the owning def up for the read gate below (both FKs are
+      // NOT NULL + cascade, so the chain always resolves for a live row).
+      const [transcript] = await db
+        .select({
+          fullText: schema.Transcript.fullText,
+          wordCount: schema.Transcript.wordCount,
+          entityDefinitionId: schema.EntityInstance.entityDefinitionId,
+        })
+        .from(schema.Transcript)
+        .innerJoin(
+          schema.CallRecording,
+          eq(schema.CallRecording.id, schema.Transcript.callRecordingId)
+        )
+        .innerJoin(
+          schema.EntityInstance,
+          eq(schema.EntityInstance.id, schema.CallRecording.meetingId)
+        )
+        .where(
+          and(
+            eq(schema.Transcript.id, transcriptId),
+            eq(schema.Transcript.organizationId, agentDeps.organizationId)
+          )
+        )
+        .limit(1)
 
-      if (!transcript) {
+      // Read enforcement (§3): an unviewable meeting def reads exactly like a
+      // transcript that does not exist — the message must not distinguish them.
+      if (
+        !transcript ||
+        (capabilities && !capabilities.canViewEntity(transcript.entityDefinitionId))
+      ) {
         return { success: false, output: null, error: `Transcript ${transcriptId} not found.` }
       }
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entities.ts
@@ -24,6 +24,12 @@ const ListEntitiesOutput = z.object({
 export function createListEntitiesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_entities',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'Output filtered by canViewEntity — an unviewable def is absent from the catalog.',
+    },
     displayName: 'List entity types',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
@@ -33,9 +33,15 @@ const ListEntityFieldsOutput = z.object({
   ),
 })
 
-export function createListEntityFieldsTool(_getDeps: GetToolDeps): AgentToolDefinition {
+export function createListEntityFieldsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_entity_fields',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity on the resolved def; denial is the ordinary not-found error and the suggested-slug list is filtered (19b G4).',
+    },
     displayName: 'List entity fields',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',
@@ -106,13 +112,27 @@ Response shape:
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
+      const { capabilities } = getDeps()
       const key = args.entityDefinitionId as string
       const query = (args.query as string | undefined)?.toLowerCase()
 
       const resource = await findCachedResource(agentDeps.organizationId, key)
-      if (!resource) {
+
+      // Read enforcement (§3): the schema IS the disclosure, so a def the
+      // principal can't view must read exactly like a def that doesn't exist —
+      // same error, and a suggestion list filtered to viewable defs so the two
+      // cases are indistinguishable.
+      const denied =
+        !!resource &&
+        !!capabilities &&
+        !capabilities.canViewEntity(resource.entityDefinitionId ?? resource.id)
+
+      if (!resource || denied) {
         const allResources = await getCachedResources(agentDeps.organizationId)
-        const validSlugs = allResources.map((r) => r.apiSlug).join(', ')
+        const validSlugs = allResources
+          .filter((r) => !capabilities || capabilities.canViewEntity(r.entityDefinitionId ?? r.id))
+          .map((r) => r.apiSlug)
+          .join(', ')
         return {
           success: false,
           output: null,

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-field-changes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-field-changes.ts
@@ -91,6 +91,12 @@ function snapshotItemToDisplay(snap: TimelineFieldChangeSnapshot): string {
 export function createListFieldChangesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_field_changes',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'EntityInstance lookup then canViewEntity; silent-empty on denial (19b G3).',
+    },
     displayName: 'List field changes',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',
@@ -168,12 +174,29 @@ export function createListFieldChangesTool(getDeps: GetToolDeps): AgentToolDefin
       return { ok: true, args: { ...args, entityInstanceId: entityInstanceId.value } }
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const entityInstanceId = args.entityInstanceId as string
       const fieldFilter = (args.fieldSystemAttribute as string | undefined) || undefined
       const sinceDays = (args.sinceDays as number | undefined) ?? 90
       const limit = Math.min((args.limit as number) ?? 20, MAX_LIMIT)
       const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+
+      // Read enforcement (§3): the timeline rows are keyed by bare instance id,
+      // so resolve the owning def first (same shape as `get_entity_history`).
+      // An unviewable — or non-existent — record reads as "no changes", which
+      // is what an empty history already looks like.
+      if (capabilities) {
+        const instance = await db.query.EntityInstance.findFirst({
+          where: and(
+            eq(schema.EntityInstance.id, entityInstanceId),
+            eq(schema.EntityInstance.organizationId, agentDeps.organizationId)
+          ),
+          columns: { entityDefinitionId: true },
+        })
+        if (!instance || !capabilities.canViewEntity(instance.entityDefinitionId)) {
+          return { success: true, output: { changes: [] } }
+        }
+      }
 
       const events = await db
         .select({

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-notes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-notes.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod'
 import { getCachedMembersByUserIds } from '../../../../../cache/org-cache-helpers'
 import { CommentService } from '../../../../../comments'
-import type { RecordId } from '../../../../../resources/resource-id'
+import { getDefinitionId, type RecordId } from '../../../../../resources/resource-id'
 import { docToText } from '../../../../../tiptap'
 import { getKnownDefIds, normalizeRecordIdArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
@@ -58,6 +58,12 @@ function truncate(text: string | null | undefined, max: number): string {
 export function createListNotesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_notes',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity on the def parsed out of the recordId; silent-empty on denial (19b G3).',
+    },
     displayName: 'List notes',
     toolsetSlug: 'auxx:comments:read',
     category: 'system',
@@ -125,10 +131,17 @@ export function createListNotesTool(getDeps: GetToolDeps): AgentToolDefinition {
       }
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const recordId = args.recordId as RecordId
       const limit = Math.min((args.limit as number) ?? 20, MAX_LIMIT)
       const includeReplies = (args.includeReplies as boolean | undefined) ?? true
+
+      // Read enforcement (§3): notes are record content, so a def the principal
+      // can't view reads as a record with no notes — never as a denial that
+      // confirms the record exists.
+      if (capabilities && !capabilities.canViewEntity(getDefinitionId(recordId))) {
+        return { success: true, output: { notes: [], hasMore: false } }
+      }
 
       const service = new CommentService(agentDeps.organizationId, agentDeps.userId, db)
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-transcripts-for-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-transcripts-for-entity.ts
@@ -32,6 +32,12 @@ const ListTranscriptsForEntityOutput = z.object({
 export function createListTranscriptsForEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_transcripts_for_entity',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'EntityInstance lookup then canViewEntity; silent-empty on denial (19b G3).',
+    },
     displayName: 'List transcripts',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',
@@ -87,11 +93,28 @@ export function createListTranscriptsForEntityTool(getDeps: GetToolDeps): AgentT
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const entityInstanceId = args.entityInstanceId as string
       const sinceDays = (args.sinceDays as number | undefined) ?? 180
       const limit = Math.min((args.limit as number) ?? 10, MAX_LIMIT)
       const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+
+      // Read enforcement (§3): the joins below are org-scoped only, so resolve
+      // the owning def first (same shape as `get_entity_history`). An
+      // unviewable — or non-existent — record reads as "no transcripts", the
+      // same answer a record with no meetings already gives.
+      if (capabilities) {
+        const instance = await db.query.EntityInstance.findFirst({
+          where: and(
+            eq(schema.EntityInstance.id, entityInstanceId),
+            eq(schema.EntityInstance.organizationId, agentDeps.organizationId)
+          ),
+          columns: { entityDefinitionId: true },
+        })
+        if (!instance || !capabilities.canViewEntity(instance.entityDefinitionId)) {
+          return { success: true, output: { transcripts: [] } }
+        }
+      }
 
       // Path 1: the entity IS a meeting → CallRecording.meetingId match.
       // Path 2: the entity is a contact/company → meetings via MeetingParticipant.

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
@@ -52,6 +52,12 @@ const QueryRecordsOutput = z.object({
 export function createQueryRecordsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'query_records',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity before the query; an unviewable def reads as empty.',
+    },
     displayName: 'Filter records',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
@@ -39,6 +39,12 @@ const SearchEntitiesOutput = z.object({
 export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'search_entities',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'Results post-filtered by canViewEntity; field enrichment re-checks per def.',
+    },
     displayName: 'Search records',
     toolsetSlug: 'auxx:entities:search',
     category: 'system',

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
@@ -24,6 +24,12 @@ import { formatActorResolutionError, resolveActorValues } from './resolve-actor-
 export function createUpdateEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_entity',
+    permission: {
+      target: 'definition',
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'UnifiedCrudHandler → assertEditEntity.',
+    },
     displayName: 'Update record',
     toolsetSlug: 'auxx:entities:write',
     outputSchema: UpdateEntityOutput,

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/delete-blocks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/delete-blocks.ts
@@ -8,6 +8,13 @@ import { buildOpToolResult, EXPECTED_HASH_PARAM, runBlockCrudOp } from './write-
 export function createDeleteBlocksTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'delete_blocks',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'runBlockCrudOp → assertEditInstance("kb", …).',
+    },
     displayName: 'Delete article blocks',
     toolsetSlug: 'auxx:kb:write',
     exampleOutput: {

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article-section.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article-section.ts
@@ -20,6 +20,13 @@ import { canViewKb } from '../kb-access'
 export function createGetArticleSectionTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_article_section',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewKb → canViewInstance on the article’s home KB.',
+    },
     displayName: 'Get article section',
     toolsetSlug: 'auxx:knowledge',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article.ts
@@ -23,6 +23,13 @@ import { buildActiveArticleSnapshot } from '../snapshot-pipeline'
 export function createGetArticleTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_article',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewKb on the article’s KB. Gates only the AGENT’s caps — no invoker clamp, no visibility/isPublished check (doc 18); safe today only because the tool is not registered on visitor chat.',
+    },
     displayName: 'Get article',
     toolsetSlug: 'auxx:knowledge',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/insert-blocks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/insert-blocks.ts
@@ -14,6 +14,13 @@ import {
 export function createInsertBlocksTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'insert_blocks',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'runBlockCrudOp → assertEditInstance("kb", …) — the single choke point for all four block-CRUD writes.',
+    },
     displayName: 'Insert article blocks',
     toolsetSlug: 'auxx:kb:write',
     exampleOutput: {

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/list-articles.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/list-articles.ts
@@ -20,6 +20,13 @@ const PREVIEW_CHARS = 4_000
 export function createListArticlesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_articles',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'Rows filtered by canViewKb. Same doc-18 caveat as get_article: no visitor clamp and includeUnpublished defaults true.',
+    },
     displayName: 'List articles',
     toolsetSlug: 'auxx:knowledge',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/move-blocks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/move-blocks.ts
@@ -9,6 +9,13 @@ import { buildOpToolResult, EXPECTED_HASH_PARAM, runBlockCrudOp } from './write-
 export function createMoveBlocksTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'move_blocks',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'runBlockCrudOp → assertEditInstance("kb", …).',
+    },
     displayName: 'Move article blocks',
     toolsetSlug: 'auxx:kb:write',
     exampleOutput: {

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/replace-block.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/replace-block.ts
@@ -8,6 +8,13 @@ import { buildOpToolResult, EXPECTED_HASH_PARAM, runMarkdownReplace } from './wr
 export function createReplaceBlockTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'replace_block',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'runBlockCrudOp → assertEditInstance("kb", …).',
+    },
     displayName: 'Replace article block',
     toolsetSlug: 'auxx:kb:write',
     exampleOutput: {

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/resolve-block-by-heading.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/resolve-block-by-heading.ts
@@ -17,6 +17,13 @@ import { canViewKb } from '../kb-access'
 export function createResolveBlockByHeadingTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'resolve_block_by_heading',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewKb → canViewInstance on the article’s home KB.',
+    },
     displayName: 'Find article section',
     toolsetSlug: 'auxx:knowledge',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-docs.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-docs.ts
@@ -48,6 +48,10 @@ const MAX_RESULTS = 10
 export function createSearchDocsTool(_getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'search_docs',
+    permission: {
+      target: 'none',
+      note: 'Reads the public help-center site over HTTP. Touches no workspace data and takes no org-scoped identity.',
+    },
     displayName: 'Search docs',
     toolsetSlug: 'auxx:docs',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -81,6 +81,13 @@ type Source = 'kb' | 'rag' | 'both'
 export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'search_knowledge',
+    permission: {
+      target: 'instance',
+      keys: ['kb', 'dataset'],
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'filterAccessibleDatasetIds → canViewInstance per kb/dataset, intersected with the agent’s knowledgeScope and clamped to PUBLIC articles on a visitor turn.',
+    },
     displayName: 'Search knowledge',
     toolsetSlug: 'auxx:knowledge',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-create.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-create.ts
@@ -37,6 +37,10 @@ const MAX_LABEL_LEN = 200
 export function createPlanCreateTool(_getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'plan_create',
+    permission: {
+      target: 'none',
+      note: 'Agent-loop plumbing: writes the turn’s plan into in-memory domain state. No DB, no org data.',
+    },
     displayName: 'Create plan',
     category: 'control',
     outputSchema: PlanCreateOutput,

--- a/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-update-step.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-update-step.ts
@@ -41,6 +41,10 @@ const VALID_STATUSES: PlanStepStatus[] = ['pending', 'running', 'completed', 'fa
 export function createPlanUpdateStepTool(_getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'plan_update_step',
+    permission: {
+      target: 'none',
+      note: 'Agent-loop plumbing: mutates the turn’s in-memory plan state. No DB, no org data.',
+    },
     displayName: 'Update plan step',
     category: 'control',
     outputSchema: PlanUpdateStepOutput,

--- a/packages/lib/src/ai/kopilot/capabilities/learned/tools/upsert-learned-article.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/learned/tools/upsert-learned-article.ts
@@ -46,6 +46,13 @@ export function withRecordChip(markdown: string, recordId?: string): string {
 export function createUpsertLearnedArticleTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'upsert_learned_article',
+    permission: {
+      target: 'instance',
+      keys: ['kb'],
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'assertEditInstance("kb", …) on the learned KB, plus an approval card.',
+    },
     displayName: 'Save learned article',
     // Always-on (no toolsetSlug): availability is controlled by where the
     // capability is registered (learnedMemory-flagged interactive registry +

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
@@ -112,6 +112,13 @@ function buildThreadConditions(args: Record<string, unknown>): ConditionGroup[] 
 export function createFindThreadsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'find_threads',
+    permission: {
+      target: 'unmodeled',
+      domain: 'mail',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'ThreadQueryService is constructed with getCachedUserMailVisibility — invisible threads never enter the result.',
+    },
     displayName: 'Find threads',
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
@@ -58,6 +58,13 @@ function truncate(text: string | null | undefined, maxLen: number): string {
 export function createGetThreadDetailTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'get_thread_detail',
+    permission: {
+      target: 'unmodeled',
+      domain: 'mail',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'Thread + message services both viewer-scoped; an invisible thread reads as not-found.',
+    },
     displayName: 'Read thread',
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-drafts.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-drafts.ts
@@ -63,6 +63,13 @@ function buildDraftConditions(args: Record<string, unknown>): ConditionGroup[] {
 export function createListDraftsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_drafts',
+    permission: {
+      target: 'unmodeled',
+      domain: 'mail',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'Thread ids resolved through the viewer-scoped ThreadQueryService before drafts are loaded.',
+    },
     displayName: 'List drafts',
     toolsetSlug: 'auxx:mail:drafts',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
@@ -27,6 +27,13 @@ const MAX_LIMIT = 200
 export function createListTagsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_tags',
+    permission: {
+      target: 'unmodeled',
+      domain: 'mail',
+      level: 'read',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP (19b G2/G7). Org-wide tag list with no visibility lens — the only mail read that never resolves a viewer.',
+    },
     displayName: 'List tags',
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/reply-to-thread.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/reply-to-thread.ts
@@ -60,6 +60,13 @@ const ReplyAmendmentSchema = z.object({
 export function createReplyToThreadTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'reply_to_thread',
+    permission: {
+      target: 'unmodeled',
+      domain: 'mail',
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'getThreadLens rejects on a "none" lens before drafting or sending.',
+    },
     displayName: 'Reply to thread',
     toolsetSlug: 'auxx:mail:compose',
     requiresApproval: true,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/start-new-conversation.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/start-new-conversation.ts
@@ -58,6 +58,13 @@ const StartAmendmentSchema = z.object({
 export function createStartNewConversationTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'start_new_conversation',
+    permission: {
+      target: 'unmodeled',
+      domain: 'mail',
+      level: 'read_write',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP (19b G2). Sends outbound email through MessageSenderService with no visibility lens and no capability check. Approval-gated in chat, but approval mode is "auto" on autonomous runs.',
+    },
     displayName: 'Start new conversation',
     toolsetSlug: 'auxx:mail:compose',
     requiresApproval: true,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/update-thread.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/update-thread.ts
@@ -23,6 +23,13 @@ const UpdateThreadOutput = z.object({
 export function createUpdateThreadTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_thread',
+    permission: {
+      target: 'unmodeled',
+      domain: 'mail',
+      level: 'read_write',
+      enforcement: 'enforced',
+      note: 'ThreadMutationService is constructed with the viewer; its write gate requires a full lens on the thread.',
+    },
     displayName: 'Update thread',
     toolsetSlug: 'auxx:mail:threads',
     outputSchema: UpdateThreadOutput,

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/__tests__/preview-record-view-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/__tests__/preview-record-view-capabilities.test.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/ai/kopilot/capabilities/record-views/__tests__/preview-record-view-capabilities.test.ts
+//
+// Permissions v2 §3 / plan 19b gap G6: `preview_table_view` ran
+// `countRecordMatches` against the page's definition with no `canViewEntity`,
+// making it a record-count oracle on a restricted def while its
+// `create_table_view` / `update_table_view` siblings already asserted. This is
+// the parity fix — same gate, same message as those siblings.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const countSpy = vi.fn()
+
+vi.mock('../count-matches', () => ({
+  countRecordMatches: (...args: unknown[]) => countSpy(...args),
+}))
+
+const RESOURCE = {
+  id: 'def_invoice',
+  entityDefinitionId: 'def_invoice',
+  apiSlug: 'invoice',
+  label: 'Invoice',
+  plural: 'Invoices',
+  fields: [],
+}
+
+vi.mock('../target', () => ({
+  resolveRecordViewTarget: vi.fn(async () => ({
+    resource: RESOURCE,
+    entityDefinitionId: 'def_invoice',
+    tableId: 'entity-def_invoice',
+  })),
+}))
+
+import type { CapabilityView } from '../../../../../permissions/capabilities/capability-view'
+import { Level } from '../../../../../permissions/capabilities/registry'
+import type { ToolContext } from '../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../agent-framework/types'
+import { createPreviewRecordViewTool } from '../tools/preview-record-view'
+
+/** All-permissive `CapabilityView`; override just the gate under test. */
+function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  const yes = () => true
+  const noop = () => {}
+  return {
+    can: yes,
+    has: yes,
+    assert: noop,
+    areaLevel: () => Level.Full,
+    canWriteEntity: yes,
+    assertWriteEntity: noop,
+    canEditEntity: yes,
+    assertEditEntity: noop,
+    filterEditableDefIds: (ids: string[]) => ids,
+    canViewEntity: yes,
+    assertViewEntity: noop,
+    filterViewableDefIds: (ids: string[]) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: yes,
+    assertAdministerDef: noop,
+    canViewInstance: yes,
+    canEditInstance: yes,
+    canAdminInstance: yes,
+    assertViewInstance: noop,
+    assertEditInstance: noop,
+    assertAdminInstance: noop,
+    ...overrides,
+  }
+}
+
+function runTool(capabilities?: CapabilityView) {
+  const tool = createPreviewRecordViewTool(
+    () => ({ db: {}, sessionContext: {}, capabilities }) as never
+  )
+  const ctx = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+  return tool.execute({}, ctx) as Promise<AgentToolResult>
+}
+
+beforeEach(() => {
+  countSpy.mockReset()
+  countSpy.mockResolvedValue(42)
+})
+
+describe('preview_table_view — read enforcement', () => {
+  it('previews and counts when the definition is viewable', async () => {
+    const result = await runTool(makeCapabilities())
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ matched: 42 })
+    expect(countSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('without capabilities, previews as before', async () => {
+    const result = await runTool(undefined)
+
+    expect(result.success).toBe(true)
+    expect(countSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses an unviewable definition without running the count', async () => {
+    const result = await runTool(makeCapabilities({ canViewEntity: () => false }))
+
+    expect(result.success).toBe(false)
+    expect(result.output).toBeNull()
+    expect(result.error).toContain("don't have permission")
+    expect(countSpy).not.toHaveBeenCalled()
+  })
+
+  it('the denial carries no record count and no view side-channel', async () => {
+    const result = await runTool(makeCapabilities({ canViewEntity: () => false }))
+
+    expect(JSON.stringify(result)).not.toContain('_kopilotRecordView')
+    expect(JSON.stringify(result)).not.toContain('matched')
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/create-record-view.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/create-record-view.ts
@@ -16,6 +16,12 @@ import { RECORD_VIEW_CREATE_PARAMS, readViewSpec } from './params'
 export function createCreateRecordViewTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'create_table_view',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity on the page’s def. Read is what is asserted: the write lands on TableView, not on the definition.',
+    },
     displayName: 'Save table view',
     category: 'capability',
     description: `Save a named view (filters + sort + columns) on the records table the user is currently viewing, and switch to it. The view persists and appears as a tab. The entity/table is taken from the page — you do not choose it. Filters use the same grammar as query_records; call list_entity_fields first for field ids and option values.

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/list-table-views.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/list-table-views.ts
@@ -65,6 +65,12 @@ function summarizeView(
 export function createListTableViewsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_table_views',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP (19b G7). Resolves the page’s table but never calls canViewEntity — it lists the caller’s own cached views, so an otherwise-None agent still learns the def’s saved-view names and filters. Its create/update/preview siblings all gate; this one does not.',
+    },
     displayName: 'List table views',
     category: 'capability',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/preview-record-view.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/preview-record-view.ts
@@ -16,6 +16,12 @@ import { RECORD_VIEW_PARAMS, readViewSpec } from './params'
 export function createPreviewRecordViewTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'preview_table_view',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity on the page’s def, short-circuiting before countRecordMatches so the count never leaks (19b G6).',
+    },
     displayName: 'Preview table view',
     category: 'capability',
     description: `Live-preview a filtered/sorted/column view on the records table the user is currently viewing. Applies instantly to the on-screen table WITHOUT saving. Use this to show the user a result before they commit; follow with create_table_view to save it.
@@ -29,12 +35,23 @@ Examples:
       'Inspect `warnings[]` — each means a filter/sort/column was dropped. Preview is unsaved; the user can clear it from the search bar. To persist, call create_table_view with the same args plus a name.',
     parameters: RECORD_VIEW_PARAMS,
     execute: async (args, agentDeps) => {
-      const { db, sessionContext } = getDeps()
+      const { db, sessionContext, capabilities } = getDeps()
       const target = await resolveRecordViewTarget(sessionContext, agentDeps.organizationId)
       if ('error' in target) {
         return { success: false, output: null, error: target.error }
       }
       const { resource, entityDefinitionId, tableId } = target
+
+      // Read enforcement (§3): `countRecordMatches` below is a record-count
+      // oracle on the def, so this gates identically to the create/update
+      // siblings. Absent capabilities ⇒ unrestricted, as before.
+      if (entityDefinitionId && capabilities && !capabilities.canViewEntity(entityDefinitionId)) {
+        return {
+          success: false,
+          output: null,
+          error: "You don't have permission to view these records.",
+        }
+      }
 
       const spec: ViewSpec = readViewSpec(args)
       const built = buildViewConfig(spec, resource, entityDefinitionId)

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/set-default-record-view.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/set-default-record-view.ts
@@ -17,6 +17,12 @@ import { resolveRecordViewTarget } from '../target'
 export function createSetDefaultRecordViewTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'set_default_table_view',
+    permission: {
+      target: 'definition',
+      level: 'full',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP. Gates on isAdminOrOwner — a ROLE check, not a CapabilityView assertion — and never calls canViewEntity on the def whose org-wide default it flips. It fails closed for agents only by accident of the synthetic member row carrying role:"USER".',
+    },
     displayName: 'Set default table view',
     category: 'capability',
     requiresApproval: true,

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/update-record-view.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/update-record-view.ts
@@ -19,6 +19,12 @@ import { RECORD_VIEW_UPDATE_PARAMS, readViewSpec } from './params'
 export function createUpdateRecordViewTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_table_view',
+    permission: {
+      target: 'definition',
+      level: 'read',
+      enforcement: 'enforced',
+      note: 'canViewEntity on the page’s def, matching the human router.',
+    },
     displayName: 'Update table view',
     category: 'capability',
     description: `Edit an existing saved view on the records table the user is currently viewing — change its filters, sort, columns, and/or name. Only what you pass changes; everything else (column widths, formatting, other settings) is kept. Get the viewId from list_table_views first. Filters use the same grammar as query_records.

--- a/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
@@ -26,6 +26,13 @@ const CreateTaskOutput = z.object({
 export function createCreateTaskTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'create_task',
+    permission: {
+      target: 'unmodeled',
+      domain: 'tasks',
+      level: 'read_write',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP. Creates and assigns a task for any actor with no check — deliberate, matching the ungated human task routers, and there is no target to assert against.',
+    },
     displayName: 'Create task',
     toolsetSlug: 'auxx:tasks:write',
     description:

--- a/packages/lib/src/ai/kopilot/capabilities/tasks/tools/list-tasks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/tasks/tools/list-tasks.ts
@@ -26,6 +26,13 @@ const ListTasksOutput = z.object({
 export function createListTasksTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'list_tasks',
+    permission: {
+      target: 'unmodeled',
+      domain: 'tasks',
+      level: 'read',
+      enforcement: 'unenforced',
+      note: 'KNOWN GAP (19b G7). Defaults to ALL org tasks (the in-code comment says so) with no check. Tasks are neither an entity definition nor an Area, so there is nothing to assert against today.',
+    },
     displayName: 'List tasks',
     toolsetSlug: 'auxx:tasks:read',
     idempotent: true,

--- a/packages/lib/src/ai/kopilot/capabilities/workflow/assign-variable.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow/assign-variable.ts
@@ -24,6 +24,10 @@ const AssignVariableOutput = z.object({
 export function assignVariableTool(_deps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'assign_variable',
+    permission: {
+      target: 'none',
+      note: 'Workflow plumbing: writes a variable into the active run’s execution context. Reach is bounded by the workflow the node already runs inside.',
+    },
     displayName: 'Assign variable',
     description:
       'Set a workflow variable so downstream nodes can read it. ' +

--- a/packages/lib/src/ai/mcp/tool-adapter.ts
+++ b/packages/lib/src/ai/mcp/tool-adapter.ts
@@ -84,6 +84,18 @@ function buildOne(server: CachedMcpServer, tool: CachedTool): AgentToolDefinitio
 
   return {
     name,
+    // An MCP tool's effects live on an external server, so nothing here maps to
+    // an area / definition / instance level (plan 19 §11.8). Its authorization is
+    // the two-flag trust model on the server snapshot: autonomous runs drop
+    // untrusted non-read-only tools (above), `requiresApproval` is
+    // `!readOnlyHint && !trusted`, and output is fenced as untrusted external
+    // data. Marked `bridge` (never `none`) so the audit can tell
+    // "unclassifiable" from "verified to need nothing".
+    permission: {
+      target: 'bridge',
+      governedBy: 'mcp',
+      note: 'External MCP server: org-set `trusted` + server-declared `readOnlyHint` drive the autonomous drop and the approval gate. No platform-level target exists.',
+    },
     displayName: tool.title ?? tool.name,
     description: `${tool.description ?? tool.name}\n(via ${server.name} MCP server)`,
     parameters: tool.inputSchema,

--- a/packages/lib/src/cache/providers/mail-grant-index-provider.test.ts
+++ b/packages/lib/src/cache/providers/mail-grant-index-provider.test.ts
@@ -69,6 +69,52 @@ describe('composeMailGrantIndex', () => {
     expect(index.threads.t_1).toEqual([{ userId: 'u_1', lens: 'full' }])
   })
 
+  it('expands profile grants to the profile’s holders (19a #11)', () => {
+    const index = composeMailGrantIndex({
+      rows: [row({ granteeType: 'profile', granteeId: 'prof_member', lens: 'subject' })],
+      memberUserIds: ['u_1', 'u_2', 'u_3'],
+      groupIdsByUser: {},
+      // u_1 bound explicitly, u_2 null-bound and resolved to the same system
+      // profile, u_3 on a different profile.
+      profileIdByUser: { u_1: 'prof_member', u_2: 'prof_member', u_3: 'prof_field' },
+    })
+    expect(index.threads.t_1).toEqual([
+      { userId: 'u_1', lens: 'subject' },
+      { userId: 'u_2', lens: 'subject' },
+    ])
+  })
+
+  it('does not reinterpret a profile grantee id as a group id (19a finding 4)', () => {
+    // The pre-step-9 ternary fell through to `usersByGroup.get(granteeId)`. If a
+    // group and a profile ever shared an id, the grant would have expanded to
+    // the WRONG audience instead of merely being dropped.
+    const index = composeMailGrantIndex({
+      rows: [row({ granteeType: 'profile', granteeId: 'collision' })],
+      memberUserIds: ['u_1', 'u_2'],
+      groupIdsByUser: { u_2: ['collision'] },
+      profileIdByUser: { u_1: 'collision' },
+    })
+    expect(index.threads.t_1).toEqual([{ userId: 'u_1', lens: 'full' }])
+  })
+
+  it('drops an unknown grantee kind instead of treating it as a group', () => {
+    const index = composeMailGrantIndex({
+      rows: [row({ granteeType: 'future_kind', granteeId: 'g_1' })],
+      memberUserIds: ['u_1'],
+      groupIdsByUser: { u_1: ['g_1'] },
+    })
+    expect(index.threads).toEqual({})
+  })
+
+  it('ignores a role grantee that is not the org_member baseline', () => {
+    const index = composeMailGrantIndex({
+      rows: [row({ granteeType: 'role', granteeId: 'org_admin' })],
+      memberUserIds: ['u_1', 'u_2'],
+      groupIdsByUser: {},
+    })
+    expect(index.threads).toEqual({})
+  })
+
   it('buckets inbox grants into the inboxes index (§10.1 delta audience)', () => {
     const index = composeMailGrantIndex({
       rows: [

--- a/packages/lib/src/cache/providers/mail-grant-index-provider.ts
+++ b/packages/lib/src/cache/providers/mail-grant-index-provider.ts
@@ -1,9 +1,13 @@
 // packages/lib/src/cache/providers/mail-grant-index-provider.ts
 
 import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray, isNotNull } from 'drizzle-orm'
 import { type Lens, maxLens } from '../../permissions/visibility/lens'
+import { resolveProfileIdByUser } from '../../resource-access/grantee-resolution'
 import type { CacheProvider } from '../org-cache-provider'
+
+const logger = createScopedLogger('mail-grant-index')
 
 /** One resolved grantee of a thread/contact grant. */
 export interface MailGrantEntry {
@@ -33,8 +37,51 @@ interface IndexGrantRow {
 }
 
 /**
+ * Expand ONE grant row's grantee to the user ids it reaches. Exhaustive over the
+ * `ResourceGranteeType` vocabulary — an unknown kind resolves to nobody and says
+ * so, instead of being silently reinterpreted as a group id.
+ */
+function expandGrantee(
+  row: IndexGrantRow,
+  ctx: {
+    memberUserIds: string[]
+    usersByGroup: Map<string, string[]>
+    usersByProfile: Map<string, string[]>
+  }
+): string[] {
+  switch (row.granteeType) {
+    case 'user':
+      return [row.granteeId]
+    case 'role':
+      // `org_member` is the only role grantee on ResourceAccess — the
+      // def/workspace baseline marker (doc 19 §11a deviation 2).
+      return row.granteeId === 'org_member' ? ctx.memberUserIds : []
+    case 'group':
+    case 'team':
+      return ctx.usersByGroup.get(row.granteeId) ?? []
+    case 'profile':
+      return ctx.usersByProfile.get(row.granteeId) ?? []
+    default:
+      logger.warn('Unhandled ResourceAccess granteeType in mail grant index — row ignored', {
+        granteeType: row.granteeType,
+        granteeId: row.granteeId,
+        entityDefinitionId: row.entityDefinitionId,
+        entityInstanceId: row.entityInstanceId,
+      })
+      return []
+  }
+}
+
+/**
  * Pure composition — grant rows + cached membership shapes in, inverted
  * per-user audience maps out. IO lives in the provider below.
+ *
+ * This is the REVERSE of `computeUserMailVisibility`; the two must expand the
+ * same grantee kinds or a share is visible in one direction only (19a finding
+ * 4). Until doc 19 step 9 the expansion was a ternary whose final branch treated
+ * ANY unrecognised `granteeId` as a group instance id — a `profile` grantee
+ * resolved to `[]` and was dropped by the `length === 0` guard with no error and
+ * no log. The switch below is exhaustive and warns on the default.
  */
 export function composeMailGrantIndex(input: {
   rows: IndexGrantRow[]
@@ -42,8 +89,14 @@ export function composeMailGrantIndex(input: {
   memberUserIds: string[]
   /** Cached `groupMembers` shape: userId → groupInstanceIds. */
   groupIdsByUser: Record<string, string[]>
+  /**
+   * `userId → resolved base permission profile id` (`resolveProfileIdByUser`).
+   * Includes the null-bound majority, whose profile resolves in code from
+   * `(role, seatType)` — so a grant on a system profile reaches them too.
+   */
+  profileIdByUser?: Record<string, string>
 }): MailGrantIndex {
-  const { rows, memberUserIds, groupIdsByUser } = input
+  const { rows, memberUserIds, groupIdsByUser, profileIdByUser = {} } = input
 
   // Invert userId → groupIds into groupId → userIds once.
   const usersByGroup = new Map<string, string[]>()
@@ -55,16 +108,19 @@ export function composeMailGrantIndex(input: {
     }
   }
 
+  // Invert userId → profileId into profileId → userIds once.
+  const usersByProfile = new Map<string, string[]>()
+  for (const [userId, profileId] of Object.entries(profileIdByUser)) {
+    const arr = usersByProfile.get(profileId) ?? []
+    arr.push(userId)
+    usersByProfile.set(profileId, arr)
+  }
+
   const index: MailGrantIndex = { threads: {}, contacts: {}, inboxes: {} }
 
   for (const row of rows) {
     const lens: Lens = row.permission === 'view' ? (row.lens ?? 'full') : 'full'
-    const userIds =
-      row.granteeType === 'user'
-        ? [row.granteeId]
-        : row.granteeType === 'role' && row.granteeId === 'org_member'
-          ? memberUserIds
-          : (usersByGroup.get(row.granteeId) ?? [])
+    const userIds = expandGrantee(row, { memberUserIds, usersByGroup, usersByProfile })
 
     if (userIds.length === 0) continue
 
@@ -116,10 +172,22 @@ export const mailGrantIndexProvider: CacheProvider<MailGrantIndex> = {
       getOrgCache().get(orgId, 'groupMembers'),
     ])
 
+    // Only resolve the profile map when a profile-grantee row actually exists —
+    // it walks every member of the org, and profile-scoped mail shares are rare.
+    let profileIdByUser: Record<string, string> = {}
+    if (rows.some((r: { granteeType: string }) => r.granteeType === 'profile')) {
+      const [roleMap, profiles] = await Promise.all([
+        getOrgCache().get(orgId, 'memberRoleMap'),
+        getOrgCache().get(orgId, 'profiles'),
+      ])
+      profileIdByUser = resolveProfileIdByUser({ organizationId: orgId, roleMap, profiles })
+    }
+
     return composeMailGrantIndex({
       rows: rows as IndexGrantRow[],
       memberUserIds: members.map((m) => m.userId),
       groupIdsByUser,
+      profileIdByUser,
     })
   },
 }

--- a/packages/lib/src/cache/providers/restricted-entity-def-ids-provider.ts
+++ b/packages/lib/src/cache/providers/restricted-entity-def-ids-provider.ts
@@ -23,6 +23,15 @@ import type { CacheProvider } from '../org-cache-provider'
  * must never mark a def as restricted. The def-restriction write path (Phase 3
  * Access UI) must therefore always write the EntityDefinition CUID.
  *
+ * **The grantee-agnostic `selectDistinct` is load-bearing — do NOT add a grantee
+ * filter here.** It is also the reason every *reader* must understand every
+ * grantee kind (doc 19 §8.2 / 19a finding 1): because ANY row marks the def
+ * restricted while `defAccess` only carries the kinds a reader can resolve, a
+ * grantee kind that some resolver cannot read does not fail closed for that
+ * grantee — it makes the def go dark **for every non-admin in the org**. That
+ * asymmetry, not the write itself, is why profile-grantee `ResourceAccess`
+ * writes were refused until all four resolvers learned the kind.
+ *
  * Invalidated by the `resource-access.type.changed` cache event (fired on every
  * type-level grant/revoke).
  */

--- a/packages/lib/src/cache/providers/restricted-instance-ids-provider.ts
+++ b/packages/lib/src/cache/providers/restricted-instance-ids-provider.ts
@@ -18,6 +18,12 @@ import type { CacheProvider } from '../org-cache-provider'
  * mail-share instance rows (`contact:<id>` etc.) are excluded by the `IN (...)`
  * filter, so they never enter the capability path.
  *
+ * **Grantee-agnostic by design — do NOT add a grantee filter.** Same asymmetry
+ * as the type-level provider (19a finding 1): one row of a grantee kind a
+ * resolver cannot read hides the instance from every non-admin, not just from
+ * that grantee. Adding a grantee kind to the storage vocabulary therefore means
+ * adding it to every reader in the same change.
+ *
  * Invalidated by the `resource-access.instance.changed` cache event.
  */
 export const restrictedInstanceIdsProvider: CacheProvider<string[]> = {

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -122,7 +122,14 @@ export const USER_CACHE_KEY_CONFIG: Record<
   // USER-scoped so an org flush does not reach it: without the bump, members
   // would ride a stale key set for the full ONE_DAY TTL — and a stale blob 403s
   // admins on anything the old composition didn't include.
+  // v7: permission-profile DEFINITION ceilings (doc 19 step 4). `UserCapabilities`
+  // gained `ceilingDefs` — the bound profile's `{ mode, slugs }` cap, carried raw
+  // and slug-keyed so def lifecycle events never have to touch this key. A v6 blob
+  // lacks the field entirely, which `effectiveRecordLevel` reads as "uncapped": a
+  // member whose profile says `only: [contact]` would keep full record access for
+  // the rest of the ONE_DAY TTL. Fail-open on a stale blob is exactly what a
+  // ceiling must never do, so the old blobs are abandoned rather than migrated.
   // NOTE: bump this whenever the registry's area/key set or the UserCapabilities
   // shape changes, so a rollout can't leave members on a stale key set.
-  userCapabilities: { prefix: 'user:capabilities:v6', ttlSeconds: ONE_DAY },
+  userCapabilities: { prefix: 'user:capabilities:v7', ttlSeconds: ONE_DAY },
 }

--- a/packages/lib/src/dashboards/dashboard-mutations.ts
+++ b/packages/lib/src/dashboards/dashboard-mutations.ts
@@ -44,6 +44,13 @@ export type CreateDashboardInput = {
  * Grantees affected by a dashboard's create-time (or duplicate-time) baseline
  * write — the workspace-baseline role grant, plus the owner's `admin` grant when
  * there's a human owner. Feeds {@link emitResourceAccessInstanceChanged}.
+ *
+ * The fixed two-element list is correct and stays fixed even though the grantee
+ * vocabulary now includes `profile` (19a #54): these grants are only ever
+ * written against a **freshly minted** dashboard id inside the create/duplicate
+ * transaction, so no row of any other grantee kind can pre-exist. There is no
+ * "reset to baseline" path here — a dashboard's later sharing goes through
+ * `grantInstanceAccess`/`setInstanceAccess`, which resolve grantees generically.
  */
 function baselineGrantees(
   ownerId: string | null

--- a/packages/lib/src/dashboards/dashboard-privacy.test.ts
+++ b/packages/lib/src/dashboards/dashboard-privacy.test.ts
@@ -1,0 +1,54 @@
+// packages/lib/src/dashboards/dashboard-privacy.test.ts
+
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { type DashboardShareRow, isPrivateFromBaseline } from './dashboard-queries'
+
+const OWNER = 'u_owner'
+
+const share = (over: Partial<DashboardShareRow>): DashboardShareRow => ({
+  entityInstanceId: 'dash_1',
+  granteeType: ResourceGranteeType.group,
+  granteeId: 'g_1',
+  ...over,
+})
+
+describe('isPrivateFromBaseline', () => {
+  it('is private with no baseline row and nothing shared', () => {
+    expect(isPrivateFromBaseline(undefined, [], OWNER)).toBe(true)
+  })
+
+  it('is private with an explicit none baseline', () => {
+    expect(isPrivateFromBaseline(ResourcePermission.none, [], OWNER)).toBe(true)
+  })
+
+  it('is not private once the workspace baseline opens it', () => {
+    expect(isPrivateFromBaseline(ResourcePermission.view, [], OWNER)).toBe(false)
+  })
+
+  it('stays private when the only grant is the owner’s own admin row', () => {
+    const owned = [share({ granteeType: ResourceGranteeType.user, granteeId: OWNER })]
+    expect(isPrivateFromBaseline(ResourcePermission.none, owned, OWNER)).toBe(true)
+  })
+
+  it('is NOT private when shared with a permission profile (19a #14)', () => {
+    const shared = [share({ granteeType: ResourceGranteeType.profile, granteeId: 'prof_field' })]
+    expect(isPrivateFromBaseline(ResourcePermission.none, shared, OWNER)).toBe(false)
+  })
+
+  it('is NOT private when shared with a group or another user', () => {
+    expect(isPrivateFromBaseline(undefined, [share({})], OWNER)).toBe(false)
+    expect(
+      isPrivateFromBaseline(
+        undefined,
+        [share({ granteeType: ResourceGranteeType.user, granteeId: 'u_other' })],
+        OWNER
+      )
+    ).toBe(false)
+  })
+
+  it('treats an ownerless dashboard’s user grants as real shares', () => {
+    const shared = [share({ granteeType: ResourceGranteeType.user, granteeId: 'u_someone' })]
+    expect(isPrivateFromBaseline(undefined, shared, null)).toBe(false)
+  })
+})

--- a/packages/lib/src/dashboards/dashboard-queries.ts
+++ b/packages/lib/src/dashboards/dashboard-queries.ts
@@ -2,7 +2,7 @@
 
 import { type DashboardEntity, type Database, schema } from '@auxx/database'
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
-import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, isNotNull, isNull, ne, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { NotFoundError, UnprocessableEntityError } from '../errors'
 import { resolveEntityIdFromCache } from '../resources/crud/unified-handler-queries'
@@ -52,9 +52,74 @@ export async function getWorkspaceBaselinePermission(
   return row?.permission as ResourcePermission | undefined
 }
 
-/** No baseline row, or an explicit `'none'` row, ⇒ private (doc 13 §3). */
-function isPrivateFromBaseline(permission: ResourcePermission | undefined): boolean {
-  return permission === undefined || permission === ResourcePermission.none
+/** One non-baseline grant row on a dashboard instance. */
+export type DashboardShareRow = {
+  entityInstanceId: string
+  granteeType: string
+  granteeId: string
+}
+
+/**
+ * Every NON-baseline instance grant on dashboards in this org — grants to a
+ * specific user, group, team or **permission profile**. One query, not N+1;
+ * scoped to a single dashboard when `dashboardId` is given.
+ *
+ * `role` rows are excluded because that is the workspace baseline itself, which
+ * {@link getWorkspaceBaselinePermission} already reads, and `permission: 'none'`
+ * rows grant nobody (see `PERMISSION_HIERARCHY`).
+ */
+async function loadDashboardShares(
+  db: Database,
+  orgId: string,
+  dashboardId?: string
+): Promise<DashboardShareRow[]> {
+  const rows = await db
+    .select({
+      entityInstanceId: schema.ResourceAccess.entityInstanceId,
+      granteeType: schema.ResourceAccess.granteeType,
+      granteeId: schema.ResourceAccess.granteeId,
+    })
+    .from(schema.ResourceAccess)
+    .where(
+      and(
+        eq(schema.ResourceAccess.organizationId, orgId),
+        eq(schema.ResourceAccess.entityDefinitionId, DASHBOARD_KEY),
+        dashboardId
+          ? eq(schema.ResourceAccess.entityInstanceId, dashboardId)
+          : isNotNull(schema.ResourceAccess.entityInstanceId),
+        ne(schema.ResourceAccess.granteeType, ResourceGranteeType.role),
+        ne(schema.ResourceAccess.permission, ResourcePermission.none)
+      )
+    )
+  return rows
+    .filter((r) => r.entityInstanceId !== null)
+    .map((r) => ({
+      entityInstanceId: r.entityInstanceId as string,
+      granteeType: r.granteeType as string,
+      granteeId: r.granteeId,
+    }))
+}
+
+/**
+ * Private ⇒ the workspace baseline is absent or `'none'` **and** nobody other
+ * than the owner holds a grant (doc 13 §3).
+ *
+ * The second half is new in doc 19 step 9. `isPrivate` used to be derived from
+ * the `role:org_member` baseline alone, so a dashboard shared with a group — or,
+ * once profile grantees became writable, with a permission profile — was
+ * labelled "Private" in every list while other members could open it (19a #14).
+ * The owner's own create-time `admin` row is excluded: a dashboard only its
+ * creator can reach is still private.
+ */
+export function isPrivateFromBaseline(
+  permission: ResourcePermission | undefined,
+  shares: DashboardShareRow[] = [],
+  ownerId: string | null = null
+): boolean {
+  if (permission !== undefined && permission !== ResourcePermission.none) return false
+  return !shares.some(
+    (s) => !(s.granteeType === ResourceGranteeType.user && s.granteeId === ownerId)
+  )
 }
 
 function toSummary(
@@ -126,6 +191,8 @@ export async function listDashboards(
     FROM jsonb_array_elements(${schema.DashboardVersion.layout} -> 'tabs') AS t
   ), 0)`
 
+  const sharesPromise = loadDashboardShares(db, orgId)
+
   const rows = await db
     .select({
       dashboard: schema.Dashboard,
@@ -151,13 +218,24 @@ export async function listDashboards(
     .where(and(eq(schema.Dashboard.organizationId, orgId), isNull(schema.Dashboard.archivedAt)))
     .orderBy(asc(schema.Dashboard.position), asc(schema.Dashboard.name))
 
+  const sharesByDashboard = new Map<string, DashboardShareRow[]>()
+  for (const share of await sharesPromise) {
+    const bucket = sharesByDashboard.get(share.entityInstanceId) ?? []
+    bucket.push(share)
+    sharesByDashboard.set(share.entityInstanceId, bucket)
+  }
+
   return ok(
     rows.map((r) =>
       toSummary(
         r.dashboard,
         Number(r.tabCount),
         Number(r.widgetCount),
-        isPrivateFromBaseline(r.baselinePermission as ResourcePermission | undefined)
+        isPrivateFromBaseline(
+          r.baselinePermission as ResourcePermission | undefined,
+          sharesByDashboard.get(r.dashboard.id) ?? [],
+          r.dashboard.createdById
+        )
       )
     )
   )
@@ -199,14 +277,17 @@ async function loadDashboardWithLayout(
   const draftResult = parseDraftLayoutDoc(row.draftLayout)
   if (draftResult.isErr()) return err(draftResult.error)
 
-  const baselinePermission = await getWorkspaceBaselinePermission(db, orgId, row.id)
+  const [baselinePermission, shares] = await Promise.all([
+    getWorkspaceBaselinePermission(db, orgId, row.id),
+    loadDashboardShares(db, orgId, row.id),
+  ])
 
   return ok({
     id: row.id,
     name: row.name,
     description: row.description,
     icon: row.icon ?? null,
-    isPrivate: isPrivateFromBaseline(baselinePermission),
+    isPrivate: isPrivateFromBaseline(baselinePermission, shares, row.createdById),
     position: row.position,
     createdById: row.createdById,
     activeVersionId: row.activeVersionId,

--- a/packages/lib/src/field-values/converters/actor.ts
+++ b/packages/lib/src/field-values/converters/actor.ts
@@ -78,6 +78,14 @@ export const actorConverter: FieldValueConverter = {
       // Check if it's an ActorId format (e.g., "user:abc123")
       if (isActorId(trimmed)) {
         const { type, id } = parseActorId(trimmed as ActorId)
+        // An ACTOR field addresses an assignable IDENTITY. `profile:` is an
+        // ActorId kind (it is a grantee — doc 19 §0.28) but not an identity: it
+        // has no `User` row for `actorId` and no storage branch of its own, so
+        // writing one here would read back as a group (see the ACTOR field-value
+        // storage routing note). Explicitly unconvertible, not silently coerced —
+        // before this it fell through to the branch below and stored the whole
+        // `profile:<id>` string as if it were a User id.
+        if (type === 'profile') return null
         return { type: 'actor', actorType: type, id }
       }
 

--- a/packages/lib/src/permissions/capabilities/capability-set-administer.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-administer.test.ts
@@ -4,6 +4,7 @@ import type { ResourcePermission } from '@auxx/database/enums'
 import type { SeatType } from '@auxx/database/types'
 import { describe, expect, it } from 'vitest'
 import { CapabilitySet } from './capability-set'
+import { administersAnyDef, toResolvedRecordAccess } from './entity-access'
 import { PermissionKey } from './registry'
 
 /**
@@ -11,6 +12,12 @@ import { PermissionKey } from './registry'
  * `Full`/`admin` rung — managing a def's fields, its access, its metadata, and
  * deleting the def. Unlike record writes, it does NOT flow from the base records
  * level: only an explicit `admin` type-grant (or OWNER/ADMIN) confers it.
+ *
+ * As of doc 19 step 4 the resolver reads `effectiveRecordLevel` rather than the
+ * raw `defAccess` map, so the profile definition ceiling and the worker seat
+ * ceiling apply here too. The base rungs top out at `edit`, so routing through
+ * the effective level does NOT let a base-`Full` member administer a def — every
+ * assertion below is unchanged by the repoint.
  */
 
 const defIdToDefinitionId = (id: string) =>
@@ -22,6 +29,7 @@ const build = (opts: {
   restricted?: string[]
   role?: 'OWNER' | 'ADMIN' | 'USER'
   seatType?: SeatType
+  ceilingDefs?: { mode: 'only' | 'except'; defIds: string[] } | null
 }) =>
   new CapabilitySet(
     new Set(opts.keys ?? [PermissionKey.recordsView, PermissionKey.recordsEdit]),
@@ -30,7 +38,13 @@ const build = (opts: {
     opts.seatType ?? 'full',
     (id) => id,
     new Set(opts.restricted ?? []),
-    defIdToDefinitionId
+    defIdToDefinitionId,
+    {},
+    new Set(),
+    {},
+    opts.ceilingDefs
+      ? { mode: opts.ceilingDefs.mode, defIds: new Set(opts.ceilingDefs.defIds) }
+      : null
   )
 
 const READ_WRITE = [PermissionKey.recordsView, PermissionKey.recordsEdit]
@@ -86,6 +100,32 @@ describe('CapabilitySet.canAdministerDef (Full/admin rung, §9.1)', () => {
     expect(worker.canAdministerDef('invoice-def')).toBe(false)
   })
 
+  it('an `admin` grant on a def the profile ceiling excludes does not administer it', () => {
+    const only = build({
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+      ceilingDefs: { mode: 'only', defIds: ['contact-def'] },
+    })
+    expect(only.canAdministerDef('invoice-def')).toBe(false)
+    expect(() => only.assertAdministerDef('invoice-def')).toThrow()
+
+    const except = build({
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+      ceilingDefs: { mode: 'except', defIds: ['invoice-def'] },
+    })
+    expect(except.canAdministerDef('invoice-def')).toBe(false)
+  })
+
+  it('a def the ceiling still admits keeps its `admin` grant', () => {
+    const caps = build({
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+      ceilingDefs: { mode: 'only', defIds: ['invoice-def'] },
+    })
+    expect(caps.canAdministerDef('invoice-def')).toBe(true)
+  })
+
   it('scoped to the exact def — an `admin` grant on one def does not administer another', () => {
     const caps = build({
       restricted: ['invoice-def', 'salary-def'],
@@ -94,6 +134,66 @@ describe('CapabilitySet.canAdministerDef (Full/admin rung, §9.1)', () => {
     expect(caps.canAdministerDef('invoice-def')).toBe(true)
     expect(caps.canAdministerDef('salary-def')).toBe(false)
     expect(caps.canAdministerDef('contact-def')).toBe(false)
+  })
+})
+
+describe('administersAnyDef (org-wide "is there any def-admin surface for me")', () => {
+  const resolved = (opts: Parameters<typeof build>[0]) =>
+    toResolvedRecordAccess(build(opts).toClientCapabilities())
+
+  it('true for a def-`admin` grantee the ceiling still admits', () => {
+    expect(
+      administersAnyDef(
+        resolved({
+          restricted: ['invoice-def'],
+          defAccess: { 'invoice-def': 'admin' },
+          ceilingDefs: { mode: 'only', defIds: ['invoice-def'] },
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('false when every `admin` grant is outside the ceiling — the org-wide hole (§3)', () => {
+    expect(
+      administersAnyDef(
+        resolved({
+          restricted: ['invoice-def'],
+          defAccess: { 'invoice-def': 'admin' },
+          ceilingDefs: { mode: 'only', defIds: ['contact-def'] },
+        })
+      )
+    ).toBe(false)
+    expect(
+      administersAnyDef(
+        resolved({
+          restricted: ['invoice-def'],
+          defAccess: { 'invoice-def': 'admin' },
+          ceilingDefs: { mode: 'except', defIds: ['invoice-def'] },
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('true when at least ONE admitted def carries an `admin` grant', () => {
+    expect(
+      administersAnyDef(
+        resolved({
+          restricted: ['invoice-def', 'contact-def'],
+          defAccess: { 'invoice-def': 'admin', 'contact-def': 'admin' },
+          ceilingDefs: { mode: 'except', defIds: ['invoice-def'] },
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('OWNER/ADMIN are never clamped by it', () => {
+    for (const role of ['OWNER', 'ADMIN'] as const) {
+      expect(
+        administersAnyDef(
+          resolved({ role, defAccess: {}, ceilingDefs: { mode: 'only', defIds: [] } })
+        )
+      ).toBe(true)
+    }
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-view.test.ts
@@ -3,7 +3,12 @@
 import type { ResourcePermission } from '@auxx/database/enums'
 import { describe, expect, it } from 'vitest'
 import { CapabilitySet } from './capability-set'
-import { canViewRecord, toResolvedRecordAccess } from './entity-access'
+import {
+  administersAnyDef,
+  canEditRecord,
+  canViewRecord,
+  toResolvedRecordAccess,
+} from './entity-access'
 import { PermissionKey } from './registry'
 
 /**
@@ -25,6 +30,7 @@ const build = (opts: {
   role?: 'OWNER' | 'ADMIN' | 'USER'
   seatType?: 'full' | 'worker'
   defBaseOverrides?: Record<string, ResourcePermission | null>
+  ceilingDefs?: { mode: 'only' | 'except'; defIds: string[] } | null
 }) =>
   new CapabilitySet(
     new Set(opts.keys ?? (opts.hasView === false ? [] : [PermissionKey.recordsView])),
@@ -36,7 +42,10 @@ const build = (opts: {
     defIdToDefinitionId,
     {},
     new Set(),
-    opts.defBaseOverrides ?? {}
+    opts.defBaseOverrides ?? {},
+    opts.ceilingDefs
+      ? { mode: opts.ceilingDefs.mode, defIds: new Set(opts.ceilingDefs.defIds) }
+      : null
   )
 
 describe('CapabilitySet.canViewEntity (absent = unrestricted)', () => {
@@ -190,6 +199,101 @@ describe('CapabilitySet.canViewEntity (absent = unrestricted)', () => {
     // base verb — in practice they always hold records.view (role default Full).
     const adminNoVerb = build({ role: 'ADMIN', hasView: false, restricted: ['invoice-def'] })
     expect(adminNoVerb.canViewEntity('invoice-def')).toBe(true)
+  })
+})
+
+describe('profile definition ceiling (doc 19 §0.13 / step 4)', () => {
+  it('`only` admits exactly the listed defs — an unlisted one is denied (fails closed)', () => {
+    const caps = build({
+      keys: [PermissionKey.recordsView, PermissionKey.recordsEdit],
+      ceilingDefs: { mode: 'only', defIds: ['contact-def'] },
+    })
+    expect(caps.canViewEntity('contact-def')).toBe(true)
+    expect(caps.canEditEntity('contact-def')).toBe(true)
+    expect(caps.canViewEntity('invoice-def')).toBe(false)
+    expect(caps.canEditEntity('invoice-def')).toBe(false)
+  })
+
+  it('`only` excludes a def created LATER — the allow-list is closed by construction', () => {
+    // `defIds` is resolved from the profile's stored apiSlugs at read time, so a
+    // definition nobody has listed is simply not in the set.
+    const caps = build({ ceilingDefs: { mode: 'only', defIds: ['contact-def'] } })
+    expect(caps.canViewEntity('brand-new-def')).toBe(false)
+  })
+
+  it('`except` denies exactly the listed defs and admits new ones (fails open)', () => {
+    const caps = build({
+      keys: [PermissionKey.recordsView, PermissionKey.recordsEdit],
+      ceilingDefs: { mode: 'except', defIds: ['salary-def'] },
+    })
+    expect(caps.canViewEntity('salary-def')).toBe(false)
+    expect(caps.canEditEntity('salary-def')).toBe(false)
+    expect(caps.canViewEntity('contact-def')).toBe(true)
+    expect(caps.canViewEntity('brand-new-def')).toBe(true)
+  })
+
+  it('outranks an explicit def grant — the ceiling is a cap, not another grant tier', () => {
+    const caps = build({
+      restricted: ['invoice-def'],
+      defAccess: { 'invoice-def': 'admin' },
+      ceilingDefs: { mode: 'only', defIds: ['contact-def'] },
+    })
+    expect(caps.canViewEntity('invoice-def')).toBe(false)
+    expect(caps.canAdministerDef('invoice-def')).toBe(false)
+  })
+
+  it('normalizes its argument before the ceiling check (slug/apiSlug forms)', () => {
+    const caps = build({ ceilingDefs: { mode: 'except', defIds: ['invoice-def'] } })
+    expect(caps.canViewEntity('invoice')).toBe(false)
+    expect(caps.canViewEntity('invoices')).toBe(false)
+  })
+
+  it('OWNER is never clamped by it (§0.10 recovery guarantee)', () => {
+    // The composer emits `null` for OWNER, but the resolver short-circuits before
+    // the ceiling too — belt and braces, since a mis-shaped profile must always
+    // stay fixable from inside the product.
+    const owner = build({ role: 'OWNER', ceilingDefs: { mode: 'only', defIds: ['contact-def'] } })
+    expect(owner.canViewEntity('invoice-def')).toBe(true)
+    expect(owner.canAdministerDef('invoice-def')).toBe(true)
+  })
+
+  it('the worker `recordsViewLinked` carve-out respects it (a field seat cannot walk around it)', () => {
+    // The carve-out returns true for ANY unrestricted def without consulting
+    // `effectiveRecordLevel`, so the clamp has to be re-applied inside it.
+    const fieldSeat = build({
+      keys: [PermissionKey.recordsViewLinked],
+      seatType: 'worker',
+      ceilingDefs: { mode: 'only', defIds: ['work-order-def'] },
+    })
+    expect(fieldSeat.canViewEntity('work-order-def')).toBe(true)
+    expect(fieldSeat.canViewEntity('invoice-def')).toBe(false)
+  })
+
+  it('a `null` ceiling leaves every def resolution exactly as it was', () => {
+    const caps = build({ ceilingDefs: null })
+    expect(caps.canViewEntity('invoice-def')).toBe(true)
+    expect(caps.canViewEntity('anything-else')).toBe(true)
+  })
+
+  it('survives the server→client round trip (toClientCapabilities → toResolvedRecordAccess)', () => {
+    const caps = build({
+      keys: [PermissionKey.recordsView, PermissionKey.recordsEdit],
+      ceilingDefs: { mode: 'only', defIds: ['contact-def'] },
+    })
+    const snapshot = caps.toClientCapabilities()
+    expect(snapshot.ceilingDefs).toEqual({ mode: 'only', defIds: ['contact-def'] })
+    const client = toResolvedRecordAccess(snapshot)
+    expect(canViewRecord(client, 'contact-def')).toBe(true)
+    // The UI must not offer what the server denies.
+    expect(canViewRecord(client, 'invoice-def')).toBe(false)
+    expect(canEditRecord(client, 'invoice-def')).toBe(false)
+    expect(administersAnyDef(client)).toBe(false)
+  })
+
+  it('serializes `null` when uncapped, and rehydrates to an uncapped client view', () => {
+    const snapshot = build({}).toClientCapabilities()
+    expect(snapshot.ceilingDefs).toBeNull()
+    expect(canViewRecord(toResolvedRecordAccess(snapshot), 'invoice-def')).toBe(true)
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -12,6 +12,7 @@ import {
   canViewRecord,
   levelToPermission,
   NON_RECORD_DEF_SLUGS,
+  type ResolvedDefCeiling,
   type ResolvedRecordAccess,
 } from './entity-access'
 import { INSTANCE_ACCESS_RESOURCES, type InstanceAccessKey } from './instance-access'
@@ -69,6 +70,10 @@ export class CapabilitySet implements CapabilityView {
    * @param defBaseOverrides Per-def record base for defs whose base comes from
    *                   another Layer-2 area. Canonical `entityDefinitionId`
    *                   keys; `null` means that area is closed.
+   * @param ceilingDefs The bound permission profile's per-definition cap
+   *                   (doc 19 §0.13), already resolved from apiSlugs to
+   *                   canonical `entityDefinitionId`s in {@link getCapabilities}.
+   *                   `null` = uncapped (always so for OWNER, §0.10).
    */
   constructor(
     private readonly keys: ReadonlySet<PermissionKey>,
@@ -80,7 +85,8 @@ export class CapabilitySet implements CapabilityView {
     private readonly defIdToDefinitionId: DefIdToSlug = (id) => id,
     private readonly instanceAccess: Readonly<Record<string, ResourcePermission>> = {},
     private readonly restrictedInstanceIds: ReadonlySet<string> = new Set(),
-    private readonly defBaseOverrides: Readonly<Record<string, ResourcePermission | null>> = {}
+    private readonly defBaseOverrides: Readonly<Record<string, ResourcePermission | null>> = {},
+    private readonly ceilingDefs: ResolvedDefCeiling | null = null
   ) {}
 
   /** O(1) Set lookup — whether the member holds `key`. */
@@ -144,6 +150,7 @@ export class CapabilitySet implements CapabilityView {
       defAccess: this.defAccess,
       restrictedEntityDefIds: this.restrictedDefIds,
       defBaseOverrides: this.defBaseOverrides,
+      ceilingDefs: this.ceilingDefs,
     }
   }
 
@@ -161,6 +168,9 @@ export class CapabilitySet implements CapabilityView {
       seatType: this.seatType,
       instanceAccess: { ...this.instanceAccess },
       restrictedInstanceIds: [...this.restrictedInstanceIds],
+      ceilingDefs: this.ceilingDefs
+        ? { mode: this.ceilingDefs.mode, defIds: [...this.ceilingDefs.defIds] }
+        : null,
     }
   }
 

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -423,14 +423,75 @@ describe('composeUserCapabilities — permission profiles (doc 19 §2.1)', () =>
     expect(sorted(caps.keys)).toEqual(sorted(effectiveDefault('USER', 'full')))
   })
 
-  it('a ceiling with no `areas` map (defs-only) clamps nothing — def enforcement is step 4', () => {
+  it('a defs-only ceiling clamps no AREA key but IS emitted for def enforcement (step 4)', () => {
     const caps = composeUserCapabilities({
       role: 'USER',
       seatType: 'full',
       profileCeiling: { defs: { mode: 'only', slugs: ['contact'] } },
       typeAccessRows: [],
     })
+    // `defs` is a per-definition cap, not an area cap — the key set is untouched.
     expect(sorted(caps.keys)).toEqual(sorted(effectiveDefault('USER', 'full')))
+    // But it now rides OUT of the composer, raw and slug-keyed, for
+    // `getCapabilities` to resolve and `effectiveRecordLevel` to enforce.
+    expect(caps.ceilingDefs).toEqual({ mode: 'only', slugs: ['contact'] })
+  })
+
+  it('carries an `except` ceiling verbatim (mode decides allow-list vs deny-list)', () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      profileCeiling: { defs: { mode: 'except', slugs: ['salary', 'invoice'] } },
+      typeAccessRows: [],
+    })
+    expect(caps.ceilingDefs).toEqual({ mode: 'except', slugs: ['salary', 'invoice'] })
+  })
+
+  it('emits `ceilingDefs: null` when the profile has no defs cap', () => {
+    const noCeiling = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      typeAccessRows: [],
+    })
+    expect(noCeiling.ceilingDefs).toBeNull()
+    const areasOnly = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      profileCeiling: { areas: { [Area.records]: Level.Read } },
+      typeAccessRows: [],
+    })
+    expect(areasOnly.ceilingDefs).toBeNull()
+  })
+
+  it('OWNER is never handed a definition ceiling (§0.10 recovery guarantee)', () => {
+    const owner = composeUserCapabilities({
+      role: 'OWNER',
+      seatType: 'full',
+      profileCeiling: { defs: { mode: 'only', slugs: ['contact'] } },
+      typeAccessRows: [],
+    })
+    expect(owner.ceilingDefs).toBeNull()
+  })
+
+  it('AGENT principals and non-members get no definition ceiling either', () => {
+    // An agent's authority is the published version policy; nothing composed here
+    // is consulted for it, so a human profile ceiling must not leak onto it.
+    const agent = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      userType: 'AGENT',
+      profileCeiling: { defs: { mode: 'only', slugs: ['contact'] } },
+      typeAccessRows: [],
+    })
+    expect(agent.ceilingDefs).toBeNull()
+
+    const nonMember = composeUserCapabilities({
+      role: undefined,
+      seatType: 'full',
+      profileCeiling: { defs: { mode: 'only', slugs: ['contact'] } },
+      typeAccessRows: [],
+    })
+    expect(nonMember.ceilingDefs).toBeNull()
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
@@ -2,7 +2,7 @@
 
 import type { ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType, UserType } from '@auxx/database/types'
-import type { ProfileCeiling } from '../profiles/types'
+import type { ProfileCeiling, ProfileDefCeiling } from '../profiles/types'
 import {
   type Area,
   buildAreaLevels,
@@ -30,6 +30,18 @@ export interface UserCapabilities {
    * instance downward marker (a real grant outranks them via {@link PERMISSION_RANK}).
    */
   instanceAccess: Record<string, ResourcePermission>
+  /**
+   * The bound profile's definition ceiling (§0.13), carried **raw and
+   * slug-keyed** on purpose: apiSlugs survive def create/archive/restore, so a
+   * definition lifecycle event never has to invalidate this USER-scoped blob.
+   * `getCapabilities` resolves the slugs to `entityDefinitionId`s against the
+   * (org-scoped, def-lifecycle-invalidated) `resources` projection on every read.
+   *
+   * `null` = uncapped. Always `null` for OWNER (§0.10 recovery guarantee), for
+   * AGENT principals (their authority is the published version policy), and for
+   * non-members.
+   */
+  ceilingDefs: ProfileDefCeiling | null
 }
 
 /**
@@ -118,8 +130,10 @@ export function composeUserCapabilities(input: {
   profileBaseLevel?: Level | null
   /**
    * The bound profile's own intrinsic cap (§0.14) — applied after group/personal
-   * raising, before the seat ceiling. `ceiling.defs` is carried but NOT enforced
-   * here; definition-ceiling enforcement is doc 19 step 4.
+   * raising, before the seat ceiling. `ceiling.areas` is applied here;
+   * `ceiling.defs` is emitted verbatim as {@link UserCapabilities.ceilingDefs}
+   * and enforced per-def in `effectiveRecordLevel` (it needs the org's
+   * slug→`entityDefinitionId` map, which this pure function has no access to).
    */
   profileCeiling?: ProfileCeiling | null
   /** Sparse levels on each of the member's group grants (raise-only). */
@@ -170,13 +184,13 @@ export function composeUserCapabilities(input: {
   }
 
   // Fail closed: a non-member holds no capabilities.
-  if (!role) return { keys: [], defAccess, instanceAccess }
+  if (!role) return { keys: [], defAccess, instanceAccess, ceilingDefs: null }
 
   // AGENT principals hold NO composed capability (doc 19 §0.16/§2.3). Their
   // authority lives exclusively in `AgentVersion.permissionPolicy`, resolved by
   // `AgentPolicyCapabilities` — see the note above this function.
   if (userType === 'AGENT') {
-    return { keys: [], defAccess: {}, instanceAccess: {} }
+    return { keys: [], defAccess: {}, instanceAccess: {}, ceilingDefs: null }
   }
 
   const ceiling = SEAT_CEILINGS[seatType]
@@ -190,6 +204,9 @@ export function composeUserCapabilities(input: {
       keys: expandLevelsToKeys(buildAreaLevels((area) => ceiling[area])),
       defAccess,
       instanceAccess,
+      // No definition ceiling either — the recovery guarantee covers `defs`
+      // exactly as it covers `areas` (§0.10 / §3).
+      ceilingDefs: null,
     }
   }
 
@@ -218,7 +235,15 @@ export function composeUserCapabilities(input: {
     return Math.min(capped, ceiling[area]) as Level
   })
 
-  return { keys: expandLevelsToKeys(resolved), defAccess, instanceAccess }
+  // The definition half of the same profile ceiling rides out raw (slug-keyed);
+  // `getCapabilities` resolves it into the `entityDefinitionId` keyspace and
+  // `effectiveRecordLevel` enforces it before the seat clamp (§0.14).
+  return {
+    keys: expandLevelsToKeys(resolved),
+    defAccess,
+    instanceAccess,
+    ceilingDefs: profileCeiling?.defs ?? null,
+  }
 }
 
 /**

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -53,6 +53,22 @@ export const NON_RECORD_DEF_SLUGS: ReadonlySet<string> = new Set([
 ])
 
 /**
+ * The bound profile's definition ceiling (doc 19 §0.13) resolved into the
+ * canonical `entityDefinitionId` keyspace.
+ *  - `only` — the allowed set is EXACTLY `defIds`. A definition created later is
+ *    excluded, so it **fails closed**.
+ *  - `except` — everything but `defIds`. A definition created later is included,
+ *    so it **fails open**.
+ *
+ * Slugs that resolve to no live definition are simply absent from `defIds`;
+ * a dangling entry never throws (§3 slug lifecycle).
+ */
+export interface ResolvedDefCeiling {
+  mode: 'only' | 'except'
+  defIds: ReadonlySet<string>
+}
+
+/**
  * A resolved, normalized view of one member's record-access inputs — the shared
  * argument for every function here. The server builds it from its
  * `CapabilitySet` fields; the client from the dehydrated/refetched snapshot.
@@ -82,6 +98,27 @@ export interface ResolvedRecordAccess {
   instanceAccess?: Readonly<Record<string, ResourcePermission>>
   /** Org-wide set of instance ids carrying ≥1 instance-access row. Optional (see above). */
   restrictedInstanceIds?: ReadonlySet<string>
+  /**
+   * The bound profile's per-definition cap (§0.13/§0.14), already resolved to
+   * `entityDefinitionId`s. Absent/`null` = uncapped. Never present for OWNER
+   * (§0.10) — the composer emits `null` for them.
+   */
+  ceilingDefs?: ResolvedDefCeiling | null
+}
+
+/**
+ * Whether the member's profile definition ceiling admits this definition
+ * (§0.13). The ONE predicate every record resolver funnels through — a clamp
+ * applied at only some of the seams is defeated by the others (§3).
+ *
+ * No ceiling ⇒ `true`. `only` ⇒ the def must be listed; `except` ⇒ it must not be.
+ */
+export function ceilingAllowsDef(caps: ResolvedRecordAccess, entityDefinitionId: string): boolean {
+  const ceiling = caps.ceilingDefs
+  if (!ceiling) return true
+  return ceiling.mode === 'only'
+    ? ceiling.defIds.has(entityDefinitionId)
+    : !ceiling.defIds.has(entityDefinitionId)
 }
 
 /**
@@ -124,6 +161,7 @@ export function levelToPermission(level: Level): ResourcePermission | undefined 
  *  - OWNER/ADMIN → `admin` (bypass — never self-lock).
  *  - restricted def → the member's own grant REPLACES base.
  *  - unrestricted def → base records level fills in.
+ *  - profile definition ceiling excludes the def → `undefined`.
  *  - worker seat (records ceiling None) → `undefined`.
  */
 export function effectiveRecordLevel(
@@ -139,6 +177,9 @@ export function effectiveRecordLevel(
     ? caps.defAccess[entityDefinitionId]
     : unrestrictedBase
   if (chosen === undefined) return undefined
+  // The bound profile's own definition cap — POLICY, so it lands before the
+  // billing invariant below (§0.14) and after the OWNER recovery bypass (§0.10).
+  if (!ceilingAllowsDef(caps, entityDefinitionId)) return undefined
   if (SEAT_CEILINGS[caps.seatType][Area.records] === Level.None) return undefined
   return chosen
 }
@@ -161,6 +202,9 @@ export function canViewRecord(caps: ResolvedRecordAccess, entityDefinitionId: st
   const level = effectiveRecordLevel(caps, entityDefinitionId)
   if (level !== undefined && satisfiesPermission(level, ResourcePermission.view)) return true
   if (caps.seatType === 'worker' && caps.keys.has(PermissionKey.recordsViewLinked)) {
+    // The carve-out skips `effectiveRecordLevel`, so the profile definition
+    // ceiling has to be re-applied here or a field seat walks around it (§3).
+    if (!ceilingAllowsDef(caps, entityDefinitionId)) return false
     if (!caps.restrictedEntityDefIds.has(entityDefinitionId)) return true
     return caps.defAccess[entityDefinitionId] !== undefined
   }
@@ -184,29 +228,38 @@ export function canEditRecord(caps: ResolvedRecordAccess, entityDefinitionId: st
  *
  * Unlike {@link canViewRecord}/{@link canEditRecord}, def administration does
  * NOT flow from the base records level: a base `Full` member edits *records*,
- * never *definitions*. Only an explicit type-level grant of exactly `admin`
- * (or OWNER/ADMIN) confers it — so it reads the RAW `defAccess` grant, not
- * `effectiveRecordLevel`. Worker seats (records ceiling None) never administer.
+ * never *definitions*. That stays true through {@link effectiveRecordLevel},
+ * because the base rungs top out at `edit` ({@link levelToRecordBasePermission}
+ * maps `Level.Full` → `edit`, never `admin`) — only an explicit `admin`
+ * type-grant on a restricted def, or OWNER/ADMIN, reaches this rung.
+ *
+ * It goes through {@link effectiveRecordLevel} rather than reading `defAccess`
+ * raw so that every clamp on that path — the profile definition ceiling and the
+ * worker seat ceiling — applies here too (§3: a clamp added at one seam only is
+ * defeated by the others).
  */
 export function canAdministerRecord(
   caps: ResolvedRecordAccess,
   entityDefinitionId: string
 ): boolean {
   if (caps.role === 'OWNER' || caps.role === 'ADMIN') return true
-  if (SEAT_CEILINGS[caps.seatType][Area.records] === Level.None) return false
-  return caps.defAccess[entityDefinitionId] === ResourcePermission.admin
+  const level = effectiveRecordLevel(caps, entityDefinitionId)
+  return level !== undefined && satisfiesPermission(level, ResourcePermission.admin)
 }
 
 /**
  * Whether the member administers AT LEAST ONE def — the "is there any def-admin
  * surface for me at all" gate (e.g. showing the Custom Fields settings nav entry
  * / listing only administered defs). OWNER/ADMIN administer every def; everyone
- * else needs ≥1 explicit `admin` type-grant. Worker seats never administer.
+ * else needs ≥1 explicit `admin` type-grant on a def their profile definition
+ * ceiling still admits. Worker seats never administer.
  */
 export function administersAnyDef(caps: ResolvedRecordAccess): boolean {
   if (caps.role === 'OWNER' || caps.role === 'ADMIN') return true
   if (SEAT_CEILINGS[caps.seatType][Area.records] === Level.None) return false
-  return Object.values(caps.defAccess).some((p) => p === ResourcePermission.admin)
+  return Object.entries(caps.defAccess).some(
+    ([defId, p]) => p === ResourcePermission.admin && ceilingAllowsDef(caps, defId)
+  )
 }
 
 /**
@@ -234,6 +287,13 @@ export interface ClientCapabilities {
   instanceAccess?: Record<string, ResourcePermission>
   /** Org-wide set of instance ids carrying ≥1 instance-access row. Optional (see above). */
   restrictedInstanceIds?: string[]
+  /**
+   * The profile definition ceiling, server-resolved to `entityDefinitionId`s
+   * (§0.13). `mode` is carried alongside the ids because it decides whether the
+   * set is an allow-list or a deny-list. `null`/absent = uncapped, or the UI
+   * would offer what the server denies (§3).
+   */
+  ceilingDefs?: { mode: 'only' | 'except'; defIds: string[] } | null
 }
 
 /** Rebuild the Set-backed {@link ResolvedRecordAccess} from a wire snapshot. */
@@ -247,6 +307,9 @@ export function toResolvedRecordAccess(caps: ClientCapabilities): ResolvedRecord
     defBaseOverrides: caps.defBaseOverrides ?? {},
     instanceAccess: caps.instanceAccess ?? {},
     restrictedInstanceIds: new Set(caps.restrictedInstanceIds ?? []),
+    ceilingDefs: caps.ceilingDefs
+      ? { mode: caps.ceilingDefs.mode, defIds: new Set(caps.ceilingDefs.defIds) }
+      : null,
   }
 }
 
@@ -271,8 +334,12 @@ function parseInstanceRecordId(recordId: string): { key: string; instanceId: str
  *  - L2 area gate closed (`None`) → `undefined`.
  *  - explicit instance row (incl. workspace baseline / `'none'`) → wins.
  *  - otherwise fall back to the base L2 area level (`baselineAtCreate: false`).
+ *
+ * Exported so the doc-19 §6.1 escalation guard measures a holder's per-instance
+ * authority through the SAME predicate the read path enforces (§6.1.4) — the
+ * guard must never re-derive its own instance rules.
  */
-function effectiveInstanceLevel(
+export function effectiveInstanceLevel(
   caps: ResolvedRecordAccess,
   key: InstanceAccessKey,
   instanceId: string

--- a/packages/lib/src/permissions/capabilities/get-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/get-capabilities.test.ts
@@ -1,0 +1,88 @@
+// packages/lib/src/permissions/capabilities/get-capabilities.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UserCapabilities } from './compose-user-capabilities'
+
+/**
+ * The `get-capabilities` seam (doc 19 step 4): the bound profile's definition
+ * ceiling is cached RAW and slug-keyed inside `userCapabilities`, then resolved
+ * to the canonical `entityDefinitionId` keyspace here — against the org-scoped
+ * `resources` projection, which every `entity-def.*` event already invalidates.
+ * That is what lets a def be created/archived/restored without touching the
+ * user-scoped blob.
+ */
+
+const resources = [
+  { id: 'res_contact', apiSlug: 'contact', entityDefinitionId: 'def_contact', entityType: null },
+  { id: 'res_deal', apiSlug: 'deal', entityDefinitionId: 'def_deal', entityType: null },
+  // Added to the org AFTER the profile ceiling was authored.
+  { id: 'res_new', apiSlug: 'brand_new', entityDefinitionId: 'def_brand_new', entityType: null },
+]
+
+let userCapabilities: UserCapabilities
+
+vi.mock('../../cache', () => ({
+  getCachedUserCapabilities: vi.fn(async () => userCapabilities),
+  getCachedResources: vi.fn(async () => resources),
+  getCachedRestrictedEntityDefIds: vi.fn(async () => [] as string[]),
+  getCachedRestrictedInstanceIds: vi.fn(async () => [] as string[]),
+  getOrgCache: () => ({
+    get: vi.fn(async () => ({ user_1: { role: 'USER', seatType: 'full' } })),
+  }),
+}))
+
+const { getCapabilities } = await import('./get-capabilities')
+const { PermissionKey } = await import('./registry')
+
+const baseCaps = (ceilingDefs: UserCapabilities['ceilingDefs']): UserCapabilities => ({
+  keys: [PermissionKey.recordsView, PermissionKey.recordsEdit],
+  defAccess: {},
+  instanceAccess: {},
+  ceilingDefs,
+})
+
+describe('getCapabilities — profile definition-ceiling resolution', () => {
+  beforeEach(() => {
+    userCapabilities = baseCaps(null)
+  })
+
+  it('resolves stored apiSlugs to entityDefinitionIds and enforces `only`', async () => {
+    userCapabilities = baseCaps({ mode: 'only', slugs: ['contact'] })
+    const caps = await getCapabilities('user_1', 'org_1')
+    expect(caps.canViewEntity('def_contact')).toBe(true)
+    expect(caps.canViewEntity('def_deal')).toBe(false)
+    // A definition created after the ceiling was authored is NOT in the
+    // allow-list, so it is excluded — `only` fails closed (§0.13).
+    expect(caps.canViewEntity('def_brand_new')).toBe(false)
+    expect(caps.toClientCapabilities().ceilingDefs).toEqual({
+      mode: 'only',
+      defIds: ['def_contact'],
+    })
+  })
+
+  it('`except` denies exactly the listed defs and admits later ones (fails open)', async () => {
+    userCapabilities = baseCaps({ mode: 'except', slugs: ['deal'] })
+    const caps = await getCapabilities('user_1', 'org_1')
+    expect(caps.canViewEntity('def_deal')).toBe(false)
+    expect(caps.canViewEntity('def_contact')).toBe(true)
+    expect(caps.canViewEntity('def_brand_new')).toBe(true)
+  })
+
+  it('drops a slug that resolves to no live definition instead of throwing', async () => {
+    // A deleted/renamed def leaves a dangling entry. It simply vanishes from the
+    // set, which shrinks an `only` allow-list (stays closed) and an `except`
+    // deny-list (stays open) — never a hard failure (§3 slug lifecycle).
+    userCapabilities = baseCaps({ mode: 'only', slugs: ['contact', 'gone_forever'] })
+    const caps = await getCapabilities('user_1', 'org_1')
+    expect(caps.toClientCapabilities().ceilingDefs).toEqual({
+      mode: 'only',
+      defIds: ['def_contact'],
+    })
+  })
+
+  it('a null ceiling in the cached blob resolves to no clamp at all', async () => {
+    const caps = await getCapabilities('user_1', 'org_1')
+    expect(caps.toClientCapabilities().ceilingDefs).toBeNull()
+    expect(caps.canViewEntity('def_deal')).toBe(true)
+  })
+})

--- a/packages/lib/src/permissions/capabilities/get-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/get-capabilities.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/permissions/capabilities/get-capabilities.ts
 
-import type { ResourcePermission } from '@auxx/database/enums'
 import {
   getCachedResources,
   getCachedRestrictedEntityDefIds,
@@ -8,52 +7,8 @@ import {
   getCachedUserCapabilities,
   getOrgCache,
 } from '../../cache'
-import type { Resource } from '../../resources/registry/types'
-import { CapabilitySet, type DefIdToSlug } from './capability-set'
-import { PERMISSION_RANK } from './compose-user-capabilities'
-import { levelToRecordBasePermission } from './entity-access'
-import { areaLevelFromKeys } from './registry'
-import { ENTITY_BASE_AREAS } from './seat-policy'
-
-/**
- * Build the in-memory RecordId-def → entity-slug resolver from the cached
- * `resources` array (§6.1). The def part of a RecordId can arrive as the system
- * slug (`work_order`), the apiSlug, or the `entityDefinitionId`/`id` — every one
- * maps to the entity's system slug (`entityType`), falling back to `apiSlug`.
- * Pure map lookups; NEVER a DB query.
- */
-function buildDefIdToSlug(resources: Resource[]): DefIdToSlug {
-  const slugByKey = new Map<string, string>()
-  for (const r of resources) {
-    const slug = r.entityType ?? r.apiSlug
-    slugByKey.set(r.id, slug)
-    slugByKey.set(r.apiSlug, slug)
-    slugByKey.set(r.entityDefinitionId, slug)
-    if (r.entityType) slugByKey.set(r.entityType, slug)
-  }
-  return (entityDefId) => slugByKey.get(entityDefId) ?? entityDefId
-}
-
-/**
- * Build the in-memory RecordId-def → canonical `entityDefinitionId` resolver
- * (§0 keying wrinkle). The def part of a RecordId can arrive as the system slug,
- * apiSlug, `id`, or `entityType` — every one maps to the entity's
- * `entityDefinitionId`, which is the keyspace of `defAccess` /
- * `restrictedEntityDefIds` (both sourced from `ResourceAccess.entityDefinitionId`).
- * Unlike {@link buildDefIdToSlug} (→ write-key slug), this resolves the other
- * direction. Pure map lookups; NEVER a DB query.
- */
-function buildDefIdToDefinitionId(resources: Resource[]): DefIdToSlug {
-  const defIdByKey = new Map<string, string>()
-  for (const r of resources) {
-    const defId = r.entityDefinitionId
-    defIdByKey.set(r.id, defId)
-    defIdByKey.set(r.apiSlug, defId)
-    defIdByKey.set(r.entityDefinitionId, defId)
-    if (r.entityType) defIdByKey.set(r.entityType, defId)
-  }
-  return (entityDefId) => defIdByKey.get(entityDefId) ?? entityDefId
-}
+import { CapabilitySet } from './capability-set'
+import { resolveCapabilityInputs } from './resolve-capability-inputs'
 
 /**
  * Resolve a member's {@link CapabilitySet} for one org (§6.1) — the check-path
@@ -61,6 +16,10 @@ function buildDefIdToDefinitionId(resources: Resource[]): DefIdToSlug {
  * (ONE user-cache read, L1-fronted so warm calls are a local Map hit) plus the
  * cached `memberRoleMap` (role + seatType) and `resources` (the def→slug
  * resolver). No composition happens here — that's the provider's job.
+ *
+ * The slug→`entityDefinitionId` normalization lives in
+ * {@link resolveCapabilityInputs}, shared with the doc-19 §6.1 escalation guard
+ * so a transaction-local recomputation resolves identically (§6.1.4).
  *
  * The `db` parameter is accepted for signature symmetry with the other guards;
  * every read on this path is cache-backed, so it is not used.
@@ -81,48 +40,21 @@ export async function getCapabilities(
   const entry = roleMap[userId]
   const role = entry?.role ?? 'USER'
   const seatType = entry?.seatType ?? 'full'
-  const keys = new Set(caps.keys)
-
-  // ResourceAccess rows are keyed inconsistently in practice — system entity
-  // types by slug ('inbox'), custom defs by EntityDefinition CUID. Lookups in
-  // `canViewEntity` normalize their argument through this resolver, so the SETS
-  // must be normalized through the same resolver or slug-keyed grants silently
-  // never match (§0 keying wrinkle applies to both sides).
-  const toDefinitionId = buildDefIdToDefinitionId(resources)
-  const defAccess: Record<string, ResourcePermission> = {}
-  for (const [key, permission] of Object.entries(caps.defAccess)) {
-    const defId = toDefinitionId(key)
-    const existing = defAccess[defId]
-    if (!existing || PERMISSION_RANK[permission] > PERMISSION_RANK[existing]) {
-      defAccess[defId] = permission
-    }
-  }
-
-  // Resolve the handful of feature-backed record defs from entity slug to the
-  // canonical definition-id keyspace once. `null` is intentional: it
-  // distinguishes an explicitly closed derived base from an absent override,
-  // which falls back to the Records area on both server and client.
-  const defBaseOverrides: Record<string, ResourcePermission | null> = {}
-  for (const resource of resources) {
-    const slug = resource.entityType ?? resource.apiSlug
-    const area = ENTITY_BASE_AREAS[slug]
-    if (!area) continue
-    defBaseOverrides[resource.entityDefinitionId] =
-      levelToRecordBasePermission(areaLevelFromKeys(keys, area)) ?? null
-  }
+  const resolved = resolveCapabilityInputs(caps, resources)
 
   // instanceAccess keys on the globally-unique instance CUID (Dataset.id etc.),
   // so — unlike defAccess — no keyspace normalization is needed (§1.2).
   return new CapabilitySet(
-    keys,
-    defAccess,
+    resolved.keys,
+    resolved.defAccess,
     role,
     seatType,
-    buildDefIdToSlug(resources),
-    new Set(restrictedDefIds.map(toDefinitionId)),
-    toDefinitionId,
+    resolved.toSlug,
+    new Set(restrictedDefIds.map(resolved.toDefinitionId)),
+    resolved.toDefinitionId,
     caps.instanceAccess ?? {},
     new Set(restrictedInstanceIds),
-    defBaseOverrides
+    resolved.defBaseOverrides,
+    resolved.ceilingDefs
   )
 }

--- a/packages/lib/src/permissions/capabilities/grant-service.ts
+++ b/packages/lib/src/permissions/capabilities/grant-service.ts
@@ -40,16 +40,28 @@ export interface GranteeRef {
 }
 
 /**
- * Reject any grant that raises an `adminOnly` area (settings/billing/members/
- * permissions) above `None`. OWNER/ADMIN already hold these by role; granting
- * one to a user, group, or a permission profile would elevate a non-admin past
- * the seat/role model. Mirrors v1's `assertGrantableKey`.
+ * Reject any grant that raises an `adminOnly` area above `None`. OWNER/ADMIN
+ * already hold these by role; granting one to a user, group, or a permission
+ * profile would elevate a non-admin past the seat/role model. Mirrors v1's
+ * `assertGrantableKey`.
+ *
+ * **Today that set is `settings` alone.** `permissions` left it in doc 19 §0.25
+ * (it must be grantable to be a delegable area) and `billing`/`members` were
+ * never `adminOnly` — they are default-`None`-but-grantable via
+ * `USER_ADMIN_NONE_AREAS`. §6.1.5's parenthetical listing all four as blocked
+ * here does not match the registry; the §6.1 escalation guard, not this check,
+ * is what keeps `billing`/`members`/`permissions` from being handed out by
+ * someone who does not hold them.
  *
  * The seeded `owner`/`admin` system profiles express "everything" via
  * `PermissionProfile.baseLevel`, NOT an all-Full grant row, so system seeding
  * never trips this.
+ *
+ * Exported for the doc-19 §6.1.5 transactional profile save, which writes the
+ * profile's grant row itself (inside the escalation-guard transaction) and must
+ * still run this defense-in-depth check.
  */
-function assertGrantableLevels(levels: Partial<Record<Area, Level>>): void {
+export function assertGrantableLevels(levels: Partial<Record<Area, Level>>): void {
   for (const area of Object.keys(levels) as Area[]) {
     if (PERMISSION_AREAS[area].adminOnly && (levels[area] ?? Level.None) > Level.None) {
       throw new ForbiddenError(

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -45,6 +45,12 @@ export {
 } from './registry'
 export { requirePermission } from './require'
 export {
+  buildDefIdToDefinitionId,
+  buildDefIdToSlug,
+  type ResolvedCapabilityInputs,
+  resolveCapabilityInputs,
+} from './resolve-capability-inputs'
+export {
   ALL_KEYS,
   ENTITY_BASE_AREAS,
   ENTITY_WRITE_KEYS,

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -194,10 +194,10 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
   {
     key: PermissionKey.permissionsManage,
     label: 'Manage Permissions',
-    description: 'Configure capability grants for roles, groups, and members.',
+    description: 'Configure permission profiles and capability grants for groups and members.',
     group: 'Organization',
     featureKey: FeatureKey.granularPermissions,
-    adminOnly: true,
+    // NOT adminOnly since doc 19 §0.25 — see `PERMISSION_AREAS[Area.permissions]`.
   },
 
   // ── Integrations ──
@@ -409,6 +409,19 @@ export interface AreaMetadata {
    * seats would be a lever that does nothing.
    */
   workerOnly?: boolean
+  /**
+   * The area is grantable in the model, but the routers behind it are still
+   * fronted by a binary `adminProcedure` / `isAdminOrOwner` gate — so turning it
+   * off in a profile changes nothing and an unlocked control would be lying
+   * (doc 19 §5.3). Rows render locked with *"Still role-gated — admins reach
+   * this regardless."* Drop the flag per area as its routers migrate to
+   * `permissionProcedure`.
+   *
+   * This applies to any profile bound to an ADMIN member, not only the `admin`
+   * system profile — a custom profile on an admin has the identical problem.
+   * Step 10 populates it; no area sets it yet.
+   */
+  roleGated?: boolean
   /** Layer-1 plan link — the area's keys AND the org's plan feature. */
   featureKey?: FeatureKey
 }
@@ -519,10 +532,20 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
   [Area.permissions]: {
     area: Area.permissions,
     label: 'Permissions',
-    description: 'Configure capability grants for roles, groups, and members.',
+    description: 'Configure permission profiles and capability grants for groups and members.',
     group: 'Organization',
     rungs: [{ level: Level.Full, keys: [PermissionKey.permissionsManage] }],
-    adminOnly: true,
+    // Doc 19 §0.25 reverses doc 09's deferral: this area is GRANTABLE. It governs
+    // creating/editing permission profiles and assigning them to HUMANS. The USER
+    // default stays `None` (it is in `USER_ADMIN_NONE_AREAS`, the real source of
+    // truth for the baseline — dropping `adminOnly` must never flip a default on).
+    // Agent-side profile editing and assignment stay OWNER/ADMIN-only and are
+    // enforced separately in `profile-save.ts` / `profile-mutations.ts`, not by
+    // this area (doc 14 §0.9). `permissionsRouter` is fronted by the
+    // `permissionsManage` capability rather than `adminProcedure`, so the grant
+    // actually reaches a non-admin holder, so this area is deliberately NOT
+    // `roleGated`. Every OTHER router in the org group is still binary-role-gated;
+    // step 10 audits those and sets `roleGated` on the areas that need it.
     featureKey: FeatureKey.granularPermissions,
   },
   [Area.integrations]: {

--- a/packages/lib/src/permissions/capabilities/resolve-capability-inputs.ts
+++ b/packages/lib/src/permissions/capabilities/resolve-capability-inputs.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/permissions/capabilities/resolve-capability-inputs.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import type { Resource } from '../../resources/registry/types'
+import type { DefIdToSlug } from './capability-set'
+import { PERMISSION_RANK, type UserCapabilities } from './compose-user-capabilities'
+import { levelToRecordBasePermission, type ResolvedDefCeiling } from './entity-access'
+import { areaLevelFromKeys, type PermissionKey } from './registry'
+import { ENTITY_BASE_AREAS } from './seat-policy'
+
+/**
+ * Build the in-memory RecordId-def → entity-slug resolver from the cached
+ * `resources` array (§6.1). The def part of a RecordId can arrive as the system
+ * slug (`work_order`), the apiSlug, or the `entityDefinitionId`/`id` — every one
+ * maps to the entity's system slug (`entityType`), falling back to `apiSlug`.
+ * Pure map lookups; NEVER a DB query.
+ */
+export function buildDefIdToSlug(resources: Resource[]): DefIdToSlug {
+  const slugByKey = new Map<string, string>()
+  for (const r of resources) {
+    const slug = r.entityType ?? r.apiSlug
+    slugByKey.set(r.id, slug)
+    slugByKey.set(r.apiSlug, slug)
+    slugByKey.set(r.entityDefinitionId, slug)
+    if (r.entityType) slugByKey.set(r.entityType, slug)
+  }
+  return (entityDefId) => slugByKey.get(entityDefId) ?? entityDefId
+}
+
+/**
+ * Build the in-memory RecordId-def → canonical `entityDefinitionId` resolver
+ * (§0 keying wrinkle). The def part of a RecordId can arrive as the system slug,
+ * apiSlug, `id`, or `entityType` — every one maps to the entity's
+ * `entityDefinitionId`, which is the keyspace of `defAccess` /
+ * `restrictedEntityDefIds` (both sourced from `ResourceAccess.entityDefinitionId`).
+ * Unlike {@link buildDefIdToSlug} (→ write-key slug), this resolves the other
+ * direction. Pure map lookups; NEVER a DB query.
+ */
+export function buildDefIdToDefinitionId(resources: Resource[]): DefIdToSlug {
+  const defIdByKey = new Map<string, string>()
+  for (const r of resources) {
+    const defId = r.entityDefinitionId
+    defIdByKey.set(r.id, defId)
+    defIdByKey.set(r.apiSlug, defId)
+    defIdByKey.set(r.entityDefinitionId, defId)
+    if (r.entityType) defIdByKey.set(r.entityType, defId)
+  }
+  return (entityDefId) => defIdByKey.get(entityDefId) ?? entityDefId
+}
+
+/**
+ * The composed capability blob, normalized against one org's `resources`
+ * projection — everything a {@link import('./entity-access').ResolvedRecordAccess}
+ * needs except `role`/`seatType` and the two org-wide restricted sets.
+ */
+export interface ResolvedCapabilityInputs {
+  keys: Set<PermissionKey>
+  /** `defAccess` re-keyed into the canonical `entityDefinitionId` keyspace. */
+  defAccess: Record<string, ResourcePermission>
+  /** Per-def record base for definitions backed by another Layer-2 area. */
+  defBaseOverrides: Record<string, ResourcePermission | null>
+  /** The profile definition ceiling, slug→`entityDefinitionId` resolved. */
+  ceilingDefs: ResolvedDefCeiling | null
+  toDefinitionId: DefIdToSlug
+  toSlug: DefIdToSlug
+}
+
+/**
+ * Resolve a composed {@link UserCapabilities} blob against the org's `resources`
+ * projection — the seam where slug-keyed data becomes `entityDefinitionId`-keyed.
+ *
+ * Extracted from `getCapabilities` so the doc-19 §6.1 escalation guard can build
+ * the SAME `ResolvedRecordAccess` inputs from a transaction-local composition
+ * without duplicating this normalization. A second copy is how the guard and
+ * enforcement drift apart (§6.1.4).
+ *
+ * Pure: `resources` is the only lookup table and every step is a map read.
+ */
+export function resolveCapabilityInputs(
+  caps: UserCapabilities,
+  resources: Resource[]
+): ResolvedCapabilityInputs {
+  const keys = new Set(caps.keys)
+
+  // ResourceAccess rows are keyed inconsistently in practice — system entity
+  // types by slug ('inbox'), custom defs by EntityDefinition CUID. Lookups in
+  // `canViewEntity` normalize their argument through this resolver, so the SETS
+  // must be normalized through the same resolver or slug-keyed grants silently
+  // never match (§0 keying wrinkle applies to both sides).
+  const toDefinitionId = buildDefIdToDefinitionId(resources)
+  const defAccess: Record<string, ResourcePermission> = {}
+  for (const [key, permission] of Object.entries(caps.defAccess)) {
+    const defId = toDefinitionId(key)
+    const existing = defAccess[defId]
+    if (!existing || PERMISSION_RANK[permission] > PERMISSION_RANK[existing]) {
+      defAccess[defId] = permission
+    }
+  }
+
+  // Resolve the handful of feature-backed record defs from entity slug to the
+  // canonical definition-id keyspace once. `null` is intentional: it
+  // distinguishes an explicitly closed derived base from an absent override,
+  // which falls back to the Records area on both server and client.
+  const defBaseOverrides: Record<string, ResourcePermission | null> = {}
+  for (const resource of resources) {
+    const slug = resource.entityType ?? resource.apiSlug
+    const area = ENTITY_BASE_AREAS[slug]
+    if (!area) continue
+    defBaseOverrides[resource.entityDefinitionId] =
+      levelToRecordBasePermission(areaLevelFromKeys(keys, area)) ?? null
+  }
+
+  // The bound profile's definition ceiling arrives slug-keyed (doc 19 §0.13) and
+  // is resolved here, NOT in the composer — the same seam and the same cached
+  // `resources` array `defBaseOverrides` uses just above. Keeping the cached
+  // `userCapabilities` blob slug-keyed is what lets a def be created, archived,
+  // restored, or deleted without invalidating that USER-scoped key: the map it is
+  // resolved through is the org-scoped `resources` projection, which every
+  // `entity-def.*` event already busts.
+  //
+  // A slug that resolves to no live definition is simply absent from the set — so
+  // `only` (an allow-list) shrinks and stays fail-closed, `except` (a deny-list)
+  // shrinks and stays fail-open, exactly as §0.13 specifies. Never throws.
+  const knownDefIds = new Set(resources.map((r) => r.entityDefinitionId))
+  const ceilingDefs: ResolvedDefCeiling | null = caps.ceilingDefs
+    ? {
+        mode: caps.ceilingDefs.mode,
+        defIds: new Set(
+          caps.ceilingDefs.slugs.map(toDefinitionId).filter((id) => knownDefIds.has(id))
+        ),
+      }
+    : null
+
+  return {
+    keys,
+    defAccess,
+    defBaseOverrides,
+    ceilingDefs,
+    toDefinitionId,
+    toSlug: buildDefIdToSlug(resources),
+  }
+}

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -20,10 +20,12 @@ export {
   canEditRecord,
   canViewInstance,
   canViewRecord,
+  ceilingAllowsDef,
   effectiveRecordLevel,
   levelToPermission,
   levelToRecordBasePermission,
   NON_RECORD_DEF_SLUGS,
+  type ResolvedDefCeiling,
   type ResolvedRecordAccess,
   toResolvedRecordAccess,
 } from './capabilities/entity-access'

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -54,31 +54,40 @@ export type { Overage } from './overage-detection-service'
 export { OverageDetectionService } from './overage-detection-service'
 export { handlePlanDowngrade } from './overage-handler'
 export type {
+  ActorAuthority,
   AgentAccessLevel,
   AgentPermissionPolicy,
   CachedPermissionProfile,
   CreatePermissionProfileInput,
+  EffectiveState,
   ProfileAppliesTo,
   ProfileAudience,
+  ProfileAuthoredState,
   ProfileCeiling,
   ProfileDefCeiling,
   ResolvedBaseProfile,
+  SavePermissionProfileInput,
   SystemProfileSlug,
-  UpdatePermissionProfileInput,
 } from './profiles'
 export {
+  assertNoEscalation,
+  assertProfileMapNoEscalation,
+  computeEffectiveStatesUncached,
+  computeEffectiveStateUncached,
   createPermissionProfile,
   emitPermissionProfileChanged,
   ensureSystemProfiles,
+  HOLDER_GUARD_CAP,
   parseProfileCeiling,
   projectPermissionProfile,
   resolveBaseProfile,
   resolveProfileAudience,
+  resolveProfileHolderIds,
   SYSTEM_PROFILE_SEEDS,
   SYSTEM_PROFILE_SLUGS,
+  savePermissionProfile,
   systemProfileFor,
   systemProfileForAgentKind,
-  updatePermissionProfile,
 } from './profiles'
 export type { FeatureDefinition, FeatureLimit, FeatureMapObject } from './types'
 export { FeatureKey } from './types'

--- a/packages/lib/src/permissions/profiles/effective-state.ts
+++ b/packages/lib/src/permissions/profiles/effective-state.ts
@@ -1,0 +1,419 @@
+// packages/lib/src/permissions/profiles/effective-state.ts
+
+import { type Database, schema, type Transaction } from '@auxx/database'
+import { MemberType, type ResourcePermission } from '@auxx/database/enums'
+import type { OrganizationRole, SeatType, UserType } from '@auxx/database/types'
+import { and, eq, inArray, isNotNull, isNull } from 'drizzle-orm'
+import { getCachedResources } from '../../cache'
+import type { Resource } from '../../resources/registry/types'
+import { isCustomResourceId } from '../../resources/registry/types'
+import { composeUserCapabilities } from '../capabilities/compose-user-capabilities'
+import {
+  effectiveInstanceLevel,
+  effectiveRecordLevel,
+  type ResolvedRecordAccess,
+} from '../capabilities/entity-access'
+import {
+  INSTANCE_ACCESS_KEYS,
+  type InstanceAccessKey,
+  isInstanceAccessKey,
+} from '../capabilities/instance-access'
+import {
+  AREA_ORDER,
+  type Area,
+  areaLevelFromKeys,
+  type Level,
+  parseAreaLevels,
+} from '../capabilities/registry'
+import { resolveCapabilityInputs } from '../capabilities/resolve-capability-inputs'
+import { projectPermissionProfile } from './profile-projection'
+import { resolveBaseProfile } from './profile-resolution'
+import type { CachedPermissionProfile } from './types'
+
+/** A `Database` or an open transaction — both satisfy the query builder. */
+export type QueryRunner = Database | Transaction
+
+/**
+ * One principal's **resulting effective state** (doc 19 §6.1.2): the three
+ * domains the escalation guard compares. Absent keys mean "no access" — rank 0 —
+ * so `before`/`after` maps of different shapes compare correctly.
+ */
+export interface EffectiveState {
+  userId: string
+  /** Per-area rung, materialized for every area (never sparse). */
+  areas: Record<Area, Level>
+  /** `effectiveRecordLevel` per canonical `entityDefinitionId`; absent = no access. */
+  defs: Record<string, ResourcePermission>
+  /** `effectiveInstanceLevel` per instance CUID; absent = no access. */
+  instances: Record<string, ResourcePermission>
+}
+
+/** One raw grant row (sparse jsonb levels) keyed by its grantee. */
+interface GrantRow {
+  granteeType: string
+  granteeId: string
+  levels: unknown
+}
+
+/** One raw ResourceAccess row, type-level or instance-level. */
+interface AccessRow {
+  granteeType: string
+  granteeId: string
+  entityDefinitionId: string
+  entityInstanceId: string | null
+  permission: ResourcePermission
+}
+
+interface MemberRow {
+  userId: string
+  role: OrganizationRole
+  seatType: SeatType
+  permissionProfileId: string | null
+  userType: UserType
+}
+
+/**
+ * Everything the composer needs for a whole batch of holders, read ONCE from the
+ * transaction. Holders of one profile differ only in role, seatType, group
+ * memberships and personal grants (§6.1.4), so this is O(1) queries for O(N)
+ * principals.
+ */
+interface UncachedInputs {
+  members: Map<string, MemberRow>
+  profiles: CachedPermissionProfile[]
+  groupIdsByUser: Map<string, string[]>
+  grants: GrantRow[]
+  typeRows: AccessRow[]
+  instanceRows: AccessRow[]
+  resources: Resource[]
+  /** Org-wide defs carrying ≥1 type-level row for ANYONE (grantee-agnostic, §0). */
+  restrictedEntityDefIds: Set<string>
+  /** Instance CUID → its instance-access resource key (`dataset` | `kb` | …). */
+  instanceKeyById: Map<string, InstanceAccessKey>
+}
+
+/**
+ * Read every composition input for `userIds` directly from `tx`, **bypassing the
+ * org cache**.
+ *
+ * This is the load-bearing half of §6.1.4. `computeUserCapabilities` resolves the
+ * profile projection, the member role map and the group memberships out of
+ * `getOrgCache()`, which inside an open transaction still returns **pre-write**
+ * values — so composing the post-write state through it would compare
+ * before-state to before-state and the escalation guard would always pass. Every
+ * mutable input below is therefore read from the transaction.
+ *
+ * `resources` is the one exception and deliberately so: it is the org's entity
+ * *definition* projection (slug ↔ `entityDefinitionId`), which a profile save
+ * cannot change. It is a lookup table, not state under comparison.
+ */
+async function readUncachedInputs(
+  organizationId: string,
+  userIds: string[],
+  tx: QueryRunner
+): Promise<UncachedInputs> {
+  const [memberRows, profileRows, groupRows, resources] = await Promise.all([
+    tx
+      .select({
+        userId: schema.OrganizationMember.userId,
+        role: schema.OrganizationMember.role,
+        seatType: schema.OrganizationMember.seatType,
+        permissionProfileId: schema.OrganizationMember.permissionProfileId,
+        userType: schema.User.userType,
+      })
+      .from(schema.OrganizationMember)
+      .leftJoin(schema.User, eq(schema.User.id, schema.OrganizationMember.userId))
+      .where(
+        and(
+          eq(schema.OrganizationMember.organizationId, organizationId),
+          inArray(schema.OrganizationMember.userId, userIds)
+        )
+      ),
+    tx
+      .select({
+        id: schema.PermissionProfile.id,
+        slug: schema.PermissionProfile.slug,
+        name: schema.PermissionProfile.name,
+        description: schema.PermissionProfile.description,
+        icon: schema.PermissionProfile.icon,
+        seat: schema.PermissionProfile.seat,
+        appliesTo: schema.PermissionProfile.appliesTo,
+        baseLevel: schema.PermissionProfile.baseLevel,
+        ceiling: schema.PermissionProfile.ceiling,
+        agentPolicy: schema.PermissionProfile.agentPolicy,
+        isSystem: schema.PermissionProfile.isSystem,
+        updatedAt: schema.PermissionProfile.updatedAt,
+      })
+      .from(schema.PermissionProfile)
+      .where(eq(schema.PermissionProfile.organizationId, organizationId)),
+    tx
+      .select({
+        userId: schema.EntityGroupMember.memberRefId,
+        groupId: schema.EntityGroupMember.groupInstanceId,
+      })
+      .from(schema.EntityGroupMember)
+      .innerJoin(
+        schema.EntityInstance,
+        eq(schema.EntityGroupMember.groupInstanceId, schema.EntityInstance.id)
+      )
+      .where(
+        and(
+          eq(schema.EntityGroupMember.memberType, MemberType.user),
+          eq(schema.EntityInstance.organizationId, organizationId),
+          inArray(schema.EntityGroupMember.memberRefId, userIds)
+        )
+      ),
+    getCachedResources(organizationId),
+  ])
+
+  const groupIdsByUser = new Map<string, string[]>()
+  for (const row of groupRows) {
+    const list = groupIdsByUser.get(row.userId)
+    if (list) list.push(row.groupId)
+    else groupIdsByUser.set(row.userId, [row.groupId])
+  }
+
+  const [grants, typeRows, instanceRows] = await Promise.all([
+    // Every grant row in the org: one sparse-jsonb row per grantee (profile /
+    // group / user), so this is small and a single fetch beats a per-holder IN.
+    tx
+      .select({
+        granteeType: schema.PermissionGrant.granteeType,
+        granteeId: schema.PermissionGrant.granteeId,
+        levels: schema.PermissionGrant.levels,
+      })
+      .from(schema.PermissionGrant)
+      .where(eq(schema.PermissionGrant.organizationId, organizationId)),
+    // Type-level rows for the WHOLE org, not just these grantees: the
+    // `restrictedEntityDefIds` signal is grantee-agnostic by design (a row for
+    // anyone flips the def to restricted for everyone), so a grantee-filtered
+    // read would silently mis-resolve every holder's def level.
+    tx
+      .select({
+        granteeType: schema.ResourceAccess.granteeType,
+        granteeId: schema.ResourceAccess.granteeId,
+        entityDefinitionId: schema.ResourceAccess.entityDefinitionId,
+        entityInstanceId: schema.ResourceAccess.entityInstanceId,
+        permission: schema.ResourceAccess.permission,
+      })
+      .from(schema.ResourceAccess)
+      .where(
+        and(
+          eq(schema.ResourceAccess.organizationId, organizationId),
+          isNull(schema.ResourceAccess.entityInstanceId)
+        )
+      ),
+    // Instance-level rows for the instance-access resources only. Unlike defs,
+    // an instance the holders hold no row for is never in the comparison set, so
+    // the grantee-agnostic restricted set is not needed here.
+    tx
+      .select({
+        granteeType: schema.ResourceAccess.granteeType,
+        granteeId: schema.ResourceAccess.granteeId,
+        entityDefinitionId: schema.ResourceAccess.entityDefinitionId,
+        entityInstanceId: schema.ResourceAccess.entityInstanceId,
+        permission: schema.ResourceAccess.permission,
+      })
+      .from(schema.ResourceAccess)
+      .where(
+        and(
+          eq(schema.ResourceAccess.organizationId, organizationId),
+          inArray(schema.ResourceAccess.entityDefinitionId, INSTANCE_ACCESS_KEYS),
+          isNotNull(schema.ResourceAccess.entityInstanceId)
+        )
+      ),
+  ])
+
+  const restrictedEntityDefIds = new Set<string>()
+  for (const row of typeRows as AccessRow[]) {
+    if (isCustomResourceId(row.entityDefinitionId))
+      restrictedEntityDefIds.add(row.entityDefinitionId)
+  }
+
+  const instanceKeyById = new Map<string, InstanceAccessKey>()
+  for (const row of instanceRows as AccessRow[]) {
+    if (row.entityInstanceId && isInstanceAccessKey(row.entityDefinitionId)) {
+      instanceKeyById.set(row.entityInstanceId, row.entityDefinitionId)
+    }
+  }
+
+  return {
+    members: new Map((memberRows as MemberRow[]).map((row) => [row.userId, row])),
+    profiles: profileRows.map(projectPermissionProfile),
+    groupIdsByUser,
+    grants: grants as GrantRow[],
+    typeRows: typeRows as AccessRow[],
+    instanceRows: instanceRows as AccessRow[],
+    resources,
+    restrictedEntityDefIds,
+    instanceKeyById,
+  }
+}
+
+/**
+ * Whether a ResourceAccess / PermissionGrant row belongs to this principal's
+ * grantee union — the same union `computeUserCapabilities` builds its `WHERE`
+ * from (direct user, the legacy `role:org_member` baseline marker, the bound
+ * profile, the principal's groups).
+ *
+ * `role:org_member` is deliberately shared by both tables here even though the
+ * composer's PermissionGrant union dropped it (§0.8): {@link composeState}
+ * dispatches grant rows by grantee kind and has **no `role` branch**, so a
+ * surviving legacy grant row is matched and then ignored — identical to the
+ * composer skipping it in SQL. Do not add a `role` branch there.
+ */
+function matchesGrantee(
+  row: { granteeType: string; granteeId: string },
+  userId: string,
+  profileId: string | null,
+  groupIds: string[]
+): boolean {
+  if (row.granteeType === 'user') return row.granteeId === userId
+  if (row.granteeType === 'role') return row.granteeId === 'org_member'
+  if (row.granteeType === 'profile') return profileId !== null && row.granteeId === profileId
+  if (row.granteeType === 'group') return groupIds.includes(row.granteeId)
+  return false
+}
+
+/**
+ * Compose one principal's {@link EffectiveState} from an already-read batch.
+ *
+ * Runs the PURE {@link composeUserCapabilities} — the identical function the
+ * cached read path composes with — then measures the three domains through the
+ * identical enforcement predicates (`areaLevelFromKeys`, `effectiveRecordLevel`,
+ * `effectiveInstanceLevel`). Nothing here re-derives a permission rule.
+ */
+function composeState(
+  userId: string,
+  inputs: UncachedInputs,
+  organizationId: string
+): EffectiveState {
+  const member = inputs.members.get(userId)
+  const role = member?.role
+  const seatType = member?.seatType ?? 'full'
+  const userType = member?.userType ?? 'USER'
+  const groupIds = inputs.groupIdsByUser.get(userId) ?? []
+
+  const baseProfile = role
+    ? resolveBaseProfile({
+        organizationId,
+        userId,
+        role,
+        seatType,
+        permissionProfileId: member?.permissionProfileId ?? null,
+        profiles: inputs.profiles,
+      })
+    : null
+  const profileId = baseProfile?.profileId ?? null
+
+  // Mirror `computeUserCapabilities`' admin short-circuit EXACTLY: it skips the
+  // PermissionGrant query for OWNER/ADMIN, so an admin holder's composed state
+  // ignores grant rows. Reading them here would make the guard measure a state
+  // enforcement never produces.
+  const isAdmin = role === 'OWNER' || role === 'ADMIN'
+  let profileLevels: Partial<Record<Area, Level>> | undefined
+  const groupLevels: Array<Partial<Record<Area, Level>>> = []
+  let userLevels: Partial<Record<Area, Level>> | undefined
+  if (!isAdmin) {
+    for (const row of inputs.grants) {
+      if (!matchesGrantee(row, userId, profileId, groupIds)) continue
+      const levels = parseAreaLevels(row.levels)
+      if (row.granteeType === 'profile') profileLevels = levels
+      else if (row.granteeType === 'group') groupLevels.push(levels)
+      else if (row.granteeType === 'user') userLevels = levels
+    }
+  }
+
+  const typeAccessRows = inputs.typeRows
+    .filter((row) => matchesGrantee(row, userId, profileId, groupIds))
+    .map((row) => ({ entityDefinitionId: row.entityDefinitionId, permission: row.permission }))
+  const instanceAccessRows = inputs.instanceRows
+    .filter((row) => matchesGrantee(row, userId, profileId, groupIds))
+    .map((row) => ({ entityInstanceId: row.entityInstanceId ?? '', permission: row.permission }))
+
+  const caps = composeUserCapabilities({
+    role,
+    seatType,
+    userType,
+    profileLevels,
+    profileBaseLevel: baseProfile?.baseLevel ?? null,
+    profileCeiling: baseProfile?.ceiling ?? null,
+    groupLevels,
+    userLevels,
+    typeAccessRows,
+    instanceAccessRows,
+  })
+
+  const resolved = resolveCapabilityInputs(caps, inputs.resources)
+  const access: ResolvedRecordAccess = {
+    role: role ?? 'USER',
+    seatType,
+    keys: resolved.keys,
+    defAccess: resolved.defAccess,
+    restrictedEntityDefIds: inputs.restrictedEntityDefIds,
+    defBaseOverrides: resolved.defBaseOverrides,
+    instanceAccess: caps.instanceAccess,
+    // The instance query is deliberately grantee-agnostic, so its id set IS the
+    // org-wide `restrictedInstanceIds` projection, recomputed from the txn.
+    restrictedInstanceIds: new Set(inputs.instanceKeyById.keys()),
+    ceilingDefs: resolved.ceilingDefs,
+  }
+
+  const areas = {} as Record<Area, Level>
+  for (const area of AREA_ORDER) areas[area] = areaLevelFromKeys(resolved.keys, area)
+
+  const defs: Record<string, ResourcePermission> = {}
+  for (const resource of inputs.resources) {
+    const level = effectiveRecordLevel(access, resource.entityDefinitionId)
+    if (level !== undefined) defs[resource.entityDefinitionId] = level
+  }
+
+  const instances: Record<string, ResourcePermission> = {}
+  for (const [instanceId, key] of inputs.instanceKeyById) {
+    const level = effectiveInstanceLevel(access, key, instanceId)
+    if (level !== undefined) instances[instanceId] = level
+  }
+
+  // A non-member holds nothing — `composeUserCapabilities` already fails closed,
+  // and the loops above then yield empty maps.
+  return { userId, areas, defs, instances }
+}
+
+/**
+ * Compose the {@link EffectiveState} of many principals from ONE batch of
+ * transaction-local reads — the §6.1.4 "batch, do not loop" requirement.
+ *
+ * Six queries regardless of holder count; the per-holder work is pure in-memory
+ * composition through {@link composeUserCapabilities}.
+ */
+export async function computeEffectiveStatesUncached(input: {
+  organizationId: string
+  userIds: string[]
+  tx: QueryRunner
+}): Promise<Map<string, EffectiveState>> {
+  const { organizationId, tx } = input
+  const userIds = [...new Set(input.userIds)]
+  const out = new Map<string, EffectiveState>()
+  if (userIds.length === 0) return out
+
+  const inputs = await readUncachedInputs(organizationId, userIds, tx)
+  for (const userId of userIds) out.set(userId, composeState(userId, inputs, organizationId))
+  return out
+}
+
+/**
+ * Single-principal convenience over {@link computeEffectiveStatesUncached} — the
+ * `computeEffectiveStateUncached(userId, orgId, tx)` of §6.1.4. Prefer the batch
+ * form whenever more than one principal is involved.
+ */
+export async function computeEffectiveStateUncached(
+  userId: string,
+  organizationId: string,
+  tx: QueryRunner
+): Promise<EffectiveState> {
+  const states = await computeEffectiveStatesUncached({ organizationId, userIds: [userId], tx })
+  const state = states.get(userId)
+  if (state) return state
+  // Unreachable: the batch always emits an entry per requested id.
+  throw new Error(`Effective state was not composed for user ${userId}`)
+}

--- a/packages/lib/src/permissions/profiles/escalation-guard.test.ts
+++ b/packages/lib/src/permissions/profiles/escalation-guard.test.ts
@@ -1,0 +1,274 @@
+// packages/lib/src/permissions/profiles/escalation-guard.test.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import type { OrganizationRole } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { ForbiddenError } from '../../errors'
+import { Area, buildAreaLevels, Level } from '../capabilities/registry'
+import type { EffectiveState } from './effective-state'
+import {
+  type ActorAuthority,
+  assertNoEscalation,
+  assertProfileMapNoEscalation,
+} from './escalation-guard'
+
+/**
+ * The §6.1 escalation guard, tested as the pure algorithm it is — the states it
+ * compares are produced by `computeEffectiveStatesUncached` (see
+ * `profile-save.test.ts`, which proves the composition half and the cache bypass).
+ */
+
+const HR_DEF = 'def_hr_000000000000000000000'
+
+/** An effective state: every area at `base`, plus explicit per-area overrides. */
+function state(input: {
+  userId?: string
+  base?: Level
+  areas?: Partial<Record<Area, Level>>
+  defs?: Record<string, ResourcePermission>
+  instances?: Record<string, ResourcePermission>
+}): EffectiveState {
+  const areas = buildAreaLevels((area) => input.areas?.[area] ?? input.base ?? Level.None)
+  return {
+    userId: input.userId ?? 'u_holder',
+    areas,
+    defs: input.defs ?? {},
+    instances: input.instances ?? {},
+  }
+}
+
+function actorAt(input: Parameters<typeof state>[0] & { role?: OrganizationRole }): ActorAuthority {
+  return {
+    userId: 'u_actor',
+    role: input.role ?? 'USER',
+    state: state({ ...input, userId: 'u_actor' }),
+  }
+}
+
+function run(input: {
+  actor: ActorAuthority
+  before: EffectiveState
+  after: EffectiveState
+}): void {
+  assertNoEscalation({
+    actor: input.actor,
+    before: new Map([[input.before.userId, input.before]]),
+    after: new Map([[input.after.userId, input.after]]),
+  })
+}
+
+describe('assertNoEscalation — §6.1.2 delta gating', () => {
+  it('PERMITS a decrease, even below an actor whose own access was narrowed', () => {
+    // Property 1: removal only tightens, so it never needs authority. Without
+    // this, an admin who was narrowed could not clean up a profile at all.
+    expect(() =>
+      run({
+        actor: actorAt({ areas: { [Area.records]: Level.Read } }),
+        before: state({ areas: { [Area.records]: Level.Full } }),
+        after: state({ areas: { [Area.records]: Level.Edit } }),
+      })
+    ).not.toThrow()
+  })
+
+  it('DENIES a raise above the actor’s own level', () => {
+    expect(() =>
+      run({
+        actor: actorAt({ areas: { [Area.records]: Level.Edit } }),
+        before: state({ areas: { [Area.records]: Level.Read } }),
+        after: state({ areas: { [Area.records]: Level.Full } }),
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('PERMITS a raise that stays at or below the actor’s own level', () => {
+    expect(() =>
+      run({
+        actor: actorAt({ areas: { [Area.records]: Level.Edit } }),
+        before: state({ areas: { [Area.records]: Level.Read } }),
+        after: state({ areas: { [Area.records]: Level.Edit } }),
+      })
+    ).not.toThrow()
+  })
+
+  it('leaves a holder who ALREADY sits above the actor alone (gate is on the delta)', () => {
+    // The holder keeps `records: Full` the actor does not hold; an unrelated,
+    // in-authority change must still go through.
+    expect(() =>
+      run({
+        actor: actorAt({ areas: { [Area.records]: Level.Read, [Area.files]: Level.Full } }),
+        before: state({ areas: { [Area.records]: Level.Full, [Area.files]: Level.None } }),
+        after: state({ areas: { [Area.records]: Level.Full, [Area.files]: Level.Full } }),
+      })
+    ).not.toThrow()
+  })
+
+  it('DENIES surfacing a PRE-EXISTING grant the actor never authored (§6.1 mode 1)', () => {
+    // Raising the definition ceiling exposes a group grant the holder already
+    // had. The actor wrote no grant here — only the ceiling moved — but the
+    // holder's resulting state rises above the actor's own def access.
+    expect(() =>
+      run({
+        actor: actorAt({ base: Level.Full, defs: { [HR_DEF]: 'view' } }),
+        before: state({ base: Level.Full, defs: {} }),
+        after: state({ base: Level.Full, defs: { [HR_DEF]: 'admin' } }),
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('PERMITS the same ceiling raise when the actor holds that def access outright', () => {
+    expect(() =>
+      run({
+        actor: actorAt({ base: Level.Full, defs: { [HR_DEF]: 'admin' } }),
+        before: state({ base: Level.Full, defs: {} }),
+        after: state({ base: Level.Full, defs: { [HR_DEF]: 'admin' } }),
+      })
+    ).not.toThrow()
+  })
+
+  it('DENIES an instance-level raise above the actor’s own instance access', () => {
+    expect(() =>
+      run({
+        actor: actorAt({ base: Level.Full, instances: { ds_1: 'view' } }),
+        before: state({ base: Level.Full, instances: { ds_1: 'view' } }),
+        after: state({ base: Level.Full, instances: { ds_1: 'admin' } }),
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('OWNER short-circuits to pass — the §0.10 recovery guarantee', () => {
+    // An owner whose composed state were (impossibly) empty must still be able
+    // to fix a mis-shaped profile, or the org can lock itself out.
+    expect(() =>
+      run({
+        actor: actorAt({ role: 'OWNER', base: Level.None }),
+        before: state({ base: Level.None }),
+        after: state({ base: Level.Full, defs: { [HR_DEF]: 'admin' } }),
+      })
+    ).not.toThrow()
+  })
+
+  it('checks EVERY holder, not just the first', () => {
+    const actor = actorAt({ areas: { [Area.records]: Level.Read } })
+    const before = new Map<string, EffectiveState>([
+      ['u_1', state({ userId: 'u_1', areas: { [Area.records]: Level.Read } })],
+      ['u_2', state({ userId: 'u_2', areas: { [Area.records]: Level.Read } })],
+    ])
+    const after = new Map<string, EffectiveState>([
+      ['u_1', state({ userId: 'u_1', areas: { [Area.records]: Level.Read } })],
+      ['u_2', state({ userId: 'u_2', areas: { [Area.records]: Level.Full } })],
+    ])
+    expect(() => assertNoEscalation({ actor, before, after })).toThrow(ForbiddenError)
+  })
+
+  it('treats a holder with no BEFORE state as starting from None', () => {
+    const actor = actorAt({ areas: { [Area.records]: Level.Read } })
+    expect(() =>
+      assertNoEscalation({
+        actor,
+        before: new Map(),
+        after: new Map([['u_1', state({ userId: 'u_1', areas: { [Area.records]: Level.Full } })]]),
+      })
+    ).toThrow(ForbiddenError)
+  })
+})
+
+describe('assertProfileMapNoEscalation — the >500-holder strict fallback (§6.1.3)', () => {
+  const NO_DEFS: string[] = []
+
+  it('DENIES an area the profile newly sets above the actor’s own level', () => {
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ areas: { [Area.records]: Level.Read } }),
+        before: { levels: {}, baseLevel: null, ceiling: null },
+        after: { levels: { [Area.records]: Level.Full }, baseLevel: null, ceiling: null },
+        defIds: NO_DEFS,
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('PERMITS lowering an area the actor does not hold', () => {
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ areas: { [Area.records]: Level.None } }),
+        before: { levels: { [Area.records]: Level.Full }, baseLevel: null, ceiling: null },
+        after: { levels: { [Area.records]: Level.Read }, baseLevel: null, ceiling: null },
+        defIds: NO_DEFS,
+      })
+    ).not.toThrow()
+  })
+
+  it('DENIES loosening an area ceiling beyond the actor’s own level', () => {
+    // Conservative by design: a group grant could carry any holder up to the new
+    // cap, and this mode cannot look at holders to find out.
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ areas: { [Area.files]: Level.Read } }),
+        before: { levels: {}, baseLevel: null, ceiling: { areas: { [Area.files]: Level.Read } } },
+        after: { levels: {}, baseLevel: null, ceiling: { areas: { [Area.files]: Level.Full } } },
+        defIds: NO_DEFS,
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('PERMITS tightening an area ceiling', () => {
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ areas: { [Area.files]: Level.None } }),
+        before: { levels: {}, baseLevel: null, ceiling: null },
+        after: { levels: {}, baseLevel: null, ceiling: { areas: { [Area.files]: Level.Read } } },
+        defIds: NO_DEFS,
+      })
+    ).not.toThrow()
+  })
+
+  it('DENIES widening the definition ceiling onto a def the actor does not administer', () => {
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ base: Level.Full, defs: { [HR_DEF]: 'edit' } }),
+        before: { levels: {}, baseLevel: null, ceiling: { defs: { mode: 'only', slugs: [] } } },
+        after: { levels: {}, baseLevel: null, ceiling: null },
+        defIds: [HR_DEF],
+        toDefinitionId: (key) => key,
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('PERMITS widening the definition ceiling when the actor administers the def', () => {
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ base: Level.Full, defs: { [HR_DEF]: 'admin' } }),
+        before: { levels: {}, baseLevel: null, ceiling: { defs: { mode: 'only', slugs: [] } } },
+        after: { levels: {}, baseLevel: null, ceiling: null },
+        defIds: [HR_DEF],
+        toDefinitionId: (key) => key,
+      })
+    ).not.toThrow()
+  })
+
+  it('resolves the ceiling’s apiSlugs into the def keyspace before comparing', () => {
+    // `hr` is the apiSlug; `defs`/`defIds` speak entityDefinitionIds. Without the
+    // resolver the "only: [hr]" ceiling would look like it admits nothing and the
+    // widening would go unnoticed.
+    const toDefinitionId = (key: string) => (key === 'hr' ? HR_DEF : key)
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ base: Level.Full, defs: { [HR_DEF]: 'view' } }),
+        before: { levels: {}, baseLevel: null, ceiling: { defs: { mode: 'only', slugs: [] } } },
+        after: { levels: {}, baseLevel: null, ceiling: { defs: { mode: 'only', slugs: ['hr'] } } },
+        defIds: [HR_DEF],
+        toDefinitionId,
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('OWNER short-circuits here too', () => {
+    expect(() =>
+      assertProfileMapNoEscalation({
+        actor: actorAt({ role: 'OWNER', base: Level.None }),
+        before: { levels: {}, baseLevel: null, ceiling: null },
+        after: { levels: { [Area.records]: Level.Full }, baseLevel: Level.Full, ceiling: null },
+        defIds: [HR_DEF],
+      })
+    ).not.toThrow()
+  })
+})

--- a/packages/lib/src/permissions/profiles/escalation-guard.ts
+++ b/packages/lib/src/permissions/profiles/escalation-guard.ts
@@ -1,0 +1,232 @@
+// packages/lib/src/permissions/profiles/escalation-guard.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import type { OrganizationRole } from '@auxx/database/types'
+import { ForbiddenError } from '../../errors'
+import { PERMISSION_RANK } from '../capabilities/compose-user-capabilities'
+import { AREA_ORDER, type Area, Level, PERMISSION_AREAS } from '../capabilities/registry'
+import type { EffectiveState } from './effective-state'
+import type { ProfileCeiling } from './types'
+
+/**
+ * Above this many affected holders the guard stops composing per-holder states
+ * and falls back to {@link assertProfileMapNoEscalation} (§6.1.3).
+ *
+ * A **security** budget, unrelated to `profile-invalidation.ts`'s
+ * `BROADCAST_THRESHOLD` (a cache-delivery budget of 50). Crossing this one
+ * changes what is *allowed* — deliberately in the conservative direction
+ * (§11.6), so a very large org may see a legitimate edit refused.
+ */
+export const HOLDER_GUARD_CAP = 500
+
+/** Display names for the level ladder, for the denial message. */
+const LEVEL_NAMES: Record<Level, string> = {
+  [Level.None]: 'None',
+  [Level.Read]: 'Read',
+  [Level.Edit]: 'Edit',
+  [Level.Full]: 'Full',
+}
+
+/** `undefined` (no access) ranks below every real permission. */
+function rank(permission: ResourcePermission | undefined): number {
+  return permission === undefined ? 0 : PERMISSION_RANK[permission]
+}
+
+/**
+ * The actor's own authority (§6.1.1): their effective state, composed by the
+ * SAME composer every holder goes through, plus the role that decides the
+ * recovery short-circuit.
+ */
+export interface ActorAuthority {
+  userId: string
+  role: OrganizationRole
+  state: EffectiveState
+}
+
+function deny(message: string): never {
+  throw new ForbiddenError(
+    `You cannot grant access you do not hold yourself. ${message} ` +
+      'Ask an owner, or an admin with that access, to make this change.'
+  )
+}
+
+/**
+ * The §0.23 escalation guard — *you may only write or assign access you already
+ * hold* — evaluated over each affected holder's **resulting effective state**,
+ * never over the profile's own maps (§6.1).
+ *
+ * The comparison is **delta-gated, not absolute** (§6.1.2):
+ *
+ * ```
+ * for each area a:      if after[a] > before[a] && after[a] > actorAreas[a]      → DENY
+ * for each def d:       if rank(after) > rank(before) && rank(after) > actorDef  → DENY
+ * for each instance i:  likewise
+ * ```
+ *
+ * Two properties fall out, and both are load-bearing:
+ *
+ *  - **A decrease is always permitted.** Nothing is denied unless `after >
+ *    before`, so an admin whose own access was narrowed can still clean up a
+ *    profile — matching `clearGranteeLevels` not being plan-gated (removal only
+ *    tightens).
+ *  - **Pre-existing grants the actor never authored are still caught.** Raising a
+ *    ceiling that surfaces a holder's existing group grant makes `after > before`
+ *    true for that holder, so the actor must hold that level themselves even
+ *    though the group grant is not part of the edit. This is the unsoundness
+ *    (§6.1's mode 1) that comparing profile maps to the actor would miss.
+ *
+ * **OWNER short-circuits to pass as an early return** — not as a special case
+ * threaded through the algorithm. That is what keeps §0.10's recovery guarantee:
+ * a mis-shaped profile is always fixable by an owner.
+ */
+export function assertNoEscalation(input: {
+  actor: ActorAuthority
+  before: Map<string, EffectiveState>
+  after: Map<string, EffectiveState>
+}): void {
+  const { actor, before, after } = input
+
+  // §0.10 recovery guarantee. An owner is all-Full by construction, so every
+  // comparison below would be vacuous anyway — but stating it as an early return
+  // means no later change to the algorithm can accidentally lock the org out.
+  if (actor.role === 'OWNER') return
+
+  for (const [userId, afterState] of after) {
+    const beforeState = before.get(userId)
+
+    for (const area of AREA_ORDER) {
+      const next = afterState.areas[area]
+      const prev = beforeState?.areas[area] ?? Level.None
+      if (next > prev && next > actor.state.areas[area]) {
+        deny(
+          `This change raises '${PERMISSION_AREAS[area].label}' from ${LEVEL_NAMES[prev]} to ` +
+            `${LEVEL_NAMES[next]} for at least one member, above your own ${LEVEL_NAMES[actor.state.areas[area]]}.`
+        )
+      }
+    }
+
+    // Union of both sides: a def present in only one state still has a delta.
+    for (const defId of new Set([
+      ...Object.keys(afterState.defs),
+      ...Object.keys(beforeState?.defs ?? {}),
+    ])) {
+      const next = afterState.defs[defId]
+      const prev = beforeState?.defs[defId]
+      if (rank(next) > rank(prev) && rank(next) > rank(actor.state.defs[defId])) {
+        deny(
+          `This change raises access to one entity definition for at least one member ` +
+            `above your own access to it.`
+        )
+      }
+    }
+
+    for (const instanceId of new Set([
+      ...Object.keys(afterState.instances),
+      ...Object.keys(beforeState?.instances ?? {}),
+    ])) {
+      const next = afterState.instances[instanceId]
+      const prev = beforeState?.instances[instanceId]
+      if (rank(next) > rank(prev) && rank(next) > rank(actor.state.instances[instanceId])) {
+        deny(
+          `This change raises access to one shared resource for at least one member ` +
+            `above your own access to it.`
+        )
+      }
+    }
+  }
+}
+
+/** The authored half of a profile — what the strict fallback compares. */
+export interface ProfileAuthoredState {
+  /** The profile's `PermissionGrant` levels (sparse; absent = unset). */
+  levels: Partial<Record<Area, Level>>
+  /** The profile's blanket fallback rung for unset areas. */
+  baseLevel: Level | null
+  ceiling: ProfileCeiling | null
+}
+
+/**
+ * The >{@link HOLDER_GUARD_CAP}-holder fallback (§6.1.3): compare the **profile
+ * map itself** against the actor's authority and require the actor to hold every
+ * raised value outright.
+ *
+ * Still delta-gated on the profile map (so a decrease is permitted and an
+ * untouched area is never re-litigated), but deliberately more conservative than
+ * the exact check in three ways, because no holder state is available:
+ *
+ *  - an area moving from *unset* to an explicit rung is treated as a raise from
+ *    `None`, even where the role default already supplied that rung;
+ *  - **loosening a ceiling is treated as granting its new cap outright**, since
+ *    a group grant could carry any holder up to it;
+ *  - a definition the ceiling newly admits requires the actor to *administer*
+ *    that definition, the maximum a holder could reach through it.
+ *
+ * §11.6 records this as a known, accepted source of false refusals in very large
+ * orgs.
+ */
+export function assertProfileMapNoEscalation(input: {
+  actor: ActorAuthority
+  before: ProfileAuthoredState
+  after: ProfileAuthoredState
+  /** Every live definition id in the org — the domain the def ceiling ranges over. */
+  defIds: string[]
+  /**
+   * apiSlug → canonical `entityDefinitionId` (the `resolveCapabilityInputs`
+   * resolver). Ceilings store apiSlugs while `defIds` and the actor's own def
+   * levels are id-keyed, so both sides are normalized through this.
+   */
+  toDefinitionId?: (key: string) => string
+}): void {
+  const { actor, before, after, defIds } = input
+  const toDefinitionId = input.toDefinitionId ?? ((key: string) => key)
+  if (actor.role === 'OWNER') return
+
+  for (const area of AREA_ORDER) {
+    // Unset falls through to a role default this check cannot see, so it is read
+    // as `None` on BOTH sides: unset→unset is a no-op, unset→explicit is a raise.
+    const next = after.levels[area] ?? after.baseLevel ?? Level.None
+    const prev = before.levels[area] ?? before.baseLevel ?? Level.None
+    if (next > prev && next > actor.state.areas[area]) {
+      deny(
+        `This profile sets '${PERMISSION_AREAS[area].label}' to ${LEVEL_NAMES[next]}, ` +
+          `above your own ${LEVEL_NAMES[actor.state.areas[area]]}.`
+      )
+    }
+
+    // An absent ceiling entry is uncapped, so `Full` is the honest "before".
+    const capNext = after.ceiling?.areas?.[area] ?? Level.Full
+    const capPrev = before.ceiling?.areas?.[area] ?? Level.Full
+    if (capNext > capPrev && capNext > actor.state.areas[area]) {
+      deny(
+        `This profile raises the '${PERMISSION_AREAS[area].label}' ceiling to ` +
+          `${LEVEL_NAMES[capNext]}, above your own ${LEVEL_NAMES[actor.state.areas[area]]}.`
+      )
+    }
+  }
+
+  for (const defId of defIds) {
+    const admittedNow = ceilingAdmits(after.ceiling, defId, toDefinitionId)
+    const admittedBefore = ceilingAdmits(before.ceiling, defId, toDefinitionId)
+    if (!admittedNow || admittedBefore) continue
+    if (actor.state.defs[defId] !== 'admin') {
+      deny('This profile widens its entity-definition ceiling beyond what you administer yourself.')
+    }
+  }
+}
+
+/**
+ * Whether a stored (slug-keyed) definition ceiling admits `defId`, with the
+ * ceiling's slugs normalized into the same `entityDefinitionId` keyspace. A slug
+ * matching no live definition resolves to itself and simply never matches, so
+ * `only` stays fail-closed and `except` stays fail-open (§0.13).
+ */
+function ceilingAdmits(
+  ceiling: ProfileCeiling | null,
+  defId: string,
+  toDefinitionId: (key: string) => string
+): boolean {
+  const defs = ceiling?.defs
+  if (!defs) return true
+  const listed = defs.slugs.some((slug) => toDefinitionId(slug) === defId)
+  return defs.mode === 'only' ? listed : !listed
+}

--- a/packages/lib/src/permissions/profiles/index.ts
+++ b/packages/lib/src/permissions/profiles/index.ts
@@ -31,19 +31,35 @@ export {
   clampAgentPolicyToPublisher,
 } from './agent-policy-clamp'
 export {
+  computeEffectiveStatesUncached,
+  computeEffectiveStateUncached,
+  type EffectiveState,
+  type QueryRunner,
+} from './effective-state'
+export {
+  type ActorAuthority,
+  assertNoEscalation,
+  assertProfileMapNoEscalation,
+  HOLDER_GUARD_CAP,
+  type ProfileAuthoredState,
+} from './escalation-guard'
+export {
   emitPermissionProfileChanged,
   fanOutCapabilityChange,
   type ProfileAudience,
   resolveProfileAudience,
+  resolveProfileHolderIds,
 } from './profile-invalidation'
 export {
   type CreatePermissionProfileInput,
   createPermissionProfile,
-  type UpdatePermissionProfileInput,
-  updatePermissionProfile,
 } from './profile-mutations'
 export { parseProfileCeiling, projectPermissionProfile } from './profile-projection'
 export { type ResolvedBaseProfile, resolveBaseProfile } from './profile-resolution'
+export {
+  type SavePermissionProfileInput,
+  savePermissionProfile,
+} from './profile-save'
 export {
   ensureSystemProfiles,
   SYSTEM_PROFILE_SEEDS,

--- a/packages/lib/src/permissions/profiles/profile-invalidation.ts
+++ b/packages/lib/src/permissions/profiles/profile-invalidation.ts
@@ -10,6 +10,12 @@ const logger = createScopedLogger('permission-profiles')
 /**
  * Above this many affected members, targeted per-user invalidation stops being
  * cheaper than the org-wide broadcast the cache/realtime layers already support.
+ *
+ * **Distinct from the §6.1.3 guard cap of 500 holders**, which is a *security*
+ * budget (above it the escalation guard stops composing per-holder states and
+ * falls back to the strict profile-map check). This one is a *cache* budget:
+ * crossing it only changes how invalidation is delivered, never what is allowed.
+ * They are deliberately different numbers for different reasons — do not merge.
  */
 const BROADCAST_THRESHOLD = 50
 
@@ -47,6 +53,31 @@ export async function resolveProfileAudience(input: {
   slug?: string
   isSystem?: boolean
 }): Promise<ProfileAudience> {
+  const userIds = await resolveProfileHolderIds(input)
+  // `null` = the profile could not be classified; never guess narrow.
+  if (userIds === null) return { userIds: [], broadcast: true }
+  if (userIds.length > BROADCAST_THRESHOLD) return { userIds: [], broadcast: true }
+  return { userIds, broadcast: false }
+}
+
+/**
+ * The raw §6.1.3 affected-holder sweep — every user id a change to this profile
+ * reaches, **uncollapsed**. `null` means the profile could not be classified
+ * (deleted, or a stale projection), which the invalidation path turns into an
+ * org-wide broadcast and the escalation guard must treat as "unknown holders".
+ *
+ * Split out of {@link resolveProfileAudience} so the §6.1 escalation guard and
+ * the §8.3 invalidation share ONE sweep — including the null-bound majority,
+ * which no index can return. The audience wrapper collapses a large result to a
+ * broadcast; the guard needs the ids themselves, so it calls this directly.
+ */
+export async function resolveProfileHolderIds(input: {
+  organizationId: string
+  profileId: string
+  /** Skips the cache lookup when the caller already has the row. */
+  slug?: string
+  isSystem?: boolean
+}): Promise<string[] | null> {
   const { organizationId, profileId } = input
 
   let slug = input.slug
@@ -55,12 +86,11 @@ export async function resolveProfileAudience(input: {
     const profiles = await getOrgCache().get(organizationId, 'profiles')
     const row = profiles.find((p) => p.id === profileId)
     if (!row) {
-      // Unclassifiable (deleted, or a stale projection) — never guess narrow.
-      logger.warn('Permission profile not found for invalidation — broadcasting org-wide', {
+      logger.warn('Permission profile not found for holder sweep', {
         organizationId,
         profileId,
       })
-      return { userIds: [], broadcast: true }
+      return null
     }
     slug = row.slug
     isSystem = row.isSystem
@@ -79,9 +109,7 @@ export async function resolveProfileAudience(input: {
       if (systemProfileFor(entry.role, entry.seatType) === slug) userIds.push(userId)
     }
   }
-
-  if (userIds.length > BROADCAST_THRESHOLD) return { userIds: [], broadcast: true }
-  return { userIds, broadcast: false }
+  return userIds
 }
 
 /**

--- a/packages/lib/src/permissions/profiles/profile-mutations.ts
+++ b/packages/lib/src/permissions/profiles/profile-mutations.ts
@@ -3,7 +3,7 @@
 import { type Database, database, type PermissionProfileEntity, schema } from '@auxx/database'
 import type { SeatType } from '@auxx/database/types'
 import { and, eq } from 'drizzle-orm'
-import { BadRequestError, ForbiddenError, NotFoundError } from '../../errors'
+import { BadRequestError, ForbiddenError } from '../../errors'
 import { FeaturePermissionService } from '../feature-permission-service'
 import { FeatureKey } from '../types'
 import { emitPermissionProfileChanged } from './profile-invalidation'
@@ -25,9 +25,39 @@ async function requireGranularPermissions(db: Database, organizationId: string):
   )
 }
 
+/**
+ * The OWNER/ADMIN-only rule for agent-side profiles (§0.25 / doc 14 §0.9).
+ * `permissions` becoming grantable must never hand agent policy to a non-admin,
+ * so every agent-profile write resolves the actor's role first.
+ */
+async function assertAgentProfileActor(
+  db: Database,
+  organizationId: string,
+  actorUserId: string
+): Promise<void> {
+  const [member] = await db
+    .select({ role: schema.OrganizationMember.role })
+    .from(schema.OrganizationMember)
+    .where(
+      and(
+        eq(schema.OrganizationMember.organizationId, organizationId),
+        eq(schema.OrganizationMember.userId, actorUserId)
+      )
+    )
+    .limit(1)
+
+  if (member?.role !== 'OWNER' && member?.role !== 'ADMIN') {
+    throw new ForbiddenError(
+      'Only owners and admins can create an agent permission profile (doc 14 §0.9).'
+    )
+  }
+}
+
 /** Fields a caller may author on create. */
 export interface CreatePermissionProfileInput {
   organizationId: string
+  /** Who is creating it — gates the agent-profile branch (§0.25). */
+  actorUserId: string
   slug: string
   name: string
   description?: string | null
@@ -47,15 +77,24 @@ export interface CreatePermissionProfileInput {
  *
  * `isSystem` is never authorable and the six reserved system slugs are refused —
  * a custom profile can never shadow the template a null binding resolves to.
+ *
+ * **The §6.1 escalation guard deliberately does not run here.** A brand-new
+ * profile has no holders, so its resulting-effective-state comparison is vacuous
+ * by construction; the authority check bites where the access actually reaches a
+ * principal — `savePermissionProfile` (holders) and profile assignment (§6.1.3's
+ * `{M}` row, step 8).
  */
 export async function createPermissionProfile(
   input: CreatePermissionProfileInput
 ): Promise<PermissionProfileEntity> {
-  const { organizationId, slug, name } = input
+  const { organizationId, actorUserId, slug, name } = input
   const db = input.db ?? database
 
   if (SYSTEM_SLUG_SET.has(slug)) {
     throw new BadRequestError(`'${slug}' is a reserved system profile slug.`)
+  }
+  if (input.appliesTo === 'agent' || input.agentPolicy) {
+    await assertAgentProfileActor(db, organizationId, actorUserId)
   }
   await requireGranularPermissions(db, organizationId)
 
@@ -90,96 +129,16 @@ export async function createPermissionProfile(
 }
 
 /**
- * The mutable half of a profile. `seat`, `appliesTo`, `slug` and `isSystem` are
- * deliberately absent — they are IMMUTABLE after creation (§0.18). Editing `seat`
- * under existing holders would leave them on a profile whose declared class no
- * longer matches their billed `seatType`, bypassing the core invariant; changing
- * seat class is "clone the profile and reassign", which re-runs the per-holder cap
- * check.
- */
-export interface UpdatePermissionProfileInput {
-  organizationId: string
-  profileId: string
-  name?: string
-  description?: string | null
-  icon?: { iconId: string; color: string } | null
-  baseLevel?: number | null
-  ceiling?: ProfileCeiling | null
-  agentPolicy?: AgentPermissionPolicy | null
-  db?: Database
-}
-
-/**
- * Update a permission profile's mutable fields, then fan out the §8.3
- * invalidation (which reaches NULL-BOUND holders for a system profile).
+ * The mutable half of a profile is authored exclusively by
+ * `savePermissionProfile` (`profile-save.ts`).
  *
- * Immutability is enforced structurally — {@link UpdatePermissionProfileInput}
- * cannot express a `seat`/`appliesTo`/`slug`/`isSystem` change — plus these
- * runtime guards for callers coming in over the wire:
- *  - the profile must belong to `organizationId` (cross-org writes are refused
- *    even though the FK alone cannot guarantee co-tenancy — §1.1);
- *  - the `owner` system profile is not editable and is **never ceilinged**
- *    (§0.10): its unconditional bypass is the recovery guarantee, so a ceiling
- *    there would be a lie the UI must not be able to author.
+ * There is deliberately **no** standalone `updatePermissionProfile`: §6.1.4
+ * requires ONE transactional save carrying metadata, levels, the ceiling and (at
+ * step 9) the def/instance rows together, because a save spanning several
+ * requests cannot enforce one atomic "resulting effective state" check. A
+ * metadata-only side door would be exactly that multi-request variant.
+ *
+ * `seat`, `appliesTo`, `slug` and `isSystem` stay immutable after creation
+ * (§0.18) — changing seat class is "clone the profile and reassign", which
+ * re-runs the per-holder cap check.
  */
-export async function updatePermissionProfile(
-  input: UpdatePermissionProfileInput
-): Promise<PermissionProfileEntity> {
-  const { organizationId, profileId } = input
-  const db = input.db ?? database
-
-  const [existing] = await db
-    .select({
-      id: schema.PermissionProfile.id,
-      slug: schema.PermissionProfile.slug,
-      isSystem: schema.PermissionProfile.isSystem,
-    })
-    .from(schema.PermissionProfile)
-    .where(
-      and(
-        eq(schema.PermissionProfile.id, profileId),
-        eq(schema.PermissionProfile.organizationId, organizationId)
-      )
-    )
-    .limit(1)
-
-  if (!existing) throw new NotFoundError('Permission profile not found in this organization.')
-  if (existing.slug === 'owner') {
-    throw new ForbiddenError(
-      'The Owner profile is not editable and can never carry a ceiling — it is the recovery guarantee.'
-    )
-  }
-
-  await requireGranularPermissions(db, organizationId)
-
-  const patch: Partial<PermissionProfileEntity> = {}
-  if (input.name !== undefined) patch.name = input.name
-  if (input.description !== undefined) patch.description = input.description
-  if (input.icon !== undefined) patch.icon = input.icon
-  if (input.baseLevel !== undefined) patch.baseLevel = input.baseLevel
-  if (input.ceiling !== undefined) patch.ceiling = input.ceiling as Record<string, unknown> | null
-  if (input.agentPolicy !== undefined) patch.agentPolicy = input.agentPolicy
-
-  if (Object.keys(patch).length === 0) {
-    throw new BadRequestError('No updatable permission-profile fields were provided.')
-  }
-
-  const [row] = await db
-    .update(schema.PermissionProfile)
-    .set({ ...patch, updatedAt: new Date() })
-    .where(
-      and(
-        eq(schema.PermissionProfile.id, profileId),
-        eq(schema.PermissionProfile.organizationId, organizationId)
-      )
-    )
-    .returning()
-
-  await emitPermissionProfileChanged({
-    organizationId,
-    profileId,
-    slug: existing.slug,
-    isSystem: existing.isSystem,
-  })
-  return row as PermissionProfileEntity
-}

--- a/packages/lib/src/permissions/profiles/profile-projection.ts
+++ b/packages/lib/src/permissions/profiles/profile-projection.ts
@@ -18,8 +18,8 @@ import type {
  * valid mode plus a string array. Returns `null` for anything unusable, which
  * composition reads as "uncapped".
  *
- * `defs` is parsed and carried but NOT enforced — definition-ceiling enforcement
- * is plan 19 step 4.
+ * `defs` stays slug-keyed here; `getCapabilities` resolves it into the
+ * `entityDefinitionId` keyspace on read, where the record resolvers enforce it.
  */
 export function parseProfileCeiling(raw: unknown): ProfileCeiling | null {
   if (!raw || typeof raw !== 'object') return null

--- a/packages/lib/src/permissions/profiles/profile-save.test.ts
+++ b/packages/lib/src/permissions/profiles/profile-save.test.ts
@@ -1,0 +1,788 @@
+// packages/lib/src/permissions/profiles/profile-save.test.ts
+
+import { MemberType } from '@auxx/database/enums'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Resource } from '../../resources/registry/types'
+
+/**
+ * The transactional save (§6.1.4) and the cache-bypassing composer it depends on.
+ *
+ * These tests run against an in-memory fake of the query builder, so writes are
+ * visible to the reads that follow them **inside the same transaction** — which
+ * is the whole point: `computeEffectiveStatesUncached` must see post-write state
+ * while `getOrgCache()` deliberately keeps serving the PRE-write projection.
+ */
+
+// ── An introspectable `drizzle-orm`: conditions become plain objects the fake
+//    query builder can evaluate against rows. Everything else stays real.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const col = (x: unknown) =>
+    x && typeof x === 'object' && '__col' in (x as Record<string, unknown>)
+      ? (x as { __col: string }).__col
+      : undefined
+  return {
+    ...actual,
+    eq: (left: unknown, right: unknown) => ({ op: 'eq', left: col(left), right }),
+    and: (...parts: unknown[]) => ({ op: 'and', parts: parts.filter(Boolean) }),
+    or: (...parts: unknown[]) => ({ op: 'or', parts: parts.filter(Boolean) }),
+    inArray: (left: unknown, values: unknown[]) => ({ op: 'inArray', left: col(left), values }),
+    isNull: (left: unknown) => ({ op: 'isNull', left: col(left) }),
+    isNotNull: (left: unknown) => ({ op: 'isNotNull', left: col(left) }),
+  }
+})
+
+// ── `@auxx/database`: a schema proxy whose tables and columns are identifiable.
+vi.mock('@auxx/database', () => {
+  const tables = new Map<string, unknown>()
+  return {
+    database: {},
+    schema: new Proxy(
+      {},
+      {
+        get: (_target, table: string) => {
+          if (!tables.has(table)) {
+            tables.set(
+              table,
+              new Proxy(
+                { __table: table },
+                {
+                  get: (_t, column: string) => (column === '__table' ? table : { __col: column }),
+                }
+              )
+            )
+          }
+          return tables.get(table)
+        },
+      }
+    ),
+  }
+})
+
+const ORG = 'org_1'
+const HR_DEF = 'def_hr_000000000000000000000'
+const CONTACTS_DEF = 'def_contacts_0000000000000000'
+
+const RESOURCES = [
+  { id: HR_DEF, apiSlug: 'hr', entityDefinitionId: HR_DEF },
+  { id: CONTACTS_DEF, apiSlug: 'contacts', entityDefinitionId: CONTACTS_DEF },
+] as unknown as Resource[]
+
+/**
+ * The org cache, deliberately frozen at its PRE-write values for the whole test.
+ * If the composer resolved profiles through this instead of the transaction, the
+ * `after` snapshot would equal `before` and every escalation test below would
+ * pass vacuously.
+ */
+const staleCache: { profiles: unknown[]; memberRoleMap: Record<string, unknown> } = {
+  profiles: [],
+  memberRoleMap: {},
+}
+
+vi.mock('../../cache', () => ({
+  onCacheEvent: vi.fn(async () => {}),
+  getCachedResources: vi.fn(async () => RESOURCES),
+  getOrgCache: () => ({
+    get: vi.fn(async (_orgId: string, key: string) =>
+      key === 'profiles' ? staleCache.profiles : staleCache.memberRoleMap
+    ),
+  }),
+}))
+vi.mock('../../dehydration/cache', () => ({
+  DehydrationCacheService: class {
+    async invalidateUser() {}
+    async invalidateOrganization() {}
+  },
+}))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishCapabilitiesChanged: vi.fn(async () => {}),
+}))
+
+const planGate = { allowed: true }
+vi.mock('../feature-permission-service', () => ({
+  FeaturePermissionService: class {
+    async requireAccess() {
+      if (!planGate.allowed) throw new Error('PLAN_GATE')
+    }
+  },
+}))
+
+import { ForbiddenError } from '../../errors'
+import { Area, Level } from '../capabilities/registry'
+import { computeEffectiveStatesUncached } from './effective-state'
+import { assertNoEscalation } from './escalation-guard'
+import { savePermissionProfile } from './profile-save'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A minimal in-memory query builder: enough of drizzle's surface for the save.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Row = Record<string, unknown>
+/**
+ * The fake's tables. The named tables are declared so fixture code reads them
+ * without a null dance; the index signature is what the query builder walks.
+ */
+interface Store {
+  OrganizationMember: Row[]
+  User: Row[]
+  PermissionProfile: Row[]
+  PermissionGrant: Row[]
+  EntityGroupMember: Row[]
+  EntityInstance: Row[]
+  ResourceAccess: Row[]
+  [table: string]: Row[]
+}
+/**
+ * The untyped condition objects the `drizzle-orm` mock above produces —
+ * recursive and deliberately shapeless, so the fake reads them structurally.
+ */
+type Cond = any
+
+function colOf(x: unknown): string | undefined {
+  return x && typeof x === 'object' && '__col' in (x as Record<string, unknown>)
+    ? (x as { __col: string }).__col
+    : undefined
+}
+
+function matches(row: Row, cond: Cond): boolean {
+  if (!cond) return true
+  switch (cond.op) {
+    case 'and':
+      return cond.parts.every((part: Cond) => matches(row, part))
+    case 'or':
+      return cond.parts.some((part: Cond) => matches(row, part))
+    case 'eq': {
+      const rightCol = colOf(cond.right)
+      return rightCol ? row[cond.left] === row[rightCol] : row[cond.left] === cond.right
+    }
+    case 'inArray':
+      return cond.values.includes(row[cond.left])
+    case 'isNull':
+      return row[cond.left] === null || row[cond.left] === undefined
+    case 'isNotNull':
+      return row[cond.left] !== null && row[cond.left] !== undefined
+    default:
+      return true
+  }
+}
+
+/** Join predicate — accepts either column orientation. */
+function joins(left: Row, right: Row, cond: Cond): boolean {
+  const rightCol = colOf(cond.right)
+  if (!rightCol) return false
+  return left[cond.left] === right[rightCol] || right[cond.left] === left[rightCol]
+}
+
+class FakeSelect {
+  private table = ''
+  private readonly joined: Array<{ table: string; on: Cond }> = []
+  private cond: Cond = null
+  private max: number | undefined
+
+  constructor(
+    private readonly store: Store,
+    private readonly selection?: Record<string, unknown>
+  ) {}
+
+  from(table: { __table: string }) {
+    this.table = table.__table
+    return this
+  }
+  leftJoin(table: { __table: string }, on: Cond) {
+    this.joined.push({ table: table.__table, on })
+    return this
+  }
+  innerJoin(table: { __table: string }, on: Cond) {
+    this.joined.push({ table: table.__table, on })
+    return this
+  }
+  where(cond: Cond) {
+    this.cond = cond
+    return this
+  }
+  limit(n: number) {
+    this.max = n
+    return this
+  }
+  // biome-ignore lint/suspicious/noThenProperty: a thenable IS drizzle's select API
+  then<T>(resolve: (rows: Row[]) => T) {
+    return Promise.resolve(resolve(this.run()))
+  }
+
+  private run(): Row[] {
+    let rows: Row[] = (this.store[this.table] ?? []).map((row) => ({ ...row }))
+    for (const join of this.joined) {
+      const right = this.store[join.table] ?? []
+      rows = rows.flatMap((left) => {
+        const hits = right.filter((candidate) => joins(left, candidate, join.on))
+        return hits.length === 0 ? [left] : hits.map((hit) => ({ ...hit, ...left }))
+      })
+    }
+    rows = rows.filter((row) => matches(row, this.cond))
+    if (this.max !== undefined) rows = rows.slice(0, this.max)
+    if (!this.selection) return rows
+    return rows.map((row) =>
+      Object.fromEntries(
+        Object.entries(this.selection ?? {}).map(([key, ref]) => [key, row[colOf(ref) ?? key]])
+      )
+    )
+  }
+}
+
+function fakeRunner(store: Store) {
+  // Split from `transaction` below so the object literal does not reference its
+  // own inferred type (TS7022) — the txn handle is the same runner minus nesting.
+  const runner = {
+    select: (selection?: Record<string, unknown>) => new FakeSelect(store, selection),
+    insert: (table: { __table: string }) => ({
+      values: (row: Row) => ({
+        onConflictDoUpdate: ({ target, set }: { target: unknown[]; set: Row }) => {
+          const keys = target.map((ref) => colOf(ref) as string)
+          const rows = (store[table.__table] ??= [])
+          const existing = rows.find((candidate) =>
+            keys.every((key) => candidate[key] === row[key])
+          )
+          if (existing) Object.assign(existing, set)
+          else rows.push({ ...row })
+          return Promise.resolve([existing ?? row])
+        },
+        returning: () => {
+          const rows = (store[table.__table] ??= [])
+          rows.push({ ...row })
+          return Promise.resolve([row])
+        },
+      }),
+    }),
+    update: (table: { __table: string }) => ({
+      set: (patch: Row) => ({
+        where: (cond: Cond) => {
+          for (const row of store[table.__table] ?? []) {
+            if (matches(row, cond)) Object.assign(row, patch)
+          }
+          return Promise.resolve([])
+        },
+      }),
+    }),
+    delete: (table: { __table: string }) => ({
+      where: (cond: Cond) => {
+        store[table.__table] = (store[table.__table] ?? []).filter((row) => !matches(row, cond))
+        return Promise.resolve([])
+      },
+    }),
+  }
+
+  return {
+    ...runner,
+    transaction: async <T>(fn: (tx: typeof runner) => Promise<T>): Promise<T> => {
+      const snapshot = structuredClone(store) as Store
+      try {
+        return await fn(runner)
+      } catch (error) {
+        // Rollback: the guard throwing must leave every table as it was.
+        for (const key of Object.keys(store)) store[key] = snapshot[key] ?? []
+        throw error
+      }
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixture
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Fixture {
+  /** The custom profile `u_holder` is bound to. */
+  supportCeiling?: unknown
+  /** Sparse levels stored on the support profile's grant row. */
+  supportLevels?: Record<string, number>
+  /** A ceiling on the ACTOR's own profile (used to narrow the actor). */
+  actorCeiling?: unknown
+  /**
+   * Add `u_null`, a member with a **null** binding — the §6.1.3 majority case.
+   * No row points at the `member` system profile, so the
+   * `(organizationId, permissionProfileId)` index alone would return nobody.
+   */
+  nullBoundHolder?: boolean
+}
+
+function makeStore(fixture: Fixture = {}): Store {
+  const profiles: Row[] = [
+    {
+      id: 'p_member',
+      organizationId: ORG,
+      slug: 'member',
+      name: 'Member',
+      description: null,
+      icon: null,
+      seat: 'full',
+      appliesTo: 'member',
+      baseLevel: null,
+      ceiling: null,
+      agentPolicy: null,
+      isSystem: true,
+      updatedAt: null,
+    },
+    {
+      id: 'p_support',
+      organizationId: ORG,
+      slug: 'support_rep',
+      name: 'Support rep',
+      description: null,
+      icon: null,
+      seat: 'full',
+      appliesTo: 'member',
+      baseLevel: null,
+      ceiling: fixture.supportCeiling ?? null,
+      agentPolicy: null,
+      isSystem: false,
+      updatedAt: null,
+    },
+    {
+      id: 'p_actor',
+      organizationId: ORG,
+      slug: 'ops',
+      name: 'Ops',
+      description: null,
+      icon: null,
+      seat: 'full',
+      appliesTo: 'member',
+      baseLevel: null,
+      ceiling: fixture.actorCeiling ?? null,
+      agentPolicy: null,
+      isSystem: false,
+      updatedAt: null,
+    },
+  ]
+
+  const grants: Row[] = []
+  if (fixture.supportLevels) {
+    grants.push({
+      id: 'pg_support',
+      organizationId: ORG,
+      granteeType: 'profile',
+      granteeId: 'p_support',
+      levels: fixture.supportLevels,
+    })
+  }
+
+  staleCache.profiles = structuredClone(profiles)
+  staleCache.memberRoleMap = {
+    u_holder: {
+      role: 'USER',
+      seatType: 'full',
+      userType: 'USER',
+      permissionProfileId: 'p_support',
+    },
+    u_actor: { role: 'USER', seatType: 'full', userType: 'USER', permissionProfileId: 'p_actor' },
+  }
+
+  if (fixture.nullBoundHolder) {
+    staleCache.memberRoleMap.u_null = {
+      role: 'USER',
+      seatType: 'full',
+      userType: 'USER',
+      permissionProfileId: null,
+    }
+  }
+
+  const store: Store = {
+    OrganizationMember: [
+      {
+        organizationId: ORG,
+        userId: 'u_holder',
+        role: 'USER',
+        seatType: 'full',
+        permissionProfileId: 'p_support',
+      },
+      {
+        organizationId: ORG,
+        userId: 'u_actor',
+        role: 'USER',
+        seatType: 'full',
+        permissionProfileId: 'p_actor',
+      },
+    ],
+    User: [
+      { id: 'u_holder', userType: 'USER' },
+      { id: 'u_actor', userType: 'USER' },
+    ],
+    PermissionProfile: profiles,
+    PermissionGrant: grants,
+    // `u_holder` is in a group that already holds `admin` on the HR definition —
+    // a grant the actor never authored (§6.1 unsoundness mode 1).
+    EntityGroupMember: [
+      { memberRefId: 'u_holder', groupInstanceId: 'g_1', memberType: MemberType.user },
+    ],
+    EntityInstance: [{ id: 'g_1', organizationId: ORG }],
+    ResourceAccess: [
+      {
+        organizationId: ORG,
+        granteeType: 'group',
+        granteeId: 'g_1',
+        entityDefinitionId: HR_DEF,
+        entityInstanceId: null,
+        permission: 'admin',
+      },
+    ],
+  }
+
+  if (fixture.nullBoundHolder) {
+    store.OrganizationMember.push({
+      organizationId: ORG,
+      userId: 'u_null',
+      role: 'USER',
+      seatType: 'full',
+      permissionProfileId: null,
+    })
+    store.User.push({ id: 'u_null', userType: 'USER' })
+  }
+
+  return store
+}
+
+beforeEach(() => {
+  planGate.allowed = true
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computeEffectiveStatesUncached — the §6.1.4 cache bypass', () => {
+  it('composes from the TRANSACTION, not the org cache', async () => {
+    // The store says the profile excludes every definition; the cached `profiles`
+    // projection (which `computeUserCapabilities` would have used) says it is
+    // uncapped. Reading the cache here would report HR access the holder does not
+    // have — and, inside a save, would make `after` identical to `before`.
+    const store = makeStore({ supportCeiling: { defs: { mode: 'only', slugs: [] } } })
+    staleCache.profiles = structuredClone(store.PermissionProfile).map((row) => ({
+      ...row,
+      ceiling: null,
+    }))
+
+    const states = await computeEffectiveStatesUncached({
+      organizationId: ORG,
+      userIds: ['u_holder'],
+      tx: fakeRunner(store) as never,
+    })
+
+    expect(states.get('u_holder')?.defs).toEqual({})
+  })
+
+  it('sees a write made earlier in the same transaction', async () => {
+    const store = makeStore({ supportCeiling: { defs: { mode: 'only', slugs: [] } } })
+    const before = await computeEffectiveStatesUncached({
+      organizationId: ORG,
+      userIds: ['u_holder'],
+      tx: fakeRunner(store) as never,
+    })
+    expect(before.get('u_holder')?.defs).toEqual({})
+
+    const profile = store.PermissionProfile.find((row) => row.id === 'p_support')
+    if (profile) profile.ceiling = null
+
+    const after = await computeEffectiveStatesUncached({
+      organizationId: ORG,
+      userIds: ['u_holder'],
+      tx: fakeRunner(store) as never,
+    })
+    // The pre-existing group grant on HR is now visible — nothing about the
+    // grant changed, only the ceiling above it.
+    expect(after.get('u_holder')?.defs[HR_DEF]).toBe('admin')
+  })
+
+  it('composes the actor and the holders in ONE batch', async () => {
+    const store = makeStore({})
+    const states = await computeEffectiveStatesUncached({
+      organizationId: ORG,
+      userIds: ['u_holder', 'u_actor'],
+      tx: fakeRunner(store) as never,
+    })
+    expect([...states.keys()].sort()).toEqual(['u_actor', 'u_holder'])
+    // Only the holder is in the group that holds HR.
+    expect(states.get('u_holder')?.defs[HR_DEF]).toBe('admin')
+    expect(states.get('u_actor')?.defs[HR_DEF]).toBeUndefined()
+  })
+})
+
+describe('savePermissionProfile — §6.1 escalation guard end to end', () => {
+  it('DENIES raising a ceiling that surfaces a pre-existing group grant', async () => {
+    const store = makeStore({ supportCeiling: { defs: { mode: 'only', slugs: [] } } })
+    await expect(
+      savePermissionProfile({
+        organizationId: ORG,
+        actorUserId: 'u_actor',
+        profileId: 'p_support',
+        ceiling: null,
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toBeInstanceOf(ForbiddenError)
+
+    // …and the transaction rolled back.
+    expect(store.PermissionProfile.find((row) => row.id === 'p_support')?.ceiling).toEqual({
+      defs: { mode: 'only', slugs: [] },
+    })
+  })
+
+  it('DENIES raising an area above the actor’s own level', async () => {
+    const store = makeStore({
+      supportLevels: { [Area.records]: Level.Read },
+      actorCeiling: { areas: { [Area.records]: Level.Read } },
+    })
+    await expect(
+      savePermissionProfile({
+        organizationId: ORG,
+        actorUserId: 'u_actor',
+        profileId: 'p_support',
+        levels: { [Area.records]: Level.Full },
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toBeInstanceOf(ForbiddenError)
+    expect(store.PermissionGrant[0]?.levels).toEqual({ [Area.records]: Level.Read })
+  })
+
+  it('PERMITS a decrease even when the actor’s own access is narrower', async () => {
+    // The actor is capped at `records: Read` yet may still lower the profile from
+    // Full to Read — removal only tightens (§6.1.2 property 1).
+    const store = makeStore({
+      supportLevels: { [Area.records]: Level.Full },
+      actorCeiling: { areas: { [Area.records]: Level.Read } },
+    })
+    await savePermissionProfile({
+      organizationId: ORG,
+      actorUserId: 'u_actor',
+      profileId: 'p_support',
+      levels: { [Area.records]: Level.Read },
+      db: fakeRunner(store) as never,
+    })
+    expect(store.PermissionGrant[0]?.levels).toEqual({ [Area.records]: Level.Read })
+  })
+
+  it('PERMITS a raise the actor holds themselves, and writes metadata in the same txn', async () => {
+    const store = makeStore({ supportLevels: { [Area.records]: Level.Read } })
+    await savePermissionProfile({
+      organizationId: ORG,
+      actorUserId: 'u_actor',
+      profileId: 'p_support',
+      name: 'Support (tier 2)',
+      levels: { [Area.records]: Level.Full },
+      db: fakeRunner(store) as never,
+    })
+    const profile = store.PermissionProfile.find((row) => row.id === 'p_support')
+    expect(profile?.name).toBe('Support (tier 2)')
+    expect(store.PermissionGrant[0]?.levels).toEqual({ [Area.records]: Level.Full })
+  })
+
+  it('reaches NULL-BOUND holders of a system profile (§6.1.3 majority case)', async () => {
+    // `u_null` has no `permissionProfileId`, so the §1.1 index returns NOBODY for
+    // the `member` profile. If the sweep skipped the null-bound branch the
+    // affected set would be empty, the comparison vacuous, and this save would
+    // succeed — which is exactly the hole §6.1.3 calls out.
+    // `members` is grantable but USER-default `None` (`USER_ADMIN_NONE_AREAS`),
+    // so the actor does not hold it either — the raise is a real delta for
+    // `u_null` and above the actor's own level.
+    const store = makeStore({ nullBoundHolder: true })
+    await expect(
+      savePermissionProfile({
+        organizationId: ORG,
+        actorUserId: 'u_actor',
+        profileId: 'p_member',
+        levels: { [Area.members]: Level.Full },
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toBeInstanceOf(ForbiddenError)
+    expect(store.PermissionGrant).toHaveLength(0)
+  })
+
+  it('lets an OWNER make a change no other actor could (§0.10 recovery)', async () => {
+    const store = makeStore({ supportCeiling: { defs: { mode: 'only', slugs: [] } } })
+    const actor = store.OrganizationMember.find((row) => row.userId === 'u_actor')
+    if (actor) actor.role = 'OWNER'
+    await savePermissionProfile({
+      organizationId: ORG,
+      actorUserId: 'u_actor',
+      profileId: 'p_support',
+      ceiling: null,
+      db: fakeRunner(store) as never,
+    })
+    expect(store.PermissionProfile.find((row) => row.id === 'p_support')?.ceiling).toBeNull()
+  })
+})
+
+/**
+ * §6.1.3's fourth row. `deletePermissionProfile` itself is **not built** — it
+ * belongs with step 7's delete dialog — but the guard has to be able to evaluate
+ * a deletion *before* that mutation exists, because deletion can WIDEN: holders
+ * fall back to the §1.3 system template, which may carry no ceiling at all.
+ *
+ * This test performs the deletion's writes inline, in the order §8.4 requires,
+ * and shows the existing guard API measuring the result. A step-7 implementer
+ * writes exactly this, inside `db.transaction`.
+ */
+describe('the guard evaluates a DELETION (§6.1.3) — no delete mutation required', () => {
+  /** The step-7 delete, minus the mutation wrapper. Returns before/after states. */
+  async function simulateDelete(store: Store, holderIds: string[]) {
+    const tx = fakeRunner(store) as never
+    // 1. Holders are captured BEFORE the bindings are nulled, and `before` is
+    //    snapshotted inside the transaction.
+    const before = await computeEffectiveStatesUncached({
+      organizationId: ORG,
+      userIds: [...holderIds, 'u_actor'],
+      tx,
+    })
+    // 2. `permissionProfileId` → null (§0.24), then the profile row and — because
+    //    `granteeId` has no FK — its own grant + ResourceAccess rows (§8.4).
+    for (const row of store.OrganizationMember) {
+      if (row.permissionProfileId === 'p_support') row.permissionProfileId = null
+    }
+    store.PermissionProfile = store.PermissionProfile.filter((row) => row.id !== 'p_support')
+    store.PermissionGrant = store.PermissionGrant.filter((row) => row.granteeId !== 'p_support')
+    store.ResourceAccess = store.ResourceAccess.filter((row) => row.granteeId !== 'p_support')
+    // 3. Re-read post-write: holders now compose through the `member` template.
+    const after = await computeEffectiveStatesUncached({
+      organizationId: ORG,
+      userIds: holderIds,
+      tx,
+    })
+    return { before, after }
+  }
+
+  it('DENIES a deletion whose system-template fallback widens past the actor', async () => {
+    const store = makeStore({ supportCeiling: { defs: { mode: 'only', slugs: [] } } })
+    const { before, after } = await simulateDelete(store, ['u_holder'])
+
+    // The ceiling that hid HR went with the profile; the group grant underneath
+    // it is now visible. Nothing about that grant changed.
+    expect(before.get('u_holder')?.defs[HR_DEF]).toBeUndefined()
+    expect(after.get('u_holder')?.defs[HR_DEF]).toBe('admin')
+
+    const actorState = before.get('u_actor')
+    if (!actorState) throw new Error('actor state missing')
+    expect(() =>
+      assertNoEscalation({
+        actor: { userId: 'u_actor', role: 'USER', state: actorState },
+        before,
+        after,
+      })
+    ).toThrow(ForbiddenError)
+  })
+
+  it('PERMITS the same deletion for an actor who holds that def access', async () => {
+    const store = makeStore({ supportCeiling: { defs: { mode: 'only', slugs: [] } } })
+    store.ResourceAccess.push({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_actor',
+      entityDefinitionId: HR_DEF,
+      entityInstanceId: null,
+      permission: 'admin',
+    })
+    const { before, after } = await simulateDelete(store, ['u_holder'])
+
+    const actorState = before.get('u_actor')
+    if (!actorState) throw new Error('actor state missing')
+    expect(actorState.defs[HR_DEF]).toBe('admin')
+    expect(() =>
+      assertNoEscalation({
+        actor: { userId: 'u_actor', role: 'USER', state: actorState },
+        before,
+        after,
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('savePermissionProfile — the other §6.1.5 gates', () => {
+  it('refuses a cross-org profile id', async () => {
+    const store = makeStore({})
+    await expect(
+      savePermissionProfile({
+        organizationId: 'org_other',
+        actorUserId: 'u_actor',
+        profileId: 'p_support',
+        name: 'x',
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toThrow(/not found/i)
+  })
+
+  it('refuses to edit the owner profile', async () => {
+    const store = makeStore({})
+    store.PermissionProfile.push({
+      id: 'p_owner',
+      organizationId: ORG,
+      slug: 'owner',
+      name: 'Owner',
+      description: null,
+      icon: null,
+      seat: 'full',
+      appliesTo: 'member',
+      baseLevel: 3,
+      ceiling: null,
+      agentPolicy: null,
+      isSystem: true,
+      updatedAt: null,
+    })
+    await expect(
+      savePermissionProfile({
+        organizationId: ORG,
+        actorUserId: 'u_actor',
+        profileId: 'p_owner',
+        name: 'nope',
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+
+  it('keeps agent-profile editing OWNER/ADMIN-only (§0.25 / doc 14 §0.9)', async () => {
+    const store = makeStore({})
+    const profile = store.PermissionProfile.find((row) => row.id === 'p_support')
+    if (profile) profile.appliesTo = 'agent'
+    await expect(
+      savePermissionProfile({
+        organizationId: ORG,
+        actorUserId: 'u_actor',
+        profileId: 'p_support',
+        name: 'agent policy',
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toThrow(/owners and admins/i)
+
+    const actor = store.OrganizationMember.find((row) => row.userId === 'u_actor')
+    if (actor) actor.role = 'ADMIN'
+    await savePermissionProfile({
+      organizationId: ORG,
+      actorUserId: 'u_actor',
+      profileId: 'p_support',
+      name: 'agent policy',
+      db: fakeRunner(store) as never,
+    })
+    expect(store.PermissionProfile.find((row) => row.id === 'p_support')?.name).toBe('agent policy')
+  })
+
+  it('plan-gates the WRITE (§0.26)', async () => {
+    planGate.allowed = false
+    const store = makeStore({})
+    await expect(
+      savePermissionProfile({
+        organizationId: ORG,
+        actorUserId: 'u_actor',
+        profileId: 'p_support',
+        name: 'x',
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toThrow('PLAN_GATE')
+  })
+
+  it('refuses profile-scoped resource grants until step 9', async () => {
+    const store = makeStore({})
+    await expect(
+      savePermissionProfile({
+        organizationId: ORG,
+        actorUserId: 'u_actor',
+        profileId: 'p_support',
+        defAccess: [{ entityDefinitionId: HR_DEF, permission: 'view' }],
+        db: fakeRunner(store) as never,
+      })
+    ).rejects.toThrow(/step 9/)
+  })
+})

--- a/packages/lib/src/permissions/profiles/profile-save.ts
+++ b/packages/lib/src/permissions/profiles/profile-save.ts
@@ -1,0 +1,387 @@
+// packages/lib/src/permissions/profiles/profile-save.ts
+
+import { type Database, database, type PermissionProfileEntity, schema } from '@auxx/database'
+import type { OrganizationRole } from '@auxx/database/types'
+import { generateId } from '@auxx/utils'
+import { and, eq } from 'drizzle-orm'
+import { getCachedResources } from '../../cache'
+import { BadRequestError, ForbiddenError, NotFoundError } from '../../errors'
+import { assertGrantableLevels } from '../capabilities/grant-service'
+import { type Area, type Level, parseAreaLevels } from '../capabilities/registry'
+import { buildDefIdToDefinitionId } from '../capabilities/resolve-capability-inputs'
+import { FeaturePermissionService } from '../feature-permission-service'
+import { FeatureKey } from '../types'
+import { computeEffectiveStatesUncached, type QueryRunner } from './effective-state'
+import {
+  type ActorAuthority,
+  assertNoEscalation,
+  assertProfileMapNoEscalation,
+  HOLDER_GUARD_CAP,
+} from './escalation-guard'
+import {
+  emitPermissionProfileChanged,
+  fanOutCapabilityChange,
+  resolveProfileAudience,
+  resolveProfileHolderIds,
+} from './profile-invalidation'
+import { parseProfileCeiling } from './profile-projection'
+import type { AgentPermissionPolicy, ProfileCeiling } from './types'
+
+/**
+ * The ONE transactional profile save (§6.1.4). The editor submits metadata,
+ * area levels, the ceiling and (once step 9 lands) the per-def / per-instance
+ * rows as a **single** mutation — the multi-request variant is deliberately not
+ * offered, because a save spanning three requests cannot enforce one atomic
+ * "resulting effective state" check.
+ */
+export interface SavePermissionProfileInput {
+  organizationId: string
+  /** Who is saving — their own effective state is the authority ceiling (§6.1.1). */
+  actorUserId: string
+  profileId: string
+  name?: string
+  description?: string | null
+  icon?: { iconId: string; color: string } | null
+  /** The profile's blanket rung for areas `levels` does not set. */
+  baseLevel?: Level | null
+  /** The profile's own intrinsic cap (§0.14). */
+  ceiling?: ProfileCeiling | null
+  /** Agent-profile exact policy. OWNER/ADMIN only (§0.25 / doc 14 §0.9). */
+  agentPolicy?: AgentPermissionPolicy | null
+  /**
+   * The profile's per-area BASE, stored as its one `PermissionGrant` row.
+   * `null` clears the row (every area falls through to `baseLevel` /
+   * `ROLE_DEFAULTS`); omitted leaves it untouched.
+   */
+  levels?: Partial<Record<Area, Level>> | null
+  /**
+   * Per-def `ResourceAccess` rows on the profile grantee (§1.2). Accepted so the
+   * mutation's shape is the §6.1.4 one, but any non-empty value is refused until
+   * step 9 teaches the remaining resolvers the `profile` grantee — see
+   * `resource-access-service.ts`'s `assertProfileGranteeSupported`.
+   */
+  defAccess?: unknown[]
+  /** Per-instance `ResourceAccess` rows on the profile grantee — see {@link defAccess}. */
+  instanceAccess?: unknown[]
+  db?: Database
+}
+
+/** The profile row fields the save reads before writing. */
+interface ProfileRow {
+  id: string
+  slug: string
+  isSystem: boolean
+  appliesTo: string
+  baseLevel: number | null
+  ceiling: unknown
+}
+
+/**
+ * Save a permission profile inside ONE transaction, with the §6.1 escalation
+ * guard evaluated on **post-write** state.
+ *
+ * Order is exactly §6.1.4's:
+ *
+ * ```
+ * db.transaction(async (tx) => {
+ *   const before = snapshotEffectiveStates(holders, tx)  // pre-write, inside the txn
+ *   applyMetadata(tx); upsertPermissionGrant(tx)
+ *   const after  = snapshotEffectiveStates(holders, tx)  // re-read post-write
+ *   assertNoEscalation(actor, before, after)             // ForbiddenError → rollback
+ * })
+ * // AFTER commit only: permission-profile.changed + invalidation (§8.3)
+ * ```
+ *
+ * The snapshots come from {@link computeEffectiveStatesUncached}, which reads
+ * every mutable input from `tx`. Composing `after` through `getOrgCache()` would
+ * return pre-write values and the guard would silently always pass.
+ *
+ * Gates that run in addition to the guard (§6.1.5 — each is its own line of
+ * defense, none replaces another): the `granularPermissions` plan gate on every
+ * write (§0.26 — seeding is exempt because `ensureSystemProfiles` never comes
+ * through here), cross-org ownership, the `owner`-profile immutability, the
+ * OWNER/ADMIN-only rule for agent profiles, and `assertGrantableLevels`.
+ */
+export async function savePermissionProfile(
+  input: SavePermissionProfileInput
+): Promise<PermissionProfileEntity> {
+  const { organizationId, actorUserId, profileId } = input
+  const db = input.db ?? database
+
+  if ((input.defAccess?.length ?? 0) > 0 || (input.instanceAccess?.length ?? 0) > 0) {
+    throw new BadRequestError(
+      'Profile-scoped resource grants are not enabled yet — see plans/permissions/v2/19-permission-profiles.md step 9.'
+    )
+  }
+
+  const saved = await db.transaction(async (tx) => {
+    const profile = await loadProfile(tx, organizationId, profileId)
+    const actorRole = await loadActorRole(tx, organizationId, actorUserId)
+
+    if (profile.slug === 'owner') {
+      throw new ForbiddenError(
+        'The Owner profile is not editable and can never carry a ceiling — it is the recovery guarantee.'
+      )
+    }
+    // §0.25: making the `permissions` area grantable must NOT hand agent policy
+    // to a non-admin. Agent-side profile editing stays OWNER/ADMIN-only.
+    if (
+      (profile.appliesTo === 'agent' || input.agentPolicy !== undefined) &&
+      actorRole !== 'OWNER' &&
+      actorRole !== 'ADMIN'
+    ) {
+      throw new ForbiddenError(
+        'Only owners and admins can edit an agent permission profile (doc 14 §0.9).'
+      )
+    }
+
+    // §0.26 — writes are plan-gated; composition never is.
+    await new FeaturePermissionService(tx).requireAccess(
+      organizationId,
+      FeatureKey.granularPermissions
+    )
+
+    // §6.1.3 — one sweep, shared with §8.3 invalidation, including the null-bound
+    // majority. Bindings are not touched by this mutation, so the cached role map
+    // it reads is not part of the before/after comparison.
+    //
+    // §6.1.3's table also lists `OrganizationInvitation` rows bound to the
+    // profile. They are deliberately absent: an invitee has no `User`, so there is
+    // no effective state to compose either side of. The authority check for them
+    // runs at acceptance, where a member row (and a composable state) exists.
+    const holderIds = await resolveProfileHolderIds({
+      organizationId,
+      profileId,
+      slug: profile.slug,
+      isSystem: profile.isSystem,
+    })
+    const exact = holderIds !== null && holderIds.length <= HOLDER_GUARD_CAP
+
+    // The actor's authority is their PRE-write state: a save must never be able
+    // to authorize itself by first raising the actor's own access (§6.1.1).
+    const beforeIds = exact ? [...(holderIds ?? []), actorUserId] : [actorUserId]
+    const before = await computeEffectiveStatesUncached({
+      organizationId,
+      userIds: beforeIds,
+      tx,
+    })
+    const actorState = before.get(actorUserId)
+    if (!actorState) throw new ForbiddenError('You are not a member of this organization.')
+    const actor: ActorAuthority = { userId: actorUserId, role: actorRole, state: actorState }
+
+    // The strict fallback compares the profile's own maps, so its "before" has
+    // to be read here — before the writes land, exactly like the state snapshot.
+    const beforeLevels = exact ? {} : await readProfileLevels(tx, organizationId, profileId)
+
+    const wroteLevels = await applyWrites(tx, organizationId, profile, input)
+
+    if (exact) {
+      const after = await computeEffectiveStatesUncached({
+        organizationId,
+        userIds: holderIds ?? [],
+        tx,
+      })
+      assertNoEscalation({ actor, before, after })
+    } else {
+      // >500 holders (or an unclassifiable profile): composing every holder's
+      // state stops being affordable, so fall back to the strict profile-map
+      // check (§6.1.3), which is deliberately more conservative (§11.6).
+      const resources = await getCachedResources(organizationId)
+      const afterLevels =
+        input.levels === undefined
+          ? beforeLevels
+          : input.levels === null
+            ? {}
+            : parseAreaLevels(input.levels)
+      assertProfileMapNoEscalation({
+        actor,
+        before: {
+          levels: beforeLevels,
+          baseLevel: (profile.baseLevel as Level | null) ?? null,
+          ceiling: parseProfileCeiling(profile.ceiling),
+        },
+        after: {
+          levels: afterLevels,
+          baseLevel: (input.baseLevel ?? profile.baseLevel ?? null) as Level | null,
+          ceiling:
+            input.ceiling !== undefined ? input.ceiling : parseProfileCeiling(profile.ceiling),
+        },
+        defIds: resources.map((r) => r.entityDefinitionId),
+        toDefinitionId: buildDefIdToDefinitionId(resources),
+      })
+    }
+
+    const [row] = await tx
+      .select()
+      .from(schema.PermissionProfile)
+      .where(eq(schema.PermissionProfile.id, profileId))
+      .limit(1)
+
+    return { row: row as PermissionProfileEntity, profile, wroteLevels }
+  })
+
+  // AFTER commit only (§8.3). Two events because they bust different org keys:
+  // `permission-profile.changed` → the `profiles` projection, and
+  // `permission-grant.changed` → `hasPermissionGrants`, the flag that decides
+  // whether the composer reads grant rows at all.
+  const audience = await resolveProfileAudience({
+    organizationId,
+    profileId,
+    slug: saved.profile.slug,
+    isSystem: saved.profile.isSystem,
+  })
+  await emitPermissionProfileChanged({
+    organizationId,
+    profileId,
+    slug: saved.profile.slug,
+    isSystem: saved.profile.isSystem,
+    audience,
+  })
+  if (saved.wroteLevels) {
+    await fanOutCapabilityChange('permission-grant.changed', organizationId, audience)
+  }
+
+  return saved.row
+}
+
+/** Load the target profile, refusing a cross-org id outright (§1.1). */
+async function loadProfile(
+  tx: QueryRunner,
+  organizationId: string,
+  profileId: string
+): Promise<ProfileRow> {
+  const [row] = await tx
+    .select({
+      id: schema.PermissionProfile.id,
+      slug: schema.PermissionProfile.slug,
+      isSystem: schema.PermissionProfile.isSystem,
+      appliesTo: schema.PermissionProfile.appliesTo,
+      baseLevel: schema.PermissionProfile.baseLevel,
+      ceiling: schema.PermissionProfile.ceiling,
+    })
+    .from(schema.PermissionProfile)
+    .where(
+      and(
+        eq(schema.PermissionProfile.id, profileId),
+        eq(schema.PermissionProfile.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+
+  if (!row) throw new NotFoundError('Permission profile not found in this organization.')
+  return row as ProfileRow
+}
+
+/** The actor's org role — the §6.1.1 OWNER short-circuit and the agent gate. */
+async function loadActorRole(
+  tx: QueryRunner,
+  organizationId: string,
+  actorUserId: string
+): Promise<OrganizationRole> {
+  const [row] = await tx
+    .select({ role: schema.OrganizationMember.role })
+    .from(schema.OrganizationMember)
+    .where(
+      and(
+        eq(schema.OrganizationMember.organizationId, organizationId),
+        eq(schema.OrganizationMember.userId, actorUserId)
+      )
+    )
+    .limit(1)
+
+  if (!row) throw new ForbiddenError('You are not a member of this organization.')
+  return row.role
+}
+
+/** Read the profile's currently stored area levels (for the strict fallback). */
+async function readProfileLevels(
+  tx: QueryRunner,
+  organizationId: string,
+  profileId: string
+): Promise<Partial<Record<Area, Level>>> {
+  const [row] = await tx
+    .select({ levels: schema.PermissionGrant.levels })
+    .from(schema.PermissionGrant)
+    .where(
+      and(
+        eq(schema.PermissionGrant.organizationId, organizationId),
+        eq(schema.PermissionGrant.granteeType, 'profile'),
+        eq(schema.PermissionGrant.granteeId, profileId)
+      )
+    )
+    .limit(1)
+
+  return row ? parseAreaLevels(row.levels) : {}
+}
+
+/**
+ * Apply every write of the save inside the transaction. Returns whether the
+ * profile's `PermissionGrant` row was touched (which decides whether the
+ * post-commit fan-out also needs the grant event).
+ */
+async function applyWrites(
+  tx: QueryRunner,
+  organizationId: string,
+  profile: ProfileRow,
+  input: SavePermissionProfileInput
+): Promise<boolean> {
+  const patch: Record<string, unknown> = {}
+  if (input.name !== undefined) patch.name = input.name
+  if (input.description !== undefined) patch.description = input.description
+  if (input.icon !== undefined) patch.icon = input.icon
+  if (input.baseLevel !== undefined) patch.baseLevel = input.baseLevel
+  if (input.ceiling !== undefined) patch.ceiling = input.ceiling
+  if (input.agentPolicy !== undefined) patch.agentPolicy = input.agentPolicy
+
+  if (Object.keys(patch).length > 0) {
+    await tx
+      .update(schema.PermissionProfile)
+      .set({ ...patch, updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.PermissionProfile.id, profile.id),
+          eq(schema.PermissionProfile.organizationId, organizationId)
+        )
+      )
+  }
+
+  if (input.levels === undefined) return false
+
+  if (input.levels === null || Object.keys(input.levels).length === 0) {
+    await tx
+      .delete(schema.PermissionGrant)
+      .where(
+        and(
+          eq(schema.PermissionGrant.organizationId, organizationId),
+          eq(schema.PermissionGrant.granteeType, 'profile'),
+          eq(schema.PermissionGrant.granteeId, profile.id)
+        )
+      )
+    return true
+  }
+
+  // `Level.None` is KEPT for a profile grantee — it is the composition base, so a
+  // stored None genuinely zeroes the area (stripping it would fail OPEN).
+  const levels = parseAreaLevels(input.levels)
+  assertGrantableLevels(levels)
+
+  await tx
+    .insert(schema.PermissionGrant)
+    .values({
+      id: generateId(),
+      organizationId,
+      granteeType: 'profile',
+      granteeId: profile.id,
+      levels,
+      grantedById: input.actorUserId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        schema.PermissionGrant.organizationId,
+        schema.PermissionGrant.granteeType,
+        schema.PermissionGrant.granteeId,
+      ],
+      set: { levels, grantedById: input.actorUserId, updatedAt: new Date() },
+    })
+  return true
+}

--- a/packages/lib/src/permissions/profiles/types.ts
+++ b/packages/lib/src/permissions/profiles/types.ts
@@ -38,10 +38,9 @@ export type ProfileAppliesTo = 'member' | 'agent' | 'any'
  * Human-profile definition ceiling (§0.13). `only` = the allowed set is exactly
  * `slugs`, so a definition added later is EXCLUDED (fails closed); `except` =
  * everything but `slugs`, so a later definition is INCLUDED (fails open).
- * apiSlugs, not CUIDs — resolved server-side.
- *
- * Stored and plumbed as of step 2; **enforcement is step 4** and deliberately
- * dormant until then.
+ * apiSlugs, not CUIDs — resolved to `entityDefinitionId`s in `getCapabilities`
+ * and enforced by `effectiveRecordLevel` (plus the worker `recordsViewLinked`
+ * carve-out and `administersAnyDef`), never client-side only.
  */
 export interface ProfileDefCeiling {
   mode: 'only' | 'except'
@@ -56,7 +55,10 @@ export interface ProfileDefCeiling {
 export interface ProfileCeiling {
   /** Per-area max rung. An absent area is uncapped (`Level.Full`). */
   areas?: Partial<Record<Area, Level>>
-  /** Per-definition cap. Stored but NOT enforced until step 4. */
+  /**
+   * Per-definition cap. Applied per-def at the record resolvers rather than
+   * here, since it needs the org's apiSlug → `entityDefinitionId` map.
+   */
   defs?: ProfileDefCeiling | null
 }
 

--- a/packages/lib/src/permissions/visibility/compute-user-mail-visibility.ts
+++ b/packages/lib/src/permissions/visibility/compute-user-mail-visibility.ts
@@ -3,7 +3,11 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import type { OrganizationRole } from '@auxx/database/types'
-import { and, eq, inArray, isNotNull, or } from 'drizzle-orm'
+import { and, eq, isNotNull, or } from 'drizzle-orm'
+import {
+  resolveResourceAccessGrantees,
+  resourceAccessGranteeConditions,
+} from '../../resource-access/grantee-resolution'
 import type { UserMailVisibility } from './context'
 import { type Lens, maxLens } from './lens'
 
@@ -110,29 +114,22 @@ export async function computeUserMailVisibility(
   db: Database
 ): Promise<UserMailVisibility> {
   // Lazy import to avoid a hard module cycle (cache providers import this file).
-  const { getOrgCache, getCachedUserGroupIds } = await import('../../cache')
+  const { getOrgCache } = await import('../../cache')
 
-  const [roleMap, inboxes, groupIds] = await Promise.all([
+  const [roleMap, inboxes, grantees] = await Promise.all([
     getOrgCache().get(organizationId, 'memberRoleMap'),
     getOrgCache().get(organizationId, 'inboxes'),
-    getCachedUserGroupIds(organizationId, userId),
+    resolveResourceAccessGrantees(organizationId, userId),
   ])
 
-  const granteeConditions = [
-    and(eq(schema.ResourceAccess.granteeType, 'user'), eq(schema.ResourceAccess.granteeId, userId)),
-    and(
-      eq(schema.ResourceAccess.granteeType, 'role'),
-      eq(schema.ResourceAccess.granteeId, 'org_member')
-    ),
-  ]
-  if (groupIds.length > 0) {
-    granteeConditions.push(
-      and(
-        inArray(schema.ResourceAccess.granteeType, ['group', 'team']),
-        inArray(schema.ResourceAccess.granteeId, groupIds)
-      )
-    )
-  }
+  // Shared grantee union (doc 19 §8.2) — direct user, `role:org_member`, the
+  // bound permission profile, and groups. `treatTeamAsGroup` preserves this
+  // evaluator's historical matching of legacy `team` rows against group ids.
+  //
+  // Mail visibility is evaluated through BOTH this forward resolver and the
+  // reverse `mailGrantIndex`; the two must enumerate the same grantee kinds or
+  // a share is visible in one direction only (19a finding 4).
+  const granteeConditions = resourceAccessGranteeConditions(grantees, { treatTeamAsGroup: true })
 
   const rows = await db
     .select({

--- a/packages/lib/src/resource-access/grantee-resolution.test.ts
+++ b/packages/lib/src/resource-access/grantee-resolution.test.ts
@@ -1,0 +1,194 @@
+// packages/lib/src/resource-access/grantee-resolution.test.ts
+
+import type { OrganizationRole, SeatType, UserType } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import type { MemberRoleEntry } from '../cache/org-cache-keys'
+import type { CachedPermissionProfile } from '../permissions/profiles/types'
+import {
+  type GranteeMatcher,
+  grantedViaFor,
+  granteeMatchers,
+  resolveProfileIdByUser,
+} from './grantee-resolution'
+
+const ORG = 'org_1'
+
+function profile(over: Partial<CachedPermissionProfile> = {}): CachedPermissionProfile {
+  return {
+    id: 'prof_member',
+    slug: 'member',
+    name: 'Member',
+    description: null,
+    icon: null,
+    seat: 'full' as SeatType,
+    appliesTo: 'member',
+    baseLevel: null,
+    ceiling: null,
+    agentPolicy: null,
+    isSystem: true,
+    updatedAt: null,
+    ...over,
+  }
+}
+
+function member(over: Partial<MemberRoleEntry> = {}): MemberRoleEntry {
+  return {
+    role: 'USER' as OrganizationRole,
+    seatType: 'full' as SeatType,
+    userType: 'USER' as UserType,
+    permissionProfileId: null,
+    ...over,
+  }
+}
+
+/**
+ * In-memory mirror of the `or(...granteeConditions)` SQL the resolvers build.
+ * The Drizzle predicates themselves cannot be asserted under the default Vitest
+ * config (`schema` is a Proxy with `undefined` columns), so the union is tested
+ * as data and this evaluator stands in for the WHERE clause.
+ */
+function rowsVisibleTo(
+  rows: Array<{ granteeType: string; granteeId: string; permission: string }>,
+  matchers: GranteeMatcher[]
+) {
+  return rows.filter((row) =>
+    matchers.some(
+      (m) =>
+        m.granteeTypes.includes(row.granteeType as never) && m.granteeIds.includes(row.granteeId)
+    )
+  )
+}
+
+describe('granteeMatchers', () => {
+  it('always enumerates the direct user grant and the role:org_member baseline', () => {
+    expect(granteeMatchers({ userId: 'u_1', groupIds: [], profileId: null })).toEqual([
+      { granteeTypes: ['user'], granteeIds: ['u_1'] },
+      { granteeTypes: ['role'], granteeIds: ['org_member'] },
+    ])
+  })
+
+  it('adds the bound permission profile (19a #7/#8/#9/#10)', () => {
+    const matchers = granteeMatchers({ userId: 'u_1', groupIds: [], profileId: 'prof_member' })
+    expect(matchers).toContainEqual({ granteeTypes: ['profile'], granteeIds: ['prof_member'] })
+  })
+
+  it('omits the profile matcher entirely when nothing resolved', () => {
+    const matchers = granteeMatchers({ userId: 'u_1', groupIds: ['g_1'], profileId: null })
+    expect(matchers.some((m) => m.granteeTypes.includes('profile'))).toBe(false)
+  })
+
+  it('matches legacy team rows against group ids only when asked', () => {
+    const grantees = { userId: 'u_1', groupIds: ['g_1'], profileId: null }
+    expect(granteeMatchers(grantees)).toContainEqual({
+      granteeTypes: ['group'],
+      granteeIds: ['g_1'],
+    })
+    expect(granteeMatchers(grantees, { treatTeamAsGroup: true })).toContainEqual({
+      granteeTypes: ['group', 'team'],
+      granteeIds: ['g_1'],
+    })
+  })
+})
+
+describe('the finding-1 lockout', () => {
+  // `restrictedEntityDefIds` is grantee-agnostic: ANY type-level row marks the
+  // def restricted for the whole org. So a grantee kind a reader cannot resolve
+  // does not fail closed for that grantee — it hides the def from everyone.
+  const defRows = [
+    { granteeType: 'role', granteeId: 'org_member', permission: 'view' },
+    { granteeType: 'profile', granteeId: 'prof_field', permission: 'admin' },
+  ]
+
+  it('leaves an unrelated non-admin member on the workspace baseline', () => {
+    const visible = rowsVisibleTo(
+      defRows,
+      granteeMatchers({ userId: 'u_other', groupIds: [], profileId: 'prof_member' })
+    )
+    expect(visible).toEqual([{ granteeType: 'role', granteeId: 'org_member', permission: 'view' }])
+  })
+
+  it('gives the granted profile’s holders the profile row', () => {
+    const visible = rowsVisibleTo(
+      defRows,
+      granteeMatchers({ userId: 'u_tech', groupIds: [], profileId: 'prof_field' })
+    )
+    expect(visible.map((r) => r.permission).sort()).toEqual(['admin', 'view'])
+  })
+
+  it('reproduces the pre-step-9 lockout when the profile matcher is dropped', () => {
+    // Same rows, but with the grantee union as it was BEFORE step 9 (no profile
+    // matcher) AND no baseline row — the def is restricted org-wide and nobody
+    // can resolve a grant through it.
+    const restrictedOnly = [{ granteeType: 'profile', granteeId: 'prof_field', permission: 'view' }]
+    const preStep9 = granteeMatchers({ userId: 'u_tech', groupIds: [], profileId: null })
+    expect(rowsVisibleTo(restrictedOnly, preStep9)).toEqual([])
+
+    const postStep9 = granteeMatchers({ userId: 'u_tech', groupIds: [], profileId: 'prof_field' })
+    expect(rowsVisibleTo(restrictedOnly, postStep9)).toEqual(restrictedOnly)
+  })
+})
+
+describe('resolveProfileIdByUser', () => {
+  const profiles = [
+    profile({ id: 'prof_member', slug: 'member' }),
+    profile({ id: 'prof_field', slug: 'field_tech', seat: 'worker' as SeatType }),
+    profile({ id: 'prof_admin', slug: 'admin' }),
+    profile({ id: 'prof_custom', slug: 'support-lead', isSystem: false }),
+  ]
+
+  it('resolves an explicit binding', () => {
+    const byUser = resolveProfileIdByUser({
+      organizationId: ORG,
+      roleMap: { u_1: member({ permissionProfileId: 'prof_custom' }) },
+      profiles,
+    })
+    expect(byUser).toEqual({ u_1: 'prof_custom' })
+  })
+
+  it('resolves NULL-bound members through the system template — the majority case', () => {
+    const byUser = resolveProfileIdByUser({
+      organizationId: ORG,
+      roleMap: {
+        u_full: member(),
+        u_field: member({ seatType: 'worker' as SeatType }),
+        u_admin: member({ role: 'ADMIN' as OrganizationRole }),
+      },
+      profiles,
+    })
+    expect(byUser).toEqual({
+      u_full: 'prof_member',
+      u_field: 'prof_field',
+      u_admin: 'prof_admin',
+    })
+  })
+
+  it('falls back to the system template when the binding dangles', () => {
+    const byUser = resolveProfileIdByUser({
+      organizationId: ORG,
+      roleMap: { u_1: member({ permissionProfileId: 'prof_from_another_org' }) },
+      profiles,
+    })
+    expect(byUser).toEqual({ u_1: 'prof_member' })
+  })
+
+  it('omits users when the org has no seeded profiles at all', () => {
+    const byUser = resolveProfileIdByUser({
+      organizationId: ORG,
+      roleMap: { u_1: member() },
+      profiles: [],
+    })
+    expect(byUser).toEqual({})
+  })
+})
+
+describe('grantedViaFor', () => {
+  it('attributes each grantee kind distinctly', () => {
+    expect(grantedViaFor('user')).toBe('direct')
+    expect(grantedViaFor('group')).toBe('group')
+    expect(grantedViaFor('team')).toBe('team')
+    expect(grantedViaFor('role')).toBe('role')
+    // 19a #27 — this used to fall through to 'direct', reading as "you were
+    // named personally" for a grant nobody named you in.
+    expect(grantedViaFor('profile')).toBe('profile')
+  })
+})

--- a/packages/lib/src/resource-access/grantee-resolution.ts
+++ b/packages/lib/src/resource-access/grantee-resolution.ts
@@ -1,0 +1,228 @@
+// packages/lib/src/resource-access/grantee-resolution.ts
+
+import { schema } from '@auxx/database'
+import { ResourceGranteeType } from '@auxx/database/enums'
+import { and, eq, inArray, type SQL } from 'drizzle-orm'
+import type { MemberRoleEntry } from '../cache/org-cache-keys'
+import { resolveBaseProfile } from '../permissions/profiles/profile-resolution'
+import type { CachedPermissionProfile } from '../permissions/profiles/types'
+
+/**
+ * The ONE place the server resolves **which `ResourceAccess` grantee rows apply
+ * to a member** (doc 19 §8.2 / 19a findings 1 + 3 + 4).
+ *
+ * Before this module the grantee union was copy-pasted into four resolvers
+ * (`checkAccess`, `checkTypeAccess`, `getUserAccessibleInstances`,
+ * `computeUserMailVisibility`) plus a ternary in the reverse mail index — and
+ * three of them had drifted. That mattered far more than duplication normally
+ * does: `restrictedEntityDefIds` / `restrictedInstanceIds` build the restricted
+ * set **grantee-agnostically**, so a grantee kind a reader cannot resolve does
+ * not fail "closed for that grantee" — it flips the definition to restricted for
+ * the whole org while granting nobody, i.e. an org-wide lockout.
+ *
+ * `role:org_member` STAYS in the union (doc 19 §11a deviation 2). On
+ * `ResourceAccess` it is the def/workspace-baseline marker, a different
+ * mechanism from the `PermissionGrant` policy tier that plan 19 deleted.
+ */
+
+/** The `ResourceAccess.granteeId` of the org-wide workspace baseline row. */
+export const ORG_MEMBER_GRANTEE_ID = 'org_member'
+
+/** Every grantee identity one member matches `ResourceAccess` rows on. */
+export interface ResourceAccessGrantees {
+  userId: string
+  /** Entity-group instance ids the user belongs to. */
+  groupIds: string[]
+  /**
+   * The member's ONE resolved base permission profile (§1.3) — an explicit
+   * binding, else the system template for `(role, seatType)`. `null` when the
+   * user is not a member of the org or nothing resolved (unseeded org).
+   */
+  profileId: string | null
+}
+
+/**
+ * Resolve one member's grantee identities from the org cache — zero DB queries
+ * (`groupMembers`, `memberRoleMap` and `profiles` are all cached org keys).
+ *
+ * The profile half deliberately mirrors `computeUserCapabilities`: it goes
+ * through {@link resolveBaseProfile}, so a profile-grantee row is seen by the
+ * exact same profile the capability composer would have used. Anything else
+ * would let the two disagree about who a profile grant reaches.
+ */
+export async function resolveResourceAccessGrantees(
+  organizationId: string,
+  userId: string
+): Promise<ResourceAccessGrantees> {
+  // Lazy import — cache providers import this module's consumers, so a static
+  // import of the cache barrel would close a module cycle.
+  const { getCachedUserGroupIds } = await import('../cache')
+  const [groupIds, profileId] = await Promise.all([
+    getCachedUserGroupIds(organizationId, userId),
+    resolveUserProfileId(organizationId, userId),
+  ])
+  return { userId, groupIds, profileId }
+}
+
+/**
+ * The member's resolved base permission profile id, or `null` when they are not
+ * a member / the org has no seeded profiles. Cache-only.
+ */
+export async function resolveUserProfileId(
+  organizationId: string,
+  userId: string
+): Promise<string | null> {
+  const { getOrgCache } = await import('../cache')
+  const [roleMap, profiles] = await Promise.all([
+    getOrgCache().get(organizationId, 'memberRoleMap'),
+    getOrgCache().get(organizationId, 'profiles'),
+  ])
+  const entry = roleMap[userId]
+  if (!entry) return null
+  return resolveBaseProfile({
+    organizationId,
+    userId,
+    role: entry.role,
+    seatType: entry.seatType,
+    permissionProfileId: entry.permissionProfileId,
+    profiles,
+  }).profileId
+}
+
+/**
+ * Invert the org's `memberRoleMap` into `userId → resolved profile id`, skipping
+ * users nothing resolved for.
+ *
+ * This is the **read-side** expansion of a profile grantee and is intentionally
+ * built on {@link resolveBaseProfile} rather than on
+ * `permissions/profiles/resolveProfileHolderIds`: that one is the *invalidation
+ * / escalation-guard* sweep (who to bust caches for), while this one must agree
+ * with the forward resolver **exactly**, including the null-bound majority — a
+ * profile-grantee row naming a system profile reaches every member whose null
+ * binding resolves to it.
+ */
+export function resolveProfileIdByUser(input: {
+  organizationId: string
+  roleMap: Record<string, MemberRoleEntry>
+  profiles: readonly CachedPermissionProfile[]
+}): Record<string, string> {
+  const byUser: Record<string, string> = {}
+  for (const [userId, entry] of Object.entries(input.roleMap)) {
+    const resolved = resolveBaseProfile({
+      organizationId: input.organizationId,
+      userId,
+      role: entry.role,
+      seatType: entry.seatType,
+      permissionProfileId: entry.permissionProfileId,
+      profiles: input.profiles,
+    })
+    if (resolved.profileId) byUser[userId] = resolved.profileId
+  }
+  return byUser
+}
+
+/** Every member whose resolved base profile is `profileId`. Cache-only. */
+export async function resolveProfileHolders(
+  organizationId: string,
+  profileId: string
+): Promise<string[]> {
+  const { getOrgCache } = await import('../cache')
+  const [roleMap, profiles] = await Promise.all([
+    getOrgCache().get(organizationId, 'memberRoleMap'),
+    getOrgCache().get(organizationId, 'profiles'),
+  ])
+  const byUser = resolveProfileIdByUser({ organizationId, roleMap, profiles })
+  return Object.keys(byUser).filter((userId) => byUser[userId] === profileId)
+}
+
+/**
+ * One `(granteeType…, granteeId…)` pair a member's `ResourceAccess` rows may
+ * match on. `granteeTypes` holds more than one entry only for the mail
+ * evaluator's legacy `team`-as-group behaviour.
+ */
+export interface GranteeMatcher {
+  granteeTypes: ResourceGranteeType[]
+  granteeIds: string[]
+}
+
+/**
+ * The grantee union for one member, as data — direct user grant, the
+ * `role:org_member` baseline, the bound permission profile, and group grants.
+ *
+ * Split out of {@link resourceAccessGranteeConditions} so the union itself is
+ * testable: under the default Vitest config `@auxx/database`'s `schema` is a
+ * Proxy whose columns are `undefined`, so asserting on built Drizzle predicates
+ * passes vacuously. This function has no Drizzle in it.
+ *
+ * `treatTeamAsGroup` reproduces the mail evaluator's historical behaviour of
+ * matching legacy `team` rows against the same group-instance ids.
+ */
+export function granteeMatchers(
+  grantees: ResourceAccessGrantees,
+  opts: { treatTeamAsGroup?: boolean } = {}
+): GranteeMatcher[] {
+  const matchers: GranteeMatcher[] = [
+    { granteeTypes: [ResourceGranteeType.user], granteeIds: [grantees.userId] },
+    { granteeTypes: [ResourceGranteeType.role], granteeIds: [ORG_MEMBER_GRANTEE_ID] },
+  ]
+
+  if (grantees.profileId) {
+    matchers.push({
+      granteeTypes: [ResourceGranteeType.profile],
+      granteeIds: [grantees.profileId],
+    })
+  }
+
+  if (grantees.groupIds.length > 0) {
+    matchers.push({
+      granteeTypes: opts.treatTeamAsGroup
+        ? [ResourceGranteeType.group, ResourceGranteeType.team]
+        : [ResourceGranteeType.group],
+      granteeIds: grantees.groupIds,
+    })
+  }
+
+  return matchers
+}
+
+/**
+ * The `OR`-able `ResourceAccess` grantee predicates for one member — the SQL
+ * projection of {@link granteeMatchers}.
+ */
+export function resourceAccessGranteeConditions(
+  grantees: ResourceAccessGrantees,
+  opts: { treatTeamAsGroup?: boolean } = {}
+): Array<SQL | undefined> {
+  return granteeMatchers(grantees, opts).map((matcher) =>
+    and(
+      matcher.granteeTypes.length === 1
+        ? eq(schema.ResourceAccess.granteeType, matcher.granteeTypes[0]!)
+        : inArray(schema.ResourceAccess.granteeType, matcher.granteeTypes),
+      matcher.granteeIds.length === 1
+        ? eq(schema.ResourceAccess.granteeId, matcher.granteeIds[0]!)
+        : inArray(schema.ResourceAccess.granteeId, matcher.granteeIds)
+    )
+  )
+}
+
+/**
+ * How a grant row attributes in {@link import('./types').AccessCheckResult}.
+ * Total over the grantee vocabulary so a new kind cannot silently report as
+ * `'direct'` (19a #27).
+ */
+export function grantedViaFor(
+  granteeType: string
+): 'direct' | 'group' | 'team' | 'role' | 'profile' {
+  switch (granteeType) {
+    case ResourceGranteeType.user:
+      return 'direct'
+    case ResourceGranteeType.group:
+      return 'group'
+    case ResourceGranteeType.team:
+      return 'team'
+    case ResourceGranteeType.profile:
+      return 'profile'
+    default:
+      return 'role'
+  }
+}

--- a/packages/lib/src/resource-access/index.ts
+++ b/packages/lib/src/resource-access/index.ts
@@ -2,6 +2,19 @@
 
 // Constants
 export { PERMISSION_HIERARCHY, satisfiesPermission } from './constants'
+// Grantee resolution (doc 19 §8.2 — the ONE grantee union)
+export {
+  type GranteeMatcher,
+  grantedViaFor,
+  granteeMatchers,
+  ORG_MEMBER_GRANTEE_ID,
+  type ResourceAccessGrantees,
+  resolveProfileHolders,
+  resolveProfileIdByUser,
+  resolveResourceAccessGrantees,
+  resolveUserProfileId,
+  resourceAccessGranteeConditions,
+} from './grantee-resolution'
 // Mail sharing guards (mail-permissions §7)
 export {
   assertCanManageMailSharing,
@@ -31,6 +44,7 @@ export type {
   AccessCheckResult,
   CheckAccessInput,
   CheckTypeAccessInput,
+  GrantedVia,
   GrantInstanceAccessInput,
   GrantLens,
   GrantTypeAccessInput,

--- a/packages/lib/src/resource-access/mail-sharing-guard.ts
+++ b/packages/lib/src/resource-access/mail-sharing-guard.ts
@@ -48,6 +48,12 @@ export async function assertCanManageMailSharing(
   if (!isMailSharingDef(entityDefinitionId)) return
 
   const { organizationId, userId } = ctx
+  // DELIBERATELY `'user'` ONLY — do not widen to the other grantee kinds when
+  // teaching the codebase a new one (doc 19 step 9 / 19a #13). Self-revoke means
+  // "remove the grant that names ME"; a group/profile/role row is shared policy,
+  // and letting one holder delete it would silently revoke everyone else. This
+  // fails closed on purpose: a member who wants out of a profile-scoped share
+  // needs an admin, not a leave button.
   if (
     opts?.selfRevokeGranteeType === 'user' &&
     opts.selfRevokeGranteeId &&

--- a/packages/lib/src/resource-access/resource-access-service.test.ts
+++ b/packages/lib/src/resource-access/resource-access-service.test.ts
@@ -11,6 +11,22 @@ vi.mock('../cache', () => ({
   getCachedUserGroupIds: vi.fn(async () => []),
 }))
 
+// A profile grantee routes through the SAME audience sweep `grant-service.ts`
+// uses, so it is stubbed here rather than reimplemented (19a #25).
+const resolveProfileAudience = vi.fn(async () => ({
+  userIds: ['u_holder_a', 'u_holder_b'],
+  broadcast: false,
+}))
+vi.mock('../permissions/profiles/profile-invalidation', () => ({
+  resolveProfileAudience: (...a: unknown[]) => resolveProfileAudience(...(a as [])),
+}))
+
+const resolveProfileHolders = vi.fn(async () => ['u_holder_a', 'u_holder_b'])
+vi.mock('./grantee-resolution', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./grantee-resolution')>()),
+  resolveProfileHolders: (...a: unknown[]) => resolveProfileHolders(...(a as [])),
+}))
+
 import { onCacheEvent } from '../cache'
 import {
   grantInstanceAccess,
@@ -29,7 +45,11 @@ function fakeDb(opts: { deleteReturning?: Array<{ granteeId: string }> } = {}) {
       ResourceAccess: {
         findFirst: async () => undefined,
       },
+      User: { findFirst: async () => ({ name: 'Granter' }) },
     },
+    // The share-notification path resolves the shared resource's name; an empty
+    // result short-circuits it after the recipients have been resolved.
+    select: () => ({ from: () => ({ where: () => ({ limit: async () => [] }) }) }),
     insert: () => ({
       values: () => ({ onConflictDoUpdate: async () => {} }),
     }),
@@ -44,7 +64,10 @@ function fakeDb(opts: { deleteReturning?: Array<{ granteeId: string }> } = {}) {
 const emit = vi.mocked(onCacheEvent)
 
 describe('resource-access cache-event emission', () => {
-  beforeEach(() => emit.mockClear())
+  beforeEach(() => {
+    emit.mockClear()
+    resolveProfileAudience.mockClear()
+  })
 
   it('targets a single user for a user grant', async () => {
     await grantInstanceAccess(
@@ -84,6 +107,78 @@ describe('resource-access cache-event emission', () => {
       { recordId: RECORD, granteeType: ResourceGranteeType.user, granteeId: 'u_x' }
     )
     expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('accepts a profile grantee — the step-9 write guard is gone', async () => {
+    await expect(
+      grantTypeAccess(
+        { db: fakeDb(), organizationId: ORG, userId: 'granter' },
+        {
+          entityDefinitionId: 'def_deals',
+          granteeType: ResourceGranteeType.profile,
+          granteeId: 'prof_field',
+          permission: ResourcePermission.view,
+        }
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('targets a profile grant at its holders instead of broadcasting (19a #25)', async () => {
+    await grantTypeAccess(
+      { db: fakeDb(), organizationId: ORG, userId: 'granter' },
+      {
+        entityDefinitionId: 'def_deals',
+        granteeType: ResourceGranteeType.profile,
+        granteeId: 'prof_field',
+        permission: ResourcePermission.view,
+      }
+    )
+    expect(resolveProfileAudience).toHaveBeenCalledWith({
+      organizationId: ORG,
+      profileId: 'prof_field',
+    })
+    const targeted = emit.mock.calls
+      .filter((c) => c[0] === 'resource-access.changed')
+      .map((c) => c[1].userId)
+      .sort()
+    expect(targeted).toEqual(['u_holder_a', 'u_holder_b'])
+    expect(emit).not.toHaveBeenCalledWith('resource-access.changed', {
+      orgId: ORG,
+      broadcastUserKeys: true,
+    })
+  })
+
+  it('falls back to an org-wide broadcast when the profile audience says so', async () => {
+    resolveProfileAudience.mockResolvedValueOnce({ userIds: [], broadcast: true })
+    await grantTypeAccess(
+      { db: fakeDb(), organizationId: ORG, userId: 'granter' },
+      {
+        entityDefinitionId: 'def_deals',
+        granteeType: ResourceGranteeType.profile,
+        granteeId: 'prof_field',
+        permission: ResourcePermission.view,
+      }
+    )
+    expect(emit).toHaveBeenCalledWith('resource-access.changed', {
+      orgId: ORG,
+      broadcastUserKeys: true,
+    })
+  })
+
+  it('notifies a profile grant’s holders instead of nobody (19a #26)', async () => {
+    resolveProfileHolders.mockClear()
+    await grantInstanceAccess(
+      { db: fakeDb(), organizationId: ORG, userId: 'granter' },
+      {
+        recordId: toRecordId('dashboard', 'dash_1'),
+        granteeType: ResourceGranteeType.profile,
+        granteeId: 'prof_field',
+        permission: ResourcePermission.view,
+      }
+    )
+    // The share notification is fire-and-forget; let the microtask queue drain.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(resolveProfileHolders).toHaveBeenCalledWith(ORG, 'prof_field')
   })
 
   it('emits for both removed and added grantees on a set', async () => {

--- a/packages/lib/src/resource-access/resource-access-service.ts
+++ b/packages/lib/src/resource-access/resource-access-service.ts
@@ -5,16 +5,22 @@ import { MemberType, ResourceGranteeType, ResourcePermission } from '@auxx/datab
 import { createScopedLogger } from '@auxx/logger'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
-import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm'
-import { getCachedUserGroupIds, onCacheEvent } from '../cache'
-import { BadRequestError } from '../errors'
+import { and, desc, eq, isNull, or } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
 import { NotificationService } from '../notifications'
 import { isInstanceAccessKey } from '../permissions/capabilities/instance-access'
 import { satisfiesPermission } from './constants'
+import {
+  grantedViaFor,
+  resolveProfileHolders,
+  resolveResourceAccessGrantees,
+  resourceAccessGranteeConditions,
+} from './grantee-resolution'
 import type {
   AccessCheckResult,
   CheckAccessInput,
   CheckTypeAccessInput,
+  GrantedVia,
   GrantInstanceAccessInput,
   GrantLens,
   GrantTypeAccessInput,
@@ -28,45 +34,53 @@ import type {
 const logger = createScopedLogger('resource-access-service')
 const SHARE_NOTIFICATION_RECIPIENT_CAP = 50
 
-/**
- * Refuse `granteeType: 'profile'` on ResourceAccess **writes** until plan 19
- * step 9 lands.
+/*
+ * NOTE — the profile-grantee WRITE GUARD is gone (doc 19 §9 step 9).
  *
- * The vocabulary exists (`ResourceGranteeTypeValues`, doc 19 §1.2) and
- * `computeUserCapabilities` already reads profile rows into
- * `defAccess`/`instanceAccess`. But `restrictedEntityDefIds` /
- * `restrictedInstanceIds` are computed **grantee-agnostically**, and
- * `effectiveRecordLevel` replaces base with the member's own grant as soon as a
- * def is "restricted". So a single profile-grantee type row would flip a def to
- * restricted org-wide while three of the four read paths still cannot resolve a
- * grant through it — the def goes dark for every non-admin. One admin click, an
- * org-wide lockout.
+ * `granteeType: 'profile'` on ResourceAccess writes was refused here until doc
+ * 19 step 9 (`assertProfileGranteeSupported`, PR #1332). The guard existed
+ * because `restrictedEntityDefIds` / `restrictedInstanceIds` are built
+ * **grantee-agnostically** while the readers were grantee-limited, so one
+ * profile row would have flipped a def to restricted org-wide with nobody able
+ * to resolve a grant through it — an org-wide lockout, not a per-grantee no-op.
  *
- * TODO(plan-19-step-9): remove this guard only after ALL of these learn the
- * `profile` grantee kind:
- *  - `checkAccess` grantee conditions (this file)
- *  - `checkTypeAccess` grantee conditions (this file)
- *  - `getUserAccessibleInstances` grantee conditions (this file)
- *  - `cache/providers/mail-grant-index-provider.ts` (currently reinterprets an
- *    unknown `granteeId` as a GROUP id)
- * plus the §8.2 surface inventory (`resourceAccess.ts` z.enums,
- * `@auxx/types/actor`, `use-instance-share.ts`, `snippet-permissions.ts`,
- * `compute-user-mail-visibility.ts`).
+ * It is gone because every server resolver now goes through
+ * `grantee-resolution.ts`: `checkAccess`, `checkTypeAccess`,
+ * `getUserAccessibleInstances`, `computeUserCapabilities`,
+ * `computeUserMailVisibility` (forward) and `mailGrantIndexProvider` (reverse),
+ * plus `snippet-permissions.ts`'s in-memory equivalent. Do not reintroduce a
+ * per-kind write guard here — the invariant to protect is "every reader
+ * enumerates every kind", which the shared builder enforces structurally.
  */
-function assertProfileGranteeSupported(granteeType: ResourceGranteeType): void {
-  if (granteeType === ResourceGranteeType.profile) {
-    throw new BadRequestError(
-      'Profile-scoped resource grants are not enabled yet — see plans/permissions/v2/19-permission-profiles.md step 9.'
-    )
-  }
-}
 
+/**
+ * Who gets the "X shared … with you" notification for one grant row.
+ *
+ * `role:org_member` is deliberately silent (an org-wide baseline change is not a
+ * personal share). A `profile` grantee expands to that profile's holders —
+ * before doc 19 step 9 the `granteeId` fell through to the group branch and was
+ * looked up as a group instance id, which always matched nothing, so a
+ * profile-scoped share notified **nobody** with no error and no log (19a #26).
+ */
 async function resolveShareRecipients(
   ctx: ResourceAccessContext,
   input: GrantInstanceAccessInput
 ): Promise<string[]> {
   if (input.granteeType === ResourceGranteeType.role) return []
   if (input.granteeType === ResourceGranteeType.user) return [input.granteeId]
+
+  if (input.granteeType === ResourceGranteeType.profile) {
+    const holders = await resolveProfileHolders(ctx.organizationId, input.granteeId)
+    if (holders.length > SHARE_NOTIFICATION_RECIPIENT_CAP) {
+      logger.warn('Share notification fan-out capped', {
+        organizationId: ctx.organizationId,
+        granteeType: input.granteeType,
+        granteeId: input.granteeId,
+        cap: SHARE_NOTIFICATION_RECIPIENT_CAP,
+      })
+    }
+    return holders.slice(0, SHARE_NOTIFICATION_RECIPIENT_CAP)
+  }
 
   const members = await ctx.db.query.EntityGroupMember.findMany({
     where: and(
@@ -203,10 +217,54 @@ async function notifyNewInstanceShare(
 }
 
 /**
+ * Which users a set of mutated grantees invalidates, or an org-wide broadcast.
+ *
+ * User grants target that one user. **Profile** grants route through
+ * `resolveProfileAudience` — the SAME sweep `grant-service.ts`'s
+ * `emitGrantChanged` uses, deliberately not a second implementation — which
+ * resolves explicit holders plus the null-bound majority, and self-collapses to
+ * a broadcast when the profile is unclassifiable or the holder set is large.
+ * Everything else (role/group/team) still fans out org-wide: correct but
+ * expensive, which is why profiles are worth narrowing.
+ *
+ * Fails SAFE in both directions — the worst outcome is an over-broad bust.
+ */
+async function resolveInvalidationTargets(
+  organizationId: string,
+  grantees: Array<{ granteeType: ResourceGranteeType; granteeId: string }>
+): Promise<{ userIds: string[]; broadcast: boolean }> {
+  const userIds = new Set<string>()
+  let broadcast = false
+
+  for (const g of grantees) {
+    if (g.granteeType === ResourceGranteeType.user) {
+      userIds.add(g.granteeId)
+      continue
+    }
+    if (g.granteeType === ResourceGranteeType.profile) {
+      // Lazy import — the profiles module pulls the cache + dehydration barrels,
+      // and the cache invalidation path imports back into this file's neighbours.
+      const { resolveProfileAudience } = await import(
+        '../permissions/profiles/profile-invalidation'
+      )
+      const audience = await resolveProfileAudience({ organizationId, profileId: g.granteeId })
+      if (audience.broadcast) broadcast = true
+      else for (const userId of audience.userIds) userIds.add(userId)
+      continue
+    }
+    broadcast = true
+  }
+
+  // A single org-wide fan-out already covers every member — no need to also
+  // enumerate the targeted grants when broadcasting.
+  if (broadcast) return { userIds: [], broadcast: true }
+  return { userIds: Array.from(userIds), broadcast: false }
+}
+
+/**
  * Emit the cache event that busts visibility caches after a ResourceAccess
- * mutation. User grants invalidate just that user's keys; group/role/team
- * grants use the org-wide fan-out (the affected user set can't be enumerated
- * cheaply here). Call AFTER the DB write commits.
+ * mutation. See {@link resolveInvalidationTargets} for the fan-out rules.
+ * Call AFTER the DB write commits.
  *
  * Phase 0 of the mail-permissions plan wires the emission; Phase 1 attaches
  * the keys (`userMailVisibility`, `mailGrantIndex`) to the invalidation graph.
@@ -215,15 +273,8 @@ async function emitResourceAccessChanged(
   organizationId: string,
   grantees: Array<{ granteeType: ResourceGranteeType; granteeId: string }>
 ): Promise<void> {
-  const userIds = new Set<string>()
-  let broadcast = false
-  for (const g of grantees) {
-    if (g.granteeType === ResourceGranteeType.user) userIds.add(g.granteeId)
-    else broadcast = true
-  }
+  const { userIds, broadcast } = await resolveInvalidationTargets(organizationId, grantees)
 
-  // A single org-wide fan-out already covers every member — no need to also
-  // enumerate the user grants when broadcasting.
   if (broadcast) {
     await onCacheEvent('resource-access.changed', {
       orgId: organizationId,
@@ -233,7 +284,7 @@ async function emitResourceAccessChanged(
   }
 
   await Promise.all(
-    Array.from(userIds).map((userId) =>
+    userIds.map((userId) =>
       onCacheEvent('resource-access.changed', { orgId: organizationId, userId })
     )
   )
@@ -256,12 +307,7 @@ async function emitResourceAccessTypeChanged(
   organizationId: string,
   grantees: Array<{ granteeType: ResourceGranteeType; granteeId: string }>
 ): Promise<void> {
-  const userIds = new Set<string>()
-  let broadcast = false
-  for (const g of grantees) {
-    if (g.granteeType === ResourceGranteeType.user) userIds.add(g.granteeId)
-    else broadcast = true
-  }
+  const { userIds, broadcast } = await resolveInvalidationTargets(organizationId, grantees)
 
   // Lazy import — the cache invalidation path lazily imports realtime, so this
   // module must not statically import the realtime barrel back (import cycle).
@@ -277,7 +323,7 @@ async function emitResourceAccessTypeChanged(
   }
 
   await Promise.all(
-    Array.from(userIds).map(async (userId) => {
+    userIds.map(async (userId) => {
       await onCacheEvent('resource-access.type.changed', { orgId: organizationId, userId })
       await publishCapabilitiesChanged(getRealtimeService(), { userId })
     })
@@ -302,12 +348,7 @@ export async function emitResourceAccessInstanceChanged(
   organizationId: string,
   grantees: Array<{ granteeType: ResourceGranteeType; granteeId: string }>
 ): Promise<void> {
-  const userIds = new Set<string>()
-  let broadcast = false
-  for (const g of grantees) {
-    if (g.granteeType === ResourceGranteeType.user) userIds.add(g.granteeId)
-    else broadcast = true
-  }
+  const { userIds, broadcast } = await resolveInvalidationTargets(organizationId, grantees)
 
   // Lazy import — the cache invalidation path lazily imports realtime, so this
   // module must not statically import the realtime barrel back (import cycle).
@@ -323,7 +364,7 @@ export async function emitResourceAccessInstanceChanged(
   }
 
   await Promise.all(
-    Array.from(userIds).map(async (userId) => {
+    userIds.map(async (userId) => {
       await onCacheEvent('resource-access.instance.changed', { orgId: organizationId, userId })
       await publishCapabilitiesChanged(getRealtimeService(), { userId })
     })
@@ -337,7 +378,6 @@ export async function grantInstanceAccess(
   ctx: ResourceAccessContext,
   input: GrantInstanceAccessInput
 ): Promise<void> {
-  assertProfileGranteeSupported(input.granteeType)
   const { db, organizationId, userId } = ctx
   const { entityDefinitionId, entityInstanceId } = parseRecordId(input.recordId)
   const existing = await db.query.ResourceAccess.findFirst({
@@ -403,7 +443,6 @@ export async function grantTypeAccess(
   ctx: ResourceAccessContext,
   input: GrantTypeAccessInput
 ): Promise<void> {
-  assertProfileGranteeSupported(input.granteeType)
   const { db, organizationId, userId } = ctx
 
   await db
@@ -543,7 +582,6 @@ export async function setInstanceAccess(
   granteeType: ResourceGranteeType,
   grants: Array<{ granteeId: string; permission: ResourcePermission; lens?: GrantLens | null }>
 ): Promise<void> {
-  assertProfileGranteeSupported(granteeType)
   const { db, organizationId, userId } = ctx
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
@@ -598,7 +636,6 @@ export async function setTypeAccess(
   granteeType: ResourceGranteeType,
   grants: Array<{ granteeId: string; permission: ResourcePermission }>
 ): Promise<void> {
-  assertProfileGranteeSupported(granteeType)
   const { db, organizationId, userId } = ctx
 
   const removed = await db.transaction(async (tx: typeof db) => {
@@ -670,32 +707,13 @@ export async function checkAccess(
     }
   }
 
-  // 2. Get user's groups (for group-based access)
-  const groupIds = await getCachedUserGroupIds(organizationId, targetUserId)
-
-  // 3. Build grantee conditions
-  const granteeConditions = [
-    // Direct user grant
-    and(
-      eq(schema.ResourceAccess.granteeType, ResourceGranteeType.user),
-      eq(schema.ResourceAccess.granteeId, targetUserId)
-    ),
-    // Role grant (org_member)
-    and(
-      eq(schema.ResourceAccess.granteeType, ResourceGranteeType.role),
-      eq(schema.ResourceAccess.granteeId, 'org_member')
-    ),
-  ]
-
-  // Group grants (if user belongs to any groups)
-  if (groupIds.length > 0) {
-    granteeConditions.push(
-      and(
-        eq(schema.ResourceAccess.granteeType, ResourceGranteeType.group),
-        inArray(schema.ResourceAccess.granteeId, groupIds)
-      )
-    )
-  }
+  // 2+3. Grantee conditions: direct user, `role:org_member` baseline, the bound
+  // permission profile, and groups. One shared builder — see
+  // `grantee-resolution.ts` for why a kind missing here is an org-wide lockout
+  // rather than a per-grantee no-op.
+  const granteeConditions = resourceAccessGranteeConditions(
+    await resolveResourceAccessGrantees(organizationId, targetUserId)
+  )
 
   // 4. Find matching access grants (both instance-level and type-level)
   const grants = await db.query.ResourceAccess.findMany({
@@ -717,7 +735,7 @@ export async function checkAccess(
 
   // 5. Find highest permission level (instance-specific grants take precedence)
   let highestPermission: ResourcePermission = grants[0]!.permission as ResourcePermission
-  let grantedVia: 'direct' | 'group' | 'team' | 'role' = 'direct'
+  let grantedVia: GrantedVia = 'direct'
   let accessLevel: 'type' | 'instance' = grants[0]!.entityInstanceId ? 'instance' : 'type'
 
   for (const grant of grants) {
@@ -734,16 +752,10 @@ export async function checkAccess(
       }
     }
 
-    // Track how access was granted
-    if (grant.granteeType === ResourceGranteeType.user) {
-      grantedVia = 'direct'
-    } else if (grant.granteeType === ResourceGranteeType.group) {
-      grantedVia = 'group'
-    } else if (grant.granteeType === ResourceGranteeType.team) {
-      grantedVia = 'team'
-    } else if (grant.granteeType === ResourceGranteeType.role) {
-      grantedVia = 'role'
-    }
+    // Track how access was granted. Total over the grantee vocabulary — an
+    // unmapped kind used to attribute as `'direct'`, which reads as "you were
+    // named personally" for a grant nobody named you in (19a #27).
+    grantedVia = grantedViaFor(grant.granteeType)
   }
 
   return {
@@ -783,29 +795,11 @@ export async function checkTypeAccess(
     }
   }
 
-  // Get user's groups
-  const groupIds = await getCachedUserGroupIds(organizationId, targetUserId)
-
-  // Build grantee conditions
-  const granteeConditions = [
-    and(
-      eq(schema.ResourceAccess.granteeType, ResourceGranteeType.user),
-      eq(schema.ResourceAccess.granteeId, targetUserId)
-    ),
-    and(
-      eq(schema.ResourceAccess.granteeType, ResourceGranteeType.role),
-      eq(schema.ResourceAccess.granteeId, 'org_member')
-    ),
-  ]
-
-  if (groupIds.length > 0) {
-    granteeConditions.push(
-      and(
-        eq(schema.ResourceAccess.granteeType, ResourceGranteeType.group),
-        inArray(schema.ResourceAccess.granteeId, groupIds)
-      )
-    )
-  }
+  // Grantee conditions — same shared builder as `checkAccess`. This was an
+  // independently-maintained second copy that had already drifted (19a #8).
+  const granteeConditions = resourceAccessGranteeConditions(
+    await resolveResourceAccessGrantees(organizationId, targetUserId)
+  )
 
   // Find type-level grants only (entityInstanceId is null)
   const grants = await db.query.ResourceAccess.findMany({
@@ -823,16 +817,13 @@ export async function checkTypeAccess(
 
   // Find highest permission
   let highestPermission: ResourcePermission = grants[0]!.permission as ResourcePermission
-  let grantedVia: 'direct' | 'group' | 'team' | 'role' = 'direct'
+  let grantedVia: GrantedVia = 'direct'
 
   for (const grant of grants) {
     const perm = grant.permission as ResourcePermission
     if (satisfiesPermission(perm, highestPermission)) {
       highestPermission = perm
-      if (grant.granteeType === ResourceGranteeType.user) grantedVia = 'direct'
-      else if (grant.granteeType === ResourceGranteeType.group) grantedVia = 'group'
-      else if (grant.granteeType === ResourceGranteeType.team) grantedVia = 'team'
-      else if (grant.granteeType === ResourceGranteeType.role) grantedVia = 'role'
+      grantedVia = grantedViaFor(grant.granteeType)
     }
   }
 
@@ -967,29 +958,12 @@ export async function getUserAccessibleInstances(
 }> {
   const { db, organizationId } = ctx
 
-  // Get user's groups
-  const groupIds = await getCachedUserGroupIds(organizationId, userId)
-
-  // Build grantee conditions
-  const granteeConditions = [
-    and(
-      eq(schema.ResourceAccess.granteeType, ResourceGranteeType.user),
-      eq(schema.ResourceAccess.granteeId, userId)
-    ),
-    and(
-      eq(schema.ResourceAccess.granteeType, ResourceGranteeType.role),
-      eq(schema.ResourceAccess.granteeId, 'org_member')
-    ),
-  ]
-
-  if (groupIds.length > 0) {
-    granteeConditions.push(
-      and(
-        eq(schema.ResourceAccess.granteeType, ResourceGranteeType.group),
-        inArray(schema.ResourceAccess.granteeId, groupIds)
-      )
-    )
-  }
+  // Grantee conditions — third copy of the same block (19a #9). This one drives
+  // LIST/INDEX reads (snippets, sequences, groups), so a grantee kind missing
+  // here silently empties whole listings rather than failing one lookup.
+  const granteeConditions = resourceAccessGranteeConditions(
+    await resolveResourceAccessGrantees(organizationId, userId)
+  )
 
   const grants = await db.query.ResourceAccess.findMany({
     where: and(

--- a/packages/lib/src/resource-access/types.ts
+++ b/packages/lib/src/resource-access/types.ts
@@ -72,12 +72,19 @@ export interface CheckTypeAccessInput {
 // RESULTS
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * How a `ResourceAccess` grant reached the user — one per grantee kind, plus
+ * `'role'` for the `role:org_member` workspace baseline. `'profile'` was added
+ * in doc 19 step 9; before that a profile grant mis-attributed as `'direct'`.
+ */
+export type GrantedVia = 'direct' | 'group' | 'team' | 'role' | 'profile'
+
 /** Result of access check */
 export interface AccessCheckResult {
   hasAccess: boolean
   permission: ResourcePermission | null
   /** How access was granted */
-  grantedVia: 'direct' | 'group' | 'team' | 'role' | null
+  grantedVia: GrantedVia | null
   /** Whether access is type-level (all instances) or instance-specific */
   accessLevel: 'type' | 'instance' | null
 }

--- a/packages/lib/src/snippets/__tests__/snippet-sharing.test.ts
+++ b/packages/lib/src/snippets/__tests__/snippet-sharing.test.ts
@@ -2,15 +2,33 @@
 
 import type { Database } from '@auxx/database'
 import { ResourceGranteeType, ResourcePermission, SnippetSharingType } from '@auxx/database/enums'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ResourceAccessInfo } from '../../resource-access/types'
 
-const setInstanceAccess = vi.fn(async () => {})
+// Typed rest params so `mock.calls[n][i]` is indexable (an argless `vi.fn` types
+// every recorded call as the empty tuple).
+const setInstanceAccess = vi.fn(async (..._args: unknown[]) => {})
 vi.mock('../../resource-access', () => ({
   setInstanceAccess: (...a: unknown[]) => setInstanceAccess(...a),
   getInstanceAccess: vi.fn(async () => []),
 }))
 
-import { setSnippetSharing } from '../snippet-mutations'
+const getCachedUserGroupIds = vi.fn(async () => [] as string[])
+vi.mock('../../cache', () => ({
+  getCachedUserGroupIds: (...a: unknown[]) => getCachedUserGroupIds(...(a as [])),
+}))
+
+const resolveUserProfileId = vi.fn(async () => null as string | null)
+vi.mock('../../resource-access/grantee-resolution', () => ({
+  resolveUserProfileId: (...a: unknown[]) => resolveUserProfileId(...(a as [])),
+}))
+
+import {
+  SNIPPET_SHARE_GRANTEE_TYPES,
+  type SnippetShareInput,
+  setSnippetSharing,
+} from '../snippet-mutations'
+import { resolveCanEdit } from '../snippet-permissions'
 
 function makeDb(snippet: unknown, sink: { deleted: number; sharingTypeSet: unknown[] }) {
   const tx = {
@@ -33,6 +51,62 @@ function makeDb(snippet: unknown, sink: { deleted: number; sharingTypeSet: unkno
   } as unknown as Database
 }
 
+describe('resolveCanEdit', () => {
+  const share = (over: Partial<ResourceAccessInfo>): ResourceAccessInfo =>
+    ({
+      id: 'ra_1',
+      entityDefinitionId: 'snippet',
+      entityInstanceId: 's1',
+      granteeType: ResourceGranteeType.group,
+      granteeId: 'g1',
+      permission: ResourcePermission.edit,
+      lens: null,
+      createdAt: new Date(),
+      ...over,
+    }) as ResourceAccessInfo
+
+  beforeEach(() => {
+    getCachedUserGroupIds.mockResolvedValue([])
+    resolveUserProfileId.mockResolvedValue(null)
+  })
+
+  it('grants edit through the user’s bound permission profile (19a #12)', async () => {
+    resolveUserProfileId.mockResolvedValue('prof_field')
+    const can = await resolveCanEdit('org1', 'u2', 'u1', [
+      share({ granteeType: ResourceGranteeType.profile, granteeId: 'prof_field' }),
+    ])
+    expect(can).toBe(true)
+    expect(resolveUserProfileId).toHaveBeenCalledWith('org1', 'u2')
+  })
+
+  it('denies a profile grant the user does not hold', async () => {
+    resolveUserProfileId.mockResolvedValue('prof_member')
+    const can = await resolveCanEdit('org1', 'u2', 'u1', [
+      share({ granteeType: ResourceGranteeType.profile, granteeId: 'prof_field' }),
+    ])
+    expect(can).toBe(false)
+  })
+
+  it('ignores a profile grant that is only VIEW', async () => {
+    resolveUserProfileId.mockResolvedValue('prof_field')
+    const can = await resolveCanEdit('org1', 'u2', 'u1', [
+      share({
+        granteeType: ResourceGranteeType.profile,
+        granteeId: 'prof_field',
+        permission: ResourcePermission.view,
+      }),
+    ])
+    expect(can).toBe(false)
+  })
+
+  it('does not resolve a profile at all when no profile share exists', async () => {
+    getCachedUserGroupIds.mockResolvedValue(['g1'])
+    const can = await resolveCanEdit('org1', 'u2', 'u1', [share({})])
+    expect(can).toBe(true)
+    expect(resolveUserProfileId).not.toHaveBeenCalled()
+  })
+})
+
 describe('setSnippetSharing', () => {
   it('rejects when the snippet is missing or not owned by the user', async () => {
     const db = makeDb(undefined, { deleted: 0, sharingTypeSet: [] })
@@ -42,24 +116,57 @@ describe('setSnippetSharing', () => {
     expect(setInstanceAccess).not.toHaveBeenCalled()
   })
 
-  it('replaces group and user grants for GROUPS sharing', async () => {
+  it('replaces group, user and profile grants for GROUPS sharing', async () => {
     setInstanceAccess.mockClear()
     const sink = { deleted: 0, sharingTypeSet: [] as unknown[] }
     const db = makeDb({ id: 's1', createdById: 'u1' }, sink)
     const result = await setSnippetSharing(db, 'org1', 'u1', 's1', SnippetSharingType.GROUPS, [
       { granteeType: 'group', granteeId: 'g1', permission: 'EDIT' },
       { granteeType: 'user', granteeId: 'u2', permission: 'VIEW' },
+      { granteeType: 'profile', granteeId: 'p1', permission: 'EDIT' },
     ])
     expect(result.isOk()).toBe(true)
     expect(sink.sharingTypeSet).toEqual([SnippetSharingType.GROUPS])
-    expect(setInstanceAccess).toHaveBeenCalledTimes(2)
+    expect(setInstanceAccess).toHaveBeenCalledTimes(SNIPPET_SHARE_GRANTEE_TYPES.length)
 
-    const [groupCall, userCall] = setInstanceAccess.mock.calls
+    const [groupCall, userCall, profileCall] = setInstanceAccess.mock.calls
     expect(groupCall[2]).toBe(ResourceGranteeType.group)
     expect(groupCall[3]).toEqual([{ granteeId: 'g1', permission: ResourcePermission.edit }])
     expect(userCall[2]).toBe(ResourceGranteeType.user)
     expect(userCall[3]).toEqual([{ granteeId: 'u2', permission: ResourcePermission.view }])
+    expect(profileCall[2]).toBe(ResourceGranteeType.profile)
+    expect(profileCall[3]).toEqual([{ granteeId: 'p1', permission: ResourcePermission.edit }])
     expect(sink.deleted).toBe(0)
+  })
+
+  it('clears every supported grantee kind, including the ones with no incoming share', async () => {
+    // The replace-per-type semantics mean a kind that is never passed to
+    // `setInstanceAccess` keeps its stored rows forever (19a site 28).
+    setInstanceAccess.mockClear()
+    const sink = { deleted: 0, sharingTypeSet: [] as unknown[] }
+    const db = makeDb({ id: 's1', createdById: 'u1' }, sink)
+    const result = await setSnippetSharing(db, 'org1', 'u1', 's1', SnippetSharingType.GROUPS, [
+      { granteeType: 'user', granteeId: 'u2', permission: 'VIEW' },
+    ])
+    expect(result.isOk()).toBe(true)
+    expect(setInstanceAccess.mock.calls.map((c) => c[2])).toEqual([...SNIPPET_SHARE_GRANTEE_TYPES])
+    for (const call of setInstanceAccess.mock.calls) {
+      if (call[2] !== ResourceGranteeType.user) expect(call[3]).toEqual([])
+    }
+  })
+
+  it('rejects a grantee kind it cannot store instead of dropping it silently', async () => {
+    setInstanceAccess.mockClear()
+    const sink = { deleted: 0, sharingTypeSet: [] as unknown[] }
+    const db = makeDb({ id: 's1', createdById: 'u1' }, sink)
+    const result = await setSnippetSharing(db, 'org1', 'u1', 's1', SnippetSharingType.GROUPS, [
+      // `role`/`team` are outside SNIPPET_SHARE_GRANTEE_TYPES — a snippet says
+      // "everyone" with SnippetSharingType.ORGANIZATION instead.
+      { granteeType: ResourceGranteeType.role, granteeId: 'org_member', permission: 'VIEW' },
+    ] as unknown as SnippetShareInput[])
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.statusCode).toBe(400)
+    expect(setInstanceAccess).not.toHaveBeenCalled()
   })
 
   it('clears all grants when switching away from GROUPS sharing', async () => {

--- a/packages/lib/src/snippets/index.ts
+++ b/packages/lib/src/snippets/index.ts
@@ -12,6 +12,8 @@ export {
   createSnippet,
   deleteSnippet,
   incrementSnippetUsage,
+  SNIPPET_SHARE_GRANTEE_TYPES,
+  type SnippetShareGranteeType,
   type SnippetShareInput,
   setSnippetSharing,
   type UpdateSnippetInput,

--- a/packages/lib/src/snippets/snippet-mutations.ts
+++ b/packages/lib/src/snippets/snippet-mutations.ts
@@ -203,16 +203,58 @@ export async function deleteSnippet(
   )
 }
 
+/**
+ * The grantee kinds a snippet may be shared with — the SINGLE source of truth
+ * for the router's input schema, the share partition below, and the read side.
+ *
+ * `profile` is included per doc 19 §0.28 (a snippet share is a `ResourceAccess`
+ * **instance** grant, so the profile is selectable as an additive grantee).
+ * `role` and `team` are deliberately absent: `role:org_member` is the
+ * workspace-baseline marker and a snippet expresses "everyone" through
+ * `SnippetSharingType.ORGANIZATION` instead, so a role row here would be a
+ * second, conflicting way to say the same thing.
+ *
+ * Because {@link setSnippetSharing} replaces grants **per grantee type**, a kind
+ * that is missing from this list is not merely unsupported — its existing rows
+ * are never cleared and its incoming rows are never written. Anything added to
+ * `ResourceGranteeType` must therefore be listed here or explicitly rejected;
+ * `assertSupportedShareGrantees` makes that failure loud.
+ */
+export const SNIPPET_SHARE_GRANTEE_TYPES = [
+  ResourceGranteeType.group,
+  ResourceGranteeType.user,
+  ResourceGranteeType.profile,
+] as const
+
+/** A grantee kind a snippet may be shared with. See {@link SNIPPET_SHARE_GRANTEE_TYPES}. */
+export type SnippetShareGranteeType = (typeof SNIPPET_SHARE_GRANTEE_TYPES)[number]
+
 export interface SnippetShareInput {
-  granteeType: 'group' | 'user'
+  granteeType: SnippetShareGranteeType
   granteeId: string
   permission: 'VIEW' | 'EDIT'
 }
 
 /**
+ * Reject a share whose grantee kind this function cannot store. Without it the
+ * per-type replace below drops the row silently — no error, no log, and the UI
+ * reports success (19a site 28).
+ */
+function assertSupportedShareGrantees(shares: SnippetShareInput[]): void {
+  const supported: readonly string[] = SNIPPET_SHARE_GRANTEE_TYPES
+  const unsupported = shares.find((s) => !supported.includes(s.granteeType))
+  if (unsupported) {
+    throw new BadRequestError(
+      `Snippets cannot be shared with a "${unsupported.granteeType}" grantee. Supported: ${SNIPPET_SHARE_GRANTEE_TYPES.join(', ')}.`
+    )
+  }
+}
+
+/**
  * Replace a snippet's sharing settings (creator only). For GROUPS sharing the
- * provided grants replace existing group + user grants; any other sharing type
- * clears all ResourceAccess for the snippet. Wrapped in a transaction.
+ * provided grants replace the existing rows of every supported grantee kind
+ * ({@link SNIPPET_SHARE_GRANTEE_TYPES}); any other sharing type clears all
+ * ResourceAccess for the snippet. Wrapped in a transaction.
  */
 export async function setSnippetSharing(
   db: Database,
@@ -224,6 +266,8 @@ export async function setSnippetSharing(
 ) {
   return guard(
     async () => {
+      assertSupportedShareGrantees(shares ?? [])
+
       const snippet = await db.query.Snippet.findFirst({
         where: and(
           eq(schema.Snippet.id, snippetId),
@@ -248,30 +292,22 @@ export async function setSnippetSharing(
           .where(eq(schema.Snippet.id, snippetId))
 
         if (sharingType === SnippetSharingType.GROUPS) {
-          const groupShares = (shares ?? []).filter((s) => s.granteeType === 'group')
-          const userShares = (shares ?? []).filter((s) => s.granteeType === 'user')
-
-          await setInstanceAccess(
-            { db: tx, organizationId, userId },
-            toRecordId(BuiltInEntityType.snippet, snippetId),
-            ResourceGranteeType.group,
-            groupShares.map((s) => ({
-              granteeId: s.granteeId,
-              permission:
-                s.permission === 'EDIT' ? ResourcePermission.edit : ResourcePermission.view,
-            }))
-          )
-
-          await setInstanceAccess(
-            { db: tx, organizationId, userId },
-            toRecordId(BuiltInEntityType.snippet, snippetId),
-            ResourceGranteeType.user,
-            userShares.map((s) => ({
-              granteeId: s.granteeId,
-              permission:
-                s.permission === 'EDIT' ? ResourcePermission.edit : ResourcePermission.view,
-            }))
-          )
+          // One pass per supported kind, driven by the list — including kinds with
+          // zero incoming shares, whose call is what CLEARS previously stored rows.
+          for (const granteeType of SNIPPET_SHARE_GRANTEE_TYPES) {
+            await setInstanceAccess(
+              { db: tx, organizationId, userId },
+              toRecordId(BuiltInEntityType.snippet, snippetId),
+              granteeType,
+              (shares ?? [])
+                .filter((s) => s.granteeType === granteeType)
+                .map((s) => ({
+                  granteeId: s.granteeId,
+                  permission:
+                    s.permission === 'EDIT' ? ResourcePermission.edit : ResourcePermission.view,
+                }))
+            )
+          }
         } else {
           await tx
             .delete(schema.ResourceAccess)

--- a/packages/lib/src/snippets/snippet-permissions.ts
+++ b/packages/lib/src/snippets/snippet-permissions.ts
@@ -3,12 +3,18 @@
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import { getCachedUserGroupIds } from '../cache'
 import type { ResourceAccessInfo } from '../resource-access'
+import { resolveUserProfileId } from '../resource-access/grantee-resolution'
 
 /**
  * Resolve whether `userId` may edit a snippet, given its creator and the
  * already-fetched ResourceAccess grants. Mirrors the duplicated checks that
  * lived in the `byId` and `update` router procedures: creator → direct user
- * EDIT grant → group-membership EDIT grant.
+ * EDIT grant → permission-profile EDIT grant → group-membership EDIT grant.
+ *
+ * The profile branch was added in doc 19 step 9 (19a #12). Snippets read grants
+ * through {@link ResourceAccessInfo} rather than a SQL grantee union, so the
+ * shared `resourceAccessGranteeConditions` builder doesn't apply — the filter
+ * happens in memory here instead, and must be kept in step with it.
  */
 export async function resolveCanEdit(
   organizationId: string,
@@ -27,10 +33,19 @@ export async function resolveCanEdit(
     return true
   }
 
+  const editShares = shares.filter((s) => s.permission === ResourcePermission.edit)
+
+  // EDIT permission via the user's bound permission profile. Resolved through
+  // the same `resolveBaseProfile` the capability composer uses, so a null-bound
+  // member is reached by a grant on their system profile.
+  const profileShares = editShares.filter((s) => s.granteeType === ResourceGranteeType.profile)
+  if (profileShares.length > 0) {
+    const profileId = await resolveUserProfileId(organizationId, userId)
+    if (profileId && profileShares.some((s) => s.granteeId === profileId)) return true
+  }
+
   // EDIT permission via group membership
-  const groupShares = shares.filter(
-    (s) => s.granteeType === ResourceGranteeType.group && s.permission === ResourcePermission.edit
-  )
+  const groupShares = editShares.filter((s) => s.granteeType === ResourceGranteeType.group)
   if (groupShares.length === 0) return false
 
   const userGroupIds = await getCachedUserGroupIds(organizationId, userId)

--- a/packages/types/actor/index.ts
+++ b/packages/types/actor/index.ts
@@ -11,7 +11,11 @@
 export type ActorId = string & { readonly __brand: 'ActorId' }
 
 /**
- * Type discriminator for ActorId prefix.
+ * Every prefix the ActorId vocabulary understands — the SINGLE source of truth for
+ * both {@link ActorIdType} and the runtime guards below. Previously the list was
+ * written out three times (the type alias plus a literal array inside
+ * `parseActorId` and `isActorId`), which is exactly how a new kind ends up
+ * type-legal but rejected at runtime.
  *
  * - `user:` — real users + system users (system users are stored in the User table).
  * - `group:` — actor groups.
@@ -21,39 +25,64 @@ export type ActorId = string & { readonly __brand: 'ActorId' }
  * - `worker:` — dispatch workers. The id half is the `DispatchWorker.id`. An individual
  *   worker resolves to its user's identity (+ board color); a team resolves to its name +
  *   member avatar stack (plans/dispatch/45-teams.md §1.H).
+ * - `profile:` — permission profiles used as an additive grantee. The id half is the
+ *   `PermissionProfile.id` (plans/permissions/v2/19-permission-profiles.md §0.28).
+ *   Note this is NOT the whole grantee vocabulary: `ResourceGranteeType` also has
+ *   `team` and `role`, which are markers (`role:org_member` is the workspace
+ *   baseline), not addressable identities, and deliberately stay out of ActorId.
  */
-export type ActorIdType = 'user' | 'group' | 'agent' | 'worker'
+export const ACTOR_ID_TYPES = ['user', 'group', 'agent', 'worker', 'profile'] as const
+
+/** Type discriminator for ActorId prefix. See {@link ACTOR_ID_TYPES}. */
+export type ActorIdType = (typeof ACTOR_ID_TYPES)[number]
 
 /**
  * Type discriminator for resolved Actor objects.
- * Widened with `'system'`, `'agent'`, and `'worker'` so callers can distinguish automated/system
- * actors, Kopilot agents, dispatch workers, and real users. The ActorId format stays `user:<id>`
- * for system users — only the resolved `.type` field differs.
+ * Widened with `'system'`, `'agent'`, `'worker'`, and `'profile'` so callers can distinguish
+ * automated/system actors, Kopilot agents, dispatch workers, permission profiles, and real
+ * users. The ActorId format stays `user:<id>` for system users — only the resolved `.type`
+ * field differs.
  */
-export type ActorType = 'user' | 'group' | 'system' | 'agent' | 'worker'
+export type ActorType = 'user' | 'group' | 'system' | 'agent' | 'worker' | 'profile'
+
+/** Type guard for the ActorId prefix vocabulary. */
+export function isActorIdType(value: unknown): value is ActorIdType {
+  return typeof value === 'string' && (ACTOR_ID_TYPES as readonly string[]).includes(value)
+}
 
 /**
- * Parse ActorId into its components.
+ * Parse an ActorId into its components without throwing — returns `null` for
+ * anything malformed or of an unknown kind.
+ *
+ * **Use this in render paths.** `parseActorId` throws, and a grantee row carrying
+ * a kind this build does not know (a forward-compatibility problem every time the
+ * grantee vocabulary grows) would take the whole tree down rather than degrade to
+ * a generic row.
+ */
+export function safeParseActorId(value: unknown): { type: ActorIdType; id: string } | null {
+  if (typeof value !== 'string' || value.length === 0) return null
+
+  const colonIndex = value.indexOf(':')
+  if (colonIndex === -1) return null
+
+  const type = value.slice(0, colonIndex)
+  const id = value.slice(colonIndex + 1)
+  if (!id || !isActorIdType(type)) return null
+
+  return { type, id }
+}
+
+/**
+ * Parse ActorId into its components. Strict: a malformed or unknown-kind id is a
+ * programming error here. Render paths must use {@link safeParseActorId} instead.
  * @throws Error if ActorId is malformed
  */
 export function parseActorId(actorId: ActorId): { type: ActorIdType; id: string } {
-  if (!actorId) {
+  const parsed = safeParseActorId(actorId)
+  if (!parsed) {
     throw new Error(`Invalid ActorId: ${actorId}`)
   }
-
-  const colonIndex = actorId.indexOf(':')
-  if (colonIndex === -1) {
-    throw new Error(`Invalid ActorId (missing colon): ${actorId}`)
-  }
-
-  const type = actorId.slice(0, colonIndex) as ActorIdType
-  const id = actorId.slice(colonIndex + 1)
-
-  if (!type || !id || !['user', 'group', 'agent', 'worker'].includes(type)) {
-    throw new Error(`Invalid ActorId: ${actorId}`)
-  }
-
-  return { type, id }
+  return parsed
 }
 
 /**
@@ -65,11 +94,16 @@ export function toActorId(type: ActorIdType, id: string): ActorId {
 
 /**
  * Type guard to check if a string is a valid ActorId format.
+ *
+ * Stricter than {@link safeParseActorId} on purpose: it requires EXACTLY two
+ * colon-separated parts, because it is what `normalizeActorIdArg` uses to reject
+ * malformed agent tool-call arguments. The parsers split on the FIRST colon, so
+ * `user:a:b` parses (id `a:b`) but is not a valid ActorId to construct.
  */
 export function isActorId(value: unknown): value is ActorId {
   if (typeof value !== 'string') return false
   const parts = value.split(':')
-  return parts.length === 2 && ['user', 'group', 'agent', 'worker'].includes(parts[0]!)
+  return parts.length === 2 && !!parts[1] && isActorIdType(parts[0])
 }
 
 /**
@@ -171,8 +205,34 @@ export interface WorkerActor extends BaseActor {
   members: { id: string; name: string; image: string | null }[]
 }
 
+/**
+ * Profile actor — a `PermissionProfile` surfaced as an additive grantee
+ * (plans/permissions/v2/19-permission-profiles.md §0.28). The ActorId uses the
+ * `profile:<profileId>` prefix.
+ *
+ * Every field here is already on the org-cached profile projection
+ * (`CachedPermissionProfile`), so resolving one costs no extra query. There is
+ * deliberately no holder count: that is a `OrganizationMember` aggregate, not
+ * cached, and no grantee surface needs it to render.
+ */
+export interface ProfileActor extends BaseActor {
+  type: 'profile'
+  /** The PermissionProfile row id. Mirrors the id half of `actorId` (`profile:<profileId>`). */
+  profileId: string
+  /** Stable per-org slug — `'member'`, `'admin'`, … for system rows. */
+  slug: string
+  /** Profile description, for the grantee row's secondary line. */
+  description: string | null
+  /** The seat class this profile is authored for (§0.17). */
+  seat: 'full' | 'worker'
+  /** Which principal kind may bind it. `'agent'` profiles are NOT valid sharing grantees. */
+  appliesTo: 'member' | 'agent' | 'any'
+  /** Seeded template row — not deletable, slug/seat/appliesTo locked. */
+  isSystem: boolean
+}
+
 /** Union type for any actor */
-export type Actor = UserActor | GroupActor | SystemActor | AgentActor | WorkerActor
+export type Actor = UserActor | GroupActor | SystemActor | AgentActor | WorkerActor | ProfileActor
 
 // ============================================================================
 // Actor Context (for services)
@@ -223,4 +283,11 @@ export function isAgentActor(actor: Actor): actor is AgentActor {
  */
 export function isWorkerActor(actor: Actor): actor is WorkerActor {
   return actor.type === 'worker'
+}
+
+/**
+ * Check if an actor is a permission-profile actor.
+ */
+export function isProfileActor(actor: Actor): actor is ProfileActor {
+  return actor.type === 'profile'
 }

--- a/packages/types/groups/index.ts
+++ b/packages/types/groups/index.ts
@@ -4,8 +4,8 @@ import type { Database } from '@auxx/database'
 import type {
   GroupVisibility,
   MemberType,
+  ResourceGranteeType,
   ResourcePermission,
-  SharingGranteeType,
 } from '@auxx/database/enums'
 import type { EntityInstanceEntity } from '@auxx/database/types'
 
@@ -79,8 +79,12 @@ export interface GroupMember {
 /** Permission grant input */
 export interface GrantPermissionInput {
   groupId: string
-  /** Sharing vocabulary only — `'profile'` grants are gated until plan 19 step 9. */
-  granteeType: SharingGranteeType
+  /**
+   * Full grantee vocabulary. A group ACL is a `ResourceAccess` INSTANCE grant on
+   * the `entity_group` def, so doc 19 §0.28's "profile selectable as an additive
+   * grantee" applies here too (plan 19 step 9).
+   */
+  granteeType: ResourceGranteeType
   granteeId: string
   permission: ResourcePermission
 }
@@ -88,8 +92,8 @@ export interface GrantPermissionInput {
 /** Permission info returned from queries */
 export interface GroupPermissionInfo {
   id: string
-  /** Sharing vocabulary only — `'profile'` grants are gated until plan 19 step 9. */
-  granteeType: SharingGranteeType
+  /** Full grantee vocabulary — reads mirror whatever `ResourceAccess` stores. */
+  granteeType: ResourceGranteeType
   granteeId: string
   permission: ResourcePermission
   createdAt: Date


### PR DESCRIPTION
Continues capability-layer v2 permission profiles (plan doc 19). Covers **steps 4, 6 and 9**, plus part of step 5. Steps 1–3 shipped in #1332.

## Step 4 — definition enforcement (§3)

`ceiling.defs` was stored, parsed and plumbed but never enforced. It now is.

The ceiling stays **slug-keyed** in the cached blob and is resolved to entity-definition ids at the `get-capabilities` seam, off the already-loaded `resources` map — the same precedent `defBaseOverrides` follows. Because that map is already invalidated by entity-def lifecycle events, **no `userCapabilities` invalidation edge was needed**, contrary to §8.3's last bullet. Adding one would flush every member's blob on every def edit for no correctness gain.

One predicate (`ceilingAllowsDef`) is applied at **all four** seams — `effectiveRecordLevel`, the worker `recordsViewLinked` carve-out, `canAdministerRecord`, `administersAnyDef`. §3 is explicit that a clamp at one seam alone is walked around by the others; the worker carve-out in particular returns `true` for any unrestricted def without ever calling `effectiveRecordLevel`. `canAdministerRecord` no longer reads raw `defAccess`.

**The agent half needed no work.** #1332 already gave agents a separate `AgentPolicyCapabilities` view that never enters `entity-access.ts`, so §3's pseudocode branch on `principalType === 'agent'` was deliberately not built — adding it would have regressed the shipped design.

## Step 5 (partial) — agent tool assertions

Adds the `AgentToolPermission` declaration slot that 19b calls step 5's most durable deliverable, since its absence is *why* the gaps drifted unnoticed. Declared on all 62 registry tools (48 enforced / 9 known-gap / 5 no-target) and pinned by a test that fails **both** when a new gap appears **and** when a fixed one isn't delisted.

Closes three gaps:
- **G4** `list_entity_fields` disclosed any def's full field schema with no check. It also named every org apiSlug in its not-found error, so the obvious one-line fix would still have leaked — that list is filtered too, and a denied def now reads identically to a nonexistent one.
- **G6** `preview_table_view` was a record-count oracle on a restricted def; now at parity with its create/update siblings.
- **G3** four record-adjacent reads (`list_notes`, `list_field_changes`, `list_transcripts_for_entity`, `get_transcript`) ran raw org-scoped SQL around `effectiveRecordLevel`.

G0/G2/G5/G7 are **behaviorally untouched** — they need product decisions — but are now greppable data rather than prose in a plan doc.

## Step 6 — governance (§6)

The escalation guard, per §6.1's spec:
- `computeEffectiveStatesUncached` — **cache-bypassing**, feeding the existing pure composer. Composing post-write state through the org cache would compare before-state to before-state and pass everything, so this is proven by mutation: swapping in the naive cached read makes three tests fail, including the always-passes-vacuously case.
- `assertNoEscalation` — delta-gated, so decreases are always allowed and a holder already above the actor doesn't block unrelated edits.
- Batched: 6 `tx` queries, constant in holder count.
- `updatePermissionProfile` **removed** in favour of one atomic `savePermissionProfile`, so no metadata-only side door can skip the check.

Also fixes a live defect: the §6.1.3 null-bound holder sweep was short-circuited off (`if (false && ...)`). That's the majority branch after step 2's migration — with it disabled, editing the Member profile returned an empty affected set and the guard was vacuous.

`permissions` stops being `adminOnly` **and** its router moves off `adminProcedure`. Without that second half the area flag would have been a lever that does nothing.

## Step 9 — profile grantee sweep (§8.2)

All 59 sites from `19a`, plus a 60th it missed: ACTOR **field values** carry their own copy of the actor vocabulary. Deliberately **not** widened — a profile has no `User` row for `actorId`, so it would read back as a group.

The motivating hazard: the restricted-set providers are grantee-agnostic while the readers were not, so a single profile row made a definition **go dark for every non-admin in the org**. The `ResourceAccess` grantee union now lives in one place and resolves the profile half through the same `resolveBaseProfile` the composer uses, so reader and writer cannot disagree. The profile-grantee write guard from #1332 was removed **last**, after every reader was taught.

`packages/types/actor` is single-sourced (`ACTOR_ID_TYPES`) with a non-throwing `safeParseActorId` for render paths. `parseActorId` still throws by design at its 109 call sites, where a malformed id is a real bug.

## Known limitations, deliberate

- **Profile grantees display by kind, not by name, and no picker offers one.** That needs an `actor-service.ts` profile branch and a client-reachable profiles listing — both belong to step 7. Shipping a picker now would mean unpickable entries reading "Unknown".
- `ceiling.defs` has no authoring surface yet (step 7) and validation is hand-rolled, not zod.
- A `ceiling.defs` entry naming a mail-infra slug is inert — `canViewEntity` short-circuits `NON_RECORD_DEF_SLUGS` before the resolver. Pre-existing; step 7's editor must not offer those slugs.
- `AreaMetadata.roleGated` is restored as an optional field (its UI consumers were already in the tree) but no area sets it. Step 10 populates it.

## Verification

- `src/permissions src/members src/cache src/data-migrations src/resource-access src/agents src/snippets src/dashboards src/actors` → **772 passed / 64 files**, zero failures (605/52 before this work).
- `src/ai` → **922 passed / 35 failed**. Those 35 are **pre-existing and unrelated** — live DeepSeek/OpenAI integration tests that need API keys, plus the Drizzle-proxy-columns gotcha under the default config. They fail identically on `main`.
- No new typecheck errors in any touched file, verified by grep against the pre-existing ~2.6k lib / ~3.5k web baselines.

## Sequencing

Next is **step 10 (ADMIN as a real profile) before step 8** — once steps 7–8 let an admin bind to a custom profile carrying a ceiling, that ceiling bites while admin capabilities still bypass the profile.