### PR TITLE
fix(permissions): gate instance share affordances on instance admin

### DIFF
--- a/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-actions.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-actions.tsx
@@ -86,10 +86,12 @@ export function DatasetActions() {
     <>
       <div className='flex items-center gap-2'>
         {/* Primary Actions */}
-        <Button onClick={() => setShareOpen(true)} variant='outline' size='sm'>
-          <Share2 />
-          Share
-        </Button>
+        {canAdmin && (
+          <Button onClick={() => setShareOpen(true)} variant='outline' size='sm'>
+            <Share2 />
+            Share
+          </Button>
+        )}
         {canEdit && (
           <Button onClick={handleUpload} size='sm'>
             <Upload />
@@ -135,11 +137,13 @@ export function DatasetActions() {
         </DropdownMenu>
       </div>
 
-      <InstanceShareDialog
-        recordId={toRecordId('dataset', dataset.id)}
-        open={shareOpen}
-        onOpenChange={setShareOpen}
-      />
+      {canAdmin && (
+        <InstanceShareDialog
+          recordId={toRecordId('dataset', dataset.id)}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
       <ConfirmDialog />
     </>
   )

--- a/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-grid-view.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-grid-view.tsx
@@ -39,10 +39,10 @@ function WorkflowCard({ workflow }: WorkflowCardProps) {
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const [shareOpen, setShareOpen] = useState(false)
-  // Per-workflow instance access (plan 30 §4). Rename ("Edit"), Enable/Disable
-  // and Delete are the `admin` rung; Duplicate additionally CREATES a workflow,
-  // so it needs the coarse `workflows.manage` key too. Open / Favorite / Share…
-  // stay at `view` — the share dialog is already read-only for non-admins.
+  // Per-workflow instance access (plan 30 §4). Rename ("Edit"), Share…,
+  // Enable/Disable and Delete are the `admin` rung; Duplicate additionally
+  // CREATES a workflow, so it needs the coarse `workflows.manage` key too.
+  // Open / Favorite stay at `view`.
   const { can, canAdminInstance } = useAccess()
   const canAdmin = canAdminInstance(toRecordId('workflow', workflow.id))
   const canCreate = can(PermissionKey.workflowsManage)
@@ -136,10 +136,12 @@ function WorkflowCard({ workflow }: WorkflowCardProps) {
               </DropdownMenuItem>
             )}
             <FavoriteToggleMenuItem targetType='WORKFLOW' targetIds={{ workflowId: workflow.id }} />
-            <DropdownMenuItem onClick={() => setShareOpen(true)}>
-              <Share2 />
-              Share…
-            </DropdownMenuItem>
+            {canAdmin && (
+              <DropdownMenuItem onClick={() => setShareOpen(true)}>
+                <Share2 />
+                Share…
+              </DropdownMenuItem>
+            )}
             {canAdmin && (
               <>
                 <DropdownMenuSeparator />
@@ -183,11 +185,13 @@ function WorkflowCard({ workflow }: WorkflowCardProps) {
         workflowId={workflow.id}
         workflowName={workflow.name}
       />
-      <InstanceShareDialog
-        recordId={toRecordId('workflow', workflow.id)}
-        open={shareOpen}
-        onOpenChange={setShareOpen}
-      />
+      {canAdmin && (
+        <InstanceShareDialog
+          recordId={toRecordId('workflow', workflow.id)}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
     </>
   )
 }

--- a/apps/web/src/components/dashboard/ui/dashboard-card.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-card.tsx
@@ -44,9 +44,9 @@ export function DashboardCard({ dashboard }: { dashboard: DashboardSummary }) {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [shareOpen, setShareOpen] = useState(false)
   const { getResourceById } = useResources()
-  // Settings (`dashboard.update`) and Delete are Full per instance; Duplicate is
-  // the coarse `dashboards.manage` rung (it CREATES a dashboard). Open / Favorite
-  // / Share… stay at Read — the share dialog is already read-only for non-admins.
+  // Settings (`dashboard.update`), Share… and Delete are Full per instance;
+  // Duplicate is the coarse `dashboards.manage` rung (it CREATES a dashboard).
+  // Open / Favorite stay at Read.
   const { can, canAdminInstance } = useAccess()
   const canAdmin = canAdminInstance(toRecordId('dashboard', dashboard.id))
   const canCreate = can('dashboards.manage')
@@ -151,10 +151,12 @@ export function DashboardCard({ dashboard }: { dashboard: DashboardSummary }) {
                 Settings
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem onClick={() => setShareOpen(true)}>
-              <Share2 />
-              Share…
-            </DropdownMenuItem>
+            {canAdmin && (
+              <DropdownMenuItem onClick={() => setShareOpen(true)}>
+                <Share2 />
+                Share…
+              </DropdownMenuItem>
+            )}
             {canAdmin && (
               <>
                 <DropdownMenuSeparator />
@@ -172,11 +174,13 @@ export function DashboardCard({ dashboard }: { dashboard: DashboardSummary }) {
         open={settingsOpen}
         onOpenChange={setSettingsOpen}
       />
-      <InstanceShareDialog
-        recordId={toRecordId('dashboard', dashboard.id)}
-        open={shareOpen}
-        onOpenChange={setShareOpen}
-      />
+      {canAdmin && (
+        <InstanceShareDialog
+          recordId={toRecordId('dashboard', dashboard.id)}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
     </>
   )
 }

--- a/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
@@ -318,15 +318,19 @@ export function DashboardDetailView({
         targetIds={{ dashboardId: dashboard.id }}
         size='icon-xs'
       />
-      <Button variant='outline' size='sm' onClick={() => setShareOpen(true)}>
-        <Share2 />
-        Share
-      </Button>
-      <InstanceShareDialog
-        recordId={dashboardRecordId}
-        open={shareOpen}
-        onOpenChange={setShareOpen}
-      />
+      {canAdmin && (
+        <>
+          <Button variant='outline' size='sm' onClick={() => setShareOpen(true)}>
+            <Share2 />
+            Share
+          </Button>
+          <InstanceShareDialog
+            recordId={dashboardRecordId}
+            open={shareOpen}
+            onOpenChange={setShareOpen}
+          />
+        </>
+      )}
       <DashboardPublishCluster
         dashboard={dashboard}
         activeVersionNumber={persistedVersionNumber ?? dashboard.versionNumber}

--- a/apps/web/src/components/datasets/dataset-card.tsx
+++ b/apps/web/src/components/datasets/dataset-card.tsx
@@ -68,11 +68,13 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
   return (
     <>
       <ConfirmDialog />
-      <InstanceShareDialog
-        recordId={toRecordId('dataset', dataset.id)}
-        open={shareOpen}
-        onOpenChange={setShareOpen}
-      />
+      {canAdmin && (
+        <InstanceShareDialog
+          recordId={toRecordId('dataset', dataset.id)}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
       <ListCard
         onClick={onClick}
         ariaLabel={dataset.name}
@@ -123,10 +125,12 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
                 Settings
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem onClick={wrap(() => setShareOpen(true))}>
-              <Share2 />
-              Share…
-            </DropdownMenuItem>
+            {canAdmin && (
+              <DropdownMenuItem onClick={wrap(() => setShareOpen(true))}>
+                <Share2 />
+                Share…
+              </DropdownMenuItem>
+            )}
             <FavoriteToggleMenuItem targetType='DATASET' targetIds={{ datasetId: dataset.id }} />
             {canAdmin && (
               <>

--- a/apps/web/src/components/datasets/datasets-table-view.tsx
+++ b/apps/web/src/components/datasets/datasets-table-view.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import type { DatasetWithRelations } from '@auxx/lib/datasets'
+import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -21,8 +22,11 @@ import {
   TableRow,
 } from '@auxx/ui/components/table'
 import { formatBytes, formatRelativeTime } from '@auxx/utils'
-import { Archive, MoreHorizontal, Search, Settings, Trash } from 'lucide-react'
+import { Archive, MoreHorizontal, Search, Settings, Share2, Trash } from 'lucide-react'
 import Link from 'next/link'
+import { useState } from 'react'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useDatasets } from './datasets-provider'
 import { useDatasetActions } from './hooks/use-dataset-actions'
 
@@ -39,6 +43,12 @@ function DatasetTableRow({
       datasetName: dataset.name,
       onSuccess: onActionComplete,
     })
+
+  // Same per-instance gating as `dataset-card.tsx`: Browse is the `view` rung,
+  // Settings / Share… / Archive / Delete are `admin`.
+  const { canAdminInstance } = useAccess()
+  const canAdmin = canAdminInstance(toRecordId('dataset', dataset.id))
+  const [shareOpen, setShareOpen] = useState(false)
 
   const getStatusVariant = (status: string) => {
     switch (status) {
@@ -103,24 +113,39 @@ function DatasetTableRow({
                 <Search />
                 Browse
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleSettings}>
-                <Settings />
-                Settings
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleArchive}>
-                <Archive />
-                Archive
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleDelete} variant='destructive'>
-                <Trash />
-                Delete
-              </DropdownMenuItem>
+              {canAdmin && (
+                <>
+                  <DropdownMenuItem onClick={handleSettings}>
+                    <Settings />
+                    Settings
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setShareOpen(true)}>
+                    <Share2 />
+                    Share…
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleArchive}>
+                    <Archive />
+                    Archive
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleDelete} variant='destructive'>
+                    <Trash />
+                    Delete
+                  </DropdownMenuItem>
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </TableCell>
       </TableRow>
 
+      {canAdmin && (
+        <InstanceShareDialog
+          recordId={toRecordId('dataset', dataset.id)}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
       <ConfirmDialog />
     </>
   )

--- a/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
@@ -51,8 +51,8 @@ function getInitials(name?: string): string {
  * and never site-published), and a plain breadcrumb instead of the KB
  * switcher (the learned KB is excluded from `kb.list`, so the switcher
  * neither names it nor offers it). An Edit-level (non-admin) member gets the
- * same trimmed chrome minus the switcher swap — settings/layout/publish are
- * Full-only (doc 24 §A.2.4); Share stays for everyone.
+ * same trimmed chrome minus the switcher swap — settings/layout/publish AND
+ * Share are Full-only (doc 24 §A.2.4).
  */
 export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeaderProps) {
   const [panel, setPanel] = useQueryState(
@@ -80,16 +80,20 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
       action={
         isLearned ? undefined : (
           <div className='flex items-center gap-2'>
-            <Button variant='outline' size='sm' onClick={() => setShareOpen(true)}>
-              <Share2 />
-              Share
-            </Button>
-            <InstanceShareDialog
-              recordId={toRecordId('kb', knowledgeBaseId)}
-              open={shareOpen}
-              onOpenChange={setShareOpen}
-            />
-            {canAdmin && <KBPublishCluster kbId={knowledgeBaseId} />}
+            {canAdmin && (
+              <>
+                <Button variant='outline' size='sm' onClick={() => setShareOpen(true)}>
+                  <Share2 />
+                  Share
+                </Button>
+                <InstanceShareDialog
+                  recordId={toRecordId('kb', knowledgeBaseId)}
+                  open={shareOpen}
+                  onOpenChange={setShareOpen}
+                />
+                <KBPublishCluster kbId={knowledgeBaseId} />
+              </>
+            )}
           </div>
         )
       }>

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
@@ -88,11 +88,13 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
   return (
     <>
       <ConfirmDialog />
-      <InstanceShareDialog
-        recordId={toRecordId('kb', kb.id)}
-        open={shareOpen}
-        onOpenChange={setShareOpen}
-      />
+      {canAdmin && (
+        <InstanceShareDialog
+          recordId={toRecordId('kb', kb.id)}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
       <ListCard
         href={`/app/kb/${kb.id}/editor`}
         ariaLabel={kb.name}
@@ -133,10 +135,12 @@ export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: Knowle
                 Settings
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem onClick={() => setShareOpen(true)}>
-              <Share2 />
-              Share…
-            </DropdownMenuItem>
+            {canAdmin && (
+              <DropdownMenuItem onClick={() => setShareOpen(true)}>
+                <Share2 />
+                Share…
+              </DropdownMenuItem>
+            )}
             <FavoriteToggleMenuItem
               targetType='KNOWLEDGE_BASE'
               targetIds={{ knowledgeBaseId: kb.id }}


### PR DESCRIPTION
## What

The **Share** trigger on every instance-access resource was ungated. That was deliberate — three files said so:

- `dashboard-card.tsx`: *"Open / Favorite / Share… stay at Read — the share dialog is already read-only for non-admins."*
- `kb-editor-header.tsx`: *"Share stays for everyone."*
- `workflows-grid-view.tsx`: same rationale.

The premise only half holds. `instance-share-card.tsx:139` returns `null` when `!canAdmin && grants.length === 0 && unmanageableGrants.length === 0`, so a viewer on an unshared resource got a dialog with a title, a description, and an empty body — not a read-only grantee list.

This gates **both the trigger and the `<InstanceShareDialog>` mount** on `canAdminInstance`, consistently across all seven surfaces.

| File | Change |
|---|---|
| `datasets/dataset-card.tsx` | Share… + dialog gated |
| `datasets/datasets-table-view.tsx` | **Added** Share…; Settings/Archive/Delete moved inside `canAdmin` |
| `datasets/[datasetId]/_components/dataset-actions.tsx` | Share button + dialog gated |
| `kb/ui/knowledge-bases/knowledge-base-card.tsx` | Share… + dialog gated |
| `kb/ui/editor/kb-editor-header.tsx` | Share folded into the existing `canAdmin` block with `KBPublishCluster` |
| `dashboard/ui/dashboard-card.tsx` | Share… + dialog gated |
| `dashboard/ui/dashboard-detail-view.tsx` | Share button + dialog gated |
| `workflows/_components/lists/workflows-grid-view.tsx` | Share… + dialog gated |

`datasets-table-view.tsx` was the worst of the set: no Share item at all, and Settings / Archive / Delete were open to viewers while `dataset-card.tsx` gated all three. It is now at parity with the card.

The three stale comments asserting the old rule are rewritten.

## Deliberately not changed

1. **`instance-share-card.tsx:139`'s non-admin path is now nearly dead.** No product trigger reaches it. It still fires for the card embedded in `workflow-access-settings.tsx` and from the permissions console, so the branch stays — but its comment ("hiding the card would leave an admin with no signal at all") no longer describes any reachable dataset/KB/dashboard flow.
2. **`grantee-instance-rows.tsx:172`** — the permissions console's per-row "Manage sharing" still opens the dialog for anyone with `permissionsManage`, regardless of instance admin, and can still produce the empty-body dialog. Different subject (admin console, not the resource surface); gating it is a separate call.
3. **The "Shared" `Lock` badge** stays visible to non-admins on dataset/KB cards — status signal, not an affordance.

## Verification

- `biome check` clean on all 8 files.
- `tsc --noEmit` on `apps/web`: **zero errors in any of the 8** (baseline is 4072 pre-existing).
- `vitest run src/components/permissions`: **87/87 pass**, 8 files.
- **Not browser-verified** — client-side affordance gating only; no server behavior changes, and every gated action was already enforced server-side.