### PR TITLE
fix(permissions): gate the remaining kb write affordances on instance access

### DIFF
--- a/apps/web/src/components/kb/ui/editor/article-cover-strip.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-cover-strip.tsx
@@ -9,11 +9,13 @@ import { useFileSelect } from '~/components/file-select'
 import { FileSelectPicker } from '~/components/pickers/file-select-picker'
 import { useResource } from '~/components/resources/hooks'
 import { RecordTagChip } from '~/components/tags/ui/record-tag-chip'
+import { TagBadge } from '~/components/tags/ui/tag-badge'
 import { TagPicker } from '~/components/tags/ui/tag-picker'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import { useArticleTags } from '../../hooks/use-article-tags'
 import type { ArticleMeta } from '../../store/article-store'
+import { useKBEditorAccess } from './kb-editor-access-context'
 
 interface ArticleCoverStripProps {
   article: ArticleMeta
@@ -23,6 +25,11 @@ interface ArticleCoverStripProps {
 const HIDDEN_KINDS = new Set(['link', 'tab', 'header'])
 
 export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStripProps) {
+  // Cover + tags are both article writes (`kb.updateArticleDraft` /
+  // the tag mutations), so a view-level member gets the read-only strip: the
+  // cover renders without Replace/Remove, tags render as plain badges, and the
+  // "Add cover"/"Add tags" entry points disappear entirely.
+  const { canEdit } = useKBEditorAccess()
   const { updateArticleCover } = useArticleMutations(knowledgeBaseId)
   const [confirm, ConfirmDialog] = useConfirm()
   const [tagsOpen, setTagsOpen] = useState(false)
@@ -73,18 +80,24 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
 
   const tagChips = selectedTags.length > 0 && (
     <div className='flex flex-row flex-wrap items-center gap-1.5'>
-      {selectedTags.map((tagId) => (
-        <RecordTagChip
-          key={tagId}
-          tagId={tagId}
-          removeLabel='article'
-          onRemove={() => handleTagChange(selectedTags.filter((id) => id !== tagId))}
-        />
-      ))}
+      {selectedTags.map((tagId) =>
+        canEdit ? (
+          <RecordTagChip
+            key={tagId}
+            tagId={tagId}
+            removeLabel='article'
+            onRemove={() => handleTagChange(selectedTags.filter((id) => id !== tagId))}
+          />
+        ) : (
+          // Plain badge, not the chip — the chip's dropdown offers remove/edit/
+          // delete-tag, all of which are writes.
+          <TagBadge key={tagId} recordId={tagId} size='sm' />
+        )
+      )}
     </div>
   )
 
-  const tagsButton = (
+  const tagsButton = canEdit && (
     <Button
       ref={tagsButtonRef}
       type='button'
@@ -97,7 +110,7 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
     </Button>
   )
 
-  const tagPicker = tagsOpen && (
+  const tagPicker = tagsOpen && canEdit && (
     <TagPicker
       open={tagsOpen}
       onOpenChange={setTagsOpen}
@@ -111,25 +124,41 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
   )
 
   if (!coverImage) {
+    // Nothing to add, nothing to show — skip the row entirely rather than
+    // leaving an empty band of padding above the title.
+    if (!canEdit && !tagChips) return null
     return (
       <>
         <div className='page-block-openapi:ml-0 mx-auto flex w-full max-w-(--block-wrapper-max-width) flex-wrap items-center gap-2 pt-4'>
-          <FileSelectPicker fileSelect={fileSelect} hideBrowseExisting>
-            <Button
-              type='button'
-              variant='ghost'
-              size='sm'
-              className='gap-1.5 text-muted-foreground hover:text-foreground'>
-              <ImagePlus />
-              Add cover
-            </Button>
-          </FileSelectPicker>
+          {canEdit && (
+            <FileSelectPicker fileSelect={fileSelect} hideBrowseExisting>
+              <Button
+                type='button'
+                variant='ghost'
+                size='sm'
+                className='gap-1.5 text-muted-foreground hover:text-foreground'>
+                <ImagePlus />
+                Add cover
+              </Button>
+            </FileSelectPicker>
+          )}
           {tagsButton}
           {tagChips}
         </div>
         {tagPicker}
         <ConfirmDialog />
       </>
+    )
+  }
+
+  // Read-only: the cover stands alone and any tags sit under it as plain
+  // badges — the hover overlay only ever holds write affordances.
+  if (!canEdit) {
+    return (
+      <div className='page-block-openapi:ml-0 mx-auto w-full max-w-(--block-wrapper-max-width) pt-4'>
+        <CoverImage src={coverImage} />
+        {tagChips && <div className='pt-2'>{tagChips}</div>}
+      </div>
     )
   }
 

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -183,7 +183,13 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
                     knowledgeBaseId={knowledgeBaseId}
                     onReady={handleBodyEditorReady}
                     readOnly={bodyReadOnly}
-                    hideGutter={managed}
+                    // Collapse the gutter for every *durable* read-only state —
+                    // its drag handles are dead weight and its pull-left margin
+                    // leaves the body sitting left of the title. Deliberately
+                    // NOT `bodyReadOnly`: `locked` is a transient Kopilot turn,
+                    // and folding the gutter mid-turn would shift the body
+                    // sideways and back.
+                    hideGutter={managed || !canEdit}
                   />
                 )}
                 {locked && (

--- a/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
@@ -2,7 +2,8 @@
 'use client'
 
 import { mergeDraftOverLive } from '@auxx/lib/kb/client'
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
+import { toRecordId } from '@auxx/types/resource'
 import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
 import {
   DropdownMenuItem,
@@ -14,6 +15,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useActiveKnowledgeBaseId } from '../../hooks/use-knowledge-base'
 import { useKnowledgeBaseMutations } from '../../hooks/use-knowledge-base-mutations'
@@ -51,13 +53,19 @@ export function KBSwitcherDropdownContent() {
 
   const { getLimit } = useFeatureFlags()
   const kbLimit = getLimit(FeatureKey.knowledgeBases)
+  // Mirrors the server: `kb.create` asserts the L2 area key AND the plan limit,
+  // `kb.delete` asserts `assertAdminInstance` per KB. Degrade-only — the router
+  // is still the enforcement point.
+  const { can, canAdminInstance } = useAccess()
+  const canManageKBs = can(PermissionKey.knowledgeBaseManage)
 
   const canCreateKB = useMemo(() => {
+    if (!canManageKBs) return false
     if (kbLimit === null || kbLimit === false || kbLimit === 0) return false
     if (kbLimit === '+' || kbLimit === true) return true
     if (typeof kbLimit === 'number') return knowledgeBases.length < kbLimit
     return true
-  }, [kbLimit, knowledgeBases.length])
+  }, [canManageKBs, kbLimit, knowledgeBases.length])
 
   const activeKB = useMemo(() => {
     const kb = knowledgeBases.find((k) => k.id === activeKBId)
@@ -135,6 +143,7 @@ export function KBSwitcherDropdownContent() {
         knowledgeBases.map((kb) => {
           const merged = mergeDraftOverLive(kb as Record<string, unknown>) as typeof kb
           const isActive = kb.id === activeKBId
+          const canDelete = canAdminInstance(toRecordId('kb', kb.id))
           return (
             <DropdownMenuItem
               key={kb.id}
@@ -153,17 +162,19 @@ export function KBSwitcherDropdownContent() {
                     targetIds={{ knowledgeBaseId: kb.id }}
                     revealOnHoverClassName='group-hover/kb-item:flex'
                   />
-                  <button
-                    type='button'
-                    aria-label={`Delete ${merged.name}`}
-                    className='hidden group-hover/kb-item:flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-bad-100 hover:text-bad-500'
-                    onClick={(e) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      handleDelete(kb.id, merged.name ?? 'this knowledge base')
-                    }}>
-                    <Trash2 className='size-3' />
-                  </button>
+                  {canDelete && (
+                    <button
+                      type='button'
+                      aria-label={`Delete ${merged.name}`}
+                      className='hidden group-hover/kb-item:flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-bad-100 hover:text-bad-500'
+                      onClick={(e) => {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        handleDelete(kb.id, merged.name ?? 'this knowledge base')
+                      }}>
+                      <Trash2 className='size-3' />
+                    </button>
+                  )}
                   {isActive && (
                     <div className='rounded-full size-4 bg-info flex items-center justify-center border border-blue-800'>
                       <Check className='size-2.5! text-white' strokeWidth={4} />

--- a/apps/web/src/components/kb/ui/sidebar/kb-tab-strip.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-tab-strip.tsx
@@ -18,6 +18,7 @@ import { useArticleList } from '../../hooks/use-article-list'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import { usePublishWithConfirm } from '../../hooks/use-publish-with-confirm'
 import { type ArticleMeta, getArticleStoreState } from '../../store/article-store'
+import { useKBEditorAccess } from '../editor/kb-editor-access-context'
 import { TabSlugDialog } from './tab-slug-dialog'
 
 interface KBTabStripProps {
@@ -34,6 +35,10 @@ interface KBTabStripProps {
  * add UI.
  */
 export function KBTabStrip({ knowledgeBaseId, activeTabId, onTabChange }: KBTabStripProps) {
+  // View-level members get plain clickable pills: no `+`, no inline rename, no
+  // drag-reorder, no context menu. Every affordance behind `editable` maps to a
+  // mutation the router gates with `assertEditInstance` (doc 24 §A.2.4).
+  const { canEdit } = useKBEditorAccess()
   const articles = useArticleList(knowledgeBaseId)
   const tabs = useMemo(
     () =>
@@ -139,6 +144,7 @@ export function KBTabStrip({ knowledgeBaseId, activeTabId, onTabChange }: KBTabS
     <TabStrip
       tabs={tabs}
       activeTabId={activeTabId}
+      editable={canEdit}
       onSelect={onTabChange}
       onRename={(id, title) => void renameArticle(id, { title })}
       onReorder={handleReorder}

--- a/packages/ui/src/components/input-search.tsx
+++ b/packages/ui/src/components/input-search.tsx
@@ -44,7 +44,7 @@ function InputSearch({
         onChange={onChange}
         className={cn(
           'flex w-full rounded-md py-1 shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-hidden  focus-visible:ring-primary-200 disabled:cursor-not-allowed disabled:opacity-50',
-          'h-7 flex-1 border-none pl-7 text-xs',
+          'h-7 flex-1 border-none pl-7 text-xs ring-1 ring-primary-100',
           'bg-muted/50 hover:bg-muted focus-visible:bg-muted',
           'focus-visible:ring-1',
           className


### PR DESCRIPTION
Four surfaces in the KB admin UI still offered writes to view-level members. All degrade-only — the router asserts remain the enforcement point.

### `kb-switcher.tsx`
The per-KB delete button had **no capability check at all**. The landing card (`knowledge-base-card.tsx`) and the bulk bar already gate on `canAdminInstance(toRecordId('kb', kb.id))`; the switcher dropdown — rendered in both the editor header and the KB landing page — was the outlier. Delete now mirrors `kb.delete`'s `assertAdminInstance`.

While there: "Add Knowledge Base" was gated on the **plan limit only**, so a member without `knowledgeBase.manage` saw a create entry point that 403s. It now ANDs the capability with the limit, matching `kb.create` (which asserts both) and `knowledge-bases-list.tsx`.

### `kb-tab-strip.tsx`
`TabStrip` already has an `editable` prop that gates add / inline rename / drag-reorder / context menu together — it just wasn't being passed. Now `editable={canEdit}`; read-only members get plain clickable pills.

### `article-cover-strip.tsx`
Hide "Add cover", "Add tags" and the Replace/Remove hover overlay. Two related things in the same surface:

- tags rendered via `RecordTagChip`, whose dropdown offers *Remove from article / Edit tag / Delete tag* — all writes. Read-only now renders a plain `TagBadge`.
- with no cover and no tags the strip was an empty band of padding above the title, so it returns `null` in that case.

### `article-editor.tsx`
`hideGutter` was wired to `managed` only — source-managed articles. A permission-based read-only view never got it, so the gutter's negative pull-left margin stayed applied while the rail itself was inert, leaving the body sitting left of the title. This is exactly the case the prop's own doc comment describes.

Deliberately **not** `bodyReadOnly`: that includes `locked`, the transient Kopilot write turn, and folding the gutter mid-turn would shift the body sideways and back. Uses `managed || !canEdit`, matching what `ArticleEditorTop` already receives.

### Also
`style(ui)`: a 1px `primary-100` resting ring on `InputSearch` — the borderless input read as a flat fill against muted backgrounds. Doesn't touch the existing `focus-visible` ring.

## Verification
- Biome clean.
- `apps/web` typecheck: 4066 errors, the known baseline. The five reported in these files are all pre-existing — `Button` + `ref` fails at 5 sites repo-wide including inside `packages/ui`, and the other two sit outside the changed hunks.
- **Not verified in a browser.** The gutter fix in particular is worth an eyeball: open an article in a KB where you only hold `view`, and confirm the body lines up under the title.