### PR TITLE
feat(members): bulk invite dialog with email chips

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/members/_components/invite-email-editor.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/_components/invite-email-editor.tsx
@@ -1,0 +1,287 @@
+// apps/web/src/app/(protected)/app/settings/members/_components/invite-email-editor.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import Placeholder from '@tiptap/extension-placeholder'
+import type { Fragment, Node as ProseMirrorNode } from '@tiptap/pm/model'
+import type { EditorView } from '@tiptap/pm/view'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { AlertTriangle, Trash2, User } from 'lucide-react'
+import type React from 'react'
+import { useImperativeHandle } from 'react'
+import { createInlineNode, type InlineNodeBadgeProps } from '~/components/editor/inline-picker'
+import { Tooltip } from '~/components/global/tooltip'
+
+const NODE_TYPE = 'inviteEmail'
+
+/** Placeholder char standing in for a chip when reading the text before the
+ * caret, so string offsets stay in step with ProseMirror positions. */
+const LEAF_CHAR = '￼'
+
+/** The half-typed address directly before the caret (stops at a chip or separator). */
+const PENDING_RE = new RegExp(`[^\\s,;${LEAF_CHAR}]+$`)
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/** Whether an entry can actually be invited. Drives the chip's warning state. */
+export function isValidInviteEmail(value: string): boolean {
+  return EMAIL_PATTERN.test(value)
+}
+
+/** `Carl Meier <c@acme.com>` / `<c@acme.com>` / `c@acme.com,` → `c@acme.com`. */
+function normalizeEntry(raw: string): string {
+  const angled = /<([^>]*)>/.exec(raw)
+  const value = (angled?.[1] ?? raw).trim().replace(/^[<"']+|[>"',;.]+$/g, '')
+  return value.toLowerCase()
+}
+
+/**
+ * Splits pasted text into candidate addresses — names are dropped
+ * (`Name <a@b.com>` keeps only the address), the rest splits on whitespace,
+ * commas and semicolons. Junk survives as an entry on purpose: it becomes a
+ * warning chip the user can see and fix instead of being silently swallowed.
+ */
+function parseEntries(text: string): string[] {
+  return text
+    .replace(/"[^"]*"/g, ' ')
+    .replace(/[^<>,;\s]*\s*<([^>]*)>/g, ' $1 ')
+    .split(/[\s,;]+/)
+    .map(normalizeEntry)
+    .filter(Boolean)
+}
+
+/** Every chipped address, in document order. */
+function collectEntries(doc: ProseMirrorNode): string[] {
+  const entries: string[] = []
+  doc.descendants((node) => {
+    if (node.type.name === NODE_TYPE) entries.push(node.attrs.id as string)
+  })
+  return entries
+}
+
+/** Addresses and loose text in a copied slice, in document order. */
+function partsInFragment(fragment: Fragment): string[] {
+  const parts: string[] = []
+  fragment.forEach((node) => {
+    if (node.type.name === NODE_TYPE) {
+      parts.push(node.attrs.id as string)
+    } else if (node.isText) {
+      const text = node.text?.trim()
+      if (text) parts.push(text)
+    } else if (node.content.size) {
+      parts.push(...partsInFragment(node.content))
+    }
+  })
+  return parts
+}
+
+/** The half-typed text before the caret, or '' when there is none. */
+function pendingText(view: EditorView): string {
+  const { $from, empty } = view.state.selection
+  if (!empty) return ''
+  const before = $from.parent.textBetween(0, $from.parentOffset, undefined, LEAF_CHAR)
+  return PENDING_RE.exec(before)?.[0] ?? ''
+}
+
+/**
+ * Turns the text run before the caret into a chip. A duplicate is dropped
+ * rather than added — the chip the user already has is the one that stays.
+ */
+function commitPending(view: EditorView): boolean {
+  const token = pendingText(view)
+  if (!token) return false
+
+  const { state } = view
+  const { $from } = state.selection
+  const from = $from.pos - token.length
+  const to = $from.pos
+  const entry = normalizeEntry(token)
+  const nodeType = state.schema.nodes[NODE_TYPE]
+  if (!nodeType) return false
+
+  const tr =
+    entry && !collectEntries(state.doc).includes(entry)
+      ? state.tr.replaceWith(from, to, nodeType.create({ id: entry }))
+      : state.tr.delete(from, to)
+
+  view.dispatch(tr)
+  return true
+}
+
+/** One address chip: user icon + address + trash, warning-styled when invalid. */
+function InviteEmailBadge({ id, selected, deleteNode }: InlineNodeBadgeProps) {
+  const invalid = !isValidInviteEmail(id)
+
+  const badge = (
+    <Badge
+      variant={invalid ? 'destructive' : 'user'}
+      className={cn('me-1 my-0.5 gap-1 py-0.5 font-normal', selected && 'ring-2 ring-info')}>
+      {invalid ? (
+        <AlertTriangle className='size-3 shrink-0' />
+      ) : (
+        <User className='size-3 shrink-0' />
+      )}
+      <span>{id}</span>
+      <button
+        type='button'
+        aria-label={`Remove ${id}`}
+        className='ms-0.5 rounded-sm opacity-60 transition-opacity hover:opacity-100'
+        // Keep the caret where it is — blurring here would commit half-typed text.
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={deleteNode}>
+        <Trash2 className='size-3' />
+      </button>
+    </Badge>
+  )
+
+  return invalid ? <Tooltip content='Not a valid email address'>{badge}</Tooltip> : badge
+}
+
+/** The chip node. Module-scoped: the badge needs no React context, so there is
+ * nothing to close over per mount. */
+const inviteEmailNode = createInlineNode({ type: NODE_TYPE, serialize: (id) => id }, (props) => (
+  <InviteEmailBadge {...props} />
+))
+
+export interface InviteEmailEditorHandle {
+  /** Commits any half-typed address, then returns every chipped entry. */
+  flush: () => string[]
+}
+
+interface InviteEmailEditorProps {
+  ref?: React.Ref<InviteEmailEditorHandle>
+  /** Addresses to start with (e.g. carried over from the single-invite popover). */
+  initialEmails?: string[]
+  /** Fires whenever the set of chips changes. */
+  onChange: (entries: string[]) => void
+  placeholder?: string
+  disabled?: boolean
+}
+
+/**
+ * Tiptap-based multi-address input: every entry is an atom node rendered as a
+ * removable badge. Addresses commit on a separator key, Enter, Tab or blur, and
+ * a paste is split into one chip per address — invalid ones included, so the
+ * warning is visible before sending instead of coming back as a server error.
+ */
+export function InviteEmailEditor({
+  ref,
+  initialEmails,
+  onChange,
+  placeholder = 'Paste or type email addresses, separated by commas',
+  disabled,
+}: InviteEmailEditorProps) {
+  const editor = useEditor(
+    {
+      extensions: [
+        StarterKit.configure({
+          heading: false,
+          bulletList: false,
+          orderedList: false,
+          listItem: false,
+          blockquote: false,
+          codeBlock: false,
+          horizontalRule: false,
+          bold: false,
+          italic: false,
+          strike: false,
+          code: false,
+        }),
+        Placeholder.configure({ placeholder }),
+        inviteEmailNode,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: (initialEmails ?? [])
+              .map(normalizeEntry)
+              .filter(Boolean)
+              .map((id) => ({ type: NODE_TYPE, attrs: { id } })),
+          },
+        ],
+      },
+      editable: !disabled,
+      immediatelyRender: false,
+      shouldRerenderOnTransaction: false,
+      editorProps: {
+        attributes: {
+          class:
+            'prose prose-sm prose-p:my-0 focus:outline-hidden max-w-none dark:prose-invert flex-1',
+        },
+        // Chips are atoms with no text between them, so the default plain-text
+        // serialization would run them together (`a@x.comb@y.com`) on copy/cut.
+        clipboardTextSerializer: (slice) => partsInFragment(slice.content).join(', '),
+        handleKeyDown: (view, event) => {
+          // Cmd/Ctrl+Enter is the dialog's submit shortcut — leave it alone.
+          if (event.metaKey || event.ctrlKey) return false
+
+          const isSeparator = event.key.length === 1 && /[\s,;]/.test(event.key)
+          if (!isSeparator && event.key !== 'Enter' && event.key !== 'Tab') return false
+
+          if (commitPending(view)) return true
+          // Nothing pending: swallow separators and Enter (the doc stays one
+          // paragraph), but let Tab move focus out of the editor.
+          return event.key !== 'Tab'
+        },
+        handlePaste: (view, event) => {
+          const text = event.clipboardData?.getData('text/plain')
+          if (!text) return false
+          const entries = parseEntries(text)
+          if (entries.length === 0) return false
+
+          const { state } = view
+          const nodeType = state.schema.nodes[NODE_TYPE]
+          if (!nodeType) return false
+
+          event.preventDefault()
+          const seen = new Set(collectEntries(state.doc))
+          const nodes: ProseMirrorNode[] = []
+          for (const entry of entries) {
+            if (seen.has(entry)) continue
+            seen.add(entry)
+            nodes.push(nodeType.create({ id: entry }))
+          }
+
+          const { from, to } = state.selection
+          view.dispatch(state.tr.replaceWith(from, to, nodes))
+          return true
+        },
+      },
+      onUpdate: ({ editor }) => onChange(collectEntries(editor.state.doc)),
+      onBlur: ({ editor }) => {
+        commitPending(editor.view)
+        onChange(collectEntries(editor.state.doc))
+      },
+    },
+    []
+  )
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      flush: () => {
+        if (!editor) return []
+        commitPending(editor.view)
+        return collectEntries(editor.state.doc)
+      },
+    }),
+    [editor]
+  )
+
+  return (
+    <div
+      className={cn(
+        'relative rounded-md border focus-within:ring-2 focus-within:ring-info',
+        disabled && 'opacity-60'
+      )}>
+      <EditorContent
+        editor={editor}
+        className='w-full h-full flex flex-col bg-transparent px-3 py-2 text-[15px] leading-relaxed text-foreground outline-hidden ring-0 min-h-[160px] *:outline-hidden'
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(protected)/app/settings/members/_components/invite-many-dialog.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/_components/invite-many-dialog.tsx
@@ -1,0 +1,246 @@
+// apps/web/src/app/(protected)/app/settings/members/_components/invite-many-dialog.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { Check, X } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+import {
+  InviteEmailEditor,
+  type InviteEmailEditorHandle,
+  isValidInviteEmail,
+} from './invite-email-editor'
+import {
+  defaultInviteProfile,
+  InviteProfileSelect,
+  roleLabel,
+  seatClassLabel,
+  useInvitableProfiles,
+} from './invite-profile-select'
+
+/** One line of the post-send report, as `member.inviteBatch` returns it. */
+interface InviteResult {
+  email: string
+  success: boolean
+  message?: string
+  error?: string
+}
+
+interface InviteManyDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Address carried over from the single-invite popover, if any. */
+  initialEmail?: string
+  /** Profile carried over from the single-invite popover, if any. */
+  initialProfileId?: string
+}
+
+/**
+ * Bulk invite: paste a list of addresses, pick one profile for all of them.
+ *
+ * Every address is a chip, so an unusable one is visible (warning icon) before
+ * sending rather than coming back as a server error. Sending is blocked while
+ * any chip is invalid — a batch that silently drops entries is worse than one
+ * that refuses. The result list stays open afterwards because partial failure
+ * is the normal case here (already a member, invitation pending, seat cap).
+ */
+export function InviteManyDialog({
+  open,
+  onOpenChange,
+  initialEmail,
+  initialProfileId,
+}: InviteManyDialogProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const editorRef = useRef<InviteEmailEditorHandle>(null)
+  const [entries, setEntries] = useState<string[]>([])
+  const [permissionProfileId, setPermissionProfileId] = useState<string | undefined>(undefined)
+  const [results, setResults] = useState<InviteResult[] | null>(null)
+
+  const { profiles } = useInvitableProfiles()
+  const selectedProfile = profiles.find((profile) => profile.id === permissionProfileId)
+
+  // Never carry a previous run into a fresh open.
+  useEffect(() => {
+    if (!open) return
+    setEntries(initialEmail ? [initialEmail] : [])
+    setPermissionProfileId(initialProfileId)
+    setResults(null)
+  }, [open, initialEmail, initialProfileId])
+
+  // Start on the Member baseline once the profile list arrives.
+  useEffect(() => {
+    if (permissionProfileId || profiles.length === 0) return
+    const fallback = defaultInviteProfile(profiles)
+    if (fallback) setPermissionProfileId(fallback.id)
+  }, [permissionProfileId, profiles])
+
+  const inviteBatch = api.member.inviteBatch.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Error', description: error.message })
+    },
+  })
+
+  const isPending = inviteBatch.isPending
+  const invalidCount = entries.filter((entry) => !isValidInviteEmail(entry)).length
+  const validCount = entries.length - invalidCount
+  const canSend = entries.length > 0 && invalidCount === 0 && !isPending
+
+  const handleSend = async () => {
+    // Commit whatever is still half-typed, so it is judged like every other
+    // entry instead of being dropped on send.
+    const all = editorRef.current?.flush() ?? entries
+    setEntries(all)
+    if (all.length === 0 || all.some((entry) => !isValidInviteEmail(entry))) return
+
+    try {
+      const sent = await inviteBatch.mutateAsync({
+        invites: all.map((email) => ({
+          // No `role`: the profile declares both the seat class and the rank it
+          // confers, so the server derives both from it (plan 21 §2.a.3).
+          email,
+          permissionProfileId: permissionProfileId ?? null,
+        })),
+      })
+      setResults(sent)
+      // The Members list is client-fetched, so invalidate rather than relying on
+      // router.refresh (which only re-runs server components).
+      utils.member.invitations.invalidate()
+      utils.member.activeCount.invalidate()
+      router.refresh()
+    } catch {
+      // Error is surfaced by the mutation's onError toast
+    }
+  }
+
+  const sentCount = results?.filter((result) => result.success).length ?? 0
+  const failedCount = (results?.length ?? 0) - sentCount
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc' size='lg'>
+        <DialogHeader>
+          <DialogTitle>Invite team members</DialogTitle>
+          {results && (
+            <DialogDescription>
+              {sentCount} sent{failedCount > 0 && ` · ${failedCount} failed`}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {results ? (
+          <div className='flex max-h-80 flex-col gap-1.5 overflow-y-auto'>
+            {results.map((result) => (
+              <div key={result.email} className='flex items-start gap-2 text-sm'>
+                {result.success ? (
+                  <Check className='mt-0.5 size-4 shrink-0 text-emerald-600' />
+                ) : (
+                  <X className='mt-0.5 size-4 shrink-0 text-destructive' />
+                )}
+                <span className='font-medium'>{result.email}</span>
+                <span className='text-muted-foreground'>
+                  {result.success ? (result.message ?? 'Invitation sent') : result.error}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className='flex flex-col gap-3'>
+            <div className='space-y-1.5'>
+              <p className='text-sm text-primary-600'>Send invite to</p>
+              <InviteEmailEditor
+                ref={editorRef}
+                initialEmails={initialEmail ? [initialEmail] : undefined}
+                onChange={setEntries}
+                disabled={isPending}
+              />
+              {/* Always rendered, so adding the first address never shifts the
+                  layout underneath it. */}
+              <p className='text-xs text-muted-foreground'>
+                {validCount} {validCount === 1 ? 'address' : 'addresses'}
+                {invalidCount > 0 && (
+                  <span className='text-destructive'>
+                    {' '}
+                    · {invalidCount} {invalidCount === 1 ? 'address needs' : 'addresses need'}{' '}
+                    fixing
+                  </span>
+                )}
+              </p>
+            </div>
+
+            {profiles.length > 0 && (
+              <FieldPanel className='p-0'>
+                <FieldPanelRow
+                  title='Invite as'
+                  type={BaseType.ENUM}
+                  showIcon
+                  description='Sets what these members can do. Its seat class and rank are what each invitation consumes and grants.'>
+                  <InviteProfileSelect
+                    value={permissionProfileId}
+                    profiles={profiles}
+                    onChange={(profile) => setPermissionProfileId(profile.id)}
+                    disabled={isPending}
+                  />
+                </FieldPanelRow>
+              </FieldPanel>
+            )}
+
+            {selectedProfile && (
+              <p className='text-xs text-muted-foreground'>
+                {seatClassLabel(selectedProfile.seat)} · {roleLabel(selectedProfile.role)} (what
+                each invitation consumes and grants.)
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          {results ? (
+            <Button
+              data-dialog-submit
+              size='sm'
+              variant='outline'
+              onClick={() => onOpenChange(false)}>
+              Done <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          ) : (
+            <>
+              <Button
+                type='button'
+                variant='ghost'
+                size='sm'
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}>
+                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+              </Button>
+              <Button
+                data-dialog-submit
+                size='sm'
+                variant='outline'
+                disabled={!canSend}
+                loading={isPending}
+                loadingText='Sending...'
+                onClick={handleSend}>
+                Send {entries.length > 1 ? `${entries.length} invitations` : 'invitation'}
+                <KbdSubmit variant='outline' size='sm' />
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/app/(protected)/app/settings/members/_components/invite-popover.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/_components/invite-popover.tsx
@@ -1,25 +1,18 @@
 // apps/web/src/app/(protected)/app/settings/members/_components/invite-popover.tsx
 'use client'
+
+import { FieldType } from '@auxx/database/enums'
 import { Button } from '@auxx/ui/components/button'
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@auxx/ui/components/form'
-import { Input } from '@auxx/ui/components/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { toastError } from '@auxx/ui/components/toast'
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { Plus } from 'lucide-react'
+import { Plus, Users } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { type ReactNode, useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { z } from 'zod'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
 import { api } from '~/trpc/react'
+import { InviteManyDialog } from './invite-many-dialog'
 import {
   defaultInviteProfile,
   InviteProfileSelect,
@@ -28,39 +21,47 @@ import {
   useInvitableProfiles,
 } from './invite-profile-select'
 
-const formSchema = z.object({
-  email: z.email({ error: 'Please enter a valid email address.' }),
-  /** Optional: with no profiles readable the invitation binds nothing and the
-   * member resolves to the system template for their role (§1.3). */
-  permissionProfileId: z.string().optional(),
-})
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 interface InviteFormProps {
   children?: ReactNode
 }
+
+/** Popover for inviting a team member: email + the profile the invitation binds. */
 export default function InviteFormPopover({ children }: InviteFormProps) {
   const router = useRouter()
   const utils = api.useUtils()
-  const [isOpen, setIsOpen] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [email, setEmail] = useState('')
+  /** Optional: with no profiles readable the invitation binds nothing and the
+   * member resolves to the system template for their role (§1.3). */
+  const [permissionProfileId, setPermissionProfileId] = useState<string | undefined>(undefined)
+  const [manyOpen, setManyOpen] = useState(false)
+  /** Snapshot handed to the bulk dialog — kept as state so it stays stable
+   * while the dialog is open, even as the popover resets behind it. */
+  const [carried, setCarried] = useState<{ email?: string; profileId?: string }>({})
+
   const { profiles } = useInvitableProfiles()
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: standardSchemaResolver(formSchema),
-    defaultValues: { email: '', permissionProfileId: undefined },
-  })
-  const permissionProfileId = form.watch('permissionProfileId')
   const selectedProfile = profiles.find((profile) => profile.id === permissionProfileId)
+
+  // Reset form when popover opens
+  useEffect(() => {
+    if (open) {
+      setEmail('')
+      setPermissionProfileId(undefined)
+    }
+  }, [open])
 
   // Start on the Member baseline once the profile list arrives.
   useEffect(() => {
     if (permissionProfileId || profiles.length === 0) return
     const fallback = defaultInviteProfile(profiles)
-    if (fallback) form.setValue('permissionProfileId', fallback.id)
-  }, [form, permissionProfileId, profiles])
+    if (fallback) setPermissionProfileId(fallback.id)
+  }, [permissionProfileId, profiles])
 
   const inviteUser = api.member.invite.useMutation({
     onSuccess: () => {
-      form.reset()
-      setIsOpen(false)
+      setOpen(false)
       // The Members list is client-fetched, so invalidate rather than relying on
       // router.refresh (which only re-runs server components).
       utils.member.invitations.invalidate()
@@ -69,96 +70,127 @@ export default function InviteFormPopover({ children }: InviteFormProps) {
     },
     onError: (error) => {
       toastError({ title: 'Error', description: error.message })
-      setIsSubmitting(false)
     },
   })
-  async function onSubmit(values: z.infer<typeof formSchema>) {
-    setIsSubmitting(true)
-    try {
-      await inviteUser.mutateAsync({
-        email: values.email,
+
+  const isPending = inviteUser.isPending
+  const canSubmit = EMAIL_PATTERN.test(email.trim()) && !isPending
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return
+    await inviteUser
+      .mutateAsync({
+        email: email.trim(),
         // No `role`: the profile declares both the seat class and the rank it
         // confers (plan 21 §2.a.3), so the server derives both from it and caps
         // against them. The input default (`USER`) only matters for the
         // no-profile fallback (§1.3).
-        permissionProfileId: values.permissionProfileId ?? null,
+        permissionProfileId: permissionProfileId ?? null,
       })
-      setIsSubmitting(false)
-    } catch (error) {
-      // Error is handled in the mutation callbacks
-    }
+      .catch(() => {
+        // Error is surfaced by the mutation's onError toast
+      })
   }
+
+  /** Hand the popover's work to the bulk dialog instead of discarding it. */
+  const openInviteMany = () => {
+    const typed = email.trim().toLowerCase()
+    setCarried({ email: typed || undefined, profileId: permissionProfileId })
+    setOpen(false)
+    setManyOpen(true)
+  }
+
   const defaultTrigger = (
     <Button variant='outline' size='icon'>
       <Plus className='h-4 w-4' />
       <span className='sr-only'>Invite Team Member</span>
     </Button>
   )
+
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>{children || defaultTrigger}</PopoverTrigger>
-      <PopoverContent className='w-80' side='bottom' align='end'>
-        <div className='grid gap-4'>
-          <div className='space-y-2'>
-            <h4 className='font-medium leading-none'>Invite Team Members</h4>
-            <p className='text-sm text-muted-foreground'>Add people to your organization</p>
-          </div>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
-              <FormField
-                control={form.control}
-                name='email'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input placeholder='colleague@example.com' {...field} />
-                    </FormControl>
-                    <FormDescription className='text-xs'>
-                      Enter the email address of the person you want to invite.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>{children || defaultTrigger}</PopoverTrigger>
+        <PopoverContent className='w-96' side='bottom' align='end'>
+          <div className='space-y-3'>
+            <h4 className='text-sm font-semibold'>Invite Team Member</h4>
 
-              {profiles.length > 0 ? (
-                <FormField
-                  control={form.control}
-                  name='permissionProfileId'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Permission profile</FormLabel>
-                      <FormControl>
-                        <InviteProfileSelect
-                          value={field.value}
-                          profiles={profiles}
-                          onChange={(profile) => field.onChange(profile.id)}
-                        />
-                      </FormControl>
-                      <FormDescription className='text-xs'>
-                        {selectedProfile
-                          ? `${seatClassLabel(selectedProfile.seat)} · ${roleLabel(selectedProfile.role)} — what this invitation consumes and grants.`
-                          : 'Sets what this member can do. Its seat class and rank are what the invitation consumes and grants.'}
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+            <FieldPanel className='p-0'>
+              <FieldPanelRow
+                title='Email'
+                type={BaseType.EMAIL}
+                showIcon
+                isRequired
+                description='The email address of the person you want to invite'>
+                <FieldInputAdapter
+                  fieldType={FieldType.EMAIL}
+                  value={email}
+                  onChange={(val) => setEmail((val as string) ?? '')}
+                  placeholder='colleague@example.com'
+                  disabled={isPending}
                 />
-              ) : null}
+              </FieldPanelRow>
 
-              <div className='flex justify-end space-x-2'>
-                <Button type='button' variant='outline' size='sm' onClick={() => setIsOpen(false)}>
+              {profiles.length > 0 && (
+                <FieldPanelRow
+                  title='Profile'
+                  type={BaseType.ENUM}
+                  showIcon
+                  description='Sets what this member can do. Its seat class and rank are what the invitation consumes and grants.'>
+                  {/* Not a FieldInputAdapter select: profile options carry a
+                    per-option description (seat class + rank copy) that the
+                    generic select input cannot render. */}
+                  <InviteProfileSelect
+                    value={permissionProfileId}
+                    profiles={profiles}
+                    onChange={(profile) => setPermissionProfileId(profile.id)}
+                    disabled={isPending}
+                  />
+                </FieldPanelRow>
+              )}
+            </FieldPanel>
+
+            {selectedProfile && (
+              <p className='text-xs text-muted-foreground'>
+                {seatClassLabel(selectedProfile.seat)} · {roleLabel(selectedProfile.role)} (what
+                this invitation consumes and grants.)
+              </p>
+            )}
+
+            <div className='flex items-center justify-between gap-2'>
+              <Button variant='outline' size='xs' onClick={openInviteMany} disabled={isPending}>
+                <Users />
+                Invite many
+              </Button>
+              <div className='flex items-center gap-2'>
+                <Button
+                  variant='ghost'
+                  size='xs'
+                  onClick={() => setOpen(false)}
+                  disabled={isPending}>
                   Cancel
                 </Button>
-                <Button type='submit' size='sm' disabled={isSubmitting}>
-                  {isSubmitting ? 'Sending...' : 'Send Invitation'}
+                <Button
+                  variant='outline'
+                  size='xs'
+                  onClick={handleSubmit}
+                  disabled={!canSubmit}
+                  loading={isPending}
+                  loadingText='Sending...'>
+                  Send Invitation
                 </Button>
               </div>
-            </form>
-          </Form>
-        </div>
-      </PopoverContent>
-    </Popover>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <InviteManyDialog
+        open={manyOpen}
+        onOpenChange={setManyOpen}
+        initialEmail={carried.email}
+        initialProfileId={carried.profileId}
+      />
+    </>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/members/_components/invite-profile-select.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/_components/invite-profile-select.tsx
@@ -125,7 +125,7 @@ export function InviteProfileSelect({
         if (profile) onChange(profile)
       }}
       disabled={disabled || profiles.length === 0}>
-      <SelectTrigger>
+      <SelectTrigger variant='transparent' className='ps-0 pe-1'>
         <SelectValue placeholder='Select a permission profile' />
       </SelectTrigger>
       <SelectContent>

--- a/apps/web/src/server/api/routers/member.ts
+++ b/apps/web/src/server/api/routers/member.ts
@@ -335,12 +335,18 @@ export const memberRouter = createTRPCRouter({
         invites: z.array(
           z.object({
             email: z.string().email(),
-            role: z.enum(OrganizationRole),
+            role: z.enum(OrganizationRole).default('USER'),
             seatType: z.enum(SeatType).default('full'),
+            /** Permission profile chosen in the invite UI. Its `seat` supersedes
+             * `seatType` and drives the cap check (§1.1, §7). Without it a batch
+             * invitation binds nothing and the accepted member falls back to the
+             * system template for their role (§1.3). */
+            permissionProfileId: z.string().nullish(),
           })
         ),
       })
     )
+    .use(notDemo('invite team members'))
     .mutation(async ({ ctx, input }) => {
       const [org] = await ctx.db
         .select({ name: schema.Organization.name })
@@ -348,7 +354,12 @@ export const memberRouter = createTRPCRouter({
         .where(eq(schema.Organization.id, ctx.session.organizationId))
         .limit(1)
 
-      const results = []
+      const results: Array<{
+        email: string
+        success: boolean
+        message?: string
+        error?: string
+      }> = []
       for (const invite of input.invites) {
         try {
           const result = await inviteMember(
@@ -360,6 +371,7 @@ export const memberRouter = createTRPCRouter({
               email: invite.email,
               role: invite.role,
               seatType: invite.seatType,
+              permissionProfileId: invite.permissionProfileId,
             },
             ctx.db
           )


### PR DESCRIPTION
## What

Adds an **Invite many** flow to the members settings page, and moves the single-invite popover onto the shared popover pattern.

### Single-invite popover
- Rebuilt on `FieldPanel` / `FieldPanelRow` / `FieldInputAdapter` (`FieldType.EMAIL`) instead of react-hook-form + raw `Input`; footer is the usual ghost + outline `xs` pair with `loading`/`loadingText`.
- Form now resets when the popover opens (previously a cancelled invite kept its typed email).
- New **Invite many** button on the left of the footer. It closes the popover and opens the bulk dialog pre-filled with whatever was typed and the profile already selected.

### Bulk dialog (`position='tc' size='lg'`)
- **Send invite to** is a Tiptap editor where every address is an atom node rendered as a removable badge — user icon when valid, warning icon + tooltip when not. Built on the existing `createInlineNode` factory, so it inherits the React node view, backspace-deletes-chip and selection handling.
- Addresses commit on a separator key, Enter, Tab or blur. A paste is split into one chip per address (`Carl Meier <c@acme.com>` unwrapped, lowercased, deduped); junk survives as a visible warning chip rather than being silently dropped.
- `clipboardTextSerializer` joins chips with `, ` so copy/cut doesn't run them together.
- Sending is blocked while any chip is invalid — a batch that quietly drops entries is worse than one that refuses. The count line under the editor always renders (`0 addresses`) so nothing shifts.
- One `Invite as` row picks the profile for the whole batch.
- The result list stays open after sending (per-address ✓/✗ with the server's reason), because partial failure is the normal case here: already a member, invitation pending, seat cap.

### `member.inviteBatch`
- Gains `permissionProfileId` — without it the chosen profile was silently dropped and the accepted member fell back to the system template for their role.
- `role` now defaults to `USER`; the profile declares the rank it confers, so batch callers no longer have to pass one. The onboarding caller is unaffected.
- Picks up the `notDemo('invite team members')` guard that the single invite already had, and the results array is explicitly typed so `message`/`error` narrow in the UI.

## Testing

- `biome check` clean on all touched files.
- `tsc --noEmit` (apps/web) reports nothing for the new/changed client files. The four pre-existing errors in `member.ts` (`organizationName: org?.name` ×2, `new DehydrationService(ctx.db)` ×2) are unchanged from `main`.
- Chip commit, paste splitting and copy/cut were exercised manually in the dialog; the send + result-list path has not been run against a real batch.