### PR TITLE
feat(permissions): kb/dataset ui capability enforcement and segment router asserts

### DIFF
--- a/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-actions.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-actions.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react'
 import { useDatasetActions } from '~/components/datasets/hooks/use-dataset-actions'
 import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { WorkflowSubMenu } from '~/components/workflow/workflow-submenu'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDatasetDetail } from './dataset-detail-provider'
 
 /**
@@ -25,6 +26,9 @@ import { useDatasetDetail } from './dataset-detail-provider'
 export function DatasetActions() {
   const { dataset, setCurrentTab, refetch, setUploadDialogOpen } = useDatasetDetail()
   const [shareOpen, setShareOpen] = useState(false)
+  const { canEditInstance, canAdminInstance } = useAccess()
+  const canEdit = dataset ? canEditInstance(toRecordId('dataset', dataset.id)) : false
+  const canAdmin = dataset ? canAdminInstance(toRecordId('dataset', dataset.id)) : false
 
   const { handleDelete, handleArchive, isDeleting, isArchiving, ConfirmDialog } = useDatasetActions(
     {
@@ -86,10 +90,12 @@ export function DatasetActions() {
           <Share2 />
           Share
         </Button>
-        <Button onClick={handleUpload} size='sm'>
-          <Upload />
-          Upload
-        </Button>
+        {canEdit && (
+          <Button onClick={handleUpload} size='sm'>
+            <Upload />
+            Upload
+          </Button>
+        )}
 
         {/* More Actions Dropdown */}
         <DropdownMenu>
@@ -109,15 +115,22 @@ export function DatasetActions() {
               <Download />
               Export
             </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={handleArchive} disabled={isArchiving}>
-              <Archive />
-              Archive
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleDelete} variant='destructive' disabled={isDeleting}>
-              <Trash2 />
-              Delete
-            </DropdownMenuItem>
+            {canAdmin && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleArchive} disabled={isArchiving}>
+                  <Archive />
+                  Archive
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={handleDelete}
+                  variant='destructive'
+                  disabled={isDeleting}>
+                  <Trash2 />
+                  Delete
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-detail-content.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-detail-content.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import type { DocumentEntity as Document } from '@auxx/database/types'
+import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
 import {
   MainPage,
@@ -20,6 +21,7 @@ import { DocumentManagement } from '~/components/datasets/documents/document-man
 import { DatasetSearch } from '~/components/datasets/search/dataset-search'
 import { DatasetSettings } from '~/components/datasets/settings/dataset-settings'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
+import { useAccess } from '~/providers/capabilities-provider'
 import { DatasetActions } from './dataset-actions'
 import { useDatasetDetail } from './dataset-detail-provider'
 import { DatasetHeader } from './dataset-header'
@@ -30,6 +32,8 @@ import { DatasetHeader } from './dataset-header'
  */
 export function DatasetDetailContent() {
   const { currentTab, setCurrentTab, dataset, documents } = useDatasetDetail()
+  const { canAdminInstance } = useAccess()
+  const canAdmin = dataset ? canAdminInstance(toRecordId('dataset', dataset.id)) : false
 
   // Drawer state — synced to URL via ?id= param
   const [selectedDocumentId, setSelectedDocumentId] = useQueryState(
@@ -136,7 +140,7 @@ export function DatasetDetailContent() {
           </TabsContent>
 
           <TabsContent value='settings' className='overflow-y-auto'>
-            <DatasetSettings dataset={dataset} />
+            <DatasetSettings dataset={dataset} readOnly={!canAdmin} />
           </TabsContent>
         </Tabs>
       </MainPageContent>

--- a/apps/web/src/components/datasets/dataset-card.tsx
+++ b/apps/web/src/components/datasets/dataset-card.tsx
@@ -51,9 +51,10 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
   const pending = useIsPending(dataset.id)
   const pendingLabel = usePendingLabel()
   const toggle = useListSelection((s) => s.toggle)
-  const { isRestrictedInstance } = useAccess()
+  const { isRestrictedInstance, canAdminInstance } = useAccess()
   const [shareOpen, setShareOpen] = useState(false)
   const isShared = isRestrictedInstance(dataset.id)
+  const canAdmin = canAdminInstance(toRecordId('dataset', dataset.id))
 
   const status = STATUS_DOT[dataset.status] ?? STATUS_DOT.ARCHIVED
   const creatorName = dataset.createdBy.name ?? dataset.createdBy.email ?? '?'
@@ -116,24 +117,30 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
               <Search />
               Browse
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={wrap(handleSettings)}>
-              <Settings />
-              Settings
-            </DropdownMenuItem>
+            {canAdmin && (
+              <DropdownMenuItem onClick={wrap(handleSettings)}>
+                <Settings />
+                Settings
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={wrap(() => setShareOpen(true))}>
               <Share2 />
               Share…
             </DropdownMenuItem>
             <FavoriteToggleMenuItem targetType='DATASET' targetIds={{ datasetId: dataset.id }} />
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={wrap(handleArchive)}>
-              <Archive />
-              Archive
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={wrap(handleDelete)} variant='destructive'>
-              <Trash />
-              Delete
-            </DropdownMenuItem>
+            {canAdmin && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={wrap(handleArchive)}>
+                  <Archive />
+                  Archive
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={wrap(handleDelete)} variant='destructive'>
+                  <Trash />
+                  Delete
+                </DropdownMenuItem>
+              </>
+            )}
           </>
         }
       />

--- a/apps/web/src/components/datasets/datasets-bulk-bar.tsx
+++ b/apps/web/src/components/datasets/datasets-bulk-bar.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/datasets/datasets-bulk-bar.tsx
 'use client'
 
+import { toRecordId } from '@auxx/types/resource'
 import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
 import { Archive, Trash } from 'lucide-react'
 import {
@@ -10,6 +11,7 @@ import {
   useSelectionCount,
   useSelectionIds,
 } from '~/components/list-selection'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { useDatasets } from './datasets-provider'
 
@@ -23,51 +25,59 @@ export function DatasetsBulkBar() {
   const { ConfirmDialog, run, isRunning } = useBulkRunner()
   const deleteDataset = api.dataset.delete.useMutation()
   const archiveDataset = api.dataset.archive.useMutation()
+  const { canAdminInstance } = useAccess()
 
   const noun = (n: number) => `${n} dataset${n === 1 ? '' : 's'}`
 
-  const actions: ActionBarAction[] = [
-    {
-      id: 'archive',
-      label: 'Archive',
-      icon: Archive,
-      tooltip: 'Archive selected',
-      disabled: isRunning || count === 0,
-      onClick: () =>
-        run(ids, (id) => archiveDataset.mutateAsync({ id }), {
-          title: `Archive ${noun(count)}?`,
-          description: 'They will be hidden from the main view but can be restored later.',
-          confirmText: 'Archive',
-          destructive: false,
-          pendingLabel: 'Archiving…',
-          removesItem: false,
-          failureTitle: 'Some datasets could not be archived',
-          onDone: () => {
-            refetch()
-            exit()
-          },
-        }),
-    },
-    {
-      id: 'delete',
-      label: 'Delete',
-      icon: Trash,
-      variant: 'destructive',
-      tooltip: 'Delete selected',
-      disabled: isRunning || count === 0,
-      onClick: () =>
-        run(ids, (id) => deleteDataset.mutateAsync({ id }), {
-          title: `Delete ${noun(count)}?`,
-          description:
-            'This permanently removes them and all associated documents and data. This cannot be undone.',
-          failureTitle: 'Some datasets could not be deleted',
-          onDone: () => {
-            refetch()
-            exit()
-          },
-        }),
-    },
-  ]
+  // Archive/delete are Full-only per instance — hide both destructive bulk
+  // actions unless every selected dataset passes admin (simplest correct rule;
+  // per-item filtering inside a bulk action is silent-partial-failure UX).
+  const allSelectedAdmin = ids.every((id) => canAdminInstance(toRecordId('dataset', id)))
+
+  const actions: ActionBarAction[] = allSelectedAdmin
+    ? [
+        {
+          id: 'archive',
+          label: 'Archive',
+          icon: Archive,
+          tooltip: 'Archive selected',
+          disabled: isRunning || count === 0,
+          onClick: () =>
+            run(ids, (id) => archiveDataset.mutateAsync({ id }), {
+              title: `Archive ${noun(count)}?`,
+              description: 'They will be hidden from the main view but can be restored later.',
+              confirmText: 'Archive',
+              destructive: false,
+              pendingLabel: 'Archiving…',
+              removesItem: false,
+              failureTitle: 'Some datasets could not be archived',
+              onDone: () => {
+                refetch()
+                exit()
+              },
+            }),
+        },
+        {
+          id: 'delete',
+          label: 'Delete',
+          icon: Trash,
+          variant: 'destructive',
+          tooltip: 'Delete selected',
+          disabled: isRunning || count === 0,
+          onClick: () =>
+            run(ids, (id) => deleteDataset.mutateAsync({ id }), {
+              title: `Delete ${noun(count)}?`,
+              description:
+                'This permanently removes them and all associated documents and data. This cannot be undone.',
+              failureTitle: 'Some datasets could not be deleted',
+              onDone: () => {
+                refetch()
+                exit()
+              },
+            }),
+        },
+      ]
+    : []
 
   return (
     <>

--- a/apps/web/src/components/datasets/documents/document-columns.tsx
+++ b/apps/web/src/components/datasets/documents/document-columns.tsx
@@ -22,6 +22,8 @@ interface DocumentColumnsActions {
   onDelete: (document: Document) => void
   onArchive: (document: Document) => void
   onUnarchive: (document: Document) => void
+  /** Edit-instance gate on the parent dataset — hides archive/unarchive/delete when false. */
+  canEdit: boolean
 }
 
 /**
@@ -34,6 +36,7 @@ export function createDocumentColumns({
   onDelete,
   onArchive,
   onUnarchive,
+  canEdit,
 }: DocumentColumnsActions): ExtendedColumnDef<Document>[] {
   return [
     {
@@ -47,6 +50,7 @@ export function createDocumentColumns({
           onDelete={onDelete}
           onArchive={onArchive}
           onUnarchive={onUnarchive}
+          canEdit={canEdit}
         />
       ),
       enableHiding: false,

--- a/apps/web/src/components/datasets/documents/document-detail-drawer.tsx
+++ b/apps/web/src/components/datasets/documents/document-detail-drawer.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/datasets/documents/document-detail-drawer.tsx
 'use client'
 import type { DocumentEntity as Document } from '@auxx/database/types'
+import { toRecordId } from '@auxx/types/resource'
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
@@ -41,6 +42,7 @@ import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { DocumentSegmentsTab } from '../segments/document-segments'
@@ -77,6 +79,8 @@ export function DocumentDetailDrawer({
   const setDockedWidth = useDockStore((state) => state.setDockedWidth)
 
   const { deleteDocument, reprocessDocument, updateDocument } = useDatasetDetail()
+  const { canEditInstance } = useAccess()
+  const canEdit = canEditInstance(toRecordId('dataset', datasetId))
   const [confirm, ConfirmDialog] = useConfirm()
   const [editingTitle, setEditingTitle] = useState(document.title || document.filename || '')
   const [isRenaming, setIsRenaming] = useState(false)
@@ -228,7 +232,7 @@ export function DocumentDetailDrawer({
                 onBlur={handleTitleBlur}
                 onKeyDown={handleTitleKeyDown}
                 placeholder='Enter title'
-                disabled={isRenaming || updateDocumentMutation.isPending}
+                disabled={isRenaming || updateDocumentMutation.isPending || !canEdit}
                 className={cn(
                   'mr-2 h-7 min-w-0 w-full appearance-none rounded-md border bg-transparent px-1 outline-none',
                   'border-transparent',
@@ -251,58 +255,62 @@ export function DocumentDetailDrawer({
                     <Download />
                   </Button>
                 </Tooltip>
-                <Tooltip content='Reprocess file'>
-                  <Button
-                    variant='ghost'
-                    size='icon-sm'
-                    className='rounded-full'
-                    loading={displayDocument.status === 'PROCESSING'}
-                    onClick={handleReprocess}>
-                    <RefreshCw />
-                  </Button>
-                </Tooltip>
-
-                <DropdownMenu modal={false}>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant='ghost' size='icon-sm' className='rounded-full'>
-                      <MoreHorizontal />
+                {canEdit && (
+                  <Tooltip content='Reprocess file'>
+                    <Button
+                      variant='ghost'
+                      size='icon-sm'
+                      className='rounded-full'
+                      loading={displayDocument.status === 'PROCESSING'}
+                      onClick={handleReprocess}>
+                      <RefreshCw />
                     </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align='end' className='w-48'>
-                    <DropdownMenuItem
-                      onClick={() => {
-                        // Focus the input to start renaming
-                        const input = window.document.getElementById('title') as HTMLInputElement
-                        if (input) {
-                          input.focus()
-                          input.select()
-                        }
-                      }}>
-                      <TextCursorInput />
-                      Rename
-                    </DropdownMenuItem>
+                  </Tooltip>
+                )}
 
-                    {displayDocument.status === 'ARCHIVED' ? (
+                {canEdit && (
+                  <DropdownMenu modal={false}>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant='ghost' size='icon-sm' className='rounded-full'>
+                        <MoreHorizontal />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align='end' className='w-48'>
                       <DropdownMenuItem
-                        onClick={() => updateDocument(document.id, { status: 'INDEXED' })}>
-                        <ArchiveRestore />
-                        Unarchive
+                        onClick={() => {
+                          // Focus the input to start renaming
+                          const input = window.document.getElementById('title') as HTMLInputElement
+                          if (input) {
+                            input.focus()
+                            input.select()
+                          }
+                        }}>
+                        <TextCursorInput />
+                        Rename
                       </DropdownMenuItem>
-                    ) : (
-                      <DropdownMenuItem
-                        onClick={() => updateDocument(document.id, { status: 'ARCHIVED' })}>
-                        <Archive />
-                        Archive
-                      </DropdownMenuItem>
-                    )}
 
-                    <DropdownMenuItem onClick={() => handleDelete()} variant='destructive'>
-                      <Trash2 />
-                      Delete
-                      <KeyboardShortcut shortcut='Del' />
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                      {displayDocument.status === 'ARCHIVED' ? (
+                        <DropdownMenuItem
+                          onClick={() => updateDocument(document.id, { status: 'INDEXED' })}>
+                          <ArchiveRestore />
+                          Unarchive
+                        </DropdownMenuItem>
+                      ) : (
+                        <DropdownMenuItem
+                          onClick={() => updateDocument(document.id, { status: 'ARCHIVED' })}>
+                          <Archive />
+                          Archive
+                        </DropdownMenuItem>
+                      )}
+
+                      <DropdownMenuItem onClick={() => handleDelete()} variant='destructive'>
+                        <Trash2 />
+                        Delete
+                        <KeyboardShortcut shortcut='Del' />
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
                 <DockToggleButton />
               </>
             }

--- a/apps/web/src/components/datasets/documents/document-management.tsx
+++ b/apps/web/src/components/datasets/documents/document-management.tsx
@@ -49,10 +49,11 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
   const [isUploading, setIsUploading] = useState(false)
   const [confirm, ConfirmDialog] = useConfirm()
 
-  // Uploading documents is a Write on this dataset (per-instance, mirrors the
-  // `document.batchProcess` router gate) — hide the upload affordances otherwise.
+  // Uploading/archiving/deleting documents is a Write on this dataset
+  // (per-instance, mirrors the `document.*` router gates) — hide those
+  // affordances otherwise.
   const { canEditInstance } = useAccess()
-  const canUpload = canEditInstance(toRecordId('dataset', datasetId))
+  const canEdit = canEditInstance(toRecordId('dataset', datasetId))
 
   // Get utils for cache invalidation
   const utils = api.useUtils()
@@ -283,35 +284,39 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
         onDelete: handleDelete,
         onArchive: handleArchive,
         onUnarchive: handleUnarchive,
+        canEdit,
       }),
-    [handleViewDetails, handleDownload, handleDelete, handleArchive, handleUnarchive]
+    [handleViewDetails, handleDownload, handleDelete, handleArchive, handleUnarchive, canEdit]
   )
-  // Bulk actions
+  // Bulk actions — all mutate documents (same edit-instance gate as the row menu).
   const bulkActions = useMemo(
-    () => [
-      {
-        label: 'Available',
-        icon: CircleDot,
-        variant: 'outline' as const,
-        action: handleBulkEnable,
-        disabled: () => false,
-      },
-      {
-        label: 'Disabled',
-        icon: CircleSlash,
-        variant: 'outline' as const,
-        action: handleBulkDisable,
-        disabled: () => false,
-      },
-      {
-        label: 'Delete Selected',
-        icon: Trash2,
-        variant: 'destructive' as const,
-        action: handleBulkDelete,
-        disabled: () => false,
-      },
-    ],
-    [handleBulkEnable, handleBulkDisable, handleBulkDelete]
+    () =>
+      canEdit
+        ? [
+            {
+              label: 'Available',
+              icon: CircleDot,
+              variant: 'outline' as const,
+              action: handleBulkEnable,
+              disabled: () => false,
+            },
+            {
+              label: 'Disabled',
+              icon: CircleSlash,
+              variant: 'outline' as const,
+              action: handleBulkDisable,
+              disabled: () => false,
+            },
+            {
+              label: 'Delete Selected',
+              icon: Trash2,
+              variant: 'destructive' as const,
+              action: handleBulkDelete,
+              disabled: () => false,
+            },
+          ]
+        : [],
+    [handleBulkEnable, handleBulkDisable, handleBulkDelete, canEdit]
   )
   // Handle row click to view details
   const handleRowClick = useCallback(
@@ -332,7 +337,7 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
     <FileDropZone
       onFilesDropped={handleDocumentsDropped}
       currentFolderName={dataset?.name || 'Dataset'}
-      disabled={isDocumentsLoading || isUploading || isUploadActive || !canUpload}>
+      disabled={isDocumentsLoading || isUploading || isUploadActive || !canEdit}>
       {/* Dynamic Table */}
       <DynamicTable<Document>
         tableId='dataset-documents'
@@ -349,7 +354,7 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
         onRefresh={refetch}
         searchPlaceholder='Search documents...'
         searchKeys={['filename', 'title', 'mimeType']}
-        onAddNew={canUpload ? () => setUploadDialogOpen(true) : undefined}
+        onAddNew={canEdit ? () => setUploadDialogOpen(true) : undefined}
         customFilter={
           <DocumentFilterBar
             filterValue={documentFilter}
@@ -365,12 +370,12 @@ export function DocumentManagement({ datasetId, onDocumentSelect }: DocumentMana
             description={
               documentFilter !== 'all'
                 ? 'Try adjusting your filters to find documents.'
-                : canUpload
+                : canEdit
                   ? 'Upload your first documents to get started with this dataset.'
                   : "This dataset has no documents yet. You don't have permission to add files here."
             }
             button={
-              documentFilter === 'all' && canUpload ? (
+              documentFilter === 'all' && canEdit ? (
                 <Button onClick={() => setUploadDialogOpen(true)} variant='outline'>
                   <Plus />
                   Upload Documents

--- a/apps/web/src/components/datasets/documents/document-name-cell.tsx
+++ b/apps/web/src/components/datasets/documents/document-name-cell.tsx
@@ -18,6 +18,8 @@ interface DocumentNameCellProps {
   onDelete: (document: Document) => void
   onArchive: (document: Document) => void
   onUnarchive: (document: Document) => void
+  /** Edit-instance gate on the parent dataset — hides archive/unarchive/delete when false. */
+  canEdit: boolean
 }
 
 /**
@@ -32,6 +34,7 @@ export function DocumentNameCell({
   onDelete,
   onArchive,
   onUnarchive,
+  canEdit,
 }: DocumentNameCellProps) {
   const fileExtension = document.filename?.split('.').pop()
   const displayName = document.title || document.filename || 'Unnamed Document'
@@ -59,22 +62,26 @@ export function DocumentNameCell({
         targetType='DOCUMENT'
         targetIds={{ documentId: document.id, datasetId: document.datasetId }}
       />
-      <DropdownMenuSeparator />
-      {document.status === 'ARCHIVED' ? (
-        <DropdownMenuItem onClick={() => onUnarchive(document)}>
-          <ArchiveRestore />
-          Unarchive
-        </DropdownMenuItem>
-      ) : (
-        <DropdownMenuItem onClick={() => onArchive(document)}>
-          <Archive />
-          Archive
-        </DropdownMenuItem>
+      {canEdit && (
+        <>
+          <DropdownMenuSeparator />
+          {document.status === 'ARCHIVED' ? (
+            <DropdownMenuItem onClick={() => onUnarchive(document)}>
+              <ArchiveRestore />
+              Unarchive
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem onClick={() => onArchive(document)}>
+              <Archive />
+              Archive
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem variant='destructive' onClick={() => onDelete(document)}>
+            <Trash2 />
+            Delete
+          </DropdownMenuItem>
+        </>
       )}
-      <DropdownMenuItem variant='destructive' onClick={() => onDelete(document)}>
-        <Trash2 />
-        Delete
-      </DropdownMenuItem>
     </PrimaryCell>
   )
 }

--- a/apps/web/src/components/datasets/search/dataset-search.tsx
+++ b/apps/web/src/components/datasets/search/dataset-search.tsx
@@ -13,7 +13,7 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { Separator } from '@auxx/ui/components/separator'
-import { toastError, toastSuccess } from '@auxx/ui/components/toast'
+import { toastError } from '@auxx/ui/components/toast'
 import { Command, CornerDownLeft, FileSearch, Loader2, TestTubeDiagonal, XIcon } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -100,12 +100,7 @@ export function DatasetSearch({ datasetIds }: DatasetSearchProps) {
         searchError: data.success ? null : data.error || 'Search failed',
       }))
 
-      if (data.success) {
-        toastSuccess({
-          title: 'Search completed',
-          description: `Found ${data.metrics?.totalResults || 0} results in ${data.metrics?.responseTime || 0}ms`,
-        })
-      } else {
+      if (!data.success) {
         toastError({
           title: 'Search failed',
           description: data.error || 'Unknown error occurred',

--- a/apps/web/src/components/kb/ui/editor/article-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-header.tsx
@@ -13,6 +13,7 @@ import { useArticleEditorSurface } from './article-editor-surface'
 import { ArticlePublishCluster } from './article-publish-cluster'
 import { ArticleSettingsDialog } from './article-settings-dialog'
 import { HiddenParentBadge } from './hidden-parent-badge'
+import { useKBEditorAccess } from './kb-editor-access-context'
 
 interface DiffHeaderInfo {
   /** Older side label, e.g. "Published" / "v3" / "Before". */
@@ -38,6 +39,7 @@ interface ArticleEditorHeaderProps {
 }
 
 export function ArticleEditorHeader({ article, knowledgeBaseId, diff }: ArticleEditorHeaderProps) {
+  const { canEdit } = useKBEditorAccess()
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const articles = useArticleList(knowledgeBaseId)
   // Source-owned KBs aren't independently publishable, so the embedding surface
@@ -51,14 +53,16 @@ export function ArticleEditorHeader({ article, knowledgeBaseId, diff }: ArticleE
 
   return (
     <div className='flex w-full items-center gap-2 overflow-x-auto no-scrollbar border-b bg-primary-150 px-3 py-1.5 rounded-b-none'>
-      <Button
-        variant='outline'
-        size='xs'
-        className='shrink-0'
-        onClick={() => setIsSettingsOpen(true)}>
-        <Cog /> Page settings
-      </Button>
-      {!hidePublishing && (
+      {canEdit && (
+        <Button
+          variant='outline'
+          size='xs'
+          className='shrink-0'
+          onClick={() => setIsSettingsOpen(true)}>
+          <Cog /> Page settings
+        </Button>
+      )}
+      {!hidePublishing && canEdit && (
         <ArticlePublishCluster article={article} knowledgeBaseId={knowledgeBaseId} />
       )}
       <HiddenParentBadge article={article} knowledgeBaseId={knowledgeBaseId} />

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -24,6 +24,7 @@ import { type ArticleMeta, getArticleStoreState } from '../../store/article-stor
 import { ArticleEditorFooter } from './article-editor-footer'
 import { ArticleEditorHeader } from './article-editor-header'
 import { ArticleEditorTop } from './article-editor-top'
+import { useKBEditorAccess } from './kb-editor-access-context'
 
 const emptyContent: JSONContent[] = [{ type: 'block', attrs: { blockType: 'text' }, content: [] }]
 
@@ -33,6 +34,7 @@ interface ArticleEditorProps {
 }
 
 export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) {
+  const { canEdit } = useKBEditorAccess()
   const {
     draftContentJson,
     isLoading: isContentLoading,
@@ -111,7 +113,9 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
     }
   }
 
-  const bodyReadOnly = locked || managed
+  // View-level (non-edit) members get the same read-only surface as a
+  // source-managed article or a Kopilot-held write turn (doc 24 §A.2.4).
+  const bodyReadOnly = locked || managed || !canEdit
 
   return (
     <div className='flex min-h-0 flex-1 flex-col'>
@@ -130,14 +134,16 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
             Managed by {sourceName ? <span className='font-medium'>{sourceName}</span> : 'a source'}
             <span className='ml-1 text-muted-foreground'>— this article is read-only.</span>
           </span>
-          <Button
-            variant='outline'
-            size='xs'
-            className='ml-auto'
-            loading={detachArticle.isPending}
-            onClick={handleDetach}>
-            Edit / detach
-          </Button>
+          {canEdit && (
+            <Button
+              variant='outline'
+              size='xs'
+              className='ml-auto'
+              loading={detachArticle.isPending}
+              onClick={handleDetach}>
+              Edit / detach
+            </Button>
+          )}
         </div>
       )}
       {review.pending && (
@@ -167,7 +173,7 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
                 knowledgeBaseId={knowledgeBaseId}
                 onUpdateMetadata={handleMetadataUpdate}
                 onAdvanceToContent={focusBodyEditor}
-                readOnly={managed}
+                readOnly={managed || !canEdit}
               />
               <div className='relative flex min-h-0 min-w-0 flex-1 flex-col items-stretch'>
                 {!isContentLoading && (

--- a/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
+++ b/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
@@ -20,6 +20,7 @@ import { usePendingInsertStore } from '../../store/pending-insert-store'
 import { LinkArticlePicker } from '../sidebar/link-article-picker'
 import { ArticleEditorHeader } from './article-editor-header'
 import { ArticleEditorTop } from './article-editor-top'
+import { useKBEditorAccess } from './kb-editor-access-context'
 
 interface ContainerArticlePlaceholderProps {
   article: ArticleMeta
@@ -59,6 +60,7 @@ export function ContainerArticlePlaceholder({
   article,
   knowledgeBaseId,
 }: ContainerArticlePlaceholderProps) {
+  const { canEdit } = useKBEditorAccess()
   const router = useRouter()
   const articles = useArticleList(knowledgeBaseId)
   const { isCreating, updateArticleDraft } = useArticleMutations(knowledgeBaseId)
@@ -145,6 +147,7 @@ export function ContainerArticlePlaceholder({
                 knowledgeBaseId={knowledgeBaseId}
                 onUpdateMetadata={handleMetadataUpdate}
                 onAdvanceToContent={focusContent}
+                readOnly={!canEdit}
               />
               {isLink ? (
                 <div className='mx-auto mt-4 w-full max-w-md'>
@@ -168,41 +171,45 @@ export function ContainerArticlePlaceholder({
                 <div
                   ref={optionsRef}
                   className='mt-4 w-full overflow-hidden rounded-xl border text-left'>
-                  <GroupLabel>
-                    {article.articleKind === ArticleKind.tab
-                      ? 'Add to this tab'
-                      : 'Add to this section header'}
-                  </GroupLabel>
-                  <div className='flex flex-col p-1'>
-                    {options.map(({ kind, label, Icon }) => (
-                      <RowButton
-                        key={kind}
-                        disabled={isCreating}
-                        onClick={() => handleCreate(kind)}>
-                        <TreeRow
-                          icon={<Icon className='size-4 text-muted-foreground' />}
-                          title={label}
-                        />
-                      </RowButton>
-                    ))}
-                    <Popover open={linkOpen} onOpenChange={setLinkOpen}>
-                      <PopoverTrigger asChild>
-                        <RowButton>
-                          <TreeRow
-                            icon={<Database className='size-4 text-muted-foreground' />}
-                            title='Link an article'
-                          />
-                        </RowButton>
-                      </PopoverTrigger>
-                      <PopoverContent align='start' className='w-72 p-0'>
-                        <LinkArticlePicker
-                          knowledgeBaseId={knowledgeBaseId}
-                          targetParentArticleId={article.id}
-                          onClose={() => setLinkOpen(false)}
-                        />
-                      </PopoverContent>
-                    </Popover>
-                  </div>
+                  {canEdit && (
+                    <>
+                      <GroupLabel>
+                        {article.articleKind === ArticleKind.tab
+                          ? 'Add to this tab'
+                          : 'Add to this section header'}
+                      </GroupLabel>
+                      <div className='flex flex-col p-1'>
+                        {options.map(({ kind, label, Icon }) => (
+                          <RowButton
+                            key={kind}
+                            disabled={isCreating}
+                            onClick={() => handleCreate(kind)}>
+                            <TreeRow
+                              icon={<Icon className='size-4 text-muted-foreground' />}
+                              title={label}
+                            />
+                          </RowButton>
+                        ))}
+                        <Popover open={linkOpen} onOpenChange={setLinkOpen}>
+                          <PopoverTrigger asChild>
+                            <RowButton>
+                              <TreeRow
+                                icon={<Database className='size-4 text-muted-foreground' />}
+                                title='Link an article'
+                              />
+                            </RowButton>
+                          </PopoverTrigger>
+                          <PopoverContent align='start' className='w-72 p-0'>
+                            <LinkArticlePicker
+                              knowledgeBaseId={knowledgeBaseId}
+                              targetParentArticleId={article.id}
+                              onClose={() => setLinkOpen(false)}
+                            />
+                          </PopoverContent>
+                        </Popover>
+                      </div>
+                    </>
+                  )}
                   {children.length > 0 && (
                     <>
                       <div className='border-t' />

--- a/apps/web/src/components/kb/ui/editor/kb-articles-header-actions.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-articles-header-actions.tsx
@@ -22,12 +22,14 @@ import { usePendingInsertStore } from '../../store/pending-insert-store'
 import { inferCreateParent } from '../../utils/infer-create-parent'
 import { CrawlWebsiteWizard } from './crawl-website-wizard'
 import { CreateKnowledgeSourceDialog } from './create-knowledge-source-dialog'
+import { useKBEditorAccess } from './kb-editor-access-context'
 
 interface KBArticlesHeaderActionsProps {
   knowledgeBaseId: string
 }
 
 export function KBArticlesHeaderActions({ knowledgeBaseId }: KBArticlesHeaderActionsProps) {
+  const { canEdit } = useKBEditorAccess()
   const articles = useArticleList(knowledgeBaseId)
   const activeTabId = useActiveTabId(knowledgeBaseId)
   const activeArticle = useActiveArticle(knowledgeBaseId)
@@ -83,6 +85,10 @@ export function KBArticlesHeaderActions({ knowledgeBaseId }: KBArticlesHeaderAct
     },
     [activeTabId, createArticle]
   )
+
+  // Create/import/crawl are all Edit-instance affordances — hide the whole
+  // entry point for view-only members (doc 24 §A.2.4).
+  if (!canEdit) return null
 
   return (
     <>

--- a/apps/web/src/components/kb/ui/editor/kb-editor-access-context.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-access-context.tsx
@@ -1,0 +1,52 @@
+// apps/web/src/components/kb/ui/editor/kb-editor-access-context.tsx
+'use client'
+
+import { toRecordId } from '@auxx/types/resource'
+import type React from 'react'
+import { createContext, useContext, useMemo } from 'react'
+import { useAccess } from '~/providers/capabilities-provider'
+
+/** Per-instance capability booleans for the KB currently open in the editor. */
+interface KBEditorAccess {
+  /** Edit-instance on this KB — gates article create/rename/move/delete/import/crawl. */
+  canEdit: boolean
+  /** Admin-instance (Full) on this KB — gates settings tabs, layout tab, publish cluster. */
+  canAdmin: boolean
+}
+
+const KBEditorAccessContext = createContext<KBEditorAccess | undefined>(undefined)
+
+/**
+ * Derives the current member's Edit/Full capability on this KB instance ONCE
+ * at the top of the editor tree (`KBEditorFrame`) and hands it to every
+ * descendant via context instead of threading `canEdit`/`canAdmin` props
+ * through a dozen components (doc 24 §A.2.4).
+ */
+export function KBEditorAccessProvider({
+  knowledgeBaseId,
+  children,
+}: {
+  knowledgeBaseId: string
+  children: React.ReactNode
+}) {
+  const { canEditInstance, canAdminInstance } = useAccess()
+
+  const value = useMemo<KBEditorAccess>(() => {
+    const recordId = toRecordId('kb', knowledgeBaseId)
+    return {
+      canEdit: canEditInstance(recordId),
+      canAdmin: canAdminInstance(recordId),
+    }
+  }, [knowledgeBaseId, canEditInstance, canAdminInstance])
+
+  return <KBEditorAccessContext.Provider value={value}>{children}</KBEditorAccessContext.Provider>
+}
+
+/** Consume the KB editor's capability context. Must render under `KBEditorAccessProvider`. */
+export function useKBEditorAccess(): KBEditorAccess {
+  const context = useContext(KBEditorAccessContext)
+  if (context === undefined) {
+    throw new Error('useKBEditorAccess must be used within a KBEditorAccessProvider')
+  }
+  return context
+}

--- a/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
@@ -8,8 +8,10 @@ import { useMemo } from 'react'
 import { MainPageLoading } from '~/components/global/main-page-states'
 import { KopilotContext } from '~/components/kopilot/context/kopilot-context'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
+import type { KnowledgeBase } from '../../store/knowledge-base-store'
 import { ArticlesTabArrow } from '../preview/articles-tab-arrow'
 import { KBPreviewHintProvider } from '../preview/preview-hint-context'
+import { KBEditorAccessProvider, useKBEditorAccess } from './kb-editor-access-context'
 import { KBEditorHeader } from './kb-editor-header'
 import { KBTabPanel } from './kb-tab-panel'
 
@@ -27,23 +29,6 @@ interface KBEditorFrameProps {
  */
 export function KBEditorFrame({ knowledgeBaseId, children }: KBEditorFrameProps) {
   const { knowledgeBase, isLoading } = useKnowledgeBase(knowledgeBaseId)
-  const [panelParam] = useQueryState(
-    'panel',
-    parseAsStringLiteral(PANEL_VALUES).withDefault('general')
-  )
-  // The learned KB ("AI Memory") is always on the article tree.
-  const activePanel = knowledgeBase?.kind === 'learned' ? 'articles' : panelParam
-
-  const leftPanels = useMemo(() => {
-    if (!knowledgeBase) return []
-    return [
-      {
-        key: 'kb-tab-panel',
-        content: <KBTabPanel knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />,
-        width: activePanel === 'articles' ? 320 : 512,
-      },
-    ]
-  }, [knowledgeBase, knowledgeBaseId, activePanel])
 
   if (isLoading || !knowledgeBase) {
     return (
@@ -52,6 +37,41 @@ export function KBEditorFrame({ knowledgeBaseId, children }: KBEditorFrameProps)
       </MainPage>
     )
   }
+
+  return (
+    <KBEditorAccessProvider knowledgeBaseId={knowledgeBaseId}>
+      <KBEditorFrameBody knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase}>
+        {children}
+      </KBEditorFrameBody>
+    </KBEditorAccessProvider>
+  )
+}
+
+interface KBEditorFrameBodyProps {
+  knowledgeBaseId: string
+  knowledgeBase: KnowledgeBase
+  children: React.ReactNode
+}
+
+function KBEditorFrameBody({ knowledgeBaseId, knowledgeBase, children }: KBEditorFrameBodyProps) {
+  const { canAdmin } = useKBEditorAccess()
+  const [panelParam] = useQueryState(
+    'panel',
+    parseAsStringLiteral(PANEL_VALUES).withDefault('general')
+  )
+  // The learned KB ("AI Memory") is always on the article tree; so is any KB
+  // the member can't administer — settings/layout are Full-only (doc 24 §A.2.4).
+  const activePanel = knowledgeBase.kind === 'learned' || !canAdmin ? 'articles' : panelParam
+
+  const leftPanels = useMemo(() => {
+    return [
+      {
+        key: 'kb-tab-panel',
+        content: <KBTabPanel knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />,
+        width: activePanel === 'articles' ? 320 : 512,
+      },
+    ]
+  }, [knowledgeBase, knowledgeBaseId, activePanel])
 
   return (
     <KBPreviewHintProvider>

--- a/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
@@ -20,6 +20,7 @@ import { LAYOUT_TAB_ENABLED } from '../../constant'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
 import { useKBPreviewHint } from '../preview/preview-hint-context'
 import { KBSwitcherDropdownContent } from '../sidebar/kb-switcher'
+import { useKBEditorAccess } from './kb-editor-access-context'
 import { KBPublishCluster } from './kb-publish-cluster'
 
 const PANEL_VALUES = ['general', 'layout', 'articles'] as const
@@ -49,7 +50,9 @@ function getInitials(name?: string): string {
  * panel is forced to the article tree), no publish cluster (it is INTERNAL
  * and never site-published), and a plain breadcrumb instead of the KB
  * switcher (the learned KB is excluded from `kb.list`, so the switcher
- * neither names it nor offers it).
+ * neither names it nor offers it). An Edit-level (non-admin) member gets the
+ * same trimmed chrome minus the switcher swap — settings/layout/publish are
+ * Full-only (doc 24 §A.2.4); Share stays for everyone.
  */
 export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeaderProps) {
   const [panel, setPanel] = useQueryState(
@@ -58,6 +61,7 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
   )
   const { lockSession } = useKBPreviewHint()
   const [shareOpen, setShareOpen] = useState(false)
+  const { canAdmin } = useKBEditorAccess()
   const isLearned = knowledgeBase.kind === 'learned'
 
   // Once the user has reached the Articles panel they've found the answer the
@@ -85,7 +89,7 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
               open={shareOpen}
               onOpenChange={setShareOpen}
             />
-            <KBPublishCluster kbId={knowledgeBaseId} />
+            {canAdmin && <KBPublishCluster kbId={knowledgeBaseId} />}
           </div>
         )
       }>
@@ -115,7 +119,7 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
           </MainPageBreadcrumbDropdown>
         )}
       </MainPageBreadcrumb>
-      {!isLearned && (
+      {!isLearned && canAdmin && (
         <MainPageTabs
           value={panel}
           onValueChange={(v) => setPanel(v as KBEditorPanel)}

--- a/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
@@ -14,6 +14,7 @@ import { KBPreview } from '../preview/kb-preview'
 import { ArticleDiffPane } from './article-diff-pane'
 import { ArticleEditor } from './article-editor'
 import { ContainerArticlePlaceholder } from './container-article-placeholder'
+import { useKBEditorAccess } from './kb-editor-access-context'
 
 interface KBEditorPageBodyProps {
   knowledgeBaseId: string
@@ -30,11 +31,14 @@ export function KBEditorPageBody({ knowledgeBaseId, slug }: KBEditorPageBodyProp
   const [activePanel] = useQueryState('panel', { defaultValue: 'general' })
   const { knowledgeBase } = useKnowledgeBase(knowledgeBaseId)
   const hasArticlesLoaded = useIsArticleListLoaded(knowledgeBaseId)
+  const { canAdmin } = useKBEditorAccess()
 
   if (!knowledgeBase) return null
 
-  // The learned KB ("AI Memory") has no site preview — always the editor.
-  if (activePanel !== 'articles' && knowledgeBase.kind !== 'learned') {
+  // The learned KB ("AI Memory") has no site preview — always the editor. Nor
+  // does an Edit-level (non-admin) member get the site preview even via a
+  // stale `?panel=general` deep link — settings/layout are Full-only.
+  if (activePanel !== 'articles' && knowledgeBase.kind !== 'learned' && canAdmin) {
     return <KBPreview knowledgeBase={knowledgeBase} activeSlugPath={slug} />
   }
 

--- a/apps/web/src/components/kb/ui/editor/kb-tab-panel.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-tab-panel.tsx
@@ -13,6 +13,7 @@ import { GeneralTab } from '../settings/general/general-tab'
 import { LayoutTab } from '../settings/layout/layout-tab'
 import { KBArticlesPanel } from '../sidebar/kb-articles-panel'
 import { KBArticlesHeaderActions } from './kb-articles-header-actions'
+import { useKBEditorAccess } from './kb-editor-access-context'
 
 const PANEL_VALUES = ['general', 'layout', 'articles'] as const
 
@@ -39,9 +40,12 @@ export function KBTabPanel({ knowledgeBaseId, knowledgeBase }: KBTabPanelProps) 
     parseAsStringLiteral(PANEL_VALUES).withDefault('general')
   )
   // The learned KB ("AI Memory") has no settings tabs — the panel is always
-  // the article tree, retitled "Memory".
+  // the article tree, retitled "Memory". Same for an Edit-level (non-admin)
+  // member — settings/layout are Full-only (doc 24 §A.2.4) — so General/Layout
+  // never mount and their autosave hooks never run for them.
+  const { canAdmin } = useKBEditorAccess()
   const isLearned = knowledgeBase.kind === 'learned'
-  const activePanel = isLearned ? 'articles' : panelParam
+  const activePanel = isLearned || !canAdmin ? 'articles' : panelParam
 
   const isSaving = useKnowledgeBaseStore((s) => Boolean(s.pendingDraftPatches[knowledgeBaseId]))
 

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
@@ -43,8 +43,9 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
   const [confirm, ConfirmDialog] = useConfirm()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [shareOpen, setShareOpen] = useState(false)
-  const { isRestrictedInstance } = useAccess()
+  const { isRestrictedInstance, canAdminInstance } = useAccess()
   const isShared = isRestrictedInstance(kb.id)
+  const canAdmin = canAdminInstance(toRecordId('kb', kb.id))
 
   const bulkMode = useBulkMode()
   const selected = useIsSelected(kb.id)
@@ -126,10 +127,12 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
               <Book />
               Open
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
-              <Settings />
-              Settings
-            </DropdownMenuItem>
+            {canAdmin && (
+              <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
+                <Settings />
+                Settings
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={() => setShareOpen(true)}>
               <Share2 />
               Share…
@@ -138,11 +141,15 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
               targetType='KNOWLEDGE_BASE'
               targetIds={{ knowledgeBaseId: kb.id }}
             />
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant='destructive' onClick={() => void handleDelete()}>
-              <Trash />
-              Delete
-            </DropdownMenuItem>
+            {canAdmin && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant='destructive' onClick={() => void handleDelete()}>
+                  <Trash />
+                  Delete
+                </DropdownMenuItem>
+              </>
+            )}
           </>
         }
       />

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-bulk-bar.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-bulk-bar.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-bulk-bar.tsx
 'use client'
 
+import { toRecordId } from '@auxx/types/resource'
 import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
 import { pluralize } from '@auxx/utils/strings'
 import { Trash } from 'lucide-react'
@@ -11,6 +12,7 @@ import {
   useSelectionCount,
   useSelectionIds,
 } from '~/components/list-selection'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { getKnowledgeBaseStoreState } from '../../store/knowledge-base-store'
 import { useKnowledgeBasesList } from './knowledge-bases-provider'
@@ -31,34 +33,42 @@ export function KnowledgeBasesBulkBar() {
   const { refetch } = useKnowledgeBasesList()
   const { ConfirmDialog, run, isRunning } = useBulkRunner()
   const del = api.kb.delete.useMutation()
+  const { canAdminInstance } = useAccess()
 
-  const actions: ActionBarAction[] = [
-    {
-      id: 'delete',
-      label: 'Delete',
-      icon: Trash,
-      variant: 'destructive',
-      tooltip: 'Delete selected',
-      disabled: isRunning || count === 0,
-      onClick: () =>
-        run(
-          ids,
-          async (id) => {
-            await del.mutateAsync({ id })
-            getKnowledgeBaseStoreState().confirmKBDelete(id)
-          },
-          {
-            title: `Delete ${count} ${pluralize(count, 'knowledge base')}?`,
-            description: 'This permanently deletes them. This cannot be undone.',
-            failureTitle: 'Some knowledge bases could not be deleted',
-            onDone: () => {
-              refetch()
-              exit()
-            },
-          }
-        ),
-    },
-  ]
+  // Delete is Full-only per instance — hide the bulk action unless every
+  // selected KB passes admin (simplest correct rule; per-item filtering inside
+  // a bulk delete is silent-partial-failure UX).
+  const allSelectedAdmin = ids.every((id) => canAdminInstance(toRecordId('kb', id)))
+
+  const actions: ActionBarAction[] = allSelectedAdmin
+    ? [
+        {
+          id: 'delete',
+          label: 'Delete',
+          icon: Trash,
+          variant: 'destructive',
+          tooltip: 'Delete selected',
+          disabled: isRunning || count === 0,
+          onClick: () =>
+            run(
+              ids,
+              async (id) => {
+                await del.mutateAsync({ id })
+                getKnowledgeBaseStoreState().confirmKBDelete(id)
+              },
+              {
+                title: `Delete ${count} ${pluralize(count, 'knowledge base')}?`,
+                description: 'This permanently deletes them. This cannot be undone.',
+                failureTitle: 'Some knowledge bases could not be deleted',
+                onDone: () => {
+                  refetch()
+                  exit()
+                },
+              }
+            ),
+        },
+      ]
+    : []
 
   return (
     <>

--- a/apps/web/src/components/kb/ui/sidebar/article-insert-line.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/article-insert-line.tsx
@@ -17,6 +17,7 @@ import { useArticleList } from '../../hooks/use-article-list'
 import { AFTER_GROUP_SUFFIX } from '../../hooks/use-article-move'
 import type { ArticleTreeNode } from '../../store/article-store'
 import { usePendingInsertStore } from '../../store/pending-insert-store'
+import { useKBEditorAccess } from '../editor/kb-editor-access-context'
 
 type InsertMode = 'sibling-after' | 'first-child' | 'after-group'
 
@@ -49,6 +50,7 @@ export function ArticleInsertLine({
   knowledgeBaseId,
   mode = 'sibling-after',
 }: ArticleInsertLineProps) {
+  const { canEdit } = useKBEditorAccess()
   const articles = useArticleList(knowledgeBaseId)
   const setPending = usePendingInsertStore((s) => s.setPending)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -111,6 +113,10 @@ export function ArticleInsertLine({
     isAfterGroup ? 'left-0' : 'left-[-8px]',
     menuOpen ? 'bg-blue-500 text-white opacity-100' : 'text-muted-foreground opacity-0'
   )
+
+  // Create is an Edit-instance affordance — hide the insert line entirely for
+  // view-only members (doc 24 §A.2.4).
+  if (!canEdit) return null
 
   return (
     <>

--- a/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
@@ -56,6 +56,7 @@ import { usePublishWithConfirm } from '../../hooks/use-publish-with-confirm'
 import type { ArticleMeta, ArticleTreeNode } from '../../store/article-store'
 import { usePendingInsertStore } from '../../store/pending-insert-store'
 import { ArticleSettingsDialog } from '../editor/article-settings-dialog'
+import { useKBEditorAccess } from '../editor/kb-editor-access-context'
 import { ArticleInsertLine } from './article-insert-line'
 
 function StatusDot({
@@ -110,6 +111,7 @@ export function ArticleSidebarItem({
   isOpen = false,
   onToggleOpen,
 }: ArticleSidebarItemProps) {
+  const { canEdit } = useKBEditorAccess()
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const router = useRouter()
   const pathname = usePathname() ?? ''
@@ -299,17 +301,21 @@ export function ArticleSidebarItem({
         </>
       )}
       <DropdownMenuGroup>
-        <DropdownMenuItem onSelect={() => setIsRenaming(true)}>
-          <Pencil /> Rename
-        </DropdownMenuItem>
-        {!isLink && (
+        {canEdit && (
+          <DropdownMenuItem onSelect={() => setIsRenaming(true)}>
+            <Pencil /> Rename
+          </DropdownMenuItem>
+        )}
+        {!isLink && canEdit && (
           <DropdownMenuItem onClick={handleAddSubItem}>
             <Files /> Add sub-item
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem onClick={() => setIsSettingsOpen(true)}>
-          <Cog /> Page settings
-        </DropdownMenuItem>
+        {canEdit && (
+          <DropdownMenuItem onClick={() => setIsSettingsOpen(true)}>
+            <Cog /> Page settings
+          </DropdownMenuItem>
+        )}
         {!isHeader && !isLink && (
           <DropdownMenuItem asChild>
             <a href={previewHref} target='_blank' rel='noopener'>
@@ -317,9 +323,11 @@ export function ArticleSidebarItem({
             </a>
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem onClick={() => duplicateArticle(article)}>
-          <BookCopy /> Duplicate
-        </DropdownMenuItem>
+        {canEdit && (
+          <DropdownMenuItem onClick={() => duplicateArticle(article)}>
+            <BookCopy /> Duplicate
+          </DropdownMenuItem>
+        )}
         {(article.articleKind === 'page' || article.articleKind === 'category') && (
           <FavoriteToggleMenuItem
             targetType='ARTICLE'
@@ -340,36 +348,40 @@ export function ArticleSidebarItem({
           </DropdownMenuGroup>
         </>
       )}
-      <DropdownMenuSeparator />
-      <DropdownMenuGroup>
-        {isArchived ? (
-          <DropdownMenuItem onClick={() => unarchiveArticle(article.id)}>
-            <ArchiveRestore /> Unarchive
+      {canEdit && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            {isArchived ? (
+              <DropdownMenuItem onClick={() => unarchiveArticle(article.id)}>
+                <ArchiveRestore /> Unarchive
+              </DropdownMenuItem>
+            ) : article.isPublished ? (
+              <>
+                <DropdownMenuItem onClick={() => requestUnpublish(article)}>
+                  <EyeOff /> Unpublish
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => archiveArticle(article.id)}>
+                  <Archive /> Archive
+                </DropdownMenuItem>
+              </>
+            ) : (
+              <>
+                <DropdownMenuItem onClick={() => requestPublish(article)}>
+                  <Send /> Publish
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => archiveArticle(article.id)}>
+                  <Archive /> Archive
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={handleDelete} variant='destructive'>
+            <Trash2 /> Delete
           </DropdownMenuItem>
-        ) : article.isPublished ? (
-          <>
-            <DropdownMenuItem onClick={() => requestUnpublish(article)}>
-              <EyeOff /> Unpublish
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => archiveArticle(article.id)}>
-              <Archive /> Archive
-            </DropdownMenuItem>
-          </>
-        ) : (
-          <>
-            <DropdownMenuItem onClick={() => requestPublish(article)}>
-              <Send /> Publish
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => archiveArticle(article.id)}>
-              <Archive /> Archive
-            </DropdownMenuItem>
-          </>
-        )}
-      </DropdownMenuGroup>
-      <DropdownMenuSeparator />
-      <DropdownMenuItem onClick={handleDelete} variant='destructive'>
-        <Trash2 /> Delete
-      </DropdownMenuItem>
+        </>
+      )}
     </DropdownMenuContent>
   )
 
@@ -437,7 +449,7 @@ export function ArticleSidebarItem({
               isHeader && '-ml-3.5 opacity-0 group-hover/row:opacity-100'
             )}
             {...attributes}
-            {...(isRenaming ? {} : listeners)}>
+            {...(isRenaming || !canEdit ? {} : listeners)}>
             {!isHeader && (
               <span className='flex items-center group-hover/row:hidden size-4'>{icon}</span>
             )}
@@ -474,6 +486,7 @@ export function ArticleSidebarItem({
               }, 200)
             }}
             onDoubleClick={() => {
+              if (!canEdit) return
               if (navTimerRef.current) {
                 clearTimeout(navTimerRef.current)
                 navTimerRef.current = null

--- a/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
@@ -33,6 +33,7 @@ import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta, ArticleTreeNode } from '../../store/article-store'
 import { usePendingInsertStore } from '../../store/pending-insert-store'
 import { inferCreateParent } from '../../utils/infer-create-parent'
+import { useKBEditorAccess } from '../editor/kb-editor-access-context'
 import { ArticleSidebarItemPreview } from './article-sidebar-item'
 import { ArticleTreeSection } from './article-tree-section'
 import { KBTabStrip } from './kb-tab-strip'
@@ -61,6 +62,7 @@ function collectDescendants(parentId: string, all: ArticleMeta[]): ArticleMeta[]
 
 export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
   const router = useRouter()
+  const { canEdit } = useKBEditorAccess()
 
   const articles = useArticleList(knowledgeBaseId)
   const activeArticle = useActiveArticle(knowledgeBaseId)
@@ -273,7 +275,9 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
         onTabChange={handleTabChange}
       />
       <DndContext
-        sensors={sensors}
+        // Move is an Edit-instance affordance — an empty sensor list means no
+        // drag can ever start for view-only members (doc 24 §A.2.4).
+        sensors={canEdit ? sensors : []}
         collisionDetection={collisionDetection}
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
@@ -291,36 +295,42 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
             articleOpenStates={articleOpenStates}
             toggleArticleOpen={toggleArticleOpen}
           />
-          {tabSubtree.length === 0 && !(pending && pending.parentId === effectiveTabId) && (
-            <div className='px-6 text-center text-base text-muted-foreground'>
-              Nothing here yet.
-              <br /> Add a{' '}
-              <button
-                type='button'
-                onClick={() => void handleCreateInTab(ArticleKind.header)}
-                disabled={isCreating}
-                className='font-medium text-foreground underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50'>
-                Section Header
-              </button>
-              , a{' '}
-              <button
-                type='button'
-                onClick={() => void handleCreateInTab(ArticleKind.page)}
-                disabled={isCreating}
-                className='font-medium text-foreground underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50'>
-                Page
-              </button>
-              , or a{' '}
-              <button
-                type='button'
-                onClick={() => void handleCreateInTab(ArticleKind.link)}
-                disabled={isCreating}
-                className='font-medium text-foreground underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50'>
-                Link
-              </button>
-              .
-            </div>
-          )}
+          {tabSubtree.length === 0 &&
+            !(pending && pending.parentId === effectiveTabId) &&
+            (canEdit ? (
+              <div className='px-6 text-center text-base text-muted-foreground'>
+                Nothing here yet.
+                <br /> Add a{' '}
+                <button
+                  type='button'
+                  onClick={() => void handleCreateInTab(ArticleKind.header)}
+                  disabled={isCreating}
+                  className='font-medium text-foreground underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50'>
+                  Section Header
+                </button>
+                , a{' '}
+                <button
+                  type='button'
+                  onClick={() => void handleCreateInTab(ArticleKind.page)}
+                  disabled={isCreating}
+                  className='font-medium text-foreground underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50'>
+                  Page
+                </button>
+                , or a{' '}
+                <button
+                  type='button'
+                  onClick={() => void handleCreateInTab(ArticleKind.link)}
+                  disabled={isCreating}
+                  className='font-medium text-foreground underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50'>
+                  Link
+                </button>
+                .
+              </div>
+            ) : (
+              <div className='px-6 text-center text-base text-muted-foreground'>
+                Nothing here yet.
+              </div>
+            ))}
         </div>
 
         <DragOverlay
@@ -340,7 +350,7 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
       </DndContext>
 
       <div className='mt-2 px-2'>
-        {tabSubtree.length > 0 && (
+        {tabSubtree.length > 0 && canEdit && (
           <DropdownMenu
             open={addMenuOpen}
             onOpenChange={(open) => {

--- a/apps/web/src/server/api/routers/dataset.ts
+++ b/apps/web/src/server/api/routers/dataset.ts
@@ -470,8 +470,11 @@ export const datasetRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
-      // Full — testing embedding/search config is a settings-level operation.
-      ctx.capabilities.assertAdminInstance('dataset', input.datasetId)
+      // Read — running an ephemeral test search returns nothing a view-level
+      // user can't already see via listByDocument (includeInactive only
+      // surfaces disabled segments, same view). Saving config (`dataset.update`)
+      // stays admin; this just executes a throwaway query.
+      ctx.capabilities.assertViewInstance('dataset', input.datasetId)
       logger.info('Testing search configuration', {
         datasetId: input.datasetId,
         testQuery: input.testQuery,

--- a/apps/web/src/server/api/routers/segment.ts
+++ b/apps/web/src/server/api/routers/segment.ts
@@ -1,17 +1,83 @@
 // apps/web/src/server/api/routers/segment.ts
 
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
 import { IndexStatus } from '@auxx/database/enums'
 import { SegmentService } from '@auxx/lib/datasets'
+import { NotFoundError } from '@auxx/lib/errors'
 import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
 
 const logger = createScopedLogger('api/segment')
+
+/**
+ * Resolve a segment to its grandparent `datasetId` via the segment's document —
+ * segments inherit their dataset's access level same as documents (doc 11 §3).
+ * Org-scoped; 404s a missing/foreign segment.
+ */
+async function datasetIdForSegment(
+  db: Database,
+  segmentId: string,
+  organizationId: string
+): Promise<string> {
+  const [row] = await db
+    .select({ datasetId: schema.Document.datasetId })
+    .from(schema.DocumentSegment)
+    .innerJoin(schema.Document, eq(schema.DocumentSegment.documentId, schema.Document.id))
+    .where(
+      and(
+        eq(schema.DocumentSegment.id, segmentId),
+        eq(schema.DocumentSegment.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  if (!row) throw new NotFoundError('Segment not found')
+  return row.datasetId
+}
+
+/** Resolve a batch of segments to their distinct grandparent `datasetId`s (§3). */
+async function datasetIdsForSegments(
+  db: Database,
+  segmentIds: string[],
+  organizationId: string
+): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ datasetId: schema.Document.datasetId })
+    .from(schema.DocumentSegment)
+    .innerJoin(schema.Document, eq(schema.DocumentSegment.documentId, schema.Document.id))
+    .where(
+      and(
+        inArray(schema.DocumentSegment.id, segmentIds),
+        eq(schema.DocumentSegment.organizationId, organizationId)
+      )
+    )
+  return rows.map((r) => r.datasetId)
+}
+
+/** Resolve a document to its parent `datasetId` (doc 11 §3). Org-scoped; 404s a missing document. */
+async function datasetIdForDocument(
+  db: Database,
+  documentId: string,
+  organizationId: string
+): Promise<string> {
+  const [row] = await db
+    .select({ datasetId: schema.Document.datasetId })
+    .from(schema.Document)
+    .where(
+      and(eq(schema.Document.id, documentId), eq(schema.Document.organizationId, organizationId))
+    )
+    .limit(1)
+  if (!row) throw new NotFoundError('Document not found')
+  return row.datasetId
+}
+
 export const segmentRouter = createTRPCRouter({
   /**
    * Update segment content
    */
-  updateContent: protectedProcedure
+  updateContent: capabilityProcedure
     .input(
       z.object({
         segmentId: z.string(),
@@ -23,6 +89,8 @@ export const segmentRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      const datasetId = await datasetIdForSegment(ctx.db, input.segmentId, organizationId)
+      ctx.capabilities.assertEditInstance('dataset', datasetId)
       const segmentService = new SegmentService(ctx.db)
       const updatedSegment = await segmentService.updateContent(
         input.segmentId,
@@ -38,7 +106,7 @@ export const segmentRouter = createTRPCRouter({
   /**
    * Toggle segment enabled status
    */
-  toggleEnabled: protectedProcedure
+  toggleEnabled: capabilityProcedure
     .input(
       z.object({
         segmentId: z.string(),
@@ -50,6 +118,8 @@ export const segmentRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      const datasetId = await datasetIdForSegment(ctx.db, input.segmentId, organizationId)
+      ctx.capabilities.assertEditInstance('dataset', datasetId)
       const segmentService = new SegmentService(ctx.db)
       const updatedSegment = await segmentService.toggleEnabled(
         input.segmentId,
@@ -66,7 +136,7 @@ export const segmentRouter = createTRPCRouter({
   /**
    * Delete a segment
    */
-  delete: protectedProcedure
+  delete: capabilityProcedure
     .input(
       z.object({
         segmentId: z.string(),
@@ -77,6 +147,8 @@ export const segmentRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      const datasetId = await datasetIdForSegment(ctx.db, input.segmentId, organizationId)
+      ctx.capabilities.assertEditInstance('dataset', datasetId)
       const segmentService = new SegmentService(ctx.db)
       await segmentService.delete(input.segmentId, organizationId)
       logger.info('Segment deleted', {
@@ -88,7 +160,7 @@ export const segmentRouter = createTRPCRouter({
   /**
    * Batch update segments
    */
-  batchUpdate: protectedProcedure
+  batchUpdate: capabilityProcedure
     .input(
       z.object({
         segmentIds: z.array(z.string()).min(1).max(100),
@@ -99,6 +171,11 @@ export const segmentRouter = createTRPCRouter({
       const organizationId = ctx.session.user.defaultOrganizationId
       if (!organizationId) {
         throw new Error('No organization found')
+      }
+      // Write — resolve every segment to its dataset and require Edit on all.
+      const datasetIds = await datasetIdsForSegments(ctx.db, input.segmentIds, organizationId)
+      for (const datasetId of datasetIds) {
+        ctx.capabilities.assertEditInstance('dataset', datasetId)
       }
       const segmentService = new SegmentService(ctx.db)
       const results = await segmentService.batchOperation(
@@ -116,7 +193,7 @@ export const segmentRouter = createTRPCRouter({
   /**
    * Get segment by ID
    */
-  getById: protectedProcedure
+  getById: capabilityProcedure
     .input(
       z.object({
         segmentId: z.string(),
@@ -127,13 +204,15 @@ export const segmentRouter = createTRPCRouter({
       if (!organizationId) {
         return null
       }
+      const datasetId = await datasetIdForSegment(ctx.db, input.segmentId, organizationId)
+      ctx.capabilities.assertViewInstance('dataset', datasetId)
       const segmentService = new SegmentService(ctx.db)
       return await segmentService.getById(input.segmentId, organizationId)
     }),
   /**
    * List segments for a document with search and pagination
    */
-  listByDocument: protectedProcedure
+  listByDocument: capabilityProcedure
     .input(
       z.object({
         documentId: z.string(),
@@ -152,6 +231,8 @@ export const segmentRouter = createTRPCRouter({
       if (!organizationId) {
         return { segments: [], totalCount: 0, hasMore: false, page: input.page }
       }
+      const datasetId = await datasetIdForDocument(ctx.db, input.documentId, organizationId)
+      ctx.capabilities.assertViewInstance('dataset', datasetId)
       const segmentService = new SegmentService(ctx.db)
       return await segmentService.listByDocument(
         input.documentId,
@@ -173,7 +254,7 @@ export const segmentRouter = createTRPCRouter({
   /**
    * Reindex a segment
    */
-  reindex: protectedProcedure
+  reindex: capabilityProcedure
     .input(
       z.object({
         segmentId: z.string(),
@@ -184,6 +265,8 @@ export const segmentRouter = createTRPCRouter({
       if (!organizationId) {
         throw new Error('No organization found')
       }
+      const datasetId = await datasetIdForSegment(ctx.db, input.segmentId, organizationId)
+      ctx.capabilities.assertEditInstance('dataset', datasetId)
       const segmentService = new SegmentService(ctx.db)
       await segmentService.reindex(input.segmentId, organizationId)
       logger.info('Segment queued for reindexing', {


### PR DESCRIPTION
## Summary

Part A of the kb/dataset enforcement plan: the server already enforced the intended split (Edit = author articles/documents, Full = settings/delete/publish), but the UI barely checked anything — Edit-level users landed on KB settings panels that 403-looped on autosave, Read-level users saw every mutation affordance. Plus one genuine server hole.

### Server
- **`segment.ts` (security fix)**: every procedure was plain `protectedProcedure` with zero capability asserts — any org member who knew a segment/document id could read/edit/delete/reindex segments, bypassing the dataset instance-access model entirely. Now `capabilityProcedure` with org-scoped segment→document→dataset resolution and `assertEditInstance` on mutations (per distinct dataset for batches) / `assertViewInstance` on reads.
- **`dataset.testSearchConfig`**: `assertAdminInstance` → `assertViewInstance`. The config is per-request and ephemeral; results are content a view-level user can already read. Saving search config (`dataset.update`) stays admin.

### KB editor
- New `kb-editor-access-context` derives `canEdit`/`canAdmin` once from the capabilities provider.
- Non-admins get the same trimmed chrome as the learned KB: no General/Layout tabs, no publish cluster, panel forced to `articles` (deep links with `?panel=general` included) so the settings autosave hook never mounts. Share stays for everyone (dialog is already read-only for non-admins).
- View-only users: read-only article editor, no create/rename/move/settings/duplicate/publish/delete affordances, drag-reorder disabled via empty dnd-kit sensors.

### Cards, bulk bars, dataset detail
- KB/dataset card menus: Settings/Archive/Delete only with `canAdminInstance`; Share always visible.
- Bulk bars: destructive actions render only if **every** selected instance passes admin (all-or-nothing beats silent partial failure).
- Dataset detail: wires the existing-but-never-passed `readOnly` prop on `DatasetSettings`; Upload/document delete/reprocess/rename gated on `canEditInstance` (extends the existing `document-management` pattern to the table and drawer).
- Drive-by: removed the success toast in `dataset-search.tsx` (errors-only toast rule).

Gating style throughout is hide-not-disable, matching existing patterns. No new capability keys, no migrations, no cache bump — the composed `instanceAccess` blob already carries everything the client needs.

## Test plan
- [ ] Manual matrix (view / edit / admin instance levels via the share dialog, one KB + one dataset):
  - view: content + read-only Share only; KB editor opens on articles, read-only; `api.segment.updateContent` from console 403s
  - edit: full article/document authoring; no settings tabs, publish cluster, or archive/delete; dataset search works
  - admin: unchanged
- [ ] Mixed bulk selection (one admin-level + one edit-level instance) hides bulk delete
- Typecheck: touched files clean (remaining errors in shared files verified pre-existing against the known broken baseline); Biome clean via lint-staged