### PR TITLE
refactor(permissions): fall a resource type through to its own area

### DIFF
--- a/apps/web/src/components/agents/ui/detail/permissions/agent-policy-view.tsx
+++ b/apps/web/src/components/agents/ui/detail/permissions/agent-policy-view.tsx
@@ -3,7 +3,12 @@
 
 import type { AgentPermissionPolicy } from '@auxx/database'
 import type { ResourcePermission } from '@auxx/database/enums'
-import { AREA_ORDER, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
+import {
+  AREA_ORDER,
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+  PERMISSION_AREAS,
+} from '@auxx/lib/permissions/client'
 import { isAccessManageable } from '@auxx/lib/resources/client'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { useMemo } from 'react'
@@ -66,13 +71,18 @@ interface AgentDomainDefault {
 }
 
 /**
- * The three domains the runtime enforces and the rung every key in each one falls
- * back to (§2.3). Single source for both the tab's summary line and the dialog's
- * `Default` rows.
+ * The two domains that carry a blanket default of their own, and the rung every
+ * key in each one falls back to (§2.3). Single source for both the tab's summary
+ * line and the dialog's `Default` rows.
+ *
+ * **Resources is deliberately absent.** A resource type with no rule of its own
+ * follows its own L2 area, so there is no single rung to print for the domain —
+ * the per-type rows each carry their own answer instead. Printing one would mean
+ * inventing a number the policy no longer holds.
  */
 export function agentPolicyDomainDefaults(
   policy: AgentPermissionPolicy
-): [AgentDomainDefault, AgentDomainDefault, AgentDomainDefault] {
+): [AgentDomainDefault, AgentDomainDefault] {
   return [
     { key: 'areas', title: 'Areas', defaultLabel: 'Default', level: policy.areas.default },
     {
@@ -81,13 +91,16 @@ export function agentPolicyDomainDefaults(
       defaultLabel: 'Default · incl. created later',
       level: policy.definitions.default,
     },
-    {
-      key: 'resources',
-      title: 'Resources',
-      defaultLabel: 'Default',
-      level: policy.resourceDefault,
-    },
   ]
+}
+
+/**
+ * The rung a resource type with no rule of its own resolves to — its L2 area.
+ * Read-only mirror of `resourceTypeAreaLevel` in `use-agent-policy.ts`.
+ */
+function typeAreaLevel(policy: AgentPermissionPolicy, type: InstanceAccessKey): ResourcePermission {
+  const area = INSTANCE_ACCESS_RESOURCES[type].area
+  return policy.areas.overrides[area] ?? policy.areas.default
 }
 
 /** One line of the three domain defaults — the tab's answer to "what does this agent get?". */
@@ -133,7 +146,7 @@ export function AgentResolvedPolicyDialog({
 
   const domains = useMemo<ResolvedAccessDomain[]>(() => {
     if (!policy) return []
-    const [areas, definitions, instances] = agentPolicyDomainDefaults(policy)
+    const [areas, definitions] = agentPolicyDomainDefaults(policy)
 
     return [
       {
@@ -161,9 +174,11 @@ export function AgentResolvedPolicyDialog({
         })),
       },
       {
-        key: instances.key,
-        title: instances.title,
-        defaultRow: { label: instances.defaultLabel, level: AGENT_LEVEL[instances.level] },
+        key: 'resources',
+        title: 'Resources',
+        // No `defaultRow`: there is no blanket resource default left to print —
+        // each type answers from its own area. See `agentPolicyDomainDefaults`.
+        //
         // Driven off `AGENT_POLICY_INSTANCE_KEYS`, not `INSTANCE_ACCESS_KEYS` —
         // the latter carries `agent`, which an agent policy never expresses.
         rows: AGENT_POLICY_INSTANCE_KEYS.map((type) => {
@@ -178,7 +193,7 @@ export function AgentResolvedPolicyDialog({
               perTypeOverrides > 0
                 ? `${meta.description} ${perTypeOverrides} with a rule of their own.`
                 : meta.description,
-            level: AGENT_LEVEL[perType?.default ?? policy.resourceDefault],
+            level: AGENT_LEVEL[perType?.default ?? typeAreaLevel(policy, type)],
             isOverride: perType !== undefined,
           }
         }),

--- a/apps/web/src/components/permissions/hooks/use-agent-policy.test.ts
+++ b/apps/web/src/components/permissions/hooks/use-agent-policy.test.ts
@@ -2,7 +2,12 @@
 
 import type { AgentPermissionPolicy } from '@auxx/database'
 import { describe, expect, it } from 'vitest'
-import { countChanges, normalizeAgentPolicy, stableKey } from './use-agent-policy'
+import {
+  countChanges,
+  normalizeAgentPolicy,
+  resourceTypeAreaLevel,
+  stableKey,
+} from './use-agent-policy'
 
 /**
  * Plan 29 §5 verification #1 — the tree unification is a RENDERING change, so a
@@ -17,7 +22,13 @@ import { countChanges, normalizeAgentPolicy, stableKey } from './use-agent-polic
  * provider mocking between the test and the thing under test.
  */
 
-/** A policy exercising all four keyspaces, both orphan families included. */
+/**
+ * A policy exercising all four keyspaces, both orphan families included.
+ *
+ * It still carries `resourceDefault` on purpose: data migration 055 retired the
+ * field, and an un-migrated row (or an old client's payload) must normalize
+ * without it rather than round-tripping a value the model no longer reads.
+ */
 const STORED = {
   areas: { default: 'view', overrides: { records: 'admin', auditLog: 'none' } },
   definitions: { default: 'none', overrides: { companies: 'view', gone_away: 'admin' } },
@@ -56,8 +67,25 @@ describe('agent policy round-trip (plan 29 §5)', () => {
 
     expect(empty.areas.default).toBe('none')
     expect(empty.definitions.default).toBe('none')
-    expect(empty.resourceDefault).toBe('none')
     expect(empty.resources).toEqual({})
+    // No resource keyspace of its own — every type reads through the area map,
+    // which is all-`none` here.
+    expect(resourceTypeAreaLevel(empty, 'kb')).toBe('none')
+  })
+
+  it('falls a resource type with no rule through to its own area, not a sibling', () => {
+    const policy = normalizeAgentPolicy({
+      areas: { default: 'none', overrides: { datasets: 'edit', knowledgeBase: 'view' } },
+      definitions: { default: 'none', overrides: {} },
+      resources: {},
+    } as unknown as AgentPermissionPolicy)
+
+    expect(resourceTypeAreaLevel(policy, 'dataset')).toBe('edit')
+    expect(resourceTypeAreaLevel(policy, 'kb')).toBe('view')
+    // Not in the area map → `areas.default`.
+    expect(resourceTypeAreaLevel(policy, 'dashboard')).toBe('none')
+    // Not a registered resource type at all → fail closed.
+    expect(resourceTypeAreaLevel(policy, 'retired_kind')).toBe('none')
   })
 
   it('counts a cleared resource type as its default PLUS every per-item rule it drops', () => {

--- a/apps/web/src/components/permissions/hooks/use-agent-policy.ts
+++ b/apps/web/src/components/permissions/hooks/use-agent-policy.ts
@@ -3,6 +3,7 @@
 
 import type { AgentPermissionPolicy, ExactAgentPolicy } from '@auxx/database'
 import { type ResourcePermission, ResourcePermissionValues } from '@auxx/database/enums'
+import { INSTANCE_ACCESS_RESOURCES, type InstanceAccessKey } from '@auxx/lib/permissions/client'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 /**
@@ -61,19 +62,36 @@ export function normalizeAgentPolicy(
   raw: AgentPermissionPolicy | null | undefined
 ): NormalizedAgentPolicy {
   const source = (raw ?? {}) as Partial<AgentPermissionPolicy>
-  const resourceDefault = parseLevel(source.resourceDefault) ?? 'none'
   const resources: Record<string, ExactAgentPolicy> = {}
   if (source.resources && typeof source.resources === 'object') {
     for (const [type, value] of Object.entries(source.resources)) {
-      resources[type] = parseExact(value, resourceDefault)
+      resources[type] = parseExact(value, 'none')
     }
   }
   return {
     areas: parseExact(source.areas, 'none'),
     definitions: parseExact(source.definitions, 'none'),
-    resourceDefault,
     resources,
   }
+}
+
+/**
+ * What a resource type with no rule of its own resolves to: its own L2 area rung
+ * (`INSTANCE_ACCESS_RESOURCES`), the same fall-through a human's absent
+ * `ResourceAccess` row takes. Client mirror of `resourceTypeAreaLevel` in
+ * `profiles/agent-policy.ts`.
+ *
+ * There is no separate "resource default" to consult — that field is gone, and
+ * with it the second blanket dropdown that answered the same question one level
+ * above the area rung it was then intersected with.
+ */
+export function resourceTypeAreaLevel(
+  policy: NormalizedAgentPolicy,
+  type: string
+): ResourcePermission {
+  const config = INSTANCE_ACCESS_RESOURCES[type as InstanceAccessKey]
+  if (!config) return 'none'
+  return policy.areas.overrides[config.area] ?? policy.areas.default
 }
 
 /**
@@ -92,7 +110,6 @@ export function stableKey(policy: NormalizedAgentPolicy): string {
   return JSON.stringify({
     areas: exact(policy.areas),
     definitions: exact(policy.definitions),
-    resourceDefault: policy.resourceDefault,
     resources: Object.keys(policy.resources)
       .sort()
       .map((type) => ({ type, ...exact(policy.resources[type] as ExactAgentPolicy) })),
@@ -115,7 +132,6 @@ export function countChanges(saved: NormalizedAgentPolicy, draft: NormalizedAgen
   }
   diffExact(saved.areas, draft.areas)
   diffExact(saved.definitions, draft.definitions)
-  if (saved.resourceDefault !== draft.resourceDefault) changes += 1
   for (const type of new Set([...Object.keys(saved.resources), ...Object.keys(draft.resources)])) {
     const a = saved.resources[type]
     const b = draft.resources[type]
@@ -151,19 +167,18 @@ export interface UseAgentPolicyResult {
   setDefinitionsDefault: (level: ResourcePermission) => void
   /** Set (or remove) one definition's override, keyed by `apiSlug` (§3). */
   setDefinitionOverride: (apiSlug: string, level: ResourcePermission | undefined) => void
-  /** Replace the posture for resource types with no rules of their own. */
-  setResourceDefault: (level: ResourcePermission) => void
   /** Give one resource type its own default. */
   setResourceTypeDefault: (type: string, level: ResourcePermission) => void
   /**
-   * Drop a resource type's entry so it follows `resourceDefault` again. Its
-   * instance rules go with it — the shape has nowhere to keep them.
+   * Drop a resource type's entry so it follows its L2 area again. Its instance
+   * rules go with it — the shape has nowhere to keep them.
    */
   clearResourceType: (type: string) => void
   /**
    * Set (or remove) one instance's override. Materializes the type entry at the
-   * current `resourceDefault` when the type had none, so an instance rule can
-   * never exist without the type default that answers for its siblings.
+   * type's current fall-through (its area rung) when the type had none, so an
+   * instance rule can never exist without the type default that answers for its
+   * siblings.
    */
   setInstanceOverride: (
     type: string,
@@ -229,13 +244,12 @@ export function useAgentPolicy(
     [setOverride]
   )
 
-  const setResourceDefault = useCallback((level: ResourcePermission) => {
-    setDraft((prev) => ({ ...prev, resourceDefault: level }))
-  }, [])
-
   const setResourceTypeDefault = useCallback((type: string, level: ResourcePermission) => {
     setDraft((prev) => {
-      const current = prev.resources[type] ?? { default: prev.resourceDefault, overrides: {} }
+      const current = prev.resources[type] ?? {
+        default: resourceTypeAreaLevel(prev, type),
+        overrides: {},
+      }
       return { ...prev, resources: { ...prev.resources, [type]: { ...current, default: level } } }
     })
   }, [])
@@ -251,7 +265,10 @@ export function useAgentPolicy(
   const setInstanceOverride = useCallback(
     (type: string, instanceId: string, level: ResourcePermission | undefined) => {
       setDraft((prev) => {
-        const current = prev.resources[type] ?? { default: prev.resourceDefault, overrides: {} }
+        const current = prev.resources[type] ?? {
+          default: resourceTypeAreaLevel(prev, type),
+          overrides: {},
+        }
         const overrides = { ...current.overrides }
         if (level === undefined) delete overrides[instanceId]
         else overrides[instanceId] = level
@@ -273,7 +290,6 @@ export function useAgentPolicy(
     setAreaOverride,
     setDefinitionsDefault,
     setDefinitionOverride,
-    setResourceDefault,
     setResourceTypeDefault,
     clearResourceType,
     setInstanceOverride,

--- a/apps/web/src/components/permissions/ui/agent-policy-editor.test.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-editor.test.tsx
@@ -199,7 +199,6 @@ function changeCount(): number | null {
 const FULL_POLICY = {
   areas: { default: 'view', overrides: { records: 'admin', settings: 'admin' } },
   definitions: { default: 'none', overrides: { companies: 'view', gone_away: 'admin' } },
-  resourceDefault: 'none',
   resources: {
     kb: { default: 'view', overrides: { kb_1: 'admin', kb_gone: 'none' } },
     dataset: { default: 'view', overrides: {} },
@@ -252,24 +251,36 @@ describe('plan 29 §5 bar 2 — every rule reachable before is reachable after',
     expect(hintOf('Records')).toBe('')
   })
 
-  it('offers both header collection defaults, and both are editable', async () => {
+  it('offers ONE header collection default, and it is editable', async () => {
     const user = userEvent.setup()
     renderEditor()
 
-    // `areas.default` and `resourceDefault` — the two keyspaces that answer for
-    // keys with NO row of their own, so they cannot live on a row (§2.2/§4a).
+    // `areas.default` is the only keyspace left that answers for keys with NO row
+    // of their own, so it is the only one that cannot live on a row (§2.2/§4a).
     expect(headerSelect('Unset areas fall through to').textContent).toContain('Read')
-    expect(headerSelect('New resource types fall through to').textContent).toContain('None')
 
     await user.click(headerSelect('Unset areas fall through to'))
     await user.click(screen.getByRole('option', { name: 'Full' }))
     expect(headerSelect('Unset areas fall through to').textContent).toContain('Full')
     expect(changeCount()).toBe(1)
+  })
 
-    await user.click(headerSelect('New resource types fall through to'))
-    await user.click(screen.getByRole('option', { name: 'Read' }))
-    expect(headerSelect('New resource types fall through to').textContent).toContain('Read')
-    expect(changeCount()).toBe(2)
+  it('has no second blanket default — a resource type falls through to its own area', async () => {
+    const user = userEvent.setup()
+    // No `dataset` entry, and `datasets` overridden to `edit`: the "All datasets"
+    // row must read the AREA it sits under, not a policy-wide resource rung.
+    renderEditor({
+      areas: { default: 'none', overrides: { datasets: 'edit' } },
+      definitions: { default: 'none', overrides: {} },
+      resources: {},
+    } as unknown as AgentPermissionPolicy)
+
+    expect(screen.queryByText('New resource types fall through to')).not.toBeInTheDocument()
+
+    await toggleArea(user, 'Datasets')
+    // A child could once read "Default · No access" under a Read/Edit parent —
+    // the contradiction the second header dropdown made possible (#1362 follow-up).
+    expect(ruleOf('All datasets')).toBe('Default · Read and write')
   })
 
   it('offers definitions.default as the "All record types" child row, and it is editable', async () => {
@@ -364,9 +375,11 @@ describe('plan 29 §5 bar 3 — the destructive confirm survived the move', () =
     expect(h.confirm.mock.calls[0][0].description).toContain('2 per-item rules')
 
     // `clearResourceType` ran: the type entry is gone, so the listed instance
-    // falls through to `resourceDefault` and the orphan row has nothing left.
-    expect(ruleOf('All knowledge bases')).toBe('Default · No access')
-    expect(ruleOf('Returns Policy')).toBe('Default · No access')
+    // falls through to the `Knowledge Base` AREA — `areas.default` (`view`) here,
+    // since the policy names no override for it — and the orphan row has nothing
+    // left. It reads Read, not None: the child agrees with its parent now.
+    expect(ruleOf('All knowledge bases')).toBe('Default · Read only')
+    expect(ruleOf('Returns Policy')).toBe('Default · Read only')
     expect(findRow('kb_gone')).toBeUndefined()
     // The type default plus the two per-item rules it took with it.
     expect(changeCount()).toBe(3)
@@ -393,11 +406,11 @@ describe('plan 29 §5 bar 3 — the destructive confirm survived the move', () =
     await toggleArea(user, 'Datasets')
 
     // `resources.dataset` has a default of its own but an empty override map,
-    // so following the resource default destroys nothing and must not nag.
+    // so following the area destroys nothing and must not nag.
     await pick(user, 'All datasets', /^Default/)
 
     expect(h.confirm).not.toHaveBeenCalled()
-    expect(ruleOf('All datasets')).toBe('Default · No access')
+    expect(ruleOf('All datasets')).toBe('Default · Read only')
     expect(changeCount()).toBe(1)
   })
 
@@ -494,7 +507,6 @@ describe('plan 29 §5 bar 4 — search and the "Set areas only" filter reach chi
     renderEditor({
       areas: { default: 'none', overrides: {} },
       definitions: { default: 'none', overrides: { companies: 'view' } },
-      resourceDefault: 'none',
       resources: {},
     } as unknown as AgentPermissionPolicy)
 
@@ -515,7 +527,6 @@ describe('plan 29 §5 bar 4 — search and the "Set areas only" filter reach chi
     renderEditor({
       areas: { default: 'none', overrides: {} },
       definitions: { default: 'view', overrides: {} },
-      resourceDefault: 'none',
       resources: {},
     } as unknown as AgentPermissionPolicy)
 
@@ -531,14 +542,14 @@ describe('plan 29 §5 bar 4 — search and the "Set areas only" filter reach chi
     renderEditor({
       areas: { default: 'none', overrides: {} },
       definitions: { default: 'none', overrides: {} },
-      resourceDefault: 'none',
       resources: { kb: { default: 'view', overrides: {} } },
     } as unknown as AgentPermissionPolicy)
 
     await user.click(screen.getByRole('switch'))
 
     // Unlike `definitions.default`, a type entry is a deliberate departure from
-    // `resourceDefault` — a rule of its own, so it rescues its area.
+    // the area rung it would otherwise follow — a rule of its own, so it rescues
+    // its area.
     expect(rowTitles()).toContain('Knowledge Base')
     expect(rowTitles()).not.toContain('Dashboards')
   })
@@ -580,7 +591,6 @@ describe('plan 33 drift #2 — an empty list says which kind of empty it is', ()
     renderEditor({
       areas: { default: 'view', overrides: { records: 'admin' } },
       definitions: { default: 'none', overrides: {} },
-      resourceDefault: 'none',
       resources: {},
     } as unknown as AgentPermissionPolicy)
 
@@ -610,7 +620,6 @@ describe('plan 33 drift #2 — an empty list says which kind of empty it is', ()
     renderEditor({
       areas: { default: 'view', overrides: { records: 'admin' } },
       definitions: { default: 'none', overrides: {} },
-      resourceDefault: 'none',
       resources: {},
     } as unknown as AgentPermissionPolicy)
     await toggleArea(user, 'Records')

--- a/apps/web/src/components/permissions/ui/agent-policy-editor.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-editor.tsx
@@ -13,7 +13,7 @@ import { SettingsSection } from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
-import { useAgentPolicy } from '../hooks/use-agent-policy'
+import { resourceTypeAreaLevel, useAgentPolicy } from '../hooks/use-agent-policy'
 import { useAgentPolicyClamp } from '../hooks/use-agent-policy-clamp'
 import { useAgentPolicyDefinitions } from '../hooks/use-agent-policy-definitions'
 import { useAgentPolicySave } from '../hooks/use-agent-policy-save'
@@ -125,11 +125,19 @@ function emptyStateFor(
  *    (§0.5/§2.3) — never through the human per-def rows (`GranteeDefAccessRows`),
  *    which write `ResourceAccess`.
  *  - **Every collection has a default**, so a record type or resource created
- *    tomorrow has a deterministic posture (§0.5/§2.3). Three of them are child
- *    rows ("All record types", "All datasets", …); the two that answer for keys
- *    with no row at all — `areas.default` and `resourceDefault` — are the header
- *    dropdowns (plan 29 §2.2/§4a). Neither offers the human `Member default`
- *    sentinel: an agent's defaults are mandatory and fail closed at `none`.
+ *    tomorrow has a deterministic posture (§0.5/§2.3). They are child rows ("All
+ *    record types", "All datasets", …); the ONE default that answers for keys
+ *    with no row at all — `areas.default` — is the header dropdown (plan 29
+ *    §2.2/§4a). It does not offer the human `Member default` sentinel: an agent's
+ *    default is mandatory and fails closed at `none`.
+ *  - **A resource type with no rule falls through to its own area**, not to a
+ *    second blanket default. The `New resource types fall through to` dropdown is
+ *    gone with the `resourceDefault` field behind it: it answered the same
+ *    question one level above the area rung it was then intersected with, so two
+ *    header dropdowns sat side by side with no statable difference, and an
+ *    `All datasets` row could read *"Default · None"* under a `Datasets: Read`
+ *    parent. This is also the human rule verbatim — `INSTANCE_ACCESS_RESOURCES`
+ *    says an absent instance row resolves to the base L2 area level.
  *  - **Permissions are not tools.** Effective ability is the intersection of the
  *    two (§0.5a/§2.4) — granting Full here enables no tool.
  *  - **Publication semantics.** A save reaches bound drafts only; production
@@ -163,7 +171,6 @@ export function AgentPolicyEditor({
     setAreaOverride,
     setDefinitionsDefault,
     setDefinitionOverride,
-    setResourceDefault,
     setResourceTypeDefault,
     clearResourceType,
     setInstanceOverride,
@@ -212,8 +219,8 @@ export function AgentPolicyEditor({
       const overrideCount = Object.keys(policy.resources[type]?.overrides ?? {}).length
       if (overrideCount > 0) {
         const confirmed = await confirm({
-          title: `Follow the resource default for ${INSTANCE_TYPE_META[type].label.toLowerCase()}?`,
-          description: `This removes the ${overrideCount} per-item rule${overrideCount === 1 ? '' : 's'} on this type as well. The shape has nowhere to keep them once the type follows the default.`,
+          title: `Follow the area rung for ${INSTANCE_TYPE_META[type].label.toLowerCase()}?`,
+          description: `This removes the ${overrideCount} per-item rule${overrideCount === 1 ? '' : 's'} on this type as well. The shape has nowhere to keep them once the type follows its area.`,
           confirmText: 'Remove rules',
           cancelText: 'Cancel',
           destructive: true,
@@ -372,15 +379,21 @@ export function AgentPolicyEditor({
         .filter((id) => !knownIds.has(id) && matches(id, filter.query))
         .sort()
       // Unlike the record-type default, a resource TYPE entry is a deliberate
-      // departure from `resourceDefault` — so it is a rule of its own and does
-      // rescue its area under "Set areas only".
+      // departure from the area rung it would otherwise follow — so it is a rule
+      // of its own and does rescue its area under "Set areas only".
       const meta = INSTANCE_TYPE_META[type]
       const allRowCounts =
         (!filter.overridesOnly || entry !== undefined) &&
         matches(allInstancesTitle(meta.label), filter.query)
 
+      /**
+       * The type's fall-through: its own L2 area rung, which is the row directly
+       * above this one in the tree. A child can no longer contradict its parent
+       * the way a global resource default could.
+       */
+      const areaRung = resourceTypeAreaLevel(policy, type)
       /** What an instance with no rule of its own resolves to. */
-      const typeLevel = entry?.default ?? policy.resourceDefault
+      const typeLevel = entry?.default ?? areaRung
       const instanceRows: InstanceAccessRow[] = [
         ...items.map((item) => ({
           key: type,
@@ -419,7 +432,7 @@ export function AgentPolicyEditor({
                 title={allInstancesTitle(meta.label)}
                 description={
                   overrideCount > 0
-                    ? `What a ${noun} with no rule of its own resolves to, including ones created later. Choosing Default follows the resource default (${permissionLabel(policy.resourceDefault)}) and removes the ${overrideCount} per-item rule${overrideCount === 1 ? '' : 's'} below with it.`
+                    ? `What a ${noun} with no rule of its own resolves to, including ones created later. Choosing Default follows the ${meta.label.toLowerCase()} area above (${permissionLabel(areaRung)}) and removes the ${overrideCount} per-item rule${overrideCount === 1 ? '' : 's'} below with it.`
                     : `What a ${noun} with no rule of its own resolves to, including ones created later.`
                 }
                 actions={
@@ -428,7 +441,7 @@ export function AgentPolicyEditor({
                     includeInherit
                     includeNone
                     inheritLabelText={AGENT_INHERIT_LABEL}
-                    inheritedLevel={policy.resourceDefault}
+                    inheritedLevel={areaRung}
                     onInherit={() => void handleTypeChange(type, undefined)}
                     onChange={(level) => void handleTypeChange(type, level)}
                     disabled={disabled}
@@ -448,9 +461,7 @@ export function AgentPolicyEditor({
       }
     },
     [
-      policy.definitions,
-      policy.resources,
-      policy.resourceDefault,
+      policy,
       definitions,
       definitionSlugs,
       definitionsLoading,
@@ -501,20 +512,12 @@ export function AgentPolicyEditor({
         title='Agent policy'
         description='What the agent may reach, feature by feature. Expand a row to rule on individual record types or resources.'
         action={
-          <div className='flex flex-wrap items-center justify-end gap-3'>
-            <BaseLevelSelect
-              label='Unset areas fall through to'
-              value={LEVEL_OF_PERMISSION[policy.areas.default]}
-              disabled={disabled}
-              onChange={(level) => setAreasDefault(permissionOfLevel(level))}
-            />
-            <BaseLevelSelect
-              label='New resource types fall through to'
-              value={LEVEL_OF_PERMISSION[policy.resourceDefault]}
-              disabled={disabled}
-              onChange={(level) => setResourceDefault(permissionOfLevel(level))}
-            />
-          </div>
+          <BaseLevelSelect
+            label='Unset areas fall through to'
+            value={LEVEL_OF_PERMISSION[policy.areas.default]}
+            disabled={disabled}
+            onChange={(level) => setAreasDefault(permissionOfLevel(level))}
+          />
         }>
         <ProfileAreaGrid
           values={areaValues}

--- a/apps/web/src/components/permissions/ui/base-level-select.tsx
+++ b/apps/web/src/components/permissions/ui/base-level-select.tsx
@@ -53,10 +53,15 @@ type BaseLevelSelectProps = {
  * default in code — which is also why a newly added area is automatically
  * reachable for Owner/Admin on deploy instead of needing a backfill.
  *
- * Shared by the human profile editor (`Unset areas fall through to`, offering the
- * `Member default` sentinel) and the agent policy header (plan 29 §2.2/§4a: the
- * areas default and the `New resource types fall through to` default, neither of
- * which offers the sentinel).
+ * Shared by the human profile editor and the agent policy header, both labelled
+ * `Unset areas fall through to` (plan 29 §2.2/§4a). Only the human one offers the
+ * `Member default` sentinel — an agent's default is mandatory and fails closed.
+ *
+ * One control per editor. The agent header briefly carried a second,
+ * `New resource types fall through to`, backing an `AgentPermissionPolicy`
+ * field that answered the same question one level above the area rung it was then
+ * intersected with; a resource type with no rule now falls through to its own
+ * area, exactly as a human's absent instance row does.
  */
 export function BaseLevelSelect(props: BaseLevelSelectProps) {
   const { label, value, disabled = false } = props

--- a/apps/web/src/server/api/routers/permissions.ts
+++ b/apps/web/src/server/api/routers/permissions.ts
@@ -81,7 +81,6 @@ const exactAgentPolicyInput = z.object({
 const agentPolicyInput: z.ZodType<AgentPermissionPolicy> = z.object({
   areas: exactAgentPolicyInput,
   definitions: exactAgentPolicyInput,
-  resourceDefault: z.enum(ResourcePermissionValues),
   resources: z.record(z.string(), exactAgentPolicyInput),
 })
 

--- a/packages/database/src/db/schema/agent-version.ts
+++ b/packages/database/src/db/schema/agent-version.ts
@@ -73,9 +73,16 @@ export type PublishedAgentPermissionPolicy = {
   areas: ExactAgentPolicy
   /** Exact rule per entity-definition `apiSlug` (slug, not CUID — §3). */
   definitions: ExactAgentPolicy
-  /** Posture for resource types absent from {@link PublishedAgentPermissionPolicy.resources}. */
-  resourceDefault: ResourcePermission
-  /** Exact rule per resource type → per instance id. */
+  /**
+   * Exact rule per resource type → per instance id.
+   *
+   * A resource type absent from this map falls through to its own L2
+   * {@link PublishedAgentPermissionPolicy.areas} rung — see the note on
+   * `AgentPermissionPolicy.resources`. Publishing materializes every *registered*
+   * type here (that is what bounds each one by the publisher's own posture toward
+   * a future instance), so in a snapshot the fall-through only ever answers for a
+   * resource type a later deploy introduced.
+   */
   resources: Partial<Record<string, ExactAgentPolicy>>
 }
 

--- a/packages/database/src/db/schema/permission-profile.ts
+++ b/packages/database/src/db/schema/permission-profile.ts
@@ -63,9 +63,17 @@ export type AgentPermissionPolicy = {
   areas: ExactAgentPolicy
   /** Exact rule per entity-definition `apiSlug` (slug, not CUID — §3). */
   definitions: ExactAgentPolicy
-  /** Posture for resource types absent from {@link AgentPermissionPolicy.resources}. */
-  resourceDefault: ResourcePermission
-  /** Exact rule per resource type → per instance id. */
+  /**
+   * Exact rule per resource type → per instance id.
+   *
+   * Sparse in BOTH dimensions, and there is deliberately no top-level "resource
+   * default" beside it: a resource type absent from this map falls through to
+   * its own L2 {@link AgentPermissionPolicy.areas} rung, exactly as a human's
+   * absent `ResourceAccess` row falls through to their base area level
+   * (`INSTANCE_ACCESS_RESOURCES`, `baselineAtCreate: false`). One fall-through,
+   * one place to author it — including for a resource type a future deploy adds,
+   * which arrives with a new area whose rung `areas.default` already answers.
+   */
   resources: Partial<Record<string, ExactAgentPolicy>>
 }
 

--- a/packages/lib/src/agents/agent-version-permission-policy.int.test.ts
+++ b/packages/lib/src/agents/agent-version-permission-policy.int.test.ts
@@ -222,7 +222,10 @@ describe('publish snapshots the resolved permission policy', () => {
     const stored = await readVersion(version.id)
     expect(stored.permissionPolicy.areas.default).toBe('none')
     expect(stored.permissionPolicy.definitions.default).toBe('none')
-    expect(stored.permissionPolicy.resourceDefault).toBe('none')
+    // Every registered resource type is materialized at publish, each one at the
+    // rung its own area supplied — all `none` on this fail-closed profile.
+    expect(stored.permissionPolicy.resources.kb?.default).toBe('none')
+    expect(stored.permissionPolicy.resources.dataset?.default).toBe('none')
   })
 
   it('includes the policy in configHash, so the stored hash matches a recompute', async () => {

--- a/packages/lib/src/ai/agent-framework/__tests__/agent-run-capabilities.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/agent-run-capabilities.test.ts
@@ -77,7 +77,6 @@ function policy(defs: Record<string, 'none' | 'view' | 'edit' | 'admin'>) {
     clamp: [],
     areas: { default: 'admin', overrides: {} },
     definitions: { default: 'none', overrides: defs },
-    resourceDefault: 'none',
     resources: {},
   } satisfies PublishedAgentPermissionPolicy
 }
@@ -330,7 +329,6 @@ describe("source: 'draft' resolves the live binding, 'active' the snapshot (§15
         agentPolicy: {
           areas: { default: 'admin', overrides: {} },
           definitions: { default: 'none', overrides: { 'def-a': 'edit' } },
-          resourceDefault: 'none',
           resources: {},
         },
       },

--- a/packages/lib/src/data-migrations/migrations/055-agent-policy-resource-area-fallthrough.ts
+++ b/packages/lib/src/data-migrations/migrations/055-agent-policy-resource-area-fallthrough.ts
@@ -1,0 +1,210 @@
+// packages/lib/src/data-migrations/migrations/055-agent-policy-resource-area-fallthrough.ts
+
+import type { Database, PublishedAgentPermissionPolicy } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type { ResourcePermission } from '@auxx/database/enums'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { hashAgentConfig } from '../../agents/agent-config-snapshot'
+import { onCacheEvent } from '../../cache'
+import { PERMISSION_RANK } from '../../permissions/capabilities/compose-user-capabilities'
+import {
+  INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+} from '../../permissions/capabilities/instance-access'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-055')
+
+const CHUNK = 500
+
+/** Read one keyspace's rung for `key`, or its `default` when unnamed. */
+function lookup(raw: unknown, key: string): string | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const source = raw as { default?: unknown; overrides?: Record<string, unknown> }
+  const override = source.overrides?.[key]
+  const value = typeof override === 'string' ? override : source.default
+  return typeof value === 'string' ? value : undefined
+}
+
+/** `true` when `a` sits strictly below `b` on the four-rung ladder. */
+function isBelow(a: string, b: string): boolean {
+  const rankA = PERMISSION_RANK[a as ResourcePermission]
+  const rankB = PERMISSION_RANK[b as ResourcePermission]
+  if (rankA === undefined || rankB === undefined) return false
+  return rankA < rankB
+}
+
+/**
+ * Drop `resourceDefault` from one stored agent policy, materializing it as an
+ * explicit per-type entry wherever it was actually load-bearing.
+ *
+ * **The whole point is that authority must not move.** The old read was
+ * `min(resources[type]?.default ?? resourceDefault, areaRung)`; the new one is
+ * `min(resources[type]?.default ?? areaRung, areaRung)`. Those agree for every
+ * type that already HAS an entry, and for every type where `resourceDefault` was
+ * at or above its area rung (the `min` picked the area either way). They differ
+ * only where an absent type had `resourceDefault` *below* its area — an admin who
+ * deliberately held resources under the feature gate — so exactly those types get
+ * the old rung written out as a rule of their own.
+ *
+ * Types are only materialized when they change something, so the four seeded
+ * presets and any policy that left `resourceDefault` permissive come through with
+ * an unchanged (just shorter) blob rather than five new entries of noise.
+ *
+ * Exported so the equivalence is testable as a pure function.
+ */
+export function dropResourceDefault<T>(raw: T): T {
+  if (!raw || typeof raw !== 'object') return raw
+  const source = raw as Record<string, unknown>
+  if (source.resourceDefault === undefined) return raw
+
+  const resourceDefault = source.resourceDefault
+  const existing = (
+    source.resources && typeof source.resources === 'object' ? source.resources : {}
+  ) as Record<string, unknown>
+  const resources: Record<string, unknown> = { ...existing }
+
+  if (typeof resourceDefault === 'string') {
+    for (const key of INSTANCE_ACCESS_KEYS) {
+      if (resources[key] !== undefined) continue
+      const areaRung = lookup(source.areas, INSTANCE_ACCESS_RESOURCES[key].area)
+      // No readable area rung → the new fall-through is whatever the parser
+      // makes of it; pin the old answer explicitly rather than gamble.
+      if (areaRung === undefined || isBelow(resourceDefault, areaRung)) {
+        resources[key] = { default: resourceDefault, overrides: {} }
+      }
+    }
+  }
+
+  const { resourceDefault: _dropped, ...rest } = source
+  return { ...rest, resources } as T
+}
+
+/** Whether a policy blob still carries the retired field. */
+function needsMigration(raw: unknown): boolean {
+  return JSON.stringify(raw) !== JSON.stringify(dropResourceDefault(raw))
+}
+
+/**
+ * Retire `AgentPermissionPolicy.resourceDefault` — a resource type with no rule
+ * of its own now falls through to its own L2 area rung.
+ *
+ * **Why the field went.** It answered "what does a resource type with no rule
+ * resolve to?" one level above the area gate its answer was then intersected
+ * with, so the profile editor carried two blanket dropdowns side by side —
+ * `Unset areas fall through to` and `New resource types fall through to` — whose
+ * difference nobody could state, and an `All datasets` child row could read
+ * *"Default · None"* underneath a `Datasets: Read` parent. The area rung was
+ * already the intersecting term and is already authored one row above, so it is
+ * the fall-through now. This is the human model verbatim:
+ * `INSTANCE_ACCESS_RESOURCES` declares that for a `baselineAtCreate: false`
+ * resource an absent instance row resolves to the base L2 area level.
+ *
+ * **This changes no authority** — see {@link dropResourceDefault} for why, and
+ * for the one case that is materialized rather than dropped.
+ *
+ * **Two columns, and a hash**, the same three surfaces migration 054 touched:
+ *  - `PermissionProfile.agentPolicy` — the authored policy.
+ *  - `AgentVersion.permissionPolicy` — every published snapshot, historical ones
+ *    included. Publishing already materializes every registered type, so most
+ *    snapshots lose the field and nothing else; system publishes (no clamp) are
+ *    the sparse ones the materialization branch exists for.
+ *  - `AgentVersion.configHash` covers `authorizationOnlyPolicy(policy)`, which no
+ *    longer includes `resourceDefault`. Left alone, every stored hash would be
+ *    stale and the first publish after deploy would mint a pointless version —
+ *    the trap migrations 050 and 054 both document. Recomputed for every row.
+ *
+ * **Idempotent.** A blob with no `resourceDefault` is returned verbatim, so a
+ * second run writes nothing.
+ */
+export const migration055AgentPolicyResourceAreaFallthrough: DataMigrationDef = {
+  id: '055-agent-policy-resource-area-fallthrough',
+  description:
+    'Retire AgentPermissionPolicy.resourceDefault in favour of the per-type L2 area fall-through, materializing it where it sat below its area, and recomputing configHash',
+  async run(db: Database): Promise<void> {
+    const affectedOrgIds = new Set<string>()
+
+    // ── PermissionProfile.agentPolicy ────────────────────────────────────
+    const profiles = await db
+      .select({
+        id: schema.PermissionProfile.id,
+        organizationId: schema.PermissionProfile.organizationId,
+        agentPolicy: schema.PermissionProfile.agentPolicy,
+      })
+      .from(schema.PermissionProfile)
+
+    let profilesRewritten = 0
+    for (const profile of profiles) {
+      if (!profile.agentPolicy || !needsMigration(profile.agentPolicy)) continue
+      await db
+        .update(schema.PermissionProfile)
+        .set({ agentPolicy: dropResourceDefault(profile.agentPolicy) })
+        .where(eq(schema.PermissionProfile.id, profile.id))
+      profilesRewritten += 1
+      affectedOrgIds.add(profile.organizationId)
+    }
+
+    // ── AgentVersion.permissionPolicy (+ configHash) ─────────────────────
+    const versions = await db
+      .select({
+        id: schema.AgentVersion.id,
+        organizationId: schema.AgentVersion.organizationId,
+        prompt: schema.AgentVersion.prompt,
+        toolsets: schema.AgentVersion.toolsets,
+        knowledge: schema.AgentVersion.knowledge,
+        appAccounts: schema.AgentVersion.appAccounts,
+        toolRestrictions: schema.AgentVersion.toolRestrictions,
+        modelId: schema.AgentVersion.modelId,
+        permissionPolicy: schema.AgentVersion.permissionPolicy,
+        configHash: schema.AgentVersion.configHash,
+      })
+      .from(schema.AgentVersion)
+
+    let versionsRewritten = 0
+    let hashesRecomputed = 0
+
+    for (let i = 0; i < versions.length; i += CHUNK) {
+      for (const version of versions.slice(i, i + CHUNK)) {
+        const policyChanged = needsMigration(version.permissionPolicy)
+        const policy = policyChanged
+          ? dropResourceDefault(version.permissionPolicy as PublishedAgentPermissionPolicy)
+          : version.permissionPolicy
+
+        const nextHash = hashAgentConfig({ ...version, permissionPolicy: policy })
+        const hashChanged = nextHash !== version.configHash
+        if (!policyChanged && !hashChanged) continue
+
+        await db
+          .update(schema.AgentVersion)
+          .set({
+            ...(policyChanged ? { permissionPolicy: policy } : {}),
+            configHash: nextHash,
+          })
+          .where(eq(schema.AgentVersion.id, version.id))
+
+        if (policyChanged) versionsRewritten += 1
+        if (hashChanged) hashesRecomputed += 1
+        affectedOrgIds.add(version.organizationId)
+      }
+    }
+
+    // Same two org projections migration 054 invalidated: `profiles` carries
+    // `agentPolicy`, `agents` carries the active version's policy + configHash.
+    // No `broadcastUserKeys` — agent policy never enters human composition, so no
+    // member's `userCapabilities` blob changed.
+    for (const orgId of affectedOrgIds) {
+      await onCacheEvent('permission-profile.changed', { orgId })
+      await onCacheEvent('agent.updated', { orgId })
+    }
+
+    logger.info('Retired agent policy resourceDefault', {
+      profiles: profiles.length,
+      profilesRewritten,
+      versions: versions.length,
+      versionsRewritten,
+      hashesRecomputed,
+      orgsInvalidated: affectedOrgIds.size,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -24,6 +24,7 @@ import { migration051GoogleAppScopeAlignment } from './migrations/051-google-app
 import { migration052MemberBaselineBackfill } from './migrations/052-member-baseline-backfill'
 import { migration053SeedAgentPresetProfiles } from './migrations/053-seed-agent-preset-profiles'
 import { migration054AgentPolicyVocabulary } from './migrations/054-agent-policy-vocabulary'
+import { migration055AgentPolicyResourceAreaFallthrough } from './migrations/055-agent-policy-resource-area-fallthrough'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -64,6 +65,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration052MemberBaselineBackfill,
     migration053SeedAgentPresetProfiles,
     migration054AgentPolicyVocabulary,
+    migration055AgentPolicyResourceAreaFallthrough,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/permissions/profiles/agent-policy-capabilities.test.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-capabilities.test.ts
@@ -182,7 +182,7 @@ describe('the four exact levels — RESOURCE INSTANCES (§9.1)', () => {
     expect(full.canAdminInstance('kb', 'kb-1')).toBe(true)
   })
 
-  it('answers an unlisted instance from the type default, and an unlisted type from resourceDefault', () => {
+  it('answers an unlisted instance from the type default, and an unlisted type from its area', () => {
     const caps = view({
       ...legacyFullAgentPolicy(),
       resources: { kb: { default: 'view', overrides: { 'kb-1': 'admin' } } },
@@ -190,8 +190,26 @@ describe('the four exact levels — RESOURCE INSTANCES (§9.1)', () => {
     expect(caps.canAdminInstance('kb', 'kb-1')).toBe(true)
     expect(caps.canViewInstance('kb', 'kb-never-seen')).toBe(true)
     expect(caps.canEditInstance('kb', 'kb-never-seen')).toBe(false)
-    // `dataset` has no entry → resourceDefault ('admin' here).
+    // `dataset` has no entry → the `datasets` area answers ('admin' here).
     expect(caps.canAdminInstance('dataset', 'ds-1')).toBe(true)
+  })
+
+  it('falls a type with no rule through to ITS OWN area, not to a sibling type', () => {
+    const caps = view({
+      ...emptyAgentPolicy(),
+      areas: {
+        default: 'none',
+        overrides: { [Area.datasets]: 'edit', [Area.knowledgeBase]: 'view' },
+      },
+      // Nothing named at all — every type reads through the area map above.
+      resources: {},
+    })
+    expect(caps.canEditInstance('dataset', 'ds-1')).toBe(true)
+    expect(caps.canAdminInstance('dataset', 'ds-1')).toBe(false)
+    expect(caps.canViewInstance('kb', 'kb-1')).toBe(true)
+    expect(caps.canEditInstance('kb', 'kb-1')).toBe(false)
+    // `dashboards` is not in the map → `areas.default`, which is `none`.
+    expect(caps.canViewInstance('dashboard', 'dash-1')).toBe(false)
   })
 
   it('intersects the instance rule with its coarse L2 area gate', () => {

--- a/packages/lib/src/permissions/profiles/agent-policy-capabilities.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-capabilities.ts
@@ -6,7 +6,7 @@ import { ForbiddenError } from '../../errors'
 import type { CapabilityView } from '../capabilities/capability-view'
 import { PERMISSION_RANK } from '../capabilities/compose-user-capabilities'
 import { NON_RECORD_DEF_SLUGS } from '../capabilities/entity-access'
-import { INSTANCE_ACCESS_RESOURCES, type InstanceAccessKey } from '../capabilities/instance-access'
+import type { InstanceAccessKey } from '../capabilities/instance-access'
 import {
   type Area,
   buildAreaLevels,
@@ -17,8 +17,6 @@ import {
 } from '../capabilities/registry'
 import { ENTITY_WRITE_KEYS } from '../capabilities/seat-policy'
 import {
-  areaLevelToPermission,
-  minPermission,
   permissionToAreaLevel,
   policyAreaLevel,
   policyDefinitionLevel,
@@ -232,20 +230,22 @@ export class AgentPolicyCapabilities implements CapabilityView {
   }
 
   /**
-   * The effective rung for one shareable resource instance: the instance rule
-   * intersected with its coarse L2 area gate.
+   * The effective rung for one shareable resource instance.
    *
-   * The area intersection mirrors the human resolver, where an area level of
-   * `None` closes the feature regardless of per-instance rows. Without it an
-   * agent policy that says `knowledgeBase: None` but leaves a stale `kb`
-   * instance override at `Full` would route around its own area rule — and
-   * "effective execution is the intersection of every constraint" (§0.5) would
-   * stop being true for exactly the domain where it matters most.
+   * A thin delegate on purpose: {@link policyResourceLevel} owns BOTH halves of
+   * the answer — the instance rule and the intersection with its coarse L2 area
+   * gate — because the same intersection is what supplies the fall-through for a
+   * type the policy names no rule for. Splitting them left two places that had to
+   * agree about the area's authority; there is now one.
+   *
+   * The gate itself is not optional: an agent policy that says
+   * `knowledgeBase: None` but leaves a stale `kb` instance override at `Full`
+   * must not route around its own area rule, or "effective execution is the
+   * intersection of every constraint" (§0.5) stops being true for exactly the
+   * domain where it matters most.
    */
   private instanceLevel(key: InstanceAccessKey, instanceId: string): ResourcePermission {
-    const resourceLevel = policyResourceLevel(this.policy, key, instanceId)
-    const areaGate = areaLevelToPermission(this.areaLevel(INSTANCE_ACCESS_RESOURCES[key].area))
-    return minPermission(resourceLevel, areaGate)
+    return policyResourceLevel(this.policy, key, instanceId)
   }
 
   canViewInstance(key: InstanceAccessKey, instanceId: string): boolean {

--- a/packages/lib/src/permissions/profiles/agent-policy-clamp.test.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-clamp.test.ts
@@ -121,7 +121,10 @@ describe('the §9.1 author-clamp case', () => {
     // Resource instances: the member holds nothing, so neither does the agent.
     expect(policy.resources.kb?.default).toBe('none')
     expect(policy.resources.dataset?.default).toBe('none')
-    expect(policy.resourceDefault).toBe('none')
+    expect(policy.resources.dashboard?.default).toBe('none')
+    // There is no separate resource default left to bound — a resource type a
+    // future deploy adds reads through `areas.default`, floored just below.
+    expect(policy.areas.default).toBe('none')
 
     // The clamp is reported, never silent (§13).
     expect(reductions.length).toBeGreaterThan(0)
@@ -148,7 +151,9 @@ describe('the §9.1 author-clamp case', () => {
     expect(policy.areas.overrides[Area.records]).toBe('admin')
     expect(policy.definitions.default).toBe('admin')
     expect(policy.definitions.overrides.deals).toBe('admin')
-    expect(policy.resourceDefault).toBe('admin')
+    // Every registered type is materialized at the rung it fell through to.
+    expect(policy.resources.kb?.default).toBe('admin')
+    expect(policy.resources.dashboard?.default).toBe('admin')
     expect(policy.publishedByUserId).toBe('u-admin')
   })
 
@@ -190,7 +195,7 @@ describe('clamp mechanics', () => {
     // when an owner publishes it.
     expect(policy.areas.overrides[Area.records]).toBe('none')
     expect(policy.definitions.default).toBe('none')
-    expect(policy.resourceDefault).toBe('none')
+    expect(policy.resources.kb?.default).toBe('none')
     expect(reductions).toEqual([])
   })
 
@@ -247,10 +252,53 @@ describe('clamp mechanics', () => {
       definitions: DEFS,
     })
     // areas.default answers only for an area a future deploy adds; the member holds
-    // None on most areas, so the conservative floor is None.
+    // None on most areas, so the conservative floor is None. A future resource TYPE
+    // arrives with a new area and reads through that same floor — which is why the
+    // retired `resourceDefault` needed no replacement of its own.
     expect(policy.areas.default).toBe('none')
     expect(policy.definitions.default).toBe('view')
-    expect(policy.resourceDefault).toBe('none')
+  })
+
+  it('materializes a type the profile left to fall through, bounded by the publisher', () => {
+    // The publisher holds the `dashboards` AREA outright but nothing on any
+    // dashboard instance — the `baselineAtCreate: true` shape. The profile names
+    // no `dashboard` rule, so it would fall through to that Full area at run time;
+    // materializing the entry is what stops the snapshot exceeding its publisher.
+    const areaButNoInstances = publisher({
+      areas: { [Area.dashboards]: Level.Full },
+      defDefault: 'admin',
+      instanceDefault: 'none',
+    })
+    const { policy, reductions } = clampAgentPolicyToPublisher({
+      resolved: allFullResolved(),
+      publisher: areaButNoInstances,
+      publisherUserId: 'u-dash',
+      definitions: DEFS,
+    })
+
+    expect(policy.areas.overrides[Area.dashboards]).toBe('admin')
+    expect(policy.resources.dashboard).toEqual({ default: 'none', overrides: {} })
+    expect(reductions).toEqual(
+      expect.arrayContaining([{ domain: 'resource', key: 'dashboard', from: 'admin', to: 'none' }])
+    )
+  })
+
+  it('clamps a rule naming a resource type this deploy does not register', () => {
+    const { policy } = clampAgentPolicyToPublisher({
+      resolved: {
+        ...allFullResolved(),
+        resources: { retired_kind: { default: 'admin', overrides: { 'x-1': 'admin' } } },
+      },
+      publisher: MEMBER_RECORDS_READ,
+      publisherUserId: 'u-member',
+      definitions: DEFS,
+    })
+    // Kept (the type may come back) but floored by the publisher's weakest
+    // instance bound — there is no gate to probe for an unregistered type.
+    expect(policy.resources.retired_kind).toEqual({
+      default: 'none',
+      overrides: { 'x-1': 'none' },
+    })
   })
 
   it('carries a dangling definition override (archived def) instead of dropping it', () => {

--- a/packages/lib/src/permissions/profiles/agent-policy-clamp.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-clamp.ts
@@ -8,7 +8,11 @@ import type {
 import type { ResourcePermission } from '@auxx/database/enums'
 import type { CapabilityView } from '../capabilities/capability-view'
 import { PERMISSION_RANK } from '../capabilities/compose-user-capabilities'
-import { INSTANCE_ACCESS_KEYS, type InstanceAccessKey } from '../capabilities/instance-access'
+import {
+  INSTANCE_ACCESS_KEYS,
+  INSTANCE_ACCESS_RESOURCES,
+  type InstanceAccessKey,
+} from '../capabilities/instance-access'
 import { AREA_ORDER } from '../capabilities/registry'
 import { areaLevelToPermission, lookupExactPolicy, minPermission } from './agent-policy'
 
@@ -219,11 +223,22 @@ export function clampAgentPolicyToPublisher(input: {
   // actually names are probed; each type's `default` is bounded by the sentinel
   // probe, which is precisely the publisher's posture toward an instance created
   // after publication.
+  //
+  // EVERY REGISTERED TYPE IS MATERIALIZED, including the ones the profile left to
+  // fall through to their area. That materialization is the clamp, not a
+  // convenience: the publisher's authority over a *future instance* of a type can
+  // sit BELOW their area rung (a dashboard is `baselineAtCreate: true`, so an
+  // admin with the `dashboards` area still holds nothing on a dashboard that does
+  // not exist yet). Leaving the entry absent would let the snapshot fall through
+  // to the area rung at run time and quietly exceed the publisher there.
   const resources: Record<string, ExactAgentPolicy> = {}
-  let resourceDefault = resolved.resourceDefault
+  let weakestInstanceBound: ResourcePermission = 'admin'
   for (const key of INSTANCE_ACCESS_KEYS) {
     const forType = resolved.resources[key]
-    const typeDefaultWant = forType?.default ?? resolved.resourceDefault
+    // The fall-through, read off the ALREADY-CLAMPED areas: using the pre-clamp
+    // rung would re-record a reduction the area domain has already reported.
+    const areaRung = areaOverrides[INSTANCE_ACCESS_RESOURCES[key].area] ?? areasDefault
+    const typeDefaultWant = forType?.default ?? areaRung
     const typeBound = publisherInstanceLevel(publisher, key, FUTURE_TARGET_SENTINEL)
     const typeDefaultGot = minPermission(typeDefaultWant, typeBound)
     if (exceeds(typeDefaultWant, typeDefaultGot)) {
@@ -239,26 +254,23 @@ export function clampAgentPolicyToPublisher(input: {
     }
 
     resources[key] = { default: typeDefaultGot, overrides }
-    // Every registered type is now materialized, so `resourceDefault` only ever
-    // answers for a resource type added by a future deploy. Floor it.
-    resourceDefault = minPermission(resourceDefault, typeBound)
-  }
-  if (exceeds(resolved.resourceDefault, resourceDefault)) {
-    record('resource', null, resolved.resourceDefault, resourceDefault)
+    weakestInstanceBound = minPermission(weakestInstanceBound, typeBound)
   }
 
   // Preserve rules for any resource type the registry does not (yet) know, rather
-  // than silently discarding a snapshot entry — but clamp them by the floored
-  // `resourceDefault`. There is no gate to probe for an unregistered type, and
-  // carrying an UNCLAMPED rule through the clamp would be a hole by omission.
+  // than silently discarding a snapshot entry — but clamp them by the publisher's
+  // WEAKEST instance bound, the same conservative posture `areasDefault` takes for
+  // an area a future deploy adds. There is no gate to probe for an unregistered
+  // type, and carrying an UNCLAMPED rule through the clamp would be a hole by
+  // omission the day that type becomes registered again.
   for (const [type, forType] of Object.entries(resolved.resources)) {
     if (type in resources || !forType) continue
     const overrides: Record<string, ResourcePermission> = {}
     for (const [instanceId, want] of overrideEntries(forType)) {
-      overrides[instanceId] = minPermission(want, resourceDefault)
+      overrides[instanceId] = minPermission(want, weakestInstanceBound)
     }
     resources[type] = {
-      default: minPermission(forType.default, resourceDefault),
+      default: minPermission(forType.default, weakestInstanceBound),
       overrides,
     }
   }
@@ -271,7 +283,6 @@ export function clampAgentPolicyToPublisher(input: {
       clamp: reductions,
       areas: { default: areasDefault, overrides: areaOverrides },
       definitions: { default: definitionsDefault, overrides: definitionOverrides },
-      resourceDefault,
       resources,
     },
     reductions,

--- a/packages/lib/src/permissions/profiles/agent-policy-vocabulary.test.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-vocabulary.test.ts
@@ -3,6 +3,7 @@
 import type { PublishedAgentPermissionPolicy } from '@auxx/database'
 import { describe, expect, it } from 'vitest'
 import { migrateAgentPolicyVocabulary } from '../../data-migrations/migrations/054-agent-policy-vocabulary'
+import { dropResourceDefault } from '../../data-migrations/migrations/055-agent-policy-resource-area-fallthrough'
 import { AREA_ORDER, PermissionKey } from '../capabilities/registry'
 import baseline from './__snapshots__/agent-policy-vocabulary.baseline.json'
 import {
@@ -129,12 +130,44 @@ const SCENARIOS = baseline as unknown as Record<
   { policy: PublishedAgentPermissionPolicy; composed: ComposedSnapshot }
 >
 
+/**
+ * The stored-blob migration chain, in deploy order: 054 renames the rungs, 055
+ * retires `resourceDefault` in favour of the per-type area fall-through. A blob
+ * captured before either one experiences both, so the baseline must be replayed
+ * through both — and demanding the composed answer still match is what pins BOTH
+ * migrations as authority-preserving, not just the rename.
+ *
+ * 055 is where the `mixed` scenario earns its keep: it holds
+ * `resourceDefault: read_write` under `workflows: full` and names no `workflow`
+ * rule, so the retired field was genuinely load-bearing there (`min(edit, admin)`
+ * = edit). Dropping it without materializing would hand that agent `admin` on
+ * every workflow. The migration writes `workflow: { default: 'edit' }` and the
+ * composed answer is unchanged — which is exactly the line this test holds.
+ */
+function migrateStoredPolicy(policy: PublishedAgentPermissionPolicy) {
+  return dropResourceDefault(migrateAgentPolicyVocabulary(policy))
+}
+
 describe('the vocabulary rename changes no authority (plan 26 §2.6 / §4)', () => {
   it.each(Object.keys(SCENARIOS))('composes %s identically to the pre-rename baseline', (name) => {
     const scenario = SCENARIOS[name]
     if (!scenario) throw new Error(`missing baseline scenario ${name}`)
-    const migrated = migrateAgentPolicyVocabulary(scenario.policy)
-    expect(compose(migrated)).toEqual(scenario.composed)
+    expect(compose(migrateStoredPolicy(scenario.policy))).toEqual(scenario.composed)
+  })
+
+  it('needs 055 to hold that line — the rename alone would widen `mixed`', () => {
+    const scenario = SCENARIOS.mixed
+    if (!scenario) throw new Error('missing baseline scenario mixed')
+    // Renamed but NOT de-`resourceDefault`ed: the field is now ignored on read, so
+    // `workflow` falls straight through to its `full` area. A guard against this
+    // test being "fixed" one day by dropping the 055 step from the chain.
+    const renamedOnly = compose(migrateAgentPolicyVocabulary(scenario.policy))
+    expect(renamedOnly).not.toEqual(scenario.composed)
+    expect(renamedOnly.instances['workflow:wf-1']).toEqual({
+      view: true,
+      edit: true,
+      admin: true,
+    })
   })
 
   it('covers every scenario the baseline recorded — a silently emptied fixture must fail', () => {
@@ -197,6 +230,14 @@ describe('data migration 054 is idempotent', () => {
     })
   })
 
+  it('leaves 055 a clean hand-off — the two migrations touch disjoint fields', () => {
+    for (const [name, scenario] of Object.entries(SCENARIOS)) {
+      const renamed = migrateAgentPolicyVocabulary(scenario.policy)
+      // 055 never re-spells a rung, so running it cannot undo 054.
+      expect(JSON.stringify(dropResourceDefault(renamed)), name).not.toContain('"read_write"')
+    }
+  })
+
   it('rewrites the clamp trail, which is rendered but excluded from configHash', () => {
     const migrated = migrateAgentPolicyVocabulary({
       clamp: [{ domain: 'area', key: 'records', from: 'full', to: 'read' }],
@@ -204,6 +245,48 @@ describe('data migration 054 is idempotent', () => {
     expect(migrated).toEqual({
       clamp: [{ domain: 'area', key: 'records', from: 'admin', to: 'view' }],
     })
+  })
+})
+
+describe('data migration 055 retires resourceDefault without moving authority', () => {
+  it('is the identity on already-migrated input, in every scenario', () => {
+    for (const [name, scenario] of Object.entries(SCENARIOS)) {
+      const once = migrateStoredPolicy(scenario.policy)
+      expect(dropResourceDefault(once), name).toEqual(once)
+    }
+  })
+
+  it('drops the field entirely, in every scenario', () => {
+    for (const [name, scenario] of Object.entries(SCENARIOS)) {
+      expect(migrateStoredPolicy(scenario.policy), name).not.toHaveProperty('resourceDefault')
+    }
+  })
+
+  it('materializes only where the field was load-bearing, and at the old rung', () => {
+    const migrated = dropResourceDefault({
+      areas: { default: 'view', overrides: { workflows: 'admin', dashboards: 'none' } },
+      definitions: { default: 'none', overrides: {} },
+      resourceDefault: 'edit',
+      resources: { kb: { default: 'admin', overrides: {} } },
+    })
+    expect(migrated).toEqual({
+      areas: { default: 'view', overrides: { workflows: 'admin', dashboards: 'none' } },
+      definitions: { default: 'none', overrides: {} },
+      resources: {
+        // Already had a rule of its own — untouched.
+        kb: { default: 'admin', overrides: {} },
+        // `edit` sat BELOW `workflows: admin`, so it was doing work. Pinned.
+        workflow: { default: 'edit', overrides: {} },
+        // `edit` sat at or ABOVE these areas, so `min` picked the area either
+        // way and the fall-through now reproduces it with no entry at all.
+        // dataset (areas.default view), dashboard (none), agent (view): absent.
+      },
+    })
+  })
+
+  it('is a no-op on a blob that never carried the field', () => {
+    const already = { areas: { default: 'view', overrides: {} }, resources: {} }
+    expect(dropResourceDefault(already)).toBe(already)
   })
 })
 

--- a/packages/lib/src/permissions/profiles/agent-policy.test.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy.test.ts
@@ -48,7 +48,6 @@ function uniform(level: ResourcePermission): AgentPermissionPolicy {
   return {
     areas: { default: level, overrides: {} },
     definitions: { default: level, overrides: {} },
-    resourceDefault: level,
     resources: {},
   }
 }
@@ -80,7 +79,6 @@ describe('lookups are total — there is no run-time inherit (§2.3)', () => {
     ...emptyAgentPolicy(),
     areas: { default: 'view', overrides: { [Area.records]: 'admin' } },
     definitions: { default: 'edit', overrides: { deals: 'none' } },
-    resourceDefault: 'view',
     resources: { kb: { default: 'none', overrides: { 'kb-1': 'admin' } } },
   }
 
@@ -94,11 +92,27 @@ describe('lookups are total — there is no run-time inherit (§2.3)', () => {
     expect(policyDefinitionLevel(policy, 'a-def-that-did-not-exist-at-publish')).toBe('edit')
   })
 
-  it('answers an unlisted resource type from resourceDefault, not from another type', () => {
-    expect(policyResourceLevel(policy, 'kb', 'kb-1')).toBe('admin')
+  it('answers an unlisted resource type from its own area, not from another type', () => {
+    // `kb-1`'s own rule is `admin`, but `knowledgeBase` is only `view` here — the
+    // area gate is INSIDE this lookup now, so the rule cannot outrun its parent.
+    expect(policyResourceLevel(policy, 'kb', 'kb-1')).toBe('view')
     expect(policyResourceLevel(policy, 'kb', 'kb-2')).toBe('none')
-    // `dataset` has no entry at all → the top-level resourceDefault answers.
+    // `dataset` has no entry at all → the `datasets` area answers, not `kb`'s rule.
     expect(policyResourceLevel(policy, 'dataset', 'ds-1')).toBe('view')
+    // `records: admin` must not leak sideways into a resource type.
+    expect(policyResourceLevel(policy, 'dashboard', 'dash-1')).toBe('view')
+  })
+
+  it('fails closed for a resource type this deploy no longer registers', () => {
+    expect(policyResourceLevel(policy, 'a-retired-resource-kind', 'x-1')).toBe('none')
+  })
+
+  it('lets an area of none close a type that carries an explicit rule', () => {
+    const closed: PublishedAgentPermissionPolicy = {
+      ...policy,
+      areas: { default: 'none', overrides: {} },
+    }
+    expect(policyResourceLevel(closed, 'kb', 'kb-1')).toBe('none')
   })
 })
 
@@ -107,7 +121,21 @@ describe('parsePublishedAgentPolicy coerces defensively and fails closed', () =>
     const parsed = parsePublishedAgentPolicy(null)
     expect(parsed.areas.default).toBe('none')
     expect(parsed.definitions.default).toBe('none')
-    expect(parsed.resourceDefault).toBe('none')
+    expect(parsed.resources).toEqual({})
+    // No resource keyspace of its own to fail closed — an unreadable policy has
+    // an all-`none` area map, and every resource type reads through that.
+    expect(policyResourceLevel(parsed, 'kb', 'kb-1')).toBe('none')
+  })
+
+  it('reads a type entry with a corrupt default as none, not as its area rung', () => {
+    const parsed = parsePublishedAgentPolicy({
+      areas: { default: 'admin', overrides: {} },
+      resources: { kb: { default: 'sideways', overrides: {} } },
+    })
+    // The area fall-through is for a type with NO entry. A corrupt entry must not
+    // read wider than the absence it replaced.
+    expect(parsed.resources.kb?.default).toBe('none')
+    expect(policyResourceLevel(parsed, 'kb', 'kb-1')).toBe('none')
   })
 
   it('drops override values outside the closed vocabulary rather than guessing', () => {

--- a/packages/lib/src/permissions/profiles/agent-policy.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy.ts
@@ -9,6 +9,7 @@ import type {
 import { type ResourcePermission, ResourcePermissionValues } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { PERMISSION_RANK } from '../capabilities/compose-user-capabilities'
+import { INSTANCE_ACCESS_RESOURCES, type InstanceAccessKey } from '../capabilities/instance-access'
 import { AREA_ORDER, type Area, Level } from '../capabilities/registry'
 import { systemProfileForAgentKind } from './system-profiles'
 import type { CachedPermissionProfile } from './types'
@@ -96,18 +97,49 @@ export function policyDefinitionLevel(
 }
 
 /**
- * The published rung for one resource instance. A resource TYPE absent from
- * `resources` falls back to `resourceDefault` — that is what makes the snapshot
- * total for resource types (and instances) created after publication.
+ * The rung a resource type falls through to when the policy names no rule for it
+ * — its own L2 area, which is the *human* model's fallback verbatim
+ * (`INSTANCE_ACCESS_RESOURCES`: for `baselineAtCreate: false` resources "an
+ * absent instance row → the base L2 area level").
+ *
+ * This is what replaced a top-level `resourceDefault` field. That field answered
+ * the same question a second time, one level up from the area rung it was then
+ * intersected with, so the editor had to offer two blanket dropdowns whose
+ * difference nobody could state — and an `All datasets` row could read
+ * *"Default · None"* under a `Datasets: Read` area, contradicting its own parent.
+ *
+ * An UNREGISTERED type (a snapshot naming a resource kind this deploy no longer
+ * has) has no area to ask, so it fails closed at `'none'`. It is inert either
+ * way — nothing can call `canViewInstance` for a key the registry dropped.
+ */
+function resourceTypeAreaLevel(
+  policy: PublishedAgentPermissionPolicy,
+  resourceType: string
+): ResourcePermission {
+  const config = INSTANCE_ACCESS_RESOURCES[resourceType as InstanceAccessKey]
+  return config ? policyAreaLevel(policy, config.area) : 'none'
+}
+
+/**
+ * The published rung for one resource instance: the most specific rule that
+ * names it, intersected with its coarse L2 area gate.
+ *
+ * The intersection is the whole composition model in one line (§0.5) — an area
+ * of `None` closes the feature no matter what a stale instance rule says — and it
+ * is also what makes the snapshot total. A type with no entry, or a type added by
+ * a deploy that postdates publication, resolves through
+ * {@link resourceTypeAreaLevel} to the area rung, which `areas.default` already
+ * answers for an area the snapshot predates.
  */
 export function policyResourceLevel(
   policy: PublishedAgentPermissionPolicy,
   resourceType: string,
   instanceId: string
 ): ResourcePermission {
+  const areaGate = resourceTypeAreaLevel(policy, resourceType)
   const forType = policy.resources[resourceType]
-  if (!forType) return policy.resourceDefault
-  return lookupExactPolicy(forType, instanceId)
+  if (!forType) return areaGate
+  return minPermission(lookupExactPolicy(forType, instanceId), areaGate)
 }
 
 /** Coerce an arbitrary stored value into the closed rung vocabulary, or `null`. */
@@ -162,11 +194,14 @@ export function parsePublishedAgentPolicy(
     clamp?: unknown
   }
 
-  const resourceDefault = parsePolicyPermission(source.resourceDefault) ?? fallbackDefault
+  // A type entry whose own `default` is unreadable falls back to `fallbackDefault`
+  // (`'none'`), NOT to its area rung: the area fall-through is for a type with no
+  // entry at all, and a corrupt entry must not read as a wider rule than the
+  // absence it replaced.
   const resources: Record<string, ExactAgentPolicy> = {}
   if (source.resources && typeof source.resources === 'object') {
     for (const [type, value] of Object.entries(source.resources as Record<string, unknown>)) {
-      resources[type] = parseExactPolicy(value, resourceDefault)
+      resources[type] = parseExactPolicy(value, fallbackDefault)
     }
   }
 
@@ -179,7 +214,6 @@ export function parsePublishedAgentPolicy(
     clamp: Array.isArray(source.clamp) ? source.clamp : [],
     areas: parseExactPolicy(source.areas, fallbackDefault),
     definitions: parseExactPolicy(source.definitions, fallbackDefault),
-    resourceDefault,
     resources,
   }
 }
@@ -217,13 +251,11 @@ export function parseAgentPolicy(raw: unknown): AgentPermissionPolicy {
 export function authorizationOnlyPolicy(policy: PublishedAgentPermissionPolicy): {
   areas: ExactAgentPolicy
   definitions: ExactAgentPolicy
-  resourceDefault: ResourcePermission
   resources: Partial<Record<string, ExactAgentPolicy>>
 } {
   return {
     areas: policy.areas,
     definitions: policy.definitions,
-    resourceDefault: policy.resourceDefault,
     resources: policy.resources,
   }
 }
@@ -254,7 +286,6 @@ export function legacyFullAgentPolicy(): PublishedAgentPermissionPolicy {
     clamp: [],
     areas: { default: 'admin', overrides: {} },
     definitions: { default: 'admin', overrides: {} },
-    resourceDefault: 'admin',
     resources: {},
   }
 }
@@ -271,7 +302,6 @@ export function emptyAgentPolicy(): PublishedAgentPermissionPolicy {
     clamp: [],
     areas: { default: 'none', overrides: {} },
     definitions: { default: 'none', overrides: {} },
-    resourceDefault: 'none',
     resources: {},
   }
 }
@@ -307,7 +337,6 @@ function expandProfilePolicy(
     clamp: [],
     areas: { default: parsed.areas.default, overrides: areaOverrides },
     definitions: parsed.definitions,
-    resourceDefault: parsed.resourceDefault,
     resources: parsed.resources,
   }
 }

--- a/packages/lib/src/permissions/profiles/profile-queries.test.ts
+++ b/packages/lib/src/permissions/profiles/profile-queries.test.ts
@@ -61,7 +61,6 @@ const agentProfile = profile({
   agentPolicy: {
     areas: { default: 'view', overrides: {} },
     definitions: { default: 'none', overrides: {} },
-    resourceDefault: 'none',
     resources: {},
   },
 })

--- a/packages/lib/src/permissions/profiles/profile-save.test.ts
+++ b/packages/lib/src/permissions/profiles/profile-save.test.ts
@@ -854,6 +854,7 @@ describe('savePermissionProfile — the other §6.1.5 gates', () => {
       agentPolicy: {
         areas: { default: 'view', overrides: { records: 'admin', tickets: 'sideways' } },
         definitions: { default: 'none', overrides: { hr: 'edit' } },
+        // A retired field an old client might still send: stripped, never stored.
         resourceDefault: 'none',
         resources: { dataset: { default: 'view', overrides: {} } },
       } as never,
@@ -865,7 +866,6 @@ describe('savePermissionProfile — the other §6.1.5 gates', () => {
       // default rather than being guessed at.
       areas: { default: 'view', overrides: { records: 'admin' } },
       definitions: { default: 'none', overrides: { hr: 'edit' } },
-      resourceDefault: 'none',
       resources: { dataset: { default: 'view', overrides: {} } },
     })
   })

--- a/packages/lib/src/permissions/profiles/system-profiles.ts
+++ b/packages/lib/src/permissions/profiles/system-profiles.ts
@@ -42,12 +42,18 @@ interface SystemProfileSeed {
   levels: Partial<Record<Area, Level>> | null
 }
 
-/** A total agent policy at one uniform level — the `agent`/`chat_agent` seeds' shape. */
+/**
+ * A total agent policy at one uniform level — the `agent`/`chat_agent` seeds'
+ * shape.
+ *
+ * `resources` stays empty: every resource type falls through to its own area,
+ * and every area is `level` here, so the uniform posture reaches instances
+ * without restating itself five times.
+ */
 function uniformAgentPolicy(level: ResourcePermission): AgentPermissionPolicy {
   return {
     areas: { default: level, overrides: {} },
     definitions: { default: level, overrides: {} },
-    resourceDefault: level,
     resources: {},
   }
 }
@@ -177,7 +183,11 @@ export const SYSTEM_PROFILE_SEEDS: readonly SystemProfileSeed[] = [
         },
       },
       definitions: { default: 'edit', overrides: {} },
-      resourceDefault: 'none',
+      // Kept explicit even though `knowledgeBase: view` above already supplies
+      // this rung by fall-through — the entry PINS instance access at `view` if
+      // that area is later raised, which is the preset's whole shape ("answers
+      // from the KB", never rewrites it). Every other type has no entry and
+      // follows its own area, all of which are `none` here.
       resources: { kb: { default: 'view', overrides: {} } },
     },
     levels: null,
@@ -205,7 +215,10 @@ export const SYSTEM_PROFILE_SEEDS: readonly SystemProfileSeed[] = [
         },
       },
       definitions: { default: 'view', overrides: {} },
-      resourceDefault: 'view',
+      // Nothing to state: datasets, dashboards and KBs each follow the `view`
+      // area above, and workflows/agents follow `areas.default` to `none` —
+      // which is exactly what the old `resourceDefault: 'view'` resolved to once
+      // it was intersected with those same areas.
       resources: {},
     },
     levels: null,


### PR DESCRIPTION
Retires `AgentPermissionPolicy.resourceDefault`. A resource type with no rule of its own now resolves through **its own L2 area rung** — the human model verbatim (`INSTANCE_ACCESS_RESOURCES`: for a `baselineAtCreate: false` resource, an absent instance row resolves to the base L2 area level).

### Why

Came out of a question while reading the merged agent tree: *why does an agent profile show two blanket dropdowns —* `Unset areas fall through to` *and* `New resource types fall through to` *— when a human profile shows one?*

The field answered "what does an unruled resource type resolve to?" **one level above the area gate its answer was then intersected with** (`min(rule, areaGate)`). Three concrete consequences:

- Two header dropdowns side by side whose difference an admin could not state.
- An `All datasets` child row reading **"Default · None"** underneath a `Datasets: Read` parent — a child contradicting its own parent, in a tree whose entire premise is *"the nesting is the clamp"* (plan 29 §1.2).
- A gratuitous divergence from the human model. Agents were the only principal carrying a second, competing blanket default.

### What changed

`policyResourceLevel(policy, type, id)` now owns both halves — the most specific rule naming the instance, intersected with `INSTANCE_ACCESS_RESOURCES[type].area`'s rung — and a type with no entry resolves to that area rung directly. `instanceLevel` is a one-line delegate; the duplicated `min` at the call site is deleted, so the area's authority lives in one place instead of two that had to agree. An **unregistered** type (a snapshot naming a resource kind this deploy dropped) fails closed at `none`.

**A future resource type needs no knob.** It ships with a new area, that area is absent from an older snapshot's `areas.overrides`, so it reads `areas.default` — the *first* dropdown, already floored by the publish clamp. That is why the second one was removable rather than replaceable.

### Authority does not move — checked, not asserted

All four seeded presets resolve identically (`analyst_agent`'s `resourceDefault: 'view'` was already `min`'d to `none` on workflows/agents by its own area map; the all-`admin` `agent` seed reaches instances through its all-`admin` areas). `agent-policy-vocabulary.test.ts`'s pre-rename capability baseline now replays through **054 → 055** and still matches byte for byte, with a companion test asserting the rename **alone** would widen the `mixed` scenario — so the chain cannot be "fixed" later by dropping the 055 step.

### The one case that genuinely moved

Where an absent type had `resourceDefault` **strictly below** its area rung, the old `min` picked the field and the new fall-through would pick the area — a widening. **Data migration 055** materializes exactly those types as explicit entries at the old rung before dropping the field, and leaves every other policy shorter but unchanged. `dropResourceDefault` is exported and unit-tested as a pure function.

`configHash` is recomputed for every `AgentVersion` — `authorizationOnlyPolicy` no longer emits the field, so every stored hash would otherwise be stale and the first publish after deploy would mint a pointless version. Same trap migrations 050 and 054 both document.

### The publish clamp still materializes every registered type

Load-bearing, not tidiness: a publisher can hold the `dashboards` **area** outright while holding nothing on any dashboard instance (`baselineAtCreate: true`), so an unmaterialized entry would fall through to that Full area at run time and **exceed its publisher**. The type default's fall-through is read off the **already-clamped** areas so the area domain does not re-report its own reduction. Unregistered-type entries are floored by the publisher's weakest instance bound (the direct analogue of `weakestPublisherArea`), replacing the floored-`resourceDefault` they used to lean on.

### Verification

- `packages/lib` — `permissions` + `data-migrations` + `agent-run-capabilities`: **449 pass**
- `apps/web` — `components/permissions` + `components/agents`: **149 pass**; with `server/api/routers`: **551 pass**
- tsc: `apps/web` still **4066** (baseline unchanged), **zero hits on any changed file**. `agent-policy.test.ts:30` errors on a missing `role` field — pre-existing, no hunk in this diff goes near it.
- biome clean across 3207 files.

### Deploy note

Between the code deploy and the migration run, new code reads old blobs and ignores `resourceDefault` — so for that window exactly the widening case above is live. It only affects a policy where an admin deliberately held resources *below* their area gate. **Run 055 promptly**; it is idempotent.

### Owed

A browser pass on the agent policy tab. The header now has one dropdown, and the `All X` rows should read `Default · <their own area's rung>` rather than a policy-wide rung. The read-only **Resolved policy** dialog lost its `Resources` default row (there is no single rung left to print); its per-type rows carry their own area-derived level instead — worth an eyeball that the domain does not look truncated.