### PR TITLE
feat(permissions): plan gating on authoring paths and curated agent preset profiles

### DIFF
--- a/apps/web/src/components/permissions/ui/level-control.tsx
+++ b/apps/web/src/components/permissions/ui/level-control.tsx
@@ -48,7 +48,8 @@ interface LevelControlProps {
  * A compact radio-tab level picker for one capability area. Renders one segment
  * per rung the area offers (`None` + each ladder rung — so `records` shows
  * None/Read/Edit/Full while a toggle area shows None/Full). Shows the effective
- * level (`value ?? inherited`); while inherited it renders muted, and a reset
+ * level (`value ?? inherited`, clamped down to the nearest rung the area
+ * actually offers); while inherited it renders muted, and a reset
  * button appears once an explicit level is set. Every rung stays selectable —
  * the raise-only rule for overrides is enforced server-side (an override at or
  * below the baseline is composed away), and surfaced in the UI as an "ignored"
@@ -72,6 +73,12 @@ export function LevelControl({
   )
   const effective = value ?? inherited
   const isExplicit = value !== undefined
+  // Clamp the highlighted segment to the area's own ladder: a level above the top
+  // rung (owner/admin `baseLevel: Full` on the Read-only `auditLog` area) or
+  // between rungs (a baseline of Edit on a Read/Full ladder) composes down to the
+  // highest rung at or below it — highlighting `effective` verbatim would match
+  // no segment and render the row as if the holder had no access.
+  const displayed = levels.filter((l) => l <= effective).at(-1) ?? Level.None
 
   return (
     <div className='flex items-center gap-1'>
@@ -104,7 +111,7 @@ export function LevelControl({
         </Button>
       </Tooltip>
       <RadioTab
-        value={String(effective)}
+        value={String(displayed)}
         onValueChange={(v) => onChange(Number(v) as Level)}
         size='xs'
         radioGroupClassName='after:rounded-lg'

--- a/apps/web/src/server/api/routers/resource-access-plan-gate.test.ts
+++ b/apps/web/src/server/api/routers/resource-access-plan-gate.test.ts
@@ -1,0 +1,66 @@
+// apps/web/src/server/api/routers/resource-access-plan-gate.test.ts
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Plan-23 §2.1 regression guard: per-def (type-level) record-access EDITING is
+ * part of the paid `granularPermissions` feature, enforced server-side in the
+ * resourceAccess router — not only hidden by the UI. Mail-infra defs stay free
+ * (core product on every plan) and `revokeType` stays ungated (removal only
+ * tightens — the `clearGranteeLevels` doctrine).
+ *
+ * Structural assertions (same style as permissions-member-baseline.test.ts's
+ * third block): the router can't be imported under vitest without mocking the
+ * whole trpc/session/db stack, so we pin the gate's presence in source.
+ */
+
+const src = fs.readFileSync(
+  path.resolve(process.cwd(), 'src/server/api/routers/resourceAccess.ts'),
+  'utf8'
+)
+
+/** Source between two unique anchors (fails loudly if an anchor moves). */
+function between(start: string, end: string): string {
+  const from = src.indexOf(start)
+  const to = src.indexOf(end, from)
+  expect(from, `anchor not found: ${start}`).toBeGreaterThan(-1)
+  expect(to, `anchor not found after ${start}: ${end}`).toBeGreaterThan(from)
+  return src.slice(from, to)
+}
+
+describe('resourceAccess type-level plan gate (plan 23 §2.1)', () => {
+  it('the gate helper skips mail defs and requires granularPermissions', () => {
+    const helper = between('async function assertTypeAccessEditFeature', 'authorizeInstanceTarget')
+    expect(helper).toContain('isMailSharingDef(entityDefinitionId)) return')
+    expect(helper).toContain('FeaturePermissionService')
+    expect(helper).toContain('FeatureKey.granularPermissions')
+  })
+
+  it('grantType and setType run the gate before writing', () => {
+    for (const [proc, libCall] of [
+      ['grantType:', 'grantTypeAccess('],
+      ['setType:', 'setTypeAccess('],
+    ] as const) {
+      const body = between(proc, libCall)
+      expect(body, `${proc} must call the plan gate before ${libCall}`).toContain(
+        'assertTypeAccessEditFeature(ctx, input.entityDefinitionId)'
+      )
+    }
+  })
+
+  it('revokeType stays ungated — removal only tightens access', () => {
+    expect(between('revokeType:', 'revokeTypeAccess(')).not.toContain('assertTypeAccessEditFeature')
+  })
+
+  it('instance-level sharing (the sharing funnel) stays free on every plan', () => {
+    for (const [proc, end] of [
+      ['grantInstance:', 'grantInstanceAccess('],
+      ['setInstance:', 'setInstanceAccess('],
+      ['revokeInstance:', 'revokeInstanceAccess('],
+    ] as const) {
+      expect(between(proc, end)).not.toContain('assertTypeAccessEditFeature')
+    }
+  })
+})

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -4,6 +4,8 @@ import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import { BadRequestError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import {
+  FeatureKey,
+  FeaturePermissionService,
   getCapabilities,
   INSTANCE_ACCESS_RESOURCES,
   isInstanceAccessKey,
@@ -78,6 +80,26 @@ async function assertCanManageTypeAccess(
       message: 'You must be an admin or owner to manage record access',
     })
   }
+}
+
+/**
+ * Plan gate for per-def (type-level) record-access EDITING (plan 23 §2.1):
+ * writing def-wide grants is part of the paid `granularPermissions` feature.
+ * Mail-infra defs are exempt — inbox/mail sharing is core product on every
+ * plan — and removals (`revokeType`) stay ungated because revoking only
+ * tightens access (mirrors the `clearGranteeLevels` doctrine in the
+ * permissions router). `requireAccess` throws an AuxxError which
+ * `auxxErrorMiddleware` maps to the right HTTP status.
+ */
+async function assertTypeAccessEditFeature(
+  ctx: { db: any; session: { organizationId: string } },
+  entityDefinitionId: string
+): Promise<void> {
+  if (isMailSharingDef(entityDefinitionId)) return
+  await new FeaturePermissionService(ctx.db).requireAccess(
+    ctx.session.organizationId,
+    FeatureKey.granularPermissions
+  )
 }
 
 /**
@@ -188,6 +210,7 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
+      await assertTypeAccessEditFeature(ctx, input.entityDefinitionId)
       await assertProfileGranteesAuthorable(ctx.session.organizationId, input.granteeType, [
         input.granteeId,
       ])
@@ -332,6 +355,7 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertCanManageTypeAccess(ctx, input.entityDefinitionId)
+      await assertTypeAccessEditFeature(ctx, input.entityDefinitionId)
       await assertProfileGranteesAuthorable(
         ctx.session.organizationId,
         input.granteeType,

--- a/packages/lib/src/data-migrations/migrations/049-seed-permission-profiles.ts
+++ b/packages/lib/src/data-migrations/migrations/049-seed-permission-profiles.ts
@@ -15,7 +15,7 @@ const LEGACY_POLICY_GRANTEE_TYPE = 'role'
 const LEGACY_POLICY_GRANTEE_ID = 'org_member'
 
 /**
- * Seed the six system permission profiles for every EXISTING org and move the
+ * Seed the system permission profiles for every EXISTING org and move the
  * `role:org_member` capability baseline onto each org's `member` profile
  * (plan 19 §5.2 / §9 step 2).
  *

--- a/packages/lib/src/data-migrations/migrations/053-seed-agent-preset-profiles.ts
+++ b/packages/lib/src/data-migrations/migrations/053-seed-agent-preset-profiles.ts
@@ -1,0 +1,46 @@
+// packages/lib/src/data-migrations/migrations/053-seed-agent-preset-profiles.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { onCacheEvent } from '../../cache'
+import { ensureSystemProfiles } from '../../permissions/profiles'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-053')
+
+/**
+ * Seed the two new agent preset profiles (`support_agent`, `analyst_agent` —
+ * plan 23 §2.3) into every EXISTING org. New orgs get them through the
+ * org-creation call to `ensureSystemProfiles`; this backfill covers orgs
+ * created before the seeds existed.
+ *
+ * Idempotent and re-runnable: `ensureSystemProfiles` inserts with
+ * `onConflictDoNothing` on `(organizationId, slug)`, so pre-existing rows —
+ * including admin-edited system rows — are never touched, and a re-run
+ * inserts nothing.
+ *
+ * Cache: only the org `profiles` projection carries profile rows, so the
+ * `permission-profile.changed` event WITHOUT `broadcastUserKeys` suffices —
+ * agent-only profiles never feed user-capability composition, so no member
+ * blob is stale.
+ */
+export const migration053SeedAgentPresetProfiles: DataMigrationDef = {
+  id: '053-seed-agent-preset-profiles',
+  description:
+    'Seed the support_agent and analyst_agent system permission profiles into every existing org',
+  async run(db: Database): Promise<void> {
+    const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+    if (orgs.length === 0) {
+      logger.info('No organizations to seed')
+      return
+    }
+
+    for (const org of orgs) {
+      await ensureSystemProfiles(org.id, db)
+      await onCacheEvent('permission-profile.changed', { orgId: org.id })
+    }
+
+    logger.info('Seeded agent preset profiles', { orgs: orgs.length })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -22,6 +22,7 @@ import { migration049SeedPermissionProfiles } from './migrations/049-seed-permis
 import { migration050AgentVersionPermissionPolicy } from './migrations/050-agent-version-permission-policy'
 import { migration051GoogleAppScopeAlignment } from './migrations/051-google-app-scope-alignment'
 import { migration052MemberBaselineBackfill } from './migrations/052-member-baseline-backfill'
+import { migration053SeedAgentPresetProfiles } from './migrations/053-seed-agent-preset-profiles'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -60,6 +61,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration050AgentVersionPermissionPolicy,
     migration051GoogleAppScopeAlignment,
     migration052MemberBaselineBackfill,
+    migration053SeedAgentPresetProfiles,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/organizations/organization-service.ts
+++ b/packages/lib/src/organizations/organization-service.ts
@@ -742,7 +742,7 @@ export class OrganizationService {
         updatedAt: new Date(),
       })
 
-      // Seed the six system permission profiles INSIDE the transaction: every
+      // Seed the system permission profiles INSIDE the transaction: every
       // principal starts with a null binding, which resolves to one of these rows
       // in code (§1.3), so an org must never be able to commit without them. The
       // downstream `OrganizationSeeder` call runs outside this txn inside a

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -199,8 +199,11 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     label: 'Manage Permissions',
     description: 'Configure permission profiles and capability grants for groups and members.',
     group: 'Organization',
-    featureKey: FeatureKey.granularPermissions,
     // NOT adminOnly since doc 19 §0.25 — see `PERMISSION_AREAS[Area.permissions]`.
+    // Deliberately NO `granularPermissions` featureKey here (plan 23 §2.2): binding
+    // built-in profiles and permission reads must work on every plan. The plan gate
+    // lives in the four authoring paths instead (profile-save / profile-mutations /
+    // profile-delete / grant-service) per plan 19 §0.26.
   },
 
   // ── Integrations ──
@@ -612,7 +615,6 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
     // `permissionsManage` capability rather than a binary role check, so the
     // grant actually reaches a non-admin holder. Plan 21 §4 later migrated
     // every other router in the org group off its binary role gate too.
-    featureKey: FeatureKey.granularPermissions,
   },
   [Area.integrations]: {
     area: Area.integrations,

--- a/packages/lib/src/permissions/profiles/profile-mutations.ts
+++ b/packages/lib/src/permissions/profiles/profile-mutations.ts
@@ -90,7 +90,7 @@ export interface CreatePermissionProfileInput {
 /**
  * Create a custom permission profile.
  *
- * `isSystem` is never authorable and the six reserved system slugs are refused —
+ * `isSystem` is never authorable and the reserved system slugs are refused —
  * a custom profile can never shadow the template a null binding resolves to.
  *
  * **The §6.1 escalation guard deliberately does not run here.** A brand-new

--- a/packages/lib/src/permissions/profiles/profile-queries.ts
+++ b/packages/lib/src/permissions/profiles/profile-queries.ts
@@ -74,7 +74,8 @@ function orderRank(profile: CachedPermissionProfile): number {
 
 /**
  * Stable ordering for every profile surface: the seeded ladder
- * (owner → admin → member → field_tech → agent → chat_agent) then custom rows
+ * (owner → admin → member → field_tech → agent → chat_agent → support_agent →
+ * analyst_agent) then custom rows
  * alphabetically. Deterministic so a picker never reshuffles between renders.
  */
 function compareProfiles(a: CachedPermissionProfile, b: CachedPermissionProfile): number {

--- a/packages/lib/src/permissions/profiles/system-profiles.ts
+++ b/packages/lib/src/permissions/profiles/system-profiles.ts
@@ -46,7 +46,7 @@ interface SystemProfileSeed {
   levels: Partial<Record<Area, Level>> | null
 }
 
-/** A total agent policy at one uniform level — the two agent seeds' shape. */
+/** A total agent policy at one uniform level — the `agent`/`chat_agent` seeds' shape. */
 function uniformAgentPolicy(level: AgentAccessLevel): AgentPermissionPolicy {
   return {
     areas: { default: level, overrides: {} },
@@ -57,7 +57,7 @@ function uniformAgentPolicy(level: AgentAccessLevel): AgentPermissionPolicy {
 }
 
 /**
- * The six system profiles seeded into every org (§5.1). Plan 22 reverses doc
+ * The system profiles seeded into every org (§5.1). Plan 22 reverses doc
  * 19 §0.6's original *sparse-over-`ROLE_DEFAULTS`* rationale for the USER
  * rank: unset now means `None` (`ROLE_DEFAULTS.USER` is the all-`None` floor),
  * so a profile that stores nothing composes to nothing. `member` and
@@ -74,9 +74,12 @@ function uniformAgentPolicy(level: AgentAccessLevel): AgentPermissionPolicy {
  * `owner`/`admin` express "everything" as `baseLevel: Full` rather than an
  * all-Full grant row (`levels: null`) — which also keeps seeding clear of
  * `assertGrantableLevels`' admin-only rejection; `ROLE_DEFAULTS.ADMIN`/`.OWNER`
- * staying `ALL_FULL` means there is nothing to seed for them anyway. The two
+ * staying `ALL_FULL` means there is nothing to seed for them anyway. The
  * agent profiles likewise seed `levels: null` — their authority lives in
- * `agentPolicy`, never the additive grant reducers.
+ * `agentPolicy`, never the additive grant reducers. Between the all-`full`
+ * `agent` and all-`none` `chat_agent` sit two curated presets (plan 23 §2.3):
+ * `support_agent` (KB-answering, record-working) and `analyst_agent`
+ * (read-only analysis).
  *
  * `field_tech`'s cap is `SEAT_CEILINGS`, not a `ceiling` on this row (§0.20) —
  * the seat ceiling is a billing invariant and must never become profile-driven.
@@ -156,6 +159,61 @@ export const SYSTEM_PROFILE_SEEDS: readonly SystemProfileSeed[] = [
     agentPolicy: uniformAgentPolicy('none'),
     levels: null,
   },
+  {
+    slug: 'support_agent',
+    name: 'Support Agent',
+    description:
+      'Customer-facing support preset: answers from the knowledge base and works support records. No org or admin access.',
+    icon: { iconId: 'headphones', color: 'sky' },
+    seat: 'full',
+    appliesTo: 'agent',
+    role: 'USER',
+    baseLevel: null,
+    agentPolicy: {
+      areas: {
+        default: 'none',
+        overrides: {
+          knowledgeBase: 'read',
+          records: 'read_write',
+          recordsLinked: 'read',
+          comments: 'full',
+          files: 'read',
+        },
+      },
+      definitions: { default: 'read_write', overrides: {} },
+      resourceDefault: 'none',
+      resources: { kb: { default: 'read', overrides: {} } },
+    },
+    levels: null,
+  },
+  {
+    slug: 'analyst_agent',
+    name: 'Analyst Agent',
+    description:
+      'Read-only analysis preset: reads records, datasets, dashboards, and the knowledge base. Writes nothing.',
+    icon: { iconId: 'line-chart', color: 'cyan' },
+    seat: 'full',
+    appliesTo: 'agent',
+    role: 'USER',
+    baseLevel: null,
+    agentPolicy: {
+      areas: {
+        default: 'none',
+        overrides: {
+          records: 'read',
+          recordsLinked: 'read',
+          datasets: 'read',
+          dashboards: 'read',
+          knowledgeBase: 'read',
+          files: 'read',
+        },
+      },
+      definitions: { default: 'read', overrides: {} },
+      resourceDefault: 'read',
+      resources: {},
+    },
+    levels: null,
+  },
 ]
 
 const SYSTEM_SEED_BY_SLUG = new Map(SYSTEM_PROFILE_SEEDS.map((seed) => [seed.slug, seed]))
@@ -166,7 +224,7 @@ export function systemProfileSeed(slug: SystemProfileSlug): SystemProfileSeed | 
 }
 
 /**
- * Seed the six system permission profiles for an org — **idempotent**, so it is
+ * Seed the system permission profiles for an org — **idempotent**, so it is
  * safe to call from every org-creation and org-top-up path (§5.2).
  *
  * Conflicts on the `(organizationId, slug)` unique key are ignored, so an

--- a/packages/lib/src/permissions/profiles/types.ts
+++ b/packages/lib/src/permissions/profiles/types.ts
@@ -27,6 +27,8 @@ export const SYSTEM_PROFILE_SLUGS = [
   'field_tech',
   'agent',
   'chat_agent',
+  'support_agent',
+  'analyst_agent',
 ] as const
 
 export type SystemProfileSlug = (typeof SYSTEM_PROFILE_SLUGS)[number]
@@ -40,7 +42,7 @@ export type ProfileAppliesTo = 'member' | 'agent' | 'any'
  *
  * **Unauthored, deliberately.** Plan 20 §2.a.1/§2.a.3 removed the authoring
  * surface: no UI writes this, no seed writes this (`system-profiles.ts` ships
- * `ceiling: null` for all six), and no mutation accepts it — `saveProfile` and
+ * `ceiling: null` for every seed), and no mutation accepts it — `saveProfile` and
  * `savePermissionProfile` have no `ceiling` input. It survives ONLY as the clamp
  * seam a future per-definition deny tier (doc 19 §11.4) will hang off, which is
  * one `Math.min` in `composeUserCapabilities` and no cached-blob field.


### PR DESCRIPTION
## Summary

Plan 23: plan gating moves to where authoring happens, plus two curated agent preset profiles.

### Plan gating (`granularPermissions`)
- **Removed from the registry featureKeys** — binding built-in profiles and reading permissions must work on every plan; the capability read path is no longer feature-gated.
- **Added to the write paths**: the four profile-authoring paths (profile-save / profile-mutations / profile-delete / grant-service) carry the gate, and the `resourceAccess` router gains `assertTypeAccessEditFeature` on `grantType`/`setType` — def-wide record-access grants are a paid feature. Mail-infra defs are exempt (inbox/mail sharing is core product); `revokeType` stays ungated since revoking only tightens access.
- New `resource-access-plan-gate.test.ts` covers the gate.

### Curated agent preset profiles
Between the all-`full` `agent` and all-`none` `chat_agent` seeds sit two new presets:
- **Support Agent** — KB-answering, record-working: KB read, records read/write, linked records + files read, comments full; no org/admin access.
- **Analyst Agent** — read-only analysis: reads records, datasets, dashboards, KB; writes nothing.

Migration `053-seed-agent-preset-profiles` seeds them into existing orgs; new orgs get them via the transactional org-creation seeding.

### Drive-by
`LevelControl` clamps the highlighted segment to the area's nearest real rung — off-ladder composed levels (e.g. `baseLevel: Full` on a Read-only area) no longer render as if the holder had no access.

*(The invite-flow profile binding — `member.ts` `permissionProfileId` + invite UI — was pulled out of this PR; it ships together with the invite popover work.)*

## Test plan
- `resource-access-plan-gate.test.ts`: 4 passing
- `packages/lib` profiles suite: 114 passing across 7 files
- [ ] Manual: on a free/demo org, binding a built-in profile works while def-wide grant writes and profile authoring are plan-blocked; presets appear in the profile picker
- [ ] Run migration 053 against dev