### PR TITLE
fix(permissions): gate related-record tabs and cards on the listed def

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-sidebar.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sidebar.tsx
@@ -10,6 +10,7 @@ import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { getTabCardComponent } from '~/components/drawers/drawer-tab-registry'
 import EntityFields from '~/components/fields/entity-fields'
 import DrawerComments from '~/components/global/comments/drawer-comments'
+import { useCanViewRecordResource } from '~/components/resources'
 import { useAccess } from '~/providers/capabilities-provider'
 import { DetailViewCardHeader } from './components/detail-view-card-header'
 import type { DetailViewSidebarProps } from './types'
@@ -33,10 +34,15 @@ export function DetailViewSidebar({
 }: DetailViewSidebarProps) {
   const { entityInstanceId } = parseRecordId(recordId)
   const { can } = useAccess()
+  const canViewRecordResource = useCanViewRecordResource()
   const entityType = config.entityType
   // Layer-2 capability gate — drop cards (header included) the viewer lacks the
   // key for, mirroring the card's router procedure gate (e.g. billing → dispatch).
-  const sidebarCards = config.sidebarCards?.filter((c) => !c.permissionKey || can(c.permissionKey))
+  // Layer-3 `recordResource` gate for cards that are purely another definition's
+  // records — the twin of the drawer's `TabCards` filter.
+  const sidebarCards = config.sidebarCards
+    ?.filter((c) => !c.permissionKey || can(c.permissionKey))
+    .filter((c) => canViewRecordResource(c.recordResource))
 
   const beforeCards = sidebarCards?.filter((c) => c.position === 'before') ?? []
   const afterCards = sidebarCards?.filter((c) => (c.position ?? 'after') === 'after') ?? []

--- a/apps/web/src/components/detail-view/detail-view.tsx
+++ b/apps/web/src/components/detail-view/detail-view.tsx
@@ -16,7 +16,13 @@ import { useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
 import { NoAccess } from '~/components/permissions/ui/no-access'
 import { getRecordDrillPanels } from '~/components/records/record-drill-panels'
-import { toRecordId, useRecord, useResource, useResourceProperty } from '~/components/resources'
+import {
+  toRecordId,
+  useCanViewRecordResource,
+  useRecord,
+  useResource,
+  useResourceProperty,
+} from '~/components/resources'
 import { useIsMobile } from '~/hooks/use-mobile'
 import { useAccess } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
@@ -35,6 +41,7 @@ import type { DetailViewProps } from './types'
 export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: DetailViewProps) {
   const { resource, isLoading: resourceLoading } = useResource(apiSlug)
   const { can, canViewEntity } = useAccess()
+  const canViewRecordResource = useCanViewRecordResource()
 
   // Get resource properties including id (entityDefinitionId) and entityType
   const resourceProps = useResourceProperty(apiSlug, [
@@ -100,8 +107,15 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
   // sections, active-tab fallback, and lazy query owners all consume the same
   // list. This also handles a hidden default or a denied `?tab=` deep link.
   const visibleMainTabs = useMemo(
-    () => config.mainTabs.filter((tab) => !tab.permissionKey || can(tab.permissionKey)),
-    [config.mainTabs, can]
+    () =>
+      config.mainTabs
+        .filter((tab) => !tab.permissionKey || can(tab.permissionKey))
+        // Layer-3 per-definition gate for tabs that list another definition's
+        // records (contact → Tickets, part → Subparts/Vendors). Load-bearing on
+        // this surface specifically: `tickets` is the contact page's DEFAULT tab,
+        // so without it a `tickets: None` member lands on it.
+        .filter((tab) => canViewRecordResource(tab.recordResource)),
+    [config.mainTabs, can, canViewRecordResource]
   )
   const requestedMainTab = mainTab ?? config.defaultTab ?? 'overview'
   const activeMainTab = visibleMainTabs.some((tab) => tab.value === requestedMainTab)

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -47,7 +47,7 @@ import {
   useRecordDrillStack,
   useRecordPeekStack,
 } from '~/components/records/record-drill-panels'
-import { useRecord, useResource } from '~/components/resources'
+import { useCanViewRecordResource, useRecord, useResource } from '~/components/resources'
 import { useRecordLink } from '~/components/resources/utils/get-record-link'
 import { TasksSection } from '~/components/tasks/ui/tasks-section'
 import { TimelineTab } from '~/components/timeline'
@@ -179,6 +179,7 @@ function DrawerRecordFrame({
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' })
   const { hasAccess } = useFeatureFlags()
   const { can } = useAccess()
+  const canViewRecordResource = useCanViewRecordResource()
   const organizationId = useDehydratedOrganizationId()
   const user = useDehydratedUser()
 
@@ -242,6 +243,20 @@ function DrawerRecordFrame({
     return getEntityDrawerConfig(entityType, entityDefinitionId ?? undefined)
   }, [entityType, entityDefinitionId])
 
+  // The registry tabs this viewer may see — resolved ONCE so the tab strip and
+  // the rendered TabsContent below can never disagree. A `recordResource` tab
+  // lists another definition's records, so it is gated on that definition's read
+  // level: with `tickets: None` the contact drawer must not offer a Tickets tab
+  // at all (an always-empty tab fronting a Create button reads as a bug).
+  const visibleAdditionalTabs = React.useMemo(
+    () =>
+      (drawerConfig?.additionalTabs ?? [])
+        .filter((tab) => !tab.featureGate || hasAccess(tab.featureGate))
+        .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType ?? '', tab.value))
+        .filter((tab) => canViewRecordResource(tab.recordResource)),
+    [drawerConfig, hasAccess, readOnly, entityType, canViewRecordResource]
+  )
+
   // Build tabs from registry + base tabs
   const tabs = React.useMemo(() => {
     if (!drawerConfig) return []
@@ -255,18 +270,15 @@ function DrawerRecordFrame({
       // Restricted mode drops the communication/comment tabs (§11.4).
       .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType ?? '', tab.value))
 
-    const additionalTabs = drawerConfig.additionalTabs
-      .filter((tab) => !tab.featureGate || hasAccess(tab.featureGate))
-      .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType ?? '', tab.value))
-      .map((tab) => ({
-        value: tab.value,
-        label: tab.label,
-        icon: getIconComponent(tab.icon),
-      }))
+    const additionalTabs = visibleAdditionalTabs.map((tab) => ({
+      value: tab.value,
+      label: tab.label,
+      icon: getIconComponent(tab.icon),
+    }))
 
     // Overview first, then entity-specific tabs, then the shared timeline/comments/tasks tabs
     return [overviewTab, ...additionalTabs, ...trailingTabs]
-  }, [drawerConfig, hasAccess, readOnly, entityType])
+  }, [drawerConfig, visibleAdditionalTabs, readOnly, entityType])
 
   // Tab order persistence
   const tabOrderStorageKey = React.useMemo(() => {
@@ -300,6 +312,15 @@ function DrawerRecordFrame({
     if (!savedTabOrder || savedTabOrder.length === 0) return tabs
     return applyTabOrder(tabs, savedTabOrder)
   }, [tabs, savedTabOrder])
+
+  // A `?tab=` pointing at a tab this viewer can't see (a stale deep link, or a
+  // frame whose entity type has no such tab) must not render a blank body.
+  // Resolved locally and deliberately NOT written back to the URL: every frame
+  // of the peek stack shares this one query param, so a write here would clobber
+  // the frame underneath.
+  const effectiveTab = orderedTabs.some((tab) => tab.value === activeTab)
+    ? activeTab
+    : (orderedTabs[0]?.value ?? 'overview')
 
   const handleTabReorder = React.useCallback(
     (newOrder: string[]) => {
@@ -336,12 +357,12 @@ function DrawerRecordFrame({
   // entityType has drill panels, so it becomes the root NavStackPanel's
   // content when it does (byte-identical render otherwise).
   const tabsBlock = (
-    <Tabs value={activeTab} onValueChange={setActiveTab} className='w-full h-full'>
+    <Tabs value={effectiveTab} onValueChange={setActiveTab} className='w-full h-full'>
       <div className='w-full h-full flex gap-0'>
         <div className='w-full h-full flex flex-col overflow-auto justify-start'>
           <OverflowTabsList
             tabs={orderedTabs}
-            value={activeTab}
+            value={effectiveTab}
             onValueChange={setActiveTab}
             variant='outline'
             canReorder={!!tabOrderStorageKey}
@@ -417,21 +438,19 @@ function DrawerRecordFrame({
               <TasksSection recordId={recordId} />
             </TabsContent>
 
-            {/* Dynamic tabs from registry */}
-            {drawerConfig.additionalTabs
-              .filter((tab) => !tab.featureGate || hasAccess(tab.featureGate))
-              .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType, tab.value))
-              .map((tab) => (
-                <TabsContent key={tab.value} value={tab.value} className='w-full'>
-                  <LazyTabComponent
-                    entityType={entityType}
-                    tabValue={tab.value}
-                    entityInstanceId={entityInstanceId}
-                    recordId={recordId}
-                    record={record}
-                  />
-                </TabsContent>
-              ))}
+            {/* Dynamic tabs from registry — same filtered list as the strip, so a
+                gated-out tab has no mountable content either. */}
+            {visibleAdditionalTabs.map((tab) => (
+              <TabsContent key={tab.value} value={tab.value} className='w-full'>
+                <LazyTabComponent
+                  entityType={entityType}
+                  tabValue={tab.value}
+                  entityInstanceId={entityInstanceId}
+                  recordId={recordId}
+                  record={record}
+                />
+              </TabsContent>
+            ))}
           </div>
         </div>
       </div>
@@ -738,6 +757,7 @@ function TabCards({
   readOnly?: boolean
 }) {
   const { can } = useAccess()
+  const canViewRecordResource = useCanViewRecordResource()
   const cards = drawerConfig.tabCards?.[tab]
     ?.filter((c) => (c.position ?? 'after') === position)
     // Restricted mode drops communication overview cards (e.g. work_order:communications).
@@ -745,6 +765,9 @@ function TabCards({
     // Layer-2 capability gate — hide the whole section (header included) when the
     // viewer lacks the key, mirroring the card's router procedure gate.
     .filter((c) => !c.permissionKey || can(c.permissionKey))
+    // Layer-3 per-definition gate for cards that are purely another definition's
+    // records (service_request work orders/quotes, quote jobs).
+    .filter((c) => canViewRecordResource(c.recordResource))
   if (!cards?.length) return null
 
   return (

--- a/apps/web/src/components/drawers/cards/quote-jobs-card.tsx
+++ b/apps/web/src/components/drawers/cards/quote-jobs-card.tsx
@@ -8,8 +8,10 @@ import { toastError } from '@auxx/ui/components/toast'
 import { Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Tooltip } from '~/components/global/tooltip'
+import { useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { DrawerCardActions } from '../drawer-card-actions'
 import type { DrawerTabProps } from '../drawer-tab-registry'
@@ -38,6 +40,7 @@ const CONVERTIBLE_STATUSES = new Set(['draft', 'sent', 'approved'])
 export function QuoteJobsCard({ recordId }: DrawerTabProps) {
   const router = useRouter()
   const [confirm, ConfirmDialog] = useConfirm()
+  const { canEditEntity } = useAccess()
 
   const { values, isLoading } = useSystemValues(recordId, ['quote_work_orders', 'quote_status'], {
     autoFetch: true,
@@ -68,8 +71,16 @@ export function QuoteJobsCard({ recordId }: DrawerTabProps) {
     }
   }
 
+  // "Create job" writes a work_order, so it needs write on THAT def — the card
+  // itself only needs read on it (`recordResource` in the registry).
+  const workOrderDefId = useResourceProperty('work_order', 'id')
+  const canCreateJob = !!workOrderDefId && canEditEntity(workOrderDefId)
+
   const showCreateAction =
-    !isLoading && workOrderRecordIds.length === 0 && CONVERTIBLE_STATUSES.has(status)
+    !isLoading &&
+    canCreateJob &&
+    workOrderRecordIds.length === 0 &&
+    CONVERTIBLE_STATUSES.has(status)
 
   return (
     <>

--- a/apps/web/src/components/drawers/tabs/company-parts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/company-parts-tab.tsx
@@ -15,6 +15,7 @@ import { VendorPartDialog } from '~/components/manufacturing/parts/vendor-part-d
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { ContactVendorPartRow } from './contact-parts-tab-row'
@@ -31,6 +32,10 @@ export function CompanyPartsTab({ entityInstanceId }: DrawerTabProps) {
 
   // Resolve vendor_part entity definition ID
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
+  // The tab is gated on READ of vendor_part (drawer config `recordResource`);
+  // adding one additionally needs WRITE.
+  const { canEditEntity } = useAccess()
+  const canCreate = !!vendorPartDefId && canEditEntity(vendorPartDefId)
 
   // Filter vendor parts by supplier company
   const filters: ConditionGroup[] = useMemo(
@@ -131,10 +136,12 @@ export function CompanyPartsTab({ entityInstanceId }: DrawerTabProps) {
           collapsible={false}
           icon={<Package className='size-4 text-muted-foreground/50' />}
           actions={
-            <Button variant='ghost' size='sm' onClick={() => setIsDialogOpen(true)}>
-              <Package />
-              Add Part
-            </Button>
+            canCreate ? (
+              <Button variant='ghost' size='sm' onClick={() => setIsDialogOpen(true)}>
+                <Package />
+                Add Part
+              </Button>
+            ) : undefined
           }>
           {records.length === 0 ? (
             <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>

--- a/apps/web/src/components/drawers/tabs/contact-parts-tab-row.tsx
+++ b/apps/web/src/components/drawers/tabs/contact-parts-tab-row.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/drawers/tabs/contact-parts-tab-row.tsx
 'use client'
 
-import type { RecordId } from '@auxx/lib/resources/client'
+import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
@@ -17,6 +17,7 @@ import { Edit, MoreHorizontal, Star, Trash2 } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { useAccess } from '~/providers/capabilities-provider'
 
 const VENDOR_PART_ATTRIBUTES = [
   'vendor_part_vendor_sku',
@@ -41,6 +42,10 @@ export function ContactVendorPartRow({
   onSetPreferred,
 }: ContactVendorPartRowProps) {
   const { values } = useSystemValues(recordId, VENDOR_PART_ATTRIBUTES, { autoFetch: true })
+  // Read-only viewers of the vendor_part definition get the row without its
+  // actions menu — every item in it (edit, set preferred, remove) is a write.
+  const { canEditEntity } = useAccess()
+  const canEdit = canEditEntity(parseRecordId(recordId).entityDefinitionId)
 
   const vendorSku = values.vendor_part_vendor_sku as string | undefined
   const unitPrice = values.vendor_part_unit_price as number | null | undefined
@@ -78,30 +83,32 @@ export function ContactVendorPartRow({
         )}
       </TableCell>
       <TableCell>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant='ghost' size='icon-sm'>
-              <MoreHorizontal />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align='end'>
-            <DropdownMenuItem onClick={onEdit}>
-              <Edit />
-              Edit
-            </DropdownMenuItem>
-            {!isPreferred && (
-              <DropdownMenuItem onClick={onSetPreferred}>
-                <Star />
-                Set as Preferred
+        {canEdit && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant='ghost' size='icon-sm'>
+                <MoreHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuItem onClick={onEdit}>
+                <Edit />
+                Edit
               </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant='destructive' onClick={onDelete}>
-              <Trash2 />
-              Remove
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              {!isPreferred && (
+                <DropdownMenuItem onClick={onSetPreferred}>
+                  <Star />
+                  Set as Preferred
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant='destructive' onClick={onDelete}>
+                <Trash2 />
+                Remove
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </TableCell>
     </TableRow>
   )

--- a/apps/web/src/components/drawers/tabs/contact-tickets-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/contact-tickets-tab.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '~/components/global/empty-state'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import TicketRow from '~/components/tickets/ticket-row'
+import { useAccess } from '~/providers/capabilities-provider'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
 /** Contact relationship field on the ticket def — also the filter key below. */
@@ -27,6 +28,11 @@ export function ContactTicketsTab({ entityInstanceId }: DrawerTabProps) {
   const contactId = entityInstanceId
   const entityDefinitionId = useResourceProperty('ticket', 'id')
   const [isCreateOpen, setIsCreateOpen] = useState(false)
+  // The tab itself is gated on READ of the ticket definition (drawer config
+  // `recordResource`); creating from here additionally needs WRITE on it — a
+  // `tickets: Read` member sees the list without a create affordance.
+  const { canEditEntity } = useAccess()
+  const canCreate = !!entityDefinitionId && canEditEntity(entityDefinitionId)
 
   const filters: ConditionGroup[] = useMemo(
     () => [
@@ -63,7 +69,7 @@ export function ContactTicketsTab({ entityInstanceId }: DrawerTabProps) {
 
   // Generic create dialog, pre-linked to this contact. Shared across the empty
   // and populated states below.
-  const createDialog = (
+  const createDialog = canCreate && (
     <RecordEditorDialog
       open={isCreateOpen}
       onOpenChange={setIsCreateOpen}
@@ -95,13 +101,17 @@ export function ContactTicketsTab({ entityInstanceId }: DrawerTabProps) {
       <div className='flex flex-1 items-center justify-center w-full'>
         <EmptyState
           icon={TicketIcon}
-          title='Create a ticket'
-          description='Create a ticket for this contact'
+          title={canCreate ? 'Create a ticket' : 'No tickets'}
+          description={
+            canCreate ? 'Create a ticket for this contact' : 'This contact has no tickets yet'
+          }
           button={
-            <Button variant='outline' size='sm' onClick={() => setIsCreateOpen(true)}>
-              <Plus />
-              Create Ticket
-            </Button>
+            canCreate ? (
+              <Button variant='outline' size='sm' onClick={() => setIsCreateOpen(true)}>
+                <Plus />
+                Create Ticket
+              </Button>
+            ) : undefined
           }
         />
         {createDialog}
@@ -117,10 +127,12 @@ export function ContactTicketsTab({ entityInstanceId }: DrawerTabProps) {
         collapsible={false}
         icon={<TicketIcon className='size-4 text-muted-foreground/50' />}
         actions={
-          <Button variant='ghost' size='sm' onClick={() => setIsCreateOpen(true)}>
-            <Plus />
-            Create Ticket
-          </Button>
+          canCreate ? (
+            <Button variant='ghost' size='sm' onClick={() => setIsCreateOpen(true)}>
+              <Plus />
+              Create Ticket
+            </Button>
+          ) : undefined
         }>
         <div className='space-y-4 sm:p-4'>
           {records.map((record) => (

--- a/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
@@ -25,6 +25,7 @@ import { useMemo } from 'react'
 import { StockAdjustmentPopover } from '~/components/manufacturing/parts/stock-adjustment-popover'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useAccess } from '~/providers/capabilities-provider'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
 /** Map movement type values to badge color variants */
@@ -70,6 +71,10 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
   } = useSystemValues(recordId, [...PART_ATTRIBUTES], { autoFetch: true })
   const stockMovementDefId = useResourceProperty('stock_movement', 'id')
   const subpartDefId = useResourceProperty('subpart', 'id')
+  // The tab itself is NOT `recordResource`-gated — it leads with the part's own
+  // on-hand quantity — so the stock_movement gate sits on the write action.
+  const { canEditEntity } = useAccess()
+  const canAdjustStock = !!stockMovementDefId && canEditEntity(stockMovementDefId)
 
   const qoh = (values.part_quantity_on_hand as number) ?? 0
   const stockStatus =
@@ -171,16 +176,18 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
         title={`Stock Movements (${records.length})`}
         initialOpen
         actions={
-          <StockAdjustmentPopover
-            partId={partId}
-            currentQoH={qoh}
-            hasSubparts={hasSubparts}
-            onSuccess={handleAdjustSuccess}>
-            <Button variant='ghost' size='xs'>
-              <Package />
-              Adjust Stock
-            </Button>
-          </StockAdjustmentPopover>
+          canAdjustStock ? (
+            <StockAdjustmentPopover
+              partId={partId}
+              currentQoH={qoh}
+              hasSubparts={hasSubparts}
+              onSuccess={handleAdjustSuccess}>
+              <Button variant='ghost' size='xs'>
+                <Package />
+                Adjust Stock
+              </Button>
+            </StockAdjustmentPopover>
+          ) : undefined
         }>
         {records.length === 0 ? (
           <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>

--- a/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
@@ -31,6 +31,7 @@ import { SubpartDialog } from '~/components/manufacturing/parts/subpart-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
@@ -45,6 +46,10 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
 
   // Resolve subpart entity definition ID
   const subpartDefId = useResourceProperty('subpart', 'id')
+  // The tab is gated on READ of subpart (drawer config `recordResource`);
+  // adding one additionally needs WRITE.
+  const { canEditEntity } = useAccess()
+  const canCreate = !!subpartDefId && canEditEntity(subpartDefId)
 
   // Subparts section: children of this part
   const subpartFilters: ConditionGroup[] = useMemo(
@@ -173,10 +178,12 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
         title={`Subparts (${subpartRecords.length})`}
         initialOpen
         actions={
-          <Button variant='ghost' size='xs' onClick={() => setIsSubpartDialogOpen(true)}>
-            <PlusCircle />
-            Add Subpart
-          </Button>
+          canCreate ? (
+            <Button variant='ghost' size='xs' onClick={() => setIsSubpartDialogOpen(true)}>
+              <PlusCircle />
+              Add Subpart
+            </Button>
+          ) : undefined
         }>
         {subpartRecords.length === 0 ? (
           <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>
@@ -284,6 +291,10 @@ function SubpartRow({
   const { values } = useSystemValues(recordId, attributes, {
     autoFetch: true,
   })
+  // Read-only viewers of the subpart definition keep the row (and its column
+  // alignment) but lose the actions menu — edit and remove are both writes.
+  const { canEditEntity } = useAccess()
+  const canEdit = canEditEntity(parseRecordId(recordId).entityDefinitionId)
 
   // Relationship fields return RecordId[] from formatToRawValue — unwrap and extract instance ID
   const rawPartValue = values[relatedPartField]
@@ -310,23 +321,25 @@ function SubpartRow({
             {relatedPartId ? <PartCostCell partId={relatedPartId} /> : '—'}
           </TableCell>
           <TableCell>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant='ghost' size='icon-sm'>
-                  <MoreHorizontal />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='end'>
-                <DropdownMenuItem onClick={onEdit}>
-                  <Edit />
-                  Edit
-                </DropdownMenuItem>
-                <DropdownMenuItem variant='destructive' onClick={onDelete}>
-                  <Trash2 />
-                  Remove
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            {canEdit && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant='ghost' size='icon-sm'>
+                    <MoreHorizontal />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                  <DropdownMenuItem onClick={onEdit}>
+                    <Edit />
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuItem variant='destructive' onClick={onDelete}>
+                    <Trash2 />
+                    Remove
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </TableCell>
         </>
       )}

--- a/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
 'use client'
 
-import type { RecordId } from '@auxx/lib/resources/client'
+import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
@@ -17,6 +17,7 @@ import { Edit, MoreHorizontal, Star, Trash2 } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { useAccess } from '~/providers/capabilities-provider'
 
 const VENDOR_PART_ATTRIBUTES = [
   'vendor_part_vendor_sku',
@@ -40,6 +41,10 @@ interface VendorPartRowProps {
 export function VendorPartRow({ recordId, onEdit, onDelete, onSetPreferred }: VendorPartRowProps) {
   const { values } = useSystemValues(recordId, VENDOR_PART_ATTRIBUTES, { autoFetch: true })
   // const { resource: contactResource } = useResource('contacts')
+  // Read-only viewers of the vendor_part definition get the row without its
+  // actions menu — every item in it (edit, set preferred, remove) is a write.
+  const { canEditEntity } = useAccess()
+  const canEdit = canEditEntity(parseRecordId(recordId).entityDefinitionId)
 
   const vendorSku = values.vendor_part_vendor_sku as string | undefined
   const unitPrice = values.vendor_part_unit_price as number | null | undefined
@@ -93,30 +98,32 @@ export function VendorPartRow({ recordId, onEdit, onDelete, onSetPreferred }: Ve
         )}
       </TableCell>
       <TableCell>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant='ghost' size='icon-sm'>
-              <MoreHorizontal />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align='end'>
-            <DropdownMenuItem onClick={onEdit}>
-              <Edit />
-              Edit
-            </DropdownMenuItem>
-            {!isPreferred && (
-              <DropdownMenuItem onClick={onSetPreferred}>
-                <Star />
-                Set as Preferred
+        {canEdit && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant='ghost' size='icon-sm'>
+                <MoreHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuItem onClick={onEdit}>
+                <Edit />
+                Edit
               </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant='destructive' onClick={onDelete}>
-              <Trash2 />
-              Remove
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              {!isPreferred && (
+                <DropdownMenuItem onClick={onSetPreferred}>
+                  <Star />
+                  Set as Preferred
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant='destructive' onClick={onDelete}>
+                <Trash2 />
+                Remove
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </TableCell>
     </TableRow>
   )

--- a/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
@@ -16,6 +16,7 @@ import { VendorPartDialog } from '~/components/manufacturing/parts/vendor-part-d
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { VendorPartRow } from './part-vendors-tab-row'
@@ -31,6 +32,10 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
 
   // Resolve vendor_part entity definition ID
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
+  // The tab is gated on READ of vendor_part (drawer config `recordResource`);
+  // adding one additionally needs WRITE.
+  const { canEditEntity } = useAccess()
+  const canCreate = !!vendorPartDefId && canEditEntity(vendorPartDefId)
 
   // Filter vendor parts by parent part
   const filters: ConditionGroup[] = useMemo(
@@ -132,10 +137,12 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
         title={`Suppliers (${records.length})`}
         initialOpen
         actions={
-          <Button variant='ghost' size='xs' onClick={() => setIsVendorDialogOpen(true)}>
-            <Store />
-            Add Supplier
-          </Button>
+          canCreate ? (
+            <Button variant='ghost' size='xs' onClick={() => setIsVendorDialogOpen(true)}>
+              <Store />
+              Add Supplier
+            </Button>
+          ) : undefined
         }>
         {records.length === 0 ? (
           <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>

--- a/apps/web/src/components/fields/inputs/relationship-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/relationship-input-field.tsx
@@ -37,7 +37,7 @@ import { usePropertyContext } from '../property-provider'
 export function RelationshipInputField() {
   const { value, field, commitValue, onBeforeClose, recordId } = usePropertyContext()
   const nav = useFieldNavigationOptional()
-  const { canViewEntity } = useAccess()
+  const { canViewEntity, canEditEntity } = useAccess()
 
   const relationship = field.options?.relationship as RelationshipConfig | undefined
   const isSingleSelect = isSingleRelationship(relationship?.relationshipType)
@@ -105,8 +105,11 @@ export function RelationshipInputField() {
   // Dialog state for inline create
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
 
-  // Only custom resources support inline create (system resources have dedicated flows)
-  const canInlineCreate = true
+  // Inline create writes a record of the TARGET definition, so it needs write on
+  // that def — not on the record being edited. Picking an existing target only
+  // needs read (the `canViewEntity` gate below), so a `ticket: Read` member keeps
+  // the picker and loses "Create Ticket" inside it.
+  const canInlineCreate = canEditEntity(relatedEntityDefinitionId)
 
   // Convert field value to RecordId[] for RecordPicker
   const currentRecordIds = useMemo<RecordId[]>(() => {

--- a/apps/web/src/components/resources/hooks/index.ts
+++ b/apps/web/src/components/resources/hooks/index.ts
@@ -34,6 +34,7 @@ export { useRecordHydration } from './use-record-hydration'
 export { useRecordInvalidation } from './use-record-invalidation'
 // Record store hooks
 export { useRecordList } from './use-record-list'
+export { useCanViewRecordResource } from './use-record-resource-gate'
 export { useRecords } from './use-records'
 export { useRelationship } from './use-relationship'
 // Entity ID resolution hooks

--- a/apps/web/src/components/resources/hooks/use-record-resource-gate.ts
+++ b/apps/web/src/components/resources/hooks/use-record-resource-gate.ts
@@ -1,0 +1,37 @@
+// apps/web/src/components/resources/hooks/use-record-resource-gate.ts
+'use client'
+
+import { useCallback } from 'react'
+import { useAccess } from '~/providers/capabilities-provider'
+import { useResourceStore } from '../store/resource-store'
+
+/**
+ * Predicate behind the `recordResource` gate shared by drawer tabs, detail-view
+ * main tabs and overview/sidebar cards: a surface that LISTS another
+ * definition's records is hidden when the viewer can't read that definition.
+ *
+ * A coarse `permissionKey` cannot express this — `records.view` is true for
+ * anyone holding any record access at all, so the gate has to be per-definition
+ * (Layer 3, `canViewEntity`). Same rule {@link useViewableResources} applies to
+ * the sidebar and pickers, applied to a single slug.
+ *
+ * Returns `true` for an undefined slug (the surface opts out of the gate) and
+ * `false` for a slug the resource store can't resolve — the store hydrates the
+ * whole catalog as one map, so an unresolved slug means the definition genuinely
+ * doesn't exist for this org. Fail closed.
+ *
+ * @returns `(resourceSlug?: string) => boolean` — pass the slug the surface lists.
+ */
+export function useCanViewRecordResource(): (resourceSlug?: string) => boolean {
+  const resourceMap = useResourceStore((s) => s.resourceMap)
+  const { canViewEntity } = useAccess()
+
+  return useCallback(
+    (resourceSlug?: string) => {
+      if (!resourceSlug) return true
+      const defId = resourceMap.get(resourceSlug)?.entityDefinitionId
+      return defId ? canViewEntity(defId) : false
+    },
+    [resourceMap, canViewEntity]
+  )
+}

--- a/apps/web/src/components/resources/index.ts
+++ b/apps/web/src/components/resources/index.ts
@@ -4,6 +4,8 @@
 export {
   // Types
   type FieldInfo,
+  // Per-definition read gate for `recordResource` surfaces (tabs, cards)
+  useCanViewRecordResource,
   // Entity field values
   useEntityValues,
   useField,

--- a/packages/lib/src/resources/registry/detail-view-config-types.ts
+++ b/packages/lib/src/resources/registry/detail-view-config-types.ts
@@ -16,6 +16,16 @@ export interface MainTabDefinition {
   /** Capability required to render the tab and mount its query-owning content. */
   permissionKey?: string
   /**
+   * Resource slug of the record type this tab LISTS (e.g. `ticket` for the
+   * contact page's Tickets tab) — the per-definition twin of `permissionKey`,
+   * which is too coarse here (`records.view` is true for anyone holding any
+   * record access). The tab is hidden when the viewer can't read that
+   * definition. See {@link DrawerTabDefinition.recordResource}; omit for tabs
+   * that also show the base record's OWN data (part Inventory mixes stock
+   * movements with the part's on-hand fields).
+   */
+  recordResource?: string
+  /**
    * Cancel the wrapping `<Section>`'s horizontal inset so the content (e.g. a
    * line-items table) spans edge-to-edge — the `sections` layout twin of the
    * drawer card's `fullBleed` (drawer-config-types.ts). Applies `-mx-3` to the

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -27,7 +27,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
   contact: {
     entityType: 'contact',
     mainTabs: [
-      { value: 'tickets', label: 'Tickets', icon: 'ticket' },
+      { value: 'tickets', label: 'Tickets', icon: 'ticket', recordResource: 'ticket' },
       // Client-notifications plan §4.8/Phase 4 — same communications timeline as the job
       // detail page, over `contact:<id>`.
       { value: 'communications', label: 'Communications', icon: 'mail' },
@@ -79,9 +79,12 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
   part: {
     entityType: 'part',
     mainTabs: [
+      // No `recordResource` on Inventory: it leads with the part's OWN on-hand
+      // quantity/status and only then lists stock movements, so the stock_movement
+      // gate belongs on its Adjust Stock action, not on the whole tab.
       { value: 'inventory', label: 'Inventory', icon: 'package' },
-      { value: 'subparts', label: 'Subparts', icon: 'layers' },
-      { value: 'vendors', label: 'Vendors', icon: 'store' },
+      { value: 'subparts', label: 'Subparts', icon: 'layers', recordResource: 'subpart' },
+      { value: 'vendors', label: 'Vendors', icon: 'store', recordResource: 'vendor_part' },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],
@@ -127,7 +130,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     sidebarCards: [
       { value: 'customer', label: 'Customer' },
       { value: 'origin', label: 'Origin' },
-      { value: 'jobs', label: 'Jobs' },
+      { value: 'jobs', label: 'Jobs', recordResource: 'work_order' },
     ],
   },
 

--- a/packages/lib/src/resources/registry/drawer-config-types.ts
+++ b/packages/lib/src/resources/registry/drawer-config-types.ts
@@ -13,6 +13,15 @@ export interface DrawerTabDefinition {
   icon: string
   /** Optional feature gate key — tab is hidden when the org lacks access */
   featureGate?: string
+  /**
+   * Resource slug of the record type this tab LISTS (e.g. `ticket` for the
+   * contact drawer's Tickets tab) — not the drawer's own entity type. The tab is
+   * hidden when the viewer can't read that definition (Layer 3 `canViewEntity`),
+   * the same enumeration rule `useViewableResources` applies to the sidebar and
+   * pickers. Omit for tabs that don't list another definition's records (mail
+   * conversations, which are governed by the thread visibility lens instead).
+   */
+  recordResource?: string
 }
 
 /**
@@ -48,6 +57,14 @@ export interface DrawerTabCardDefinition {
    * empty section renders before the query 403s.
    */
   permissionKey?: string
+  /**
+   * Resource slug of the record type this card LISTS — the per-definition twin
+   * of `permissionKey`, applied the same way (whole section hidden). Set it only
+   * for cards that are purely another definition's records; cards showing the
+   * base record's own relationship values (`customer`, `origin`) are left alone,
+   * since the server already redacts an unreadable target.
+   */
+  recordResource?: string
   /**
    * Render the card edge-to-edge by cancelling the wrapping Section's horizontal
    * padding (and bottom gap). Use for full-bleed strips like the metrics grid.

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -15,7 +15,7 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
   contact: {
     entityType: 'contact',
     additionalTabs: [
-      { value: 'tickets', label: 'Tickets', icon: 'ticket' },
+      { value: 'tickets', label: 'Tickets', icon: 'ticket', recordResource: 'ticket' },
       { value: 'conversations', label: 'Conversations', icon: 'mail' },
     ],
     actions: {
@@ -38,7 +38,9 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
 
   company: {
     entityType: 'company',
-    additionalTabs: [{ value: 'parts', label: 'Parts', icon: 'package' }],
+    additionalTabs: [
+      { value: 'parts', label: 'Parts', icon: 'package', recordResource: 'vendor_part' },
+    ],
     actions: {
       enableArchive: true,
       enableDelete: true,
@@ -68,8 +70,8 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
   part: {
     entityType: 'part',
     additionalTabs: [
-      { value: 'subparts', label: 'Subparts', icon: 'layers' },
-      { value: 'vendors', label: 'Suppliers', icon: 'truck' },
+      { value: 'subparts', label: 'Subparts', icon: 'layers', recordResource: 'subpart' },
+      { value: 'vendors', label: 'Suppliers', icon: 'truck', recordResource: 'vendor_part' },
     ],
     actions: {
       enableArchive: true,
@@ -92,8 +94,13 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     // from the Details field panel (showInPanel:false) so they only appear here.
     tabCards: {
       overview: [
-        { value: 'work-orders', label: 'Work orders', icon: 'wrench' },
-        { value: 'quotes', label: 'Quotes', icon: 'file-text' },
+        {
+          value: 'work-orders',
+          label: 'Work orders',
+          icon: 'wrench',
+          recordResource: 'work_order',
+        },
+        { value: 'quotes', label: 'Quotes', icon: 'file-text', recordResource: 'quote' },
       ],
     },
   },
@@ -155,7 +162,7 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
         },
         { value: 'customer', label: 'Customer' },
         { value: 'origin', label: 'Origin' },
-        { value: 'jobs', label: 'Jobs' },
+        { value: 'jobs', label: 'Jobs', recordResource: 'work_order' },
         // Deposit visibility (deposit-accounting plan 16 §D.5) — the card itself renders
         // null when the quote has no deposit charge, so this stays in the list unconditionally.
         { value: 'deposit', label: 'Deposit', permissionKey: 'dispatch.board.view' },


### PR DESCRIPTION
## The bug

Found in the permissions v2 browser pass. With `contacts: Read` and `tickets: None`:

- the **contact drawer** still rendered a Tickets tab, and inside it a **Create Ticket** button;
- on the **contact detail page** `tickets` is the `defaultTab`, so the member *landed* on an always-empty tab.

The list itself was correct (server-filtered to zero rows) — the symptom was an empty tab fronting a write affordance.

## Why `permissionKey` wasn't the fix

`DrawerTabCardDefinition` and `MainTabDefinition` already had `permissionKey`, and both card surfaces already filtered on it. But `records.view` is true for anyone holding *any* record access, so a coarse key can't express "can this member read the **ticket** definition". The gate has to be per-def (Layer 3, `canViewEntity`).

Adds **`recordResource`** — the resource slug the surface *lists*, not the host record's own type — to `DrawerTabDefinition`, `MainTabDefinition` and `DrawerTabCardDefinition`, resolved through one shared `useCanViewRecordResource` hook. It fails closed on an unresolved slug: the resource store hydrates the whole catalog as one map, so an unresolved slug means the def doesn't exist for the org.

Wired on `contact → tickets`, `company → parts`, `part → subparts`/`vendors`, `service_request → work-orders`/`quotes`, `quote → jobs`.

## Hiding the tab isn't sufficient

A `tickets: Read` member legitimately keeps the tab and still got every create/edit/delete affordance. Those now gate on `canEditEntity` of the **listed** def — not the drawer's `readOnly`, which is about the base record:

- both Create Ticket buttons **and** the `RecordEditorDialog` itself
- the three manufacturing Add buttons and the row action menus (each row derives its own def from `parseRecordId`)
- part Inventory's **Adjust Stock**, and the quote Jobs card's **Create job**
- `relationship-input-field.tsx` had a hardcoded `const canInlineCreate = true` (with a stale comment claiming only custom resources support it) — so **every relationship picker in the app** offered "Create &lt;Target&gt;" regardless of write access on the target def. Now `canEditEntity(relatedEntityDefinitionId)`. Its read gate was already correct.

## Two structural fixes riding along

- `base-entity-drawer.tsx` filtered `additionalTabs` **twice** with duplicated predicates (strip + `TabsContent`) that could drift — one `visibleAdditionalTabs` memo now feeds both, so a gated-out tab has no mountable content either.
- A `?tab=` naming a hidden tab rendered a **blank body** (already true for `comments` in restricted mode). Now falls back to the first visible tab — computed **locally and never written back to the URL**, because every frame of the peek stack shares that one query param and a write would clobber the frame underneath. The detail page's equivalent fallback already existed.

## Deliberately out of scope

- **Mail tabs** (`contact:conversations`, `ticket:conversation`) are governed by the thread visibility lens, not `canViewEntity` — no `recordResource`, compose buttons still ungated. Separate call.
- **`part:inventory`** gets no `recordResource`: it leads with the part's own on-hand quantity and only then lists `stock_movement`, so the gate went on its Adjust Stock action instead of the whole tab.
- **`customer` / `origin` / `customer-site` cards** render the base record's own relationship values, which the server already redacts. Hiding the whole card there is a product call, not an enforcement one.
- The **dispatch/money card family** sits behind `dispatch.board.view` and has its own permission story.

## Verification

- Slugs are `EntityDefinition.entityType` values, checked against `seed/entity-seeder/constants.ts` (`ticket`, `subpart`, `vendor_part`, `stock_movement`, `work_order`, `quote`) — not apiSlugs (`work-orders`), though `resourceMap` is keyed by both.
- Biome clean. `tsc` on `apps/web` and `packages/lib` shows nothing new on the touched lines (the hits in these files are the known pre-existing baseline).
- **No tests**: there is no test file anywhere under `components/drawers`, so this would be a new harness rather than a backfill. Happy to add one for the two filters if wanted.
- Browser pass on the reported repro still owed.