### PR TITLE
fix(permissions): gate rest routes that read org data without capabilities

### DIFF
--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/app-oauth-authorize-access.test.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/app-oauth-authorize-access.test.ts
@@ -1,0 +1,322 @@
+// apps/web/src/app/api/apps/[slug]/oauth2/authorize/app-oauth-authorize-access.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * **The live privilege hole this slice closed.**
+ *
+ * This REST authorize route authenticated with `auth.api.getSession` alone and read NO
+ * capabilities. Its callback writes the credential's `userId` column as
+ * `metadata.global ? null : metadata.userId` — and a `null` `userId` is an **org-scoped**
+ * credential. Meanwhile the tRPC sibling `apps.saveSecretConnection` computes `isOrgScoped` and
+ * asserts `integrationsManage` for exactly that case, and `apps.install` / `uninstall` /
+ * `setDefaultConnection` are all `permissionProcedure(integrationsManage)`.
+ *
+ * The fix mirrors `saveSecretConnection` rather than gating the whole route: **user-scoped
+ * connects stay ungated** (the connection belongs to the caller, plan 21 §4.1). The carve-out
+ * case below is the regression test that matters most — gating it would break every member
+ * connecting their own Google/Slack account.
+ *
+ * Behavioral: the REAL handler runs and a REAL `CapabilitySet` answers the assert. The Redis
+ * `setex` — the state write that makes the callback's credential write reachable — is the
+ * observed side effect.
+ */
+
+const {
+  getCapabilities,
+  getSession,
+  redis,
+  db,
+  interpolate,
+  resolveAppSlug,
+  resolveAppConnection,
+  resolveOAuth2Client,
+  resolveOwnClientRequirement,
+} = vi.hoisted(() => ({
+  getCapabilities: vi.fn(),
+  getSession: vi.fn(),
+  redis: { setex: vi.fn(async () => 'OK') },
+  db: { appInstallation: vi.fn(), connectionDefinition: vi.fn() },
+  interpolate: vi.fn(() => ({ authorizeUrl: 'https://provider.test/authorize' })),
+  resolveAppSlug: vi.fn(),
+  resolveAppConnection: vi.fn(),
+  resolveOAuth2Client: vi.fn(() => ({ clientId: 'client_abc' })),
+  resolveOwnClientRequirement: vi.fn(() => ({ requiresOwnClient: false, reason: null })),
+}))
+
+vi.mock('@auxx/config/urls', () => ({ WEBAPP_URL: 'http://localhost:3000' }))
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    query: {
+      AppInstallation: { findFirst: db.appInstallation },
+      ConnectionDefinition: { findFirst: db.connectionDefinition },
+    },
+  },
+}))
+
+vi.mock('@auxx/lib/apps', () => ({ resolveAppConnectionForRuntime: resolveAppConnection }))
+vi.mock('@auxx/lib/cache', () => ({ resolveAppSlug }))
+vi.mock('@auxx/lib/connections', () => ({ resolveOAuth2Client, resolveOwnClientRequirement }))
+
+/**
+ * The `@auxx/lib/permissions` barrel hangs under vitest, so it can't be partially mocked — but
+ * `requirePermission` is re-implemented FAITHFULLY rather than stubbed: `integrationsManage`
+ * carries no `featureKey` in the registry, so the real function's plan-gate branch is dead for
+ * this key and these two lines ARE its whole body. The `PermissionKey` enum and the `assert`
+ * that throws are both the real thing.
+ */
+vi.mock('@auxx/lib/permissions', async () => {
+  const { PermissionKey } = await import('@auxx/lib/permissions/capabilities/registry')
+  return {
+    PermissionKey,
+    requirePermission: async (userId: string, orgId: string, key: never) => {
+      const caps = await getCapabilities(userId, orgId)
+      caps.assert(key)
+    },
+  }
+})
+
+vi.mock('@auxx/redis', () => ({ getRedisClient: async () => redis }))
+vi.mock('@auxx/services/app-connections', () => ({ interpolateConnectionFields: interpolate }))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const APP_ID = 'app_cuid000000000000000000000'
+const INSTALL_ID = 'ins_cuid000000000000000000000'
+const DEF_ID = 'cd_cuid0000000000000000000000'
+const SLUG = 'acme'
+
+/** A real `CapabilitySet` at the given `integrations` rung — Full is the only rung that key has. */
+function capabilitiesAt(level: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.integrations]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+function signedIn(level: Level) {
+  getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
+  getCapabilities.mockResolvedValue(capabilitiesAt(level))
+}
+
+const params = { params: Promise.resolve({ slug: SLUG }) }
+
+const request = (query: string) =>
+  ({
+    nextUrl: new URL(`http://localhost:3000/api/apps/${SLUG}/oauth2/authorize${query}`),
+  }) as never
+
+/** `?type=organization` with no picked method — the org-scoped connect. */
+const orgConnect = () => request(`?installation=${INSTALL_ID}&type=organization`)
+/** `?type=user` with no picked method — the caller's own connection. */
+const userConnect = () => request(`?installation=${INSTALL_ID}&type=user`)
+
+/** The single-method lookup constrains `cd.global` to the `type` param, so mirror that. */
+function connectionDefinition(global: boolean) {
+  return {
+    id: DEF_ID,
+    connectionType: 'oauth2-code',
+    global,
+    oauth2Features: {},
+    oauth2Scopes: ['read'],
+    oauth2AuthorizeUrl: 'https://provider.test/authorize',
+    connectionVariables: [],
+  }
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  redis.setex.mockClear()
+  interpolate.mockClear()
+  resolveAppConnection.mockReset()
+  resolveAppSlug.mockReset().mockResolvedValue(APP_ID)
+  resolveOwnClientRequirement
+    .mockReset()
+    .mockReturnValue({ requiresOwnClient: false, reason: null })
+  resolveOAuth2Client.mockReset().mockReturnValue({ clientId: 'client_abc' })
+  db.appInstallation.mockReset().mockResolvedValue({
+    id: INSTALL_ID,
+    appId: APP_ID,
+    organizationId: ORG_ID,
+    app: { title: 'Acme' },
+  })
+  // Default: the org-scoped method. Per-test overrides flip `global`.
+  db.connectionDefinition.mockReset().mockResolvedValue(connectionDefinition(true))
+})
+
+describe('GET /api/apps/[slug]/oauth2/authorize — org-scoped connects', () => {
+  it('401s without a session, before any capability read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('401s a session with no default organization', async () => {
+    getSession.mockResolvedValue({ user: { id: USER_ID } })
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('400s without installation/type', async () => {
+    signedIn(Level.Full)
+    const res = await GET(request(''), params)
+    expect(res.status).toBe(400)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('403s a member without `integrationsManage` (THE regression)', async () => {
+    // Before this slice any authenticated member reached the redirect, and the callback then
+    // wrote a credential with a null `userId` — an org-wide connection.
+    signedIn(Level.None)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.any(String) })
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('403s a member at the `integrations` Read rung', async () => {
+    signedIn(Level.Read)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(403)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('runs the gate BEFORE the state write and the redirect', async () => {
+    signedIn(Level.None)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(403)
+    expect(redis.setex).not.toHaveBeenCalled()
+    expect(interpolate).not.toHaveBeenCalled()
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('asserts against the SESSION user and org', async () => {
+    signedIn(Level.Full)
+    await GET(orgConnect(), params)
+    expect(getCapabilities).toHaveBeenCalledWith(USER_ID, ORG_ID)
+  })
+
+  it('lets an `integrationsManage` holder through to the provider redirect', async () => {
+    signedIn(Level.Full)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('https://provider.test/authorize')
+    expect(redis.setex).toHaveBeenCalledTimes(1)
+    const [key, ttl, payload] = redis.setex.mock.calls[0]!
+    expect(key).toMatch(/^oauth:app-connection:/)
+    expect(ttl).toBe(600)
+    // `global: true` here is precisely what makes the callback write `userId: null`.
+    expect(JSON.parse(payload as string)).toMatchObject({
+      userId: USER_ID,
+      organizationId: ORG_ID,
+      appId: APP_ID,
+      global: true,
+    })
+  })
+})
+
+describe('GET /api/apps/[slug]/oauth2/authorize — the user-scoped carve-out', () => {
+  it('lets a member WITHOUT `integrationsManage` connect their OWN account', async () => {
+    // THE carve-out. Gating this would be a regression: a user-scoped connect writes the
+    // credential under the caller's own `userId`, so it needs no org-level key
+    // (`saveSecretConnection` only asserts when `isOrgScoped`).
+    signedIn(Level.None)
+    db.connectionDefinition.mockResolvedValue(connectionDefinition(false))
+    const res = await GET(userConnect(), params)
+    expect(res.status).toBe(307)
+    expect(redis.setex).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(redis.setex.mock.calls[0]![2] as string)).toMatchObject({
+      userId: USER_ID,
+      global: false,
+    })
+    // The gate must not even be consulted for a user-scoped connect.
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('refuses that SAME member an org-scoped connect', async () => {
+    signedIn(Level.None)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(403)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/apps/[slug]/oauth2/authorize — a picked method owns the scope', () => {
+  const pickedConnect = (type: 'user' | 'organization') =>
+    request(`?installation=${INSTALL_ID}&type=${type}&connectionDefinitionId=${DEF_ID}`)
+
+  it('gates a `global` picked method even when the query says `type=user`', async () => {
+    // Multi-method apps look the def up BY ID; the def's `global` — not the query param — is
+    // what the callback turns into a null `userId`. Trusting the param here would hand the
+    // caller an org credential for free.
+    signedIn(Level.None)
+    db.connectionDefinition.mockResolvedValue(connectionDefinition(true))
+    const res = await GET(pickedConnect('user'), params)
+    expect(res.status).toBe(403)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('does NOT gate a non-global picked method even when the query says `type=organization`', async () => {
+    signedIn(Level.None)
+    db.connectionDefinition.mockResolvedValue(connectionDefinition(false))
+    const res = await GET(pickedConnect('organization'), params)
+    expect(res.status).toBe(307)
+    expect(redis.setex).toHaveBeenCalledTimes(1)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('lets a holder through a `global` picked method', async () => {
+    signedIn(Level.Full)
+    db.connectionDefinition.mockResolvedValue(connectionDefinition(true))
+    const res = await GET(pickedConnect('user'), params)
+    expect(res.status).toBe(307)
+    expect(redis.setex).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('GET /api/apps/[slug]/oauth2/authorize — the gate did not replace the other checks', () => {
+  it('404s an unknown app slug', async () => {
+    signedIn(Level.Full)
+    resolveAppSlug.mockResolvedValueOnce(null)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(404)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('404s an installation belonging to another org', async () => {
+    signedIn(Level.Full)
+    db.appInstallation.mockResolvedValueOnce(undefined)
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(404)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('400s a non-oauth2 connection definition', async () => {
+    signedIn(Level.Full)
+    db.connectionDefinition.mockResolvedValueOnce({
+      ...connectionDefinition(true),
+      connectionType: 'secret',
+    })
+    const res = await GET(orgConnect(), params)
+    expect(res.status).toBe(400)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
@@ -6,6 +6,8 @@ import { database as db } from '@auxx/database'
 import { resolveAppConnectionForRuntime } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
 import { resolveOAuth2Client, resolveOwnClientRequirement } from '@auxx/lib/connections'
+import { AuxxError } from '@auxx/lib/errors'
+import { PermissionKey, requirePermission } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
@@ -128,6 +130,31 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         { error: 'OAuth not configured for this app connection' },
         { status: 400 }
       )
+    }
+
+    // Scope is a property of the method, exactly as in `apps.saveSecretConnection`: with a picked
+    // method the def owns the scope, otherwise the `type` param does (the fallback lookup above
+    // already constrains `cd.global` to it). This is the same value stashed as `global` in the
+    // Redis state below, which the callback turns into the credential's `userId` column —
+    // `null` (org-wide) when org-scoped.
+    //
+    // Org-scoped connections gate on the integrations key; user-scoped ones
+    // belong to the caller (plan 21 §4.1).
+    const isOrgScoped = connectionDefinitionId ? connDef.global === true : isGlobal
+    if (isOrgScoped) {
+      try {
+        await requirePermission(session.user.id, organizationId, PermissionKey.integrationsManage)
+      } catch (permissionError) {
+        // Returned explicitly so the AuxxError keeps its own 403 instead of being flattened
+        // into the outer catch's generic 500.
+        if (permissionError instanceof AuxxError) {
+          return NextResponse.json(
+            { error: permissionError.message },
+            { status: permissionError.statusCode }
+          )
+        }
+        throw permissionError
+      }
     }
 
     // Generate state token for CSRF protection

--- a/apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
+++ b/apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
@@ -1,0 +1,116 @@
+// apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
+
+import { Area, expandLevelsToKeys, Level, type PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The eval SSE recovery route authenticated with `auth.api.getSession` and
+ * scoped the run by organization, but read no capabilities — so any
+ * authenticated member could replay any eval run's full trace (agent messages,
+ * tool calls, assertion verdicts) while every `eval.*` tRPC procedure sits
+ * behind `permissionProcedure(agentsManage)`.
+ *
+ * Behavioral: the real handler runs, with a REAL `CapabilitySet`. The DB read
+ * is the observed side effect — the gate must land ahead of it.
+ */
+
+const { getCapabilities, getSession, limit } = vi.hoisted(() => ({
+  getCapabilities: vi.fn(),
+  getSession: vi.fn(),
+  limit: vi.fn(async () => [] as unknown[]),
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({ from: () => ({ where: () => ({ limit }) }) }),
+  },
+  schema: { EvalRun: { id: 'id', organizationId: 'organizationId' } },
+}))
+
+vi.mock('drizzle-orm', () => ({ and: vi.fn(), eq: vi.fn() }))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// The barrel hangs under vitest — stub it, keep the enums real via /client.
+vi.mock('@auxx/lib/permissions', () => ({ getCapabilities }))
+
+vi.mock('@auxx/redis', () => ({
+  RedisEventRouter: {
+    getInstance: () => ({ subscribe: vi.fn(async () => 'h1'), unsubscribe: vi.fn() }),
+  },
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const RUN_ID = 'evr_cuid000000000000000000000'
+
+function signedIn(agentsLevel: Level) {
+  getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
+  getCapabilities.mockResolvedValue(
+    new CapabilitySet(
+      new Set(expandLevelsToKeys({ [Area.agents]: agentsLevel }) as PermissionKey[]),
+      {},
+      'MEMBER',
+      'full'
+    )
+  )
+}
+
+const request = () =>
+  ({
+    headers: new Headers(),
+    nextUrl: new URL(`http://localhost/api/eval/run/${RUN_ID}/events`),
+    signal: new AbortController().signal,
+  }) as never
+
+const params = { params: Promise.resolve({ runId: RUN_ID }) }
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  limit
+    .mockReset()
+    .mockResolvedValue([{ id: RUN_ID, status: 'passed', trace: [], assertionResults: [] }])
+})
+
+describe('GET /api/eval/run/[runId]/events', () => {
+  it('401s without a session', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(limit).not.toHaveBeenCalled()
+  })
+
+  it('403s a member without agents.manage before touching the run', async () => {
+    signedIn(Level.None)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    // The gate must precede the DB read — otherwise existence is still probeable.
+    expect(limit).not.toHaveBeenCalled()
+  })
+
+  it('streams the run for a member holding agents.manage', async () => {
+    signedIn(Level.Full)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(limit).toHaveBeenCalledTimes(1)
+    const body = await res.text()
+    expect(body).toContain('connected')
+  })
+
+  it('404s an unknown run for an authorized member', async () => {
+    signedIn(Level.Full)
+    limit.mockResolvedValueOnce([])
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/web/src/app/api/eval/run/[runId]/events/route.ts
+++ b/apps/web/src/app/api/eval/run/[runId]/events/route.ts
@@ -7,6 +7,8 @@
 // transport, not storage. See conventions.md §8.
 
 import { database as db, schema } from '@auxx/database'
+import { getCapabilities } from '@auxx/lib/permissions'
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { createScopedLogger } from '@auxx/logger'
 import { RedisEventRouter } from '@auxx/redis'
 import type { AssertionResult, EvalTraceEvent } from '@auxx/types/evals'
@@ -37,6 +39,21 @@ export async function GET(
     (session.user as { defaultOrganizationId?: string; organizationId?: string })
       .defaultOrganizationId ?? (session.user as { organizationId?: string }).organizationId
   if (!organizationId) return new Response('No organization', { status: 403 })
+
+  // Same class of gap as the Kopilot stream route: this handler authenticated
+  // with `getSession` and scoped by org, but read no capabilities — so any
+  // authenticated member could replay an eval run's full trace (agent messages,
+  // tool calls, assertion verdicts) while every `eval.*` tRPC procedure sits
+  // behind `permissionProcedure(agentsManage)`.
+  //
+  // Capability only, deliberately: `evalManageProcedure` also plan-ANDs
+  // `agentProcedures`, but this is a read-only RECONNECT stream for a run that
+  // was already started behind that gate, and failing a live reconnect on a
+  // mid-run plan change would be worse than the gap it closes.
+  const capabilities = await getCapabilities(session.user.id, organizationId)
+  if (!capabilities.can(PermissionKey.agentsManage)) {
+    return new Response('Forbidden', { status: 403 })
+  }
 
   const [run] = await db
     .select()

--- a/apps/web/src/app/api/files/download/[fileId]/file-download-permission.test.ts
+++ b/apps/web/src/app/api/files/download/[fileId]/file-download-permission.test.ts
@@ -1,0 +1,287 @@
+// apps/web/src/app/api/files/download/[fileId]/file-download-permission.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The raw-content sibling of the run-trace hole (`run-trace-instance-access.test.ts`).
+ *
+ * `GET /api/files/download/[fileId]` streamed file BYTES and `HEAD` returned
+ * name/size/mimeType for any `FolderFile` or `MediaAsset` in the org, after
+ * authenticating with `auth.api.getSession` alone and reading NO capabilities —
+ * `FileService.get` scopes on organization + soft-delete only. Its tRPC sibling
+ * `file.getDownloadInfo` is `permissionProcedure(PermissionKey.filesView)`, as
+ * are all eight file reads on that router.
+ *
+ * Behavioral: `requirePermission` is stubbed only as far as its two collaborators
+ * (the plan gate and the capability fetch) — the registry lookup that decides
+ * whether the plan gate runs, and `CapabilitySet.assert` itself, are REAL. The
+ * file-service calls are the observed side effect: the gate must land ahead of
+ * them, so an unauthorized caller cannot even probe whether an id exists.
+ */
+
+const {
+  getSession,
+  getCapabilities,
+  planGate,
+  fileGet,
+  fileGetContent,
+  assetGet,
+  assetGetContent,
+  createFileService,
+  MediaAssetService,
+  createFileDownloadResponse,
+} = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getCapabilities: vi.fn(),
+  planGate: vi.fn(),
+  fileGet: vi.fn(),
+  fileGetContent: vi.fn(),
+  assetGet: vi.fn(),
+  assetGetContent: vi.fn(),
+  createFileService: vi.fn(),
+  MediaAssetService: vi.fn(),
+  createFileDownloadResponse: vi.fn(),
+}))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest — stub it. The stub is a
+// faithful transcription of `capabilities/require.ts`: registry lookup → plan
+// gate (only when the key links a `featureKey`) → real `assert`.
+vi.mock('@auxx/lib/permissions', async () => {
+  const { PERMISSION_REGISTRY_MAP, PermissionKey } = await import(
+    '@auxx/lib/permissions/capabilities/registry'
+  )
+  return {
+    PermissionKey,
+    requirePermission: async (userId: string, orgId: string, key: never) => {
+      const meta = PERMISSION_REGISTRY_MAP.get(key)
+      if (meta?.featureKey) await planGate(orgId, meta.featureKey)
+      const caps = await getCapabilities(userId, orgId)
+      caps.assert(key)
+    },
+  }
+})
+
+vi.mock('@auxx/lib/files/server', () => ({
+  createFileService,
+  MediaAssetService,
+  createFileDownloadResponse,
+  parseRangeHeader: vi.fn(() => null),
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep paths on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { ForbiddenError } = await import('@auxx/lib/errors')
+const { GET, HEAD } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const FILE_ID = 'fil_cuid000000000000000000000'
+const ASSET_ID = 'ast_cuid000000000000000000000'
+
+/** A real `CapabilitySet` composing the Files area at `level`. */
+function capabilitiesAt(level: Level) {
+  return new CapabilitySet(new Set(expandLevelsToKeys({ [Area.files]: level })), {}, 'USER', 'full')
+}
+
+function signedIn(capabilities: InstanceType<typeof CapabilitySet>) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
+  })
+  getCapabilities.mockResolvedValue(capabilities)
+}
+
+const request = () => ({ headers: new Headers() }) as never
+const params = (fileId: string) => ({ params: Promise.resolve({ fileId }) })
+
+const fileRow = { id: FILE_ID, name: 'contract.pdf', mimeType: 'application/pdf', size: 2048 }
+const assetRow = { id: ASSET_ID, name: 'logo.png', mimeType: 'image/png', size: 512 }
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  planGate.mockReset().mockResolvedValue(undefined)
+  fileGet.mockReset().mockResolvedValue(fileRow)
+  fileGetContent.mockReset().mockResolvedValue(Buffer.from('file-bytes'))
+  assetGet.mockReset().mockResolvedValue(assetRow)
+  assetGetContent.mockReset().mockResolvedValue(Buffer.from('asset-bytes'))
+  createFileService.mockReset().mockReturnValue({ get: fileGet, getContent: fileGetContent })
+  // A class, not an arrow — the route calls `new MediaAssetService(...)`, and an
+  // arrow implementation is not constructible (biome also rewrites plain function
+  // expressions back to arrows, so the class is what survives `lint:fix`).
+  MediaAssetService.mockReset().mockImplementation(
+    class {
+      get = assetGet
+      getContent = assetGetContent
+    } as never
+  )
+  createFileDownloadResponse.mockReset().mockReturnValue({
+    buffer: Buffer.from('file-bytes'),
+    status: 200,
+    headers: { 'Content-Type': 'application/pdf' },
+  })
+})
+
+/** Every read the handler could perform — none may run for a denied caller. */
+function expectNoFileReads() {
+  expect(createFileService).not.toHaveBeenCalled()
+  expect(MediaAssetService).not.toHaveBeenCalled()
+  expect(fileGet).not.toHaveBeenCalled()
+  expect(assetGet).not.toHaveBeenCalled()
+}
+
+describe('GET /api/files/download/[fileId] — the raw-content hole', () => {
+  it('401s without a session, before any capability or file read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params(FILE_ID))
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expectNoFileReads()
+  })
+
+  it('400s a session with no default organization, before any capability read', async () => {
+    getSession.mockResolvedValue({ user: { id: USER_ID } })
+    const res = await GET(request(), params(FILE_ID))
+    expect(res.status).toBe(400)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expectNoFileReads()
+  })
+
+  it('403s a member composing `files: None`, before the file read', async () => {
+    // THE case this fix exists for: an authenticated org member with no Files
+    // access at all previously got the bytes.
+    signedIn(capabilitiesAt(Level.None))
+    const res = await GET(request(), params(FILE_ID))
+    expect(res.status).toBe(403)
+    // The gate must precede the read — otherwise existence is still probeable.
+    expectNoFileReads()
+  })
+
+  it('403s a `files: None` member on the `asset:` FileRef form too', async () => {
+    signedIn(capabilitiesAt(Level.None))
+    const res = await GET(request(), params(`asset:${ASSET_ID}`))
+    expect(res.status).toBe(403)
+    expectNoFileReads()
+  })
+
+  it('403s when the org plan lacks the files feature, before the file read', async () => {
+    // `PermissionKey.filesView` links `FeatureKey.files`, so `requirePermission`
+    // runs the plan gate FIRST — the same plan-AND `permissionProcedure` runs.
+    signedIn(capabilitiesAt(Level.Full))
+    planGate.mockRejectedValue(new ForbiddenError('Files is not available on your plan.'))
+    const res = await GET(request(), params(FILE_ID))
+    expect(res.status).toBe(403)
+    expect(planGate).toHaveBeenCalledWith(ORG_ID, 'files')
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expectNoFileReads()
+  })
+
+  it('500s — not 403 — when the gate fails for a non-permission reason', async () => {
+    // Only an `AuxxError` maps to its status; anything else is rethrown so a
+    // genuine failure is not masked as a permission denial.
+    signedIn(capabilitiesAt(Level.Full))
+    planGate.mockRejectedValue(new Error('redis down'))
+    const res = await GET(request(), params(FILE_ID))
+    expect(res.status).toBe(500)
+    expectNoFileReads()
+  })
+
+  it('streams the bytes for a member holding `files: Read` (bare id form)', async () => {
+    signedIn(capabilitiesAt(Level.Read))
+    const res = await GET(request(), params(FILE_ID))
+    expect(res.status).toBe(200)
+    expect(createFileService).toHaveBeenCalledWith(ORG_ID, USER_ID)
+    expect(fileGet).toHaveBeenCalledWith(FILE_ID)
+    expect(await res.text()).toBe('file-bytes')
+  })
+
+  it('streams the bytes for the `file:` FileRef form, unwrapping the prefix', async () => {
+    signedIn(capabilitiesAt(Level.Read))
+    const res = await GET(request(), params(`file:${FILE_ID}`))
+    expect(res.status).toBe(200)
+    expect(fileGet).toHaveBeenCalledWith(FILE_ID)
+    expect(MediaAssetService).not.toHaveBeenCalled()
+  })
+
+  it('streams the bytes for the `asset:` FileRef form via MediaAssetService', async () => {
+    signedIn(capabilitiesAt(Level.Read))
+    const res = await GET(request(), params(`asset:${ASSET_ID}`))
+    expect(res.status).toBe(200)
+    expect(MediaAssetService).toHaveBeenCalledWith(ORG_ID, USER_ID)
+    expect(assetGet).toHaveBeenCalledWith(ASSET_ID)
+    expect(createFileService).not.toHaveBeenCalled()
+  })
+
+  it('404s an absent file for an authorized member', async () => {
+    signedIn(capabilitiesAt(Level.Read))
+    fileGet.mockResolvedValue(null)
+    const res = await GET(request(), params(FILE_ID))
+    expect(res.status).toBe(404)
+    // No content read for a row we could not load.
+    expect(fileGetContent).not.toHaveBeenCalled()
+  })
+
+  it('400s an empty file id before touching the session', async () => {
+    signedIn(capabilitiesAt(Level.Read))
+    const res = await GET(request(), params(''))
+    expect(res.status).toBe(400)
+    expectNoFileReads()
+  })
+})
+
+describe('HEAD /api/files/download/[fileId] — the metadata half of the same hole', () => {
+  it('401s without a session, before any capability or file read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await HEAD(request(), params(FILE_ID))
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expectNoFileReads()
+  })
+
+  it('403s a member composing `files: None`, before the file read', async () => {
+    // HEAD leaks name/size/mimeType, so it needs the identical gate — a fix that
+    // lands on GET alone still hands over the file inventory.
+    signedIn(capabilitiesAt(Level.None))
+    const res = await HEAD(request(), params(FILE_ID))
+    expect(res.status).toBe(403)
+    expectNoFileReads()
+  })
+
+  it('403s a `files: None` member on the `asset:` FileRef form too', async () => {
+    signedIn(capabilitiesAt(Level.None))
+    const res = await HEAD(request(), params(`asset:${ASSET_ID}`))
+    expect(res.status).toBe(403)
+    expectNoFileReads()
+  })
+
+  it('403s when the org plan lacks the files feature, before the file read', async () => {
+    signedIn(capabilitiesAt(Level.Full))
+    planGate.mockRejectedValue(new ForbiddenError('Files is not available on your plan.'))
+    const res = await HEAD(request(), params(FILE_ID))
+    expect(res.status).toBe(403)
+    expectNoFileReads()
+  })
+
+  it('returns the metadata headers for a member holding `files: Read`', async () => {
+    signedIn(capabilitiesAt(Level.Read))
+    const res = await HEAD(request(), params(FILE_ID))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/pdf')
+    expect(res.headers.get('Content-Length')).toBe('2048')
+    expect(res.headers.get('Content-Disposition')).toBe('attachment; filename="contract.pdf"')
+  })
+
+  it('404s an absent file for an authorized member', async () => {
+    signedIn(capabilitiesAt(Level.Read))
+    fileGet.mockResolvedValue(null)
+    const res = await HEAD(request(), params(FILE_ID))
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/web/src/app/api/files/download/[fileId]/route.ts
+++ b/apps/web/src/app/api/files/download/[fileId]/route.ts
@@ -1,10 +1,12 @@
 // apps/web/src/app/api/files/download/[fileId]/route.ts
 
+import { AuxxError } from '@auxx/lib/errors'
 import {
   createFileDownloadResponse,
   createFileService,
   parseRangeHeader,
 } from '@auxx/lib/files/server'
+import { PermissionKey, requirePermission } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { isFileRef, parseFileRef } from '@auxx/types/file-ref'
 import { headers } from 'next/headers'
@@ -15,6 +17,59 @@ const logger = createScopedLogger('api-files-download')
 
 interface RouteParams {
   params: Promise<{ fileId: string }>
+}
+
+/**
+ * Session + `files.view` gate shared by GET and HEAD.
+ *
+ * Returns the resolved caller on success, or the `Response` to send back.
+ *
+ * Both handlers previously authenticated with `auth.api.getSession` alone and
+ * read no capabilities: `FileService.get` scopes on organization + soft-delete
+ * only, so any authenticated member of the org could stream the CONTENT of any
+ * `FolderFile` or `MediaAsset` (GET), or read its name/size/mimeType (HEAD),
+ * simply by knowing — or guessing — an id. The eight file reads on the tRPC
+ * sibling `fileRouter` (`list`, `getById`, `search`, `getDownloadInfo`, …) all
+ * sit behind `permissionProcedure(PermissionKey.filesView)`; this route is the
+ * same read, so it takes the same key.
+ *
+ * {@link requirePermission} runs the identical pair `permissionProcedure` runs:
+ * the `FeatureKey.files` plan gate, then `getCapabilities(...).assert(...)`.
+ * It THROWS an {@link AuxxError} rather than returning a boolean, and an App
+ * Router handler has no `auxxErrorMiddleware`/`errorFormatter` in the path — so
+ * the throw is mapped to `error.statusCode` here (403 for the `ForbiddenError`
+ * both gates raise). Anything that is not an `AuxxError` is rethrown, so a
+ * genuine failure surfaces as the handler's 500 instead of masquerading as a
+ * permission denial. Same shape as the sibling
+ * `api/files/upload/sessions/route.ts`.
+ *
+ * The gate deliberately runs **before** {@link resolveFile}, so an unauthorized
+ * caller cannot probe file existence through the 404-vs-200 difference either.
+ */
+async function authorize(): Promise<
+  { ok: true; organizationId: string; userId: string } | { ok: false; response: Response }
+> {
+  const session = await auth.api.getSession({ headers: await headers() })
+
+  if (!session?.user) {
+    return { ok: false, response: new Response('Unauthorized', { status: 401 }) }
+  }
+
+  const organizationId = (session.user as any).defaultOrganizationId
+  if (!organizationId) {
+    return { ok: false, response: new Response('Organization ID is required', { status: 400 }) }
+  }
+
+  try {
+    await requirePermission(session.user.id, organizationId, PermissionKey.filesView)
+  } catch (error) {
+    if (error instanceof AuxxError) {
+      return { ok: false, response: new Response(error.message, { status: error.statusCode }) }
+    }
+    throw error
+  }
+
+  return { ok: true, organizationId, userId: session.user.id }
 }
 
 /**
@@ -53,24 +108,17 @@ async function resolveFile(
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const { fileId } = await params
-    const session = await auth.api.getSession({ headers: await headers() })
-
-    if (!session?.user) {
-      return new Response('Unauthorized', { status: 401 })
-    }
-
-    const organizationId = (session.user as any).defaultOrganizationId
-    if (!organizationId) {
-      return new Response('Organization ID is required', { status: 400 })
-    }
 
     if (!fileId) {
       return new Response('File ID is required', { status: 400 })
     }
 
+    const caller = await authorize()
+    if (!caller.ok) return caller.response
+
     logger.info(`Downloading file: ${fileId}`)
 
-    const resolved = await resolveFile(fileId, organizationId, session.user.id)
+    const resolved = await resolveFile(fileId, caller.organizationId, caller.userId)
     if (!resolved) {
       return new Response('File not found', { status: 404 })
     }
@@ -103,18 +151,15 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 export async function HEAD(_request: NextRequest, { params }: RouteParams) {
   try {
     const { fileId } = await params
-    const session = await auth.api.getSession({ headers: await headers() })
 
-    if (!session?.user) {
-      return new Response('Unauthorized', { status: 401 })
+    if (!fileId) {
+      return new Response('File ID is required', { status: 400 })
     }
 
-    const organizationId = (session.user as any).defaultOrganizationId
-    if (!organizationId) {
-      return new Response('Organization ID is required', { status: 400 })
-    }
+    const caller = await authorize()
+    if (!caller.ok) return caller.response
 
-    const resolved = await resolveFile(fileId, organizationId, session.user.id)
+    const resolved = await resolveFile(fileId, caller.organizationId, caller.userId)
     if (!resolved) {
       return new Response('File not found', { status: 404 })
     }

--- a/apps/web/src/app/api/imports/[importJobId]/events/records-import-access.test.ts
+++ b/apps/web/src/app/api/imports/[importJobId]/events/records-import-access.test.ts
@@ -1,0 +1,205 @@
+// apps/web/src/app/api/imports/[importJobId]/events/records-import-access.test.ts
+
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Same class of gap as the eval / workflow-run SSE routes: this handler
+ * authenticated with `auth.api.getSession` and scoped the job by organization,
+ * but read NO capabilities — so any authenticated member could stream a live
+ * import. The forwarded `planning:row` events carry the imported record VALUES
+ * (`fields`) plus `existingRecordId`, and the terminal replay carries
+ * `statistics`. Its tRPC sibling (`server/api/routers/data-import.ts`) puts
+ * every one of its procedures behind `permissionProcedure(recordsImport)`.
+ *
+ * Behavioral: the real handler runs, and the gate resolves through a REAL
+ * `CapabilitySet` built from `expandLevelsToKeys`. The job lookup is the
+ * observed side effect — the gate must land ahead of it.
+ */
+
+const { requirePermission, getSession, limit } = vi.hoisted(() => ({
+  requirePermission: vi.fn(),
+  getSession: vi.fn(),
+  limit: vi.fn(),
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({ from: () => ({ where: () => ({ limit }) }) }),
+  },
+  schema: { ImportJob: { id: 'id', organizationId: 'organizationId' } },
+}))
+
+vi.mock('drizzle-orm', () => ({ and: vi.fn(), eq: vi.fn() }))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest — stub it, keep the
+// enums real via `/client` and the assert real via the deep `capability-set`.
+vi.mock('@auxx/lib/permissions', () => ({ requirePermission }))
+
+vi.mock('@auxx/redis', () => ({
+  createDedicatedClient: vi.fn(async () => ({
+    subscribe: vi.fn(async () => undefined),
+    unsubscribe: vi.fn(async () => undefined),
+    quit: vi.fn(async () => undefined),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  })),
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const JOB_ID = 'imj_cuid000000000000000000000'
+
+/**
+ * Signs a member in at `level` on the `records` area and wires the stubbed
+ * `requirePermission` to the REAL `CapabilitySet.assert` for that composition —
+ * so allow/deny comes from the shipped registry expansion, not from the test.
+ * (`recordsImport` carries no `featureKey`, so the real `requirePermission`
+ * reduces to exactly this assert; there is no plan gate to model.)
+ */
+function signedIn(level: Level) {
+  getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
+  const capabilities = new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.records]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+  requirePermission.mockImplementation(async (_userId, _orgId, key: PermissionKey) =>
+    capabilities.assert(key)
+  )
+}
+
+const request = () =>
+  ({
+    headers: new Headers(),
+    signal: new AbortController().signal,
+  }) as never
+
+const params = { params: Promise.resolve({ importJobId: JOB_ID }) }
+
+const runningJob = {
+  id: JOB_ID,
+  organizationId: ORG_ID,
+  status: 'processing',
+  rowCount: 42,
+  columnCount: 7,
+  receivedChunks: 1,
+  totalChunks: 3,
+  allowPlanGeneration: false,
+  statistics: null,
+  completedAt: null,
+}
+
+const completedJob = {
+  ...runningJob,
+  status: 'completed',
+  statistics: { created: 40, updated: 2, skipped: 0 },
+  completedAt: new Date('2026-07-27T00:00:00.000Z'),
+}
+
+/** Reads `count` SSE chunks, then cancels so no heartbeat interval leaks. */
+async function readChunks(res: Response, count = 1) {
+  const reader = res.body?.getReader()
+  if (!reader) throw new Error('no body')
+  const decoder = new TextDecoder()
+  let out = ''
+  for (let i = 0; i < count; i++) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out += decoder.decode(value)
+  }
+  await reader.cancel()
+  return out
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  requirePermission.mockReset()
+  limit.mockReset().mockResolvedValue([runningJob])
+})
+
+describe('GET /api/imports/[importJobId]/events — the records-import hole', () => {
+  it('401s without a session, before any capability or DB read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(requirePermission).not.toHaveBeenCalled()
+    expect(limit).not.toHaveBeenCalled()
+  })
+
+  it('403s a member composing `records: Edit` before touching the job', async () => {
+    // Edit grants recordsView + recordsEdit but NOT recordsImport — the exact
+    // member who used to get the whole stream, row values included.
+    signedIn(Level.Edit)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    // The gate must precede the lookup — otherwise job existence is probeable.
+    expect(limit).not.toHaveBeenCalled()
+  })
+
+  it('403s a member composing `records: None`', async () => {
+    signedIn(Level.None)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(limit).not.toHaveBeenCalled()
+  })
+
+  it('asserts `records.import` specifically', async () => {
+    signedIn(Level.Full)
+    await readChunks(await GET(request(), params))
+    expect(requirePermission).toHaveBeenCalledWith(USER_ID, ORG_ID, PermissionKey.recordsImport)
+  })
+
+  it('streams the job for a member holding records.import, gate first', async () => {
+    signedIn(Level.Full)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(limit).toHaveBeenCalledTimes(1)
+    // Ordering pinned on the ALLOWED path too: moving the gate below the lookup
+    // still 403s the unauthorized caller, but leaks existence timing.
+    expect(requirePermission.mock.invocationCallOrder[0]).toBeLessThan(
+      limit.mock.invocationCallOrder[0]
+    )
+    expect(await readChunks(res)).toContain('event: connected')
+  })
+
+  it('404s an unknown job for an authorized member', async () => {
+    signedIn(Level.Full)
+    limit.mockResolvedValue([])
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+  })
+
+  it('withholds the terminal statistics replay from a member without records.import', async () => {
+    // The finished-job branch replays `importJob.statistics` — behind the same gate.
+    signedIn(Level.Edit)
+    limit.mockResolvedValue([completedJob])
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(await res.text()).not.toContain('statistics')
+    expect(limit).not.toHaveBeenCalled()
+  })
+
+  it('replays the terminal statistics for a member holding records.import', async () => {
+    signedIn(Level.Full)
+    limit.mockResolvedValue([completedJob])
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    const body = await readChunks(res, 2)
+    expect(body).toContain('event: job:status')
+    expect(body).toContain('statistics')
+  })
+})

--- a/apps/web/src/app/api/imports/[importJobId]/events/route.ts
+++ b/apps/web/src/app/api/imports/[importJobId]/events/route.ts
@@ -1,6 +1,9 @@
 // apps/web/src/app/api/imports/[importJobId]/events/route.ts
 
 import { database as db, schema } from '@auxx/database'
+import { AuxxError } from '@auxx/lib/errors'
+import { requirePermission } from '@auxx/lib/permissions'
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { createScopedLogger } from '@auxx/logger'
 import { createDedicatedClient } from '@auxx/redis'
 import { and, eq } from 'drizzle-orm'
@@ -19,6 +22,22 @@ const IMPORT_EVENTS_CHANNEL = 'import:events'
 /**
  * SSE endpoint for import job events.
  * Clients subscribe to receive real-time updates on import progress.
+ *
+ * Gated on `records.import`, matching its tRPC sibling: every procedure in
+ * `server/api/routers/data-import.ts` runs through
+ * `permissionProcedure(recordsImport)`. Before this, the handler authenticated
+ * with `getSession` and scoped by org but read no capabilities, so any
+ * authenticated member could stream a live import — the `planning:row` events
+ * forwarded verbatim below carry the imported record VALUES (`fields`) plus
+ * `existingRecordId`, and the terminal replay carries `statistics`.
+ *
+ * The gate deliberately runs **before** the job lookup, so an unauthorized
+ * caller cannot probe job existence.
+ *
+ * `recordsImport` carries no `featureKey` in the permission registry, so
+ * `requirePermission` here reduces to `getCapabilities(...).assert(key)` — no
+ * plan-AND today. It is used rather than a bare `can()` so the Layer-1 gate
+ * comes along automatically if the key is ever linked to a feature.
  */
 export async function GET(
   request: NextRequest,
@@ -37,6 +56,17 @@ export async function GET(
 
   if (!organizationId) {
     return new Response('Organization not found', { status: 403 })
+  }
+
+  try {
+    await requirePermission(session.user.id, organizationId, PermissionKey.recordsImport)
+  } catch (error) {
+    // Returned explicitly so the AuxxError keeps its own status instead of
+    // surfacing as an unhandled 500 — this handler has no tRPC error formatter.
+    if (error instanceof AuxxError) {
+      return new Response(error.message, { status: error.statusCode })
+    }
+    throw error
   }
 
   // Verify access to the import job

--- a/apps/web/src/app/api/kb/articles/[articleId]/events/kb-article-instance-access.test.ts
+++ b/apps/web/src/app/api/kb/articles/[articleId]/events/kb-article-instance-access.test.ts
@@ -1,0 +1,242 @@
+// apps/web/src/app/api/kb/articles/[articleId]/events/kb-article-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The KB article realtime SSE route — same class as the run-trace hole.
+ *
+ * Its ONLY authorization was "this article exists in the caller's org": it
+ * selected `{ id }`, matched `Article.organizationId`, and opened a subscription
+ * to `kb:article:<id>` with no capability read and no instance assert. That
+ * channel carries `kb-article-resync`, whose payload is the article's ENTIRE
+ * `contentJson`, emitted on every manual save, Kopilot turn and revert (plus
+ * `kb-article-patch`'s block-level diffs). So any authenticated org member could
+ * tail the live body of any article — including one in a KB they hold an
+ * explicit `none` restriction on. The tRPC sibling `kb.getArticleById` resolves
+ * the parent KB and runs `assertViewInstance('kb', kbId)`.
+ *
+ * Behavioral: the real handler runs with a REAL `CapabilitySet`. Opening the
+ * Redis subscription (`createDedicatedClient`) is the observed side effect — the
+ * gate must land ahead of it, so an unauthorized caller never gets a stream.
+ */
+
+const { getCapabilities, getSession, select, articleLimit, createDedicatedClient, eq, and } =
+  vi.hoisted(() => ({
+    getCapabilities: vi.fn(),
+    getSession: vi.fn(),
+    select: vi.fn(),
+    articleLimit: vi.fn(),
+    createDedicatedClient: vi.fn(),
+    eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+    and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+  }))
+
+vi.mock('@auxx/database', () => ({
+  database: { select },
+  schema: {
+    Article: {
+      id: 'Article.id',
+      organizationId: 'Article.organizationId',
+      homeKnowledgeBaseId: 'Article.homeKnowledgeBaseId',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({ and, eq }))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest (get-capabilities,
+// record-view-scope, overage-*) — stub it, keep the enums real via `/client`.
+vi.mock('@auxx/lib/permissions', () => ({ getCapabilities }))
+vi.mock('@auxx/lib/kb', () => ({
+  kbArticleChannel: (articleId: string) => `kb:article:${articleId}`,
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('@auxx/redis', () => ({ createDedicatedClient }))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const ARTICLE_ID = 'art_cuid000000000000000000000'
+/** The article's home `KnowledgeBase.id` — what instance access keys on. */
+const KB_ID = 'kb_cuid0000000000000000000000'
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/** A real `CapabilitySet` holding `permission` on {@link KB_ID} via an explicit row. */
+function capabilitiesFor(permission: ResourcePermission, areaLevel = AREA_LEVEL_OF[permission]) {
+  const instances = { [KB_ID]: permission }
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/** A real `CapabilitySet` with no instance rows at all — pure area level. */
+function areaOnly(level: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+function signedIn(capabilities: InstanceType<typeof CapabilitySet>) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
+  })
+  getCapabilities.mockResolvedValue(capabilities)
+}
+
+const request = () =>
+  ({
+    headers: new Headers(),
+    signal: new AbortController().signal,
+  }) as never
+
+const params = { params: Promise.resolve({ articleId: ARTICLE_ID }) }
+
+/** Reads the first SSE chunk, then cancels so no heartbeat interval leaks. */
+async function firstChunk(res: Response) {
+  const reader = res.body?.getReader()
+  if (!reader) throw new Error('no body')
+  const { value } = await reader.read()
+  await reader.cancel()
+  return new TextDecoder().decode(value)
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  articleLimit.mockReset().mockResolvedValue([{ id: ARTICLE_ID, homeKnowledgeBaseId: KB_ID }])
+  eq.mockClear()
+  and.mockClear()
+  select.mockReset().mockReturnValue({
+    from: () => ({ where: () => ({ limit: articleLimit }) }),
+  })
+  createDedicatedClient.mockReset().mockResolvedValue({
+    subscribe: vi.fn(async () => undefined),
+    unsubscribe: vi.fn(async () => undefined),
+    quit: vi.fn(async () => undefined),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  })
+})
+
+describe('GET /api/kb/articles/[articleId]/events — the article-body hole', () => {
+  it('401s without a session, before any capability or DB read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('403s a member composing `knowledgeBase: None`, before the stream opens', async () => {
+    signedIn(areaOnly(Level.None))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(res.headers.get('Content-Type')).not.toBe('text/event-stream')
+    // The gate must precede the subscription — otherwise the caller is already
+    // attached to the channel when the next resync lands.
+    expect(createDedicatedClient).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding an explicit `none` restriction on the KB', async () => {
+    // THE case this fix exists for: the area is wide open (Full), and only the
+    // per-instance `none` row stands between the caller and the article body.
+    // Before the fix this member got the full stream.
+    signedIn(capabilitiesFor(ResourcePermission.none, Level.Full))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(createDedicatedClient).not.toHaveBeenCalled()
+  })
+
+  it('streams for a member holding instance `view` on the KB', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(await firstChunk(res)).toContain('event: connected')
+  })
+
+  it('streams for a row-less KB at the area Read rung (baselineAtCreate: false)', async () => {
+    // KBs are org-shared by default (doc 12 §0.2): with no `ResourceAccess` row
+    // anywhere, the absent-row fallback IS the area level.
+    signedIn(areaOnly(Level.Read))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(await firstChunk(res)).toContain('event: connected')
+  })
+
+  it('gates on the home KB, not the article id', async () => {
+    // The article id is what the URL carries, so keying the assert on it is the
+    // easy mistake. Here the area is None and the ONLY grant is an explicit
+    // `view` row on the KB — asserting against `ARTICLE_ID` would fall through
+    // to the closed area level and 403 a member who legitimately has access.
+    signedIn(capabilitiesFor(ResourcePermission.view, Level.None))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(await firstChunk(res)).toContain('event: connected')
+  })
+
+  it('selects the home KB id so the gate has a subject', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(), params)
+    expect(select.mock.calls[0]?.[0]).toHaveProperty(
+      'homeKnowledgeBaseId',
+      'Article.homeKnowledgeBaseId'
+    )
+    await firstChunk(res)
+  })
+
+  it('404s an absent article without reading capabilities or opening a stream', async () => {
+    // The read is org-scoped, so another org's article id is absent here too —
+    // identical to an article that never existed.
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    articleLimit.mockResolvedValue([])
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(createDedicatedClient).not.toHaveBeenCalled()
+  })
+
+  it('scopes the article read by organization', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(), params)
+    expect(eq).toHaveBeenCalledWith('Article.organizationId', ORG_ID)
+    await firstChunk(res)
+  })
+
+  it('403s a session with no organization, before any read', async () => {
+    getSession.mockResolvedValue({ user: { id: USER_ID, isSuperAdmin: false } })
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/api/kb/articles/[articleId]/events/route.ts
+++ b/apps/web/src/app/api/kb/articles/[articleId]/events/route.ts
@@ -2,6 +2,7 @@
 
 import { database as db, schema } from '@auxx/database'
 import { kbArticleChannel } from '@auxx/lib/kb'
+import { getCapabilities } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { createDedicatedClient } from '@auxx/redis'
 import { and, eq } from 'drizzle-orm'
@@ -24,6 +25,25 @@ export const dynamic = 'force-dynamic'
  * Auth happens at connect time only; subsequent events are delivered
  * to whoever is subscribed to the channel. This matches the existing
  * imports/documents SSE pattern.
+ *
+ * Gated on instance **`view`** of the article's home KnowledgeBase, matching the
+ * tRPC sibling `kb.getArticleById` (`capabilityProcedure` +
+ * `assertViewInstance('kb', kbId)`). Before this, the only check was "the
+ * article exists in the caller's org", so any authenticated org member could
+ * tail the channel — and `kb-article-resync` carries the article's ENTIRE
+ * `contentJson`, `kb-article-patch` its block-level diffs — even for a KB they
+ * hold an explicit `none` restriction on.
+ *
+ * Articles inherit their KB's access level (doc 12 §0.5) and
+ * `Article.homeKnowledgeBaseId` is `notNull`, so the row read below resolves the
+ * gate's subject totally. The gate runs **before the stream opens** and before
+ * any further read, so an unauthorized caller never gets a subscription.
+ *
+ * No `FeatureKey.knowledgeBase` plan-AND: the tRPC sibling is a
+ * `capabilityProcedure`, which runs no plan gate, and this is the same
+ * read-only surface (it also matches the run-trace SSE precedent). An org
+ * downgraded off the KB plan can still tail an article it already owns —
+ * accepted, and deliberately not a stricter gate than the tRPC read it mirrors.
  */
 export async function GET(
   request: NextRequest,
@@ -44,15 +64,22 @@ export async function GET(
     return new Response('Organization not found', { status: 403 })
   }
 
-  // Verify access: article must belong to this org.
+  // Org scope + resolve the gate's subject. An article in another org is
+  // indistinguishable from one that never existed (both → 404), so article ids
+  // are not probeable across orgs.
   const [article] = await db
-    .select({ id: schema.Article.id })
+    .select({ id: schema.Article.id, homeKnowledgeBaseId: schema.Article.homeKnowledgeBaseId })
     .from(schema.Article)
     .where(and(eq(schema.Article.id, articleId), eq(schema.Article.organizationId, organizationId)))
     .limit(1)
 
   if (!article) {
     return new Response('Article not found', { status: 404 })
+  }
+
+  const capabilities = await getCapabilities(session.user.id, organizationId)
+  if (!capabilities.canViewInstance('kb', article.homeKnowledgeBaseId)) {
+    return new Response('Forbidden', { status: 403 })
   }
 
   const encoder = new TextEncoder()

--- a/apps/web/src/app/api/kopilot/stream/agent-access.test.ts
+++ b/apps/web/src/app/api/kopilot/stream/agent-access.test.ts
@@ -1,0 +1,419 @@
+// apps/web/src/app/api/kopilot/stream/agent-access.test.ts
+
+import {
+  Area,
+  expandLevelsToKeys,
+  FeatureKey,
+  Level,
+  type PermissionKey as PermissionKeyType,
+} from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * **The live authorization hole this file closes.**
+ *
+ * `POST /api/kopilot/stream` authenticated with `auth.api.getSession` alone and
+ * read NO capabilities, while every `agent.*` tRPC procedure requires
+ * `agents.manage`. `agentId` arrives verbatim on the request body, so any
+ * authenticated member could chat with any agent in the org — including agents
+ * they cannot see in the UI. The only agent-side check was
+ * `buildDmTriggerContext`, which tests the ORG-WIDE `dmEnabled` toggle, not the
+ * caller.
+ *
+ * Behavioral: the real handler is invoked and driven end to end, with a REAL
+ * `CapabilitySet` handed back by `getCapabilities`. `withAgentRunLog` is the
+ * observed side effect — it wraps the whole turn, so "was it called?" is
+ * exactly "did this request get past the gate into the run?".
+ *
+ * Two halves are tested separately on purpose: a NEW session is authorized from
+ * `body.agentId` before the stream opens (plain 403), while a CONTINUATION turn
+ * restores its agent from the SESSION ROW and is authorized inside the stream
+ * (`turn-error` / `forbidden`). Deleting either arm reopens the hole.
+ */
+
+const {
+  getCapabilities,
+  getSession,
+  hasFeature,
+  getCachedAgentById,
+  createSession,
+  getSessionById,
+  runTurn,
+  isAdminOrOwner,
+} = vi.hoisted(() => ({
+  getCapabilities: vi.fn(),
+  getSession: vi.fn(),
+  hasFeature: vi.fn(),
+  getCachedAgentById: vi.fn(),
+  createSession: vi.fn(),
+  getSessionById: vi.fn(),
+  /**
+   * Stands in for `withAgentRunLog`, which wraps the entire turn. It
+   * deliberately does NOT invoke the wrapped `runPath` — reaching it at all is
+   * the proof the gate let the caller through, and running the real engine here
+   * would buy nothing.
+   */
+  runTurn: vi.fn(async () => undefined),
+  isAdminOrOwner: vi.fn(async () => false),
+}))
+
+vi.mock('@auxx/database', () => ({ database: {}, schema: {} }))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+// The `@auxx/lib/permissions` barrel hangs under vitest (get-capabilities,
+// record-view-scope, overage-*), and it is exactly what this route imports, so
+// it has to be stubbed wholesale. The enums come from the client subpath so the
+// route asserts the REAL `agents.manage` / `agents` values.
+vi.mock('@auxx/lib/permissions', async () => {
+  const client = await import('@auxx/lib/permissions/client')
+  return {
+    FeatureKey: client.FeatureKey,
+    PermissionKey: client.PermissionKey,
+    getCapabilities,
+    FeaturePermissionService: class {
+      hasAccess = hasFeature
+    },
+  }
+})
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedAgentById,
+  getCachedDefaultModel: vi.fn(async () => null),
+}))
+
+vi.mock('@auxx/lib/errors', () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+}))
+
+vi.mock('@auxx/lib/members', () => ({ isAdminOrOwner }))
+
+vi.mock('@auxx/lib/tiptap', () => ({ docToText: () => '' }))
+
+vi.mock('@auxx/lib/agents', () => ({
+  buildDmTriggerContext: vi.fn(() => ({
+    triggerContext: { triggerId: 'trg_1', kind: 'dm', firedAt: new Date().toISOString() },
+    triggerInstructions: null,
+  })),
+  filterToolsByToolsets: vi.fn((tools: unknown) => tools),
+  resolveAgentConfig: vi.fn(async () => ({ knowledge: [] })),
+  resolveAgentKnowledgeScope: vi.fn(async () => null),
+}))
+
+vi.mock('@auxx/lib/ai', () => ({
+  UsageTrackingService: class {
+    trackUsageBatch = vi.fn(async () => undefined)
+  },
+}))
+
+vi.mock('@auxx/lib/ai/agent-framework', () => ({
+  AgentEngine: class {},
+  cleanDomainStateForModelSwitch: vi.fn((s: unknown) => s),
+  createCallModel: vi.fn(),
+  enqueueAgentJob: vi.fn(async () => undefined),
+  flattenMessagesForModelSwitch: vi.fn((m: unknown) => m),
+  resolveAgentRunCapabilities: vi.fn(async () => null),
+  subscribeToAgentEvents: vi.fn(),
+  withAgentRunLog: runTurn,
+  BUILDER_MODEL: { provider: 'anthropic', model: 'x' },
+}))
+
+vi.mock('@auxx/lib/ai/kopilot', () => ({
+  createActorCapabilities: vi.fn(),
+  createAgentsBuilderCapabilities: vi.fn(),
+  createAppCapabilities: vi.fn(),
+  createCapabilityRegistry: vi.fn(),
+  createEntityCapabilities: vi.fn(),
+  createKbCapabilities: vi.fn(),
+  createKbReadCapabilities: vi.fn(),
+  createKnowledgeCapabilities: vi.fn(),
+  createKopilotCapabilities: vi.fn(),
+  createKopilotDomainConfig: vi.fn(),
+  createMailCapabilities: vi.fn(),
+  createRecordViewCapabilities: vi.fn(),
+  createSuggestRepliesGlobalCapability: vi.fn(),
+  createTaskCapabilities: vi.fn(),
+  generateSessionTitle: vi.fn(async () => null),
+  LAST_CONTEXT_KEY: '_lastContext',
+  LAST_PAGE_KEY: '_lastPage',
+  resolveContinuationSurface: vi.fn(
+    ({ requestPage, requestContext }: { requestPage?: string; requestContext?: unknown }) => ({
+      page: requestPage,
+      context: requestContext,
+    })
+  ),
+}))
+
+vi.mock('@auxx/lib/ai/kopilot/capabilities', () => ({
+  createLearnedKbCapabilities: vi.fn(),
+  createToolDepsFactory: vi.fn(),
+}))
+
+vi.mock('@auxx/lib/ai/mcp', () => ({ createMcpCapabilities: vi.fn() }))
+
+vi.mock('@auxx/services', () => ({
+  createSession,
+  getSessionById,
+  saveSessionMessages: vi.fn(async () => undefined),
+  updateSessionDomainState: vi.fn(async () => undefined),
+  updateSessionModelId: vi.fn(async () => undefined),
+  updateSessionTitle: vi.fn(async () => undefined),
+}))
+
+vi.mock('./task-notification', () => ({ resolveTaskNotification: vi.fn() }))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel above is mocked, and it hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { POST } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const AGENT_ID = 'agt_cuid000000000000000000000'
+const SESSION_ID = 'ses_cuid000000000000000000000'
+
+/** A real `CapabilitySet` composed from one area level, exactly as the composer does. */
+function capabilitiesWith(agentsLevel: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.agents]: agentsLevel }) as PermissionKeyType[]),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+/**
+ * `Level.Full` is what `MEMBER_BASELINE_LEVELS[Area.agents]` seeds, so this is
+ * the ordinary full-seat member. `Level.None` is the population the fix is FOR:
+ * a restricted profile, or any worker seat (`agents` is absent from
+ * `WORKER_AREAS`, so `SEAT_CEILINGS.worker` clamps it to None).
+ */
+function signedIn(agentsLevel: Level) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
+  })
+  getCapabilities.mockResolvedValue(capabilitiesWith(agentsLevel))
+}
+
+/** The session row a continuation turn restores its agent from. */
+function existingSession(agentId: string | null, type: 'kopilot' | 'builder' = 'kopilot') {
+  getSessionById.mockResolvedValue({
+    isErr: () => false,
+    value: { messages: [], domainState: {}, modelId: null, agentId, type },
+  })
+}
+
+function request(body: Record<string, unknown>) {
+  return {
+    json: async () => body,
+    signal: new AbortController().signal,
+    url: 'http://localhost/api/kopilot/stream',
+  } as never
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  getCachedAgentById.mockReset().mockResolvedValue({ id: AGENT_ID, dmEnabled: true })
+  getSessionById.mockReset()
+  createSession.mockReset().mockResolvedValue({
+    isErr: () => false,
+    value: { id: SESSION_ID, type: 'kopilot', createdAt: new Date() },
+  })
+  runTurn.mockReset().mockResolvedValue(undefined)
+  isAdminOrOwner.mockReset().mockResolvedValue(false)
+  // Every feature on by default; individual tests close the ones they test.
+  hasFeature.mockReset().mockResolvedValue(true)
+})
+
+describe('POST /api/kopilot/stream — new session binds body.agentId', () => {
+  it('401s without a session', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(401)
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('lets an authorized member reach the agent', async () => {
+    signedIn(Level.Full)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(createSession).toHaveBeenCalledTimes(1)
+    expect(createSession.mock.calls[0]?.[0]).toMatchObject({ agentId: AGENT_ID })
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('403s a member without agents.manage — THE hole', async () => {
+    // Before the fix this member got a full agent turn.
+    signedIn(Level.None)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(403)
+    // Refused as plain HTTP, before the stream opens and before a session row
+    // pointing at an unreachable agent is written.
+    expect(res.headers.get('Content-Type')).not.toBe('text/event-stream')
+    expect(createSession).not.toHaveBeenCalled()
+    expect(runTurn).not.toHaveBeenCalled()
+  })
+
+  it('403s an unauthorized DM turn before the agent is ever read', async () => {
+    // The DM path's only agent-side check was `dmEnabled` — an ORG-WIDE toggle.
+    // The capability gate has to come first, or an unauthorized caller still
+    // learns whether the agent exists and has DMs on.
+    signedIn(Level.None)
+    const res = await POST(
+      request({ message: 'hi', agentId: AGENT_ID, triggerKind: 'dm', page: 'agents.dm' })
+    )
+    expect(res.status).toBe(403)
+    expect(getCachedAgentById).not.toHaveBeenCalled()
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('403s an authorized member when the org has no agents feature', async () => {
+    // The plan-AND every `permissionProcedure(agentsManage)` sibling runs. The
+    // route's own FeatureKey.kopilot gate does not cover it.
+    signedIn(Level.Full)
+    hasFeature.mockImplementation(async (_org: string, key: string) => key !== FeatureKey.agents)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(403)
+    await expect(res.text()).resolves.toContain('plan')
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('still 403s on the kopilot feature gate ahead of everything', async () => {
+    signedIn(Level.Full)
+    hasFeature.mockImplementation(async (_org: string, key: string) => key !== FeatureKey.kopilot)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(403)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/kopilot/stream — continuation turns restore the agent from the session row', () => {
+  it('refuses turn 2 on a session whose agent the caller cannot access', async () => {
+    // THE subtle half. `body.agentId` is ignored on an existing session, so a
+    // body-only check would let every turn after the first through — including
+    // on a session hijacked (or legitimately created) before the caller's
+    // profile was tightened.
+    signedIn(Level.None)
+    existingSession(AGENT_ID)
+    const res = await POST(request({ message: 'again', sessionId: SESSION_ID }))
+    // The stream is already open by the time the agent is known, so the refusal
+    // uses the route's own SSE error shape rather than an HTTP status.
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('turn-error')
+    expect(body).toContain('forbidden')
+    expect(runTurn).not.toHaveBeenCalled()
+  })
+
+  it('refuses a DM continuation before re-reading the agent', async () => {
+    signedIn(Level.None)
+    existingSession(AGENT_ID)
+    const res = await POST(request({ message: 'again', sessionId: SESSION_ID, triggerKind: 'dm' }))
+    const body = await res.text()
+    expect(body).toContain('forbidden')
+    expect(getCachedAgentById).not.toHaveBeenCalled()
+    expect(runTurn).not.toHaveBeenCalled()
+  })
+
+  it('lets an authorized member continue an agent session', async () => {
+    signedIn(Level.Full)
+    existingSession(AGENT_ID)
+    const res = await POST(request({ message: 'again', sessionId: SESSION_ID }))
+    const body = await res.text()
+    expect(body).not.toContain('forbidden')
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a stale body.agentId on a session that has no agent', async () => {
+    // `agentId` is documented as ignored on existing sessions. A stale value
+    // left on the client must not deny a plain-Kopilot turn it has no effect
+    // on — which is why the pre-stream gate is scoped to new sessions.
+    signedIn(Level.None)
+    existingSession(null)
+    const res = await POST(request({ message: 'again', sessionId: SESSION_ID, agentId: AGENT_ID }))
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).not.toContain('forbidden')
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('POST /api/kopilot/stream — sessions with no agent in play', () => {
+  it('runs a plain Kopilot session for a member without agents.manage', async () => {
+    // The gate must not leak onto master Kopilot: `agentsManage` fronts agent
+    // AUTHORING, and plain Kopilot is the human alone.
+    signedIn(Level.None)
+    const res = await POST(request({ message: 'hi' }))
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).not.toContain('forbidden')
+    expect(createSession).toHaveBeenCalledTimes(1)
+    expect(createSession.mock.calls[0]?.[0]).toMatchObject({ agentId: null })
+    expect(runTurn).toHaveBeenCalledTimes(1)
+    // No agent in play → the route reads no capabilities at all.
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('runs a plain Kopilot session on an org with no agents feature', async () => {
+    signedIn(Level.Full)
+    hasFeature.mockImplementation(async (_org: string, key: string) => key !== FeatureKey.agents)
+    const res = await POST(request({ message: 'hi' }))
+    expect(res.status).toBe(200)
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues an agent-less session without a capability read', async () => {
+    signedIn(Level.None)
+    existingSession(null)
+    const res = await POST(request({ message: 'again', sessionId: SESSION_ID }))
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/kopilot/stream — builder sessions', () => {
+  it('lets an authorized member open a builder session', async () => {
+    signedIn(Level.Full)
+    const res = await POST(request({ message: 'build', agentId: AGENT_ID, sessionType: 'builder' }))
+    expect(res.status).toBe(200)
+    expect(createSession.mock.calls[0]?.[0]).toMatchObject({
+      agentId: AGENT_ID,
+      type: 'builder',
+    })
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('403s a builder session for a member without agents.manage', async () => {
+    // Deliberate: a builder session's agent is the SUBJECT OF EDITING, which is
+    // exactly what `agentsManage` fronts. The page hosting it is already
+    // capability-gated client-side, so no legitimate session loses anything.
+    signedIn(Level.None)
+    const res = await POST(request({ message: 'build', agentId: AGENT_ID, sessionType: 'builder' }))
+    expect(res.status).toBe(403)
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('refuses a builder CONTINUATION turn too', async () => {
+    signedIn(Level.None)
+    existingSession(AGENT_ID, 'builder')
+    const res = await POST(request({ message: 'build', sessionId: SESSION_ID }))
+    const body = await res.text()
+    expect(body).toContain('forbidden')
+    expect(runTurn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -54,6 +54,7 @@ import {
   FeatureKey,
   FeaturePermissionService,
   getCapabilities,
+  PermissionKey,
 } from '@auxx/lib/permissions'
 import { docToText } from '@auxx/lib/tiptap'
 import { createScopedLogger } from '@auxx/logger'
@@ -91,6 +92,50 @@ function renderDmInstructions(instructions: Record<string, unknown> | null): str
   }
   const text = docToText(instructions, {})
   return text.length > 0 ? text : null
+}
+
+/**
+ * Whether the caller may run a turn that targets a user-authored agent.
+ * Returns `null` when allowed, or the denial message when not.
+ *
+ * **This closes a live authorization hole.** Until 2026-07-27 this route
+ * authenticated with `auth.api.getSession` alone and read no capabilities at
+ * all, while every `agent.*` tRPC procedure requires
+ * {@link PermissionKey.agentsManage}. `agentId` arrives verbatim on the request
+ * body, so any authenticated member could POST an arbitrary agent id and chat
+ * with an agent they cannot see in the UI — including the DM path, whose only
+ * agent-side check (`buildDmTriggerContext`) tests the org-wide `dmEnabled`
+ * toggle, not the caller.
+ *
+ * Two gates, matching what `permissionProcedure(agentsManage)` runs for the
+ * tRPC siblings: the {@link FeatureKey.agents} plan-AND (the route's existing
+ * {@link FeatureKey.kopilot} gate does not cover the agents feature) and the
+ * capability itself.
+ *
+ * TODO(permissions v2, item 4 — agents instance access): `Area.agents` is a
+ * SINGLE-RUNG area today (`Full → agents.manage` is its only rung, see
+ * `registry.ts`), so this is deliberately agent-id-blind — there is no View
+ * rung to gate on yet. When item 4 splits the area into View/Edit/Full,
+ * re-point this at the new View rung and add
+ * `capabilities.assertViewInstance('agent', agentId)` beside it, taking the id
+ * as a parameter. **Extend this function — do not add a second gate elsewhere.**
+ */
+async function resolveAgentAccessDenial(params: {
+  organizationId: string
+  userId: string
+}): Promise<string | null> {
+  const { organizationId, userId } = params
+  const hasAgents = await new FeaturePermissionService().hasAccess(
+    organizationId,
+    FeatureKey.agents
+  )
+  if (!hasAgents) return 'Agents are not available on your plan'
+
+  const capabilities = await getCapabilities(userId, organizationId)
+  if (!capabilities.can(PermissionKey.agentsManage)) {
+    return 'You do not have access to this agent'
+  }
+  return null
 }
 
 export const runtime = 'nodejs'
@@ -189,6 +234,18 @@ export async function POST(request: NextRequest) {
 
   if (!body.message || typeof body.message !== 'string') {
     return new Response('Message is required', { status: 400 })
+  }
+
+  // Agent authorization, first half: a NEW session binds `body.agentId`
+  // verbatim, so refuse before `createSession` writes a row pointing at an
+  // agent the caller can't reach — and as plain HTTP, before the stream opens.
+  // `agentId` is documented as ignored on existing sessions, so a stale value
+  // from the client must not deny a turn it has no effect on; the resolved id
+  // is authorized separately below. Plain Kopilot (no agent) skips this
+  // entirely.
+  if (!body.sessionId && body.agentId) {
+    const denial = await resolveAgentAccessDenial({ organizationId, userId })
+    if (denial) return new Response(denial, { status: 403 })
   }
 
   // Async-task continuation: validate, dedupe, and rewrite the body from DB
@@ -367,6 +424,25 @@ export async function POST(request: NextRequest) {
             title: placeholderTitle,
             createdAt: createResult.value.createdAt.toISOString(),
           })
+        }
+
+        // Agent authorization, second half — the one that matters on turn 2.
+        // `sessionAgentId` is restored from the SESSION ROW on continuation
+        // turns, not from the body, so authorizing only the body-supplied id
+        // would let every turn after the first sail through on a session whose
+        // agent the caller can't access (including one bound before their
+        // profile was tightened). Authorize the RESOLVED id on every turn.
+        //
+        // Builder sessions are included on purpose: their agent is the subject
+        // of editing, which is exactly what `agentsManage` fronts. Sessions
+        // with no agent (plain Kopilot) read no capabilities at all.
+        if (sessionAgentId) {
+          const denial = await resolveAgentAccessDenial({ organizationId, userId })
+          if (denial) {
+            send({ type: 'turn-error', error: denial, code: 'forbidden' })
+            cleanup()
+            return
+          }
         }
 
         // Existing-session DM gate: re-resolve the cached agent on every send

--- a/apps/web/src/app/api/mcp/[serverId]/oauth2/authorize/mcp-oauth-authorize-access.test.ts
+++ b/apps/web/src/app/api/mcp/[serverId]/oauth2/authorize/mcp-oauth-authorize-access.test.ts
@@ -1,0 +1,220 @@
+// apps/web/src/app/api/mcp/[serverId]/oauth2/authorize/mcp-oauth-authorize-access.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * **The live privilege hole this slice closed.**
+ *
+ * This REST authorize route authenticated with `auth.api.getSession` alone and read NO
+ * capabilities, while every mutating tRPC sibling (`mcp.create` / `connect` / `update` /
+ * `delete`) sits behind `mcpAdminProcedure` = `permissionProcedure(integrationsManage)`.
+ * The route mints Redis OAuth state and redirects; its callback then calls
+ * `saveMcpConnection` with the `organizationId` taken straight out of that state, writing an
+ * **org-level** MCP credential. `mcp.list` is a bare `protectedProcedure`, so any member could
+ * enumerate every `serverId` first.
+ *
+ * Behavioral: the REAL handler is invoked and a REAL `CapabilitySet` (built from
+ * `expandLevelsToKeys`) answers the assert. The Redis `setex` — the state write that makes the
+ * callback's credential write reachable — is the observed side effect.
+ */
+
+const { getCapabilities, getSession, redis, db, interpolate, resolveMcpConnection } = vi.hoisted(
+  () => ({
+    getCapabilities: vi.fn(),
+    getSession: vi.fn(),
+    redis: { setex: vi.fn(async () => 'OK') },
+    db: {
+      mcpServer: vi.fn(),
+      connectionDefinition: vi.fn(),
+    },
+    interpolate: vi.fn(() => ({
+      authorizeUrl: 'https://provider.test/authorize',
+      clientId: 'client_abc',
+    })),
+    resolveMcpConnection: vi.fn(),
+  })
+)
+
+vi.mock('@auxx/config/urls', () => ({ WEBAPP_URL: 'http://localhost:3000' }))
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    query: {
+      McpServer: { findFirst: db.mcpServer },
+      ConnectionDefinition: { findFirst: db.connectionDefinition },
+    },
+  },
+}))
+
+vi.mock('@auxx/lib/ai/mcp', () => ({ resolveMcpConnectionForRuntime: resolveMcpConnection }))
+
+/**
+ * The `@auxx/lib/permissions` barrel hangs under vitest (get-capabilities, record-view-scope,
+ * overage-*), so it can't be partially mocked — but `requirePermission` is re-implemented here
+ * FAITHFULLY rather than stubbed: `integrationsManage` carries no `featureKey` in the registry,
+ * so the real function's plan-gate branch is dead for this key and these two lines ARE its whole
+ * body. The `PermissionKey` enum and the `assert` that throws are both the real thing.
+ */
+vi.mock('@auxx/lib/permissions', async () => {
+  const { PermissionKey } = await import('@auxx/lib/permissions/capabilities/registry')
+  return {
+    PermissionKey,
+    requirePermission: async (userId: string, orgId: string, key: never) => {
+      const caps = await getCapabilities(userId, orgId)
+      caps.assert(key)
+    },
+  }
+})
+
+vi.mock('@auxx/redis', () => ({ getRedisClient: async () => redis }))
+
+vi.mock('@auxx/services/app-connections', () => ({ interpolateConnectionFields: interpolate }))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const SERVER_ID = 'mcp_cuid00000000000000000000'
+
+/** A real `CapabilitySet` at the given `integrations` rung — Full is the only rung that key has. */
+function capabilitiesAt(level: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.integrations]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+function signedIn(level: Level) {
+  getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
+  getCapabilities.mockResolvedValue(capabilitiesAt(level))
+}
+
+const params = { params: Promise.resolve({ serverId: SERVER_ID }) }
+
+const request = (query = '') =>
+  ({
+    nextUrl: new URL(`http://localhost:3000/api/mcp/${SERVER_ID}/oauth2/authorize${query}`),
+  }) as never
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  redis.setex.mockClear()
+  interpolate.mockClear()
+  resolveMcpConnection.mockReset()
+  db.mcpServer.mockReset().mockResolvedValue({
+    id: SERVER_ID,
+    organizationId: ORG_ID,
+    name: 'Acme MCP',
+    endpoint: 'https://acme.test/mcp',
+  })
+  db.connectionDefinition.mockReset().mockResolvedValue({
+    id: 'cd_cuid0000000000000000000000',
+    connectionType: 'oauth2-code',
+    oauth2Features: {},
+    oauth2Scopes: ['read'],
+    connectionVariables: [],
+  })
+})
+
+describe('GET /api/mcp/[serverId]/oauth2/authorize — the org-credential hole', () => {
+  it('401s without a session, before any capability read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('401s a session with no default organization', async () => {
+    getSession.mockResolvedValue({ user: { id: USER_ID } })
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('403s a member without `integrationsManage` (THE regression)', async () => {
+    // Before this slice any authenticated member reached the redirect, and the callback
+    // then wrote an org-level MCP credential on their behalf.
+    signedIn(Level.None)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.any(String) })
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('403s a member at the `integrations` Read rung', async () => {
+    // `integrations` exposes the key only at Full — Read must not be enough.
+    signedIn(Level.Read)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('runs the gate BEFORE the server lookup, the state write and the redirect', async () => {
+    signedIn(Level.None)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    // No enumeration oracle either: a refused caller never learns whether the server exists.
+    expect(db.mcpServer).not.toHaveBeenCalled()
+    expect(db.connectionDefinition).not.toHaveBeenCalled()
+    expect(redis.setex).not.toHaveBeenCalled()
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('asserts against the SESSION user and org', async () => {
+    signedIn(Level.Full)
+    await GET(request(), params)
+    expect(getCapabilities).toHaveBeenCalledWith(USER_ID, ORG_ID)
+  })
+
+  it('lets an `integrationsManage` holder through to the provider redirect', async () => {
+    signedIn(Level.Full)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('https://provider.test/authorize')
+    expect(redis.setex).toHaveBeenCalledTimes(1)
+    const [key, ttl, payload] = redis.setex.mock.calls[0]!
+    expect(key).toMatch(/^oauth:mcp-connection:/)
+    expect(ttl).toBe(600)
+    expect(JSON.parse(payload as string)).toMatchObject({
+      userId: USER_ID,
+      organizationId: ORG_ID,
+      mcpServerId: SERVER_ID,
+    })
+  })
+
+  it('still 404s an unknown server for a holder (the gate did not replace the lookup)', async () => {
+    signedIn(Level.Full)
+    db.mcpServer.mockResolvedValueOnce(undefined)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+
+  it('still 404s another org’s server for a holder', async () => {
+    signedIn(Level.Full)
+    db.mcpServer.mockResolvedValueOnce({
+      id: SERVER_ID,
+      organizationId: 'org_someoneelse000000000000',
+      name: 'Theirs',
+      endpoint: 'https://theirs.test/mcp',
+    })
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+    expect(redis.setex).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/api/mcp/[serverId]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/mcp/[serverId]/oauth2/authorize/route.ts
@@ -4,6 +4,8 @@ import { WEBAPP_URL } from '@auxx/config/urls'
 import type { OAuth2Features } from '@auxx/database'
 import { database as db } from '@auxx/database'
 import { resolveMcpConnectionForRuntime } from '@auxx/lib/ai/mcp'
+import { AuxxError } from '@auxx/lib/errors'
+import { PermissionKey, requirePermission } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
@@ -19,6 +21,12 @@ const logger = createScopedLogger('mcp-oauth-authorize')
  * MCP OAuth authorize — mirrors the app route at `/api/apps/[slug]/oauth2/authorize`, keyed on
  * `McpServer.id` instead of an app slug + installation. Always uses PKCE and appends the RFC 8707
  * `resource` indicator (the MCP endpoint) per the MCP spec.
+ *
+ * Gated on `integrationsManage`, matching `mcpAdminProcedure` — the tRPC sibling `mcp.connect`
+ * and every other mutating MCP procedure. This handler leads to an ORG-LEVEL credential write
+ * (its callback calls `saveMcpConnection` with the `organizationId` stashed in Redis state), so
+ * before this gate any authenticated member could enumerate server ids via the bare
+ * `protectedProcedure` `mcp.list` and connect an org-wide MCP credential.
  */
 export async function GET(
   request: NextRequest,
@@ -31,6 +39,20 @@ export async function GET(
   const organizationId = (session.user as { defaultOrganizationId?: string }).defaultOrganizationId
   if (!organizationId) {
     return NextResponse.json({ error: 'No organization' }, { status: 401 })
+  }
+
+  // Ahead of every read, the Redis state write and the redirect. Returned explicitly so the
+  // AuxxError keeps its own 403 instead of being swallowed by the outer 500 handler below.
+  try {
+    await requirePermission(session.user.id, organizationId, PermissionKey.integrationsManage)
+  } catch (permissionError) {
+    if (permissionError instanceof AuxxError) {
+      return NextResponse.json(
+        { error: permissionError.message },
+        { status: permissionError.statusCode }
+      )
+    }
+    throw permissionError
   }
 
   const { serverId } = await params

--- a/apps/web/src/app/api/workflow/run/[runId]/events/route.ts
+++ b/apps/web/src/app/api/workflow/run/[runId]/events/route.ts
@@ -1,7 +1,9 @@
 // apps/web/src/app/api/workflow/run/[runId]/events/route.ts
 
 import { database as db, schema } from '@auxx/database'
+import { getCapabilities } from '@auxx/lib/permissions'
 import { safeJsonStringify } from '@auxx/lib/workflow-engine'
+import { assertWorkflowRunNotSystemOwned } from '@auxx/lib/workflows'
 import { createScopedLogger } from '@auxx/logger'
 import { createDedicatedClient } from '@auxx/redis'
 import { and, asc, eq } from 'drizzle-orm'
@@ -14,6 +16,26 @@ const logger = createScopedLogger('workflow-run-events-api')
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
+/**
+ * SSE replay + live tail of a workflow run's node executions.
+ *
+ * Gated on instance **`view`** of the run's parent `WorkflowApp`, matching the
+ * tRPC sibling `workflow.getWorkflowRun` (`permissionProcedure(workflowsView)` +
+ * `assertViewInstance`): reading a run trace is a read, and `view` already means
+ * "you may RUN it" (plan 30 §2). Before this, the handler authenticated with
+ * `getSession` alone and read no capabilities, so any authenticated org member
+ * could replay any run's full trace — node inputs and outputs included — even
+ * for a workflow they hold an explicit `none` restriction on.
+ *
+ * The gate deliberately runs **before** the run/node-execution reads, so an
+ * unauthorized caller cannot probe run state at all.
+ *
+ * No `FeatureKey.workflows` plan-AND: this follows the read-only precedent
+ * (`workflow.list` / `getManualWorkflows` use `capabilityProcedure` and skip it)
+ * and its own REST siblings in `/api/workflows/[workflowId]/run`, which resolve
+ * capabilities directly. An org off a workflows plan can still replay traces of
+ * runs it already produced — accepted, read-only.
+ */
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ runId: string }> }
@@ -29,7 +51,32 @@ export async function GET(
   const organizationId =
     (session.user as any).defaultOrganizationId || (session.user as any).organizationId
 
-  // Verify access and get current state
+  // System-owned workflows (Sequences plan §3.4) stay invisible to org users.
+  // The guard is org-scoped and also resolves the parent `WorkflowApp.id`, which
+  // is what per-workflow instance access keys on — the URL only carries a run id.
+  // A run belonging to another org is indistinguishable from one that never
+  // existed (both `undefined` → 404), so run ids are not probeable across orgs.
+  let workflowAppId: string | undefined
+  try {
+    workflowAppId = await assertWorkflowRunNotSystemOwned(db, {
+      runId,
+      organizationId,
+      isSuperAdmin: (session.user as any).isSuperAdmin,
+      allowSuperAdminRead: true,
+    })
+  } catch (_error) {
+    return new Response('Forbidden', { status: 403 })
+  }
+  if (!workflowAppId) {
+    return new Response('Workflow run not found', { status: 404 })
+  }
+
+  const capabilities = await getCapabilities(session.user.id, organizationId)
+  if (!capabilities.canViewInstance('workflow', workflowAppId)) {
+    return new Response('Forbidden', { status: 403 })
+  }
+
+  // Get current state. Authorization already happened above.
   const [workflowRun] = await db
     .select()
     .from(schema.WorkflowRun)
@@ -38,15 +85,22 @@ export async function GET(
     )
     .limit(1)
 
-  const nodeExecutions = await db
-    .select()
-    .from(schema.WorkflowNodeExecution)
-    .where(eq(schema.WorkflowNodeExecution.workflowRunId, runId))
-    .orderBy(asc(schema.WorkflowNodeExecution.createdAt))
-
   if (!workflowRun) {
     return new Response('Workflow run not found', { status: 404 })
   }
+
+  // Org-scoped through the run we just loaded: filtering on `workflowRunId`
+  // alone was a latent IDOR if a run id ever leaked across org boundaries.
+  const nodeExecutions = await db
+    .select()
+    .from(schema.WorkflowNodeExecution)
+    .where(
+      and(
+        eq(schema.WorkflowNodeExecution.workflowRunId, runId),
+        eq(schema.WorkflowNodeExecution.organizationId, workflowRun.organizationId)
+      )
+    )
+    .orderBy(asc(schema.WorkflowNodeExecution.createdAt))
 
   const encoder = new TextEncoder()
 

--- a/apps/web/src/app/api/workflow/run/[runId]/events/run-trace-instance-access.test.ts
+++ b/apps/web/src/app/api/workflow/run/[runId]/events/run-trace-instance-access.test.ts
@@ -1,0 +1,254 @@
+// apps/web/src/app/api/workflow/run/[runId]/events/run-trace-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 30 §2.4, third instance of the class — the run-TRACE SSE route.
+ *
+ * `#1345` closed the hole on `/api/workflows/[workflowId]/run` (POST test-run,
+ * DELETE stop) and missed this sibling. It authenticated with
+ * `auth.api.getSession` alone and read NO capabilities, then streamed every
+ * `WorkflowNodeExecution` for the run — node **inputs and outputs** — so any
+ * authenticated org member could replay any run's full trace, including runs of
+ * a workflow they hold an explicit `none` restriction on. Its tRPC sibling
+ * `workflow.getWorkflowRun` sits behind `permissionProcedure(workflowsView)` +
+ * `assertViewInstance`.
+ *
+ * Behavioral: the real handler runs with a REAL `CapabilitySet`. The DB reads
+ * are the observed side effect — the gate must land ahead of them, so an
+ * unauthorized caller cannot even probe run state.
+ */
+
+const { getCapabilities, getSession, guardRun, select, runLimit, nodeOrderBy, eq, and } =
+  vi.hoisted(() => ({
+    getCapabilities: vi.fn(),
+    getSession: vi.fn(),
+    guardRun: vi.fn(),
+    runLimit: vi.fn(),
+    nodeOrderBy: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+    and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+  }))
+
+vi.mock('@auxx/database', () => ({
+  database: { select },
+  schema: {
+    WorkflowRun: { id: 'WorkflowRun.id', organizationId: 'WorkflowRun.organizationId' },
+    WorkflowNodeExecution: {
+      workflowRunId: 'WorkflowNodeExecution.workflowRunId',
+      organizationId: 'WorkflowNodeExecution.organizationId',
+      createdAt: 'WorkflowNodeExecution.createdAt',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({ and, eq, asc: vi.fn((c: unknown) => c) }))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest (get-capabilities,
+// record-view-scope, overage-*) — stub it, keep the enums real via `/client`.
+vi.mock('@auxx/lib/permissions', () => ({ getCapabilities }))
+vi.mock('@auxx/lib/workflows', () => ({ assertWorkflowRunNotSystemOwned: guardRun }))
+vi.mock('@auxx/lib/workflow-engine', () => ({
+  safeJsonStringify: (v: unknown) => JSON.stringify(v),
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('@auxx/redis', () => ({
+  createDedicatedClient: vi.fn(async () => ({
+    subscribe: vi.fn(async () => undefined),
+    unsubscribe: vi.fn(async () => undefined),
+    quit: vi.fn(async () => undefined),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  })),
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const RUN_ID = 'run_cuid000000000000000000'
+/** The run's parent `WorkflowApp.id` — what instance access keys on. */
+const WF_ID = 'wf_cuid0000000000000000000'
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/** A real `CapabilitySet` holding `permission` on {@link WF_ID} via an explicit row. */
+function capabilitiesFor(permission: ResourcePermission, areaLevel = AREA_LEVEL_OF[permission]) {
+  const instances = { [WF_ID]: permission }
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.workflows]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+function signedIn(capabilities: InstanceType<typeof CapabilitySet>) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
+  })
+  getCapabilities.mockResolvedValue(capabilities)
+}
+
+const request = () =>
+  ({
+    headers: new Headers(),
+    signal: new AbortController().signal,
+  }) as never
+
+const params = { params: Promise.resolve({ runId: RUN_ID }) }
+
+const runRow = {
+  id: RUN_ID,
+  organizationId: ORG_ID,
+  workflowId: 'wfv_cuid000000000000000000',
+  status: 'RUNNING',
+  outputs: {},
+  elapsedTime: 0,
+  totalTokens: 0,
+  totalSteps: 0,
+  createdAt: new Date('2026-07-27T00:00:00.000Z'),
+  finishedAt: null,
+}
+
+/** Reads the first SSE chunk, then cancels so no heartbeat interval leaks. */
+async function firstChunk(res: Response) {
+  const reader = res.body?.getReader()
+  if (!reader) throw new Error('no body')
+  const { value } = await reader.read()
+  await reader.cancel()
+  return new TextDecoder().decode(value)
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  guardRun.mockReset().mockResolvedValue(WF_ID)
+  runLimit.mockReset().mockResolvedValue([runRow])
+  nodeOrderBy.mockReset().mockResolvedValue([])
+  eq.mockClear()
+  and.mockClear()
+  select.mockReset().mockReturnValue({
+    from: () => ({ where: () => ({ limit: runLimit, orderBy: nodeOrderBy }) }),
+  })
+})
+
+describe('GET /api/workflow/run/[runId]/events — the run-trace hole', () => {
+  it('401s without a session, before any capability or DB read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('403s a member composing `workflows: None`, before the DB reads', async () => {
+    signedIn(
+      new CapabilitySet(
+        new Set(expandLevelsToKeys({ [Area.workflows]: Level.None })),
+        {},
+        'MEMBER',
+        'full'
+      )
+    )
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    // The gate must precede the reads — otherwise run state is still probeable.
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding an explicit `none` restriction on the workflow', async () => {
+    // THE case this fix exists for: the area is wide open (Full), and only the
+    // per-instance `none` row stands between the caller and the trace. Before
+    // the fix this member got the full stream.
+    signedIn(capabilitiesFor(ResourcePermission.none, Level.Full))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('streams the trace for a member holding instance `view`', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(select).toHaveBeenCalledTimes(2)
+    expect(await firstChunk(res)).toContain('event: connected')
+  })
+
+  it('streams for a row-less workflow at the area Read rung (baselineAtCreate: false)', async () => {
+    // Workflows are org-shared by default (plan 30 §3): with no `ResourceAccess`
+    // row anywhere, the absent-row fallback IS the area level.
+    signedIn(
+      new CapabilitySet(
+        new Set(expandLevelsToKeys({ [Area.workflows]: Level.Read })),
+        {},
+        'MEMBER',
+        'full'
+      )
+    )
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    await firstChunk(res)
+  })
+
+  it('404s an absent run without reading capabilities or run state', async () => {
+    // The guard is org-scoped, so another org's run id is `undefined` here too —
+    // identical to a run that never existed. Run ids are not probeable across orgs.
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    guardRun.mockResolvedValue(undefined)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('403s a system-owned run (the guard throws)', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    guardRun.mockRejectedValue(new Error('system-owned'))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('404s when the run row vanished between the guard and the read', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    runLimit.mockResolvedValue([])
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+    // The node-execution read must not happen for a run we could not load.
+    expect(nodeOrderBy).not.toHaveBeenCalled()
+  })
+
+  it('scopes the node-execution read by organization (latent IDOR)', async () => {
+    // It filtered on `workflowRunId` ALONE — no org scope at all — so a run id
+    // leaking across org boundaries would have handed over another org's trace.
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(eq).toHaveBeenCalledWith('WorkflowNodeExecution.organizationId', ORG_ID)
+    await firstChunk(res)
+  })
+})

--- a/apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/file-instance-access.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/file-instance-access.test.ts
@@ -1,0 +1,382 @@
+// apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/file-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 30 §2.4, fourth instance of the class — the workflow-FILE REST route.
+ *
+ * `#1345` closed the hole on `/api/workflows/[workflowId]/run` and missed this
+ * sibling. Both handlers here authenticated with `auth.api.getSession` and read
+ * NO capabilities, scoping on `Workflow.organizationId` alone: GET handed back
+ * `File.url` — the direct storage link — for any workflow's attachment, and
+ * DELETE hard-deleted the `WorkflowFile` row, both for a workflow the caller
+ * holds an explicit `none` restriction on.
+ *
+ * There is no tRPC procedure anywhere in the repo that touches `WorkflowFile`,
+ * so the governing analogue is the workflow instance ladder itself:
+ * `workflow.getById` → `assertViewInstance`, `workflow.update` →
+ * `assertEditInstance`, `workflow.delete` → `assertAdminInstance`.
+ *
+ * Behavioral: the real handlers run with a REAL `CapabilitySet`. The DB reads
+ * are the observed side effect — the gate must land ahead of them, so an
+ * unauthorized caller cannot probe which files exist.
+ */
+
+const { getCapabilities, getSession, guardVersion, select, limit, del, deleteWhere, eq, and } =
+  vi.hoisted(() => ({
+    getCapabilities: vi.fn(),
+    getSession: vi.fn(),
+    guardVersion: vi.fn(),
+    select: vi.fn(),
+    limit: vi.fn(),
+    del: vi.fn(),
+    deleteWhere: vi.fn(),
+    eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+    and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+  }))
+
+vi.mock('@auxx/database', () => ({
+  database: { select, delete: del },
+  schema: {
+    WorkflowFile: {
+      id: 'WorkflowFile.id',
+      fileId: 'WorkflowFile.fileId',
+      workflowId: 'WorkflowFile.workflowId',
+      nodeId: 'WorkflowFile.nodeId',
+      uploadedAt: 'WorkflowFile.uploadedAt',
+      expiresAt: 'WorkflowFile.expiresAt',
+      uploadSource: 'WorkflowFile.uploadSource',
+      metadata: 'WorkflowFile.metadata',
+    },
+    File: {
+      id: 'File.id',
+      name: 'File.name',
+      mimeType: 'File.mimeType',
+      size: 'File.size',
+      url: 'File.url',
+    },
+    Workflow: { id: 'Workflow.id', organizationId: 'Workflow.organizationId' },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({ and, eq }))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest (get-capabilities,
+// record-view-scope, overage-*) — stub it, keep the enums real via `/client`.
+vi.mock('@auxx/lib/permissions', () => ({ getCapabilities }))
+vi.mock('@auxx/lib/workflows', () => ({
+  assertWorkflowVersionNotSystemOwned: guardVersion,
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET, DELETE } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+/** A `Workflow.id` (a version/draft) — what this route's path segment carries. */
+const VERSION_ID = 'wfv_cuid000000000000000000'
+/** The version's parent `WorkflowApp.id` — what instance access keys on. */
+const WF_ID = 'wf_cuid0000000000000000000'
+/** The parent app a "belongs to another workflow" case resolves to. */
+const OTHER_WF_ID = 'wf_othercuid0000000000000'
+const FILE_ID = 'wff_cuid000000000000000000'
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/** A real `CapabilitySet` holding `permission` on {@link WF_ID} via an explicit row. */
+function capabilitiesFor(
+  permission: ResourcePermission,
+  {
+    areaLevel = AREA_LEVEL_OF[permission],
+    extraInstances = {},
+  }: { areaLevel?: Level; extraInstances?: Record<string, ResourcePermission> } = {}
+) {
+  const instances = { [WF_ID]: permission, ...extraInstances }
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.workflows]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/** A real `CapabilitySet` with NO `ResourceAccess` row anywhere — area level only. */
+const areaOnly = (level: Level) =>
+  new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.workflows]: level })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    {},
+    new Set()
+  )
+
+function signedIn(
+  capabilities: InstanceType<typeof CapabilitySet>,
+  { isSuperAdmin = false }: { isSuperAdmin?: boolean } = {}
+) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin },
+  })
+  getCapabilities.mockResolvedValue(capabilities)
+}
+
+const request = () => ({ headers: new Headers() }) as never
+const params = { params: Promise.resolve({ workflowId: VERSION_ID, fileId: FILE_ID }) }
+
+const fileRow = {
+  id: FILE_ID,
+  fileId: 'file_cuid00000000000000000',
+  workflowId: VERSION_ID,
+  nodeId: 'node_1',
+  uploadedAt: new Date('2026-07-27T00:00:00.000Z'),
+  expiresAt: null,
+  uploadSource: 'USER',
+  metadata: {},
+  file: {
+    name: 'secret.pdf',
+    mimeType: 'application/pdf',
+    size: 1234,
+    url: 'https://s3.example/private/secret.pdf',
+  },
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  guardVersion.mockReset().mockResolvedValue(WF_ID)
+  limit.mockReset().mockResolvedValue([fileRow])
+  deleteWhere.mockReset().mockResolvedValue(undefined)
+  del.mockReset().mockReturnValue({ where: deleteWhere })
+  eq.mockClear()
+  and.mockClear()
+  // `.from()` → self-referential chain so both the 2-join GET query and the
+  // 1-join DELETE query land on the same terminal `.limit()`.
+  select.mockReset().mockImplementation(() => {
+    const chain: Record<string, unknown> = {}
+    chain.innerJoin = () => chain
+    chain.where = () => ({ limit })
+    return { from: () => chain }
+  })
+})
+
+describe('GET /api/workflows/[workflowId]/files/[fileId] — the §2.4 file hole', () => {
+  it('401s without a session, before the guard, capabilities, or DB read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(guardVersion).not.toHaveBeenCalled()
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('403s a member composing `workflows: None`, before the DB read', async () => {
+    signedIn(areaOnly(Level.None))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    // The gate must precede the read — otherwise file existence is still probeable.
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding an explicit `none` restriction on the workflow', async () => {
+    // THE case this fix exists for: the area is wide open (Full), and only the
+    // per-instance `none` row stands between the caller and `File.url`. Before
+    // the fix this member got the signed storage link.
+    signedIn(capabilitiesFor(ResourcePermission.none, { areaLevel: Level.Full }))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('returns the file for a member holding instance `view`', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(select).toHaveBeenCalledTimes(1)
+    await expect(res.json()).resolves.toMatchObject({
+      file: { url: fileRow.file.url, filename: 'secret.pdf' },
+    })
+  })
+
+  it('returns the file for a row-less workflow at the area Read rung (baselineAtCreate: false)', async () => {
+    // Workflows are org-shared by default (plan 30 §3): with no `ResourceAccess`
+    // row anywhere, the absent-row fallback IS the area level.
+    signedIn(areaOnly(Level.Read))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(select).toHaveBeenCalledTimes(1)
+  })
+
+  it('gates on the PARENT app the version resolves to, not the path id', async () => {
+    // `[workflowId]` is a `Workflow.id` (a VERSION); instance access keys on the
+    // parent `WorkflowApp.id` the guard hands back. A member who administers
+    // WF_ID must still be refused a version whose parent they're restricted from.
+    signedIn(
+      capabilitiesFor(ResourcePermission.admin, {
+        extraInstances: { [OTHER_WF_ID]: ResourcePermission.none },
+      })
+    )
+    guardVersion.mockResolvedValueOnce(OTHER_WF_ID)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('404s an unknown version before any capability read', async () => {
+    // The guard is org-scoped, so another org's version id is `undefined` here
+    // too — identical to a version that never existed. Not probeable across orgs.
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    guardVersion.mockResolvedValueOnce(undefined)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('403s a system-owned workflow (the guard throws) ahead of the capability read', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    guardVersion.mockRejectedValueOnce(new Error('system-owned'))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('lets super admins read system-owned workflows (allowSuperAdminRead)', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin), { isSuperAdmin: true })
+    await GET(request(), params)
+    expect(guardVersion).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ isSuperAdmin: true, allowSuperAdminRead: true })
+    )
+  })
+
+  it('404s an absent file for an authorized member', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    limit.mockResolvedValueOnce([])
+    const res = await GET(request(), params)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE /api/workflows/[workflowId]/files/[fileId] — detaching a file', () => {
+  it('401s without a session, before the guard or any DB access', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(401)
+    expect(guardVersion).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('403s a member composing `workflows: None`, before the DB read', async () => {
+    signedIn(areaOnly(Level.None))
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('403s an instance `view` holder — reading a workflow is not mutating it', async () => {
+    // The rung boundary: `view` confers running, `edit` confers authoring.
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding an explicit `none` restriction on the workflow', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.none, { areaLevel: Level.Full }))
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(403)
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('deletes for an instance `edit` holder — NOT gated at admin', async () => {
+    // Deliberately below `workflow.delete`'s `assertAdminInstance`: removing one
+    // attached file is an authoring mutation of the version's content, the same
+    // class as `workflow.update`'s draft-graph save.
+    signedIn(capabilitiesFor(ResourcePermission.edit))
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ success: true })
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(del).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes for a row-less workflow at the area Edit rung (baselineAtCreate: false)', async () => {
+    signedIn(areaOnly(Level.Edit))
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(200)
+    expect(del).toHaveBeenCalledTimes(1)
+  })
+
+  it('gates on the PARENT app the version resolves to, not the path id', async () => {
+    signedIn(
+      capabilitiesFor(ResourcePermission.admin, {
+        extraInstances: { [OTHER_WF_ID]: ResourcePermission.none },
+      })
+    )
+    guardVersion.mockResolvedValueOnce(OTHER_WF_ID)
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(403)
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('404s an unknown version before any capability read', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    guardVersion.mockResolvedValueOnce(undefined)
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(404)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('403s a system-owned workflow (the guard throws) ahead of the capability read', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    guardVersion.mockRejectedValueOnce(new Error('system-owned'))
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(403)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('gives super admins NO read-only bypass on this write path', async () => {
+    // `allowSuperAdminRead` is a debugging affordance for reads only — a
+    // system-owned workflow must stay immutable through this guard.
+    signedIn(capabilitiesFor(ResourcePermission.admin), { isSuperAdmin: true })
+    await DELETE(request(), params)
+    expect(guardVersion).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ isSuperAdmin: true, allowSuperAdminRead: false })
+    )
+  })
+
+  it('stays a no-op when the file row is absent for an authorized member', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.edit))
+    limit.mockResolvedValueOnce([])
+    const res = await DELETE(request(), params)
+    expect(res.status).toBe(200)
+    expect(del).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/route.ts
@@ -1,6 +1,8 @@
 // apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/route.ts
 
 import { database as db, schema } from '@auxx/database'
+import { getCapabilities } from '@auxx/lib/permissions'
+import { assertWorkflowVersionNotSystemOwned } from '@auxx/lib/workflows'
 import { and, eq } from 'drizzle-orm'
 import { headers } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
@@ -10,7 +12,60 @@ interface RouteParams {
   params: Promise<{ workflowId: string; fileId: string }>
 }
 
-export async function GET(request: NextRequest, { params }: RouteParams) {
+/**
+ * Resolves the parent `WorkflowApp.id` that per-workflow instance access keys on.
+ *
+ * `[workflowId]` here is a **`Workflow.id` (a version/draft)** — `WorkflowFile.workflowId`
+ * FKs `Workflow.id`, not `WorkflowApp.id`, so this route sits in a different id space from
+ * its neighbour `/api/workflows/[workflowId]` (which passes its segment straight into
+ * `workflow.getById` as a `WorkflowApp.id`). The system-owned guard already joins the
+ * parent row, so it hands the app id back rather than us querying twice.
+ *
+ * Returns a `Response` to send as-is when the caller must be stopped: `403` for a
+ * system-owned workflow (Sequences plan §3.4) and `404` for a version that doesn't exist
+ * in the caller's org — indistinguishable from another org's version, so version ids stay
+ * unprobeable across orgs.
+ */
+async function resolveWorkflowAppId(
+  workflowId: string,
+  organizationId: string,
+  isSuperAdmin: boolean,
+  allowSuperAdminRead: boolean
+): Promise<{ workflowAppId: string } | { response: NextResponse }> {
+  let workflowAppId: string | undefined
+  try {
+    workflowAppId = await assertWorkflowVersionNotSystemOwned(db, {
+      workflowId,
+      organizationId,
+      isSuperAdmin,
+      allowSuperAdminRead,
+    })
+  } catch (_error) {
+    return { response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  if (!workflowAppId) {
+    return { response: NextResponse.json({ error: 'File not found' }, { status: 404 }) }
+  }
+  return { workflowAppId }
+}
+
+/**
+ * Read one file attached to a workflow version.
+ *
+ * Gated on instance **`view`** of the parent `WorkflowApp`, matching the tRPC ladder's
+ * read rung (`workflow.getById` → `assertViewInstance`) and the run-trace SSE route,
+ * which exposes comparable run payloads at `view`. `view` already means "you may RUN it"
+ * (plan 30 §2), and running a workflow with file inputs implies seeing those inputs.
+ *
+ * Before this, both handlers scoped on `Workflow.organizationId` alone and read no
+ * capabilities, so any authenticated org member could fetch the `File.url` — the direct
+ * storage link — for any workflow's attachments, including a workflow they hold an
+ * explicit `none` restriction on. #1345 fixed the sibling `/run` route and missed this one.
+ *
+ * The gate deliberately runs **before** the file read, so an unauthorized caller cannot
+ * probe which files exist.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
     const session = await auth.api.getSession({ headers: await headers() })
     if (!session?.user?.defaultOrganizationId) {
@@ -20,7 +75,20 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const { workflowId, fileId } = await params
     const organizationId = session.user.defaultOrganizationId
 
-    // Get specific workflow file with file details
+    const resolved = await resolveWorkflowAppId(
+      workflowId,
+      organizationId,
+      (session.user as { isSuperAdmin?: boolean }).isSuperAdmin ?? false,
+      true
+    )
+    if ('response' in resolved) return resolved.response
+
+    const capabilities = await getCapabilities(session.user.id, organizationId)
+    if (!capabilities.canViewInstance('workflow', resolved.workflowAppId)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    // Get specific workflow file with file details. Authorization already happened above.
     const [workflowFile] = await db
       .select({
         id: schema.WorkflowFile.id,
@@ -80,7 +148,21 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 }
 
-export async function DELETE(request: NextRequest, { params }: RouteParams) {
+/**
+ * Detach (hard-delete) one file from a workflow version.
+ *
+ * Gated on instance **`edit`**, NOT `admin`. The ladder's `admin` rung is reserved for
+ * destroying the workflow itself (`workflow.delete` → `assertAdminInstance`, "the workflow
+ * and every version") and for its settings/sharing surface (`ADMIN_ONLY_UPDATE_FIELDS`).
+ * Removing one attached file is an ordinary authoring mutation of the version's content —
+ * the same class as saving the draft graph, which `workflow.update` gates at
+ * `assertEditInstance`. It is also symmetric with the surface that CREATES these rows:
+ * `/api/workflows/[workflowId]/run` accepts file inputs at instance `edit`, so requiring
+ * `admin` to clean them up would strand ordinary authors with their own uploads.
+ *
+ * Deliberately NOT `view`: `view` confers running, not mutating.
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const session = await auth.api.getSession({ headers: await headers() })
     if (!session?.user?.defaultOrganizationId) {
@@ -89,6 +171,20 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     const { workflowId, fileId } = await params
     const organizationId = session.user.defaultOrganizationId
+
+    // Write path — super admins get no read-only bypass here.
+    const resolved = await resolveWorkflowAppId(
+      workflowId,
+      organizationId,
+      (session.user as { isSuperAdmin?: boolean }).isSuperAdmin ?? false,
+      false
+    )
+    if ('response' in resolved) return resolved.response
+
+    const capabilities = await getCapabilities(session.user.id, organizationId)
+    if (!capabilities.canEditInstance('workflow', resolved.workflowAppId)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
 
     // Delete workflow file (this will cascade to delete the File record too if no other references)
     // First verify the file exists and belongs to the organization

--- a/apps/web/src/server/api/routers/file-attachment-permission.test.ts
+++ b/apps/web/src/server/api/routers/file-attachment-permission.test.ts
@@ -1,0 +1,286 @@
+// apps/web/src/server/api/routers/file-attachment-permission.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The two bare-`protectedProcedure` reads that made `filesView` decorative on
+ * `fileRouter` — the tRPC half of the `api/files/download/[fileId]` hole
+ * (`file-download-permission.test.ts`).
+ *
+ * - `getAttachmentPreviewRef` returned a LIVE presigned download ref for any
+ *   `FolderFile` or `MediaAsset` id in the org. Fixed here: it now sits behind
+ *   `permissionProcedure(PermissionKey.filesView)` like its eight siblings.
+ * - `resolveFileRefs` returns name/mimeType/size for any org file/asset id and
+ *   is deliberately STILL open — see the last block for why.
+ *
+ * Behavioral: the real `permissionProcedure` middleware runs, with the real
+ * `PERMISSION_REGISTRY_MAP` deciding whether the plan gate fires and a real
+ * `CapabilitySet.assert` doing the check. Only the DB-backed capability fetch
+ * and the plan lookup are stubbed. The file-service calls are the observed side
+ * effect: the gate must land ahead of them.
+ */
+
+const {
+  getCapabilities,
+  planGate,
+  getFileDownloadRef,
+  getAssetDownloadRef,
+  createFileService,
+  createMediaAssetService,
+  dbSelect,
+  dbWhere,
+} = vi.hoisted(() => ({
+  getCapabilities: vi.fn(),
+  planGate: vi.fn(),
+  getFileDownloadRef: vi.fn(),
+  getAssetDownloadRef: vi.fn(),
+  createFileService: vi.fn(),
+  createMediaAssetService: vi.fn(),
+  dbSelect: vi.fn(),
+  dbWhere: vi.fn(),
+}))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest — stub it, but keep the
+// registry REAL so `permissionProcedure`'s `featureKey` lookup is the real one.
+vi.mock('@auxx/lib/permissions', async () => {
+  const { PERMISSION_REGISTRY_MAP, PermissionKey } = await import(
+    '@auxx/lib/permissions/capabilities/registry'
+  )
+  const { FeatureKey } = await import('@auxx/lib/permissions/types')
+  return {
+    FeatureKey,
+    PERMISSION_REGISTRY_MAP,
+    PermissionKey,
+    getCapabilities,
+    FeaturePermissionService: class {
+      requireAccess(orgId: string, featureKey: string) {
+        return planGate(orgId, featureKey)
+      }
+    },
+  }
+})
+
+vi.mock('@auxx/lib/files', () => ({
+  createFileService,
+  createFilesystemService: vi.fn(),
+  createMediaAssetService,
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: {},
+  schema: {
+    MediaAsset: {
+      id: 'MediaAsset.id',
+      name: 'MediaAsset.name',
+      mimeType: 'MediaAsset.mimeType',
+      size: 'MediaAsset.size',
+      organizationId: 'MediaAsset.organizationId',
+      deletedAt: 'MediaAsset.deletedAt',
+    },
+    FolderFile: {
+      id: 'FolderFile.id',
+      name: 'FolderFile.name',
+      mimeType: 'FolderFile.mimeType',
+      size: 'FolderFile.size',
+      organizationId: 'FolderFile.organizationId',
+      deletedAt: 'FolderFile.deletedAt',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+  eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+  inArray: vi.fn((a: unknown, b: unknown) => ({ op: 'inArray', a, b })),
+  isNull: vi.fn((a: unknown) => ({ op: 'isNull', a })),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({ getOrgCache: vi.fn() }))
+vi.mock('@auxx/lib/members', () => ({ isOwner: vi.fn() }))
+vi.mock('@auxx/lib/utils/rate-limiter/redis-rate-limiter', () => ({
+  RedisRateLimiter: class {
+    acquire = vi.fn(async () => true)
+  },
+}))
+vi.mock('~/auth/session', () => ({ getSession: vi.fn() }))
+vi.mock('~/server/bootstrap', () => ({ ensureWebAppInitialized: vi.fn() }))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { ForbiddenError } = await import('@auxx/lib/errors')
+const { createCallerFactory } = await import('~/server/api/trpc')
+const { fileRouter } = await import('./file')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const FILE_ID = 'fil_cuid000000000000000000000'
+const ASSET_ID = 'ast_cuid000000000000000000000'
+
+const createCaller = createCallerFactory(fileRouter)
+
+/** A real `CapabilitySet` composing the Files area at `level`. */
+function capabilitiesAt(level: Level) {
+  return new CapabilitySet(new Set(expandLevelsToKeys({ [Area.files]: level })), {}, 'USER', 'full')
+}
+
+/** A caller for a signed-in member holding `capabilities`. */
+function callerFor(capabilities: InstanceType<typeof CapabilitySet>) {
+  getCapabilities.mockResolvedValue(capabilities)
+  return createCaller({
+    session: { user: { id: USER_ID, defaultOrganizationId: ORG_ID } },
+    db: { select: dbSelect },
+    headers: new Headers(),
+  } as never)
+}
+
+const downloadRef = {
+  type: 'url' as const,
+  url: 'https://s3.example/presigned',
+  filename: 'contract.pdf',
+  mimeType: 'application/pdf',
+  size: 2048n,
+  versionNumber: 1,
+  expiresAt: new Date('2026-07-27T01:00:00.000Z'),
+}
+
+beforeEach(() => {
+  getCapabilities.mockReset()
+  planGate.mockReset().mockResolvedValue(undefined)
+  getFileDownloadRef.mockReset().mockResolvedValue(downloadRef)
+  getAssetDownloadRef.mockReset().mockResolvedValue({ ...downloadRef, filename: 'logo.png' })
+  createFileService.mockReset().mockReturnValue({
+    getDownloadRefForVersion: getFileDownloadRef,
+  })
+  createMediaAssetService.mockReset().mockReturnValue({
+    getDownloadRefForVersion: getAssetDownloadRef,
+  })
+  dbWhere.mockReset().mockResolvedValue([])
+  dbSelect.mockReset().mockReturnValue({ from: () => ({ where: dbWhere }) })
+})
+
+/** Neither backing service may be constructed for a denied caller. */
+function expectNoFileReads() {
+  expect(createFileService).not.toHaveBeenCalled()
+  expect(createMediaAssetService).not.toHaveBeenCalled()
+}
+
+describe('file.getAttachmentPreviewRef — the live-download-ref hole', () => {
+  it('FORBIDDENs a member composing `files: None`, before the service call', async () => {
+    // THE case this fix exists for: as a bare `protectedProcedure` this handed
+    // any authenticated org member a presigned URL for any file id they guessed.
+    const caller = callerFor(capabilitiesAt(Level.None))
+    await expect(
+      caller.getAttachmentPreviewRef({ type: 'file', id: FILE_ID })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expectNoFileReads()
+  })
+
+  it('FORBIDDENs a `files: None` member on the asset branch too', async () => {
+    const caller = callerFor(capabilitiesAt(Level.None))
+    await expect(
+      caller.getAttachmentPreviewRef({ type: 'asset', id: ASSET_ID })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expectNoFileReads()
+  })
+
+  it('FORBIDDENs when the org plan lacks the files feature, before capabilities', async () => {
+    // `PermissionKey.filesView` links `FeatureKey.files`, so the plan-AND runs
+    // first — the same order `requirePermission` uses on the REST route.
+    const caller = callerFor(capabilitiesAt(Level.Full))
+    planGate.mockRejectedValue(new ForbiddenError('Files is not available on your plan.'))
+    await expect(
+      caller.getAttachmentPreviewRef({ type: 'file', id: FILE_ID })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(planGate).toHaveBeenCalledWith(ORG_ID, 'files')
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expectNoFileReads()
+  })
+
+  it('returns the ref for a member holding `files: Read` (file branch)', async () => {
+    const caller = callerFor(capabilitiesAt(Level.Read))
+    const result = await caller.getAttachmentPreviewRef({ type: 'file', id: FILE_ID })
+    expect(result).toEqual(downloadRef)
+    expect(createFileService).toHaveBeenCalledWith(ORG_ID, USER_ID)
+    expect(getFileDownloadRef).toHaveBeenCalledWith(FILE_ID, {
+      version: 'current',
+      disposition: 'inline',
+    })
+  })
+
+  it('returns the ref for a member holding `files: Read` (asset branch)', async () => {
+    const caller = callerFor(capabilitiesAt(Level.Read))
+    const result = await caller.getAttachmentPreviewRef({
+      type: 'asset',
+      id: ASSET_ID,
+      disposition: 'attachment',
+    })
+    expect(result).toMatchObject({ filename: 'logo.png' })
+    expect(createMediaAssetService).toHaveBeenCalledWith(ORG_ID, USER_ID)
+    expect(getAssetDownloadRef).toHaveBeenCalledWith(ASSET_ID, {
+      version: 'current',
+      disposition: 'attachment',
+    })
+    expect(createFileService).not.toHaveBeenCalled()
+  })
+
+  it('UNAUTHORIZEDs a caller with no session, before capabilities', async () => {
+    const caller = createCaller({
+      session: null,
+      db: { select: dbSelect },
+      headers: new Headers(),
+    } as never)
+    await expect(
+      caller.getAttachmentPreviewRef({ type: 'file', id: FILE_ID })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expectNoFileReads()
+  })
+})
+
+describe('file.resolveFileRefs — STILL an open metadata read (deliberate)', () => {
+  /**
+   * Not moved to `permissionProcedure(filesView)` with its sibling, and this
+   * test pins that so the gap is visible rather than forgotten.
+   *
+   * Every one of its four callers renders FILE **custom fields** or sequence
+   * attachments — `fields/displays/display-file.tsx`,
+   * `dynamic-table/utils/cell-renderers.tsx`,
+   * `fields/inputs/hooks/use-field-file-upload.ts`,
+   * `sequences/ui/detail/sequence-step-attachments.tsx`. NOT ONE is a Files-app
+   * surface. Gating it on `filesView` would make the Files area decide whether
+   * FILE field values render anywhere in the product, and `SEAT_CEILINGS.worker`
+   * clamps `files` to `None` unliftably while granting `recordsLinked: Full` —
+   * so a field seat could never resolve a FILE field on a record it is entitled
+   * to read. That is a design decision (probably: scope resolution to refs
+   * reachable from records the caller can read, which also closes the
+   * enumeration hole more tightly), not a mechanical key swap.
+   *
+   * When that decision lands, this test should flip to a FORBIDDEN assertion.
+   */
+  it('still answers a member composing `files: None` (documents the open hole)', async () => {
+    const caller = callerFor(capabilitiesAt(Level.None))
+    dbWhere.mockResolvedValue([
+      { id: FILE_ID, name: 'contract.pdf', mimeType: 'application/pdf', size: 2048 },
+    ])
+    const result = await caller.resolveFileRefs({ refs: [`file:${FILE_ID}`] })
+    expect(result).toEqual([
+      { ref: `file:${FILE_ID}`, name: 'contract.pdf', mimeType: 'application/pdf', size: 2048 },
+    ])
+  })
+
+  it('UNAUTHORIZEDs a caller with no session', async () => {
+    const caller = createCaller({
+      session: null,
+      db: { select: dbSelect },
+      headers: new Headers(),
+    } as never)
+    await expect(caller.resolveFileRefs({ refs: [`file:${FILE_ID}`] })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    })
+  })
+})

--- a/apps/web/src/server/api/routers/file.ts
+++ b/apps/web/src/server/api/routers/file.ts
@@ -369,8 +369,24 @@ export const fileRouter = createTRPCRouter({
       }
     }),
 
-  /** Get preview download reference for attachment (files or assets) */
-  getAttachmentPreviewRef: protectedProcedure
+  /**
+   * Get preview download reference for attachment (files or assets).
+   *
+   * `filesView`, matching every other read on this router: the returned ref is a
+   * live, presigned download URL for any `FolderFile` or `MediaAsset` in the org,
+   * resolved by id with no ownership or folder check — as a bare
+   * `protectedProcedure` it made the `filesView` gate on `getDownloadInfo` (the
+   * same read, one procedure over) decorative.
+   *
+   * Both UI callers are covered by the key: the Files detail drawer (Files is the
+   * authority) and the dataset document drawer, which is reachable only by a
+   * member holding `datasets: Read` — and the member baseline ships `files: Full`
+   * (`seat-policy.ts` `MEMBER_BASELINE_LEVELS`), while a worker seat has
+   * `datasets: None` and cannot open that drawer at all. So no principal loses a
+   * surface here except a member whose admin *deliberately* set `files` below
+   * `Read`.
+   */
+  getAttachmentPreviewRef: permissionProcedure(PermissionKey.filesView)
     .input(getAttachmentPreviewRefSchema)
     .query(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session


### PR DESCRIPTION
Six REST/SSE routes authenticated with `getSession`, scoped by `organizationId`, then read or acted on a resource **without ever loading the caller's capabilities** — while the equivalent tRPC procedure sat behind `permissionProcedure` plus a per-instance assert.

Found by sweeping `apps/web/src/app/api/` for routes matching that shape. Full 30-route triage (including the SAFE-BY-DESIGN and UNCLEAR buckets) is in `plans/permissions/v2/31-rest-route-authorization-audit.md`.

## What was open

| Route | Exposed | Stricter sibling |
|---|---|---|
| `kopilot/stream` | took `agentId` from the request body; only gate was the org-wide `dmEnabled` flag — any member could chat with any agent | every `agent.*` procedure requires `agentsManage` |
| `eval/run/[runId]/events` | full eval run trace: agent messages, tool calls, assertion verdicts | every `eval.*` procedure requires `agentsManage` |
| `workflow/run/[runId]/events` | `WorkflowRun` + `WorkflowNodeExecution` rows — node inputs/outputs | `workflow.getWorkflowRun` requires `workflowsView` + `assertViewInstance` |
| `kb/articles/[articleId]/events` | SSE channel carries `contentJson` — **whole article bodies** — on every save | `kb.getArticleById` runs `assertViewInstance('kb', kbId)` |
| `mcp/…/oauth2/authorize`, `apps/…/oauth2/authorize` | both lead to an **org-level credential write** | every mutating `mcp.*` / `apps.*` procedure requires `integrationsManage` |
| `imports/[importJobId]/events` | `planning:row` events carry **actual imported field values** | all 23 `data-import` procedures require `recordsImport` |
| `files/download/[fileId]` + `file.getAttachmentPreviewRef` | raw file content; live presigned download refs | all 8 file reads require `filesView` |

`workflow/run/[runId]/events` is a **different route** from the `workflows/[workflowId]/run` one #1345 fixed — that PR fixed the sibling and missed this one. Its `WorkflowNodeExecution` query was not org-scoped either, and it read every node execution *before* checking the run existed. Both fixed.

`workflows/[workflowId]/files/[fileId]` has an id-space trap: its `[workflowId]` is a `Workflow.id` (version), not a `WorkflowApp.id` like its neighbour. Instance access keys on the parent app, so it resolves through `assertWorkflowVersionNotSystemOwned`. Worth knowing: that route's GET selects `File.mimeType` and `File.url`, **neither of which exists on the table** — it can never have returned a 200. Fixed rather than deleted.

## The 403-vs-500 trap

`requirePermission` **throws** an `AuxxError`, and App Router handlers have no `auxxErrorMiddleware`. An uncaught throw surfaces as a **500, not a 403** — on the apps route the mutation test failed with literally `expected 500 to be 403`, because its outer catch flattens the error. Every route here maps `AuxxError → error.statusCode` and rethrows anything else, following `api/files/upload/sessions/route.ts`.

## Deliberately NOT gated

`file.resolveFileRefs` stays open. Its callers are record FILE fields, table cells and sequence attachments — not Files-app surfaces. `SEAT_CEILINGS.worker` clamps `files → None` **unliftably** (files is not in `WORKER_AREAS`) while granting `recordsLinked: Full`, so a field seat could never resolve a FILE field on a record it is entitled to read, and no admin config could fix it. Panel-visible FILE fields exist on exactly the entities a worker drills into via links. The right fix is record-scoped resolution, which also closes the enumeration hole more tightly than `filesView` would. Residual exposure is name/mimeType/size only, no content. Its still-open state is pinned by a test so it flips loudly when that lands.

## Verification

138 behavioral tests — real handlers, real `CapabilitySet` built from `expandLevelsToKeys`, DB/Redis reads observed via mock call counts. Every gate mutation-verified, each with a comment-only negative control confirming the harness discriminates rather than reporting everything caught.

No `user:capabilities:vN` bump — no new area, key, or shape change. These are new consumers of an existing composed set.