### PR TITLE
feat(permissions): expandable per-def and per-instance access rows in all permission grids

### DIFF
--- a/apps/web/src/components/groups/ui/group-detail.tsx
+++ b/apps/web/src/components/groups/ui/group-detail.tsx
@@ -16,7 +16,6 @@ import { Globe, Lock, ShieldCheck, UsersRound } from 'lucide-react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { UpgradeBanner } from '~/components/banner/upgrade-banner'
 import SettingsPage from '~/components/global/settings-page'
-import { GranteeDefAccessSection } from '~/components/permissions/ui/grantee-def-access-section'
 import { GranteeLevelsSection } from '~/components/permissions/ui/grantee-levels-section'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
@@ -134,11 +133,6 @@ export function GroupDetail({ groupId }: { groupId: string }) {
               />
             )}
             <GranteeLevelsSection
-              granteeKind='group'
-              granteeId={group.id}
-              canEdit={canEditPermissions}
-            />
-            <GranteeDefAccessSection
               granteeKind='group'
               granteeId={group.id}
               canEdit={canEditPermissions}

--- a/apps/web/src/components/members/ui/member-detail.tsx
+++ b/apps/web/src/components/members/ui/member-detail.tsx
@@ -17,7 +17,6 @@ import { ShieldCheck, User, Users } from 'lucide-react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { UpgradeBanner } from '~/components/banner/upgrade-banner'
 import SettingsPage from '~/components/global/settings-page'
-import { GranteeDefAccessSection } from '~/components/permissions/ui/grantee-def-access-section'
 import { GranteeLevelsSection } from '~/components/permissions/ui/grantee-levels-section'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
@@ -155,11 +154,6 @@ export function MemberDetail({ userId }: { userId: string }) {
             )}
             <MemberAccessSection member={member} viewerRole={viewerRole} viewerId={viewerId} />
             <GranteeLevelsSection
-              granteeKind='user'
-              granteeId={member.userId}
-              canEdit={canEditPermissions}
-            />
-            <GranteeDefAccessSection
               granteeKind='user'
               granteeId={member.userId}
               canEdit={canEditPermissions}

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
@@ -1,11 +1,7 @@
 // apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
 'use client'
 
-import {
-  ResourceGranteeType,
-  ResourcePermission,
-  type SharingGranteeType,
-} from '@auxx/database/enums'
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import {
   Area,
   ENTITY_BASE_AREAS,
@@ -22,17 +18,18 @@ import { api } from '~/trpc/react'
 import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permission-grants'
 
 /**
- * The grantee axis this section edits: an individual member or a team.
+ * The grantee axis this section edits: an individual member, a team, or (doc 19
+ * §9 step 9 lifted the write guard) a **profile itself** — the profile editor's
+ * own Records-area nesting (capability layer v2 Part B extension, plan 24).
  *
- * A `'profile'` kind is deliberately absent. It is not a missing tab — the
- * grantee-centric def grid writes `ResourceAccess` rows through
- * `resourceAccess.grantType`/`revokeType`, and profile-grantee `ResourceAccess`
- * writes are refused at the service layer (`assertProfileGranteeSupported`) until
- * every resolver reads them. Adding it here would ship a picker whose every
- * selection 400s. Per-def profile access is therefore explicitly **unsupported**
- * on this surface; it belongs to the profile-side def grid in doc 19 §7.
+ * A `'profile'` grantee is NOT a member/team override: it has no separate
+ * workspace-baseline-relative composition, because a profile's def override
+ * doesn't raise above anything external — it's authored directly on the
+ * profile being edited. Its "own area levels" therefore come from the caller's
+ * live (possibly unsaved) draft, passed in as `profileOwnLevels`, never from
+ * `usePermissionGrants()`'s persisted `groupGrants`/`userGrants`.
  */
-export type GranteeKind = 'user' | 'group'
+export type GranteeKind = 'user' | 'group' | 'profile'
 
 /**
  * How the grantee's Layer-2 area levels compose — which decides what an
@@ -45,14 +42,16 @@ export type GranteeKind = 'user' | 'group'
 export type GranteePrincipal = 'member' | 'agent'
 
 /**
- * Typed against `SharingGranteeType`, not `ResourceGranteeType`: the wider union
- * carries `'profile'`, whose ResourceAccess writes are still refused server-side.
- * Total over {@link GranteeKind} by construction — there is no fall-through
- * branch that could turn an unmodelled kind into a `user` write.
+ * Typed against the full `ResourceGranteeType` (not the narrower
+ * `SharingGranteeType`, which excludes `profile` by construction) so a
+ * `'profile'` kind resolves to a real, authorable grantee address. Total over
+ * {@link GranteeKind} by construction — there is no fall-through branch that
+ * could turn an unmodelled kind into a `user` write.
  */
-const GRANTEE_TYPE: Record<GranteeKind, SharingGranteeType> = {
+const GRANTEE_TYPE: Record<GranteeKind, ResourceGranteeType> = {
   user: ResourceGranteeType.user,
   group: ResourceGranteeType.group,
+  profile: ResourceGranteeType.profile,
 }
 
 /** One def's row in the grantee-centric Access grid. */
@@ -96,7 +95,15 @@ export interface GranteeDefAccessRow {
 export function useGranteeDefAccess(
   granteeKind: GranteeKind,
   granteeId: string,
-  principal: GranteePrincipal = 'member'
+  principal: GranteePrincipal = 'member',
+  /**
+   * Required (and only meaningful) for `granteeKind: 'profile'` — the
+   * profile's own live draft: its per-area base `levels` and blanket
+   * `baseLevel`, exactly as the profile editor's own grid renders them. A
+   * profile grantee has no external baseline to raise above, so its "Inherit"
+   * fall-through is this draft, not `usePermissionGrants()`'s persisted maps.
+   */
+  profileOwnLevels?: { levels: Partial<Record<Area, Level>>; baseLevel: Level | null }
 ) {
   const utils = api.useUtils()
   const { resources, isLoading: resourcesLoading } = useResources()
@@ -112,19 +119,25 @@ export function useGranteeDefAccess(
     userGrants,
   } = usePermissionGrants()
   const ownAreaLevels = useMemo(() => {
+    if (granteeKind === 'profile') return profileOwnLevels?.levels ?? {}
     const persisted = granteeKind === 'group' ? groupGrants : userGrants
     return persisted.find((g) => g.granteeId === granteeId)?.levels ?? {}
-  }, [granteeKind, granteeId, groupGrants, userGrants])
+  }, [granteeKind, granteeId, groupGrants, userGrants, profileOwnLevels])
 
   const targetBasePermission = useCallback(
     (area: Area): ResourcePermission => {
       const level =
         principal === 'agent'
           ? (ownAreaLevels[area] ?? Level.Full)
-          : (ownAreaLevels[area] ?? effectiveBaseline[area] ?? roleDefaults?.[area] ?? Level.None)
+          : granteeKind === 'profile'
+            ? (ownAreaLevels[area] ??
+              profileOwnLevels?.baseLevel ??
+              roleDefaults?.[area] ??
+              Level.None)
+            : (ownAreaLevels[area] ?? effectiveBaseline[area] ?? roleDefaults?.[area] ?? Level.None)
       return levelToRecordBasePermission(level) ?? ResourcePermission.none
     },
-    [principal, ownAreaLevels, effectiveBaseline, roleDefaults]
+    [principal, granteeKind, ownAreaLevels, profileOwnLevels, effectiveBaseline, roleDefaults]
   )
 
   const workspaceBasePermission = useCallback(

--- a/apps/web/src/components/permissions/hooks/use-instance-baseline-rows.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-baseline-rows.ts
@@ -1,0 +1,140 @@
+// apps/web/src/components/permissions/hooks/use-instance-baseline-rows.ts
+'use client'
+
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import {
+  INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+  levelToPermission,
+} from '@auxx/lib/permissions/client'
+import { toRecordId } from '@auxx/types/resource'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useMemo } from 'react'
+import { api } from '~/trpc/react'
+import { deriveInstanceBadge, type InstanceAccessBadge } from '../utils/instance-access-badge'
+import { type OpenInstanceTypes, useInstanceResourceLists } from './use-instance-resource-lists'
+import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permission-grants'
+
+/** Every instance-access key is always "open" here — see the hook doc below. */
+const ALWAYS_OPEN: OpenInstanceTypes = { dataset: true, kb: true, dashboard: true }
+
+/** One dataset/kb/dashboard row nested under its area on the Member baseline grid. */
+export interface InstanceBaselineRow {
+  key: InstanceAccessKey
+  id: string
+  name: string
+  /** The `role:org_member` row's permission; `undefined` = Inherit (no row). */
+  baselineLevel: ResourcePermission | undefined
+  /** What "Inherit" resolves to — the area's base level, or No Access when the
+   *  resource is born with no baseline (`baselineAtCreate: true`, dashboards). */
+  inheritedLevel: ResourcePermission
+  /** Collapsed-row badge derived from the org-wide `allInstanceAccess` rows. */
+  badge: InstanceAccessBadge
+}
+
+/**
+ * Data + mutations for the per-instance rows nested under the Datasets /
+ * Knowledge base / Dashboards area rows on the Member baseline grid
+ * (capability layer v2 Part B) — the instance twin of `useDefBaselines`.
+ *
+ * Reads every listed instance via `useInstanceResourceLists` (always "open":
+ * the host's search box has to match instance names to decide whether to
+ * auto-expand an area, so there is no lazy gate to defer the listing behind —
+ * unlike the agent-policy grid's own per-row expand toggle) plus the org-wide
+ * `resourceAccess.allInstanceAccess` rows, and derives each instance's
+ * workspace-baseline level and collapsed-row badge without a per-instance
+ * query (§B.2.5). Writes reuse the same `grantInstance`/`revokeInstance`
+ * funnel the Share card and dialog already use, keyed to the `role:org_member`
+ * grantee — "Inherit" REVOKES that row (no explicit baseline), "Restricted"
+ * WRITES it at `'none'`, and Read/Write/Full write the matching permission.
+ */
+export function useInstanceBaselineRows() {
+  const utils = api.useUtils()
+  const { roleDefaults, baseline } = usePermissionGrants()
+  const lists = useInstanceResourceLists(ALWAYS_OPEN)
+
+  const allQuery = api.resourceAccess.allInstanceAccess.useQuery(undefined, { staleTime: 30_000 })
+  const allRows = useMemo(() => allQuery.data ?? [], [allQuery.data])
+
+  const invalidate = useCallback(() => {
+    void utils.resourceAccess.allInstanceAccess.invalidate()
+  }, [utils])
+
+  const grantInstance = api.resourceAccess.grantInstance.useMutation({
+    onError: (error) => toastError({ title: 'Error updating access', description: error.message }),
+    onSettled: (_data, _error, variables) => {
+      invalidate()
+      if (variables)
+        void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
+    },
+  })
+  const revokeInstance = api.resourceAccess.revokeInstance.useMutation({
+    onError: (error) => toastError({ title: 'Error removing access', description: error.message }),
+    onSettled: (_data, _error, variables) => {
+      invalidate()
+      if (variables)
+        void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
+    },
+  })
+
+  const rowsByKey = useMemo(() => {
+    const result = {} as Record<InstanceAccessKey, InstanceBaselineRow[]>
+    for (const key of INSTANCE_ACCESS_KEYS) {
+      const cfg = INSTANCE_ACCESS_RESOURCES[key]
+      const areaLevel = baseline[cfg.area] ?? roleDefaults?.[cfg.area]
+      const inheritedLevel = cfg.baselineAtCreate
+        ? ResourcePermission.none
+        : ((areaLevel !== undefined ? levelToPermission(areaLevel) : undefined) ??
+          ResourcePermission.none)
+
+      result[key] = lists[key].items.map((item) => {
+        const instanceRows = allRows.filter(
+          (r) => r.entityDefinitionId === key && r.entityInstanceId === item.id
+        )
+        const baselineRow = instanceRows.find(
+          (r) =>
+            r.granteeType === ResourceGranteeType.role && r.granteeId === MEMBER_BASELINE_GRANTEE_ID
+        )
+        return {
+          key,
+          id: item.id,
+          name: item.name,
+          baselineLevel: baselineRow?.permission,
+          inheritedLevel,
+          badge: deriveInstanceBadge(instanceRows),
+        }
+      })
+    }
+    return result
+  }, [lists, allRows, baseline, roleDefaults])
+
+  /** Set (or, `'inherit'`, revoke) the `role:org_member` row for one instance. */
+  const setBaseline = useCallback(
+    (key: InstanceAccessKey, instanceId: string, level: ResourcePermission | 'inherit') => {
+      const recordId = toRecordId(key, instanceId)
+      if (level === 'inherit') {
+        revokeInstance.mutate({
+          recordId,
+          granteeType: ResourceGranteeType.role,
+          granteeId: MEMBER_BASELINE_GRANTEE_ID,
+        })
+        return
+      }
+      grantInstance.mutate({
+        recordId,
+        granteeType: ResourceGranteeType.role,
+        granteeId: MEMBER_BASELINE_GRANTEE_ID,
+        permission: level,
+      })
+    },
+    [grantInstance, revokeInstance]
+  )
+
+  return {
+    lists,
+    isLoading: allQuery.isLoading,
+    rowsByKey,
+    setBaseline,
+  }
+}

--- a/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
@@ -1,0 +1,112 @@
+// apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
+'use client'
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import { INSTANCE_ACCESS_KEYS, type InstanceAccessKey } from '@auxx/lib/permissions/client'
+import { toRecordId } from '@auxx/types/resource'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useMemo } from 'react'
+import { api } from '~/trpc/react'
+import { deriveInstanceBadge, type InstanceAccessBadge } from '../utils/instance-access-badge'
+import type { GranteeKind } from './use-grantee-def-access'
+import { type OpenInstanceTypes, useInstanceResourceLists } from './use-instance-resource-lists'
+
+/** Every instance-access key is always "open" here — same rationale as the
+ *  baseline-scope hook: the host's search box has to match instance names. */
+const ALWAYS_OPEN: OpenInstanceTypes = { dataset: true, kb: true, dashboard: true }
+
+/** One dataset/kb/dashboard row nested under its area in a grantee scope. */
+export interface InstanceGranteeRow {
+  key: InstanceAccessKey
+  id: string
+  name: string
+  /** This grantee's own explicit grant; `undefined` = Inherit (no row). */
+  grantLevel: ResourcePermission | undefined
+  /** Collapsed-row badge derived from the org-wide `allInstanceAccess` rows —
+   *  the same fact regardless of which grantee's page this is (§B.2.5). */
+  badge: InstanceAccessBadge
+}
+
+/**
+ * Data + mutations for the per-instance rows nested under the Datasets /
+ * Knowledge base / Dashboards area rows in a **grantee scope** (a member or
+ * team's own override grid — capability layer v2 Part B). Unlike the area
+ * levels above it, instance grants are NOT raise-only (§B.2.6): this surface
+ * writes the grantee's raw instance-access grant through the same
+ * `grantInstance`/`revokeInstance` funnel the Share card uses, offering the
+ * full Inherit / Read / Write / Full / No Access vocabulary.
+ *
+ * Reads the same org-wide `resourceAccess.allInstanceAccess` rows as the
+ * baseline-scope hook (one query, shared React Query cache across every
+ * mounted area) and narrows to this grantee's own row per instance.
+ */
+export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: string) {
+  const utils = api.useUtils()
+  const lists = useInstanceResourceLists(ALWAYS_OPEN)
+
+  const allQuery = api.resourceAccess.allInstanceAccess.useQuery(undefined, { staleTime: 30_000 })
+  const allRows = useMemo(() => allQuery.data ?? [], [allQuery.data])
+
+  const invalidate = useCallback(() => {
+    void utils.resourceAccess.allInstanceAccess.invalidate()
+  }, [utils])
+
+  const grantInstance = api.resourceAccess.grantInstance.useMutation({
+    onError: (error) => toastError({ title: 'Error updating access', description: error.message }),
+    onSettled: (_data, _error, variables) => {
+      invalidate()
+      if (variables)
+        void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
+    },
+  })
+  const revokeInstance = api.resourceAccess.revokeInstance.useMutation({
+    onError: (error) => toastError({ title: 'Error removing access', description: error.message }),
+    onSettled: (_data, _error, variables) => {
+      invalidate()
+      if (variables)
+        void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
+    },
+  })
+
+  const rowsByKey = useMemo(() => {
+    const result = {} as Record<InstanceAccessKey, InstanceGranteeRow[]>
+    for (const key of INSTANCE_ACCESS_KEYS) {
+      result[key] = lists[key].items.map((item) => {
+        const instanceRows = allRows.filter(
+          (r) => r.entityDefinitionId === key && r.entityInstanceId === item.id
+        )
+        const ownRow = instanceRows.find(
+          (r) => r.granteeType === granteeType && r.granteeId === granteeId
+        )
+        return {
+          key,
+          id: item.id,
+          name: item.name,
+          grantLevel: ownRow?.permission,
+          badge: deriveInstanceBadge(instanceRows),
+        }
+      })
+    }
+    return result
+  }, [lists, allRows, granteeType, granteeId])
+
+  /** Set (or, `'inherit'`, revoke) this grantee's own row for one instance. */
+  const setGrant = useCallback(
+    (key: InstanceAccessKey, instanceId: string, level: ResourcePermission | 'inherit') => {
+      const recordId = toRecordId(key, instanceId)
+      if (level === 'inherit') {
+        revokeInstance.mutate({ recordId, granteeType, granteeId })
+        return
+      }
+      grantInstance.mutate({ recordId, granteeType, granteeId, permission: level })
+    },
+    [grantInstance, revokeInstance, granteeType, granteeId]
+  )
+
+  return {
+    lists,
+    isLoading: allQuery.isLoading,
+    rowsByKey,
+    setGrant,
+  }
+}

--- a/apps/web/src/components/permissions/hooks/use-instance-resource-lists.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-resource-lists.ts
@@ -1,49 +1,52 @@
-// apps/web/src/components/permissions/hooks/use-agent-policy-resources.ts
+// apps/web/src/components/permissions/hooks/use-instance-resource-lists.ts
 'use client'
 
 import type { InstanceAccessKey } from '@auxx/lib/permissions/client'
 import { useMemo } from 'react'
 import { api } from '~/trpc/react'
 
-/**
- * Instance lists for the Resources grid — one query per shareable resource type
- * (`dataset` / `kb` / `dashboard`), each fetched only while its type row is
- * expanded.
- *
- * Lazy on purpose: the policy itself is sparse, so an admin who only sets type
- * defaults never pays for three list queries. The lists are needed for the
- * *names* of instance overrides, not for the policy's correctness — an override
- * whose instance no longer exists is simply never looked up.
- */
-
-/** How many instances one type row lists before it says "showing the first N". */
+/** How many instances one list fetches before it says "showing the first N". */
 const INSTANCE_PAGE_SIZE = 100
 
 /** One selectable resource instance. */
-export interface PolicyResourceInstance {
+export interface InstanceResourceItem {
   id: string
   name: string
 }
 
 /** One resource type's loaded instances. */
-export interface PolicyResourceList {
-  items: PolicyResourceInstance[]
+export interface InstanceResourceList {
+  items: InstanceResourceItem[]
   isLoading: boolean
   /** More instances exist than were fetched — the grid says so rather than lying. */
   truncated: boolean
 }
 
-/** Which type rows are currently expanded (and therefore worth querying). */
-export type OpenResourceTypes = Partial<Record<InstanceAccessKey, boolean>>
+/** Which resource types are currently worth querying. */
+export type OpenInstanceTypes = Partial<Record<InstanceAccessKey, boolean>>
 
 /**
- * Fetch the instances of every expanded resource type.
+ * Fetch the instances of every "open" instance-access resource type — one
+ * query per shareable type (`api.dataset.list` / `api.kb.list` /
+ * `api.dashboard.list`), each fetched only while its caller marks it `open`.
  *
- * @param open - Expanded state per type; a collapsed type issues no query.
+ * Generalized (capability layer v2 Part B.3) out of the agent-policy Resources
+ * grid, which fetches lazily per manually-expanded type row (the policy is
+ * sparse, so an admin who only sets type defaults never pays for three list
+ * queries). The Datasets / Knowledge base / Dashboards area rows on the
+ * Member baseline and grantee-override grids are the second caller: they pass
+ * every key `open: true` unconditionally, because their host's search box has
+ * to match against instance names to decide whether to auto-expand an area —
+ * unlike the agent-policy grid, there is no search there to defer the fetch
+ * behind.
+ *
+ * The lists are needed for the *names* of instances, not for correctness — an
+ * override/grant whose instance no longer exists (or is outside the first
+ * page) is simply rendered with its raw id and kept until cleared.
  */
-export function useAgentPolicyResourceInstances(
-  open: OpenResourceTypes
-): Record<InstanceAccessKey, PolicyResourceList> {
+export function useInstanceResourceLists(
+  open: OpenInstanceTypes
+): Record<InstanceAccessKey, InstanceResourceList> {
   const datasets = api.dataset.list.useQuery(
     { limit: INSTANCE_PAGE_SIZE },
     { enabled: open.dataset === true, staleTime: 60_000 }

--- a/apps/web/src/components/permissions/hooks/use-instance-share.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-share.ts
@@ -2,6 +2,7 @@
 'use client'
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import type { Level } from '@auxx/lib/permissions/client'
 import type { ResourceAccessInfo } from '@auxx/lib/resource-access'
 import type { ActorId } from '@auxx/types/actor'
 import type { RecordId } from '@auxx/types/resource'
@@ -32,6 +33,15 @@ export type WorkspaceBaseline = InstanceLevel | 'restricted' | undefined
 export interface InstanceShareGrant {
   actorId: ActorId
   choice: InstanceLevel
+  /**
+   * The user grantee's own composed Layer-2 level for this instance's L2 area
+   * (capability layer v2 Part B.2.8), server-annotated on `forInstance`.
+   * `undefined` for group/team/role/profile grantees — they are level
+   * *sources*, not subjects — and while the annotation hasn't loaded yet.
+   * `Level.None` here means the grant is a dead grant: `effectiveInstanceLevel`
+   * short-circuits at area None before ever consulting this row.
+   */
+  granteeAreaLevel?: Level
 }
 
 /** The fixed grantee for the workspace baseline (everyone in the org). */
@@ -132,7 +142,13 @@ export function useInstanceShare({
       rows.flatMap((r) => {
         const actorId = granteeToActorId(r.granteeType, r.granteeId)
         if (!actorId) return []
-        return [{ actorId, choice: r.permission as InstanceLevel }]
+        return [
+          {
+            actorId,
+            choice: r.permission as InstanceLevel,
+            granteeAreaLevel: r.granteeAreaLevel,
+          },
+        ]
       }),
     [rows]
   )

--- a/apps/web/src/components/permissions/ui/agent-policy-resources-grid.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-resources-grid.tsx
@@ -15,7 +15,7 @@ import { type ReactNode, useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { useConfirm } from '~/hooks/use-confirm'
 import type { NormalizedAgentPolicy } from '../hooks/use-agent-policy'
-import { useAgentPolicyResourceInstances } from '../hooks/use-agent-policy-resources'
+import { useInstanceResourceLists } from '../hooks/use-instance-resource-lists'
 import { AGENT_LEVEL_LABELS, AGENT_LEVEL_RANK, RESOURCE_AREA_CLAMP } from './agent-policy-copy'
 import { AgentPolicyDefaultRow, AgentPolicyLevelControl } from './agent-policy-level-control'
 
@@ -59,7 +59,7 @@ export function AgentPolicyResourcesGrid({
   disabled?: boolean
 }) {
   const [open, setOpen] = useState<Partial<Record<InstanceAccessKey, boolean>>>({})
-  const instances = useAgentPolicyResourceInstances(open)
+  const instances = useInstanceResourceLists(open)
   const [confirm, ConfirmDialog] = useConfirm()
 
   /** The rung each type's area allows — the ceiling every row below it is min'd with. */

--- a/apps/web/src/components/permissions/ui/grantee-def-access-rows.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-rows.tsx
@@ -1,0 +1,157 @@
+// apps/web/src/components/permissions/ui/grantee-def-access-rows.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { EmptySection } from '@auxx/ui/components/section'
+import { TreeRow, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Lock, ShieldCheck } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
+import type {
+  GranteeDefAccessRow,
+  GranteePrincipal,
+  useGranteeDefAccess,
+} from '../hooks/use-grantee-def-access'
+import { AccessLevelSelect } from './access-level-select'
+
+/** Indent of the def rows under the Records area row (matches `DefBaselineRows`). */
+const CHILD_DEPTH = 1
+
+/**
+ * The nested per-def rows under the Records area row in grantee scopes (member
+ * detail, group detail, the overrides tab) — the grantee-centric twin of
+ * `DefBaselineRows`. One CRM record type per row with this grantee's
+ * `Inherit / Read / Edit / Full` picker, writing the same type-level
+ * `ResourceAccess` rows `useGranteeDefAccess` composes.
+ *
+ * Presentational only — filtering, loading and persistence are owned by the
+ * host, exactly like `DefBaselineRows` is host-driven by `MemberBaselineTab`.
+ * Extracted from the former standalone `GranteeDefAccessSection` (capability
+ * layer v2 Part B.0) so the same rows nest under the Records area instead of
+ * living in a flat section of their own.
+ */
+export function GranteeDefAccessRows({
+  rows,
+  isLoading = false,
+  canEdit,
+  principal = 'member',
+  depth = CHILD_DEPTH,
+  onChange,
+}: {
+  rows: GranteeDefAccessRow[]
+  isLoading?: boolean
+  canEdit: boolean
+  /**
+   * `agent` switches the "Inherit" fall-through to the agent SET-semantics
+   * default (Full) — see {@link GranteePrincipal}.
+   */
+  principal?: GranteePrincipal
+  /** Row indent. Defaults to nesting under a parent area row; the retired flat
+   *  `GranteeDefAccessSection` passes `0` to keep its own un-nested layout. */
+  depth?: number
+  onChange: (
+    entityDefinitionId: string,
+    level: Parameters<ReturnType<typeof useGranteeDefAccess>['setLevel']>[1]
+  ) => void
+}) {
+  if (isLoading) {
+    return (
+      <div className='flex flex-col gap-0.5'>
+        <TreeRowSkeleton depth={depth} />
+        <TreeRowSkeleton depth={depth} />
+        <TreeRowSkeleton depth={depth} />
+      </div>
+    )
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptySection
+        orientation='horizontal'
+        icon={<ShieldCheck />}
+        title='No matches'
+        description='No record types match your search.'
+      />
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-0.5'>
+      {rows.map((row) => (
+        <DefAccessRow
+          key={row.resource.entityDefinitionId}
+          row={row}
+          canEdit={canEdit}
+          principal={principal}
+          depth={depth}
+          onChange={(level) => onChange(row.resource.entityDefinitionId, level)}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** One record-type row: def icon + name, restriction lock, override pill, picker. */
+function DefAccessRow({
+  row,
+  canEdit,
+  principal,
+  depth,
+  onChange,
+}: {
+  row: GranteeDefAccessRow
+  canEdit: boolean
+  principal: GranteePrincipal
+  depth: number
+  onChange: (level: Parameters<ReturnType<typeof useGranteeDefAccess>['setLevel']>[1]) => void
+}) {
+  const { resource, isLockedDown, grantLevel, inheritedLevel, inheritLabelText, isNoEffect } = row
+  const isOverridden = grantLevel !== undefined
+  return (
+    <TreeRow
+      depth={depth}
+      rowClassName='bg-primary-50 hover:bg-primary-100'
+      icon={<EntityIcon iconId={resource.icon} color={resource.color} size='xs' />}
+      title={<span className='truncate'>{resource.plural}</span>}
+      secondary={
+        isLockedDown ? (
+          <Tooltip content='Restricted: hidden from everyone by default. Only members you grant access (directly or via a team) can see this type.'>
+            <Lock className='size-3 text-muted-foreground' />
+          </Tooltip>
+        ) : undefined
+      }
+      actions={
+        <>
+          {isOverridden && (
+            <Tooltip
+              content={
+                isNoEffect
+                  ? 'This override is at or below the default, so it changes nothing.'
+                  : 'Overrides the default for this record type.'
+              }>
+              <Badge
+                variant='secondary'
+                size='xs'
+                className={cn(isNoEffect && 'border-amber-300 text-amber-600')}>
+                Override
+              </Badge>
+            </Tooltip>
+          )}
+          <AccessLevelSelect
+            value={grantLevel}
+            includeInherit
+            inheritedLevel={inheritedLevel}
+            inheritLabelText={inheritLabelText ?? (principal === 'agent' ? 'Default' : undefined)}
+            onInherit={() => onChange('inherit')}
+            onChange={(level) => onChange(level)}
+            disabled={!canEdit}
+            size='sm'
+            variant='transparent'
+            className='h-7 w-44'
+          />
+        </>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
@@ -1,27 +1,21 @@
 // apps/web/src/components/permissions/ui/grantee-def-access-section.tsx
 'use client'
 
-import { Badge } from '@auxx/ui/components/badge'
 import { ButtonSwitch } from '@auxx/ui/components/button-switch'
-import { EntityIcon } from '@auxx/ui/components/icons'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { TreeRow } from '@auxx/ui/components/tree-row'
-import { cn } from '@auxx/ui/lib/utils'
-import { Lock, ShieldCheck } from 'lucide-react'
+import { ShieldCheck } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
-import { Tooltip } from '~/components/global/tooltip'
 import {
-  type GranteeDefAccessRow,
   type GranteeKind,
   type GranteePrincipal,
   useGranteeDefAccess,
 } from '../hooks/use-grantee-def-access'
-import { AccessLevelSelect } from './access-level-select'
+import { GranteeDefAccessRows } from './grantee-def-access-rows'
 
-const COPY: Record<GranteeKind, { description: string }> = {
+const COPY: Partial<Record<GranteeKind, { description: string }>> = {
   user: {
     description:
       'Access to individual record types. Each row shows what this member gets by default; pick a level to override it for that type.',
@@ -143,81 +137,18 @@ export function GranteeDefAccessSection({
               description='No record types match your search.'
             />
           ) : (
-            <div className='border p-1 rounded-xl flex flex-col gap-1'>
-              {filteredRows.map((row) => (
-                <DefAccessRow
-                  key={row.resource.entityDefinitionId}
-                  row={row}
-                  canEdit={canEdit}
-                  principal={principal}
-                  onChange={(level) => setLevel(row.resource.entityDefinitionId, level)}
-                />
-              ))}
+            <div className='border p-1 rounded-xl'>
+              <GranteeDefAccessRows
+                rows={filteredRows}
+                canEdit={canEdit}
+                principal={principal}
+                depth={0}
+                onChange={(entityDefinitionId, level) => setLevel(entityDefinitionId, level)}
+              />
             </div>
           )}
         </div>
       )}
     </SettingsSection>
-  )
-}
-
-/** One record-type row: def icon + name, restriction lock, override pill, picker. */
-function DefAccessRow({
-  row,
-  canEdit,
-  principal,
-  onChange,
-}: {
-  row: GranteeDefAccessRow
-  canEdit: boolean
-  principal: GranteePrincipal
-  onChange: (level: Parameters<ReturnType<typeof useGranteeDefAccess>['setLevel']>[1]) => void
-}) {
-  const { resource, isLockedDown, grantLevel, inheritedLevel, inheritLabelText, isNoEffect } = row
-  const isOverridden = grantLevel !== undefined
-  return (
-    <TreeRow
-      rowClassName='bg-primary-50 hover:bg-primary-100'
-      icon={<EntityIcon iconId={resource.icon} color={resource.color} size='xs' />}
-      title={<span className='truncate'>{resource.plural}</span>}
-      secondary={
-        isLockedDown ? (
-          <Tooltip content='Restricted: hidden from everyone by default. Only members you grant access (directly or via a team) can see this type.'>
-            <Lock className='size-3 text-muted-foreground' />
-          </Tooltip>
-        ) : undefined
-      }
-      actions={
-        <>
-          {isOverridden && (
-            <Tooltip
-              content={
-                isNoEffect
-                  ? 'This override is at or below the default, so it changes nothing.'
-                  : 'Overrides the default for this record type.'
-              }>
-              <Badge
-                variant='secondary'
-                size='xs'
-                className={cn(isNoEffect && 'border-amber-300 text-amber-600')}>
-                Override
-              </Badge>
-            </Tooltip>
-          )}
-          <AccessLevelSelect
-            value={grantLevel}
-            includeInherit
-            inheritedLevel={inheritedLevel}
-            inheritLabelText={inheritLabelText ?? (principal === 'agent' ? 'Default' : undefined)}
-            onInherit={() => onChange('inherit')}
-            onChange={(level) => onChange(level)}
-            disabled={!canEdit}
-            size='sm'
-            variant='transparent'
-            className='h-7 w-44'
-          />
-        </>
-      }
-    />
   )
 }

--- a/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
@@ -1,0 +1,167 @@
+// apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
+'use client'
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import { type InstanceAccessKey, Level } from '@auxx/lib/permissions/client'
+import { toRecordId } from '@auxx/types/resource'
+import { Badge } from '@auxx/ui/components/badge'
+import { EmptySection } from '@auxx/ui/components/section'
+import { TreeRow, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { AlertTriangle, Library } from 'lucide-react'
+import { useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
+import type { InstanceGranteeRow } from '../hooks/use-instance-grantee-rows'
+import { AccessLevelSelect } from './access-level-select'
+import { InstanceShareBody } from './instance-share-body'
+import {
+  deadGrantWarning,
+  INSTANCE_ROW_COPY,
+  INSTANCE_SHARE_COPY,
+  INSTANCE_TYPE_META,
+} from './instance-share-copy'
+
+/** Indent of the instance rows under their Datasets / Knowledge base / Dashboards area row. */
+const CHILD_DEPTH = 1
+
+/**
+ * The nested per-instance rows under a Datasets / Knowledge base / Dashboards
+ * area row in a **grantee scope** (a member/team's own overrides — capability
+ * layer v2 Part B): one dataset/KB/dashboard per row with THIS grantee's own
+ * explicit grant — Inherit (no row) / Read / Read+write / Full / No Access.
+ *
+ * Unlike the area-level grid above it, this picker is **not raise-only**
+ * (§B.2.6): it writes the grantee's raw `ResourceAccess` row through
+ * `grantInstance`/`revokeInstance`, so it can restrict a specific instance for
+ * one member even while their area level stays open. Copy therefore never uses
+ * "override"/"raise" language — see `instance-share-copy.ts`'s `grantee` entry.
+ *
+ * Expanding a row lazily mounts `InstanceShareBody` — the same grantee list
+ * the Share card and dialog show, covering every OTHER grantee on that
+ * instance (not just this one).
+ *
+ * Dead-grant warning (§B.2.8): shown only for `user` grantees (`isUser`),
+ * using the composed area level the HOST already knows from the same grid
+ * (the area row sits directly above these rows) — no extra server call.
+ */
+export function GranteeInstanceRows({
+  rows,
+  isLoading = false,
+  canEdit,
+  isUser,
+  areaLevel,
+  areaLabel,
+  onChange,
+}: {
+  rows: InstanceGranteeRow[]
+  isLoading?: boolean
+  canEdit: boolean
+  /** Whether this grantee is a single member (vs. a team) — gates the dead-grant warning. */
+  isUser: boolean
+  /** This grantee's own composed level for the area these instances belong to. */
+  areaLevel: Level
+  areaLabel: string
+  onChange: (
+    key: InstanceAccessKey,
+    instanceId: string,
+    level: ResourcePermission | 'inherit'
+  ) => void
+}) {
+  if (isLoading) {
+    return (
+      <div className='flex flex-col gap-0.5'>
+        <TreeRowSkeleton depth={CHILD_DEPTH} />
+        <TreeRowSkeleton depth={CHILD_DEPTH} />
+      </div>
+    )
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptySection
+        orientation='horizontal'
+        icon={<Library />}
+        title='No matches'
+        description='No items match your search.'
+      />
+    )
+  }
+
+  const showDeadGrantWarning = isUser && areaLevel === Level.None
+
+  return (
+    <div className='flex flex-col gap-0.5'>
+      {rows.map((row) => (
+        <GranteeInstanceRowItem
+          key={`${row.key}:${row.id}`}
+          row={row}
+          disabled={!canEdit}
+          showDeadGrantWarning={showDeadGrantWarning}
+          areaLabel={areaLabel}
+          onChange={(level) => onChange(row.key, row.id, level)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function GranteeInstanceRowItem({
+  row,
+  disabled,
+  showDeadGrantWarning,
+  areaLabel,
+  onChange,
+}: {
+  row: InstanceGranteeRow
+  disabled: boolean
+  showDeadGrantWarning: boolean
+  areaLabel: string
+  onChange: (level: ResourcePermission | 'inherit') => void
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const meta = INSTANCE_TYPE_META[row.key]
+  const recordId = toRecordId(row.key, row.id)
+  const isDeadGrant = showDeadGrantWarning && row.grantLevel !== undefined
+
+  return (
+    <TreeRow
+      depth={CHILD_DEPTH}
+      rowClassName='bg-primary-50 hover:bg-primary-100'
+      icon={<meta.icon className='size-4' />}
+      title={<span className='truncate'>{row.name}</span>}
+      description={INSTANCE_ROW_COPY.grantee.description(INSTANCE_SHARE_COPY[row.key].noun)}
+      expandable
+      isOpen={isOpen}
+      onToggleOpen={() => setIsOpen((v) => !v)}
+      actions={
+        <>
+          {isDeadGrant && (
+            <Tooltip content={deadGrantWarning(areaLabel)}>
+              <AlertTriangle className='size-3.5 text-amber-500' />
+            </Tooltip>
+          )}
+          {row.badge === 'restricted' ? (
+            <Badge variant='secondary' size='xs'>
+              Restricted
+            </Badge>
+          ) : typeof row.badge === 'number' ? (
+            <Badge variant='secondary' size='xs'>
+              Shared · {row.badge}
+            </Badge>
+          ) : undefined}
+          <AccessLevelSelect
+            value={row.grantLevel}
+            includeInherit
+            includeNone
+            onInherit={() => onChange('inherit')}
+            onChange={(level) => onChange(level)}
+            disabled={disabled}
+            size='sm'
+            variant='transparent'
+            className='h-7 w-44'
+          />
+        </>
+      }>
+      {isOpen && <InstanceShareBody recordId={recordId} />}
+    </TreeRow>
+  )
+}

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
@@ -1,15 +1,31 @@
 // apps/web/src/components/permissions/ui/grantee-levels-section.tsx
 'use client'
 
-import type { Area, Level } from '@auxx/lib/permissions/client'
+import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SlidersHorizontal } from 'lucide-react'
+import { useCallback } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
-import type { GranteeKind } from '../hooks/use-grantee-def-access'
+import { type GranteeKind, useGranteeDefAccess } from '../hooks/use-grantee-def-access'
+import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
 import { usePermissionGrants } from '../hooks/use-permission-grants'
-import { LeveledAreaGrid } from './leveled-area-grid'
+import { GranteeDefAccessRows } from './grantee-def-access-rows'
+import { GranteeInstanceRows } from './grantee-instance-rows'
+import { AREA_TO_INSTANCE_KEY } from './instance-share-copy'
+import { type AreaChildFilter, type AreaChildren, LeveledAreaGrid } from './leveled-area-grid'
 
-const COPY: Record<GranteeKind, { description: string }> = {
+/**
+ * This section's own grantee axis — a member or a team, never a profile: it
+ * writes through `usePermissionGrants().save`, whose `GrantGranteeType` input
+ * deliberately excludes `'profile'` (a profile's own area levels are authored
+ * on the Profiles page, not raised as an override here). Narrower than the
+ * shared {@link GranteeKind} on purpose — `useGranteeDefAccess` /
+ * `useInstanceGranteeRows` both accept the wider union, so a `MemberOrGroup`
+ * value passes through them fine.
+ */
+type MemberOrGroup = Exclude<GranteeKind, 'profile'>
+
+const COPY: Partial<Record<GranteeKind, { description: string }>> = {
   user: {
     description:
       'What this member can do across the workspace. Overrides only raise access above the member baseline; admins always have full access.',
@@ -64,7 +80,7 @@ export function GranteeLevelsSection({
   canEdit,
   mode = 'override',
 }: {
-  granteeKind: GranteeKind
+  granteeKind: MemberOrGroup
   granteeId: string
   canEdit: boolean
   /** `override` — a member/team grant; `agent` — an agent's own profile. */
@@ -76,6 +92,19 @@ export function GranteeLevelsSection({
   const persisted = granteeKind === 'group' ? groupGrants : userGrants
   const values = persisted.find((g) => g.granteeId === granteeId)?.levels ?? {}
 
+  const principal = mode === 'agent' ? 'agent' : 'member'
+  const {
+    isLoading: defAccessLoading,
+    rows: defRows,
+    setLevel: setDefLevel,
+  } = useGranteeDefAccess(granteeKind, granteeId, principal)
+  const {
+    isLoading: instanceRowsLoadingAll,
+    lists: instanceLists,
+    rowsByKey: instanceRowsByKey,
+    setGrant: setInstanceGrant,
+  } = useInstanceGranteeRows(granteeKind, granteeId)
+
   const handleChange = (area: Area, level: Level | undefined) => {
     const next = { ...values }
     // `undefined` DELETES the key (no grant → the grantee's fall-through: the
@@ -86,6 +115,115 @@ export function GranteeLevelsSection({
     else next[area] = level
     save(granteeKind, granteeId, next)
   }
+
+  /**
+   * Per-def overrides nested under Records (capability layer v2 Part B.0), and
+   * per-instance grants nested under Datasets / Knowledge base / Dashboards
+   * (Part B) — the grantee-scoped twin of `MemberBaselineTab`'s
+   * `renderChildren`. "Overrides only" means "has an explicit grant for this
+   * grantee"; a def/instance-name match keeps (and expands) the parent area
+   * row even when the area label itself didn't match.
+   */
+  const renderChildren = useCallback(
+    (area: Area, filter: AreaChildFilter): AreaChildren | undefined => {
+      if (area === Area.records) {
+        if (defAccessLoading)
+          return {
+            matchCount: 0,
+            rows: (
+              <GranteeDefAccessRows rows={[]} isLoading canEdit={canEdit} onChange={setDefLevel} />
+            ),
+          }
+
+        const matched = defRows.filter((row) => {
+          if (filter.overridesOnly && row.grantLevel === undefined) return false
+          if (!filter.query) return true
+          const { plural, label } = row.resource
+          return (
+            plural.toLowerCase().includes(filter.query) ||
+            label.toLowerCase().includes(filter.query)
+          )
+        })
+
+        return {
+          matchCount: matched.length,
+          rows: (
+            <GranteeDefAccessRows
+              rows={matched}
+              canEdit={canEdit}
+              principal={principal}
+              onChange={setDefLevel}
+            />
+          ),
+        }
+      }
+
+      const instanceKey = AREA_TO_INSTANCE_KEY[area]
+      if (!instanceKey) return undefined
+
+      // This grantee's composed level for the area shown right above these
+      // rows, re-derived with the same fall-through `LeveledAreaGrid` uses for
+      // this `mode` — so the dead-grant warning needs no extra server call
+      // (§B.2.8). Agents compose by SET over an all-Full base (no baseline).
+      const areaLevel =
+        mode === 'agent'
+          ? (values[area] ?? Level.Full)
+          : (values[area] ?? effectiveBaseline[area] ?? roleDefaults?.[area] ?? Level.None)
+
+      const instanceLoading = instanceRowsLoadingAll || instanceLists[instanceKey].isLoading
+      if (instanceLoading)
+        return {
+          matchCount: 0,
+          rows: (
+            <GranteeInstanceRows
+              rows={[]}
+              isLoading
+              canEdit={canEdit}
+              isUser={granteeKind === 'user'}
+              areaLevel={areaLevel}
+              areaLabel=''
+              onChange={setInstanceGrant}
+            />
+          ),
+        }
+
+      const matched = instanceRowsByKey[instanceKey].filter((row) => {
+        if (filter.overridesOnly && row.grantLevel === undefined) return false
+        if (!filter.query) return true
+        return row.name.toLowerCase().includes(filter.query)
+      })
+
+      return {
+        matchCount: matched.length,
+        rows: (
+          <GranteeInstanceRows
+            rows={matched}
+            canEdit={canEdit}
+            isUser={granteeKind === 'user'}
+            areaLevel={areaLevel}
+            areaLabel={PERMISSION_AREAS[area].label}
+            onChange={setInstanceGrant}
+          />
+        ),
+      }
+    },
+    [
+      defAccessLoading,
+      defRows,
+      canEdit,
+      principal,
+      setDefLevel,
+      mode,
+      values,
+      effectiveBaseline,
+      roleDefaults,
+      instanceRowsLoadingAll,
+      instanceLists,
+      instanceRowsByKey,
+      granteeKind,
+      setInstanceGrant,
+    ]
+  )
 
   return (
     <SettingsSection
@@ -105,6 +243,7 @@ export function GranteeLevelsSection({
           baseline={effectiveBaseline}
           onChange={handleChange}
           disabled={!canEdit}
+          renderChildren={renderChildren}
         />
       )}
     </SettingsSection>

--- a/apps/web/src/components/permissions/ui/grantee-list.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-list.tsx
@@ -25,6 +25,13 @@ export type RenderPicker<TChoice extends string> = (args: {
   value: TChoice
   onChange: (choice: TChoice) => void
   disabled: boolean
+  /**
+   * The row's actor, handed through so a picker can look up per-grantee data
+   * the neutral `{ actorId, choice }` grant shape doesn't otherwise carry (e.g.
+   * the instance-share dead-grant warning, capability layer v2 Part B.2.8).
+   * Additive — existing pickers destructure only `value`/`onChange`/`disabled`.
+   */
+  actorId: ActorId
 }) => ReactNode
 
 export interface GranteeListProps<TChoice extends string> {
@@ -214,6 +221,7 @@ function GranteeRow<TChoice extends string>({
               value: choice,
               onChange: (next) => onChange(actorId, next),
               disabled,
+              actorId,
             })}
             <TreeRowButton
               variant='destructive'

--- a/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
 'use client'
 
-import type { Area, Level } from '@auxx/lib/permissions/client'
+import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
@@ -11,13 +11,18 @@ import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
 import { Folder, Plus, SlidersHorizontal, Trash2, Users } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useActor, useActors } from '~/components/resources/hooks/use-actor'
 import { ActorAvatar } from '~/components/resources/ui/actor-badge'
 import { useUser } from '~/hooks/use-user'
+import { useGranteeDefAccess } from '../hooks/use-grantee-def-access'
+import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
 import { usePermissionGrants } from '../hooks/use-permission-grants'
-import { LeveledAreaGrid } from './leveled-area-grid'
+import { GranteeDefAccessRows } from './grantee-def-access-rows'
+import { GranteeInstanceRows } from './grantee-instance-rows'
+import { AREA_TO_INSTANCE_KEY } from './instance-share-copy'
+import { type AreaChildFilter, type AreaChildren, LeveledAreaGrid } from './leveled-area-grid'
 
 /**
  * The grantee kinds this tab edits.
@@ -337,6 +342,119 @@ function GranteeAccessDetail({
   onChange: (area: Area, level: Level | undefined) => void
 }) {
   const { name } = useGranteeName(granteeType, granteeId)
+  const {
+    isLoading: defAccessLoading,
+    rows: defRows,
+    setLevel: setDefLevel,
+  } = useGranteeDefAccess(granteeType, granteeId)
+  const {
+    isLoading: instanceRowsLoadingAll,
+    lists: instanceLists,
+    rowsByKey: instanceRowsByKey,
+    setGrant: setInstanceGrant,
+  } = useInstanceGranteeRows(granteeType, granteeId)
+
+  /**
+   * Per-def overrides nested under Records (capability layer v2 Part B.0), and
+   * per-instance grants nested under Datasets / Knowledge base / Dashboards
+   * (Part B) — the grantee-scoped twin of `MemberBaselineTab`'s
+   * `renderChildren`. "Overrides only" means "has an explicit grant for this
+   * grantee"; a def/instance-name match keeps (and expands) the parent area
+   * row even when the area label itself didn't match.
+   */
+  const renderChildren = useCallback(
+    (area: Area, filter: AreaChildFilter): AreaChildren | undefined => {
+      if (area === Area.records) {
+        if (defAccessLoading)
+          return {
+            matchCount: 0,
+            rows: (
+              <GranteeDefAccessRows
+                rows={[]}
+                isLoading
+                canEdit={!disabled}
+                onChange={setDefLevel}
+              />
+            ),
+          }
+
+        const matched = defRows.filter((row) => {
+          if (filter.overridesOnly && row.grantLevel === undefined) return false
+          if (!filter.query) return true
+          const { plural, label } = row.resource
+          return (
+            plural.toLowerCase().includes(filter.query) ||
+            label.toLowerCase().includes(filter.query)
+          )
+        })
+
+        return {
+          matchCount: matched.length,
+          rows: <GranteeDefAccessRows rows={matched} canEdit={!disabled} onChange={setDefLevel} />,
+        }
+      }
+
+      const instanceKey = AREA_TO_INSTANCE_KEY[area]
+      if (!instanceKey) return undefined
+
+      // This grantee's composed level for the area shown right above these
+      // rows — the raise-only override grid's own inherited-value formula
+      // (`LeveledAreaGrid`'s `override` mode), re-derived here so the
+      // dead-grant warning needs no extra server call (§B.2.8).
+      const areaLevel = values[area] ?? baseline[area] ?? roleDefaults[area] ?? Level.None
+
+      const instanceLoading = instanceRowsLoadingAll || instanceLists[instanceKey].isLoading
+      if (instanceLoading)
+        return {
+          matchCount: 0,
+          rows: (
+            <GranteeInstanceRows
+              rows={[]}
+              isLoading
+              canEdit={!disabled}
+              isUser={granteeType === 'user'}
+              areaLevel={areaLevel}
+              areaLabel=''
+              onChange={setInstanceGrant}
+            />
+          ),
+        }
+
+      const matched = instanceRowsByKey[instanceKey].filter((row) => {
+        if (filter.overridesOnly && row.grantLevel === undefined) return false
+        if (!filter.query) return true
+        return row.name.toLowerCase().includes(filter.query)
+      })
+
+      return {
+        matchCount: matched.length,
+        rows: (
+          <GranteeInstanceRows
+            rows={matched}
+            canEdit={!disabled}
+            isUser={granteeType === 'user'}
+            areaLevel={areaLevel}
+            areaLabel={PERMISSION_AREAS[area].label}
+            onChange={setInstanceGrant}
+          />
+        ),
+      }
+    },
+    [
+      defAccessLoading,
+      defRows,
+      disabled,
+      setDefLevel,
+      values,
+      baseline,
+      roleDefaults,
+      instanceRowsLoadingAll,
+      instanceLists,
+      instanceRowsByKey,
+      granteeType,
+      setInstanceGrant,
+    ]
+  )
 
   return (
     <Section
@@ -350,6 +468,7 @@ function GranteeAccessDetail({
         baseline={baseline}
         onChange={onChange}
         disabled={disabled}
+        renderChildren={renderChildren}
       />
     </Section>
   )

--- a/apps/web/src/components/permissions/ui/instance-baseline-rows.tsx
+++ b/apps/web/src/components/permissions/ui/instance-baseline-rows.tsx
@@ -1,0 +1,133 @@
+// apps/web/src/components/permissions/ui/instance-baseline-rows.tsx
+'use client'
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import type { InstanceAccessKey } from '@auxx/lib/permissions/client'
+import { toRecordId } from '@auxx/types/resource'
+import { Badge } from '@auxx/ui/components/badge'
+import { EmptySection } from '@auxx/ui/components/section'
+import { TreeRow, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { Library } from 'lucide-react'
+import { useState } from 'react'
+import type { InstanceBaselineRow } from '../hooks/use-instance-baseline-rows'
+import { AccessLevelSelect } from './access-level-select'
+import { InstanceShareBody } from './instance-share-body'
+import { INSTANCE_ROW_COPY, INSTANCE_TYPE_META } from './instance-share-copy'
+
+/** Indent of the instance rows under their Datasets / Knowledge base / Dashboards area row. */
+const CHILD_DEPTH = 1
+
+/**
+ * The nested per-instance rows under a Datasets / Knowledge base / Dashboards
+ * area row on the Member baseline grid (capability layer v2 Part B) — the
+ * instance twin of `DefBaselineRows`. One dataset/KB/dashboard per row with
+ * its **workspace baseline** picker (the `role:org_member` row the standalone
+ * Share card's own baseline row writes): Inherit (no row) / Read / Read+write /
+ * Full / No Access ("Restricted"). Expanding a row lazily mounts
+ * `InstanceShareBody` — the same grantee list the Share card and dialog show.
+ *
+ * Presentational: filtering, loading and persistence are owned by the host
+ * (`MemberBaselineTab` + `useInstanceBaselineRows`), exactly like
+ * `DefBaselineRows`.
+ */
+export function InstanceBaselineRows({
+  rows,
+  isLoading = false,
+  disabled = false,
+  onChange,
+}: {
+  rows: InstanceBaselineRow[]
+  isLoading?: boolean
+  disabled?: boolean
+  onChange: (
+    key: InstanceAccessKey,
+    instanceId: string,
+    level: ResourcePermission | 'inherit'
+  ) => void
+}) {
+  if (isLoading) {
+    return (
+      <div className='flex flex-col gap-0.5'>
+        <TreeRowSkeleton depth={CHILD_DEPTH} />
+        <TreeRowSkeleton depth={CHILD_DEPTH} />
+      </div>
+    )
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptySection
+        orientation='horizontal'
+        icon={<Library />}
+        title='No matches'
+        description='No items match your search.'
+      />
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-0.5'>
+      {rows.map((row) => (
+        <InstanceBaselineRowItem
+          key={`${row.key}:${row.id}`}
+          row={row}
+          disabled={disabled}
+          onChange={(level) => onChange(row.key, row.id, level)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function InstanceBaselineRowItem({
+  row,
+  disabled,
+  onChange,
+}: {
+  row: InstanceBaselineRow
+  disabled: boolean
+  onChange: (level: ResourcePermission | 'inherit') => void
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const meta = INSTANCE_TYPE_META[row.key]
+  const recordId = toRecordId(row.key, row.id)
+
+  return (
+    <TreeRow
+      depth={CHILD_DEPTH}
+      rowClassName='bg-primary-50 hover:bg-primary-100'
+      icon={<meta.icon className='size-4' />}
+      title={<span className='truncate'>{row.name}</span>}
+      description={INSTANCE_ROW_COPY.baseline.description}
+      expandable
+      isOpen={isOpen}
+      onToggleOpen={() => setIsOpen((v) => !v)}
+      actions={
+        <>
+          {row.badge === 'restricted' ? (
+            <Badge variant='secondary' size='xs'>
+              Restricted
+            </Badge>
+          ) : typeof row.badge === 'number' ? (
+            <Badge variant='secondary' size='xs'>
+              Shared · {row.badge}
+            </Badge>
+          ) : undefined}
+          <AccessLevelSelect
+            value={row.baselineLevel}
+            includeInherit
+            includeNone
+            inheritedLevel={row.inheritedLevel}
+            onInherit={() => onChange('inherit')}
+            onChange={(level) => onChange(level)}
+            disabled={disabled}
+            size='sm'
+            variant='transparent'
+            className='h-7 w-44'
+          />
+        </>
+      }>
+      {isOpen && <InstanceShareBody recordId={recordId} />}
+    </TreeRow>
+  )
+}

--- a/apps/web/src/components/permissions/ui/instance-share-body.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-body.tsx
@@ -1,0 +1,151 @@
+// apps/web/src/components/permissions/ui/instance-share-body.tsx
+'use client'
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { INSTANCE_ACCESS_RESOURCES, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
+import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId } from '@auxx/types/resource'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { AlertTriangle } from 'lucide-react'
+import { useMemo } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
+import { useCanAdminInstance } from '~/providers/capabilities-provider'
+import type { InstanceLevel } from '../hooks/use-instance-share'
+import { useInstanceShare } from '../hooks/use-instance-share'
+import { GranteeList } from './grantee-list'
+import {
+  deadGrantWarning,
+  INSTANCE_SHARE_COPY,
+  type InstanceShareCopy,
+} from './instance-share-copy'
+
+export const LEVEL_ORDER: InstanceLevel[] = [
+  ResourcePermission.view,
+  ResourcePermission.edit,
+  ResourcePermission.admin,
+]
+
+export const LEVEL_TIER: Record<InstanceLevel, string> = {
+  [ResourcePermission.view]: 'Read',
+  [ResourcePermission.edit]: 'Write',
+  [ResourcePermission.admin]: 'Full',
+}
+
+export function levelHelper(copy: InstanceShareCopy, level: InstanceLevel): string {
+  if (level === ResourcePermission.edit) return copy.levels.write
+  if (level === ResourcePermission.admin) return copy.levels.full
+  return copy.levels.read
+}
+
+/** The Read / Write / Full picker for a grantee row. */
+export function InstanceLevelSelect({
+  value,
+  onChange,
+  copy,
+  disabled,
+}: {
+  value: InstanceLevel
+  onChange: (value: InstanceLevel) => void
+  copy: InstanceShareCopy
+  disabled: boolean
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as InstanceLevel)} disabled={disabled}>
+      <SelectTrigger size='sm' variant='transparent' className='h-7 w-32'>
+        <SelectValue>{LEVEL_TIER[value]}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align='end' className='min-w-56'>
+        {LEVEL_ORDER.map((level) => (
+          <SelectItem key={level} value={level} textValue={LEVEL_TIER[level]}>
+            <div className='flex flex-col items-start'>
+              <span>{LEVEL_TIER[level]}</span>
+              <span className='text-muted-foreground text-xs'>{levelHelper(copy, level)}</span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+/**
+ * The generic per-instance grantee list — extracted out of `InstanceShareCard`
+ * (capability layer v2 Part B.2.3) so the standalone Share card/dialog AND the
+ * nested per-instance rows on the Member baseline / grantee-override grids
+ * (`instance-baseline-rows.tsx` / `grantee-instance-rows.tsx`) render the exact
+ * same grantee list, Read/Write/Full picker, revoke button and "add people or
+ * groups" trigger. Every mount is driven by its own {@link useInstanceShare},
+ * so opening several nested rows at once just runs several small `forInstance`
+ * queries (accepted per-open-row cost, §B.2.4) — no new mutation surface.
+ *
+ * Editability is gated on {@link useCanAdminInstance} exactly as before: an
+ * instance-restricted admin sees this list read-only (§B.2.7).
+ *
+ * Dead-grant warning (§B.2.8): a `user` grant whose composed area level is
+ * `None` is inert — `effectiveInstanceLevel` closes the area gate before ever
+ * consulting the instance row — so each such row gets an inline warning icon,
+ * driven by the `granteeAreaLevel` the server annotates onto `forInstance` for
+ * `user` grantees only.
+ */
+export function InstanceShareBody({ recordId }: { recordId: RecordId }) {
+  const { entityDefinitionId: key } = parseRecordId(recordId)
+  const isSupported = key in INSTANCE_SHARE_COPY
+  const canAdmin = useCanAdminInstance(recordId)
+  const { grants, unmanageableGrants, grant, changeLevel, revoke } = useInstanceShare({
+    recordId,
+    enabled: isSupported,
+  })
+
+  const areaLabel = useMemo(() => {
+    if (!isSupported) return undefined
+    const area = INSTANCE_ACCESS_RESOURCES[key as keyof typeof INSTANCE_ACCESS_RESOURCES].area
+    return PERMISSION_AREAS[area].label
+  }, [isSupported, key])
+
+  const granteeAreaLevelByActor = useMemo(() => {
+    const map = new Map<string, Level | undefined>()
+    for (const g of grants) map.set(g.actorId, g.granteeAreaLevel)
+    return map
+  }, [grants])
+
+  if (!isSupported) return null
+  const copy = INSTANCE_SHARE_COPY[key as keyof typeof INSTANCE_SHARE_COPY]
+
+  return (
+    <GranteeList<InstanceLevel>
+      grants={grants}
+      onGrant={grant}
+      onChange={changeLevel}
+      onRevoke={revoke}
+      defaultChoice={ResourcePermission.view}
+      renderLockedLabel={(choice) => LEVEL_TIER[choice]}
+      renderPicker={({ value, onChange, disabled, actorId }) => {
+        const isDeadGrant = granteeAreaLevelByActor.get(actorId) === Level.None
+        return (
+          <>
+            {isDeadGrant && areaLabel && (
+              <Tooltip content={deadGrantWarning(areaLabel)}>
+                <AlertTriangle className='size-3.5 text-amber-500' />
+              </Tooltip>
+            )}
+            <InstanceLevelSelect
+              value={value}
+              onChange={onChange}
+              copy={copy}
+              disabled={disabled}
+            />
+          </>
+        )
+      }}
+      disabled={!canAdmin}
+      unmanageableGrants={unmanageableGrants}
+      emptyHint={`Not shared with anyone specific. Adjust the workspace default above to restrict this ${copy.noun}.`}
+    />
+  )
+}

--- a/apps/web/src/components/permissions/ui/instance-share-card.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-card.tsx
@@ -17,57 +17,8 @@ import { Globe, Lock } from 'lucide-react'
 import { useCanAdminInstance } from '~/providers/capabilities-provider'
 import type { InstanceLevel, WorkspaceBaseline } from '../hooks/use-instance-share'
 import { useInstanceShare } from '../hooks/use-instance-share'
-import { GranteeList } from './grantee-list'
+import { InstanceShareBody, LEVEL_ORDER, LEVEL_TIER, levelHelper } from './instance-share-body'
 import { INSTANCE_SHARE_COPY, type InstanceShareCopy } from './instance-share-copy'
-
-const LEVEL_ORDER: InstanceLevel[] = [
-  ResourcePermission.view,
-  ResourcePermission.edit,
-  ResourcePermission.admin,
-]
-
-const LEVEL_TIER: Record<InstanceLevel, string> = {
-  [ResourcePermission.view]: 'Read',
-  [ResourcePermission.edit]: 'Write',
-  [ResourcePermission.admin]: 'Full',
-}
-
-function levelHelper(copy: InstanceShareCopy, level: InstanceLevel): string {
-  if (level === ResourcePermission.edit) return copy.levels.write
-  if (level === ResourcePermission.admin) return copy.levels.full
-  return copy.levels.read
-}
-
-/** The Read / Write / Full picker for a grantee row. */
-function InstanceLevelSelect({
-  value,
-  onChange,
-  copy,
-  disabled,
-}: {
-  value: InstanceLevel
-  onChange: (value: InstanceLevel) => void
-  copy: InstanceShareCopy
-  disabled: boolean
-}) {
-  return (
-    <Select value={value} onValueChange={(v) => onChange(v as InstanceLevel)} disabled={disabled}>
-      <SelectTrigger size='sm' variant='transparent' className='h-7 w-32'>
-        <SelectValue>{LEVEL_TIER[value]}</SelectValue>
-      </SelectTrigger>
-      <SelectContent align='end' className='min-w-56'>
-        {LEVEL_ORDER.map((level) => (
-          <SelectItem key={level} value={level} textValue={LEVEL_TIER[level]}>
-            <div className='flex flex-col items-start'>
-              <span>{LEVEL_TIER[level]}</span>
-              <span className='text-muted-foreground text-xs'>{levelHelper(copy, level)}</span>
-            </div>
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  )
-}
 
 /** The workspace-baseline picker: Read / Write / Full + "No access (Restricted)". */
 function WorkspaceBaselineSelect({
@@ -169,11 +120,10 @@ export function InstanceShareCard({ recordId }: { recordId: RecordId }) {
   const { entityDefinitionId: key } = parseRecordId(recordId)
   const isSupported = key in INSTANCE_SHARE_COPY
   const canAdmin = useCanAdminInstance(recordId)
-  const { grants, unmanageableGrants, baseline, grant, changeLevel, revoke, setBaseline } =
-    useInstanceShare({
-      recordId,
-      enabled: isSupported,
-    })
+  const { grants, unmanageableGrants, baseline, setBaseline } = useInstanceShare({
+    recordId,
+    enabled: isSupported,
+  })
 
   if (!isSupported) return null
   const copy = INSTANCE_SHARE_COPY[key as keyof typeof INSTANCE_SHARE_COPY]
@@ -208,20 +158,7 @@ export function InstanceShareCard({ recordId }: { recordId: RecordId }) {
         />
       </div>
 
-      <GranteeList<InstanceLevel>
-        grants={grants}
-        onGrant={grant}
-        onChange={changeLevel}
-        onRevoke={revoke}
-        defaultChoice={ResourcePermission.view}
-        renderLockedLabel={(choice) => LEVEL_TIER[choice]}
-        renderPicker={({ value, onChange, disabled }) => (
-          <InstanceLevelSelect value={value} onChange={onChange} copy={copy} disabled={disabled} />
-        )}
-        disabled={!canAdmin}
-        unmanageableGrants={unmanageableGrants}
-        emptyHint={`Not shared with anyone specific. Adjust the workspace default above to restrict this ${copy.noun}.`}
-      />
+      <InstanceShareBody recordId={recordId} />
     </div>
   )
 }

--- a/apps/web/src/components/permissions/ui/instance-share-copy.ts
+++ b/apps/web/src/components/permissions/ui/instance-share-copy.ts
@@ -1,6 +1,12 @@
 // apps/web/src/components/permissions/ui/instance-share-copy.ts
 
-import type { InstanceAccessKey } from '@auxx/lib/permissions/client'
+import {
+  type Area,
+  INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+} from '@auxx/lib/permissions/client'
+import { BookOpen, Database, LayoutDashboard, type LucideIcon } from 'lucide-react'
 
 /**
  * Per-resource UI copy for the generic {@link import('./instance-share-card').InstanceShareCard}
@@ -49,4 +55,57 @@ export const INSTANCE_SHARE_COPY: Record<InstanceAccessKey, InstanceShareCopy> =
       full: 'Manage & delete',
     },
   },
+}
+
+/**
+ * Display metadata for the per-instance rows nested under the Datasets /
+ * Knowledge base / Dashboards area rows (capability layer v2 Part B) — the
+ * `instance-baseline-rows.tsx` / `grantee-instance-rows.tsx` twin of
+ * `agent-policy-resources-grid.tsx`'s own local `TYPE_META` (kept separate
+ * there — different grid, different write path, §B.2.1).
+ */
+export const INSTANCE_TYPE_META: Record<InstanceAccessKey, { label: string; icon: LucideIcon }> = {
+  dataset: { label: 'Datasets', icon: Database },
+  kb: { label: 'Knowledge bases', icon: BookOpen },
+  dashboard: { label: 'Dashboards', icon: LayoutDashboard },
+}
+
+/**
+ * The reverse of `INSTANCE_ACCESS_RESOURCES` — which instance-access key (if
+ * any) a given L2 area expands into per-instance rows for. Shared by every
+ * `renderChildren` host that nests `InstanceBaselineRows` / `GranteeInstanceRows`
+ * under an area row (`member-baseline-tab.tsx`, `grantee-overrides-tab.tsx`,
+ * `grantee-levels-section.tsx`) so the mapping is defined once.
+ */
+export const AREA_TO_INSTANCE_KEY: Partial<Record<Area, InstanceAccessKey>> = Object.fromEntries(
+  INSTANCE_ACCESS_KEYS.map((key) => [INSTANCE_ACCESS_RESOURCES[key].area, key])
+)
+
+/**
+ * Row copy for the two per-instance row scopes (capability layer v2 §B.2.6):
+ * the **baseline** scope ("everyone in the workspace") and a **grantee**
+ * scope (a specific member/team's own access), which must never borrow the
+ * area grid's raise-only framing — instance grants can restrict as well as
+ * raise.
+ */
+export const INSTANCE_ROW_COPY = {
+  baseline: {
+    description:
+      'The default access every member starts with for each item. Expand an item to see or ' +
+      'change who else can reach it.',
+  },
+  grantee: {
+    description: (noun: string) => `Their own access to this ${noun}, on top of the default above.`,
+  },
+} as const
+
+/**
+ * The dead-grant warning (capability layer v2 §B.2.8): a `user` grant on an
+ * instance is inert when that member's own composed area level is `None` —
+ * `effectiveInstanceLevel` closes the area gate before ever consulting the
+ * instance row, so the grant silently does nothing until their profile grants
+ * the area.
+ */
+export function deadGrantWarning(areaLabel: string): string {
+  return `No effect — their profile has no ${areaLabel} access.`
 }

--- a/apps/web/src/components/permissions/ui/member-baseline-tab.tsx
+++ b/apps/web/src/components/permissions/ui/member-baseline-tab.tsx
@@ -5,8 +5,11 @@ import { Area, type Level } from '@auxx/lib/permissions/client'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { useCallback } from 'react'
 import { useDefBaselines } from '../hooks/use-def-baselines'
+import { useInstanceBaselineRows } from '../hooks/use-instance-baseline-rows'
 import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from '../hooks/use-permission-grants'
 import { DefBaselineRows } from './def-baseline-rows'
+import { InstanceBaselineRows } from './instance-baseline-rows'
+import { AREA_TO_INSTANCE_KEY } from './instance-share-copy'
 import { type AreaChildFilter, type AreaChildren, LeveledAreaGrid } from './leveled-area-grid'
 
 /**
@@ -32,6 +35,12 @@ import { type AreaChildFilter, type AreaChildren, LeveledAreaGrid } from './leve
 export function MemberBaselineTab({ disabled = false }: { disabled?: boolean }) {
   const { isLoading, roleDefaults, baseline, save, remove } = usePermissionGrants()
   const { isLoading: defsLoading, rows: defRows, setBaseline: setDefBaseline } = useDefBaselines()
+  const {
+    isLoading: instanceRowsLoadingAll,
+    lists: instanceLists,
+    rowsByKey: instanceRowsByKey,
+    setBaseline: setInstanceBaseline,
+  } = useInstanceBaselineRows()
 
   const handleChange = (area: Area, level: Level | undefined) => {
     const next = { ...baseline }
@@ -45,34 +54,71 @@ export function MemberBaselineTab({ disabled = false }: { disabled?: boolean }) 
   }
 
   /**
-   * Per-def workspace baselines nested under Records. "Overrides only" here means
-   * "defs with a stored `role:org_member` row"; the match count lets the grid keep
-   * (and expand) the Records row when a def name — not the area label — matched.
+   * Per-def workspace baselines nested under Records, and per-instance
+   * workspace baselines nested under Datasets / Knowledge base / Dashboards
+   * (capability layer v2 Part B). "Overrides only" means "has a stored
+   * `role:org_member` row of its own"; the match count lets the grid keep
+   * (and expand) the parent area row when a def/instance name — not the area
+   * label — matched.
    */
   const renderChildren = useCallback(
     (area: Area, filter: AreaChildFilter): AreaChildren | undefined => {
-      if (area !== Area.records) return undefined
-      if (defsLoading)
+      if (area === Area.records) {
+        if (defsLoading)
+          return {
+            matchCount: 0,
+            rows: <DefBaselineRows rows={[]} isLoading onChange={setDefBaseline} />,
+          }
+
+        const matched = defRows.filter((row) => {
+          if (filter.overridesOnly && row.baselineLevel === undefined) return false
+          if (!filter.query) return true
+          const { plural, label } = row.resource
+          return (
+            plural.toLowerCase().includes(filter.query) ||
+            label.toLowerCase().includes(filter.query)
+          )
+        })
+
+        return {
+          matchCount: matched.length,
+          rows: <DefBaselineRows rows={matched} disabled={disabled} onChange={setDefBaseline} />,
+        }
+      }
+
+      const instanceKey = AREA_TO_INSTANCE_KEY[area]
+      if (!instanceKey) return undefined
+
+      const instanceLoading = instanceRowsLoadingAll || instanceLists[instanceKey].isLoading
+      if (instanceLoading)
         return {
           matchCount: 0,
-          rows: <DefBaselineRows rows={[]} isLoading onChange={setDefBaseline} />,
+          rows: <InstanceBaselineRows rows={[]} isLoading onChange={setInstanceBaseline} />,
         }
 
-      const matched = defRows.filter((row) => {
+      const matched = instanceRowsByKey[instanceKey].filter((row) => {
         if (filter.overridesOnly && row.baselineLevel === undefined) return false
         if (!filter.query) return true
-        const { plural, label } = row.resource
-        return (
-          plural.toLowerCase().includes(filter.query) || label.toLowerCase().includes(filter.query)
-        )
+        return row.name.toLowerCase().includes(filter.query)
       })
 
       return {
         matchCount: matched.length,
-        rows: <DefBaselineRows rows={matched} disabled={disabled} onChange={setDefBaseline} />,
+        rows: (
+          <InstanceBaselineRows rows={matched} disabled={disabled} onChange={setInstanceBaseline} />
+        ),
       }
     },
-    [defsLoading, defRows, disabled, setDefBaseline]
+    [
+      defsLoading,
+      defRows,
+      disabled,
+      setDefBaseline,
+      instanceRowsLoadingAll,
+      instanceLists,
+      instanceRowsByKey,
+      setInstanceBaseline,
+    ]
   )
 
   if (isLoading || !roleDefaults) {

--- a/apps/web/src/components/permissions/ui/profile-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/profile-area-grid.tsx
@@ -8,9 +8,10 @@ import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { Lock, SlidersHorizontal } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { LevelControl } from './level-control'
+import type { AreaChildFilter, AreaChildren } from './leveled-area-grid'
 import {
   PROFILE_AREA_GROUPS,
   UNSET_HINT_BY_ROLE,
@@ -44,6 +45,19 @@ interface ProfileAreaGridProps {
   profileRole?: OrganizationRole
   onChange: (area: Area, level: Level | undefined) => void
   disabled?: boolean
+  /**
+   * Render nested child rows under an area — Records → this profile's per-def
+   * overrides, Datasets / Knowledge base / Dashboards → this profile's
+   * per-instance grants (capability layer v2 Part B, extended to the profile
+   * editor: "expand Records and set the permissions for Companies", combined
+   * into this same grid rather than a separate section). Mirrors
+   * `LeveledAreaGrid`'s `renderChildren` contract exactly — same
+   * {@link AreaChildFilter}/{@link AreaChildren} shape, same search/auto-expand
+   * behavior — even though this grid predates and isn't built on
+   * `LeveledAreaGrid` (its three-state Not-set/explicit/Locked row is its own
+   * thing; only the nesting mechanism is shared).
+   */
+  renderChildren?: (area: Area, filter: AreaChildFilter) => AreaChildren | undefined
 }
 
 /** Why one row is not editable, or `null` when it is. */
@@ -67,6 +81,13 @@ function lockReasonFor(area: Area, seat: SeatType): string | null {
  * 3. **Locked** — a field seat can never reach a non-worker area (§0.19: the
  *    editor refuses to author a contradiction with `SEAT_CEILINGS`). Locked rows
  *    render disabled at the level that actually applies, with the reason on hover.
+ *
+ * An area may also nest child rows via `renderChildren` — Records → this
+ * profile's per-def overrides, Datasets / Knowledge base / Dashboards → this
+ * profile's per-instance grants (capability layer v2 Part B, extended here so
+ * "expand Records, set Companies" lives in this same grid rather than a
+ * separate section). Children are collapsed by default and participate in the
+ * search, exactly like `LeveledAreaGrid`'s area rows.
  */
 export function ProfileAreaGrid({
   values,
@@ -76,26 +97,48 @@ export function ProfileAreaGrid({
   profileRole = 'USER',
   onChange,
   disabled = false,
+  renderChildren,
 }: ProfileAreaGridProps) {
   const [search, setSearch] = useState('')
   const [configuredOnly, setConfiguredOnly] = useState(false)
+  /** Explicit expand state per area; absent = follow the row's `autoOpen`. */
+  const [openAreas, setOpenAreas] = useState<Partial<Record<Area, boolean>>>({})
   const query = search.trim().toLowerCase()
 
+  /**
+   * Groups with their areas narrowed by the search query and the "set areas
+   * only" toggle, each carrying its resolved children — same shape as
+   * `LeveledAreaGrid`'s `filteredGroups`: an area survives when it matches
+   * itself OR one of its children does, and the latter also auto-expands it.
+   */
   const groups = useMemo(() => {
-    const out: Array<{ group: string; areas: Area[] }> = []
+    const out: Array<{
+      group: string
+      rows: Array<{ area: Area; children: AreaChildren | undefined; autoOpen: boolean }>
+    }> = []
     for (const { group, areas } of PROFILE_AREA_GROUPS) {
-      const rows = areas.filter((area) => {
-        if (configuredOnly && values[area] === undefined) return false
-        if (!query) return true
+      const rows: Array<{ area: Area; children: AreaChildren | undefined; autoOpen: boolean }> = []
+      for (const area of areas) {
         const meta = PERMISSION_AREAS[area]
-        return (
-          meta.label.toLowerCase().includes(query) || meta.description.toLowerCase().includes(query)
-        )
-      })
-      if (rows.length > 0) out.push({ group, areas: rows })
+        const selfMatch =
+          !query ||
+          meta.label.toLowerCase().includes(query) ||
+          meta.description.toLowerCase().includes(query)
+        // A parent that matched by its own label shows all of its children;
+        // otherwise the query narrows them and a survivor rescues the parent.
+        const children = renderChildren?.(area, {
+          query: selfMatch ? '' : query,
+          overridesOnly: configuredOnly,
+        })
+        const childMatch = (children?.matchCount ?? 0) > 0
+        if (configuredOnly && values[area] === undefined && !childMatch) continue
+        if (!selfMatch && !childMatch) continue
+        rows.push({ area, children, autoOpen: !selfMatch && childMatch })
+      }
+      if (rows.length > 0) out.push({ group, rows })
     }
     return out
-  }, [query, configuredOnly, values])
+  }, [query, configuredOnly, values, renderChildren])
 
   return (
     <div className='flex flex-col gap-3'>
@@ -121,22 +164,32 @@ export function ProfileAreaGrid({
         />
       ) : (
         <div className='flex flex-col gap-4'>
-          {groups.map(({ group, areas }) => (
+          {groups.map(({ group, rows }) => (
             <div key={group} className='flex flex-col gap-0.5'>
               <span className='px-1 text-xs font-semibold uppercase text-primary-600'>{group}</span>
-              {areas.map((area) => (
-                <ProfileAreaRow
-                  key={area}
-                  area={area}
-                  value={values[area]}
-                  roleDefault={roleDefaults[area]}
-                  baseLevel={baseLevel}
-                  seat={seat}
-                  profileRole={profileRole}
-                  disabled={disabled}
-                  onChange={(level) => onChange(area, level)}
-                />
-              ))}
+              {rows.map(({ area, children, autoOpen }) => {
+                const isOpen = openAreas[area] ?? autoOpen
+                return (
+                  <ProfileAreaRow
+                    key={area}
+                    area={area}
+                    value={values[area]}
+                    roleDefault={roleDefaults[area]}
+                    baseLevel={baseLevel}
+                    seat={seat}
+                    profileRole={profileRole}
+                    disabled={disabled}
+                    onChange={(level) => onChange(area, level)}
+                    childRows={children?.rows}
+                    isOpen={isOpen}
+                    onToggleOpen={
+                      children !== undefined
+                        ? () => setOpenAreas((prev) => ({ ...prev, [area]: !isOpen }))
+                        : undefined
+                    }
+                  />
+                )
+              })}
             </div>
           ))}
         </div>
@@ -155,6 +208,9 @@ function ProfileAreaRow({
   profileRole,
   disabled,
   onChange,
+  childRows,
+  isOpen,
+  onToggleOpen,
 }: {
   area: Area
   value: Level | undefined
@@ -164,6 +220,11 @@ function ProfileAreaRow({
   profileRole: OrganizationRole
   disabled: boolean
   onChange: (level: Level | undefined) => void
+  /** Nested rows from `renderChildren` (Records → per-def, Datasets / Knowledge
+   *  base / Dashboards → per-instance). `undefined` = no children for this area. */
+  childRows?: ReactNode
+  isOpen?: boolean
+  onToggleOpen?: () => void
 }) {
   const meta = PERMISSION_AREAS[area]
   const lockReason = lockReasonFor(area, seat)
@@ -193,6 +254,9 @@ function ProfileAreaRow({
           </Tooltip>
         ) : undefined
       }
+      expandable={childRows !== undefined}
+      isOpen={childRows !== undefined ? isOpen : undefined}
+      onToggleOpen={childRows !== undefined ? onToggleOpen : undefined}
       trailing={
         <LevelControl
           area={meta}
@@ -203,7 +267,8 @@ function ProfileAreaRow({
           onChange={onChange}
           disabled={disabled || lockReason !== null}
         />
-      }
-    />
+      }>
+      {childRows}
+    </TreeRow>
   )
 }

--- a/apps/web/src/components/permissions/ui/profile-editor.tsx
+++ b/apps/web/src/components/permissions/ui/profile-editor.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/permissions/ui/profile-editor.tsx
 'use client'
 
-import { Level } from '@auxx/lib/permissions/client'
+import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
@@ -14,12 +14,19 @@ import {
 } from '@auxx/ui/components/select'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { ChevronLeft, SlidersHorizontal } from 'lucide-react'
+import { useCallback } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useGranteeDefAccess } from '../hooks/use-grantee-def-access'
+import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
 import { useProfileEditor } from '../hooks/use-profile-editor'
 import type { PermissionProfile } from '../hooks/use-profiles'
 import { AgentPolicyEditor } from './agent-policy-editor'
+import { GranteeDefAccessRows } from './grantee-def-access-rows'
+import { GranteeInstanceRows } from './grantee-instance-rows'
+import { AREA_TO_INSTANCE_KEY } from './instance-share-copy'
 import { LEVEL_LABELS } from './level-control'
+import type { AreaChildFilter, AreaChildren } from './leveled-area-grid'
 import { ProfileAreaGrid } from './profile-area-grid'
 import {
   APPLIES_TO_COPY,
@@ -74,6 +81,121 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
   const isAgentProfile = profile.appliesTo === 'agent'
   const editable = canEdit && !isOwner
   const icon = draft.icon ?? DEFAULT_PROFILE_ICON
+
+  // Per-def overrides nested under Records, and per-instance grants nested
+  // under Datasets / Knowledge base / Dashboards — this profile's OWN
+  // `ResourceAccess` rows (`granteeType: 'profile'`), user requirement:
+  // "expand Records and set the permissions for Companies", combined into
+  // this same grid (not a separate section). Called unconditionally (rules of
+  // hooks) even for an agent profile, which never renders `ProfileAreaGrid`.
+  const {
+    isLoading: defAccessLoading,
+    rows: defRows,
+    setLevel: setDefLevel,
+  } = useGranteeDefAccess('profile', profile.id, 'member', {
+    levels: draft.levels,
+    baseLevel: draft.baseLevel,
+  })
+  const {
+    isLoading: instanceRowsLoadingAll,
+    lists: instanceLists,
+    rowsByKey: instanceRowsByKey,
+    setGrant: setInstanceGrant,
+  } = useInstanceGranteeRows('profile', profile.id)
+
+  /**
+   * `ProfileAreaGrid`'s `renderChildren` — the profile-authoring twin of
+   * `grantee-levels-section.tsx`'s host-owned `renderChildren` (capability
+   * layer v2 Part B). A profile is a level SOURCE, not a subject
+   * (`resourceAccess.forInstance`'s doc comment), so the per-instance rows
+   * never show the dead-grant warning (`isUser` stays `false`).
+   */
+  const renderChildren = useCallback(
+    (area: Area, filter: AreaChildFilter): AreaChildren | undefined => {
+      if (area === Area.records) {
+        if (defAccessLoading)
+          return {
+            matchCount: 0,
+            rows: (
+              <GranteeDefAccessRows rows={[]} isLoading canEdit={editable} onChange={setDefLevel} />
+            ),
+          }
+
+        const matched = defRows.filter((row) => {
+          if (filter.overridesOnly && row.grantLevel === undefined) return false
+          if (!filter.query) return true
+          const { plural, label } = row.resource
+          return (
+            plural.toLowerCase().includes(filter.query) ||
+            label.toLowerCase().includes(filter.query)
+          )
+        })
+
+        return {
+          matchCount: matched.length,
+          rows: <GranteeDefAccessRows rows={matched} canEdit={editable} onChange={setDefLevel} />,
+        }
+      }
+
+      const instanceKey = AREA_TO_INSTANCE_KEY[area]
+      if (!instanceKey) return undefined
+
+      // This profile's own composed level for the area shown right above
+      // these rows — the same fall-through the parent row itself renders
+      // (`ProfileAreaRow`'s `inherited`).
+      const areaLevel = draft.levels[area] ?? draft.baseLevel ?? roleDefaults?.[area] ?? Level.None
+
+      const instanceLoading = instanceRowsLoadingAll || instanceLists[instanceKey].isLoading
+      if (instanceLoading)
+        return {
+          matchCount: 0,
+          rows: (
+            <GranteeInstanceRows
+              rows={[]}
+              isLoading
+              canEdit={editable}
+              isUser={false}
+              areaLevel={areaLevel}
+              areaLabel=''
+              onChange={setInstanceGrant}
+            />
+          ),
+        }
+
+      const matched = instanceRowsByKey[instanceKey].filter((row) => {
+        if (filter.overridesOnly && row.grantLevel === undefined) return false
+        if (!filter.query) return true
+        return row.name.toLowerCase().includes(filter.query)
+      })
+
+      return {
+        matchCount: matched.length,
+        rows: (
+          <GranteeInstanceRows
+            rows={matched}
+            canEdit={editable}
+            isUser={false}
+            areaLevel={areaLevel}
+            areaLabel={PERMISSION_AREAS[area].label}
+            onChange={setInstanceGrant}
+          />
+        ),
+      }
+    },
+    [
+      defAccessLoading,
+      defRows,
+      editable,
+      setDefLevel,
+      draft.levels,
+      draft.baseLevel,
+      roleDefaults,
+      instanceRowsLoadingAll,
+      instanceLists,
+      instanceRowsByKey,
+      setInstanceGrant,
+    ]
+  )
 
   const handleDiscard = async () => {
     const confirmed = await confirm({
@@ -200,6 +322,7 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
               profileRole={profile.role}
               disabled={!editable}
               onChange={setAreaLevel}
+              renderChildren={renderChildren}
             />
           </SettingsSection>
         )}

--- a/apps/web/src/components/permissions/utils/instance-access-badge.ts
+++ b/apps/web/src/components/permissions/utils/instance-access-badge.ts
@@ -1,0 +1,28 @@
+// apps/web/src/components/permissions/utils/instance-access-badge.ts
+
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import type { ResourceAccessInfo } from '@auxx/lib/resource-access'
+
+/**
+ * The collapsed-row badge for one instance-access resource instance (dataset /
+ * KB / dashboard — capability layer v2 Part B.2.5): `'restricted'` when the
+ * workspace baseline (`role:org_member`) row is explicitly `'none'`, the
+ * number of non-baseline grantee rows when the instance carries any, or
+ * `undefined` when the instance is untouched (no explicit rows at all). This
+ * is a fact about the INSTANCE, not the viewer, so both the Member-baseline
+ * (workspace) scope and every grantee scope show the same badge for the same
+ * instance.
+ */
+export type InstanceAccessBadge = 'restricted' | number | undefined
+
+const BASELINE_GRANTEE_ID = 'org_member'
+
+/** Derive {@link InstanceAccessBadge} from the rows of ONE instance (already filtered). */
+export function deriveInstanceBadge(rows: ResourceAccessInfo[]): InstanceAccessBadge {
+  const baselineRow = rows.find(
+    (r) => r.granteeType === ResourceGranteeType.role && r.granteeId === BASELINE_GRANTEE_ID
+  )
+  if (baselineRow?.permission === ResourcePermission.none) return 'restricted'
+  const grantCount = rows.length - (baselineRow ? 1 : 0)
+  return grantCount > 0 ? grantCount : undefined
+}

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -1,16 +1,22 @@
 // apps/web/src/server/api/routers/resourceAccess.ts
 
-import { ResourcePermission } from '@auxx/database/enums'
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import { BadRequestError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
-import { getCapabilities, isInstanceAccessKey } from '@auxx/lib/permissions'
-import type { ResourceAccessContext } from '@auxx/lib/resource-access'
+import {
+  getCapabilities,
+  INSTANCE_ACCESS_RESOURCES,
+  isInstanceAccessKey,
+  type Level,
+} from '@auxx/lib/permissions'
+import type { ResourceAccessContext, ResourceAccessInfo } from '@auxx/lib/resource-access'
 import {
   assertCanManageMailSharing,
   assertCanManageMailTypeAccess,
   assertMailSharingFeature,
   checkAccess,
   checkTypeAccess,
+  getAllInstanceAccess,
   getAllTypeAccess,
   getInstanceAccess,
   getTypeAccess,
@@ -371,16 +377,62 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     }),
 
-  /** Get all access grants for a specific instance */
+  /**
+   * Get all access grants for a specific instance.
+   *
+   * `user` grantees are annotated with `granteeAreaLevel` — their composed
+   * Layer-2 level for the instance's L2 `area` (capability layer v2 Part
+   * B.2.8) — so the Share UI can warn when a grant is inert: `effectiveInstanceLevel`
+   * short-circuits at area None *before* consulting instance rows, so sharing to
+   * a user whose profile composes that area to None is a silent no-op. Skipped
+   * for non-`user` grantees (group/team/role/profile are level *sources*, not
+   * subjects) and for defs outside the instance-access registry.
+   * `getCapabilities` is cache-backed, and only the few user grantees on one
+   * instance are resolved, so this stays cheap even though it fans out to one
+   * cache read per grantee.
+   */
   forInstance: protectedProcedure
     .input(
       z.object({
         recordId: z.string(),
       })
     )
-    .query(async ({ ctx, input }) => {
-      return getInstanceAccess(toContext(ctx), input.recordId as RecordId)
-    }),
+    .query(
+      async ({ ctx, input }): Promise<Array<ResourceAccessInfo & { granteeAreaLevel?: Level }>> => {
+        const recordId = input.recordId as RecordId
+        const rows = await getInstanceAccess(toContext(ctx), recordId)
+        const { entityDefinitionId } = parseRecordId(recordId)
+        if (!isInstanceAccessKey(entityDefinitionId)) return rows
+
+        const area = INSTANCE_ACCESS_RESOURCES[entityDefinitionId].area
+        return Promise.all(
+          rows.map(async (row) => {
+            if (row.granteeType !== ResourceGranteeType.user) return row
+            const capabilities = await getCapabilities(row.granteeId, ctx.session.organizationId)
+            return { ...row, granteeAreaLevel: capabilities.areaLevel(area) }
+          })
+        )
+      }
+    ),
+
+  /**
+   * All instance-level access rows for the org's instance-access resources
+   * (datasets/KB/dashboards — capability layer v2 Part B.2.5). The instance
+   * twin of `allTypeAccess`: today only type-level rows can be read in bulk,
+   * so a collapsed per-instance row in the permissions grid can't show a
+   * "Restricted / Shared · N" badge without one query per instance. Same
+   * admin gate as `allTypeAccess` — it reveals the org's per-instance sharing
+   * map.
+   */
+  allInstanceAccess: protectedProcedure.query(async ({ ctx }): Promise<ResourceAccessInfo[]> => {
+    if (!(await isAdminOrOwner(ctx.session.organizationId, ctx.session.userId))) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'You must be an admin or owner to view instance-level access',
+      })
+    }
+    return getAllInstanceAccess(toContext(ctx))
+  }),
 
   /** Get all type-level access grants for an entity type */
   forType: protectedProcedure

--- a/packages/lib/src/resource-access/index.ts
+++ b/packages/lib/src/resource-access/index.ts
@@ -27,6 +27,7 @@ export {
   checkAccess,
   checkTypeAccess,
   emitResourceAccessInstanceChanged,
+  getAllInstanceAccess,
   getAllTypeAccess,
   getInstanceAccess,
   getTypeAccess,

--- a/packages/lib/src/resource-access/resource-access-service.ts
+++ b/packages/lib/src/resource-access/resource-access-service.ts
@@ -5,10 +5,13 @@ import { MemberType, ResourceGranteeType, ResourcePermission } from '@auxx/datab
 import { createScopedLogger } from '@auxx/logger'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
-import { and, desc, eq, isNull, or } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, isNull, or } from 'drizzle-orm'
 import { onCacheEvent } from '../cache'
 import { NotificationService } from '../notifications'
-import { isInstanceAccessKey } from '../permissions/capabilities/instance-access'
+import {
+  INSTANCE_ACCESS_KEYS,
+  isInstanceAccessKey,
+} from '../permissions/capabilities/instance-access'
 import { satisfiesPermission } from './constants'
 import {
   grantedViaFor,
@@ -938,6 +941,43 @@ export async function getAllTypeAccess(ctx: ResourceAccessContext): Promise<Reso
     where: and(
       eq(schema.ResourceAccess.organizationId, organizationId),
       isNull(schema.ResourceAccess.entityInstanceId)
+    ),
+    orderBy: desc(schema.ResourceAccess.createdAt),
+  })
+
+  return grants.map((g: any) => ({
+    id: g.id,
+    entityDefinitionId: g.entityDefinitionId,
+    entityInstanceId: g.entityInstanceId,
+    granteeType: g.granteeType as ResourceGranteeType,
+    granteeId: g.granteeId,
+    permission: g.permission as ResourcePermission,
+    createdAt: g.createdAt,
+  }))
+}
+
+/**
+ * All instance-level (`entityInstanceId IS NOT NULL`) access rows for the org,
+ * across every instance-access resource (datasets/KB/dashboards — capability
+ * layer v2 Part B.2.5). The sibling of {@link getAllTypeAccess}: today only the
+ * type-level twin exists, so a collapsed per-instance row in the permissions
+ * grid can't show a "Restricted / Shared · N" badge without one query per
+ * instance. Reading every instance row for the org in one shot lets the client
+ * derive both the collapsed-row badge and a given grantee's own grant from a
+ * single payload; instance-access rows are sparse and org instance-row counts
+ * are small, so this stays cheap. Admin-only at the endpoint — it reveals the
+ * whole org's per-instance sharing map.
+ */
+export async function getAllInstanceAccess(
+  ctx: ResourceAccessContext
+): Promise<ResourceAccessInfo[]> {
+  const { db, organizationId } = ctx
+
+  const grants = await db.query.ResourceAccess.findMany({
+    where: and(
+      eq(schema.ResourceAccess.organizationId, organizationId),
+      inArray(schema.ResourceAccess.entityDefinitionId, INSTANCE_ACCESS_KEYS),
+      isNotNull(schema.ResourceAccess.entityInstanceId)
     ),
     orderBy: desc(schema.ResourceAccess.createdAt),
   })


### PR DESCRIPTION
## Summary

Part B of the permissions plan (plus its profile-editor extension): **every leveled area grid now expands its resource-bearing rows in place** — one unified pattern across Member baseline, Group/Member overrides, member/group detail pages, and the profile editor. No new tabs; access management lives where the area levels already are.

### Expandable rows
- **Records** expands into per-record-type rows: baseline scope edits the def's workspace default; grantee scopes (group/member/profile) edit that grantee's type-level override. The standalone flat "Record access" section on member/group detail is retired — same hook, same write path, now nested.
- **Datasets / Knowledge base / Dashboards** expand into per-instance rows:
  - baseline scope: the instance's workspace baseline — Inherit / Read / Write / Full / **Restricted** (`role:org_member` row; Restricted = `permission:'none'`)
  - grantee scopes: that grantee's instance grant, full vocabulary including No Access — deliberately **not** raise-only, instance grants can restrict as well as raise
- Expanding an instance reveals its per-grantee share rows — the share dialog's body, extracted as `InstanceShareBody` and reused by the card, the dialog, and the grids. All writes stay on the `grantInstance`/`revokeInstance` funnel (notifications + realtime unchanged).

### Profile editor
`profile-area-grid` gains the same expandable children mechanism (rank-aware unset hints untouched). A profile's per-def and per-instance rows write profile-keyed `ResourceAccess` rows; verified that `compute-user-capabilities` composes profile-keyed rows (def **and** instance) into every bound holder — no server changes needed for composition.

### Server
- New admin-gated `resourceAccess.allInstanceAccess`: bulk instance-level rows for the org's instance-access resources — powers the collapsed-row "Restricted / Shared · N" badges and per-grantee lookups from one payload.
- `resourceAccess.forInstance` annotates **user** grantees with their composed area level (`granteeAreaLevel`) so the UI flags **dead grants**: `effectiveInstanceLevel` short-circuits at area None before consulting instance rows, so a share to a user whose profile composes the area to None is a silent no-op — the share body now warns inline.
- `use-agent-policy-resources` generalized into `use-instance-resource-lists` (agent-policy grid consumes it, behavior unchanged).

### Implementation notes
- Row pickers reuse `AccessLevelSelect` for grid-wide consistency.
- Instance lists load with the grid (the search/auto-expand contract needs names pre-expansion); grantee share rows lazy-load per opened instance.
- `GranteeDefAccessSection` survives mount-free (its assumed agent-policy mount was comment-only) — cleanup in a follow-up alongside the planned agent/user permission UI unification.

## Test plan
- [ ] Member baseline: expand Records → set a def's default; expand Datasets → set an instance baseline to Restricted → affected member loses the instance (list + direct URL); revert to Inherit
- [ ] First explicit grant on an unshared dataset auto-materializes the workspace baseline row (same as the share dialog)
- [ ] Overrides tab + member detail: nested Records rows behave identically to the old flat section (lock icon, Override pill, "no effect" tag)
- [ ] Profile editor: expand Records on a custom profile → set Companies; holders' composed capabilities reflect it after the realtime refresh
- [ ] Dead-grant warning shows for a sparse-profile user granted on a dataset; disappears once their profile grants the area
- Typecheck scoped to apps/web + packages/lib: zero errors in touched files (baselines pre-existing); Biome clean; 166 resource-access/capabilities vitest tests pass