### PR TITLE
feat(permissions): add per-agent instance access

### DIFF
--- a/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
@@ -64,7 +64,11 @@ export default function AgentDetailPage() {
   const { hasAccess } = useFeatureFlags()
   const { can } = useAccess()
 
-  if (!hasAccess(FeatureKey.agents) || !can('agents.manage')) {
+  // `agents.view` — the coarse "is there an agents surface for me" gate. The
+  // per-agent answer is enforced server-side by `agent.getById`, which asserts
+  // instance access on the RESOLVED id; a member restricted from THIS agent
+  // falls through to the not-found state below rather than this lock screen.
+  if (!hasAccess(FeatureKey.agents) || !can('agents.view')) {
     return (
       <MainPage>
         <MainPageHeader>
@@ -75,7 +79,7 @@ export default function AgentDetailPage() {
         </MainPageHeader>
         <MainPageNoPermission
           title='Agents Not Available'
-          description='Agents require the agents feature on your plan and permission to manage agents.'
+          description='Agents require the agents feature on your plan and permission to use agents.'
         />
       </MainPage>
     )

--- a/apps/web/src/app/(protected)/app/agents/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/page.tsx
@@ -20,7 +20,13 @@ export default function AgentsPage() {
   const { hasAccess } = useFeatureFlags()
   const { can } = useAccess()
 
-  if (!hasAccess(FeatureKey.agents) || !can('agents.manage')) {
+  // `agents.view`, NOT `agents.manage` (plan 25 §4.2.DECIDED): `view` is the
+  // *usable* rung, and this is the "can I get in at all" gate. Gating the
+  // landing page on the authoring key leaves a member holding view/edit — or
+  // one single shared agent — staring at a lock screen. #1346 shipped exactly
+  // that bug for workflows. Creating an agent is still `agents.manage`; that
+  // gate lives on `CreateAgentButton`.
+  if (!hasAccess(FeatureKey.agents) || !can('agents.view')) {
     return (
       <MainPage>
         <MainPageHeader>
@@ -33,7 +39,7 @@ export default function AgentsPage() {
           <EmptyState
             icon={Lock}
             title='Agents Not Available'
-            description='Agents require the agents feature on your plan and permission to manage agents.'
+            description='Agents require the agents feature on your plan and permission to use agents.'
             button={<div className='h-12' />}
           />
         </MainPageContent>

--- a/apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
+++ b/apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
@@ -1,6 +1,13 @@
 // apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
 
-import { Area, expandLevelsToKeys, Level, type PermissionKey } from '@auxx/lib/permissions/client'
+import { ResourcePermission } from '@auxx/database/enums'
+import {
+  Area,
+  expandLevelsToKeys,
+  Level,
+  type PermissionKey,
+  PermissionKey as PermissionKeyEnum,
+} from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -8,23 +15,38 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * scoped the run by organization, but read no capabilities — so any
  * authenticated member could replay any eval run's full trace (agent messages,
  * tool calls, assertion verdicts) while every `eval.*` tRPC procedure sits
- * behind `permissionProcedure(agentsManage)`.
+ * behind a capability gate.
  *
  * Behavioral: the real handler runs, with a REAL `CapabilitySet`. The DB read
- * is the observed side effect — the gate must land ahead of it.
+ * is the observed side effect — the coarse gate must land ahead of it.
+ *
+ * **The fake distinguishes tables on purpose.** The original version stubbed
+ * `from()` as a table-blind passthrough, so every query in the handler returned
+ * the same row. That made all four tests pass against a handler that never ran
+ * its per-agent check at all: the run row carried no `caseId`, so it always took
+ * the orphan branch. A fake that models the return value but not the REQUEST
+ * cannot fail on the request — the same lesson `grantee-access.test.ts` records
+ * for `fakeDb`'s invisible WHERE clause.
  */
 
-const { getCapabilities, getSession, limit } = vi.hoisted(() => ({
+const { getCapabilities, getSession, selectFrom } = vi.hoisted(() => ({
   getCapabilities: vi.fn(),
   getSession: vi.fn(),
-  limit: vi.fn(async () => [] as unknown[]),
+  // table name -> rows. Set per test; an unset table yields [].
+  selectFrom: vi.fn((_table: string) => [] as unknown[]),
 }))
 
 vi.mock('@auxx/database', () => ({
   database: {
-    select: () => ({ from: () => ({ where: () => ({ limit }) }) }),
+    select: () => ({
+      from: (table: string) => ({ where: () => ({ limit: async () => selectFrom(table) }) }),
+    }),
   },
-  schema: { EvalRun: { id: 'id', organizationId: 'organizationId' } },
+  schema: {
+    EvalRun: { id: 'id', organizationId: 'organizationId' },
+    EvalCase: { id: 'id', organizationId: 'organizationId', agentId: 'agentId' },
+    EvalSuiteRun: { id: 'id', organizationId: 'organizationId', agentId: 'agentId' },
+  },
 }))
 
 vi.mock('drizzle-orm', () => ({ and: vi.fn(), eq: vi.fn() }))
@@ -51,15 +73,41 @@ const { GET } = await import('./route')
 const ORG_ID = 'org_cuid000000000000000000000'
 const USER_ID = 'usr_cuid000000000000000000000'
 const RUN_ID = 'evr_cuid000000000000000000000'
+const CASE_ID = 'evc_cuid000000000000000000000'
+const SUITE_RUN_ID = 'esr_cuid000000000000000000000'
+const AGENT_ID = 'agt_cuid000000000000000000000'
 
-function signedIn(agentsLevel: Level) {
+/**
+ * @param agentsLevel the member's composed `Area.agents` level
+ * @param instance an explicit `ResourceAccess` row on {@link AGENT_ID}, or none.
+ *   `instanceAccess` is keyed by bare instance id and `restrictedInstanceIds`
+ *   marks which ids carry an explicit row — both are needed, or the row is
+ *   invisible to `effectiveInstanceLevel`.
+ */
+function signedIn(agentsLevel: Level, instance?: ResourcePermission) {
   getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
+  // Item 5b: a grant that reaches `view` synthesizes the area's Read rung into
+  // `instanceDerivedKeys`, which is what lets a member composing `agents: None`
+  // past a coarse `agents.view` front door at all. `computeUserCapabilities`
+  // does this in production, so a harness that omits it would report a 403 the
+  // real system never returns.
+  const derived =
+    instance !== undefined && instance !== ResourcePermission.none
+      ? new Set([PermissionKeyEnum.agentsView])
+      : new Set<PermissionKey>()
   getCapabilities.mockResolvedValue(
     new CapabilitySet(
       new Set(expandLevelsToKeys({ [Area.agents]: agentsLevel }) as PermissionKey[]),
       {},
       'MEMBER',
-      'full'
+      'full',
+      (id) => id,
+      new Set(),
+      (id) => id,
+      instance === undefined ? {} : { [AGENT_ID]: instance },
+      instance === undefined ? new Set() : new Set([AGENT_ID]),
+      {},
+      derived
     )
   )
 }
@@ -73,44 +121,112 @@ const request = () =>
 
 const params = { params: Promise.resolve({ runId: RUN_ID }) }
 
+/**
+ * Wire the three tables the handler reads.
+ *
+ * `caseAgentId` and `suiteAgentId` are INDEPENDENT so the case→suite fallback
+ * can actually be exercised. An earlier version drove both from one flag, which
+ * meant the "falls back to the suite run" test never took the suite branch at
+ * all — deleting that branch outright left the whole file green.
+ */
+function withRun(
+  opts: {
+    caseId?: string | null
+    suiteRunId?: string | null
+    caseAgentId?: string | null
+    suiteAgentId?: string | null
+  } = {}
+) {
+  const {
+    caseId = CASE_ID,
+    suiteRunId = SUITE_RUN_ID,
+    caseAgentId = AGENT_ID,
+    suiteAgentId = AGENT_ID,
+  } = opts
+  selectFrom.mockImplementation((table: unknown) => {
+    // The mocked `schema` entries are objects; identify them by reference.
+    if (table === mockedSchema.EvalRun) {
+      return [{ id: RUN_ID, status: 'passed', trace: [], assertionResults: [], caseId, suiteRunId }]
+    }
+    if (table === mockedSchema.EvalCase) return caseAgentId ? [{ agentId: caseAgentId }] : []
+    if (table === mockedSchema.EvalSuiteRun) return suiteAgentId ? [{ agentId: suiteAgentId }] : []
+    return []
+  })
+}
+
+const { schema: mockedSchema } = await import('@auxx/database')
+
 beforeEach(() => {
   getSession.mockReset()
   getCapabilities.mockReset()
-  limit
-    .mockReset()
-    .mockResolvedValue([{ id: RUN_ID, status: 'passed', trace: [], assertionResults: [] }])
+  selectFrom.mockReset()
+  withRun()
 })
 
-describe('GET /api/eval/run/[runId]/events', () => {
+describe('GET /api/eval/run/[runId]/events — coarse gate', () => {
   it('401s without a session', async () => {
     getSession.mockResolvedValue(null)
     const res = await GET(request(), params)
     expect(res.status).toBe(401)
-    expect(limit).not.toHaveBeenCalled()
+    expect(selectFrom).not.toHaveBeenCalled()
   })
 
-  it('403s a member without agents.manage before touching the run', async () => {
+  it('403s a member without agents.view before touching the run', async () => {
     signedIn(Level.None)
     const res = await GET(request(), params)
     expect(res.status).toBe(403)
     // The gate must precede the DB read — otherwise existence is still probeable.
-    expect(limit).not.toHaveBeenCalled()
-  })
-
-  it('streams the run for a member holding agents.manage', async () => {
-    signedIn(Level.Full)
-    const res = await GET(request(), params)
-    expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
-    expect(limit).toHaveBeenCalledTimes(1)
-    const body = await res.text()
-    expect(body).toContain('connected')
+    expect(selectFrom).not.toHaveBeenCalled()
   })
 
   it('404s an unknown run for an authorized member', async () => {
     signedIn(Level.Full)
-    limit.mockResolvedValueOnce([])
+    selectFrom.mockImplementation(() => [])
     const res = await GET(request(), params)
     expect(res.status).toBe(404)
+  })
+})
+
+describe('GET /api/eval/run/[runId]/events — per-agent access', () => {
+  it('streams a run whose agent the member may view', async () => {
+    signedIn(Level.Read)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(await res.text()).toContain('connected')
+  })
+
+  it('403s a member restricted on THAT agent, even holding the whole area', async () => {
+    // The exact bypass the per-instance check exists for: `agents: Full` is the
+    // top rung, and an explicit `none` row must still win.
+    signedIn(Level.Full, ResourcePermission.none)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+  })
+
+  it('streams for a member with agents: None plus an explicit grant on that agent', async () => {
+    // Plan 25 §2: an explicit instance row outranks a closed area floor.
+    signedIn(Level.None, ResourcePermission.view)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+  })
+
+  it('falls back to the SUITE RUN when the case no longer names an agent', async () => {
+    // `EvalCase.agentId` is nullable and the case row itself may be gone; the
+    // suite run still knows which agent ran. This must resolve to a real agent
+    // — not to the orphan branch — so a restriction on that agent still binds.
+    withRun({ caseAgentId: null, suiteAgentId: AGENT_ID })
+    signedIn(Level.Full, ResourcePermission.none)
+    expect((await GET(request(), params)).status).toBe(403)
+    signedIn(Level.None, ResourcePermission.view)
+    expect((await GET(request(), params)).status).toBe(200)
+  })
+
+  it('requires the top rung for an orphaned run with no agent to judge', async () => {
+    withRun({ caseId: null, suiteRunId: null, caseAgentId: null, suiteAgentId: null })
+    signedIn(Level.Edit)
+    expect((await GET(request(), params)).status).toBe(403)
+    signedIn(Level.Full)
+    expect((await GET(request(), params)).status).toBe(200)
   })
 })

--- a/apps/web/src/app/api/eval/run/[runId]/events/route.ts
+++ b/apps/web/src/app/api/eval/run/[runId]/events/route.ts
@@ -27,6 +27,47 @@ type EvalRunEvent =
   | { type: 'status'; status: string; assertionResults?: AssertionResult[] }
   | { type: 'done' }
 
+/**
+ * Which agent an eval run exercised, or `null` when the run is orphaned.
+ *
+ * Tries the case link first (`EvalCase.agentId` is denormalized from `target`
+ * precisely so the hot path need not join), then the suite run. Both columns are
+ * nullable, so `null` genuinely means "no agent to judge this against" rather
+ * than "lookup failed".
+ */
+async function resolveEvalRunAgentId(
+  caseId: string | null,
+  suiteRunId: string | null,
+  organizationId: string
+): Promise<string | null> {
+  if (caseId) {
+    const [row] = await db
+      .select({ agentId: schema.EvalCase.agentId })
+      .from(schema.EvalCase)
+      .where(
+        and(eq(schema.EvalCase.id, caseId), eq(schema.EvalCase.organizationId, organizationId))
+      )
+      .limit(1)
+    if (row?.agentId) return row.agentId
+  }
+
+  if (suiteRunId) {
+    const [row] = await db
+      .select({ agentId: schema.EvalSuiteRun.agentId })
+      .from(schema.EvalSuiteRun)
+      .where(
+        and(
+          eq(schema.EvalSuiteRun.id, suiteRunId),
+          eq(schema.EvalSuiteRun.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+    if (row?.agentId) return row.agentId
+  }
+
+  return null
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ runId: string }> }
@@ -44,14 +85,14 @@ export async function GET(
   // with `getSession` and scoped by org, but read no capabilities — so any
   // authenticated member could replay an eval run's full trace (agent messages,
   // tool calls, assertion verdicts) while every `eval.*` tRPC procedure sits
-  // behind `permissionProcedure(agentsManage)`.
+  // behind a capability gate.
   //
   // Capability only, deliberately: `evalManageProcedure` also plan-ANDs
   // `agentProcedures`, but this is a read-only RECONNECT stream for a run that
   // was already started behind that gate, and failing a live reconnect on a
   // mid-run plan change would be worse than the gap it closes.
   const capabilities = await getCapabilities(session.user.id, organizationId)
-  if (!capabilities.can(PermissionKey.agentsManage)) {
+  if (!capabilities.can(PermissionKey.agentsView)) {
     return new Response('Forbidden', { status: 403 })
   }
 
@@ -61,6 +102,29 @@ export async function GET(
     .where(and(eq(schema.EvalRun.id, runId), eq(schema.EvalRun.organizationId, organizationId)))
     .limit(1)
   if (!run) return new Response('Eval run not found', { status: 404 })
+
+  // Per-agent access (plan 25 §4.2). The coarse key above answers "may this
+  // member reach evals at all", never "may they replay THIS agent's run" — the
+  // standing "requirePermission is coarse-key only" trap. Reading an eval trace
+  // is a `view`-tier read of the agent it exercised.
+  //
+  // `EvalRun` carries no `agentId` of its own; it hangs off a case or a suite
+  // run, and BOTH links are nullable (`onDelete: 'set null'` — deleting a case
+  // keeps its runs by the history-retention policy). An ORPHANED run therefore
+  // has no agent to judge, so it falls back to the area's top rung rather than
+  // being waved through: same shape as #1345, where a workflow run with no
+  // resolvable owner needs `edit` instead of the owner short-circuit.
+  const agentId = await resolveEvalRunAgentId(run.caseId, run.suiteRunId, organizationId)
+  if (agentId === null) {
+    if (!capabilities.can(PermissionKey.agentsManage)) {
+      return new Response('Forbidden', { status: 403 })
+    }
+  } else if (!capabilities.canViewInstance('agent', agentId)) {
+    // `canViewInstance`, not `assertViewInstance`: App Router route handlers have
+    // no `auxxErrorMiddleware`, so a thrown `AuxxError` would surface as a 500
+    // rather than this 403.
+    return new Response('Forbidden', { status: 403 })
+  }
 
   // Resume point: `Last-Event-ID` (our trace sequence) or `?afterSequence=`.
   const lastEventId = request.headers.get('last-event-id')

--- a/apps/web/src/app/api/kopilot/stream/agent-access.test.ts
+++ b/apps/web/src/app/api/kopilot/stream/agent-access.test.ts
@@ -1,10 +1,12 @@
 // apps/web/src/app/api/kopilot/stream/agent-access.test.ts
 
+import { ResourcePermission } from '@auxx/database/enums'
 import {
   Area,
   expandLevelsToKeys,
   FeatureKey,
   Level,
+  PermissionKey,
   type PermissionKey as PermissionKeyType,
 } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -29,6 +31,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * `body.agentId` before the stream opens (plain 403), while a CONTINUATION turn
  * restores its agent from the SESSION ROW and is authorized inside the stream
  * (`turn-error` / `forbidden`). Deleting either arm reopens the hole.
+ *
+ * **Permissions v2 item 4 (plan 25 §4.2) then made the gate agent-ID-AWARE.**
+ * The coarse rung dropped from `agents.manage` to the new `agents.view` (chat is
+ * USE, not authoring), and `assertViewInstance('agent', id)` joined it on the
+ * resolved id. Three things below exist only for that:
+ *  - a member at `agents: Full` restricted from ONE agent is refused it;
+ *  - a member at `agents: None` holding ONE explicit grant reaches exactly it;
+ *  - a SLUG in `body.agentId` is resolved to the real `Agent.id` before the
+ *    assert, or the row lookup misses and the area level lets them straight in.
+ * The status code is asserted on every denial, not merely "it didn't run": the
+ * `assert*Instance` helpers THROW `AuxxError`, and this is an App Router handler
+ * with no `auxxErrorMiddleware` to map it — an escaping throw is a 500.
  */
 
 const {
@@ -36,6 +50,7 @@ const {
   getSession,
   hasFeature,
   getCachedAgentById,
+  getAllCachedAgents,
   createSession,
   getSessionById,
   runTurn,
@@ -45,6 +60,14 @@ const {
   getSession: vi.fn(),
   hasFeature: vi.fn(),
   getCachedAgentById: vi.fn(),
+  /**
+   * `resolveAgentId`'s only input — the org agents cache. Returning a row with
+   * BOTH an id and a slug is what makes the "addressed by slug" case meaningful:
+   * a resolver that handed the raw input straight through would look up a
+   * `ResourceAccess` row keyed on the slug, find none, and fall back to the area
+   * level.
+   */
+  getAllCachedAgents: vi.fn(),
   createSession: vi.fn(),
   getSessionById: vi.fn(),
   /**
@@ -86,12 +109,15 @@ vi.mock('@auxx/lib/permissions', async () => {
 
 vi.mock('@auxx/lib/cache', () => ({
   getCachedAgentById,
+  getAllCachedAgents,
   getCachedDefaultModel: vi.fn(async () => null),
 }))
 
-vi.mock('@auxx/lib/errors', () => ({
-  ForbiddenError: class ForbiddenError extends Error {},
-}))
+// NOT stubbed any more. `agent-instance-access` throws the real `NotFoundError`
+// and `CapabilitySet.assertViewInstance` the real `ForbiddenError`, and the
+// route's `error instanceof AuxxError` catch is what keeps those from escaping
+// as a 500 — a hand-rolled stub class would make that catch pass vacuously.
+// `@auxx/lib/errors` is a dependency-free leaf, so importing it is safe here.
 
 vi.mock('@auxx/lib/members', () => ({ isAdminOrOwner }))
 
@@ -179,15 +205,35 @@ const { POST } = await import('./route')
 const ORG_ID = 'org_cuid000000000000000000000'
 const USER_ID = 'usr_cuid000000000000000000000'
 const AGENT_ID = 'agt_cuid000000000000000000000'
+const AGENT_SLUG = 'escalation-lead'
 const SESSION_ID = 'ses_cuid000000000000000000000'
 
-/** A real `CapabilitySet` composed from one area level, exactly as the composer does. */
-function capabilitiesWith(agentsLevel: Level) {
+/**
+ * A real `CapabilitySet` composed from one area level, exactly as the composer
+ * does.
+ *
+ * `instances` adds explicit `ResourceAccess` instance rows (what the share
+ * dialog writes) and, with them, the derived Read rung
+ * `composeUserCapabilities` synthesizes for any member holding a ≥`view` grant —
+ * without it an `agents: None` grantee would be refused at the coarse front door
+ * and the `include` regime would be untestable.
+ */
+function capabilitiesWith(agentsLevel: Level, instances: Record<string, ResourcePermission> = {}) {
+  const derived = Object.values(instances).some((p) => p !== ResourcePermission.none)
+    ? [PermissionKey.agentsView]
+    : []
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.agents]: agentsLevel }) as PermissionKeyType[]),
     {},
     'MEMBER',
-    'full'
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived as PermissionKeyType[])
   )
 }
 
@@ -197,11 +243,11 @@ function capabilitiesWith(agentsLevel: Level) {
  * a restricted profile, or any worker seat (`agents` is absent from
  * `WORKER_AREAS`, so `SEAT_CEILINGS.worker` clamps it to None).
  */
-function signedIn(agentsLevel: Level) {
+function signedIn(agentsLevel: Level, instances: Record<string, ResourcePermission> = {}) {
   getSession.mockResolvedValue({
     user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
   })
-  getCapabilities.mockResolvedValue(capabilitiesWith(agentsLevel))
+  getCapabilities.mockResolvedValue(capabilitiesWith(agentsLevel, instances))
 }
 
 /** The session row a continuation turn restores its agent from. */
@@ -224,6 +270,7 @@ beforeEach(() => {
   getSession.mockReset()
   getCapabilities.mockReset()
   getCachedAgentById.mockReset().mockResolvedValue({ id: AGENT_ID, dmEnabled: true })
+  getAllCachedAgents.mockReset().mockResolvedValue([{ id: AGENT_ID, slug: AGENT_SLUG }])
   getSessionById.mockReset()
   createSession.mockReset().mockResolvedValue({
     isErr: () => false,
@@ -254,7 +301,7 @@ describe('POST /api/kopilot/stream — new session binds body.agentId', () => {
     expect(runTurn).toHaveBeenCalledTimes(1)
   })
 
-  it('403s a member without agents.manage — THE hole', async () => {
+  it('403s a member with the agents area shut — THE hole', async () => {
     // Before the fix this member got a full agent turn.
     signedIn(Level.None)
     const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
@@ -351,9 +398,9 @@ describe('POST /api/kopilot/stream — continuation turns restore the agent from
 })
 
 describe('POST /api/kopilot/stream — sessions with no agent in play', () => {
-  it('runs a plain Kopilot session for a member without agents.manage', async () => {
-    // The gate must not leak onto master Kopilot: `agentsManage` fronts agent
-    // AUTHORING, and plain Kopilot is the human alone.
+  it('runs a plain Kopilot session for a member with the agents area shut', async () => {
+    // The gate must not leak onto master Kopilot: the `agents` area fronts the
+    // agent feature, and plain Kopilot is the human alone.
     signedIn(Level.None)
     const res = await POST(request({ message: 'hi' }))
     expect(res.status).toBe(200)
@@ -398,10 +445,11 @@ describe('POST /api/kopilot/stream — builder sessions', () => {
     expect(runTurn).toHaveBeenCalledTimes(1)
   })
 
-  it('403s a builder session for a member without agents.manage', async () => {
-    // Deliberate: a builder session's agent is the SUBJECT OF EDITING, which is
-    // exactly what `agentsManage` fronts. The page hosting it is already
-    // capability-gated client-side, so no legitimate session loses anything.
+  it('403s a builder session for a member with the agents area shut', async () => {
+    // Deliberate: a builder session's agent is the SUBJECT OF EDITING, and
+    // `view` is the floor for touching it at all (each authoring tool re-asserts
+    // its own Edit/Full rung). The page hosting it is already capability-gated
+    // client-side, so no legitimate session loses anything.
     signedIn(Level.None)
     const res = await POST(request({ message: 'build', agentId: AGENT_ID, sessionType: 'builder' }))
     expect(res.status).toBe(403)
@@ -415,5 +463,147 @@ describe('POST /api/kopilot/stream — builder sessions', () => {
     const body = await res.text()
     expect(body).toContain('forbidden')
     expect(runTurn).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/kopilot/stream — the coarse rung is agents.view, not agents.manage', () => {
+  it('a member at agents: Read may chat', async () => {
+    // The re-point (permissions v2 item 4). Chatting is USING the agent; under
+    // the old `agentsManage` gate this member — the ordinary read-only seat the
+    // View rung was created for — got a 403.
+    signedIn(Level.Read)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(200)
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('a member at agents: Edit may chat', async () => {
+    signedIn(Level.Edit)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(200)
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('POST /api/kopilot/stream — per-agent instance access (plan 25 §4.2)', () => {
+  const OTHER_AGENT_ID = 'agt_othercuid00000000000000'
+
+  it('403s an agent restricted to `none` under an OPEN agents area', async () => {
+    // The `exclude` regime: the member administers agents generally, and one
+    // agent carries an explicit `none` row for them. The coarse rung passes, so
+    // only the per-instance assert can refuse this.
+    signedIn(Level.Full, { [AGENT_ID]: ResourcePermission.none })
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    // The status code, not merely "it didn't run": `assertViewInstance` throws
+    // `AuxxError`, and this route has no `auxxErrorMiddleware`. An uncaught
+    // throw here is a 500 while still satisfying every `not.toHaveBeenCalled`.
+    expect(res.status).toBe(403)
+    expect(res.headers.get('Content-Type')).not.toBe('text/event-stream')
+    expect(createSession).not.toHaveBeenCalled()
+    expect(runTurn).not.toHaveBeenCalled()
+  })
+
+  it('lets the same member through to an agent they are NOT restricted from', async () => {
+    signedIn(Level.Full, { [OTHER_AGENT_ID]: ResourcePermission.none })
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(200)
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('a member at agents: None reaches exactly the ONE agent shared with them', async () => {
+    // The `include` regime — an explicit instance row beats the closed area
+    // floor (plan 25 §2), and the derived Read rung is what gets them past the
+    // coarse gate to find out.
+    signedIn(Level.None, { [AGENT_ID]: ResourcePermission.view })
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(200)
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('and reaches nothing else', async () => {
+    signedIn(Level.None, { [AGENT_ID]: ResourcePermission.view })
+    getAllCachedAgents.mockResolvedValue([
+      { id: AGENT_ID, slug: AGENT_SLUG },
+      { id: OTHER_AGENT_ID, slug: 'other-agent' },
+    ])
+    const res = await POST(request({ message: 'hi', agentId: OTHER_AGENT_ID }))
+    expect(res.status).toBe(403)
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('resolves a SLUG before asserting — a restricted agent stays restricted', async () => {
+    // `agentId` arrives verbatim on the body and the agent detail page routes by
+    // slug. `assertViewInstance('agent', 'escalation-lead')` finds no
+    // `ResourceAccess` row (they key on `Agent.id`), falls back to the area
+    // level — `Full` here — and hands the agent over. Only the resolve stops it.
+    signedIn(Level.Full, { [AGENT_ID]: ResourcePermission.none })
+    const res = await POST(request({ message: 'hi', agentId: AGENT_SLUG }))
+    expect(res.status).toBe(403)
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('an agent id from another org is refused, not 500ed', async () => {
+    // `resolveAgentId` throws `NotFoundError` — an `AuxxError` like any other,
+    // and uncaught it would escape this handler as a 500. Collapsed into the
+    // same denial as a restriction so the endpoint cannot be used to enumerate.
+    signedIn(Level.Full)
+    const res = await POST(request({ message: 'hi', agentId: 'agt_fromanotherorg0000000000' }))
+    expect(res.status).toBe(403)
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('refuses a CONTINUATION turn on a restricted agent', async () => {
+    // The half that matters after turn 1: `sessionAgentId` comes off the session
+    // ROW, so a member restricted from an agent AFTER the session was opened
+    // must lose it on the next send.
+    signedIn(Level.Full, { [AGENT_ID]: ResourcePermission.none })
+    existingSession(AGENT_ID)
+    const res = await POST(request({ message: 'again', sessionId: SESSION_ID }))
+    const body = await res.text()
+    expect(body).toContain('turn-error')
+    expect(body).toContain('forbidden')
+    expect(runTurn).not.toHaveBeenCalled()
+  })
+
+  it('the plan gate still fires ahead of the instance check', async () => {
+    // FeatureKey.agents is Layer 1 and outranks any Layer-2 grant: an org
+    // without the feature gets the plan message even for an agent the member
+    // holds an explicit `admin` row on.
+    signedIn(Level.Full, { [AGENT_ID]: ResourcePermission.admin })
+    hasFeature.mockImplementation(async (_org: string, key: string) => key !== FeatureKey.agents)
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(403)
+    await expect(res.text()).resolves.toContain('plan')
+    expect(getAllCachedAgents).not.toHaveBeenCalled()
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('an OWNER keeps every agent, restriction row or not', async () => {
+    // §0.10 recovery guarantee — nothing authored on an agent can lock the last
+    // owner out of the chat that would let them undo it.
+    getSession.mockResolvedValue({
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
+    })
+    getCapabilities.mockResolvedValue(
+      new CapabilitySet(
+        new Set(expandLevelsToKeys({ [Area.agents]: Level.Full }) as PermissionKeyType[]),
+        {},
+        'OWNER',
+        'full',
+        undefined,
+        undefined,
+        undefined,
+        { [AGENT_ID]: ResourcePermission.none },
+        new Set([AGENT_ID])
+      )
+    )
+    const res = await POST(request({ message: 'hi', agentId: AGENT_ID }))
+    expect(res.status).toBe(200)
+    await res.text()
+    expect(runTurn).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -47,7 +47,7 @@ import {
 } from '@auxx/lib/ai/kopilot/capabilities'
 import { createMcpCapabilities } from '@auxx/lib/ai/mcp'
 import { getCachedAgentById } from '@auxx/lib/cache'
-import { ForbiddenError } from '@auxx/lib/errors'
+import { AuxxError, ForbiddenError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import {
   type CapabilityView,
@@ -69,6 +69,7 @@ import {
 import { headers } from 'next/headers'
 import type { NextRequest } from 'next/server'
 import { auth } from '~/auth/server'
+import { assertAgentAccess } from '~/server/lib/agent-instance-access'
 import { resolveTaskNotification } from './task-notification'
 
 const logger = createScopedLogger('kopilot-stream')
@@ -107,24 +108,38 @@ function renderDmInstructions(instructions: Record<string, unknown> | null): str
  * agent-side check (`buildDmTriggerContext`) tests the org-wide `dmEnabled`
  * toggle, not the caller.
  *
- * Two gates, matching what `permissionProcedure(agentsManage)` runs for the
- * tRPC siblings: the {@link FeatureKey.agents} plan-AND (the route's existing
- * {@link FeatureKey.kopilot} gate does not cover the agents feature) and the
- * capability itself.
+ * Three gates, and the id-aware one is the point (permissions v2 item 4, plan
+ * 25 §4.2 — the TODO that used to sit here is DONE):
  *
- * TODO(permissions v2, item 4 — agents instance access): `Area.agents` is a
- * SINGLE-RUNG area today (`Full → agents.manage` is its only rung, see
- * `registry.ts`), so this is deliberately agent-id-blind — there is no View
- * rung to gate on yet. When item 4 splits the area into View/Edit/Full,
- * re-point this at the new View rung and add
- * `capabilities.assertViewInstance('agent', agentId)` beside it, taking the id
- * as a parameter. **Extend this function — do not add a second gate elsewhere.**
+ *  1. the {@link FeatureKey.agents} plan-AND (the route's existing
+ *     {@link FeatureKey.kopilot} gate does not cover the agents feature);
+ *  2. the coarse {@link PermissionKey.agentsView} rung. This used to be
+ *     `agentsManage`, because `Area.agents` had no lower rung to aim at.
+ *     Chatting with an agent is USING it, not authoring it, so Read is the
+ *     correct front door now that the area has one;
+ *  3. per-agent instance access on the RESOLVED agent id. `agentId` arrives
+ *     verbatim on the request body, so it goes through
+ *     {@link assertAgentAccess} — which resolves id-or-slug to a real
+ *     `Agent.id` first. Asserting the raw value would find no `ResourceAccess`
+ *     row for a slug, fall through to the area level, and hand over a
+ *     restricted agent.
+ *
+ * **Denials are returned, never thrown.** App Router route handlers have no
+ * `auxxErrorMiddleware`, so an escaping `AuxxError` surfaces as a 500 rather
+ * than the 403 the caller must see. Every `AuxxError` from the resolve+assert
+ * is collapsed into the same message on purpose: a restricted agent, an
+ * archived one and an id from another org are then indistinguishable, so this
+ * endpoint cannot be used to enumerate the org's agents. Anything that is not
+ * an `AuxxError` is a genuine fault and rethrows.
+ *
+ * **Extend this function — do not add a second gate elsewhere.**
  */
 async function resolveAgentAccessDenial(params: {
   organizationId: string
   userId: string
+  agentId: string
 }): Promise<string | null> {
-  const { organizationId, userId } = params
+  const { organizationId, userId, agentId } = params
   const hasAgents = await new FeaturePermissionService().hasAccess(
     organizationId,
     FeatureKey.agents
@@ -132,8 +147,15 @@ async function resolveAgentAccessDenial(params: {
   if (!hasAgents) return 'Agents are not available on your plan'
 
   const capabilities = await getCapabilities(userId, organizationId)
-  if (!capabilities.can(PermissionKey.agentsManage)) {
+  if (!capabilities.can(PermissionKey.agentsView)) {
     return 'You do not have access to this agent'
+  }
+
+  try {
+    await assertAgentAccess({ capabilities, organizationId, idOrSlug: agentId, tier: 'view' })
+  } catch (error) {
+    if (error instanceof AuxxError) return 'You do not have access to this agent'
+    throw error
   }
   return null
 }
@@ -244,7 +266,11 @@ export async function POST(request: NextRequest) {
   // is authorized separately below. Plain Kopilot (no agent) skips this
   // entirely.
   if (!body.sessionId && body.agentId) {
-    const denial = await resolveAgentAccessDenial({ organizationId, userId })
+    const denial = await resolveAgentAccessDenial({
+      organizationId,
+      userId,
+      agentId: body.agentId,
+    })
     if (denial) return new Response(denial, { status: 403 })
   }
 
@@ -434,10 +460,15 @@ export async function POST(request: NextRequest) {
         // profile was tightened). Authorize the RESOLVED id on every turn.
         //
         // Builder sessions are included on purpose: their agent is the subject
-        // of editing, which is exactly what `agentsManage` fronts. Sessions
-        // with no agent (plain Kopilot) read no capabilities at all.
+        // of editing, and `view` is the floor for touching it at all (the
+        // authoring tools re-assert Edit/Full for themselves). Sessions with no
+        // agent (plain Kopilot) read no capabilities at all.
         if (sessionAgentId) {
-          const denial = await resolveAgentAccessDenial({ organizationId, userId })
+          const denial = await resolveAgentAccessDenial({
+            organizationId,
+            userId,
+            agentId: sessionAgentId,
+          })
           if (denial) {
             send({ type: 'turn-error', error: denial, code: 'forbidden' })
             cleanup()

--- a/apps/web/src/components/agents/agent-page-gates.test.tsx
+++ b/apps/web/src/components/agents/agent-page-gates.test.tsx
@@ -1,0 +1,173 @@
+// apps/web/src/components/agents/agent-page-gates.test.tsx
+
+import { SidebarProvider } from '@auxx/ui/components/sidebar'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render, screen } from '@testing-library/react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 25 §4.2.DECIDED — **the coarse gates read `agents.view`, not
+ * `agents.manage`.**
+ *
+ * This is the #1346 regression, pinned. #1346 split `Area.workflows` into
+ * three rungs but left the landing pages, the sidebar and cmd+K gated on the
+ * authoring key, so every member holding only `view`/`edit` — or holding one
+ * single shared workflow — was shown a lock screen for a resource they were
+ * explicitly granted. `Area.agents` has just been split the same way, so the
+ * same four sites are the same trap.
+ *
+ * The assertions are deliberately about the *landing* surfaces only. Which
+ * particular agent a member may open is NOT decided here: `agent.getById`
+ * asserts instance access on the resolved id server-side, and a restricted
+ * agent surfaces as "not found", never as this lock screen.
+ */
+
+const h = vi.hoisted(() => ({
+  /** The member's composed AREA keys. */
+  keys: new Set<string>(),
+  hasFeature: true,
+}))
+
+vi.mock('~/providers/feature-flag-provider', () => ({
+  useFeatureFlags: () => ({ hasAccess: () => h.hasFeature }),
+}))
+vi.mock('~/providers/capabilities-provider', () => ({
+  useAccess: () => ({
+    can: (key: string) => h.keys.has(key),
+    canViewInstance: () => true,
+    canEditInstance: () => true,
+    canAdminInstance: () => true,
+    isRestrictedInstance: () => false,
+    capabilities: [...h.keys],
+    isLoading: false,
+  }),
+}))
+
+// The page bodies are irrelevant to the gate — stub them to a marker so the
+// test asserts "did we get in", not "did the list render".
+vi.mock('~/components/agents', () => ({
+  AgentsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('~/components/agents/ui/list/agents-page-content', () => ({
+  AgentsPageContent: () => <div data-testid='agents-list' />,
+}))
+vi.mock('~/components/agents/hooks/use-agent', () => ({
+  useAgent: () => ({ detail: { id: 'agent_1', name: 'Support bot' }, isLoading: false }),
+}))
+vi.mock('~/components/agents/hooks/use-agent-realtime', () => ({
+  useAgentRealtime: () => {},
+}))
+vi.mock('~/components/agents/ui/detail/agent-detail-view', () => ({
+  AgentDetailView: () => <div data-testid='agent-detail' />,
+}))
+vi.mock('~/components/resources/hooks/use-viewable-resources', () => ({
+  useViewableResources: () => ({ resources: [], isLoading: false }),
+}))
+
+import { renderHook } from '@testing-library/react'
+import AgentDetailPage from '~/app/(protected)/app/agents/[slug]/page'
+import AgentsPage from '~/app/(protected)/app/agents/page'
+import { useNavigationActions } from '~/components/kbar/actions/navigation'
+import { SIDEBAR_MENU } from '~/constants/menu'
+
+// The lock screens render a `next/link` back-link, whose `useIntersection`
+// calls `new IntersectionObserver(...)`. The global setup stubs it as a plain
+// arrow function, which is not constructible.
+beforeAll(() => {
+  class NoopIntersectionObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return []
+    }
+  }
+  vi.stubGlobal('IntersectionObserver', NoopIntersectionObserver)
+})
+
+beforeEach(() => {
+  h.keys = new Set()
+  h.hasFeature = true
+})
+
+/** `MainPageHeader` mounts a `SidebarTrigger`, which needs the sidebar context. */
+function renderPage(ui: React.ReactElement) {
+  return render(
+    <SidebarProvider>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </SidebarProvider>
+  )
+}
+
+describe('agents landing pages — the coarse gate is `agents.view`', () => {
+  it('lets a VIEW-only member into the agents list', () => {
+    h.keys = new Set(['agents.view'])
+
+    renderPage(<AgentsPage />)
+
+    expect(screen.getByTestId('agents-list')).toBeTruthy()
+    expect(screen.queryByText('Agents Not Available')).toBeNull()
+  })
+
+  it('lets a VIEW-only member into an agent detail page', () => {
+    h.keys = new Set(['agents.view'])
+
+    renderPage(<AgentDetailPage />)
+
+    expect(screen.getByTestId('agent-detail')).toBeTruthy()
+    expect(screen.queryByText('Agents Not Available')).toBeNull()
+  })
+
+  it('still locks out a member holding NO agents rung', () => {
+    h.keys = new Set()
+
+    renderPage(<AgentsPage />)
+
+    expect(screen.getByText('Agents Not Available')).toBeTruthy()
+    expect(screen.queryByTestId('agents-list')).toBeNull()
+  })
+
+  it('still locks out the detail page for a member holding NO agents rung', () => {
+    h.keys = new Set()
+
+    renderPage(<AgentDetailPage />)
+
+    expect(screen.getByText('Agents Not Available')).toBeTruthy()
+    expect(screen.queryByTestId('agent-detail')).toBeNull()
+  })
+
+  it('locks the list when the plan lacks the agents feature, even at Full', () => {
+    h.keys = new Set(['agents.view', 'agents.edit', 'agents.manage'])
+    h.hasFeature = false
+
+    renderPage(<AgentsPage />)
+
+    expect(screen.getByText('Agents Not Available')).toBeTruthy()
+  })
+})
+
+describe('navigation surfaces — sidebar and cmd+K', () => {
+  it('gates the sidebar Agents entry on `agents.view`', () => {
+    const entry = SIDEBAR_MENU.find((item) => item.id === 'agents')
+
+    expect(entry).toBeTruthy()
+    // The exact string matters: `agents.manage` here is the #1346 bug.
+    expect(entry?.permissionKey).toBe('agents.view')
+  })
+
+  it('offers the cmd+K Agents action to a VIEW-only member', () => {
+    h.keys = new Set(['agents.view'])
+
+    const { result } = renderHook(() => useNavigationActions())
+
+    expect(result.current.some((action) => action.id === 'nav.agents')).toBe(true)
+  })
+
+  it('withholds the cmd+K Agents action from a member holding no agents rung', () => {
+    h.keys = new Set()
+
+    const { result } = renderHook(() => useNavigationActions())
+
+    expect(result.current.some((action) => action.id === 'nav.agents')).toBe(false)
+  })
+})

--- a/apps/web/src/components/agents/hooks/index.ts
+++ b/apps/web/src/components/agents/hooks/index.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/agents/hooks/index.ts
 
 export { useAgent } from './use-agent'
+export { type AgentAccess, useAgentAccess } from './use-agent-access'
 export { useAgentMutations } from './use-agent-mutations'
 export {
   type AgentProfileOption,

--- a/apps/web/src/components/agents/hooks/use-agent-access.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-access.ts
@@ -1,0 +1,76 @@
+// apps/web/src/components/agents/hooks/use-agent-access.ts
+'use client'
+
+import { PermissionKey } from '@auxx/lib/permissions/client'
+import { toRecordId } from '@auxx/types/resource'
+import { useMemo } from 'react'
+import { useAccess } from '~/providers/capabilities-provider'
+
+/** The three per-agent rungs plus the coarse "may create an agent" gate. */
+export interface AgentAccess {
+  /** `view` — *usable*: open the detail page read-only, chat, DM, @-mention, assign work. */
+  canView: boolean
+  /** `edit` — prompt, drafts, toolsets, bindings, knowledge scope, procedures, evals. */
+  canEdit: boolean
+  /** `admin` — publish, restore, delete, archive, rename, run-as, permission profile, triggers. */
+  canAdmin: boolean
+  /** Coarse `agents.manage` — creating a NEW agent is not per-instance. */
+  canCreate: boolean
+}
+
+/**
+ * Per-agent instance access for the client (plan 25 §4.2.DECIDED) — the agent
+ * twin of {@link import('~/components/workflow/hooks/use-workflow-access').useWorkflowAccess},
+ * keyed by `Agent.id`.
+ *
+ * Tiers (user decision 2026-07-27/28): **`view` means the agent is USABLE** —
+ * chat with it in Kopilot, DM it, @-mention it, assign it work, see it in actor
+ * pickers. It does *not* mean "can author it". Every coarse gate that decides
+ * whether a member reaches the agents list/detail at all must therefore read
+ * `canView` (i.e. `agents.view`), never `agents.manage` — #1346 shipped exactly
+ * that bug for workflows by leaving the sidebar and cmd+K on `.manage`.
+ *
+ * This is the TRANSPOSE of *agent policy* (`AgentPermissionsSection`, the
+ * `agent-policy-*` grids): policy is what the AGENT may do when it runs, this is
+ * what USERS may do to the agent. The two render as similar grids — keep the
+ * copy apart.
+ *
+ * With no id resolved yet (the detail page routes by slug and mounts before the
+ * agent loads) this falls back to the coarse `Area.agents` rungs. That is not a
+ * guess: agents are `baselineAtCreate: false`, so an agent with no explicit
+ * `ResourceAccess` row resolves to exactly the area level anyway — the fallback
+ * and the per-instance answer agree for every unrestricted agent, and only a
+ * restricted one flips once its id arrives.
+ *
+ * Server enforcement is the source of truth (`~/server/lib/agent-instance-access`);
+ * this is degrade-only, to avoid rendering affordances that 403.
+ *
+ * MUST be called inside `CapabilitiesProvider` — i.e. only from `(protected)`
+ * surfaces. Visitor/widget chat has no capability context and is deliberately
+ * excluded from agent instance access altogether.
+ *
+ * @param agentId The `Agent.id`. Pass `null`/`undefined` before it resolves —
+ *   never a slug, which matches no `ResourceAccess` row.
+ */
+export function useAgentAccess(agentId?: string | null): AgentAccess {
+  const { can, canViewInstance, canEditInstance, canAdminInstance } = useAccess()
+
+  return useMemo(() => {
+    const canCreate = can(PermissionKey.agentsManage)
+    if (!agentId) {
+      return {
+        canView: can(PermissionKey.agentsView),
+        canEdit: can(PermissionKey.agentsEdit),
+        canAdmin: canCreate,
+        canCreate,
+      }
+    }
+    const recordId = toRecordId('agent', agentId)
+    return {
+      canView: canViewInstance(recordId),
+      canEdit: canEditInstance(recordId),
+      canAdmin: canAdminInstance(recordId),
+      canCreate,
+    }
+  }, [agentId, can, canViewInstance, canEditInstance, canAdminInstance])
+}

--- a/apps/web/src/components/agents/procedures/ui/procedures-section.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedures-section.tsx
@@ -9,6 +9,7 @@ import { ListChecks, Plus } from 'lucide-react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
+import { useAgentAccess } from '../../hooks/use-agent-access'
 import type { AgentDetail } from '../../store/agent-store'
 import { ProcedureRow } from './procedure-row'
 
@@ -31,7 +32,10 @@ export function ProceduresSection({ agent, onSelect }: ProceduresSectionProps) {
   // Beta gate — also enforced on the tab visibility + backend mutations. Hides the
   // "Add procedure" action if the org loses entitlement while this view is mounted.
   const { hasAccess } = useFeatureFlags()
-  const canEdit = hasAccess(FeatureKey.agentProcedures)
+  // Two independent gates, both required: the org's plan entitlement, and the
+  // viewer's `edit` rung on THIS agent (plan 25 §4.2 — procedures are authoring).
+  const { canEdit: canEditAgent } = useAgentAccess(agent.id)
+  const canEdit = hasAccess(FeatureKey.agentProcedures) && canEditAgent
 
   const procedures = api.agentProcedure.list.useQuery({ agentId: agent.id })
   const invalidate = () => utils.agentProcedure.list.invalidate({ agentId: agent.id })

--- a/apps/web/src/components/agents/ui/agent-instance-access.test.tsx
+++ b/apps/web/src/components/agents/ui/agent-instance-access.test.tsx
@@ -1,0 +1,481 @@
+// apps/web/src/components/agents/ui/agent-instance-access.test.tsx
+
+import { SidebarProvider } from '@auxx/ui/components/sidebar'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 25 §4.2.DECIDED — **the three per-agent rungs, on the surfaces that
+ * render them.**
+ *
+ * The vocabulary these pin (user decision 2026-07-27/28):
+ *  - `view` is *usable*, not "read the builder and nothing else": the page
+ *    opens, the docked chat works, the persona is readable. What disappears is
+ *    every authoring affordance.
+ *  - `edit` is authoring: prompt, toolsets, bindings, knowledge, procedures.
+ *  - `admin` is administration: Share, Publish, Archive, Delete, rename
+ *    (name + slug — the slug is the agent's `@handle` and its URL), and the
+ *    permission-profile / run-as pair.
+ *
+ * Sharing follows #1355 exactly: the Share affordance AND the dialog mount only
+ * for an instance-admin, so a non-admin can neither open it nor be handed one
+ * by a stray `open` state.
+ *
+ * The gating is degrade-only — `~/server/lib/agent-instance-access` is the
+ * authority — so these tests are about not *offering* a click that 403s.
+ */
+
+type Tier = 'view' | 'edit' | 'admin'
+
+const AGENT_ID = 'agent_1'
+
+const h = vi.hoisted(() => ({
+  tier: 'admin' as 'view' | 'edit' | 'admin',
+  /** Org rank, independent of the per-agent rung. */
+  isAdminOrOwner: true,
+}))
+
+const rank = (): number => ({ view: 1, edit: 2, admin: 3 })[h.tier]
+
+vi.mock('~/providers/feature-flag-provider', () => ({
+  useFeatureFlags: () => ({ hasAccess: () => true }),
+}))
+vi.mock('~/hooks/use-user', () => ({ useUser: () => ({ isAdminOrOwner: h.isAdminOrOwner }) }))
+vi.mock('~/providers/capabilities-provider', () => ({
+  useAccess: () => ({
+    // Area keys track the tier, so the id-less fallback branch of
+    // `useAgentAccess` agrees with the per-instance one (agents are
+    // `baselineAtCreate: false` — that agreement is the whole point).
+    can: (key: string) =>
+      key === 'agents.view' ||
+      (key === 'agents.edit' && rank() >= 2) ||
+      (key === 'agents.manage' && rank() >= 3),
+    canViewInstance: (recordId: string) => recordId === `agent:${AGENT_ID}`,
+    canEditInstance: (recordId: string) => recordId === `agent:${AGENT_ID}` && rank() >= 2,
+    canAdminInstance: (recordId: string) => recordId === `agent:${AGENT_ID}` && rank() >= 3,
+    isRestrictedInstance: () => false,
+    capabilities: [],
+    isLoading: false,
+  }),
+  useCanAdminInstance: () => rank() >= 3,
+}))
+
+// The share dialog is stubbed, not removed — #1355's rule is that BOTH the
+// trigger and the dialog are admin-gated, so the stub has to be observable.
+vi.mock('~/components/permissions/ui/instance-share-dialog', () => ({
+  InstanceShareDialog: ({ recordId, open }: { recordId: string; open: boolean }) => (
+    <div data-testid='share-dialog' data-open={String(open)}>
+      {recordId}
+    </div>
+  ),
+}))
+
+// Chrome that has nothing to do with the tiers.
+vi.mock('~/hooks/use-docked-panels', () => ({
+  // Render the docked content inline — the point is that a `view` holder still
+  // gets the chat panel, so it has to actually mount.
+  useDockedPanels: (panels: Array<{ key: string; content: React.ReactNode }>) => ({
+    dockedPanels: [],
+    leftPanels: [],
+    overlays: panels.map((panel) => <div key={panel.key}>{panel.content}</div>),
+    isDocked: true,
+  }),
+}))
+vi.mock('~/stores/dock-store', () => ({
+  useDockStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ dockedWidth: 320, setDockedWidth: vi.fn(), minWidth: 240, maxWidth: 640 }),
+}))
+vi.mock('~/components/agents/ui/detail/agent-detail-tabs', () => ({
+  AgentDetailTabs: () => <div data-testid='agent-tabs' />,
+}))
+vi.mock('~/components/agents/ui/detail/agent-docked-chat', () => ({
+  AgentDockedChat: () => <div data-testid='agent-chat' />,
+}))
+vi.mock('~/components/agents/ui/detail/agent-breadcrumb-switcher', () => ({
+  AgentBreadcrumbSwitcher: () => <span>Support bot</span>,
+}))
+vi.mock('~/components/agents/ui/detail/setup/agent-setup-mode', () => ({
+  AgentSetupMode: () => <div data-testid='agent-setup' />,
+}))
+vi.mock('~/components/agents/ui/detail/agent-setup-discard-button', () => ({
+  AgentSetupDiscardButton: () => <div data-testid='agent-setup-discard' />,
+}))
+vi.mock('~/components/agents/ui/detail/agent-versions-dialog', () => ({
+  AgentVersionsDialog: () => null,
+}))
+vi.mock('~/components/agents/ui/detail/permissions/publish-clamp-dialog', () => ({
+  PublishClampDialog: () => null,
+}))
+vi.mock('~/components/agents/ui/detail/agent-model-badge', () => ({
+  AgentModelBadge: () => null,
+}))
+vi.mock('~/components/file-upload/ui/avatar-upload', () => ({
+  AvatarUpload: ({ disabled }: { disabled?: boolean }) => (
+    <div data-testid='avatar-upload' data-disabled={String(!!disabled)} />
+  ),
+}))
+vi.mock('~/components/agents/ui/shared/agent-avatar', () => ({
+  AgentAvatar: () => <div data-testid='agent-avatar' />,
+}))
+vi.mock('~/components/list-selection', () => ({
+  useBulkMode: () => false,
+  useIsPending: () => false,
+  useIsSelected: () => false,
+  useListSelection: () => vi.fn(),
+  usePendingLabel: () => '',
+}))
+vi.mock('~/hooks/use-confirm', () => ({
+  useConfirm: () => [vi.fn().mockResolvedValue(true), () => null],
+}))
+vi.mock('~/components/agents/hooks/use-agent-mutations', () => ({
+  useAgentMutations: () => ({
+    updateAgent: vi.fn(),
+    publishAgent: vi.fn(),
+    discardChanges: vi.fn(),
+    archiveAgent: vi.fn(),
+    unarchiveAgent: vi.fn(),
+    deleteAgent: vi.fn(),
+    deleteSetupDraft: vi.fn(),
+    isPublishing: false,
+    isDiscarding: false,
+    isUpdating: false,
+  }),
+}))
+vi.mock('~/components/agents/hooks/use-agent-permission-profiles', () => ({
+  useAgentPermissionProfiles: () => ({
+    profiles: [],
+    byId: new Map(),
+    isLoading: false,
+    fallbackFor: () => null,
+  }),
+  useAgentProfileBinding: () => ({ setProfile: vi.fn(), isSaving: false }),
+  useAgentProfilePolicy: () => ({ policy: null }),
+}))
+vi.mock('~/components/agents/ui/detail/permissions/agent-profile-picker', () => ({
+  AgentProfilePicker: ({ disabled }: { disabled?: boolean }) => (
+    <div data-testid='profile-picker' data-disabled={String(!!disabled)} />
+  ),
+}))
+vi.mock('~/components/agents/ui/detail/permissions/agent-policy-view', () => ({
+  AgentPolicySummary: () => null,
+  AgentResolvedPolicyDialog: () => null,
+}))
+vi.mock('~/components/agents/ui/detail/permissions/author-clamp-notice', () => ({
+  AuthorClampNotice: () => null,
+}))
+vi.mock('~/components/agents/ui/detail/agent-guide-dialog', () => ({
+  AgentGuideDialog: () => null,
+}))
+vi.mock('~/components/banner/upgrade-banner', () => ({ UpgradeBanner: () => null }))
+vi.mock('~/trpc/react', () => ({
+  api: {
+    member: { all: { useQuery: () => ({ data: { members: [] } }) } },
+    useUtils: () => ({
+      agent: {
+        list: { invalidate: vi.fn() },
+        getById: { invalidate: vi.fn() },
+        checkSlug: { fetch: vi.fn() },
+      },
+      agentToolset: { listTools: { prefetch: vi.fn() } },
+    }),
+    agent: {
+      getById: {
+        useQuery: () => ({
+          data: {
+            id: AGENT_ID,
+            name: 'Support bot',
+            activeVersionId: 'ver_1',
+            hasUnpublishedChanges: true,
+            archivedAt: null,
+          },
+        }),
+      },
+    },
+  },
+}))
+
+import type { AgentDetail, AgentListItem } from '~/components/agents/store/agent-store'
+import { AgentDetailView } from '~/components/agents/ui/detail/agent-detail-view'
+import { AgentHero } from '~/components/agents/ui/detail/agent-hero'
+import { AgentPermissionsSection } from '~/components/agents/ui/detail/agent-permissions-section'
+import { AgentCard } from '~/components/agents/ui/list/agent-card'
+
+const AGENT = {
+  id: AGENT_ID,
+  name: 'Support bot',
+  slug: 'support-bot',
+  description: 'Answers refunds',
+  kind: 'internal',
+  avatarUrl: null,
+  userId: 'user_bot',
+  modelId: 'gpt-5',
+  archivedAt: null,
+  setupCompletedAt: new Date('2026-01-01'),
+  activeVersionId: 'ver_1',
+  activeVersionNumber: 1,
+  hasUnpublishedChanges: true,
+  prompt: null,
+  runAsUserId: null,
+  permissionProfileId: null,
+  updatedAt: new Date('2026-01-01'),
+} as unknown as AgentDetail
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+  // `next/link`'s `useIntersection` constructs one; the global setup stubs it
+  // as a plain arrow function, which is not constructible.
+  class NoopIntersectionObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return []
+    }
+  }
+  vi.stubGlobal('IntersectionObserver', NoopIntersectionObserver)
+  // Same story for Radix/floating-ui's `autoUpdate`, which constructs one.
+  class NoopResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+  // Radix's dropdown needs these; jsdom ships neither.
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+    Element.prototype.setPointerCapture = () => {}
+    Element.prototype.releasePointerCapture = () => {}
+  }
+})
+
+beforeEach(() => {
+  h.tier = 'admin'
+  h.isAdminOrOwner = true
+})
+
+function renderDetail(tier: Tier) {
+  h.tier = tier
+  return render(
+    <SidebarProvider>
+      <TooltipProvider>
+        <AgentDetailView agent={AGENT} />
+      </TooltipProvider>
+    </SidebarProvider>
+  )
+}
+
+describe('AgentDetailView — the Share affordance is instance-admin only', () => {
+  it('offers Share to an admin, mounted on this agent’s recordId', () => {
+    renderDetail('admin')
+
+    expect(screen.getByRole('button', { name: 'Share' })).toBeTruthy()
+    expect(screen.getByTestId('share-dialog').textContent).toBe(`agent:${AGENT_ID}`)
+  })
+
+  it('withholds Share — trigger AND dialog — from an EDIT holder', () => {
+    renderDetail('edit')
+
+    expect(screen.queryByRole('button', { name: 'Share' })).toBeNull()
+    expect(screen.queryByTestId('share-dialog')).toBeNull()
+  })
+
+  it('withholds Share — trigger AND dialog — from a VIEW holder', () => {
+    renderDetail('view')
+
+    expect(screen.queryByRole('button', { name: 'Share' })).toBeNull()
+    expect(screen.queryByTestId('share-dialog')).toBeNull()
+  })
+})
+
+describe('AgentDetailView — publish chrome by tier', () => {
+  it('gives an admin Publish, Archive and Delete', async () => {
+    const user = userEvent.setup()
+    renderDetail('admin')
+
+    expect(screen.getByRole('button', { name: /Publish$/ })).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'Publish menu' }))
+    expect(screen.getByRole('menuitem', { name: /Archive/ })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /Delete/ })).toBeTruthy()
+  })
+
+  it('gives an EDIT holder the draft controls but no Publish, Archive or Delete', async () => {
+    const user = userEvent.setup()
+    renderDetail('edit')
+
+    // Discard (the draft control) survives; Publish does not.
+    expect(screen.getByRole('button', { name: 'Discard changes' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Publish$/ })).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Publish menu' }))
+    expect(screen.getByRole('menuitem', { name: /Version history/ })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: /Archive/ })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /Delete/ })).toBeNull()
+  })
+
+  it('gives a VIEW holder no publish cluster at all, and says why', () => {
+    renderDetail('view')
+
+    expect(screen.queryByRole('button', { name: 'Publish menu' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Publish$/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Discard changes' })).toBeNull()
+    expect(screen.getByText('View only')).toBeTruthy()
+  })
+
+  it('still opens the page and its docked chat for a VIEW holder', () => {
+    renderDetail('view')
+
+    // The #1346 shape, one level in: `view` is USABLE. The builder body and the
+    // chat panel must both still mount.
+    expect(screen.getByTestId('agent-tabs')).toBeTruthy()
+    expect(screen.getByTestId('agent-chat')).toBeTruthy()
+  })
+})
+
+describe('AgentHero — rename is admin, description is edit', () => {
+  function renderHero(tier: Tier) {
+    h.tier = tier
+    return render(
+      <TooltipProvider>
+        <AgentHero agent={AGENT} />
+      </TooltipProvider>
+    )
+  }
+
+  it('lets an admin click into name, slug and description', () => {
+    renderHero('admin')
+
+    expect(screen.getByRole('button', { name: 'Support bot' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '@support-bot' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Answers refunds' })).toBeTruthy()
+    expect(screen.getByTestId('avatar-upload').dataset.disabled).toBe('false')
+  })
+
+  it('lets an EDIT holder rename, because the server does (user decision 2026-07-28)', () => {
+    renderHero('edit')
+
+    // Rename is an AUTHORING field, not administration: `agent.update`'s
+    // `ADMIN_ONLY_UPDATE_FIELDS` is `runAsUserId` / `permissionProfileId` /
+    // `archivedAt` only, so name and slug go through on the Edit rung. This
+    // test is the tripwire for the UI drifting stricter than the server — the
+    // direction that never 403s and therefore never gets reported as a bug,
+    // it just silently removes an affordance. It also keeps `agent.checkSlug`'s
+    // instance-`edit` branch (the live slug hint) reachable.
+    expect(screen.getByRole('button', { name: 'Support bot' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '@support-bot' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Answers refunds' })).toBeTruthy()
+    expect(screen.getByTestId('avatar-upload').dataset.disabled).toBe('false')
+  })
+
+  it('freezes every field, and the avatar, for a VIEW holder', () => {
+    renderHero('view')
+
+    expect(screen.queryByRole('button', { name: 'Support bot' })).toBeNull()
+    expect(screen.queryByRole('button', { name: '@support-bot' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Answers refunds' })).toBeNull()
+    expect(screen.getByText('Answers refunds')).toBeTruthy()
+    expect(screen.getByTestId('avatar-upload').dataset.disabled).toBe('true')
+  })
+})
+
+describe('AgentCard — the list menu follows the same tiers', () => {
+  const LIST_AGENT = {
+    id: AGENT_ID,
+    name: 'Support bot',
+    slug: 'support-bot',
+    description: 'Answers refunds',
+    kind: 'internal',
+    modelId: 'gpt-5',
+    archivedAt: null,
+    setupCompletedAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  } as unknown as AgentListItem
+
+  function renderCard(tier: Tier) {
+    h.tier = tier
+    return render(
+      <TooltipProvider>
+        <AgentCard agent={LIST_AGENT} />
+      </TooltipProvider>
+    )
+  }
+
+  async function openMenu() {
+    const user = userEvent.setup()
+    // `ListCard`'s menu button carries no accessible name — Radix's
+    // `aria-haspopup` is the stable handle on it.
+    const trigger = document.querySelector('[aria-haspopup="menu"]')
+    if (!trigger) throw new Error('card menu trigger not found')
+    await user.click(trigger)
+  }
+
+  it('offers Share…, Archive and Delete to an admin', async () => {
+    renderCard('admin')
+    await openMenu()
+
+    expect(screen.getByRole('menuitem', { name: /Share/ })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /Archive/ })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /Delete/ })).toBeTruthy()
+    expect(screen.getByTestId('share-dialog')).toBeTruthy()
+  })
+
+  it('gives an EDIT holder Edit but neither Share…, Archive nor Delete', async () => {
+    renderCard('edit')
+    await openMenu()
+
+    expect(screen.getByRole('menuitem', { name: /Edit/ })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: /Share/ })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /Archive/ })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /Delete/ })).toBeNull()
+    expect(screen.queryByTestId('share-dialog')).toBeNull()
+  })
+
+  it('offers a VIEW holder only Open', async () => {
+    renderCard('view')
+    await openMenu()
+
+    expect(screen.getByRole('menuitem', { name: /Open/ })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: /^Edit/ })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /Share/ })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /Delete/ })).toBeNull()
+  })
+})
+
+describe('AgentPermissionsSection — the authority pair is instance-admin AND org rank', () => {
+  function renderSection(tier: Tier, isAdminOrOwner: boolean) {
+    h.tier = tier
+    h.isAdminOrOwner = isAdminOrOwner
+    return render(
+      <TooltipProvider>
+        <AgentPermissionsSection agent={AGENT} />
+      </TooltipProvider>
+    )
+  }
+
+  it('enables the profile picker and run-as for an org admin who administers the agent', () => {
+    renderSection('admin', true)
+
+    expect(screen.getByTestId('profile-picker').dataset.disabled).toBe('false')
+    expect(screen.getByRole('combobox')).not.toHaveAttribute('data-disabled')
+  })
+
+  it('freezes them for an ORG ADMIN restricted to `edit` on this agent', () => {
+    // `permissionProfileId` / `runAsUserId` are `ADMIN_ONLY_UPDATE_FIELDS`, so
+    // org rank alone would render an enabled control that 403s.
+    renderSection('edit', true)
+
+    expect(screen.getByTestId('profile-picker').dataset.disabled).toBe('true')
+    expect(screen.getByRole('combobox')).toHaveAttribute('data-disabled')
+    expect(screen.getByText(/do not administer this agent/i)).toBeTruthy()
+  })
+
+  it('freezes them for a non-admin member who DOES administer the agent', () => {
+    renderSection('admin', false)
+
+    expect(screen.getByTestId('profile-picker').dataset.disabled).toBe('true')
+    expect(screen.getByRole('combobox')).toHaveAttribute('data-disabled')
+    expect(screen.getByText(/Only an owner or admin can change these/i)).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -31,6 +31,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { useScrollSpy } from '~/hooks/use-scroll-spy'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { AGENT_TABS, type AgentTab, DEFAULT_AGENT_TAB } from '../../constant'
+import { useAgentAccess } from '../../hooks/use-agent-access'
 import { usePersonaRealtime } from '../../hooks/use-persona-realtime'
 import { useProcedureRealtime } from '../../procedures/hooks/use-procedure-realtime'
 import { ProcedureDetailBar } from '../../procedures/ui/procedure-detail-bar'
@@ -124,6 +125,11 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
   // enforce it). Self-hosted is unlimited, so the gate is a no-op there.
   const { hasAccess } = useFeatureFlags()
   const canProcedures = hasAccess(FeatureKey.agentProcedures)
+  // Per-agent instance access (plan 25 §4.2). Triggers are administration —
+  // they decide when the agent runs autonomously — so their Add affordance sits
+  // on `admin`, matching `agentTrigger.create`'s `tier: 'admin'` assert.
+  // Everything else on this page is authoring and sits on `edit`.
+  const { canEdit, canAdmin } = useAgentAccess(agent.id)
 
   // Chat-kind agents fire from their `ChatWidget.agentId` binding, not from
   // AgentTrigger rows — there are no user-configurable triggers in v5, so the
@@ -240,6 +246,7 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
                     <PersonaEditor
                       key={personaReloadKey}
                       agent={agent}
+                      readOnly={!canEdit}
                       onAutosaveChange={onAutosaveChange}
                     />
                   </Section>
@@ -285,28 +292,30 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
                       description='Autonomous triggers fire this agent on a schedule, on a record event, or on an app event.'
                       collapsible={false}
                       actions={
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button variant='ghost' size='xs'>
-                              <Plus />
-                              Add trigger
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align='end'>
-                            <DropdownMenuItem onClick={() => setAddingKind('scheduled')}>
-                              <Clock />
-                              Scheduled
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => setAddingKind('event')}>
-                              <Zap />
-                              Event
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => setAddingKind('source')}>
-                              <Plug />
-                              App or webhook
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                        canAdmin ? (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant='ghost' size='xs'>
+                                <Plus />
+                                Add trigger
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align='end'>
+                              <DropdownMenuItem onClick={() => setAddingKind('scheduled')}>
+                                <Clock />
+                                Scheduled
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => setAddingKind('event')}>
+                                <Zap />
+                                Event
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => setAddingKind('source')}>
+                                <Plug />
+                                App or webhook
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        ) : undefined
                       }>
                       <TriggersSectionContent
                         agent={agent}

--- a/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
@@ -1,6 +1,8 @@
 // apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
 'use client'
 
+import { toRecordId } from '@auxx/types/resource'
+import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { DrawerHeader } from '@auxx/ui/components/drawer'
@@ -11,10 +13,12 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { MessageSquare } from 'lucide-react'
+import { Eye, MessageSquare, Share2 } from 'lucide-react'
 import { useState } from 'react'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useDockStore } from '~/stores/dock-store'
+import { useAgentAccess } from '../../hooks/use-agent-access'
 import type { AgentDetail } from '../../store/agent-store'
 import { AutosaveIndicator, type AutosaveState } from '../shared/autosave-indicator'
 import { AgentBreadcrumbSwitcher } from './agent-breadcrumb-switcher'
@@ -30,6 +34,12 @@ interface AgentDetailViewProps {
 
 export function AgentDetailView({ agent }: AgentDetailViewProps) {
   const [autosave, setAutosave] = useState<AutosaveState>({ kind: 'idle' })
+  const [shareOpen, setShareOpen] = useState(false)
+  // Per-agent instance access (plan 25 §4.2.DECIDED). `admin` owns Share,
+  // Publish/Archive/Delete; `edit` owns the draft (autosave + discard); `view`
+  // is *usable* — the page still opens, the docked chat still works, and the
+  // header carries a "View only" badge instead of authoring chrome.
+  const { canEdit, canAdmin } = useAgentAccess(agent.id)
   // AgentDockedChat has no chrome of its own (unlike DockableDrawer-based panels
   // elsewhere), so below the desktop breakpoint it needs an explicit trigger +
   // drawer wrapper rather than branching on its own isDocked prop.
@@ -83,18 +93,39 @@ export function AgentDetailView({ agent }: AgentDetailViewProps) {
                 <MessageSquare />
               </Button>
             )}
-            <AutosaveIndicator state={autosave} />
-            {agent.setupCompletedAt != null ? (
-              <AgentPublishCluster
-                agentId={agent.id}
-                onSavingChange={(saving) =>
-                  setAutosave(saving ? { kind: 'saving' } : { kind: 'saved', at: Date.now() })
-                }
-                onSaved={() => setAutosave({ kind: 'saved', at: Date.now() })}
-              />
-            ) : (
-              <AgentSetupDiscardButton agentId={agent.id} name={agent.name} />
+            {canEdit && <AutosaveIndicator state={autosave} />}
+            {!canEdit && (
+              <Badge variant='outline' size='sm' className='shrink-0'>
+                <Eye />
+                View only
+              </Badge>
             )}
+            {canAdmin && (
+              <>
+                <Button variant='outline' size='sm' onClick={() => setShareOpen(true)}>
+                  <Share2 />
+                  Share
+                </Button>
+                <InstanceShareDialog
+                  recordId={toRecordId('agent', agent.id)}
+                  open={shareOpen}
+                  onOpenChange={setShareOpen}
+                />
+              </>
+            )}
+            {canEdit &&
+              (agent.setupCompletedAt != null ? (
+                <AgentPublishCluster
+                  agentId={agent.id}
+                  canAdmin={canAdmin}
+                  onSavingChange={(saving) =>
+                    setAutosave(saving ? { kind: 'saving' } : { kind: 'saved', at: Date.now() })
+                  }
+                  onSaved={() => setAutosave({ kind: 'saved', at: Date.now() })}
+                />
+              ) : (
+                <AgentSetupDiscardButton agentId={agent.id} name={agent.name} />
+              ))}
           </div>
         }>
         <MainPageBreadcrumb>

--- a/apps/web/src/components/agents/ui/detail/agent-hero.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-hero.tsx
@@ -13,6 +13,7 @@ import { Tooltip } from '~/components/global/tooltip'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 import { api } from '~/trpc/react'
 import { AvatarUpload } from '../../../file-upload/ui/avatar-upload'
+import { useAgentAccess } from '../../hooks/use-agent-access'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
 import type { AgentDetail } from '../../store/agent-store'
 import { toSlug } from '../../utils/agent-slug'
@@ -26,12 +27,20 @@ interface AgentHeroProps {
  * Detail-view header for a completed agent. Three inline editors (name, slug,
  * description) sit alongside the avatar uploader. Setup-mode agents use a
  * different surface — this hero only renders post-`setupCompletedAt`.
+ *
+ * Per-agent instance access (plan 25 §4.2) splits the four fields along the
+ * tier line. **Name and slug are RENAME — the `admin` rung.** The slug is not
+ * cosmetic: it is the agent's `@handle` and its URL, so changing it re-points
+ * every mention. Description and avatar are descriptive authoring and sit on
+ * `edit`, next to the prompt. A `view` holder edits none of them and sees plain
+ * text instead of click-to-edit buttons.
  */
 export function AgentHero({ agent }: AgentHeroProps) {
   const isArchived = !!agent.archivedAt
   const router = useRouter()
   const utils = api.useUtils()
   const { updateAgent } = useAgentMutations()
+  const { canEdit } = useAgentAccess(agent.id)
 
   const handleSlugCommit = useCallback(
     async (next: string) => {
@@ -53,6 +62,7 @@ export function AgentHero({ agent }: AgentHeroProps) {
           size='xs'
           compact
           shape='square'
+          disabled={!canEdit}
           fallback={<Bot className='size-4' />}
           onUploadComplete={() => {
             utils.agent.list.invalidate()
@@ -70,8 +80,15 @@ export function AgentHero({ agent }: AgentHeroProps) {
       </div>
       <div className='flex flex-col align-start flex-1 min-w-0'>
         <div className='flex items-center gap-2'>
+          {/* Rename is EDIT, not admin (user decision 2026-07-28): `agent.update`'s
+              `ADMIN_ONLY_UPDATE_FIELDS` covers only `runAsUserId` /
+              `permissionProfileId` / `archivedAt`, so name and slug are authoring
+              fields on the server. Gating them on admin here would hide an
+              affordance the server allows — and would make `agent.checkSlug`'s
+              instance-`edit` path (the live slug hint below) unreachable. */}
           <InlineNameField
             initialName={agent.name}
+            readOnly={!canEdit}
             onCommit={(next) => updateAgent(agent.id, { name: next })}
           />
           {agent.kind === 'chat' ? (
@@ -88,11 +105,13 @@ export function AgentHero({ agent }: AgentHeroProps) {
           <InlineSlugField
             agentId={agent.id}
             initialSlug={agent.slug}
+            readOnly={!canEdit}
             onCommit={handleSlugCommit}
           />
           <span className='shrink-0'>·</span>
           <InlineDescriptionField
             initialDescription={agent.description}
+            readOnly={!canEdit}
             onCommit={(next) =>
               updateAgent(agent.id, { description: next.length > 0 ? next : null })
             }
@@ -107,10 +126,12 @@ export function AgentHero({ agent }: AgentHeroProps) {
 
 interface InlineNameFieldProps {
   initialName: string | null
+  /** Renders as static text — no click-to-edit button, no input. */
+  readOnly?: boolean
   onCommit: (next: string) => void
 }
 
-function InlineNameField({ initialName, onCommit }: InlineNameFieldProps) {
+function InlineNameField({ initialName, readOnly, onCommit }: InlineNameFieldProps) {
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(initialName ?? '')
   const inputRef = useRef<AutosizeInputRef>(null)
@@ -155,6 +176,18 @@ function InlineNameField({ initialName, onCommit }: InlineNameFieldProps) {
     }
   }
 
+  if (readOnly) {
+    return (
+      <span
+        className={cn(
+          'text-lg font-medium dark:text-neutral-400 truncate text-left px-1 -mx-1',
+          initialName ? 'text-neutral-900' : 'italic text-muted-foreground'
+        )}>
+        {initialName ?? 'Untitled agent'}
+      </span>
+    )
+  }
+
   if (!editing) {
     return (
       <button
@@ -188,10 +221,12 @@ function InlineNameField({ initialName, onCommit }: InlineNameFieldProps) {
 interface InlineSlugFieldProps {
   agentId: string
   initialSlug: string
+  /** Renders as static text — no click-to-edit button, no input. */
+  readOnly?: boolean
   onCommit: (next: string) => void
 }
 
-function InlineSlugField({ agentId, initialSlug, onCommit }: InlineSlugFieldProps) {
+function InlineSlugField({ agentId, initialSlug, readOnly, onCommit }: InlineSlugFieldProps) {
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(initialSlug)
   const [error, setError] = useState<string | null>(null)
@@ -283,6 +318,10 @@ function InlineSlugField({ agentId, initialSlug, onCommit }: InlineSlugFieldProp
     }
   }
 
+  if (readOnly) {
+    return <span className='font-mono text-xs px-1 -mx-1 truncate text-left'>@{initialSlug}</span>
+  }
+
   if (!editing) {
     return (
       <button
@@ -325,10 +364,16 @@ function InlineSlugField({ agentId, initialSlug, onCommit }: InlineSlugFieldProp
 
 interface InlineDescriptionFieldProps {
   initialDescription: string | null
+  /** Renders as static text — no click-to-edit button, no input. */
+  readOnly?: boolean
   onCommit: (next: string) => void
 }
 
-function InlineDescriptionField({ initialDescription, onCommit }: InlineDescriptionFieldProps) {
+function InlineDescriptionField({
+  initialDescription,
+  readOnly,
+  onCommit,
+}: InlineDescriptionFieldProps) {
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(initialDescription ?? '')
   const inputRef = useRef<AutosizeInputRef>(null)
@@ -366,6 +411,14 @@ function InlineDescriptionField({ initialDescription, onCommit }: InlineDescript
       e.preventDefault()
       cancel()
     }
+  }
+
+  if (readOnly) {
+    // No "Add a description" affordance — it would advertise an edit this
+    // member cannot make. An empty description simply renders nothing.
+    return initialDescription ? (
+      <span className='text-xs px-1 -mx-1 truncate text-left min-w-0'>{initialDescription}</span>
+    ) : null
   }
 
   if (!editing) {

--- a/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
@@ -30,6 +30,7 @@ import { getInitials } from '~/components/members/utils'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
+import { useAgentAccess } from '../../hooks/use-agent-access'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
 import {
   useAgentPermissionProfiles,
@@ -67,6 +68,12 @@ interface AgentPermissionsSectionProps {
 export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsSectionProps) {
   const { hasAccess } = useFeatureFlags()
   const { isAdminOrOwner } = useUser()
+  // `permissionProfileId` and `runAsUserId` are `ADMIN_ONLY_UPDATE_FIELDS` on
+  // `agent.update` (plan 25 §4.2) — they decide whose capabilities a run
+  // resolves against. Org rank alone is no longer enough: an OWNER/ADMIN who
+  // has been restricted to `edit` on THIS agent would otherwise get an enabled
+  // control that 403s. Both conditions must hold.
+  const { canAdmin } = useAgentAccess(agent.id)
   const { updateAgent, isUpdating } = useAgentMutations()
   const { profiles, byId, isLoading: profilesLoading, fallbackFor } = useAgentPermissionProfiles()
   const { setProfile, isSaving } = useAgentProfileBinding()
@@ -75,8 +82,8 @@ export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsS
 
   const hasGranularPermissions = hasAccess(FeatureKey.granularPermissions)
   /** Run-as is an agent field, not a policy — it needs no plan feature. */
-  const canEditRunAs = isAdminOrOwner
-  const canEditProfile = isAdminOrOwner
+  const canEditRunAs = isAdminOrOwner && canAdmin
+  const canEditProfile = isAdminOrOwner && canAdmin
   const isDelegated = agent.runAsUserId != null
 
   const boundProfileId = agent.permissionProfileId
@@ -124,11 +131,13 @@ export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsS
       <div className='space-y-6'>
         <DraftVersusPublished agent={agent} />
 
-        {!isAdminOrOwner && (
+        {!canEditProfile && (
           <Alert>
             <ShieldCheck className='size-4' />
             <AlertDescription>
-              Only an owner or admin can change these. The resolved policy is read-only.
+              {isAdminOrOwner
+                ? 'You do not administer this agent, so these are read-only. Ask someone with full access to this agent to change them.'
+                : 'Only an owner or admin can change these. The resolved policy is read-only.'}
             </AlertDescription>
           </Alert>
         )}

--- a/apps/web/src/components/agents/ui/detail/agent-publish-cluster.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-publish-cluster.tsx
@@ -14,6 +14,14 @@ import { PublishClampDialog } from './permissions/publish-clamp-dialog'
 
 interface AgentPublishClusterProps {
   agentId: string
+  /**
+   * Whether the viewer holds the `admin` rung on THIS agent (plan 25 §4.2).
+   * Splits the cluster along the tier line: Publish, Archive/Unarchive and
+   * Delete are administration; Discard and Version history are authoring, so an
+   * `edit`-only holder keeps them. The whole cluster is unmounted for a `view`
+   * holder by {@link import('./agent-detail-view').AgentDetailView}.
+   */
+  canAdmin: boolean
   /** Mirrors the autosave indicator while Archive/Unarchive persists. */
   onSavingChange?: (saving: boolean) => void
   onSaved?: () => void
@@ -31,6 +39,7 @@ const PILL_TOOLTIP =
  */
 export function AgentPublishCluster({
   agentId,
+  canAdmin,
   onSavingChange,
   onSaved,
 }: AgentPublishClusterProps) {
@@ -115,26 +124,32 @@ export function AgentPublishCluster({
       <PublishClusterShell
         status={{ isPublished, hasUnsaved, isArchived }}
         pillTooltip={PILL_TOOLTIP}
-        publish={{ onClick: () => void handlePublish(), isPending: isPublishing }}
+        publish={
+          canAdmin ? { onClick: () => void handlePublish(), isPending: isPublishing } : undefined
+        }
         discard={{ onClick: handleDiscard, isPending: isDiscarding }}>
         <DropdownMenuItem onClick={() => setIsVersionsOpen(true)}>
           <History /> Version history
         </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => void handleArchiveToggle()} disabled={isUpdating}>
-          {isArchived ? (
-            <>
-              <ArchiveRestore /> Unarchive
-            </>
-          ) : (
-            <>
-              <Archive /> Archive
-            </>
-          )}
-        </DropdownMenuItem>
-        <DropdownMenuItem variant='destructive' onClick={() => void handleDelete()}>
-          <Trash2 /> Delete
-        </DropdownMenuItem>
+        {canAdmin && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => void handleArchiveToggle()} disabled={isUpdating}>
+              {isArchived ? (
+                <>
+                  <ArchiveRestore /> Unarchive
+                </>
+              ) : (
+                <>
+                  <Archive /> Archive
+                </>
+              )}
+            </DropdownMenuItem>
+            <DropdownMenuItem variant='destructive' onClick={() => void handleDelete()}>
+              <Trash2 /> Delete
+            </DropdownMenuItem>
+          </>
+        )}
       </PublishClusterShell>
 
       <AgentVersionsDialog

--- a/apps/web/src/components/agents/ui/detail/bindings/bindings-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/bindings/bindings-section.tsx
@@ -10,6 +10,7 @@ import { Plus, ShieldCheck } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAgentAccess } from '../../../hooks/use-agent-access'
 import type { AgentDetail } from '../../../store/agent-store'
 import { AddBindingDialog } from './add-binding-dialog'
 import { BindingRow } from './binding-row'
@@ -53,6 +54,7 @@ export function BindingsSection({ agent }: BindingsSectionProps) {
   const toolMeta = useToolMeta(agent)
   const { bindings, save } = useBindings(agent)
   const refLabel = useBindingRefLabel()
+  const { canEdit } = useAgentAccess(agent.id)
 
   // Split overrides into enabled-tool entries (shown) vs disabled-tool entries
   // (kept inert, hidden — surfaced only as a count).
@@ -101,16 +103,19 @@ export function BindingsSection({ agent }: BindingsSectionProps) {
       description='Tools are scoped by their built-in defaults. Override an input to pin a value or rebind it.'
       collapsible={false}
       actions={
-        <Button
-          variant='ghost'
-          size='xs'
-          onClick={() => {
-            setEditing(null)
-            setDialogOpen(true)
-          }}>
-          <Plus />
-          Add override
-        </Button>
+        // Bindings are authoring (plan 25 §4.2) — `edit`, not `admin`.
+        canEdit ? (
+          <Button
+            variant='ghost'
+            size='xs'
+            onClick={() => {
+              setEditing(null)
+              setDialogOpen(true)
+            }}>
+            <Plus />
+            Add override
+          </Button>
+        ) : undefined
       }>
       {toolMeta.isLoading ? (
         <EmptySection loading className='mx-3' />

--- a/apps/web/src/components/agents/ui/detail/permissions/agent-policy-view.tsx
+++ b/apps/web/src/components/agents/ui/detail/permissions/agent-policy-view.tsx
@@ -3,16 +3,12 @@
 
 import type { AgentPermissionPolicy } from '@auxx/database'
 import type { ResourcePermission } from '@auxx/database/enums'
-import {
-  AREA_ORDER,
-  INSTANCE_ACCESS_RESOURCES,
-  type InstanceAccessKey,
-  PERMISSION_AREAS,
-} from '@auxx/lib/permissions/client'
+import { AREA_ORDER, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { isAccessManageable } from '@auxx/lib/resources/client'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { BookOpen, Database, LayoutDashboard, Workflow } from 'lucide-react'
 import { useMemo } from 'react'
+import type { AgentPolicyInstanceKey } from '~/components/permissions/ui/profile-copy'
 import {
   ResolvedAccessBadge,
   ResolvedAccessDialog,
@@ -24,8 +20,10 @@ import {
 import { useResources } from '~/components/resources/hooks'
 import { AGENT_ACCESS_LEVEL_META, hasAgentOverride, resolveAgentLevel } from './agent-access-level'
 
+// Keyed by `AgentPolicyInstanceKey`, not `InstanceAccessKey` — `agent` is
+// deliberately outside an agent policy's keyspace (see that type).
 const RESOURCE_TYPE_META: Record<
-  InstanceAccessKey,
+  AgentPolicyInstanceKey,
   { label: string; icon: React.ReactNode; description: string }
 > = {
   dataset: {
@@ -194,7 +192,9 @@ export function AgentResolvedPolicyDialog({
         key: instances.key,
         title: instances.title,
         defaultRow: { label: instances.defaultLabel, level: AGENT_LEVEL[instances.level] },
-        rows: (Object.keys(INSTANCE_ACCESS_RESOURCES) as InstanceAccessKey[]).map((type) => {
+        // Driven off `RESOURCE_TYPE_META`, not `INSTANCE_ACCESS_RESOURCES` —
+        // the latter now carries `agent`, which an agent policy never expresses.
+        rows: (Object.keys(RESOURCE_TYPE_META) as AgentPolicyInstanceKey[]).map((type) => {
           const perType = policy.resources?.[type]
           const perTypeOverrides = Object.keys(perType?.overrides ?? {}).length
           const meta = RESOURCE_TYPE_META[type]

--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
@@ -25,6 +25,13 @@ import type { AutosaveState } from '../../shared/autosave-indicator'
 
 interface PersonaEditorProps {
   agent: AgentDetail
+  /**
+   * The viewer holds `view` but not `edit` on this agent (plan 25 §4.2). The
+   * prompt is still shown — `view` is *usable*, and reading the persona is part
+   * of knowing what you are chatting with — but TipTap mounts non-editable, so
+   * no autosave can fire.
+   */
+  readOnly?: boolean
   /** Lifted autosave state — used by the page-header indicator. */
   onAutosaveChange?: (state: AutosaveState) => void
 }
@@ -64,7 +71,7 @@ function readPromptContent(
  * the subtree's host changes (portal target swap or simple reparenting),
  * leaving the view DOM in a broken state.
  */
-export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
+export function PersonaEditor({ agent, readOnly, onAutosaveChange }: PersonaEditorProps) {
   const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
   const { patch } = useAgentAutosave(agent.id, { onStateChange: onAutosaveChange })
   const utils = api.useUtils()
@@ -166,6 +173,7 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
                   referencePickerRef={referencePickerRef}
                   referenceTabs={PERSONA_REFERENCE_TABS}
                   allowedBlocks={PERSONA_BLOCKS}
+                  editable={!readOnly}
                 />
               </div>
             </CollapseWrap>
@@ -195,6 +203,7 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
                   referencePickerRef={referencePickerRef}
                   referenceTabs={PERSONA_REFERENCE_TABS}
                   allowedBlocks={PERSONA_BLOCKS}
+                  editable={!readOnly}
                 />
               )}
             </ScrollArea>

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { Lock, Plus, Wrench } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { useAgentAccess } from '~/components/agents/hooks/use-agent-access'
 import { useToolCatalog } from '~/components/agents/hooks/use-tool-catalog'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 import { AppAccountDialog } from '~/components/apps/ui/app-account-dialog'
@@ -41,6 +42,7 @@ export function ToolsSection({ agent, onAutosaveChange, onNavigate }: ToolsSecti
   const { catalog, isLoading: catalogIsLoading } = useToolCatalog({
     surface: agent.kind === 'chat' ? 'chat' : undefined,
   })
+  const { canEdit } = useAgentAccess(agent.id)
 
   const handleSavingChange = useCallback(
     (saving: boolean) => {
@@ -212,16 +214,19 @@ export function ToolsSection({ agent, onAutosaveChange, onNavigate }: ToolsSecti
         initialOpen
         collapsible={false}
         actions={
-          <Button
-            size='xs'
-            variant='ghost'
-            onClick={() => {
-              setPendingAppId(null)
-              setDialogOpen(true)
-            }}>
-            <Plus />
-            Add tools
-          </Button>
+          // Toolsets are authoring (plan 25 §4.2) — `edit`, not `admin`.
+          canEdit ? (
+            <Button
+              size='xs'
+              variant='ghost'
+              onClick={() => {
+                setPendingAppId(null)
+                setDialogOpen(true)
+              }}>
+              <Plus />
+              Add tools
+            </Button>
+          ) : undefined
         }>
         {catalogIsLoading ? (
           <div className='flex flex-col pe-4'>
@@ -256,13 +261,21 @@ export function ToolsSection({ agent, onAutosaveChange, onNavigate }: ToolsSecti
                 restrictionCountBySlug={restrictionCountBySlug}
                 collapsed={collapsed}
                 onToggleCollapsed={toggleCollapsed}
-                onRemove={handleRemove}
-                onToggleTool={toggleTool}
-                onAddToApp={(appId) => {
-                  setPendingAppId(appId)
-                  setDialogOpen(true)
-                }}
-                onOpenAccountPicker={setAccountPickerAppId}
+                // Every mutating affordance on a row is an optional callback,
+                // so withholding them renders the whole tree read-only for a
+                // `view` holder (`agentToolset.listTools` is `agentsView`, so
+                // they can still SEE what the agent may call).
+                onRemove={canEdit ? handleRemove : undefined}
+                onToggleTool={canEdit ? toggleTool : undefined}
+                onAddToApp={
+                  canEdit
+                    ? (appId) => {
+                        setPendingAppId(appId)
+                        setDialogOpen(true)
+                      }
+                    : undefined
+                }
+                onOpenAccountPicker={canEdit ? setAccountPickerAppId : undefined}
                 boundCredIdByApp={boundCredIdByApp}
                 warnNotExternalSafe={agent.kind === 'chat'}
                 mcpReconnectSlugs={mcpReconnectSlugs}

--- a/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/components/pickers/trigger-source'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api, type RouterOutputs } from '~/trpc/react'
+import { useAgentAccess } from '../../../hooks/use-agent-access'
 import type { AgentDetail } from '../../../store/agent-store'
 import { AgentTriggerDialog } from './agent-trigger-dialog'
 import { TriggerLabel } from './trigger-label'
@@ -96,6 +97,12 @@ export function TriggersSectionContent({
     useState<WebhookEndpointSource | null>(null)
   const { appInstallations } = useAppsContext()
   const utils = api.useUtils()
+  // Triggers are ADMINISTRATION, not authoring (plan 25 §4.2): a trigger makes
+  // the agent act autonomously on its own credentials, with no invoker to
+  // intersect against. All four `agentTrigger` writes — create, update, delete,
+  // runNow — assert `admin` server-side, so every affordance here (edit, delete,
+  // and the enable switch, which is an `update`) follows.
+  const { canAdmin } = useAgentAccess(agent.id)
 
   const triggers = api.agentTrigger.list.useQuery({ agentId: agent.id })
 
@@ -254,8 +261,9 @@ export function TriggersSectionContent({
                   lastFiredAt={existing.lastFiredAt}
                   hasError={!!existing.lastError}
                   enabled={existing.enabled}
-                  isEditable
+                  isEditable={canAdmin}
                   isDeletable={false}
+                  readOnly={!canAdmin}
                   onEdit={() => setEditingTrigger(existing)}
                   onToggle={(checked) =>
                     updateTrigger.mutate({ id: existing.id, enabled: checked })
@@ -272,8 +280,9 @@ export function TriggersSectionContent({
                 lastFiredAt={null}
                 hasError={false}
                 enabled={false}
-                isEditable
+                isEditable={canAdmin}
                 isDeletable={false}
+                readOnly={!canAdmin}
                 onEdit={() => setCreatingBuiltinKind(kind)}
                 onToggle={(checked) => {
                   if (!checked) return
@@ -319,8 +328,9 @@ export function TriggersSectionContent({
                 lastFiredAt={row.lastFiredAt}
                 hasError={!!row.lastError}
                 enabled={row.enabled}
-                isEditable={isEditable}
-                isDeletable
+                isEditable={canAdmin && isEditable}
+                isDeletable={canAdmin}
+                readOnly={!canAdmin}
                 onEdit={() => setEditingTrigger(row)}
                 onDelete={() => handleDelete(row)}
                 onToggle={(checked) => updateTrigger.mutate({ id: row.id, enabled: checked })}
@@ -346,6 +356,8 @@ interface TriggerRowProps {
   enabled: boolean
   isEditable: boolean
   isDeletable: boolean
+  /** The viewer lacks `admin` on this agent — the enable switch is frozen too. */
+  readOnly?: boolean
   onEdit?: () => void
   onDelete?: () => void
   onToggle: (checked: boolean) => void
@@ -366,6 +378,7 @@ function TriggerRow({
   enabled,
   isEditable,
   isDeletable,
+  readOnly,
   onEdit,
   onDelete,
   onToggle,
@@ -424,7 +437,13 @@ function TriggerRow({
               </button>
             </Tooltip>
           ) : null}
-          <Switch size='xs' className='ml-1' checked={enabled} onCheckedChange={onToggle} />
+          <Switch
+            size='xs'
+            className='ml-1'
+            checked={enabled}
+            disabled={readOnly}
+            onCheckedChange={onToggle}
+          />
         </>
       }
     />

--- a/apps/web/src/components/agents/ui/list/agent-card.tsx
+++ b/apps/web/src/components/agents/ui/list/agent-card.tsx
@@ -1,12 +1,14 @@
 // apps/web/src/components/agents/ui/list/agent-card.tsx
 'use client'
 
+import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
 import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ListCard } from '@auxx/ui/components/list-card'
-import { Archive, ArchiveRestore, MessageCircle, Pencil, Trash2 } from 'lucide-react'
+import { Archive, ArchiveRestore, Eye, MessageCircle, Pencil, Share2, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import {
   useBulkMode,
   useIsPending,
@@ -14,7 +16,9 @@ import {
   useListSelection,
   usePendingLabel,
 } from '~/components/list-selection'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAgentAccess } from '../../hooks/use-agent-access'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
 import type { AgentListItem } from '../../store/agent-store'
 import { AgentAvatar } from '../shared/agent-avatar'
@@ -27,6 +31,13 @@ export function AgentCard({ agent }: AgentCardProps) {
   const router = useRouter()
   const { archiveAgent, unarchiveAgent, deleteAgent, deleteSetupDraft } = useAgentMutations()
   const [confirm, ConfirmDialog] = useConfirm()
+  const [shareOpen, setShareOpen] = useState(false)
+  // Per-agent instance access (plan 25 §4.2). Share…, Archive/Unarchive and
+  // Delete are the `admin` rung; discarding an unfinished setup draft is
+  // authoring (`edit`). Opening the agent stays at `view` — `agent.list`
+  // already filters to what this member may see, so every card here is at
+  // least viewable.
+  const { canEdit, canAdmin } = useAgentAccess(agent.id)
   const bulkMode = useBulkMode()
   const selected = useIsSelected(agent.id)
   const pending = useIsPending(agent.id)
@@ -81,6 +92,13 @@ export function AgentCard({ agent }: AgentCardProps) {
   return (
     <>
       <ConfirmDialog />
+      {canAdmin && (
+        <InstanceShareDialog
+          recordId={toRecordId('agent', agent.id)}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
       <ListCard
         href={`/app/agents/${agent.slug}`}
         ariaLabel={displayName}
@@ -121,32 +139,45 @@ export function AgentCard({ agent }: AgentCardProps) {
         menu={
           <>
             <DropdownMenuItem onClick={wrap(handleNavigate)}>
-              <Pencil />
-              {isDraft ? 'Continue setup' : 'Edit'}
+              {canEdit ? <Pencil /> : <Eye />}
+              {isDraft ? 'Continue setup' : canEdit ? 'Edit' : 'Open'}
             </DropdownMenuItem>
-            {isDraft ? (
-              <DropdownMenuItem onClick={wrap(handleDiscardDraft)}>
-                <Trash2 />
-                Discard draft
+            {canAdmin && !isDraft && (
+              <DropdownMenuItem onClick={wrap(() => setShareOpen(true))}>
+                <Share2 />
+                Share…
               </DropdownMenuItem>
+            )}
+            {isDraft ? (
+              canEdit && (
+                <DropdownMenuItem onClick={wrap(handleDiscardDraft)}>
+                  <Trash2 />
+                  Discard draft
+                </DropdownMenuItem>
+              )
             ) : (
               <>
-                {archived ? (
-                  <DropdownMenuItem onClick={wrap(() => unarchiveAgent(agent.id))}>
-                    <ArchiveRestore />
-                    Unarchive
-                  </DropdownMenuItem>
-                ) : (
-                  <DropdownMenuItem onClick={wrap(handleArchive)}>
-                    <Archive />
-                    Archive
-                  </DropdownMenuItem>
+                {canAdmin &&
+                  (archived ? (
+                    <DropdownMenuItem onClick={wrap(() => unarchiveAgent(agent.id))}>
+                      <ArchiveRestore />
+                      Unarchive
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem onClick={wrap(handleArchive)}>
+                      <Archive />
+                      Archive
+                    </DropdownMenuItem>
+                  ))}
+                {canAdmin && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem variant='destructive' onClick={wrap(handleDelete)}>
+                      <Trash2 />
+                      Delete
+                    </DropdownMenuItem>
+                  </>
                 )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem variant='destructive' onClick={wrap(handleDelete)}>
-                  <Trash2 />
-                  Delete
-                </DropdownMenuItem>
               </>
             )}
           </>

--- a/apps/web/src/components/kbar/actions/navigation.ts
+++ b/apps/web/src/components/kbar/actions/navigation.ts
@@ -75,11 +75,13 @@ export function useNavigationActions(): PaletteAction[] {
       })
     }
 
-    if (hasAccess('agents') && can('agents.manage')) {
+    // `agents.view` — navigation is reachability, not authoring (see the
+    // `workflows.view` entry below).
+    if (hasAccess('agents') && can('agents.view')) {
       actions.push({
         id: 'nav.agents',
         label: 'Agents',
-        subtitle: 'Manage your agents',
+        subtitle: 'Your agents',
         icon: 'brain',
         keywords: 'agents ai',
         perform: () => nav('/agents'),

--- a/apps/web/src/components/permissions/hooks/use-instance-resource-lists.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-resource-lists.ts
@@ -63,6 +63,11 @@ export function useInstanceResourceLists(
     { limit: INSTANCE_PAGE_SIZE, offset: 0 },
     { enabled: open.workflow === true, staleTime: 60_000 }
   )
+  // `agent.list` is unpaginated (the `kb.list` shape), so it can never truncate.
+  const agents = api.agent.list.useQuery(undefined, {
+    enabled: open.agent === true,
+    staleTime: 60_000,
+  })
 
   return useMemo(
     () => ({
@@ -89,6 +94,14 @@ export function useInstanceResourceLists(
         isLoading: workflows.isLoading && open.workflow === true,
         truncated: workflows.data?.hasMore === true,
       },
+      agent: {
+        // `Agent.name` is nullable (chat-driven creation leaves it unset and
+        // writes `slug = id`), so fall back to the slug rather than rendering a
+        // blank row.
+        items: (agents.data ?? []).map((a) => ({ id: a.id, name: a.name ?? a.slug })),
+        isLoading: agents.isLoading && open.agent === true,
+        truncated: false,
+      },
     }),
     [
       datasets.data,
@@ -99,6 +112,8 @@ export function useInstanceResourceLists(
       dashboards.isLoading,
       workflows.data,
       workflows.isLoading,
+      agents.data,
+      agents.isLoading,
       open,
     ]
   )

--- a/apps/web/src/components/permissions/ui/agent-policy-editor.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-editor.tsx
@@ -3,13 +3,7 @@
 
 import type { AgentPermissionPolicy } from '@auxx/database'
 import type { ResourcePermission } from '@auxx/database/enums'
-import {
-  Area,
-  FeatureKey,
-  type InstanceAccessKey,
-  type Level,
-  PERMISSION_AREAS,
-} from '@auxx/lib/permissions/client'
+import { Area, FeatureKey, type Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Bot, SlidersHorizontal } from 'lucide-react'
@@ -47,7 +41,11 @@ import { clampToArea } from './level-control'
 import { LEVEL_OF_PERMISSION, permissionOfLevel } from './level-labels'
 import type { AreaChildFilter, AreaChildren } from './leveled-area-grid'
 import { ProfileAreaGrid } from './profile-area-grid'
-import { AGENT_POLICY_AREA_GROUPS, AGENT_POLICY_AREAS } from './profile-copy'
+import {
+  AGENT_POLICY_AREA_GROUPS,
+  AGENT_POLICY_AREAS,
+  type AgentPolicyInstanceKey,
+} from './profile-copy'
 
 /** A draft agent bound to this profile — what a save actually reaches. */
 export interface BoundAgentDraft {
@@ -181,7 +179,7 @@ export function AgentPolicyEditor({
    * them. Never silent (plan 29 §2.3).
    */
   const handleTypeChange = useCallback(
-    async (type: InstanceAccessKey, level: ResourcePermission | undefined) => {
+    async (type: AgentPolicyInstanceKey, level: ResourcePermission | undefined) => {
       if (level !== undefined) {
         setResourceTypeDefault(type, level)
         return
@@ -287,7 +285,13 @@ export function AgentPolicyEditor({
       }
 
       const type = AREA_TO_INSTANCE_KEY[area]
-      if (!type) return undefined
+      // `agent` is an instance-access key but NOT an agent-policy one — an agent
+      // policy has nothing to say about which agents an agent may reach (see
+      // `AgentPolicyInstanceKey`). `Area.agents` is already excluded from
+      // `AGENT_POLICY_AREA_GROUPS`, so this branch is unreachable in practice;
+      // narrowing here is what makes that exclusion checkable rather than
+      // assumed, since `AREA_TO_INSTANCE_KEY` is derived from the full registry.
+      if (!type || type === 'agent') return undefined
 
       const entry = policy.resources[type]
       const overrides = entry?.overrides ?? {}

--- a/apps/web/src/components/permissions/ui/agent-policy-instance-rows.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-instance-rows.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import type { ResourcePermission } from '@auxx/database/enums'
-import type { InstanceAccessKey } from '@auxx/lib/permissions/client'
 import { EmptySection } from '@auxx/ui/components/section'
 import { TreeRow, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
 import { BookOpen, Database, LayoutDashboard, Library, Workflow } from 'lucide-react'
@@ -11,6 +10,7 @@ import type { InstanceResourceItem } from '../hooks/use-instance-resource-lists'
 import { AccessLevelSelect } from './access-level-select'
 import { allInstancesTitle } from './agent-policy-copy'
 import { permissionLabel } from './level-labels'
+import type { AgentPolicyInstanceKey } from './profile-copy'
 
 /** Indent of every agent-policy child row under its area row. */
 const CHILD_DEPTH = 1
@@ -19,8 +19,16 @@ const CHILD_DEPTH = 1
  * Display metadata per shareable resource type. The plural label is what the
  * "All X" row is named after, so it also reaches the host's destructive-confirm
  * copy — exported rather than duplicated there.
+ *
+ * Keyed by {@link AgentPolicyInstanceKey}, NOT `InstanceAccessKey`: `agent`
+ * joined the instance-access registry in 2026-07-28's agents slice, and an
+ * agent policy has nothing to say about which agents an agent may reach. See
+ * that type for why the exclusion is structural rather than a runtime filter.
  */
-export const RESOURCE_TYPE_META: Record<InstanceAccessKey, { label: string; icon: ReactNode }> = {
+export const RESOURCE_TYPE_META: Record<
+  AgentPolicyInstanceKey,
+  { label: string; icon: ReactNode }
+> = {
   dataset: { label: 'Datasets', icon: <Database className='size-4' /> },
   kb: { label: 'Knowledge bases', icon: <BookOpen className='size-4' /> },
   dashboard: { label: 'Dashboards', icon: <LayoutDashboard className='size-4' /> },
@@ -28,7 +36,7 @@ export const RESOURCE_TYPE_META: Record<InstanceAccessKey, { label: string; icon
 }
 
 interface AgentPolicyInstanceRowsProps {
-  type: InstanceAccessKey
+  type: AgentPolicyInstanceKey
   /** `resources[type].default`, or `undefined` when the type has no entry at all. */
   typeDefault: ResourcePermission | undefined
   /** `resourceDefault` — what a type with no entry of its own resolves to. */

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.test.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.test.tsx
@@ -28,6 +28,12 @@ const { granteeAccess, save, defAccess, instanceRows } = vi.hoisted(() => ({
   granteeAccess: { current: undefined as unknown },
   save: vi.fn(),
   defAccess: { isLoading: false, rows: [], setLevel: vi.fn() },
+  // One entry per `InstanceAccessKey`. `agent` joined the registry in the
+  // 2026-07-28 agents slice, and because `AREA_TO_INSTANCE_KEY` is DERIVED from
+  // that registry, the Agents area row immediately started nesting instance
+  // rows — so a mock missing the key crashes on `instances[type].isLoading`
+  // rather than merely under-covering. Adding an instance-access resource will
+  // do this again; the fix is another entry here, not a guard in the component.
   instanceRows: {
     isLoading: false,
     lists: {
@@ -35,8 +41,9 @@ const { granteeAccess, save, defAccess, instanceRows } = vi.hoisted(() => ({
       kb: { items: [], isLoading: false, truncated: false },
       dashboard: { items: [], isLoading: false, truncated: false },
       workflow: { items: [], isLoading: false, truncated: false },
+      agent: { items: [], isLoading: false, truncated: false },
     },
-    rowsByKey: { dataset: [], kb: [], dashboard: [], workflow: [] },
+    rowsByKey: { dataset: [], kb: [], dashboard: [], workflow: [], agent: [] },
     setGrant: vi.fn(),
   },
 }))

--- a/apps/web/src/components/permissions/ui/instance-share-copy.ts
+++ b/apps/web/src/components/permissions/ui/instance-share-copy.ts
@@ -6,7 +6,7 @@ import {
   INSTANCE_ACCESS_RESOURCES,
   type InstanceAccessKey,
 } from '@auxx/lib/permissions/client'
-import { BookOpen, Database, LayoutDashboard, type LucideIcon, Workflow } from 'lucide-react'
+import { BookOpen, Bot, Database, LayoutDashboard, type LucideIcon, Workflow } from 'lucide-react'
 
 /**
  * Per-resource UI copy for the generic {@link import('./instance-share-card').InstanceShareCard}
@@ -76,6 +76,28 @@ export const INSTANCE_SHARE_COPY: Record<InstanceAccessKey, InstanceShareCopy> =
       'and polling triggers run as the system and keep firing this workflow even when nobody ' +
       'here can see it. Only runs someone starts by hand are affected.',
   },
+  agent: {
+    noun: 'agent',
+    baselineHint: 'Shared with the workspace by default. Restrict it to lock it down.',
+    levels: {
+      read: 'Chat, mention & assign work',
+      write: 'Edit prompt, tools & knowledge',
+      full: 'Publish, rename & delete',
+    },
+    // Plan 25 §4.2.DECIDED. The obvious fear — "sharing an agent hands over
+    // everything the agent can reach" — is FALSE here, and saying so is the
+    // point: `agent-run-capabilities.ts` intersects the agent's published policy
+    // with the INVOKER's own capabilities on every human-driven path, so the
+    // note must not repeat the warning plan 25 §4.2.a originally drafted. What a
+    // share genuinely does hand over is narrower and invisible in the policy
+    // grid: the agent's bound connections and installed app tools.
+    scopeNote:
+      'People you share this with chat as themselves — the agent cannot read anything on their ' +
+      'behalf that they could not read directly. What they do gain is the agent’s connected ' +
+      'accounts and installed app tools, which run on the agent’s credentials. Automation is ' +
+      'unaffected: schedules, record events, and app triggers run as the system and keep going ' +
+      'even when nobody here can see the agent.',
+  },
 }
 
 /**
@@ -90,6 +112,7 @@ export const INSTANCE_TYPE_META: Record<InstanceAccessKey, { label: string; icon
   kb: { label: 'Knowledge bases', icon: BookOpen },
   dashboard: { label: 'Dashboards', icon: LayoutDashboard },
   workflow: { label: 'Workflows', icon: Workflow },
+  agent: { label: 'Agents', icon: Bot },
 }
 
 /**

--- a/apps/web/src/components/permissions/ui/profile-copy.ts
+++ b/apps/web/src/components/permissions/ui/profile-copy.ts
@@ -1,7 +1,13 @@
 // apps/web/src/components/permissions/ui/profile-copy.ts
 
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
-import { AREA_ORDER, Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
+import {
+  AREA_ORDER,
+  Area,
+  type InstanceAccessKey,
+  Level,
+  PERMISSION_AREAS,
+} from '@auxx/lib/permissions/client'
 
 /**
  * Shared copy + constants for the permission-profile editor (doc 19 §7).
@@ -92,16 +98,21 @@ export const WORKER_LOCK_REASON =
 export function areaGroups({
   excludeAdminOnly,
   excludeWorkerOnly,
+  exclude,
 }: {
   excludeAdminOnly: boolean
   excludeWorkerOnly: boolean
+  /** Areas dropped by name, for reasons no registry flag expresses. */
+  exclude?: readonly Area[]
 }): Array<{ group: string; areas: Area[] }> {
   const order: string[] = []
   const byGroup = new Map<string, Area[]>()
+  const excluded = new Set(exclude ?? [])
   for (const area of AREA_ORDER) {
     const meta = PERMISSION_AREAS[area]
     if (excludeAdminOnly && meta.adminOnly) continue
     if (excludeWorkerOnly && meta.workerOnly) continue
+    if (excluded.has(area)) continue
     if (!byGroup.has(meta.group)) {
       byGroup.set(meta.group, [])
       order.push(meta.group)
@@ -133,14 +144,40 @@ export const PROFILE_AREA_GROUPS: Array<{ group: string; areas: Area[] }> = area
  * the *human* baseline; an agent's authority comes from this policy and nothing
  * else, bounded at publish by the §2.4a author clamp — so the honest treatment is
  * to show the rung and name the clamp, not to hide it.
+ *
+ * **`Area.agents` is excluded by name** (plan 25 §4.2.DECIDED, decision 4). It
+ * became an `INSTANCE_ACCESS_RESOURCES` key in 2026-07-28's agents slice, and
+ * {@link AREA_TO_INSTANCE_KEY} is *derived* from that registry — so leaving the
+ * area here would auto-grow per-agent child rows **inside another agent's
+ * policy** ("which agents may this agent access") with no code change and no
+ * failing test. Nothing consumes agent-vs-agent instance access, so that is a
+ * control wired to nothing: the exact phantom-control failure
+ * `NON_RECORD_ENTITY_SLUGS`' doc comment exists to prevent. Re-admitting it
+ * means first building the thing it would claim to configure.
  */
 export const AGENT_POLICY_AREA_GROUPS: Array<{ group: string; areas: Area[] }> = areaGroups({
   excludeAdminOnly: false,
   excludeWorkerOnly: true,
+  exclude: [Area.agents],
 })
 
 /** Every area the agent policy renders — also the keyspace the clamp preview checks. */
 export const AGENT_POLICY_AREAS: readonly Area[] = AGENT_POLICY_AREA_GROUPS.flatMap((g) => g.areas)
+
+/**
+ * The instance-access resource types an AGENT policy can express per-instance
+ * rules for — every one except `agent` itself, for the reason on
+ * {@link AGENT_POLICY_AREA_GROUPS}.
+ *
+ * This is a TYPE-level exclusion on purpose. Dropping `Area.agents` from the
+ * groups above stops the rows rendering today, but nothing would stop a future
+ * edit re-admitting the area and silently growing "which agents may this agent
+ * access" controls again. Every agent-policy map keyed by resource type is
+ * `Record<AgentPolicyInstanceKey, …>`, so the exclusion survives as a compile
+ * error while a genuinely NEW instance-access resource still breaks the build
+ * the way an exhaustive map should.
+ */
+export type AgentPolicyInstanceKey = Exclude<InstanceAccessKey, 'agent'>
 
 /** The icon a profile falls back to when it carries no `icon` of its own. */
 export const DEFAULT_PROFILE_ICON = { iconId: 'shield-check', color: 'blue' }

--- a/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
+++ b/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
@@ -265,4 +265,5 @@ const NOUNS: Record<InstanceAccessKey, string> = {
   kb: 'knowledge base',
   dashboard: 'dashboard',
   workflow: 'workflow',
+  agent: 'agent',
 }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -122,7 +122,11 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     slug: 'agents',
     icon: <Bot />,
     featureKey: 'agents',
-    permissionKey: 'agents.manage',
+    // The nav entry is a "can I get in at all" gate, so it reads the Read rung
+    // (`agents.view`), not the authoring one — matching the `workflows.view`
+    // entry below. #1346 left workflows on `.manage` and hid the sidebar from
+    // every view/edit holder; do not repeat it here.
+    permissionKey: 'agents.view',
   },
   {
     id: 'calls',

--- a/apps/web/src/server/api/routers/actor-agent-access.test.ts
+++ b/apps/web/src/server/api/routers/actor-agent-access.test.ts
@@ -1,0 +1,324 @@
+// apps/web/src/server/api/routers/actor-agent-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import type { Actor } from '@auxx/types/actor'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 25 §4.2 decision 1 at the picker endpoint — `view` means **usable**, and
+ * "the picker hides what the endpoint still serves" is the consequence it names.
+ *
+ * `actor.list` / `actor.search` / `actor.getByIds` fill every actor picker in
+ * the app (assignees, @-mentions, DM sender, ACTOR field values). They filtered
+ * agents not at all, so an agent restricted to `none` still showed up to be
+ * picked — and `getByIds` additionally handed back that agent's name, avatar,
+ * slug and synthetic user id for any id a client cared to ask about.
+ *
+ * Two properties, and the second is why this is a FILTER and not an assert:
+ *  1. an agent the caller cannot view never appears;
+ *  2. users and groups are untouched — a member who can see zero agents still
+ *     gets a working picker, not a 403 (the mistake plan 30 §2.2 calls out for
+ *     `workflow.list`).
+ *
+ * Behavioral: the real router is driven through a tRPC caller with a REAL
+ * {@link CapabilitySet}. `ActorService` is mocked to return the org's FULL
+ * unfiltered actor set, so the router is the only thing that can be dropping
+ * rows — a router that stopped filtering hands the fixture straight back and
+ * every case below fails.
+ */
+
+const { listActors, getByIds, searchActors } = vi.hoisted(() => ({
+  listActors: vi.fn(),
+  getByIds: vi.fn(),
+  searchActors: vi.fn(),
+}))
+
+vi.mock('@auxx/lib/actors', () => ({
+  ActorService: class {
+    listActors = listActors
+    getByIds = getByIds
+    searchActors = searchActors
+  },
+  GroupMemberService: class {
+    getMembers = vi.fn(async () => [])
+    expandToUsers = vi.fn(async () => [])
+  },
+}))
+
+/**
+ * The procedure builders, mirroring what `trpc.ts` really does.
+ *
+ * `protectedProcedure` deliberately STRIPS `ctx.capabilities`: the real one does
+ * not resolve a `CapabilitySet` (only `capabilityProcedure` does), so a
+ * procedure downgraded back to `protectedProcedure` would throw on
+ * `ctx.capabilities.instanceListScope` in production. Modelling that here makes
+ * the downgrade fail a test instead of shipping.
+ */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    // `next({ ctx })` MERGES, so the strip has to be an explicit overwrite.
+    protectedProcedure: t.procedure.use(({ next }) => next({ ctx: { capabilities: undefined } })),
+  }
+})
+
+// Deep path on purpose — the `@auxx/lib/permissions` barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { actorRouter } = await import('./actor')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+
+const OPEN_AGENT = 'agt_opencuid00000000000000'
+const RESTRICTED_AGENT = 'agt_restrictedcuid00000000'
+const OPEN_AGENT_USER = 'usr_agentopen0000000000000'
+const RESTRICTED_AGENT_USER = 'usr_agentrestricted0000000'
+
+const HUMAN: Actor = {
+  actorId: 'user:usr_human000000000000000',
+  type: 'user',
+  name: 'Ada',
+  email: 'ada@example.com',
+  avatarUrl: null,
+  role: 'USER',
+}
+
+const GROUP: Actor = {
+  actorId: 'group:grp_cuid00000000000000',
+  type: 'group',
+  name: 'Support',
+  description: null,
+  avatarUrl: null,
+  memberCount: 3,
+  visibility: 'public',
+}
+
+function agentActor(agentId: string, userId: string, slug: string): Actor {
+  return {
+    actorId: `agent:${agentId}`,
+    type: 'agent',
+    name: slug,
+    avatarUrl: null,
+    agentId,
+    userId,
+    slug,
+    mentionable: true,
+  }
+}
+
+const OPEN = agentActor(OPEN_AGENT, OPEN_AGENT_USER, 'open-agent')
+const RESTRICTED = agentActor(RESTRICTED_AGENT, RESTRICTED_AGENT_USER, 'restricted-agent')
+
+/** Everything the org has, as `ActorService` would hand it over unfiltered. */
+const ALL_ACTORS: Actor[] = [HUMAN, OPEN, RESTRICTED, GROUP]
+
+/**
+ * A real `CapabilitySet` for a MEMBER at `agentsLevel` with explicit
+ * `ResourceAccess` instance rows.
+ *
+ * The derived Read rung mirrors `composeUserCapabilities`: any ≥`view` agent row
+ * synthesizes `agentsView`, so an `agents: None` grantee is not shut out at the
+ * coarse front door. Clamped away on a worker seat, where `agents` is outside
+ * `WORKER_AREAS`.
+ */
+function capabilitiesFor(
+  agentsLevel: Level,
+  opts: {
+    instances?: Record<string, ResourcePermission>
+    role?: 'MEMBER' | 'OWNER'
+    seatType?: 'full' | 'worker'
+  } = {}
+) {
+  const instances = opts.instances ?? {}
+  const seatType = opts.seatType ?? 'full'
+  const derived =
+    seatType !== 'worker' && Object.values(instances).some((p) => p !== ResourcePermission.none)
+      ? [PermissionKey.agentsView]
+      : []
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.agents]: agentsLevel })),
+    {},
+    opts.role ?? 'MEMBER',
+    seatType,
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived)
+  )
+}
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return actorRouter.createCaller({
+    db: {},
+    capabilities,
+    session: { organizationId: ORG_ID, userId: USER_ID, isSuperAdmin: false },
+  } as never)
+}
+
+/** Ids of whatever actors came back, in order. */
+const idsOf = (actors: Actor[]) => actors.map((a) => a.actorId)
+
+beforeEach(() => {
+  listActors.mockReset().mockResolvedValue(ALL_ACTORS)
+  searchActors.mockReset().mockResolvedValue(ALL_ACTORS)
+  getByIds.mockReset().mockResolvedValue(
+    new Map<string, Actor>([
+      [HUMAN.actorId, HUMAN],
+      [OPEN.actorId, OPEN],
+      [RESTRICTED.actorId, RESTRICTED],
+      [GROUP.actorId, GROUP],
+    ])
+  )
+})
+
+/** Area open (`exclude` arm) with ONE agent explicitly restricted to `none`. */
+const restrictedFromOne = () =>
+  capabilitiesFor(Level.Full, { instances: { [RESTRICTED_AGENT]: ResourcePermission.none } })
+
+describe('actor router — a restricted agent never reaches the picker', () => {
+  it('list drops it', async () => {
+    const result = await caller(restrictedFromOne()).list({ target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, OPEN.actorId, GROUP.actorId])
+  })
+
+  it('search drops it', async () => {
+    const result = await caller(restrictedFromOne()).search({ query: 'a', target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, OPEN.actorId, GROUP.actorId])
+  })
+
+  it('getByIds drops it', async () => {
+    const result = await caller(restrictedFromOne()).getByIds({
+      ids: [HUMAN.actorId, OPEN.actorId, RESTRICTED.actorId, GROUP.actorId],
+    })
+    expect(Object.keys(result).sort()).toEqual([HUMAN.actorId, OPEN.actorId, GROUP.actorId].sort())
+  })
+
+  it('getByIds also drops the LEGACY `user:<syntheticUserId>` spelling', async () => {
+    // `ActorService.getByIds` stamps an AgentActor under BOTH `agent:<id>` and
+    // `user:<agent.userId>`, because Thread.assigneeIds / ACTOR field rows still
+    // address agents the old way. Filtering on the map KEY would let the whole
+    // agent through under its user spelling — the value is what carries the
+    // agent id, so the value is what gets judged.
+    getByIds.mockResolvedValue(
+      new Map<string, Actor>([
+        [`user:${RESTRICTED_AGENT_USER}`, RESTRICTED],
+        [RESTRICTED.actorId, RESTRICTED],
+        [`user:${OPEN_AGENT_USER}`, OPEN],
+        [HUMAN.actorId, HUMAN],
+      ])
+    )
+    const result = await caller(restrictedFromOne()).getByIds({
+      ids: [`user:${RESTRICTED_AGENT_USER}`, `user:${OPEN_AGENT_USER}`, HUMAN.actorId],
+    })
+    expect(Object.keys(result).sort()).toEqual([`user:${OPEN_AGENT_USER}`, HUMAN.actorId].sort())
+  })
+
+  it('an unrestricted org loses nothing', async () => {
+    // The control. `agent` is `baselineAtCreate: false`, so with no
+    // `ResourceAccess` rows anywhere every agent falls back to the area level and
+    // the exclusion is empty — nobody regresses.
+    const result = await caller(capabilitiesFor(Level.Full)).list({ target: 'all' })
+    expect(idsOf(result)).toEqual(idsOf(ALL_ACTORS))
+  })
+})
+
+describe('actor router — all three instanceListScope arms', () => {
+  it('`exclude`: an open area drops only the explicitly restricted agents', async () => {
+    const result = await caller(restrictedFromOne()).list({ target: 'all' })
+    expect(idsOf(result)).toContain(OPEN.actorId)
+    expect(idsOf(result)).not.toContain(RESTRICTED.actorId)
+  })
+
+  it('`include`: `agents: None` + one grant shows exactly that agent', async () => {
+    // The headline case. An explicit instance row beats the closed area floor
+    // (plan 25 §2), and it is an ALLOW-list — every row-less agent stays hidden,
+    // which is the arm a deny-list cannot express.
+    const result = await caller(
+      capabilitiesFor(Level.None, { instances: { [OPEN_AGENT]: ResourcePermission.view } })
+    ).list({ target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, OPEN.actorId, GROUP.actorId])
+  })
+
+  it('`include` still hides an agent whose grant is `none`', async () => {
+    const result = await caller(
+      capabilitiesFor(Level.None, {
+        instances: {
+          [OPEN_AGENT]: ResourcePermission.view,
+          [RESTRICTED_AGENT]: ResourcePermission.none,
+        },
+      })
+    ).list({ target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, OPEN.actorId, GROUP.actorId])
+  })
+
+  it('`none`: `agents: None` with no grants hides every agent', async () => {
+    const result = await caller(capabilitiesFor(Level.None)).list({ target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, GROUP.actorId])
+  })
+
+  it('`none` on a WORKER seat, whose ceiling closes the area over any grant', async () => {
+    // `agents` is absent from `WORKER_AREAS`, so `SEAT_CEILINGS.worker` clamps it
+    // to None and `instanceListScope` short-circuits before a single row is read.
+    const result = await caller(
+      capabilitiesFor(Level.Full, {
+        seatType: 'worker',
+        instances: { [OPEN_AGENT]: ResourcePermission.admin },
+      })
+    ).list({ target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, GROUP.actorId])
+  })
+
+  it('an OWNER keeps every agent, restriction rows and all', async () => {
+    // §0.10 recovery guarantee — an owner must always be able to see the agent
+    // whose restriction they need to undo.
+    const result = await caller(
+      capabilitiesFor(Level.Full, {
+        role: 'OWNER',
+        instances: { [RESTRICTED_AGENT]: ResourcePermission.none },
+      })
+    ).list({ target: 'all' })
+    expect(idsOf(result)).toEqual(idsOf(ALL_ACTORS))
+  })
+})
+
+describe('actor router — FILTER, never assert (the picker must keep working)', () => {
+  it('a member who can see NO agents still gets users and groups from list', async () => {
+    const result = await caller(capabilitiesFor(Level.None)).list({ target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, GROUP.actorId])
+  })
+
+  it('…and from search', async () => {
+    const result = await caller(capabilitiesFor(Level.None)).search({ query: 'a', target: 'all' })
+    expect(idsOf(result)).toEqual([HUMAN.actorId, GROUP.actorId])
+  })
+
+  it('…and from getByIds', async () => {
+    const result = await caller(capabilitiesFor(Level.None)).getByIds({
+      ids: [HUMAN.actorId, OPEN.actorId, GROUP.actorId],
+    })
+    expect(Object.keys(result).sort()).toEqual([HUMAN.actorId, GROUP.actorId].sort())
+  })
+
+  it('none of the three throws for a member with the agents area shut', async () => {
+    // A 403 here would blank the assignee picker, the mention menu and every
+    // hydrated ACTOR cell on the page at once.
+    const c = caller(capabilitiesFor(Level.None))
+    await expect(c.list({ target: 'all' })).resolves.toBeDefined()
+    await expect(c.search({ query: 'a', target: 'all' })).resolves.toBeDefined()
+    await expect(c.getByIds({ ids: [HUMAN.actorId] })).resolves.toBeDefined()
+  })
+
+  it('the service is still asked for the full set — filtering is the router’s job', async () => {
+    // Pins WHERE the filter lives. `ActorService` has no capability parameter, so
+    // the router must not be quietly narrowing the request instead.
+    await caller(restrictedFromOne()).list({ target: 'all', includeAgents: true })
+    expect(listActors).toHaveBeenCalledWith({ target: 'all', includeAgents: true })
+  })
+})

--- a/apps/web/src/server/api/routers/actor.ts
+++ b/apps/web/src/server/api/routers/actor.ts
@@ -1,9 +1,10 @@
 // apps/web/src/server/api/routers/actor.ts
 
 import { ActorService, GroupMemberService } from '@auxx/lib/actors'
-import type { ActorContext, ActorId } from '@auxx/types/actor'
+import type { CapabilitySet } from '@auxx/lib/permissions/capabilities/capability-set'
+import type { Actor, ActorContext, ActorId } from '@auxx/types/actor'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '../trpc'
+import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
 /**
  * Helper to create ActorContext from tRPC context
@@ -20,6 +21,50 @@ function toActorContext(ctx: {
 }
 
 /**
+ * Predicate over one agent id: may this member see it in a picker?
+ *
+ * Plan 25 §4.2 decision 1 — `view` means **usable** (chat, DM, @-mention,
+ * assign). An actor picker that offers an agent the caller cannot use is a
+ * broken affordance, and this router is the endpoint that fills those pickers,
+ * so it has to agree with `assertViewInstance('agent', id)`.
+ *
+ * All three `instanceListScope` arms are handled: `'none'` (the area is shut and
+ * the member holds no ≥`view` grant) hides every agent; `'include'` is the
+ * `agents: None` + explicit-grants regime, where the allow-list is exactly what
+ * they may see; `'exclude'` is the ordinary open-area regime, where the
+ * deny-list is only the explicitly-restricted agents (`agent` is
+ * `baselineAtCreate: false`, so restriction is the rare case and the list is
+ * usually empty).
+ */
+function agentVisibility(capabilities: CapabilitySet): (agentId: string) => boolean {
+  const scope = capabilities.instanceListScope('agent')
+  if (scope.kind === 'none') return () => false
+  if (scope.kind === 'include') {
+    const allowed = new Set(scope.includeIds)
+    return (agentId) => allowed.has(agentId)
+  }
+  const denied = new Set(scope.excludeIds)
+  return (agentId) => !denied.has(agentId)
+}
+
+/**
+ * Drop agents the caller may not view, leaving every other actor kind alone.
+ *
+ * **Filter, never assert.** These procedures also serve users, groups, workers
+ * and permission profiles, so a coarse `agentsView` gate would 403 the whole
+ * picker for a member who simply has no agents — the same mistake plan 30 §2.2
+ * calls out for `workflow.list`.
+ *
+ * Keyed on `AgentActor.agentId`, not on the map key, because
+ * `ActorService.getByIds` also stamps an AgentActor under the legacy
+ * `user:<syntheticUserId>` spelling; matching on the VALUE covers both.
+ */
+function filterVisibleActors(actors: Actor[], capabilities: CapabilitySet): Actor[] {
+  const canSee = agentVisibility(capabilities)
+  return actors.filter((actor) => actor.type !== 'agent' || canSee(actor.agentId))
+}
+
+/**
  * TRPC router for actor operations.
  *
  * Actors are unified references to users or groups.
@@ -33,8 +78,12 @@ export const actorRouter = createTRPCRouter({
   /**
    * List all available actors for the organization.
    * Used for preloading on page load.
+   *
+   * Unpaginated — it returns the whole org — so the agent filter has nothing to
+   * run "before". `capabilityProcedure` (not `permissionProcedure`) because
+   * nothing here is asserted: see {@link filterVisibleActors}.
    */
-  list: protectedProcedure
+  list: capabilityProcedure
     .input(
       z
         .object({
@@ -47,14 +96,20 @@ export const actorRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       const service = new ActorService(toActorContext(ctx))
-      return service.listActors(input ?? {})
+      return filterVisibleActors(await service.listActors(input ?? {}), ctx.capabilities)
     }),
 
   /**
    * Get multiple actors by ActorId.
    * Used for batch hydration of ACTOR field values.
+   *
+   * Filtered too, and not only for tidiness: the ids arrive verbatim from the
+   * client, so an unfiltered hydration hands back the name, avatar, slug and
+   * synthetic user id of any agent in the org for the asking. A restricted
+   * agent resolves to nothing here, exactly as if the row were dangling — which
+   * is how every other unresolvable id already renders.
    */
-  getByIds: protectedProcedure
+  getByIds: capabilityProcedure
     .input(
       z.object({
         ids: z.array(z.string()),
@@ -64,15 +119,24 @@ export const actorRouter = createTRPCRouter({
       const service = new ActorService(toActorContext(ctx))
       const result = await service.getByIds(input.ids as ActorId[])
 
+      const canSee = agentVisibility(ctx.capabilities)
       // Convert Map to object for JSON serialization
-      return Object.fromEntries(result)
+      return Object.fromEntries(
+        [...result].filter(([, actor]) => actor.type !== 'agent' || canSee(actor.agentId))
+      )
     }),
 
   /**
    * Search actors by name/email.
    * Used for typeahead in ACTOR field selectors.
+   *
+   * `limit` is a typeahead cap, not pagination — there is no offset, cursor,
+   * `total` or `hasMore` — so filtering the result cannot produce the lying
+   * `hasMore` / empty-page pathology that post-pagination filtering caused in
+   * `dataset.list` (#1345). It can only make a capped page shorter, for the rare
+   * member who is restricted from an agent that also matched their query.
    */
-  search: protectedProcedure
+  search: capabilityProcedure
     .input(
       z.object({
         query: z.string().min(1),
@@ -85,7 +149,7 @@ export const actorRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       const service = new ActorService(toActorContext(ctx))
-      return service.searchActors(input)
+      return filterVisibleActors(await service.searchActors(input), ctx.capabilities)
     }),
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -110,7 +174,20 @@ export const actorRouter = createTRPCRouter({
    * Expand actors to user IDs (groups → their user members).
    * Useful for notifications, mentions, etc.
    */
-  expandToUsers: protectedProcedure
+  /**
+   * Expand actor ids to the underlying user ids.
+   *
+   * `includeAgents` resolves `agent:<id>` to the agent's backing `User.id`, so
+   * the same visibility filter as the read procedures applies: an agent the
+   * caller cannot view is dropped from the input rather than resolved. Weakest
+   * of the four agent-touching procedures here — it only echoes back ids the
+   * caller already supplied — but leaving one unfiltered path in a router the
+   * rest of which filters is how the next audit loses an hour.
+   *
+   * Filter, never assert: a caller expanding a list of USER ids must not 403
+   * because they happen to have no agent access.
+   */
+  expandToUsers: capabilityProcedure
     .input(
       z.object({
         actorIds: z.array(z.string()),
@@ -118,9 +195,16 @@ export const actorRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      const includeAgents = input.includeAgents ?? false
       const service = new GroupMemberService(toActorContext(ctx))
       return service.expandToUsers(input.actorIds as ActorId[], {
-        includeAgents: input.includeAgents ?? false,
+        includeAgents,
+        // Filtering the INPUT here would be a phantom control: an agent reaches
+        // the output through three doors — `agent:<id>`, the legacy
+        // `user:<backingUserId>` spelling, and group membership — and only the
+        // first is visible in the input array. The predicate goes to the service,
+        // which is where all three converge on one `agentById` lookup.
+        canSeeAgent: includeAgents ? agentVisibility(ctx.capabilities) : undefined,
       })
     }),
 })

--- a/apps/web/src/server/api/routers/agent-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/agent-instance-access.test.ts
@@ -1,0 +1,787 @@
+// apps/web/src/server/api/routers/agent-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+/**
+ * Plan 25 §4.2.DECIDED at the router layer — per-agent instance access.
+ *
+ * Four things this file exists to pin, in order of how easy they are to break:
+ *  1. **`getById` resolves BEFORE it asserts.** It accepts an id *or* a slug
+ *     (the detail page routes by slug) while `ResourceAccess` rows are keyed on
+ *     `Agent.id`. An assert on the raw input finds no row, falls through to the
+ *     area level, and hands over an agent the member was restricted from — in
+ *     the `agents: None` + explicit-grant direction it does the opposite and
+ *     403s a legitimate holder on their own agent. Both directions are pinned.
+ *  2. **The three-rung ladder.** `view` = usable (open it, chat, mention),
+ *     `edit` = authoring, `admin` = publish / restore / delete / archive /
+ *     run-as / permission-profile. Each boundary is tested from BOTH sides.
+ *  3. **`update`'s field-presence escalation.** One fat mutation serves the
+ *     persona autosave (Edit) and the administration panels (Full), so the tier
+ *     is decided by which KEYS the payload carries (`ADMIN_ONLY_UPDATE_FIELDS`),
+ *     not by the procedure.
+ *  4. **`list` FILTERS, never asserts per agent** — and does so through all
+ *     three `instanceListScope` arms, since plan 25 §2 gave the view gate two
+ *     regimes that no single id list can express.
+ *
+ * Behavioral, not source-text: the real router module is imported and driven
+ * through a tRPC caller, `ctx.capabilities` is a **real** `CapabilitySet` (the
+ * shipped assert methods), and the real `~/server/lib/agent-instance-access`
+ * resolver runs against a mocked org agents cache. The `permissionProcedure`
+ * stand-in runs the real `capabilities.assert(key)`, so the coarse rung on the
+ * builder is under test too — `create`/`checkSlug`'s `agentsManage` gate lives
+ * there, not in the body.
+ *
+ * Deleting or weakening any assert makes a case here fail, because the mocked
+ * `@auxx/lib/agents` service functions are the observed side effect.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+/** The agent every tier case is keyed on. */
+const AGENT_ID = 'agt_cuid0000000000000000000'
+/** …and its slug. `getById` is routinely called with THIS, never the id. */
+const AGENT_SLUG = 'escalation-lead'
+const VERSION_ID = 'agv_cuid0000000000000000000'
+
+const { agents, cache, realtime, featureService } = vi.hoisted(() => {
+  /**
+   * The org's agents, as BOTH the cache resolver and `listAgents` see them.
+   * One fixture on purpose: `agent.list`'s filter and
+   * `assertAgentAccess`' id-or-slug resolve must agree about what exists.
+   */
+  const fixture: { rows: { id: string; slug: string }[] } = {
+    rows: [{ id: 'agt_cuid0000000000000000000', slug: 'escalation-lead' }],
+  }
+  return {
+    cache: {
+      fixture,
+      getAllCachedAgents: vi.fn(async () => fixture.rows),
+    },
+    agents: {
+      listAgents: vi.fn(async () => fixture.rows.map((r) => ({ id: r.id, slug: r.slug }))),
+      getAgentDetailByIdOrSlug: vi.fn(async (_org: string, id: string) => ({ id })),
+      createAgent: vi.fn(async () => ({
+        agentId: 'agt_new',
+        userId: null,
+        toolsetSlugs: [],
+        toolsetSource: 'auto_default',
+      })),
+      completeAgentSetup: vi.fn(async () => undefined),
+      deleteDraftAgent: vi.fn(async () => ({ deleted: true })),
+      deleteAgent: vi.fn(async () => ({ deleted: true })),
+      updateAgent: vi.fn(async () => undefined),
+      isAgentSlugTaken: vi.fn(async () => false),
+      setAgentToolBindings: vi.fn(async () => undefined),
+      publishAgent: vi.fn(async () => ({
+        isErr: () => false,
+        value: { version: { id: VERSION_ID, versionNumber: 2 }, reductions: [] },
+      })),
+      discardAgentDraft: vi.fn(async () => ({ isErr: () => false, value: undefined })),
+      restoreAgentVersion: vi.fn(async () => ({ isErr: () => false, value: undefined })),
+      renameAgentVersion: vi.fn(async () => ({ isErr: () => false, value: undefined })),
+      listAgentVersions: vi.fn(async () => ({ isErr: () => false, value: [] })),
+    },
+    realtime: {
+      publishAgentUpdated: vi.fn(async () => undefined),
+    },
+    featureService: { requireAccess: vi.fn(async () => undefined) },
+  }
+})
+
+vi.mock('@auxx/lib/agents', () => ({
+  ...agents,
+  // Faithful stand-in for `packages/lib/src/agents/slug-schema.ts`; slug
+  // *validation* is not what this file is about, only that inputs still parse.
+  agentSlugSchema: z
+    .string()
+    .min(1)
+    .max(60)
+    .regex(/^[a-z0-9-]+$/),
+}))
+
+// `~/server/lib/agent-instance-access` (the real module, deliberately NOT
+// mocked — its resolve is property #1 above) reads the org agents cache.
+vi.mock('@auxx/lib/cache', () => ({ getAllCachedAgents: cache.getAllCachedAgents }))
+
+vi.mock('@auxx/lib/realtime', () => ({
+  publishAgentUpdated: realtime.publishAgentUpdated,
+  getRealtimeService: () => ({}),
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+// See the note in `workflow-instance-access.test.ts` — the `@auxx/lib/permissions`
+// barrel reaches redis/db at import time and hangs under vitest. Hand back the
+// real registry plus a stub feature service (Layer-1 plan gating is not what
+// this file is about).
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+      requireLimit = featureService.requireAccess
+    },
+  }
+})
+
+/**
+ * The `permissionProcedure` stand-in mirrors the REAL builder's gate: a plain
+ * `capabilities.assert(key)`. Kept in lockstep with `trpc.ts`; only the plan-AND
+ * and the `getCapabilities` read are dropped, since ctx carries the set already.
+ *
+ * So the coarse rung on the procedure builder is under test alongside the
+ * per-instance asserts in the bodies — dropping
+ * `permissionProcedure(agentsManage)` from `create` fails a case below.
+ */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
+        return next()
+      }),
+  }
+})
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { agentRouter } = await import('./agent')
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+/** `assertAgentAccess` 404s an unresolvable identifier BEFORE the capability check. */
+const NOT_FOUND = { cause: { name: 'NotFoundError', statusCode: 404 } }
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/**
+ * A real `CapabilitySet` for a MEMBER holding `permission` on {@link AGENT_ID}
+ * via an explicit `ResourceAccess` instance row (what the share dialog writes).
+ *
+ * `areaPermission` defaults to `permission` so the coarse `agents` rungs stay
+ * consistent with the instance row; pass it separately to exercise the two
+ * independently (e.g. a member sitting at area `Full` but restricted on one
+ * agent). `instances: {}` models an agent with NO row at all — the
+ * `baselineAtCreate: false` fallback to the area level.
+ */
+function capabilitiesFor(
+  permission: ResourcePermission,
+  opts: {
+    instances?: Record<string, ResourcePermission>
+    areaPermission?: ResourcePermission
+    role?: 'MEMBER' | 'OWNER'
+    seatType?: 'full' | 'worker'
+    /**
+     * Override the derived front-door keys. Only the `list` `kind: 'none'` case
+     * needs this — see the note there.
+     */
+    derivedKeys?: PermissionKey[]
+  } = {}
+) {
+  const instances = opts.instances ?? { [AGENT_ID]: permission }
+  const seatType = opts.seatType ?? 'full'
+  // Reproduce `deriveInstanceReadKeys`: any ≥`view` agent row synthesizes
+  // `agentsView`, clamped away on a worker seat (`agents` is outside
+  // WORKER_AREAS). Without this an `agents: None` grantee would 403 at the
+  // coarse front door on every instance-asserted procedure.
+  const derived =
+    opts.derivedKeys ??
+    (seatType !== 'worker' &&
+    Object.values(instances).some((p) => p !== ResourcePermission.none && p !== undefined)
+      ? [PermissionKey.agentsView]
+      : [])
+  return new CapabilitySet(
+    new Set(
+      expandLevelsToKeys({ [Area.agents]: AREA_LEVEL_OF[opts.areaPermission ?? permission] })
+    ),
+    {},
+    opts.role ?? 'MEMBER',
+    seatType,
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived)
+  )
+}
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return agentRouter.createCaller({
+    db: {},
+    capabilities,
+    headers: new Headers(),
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      isSuperAdmin: false,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, email: 'a@b.c', name: 'A' },
+    },
+  } as never)
+}
+
+type Caller = ReturnType<typeof caller>
+
+/** View tier — everything a `view` holder may read. */
+const VIEW_READS = [
+  [
+    'getById',
+    (c: Caller) => c.getById({ agentId: AGENT_ID }),
+    () => agents.getAgentDetailByIdOrSlug,
+  ],
+  [
+    'listVersions',
+    (c: Caller) => c.listVersions({ agentId: AGENT_ID }),
+    () => agents.listAgentVersions,
+  ],
+] as const
+
+/** Edit tier — authoring the draft. */
+const EDIT_LEVEL = [
+  [
+    'update (prompt)',
+    (c: Caller) => c.update({ agentId: AGENT_ID, prompt: { type: 'doc' } }),
+    () => agents.updateAgent,
+  ],
+  [
+    'setToolBindings',
+    (c: Caller) => c.setToolBindings({ agentId: AGENT_ID, bindings: {} }),
+    () => agents.setAgentToolBindings,
+  ],
+  [
+    'deleteDraft',
+    (c: Caller) => c.deleteDraft({ agentId: AGENT_ID }),
+    () => agents.deleteDraftAgent,
+  ],
+  [
+    'discardChanges',
+    (c: Caller) => c.discardChanges({ agentId: AGENT_ID }),
+    () => agents.discardAgentDraft,
+  ],
+  [
+    'renameVersion',
+    (c: Caller) => c.renameVersion({ agentId: AGENT_ID, versionId: VERSION_ID, label: 'v2' }),
+    () => agents.renameAgentVersion,
+  ],
+] as const
+
+/** Admin tier — promote to production, rewind it, or destroy the agent. */
+const ADMIN_ONLY = [
+  [
+    'completeSetup',
+    (c: Caller) => c.completeSetup({ agentId: AGENT_ID }),
+    () => agents.completeAgentSetup,
+  ],
+  ['publish', (c: Caller) => c.publish({ agentId: AGENT_ID }), () => agents.publishAgent],
+  [
+    'restoreVersion',
+    (c: Caller) => c.restoreVersion({ agentId: AGENT_ID, toVersionId: VERSION_ID }),
+    () => agents.restoreAgentVersion,
+  ],
+  ['delete', (c: Caller) => c.delete({ agentId: AGENT_ID }), () => agents.deleteAgent],
+] as const
+
+/**
+ * Every `ADMIN_ONLY_UPDATE_FIELDS` key, with a value that is genuinely present.
+ * `null` on two of them is deliberate — CLEARING a run-as delegation or a
+ * profile binding is as administrative as setting one, and a falsy-but-defined
+ * value must still escalate, which an `if (input[field])` check would miss.
+ */
+const ADMIN_UPDATE_PAYLOADS = [
+  ['runAsUserId (set)', { runAsUserId: 'usr_delegate0000000000000000' }],
+  ['runAsUserId (clear)', { runAsUserId: null }],
+  ['permissionProfileId (set)', { permissionProfileId: 'prf_cuid0000000000000000000' }],
+  ['permissionProfileId (clear)', { permissionProfileId: null }],
+  ['archivedAt (archive)', { archivedAt: new Date('2026-07-28T00:00:00Z') }],
+  ['archivedAt (unarchive)', { archivedAt: null }],
+] as const
+
+/** Ordinary authoring fields — these must NOT escalate. */
+const EDIT_UPDATE_PAYLOADS = [
+  ['name', { name: 'Renamed' }],
+  ['slug', { slug: 'renamed-agent' }],
+  ['description', { description: 'A description' }],
+  ['prompt', { prompt: { type: 'doc' } }],
+  ['modelId', { modelId: 'claude-sonnet' }],
+  ['mentionable', { mentionable: false }],
+  ['appAccounts', { appAccounts: { quickbooks: { credId: 'crd_1' } } }],
+] as const
+
+const ALL_MOCKS = [
+  ...Object.values(agents),
+  realtime.publishAgentUpdated,
+  featureService.requireAccess,
+]
+
+beforeEach(() => {
+  for (const fn of ALL_MOCKS) fn.mockClear()
+  cache.getAllCachedAgents.mockClear()
+  agents.isAgentSlugTaken.mockReset()
+  agents.isAgentSlugTaken.mockResolvedValue(false)
+  cache.fixture.rows = [{ id: AGENT_ID, slug: AGENT_SLUG }]
+})
+
+describe('agent router — `getById` asserts on the RESOLVED id, not the raw input', () => {
+  it('a slug reaches the agent whose grant is keyed on the ID', async () => {
+    // The detail page routes by slug. `assertViewInstance('agent', <slug>)` would
+    // find no ResourceAccess row for `escalation-lead`, fall back to the area
+    // level (None here) and 403 a member who genuinely holds the agent.
+    const caps = capabilitiesFor(ResourcePermission.view, {
+      areaPermission: ResourcePermission.none,
+      instances: { [AGENT_ID]: ResourcePermission.view },
+    })
+    await expect(caller(caps).getById({ agentId: AGENT_SLUG })).resolves.toEqual({ id: AGENT_ID })
+    // …and the service is handed the RESOLVED id, never the slug.
+    expect(agents.getAgentDetailByIdOrSlug).toHaveBeenCalledWith(ORG_ID, AGENT_ID)
+  })
+
+  it('a slug does NOT escape a restriction keyed on the id', async () => {
+    // The other direction, and the leak that matters: an area-Full member who
+    // was explicitly restricted from this agent must not walk around the row by
+    // asking for it by slug. Asserting on the raw slug finds no row, falls
+    // through to the area level (`admin`) and hands the agent straight over.
+    const caps = capabilitiesFor(ResourcePermission.none, {
+      areaPermission: ResourcePermission.admin,
+      instances: { [AGENT_ID]: ResourcePermission.none },
+    })
+    await expect(caller(caps).getById({ agentId: AGENT_SLUG })).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.getAgentDetailByIdOrSlug).not.toHaveBeenCalled()
+  })
+
+  it('every instance-asserted procedure resolves, not just getById', async () => {
+    // The resolver is the ONE authority (`assertAgentAccess`), so the slug path
+    // works uniformly — a caller that passes a slug to `update` gets the same
+    // treatment, and the service receives the id.
+    const caps = capabilitiesFor(ResourcePermission.edit)
+    await expect(
+      caller(caps).update({ agentId: AGENT_SLUG, prompt: { type: 'doc' } })
+    ).resolves.toBeUndefined()
+    expect(agents.updateAgent).toHaveBeenCalledWith(AGENT_ID, ORG_ID, expect.anything(), {
+      excludeSocketId: undefined,
+    })
+  })
+
+  it('an unknown identifier 404s BEFORE any capability decision leaks its existence', async () => {
+    // An agent id from another org must not be distinguishable from one this
+    // member is restricted from — both end as NotFoundError.
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).getById({ agentId: 'agt_missing' })
+    ).rejects.toMatchObject(NOT_FOUND)
+    expect(agents.getAgentDetailByIdOrSlug).not.toHaveBeenCalled()
+  })
+})
+
+describe('agent router — the view tier', () => {
+  it.each(VIEW_READS)('%s succeeds at instance view', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).resolves.toBeDefined()
+    expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(VIEW_READS)('%s is refused for an agent restricted to `none`', async (_n, call, mock) => {
+    await expect(
+      call(
+        caller(
+          capabilitiesFor(ResourcePermission.none, {
+            areaPermission: ResourcePermission.admin,
+            instances: { [AGENT_ID]: ResourcePermission.none },
+          })
+        )
+      )
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(mock()).not.toHaveBeenCalled()
+  })
+})
+
+describe('agent router — the edit tier', () => {
+  it.each(EDIT_LEVEL)('%s succeeds at instance edit', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.edit)))).resolves.not.toThrow()
+    expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(EDIT_LEVEL)('%s is refused at instance view', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(mock()).not.toHaveBeenCalled()
+  })
+})
+
+describe('agent router — the admin tier', () => {
+  it.each(ADMIN_ONLY)('%s succeeds at instance admin', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.admin)))).resolves.not.toThrow()
+    expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(ADMIN_ONLY)('%s is refused at instance edit', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.edit)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(ADMIN_ONLY)('%s is refused at instance view', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it('deleteDraft and delete sit on DIFFERENT rungs', async () => {
+    // The pair is easy to collapse: both destroy an agent row. `deleteDraft`
+    // only ever touches an agent that never completed setup (no backing User,
+    // nothing published), so it is authoring; `delete` destroys a live agent.
+    const editor = capabilitiesFor(ResourcePermission.edit)
+    await expect(caller(editor).deleteDraft({ agentId: AGENT_ID })).resolves.toBeUndefined()
+    await expect(caller(editor).delete({ agentId: AGENT_ID })).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.deleteAgent).not.toHaveBeenCalled()
+  })
+})
+
+describe('agent router — `update` escalates on field PRESENCE', () => {
+  it.each(EDIT_UPDATE_PAYLOADS)('carrying `%s` stays on the edit rung', async (_f, payload) => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).update({ agentId: AGENT_ID, ...payload })
+    ).resolves.toBeUndefined()
+    expect(agents.updateAgent).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(
+    EDIT_UPDATE_PAYLOADS
+  )('carrying `%s` is still refused at instance view', async (_f, p) => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view)).update({ agentId: AGENT_ID, ...p })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.updateAgent).not.toHaveBeenCalled()
+  })
+
+  it.each(
+    ADMIN_UPDATE_PAYLOADS
+  )('carrying `%s` escalates the save to Full — refused at instance edit', async (_f, payload) => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).update({
+        agentId: AGENT_ID,
+        prompt: { type: 'doc' },
+        ...payload,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.updateAgent).not.toHaveBeenCalled()
+  })
+
+  it.each(
+    ADMIN_UPDATE_PAYLOADS
+  )('carrying `%s` succeeds at instance admin', async (_f, payload) => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).update({ agentId: AGENT_ID, ...payload })
+    ).resolves.toBeUndefined()
+    expect(agents.updateAgent).toHaveBeenCalledTimes(1)
+  })
+
+  it('an admin field present but explicitly `undefined` does NOT escalate', async () => {
+    // THE TRIPWIRE for `ADMIN_ONLY_UPDATE_FIELDS`' `input[field] !== undefined`
+    // form. That check is safe only because the router's own payload builder
+    // guards each of the three with the SAME `!== undefined` test, so an
+    // explicitly-undefined key never reaches `updateAgent` and cannot change
+    // anything either. The assertion below is on KEY PRESENCE, not on the value,
+    // because `updateAgent` detects an archive transition with
+    // `'archivedAt' in input` — a payload builder that ever forwarded the key
+    // with an undefined value would silently UNARCHIVE the agent (and ban/unban
+    // its backing User) on a plain persona autosave. If that day comes this test
+    // fails, and the router's escalation check has to become key-presence-based
+    // (`field in patch`) to match.
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).update({
+        agentId: AGENT_ID,
+        prompt: { type: 'doc' },
+        runAsUserId: undefined,
+        permissionProfileId: undefined,
+        archivedAt: undefined,
+      })
+    ).resolves.toBeUndefined()
+    expect(agents.updateAgent).toHaveBeenCalledTimes(1)
+    const written = agents.updateAgent.mock.calls[0]?.[2] as Record<string, unknown>
+    expect('runAsUserId' in written).toBe(false)
+    expect('permissionProfileId' in written).toBe(false)
+    expect('archivedAt' in written).toBe(false)
+  })
+
+  it('the escalation runs BEFORE the slug-conflict probe', async () => {
+    // Order matters for disclosure: a member who may not archive must not learn
+    // whether a slug is taken by bundling one into the same payload.
+    agents.isAgentSlugTaken.mockResolvedValue(true)
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).update({
+        agentId: AGENT_ID,
+        slug: 'taken-slug',
+        archivedAt: new Date(),
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.isAgentSlugTaken).not.toHaveBeenCalled()
+  })
+})
+
+describe('agent router — creating is the coarse `agentsManage` rung', () => {
+  it('create is refused for a member at the agents Edit rung', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).create({ name: 'New' })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.createAgent).not.toHaveBeenCalled()
+  })
+
+  it('create succeeds once the member holds agents Full', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).create({ name: 'New' })
+    ).resolves.toMatchObject({ agentId: 'agt_new' })
+    expect(agents.createAgent).toHaveBeenCalledTimes(1)
+  })
+
+  it('one instance `admin` grant does NOT confer the create rung', async () => {
+    // `deriveInstanceReadKeys` synthesizes the Read rung only, regardless of
+    // grant strength — precisely so that a share cannot front-door `create`.
+    await expect(
+      caller(
+        capabilitiesFor(ResourcePermission.admin, { areaPermission: ResourcePermission.none })
+      ).create({ name: 'New' })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.createAgent).not.toHaveBeenCalled()
+  })
+
+  /**
+   * `checkSlug` serves two callers with two different authorities, so it is the
+   * one procedure whose gate lives in the BODY rather than on the builder.
+   * Without `excludeAgentId` it is the create dialog asking about the org's slug
+   * namespace (coarse `agentsManage`); with it, it is the detail page's live
+   * rename hint asking about ONE agent (instance `edit`).
+   */
+  it('checkSlug without excludeAgentId rides the coarse create rung', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).checkSlug({ slug: 'anything' })
+    ).rejects.toMatchObject(FORBIDDEN)
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).checkSlug({ slug: 'anything' })
+    ).resolves.toEqual({ available: true })
+  })
+
+  it('checkSlug with excludeAgentId is an instance edit check, not the create rung', async () => {
+    // The rename hint must survive for an instance-`edit` holder below coarse
+    // Full — `update` already lets them rename, so taking the preview away is an
+    // affordance vanishing for no visible reason.
+    await expect(
+      caller(
+        capabilitiesFor(ResourcePermission.edit, { areaPermission: ResourcePermission.none })
+      ).checkSlug({ slug: 'anything', excludeAgentId: AGENT_ID })
+    ).resolves.toEqual({ available: true })
+
+    // …and it is still a real check: `view` on that agent is not enough.
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view)).checkSlug({
+        slug: 'anything',
+        excludeAgentId: AGENT_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('checkSlug resolves excludeAgentId by slug, like every other instance assert', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).checkSlug({
+        slug: 'anything',
+        excludeAgentId: AGENT_SLUG,
+      })
+    ).resolves.toEqual({ available: true })
+  })
+})
+
+describe('agent router — `list` filters through all three instanceListScope arms', () => {
+  const OTHER_ID = 'agt_othercuid000000000000'
+
+  beforeEach(() => {
+    cache.fixture.rows = [
+      { id: AGENT_ID, slug: AGENT_SLUG },
+      { id: OTHER_ID, slug: 'other-agent' },
+    ]
+  })
+
+  it('EXCLUDE — an open area drops only the explicitly restricted agent', async () => {
+    const result = await caller(
+      capabilitiesFor(ResourcePermission.admin, {
+        areaPermission: ResourcePermission.admin,
+        instances: { [OTHER_ID]: ResourcePermission.none },
+      })
+    ).list()
+    expect(result.map((a: { id: string }) => a.id)).toEqual([AGENT_ID])
+  })
+
+  it('EXCLUDE with nothing restricted — an unrestricted org pays nothing', async () => {
+    const result = await caller(capabilitiesFor(ResourcePermission.admin, { instances: {} })).list()
+    expect(result.map((a: { id: string }) => a.id)).toEqual([AGENT_ID, OTHER_ID])
+  })
+
+  it('INCLUDE — an `agents: None` member sees ONLY what was shared with them', async () => {
+    // The regime that makes sharing work at all (plan 25 §2): the member
+    // composes the area to None, so every row-LESS agent is invisible and no
+    // exclusion list could enumerate them. The scope inverts to an allow-list.
+    const result = await caller(
+      capabilitiesFor(ResourcePermission.view, {
+        areaPermission: ResourcePermission.none,
+        instances: { [AGENT_ID]: ResourcePermission.view },
+      })
+    ).list()
+    expect(result.map((a: { id: string }) => a.id)).toEqual([AGENT_ID])
+  })
+
+  it('NONE — returns an empty list WITHOUT reading the agents cache', async () => {
+    // `kind: 'none'` means nothing is visible, so the router must short-circuit
+    // rather than fetch the org's agents and filter them all away.
+    //
+    // A worker seat is the only producer of this arm (`agents` is outside
+    // WORKER_AREAS, so `SEAT_CEILINGS.worker` closes it). The `agentsView` key
+    // is handed in explicitly because production clamps it away upstream — this
+    // pins the router's own defense-in-depth short-circuit, which is what
+    // survives if the front-door gate is ever relaxed to `capabilityProcedure`.
+    const worker = capabilitiesFor(ResourcePermission.admin, {
+      seatType: 'worker',
+      derivedKeys: [PermissionKey.agentsView],
+      instances: { [AGENT_ID]: ResourcePermission.admin },
+    })
+    await expect(caller(worker).list()).resolves.toEqual([])
+    expect(agents.listAgents).not.toHaveBeenCalled()
+  })
+
+  it('keeps the `includeArchived` passthrough', async () => {
+    await caller(capabilitiesFor(ResourcePermission.admin, { instances: {} })).list({
+      includeArchived: true,
+    })
+    expect(agents.listAgents).toHaveBeenCalledWith(ORG_ID, { includeArchived: true })
+  })
+})
+
+describe('agent router — composition: `agents: None` + ONE explicit grant (plan 25 §2)', () => {
+  /**
+   * The member the whole feature exists for: their profile grants no agents at
+   * all, and a single share hands them one. Three things must all hold — the
+   * coarse front door opens (via the derived Read rung), the instance assert
+   * passes for THAT agent, and nothing else in the org becomes reachable.
+   */
+  const shared = (permission: ResourcePermission) =>
+    capabilitiesFor(permission, {
+      areaPermission: ResourcePermission.none,
+      instances: { [AGENT_ID]: permission },
+    })
+
+  it('an `admin` grant reaches every rung on that one agent', async () => {
+    await expect(
+      caller(shared(ResourcePermission.admin)).getById({ agentId: AGENT_ID })
+    ).resolves.toBeDefined()
+    await expect(
+      caller(shared(ResourcePermission.admin)).update({
+        agentId: AGENT_ID,
+        prompt: { type: 'doc' },
+      })
+    ).resolves.toBeUndefined()
+    await expect(
+      caller(shared(ResourcePermission.admin)).publish({ agentId: AGENT_ID })
+    ).resolves.toBeDefined()
+    await expect(
+      caller(shared(ResourcePermission.admin)).delete({ agentId: AGENT_ID })
+    ).resolves.toBeUndefined()
+  })
+
+  it('and reaches NOTHING else — a row-less agent stays invisible', async () => {
+    const OTHER_ID = 'agt_othercuid000000000000'
+    cache.fixture.rows = [
+      { id: AGENT_ID, slug: AGENT_SLUG },
+      { id: OTHER_ID, slug: 'other-agent' },
+    ]
+    await expect(
+      caller(shared(ResourcePermission.admin)).getById({ agentId: OTHER_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(agents.getAgentDetailByIdOrSlug).not.toHaveBeenCalled()
+  })
+
+  it('a `view` grant is usable but not editable', async () => {
+    await expect(
+      caller(shared(ResourcePermission.view)).getById({ agentId: AGENT_ID })
+    ).resolves.toBeDefined()
+    await expect(
+      caller(shared(ResourcePermission.view)).update({ agentId: AGENT_ID, prompt: { type: 'doc' } })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+})
+
+describe('agent router — `baselineAtCreate: false`: no row falls back to the AREA', () => {
+  /** A member with NO instance rows at all — nothing is in `restrictedInstanceIds`. */
+  const noRows = (areaPermission: ResourcePermission) =>
+    capabilitiesFor(areaPermission, { areaPermission, instances: {} })
+
+  it('area Read ⇒ the agent opens, but does not save', async () => {
+    await expect(
+      caller(noRows(ResourcePermission.view)).getById({ agentId: AGENT_ID })
+    ).resolves.toBeDefined()
+    await expect(
+      caller(noRows(ResourcePermission.view)).update({ agentId: AGENT_ID, prompt: { type: 'doc' } })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('area Edit ⇒ saves, but does not publish or archive', async () => {
+    await expect(
+      caller(noRows(ResourcePermission.edit)).update({ agentId: AGENT_ID, prompt: { type: 'doc' } })
+    ).resolves.toBeUndefined()
+    await expect(
+      caller(noRows(ResourcePermission.edit)).publish({ agentId: AGENT_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    await expect(
+      caller(noRows(ResourcePermission.edit)).update({ agentId: AGENT_ID, archivedAt: new Date() })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('area Full ⇒ everything, with no ResourceAccess row anywhere', async () => {
+    // The no-regression guarantee: `MEMBER_BASELINE_LEVELS[agents] = Full`, so
+    // this is what every existing member is, and nothing here may 403.
+    await expect(
+      caller(noRows(ResourcePermission.admin)).delete({ agentId: AGENT_ID })
+    ).resolves.toBeUndefined()
+    await expect(
+      caller(noRows(ResourcePermission.admin)).publish({ agentId: AGENT_ID })
+    ).resolves.toBeDefined()
+    await expect(
+      caller(noRows(ResourcePermission.admin)).completeSetup({ agentId: AGENT_ID })
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('agent router — OWNER regression', () => {
+  it('short-circuits to admin on an agent restricted to `none`', async () => {
+    // §0.10 recovery guarantee: nothing authored on an agent can lock the last
+    // owner out of the agent that would let them undo it.
+    const owner = capabilitiesFor(ResourcePermission.admin, {
+      role: 'OWNER',
+      instances: { [AGENT_ID]: ResourcePermission.none },
+    })
+    await expect(caller(owner).delete({ agentId: AGENT_ID })).resolves.toBeUndefined()
+    expect(agents.deleteAgent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/server/api/routers/agent-procedure.ts
+++ b/apps/web/src/server/api/routers/agent-procedure.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/agent-procedure.ts
 
-import { agentExistsInOrg } from '@auxx/lib/agents'
+import { type Database, schema } from '@auxx/database'
 import {
   attachProcedure,
   createProcedure,
@@ -13,12 +13,21 @@ import {
 import { FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { TRPCError } from '@trpc/server'
+import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
+import { assertAgentAccess } from '~/server/lib/agent-instance-access'
+import { createTRPCRouter, permissionProcedure } from '../trpc'
 import { unwrap } from '../unwrap'
 
-/** permissionProcedure(agentsManage) + a beta gate: requires the `agentProcedures` feature on the org's plan. */
-const agentProceduresManageProcedure = permissionProcedure(PermissionKey.agentsManage).use(
+/**
+ * `permissionProcedure(agentsView)` + the `agentProcedures` beta plan gate.
+ *
+ * The coarse rung is the derived Read key, not `agentsManage`: the real decision
+ * is the per-agent `assertAgentAccess(..., 'edit')` in each body (`workflow.ts`
+ * precedent — see `agent-trigger.ts`'s router doc for why). Procedures are
+ * authoring surface, so they sit on **edit**, unlike triggers.
+ */
+const agentProceduresWriteProcedure = permissionProcedure(PermissionKey.agentsView).use(
   async ({ ctx, next }) => {
     await new FeaturePermissionService().requireAccess(
       ctx.session.organizationId,
@@ -28,10 +37,33 @@ const agentProceduresManageProcedure = permissionProcedure(PermissionKey.agentsM
   }
 )
 
-async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
-  if (!(await agentExistsInOrg(organizationId, agentId))) {
-    throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
+/**
+ * `AgentProcedure.id` (a LINK id) → the agent it hangs off, or a 404.
+ *
+ * `update` and `detach` name only the link, but per-instance access is keyed on
+ * the agent — so the link has to be resolved BEFORE the write, not read off the
+ * service's return value afterwards (which is what `detachProcedure` hands back,
+ * far too late to authorize anything).
+ */
+async function resolveLinkAgentId(
+  db: Database,
+  organizationId: string,
+  linkId: string
+): Promise<string> {
+  const [row] = await db
+    .select({ agentId: schema.AgentProcedure.agentId })
+    .from(schema.AgentProcedure)
+    .where(
+      and(
+        eq(schema.AgentProcedure.id, linkId),
+        eq(schema.AgentProcedure.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  if (!row) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Procedure link not found' })
   }
+  return row.agentId
 }
 
 /**
@@ -42,15 +74,19 @@ async function ensureAgentInOrg(organizationId: string, agentId: string): Promis
  */
 export const agentProcedureRouter = createTRPCRouter({
   // The agent's attached procedures, joined with each procedure's summary.
-  list: protectedProcedure
+  list: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
-      const links = unwrap(
-        await listAgentProcedures({ agentId: input.agentId }),
-        'list agent procedures'
-      )
+      // Single-agent shape — every link returned belongs to `input.agentId`, so
+      // this asserts rather than filters.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'view',
+      })
+      const links = unwrap(await listAgentProcedures({ agentId }), 'list agent procedures')
       const procedures = unwrap(await listProcedures({ organizationId }), 'list procedures')
       const byId = new Map(procedures.map((p) => [p.id, p]))
       return links
@@ -72,50 +108,52 @@ export const agentProcedureRouter = createTRPCRouter({
     }),
 
   // "Add procedure": create a new standalone procedure and attach it to the agent.
-  createAndAttach: agentProceduresManageProcedure
+  createAndAttach: agentProceduresWriteProcedure
     .input(z.object({ agentId: z.string().min(1), name: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
       const procedure = unwrap(
         await createProcedure({ organizationId, name: input.name }),
         'create procedure'
       )
       const link = unwrap(
-        await attachProcedure({
-          organizationId,
-          agentId: input.agentId,
-          procedureId: procedure.id,
-        }),
+        await attachProcedure({ organizationId, agentId, procedureId: procedure.id }),
         'attach procedure'
       )
       // A fresh procedure has an empty doc, but reconcile anyway so the agent's
       // `'procedure'` tag is initialized (and stays correct if the create seeds a body).
-      await reconcileAgentProcedureMentions(organizationId, input.agentId)
+      await reconcileAgentProcedureMentions(organizationId, agentId)
       return { linkId: link.id, procedureId: procedure.id }
     }),
 
   // Attach an EXISTING procedure to the agent.
-  attach: agentProceduresManageProcedure
+  attach: agentProceduresWriteProcedure
     .input(z.object({ agentId: z.string().min(1), procedureId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
       const link = unwrap(
-        await attachProcedure({
-          organizationId,
-          agentId: input.agentId,
-          procedureId: input.procedureId,
-        }),
+        await attachProcedure({ organizationId, agentId, procedureId: input.procedureId }),
         'attach procedure'
       )
       // Attaching an existing (possibly published) procedure can lock new
       // toolsets/knowledge on the agent — reconcile its `'procedure'` tag.
-      await reconcileAgentProcedureMentions(organizationId, input.agentId)
+      await reconcileAgentProcedureMentions(organizationId, agentId)
       return { linkId: link.id }
     }),
 
-  update: agentProceduresManageProcedure
+  update: agentProceduresWriteProcedure
     .input(
       z.object({
         id: z.string().min(1),
@@ -129,6 +167,12 @@ export const agentProcedureRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
       const { id, ...patch } = input
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: await resolveLinkAgentId(ctx.db, organizationId, id),
+        tier: 'edit',
+      })
       const row = unwrap(
         await updateAgentProcedure({ organizationId, id, patch }),
         'update agent procedure'
@@ -142,10 +186,16 @@ export const agentProcedureRouter = createTRPCRouter({
       return { ok: true as const }
     }),
 
-  detach: agentProceduresManageProcedure
+  detach: agentProceduresWriteProcedure
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: await resolveLinkAgentId(ctx.db, organizationId, input.id),
+        tier: 'edit',
+      })
       // detach returns the removed link's agentId so we can reconcile its
       // `'procedure'` tag AFTER the delete (the link is now excluded).
       const agentId = unwrap(

--- a/apps/web/src/server/api/routers/agent-scope.ts
+++ b/apps/web/src/server/api/routers/agent-scope.ts
@@ -1,7 +1,6 @@
 // apps/web/src/server/api/routers/agent-scope.ts
 
 import {
-  agentExistsInOrg,
   isKnowledgeScopeRecordId,
   removeAgentScopeRow,
   ScopeRowImmutableError,
@@ -11,6 +10,7 @@ import { PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { assertAgentAccess } from '~/server/lib/agent-instance-access'
 import { createTRPCRouter, permissionProcedure } from '../trpc'
 
 const logger = createScopedLogger('agent-scope-router')
@@ -22,12 +22,6 @@ const recordIdSchema = z.string().min(1).max(180)
 const knowledgeScopeRecordIdSchema = recordIdSchema.refine(isKnowledgeScopeRecordId, {
   message: 'recordId must target a knowledge source (kb, article, or dataset)',
 })
-
-async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
-  if (!(await agentExistsInOrg(organizationId, agentId))) {
-    throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-  }
-}
 
 function mapServiceError(err: unknown): TRPCError {
   if (err instanceof ScopeRowImmutableError) {
@@ -45,10 +39,17 @@ function mapServiceError(err: unknown): TRPCError {
  * access-control surface; record/entity permissions are configured
  * separately (doc 14). Reads come from `agent.getById.knowledge`.
  * Mention-sourced entries are owned by the prompt reconciler and are rejected
- * here; admin edits write `manual`.
+ * here; manual edits write `manual`.
+ *
+ * Access is per-agent (plan 25 §4.2) at the **edit** tier — the knowledge scope
+ * is part of authoring the agent, alongside its prompt, toolsets and procedures.
+ * It is emphatically NOT an access-control surface (see the note above), so
+ * putting it on the admin rung with triggers would be misreading what it does.
+ * `assertAgentAccess` also subsumes the old `ensureAgentInOrg` check: an
+ * out-of-org id fails resolution with a 404 before any capability is consulted.
  */
 export const agentScopeRouter = createTRPCRouter({
-  upsertRow: permissionProcedure(PermissionKey.agentsManage)
+  upsertRow: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         agentId: z.string(),
@@ -58,21 +59,26 @@ export const agentScopeRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
       try {
-        await upsertAgentScopeRow(organizationId, input)
+        await upsertAgentScopeRow(organizationId, { ...input, agentId })
       } catch (err) {
         throw mapServiceError(err)
       }
       logger.info('Agent knowledge entry upserted', {
         organizationId,
-        agentId: input.agentId,
+        agentId,
         recordId: input.recordId,
         mode: input.mode,
       })
     }),
 
-  removeRow: permissionProcedure(PermissionKey.agentsManage)
+  removeRow: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         agentId: z.string(),
@@ -81,15 +87,20 @@ export const agentScopeRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
       try {
-        await removeAgentScopeRow(organizationId, input)
+        await removeAgentScopeRow(organizationId, { ...input, agentId })
       } catch (err) {
         throw mapServiceError(err)
       }
       logger.info('Agent knowledge entry removed', {
         organizationId,
-        agentId: input.agentId,
+        agentId,
         recordId: input.recordId,
       })
     }),

--- a/apps/web/src/server/api/routers/agent-siblings-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/agent-siblings-instance-access.test.ts
@@ -1,0 +1,755 @@
+// apps/web/src/server/api/routers/agent-siblings-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 25 §4.2 at the router layer, for the FOUR sibling routers that hang off
+ * the agent detail page — `agent-trigger`, `agent-procedure`, `agent-toolset`,
+ * `agent-scope`. `agent.ts` itself is covered separately.
+ *
+ * Four things this file exists to pin, in order of how easy they are to break:
+ *
+ *  1. **Trigger writes are `admin`, not `edit`** (user decision 2026-07-28). A
+ *     trigger makes the agent act autonomously on its OWN credentials with no
+ *     invoker to intersect against, so `create`/`update`/`delete`/`runNow` sit
+ *     on the same rung as `runAsUserId`. Everything else about an agent that a
+ *     builder touches is `edit`, which makes this the one rung a future refactor
+ *     would "tidy" downwards — hence an explicit `it.each` proving an **edit
+ *     holder is denied on all four**.
+ *  2. **The three formerly-bare `protectedProcedure`s now deny.**
+ *     `agentTrigger.list`, `agentTrigger.listRuns` and `agentProcedure.list` read
+ *     NO capabilities at HEAD~ — closing them is a real hole, not a re-tier.
+ *  3. **Indirect agent resolution.** Four procedures are keyed on a TRIGGER id
+ *     and two on a procedure LINK id. Instance access lives on the agent, so each
+ *     must resolve the owning agent BEFORE asserting; a test per procedure points
+ *     the resolver at a *different* agent and requires the denial to follow it.
+ *  4. **`assertAgentAccess` keys on the resolved `Agent.id`, never a slug.**
+ *     Every input here is nominally an id, but `assertAgentAccess` accepts either
+ *     — and asserting on a slug finds no `ResourceAccess` row, falls through to
+ *     the area level, and hands over a restricted agent.
+ *
+ * Behavioral, not source-text: the real router modules are imported and driven
+ * through tRPC callers, `ctx.capabilities` is a **real** `CapabilitySet` (the
+ * shipped assert methods), and `~/server/lib/agent-instance-access` is the real
+ * module resolving against a mocked org agents cache. The `permissionProcedure`
+ * stand-in runs the real `capabilities.assert(key)`, so the coarse rung is under
+ * test too — `agentToolset.listTools` moving off `agentsManage` onto `agentsView`
+ * is proven by a case below, not by reading the source.
+ *
+ * Deleting or weakening any assert makes a case here fail, because the mocked
+ * services are the observed side effect.
+ */
+
+const {
+  triggerService,
+  agentsFixture,
+  linkFixture,
+  getCachedAgentById,
+  onCacheEvent,
+  enqueueAgentJob,
+  createSession,
+  getOrgToolCatalog,
+  updateAgentToolset,
+  batchUpdateAgentToolsets,
+  upsertAgentScopeRow,
+  removeAgentScopeRow,
+  procedures,
+  featureService,
+} = vi.hoisted(() => {
+  const AGENT_ID = 'agt_cuid00000000000000000000'
+  /** Which agent the mocked resolvers claim owns the trigger / the link. */
+  const triggerFixture: { agentId: string | null } = { agentId: AGENT_ID }
+  const linkFixture: { agentId: string | null } = { agentId: AGENT_ID }
+  const row = (agentId: string) => ({
+    id: 'trg_cuid00000000000000000000',
+    agentId,
+    organizationId: 'org_cuid000000000000000000000',
+    kind: 'scheduled',
+    enabled: true,
+    triggerType: null,
+    entityDefinitionId: null,
+    eventType: null,
+    triggerAppId: null,
+    triggerAppTriggerId: null,
+    triggerInstallationId: null,
+    triggerConnectionId: null,
+    triggerWebhookEndpointId: null,
+    triggerTopic: null,
+    config: {},
+    instructions: null,
+    lastFiredAt: null,
+    lastErrorAt: null,
+    lastError: null,
+    createdById: 'usr_cuid000000000000000000000',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  })
+  return {
+    linkFixture,
+    agentsFixture: triggerFixture,
+    triggerService: {
+      /**
+       * `getTrigger` is the ONLY thing standing between a trigger id and the
+       * agent the assert keys on. Reading `triggerFixture` (rather than a fixed
+       * row) is what lets a test say "this trigger actually belongs to a
+       * different agent" and require the denial to follow it.
+       */
+      getTrigger: vi.fn(async () => (triggerFixture.agentId ? row(triggerFixture.agentId) : null)),
+      listForAgent: vi.fn(async () => []),
+      createTrigger: vi.fn(async () => row(triggerFixture.agentId ?? AGENT_ID)),
+      updateTrigger: vi.fn(async () => row(triggerFixture.agentId ?? AGENT_ID)),
+      deleteTrigger: vi.fn(async () => undefined),
+    },
+    getCachedAgentById: vi.fn(async (_org: string, id: string) => ({
+      id,
+      userId: 'usr_agentbackinguser00000000',
+      archivedAt: null,
+      modelId: 'gpt-x',
+    })),
+    onCacheEvent: vi.fn(async () => undefined),
+    enqueueAgentJob: vi.fn(async () => undefined),
+    createSession: vi.fn(async () => ({ isErr: () => false, value: { id: 'ses_1' } })),
+    getOrgToolCatalog: vi.fn(async () => []),
+    updateAgentToolset: vi.fn(async () => undefined),
+    batchUpdateAgentToolsets: vi.fn(async () => undefined),
+    upsertAgentScopeRow: vi.fn(async () => undefined),
+    removeAgentScopeRow: vi.fn(async () => undefined),
+    procedures: {
+      listAgentProcedures: vi.fn(async () => ({ isErr: () => false, value: [] })),
+      listProcedures: vi.fn(async () => ({ isErr: () => false, value: [] })),
+      createProcedure: vi.fn(async () => ({ isErr: () => false, value: { id: 'prc_1' } })),
+      attachProcedure: vi.fn(async () => ({ isErr: () => false, value: { id: 'lnk_1' } })),
+      updateAgentProcedure: vi.fn(async () => ({
+        isErr: () => false,
+        value: { id: 'lnk_1', agentId: AGENT_ID },
+      })),
+      detachProcedure: vi.fn(async () => ({ isErr: () => false, value: AGENT_ID })),
+      reconcileAgentProcedureMentions: vi.fn(async () => undefined),
+    },
+    featureService: { requireAccess: vi.fn(async () => undefined) },
+  }
+})
+
+vi.mock('@auxx/lib/agents', () => ({
+  AgentTriggerService: class {
+    getTrigger = triggerService.getTrigger
+    listForAgent = triggerService.listForAgent
+    createTrigger = triggerService.createTrigger
+    updateTrigger = triggerService.updateTrigger
+    deleteTrigger = triggerService.deleteTrigger
+  },
+  getOrgToolCatalog,
+  updateAgentToolset,
+  batchUpdateAgentToolsets,
+  upsertAgentScopeRow,
+  removeAgentScopeRow,
+  isKnowledgeScopeRecordId: () => true,
+  ScopeRowImmutableError: class ScopeRowImmutableError extends Error {},
+}))
+
+vi.mock('@auxx/lib/agents/procedures', () => procedures)
+vi.mock('@auxx/lib/ai/agent-framework', () => ({ enqueueAgentJob }))
+vi.mock('@auxx/services', () => ({ createSession }))
+
+/**
+ * `getAllCachedAgents` is what `resolveAgentId` reads, so the id↔slug pair here
+ * IS the resolution under test. `getCachedAgentById` is `runNow`'s own lookup,
+ * downstream of the assert.
+ */
+vi.mock('@auxx/lib/cache', () => ({
+  getAllCachedAgents: vi.fn(async () => [
+    { id: 'agt_cuid00000000000000000000', slug: 'support-bot', archivedAt: null },
+    { id: 'agt_othercuid0000000000000', slug: 'other-bot', archivedAt: null },
+  ]),
+  getCachedAgentById,
+  onCacheEvent,
+}))
+
+/**
+ * `agent-trigger`'s `listRuns` and `agent-procedure`'s link resolver are the two
+ * places these routers touch Drizzle directly. `database` backs the former;
+ * `ctx.db` (see {@link fakeDb}) backs the latter.
+ */
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ orderBy: () => ({ limit: async () => [] }) }),
+      }),
+    }),
+  },
+  schema: {
+    AiAgentSession: {
+      id: 'AiAgentSession.id',
+      title: 'AiAgentSession.title',
+      type: 'AiAgentSession.type',
+      createdAt: 'AiAgentSession.createdAt',
+      updatedAt: 'AiAgentSession.updatedAt',
+      triggerContext: 'AiAgentSession.triggerContext',
+      organizationId: 'AiAgentSession.organizationId',
+      agentTriggerId: 'AiAgentSession.agentTriggerId',
+    },
+    AgentProcedure: {
+      id: 'AgentProcedure.id',
+      agentId: 'AgentProcedure.agentId',
+      organizationId: 'AgentProcedure.organizationId',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ op: 'and', parts }),
+  desc: (a: unknown) => ({ op: 'desc', a }),
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+  lt: (a: unknown, b: unknown) => ({ op: 'lt', a, b }),
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// The `@auxx/lib/permissions` barrel reaches redis/db at import time and hangs
+// under vitest — hand back the real registry plus a stub feature service (the
+// `agentProcedures` beta plan gate is not what this file is about).
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+      requireLimit = featureService.requireAccess
+    },
+  }
+})
+
+/**
+ * The `permissionProcedure` stand-in mirrors the REAL builder's gate: a plain
+ * `capabilities.assert(key)` (see `workflow-instance-access.test.ts` for the
+ * full rationale). `protectedProcedure` is kept as a bare procedure so that a
+ * regression BACK to `protectedProcedure` on any of the three formerly-open
+ * reads still runs the body — and fails the denial cases below on the missing
+ * instance assert rather than passing for the wrong reason.
+ */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
+        return next()
+      }),
+  }
+})
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { agentTriggerRouter } = await import('./agent-trigger')
+const { agentProcedureRouter } = await import('./agent-procedure')
+const { agentToolsetRouter } = await import('./agent-toolset')
+const { agentScopeRouter } = await import('./agent-scope')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const AGENT_ID = 'agt_cuid00000000000000000000'
+const AGENT_SLUG = 'support-bot'
+const OTHER_AGENT_ID = 'agt_othercuid0000000000000'
+const TRIGGER_ID = 'trg_cuid00000000000000000000'
+const LINK_ID = 'lnk_cuid00000000000000000000'
+const RECORD_ID = 'kb:kb_cuid0000000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/**
+ * A real `CapabilitySet` for a MEMBER holding `permission` on {@link AGENT_ID}
+ * via an explicit `ResourceAccess` instance row (what the share dialog writes).
+ *
+ * `areaPermission` defaults to `permission` so the coarse `agents` rungs stay
+ * consistent with the instance row; pass it separately to exercise the two
+ * independently (the restriction case: area `Full`, one agent at `none`).
+ * `instances: {}` models an agent with NO row at all — the
+ * `baselineAtCreate: false` fallback to the area level.
+ */
+function capabilitiesFor(
+  permission: ResourcePermission,
+  opts: {
+    instances?: Record<string, ResourcePermission>
+    areaPermission?: ResourcePermission
+    role?: 'MEMBER' | 'OWNER'
+  } = {}
+) {
+  const instances = opts.instances ?? { [AGENT_ID]: permission }
+  // Reproduce `composeUserCapabilities`' derived Read rung: any ≥`view` agent row
+  // synthesizes `agentsView`, so an `agents: None` grantee doesn't 403 at the
+  // coarse front door before the instance assert gets a say.
+  const derived = Object.values(instances).some((p) => p !== ResourcePermission.none)
+    ? [PermissionKey.agentsView]
+    : []
+  return new CapabilitySet(
+    new Set(
+      expandLevelsToKeys({ [Area.agents]: AREA_LEVEL_OF[opts.areaPermission ?? permission] })
+    ),
+    {},
+    opts.role ?? 'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived)
+  )
+}
+
+/** Area `Full` everywhere EXCEPT {@link AGENT_ID}, which is restricted to `none`. */
+const restricted = () =>
+  capabilitiesFor(ResourcePermission.none, {
+    areaPermission: ResourcePermission.admin,
+    instances: { [AGENT_ID]: ResourcePermission.none },
+  })
+
+/**
+ * Query-builder stand-in for `agent-procedure`'s link → agent resolution, which
+ * reads `ctx.db` directly. Driven by {@link linkFixture} so a test can point the
+ * link at a different agent (or at nothing, for the 404 case).
+ */
+function fakeDb() {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (linkFixture.agentId ? [{ agentId: linkFixture.agentId }] : []),
+        }),
+      }),
+    }),
+  }
+}
+
+function ctxFor(capabilities: InstanceType<typeof CapabilitySet>) {
+  return {
+    db: fakeDb(),
+    capabilities,
+    headers: new Headers(),
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      isSuperAdmin: false,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, email: 'a@b.c', name: 'A' },
+    },
+  } as never
+}
+
+const triggerCaller = (c: InstanceType<typeof CapabilitySet>) =>
+  agentTriggerRouter.createCaller(ctxFor(c))
+const procedureCaller = (c: InstanceType<typeof CapabilitySet>) =>
+  agentProcedureRouter.createCaller(ctxFor(c))
+const toolsetCaller = (c: InstanceType<typeof CapabilitySet>) =>
+  agentToolsetRouter.createCaller(ctxFor(c))
+const scopeCaller = (c: InstanceType<typeof CapabilitySet>) =>
+  agentScopeRouter.createCaller(ctxFor(c))
+
+type Caps = InstanceType<typeof CapabilitySet>
+
+/** The three reads that were bare `protectedProcedure` at HEAD~. */
+const FORMERLY_OPEN_READS = [
+  [
+    'agentTrigger.list',
+    (c: Caps) => triggerCaller(c).list({ agentId: AGENT_ID }),
+    () => triggerService.listForAgent,
+  ],
+  ['agentTrigger.listRuns', (c: Caps) => triggerCaller(c).listRuns({ id: TRIGGER_ID }), null],
+  [
+    'agentProcedure.list',
+    (c: Caps) => procedureCaller(c).list({ agentId: AGENT_ID }),
+    () => procedures.listAgentProcedures,
+  ],
+] as const
+
+/** The four trigger writes — `admin`, deliberately not `edit`. */
+const TRIGGER_WRITES = [
+  [
+    'create',
+    (c: Caps) =>
+      triggerCaller(c).create({
+        agentId: AGENT_ID,
+        trigger: { kind: 'mention' },
+      }),
+    () => triggerService.createTrigger,
+  ],
+  [
+    'update',
+    (c: Caps) => triggerCaller(c).update({ id: TRIGGER_ID, enabled: false }),
+    () => triggerService.updateTrigger,
+  ],
+  [
+    'delete',
+    (c: Caps) => triggerCaller(c).delete({ id: TRIGGER_ID }),
+    () => triggerService.deleteTrigger,
+  ],
+  ['runNow', (c: Caps) => triggerCaller(c).runNow({ id: TRIGGER_ID }), () => enqueueAgentJob],
+] as const
+
+/** Everything that is authoring surface, and therefore `edit`. */
+const EDIT_WRITES = [
+  [
+    'agentProcedure.createAndAttach',
+    (c: Caps) => procedureCaller(c).createAndAttach({ agentId: AGENT_ID, name: 'P' }),
+    () => procedures.createProcedure,
+  ],
+  [
+    'agentProcedure.attach',
+    (c: Caps) => procedureCaller(c).attach({ agentId: AGENT_ID, procedureId: 'prc_1' }),
+    () => procedures.attachProcedure,
+  ],
+  [
+    'agentProcedure.update',
+    (c: Caps) => procedureCaller(c).update({ id: LINK_ID, enabled: true }),
+    () => procedures.updateAgentProcedure,
+  ],
+  [
+    'agentProcedure.detach',
+    (c: Caps) => procedureCaller(c).detach({ id: LINK_ID }),
+    () => procedures.detachProcedure,
+  ],
+  [
+    'agentToolset.update',
+    (c: Caps) => toolsetCaller(c).update({ agentId: AGENT_ID, slug: 'auxx', enabled: true }),
+    () => updateAgentToolset,
+  ],
+  [
+    'agentToolset.batchUpdate',
+    (c: Caps) =>
+      toolsetCaller(c).batchUpdate({
+        agentId: AGENT_ID,
+        toolsets: [{ slug: 'auxx', enabled: true }],
+      }),
+    () => batchUpdateAgentToolsets,
+  ],
+  [
+    'agentScope.upsertRow',
+    (c: Caps) =>
+      scopeCaller(c).upsertRow({ agentId: AGENT_ID, recordId: RECORD_ID, mode: 'include_one' }),
+    () => upsertAgentScopeRow,
+  ],
+  [
+    'agentScope.removeRow',
+    (c: Caps) => scopeCaller(c).removeRow({ agentId: AGENT_ID, recordId: RECORD_ID }),
+    () => removeAgentScopeRow,
+  ],
+] as const
+
+const ALL_MOCKS = [
+  ...Object.values(triggerService),
+  ...Object.values(procedures),
+  getCachedAgentById,
+  onCacheEvent,
+  enqueueAgentJob,
+  createSession,
+  getOrgToolCatalog,
+  updateAgentToolset,
+  batchUpdateAgentToolsets,
+  upsertAgentScopeRow,
+  removeAgentScopeRow,
+  featureService.requireAccess,
+]
+
+beforeEach(() => {
+  // `mockReset` on the two resolvers, not `mockClear`: a `mockResolvedValueOnce`
+  // a test QUEUES but never consumes (an assert short-circuits ahead of it)
+  // would otherwise survive into the next test and shift every subsequent
+  // once-value by one.
+  for (const fn of ALL_MOCKS) fn.mockClear()
+  agentsFixture.agentId = AGENT_ID
+  linkFixture.agentId = AGENT_ID
+})
+
+describe('the three formerly-bare `protectedProcedure` reads', () => {
+  it.each(
+    FORMERLY_OPEN_READS
+  )('%s denies a member restricted from the agent', async (_name, call, mock) => {
+    await expect(call(restricted())).rejects.toMatchObject(FORBIDDEN)
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(FORMERLY_OPEN_READS)('%s succeeds at instance view', async (_name, call, mock) => {
+    await expect(call(capabilitiesFor(ResourcePermission.view))).resolves.toBeDefined()
+    if (mock) expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(
+    FORMERLY_OPEN_READS
+  )('%s denies a member at agents: None with no grants', async (_n, call, mock) => {
+    // No instance row anywhere ⇒ the `baselineAtCreate: false` fallback IS the
+    // area level, and the coarse `agentsView` gate is shut too.
+    await expect(
+      call(capabilitiesFor(ResourcePermission.none, { instances: {} }))
+    ).rejects.toMatchObject(FORBIDDEN)
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+})
+
+describe('agent triggers are the ADMIN rung (user decision 2026-07-28)', () => {
+  it.each(
+    TRIGGER_WRITES
+  )('%s is DENIED for an instance `edit` holder', async (_name, call, mock) => {
+    // The tier decision. A trigger runs the agent autonomously on its own
+    // credentials, so authoring one is publishing-grade, not authoring-grade.
+    // If this ever relaxes to `edit`, it must be a deliberate user decision —
+    // not a refactor that made four procedures look like their neighbours.
+    await expect(call(capabilitiesFor(ResourcePermission.edit))).rejects.toMatchObject(FORBIDDEN)
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(TRIGGER_WRITES)('%s is denied at instance view', async (_name, call, mock) => {
+    await expect(call(capabilitiesFor(ResourcePermission.view))).rejects.toMatchObject(FORBIDDEN)
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(TRIGGER_WRITES)('%s succeeds at instance admin', async (_name, call, mock) => {
+    await expect(call(capabilitiesFor(ResourcePermission.admin))).resolves.toBeDefined()
+    expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(
+    TRIGGER_WRITES
+  )('%s is denied for an agent restricted to `none`', async (_n, call, mock) => {
+    await expect(call(restricted())).rejects.toMatchObject(FORBIDDEN)
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it('runNow never reaches the agent lookup, let alone the queue, at instance edit', async () => {
+    await expect(
+      triggerCaller(capabilitiesFor(ResourcePermission.edit)).runNow({ id: TRIGGER_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(getCachedAgentById).not.toHaveBeenCalled()
+    expect(createSession).not.toHaveBeenCalled()
+    expect(enqueueAgentJob).not.toHaveBeenCalled()
+  })
+})
+
+describe('procedures / toolsets / knowledge scope are the EDIT rung', () => {
+  it.each(EDIT_WRITES)('%s succeeds at instance edit', async (_name, call, mock) => {
+    await call(capabilitiesFor(ResourcePermission.edit))
+    expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(EDIT_WRITES)('%s is denied at instance view', async (_name, call, mock) => {
+    await expect(call(capabilitiesFor(ResourcePermission.view))).rejects.toMatchObject(FORBIDDEN)
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(EDIT_WRITES)('%s is denied for an agent restricted to `none`', async (_n, call, mock) => {
+    await expect(call(restricted())).rejects.toMatchObject(FORBIDDEN)
+    expect(mock()).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * Six procedures never see an agent id. Each resolves one — via the trigger row
+ * or the `AgentProcedure` link — and the assert must key on THAT agent. Pointing
+ * the resolver at an agent the caller is restricted from is the only way to
+ * prove the resolution actually happens: a router that skipped it and asserted
+ * on, say, `input.id` would pass every other case in this file.
+ */
+describe('procedures that resolve the agent INDIRECTLY', () => {
+  /** admin on AGENT_ID, restricted from OTHER_AGENT_ID. */
+  const adminHereRestrictedThere = () =>
+    capabilitiesFor(ResourcePermission.admin, {
+      areaPermission: ResourcePermission.admin,
+      instances: {
+        [AGENT_ID]: ResourcePermission.admin,
+        [OTHER_AGENT_ID]: ResourcePermission.none,
+      },
+    })
+
+  const TRIGGER_KEYED = [
+    [
+      'update',
+      (c: Caps) => triggerCaller(c).update({ id: TRIGGER_ID, enabled: false }),
+      () => triggerService.updateTrigger,
+    ],
+    [
+      'delete',
+      (c: Caps) => triggerCaller(c).delete({ id: TRIGGER_ID }),
+      () => triggerService.deleteTrigger,
+    ],
+    ['runNow', (c: Caps) => triggerCaller(c).runNow({ id: TRIGGER_ID }), () => enqueueAgentJob],
+    ['listRuns', (c: Caps) => triggerCaller(c).listRuns({ id: TRIGGER_ID }), null],
+  ] as const
+
+  it.each(
+    TRIGGER_KEYED
+  )('agentTrigger.%s keys on the trigger’s OWNING agent', async (_name, call, mock) => {
+    agentsFixture.agentId = OTHER_AGENT_ID
+    await expect(call(adminHereRestrictedThere())).rejects.toMatchObject(FORBIDDEN)
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(
+    TRIGGER_KEYED
+  )('agentTrigger.%s 404s an unknown trigger before any capability decision', async (_n, call, mock) => {
+    agentsFixture.agentId = null
+    await expect(call(capabilitiesFor(ResourcePermission.admin))).rejects.toMatchObject({
+      cause: undefined,
+      code: 'NOT_FOUND',
+    })
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+
+  const LINK_KEYED = [
+    [
+      'update',
+      (c: Caps) => procedureCaller(c).update({ id: LINK_ID, enabled: true }),
+      () => procedures.updateAgentProcedure,
+    ],
+    [
+      'detach',
+      (c: Caps) => procedureCaller(c).detach({ id: LINK_ID }),
+      () => procedures.detachProcedure,
+    ],
+  ] as const
+
+  it.each(LINK_KEYED)('agentProcedure.%s keys on the LINK’s agent', async (_name, call, mock) => {
+    linkFixture.agentId = OTHER_AGENT_ID
+    await expect(call(adminHereRestrictedThere())).rejects.toMatchObject(FORBIDDEN)
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(LINK_KEYED)('agentProcedure.%s 404s an unknown link', async (_n, call, mock) => {
+    linkFixture.agentId = null
+    await expect(call(capabilitiesFor(ResourcePermission.admin))).rejects.toMatchObject({
+      cause: undefined,
+      code: 'NOT_FOUND',
+    })
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it('agentProcedure.detach resolves BEFORE the delete, not from its return value', async () => {
+    // `detachProcedure` hands back the removed link's agentId — far too late to
+    // authorize anything. The resolve has to be its own read, ahead of the write.
+    linkFixture.agentId = OTHER_AGENT_ID
+    await expect(
+      procedureCaller(adminHereRestrictedThere()).detach({ id: LINK_ID })
+    ).rejects.toThrow()
+    expect(procedures.detachProcedure).not.toHaveBeenCalled()
+  })
+})
+
+describe('the assert keys on the resolved `Agent.id`, never the slug', () => {
+  it('a slug belonging to a restricted agent is still denied', async () => {
+    // The regression this guards: `assertViewInstance('agent', 'support-bot')`
+    // finds no `ResourceAccess` row (rows are keyed on the id), falls through to
+    // the area level — `admin` here — and hands over the restricted agent.
+    await expect(triggerCaller(restricted()).list({ agentId: AGENT_SLUG })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(triggerService.listForAgent).not.toHaveBeenCalled()
+  })
+
+  it('a slug for an agent the member CAN view resolves to the id downstream', async () => {
+    await triggerCaller(capabilitiesFor(ResourcePermission.view)).list({ agentId: AGENT_SLUG })
+    expect(triggerService.listForAgent).toHaveBeenCalledWith(AGENT_ID, ORG_ID)
+  })
+
+  it('an agent from another org 404s rather than 403s', async () => {
+    // `resolveAgentId` throws the lib-layer `NotFoundError`, which the app's
+    // `auxxErrorMiddleware` maps to a 404. That middleware is not in this
+    // harness (the `~/server/api/trpc` stand-in replaces it), so the assertion
+    // is on the AuxxError carried as `cause` — same shape as {@link FORBIDDEN}.
+    await expect(
+      triggerCaller(capabilitiesFor(ResourcePermission.admin)).list({
+        agentId: 'agt_foreign000000',
+      })
+    ).rejects.toMatchObject({ cause: { name: 'NotFoundError', statusCode: 404 } })
+    expect(triggerService.listForAgent).not.toHaveBeenCalled()
+  })
+})
+
+describe('agentToolset.listTools is coarse, on `agentsView`', () => {
+  it('succeeds for a member at the agents Read rung', async () => {
+    // It takes no agent id and returns the ORG's tool catalogue — so it stays
+    // coarse. But an instance-`view` holder has to be able to render an agent's
+    // enabled tools, so `agentsManage` was the #1346 bug: a read gated on the
+    // authoring rung.
+    await expect(
+      toolsetCaller(capabilitiesFor(ResourcePermission.view, { instances: {} })).listTools()
+    ).resolves.toBeDefined()
+    expect(getOrgToolCatalog).toHaveBeenCalledTimes(1)
+  })
+
+  it('is refused for a member at agents: None', async () => {
+    await expect(
+      toolsetCaller(capabilitiesFor(ResourcePermission.none, { instances: {} })).listTools()
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(getOrgToolCatalog).not.toHaveBeenCalled()
+  })
+})
+
+describe('`baselineAtCreate: false` — no row falls back to the AREA level', () => {
+  const noRows = (areaPermission: ResourcePermission) =>
+    capabilitiesFor(areaPermission, { areaPermission, instances: {} })
+
+  it('area Read ⇒ the triggers tab renders, but nothing writes', async () => {
+    await expect(
+      triggerCaller(noRows(ResourcePermission.view)).list({ agentId: AGENT_ID })
+    ).resolves.toBeDefined()
+    await expect(
+      scopeCaller(noRows(ResourcePermission.view)).removeRow({
+        agentId: AGENT_ID,
+        recordId: RECORD_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('area Edit ⇒ toolsets/scope/procedures save, triggers still do not', async () => {
+    await toolsetCaller(noRows(ResourcePermission.edit)).update({
+      agentId: AGENT_ID,
+      slug: 'auxx',
+      enabled: true,
+    })
+    expect(updateAgentToolset).toHaveBeenCalledTimes(1)
+    await expect(
+      triggerCaller(noRows(ResourcePermission.edit)).delete({ id: TRIGGER_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(triggerService.deleteTrigger).not.toHaveBeenCalled()
+  })
+
+  it('area Full ⇒ triggers too, with no ResourceAccess row anywhere', async () => {
+    await expect(
+      triggerCaller(noRows(ResourcePermission.admin)).delete({ id: TRIGGER_ID })
+    ).resolves.toBeDefined()
+    expect(triggerService.deleteTrigger).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('OWNER regression', () => {
+  it('an owner short-circuits to admin on an agent restricted to `none`', async () => {
+    // Nothing authored on an agent may lock the last owner out of the agent that
+    // would let them undo it.
+    const owner = capabilitiesFor(ResourcePermission.admin, {
+      role: 'OWNER',
+      instances: { [AGENT_ID]: ResourcePermission.none },
+    })
+    await expect(
+      triggerCaller(owner).create({ agentId: AGENT_ID, trigger: { kind: 'dm' } })
+    ).resolves.toBeDefined()
+    expect(triggerService.createTrigger).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/server/api/routers/agent-toolset.ts
+++ b/apps/web/src/server/api/routers/agent-toolset.ts
@@ -1,15 +1,10 @@
 // apps/web/src/server/api/routers/agent-toolset.ts
 
-import {
-  agentExistsInOrg,
-  batchUpdateAgentToolsets,
-  getOrgToolCatalog,
-  updateAgentToolset,
-} from '@auxx/lib/agents'
+import { batchUpdateAgentToolsets, getOrgToolCatalog, updateAgentToolset } from '@auxx/lib/agents'
 import { PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { assertAgentAccess } from '~/server/lib/agent-instance-access'
 import { createTRPCRouter, permissionProcedure } from '../trpc'
 
 const logger = createScopedLogger('agent-toolset-router')
@@ -20,19 +15,19 @@ const toolsetPatchSchema = z.object({
   enabledTools: z.array(z.string().min(1).max(120)).max(500).optional(),
 })
 
-async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
-  if (!(await agentExistsInOrg(organizationId, agentId))) {
-    throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-  }
-}
-
 /**
  * Per-agent toolset CRUD. Mention-locked rows/targets (`mentions` non-empty)
  * are managed by the prompt/procedure reconcilers — the UI blocks edits to
  * them and the reconcilers self-heal out-of-band writes on the next pass.
  * This router writes `manual` (or promotes `auto_default` → `manual`). All
  * persistence lives in `@auxx/lib/agents/agent-toolset-service`; the router
- * just validates input, enforces org scope via the cache, and delegates.
+ * just validates input, delegates, and — since plan 25 §4.2 — decides access
+ * per-agent.
+ *
+ * Toolsets are authoring surface, so the writes sit on **edit**
+ * (`assertAgentAccess(..., 'edit')`), which also replaces the old
+ * `ensureAgentInOrg` org-scope check: resolution 404s an out-of-org id before
+ * the assert runs.
  */
 export const agentToolsetRouter = createTRPCRouter({
   /**
@@ -43,23 +38,35 @@ export const agentToolsetRouter = createTRPCRouter({
    * the server — clients now derive it locally from
    * `useAppsContext().appInstallations` via `useToolCatalog`. See
    * `plans/kopilot/agents/tools/project-builtin-auxx-into-installations.md`.
+   *
+   * Takes NO agent id and returns nothing agent-specific — it is the ORG's tool
+   * catalogue, the picker's raw material. So it stays coarse, but on
+   * `agentsView` rather than the authoring rung: an instance-`view` holder has
+   * to be able to render an agent's enabled tools with their display metadata,
+   * and gating that on `agentsManage` is exactly the bug #1346 shipped for
+   * workflows.
    */
-  listTools: permissionProcedure(PermissionKey.agentsManage).query(async ({ ctx }) => {
+  listTools: permissionProcedure(PermissionKey.agentsView).query(async ({ ctx }) => {
     return getOrgToolCatalog(ctx.session.organizationId)
   }),
 
-  update: permissionProcedure(PermissionKey.agentsManage)
+  update: permissionProcedure(PermissionKey.agentsView)
     .input(toolsetPatchSchema.extend({ agentId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
 
       // Exclude the writer's own socket from the `agent:updated` broadcast so
       // the realtime self-echo doesn't refetch over its optimistic cache.
       const excludeSocketId = ctx.headers.get('x-realtime-socket-id') ?? undefined
       await updateAgentToolset(
         organizationId,
-        input.agentId,
+        agentId,
         {
           slug: input.slug,
           enabled: input.enabled,
@@ -70,12 +77,12 @@ export const agentToolsetRouter = createTRPCRouter({
 
       logger.info('Agent toolset updated', {
         organizationId,
-        agentId: input.agentId,
+        agentId,
         slug: input.slug,
       })
     }),
 
-  batchUpdate: permissionProcedure(PermissionKey.agentsManage)
+  batchUpdate: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         agentId: z.string(),
@@ -84,16 +91,21 @@ export const agentToolsetRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
 
       const excludeSocketId = ctx.headers.get('x-realtime-socket-id') ?? undefined
-      await batchUpdateAgentToolsets(organizationId, input.agentId, input.toolsets, {
+      await batchUpdateAgentToolsets(organizationId, agentId, input.toolsets, {
         excludeSocketId,
       })
 
       logger.info('Agent toolsets batch-updated', {
         organizationId,
-        agentId: input.agentId,
+        agentId,
         count: input.toolsets.length,
       })
     }),

--- a/apps/web/src/server/api/routers/agent-trigger.ts
+++ b/apps/web/src/server/api/routers/agent-trigger.ts
@@ -1,7 +1,7 @@
 // apps/web/src/server/api/routers/agent-trigger.ts
 
 import { database, schema } from '@auxx/database'
-import { type AgentTriggerInput, AgentTriggerService, agentExistsInOrg } from '@auxx/lib/agents'
+import { type AgentTriggerInput, AgentTriggerService } from '@auxx/lib/agents'
 import { enqueueAgentJob } from '@auxx/lib/ai/agent-framework'
 import { getCachedAgentById, onCacheEvent } from '@auxx/lib/cache'
 import { PermissionKey } from '@auxx/lib/permissions'
@@ -10,7 +10,8 @@ import { createSession } from '@auxx/services'
 import { TRPCError } from '@trpc/server'
 import { and, desc, eq, lt } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
+import { assertAgentAccess } from '~/server/lib/agent-instance-access'
+import { createTRPCRouter, permissionProcedure } from '../trpc'
 
 const logger = createScopedLogger('agent-trigger-router')
 
@@ -78,10 +79,24 @@ const triggerInputSchema = z.union([
   dmInputSchema,
 ])
 
-async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
-  if (!(await agentExistsInOrg(organizationId, agentId))) {
-    throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
+/**
+ * `AgentTrigger.id` → the row, or a 404. Four of the six procedures here are
+ * keyed on a TRIGGER id, but per-instance access lives on the **agent**: the
+ * trigger carries it only transitively. Loading the row first is what turns
+ * `input.id` into an `Agent.id` the assert can key on — without it those
+ * procedures would fall back to the coarse area rung and hand a restricted
+ * agent's triggers to anyone.
+ *
+ * The 404 lands BEFORE the assert on purpose (same rule as
+ * `resolveAgentId`): a trigger from another org must not be distinguishable
+ * from one the caller is restricted from.
+ */
+async function loadTrigger(triggerId: string, organizationId: string) {
+  const trigger = await new AgentTriggerService().getTrigger(triggerId, organizationId)
+  if (!trigger) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Trigger not found' })
   }
+  return trigger
 }
 
 function rowToDto(row: typeof schema.AgentTrigger.$inferSelect) {
@@ -111,17 +126,43 @@ function rowToDto(row: typeof schema.AgentTrigger.$inferSelect) {
   }
 }
 
+/**
+ * Agent triggers — per-agent instance access (plan 25 §4.2).
+ *
+ * Tiers here are deliberately lopsided: reading which triggers exist and what
+ * they fired is **view**, but every WRITE is **admin**, not edit. A trigger is
+ * the thing that makes an agent act autonomously on its OWN credentials with no
+ * invoker to intersect against (`agent-run-capabilities.ts` only narrows to the
+ * invoker on human-driven paths; schedules, record events, app triggers and
+ * webhooks pass none). So authoring a trigger is closer to publishing the agent
+ * than to editing its prompt — user decision 2026-07-28, same rung as
+ * `runAsUserId` and `permissionProfileId`. `runNow` fires the agent on the spot,
+ * so it sits on the same rung as creating the trigger that would have fired it.
+ *
+ * Base procedure is `permissionProcedure(agentsView)` throughout, with the real
+ * decision in the body (`workflow.ts` precedent): the coarse rung keeps the
+ * plan-AND these procedures already ran, and a member composing `agents: None`
+ * who holds one explicit instance grant genuinely holds `agentsView` because the
+ * composer derives that Read rung from their grants. **Every procedure on that
+ * base must assert on a specific agent** — the derived key says only "this
+ * member has some agent access", never which agent.
+ */
 export const agentTriggerRouter = createTRPCRouter({
-  list: protectedProcedure
+  list: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
-      const rows = await new AgentTriggerService().listForAgent(input.agentId, organizationId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'view',
+      })
+      const rows = await new AgentTriggerService().listForAgent(agentId, organizationId)
       return rows.map(rowToDto)
     }),
 
-  create: permissionProcedure(PermissionKey.agentsManage)
+  create: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -132,10 +173,15 @@ export const agentTriggerRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      await ensureAgentInOrg(organizationId, input.agentId)
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'admin',
+      })
 
       const row = await new AgentTriggerService().createTrigger({
-        agentId: input.agentId,
+        agentId,
         organizationId,
         createdById: userId,
         enabled: input.enabled,
@@ -149,7 +195,7 @@ export const agentTriggerRouter = createTRPCRouter({
 
       logger.info('Agent trigger created', {
         organizationId,
-        agentId: input.agentId,
+        agentId,
         triggerId: row.id,
         kind: row.kind,
       })
@@ -157,7 +203,7 @@ export const agentTriggerRouter = createTRPCRouter({
       return rowToDto(row)
     }),
 
-  update: permissionProcedure(PermissionKey.agentsManage)
+  update: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         id: z.string().min(1),
@@ -168,6 +214,13 @@ export const agentTriggerRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      const trigger = await loadTrigger(input.id, organizationId)
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: trigger.agentId,
+        tier: 'admin',
+      })
       const row = await new AgentTriggerService().updateTrigger(input.id, organizationId, {
         enabled: input.enabled,
         instructions: input.instructions,
@@ -177,25 +230,36 @@ export const agentTriggerRouter = createTRPCRouter({
       return rowToDto(row)
     }),
 
-  delete: permissionProcedure(PermissionKey.agentsManage)
+  delete: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      const service = new AgentTriggerService()
-      await service.deleteTrigger(input.id, organizationId)
+      const trigger = await loadTrigger(input.id, organizationId)
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: trigger.agentId,
+        tier: 'admin',
+      })
+      await new AgentTriggerService().deleteTrigger(input.id, organizationId)
       await onCacheEvent('agent.updated', { orgId: organizationId })
       return { ok: true as const }
     }),
 
-  runNow: permissionProcedure(PermissionKey.agentsManage)
+  runNow: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      const service = new AgentTriggerService()
-      const trigger = await service.getTrigger(input.id, organizationId)
-      if (!trigger) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Trigger not found' })
-      }
+      const trigger = await loadTrigger(input.id, organizationId)
+      // Firing the agent by hand is the trigger's whole effect, minus the wait —
+      // it runs on the agent's credentials with `approvalMode: 'auto'`. Same
+      // admin rung as authoring the trigger.
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: trigger.agentId,
+        tier: 'admin',
+      })
 
       const agent = await getCachedAgentById(organizationId, trigger.agentId)
       if (!agent || agent.archivedAt) {
@@ -254,7 +318,7 @@ export const agentTriggerRouter = createTRPCRouter({
       return { sessionId: session.id }
     }),
 
-  listRuns: protectedProcedure
+  listRuns: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         id: z.string().min(1),
@@ -264,6 +328,15 @@ export const agentTriggerRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      // Single-agent shape: every row returned belongs to the ONE trigger named
+      // in the input, so this asserts rather than filters.
+      const trigger = await loadTrigger(input.id, organizationId)
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: trigger.agentId,
+        tier: 'view',
+      })
       const conditions = [
         eq(schema.AiAgentSession.organizationId, organizationId),
         eq(schema.AiAgentSession.agentTriggerId, input.id),

--- a/apps/web/src/server/api/routers/agent.ts
+++ b/apps/web/src/server/api/routers/agent.ts
@@ -1,7 +1,6 @@
 // apps/web/src/server/api/routers/agent.ts
 
 import {
-  agentExistsInOrg,
   agentSlugSchema,
   completeAgentSetup,
   createAgent as createAgentService,
@@ -18,12 +17,14 @@ import {
   setAgentToolBindings,
   updateAgent as updateAgentService,
 } from '@auxx/lib/agents'
+import { ForbiddenError } from '@auxx/lib/errors'
 import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { getRealtimeService, publishAgentUpdated } from '@auxx/lib/realtime'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { createTRPCRouter, permissionProcedure } from '../trpc'
+import { assertAgentAccess } from '~/server/lib/agent-instance-access'
+import { capabilityProcedure, createTRPCRouter, permissionProcedure } from '../trpc'
 import { unwrap } from '../unwrap'
 
 const logger = createScopedLogger('agent-router')
@@ -31,30 +32,148 @@ const logger = createScopedLogger('agent-router')
 const promptSchema = z.record(z.string(), z.unknown())
 
 /**
- * Admin-only CRUD for user-authored Kopilot agents. Toolset rows are managed
- * via the sibling `agentToolset.*` router. Archive is driven through `update`
+ * `agent.update` fields that are AGENT ADMINISTRATION rather than authoring, and
+ * therefore sit on the Full rung (plan 25 §4.2: "admin = create, publish,
+ * delete, archive, rename, `runAsUserId`, `permissionProfileId`, triggers").
+ *
+ * `update` is a single fat mutation fed by several surfaces — the persona
+ * editor's autosave, the agents list's archive toggle, and the settings panels
+ * that bind a run-as user or a permission profile — so the tier can't come from
+ * the procedure alone. Presence of ANY of these keys escalates the assert from
+ * `assertEditInstance` to `assertAdminInstance`. Everything else (`name`,
+ * `slug`, `description`, `prompt`, `modelId`, `mentionable`, `appAccounts`) is
+ * authoring and stays on the Edit rung.
+ *
+ * `runAsUserId` and `permissionProfileId` are the authority-shaped pair: they
+ * decide whose capabilities a run resolves against and what the next publish
+ * snapshots. `archivedAt` bans the agent's backing `User` (`agent-service.ts`
+ * `updateAgent`), which is the soft-delete half of `delete`.
+ *
+ * Mirrors #1345's `ADMIN_ONLY_UPDATE_FIELDS` in `workflow.ts`, including the
+ * `input[field] !== undefined` form — see the note on the escalation itself for
+ * why that is safe here.
+ */
+const ADMIN_ONLY_UPDATE_FIELDS = ['runAsUserId', 'permissionProfileId', 'archivedAt'] as const
+
+/**
+ * CRUD for user-authored Kopilot agents. Toolset rows are managed via the
+ * sibling `agentToolset.*` router. Archive is driven through `update`
  * (`archivedAt: Date | null`) per plans/kopilot/agents/phase-1-engine-and-api.md
  * §3.2. Reads flow through the org agents cache; writes go through
  * `@auxx/lib/agents` service functions — no raw SQL lives in this router.
+ *
+ * Per-agent instance access (plan 25 §4.2.DECIDED). `agent` is an
+ * `INSTANCE_ACCESS_RESOURCES` key with `baselineAtCreate: false`, so an agent
+ * with no explicit `ResourceAccess` row falls back to the member's `agents` area
+ * level — Read ⇒ `view`, Edit ⇒ `edit`, Full ⇒ `admin`. `MEMBER_BASELINE_LEVELS`
+ * puts members at `agents: Full`, so **restriction is the use case** and nobody
+ * regresses.
+ *
+ * Tiers (plan 25 §4.2, user decision 2026-07-27/28):
+ *  - **view** — *usable*: open the detail page, chat in Kopilot, DM, @-mention,
+ *    assign work, appear in actor pickers, read version history.
+ *  - **edit** — authoring: prompt, drafts, toolsets/bindings, knowledge scope,
+ *    procedures, evals; RENAME (name + slug); discard draft edits; label a
+ *    version; discard a draft agent that never completed setup. Rename is edit
+ *    rather than admin (user decision 2026-07-28) — it is an authoring field,
+ *    which is why it is absent from `ADMIN_ONLY_UPDATE_FIELDS`.
+ *  - **admin** — create, complete setup, publish, restore a past version,
+ *    delete, archive, `runAsUserId`, `permissionProfileId`.
+ *  - `create` has no instance to key on, so it gates on the coarse
+ *    `agentsManage` rung. `checkSlug` serves both callers and decides in its
+ *    body — see its own doc.
+ *
+ * Base procedure: `permissionProcedure(agentsView)` everywhere the instance
+ * assert does the real work — a member composing `agents: None` who holds one
+ * explicit instance grant genuinely HOLDS `agentsView`, because
+ * `composeUserCapabilities` derives that Read rung from their grants
+ * (`deriveInstanceReadKeys`). **Every procedure on this base MUST assert on a
+ * specific instance** and must not return org-wide data: the derived key says
+ * only "this member has some agent access", never which agent.
+ *
+ * Every instance assert goes through {@link assertAgentAccess}, never
+ * `ctx.capabilities.assert*Instance('agent', input.agentId)` directly:
+ * `getById` accepts an id OR a slug (the detail page routes by slug) while
+ * grants are keyed on `Agent.id`, so asserting on the raw input would find no
+ * row, fall through to the area level, and hand over a restricted agent. It
+ * also subsumes the `agentExistsInOrg` existence check these procedures used to
+ * run — an unresolvable identifier is a `NotFoundError` BEFORE the capability
+ * check, so a foreign-org id is indistinguishable from a restricted one.
+ *
+ * NOT gated by any of this: **headless agent runs**. Schedules, record events,
+ * app triggers, webhooks and evals pass no `invokerUserId`, so a restricted
+ * agent still runs. And instance access is the TRANSPOSE of agent policy: this
+ * is what USERS may do to the agent, not what the agent may do (plan 25 §4.2).
  */
 export const agentRouter = createTRPCRouter({
-  list: permissionProcedure(PermissionKey.agentsManage)
+  // `capabilityProcedure`, NOT `permissionProcedure(agentsView)` — matching
+  // `kb.list` / `dataset.list` / `dashboard.list` / `workflow.list`, all four of
+  // which resolve the capability set without asserting any coarse key. A coarse
+  // assert here would 403 a member composing `agents: None` with no grants
+  // instead of handing them an empty list, and the surface that breaks is the
+  // permission grid's own Agents row (`use-instance-resource-lists.ts`), where a
+  // permissions admin who happens to compose `agents: None` would get a broken
+  // row rather than an empty one.
+  //
+  // The known cost, identical to the one #1345 accepted for `workflow.list`
+  // (plan 30 §8 item 3): `capabilityProcedure` skips the `FeatureKey.agents`
+  // plan-AND, so an org on a plan without agents can still enumerate agent
+  // names. Read-only and low severity, but real and undocumented at the other
+  // call sites — recorded here rather than rediscovered.
+  list: capabilityProcedure
     .input(z.object({ includeArchived: z.boolean().optional() }).optional())
-    .query(({ ctx, input }) =>
-      listAgents(ctx.session.organizationId, {
+    .query(async ({ ctx, input }) => {
+      // FILTER, never assert — a member restricted from one agent gets a
+      // shorter list, not a 403 on the whole page (`kb.list` precedent).
+      //
+      // `instanceListScope` is three-way because plan 25 §2 gave the view gate
+      // two regimes and no single id list expresses both:
+      //  - open `agents` area → `exclude`, near-empty in practice (`agent` is
+      //    `baselineAtCreate: false`, so the only exclusions are agents someone
+      //    deliberately restricted);
+      //  - `agents: None` + explicit grants → `include`, naming exactly the
+      //    agents shared with this member. Returning everything here would
+      //    contradict `getById`, which lets them open only those.
+      //  - `none` → nothing is visible; return early WITHOUT the cache read.
+      //
+      // Unlike `workflow.list` this is unpaginated (`agent-service.ts`
+      // `listAgents` returns the whole org cache slice), so filtering the array
+      // is exact — there is no `total`/`hasMore` for it to desynchronize.
+      const scope = ctx.capabilities.instanceListScope('agent')
+      if (scope.kind === 'none') return []
+
+      const agents = await listAgents(ctx.session.organizationId, {
         includeArchived: input?.includeArchived ?? false,
       })
-    ),
+
+      if (scope.kind === 'include') {
+        const allowed = new Set(scope.includeIds)
+        return agents.filter((agent) => allowed.has(agent.id))
+      }
+      if (scope.excludeIds.length === 0) return agents
+      const excluded = new Set(scope.excludeIds)
+      return agents.filter((agent) => !excluded.has(agent.id))
+    }),
 
   /**
    * Resolve an agent by id or slug. The input field is named `agentId` for
    * backward compatibility with existing callers, but accepts either form —
    * the service helper checks both columns against the org agents cache.
    */
-  getById: permissionProcedure(PermissionKey.agentsManage)
+  getById: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
-      const detail = await getAgentDetailByIdOrSlug(ctx.session.organizationId, input.agentId)
+      // Read — opening an agent (read-only at `view`, editable at `edit`).
+      // The assert MUST run on the RESOLVED id: this is the one procedure that
+      // is routinely called with a slug, and a slug matches no `ResourceAccess`
+      // row. `assertAgentAccess` resolves first and hands the id back.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: input.agentId,
+        tier: 'view',
+      })
+      const detail = await getAgentDetailByIdOrSlug(ctx.session.organizationId, agentId)
       if (!detail) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
       }
@@ -94,6 +213,10 @@ export const agentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
       const args = input ?? {}
+
+      // Full — no instance exists yet to key on, so the coarse `agentsManage`
+      // rung is the gate. That rung is never derived from instance grants, so a
+      // member holding one shared agent cannot mint new ones.
 
       // Gate creation on the plan's agent allowance (0 on Free).
       await new FeaturePermissionService().requireLimit(
@@ -136,17 +259,22 @@ export const agentRouter = createTRPCRouter({
    * the user finishes configuration in the live tabs. The AI chat-builder
    * tool calls `completeAgentSetup` directly and keeps those gates.
    */
-  completeSetup: permissionProcedure(PermissionKey.agentsManage)
+  completeSetup: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      if (!(await agentExistsInOrg(organizationId, input.agentId))) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
+      // Full — completing setup auto-publishes v1 and turns a draft into a live
+      // agent with a backing `User`. Same rung as `publish`, which it performs.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'admin',
+      })
       // `completedByUserId` bounds the auto-published v1 policy by this user's own
-      // authority (doc 19 §2.4a) — `agentsManage` is grantable to non-admins, so a
-      // member completing setup must not mint an agent stronger than themselves.
-      await completeAgentSetup(input.agentId, organizationId, undefined, {
+      // authority (doc 19 §2.4a) — instance `admin` is grantable to non-admins, so
+      // a member completing setup must not mint an agent stronger than themselves.
+      await completeAgentSetup(agentId, organizationId, undefined, {
         force: true,
         completedByUserId: userId,
       })
@@ -157,11 +285,20 @@ export const agentRouter = createTRPCRouter({
    * agents-list "Discard draft" overflow item. Refuses to touch completed
    * agents — use the archive path for those.
    */
-  deleteDraft: permissionProcedure(PermissionKey.agentsManage)
+  deleteDraft: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      const result = await deleteDraftAgent(input.agentId, organizationId)
+      // Write — a draft has never been published and has no backing `User`, so
+      // discarding it destroys unpublished authoring, not a live agent. That is
+      // the Edit rung; `delete` (any state) is the Full one.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
+      const result = await deleteDraftAgent(agentId, organizationId)
       if (!result.deleted) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -175,16 +312,24 @@ export const agentRouter = createTRPCRouter({
    * `Agent` row and its synthetic `User`; conversation history is preserved
    * orphaned. Use `deleteDraft` only for incomplete drafts.
    */
-  delete: permissionProcedure(PermissionKey.agentsManage)
+  delete: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const result = await deleteAgentService(input.agentId, ctx.session.organizationId)
+      // Full — destroying the agent, its synthetic `User` and every version
+      // (KB / dataset / dashboard / workflow delete precedent).
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: input.agentId,
+        tier: 'admin',
+      })
+      const result = await deleteAgentService(agentId, ctx.session.organizationId)
       if (!result.deleted) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
       }
     }),
 
-  update: permissionProcedure(PermissionKey.agentsManage)
+  update: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         agentId: z.string(),
@@ -223,10 +368,29 @@ export const agentRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      const { agentId, ...patch } = input
+      const { agentId: agentIdOrSlug, ...patch } = input
 
-      if (!(await agentExistsInOrg(organizationId, agentId))) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
+      // Write — authoring the agent (persona, model, toolset bindings).
+      // ESCALATES to Full when the payload also carries an administration field
+      // (see `ADMIN_ONLY_UPDATE_FIELDS`): run-as delegation, the draft
+      // permission-profile binding, and archive/unarchive.
+      //
+      // The escalation test is `input[field] !== undefined`, not key presence.
+      // That is safe ONLY because the payload builder below guards each of the
+      // three with the SAME `!== undefined` check, so an explicitly-`undefined`
+      // key is dropped before `updateAgent` ever sees it and cannot change
+      // anything either. The two must stay in lockstep — if a field ever starts
+      // being forwarded on presence alone (`'archivedAt' in patch`, which is
+      // exactly how `updateAgent` detects an archive transition), this check has
+      // to become key-presence-based too.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: agentIdOrSlug,
+        tier: 'edit',
+      })
+      if (ADMIN_ONLY_UPDATE_FIELDS.some((field) => patch[field] !== undefined)) {
+        ctx.capabilities.assertAdminInstance('agent', agentId)
       }
 
       if (patch.slug !== undefined) {
@@ -260,9 +424,38 @@ export const agentRouter = createTRPCRouter({
       await updateAgentService(agentId, organizationId, updatePayload, { excludeSocketId })
     }),
 
-  checkSlug: permissionProcedure(PermissionKey.agentsManage)
+  /**
+   * Is this slug free? Serves two callers with two different authorities, which
+   * is why the gate is inside the body rather than on the procedure.
+   *
+   * - **Create dialog** (no `excludeAgentId`): there is no instance to key on,
+   *   so it answers a question about the org's slug namespace and needs the same
+   *   coarse `agentsManage` rung as `create` itself.
+   * - **Rename hint** (`excludeAgentId` present — `agent-hero.tsx` polls this
+   *   live as you type): this is a question about ONE agent, so it is an
+   *   instance `edit` check on that agent. Gating the whole procedure on the
+   *   coarse rung instead would take the hint away from every instance-`edit`
+   *   holder below coarse Full, while `update` still let them rename — an
+   *   affordance that vanishes for no reason the user can see.
+   */
+  checkSlug: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ slug: agentSlugSchema, excludeAgentId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
+      if (input.excludeAgentId) {
+        await assertAgentAccess({
+          capabilities: ctx.capabilities,
+          organizationId: ctx.session.organizationId,
+          idOrSlug: input.excludeAgentId,
+          tier: 'edit',
+        })
+      } else if (!ctx.capabilities.can(PermissionKey.agentsManage)) {
+        // `ForbiddenError`, not `TRPCError` — every other permission denial in
+        // this router comes from the `CapabilitySet` as an `AuxxError` and is
+        // mapped by `auxxErrorMiddleware`. A raw `TRPCError` here would be the
+        // one denial with a different cause shape.
+        throw new ForbiddenError('You don’t have permission to create agents.')
+      }
+
       const taken = await isAgentSlugTaken(ctx.session.organizationId, input.slug, {
         excludeAgentId: input.excludeAgentId,
       })
@@ -276,7 +469,7 @@ export const agentRouter = createTRPCRouter({
    * the org agents cache. An empty map means "everything runs on author
    * defaults". See plans/chat/v8 phase-5.
    */
-  setToolBindings: permissionProcedure(PermissionKey.agentsManage)
+  setToolBindings: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -298,12 +491,16 @@ export const agentRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      if (!(await agentExistsInOrg(organizationId, input.agentId))) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
+      // Write — toolset bindings are authoring (plan 25 §4.2's "toolsets").
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
       await setAgentToolBindings({
         organizationId,
-        agentId: input.agentId,
+        agentId,
         bindings: input.bindings,
       })
     }),
@@ -316,17 +513,25 @@ export const agentRouter = createTRPCRouter({
   // plans/agents/agent-versions/build-plan.md §6.
 
   /** Snapshot the draft as a new version (or no-op republish). Human-only. */
-  publish: permissionProcedure(PermissionKey.agentsManage)
+  publish: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1), label: z.string().max(120).optional() }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      if (!(await agentExistsInOrg(organizationId, input.agentId))) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
+      // Full — publishing promotes the draft into PRODUCTION and snapshots the
+      // resolved permission policy that every subsequent run executes under
+      // (plan 25 §4.2: "admin = create, publish, delete"). Note this is the one
+      // place where the agent tiers deliberately part company with workflows,
+      // where publish is Edit: a published agent acts with authority.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'admin',
+      })
       const { version, reductions } = unwrap(
         await publishAgent({
           organizationId,
-          agentId: input.agentId,
+          agentId,
           editorId: userId,
           label: input.label ?? null,
           // The AUTHOR CLAMP (doc 19 §2.4a): the published policy is
@@ -335,7 +540,7 @@ export const agentRouter = createTRPCRouter({
         }),
         'publish agent'
       )
-      await publishAgentUpdated(getRealtimeService(), organizationId, { agentId: input.agentId })
+      await publishAgentUpdated(getRealtimeService(), organizationId, { agentId })
       // `reductions` is returned, never swallowed: publish must be able to say
       // "Deals reduced from Full to Read — you hold Read" rather than silently
       // downgrading what the admin configured (§2.4a). Rendering it is step 8's.
@@ -347,43 +552,51 @@ export const agentRouter = createTRPCRouter({
     }),
 
   /** Discard draft edits — restore the active version onto the row. */
-  discardChanges: permissionProcedure(PermissionKey.agentsManage)
+  discardChanges: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      if (!(await agentExistsInOrg(organizationId, input.agentId))) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
-      unwrap(
-        await discardAgentDraft({ organizationId, agentId: input.agentId }),
-        'discard agent draft'
-      )
-      await publishAgentUpdated(getRealtimeService(), organizationId, { agentId: input.agentId })
+      // Write — throwing away UNPUBLISHED authoring and reloading the active
+      // version. Production is untouched, so it never reaches the Full rung.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
+      unwrap(await discardAgentDraft({ organizationId, agentId }), 'discard agent draft')
+      await publishAgentUpdated(getRealtimeService(), organizationId, { agentId })
       return { ok: true as const }
     }),
 
   /** Restore-as-draft: load a past version into the draft + mark dirty. */
-  restoreVersion: permissionProcedure(PermissionKey.agentsManage)
+  restoreVersion: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1), toVersionId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      if (!(await agentExistsInOrg(organizationId, input.agentId))) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
+      // Full — restoring rewinds the draft to a past version wholesale,
+      // including its permission-profile binding, and is the setup half of a
+      // publish-to-roll-back. It sits with `publish`, not with `discardChanges`.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'admin',
+      })
       unwrap(
         await restoreAgentVersion({
           organizationId,
-          agentId: input.agentId,
+          agentId,
           toVersionId: input.toVersionId,
         }),
         'restore agent version'
       )
-      await publishAgentUpdated(getRealtimeService(), organizationId, { agentId: input.agentId })
+      await publishAgentUpdated(getRealtimeService(), organizationId, { agentId })
       return { ok: true as const }
     }),
 
   /** Rename a published version's label (annotation only). */
-  renameVersion: permissionProcedure(PermissionKey.agentsManage)
+  renameVersion: permissionProcedure(PermissionKey.agentsView)
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -393,13 +606,19 @@ export const agentRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      if (!(await agentExistsInOrg(organizationId, input.agentId))) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
+      // Write — labelling a VERSION is an annotation, not renaming the agent
+      // (that is `update` with `name`, which stays on Edit as well). Mirrors
+      // `workflow.renameVersion`.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
       unwrap(
         await renameAgentVersion({
           organizationId,
-          agentId: input.agentId,
+          agentId,
           versionId: input.versionId,
           label: input.label,
         }),
@@ -409,13 +628,21 @@ export const agentRouter = createTRPCRouter({
     }),
 
   /** Published version history (newest first) with editor names. */
-  listVersions: permissionProcedure(PermissionKey.agentsManage)
+  listVersions: permissionProcedure(PermissionKey.agentsView)
     .input(z.object({ agentId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
+      // Read — the history list is visible at `view`; restore is the Full half
+      // and rename the Edit half.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: input.agentId,
+        tier: 'view',
+      })
       const rows = unwrap(
         await listAgentVersions({
           organizationId: ctx.session.organizationId,
-          agentId: input.agentId,
+          agentId,
         }),
         'list agent versions'
       )

--- a/apps/web/src/server/api/routers/eval-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/eval-instance-access.test.ts
@@ -1,0 +1,712 @@
+// apps/web/src/server/api/routers/eval-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 25 §4.2 at the eval router — per-agent instance access over an agent's
+ * simulations, suites and run history.
+ *
+ * The headline here is a **closed hole, not a re-tiering**: 11 of these
+ * procedures were bare `protectedProcedure` and read no capabilities at all, so
+ * any org member could list, open and diff any agent's eval cases, runs, traces
+ * and credit spend. Every one of those 11 gets its own denial case below.
+ *
+ * The second thing this file exists to pin is **where the agent id comes from**.
+ * Only 5 of the 19 procedures are handed an `agentId`; the rest arrive with an
+ * eval-case id, a run id, or a suite-run id, and each has to resolve the owning
+ * agent before it can assert. Those resolutions are the easy thing to get
+ * subtly wrong (assert the wrong agent, or the *input* id, and the gate reads as
+ * present while gating nothing), so each indirect path has a case that points
+ * the fixture at a DIFFERENT agent and demands a 403.
+ *
+ * Behavioral, not source-text: the real router module is imported and driven
+ * through a tRPC caller, `ctx.capabilities` is a **real** {@link CapabilitySet},
+ * and `~/server/lib/agent-instance-access` is the REAL module (only the agents
+ * cache underneath it is stubbed) so id-or-slug resolution is under test too.
+ * The mocked `@auxx/lib/evals` functions are the observed side effect.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const AGENT_ID = 'agt_cuid000000000000000000000'
+const AGENT_SLUG = 'support-agent'
+const OTHER_AGENT_ID = 'agt_othercuid00000000000000'
+const CASE_ID = 'evc_cuid000000000000000000000'
+const RUN_ID = 'evr_cuid000000000000000000000'
+const SUITE_ID = 'evs_cuid000000000000000000000'
+const BASELINE_SUITE_ID = 'evs_baseline0000000000000000'
+
+/** A valid `SimulationConfig` — `parseCase` runs the REAL Zod schemas. */
+const CONFIG = {
+  openingMessage: 'hello',
+  customerContext: null,
+  channel: 'chat' as const,
+  timeFrozenAt: null,
+  maxCustomerTurns: 3,
+  subject: { recordIds: [], identityVerified: false },
+  startingFields: [],
+  unmatchedToolPolicy: 'error' as const,
+  connectorMocks: [],
+}
+
+/** `agentEvalAssertionsSchema` rejects empty lists, so cases need at least one. */
+const ASSERTIONS = [
+  { id: 'a1', type: 'terminal_outcome' as const, data: { outcome: 'finished' as const } },
+]
+
+const targetFor = (agentId: string) => ({
+  kind: 'agent_simulation' as const,
+  scope: 'agent' as const,
+  agentId,
+})
+
+const { evals, startAgentSuiteRun, enqueueEvalRun, getAllCachedAgents, featureService, fixture } =
+  vi.hoisted(() => {
+    /**
+     * Which agent each persisted row resolves to. Mutated per test — this is how
+     * the indirect-resolution cases prove the router reads the ROW's agent
+     * rather than echoing whatever id arrived on the input.
+     */
+    const fixture = {
+      /** `EvalCase.agentId`; `null` exercises the `target`-is-source-of-truth fallback. */
+      caseAgentId: null as string | null,
+      /** `EvalCase.target` — the source of truth `caseAgentId()` falls back to. */
+      caseTarget: null as unknown,
+      /** `EvalRun.definitionSnapshot.case.target` — `null` models an unparseable snapshot. */
+      runSnapshotTarget: null as unknown,
+      /** `EvalSuiteRun.agentId` per suite id. `null` models a suite with no agent. */
+      suiteAgents: {} as Record<string, string | null>,
+      /** Rows `listEvalCasesByAgent` hands back (the `list` projection needs real Dates). */
+      caseRows: [] as unknown[],
+    }
+
+    const okResult = <T>(value: T) => ({ isErr: () => false, value })
+
+    return {
+      fixture,
+      featureService: { requireAccess: vi.fn(async () => undefined) },
+      getAllCachedAgents: vi.fn(async () => [
+        { id: AGENT_ID, slug: AGENT_SLUG },
+        { id: OTHER_AGENT_ID, slug: 'other-agent' },
+      ]),
+      startAgentSuiteRun: vi.fn(async () =>
+        okResult({ suiteRun: { id: SUITE_ID }, runIds: [RUN_ID], requestedCount: 1 })
+      ),
+      enqueueEvalRun: vi.fn(async () => undefined),
+      evals: {
+        getEvalCaseById: vi.fn(async () =>
+          okResult({
+            id: CASE_ID,
+            name: 'Refund flow',
+            agentId: fixture.caseAgentId,
+            target: fixture.caseTarget,
+            config: CONFIG,
+            assertions: ASSERTIONS,
+            suggestionId: null,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          })
+        ),
+        listEvalCasesByAgent: vi.fn(async () => okResult(fixture.caseRows)),
+        getLatestRunsByCaseIds: vi.fn(async () => okResult([])),
+        createEvalCase: vi.fn(async () => okResult({ id: 'evc_new' })),
+        updateEvalCase: vi.fn(async () => okResult({ id: CASE_ID })),
+        deleteEvalCase: vi.fn(async () => okResult(undefined)),
+        getEvalRun: vi.fn(async () =>
+          okResult({
+            id: RUN_ID,
+            caseId: CASE_ID,
+            status: 'passed',
+            definitionSnapshot: { case: { target: fixture.runSnapshotTarget } },
+          })
+        ),
+        listEvalRuns: vi.fn(async () => okResult([])),
+        getEvalRunCredits: vi.fn(async () => okResult({ creditsUsed: 1, totalTokens: 2 })),
+        deleteEvalRun: vi.fn(async () => okResult(undefined)),
+        cancelEvalRun: vi.fn(async () => okResult({ status: 'cancelled' })),
+        getEvalSuiteRun: vi.fn(async ({ suiteRunId }: { suiteRunId: string }) => {
+          const agentId = fixture.suiteAgents[suiteRunId]
+          if (agentId === undefined) return okResult(null)
+          return okResult({
+            id: suiteRunId,
+            agentId,
+            status: 'completed',
+            runMode: 'pinned',
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          })
+        }),
+        listEvalSuiteRuns: vi.fn(async () => okResult([])),
+        listSuiteChildRunSummaries: vi.fn(async () => okResult([])),
+        compareSuiteRuns: vi.fn(async () => okResult({ counts: {}, entries: [] })),
+        createQueuedEvalRun: vi.fn(async () => okResult({ id: RUN_ID })),
+        failQueuedEvalRun: vi.fn(async () => undefined),
+        prepareRunSnapshots: vi.fn(async () =>
+          okResult({ definitionSnapshot: {}, runtimeSnapshot: { runMode: 'pinned' } })
+        ),
+        suggestAgentSimulations: vi.fn(async () => okResult({ suggestions: [] })),
+        validateAgentToolMock: vi.fn(async () => ({ valid: true })),
+        validateEvalCase: vi.fn(async () => ({ ok: true, issues: [] })),
+      },
+    }
+  })
+
+vi.mock('@auxx/lib/evals', () => ({ ...evals }))
+vi.mock('@auxx/lib/evals/start-suite-run', () => ({ startAgentSuiteRun }))
+vi.mock('@auxx/lib/evals/worker', () => ({ enqueueEvalRun }))
+
+// `agent-instance-access.ts` itself is REAL — only the org agents cache beneath
+// it is stubbed, so id-or-slug resolution and the 404-before-assert rule are
+// both exercised for real.
+vi.mock('@auxx/lib/cache', () => ({ getAllCachedAgents }))
+
+// See the note in `dataset-instance-access.test.ts` — the `@auxx/lib/permissions`
+// barrel reaches redis/db at import time and hangs under vitest. Hand back the
+// real registry plus a stub feature service (Layer-1 plan gating is not what
+// this file is about).
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+      requireLimit = featureService.requireAccess
+    },
+  }
+})
+
+/**
+ * The `permissionProcedure` stand-in mirrors the REAL builder's gate: a plain
+ * `capabilities.assert(key)`. Kept in lockstep with `trpc.ts`; only the plan-AND
+ * and the `getCapabilities` read are dropped, since ctx carries the set already.
+ * So the coarse `agentsView` front door is under test alongside the per-instance
+ * asserts in the bodies.
+ */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
+        return next()
+      }),
+  }
+})
+
+// Deep path on purpose — see the note in `segment-instance-access.test.ts`.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { evalRouter } = await import('./eval')
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/**
+ * A real `CapabilitySet` for a MEMBER holding `permission` on {@link AGENT_ID}
+ * via an explicit `ResourceAccess` instance row (what the share dialog writes).
+ *
+ * `areaPermission` defaults to `permission` so the coarse `agents` rungs stay
+ * consistent with the instance row; pass it separately to exercise the two
+ * independently (e.g. a member at area `Full` but restricted on one agent).
+ * `instances: {}` models an agent with NO row at all — the
+ * `baselineAtCreate: false` fallback to the area level.
+ */
+function capabilitiesFor(
+  permission: ResourcePermission,
+  opts: {
+    instances?: Record<string, ResourcePermission>
+    areaPermission?: ResourcePermission
+    role?: 'MEMBER' | 'OWNER'
+  } = {}
+) {
+  const instances = opts.instances ?? { [AGENT_ID]: permission }
+  // Reproduce `composeUserCapabilities`' derived Read rung: any ≥`view` agent row
+  // synthesizes `agentsView`, so an `agents: None` grantee is not 403'd at the
+  // coarse front door before the per-instance assert can speak.
+  const derived = Object.values(instances).some((p) => p !== ResourcePermission.none)
+    ? [PermissionKey.agentsView]
+    : []
+  return new CapabilitySet(
+    new Set(
+      expandLevelsToKeys({ [Area.agents]: AREA_LEVEL_OF[opts.areaPermission ?? permission] })
+    ),
+    {},
+    opts.role ?? 'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived)
+  )
+}
+
+/** A member at area `Full` who is explicitly restricted from {@link AGENT_ID}. */
+const restrictedFromAgent = () =>
+  capabilitiesFor(ResourcePermission.none, {
+    areaPermission: ResourcePermission.admin,
+    instances: { [AGENT_ID]: ResourcePermission.none },
+  })
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return evalRouter.createCaller({
+    capabilities,
+    headers: new Headers(),
+    session: { organizationId: ORG_ID, userId: USER_ID, isSuperAdmin: false },
+  } as never)
+}
+
+type Caller = ReturnType<typeof caller>
+
+/**
+ * The `view` tier — all 11 procedures that read no capabilities at all before
+ * plan 25 §4.2. The third slot is the post-assert side effect, where there is
+ * one; `getById` / `getRun` / `getSuiteRun` do their only load BEFORE the assert
+ * (the row is what names the agent), so for those the rejection IS the observation.
+ */
+const VIEW_READS = [
+  ['list', (c: Caller) => c.list({ agentId: AGENT_ID }), () => evals.listEvalCasesByAgent],
+  ['getById', (c: Caller) => c.getById({ id: CASE_ID }), null],
+  [
+    'validateMock',
+    (c: Caller) => c.validateMock({ agentId: AGENT_ID, toolName: 'get_order', output: {} }),
+    () => evals.validateAgentToolMock,
+  ],
+  ['validate', (c: Caller) => c.validate({ id: CASE_ID }), () => evals.validateEvalCase],
+  ['listRuns', (c: Caller) => c.listRuns({ caseId: CASE_ID }), () => evals.listEvalRuns],
+  ['getRun', (c: Caller) => c.getRun({ runId: RUN_ID }), null],
+  [
+    'getRunCredits',
+    (c: Caller) => c.getRunCredits({ runId: RUN_ID }),
+    () => evals.getEvalRunCredits,
+  ],
+  ['getSuiteRun', (c: Caller) => c.getSuiteRun({ suiteRunId: SUITE_ID }), null],
+  [
+    'listSuiteRuns',
+    (c: Caller) => c.listSuiteRuns({ agentId: AGENT_ID }),
+    () => evals.listEvalSuiteRuns,
+  ],
+  [
+    'listSuiteChildRuns',
+    (c: Caller) => c.listSuiteChildRuns({ suiteRunId: SUITE_ID }),
+    () => evals.listSuiteChildRunSummaries,
+  ],
+  [
+    'compareSuiteRuns',
+    (c: Caller) =>
+      c.compareSuiteRuns({
+        baselineSuiteRunId: BASELINE_SUITE_ID,
+        candidateSuiteRunId: SUITE_ID,
+      }),
+    () => evals.compareSuiteRuns,
+  ],
+] as const
+
+/** The `edit` tier — authoring cases, deleting runs, and spending credits. */
+const EDIT_WRITES = [
+  [
+    'create',
+    (c: Caller) =>
+      c.create({
+        name: 'New case',
+        target: targetFor(AGENT_ID),
+        config: CONFIG,
+        assertions: ASSERTIONS,
+      }),
+    () => evals.createEvalCase,
+  ],
+  [
+    'update',
+    (c: Caller) => c.update({ id: CASE_ID, patch: { name: 'Renamed' } }),
+    () => evals.updateEvalCase,
+  ],
+  ['delete', (c: Caller) => c.delete({ id: CASE_ID }), () => evals.deleteEvalCase],
+  ['run', (c: Caller) => c.run({ id: CASE_ID }), () => evals.prepareRunSnapshots],
+  ['runAll', (c: Caller) => c.runAll({ agentId: AGENT_ID }), () => startAgentSuiteRun],
+  ['cancelRun', (c: Caller) => c.cancelRun({ runId: RUN_ID }), () => evals.cancelEvalRun],
+  ['deleteRun', (c: Caller) => c.deleteRun({ runId: RUN_ID }), () => evals.deleteEvalRun],
+  [
+    'suggest',
+    (c: Caller) => c.suggest({ agentId: AGENT_ID, procedureId: 'prc_1' }),
+    () => evals.suggestAgentSimulations,
+  ],
+] as const
+
+const ALL_MOCKS = [
+  ...Object.values(evals),
+  startAgentSuiteRun,
+  enqueueEvalRun,
+  getAllCachedAgents,
+  featureService.requireAccess,
+]
+
+beforeEach(() => {
+  // `mockReset` would drop the implementations set in `vi.hoisted`, so clear —
+  // no test queues a `mockResolvedValueOnce` here; the `fixture` object is the
+  // per-test lever instead, and it is fully reassigned below.
+  for (const fn of ALL_MOCKS) fn.mockClear()
+  fixture.caseAgentId = AGENT_ID
+  fixture.caseTarget = targetFor(AGENT_ID)
+  fixture.runSnapshotTarget = targetFor(AGENT_ID)
+  fixture.suiteAgents = { [SUITE_ID]: AGENT_ID, [BASELINE_SUITE_ID]: AGENT_ID }
+  fixture.caseRows = [
+    {
+      id: CASE_ID,
+      name: 'Refund flow',
+      target: targetFor(AGENT_ID),
+      suggestionId: null,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    },
+  ]
+})
+
+describe('eval router — the 11 formerly ungated reads now need `view` on the agent', () => {
+  it.each(VIEW_READS)('%s is refused for an agent restricted to `none`', async (_n, call, mock) => {
+    await expect(call(caller(restrictedFromAgent()))).rejects.toMatchObject(FORBIDDEN)
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(VIEW_READS)('%s succeeds at instance view', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).resolves.toBeDefined()
+    if (mock) expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(VIEW_READS)('%s is refused for a member at agents: None', async (_n, call, mock) => {
+    // No instance row anywhere — `baselineAtCreate: false` falls back to the area
+    // level, and a closed area denies every agent including row-less ones.
+    await expect(
+      call(caller(capabilitiesFor(ResourcePermission.none, { instances: {} })))
+    ).rejects.toMatchObject(FORBIDDEN)
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+})
+
+describe('eval router — the 8 writes need `edit`, not `view`', () => {
+  it.each(EDIT_WRITES)('%s is refused at instance view', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.view)))).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it.each(EDIT_WRITES)('%s succeeds at instance edit', async (_name, call, mock) => {
+    await expect(call(caller(capabilitiesFor(ResourcePermission.edit)))).resolves.toBeDefined()
+    expect(mock()).toHaveBeenCalledTimes(1)
+  })
+
+  it('run and runAll really are `edit` — a viewer cannot spend org credits', async () => {
+    // These two are the only procedures on this router that cost money. The user
+    // accepted that an instance EDITOR may spend it; a viewer may not, and a
+    // stray `tier: 'view'` on either would be invisible without this.
+    const viewer = caller(capabilitiesFor(ResourcePermission.view))
+    await expect(viewer.run({ id: CASE_ID })).rejects.toMatchObject(FORBIDDEN)
+    await expect(viewer.runAll({ agentId: AGENT_ID })).rejects.toMatchObject(FORBIDDEN)
+    expect(evals.createQueuedEvalRun).not.toHaveBeenCalled()
+    expect(enqueueEvalRun).not.toHaveBeenCalled()
+    expect(startAgentSuiteRun).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * The part that is easy to fake and hard to get right: 14 of the 19 procedures
+ * never receive an `agentId`. Each case below points the persisted row at
+ * {@link OTHER_AGENT_ID} while the caller administers {@link AGENT_ID}, so a
+ * router that asserted on the input id — or on the wrong row — would pass.
+ */
+describe('eval router — the agent id is resolved from the ROW, not the input', () => {
+  /** Administers AGENT_ID, explicitly restricted from OTHER_AGENT_ID. */
+  const adminHereNotThere = () =>
+    capabilitiesFor(ResourcePermission.admin, {
+      areaPermission: ResourcePermission.admin,
+      instances: {
+        [AGENT_ID]: ResourcePermission.admin,
+        [OTHER_AGENT_ID]: ResourcePermission.none,
+      },
+    })
+
+  it('getById keys on the CASE’s agent', async () => {
+    fixture.caseAgentId = OTHER_AGENT_ID
+    await expect(caller(adminHereNotThere()).getById({ id: CASE_ID })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+  })
+
+  it('validate keys on the CASE’s agent', async () => {
+    fixture.caseAgentId = OTHER_AGENT_ID
+    await expect(caller(adminHereNotThere()).validate({ id: CASE_ID })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(evals.validateEvalCase).not.toHaveBeenCalled()
+  })
+
+  it('listRuns keys on the case behind the caseId, not the caseId itself', async () => {
+    fixture.caseAgentId = OTHER_AGENT_ID
+    await expect(caller(adminHereNotThere()).listRuns({ caseId: CASE_ID })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(evals.listEvalRuns).not.toHaveBeenCalled()
+  })
+
+  it('a case with a null agentId column falls back to `target.agentId`', async () => {
+    // `EvalCase.agentId` is a denormalized copy; `target` is the source of truth.
+    // A row the column is null on must still be judged, never served ungated.
+    fixture.caseAgentId = null
+    fixture.caseTarget = targetFor(OTHER_AGENT_ID)
+    await expect(caller(adminHereNotThere()).getById({ id: CASE_ID })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+
+    // …and the fallback is a real read, not a rubber stamp: the same row with the
+    // target pointing back at the caller's agent must go through.
+    fixture.caseTarget = targetFor(AGENT_ID)
+    await expect(caller(adminHereNotThere()).getById({ id: CASE_ID })).resolves.toBeDefined()
+  })
+
+  it('a case with neither an agentId nor a parseable target 404s', async () => {
+    // Nothing names an agent, so nothing can judge the row — it must not be
+    // served, and it must not resolve to some other identifier that happens to
+    // be lying around (the case id, say).
+    fixture.caseAgentId = null
+    fixture.caseTarget = { nonsense: true }
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).getById({ id: CASE_ID })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it.each([
+    ['getRun', (c: Caller) => c.getRun({ runId: RUN_ID }), null],
+    [
+      'getRunCredits',
+      (c: Caller) => c.getRunCredits({ runId: RUN_ID }),
+      () => evals.getEvalRunCredits,
+    ],
+    ['cancelRun', (c: Caller) => c.cancelRun({ runId: RUN_ID }), () => evals.cancelEvalRun],
+    ['deleteRun', (c: Caller) => c.deleteRun({ runId: RUN_ID }), () => evals.deleteEvalRun],
+  ] as const)('%s keys on the run’s SNAPSHOT agent', async (_n, call, mock) => {
+    // `EvalRun.caseId` is ON DELETE SET NULL, so the immutable
+    // `definitionSnapshot.case.target.agentId` — not the case — is the only
+    // durable owner. Point it elsewhere and the run must become unreachable.
+    fixture.runSnapshotTarget = targetFor(OTHER_AGENT_ID)
+    await expect(call(caller(adminHereNotThere()))).rejects.toMatchObject(FORBIDDEN)
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it('a run with an unparseable snapshot 404s instead of reading as ungated', async () => {
+    fixture.runSnapshotTarget = { nonsense: true }
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).getRun({ runId: RUN_ID })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it.each([
+    ['getSuiteRun', (c: Caller) => c.getSuiteRun({ suiteRunId: SUITE_ID }), null],
+    [
+      'listSuiteChildRuns',
+      (c: Caller) => c.listSuiteChildRuns({ suiteRunId: SUITE_ID }),
+      () => evals.listSuiteChildRunSummaries,
+    ],
+  ] as const)('%s keys on the SUITE’s agent', async (_n, call, mock) => {
+    fixture.suiteAgents[SUITE_ID] = OTHER_AGENT_ID
+    await expect(call(caller(adminHereNotThere()))).rejects.toMatchObject(FORBIDDEN)
+    if (mock) expect(mock()).not.toHaveBeenCalled()
+  })
+
+  it('a suite with no agentId 404s instead of reading as ungated', async () => {
+    // `EvalSuiteRun.agentId` is nullable and FK-less (suite history outlives
+    // deleted agents), so "no agent" is unjudgeable and must not be served.
+    fixture.suiteAgents[SUITE_ID] = null
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).getSuiteRun({ suiteRunId: SUITE_ID })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('compareSuiteRuns asserts BOTH sides, not just the candidate', async () => {
+    // It accepts any two suite ids, including ones belonging to different
+    // agents, so gating only the candidate would leak the baseline's verdicts.
+    fixture.suiteAgents[BASELINE_SUITE_ID] = OTHER_AGENT_ID
+    await expect(
+      caller(adminHereNotThere()).compareSuiteRuns({
+        baselineSuiteRunId: BASELINE_SUITE_ID,
+        candidateSuiteRunId: SUITE_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(evals.compareSuiteRuns).not.toHaveBeenCalled()
+  })
+
+  it('compareSuiteRuns is also refused when only the CANDIDATE is restricted', async () => {
+    fixture.suiteAgents[SUITE_ID] = OTHER_AGENT_ID
+    await expect(
+      caller(adminHereNotThere()).compareSuiteRuns({
+        baselineSuiteRunId: BASELINE_SUITE_ID,
+        candidateSuiteRunId: SUITE_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(evals.compareSuiteRuns).not.toHaveBeenCalled()
+  })
+
+  it('create keys on `target.agentId` — authoring onto an agent edits it', async () => {
+    await expect(
+      caller(adminHereNotThere()).create({
+        name: 'Sneaky',
+        target: targetFor(OTHER_AGENT_ID),
+        config: CONFIG,
+        assertions: ASSERTIONS,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(evals.createEvalCase).not.toHaveBeenCalled()
+  })
+
+  it('update RE-TARGETING a case onto another agent needs edit on that agent too', async () => {
+    // Otherwise `edit` on a agent you control is enough to plant a case on one
+    // you do not.
+    await expect(
+      caller(adminHereNotThere()).update({
+        id: CASE_ID,
+        patch: { target: targetFor(OTHER_AGENT_ID) },
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(evals.updateEvalCase).not.toHaveBeenCalled()
+  })
+})
+
+describe('eval router — id-or-slug resolution', () => {
+  it('list accepts the agent SLUG and passes the resolved Agent.id downstream', async () => {
+    // `EvalCase.agentId` stores `Agent.id`, so a slug forwarded verbatim would
+    // have listed nothing — and `assertViewInstance` keyed on a slug finds no
+    // ResourceAccess row and silently falls through to the area level.
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view)).list({ agentId: AGENT_SLUG })
+    ).resolves.toBeDefined()
+    expect(evals.listEvalCasesByAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: AGENT_ID })
+    )
+  })
+
+  it('the slug is judged by the resolved id’s grant, not by falling through', async () => {
+    await expect(caller(restrictedFromAgent()).list({ agentId: AGENT_SLUG })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(evals.listEvalCasesByAgent).not.toHaveBeenCalled()
+  })
+
+  it('runAll and suggest also forward the resolved id', async () => {
+    const editor = caller(capabilitiesFor(ResourcePermission.edit))
+    await editor.runAll({ agentId: AGENT_SLUG })
+    await editor.suggest({ agentId: AGENT_SLUG, procedureId: 'prc_1' })
+    expect(startAgentSuiteRun).toHaveBeenCalledWith(expect.objectContaining({ agentId: AGENT_ID }))
+    expect(evals.suggestAgentSimulations).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: AGENT_ID })
+    )
+  })
+
+  it('create persists the RESOLVED id in the target', async () => {
+    await caller(capabilitiesFor(ResourcePermission.edit)).create({
+      name: 'New case',
+      target: targetFor(AGENT_SLUG),
+      config: CONFIG,
+      assertions: ASSERTIONS,
+    })
+    expect(evals.createEvalCase).toHaveBeenCalledWith(
+      expect.objectContaining({ target: expect.objectContaining({ agentId: AGENT_ID }) })
+    )
+  })
+
+  it('an agent id from another org 404s before any capability decision', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).list({ agentId: 'agt_fromanotherorg' })
+    ).rejects.toMatchObject({ cause: { name: 'NotFoundError', statusCode: 404 } })
+    expect(evals.listEvalCasesByAgent).not.toHaveBeenCalled()
+  })
+})
+
+describe('eval router — an `agents: None` member with one explicit grant', () => {
+  /** The whole point of instance access: no area level, one shared agent. */
+  const grantOnly = (permission: ResourcePermission) =>
+    capabilitiesFor(permission, {
+      areaPermission: ResourcePermission.none,
+      instances: { [AGENT_ID]: permission },
+    })
+
+  it('an `admin` grant reaches that agent’s evals, reads and writes', async () => {
+    const c = caller(grantOnly(ResourcePermission.admin))
+    await expect(c.list({ agentId: AGENT_ID })).resolves.toBeDefined()
+    await expect(c.getById({ id: CASE_ID })).resolves.toBeDefined()
+    await expect(c.listSuiteChildRuns({ suiteRunId: SUITE_ID })).resolves.toBeDefined()
+    await expect(c.run({ id: CASE_ID })).resolves.toBeDefined()
+    await expect(c.delete({ id: CASE_ID })).resolves.toBeDefined()
+  })
+
+  it('a `view` grant reads but does not write', async () => {
+    const c = caller(grantOnly(ResourcePermission.view))
+    await expect(c.getById({ id: CASE_ID })).resolves.toBeDefined()
+    await expect(c.delete({ id: CASE_ID })).rejects.toMatchObject(FORBIDDEN)
+    expect(evals.deleteEvalCase).not.toHaveBeenCalled()
+  })
+
+  it('the grant does NOT reach a different agent', async () => {
+    // The derived `agentsView` front door says only "this member has some agent
+    // access" — never which agent. A body that stopped at the coarse rung would
+    // hand over every other agent's history.
+    fixture.suiteAgents[SUITE_ID] = OTHER_AGENT_ID
+    await expect(
+      caller(grantOnly(ResourcePermission.admin)).getSuiteRun({ suiteRunId: SUITE_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+})
+
+describe('eval router — `baselineAtCreate: false`: no row falls back to the AREA', () => {
+  /** A member with NO instance rows at all — nothing is in `restrictedInstanceIds`. */
+  const noRows = (areaPermission: ResourcePermission) =>
+    capabilitiesFor(areaPermission, { areaPermission, instances: {} })
+
+  it('area Read ⇒ the suites list and open, but nothing runs or saves', async () => {
+    const c = caller(noRows(ResourcePermission.view))
+    await expect(c.list({ agentId: AGENT_ID })).resolves.toBeDefined()
+    await expect(c.getRun({ runId: RUN_ID })).resolves.toBeDefined()
+    await expect(c.run({ id: CASE_ID })).rejects.toMatchObject(FORBIDDEN)
+    await expect(c.update({ id: CASE_ID, patch: { name: 'x' } })).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('area Edit ⇒ authors and runs, with no ResourceAccess row anywhere', async () => {
+    const c = caller(noRows(ResourcePermission.edit))
+    await expect(c.update({ id: CASE_ID, patch: { name: 'x' } })).resolves.toBeDefined()
+    await expect(c.runAll({ agentId: AGENT_ID })).resolves.toBeDefined()
+  })
+
+  it('area None ⇒ nothing, even though the agent is org-shared', async () => {
+    await expect(
+      caller(noRows(ResourcePermission.none)).getById({ id: CASE_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+})
+
+describe('eval router — OWNER regression', () => {
+  it('short-circuits to admin on an agent restricted to `none`', async () => {
+    // The recovery guarantee: nothing authored on an agent can lock the last
+    // owner out of it.
+    const owner = capabilitiesFor(ResourcePermission.admin, {
+      role: 'OWNER',
+      instances: { [AGENT_ID]: ResourcePermission.none },
+    })
+    await expect(caller(owner).getById({ id: CASE_ID })).resolves.toBeDefined()
+    await expect(caller(owner).delete({ id: CASE_ID })).resolves.toBeDefined()
+    expect(evals.deleteEvalCase).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/server/api/routers/eval.ts
+++ b/apps/web/src/server/api/routers/eval.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/eval.ts
 
-import type { EvalCaseEntity } from '@auxx/database'
+import type { EvalCaseEntity, EvalRunEntity, EvalSuiteRunEntity } from '@auxx/database'
 import {
   cancelEvalRun,
   compareSuiteRuns,
@@ -35,19 +35,42 @@ import {
 } from '@auxx/types/evals/schema'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
+import { assertAgentAccess } from '~/server/lib/agent-instance-access'
+import { createTRPCRouter, permissionProcedure } from '../trpc'
 import { unwrap } from '../unwrap'
 
-/** permissionProcedure(agentsManage) + the `agentProcedures` feature gate (evals exercise procedures). */
-const evalManageProcedure = permissionProcedure(PermissionKey.agentsManage).use(
-  async ({ ctx, next }) => {
-    await new FeaturePermissionService().requireAccess(
-      ctx.session.organizationId,
-      FeatureKey.agentProcedures
-    )
-    return next()
-  }
-)
+/**
+ * Per-agent instance access for evals (plan 25 §4.2, user decision 2026-07-28):
+ * **reads need `view` on the owning agent, writes need `edit`** — an agent's
+ * simulations, suites and run traces are part of the agent, so they are judged
+ * by the same `ResourceAccess` row the agent itself is.
+ *
+ * Until this landed, 11 of these procedures were bare `protectedProcedure` and
+ * read no capabilities at all: any org member could list, open and diff any
+ * agent's eval suites and run history. That was the hole, not a re-tiering.
+ *
+ * Base procedure is `permissionProcedure(agentsView)` throughout — the same
+ * choice `workflow.ts` made. A member composing `agents: None` who holds one
+ * explicit instance grant genuinely HOLDS `agentsView` (the composer derives the
+ * Read rung from their grants), so the coarse rung is a front door and the
+ * per-instance assert below it does the real work. **Every procedure here
+ * asserts on a specific agent** — there is no org-wide eval list to filter, both
+ * `list` and `listSuiteRuns` are already scoped to one required `agentId`.
+ *
+ * `run` / `runAll` spend org credits at the `edit` tier. Deliberate (user,
+ * 2026-07-28): an instance editor authoring simulations must be able to run
+ * them, and every other spend on the agent (drafts, procedures) is already edit.
+ */
+const evalProcedure = permissionProcedure(PermissionKey.agentsView)
+
+/** {@link evalProcedure} + the `agentProcedures` feature gate (evals exercise procedures). */
+const evalWriteProcedure = evalProcedure.use(async ({ ctx, next }) => {
+  await new FeaturePermissionService().requireAccess(
+    ctx.session.organizationId,
+    FeatureKey.agentProcedures
+  )
+  return next()
+})
 
 /** Parse a persisted case row's JSONB into typed, validated fields. */
 function parseCase(row: EvalCaseEntity) {
@@ -61,16 +84,68 @@ function parseCase(row: EvalCaseEntity) {
   }
 }
 
+/**
+ * The agent a persisted CASE belongs to. `EvalCase.agentId` is the denormalized
+ * copy the service keeps in sync on every write; `target` is the source of truth
+ * and covers any row the column is null on.
+ *
+ * A case that resolves to no agent cannot be judged by instance access, so it is
+ * a 404 rather than an ungated read — the same "unjudgeable ⇒ invisible" rule
+ * `assertAgentAccess` applies to an unresolvable agent id.
+ */
+function caseAgentId(row: EvalCaseEntity): string {
+  if (row.agentId) return row.agentId
+  const target = agentEvalTargetSchema.safeParse(row.target)
+  if (!target.success) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
+  return target.data.agentId
+}
+
+/**
+ * The agent a persisted RUN belongs to — read off the immutable
+ * `definitionSnapshot`, NOT the case.
+ *
+ * `EvalRun.caseId` is `ON DELETE SET NULL` (runs outlive their case by policy),
+ * so joining back to `EvalCase` would leave every orphaned run ungatable.
+ * Snapshot truth is also the more correct answer: a case later re-targeted to
+ * another agent must not retroactively move the runs it already produced.
+ */
+function runAgentId(run: EvalRunEntity): string {
+  const snapshot = run.definitionSnapshot as { case?: { target?: unknown } } | null
+  const target = agentEvalTargetSchema.safeParse(snapshot?.case?.target)
+  if (!target.success) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
+  return target.data.agentId
+}
+
+/**
+ * The agent a SUITE run belongs to (`EvalSuiteRun.agentId`, denormalized from
+ * the `runAll` selection). Nullable and FK-less — suite history outlives deleted
+ * agents — so a null is an unjudgeable suite and therefore a 404.
+ */
+function suiteAgentId(suite: EvalSuiteRunEntity): string {
+  if (!suite.agentId)
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval suite run not found' })
+  return suite.agentId
+}
+
 export const evalRouter = createTRPCRouter({
   // ── Case CRUD ───────────────────────────────────────────────────────────
-  list: protectedProcedure
+  list: evalProcedure
     .input(z.object({ agentId: z.string().min(1), procedureId: z.string().min(1).optional() }))
     .query(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      // Scoped to ONE agent, so this asserts rather than filters. The resolved id
+      // also goes downstream — `EvalCase.agentId` stores `Agent.id`, so a slug
+      // would have silently listed nothing.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'view',
+      })
       const cases = unwrap(
         await listEvalCasesByAgent({
           organizationId,
-          agentId: input.agentId,
+          agentId,
           procedureId: input.procedureId,
         }),
         'list eval cases'
@@ -116,7 +191,7 @@ export const evalRouter = createTRPCRouter({
       })
     }),
 
-  getById: protectedProcedure
+  getById: evalProcedure
     .input(z.object({ id: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const found = unwrap(
@@ -124,10 +199,17 @@ export const evalRouter = createTRPCRouter({
         'get eval case'
       )
       if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
+      // The row we already loaded carries the agent — no second lookup.
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: caseAgentId(found),
+        tier: 'view',
+      })
       return parseCase(found)
     }),
 
-  create: evalManageProcedure
+  create: evalWriteProcedure
     .input(
       z.object({
         name: z.string().min(1),
@@ -139,12 +221,22 @@ export const evalRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // The new case's OWNER is `target.agentId` — authoring an eval onto an
+      // agent is editing that agent.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: input.target.agentId,
+        tier: 'edit',
+      })
       const created = unwrap(
         await createEvalCase({
           organizationId: ctx.session.organizationId,
           createdById: ctx.session.userId,
           name: input.name,
-          target: input.target,
+          // Persist the RESOLVED id: `target.agentId` is what every later
+          // instance assert keys on, and it must never hold a slug.
+          target: { ...input.target, agentId },
           config: input.config,
           assertions: input.assertions,
           suggestionId: input.suggestionId,
@@ -157,7 +249,7 @@ export const evalRouter = createTRPCRouter({
       return { id: created.id }
     }),
 
-  update: evalManageProcedure
+  update: evalWriteProcedure
     .input(
       z.object({
         id: z.string().min(1),
@@ -170,11 +262,34 @@ export const evalRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const found = unwrap(await getEvalCaseById({ organizationId, id: input.id }), 'get eval case')
+      if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: caseAgentId(found),
+        tier: 'edit',
+      })
+
+      // A `target` patch can RE-TARGET the case onto another agent, which is a
+      // write to that agent too — assert it, and persist the resolved id.
+      let patch = input.patch
+      if (patch.target) {
+        const agentId = await assertAgentAccess({
+          capabilities: ctx.capabilities,
+          organizationId,
+          idOrSlug: patch.target.agentId,
+          tier: 'edit',
+        })
+        patch = { ...patch, target: { ...patch.target, agentId } }
+      }
+
       const updated = unwrap(
         await updateEvalCase({
-          organizationId: ctx.session.organizationId,
+          organizationId,
           id: input.id,
-          patch: input.patch,
+          patch,
           excludeSocketId: ctx.headers.get('x-realtime-socket-id') ?? undefined,
         }),
         'update eval case'
@@ -182,12 +297,21 @@ export const evalRouter = createTRPCRouter({
       return { id: updated.id }
     }),
 
-  delete: evalManageProcedure
+  delete: evalWriteProcedure
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const found = unwrap(await getEvalCaseById({ organizationId, id: input.id }), 'get eval case')
+      if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: caseAgentId(found),
+        tier: 'edit',
+      })
       unwrap(
         await deleteEvalCase({
-          organizationId: ctx.session.organizationId,
+          organizationId,
           id: input.id,
           excludeSocketId: ctx.headers.get('x-realtime-socket-id') ?? undefined,
         }),
@@ -199,7 +323,7 @@ export const evalRouter = createTRPCRouter({
   // ── Editor support (tool responses) ───────────────────────────────────────
   // The displayed tool list is derived client-side from the unified catalog
   // (`useToolGroups`); only mock validation needs the server's Zod schemas.
-  validateMock: protectedProcedure
+  validateMock: evalProcedure
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -207,18 +331,25 @@ export const evalRouter = createTRPCRouter({
         output: z.unknown(),
       })
     )
-    .query(async ({ ctx, input }) =>
-      validateAgentToolMock({
+    .query(async ({ ctx, input }) => {
+      // Reads the agent's tool schemas — `view` on the agent, not just on evals.
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: input.agentId,
+        tier: 'view',
+      })
+      return validateAgentToolMock({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.userId,
-        agentId: input.agentId,
+        agentId,
         toolName: input.toolName,
         output: input.output,
       })
-    ),
+    }),
 
   // ── Validation ──────────────────────────────────────────────────────────
-  validate: protectedProcedure
+  validate: evalProcedure
     .input(z.object({ id: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const found = unwrap(
@@ -226,6 +357,12 @@ export const evalRouter = createTRPCRouter({
         'get eval case'
       )
       if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: caseAgentId(found),
+        tier: 'view',
+      })
       const parsed = parseCase(found)
       return validateEvalCase({
         organizationId: ctx.session.organizationId,
@@ -237,9 +374,23 @@ export const evalRouter = createTRPCRouter({
     }),
 
   // ── Runs ──────────────────────────────────────────────────────────────────
-  listRuns: protectedProcedure
+  listRuns: evalProcedure
     .input(z.object({ caseId: z.string().min(1), cursor: z.string().optional() }))
     .query(async ({ ctx, input }) => {
+      // Only a case id arrives, so the owning agent costs one lookup. The runs
+      // themselves carry it in their snapshots, but we must gate BEFORE loading
+      // them, and a page of runs can span no more than the one case anyway.
+      const found = unwrap(
+        await getEvalCaseById({ organizationId: ctx.session.organizationId, id: input.caseId }),
+        'get eval case'
+      )
+      if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: caseAgentId(found),
+        tier: 'view',
+      })
       const limit = 20
       const runs = unwrap(
         await listEvalRuns({
@@ -256,7 +407,7 @@ export const evalRouter = createTRPCRouter({
       return { runs: page, nextCursor }
     }),
 
-  getRun: protectedProcedure
+  getRun: evalProcedure
     .input(z.object({ runId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const run = unwrap(
@@ -264,13 +415,32 @@ export const evalRouter = createTRPCRouter({
         'get eval run'
       )
       if (!run) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
+      // The trace is the agent's transcript — gate it on the agent that ran.
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: runAgentId(run),
+        tier: 'view',
+      })
       return run
     }),
 
   /** AI credits + tokens a single eval run consumed (rolled up from AiUsage). */
-  getRunCredits: protectedProcedure
+  getRunCredits: evalProcedure
     .input(z.object({ runId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
+      // Spend is org data keyed on a run; the run's agent decides who may see it.
+      const run = unwrap(
+        await getEvalRun({ organizationId: ctx.session.organizationId, runId: input.runId }),
+        'get eval run'
+      )
+      if (!run) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: runAgentId(run),
+        tier: 'view',
+      })
       return unwrap(
         await getEvalRunCredits({
           organizationId: ctx.session.organizationId,
@@ -280,7 +450,7 @@ export const evalRouter = createTRPCRouter({
       )
     }),
 
-  getSuiteRun: protectedProcedure
+  getSuiteRun: evalProcedure
     .input(z.object({ suiteRunId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const suite = unwrap(
@@ -291,11 +461,17 @@ export const evalRouter = createTRPCRouter({
         'get eval suite run'
       )
       if (!suite) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval suite run not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: suiteAgentId(suite),
+        tier: 'view',
+      })
       return suite
     }),
 
   /** Iteration-history feed: suite runs for an agent (optionally one procedure), newest first. */
-  listSuiteRuns: protectedProcedure
+  listSuiteRuns: evalProcedure
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -304,11 +480,17 @@ export const evalRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: input.agentId,
+        tier: 'view',
+      })
       const limit = 20
       const suiteRuns = unwrap(
         await listEvalSuiteRuns({
           organizationId: ctx.session.organizationId,
-          agentId: input.agentId,
+          agentId,
           procedureId: input.procedureId,
           limit: limit + 1,
           before: input.cursor ? new Date(input.cursor) : undefined,
@@ -322,9 +504,23 @@ export const evalRouter = createTRPCRouter({
     }),
 
   /** Child runs of a suite without trace/snapshot payloads (suite detail view). */
-  listSuiteChildRuns: protectedProcedure
+  listSuiteChildRuns: evalProcedure
     .input(z.object({ suiteRunId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
+      const suite = unwrap(
+        await getEvalSuiteRun({
+          organizationId: ctx.session.organizationId,
+          suiteRunId: input.suiteRunId,
+        }),
+        'get eval suite run'
+      )
+      if (!suite) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval suite run not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: suiteAgentId(suite),
+        tier: 'view',
+      })
       return unwrap(
         await listSuiteChildRunSummaries({
           organizationId: ctx.session.organizationId,
@@ -335,7 +531,7 @@ export const evalRouter = createTRPCRouter({
     }),
 
   /** Verdict diff of two terminal suites (5B). Read-only; computed on request. */
-  compareSuiteRuns: protectedProcedure
+  compareSuiteRuns: evalProcedure
     .input(
       z.object({
         baselineSuiteRunId: z.string().min(1),
@@ -343,6 +539,30 @@ export const evalRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      // BOTH sides are read, so both must be viewable — `compareSuiteRuns`
+      // accepts any two suite ids, including ones from different agents, so
+      // asserting only the candidate would leak the baseline's verdicts.
+      const [baseline, candidate] = await Promise.all([
+        getEvalSuiteRun({
+          organizationId: ctx.session.organizationId,
+          suiteRunId: input.baselineSuiteRunId,
+        }),
+        getEvalSuiteRun({
+          organizationId: ctx.session.organizationId,
+          suiteRunId: input.candidateSuiteRunId,
+        }),
+      ])
+      for (const loaded of [baseline, candidate]) {
+        const suite = unwrap(loaded, 'get eval suite run')
+        if (!suite) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval suite run not found' })
+        await assertAgentAccess({
+          capabilities: ctx.capabilities,
+          organizationId: ctx.session.organizationId,
+          idOrSlug: suiteAgentId(suite),
+          tier: 'view',
+        })
+      }
+
       const result = await compareSuiteRuns({
         organizationId: ctx.session.organizationId,
         baselineSuiteRunId: input.baselineSuiteRunId,
@@ -361,7 +581,7 @@ export const evalRouter = createTRPCRouter({
     }),
 
   // ── Execute ───────────────────────────────────────────────────────────────
-  run: evalManageProcedure
+  run: evalWriteProcedure
     // `useDraft`: run the current draft (the Simulations editor surface always
     // passes true); headless/CI default to the pinned version (regression gate).
     .input(z.object({ id: z.string().min(1), useDraft: z.boolean().optional() }))
@@ -369,6 +589,14 @@ export const evalRouter = createTRPCRouter({
       const { organizationId, userId } = ctx.session
       const found = unwrap(await getEvalCaseById({ organizationId, id: input.id }), 'get eval case')
       if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
+      // `edit`, not `view` — this spends org credits (accepted, see the header).
+      // The case row is already loaded, so the tier costs no extra query.
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: caseAgentId(found),
+        tier: 'edit',
+      })
       const parsed = parseCase(found)
 
       const prepared = await prepareRunSnapshots({
@@ -424,7 +652,7 @@ export const evalRouter = createTRPCRouter({
       return { runId: run.id }
     }),
 
-  runAll: evalManageProcedure
+  runAll: evalWriteProcedure
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -436,13 +664,20 @@ export const evalRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
+      // `edit` — a suite is the expensive spend on this router (N runs).
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
 
       // Shared with the Kopilot `run_eval_suite` tool — selection, snapshots,
       // atomic suite creation, and per-child enqueue all live in the lib recipe.
       const result = await startAgentSuiteRun({
         organizationId,
         userId,
-        agentId: input.agentId,
+        agentId,
         procedureId: input.procedureId,
         caseIds: input.caseIds,
         useDraft: input.useDraft,
@@ -464,33 +699,48 @@ export const evalRouter = createTRPCRouter({
       return { suiteRunId: result.value.suiteRun.id, runIds: result.value.runIds }
     }),
 
-  cancelRun: evalManageProcedure
+  cancelRun: evalWriteProcedure
     .input(z.object({ runId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const run = unwrap(await getEvalRun({ organizationId, runId: input.runId }), 'get eval run')
+      if (!run) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: runAgentId(run),
+        tier: 'edit',
+      })
       const cancelled = unwrap(
-        await cancelEvalRun({ organizationId: ctx.session.organizationId, runId: input.runId }),
+        await cancelEvalRun({ organizationId, runId: input.runId }),
         'cancel eval run'
       )
       if (!cancelled) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
       return { status: cancelled.status }
     }),
 
-  deleteRun: evalManageProcedure
+  deleteRun: evalWriteProcedure
     .input(z.object({ runId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
-      unwrap(
-        await deleteEvalRun({ organizationId: ctx.session.organizationId, runId: input.runId }),
-        'delete eval run'
-      )
+      const { organizationId } = ctx.session
+      const run = unwrap(await getEvalRun({ organizationId, runId: input.runId }), 'get eval run')
+      if (!run) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
+      await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId,
+        idOrSlug: runAgentId(run),
+        tier: 'edit',
+      })
+      unwrap(await deleteEvalRun({ organizationId, runId: input.runId }), 'delete eval run')
       return { ok: true as const }
     }),
 
   // ── Suggestions ───────────────────────────────────────────────────────────
   // Mutation, not query: it spends tokens and is non-idempotent. The client holds
   // the result keyed by the returned `draftHash` rather than auto-refetching.
-  // `evalManageProcedure` gates the spend; org/agent scoping is enforced inside the
-  // service by `getAttachedProcedureDraft`.
-  suggest: evalManageProcedure
+  // Instance `edit` on the agent gates the spend; org/agent scoping is enforced
+  // inside the service by `getAttachedProcedureDraft`.
+  suggest: evalWriteProcedure
     .input(
       z.object({
         agentId: z.string().min(1),
@@ -499,16 +749,22 @@ export const evalRouter = createTRPCRouter({
         force: z.boolean().optional(),
       })
     )
-    .mutation(async ({ ctx, input }) =>
-      unwrap(
+    .mutation(async ({ ctx, input }) => {
+      const agentId = await assertAgentAccess({
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        idOrSlug: input.agentId,
+        tier: 'edit',
+      })
+      return unwrap(
         await suggestAgentSimulations({
           organizationId: ctx.session.organizationId,
           userId: ctx.session.userId,
-          agentId: input.agentId,
+          agentId,
           procedureId: input.procedureId,
           force: input.force,
         }),
         'suggest simulations'
       )
-    ),
+    }),
 })

--- a/apps/web/src/server/lib/agent-instance-access.ts
+++ b/apps/web/src/server/lib/agent-instance-access.ts
@@ -1,0 +1,65 @@
+// apps/web/src/server/lib/agent-instance-access.ts
+
+import { getAllCachedAgents } from '@auxx/lib/cache'
+import { NotFoundError } from '@auxx/lib/errors'
+import type { CapabilitySet } from '@auxx/lib/permissions/capabilities/capability-set'
+
+/**
+ * The one authority for per-agent instance access (plan 25 §4.2).
+ *
+ * Every `agentId` that reaches an assert must be a real {@link Agent.id} first.
+ * That is not pedantry: `agent.getById` accepts **an id OR a slug** (the detail
+ * page routes by slug), and `assertViewInstance('agent', slug)` looks up a
+ * `ResourceAccess` row keyed on the id — so it would find none, fall through to
+ * the area level, and hand a restricted agent straight to the caller. #1345 hit
+ * the same class from the other side, where `assertWorkflowVersionNotSystemOwned`
+ * had to return the PARENT `WorkflowApp.id` because instance access keys on the
+ * parent while version surfaces only hold a child id.
+ *
+ * Resolution runs off the org agents cache (`getAllCachedAgents` — it includes
+ * archived rows, so an archived agent still resolves and is judged by its
+ * grants rather than vanishing into a 404 for an admin who may see it).
+ *
+ * **Not found is a 404 BEFORE the assert, deliberately.** An agent id from
+ * another org must not be distinguishable from a restricted one in this org;
+ * both end as `NotFoundError`, and only a resolvable in-org agent reaches the
+ * capability check.
+ */
+export type AgentAccessTier = 'view' | 'edit' | 'admin'
+
+/**
+ * Resolve `idOrSlug` to a real `Agent.id` within the org, then assert the tier
+ * against it. Returns the resolved id so callers can use it downstream instead
+ * of re-resolving.
+ *
+ * @throws NotFoundError when no agent in the org matches the identifier.
+ * @throws ForbiddenError (from the CapabilitySet) when the tier is not met.
+ */
+export async function assertAgentAccess(params: {
+  capabilities: CapabilitySet
+  organizationId: string
+  idOrSlug: string
+  tier: AgentAccessTier
+}): Promise<string> {
+  const { capabilities, organizationId, idOrSlug, tier } = params
+  const agentId = await resolveAgentId(organizationId, idOrSlug)
+
+  if (tier === 'view') capabilities.assertViewInstance('agent', agentId)
+  else if (tier === 'edit') capabilities.assertEditInstance('agent', agentId)
+  else capabilities.assertAdminInstance('agent', agentId)
+
+  return agentId
+}
+
+/**
+ * `idOrSlug` → `Agent.id`, or a 404. Exported for the rare caller that needs
+ * the id without an assert (the kopilot SSE route resolves before it can build
+ * its denial message). Prefer {@link assertAgentAccess} — a bare resolve is a
+ * lookup, not a permission check.
+ */
+export async function resolveAgentId(organizationId: string, idOrSlug: string): Promise<string> {
+  const all = await getAllCachedAgents(organizationId)
+  const match = all.find((a) => a.id === idOrSlug || a.slug === idOrSlug)
+  if (!match) throw new NotFoundError('Agent not found')
+  return match.id
+}

--- a/packages/lib/src/actors/__tests__/expand-to-users-agent-visibility.test.ts
+++ b/packages/lib/src/actors/__tests__/expand-to-users-agent-visibility.test.ts
@@ -1,0 +1,156 @@
+// packages/lib/src/actors/__tests__/expand-to-users-agent-visibility.test.ts
+
+import type { ActorContext, ActorId } from '@auxx/types/actor'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `expandToUsers`' `canSeeAgent` predicate — per-agent instance access (plan 25
+ * §4.2) applied where it actually belongs.
+ *
+ * **The point of these tests is the THREE DOORS.** An agent reaches the output
+ * of `expandToUsers` by three different routes and only one of them is visible
+ * in the `actorIds` the caller passes:
+ *
+ *  1. `agent:<id>` — the obvious spelling.
+ *  2. `user:<backingUserId>` — the legacy spelling this method deliberately
+ *     reroutes through the agent rules.
+ *  3. group membership — a group the caller may see can contain an agent they
+ *     may not, and the expansion happens inside the loop.
+ *
+ * A caller that filtered its own input array would close (1) and look complete.
+ * Each door gets a test that fails if only the other two are closed.
+ *
+ * The fourth case is the one that makes the predicate safe to add at all:
+ * omitting it must leave system paths (trigger routing, notification fan-out,
+ * which run with no invoking user) completely unclamped.
+ */
+
+const { getCachedAgents, getCachedAgentsByUserIds, getMembers, getGroupsForUser } = vi.hoisted(
+  () => ({
+    getCachedAgents: vi.fn(),
+    getCachedAgentsByUserIds: vi.fn(),
+    getMembers: vi.fn(async () => []),
+    getGroupsForUser: vi.fn(async () => []),
+  })
+)
+
+vi.mock('../../cache', () => ({ getCachedAgents, getCachedAgentsByUserIds }))
+vi.mock('../../groups/group-functions', () => ({ getMembers, getGroupsForUser }))
+
+const { GroupMemberService } = await import('../group-member-service')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const HUMAN_ID = 'usr_human00000000000000000000'
+
+/** Visible to the caller. */
+const SEEN_AGENT = { id: 'agt_seen0000000000000000000', userId: 'usr_seen0000000000000000000' }
+/** Restricted from the caller — must not surface through ANY door. */
+const HIDDEN_AGENT = { id: 'agt_hidden00000000000000000', userId: 'usr_hidden00000000000000000' }
+
+const ctx = { organizationId: ORG_ID, userId: HUMAN_ID } as unknown as ActorContext
+
+/** Only {@link SEEN_AGENT} is visible. */
+const canSeeAgent = (agentId: string) => agentId === SEEN_AGENT.id
+
+function service() {
+  return new GroupMemberService(ctx)
+}
+
+beforeEach(() => {
+  getCachedAgents.mockReset().mockResolvedValue([SEEN_AGENT, HIDDEN_AGENT])
+  getCachedAgentsByUserIds.mockReset().mockResolvedValue([])
+  getMembers.mockReset().mockResolvedValue([])
+})
+
+describe('expandToUsers — door 1: the `agent:<id>` spelling', () => {
+  it('resolves a visible agent and drops a hidden one', async () => {
+    const out = await service().expandToUsers(
+      [`agent:${SEEN_AGENT.id}`, `agent:${HIDDEN_AGENT.id}`] as ActorId[],
+      { includeAgents: true, canSeeAgent }
+    )
+    expect(out).toEqual([SEEN_AGENT.userId])
+  })
+})
+
+describe('expandToUsers — door 2: the legacy `user:<backingUserId>` spelling', () => {
+  it('drops a hidden agent addressed by its backing user id', async () => {
+    // The door a caller-side filter on `actorIds` cannot see: nothing in this
+    // input says "agent". If the hidden agent's user id came back here it would
+    // be indistinguishable from a genuine human in the result.
+    const out = await service().expandToUsers([`user:${HIDDEN_AGENT.userId}`] as ActorId[], {
+      includeAgents: true,
+      canSeeAgent,
+    })
+    expect(out).toEqual([])
+  })
+
+  it('still resolves a VISIBLE agent addressed the legacy way', async () => {
+    const out = await service().expandToUsers([`user:${SEEN_AGENT.userId}`] as ActorId[], {
+      includeAgents: true,
+      canSeeAgent,
+    })
+    expect(out).toEqual([SEEN_AGENT.userId])
+  })
+
+  it('never mistakes a genuine human for an agent', async () => {
+    // The failure mode of getting the two sets backwards: a real user id is in
+    // neither agent set and must always pass through.
+    const out = await service().expandToUsers([`user:${HUMAN_ID}`] as ActorId[], {
+      includeAgents: true,
+      canSeeAgent,
+    })
+    expect(out).toEqual([HUMAN_ID])
+  })
+})
+
+describe('expandToUsers — door 3: group membership', () => {
+  /**
+   * Group rows store EVERY member as `memberType: 'user'` + `memberRefId`; an
+   * agent member is only recognizable by its backing user id matching an agent.
+   * `getAgentActors` re-spells those as `agent:<id>` and `getUserActors` drops
+   * them from the user half, so by the time the expansion loop sees them they
+   * are on the `agent:` branch.
+   *
+   * **Which arm this test actually pins:** the `agentById` visibility filter,
+   * not the group loop's `addUserActor` call. Mutating that call to a bare
+   * `userIds.add` leaves this green, because the pre-split means it never sees
+   * an agent-backed id — documented at the call site too. What DOES kill this
+   * test is building `agentById` from all agents instead of the visible ones.
+   */
+  it('drops a hidden agent reached through a group the caller CAN see', async () => {
+    getMembers.mockResolvedValue([
+      { memberType: 'user', memberRefId: HUMAN_ID, user: { id: HUMAN_ID } },
+      { memberType: 'user', memberRefId: SEEN_AGENT.userId, user: { id: SEEN_AGENT.userId } },
+      { memberType: 'user', memberRefId: HIDDEN_AGENT.userId, user: { id: HIDDEN_AGENT.userId } },
+    ] as never)
+    getCachedAgentsByUserIds.mockResolvedValue([SEEN_AGENT, HIDDEN_AGENT] as never)
+
+    const out = await service().expandToUsers(['group:grp_1'] as ActorId[], {
+      includeAgents: true,
+      canSeeAgent,
+    })
+    expect(out.sort()).toEqual([HUMAN_ID, SEEN_AGENT.userId].sort())
+    expect(out).not.toContain(HIDDEN_AGENT.userId)
+  })
+})
+
+describe('expandToUsers — omitting the predicate leaves system paths unclamped', () => {
+  it('resolves every agent when no `canSeeAgent` is supplied', async () => {
+    // Trigger routing and notification fan-out have no invoking user, so they
+    // must not inherit anyone's visibility. If this ever starts filtering,
+    // headless agent runs silently stop reaching their targets.
+    const out = await service().expandToUsers(
+      [`agent:${SEEN_AGENT.id}`, `agent:${HIDDEN_AGENT.id}`] as ActorId[],
+      { includeAgents: true }
+    )
+    expect(out.sort()).toEqual([SEEN_AGENT.userId, HIDDEN_AGENT.userId].sort())
+  })
+
+  it('still excludes agents entirely when includeAgents is false', async () => {
+    const out = await service().expandToUsers(
+      [`user:${HUMAN_ID}`, `agent:${SEEN_AGENT.id}`, `user:${SEEN_AGENT.userId}`] as ActorId[],
+      {}
+    )
+    expect(out).toEqual([HUMAN_ID])
+  })
+})

--- a/packages/lib/src/actors/group-member-service.ts
+++ b/packages/lib/src/actors/group-member-service.ts
@@ -129,45 +129,88 @@ export class GroupMemberService {
    * receive email/notification fan-out). Pass `includeAgents: true` for
    * agent-aware paths (e.g. agent trigger routing).
    *
+   * `canSeeAgent` applies per-agent instance access (plan 25 §4.2) when the
+   * caller is a USER-facing surface. It belongs here rather than in the caller
+   * because an agent reaches the output through **three** doors and only one is
+   * visible in `actorIds`: the `agent:<id>` spelling, the legacy
+   * `user:<backingUserId>` spelling that this method deliberately reroutes, and
+   * group membership expanded inside the loop below. A caller that filtered its
+   * input array would close one and look like it had closed all three.
+   *
+   * Omit it for system paths (trigger routing, notification fan-out), which run
+   * with no invoking user and must not be clamped by anyone's visibility.
+   *
    * @returns Array of unique user IDs
    */
   async expandToUsers(
     actorIds: ActorId[],
-    options: { includeAgents?: boolean } = {}
+    options: { includeAgents?: boolean; canSeeAgent?: (agentId: string) => boolean } = {}
   ): Promise<string[]> {
     const includeAgents = options.includeAgents ?? false
+    const canSeeAgent = options.canSeeAgent ?? (() => true)
     const userIds = new Set<string>()
 
     // Index agents by id so `agent:<id>` actors expand to their backing user id.
     // Drafts have no backing user — skip them by filtering on userId.
     const agents = await getCachedAgents(this.organizationId)
-    const agentById = new Map(agents.filter((a) => a.userId !== null).map((a) => [a.id, a]))
-    const agentUserIdSet = new Set(
+    const visibleAgents = agents.filter((a) => canSeeAgent(a.id))
+    const agentById = new Map(visibleAgents.filter((a) => a.userId !== null).map((a) => [a.id, a]))
+    // Door 2: the legacy `user:<backingUserId>` spelling. Two sets, not one —
+    // `visible` decides whether an agent may be resolved, `all` decides whether
+    // a given user id IS an agent at all. Collapsing them would let an agent the
+    // caller cannot see fall through as an ordinary user.
+    const visibleAgentUserIds = new Set(
+      visibleAgents.map((a) => a.userId).filter((id): id is string => id !== null)
+    )
+    const allAgentUserIds = new Set(
       agents.map((a) => a.userId).filter((id): id is string => id !== null)
     )
+
+    /**
+     * Add a `user:`-spelled id, applying the agent rules when it turns out to
+     * name an agent's backing user. A genuine human user is always added.
+     */
+    const addUserActor = (id: string) => {
+      if (!allAgentUserIds.has(id)) {
+        userIds.add(id)
+        return
+      }
+      if (includeAgents && visibleAgentUserIds.has(id)) userIds.add(id)
+    }
 
     for (const actorId of actorIds) {
       try {
         const { type, id } = parseActorId(actorId)
 
         if (type === 'user') {
-          // Defensive: if a caller still passes user:<agentUserId> (legacy),
-          // route through includeAgents the same way it would for an agent.
-          if (includeAgents || !agentUserIdSet.has(id)) {
-            userIds.add(id)
-          }
+          // Defensive: a caller may still pass user:<agentUserId> (legacy), so
+          // route it through the same agent rules an `agent:` id would take.
+          addUserActor(id)
         } else if (type === 'agent') {
           if (!includeAgents) continue
+          // `agentById` holds VISIBLE agents only, so an unseeable id misses.
           const agent = agentById.get(id)
           if (agent?.userId) userIds.add(agent.userId)
         } else if (type === 'group') {
+          // Door 3: group membership. A group the caller may see can still
+          // contain an agent they may not — closed by `agentById` below holding
+          // VISIBLE agents only.
           const members = includeAgents
             ? await this.getAllMemberActors(id)
             : await this.getUserActors(id)
           for (const member of members) {
             const parsed = parseActorId(member.actorId)
             if (parsed.type === 'user') {
-              userIds.add(parsed.id)
+              // `addUserActor` rather than a bare add, but note this arm is
+              // currently DEFENSIVE, not load-bearing: `getUserActors` already
+              // drops any member whose id belongs to an agent (see its
+              // `!agentUserIds.has(...)` filter), so an agent member always
+              // arrives on the `agent:` branch instead. Mutating this line to a
+              // bare `userIds.add` therefore kills no test — verified, and said
+              // out loud rather than left to imply coverage it does not have.
+              // It stays because the day `getUserActors` stops pre-splitting,
+              // this is the line that decides whether door 3 reopens.
+              addUserActor(parsed.id)
             } else if (parsed.type === 'agent') {
               const agent = agentById.get(parsed.id)
               if (agent?.userId) userIds.add(agent.userId)

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/agent-authoring-instance-access.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/agent-authoring-instance-access.test.ts
@@ -1,0 +1,243 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/agent-authoring-instance-access.test.ts
+//
+// Per-AGENT access for the `agents.builder` meta-tools (plan 25 §4.2).
+//
+// The sibling `agent-authoring-guard.test.ts` pins that every tool runs the
+// COARSE key + org-scope check. This file pins the third check that coarse key
+// cannot make: **which agent**. Without it a member holding `agents: Full` with
+// an explicit `none` row on one agent rewrites that agent's prompt through chat
+// — the standing "requirePermission is coarse-key only" trap, one layer below
+// the routers where it is easiest to miss.
+//
+// Enumerated, not per-tool, for the same reason the sibling file enumerates: a
+// tool registered later must not be able to ship without a tier. `TIERS` is
+// asserted to cover the registry exactly, so a new tool fails here until
+// somebody decides what it costs.
+//
+// The capability set is a REAL `CapabilitySet`. The sibling file's fake is
+// `{ can: () => boolean }` with no assert methods at all, which is why every one
+// of its 63 cases passes even when the per-instance assert is replaced with an
+// unconditional throw — verified before writing this.
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ForbiddenError } from '../../../../../../errors'
+import { CapabilitySet } from '../../../../../../permissions/capabilities/capability-set'
+import type { PermissionKey } from '../../../../../../permissions/capabilities/registry'
+import {
+  Area,
+  expandLevelsToKeys,
+  Level,
+} from '../../../../../../permissions/capabilities/registry'
+import type { AgentToolDefinition, AgentToolResult } from '../../../../../agent-framework/types'
+import type { GetToolDeps } from '../../../types'
+
+type ToolExecContext = Parameters<AgentToolDefinition['execute']>[1]
+
+const ORG = 'org-1'
+const AGENT_ID = 'a1'
+
+/** Tool name → the per-agent tier it must require. */
+const TIERS: Record<string, 'view' | 'edit' | 'admin'> = {
+  // Reads
+  get_eval_case: 'view',
+  get_eval_run: 'view',
+  get_suite_diff: 'view',
+  list_eval_cases: 'view',
+  read_procedure: 'view',
+  // Authoring
+  set_agent_prompt: 'edit',
+  set_agent_toolsets: 'edit',
+  set_agent_resource_scope: 'edit',
+  create_eval_case: 'edit',
+  update_eval_case_mock: 'edit',
+  run_eval_suite: 'edit',
+  create_procedure: 'edit',
+  set_procedure_body: 'edit',
+  update_procedure_criteria: 'edit',
+  // Administration
+  set_agent_triggers: 'admin',
+  update_agent_identity: 'admin',
+  complete_agent_setup: 'admin',
+}
+
+const RANK = { view: 0, edit: 1, admin: 2 } as const
+
+const { capsRef, getCapabilities, getCachedAgentById } = vi.hoisted(() => {
+  const capsRef = { caps: null as unknown }
+  return {
+    capsRef,
+    getCapabilities: vi.fn(async () => capsRef.caps as never),
+    getCachedAgentById: vi.fn(async () => ({ id: 'a1', kind: 'internal' }) as never),
+  }
+})
+
+vi.mock('../../../../../../permissions/capabilities/get-capabilities', () => ({ getCapabilities }))
+vi.mock('../../../../../../cache', () => ({
+  getCachedAgentById,
+  onCacheEvent: vi.fn(async () => {}),
+}))
+vi.mock('../../../../../../agents/procedures/authoring', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listAgentProceduresForAuthoring: vi.fn(async () => ok([])),
+}))
+vi.mock('../../../../../../agents/toolset-catalog', () => ({
+  getOrgToolsetCatalog: vi.fn(async () => []),
+  getOrgToolsetCatalogForSurface: vi.fn(async () => []),
+}))
+// Permissive: a plan denial here would masquerade as an authorization failure.
+vi.mock('../../../../../../permissions', () => ({
+  FeaturePermissionService: class {
+    async requireAccess() {}
+    async hasAccess() {
+      return true
+    }
+  },
+}))
+
+import { createAgentsBuilderCapabilities } from '../../index'
+
+const getDeps: GetToolDeps = () =>
+  ({
+    db: {},
+    sessionContext: { page: 'agents.builder', references: [{ kind: 'agent', id: AGENT_ID }] },
+    organizationId: ORG,
+    userId: 'member-1',
+    sessionId: 's-1',
+  }) as never
+
+const agentDeps = { organizationId: ORG, userId: 'member-1', sessionId: 's-1' } as ToolExecContext
+
+/**
+ * Area `agents: Full` throughout — so the ONLY thing that can deny is the
+ * per-instance row. A test that lowered the area level too would pass even if
+ * the instance check were deleted.
+ */
+function capsWithInstance(
+  permission: ResourcePermission,
+  areaLevel: Level = Level.Full
+): CapabilitySet {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.agents]: areaLevel }) as PermissionKey[]),
+    {},
+    'MEMBER',
+    'full',
+    (id) => id,
+    new Set(),
+    (id) => id,
+    { [AGENT_ID]: permission },
+    new Set([AGENT_ID])
+  )
+}
+
+async function builderTools(): Promise<AgentToolDefinition[]> {
+  const capability = await createAgentsBuilderCapabilities(getDeps, ORG)
+  return capability.tools
+}
+
+/** Did the guard deny this tool? Any non-Forbidden outcome counts as passing it. */
+async function deniedByGuard(tool: AgentToolDefinition): Promise<boolean> {
+  try {
+    await (tool.execute({} as never, agentDeps) as Promise<AgentToolResult>)
+    return false
+  } catch (error) {
+    return error instanceof ForbiddenError
+  }
+}
+
+beforeEach(() => {
+  capsRef.caps = capsWithInstance(ResourcePermission.admin)
+  getCachedAgentById.mockClear()
+})
+
+describe('agents.builder tools — every tool declares a per-agent tier', () => {
+  it('TIERS covers the registry exactly, so a new tool cannot ship without one', async () => {
+    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    const names = (await builderTools()).map((t) => t.name).sort()
+    expect(names).toEqual(Object.keys(TIERS).sort())
+  })
+})
+
+describe('agents.builder tools — an explicit `none` row beats the whole area', () => {
+  it('denies EVERY tool for a member holding agents: Full but restricted on this agent', async () => {
+    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    const tools = await builderTools()
+    expect(tools.length).toBeGreaterThan(0)
+
+    capsRef.caps = capsWithInstance(ResourcePermission.none)
+    for (const tool of tools) {
+      expect(await deniedByGuard(tool), tool.name).toBe(true)
+    }
+  })
+})
+
+describe('agents.builder tools — each tier admits exactly its own rung and above', () => {
+  for (const [grant, granted] of [
+    [ResourcePermission.view, 'view'],
+    [ResourcePermission.edit, 'edit'],
+    [ResourcePermission.admin, 'admin'],
+  ] as const) {
+    it(`an instance \`${granted}\` holder reaches the ${granted}-and-below tools and no others`, async () => {
+      capsRef.caps = capsWithInstance(ResourcePermission.admin)
+      const tools = await builderTools()
+
+      capsRef.caps = capsWithInstance(grant)
+      for (const tool of tools) {
+        const required = TIERS[tool.name]
+        if (!required) throw new Error(`no tier declared for ${tool.name}`)
+        const shouldDeny = RANK[required] > RANK[granted]
+        expect(await deniedByGuard(tool), `${tool.name} (needs ${required}, has ${granted})`).toBe(
+          shouldDeny
+        )
+      }
+    })
+  }
+})
+
+describe('agents.builder tools — the Kopilot path is no cheaper than the tRPC path', () => {
+  it('keeps `set_agent_triggers` at admin, matching agent-trigger.ts', async () => {
+    // The specific bypass a single shared tier would have created: triggers are
+    // `assertAdminInstance` on the router because they make the agent act
+    // autonomously on its own credentials, so an instance-`edit` holder must not
+    // reach them through chat instead.
+    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    const tools = await builderTools()
+    const triggers = tools.find((t) => t.name === 'set_agent_triggers')
+    if (!triggers) throw new Error('set_agent_triggers is not registered')
+
+    capsRef.caps = capsWithInstance(ResourcePermission.edit)
+    expect(await deniedByGuard(triggers)).toBe(true)
+  })
+
+  it('takes the COARSE rung from the tier too, so a read tool needs only agents.view', async () => {
+    // The guard runs two checks per tier: the area rung, then the instance row.
+    // Every other case here grants `agents: Full`, which holds all three keys —
+    // so the area half is invisible to them and a mutation hardcoding
+    // `agentsManage` there survives. This is the case that kills it: a member
+    // whose AREA level is only Read must still reach the read tools, exactly as
+    // `agentToolset.listTools` moved to `agentsView` on the router side.
+    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    const tools = await builderTools()
+    const read = tools.find((t) => t.name === 'get_eval_case')
+    const write = tools.find((t) => t.name === 'set_agent_prompt')
+    if (!read || !write) throw new Error('expected tools are not registered')
+
+    capsRef.caps = capsWithInstance(ResourcePermission.admin, Level.Read)
+    expect(await deniedByGuard(read)).toBe(false)
+    // …and the area rung still binds upward: Read is not enough to author.
+    expect(await deniedByGuard(write)).toBe(true)
+  })
+
+  it('lets an instance `view` holder read an eval case but not create one', async () => {
+    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    const tools = await builderTools()
+    const read = tools.find((t) => t.name === 'get_eval_case')
+    const write = tools.find((t) => t.name === 'create_eval_case')
+    if (!read || !write) throw new Error('eval tools are not registered')
+
+    capsRef.caps = capsWithInstance(ResourcePermission.view)
+    expect(await deniedByGuard(read)).toBe(false)
+    expect(await deniedByGuard(write)).toBe(true)
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/agent-authoring-guard.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/agent-authoring-guard.ts
@@ -21,6 +21,17 @@ export type AgentAuthoringResolution =
   | { ok: false; error: string }
 
 /**
+ * Which per-agent tier a builder tool needs. Mirrors the tRPC ladder exactly —
+ * see the tier table on {@link resolveAgentAuthoring}.
+ *
+ * There is no default on purpose. A shared gate with a single hardcoded tier is
+ * how a Kopilot tool ends up cheaper than the router it mirrors, which is the
+ * bypass this parameter exists to prevent: `set_agent_triggers` is `admin` on
+ * the tRPC side, so it must not be reachable at `edit` through chat.
+ */
+export type AgentAuthoringTier = 'view' | 'edit' | 'admin'
+
+/**
  * **The** authorization gate for every agent-authoring meta-tool in the
  * `agents.builder` capability set (prompt, toolsets, triggers, resource scope,
  * identity, setup completion, procedures, evals).
@@ -34,10 +45,10 @@ export type AgentAuthoringResolution =
  * in particular is the self-rewriting-boundary case
  * `plans/permissions/v2/19-permission-profiles.md` §0 forbids.
  *
- * Two checks, one code path:
- * 1. **`PermissionKey.agentsManage`** — exact parity with every procedure in
- *    `apps/web/src/server/api/routers/agent.ts`, which is what these tools are
- *    the Kopilot-side twin of.
+ * Three checks, one code path:
+ * 1. **The area rung for `tier`** — exact parity with the procedure in
+ *    `apps/web/src/server/api/routers/agent.ts` that each tool is the
+ *    Kopilot-side twin of.
  *
  *    This was deliberately stricter (OWNER/ADMIN) until plan 19 step 3, and the
  *    reason is worth recording: while the seeded `agent` profile was all-`Full`
@@ -57,6 +68,30 @@ export type AgentAuthoringResolution =
  * 2. **Org scope** — the agent id arrives in client-supplied session refs, and
  *    `updateAgent` / the toolset+trigger+scope services key on `Agent.id`
  *    without an org predicate, so an unscoped ref is a cross-tenant write.
+ * 3. **Per-agent instance access** (plan 25 §4.2, 2026-07-28). Agents joined
+ *    `INSTANCE_ACCESS_RESOURCES`, and check 1 is a COARSE key — it answers "may
+ *    this member author agents at all", never "may they author THIS one". Without
+ *    this third check a member holding `agents: Full` with an explicit `none` row
+ *    on one agent sails straight through and rewrites it through chat, which is
+ *    the standing "requirePermission is coarse-key only" trap applied to the
+ *    tool layer. The tier table:
+ *
+ *    | tool                                                       | tier  |
+ *    |------------------------------------------------------------|-------|
+ *    | `get_eval_case`, `get_eval_run`, `get_suite_diff`,          | view  |
+ *    | `list_eval_cases`, `procedure_read`                         |       |
+ *    | `set_agent_prompt`, `set_agent_toolsets`,                   | edit  |
+ *    | `set_agent_resource_scope`, `create_eval_case`,             |       |
+ *    | `update_eval_case_mock`, `run_eval_suite`,                  |       |
+ *    | `procedure_create`, `procedure_set_body`,                   |       |
+ *    | `procedure_update_criteria`                                 |       |
+ *    | `set_agent_triggers`, `update_agent_identity`,              | admin |
+ *    | `complete_agent_setup`                                      |       |
+ *
+ *    `set_agent_triggers` is `admin` because a trigger makes the agent act
+ *    autonomously on its own credentials (user decision 2026-07-28), matching
+ *    `agent-trigger.ts`. `update_agent_identity` renames, and
+ *    `complete_agent_setup` finalizes — both admin on the tRPC side.
  *
  * Authorization failures **throw `ForbiddenError`** (an `AuxxError`; lib code
  * never throws `TRPCError`). The engine turns a thrown tool error into a
@@ -67,7 +102,8 @@ export type AgentAuthoringResolution =
  */
 export async function resolveAgentAuthoring(
   getDeps: GetToolDeps,
-  agentDeps: AgentDeps
+  agentDeps: AgentDeps,
+  tier: AgentAuthoringTier
 ): Promise<AgentAuthoringResolution> {
   const { sessionContext } = getDeps()
   const agentRef = findRef(sessionContext, 'agent')
@@ -76,7 +112,7 @@ export async function resolveAgentAuthoring(
   }
 
   const caps = await getCapabilities(agentDeps.userId, agentDeps.organizationId)
-  if (!caps.can(PermissionKey.agentsManage)) {
+  if (!caps.can(AREA_KEY_FOR_TIER[tier])) {
     throw new ForbiddenError('You don’t have permission to configure agents.')
   }
 
@@ -88,5 +124,28 @@ export async function resolveAgentAuthoring(
     throw new ForbiddenError('Agent not found in this workspace.')
   }
 
+  // Per-agent tier. Runs AFTER the org-scope check so a foreign id reads as
+  // "not in this workspace" rather than leaking that it exists elsewhere.
+  // `agentRef.id` is a real `Agent.id` here — `getCachedAgentById` matched it,
+  // and it is keyed by id, not slug — so it is safe to assert on directly.
+  ASSERT_FOR_TIER[tier](caps, agentRef.id)
+
   return { ok: true, agentId: agentRef.id, agent }
+}
+
+/** The coarse area rung each tier requires, before the per-instance check. */
+const AREA_KEY_FOR_TIER: Record<AgentAuthoringTier, PermissionKey> = {
+  view: PermissionKey.agentsView,
+  edit: PermissionKey.agentsEdit,
+  admin: PermissionKey.agentsManage,
+}
+
+/** The per-instance assert each tier runs. Throws `ForbiddenError` on denial. */
+const ASSERT_FOR_TIER: Record<
+  AgentAuthoringTier,
+  (caps: Awaited<ReturnType<typeof getCapabilities>>, agentId: string) => void
+> = {
+  view: (caps, agentId) => caps.assertViewInstance('agent', agentId),
+  edit: (caps, agentId) => caps.assertEditInstance('agent', agentId),
+  admin: (caps, agentId) => caps.assertAdminInstance('agent', agentId),
 }

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
@@ -40,7 +40,7 @@ finalization signal. No arguments — operates on the agent in session context.`
       additionalProperties: false,
     },
     execute: async (_args, agentDeps) => {
-      const auth = await resolveAgentAuthoring(getDeps, agentDeps)
+      const auth = await resolveAgentAuthoring(getDeps, agentDeps, 'admin')
       if (!auth.ok) return { success: false, output: null, error: auth.error }
       const { agentId } = auth
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/create-eval-case.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/create-eval-case.ts
@@ -143,7 +143,7 @@ export function createCreateEvalCaseTool(getDeps: GetToolDeps): AgentToolDefinit
       return { caseId: o?.caseId, name: o?.name }
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'edit')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
       const { agentId } = ctx
       const { organizationId, userId } = agentDeps

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-case.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-case.ts
@@ -85,7 +85,7 @@ export function createGetEvalCaseTool(getDeps: GetToolDeps): AgentToolDefinition
       ],
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'view')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const caseId = typeof args.caseId === 'string' ? args.caseId : ''

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-run.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-run.ts
@@ -75,7 +75,7 @@ export function createGetEvalRunTool(getDeps: GetToolDeps): AgentToolDefinition 
       truncated: false,
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'view')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const runId = typeof args.runId === 'string' ? args.runId : ''

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-suite-diff.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-suite-diff.ts
@@ -88,7 +88,7 @@ export function createGetSuiteDiffTool(getDeps: GetToolDeps): AgentToolDefinitio
       ],
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'view')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const baselineSuiteRunId =

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/list-eval-cases.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/list-eval-cases.ts
@@ -71,7 +71,7 @@ export function createListEvalCasesTool(getDeps: GetToolDeps): AgentToolDefiniti
       total: 1,
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'view')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const procedureId = typeof args.procedureId === 'string' ? args.procedureId : undefined

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-authoring-guard.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-authoring-guard.ts
@@ -4,7 +4,11 @@ import { FeaturePermissionService } from '../../../../../permissions'
 import { FeatureKey } from '../../../../../permissions/client'
 import type { AgentDeps } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
-import { type AgentAuthoringResolution, resolveAgentAuthoring } from './agent-authoring-guard'
+import {
+  type AgentAuthoringResolution,
+  type AgentAuthoringTier,
+  resolveAgentAuthoring,
+} from './agent-authoring-guard'
 
 /**
  * Authorization for the procedure- and eval-authoring tools (Phase 7 §4.0).
@@ -20,9 +24,10 @@ import { type AgentAuthoringResolution, resolveAgentAuthoring } from './agent-au
  */
 export async function resolveProcedureAuthoring(
   getDeps: GetToolDeps,
-  agentDeps: AgentDeps
+  agentDeps: AgentDeps,
+  tier: AgentAuthoringTier
 ): Promise<AgentAuthoringResolution> {
-  const resolved = await resolveAgentAuthoring(getDeps, agentDeps)
+  const resolved = await resolveAgentAuthoring(getDeps, agentDeps, tier)
   if (!resolved.ok) return resolved
 
   try {

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-create.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-create.ts
@@ -74,7 +74,7 @@ Optionally pass \`body\` (the step DSL) to seed the procedure now, or omit it an
       },
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'edit')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const name = typeof args.name === 'string' ? args.name.trim() : ''

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-read.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-read.ts
@@ -31,7 +31,7 @@ export function createReadProcedureTool(getDeps: GetToolDeps): AgentToolDefiniti
       properties: { procedureId: { type: 'string', minLength: 1 } },
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'view')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const procedureId = typeof args.procedureId === 'string' ? args.procedureId : ''

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-set-body.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-set-body.ts
@@ -58,7 +58,7 @@ export function createSetProcedureBodyTool(getDeps: GetToolDeps): AgentToolDefin
       },
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'edit')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const procedureId = typeof args.procedureId === 'string' ? args.procedureId : ''

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-update-criteria.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-update-criteria.ts
@@ -52,7 +52,7 @@ export function createUpdateProcedureCriteriaTool(getDeps: GetToolDeps): AgentTo
       },
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'edit')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const procedureId = typeof args.procedureId === 'string' ? args.procedureId : ''

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/run-eval-suite.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/run-eval-suite.ts
@@ -80,7 +80,7 @@ The results arrive automatically as a \`<task-notification>\` message in a later
       // Same contract as the eval tRPC router: agentProcedures feature + admin,
       // and the session agent verified org-scoped. One guard, shared with the
       // procedure-authoring tools.
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'edit')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const procedureId = typeof args.procedureId === 'string' ? args.procedureId : undefined

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
@@ -73,7 +73,7 @@ The previous prompt is replaced wholesale.`,
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
-      const auth = await resolveAgentAuthoring(getDeps, agentDeps)
+      const auth = await resolveAgentAuthoring(getDeps, agentDeps, 'edit')
       if (!auth.ok) return { success: false, output: null, error: auth.error }
       const { agentId } = auth
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
@@ -82,7 +82,7 @@ recordIds.`,
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
-      const auth = await resolveAgentAuthoring(getDeps, agentDeps)
+      const auth = await resolveAgentAuthoring(getDeps, agentDeps, 'edit')
       if (!auth.ok) return { success: false, output: null, error: auth.error }
       const { agentId } = auth
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
@@ -68,7 +68,7 @@ to change; omitted slugs are left alone.`,
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
-      const auth = await resolveAgentAuthoring(getDeps, agentDeps)
+      const auth = await resolveAgentAuthoring(getDeps, agentDeps, 'edit')
       if (!auth.ok) return { success: false, output: null, error: auth.error }
       const { agentId, agent } = auth
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
@@ -135,7 +135,7 @@ has two, send all three in the call.`,
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
-      const auth = await resolveAgentAuthoring(getDeps, agentDeps)
+      const auth = await resolveAgentAuthoring(getDeps, agentDeps, 'admin')
       if (!auth.ok) return { success: false, output: null, error: auth.error }
       const { agentId } = auth
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-agent-identity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-agent-identity.ts
@@ -65,7 +65,7 @@ active references — you do NOT pass an agentId.
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
-      const auth = await resolveAgentAuthoring(getDeps, agentDeps)
+      const auth = await resolveAgentAuthoring(getDeps, agentDeps, 'admin')
       if (!auth.ok) return { success: false, output: null, error: auth.error }
       const { agentId } = auth
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-eval-case-mock.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-eval-case-mock.ts
@@ -121,7 +121,7 @@ export function createUpdateEvalCaseMockTool(getDeps: GetToolDeps): AgentToolDef
       return { caseId: o?.caseId, mockCount: o?.mocks?.length }
     },
     execute: async (args, agentDeps) => {
-      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps, 'edit')
       if (!ctx.ok) return { success: false, output: null, error: ctx.error }
 
       const caseId = typeof args.caseId === 'string' ? args.caseId : ''

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -166,7 +166,26 @@ export const USER_CACHE_KEY_CONFIG: Record<
   // mandatory: a dev flush is NOT a substitute, because during a rollout a
   // draining old instance repopulates the same keyspace, which is the entire
   // reason `vN` exists.
+  // v12: agents instance access (plan 25 §4.2). `Area.agents` split from its
+  // single `Full → agents.manage` rung into Read/Edit/Full, and `agent` joined
+  // `INSTANCE_ACCESS_RESOURCES` — the same pair of changes `workflow` made in
+  // v11's part 2, so the same two staleness effects apply:
+  //   1. A v11 blob's `keys` hold `agents.manage` but NOT `agents.view` /
+  //      `agents.edit`, because it was expanded against the 1-rung ladder.
+  //      `areaLevelFromKeys` walks rungs in order and `break`s at the first
+  //      unheld one, so `Area.agents` composes to **None** off a v11 blob, not
+  //      to Full — the member loses agents entirely rather than keeping them.
+  //   2. A v11 blob carries no `agent` rows in `instanceAccess` or
+  //      `instanceDerivedKeys` at all: its instance query ran with `agent`
+  //      absent from `INSTANCE_ACCESS_KEYS`, so an explicit grant is invisible
+  //      and cannot rescue (1).
+  // Both fail CLOSED, so this stays a lost-access bump like v11 — but note the
+  // direction is only lucky, not structural. Had `areaLevelFromKeys` taken the
+  // highest SATISFIED rung instead of stopping at the first gap, a v11 blob
+  // would have read `Full` and handed every member `admin` on every agent
+  // (`baselineAtCreate: false` ⇒ the area level IS the absent-row fallback) for
+  // the full ONE_DAY TTL, silently voiding every restriction this slice ships.
   // NOTE: bump this whenever the registry's area/key set or the UserCapabilities
   // shape changes, so a rollout can't leave members on a stale key set.
-  userCapabilities: { prefix: 'user:capabilities:v11', ttlSeconds: ONE_DAY },
+  userCapabilities: { prefix: 'user:capabilities:v12', ttlSeconds: ONE_DAY },
 }

--- a/packages/lib/src/notifications/client.ts
+++ b/packages/lib/src/notifications/client.ts
@@ -14,6 +14,7 @@ export const NOTIFICATION_TARGET_TYPES = [
   'KNOWLEDGE_BASE',
   'DASHBOARD',
   'WORKFLOW',
+  'AGENT',
   'SETTINGS',
   'NONE',
 ] as const
@@ -33,6 +34,8 @@ export interface NotificationTargetIdsMap {
   DASHBOARD: { dashboardId: string }
   /** The `WorkflowApp.id` — the instance-access key `workflow` is keyed on it. */
   WORKFLOW: { workflowAppId: string }
+  /** The `Agent.id`. Deep links route by SLUG, so the renderer resolves it. */
+  AGENT: { agentId: string }
   SETTINGS: { path: string }
   NONE: Record<string, never>
 }
@@ -52,7 +55,7 @@ export type NotificationMetadata =
       resourceName: string
       noun: string
       /** Mirrors `InstanceAccessKey` — kept as a literal union so this module stays client-safe. */
-      resourceKey: 'dataset' | 'kb' | 'dashboard' | 'workflow'
+      resourceKey: 'dataset' | 'kb' | 'dashboard' | 'workflow' | 'agent'
       level: 'read' | 'write' | 'full'
     }
   | { kind: 'MESSAGE_SHARED'; subject?: string | null; lens: string }

--- a/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
+++ b/packages/lib/src/permissions/capabilities/capability-set-instance.test.ts
@@ -441,6 +441,12 @@ describe('the area Read rung derived from instance grants (item 5b)', () => {
       kb: [PermissionKey.knowledgeBaseView],
       dashboard: [PermissionKey.dashboardsView],
       workflow: [PermissionKey.workflowsView],
+      // `agent` joined the registry in 2026-07-28's agents slice. It is
+      // non-empty precisely because `Area.agents` gained a `Level.Read` rung in
+      // the same change — the derivation is "the area's Read rung or nothing",
+      // so an instance-access area with no Read rung would land here as `[]`
+      // and fail closed rather than confer a key it has no name for.
+      agent: [PermissionKey.agentsView],
     })
   })
 })

--- a/packages/lib/src/permissions/capabilities/instance-access.ts
+++ b/packages/lib/src/permissions/capabilities/instance-access.ts
@@ -44,6 +44,24 @@ export const INSTANCE_ACCESS_RESOURCES = {
   // restricted to `none` still fires — see the `Area.workflows` note in
   // `registry.ts` and plan 30 §2.1.
   workflow: { baselineAtCreate: false, area: Area.workflows },
+  // org-shared; absent instance row → base L2 `agents` level (plan 25 §4.2).
+  // Same posture as workflows and for the same reason: members compose
+  // `agents: Full`, so RESTRICTION is the use case ("only the support leads may
+  // touch the escalation agent"), and `false` means no create-time row write
+  // and no backfill migration. The `Area.agents` Read/Edit rungs exist
+  // precisely so this fallback can land on a real view/edit tier.
+  //
+  // `view` means USABLE, not merely visible (user decision 2026-07-27): chat in
+  // Kopilot, DM, @-mention, assign, and appear in actor pickers. There was no
+  // pre-existing "usable but not editable" tier to preserve — `actor.list` /
+  // `actor.search` filtered agents not at all, and `dmEnabled` / `mentionable`
+  // are org-wide booleans with no grantee dimension.
+  //
+  // Instance access gates HUMAN-INITIATED work only. The autonomous paths
+  // (schedule, record event, app trigger, webhook, visitor, eval) pass no
+  // `invokerUserId` by design, so a restricted agent still runs headlessly —
+  // the same carve-out `workflow` documents above.
+  agent: { baselineAtCreate: false, area: Area.agents },
 } as const satisfies Record<string, InstanceAccessResourceConfig>
 
 /** The set of resource keys backed by instance-level access. */

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -24,6 +24,10 @@ export enum PermissionKey {
   workflowsView = 'workflows.view',
   workflowsEdit = 'workflows.edit',
   workflowsManage = 'workflows.manage',
+  // agents is an instance-access resource — per-agent `ResourceAccess` grants
+  // sit on these three rungs (plan 25 §4.2.DECIDED).
+  agentsView = 'agents.view',
+  agentsEdit = 'agents.edit',
   agentsManage = 'agents.manage',
 
   // collaboration
@@ -142,9 +146,23 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
     featureKey: FeatureKey.workflows,
   },
   {
+    key: PermissionKey.agentsView,
+    label: 'View & Use Agents',
+    description: 'See agents shared with you and chat with, mention, or assign work to them.',
+    group: 'Automation',
+    featureKey: FeatureKey.agents,
+  },
+  {
+    key: PermissionKey.agentsEdit,
+    label: 'Edit Agents',
+    description: 'Edit an agent’s prompt, tools, knowledge scope, procedures, and evals.',
+    group: 'Automation',
+    featureKey: FeatureKey.agents,
+  },
+  {
     key: PermissionKey.agentsManage,
     label: 'Manage Agents',
-    description: 'Create and configure Kopilot agents.',
+    description: 'Create, publish, delete, and configure Kopilot agents.',
     group: 'Automation',
     featureKey: FeatureKey.agents,
   },
@@ -554,16 +572,57 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
   [Area.agents]: {
     area: Area.agents,
     label: 'Agents',
-    description: 'Create and configure Kopilot agents.',
+    description:
+      'Use agents shared with you, edit their prompt and tools, or create, publish, and delete them.',
     group: 'Automation',
-    rungs: [{ level: Level.Full, keys: [PermissionKey.agentsManage] }],
-    // Migrated 2026-07-27 (plan 21 §4.1, Tier B): every sibling authoring
-    // router that used to gate on a bare `adminProcedure` now asserts
-    // `agentsManage` instead — `agent-toolset.ts`, `agent-trigger.ts`,
-    // `agent-scope.ts`, `agent-procedure.ts` + `procedure.ts`
-    // (`agentProceduresManageProcedure`), and `eval.ts`'s `evalManageProcedure`
-    // all route through `permissionProcedure(agentsManage)`, matching
-    // `agent.ts`. The area's lever is fully real; flag dropped.
+    rungs: [
+      { level: Level.Read, keys: [PermissionKey.agentsView] },
+      { level: Level.Edit, keys: [PermissionKey.agentsEdit] },
+      { level: Level.Full, keys: [PermissionKey.agentsManage] },
+    ],
+    // `Read`/`Edit` rungs added 2026-07-28 (plan 25 §4.2.DECIDED) — prerequisite
+    // for per-agent instance access, exactly as plan 30 §1 was for workflows.
+    // Agents are an `INSTANCE_ACCESS_RESOURCES` entry with
+    // `baselineAtCreate: false`, so an agent with NO explicit `ResourceAccess`
+    // row falls back to THIS area level; on the old single-rung ladder that
+    // fallback could only be `None` or `Full`, which would have handed every
+    // member `admin` on every agent the moment instance access shipped.
+    //   Read  = see the agent and USE it — chat in Kopilot, DM it, @-mention it,
+    //           assign work to it, pick it in an actor picker (user decision
+    //           2026-07-27: `view` means "usable"). There is no separate
+    //           "usable but not editable" tier being preserved here; usability
+    //           and manageability were the SAME key before this split.
+    //   Edit  = prompt, drafts, toolsets, knowledge scope, procedures, evals,
+    //           and RENAME (name + slug). Rename sits here rather than on Full
+    //           — deliberately unlike `Area.workflows` above — because it is an
+    //           authoring field, and `agent.update`'s `ADMIN_ONLY_UPDATE_FIELDS`
+    //           reflects that (user decision 2026-07-28).
+    //   Full  = create, publish, delete, archive, triggers, and the agent's own
+    //           permission profile / `runAsUserId`.
+    // Purely a SPLIT of the old Full rung: no path got more permissive, and no
+    // migration is needed. `Level` is ordinal, and the dev check that #1344's
+    // dashboards rung established as the bar came back clean — all 25
+    // `PermissionGrant` rows carrying an `agents` level store `3` (Full), none
+    // store `1` or `2`, and `ResourceAccess` had zero `agent` rows — so nothing
+    // silently gained rights. `MEMBER_BASELINE_LEVELS[agents]` is `Full`, so no
+    // member regresses and RESTRICTION is the use case, not sharing-up.
+    //
+    // SHARING AN AGENT IS NOT A CAPABILITY GRANT. A chatting user acts as
+    // THEMSELVES: `agent-run-capabilities.ts` intersects the agent's published
+    // policy with the invoker's own capabilities for every human-driven path
+    // (Kopilot SSE, mention, assignment), so an agent can never read data on
+    // someone's behalf that they could not read directly. What a share DOES
+    // hand over is the agent's bound third-party credentials and installed app
+    // tools, which run on the agent's connection — see plan 25 §4.2.DECIDED and
+    // the share dialog's scope note.
+    //
+    // Prior history — migrated 2026-07-27 (plan 21 §4.1, Tier B): every sibling
+    // authoring router that used to gate on a bare `adminProcedure` asserts an
+    // agents key instead (`agent-toolset.ts`, `agent-trigger.ts`,
+    // `agent-scope.ts`, `agent-procedure.ts` + `procedure.ts`, and `eval.ts`'s
+    // `evalManageProcedure`). That pass covered the MUTATING procedures only —
+    // 13 read procedures in those same routers stayed bare `protectedProcedure`
+    // and read no capabilities at all until this slice.
     featureKey: FeatureKey.agents,
   },
   [Area.comments]: {

--- a/packages/lib/src/permissions/profiles/__snapshots__/agent-policy-vocabulary.baseline.json
+++ b/packages/lib/src/permissions/profiles/__snapshots__/agent-policy-vocabulary.baseline.json
@@ -141,7 +141,9 @@
     },
     "composed": {
       "keys": [
+        "agents.edit",
         "agents.manage",
+        "agents.view",
         "aiConfig.manage",
         "auditLog.view",
         "automationRules.manage",
@@ -330,6 +332,7 @@
     },
     "composed": {
       "keys": [
+        "agents.view",
         "auditLog.view",
         "datasets.view",
         "dispatch.board.view",
@@ -489,7 +492,9 @@
     },
     "composed": {
       "keys": [
+        "agents.edit",
         "agents.manage",
+        "agents.view",
         "automationRules.manage",
         "billing.view",
         "dashboards.view",
@@ -626,7 +631,9 @@
     },
     "composed": {
       "keys": [
+        "agents.edit",
         "agents.manage",
+        "agents.view",
         "aiConfig.manage",
         "auditLog.view",
         "automationRules.manage",

--- a/packages/lib/src/permissions/profiles/agent-policy-vocabulary.test.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-vocabulary.test.ts
@@ -34,6 +34,22 @@ import { SYSTEM_PROFILE_SEEDS } from './system-profiles'
  *
  * It also pins the migration's own idempotence, which is the other half of the
  * bar: a second pass over already-migrated input must be the identity.
+ *
+ * **AMENDED 2026-07-28 — the fixture is no longer a pristine pre-rename
+ * capture.** The agents instance-access slice (plan 25 §4.2) split `Area.agents`
+ * from one `Full → agents.manage` rung into Read/Edit/Full, so every scenario
+ * composing a non-`None` agents level now expands to more keys than the capture
+ * recorded. The whole delta was `+4 × agents.view` and `+3 × agents.edit`
+ * across five scenarios — nothing removed, no `areaLevels` entry moved — and the
+ * fixture was amended by exactly that rule (`level ≥ 1 ⇒ view`, `≥ 2 ⇒ edit`).
+ * {@link agentsRungsAreTheOnlyAmendment} re-derives it from `areaLevels` so the
+ * amendment stays checkable instead of resting on this comment.
+ *
+ * Note the shape of that change: the `mixed` scenario composed `agents` at
+ * `Level.Read` with ZERO keys, because the 1-rung ladder had nothing to expand
+ * at Read. That rung was inert; now it confers `agents.view`. #1345's workflows
+ * split had the same effect and it was accepted then for the same reason — the
+ * rung meaning something is the point of adding it.
  */
 
 const RESOURCES: PolicyResourceRef[] = [
@@ -131,6 +147,29 @@ describe('the vocabulary rename changes no authority (plan 26 §2.6 / §4)', () 
     if (!legacy || !empty) throw new Error('missing baseline scenario')
     expect(legacy.composed.keys.length).toBeGreaterThan(20)
     expect(empty.composed.keys).toEqual([])
+  })
+
+  /**
+   * The 2026-07-28 amendment, re-derived rather than asserted in prose.
+   *
+   * The fixture was hand-edited when `Area.agents` gained its Read/Edit rungs,
+   * which is exactly the kind of edit that can quietly launder a real
+   * regression into a "baseline update". Every recorded agents key must follow
+   * from that scenario's recorded agents `areaLevel` and nothing else — so an
+   * amendment that added a key the ladder does not imply, or dropped one it
+   * does, fails here naming the scenario.
+   */
+  it('carries exactly the agents keys its recorded area level implies (agentsRungsAreTheOnlyAmendment)', () => {
+    for (const [name, scenario] of Object.entries(SCENARIOS)) {
+      const level = scenario.composed.areaLevels.agents ?? 0
+      const expected = [
+        ...(level >= 1 ? [PermissionKey.agentsView] : []),
+        ...(level >= 2 ? [PermissionKey.agentsEdit] : []),
+        ...(level >= 3 ? [PermissionKey.agentsManage] : []),
+      ]
+      const actual = scenario.composed.keys.filter((key) => key.startsWith('agents.')).sort()
+      expect(actual, name).toEqual([...expected].sort())
+    }
   })
 })
 

--- a/packages/lib/src/resource-access/resource-access-service.ts
+++ b/packages/lib/src/resource-access/resource-access-service.ts
@@ -6,6 +6,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { and, desc, eq, inArray, isNotNull, isNull, or } from 'drizzle-orm'
+import type { AnyPgColumn } from 'drizzle-orm/pg-core'
 import { onCacheEvent } from '../cache'
 import { NotificationService } from '../notifications'
 import type { NotificationTargetIds, NotificationTargetType } from '../notifications/client'
@@ -147,6 +148,14 @@ const INSTANCE_SHARE_NOTIFICATION_CONFIG: Record<
       | typeof schema.KnowledgeBase
       | typeof schema.Dashboard
       | typeof schema.WorkflowApp
+      | typeof schema.Agent
+    /**
+     * Which column names the instance in the notification. Explicit rather than
+     * an implicit `table.name`, because `Agent` HAS no `name` column — an
+     * agent's display name is User-owned, carried on its backing `User` row —
+     * so the assumption that every shareable table has one is false.
+     */
+    nameColumn: AnyPgColumn
     noun: string
     targetType: NotificationTargetType
     targetIds: (instanceId: string) => NotificationTargetIds
@@ -154,27 +163,42 @@ const INSTANCE_SHARE_NOTIFICATION_CONFIG: Record<
 > = {
   dataset: {
     table: schema.Dataset,
+    nameColumn: schema.Dataset.name,
     noun: 'dataset',
     targetType: 'DATASET',
     targetIds: (id) => ({ datasetId: id }),
   },
   kb: {
     table: schema.KnowledgeBase,
+    nameColumn: schema.KnowledgeBase.name,
     noun: 'knowledge base',
     targetType: 'KNOWLEDGE_BASE',
     targetIds: (id) => ({ knowledgeBaseId: id }),
   },
   dashboard: {
     table: schema.Dashboard,
+    nameColumn: schema.Dashboard.name,
     noun: 'dashboard',
     targetType: 'DASHBOARD',
     targetIds: (id) => ({ dashboardId: id }),
   },
   workflow: {
     table: schema.WorkflowApp,
+    nameColumn: schema.WorkflowApp.name,
     noun: 'workflow',
     targetType: 'WORKFLOW',
     targetIds: (id) => ({ workflowAppId: id }),
+  },
+  agent: {
+    table: schema.Agent,
+    // No `name` column on `Agent` — the display name lives on the backing
+    // `User`. `slug` is the stable, always-present, human-readable identifier
+    // (it is what the agent detail route is keyed by), so it stands in here
+    // rather than widening this query into a join for one resource.
+    nameColumn: schema.Agent.slug,
+    noun: 'agent',
+    targetType: 'AGENT',
+    targetIds: (id) => ({ agentId: id }),
   },
 }
 
@@ -236,7 +260,7 @@ async function notifyNewInstanceShare(
   const resourceConfig = INSTANCE_SHARE_NOTIFICATION_CONFIG[entityDefinitionId]
 
   const [resource] = await ctx.db
-    .select({ name: resourceConfig.table.name })
+    .select({ name: resourceConfig.nameColumn })
     .from(resourceConfig.table)
     .where(
       and(
@@ -246,6 +270,11 @@ async function notifyNewInstanceShare(
     )
     .limit(1)
   if (!resource) return
+
+  // `Agent.name` is nullable — chat-driven creation leaves it unset — while the
+  // other four tables' name columns are `notNull`. Without this the message
+  // reads "shared the agent null with you".
+  const resourceName = resource.name ?? `Untitled ${resourceConfig.noun}`
 
   const level =
     input.permission === ResourcePermission.admin
@@ -264,10 +293,10 @@ async function notifyNewInstanceShare(
         actorId: ctx.userId,
         targetType: resourceConfig.targetType,
         targetIds: targetIds as never,
-        message: `${actorName} shared the ${resourceConfig.noun} ${resource.name} with you`,
+        message: `${actorName} shared the ${resourceConfig.noun} ${resourceName} with you`,
         metadata: {
           kind: 'RESOURCE_SHARED',
-          resourceName: resource.name,
+          resourceName,
           noun: resourceConfig.noun,
           resourceKey: entityDefinitionId,
           level,


### PR DESCRIPTION
Plan 25 §4.2 (permissions v2 item 4). `Area.agents` splits from its single `Full → agents.manage` rung into Read/Edit/Full, and `agent` joins `INSTANCE_ACCESS_RESOURCES` with `baselineAtCreate: false`.

Because the absent-row fallback *is* the area level and `MEMBER_BASELINE_LEVELS[agents]` is `Full`, **restriction is the use case and nobody regresses**. The rung split was the hard prerequisite: without it every agent would have resolved to `admin` the moment instance access shipped — the same wrong "cheap one" assumption plan 25 §4.1 made about workflows.

## Tiers

| tier | what it buys |
|---|---|
| **view** | *usable* — Kopilot chat, DM, @-mention, assign work, appear in actor pickers, read version history |
| **edit** | prompt, drafts, toolsets/bindings, knowledge scope, procedures, evals, **rename** |
| **admin** | create, publish, delete, archive, **triggers**, `runAsUserId`, `permissionProfileId` |

Trigger writes are admin rather than edit because a trigger makes the agent act autonomously on its own bound credentials.

## Three of these were holes, not re-tiering

- **`eval.ts` had 11 bare `protectedProcedure`s reading no capabilities at all** — any member could replay any agent's eval traces, tool calls and assertion verdicts.
- **`actor.getByIds` was a metadata oracle**: POST any `agent:<id>` and get back that agent's name, avatar and slug. It has a second door via the legacy `user:<syntheticUserId>` spelling, so the filter keys on the value, not the map key.
- **`agent-trigger.ts` and `agent-procedure.ts`** carried 3 more ungated reads.

## The Kopilot tools were a parallel path around the routers

The 19 `agents.builder` meta-tools run *below* tRPC, reached through `POST /api/kopilot/stream`. Plan 25 never counted them. They all funnel through `agent-authoring-guard.ts`, which now takes a `tier` — a single shared rung would have left `set_agent_triggers` reachable at `edit` through chat while `agent-trigger.ts` reserves it for `admin`.

## Sharing an agent is not a capability grant

`agent-run-capabilities.ts` already intersects the agent's published policy with the **invoker's** own capabilities on every human-driven path. So the share copy states what a share actually hands over — the agent's connected accounts and installed app tools, which run on the agent's credentials — rather than the warning plan 25 §4.2.a drafted against a premise that is false at HEAD.

## Notable

- **`Agent` has no `name` column** (the display name is User-owned), so `INSTANCE_SHARE_NOTIFICATION_CONFIG` gained an explicit `nameColumn` rather than assuming `table.name` on every shareable table.
- **`expandToUsers` reaches an agent through three doors** — `agent:<id>`, the legacy `user:<backingUserId>`, and group membership. The predicate therefore lives in `GroupMemberService`; filtering the router's input array would have closed one door and looked complete.
- **`AgentPolicyInstanceKey = Exclude<InstanceAccessKey, 'agent'>`** implements plan 25 decision 4 as a *type*. `AREA_TO_INSTANCE_KEY` is derived, so a runtime-only exclusion would let "which agents may this agent access" rows reappear inside another agent's policy with no failing test.
- **`agent.list` is `capabilityProcedure` + `instanceListScope`**, matching the four `*.list` precedents: it filters, never 403s.
- The old `agent-authoring-guard.test.ts` fakes capabilities as `{ can: () => boolean }` with no assert methods, so all 63 of its cases pass even with the per-instance assert replaced by an unconditional `throw` (verified by probe). Its companion uses a real `CapabilitySet`.

## Cache bump

`user:capabilities` **v11 → v12** with a ledger entry. A stale v11 blob composes `Area.agents` to **None**, not Full, because `areaLevelFromKeys` breaks at the first unheld rung — fail-closed. The ledger records that this is luck rather than structure: a "highest satisfied rung" implementation would have handed every member `admin` on every agent for the full 24h TTL.

The `agent-policy-vocabulary` baseline fixture is **amended** (+4 `agents.view`, +3 `agents.edit`) and is no longer a pristine pre-rename capture. A new test re-derives the amendment from each scenario's recorded `areaLevels`, so the edit stays checkable instead of resting on a comment.

## Verification

524 lib tests + 782 `apps/web` tests. Every assert mutation-verified against an unmutated control. **Zero new tsc errors in any changed file** — checked per file against a pre-change capture (repo total is 4069 before and after). Dev capabilities cache flushed.

## Not done

- **No browser pass.** Highest-value check: restrict an agent to one member, confirm they still reach `/app/agents`, see only that agent, open it read-only, and that Kopilot/@-mention/pickers still offer it.
- Bulk surfaces (`agents-bulk-bar.tsx`, `apply-profile-dialog.tsx`) are ungated over a mixed-tier selection — server-enforced, so a UX gap, but it needs the same "intersect the selection" design call `dashboard-switcher-list.tsx` is waiting on.
- Also ungated in the UI (all server-enforced): knowledge-scope tree leaves, `agent-versions-dialog.tsx`, `agent-setup-mode`.
- `permissions.ts:120` gates permission-profile *reads* on coarse `agentsManage`, so an instance-admin without the coarse key sees an empty profile list.
- `agentExistsInOrg` now has zero callers repo-wide.
- `ActorService.searchActors` slices before the visibility filter, so a restricted member can get a short page. Not a leak; no client can page past it.
