### PR TITLE
feat(permissions): scope grantee def and area reads to one grantee

### DIFF
--- a/apps/web/src/components/permissions/hooks/use-grantee-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-access.ts
@@ -2,8 +2,11 @@
 'use client'
 
 import { useCallback } from 'react'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import type { GranteeKind } from './use-grantee-def-access'
+
+/** The whole `granteeAccess` payload, as the query cache holds it. */
+export type GranteeAccessData = RouterOutputs['permissions']['granteeAccess']
 
 /**
  * Invalidate every `granteeAccess` query — call after ANY permission write.
@@ -36,6 +39,39 @@ export function useInvalidateGranteeAccess() {
   return useCallback(() => {
     void utils.permissions.granteeAccess.invalidate()
   }, [utils])
+}
+
+/**
+ * Optimistically patch one grantee's cached payload, so a select moves the
+ * instant it is clicked instead of after a round-trip.
+ *
+ * **Patch `own` and `baseline` only. Never `effective`.** That is not a style
+ * rule, it is the line the last bug in this file was on: `own` and `baseline`
+ * are rows the server stores verbatim, so the client can predict them exactly;
+ * `effective` is COMPOSED — `max` across the grantee's profile, every group they
+ * are in and their own row, then clamped by the profile and seat ceilings — and
+ * predicting it here would mean a second implementation of composition running
+ * against the enforcement path. Leave it stale and let
+ * {@link useInvalidateGranteeAccess} refetch it; a briefly-behind effective line
+ * is honest, a confidently-wrong one is not.
+ *
+ * A no-op when the query is not mounted, which is what makes it safe to fire
+ * from the shared write path regardless of which surface is on screen.
+ */
+export function usePatchGranteeAccess() {
+  const utils = api.useUtils()
+  return useCallback(
+    (
+      granteeType: GranteeKind,
+      granteeId: string,
+      patch: (prev: GranteeAccessData) => GranteeAccessData
+    ) => {
+      utils.permissions.granteeAccess.setData({ granteeType, granteeId }, (prev) =>
+        prev ? patch(prev) : prev
+      )
+    },
+    [utils]
+  )
 }
 
 /**

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.test.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.test.ts
@@ -1,0 +1,332 @@
+// apps/web/src/components/permissions/hooks/use-grantee-def-access.test.ts
+
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { Area, Level } from '@auxx/lib/permissions/client'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 31 §2.4, phase 2's **def half** — this hook reads ONE grantee.
+ *
+ * It used to run `resourceAccess.allTypeAccess`: every type-level row for every
+ * grantee in the org, narrowed client-side with two filters. That query was
+ * properly gated (`isAdminOrOwner`), so this was never an authorization fix — it
+ * is the SHAPE finding. Having the org's whole access table in a member page's
+ * query cache is what made the §2.1 scope leak buildable, and is what the next
+ * row would have reached for. `allTypeAccess` itself survives for the Workspace
+ * defaults tab, which is org-wide by definition.
+ *
+ * What that leaves worth testing is the two things a swap like this breaks:
+ * that the rows are still derived from the right halves of the new payload
+ * (`own.defs` for the grantee's grant, `baseline.defs` for the workspace
+ * default), and that the optimistic write still lands — on `own`/`baseline`,
+ * which the server stores verbatim, and NEVER on `effective`, which is composed.
+ */
+
+const {
+  granteeAccessQuery,
+  roleDefaultsQuery,
+  granteeAccessSetData,
+  granteeAccessInvalidate,
+  resourceAccessInvalidate,
+  grantTypeMutate,
+  revokeTypeMutate,
+  resources,
+} = vi.hoisted(() => ({
+  granteeAccessQuery: vi.fn(),
+  roleDefaultsQuery: vi.fn(),
+  granteeAccessSetData: vi.fn(),
+  granteeAccessInvalidate: vi.fn(),
+  resourceAccessInvalidate: vi.fn(),
+  grantTypeMutate: vi.fn(),
+  revokeTypeMutate: vi.fn(),
+  resources: { current: [] as unknown[] },
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      permissions: {
+        granteeAccess: { setData: granteeAccessSetData, invalidate: granteeAccessInvalidate },
+      },
+      resourceAccess: { invalidate: resourceAccessInvalidate },
+    }),
+    permissions: {
+      granteeAccess: { useQuery: granteeAccessQuery },
+      roleDefaults: { useQuery: roleDefaultsQuery },
+    },
+    resourceAccess: {
+      grantType: { useMutation: () => ({ mutate: grantTypeMutate }) },
+      revokeType: { useMutation: () => ({ mutate: revokeTypeMutate }) },
+    },
+  },
+}))
+
+vi.mock('~/components/resources/hooks', () => ({
+  useResources: () => ({ resources: resources.current, isLoading: false }),
+}))
+
+const { useGranteeDefAccess } = await import('./use-grantee-def-access')
+
+const USER = 'usr_alice'
+const TICKET = 'edef_ticket'
+const CONTACT = 'edef_contact'
+
+/** Two record-type resources, both access-manageable. */
+const RESOURCES = [
+  {
+    id: 'ticket',
+    apiSlug: 'tickets',
+    entityType: 'ticket',
+    entityDefinitionId: TICKET,
+    plural: 'Tickets',
+    label: 'Ticket',
+  },
+  {
+    id: 'contact',
+    apiSlug: 'contacts',
+    entityType: 'contact',
+    entityDefinitionId: CONTACT,
+    plural: 'Contacts',
+    label: 'Contact',
+  },
+]
+
+/** `ROLE_DEFAULTS.USER` — the all-`None` floor, trimmed to what these read. */
+const ROLE_DEFAULTS = { [Area.records]: Level.None }
+
+interface Payload {
+  own: { areas: Record<string, Level>; defs: Record<string, ResourcePermission> }
+  baseline: { areas: Record<string, Level>; defs: Record<string, ResourcePermission> }
+  effective: { areas: Record<string, Level>; defs: Record<string, ResourcePermission | null> }
+}
+
+function payload(overrides: Partial<Payload> = {}): Payload {
+  return {
+    own: { areas: {}, defs: {}, ...overrides.own },
+    baseline: { areas: {}, defs: {}, ...overrides.baseline },
+    effective: { areas: {}, defs: {}, ...overrides.effective },
+  }
+}
+
+function setup(data: Payload, granteeKind: 'user' | 'group' = 'user') {
+  granteeAccessQuery.mockReturnValue({ data, isLoading: false })
+  roleDefaultsQuery.mockReturnValue({ data: ROLE_DEFAULTS, isLoading: false })
+  resources.current = RESOURCES
+  return renderHook(() => useGranteeDefAccess(granteeKind, USER)).result
+}
+
+/** Run the last `setData` updater over `prev` and return what it produced. */
+function patched(prev: Payload) {
+  const call = granteeAccessSetData.mock.calls.at(-1)
+  const updater = call?.[1] as (p: Payload) => Payload
+  return { input: call?.[0], next: updater(prev) }
+}
+
+beforeEach(() => {
+  for (const fn of [
+    granteeAccessQuery,
+    roleDefaultsQuery,
+    granteeAccessSetData,
+    granteeAccessInvalidate,
+    resourceAccessInvalidate,
+    grantTypeMutate,
+    revokeTypeMutate,
+  ]) {
+    fn.mockReset()
+  }
+})
+
+describe('rows are derived from the grantee-scoped payload', () => {
+  it("reads this grantee's grant from own.defs and the default from baseline.defs", () => {
+    const result = setup(
+      payload({
+        own: { areas: {}, defs: { [TICKET]: ResourcePermission.edit } },
+        baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } },
+      })
+    )
+
+    const ticket = result.current.rows.find((r) => r.resource.entityDefinitionId === TICKET)
+    expect(ticket?.grantLevel).toBe(ResourcePermission.edit)
+    expect(ticket?.baselineLevel).toBe(ResourcePermission.view)
+    // Configured def → Inherit resolves to its workspace baseline, not the area.
+    expect(ticket?.inheritedLevel).toBe(ResourcePermission.view)
+  })
+
+  it('leaves an unconfigured def with no grant and no baseline row', () => {
+    const result = setup(payload())
+
+    const contact = result.current.rows.find((r) => r.resource.entityDefinitionId === CONTACT)
+    expect(contact?.grantLevel).toBeUndefined()
+    // Records is `None` on both the role floor and the member profile.
+    expect(contact?.baselineLevel).toBe(ResourcePermission.none)
+    expect(contact?.isLockedDown).toBe(true)
+  })
+
+  it("falls the Inherit value through to the grantee's OWN area level", () => {
+    const result = setup(
+      payload({
+        own: { areas: { [Area.records]: Level.Full }, defs: {} },
+        baseline: { areas: { [Area.records]: Level.Read }, defs: {} },
+      })
+    )
+
+    const contact = result.current.rows.find((r) => r.resource.entityDefinitionId === CONTACT)
+    // The grantee's raise decides what they inherit — `edit`, not `admin`:
+    // `levelToRecordBasePermission` caps at Edit because a record type has no
+    // `admin` BASE, only a per-record grant.
+    expect(contact?.inheritedLevel).toBe(ResourcePermission.edit)
+    // ...while the workspace baseline is what everyone else gets.
+    expect(contact?.baselineLevel).toBe(ResourcePermission.view)
+  })
+
+  it('flags a grant that lifts nothing above the baseline', () => {
+    const result = setup(
+      payload({
+        own: { areas: {}, defs: { [TICKET]: ResourcePermission.view } },
+        baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } },
+      })
+    )
+
+    expect(
+      result.current.rows.find((r) => r.resource.entityDefinitionId === TICKET)?.isNoEffect
+    ).toBe(true)
+  })
+})
+
+describe('writes patch own/baseline optimistically and never effective', () => {
+  const prev = payload({
+    own: { areas: {}, defs: { [CONTACT]: ResourcePermission.view } },
+    baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } },
+  })
+
+  it("writes the new permission onto own.defs, addressed to this grantee's key", () => {
+    const result = setup(
+      payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
+    )
+
+    result.current.setLevel(TICKET, ResourcePermission.edit)
+
+    const { input, next } = patched(prev)
+    expect(input).toEqual({ granteeType: 'user', granteeId: USER })
+    expect(next.own.defs[TICKET]).toBe(ResourcePermission.edit)
+    // The grantee's OTHER defs survive — the patch upserts one key, it does not
+    // rebuild the map from somewhere else.
+    expect(next.own.defs[CONTACT]).toBe(ResourcePermission.view)
+    expect(grantTypeMutate).toHaveBeenCalledWith({
+      entityDefinitionId: TICKET,
+      granteeType: ResourceGranteeType.user,
+      granteeId: USER,
+      permission: ResourcePermission.edit,
+    })
+  })
+
+  it('leaves effective alone — it is composed, and the invalidation owns it', () => {
+    const result = setup(
+      payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
+    )
+
+    result.current.setLevel(TICKET, ResourcePermission.edit)
+
+    expect(patched(prev).next.effective).toBe(prev.effective)
+  })
+
+  it('drops the row from own.defs on Inherit, and revokes', () => {
+    const result = setup(
+      payload({ own: { areas: {}, defs: { [CONTACT]: ResourcePermission.view } } })
+    )
+
+    result.current.setLevel(CONTACT, 'inherit')
+
+    expect(patched(prev).next.own.defs).toEqual({})
+    expect(revokeTypeMutate).toHaveBeenCalledWith({
+      entityDefinitionId: CONTACT,
+      granteeType: ResourceGranteeType.user,
+      granteeId: USER,
+    })
+  })
+
+  /**
+   * The first-touch rule is correctness, not polish: raising one grantee on a
+   * def with no baseline row would otherwise make that def restricted and lock
+   * every other member out. The baseline write has to be patched too, or the row
+   * re-renders as "Restricted" for the moment before the refetch lands.
+   */
+  it('writes and patches the workspace baseline on first touch', () => {
+    const result = setup(payload({ own: { areas: { [Area.records]: Level.Full }, defs: {} } }))
+
+    result.current.setLevel(CONTACT, ResourcePermission.admin)
+
+    // Two `grantType` calls: the baseline first, then the grantee's own row.
+    expect(grantTypeMutate).toHaveBeenNthCalledWith(1, {
+      entityDefinitionId: CONTACT,
+      granteeType: ResourceGranteeType.role,
+      granteeId: 'org_member',
+      permission: ResourcePermission.none,
+    })
+    expect(grantTypeMutate).toHaveBeenNthCalledWith(2, {
+      entityDefinitionId: CONTACT,
+      granteeType: ResourceGranteeType.user,
+      granteeId: USER,
+      permission: ResourcePermission.admin,
+    })
+
+    // Both patches ran against the same key, baseline before own.
+    const baselinePatch = granteeAccessSetData.mock.calls.at(-2)?.[1] as (p: Payload) => Payload
+    expect(baselinePatch(prev).baseline.defs[CONTACT]).toBe(ResourcePermission.none)
+    expect(patched(prev).next.own.defs[CONTACT]).toBe(ResourcePermission.admin)
+  })
+
+  it('does NOT re-write the baseline when the def already has one', () => {
+    const result = setup(
+      payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
+    )
+
+    result.current.setLevel(TICKET, ResourcePermission.admin)
+
+    expect(grantTypeMutate).toHaveBeenCalledTimes(1)
+    expect(grantTypeMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ granteeType: ResourceGranteeType.user })
+    )
+  })
+
+  it('does not touch the cache when the grantee page is not mounted', () => {
+    const result = setup(
+      payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
+    )
+
+    result.current.setLevel(TICKET, ResourcePermission.edit)
+
+    const updater = granteeAccessSetData.mock.calls.at(-1)?.[1] as (p: unknown) => unknown
+    expect(updater(undefined)).toBeUndefined()
+  })
+})
+
+describe('a profile grantee takes its area levels from the live draft', () => {
+  /**
+   * A profile's def override is authored directly ON the profile being edited,
+   * so its Inherit fall-through is the editor's unsaved draft — never the
+   * persisted `own.areas` the endpoint returns for it.
+   */
+  it('prefers profileOwnLevels over the persisted own.areas', () => {
+    granteeAccessQuery.mockReturnValue({
+      data: payload({ own: { areas: { [Area.records]: Level.None }, defs: {} } }),
+      isLoading: false,
+    })
+    roleDefaultsQuery.mockReturnValue({ data: ROLE_DEFAULTS, isLoading: false })
+    resources.current = RESOURCES
+
+    const { result } = renderHook(() =>
+      useGranteeDefAccess('profile', 'pprf_1', {
+        levels: { [Area.records]: Level.Full },
+        baseLevel: null,
+      })
+    )
+
+    const contact = result.current.rows.find((r) => r.resource.entityDefinitionId === CONTACT)
+    // The draft's Full, mapped to the record base vocabulary...
+    expect(contact?.inheritedLevel).toBe(ResourcePermission.edit)
+    // ...and NOT the persisted `None` the endpoint returned for this profile.
+    expect(contact?.inheritedLevel).not.toBe(ResourcePermission.none)
+  })
+})

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
@@ -15,8 +15,12 @@ import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
 import { useResources } from '~/components/resources/hooks'
 import { api } from '~/trpc/react'
-import { useInvalidateGranteeAccess } from './use-grantee-access'
-import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permission-grants'
+import {
+  useGranteeAccess,
+  useInvalidateGranteeAccess,
+  usePatchGranteeAccess,
+} from './use-grantee-access'
+import { MEMBER_BASELINE_GRANTEE_ID, useRoleDefaults } from './use-permission-grants'
 
 /**
  * The grantee axis this section edits: an individual member, a team, or (doc 19
@@ -73,10 +77,17 @@ export interface GranteeDefAccessRow {
  * CRM def with that grantee's effective level and lets an admin set it, editing
  * the same type-level `ResourceAccess` rows the per-def Permissions tab writes.
  *
- * Reads once from `resourceAccess.allTypeAccess` (all type rows, org-wide) and
- * `useResources`, then derives per def: the baseline (`role:org_member` row), the
- * locked-down flag (baseline = No Access), this grantee's grant, and whether that
- * grant is a no-op (≤ baseline). Writes reuse `grantType`/`revokeType`.
+ * Reads ONE grantee, not the org (plan 31 §2.4): `permissions.granteeAccess`
+ * supplies this grantee's own type rows, the org's `role:org_member` workspace
+ * defaults and the Member profile's area levels; `useResources` supplies the def
+ * list. It used to pull `resourceAccess.allTypeAccess` — every type row for
+ * every grantee — and narrow client-side. That was properly gated, so this is a
+ * SHAPE fix, not an authorization one; `allTypeAccess` survives for the
+ * Workspace defaults tab, which is org-wide by definition.
+ *
+ * Derives per def: the baseline (`role:org_member` row), the locked-down flag
+ * (baseline = No Access), this grantee's grant, and whether that grant is a
+ * no-op (≤ baseline). Writes reuse `grantType`/`revokeType`.
  *
  * **First-touch rule (correctness, not polish):** setting an explicit grant on a
  * def with no baseline row yet ALSO writes `role:org_member @ edit`, so the def
@@ -101,18 +112,17 @@ export function useGranteeDefAccess(
 
   // The grantee's Layer-2 levels — what unconfigured (non-restricted) defs
   // inherit from their mapped base area. Own override → member baseline → role default.
-  const {
-    isLoading: grantsLoading,
-    roleDefaults,
-    effectiveBaseline,
-    groupGrants,
-    userGrants,
-  } = usePermissionGrants()
-  const ownAreaLevels = useMemo(() => {
-    if (granteeKind === 'profile') return profileOwnLevels?.levels ?? {}
-    const persisted = granteeKind === 'group' ? groupGrants : userGrants
-    return persisted.find((g) => g.granteeId === granteeId)?.levels ?? {}
-  }, [granteeKind, granteeId, groupGrants, userGrants, profileOwnLevels])
+  const { roleDefaults, isLoading: roleDefaultsLoading } = useRoleDefaults()
+  const { isLoading: granteeLoading, own, baseline } = useGranteeAccess(granteeKind, granteeId)
+  const ownAreaLevels = useMemo(
+    () => (granteeKind === 'profile' ? (profileOwnLevels?.levels ?? {}) : (own?.areas ?? {})),
+    [granteeKind, own, profileOwnLevels]
+  )
+  /** The org-wide member baseline per area — role default merged with org policy. */
+  const effectiveBaseline = useMemo<Partial<Record<Area, Level>>>(
+    () => ({ ...(roleDefaults ?? {}), ...(baseline?.areas ?? {}) }),
+    [roleDefaults, baseline]
+  )
 
   const targetBasePermission = useCallback(
     (area: Area): ResourcePermission => {
@@ -136,10 +146,9 @@ export function useGranteeDefAccess(
     [effectiveBaseline, roleDefaults]
   )
 
-  const rowsQuery = api.resourceAccess.allTypeAccess.useQuery(undefined, { staleTime: 30_000 })
-
   // Broad on purpose: the per-def Permissions tab reads the same rows under
-  // `resourceAccess.forType`, so a write here must refresh that key too.
+  // `resourceAccess.forType`, and the Workspace defaults tab under
+  // `resourceAccess.allTypeAccess`, so a write here must refresh those keys too.
   // `granteeAccess` rides along because a def write moves its COMPOSED
   // `effective` half, which no optimistic patch here can predict.
   const invalidateGranteeAccess = useInvalidateGranteeAccess()
@@ -148,38 +157,27 @@ export function useGranteeDefAccess(
     return utils.resourceAccess.invalidate()
   }, [utils, invalidateGranteeAccess])
 
-  /** Optimistically upsert (or, with `permission` undefined, drop) one type row. */
+  const patchGranteeAccess = usePatchGranteeAccess()
+
+  /**
+   * Optimistically upsert (or, with `permission` undefined, drop) one type row
+   * in this grantee's cached payload — what makes a def write feel instant.
+   *
+   * Patches `own.defs` or `baseline.defs` depending on which row is being
+   * written; both are stored verbatim by the server, so the client predicts them
+   * exactly. `effective.defs` is left alone and refetched — see
+   * {@link usePatchGranteeAccess}.
+   */
   const patchLocal = useCallback(
-    (
-      entityDefinitionId: string,
-      rowGranteeType: ResourceGranteeType,
-      rowGranteeId: string,
-      permission?: ResourcePermission
-    ) => {
-      utils.resourceAccess.allTypeAccess.setData(undefined, (prev) => {
-        const rows = (prev ?? []).filter(
-          (r) =>
-            !(
-              r.entityDefinitionId === entityDefinitionId &&
-              r.granteeType === rowGranteeType &&
-              r.granteeId === rowGranteeId
-            )
-        )
-        if (permission) {
-          rows.unshift({
-            id: `optimistic-${entityDefinitionId}-${rowGranteeType}-${rowGranteeId}`,
-            entityDefinitionId,
-            entityInstanceId: null,
-            granteeType: rowGranteeType,
-            granteeId: rowGranteeId,
-            permission,
-            createdAt: new Date(),
-          } as (typeof rows)[number])
-        }
-        return rows
+    (entityDefinitionId: string, target: 'own' | 'baseline', permission?: ResourcePermission) => {
+      patchGranteeAccess(granteeKind, granteeId, (prev) => {
+        const defs = { ...prev[target].defs }
+        if (permission) defs[entityDefinitionId] = permission
+        else delete defs[entityDefinitionId]
+        return { ...prev, [target]: { ...prev[target], defs } }
       })
     },
-    [utils]
+    [patchGranteeAccess, granteeKind, granteeId]
   )
 
   const grantType = api.resourceAccess.grantType.useMutation({
@@ -197,41 +195,20 @@ export function useGranteeDefAccess(
     onSettled: () => void invalidate(),
   })
 
-  const allRows = useMemo(() => rowsQuery.data ?? [], [rowsQuery.data])
-
   /** Per-def baseline permission (`role:org_member` row), keyed by def id. */
-  const baselineByDef = useMemo(() => {
-    const map = new Map<string, ResourcePermission>()
-    for (const r of allRows) {
-      if (
-        r.granteeType === ResourceGranteeType.role &&
-        r.granteeId === MEMBER_BASELINE_GRANTEE_ID
-      ) {
-        map.set(r.entityDefinitionId, r.permission)
-      }
-    }
-    return map
-  }, [allRows])
+  const baselineByDef = useMemo(() => baseline?.defs ?? {}, [baseline])
 
   /** This grantee's explicit grant per def, keyed by def id. */
-  const grantByDef = useMemo(() => {
-    const map = new Map<string, ResourcePermission>()
-    for (const r of allRows) {
-      if (r.granteeType === granteeType && r.granteeId === granteeId) {
-        map.set(r.entityDefinitionId, r.permission)
-      }
-    }
-    return map
-  }, [allRows, granteeType, granteeId])
+  const grantByDef = useMemo(() => own?.defs ?? {}, [own])
 
   const rows = useMemo<GranteeDefAccessRow[]>(() => {
     return resources
       .filter(isAccessManageable)
       .map((resource) => {
-        const configuredBaseline = baselineByDef.get(resource.entityDefinitionId)
+        const configuredBaseline = baselineByDef[resource.entityDefinitionId]
         const baseArea = ENTITY_BASE_AREAS[resource.entityType ?? ''] ?? Area.records
         const baselineLevel = configuredBaseline ?? workspaceBasePermission(baseArea)
-        const grantLevel = grantByDef.get(resource.entityDefinitionId)
+        const grantLevel = grantByDef[resource.entityDefinitionId]
         // Configured def → inherit its workspace baseline; unconfigured → the
         // grantee's general Records level.
         const inheritedLevel = configuredBaseline ?? targetBasePermission(baseArea)
@@ -260,21 +237,16 @@ export function useGranteeDefAccess(
   const setLevel = useCallback(
     (entityDefinitionId: string, level: ResourcePermission | 'inherit') => {
       if (level === 'inherit') {
-        patchLocal(entityDefinitionId, granteeType, granteeId)
+        patchLocal(entityDefinitionId, 'own')
         revokeType.mutate({ entityDefinitionId, granteeType, granteeId })
         return
       }
       // First-touch: keep everyone at the default while this grantee is raised.
-      if (!baselineByDef.has(entityDefinitionId)) {
+      if (baselineByDef[entityDefinitionId] === undefined) {
         const resource = resources.find((item) => item.entityDefinitionId === entityDefinitionId)
         const baseArea = ENTITY_BASE_AREAS[resource?.entityType ?? ''] ?? Area.records
         const defaultBaseline = workspaceBasePermission(baseArea)
-        patchLocal(
-          entityDefinitionId,
-          ResourceGranteeType.role,
-          MEMBER_BASELINE_GRANTEE_ID,
-          defaultBaseline
-        )
+        patchLocal(entityDefinitionId, 'baseline', defaultBaseline)
         grantType.mutate({
           entityDefinitionId,
           granteeType: ResourceGranteeType.role,
@@ -282,7 +254,7 @@ export function useGranteeDefAccess(
           permission: defaultBaseline,
         })
       }
-      patchLocal(entityDefinitionId, granteeType, granteeId, level)
+      patchLocal(entityDefinitionId, 'own', level)
       grantType.mutate({ entityDefinitionId, granteeType, granteeId, permission: level })
     },
     [
@@ -298,7 +270,7 @@ export function useGranteeDefAccess(
   )
 
   return {
-    isLoading: resourcesLoading || rowsQuery.isLoading || grantsLoading,
+    isLoading: resourcesLoading || granteeLoading || roleDefaultsLoading,
     rows,
     setLevel,
   }

--- a/apps/web/src/components/permissions/hooks/use-permission-grants.test.ts
+++ b/apps/web/src/components/permissions/hooks/use-permission-grants.test.ts
@@ -29,6 +29,7 @@ const {
   grantMutate,
   revokeMutate,
   granteeAccessInvalidate,
+  granteeAccessSetData,
   grantOptions,
   revokeOptions,
 } = vi.hoisted(() => ({
@@ -38,9 +39,18 @@ const {
   grantMutate: vi.fn(),
   revokeMutate: vi.fn(),
   granteeAccessInvalidate: vi.fn(),
+  granteeAccessSetData: vi.fn(),
   /** The options object each mutation was registered with, so its hooks can be fired. */
-  grantOptions: { current: undefined as undefined | { onSettled?: () => void } },
-  revokeOptions: { current: undefined as undefined | { onSettled?: () => void } },
+  grantOptions: {
+    current: undefined as
+      | undefined
+      | { onSettled?: () => void; onMutate?: (input: unknown) => Promise<void> | void },
+  },
+  revokeOptions: {
+    current: undefined as
+      | undefined
+      | { onSettled?: () => void; onMutate?: (input: unknown) => Promise<void> | void },
+  },
 }))
 
 vi.mock('~/trpc/react', () => ({
@@ -48,7 +58,7 @@ vi.mock('~/trpc/react', () => ({
     useUtils: () => ({
       permissions: {
         listGrants: { setData: vi.fn(), cancel: vi.fn(), invalidate: vi.fn() },
-        granteeAccess: { invalidate: granteeAccessInvalidate },
+        granteeAccess: { invalidate: granteeAccessInvalidate, setData: granteeAccessSetData },
       },
     }),
     permissions: {
@@ -56,13 +66,19 @@ vi.mock('~/trpc/react', () => ({
       listProfiles: { useQuery: listProfilesQuery },
       roleDefaults: { useQuery: roleDefaultsQuery },
       grant: {
-        useMutation: (options?: { onSettled?: () => void }) => {
+        useMutation: (options?: {
+          onSettled?: () => void
+          onMutate?: (input: unknown) => Promise<void> | void
+        }) => {
           grantOptions.current = options
           return { mutate: grantMutate, isPending: false }
         },
       },
       revoke: {
-        useMutation: (options?: { onSettled?: () => void }) => {
+        useMutation: (options?: {
+          onSettled?: () => void
+          onMutate?: (input: unknown) => Promise<void> | void
+        }) => {
           revokeOptions.current = options
           return { mutate: revokeMutate, isPending: false }
         },
@@ -314,5 +330,96 @@ describe('granteeAccess is refetched after an area-level write', () => {
     grantOptions.current?.onSettled?.()
 
     expect(granteeAccessInvalidate).toHaveBeenCalledWith()
+  })
+})
+
+/**
+ * Plan 31 §2.4, phase 2's areas half — **the write patches `granteeAccess.own`
+ * optimistically, and `effective` never.**
+ *
+ * The grantee detail page reads its area levels from `granteeAccess.own.areas`
+ * now, not from the org-wide `listGrants`. Without an optimistic patch on that
+ * key the ladder would snap back to its pre-write rung until the refetch landed,
+ * so the patch is what keeps the control feeling immediate.
+ *
+ * `effective` must stay untouched in the same breath. `own` is a row the server
+ * stores verbatim, so the client predicts it exactly; `effective` is composed
+ * across the profile, every group and the ceilings, and predicting it here would
+ * be a second implementation of composition racing the enforcement path. It is
+ * left stale on purpose and refetched by the invalidation above.
+ *
+ * These fire the real `onMutate` the hook registered. The previous version of
+ * this file could not have caught a regression here: its `useUtils` mock had no
+ * `granteeAccess.setData` at all, and the suite stayed green because nothing
+ * ever invoked the callback — the same partial-mock trap that hid the missing
+ * refetch this file was written to pin.
+ */
+describe('an area-level write patches granteeAccess.own optimistically', () => {
+  /** A cached payload in the shape `granteeAccess` returns. */
+  const cached = {
+    own: { areas: { [Area.files]: Level.Read }, defs: {}, instances: {} },
+    baseline: { areas: {}, defs: {}, instances: {} },
+    effective: {
+      areas: { [Area.files]: Level.Full },
+      defs: {},
+      instances: {},
+      instanceFallback: {},
+    },
+  }
+
+  /** Run the hook's `setData` updater over {@link cached} and return the result. */
+  function patched() {
+    const call = granteeAccessSetData.mock.calls.at(-1)
+    const updater = call?.[1] as (prev: typeof cached) => typeof cached
+    return { input: call?.[0], next: updater(cached) }
+  }
+
+  beforeEach(() => {
+    granteeAccessSetData.mockReset()
+    setup({ grants: [], profiles: [] })
+  })
+
+  it('writes the new levels onto own.areas, addressed to the written grantee', async () => {
+    await grantOptions.current?.onMutate?.({
+      granteeType: 'user',
+      granteeId: 'usr_1',
+      levels: { [Area.files]: Level.Full },
+    })
+
+    const { input, next } = patched()
+    expect(input).toEqual({ granteeType: 'user', granteeId: 'usr_1' })
+    expect(next.own.areas).toEqual({ [Area.files]: Level.Full })
+  })
+
+  it('leaves effective alone — it is composed, and the refetch owns it', async () => {
+    await grantOptions.current?.onMutate?.({
+      granteeType: 'user',
+      granteeId: 'usr_1',
+      levels: { [Area.files]: Level.Full },
+    })
+
+    expect(patched().next.effective).toBe(cached.effective)
+  })
+
+  it('clears own.areas on revoke, which stores no row at all', async () => {
+    await revokeOptions.current?.onMutate?.({ granteeType: 'group', granteeId: 'grp_1' })
+
+    const { input, next } = patched()
+    expect(input).toEqual({ granteeType: 'group', granteeId: 'grp_1' })
+    expect(next.own.areas).toEqual({})
+  })
+
+  it('does not touch the cache when the grantee page is not mounted', async () => {
+    granteeAccessSetData.mockReset()
+    await grantOptions.current?.onMutate?.({
+      granteeType: 'user',
+      granteeId: 'usr_1',
+      levels: {},
+    })
+
+    // The updater is handed `undefined` by React Query when the key is cold,
+    // and must hand it straight back rather than inventing a payload.
+    const updater = granteeAccessSetData.mock.calls.at(-1)?.[1] as (prev: unknown) => unknown
+    expect(updater(undefined)).toBeUndefined()
   })
 })

--- a/apps/web/src/components/permissions/hooks/use-permission-grants.ts
+++ b/apps/web/src/components/permissions/hooks/use-permission-grants.ts
@@ -5,7 +5,7 @@ import type { Area, GranteeGrant, GrantGranteeType, Level } from '@auxx/lib/perm
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useMemo } from 'react'
 import { api } from '~/trpc/react'
-import { useInvalidateGranteeAccess } from './use-grantee-access'
+import { useInvalidateGranteeAccess, usePatchGranteeAccess } from './use-grantee-access'
 
 /**
  * The fixed `ResourceAccess` grantee id for the org-wide **workspace default** —
@@ -32,35 +32,42 @@ const MEMBER_PROFILE_SLUG = 'member'
 export type OverrideGranteeType = Extract<GrantGranteeType, 'group' | 'user'>
 
 /**
- * Loads every grant row for the org and exposes the permission surfaces it
- * feeds — the profile bases, group overrides and user overrides, plus the Member
- * profile's own levels as the {@link baseline} every override is measured
- * against — with save/remove mutations that write sparse level maps through the
- * grant service.
- *
- * `save`/`remove` reach the **override** tiers only (`group`, `user`). A
- * profile's base is written by `permissions.saveProfile` (see
- * {@link useProfileEditor}), the only path that runs the doc 19 §6.1 escalation
- * guard over each holder's resulting effective state.
- *
- * `save` always upserts — an empty map stores an empty override row, which
- * composes to nothing but keeps the grantee listed across reloads; `remove`
- * deletes the row. Writes update the `listGrants` cache optimistically
- * (the server stores exactly the sparse map the client sends), so successful
- * saves never refetch — only a failed write invalidates to re-sync. The
- * `permission-grant.changed` realtime event separately refreshes affected
- * members' own capabilities.
+ * The USER role's code defaults — a server constant, so it is fetched once and
+ * never refetched. Split out of {@link usePermissionGrants} because the
+ * grantee-scoped surfaces need it WITHOUT the org-wide `listGrants` read that
+ * hook exists to run (plan 31 §2.4).
  */
-export function usePermissionGrants() {
-  const utils = api.useUtils()
-  const grantsQuery = api.permissions.listGrants.useQuery(undefined, { staleTime: 30_000 })
-  // The USER role's code defaults — a server constant, never worth refetching.
-  const roleDefaultsQuery = api.permissions.roleDefaults.useQuery(undefined, {
+export function useRoleDefaults() {
+  const query = api.permissions.roleDefaults.useQuery(undefined, {
     staleTime: Number.POSITIVE_INFINITY,
   })
-  // Grant rows are keyed by profile ID; only the profile list knows which id is
-  // the `member` slug. Same query key as `useProfiles`, so React Query dedupes it.
-  const profilesQuery = api.permissions.listProfiles.useQuery(undefined, { staleTime: 30_000 })
+  return { roleDefaults: query.data, isLoading: query.isLoading }
+}
+
+/**
+ * The area-level write path — `permissions.grant` / `permissions.revoke` with
+ * their optimistic cache handling — with **no org-wide read attached**.
+ *
+ * Split out of {@link usePermissionGrants} so a grantee detail page can write
+ * area levels without pulling every grant row in the org into its query cache
+ * (plan 31 §2.4). `usePermissionGrants` composes this with the `listGrants`
+ * query for the surfaces that genuinely are org-wide — the overrides tab's
+ * grantee LIST, and the profile surfaces.
+ *
+ * Reaches the **override** tiers only (`group`, `user`). A profile's base is
+ * written by `permissions.saveProfile`, the only path that runs the doc 19 §6.1
+ * escalation guard over each holder's resulting effective state.
+ *
+ * Two optimistic patches, both predictable-by-construction because the server
+ * stores exactly the sparse map we send: the `listGrants` row (for the overrides
+ * tab) and `granteeAccess.own.areas` (for the detail pages). Both are no-ops
+ * where the query is not mounted, so one write path serves both surfaces.
+ * `granteeAccess.effective` is deliberately NOT patched — see
+ * {@link usePatchGranteeAccess}.
+ */
+export function useGrantWrites() {
+  const utils = api.useUtils()
+  const patchGranteeAccess = usePatchGranteeAccess()
 
   /** Upsert (or drop, when `levels` is undefined) one grantee row in the cache. */
   const setLocalGrant = useCallback(
@@ -78,21 +85,32 @@ export function usePermissionGrants() {
   )
   const resync = useCallback(() => utils.permissions.listGrants.invalidate(), [utils])
   /**
-   * `listGrants` stays optimistic-with-no-refetch (the server stores exactly the
-   * sparse map we send), but `granteeAccess.effective` is COMPOSED — this write
-   * changes it and we cannot predict the new value here without re-implementing
-   * composition. So it refetches, on success as well as failure.
+   * `listGrants` and `granteeAccess.own` stay optimistic (the server stores
+   * exactly the sparse map we send), but `granteeAccess.effective` is COMPOSED —
+   * this write changes it and we cannot predict the new value here without
+   * re-implementing composition. So it refetches, on success as well as failure.
    */
   const invalidateGranteeAccess = useInvalidateGranteeAccess()
+
+  const applyLocal = useCallback(
+    (
+      granteeType: OverrideGranteeType,
+      granteeId: string,
+      levels?: Partial<Record<Area, Level>>
+    ) => {
+      setLocalGrant(granteeType, granteeId, levels)
+      patchGranteeAccess(granteeType, granteeId, (prev) => ({
+        ...prev,
+        own: { ...prev.own, areas: levels ?? {} },
+      }))
+    },
+    [setLocalGrant, patchGranteeAccess]
+  )
 
   const grant = api.permissions.grant.useMutation({
     onMutate: async (input) => {
       await utils.permissions.listGrants.cancel()
-      setLocalGrant(
-        input.granteeType,
-        input.granteeId,
-        input.levels as Partial<Record<Area, Level>>
-      )
+      applyLocal(input.granteeType, input.granteeId, input.levels as Partial<Record<Area, Level>>)
     },
     onError: (error) => {
       toastError({ title: 'Error saving permission', description: error.message })
@@ -103,7 +121,7 @@ export function usePermissionGrants() {
   const revoke = api.permissions.revoke.useMutation({
     onMutate: async (input) => {
       await utils.permissions.listGrants.cancel()
-      setLocalGrant(input.granteeType, input.granteeId)
+      applyLocal(input.granteeType, input.granteeId)
     },
     onError: (error) => {
       toastError({ title: 'Error clearing permission', description: error.message })
@@ -112,8 +130,63 @@ export function usePermissionGrants() {
     onSettled: invalidateGranteeAccess,
   })
 
+  /**
+   * Upsert an override grantee's sparse level map (`{}` stores an empty row).
+   *
+   * Narrowed to the two raise-only tiers, matching `permissions.grant`'s input
+   * enum. `'profile'` and the legacy `'role'` are both excluded server-side
+   * because `setGranteeLevels` runs no escalation guard; a profile base is
+   * written through `permissions.saveProfile` instead.
+   */
+  const save = useCallback(
+    (granteeType: OverrideGranteeType, granteeId: string, levels: Partial<Record<Area, Level>>) => {
+      // Sparse by contract — the router's `z.record` input type isn't partial.
+      grant.mutate({ granteeType, granteeId, levels: levels as Record<Area, Level> })
+    },
+    [grant]
+  )
+
+  const remove = useCallback(
+    (granteeType: OverrideGranteeType, granteeId: string) =>
+      revoke.mutate({ granteeType, granteeId }),
+    [revoke]
+  )
+
+  return { save, remove, isSaving: grant.isPending || revoke.isPending }
+}
+
+/**
+ * Loads every grant row for the org and exposes the permission surfaces it
+ * feeds — the profile bases, group overrides and user overrides, plus the Member
+ * profile's own levels as the {@link baseline} every override is measured
+ * against — with save/remove mutations that write sparse level maps through the
+ * grant service.
+ *
+ * `save`/`remove` reach the **override** tiers only (`group`, `user`). A
+ * profile's base is written by `permissions.saveProfile` (see
+ * {@link useProfileEditor}), the only path that runs the doc 19 §6.1 escalation
+ * guard over each holder's resulting effective state.
+ *
+ * `save`/`remove` are {@link useGrantWrites} verbatim — see there for the
+ * optimistic-cache contract.
+ *
+ * **This is the ORG-WIDE hook: it reads every grant row in the org.** A surface
+ * about ONE grantee must not use it (plan 31 §2.4) — take `own.areas` /
+ * `baseline.areas` from {@link useGranteeAccess}, `roleDefaults` from
+ * {@link useRoleDefaults} and the writes from {@link useGrantWrites}. What
+ * legitimately stays here: the overrides tab's grantee LIST (it has to know who
+ * holds an override at all) and the profile surfaces, which read
+ * {@link profileGrants} across the org by definition.
+ */
+export function usePermissionGrants() {
+  const grantsQuery = api.permissions.listGrants.useQuery(undefined, { staleTime: 30_000 })
+  const { roleDefaults, isLoading: roleDefaultsLoading } = useRoleDefaults()
+  // Grant rows are keyed by profile ID; only the profile list knows which id is
+  // the `member` slug. Same query key as `useProfiles`, so React Query dedupes it.
+  const profilesQuery = api.permissions.listProfiles.useQuery(undefined, { staleTime: 30_000 })
+  const { save, remove, isSaving } = useGrantWrites()
+
   const grants = useMemo(() => grantsQuery.data?.grants ?? [], [grantsQuery.data])
-  const roleDefaults = roleDefaultsQuery.data
 
   /** The org's `member` system profile — the row every other tier is measured against. */
   const memberProfileId = useMemo(
@@ -170,37 +243,15 @@ export function usePermissionGrants() {
     [roleDefaults, baseline]
   )
 
-  /**
-   * Upsert an override grantee's sparse level map (`{}` stores an empty row).
-   *
-   * Narrowed to the two raise-only tiers, matching `permissions.grant`'s input
-   * enum. `'profile'` and the legacy `'role'` are both excluded server-side
-   * because `setGranteeLevels` runs no escalation guard; a profile base is
-   * written through `permissions.saveProfile` instead.
-   */
-  const save = useCallback(
-    (granteeType: OverrideGranteeType, granteeId: string, levels: Partial<Record<Area, Level>>) => {
-      // Sparse by contract — the router's `z.record` input type isn't partial.
-      grant.mutate({ granteeType, granteeId, levels: levels as Record<Area, Level> })
-    },
-    [grant]
-  )
-
-  const remove = useCallback(
-    (granteeType: OverrideGranteeType, granteeId: string) =>
-      revoke.mutate({ granteeType, granteeId }),
-    [revoke]
-  )
-
   return {
-    isLoading: grantsQuery.isLoading || roleDefaultsQuery.isLoading || profilesQuery.isLoading,
+    isLoading: grantsQuery.isLoading || roleDefaultsLoading || profilesQuery.isLoading,
     roleDefaults,
     baseline,
     groupGrants,
     userGrants,
     profileGrants,
     effectiveBaseline,
-    isSaving: grant.isPending || revoke.isPending,
+    isSaving,
     save,
     remove,
   }

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.test.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.test.tsx
@@ -1,0 +1,158 @@
+// apps/web/src/components/permissions/ui/grantee-levels-section.test.tsx
+
+import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 31 §2.4, phase 2's **areas half** — this section reads ONE grantee.
+ *
+ * It used to take a member's area levels out of `usePermissionGrants`, the
+ * org-wide store that loads every grant row in the org, with
+ * `persisted.find(g => g.granteeId === granteeId)?.levels`. Now they arrive
+ * pre-scoped as `granteeAccess.own.areas`, and the *Inherit* fall-through as
+ * `granteeAccess.baseline.areas`.
+ *
+ * The load-bearing part is not the read, it is `handleChange`: it edits a COPY
+ * of that map and saves the whole thing, so a swap that pointed `values` at the
+ * wrong half would silently wipe every other area the grantee holds on the next
+ * click. That is the test worth having here.
+ */
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+const { granteeAccess, save, defAccess, instanceRows } = vi.hoisted(() => ({
+  granteeAccess: { current: undefined as unknown },
+  save: vi.fn(),
+  defAccess: { isLoading: false, rows: [], setLevel: vi.fn() },
+  instanceRows: {
+    isLoading: false,
+    lists: {
+      dataset: { items: [], isLoading: false, truncated: false },
+      kb: { items: [], isLoading: false, truncated: false },
+      dashboard: { items: [], isLoading: false, truncated: false },
+      workflow: { items: [], isLoading: false, truncated: false },
+    },
+    rowsByKey: { dataset: [], kb: [], dashboard: [], workflow: [] },
+    setGrant: vi.fn(),
+  },
+}))
+
+const ROLE_DEFAULTS = Object.fromEntries(
+  Object.keys(PERMISSION_AREAS).map((area) => [area, Level.None])
+) as Record<Area, Level>
+
+vi.mock('../hooks/use-grantee-access', () => ({
+  useGranteeAccess: () => granteeAccess.current,
+}))
+vi.mock('../hooks/use-permission-grants', () => ({
+  useGrantWrites: () => ({ save }),
+  useRoleDefaults: () => ({ roleDefaults: ROLE_DEFAULTS, isLoading: false }),
+}))
+vi.mock('../hooks/use-grantee-def-access', () => ({
+  useGranteeDefAccess: () => defAccess,
+}))
+vi.mock('../hooks/use-instance-grantee-rows', () => ({
+  useInstanceGranteeRows: () => instanceRows,
+}))
+vi.mock('~/components/global/settings-page', () => ({
+  SettingsSection: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+const { GranteeLevelsSection } = await import('./grantee-levels-section')
+
+const GRANTEE = 'usr_alice'
+const FILES_LABEL = PERMISSION_AREAS[Area.files].label
+const WORKFLOWS_LABEL = PERMISSION_AREAS[Area.workflows].label
+
+function setup(payload: {
+  own?: Partial<Record<Area, Level>>
+  baseline?: Partial<Record<Area, Level>>
+  effective?: Partial<Record<Area, Level>>
+}) {
+  granteeAccess.current = {
+    isLoading: false,
+    own: { areas: payload.own ?? {}, defs: {}, instances: {} },
+    baseline: { areas: payload.baseline ?? {}, defs: {}, instances: {} },
+    effective: payload.effective
+      ? { areas: payload.effective, defs: {}, instances: {}, instanceFallback: {} }
+      : null,
+  }
+  return render(
+    <TooltipProvider>
+      <GranteeLevelsSection granteeKind='user' granteeId={GRANTEE} canEdit />
+    </TooltipProvider>
+  )
+}
+
+/**
+ * One area's row. The label appears twice — once as its group's uppercase
+ * header, once as the row title — so the header is filtered out by class, then
+ * we walk up to the nearest ancestor that actually holds a ladder.
+ */
+function areaRow(areaLabel: string): HTMLElement {
+  const title = screen.getAllByText(areaLabel).find((el) => !el.className.includes('uppercase'))
+  if (!title) throw new Error(`no row titled ${areaLabel}`)
+  let node: HTMLElement | null = title.parentElement
+  while (node && !node.querySelector('[role="radio"]')) node = node.parentElement
+  if (!node) throw new Error(`no ladder under ${areaLabel}`)
+  return node
+}
+
+/** One rung of that row's ladder — the radio itself, which carries the state. */
+function rung(areaLabel: string, label: string): HTMLElement {
+  const match = Array.from(areaRow(areaLabel).querySelectorAll('label')).find(
+    (el) => el.textContent === label
+  )
+  const radio = match?.querySelector('[role="radio"]')
+  if (!radio) throw new Error(`no "${label}" rung under ${areaLabel}`)
+  return radio as HTMLElement
+}
+
+beforeEach(() => {
+  save.mockReset()
+})
+
+describe('the ladder reads the grantee-scoped payload', () => {
+  it("shows the grantee's own rung, not the workspace baseline's", () => {
+    setup({ own: { [Area.files]: Level.Full }, baseline: { [Area.files]: Level.Read } })
+
+    // `aria-checked` is the ladder's own statement of which rung is selected.
+    expect(rung(FILES_LABEL, 'Full').getAttribute('aria-checked')).toBe('true')
+    expect(rung(FILES_LABEL, 'Read').getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('renders the effective line off the composed half', () => {
+    setup({ own: {}, baseline: {}, effective: { [Area.workflows]: Level.Edit } })
+
+    // A member raised into Workflows by a team: the ladder says No access, the
+    // composed answer says Edit, and the row now says both.
+    expect(screen.getByText('Effective · Edit')).toBeTruthy()
+  })
+})
+
+describe('an area write keeps every other area the grantee holds', () => {
+  /**
+   * The clobber case. `handleChange` spreads `values` and saves the whole map,
+   * so if `values` ever stopped being this grantee's own areas — pointing at
+   * `baseline.areas`, or at an empty object while the query was still settling —
+   * changing one area would silently revoke all the others. Server-side there is
+   * no guard against it: `setGranteeLevels` stores the sparse map verbatim.
+   */
+  it('saves the untouched areas alongside the changed one', () => {
+    setup({
+      own: { [Area.files]: Level.Read, [Area.workflows]: Level.Edit },
+      baseline: {},
+    })
+
+    fireEvent.click(rung(FILES_LABEL, 'Full'))
+
+    expect(save).toHaveBeenCalledWith('user', GRANTEE, {
+      [Area.files]: Level.Full,
+      [Area.workflows]: Level.Edit,
+    })
+  })
+})

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
@@ -4,12 +4,12 @@
 import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SlidersHorizontal } from 'lucide-react'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
 import { useGranteeAccess } from '../hooks/use-grantee-access'
 import { type GranteeKind, useGranteeDefAccess } from '../hooks/use-grantee-def-access'
 import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
-import { usePermissionGrants } from '../hooks/use-permission-grants'
+import { useGrantWrites, useRoleDefaults } from '../hooks/use-permission-grants'
 import { GranteeDefAccessRows } from './grantee-def-access-rows'
 import { GranteeInstanceRows } from './grantee-instance-rows'
 import { AREA_TO_INSTANCE_KEY } from './instance-share-copy'
@@ -52,9 +52,18 @@ function descriptionFor(granteeKind: string): string {
 
 /**
  * The Layer-2 (per-area None/Read/Edit/Full) override editor for a single grantee
- * — a member or a team — surfaced on their detail page's Permissions tab. Reuses
- * the org-wide {@link usePermissionGrants} store and renders one grantee's sparse
- * level map through {@link LeveledAreaGrid} in `override` mode: every area
+ * — a member or a team — surfaced on their detail page's Permissions tab.
+ *
+ * Reads ONE grantee (plan 31 §2.4): `useGranteeAccess` supplies this grantee's
+ * own area levels, the Member profile's baseline and the composed `effective`
+ * line. It used to read the org-wide `usePermissionGrants` store — every grant
+ * row in the org — and pick this grantee's out client-side. That hook survives
+ * for the surfaces that genuinely are org-wide; only the writes
+ * ({@link useGrantWrites}) and the role defaults ({@link useRoleDefaults}) are
+ * still shared with it.
+ *
+ * Renders that sparse level map through {@link LeveledAreaGrid} in
+ * `override` mode: every area
  * inherits the effective member baseline and can only be *raised* above it
  * (raise-only enforced server-side; an override that lifts nothing is flagged
  * "ignored"). Sits above the Layer-3 Record-access grid, which overrides the
@@ -69,11 +78,29 @@ export function GranteeLevelsSection({
   granteeId: string
   canEdit: boolean
 }) {
-  const { isLoading, roleDefaults, effectiveBaseline, groupGrants, userGrants, save } =
-    usePermissionGrants()
+  const { roleDefaults, isLoading: roleDefaultsLoading } = useRoleDefaults()
+  const { save } = useGrantWrites()
+  // One grantee, not the org (plan 31 §2.4). `useGranteeDefAccess` and
+  // `useInstanceGranteeRows` below run the same query — React Query dedupes it,
+  // so all three read one request. `effective` is null for a team, which is
+  // exactly when the area line must not render.
+  const {
+    isLoading: granteeLoading,
+    own,
+    baseline,
+    effective,
+  } = useGranteeAccess(granteeKind, granteeId)
 
-  const persisted = granteeKind === 'group' ? groupGrants : userGrants
-  const values = persisted.find((g) => g.granteeId === granteeId)?.levels ?? {}
+  // Memoized: both feed `renderChildren`'s dependency list, and a fresh object
+  // each render would rebuild every nested grid on every keystroke in the
+  // grid's search box.
+  const values = useMemo(() => own?.areas ?? {}, [own])
+  /** The org-wide member baseline per area — role default merged with org policy. */
+  const effectiveBaseline = useMemo(
+    () => ({ ...(roleDefaults ?? {}), ...(baseline?.areas ?? {}) }),
+    [roleDefaults, baseline]
+  )
+  const isLoading = roleDefaultsLoading || granteeLoading
 
   const {
     isLoading: defAccessLoading,
@@ -86,10 +113,6 @@ export function GranteeLevelsSection({
     rowsByKey: instanceRowsByKey,
     setGrant: setInstanceGrant,
   } = useInstanceGranteeRows(granteeKind, granteeId)
-  // Same query `useInstanceGranteeRows` already runs — React Query dedupes it,
-  // so reading it here for the area rows costs no extra request. `effective` is
-  // null for a team, which is exactly when the area line must not render.
-  const { effective } = useGranteeAccess(granteeKind, granteeId)
 
   const handleChange = (area: Area, level: Level | undefined) => {
     const next = { ...values }

--- a/packages/lib/src/permissions/capabilities/grantee-access.test.ts
+++ b/packages/lib/src/permissions/capabilities/grantee-access.test.ts
@@ -26,9 +26,39 @@ import { Area, Level } from './registry'
 const ORG = 'org_1'
 const USER = 'user_alice'
 
-const h = vi.hoisted(() => ({ caps: null as unknown }))
+const MEMBER_PROFILE_ID = 'prof_member'
+const MEMBER_PROFILE_SLUG = 'member'
+
+const h = vi.hoisted(() => ({
+  caps: null as unknown,
+  profiles: [] as { id: string; slug: string }[],
+  /** Disjunct count of every `or(...)` the module built, in call order. */
+  orArgs: [] as number[],
+}))
 
 vi.mock('./get-capabilities', () => ({ getCapabilities: async () => h.caps }))
+// The Member-profile lookup is a cache read, not a query — stubbed here so the
+// test never loads the real cache barrel (see the standing vitest gotcha).
+vi.mock('../../cache', () => ({ getCachedPermissionProfiles: async () => h.profiles }))
+
+/**
+ * `or` is spied, not stubbed, because `fakeDb` below cannot see a WHERE clause:
+ * it returns whatever rows a test declares regardless of what was asked for. So
+ * "the grant query asks for BOTH addresses" is invisible to every other
+ * assertion in this file — dropping the Member-profile address entirely would
+ * leave them all green while `baseline.areas` came back empty against a real
+ * database. Counting the disjuncts is the cheapest thing that actually fails.
+ */
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return {
+    ...actual,
+    or: (...args: Parameters<typeof actual.or>) => {
+      h.orArgs.push(args.length)
+      return actual.or(...args)
+    },
+  }
+})
 
 const { getGranteeAccess } = await import('./grantee-access')
 
@@ -41,11 +71,28 @@ interface AccessRow {
   permission: ResourcePermission
 }
 
+/** A `PermissionGrant` row as the first select projects it. */
+interface GrantRow {
+  granteeType: string
+  granteeId: string
+  levels: unknown
+}
+
 /**
- * The two selects `getGranteeAccess` issues, in order: the grantee's own
- * `PermissionGrant` row (`.limit(1)`) and the org's `ResourceAccess` rows.
+ * The two selects `getGranteeAccess` issues, in order: the `PermissionGrant`
+ * rows at the grantee's address AND the Member profile's, then the org's
+ * `ResourceAccess` rows.
+ *
+ * `grants` accepts either a bare levels map — the common case, read as the
+ * grantee's own row — or explicit rows when a test cares about the Member
+ * profile's baseline levels too.
  */
-function fakeDb(grantLevels: unknown, accessRows: AccessRow[]) {
+function fakeDb(
+  grants: unknown | GrantRow[],
+  accessRows: AccessRow[],
+  grantee: { granteeType: string; granteeId: string } = { granteeType: 'user', granteeId: USER }
+) {
+  const grantRows: GrantRow[] = Array.isArray(grants) ? grants : [{ ...grantee, levels: grants }]
   let call = 0
   const builder = (rows: unknown[]) => {
     const chain = {
@@ -59,13 +106,18 @@ function fakeDb(grantLevels: unknown, accessRows: AccessRow[]) {
   return {
     select: () => {
       call += 1
-      return call === 1 ? builder([{ levels: grantLevels }]) : builder(accessRows)
+      return call === 1 ? builder(grantRows) : builder(accessRows)
     },
   } as never
 }
 
 /** A real `CapabilitySet`, composed exactly as the read path composes one. */
-function capsFor(input: Parameters<typeof composeUserCapabilities>[0], seatType = 'full' as const) {
+function capsFor(
+  input: Parameters<typeof composeUserCapabilities>[0],
+  // Not `'full' as const` — that narrows the parameter itself, so the worker-seat
+  // case below could not pass its own seat in (a pre-existing tsc error).
+  seatType: Parameters<typeof composeUserCapabilities>[0]['seatType'] = 'full'
+) {
   const composed = composeUserCapabilities(input)
   const instanceIds = new Set(Object.keys(composed.instanceAccess))
   return new CapabilitySet(
@@ -88,6 +140,8 @@ const DASH = 'dash_shared'
 
 beforeEach(() => {
   h.caps = null
+  h.profiles = [{ id: MEMBER_PROFILE_ID, slug: MEMBER_PROFILE_SLUG }]
+  h.orArgs = []
 })
 
 describe('getGranteeAccess — own / baseline / effective are split cleanly', () => {
@@ -308,15 +362,19 @@ describe('getGranteeAccess — a group/profile is a level SOURCE, not a subject'
 
     const result = await getGranteeAccess(
       { organizationId: ORG, granteeType: 'group', granteeId: 'grp_support' },
-      fakeDb({ [Area.workflows]: Level.Read }, [
-        {
-          entityDefinitionId: 'workflow',
-          entityInstanceId: WF,
-          granteeType: 'group',
-          granteeId: 'grp_support',
-          permission: ResourcePermission.view,
-        },
-      ])
+      fakeDb(
+        { [Area.workflows]: Level.Read },
+        [
+          {
+            entityDefinitionId: 'workflow',
+            entityInstanceId: WF,
+            granteeType: 'group',
+            granteeId: 'grp_support',
+            permission: ResourcePermission.view,
+          },
+        ],
+        { granteeType: 'group', granteeId: 'grp_support' }
+      )
     )
 
     expect(result.own.instances).toEqual({ [WF]: ResourcePermission.view })
@@ -328,10 +386,111 @@ describe('getGranteeAccess — a group/profile is a level SOURCE, not a subject'
 
     const result = await getGranteeAccess(
       { organizationId: ORG, granteeType: 'profile', granteeId: 'prof_1' },
-      fakeDb({}, [])
+      fakeDb({}, [], { granteeType: 'profile', granteeId: 'prof_1' })
     )
 
     expect(result.effective).toBeNull()
+  })
+})
+
+describe('getGranteeAccess — the Member profile supplies the baseline area levels', () => {
+  /**
+   * The override grids render their *Inherit* fall-through from these. Before
+   * they rode this payload the grantee pages read `permissions.listGrants` —
+   * every grant row in the org — and picked the Member profile's out
+   * client-side, which is the shape §2.4 exists to remove.
+   */
+  it("returns the Member profile's levels alongside the grantee's own", async () => {
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb(
+        [
+          { granteeType: 'user', granteeId: USER, levels: { [Area.workflows]: Level.Edit } },
+          {
+            granteeType: 'profile',
+            granteeId: MEMBER_PROFILE_ID,
+            levels: { [Area.workflows]: Level.Read, [Area.datasets]: Level.Read },
+          },
+          // Another profile's row must not be mistaken for the baseline — the
+          // query asks for two addresses, and only one of them is Member.
+          {
+            granteeType: 'profile',
+            granteeId: 'prof_support',
+            levels: { [Area.workflows]: Level.Full },
+          },
+        ],
+        []
+      )
+    )
+
+    expect(result.own.areas).toEqual({ [Area.workflows]: Level.Edit })
+    expect(result.baseline.areas).toEqual({
+      [Area.workflows]: Level.Read,
+      [Area.datasets]: Level.Read,
+    })
+  })
+
+  it('asks the grant query for BOTH addresses', async () => {
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({}, [])
+    )
+
+    expect(h.orArgs).toEqual([2])
+  })
+
+  it('asks for one address only when the org has no Member profile', async () => {
+    h.profiles = []
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({}, [])
+    )
+
+    // Not two-with-a-null: an `or` over an undefined arm is a query bug, not an
+    // empty result.
+    expect(h.orArgs).toEqual([1])
+  })
+
+  it('reports an empty baseline when the org has no Member profile', async () => {
+    h.profiles = []
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'user', granteeId: USER },
+      fakeDb({ [Area.workflows]: Level.Edit }, [])
+    )
+
+    // The same state `resolveBaseProfile` composes against — empty, not absent.
+    expect(result.baseline.areas).toEqual({})
+    expect(result.own.areas).toEqual({ [Area.workflows]: Level.Edit })
+  })
+
+  it('serves the same row to both halves when the grantee IS the Member profile', async () => {
+    h.caps = capsFor({ role: 'USER', seatType: 'full', typeAccessRows: [] })
+
+    const result = await getGranteeAccess(
+      { organizationId: ORG, granteeType: 'profile', granteeId: MEMBER_PROFILE_ID },
+      fakeDb(
+        [
+          {
+            granteeType: 'profile',
+            granteeId: MEMBER_PROFILE_ID,
+            levels: { [Area.workflows]: Level.Read },
+          },
+        ],
+        [],
+        { granteeType: 'profile', granteeId: MEMBER_PROFILE_ID }
+      )
+    )
+
+    expect(result.own.areas).toEqual({ [Area.workflows]: Level.Read })
+    expect(result.baseline.areas).toEqual({ [Area.workflows]: Level.Read })
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/grantee-access.ts
+++ b/packages/lib/src/permissions/capabilities/grantee-access.ts
@@ -2,7 +2,8 @@
 
 import { type Database, database, schema } from '@auxx/database'
 import type { ResourcePermission } from '@auxx/database/enums'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, or } from 'drizzle-orm'
+import { getCachedPermissionProfiles } from '../../cache'
 import { getCapabilities } from './get-capabilities'
 import {
   INSTANCE_ACCESS_KEYS,
@@ -21,6 +22,12 @@ export type AccessGranteeType = 'user' | 'group' | 'profile'
  */
 const WORKSPACE_BASELINE_GRANTEE_TYPE = 'role'
 const WORKSPACE_BASELINE_GRANTEE_ID = 'org_member'
+
+/**
+ * The `PermissionProfile.slug` that IS the org-wide area-level baseline
+ * (doc 19 §0.8) — what every override grid measures "raise only" against.
+ */
+const MEMBER_PROFILE_SLUG = 'member'
 
 /**
  * The rows keyed to THIS grantee — what the Access grids' selects read and write.
@@ -75,6 +82,26 @@ export interface GranteeEffectiveAccess {
  * fact the grid already states out loud, with no grantee in it.
  */
 export interface GranteeBaselineAccess {
+  /**
+   * The **Member profile**'s own sparse area levels — the org-wide floor an
+   * override grid renders its *Inherit* fall-through from, and the level
+   * `useGranteeDefAccess` maps to a record permission for an unconfigured def.
+   *
+   * Same "one org-wide fact, no grantee in it" argument as {@link defs} below,
+   * one layer up: it is a single row, and every grid that reads it already
+   * states it out loud.
+   *
+   * **Levels only, deliberately — not the profile's `baseLevel`, and not the
+   * grantee's actually-bound profile.** Both are faithful to what the client
+   * derived from `listGrants` before this field existed, and neither is quite
+   * the truth: a member bound to a custom profile falls through to THAT
+   * profile, not to Member. The grids do not lie about it, because the composed
+   * `effective.areas` line (#1352) sits on the same row and wins any
+   * disagreement — but if that fall-through is ever made accurate, this is the
+   * field to change, and the copy above the grid ("raise access above the
+   * member baseline") has to move with it.
+   */
+  areas: Partial<Record<Area, Level>>
   defs: Record<string, ResourcePermission>
   instances: Record<string, ResourcePermission>
 }
@@ -112,10 +139,12 @@ export interface GranteeAccess {
  * re-derives a composition rule, which is why this addition needs **no cache
  * bump**: it reads the existing blob unchanged.
  *
- * Two DB reads, both org-scoped and indexed: the grantee's own `PermissionGrant`
- * row, and the org's `ResourceAccess` rows. The latter stays org-wide because
- * `effective.instances` must cover every instance the org manages a row on — but
- * it never leaves this function; only one grantee's levels go over the wire.
+ * Two DB reads, both org-scoped and indexed: the `PermissionGrant` rows at two
+ * addresses (this grantee's, and the Member profile's — see
+ * {@link GranteeBaselineAccess.areas}), and the org's `ResourceAccess` rows. The
+ * latter stays org-wide because `effective.instances` must cover every instance
+ * the org manages a row on — but it never leaves this function; only one
+ * grantee's levels go over the wire.
  */
 export async function getGranteeAccess(
   params: {
@@ -127,18 +156,39 @@ export async function getGranteeAccess(
 ): Promise<GranteeAccess> {
   const { organizationId, granteeType, granteeId } = params
 
-  const [grantRow, accessRows] = await Promise.all([
-    db
-      .select({ levels: schema.PermissionGrant.levels })
-      .from(schema.PermissionGrant)
-      .where(
-        and(
-          eq(schema.PermissionGrant.organizationId, organizationId),
-          eq(schema.PermissionGrant.granteeType, granteeType),
-          eq(schema.PermissionGrant.granteeId, granteeId)
-        )
+  // Cache read, not a query — the same `profiles` org-cache entry
+  // `computeUserCapabilities` resolves the bound base profile from, so the id
+  // this finds is the id composition uses.
+  const profiles = await getCachedPermissionProfiles(organizationId)
+  const memberProfileId = profiles.find((p) => p.slug === MEMBER_PROFILE_SLUG)?.id ?? null
+
+  // Two addresses, one query: this grantee's row and the Member profile's. When
+  // the grantee IS the Member profile they are the same row, and it correctly
+  // lands in both halves.
+  const grantAddresses = [
+    and(
+      eq(schema.PermissionGrant.granteeType, granteeType),
+      eq(schema.PermissionGrant.granteeId, granteeId)
+    ),
+  ]
+  if (memberProfileId) {
+    grantAddresses.push(
+      and(
+        eq(schema.PermissionGrant.granteeType, 'profile'),
+        eq(schema.PermissionGrant.granteeId, memberProfileId)
       )
-      .limit(1),
+    )
+  }
+
+  const [grantRows, accessRows] = await Promise.all([
+    db
+      .select({
+        granteeType: schema.PermissionGrant.granteeType,
+        granteeId: schema.PermissionGrant.granteeId,
+        levels: schema.PermissionGrant.levels,
+      })
+      .from(schema.PermissionGrant)
+      .where(and(eq(schema.PermissionGrant.organizationId, organizationId), or(...grantAddresses))),
     db
       .select({
         entityDefinitionId: schema.ResourceAccess.entityDefinitionId,
@@ -151,12 +201,24 @@ export async function getGranteeAccess(
       .where(eq(schema.ResourceAccess.organizationId, organizationId)),
   ])
 
+  let ownLevels: unknown
+  let baselineLevels: unknown
+  for (const row of grantRows) {
+    if (row.granteeType === granteeType && row.granteeId === granteeId) ownLevels = row.levels
+    if (row.granteeType === 'profile' && row.granteeId === memberProfileId)
+      baselineLevels = row.levels
+  }
+
   const own: GranteeOwnAccess = {
-    areas: parseAreaLevels(grantRow[0]?.levels),
+    areas: parseAreaLevels(ownLevels),
     defs: {},
     instances: {},
   }
-  const baseline: GranteeBaselineAccess = { defs: {}, instances: {} }
+  const baseline: GranteeBaselineAccess = {
+    areas: parseAreaLevels(baselineLevels),
+    defs: {},
+    instances: {},
+  }
 
   /** Instance id → its resource type, so each id is resolved against its OWN area. */
   const keyOfInstance = new Map<string, InstanceAccessKey>()


### PR DESCRIPTION
Plan 31 phase 2's **def + areas half** — the remaining read swap after #1352 shipped phase 1 and phase 2's server + instance halves.

## What moved

| Surface | Was | Now |
|---|---|---|
| `useGranteeDefAccess` | `resourceAccess.allTypeAccess` — every type row, every grantee | `permissions.granteeAccess` |
| `GranteeLevelsSection` | `permissions.listGrants` — every grant row in the org | `permissions.granteeAccess` |

Neither query was an authorization hole (`isAdminOrOwner` / `permissionsProcedure`), so this is the **shape** finding, not a fix for a broken check: having the org's whole access table in a member page's query cache is what made the phase 1 scope leak buildable, and is what the next row would have reached for. Both endpoints survive for the surfaces that genuinely are org-wide — the overrides tab's grantee LIST and the Workspace defaults tab.

## `granteeAccess` gains `baseline.areas`

The override grids render their *Inherit* fall-through from the Member profile's area levels, which only `listGrants` carried. It is now one extra address on the existing `PermissionGrant` query, with the profile id resolved from the same `profiles` org cache `computeUserCapabilities` uses. Same "one org-wide fact, no grantee in it" argument as the `baseline.defs`/`baseline.instances` deviation #1352 already documented, one layer up.

**No cache bump, and none owed** — the composed `user:capabilities:v11` blob is read unchanged.

## `usePermissionGrants` splits

`useRoleDefaults` and `useGrantWrites` are now usable without the org-wide read; `usePermissionGrants` is those two composed with `listGrants`. Its doc says out loud that a single-grantee surface must not use it.

## The optimistic half — which is the actual work

Writes patch the `granteeAccess` cache instead of `allTypeAccess`/`listGrants`, and patch **`own` and `baseline` only**. `effective` is left stale for the invalidation to refetch, because it is composed (`max` across profile/groups/own row, then both ceilings) and predicting it here would put display and enforcement on separate implementations of composition — the failure mode §2.5 rules out explicitly. That line is now a documented rule on `usePatchGranteeAccess`, and it is mutation-tested in both directions.

## Verification

- **412** tests in `packages/lib/src/permissions` (+5), **87** in `apps/web` `components/permissions` (+18 across 2 new files: `use-grantee-def-access.test.ts`, `grantee-levels-section.test.tsx`).
- **9 mutations, 8 caught outright.** The 9th was not: a `patchLocal` that rebuilt the def map from the wrong half still satisfied the original assertion, because the fixture could not tell the two apart. Fixed by asserting the grantee's *other* defs survive the patch — the property that actually matters — after which it fails.
- One mutation exposed a genuine test-harness gap: `fakeDb` returns whatever rows a test declares regardless of the WHERE clause, so "the grant query asks for both addresses" was invisible to every assertion. `or` is now spied and its disjunct count asserted, which fails when the Member-profile address is dropped.
- Unmutated control green before and after each.
- **Zero tsc hits on any changed file** in either package (baselines: 4072 `apps/web`, 3649 `packages/lib`).
- Fixed a pre-existing tsc error in `grantee-access.test.ts` — `capsFor`'s `seatType = 'full' as const` narrowed the parameter, so the worker-seat case could not pass its own seat in.

## Not in this PR

- **Phase 3** (source attribution) — changes the `UserCapabilities` shape and carries `v11 → v12`. Deliberately unbundled, since phase 2's whole point is that it needs no bump.
- **The browser pass** — §4's network-bar check plus the two UI relocations that rode along in #1352.

## One thing worth a decision, deliberately left alone

`baseline.areas` is the **Member profile's** levels, faithfully reproducing what the client derived from `listGrants` before. That is not quite the truth: a member bound to a custom profile falls through to *that* profile, not to Member. The grids do not lie about it — the composed `effective.areas` line from #1352 sits on the same row and wins any disagreement — but if that fall-through is ever made accurate, `GranteeBaselineAccess.areas` is the field to change, and the section's "raise access above the member baseline" copy moves with it. Documented at the field.