### PR TITLE
feat(permissions): agent policy persistence, profile bindings, and editor polish

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/members/_components/invite-profile-select.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/_components/invite-profile-select.tsx
@@ -100,17 +100,15 @@ export function InviteProfileSelect({
       </SelectTrigger>
       <SelectContent>
         {profiles.map((profile) => (
-          <SelectItem key={profile.id} value={profile.id}>
-            <span className='flex flex-col gap-0.5 text-left'>
-              <span className='flex items-center gap-2'>
-                <span className='font-medium'>{profile.name}</span>
-                <span className='text-muted-foreground text-xs'>
-                  {seatClassLabel(profile.seat)}
-                </span>
-              </span>
-              {profile.description ? (
-                <span className='text-muted-foreground text-xs'>{profile.description}</span>
-              ) : null}
+          // `description` renders OUTSIDE Radix's ItemText, so it stays in the
+          // dropdown instead of being copied into the trigger.
+          <SelectItem
+            key={profile.id}
+            value={profile.id}
+            description={profile.description ?? undefined}>
+            <span className='flex items-center gap-2'>
+              <span className='font-medium'>{profile.name}</span>
+              <span className='text-muted-foreground text-xs'>{seatClassLabel(profile.seat)}</span>
             </span>
           </SelectItem>
         ))}

--- a/apps/web/src/app/(protected)/app/settings/members/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/page.tsx
@@ -70,7 +70,7 @@ export default function MembersPage() {
         button={headerButton}
         subHeaderClassName='p-0'
         subHeader={
-          <TabsList variant='outline'>
+          <TabsList variant='outline' className='border-b-0'>
             <TabsTrigger value='members' variant='outline'>
               <Users />
               Members

--- a/apps/web/src/app/(protected)/app/settings/permissions/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/permissions/page.tsx
@@ -40,7 +40,7 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
  */
 export default function PermissionsPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })
-  const [tab, setTab] = useQueryState('t', { defaultValue: 'baseline' })
+  const [tab, setTab] = useQueryState('t', { defaultValue: 'profiles' })
   const { hasAccess } = useFeatureFlags()
 
   const canEdit = hasAccess(FeatureKey.granularPermissions)
@@ -54,7 +54,7 @@ export default function PermissionsPage() {
         breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Permissions' }]}
         subHeaderClassName='p-0'
         subHeader={
-          <TabsList variant='outline'>
+          <TabsList variant='outline' className='border-b-0'>
             <TabsTrigger value='profiles' variant='outline'>
               <IdCard />
               Profiles

--- a/apps/web/src/components/agents/hooks/index.ts
+++ b/apps/web/src/components/agents/hooks/index.ts
@@ -4,7 +4,6 @@ export { useAgent } from './use-agent'
 export { useAgentMutations } from './use-agent-mutations'
 export {
   type AgentProfileOption,
-  readDraftProfileId,
   useAgentPermissionProfiles,
   useAgentProfileBinding,
 } from './use-agent-permission-profiles'

--- a/apps/web/src/components/agents/hooks/use-agent-permission-profiles.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-permission-profiles.ts
@@ -4,7 +4,7 @@
 import type { AgentPermissionPolicy } from '@auxx/database'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
-import { api, type RouterInputs, type RouterOutputs } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 
 /** Which system profile a draft with no explicit binding resolves to (§1.3). */
 const FALLBACK_SLUG_BY_KIND: Record<string, string> = {
@@ -18,23 +18,6 @@ const FALLBACK_SLUG_BY_KIND: Record<string, string> = {
  * policy comes from {@link useAgentProfilePolicy}.
  */
 export type AgentProfileOption = RouterOutputs['permissions']['listProfiles'][number]
-
-/**
- * Read the draft profile binding off an agent detail row.
- *
- * TODO(plan-19-step-8): `Agent.permissionProfileId` is written at creation
- * (`agent-service.ts`) but is **not** projected by `getAgentDetail` yet, so this
- * resolves `null` until the service adds the field — at which point the picker
- * starts reflecting the stored binding with no change here. Reading it
- * defensively (rather than typing against a field that does not exist) keeps the
- * whole tab honest in the meantime: an unbound draft is shown as running the
- * system default for its kind, which is exactly what §1.3 resolves it to.
- */
-export function readDraftProfileId(
-  agent: { id: string; permissionProfileId?: string | null } | null | undefined
-): string | null {
-  return agent?.permissionProfileId ?? null
-}
 
 interface UseAgentPermissionProfilesResult {
   /** Profiles bindable to an agent (`appliesTo: 'agent' | 'any'`), in server order. */
@@ -113,15 +96,8 @@ interface UseAgentProfileBindingResult {
 /**
  * Writes the **draft** binding `Agent.permissionProfileId` (§0.16). Draft only:
  * production keeps running the active version's immutable
- * `AgentVersion.permissionPolicy` snapshot until the agent is published.
- *
- * TODO(plan-19-step-8): `agent.update` does not accept `permissionProfileId` yet
- * (neither its zod input nor lib's `UpdateAgentInput`), and a zod object silently
- * **strips** unknown keys — so without the read-back below this hook would report
- * success while changing nothing, which is the one failure mode a permissions
- * surface must never have. The read-back turns that into an explicit error and
- * disappears on its own once the field lands: the cast is then the only line to
- * remove.
+ * `AgentVersion.permissionPolicy` snapshot until the agent is published — which
+ * is why the write also marks the draft as having unpublished changes.
  */
 export function useAgentProfileBinding(): UseAgentProfileBindingResult {
   const utils = api.useUtils()
@@ -130,25 +106,7 @@ export function useAgentProfileBinding(): UseAgentProfileBindingResult {
   const setProfile = useCallback(
     async (agentId: string, profileId: string, options?: { silent?: boolean }) => {
       try {
-        await updateAgent.mutateAsync({
-          agentId,
-          permissionProfileId: profileId,
-        } as unknown as RouterInputs['agent']['update'])
-
-        // Read back: prove the binding actually landed before telling the user
-        // their agent's authority changed.
-        const fresh = await utils.agent.getById.fetch({ agentId })
-        if (readDraftProfileId(fresh) !== profileId) {
-          if (!options?.silent) {
-            toastError({
-              title: 'Permission profile not saved',
-              description:
-                'The server did not accept a draft profile binding for this agent, so its permissions are unchanged.',
-            })
-          }
-          return false
-        }
-
+        await updateAgent.mutateAsync({ agentId, permissionProfileId: profileId })
         await Promise.all([utils.agent.getById.invalidate(), utils.agent.list.invalidate()])
         return true
       } catch (error) {

--- a/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
@@ -32,7 +32,6 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
 import {
-  readDraftProfileId,
   useAgentPermissionProfiles,
   useAgentProfileBinding,
   useAgentProfilePolicy,
@@ -80,7 +79,7 @@ export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsS
   const canEditProfile = isAdminOrOwner
   const isDelegated = agent.runAsUserId != null
 
-  const boundProfileId = readDraftProfileId(agent)
+  const boundProfileId = agent.permissionProfileId
   // An unbound draft is not unrestricted — §1.3 resolves it to the system
   // profile for its kind (`internal → agent`, `chat → chat_agent`), so that is
   // the policy the tab must show.

--- a/apps/web/src/components/members/hooks/use-member-profiles.ts
+++ b/apps/web/src/components/members/hooks/use-member-profiles.ts
@@ -267,8 +267,8 @@ export function useMemberProfiles() {
             disabled: true,
             reason:
               profile.seat === 'worker'
-                ? 'Field-seat profile — this member holds a full seat. Change the seat first.'
-                : 'Full-seat profile — this member holds a field seat. Change the seat first.',
+                ? 'Field-seat profile. This member holds a full seat. Change the seat first.'
+                : 'Full-seat profile. This member holds a field seat. Change the seat first.',
           }
         }
         // `seatType='worker' ⇒ role='USER'`: a field-seat profile never binds to

--- a/apps/web/src/components/members/ui/apply-profile-dialog.tsx
+++ b/apps/web/src/components/members/ui/apply-profile-dialog.tsx
@@ -93,7 +93,7 @@ export function ApplyProfileDialog({
             <span>
               The selection mixes full seats and field seats. A profile declares its seat class and
               applying one can never move a member between classes, so select members that share a
-              seat — or change a seat first from the row menu.
+              seat, or change a seat first from the row menu.
             </span>
           </div>
         ) : (

--- a/apps/web/src/components/members/ui/member-access-section.tsx
+++ b/apps/web/src/components/members/ui/member-access-section.tsx
@@ -153,7 +153,7 @@ export function MemberAccessSection({ member, viewerRole, viewerId }: MemberAcce
                       disabled={seatBlocksPromotion}
                       description={
                         seatBlocksPromotion
-                          ? 'Field seats are always Members — change the seat first.'
+                          ? 'Field seats are always Members. Change the seat first.'
                           : undefined
                       }>
                       Owner
@@ -164,7 +164,7 @@ export function MemberAccessSection({ member, viewerRole, viewerId }: MemberAcce
                     disabled={seatBlocksPromotion}
                     description={
                       seatBlocksPromotion
-                        ? 'Field seats are always Members — change the seat first.'
+                        ? 'Field seats are always Members. Change the seat first.'
                         : undefined
                     }>
                     Admin

--- a/apps/web/src/components/members/ui/member-profile-badge.tsx
+++ b/apps/web/src/components/members/ui/member-profile-badge.tsx
@@ -32,7 +32,7 @@ interface MemberProfileBadgeProps {
 export function MemberProfileBadge({ profile, seatType, className }: MemberProfileBadgeProps) {
   const fieldSeat =
     seatType === 'worker' ? (
-      <Tooltip content='Billed as a field seat — schedule and assigned jobs only.'>
+      <Tooltip content='Billed as a field seat: schedule and assigned jobs only.'>
         <Badge variant='amber' size='xs' className='gap-1'>
           <HardHat />
           <span>{seatLabel(seatType)}</span>
@@ -47,7 +47,7 @@ export function MemberProfileBadge({ profile, seatType, className }: MemberProfi
       <Tooltip
         content={
           profile.description ??
-          `${profile.name} — the access this member composes from (${seatLabel(profile.seat)}).`
+          `${profile.name}: the access this member composes from (${seatLabel(profile.seat)}).`
         }>
         <Badge variant='secondary' size='xs' className={cn('gap-1', className)}>
           {profile.icon?.iconId ? (

--- a/apps/web/src/components/members/ui/members-tab.tsx
+++ b/apps/web/src/components/members/ui/members-tab.tsx
@@ -176,7 +176,7 @@ function MembersTabInner() {
       const confirmed = await confirm({
         title: 'Switch to a field seat?',
         description:
-          'This limits the member to their schedule and assigned jobs — they lose access to tickets, records and other areas. You can switch them back to a full member later.',
+          'This limits the member to their schedule and assigned jobs. They lose access to tickets, records and other areas. You can switch them back to a full member later.',
         confirmText: 'Switch to field seat',
         cancelText: 'Cancel',
         destructive: true,
@@ -420,9 +420,9 @@ function MembersTabInner() {
                 </SelectContent>
               </Select>
               {selectedMember?.seatType === 'worker' ? (
-                <Tooltip content='Field seats are always members — change to Full member first.'>
+                <Tooltip content='Field seats are always members. Change to Full member first.'>
                   <p className='text-xs text-muted-foreground'>
-                    Field seats are always members — change to Full member first to promote.
+                    Field seats are always members. Change to Full member first to promote.
                   </p>
                 </Tooltip>
               ) : (
@@ -484,7 +484,7 @@ function MembersTabInner() {
                 {selectedMember?.user.name || 'This member'} is on the {selectedMemberProfile?.name}{' '}
                 profile, which is a {seatLabel(selectedMemberProfile?.seat ?? 'full')} profile.
                 After the seat change you will need to pick a {seatLabel(newSeatType)} profile for
-                them — a profile can never carry a member across seat classes.
+                them. A profile can never carry a member across seat classes.
               </p>
             )}
           </div>

--- a/apps/web/src/components/members/ui/profile-change-delta.tsx
+++ b/apps/web/src/components/members/ui/profile-change-delta.tsx
@@ -50,7 +50,7 @@ export function ProfileChangeDelta({
     <div className={cn('flex flex-col gap-3 rounded-xl border bg-muted/30 p-3', className)}>
       <p className='text-xs text-muted-foreground'>
         {from?.name ?? 'Current profile'} <ArrowRight className='inline size-3' />{' '}
-        <span className='font-medium text-foreground'>{to?.name ?? 'New profile'}</span> — this is
+        <span className='font-medium text-foreground'>{to?.name ?? 'New profile'}</span>. This is
         the member's effective access after the change, including their team and personal grants.
       </p>
 

--- a/apps/web/src/components/permissions/ui/agent-policy-areas-grid.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-areas-grid.tsx
@@ -79,7 +79,7 @@ function inertNoteFor(meta: AreaMetadata, level: AgentAccessLevel): string | und
     if (rung.level <= target) actual = rung.level
   }
   if (actual === target) return undefined
-  return `${meta.label} has no ${AGENT_LEVEL_LABELS[level]} rung — this behaves as ${AGENT_LEVEL_LABELS[agentLevelOfAreaLevel(actual)]}.`
+  return `${meta.label} has no ${AGENT_LEVEL_LABELS[level]} rung, so this behaves as ${AGENT_LEVEL_LABELS[agentLevelOfAreaLevel(actual)]}.`
 }
 
 /**
@@ -124,7 +124,7 @@ export function AgentPolicyAreasGrid({
     <div className='flex flex-col gap-3'>
       <AgentPolicyDefaultRow
         title='Default for every area'
-        description='What an area with no rule below resolves to — including areas added in a future release.'
+        description='What an area with no rule below resolves to, including areas added in a future release.'
         value={policy.areas.default}
         onChange={onDefaultChange}
         disabled={disabled}
@@ -167,7 +167,7 @@ export function AgentPolicyAreasGrid({
                     title={meta.label}
                     description={
                       meta.adminOnly
-                        ? `${meta.description} Admin-only for people — an agent may still hold it, but a non-admin publishing this profile has it clamped to their own access.`
+                        ? `${meta.description} Admin-only for people. An agent may still hold it, but a non-admin publishing this profile has it clamped to their own access.`
                         : meta.description
                     }
                     trailing={

--- a/apps/web/src/components/permissions/ui/agent-policy-copy.ts
+++ b/apps/web/src/components/permissions/ui/agent-policy-copy.ts
@@ -40,7 +40,7 @@ export const AGENT_LEVEL_RANK: Record<AgentAccessLevel, number> = {
  * for an absent value.
  */
 export const AGENT_LEVEL_DESCRIPTIONS: Record<AgentAccessLevel, string> = {
-  none: 'No access. A deliberate deny — not an absent value, and nothing raises it back.',
+  none: 'No access. A deliberate deny, not an absent value, and nothing raises it back.',
   read: 'View, list and search.',
   read_write: 'Read, plus create, update and delete.',
   full: 'Read + Write, plus administration and settings.',
@@ -50,7 +50,7 @@ export const AGENT_LEVEL_DESCRIPTIONS: Record<AgentAccessLevel, string> = {
 export const POLICY_INTRO = {
   title: 'This policy is exact',
   body:
-    'Every area, record type and resource resolves to exactly one of four levels — there is no ' +
+    'Every area, record type and resource resolves to exactly one of four levels. There is no ' +
     '"not set" at run time. A rule you leave alone follows the collection default shown above ' +
     'it, and that default is itself one of the four levels, so anything created later has a ' +
     'deterministic posture too.',
@@ -66,7 +66,7 @@ export const TOOLS_VS_PERMISSIONS = {
   body:
     'Permissions decide what an agent is allowed to reach. Tools decide what it can call. ' +
     'Neither implies the other: granting Full here enables no tool, and enabling a tool grants ' +
-    'no permission. What the agent can actually do is the intersection — a tool it holds, ' +
+    'no permission. What the agent can actually do is the intersection: a tool it holds, ' +
     'pointed at a target this policy allows.',
   link: 'Tools live on the agent’s Tools tab.',
 } as const
@@ -79,18 +79,18 @@ export const TOOLS_VS_PERMISSIONS = {
  */
 export const DEFINITION_FULL_IS_INERT =
   'Full adds definition administration on top of Read + Write. No native agent tool creates or ' +
-  'alters entity definitions or fields today, and none checks the administration rung at all — ' +
+  'alters entity definitions or fields today, and none checks the administration rung at all, ' +
   'so on this grid Full currently behaves like Read + Write. It is stored exactly as you set it ' +
   'and starts biting the day such a tool ships.'
 
 /** §11a — mail is outside the four-level model; the areas grid must not imply otherwise. */
 export const MAIL_IS_OUTSIDE =
   'Mail is outside this model. There is no mail area, and mail tools are authorized by the ' +
-  'mailbox the agent is given — this grid neither opens nor closes them.'
+  'mailbox the agent is given. This grid neither opens nor closes them.'
 
 /** Why threads/inboxes/datasets/KBs/dashboards are absent from the definitions grid. */
 export const DEFINITIONS_EXCLUSIONS =
-  'Threads, inboxes, messages and other mail records are not listed — they are not governed by ' +
+  'Threads, inboxes, messages and other mail records are not listed. They are not governed by ' +
   'this keyspace. Datasets, knowledge bases and dashboards have their own grid below.'
 
 /** The resources grid's intersection rule — an instance rule can never beat its area. */
@@ -100,7 +100,7 @@ export const RESOURCE_AREA_CLAMP =
 
 /** Publication semantics (§0.3/§0.16) — shown whether or not there are pending edits. */
 export const PUBLICATION_NOTE =
-  'Saving reaches bound agent drafts only — their builder Chat and draft evals. Live agents keep ' +
+  'Saving reaches bound agent drafts only: their builder Chat and draft evals. Live agents keep ' +
   'the policy they were published with until someone republishes them.'
 
 /** The state after a save, before a republish. */
@@ -121,17 +121,17 @@ export const PLAN_GATED_NOTE =
 
 /** A profile that has never carried an agent policy. Fail-closed is the safe start. */
 export const NO_POLICY_YET =
-  'This profile carries no agent policy yet. It starts fail-closed — None everywhere — and is ' +
+  'This profile carries no agent policy yet. It starts fail-closed at None everywhere, and is ' +
   'written the first time you save.'
 
 /**
  * §2.4a — the author clamp, in the exact shape the plan requires: name the key,
  * both rungs, and the authority that bounded it. Never a silent downgrade.
  *
- * @example clampSentence('Deals', 'full', 'read') // 'Deals reduced from Full to Read — you hold Read'
+ * @example clampSentence('Deals', 'full', 'read') // 'Deals reduced from Full to Read (you hold Read)'
  */
 export function clampSentence(label: string, from: AgentAccessLevel, to: AgentAccessLevel): string {
-  return `${label} reduced from ${AGENT_LEVEL_LABELS[from]} to ${AGENT_LEVEL_LABELS[to]} — you hold ${AGENT_LEVEL_LABELS[to]}`
+  return `${label} reduced from ${AGENT_LEVEL_LABELS[from]} to ${AGENT_LEVEL_LABELS[to]} (you hold ${AGENT_LEVEL_LABELS[to]})`
 }
 
 /** Heading for the clamp preview block. */
@@ -139,10 +139,10 @@ export const CLAMP_PREVIEW = {
   title: 'Publishing would reduce this policy',
   body:
     'A published agent can never exceed the person who published it. These rules would be lowered ' +
-    'to your own access at publish time — the agent would run with the reduced rung, and the ' +
+    'to your own access at publish time. The agent would run with the reduced rung, and the ' +
     'reduction is recorded on the published version. An owner or admin publishing the same ' +
     'profile may keep more of it.',
-  clear: 'You hold everything this policy asks for — publishing it would reduce nothing.',
+  clear: 'You hold everything this policy asks for, so publishing it would reduce nothing.',
 } as const
 
 /** Tooltip on the "follow the default" reset affordance of an override row. */

--- a/apps/web/src/components/permissions/ui/agent-policy-definitions-grid.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-definitions-grid.tsx
@@ -72,7 +72,7 @@ export function AgentPolicyDefinitionsGrid({
     <div className='flex flex-col gap-3'>
       <AgentPolicyDefaultRow
         title='Default for every record type'
-        description='What a record type with no rule below resolves to — including types created later.'
+        description='What a record type with no rule below resolves to, including types created later.'
         value={policy.definitions.default}
         onChange={onDefaultChange}
         disabled={disabled}

--- a/apps/web/src/components/permissions/ui/agent-policy-editor.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-editor.tsx
@@ -6,7 +6,7 @@ import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
-import { Bot, Info, Library, ShieldCheck, SlidersHorizontal, Table2 } from 'lucide-react'
+import { Bot, Library, SlidersHorizontal, Table2 } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 import { useUser } from '~/hooks/use-user'
@@ -17,16 +17,7 @@ import { useAgentPolicyDefinitions } from '../hooks/use-agent-policy-definitions
 import { useAgentPolicySave } from '../hooks/use-agent-policy-save'
 import { AGENT_POLICY_AREAS, AgentPolicyAreasGrid } from './agent-policy-areas-grid'
 import { AgentPolicyClampPreview } from './agent-policy-clamp-preview'
-import {
-  ADMIN_ONLY_NOTE,
-  NO_POLICY_YET,
-  PLAN_GATED_NOTE,
-  POLICY_INTRO,
-  PUBLICATION_NOTE,
-  TOOLS_VS_PERMISSIONS,
-  UNPUBLISHED_TITLE,
-  UNSAVED_TITLE,
-} from './agent-policy-copy'
+import { UNPUBLISHED_TITLE, UNSAVED_TITLE } from './agent-policy-copy'
 import { AgentPolicyDefinitionsGrid } from './agent-policy-definitions-grid'
 import { AgentPolicyResourcesGrid } from './agent-policy-resources-grid'
 
@@ -47,8 +38,6 @@ interface AgentPolicyEditorProps {
    * of leaving the reader to guess whether a live agent just changed.
    */
   boundDrafts?: BoundAgentDraft[]
-  /** Link to the agent's Tools tab, when the editor is rendered with agent context. */
-  toolsHref?: string
   /** Force read-only regardless of the viewer's authority (e.g. a locked profile). */
   readOnly?: boolean
 }
@@ -70,12 +59,10 @@ interface AgentPolicyEditorProps {
  *    (§0.5/§2.3) — never through `GranteeDefAccessSection`.
  *  - **Every collection has a default**, so a record type or resource created
  *    tomorrow has a deterministic posture (§0.5/§2.3).
- *  - **Permissions are not tools.** Effective ability is the intersection; the
- *    explainer and the Tools cross-link are part of the feature, not decoration
- *    (§0.5a/§2.4).
+ *  - **Permissions are not tools.** Effective ability is the intersection of the
+ *    two (§0.5a/§2.4) — granting Full here enables no tool.
  *  - **Publication semantics.** A save reaches bound drafts only; production
- *    changes on publish, and the editor says so before and after every write
- *    (§0.3/§0.16).
+ *    changes on publish, and the editor says so after a write (§0.3/§0.16).
  *  - **Author clamp.** Publishing lowers the policy to the publisher's own
  *    authority; the reduction is previewed here and disclosed at publish (§2.4a).
  *  - **OWNER/ADMIN only.** Agent-side profile editing is admin-gated (doc 14
@@ -89,7 +76,6 @@ export function AgentPolicyEditor({
   profileId,
   savedPolicy,
   boundDrafts,
-  toolsHref,
   readOnly = false,
 }: AgentPolicyEditorProps) {
   const { isAdminOrOwner } = useUser()
@@ -101,7 +87,6 @@ export function AgentPolicyEditor({
     policy,
     isDirty,
     changeCount,
-    isNew,
     reset,
     setAreasDefault,
     setAreaOverride,
@@ -127,46 +112,6 @@ export function AgentPolicyEditor({
 
   return (
     <div className='flex flex-col gap-4'>
-      {!isAdminOrOwner ? (
-        <Alert className='flex gap-3'>
-          <ShieldCheck className='size-4 shrink-0' />
-          <span>{ADMIN_ONLY_NOTE}</span>
-        </Alert>
-      ) : null}
-
-      {isAdminOrOwner && !planAllowsWrites ? (
-        <Alert className='flex gap-3'>
-          <ShieldCheck className='size-4 shrink-0' />
-          <span>{PLAN_GATED_NOTE}</span>
-        </Alert>
-      ) : null}
-
-      <Alert className='flex gap-3'>
-        <Info className='size-4 shrink-0' />
-        <div className='flex min-w-0 flex-col gap-1'>
-          <span className='font-medium'>{POLICY_INTRO.title}</span>
-          <span className='opacity-90'>{POLICY_INTRO.body}</span>
-          <span className='mt-1 font-medium'>{TOOLS_VS_PERMISSIONS.title}</span>
-          <span className='opacity-90'>
-            {TOOLS_VS_PERMISSIONS.body}{' '}
-            {toolsHref ? (
-              <Link href={toolsHref} className='underline'>
-                {TOOLS_VS_PERMISSIONS.link}
-              </Link>
-            ) : (
-              TOOLS_VS_PERMISSIONS.link
-            )}
-          </span>
-        </div>
-      </Alert>
-
-      {isNew ? (
-        <Alert className='flex gap-3'>
-          <Bot className='size-4 shrink-0' />
-          <span>{NO_POLICY_YET}</span>
-        </Alert>
-      ) : null}
-
       {savedThisSession ? (
         <Alert variant='warning' className='flex gap-3'>
           <Bot className='size-4 shrink-0' />
@@ -174,8 +119,8 @@ export function AgentPolicyEditor({
             <span className='font-medium'>{UNPUBLISHED_TITLE}</span>
             <span className='opacity-90'>
               {draftCount > 0
-                ? `${draftCount} agent draft${draftCount === 1 ? '' : 's'} bound to this profile now run a policy that differs from what is published. Publish each one to move the change into production — no live agent changed when you saved.`
-                : 'Agent drafts bound to this profile now run a policy that differs from what is published. Publish each one to move the change into production — no live agent changed when you saved.'}
+                ? `${draftCount} agent draft${draftCount === 1 ? '' : 's'} bound to this profile now run a policy that differs from what is published. Publish each one to move the change into production. No live agent changed when you saved.`
+                : 'Agent drafts bound to this profile now run a policy that differs from what is published. Publish each one to move the change into production. No live agent changed when you saved.'}
             </span>
             {boundDrafts && boundDrafts.length > 0 ? (
               <ul className='mt-1 flex flex-wrap gap-x-3 gap-y-0.5'>
@@ -190,17 +135,7 @@ export function AgentPolicyEditor({
             ) : null}
           </div>
         </Alert>
-      ) : (
-        <Alert className='flex gap-3'>
-          <Bot className='size-4 shrink-0' />
-          <span>
-            {PUBLICATION_NOTE}
-            {draftCount > 0
-              ? ` Bound right now: ${boundDrafts?.map((d) => d.name).join(', ')}.`
-              : ''}
-          </span>
-        </Alert>
-      )}
+      ) : null}
 
       <AgentPolicyClampPreview entries={clampEntries} />
 
@@ -235,7 +170,7 @@ export function AgentPolicyEditor({
       <Section
         title='Resources'
         icon={<Library className='size-4' />}
-        description='Datasets, knowledge bases and dashboards — per type, and per item.'
+        description='Datasets, knowledge bases and dashboards, per type and per item.'
         initialOpen>
         <AgentPolicyResourcesGrid
           policy={policy}
@@ -252,8 +187,7 @@ export function AgentPolicyEditor({
           <span className='text-sm'>
             <span className='font-medium'>{UNSAVED_TITLE}</span>
             <span className='text-muted-foreground'>
-              {' '}
-              — {changeCount} rule{changeCount === 1 ? '' : 's'} differ from the saved policy.
+              : {changeCount} rule{changeCount === 1 ? '' : 's'} differ from the saved policy.
             </span>
           </span>
           <div className='flex items-center gap-2'>

--- a/apps/web/src/components/permissions/ui/agent-policy-resources-grid.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-resources-grid.tsx
@@ -82,7 +82,7 @@ export function AgentPolicyResourcesGrid({
     if (overrideCount > 0) {
       const confirmed = await confirm({
         title: `Follow the resource default for ${TYPE_META[type].label.toLowerCase()}?`,
-        description: `This removes the ${overrideCount} per-item rule${overrideCount === 1 ? '' : 's'} on this type as well — the shape has nowhere to keep them once the type follows the default.`,
+        description: `This removes the ${overrideCount} per-item rule${overrideCount === 1 ? '' : 's'} on this type as well. The shape has nowhere to keep them once the type follows the default.`,
         confirmText: 'Remove rules',
         cancelText: 'Cancel',
         destructive: true,
@@ -98,7 +98,7 @@ export function AgentPolicyResourcesGrid({
 
       <AgentPolicyDefaultRow
         title='Default for every resource'
-        description='What a resource type with no rule of its own resolves to — including types added later.'
+        description='What a resource type with no rule of its own resolves to, including types added later.'
         value={policy.resourceDefault}
         onChange={onDefaultChange}
         disabled={disabled}
@@ -142,7 +142,7 @@ export function AgentPolicyResourcesGrid({
                   label={TYPE_META[type].label}
                   value={entry?.default}
                   fallback={policy.resourceDefault}
-                  resetTooltip={`Follow the resource default (${AGENT_LEVEL_LABELS[policy.resourceDefault]}) — removes this type's per-item rules`}
+                  resetTooltip={`Follow the resource default (${AGENT_LEVEL_LABELS[policy.resourceDefault]}), removing this type's per-item rules`}
                   onChange={(level) => void handleTypeChange(type, level)}
                   disabled={disabled}
                 />
@@ -157,7 +157,7 @@ export function AgentPolicyResourcesGrid({
                   orientation='horizontal'
                   icon={<Library />}
                   title={`No ${TYPE_META[type].label.toLowerCase()}`}
-                  description={`Nothing to rule on yet — anything created later resolves to ${AGENT_LEVEL_LABELS[typeLevel]}.`}
+                  description={`Nothing to rule on yet. Anything created later resolves to ${AGENT_LEVEL_LABELS[typeLevel]}.`}
                 />
               ) : (
                 <div className='flex flex-col gap-0.5'>
@@ -201,7 +201,7 @@ export function AgentPolicyResourcesGrid({
                   ))}
                   {list.truncated ? (
                     <p className='px-1 py-1 text-xs text-muted-foreground'>
-                      Showing the first page only — rule on anything not listed here from that
+                      Showing the first page only. Rule on anything not listed here from that
                       resource’s own page.
                     </p>
                   ) : null}

--- a/apps/web/src/components/permissions/ui/def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/def-access-section.tsx
@@ -444,7 +444,7 @@ function GranteeRow({
               load-bearing one. */}
           {ignored && (
             <Tooltip
-              content={`Ignored — this grant is at or below the workspace baseline (${baselineLevel}).`}>
+              content={`Ignored: this grant is at or below the workspace baseline (${baselineLevel}).`}>
               <AlertTriangle className='size-4 text-amber-500' />
             </Tooltip>
           )}

--- a/apps/web/src/components/permissions/ui/def-baseline-rows.tsx
+++ b/apps/web/src/components/permissions/ui/def-baseline-rows.tsx
@@ -74,7 +74,7 @@ export function DefBaselineRows({
           title={<span className='truncate'>{row.resource.plural}</span>}
           secondary={
             row.isLockedDown ? (
-              <Tooltip content='Restricted: hidden from everyone by default — only members you grant access (directly or via a team) can see this type.'>
+              <Tooltip content='Restricted: hidden from everyone by default. Only members you grant access (directly or via a team) can see this type.'>
                 <Lock className='size-3 text-muted-foreground' />
               </Tooltip>
             ) : undefined

--- a/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
@@ -37,7 +37,7 @@ const COPY: Record<GranteeKind, { description: string }> = {
  * lowered above, or the type itself is restricted workspace-wide.
  */
 const AGENT_DESCRIPTION =
-  'Access to individual record types. Each row shows what this agent gets by default — pick a level to override it for that type.'
+  'Access to individual record types. Each row shows what this agent gets by default. Pick a level to override it for that type.'
 
 /** Neutral copy for a grantee kind this section does not model (e.g. `profile`). */
 const FALLBACK_DESCRIPTION =
@@ -182,7 +182,7 @@ function DefAccessRow({
       title={<span className='truncate'>{resource.plural}</span>}
       secondary={
         isLockedDown ? (
-          <Tooltip content='Restricted: hidden from everyone by default — only members you grant access (directly or via a team) can see this type.'>
+          <Tooltip content='Restricted: hidden from everyone by default. Only members you grant access (directly or via a team) can see this type.'>
             <Lock className='size-3 text-muted-foreground' />
           </Tooltip>
         ) : undefined

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
@@ -38,7 +38,7 @@ function descriptionFor(granteeKind: string): string {
  * inheritance — so the surface is a restriction editor, not an elevation one.
  */
 const AGENT_DESCRIPTION =
-  'What this agent can reach when it runs. An area you leave on Default gives the agent full access — set a lower level (or None) to restrict it.'
+  'What this agent can reach when it runs. An area you leave on Default gives the agent full access. Set a lower level (or None) to restrict it.'
 
 /**
  * The Layer-2 (per-area None/Read/Edit/Full) override editor for a single grantee

--- a/apps/web/src/components/permissions/ui/instance-share-card.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-card.tsx
@@ -188,7 +188,7 @@ export function InstanceShareCard({ recordId }: { recordId: RecordId }) {
       <p className='text-muted-foreground text-xs'>
         {restricted ? (
           <>
-            This {copy.noun} is <span className='font-medium'>restricted</span> — only the people
+            This {copy.noun} is <span className='font-medium'>restricted</span>. Only the people
             below and admins can access it.
           </>
         ) : (

--- a/apps/web/src/components/permissions/ui/instance-share-copy.ts
+++ b/apps/web/src/components/permissions/ui/instance-share-copy.ts
@@ -42,7 +42,7 @@ export const INSTANCE_SHARE_COPY: Record<InstanceAccessKey, InstanceShareCopy> =
   },
   dashboard: {
     noun: 'dashboard',
-    baselineHint: 'Shared with the workspace by default — restrict it to make it private.',
+    baselineHint: 'Shared with the workspace by default. Restrict it to make it private.',
     levels: {
       read: 'View',
       write: 'Edit widgets & layout',

--- a/apps/web/src/components/permissions/ui/level-control.tsx
+++ b/apps/web/src/components/permissions/ui/level-control.tsx
@@ -75,7 +75,7 @@ export function LevelControl({
 
   return (
     <div className='flex items-center gap-1'>
-      <Tooltip content='This override is ignored — the member baseline already grants this level of access.'>
+      <Tooltip content='This override is ignored. The member baseline already grants this level of access.'>
         <AlertTriangle
           className={cn('size-3.5 text-amber-500', !ignored && 'invisible')}
           aria-hidden={!ignored}

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -69,7 +69,7 @@ interface LeveledAreaGridProps {
 }
 
 /** The §5.3 wording for an area whose routers are still a binary admin gate. */
-const ROLE_GATED_NOTE = 'Still role-gated — admins reach this regardless.'
+const ROLE_GATED_NOTE = 'Still role-gated. Admins reach this regardless.'
 
 /**
  * Grantable areas, grouped by registry `group` in area order. Excludes
@@ -219,7 +219,7 @@ export function LeveledAreaGrid({
                         ignored={mode === 'override' && value !== undefined && value <= inherited}
                         unsetHint={mode === 'agent' ? 'Default' : undefined}
                         resetTooltip={
-                          mode === 'agent' ? 'Clear — back to full access' : 'Reset to inherited'
+                          mode === 'agent' ? 'Clear (back to full access)' : 'Reset to inherited'
                         }
                         onChange={(level) => onChange(area, level)}
                         disabled={disabled || meta.roleGated === true}

--- a/apps/web/src/components/permissions/ui/profile-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/profile-area-grid.tsx
@@ -185,7 +185,7 @@ function ProfileAreaRow({
           value={value}
           inherited={inherited}
           unsetHint={unsetHint}
-          resetTooltip='Clear — back to the default'
+          resetTooltip='Clear (back to the default)'
           onChange={onChange}
           disabled={disabled || lockReason !== null}
         />

--- a/apps/web/src/components/permissions/ui/profile-copy.ts
+++ b/apps/web/src/components/permissions/ui/profile-copy.ts
@@ -57,10 +57,10 @@ export const WORKER_SEAT_AREAS: ReadonlySet<Area> = new Set<Area>([
 
 /** Locked-row reason for an area a field seat can never reach. */
 export const WORKER_LOCK_REASON =
-  'Field seats can never reach this area — the seat ceiling clamps it to None, whatever this profile says.'
+  'Field seats can never reach this area. The seat ceiling clamps it to None, whatever this profile says.'
 
 /** The §5.3 wording for an area whose routers are still a binary admin gate. */
-export const ROLE_GATED_REASON = 'Still role-gated — admins reach this regardless.'
+export const ROLE_GATED_REASON = 'Still role-gated. Admins reach this regardless.'
 
 /**
  * Grantable areas grouped by registry group, in area order — the same selection

--- a/apps/web/src/components/permissions/ui/profile-create-dialog.tsx
+++ b/apps/web/src/components/permissions/ui/profile-create-dialog.tsx
@@ -121,7 +121,7 @@ export function ProfileCreateDialog({
         <DialogHeader>
           <DialogTitle>{cloneFrom ? 'Duplicate profile' : 'New permission profile'}</DialogTitle>
           <DialogDescription>
-            Seat class and principal type are fixed once the profile exists — pick them now.
+            Seat class and principal type are fixed once the profile exists, so pick them now.
             Everything else is editable afterwards.
           </DialogDescription>
         </DialogHeader>
@@ -171,8 +171,7 @@ export function ProfileCreateDialog({
             <RadioGroup
               value={appliesTo}
               onValueChange={(value) => setAppliesTo(value as ProfileAppliesTo)}
-              disabled={isPending || !!cloneFrom}
-              className='grid gap-2 sm:grid-cols-2'>
+              disabled={isPending || !!cloneFrom}>
               <RadioGroupItemCard
                 value='member'
                 icon={<Users />}

--- a/apps/web/src/components/permissions/ui/profile-editor.tsx
+++ b/apps/web/src/components/permissions/ui/profile-editor.tsx
@@ -82,50 +82,42 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
   }
 
   return (
-    <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
+    <div className='flex flex-1 flex-col'>
       <ConfirmDialog />
 
-      <div className='flex flex-wrap items-start justify-between gap-3'>
-        <div className='flex items-start gap-3'>
-          <Button variant='ghost' size='icon-sm' aria-label='Back to profiles' onClick={onBack}>
-            <ChevronLeft />
-          </Button>
-          <EntityIcon
-            iconId={icon.iconId}
-            color={icon.color}
-            className='size-9! rounded-md border'
-          />
-          <div className='space-y-1'>
-            <div className='flex flex-wrap items-center gap-2'>
-              <span className='text-base font-semibold'>{draft.name || profile.name}</span>
-              <Badge variant='secondary' size='xs'>
-                {APPLIES_TO_COPY[profile.appliesTo as ProfileAppliesTo].label}
-              </Badge>
-              <SeatTypeBadge seatType={profile.seat} showFull />
-              {profile.isSystem && (
-                <Badge variant='secondary' size='xs'>
-                  System
-                </Badge>
-              )}
-            </div>
-            <p className='text-sm text-muted-foreground'>
-              {APPLIES_TO_COPY[profile.appliesTo as ProfileAppliesTo].description}
-            </p>
-          </div>
-        </div>
+      <div className='flex h-9 shrink-0 items-center gap-2 border-b bg-primary-150 px-2'>
+        <Button
+          variant='ghost'
+          size='icon-xs'
+          className='rounded-md'
+          aria-label='Back to profiles'
+          onClick={onBack}>
+          <ChevronLeft />
+        </Button>
+        <EntityIcon iconId={icon.iconId} color={icon.color} size='sm' className='shrink-0' />
+        <span className='truncate text-sm font-medium'>{draft.name || profile.name}</span>
+        <Badge variant='secondary' size='xs' className='shrink-0'>
+          {APPLIES_TO_COPY[profile.appliesTo as ProfileAppliesTo].label}
+        </Badge>
+        <SeatTypeBadge seatType={profile.seat} showFull />
+        {profile.isSystem && (
+          <Badge variant='secondary' size='xs' className='shrink-0'>
+            System
+          </Badge>
+        )}
 
-        <div className='flex items-center gap-2'>
+        <div className='ml-auto flex shrink-0 items-center gap-2'>
           {isDirty && (
             <Badge variant='secondary' size='xs' className='border-amber-300 text-amber-600'>
               Unsaved changes
             </Badge>
           )}
-          <Button variant='ghost' size='sm' onClick={handleDiscard} disabled={!isDirty || isSaving}>
+          <Button variant='ghost' size='xs' onClick={handleDiscard} disabled={!isDirty || isSaving}>
             Discard
           </Button>
           <Button
             variant='outline'
-            size='sm'
+            size='xs'
             loading={isSaving}
             loadingText='Saving...'
             // Never savable mid-hydration: the payload carries the WHOLE profile
@@ -138,67 +130,69 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
         </div>
       </div>
 
-      {isOwner && (
-        <div className='rounded-xl border border-dashed p-4 text-sm text-muted-foreground'>
-          The Owner profile is fixed. Owners bypass every permission check by design — that bypass
-          is what guarantees a mis-shaped profile can always be repaired, so this profile carries no
-          levels of its own.
-        </div>
-      )}
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
+        {isOwner && (
+          <div className='rounded-xl border border-dashed p-4 text-sm text-muted-foreground'>
+            The Owner profile is fixed. Owners bypass every permission check by design. That bypass
+            is what guarantees a mis-shaped profile can always be repaired, so this profile carries
+            no levels of its own.
+          </div>
+        )}
 
-      {!canEdit && !isOwner && (
-        <div className='rounded-xl border border-dashed p-4 text-sm text-muted-foreground'>
-          Profiles are read-only on your plan. Upgrade to granular permissions to edit them — the
-          system profiles below still supply everyone's access in the meantime.
-        </div>
-      )}
+        {!canEdit && !isOwner && (
+          <div className='rounded-xl border border-dashed p-4 text-sm text-muted-foreground'>
+            Profiles are read-only on your plan. Upgrade to granular permissions to edit them. The
+            system profiles below still supply everyone's access in the meantime.
+          </div>
+        )}
 
-      <ProfileIdentitySection
-        name={draft.name}
-        description={draft.description}
-        icon={draft.icon}
-        slug={profile.slug}
-        seat={profile.seat}
-        appliesTo={profile.appliesTo as ProfileAppliesTo}
-        isSystem={profile.isSystem}
-        disabled={!editable}
-        onChange={patch}
-      />
+        <ProfileIdentitySection
+          name={draft.name}
+          description={draft.description}
+          icon={draft.icon}
+          slug={profile.slug}
+          seat={profile.seat}
+          appliesTo={profile.appliesTo as ProfileAppliesTo}
+          isSystem={profile.isSystem}
+          disabled={!editable}
+          onChange={patch}
+        />
 
-      {profile.seat === 'worker' && <ProfileSeatReference />}
+        {profile.seat === 'worker' && <ProfileSeatReference />}
 
-      {isAgentProfile ? (
-        // An agent profile has no additive base — its rules are exact (SET
-        // semantics) and live in `agentPolicy`, with their own save path. Never
-        // render the human base map for one.
-        <AgentPolicyEditor profileId={profile.id} savedPolicy={agentPolicy} readOnly={!canEdit} />
-      ) : isLoading || !roleDefaults ? (
-        <div className='space-y-2'>
-          <Skeleton className='h-16 w-full rounded-lg' />
-          <Skeleton className='h-16 w-full rounded-lg' />
-        </div>
-      ) : (
-        <SettingsSection
-          icon={SlidersHorizontal}
-          title='Base access'
-          description='Where a holder starts. Teams and personal grants can raise from here, never lower it.'
-          action={
-            <BaseLevelSelect
-              value={draft.baseLevel}
+        {isAgentProfile ? (
+          // An agent profile has no additive base — its rules are exact (SET
+          // semantics) and live in `agentPolicy`, with their own save path. Never
+          // render the human base map for one.
+          <AgentPolicyEditor profileId={profile.id} savedPolicy={agentPolicy} readOnly={!canEdit} />
+        ) : isLoading || !roleDefaults ? (
+          <div className='space-y-2'>
+            <Skeleton className='h-16 w-full rounded-lg' />
+            <Skeleton className='h-16 w-full rounded-lg' />
+          </div>
+        ) : (
+          <SettingsSection
+            icon={SlidersHorizontal}
+            title='Base access'
+            description='Where a holder starts. Teams and personal grants can raise from here, never lower it.'
+            action={
+              <BaseLevelSelect
+                value={draft.baseLevel}
+                disabled={!editable}
+                onChange={(baseLevel) => patch({ baseLevel })}
+              />
+            }>
+            <ProfileAreaGrid
+              values={draft.levels}
+              roleDefaults={roleDefaults}
+              baseLevel={draft.baseLevel}
+              seat={profile.seat}
               disabled={!editable}
-              onChange={(baseLevel) => patch({ baseLevel })}
+              onChange={setAreaLevel}
             />
-          }>
-          <ProfileAreaGrid
-            values={draft.levels}
-            roleDefaults={roleDefaults}
-            baseLevel={draft.baseLevel}
-            seat={profile.seat}
-            disabled={!editable}
-            onChange={setAreaLevel}
-          />
-        </SettingsSection>
-      )}
+          </SettingsSection>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/permissions/ui/profile-identity-section.tsx
+++ b/apps/web/src/components/permissions/ui/profile-identity-section.tsx
@@ -121,7 +121,7 @@ export function ProfileIdentitySection({
           title='Seat class'
           type={BaseType.STRING}
           showIcon
-          description='Fixed at creation. Change it by cloning this profile onto the other seat class and reassigning — assignment is never a billing event.'>
+          description='Fixed at creation. Change it by cloning this profile onto the other seat class and reassigning. Assignment is never a billing event.'>
           <ReadOnlyRow>
             <SeatTypeBadge seatType={seat} showFull />
           </ReadOnlyRow>

--- a/apps/web/src/components/permissions/ui/profile-list.tsx
+++ b/apps/web/src/components/permissions/ui/profile-list.tsx
@@ -75,7 +75,7 @@ export function ProfileList({ canEdit, onSelect }: ProfileListProps) {
           },
           { label: APPLIES_TO_COPY[profile.appliesTo].label },
           ...(profile.isSystem
-            ? [{ label: 'System', description: 'Seeded template — not deletable.' }]
+            ? [{ label: 'System', description: 'Seeded template. Not deletable.' }]
             : []),
         ])}
         menuItems={
@@ -100,7 +100,7 @@ export function ProfileList({ canEdit, onSelect }: ProfileListProps) {
       <SettingsSection
         icon={Users}
         title='People profiles'
-        description='A profile supplies the base access a member starts from. Every member resolves to one — explicitly assigned, or the system profile for their role and seat.'>
+        description='A profile supplies the base access a member starts from. Every member resolves to one: explicitly assigned, or the system profile for their role and seat.'>
         {isLoading ? (
           <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-3'>
             <ListCard loading />
@@ -128,7 +128,7 @@ export function ProfileList({ canEdit, onSelect }: ProfileListProps) {
       <SettingsSection
         icon={Bot}
         title='Agent profiles'
-        description='Agent profiles carry an exact policy — None / Read / Read + Write / Full — that is snapshotted onto the agent version at publish. Editing one changes draft agents; production changes only on the next publish.'>
+        description='Agent profiles carry an exact policy (None, Read, Read + Write, or Full) that is snapshotted onto the agent version at publish. Editing one changes draft agents; production changes only on the next publish.'>
         {agentProfiles.length === 0 ? (
           <EmptySection
             orientation='horizontal'

--- a/apps/web/src/components/permissions/ui/profile-seat-reference.tsx
+++ b/apps/web/src/components/permissions/ui/profile-seat-reference.tsx
@@ -33,7 +33,7 @@ export function ProfileSeatReference() {
         </Badge>
       </div>
       <p className='mt-1 text-sm text-muted-foreground'>
-        A field seat can only ever reach the areas below — whatever this profile, a group, or a
+        A field seat can only ever reach the areas below, whatever this profile, a group, or a
         personal override says. This clamp is applied last and is not editable here; moving someone
         off it is a seat change, not a profile change.
       </p>

--- a/apps/web/src/server/api/routers/agent.ts
+++ b/apps/web/src/server/api/routers/agent.ts
@@ -211,6 +211,14 @@ export const agentRouter = createTRPCRouter({
          * validates the target is an ACTIVE `userType:'USER'` member.
          */
         runAsUserId: z.string().nullable().optional(),
+        /**
+         * The DRAFT permission-profile binding (capability layer v2 §0.16).
+         * `null` unbinds (falls back to the system profile for the agent's
+         * kind); omit to leave unchanged. The service validates the profile is
+         * in this org and admits agents. Production is unaffected until the
+         * agent is published.
+         */
+        permissionProfileId: z.string().nullable().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -240,6 +248,9 @@ export const agentRouter = createTRPCRouter({
       if (patch.archivedAt !== undefined) updatePayload.archivedAt = patch.archivedAt
       if (patch.appAccounts !== undefined) updatePayload.appAccounts = patch.appAccounts
       if (patch.runAsUserId !== undefined) updatePayload.runAsUserId = patch.runAsUserId
+      if (patch.permissionProfileId !== undefined) {
+        updatePayload.permissionProfileId = patch.permissionProfileId
+      }
 
       // Exclude the writer's own socket from the `agent:updated` broadcast so
       // the persona editor's autosave doesn't echo back and remount over the

--- a/apps/web/src/server/api/routers/permissions.ts
+++ b/apps/web/src/server/api/routers/permissions.ts
@@ -1,6 +1,7 @@
 // apps/web/src/server/api/routers/permissions.ts
 
 import {
+  type AgentPermissionPolicy,
   type Area,
   clearGranteeLevels,
   createPermissionProfile,
@@ -41,6 +42,34 @@ const levelsInput = z.record(z.string(), z.coerce.number().int().min(Level.None)
 
 /** Profile identity chrome (§7): an icon id + colour token, or nothing. */
 const iconInput = z.object({ iconId: z.string(), color: z.string() }).nullable()
+
+/**
+ * One exact-policy keyspace of an agent profile: an explicit `default` plus
+ * sparse `overrides` (plan 19 §2.3).
+ *
+ * The rung vocabulary is closed, so it is a `z.enum` rather than a loose string —
+ * a typo'd rung must be a 400, not a value silently dropped into "reads as the
+ * default". Keys stay free strings (area slugs, entity `apiSlug`s, instance ids);
+ * `parseAgentPolicy` inside the save is the gate that normalizes them.
+ */
+const exactAgentPolicyInput = z.object({
+  default: z.enum(['none', 'read', 'read_write', 'full']),
+  overrides: z.record(z.string(), z.enum(['none', 'read', 'read_write', 'full'])),
+})
+
+/**
+ * `PermissionProfile.agentPolicy` — the agent half of a profile (§2.3). Typed as
+ * `ZodType<AgentPermissionPolicy>` on purpose: if the stored shape gains a
+ * keyspace, this input fails to compile instead of quietly stripping it, which is
+ * exactly the failure this field shipped with (the whole editor reported saved and
+ * persisted nothing).
+ */
+const agentPolicyInput: z.ZodType<AgentPermissionPolicy> = z.object({
+  areas: exactAgentPolicyInput,
+  definitions: exactAgentPolicyInput,
+  resourceDefault: z.enum(['none', 'read', 'read_write', 'full']),
+  resources: z.record(z.string(), exactAgentPolicyInput),
+})
 
 /**
  * The Layer-2 gate for this router: the `permissions` area itself.
@@ -301,6 +330,11 @@ export const permissionsRouter = createTRPCRouter({
         icon: iconInput.optional(),
         levels: levelsInput.nullish(),
         baseLevel: z.number().int().min(Level.None).max(Level.Full).nullish(),
+        /**
+         * The agent-profile exact policy. OWNER/ADMIN-only — the save enforces
+         * that, not this input. `null` clears it; omit to leave it untouched.
+         */
+        agentPolicy: agentPolicyInput.nullish(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -316,6 +350,7 @@ export const permissionsRouter = createTRPCRouter({
         // is the real gate (drops unknown areas, clamps each value).
         levels: input.levels as Partial<Record<Area, Level>> | null | undefined,
         baseLevel: input.baseLevel as Level | null | undefined,
+        agentPolicy: input.agentPolicy,
       })
 
       await recordAuditFromCtx(ctx, {
@@ -328,6 +363,9 @@ export const permissionsRouter = createTRPCRouter({
           name: profile.name,
           levels: input.levels ?? undefined,
           baseLevel: input.baseLevel ?? undefined,
+          // The policy IS the authority for an agent profile — an audit row that
+          // omits it records that permissions changed without recording to what.
+          agentPolicy: input.agentPolicy === undefined ? undefined : input.agentPolicy,
         },
       })
 

--- a/packages/lib/src/agents/agent-service.ts
+++ b/packages/lib/src/agents/agent-service.ts
@@ -19,6 +19,7 @@ import {
   getCachedAgents,
   getCachedMembers,
   getCachedPermissionProfileBySlug,
+  getCachedPermissionProfiles,
   onCacheEvent,
 } from '../cache'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../errors'
@@ -265,6 +266,15 @@ export interface UpdateAgentInput {
    * rejected with `BadRequestError` otherwise. Omit to leave untouched.
    */
   runAsUserId?: string | null
+  /**
+   * The DRAFT permission-profile binding (plan 19 §0.16). Production keeps
+   * running the active version's `permissionPolicy` snapshot until the agent is
+   * published, so this only changes what the *next* publish resolves — which is
+   * why it also flips `hasUnpublishedChanges`. `null` unbinds, falling back to
+   * the system profile for the agent's kind (§1.3). Must be a profile in this
+   * org whose `appliesTo` admits agents. Omit to leave untouched.
+   */
+  permissionProfileId?: string | null
 }
 
 /**
@@ -310,6 +320,13 @@ export async function updateAgent(
   // `resolveAgentRunCapabilities` (§0.6), so reject it at the write instead.
   if (input.runAsUserId != null) {
     await assertRunAsCandidate(organizationId, input.runAsUserId)
+  }
+
+  // A binding the resolver would refuse is worse than no binding: it resolves
+  // fail-closed at run time (`resolveDraftAgentPolicy`), so the agent goes inert
+  // with no sign at the write. Refuse it here instead.
+  if (input.permissionProfileId != null) {
+    await assertAgentProfileCandidate(organizationId, input.permissionProfileId)
   }
 
   await db.transaction(async (tx) => {
@@ -358,8 +375,17 @@ export async function updateAgent(
     // versioned too). Identity/lifecycle edits (name/slug/description/
     // mentionable/archivedAt) never mark dirty. The SQL guard sets it true only
     // when an active version exists — pre-setup drafts have no baseline.
+    //
+    // `permissionProfileId` counts even though the binding itself is NOT in
+    // `AgentConfigSnapshot`: `configHash` folds in the resolved policy, so a
+    // rebind genuinely changes what the next publish would write. Leaving it out
+    // would show "no unpublished changes" on a draft whose authority differs
+    // from production.
     const behaviorChanged =
-      input.prompt !== undefined || input.modelId !== undefined || input.appAccounts !== undefined
+      input.prompt !== undefined ||
+      input.modelId !== undefined ||
+      input.appAccounts !== undefined ||
+      input.permissionProfileId !== undefined
     if (behaviorChanged) {
       patch.hasUnpublishedChanges = sql`${schema.Agent.activeVersionId} is not null`
     }
@@ -830,6 +856,12 @@ export interface AgentDetail extends AgentSummary {
   activeVersionNumber: number | null
   /** Whether the draft (this view's behavior fields) diverges from the active version. */
   hasUnpublishedChanges: boolean
+  /**
+   * The DRAFT permission-profile binding; `null` falls back to the system
+   * profile for this agent's kind (plan 19 §1.3). Not the resolved policy —
+   * that is `AgentVersion.permissionPolicy`, cut at publish.
+   */
+  permissionProfileId: string | null
 }
 
 /**
@@ -873,6 +905,7 @@ export async function getAgentDetail(
       modelId: schema.Agent.modelId,
       activeVersionId: schema.Agent.activeVersionId,
       hasUnpublishedChanges: schema.Agent.hasUnpublishedChanges,
+      permissionProfileId: schema.Agent.permissionProfileId,
       activeVersionNumber: schema.AgentVersion.versionNumber,
     })
     .from(schema.Agent)
@@ -894,6 +927,7 @@ export async function getAgentDetail(
     activeVersionId: row.activeVersionId ?? null,
     activeVersionNumber: row.activeVersionNumber ?? null,
     hasUnpublishedChanges: row.hasUnpublishedChanges,
+    permissionProfileId: row.permissionProfileId ?? null,
   }
 }
 
@@ -936,6 +970,28 @@ async function assertRunAsCandidate(organizationId: string, runAsUserId: string)
   }
   if (member.user?.userType !== 'USER') {
     throw new BadRequestError('An agent can only run as a human member, not another agent.')
+  }
+}
+
+/**
+ * Verify a draft profile binding is one an agent may actually hold: a profile in
+ * THIS org (the cache is org-scoped, so a foreign id simply misses) whose
+ * `appliesTo` admits agents. A `member` profile carries no `agentPolicy` at all,
+ * so binding one resolves to `emptyAgentPolicy()` — an agent that silently can
+ * do nothing (plan 19 §1.3).
+ */
+async function assertAgentProfileCandidate(
+  organizationId: string,
+  permissionProfileId: string
+): Promise<void> {
+  const profile = (await getCachedPermissionProfiles(organizationId)).find(
+    (p) => p.id === permissionProfileId
+  )
+  if (!profile) {
+    throw new BadRequestError('Permission profile not found in this organization.')
+  }
+  if (profile.appliesTo !== 'agent' && profile.appliesTo !== 'any') {
+    throw new BadRequestError(`The "${profile.name}" profile cannot be bound to an agent.`)
   }
 }
 

--- a/packages/lib/src/permissions/profiles/agent-policy.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy.ts
@@ -219,6 +219,21 @@ export function parsePublishedAgentPolicy(
 }
 
 /**
+ * Coerce an authored `PermissionProfile.agentPolicy` into the trusted shape
+ * before it is stored.
+ *
+ * This is the real gate on the profile-save path — the router's zod input only
+ * checks the envelope, exactly as `parseAreaLevels` is the gate for human
+ * `levels`. Values outside the closed rung vocabulary are DROPPED (the key then
+ * reads as its collection default) and an unreadable `default` falls back to
+ * `'none'`, so a malformed payload can only ever narrow authority, never widen
+ * it.
+ */
+export function parseAgentPolicy(raw: unknown): AgentPermissionPolicy {
+  return authorizationOnlyPolicy(parsePublishedAgentPolicy(raw))
+}
+
+/**
  * The authorization-only projection of a policy — everything that decides what
  * the agent may do, and nothing that merely records who published it.
  *

--- a/packages/lib/src/permissions/profiles/profile-delete.ts
+++ b/packages/lib/src/permissions/profiles/profile-delete.ts
@@ -321,7 +321,7 @@ async function runDeletion(
   // §0.24 — a template must always exist to fall back to.
   if (profile.isSystem) {
     throw new ForbiddenError(
-      `The '${profile.name}' profile is a system profile and cannot be deleted — it is the template holders fall back to.`
+      `The '${profile.name}' profile is a system profile and cannot be deleted. It is the template holders fall back to.`
     )
   }
   // §0.25 / doc 14 §0.9 — `permissions` being grantable must not hand agent

--- a/packages/lib/src/permissions/profiles/profile-save.test.ts
+++ b/packages/lib/src/permissions/profiles/profile-save.test.ts
@@ -787,6 +787,74 @@ describe('savePermissionProfile — the other §6.1.5 gates', () => {
     ).rejects.toThrow('PLAN_GATE')
   })
 
+  /**
+   * Regression: `saveProfile`'s zod input shipped without an `agentPolicy` field
+   * while the editor sent one. A zod object STRIPS unknown keys, so every save
+   * succeeded, invalidated the cache and reported saved — and persisted nothing.
+   * These pin the field end to end, and pin the parse that stands between an
+   * authored blob and the jsonb the runtime enforces verbatim.
+   */
+  it('PERSISTS an authored agentPolicy, coerced into the closed vocabulary', async () => {
+    const store = makeStore({})
+    const profile = store.PermissionProfile.find((row) => row.id === 'p_support')
+    if (profile) profile.appliesTo = 'agent'
+    const actor = store.OrganizationMember.find((row) => row.userId === 'u_actor')
+    if (actor) actor.role = 'ADMIN'
+
+    await savePermissionProfile({
+      organizationId: ORG,
+      actorUserId: 'u_actor',
+      profileId: 'p_support',
+      agentPolicy: {
+        areas: { default: 'read', overrides: { records: 'full', tickets: 'sideways' } },
+        definitions: { default: 'none', overrides: { hr: 'read_write' } },
+        resourceDefault: 'none',
+        resources: { dataset: { default: 'read', overrides: {} } },
+      } as never,
+      db: fakeRunner(store) as never,
+    })
+
+    expect(store.PermissionProfile.find((row) => row.id === 'p_support')?.agentPolicy).toEqual({
+      // `sideways` is not a rung — dropped, so `tickets` reads as the `read`
+      // default rather than being guessed at.
+      areas: { default: 'read', overrides: { records: 'full' } },
+      definitions: { default: 'none', overrides: { hr: 'read_write' } },
+      resourceDefault: 'none',
+      resources: { dataset: { default: 'read', overrides: {} } },
+    })
+  })
+
+  it('clears the agentPolicy on an explicit null, and leaves it alone when omitted', async () => {
+    const store = makeStore({})
+    const profile = store.PermissionProfile.find((row) => row.id === 'p_support')
+    if (profile) {
+      profile.appliesTo = 'agent'
+      profile.agentPolicy = { areas: { default: 'full', overrides: {} } }
+    }
+    const actor = store.OrganizationMember.find((row) => row.userId === 'u_actor')
+    if (actor) actor.role = 'ADMIN'
+
+    await savePermissionProfile({
+      organizationId: ORG,
+      actorUserId: 'u_actor',
+      profileId: 'p_support',
+      name: 'renamed',
+      db: fakeRunner(store) as never,
+    })
+    expect(
+      store.PermissionProfile.find((row) => row.id === 'p_support')?.agentPolicy
+    ).not.toBeNull()
+
+    await savePermissionProfile({
+      organizationId: ORG,
+      actorUserId: 'u_actor',
+      profileId: 'p_support',
+      agentPolicy: null,
+      db: fakeRunner(store) as never,
+    })
+    expect(store.PermissionProfile.find((row) => row.id === 'p_support')?.agentPolicy).toBeNull()
+  })
+
   it('refuses profile-scoped resource grants until step 9', async () => {
     const store = makeStore({})
     await expect(

--- a/packages/lib/src/permissions/profiles/profile-save.ts
+++ b/packages/lib/src/permissions/profiles/profile-save.ts
@@ -9,6 +9,7 @@ import { assertGrantableLevels } from '../capabilities/grant-service'
 import { type Area, type Level, parseAreaLevels } from '../capabilities/registry'
 import { FeaturePermissionService } from '../feature-permission-service'
 import { FeatureKey } from '../types'
+import { parseAgentPolicy } from './agent-policy'
 import { computeEffectiveStatesUncached, type QueryRunner } from './effective-state'
 import {
   type ActorAuthority,
@@ -110,7 +111,7 @@ export async function savePermissionProfile(
 
   if ((input.defAccess?.length ?? 0) > 0 || (input.instanceAccess?.length ?? 0) > 0) {
     throw new BadRequestError(
-      'Profile-scoped resource grants are not enabled yet — see plans/permissions/v2/19-permission-profiles.md step 9.'
+      'Profile-scoped resource grants are not enabled yet. See plans/permissions/v2/19-permission-profiles.md step 9.'
     )
   }
 
@@ -119,7 +120,7 @@ export async function savePermissionProfile(
     const actorRole = await loadActorRole(tx, organizationId, actorUserId)
 
     if (profile.slug === 'owner') {
-      throw new ForbiddenError('The Owner profile is not editable — it is the recovery guarantee.')
+      throw new ForbiddenError('The Owner profile is not editable. It is the recovery guarantee.')
     }
     // §0.25: making the `permissions` area grantable must NOT hand agent policy
     // to a non-admin. Agent-side profile editing stays OWNER/ADMIN-only.
@@ -327,7 +328,12 @@ async function applyWrites(
   if (input.description !== undefined) patch.description = input.description
   if (input.icon !== undefined) patch.icon = input.icon
   if (input.baseLevel !== undefined) patch.baseLevel = input.baseLevel
-  if (input.agentPolicy !== undefined) patch.agentPolicy = input.agentPolicy
+  // `null` clears the policy (a profile that carries none); anything else is
+  // coerced into the closed vocabulary before it reaches jsonb — an authored
+  // policy is enforced verbatim at run time, so it never goes in unparsed.
+  if (input.agentPolicy !== undefined) {
+    patch.agentPolicy = input.agentPolicy === null ? null : parseAgentPolicy(input.agentPolicy)
+  }
 
   if (Object.keys(patch).length > 0) {
     await tx

--- a/packages/lib/src/permissions/profiles/system-profiles.ts
+++ b/packages/lib/src/permissions/profiles/system-profiles.ts
@@ -90,7 +90,7 @@ export const SYSTEM_PROFILE_SEEDS: readonly SystemProfileSeed[] = [
   {
     slug: 'field_tech',
     name: 'Field Tech',
-    description: 'Field seat — assigned schedule, visit reports, and linked records only.',
+    description: 'Field seat: assigned schedule, visit reports, and linked records only.',
     icon: { iconId: 'hard-hat', color: 'orange' },
     seat: 'worker',
     appliesTo: 'member',
@@ -100,7 +100,7 @@ export const SYSTEM_PROFILE_SEEDS: readonly SystemProfileSeed[] = [
   {
     slug: 'agent',
     name: 'Internal Agent',
-    description: 'Permissive default for internal agents — full access to every domain.',
+    description: 'Permissive default for internal agents. Full access to every domain.',
     icon: { iconId: 'bot', color: 'violet' },
     seat: 'full',
     appliesTo: 'agent',
@@ -110,7 +110,7 @@ export const SYSTEM_PROFILE_SEEDS: readonly SystemProfileSeed[] = [
   {
     slug: 'chat_agent',
     name: 'Chat Agent',
-    description: 'Fail-closed default for customer-facing agents — no access until granted.',
+    description: 'Fail-closed default for customer-facing agents. No access until granted.',
     icon: { iconId: 'message-circle', color: 'emerald' },
     seat: 'full',
     appliesTo: 'agent',

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -224,7 +224,7 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     key: FeatureKey.workerSeats,
     type: 'static',
     label: 'Field Seats',
-    description: 'Bundled field seats — cheaper, capability-capped member seats for field staff.',
+    description: 'Bundled field seats: cheaper, capability-capped member seats for field staff.',
     group: 'Team',
     unit: 'seats',
   },

--- a/packages/lib/src/permissions/visibility/lens-labels.ts
+++ b/packages/lib/src/permissions/visibility/lens-labels.ts
@@ -21,9 +21,9 @@ export const LENS_LABELS: Record<Lens | 'manager', LensLabel> = {
   full: { label: 'Full access', helper: 'Read and reply to conversations' },
   subject: {
     label: 'Subject only',
-    helper: 'See who, when, and subject lines — not message content',
+    helper: 'See who, when, and subject lines, not message content',
   },
-  metadata: { label: 'Activity only', helper: 'See who and when — not subjects or content' },
+  metadata: { label: 'Activity only', helper: 'See who and when, not subjects or content' },
   none: { label: 'No access', helper: 'Hidden unless individually shared' },
   manager: { label: 'Manager', helper: 'Full access + manage sharing' },
 }

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -58,7 +58,7 @@ const badgeVariants = cva(
       },
       size: {
         default: 'px-2.5 py-0.5 [&_svg]:size-3 has-[svg]:ps-1.5',
-        xs: 'px-1 py-0 text-xs',
+        xs: 'px-1 py-0 text-xs [&_svg]:size-3',
         sm: 'px-2 py-[1px] text-xs [&_svg]:size-3 has-[svg]:ps-1',
       },
     },

--- a/packages/ui/src/components/icon-data.ts
+++ b/packages/ui/src/components/icon-data.ts
@@ -30,6 +30,7 @@ import {
   BellRing,
   Bookmark,
   BookOpen,
+  Bot,
   Box,
   Boxes,
   Braces,
@@ -96,6 +97,7 @@ import {
   Grid,
   Hammer,
   Handshake,
+  HardHat,
   Hash,
   Heading1,
   Heading2,
@@ -271,6 +273,7 @@ export const ICON_DATA: IconItem[] = [
   { id: 'user-check', label: 'User Check', icon: UserCheck },
   { id: 'user-x', label: 'User X', icon: UserX },
   { id: 'circle-user', label: 'Circle User', icon: CircleUser },
+  { id: 'bot', label: 'Bot', icon: Bot },
   // Files/Documents
   { id: 'feather', label: 'Feather', icon: Feather },
   { id: 'file', label: 'File', icon: File },
@@ -352,6 +355,7 @@ export const ICON_DATA: IconItem[] = [
   // Tools
   { id: 'wrench', label: 'Wrench', icon: Wrench },
   { id: 'hammer', label: 'Hammer', icon: Hammer },
+  { id: 'hard-hat', label: 'Hard Hat', icon: HardHat },
   { id: 'key', label: 'Key', icon: Key },
   { id: 'lock', label: 'Lock', icon: Lock },
   { id: 'unlock', label: 'Unlock', icon: Unlock },

--- a/packages/ui/src/components/list-card.tsx
+++ b/packages/ui/src/components/list-card.tsx
@@ -145,7 +145,9 @@ export interface ListCardProps {
 /**
  * Renders a `{ label?, icon?, variant?, description? }[]` chip row — handy for
  * `badges`/`headerEnd`. Pass `options.gap` (a Tailwind gap class) to override the
- * default tight `gap-0.5`, e.g. when mixing icon-only and label chips.
+ * default `gap-1`, e.g. when mixing icon-only and label chips. Anything tighter
+ * reads as zero: every `Badge` paints a 1px non-inset `ring`, so each neighbour
+ * eats 1px of the gap and the two ring strokes end up flush.
  */
 export function renderBadgeChips(
   chips: ListCardBadgeChip[],
@@ -153,7 +155,7 @@ export function renderBadgeChips(
 ): React.ReactNode {
   if (chips.length === 0) return null
   return (
-    <div className={cn('flex flex-row items-center shrink-0', options?.gap ?? 'gap-0.5')}>
+    <div className={cn('flex flex-row items-center shrink-0', options?.gap ?? 'gap-1')}>
       {chips.map((chip, i) => {
         const badge = (
           <Badge key={`chip-${i}`} size='xs' variant={chip.variant ?? 'gray'}>


### PR DESCRIPTION
Follow-up on `plans/permissions/v2/19-permission-profiles.md`. Two real bugs on the agent-profile path, plus UI and copy cleanup across the permissions surfaces.

## Fixes

**Authored agent policies were never saved.** `saveProfile` accepted an `agentPolicy` the router's zod input never declared, and zod strips unknown keys — the editor reported success and wrote nothing. The input is now declared as `ZodType<AgentPermissionPolicy>` (a new keyspace fails to compile rather than being silently dropped), `parseAgentPolicy` is the real gate on the save path, and the policy is recorded on the audit row.

**Draft profile bindings were unreachable.** `Agent.permissionProfileId` was written at creation but neither accepted by `agent.update` nor projected by `getAgentDetail`. Both now handle it, `updateAgent` validates the profile is in-org and admits agents (a binding the resolver would refuse goes fail-closed at run time with no sign at the write), and a rebind counts as a behavior change so the draft shows unpublished changes. The `readDraftProfileId` shim and the write-then-read-back workaround are gone.

## UI

- `bot` and `hard-hat` added to `ICON_DATA` — both are referenced by system profiles (`agent`, `field_tech`) but resolved to nothing, so those profiles rendered iconless
- profile editor header is now a single full-bleed `NavStackBar`-style row instead of a wrapping two-row block
- the agent policy editor's five stacked explainer alerts are removed; the post-save "unpublished changes" warning stays
- permissions settings lands on the Profiles tab; invite profile descriptions render via `SelectItem`'s `description` prop so they stay in the dropdown
- `size='xs'` badge icons are sized, and `renderBadgeChips` defaults to `gap-1` (badge rings were eating the old `gap-0.5`)

## Copy

Em dashes removed from user-facing strings across permissions and members: descriptions, tooltips, alert bodies, seat and lens labels, system profile seed descriptions, and the user-visible errors in profile save/delete. Comments and logger messages untouched.

## Worth knowing before merge

- **Seed descriptions won't reach existing orgs.** `ensureSystemProfiles` inserts with `onConflictDoNothing`, so orgs already seeded keep the old em-dash text in `PermissionProfile.description`. Needs a migration if that matters.
- **Read-only state is now unexplained.** Dropping the admin-only and plan-gate banners means a non-admin or un-entitled org sees the policy grids disabled with no reason given. A lock/tooltip on the section headers would be the smaller replacement.
- `POLICY_INTRO`, `TOOLS_VS_PERMISSIONS`, `ADMIN_ONLY_NOTE`, `PLAN_GATED_NOTE`, `NO_POLICY_YET` and `PUBLICATION_NOTE` are now unreferenced in `agent-policy-copy.ts`, kept in case the copy moves into a guide dialog.

## Verification

Biome clean on every touched path. `tsc --noEmit` on `apps/web` and `packages/lib` shows no new errors (the lib errors that surface are pre-existing baseline ones in `visibility/context.ts` and `visibility/redact.ts`). No tests were run beyond that.