### PR TITLE
feat(permissions): move the agent tab's notices into the section header

### DIFF
--- a/apps/web/src/components/activity-log/ui/audit-table.tsx
+++ b/apps/web/src/components/activity-log/ui/audit-table.tsx
@@ -105,15 +105,18 @@ export function AuditTable({
   }
 
   return (
-    <div className='flex flex-col flex-1 overflow-y-auto w-full'>
-      <table className='w-full caption-bottom text-sm max-w-full table-fixed'>
+    <div className='flex flex-col flex-1 overflow-auto w-full'>
+      <table
+        className={`caption-bottom text-sm table-fixed w-full ${
+          isAdmin ? 'min-w-[1240px]' : 'min-w-[1040px]'
+        }`}>
         <TableHeader className='sticky top-0 bg-background z-10'>
           <TableRow>
             <TableHead className='w-[300px]'>When</TableHead>
             {isAdmin && <TableHead className='w-[110px]'>Org</TableHead>}
             <TableHead className='w-[220px]'>Action</TableHead>
             <TableHead className='w-[160px]'>Actor</TableHead>
-            <TableHead className='flex-1'>Target</TableHead>
+            <TableHead className='min-w-[240px]'>Target</TableHead>
             <TableHead className='w-[120px]'>IP</TableHead>
             {isAdmin && <TableHead className='w-[90px]'>Visibility</TableHead>}
           </TableRow>
@@ -126,12 +129,14 @@ export function AuditTable({
                 key={row.id}
                 className={onRowClick ? 'cursor-pointer' : undefined}
                 onClick={onRowClick ? () => onRowClick(row) : undefined}>
-                <TableCell className='font-mono text-xs w-[190px]'>
+                <TableCell className='font-mono text-xs'>
                   <div className='flex items-center gap-2'>
-                    <Badge variant={badge.variant} size='xs'>
+                    <Badge variant={badge.variant} size='xs' className='shrink-0'>
                       {badge.label}
                     </Badge>
-                    <span>{format(new Date(row.createdAt), 'MMM dd, HH:mm:ss')}</span>
+                    <span className='whitespace-nowrap'>
+                      {format(new Date(row.createdAt), 'MMM dd, HH:mm:ss')}
+                    </span>
                   </div>
                 </TableCell>
                 {isAdmin && (
@@ -145,7 +150,7 @@ export function AuditTable({
                 <TableCell className='w-[160px] overflow-hidden'>
                   <AuditActor row={row} />
                 </TableCell>
-                <TableCell className='flex-1 font-mono text-xs overflow-hidden min-w-0'>
+                <TableCell className='font-mono text-xs overflow-hidden'>
                   <div className='break-words'>
                     {row.targetType ? (
                       <>

--- a/apps/web/src/components/agents/ui/agent-instance-access.test.tsx
+++ b/apps/web/src/components/agents/ui/agent-instance-access.test.tsx
@@ -476,7 +476,9 @@ describe('AgentPermissionsSection — the authority pair is instance-admin AND o
 
     expect(screen.getByTestId('profile-picker').dataset.disabled).toBe('true')
     expect(screen.getByTestId('run-as-picker').dataset.disabled).toBe('true')
-    expect(screen.getByText(/do not administer this agent/i)).toBeTruthy()
+    // The reason is the warning glyph's accessible name — the tooltip only
+    // renders its content on hover, the label is what states it unconditionally.
+    expect(screen.getByLabelText(/do not administer this agent/i)).toBeTruthy()
   })
 
   it('freezes them for a non-admin member who DOES administer the agent', () => {
@@ -484,6 +486,6 @@ describe('AgentPermissionsSection — the authority pair is instance-admin AND o
 
     expect(screen.getByTestId('profile-picker').dataset.disabled).toBe('true')
     expect(screen.getByTestId('run-as-picker').dataset.disabled).toBe('true')
-    expect(screen.getByText(/Only an owner or admin can change these/i)).toBeTruthy()
+    expect(screen.getByLabelText(/Only an owner or admin can change these/i)).toBeTruthy()
   })
 })

--- a/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-permissions-section.tsx
@@ -3,24 +3,22 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { type Actor, type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
-import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import {
+  AlertTriangle,
   CircleHelp,
-  ExternalLink,
   Lock,
   ScrollText,
   ShieldCheck,
   UserCog,
   Wrench,
 } from 'lucide-react'
-import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import { UpgradeBanner } from '~/components/banner/upgrade-banner'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
-import { SettingsSection } from '~/components/global/settings-page'
+import { Tooltip } from '~/components/global/tooltip'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { ProfilePicker } from '~/components/pickers/profile-picker'
 import { useActor } from '~/components/resources/hooks/use-actor'
@@ -35,7 +33,7 @@ import {
 } from '../../hooks/use-agent-permission-profiles'
 import type { AgentDetail } from '../../store/agent-store'
 import { AgentGuideDialog } from './agent-guide-dialog'
-import { AgentPolicySummary, AgentResolvedPolicyDialog } from './permissions/agent-policy-view'
+import { AgentResolvedPolicyDialog } from './permissions/agent-policy-view'
 import { AuthorClampNotice } from './permissions/author-clamp-notice'
 
 /**
@@ -133,6 +131,13 @@ export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsS
       initialOpen
       collapsible={false}
       description='What this agent can do when it runs.'
+      secondary={
+        <PermissionsHeaderNotes
+          agent={agent}
+          canEdit={canEditProfile}
+          isAdminOrOwner={isAdminOrOwner}
+        />
+      }
       actions={
         <Button
           variant='ghost'
@@ -143,20 +148,11 @@ export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsS
           <CircleHelp />
         </Button>
       }>
-      <div className='space-y-6'>
-        <DraftVersusPublished agent={agent} />
-
-        {!canEditProfile && (
-          <Alert>
-            <ShieldCheck className='size-4' />
-            <AlertDescription>
-              {isAdminOrOwner
-                ? 'You do not administer this agent, so these are read-only. Ask someone with full access to this agent to change them.'
-                : 'Only an owner or admin can change these. The resolved policy is read-only.'}
-            </AlertDescription>
-          </Alert>
-        )}
-
+      {/* `pe-1` on top of the Section's own `p-3` lands the content 16px from
+          the edge — the same inset the Tools section reaches via `-mx-3` + `pe-4`.
+          The root ScrollArea's bar is `w-1.5` but carries a `before:w-5` hit
+          strip, so 12px alone leaves it sitting over the panel's right edge. */}
+      <div className='space-y-4 pe-1'>
         {!hasGranularPermissions && (
           <UpgradeBanner
             title='Upgrade to author your own profiles'
@@ -164,92 +160,83 @@ export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsS
           />
         )}
 
-        <SettingsSection
-          icon={ShieldCheck}
-          title='Access'
-          description='The profile this draft resolves its policy from, and who it runs as.'
-          action={
-            <Button variant='ghost' size='xs' asChild>
-              <Link href='/app/settings/permissions'>
-                Edit in Settings
-                <ExternalLink />
-              </Link>
-            </Button>
-          }>
-          <div className='flex flex-col gap-2'>
-            <FieldPanel orientation='responsive' breakpoint='sm' resizeId='agent-permissions'>
-              <FieldPanelRow
-                title='Profile'
-                description='Supplies this draft its exact policy.'
-                icon={<ShieldCheck />}
-                showIcon>
-                {profilesLoading ? (
-                  <Skeleton className='my-1 h-7 w-56' />
-                ) : (
-                  <ProfilePicker
-                    value={resolvedProfile?.id}
-                    options={profileOptions}
-                    onChange={(profileId) => void setProfile(agent.id, profileId)}
-                    disabled={!canEditProfile || isSaving}
-                    emptyLabel='Select a permission profile'
-                    // An unbound draft is not unrestricted — §1.3 resolves it to
-                    // the system profile for its kind, so the trigger shows that
-                    // profile and labels it as inherited rather than sitting empty.
-                    hint={
-                      boundProfileId === null ? `· default for ${agent.kind} agents` : undefined
-                    }
-                  />
-                )}
-              </FieldPanelRow>
-
-              <FieldPanelRow
-                title='Run as'
-                description='Delegate to a member. Runs resolve whichever of the two is narrower.'
-                icon={<UserCog />}
-                showIcon>
-                <ActorPicker
-                  target='user'
-                  multi={false}
-                  value={[runAsActorId]}
-                  onChange={(next) => handleRunAsChange(next[0] ?? OWN_PERMISSIONS_ACTOR_ID)}
-                  pinnedItem={OWN_PERMISSIONS_ACTOR}
-                  disabled={!canEditRunAs || isUpdating}
-                  emptyLabel='Own permissions (default)'
-                  placeholder='Search members...'
+        <div className='flex flex-col gap-2'>
+          <FieldPanel orientation='responsive' breakpoint='sm' resizeId='agent-permissions'>
+            <FieldPanelRow
+              title='Profile'
+              description='Supplies this draft its exact policy.'
+              icon={<ShieldCheck />}
+              showIcon>
+              {profilesLoading ? (
+                <Skeleton className='my-1 h-7 w-56' />
+              ) : (
+                <ProfilePicker
+                  value={resolvedProfile?.id}
+                  options={profileOptions}
+                  onChange={(profileId) => void setProfile(agent.id, profileId)}
+                  disabled={!canEditProfile || isSaving}
+                  emptyLabel='Select a permission profile'
+                  triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+                  // An unbound draft is not unrestricted — §1.3 resolves it to
+                  // the system profile for its kind, so the trigger shows that
+                  // profile and labels it as inherited rather than sitting empty.
+                  hint={boundProfileId === null ? `· default for ${agent.kind} agents` : undefined}
                 />
-              </FieldPanelRow>
-            </FieldPanel>
+              )}
+            </FieldPanelRow>
 
-            {isDelegated && (
-              <p className='text-xs text-muted-foreground'>
-                Runs fail if {runAsName} is deactivated or removed.
-              </p>
+            <FieldPanelRow
+              title='Run as'
+              description='Delegate to a member. Runs resolve whichever of the two is narrower.'
+              icon={<UserCog />}
+              showIcon>
+              <ActorPicker
+                target='user'
+                multi={false}
+                value={[runAsActorId]}
+                onChange={(next) => handleRunAsChange(next[0] ?? OWN_PERMISSIONS_ACTOR_ID)}
+                pinnedItem={OWN_PERMISSIONS_ACTOR}
+                triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+                disabled={!canEditRunAs || isUpdating}
+                emptyLabel='Own permissions (default)'
+                placeholder='Search members...'
+              />
+            </FieldPanelRow>
+
+            {/* The per-area rungs are the dialog's job, not a summary's: the
+                profile above already names the policy, and three rows reading
+                "Full" restated it without saying which records or which tools. */}
+            <FieldPanelRow
+              title='Resolved policy'
+              description='The exact rungs this draft resolves to, area by area.'
+              icon={<ScrollText />}
+              showIcon>
+              <div className='py-1'>
+                <Button variant='outline' size='xs' onClick={() => setPolicyOpen(true)}>
+                  View resolved policy
+                </Button>
+              </div>
+            </FieldPanelRow>
+          </FieldPanel>
+
+          {isDelegated && (
+            <p className='text-xs text-muted-foreground'>
+              Runs fail if {runAsName} is deactivated or removed.
+            </p>
+          )}
+
+          <div className='flex flex-wrap items-center gap-1 text-xs text-muted-foreground'>
+            <span>A call needs both: the tool enabled, and this policy allowing its target.</span>
+            {onNavigate && (
+              <Button variant='ghost' size='xs' onClick={() => onNavigate('tools')}>
+                <Wrench />
+                Go to Tools
+              </Button>
             )}
           </div>
-        </SettingsSection>
+        </div>
 
         <AuthorClampNotice policy={policy} />
-
-        <SettingsSection
-          icon={ScrollText}
-          title='Resolved policy'
-          action={
-            <Button variant='outline' size='xs' onClick={() => setPolicyOpen(true)}>
-              View resolved policy
-            </Button>
-          }>
-          <AgentPolicySummary policy={policy} />
-        </SettingsSection>
-
-        <div className='flex flex-wrap items-center gap-1 text-xs text-muted-foreground'>
-          <span>A call needs both: the tool enabled, and this policy allowing its target.</span>
-          {onNavigate && (
-            <Button variant='ghost' size='xs' onClick={() => onNavigate('tools')}>
-              <Wrench />
-              Go to Tools
-            </Button>
-          )}
-        </div>
       </div>
 
       {policyOpen && (
@@ -270,38 +257,65 @@ export function AgentPermissionsSection({ agent, onNavigate }: AgentPermissionsS
 }
 
 /**
- * Which policy is live: the draft's (Chat + eval runs) or a published version's.
- * Every control on this tab edits the draft (§0.3 / §0.16).
+ * One amber glyph in the section header carrying its whole message in the
+ * tooltip. `label` doubles as the accessible name, so the reason is readable
+ * without a hover — a tooltip alone would state it only to a mouse.
  */
-function DraftVersusPublished({ agent }: { agent: AgentDetail }) {
+function HeaderWarning({ label }: { label: string }) {
+  return (
+    <Tooltip content={label}>
+      <Button
+        variant='ghost'
+        size='icon-xs'
+        aria-label={label}
+        className='text-amber-600 hover:text-amber-600'>
+        <AlertTriangle />
+      </Button>
+    </Tooltip>
+  )
+}
+
+/**
+ * The two things true of this tab that are not settings on it: which policy is
+ * actually live, and whether the reader may change any of it.
+ *
+ * Both live in the header rather than as banners above the controls. They
+ * describe the whole tab and neither is actionable here — publishing happens
+ * from the hero, and a read-only reader has nothing to click — so a stacked
+ * pair of alerts only pushed the controls they qualify further down the page.
+ */
+function PermissionsHeaderNotes({
+  agent,
+  canEdit,
+  isAdminOrOwner,
+}: {
+  agent: AgentDetail
+  canEdit: boolean
+  isAdminOrOwner: boolean
+}) {
   const version = agent.activeVersionNumber
 
-  if (agent.hasUnpublishedChanges) {
-    return (
-      <Alert variant='warning'>
-        <ShieldCheck className='size-4' />
-        <AlertTitle>Unpublished changes</AlertTitle>
-        <AlertDescription>
-          This policy applies to draft Chat and eval runs only.
-          {version ? ` Production runs version ${version}.` : ''}
-        </AlertDescription>
-      </Alert>
-    )
-  }
-
-  if (!agent.activeVersionId) {
-    return (
-      <Alert>
-        <ShieldCheck className='size-4' />
-        <AlertTitle>Not published yet</AlertTitle>
-        <AlertDescription>This policy applies to draft Chat and eval runs.</AlertDescription>
-      </Alert>
-    )
-  }
+  // Editing is OWNER/ADMIN-only (doc 14 §0.9), and the two ways to fail it have
+  // different fixes — an admin who does not administer *this* agent has someone
+  // to ask, a non-admin does not — so the glyph names which one applies.
+  const readOnlyReason = isAdminOrOwner
+    ? 'You do not administer this agent, so these are read-only. Ask someone with full access to this agent to change them.'
+    : 'Only an owner or admin can change these. The resolved policy is read-only.'
 
   return (
-    <p className='text-xs text-muted-foreground'>
-      Production runs version {version}&apos;s published policy.
-    </p>
+    <span className='inline-flex items-center gap-1'>
+      {agent.hasUnpublishedChanges ? (
+        <HeaderWarning
+          label={`Unpublished changes. This policy applies to draft Chat and eval runs only.${
+            version ? ` Production runs version ${version}.` : ''
+          }`}
+        />
+      ) : !agent.activeVersionId ? (
+        <span className='truncate'>Not published — draft Chat and eval runs only</span>
+      ) : (
+        <span className='truncate'>Production runs version {version}&apos;s published policy</span>
+      )}
+      {!canEdit && <HeaderWarning label={readOnlyReason} />}
+    </span>
   )
 }

--- a/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
@@ -214,10 +214,11 @@ export function TriggersSectionContent({
   }
 
   return (
-    <div className='space-y-4'>
+    <>
       {/* The picker has no inline trigger (it's opened from the section-header "Add trigger"
-          dropdown), so it anchors to a zero-height element at the top of the list and aligns
-          to the end — i.e. it floats just under the "Add trigger" button. */}
+          dropdown), so it anchors to a zero-height element above the list and aligns to the
+          end — i.e. it floats just under the "Add trigger" button. It sits outside the
+          spaced container so its anchor doesn't add a gap above the first row. */}
       <TriggerSourcePickerPopover
         open={isPickerOpen}
         onOpenChange={handlePickerOpenChange}
@@ -227,121 +228,123 @@ export function TriggersSectionContent({
         anchor={<div className='h-0 w-full' aria-hidden />}
       />
 
-      <AgentTriggerDialog
-        open={isDialogOpen}
-        onOpenChange={handleDialogOpenChange}
-        agentId={agent.id}
-        kind={dialogKind}
-        trigger={editingTrigger ?? undefined}
-        appSelection={appSelectionForDialog}
-        webhookSelection={webhookSelectionForDialog}
-        onSuccess={invalidateList}
-        onRepick={() => {
-          setEditingTrigger(null)
-          setCreatingBuiltinKind(null)
-          setPendingAppSelection(null)
-          setPendingWebhookSelection(null)
-          onAddingKindChange('source')
-        }}
-      />
+      <div className='space-y-4'>
+        <AgentTriggerDialog
+          open={isDialogOpen}
+          onOpenChange={handleDialogOpenChange}
+          agentId={agent.id}
+          kind={dialogKind}
+          trigger={editingTrigger ?? undefined}
+          appSelection={appSelectionForDialog}
+          webhookSelection={webhookSelectionForDialog}
+          onSuccess={invalidateList}
+          onRepick={() => {
+            setEditingTrigger(null)
+            setCreatingBuiltinKind(null)
+            setPendingAppSelection(null)
+            setPendingWebhookSelection(null)
+            onAddingKindChange('source')
+          }}
+        />
 
-      {triggers.isLoading ? (
-        <EmptySection loading className='mx-3' />
-      ) : (
-        <div className='flex flex-col pe-4'>
-          {BUILTIN_KINDS.map((kind) => {
-            const existing = builtinByKind[kind]
-            if (existing) {
+        {triggers.isLoading ? (
+          <EmptySection loading className='mx-3' />
+        ) : (
+          <div className='flex flex-col pe-4'>
+            {BUILTIN_KINDS.map((kind) => {
+              const existing = builtinByKind[kind]
+              if (existing) {
+                return (
+                  <TriggerRow
+                    key={existing.id}
+                    meta={KIND_META[kind]}
+                    title={<TriggerLabel row={existing} />}
+                    description={KIND_META[kind].description}
+                    lastFiredAt={existing.lastFiredAt}
+                    hasError={!!existing.lastError}
+                    enabled={existing.enabled}
+                    isEditable={canAdmin}
+                    isDeletable={false}
+                    readOnly={!canAdmin}
+                    onEdit={() => setEditingTrigger(existing)}
+                    onToggle={(checked) =>
+                      updateTrigger.mutate({ id: existing.id, enabled: checked })
+                    }
+                  />
+                )
+              }
               return (
                 <TriggerRow
-                  key={existing.id}
+                  key={`virtual-${kind}`}
                   meta={KIND_META[kind]}
-                  title={<TriggerLabel row={existing} />}
+                  title={<span className='text-muted-foreground'>On {kind}</span>}
                   description={KIND_META[kind].description}
-                  lastFiredAt={existing.lastFiredAt}
-                  hasError={!!existing.lastError}
-                  enabled={existing.enabled}
+                  lastFiredAt={null}
+                  hasError={false}
+                  enabled={false}
                   isEditable={canAdmin}
                   isDeletable={false}
                   readOnly={!canAdmin}
-                  onEdit={() => setEditingTrigger(existing)}
-                  onToggle={(checked) =>
-                    updateTrigger.mutate({ id: existing.id, enabled: checked })
-                  }
+                  onEdit={() => setCreatingBuiltinKind(kind)}
+                  onToggle={(checked) => {
+                    if (!checked) return
+                    createTrigger.mutate({
+                      agentId: agent.id,
+                      enabled: true,
+                      trigger: { kind },
+                    })
+                  }}
                 />
               )
-            }
-            return (
-              <TriggerRow
-                key={`virtual-${kind}`}
-                meta={KIND_META[kind]}
-                title={<span className='text-muted-foreground'>On {kind}</span>}
-                description={KIND_META[kind].description}
-                lastFiredAt={null}
-                hasError={false}
-                enabled={false}
-                isEditable={canAdmin}
-                isDeletable={false}
-                readOnly={!canAdmin}
-                onEdit={() => setCreatingBuiltinKind(kind)}
-                onToggle={(checked) => {
-                  if (!checked) return
-                  createTrigger.mutate({
-                    agentId: agent.id,
-                    enabled: true,
-                    trigger: { kind },
-                  })
-                }}
-              />
-            )
-          })}
+            })}
 
-          {customRows.map((row) => {
-            const meta = KIND_META[row.kind as TriggerKind]
-            const isDirectEventRow =
-              row.kind === 'event' && !row.entityDefinitionId && !!row.eventType
-            const isEditable = !isDirectEventRow
+            {customRows.map((row) => {
+              const meta = KIND_META[row.kind as TriggerKind]
+              const isDirectEventRow =
+                row.kind === 'event' && !row.entityDefinitionId && !!row.eventType
+              const isEditable = !isDirectEventRow
 
-            let iconOverride: ReactNode | undefined
-            if (row.kind === 'app' && row.triggerAppId) {
-              const installation =
-                appInstallations.find((i) => i.installationId === row.triggerInstallationId) ??
-                appInstallations.find((i) => i.app.id === row.triggerAppId)
-              const avatarUrl = installation?.app.avatarUrl
-              if (avatarUrl) {
-                iconOverride = (
-                  <Tooltip content={installation?.app.title ?? meta.label}>
-                    <span className='inline-flex'>
-                      <AppIcon iconId={avatarUrl} size='sm' />
-                    </span>
-                  </Tooltip>
-                )
+              let iconOverride: ReactNode | undefined
+              if (row.kind === 'app' && row.triggerAppId) {
+                const installation =
+                  appInstallations.find((i) => i.installationId === row.triggerInstallationId) ??
+                  appInstallations.find((i) => i.app.id === row.triggerAppId)
+                const avatarUrl = installation?.app.avatarUrl
+                if (avatarUrl) {
+                  iconOverride = (
+                    <Tooltip content={installation?.app.title ?? meta.label}>
+                      <span className='inline-flex'>
+                        <AppIcon iconId={avatarUrl} size='sm' />
+                      </span>
+                    </Tooltip>
+                  )
+                }
               }
-            }
 
-            return (
-              <TriggerRow
-                key={row.id}
-                meta={meta}
-                icon={iconOverride}
-                title={<TriggerLabel row={row} />}
-                lastFiredAt={row.lastFiredAt}
-                hasError={!!row.lastError}
-                enabled={row.enabled}
-                isEditable={canAdmin && isEditable}
-                isDeletable={canAdmin}
-                readOnly={!canAdmin}
-                onEdit={() => setEditingTrigger(row)}
-                onDelete={() => handleDelete(row)}
-                onToggle={(checked) => updateTrigger.mutate({ id: row.id, enabled: checked })}
-              />
-            )
-          })}
-        </div>
-      )}
+              return (
+                <TriggerRow
+                  key={row.id}
+                  meta={meta}
+                  icon={iconOverride}
+                  title={<TriggerLabel row={row} />}
+                  lastFiredAt={row.lastFiredAt}
+                  hasError={!!row.lastError}
+                  enabled={row.enabled}
+                  isEditable={canAdmin && isEditable}
+                  isDeletable={canAdmin}
+                  readOnly={!canAdmin}
+                  onEdit={() => setEditingTrigger(row)}
+                  onDelete={() => handleDelete(row)}
+                  onToggle={(checked) => updateTrigger.mutate({ id: row.id, enabled: checked })}
+                />
+              )
+            })}
+          </div>
+        )}
 
-      <ConfirmDialog />
-    </div>
+        <ConfirmDialog />
+      </div>
+    </>
   )
 }
 

--- a/apps/web/src/components/pickers/index.ts
+++ b/apps/web/src/components/pickers/index.ts
@@ -36,6 +36,7 @@ export type {
   ProfilePickerProps,
 } from './profile-picker'
 export {
+  MANAGE_PROFILES_HREF,
   ProfileCommandBody,
   ProfileGlyph,
   ProfileItem,

--- a/apps/web/src/components/pickers/profile-picker/index.ts
+++ b/apps/web/src/components/pickers/profile-picker/index.ts
@@ -2,7 +2,11 @@
 
 export { ProfileGlyph, ProfileItem } from './profile-item'
 export { ProfilePicker } from './profile-picker'
-export { ProfileCommandBody, ProfilePickerContent } from './profile-picker-content'
+export {
+  MANAGE_PROFILES_HREF,
+  ProfileCommandBody,
+  ProfilePickerContent,
+} from './profile-picker-content'
 export type {
   PickerProfile,
   ProfilePickerContentProps,

--- a/apps/web/src/components/pickers/profile-picker/profile-picker-content.tsx
+++ b/apps/web/src/components/pickers/profile-picker/profile-picker-content.tsx
@@ -4,16 +4,22 @@
 
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
+  CommandItem,
   CommandList,
+  CommandPlaceholder,
   CommandSeparator,
 } from '@auxx/ui/components/command'
 import { cn } from '@auxx/ui/lib/utils'
+import { Settings2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ProfileItem } from './profile-item'
 import type { ProfilePickerContentProps } from './types'
+
+/** Where profiles are authored — the one destination every picker points at. */
+export const MANAGE_PROFILES_HREF = '/app/settings/permissions'
 
 /**
  * ProfilePickerContent — the searchable permission-profile list, wrapped in its
@@ -47,10 +53,13 @@ export function ProfileCommandBody({
   placeholder = 'Search profiles...',
   isLoading = false,
   showSeat = false,
+  showManage = true,
+  onManage,
   onSelectSingle,
   onCaptureChange,
 }: Omit<ProfilePickerContentProps, 'className'>) {
   const [search, setSearch] = useState('')
+  const router = useRouter()
 
   // Notify parent about capture state on mount/unmount
   useEffect(() => {
@@ -86,10 +95,20 @@ export function ProfileCommandBody({
     [onChange, onSelectSingle]
   )
 
+  const handleManage = useCallback(() => {
+    // The wrapper closes first so the popover is gone before the route changes.
+    onManage?.()
+    router.push(MANAGE_PROFILES_HREF)
+  }, [onManage, router])
+
   const hasSystemSection = grouped.system.length > 0
   const hasCustomSection = grouped.custom.length > 0
   // Headings only earn their space when both groups are on screen.
   const showGroupHeadings = hasSystemSection && hasCustomSection
+  // `CommandEmpty` counts every rendered item, so the always-present Manage row
+  // would keep it from ever firing. The list is filtered here anyway, so the
+  // empty state is stated outright instead of inferred.
+  const isEmpty = !hasSystemSection && !hasCustomSection
 
   return (
     <>
@@ -102,7 +121,11 @@ export function ProfileCommandBody({
         autoFocus
       />
       <CommandList>
-        <CommandEmpty>{isLoading ? 'Loading profiles...' : 'No profiles found'}</CommandEmpty>
+        {isEmpty && (
+          <CommandPlaceholder>
+            {isLoading ? 'Loading profiles...' : 'No profiles found'}
+          </CommandPlaceholder>
+        )}
 
         {hasSystemSection && (
           <CommandGroup
@@ -136,6 +159,18 @@ export function ProfileCommandBody({
               />
             ))}
           </CommandGroup>
+        )}
+
+        {showManage && (
+          <>
+            {!isEmpty && <CommandSeparator />}
+            <CommandGroup aria-label='Profile settings'>
+              <CommandItem value='__manage__' onSelect={handleManage}>
+                <Settings2 className='size-4 text-muted-foreground' />
+                <span>Manage profiles</span>
+              </CommandItem>
+            </CommandGroup>
+          </>
         )}
       </CommandList>
     </>

--- a/apps/web/src/components/pickers/profile-picker/profile-picker.tsx
+++ b/apps/web/src/components/pickers/profile-picker/profile-picker.tsx
@@ -128,6 +128,7 @@ export function ProfilePicker({
           onChange={onChange}
           options={options}
           onSelectSingle={handleSelectSingle}
+          onManage={() => handleOpenChange(false)}
           disabled={disabled}
           {...pickerProps}
         />

--- a/apps/web/src/components/pickers/profile-picker/types.ts
+++ b/apps/web/src/components/pickers/profile-picker/types.ts
@@ -53,6 +53,19 @@ export interface ProfilePickerContentProps {
   /** Show each profile's seat class inline on its row (member surfaces). */
   showSeat?: boolean
 
+  /**
+   * Show the pinned "Manage profiles" row that navigates to the permissions
+   * settings page. Default true — authoring a profile is the natural next step
+   * from a picker that has none that fit.
+   */
+  showManage?: boolean
+
+  /**
+   * Called just before "Manage profiles" navigates, so a popover wrapper can
+   * close itself. The navigation itself is the picker's own.
+   */
+  onManage?: () => void
+
   /** Called after a pick, so a popover wrapper can close itself. */
   onSelectSingle?: (profileId: string) => void
 
@@ -67,7 +80,10 @@ export interface ProfilePickerContentProps {
  * Props for ProfilePicker — the popover wrapper around ProfilePickerContent.
  */
 export interface ProfilePickerProps
-  extends Omit<ProfilePickerContentProps, 'onCaptureChange' | 'className' | 'onSelectSingle'> {
+  extends Omit<
+    ProfilePickerContentProps,
+    'onCaptureChange' | 'className' | 'onSelectSingle' | 'onManage'
+  > {
   /** Custom trigger element (if not provided, uses the default PickerTrigger) */
   children?: React.ReactNode
 

--- a/packages/ui/src/components/section.tsx
+++ b/packages/ui/src/components/section.tsx
@@ -23,6 +23,11 @@ export interface SectionProps {
   titleClassName?: string
   /** Custom className for the CollapsibleContent wrapper */
   description?: string
+  /**
+   * Secondary text rendered to the right of the description — same slot as
+   * `TreeRow`'s `secondary` (muted, truncating, not uppercased).
+   */
+  secondary?: React.ReactNode
   isRequired?: boolean
   children?: React.ReactNode
   actions?: React.ReactNode
@@ -59,6 +64,7 @@ export function Section({
   title,
   titleClassName,
   description,
+  secondary,
   isRequired = false,
   children,
   showEnable = false,
@@ -114,10 +120,13 @@ export function Section({
         data-slot='section'
         className={cn('p-3 pb-4 group-data-[state=closed]:pb-0 border-b flex flex-col min-h-0')}>
         <div className={cn('flex items-center justify-between pb-2')}>
-          <div className='flex items-center gap-1'>
+          <div className='flex min-w-0 items-center gap-1'>
             <div
               data-slot='section-title'
-              className={cn(titleClassName, 'flex items-center text-xs font-medium uppercase')}>
+              className={cn(
+                titleClassName,
+                'flex min-w-0 items-center text-xs font-medium uppercase'
+              )}>
               {icon && <span className='mr-1'>{icon}</span>}
               <CollapsibleTrigger
                 disabled={!showCollapseTrigger}
@@ -126,7 +135,14 @@ export function Section({
               </CollapsibleTrigger>
               {isRequired && <span className='mr-1 text-xs font-semibold text-[#D92D20]'>*</span>}
               {description && (
-                <TooltipExplanation text={description} className='text-primary-400' />
+                <TooltipExplanation text={description} className='text-primary-400 shrink-0' />
+              )}
+              {secondary && (
+                <span
+                  data-slot='section-secondary'
+                  className='ml-1 min-w-0 truncate font-normal text-primary-400 normal-case'>
+                  {secondary}
+                </span>
               )}
             </div>
             <CollapsibleTrigger


### PR DESCRIPTION
Follow-up to #1360.

## Agent Permissions tab

The tab opened onto two stacked alert banners before reaching any control they qualified:

**Before**
```
🔒 PERMISSIONS (?)                                    [?]
  ┌─ Alert ─────────────────────────────────┐
  │ 🛡 Unpublished changes                   │
  │   Applies to draft Chat and eval runs…  │
  └──────────────────────────────────────────┘
  ┌─ Alert ─────────────────────────────────┐
  │ 🛡 You do not administer this agent…     │
  └──────────────────────────────────────────┘
  ▸ Access
    The profile this draft resolves its policy from, and who it runs as.
    ┌─ FieldPanel ─────────────────────────┐
    │ Profile │ Run as                     │
    └──────────────────────────────────────┘
  ▸ Resolved policy            [View resolved policy]
    Areas Full · Record types Full · Resources Full
```

**After**
```
🔒 PERMISSIONS (?)  Production runs version 1's published policy  ⚠   [?]

  ┌─ FieldPanel ──────────────────────────────────────┐
  │ 🛡 Profile          [ Agent · default for internal ] │
  │ 👤 Run as           [ Own permissions (default)   ] │
  │ 📜 Resolved policy  [ View resolved policy ]        │
  └────────────────────────────────────────────────────┘
  Runs fail if Jane is deactivated or removed.
  A call needs both: the tool enabled, and this policy allowing its target.  [🔧 Go to Tools]
```

- **Both notices moved to the header** on `Section`'s new `secondary` slot. Each is a state of the whole tab and neither is actionable there — publishing lives in the hero, a read-only reader has nothing to click — so they were banners the eye had to clear to reach the controls they described. Now an amber glyph carrying the message in its tooltip, with `aria-label` set to the same string so the reason reads without a hover (a tooltip alone states it only to a mouse). The read-only glyph still distinguishes "you don't administer this agent" from "you're not an admin" — different fixes.
- **The "Access" `SettingsSection` wrapper is gone.** The `FieldPanel` sits directly under the Permissions section; its title and description only restated what the rows say.
- **Resolved policy is a third `FieldPanelRow`** holding just the dialog button. `AgentPolicySummary` is no longer rendered — three rows reading "Full" restated the profile name without saying *which* records or *which* tools, which is exactly the dialog's job. The component stays exported in `agent-policy-view.tsx` rather than being deleted.
- **`space-y-6` → `space-y-4`**, and the "A call needs both…" line moved directly under the "Runs fail if…" paragraph.
- **`pe-1` on the tab content.** The root `ScrollArea` bar is `w-1.5`, but `scroll-area.tsx:120` gives it a `before:w-5` invisible hit strip — that was sitting over the `FieldPanel`'s right edge and over `FieldPanelRow`'s `-right-2` clear button. `pe-1` on top of `Section`'s `p-3` lands the content at 16px, the same inset Tools reaches via `-mx-3` + `pe-4`.

## Profile picker

"Edit in Settings" is replaced by a pinned **Manage profiles** row in the list itself, routing to `/app/settings/permissions` (exported as `MANAGE_PROFILES_HREF`). The popover closes before navigating, matching `ai-model-picker`'s settings jump. Opt out with `showManage={false}`.

That row is always rendered, which would have kept `CommandEmpty` — which counts every rendered item — from ever firing, so the empty state moved to `CommandPlaceholder` driven off the already-computed filter result.

## `packages/ui` — `Section.secondary`

New `ReactNode` slot rendered right of the description, styled like `TreeRow`'s `secondary` (muted, truncating, not uppercased). Also adds `min-w-0` to the title row and `shrink-0` to the description's help icon, so a long secondary truncates instead of pushing the collapse chevron out of the header.

## Bundled on request (unrelated)

- **`audit-table.tsx`** — the table now carries a `min-w` (1240px for admins, 1040px otherwise) and scrolls horizontally instead of collapsing the Target column; the `flex-1` cells that never worked inside `table-fixed` are replaced with a `min-w`, and the timestamp gets `whitespace-nowrap` + a `shrink-0` badge so it stops wrapping.
- **`triggers-section-content.tsx`** — the zero-height picker anchor moves outside the `space-y-4` container, so it stops contributing a gap above the first trigger row.

## Verification

- `apps/web` typecheck: zero errors in every touched file
- Biome clean
- `vitest run src/components/{agents,members,permissions}` → **127 passed**. `agent-instance-access.test.tsx` switched from `getByText` to `getByLabelText` for the two read-only assertions, since the reason now lives on the glyph's accessible name rather than in rendered body text.