### PR TITLE
fix(permissions): scope the attachment preview to its owning resource

### DIFF
--- a/apps/web/src/components/attachments/attachment-preview.tsx
+++ b/apps/web/src/components/attachments/attachment-preview.tsx
@@ -37,6 +37,13 @@ interface AttachmentPreviewProps {
   knownMimeType?: string
   /** Filename — used for display in the fallback state */
   filename?: string
+  /**
+   * Which resource authorizes the preview. Defaults to the Files app being the
+   * authority (`FeatureKey.files` + `filesView`). Pass `datasetDocument` when the
+   * asset belongs to a dataset document so it authorizes against the parent
+   * dataset instead — a member scoped to datasets need not hold `files` access.
+   */
+  scope?: { kind: 'files' } | { kind: 'datasetDocument'; documentId: string }
 }
 
 /**
@@ -54,6 +61,7 @@ export function AttachmentPreview({
   height = 300,
   knownMimeType,
   filename: filenameProp,
+  scope = { kind: 'files' },
 }: AttachmentPreviewProps) {
   const isPreviewable = knownMimeType ? canPreviewInline(knownMimeType) : true
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
@@ -77,6 +85,7 @@ export function AttachmentPreview({
       id,
       version,
       disposition: 'inline',
+      scope,
     },
     {
       enabled: Boolean(id) && isPreviewable,
@@ -183,7 +192,7 @@ export function AttachmentPreview({
   // On-demand download query for non-previewable files
   const { refetch: fetchDownloadRef, isFetching: isDownloading } =
     api.file.getAttachmentPreviewRef.useQuery(
-      { type, id, version, disposition: 'attachment' },
+      { type, id, version, disposition: 'attachment', scope },
       { enabled: false }
     )
 

--- a/apps/web/src/components/datasets/documents/document-detail-drawer.tsx
+++ b/apps/web/src/components/datasets/documents/document-detail-drawer.tsx
@@ -394,6 +394,7 @@ export function DocumentDetailDrawer({
                     interactive
                     knownMimeType={displayDocument.mimeType ?? undefined}
                     filename={displayDocument.title || displayDocument.filename || undefined}
+                    scope={{ kind: 'datasetDocument', documentId: displayDocument.id }}
                   />
                 ) : (
                   <div className='flex flex-col items-center justify-center h-64 text-center'>

--- a/apps/web/src/server/api/routers/file-attachment-permission.test.ts
+++ b/apps/web/src/server/api/routers/file-attachment-permission.test.ts
@@ -9,16 +9,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * (`file-download-permission.test.ts`).
  *
  * - `getAttachmentPreviewRef` returned a LIVE presigned download ref for any
- *   `FolderFile` or `MediaAsset` id in the org. Fixed here: it now sits behind
- *   `permissionProcedure(PermissionKey.filesView)` like its eight siblings.
+ *   `FolderFile` or `MediaAsset` id in the org. Gated here — but per SCOPE, not
+ *   on one key: the Files drawer keeps `FeatureKey.files` + `filesView`, while
+ *   the dataset document drawer authorizes against its parent dataset. A single
+ *   `filesView` gate blocked no content (`document.getDownloadUrl` resolves the
+ *   same bytes behind `assertViewInstance('dataset', …)`) and only broke the
+ *   preview pane for a member scoped to datasets with `files` below Read.
  * - `resolveFileRefs` returns name/mimeType/size for any org file/asset id and
  *   is deliberately STILL open — see the last block for why.
  *
- * Behavioral: the real `permissionProcedure` middleware runs, with the real
- * `PERMISSION_REGISTRY_MAP` deciding whether the plan gate fires and a real
- * `CapabilitySet.assert` doing the check. Only the DB-backed capability fetch
- * and the plan lookup are stubbed. The file-service calls are the observed side
- * effect: the gate must land ahead of them.
+ * Behavioral: real middleware, real `PERMISSION_REGISTRY_MAP`, and a real
+ * `CapabilitySet` doing every check. Only the DB-backed capability fetch and the
+ * plan lookup are stubbed. The file-service calls are the observed side effect:
+ * the gate must land ahead of them.
  */
 
 const {
@@ -86,6 +89,12 @@ vi.mock('@auxx/database', () => ({
       organizationId: 'FolderFile.organizationId',
       deletedAt: 'FolderFile.deletedAt',
     },
+    Document: {
+      id: 'Document.id',
+      datasetId: 'Document.datasetId',
+      mediaAssetId: 'Document.mediaAssetId',
+      organizationId: 'Document.organizationId',
+    },
   },
 }))
 
@@ -112,6 +121,7 @@ vi.mock('@auxx/logger', () => ({
 
 // Deep path on purpose — the barrel hangs (see above).
 const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { ResourcePermission } = await import('@auxx/database/enums')
 const { ForbiddenError } = await import('@auxx/lib/errors')
 const { createCallerFactory } = await import('~/server/api/trpc')
 const { fileRouter } = await import('./file')
@@ -120,12 +130,35 @@ const ORG_ID = 'org_cuid000000000000000000000'
 const USER_ID = 'usr_cuid000000000000000000000'
 const FILE_ID = 'fil_cuid000000000000000000000'
 const ASSET_ID = 'ast_cuid000000000000000000000'
+const DOC_ID = 'doc_cuid000000000000000000000'
+const DATASET_ID = 'dst_cuid000000000000000000000'
 
 const createCaller = createCallerFactory(fileRouter)
 
 /** A real `CapabilitySet` composing the Files area at `level`. */
 function capabilitiesAt(level: Level) {
   return new CapabilitySet(new Set(expandLevelsToKeys({ [Area.files]: level })), {}, 'USER', 'full')
+}
+
+/**
+ * Member 1 from the repro: scoped to datasets, with Files deliberately closed.
+ * `dataset` is `baselineAtCreate: false`, so with no explicit row the area level
+ * IS the per-instance answer — `datasets: Read` ⇒ `view` on every dataset.
+ * Pass `restrictedDatasetId` to add the explicit `none` row that denies one.
+ */
+function datasetScopedCapabilities(datasets: Level, opts: { restrictedDatasetId?: string } = {}) {
+  const restricted = opts.restrictedDatasetId
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.datasets]: datasets, [Area.files]: Level.None })),
+    {},
+    'USER',
+    'full',
+    (id) => id,
+    new Set(),
+    (id) => id,
+    restricted ? { [restricted]: ResourcePermission.none } : {},
+    restricted ? new Set([restricted]) : new Set()
+  )
 }
 
 /** A caller for a signed-in member holding `capabilities`. */
@@ -160,7 +193,17 @@ beforeEach(() => {
     getDownloadRefForVersion: getAssetDownloadRef,
   })
   dbWhere.mockReset().mockResolvedValue([])
-  dbSelect.mockReset().mockReturnValue({ from: () => ({ where: dbWhere }) })
+  // `where()` is awaited directly by `resolveFileRefs` and `.limit(1)`-chained by
+  // `assertDatasetDocumentAssetAccess`, so the fake must be both thenable and
+  // chainable off the same call.
+  dbSelect.mockReset().mockReturnValue({
+    from: () => ({
+      where: (...args: unknown[]) => {
+        const rows = dbWhere(...args)
+        return Object.assign(rows, { limit: () => rows })
+      },
+    }),
+  })
 })
 
 /** Neither backing service may be constructed for a denied caller. */
@@ -188,16 +231,18 @@ describe('file.getAttachmentPreviewRef — the live-download-ref hole', () => {
     expectNoFileReads()
   })
 
-  it('FORBIDDENs when the org plan lacks the files feature, before capabilities', async () => {
-    // `PermissionKey.filesView` links `FeatureKey.files`, so the plan-AND runs
-    // first — the same order `requirePermission` uses on the REST route.
+  it('FORBIDDENs when the org plan lacks the files feature, before the service call', async () => {
+    // The plan-AND survives the move off `permissionProcedure`: the `files` scope
+    // runs `FeatureKey.files` by hand, exactly as the middleware did. Ordering vs
+    // `getCapabilities` DID change — `capabilityProcedure` composes capabilities
+    // in middleware, so that cached read now happens first. Nothing is authorized
+    // by it; the assertion that matters is that no file is read.
     const caller = callerFor(capabilitiesAt(Level.Full))
     planGate.mockRejectedValue(new ForbiddenError('Files is not available on your plan.'))
     await expect(
       caller.getAttachmentPreviewRef({ type: 'file', id: FILE_ID })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' })
     expect(planGate).toHaveBeenCalledWith(ORG_ID, 'files')
-    expect(getCapabilities).not.toHaveBeenCalled()
     expectNoFileReads()
   })
 
@@ -238,6 +283,141 @@ describe('file.getAttachmentPreviewRef — the live-download-ref hole', () => {
       caller.getAttachmentPreviewRef({ type: 'file', id: FILE_ID })
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
     expect(getCapabilities).not.toHaveBeenCalled()
+    expectNoFileReads()
+  })
+})
+
+describe('file.getAttachmentPreviewRef — the `datasetDocument` scope', () => {
+  /** The document row `assertDatasetDocumentAssetAccess` resolves. */
+  function documentRow(overrides: Record<string, unknown> = {}) {
+    return [{ datasetId: DATASET_ID, mediaAssetId: ASSET_ID, ...overrides }]
+  }
+
+  it('serves a dataset-scoped member who holds NO files access — the repro', async () => {
+    // Member 1: dataset access, `files` below Read. Under the old single
+    // `filesView` gate this 403'd while `document.getDownloadUrl` served the
+    // same bytes to the same member.
+    const caller = callerFor(datasetScopedCapabilities(Level.Read))
+    dbWhere.mockResolvedValue(documentRow())
+    const result = await caller.getAttachmentPreviewRef({
+      type: 'asset',
+      id: ASSET_ID,
+      scope: { kind: 'datasetDocument', documentId: DOC_ID },
+    })
+    expect(result).toMatchObject({ filename: 'logo.png' })
+    expect(getAssetDownloadRef).toHaveBeenCalledWith(ASSET_ID, {
+      version: 'current',
+      disposition: 'inline',
+    })
+  })
+
+  it('does NOT run the files plan gate on the dataset branch', async () => {
+    // Matches `routers/document.ts`, which is `capabilityProcedure` throughout —
+    // a dataset document must not be gated on the Files feature.
+    const caller = callerFor(datasetScopedCapabilities(Level.Read))
+    planGate.mockRejectedValue(new ForbiddenError('Files is not available on your plan.'))
+    dbWhere.mockResolvedValue(documentRow())
+    await expect(
+      caller.getAttachmentPreviewRef({
+        type: 'asset',
+        id: ASSET_ID,
+        scope: { kind: 'datasetDocument', documentId: DOC_ID },
+      })
+    ).resolves.toMatchObject({ filename: 'logo.png' })
+    expect(planGate).not.toHaveBeenCalled()
+  })
+
+  it('FORBIDDENs a member with an explicit `none` row on the parent dataset', async () => {
+    const caller = callerFor(
+      datasetScopedCapabilities(Level.Read, { restrictedDatasetId: DATASET_ID })
+    )
+    dbWhere.mockResolvedValue(documentRow())
+    await expect(
+      caller.getAttachmentPreviewRef({
+        type: 'asset',
+        id: ASSET_ID,
+        scope: { kind: 'datasetDocument', documentId: DOC_ID },
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expectNoFileReads()
+  })
+
+  it('FORBIDDENs a member composing `datasets: None`', async () => {
+    const caller = callerFor(datasetScopedCapabilities(Level.None))
+    dbWhere.mockResolvedValue(documentRow())
+    await expect(
+      caller.getAttachmentPreviewRef({
+        type: 'asset',
+        id: ASSET_ID,
+        scope: { kind: 'datasetDocument', documentId: DOC_ID },
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expectNoFileReads()
+  })
+
+  it('NOT_FOUNDs a document id that is missing or in another org', async () => {
+    // Resolution 404s before any capability is read, so a foreign-org id is
+    // indistinguishable from one this member merely cannot see.
+    const caller = callerFor(datasetScopedCapabilities(Level.Read))
+    dbWhere.mockResolvedValue([])
+    await expect(
+      caller.getAttachmentPreviewRef({
+        type: 'asset',
+        id: ASSET_ID,
+        scope: { kind: 'datasetDocument', documentId: DOC_ID },
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expectNoFileReads()
+  })
+
+  it('refuses an asset the named document does not own — the confused deputy', async () => {
+    // THE check that makes the scope safe. Without it, view on any one dataset
+    // would launder into a presigned URL for any asset in the org.
+    const caller = callerFor(datasetScopedCapabilities(Level.Read))
+    dbWhere.mockResolvedValue(documentRow({ mediaAssetId: 'ast_someone_elses_asset' }))
+    await expect(
+      caller.getAttachmentPreviewRef({
+        type: 'asset',
+        id: ASSET_ID,
+        scope: { kind: 'datasetDocument', documentId: DOC_ID },
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expectNoFileReads()
+  })
+
+  it('refuses a document that has no media asset at all', async () => {
+    const caller = callerFor(datasetScopedCapabilities(Level.Read))
+    dbWhere.mockResolvedValue(documentRow({ mediaAssetId: null }))
+    await expect(
+      caller.getAttachmentPreviewRef({
+        type: 'asset',
+        id: ASSET_ID,
+        scope: { kind: 'datasetDocument', documentId: DOC_ID },
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expectNoFileReads()
+  })
+
+  it('BAD_REQUESTs the `file` type under a dataset scope', async () => {
+    // Dataset documents are asset-backed; a `FolderFile` id under this scope
+    // would skip the ownership check entirely.
+    const caller = callerFor(datasetScopedCapabilities(Level.Read))
+    await expect(
+      caller.getAttachmentPreviewRef({
+        type: 'file',
+        id: FILE_ID,
+        scope: { kind: 'datasetDocument', documentId: DOC_ID },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expectNoFileReads()
+  })
+
+  it('defaults to the `files` scope when none is passed', async () => {
+    // The Files drawer passes no scope, so the default must keep its old gate.
+    const caller = callerFor(datasetScopedCapabilities(Level.Read))
+    await expect(
+      caller.getAttachmentPreviewRef({ type: 'asset', id: ASSET_ID })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
     expectNoFileReads()
   })
 })

--- a/apps/web/src/server/api/routers/file.ts
+++ b/apps/web/src/server/api/routers/file.ts
@@ -6,12 +6,18 @@ import {
   createFilesystemService,
   createMediaAssetService,
 } from '@auxx/lib/files'
-import { PermissionKey } from '@auxx/lib/permissions'
+import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, permissionProcedure, protectedProcedure } from '~/server/api/trpc'
+import {
+  capabilityProcedure,
+  createTRPCRouter,
+  permissionProcedure,
+  protectedProcedure,
+} from '~/server/api/trpc'
+import { assertDatasetDocumentAssetAccess } from '~/server/lib/dataset-document-asset-access'
 
 const logger = createScopedLogger('api/file')
 
@@ -106,11 +112,29 @@ const getFileSystemSchema = z.object({
   lastSync: z.date().optional(),
 })
 
+/**
+ * Which resource authorizes an attachment preview.
+ *
+ * `files` (the default) — the Files app is the authority, so the request runs
+ * the `FeatureKey.files` plan gate plus `filesView`, i.e. exactly what
+ * `permissionProcedure(PermissionKey.filesView)` used to run for every caller.
+ *
+ * `datasetDocument` — the asset belongs to a dataset document, which is dataset
+ * content and authorizes against the parent dataset instead. See
+ * `assertDatasetDocumentAssetAccess` for why, and for the check that stops the
+ * scope from being claimed over an unrelated asset.
+ */
+const attachmentPreviewScopeSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('files') }),
+  z.object({ kind: z.literal('datasetDocument'), documentId: z.string() }),
+])
+
 const getAttachmentPreviewRefSchema = z.object({
   type: z.enum(['file', 'asset']),
   id: z.string(),
   version: z.union([z.literal('current'), z.literal('latest'), z.number()]).default('current'),
   disposition: z.enum(['inline', 'attachment']).default('inline'),
+  scope: attachmentPreviewScopeSchema.default({ kind: 'files' }),
 })
 
 export const fileRouter = createTRPCRouter({
@@ -372,24 +396,46 @@ export const fileRouter = createTRPCRouter({
   /**
    * Get preview download reference for attachment (files or assets).
    *
-   * `filesView`, matching every other read on this router: the returned ref is a
-   * live, presigned download URL for any `FolderFile` or `MediaAsset` in the org,
-   * resolved by id with no ownership or folder check — as a bare
-   * `protectedProcedure` it made the `filesView` gate on `getDownloadInfo` (the
-   * same read, one procedure over) decorative.
+   * The returned ref is a live, presigned download URL for any `FolderFile` or
+   * `MediaAsset` in the org, resolved by id with no ownership or folder check, so
+   * it must be authorized — as a bare `protectedProcedure` it made the `filesView`
+   * gate on `getDownloadInfo` (the same read, one procedure over) decorative.
    *
-   * Both UI callers are covered by the key: the Files detail drawer (Files is the
-   * authority) and the dataset document drawer, which is reachable only by a
-   * member holding `datasets: Read` — and the member baseline ships `files: Full`
-   * (`seat-policy.ts` `MEMBER_BASELINE_LEVELS`), while a worker seat has
-   * `datasets: None` and cannot open that drawer at all. So no principal loses a
-   * surface here except a member whose admin *deliberately* set `files` below
-   * `Read`.
+   * Authorization is per `input.scope`, because the two callers are owned by
+   * different resources. The Files detail drawer keeps `FeatureKey.files` +
+   * `filesView`; the dataset document drawer authorizes against its parent
+   * dataset, matching `document.getDownloadUrl`, which already resolves the same
+   * bytes for the same principal. A single `permissionProcedure(filesView)` here
+   * meant a member scoped to a dataset with `files` below Read could download a
+   * document but not preview it — the gate blocked no content, it only broke the
+   * pane. No plan gate on the dataset branch, matching every procedure in
+   * `routers/document.ts`, which is `capabilityProcedure` throughout.
+   *
+   * The gates run BEFORE the try/catch below on purpose: that catch rewrites
+   * anything that is not a `TRPCError` into a 400, which would flatten a denial
+   * into `BAD_REQUEST` instead of 403/404.
    */
-  getAttachmentPreviewRef: permissionProcedure(PermissionKey.filesView)
+  getAttachmentPreviewRef: capabilityProcedure
     .input(getAttachmentPreviewRefSchema)
     .query(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
+
+      if (input.scope.kind === 'datasetDocument') {
+        if (input.type !== 'asset') {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Dataset documents are backed by media assets',
+          })
+        }
+        await assertDatasetDocumentAssetAccess(ctx.db, ctx.capabilities, {
+          documentId: input.scope.documentId,
+          assetId: input.id,
+          organizationId,
+        })
+      } else {
+        await new FeaturePermissionService().requireAccess(organizationId, FeatureKey.files)
+        ctx.capabilities.assert(PermissionKey.filesView)
+      }
 
       try {
         if (input.type === 'file') {

--- a/apps/web/src/server/lib/dataset-document-asset-access.ts
+++ b/apps/web/src/server/lib/dataset-document-asset-access.ts
@@ -1,0 +1,53 @@
+// apps/web/src/server/lib/dataset-document-asset-access.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { NotFoundError } from '@auxx/lib/errors'
+import type { CapabilitySet } from '@auxx/lib/permissions/capabilities/capability-set'
+import { and, eq } from 'drizzle-orm'
+
+/**
+ * Authorize a read of the `MediaAsset` backing a dataset document.
+ *
+ * A dataset document's asset is DATASET content, so it authorizes against
+ * `canViewInstance('dataset', …)` — the same predicate `document.getDownloadUrl`
+ * already applies to the same bytes — and never against `Area.files`. Gating it
+ * on `filesView` made dataset access non-self-sufficient: a member scoped to one
+ * dataset with `files` below Read could download the document through
+ * `document.getDownloadUrl` but got a blank preview pane, so the Files gate
+ * enforced no boundary and only broke the UI.
+ *
+ * The `assetId` equality check is load-bearing. Without it the scope is a
+ * confused deputy: a caller holding view on any one dataset could name a
+ * document in that dataset while requesting an unrelated asset elsewhere in the
+ * org, and inherit the dataset's authorization for it.
+ *
+ * Resolution order matches `datasetIdForDocument` in `routers/document.ts`: a
+ * missing or foreign-org document 404s before any capability is read.
+ */
+export async function assertDatasetDocumentAssetAccess(
+  db: Database,
+  capabilities: CapabilitySet,
+  params: { documentId: string; assetId: string; organizationId: string }
+): Promise<void> {
+  const { documentId, assetId, organizationId } = params
+
+  const [row] = await db
+    .select({
+      datasetId: schema.Document.datasetId,
+      mediaAssetId: schema.Document.mediaAssetId,
+    })
+    .from(schema.Document)
+    .where(
+      and(eq(schema.Document.id, documentId), eq(schema.Document.organizationId, organizationId))
+    )
+    .limit(1)
+
+  if (!row) throw new NotFoundError('Document not found')
+
+  capabilities.assertViewInstance('dataset', row.datasetId)
+
+  if (!row.mediaAssetId || row.mediaAssetId !== assetId) {
+    throw new NotFoundError('Document asset not found')
+  }
+}


### PR DESCRIPTION
## The bug

A member with dataset instance access and `files` below Read opened a dataset document and got a blank preview pane.

`file.getAttachmentPreviewRef` was `permissionProcedure(PermissionKey.filesView)`, so it authorized every caller against the Files area. But `document.getDownloadUrl` resolves the **same bytes** for the **same principal** behind `assertViewInstance('dataset', datasetId)` — so the member could download the document and not preview it. The gate blocked no content; it only broke the UI.

The `getAttachmentPreviewRef` doc comment called this case and waved it off — "no principal loses a surface here except a member whose admin *deliberately* set `files` below `Read`." That is exactly the normal way you scope someone to datasets only, and dismissing it was the defect.

## What changed

Authorization is now per `input.scope`, because the two callers are owned by different resources.

- **`files` (default)** — the Files drawer. `FeatureKey.files` plan gate + `filesView`, run by hand in the handler, i.e. byte-for-byte what the middleware did. The `kb.ts` precedent for a conditional plan gate.
- **`datasetDocument`** — the dataset document drawer. Authorizes against the parent dataset and runs **no** plan gate, matching every procedure in `routers/document.ts`, which is `capabilityProcedure` throughout.

New `apps/web/src/server/lib/dataset-document-asset-access.ts` is the single authority (the `agent-instance-access.ts` shape): it 404s a missing or foreign-org document **before** reading any capability, asserts dataset view, then verifies the requested asset is the one that document owns.

That ownership check is load-bearing — without it the scope is a confused deputy, and view on any one dataset would launder into a presigned URL for any asset in the org.

Both gates run **ahead of** the handler's existing `try/catch`, which rewrites non-`TRPCError`s into a 400 and would otherwise flatten a 403/404 denial into `BAD_REQUEST`.

## Related, deliberately not fixed

Same class as the open `file.resolveFileRefs` finding: file-shaped content owned by another resource must authorize against that resource, not the Files area. `resolveFileRefs` is untouched and its test still pins it as open — its callers are FILE custom fields, table cells and sequence attachments, which need their own record-scoped decision.

## Verification

- **17 tests** in `file-attachment-permission.test.ts` (10 new), including the repro: a `datasets: Read` / `files: None` member now gets the preview.
- **6 mutations, all caught** against a clean 17/17 control — dropping `assertViewInstance` (2 fail), the asset-ownership check (2), the 404 (1), the files-branch capability assert (3), the files-branch plan gate (1), the asset-type guard (1).
- **Zero new tsc errors.** `file.ts` carries the same 12 pre-existing hits as HEAD (identical error set, captured by swapping HEAD's file in); the other four files zero.
- Browser-verified by the user against the original repro.

One deliberate behavior change: the old test asserted the plan gate fired before `getCapabilities`. Under `capabilityProcedure` that cached read now happens first in middleware. Nothing is authorized by it and the denial is identical; the assertion was rewritten to pin what matters (no file is read), with the reasoning recorded at it.