### PR TITLE
feat(permissions): derive the area read key from instance grants

### DIFF
--- a/apps/web/src/components/datasets/settings/sections/embedding-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/embedding-settings-section.tsx
@@ -63,7 +63,9 @@ export function EmbeddingSettingsSection({
     },
   })
 
-  const embeddingOptions = api.dataset.getAvailableEmbeddingOptions.useQuery()
+  const embeddingOptions = api.dataset.getAvailableEmbeddingOptions.useQuery({
+    datasetId: dataset.id,
+  })
 
   const unifiedModelData = api.aiIntegration.getUnifiedModelData.useQuery(
     {

--- a/apps/web/src/components/global/notifications/ui/items/resource-notifications.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/resource-notifications.tsx
@@ -68,7 +68,8 @@ export function DashboardNotification(props: NotificationItemProps<'DASHBOARD'>)
  * resource, so `resourceAccess.grantInstance` now emits `RESOURCE_SHARED` for it).
  *
  * `useFavoriteWorkflow` reads `api.workflow.getById`, which gates on the
- * `workflowsView` rung plus `assertViewInstance`, so the member the share was
+ * `workflowsView` rung plus `assertViewInstance` — and the share itself derives
+ * that rung for the grantee (handoff item 5b), so the member the share was
  * just granted to resolves the name. A later revoke drops them to the
  * Unavailable row, same as the other three types.
  */

--- a/apps/web/src/components/kbar/actions/navigation.ts
+++ b/apps/web/src/components/kbar/actions/navigation.ts
@@ -39,7 +39,10 @@ export function useNavigationActions(): PaletteAction[] {
   return useMemo<PaletteAction[]>(() => {
     const actions: PaletteAction[] = []
 
-    if (hasAccess('dashboards')) {
+    // View, not Manage — matches SIDEBAR_MENU. Without the capability half this
+    // entry walked members straight into the landing page's /access-denied
+    // redirect, because `dashboards-list-view.tsx` guards on the same key.
+    if (hasAccess('dashboards') && can('dashboards.view')) {
       actions.push({
         id: 'nav.dashboards',
         label: 'Dashboards',

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -98,7 +98,11 @@ interface CapabilitiesContextType {
    * the bare `entityInstanceId` (CUID), NOT a `RecordId`.
    */
   isRestrictedInstance: (instanceId: string) => boolean
-  /** The current member's composed capability keys. */
+  /**
+   * The current member's composed capability keys, from resolved AREA levels
+   * only — instance-derived Read rungs are excluded, because the consumers of
+   * this field recover area levels from it. Use `can()` for gating.
+   */
   capabilities: PermissionKey[]
   isLoading: boolean
 }
@@ -164,7 +168,14 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
   useRealtimeRoom(organizationId ? rooms.orgEvents(organizationId) : null, handlers)
 
   const value = useMemo<CapabilitiesContextType>(() => {
-    const capKeys = new Set<string>(snapshot.keys)
+    // The `can()` gate reads the UNION of resolved-area keys and the Read rungs
+    // derived from instance grants, so a member whose only access to a feature is
+    // one shared instance still passes the coarse nav / cmd+K / landing-page
+    // gates. `toResolvedRecordAccess` below deliberately gets `snapshot` with its
+    // pure `keys` — that view is the AREA-level source of truth for
+    // `canViewInstance`, and merging the derived key there would hand them every
+    // row-less instance in the org.
+    const capKeys = new Set<string>([...snapshot.keys, ...(snapshot.instanceDerivedKeys ?? [])])
     const resolved = toResolvedRecordAccess(snapshot)
     const restrictedInstances = new Set<string>(snapshot.restrictedInstanceIds ?? [])
 
@@ -196,6 +207,9 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
       canEditInstance: (recordId: RecordId) => canEditInstance(resolved, recordId),
       canAdminInstance: (recordId: RecordId) => canAdminInstance(resolved, recordId),
       isRestrictedInstance: (instanceId: string) => restrictedInstances.has(instanceId),
+      // Pure area-derived keys, NOT the `can()` union: the only consumers feed
+      // this straight into `areaLevelFromKeys` (the agent-policy / author clamp
+      // previews), which must read a true area rung.
       capabilities: snapshot.keys,
       isLoading: false,
     }

--- a/apps/web/src/server/api/routers/dataset-org-aggregate-scope.test.ts
+++ b/apps/web/src/server/api/routers/dataset-org-aggregate-scope.test.ts
@@ -1,0 +1,261 @@
+// apps/web/src/server/api/routers/dataset-org-aggregate-scope.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * **The item-5b coarse-key audit, at the router layer.**
+ *
+ * Synthesizing the area Read rung from a member's instance grants makes every
+ * procedure that asserts that coarse key newly reachable by a single-instance
+ * grantee. For instance-SCOPED procedures that is exactly the point. For
+ * ORG-WIDE aggregates it is a data leak, and `dataset.ts` held the only two such
+ * sites in the whole server tree:
+ *
+ *  - `getOrganizationStats` — counts, document totals and byte sizes over EVERY
+ *    non-managed dataset in the org.
+ *  - `getAvailableEmbeddingOptions` — org-level AI configuration, no dataset in
+ *    the input at all.
+ *
+ * Both used `ctx.capabilities.assert(PermissionKey.datasetsView)`, which stopped
+ * being a real boundary the moment that key became derivable from one share.
+ * The fixes are different on purpose and this file pins both:
+ *  1. stats is SCOPED — `instanceListScope('dataset')` narrows the aggregate to
+ *     the datasets the member may open, so the tiles agree with the grid;
+ *  2. embedding options is made INSTANCE-SCOPED — it takes a `datasetId` and
+ *     asserts on it.
+ *
+ * Behavioral: the real router is driven through a tRPC caller with a real
+ * `CapabilitySet`. The narrowing is observed through `drizzle-orm`'s
+ * `inArray`/`notInArray`, which is where the router's scoping decision actually
+ * lands — dropping the scope stops calling them and fails a case here.
+ */
+
+const { datasetService, featureService, inArraySpy, notInArraySpy } = vi.hoisted(() => ({
+  datasetService: {
+    getAvailableEmbeddingOptions: vi.fn(async () => ({ systemDefault: 'openai:text-embed-3' })),
+  },
+  featureService: { requireAccess: vi.fn(async () => undefined) },
+  inArraySpy: vi.fn(),
+  notInArraySpy: vi.fn(),
+}))
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return {
+    ...actual,
+    inArray: (...args: Parameters<typeof actual.inArray>) => {
+      inArraySpy(...(args as unknown[]))
+      return actual.inArray(...args)
+    },
+    notInArray: (...args: Parameters<typeof actual.notInArray>) => {
+      notInArraySpy(...(args as unknown[]))
+      return actual.notInArray(...args)
+    },
+  }
+})
+
+vi.mock('@auxx/lib/datasets', () => ({
+  DatasetService: class {
+    getAvailableEmbeddingOptions = datasetService.getAvailableEmbeddingOptions
+  },
+  SearchService: {},
+}))
+
+vi.mock('@auxx/lib/cache', () => ({ onCacheEvent: vi.fn(async () => undefined) }))
+
+// The `@auxx/lib/permissions` barrel reaches redis/db at import time and hangs
+// under vitest — hand the router the real registry plus a stub feature service.
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+      requireLimit = featureService.requireAccess
+    },
+  }
+})
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
+        return next()
+      }),
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  }
+})
+
+// Deep path on purpose — the permissions barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { datasetRouter } = await import('./dataset')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const SHARED = 'ds_shared0000000000000000'
+const OTHER = 'ds_other00000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+/**
+ * A real `CapabilitySet`, composed the way `composeUserCapabilities` does it:
+ * any `≥view` dataset row synthesizes `datasets.view` into the DERIVED key set —
+ * never into `keys`, which stays the area-level source of truth.
+ */
+function caps(opts: {
+  areaLevel?: Level
+  rows?: Record<string, ResourcePermission>
+  role?: 'MEMBER' | 'OWNER'
+}) {
+  const rows = opts.rows ?? {}
+  const derived = Object.values(rows).some((p) => p !== ResourcePermission.none)
+    ? [PermissionKey.datasetsView]
+    : []
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.datasets]: opts.areaLevel ?? Level.None })),
+    {},
+    opts.role ?? 'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    rows,
+    new Set(Object.keys(rows)),
+    undefined,
+    new Set(derived)
+  )
+}
+
+const SESSION = {
+  organizationId: ORG_ID,
+  userId: USER_ID,
+  isSuperAdmin: false,
+  user: { id: USER_ID, defaultOrganizationId: ORG_ID, email: 'a@b.c', name: 'A' },
+}
+
+type Caps = InstanceType<typeof CapabilitySet>
+
+/**
+ * Query-builder stand-in for `getOrganizationStats`' four raw drizzle reads.
+ * `selects` counts how many aggregate queries were issued, so "returned zeros
+ * WITHOUT touching the DB" is an observable outcome rather than an inference.
+ */
+function fakeDb() {
+  const selects = { count: 0 }
+  // `where()` is both awaitable (the three scalar reads) and `.groupBy()`-able
+  // (the status histogram), which is exactly what a drizzle builder is. Built as
+  // a Promise with `groupBy` hung off it rather than a hand-rolled thenable.
+  const where = () =>
+    Object.assign(Promise.resolve([{ totalCount: 7, docSum: 42, sizeSum: 1024 }]), {
+      groupBy: async () => [] as unknown[],
+    })
+  const chain = { from: () => chain, where } as { from: () => unknown; where: typeof where }
+  return {
+    selects,
+    db: {
+      select: () => {
+        selects.count += 1
+        return chain
+      },
+    },
+  }
+}
+
+function caller(capabilities: Caps, db: unknown = fakeDb().db) {
+  return datasetRouter.createCaller({ db, capabilities, session: SESSION } as never)
+}
+
+beforeEach(() => {
+  inArraySpy.mockReset()
+  notInArraySpy.mockReset()
+  datasetService.getAvailableEmbeddingOptions.mockClear()
+})
+
+describe('dataset.getOrganizationStats — the org-wide aggregate is SCOPED, not coarse-gated', () => {
+  it('narrows to an ALLOW-LIST for a member whose only access is one shared dataset', async () => {
+    // THE LEAK THIS CLOSES. Before item 5b this member held no `datasets.view`
+    // and got a 403; after it they hold the derived key, so without the scope
+    // they would have received counts and byte sizes for every dataset in the
+    // org — including the ones they cannot open.
+    await caller(caps({ rows: { [SHARED]: ResourcePermission.view } })).getOrganizationStats()
+    expect(inArraySpy).toHaveBeenCalled()
+    expect(inArraySpy.mock.calls[0]?.[1]).toEqual([SHARED])
+    // An allow-list is the whole filter — nothing is expressed as an exclusion.
+    expect(notInArraySpy).not.toHaveBeenCalled()
+  })
+
+  it('returns zeros WITHOUT querying when the member may see no dataset at all', async () => {
+    const { db, selects } = fakeDb()
+    const stats = await caller(caps({ rows: {} }), db).getOrganizationStats()
+    expect(stats).toEqual({ total: 0, byStatus: {}, totalDocuments: 0, totalSize: 0n })
+    expect(selects.count).toBe(0)
+  })
+
+  it('excludes the restricted datasets for a member with the area open', async () => {
+    await caller(
+      caps({ areaLevel: Level.Read, rows: { [OTHER]: ResourcePermission.none } })
+    ).getOrganizationStats()
+    expect(notInArraySpy.mock.calls[0]?.[1]).toEqual([OTHER])
+    expect(inArraySpy).not.toHaveBeenCalled()
+  })
+
+  it('does not narrow at all for an unrestricted org', async () => {
+    await caller(caps({ areaLevel: Level.Full })).getOrganizationStats()
+    expect(inArraySpy).not.toHaveBeenCalled()
+    expect(notInArraySpy).not.toHaveBeenCalled()
+  })
+
+  it('OWNER sees everything, unnarrowed', async () => {
+    await caller(
+      caps({ role: 'OWNER', rows: { [OTHER]: ResourcePermission.none } })
+    ).getOrganizationStats()
+    expect(inArraySpy).not.toHaveBeenCalled()
+    expect(notInArraySpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('dataset.getAvailableEmbeddingOptions — instance-scoped, not coarse-gated', () => {
+  it('succeeds for the dataset the member was actually granted', async () => {
+    await expect(
+      caller(caps({ rows: { [SHARED]: ResourcePermission.view } })).getAvailableEmbeddingOptions({
+        datasetId: SHARED,
+      })
+    ).resolves.toEqual({ systemDefault: 'openai:text-embed-3' })
+    expect(datasetService.getAvailableEmbeddingOptions).toHaveBeenCalledTimes(1)
+  })
+
+  it('is refused for a dataset the member was NOT granted, despite the derived key', async () => {
+    // The member holds `datasets.view` (derived from the SHARED grant) — the
+    // exact caller the old coarse assert would have waved through.
+    const member = caps({ rows: { [SHARED]: ResourcePermission.view } })
+    expect(member.can(PermissionKey.datasetsView)).toBe(true)
+    await expect(
+      caller(member).getAvailableEmbeddingOptions({ datasetId: OTHER })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(datasetService.getAvailableEmbeddingOptions).not.toHaveBeenCalled()
+  })
+
+  it('is refused for a dataset restricted to `none`', async () => {
+    await expect(
+      caller(
+        caps({ areaLevel: Level.Full, rows: { [OTHER]: ResourcePermission.none } })
+      ).getAvailableEmbeddingOptions({ datasetId: OTHER })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(datasetService.getAvailableEmbeddingOptions).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/server/api/routers/dataset.ts
+++ b/apps/web/src/server/api/routers/dataset.ts
@@ -10,7 +10,7 @@ import { onCacheEvent } from '@auxx/lib/cache'
 import { DatasetService } from '@auxx/lib/datasets'
 import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
-import { and, count, eq, sum } from 'drizzle-orm'
+import { and, count, eq, inArray, notInArray, sum } from 'drizzle-orm'
 import { z } from 'zod'
 import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
 
@@ -356,15 +356,29 @@ export const datasetRouter = createTRPCRouter({
     if (!organizationId) {
       throw new Error('No organization found')
     }
-    // Org-wide aggregate — no single instance to key on; gate on the coarse
-    // `datasets` area Read rung.
-    ctx.capabilities.assert(PermissionKey.datasetsView)
+    // NOT a coarse `datasetsView` assert. The area Read rung is now SYNTHESIZED
+    // from a member's instance grants (`UserCapabilities.instanceDerivedKeys`),
+    // so a member shared exactly ONE dataset holds `datasets.view` — and this
+    // is an org-wide aggregate, which under that key would have handed them
+    // counts, document totals and byte sizes for every dataset in the org.
+    //
+    // Scoped instead, the same way `list` is: the totals describe exactly the
+    // datasets the member may open, so the stat tiles agree with the grid
+    // beneath them. A member with no datasets at all gets zeros rather than a
+    // 403, matching `list`'s empty page (the landing page owns the "No Access"
+    // surface).
+    const scope = ctx.capabilities.instanceListScope('dataset')
+    if (scope.kind === 'none') {
+      return { total: 0, byStatus: {} as Record<string, number>, totalDocuments: 0, totalSize: 0n }
+    }
     // Get overall counts and stats from the database.
     // Managed datasets (KB-synced private datasets) are hidden from /app/datasets and
     // excluded here so the totals match what the user actually sees and can manage.
     const userDatasetFilter = and(
       eq(schema.Dataset.organizationId, organizationId),
-      eq(schema.Dataset.isManaged, false)
+      eq(schema.Dataset.isManaged, false),
+      scope.excludeIds?.length ? notInArray(schema.Dataset.id, scope.excludeIds) : undefined,
+      scope.includeIds ? inArray(schema.Dataset.id, scope.includeIds) : undefined
     )
     const [{ totalCount }] = await ctx.db
       .select({ totalCount: count() })
@@ -399,18 +413,26 @@ export const datasetRouter = createTRPCRouter({
     }
   }),
   /**
-   * Get available embedding options for organization
+   * Get the org's default embedding model, for one dataset's settings form.
+   *
+   * Takes a `datasetId` and asserts per instance. It used to be an instance-LESS
+   * query gated on the coarse `datasetsView` rung, which stopped being a real
+   * gate once that rung became derivable from a single instance grant — and this
+   * returns org-level AI configuration, not dataset content. Its only caller is
+   * the per-dataset Embedding settings section, which always has the dataset in
+   * hand, so naming it costs nothing and makes the gate honest.
    */
-  getAvailableEmbeddingOptions: capabilityProcedure.query(async ({ ctx }) => {
-    const organizationId = ctx.session.user.defaultOrganizationId
-    if (!organizationId) {
-      throw new Error('No organization found')
-    }
-    // Org-wide option list — gate on the coarse `datasets` area Read rung.
-    ctx.capabilities.assert(PermissionKey.datasetsView)
-    const datasetService = new DatasetService(ctx.db)
-    return await datasetService.getAvailableEmbeddingOptions(organizationId)
-  }),
+  getAvailableEmbeddingOptions: capabilityProcedure
+    .input(z.object({ datasetId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const organizationId = ctx.session.user.defaultOrganizationId
+      if (!organizationId) {
+        throw new Error('No organization found')
+      }
+      ctx.capabilities.assertViewInstance('dataset', input.datasetId)
+      const datasetService = new DatasetService(ctx.db)
+      return await datasetService.getAvailableEmbeddingOptions(organizationId)
+    }),
   /**
    * Get recommended search configuration for a dataset
    */

--- a/apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
+++ b/apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
@@ -1,7 +1,7 @@
 // apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
 
 import { ResourcePermission } from '@auxx/database/enums'
-import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { Area, expandLevelsToKeys, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -25,7 +25,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  *  3. area `None` + an explicit `'none'` restriction ⇒ denied, absent from list;
  *  4. OWNER unaffected.
  *
- * Plus the hole the type-blind front-door waiver could have opened: a
+ * Plus the hole the derived Read rung must not open (handoff item 5b, which
+ * replaced the type-blind front-door waiver this file was written against): a
  * `workflows: None` member holding a grant reaches `permissionProcedure`'s Read
  * rung, but must NOT reach the Manage rung that fronts `create` — which has no
  * instance to assert on.
@@ -224,32 +225,23 @@ vi.mock('@auxx/lib/permissions', async () => {
 })
 
 /**
- * Mirrors the REAL `permissionProcedure` gate from `trpc.ts`, including the plan
- * 25 §2 waiver — without it, `workflow.getById` would 403 at the front door for
- * exactly the member this file is about, and every case below would pass for the
- * wrong reason. Only the plan-AND and the `getCapabilities` read are dropped
- * (ctx already carries the set).
+ * Mirrors the REAL `permissionProcedure` gate from `trpc.ts`: a plain
+ * `capabilities.assert(key)`. The plan 25 §2 waiver that used to sit here is
+ * GONE (handoff item 5b) — `workflow.getById` reaches the member this file is
+ * about because they now genuinely hold the derived `workflowsView` key, which
+ * {@link caps} synthesizes below exactly as `composeUserCapabilities` does. Only
+ * the plan-AND and the `getCapabilities` read are dropped (ctx carries the set).
  */
 vi.mock('~/server/api/trpc', async () => {
   const { initTRPC } = await import('@trpc/server')
   const t = initTRPC.context<Record<string, unknown>>().create()
-  const { INSTANCE_ACCESS_VIEW_KEYS } = await import(
-    '@auxx/lib/permissions/capabilities/instance-access'
-  )
   return {
     createTRPCRouter: t.router,
     capabilityProcedure: t.procedure,
     protectedProcedure: t.procedure,
     permissionProcedure: (key: string) =>
       t.procedure.use(({ ctx, next }) => {
-        const capabilities = (
-          ctx as {
-            capabilities: { assert: (k: string) => void; hasAnyInstanceGrant: () => boolean }
-          }
-        ).capabilities
-        const waived =
-          INSTANCE_ACCESS_VIEW_KEYS.has(key as never) && capabilities.hasAnyInstanceGrant()
-        if (!waived) capabilities.assert(key)
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
         return next()
       }),
     notDemo:
@@ -283,6 +275,17 @@ function caps(opts: {
   role?: 'MEMBER' | 'OWNER'
 }) {
   const rows = opts.rows ?? {}
+  // The item-5b derived Read rung, reproduced exactly as `composeUserCapabilities`
+  // computes it: any ≥`view` row on this area's resource synthesizes the area's
+  // Read key (full seat, so no ceiling clamp applies). This is what lets a member
+  // composing the area to `None` past `permissionProcedure`'s coarse assert now
+  // that the waiver is gone.
+  const derivedReadKey = PERMISSION_AREAS[opts.area].rungs.find((r) => r.level === Level.Read)
+    ?.keys[0]
+  const derived =
+    derivedReadKey && Object.values(rows).some((p) => p !== ResourcePermission.none)
+      ? [derivedReadKey]
+      : []
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [opts.area]: opts.areaLevel ?? Level.None })),
     {},
@@ -292,7 +295,9 @@ function caps(opts: {
     undefined,
     undefined,
     rows,
-    new Set(Object.keys(rows))
+    new Set(Object.keys(rows)),
+    undefined,
+    new Set(derived)
   )
 }
 
@@ -404,19 +409,19 @@ describe.each(FAMILIES)('$name — an explicit grant overrides the area-None flo
   })
 })
 
-describe('the front-door waiver is scoped to the Read rung (no create hole)', () => {
+describe('the derived Read rung is scoped to the Read rung (no create hole)', () => {
   const granted = () => caps({ area: Area.workflows, rows: { [SHARED]: ResourcePermission.admin } })
 
   it('a `workflows: None` member holding an admin grant reaches the Read-rung procedure', async () => {
-    // `permissionProcedure(workflowsView)` waives its coarse assert, and
-    // `assertViewInstance` then lets them through on their own row.
+    // The composer DERIVES `workflowsView` from their instance grant, so the
+    // coarse assert passes, and `assertViewInstance` then judges the row itself.
     await expect(wf(granted()).getById({ id: SHARED })).resolves.toBeDefined()
   })
 
   it('…but is still refused `create`, which sits on the Manage rung', async () => {
     // `create` has NO instance to assert on, so the coarse rung is the only
-    // gate. Widening the waiver past the Read rung would hand every grant
-    // holder the ability to create workflows in an area they compose to None.
+    // gate. Deriving anything past the Read rung would hand every grant holder
+    // the ability to create workflows in an area they compose to None.
     await expect(wf(granted()).create({ name: 'x', enabled: false })).rejects.toMatchObject(
       FORBIDDEN
     )
@@ -430,13 +435,10 @@ describe('the front-door waiver is scoped to the Read rung (no create hole)', ()
   })
 
   it('a member holding ONLY an explicit `none` row is refused too', async () => {
-    // These two are the safety argument for the waiver's looseness, not a test
-    // OF it: the waiver grants nothing, so widening it (e.g.
-    // `hasAnyInstanceGrant` returning true unconditionally) changes NO router
-    // outcome — `assertViewInstance` denies the same callers either way. The
-    // waiver's own inputs are pinned as unit assertions in
-    // `packages/lib/.../capability-set-instance.test.ts`, which is the only
-    // place a widening can be caught.
+    // Denied TWICE over now: a `none` row derives no Read key (so the coarse
+    // assert fires), and `assertViewInstance` would deny anyway. The derived
+    // key's own inputs — Read rung only, type-aware, seat-clamped — are pinned
+    // in `packages/lib/.../capability-set-instance.test.ts`.
     await expect(
       wf(caps({ area: Area.workflows, rows: { [OTHER]: ResourcePermission.none } })).getById({
         id: SHARED,

--- a/apps/web/src/server/api/routers/workflow-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/workflow-instance-access.test.ts
@@ -1,7 +1,7 @@
 // apps/web/src/server/api/routers/workflow-instance-access.test.ts
 
 import { ResourcePermission } from '@auxx/database/enums'
-import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -211,39 +211,28 @@ vi.mock('@auxx/lib/permissions', async () => {
 })
 
 /**
- * The `permissionProcedure` stand-in mirrors the REAL builder's gate: the real
- * `capabilities.assert(key)`, WAIVED for the `INSTANCE_ACCESS_VIEW_KEYS` when the
- * member holds any instance grant (plan 25 §2 — otherwise a `workflows: None`
- * member with one explicit grant 403s at the front door and the grant is inert
- * all over again). Kept in lockstep with `trpc.ts`; only the plan-AND and the
- * `getCapabilities` read are dropped, since ctx carries the set already.
+ * The `permissionProcedure` stand-in mirrors the REAL builder's gate: a plain
+ * `capabilities.assert(key)`. There is no waiver any more (handoff item 5b) —
+ * a `workflows: None` member holding one explicit grant now genuinely HOLDS
+ * `workflowsView`, because `composeUserCapabilities` derives that Read rung from
+ * their instance grants. Kept in lockstep with `trpc.ts`; only the plan-AND and
+ * the `getCapabilities` read are dropped, since ctx carries the set already.
  *
  * So the coarse rung on the procedure builder is under test alongside the
  * per-instance asserts in the bodies. (The dataset/KB files couldn't do this —
  * their routers assert coarse keys inline.) Dropping
- * `permissionProcedure(workflowsManage)` from `create` fails a case below, and
- * so does widening the waiver to the Manage rung.
+ * `permissionProcedure(workflowsManage)` from `create` fails a case below.
  */
 vi.mock('~/server/api/trpc', async () => {
   const { initTRPC } = await import('@trpc/server')
   const t = initTRPC.context<Record<string, unknown>>().create()
-  const { INSTANCE_ACCESS_VIEW_KEYS } = await import(
-    '@auxx/lib/permissions/capabilities/instance-access'
-  )
   return {
     createTRPCRouter: t.router,
     capabilityProcedure: t.procedure,
     protectedProcedure: t.procedure,
     permissionProcedure: (key: string) =>
       t.procedure.use(({ ctx, next }) => {
-        const capabilities = (
-          ctx as {
-            capabilities: { assert: (k: string) => void; hasAnyInstanceGrant: () => boolean }
-          }
-        ).capabilities
-        const waived =
-          INSTANCE_ACCESS_VIEW_KEYS.has(key as never) && capabilities.hasAnyInstanceGrant()
-        if (!waived) capabilities.assert(key)
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
         return next()
       }),
     // The real one blocks demo orgs; irrelevant to capability gating, and it
@@ -296,18 +285,30 @@ function capabilitiesFor(
   } = {}
 ) {
   const instances = opts.instances ?? { [WF_ID]: permission }
+  const seatType = opts.seatType ?? 'full'
+  // Reproduce `composeUserCapabilities`' derived Read rung: any ≥`view` workflow
+  // row synthesizes `workflowsView`, clamped away on a worker seat (workflows is
+  // outside WORKER_AREAS). Without this a `workflows: None` grantee would 403 at
+  // the coarse front door — the exact regression item 5b closes.
+  const derived =
+    seatType !== 'worker' &&
+    Object.values(instances).some((p) => p !== ResourcePermission.none && p !== undefined)
+      ? [PermissionKey.workflowsView]
+      : []
   return new CapabilitySet(
     new Set(
       expandLevelsToKeys({ [Area.workflows]: AREA_LEVEL_OF[opts.areaPermission ?? permission] })
     ),
     {},
     opts.role ?? 'MEMBER',
-    opts.seatType ?? 'full',
+    seatType,
     undefined,
     undefined,
     undefined,
     instances,
-    new Set(Object.keys(instances))
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived)
   )
 }
 

--- a/apps/web/src/server/api/routers/workflow.ts
+++ b/apps/web/src/server/api/routers/workflow.ts
@@ -240,13 +240,14 @@ const ADMIN_ONLY_UPDATE_FIELDS = [
  * Base procedure: `permissionProcedure(workflowsView)` everywhere the instance
  * assert does the real work. That keeps the `FeatureKey.workflows` plan-AND
  * these procedures have always run (`capabilityProcedure` does NOT run it) and
- * costs nothing — `workflowsView` is an `INSTANCE_ACCESS_VIEW_KEYS` member, so
- * `permissionProcedure` waives its coarse assert for a member who holds any
- * instance grant (plan 25 §2) and lets the per-instance assert below decide.
- * **Every procedure on this base MUST assert on a specific instance** — that
- * waiver is what makes the coarse rung non-load-bearing here.
+ * costs nothing — a member composing `workflows: None` who holds one explicit
+ * instance grant genuinely HOLDS `workflowsView`, because the composer derives
+ * that Read rung from their grants (handoff item 5b, replacing plan 25 §2's
+ * front-door waiver). **Every procedure on this base MUST assert on a specific
+ * instance**, and must NOT return org-wide data: the derived key says only "this
+ * member has some workflow access", never which workflow.
  * `create`/`createForResource` have no instance to assert on and therefore sit
- * on `workflowsManage`, which is NOT waived. `list` and `getManualWorkflows` are
+ * on `workflowsManage`, which is never derived. `list` and `getManualWorkflows` are
  * the two exceptions in the other direction: they render passively inside other
  * screens, so they use `capabilityProcedure` and FILTER rather than assert (plan
  * 30 §2.2 — a 403 there is a broken screen, not a denied action).

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -15,7 +15,6 @@ import {
   FeatureKey,
   FeaturePermissionService,
   getCapabilities,
-  INSTANCE_ACCESS_VIEW_KEYS,
   PERMISSION_REGISTRY_MAP,
   type PermissionKey,
 } from '@auxx/lib/permissions'
@@ -399,27 +398,19 @@ export const superAdminProcedure = protectedProcedure.use(({ ctx, next }) => {
  * `featureKey`, asserts the key, and attaches the resolved set as
  * `ctx.capabilities` so router bodies reuse it with zero re-resolve.
  *
- * **The instance-grant waiver (plan 25 §2).** Since an explicit instance
- * `ResourceAccess` row now beats the area floor, a member composing e.g.
- * `workflows: None` who was granted `read` on ONE workflow holds no
- * `workflowsView` key — and would 403 at this front door before the procedure's
- * own `assertViewInstance` ever ran, making the grant inert all over again. So
- * for the `Level.Read` rung keys of the instance-access areas
- * ({@link INSTANCE_ACCESS_VIEW_KEYS}) the coarse assert is WAIVED when the member
- * holds any instance grant at all.
+ * **There is no instance-grant waiver here any more** (handoff item 5b, replacing
+ * plan 25 §2's). A member composing `workflows: None` who holds one explicit
+ * `view` grant now genuinely HOLDS `workflowsView`: `composeUserCapabilities`
+ * synthesizes the area's Read rung from their instance grants, type-aware, at
+ * composition time. So the plain assert below is correct for them and the
+ * type-blind waiver — which any org with ≥1 dashboard turned into an open door
+ * on all four instance-access areas — is gone.
  *
- * The waiver is deliberately loose in two ways, both bounded:
- *  - **Type-blind.** `instanceAccess` keys on the bare instance CUID with no
- *    resource type, so "holds a *workflow* grant" is unanswerable without
- *    changing the cached blob shape — which would force a `user:capabilities:vN`
- *    bump. A member holding only a dataset grant therefore also gets through the
- *    workflow door, and is stopped one line later by `assertViewInstance`.
- *  - **Front door only.** It grants NOTHING. Every procedure behind these keys
- *    asserts on a specific instance immediately after; that is a real
- *    precondition, which is why the waiver is scoped to the Read rung — the
- *    higher rungs front the instance-LESS actions (`workflowsManage` fronts
- *    `create`/`createForResource`, which have no instance to assert on) and
- *    stay strict.
+ * The derived key is a FRONT DOOR only: it says the member has some access
+ * inside the feature, never which instance. Every procedure behind an
+ * instance-access Read key must still assert per instance, and any procedure
+ * that returns ORG-WIDE data behind one must scope that data to the instances
+ * the member can view (see `dataset.getOrganizationStats`).
  *
  * The `FeatureKey` plan-AND is unaffected and still runs first — it is the whole
  * reason instance-scoped procedures use this rather than `capabilityProcedure`.
@@ -437,8 +428,7 @@ export const permissionProcedure = (key: PermissionKey) =>
       )
     }
     const capabilities = await getCapabilities(ctx.session.userId, ctx.session.organizationId)
-    const waived = INSTANCE_ACCESS_VIEW_KEYS.has(key) && capabilities.hasAnyInstanceGrant()
-    if (!waived) capabilities.assert(key)
+    capabilities.assert(key)
     return next({ ctx: { capabilities } })
   })
 

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -147,7 +147,26 @@ export const USER_CACHE_KEY_CONFIG: Record<
   // member's profile no longer grants — fail-OPEN on a stale blob, the same
   // dangerous direction as v7→v8, so this bump ships in the SAME change as the
   // strip rather than being treated as cosmetic.
+  // v11: ONE bump for the whole accumulated instance-access batch, all three
+  // parts of which change what a v10 blob contains:
+  //   1. `dashboards.edit` (#1344) split the dashboards ladder into
+  //      Read/Edit/Full. A v10 blob was expanded against the 2-rung ladder, so
+  //      it lacks the key entirely and a Full-level holder cannot edit widgets.
+  //   2. `workflows.view` / `workflows.edit` (#1345) split the single-rung
+  //      workflows area the same way, and `workflow` joined
+  //      `INSTANCE_ACCESS_RESOURCES`.
+  //   3. `UserCapabilities` gained `instanceDerivedKeys` (item 5b) — the area
+  //      Read rungs synthesized from a member's own instance grants, which is
+  //      what makes `can('workflows.view')` true for a member whose only access
+  //      is one shared workflow. A v10 blob has no such field, so every coarse
+  //      gate (sidebar, cmd+K, the KB/Dashboards landing redirects) would keep
+  //      firing against them until the 24h TTL expired.
+  // All three fail CLOSED on a stale blob (a missing key denies), so this is a
+  // lost-access bump rather than a lost-restriction one — but it is still
+  // mandatory: a dev flush is NOT a substitute, because during a rollout a
+  // draining old instance repopulates the same keyspace, which is the entire
+  // reason `vN` exists.
   // NOTE: bump this whenever the registry's area/key set or the UserCapabilities
   // shape changes, so a rollout can't leave members on a stale key set.
-  userCapabilities: { prefix: 'user:capabilities:v10', ttlSeconds: ONE_DAY },
+  userCapabilities: { prefix: 'user:capabilities:v11', ttlSeconds: ONE_DAY },
 }

--- a/packages/lib/src/permissions/capabilities/admin-profile-parity.test.ts
+++ b/packages/lib/src/permissions/capabilities/admin-profile-parity.test.ts
@@ -92,7 +92,11 @@ function composeAdmin(
     groupLevels?: Array<Partial<Record<Area, Level>>>
     userLevels?: Partial<Record<Area, Level>>
     typeAccessRows?: Array<{ entityDefinitionId: string; permission: ResourcePermission }>
-    instanceAccessRows?: Array<{ entityInstanceId: string; permission: ResourcePermission }>
+    instanceAccessRows?: Array<{
+      entityDefinitionId: string
+      entityInstanceId: string
+      permission: ResourcePermission
+    }>
   } = {}
 ) {
   const seed = systemProfileSeed('admin')
@@ -117,7 +121,11 @@ function adminAccess(
     restricted?: string[]
     restrictedInstances?: string[]
     typeAccessRows?: Array<{ entityDefinitionId: string; permission: ResourcePermission }>
-    instanceAccessRows?: Array<{ entityInstanceId: string; permission: ResourcePermission }>
+    instanceAccessRows?: Array<{
+      entityDefinitionId: string
+      entityInstanceId: string
+      permission: ResourcePermission
+    }>
   } = {}
 ): ResolvedRecordAccess {
   const caps = composeAdmin({
@@ -200,11 +208,18 @@ describe('ADMIN parity — areas (byte-identical to the removed short-circuit)',
     )
   })
 
-  it('the composed blob carries exactly three fields (no ceiling rides out)', () => {
+  it('the composed blob carries exactly four fields (no ceiling rides out)', () => {
     // Plan 20 §2.a.2: `ceilingDefs` is gone from `UserCapabilities`. Pinned here
     // as a shape assertion because a re-added field would silently ride into the
     // cached blob and force another `user:capabilities:vN` bump.
-    expect(Object.keys(composeAdmin()).sort()).toEqual(['defAccess', 'instanceAccess', 'keys'])
+    // `instanceDerivedKeys` joined the shape in item 5b — and did force the
+    // v10 → v11 bump, which is exactly the tripwire this assertion is.
+    expect(Object.keys(composeAdmin()).sort()).toEqual([
+      'defAccess',
+      'instanceAccess',
+      'instanceDerivedKeys',
+      'keys',
+    ])
   })
 })
 
@@ -289,7 +304,13 @@ describe('ADMIN parity — instance-access resources', () => {
     // nothing at all on a private one. OWNER remains the recovery path.
     const shared = adminAccess({
       restrictedInstances: ['dash_1'],
-      instanceAccessRows: [{ entityInstanceId: 'dash_1', permission: ResourcePermission.view }],
+      instanceAccessRows: [
+        {
+          entityDefinitionId: 'dashboard',
+          entityInstanceId: 'dash_1',
+          permission: ResourcePermission.view,
+        },
+      ],
     })
     expect(effectiveInstanceLevel(shared, 'dashboard', 'dash_1')).toBe(ResourcePermission.view)
     expect(effectiveInstanceLevel({ ...shared, role: 'OWNER' }, 'dashboard', 'dash_1')).toBe(

--- a/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
@@ -6,9 +6,9 @@ import { describe, expect, it } from 'vitest'
 import { CapabilitySet } from './capability-set'
 import { composeUserCapabilities } from './compose-user-capabilities'
 import { effectiveInstanceLevel, toResolvedRecordAccess } from './entity-access'
-import { INSTANCE_ACCESS_VIEW_KEYS, type InstanceAccessKey } from './instance-access'
-import { Area, Level, PermissionKey } from './registry'
-import { MEMBER_BASELINE_LEVELS } from './seat-policy'
+import { INSTANCE_ACCESS_READ_KEYS, type InstanceAccessKey } from './instance-access'
+import { Area, areaLevelFromKeys, Level, PermissionKey } from './registry'
+import { MEMBER_BASELINE_LEVELS, SEAT_CEILINGS } from './seat-policy'
 
 /**
  * Per-INSTANCE enforcement for the instance-access resources (datasets / KBs /
@@ -42,7 +42,12 @@ interface MemberOpts {
    * grantee union (`user` + `role:org_member` + bound profile + groups) — i.e.
    * what `computeUserCapabilities`' second query returns for them.
    */
-  rows?: Array<{ entityInstanceId: string; permission: ResourcePermission }>
+  rows?: Array<{
+    /** The instance-access resource the row is for; defaults to `'dataset'`. */
+    entityDefinitionId?: InstanceAccessKey
+    entityInstanceId: string
+    permission: ResourcePermission
+  }>
   /**
    * The org-wide "has ≥1 instance row for anyone" set
    * (`restrictedInstanceIdsProvider`). Defaults to the instances in `rows`;
@@ -59,7 +64,7 @@ function member(opts: MemberOpts = {}) {
     seatType,
     profileLevels: opts.profileLevels ?? MEMBER_BASELINE_LEVELS,
     typeAccessRows: [],
-    instanceAccessRows: opts.rows ?? [],
+    instanceAccessRows: (opts.rows ?? []).map((row) => ({ entityDefinitionId: 'dataset', ...row })),
   })
   const restricted = new Set(
     opts.restrictedInstances ?? (opts.rows ?? []).map((r) => r.entityInstanceId)
@@ -74,7 +79,8 @@ function member(opts: MemberOpts = {}) {
     (id) => id,
     caps.instanceAccess,
     restricted,
-    {}
+    {},
+    new Set(caps.instanceDerivedKeys)
   )
   // The client only ever sees the wire snapshot — build its view from that, not
   // from the composed blob, so a field dropped in serialization shows up here.
@@ -299,54 +305,142 @@ describe('OWNER regression (plan 24 §A.4)', () => {
 })
 
 /**
- * `hasAnyInstanceGrant()` + `INSTANCE_ACCESS_VIEW_KEYS` — the two halves of
- * `permissionProcedure`'s front-door waiver (plan 25 §2).
+ * The area Read rung DERIVED from instance grants (handoff item 5b) — the
+ * replacement for `permissionProcedure`'s deleted type-blind waiver.
  *
- * Pinned as UNIT assertions rather than through a router on purpose: the waiver
- * grants nothing, so it is behaviorally invisible downstream — every procedure
- * behind those keys asserts on a specific instance immediately after, and denies
- * the same callers either way. That invisibility IS the safety argument, and it
- * is also why widening the waiver has to be caught here.
+ * Driven through the real composer into a real `CapabilitySet` and its wire
+ * snapshot, because the whole point is behavioral: `can('<area>.view')` must
+ * become true for a member whose only access is one shared instance, so the
+ * sidebar / cmd+K / landing-page guards and the coarse procedure assert all stop
+ * firing against them.
+ *
+ * The four properties that must hold together — take any one away and this is
+ * either useless or a leak:
+ *  1. a ≥`view` grant derives the Read rung, at any grant strength;
+ *  2. it derives NOTHING above Read (those rungs front instance-LESS actions);
+ *  3. it is TYPE-AWARE (a dashboard grant is not a workflows key);
+ *  4. it does NOT change the member's AREA LEVEL — otherwise every row-less
+ *     instance of a `baselineAtCreate: false` resource falls back to `view`.
  */
-describe('the permissionProcedure waiver inputs (plan 25 §2)', () => {
-  it('hasAnyInstanceGrant is true for a row that reaches view, at any rung', () => {
-    for (const permission of ['view', 'edit', 'admin'] as const) {
-      expect(
-        member({ rows: [{ entityInstanceId: 'ds_x', permission }] }).server.hasAnyInstanceGrant()
-      ).toBe(true)
-    }
+describe('the area Read rung derived from instance grants (item 5b)', () => {
+  /** A member with the named area shut on their profile. */
+  const closed = (area: Area, rows: MemberOpts['rows'], seatType?: SeatType) =>
+    member({
+      seatType,
+      profileLevels: { ...MEMBER_BASELINE_LEVELS, [area]: Level.None },
+      rows,
+    })
+
+  it.each([
+    'view',
+    'edit',
+    'admin',
+  ] as const)('a `%s` grant on ONE dataset makes can(datasets.view) true with the area shut', (permission) => {
+    const m = closed(Area.datasets, [{ entityInstanceId: 'ds_x', permission }])
+    expect(m.server.can(PermissionKey.datasetsView)).toBe(true)
+    expect(m.caps.instanceDerivedKeys).toEqual([PermissionKey.datasetsView])
+    // The grant is real, not just a front door.
+    expect(m.server.canViewInstance('dataset', 'ds_x')).toBe(true)
   })
 
-  it('hasAnyInstanceGrant is false with no rows, and false for `none` rows only', () => {
-    // A restriction is not a grant — it must not open the front door.
-    expect(member().server.hasAnyInstanceGrant()).toBe(false)
+  it('an `admin` grant derives the Read rung ONLY — never edit/manage', () => {
+    // `datasetsManage` fronts dataset CREATION, which has no instance to assert
+    // on. Deriving it from one shared instance would hand out org-wide authoring.
+    const m = closed(Area.datasets, [{ entityInstanceId: 'ds_x', permission: 'admin' }])
+    expect(m.server.can(PermissionKey.datasetsView)).toBe(true)
+    expect(m.server.can(PermissionKey.datasetsEdit)).toBe(false)
+    expect(m.server.can(PermissionKey.datasetsManage)).toBe(false)
+  })
+
+  it('an explicit `none` restriction derives NOTHING (a restriction is not a grant)', () => {
+    const m = closed(Area.datasets, [{ entityInstanceId: 'ds_locked', permission: 'none' }])
+    expect(m.caps.instanceDerivedKeys).toEqual([])
+    expect(m.server.can(PermissionKey.datasetsView)).toBe(false)
+  })
+
+  it('no rows at all derives nothing', () => {
+    expect(closed(Area.datasets, []).server.can(PermissionKey.datasetsView)).toBe(false)
+  })
+
+  it('is TYPE-AWARE: a dashboard grant does not open the workflows door', () => {
+    // The looseness this replaces: dashboards are `baselineAtCreate: true`, so
+    // EVERY dashboard writes a `role:org_member @ view` row at create. Under the
+    // old type-blind waiver that made "holds an instance grant" true for
+    // practically every member of every org, and the Read rung of all four
+    // instance-access areas decorative.
+    const m = member({
+      profileLevels: {
+        ...MEMBER_BASELINE_LEVELS,
+        [Area.workflows]: Level.None,
+        [Area.datasets]: Level.None,
+        [Area.knowledgeBase]: Level.None,
+      },
+      rows: [{ entityDefinitionId: 'dashboard', entityInstanceId: 'dash_x', permission: 'view' }],
+    })
+    expect(m.caps.instanceDerivedKeys).toEqual([PermissionKey.dashboardsView])
+    expect(m.server.can(PermissionKey.workflowsView)).toBe(false)
+    expect(m.server.can(PermissionKey.datasetsView)).toBe(false)
+    expect(m.server.can(PermissionKey.knowledgeBaseView)).toBe(false)
+  })
+
+  it('the SEAT CEILING still dominates — a worker seat derives nothing', () => {
+    // `workflows`/`datasets` are outside WORKER_AREAS, so the ceiling shuts them
+    // regardless of any grant. Without this check the member would hold a front
+    // door key into an area every enforcement point then denies — a 403 maze.
+    expect(SEAT_CEILINGS.worker[Area.datasets]).toBe(Level.None)
+    const m = closed(Area.datasets, [{ entityInstanceId: 'ds_x', permission: 'admin' }], 'worker')
+    expect(m.caps.instanceDerivedKeys).toEqual([])
+    expect(m.server.can(PermissionKey.datasetsView)).toBe(false)
+    expect(m.server.canViewInstance('dataset', 'ds_x')).toBe(false)
+  })
+
+  it('OWNER is unaffected — holds everything, derives nothing', () => {
+    const m = member({ role: 'OWNER', rows: [{ entityInstanceId: 'ds_x', permission: 'view' }] })
+    expect(m.caps.instanceDerivedKeys).toEqual([])
+    expect(m.server.can(PermissionKey.datasetsView)).toBe(true)
+    expect(m.server.can(PermissionKey.datasetsManage)).toBe(true)
+  })
+
+  it('THE LEAK GUARD: the derived key does NOT raise the area level', () => {
+    // `areaLevelFromKeys` is the absent-row fallback `effectiveInstanceLevel` and
+    // `instanceListScope` read. If the derived `datasets.view` were folded into
+    // `keys`, the area would read `Level.Read` and — `dataset` being
+    // `baselineAtCreate: false` — EVERY dataset in the org with no explicit row
+    // would resolve to `view`. "Shared one dataset" would silently mean "can see
+    // them all". This is the assertion that keeps the two key sets apart.
+    const m = closed(Area.datasets, [{ entityInstanceId: 'ds_x', permission: 'admin' }])
+    expect(m.server.areaLevel(Area.datasets)).toBe(Level.None)
+    expect(areaLevelFromKeys(new Set(m.caps.keys), Area.datasets)).toBe(Level.None)
+    expect(m.caps.keys).not.toContain(PermissionKey.datasetsView)
+    // …and the row-less dataset stays invisible on BOTH resolvers.
+    expect(levelFor(m, 'dataset', 'ds_someone_elses')).toBeUndefined()
+    expect(m.server.instanceListScope('dataset')).toEqual({
+      kind: 'include',
+      includeIds: ['ds_x'],
+    })
+  })
+
+  it('survives the wire round-trip and the client `can()` union rebuilds it', () => {
+    const m = closed(Area.datasets, [{ entityInstanceId: 'ds_x', permission: 'view' }])
+    const snapshot = m.server.toClientCapabilities()
+    expect(snapshot.instanceDerivedKeys).toEqual([PermissionKey.datasetsView])
+    // The client `can()` reads the union (capabilities-provider.tsx)…
     expect(
-      member({
-        rows: [{ entityInstanceId: 'ds_locked', permission: 'none' }],
-      }).server.hasAnyInstanceGrant()
-    ).toBe(false)
+      new Set<string>([...snapshot.keys, ...(snapshot.instanceDerivedKeys ?? [])]).has(
+        PermissionKey.datasetsView
+      )
+    ).toBe(true)
+    // …while `toResolvedRecordAccess` keeps `keys` pure, so the client mirror of
+    // the area fallback agrees with the server's.
+    expect(m.client.keys.has(PermissionKey.datasetsView)).toBe(false)
   })
 
-  it('the waivable keys are exactly the Read rung of each instance-access area', () => {
-    // The scope that closes the create hole: `workflowsManage` fronts `create`,
-    // which has NO instance to assert on, so waiving it would let a `None`-area
-    // grant holder create workflows.
-    expect([...INSTANCE_ACCESS_VIEW_KEYS].sort()).toEqual(
-      [
-        PermissionKey.datasetsView,
-        PermissionKey.knowledgeBaseView,
-        PermissionKey.dashboardsView,
-        PermissionKey.workflowsView,
-      ].sort()
-    )
-    for (const key of [
-      PermissionKey.workflowsManage,
-      PermissionKey.datasetsManage,
-      PermissionKey.knowledgeBaseManage,
-      PermissionKey.dashboardsManage,
-      PermissionKey.workflowsEdit,
-    ]) {
-      expect(INSTANCE_ACCESS_VIEW_KEYS.has(key)).toBe(false)
-    }
+  it('the derived keys are exactly the Read rung of each instance-access area', () => {
+    expect(INSTANCE_ACCESS_READ_KEYS).toEqual({
+      dataset: [PermissionKey.datasetsView],
+      kb: [PermissionKey.knowledgeBaseView],
+      dashboard: [PermissionKey.dashboardsView],
+      workflow: [PermissionKey.workflowsView],
+    })
   })
 })

--- a/packages/lib/src/permissions/capabilities/capability-set-workflow-instance.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-workflow-instance.test.ts
@@ -38,7 +38,12 @@ interface MemberOpts {
   role?: OrganizationRole
   seatType?: SeatType
   profileLevels?: Partial<Record<Area, Level>>
-  rows?: Array<{ entityInstanceId: string; permission: ResourcePermission }>
+  /** `entityDefinitionId` defaults to `'workflow'` — the resource under test here. */
+  rows?: Array<{
+    entityDefinitionId?: string
+    entityInstanceId: string
+    permission: ResourcePermission
+  }>
   restrictedInstances?: string[]
 }
 
@@ -50,7 +55,10 @@ function member(opts: MemberOpts = {}) {
     seatType,
     profileLevels: opts.profileLevels ?? MEMBER_BASELINE_LEVELS,
     typeAccessRows: [],
-    instanceAccessRows: opts.rows ?? [],
+    instanceAccessRows: (opts.rows ?? []).map((row) => ({
+      entityDefinitionId: 'workflow',
+      ...row,
+    })),
   })
   const restricted = new Set(
     opts.restrictedInstances ?? (opts.rows ?? []).map((r) => r.entityInstanceId)
@@ -65,7 +73,8 @@ function member(opts: MemberOpts = {}) {
     (id) => id,
     caps.instanceAccess,
     restricted,
-    {}
+    {},
+    new Set(caps.instanceDerivedKeys)
   )
   return { caps, server, client: toResolvedRecordAccess(server.toClientCapabilities()) }
 }

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -72,6 +72,14 @@ export class CapabilitySet implements CapabilityView {
    * @param defBaseOverrides Per-def record base for defs whose base comes from
    *                   another Layer-2 area. Canonical `entityDefinitionId`
    *                   keys; `null` means that area is closed.
+   * @param instanceDerivedKeys Coarse Read-rung keys SYNTHESIZED at composition
+   *                   time from the member's instance grants (see
+   *                   {@link import('./compose-user-capabilities').UserCapabilities.instanceDerivedKeys}).
+   *                   Read by {@link can}/{@link has}/{@link assert} ONLY —
+   *                   {@link areaLevel} and {@link resolved} deliberately ignore
+   *                   them, because `keys` is the area-level source of truth
+   *                   that `effectiveInstanceLevel` reads its absent-row
+   *                   fallback from.
    */
   constructor(
     private readonly keys: ReadonlySet<PermissionKey>,
@@ -83,23 +91,39 @@ export class CapabilitySet implements CapabilityView {
     private readonly defIdToDefinitionId: DefIdToSlug = (id) => id,
     private readonly instanceAccess: Readonly<Record<string, ResourcePermission>> = {},
     private readonly restrictedInstanceIds: ReadonlySet<string> = new Set(),
-    private readonly defBaseOverrides: Readonly<Record<string, ResourcePermission | null>> = {}
+    private readonly defBaseOverrides: Readonly<Record<string, ResourcePermission | null>> = {},
+    private readonly instanceDerivedKeys: ReadonlySet<PermissionKey> = new Set()
   ) {}
 
-  /** O(1) Set lookup — whether the member holds `key`. */
+  /**
+   * O(1) Set lookup — whether the member holds `key`, either from their resolved
+   * area levels or as a Read rung derived from an instance grant.
+   *
+   * The derived half is a FRONT DOOR, not an authorization answer: it says only
+   * that the member has *some* access inside that feature, so the coarse gate
+   * (nav, cmd+K, a landing-page guard, `permissionProcedure`) must not deny them
+   * outright. Anything that reads org-wide data behind such a key must scope
+   * itself per instance — see `dataset.getOrganizationStats` for the pattern.
+   */
   can(key: PermissionKey): boolean {
-    return this.keys.has(key)
+    return this.keys.has(key) || this.instanceDerivedKeys.has(key)
   }
 
   /** Alias for {@link can} — reads better at some call sites. */
   has(key: PermissionKey): boolean {
-    return this.keys.has(key)
+    return this.can(key)
   }
 
   /**
    * The member's effective {@link Level} for one {@link Area}, recovered from the
    * already-composed (seat-clamped) key set via {@link areaLevelFromKeys}. Zero
-   * I/O, and by construction identical to what every `can()` gate sees.
+   * I/O.
+   *
+   * Reads `keys` ONLY — never the instance-derived keys. This is the area-level
+   * source of truth `effectiveInstanceLevel` / `instanceListScope` take their
+   * absent-row fallback from, so a member whose only workflow access is one
+   * explicit grant must still report `workflows: None` here. `can()` and this
+   * method therefore disagree for exactly those members, on purpose.
    */
   areaLevel(area: Area): Level {
     return areaLevelFromKeys(this.keys, area)
@@ -110,7 +134,7 @@ export class CapabilitySet implements CapabilityView {
    * lacks `key`. The single enforcement primitive every guard funnels through.
    */
   assert(key: PermissionKey): void {
-    if (this.keys.has(key)) return
+    if (this.can(key)) return
     const label = PERMISSION_REGISTRY_MAP.get(key)?.label ?? key
     throw new ForbiddenError(`You don't have permission to ${label}.`)
   }
@@ -157,6 +181,7 @@ export class CapabilitySet implements CapabilityView {
   toClientCapabilities(): ClientCapabilities {
     return {
       keys: [...this.keys],
+      instanceDerivedKeys: [...this.instanceDerivedKeys],
       defAccess: { ...this.defAccess },
       restrictedEntityDefIds: [...this.restrictedDefIds],
       defBaseOverrides: { ...this.defBaseOverrides },
@@ -307,26 +332,6 @@ export class CapabilitySet implements CapabilityView {
     const areaLevel = areaLevelFromKeys(this.keys, cfg.area)
     if (areaLevel === Level.None) return undefined
     return cfg.baselineAtCreate ? undefined : levelToPermission(areaLevel)
-  }
-
-  /**
-   * Whether this member holds ANY instance grant reaching `view`, across ALL
-   * instance-access resources. Deliberately TYPE-BLIND: `instanceAccess` keys on
-   * the bare instance CUID with no resource type, so the composed blob cannot
-   * answer "does this member hold a *workflow* grant?" without a shape change
-   * (and therefore a `user:capabilities:vN` bump). Zero I/O.
-   *
-   * Used ONLY as the coarse front-door waiver in `permissionProcedure` (plan
-   * 25 §2): a member composing an instance-access area to `None` still has to
-   * reach the procedure whose per-instance assert will judge them. It is safe
-   * because it is scoped to `INSTANCE_ACCESS_VIEW_KEYS` and every
-   * procedure behind those keys asserts on a specific instance immediately
-   * after — it is NOT an authorization answer and must never be used as one.
-   */
-  hasAnyInstanceGrant(): boolean {
-    return Object.values(this.instanceAccess).some((permission) =>
-      satisfiesPermission(permission, ResourcePermission.view)
-    )
   }
 
   /**

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -259,7 +259,9 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
       role: 'USER',
       seatType: 'full',
       typeAccessRows: [],
-      instanceAccessRows: [{ entityInstanceId: 'ds_locked', permission: 'none' }],
+      instanceAccessRows: [
+        { entityDefinitionId: 'dataset', entityInstanceId: 'ds_locked', permission: 'none' },
+      ],
     })
     expect(caps.instanceAccess).toEqual({ ds_locked: 'none' })
   })
@@ -270,8 +272,8 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     // last-wins reducer would leave the person the instance was just shared with
     // sitting on the lockdown marker.
     const rows = [
-      { entityInstanceId: 'ds_locked', permission: 'none' as const },
-      { entityInstanceId: 'ds_locked', permission: 'edit' as const },
+      { entityDefinitionId: 'dataset', entityInstanceId: 'ds_locked', permission: 'none' as const },
+      { entityDefinitionId: 'dataset', entityInstanceId: 'ds_locked', permission: 'edit' as const },
     ]
     for (const instanceAccessRows of [rows, [...rows].reverse()]) {
       const caps = composeUserCapabilities({
@@ -312,7 +314,9 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
       groupLevels: [{ [Area.records]: Level.Full, [Area.workflows]: Level.None }],
       userLevels: { [Area.knowledgeBase]: Level.Full },
       typeAccessRows: [{ entityDefinitionId: 'def_a', permission: 'edit' }],
-      instanceAccessRows: [{ entityInstanceId: 'inst_a', permission: 'none' }],
+      instanceAccessRows: [
+        { entityDefinitionId: 'dataset', entityInstanceId: 'inst_a', permission: 'none' },
+      ],
     })
     for (const userType of ['USER', 'SYSTEM'] as const) {
       const withType = composeUserCapabilities({
@@ -323,7 +327,9 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
         groupLevels: [{ [Area.records]: Level.Full, [Area.workflows]: Level.None }],
         userLevels: { [Area.knowledgeBase]: Level.Full },
         typeAccessRows: [{ entityDefinitionId: 'def_a', permission: 'edit' }],
-        instanceAccessRows: [{ entityInstanceId: 'inst_a', permission: 'none' }],
+        instanceAccessRows: [
+          { entityDefinitionId: 'dataset', entityInstanceId: 'inst_a', permission: 'none' },
+        ],
       })
       expect(withType).toEqual(legacy)
     }
@@ -623,13 +629,22 @@ describe('composeUserCapabilities — permission profiles (doc 19 §2.1)', () =>
           { entityDefinitionId: 'def_locked', permission: 'none' },
         ],
         instanceAccessRows: [
-          { entityInstanceId: 'inst_a', permission: 'none' },
-          { entityInstanceId: 'inst_b', permission: 'edit' },
+          { entityDefinitionId: 'dataset', entityInstanceId: 'inst_a', permission: 'none' },
+          { entityDefinitionId: 'dataset', entityInstanceId: 'inst_b', permission: 'edit' },
         ],
       })
-      expect(Object.keys(caps).sort()).toEqual(['defAccess', 'instanceAccess', 'keys'])
+      expect(Object.keys(caps).sort()).toEqual([
+        'defAccess',
+        'instanceAccess',
+        'instanceDerivedKeys',
+        'keys',
+      ])
       expect(caps).toEqual({
         keys: caps.keys,
+        // OWNER short-circuits and ADMIN already holds `datasets.view` from the
+        // all-Full profile, so nothing is DERIVED for either — the `edit` row on
+        // `inst_b` would derive the Read rung for a member, not for these two.
+        instanceDerivedKeys: role === 'OWNER' ? [] : [PermissionKey.datasetsView],
         defAccess: { def_a: 'admin' },
         instanceAccess: { inst_a: 'none', inst_b: 'edit' },
       })
@@ -656,8 +671,8 @@ describe('composeUserCapabilities — permission profiles (doc 19 §2.1)', () =>
           { entityDefinitionId: 'def_locked', permission: 'none' },
         ],
         instanceAccessRows: [
-          { entityInstanceId: 'inst_a', permission: 'none' },
-          { entityInstanceId: 'inst_b', permission: 'edit' },
+          { entityDefinitionId: 'dataset', entityInstanceId: 'inst_a', permission: 'none' },
+          { entityDefinitionId: 'dataset', entityInstanceId: 'inst_b', permission: 'edit' },
         ],
       })
       expect(caps.keys).toEqual([])
@@ -726,7 +741,9 @@ describe('composeUserCapabilities — AGENT branch composes NOTHING (doc 19 §0.
         { entityDefinitionId: 'def_deals', permission: 'admin' as const },
         { entityDefinitionId: 'def_a', permission: 'view' as const },
       ],
-      instanceAccessRows: [{ entityInstanceId: 'kb_1', permission: 'edit' as const }],
+      instanceAccessRows: [
+        { entityDefinitionId: 'kb', entityInstanceId: 'kb_1', permission: 'edit' as const },
+      ],
     })
     expect(caps.defAccess).toEqual({})
     expect(caps.instanceAccess).toEqual({})
@@ -740,8 +757,8 @@ describe('composeUserCapabilities — AGENT branch composes NOTHING (doc 19 §0.
         { entityDefinitionId: 'def_locked', permission: 'none' as const },
       ],
       instanceAccessRows: [
-        { entityInstanceId: 'inst_a', permission: 'none' as const },
-        { entityInstanceId: 'inst_b', permission: 'edit' as const },
+        { entityDefinitionId: 'dataset', entityInstanceId: 'inst_a', permission: 'none' as const },
+        { entityDefinitionId: 'dataset', entityInstanceId: 'inst_b', permission: 'edit' as const },
       ],
     }
     const human = composeUserCapabilities({
@@ -940,7 +957,9 @@ describe('plan 25 §2 — an explicit instance grant overrides the area-None flo
       seatType: opts.seatType ?? 'full',
       profileLevels: { ...MEMBER_BASELINE_LEVELS, [opts.area]: Level.None },
       typeAccessRows: [],
-      instanceAccessRows: opts.rows,
+      // Every row belongs to the resource under test — the composer needs the
+      // type to decide WHICH area's Read rung (if any) it derives.
+      instanceAccessRows: opts.rows.map((row) => ({ entityDefinitionId: opts.key, ...row })),
     })
     const access: ResolvedRecordAccess = {
       role,

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.ts
@@ -4,13 +4,18 @@ import type { ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType, UserType } from '@auxx/database/types'
 import type { ProfileCeiling } from '../profiles/types'
 import {
+  INSTANCE_ACCESS_READ_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+  isInstanceAccessKey,
+} from './instance-access'
+import {
   type Area,
   buildAreaLevels,
   expandLevelsToKeys,
   Level,
   type PermissionKey,
 } from './registry'
-import { ROLE_DEFAULTS, SEAT_CEILINGS } from './seat-policy'
+import { ALL_KEYS, ROLE_DEFAULTS, SEAT_CEILINGS } from './seat-policy'
 
 /**
  * A user's composed Layer-2 capability set for one org.
@@ -21,6 +26,26 @@ import { ROLE_DEFAULTS, SEAT_CEILINGS } from './seat-policy'
  */
 export interface UserCapabilities {
   keys: PermissionKey[]
+  /**
+   * Coarse capability keys SYNTHESIZED from the member's instance grants — the
+   * `Level.Read` rung of an instance-access area the member holds ≥1 `view`-or-
+   * better instance grant on (handoff item 5b). Kept in a SEPARATE field from
+   * {@link keys} on purpose, and the separation is load-bearing:
+   *
+   * `keys` is the ONLY input {@link import('./registry').areaLevelFromKeys} has
+   * for recovering a member's AREA level, and that recovered level is what
+   * `effectiveInstanceLevel` / `instanceListScope` use as the absent-row
+   * fallback for the `baselineAtCreate: false` resources. Folding a derived
+   * `workflows.view` into `keys` would make `areaLevelFromKeys` report
+   * `Level.Read` for the area, and every row-LESS workflow in the org would fall
+   * back to `view` — turning "shared one workflow" into "can see all of them".
+   *
+   * So: `keys` answers *"what is my area level"*, `keys ∪ instanceDerivedKeys`
+   * answers *"may I reach this feature's front door"*. `CapabilitySet.can` /
+   * `has` / `assert` and the client `can()` read the union; `areaLevel()`,
+   * `resolved()` and every area-level computation read `keys` alone.
+   */
+  instanceDerivedKeys: PermissionKey[]
   defAccess: Record<string, ResourcePermission>
   /**
    * Highest instance-level ResourceAccess permission per `entityInstanceId`
@@ -143,8 +168,18 @@ export function composeUserCapabilities(input: {
   /** Sparse levels on the member's direct user grant (raise-only). */
   userLevels?: Partial<Record<Area, Level>>
   typeAccessRows: Array<{ entityDefinitionId: string; permission: ResourcePermission }>
-  /** Instance-level rows (entityInstanceId IS NOT NULL) for the instance-access resources. */
-  instanceAccessRows?: Array<{ entityInstanceId: string; permission: ResourcePermission }>
+  /**
+   * Instance-level rows (entityInstanceId IS NOT NULL) for the instance-access
+   * resources. `entityDefinitionId` is the resource KEY (`dataset` | `kb` |
+   * `dashboard` | `workflow`) and is REQUIRED — it is what makes
+   * {@link UserCapabilities.instanceDerivedKeys} type-aware, so a dashboard
+   * grant cannot open the workflows front door.
+   */
+  instanceAccessRows?: Array<{
+    entityDefinitionId: string
+    entityInstanceId: string
+    permission: ResourcePermission
+  }>
 }): UserCapabilities {
   const {
     role,
@@ -186,13 +221,13 @@ export function composeUserCapabilities(input: {
   }
 
   // Fail closed: a non-member holds no capabilities.
-  if (!role) return { keys: [], defAccess, instanceAccess }
+  if (!role) return { keys: [], instanceDerivedKeys: [], defAccess, instanceAccess }
 
   // AGENT principals hold NO composed capability (doc 19 §0.16/§2.3). Their
   // authority lives exclusively in `AgentVersion.permissionPolicy`, resolved by
   // `AgentPolicyCapabilities` — see the note above this function.
   if (userType === 'AGENT') {
-    return { keys: [], defAccess: {}, instanceAccess: {} }
+    return { keys: [], instanceDerivedKeys: [], defAccess: {}, instanceAccess: {} }
   }
 
   const ceiling = SEAT_CEILINGS[seatType]
@@ -201,9 +236,14 @@ export function composeUserCapabilities(input: {
   // profile ceiling is consulted, clamped only by the seat ceiling (a billing
   // invariant). Last-owner protection guarantees ≥1 owner exists, so a
   // mis-shaped profile is always fixable from inside the product.
+  //
+  // No derived keys: an owner already holds every rung the seat ceiling allows,
+  // so synthesizing a Read rung could only ever be a no-op — or, worse, hand
+  // back an area the ceiling deliberately closed.
   if (role === 'OWNER') {
     return {
       keys: expandLevelsToKeys(buildAreaLevels((area) => ceiling[area])),
+      instanceDerivedKeys: [],
       defAccess,
       instanceAccess,
     }
@@ -243,9 +283,51 @@ export function composeUserCapabilities(input: {
 
   return {
     keys: expandLevelsToKeys(resolved),
+    instanceDerivedKeys: deriveInstanceReadKeys(instanceAccessRows, ceiling),
     defAccess,
     instanceAccess,
   }
+}
+
+/**
+ * Synthesize the `Level.Read` rung of every instance-access area the member
+ * holds ≥1 `view`-or-better instance grant on — see
+ * {@link UserCapabilities.instanceDerivedKeys} for why the result is kept out of
+ * `keys`.
+ *
+ * Three properties, each deliberate:
+ *
+ * - **Read rung only, regardless of grant strength.** An `admin` grant on one
+ *   workflow yields `workflows.view`, never `workflows.manage` — that rung
+ *   fronts `create`, which has no instance to assert on.
+ * - **Type-aware.** The row's `entityDefinitionId` names the resource, so a
+ *   dashboard grant opens `dashboards.view` and nothing else. This is what
+ *   `baselineAtCreate: true` makes essential: every dashboard writes a
+ *   `role:org_member @ view` row at create, so "holds SOME instance grant" is
+ *   true for practically every member of every org with a dashboard.
+ * - **The seat ceiling still dominates**, matching `effectiveInstanceLevel`,
+ *   which checks the same clamp before it reads any row. Without this a worker
+ *   seat holding one grant would be handed a front-door key to an area its
+ *   billing packaging excludes — and the enforcement path would then deny it
+ *   anyway, which is a 403 maze rather than a hidden nav entry.
+ *
+ * Rows whose `entityDefinitionId` is not a registered instance-access key are
+ * skipped (fail closed); `'none'` rows never reach `view` and so never derive.
+ * Ordered by {@link ALL_KEYS} so the cached blob is byte-stable across recomputes
+ * regardless of row order.
+ */
+function deriveInstanceReadKeys(
+  rows: Array<{ entityDefinitionId: string; permission: ResourcePermission }>,
+  ceiling: Record<Area, Level>
+): PermissionKey[] {
+  const held = new Set<PermissionKey>()
+  for (const row of rows) {
+    if (PERMISSION_RANK[row.permission] < PERMISSION_RANK.view) continue
+    if (!isInstanceAccessKey(row.entityDefinitionId)) continue
+    if (ceiling[INSTANCE_ACCESS_RESOURCES[row.entityDefinitionId].area] === Level.None) continue
+    for (const key of INSTANCE_ACCESS_READ_KEYS[row.entityDefinitionId]) held.add(key)
+  }
+  return held.size === 0 ? [] : ALL_KEYS.filter((key) => held.has(key))
 }
 
 /**

--- a/packages/lib/src/permissions/capabilities/compute-user-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/compute-user-capabilities.ts
@@ -178,9 +178,14 @@ export async function computeUserCapabilities(
 
   // Second ResourceAccess query: INSTANCE-level rows (entityInstanceId IS NOT
   // NULL) for the instance-access resources (datasets etc., §1.2), reusing the
-  // same grantee union. Keyed on the globally-unique instance CUID alone.
+  // same grantee union. `instanceAccess` itself is keyed on the globally-unique
+  // instance CUID alone; `entityDefinitionId` rides along (same query, one more
+  // column — the WHERE clause already filters on it) because
+  // `UserCapabilities.instanceDerivedKeys` must know WHICH resource a grant is
+  // for, or a dashboard grant would open the workflows front door.
   const instanceAccessPromise = db
     .select({
+      entityDefinitionId: schema.ResourceAccess.entityDefinitionId,
       entityInstanceId: schema.ResourceAccess.entityInstanceId,
       permission: schema.ResourceAccess.permission,
     })
@@ -234,6 +239,7 @@ export async function computeUserCapabilities(
       permission: ResourcePermission
     }>,
     instanceAccessRows: instanceAccessRows as Array<{
+      entityDefinitionId: string
       entityInstanceId: string
       permission: ResourcePermission
     }>,

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -258,6 +258,19 @@ export function administersAnyDef(caps: ResolvedRecordAccess): boolean {
  */
 export interface ClientCapabilities {
   keys: PermissionKey[]
+  /**
+   * Coarse keys synthesized from the member's instance grants — the mirror of
+   * {@link import('./compose-user-capabilities').UserCapabilities.instanceDerivedKeys}.
+   * The client `can()` gate reads `keys ∪ instanceDerivedKeys`; every AREA-level
+   * computation ({@link toResolvedRecordAccess} → `areaLevelFromKeys` →
+   * `effectiveInstanceLevel` / `instanceListScope`, and the agent-policy clamp
+   * previews) reads `keys` alone. Optional — absent = `[]`.
+   *
+   * Mixing them would be a leak, not a nicety: a derived `workflows.view` inside
+   * `keys` makes `areaLevelFromKeys` report `Level.Read` for the area, and every
+   * workflow with no explicit row would then fall back to `view`.
+   */
+  instanceDerivedKeys?: PermissionKey[]
   defAccess: Record<string, ResourcePermission>
   restrictedEntityDefIds: string[]
   /**
@@ -278,7 +291,15 @@ export interface ClientCapabilities {
   restrictedInstanceIds?: string[]
 }
 
-/** Rebuild the Set-backed {@link ResolvedRecordAccess} from a wire snapshot. */
+/**
+ * Rebuild the Set-backed {@link ResolvedRecordAccess} from a wire snapshot.
+ *
+ * `instanceDerivedKeys` is deliberately NOT merged into `keys` here: this view's
+ * `keys` is the AREA-level source of truth for `effectiveInstanceLevel` /
+ * `instanceListScope`, and folding a derived Read key into it would re-open the
+ * area's absent-row fallback for every instance in the org. The front-door union
+ * lives in the `can()` gate (`capabilities-provider`), not in this view.
+ */
 export function toResolvedRecordAccess(caps: ClientCapabilities): ResolvedRecordAccess {
   return {
     role: caps.role,

--- a/packages/lib/src/permissions/capabilities/get-capabilities.ts
+++ b/packages/lib/src/permissions/capabilities/get-capabilities.ts
@@ -54,6 +54,11 @@ export async function getCapabilities(
     resolved.toDefinitionId,
     caps.instanceAccess ?? {},
     new Set(restrictedInstanceIds),
-    resolved.defBaseOverrides
+    resolved.defBaseOverrides,
+    // Composed, not recomputed here: `instanceDerivedKeys` is type-aware, and the
+    // type lives on the ResourceAccess row that only the composer reads. `?? []`
+    // covers a blob composed before the field existed — a missing derived key
+    // fails CLOSED (the member simply sees the coarse gate they saw before).
+    new Set(caps.instanceDerivedKeys ?? [])
   )
 }

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -22,8 +22,8 @@ export {
 } from './grant-service'
 export {
   INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_READ_KEYS,
   INSTANCE_ACCESS_RESOURCES,
-  INSTANCE_ACCESS_VIEW_KEYS,
   type InstanceAccessKey,
   type InstanceAccessResourceConfig,
   isInstanceAccessKey,

--- a/packages/lib/src/permissions/capabilities/instance-access.ts
+++ b/packages/lib/src/permissions/capabilities/instance-access.ts
@@ -58,31 +58,47 @@ export function isInstanceAccessKey(key: string): key is InstanceAccessKey {
 }
 
 /**
- * The `Level.Read` rung keys of every instance-access resource's L2 area — the
- * ONLY keys a coarse procedure gate may waive in favour of an explicit instance
- * grant (plan 25 §2).
+ * The `Level.Read` rung keys of each instance-access resource's L2 area, keyed
+ * BY RESOURCE — the keys {@link import('./compose-user-capabilities')
+ * .composeUserCapabilities} synthesizes for a member who holds ≥1 instance grant
+ * reaching `view` on that resource (plan 25 §2 / handoff item 5b).
  *
- * Since an explicit instance row now beats the area floor
+ * Since an explicit instance row beats the area floor
  * ({@link import('./entity-access').effectiveInstanceLevel}), a member composing
- * `workflows: None` who holds one `read` grant must still reach
- * `workflow.getById` — but the base procedure asserts `workflowsView`, which
- * they do not hold. `permissionProcedure` therefore waives the assert for the
- * keys in this set when the member holds ANY instance grant, and lets the
- * procedure's own `assert{View,Edit,Admin}Instance` decide.
+ * `workflows: None` who holds one `view` grant genuinely has workflow access —
+ * but their composed key set, built purely from resolved AREA levels, said
+ * otherwise, so every coarse gate (sidebar, cmd+K, landing-page guards, the
+ * `permissionProcedure` front door) fired against them. Deriving the Read rung
+ * from the grants they actually hold makes the coarse key TRUE for exactly the
+ * members it should be true for.
  *
- * **Read rung only, deliberately.** The waiver is sound only for procedures that
- * immediately assert on a specific instance. The higher rungs of these same
- * areas gate the instance-LESS actions — `workflowsManage` fronts `create` /
- * `createForResource`, which have no instance to assert on — so waiving those
- * would hand a `None`-area member the ability to create. Derived from
- * {@link INSTANCE_ACCESS_RESOURCES} rather than hand-listed: an area with no
- * `Level.Read` rung contributes nothing and therefore fails closed.
+ * **Read rung only, deliberately.** The higher rungs of these same areas front
+ * the instance-LESS actions — `workflowsManage` fronts `create` /
+ * `createForResource`, `datasetsManage` fronts dataset creation — which have no
+ * instance to assert on, so an `admin` grant on ONE instance must never expand
+ * to them. The derived key confers only "the feature's front door is open"; the
+ * per-instance `assert{View,Edit,Admin}Instance` still decides everything else.
+ *
+ * **Per-resource, not a flat union.** The predecessor of this map was a single
+ * type-blind `Set` used by the `permissionProcedure` waiver; because dashboards
+ * are `baselineAtCreate: true`, every dashboard writes a `role:org_member @ view`
+ * row at create, so in any org with ≥1 dashboard "holds an instance grant" was
+ * effectively always true and the front door stood open on ALL four areas.
+ * Keying by resource is what makes a dashboard grant confer `dashboards.view`
+ * and nothing else.
+ *
+ * Derived from {@link INSTANCE_ACCESS_RESOURCES} rather than hand-listed: an
+ * area with no `Level.Read` rung contributes nothing and therefore fails closed.
  */
-export const INSTANCE_ACCESS_VIEW_KEYS: ReadonlySet<PermissionKey> = new Set(
-  INSTANCE_ACCESS_KEYS.flatMap(
-    (key) =>
+export const INSTANCE_ACCESS_READ_KEYS: Readonly<
+  Record<InstanceAccessKey, readonly PermissionKey[]>
+> = INSTANCE_ACCESS_KEYS.reduce(
+  (acc, key) => {
+    acc[key] =
       PERMISSION_AREAS[INSTANCE_ACCESS_RESOURCES[key].area].rungs.find(
         (rung) => rung.level === Level.Read
       )?.keys ?? []
-  )
+    return acc
+  },
+  {} as Record<InstanceAccessKey, readonly PermissionKey[]>
 )

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -19,8 +19,8 @@ export {
 } from './capabilities/grant-service'
 export {
   INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_READ_KEYS,
   INSTANCE_ACCESS_RESOURCES,
-  INSTANCE_ACCESS_VIEW_KEYS,
   type InstanceAccessKey,
   type InstanceAccessResourceConfig,
   isInstanceAccessKey,

--- a/packages/lib/src/permissions/profiles/effective-state.ts
+++ b/packages/lib/src/permissions/profiles/effective-state.ts
@@ -332,7 +332,11 @@ function composeState(
     .map((row) => ({ entityDefinitionId: row.entityDefinitionId, permission: row.permission }))
   const instanceAccessRows = inputs.instanceRows
     .filter((row) => matchesGrantee(row, userId, profileId, groupIds))
-    .map((row) => ({ entityInstanceId: row.entityInstanceId ?? '', permission: row.permission }))
+    .map((row) => ({
+      entityDefinitionId: row.entityDefinitionId,
+      entityInstanceId: row.entityInstanceId ?? '',
+      permission: row.permission,
+    }))
 
   const caps = composeUserCapabilities({
     role,


### PR DESCRIPTION
Handoff item 5b. Supersedes #1346's `permissionProcedure` waiver, and carries the `user:capabilities:v10 → v11` bump owed since #1344.

## The problem

A member composing `workflows: None` who was granted `view` on ONE workflow genuinely has workflow access. But `ClientCapabilities.keys` is built purely from resolved AREA levels, so `can('workflows.view')` was false and every coarse gate fired against them:

- sidebar (`menu.tsx`) and cmd+K (`navigation.ts`)
- landing pages — KB and Dashboards **hard-redirect to `/access-denied`**, Datasets renders "No Access"

Only Workflows has no coarse landing gate, which is the only reason the original repro worked end-to-end at all.

#1346 papered over this at one door, with a waiver in `permissionProcedure`. That waiver was **type-blind**, and because dashboards are `baselineAtCreate: true` every dashboard writes a `role:org_member @ view` row at create — so in any org with ≥1 dashboard, "holds an instance grant" was effectively always true and the front door stood open on all four instance-access areas. The coarse rung there had become decorative.

## The fix

Synthesize the area's **Read rung only** at composition time from the grants the member actually holds. It is **type-aware for free** — `computeUserCapabilities`'s instance query already filtered on the resource key, it just wasn't selecting it. A dashboard grant now confers `dashboards.view` and nothing else.

The waiver and `INSTANCE_ACCESS_VIEW_KEYS` are deleted (the latter replaced by a per-resource `INSTANCE_ACCESS_READ_KEYS` map). Nav, cmd+K and the landing pages all work with **no per-site changes**.

### The load-bearing detail

Derived keys live in a separate `instanceDerivedKeys` field rather than being folded into `keys`. This is not tidiness:

`keys` is the only input `areaLevelFromKeys` has for recovering a member's area level, and that recovered level is the absent-row fallback for the `baselineAtCreate: false` resources. Folding a derived `workflows.view` into `keys` would make `areaLevelFromKeys` report `Level.Read` for the area — and every row-less workflow in the org would fall back to `view`, turning *"shared one workflow"* into *"can see all of them"*.

So: `keys` answers *"what is my area level"*; `keys ∪ instanceDerivedKeys` answers *"may I reach this feature's front door"*. `CapabilitySet.can`/`has`/`assert` and the client `can()` read the union; `areaLevel()`, `resolved()` and every area-level computation read `keys` alone.

### Bounds

- **Read rung only, regardless of grant strength.** The higher rungs front the instance-LESS actions (`workflowsManage` fronts `create`/`createForResource`), so an `admin` grant on one instance must never expand to them.
- **OWNER derives nothing** — it already holds every rung the seat ceiling allows, so synthesizing could only be a no-op, or worse, hand back an area the ceiling deliberately closed.
- **The derived key is a front door, not an answer about any instance.** Any procedure returning ORG-WIDE data behind one must scope that data to the instances the member can view. `dataset.getOrganizationStats` and `getAvailableEmbeddingOptions` are fixed accordingly and pinned by `dataset-org-aggregate-scope.test.ts`.

## Also fixed

The cmd+K "Dashboards" entry had **no capability half at all** while its landing page redirects, so it walked members straight into `/access-denied`.

## The cache bump

`user:capabilities:v10 → v11`. One bump, covering the whole accumulated batch:

| PR | Change | Bumped? |
|---|---|---|
| #1344 | `dashboards.edit` key | no |
| #1345 | `workflows.view` / `workflows.edit` rungs | no |
| #1346 | composition reorder | no |
| this | `keys` content changes | **yes** |

The earlier three were harmless — a missing key fails CLOSED and nothing is live — and dev was flushed each time. This change is the first that fails the *other* way: a stale blob would silently strip a grantee's access. Flush ≠ bump at deploy time, since a draining old instance repopulates the same keyspace.

## Tests

636 green: 385 in `packages/lib/src/permissions`, 251 in `apps/web/src/server/api/routers`.

## Not done — one listed sub-item, with a wrong premise

The handoff also listed `kb/ui/sources/connect-source-button.tsx:51` (gates on coarse `knowledgeBaseEdit`, so *"a member with an `edit` grant on one KB loses Connect Source even on that KB"*).

On inspection that premise looks wrong. The component's own doc comment says a source **is its own container** and this entry point is **org-wide** — KB linking happens inside the wizard. There is no KB id in scope, so there is no per-instance check to make. Whether a member holding `edit` on one KB should be able to create an org-wide source is a real design question, not a mechanical fix, so I left it. Worth deciding separately.