### PR TITLE
feat(permissions): explicit instance grant overrides an area level of none

### DIFF
--- a/apps/web/src/components/kbar/actions/navigation.ts
+++ b/apps/web/src/components/kbar/actions/navigation.ts
@@ -291,7 +291,8 @@ export function useNavigationActions(): PaletteAction[] {
         perform: () => nav('/schedule'),
       })
     }
-    if (hasAccess('workflows') && can('workflows.manage')) {
+    // View, not Manage — matches SIDEBAR_MENU; Manage fronts creation, not reaching the list.
+    if (hasAccess('workflows') && can('workflows.view')) {
       actions.push({
         id: 'nav.workflows',
         label: 'Workflows',

--- a/apps/web/src/components/permissions/hooks/use-instance-share.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-share.ts
@@ -34,12 +34,21 @@ export interface InstanceShareGrant {
   actorId: ActorId
   choice: InstanceLevel
   /**
+   * The raw stored permission, INCLUDING `'none'` — which {@link choice} cannot
+   * express. Only the dead-row warning reads it (see {@link granteeAreaLevel}).
+   */
+  permission: ResourcePermission
+  /**
    * The user grantee's own composed Layer-2 level for this instance's L2 area
    * (capability layer v2 Part B.2.8), server-annotated on `forInstance`.
    * `undefined` for group/team/role/profile grantees — they are level
    * *sources*, not subjects — and while the annotation hasn't loaded yet.
-   * `Level.None` here means the grant is a dead grant: `effectiveInstanceLevel`
-   * short-circuits at area None before ever consulting this row.
+   *
+   * `Level.None` no longer means the row is dead: since plan 25 §2 an explicit
+   * row beats the area floor, so a positive grant on a `None`-area member is
+   * precisely how a single-instance share works. Only `Level.None` combined with
+   * an explicit `'none'` {@link permission} is inert — it removes access the
+   * member never had.
    */
   granteeAreaLevel?: Level
 }
@@ -146,6 +155,7 @@ export function useInstanceShare({
           {
             actorId,
             choice: r.permission as InstanceLevel,
+            permission: r.permission,
             granteeAreaLevel: r.granteeAreaLevel,
           },
         ]

--- a/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
 'use client'
 
-import type { ResourcePermission } from '@auxx/database/enums'
+import { ResourcePermission } from '@auxx/database/enums'
 import { type InstanceAccessKey, Level } from '@auxx/lib/permissions/client'
 import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
@@ -39,9 +39,13 @@ const CHILD_DEPTH = 1
  * the Share card and dialog show, covering every OTHER grantee on that
  * instance (not just this one).
  *
- * Dead-grant warning (§B.2.8): shown only for `user` grantees (`isUser`),
- * using the composed area level the HOST already knows from the same grid
- * (the area row sits directly above these rows) — no extra server call.
+ * Dead-row warning (§B.2.8, re-aimed by plan 25 §2): shown only for `user`
+ * grantees (`isUser`), using the composed area level the HOST already knows from
+ * the same grid (the area row sits directly above these rows) — no extra server
+ * call. An explicit row now beats the area floor, so a positive grant on a
+ * `None`-area member is a real single-instance share; only an explicit
+ * `No access` row on such a member is inert, because it takes away access they
+ * never had.
  */
 export function GranteeInstanceRows({
   rows,
@@ -86,7 +90,7 @@ export function GranteeInstanceRows({
     )
   }
 
-  const showDeadGrantWarning = isUser && areaLevel === Level.None
+  const showDeadRowWarning = isUser && areaLevel === Level.None
 
   return (
     <div className='flex flex-col gap-0.5'>
@@ -95,7 +99,7 @@ export function GranteeInstanceRows({
           key={`${row.key}:${row.id}`}
           row={row}
           disabled={!canEdit}
-          showDeadGrantWarning={showDeadGrantWarning}
+          showDeadRowWarning={showDeadRowWarning}
           areaLabel={areaLabel}
           onChange={(level) => onChange(row.key, row.id, level)}
         />
@@ -107,20 +111,20 @@ export function GranteeInstanceRows({
 function GranteeInstanceRowItem({
   row,
   disabled,
-  showDeadGrantWarning,
+  showDeadRowWarning,
   areaLabel,
   onChange,
 }: {
   row: InstanceGranteeRow
   disabled: boolean
-  showDeadGrantWarning: boolean
+  showDeadRowWarning: boolean
   areaLabel: string
   onChange: (level: ResourcePermission | 'inherit') => void
 }) {
   const [isOpen, setIsOpen] = useState(false)
   const meta = INSTANCE_TYPE_META[row.key]
   const recordId = toRecordId(row.key, row.id)
-  const isDeadGrant = showDeadGrantWarning && row.grantLevel !== undefined
+  const isDeadRow = showDeadRowWarning && row.grantLevel === ResourcePermission.none
 
   return (
     <TreeRow
@@ -134,7 +138,7 @@ function GranteeInstanceRowItem({
       onToggleOpen={() => setIsOpen((v) => !v)}
       actions={
         <>
-          {isDeadGrant && (
+          {isDeadRow && (
             <Tooltip content={deadGrantWarning(areaLabel)}>
               <AlertTriangle className='size-3.5 text-amber-500' />
             </Tooltip>

--- a/apps/web/src/components/permissions/ui/instance-share-body.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-body.tsx
@@ -82,11 +82,13 @@ export function InstanceLevelSelect({
  * Editability is gated on {@link useCanAdminInstance} exactly as before: an
  * instance-restricted admin sees this list read-only (§B.2.7).
  *
- * Dead-grant warning (§B.2.8): a `user` grant whose composed area level is
- * `None` is inert — `effectiveInstanceLevel` closes the area gate before ever
- * consulting the instance row — so each such row gets an inline warning icon,
- * driven by the `granteeAreaLevel` the server annotates onto `forInstance` for
- * `user` grantees only.
+ * Dead-row warning (§B.2.8, re-aimed by plan 25 §2): an explicit instance row
+ * now beats the area floor, so a positive grant to a member composing the area
+ * to `None` is a REAL single-instance share, not a no-op. What is inert is an
+ * explicit `'none'` RESTRICTION on such a member — it removes access they never
+ * had — and only those rows get the inline warning icon, driven by the
+ * `granteeAreaLevel` the server annotates onto `forInstance` for `user`
+ * grantees only.
  */
 export function InstanceShareBody({
   recordId,
@@ -114,10 +116,16 @@ export function InstanceShareBody({
     return PERMISSION_AREAS[area].label
   }, [isSupported, key])
 
-  const granteeAreaLevelByActor = useMemo(() => {
-    const map = new Map<string, Level | undefined>()
-    for (const g of grants) map.set(g.actorId, g.granteeAreaLevel)
-    return map
+  // An explicit `'none'` restriction on a member who already composes the area
+  // to `None` — the only row shape that is still genuinely inert (plan 25 §2).
+  const deadRowActorIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const g of grants) {
+      if (g.granteeAreaLevel === Level.None && g.permission === ResourcePermission.none) {
+        ids.add(g.actorId)
+      }
+    }
+    return ids
   }, [grants])
 
   if (!isSupported) return null
@@ -133,10 +141,10 @@ export function InstanceShareBody({
       depth={depth}
       renderLockedLabel={(choice) => permissionLabel(choice, 'long')}
       renderPicker={({ value, onChange, disabled, actorId }) => {
-        const isDeadGrant = granteeAreaLevelByActor.get(actorId) === Level.None
+        const isDeadRow = deadRowActorIds.has(actorId)
         return (
           <>
-            {isDeadGrant && areaLabel && (
+            {isDeadRow && areaLabel && (
               <Tooltip content={deadGrantWarning(areaLabel)}>
                 <AlertTriangle className='size-3.5 text-amber-500' />
               </Tooltip>

--- a/apps/web/src/components/permissions/ui/instance-share-copy.ts
+++ b/apps/web/src/components/permissions/ui/instance-share-copy.ts
@@ -122,12 +122,19 @@ export const INSTANCE_ROW_COPY = {
 } as const
 
 /**
- * The dead-grant warning (capability layer v2 §B.2.8): a `user` grant on an
- * instance is inert when that member's own composed area level is `None` —
- * `effectiveInstanceLevel` closes the area gate before ever consulting the
- * instance row, so the grant silently does nothing until their profile grants
- * the area.
+ * The dead-row warning (capability layer v2 §B.2.8, re-aimed by plan 25 §2).
+ *
+ * It used to mark any `user` row on a member whose composed area level was
+ * `None`, because `effectiveInstanceLevel` closed the area gate *before* it
+ * consulted instance rows and every such share was silently inert. Plan 25 §2
+ * inverted that: an explicit row now beats the area floor, so a POSITIVE grant
+ * against a sparse profile is exactly how "no workflows except this one" is
+ * expressed — warning about it would now be actively wrong.
+ *
+ * What remains genuinely dead is the opposite row: an explicit `none`
+ * RESTRICTION on a member who already composes the area to `None`. It takes away
+ * something they never had.
  */
 export function deadGrantWarning(areaLabel: string): string {
-  return `No effect — their profile has no ${areaLabel} access.`
+  return `No effect — their profile already has no ${areaLabel} access to take away.`
 }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -137,7 +137,9 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     slug: 'workflows',
     icon: <Zap />,
     featureKey: 'workflows',
-    permissionKey: 'workflows.manage',
+    // View, not Manage: workflows gained Read/Edit rungs in plan 30, so gating the
+    // nav entry on Manage hid it from every legitimate Read/Edit holder.
+    permissionKey: 'workflows.view',
   },
   { id: 'tasks', label: 'Tasks', slug: 'tasks', icon: <CheckSquare /> },
   {

--- a/apps/web/src/server/api/routers/dataset.ts
+++ b/apps/web/src/server/api/routers/dataset.ts
@@ -259,19 +259,23 @@ export const datasetRouter = createTRPCRouter({
     // `datasets: None` member gets an empty list rather than a 403, which
     // matters because this feeds passive UI like the permission grids).
     //
-    // The exclusion is computed UP FRONT and handed to the query, so `limit`,
+    // The filter is computed UP FRONT and handed to the query, so `limit`,
     // `page`, `totalCount` and `hasMore` all describe the FILTERED set.
     // Filtering the returned page instead (what this did originally) leaves
     // `totalCount`/`hasMore` describing the unfiltered page, returns short
     // pages, and can hand back an EMPTY page with `hasMore: true` — which
     // breaks any client that stops on an empty page.
     //
-    // The denied set is near-empty in practice: `dataset` is
-    // `baselineAtCreate: false`, so the ONLY exclusions are explicitly-restricted
-    // datasets. See `deniedInstanceIds` for the proof that no non-restriction
-    // denial path exists once the area gate is open.
-    const { deniesAll, deniedIds } = ctx.capabilities.deniedInstanceIds('dataset')
-    if (deniesAll) return { datasets: [], totalCount: 0, hasMore: false }
+    // Two shapes, because `instanceListScope` is the list-side twin of
+    // `canViewInstance` and that gate now has two regimes (plan 25 §2):
+    //  - open `datasets` area → `exclude`, near-empty in practice (`dataset` is
+    //    `baselineAtCreate: false`, so the ONLY exclusions are explicitly
+    //    restricted datasets);
+    //  - `datasets: None` + explicit grants → `include`, naming exactly the
+    //    datasets shared with this member. Returning an empty list here instead
+    //    would contradict `getById`, which lets them open it.
+    const scope = ctx.capabilities.instanceListScope('dataset')
+    if (scope.kind === 'none') return { datasets: [], totalCount: 0, hasMore: false }
 
     const datasetService = new DatasetService(ctx.db)
     const filters = {
@@ -280,7 +284,8 @@ export const datasetRouter = createTRPCRouter({
       createdById: input.createdById,
       dateRange: input.dateRange,
       hideManaged: input.hideManaged,
-      excludeIds: deniedIds,
+      excludeIds: scope.excludeIds,
+      includeIds: scope.includeIds,
     }
     const pagination = {
       page: input.page,

--- a/apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
+++ b/apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
@@ -1,0 +1,501 @@
+// apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 25 §2 at the router layer — **an explicit instance grant overrides the
+ * area-`None` short-circuit**.
+ *
+ * The live bug this pins (hit by the user 2026-07-27, immediately after #1345):
+ * a member whose profile composes `workflows: None` was granted instance `read`
+ * on ONE workflow, and the grant was inert. `effectiveInstanceLevel` returned
+ * `undefined` at the area gate BEFORE it ever consulted the row, so the only
+ * workaround was raising the profile to `workflows: Read` — which, because
+ * `workflow` is `baselineAtCreate: false`, grants read on EVERY workflow. There
+ * was no way to say "no workflows except this one".
+ *
+ * Four properties, asserted for all three router families (`workflow`,
+ * `dataset`, `dashboard`) so the rule is uniform across `baselineAtCreate`:
+ *  1. area `None` + an explicit `view` grant ⇒ the read procedure SUCCEEDS and
+ *     the instance APPEARS in `list`;
+ *  2. area `None` + NO row ⇒ still denied, and `list` is empty (fail-closed —
+ *     the load-bearing regression risk);
+ *  3. area `None` + an explicit `'none'` restriction ⇒ denied, absent from list;
+ *  4. OWNER unaffected.
+ *
+ * Plus the hole the type-blind front-door waiver could have opened: a
+ * `workflows: None` member holding a grant reaches `permissionProcedure`'s Read
+ * rung, but must NOT reach the Manage rung that fronts `create` — which has no
+ * instance to assert on.
+ *
+ * `list` is the half that silently contradicts the gate when it is missed: a
+ * member can open a workflow whose row grants them `view` while `list` hands
+ * them an empty page. The list mocks therefore honour the ids the router passes
+ * rather than ignoring them.
+ *
+ * Behavioral: the REAL routers are driven through a tRPC caller with a REAL
+ * `CapabilitySet`; the services are the observed side effect.
+ */
+
+/** The one instance each family shares with our member, plus an unshared sibling. */
+const SHARED = 'inst_shared00000000000000'
+const OTHER = 'inst_other000000000000000'
+
+const { workflowService, datasetService, dashboards, searchService, featureService } = vi.hoisted(
+  () => {
+    const shared = 'inst_shared00000000000000'
+    const other = 'inst_other000000000000000'
+    const orgIds = [shared, other]
+    /** Apply the router's id filter exactly as the real query layers do. */
+    const narrow = (filters: {
+      excludeIds?: readonly string[]
+      includeIds?: readonly string[]
+    }) => {
+      const excluded = new Set(filters.excludeIds ?? [])
+      const included = filters.includeIds?.length ? new Set(filters.includeIds) : null
+      return orgIds.filter((id) => !excluded.has(id) && (included === null || included.has(id)))
+    }
+    return {
+      workflowService: {
+        getAll: vi.fn(
+          async (
+            _organizationId: string,
+            filters: {
+              limit: number
+              offset: number
+              excludeIds?: readonly string[]
+              includeIds?: readonly string[]
+            }
+          ) => {
+            const visible = narrow(filters)
+            return {
+              workflows: visible.map((id) => ({ id })),
+              total: visible.length,
+              hasMore: false,
+            }
+          }
+        ),
+        getById: vi.fn(async (id: string) => ({ id })),
+        create: vi.fn(async () => ({ id: 'wf_new' })),
+      },
+      datasetService: {
+        list: vi.fn(
+          async (
+            _organizationId: string,
+            filters: { excludeIds?: readonly string[]; includeIds?: readonly string[] }
+          ) => {
+            const visible = narrow(filters)
+            return {
+              datasets: visible.map((id) => ({ id })),
+              totalCount: visible.length,
+              hasMore: false,
+            }
+          }
+        ),
+        getById: vi.fn(async (id: string) => ({ id })),
+      },
+      dashboards: {
+        listDashboards: vi.fn(async () => ({
+          isErr: () => false,
+          value: orgIds.map((id) => ({ id, name: id })),
+        })),
+        getDashboard: vi.fn(async (_db: unknown, _org: string, by: { id?: string }) => ({
+          isErr: () => false,
+          value: { id: by.id ?? shared },
+        })),
+      },
+      searchService: { search: vi.fn(async () => ({ results: [], total: 0 })) },
+      featureService: { requireAccess: vi.fn(async () => undefined) },
+    }
+  }
+)
+
+vi.mock('@auxx/lib/workflows', () => ({
+  WorkflowService: class {
+    getAll = workflowService.getAll
+    getById = workflowService.getById
+    create = workflowService.create
+  },
+  WorkflowVersionService: class {},
+  WorkflowStatsService: class {},
+  WorkflowExecutionService: class {},
+  assertWorkflowAppNotSystemOwned: vi.fn(async () => undefined),
+  assertWorkflowRunNotSystemOwned: vi.fn(async () => 'inst_shared00000000000000'),
+  getWorkflowRunCreatorId: vi.fn(async () => null),
+  buildTemplateWorkflowData: vi.fn(async () => ({})),
+  toWorkflowAppResponse: (app: unknown) => app,
+  WORKFLOW_TRIGGER_TYPE_VALUES: ['manual', 'form', 'scheduled'] as const,
+  checkEntityReadiness: vi.fn(async () => ({ ready: true })),
+  listFileTemplates: vi.fn(() => []),
+}))
+
+vi.mock('@auxx/lib/datasets', () => ({
+  DatasetService: class {
+    list = datasetService.list
+    getById = datasetService.getById
+  },
+  SearchService: searchService,
+}))
+
+vi.mock('@auxx/lib/dashboards', async () => {
+  const { z } = await import('zod')
+  const passthrough = z.object({}).passthrough()
+  return {
+    listDashboards: dashboards.listDashboards,
+    getDashboard: dashboards.getDashboard,
+    loadDashboardRow: vi.fn(async () => ({ isErr: () => false, value: { id: SHARED } })),
+    archiveDashboard: vi.fn(),
+    createDashboard: vi.fn(),
+    deleteVersion: vi.fn(),
+    discardDashboardDraft: vi.fn(),
+    duplicateDashboard: vi.fn(),
+    getVersion: vi.fn(),
+    listVersions: vi.fn(),
+    publishDashboard: vi.fn(),
+    renameVersion: vi.fn(),
+    restoreVersion: vi.fn(),
+    saveDraft: vi.fn(),
+    updateDashboard: vi.fn(),
+    chartQueryInputSchema: passthrough,
+    draftLayoutDocSchema: passthrough,
+    globalFiltersSchema: passthrough,
+  }
+})
+
+// `dashboard.ts` pulls the aggregate engine, which transitively reaches the
+// dataset/vector stack — irrelevant here and unresolvable under vitest.
+vi.mock('@auxx/lib/resources/aggregate', () => ({
+  buildAggregateQueryForWidget: vi.fn(() => ({})),
+  resolveDateRangePreset: vi.fn(() => undefined),
+  runAggregate: vi.fn(async () => ({ rows: [] })),
+  runKpi: vi.fn(async () => ({ value: 0 })),
+  trendSpecForWidget: vi.fn(() => undefined),
+}))
+
+vi.mock('@auxx/lib/workflow-engine', () => ({
+  triggerManualResourceWorkflow: vi.fn(),
+  triggerManualResourceWorkflowBulk: vi.fn(),
+}))
+
+vi.mock('@auxx/services/workflows', () => ({
+  getWorkflowAppsByTrigger: vi.fn(async () => ({ isErr: () => false, value: [] })),
+}))
+
+vi.mock('@auxx/services/workflow-templates', () => ({
+  getAllTemplates: vi.fn(async () => ({ isErr: () => false, value: [] })),
+  getTemplateById: vi.fn(async () => ({ isErr: () => false, value: null })),
+}))
+
+vi.mock('~/server/api/workflow-template-resolver', () => ({
+  resolveTemplateById: vi.fn(async () => null),
+}))
+
+vi.mock('~/server/api/audit-context', () => ({
+  recordAuditFromCtx: vi.fn(async () => undefined),
+}))
+
+vi.mock('@auxx/lib/demo', () => ({
+  DemoGuard: { requireNotDemo: vi.fn(async () => undefined) },
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedWorkflowAppCount: vi.fn(async () => 0),
+  getAppCache: () => ({ getOrRecompute: vi.fn(async () => ({})) }),
+  getUserCache: () => ({ get: vi.fn(async () => ({ preferredTimezone: 'UTC' })) }),
+  onCacheEvent: vi.fn(async () => undefined),
+}))
+
+// The `@auxx/lib/permissions` barrel reaches redis/db at import time and hangs
+// under vitest — hand the routers the real registry plus a stub feature service.
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+      requireLimit = featureService.requireAccess
+    },
+  }
+})
+
+/**
+ * Mirrors the REAL `permissionProcedure` gate from `trpc.ts`, including the plan
+ * 25 §2 waiver — without it, `workflow.getById` would 403 at the front door for
+ * exactly the member this file is about, and every case below would pass for the
+ * wrong reason. Only the plan-AND and the `getCapabilities` read are dropped
+ * (ctx already carries the set).
+ */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  const { INSTANCE_ACCESS_VIEW_KEYS } = await import(
+    '@auxx/lib/permissions/capabilities/instance-access'
+  )
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        const capabilities = (
+          ctx as {
+            capabilities: { assert: (k: string) => void; hasAnyInstanceGrant: () => boolean }
+          }
+        ).capabilities
+        const waived =
+          INSTANCE_ACCESS_VIEW_KEYS.has(key as never) && capabilities.hasAnyInstanceGrant()
+        if (!waived) capabilities.assert(key)
+        return next()
+      }),
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  }
+})
+
+// Deep paths on purpose — the barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { workflowRouter } = await import('./workflow')
+const { datasetRouter } = await import('./dataset')
+const { dashboardRouter } = await import('./dashboard')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+/**
+ * A real `CapabilitySet` for a member whose profile composes `area` to a level,
+ * carrying whatever explicit instance rows are given. `rows: {}` models the
+ * "granted nothing" member; `role: 'OWNER'` the recovery bypass.
+ */
+function caps(opts: {
+  area: Area
+  areaLevel?: Level
+  rows?: Record<string, ResourcePermission>
+  role?: 'MEMBER' | 'OWNER'
+}) {
+  const rows = opts.rows ?? {}
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [opts.area]: opts.areaLevel ?? Level.None })),
+    {},
+    opts.role ?? 'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    rows,
+    new Set(Object.keys(rows))
+  )
+}
+
+const SESSION = {
+  organizationId: ORG_ID,
+  userId: USER_ID,
+  isSuperAdmin: false,
+  user: { id: USER_ID, defaultOrganizationId: ORG_ID, email: 'a@b.c', name: 'A' },
+}
+
+type Caps = InstanceType<typeof CapabilitySet>
+
+const wf = (capabilities: Caps) =>
+  workflowRouter.createCaller({ db: {}, capabilities, session: SESSION } as never)
+const ds = (capabilities: Caps) =>
+  datasetRouter.createCaller({ db: {}, capabilities, session: SESSION } as never)
+const dash = (capabilities: Caps) =>
+  dashboardRouter.createCaller({ db: {}, capabilities, session: SESSION } as never)
+
+/**
+ * One row per instance-access family: the area it composes against, how to read
+ * ONE instance, and how to list them. `dashboard` is `baselineAtCreate: true`
+ * and the other two are `false`, so running the same cases over all three proves
+ * the rule does not depend on that flag.
+ */
+const FAMILIES = [
+  {
+    name: 'workflow',
+    area: Area.workflows,
+    read: (c: Caps, id: string) => wf(c).getById({ id }),
+    list: async (c: Caps) => (await wf(c).list({ limit: 50, offset: 0 })).workflows,
+  },
+  {
+    name: 'dataset',
+    area: Area.datasets,
+    read: (c: Caps, id: string) => ds(c).getById({ id }),
+    list: async (c: Caps) => (await ds(c).list({ page: 1, limit: 50 })).datasets,
+  },
+  {
+    name: 'dashboard',
+    area: Area.dashboards,
+    read: (c: Caps, id: string) => dash(c).get({ id }),
+    list: (c: Caps) => dash(c).list(),
+  },
+] as const
+
+const ids = (rows: Array<{ id: string }>) => rows.map((r) => r.id)
+
+beforeEach(() => {
+  workflowService.getAll.mockClear()
+  workflowService.getById.mockClear()
+  workflowService.create.mockClear()
+  datasetService.list.mockClear()
+  datasetService.getById.mockClear()
+  dashboards.listDashboards.mockClear()
+  dashboards.getDashboard.mockClear()
+})
+
+describe.each(FAMILIES)('$name — an explicit grant overrides the area-None floor (plan 25 §2)', ({
+  area,
+  read,
+  list,
+}) => {
+  it('THE REPRO: area None + an explicit `view` grant can read the instance', async () => {
+    const c = caps({ area, rows: { [SHARED]: ResourcePermission.view } })
+    await expect(read(c, SHARED)).resolves.toBeDefined()
+  })
+
+  it('THE REPRO, list half: the granted instance APPEARS, alone', async () => {
+    // The half that silently contradicts the gate when missed — an empty page
+    // for an instance the member can demonstrably open.
+    const c = caps({ area, rows: { [SHARED]: ResourcePermission.view } })
+    expect(ids(await list(c))).toEqual([SHARED])
+  })
+
+  it('area None + NO row is still denied (fail-closed)', async () => {
+    const c = caps({ area, rows: {} })
+    await expect(read(c, SHARED)).rejects.toMatchObject(FORBIDDEN)
+    expect(await list(c)).toEqual([])
+  })
+
+  it('area None + a grant does NOT open the instances with no row of their own', async () => {
+    // The other fail-closed half: the flip must not turn a closed area into an
+    // open one for everything else in the org.
+    const c = caps({ area, rows: { [SHARED]: ResourcePermission.view } })
+    await expect(read(c, OTHER)).rejects.toMatchObject(FORBIDDEN)
+    expect(ids(await list(c))).not.toContain(OTHER)
+  })
+
+  it('area None + an explicit `none` restriction is denied', async () => {
+    const c = caps({ area, rows: { [SHARED]: ResourcePermission.none } })
+    await expect(read(c, SHARED)).rejects.toMatchObject(FORBIDDEN)
+    expect(await list(c)).toEqual([])
+  })
+
+  it('OWNER is unaffected — reads and lists everything despite a `none` row', async () => {
+    // `areaLevel: Full` because `composeUserCapabilities` short-circuits OWNER
+    // to every key (§0.10) — a key-less OWNER is not a state the composition
+    // can produce, and `permissionProcedure`'s coarse assert is key-based with
+    // no role bypass.
+    const c = caps({
+      area,
+      areaLevel: Level.Full,
+      rows: { [SHARED]: ResourcePermission.none },
+      role: 'OWNER',
+    })
+    await expect(read(c, SHARED)).resolves.toBeDefined()
+    expect(ids(await list(c))).toEqual([SHARED, OTHER])
+  })
+})
+
+describe('the front-door waiver is scoped to the Read rung (no create hole)', () => {
+  const granted = () => caps({ area: Area.workflows, rows: { [SHARED]: ResourcePermission.admin } })
+
+  it('a `workflows: None` member holding an admin grant reaches the Read-rung procedure', async () => {
+    // `permissionProcedure(workflowsView)` waives its coarse assert, and
+    // `assertViewInstance` then lets them through on their own row.
+    await expect(wf(granted()).getById({ id: SHARED })).resolves.toBeDefined()
+  })
+
+  it('…but is still refused `create`, which sits on the Manage rung', async () => {
+    // `create` has NO instance to assert on, so the coarse rung is the only
+    // gate. Widening the waiver past the Read rung would hand every grant
+    // holder the ability to create workflows in an area they compose to None.
+    await expect(wf(granted()).create({ name: 'x', enabled: false })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(workflowService.create).not.toHaveBeenCalled()
+  })
+
+  it('a member with NO grant at all is still refused the Read-rung procedure', async () => {
+    await expect(
+      wf(caps({ area: Area.workflows, rows: {} })).getById({ id: SHARED })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('a member holding ONLY an explicit `none` row is refused too', async () => {
+    // These two are the safety argument for the waiver's looseness, not a test
+    // OF it: the waiver grants nothing, so widening it (e.g.
+    // `hasAnyInstanceGrant` returning true unconditionally) changes NO router
+    // outcome — `assertViewInstance` denies the same callers either way. The
+    // waiver's own inputs are pinned as unit assertions in
+    // `packages/lib/.../capability-set-instance.test.ts`, which is the only
+    // place a widening can be caught.
+    await expect(
+      wf(caps({ area: Area.workflows, rows: { [OTHER]: ResourcePermission.none } })).getById({
+        id: SHARED,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+})
+
+describe('the list filter and the gate agree (the two cannot drift)', () => {
+  it('workflow.list hands the query an ALLOW-LIST when the area is closed', async () => {
+    await wf(caps({ area: Area.workflows, rows: { [SHARED]: ResourcePermission.view } })).list({
+      limit: 50,
+      offset: 0,
+    })
+    const filters = workflowService.getAll.mock.calls[0]?.[1] as {
+      includeIds?: string[]
+      excludeIds?: string[]
+    }
+    expect(filters.includeIds).toEqual([SHARED])
+    expect(filters.excludeIds).toBeUndefined()
+  })
+
+  it('workflow.list does not query at all when nothing is visible', async () => {
+    const result = await wf(caps({ area: Area.workflows, rows: {} })).list({
+      limit: 50,
+      offset: 0,
+    })
+    expect(result).toEqual({ workflows: [], total: 0, hasMore: false })
+    expect(workflowService.getAll).not.toHaveBeenCalled()
+  })
+
+  it('dataset.list hands the query an ALLOW-LIST when the area is closed', async () => {
+    await ds(caps({ area: Area.datasets, rows: { [SHARED]: ResourcePermission.edit } })).list({
+      page: 1,
+      limit: 50,
+    })
+    const filters = datasetService.list.mock.calls[0]?.[1] as {
+      includeIds?: string[]
+      excludeIds?: string[]
+    }
+    expect(filters.includeIds).toEqual([SHARED])
+    expect(filters.excludeIds).toBeUndefined()
+  })
+
+  it('an OPEN area still uses the exclusion form, not the allow-list', async () => {
+    // The regime that must not change: a member with the area open sees
+    // everything except their explicitly-restricted instances.
+    await wf(
+      caps({
+        area: Area.workflows,
+        areaLevel: Level.Full,
+        rows: { [SHARED]: ResourcePermission.none },
+      })
+    ).list({ limit: 50, offset: 0 })
+    const filters = workflowService.getAll.mock.calls[0]?.[1] as {
+      includeIds?: string[]
+      excludeIds?: string[]
+    }
+    expect(filters.excludeIds).toEqual([SHARED])
+    expect(filters.includeIds).toBeUndefined()
+  })
+})

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -405,12 +405,15 @@ export const resourceAccessRouter = createTRPCRouter({
    * Get all access grants for a specific instance.
    *
    * `user` grantees are annotated with `granteeAreaLevel` — their composed
-   * Layer-2 level for the instance's L2 `area` (capability layer v2 Part
-   * B.2.8) — so the Share UI can warn when a grant is inert: `effectiveInstanceLevel`
-   * short-circuits at area None *before* consulting instance rows, so sharing to
-   * a user whose profile composes that area to None is a silent no-op. Skipped
-   * for non-`user` grantees (group/team/role/profile are level *sources*, not
-   * subjects) and for defs outside the instance-access registry.
+   * Layer-2 level for the instance's L2 `area` (capability layer v2 Part B.2.8)
+   * — so the Share UI can warn when a row is inert. Since plan 25 §2 an explicit
+   * row BEATS the area floor, so `Level.None` alone no longer means dead: a
+   * positive grant to such a member is exactly how a single-instance share
+   * works. Only `Level.None` paired with an explicit `'none'` permission is
+   * inert (it removes access they never had), which is the pairing
+   * `instance-share-body.tsx` warns on. Skipped for non-`user` grantees
+   * (group/team/role/profile are level *sources*, not subjects) and for defs
+   * outside the instance-access registry.
    * `getCapabilities` is cache-backed, and only the few user grantees on one
    * instance are resolved, so this stays cheap even though it fans out to one
    * cache read per grantee.

--- a/apps/web/src/server/api/routers/workflow-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/workflow-instance-access.test.ts
@@ -52,17 +52,27 @@ const {
       /**
        * Stands in for `WorkflowService.getAll` → the cached-list accessor,
        * reproducing the ONE property `list`'s contract rests on: the access
-       * exclusion is applied with the other predicates and **before** the slice,
+       * filter is applied with the other predicates and **before** the slice,
        * so `total`/`hasMore` describe the filtered set. A mock that ignored
-       * `excludeIds` would let a router that stopped passing it still pass.
+       * `excludeIds`/`includeIds` would let a router that stopped passing them
+       * still pass. Empty arrays mean "not set" on both, exactly as the real
+       * accessor treats them.
        */
       getAll: vi.fn(
         async (
           _organizationId: string,
-          filters: { limit: number; offset: number; excludeIds?: readonly string[] }
+          filters: {
+            limit: number
+            offset: number
+            excludeIds?: readonly string[]
+            includeIds?: readonly string[]
+          }
         ) => {
           const excluded = new Set(filters.excludeIds ?? [])
-          const visible = listFixture.ids.filter((id) => !excluded.has(id))
+          const included = filters.includeIds?.length ? new Set(filters.includeIds) : null
+          const visible = listFixture.ids.filter(
+            (id) => !excluded.has(id) && (included === null || included.has(id))
+          )
           const page = visible.slice(filters.offset, filters.offset + filters.limit)
           return {
             workflows: page.map((id) => ({ id })),
@@ -201,22 +211,39 @@ vi.mock('@auxx/lib/permissions', async () => {
 })
 
 /**
- * The `permissionProcedure` stand-in runs the REAL `capabilities.assert(key)`
- * against the test ctx, so the coarse rung on the procedure builder is under
- * test alongside the per-instance asserts in the bodies. (The dataset/KB files
- * couldn't do this — their routers assert coarse keys inline.) Dropping
- * `permissionProcedure(workflowsManage)` from `create` fails a case below.
+ * The `permissionProcedure` stand-in mirrors the REAL builder's gate: the real
+ * `capabilities.assert(key)`, WAIVED for the `INSTANCE_ACCESS_VIEW_KEYS` when the
+ * member holds any instance grant (plan 25 §2 — otherwise a `workflows: None`
+ * member with one explicit grant 403s at the front door and the grant is inert
+ * all over again). Kept in lockstep with `trpc.ts`; only the plan-AND and the
+ * `getCapabilities` read are dropped, since ctx carries the set already.
+ *
+ * So the coarse rung on the procedure builder is under test alongside the
+ * per-instance asserts in the bodies. (The dataset/KB files couldn't do this —
+ * their routers assert coarse keys inline.) Dropping
+ * `permissionProcedure(workflowsManage)` from `create` fails a case below, and
+ * so does widening the waiver to the Manage rung.
  */
 vi.mock('~/server/api/trpc', async () => {
   const { initTRPC } = await import('@trpc/server')
   const t = initTRPC.context<Record<string, unknown>>().create()
+  const { INSTANCE_ACCESS_VIEW_KEYS } = await import(
+    '@auxx/lib/permissions/capabilities/instance-access'
+  )
   return {
     createTRPCRouter: t.router,
     capabilityProcedure: t.procedure,
     protectedProcedure: t.procedure,
     permissionProcedure: (key: string) =>
       t.procedure.use(({ ctx, next }) => {
-        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
+        const capabilities = (
+          ctx as {
+            capabilities: { assert: (k: string) => void; hasAnyInstanceGrant: () => boolean }
+          }
+        ).capabilities
+        const waived =
+          INSTANCE_ACCESS_VIEW_KEYS.has(key as never) && capabilities.hasAnyInstanceGrant()
+        if (!waived) capabilities.assert(key)
         return next()
       }),
     // The real one blocks demo orgs; irrelevant to capability gating, and it

--- a/apps/web/src/server/api/routers/workflow.ts
+++ b/apps/web/src/server/api/routers/workflow.ts
@@ -240,12 +240,16 @@ const ADMIN_ONLY_UPDATE_FIELDS = [
  * Base procedure: `permissionProcedure(workflowsView)` everywhere the instance
  * assert does the real work. That keeps the `FeatureKey.workflows` plan-AND
  * these procedures have always run (`capabilityProcedure` does NOT run it) and
- * costs nothing — `effectiveInstanceLevel` already returns `undefined` when the
- * area level is `None`, so the coarse Read gate can only deny callers the
- * instance assert would deny anyway. `list` and `getManualWorkflows` are the
- * two exceptions: they render passively inside other screens, so they use
- * `capabilityProcedure` and FILTER rather than assert (plan 30 §2.2 — a 403
- * there is a broken screen, not a denied action).
+ * costs nothing — `workflowsView` is an `INSTANCE_ACCESS_VIEW_KEYS` member, so
+ * `permissionProcedure` waives its coarse assert for a member who holds any
+ * instance grant (plan 25 §2) and lets the per-instance assert below decide.
+ * **Every procedure on this base MUST assert on a specific instance** — that
+ * waiver is what makes the coarse rung non-load-bearing here.
+ * `create`/`createForResource` have no instance to assert on and therefore sit
+ * on `workflowsManage`, which is NOT waived. `list` and `getManualWorkflows` are
+ * the two exceptions in the other direction: they render passively inside other
+ * screens, so they use `capabilityProcedure` and FILTER rather than assert (plan
+ * 30 §2.2 — a 403 there is a broken screen, not a denied action).
  *
  * NOT gated by any of this (plan 30 §2.1): **headless execution**. Schedules,
  * record-CRUD events, record rules, message-received, app triggers, webhook
@@ -274,26 +278,30 @@ export const workflowRouter = createTRPCRouter({
     // permission grids' Workflows row (`use-instance-resource-lists.ts`) and the
     // workflows landing page.
     //
-    // The exclusion is computed UP FRONT and handed to the query, so `limit`,
+    // The filter is computed UP FRONT and handed to the query, so `limit`,
     // `offset`, `total` and `hasMore` all describe the FILTERED set. Filtering
-    // the returned page instead (what this did originally, and what
-    // `dataset.list` still does) leaves `total`/`hasMore` describing the
-    // unfiltered page, returns short pages, and can hand back an EMPTY page with
-    // `hasMore: true` — which breaks any client that stops on an empty page.
+    // the returned page instead (what this did originally) leaves
+    // `total`/`hasMore` describing the unfiltered page, returns short pages, and
+    // can hand back an EMPTY page with `hasMore: true` — which breaks any client
+    // that stops on an empty page.
     //
-    // The denied set is near-empty in practice: `workflow` is
-    // `baselineAtCreate: false`, so the ONLY exclusions are explicitly-restricted
-    // workflows (plan 30 §3 — restriction is the rare case). See
-    // `deniedInstanceIds` for the proof that no non-restriction denial path
-    // exists once the area gate is open.
-    const { deniesAll, deniedIds } = ctx.capabilities.deniedInstanceIds('workflow')
-    if (deniesAll) return { workflows: [], total: 0, hasMore: false }
+    // Two shapes, because `instanceListScope` is the list-side twin of
+    // `canViewInstance` and that gate now has two regimes (plan 25 §2):
+    //  - open `workflows` area → `exclude`, near-empty in practice (`workflow` is
+    //    `baselineAtCreate: false`, so the ONLY exclusions are explicitly
+    //    restricted workflows — plan 30 §3, restriction is the rare case);
+    //  - `workflows: None` + explicit grants → `include`, naming exactly the
+    //    workflows shared with this member. Returning an empty list here instead
+    //    would contradict `getById`, which lets them open it.
+    const scope = ctx.capabilities.instanceListScope('workflow')
+    if (scope.kind === 'none') return { workflows: [], total: 0, hasMore: false }
 
     const workflowService = new WorkflowService(ctx.db)
     try {
       return await workflowService.getAll(ctx.session.organizationId, {
         ...input,
-        excludeIds: deniedIds,
+        excludeIds: scope.excludeIds,
+        includeIds: scope.includeIds,
       })
     } catch (error) {
       throw new TRPCError({

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -15,6 +15,7 @@ import {
   FeatureKey,
   FeaturePermissionService,
   getCapabilities,
+  INSTANCE_ACCESS_VIEW_KEYS,
   PERMISSION_REGISTRY_MAP,
   type PermissionKey,
 } from '@auxx/lib/permissions'
@@ -398,6 +399,31 @@ export const superAdminProcedure = protectedProcedure.use(({ ctx, next }) => {
  * `featureKey`, asserts the key, and attaches the resolved set as
  * `ctx.capabilities` so router bodies reuse it with zero re-resolve.
  *
+ * **The instance-grant waiver (plan 25 §2).** Since an explicit instance
+ * `ResourceAccess` row now beats the area floor, a member composing e.g.
+ * `workflows: None` who was granted `read` on ONE workflow holds no
+ * `workflowsView` key — and would 403 at this front door before the procedure's
+ * own `assertViewInstance` ever ran, making the grant inert all over again. So
+ * for the `Level.Read` rung keys of the instance-access areas
+ * ({@link INSTANCE_ACCESS_VIEW_KEYS}) the coarse assert is WAIVED when the member
+ * holds any instance grant at all.
+ *
+ * The waiver is deliberately loose in two ways, both bounded:
+ *  - **Type-blind.** `instanceAccess` keys on the bare instance CUID with no
+ *    resource type, so "holds a *workflow* grant" is unanswerable without
+ *    changing the cached blob shape — which would force a `user:capabilities:vN`
+ *    bump. A member holding only a dataset grant therefore also gets through the
+ *    workflow door, and is stopped one line later by `assertViewInstance`.
+ *  - **Front door only.** It grants NOTHING. Every procedure behind these keys
+ *    asserts on a specific instance immediately after; that is a real
+ *    precondition, which is why the waiver is scoped to the Read rung — the
+ *    higher rungs front the instance-LESS actions (`workflowsManage` fronts
+ *    `create`/`createForResource`, which have no instance to assert on) and
+ *    stay strict.
+ *
+ * The `FeatureKey` plan-AND is unaffected and still runs first — it is the whole
+ * reason instance-scoped procedures use this rather than `capabilityProcedure`.
+ *
  * @example
  * getWorkflow: permissionProcedure(PermissionKey.workflowsManage).query(...)
  */
@@ -411,7 +437,8 @@ export const permissionProcedure = (key: PermissionKey) =>
       )
     }
     const capabilities = await getCapabilities(ctx.session.userId, ctx.session.organizationId)
-    capabilities.assert(key)
+    const waived = INSTANCE_ACCESS_VIEW_KEYS.has(key) && capabilities.hasAnyInstanceGrant()
+    if (!waived) capabilities.assert(key)
     return next({ ctx: { capabilities } })
   })
 

--- a/packages/lib/src/cache/providers/workflow-apps-provider.test.ts
+++ b/packages/lib/src/cache/providers/workflow-apps-provider.test.ts
@@ -158,3 +158,72 @@ describe('list — excludeIds is applied BEFORE pagination', () => {
     expect(hasMore).toBe(true)
   })
 })
+
+/**
+ * `list({ includeIds })` — the INVERSE filter (plan 25 §2): a member composing
+ * `workflows: None` who holds explicit instance grants may see exactly those
+ * workflows, and the denied set (every row-less workflow in the org) is
+ * unbounded, so only an allow-list can express it.
+ */
+describe('list — includeIds narrows to an allow-list, also BEFORE pagination', () => {
+  const six = () => ['a', 'b', 'c', 'd', 'e', 'f'].map((id) => app(id, true, null))
+
+  it('returns only the named ids, and total describes THAT set', async () => {
+    const { workflows, total, hasMore } = await accessorOver(six()).list({
+      includeIds: ['b', 'e'],
+      limit: 50,
+      offset: 0,
+    })
+    expect(workflows.map((w: CachedWorkflowApp) => w.id)).toEqual(['b', 'e'])
+    expect(total).toBe(2)
+    expect(hasMore).toBe(false)
+  })
+
+  it('paginates over the narrowed set', async () => {
+    const { workflows, total, hasMore } = await accessorOver(six()).list({
+      includeIds: ['b', 'd', 'f'],
+      limit: 2,
+      offset: 0,
+    })
+    expect(workflows.map((w: CachedWorkflowApp) => w.id)).toEqual(['b', 'd'])
+    expect(total).toBe(3)
+    expect(hasMore).toBe(true)
+  })
+
+  it('ignores ids that name no workflow (foreign instance-access ids)', async () => {
+    // `restrictedInstanceIds` is org-wide across datasets/KBs/dashboards, so an
+    // allow-list built from it can name a dataset id while listing workflows.
+    const { workflows, total } = await accessorOver(six()).list({
+      includeIds: ['b', 'ds_shared'],
+      limit: 50,
+      offset: 0,
+    })
+    expect(workflows.map((w: CachedWorkflowApp) => w.id)).toEqual(['b'])
+    expect(total).toBe(1)
+  })
+
+  it('an EMPTY allow-list is treated as "not set", never as "show nothing"', async () => {
+    // `instanceListScope` returns `kind: 'none'` for that case and the router
+    // short-circuits, so an empty array must never reach here — but if it does,
+    // silently blanking the list would be the worst possible reading.
+    const { workflows, total } = await accessorOver(six()).list({
+      includeIds: [],
+      limit: 50,
+      offset: 0,
+    })
+    expect(workflows).toHaveLength(6)
+    expect(total).toBe(6)
+  })
+
+  it('composes with the other predicates rather than replacing them', async () => {
+    const apps = [...six(), { ...app('sys', true, null), ownerType: 'sequence' }]
+    const { workflows, total } = await accessorOver(apps).list({
+      includeIds: ['a', 'b', 'sys'],
+      search: 'b',
+      limit: 50,
+      offset: 0,
+    })
+    expect(workflows.map((w: CachedWorkflowApp) => w.id)).toEqual(['b'])
+    expect(total).toBe(1)
+  })
+})

--- a/packages/lib/src/cache/providers/workflow-apps-provider.ts
+++ b/packages/lib/src/cache/providers/workflow-apps-provider.ts
@@ -209,6 +209,12 @@ export const workflowAppsProvider: CacheProvider<CachedWorkflowApp[]> = {
        * and the slice. Filtering the returned page instead would make `total`
        * describe the unfiltered set and could hand back an empty page with
        * `hasMore: true`.
+       *
+       * `includeIds` is its inverse (plan 25 §2): the ONLY ids the caller may
+       * view, used when they compose `workflows: None` yet hold explicit
+       * instance grants. `CapabilitySet.instanceListScope` produces one or the
+       * other, never both; an empty array on either is treated as "not set" so
+       * an accidental empty allow-list can never silently blank the list.
        */
       async list(filters?: {
         search?: string
@@ -217,9 +223,14 @@ export const workflowAppsProvider: CacheProvider<CachedWorkflowApp[]> = {
         limit?: number
         offset?: number
         excludeIds?: readonly string[]
+        includeIds?: readonly string[]
       }): Promise<{ workflows: CachedWorkflowApp[]; total: number; hasMore: boolean }> {
         let data = (await dataFn()).filter((app) => !app.ownerType)
 
+        if (filters?.includeIds?.length) {
+          const included = new Set(filters.includeIds)
+          data = data.filter((app) => included.has(app.id))
+        }
         if (filters?.excludeIds?.length) {
           const excluded = new Set(filters.excludeIds)
           data = data.filter((app) => !excluded.has(app.id))

--- a/packages/lib/src/cache/workflow-app-queries.ts
+++ b/packages/lib/src/cache/workflow-app-queries.ts
@@ -58,9 +58,10 @@ export async function getCachedWorkflowAppCount(organizationId: string): Promise
  * Get workflow apps list with filtering and pagination from cache.
  * Used by the workflow list view — pure cache read, zero DB queries.
  *
- * `excludeIds` (plan 30) is the caller's per-member access exclusion; it is
- * applied with the other predicates, before pagination, so `total`/`hasMore`
- * describe the filtered set.
+ * `excludeIds` (plan 30) is the caller's per-member access exclusion and
+ * `includeIds` (plan 25 §2) its inverse allow-list; both are applied with the
+ * other predicates, before pagination, so `total`/`hasMore` describe the
+ * filtered set.
  */
 export async function getCachedWorkflowAppsList(
   organizationId: string,
@@ -71,6 +72,7 @@ export async function getCachedWorkflowAppsList(
     limit?: number
     offset?: number
     excludeIds?: readonly string[]
+    includeIds?: readonly string[]
   }
 ) {
   return getOrgCache().from(organizationId, 'workflowApps').list(filters)

--- a/packages/lib/src/datasets/services/__tests__/dataset-service-list-exclusion.test.ts
+++ b/packages/lib/src/datasets/services/__tests__/dataset-service-list-exclusion.test.ts
@@ -60,6 +60,12 @@ async function whereClausesFor(excludeIds?: readonly string[]) {
   return captured
 }
 
+async function whereClausesForInclude(includeIds?: readonly string[]) {
+  const { db, captured } = fakeDb()
+  await new DatasetService(db as never).list('org_1', { includeIds }, { page: 1, limit: 20 })
+  return captured
+}
+
 describe('DatasetService.list — excludeIds', () => {
   it('runs the page query and the totalCount query over the same where-clause', async () => {
     const captured = await whereClausesFor(['dset_a', 'dset_b'])
@@ -80,5 +86,33 @@ describe('DatasetService.list — excludeIds', () => {
     const captured = await whereClausesFor([])
     expect(sqlShape(captured.page)).not.toContain(' not in ')
     expect(sqlShape(captured.page)).toBe(sqlShape((await whereClausesFor(undefined)).page))
+  })
+})
+
+/**
+ * `DatasetFilters.includeIds` — the plan 25 §2 inverse: a `datasets: None`
+ * member holding explicit grants sees exactly those datasets. Same two
+ * properties, and the same empty-array hazard (`inArray([])` is invalid SQL too).
+ */
+describe('DatasetService.list — includeIds', () => {
+  it('emits an `in` predicate when ids are named', async () => {
+    const captured = await whereClausesForInclude(['dset_a', 'dset_b'])
+    const shape = sqlShape(captured.page)
+    expect(shape).toContain(' in ')
+    expect(shape).not.toContain(' not in ')
+  })
+
+  it('runs the page query and the totalCount query over the same where-clause', async () => {
+    const captured = await whereClausesForInclude(['dset_a'])
+    expect(captured.page).toBeDefined()
+    expect(captured.count).toBe(captured.page)
+  })
+
+  it('emits NO predicate for an empty id list', async () => {
+    // Drizzle renders an empty `inArray` as invalid SQL. `instanceListScope`
+    // returns `kind: 'none'` in that case and the router short-circuits before
+    // reaching here, but the guard must hold on its own.
+    const captured = await whereClausesForInclude([])
+    expect(sqlShape(captured.page)).toBe(sqlShape((await whereClausesForInclude(undefined)).page))
   })
 })

--- a/packages/lib/src/datasets/services/dataset-service.ts
+++ b/packages/lib/src/datasets/services/dataset-service.ts
@@ -677,11 +677,14 @@ export class DatasetService {
       conditions.push(eq(schema.Dataset.isManaged, false))
     }
 
-    // Access exclusion (see `DatasetFilters.excludeIds`). Guarded on non-empty:
-    // Drizzle renders an empty `notInArray` as invalid SQL. Because this clause
-    // is shared by BOTH halves of `list` — the paginated `findMany` and the
-    // `count()` — excluding here keeps the page, `totalCount` and `hasMore`
-    // describing one and the same filtered set.
+    // Access filter (see `DatasetFilters.excludeIds` / `includeIds`). BOTH are
+    // guarded on non-empty: Drizzle renders an empty `notInArray`/`inArray` as
+    // invalid SQL. Because this clause is shared by BOTH halves of `list` — the
+    // paginated `findMany` and the `count()` — filtering here keeps the page,
+    // `totalCount` and `hasMore` describing one and the same set.
+    if (filters?.includeIds?.length) {
+      conditions.push(inArray(schema.Dataset.id, [...filters.includeIds]))
+    }
     if (filters?.excludeIds?.length) {
       conditions.push(notInArray(schema.Dataset.id, [...filters.excludeIds]))
     }

--- a/packages/lib/src/datasets/types/index.ts
+++ b/packages/lib/src/datasets/types/index.ts
@@ -354,7 +354,7 @@ export interface DatasetFilters {
   hideManaged?: boolean
   /**
    * Dataset ids to exclude from the query — the caller's per-member access
-   * exclusion (plan 30 / `CapabilitySet.deniedInstanceIds('dataset')`).
+   * exclusion (plan 30 / `CapabilitySet.instanceListScope('dataset')`).
    *
    * Applied with the other predicates and therefore BEFORE `limit`/`offset` and
    * inside the `totalCount` query, so pagination and totals describe the set the
@@ -362,6 +362,13 @@ export interface DatasetFilters {
    * `totalCount`/`hasMore` speaking for rows the caller can never receive.
    */
   excludeIds?: readonly string[]
+  /**
+   * The caller may see ONLY these dataset ids — the inverse of
+   * {@link excludeIds}, used when the member composes `datasets: None` but holds
+   * explicit instance grants (plan 25 §2). Mutually exclusive with
+   * `excludeIds`; `CapabilitySet.instanceListScope` never produces both.
+   */
+  includeIds?: readonly string[]
 }
 /**
  * Filter parameters for listing documents

--- a/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, it } from 'vitest'
 import { CapabilitySet } from './capability-set'
 import { composeUserCapabilities } from './compose-user-capabilities'
 import { effectiveInstanceLevel, toResolvedRecordAccess } from './entity-access'
-import type { InstanceAccessKey } from './instance-access'
-import { Area, Level } from './registry'
+import { INSTANCE_ACCESS_VIEW_KEYS, type InstanceAccessKey } from './instance-access'
+import { Area, Level, PermissionKey } from './registry'
 import { MEMBER_BASELINE_LEVELS } from './seat-policy'
 
 /**
@@ -184,28 +184,51 @@ describe('grantee-scoped instance grants (plan 24 §B.4)', () => {
   })
 })
 
-describe('dead grants — an instance grant under a closed area (plan 24 §B.2.8)', () => {
-  it('grants nothing to a member whose profile closes the area', () => {
-    // `effectiveInstanceLevel` short-circuits at area None BEFORE consulting
-    // instance rows, so sharing to a sparse-profile holder is a silent no-op.
-    // This is the behaviour the Share UI's "No effect" warning describes — and
-    // the behaviour plan 25 §2 will deliberately flip, so it is pinned here.
+describe('an instance grant under a closed area (plan 24 §B.2.8, flipped by plan 25 §2)', () => {
+  it('takes effect anyway — an explicit row beats the area floor', () => {
+    // Was the "dead grant" case: `effectiveInstanceLevel` short-circuited at
+    // area None BEFORE consulting instance rows, so sharing to a sparse-profile
+    // holder was a silent no-op and the only workaround was raising their
+    // profile — which, under `baselineAtCreate: false`, hands them EVERY
+    // dataset. Plan 25 §2 inverted it: most-specific-wins runs all the way down.
     const m = member({
       profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.datasets]: Level.None },
       rows: [{ entityInstanceId: 'ds_shared', permission: 'admin' }],
     })
-    expect(levelFor(m, 'dataset', 'ds_shared')).toBeUndefined()
-    expect(m.server.canViewInstance('dataset', 'ds_shared')).toBe(false)
+    expect(levelFor(m, 'dataset', 'ds_shared')).toBe(ResourcePermission.admin)
+    expect(m.server.canViewInstance('dataset', 'ds_shared')).toBe(true)
 
-    // The two signals the server annotation (`forInstance.granteeAreaLevel`) is
-    // built from: the grant is genuinely stored, and the area is genuinely shut.
+    // The grant is genuinely stored and the area is genuinely shut — the two
+    // signals the server annotation (`forInstance.granteeAreaLevel`) is built
+    // from. Their combination no longer means "inert"; only pairing a shut area
+    // with an explicit `'none'` row does.
     expect(m.caps.instanceAccess).toEqual({ ds_shared: 'admin' })
     expect(m.server.areaLevel(Area.datasets)).toBe(Level.None)
   })
 
-  it('the same grant takes effect once the profile grants the area', () => {
-    // The other half of the warning's lifecycle — without this the test above
-    // would pass for a grant that never works at all.
+  it('but a member with NO row on that closed area still sees nothing', () => {
+    // The load-bearing half: the flip must not turn a closed area into an open
+    // one. Only instances someone deliberately authored a row for escape.
+    const m = member({
+      profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.datasets]: Level.None },
+      rows: [{ entityInstanceId: 'ds_shared', permission: 'admin' }],
+    })
+    expect(levelFor(m, 'dataset', 'ds_untouched')).toBeUndefined()
+    expect(m.server.canViewInstance('dataset', 'ds_untouched')).toBe(false)
+  })
+
+  it('an explicit `none` row on a closed area still denies', () => {
+    const m = member({
+      profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.datasets]: Level.None },
+      rows: [{ entityInstanceId: 'ds_locked', permission: 'none' }],
+    })
+    expect(levelFor(m, 'dataset', 'ds_locked')).toBe(ResourcePermission.none)
+    expect(m.server.canViewInstance('dataset', 'ds_locked')).toBe(false)
+  })
+
+  it('the same grant takes effect with the area open too', () => {
+    // The other half of the lifecycle — without this the test above would pass
+    // for a grant that never works at all.
     const m = member({ rows: [{ entityInstanceId: 'ds_shared', permission: 'admin' }] })
     expect(m.server.areaLevel(Area.datasets)).toBe(Level.Read)
     expect(levelFor(m, 'dataset', 'ds_shared')).toBe(ResourcePermission.admin)
@@ -213,7 +236,10 @@ describe('dead grants — an instance grant under a closed area (plan 24 §B.2.8
 
   it('an area closed only by the SEAT ceiling kills the grant too', () => {
     // A worker seat zeroes `datasets` regardless of the profile, and the ceiling
-    // is applied last — an instance grant must not slip past a billing invariant.
+    // is applied last — an instance grant must not slip past a billing
+    // invariant. Load-bearing since plan 25 §2: with the row now outranking the
+    // AREA floor, the seat clamp had to become an explicit check in
+    // `effectiveInstanceLevel` rather than riding on the seat-clamped key set.
     const m = member({
       seatType: 'worker',
       profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.datasets]: Level.Full },
@@ -269,5 +295,58 @@ describe('OWNER regression (plan 24 §A.4)', () => {
     const other = member({ restrictedInstances: ['dash_private'] })
     expect(levelFor(owner, 'dashboard', 'dash_private')).toBe(ResourcePermission.admin)
     expect(levelFor(other, 'dashboard', 'dash_private')).toBeUndefined()
+  })
+})
+
+/**
+ * `hasAnyInstanceGrant()` + `INSTANCE_ACCESS_VIEW_KEYS` — the two halves of
+ * `permissionProcedure`'s front-door waiver (plan 25 §2).
+ *
+ * Pinned as UNIT assertions rather than through a router on purpose: the waiver
+ * grants nothing, so it is behaviorally invisible downstream — every procedure
+ * behind those keys asserts on a specific instance immediately after, and denies
+ * the same callers either way. That invisibility IS the safety argument, and it
+ * is also why widening the waiver has to be caught here.
+ */
+describe('the permissionProcedure waiver inputs (plan 25 §2)', () => {
+  it('hasAnyInstanceGrant is true for a row that reaches view, at any rung', () => {
+    for (const permission of ['view', 'edit', 'admin'] as const) {
+      expect(
+        member({ rows: [{ entityInstanceId: 'ds_x', permission }] }).server.hasAnyInstanceGrant()
+      ).toBe(true)
+    }
+  })
+
+  it('hasAnyInstanceGrant is false with no rows, and false for `none` rows only', () => {
+    // A restriction is not a grant — it must not open the front door.
+    expect(member().server.hasAnyInstanceGrant()).toBe(false)
+    expect(
+      member({
+        rows: [{ entityInstanceId: 'ds_locked', permission: 'none' }],
+      }).server.hasAnyInstanceGrant()
+    ).toBe(false)
+  })
+
+  it('the waivable keys are exactly the Read rung of each instance-access area', () => {
+    // The scope that closes the create hole: `workflowsManage` fronts `create`,
+    // which has NO instance to assert on, so waiving it would let a `None`-area
+    // grant holder create workflows.
+    expect([...INSTANCE_ACCESS_VIEW_KEYS].sort()).toEqual(
+      [
+        PermissionKey.datasetsView,
+        PermissionKey.knowledgeBaseView,
+        PermissionKey.dashboardsView,
+        PermissionKey.workflowsView,
+      ].sort()
+    )
+    for (const key of [
+      PermissionKey.workflowsManage,
+      PermissionKey.datasetsManage,
+      PermissionKey.knowledgeBaseManage,
+      PermissionKey.dashboardsManage,
+      PermissionKey.workflowsEdit,
+    ]) {
+      expect(INSTANCE_ACCESS_VIEW_KEYS.has(key)).toBe(false)
+    }
   })
 })

--- a/packages/lib/src/permissions/capabilities/capability-set-workflow-instance.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-workflow-instance.test.ts
@@ -128,16 +128,18 @@ describe('the Area.workflows ladder (plan 30 §1)', () => {
     expect(levelFor(m, 'workflow', 'wf_unrestricted')).toBe(permission)
   })
 
-  it('area None denies a workflow outright, row or no row', () => {
+  it('area None denies a workflow with NO row, but an explicit row overrides it', () => {
     const m = member({
       profileLevels: { [Area.workflows]: Level.None },
       rows: [{ entityInstanceId: 'wf_shared', permission: 'admin' }],
     })
+    // Fail-closed for the unshared majority — the load-bearing half.
     expect(levelFor(m, 'workflow', 'wf_unrestricted')).toBeUndefined()
-    // A dead grant: the row composes, but the area short-circuit is checked
-    // first (plan 24 §B.2.8 — the behaviour plan 25 §2 will deliberately flip).
+    // …and the grant is LIVE (plan 25 §2, flipped from plan 24 §B.2.8's dead
+    // grant): most-specific-wins runs all the way down, so "no workflows except
+    // this one" is expressible at last.
     expect(m.caps.instanceAccess).toEqual({ wf_shared: 'admin' })
-    expect(levelFor(m, 'workflow', 'wf_shared')).toBeUndefined()
+    expect(levelFor(m, 'workflow', 'wf_shared')).toBe(ResourcePermission.admin)
   })
 })
 
@@ -238,6 +240,12 @@ describe('worker seats compose `workflows: None` (plan 30 §8 item 1 — DELIBER
     // manual workflow from a record. Reopening it means adding `Area.workflows`
     // to `WORKER_AREAS` — at which point this test should fail loudly rather
     // than the semantics changing silently.
+    //
+    // Load-bearing since plan 25 §2: an explicit row now outranks the AREA
+    // floor, so the seat ceiling had to become an explicit check in
+    // `effectiveInstanceLevel` instead of riding on the already-clamped key set.
+    // Without it this exact case — worker seat + `admin` grant — would hand out
+    // a workflow the seat's billing packaging excludes.
     const m = member({
       seatType: 'worker',
       profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.workflows]: Level.Full },
@@ -273,27 +281,32 @@ describe('the seeded Member baseline is unaffected by the rung split', () => {
 })
 
 /**
- * `deniedInstanceIds` — the exclusion `workflow.list` computes UP FRONT so its
- * query can filter before it paginates.
+ * `instanceListScope` — the id filter `workflow.list` computes UP FRONT so its
+ * query can narrow before it paginates.
  *
- * The property that matters is not the shape of the returned array but that it
- * is the exact COMPLEMENT of `canViewInstance`. Every case below asserts that
- * equivalence over a candidate id list, so the exclusion and the gate cannot
- * drift into a leak (an id the gate denies but the exclusion omits) or a
- * disappearance (an id the gate allows but the exclusion drops).
+ * The property that matters is not the shape of the returned lists but that
+ * applying them reproduces `canViewInstance` EXACTLY. Every case below asserts
+ * that equivalence over a candidate id list, so the filter and the gate cannot
+ * drift into a leak (an id the gate denies but the filter admits) or a
+ * disappearance (an id the gate allows but the filter drops — the plan 25 §2
+ * failure mode: an empty page for a workflow you can demonstrably open).
  */
-describe('deniedInstanceIds — the list exclusion is the complement of the gate', () => {
+describe('instanceListScope — the list filter reproduces the gate exactly', () => {
   const CANDIDATES = ['wf_open', 'wf_locked', 'wf_other', 'wf_shared', 'wf_never_touched']
 
   /** What the list SHOULD contain, derived from the shipped per-instance gate. */
   const viewableByGate = (m: ReturnType<typeof member>) =>
     CANDIDATES.filter((id) => m.server.canViewInstance('workflow', id))
 
-  /** What the list DOES contain once the exclusion is applied to the query. */
-  const viewableByExclusion = (m: ReturnType<typeof member>) => {
-    const { deniesAll, deniedIds } = m.server.deniedInstanceIds('workflow')
-    if (deniesAll) return []
-    const excluded = new Set(deniedIds)
+  /** What the list DOES contain once the scope is applied to the query. */
+  const viewableByScope = (m: ReturnType<typeof member>) => {
+    const scope = m.server.instanceListScope('workflow')
+    if (scope.kind === 'none') return []
+    if (scope.kind === 'include') {
+      const included = new Set(scope.includeIds)
+      return CANDIDATES.filter((id) => included.has(id))
+    }
+    const excluded = new Set(scope.excludeIds)
     return CANDIDATES.filter((id) => !excluded.has(id))
   }
 
@@ -304,12 +317,13 @@ describe('deniedInstanceIds — the list exclusion is the complement of the gate
         { entityInstanceId: 'wf_shared', permission: 'view' },
       ],
     })
-    const { deniesAll, deniedIds } = m.server.deniedInstanceIds('workflow')
-    expect(deniesAll).toBe(false)
     // `wf_shared` carries a row but the member may still VIEW it, so it must NOT
     // be excluded — "has a row" is not "is denied".
-    expect(deniedIds).toEqual(['wf_locked'])
-    expect(viewableByExclusion(m)).toEqual(viewableByGate(m))
+    expect(m.server.instanceListScope('workflow')).toEqual({
+      kind: 'exclude',
+      excludeIds: ['wf_locked'],
+    })
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
   })
 
   it('excludes a workflow whose rows do not include this member', () => {
@@ -318,28 +332,55 @@ describe('deniedInstanceIds — the list exclusion is the complement of the gate
     // as denial. Still a restriction — still enumerable from
     // `restrictedInstanceIds`.
     const m = member({ rows: [], restrictedInstances: ['wf_locked'] })
-    expect(m.server.deniedInstanceIds('workflow').deniedIds).toEqual(['wf_locked'])
-    expect(viewableByExclusion(m)).toEqual(viewableByGate(m))
+    expect(m.server.instanceListScope('workflow').excludeIds).toEqual(['wf_locked'])
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
   })
 
-  it('area None denies EVERYTHING — not expressible as an id list', () => {
-    // The one non-restriction denial path, and the reason `deniesAll` exists:
-    // with the area gate closed even a row-less workflow is denied, so no
-    // exclusion list could be complete. The caller must return an empty list.
+  it('area None with NO grants sees nothing at all', () => {
+    // Row-less denial cannot be enumerated as an exclusion, so this arm must be
+    // `'none'` and the caller must return an empty list without querying.
     const m = member({ profileLevels: { [Area.workflows]: Level.None } })
-    expect(m.server.deniedInstanceIds('workflow')).toEqual({ deniesAll: true, deniedIds: [] })
+    expect(m.server.instanceListScope('workflow')).toEqual({ kind: 'none' })
     expect(viewableByGate(m)).toEqual([])
-    expect(viewableByExclusion(m)).toEqual([])
+    expect(viewableByScope(m)).toEqual([])
   })
 
-  it('a worker seat is the same deniesAll case (seat ceiling, not a row)', () => {
+  it('area None WITH a grant INVERTS to an allow-list (plan 25 §2)', () => {
+    // The live repro. Before the flip this member got `deniesAll` and an empty
+    // page while `getById('wf_shared')` succeeded — `list` silently
+    // contradicting `canViewInstance`.
+    const m = member({
+      profileLevels: { [Area.workflows]: Level.None },
+      rows: [
+        { entityInstanceId: 'wf_shared', permission: 'view' },
+        { entityInstanceId: 'wf_locked', permission: 'none' },
+      ],
+    })
+    expect(m.server.instanceListScope('workflow')).toEqual({
+      kind: 'include',
+      includeIds: ['wf_shared'],
+    })
+    expect(viewableByGate(m)).toEqual(['wf_shared'])
+    expect(viewableByScope(m)).toEqual(['wf_shared'])
+  })
+
+  it('area None whose only rows are `none` restrictions still sees nothing', () => {
+    const m = member({
+      profileLevels: { [Area.workflows]: Level.None },
+      rows: [{ entityInstanceId: 'wf_locked', permission: 'none' }],
+    })
+    expect(m.server.instanceListScope('workflow')).toEqual({ kind: 'none' })
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
+  })
+
+  it('a worker seat sees nothing even holding an admin grant (seat ceiling)', () => {
     const m = member({
       seatType: 'worker',
       profileLevels: { ...MEMBER_BASELINE_LEVELS, [Area.workflows]: Level.Full },
       rows: [{ entityInstanceId: 'wf_shared', permission: 'admin' }],
     })
-    expect(m.server.deniedInstanceIds('workflow').deniesAll).toBe(true)
-    expect(viewableByExclusion(m)).toEqual(viewableByGate(m))
+    expect(m.server.instanceListScope('workflow')).toEqual({ kind: 'none' })
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
   })
 
   it('excludes nothing for an OWNER, even with a `none` row', () => {
@@ -347,17 +388,17 @@ describe('deniedInstanceIds — the list exclusion is the complement of the gate
       role: 'OWNER',
       rows: [{ entityInstanceId: 'wf_locked', permission: 'none' }],
     })
-    expect(m.server.deniedInstanceIds('workflow')).toEqual({ deniesAll: false, deniedIds: [] })
-    expect(viewableByExclusion(m)).toEqual(CANDIDATES)
-    expect(viewableByExclusion(m)).toEqual(viewableByGate(m))
+    expect(m.server.instanceListScope('workflow')).toEqual({ kind: 'exclude', excludeIds: [] })
+    expect(viewableByScope(m)).toEqual(CANDIDATES)
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
   })
 
   it('excludes nothing when the org has no instance rows at all', () => {
     // The overwhelmingly common shape under `baselineAtCreate: false`: the
     // exclusion is empty, so the query is unchanged and the fix costs nothing.
     const m = member()
-    expect(m.server.deniedInstanceIds('workflow')).toEqual({ deniesAll: false, deniedIds: [] })
-    expect(viewableByExclusion(m)).toEqual(viewableByGate(m))
+    expect(m.server.instanceListScope('workflow')).toEqual({ kind: 'exclude', excludeIds: [] })
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
   })
 
   it('is grantable-up: an explicit grant on a restricted workflow drops out of the exclusion', () => {
@@ -367,8 +408,8 @@ describe('deniedInstanceIds — the list exclusion is the complement of the gate
         { entityInstanceId: 'wf_locked', permission: 'view' },
       ],
     })
-    expect(m.server.deniedInstanceIds('workflow').deniedIds).toEqual([])
-    expect(viewableByExclusion(m)).toEqual(viewableByGate(m))
+    expect(m.server.instanceListScope('workflow').excludeIds).toEqual([])
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
   })
 
   it('carries ids of OTHER instance-access types, which is harmless', () => {
@@ -378,9 +419,26 @@ describe('deniedInstanceIds — the list exclusion is the complement of the gate
     // a workflow the member may see — documented here so nobody "fixes" it by
     // adding a per-type query.
     const m = member({ rows: [{ entityInstanceId: 'ds_locked', permission: 'none' }] })
-    expect(m.server.deniedInstanceIds('workflow').deniedIds).toEqual(['ds_locked'])
-    expect(viewableByExclusion(m)).toEqual(CANDIDATES)
-    expect(viewableByExclusion(m)).toEqual(viewableByGate(m))
+    expect(m.server.instanceListScope('workflow').excludeIds).toEqual(['ds_locked'])
+    expect(viewableByScope(m)).toEqual(CANDIDATES)
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
+  })
+
+  it('an allow-list may name foreign ids too, equally harmless', () => {
+    // The `include` mirror of the case above: a `datasets: None` member holding
+    // one dataset grant, listing WORKFLOWS. The allow-list names the dataset id,
+    // which matches no workflow row — an over-broad allow-list can no more admit
+    // a workflow than an over-broad exclusion can drop one.
+    const m = member({
+      profileLevels: { [Area.workflows]: Level.None },
+      rows: [{ entityInstanceId: 'ds_shared', permission: 'view' }],
+    })
+    expect(m.server.instanceListScope('workflow')).toEqual({
+      kind: 'include',
+      includeIds: ['ds_shared'],
+    })
+    expect(viewableByScope(m)).toEqual([])
+    expect(viewableByScope(m)).toEqual(viewableByGate(m))
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -10,8 +10,8 @@ import {
   canAdministerRecord,
   canEditRecord,
   canViewRecord,
-  deniedInstanceIds,
-  type InstanceExclusion,
+  type InstanceListScope,
+  instanceListScope,
   levelToPermission,
   NON_RECORD_DEF_SLUGS,
   type OrgSharedInstanceAccessKey,
@@ -25,7 +25,7 @@ import {
   PERMISSION_REGISTRY_MAP,
   PermissionKey,
 } from './registry'
-import { ENTITY_WRITE_KEYS } from './seat-policy'
+import { ENTITY_WRITE_KEYS, SEAT_CEILINGS } from './seat-policy'
 
 /**
  * Resolves the definition part of a RecordId (a system slug like `work_order`,
@@ -284,14 +284,17 @@ export class CapabilitySet implements CapabilityView {
   /**
    * Effective per-instance permission for an instance-access resource
    * (most-specific-wins), or `undefined` = no access (§1.4). OWNER bypasses to
-   * `admin` (§0.10); the coarse L2 area gate must be open; an explicit instance
-   * row (incl. the workspace baseline / `'none'`) wins; otherwise fall back to
-   * the base L2 area level (for `baselineAtCreate: false` resources). Zero I/O.
+   * `admin` (§0.10); an explicit instance row (incl. the workspace baseline /
+   * `'none'`) wins outright; with no row, the coarse L2 area gate must be open
+   * and supplies the fallback level (for `baselineAtCreate: false` resources).
+   * The SEAT ceiling is checked before any of that — it is a billing invariant
+   * and outranks even an explicit row. Zero I/O.
    *
-   * **ADMIN no longer bypasses** (doc 19 §5.3 piece 2, step 10) — kept
-   * byte-for-byte in sync with the client mirror
+   * **An explicit row beats the area floor** (plan 25 §2) and **ADMIN no longer
+   * bypasses** (doc 19 §5.3 piece 2, step 10) — kept byte-for-byte in sync with
+   * the client mirror
    * {@link import('./entity-access').effectiveInstanceLevel}, which carries the
-   * full rationale.
+   * full rationale for both.
    */
   private effectiveInstanceLevel(
     key: InstanceAccessKey,
@@ -299,28 +302,53 @@ export class CapabilitySet implements CapabilityView {
   ): ResourcePermission | undefined {
     if (this.role === 'OWNER') return ResourcePermission.admin
     const cfg = INSTANCE_ACCESS_RESOURCES[key]
+    if (SEAT_CEILINGS[this.seatType][cfg.area] === Level.None) return undefined
+    if (this.restrictedInstanceIds.has(instanceId)) return this.instanceAccess[instanceId]
     const areaLevel = areaLevelFromKeys(this.keys, cfg.area)
     if (areaLevel === Level.None) return undefined
-    if (this.restrictedInstanceIds.has(instanceId)) return this.instanceAccess[instanceId]
     return cfg.baselineAtCreate ? undefined : levelToPermission(areaLevel)
   }
 
   /**
-   * The exclusion a paginated LIST query needs so `limit`/`offset`/`total` run
-   * over the rows this member may actually see — the complement of
+   * Whether this member holds ANY instance grant reaching `view`, across ALL
+   * instance-access resources. Deliberately TYPE-BLIND: `instanceAccess` keys on
+   * the bare instance CUID with no resource type, so the composed blob cannot
+   * answer "does this member hold a *workflow* grant?" without a shape change
+   * (and therefore a `user:capabilities:vN` bump). Zero I/O.
+   *
+   * Used ONLY as the coarse front-door waiver in `permissionProcedure` (plan
+   * 25 §2): a member composing an instance-access area to `None` still has to
+   * reach the procedure whose per-instance assert will judge them. It is safe
+   * because it is scoped to `INSTANCE_ACCESS_VIEW_KEYS` and every
+   * procedure behind those keys asserts on a specific instance immediately
+   * after — it is NOT an authorization answer and must never be used as one.
+   */
+  hasAnyInstanceGrant(): boolean {
+    return Object.values(this.instanceAccess).some((permission) =>
+      satisfiesPermission(permission, ResourcePermission.view)
+    )
+  }
+
+  /**
+   * The id filter a paginated LIST query needs so `limit`/`offset`/`total` run
+   * over the rows this member may actually see — the list-side twin of
    * {@link canViewInstance}, computed up front instead of filtering a page after
    * the fact. Delegates to the shared client-safe
-   * {@link import('./entity-access').deniedInstanceIds}, which carries the proof
-   * that no non-restriction denial path exists. Zero I/O.
+   * {@link import('./entity-access').instanceListScope}, which carries the proof
+   * that its two id lists reproduce the gate exactly. Zero I/O.
    *
    * ```ts
-   * const { deniesAll, deniedIds } = ctx.capabilities.deniedInstanceIds('workflow')
-   * if (deniesAll) return { workflows: [], total: 0, hasMore: false }
-   * return service.getAll(orgId, { ...input, excludeIds: deniedIds })
+   * const scope = ctx.capabilities.instanceListScope('workflow')
+   * if (scope.kind === 'none') return { workflows: [], total: 0, hasMore: false }
+   * return service.getAll(orgId, {
+   *   ...input,
+   *   excludeIds: scope.excludeIds,
+   *   includeIds: scope.includeIds,
+   * })
    * ```
    */
-  deniedInstanceIds(key: OrgSharedInstanceAccessKey): InstanceExclusion {
-    return deniedInstanceIds(
+  instanceListScope(key: OrgSharedInstanceAccessKey): InstanceListScope {
+    return instanceListScope(
       {
         ...this.resolved(),
         instanceAccess: this.instanceAccess,

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -1,8 +1,11 @@
 // packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
 
+import type { ResourcePermission } from '@auxx/database/enums'
 import type { SeatType } from '@auxx/database/types'
 import { describe, expect, it } from 'vitest'
 import { composeUserCapabilities } from './compose-user-capabilities'
+import { effectiveInstanceLevel, type ResolvedRecordAccess } from './entity-access'
+import { INSTANCE_ACCESS_RESOURCES, type InstanceAccessKey } from './instance-access'
 import {
   AREA_ORDER,
   Area,
@@ -899,5 +902,134 @@ describe('plan 22 (member baseline strip) — §5 verification', () => {
 
     const admin = composeUserCapabilities({ role: 'ADMIN', seatType: 'full', typeAccessRows: [] })
     expect(areaLevelFromKeys(new Set(admin.keys), Area.channels)).toBe(Level.Full)
+  })
+})
+
+/**
+ * Plan 25 §2 — an explicit instance row beats the area floor.
+ *
+ * These drive the REAL composition (`composeUserCapabilities`) into the REAL
+ * resolver (`effectiveInstanceLevel`), so they pin the whole path a share
+ * travels: rows compose into `instanceAccess`, `restrictedInstanceIds` marks the
+ * instance as explicitly managed, and the resolver reads the row BEFORE the area
+ * gate.
+ *
+ * The three properties that must hold together — take any one away and the
+ * change is either useless or a leak:
+ *  1. area `None` + an explicit ≥`view` row ⇒ access (the live repro);
+ *  2. area `None` + NO row ⇒ denied (fail-closed for the unshared majority);
+ *  3. area `None` + an explicit `'none'` row ⇒ denied (restrictions still bite).
+ *
+ * Run across all four registry keys so the rule is uniform over
+ * `baselineAtCreate` — dashboards (`true`) must behave identically to the three
+ * org-shared resources here.
+ */
+describe('plan 25 §2 — an explicit instance grant overrides the area-None floor', () => {
+  /** Compose a full-seat USER whose ONE named area is closed, then resolve one instance. */
+  function resolve(opts: {
+    area: Area
+    rows: Array<{ entityInstanceId: string; permission: ResourcePermission }>
+    instanceId: string
+    key: InstanceAccessKey
+    role?: 'USER' | 'OWNER'
+    seatType?: SeatType
+  }) {
+    const role = opts.role ?? 'USER'
+    const caps = composeUserCapabilities({
+      role,
+      seatType: opts.seatType ?? 'full',
+      profileLevels: { ...MEMBER_BASELINE_LEVELS, [opts.area]: Level.None },
+      typeAccessRows: [],
+      instanceAccessRows: opts.rows,
+    })
+    const access: ResolvedRecordAccess = {
+      role,
+      seatType: opts.seatType ?? 'full',
+      keys: new Set(caps.keys),
+      defAccess: caps.defAccess,
+      restrictedEntityDefIds: new Set(),
+      instanceAccess: caps.instanceAccess,
+      // Grantee-agnostic by construction (see `computeUserCapabilities`): any row
+      // on an instance puts it under explicit management, grant or restriction.
+      restrictedInstanceIds: new Set(opts.rows.map((r) => r.entityInstanceId)),
+    }
+    return { caps, level: effectiveInstanceLevel(access, opts.key, opts.instanceId) }
+  }
+
+  const KEYS: InstanceAccessKey[] = ['workflow', 'dataset', 'kb', 'dashboard']
+
+  it.each(KEYS)('%s: area None + an explicit `view` grant resolves to view', (key) => {
+    const area = INSTANCE_ACCESS_RESOURCES[key].area
+    const { caps, level } = resolve({
+      area,
+      key,
+      instanceId: 'inst_shared',
+      rows: [{ entityInstanceId: 'inst_shared', permission: 'view' }],
+    })
+    // The area really is shut — otherwise this test proves nothing.
+    expect(areaLevelFromKeys(new Set(caps.keys), area)).toBe(Level.None)
+    expect(level).toBe('view')
+  })
+
+  it.each(KEYS)('%s: area None + NO row is still denied (fail-closed)', (key) => {
+    const { level } = resolve({
+      area: INSTANCE_ACCESS_RESOURCES[key].area,
+      key,
+      instanceId: 'inst_untouched',
+      rows: [{ entityInstanceId: 'inst_shared', permission: 'admin' }],
+    })
+    expect(level).toBeUndefined()
+  })
+
+  it.each(KEYS)('%s: area None + an explicit `none` restriction is denied', (key) => {
+    const { level } = resolve({
+      area: INSTANCE_ACCESS_RESOURCES[key].area,
+      key,
+      instanceId: 'inst_locked',
+      rows: [{ entityInstanceId: 'inst_locked', permission: 'none' }],
+    })
+    expect(level).toBe('none')
+  })
+
+  it.each(KEYS)('%s: the grant carries its own rung, not a flattened view', (key) => {
+    // A share is not silently downgraded to Read by the closed area: `edit` and
+    // `admin` grants survive intact, which is what makes "you may manage exactly
+    // this one" expressible.
+    for (const permission of ['edit', 'admin'] as const) {
+      const { level } = resolve({
+        area: INSTANCE_ACCESS_RESOURCES[key].area,
+        key,
+        instanceId: 'inst_shared',
+        rows: [{ entityInstanceId: 'inst_shared', permission }],
+      })
+      expect(level).toBe(permission)
+    }
+  })
+
+  it('OWNER is unaffected — still admin on a closed area with a `none` row', () => {
+    const { level } = resolve({
+      area: Area.workflows,
+      key: 'workflow',
+      role: 'OWNER',
+      instanceId: 'inst_locked',
+      rows: [{ entityInstanceId: 'inst_locked', permission: 'none' }],
+    })
+    expect(level).toBe('admin')
+  })
+
+  it('a worker seat is NOT lifted by a grant — the seat ceiling still dominates', () => {
+    // The regression the reorder opened: `effectiveInstanceLevel` used to reach
+    // the seat clamp implicitly, through the already-clamped key set. It is now
+    // an explicit check, and this is the test that keeps it there.
+    const { level } = resolve({
+      // Full on the profile; the ceiling, not the profile, is what shuts it.
+      area: Area.records,
+      key: 'workflow',
+      seatType: 'worker',
+      instanceId: 'inst_shared',
+      rows: [{ entityInstanceId: 'inst_shared', permission: 'admin' }],
+    })
+    expect(SEAT_CEILINGS.worker[Area.workflows]).toBe(Level.None)
+    expect(level).toBeUndefined()
   })
 })

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -310,9 +310,34 @@ function parseInstanceRecordId(recordId: string): { key: string; instanceId: str
  * `effectiveInstanceLevel`, kept byte-for-byte in sync so client affordances and
  * server enforcement never drift (§1.4):
  *  - OWNER → `admin` (the §0.10 recovery bypass — never self-lock).
- *  - L2 area gate closed (`None`) → `undefined`.
- *  - explicit instance row (incl. workspace baseline / `'none'`) → wins.
+ *  - explicit instance row (incl. workspace baseline / `'none'`) → wins, even
+ *    when the L2 area gate is closed.
+ *  - L2 area gate closed (`None`) and NO row → `undefined`.
  *  - otherwise fall back to the base L2 area level (`baselineAtCreate: false`).
+ *
+ * **An explicit instance row beats the area floor** (plan 25 §2, decided
+ * 2026-07-27). The row check used to sit BELOW the `areaLevel === Level.None`
+ * return, which made every share to a sparse-profile member inert: the only way
+ * to make "you may see this ONE workflow" work was to raise their profile to
+ * `workflows: Read`, and because `workflow` is `baselineAtCreate: false` that
+ * granted read on EVERY workflow — the exact opposite of a single-instance
+ * share. Most-specific-wins now runs all the way down, matching
+ * {@link effectiveRecordLevel}, where an explicit per-def grant has always
+ * REPLACED the base rather than being clamped by it.
+ *
+ * Fail-closed is preserved by `restrictedInstanceIds`: the unshared majority
+ * have no row at all, so they fall through to the area gate and are denied. Only
+ * an instance someone deliberately authored a row for can escape the floor, and
+ * an explicit `'none'` row still denies (it is the per-instance downward marker).
+ *
+ * **The SEAT ceiling still dominates, and is now checked explicitly.** It used
+ * to be enforced implicitly: `areaLevelFromKeys` reads an already seat-clamped
+ * key set, so a closed seat area meant `areaLevel === Level.None` and the
+ * short-circuit denied before any row was read. Now that a row outranks the
+ * floor, that implicit path is gone and the clamp has to be stated — otherwise
+ * one `admin` grant would hand a worker seat a workflow its billing packaging
+ * excludes. Same shape as {@link effectiveRecordLevel}'s records-ceiling check
+ * (§3: a clamp applied at some seams only is defeated by the others).
  *
  * **ADMIN no longer bypasses** (doc 19 §5.3 piece 2, step 10). On the seeded
  * all-`Full` `admin` profile the fallback branch returns `admin` anyway for the
@@ -331,11 +356,12 @@ export function effectiveInstanceLevel(
 ): ResourcePermission | undefined {
   if (caps.role === 'OWNER') return ResourcePermission.admin
   const cfg = INSTANCE_ACCESS_RESOURCES[key]
-  const areaLevel = areaLevelFromKeys(caps.keys, cfg.area)
-  if (areaLevel === Level.None) return undefined
+  if (SEAT_CEILINGS[caps.seatType][cfg.area] === Level.None) return undefined
   if ((caps.restrictedInstanceIds ?? EMPTY_INSTANCE_SET).has(instanceId)) {
     return caps.instanceAccess?.[instanceId]
   }
+  const areaLevel = areaLevelFromKeys(caps.keys, cfg.area)
+  if (areaLevel === Level.None) return undefined
   return cfg.baselineAtCreate ? undefined : levelToPermission(areaLevel)
 }
 
@@ -346,7 +372,7 @@ const EMPTY_INSTANCE_SET: ReadonlySet<string> = new Set()
  * (`baselineAtCreate: false` — `dataset`, `kb`, `workflow`). Derived from
  * {@link INSTANCE_ACCESS_RESOURCES} rather than hand-listed, so flipping a
  * resource to `baselineAtCreate: true` removes it here and makes
- * {@link deniedInstanceIds} a COMPILE error at its call sites instead of a
+ * {@link instanceListScope} a COMPILE error at its call sites instead of a
  * silent leak — see that function for why the distinction is load-bearing.
  */
 export type OrgSharedInstanceAccessKey = {
@@ -356,68 +382,101 @@ export type OrgSharedInstanceAccessKey = {
 }[InstanceAccessKey]
 
 /**
- * The exclusion a paginated LIST query needs so that `limit`/`offset`/`total`
+ * The id filter a paginated LIST query needs so that `limit`/`offset`/`total`
  * run over the set the member may actually see.
  *
  * Post-pagination filtering (fetch a page, then drop the rows the member can't
  * view) makes `total`/`hasMore` describe the UNFILTERED page, returns short
  * pages, and — with enough restrictions — an EMPTY page alongside
  * `hasMore: true`, which breaks any client that stops on an empty page.
+ *
+ * Three outcomes, because plan 25 §2 made the member's visible set either a
+ * near-total set with holes or a tiny explicit allow-list, and no single id list
+ * can express both:
+ *  - `'none'` — view nothing; return an empty list WITHOUT querying.
+ *  - `'exclude'` — everything except {@link excludeIds} (the open-area case; the
+ *    array is usually empty).
+ *  - `'include'` — ONLY {@link includeIds} (the closed-area case: the member
+ *    composes the area to `None` but holds explicit instance grants).
+ *
+ * The unused arm is typed `undefined` on each variant so a caller that has
+ * already excluded `'none'` can spread both fields into a filter object without
+ * branching.
  */
-export interface InstanceExclusion {
-  /**
-   * `true` ⇒ the member may view NO instance of this resource (their L2 area
-   * gate is closed). {@link InstanceExclusion.deniedIds} is meaningless; the
-   * caller must return an empty list without querying at all.
-   */
-  deniesAll: boolean
-  /** Instance ids to exclude from the query. Empty when `deniesAll`. */
-  deniedIds: string[]
-}
+export type InstanceListScope =
+  | { kind: 'none'; excludeIds?: undefined; includeIds?: undefined }
+  | { kind: 'exclude'; excludeIds: string[]; includeIds?: undefined }
+  | { kind: 'include'; includeIds: string[]; excludeIds?: undefined }
 
 /**
- * The instance ids a member may NOT view for an org-shared instance-access
- * resource — the complement of {@link canViewInstance}, computed UP FRONT so a
- * list query can exclude them BEFORE it paginates.
+ * The id filter that reproduces {@link canViewInstance} for an org-shared
+ * instance-access resource, computed UP FRONT so a list query can apply it
+ * BEFORE it paginates. The list-side twin of `canViewInstance` — if these two
+ * disagree, a member sees an empty page for an instance they can demonstrably
+ * open.
  *
- * Enumerating the denied set is only sound for `baselineAtCreate: false`
- * resources, which is why the `key` parameter is narrowed to
+ * Enumerating either side is only sound for `baselineAtCreate: false` resources,
+ * which is why the `key` parameter is narrowed to
  * {@link OrgSharedInstanceAccessKey}. There, {@link effectiveInstanceLevel} has
- * exactly three outcomes and only two of them can deny:
- *  1. `role === 'OWNER'` → `admin`. Never denies.
- *  2. area level `None` → `undefined`. Denies EVERYTHING, including instances
- *     with no row — not enumerable, hence `deniesAll`.
- *  3. instance in `restrictedInstanceIds` → that member's own row, which denies
- *     when it is absent or below `view`. **Enumerable** — the set is exactly the
- *     org's explicitly-shared instances.
- *  4. otherwise → `levelToPermission(areaLevel)`, which for a non-`None` area is
- *     always ≥ `view`. Never denies.
- * So outside the `deniesAll` case, an instance can only be denied by an explicit
- * `ResourceAccess` row — there is no fourth, non-restriction denial path. With
+ * exactly four outcomes:
+ *  1. `role === 'OWNER'` → `admin`. Never denies → `exclude` with nothing.
+ *  1b. seat ceiling closes the area → `undefined` for everything, rows included
+ *     → `'none'`.
+ *  2. instance in `restrictedInstanceIds` → that member's own row, which denies
+ *     when it is absent or below `view`. **Enumerable both ways** — the set is
+ *     exactly the org's explicitly-managed instances.
+ *  3. no row + area level `None` → `undefined`. Denies every row-LESS instance,
+ *     which no exclusion list can enumerate — so this case inverts to `include`,
+ *     naming the explicitly-granted instances instead. When none of the member's
+ *     rows reach `view`, the answer is `'none'`.
+ *  4. no row + open area → `levelToPermission(areaLevel)`, always ≥ `view`.
+ *     Never denies.
+ * So an instance is denied either by an explicit `ResourceAccess` row or by the
+ * area floor with no row — there is no third denial path. With
  * `baselineAtCreate: true` (dashboards) branch 4 flips to `undefined` and every
- * row-less instance is denied, which no id list can express.
+ * row-less instance is denied even on an open area, so that resource would need
+ * the `include` form unconditionally; the type narrowing makes flipping a
+ * resource a COMPILE error at the call sites rather than a silent leak.
  *
  * `restrictedInstanceIds` is org-wide across ALL instance-access resources, so
  * the result may name ids of other types (a restricted dataset while listing
- * workflows). Harmless: ids are globally-unique cuid2s, so excluding a foreign
- * id can never drop a row of the type being listed.
+ * workflows). Harmless in both directions: ids are globally-unique cuid2s, so a
+ * foreign id can neither drop a row of the type being listed (`exclude`) nor
+ * admit one (`include`).
  */
-export function deniedInstanceIds(
+export function instanceListScope(
   caps: ResolvedRecordAccess,
   key: OrgSharedInstanceAccessKey
-): InstanceExclusion {
-  if (caps.role === 'OWNER') return { deniesAll: false, deniedIds: [] }
-  if (areaLevelFromKeys(caps.keys, INSTANCE_ACCESS_RESOURCES[key].area) === Level.None) {
-    return { deniesAll: true, deniedIds: [] }
+): InstanceListScope {
+  if (caps.role === 'OWNER') return { kind: 'exclude', excludeIds: [] }
+  const area = INSTANCE_ACCESS_RESOURCES[key].area
+  // The seat ceiling dominates every row (see `effectiveInstanceLevel`), so a
+  // seat that excludes the area sees nothing regardless of grants.
+  if (SEAT_CEILINGS[caps.seatType][area] === Level.None) return { kind: 'none' }
+  const managed = caps.restrictedInstanceIds ?? EMPTY_INSTANCE_SET
+
+  if (areaLevelFromKeys(caps.keys, area) === Level.None) {
+    // Area closed: the visible set is exactly the member's own ≥`view` rows
+    // (plan 25 §2). An allow-list, not a deny-list — every row-less instance is
+    // invisible and there is no bound on how many of those there are.
+    const includeIds: string[] = []
+    for (const instanceId of managed) {
+      const level = caps.instanceAccess?.[instanceId]
+      if (level !== undefined && satisfiesPermission(level, ResourcePermission.view)) {
+        includeIds.push(instanceId)
+      }
+    }
+    return includeIds.length > 0 ? { kind: 'include', includeIds } : { kind: 'none' }
   }
-  const deniedIds: string[] = []
-  for (const instanceId of caps.restrictedInstanceIds ?? EMPTY_INSTANCE_SET) {
+
+  const excludeIds: string[] = []
+  for (const instanceId of managed) {
     const level = caps.instanceAccess?.[instanceId]
     if (level === undefined || !satisfiesPermission(level, ResourcePermission.view)) {
-      deniedIds.push(instanceId)
+      excludeIds.push(instanceId)
     }
   }
-  return { deniesAll: false, deniedIds }
+  return { kind: 'exclude', excludeIds }
 }
 
 /**

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -23,6 +23,7 @@ export {
 export {
   INSTANCE_ACCESS_KEYS,
   INSTANCE_ACCESS_RESOURCES,
+  INSTANCE_ACCESS_VIEW_KEYS,
   type InstanceAccessKey,
   type InstanceAccessResourceConfig,
   isInstanceAccessKey,

--- a/packages/lib/src/permissions/capabilities/instance-access.ts
+++ b/packages/lib/src/permissions/capabilities/instance-access.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/permissions/capabilities/instance-access.ts
 
-import { Area } from './registry'
+import { Area, Level, PERMISSION_AREAS, type PermissionKey } from './registry'
 
 /**
  * Per-resource declaration for instance-level access (doc 08 §1.1 / doc 11 §1.1).
@@ -56,3 +56,33 @@ export const INSTANCE_ACCESS_KEYS = Object.keys(INSTANCE_ACCESS_RESOURCES) as In
 export function isInstanceAccessKey(key: string): key is InstanceAccessKey {
   return Object.hasOwn(INSTANCE_ACCESS_RESOURCES, key)
 }
+
+/**
+ * The `Level.Read` rung keys of every instance-access resource's L2 area — the
+ * ONLY keys a coarse procedure gate may waive in favour of an explicit instance
+ * grant (plan 25 §2).
+ *
+ * Since an explicit instance row now beats the area floor
+ * ({@link import('./entity-access').effectiveInstanceLevel}), a member composing
+ * `workflows: None` who holds one `read` grant must still reach
+ * `workflow.getById` — but the base procedure asserts `workflowsView`, which
+ * they do not hold. `permissionProcedure` therefore waives the assert for the
+ * keys in this set when the member holds ANY instance grant, and lets the
+ * procedure's own `assert{View,Edit,Admin}Instance` decide.
+ *
+ * **Read rung only, deliberately.** The waiver is sound only for procedures that
+ * immediately assert on a specific instance. The higher rungs of these same
+ * areas gate the instance-LESS actions — `workflowsManage` fronts `create` /
+ * `createForResource`, which have no instance to assert on — so waiving those
+ * would hand a `None`-area member the ability to create. Derived from
+ * {@link INSTANCE_ACCESS_RESOURCES} rather than hand-listed: an area with no
+ * `Level.Read` rung contributes nothing and therefore fails closed.
+ */
+export const INSTANCE_ACCESS_VIEW_KEYS: ReadonlySet<PermissionKey> = new Set(
+  INSTANCE_ACCESS_KEYS.flatMap(
+    (key) =>
+      PERMISSION_AREAS[INSTANCE_ACCESS_RESOURCES[key].area].rungs.find(
+        (rung) => rung.level === Level.Read
+      )?.keys ?? []
+  )
+)

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -20,6 +20,7 @@ export {
 export {
   INSTANCE_ACCESS_KEYS,
   INSTANCE_ACCESS_RESOURCES,
+  INSTANCE_ACCESS_VIEW_KEYS,
   type InstanceAccessKey,
   type InstanceAccessResourceConfig,
   isInstanceAccessKey,

--- a/packages/lib/src/workflows/types.ts
+++ b/packages/lib/src/workflows/types.ts
@@ -39,6 +39,13 @@ export interface WorkflowFilter {
    * `total`/`hasMore` describe the set the member can actually see.
    */
   excludeIds?: readonly string[]
+  /**
+   * The caller may view ONLY these workflow ids — the inverse of
+   * {@link excludeIds}, used when the member composes `workflows: None` but
+   * holds explicit instance grants (plan 25 §2). Mutually exclusive with
+   * `excludeIds`; `CapabilitySet.instanceListScope` never produces both.
+   */
+  includeIds?: readonly string[]
 }
 export interface WorkflowCreateInput {
   name: string

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -89,6 +89,7 @@ export class WorkflowService {
         limit: filters.limit,
         offset: filters.offset,
         excludeIds: filters.excludeIds,
+        includeIds: filters.includeIds,
       })
 
       const workflows = cached.workflows.map((app) => ({


### PR DESCRIPTION
Plan 25 §2, option (b). Fixes a bug hit live: a member granted instance `read` on ONE workflow, whose profile has `workflows: None`, got a "profile has no workflow access" warning — and the warning was *correct*, the grant was genuinely inert.

`effectiveInstanceLevel` returned `undefined` on `areaLevel === Level.None` **before** it consulted the instance row. The only workaround was raising the profile to `workflows: Read`, which — because `workflow` is `baselineAtCreate: false` — grants read on **every** workflow. There was no way to express "no workflows except this one."

Now an explicit row beats the area floor: most-specific-wins, all the way down. The unshared majority still fails closed, because they have no row at all.

## A hole the reorder opened, closed in the same change

The seat ceiling was enforced **implicitly**: `areaLevelFromKeys` reads an already seat-clamped key set, so a closed seat area meant `areaLevel === None` and the short-circuit denied before any row was read. Once a row outranks the floor, that path is gone — a worker seat holding one `admin` grant would have been handed an instance its billing packaging excludes. Both `effectiveInstanceLevel` copies and `instanceListScope` now carry an explicit `SEAT_CEILINGS` check ahead of the row lookup, mirroring `effectiveRecordLevel`'s records clamp. Mutation-verified three ways.

## `deniedInstanceIds` → `instanceListScope`

The old name was already a lie, and the shape had to invert. A closed-area member with grants needs an **inclusion** list (`inArray`), not an exclusion — the denied set is unbounded, the allowed set is tiny:

```ts
type InstanceListScope =
  | { kind: 'none' }
  | { kind: 'exclude'; excludeIds: string[] }
  | { kind: 'include'; includeIds: string[] }
```

Missing this site would have made `list` silently contradict `canViewInstance` — an empty page for a workflow the member can demonstrably open. Both `inArray` and `notInArray` are guarded against empty arrays, and an empty allow-list is treated as "not set", never "show nothing".

## The coarse gate

`permissionProcedure` waives its assert for the **Read-rung keys only** of instance-access areas when the member holds any instance grant reaching `view`. Type-blind, as decided — the blob keys on bare instance CUIDs with no resource type, and making it type-aware would force a `user:capabilities:vN` bump.

Safe because every one of the 19 `workflowsView` procedures asserts per-instance — **audited individually**, listed in the commit. Higher rungs stay strict, which keeps `create`/`createForResource` (the only instance-*less* actions) on `workflowsManage`. That scoping is itself mutation-tested: widening the waiver to every rung fails a test.

## Also fixes a bug shipped in #1345

The Workflows nav entry (`menu.tsx`) and cmd+K action (`kbar/actions/navigation.ts`) were still gated on `workflows.manage` — a leftover from when workflows was a single-rung area. Every legitimate `Read`/`Edit` holder saw no way in. Both now use `workflows.view`.

## Dead-grant warning

Flipped to mark only explicit `none` restrictions — a grant against a sparse profile is no longer dead, so warning about it was actively wrong. `InstanceShareGrant` gained a raw `permission` field because `choice` can't express `none`.

## Tests

12 mutations, **all caught**, each restored byte-identically with an unmutated control run. 261 web + 552 lib green.

One mutation (`hasAnyInstanceGrant` always true) was initially **uncaught**, and that's a finding worth keeping: the waiver grants nothing, so widening it changes no router outcome — `assertViewInstance` denies the same callers either way. That invisibility *is* the safety argument. It's now pinned as a unit assertion instead.

## Known follow-ups (not in this PR)

- `datasets/page.tsx:106` blocks the whole page on `datasetsView`, so a `datasets: None` member with one grant can open `/app/datasets/<id>` but sees "No Access" on the landing page. It can't just be deleted — the page mounts `DatasetsProvider`, whose `getOrganizationStats` asserts `datasetsView` server-side, deliberately, since those are org-wide aggregates. Needs a product decision on what the stats header shows for a partial-access member. KB and Dashboards have the same shape and hard-redirect to `/access-denied`.
- The cmd+K "Dashboards" entry has **no** permission key while its landing page redirects — so it walks users into a redirect. Pre-existing.