### PR TITLE
fix(permissions): show the effective access line on every area row

### DIFF
--- a/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
@@ -40,12 +40,11 @@ const CHILD_DEPTH = 1
  * it would hide the one thing this exists to show. It goes in `secondary`, the
  * visible slot beside the title. `description` keeps its existing row copy.
  *
- * **Unconditional here, unlike the area rows**, which show their line only when
- * it disagrees with their ladder. The difference is what the row already states:
- * an area row's ladder always highlights a concrete rung, while this row's
- * select reads a bare "Inherit" for every un-granted instance (it is not given
- * an `inheritedLevel` to name) — so there is nothing to disagree WITH, and a
- * conditional line would simply never appear on the rows that need it most.
+ * **Unconditional**, on every row that has an effective level to report — the
+ * same rule the area rows above now follow. Both surfaces once differed here
+ * (the area grid showed its line only where composition disagreed with the
+ * ladder), which made a missing line mean two different things depending on the
+ * row it was missing from.
  *
  * Level only, no source attribution — that is phase 3, and it needs a
  * `user:capabilities` bump because composition discards which row won.

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.test.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.test.tsx
@@ -69,7 +69,7 @@ describe('LeveledAreaGrid — effectiveLevels is additive', () => {
   })
 })
 
-describe('LeveledAreaGrid — the line marks a DISCREPANCY, not every row', () => {
+describe('LeveledAreaGrid — the line reports EVERY area it has a level for', () => {
   it('shows the composed level when it exceeds what the ladder displays', () => {
     // The member's own row says nothing and their profile base is None, so the
     // ladder reads "No access" — but a team raised them to Edit.
@@ -78,21 +78,26 @@ describe('LeveledAreaGrid — the line marks a DISCREPANCY, not every row', () =
     expect(screen.getByText('Effective · Edit')).toBeTruthy()
   })
 
-  it('stays silent when the composed level agrees with the ladder', () => {
+  /**
+   * Agreement is still reported. The line used to be suppressed here, which made
+   * its absence say two things at once — "the ladder is the truth on this row"
+   * and "this surface has no effective access to report at all" (teams, above).
+   */
+  it('shows the composed level when it agrees with the ladder', () => {
     // `value` is undefined, `inherited` falls through to roleDefaults = None,
-    // and composition also lands on None. Nothing to report.
+    // and composition also lands on None.
     renderGrid({ effectiveLevels: { [Area.workflows]: Level.None } })
 
-    expect(screen.queryByText(/^Effective ·/)).toBeNull()
+    expect(screen.getByText('Effective · No access')).toBeTruthy()
   })
 
-  it('stays silent when an explicit override already displays the composed level', () => {
+  it('shows the composed level when an explicit override already displays it', () => {
     renderGrid({
       values: { [Area.workflows]: Level.Full },
       effectiveLevels: { [Area.workflows]: Level.Full },
     })
 
-    expect(screen.queryByText(/^Effective ·/)).toBeNull()
+    expect(screen.getByText('Effective · Full')).toBeTruthy()
   })
 
   /**
@@ -109,12 +114,17 @@ describe('LeveledAreaGrid — the line marks a DISCREPANCY, not every row', () =
     expect(screen.getByText('Effective · No access')).toBeTruthy()
   })
 
-  it('reports per area, not across the grid', () => {
+  /**
+   * Sparse in, sparse out: an area missing from `effectiveLevels` still renders
+   * no line, so a partial map never invents a rung for the areas it omits.
+   */
+  it('reports per area, and only for the areas it was given', () => {
     renderGrid({
       effectiveLevels: { [Area.workflows]: Level.Read, [Area.dashboards]: Level.None },
     })
 
-    expect(screen.getAllByText(/^Effective ·/)).toHaveLength(1)
+    expect(screen.getAllByText(/^Effective ·/)).toHaveLength(2)
     expect(screen.getByText('Effective · Read')).toBeTruthy()
+    expect(screen.getByText('Effective · No access')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -186,16 +186,18 @@ export function LeveledAreaGrid({
                     key={area}
                     title={meta.label}
                     description={meta.description}
-                    // Shown ONLY where it disagrees with the ladder, unlike the
-                    // instance rows, which always show it. Not an inconsistency:
-                    // the ladder here always highlights a concrete rung
-                    // (`value ?? inherited`), so a matching line would be noise
-                    // on every row and the discrepancy — a group raise, a
-                    // profile ceiling, the seat clamp — is the whole signal. A
-                    // grantee instance row's select reads a bare "Inherit" with
-                    // no rung named, so there it has to be unconditional.
+                    // Unconditional, like the instance rows: every area states
+                    // what this grantee can ACTUALLY reach, not only the ones
+                    // where composition disagrees with the ladder. Showing it
+                    // only on disagreement made the line's absence ambiguous —
+                    // a reader could not tell "the ladder is the truth here"
+                    // from "this surface never reports effective access" (it
+                    // doesn't for teams, which have none). Agreement is a
+                    // confirmation worth reading; the discrepancies — a group
+                    // raise, a profile ceiling, the seat clamp — still stand out
+                    // against the rung the control shows.
                     secondary={
-                      effective !== undefined && effective !== (value ?? inherited) ? (
+                      effective !== undefined ? (
                         <span className='whitespace-nowrap text-xs'>
                           Effective · {effectiveLevelLabel(effective)}
                         </span>


### PR DESCRIPTION
## What

The `LeveledAreaGrid` area rows render an `Effective · <rung>` line beside the level control — what the grantee can **actually** reach after composition (`min(min(max(profileBase, maxOverGroups, userLevel), profileCeiling), seatCeiling)`), as opposed to the rung the ladder displays (`values[area] ?? inherited`).

It was gated on those two disagreeing, so the line only appeared where composition diverged from the ladder. Now it renders on every area that has a level to report.

## Why

Suppressing the line on agreement made its **absence** mean two different things:

- "the ladder is the truth on this row" (composition agreed), and
- "this surface reports no effective access at all" — which is the case for **teams**, whose `effective` composes to `null` server-side, so `effectiveLevels` is `undefined` and no row ever shows a line.

Nothing on the row distinguished those. The instance rows below already showed their line unconditionally for exactly this reason; the two halves of the same tab now follow one rule.

## Scope

- `leveled-area-grid.tsx` — drop the `effective !== (value ?? inherited)` half of the condition.
- `grantee-instance-rows.tsx` — its JSDoc explicitly documented the old asymmetry ("Unconditional here, unlike the area rows…"); rewritten so it no longer describes behavior that doesn't exist.
- `leveled-area-grid.test.tsx` — two tests pinned the suppression; flipped to assert the line now shows.

Unchanged, deliberately:

- **Teams still show no line anywhere** — `effective?.areas` is `undefined` for a group grantee. The two "effectiveLevels is additive" tests still pin that.
- **Sparse in, sparse out** — an area absent from `effectiveLevels` renders nothing. The per-area test now asserts 2 lines from a 2-entry map, which is the part that proves a partial map doesn't invent rungs.

Both consumers (`GranteeLevelsSection`, `GranteeOverridesTab`) feed the prop from the same `effective?.areas`, so they move together.

## Follow-up worth considering

With the line on every row, a discrepancy — a group raise, a profile ceiling, the seat clamp — is now only visible by reading the line against the control's rung, where before its mere presence was the signal. If that regression in scannability matters, the cheap fix is to *style* the line when `effective !== (value ?? inherited)` (amber, or a small clamp icon) rather than hide it. Not included here.

## Testing

`vitest run` over the three permissions UI suites — 24 tests pass (`leveled-area-grid`, `grantee-levels-section`, `grantee-instance-rows`). Biome clean on the touched files.