### PR TITLE
fix(permissions): scope per-instance grantee rows to their own grantee

### DIFF
--- a/apps/web/src/components/permissions/hooks/use-grantee-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-access.ts
@@ -1,0 +1,35 @@
+// apps/web/src/components/permissions/hooks/use-grantee-access.ts
+'use client'
+
+import { api } from '~/trpc/react'
+import type { GranteeKind } from './use-grantee-def-access'
+
+/**
+ * One grantee's access, for one grantee (plan 31 §2.4) — the grantee-scoped
+ * replacement for the three org-wide reads the detail pages used to run and
+ * filter client-side (`permissions.listGrants`, `resourceAccess.allTypeAccess`,
+ * `resourceAccess.allInstanceAccess`).
+ *
+ * Returns two halves because every row shows both: `own` drives the
+ * `AccessLevelSelect` (this grantee's explicit row), `effective` drives the line
+ * under the name (what they can actually open). `effective` is `null` for
+ * `group`/`profile` — they are level sources, not subjects.
+ *
+ * The org-wide endpoints deliberately SURVIVE: the overrides tab's grantee LIST
+ * needs `listGrants` to know who has an override at all, and the Workspace
+ * defaults tab is org-wide by definition. Only the grantee DETAIL moved.
+ */
+export function useGranteeAccess(granteeType: GranteeKind, granteeId: string) {
+  const query = api.permissions.granteeAccess.useQuery(
+    { granteeType, granteeId },
+    { staleTime: 30_000, enabled: granteeId.length > 0 }
+  )
+
+  return {
+    isLoading: query.isLoading,
+    own: query.data?.own,
+    baseline: query.data?.baseline,
+    effective: query.data?.effective ?? null,
+    invalidate: query.refetch,
+  }
+}

--- a/apps/web/src/components/permissions/hooks/use-grantee-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-access.ts
@@ -1,8 +1,42 @@
 // apps/web/src/components/permissions/hooks/use-grantee-access.ts
 'use client'
 
+import { useCallback } from 'react'
 import { api } from '~/trpc/react'
 import type { GranteeKind } from './use-grantee-def-access'
+
+/**
+ * Invalidate every `granteeAccess` query — call after ANY permission write.
+ *
+ * **The whole keyspace, deliberately, not `{granteeType, granteeId}`.** `own` is
+ * per-grantee, but `effective` is COMPOSED, so a write aimed at one grantee moves
+ * another's answer: a group grant changes every member of that group, a profile
+ * save changes every holder, and a `role:org_member` workspace default changes
+ * everyone. Scoping the invalidation to the grantee that was written is the
+ * obvious-looking version and is wrong in exactly the cases the effective line
+ * exists to expose.
+ *
+ * Cheap regardless: only mounted queries refetch, and a grantee page has one.
+ *
+ * The server half is already correct and needs nothing — `setGranteeLevels` and
+ * the `resource-access.*` emitters both `await onCacheEvent(...)` after commit,
+ * so the composed `user:capabilities` blob is busted before the mutation returns
+ * and a refetch here is guaranteed to compose fresh. What was missing was purely
+ * this client-side refetch: `permissions.grant`/`revoke` update `listGrants`
+ * optimistically and deliberately never refetch on success, so nothing told
+ * `granteeAccess` its answer had changed and the effective line kept showing the
+ * pre-write composition for up to its 30s `staleTime`.
+ *
+ * The `permission-grant.changed` realtime nudge does not cover this either: it
+ * targets the AFFECTED member's own client so their `myCapabilities` refreshes,
+ * not the admin's client sitting on that member's Permissions tab.
+ */
+export function useInvalidateGranteeAccess() {
+  const utils = api.useUtils()
+  return useCallback(() => {
+    void utils.permissions.granteeAccess.invalidate()
+  }, [utils])
+}
 
 /**
  * One grantee's access, for one grantee (plan 31 §2.4) — the grantee-scoped
@@ -30,6 +64,5 @@ export function useGranteeAccess(granteeType: GranteeKind, granteeId: string) {
     own: query.data?.own,
     baseline: query.data?.baseline,
     effective: query.data?.effective ?? null,
-    invalidate: query.refetch,
   }
 }

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
@@ -15,6 +15,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
 import { useResources } from '~/components/resources/hooks'
 import { api } from '~/trpc/react'
+import { useInvalidateGranteeAccess } from './use-grantee-access'
 import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permission-grants'
 
 /**
@@ -139,7 +140,13 @@ export function useGranteeDefAccess(
 
   // Broad on purpose: the per-def Permissions tab reads the same rows under
   // `resourceAccess.forType`, so a write here must refresh that key too.
-  const invalidate = useCallback(() => utils.resourceAccess.invalidate(), [utils])
+  // `granteeAccess` rides along because a def write moves its COMPOSED
+  // `effective` half, which no optimistic patch here can predict.
+  const invalidateGranteeAccess = useInvalidateGranteeAccess()
+  const invalidate = useCallback(() => {
+    invalidateGranteeAccess()
+    return utils.resourceAccess.invalidate()
+  }, [utils, invalidateGranteeAccess])
 
   /** Optimistically upsert (or, with `permission` undefined, drop) one type row. */
   const patchLocal = useCallback(

--- a/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
@@ -7,7 +7,7 @@ import { toRecordId } from '@auxx/types/resource'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
 import { api } from '~/trpc/react'
-import { deriveInstanceBadge, type InstanceAccessBadge } from '../utils/instance-access-badge'
+import { useGranteeAccess } from './use-grantee-access'
 import type { GranteeKind } from './use-grantee-def-access'
 import { type OpenInstanceTypes, useInstanceResourceLists } from './use-instance-resource-lists'
 
@@ -27,34 +27,48 @@ export interface InstanceGranteeRow {
   name: string
   /** This grantee's own explicit grant; `undefined` = Inherit (no row). */
   grantLevel: ResourcePermission | undefined
-  /** Collapsed-row badge derived from the org-wide `allInstanceAccess` rows —
-   *  the same fact regardless of which grantee's page this is (§B.2.5). */
-  badge: InstanceAccessBadge
+  /**
+   * What the grantee can ACTUALLY reach here, composed server-side through the
+   * enforcement predicate; `null` = no access, `undefined` = not applicable
+   * (a group/profile has no effective access — see {@link useGranteeAccess}).
+   *
+   * Distinct from {@link grantLevel} on purpose, and the gap between them is the
+   * point: a user-level `none` LOSES to any group's `view`, so an admin can set
+   * No access, watch the select change, and change nothing (plan 31 finding 4).
+   */
+  effectiveLevel: ResourcePermission | null | undefined
 }
 
 /**
  * Data + mutations for the per-instance rows nested under the Datasets /
- * Knowledge base / Dashboards area rows in a **grantee scope** (a member or
- * team's own override grid — capability layer v2 Part B). Unlike the area
- * levels above it, instance grants are NOT raise-only (§B.2.6): this surface
- * writes the grantee's raw instance-access grant through the same
- * `grantInstance`/`revokeInstance` funnel the Share card uses, offering the
- * full Inherit / Read / Write / Full / No Access vocabulary.
+ * Knowledge base / Dashboards / Workflows area rows in a **grantee scope** (a
+ * member, team or profile's own override grid — capability layer v2 Part B).
+ * Unlike the area levels above it, instance grants are NOT raise-only (§B.2.6):
+ * this surface writes the grantee's raw instance-access grant through the same
+ * `grantInstance`/`revokeInstance` funnel the Share card uses, offering the full
+ * Inherit / Read / Write / Full / No Access vocabulary.
  *
- * Reads the same org-wide `resourceAccess.allInstanceAccess` rows as the
- * baseline-scope hook (one query, shared React Query cache across every
- * mounted area) and narrows to this grantee's own row per instance.
+ * **Reads one grantee, not the org** (plan 31 §2.4). It used to pull
+ * `resourceAccess.allInstanceAccess` — every per-instance row for every grantee
+ * — and narrow client-side. That was properly gated, so this is a SHAPE fix, not
+ * an authorization one: having the org's sharing map in a member page's query
+ * cache is what made the §2.1 scope leak buildable, and is what the next row
+ * would have reached for.
  */
 export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: string) {
   const utils = api.useUtils()
   const lists = useInstanceResourceLists(ALWAYS_OPEN)
-
-  const allQuery = api.resourceAccess.allInstanceAccess.useQuery(undefined, { staleTime: 30_000 })
-  const allRows = useMemo(() => allQuery.data ?? [], [allQuery.data])
+  const {
+    isLoading,
+    own,
+    effective,
+    invalidate: refetchAccess,
+  } = useGranteeAccess(granteeType, granteeId)
 
   const invalidate = useCallback(() => {
-    void utils.resourceAccess.allInstanceAccess.invalidate()
-  }, [utils])
+    void utils.permissions.granteeAccess.invalidate({ granteeType, granteeId })
+    void refetchAccess()
+  }, [utils, granteeType, granteeId, refetchAccess])
 
   const grantInstance = api.resourceAccess.grantInstance.useMutation({
     onError: (error) => toastError({ title: 'Error updating access', description: error.message }),
@@ -76,24 +90,22 @@ export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: stri
   const rowsByKey = useMemo(() => {
     const result = {} as Record<InstanceAccessKey, InstanceGranteeRow[]>
     for (const key of INSTANCE_ACCESS_KEYS) {
-      result[key] = lists[key].items.map((item) => {
-        const instanceRows = allRows.filter(
-          (r) => r.entityDefinitionId === key && r.entityInstanceId === item.id
-        )
-        const ownRow = instanceRows.find(
-          (r) => r.granteeType === granteeType && r.granteeId === granteeId
-        )
-        return {
-          key,
-          id: item.id,
-          name: item.name,
-          grantLevel: ownRow?.permission,
-          badge: deriveInstanceBadge(instanceRows),
-        }
-      })
+      result[key] = lists[key].items.map((item) => ({
+        key,
+        id: item.id,
+        name: item.name,
+        grantLevel: own?.instances[item.id],
+        // An instance absent from `effective.instances` has no row anywhere in
+        // the org, so its answer is the per-type row-less fallback. A pure
+        // lookup — §2.5 is explicit that re-deriving this client-side would put
+        // display and enforcement on separate implementations.
+        effectiveLevel: effective
+          ? (effective.instances[item.id] ?? effective.instanceFallback[key])
+          : undefined,
+      }))
     }
     return result
-  }, [lists, allRows, granteeType, granteeId])
+  }, [lists, own, effective])
 
   /** Set (or, `'inherit'`, revoke) this grantee's own row for one instance. */
   const setGrant = useCallback(
@@ -110,7 +122,7 @@ export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: stri
 
   return {
     lists,
-    isLoading: allQuery.isLoading,
+    isLoading,
     rowsByKey,
     setGrant,
   }

--- a/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
@@ -7,7 +7,7 @@ import { toRecordId } from '@auxx/types/resource'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
 import { api } from '~/trpc/react'
-import { useGranteeAccess } from './use-grantee-access'
+import { useGranteeAccess, useInvalidateGranteeAccess } from './use-grantee-access'
 import type { GranteeKind } from './use-grantee-def-access'
 import { type OpenInstanceTypes, useInstanceResourceLists } from './use-instance-resource-lists'
 
@@ -58,17 +58,8 @@ export interface InstanceGranteeRow {
 export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: string) {
   const utils = api.useUtils()
   const lists = useInstanceResourceLists(ALWAYS_OPEN)
-  const {
-    isLoading,
-    own,
-    effective,
-    invalidate: refetchAccess,
-  } = useGranteeAccess(granteeType, granteeId)
-
-  const invalidate = useCallback(() => {
-    void utils.permissions.granteeAccess.invalidate({ granteeType, granteeId })
-    void refetchAccess()
-  }, [utils, granteeType, granteeId, refetchAccess])
+  const { isLoading, own, effective } = useGranteeAccess(granteeType, granteeId)
+  const invalidate = useInvalidateGranteeAccess()
 
   const grantInstance = api.resourceAccess.grantInstance.useMutation({
     onError: (error) => toastError({ title: 'Error updating access', description: error.message }),

--- a/apps/web/src/components/permissions/hooks/use-permission-grants.test.ts
+++ b/apps/web/src/components/permissions/hooks/use-permission-grants.test.ts
@@ -22,28 +22,51 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * projection reads exactly like a broken mutation.
  */
 
-const { listGrantsQuery, listProfilesQuery, roleDefaultsQuery, grantMutate, revokeMutate } =
-  vi.hoisted(() => ({
-    listGrantsQuery: vi.fn(),
-    listProfilesQuery: vi.fn(),
-    roleDefaultsQuery: vi.fn(),
-    grantMutate: vi.fn(),
-    revokeMutate: vi.fn(),
-  }))
+const {
+  listGrantsQuery,
+  listProfilesQuery,
+  roleDefaultsQuery,
+  grantMutate,
+  revokeMutate,
+  granteeAccessInvalidate,
+  grantOptions,
+  revokeOptions,
+} = vi.hoisted(() => ({
+  listGrantsQuery: vi.fn(),
+  listProfilesQuery: vi.fn(),
+  roleDefaultsQuery: vi.fn(),
+  grantMutate: vi.fn(),
+  revokeMutate: vi.fn(),
+  granteeAccessInvalidate: vi.fn(),
+  /** The options object each mutation was registered with, so its hooks can be fired. */
+  grantOptions: { current: undefined as undefined | { onSettled?: () => void } },
+  revokeOptions: { current: undefined as undefined | { onSettled?: () => void } },
+}))
 
 vi.mock('~/trpc/react', () => ({
   api: {
     useUtils: () => ({
       permissions: {
         listGrants: { setData: vi.fn(), cancel: vi.fn(), invalidate: vi.fn() },
+        granteeAccess: { invalidate: granteeAccessInvalidate },
       },
     }),
     permissions: {
       listGrants: { useQuery: listGrantsQuery },
       listProfiles: { useQuery: listProfilesQuery },
       roleDefaults: { useQuery: roleDefaultsQuery },
-      grant: { useMutation: () => ({ mutate: grantMutate, isPending: false }) },
-      revoke: { useMutation: () => ({ mutate: revokeMutate, isPending: false }) },
+      grant: {
+        useMutation: (options?: { onSettled?: () => void }) => {
+          grantOptions.current = options
+          return { mutate: grantMutate, isPending: false }
+        },
+      },
+      revoke: {
+        useMutation: (options?: { onSettled?: () => void }) => {
+          revokeOptions.current = options
+          return { mutate: revokeMutate, isPending: false }
+        },
+      },
     },
   },
 }))
@@ -237,5 +260,59 @@ describe('the write surface', () => {
 
     result.current.remove('user', 'usr_1')
     expect(revokeMutate).toHaveBeenCalledWith({ granteeType: 'user', granteeId: 'usr_1' })
+  })
+})
+
+/**
+ * Plan 31 §2.5 — **an area write has to refetch `granteeAccess`.**
+ *
+ * This hook keeps `listGrants` optimistic and deliberately never refetches it on
+ * success: the server stores exactly the sparse map the client sends, so the
+ * local patch is already the truth. `granteeAccess.effective` is not like that.
+ * It is COMPOSED — `min(min(max(profileBase, maxOverGroups, userLevel),
+ * profileCeiling), seatCeiling)` — so this write moves it and no optimistic patch
+ * here could predict the new value without re-implementing composition, which
+ * §2.5 rules out precisely because a display path that drifts from enforcement
+ * fails quietly.
+ *
+ * The bug this pins: raising a member's area level left the effective line
+ * showing the pre-write composition for up to `granteeAccess`'s 30s `staleTime`.
+ * The server was already correct — `setGranteeLevels` awaits
+ * `onCacheEvent('permission-grant.changed', …)` after commit, so the composed
+ * blob is busted before the mutation returns. Only the client refetch was
+ * missing, and the `permission-grant.changed` realtime nudge does not cover it:
+ * that targets the AFFECTED member's own client, not the admin sitting on their
+ * Permissions tab.
+ */
+describe('granteeAccess is refetched after an area-level write', () => {
+  beforeEach(() => {
+    granteeAccessInvalidate.mockClear()
+    // Through `setup`, not a bare `renderHook`: the file's outer `beforeEach`
+    // resets the query mocks, so the hook needs them re-stubbed to render.
+    setup({ grants: [], profiles: [] })
+  })
+
+  it('invalidates on a successful grant, not only on failure', () => {
+    grantOptions.current?.onSettled?.()
+
+    expect(granteeAccessInvalidate).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidates on revoke too', () => {
+    revokeOptions.current?.onSettled?.()
+
+    expect(granteeAccessInvalidate).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * Whole keyspace, no input filter. `own` is per-grantee but `effective` is not:
+   * a GROUP grant changes every member of that group, so scoping the
+   * invalidation to the grantee that was written is the obvious-looking version
+   * and is wrong in exactly the cases the effective line exists to expose.
+   */
+  it('invalidates every granteeAccess query, not just the written grantee', () => {
+    grantOptions.current?.onSettled?.()
+
+    expect(granteeAccessInvalidate).toHaveBeenCalledWith()
   })
 })

--- a/apps/web/src/components/permissions/hooks/use-permission-grants.ts
+++ b/apps/web/src/components/permissions/hooks/use-permission-grants.ts
@@ -5,6 +5,7 @@ import type { Area, GranteeGrant, GrantGranteeType, Level } from '@auxx/lib/perm
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
 import { api } from '~/trpc/react'
+import { useInvalidateGranteeAccess } from './use-grantee-access'
 
 /**
  * The fixed `ResourceAccess` grantee id for the org-wide **workspace default** —
@@ -76,6 +77,13 @@ export function usePermissionGrants() {
     [utils]
   )
   const resync = useCallback(() => utils.permissions.listGrants.invalidate(), [utils])
+  /**
+   * `listGrants` stays optimistic-with-no-refetch (the server stores exactly the
+   * sparse map we send), but `granteeAccess.effective` is COMPOSED — this write
+   * changes it and we cannot predict the new value here without re-implementing
+   * composition. So it refetches, on success as well as failure.
+   */
+  const invalidateGranteeAccess = useInvalidateGranteeAccess()
 
   const grant = api.permissions.grant.useMutation({
     onMutate: async (input) => {
@@ -90,6 +98,7 @@ export function usePermissionGrants() {
       toastError({ title: 'Error saving permission', description: error.message })
       void resync()
     },
+    onSettled: invalidateGranteeAccess,
   })
   const revoke = api.permissions.revoke.useMutation({
     onMutate: async (input) => {
@@ -100,6 +109,7 @@ export function usePermissionGrants() {
       toastError({ title: 'Error clearing permission', description: error.message })
       void resync()
     },
+    onSettled: invalidateGranteeAccess,
   })
 
   const grants = useMemo(() => grantsQuery.data?.grants ?? [], [grantsQuery.data])

--- a/apps/web/src/components/permissions/ui/grantee-instance-rows.test.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-instance-rows.test.tsx
@@ -1,0 +1,233 @@
+// apps/web/src/components/permissions/ui/grantee-instance-rows.test.tsx
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Level } from '@auxx/lib/permissions/client'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import type { InstanceGranteeRow } from '../hooks/use-instance-grantee-rows'
+import { GranteeInstanceRows } from './grantee-instance-rows'
+
+/**
+ * Plan 31 phase 1 — **a grantee row is a leaf.**
+ *
+ * The finding these pin is a scope leak, not a layout nit: expanding a workflow
+ * under Alice's Permissions tab used to mount `InstanceShareBody`, which lists
+ * every OTHER grantee on that workflow *and lets you edit and revoke them*. So a
+ * page about one member ran three subjects deep — area level (Alice), instance
+ * grant (Alice), all grantees (everyone).
+ *
+ * The rule being enforced (§2.1): *the expand belongs to a row whose subject is
+ * everyone, because its children are the exceptions to that row.* These tests
+ * therefore assert the ABSENCE of an expand affordance, which is a promise that
+ * a future "let's unify the two row components" pass can break silently — §5
+ * warns about exactly that. If a shared primitive ever happens, the axis must be
+ * `subject`, never a standalone `expandable` boolean.
+ *
+ * The escape hatch is tested through the REAL `InstanceShareDialog` with only
+ * its body stubbed, so the `recordId` handed across the scope switch is checked
+ * rather than assumed.
+ */
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+// The dialog itself is real (it derives its own title from the recordId); only
+// its data-fetching body is stubbed, so the recordId that crosses the scope
+// switch is observable.
+vi.mock('./instance-share-card', () => ({
+  InstanceShareCard: ({ recordId }: { recordId: string }) => (
+    <div data-testid='share-card'>{recordId}</div>
+  ),
+}))
+
+const ROWS: InstanceGranteeRow[] = [
+  { key: 'workflow', id: 'wf_1', name: 'Order intake', grantLevel: ResourcePermission.view },
+  { key: 'workflow', id: 'wf_2', name: 'Refund sweep', grantLevel: undefined },
+]
+
+function renderRows(props: Partial<React.ComponentProps<typeof GranteeInstanceRows>> = {}) {
+  return render(
+    <TooltipProvider>
+      <GranteeInstanceRows
+        rows={ROWS}
+        canEdit
+        isUser
+        areaLevel={Level.Read}
+        areaLabel='Workflows'
+        onChange={vi.fn()}
+        {...props}
+      />
+    </TooltipProvider>
+  )
+}
+
+describe('GranteeInstanceRows — the rows are leaves (§2.1)', () => {
+  it('renders no expand affordance on any row', () => {
+    renderRows()
+
+    expect(screen.getByText('Order intake')).toBeTruthy()
+    expect(screen.getByText('Refund sweep')).toBeTruthy()
+    // `TreeRow`'s chevron is the only Expand/Collapse control it renders.
+    expect(screen.queryByRole('button', { name: /expand|collapse/i })).toBeNull()
+  })
+
+  it('renders no grantee list — nobody else appears on a page about one grantee', () => {
+    renderRows()
+
+    // `InstanceShareBody`/`GranteeList`'s own affordances. Their absence is the
+    // whole fix: these are what let an admin edit Bob from Alice's screen.
+    expect(screen.queryByText(/add people/i)).toBeNull()
+    expect(screen.queryByTestId('share-card')).toBeNull()
+  })
+
+  it('renders no Shared·N / Restricted badge (§2.2)', () => {
+    renderRows()
+
+    expect(screen.queryByText(/^Shared ·/)).toBeNull()
+    expect(screen.queryByText('Restricted')).toBeNull()
+  })
+})
+
+describe('GranteeInstanceRows — the "Manage sharing" escape hatch (§2.3)', () => {
+  it('opens the share dialog for the row it was clicked on', async () => {
+    const user = userEvent.setup()
+    renderRows()
+
+    // Nothing is open until asked — the scope switch is explicit, not ambient.
+    expect(screen.queryByTestId('share-card')).toBeNull()
+
+    await user.click(screen.getAllByRole('button', { name: 'Manage sharing' })[1])
+
+    // The SECOND row's id, not the first — proves the hoisted dialog is keyed to
+    // the clicked row rather than to whichever row rendered first.
+    expect(screen.getByTestId('share-card').textContent).toBe('workflow:wf_2')
+    expect(screen.getByText('Share workflow')).toBeTruthy()
+  })
+
+  it('mounts one dialog for the whole list, not one per row', async () => {
+    const user = userEvent.setup()
+    renderRows()
+
+    await user.click(screen.getAllByRole('button', { name: 'Manage sharing' })[0])
+
+    expect(screen.getAllByTestId('share-card')).toHaveLength(1)
+    expect(screen.getByTestId('share-card').textContent).toBe('workflow:wf_1')
+  })
+})
+
+describe('GranteeInstanceRows — truncation (§2.6, finding 5)', () => {
+  it('says so when more instances exist than were listed', () => {
+    renderRows({ truncated: true })
+
+    expect(screen.getByText(/Showing the first page only/)).toBeTruthy()
+  })
+
+  it('stays silent when the list is complete', () => {
+    renderRows()
+
+    expect(screen.queryByText(/Showing the first page only/)).toBeNull()
+  })
+
+  it('says so alongside the empty state too — "No matches" on a truncated list is the same lie', () => {
+    renderRows({ rows: [], truncated: true })
+
+    expect(screen.getByText('No matches')).toBeTruthy()
+    expect(screen.getByText(/Showing the first page only/)).toBeTruthy()
+  })
+})
+
+describe('GranteeInstanceRows — the effective line (§2.5, finding 4)', () => {
+  /**
+   * The case the line exists for: a user-level `none` LOSES to a group's `view`
+   * (`instanceAccess` is `max` by `PERMISSION_RANK`, `none` ranked 0). Today the
+   * admin sets No access, sees the select change, and is told nothing.
+   */
+  it("reports the composed level even when it contradicts the grantee's own row", () => {
+    renderRows({
+      rows: [
+        {
+          key: 'workflow',
+          id: 'wf_1',
+          name: 'Order intake',
+          grantLevel: 'none',
+          effectiveLevel: ResourcePermission.view,
+        },
+      ],
+    })
+
+    expect(screen.getByText('Effective · Read')).toBeTruthy()
+  })
+
+  it('spells out "No access" rather than hiding the line', () => {
+    renderRows({
+      rows: [
+        {
+          key: 'workflow',
+          id: 'wf_1',
+          name: 'Order intake',
+          grantLevel: undefined,
+          effectiveLevel: null,
+        },
+      ],
+    })
+
+    expect(screen.getByText('Effective · No access')).toBeTruthy()
+  })
+
+  it('renders no line for a group/profile, which has no effective access', () => {
+    renderRows({
+      isUser: false,
+      rows: [
+        {
+          key: 'workflow',
+          id: 'wf_1',
+          name: 'Order intake',
+          grantLevel: ResourcePermission.view,
+          effectiveLevel: undefined,
+        },
+      ],
+    })
+
+    expect(screen.queryByText(/^Effective ·/)).toBeNull()
+  })
+})
+
+describe('GranteeInstanceRows — the dead-grant warning survived the change (§B.2.8)', () => {
+  /**
+   * Plan 25 §2 left exactly one inert row shape: an explicit `none` on a member
+   * who already composes the area to `None`. A positive grant on such a member is
+   * a REAL single-instance share, so warning about it would now be wrong.
+   */
+  it('marks an explicit No-access row on a None-area member', () => {
+    renderRows({
+      areaLevel: Level.None,
+      rows: [{ key: 'workflow', id: 'wf_1', name: 'Order intake', grantLevel: 'none' }],
+    })
+
+    expect(document.querySelector('svg.lucide-triangle-alert')).toBeTruthy()
+  })
+
+  it('leaves a POSITIVE grant on a None-area member unmarked', () => {
+    renderRows({
+      areaLevel: Level.None,
+      rows: [
+        { key: 'workflow', id: 'wf_1', name: 'Order intake', grantLevel: ResourcePermission.view },
+      ],
+    })
+
+    expect(document.querySelector('svg.lucide-triangle-alert')).toBeNull()
+  })
+
+  it('never marks a team, whose area level this component does not model', () => {
+    renderRows({
+      isUser: false,
+      areaLevel: Level.None,
+      rows: [{ key: 'workflow', id: 'wf_1', name: 'Order intake', grantLevel: 'none' }],
+    })
+
+    expect(document.querySelector('svg.lucide-triangle-alert')).toBeNull()
+  })
+})

--- a/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
@@ -3,31 +3,64 @@
 
 import { ResourcePermission } from '@auxx/database/enums'
 import { type InstanceAccessKey, Level } from '@auxx/lib/permissions/client'
-import { toRecordId } from '@auxx/types/resource'
-import { Badge } from '@auxx/ui/components/badge'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
 import { EmptySection } from '@auxx/ui/components/section'
-import { TreeRow, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
-import { AlertTriangle, Library } from 'lucide-react'
+import { TreeRow, TreeRowButton, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { AlertTriangle, Library, Users } from 'lucide-react'
 import { useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import type { InstanceGranteeRow } from '../hooks/use-instance-grantee-rows'
 import { AccessLevelSelect } from './access-level-select'
-import { InstanceShareBody } from './instance-share-body'
 import {
   deadGrantWarning,
   INSTANCE_ROW_COPY,
   INSTANCE_SHARE_COPY,
   INSTANCE_TYPE_META,
 } from './instance-share-copy'
+import { InstanceShareDialog } from './instance-share-dialog'
+import { InstanceTruncationNote } from './instance-truncation-note'
+import { effectiveLevelLabel, LEVEL_OF_PERMISSION } from './level-labels'
 
 /** Indent of the instance rows under their Datasets / Knowledge base / Dashboards area row. */
 const CHILD_DEPTH = 1
 
 /**
- * The nested per-instance rows under a Datasets / Knowledge base / Dashboards
- * area row in a **grantee scope** (a member/team's own overrides — capability
- * layer v2 Part B): one dataset/KB/dashboard per row with THIS grantee's own
- * explicit grant — Inherit (no row) / Read / Read+write / Full / No Access.
+ * The effective-access line (plan 31 §2.5) — what this grantee can ACTUALLY
+ * open, beside the grant they hold.
+ *
+ * Without it, plan 31 finding 4 is invisible: `instanceAccess` is `max` by
+ * `PERMISSION_RANK` with `none` ranked 0, so a user-level `No access` LOSES to
+ * any group's `view`. The admin sets No access, the select changes, nothing
+ * happens, and the screen says nothing. `Effective: Read` beside a `No access`
+ * select is what makes that legible — which is why §2.5 calls this the half that
+ * is not optional polish.
+ *
+ * **Deviation from §2.5, which puts this in the row's `description` slot:** in
+ * `TreeRow` that slot is a `TooltipExplanation` help icon, not visible text, so
+ * it would hide the one thing this exists to show. It goes in `secondary`, the
+ * visible slot beside the title. `description` keeps its existing row copy.
+ *
+ * **Unconditional here, unlike the area rows**, which show their line only when
+ * it disagrees with their ladder. The difference is what the row already states:
+ * an area row's ladder always highlights a concrete rung, while this row's
+ * select reads a bare "Inherit" for every un-granted instance (it is not given
+ * an `inheritedLevel` to name) — so there is nothing to disagree WITH, and a
+ * conditional line would simply never appear on the rows that need it most.
+ *
+ * Level only, no source attribution — that is phase 3, and it needs a
+ * `user:capabilities` bump because composition discards which row won.
+ */
+function effectiveLabel(level: ResourcePermission | null): string {
+  const rung = level === null ? Level.None : LEVEL_OF_PERMISSION[level]
+  return `Effective · ${effectiveLevelLabel(rung)}`
+}
+
+/**
+ * The nested per-instance rows under a Datasets / Knowledge base / Dashboards /
+ * Workflows area row in a **grantee scope** (a member/team/profile's own
+ * overrides — capability layer v2 Part B): one instance per row with THIS
+ * grantee's own explicit grant — Inherit (no row) / Read / Read+write / Full /
+ * No Access.
  *
  * Unlike the area-level grid above it, this picker is **not raise-only**
  * (§B.2.6): it writes the grantee's raw `ResourceAccess` row through
@@ -35,9 +68,24 @@ const CHILD_DEPTH = 1
  * one member even while their area level stays open. Copy therefore never uses
  * "override"/"raise" language — see `instance-share-copy.ts`'s `grantee` entry.
  *
- * Expanding a row lazily mounts `InstanceShareBody` — the same grantee list
- * the Share card and dialog show, covering every OTHER grantee on that
- * instance (not just this one).
+ * **These rows are leaves** (plan 31 §2.1). They used to expand into
+ * `InstanceShareBody`, which lists *every* grantee on the instance — so a page
+ * about Alice ran area level (Alice) → instance grant (Alice) → all grantees
+ * (everyone), and let you edit and revoke Bob's access from Alice's screen. All
+ * three call sites are single-grantee, so nothing wanted it. The rule that keeps
+ * this from being arbitrary: *the expand belongs to a row whose subject is
+ * everyone, because its children are the exceptions to that row.* Here the
+ * children were a different subject, which is why it read as a scope jump.
+ *
+ * The capability survives as a **"Manage sharing"** action opening
+ * `InstanceShareDialog` (§2.3) — the same scope switch, made explicit as a modal
+ * titled *Share <noun>* rather than ambient tree depth. One dialog is hoisted for
+ * the whole list, so N rows do not mount N dialogs.
+ *
+ * The `Shared · N` / `Restricted` badge went with the expand (§2.2): it is
+ * org-scope information (how many *other* people hold this instance) on a page
+ * about one person. `InstanceBaselineRows` keeps its own, where that count is
+ * the point of the row.
  *
  * Dead-row warning (§B.2.8, re-aimed by plan 25 §2): shown only for `user`
  * grantees (`isUser`), using the composed area level the HOST already knows from
@@ -50,6 +98,7 @@ const CHILD_DEPTH = 1
 export function GranteeInstanceRows({
   rows,
   isLoading = false,
+  truncated = false,
   canEdit,
   isUser,
   areaLevel,
@@ -58,6 +107,8 @@ export function GranteeInstanceRows({
 }: {
   rows: InstanceGranteeRow[]
   isLoading?: boolean
+  /** More instances exist than were fetched — see {@link InstanceTruncationNote}. */
+  truncated?: boolean
   canEdit: boolean
   /** Whether this grantee is a single member (vs. a team) — gates the dead-grant warning. */
   isUser: boolean
@@ -70,6 +121,13 @@ export function GranteeInstanceRows({
     level: ResourcePermission | 'inherit'
   ) => void
 }) {
+  /**
+   * The instance whose Share dialog is open, or `null`. Hoisted out of the row so
+   * the list mounts exactly one dialog — and so opening it cannot be mistaken for
+   * expanding the row it came from.
+   */
+  const [sharingRecordId, setSharingRecordId] = useState<RecordId | null>(null)
+
   if (isLoading) {
     return (
       <div className='flex flex-col gap-0.5'>
@@ -81,12 +139,15 @@ export function GranteeInstanceRows({
 
   if (rows.length === 0) {
     return (
-      <EmptySection
-        orientation='horizontal'
-        icon={<Library />}
-        title='No matches'
-        description='No items match your search.'
-      />
+      <>
+        <EmptySection
+          orientation='horizontal'
+          icon={<Library />}
+          title='No matches'
+          description='No items match your search.'
+        />
+        {truncated ? <InstanceTruncationNote /> : null}
+      </>
     )
   }
 
@@ -101,9 +162,21 @@ export function GranteeInstanceRows({
           disabled={!canEdit}
           showDeadRowWarning={showDeadRowWarning}
           areaLabel={areaLabel}
+          onManageSharing={() => setSharingRecordId(toRecordId(row.key, row.id))}
           onChange={(level) => onChange(row.key, row.id, level)}
         />
       ))}
+      {truncated ? <InstanceTruncationNote /> : null}
+
+      {sharingRecordId && (
+        <InstanceShareDialog
+          recordId={sharingRecordId}
+          open
+          onOpenChange={(open) => {
+            if (!open) setSharingRecordId(null)
+          }}
+        />
+      )}
     </div>
   )
 }
@@ -113,17 +186,17 @@ function GranteeInstanceRowItem({
   disabled,
   showDeadRowWarning,
   areaLabel,
+  onManageSharing,
   onChange,
 }: {
   row: InstanceGranteeRow
   disabled: boolean
   showDeadRowWarning: boolean
   areaLabel: string
+  onManageSharing: () => void
   onChange: (level: ResourcePermission | 'inherit') => void
 }) {
-  const [isOpen, setIsOpen] = useState(false)
   const meta = INSTANCE_TYPE_META[row.key]
-  const recordId = toRecordId(row.key, row.id)
   const isDeadRow = showDeadRowWarning && row.grantLevel === ResourcePermission.none
 
   return (
@@ -133,9 +206,11 @@ function GranteeInstanceRowItem({
       icon={<meta.icon className='size-4' />}
       title={<span className='truncate'>{row.name}</span>}
       description={INSTANCE_ROW_COPY.grantee.description(INSTANCE_SHARE_COPY[row.key].noun)}
-      expandable
-      isOpen={isOpen}
-      onToggleOpen={() => setIsOpen((v) => !v)}
+      secondary={
+        row.effectiveLevel !== undefined ? (
+          <span className='whitespace-nowrap text-xs'>{effectiveLabel(row.effectiveLevel)}</span>
+        ) : undefined
+      }
       actions={
         <>
           {isDeadRow && (
@@ -143,15 +218,12 @@ function GranteeInstanceRowItem({
               <AlertTriangle className='size-3.5 text-amber-500' />
             </Tooltip>
           )}
-          {row.badge === 'restricted' ? (
-            <Badge variant='secondary' size='xs'>
-              Restricted
-            </Badge>
-          ) : typeof row.badge === 'number' ? (
-            <Badge variant='secondary' size='xs'>
-              Shared · {row.badge}
-            </Badge>
-          ) : undefined}
+          <TreeRowButton
+            tooltipText={`Manage who else can reach this ${INSTANCE_SHARE_COPY[row.key].noun}`}
+            aria-label='Manage sharing'
+            onClick={onManageSharing}>
+            <Users />
+          </TreeRowButton>
           <AccessLevelSelect
             value={row.grantLevel}
             includeInherit
@@ -164,8 +236,7 @@ function GranteeInstanceRowItem({
             className='h-7 w-44'
           />
         </>
-      }>
-      {isOpen && <InstanceShareBody recordId={recordId} depth={CHILD_DEPTH + 1} />}
-    </TreeRow>
+      }
+    />
   )
 }

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SlidersHorizontal } from 'lucide-react'
 import { useCallback } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
+import { useGranteeAccess } from '../hooks/use-grantee-access'
 import { type GranteeKind, useGranteeDefAccess } from '../hooks/use-grantee-def-access'
 import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
 import { usePermissionGrants } from '../hooks/use-permission-grants'
@@ -85,6 +86,10 @@ export function GranteeLevelsSection({
     rowsByKey: instanceRowsByKey,
     setGrant: setInstanceGrant,
   } = useInstanceGranteeRows(granteeKind, granteeId)
+  // Same query `useInstanceGranteeRows` already runs — React Query dedupes it,
+  // so reading it here for the area rows costs no extra request. `effective` is
+  // null for a team, which is exactly when the area line must not render.
+  const { effective } = useGranteeAccess(granteeKind, granteeId)
 
   const handleChange = (area: Area, level: Level | undefined) => {
     const next = { ...values }
@@ -169,6 +174,7 @@ export function GranteeLevelsSection({
         rows: (
           <GranteeInstanceRows
             rows={matched}
+            truncated={instanceLists[instanceKey].truncated}
             canEdit={canEdit}
             isUser={granteeKind === 'user'}
             areaLevel={areaLevel}
@@ -213,6 +219,7 @@ export function GranteeLevelsSection({
           onChange={handleChange}
           disabled={!canEdit}
           renderChildren={renderChildren}
+          effectiveLevels={effective?.areas}
         />
       )}
     </SettingsSection>

--- a/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
@@ -16,6 +16,7 @@ import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useActor, useActors } from '~/components/resources/hooks/use-actor'
 import { ActorAvatar } from '~/components/resources/ui/actor-badge'
 import { useUser } from '~/hooks/use-user'
+import { useGranteeAccess } from '../hooks/use-grantee-access'
 import { useGranteeDefAccess } from '../hooks/use-grantee-def-access'
 import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
 import { usePermissionGrants } from '../hooks/use-permission-grants'
@@ -353,6 +354,10 @@ function GranteeAccessDetail({
     rowsByKey: instanceRowsByKey,
     setGrant: setInstanceGrant,
   } = useInstanceGranteeRows(granteeType, granteeId)
+  // Deduped by React Query with the call inside `useInstanceGranteeRows`, so the
+  // area rows' effective line costs no extra request. Null for a team, which is
+  // exactly when it must not render.
+  const { effective } = useGranteeAccess(granteeType, granteeId)
 
   /**
    * Per-def overrides nested under Records (capability layer v2 Part B.0), and
@@ -431,6 +436,7 @@ function GranteeAccessDetail({
         rows: (
           <GranteeInstanceRows
             rows={matched}
+            truncated={instanceLists[instanceKey].truncated}
             canEdit={!disabled}
             isUser={granteeType === 'user'}
             areaLevel={areaLevel}
@@ -469,6 +475,7 @@ function GranteeAccessDetail({
         onChange={onChange}
         disabled={disabled}
         renderChildren={renderChildren}
+        effectiveLevels={effective?.areas}
       />
     </Section>
   )

--- a/apps/web/src/components/permissions/ui/instance-baseline-rows.tsx
+++ b/apps/web/src/components/permissions/ui/instance-baseline-rows.tsx
@@ -13,6 +13,7 @@ import type { InstanceBaselineRow } from '../hooks/use-instance-baseline-rows'
 import { AccessLevelSelect } from './access-level-select'
 import { InstanceShareBody } from './instance-share-body'
 import { INSTANCE_ROW_COPY, INSTANCE_TYPE_META } from './instance-share-copy'
+import { InstanceTruncationNote } from './instance-truncation-note'
 
 /** Indent of the instance rows under their collection row. */
 const CHILD_DEPTH = 1
@@ -30,16 +31,28 @@ const CHILD_DEPTH = 1
  * Presentational: filtering, loading and persistence are owned by the host
  * (`WorkspaceDefaultsTab` + `useInstanceBaselineRows`), exactly like
  * `DefBaselineRows`.
+ *
+ * **Keeps its expand** where `GranteeInstanceRows` lost it (plan 31 §2.1): this
+ * row's subject IS everyone, so the grantees nested under it are exactly the
+ * exceptions to the level it sets. On a grantee row they would be a different
+ * subject entirely.
  */
 export function InstanceBaselineRows({
   rows,
   isLoading = false,
   disabled = false,
+  truncated = false,
   onChange,
 }: {
   rows: InstanceBaselineRow[]
   isLoading?: boolean
   disabled?: boolean
+  /**
+   * More instances exist than `useInstanceResourceLists` fetched. Says so rather
+   * than implying the list is complete — the grid's search only ever matched
+   * within the first page (plan 31 finding 5).
+   */
+  truncated?: boolean
   onChange: (
     key: InstanceAccessKey,
     instanceId: string,
@@ -57,12 +70,15 @@ export function InstanceBaselineRows({
 
   if (rows.length === 0) {
     return (
-      <EmptySection
-        orientation='horizontal'
-        icon={<Library />}
-        title='No matches'
-        description='No items match your search.'
-      />
+      <>
+        <EmptySection
+          orientation='horizontal'
+          icon={<Library />}
+          title='No matches'
+          description='No items match your search.'
+        />
+        {truncated ? <InstanceTruncationNote /> : null}
+      </>
     )
   }
 
@@ -76,6 +92,7 @@ export function InstanceBaselineRows({
           onChange={(level) => onChange(row.key, row.id, level)}
         />
       ))}
+      {truncated ? <InstanceTruncationNote /> : null}
     </div>
   )
 }
@@ -128,7 +145,13 @@ function InstanceBaselineRowItem({
           />
         </>
       }>
-      {isOpen && <InstanceShareBody recordId={recordId} depth={CHILD_DEPTH + 1} />}
+      {isOpen && (
+        <InstanceShareBody
+          recordId={recordId}
+          depth={CHILD_DEPTH + 1}
+          emptyHint={INSTANCE_ROW_COPY.baseline.emptyHint}
+        />
+      )}
     </TreeRow>
   )
 }

--- a/apps/web/src/components/permissions/ui/instance-share-body.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-body.tsx
@@ -72,12 +72,20 @@ export function InstanceLevelSelect({
 /**
  * The generic per-instance grantee list — extracted out of `InstanceShareCard`
  * (capability layer v2 Part B.2.3) so the standalone Share card/dialog AND the
- * nested per-instance rows on the Workspace defaults / grantee-override grids
- * (`instance-baseline-rows.tsx` / `grantee-instance-rows.tsx`) render the exact
- * same grantee list, level picker, revoke button and "add people or
- * groups" trigger. Every mount is driven by its own {@link useInstanceShare},
- * so opening several nested rows at once just runs several small `forInstance`
- * queries (accepted per-open-row cost, §B.2.4) — no new mutation surface.
+ * nested per-instance rows on the Workspace defaults grid
+ * (`instance-baseline-rows.tsx`) render the exact same grantee list, level
+ * picker, revoke button and "add people or groups" trigger. Every mount is
+ * driven by its own {@link useInstanceShare}, so opening several nested rows at
+ * once just runs several small `forInstance` queries (accepted per-open-row
+ * cost, §B.2.4) — no new mutation surface.
+ *
+ * **This list's subject is always *everyone*** (plan 31 §2.1). It belongs under
+ * a row whose own subject is the workspace, because its children are that row's
+ * exceptions. `grantee-instance-rows.tsx` used to mount it too, which put every
+ * OTHER grantee's access — editable and revocable — inside a page about one
+ * member; those rows are leaves now and link out to `InstanceShareDialog`
+ * instead. If this list ever gains a shared primitive, the axis is **subject**,
+ * never a standalone `expandable` boolean.
  *
  * Editability is gated on {@link useCanAdminInstance} exactly as before: an
  * instance-restricted admin sees this list read-only (§B.2.7).
@@ -93,6 +101,7 @@ export function InstanceLevelSelect({
 export function InstanceShareBody({
   recordId,
   depth = 0,
+  emptyHint,
 }: {
   recordId: RecordId
   /**
@@ -101,6 +110,13 @@ export function InstanceShareBody({
    * people belong under the dataset, not level with the area above it.
    */
   depth?: number
+  /**
+   * The empty-state sentence, built from the resource noun this mount resolves.
+   * **Required, and deliberately not defaulted** (plan 31 §2.6): the previous
+   * hardcoded copy pointed at "the workspace default above", which is only true
+   * where such a control exists. Every mount states its own scope.
+   */
+  emptyHint: (noun: string) => string
 }) {
   const { entityDefinitionId: key } = parseRecordId(recordId)
   const isSupported = key in INSTANCE_SHARE_COPY
@@ -160,7 +176,7 @@ export function InstanceShareBody({
       }}
       disabled={!canAdmin}
       unmanageableGrants={unmanageableGrants}
-      emptyHint={`Not shared with anyone specific. Adjust the workspace default above to restrict this ${copy.noun}.`}
+      emptyHint={emptyHint(copy.noun)}
     />
   )
 }

--- a/apps/web/src/components/permissions/ui/instance-share-card.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-card.tsx
@@ -18,7 +18,11 @@ import { useCanAdminInstance } from '~/providers/capabilities-provider'
 import type { InstanceLevel, WorkspaceBaseline } from '../hooks/use-instance-share'
 import { useInstanceShare } from '../hooks/use-instance-share'
 import { InstanceShareBody, LEVEL_ORDER, levelHelper } from './instance-share-body'
-import { INSTANCE_SHARE_COPY, type InstanceShareCopy } from './instance-share-copy'
+import {
+  INSTANCE_ROW_COPY,
+  INSTANCE_SHARE_COPY,
+  type InstanceShareCopy,
+} from './instance-share-copy'
 import { permissionLabel } from './level-labels'
 
 /** The workspace-baseline picker: the three positive rungs + "No access (Restricted)". */
@@ -166,7 +170,7 @@ export function InstanceShareCard({ recordId }: { recordId: RecordId }) {
         />
       </div>
 
-      <InstanceShareBody recordId={recordId} />
+      <InstanceShareBody recordId={recordId} emptyHint={INSTANCE_ROW_COPY.baseline.emptyHint} />
     </div>
   )
 }

--- a/apps/web/src/components/permissions/ui/instance-share-copy.ts
+++ b/apps/web/src/components/permissions/ui/instance-share-copy.ts
@@ -115,6 +115,15 @@ export const INSTANCE_ROW_COPY = {
     description:
       'The default access every member starts with for each item. Expand an item to see or ' +
       'change who else can reach it.',
+    /**
+     * `InstanceShareBody`'s empty state. Names the workspace-default control
+     * sitting directly above the list — true under `InstanceBaselineRows` and
+     * the Share card, where that control is the `role:org_member` row itself.
+     * Passed in rather than hardcoded (plan 31 §2.6) so a mount whose scope has
+     * no such control cannot inherit the sentence by accident.
+     */
+    emptyHint: (noun: string) =>
+      `Not shared with anyone specific. Adjust the workspace default above to restrict this ${noun}.`,
   },
   grantee: {
     description: (noun: string) => `Their own access to this ${noun}, on top of the default above.`,

--- a/apps/web/src/components/permissions/ui/instance-truncation-note.tsx
+++ b/apps/web/src/components/permissions/ui/instance-truncation-note.tsx
@@ -1,0 +1,23 @@
+// apps/web/src/components/permissions/ui/instance-truncation-note.tsx
+
+/**
+ * The "there are more of these than we listed" line for the per-instance rows on
+ * the Workspace defaults and grantee grids (plan 31 §2.6 / finding 5).
+ *
+ * `useInstanceResourceLists` fetches one page per resource type and reports
+ * `truncated`, but only the agent-policy grid ever consumed it — the other two
+ * surfaces silently showed the first page, and their host's search box matched
+ * only within it. Shared by both so the two surfaces cannot drift on the one
+ * sentence whose whole job is to stop the grid implying it is complete.
+ *
+ * Rendered next to the empty state too: "No matches" on a truncated list is the
+ * same lie in a louder voice.
+ */
+export function InstanceTruncationNote() {
+  return (
+    <p className='px-1 py-1 text-xs text-muted-foreground'>
+      Showing the first page only. Set access for anything not listed here from that item’s own
+      page.
+    </p>
+  )
+}

--- a/apps/web/src/components/permissions/ui/level-control.tsx
+++ b/apps/web/src/components/permissions/ui/level-control.tsx
@@ -39,14 +39,6 @@ interface LevelControlProps {
   /** Emits the new explicit level, or `undefined` to reset the area to inherited. */
   onChange: (level: Level | undefined) => void
   disabled?: boolean
-  /**
-   * Muted text rendered beside the control while nothing explicit is stored —
-   * how a caller names the fall-through. Agent grantees pass `'Default'` so an
-   * unset area reads "Default · Full" (set-semantics: absent ⇒ Full) instead of
-   * silently looking identical to an explicit Full. Omitted for the member
-   * surfaces, where the reset button alone marks the explicit state.
-   */
-  unsetHint?: string
   /** Tooltip on the reset button. Defaults to the inherit wording. */
   resetTooltip?: string
 }
@@ -60,9 +52,16 @@ interface LevelControlProps {
  * button appears once an explicit level is set. Every rung stays selectable —
  * the raise-only rule for overrides is enforced server-side (an override at or
  * below the baseline is composed away), and surfaced in the UI as an "ignored"
- * warning rather than a disabled rung. For AGENT grantees (set-semantics, no
- * inheritance) the caller passes `unsetHint` so the unset state is legible as a
- * default rather than an inherited value.
+ * warning rather than a disabled rung.
+ *
+ * **The fall-through hint is NOT here.** It used to render in this trailing
+ * cluster as an `unsetHint` prop, which put "Not set · no access" at the far
+ * right of the row, hard against the ladder it describes. It now lives in the
+ * row's `secondary` slot beside the title — see `ProfileAreaGrid`'s
+ * `ProfileAreaRow`, its only caller. Two things fell out: the hint no longer
+ * has to reserve width in this cluster to keep rows aligned (it was rendered
+ * `invisible` rather than dropped, purely for layout), and it now sits with the
+ * other left-side row state instead of competing with the control.
  */
 export function LevelControl({
   area,
@@ -71,7 +70,6 @@ export function LevelControl({
   ignored = false,
   onChange,
   disabled = false,
-  unsetHint,
   resetTooltip = 'Reset to inherited',
 }: LevelControlProps) {
   const levels = useMemo<Level[]>(
@@ -95,41 +93,45 @@ export function LevelControl({
           aria-hidden={!ignored}
         />
       </Tooltip>
-      {unsetHint !== undefined && (
-        <span
-          className={cn(
-            'text-xs text-muted-foreground whitespace-nowrap',
-            isExplicit && 'invisible'
-          )}
-          aria-hidden={isExplicit}>
-          {unsetHint}
-        </span>
-      )}
-      <Tooltip content={resetTooltip}>
-        <Button
-          type='button'
-          size='icon-sm'
-          variant='ghost'
-          aria-label={resetTooltip}
-          disabled={disabled || !isExplicit}
-          className={cn('size-6 text-muted-foreground', !isExplicit && 'invisible')}
-          onClick={() => onChange(undefined)}>
-          <Undo2 />
-        </Button>
-      </Tooltip>
       {/*
-        Fixed-width slot for the ladder, so every row's hint/reset cluster starts
-        at the same x whatever the area's rung count. The min-width belongs HERE
-        and not on `RadioTab`: that component's own container is the grey pill, so
-        widening it would stretch an empty pill behind a 2-rung toggle. The
-        wrapper keeps the pill content-sized and pins it right instead.
-        `min-w-` (not `w-`) so a hypothetical 5-rung area overflows the slot and
-        renders correctly-but-unaligned rather than clipped. 52 = 208px is the
-        smallest 0.25rem step that clears the widest ladder we ship —
-        None/Read/Edit/Full measures 206.4px (4 × (px-2.5 = 20px + the 30.6px
-        `text-xs`/500 "None") + the pill's 4px p-0.5).
+        Fixed-width slot holding the reset button AND the ladder, right-pinned so
+        every row's ladder ends at the same x whatever the area's rung count.
+
+        The reset button lives INSIDE the slot (it used to sit outside, left of
+        it) so it hugs the pill it acts on. Outside, it was separated from the
+        pill by however much of the slot a narrow ladder left empty — on a 2-rung
+        None/Full toggle that gap was most of the slot's width, and the button
+        read as belonging to nothing. The trade is deliberate: reset buttons no
+        longer share an x across rows, because "next to its own picker" beats
+        "aligned with a picker three rows up".
+
+        The min-width belongs HERE and not on `RadioTab`: that component's own
+        container is the grey pill, so widening it would stretch an empty pill
+        behind a 2-rung toggle. This wrapper keeps the pill content-sized and
+        pins the group right instead. `min-w-` (not `w-`) so a hypothetical
+        5-rung area overflows and renders correctly-but-unaligned rather than
+        clipped.
+
+        60 = 240px, re-derived for the new contents (it was 52 = 208px when the
+        slot held the ladder alone): the widest ladder we ship,
+        None/Read/Edit/Full, measures 206.4px — 4 × (px-2.5 = 20px + the 30.6px
+        `text-xs`/500 "None") + the pill's 4px p-0.5 — plus the size-6 (24px)
+        button and the 4px gap-1 = 234.4px. 240 is the smallest 0.25rem step that
+        clears it, with 5.6px of slack.
       */}
-      <div className='flex min-w-52 justify-end'>
+      <div className='flex min-w-60 items-center justify-end gap-1'>
+        <Tooltip content={resetTooltip}>
+          <Button
+            type='button'
+            size='icon-sm'
+            variant='ghost'
+            aria-label={resetTooltip}
+            disabled={disabled || !isExplicit}
+            className={cn('size-6 shrink-0 text-muted-foreground', !isExplicit && 'invisible')}
+            onClick={() => onChange(undefined)}>
+            <Undo2 />
+          </Button>
+        </Tooltip>
         <RadioTab
           value={String(displayed)}
           onValueChange={(v) => onChange(Number(v) as Level)}

--- a/apps/web/src/components/permissions/ui/level-labels.ts
+++ b/apps/web/src/components/permissions/ui/level-labels.ts
@@ -44,6 +44,23 @@ export const RUNG_LABELS_LONG: Record<Level, string> = {
 /** Which form of the label a caller wants. */
 export type LabelForm = 'short' | 'long'
 
+/**
+ * The rung as it appears in an **effective-access line** (plan 31 §2.5) — what a
+ * grantee can ACTUALLY reach, shown beside the grant they hold.
+ *
+ * Short form, except `None`, which takes the long spelling: "Effective · None"
+ * reads as a missing value when it sits beside a ladder that also has a None
+ * rung, where "Effective · No access" is unambiguous.
+ *
+ * Lives here rather than at its two call sites (the area rows and the instance
+ * rows) because plan 26 Phase 1 made this file the ONE rung vocabulary — a
+ * second spelling of a rung anywhere else is precisely what that cleanup
+ * deleted, four maps at a time.
+ */
+export function effectiveLevelLabel(level: Level): string {
+  return level === Level.None ? RUNG_LABELS_LONG[Level.None] : RUNG_LABELS[level]
+}
+
 function labelOf(level: Level, form: LabelForm): string {
   return form === 'long' ? RUNG_LABELS_LONG[level] : RUNG_LABELS[level]
 }

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.test.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.test.tsx
@@ -1,0 +1,120 @@
+// apps/web/src/components/permissions/ui/leveled-area-grid.test.tsx
+
+import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { LeveledAreaGrid } from './leveled-area-grid'
+
+/**
+ * The area rows' **effective-access line** — plan 31 §2.5 extended one level up.
+ *
+ * The plan names the read-vs-enforcement gap only for instance rows (finding 4).
+ * The same gap exists on the area rows and is arguably worse, because they had
+ * no way to show it at all: the ladder renders `values[area] ?? inherited`, where
+ * `inherited` is the member profile's base, while real composition is
+ * `min(min(max(profileBase, maxOverGroups, userLevel), profileCeiling), seatCeiling)`.
+ * A member raised into an area by a team read "Inherit · No access" here while
+ * reaching it fine.
+ *
+ * `effectiveLevels` is additive: absent ⇒ exactly today's behaviour. That matters
+ * because this grid is shared by member detail, group detail and the overrides
+ * tab, and plan 29 §4 is explicit that widening a shared grid's props means
+ * auditing every consumer. These tests pin the absent case first.
+ */
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+const ROLE_DEFAULTS = Object.fromEntries(
+  Object.keys(PERMISSION_AREAS).map((area) => [area, Level.None])
+) as Record<Area, Level>
+
+const WORKFLOWS_LABEL = PERMISSION_AREAS[Area.workflows].label
+
+function renderGrid(props: Partial<React.ComponentProps<typeof LeveledAreaGrid>> = {}) {
+  return render(
+    <TooltipProvider>
+      <LeveledAreaGrid
+        mode='override'
+        values={{}}
+        roleDefaults={ROLE_DEFAULTS}
+        baseline={{}}
+        onChange={vi.fn()}
+        {...props}
+      />
+    </TooltipProvider>
+  )
+}
+
+describe('LeveledAreaGrid — effectiveLevels is additive', () => {
+  it('renders no effective line at all when the prop is absent', () => {
+    renderGrid()
+
+    expect(screen.getByText(WORKFLOWS_LABEL)).toBeTruthy()
+    expect(screen.queryByText(/^Effective ·/)).toBeNull()
+  })
+
+  /**
+   * A group grantee composes to `null` server-side (it is a level SOURCE, not a
+   * subject), so its host passes `effective?.areas` = `undefined`. Same path as
+   * above, stated separately because it is the case a future refactor is most
+   * likely to "helpfully" fill in.
+   */
+  it('renders no effective line for a grantee with no composed access', () => {
+    renderGrid({ effectiveLevels: undefined })
+
+    expect(screen.queryByText(/^Effective ·/)).toBeNull()
+  })
+})
+
+describe('LeveledAreaGrid — the line marks a DISCREPANCY, not every row', () => {
+  it('shows the composed level when it exceeds what the ladder displays', () => {
+    // The member's own row says nothing and their profile base is None, so the
+    // ladder reads "No access" — but a team raised them to Edit.
+    renderGrid({ effectiveLevels: { [Area.workflows]: Level.Edit } })
+
+    expect(screen.getByText('Effective · Edit')).toBeTruthy()
+  })
+
+  it('stays silent when the composed level agrees with the ladder', () => {
+    // `value` is undefined, `inherited` falls through to roleDefaults = None,
+    // and composition also lands on None. Nothing to report.
+    renderGrid({ effectiveLevels: { [Area.workflows]: Level.None } })
+
+    expect(screen.queryByText(/^Effective ·/)).toBeNull()
+  })
+
+  it('stays silent when an explicit override already displays the composed level', () => {
+    renderGrid({
+      values: { [Area.workflows]: Level.Full },
+      effectiveLevels: { [Area.workflows]: Level.Full },
+    })
+
+    expect(screen.queryByText(/^Effective ·/)).toBeNull()
+  })
+
+  /**
+   * The downward direction, which no other affordance on this row can express:
+   * the grant says Full, the seat ceiling (or a profile ceiling) closes the area,
+   * and the ladder happily shows Full.
+   */
+  it('shows the composed level when a ceiling clamps BELOW the granted rung', () => {
+    renderGrid({
+      values: { [Area.workflows]: Level.Full },
+      effectiveLevels: { [Area.workflows]: Level.None },
+    })
+
+    expect(screen.getByText('Effective · No access')).toBeTruthy()
+  })
+
+  it('reports per area, not across the grid', () => {
+    renderGrid({
+      effectiveLevels: { [Area.workflows]: Level.Read, [Area.dashboards]: Level.None },
+    })
+
+    expect(screen.getAllByText(/^Effective ·/)).toHaveLength(1)
+    expect(screen.getByText('Effective · Read')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -10,6 +10,7 @@ import { TreeRow } from '@auxx/ui/components/tree-row'
 import { SlidersHorizontal } from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
 import { LevelControl } from './level-control'
+import { effectiveLevelLabel } from './level-labels'
 import { PROFILE_AREA_GROUPS } from './profile-copy'
 
 /** The grid's live filter, handed to {@link LeveledAreaGridProps.renderChildren}. */
@@ -64,6 +65,23 @@ interface LeveledAreaGridProps {
    * auto-expand a parent whose own label doesn't match the search.
    */
   renderChildren?: (area: Area, filter: AreaChildFilter) => AreaChildren | undefined
+  /**
+   * What this grantee can ACTUALLY reach per area — `CapabilitySet.areaLevel`,
+   * from `permissions.granteeAccess` (plan 31 §2.4).
+   *
+   * **Optional, and absent means today's behaviour** — the profile editor
+   * renders `ProfileAreaGrid`, not this component, and a group/profile has no
+   * effective access to report, so those surfaces simply pass nothing.
+   *
+   * Why this exists: the ladder shows `values[area] ?? inherited`, where
+   * `inherited` is the member profile's base. Real composition is
+   * `min(min(max(profileBase, maxOverGroups, userLevel), profileCeiling), seatCeiling)`
+   * — so the row displays the first and last terms of that `max` and NEITHER
+   * clamp. A member raised by a team reads "Inherit · No access" here while
+   * reaching the area fine. Same class as plan 31 finding 4, one level up; the
+   * plan names it only for instance rows.
+   */
+  effectiveLevels?: Partial<Record<Area, Level>>
 }
 
 /**
@@ -88,6 +106,7 @@ export function LeveledAreaGrid({
   onChange,
   disabled = false,
   renderChildren,
+  effectiveLevels,
 }: LeveledAreaGridProps) {
   const [search, setSearch] = useState('')
   const [overridesOnly, setOverridesOnly] = useState(false)
@@ -160,12 +179,28 @@ export function LeveledAreaGrid({
                     ? (baseline?.[area] ?? roleDefaults[area])
                     : roleDefaults[area]
                 const isOpen = openAreas[area] ?? autoOpen
+                const effective = effectiveLevels?.[area]
                 return (
                   <TreeRow
                     rowClassName='bg-primary-50 hover:bg-primary-100'
                     key={area}
                     title={meta.label}
                     description={meta.description}
+                    // Shown ONLY where it disagrees with the ladder, unlike the
+                    // instance rows, which always show it. Not an inconsistency:
+                    // the ladder here always highlights a concrete rung
+                    // (`value ?? inherited`), so a matching line would be noise
+                    // on every row and the discrepancy — a group raise, a
+                    // profile ceiling, the seat clamp — is the whole signal. A
+                    // grantee instance row's select reads a bare "Inherit" with
+                    // no rung named, so there it has to be unconditional.
+                    secondary={
+                      effective !== undefined && effective !== (value ?? inherited) ? (
+                        <span className='whitespace-nowrap text-xs'>
+                          Effective · {effectiveLevelLabel(effective)}
+                        </span>
+                      ) : undefined
+                    }
                     expandable={children !== undefined}
                     isOpen={children !== undefined ? isOpen : undefined}
                     onToggleOpen={

--- a/apps/web/src/components/permissions/ui/profile-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/profile-area-grid.tsx
@@ -6,7 +6,8 @@ import { type Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client
 import { ButtonSwitch } from '@auxx/ui/components/button-switch'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
-import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
 import { Lock, SlidersHorizontal } from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
@@ -222,7 +223,10 @@ export function ProfileAreaGrid({
       ) : (
         <div className='flex flex-col gap-4'>
           {groups.map(({ group, rows }) => (
-            <div key={group} className='flex flex-col gap-0.5'>
+            // `TREE_SECONDARY_NOTRUNCATE` because the `secondary` slot now
+            // carries the fall-through hint, and its default `truncate` would
+            // clip "Not set · no access" as soon as an area label runs long.
+            <div key={group} className={cn('flex flex-col gap-0.5', TREE_SECONDARY_NOTRUNCATE)}>
               <span className='px-1 text-xs font-semibold uppercase text-primary-600'>{group}</span>
               {rows.map(({ area, children, autoOpen }) => {
                 const isOpen = openAreas[area] ?? autoOpen
@@ -296,6 +300,8 @@ function ProfileAreaRow({
   const meta = PERMISSION_AREAS[area]
   const lockReason = lockReasonFor(area, seat)
   const isSeatLocked = lockReason === WORKER_LOCK_REASON
+  /** An explicit level of its own — the hint describes a fall-through, so it goes. */
+  const isExplicit = value !== undefined
 
   // What the area falls through to when nothing is stored. A field-seat-locked row
   // shows the level that actually applies (None, from `SEAT_CEILINGS`) — a base
@@ -315,11 +321,23 @@ function ProfileAreaRow({
       rowClassName='bg-primary-50 hover:bg-primary-100'
       title={meta.label}
       description={meta.description}
+      // The fall-through hint sits HERE, beside the title, rather than in
+      // `LevelControl`'s trailing cluster where it used to render hard against
+      // the ladder. Dropped outright when a level is explicitly stored — the old
+      // slot had to keep it `invisible` instead, purely so the trailing clusters
+      // stayed aligned across rows; on this side nothing depends on its width.
       secondary={
-        lockReason ? (
-          <Tooltip content={lockReason}>
-            <Lock className='size-3 text-muted-foreground' />
-          </Tooltip>
+        lockReason || !isExplicit ? (
+          <span className='flex items-center gap-1.5'>
+            {lockReason ? (
+              <Tooltip content={lockReason}>
+                <Lock className='size-3 text-muted-foreground' />
+              </Tooltip>
+            ) : null}
+            {!isExplicit && (
+              <span className='text-xs text-muted-foreground whitespace-nowrap'>{unsetHint}</span>
+            )}
+          </span>
         ) : undefined
       }
       expandable={childRows !== undefined}
@@ -330,7 +348,6 @@ function ProfileAreaRow({
           area={meta}
           value={value}
           inherited={inherited}
-          unsetHint={unsetHint}
           resetTooltip='Clear (back to the default)'
           onChange={onChange}
           disabled={disabled || lockReason !== null}

--- a/apps/web/src/components/permissions/ui/profile-editor.tsx
+++ b/apps/web/src/components/permissions/ui/profile-editor.tsx
@@ -242,6 +242,7 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
         rows: (
           <GranteeInstanceRows
             rows={matched}
+            truncated={instanceLists[instanceKey].truncated}
             canEdit={editable}
             isUser={false}
             areaLevel={areaLevel}

--- a/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
+++ b/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
@@ -135,7 +135,12 @@ export function WorkspaceDefaultsTab({ disabled = false }: { disabled?: boolean 
         matchCount: matched.length,
         configuredCount: all.filter((row) => row.baselineLevel !== undefined).length,
         rows: (
-          <InstanceBaselineRows rows={matched} disabled={disabled} onChange={setInstanceBaseline} />
+          <InstanceBaselineRows
+            rows={matched}
+            truncated={instanceLists[key].truncated}
+            disabled={disabled}
+            onChange={setInstanceBaseline}
+          />
         ),
       })
     }

--- a/apps/web/src/server/api/routers/permissions.ts
+++ b/apps/web/src/server/api/routers/permissions.ts
@@ -7,6 +7,7 @@ import {
   clearGranteeLevels,
   createPermissionProfile,
   getCapabilities,
+  getGranteeAccess,
   getPermissionProfile,
   Level,
   listGranteeGrants,
@@ -179,6 +180,44 @@ export const permissionsRouter = createTRPCRouter({
     const grants = await listGranteeGrants(ctx.session.organizationId, ctx.db)
     return { grants }
   }),
+
+  /**
+   * Everything ONE grantee page needs, for one grantee (plan 31 §2.4): the rows
+   * keyed to them (`own`, what the selects edit) and what they can actually reach
+   * (`effective`, what the lines report).
+   *
+   * Replaces three org-wide reads the grantee pages did and filtered client-side
+   * — {@link permissionsRouter.listGrants}, `resourceAccess.allTypeAccess` and
+   * `resourceAccess.allInstanceAccess`. Those three SURVIVE: the overrides tab's
+   * grantee LIST legitimately needs to know who has an override at all, and the
+   * Workspace defaults tab is org-wide by definition. Only the grantee DETAIL
+   * switched.
+   *
+   * Same `permissions` gate as its neighbours, which is at least as strict as the
+   * `isAdminOrOwner` the two `resourceAccess` reads it replaces used —
+   * OWNER/ADMIN hold `permissionsManage` through `ROLE_DEFAULTS`. It returns
+   * strictly less than they did: one grantee's levels, never the org's map.
+   *
+   * `effective` is `null` for `group`/`profile` — they are level sources, not
+   * subjects. See `getGranteeAccess`.
+   */
+  granteeAccess: permissionsProcedure
+    .input(
+      z.object({
+        granteeType: z.enum(['user', 'group', 'profile']),
+        granteeId: z.string(),
+      })
+    )
+    .query(async ({ ctx, input }) =>
+      getGranteeAccess(
+        {
+          organizationId: ctx.session.organizationId,
+          granteeType: input.granteeType,
+          granteeId: input.granteeId,
+        },
+        ctx.db
+      )
+    ),
 
   /**
    * Set (upsert) the per-area levels for one **override** grantee (group or

--- a/packages/lib/src/permissions/capabilities/capability-set.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set.ts
@@ -11,6 +11,7 @@ import {
   canEditRecord,
   canViewRecord,
   type InstanceListScope,
+  instanceFallbackLevel,
   instanceListScope,
   levelToPermission,
   NON_RECORD_DEF_SLUGS,
@@ -361,6 +362,33 @@ export class CapabilitySet implements CapabilityView {
       },
       key
     )
+  }
+
+  /**
+   * {@link effectiveInstanceLevel} as a public read — the composed level itself
+   * rather than a yes/no gate.
+   *
+   * For DISPLAY, and only where the display must agree with enforcement: the
+   * grantee Access grids render "what can this member actually open" beside the
+   * grantee's own grant, and plan 31 finding 4 is what happens when they don't
+   * agree (a user-level `none` LOSES to any group's `view`, so the admin sets
+   * No access, the select changes, and nothing happens). Reading the enforcement
+   * predicate is the whole point — never re-derive this from `instanceAccess`.
+   *
+   * Not a substitute for {@link assertViewInstance} on a request path. Zero I/O.
+   */
+  instanceLevel(key: InstanceAccessKey, instanceId: string): ResourcePermission | undefined {
+    return this.effectiveInstanceLevel(key, instanceId)
+  }
+
+  /**
+   * What {@link instanceLevel} answers for an instance with no `ResourceAccess`
+   * row anywhere in the org — see
+   * {@link import('./entity-access').instanceFallbackLevel}. Lets a bulk read
+   * cover "every other instance of this type" with one value. Zero I/O.
+   */
+  instanceFallbackLevel(key: InstanceAccessKey): ResourcePermission | undefined {
+    return instanceFallbackLevel(this.resolved(), key)
   }
 
   /** Whether the member may VIEW the instance (Read). Zero I/O. */

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -381,6 +381,32 @@ export function effectiveInstanceLevel(
   if ((caps.restrictedInstanceIds ?? EMPTY_INSTANCE_SET).has(instanceId)) {
     return caps.instanceAccess?.[instanceId]
   }
+  return instanceFallbackLevel(caps, key)
+}
+
+/**
+ * What {@link effectiveInstanceLevel} answers for an instance the org holds NO
+ * `ResourceAccess` row on — the area fall-through, on its own.
+ *
+ * Extracted (plan 31 §2.4) so a caller resolving MANY instances at once can ask
+ * one question per resource type instead of one per id: `permissions.granteeAccess`
+ * returns explicit answers for the instances the org manages a row on, and this
+ * value for everything else, so the client's per-row lookup is
+ * `instances[id] ?? instanceFallback[key]` — never a re-derivation. The
+ * extraction, rather than a second copy, is the point: §2.5 is explicit that a
+ * display path which drifts from enforcement is the same class of bug with a
+ * quieter failure.
+ *
+ * Order matters and mirrors its caller exactly: OWNER first (§0.10), then the
+ * seat ceiling (a billing invariant that outranks every row), then the area gate.
+ */
+export function instanceFallbackLevel(
+  caps: ResolvedRecordAccess,
+  key: InstanceAccessKey
+): ResourcePermission | undefined {
+  if (caps.role === 'OWNER') return ResourcePermission.admin
+  const cfg = INSTANCE_ACCESS_RESOURCES[key]
+  if (SEAT_CEILINGS[caps.seatType][cfg.area] === Level.None) return undefined
   const areaLevel = areaLevelFromKeys(caps.keys, cfg.area)
   if (areaLevel === Level.None) return undefined
   return cfg.baselineAtCreate ? undefined : levelToPermission(areaLevel)

--- a/packages/lib/src/permissions/capabilities/grantee-access.test.ts
+++ b/packages/lib/src/permissions/capabilities/grantee-access.test.ts
@@ -1,0 +1,382 @@
+// packages/lib/src/permissions/capabilities/grantee-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CapabilitySet } from './capability-set'
+import { composeUserCapabilities } from './compose-user-capabilities'
+import { Area, Level } from './registry'
+
+/**
+ * Plan 31 §4, phase 2 — **`granteeAccess` agrees with the enforcement path.**
+ *
+ * The bar §4 sets is deliberate: assert against `effectiveInstanceLevel`, not
+ * against a hand-written expectation. So every scenario below builds a REAL
+ * `CapabilitySet` from `composeUserCapabilities` — the same composition the read
+ * path runs — and checks what the endpoint reports for it.
+ *
+ * What that leaves this file testing is the WIRING, which is where a bug would
+ * actually live: that each instance is resolved against its own resource type
+ * (a dashboard id must not be answered through the workflows area), that the
+ * row-less fallback is per type, and that `own` / `baseline` / `effective` are
+ * split from one org-wide row set without bleeding into each other. Composition
+ * itself is already pinned by `compose-user-capabilities.test.ts` and
+ * `capability-set-instance.test.ts`.
+ */
+
+const ORG = 'org_1'
+const USER = 'user_alice'
+
+const h = vi.hoisted(() => ({ caps: null as unknown }))
+
+vi.mock('./get-capabilities', () => ({ getCapabilities: async () => h.caps }))
+
+const { getGranteeAccess } = await import('./grantee-access')
+
+/** Rows the fake db returns, in `ResourceAccess` shape. */
+interface AccessRow {
+  entityDefinitionId: string
+  entityInstanceId: string | null
+  granteeType: string
+  granteeId: string
+  permission: ResourcePermission
+}
+
+/**
+ * The two selects `getGranteeAccess` issues, in order: the grantee's own
+ * `PermissionGrant` row (`.limit(1)`) and the org's `ResourceAccess` rows.
+ */
+function fakeDb(grantLevels: unknown, accessRows: AccessRow[]) {
+  let call = 0
+  const builder = (rows: unknown[]) => {
+    const chain = {
+      from: () => chain,
+      where: () => chain,
+      limit: () => Promise.resolve(rows),
+      then: (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve),
+    }
+    return chain
+  }
+  return {
+    select: () => {
+      call += 1
+      return call === 1 ? builder([{ levels: grantLevels }]) : builder(accessRows)
+    },
+  } as never
+}
+
+/** A real `CapabilitySet`, composed exactly as the read path composes one. */
+function capsFor(input: Parameters<typeof composeUserCapabilities>[0], seatType = 'full' as const) {
+  const composed = composeUserCapabilities(input)
+  const instanceIds = new Set(Object.keys(composed.instanceAccess))
+  return new CapabilitySet(
+    new Set(composed.keys),
+    composed.defAccess,
+    input.role ?? 'USER',
+    seatType,
+    (id) => id,
+    new Set(),
+    (id) => id,
+    composed.instanceAccess,
+    instanceIds,
+    {},
+    new Set(composed.instanceDerivedKeys)
+  )
+}
+
+const WF = 'wf_shared'
+const DASH = 'dash_shared'
+
+beforeEach(() => {
+  h.caps = null
+})
+
+describe('getGranteeAccess — own / baseline / effective are split cleanly', () => {
+  it('keeps another grantee\'s row out of "own" while still answering "effective"', async () => {
+    const rows: AccessRow[] = [
+      // Alice's own row.
+      {
+        entityDefinitionId: 'workflow',
+        entityInstanceId: WF,
+        granteeType: 'user',
+        granteeId: USER,
+        permission: ResourcePermission.none,
+      },
+      // Bob's row on the SAME workflow — org-scope data that must not surface
+      // as Alice's, which is the §2.1 leak restated at the data layer.
+      {
+        entityDefinitionId: 'workflow',
+        entityInstanceId: WF,
+        granteeType: 'user',
+        granteeId: 'user_bob',
+        permission: ResourcePermission.admin,
+      },
+      // The workspace default — one row per instance, no grantee in it.
+      {
+        entityDefinitionId: 'workflow',
+        entityInstanceId: WF,
+        granteeType: 'role',
+        granteeId: 'org_member',
+        permission: ResourcePermission.view,
+      },
+    ]
+
+    h.caps = capsFor({
+      role: 'USER',
+      seatType: 'full',
+      profileLevels: { [Area.workflows]: Level.Read },
+      typeAccessRows: [],
+      instanceAccessRows: [
+        {
+          entityDefinitionId: 'workflow',
+          entityInstanceId: WF,
+          permission: ResourcePermission.none,
+        },
+      ],
+    })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({ [Area.workflows]: Level.Read }, rows)
+    )
+
+    expect(result.own.instances).toEqual({ [WF]: ResourcePermission.none })
+    expect(result.baseline.instances).toEqual({ [WF]: ResourcePermission.view })
+    // Bob's `admin` appears NOWHERE in the payload.
+    expect(JSON.stringify(result)).not.toContain('user_bob')
+  })
+
+  it("reads the grantee's own area levels from their PermissionGrant row", async () => {
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({ [Area.workflows]: Level.Edit }, [])
+    )
+
+    expect(result.own.areas).toEqual({ [Area.workflows]: Level.Edit })
+  })
+})
+
+describe('getGranteeAccess — each instance is resolved against its OWN resource type', () => {
+  /**
+   * **This pair agrees with the enforcement path but does NOT pin the per-type
+   * mapping, and that is worth stating rather than implying.** Mutating
+   * `caps.instanceLevel(key, id)` to a hardcoded `'workflow'` leaves both green.
+   *
+   * The reason is structural: for an instance the org holds a row on,
+   * `effectiveInstanceLevel` returns `instanceAccess[id]` outright, and every
+   * branch above that is key-independent EXCEPT the seat ceiling — which today
+   * cannot distinguish these areas, because `WORKER_AREAS` contains none of the
+   * four instance-access areas, so a worker seat closes all of them and a full
+   * seat opens all of them.
+   *
+   * So the mapping is currently correct-by-construction rather than
+   * correct-by-test. It is kept because the alternative is correct only by
+   * coincidence of today's seat table: a future tier that opens dashboards while
+   * closing workflows would break a collapsed version silently. The row-less
+   * fallback below IS key-dependent and IS mutation-caught — that is where the
+   * per-type weight actually rests.
+   */
+  it('answers a dashboard through dashboards and a workflow through workflows', async () => {
+    const rows: AccessRow[] = [
+      {
+        entityDefinitionId: 'workflow',
+        entityInstanceId: WF,
+        granteeType: 'role',
+        granteeId: 'org_member',
+        permission: ResourcePermission.view,
+      },
+      {
+        entityDefinitionId: 'dashboard',
+        entityInstanceId: DASH,
+        granteeType: 'user',
+        granteeId: USER,
+        permission: ResourcePermission.edit,
+      },
+    ]
+
+    const caps = capsFor({
+      role: 'USER',
+      seatType: 'full',
+      profileLevels: { [Area.workflows]: Level.Read, [Area.dashboards]: Level.Read },
+      typeAccessRows: [],
+      instanceAccessRows: [
+        {
+          entityDefinitionId: 'workflow',
+          entityInstanceId: WF,
+          permission: ResourcePermission.view,
+        },
+        {
+          entityDefinitionId: 'dashboard',
+          entityInstanceId: DASH,
+          permission: ResourcePermission.edit,
+        },
+      ],
+    })
+    h.caps = caps
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({}, rows)
+    )
+
+    // The enforcement path is the expectation — §4's bar.
+    expect(result.effective?.instances[WF]).toBe(caps.instanceLevel('workflow', WF))
+    expect(result.effective?.instances[DASH]).toBe(caps.instanceLevel('dashboard', DASH))
+  })
+
+  it('reports a per-type row-less fallback, matching the enforcement path', async () => {
+    const caps = capsFor({
+      role: 'USER',
+      seatType: 'full',
+      profileLevels: { [Area.workflows]: Level.Read, [Area.dashboards]: Level.Full },
+      typeAccessRows: [],
+    })
+    h.caps = caps
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({}, [])
+    )
+
+    // `workflow` is baselineAtCreate:false → the open area supplies a level.
+    expect(result.effective?.instanceFallback.workflow).toBe(caps.instanceFallbackLevel('workflow'))
+    expect(result.effective?.instanceFallback.workflow).toBe(ResourcePermission.view)
+    // `dashboard` is baselineAtCreate:true → a row-less dashboard is private
+    // even on a wide-open area. Same value, opposite meaning.
+    // `?? null` because "no access" is normalized to `null` on the wire — an
+    // absent key would otherwise be indistinguishable from a denial.
+    expect(result.effective?.instanceFallback.dashboard).toBe(
+      caps.instanceFallbackLevel('dashboard') ?? null
+    )
+    expect(result.effective?.instanceFallback.dashboard).toBeNull()
+  })
+})
+
+describe('getGranteeAccess — finding 4: a user-level "none" loses to a group grant', () => {
+  /**
+   * The whole reason the effective line is not optional polish (§2.5). The admin
+   * sets No access, the select changes, and today nothing tells them the group
+   * grant still wins — `instanceAccess` is `max` by `PERMISSION_RANK` with `none`
+   * ranked 0.
+   */
+  it("reports the composed level, not the grantee's own row", async () => {
+    const rows: AccessRow[] = [
+      {
+        entityDefinitionId: 'workflow',
+        entityInstanceId: WF,
+        granteeType: 'user',
+        granteeId: USER,
+        permission: ResourcePermission.none,
+      },
+    ]
+
+    h.caps = capsFor({
+      role: 'USER',
+      seatType: 'full',
+      profileLevels: { [Area.workflows]: Level.Read },
+      typeAccessRows: [],
+      // Both rows reach composition: Alice's `none` and her team's `view`.
+      instanceAccessRows: [
+        {
+          entityDefinitionId: 'workflow',
+          entityInstanceId: WF,
+          permission: ResourcePermission.none,
+        },
+        {
+          entityDefinitionId: 'workflow',
+          entityInstanceId: WF,
+          permission: ResourcePermission.view,
+        },
+      ],
+    })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({}, rows)
+    )
+
+    expect(result.own.instances[WF]).toBe(ResourcePermission.none)
+    // Both true, and the screen can now say so.
+    expect(result.effective?.instances[WF]).toBe(ResourcePermission.view)
+  })
+})
+
+describe('getGranteeAccess — a group/profile is a level SOURCE, not a subject', () => {
+  it('returns own + baseline but no effective for a group', async () => {
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'group', granteeId: 'grp_support' },
+      fakeDb({ [Area.workflows]: Level.Read }, [
+        {
+          entityDefinitionId: 'workflow',
+          entityInstanceId: WF,
+          granteeType: 'group',
+          granteeId: 'grp_support',
+          permission: ResourcePermission.view,
+        },
+      ])
+    )
+
+    expect(result.own.instances).toEqual({ [WF]: ResourcePermission.view })
+    expect(result.effective).toBeNull()
+  })
+
+  it('returns no effective for a profile either', async () => {
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'profile', granteeId: 'prof_1' },
+      fakeDb({}, [])
+    )
+
+    expect(result.effective).toBeNull()
+  })
+})
+
+describe('getGranteeAccess — the seat ceiling still dominates', () => {
+  /**
+   * A worker seat holds `workflows: None` unliftably. Plan 25 §2 made an
+   * explicit row beat the AREA floor, so the ceiling had to become an explicit
+   * check — a display path that missed it would tell an admin the field tech can
+   * open a workflow their billing packaging excludes.
+   */
+  it('reports no access for a worker seat holding an explicit grant', async () => {
+    const caps = capsFor(
+      {
+        role: 'USER',
+        seatType: 'worker',
+        profileLevels: { [Area.workflows]: Level.Full },
+        typeAccessRows: [],
+        instanceAccessRows: [
+          {
+            entityDefinitionId: 'workflow',
+            entityInstanceId: WF,
+            permission: ResourcePermission.admin,
+          },
+        ],
+      },
+      'worker'
+    )
+    h.caps = caps
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({}, [
+        {
+          entityDefinitionId: 'workflow',
+          entityInstanceId: WF,
+          granteeType: 'user',
+          granteeId: USER,
+          permission: ResourcePermission.admin,
+        },
+      ])
+    )
+
+    // The row is theirs, and it buys them nothing.
+    expect(result.own.instances[WF]).toBe(ResourcePermission.admin)
+    expect(result.effective?.instances[WF]).toBe(caps.instanceLevel('workflow', WF) ?? null)
+    expect(result.effective?.instances[WF]).toBeNull()
+  })
+})

--- a/packages/lib/src/permissions/capabilities/grantee-access.ts
+++ b/packages/lib/src/permissions/capabilities/grantee-access.ts
@@ -1,0 +1,205 @@
+// packages/lib/src/permissions/capabilities/grantee-access.ts
+
+import { type Database, database, schema } from '@auxx/database'
+import type { ResourcePermission } from '@auxx/database/enums'
+import { and, eq } from 'drizzle-orm'
+import { getCapabilities } from './get-capabilities'
+import {
+  INSTANCE_ACCESS_KEYS,
+  type InstanceAccessKey,
+  isInstanceAccessKey,
+} from './instance-access'
+import { AREA_ORDER, type Area, type Level, parseAreaLevels } from './registry'
+
+/** Who a grantee page is about. Mirrors the `ResourceAccess`/`PermissionGrant` grantee axis. */
+export type AccessGranteeType = 'user' | 'group' | 'profile'
+
+/**
+ * The `ResourceAccess` address of the workspace default (plan 16's aggregate
+ * view). Still live and load-bearing on THIS table — unlike the identically
+ * named `PermissionGrant` tier, which plan 19 §0.8 deleted and no composer reads.
+ */
+const WORKSPACE_BASELINE_GRANTEE_TYPE = 'role'
+const WORKSPACE_BASELINE_GRANTEE_ID = 'org_member'
+
+/**
+ * The rows keyed to THIS grantee — what the Access grids' selects read and write.
+ * Sparse throughout: an absent key means "no explicit row", which every surface
+ * renders as *Inherit*.
+ */
+export interface GranteeOwnAccess {
+  /** The grantee's own `PermissionGrant.levels`, per L2 area. */
+  areas: Partial<Record<Area, Level>>
+  /** Their type-level `ResourceAccess` rows, keyed by `entityDefinitionId`. */
+  defs: Record<string, ResourcePermission>
+  /** Their instance-level `ResourceAccess` rows, keyed by instance id. */
+  instances: Record<string, ResourcePermission>
+}
+
+/**
+ * What the grantee can ACTUALLY reach, composed through the same predicates the
+ * read path enforces — never a second implementation of the composition rules.
+ *
+ * `null` means *no access*, distinct from an absent key: the maps below are total
+ * over what they cover, so a client reading them never has to decide what a hole
+ * means.
+ */
+export interface GranteeEffectiveAccess {
+  /** Composed level per L2 area — total over {@link AREA_ORDER}. */
+  areas: Record<Area, Level>
+  /** Composed type-level permission per `entityDefinitionId` that has any row. */
+  defs: Record<string, ResourcePermission | null>
+  /**
+   * Composed permission for every instance the ORG holds a row on (any grantee).
+   * An instance absent here has no row anywhere, so its answer is
+   * {@link instanceFallback} for its resource type — the client's lookup is
+   * `instances[id] ?? instanceFallback[key]`, a pure lookup with no math.
+   */
+  instances: Record<string, ResourcePermission | null>
+  /** The answer for a row-less instance, per resource type. */
+  instanceFallback: Record<InstanceAccessKey, ResourcePermission | null>
+}
+
+/**
+ * The org's `role:org_member` workspace defaults — one row per def/instance,
+ * NOT per grantee.
+ *
+ * Plan 31 §2.4 omits this, and that is a gap in the plan rather than a decision:
+ * the grantee def grid renders `baselineLevel` / `isLockedDown` / the resolved
+ * *Inherit* value for every row, and all three come from these rows. Dropping
+ * them would have replaced a scope leak with a blank column.
+ *
+ * Including them is not a reintroduction of what §2.4 removes. The shape finding
+ * is about *every grantee's* rows sitting in a member page's cache — the thing
+ * that made the §2.1 leak buildable. A workspace default is a single org-wide
+ * fact the grid already states out loud, with no grantee in it.
+ */
+export interface GranteeBaselineAccess {
+  defs: Record<string, ResourcePermission>
+  instances: Record<string, ResourcePermission>
+}
+
+export interface GranteeAccess {
+  own: GranteeOwnAccess
+  baseline: GranteeBaselineAccess
+  /**
+   * `null` for `group` and `profile` grantees.
+   *
+   * They are level *sources*, not subjects: a group does not "have" effective
+   * access, its members do, and composing one would mean inventing a fictional
+   * member. This is the same distinction the grids' existing `isUser` prop
+   * already encodes for the dead-grant warning (plan 31 §2.4) — reuse it rather
+   * than adding a second flag.
+   */
+  effective: GranteeEffectiveAccess | null
+}
+
+/**
+ * Everything one grantee page needs, for ONE grantee (plan 31 §2.4).
+ *
+ * Replaces three org-wide reads the grantee pages used to do and filter
+ * client-side — `permissions.listGrants`, `resourceAccess.allTypeAccess` and
+ * `resourceAccess.allInstanceAccess`, each returning every row for every grantee
+ * in the org. Those were properly gated, so this is not a fix for a broken
+ * authorization check; it is a fix for the SHAPE. Having the org's whole grant
+ * table sitting in a member page's query cache is what made the §2.1 scope leak
+ * buildable in the first place, and is what the next row would have reached for.
+ *
+ * **`effective` is a thin wrapper over machinery that already exists and is
+ * already cached.** `getCapabilities` reads the composed blob at
+ * `user:capabilities:v11` (one user-cache read, L1-fronted), and
+ * `CapabilitySet.instanceLevel` is the enforcement predicate itself. Nothing here
+ * re-derives a composition rule, which is why this addition needs **no cache
+ * bump**: it reads the existing blob unchanged.
+ *
+ * Two DB reads, both org-scoped and indexed: the grantee's own `PermissionGrant`
+ * row, and the org's `ResourceAccess` rows. The latter stays org-wide because
+ * `effective.instances` must cover every instance the org manages a row on — but
+ * it never leaves this function; only one grantee's levels go over the wire.
+ */
+export async function getGranteeAccess(
+  params: {
+    organizationId: string
+    granteeType: AccessGranteeType
+    granteeId: string
+  },
+  db: Database = database
+): Promise<GranteeAccess> {
+  const { organizationId, granteeType, granteeId } = params
+
+  const [grantRow, accessRows] = await Promise.all([
+    db
+      .select({ levels: schema.PermissionGrant.levels })
+      .from(schema.PermissionGrant)
+      .where(
+        and(
+          eq(schema.PermissionGrant.organizationId, organizationId),
+          eq(schema.PermissionGrant.granteeType, granteeType),
+          eq(schema.PermissionGrant.granteeId, granteeId)
+        )
+      )
+      .limit(1),
+    db
+      .select({
+        entityDefinitionId: schema.ResourceAccess.entityDefinitionId,
+        entityInstanceId: schema.ResourceAccess.entityInstanceId,
+        granteeType: schema.ResourceAccess.granteeType,
+        granteeId: schema.ResourceAccess.granteeId,
+        permission: schema.ResourceAccess.permission,
+      })
+      .from(schema.ResourceAccess)
+      .where(eq(schema.ResourceAccess.organizationId, organizationId)),
+  ])
+
+  const own: GranteeOwnAccess = {
+    areas: parseAreaLevels(grantRow[0]?.levels),
+    defs: {},
+    instances: {},
+  }
+  const baseline: GranteeBaselineAccess = { defs: {}, instances: {} }
+
+  /** Instance id → its resource type, so each id is resolved against its OWN area. */
+  const keyOfInstance = new Map<string, InstanceAccessKey>()
+
+  for (const row of accessRows) {
+    if (row.entityInstanceId && isInstanceAccessKey(row.entityDefinitionId)) {
+      keyOfInstance.set(row.entityInstanceId, row.entityDefinitionId)
+    }
+    const isBaselineRow =
+      row.granteeType === WORKSPACE_BASELINE_GRANTEE_TYPE &&
+      row.granteeId === WORKSPACE_BASELINE_GRANTEE_ID
+    if (isBaselineRow) {
+      if (row.entityInstanceId) baseline.instances[row.entityInstanceId] = row.permission
+      else baseline.defs[row.entityDefinitionId] = row.permission
+    }
+    if (row.granteeType !== granteeType || row.granteeId !== granteeId) continue
+    if (row.entityInstanceId) own.instances[row.entityInstanceId] = row.permission
+    else own.defs[row.entityDefinitionId] = row.permission
+  }
+
+  // A group/profile has no composed capability set of its own — see `effective`.
+  if (granteeType !== 'user') return { own, baseline, effective: null }
+
+  const caps = await getCapabilities(granteeId, organizationId)
+
+  const areas = {} as Record<Area, Level>
+  for (const area of AREA_ORDER) areas[area] = caps.areaLevel(area)
+
+  const defs: Record<string, ResourcePermission | null> = {}
+  for (const row of accessRows) {
+    if (row.entityInstanceId) continue
+    defs[row.entityDefinitionId] ??= caps.viewAccessFor(row.entityDefinitionId) ?? null
+  }
+
+  const instances: Record<string, ResourcePermission | null> = {}
+  for (const [instanceId, key] of keyOfInstance) {
+    instances[instanceId] = caps.instanceLevel(key, instanceId) ?? null
+  }
+
+  const instanceFallback = {} as Record<InstanceAccessKey, ResourcePermission | null>
+  for (const key of INSTANCE_ACCESS_KEYS) {
+    instanceFallback[key] = caps.instanceFallbackLevel(key) ?? null
+  }
+
+  return { own, baseline, effective: { areas, defs, instances, instanceFallback } }
+}

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -21,6 +21,14 @@ export {
   setGranteeLevels,
 } from './grant-service'
 export {
+  type AccessGranteeType,
+  type GranteeAccess,
+  type GranteeBaselineAccess,
+  type GranteeEffectiveAccess,
+  type GranteeOwnAccess,
+  getGranteeAccess,
+} from './grantee-access'
+export {
   INSTANCE_ACCESS_KEYS,
   INSTANCE_ACCESS_READ_KEYS,
   INSTANCE_ACCESS_RESOURCES,

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -18,6 +18,14 @@ export {
   setGranteeLevels,
 } from './capabilities/grant-service'
 export {
+  type AccessGranteeType,
+  type GranteeAccess,
+  type GranteeBaselineAccess,
+  type GranteeEffectiveAccess,
+  type GranteeOwnAccess,
+  getGranteeAccess,
+} from './capabilities/grantee-access'
+export {
   INSTANCE_ACCESS_KEYS,
   INSTANCE_ACCESS_READ_KEYS,
   INSTANCE_ACCESS_RESOURCES,


### PR DESCRIPTION
Plan 31 phase 1, plus the server half and the instance half of phase 2.

## The leak

`GranteeInstanceRows` mounted `InstanceShareBody` on every expanded row, so a member's Permissions tab ran three subjects deep — area level (Alice) → instance grant (Alice) → **all grantees (everyone)** — and let an admin edit and revoke Bob's access from Alice's screen. All three call sites are single-grantee, so nothing wanted it.

The rows are leaves now. The `Shared · N` / `Restricted` badge went with the expand — it is org-scope information (how many *other* people hold this instance) on a page about one person — and the capability survives as a **"Manage sharing"** action opening `InstanceShareDialog`, one dialog hoisted for the whole list.

The rule, so this isn't arbitrary: *the expand belongs to a row whose subject is everyone, because its children are the exceptions to that row.* `InstanceBaselineRows` keeps both.

## Also in here

- **`permissions.granteeAccess({granteeType, granteeId}) → {own, baseline, effective}`**, wrapping `computeUserCapabilities` + `CapabilitySet.instanceLevel`. Reads the existing `user:capabilities:v11` blob unchanged, so **no cache bump**. `effective` is `null` for group/profile — they are level *sources*, not subjects.
- **Effective-access lines** on instance rows and area rows. This is the finding-4 fix: `instanceAccess` is `max` by `PERMISSION_RANK` with `none` ranked 0, so a user-level "No access" loses to any group's `view` — the admin set it, the select changed, and nothing said so. Area rows had the same gap one level up and no way to show it at all: the ladder renders `values[area] ?? profileBase`, while composition is `min(min(max(base, groups, user), profileCeiling), seatCeiling)`.
- **`truncated` threaded** into both row components (only the agent-policy grid consumed it before), rendered beside the empty state too — "No matches" on a truncated list is the same lie in a louder voice.
- **`InstanceShareBody.emptyHint` is a required caller prop.** The hardcoded copy named a workspace-default control that doesn't exist in every scope.
- **UI**: the profile grid's "Not set · no access" hint moves to the row's `secondary` slot, and `LevelControl`'s reset button moves *inside* the width slot so it hugs its own picker. That slot is re-derived to `min-w-60` (240px) — its old 208px covered the ladder alone.

## Two deviations from the plan

Both documented at the call sites:

1. **`baseline` added to the endpoint.** §2.4's `{own, effective}` omits the `role:org_member` rows, but the def grid renders `baselineLevel` / `isLockedDown` / the resolved *Inherit* value from them — dropping them would have replaced a scope leak with a blank column. It's one row per def/instance with no grantee in it, so it doesn't reintroduce what §2.4 removes.
2. **The effective line uses `secondary`, not `description`.** In `TreeRow` that slot is a `TooltipExplanation` help icon, not visible text, so §2.5's placement would hide the one thing the line exists to show.

## Verification

- 66 web permissions tests, 407 in `packages/lib` (399 baseline + 8 new).
- 7 mutations verified, each with an unmutated control.
- Zero `tsc` errors on any changed file (against the 4072 / 3649 broken baselines).
- Grep bar from §4: the only `InstanceShareBody` mounts are `instance-baseline-rows.tsx` and `instance-share-card.tsx`.

**One test claim was walked back rather than left standing.** "Each instance resolves against its own resource type" survived a mutation hardcoding `'workflow'`. The reason is structural — for a *managed* instance every branch of `effectiveInstanceLevel` is key-independent except the seat ceiling, and `WORKER_AREAS` contains none of the four instance-access areas, so no seat distinguishes them today. The mapping is kept (a future tier opening dashboards but not workflows would break a collapsed version silently) and the comment now says it is correct-by-construction, not correct-by-test. The row-less fallback *is* key-dependent and *is* mutation-caught.

## Not in scope

Plan 31 phase 2's def/areas half (`useGranteeDefAccess` still reads `allTypeAccess` org-wide; `usePermissionGrants` still reads `listGrants`) and phase 3 entirely (source attribution, which needs `v11 → v12`).

No browser pass yet.
