### PR TITLE
feat(permissions): dashboards edit rung, ui gating, and instance-access test backfill

### DIFF
--- a/apps/web/src/components/dashboard/ui/dashboard-card.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-card.tsx
@@ -34,6 +34,7 @@ import {
 import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { useResources } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDashboardMutations } from '../hooks/use-dashboard-mutations'
 import { DashboardFormDialog } from './dashboard-form-dialog'
 
@@ -43,6 +44,12 @@ export function DashboardCard({ dashboard }: { dashboard: DashboardSummary }) {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [shareOpen, setShareOpen] = useState(false)
   const { getResourceById } = useResources()
+  // Settings (`dashboard.update`) and Delete are Full per instance; Duplicate is
+  // the coarse `dashboards.manage` rung (it CREATES a dashboard). Open / Favorite
+  // / Share… stay at Read — the share dialog is already read-only for non-admins.
+  const { can, canAdminInstance } = useAccess()
+  const canAdmin = canAdminInstance(toRecordId('dashboard', dashboard.id))
+  const canCreate = can('dashboards.manage')
   // Entity-linked dashboards (plan 02) show a small badge with the entity's
   // icon + plural — the second "door" onto this same row (the other is its
   // own `/app/<entity>/dashboard` route).
@@ -132,23 +139,31 @@ export function DashboardCard({ dashboard }: { dashboard: DashboardSummary }) {
               targetType='DASHBOARD'
               targetIds={{ dashboardId: dashboard.id }}
             />
-            <DropdownMenuItem onClick={() => void handleDuplicate()}>
-              <Copy />
-              Duplicate
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
-              <Settings />
-              Settings
-            </DropdownMenuItem>
+            {canCreate && (
+              <DropdownMenuItem onClick={() => void handleDuplicate()}>
+                <Copy />
+                Duplicate
+              </DropdownMenuItem>
+            )}
+            {canAdmin && (
+              <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
+                <Settings />
+                Settings
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={() => setShareOpen(true)}>
               <Share2 />
               Share…
             </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant='destructive' onClick={() => void handleDelete()}>
-              <Trash />
-              Delete
-            </DropdownMenuItem>
+            {canAdmin && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant='destructive' onClick={() => void handleDelete()}>
+                  <Trash />
+                  Delete
+                </DropdownMenuItem>
+              </>
+            )}
           </>
         }
       />

--- a/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
@@ -48,6 +48,7 @@ import { RecordDrawer } from '~/components/records/record-drawer'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { useDashboardAutosave } from '../hooks/use-dashboard-autosave'
 import { useDashboardDraftSync } from '../hooks/use-dashboard-draft-sync'
@@ -84,13 +85,26 @@ export function DashboardDetailView({
   const draftQuery = useDashboardDraftSync(dashboard.id)
   useDashboardAutosave()
 
+  // Per-instance tiers for THIS dashboard, derived once (doc 24 §A.2.4's shape,
+  // by props rather than a context — the tree is three components deep):
+  //   canEdit  → widgets/tabs/layout, publish, discard, version restore/delete/
+  //              rename. Everything downstream of it hangs off `isEditMode`, so
+  //              gating the mode is what gates the whole canvas.
+  //   canAdmin → dashboard settings (`dashboard.update`) + archive.
+  //   canCreate → the coarse `dashboards.manage` rung behind Duplicate.
+  const { can, canEditInstance, canAdminInstance } = useAccess()
+  const dashboardRecordId = toRecordId('dashboard', dashboard.id)
+  const canEdit = canEditInstance(dashboardRecordId)
+  const canAdmin = canAdminInstance(dashboardRecordId)
+  const canCreate = can('dashboards.manage')
+
   const enteredInitialEditRef = useRef(false)
   const enterEditModeAction = useDashboardStore((s) => s.enterEditMode)
   useEffect(() => {
-    if (!startInEditMode || enteredInitialEditRef.current || !draftQuery.data) return
+    if (!canEdit || !startInEditMode || enteredInitialEditRef.current || !draftQuery.data) return
     enteredInitialEditRef.current = true
     enterEditModeAction()
-  }, [startInEditMode, draftQuery.data, enterEditModeAction])
+  }, [canEdit, startInEditMode, draftQuery.data, enterEditModeAction])
 
   const [confirm, ConfirmDialog] = useConfirm()
   const [tabParam, setTab] = useQueryState('tab')
@@ -103,7 +117,13 @@ export function DashboardDetailView({
   const [openRecordId, setOpenRecordId] = useState<RecordId | null>(null)
 
   const tabs = useDashboardStore(selectCurrentTabs)
-  const isEditMode = useDashboardStore((s) => s.isEditMode)
+  const storeIsEditMode = useDashboardStore((s) => s.isEditMode)
+  // One gate for the whole editable canvas: the tab strip's add/rename/reorder/
+  // delete, the grid's drag/resize, every widget card action, the config panel,
+  // and richText's inline editor all key off `isEditMode`. Clamping it here means
+  // a Read member can never render a widget/layout affordance even if the store
+  // carries a stale edit flag.
+  const isEditMode = storeIsEditMode && canEdit
   const hasUnpublishedChanges = useDashboardStore(selectHasUnpublishedChanges)
   const viewLayer = useDashboardStore(selectViewLayer)
   const setViewLayer = useDashboardStore((s) => s.setViewLayer)
@@ -208,21 +228,23 @@ export function DashboardDetailView({
     // Command-palette scope for the open dashboard. Edit-only actions mirror
     // the header cluster's affordances.
     <CommandContext kind='page' label={dashboard.name}>
-      <CommandAction
-        label={isEditMode ? 'Done editing' : 'Edit dashboard'}
-        icon={isEditMode ? 'check' : 'edit'}
-        keywords='edit done toggle layout arrange'
-        priority={10}
-        perform={() => {
-          useCommandPaletteStore.getState().close()
-          if (isEditMode) {
-            exitEditMode()
-          } else {
-            setOpenRecordId(null)
-            enterEditMode()
-          }
-        }}
-      />
+      {canEdit && (
+        <CommandAction
+          label={isEditMode ? 'Done editing' : 'Edit dashboard'}
+          icon={isEditMode ? 'check' : 'edit'}
+          keywords='edit done toggle layout arrange'
+          priority={10}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            if (isEditMode) {
+              exitEditMode()
+            } else {
+              setOpenRecordId(null)
+              enterEditMode()
+            }
+          }}
+        />
+      )}
       <CommandAction
         label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
         icon='star'
@@ -258,7 +280,7 @@ export function DashboardDetailView({
           />
         </>
       )}
-      {hasUnpublishedChanges && (
+      {canEdit && hasUnpublishedChanges && (
         <>
           <CommandAction
             label='Publish changes'
@@ -301,7 +323,7 @@ export function DashboardDetailView({
         Share
       </Button>
       <InstanceShareDialog
-        recordId={toRecordId('dashboard', dashboard.id)}
+        recordId={dashboardRecordId}
         open={shareOpen}
         onOpenChange={setShareOpen}
       />
@@ -314,6 +336,9 @@ export function DashboardDetailView({
         isDiscarding={isDiscarding}
         saveState={saveState}
         hasPersisted={hasPersisted}
+        canEdit={canEdit}
+        canAdmin={canAdmin}
+        canCreate={canCreate}
         viewLayer={viewLayer}
         onViewLayerChange={setViewLayer}
         onEnterEdit={() => {

--- a/apps/web/src/components/dashboard/ui/dashboard-publish-cluster.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-publish-cluster.tsx
@@ -11,7 +11,9 @@
 // `extraSegments` carries the mode controls in the same ButtonGroup:
 //   • view mode — the Edit button.
 //   • edit mode — Add widget ▾, then Done (exit edit; the draft stays parked).
-// The chevron menu (Version history / Duplicate / Settings / Archive) is constant.
+// The chevron menu holds Version history (Read) / Duplicate (`dashboards.manage`)
+// / Settings + Archive (Full per instance); each entry renders only at its tier,
+// so the menu shrinks rather than 403-ing (hide-don't-disable, doc 24 §A.2.3).
 // In view mode with a parked draft the status pill doubles as a Live/Draft view
 // toggle (via the shell's `pillOverride`): its label + dot show what the canvas is
 // showing NOW, and clicking flips between the published version and the draft so
@@ -50,6 +52,15 @@ export interface DashboardPublishClusterProps {
   saveState: SaveState
   /** No persisted version yet — disables Edit. */
   hasPersisted: boolean
+  /**
+   * Edit-instance on this dashboard — gates Edit / Add widget / Done and the
+   * Publish/Discard segments, plus every write in the version-history dialog.
+   */
+  canEdit: boolean
+  /** Admin-instance (Full) — gates Settings and Archive. */
+  canAdmin: boolean
+  /** Coarse `dashboards.manage` — gates Duplicate (it CREATES a dashboard). */
+  canCreate: boolean
   /** View-mode canvas layer — drives the Live/Draft toggle. */
   viewLayer: ViewLayer
   onViewLayerChange: (layer: ViewLayer) => void
@@ -69,6 +80,9 @@ export function DashboardPublishCluster({
   isDiscarding,
   saveState,
   hasPersisted,
+  canEdit,
+  canAdmin,
+  canCreate,
   viewLayer,
   onViewLayerChange,
   onEnterEdit,
@@ -113,7 +127,8 @@ export function DashboardPublishCluster({
     if (ok) onDiscard()
   }
 
-  const editSegment = (
+  // Read-only members get no Edit entry point at all — hide, don't disable.
+  const editSegment = canEdit ? (
     <Button
       size='xs'
       variant='outline'
@@ -122,7 +137,7 @@ export function DashboardPublishCluster({
       onClick={onEnterEdit}>
       <Pencil /> Edit
     </Button>
-  )
+  ) : null
 
   const editModeSegments = (
     <>
@@ -168,21 +183,34 @@ export function DashboardPublishCluster({
         // While editing, the autosave indicator conveys status — drop the pill.
         hidePill={isEditMode}
         extraSegments={isEditMode ? editModeSegments : editSegment}
-        publish={{ onClick: onPublish, isPending: isPublishing }}
-        discard={{ onClick: () => void handleDiscard(), isPending: isDiscarding }}>
+        // Publish/Discard are Edit — omitting the slots drops the segments.
+        publish={canEdit ? { onClick: onPublish, isPending: isPublishing } : undefined}
+        discard={
+          canEdit ? { onClick: () => void handleDiscard(), isPending: isDiscarding } : undefined
+        }>
+        {/* Version history itself is Read (`listVersions`); the dialog's own
+            writes are gated by `canEdit`. */}
         <DropdownMenuItem onClick={() => setVersionsOpen(true)}>
           <History /> Version history
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => void handleDuplicate()}>
-          <Copy /> Duplicate
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
-          <Settings /> Settings
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem variant='destructive' onClick={() => void handleArchive()}>
-          <Archive /> Archive
-        </DropdownMenuItem>
+        {canCreate && (
+          <DropdownMenuItem onClick={() => void handleDuplicate()}>
+            <Copy /> Duplicate
+          </DropdownMenuItem>
+        )}
+        {canAdmin && (
+          <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
+            <Settings /> Settings
+          </DropdownMenuItem>
+        )}
+        {canAdmin && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant='destructive' onClick={() => void handleArchive()}>
+              <Archive /> Archive
+            </DropdownMenuItem>
+          </>
+        )}
       </PublishClusterShell>
 
       <DashboardVersionsDialog
@@ -190,6 +218,7 @@ export function DashboardPublishCluster({
         onOpenChange={setVersionsOpen}
         dashboardId={dashboard.id}
         activeVersionNumber={activeVersionNumber}
+        canEdit={canEdit}
       />
       <DashboardFormDialog
         dashboard={dashboard}

--- a/apps/web/src/components/dashboard/ui/dashboard-switcher-list.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-switcher-list.tsx
@@ -3,8 +3,10 @@
 'use client'
 
 import type { SelectOption } from '@auxx/types/custom-field'
+import { toRecordId } from '@auxx/types/resource'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { useDashboardMutations } from '../hooks/use-dashboard-mutations'
 
@@ -35,10 +37,21 @@ export function DashboardSwitcherList({
 }: DashboardSwitcherListProps) {
   const dashboards = api.dashboard.list.useQuery(undefined, { staleTime: 30_000 })
   const { updateDashboard, deleteDashboard } = useDashboardMutations()
+  const { canAdminInstance } = useAccess()
 
   const dashboardOptions: SelectOption[] = useMemo(
     () => (dashboards.data ?? []).map((d) => ({ value: d.id, label: d.name })),
     [dashboards.data]
+  )
+
+  // Manage mode is a single all-or-nothing switch over the WHOLE list — the
+  // picker has no per-row suppression — and both of its writes (inline rename →
+  // `dashboard.update`, row × → `dashboard.delete`) are Full per instance. Same
+  // rule as the bulk bar (doc 24 §A.2.6): render it only when every listed
+  // dashboard passes admin, so a manage click can never 403.
+  const canManage = useMemo(
+    () => (dashboards.data ?? []).every((d) => canAdminInstance(toRecordId('dashboard', d.id))),
+    [dashboards.data, canAdminInstance]
   )
 
   const prevOptionsRef = useRef<SelectOption[]>(dashboardOptions)
@@ -74,7 +87,7 @@ export function DashboardSwitcherList({
       onChange={() => {}}
       multi={false}
       onSelectSingle={onSelectDashboard}
-      canManage={true}
+      canManage={canManage}
       canAdd={false}
       manageLabel='Manage dashboards'
       placeholder='Search dashboards...'

--- a/apps/web/src/components/dashboard/ui/dashboard-versions-dialog.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-versions-dialog.tsx
@@ -21,11 +21,18 @@ export function DashboardVersionsDialog({
   onOpenChange,
   dashboardId,
   activeVersionNumber,
+  canEdit,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   dashboardId: string
   activeVersionNumber: number | null
+  /**
+   * Edit-instance on this dashboard. Reading history is Read
+   * (`dashboard.listVersions`), but restore / delete / label-rename are all Edit
+   * — without it the dialog is a read-only log.
+   */
+  canEdit: boolean
 }) {
   const versionsQuery = api.dashboard.listVersions.useQuery({ id: dashboardId }, { enabled: open })
   const { restoreVersion, deleteVersion, renameVersion } = useDashboardMutations()
@@ -54,6 +61,7 @@ export function DashboardVersionsDialog({
           'This version is loaded as an editable draft. Review it, then Publish to make it the live dashboard.',
         confirmText: 'Restore to draft',
       })}
+      canRestore={canEdit}
       onRestore={async (v) => {
         if (v.versionNumber == null) return false
         const dashboard = await restoreVersion(dashboardId, v.versionNumber)
@@ -61,15 +69,23 @@ export function DashboardVersionsDialog({
         adoptDraft(dashboard.draftLayout ?? dashboard.layout, dashboard.hasUnpublishedChanges)
         return true
       }}
-      onDelete={async (v) => {
-        if (v.versionNumber == null) return false
-        return deleteVersion(dashboardId, v.versionNumber)
-      }}
-      onRenameLabel={async (versionId, label) => {
-        const v = versionsQuery.data?.find((x) => x.id === versionId)
-        if (!v) return
-        await renameVersion(dashboardId, v.versionNumber, label)
-      }}
+      onDelete={
+        canEdit
+          ? async (v) => {
+              if (v.versionNumber == null) return false
+              return deleteVersion(dashboardId, v.versionNumber)
+            }
+          : undefined
+      }
+      onRenameLabel={
+        canEdit
+          ? async (versionId, label) => {
+              const v = versionsQuery.data?.find((x) => x.id === versionId)
+              if (!v) return
+              await renameVersion(dashboardId, v.versionNumber, label)
+            }
+          : undefined
+      }
     />
   )
 }

--- a/apps/web/src/components/dashboard/ui/dashboards-bulk-bar.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboards-bulk-bar.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/dashboard/ui/dashboards-bulk-bar.tsx
 'use client'
 
+import { toRecordId } from '@auxx/types/resource'
 import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
 import { pluralize } from '@auxx/utils/strings'
 import { Trash } from 'lucide-react'
@@ -11,6 +12,7 @@ import {
   useSelectionCount,
   useSelectionIds,
 } from '~/components/list-selection'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { useDashboards } from './dashboards-provider'
 
@@ -23,27 +25,35 @@ export function DashboardsBulkBar() {
   const { refetch } = useDashboards()
   const { ConfirmDialog, run, isRunning } = useBulkRunner()
   const del = api.dashboard.delete.useMutation()
+  const { canAdminInstance } = useAccess()
 
-  const actions: ActionBarAction[] = [
-    {
-      id: 'delete',
-      label: 'Delete',
-      icon: Trash,
-      variant: 'destructive',
-      tooltip: 'Delete selected',
-      disabled: isRunning || count === 0,
-      onClick: () =>
-        run(ids, (id) => del.mutateAsync({ id }), {
-          title: `Delete ${count} ${pluralize(count, 'dashboard')}?`,
-          description: 'This permanently deletes them. This cannot be undone.',
-          failureTitle: 'Some dashboards could not be deleted',
-          onDone: () => {
-            refetch()
-            exit()
-          },
-        }),
-    },
-  ]
+  // Delete is Full-only per instance — hide the bulk action unless every
+  // selected dashboard passes admin (doc 24 §A.2.6; per-item filtering inside a
+  // bulk delete is silent-partial-failure UX).
+  const allSelectedAdmin = ids.every((id) => canAdminInstance(toRecordId('dashboard', id)))
+
+  const actions: ActionBarAction[] = allSelectedAdmin
+    ? [
+        {
+          id: 'delete',
+          label: 'Delete',
+          icon: Trash,
+          variant: 'destructive',
+          tooltip: 'Delete selected',
+          disabled: isRunning || count === 0,
+          onClick: () =>
+            run(ids, (id) => del.mutateAsync({ id }), {
+              title: `Delete ${count} ${pluralize(count, 'dashboard')}?`,
+              description: 'This permanently deletes them. This cannot be undone.',
+              failureTitle: 'Some dashboards could not be deleted',
+              onDone: () => {
+                refetch()
+                exit()
+              },
+            }),
+        },
+      ]
+    : []
 
   return (
     <>

--- a/apps/web/src/components/dashboard/ui/entity-dashboard-page.tsx
+++ b/apps/web/src/components/dashboard/ui/entity-dashboard-page.tsx
@@ -18,12 +18,14 @@ import { useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { MainPageLoading, MainPageNoPermission } from '~/components/global/main-page-states'
 import { useResources } from '~/components/resources'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { DashboardDetailView } from './dashboard-detail-view'
 
 export function EntityDashboardPage({ slug }: { slug: string }) {
   const { hasAccess } = useFeatureFlags()
+  const { can } = useAccess()
   const utils = api.useUtils()
   const { getResourceById } = useResources()
   const resource = getResourceById(slug)
@@ -71,28 +73,40 @@ export function EntityDashboardPage({ slug }: { slug: string }) {
     )
   }
 
+  // `dashboard.create` is the coarse `dashboards.manage` rung — a Read/Edit
+  // member sees the same empty state without the CTA (same rule as
+  // `CreateDashboardButton`), not a button that 403s.
   const plural = resource?.plural?.toLowerCase() ?? 'records'
+  const canCreate = can('dashboards.manage')
   return (
     <MainPageContent>
       <EmptyState
         icon={ChartColumn}
         title='No dashboard yet'
-        description={`Create a dashboard to visualize your ${plural}.`}
+        description={
+          canCreate
+            ? `Create a dashboard to visualize your ${plural}.`
+            : `No dashboard has been set up for ${plural} yet.`
+        }
         button={
-          <Button
-            onClick={() => {
-              if (!resource) return
-              createDashboard.mutate({
-                name: `${resource.plural} Dashboard`,
-                icon: { iconId: resource.icon, color: resource.color },
-                entityDefinitionId: resource.id,
-              })
-            }}
-            disabled={!resource}
-            loading={createDashboard.isPending}
-            loadingText='Creating...'>
-            Create dashboard
-          </Button>
+          !canCreate ? (
+            <div className='h-12' />
+          ) : (
+            <Button
+              onClick={() => {
+                if (!resource) return
+                createDashboard.mutate({
+                  name: `${resource.plural} Dashboard`,
+                  icon: { iconId: resource.icon, color: resource.color },
+                  entityDefinitionId: resource.id,
+                })
+              }}
+              disabled={!resource}
+              loading={createDashboard.isPending}
+              loadingText='Creating...'>
+              Create dashboard
+            </Button>
+          )
         }
       />
     </MainPageContent>

--- a/apps/web/src/components/kbar/actions/launchers.ts
+++ b/apps/web/src/components/kbar/actions/launchers.ts
@@ -106,7 +106,9 @@ export function useLauncherActions(): PaletteAction[] {
       })
     }
 
-    if (hasAccess('dashboards')) {
+    // Creating a dashboard is the `dashboards` Full rung (`dashboards.manage`) —
+    // mirrors CreateDashboardButton; Read/Edit members can browse but not create.
+    if (hasAccess('dashboards') && can('dashboards.manage')) {
       actions.push({
         id: 'create.dashboard',
         label: 'Create Dashboard',

--- a/apps/web/src/components/members/types.ts
+++ b/apps/web/src/components/members/types.ts
@@ -13,10 +13,9 @@ export interface Member {
    * The bound permission profile (doc 19 §1.1). `null`/absent resolves to the
    * system template for (role, seat) exactly as the server does (§1.3).
    *
-   * TODO(plan-19-step-8): optional because `member.all` does not project it yet —
-   * the cached member row already carries it (`members-provider.ts`), the router
-   * mapping simply drops it. Until that one field is added, an explicitly bound
-   * CUSTOM profile reads on these surfaces as the system template.
+   * Optional only because other surfaces build partial member shapes; the org
+   * cache carries it (`members-provider.ts`) and `member.all` projects it, so an
+   * explicitly bound CUSTOM profile resolves rather than reading as the template.
    */
   permissionProfileId?: string | null
   user: {

--- a/apps/web/src/components/versioning/ui/version-history-dialog.tsx
+++ b/apps/web/src/components/versioning/ui/version-history-dialog.tsx
@@ -39,6 +39,13 @@ export interface VersionHistoryDialogProps {
   currentVersionId: string | null
   /** Resolves the restore mutation; the dialog owns the confirm. Return false to keep it open. */
   onRestore: (version: VersionRowData) => Promise<boolean>
+  /**
+   * Whether the viewer may restore a version onto the draft. Defaults to `true`.
+   * Pass `false` when reading history is allowed but writing is not (e.g. a
+   * dashboard the member holds Read on: `listVersions` is Read, `restoreVersion`
+   * is Edit) — the row's restore control is then not rendered at all.
+   */
+  canRestore?: boolean
   /** Presence enables the inline {@link VersionLabelRow} on every row. */
   onRenameLabel?: (versionId: string, label: string | null) => Promise<void>
   /**
@@ -84,6 +91,7 @@ export function VersionHistoryDialog({
   isLoading,
   currentVersionId,
   onRestore,
+  canRestore = true,
   onRenameLabel,
   onDelete,
   deleteConfirm,
@@ -212,7 +220,7 @@ export function VersionHistoryDialog({
                         </div>
                         <div className='flex shrink-0 items-center gap-1'>
                           {renderRowActions?.(v, { isCurrent })}
-                          {!isCurrent && (
+                          {canRestore && !isCurrent && (
                             <Tooltip content='Restore as draft'>
                               <Button
                                 size='icon-xs'

--- a/apps/web/src/server/api/routers/dashboard.ts
+++ b/apps/web/src/server/api/routers/dashboard.ts
@@ -170,8 +170,12 @@ export const dashboardRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...patch } = input
-      // Write — editing dashboard metadata.
-      ctx.capabilities.assertEditInstance('dashboard', id)
+      // Full — this patch is entirely CONTAINER metadata (name, description,
+      // icon, list position, primary-entity link); widget/layout edits never
+      // come through here, they go to `saveDraft`/`publish`. Renaming is a Full
+      // act per the dashboards ladder, so the whole patch sits at Full rather
+      // than splitting one input across two rungs.
+      ctx.capabilities.assertAdminInstance('dashboard', id)
       return unwrap(
         await updateDashboard(ctx.db, ctx.session.organizationId, ctx.session.userId, id, patch)
       )
@@ -200,7 +204,7 @@ export const dashboardRouter = createTRPCRouter({
   saveDraft: capabilityProcedure
     .input(z.object({ id: z.string(), doc: draftLayoutDocSchema }))
     .mutation(async ({ ctx, input }) => {
-      // Write — auto-saving draft layout edits.
+      // Edit — auto-saving draft widget/layout edits.
       ctx.capabilities.assertEditInstance('dashboard', input.id)
       return unwrap(
         await saveDraft(
@@ -216,7 +220,7 @@ export const dashboardRouter = createTRPCRouter({
   publish: capabilityProcedure
     .input(z.object({ id: z.string(), label: z.string().max(120).nullable().optional() }))
     .mutation(async ({ ctx, input }) => {
-      // Write — publishing the draft into a new version.
+      // Edit — publishing the widget/layout draft into a new version.
       ctx.capabilities.assertEditInstance('dashboard', input.id)
       return unwrap(
         await publishDashboard(
@@ -233,7 +237,7 @@ export const dashboardRouter = createTRPCRouter({
   discardDraft: capabilityProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      // Write — discarding draft edits.
+      // Edit — discarding draft widget/layout edits.
       ctx.capabilities.assertEditInstance('dashboard', input.id)
       return unwrap(await discardDashboardDraft(ctx.db, ctx.session.organizationId, input.id))
     }),
@@ -259,7 +263,7 @@ export const dashboardRouter = createTRPCRouter({
   restoreVersion: capabilityProcedure
     .input(z.object({ id: z.string(), versionNumber: z.number().int().positive() }))
     .mutation(async ({ ctx, input }) => {
-      // Write — restoring a version onto the draft.
+      // Edit — restoring a version onto the draft.
       ctx.capabilities.assertEditInstance('dashboard', input.id)
       return unwrap(
         await restoreVersion(ctx.db, ctx.session.organizationId, input.id, input.versionNumber)
@@ -269,7 +273,7 @@ export const dashboardRouter = createTRPCRouter({
   deleteVersion: capabilityProcedure
     .input(z.object({ id: z.string(), versionNumber: z.number().int().positive() }))
     .mutation(async ({ ctx, input }) => {
-      // Write — deleting a non-live version.
+      // Edit — deleting a non-live version.
       ctx.capabilities.assertEditInstance('dashboard', input.id)
       return unwrap(
         await deleteVersion(ctx.db, ctx.session.organizationId, input.id, input.versionNumber)
@@ -285,7 +289,7 @@ export const dashboardRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // Write — annotating a version's label.
+      // Edit — annotating a VERSION's label (not the dashboard's name).
       ctx.capabilities.assertEditInstance('dashboard', input.id)
       return unwrap(
         await renameVersion(

--- a/apps/web/src/server/api/routers/dataset-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/dataset-instance-access.test.ts
@@ -1,0 +1,241 @@
+// apps/web/src/server/api/routers/dataset-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 24 §A.4's dataset half, at the router layer: **`edit` must not reach
+ * settings / archive / delete** (those are `assertAdminInstance`), `view` must not
+ * reach the one edit-level mutation (`updateMetrics`), and the reads — including
+ * `testSearchConfig`, downgraded from admin to view by §A.2.2 — must stay open at
+ * `view`.
+ *
+ * `ctx.capabilities` is a real {@link CapabilitySet}, so these fail if an assert
+ * is deleted or weakened (edit→view, admin→edit). `DatasetService` is the
+ * observed side effect: "did the write get through?".
+ */
+
+const { datasetService, searchService, featureService, onCacheEvent } = vi.hoisted(() => ({
+  datasetService: {
+    create: vi.fn(async () => ({ id: 'dset_new' })),
+    getById: vi.fn(async () => ({ id: 'dset_1' })),
+    getStats: vi.fn(async () => ({ documentCount: 0 })),
+    list: vi.fn(async () => ({ datasets: [], totalCount: 0, hasMore: false })),
+    update: vi.fn(async () => ({ id: 'dset_1' })),
+    updateMetrics: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+  },
+  searchService: {
+    search: vi.fn(async () => ({ results: [], total: 0, responseTime: 1, searchType: 'hybrid' })),
+  },
+  featureService: { requireAccess: vi.fn(async () => undefined) },
+  onCacheEvent: vi.fn(async () => undefined),
+}))
+
+vi.mock('@auxx/lib/datasets', () => ({
+  DatasetService: class {
+    create = datasetService.create
+    getById = datasetService.getById
+    getStats = datasetService.getStats
+    list = datasetService.list
+    update = datasetService.update
+    updateMetrics = datasetService.updateMetrics
+    delete = datasetService.delete
+  },
+  SearchService: searchService,
+}))
+
+vi.mock('@auxx/lib/cache', () => ({ onCacheEvent }))
+
+// The `@auxx/lib/permissions` barrel reaches redis/db at import time and hangs
+// under vitest — hand the router the real registry/feature enums it needs and a
+// stub feature service (Layer-1 plan gating is not what this file is about).
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+    },
+  }
+})
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return { createTRPCRouter: t.router, capabilityProcedure: t.procedure }
+})
+
+// Deep path on purpose — see the note in `segment-instance-access.test.ts`.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { datasetRouter } = await import('./dataset')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const DATASET_ID = 'dset_cuid00000000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+/** A real `CapabilitySet` holding `permission` on {@link DATASET_ID} via an explicit row. */
+function capabilitiesFor(
+  permission: ResourcePermission,
+  instances: Record<string, ResourcePermission> = { [DATASET_ID]: permission }
+) {
+  const areaLevel = {
+    [ResourcePermission.none]: Level.None,
+    [ResourcePermission.view]: Level.Read,
+    [ResourcePermission.edit]: Level.Edit,
+    [ResourcePermission.admin]: Level.Full,
+  }[permission]
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.datasets]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return datasetRouter.createCaller({
+    db: {},
+    capabilities,
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID },
+    },
+  } as any)
+}
+
+/** Settings-class mutations: Full only (`assertAdminInstance`). */
+const ADMIN_ONLY = [
+  [
+    'update',
+    (c: ReturnType<typeof caller>) => c.update({ id: DATASET_ID, data: { name: 'x' } }),
+    'update',
+  ],
+  ['archive', (c: ReturnType<typeof caller>) => c.archive({ id: DATASET_ID }), 'update'],
+  ['delete', (c: ReturnType<typeof caller>) => c.delete({ id: DATASET_ID }), 'delete'],
+] as const
+
+beforeEach(() => {
+  for (const fn of Object.values(datasetService)) fn.mockClear()
+  searchService.search.mockClear()
+})
+
+describe('dataset router — `edit` does not reach settings/archive/delete (plan 24 §A.4)', () => {
+  it.each(ADMIN_ONLY)('%s is refused at instance edit', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.edit)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(datasetService[serviceFn]).not.toHaveBeenCalled()
+  })
+
+  it.each(ADMIN_ONLY)('%s is refused at instance view', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(datasetService[serviceFn]).not.toHaveBeenCalled()
+  })
+
+  it.each(ADMIN_ONLY)('%s succeeds at instance admin', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.admin)))).resolves.toBeDefined()
+    expect(datasetService[serviceFn]).toHaveBeenCalledTimes(1)
+  })
+
+  it('creating a dataset needs the coarse datasets Full rung, not instance edit', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).create({
+        name: 'New',
+        vectorDbType: 'POSTGRESQL',
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(datasetService.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('dataset router — the edit rung', () => {
+  it('updateMetrics (content churn, not settings) succeeds at instance edit', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).updateMetrics({ id: DATASET_ID })
+    ).resolves.toEqual({ success: true })
+    expect(datasetService.updateMetrics).toHaveBeenCalledTimes(1)
+  })
+
+  it('updateMetrics is refused at instance view', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view)).updateMetrics({ id: DATASET_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(datasetService.updateMetrics).not.toHaveBeenCalled()
+  })
+})
+
+describe('dataset router — reads stay open at instance view', () => {
+  it('getById and getStats succeed at view', async () => {
+    const c = caller(capabilitiesFor(ResourcePermission.view))
+    await expect(c.getById({ id: DATASET_ID })).resolves.toBeDefined()
+    await expect(c.getStats({ id: DATASET_ID })).resolves.toBeDefined()
+  })
+
+  it('testSearchConfig is a READ (§A.2.2 downgrade) — reachable at instance view', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view)).testSearchConfig({
+        datasetId: DATASET_ID,
+        testQuery: 'hello',
+        searchConfig: {},
+      })
+    ).resolves.toMatchObject({ success: true })
+    expect(searchService.search).toHaveBeenCalledTimes(1)
+  })
+
+  it('testSearchConfig is still refused with the instance restricted to none', async () => {
+    await expect(
+      caller(
+        capabilitiesFor(ResourcePermission.view, { [DATASET_ID]: ResourcePermission.none })
+      ).testSearchConfig({ datasetId: DATASET_ID, testQuery: 'hello', searchConfig: {} })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(searchService.search).not.toHaveBeenCalled()
+  })
+
+  it('getById is refused with the instance restricted to none', async () => {
+    await expect(
+      caller(
+        capabilitiesFor(ResourcePermission.view, { [DATASET_ID]: ResourcePermission.none })
+      ).getById({ id: DATASET_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(datasetService.getById).not.toHaveBeenCalled()
+  })
+})
+
+describe('dataset router — list drops instances the member may not view', () => {
+  it('filters restricted datasets out of the page instead of 403ing the whole list', async () => {
+    const RESTRICTED = 'dset_restrictedcuid0000000000'
+    datasetService.list.mockResolvedValueOnce({
+      datasets: [{ id: DATASET_ID }, { id: RESTRICTED }],
+      totalCount: 2,
+      hasMore: false,
+    } as any)
+
+    const result = await caller(
+      capabilitiesFor(ResourcePermission.view, {
+        [DATASET_ID]: ResourcePermission.view,
+        [RESTRICTED]: ResourcePermission.none,
+      })
+    ).list({})
+
+    expect(result.datasets).toEqual([{ id: DATASET_ID }])
+    // The unfiltered count is deliberately preserved by the router — assert what
+    // it actually returns so a future change to that contract is visible.
+    expect(result.totalCount).toBe(2)
+  })
+})

--- a/apps/web/src/server/api/routers/kb-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/kb-instance-access.test.ts
@@ -1,0 +1,282 @@
+// apps/web/src/server/api/routers/kb-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 24 §A.4's KB half, at the router layer: **`edit` authors articles but must
+ * not reach settings / publish / delete** (those are `assertAdminInstance`), and
+ * `view` must not reach the article mutations. The UI gating from PR #1338 hides
+ * those affordances; this pins the server truth the UI is mirroring.
+ *
+ * `ctx.capabilities` is a real {@link CapabilitySet}; `KBService` is the observed
+ * side effect. Weakening any assert (admin→edit, edit→view) fails a case here.
+ */
+
+const { kbService, featureService, onCacheEvent, getUserOrganizationId, fireKBRevalidate } =
+  vi.hoisted(() => ({
+    kbService: {
+      getKnowledgeBaseById: vi.fn(async () => ({ id: 'kb_1' })),
+      listKnowledgeBases: vi.fn(async () => [] as { id: string }[]),
+      createKnowledgeBase: vi.fn(async () => ({ id: 'kb_new' })),
+      updateKnowledgeBase: vi.fn(async () => ({ id: 'kb_1' })),
+      updateDraftSettings: vi.fn(async () => ({ id: 'kb_1' })),
+      publishPendingSettings: vi.fn(async () => ({ id: 'kb_1' })),
+      discardSettingsDraft: vi.fn(async () => ({ id: 'kb_1' })),
+      deleteKnowledgeBase: vi.fn(async () => ({ success: true })),
+      publishKnowledgeBase: vi.fn(async () => ({ id: 'kb_1' })),
+      unpublishKnowledgeBase: vi.fn(async () => ({ id: 'kb_1' })),
+      getArticles: vi.fn(async () => []),
+      createArticle: vi.fn(async () => ({ id: 'art_1' })),
+      deleteArticle: vi.fn(async () => ({ success: true })),
+      updateArticlesBatch: vi.fn(async () => ({ updated: 1 })),
+      getArticleSlugPath: vi.fn(async () => 'some/path'),
+    },
+    featureService: { requireAccess: vi.fn(async () => undefined) },
+    onCacheEvent: vi.fn(async () => undefined),
+    getUserOrganizationId: vi.fn(() => 'org_cuid000000000000000000000'),
+    fireKBRevalidate: vi.fn(() => Promise.resolve()),
+  }))
+
+vi.mock('@auxx/lib/kb', () => ({
+  KBService: class {
+    getKnowledgeBaseById = kbService.getKnowledgeBaseById
+    listKnowledgeBases = kbService.listKnowledgeBases
+    createKnowledgeBase = kbService.createKnowledgeBase
+    updateKnowledgeBase = kbService.updateKnowledgeBase
+    updateDraftSettings = kbService.updateDraftSettings
+    publishPendingSettings = kbService.publishPendingSettings
+    discardSettingsDraft = kbService.discardSettingsDraft
+    deleteKnowledgeBase = kbService.deleteKnowledgeBase
+    publishKnowledgeBase = kbService.publishKnowledgeBase
+    unpublishKnowledgeBase = kbService.unpublishKnowledgeBase
+    getArticles = kbService.getArticles
+    createArticle = kbService.createArticle
+    deleteArticle = kbService.deleteArticle
+    updateArticlesBatch = kbService.updateArticlesBatch
+    getArticleSlugPath = kbService.getArticleSlugPath
+  },
+  ensureLearnedKb: vi.fn(async () => ({ kb: { id: 'kb_learned' } })),
+  articleToMarkdown: vi.fn(() => ''),
+  linkArticlesIntoKb: vi.fn(async () => undefined),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({ onCacheEvent }))
+vi.mock('@auxx/lib/email', () => ({ getUserOrganizationId }))
+vi.mock('~/server/lib/kb-revalidate', () => ({ fireKBRevalidate }))
+
+// See the note in `dataset-instance-access.test.ts` — the permissions barrel
+// hangs under vitest; hand back the real enums plus a stub feature service.
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+    },
+  }
+})
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    // The real one blocks demo orgs; irrelevant to capability gating, and it must
+    // stay downstream of the assert either way.
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  }
+})
+
+// Deep path on purpose — see the note in `segment-instance-access.test.ts`.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { knowledgeBaseRouter } = await import('./kb')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const KB_ID = 'kb_cuid00000000000000000000'
+const ARTICLE_ID = 'art_cuid0000000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+/** A real `CapabilitySet` holding `permission` on {@link KB_ID} via an explicit row. */
+function capabilitiesFor(
+  permission: ResourcePermission,
+  instances: Record<string, ResourcePermission> = { [KB_ID]: permission }
+) {
+  const areaLevel = {
+    [ResourcePermission.none]: Level.None,
+    [ResourcePermission.view]: Level.Read,
+    [ResourcePermission.edit]: Level.Edit,
+    [ResourcePermission.admin]: Level.Full,
+  }[permission]
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return knowledgeBaseRouter.createCaller({
+    db: {},
+    capabilities,
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID },
+    },
+  } as any)
+}
+
+/** Settings / publish / delete: Full only (`assertAdminInstance`). */
+const ADMIN_ONLY = [
+  [
+    'update',
+    (c: ReturnType<typeof caller>) => c.update({ id: KB_ID, data: { slug: 'help' } }),
+    'updateKnowledgeBase',
+  ],
+  [
+    'updateDraftSettings',
+    (c: ReturnType<typeof caller>) => c.updateDraftSettings({ id: KB_ID, patch: { name: 'Help' } }),
+    'updateDraftSettings',
+  ],
+  [
+    'publishPendingSettings',
+    (c: ReturnType<typeof caller>) => c.publishPendingSettings({ id: KB_ID }),
+    'publishPendingSettings',
+  ],
+  [
+    'discardSettingsDraft',
+    (c: ReturnType<typeof caller>) => c.discardSettingsDraft({ id: KB_ID }),
+    'discardSettingsDraft',
+  ],
+  ['delete', (c: ReturnType<typeof caller>) => c.delete({ id: KB_ID }), 'deleteKnowledgeBase'],
+  [
+    'publishSite',
+    (c: ReturnType<typeof caller>) => c.publishSite({ id: KB_ID, status: 'PUBLISHED' }),
+    'publishKnowledgeBase',
+  ],
+  [
+    'unpublishSite',
+    (c: ReturnType<typeof caller>) => c.unpublishSite({ id: KB_ID }),
+    'unpublishKnowledgeBase',
+  ],
+] as const
+
+/** Article authoring: Write (`assertEditInstance`). */
+const EDIT_LEVEL = [
+  [
+    'createArticle',
+    (c: ReturnType<typeof caller>) => c.createArticle({ knowledgeBaseId: KB_ID, title: 'New' }),
+    'createArticle',
+  ],
+  [
+    'deleteArticle',
+    (c: ReturnType<typeof caller>) => c.deleteArticle({ id: ARTICLE_ID, knowledgeBaseId: KB_ID }),
+    'deleteArticle',
+  ],
+  [
+    'updateArticlesBatch',
+    (c: ReturnType<typeof caller>) =>
+      c.updateArticlesBatch({
+        knowledgeBaseId: KB_ID,
+        articles: [{ id: ARTICLE_ID, updates: { slug: 'a-slug' } }],
+      }),
+    'updateArticlesBatch',
+  ],
+] as const
+
+beforeEach(() => {
+  for (const fn of Object.values(kbService)) fn.mockClear()
+})
+
+describe('kb router — `edit` does not reach settings/publish/delete (plan 24 §A.4)', () => {
+  it.each(ADMIN_ONLY)('%s is refused at instance edit', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.edit)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(kbService[serviceFn]).not.toHaveBeenCalled()
+  })
+
+  it.each(ADMIN_ONLY)('%s is refused at instance view', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(kbService[serviceFn]).not.toHaveBeenCalled()
+  })
+
+  it.each(ADMIN_ONLY)('%s succeeds at instance admin', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.admin)))).resolves.toBeDefined()
+    expect(kbService[serviceFn]).toHaveBeenCalledTimes(1)
+  })
+
+  it('creating a KB needs the coarse knowledgeBase Full rung, not instance edit', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).create({ name: 'Help', slug: 'help' })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(kbService.createKnowledgeBase).not.toHaveBeenCalled()
+  })
+})
+
+describe('kb router — article authoring is the edit rung', () => {
+  it.each(EDIT_LEVEL)('%s succeeds at instance edit', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.edit)))).resolves.toBeDefined()
+    expect(kbService[serviceFn]).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(EDIT_LEVEL)('%s is refused at instance view', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(kbService[serviceFn]).not.toHaveBeenCalled()
+  })
+})
+
+describe('kb router — reads stay open at instance view', () => {
+  it('byId and getArticles succeed at view', async () => {
+    const c = caller(capabilitiesFor(ResourcePermission.view))
+    await expect(c.byId({ id: KB_ID })).resolves.toBeDefined()
+    await expect(c.getArticles({ knowledgeBaseId: KB_ID })).resolves.toBeDefined()
+  })
+
+  it('byId is refused with the instance restricted to none', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view, { [KB_ID]: ResourcePermission.none })).byId({
+        id: KB_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(kbService.getKnowledgeBaseById).not.toHaveBeenCalled()
+  })
+})
+
+describe('kb router — list drops instances the member may not view', () => {
+  it('filters restricted KBs out of the list instead of 403ing', async () => {
+    const RESTRICTED = 'kb_restrictedcuid00000000000'
+    kbService.listKnowledgeBases.mockResolvedValueOnce([{ id: KB_ID }, { id: RESTRICTED }])
+
+    await expect(
+      caller(
+        capabilitiesFor(ResourcePermission.view, {
+          [KB_ID]: ResourcePermission.view,
+          [RESTRICTED]: ResourcePermission.none,
+        })
+      ).list()
+    ).resolves.toEqual([{ id: KB_ID }])
+  })
+})

--- a/apps/web/src/server/api/routers/member.ts
+++ b/apps/web/src/server/api/routers/member.ts
@@ -93,6 +93,11 @@ export const memberRouter = createTRPCRouter({
           seatType: m.seatType,
           status: m.status,
           organizationId: m.organizationId,
+          // Without this the member detail's profile picker resolves every member
+          // to the system template for their role/seat, so an explicit CUSTOM
+          // binding is invisible — and assigning one appears to do nothing, since
+          // the refetch after a successful write reports the same fallback.
+          permissionProfileId: m.permissionProfileId ?? null,
           user: m.user!,
         }))
 

--- a/apps/web/src/server/api/routers/resource-access-instance-baseline.test.ts
+++ b/apps/web/src/server/api/routers/resource-access-instance-baseline.test.ts
@@ -1,0 +1,305 @@
+// apps/web/src/server/api/routers/resource-access-instance-baseline.test.ts
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 24 §B.4 — the **instance baseline picker round-trip** at the router that
+ * owns the write. Every sharing surface (share card, share dialog, and the new
+ * per-instance rows nested in the permission grids) funnels through
+ * `resourceAccess.grantInstance`; picking **Restricted** on an instance row is
+ * exactly `grantInstance({ granteeType: 'role', granteeId: 'org_member',
+ * permission: 'none' })`.
+ *
+ * What these pin:
+ *  - `none` survives the router untouched onto `grantInstanceAccess` (an
+ *    `undefined`/dropped permission would render as "inherit" and make Restricted
+ *    unreachable — the doc 16 §10 bug class);
+ *  - `none` is refused for non-instance-access (mail) targets;
+ *  - `authorizeInstanceTarget` really gates on `canAdminInstance` for the exact
+ *    instance (§B.2.7): an instance-`edit` holder cannot re-share, and no write
+ *    happens when it throws.
+ *
+ * `getCapabilities` is stubbed to return a **real** {@link CapabilitySet}, so the
+ * authorization decision is the shipped one, not a boolean fake.
+ */
+
+const { getCapabilities, resourceAccess, isAdminOrOwner, recordAuditFromCtx } = vi.hoisted(() => ({
+  getCapabilities: vi.fn(),
+  resourceAccess: {
+    grantInstanceAccess: vi.fn(async () => undefined),
+    setInstanceAccess: vi.fn(async () => undefined),
+    revokeInstanceAccess: vi.fn(async () => true),
+    grantTypeAccess: vi.fn(async () => undefined),
+    setTypeAccess: vi.fn(async () => undefined),
+    revokeTypeAccess: vi.fn(async () => true),
+    getInstanceAccess: vi.fn(async () => []),
+    getTypeAccess: vi.fn(async () => []),
+    getAllInstanceAccess: vi.fn(async () => []),
+    getAllTypeAccess: vi.fn(async () => []),
+    checkAccess: vi.fn(async () => true),
+    checkTypeAccess: vi.fn(async () => true),
+    assertCanManageMailSharing: vi.fn(async () => undefined),
+    assertCanManageMailTypeAccess: vi.fn(async () => undefined),
+    assertMailSharingFeature: vi.fn(async () => undefined),
+    isMailSharingDef: vi.fn(() => false),
+  },
+  isAdminOrOwner: vi.fn(async () => false),
+  recordAuditFromCtx: vi.fn(async () => undefined),
+}))
+
+vi.mock('@auxx/lib/resource-access', () => resourceAccess)
+vi.mock('@auxx/lib/members', () => ({ isAdminOrOwner }))
+vi.mock('~/server/api/audit-context', () => ({ recordAuditFromCtx }))
+vi.mock('@auxx/lib/cache', () => ({
+  // `grantee-schema.ts` (kept real — it decides which grantee kinds are legal)
+  getCachedPermissionProfiles: vi.fn(async () => []),
+}))
+
+// The permissions barrel reaches redis/db at import time and hangs under vitest.
+// Re-export the REAL instance-access registry (it decides whether `none` is legal
+// for a target) and stub only the capability resolution.
+vi.mock('@auxx/lib/permissions', async () => {
+  const instanceAccess = await import('@auxx/lib/permissions/capabilities/instance-access')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    ...instanceAccess,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = vi.fn(async () => undefined)
+    },
+    getCapabilities,
+  }
+})
+
+vi.mock('../trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return { createTRPCRouter: t.router, protectedProcedure: t.procedure }
+})
+
+// Deep path on purpose — see the note in `segment-instance-access.test.ts`.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { resourceAccessRouter } = await import('./resourceAccess')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const DATASET_ID = 'dset_cuid00000000000000000000'
+const DATASET_RECORD_ID = `dataset:${DATASET_ID}`
+const CONTACT_RECORD_ID = 'contact:cont_cuid0000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to a status). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+const BAD_REQUEST = { cause: { name: 'BadRequestError', statusCode: 400 } }
+
+/** The workspace-baseline marker row the instance pickers write through. */
+const WORKSPACE_BASELINE = {
+  granteeType: ResourceGranteeType.role,
+  granteeId: 'org_member',
+} as const
+
+/** A real `CapabilitySet` holding `permission` on {@link DATASET_ID}. */
+function capabilitiesFor(permission: ResourcePermission) {
+  const areaLevel = {
+    [ResourcePermission.none]: Level.None,
+    [ResourcePermission.view]: Level.Read,
+    [ResourcePermission.edit]: Level.Edit,
+    [ResourcePermission.admin]: Level.Full,
+  }[permission]
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.datasets]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    { [DATASET_ID]: permission },
+    new Set([DATASET_ID])
+  )
+}
+
+const caller = resourceAccessRouter.createCaller({
+  db: {},
+  headers: new Headers(),
+  session: { organizationId: ORG_ID, userId: USER_ID, user: { id: USER_ID } },
+} as any)
+
+beforeEach(() => {
+  for (const fn of Object.values(resourceAccess)) fn.mockClear()
+  resourceAccess.isMailSharingDef.mockReturnValue(false)
+  isAdminOrOwner.mockResolvedValue(false)
+  getCapabilities.mockResolvedValue(capabilitiesFor(ResourcePermission.admin))
+})
+
+describe('grantInstance — the Restricted baseline round-trip (plan 24 §B.4)', () => {
+  it('writes permission `none` verbatim for the workspace-baseline row', async () => {
+    await expect(
+      caller.grantInstance({
+        recordId: DATASET_RECORD_ID,
+        ...WORKSPACE_BASELINE,
+        permission: ResourcePermission.none,
+      })
+    ).resolves.toEqual({ success: true })
+
+    expect(resourceAccess.grantInstanceAccess).toHaveBeenCalledTimes(1)
+    expect(resourceAccess.grantInstanceAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: ORG_ID, userId: USER_ID }),
+      expect.objectContaining({
+        recordId: DATASET_RECORD_ID,
+        granteeType: 'role',
+        granteeId: 'org_member',
+        // `undefined` here would read back as "inherit" and Restricted would be
+        // unreachable from the picker.
+        permission: ResourcePermission.none,
+      })
+    )
+  })
+
+  it('records the lockdown in the audit log as a security event', async () => {
+    await caller.grantInstance({
+      recordId: DATASET_RECORD_ID,
+      ...WORKSPACE_BASELINE,
+      permission: ResourcePermission.none,
+    })
+    expect(recordAuditFromCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'permission.granted',
+        metadata: expect.objectContaining({ scope: 'instance', permission: 'none' }),
+      })
+    )
+  })
+
+  it('carries the raise levels through unchanged too (view/edit/admin)', async () => {
+    for (const permission of [
+      ResourcePermission.view,
+      ResourcePermission.edit,
+      ResourcePermission.admin,
+    ] as const) {
+      resourceAccess.grantInstanceAccess.mockClear()
+      await caller.grantInstance({
+        recordId: DATASET_RECORD_ID,
+        granteeType: ResourceGranteeType.user,
+        granteeId: 'usr_grantee',
+        permission,
+      })
+      expect(resourceAccess.grantInstanceAccess).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ permission })
+      )
+    }
+  })
+
+  it('refuses `none` on a mail target — it is an instance-access-only marker', async () => {
+    await expect(
+      caller.grantInstance({
+        recordId: CONTACT_RECORD_ID,
+        ...WORKSPACE_BASELINE,
+        permission: ResourcePermission.none,
+      })
+    ).rejects.toMatchObject(BAD_REQUEST)
+    expect(resourceAccess.grantInstanceAccess).not.toHaveBeenCalled()
+  })
+})
+
+describe('grantInstance — authorizeInstanceTarget gates on THIS instance (§B.2.7)', () => {
+  it('refuses a sharer who only holds edit on the dataset', async () => {
+    getCapabilities.mockResolvedValue(capabilitiesFor(ResourcePermission.edit))
+
+    await expect(
+      caller.grantInstance({
+        recordId: DATASET_RECORD_ID,
+        granteeType: ResourceGranteeType.user,
+        granteeId: 'usr_grantee',
+        permission: ResourcePermission.admin,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(resourceAccess.grantInstanceAccess).not.toHaveBeenCalled()
+  })
+
+  it('refuses a sharer restricted out of the dataset entirely', async () => {
+    getCapabilities.mockResolvedValue(capabilitiesFor(ResourcePermission.none))
+
+    await expect(
+      caller.grantInstance({
+        recordId: DATASET_RECORD_ID,
+        ...WORKSPACE_BASELINE,
+        permission: ResourcePermission.none,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(resourceAccess.grantInstanceAccess).not.toHaveBeenCalled()
+  })
+
+  it('an instance admin never falls through to the mail-sharing authorizer', async () => {
+    await caller.grantInstance({
+      recordId: DATASET_RECORD_ID,
+      granteeType: ResourceGranteeType.group,
+      granteeId: 'grp_sales',
+      permission: ResourcePermission.view,
+    })
+    expect(resourceAccess.assertCanManageMailSharing).not.toHaveBeenCalled()
+    expect(resourceAccess.assertMailSharingFeature).not.toHaveBeenCalled()
+  })
+
+  it('a mail target still goes through the mail authorizer, not the capability gate', async () => {
+    await caller.grantInstance({
+      recordId: CONTACT_RECORD_ID,
+      granteeType: ResourceGranteeType.user,
+      granteeId: 'usr_grantee',
+      permission: ResourcePermission.view,
+    })
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(resourceAccess.assertCanManageMailSharing).toHaveBeenCalledTimes(1)
+    expect(resourceAccess.grantInstanceAccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('revokeInstance is gated the same way — an edit holder cannot un-share', async () => {
+    getCapabilities.mockResolvedValue(capabilitiesFor(ResourcePermission.edit))
+
+    await expect(
+      caller.revokeInstance({
+        recordId: DATASET_RECORD_ID,
+        granteeType: ResourceGranteeType.user,
+        granteeId: 'usr_grantee',
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(resourceAccess.revokeInstanceAccess).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * `setInstance` (the replace-all path) deliberately does NOT accept `none`, so
+ * Restricted can only be expressed through `grantInstance`. Pin the input schema
+ * in source — a `none` sneaking into that enum would give the picker a second,
+ * unaudited lockdown path.
+ */
+describe('resourceAccess — structural invariants', () => {
+  const src = fs.readFileSync(
+    path.resolve(process.cwd(), 'src/server/api/routers/resourceAccess.ts'),
+    'utf8'
+  )
+
+  it('setInstance accepts only view/edit/admin — Restricted funnels through grantInstance', () => {
+    const from = src.indexOf('setInstance: protectedProcedure')
+    const to = src.indexOf('.mutation(', from)
+    const inputBlock = src.slice(from, to)
+    expect(inputBlock).toContain('ResourcePermission.view')
+    expect(inputBlock).not.toContain('ResourcePermission.none')
+  })
+
+  it('every instance write authorizes through authorizeInstanceTarget', () => {
+    for (const [proc, libCall] of [
+      ['grantInstance:', 'grantInstanceAccess('],
+      ['setInstance:', 'setInstanceAccess('],
+      ['revokeInstance:', 'revokeInstanceAccess('],
+    ] as const) {
+      const from = src.indexOf(proc)
+      const to = src.indexOf(libCall, from)
+      expect(src.slice(from, to)).toContain('authorizeInstanceTarget(ctx')
+    }
+  })
+})

--- a/apps/web/src/server/api/routers/segment-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/segment-instance-access.test.ts
@@ -1,0 +1,363 @@
+// apps/web/src/server/api/routers/segment-instance-access.test.ts
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { schema } from '@auxx/database'
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 24 §A.2.1 / §A.4 — the one genuine **privilege hole** this plan closed:
+ * `segment.ts` used to be all `protectedProcedure` with no capability asserts, so
+ * a datasets-`view` (or datasets-None) member who knew segment ids could read and
+ * rewrite dataset content end-to-end. PR #1338 switched every procedure to
+ * `capabilityProcedure` + `assertEditInstance` / `assertViewInstance` on the
+ * segment's grandparent dataset.
+ *
+ * These are behavioral tests, not restatements: the router module is imported for
+ * real and driven through a tRPC caller, and `ctx.capabilities` is a **real**
+ * {@link CapabilitySet} (the assert methods are the shipped ones). Deleting an
+ * assert from any procedure makes the matching "denies …" case fail, because the
+ * mocked `SegmentService` would then be reached.
+ *
+ * Mocked, and why:
+ *  - `~/server/api/trpc` — the real module pulls auth/db/redis/rate-limiter at
+ *    import time. The stand-in is a plain tRPC instance whose `capabilityProcedure`
+ *    passes the test ctx through untouched. A downgrade back to
+ *    `protectedProcedure` is caught by the structural block at the bottom (and by
+ *    the mock not exporting one at all).
+ *  - `@auxx/lib/datasets` — `SegmentService` is the side effect under observation:
+ *    "was the write reached?" is the whole assertion.
+ */
+
+const { segmentService } = vi.hoisted(() => ({
+  segmentService: {
+    updateContent: vi.fn(async () => ({ id: 'seg_1' })),
+    toggleEnabled: vi.fn(async () => ({ id: 'seg_1' })),
+    delete: vi.fn(async () => undefined),
+    batchOperation: vi.fn(async () => ({ updated: 1 })),
+    getById: vi.fn(async () => ({ id: 'seg_1' })),
+    listByDocument: vi.fn(async () => ({ segments: [], totalCount: 0, hasMore: false, page: 1 })),
+    reindex: vi.fn(async () => undefined),
+  },
+}))
+
+vi.mock('@auxx/lib/datasets', () => ({
+  SegmentService: class {
+    updateContent = segmentService.updateContent
+    toggleEnabled = segmentService.toggleEnabled
+    delete = segmentService.delete
+    batchOperation = segmentService.batchOperation
+    getById = segmentService.getById
+    listByDocument = segmentService.listByDocument
+    reindex = segmentService.reindex
+  },
+}))
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return { createTRPCRouter: t.router, capabilityProcedure: t.procedure }
+})
+
+// Deep path on purpose: `@auxx/lib/permissions`' barrel reaches redis/db at import
+// time (get-capabilities, record-view-scope, overage-*) and hangs under vitest,
+// and `CapabilitySet` is not on the client-safe subpath. Test files are excluded
+// from apps/web's tsconfig, so this stays a test-only affordance.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { segmentRouter } = await import('./segment')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const DATASET_ID = 'dset_cuid00000000000000000000'
+const OTHER_DATASET_ID = 'dset_othercuid000000000000000'
+const SEGMENT_ID = 'seg_cuid0000000000000000000'
+const DOCUMENT_ID = 'doc_cuid0000000000000000000'
+
+/**
+ * A real `CapabilitySet` for a MEMBER holding `permission` on {@link DATASET_ID}
+ * (an explicit `ResourceAccess` instance row, which is what the share dialog
+ * writes). `undefined` = the datasets area is closed for them entirely.
+ */
+function capabilitiesFor(
+  permission: ResourcePermission | undefined,
+  overrides: { role?: 'MEMBER' | 'OWNER'; instances?: Record<string, ResourcePermission> } = {}
+) {
+  const areaLevel =
+    permission === undefined || permission === ResourcePermission.none
+      ? Level.None
+      : permission === ResourcePermission.view
+        ? Level.Read
+        : permission === ResourcePermission.edit
+          ? Level.Edit
+          : Level.Full
+  const instances =
+    overrides.instances ?? (permission === undefined ? {} : { [DATASET_ID]: permission })
+  return new CapabilitySet(
+    // The area gate has to be open for an instance row to be consulted at all
+    // (`effectiveInstanceLevel` short-circuits at area None) — mirror the level.
+    new Set(expandLevelsToKeys({ [Area.datasets]: overrides.instances ? Level.Read : areaLevel })),
+    {},
+    overrides.role ?? 'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/**
+ * Query-builder stand-in that answers by the table the router selected FROM, so
+ * the tests also pin *which* parent the gate resolves through: segments join
+ * `DocumentSegment` → `Document`, `listByDocument` reads `Document` directly.
+ */
+function fakeDb(rows: { segments?: { datasetId: string }[]; documents?: { datasetId: string }[] }) {
+  const build = () => {
+    let table: unknown
+    const resolve = () =>
+      table === schema.Document ? (rows.documents ?? []) : (rows.segments ?? [])
+    // `.where(...)` is both awaitable (selectDistinct) and chainable into
+    // `.limit(1)` (single-row lookups), so it returns a real promise carrying an
+    // extra method rather than a hand-rolled thenable.
+    const where = () => {
+      const pending = Promise.resolve(resolve()) as Promise<{ datasetId: string }[]> & {
+        limit: () => Promise<{ datasetId: string }[]>
+      }
+      pending.limit = () => Promise.resolve(resolve())
+      return pending
+    }
+    const chain: Record<string, unknown> = {
+      from(t: unknown) {
+        table = t
+        return chain
+      },
+      innerJoin: () => chain,
+      where,
+    }
+    return chain
+  }
+  return { select: build, selectDistinct: build }
+}
+
+function caller(
+  capabilities: InstanceType<typeof CapabilitySet>,
+  db = fakeDb({ segments: [{ datasetId: DATASET_ID }], documents: [{ datasetId: DATASET_ID }] })
+) {
+  return segmentRouter.createCaller({
+    db,
+    capabilities,
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID },
+    },
+  } as any)
+}
+
+/**
+ * The capability asserts throw `AuxxError` (never `TRPCError`) — tRPC wraps that
+ * as `cause`, and in the app `auxxErrorMiddleware` + `errorFormatter` map it onto
+ * the HTTP status asserted here.
+ */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+const NOT_FOUND = { cause: { name: 'NotFoundError', statusCode: 404 } }
+
+/** Every mutating procedure, with the minimum valid input. */
+const MUTATIONS = [
+  [
+    'updateContent',
+    (c: ReturnType<typeof caller>) =>
+      c.updateContent({ segmentId: SEGMENT_ID, content: 'rewritten' }),
+    'updateContent',
+  ],
+  [
+    'toggleEnabled',
+    (c: ReturnType<typeof caller>) => c.toggleEnabled({ segmentId: SEGMENT_ID, enabled: false }),
+    'toggleEnabled',
+  ],
+  ['delete', (c: ReturnType<typeof caller>) => c.delete({ segmentId: SEGMENT_ID }), 'delete'],
+  [
+    'batchUpdate',
+    (c: ReturnType<typeof caller>) =>
+      c.batchUpdate({ segmentIds: [SEGMENT_ID], operation: 'delete' }),
+    'batchOperation',
+  ],
+  ['reindex', (c: ReturnType<typeof caller>) => c.reindex({ segmentId: SEGMENT_ID }), 'reindex'],
+] as const
+
+/** Every read procedure, with the minimum valid input. */
+const READS = [
+  ['getById', (c: ReturnType<typeof caller>) => c.getById({ segmentId: SEGMENT_ID }), 'getById'],
+  [
+    'listByDocument',
+    (c: ReturnType<typeof caller>) => c.listByDocument({ documentId: DOCUMENT_ID }),
+    'listByDocument',
+  ],
+] as const
+
+beforeEach(() => {
+  for (const fn of Object.values(segmentService)) fn.mockClear()
+})
+
+describe('segment router — instance `view` cannot mutate (plan 24 §A.4, "the actual hole")', () => {
+  it.each(MUTATIONS)('%s is refused for a view-only member', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(segmentService[serviceFn]).not.toHaveBeenCalled()
+  })
+
+  it.each(MUTATIONS)('%s succeeds at instance edit', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.edit)))).resolves.toBeDefined()
+    expect(segmentService[serviceFn]).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(MUTATIONS)('%s is refused with no instance access at all', async (_n, call, fn) => {
+    await expect(call(caller(capabilitiesFor(undefined)))).rejects.toMatchObject(FORBIDDEN)
+    expect(segmentService[fn]).not.toHaveBeenCalled()
+  })
+
+  it.each(
+    MUTATIONS
+  )('%s is refused for an explicit `none` restriction row', async (_n, call, fn) => {
+    await expect(
+      call(
+        caller(capabilitiesFor(undefined, { instances: { [DATASET_ID]: ResourcePermission.none } }))
+      )
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(segmentService[fn]).not.toHaveBeenCalled()
+  })
+})
+
+describe('segment router — reads are open at instance `view`', () => {
+  it.each(READS)('%s succeeds at instance view', async (_name, call, serviceFn) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).resolves.toBeDefined()
+    expect(segmentService[serviceFn]).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(READS)('%s is refused with no instance access at all', async (_n, call, fn) => {
+    await expect(call(caller(capabilitiesFor(undefined)))).rejects.toMatchObject(FORBIDDEN)
+    expect(segmentService[fn]).not.toHaveBeenCalled()
+  })
+
+  it.each(READS)('%s is refused for an explicit `none` restriction row', async (_n, call, fn) => {
+    await expect(
+      call(
+        caller(capabilitiesFor(undefined, { instances: { [DATASET_ID]: ResourcePermission.none } }))
+      )
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(segmentService[fn]).not.toHaveBeenCalled()
+  })
+})
+
+describe('segment router — how the dataset is resolved', () => {
+  it('batchUpdate requires edit on EVERY distinct dataset in the batch', async () => {
+    const db = fakeDb({
+      segments: [{ datasetId: DATASET_ID }, { datasetId: OTHER_DATASET_ID }],
+    })
+    const capabilities = capabilitiesFor(undefined, {
+      // Edit on the first dataset, read-only on the second: a per-batch loop that
+      // only checked the first id would let the second dataset's segments be
+      // deleted by a viewer.
+      instances: {
+        [DATASET_ID]: ResourcePermission.edit,
+        [OTHER_DATASET_ID]: ResourcePermission.view,
+      },
+    })
+
+    await expect(
+      caller(capabilities, db).batchUpdate({
+        segmentIds: [SEGMENT_ID, 'seg_from_other_dataset'],
+        operation: 'delete',
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(segmentService.batchOperation).not.toHaveBeenCalled()
+  })
+
+  it('listByDocument gates on the DOCUMENT’s dataset, not the segment join', async () => {
+    // The document lives in a dataset restricted away from the caller; the
+    // segment join would answer with one they administer. Only the document
+    // lookup may decide.
+    const db = fakeDb({
+      segments: [{ datasetId: DATASET_ID }],
+      documents: [{ datasetId: OTHER_DATASET_ID }],
+    })
+    const capabilities = capabilitiesFor(undefined, {
+      instances: {
+        [DATASET_ID]: ResourcePermission.admin,
+        [OTHER_DATASET_ID]: ResourcePermission.none,
+      },
+    })
+
+    await expect(
+      caller(capabilities, db).listByDocument({ documentId: DOCUMENT_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(segmentService.listByDocument).not.toHaveBeenCalled()
+  })
+
+  it('an unknown segment 404s before any capability decision leaks its existence', async () => {
+    const db = fakeDb({ segments: [], documents: [] })
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin), db).updateContent({
+        segmentId: 'seg_missing',
+        content: 'x',
+      })
+    ).rejects.toMatchObject(NOT_FOUND)
+    expect(segmentService.updateContent).not.toHaveBeenCalled()
+  })
+
+  it('OWNER short-circuits to admin even with no instance row (§A.4 regression)', async () => {
+    const owner = capabilitiesFor(undefined, { role: 'OWNER' })
+    await expect(
+      caller(owner).updateContent({ segmentId: SEGMENT_ID, content: 'x' })
+    ).resolves.toBeDefined()
+    expect(segmentService.updateContent).toHaveBeenCalledTimes(1)
+  })
+})
+
+/**
+ * The behavioral block above runs against a stubbed `~/server/api/trpc`, so it
+ * cannot see a downgrade of the procedure builder itself. Pin that in source —
+ * same idiom as `resource-access-plan-gate.test.ts`.
+ */
+describe('segment router — structural invariants', () => {
+  const src = fs.readFileSync(
+    path.resolve(process.cwd(), 'src/server/api/routers/segment.ts'),
+    'utf8'
+  )
+
+  const PROCEDURES = [
+    'updateContent',
+    'toggleEnabled',
+    'delete',
+    'batchUpdate',
+    'getById',
+    'listByDocument',
+    'reindex',
+  ]
+
+  it('every procedure is a capabilityProcedure — no bare protectedProcedure', () => {
+    for (const name of PROCEDURES) {
+      expect(src, `${name} must build on capabilityProcedure`).toContain(
+        `${name}: capabilityProcedure`
+      )
+    }
+    expect(src).not.toContain('protectedProcedure')
+    expect(src).not.toContain('publicProcedure')
+  })
+
+  it('the procedure list is exhaustive — a new procedure must be gated too', () => {
+    const declared = [...src.matchAll(/^ {2}([a-zA-Z][a-zA-Z0-9]*): capabilityProcedure/gm)].map(
+      (m) => m[1]
+    )
+    expect(declared.sort()).toEqual([...PROCEDURES].sort())
+  })
+
+  it('every procedure body carries an instance assert', () => {
+    const asserts = src.match(/ctx\.capabilities\.assert(View|Edit)Instance\('dataset',/g) ?? []
+    expect(asserts).toHaveLength(PROCEDURES.length)
+  })
+})

--- a/packages/lib/scripts/flush-user-capabilities-cache.ts
+++ b/packages/lib/scripts/flush-user-capabilities-cache.ts
@@ -1,0 +1,24 @@
+// packages/lib/scripts/flush-user-capabilities-cache.ts
+//
+// Dev util: bust the `userCapabilities` cache for all users so every blob recomposes
+// against the CURRENT registry (area/key set) and `UserCapabilities` shape. Next read
+// per user lazily recomputes.
+//
+// Use this while a capabilities shape change is still being iterated on. The
+// `user:capabilities:vN` prefix in `user-cache-keys.ts` stays the mechanism for a real
+// rollout — bump it in the same change that reaches users, so a draining old instance
+// cannot repopulate the new keyspace. A flush cannot promise that mid-deploy; it is the
+// dev-loop shortcut, not a replacement.
+//
+// Run with the source condition so it picks up src, not stale dist:
+//   npx dotenv -- node --conditions source --import tsx/esm packages/lib/scripts/flush-user-capabilities-cache.ts
+
+import { getUserCache } from '../src/cache'
+
+async function main() {
+  await getUserCache().flushKeyForAllUsers(['userCapabilities'])
+  console.log('Flushed `userCapabilities` cache for all users — next read recomputes.')
+  process.exit(0)
+}
+
+void main()

--- a/packages/lib/src/cache/user-cache-service.ts
+++ b/packages/lib/src/cache/user-cache-service.ts
@@ -258,6 +258,47 @@ export class UserCacheService {
   }
 
   /**
+   * Flush specific cache keys for ALL users, by Redis SCAN over the key's prefix.
+   * Does NOT recompute — the next read per user triggers a lazy recompute.
+   *
+   * The `vN` in each prefix ({@link USER_CACHE_KEY_CONFIG}) remains the mechanism
+   * for a real rollout: a shape change that reaches users bumps it, so old and
+   * new blobs occupy different keyspaces and a draining old instance cannot
+   * repopulate the new one. A flush cannot give that guarantee mid-deploy.
+   * This is the counterpart for the dev loop — while a shape is still being
+   * iterated on and nothing is live, flushing beats burning a version per edit.
+   *
+   * Scanning `prefix:*` catches every variant at once: `:data` and `:hash`, and
+   * both the plain `userId` and org-scoped `userId:orgId` scopes.
+   */
+  async flushKeyForAllUsers(keys: readonly UserCacheKeyName[]): Promise<void> {
+    for (const keyName of keys) {
+      this.localCache.deleteByPrefix(USER_CACHE_KEY_CONFIG[keyName].prefix)
+    }
+
+    const redis = await this.getRedis()
+    if (!redis) return
+
+    for (const keyName of keys) {
+      const prefix = USER_CACHE_KEY_CONFIG[keyName].prefix
+      let cursor = '0'
+      do {
+        const [nextCursor, matchedKeys] = await redis.scan(
+          cursor,
+          'MATCH',
+          `${prefix}:*`,
+          'COUNT',
+          100
+        )
+        cursor = nextCursor
+        if (matchedKeys.length > 0) {
+          await Promise.all(matchedKeys.map((k) => redis.del(k)))
+        }
+      } while (cursor !== '0')
+    }
+  }
+
+  /**
    * Invalidate org-scoped user cache keys for ALL members of an organization.
    * Fetches the member list from org cache, then invalidates each member's keys.
    * Call after org-level changes that affect user-scoped data (e.g. shared views, org settings).

--- a/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
@@ -1,0 +1,273 @@
+// packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import type { OrganizationRole, SeatType } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { CapabilitySet } from './capability-set'
+import { composeUserCapabilities } from './compose-user-capabilities'
+import { effectiveInstanceLevel, toResolvedRecordAccess } from './entity-access'
+import type { InstanceAccessKey } from './instance-access'
+import { Area, Level } from './registry'
+import { MEMBER_BASELINE_LEVELS } from './seat-policy'
+
+/**
+ * Per-INSTANCE enforcement for the instance-access resources (datasets / KBs /
+ * dashboards) — the composition half of plan 24 §B.4's deferred manual matrix.
+ *
+ * The def-level siblings (`capability-set-{view,edit,administer}.test.ts`) hand
+ * `CapabilitySet` a pre-made `defAccess` map. These cases deliberately do not:
+ * they start from the `ResourceAccess` rows a member's grantee union actually
+ * returns, run them through `composeUserCapabilities`, and only then resolve the
+ * gates — so a break anywhere along "row → blob → gate" fails here, which is the
+ * path §B.4's UI round-trips exercise by hand.
+ *
+ * Both resolvers are asserted every time: the server's private
+ * `CapabilitySet.effectiveInstanceLevel` and the client mirror
+ * `entity-access.ts#effectiveInstanceLevel`, reached through the real wire
+ * snapshot. They are two copies of one rule, and a UI that offers what the server
+ * denies is the failure mode the mirror exists to prevent.
+ */
+
+interface MemberOpts {
+  role?: OrganizationRole
+  seatType?: SeatType
+  /**
+   * The bound profile's sparse levels. Defaults to the seeded Member baseline
+   * (`datasets: Read`, `knowledgeBase: Edit`, `dashboards: Full`) so every case
+   * below starts from a realistic org member rather than an invented level map.
+   */
+  profileLevels?: Partial<Record<Area, Level>>
+  /**
+   * The instance-level `ResourceAccess` rows that reach THIS member through their
+   * grantee union (`user` + `role:org_member` + bound profile + groups) — i.e.
+   * what `computeUserCapabilities`' second query returns for them.
+   */
+  rows?: Array<{ entityInstanceId: string; permission: ResourcePermission }>
+  /**
+   * The org-wide "has ≥1 instance row for anyone" set
+   * (`restrictedInstanceIdsProvider`). Defaults to the instances in `rows`;
+   * pass it explicitly for a member who is not a grantee of a row that exists.
+   */
+  restrictedInstances?: string[]
+}
+
+function member(opts: MemberOpts = {}) {
+  const role = opts.role ?? 'USER'
+  const seatType = opts.seatType ?? 'full'
+  const caps = composeUserCapabilities({
+    role,
+    seatType,
+    profileLevels: opts.profileLevels ?? MEMBER_BASELINE_LEVELS,
+    typeAccessRows: [],
+    instanceAccessRows: opts.rows ?? [],
+  })
+  const restricted = new Set(
+    opts.restrictedInstances ?? (opts.rows ?? []).map((r) => r.entityInstanceId)
+  )
+  const server = new CapabilitySet(
+    new Set(caps.keys),
+    caps.defAccess,
+    role,
+    seatType,
+    (id) => id,
+    new Set(),
+    (id) => id,
+    caps.instanceAccess,
+    restricted,
+    {}
+  )
+  // The client only ever sees the wire snapshot — build its view from that, not
+  // from the composed blob, so a field dropped in serialization shows up here.
+  return { caps, server, client: toResolvedRecordAccess(server.toClientCapabilities()) }
+}
+
+/** Assert the server gate and the client mirror agree, and return the answer. */
+function levelFor(
+  m: ReturnType<typeof member>,
+  key: InstanceAccessKey,
+  instanceId: string
+): ResourcePermission | undefined {
+  const client = effectiveInstanceLevel(m.client, key, instanceId)
+  expect(m.server.canViewInstance(key, instanceId)).toBe(
+    client !== undefined && client !== ResourcePermission.none
+  )
+  return client
+}
+
+describe('workspace baseline set to Restricted (plan 24 §B.4)', () => {
+  it.each([
+    ['dataset', Area.datasets],
+    ['kb', Area.knowledgeBase],
+  ] as const)('a Restricted %s is denied to an ordinary member at every rung', (key, area) => {
+    // "Restricted" writes ONE row: `role:org_member @ none`. It reaches every
+    // member through the ResourceAccess grantee union, so this IS what the
+    // affected member composes.
+    const m = member({ rows: [{ entityInstanceId: 'inst_locked', permission: 'none' }] })
+
+    // The member's Layer-2 area level is untouched and open — the instance row
+    // alone is what denies. (kb sits at Edit on the seeded baseline, so this
+    // also proves a row beats a HIGHER area level, not just an equal one.)
+    expect(m.server.areaLevel(area)).toBe(area === Area.datasets ? Level.Read : Level.Edit)
+
+    expect(levelFor(m, key, 'inst_locked')).toBe(ResourcePermission.none)
+    expect(m.server.canViewInstance(key, 'inst_locked')).toBe(false)
+    expect(m.server.canEditInstance(key, 'inst_locked')).toBe(false)
+    expect(m.server.canAdminInstance(key, 'inst_locked')).toBe(false)
+    expect(() => m.server.assertViewInstance(key, 'inst_locked')).toThrow()
+  })
+
+  it('the restricted instance drops out of list filtering while its siblings stay', () => {
+    // `dataset.list` / `kb.list` filter with the SAME predicate the detail route
+    // asserts with, so "gone from the list" and "403 on the direct URL" are one
+    // claim — this pins the list half against the exact filter the router runs.
+    const m = member({ rows: [{ entityInstanceId: 'ds_locked', permission: 'none' }] })
+    const listed = ['ds_open', 'ds_locked', 'ds_other'].filter((id) =>
+      m.server.canViewInstance('dataset', id)
+    )
+    expect(listed).toEqual(['ds_open', 'ds_other'])
+  })
+
+  it('an explicit grant on a Restricted instance restores exactly that instance', () => {
+    // The grantee composes BOTH rows (baseline none + their own grant); the real
+    // grant outranks the marker, and nothing else about their access moves.
+    const m = member({
+      rows: [
+        { entityInstanceId: 'ds_locked', permission: 'none' },
+        { entityInstanceId: 'ds_locked', permission: 'edit' },
+      ],
+    })
+    expect(levelFor(m, 'dataset', 'ds_locked')).toBe(ResourcePermission.edit)
+    expect(m.server.canViewInstance('dataset', 'ds_locked')).toBe(true)
+    expect(m.server.canEditInstance('dataset', 'ds_locked')).toBe(true)
+    // `edit`, not `admin`: settings/delete stay closed (plan 24 §A.4's edit row).
+    expect(m.server.canAdminInstance('dataset', 'ds_locked')).toBe(false)
+  })
+
+  it('a member who is not a grantee is denied even though the row set is not empty', () => {
+    // The lockdown row exists org-wide (so the instance is in
+    // `restrictedInstanceIds`) but this member's grantee union returns nothing
+    // for it — absent entry must read as denial, never as "unrestricted".
+    const m = member({ rows: [], restrictedInstances: ['ds_locked'] })
+    expect(levelFor(m, 'dataset', 'ds_locked')).toBeUndefined()
+    expect(m.server.canViewInstance('dataset', 'ds_locked')).toBe(false)
+    // …while an instance with no row anywhere still falls back to the area level.
+    expect(m.server.canViewInstance('dataset', 'ds_untouched')).toBe(true)
+  })
+})
+
+describe('grantee-scoped instance grants (plan 24 §B.4)', () => {
+  it('a grant raises the grantee above their area baseline on that instance only', () => {
+    // Datasets sits at Read on the seeded Member baseline. An `admin` grant on
+    // one dataset must carry that member all the way to the settings/delete rung
+    // for it, and change nothing for the datasets they were not granted.
+    const m = member({ rows: [{ entityInstanceId: 'ds_shared', permission: 'admin' }] })
+    expect(m.caps.instanceAccess).toEqual({ ds_shared: 'admin' })
+
+    expect(levelFor(m, 'dataset', 'ds_shared')).toBe(ResourcePermission.admin)
+    expect(m.server.canAdminInstance('dataset', 'ds_shared')).toBe(true)
+
+    expect(levelFor(m, 'dataset', 'ds_other')).toBe(ResourcePermission.view)
+    expect(m.server.canEditInstance('dataset', 'ds_other')).toBe(false)
+  })
+
+  it('a grant can also LOWER a member on one instance (instance grants are not raise-only)', () => {
+    // Area-level grantee overrides are Camp-1 raise-only; instance grants are
+    // deliberately not (plan 24 §B.2.6). A `view` row under a `knowledgeBase:
+    // Edit` baseline must actually take the write affordances away.
+    const m = member({ rows: [{ entityInstanceId: 'kb_readonly', permission: 'view' }] })
+    expect(m.server.areaLevel(Area.knowledgeBase)).toBe(Level.Edit)
+    expect(levelFor(m, 'kb', 'kb_readonly')).toBe(ResourcePermission.view)
+    expect(m.server.canViewInstance('kb', 'kb_readonly')).toBe(true)
+    expect(m.server.canEditInstance('kb', 'kb_readonly')).toBe(false)
+    // An untouched KB keeps the area's Edit rung.
+    expect(m.server.canEditInstance('kb', 'kb_other')).toBe(true)
+  })
+})
+
+describe('dead grants — an instance grant under a closed area (plan 24 §B.2.8)', () => {
+  it('grants nothing to a member whose profile closes the area', () => {
+    // `effectiveInstanceLevel` short-circuits at area None BEFORE consulting
+    // instance rows, so sharing to a sparse-profile holder is a silent no-op.
+    // This is the behaviour the Share UI's "No effect" warning describes — and
+    // the behaviour plan 25 §2 will deliberately flip, so it is pinned here.
+    const m = member({
+      profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.datasets]: Level.None },
+      rows: [{ entityInstanceId: 'ds_shared', permission: 'admin' }],
+    })
+    expect(levelFor(m, 'dataset', 'ds_shared')).toBeUndefined()
+    expect(m.server.canViewInstance('dataset', 'ds_shared')).toBe(false)
+
+    // The two signals the server annotation (`forInstance.granteeAreaLevel`) is
+    // built from: the grant is genuinely stored, and the area is genuinely shut.
+    expect(m.caps.instanceAccess).toEqual({ ds_shared: 'admin' })
+    expect(m.server.areaLevel(Area.datasets)).toBe(Level.None)
+  })
+
+  it('the same grant takes effect once the profile grants the area', () => {
+    // The other half of the warning's lifecycle — without this the test above
+    // would pass for a grant that never works at all.
+    const m = member({ rows: [{ entityInstanceId: 'ds_shared', permission: 'admin' }] })
+    expect(m.server.areaLevel(Area.datasets)).toBe(Level.Read)
+    expect(levelFor(m, 'dataset', 'ds_shared')).toBe(ResourcePermission.admin)
+  })
+
+  it('an area closed only by the SEAT ceiling kills the grant too', () => {
+    // A worker seat zeroes `datasets` regardless of the profile, and the ceiling
+    // is applied last — an instance grant must not slip past a billing invariant.
+    const m = member({
+      seatType: 'worker',
+      profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.datasets]: Level.Full },
+      rows: [{ entityInstanceId: 'ds_shared', permission: 'admin' }],
+    })
+    expect(m.server.areaLevel(Area.datasets)).toBe(Level.None)
+    expect(levelFor(m, 'dataset', 'ds_shared')).toBeUndefined()
+  })
+})
+
+describe('instance-restricted ADMIN (plan 24 §B.2.7)', () => {
+  /** An ADMIN on the seeded all-Full `admin` profile. */
+  const admin = (opts: Omit<MemberOpts, 'role' | 'profileLevels'>) =>
+    member({ ...opts, role: 'ADMIN', profileLevels: {} })
+
+  it('loses an instance restricted to none, keeping every other instance', () => {
+    const m = admin({ rows: [{ entityInstanceId: 'ds_locked', permission: 'none' }] })
+    expect(m.server.areaLevel(Area.datasets)).toBe(Level.Full)
+    expect(levelFor(m, 'dataset', 'ds_locked')).toBe(ResourcePermission.none)
+    expect(m.server.canViewInstance('dataset', 'ds_locked')).toBe(false)
+    // The share rows for that instance are therefore read-only: the editability
+    // gate is `canAdminInstance` on the exact instance, not the area level.
+    expect(m.server.canAdminInstance('dataset', 'ds_locked')).toBe(false)
+    expect(m.server.canAdminInstance('dataset', 'ds_other')).toBe(true)
+  })
+
+  it('is held to a read-only instance grant instead of bypassing to admin', () => {
+    const m = admin({ rows: [{ entityInstanceId: 'ds_readonly', permission: 'view' }] })
+    expect(levelFor(m, 'dataset', 'ds_readonly')).toBe(ResourcePermission.view)
+    expect(m.server.canViewInstance('dataset', 'ds_readonly')).toBe(true)
+    expect(m.server.canEditInstance('dataset', 'ds_readonly')).toBe(false)
+    expect(m.server.canAdminInstance('dataset', 'ds_readonly')).toBe(false)
+  })
+})
+
+describe('OWNER regression (plan 24 §A.4)', () => {
+  it('short-circuits to admin on an instance restricted to none', () => {
+    // The §0.10 recovery guarantee: nothing authored on an instance can lock the
+    // last owner out of the instance that would let them undo it.
+    const m = member({
+      role: 'OWNER',
+      rows: [{ entityInstanceId: 'ds_locked', permission: 'none' }],
+    })
+    expect(levelFor(m, 'dataset', 'ds_locked')).toBe(ResourcePermission.admin)
+    expect(m.server.canAdminInstance('dataset', 'ds_locked')).toBe(true)
+    expect(m.server.canViewInstance('kb', 'kb_locked')).toBe(true)
+  })
+
+  it('short-circuits ahead of the row lookup entirely (private dashboard, no row)', () => {
+    // `dashboard` is `baselineAtCreate: true`, so "no row" means no access for
+    // everyone else — the branch OWNER must still skip.
+    const owner = member({ role: 'OWNER', restrictedInstances: ['dash_private'] })
+    const other = member({ restrictedInstances: ['dash_private'] })
+    expect(levelFor(owner, 'dashboard', 'dash_private')).toBe(ResourcePermission.admin)
+    expect(levelFor(other, 'dashboard', 'dash_private')).toBeUndefined()
+  })
+})

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -247,6 +247,40 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     expect(grantee.defAccess).toEqual({ def_locked: 'view' })
   })
 
+  it("keeps a lone baseline 'none' INSTANCE row (it is the per-instance downward marker)", () => {
+    // The mirror-image of the `defAccess` rule directly above: on instances a
+    // `none` row is KEPT, because `effectiveInstanceLevel` reads the composed
+    // entry itself rather than "is there an entry at all". Dropping it here is
+    // what plan 24's "Restricted" baseline would have to survive.
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      typeAccessRows: [],
+      instanceAccessRows: [{ entityInstanceId: 'ds_locked', permission: 'none' }],
+    })
+    expect(caps.instanceAccess).toEqual({ ds_locked: 'none' })
+  })
+
+  it("lets a real grant outrank the baseline 'none' on the SAME instance, in either row order", () => {
+    // A grantee of a Restricted instance composes BOTH rows. The reduce is
+    // max-by-rank, so row order must not decide the outcome — a first-wins or
+    // last-wins reducer would leave the person the instance was just shared with
+    // sitting on the lockdown marker.
+    const rows = [
+      { entityInstanceId: 'ds_locked', permission: 'none' as const },
+      { entityInstanceId: 'ds_locked', permission: 'edit' as const },
+    ]
+    for (const instanceAccessRows of [rows, [...rows].reverse()]) {
+      const caps = composeUserCapabilities({
+        role: 'USER',
+        seatType: 'full',
+        typeAccessRows: [],
+        instanceAccessRows,
+      })
+      expect(caps.instanceAccess).toEqual({ ds_locked: 'edit' })
+    }
+  })
+
   it("a baseline 'view' row makes the def visible to everyone (grant present)", () => {
     const caps = composeUserCapabilities({
       role: 'USER',

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -61,6 +61,7 @@ export enum PermissionKey {
 
   // dashboards (instance-access resource — per-dashboard ResourceAccess grants, doc 13 §2)
   dashboardsView = 'dashboards.view',
+  dashboardsEdit = 'dashboards.edit',
   dashboardsManage = 'dashboards.manage',
 
   // channels (mail + channel infrastructure — created 2026-07-27, plan 21 §6 Option A)
@@ -313,14 +314,21 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
   {
     key: PermissionKey.dashboardsView,
     label: 'View Dashboards',
-    description: 'See dashboards shared with you.',
+    description: 'See dashboards shared with you and the widgets on them.',
+    group: 'Analytics',
+    featureKey: FeatureKey.dashboards,
+  },
+  {
+    key: PermissionKey.dashboardsEdit,
+    label: 'Edit Dashboard Widgets',
+    description: 'Add, remove, and edit the widgets and layout inside dashboards.',
     group: 'Analytics',
     featureKey: FeatureKey.dashboards,
   },
   {
     key: PermissionKey.dashboardsManage,
     label: 'Manage Dashboards',
-    description: 'Create, delete, and configure dashboards.',
+    description: 'Create, rename, delete, and configure dashboards.',
     group: 'Analytics',
     featureKey: FeatureKey.dashboards,
   },
@@ -714,12 +722,20 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
   [Area.dashboards]: {
     area: Area.dashboards,
     label: 'Dashboards',
-    description: 'See dashboards shared with you, or create and manage dashboards.',
+    description:
+      'View dashboards, edit their widgets and layout, or create, rename, and delete them.',
     group: 'Analytics',
     rungs: [
       { level: Level.Read, keys: [PermissionKey.dashboardsView] },
+      { level: Level.Edit, keys: [PermissionKey.dashboardsEdit] },
       { level: Level.Full, keys: [PermissionKey.dashboardsManage] },
     ],
+    // `Edit` rung added 2026-07-27: dashboards were the only instance-access
+    // area on a 2-rung ladder even though the share dialog and `dashboard.ts`
+    // already spoke three per-instance tiers (view / edit widgets / manage).
+    // Read = see the dashboard and its widgets; Edit = add/remove/edit widgets
+    // and layout (draft, publish, versions); Full = rename, delete, create.
+    // Purely a SPLIT of the old Full rung — no path got more permissive.
     featureKey: FeatureKey.dashboards,
   },
 }


### PR DESCRIPTION
Four separable changes, kept together because the UI gating exists to close the gap the rung change opens.

## 1. Dashboards `Edit` rung

`Area.dashboards` was the odd one out — 2 rungs (Read/Full) while `datasets` and `knowledgeBase` had 3 — even though the share dialog **already** offered `write: 'Edit widgets & layout'` and `dashboard.ts` **already** enforced three tiers via `assertView/Edit/AdminInstance`. The edit tier existed per-instance; the area ladder just couldn't express it.

Adds `PermissionKey.dashboardsEdit` and the `Edit` rung:

| Rung | Meaning |
|---|---|
| Read | view the dashboard and its widgets |
| Edit | add / remove / edit its widgets |
| Full | rename it, delete it (and create dashboards) |

**One router change**: `update` moved `assertEditInstance` → `assertAdminInstance`. Its input is pure container metadata (`name/description/icon/position/entityDefinitionId`) — layout goes through `saveDraft`/`publish` — so no split assert was needed.

⚠️ **This tightens**: an instance-`edit` holder loses icon/description/position editing. Accepted deliberately rather than straddling one payload across two rungs.

**No migration.** `Level` is ordinal (`None=0…Full=3`) so nothing renumbers, and area levels live in `PermissionGrant.levels` jsonb. A dev-data check found **zero** rows storing `dashboards: 2` (and every non-null `baseLevel` is `3`), so nothing silently gains rights.

**Nothing got more permissive**: `dashboard` is `baselineAtCreate: true`, so the area level is only a `Level.None` gate and never a fallback rung — adding a rung cannot lift any instance's effective permission.

**No `user:capabilities:vN` bump** — deferred deliberately while the batch (dashboards + workflows + agents) is iterated on, since none of this is live. One `v10 → v11` ships with whichever PR first reaches users.

## 2. Dashboard UI instance gating

`components/dashboard/` had almost no instance-level gating: `dashboard-switcher-list.tsx` hardcoded `canManage={true}` and the only capability check in the whole directory was `can('dashboards.manage')` on the create button. Rename/delete affordances rendered for everyone and failed server-side with a 403 toast — and after §1 a member at `edit` would see a Settings dialog they couldn't save.

Follows plan 24 Part A (**hide, don't disable**). The load-bearing move: every widget/tab/layout affordance already keys off `isEditMode`, so clamping that one flag with `canEdit` covers the entire Edit tier rather than gating dozens of components individually. Bulk delete hides on mixed selection, per plan 24 §A.4.

`version-history-dialog.tsx` gains an optional `canRestore` (default `true`), so the agents / procedures / KB consumers are unaffected.

**Known reduction**: `MultiSelectPicker` has no per-row capability hook, so the breadcrumb switcher's manage mode requires admin on *every* listed dashboard. Since dashboards are `baselineAtCreate: true` (creator `admin`, everyone else `view`), manage mode disappears there for everyone but OWNER once an org has two authors. Server-truth-correct, and per-dashboard Settings/Delete still works from the card menu; the real fix is a per-row hook, which is a bigger change than this pass.

## 3. Member profile projection fix

`member.all` reads the org cache — which **does** carry `permissionProfileId` — but its `.map()` dropped the field. So `resolveMemberProfile()` resolved every member to the system template for their role/seat: an explicitly assigned custom profile was invisible, and reassigning one looked like a no-op *even after a full refresh*, despite the write and the cache invalidation both being correct.

Worth remembering as a class of bug: **a correct write path plus a lossy read projection reads exactly like a broken mutation.** Also removes the `TODO(plan-19-step-8)` that documented this gap.

## 4. Instance-access test backfill (plan 24 §A.4/§B.4)

92 tests for enforcement that shipped across #1338–#1339 and was never covered. All **behavioral** — real routers driven through a real `CapabilitySet` — and each **mutation-verified** by deliberately breaking the source and confirming the tests fail.

| File | Tests | Covers |
|---|---|---|
| `segment-instance-access.test.ts` | 33 | the §A.2.1 privilege hole, all 7 procedures |
| `kb-instance-access.test.ts` | 31 | edit-vs-admin tiers |
| `dataset-instance-access.test.ts` | 17 | edit-vs-admin tiers, `testSearchConfig` downgrade |
| `capability-set-instance.test.ts` | 14 | restriction denial, dead grants, OWNER short-circuit |
| `resource-access-instance-baseline.test.ts` | 11 | Restricted writes `permission:'none'` verbatim |
| `compose-user-capabilities.test.ts` | +2 | `none` row survives the reduce, in either row order |

**Audited every procedure in `segment.ts`, `document.ts`, `dataset.ts`, `kb.ts` — 62/62 gated, no missing asserts, no bugs found.** All six §B.4 composition claims hold as written.

Two notes: the pre-existing router tests were all *source-text* assertions because routers were assumed unimportable under vitest — that assumption was false. And these files deep-import `CapabilitySet` because the `@auxx/lib/permissions` barrel **hangs** under vitest (bisected to `get-capabilities`, `record-view-scope`, `overage-detection-service`, `overage-handler`).

## 5. Cache flush tooling

`UserCacheService.flushKeyForAllUsers` mirrors the existing `flushKeyForAllOrgs` SCAN, plus `packages/lib/scripts/flush-user-capabilities-cache.ts`.

This is the dev-loop counterpart to a version bump, **not a replacement**: during a rollout a draining old instance repopulates the same keyspace, which is precisely why `vN` exists. Documented as such on both the method and the script.

## Verification

- `apps/web`: `vitest run src/server/api` → **125 passed** (8 files)
- `packages/lib`: `vitest run src/permissions` → **321 passed** (18 files)
- `biome check` clean on all 21 files
- `tsc --noEmit` scoped per package, grepped per-file: no new errors. The 6 hits in touched dashboard files are the pre-existing `neverthrow` module-resolution cascade (`routers/dashboard.ts:35`) — proven pre-existing because one lands in `procedure-versions-dialog.tsx`, a file this PR never opens
- Cache flushed in dev after the rung change; `user:capabilities:v10:*` verified empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)