### PR TITLE
feat(permissions): honour per-kb instance access in apps/kb

### DIFF
--- a/apps/kb/package.json
+++ b/apps/kb/package.json
@@ -7,7 +7,10 @@
     "dev": "next dev --turbopack --port 3002",
     "build": "next build",
     "clean": "rm -rf .turbo node_modules .next",
-    "start": "PORT=3002 node .next/standalone/apps/kb/server.js"
+    "start": "PORT=3002 node .next/standalone/apps/kb/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@aws-sdk/s3-presigned-post": "catalog:",
@@ -40,6 +43,9 @@
     "prettier": "^3.8.1",
     "rimraf": "catalog:",
     "tailwindcss": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-tsconfig-paths": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
@@ -1,7 +1,5 @@
 // apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
 
-import { WEBAPP_URL } from '@auxx/config/urls'
-import { isOrgMember } from '@auxx/lib/cache'
 import {
   findArticleBySlugPath,
   findFirstNavigableUnder,
@@ -17,6 +15,7 @@ import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { ArticleMarkdownCopy } from '~/components/article-markdown-copy'
 import { getLocalSession, getLoginUrl } from '~/lib/auth'
+import { canViewKB, kbDenialRedirect } from '../../../../server/kb-access'
 import {
   getCachedKBVisibility,
   getPublicKBPayloadWithContent,
@@ -149,14 +148,16 @@ async function InternalArticleGate({
   if (!session) {
     redirect(getLoginUrl(kbId, `/${orgSlug}/${kbSlug}/${articleSlug.join('/')}`))
   }
-  const member = await isOrgMember(organizationId, session.userId)
-  if (!member) {
-    redirect(`${WEBAPP_URL}/kb-auth/no-access`)
+  if (!(await canViewKB(kbId, organizationId, session.userId))) {
+    await kbDenialRedirect(organizationId, session.userId)
   }
 
-  const { articles } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
+  const { articles, accessDenied } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
     session: { userId: session.userId },
   })
+  // See the layout gate: covers a revocation landing between the pre-flight
+  // and the chokepoint, which would otherwise 404 instead of explaining.
+  if (accessDenied === 'forbidden') await kbDenialRedirect(organizationId, session.userId)
   return (
     <ArticleBodyContent
       articles={articles}

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
@@ -1,7 +1,5 @@
 // apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
 
-import { WEBAPP_URL } from '@auxx/config/urls'
-import { isOrgMember } from '@auxx/lib/cache'
 import { KBLayout } from '@auxx/ui/components/kb'
 import '@auxx/ui/global.css'
 import type { Metadata } from 'next'
@@ -9,6 +7,7 @@ import { cacheLife, cacheTag } from 'next/cache'
 import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { getLocalSession, getLoginUrl } from '~/lib/auth'
+import { canViewKB, kbDenialRedirect } from '../../../server/kb-access'
 import { getCachedKBVisibility, getPublicKBPayload, kbTag } from '../../../server/kb-cache'
 import { loadKBPayload } from '../../../server/kb-data'
 
@@ -102,14 +101,18 @@ async function InternalKBLayoutGate({
   if (!session) {
     redirect(getLoginUrl(kbId, `/${orgSlug}/${kbSlug}`))
   }
-  const member = await isOrgMember(organizationId, session.userId)
-  if (!member) {
-    redirect(`${WEBAPP_URL}/kb-auth/no-access`)
+  if (!(await canViewKB(kbId, organizationId, session.userId))) {
+    await kbDenialRedirect(organizationId, session.userId)
   }
 
-  const { kb, articles } = await loadKBPayload(orgSlug, kbSlug, {
+  const { kb, articles, accessDenied } = await loadKBPayload(orgSlug, kbSlug, {
     session: { userId: session.userId },
   })
+  // The chokepoint denied after the pre-flight allowed — the two read
+  // capabilities a moment apart, so a grant revoked in between lands here.
+  // Without this the member gets a bare 404 mid-layout instead of the
+  // no-access screen the pre-flight would have sent them to.
+  if (accessDenied === 'forbidden') await kbDenialRedirect(organizationId, session.userId)
   if (!kb) notFound()
 
   const basePath = `/${orgSlug}/${kbSlug}`

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
@@ -1,7 +1,5 @@
 // apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
 
-import { WEBAPP_URL } from '@auxx/config/urls'
-import { isOrgMember } from '@auxx/lib/cache'
 import {
   findFirstNavigableUnder,
   getFullSlugPath,
@@ -15,6 +13,7 @@ import { cacheLife, cacheTag } from 'next/cache'
 import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { getLocalSession, getLoginUrl } from '~/lib/auth'
+import { canViewKB, kbDenialRedirect } from '../../../server/kb-access'
 import {
   getCachedKBVisibility,
   getPublicKBPayloadWithContent,
@@ -106,14 +105,16 @@ async function InternalLandingGate({
   if (!session) {
     redirect(getLoginUrl(kbId, `/${orgSlug}/${kbSlug}`))
   }
-  const member = await isOrgMember(organizationId, session.userId)
-  if (!member) {
-    redirect(`${WEBAPP_URL}/kb-auth/no-access`)
+  if (!(await canViewKB(kbId, organizationId, session.userId))) {
+    await kbDenialRedirect(organizationId, session.userId)
   }
 
-  const { kb, articles } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
+  const { kb, articles, accessDenied } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
     session: { userId: session.userId },
   })
+  // See the layout gate: covers a revocation landing between the pre-flight
+  // and the chokepoint, which would otherwise 404 instead of explaining.
+  if (accessDenied === 'forbidden') await kbDenialRedirect(organizationId, session.userId)
   if (!kb) notFound()
 
   return <LandingBody kb={kb} articles={articles} orgSlug={orgSlug} kbSlug={kbSlug} />

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
@@ -1,9 +1,9 @@
 // apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
 
-import { isOrgMember } from '@auxx/lib/cache'
 import { buildKBSearchIndex, getArticleSlugPaths } from '@auxx/ui/components/kb'
 import { cacheLife, cacheTag } from 'next/cache'
 import { getLocalSession } from '~/lib/auth'
+import { canViewKB } from '../../../../server/kb-access'
 import { getPublicKBPayloadWithContent, kbTag } from '../../../../server/kb-cache'
 import { getKBVisibility, loadKBPayloadWithContent } from '../../../../server/kb-data'
 
@@ -34,13 +34,14 @@ export async function GET(
     })
   }
 
-  // INTERNAL: gate on session + membership, never cache.
+  // INTERNAL: gate on session + per-KB access, never cache. Denials stay an
+  // opaque 404 — this surface has no UI to explain anything, and a 403 would
+  // confirm the KB exists to a caller who may not even be a member.
   const session = await getLocalSession()
   if (!session) {
     return new Response('Not Found', { status: 404 })
   }
-  const member = await isOrgMember(visibility.organizationId, session.userId)
-  if (!member) {
+  if (!(await canViewKB(visibility.id, visibility.organizationId, session.userId))) {
     return new Response('Not Found', { status: 404 })
   }
 

--- a/apps/kb/src/app/md/[orgSlug]/[kbSlug]/[...articleSlug]/route.ts
+++ b/apps/kb/src/app/md/[orgSlug]/[kbSlug]/[...articleSlug]/route.ts
@@ -1,6 +1,5 @@
 // apps/kb/src/app/_md/[orgSlug]/[kbSlug]/[...articleSlug]/route.ts
 
-import { isOrgMember } from '@auxx/lib/cache'
 import { articleToMarkdown } from '@auxx/lib/kb/markdown'
 import {
   findArticleBySlugPath,
@@ -9,6 +8,7 @@ import {
 } from '@auxx/ui/components/kb'
 import { cacheLife, cacheTag } from 'next/cache'
 import { getLocalSession } from '~/lib/auth'
+import { canViewKB } from '../../../../../server/kb-access'
 import {
   getCachedKBVisibility,
   getPublicKBPayloadWithContent,
@@ -40,10 +40,12 @@ export async function GET(req: Request, { params }: RouteParams): Promise<Respon
     return renderPublic(req, orgSlug, kbSlug, articleSlug)
   }
 
+  // Denials stay an opaque 404 for the same reason as `search.json`.
   const session = await getLocalSession()
   if (!session) return new Response('Not Found', { status: 404 })
-  const member = await isOrgMember(visibility.organizationId, session.userId)
-  if (!member) return new Response('Not Found', { status: 404 })
+  if (!(await canViewKB(visibility.id, visibility.organizationId, session.userId))) {
+    return new Response('Not Found', { status: 404 })
+  }
 
   const { articles } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
     session: { userId: session.userId },

--- a/apps/kb/src/app/r/[articleId]/route.ts
+++ b/apps/kb/src/app/r/[articleId]/route.ts
@@ -6,11 +6,11 @@
 // at click time and 308-redirects.
 
 import { ArticlePlacement, database, KnowledgeBase, Organization } from '@auxx/database'
-import { isOrgMember } from '@auxx/lib/cache'
 import { and, desc, eq } from 'drizzle-orm'
 import { redirect } from 'next/navigation'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getLocalSession, getLoginUrl } from '~/lib/auth'
+import { canViewKB } from '~/server/kb-access'
 
 interface RouteContext {
   params: Promise<{ articleId: string }>
@@ -49,11 +49,16 @@ export async function GET(_req: NextRequest, ctx: RouteContext): Promise<Respons
   if (row.kbVisibility === 'INTERNAL') {
     const session = await getLocalSession()
     if (!session) {
-      const slugPath = await buildSlugPath(row.id, row.knowledgeBaseId)
-      redirect(getLoginUrl(row.knowledgeBaseId, `/${row.orgSlug}/${row.kbSlug}/${slugPath}`))
+      // Return to THIS route, not the canonical article URL: resolving the
+      // slug path here would run pre-auth and leak the org handle, KB slug and
+      // title-derived path into a redirect an unauthenticated caller holding
+      // only an article id can trigger. `/r/<id>` re-resolves after login and
+      // preserves the deep link.
+      redirect(getLoginUrl(row.knowledgeBaseId, `/r/${articleId}`))
     }
-    const member = await isOrgMember(row.organizationId, session.userId)
-    if (!member) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    if (!(await canViewKB(row.knowledgeBaseId, row.organizationId, session.userId))) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
   }
 
   const slugPath = await buildSlugPath(row.id, row.knowledgeBaseId)

--- a/apps/kb/src/server/kb-access.test.ts
+++ b/apps/kb/src/server/kb-access.test.ts
@@ -1,0 +1,271 @@
+// apps/kb/src/server/kb-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import type { OrganizationRole } from '@auxx/database/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * apps/kb's per-instance gate. Two layers, deliberately split:
+ *
+ * - **Predicate tests** drive `canViewKB` against a REAL `CapabilitySet` with a
+ *   stubbed `getCapabilities`. Pure composition — no database mock at all.
+ * - **Wiring tests** drive `loadKBPayload` to pin the ORDER of the checks
+ *   (public short-circuit, unauthenticated short-circuit, DRAFT outranks
+ *   access) and — critically — that the chokepoint actually calls the
+ *   predicate. Without that last one, reverting the gate to `isOrgMember`
+ *   would leave the predicate tests green and prove nothing.
+ *
+ * `isOrgMember` is stubbed to `true` throughout so a regression back to it
+ * fails loudly rather than accidentally denying.
+ */
+
+const { getCapabilities, isOrgMember, redirect, dbRows, select } = vi.hoisted(() => {
+  const dbRows = {
+    kb: [] as Record<string, unknown>[],
+    placements: [] as Record<string, unknown>[],
+  }
+
+  // Drizzle's builder is thenable and the two selects in `kb-data.ts` have
+  // different shapes; branch on the projection keys rather than call order.
+  const chain = (rows: unknown[]) => {
+    const q: Record<string, unknown> = {}
+    q.from = () => q
+    q.innerJoin = () => q
+    q.where = () => q
+    q.orderBy = () => q
+    q.limit = () => Promise.resolve(rows)
+    // `kb-data.ts` awaits one query without `.limit()`, so the stub must be thenable too.
+    // biome-ignore lint/suspicious/noThenProperty: mirroring drizzle's own thenable builder
+    q.then = (ok: (v: unknown) => unknown, err: (e: unknown) => unknown) =>
+      Promise.resolve(rows).then(ok, err)
+    return q
+  }
+
+  return {
+    getCapabilities: vi.fn(),
+    isOrgMember: vi.fn(async () => true),
+    redirect: vi.fn(),
+    dbRows,
+    select: vi.fn((fields: Record<string, unknown>) =>
+      chain('kb' in fields ? dbRows.kb : dbRows.placements)
+    ),
+  }
+})
+
+vi.mock('@auxx/lib/permissions/capabilities/get-capabilities', () => ({ getCapabilities }))
+vi.mock('@auxx/lib/cache', () => ({ isOrgMember }))
+vi.mock('@auxx/config/urls', () => ({ WEBAPP_URL: 'https://app.test' }))
+vi.mock('next/navigation', () => ({ redirect }))
+vi.mock('@auxx/lib/files/server', () => ({
+  MediaAssetService: class {
+    getDownloadUrl = async () => null
+  },
+}))
+vi.mock('@auxx/database', () => ({
+  database: { select },
+  Article: {},
+  ArticlePlacement: {},
+  ArticleRevision: {},
+  KnowledgeBase: {},
+  Organization: {},
+}))
+vi.mock('drizzle-orm', () => ({ and: vi.fn(), eq: vi.fn(), isNull: vi.fn() }))
+vi.mock('drizzle-orm/pg-core', () => ({ alias: (table: unknown) => table }))
+
+// Deep paths on purpose — the `@auxx/lib/permissions` barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { Area, expandLevelsToKeys, Level } = await import(
+  '@auxx/lib/permissions/capabilities/registry'
+)
+const { canViewKB } = await import('./kb-access')
+const { loadKBPayload } = await import('./kb-data')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const KB_ID = 'kb_cuid00000000000000000000'
+
+/** A real {@link CapabilitySet} — the composition under test, never a stub. */
+function capabilitiesFor({
+  role = 'MEMBER' as OrganizationRole,
+  area = Level.Read,
+  instances = {} as Record<string, ResourcePermission>,
+} = {}) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: area })),
+    {},
+    role,
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+function givenCapabilities(caps: InstanceType<typeof CapabilitySet>) {
+  getCapabilities.mockResolvedValue(caps)
+}
+
+function kbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    kb: {
+      id: KB_ID,
+      organizationId: ORG_ID,
+      name: 'HR Policies',
+      slug: 'hr-policies',
+      description: null,
+      publishStatus: 'PUBLISHED',
+      visibility: 'INTERNAL',
+      defaultMode: null,
+      ...overrides,
+    },
+    orgId: ORG_ID,
+  }
+}
+
+const PLACEMENT = {
+  placementId: 'plc_1',
+  articleId: 'art_1',
+  knowledgeBaseId: KB_ID,
+  slug: 'leave-policy',
+  parentPlacementId: null,
+  articleKind: 'standard',
+  sortOrder: 'a0',
+  isPublished: true,
+  title: 'Leave policy',
+  emoji: null,
+  description: null,
+  excerpt: null,
+}
+
+beforeEach(() => {
+  getCapabilities.mockReset()
+  isOrgMember.mockReset()
+  isOrgMember.mockResolvedValue(true)
+  redirect.mockReset()
+  select.mockClear()
+  dbRows.kb = [kbRow()]
+  dbRows.placements = [PLACEMENT]
+})
+
+describe('canViewKB — composition', () => {
+  it('resolves capabilities for (userId, orgId), in that order', async () => {
+    givenCapabilities(capabilitiesFor())
+    await canViewKB(KB_ID, ORG_ID, USER_ID)
+    expect(getCapabilities).toHaveBeenCalledWith(USER_ID, ORG_ID)
+  })
+
+  it('allows a member with no explicit row and knowledgeBase: Read', async () => {
+    givenCapabilities(capabilitiesFor({ area: Level.Read }))
+    await expect(canViewKB(KB_ID, ORG_ID, USER_ID)).resolves.toBe(true)
+  })
+
+  it('denies a member with an explicit permission: none row on this KB', async () => {
+    givenCapabilities(
+      capabilitiesFor({ area: Level.Full, instances: { [KB_ID]: ResourcePermission.none } })
+    )
+    await expect(canViewKB(KB_ID, ORG_ID, USER_ID)).resolves.toBe(false)
+  })
+
+  it('denies a member composing knowledgeBase: None with no instance row', async () => {
+    givenCapabilities(capabilitiesFor({ area: Level.None }))
+    await expect(canViewKB(KB_ID, ORG_ID, USER_ID)).resolves.toBe(false)
+  })
+
+  it('denies a non-member (the regression guard for the isOrgMember swap)', async () => {
+    // What `getCapabilities` composes for a user with no memberRoleMap entry.
+    givenCapabilities(capabilitiesFor({ role: 'USER', area: Level.None }))
+    await expect(canViewKB(KB_ID, ORG_ID, USER_ID)).resolves.toBe(false)
+  })
+
+  it('allows OWNER regardless of area level or explicit row', async () => {
+    givenCapabilities(
+      capabilitiesFor({
+        role: 'OWNER',
+        area: Level.None,
+        instances: { [KB_ID]: ResourcePermission.none },
+      })
+    )
+    await expect(canViewKB(KB_ID, ORG_ID, USER_ID)).resolves.toBe(true)
+  })
+
+  it('lets an explicit view grant beat a knowledgeBase: None area floor', async () => {
+    givenCapabilities(
+      capabilitiesFor({ area: Level.None, instances: { [KB_ID]: ResourcePermission.view } })
+    )
+    await expect(canViewKB(KB_ID, ORG_ID, USER_ID)).resolves.toBe(true)
+  })
+
+  it('scopes the grant to the KB it was written for', async () => {
+    givenCapabilities(
+      capabilitiesFor({ area: Level.None, instances: { [KB_ID]: ResourcePermission.view } })
+    )
+    await expect(canViewKB('kb_other', ORG_ID, USER_ID)).resolves.toBe(false)
+  })
+})
+
+describe('loadKBPayload — gate wiring', () => {
+  it('serves a PUBLIC KB with no session and never resolves capabilities', async () => {
+    dbRows.kb = [kbRow({ visibility: 'PUBLIC' })]
+
+    const { kb, articles, accessDenied } = await loadKBPayload('acme', 'hr-policies')
+
+    expect(kb?.id).toBe(KB_ID)
+    expect(articles).toHaveLength(1)
+    expect(accessDenied).toBeUndefined()
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('short-circuits an anonymous caller on an INTERNAL KB before the gate', async () => {
+    const { kb, articles, accessDenied } = await loadKBPayload('acme', 'hr-policies')
+
+    expect(kb).toBeNull()
+    expect(articles).toEqual([])
+    expect(accessDenied).toBe('unauthenticated')
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('runs the per-instance gate for a session on an INTERNAL KB', async () => {
+    givenCapabilities(
+      capabilitiesFor({ area: Level.Full, instances: { [KB_ID]: ResourcePermission.none } })
+    )
+
+    const { kb, articles, accessDenied } = await loadKBPayload('acme', 'hr-policies', {
+      session: { userId: USER_ID },
+    })
+
+    // The wiring assertion: without this, reverting the chokepoint to
+    // `isOrgMember` leaves every predicate test above green.
+    expect(getCapabilities).toHaveBeenCalledWith(USER_ID, ORG_ID)
+    expect(kb).toBeNull()
+    expect(articles).toEqual([])
+    expect(accessDenied).toBe('forbidden')
+  })
+
+  it('serves an INTERNAL KB to a member the gate admits', async () => {
+    givenCapabilities(capabilitiesFor({ area: Level.Read }))
+
+    const { kb, articles, accessDenied } = await loadKBPayload('acme', 'hr-policies', {
+      session: { userId: USER_ID },
+    })
+
+    expect(kb?.id).toBe(KB_ID)
+    expect(articles).toHaveLength(1)
+    expect(accessDenied).toBeUndefined()
+  })
+
+  it('lets DRAFT lifecycle outrank access for a fully-privileged session', async () => {
+    dbRows.kb = [kbRow({ publishStatus: 'DRAFT' })]
+    givenCapabilities(capabilitiesFor({ role: 'OWNER', area: Level.Full }))
+
+    const { kb, articles, accessDenied } = await loadKBPayload('acme', 'hr-policies', {
+      session: { userId: USER_ID },
+    })
+
+    expect(kb).toBeNull()
+    expect(articles).toEqual([])
+    expect(accessDenied).toBeUndefined()
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kb/src/server/kb-access.ts
+++ b/apps/kb/src/server/kb-access.ts
@@ -1,0 +1,61 @@
+// apps/kb/src/server/kb-access.ts
+
+import { WEBAPP_URL } from '@auxx/config/urls'
+import { isOrgMember } from '@auxx/lib/cache'
+// Deep subpath on purpose: `@auxx/lib/permissions` (the barrel) also re-exports
+// `overage-handler` → `NotificationService` → `../realtime`, which would drag
+// realtime + queue dependencies this satellite app does not have into the KB
+// bundle. `get-capabilities`' own graph is cache + capability modules only.
+import { getCapabilities } from '@auxx/lib/permissions/capabilities/get-capabilities'
+import { redirect } from 'next/navigation'
+import { cache } from 'react'
+
+/**
+ * Whether `userId` may READ the INTERNAL knowledge base `kbId` — the single
+ * per-instance predicate this app has (`kb` is an `INSTANCE_ACCESS_RESOURCES`
+ * key, so an explicit `ResourceAccess` row, including `permission: 'none'`,
+ * beats the coarse `knowledgeBase` area level).
+ *
+ * This SUBSUMES the `isOrgMember` check it replaced: a non-member has no
+ * `memberRoleMap` entry, so `getCapabilities` composes an empty blob at role
+ * `USER`, the `knowledgeBase` area resolves to `Level.None`, and
+ * `effectiveInstanceLevel` returns `undefined` → denied.
+ *
+ * Deliberately NOT feature-gated (no `FeatureKey.knowledgeBase` check): a plan
+ * downgrade must not dark an already-published internal KB mid billing cycle.
+ * Same posture as the other read-only capability call sites.
+ *
+ * Memoized with React `cache()` — the layout gate, the page gate and the
+ * `loadKBPayload` chokepoint would otherwise each resolve capabilities on a
+ * single internal render. Outside a React request scope (route handlers)
+ * `cache()` degrades to a plain call, which is still correct.
+ *
+ * apps/kb is read-only; there is no authoring surface here, so `canEditInstance`
+ * has no meaning in this app and must not be added for symmetry.
+ */
+export const canViewKB = cache(
+  async (kbId: string, organizationId: string, userId: string): Promise<boolean> => {
+    const capabilities = await getCapabilities(userId, organizationId)
+    return capabilities.canViewInstance('kb', kbId)
+  }
+)
+
+/**
+ * Redirect a denied visitor to the web app's no-access screen, picking the
+ * wording that matches who they actually are.
+ *
+ * The membership read here is **not** the gate — {@link canViewKB} already
+ * denied. It only chooses between two denial strings, because one boolean
+ * merges two populations: a member restricted from this specific KB (tell them
+ * to ask an admin for access) and a stranger holding a live KB session from
+ * another org on the shared host (tell them they're not in the org). Getting
+ * this wrong can only show the wrong copy — it cannot reopen the hole.
+ *
+ * HTML surfaces only. `search.json`, `.md` and `/r/<id>` keep an opaque
+ * `404`/`403`: they have no UI to explain anything, and a distinguishable
+ * response would confirm the KB's existence to a non-member.
+ */
+export async function kbDenialRedirect(organizationId: string, userId: string): Promise<never> {
+  const member = await isOrgMember(organizationId, userId)
+  redirect(`${WEBAPP_URL}/kb-auth/no-access${member ? '?reason=restricted' : ''}`)
+}

--- a/apps/kb/src/server/kb-cache.ts
+++ b/apps/kb/src/server/kb-cache.ts
@@ -23,7 +23,16 @@ export async function getCachedKBVisibility(orgSlug: string, kbSlug: string) {
   return getKBVisibility(orgSlug, kbSlug)
 }
 
-/** Public-only cached payload — never used for INTERNAL KBs. */
+/**
+ * Public-only cached payload — never used for INTERNAL KBs.
+ *
+ * Passes **no session on purpose**. `loadKBPayload`'s INTERNAL branch runs a
+ * per-user capability read; threading a session through here would bake that
+ * per-user answer into a scope keyed only on `(orgSlug, kbSlug)` and leak one
+ * member's access to every other visitor. Without a session an INTERNAL KB
+ * returns `{ kb: null }` before the gate, which is what keeps this cached
+ * payload structurally incapable of holding internal content.
+ */
 export async function getPublicKBPayload(orgSlug: string, kbSlug: string) {
   'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))
@@ -31,7 +40,10 @@ export async function getPublicKBPayload(orgSlug: string, kbSlug: string) {
   return loadKBPayload(orgSlug, kbSlug)
 }
 
-/** Public-only cached payload with content — never used for INTERNAL KBs. */
+/**
+ * Public-only cached payload with content — never used for INTERNAL KBs.
+ * Passes no session for the same reason as {@link getPublicKBPayload}.
+ */
 export async function getPublicKBPayloadWithContent(orgSlug: string, kbSlug: string) {
   'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))

--- a/apps/kb/src/server/kb-data.ts
+++ b/apps/kb/src/server/kb-data.ts
@@ -9,11 +9,11 @@ import {
   Organization,
 } from '@auxx/database'
 import type { ArticleKind } from '@auxx/database/types'
-import { isOrgMember } from '@auxx/lib/cache'
 import { MediaAssetService } from '@auxx/lib/files/server'
 import type { ArticleNodeJSON, KBLayoutKB } from '@auxx/ui/components/kb'
 import { and, eq, isNull } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
+import { canViewKB } from './kb-access'
 
 export interface PublicArticleListItem {
   id: string
@@ -116,6 +116,19 @@ function filterVisibleSubtree<
   })
 }
 
+/**
+ * The single data-layer chokepoint every KB read funnels through — and
+ * therefore the place the INTERNAL access gate lives, so a seventh route
+ * cannot be added ungated.
+ *
+ * **INVARIANT: never call this with a session from inside a `'use cache'`
+ * scope.** The gate below is per-user; baking its result into a scope keyed on
+ * `(orgSlug, kbSlug)` would be a cross-user capability leak — strictly worse
+ * than the bug it fixes. The session is a parameter (never an ambient
+ * `cookies()` read) precisely so this stays checkable: every cached caller
+ * reaches this function via `getPublicKBPayload*`, which passes no `opts` at
+ * all and so short-circuits at the `!opts?.session` line below.
+ */
 export async function loadKBPayload(
   orgSlug: string,
   kbSlug: string,
@@ -151,8 +164,12 @@ export async function loadKBPayload(
 
   if (kb.visibility === 'INTERNAL') {
     if (!opts?.session) return { kb: null, articles: [], accessDenied: 'unauthenticated' }
-    const member = await isOrgMember(kb.organizationId, opts.session.userId)
-    if (!member) return { kb: null, articles: [], accessDenied: 'forbidden' }
+    // Per-instance gate. `canViewKB` subsumes the membership check it replaced
+    // (a non-member composes to `Level.None`) and additionally honours both an
+    // explicit `ResourceAccess` row on this KB and a coarse `knowledgeBase:
+    // None` composition — neither of which this app used to see.
+    const viewable = await canViewKB(kb.id, kb.organizationId, opts.session.userId)
+    if (!viewable) return { kb: null, articles: [], accessDenied: 'forbidden' }
   }
 
   const pub = alias(ArticleRevision, 'pub')

--- a/apps/kb/tsconfig.json
+++ b/apps/kb/tsconfig.json
@@ -11,5 +11,5 @@
     "module": "esnext"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vitest.config.*"]
 }

--- a/apps/kb/vitest.config.ts
+++ b/apps/kb/vitest.config.ts
@@ -1,0 +1,42 @@
+// apps/kb/vitest.config.ts
+
+import path from 'path'
+import { loadEnv } from 'vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(({ mode }) => {
+  const monorepoRoot = path.resolve(__dirname, '../..')
+  const env = { ...loadEnv(mode, monorepoRoot, ''), ...loadEnv(mode, process.cwd(), '') }
+
+  return {
+    plugins: [tsconfigPaths()],
+
+    test: {
+      name: 'kb',
+      globals: true,
+      environment: 'node',
+      include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}'],
+      exclude: ['node_modules/**', '.next/**', '**/*.config.*'],
+      testTimeout: 10000,
+      hookTimeout: 10000,
+      teardownTimeout: 10000,
+    },
+
+    resolve: {
+      alias: {
+        '~': path.resolve(__dirname, './src'),
+        // Resolve @auxx/lib to SOURCE, not the built dist — a stale dist would
+        // silently test old permission composition code.
+        '@auxx/database/enums': path.resolve(monorepoRoot, 'packages/database/src/enums.ts'),
+        '@auxx/database': path.resolve(monorepoRoot, 'packages/database/src'),
+        '@auxx/lib': path.resolve(monorepoRoot, 'packages/lib/src'),
+        '@auxx/config': path.resolve(monorepoRoot, 'packages/config/src'),
+      },
+    },
+
+    define: {
+      'process.env': env,
+    },
+  }
+})

--- a/apps/web/src/app/(auth)/kb-auth/no-access/page.tsx
+++ b/apps/web/src/app/(auth)/kb-auth/no-access/page.tsx
@@ -35,6 +35,17 @@ function NoAccessContent() {
         description: "The knowledge base you're trying to access doesn't exist.",
       }
     }
+    // Only ever reached for a confirmed member of the owning organization, so
+    // it can safely say the org exists and point at an admin. The default
+    // branch below must stay anonymous — it also serves people with no
+    // relationship to the org at all.
+    if (reason === 'restricted') {
+      return {
+        title: "You don't have access to this knowledge base",
+        description:
+          'Your account is a member of this organization, but this knowledge base is restricted. Ask an admin to grant you access.',
+      }
+    }
     return {
       title: 'You do not have access',
       description:

--- a/apps/web/src/app/(auth)/kb-auth/route.ts
+++ b/apps/web/src/app/(auth)/kb-auth/route.ts
@@ -9,6 +9,7 @@ import { issueLoginToken, sanitizeReturnTo } from '@auxx/credentials/login-token
 import { database, schema } from '@auxx/database'
 import { isOrgMember } from '@auxx/lib/cache'
 import { getDemoEmailDomain } from '@auxx/lib/demo'
+import { getCapabilities } from '@auxx/lib/permissions'
 import { eq } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
@@ -70,6 +71,18 @@ export async function GET(request: NextRequest) {
   const member = await isOrgMember(kb.organizationId, session.user.id)
   if (!member) {
     return NextResponse.redirect(new URL('/kb-auth/no-access', WEBAPP_URL))
+  }
+
+  // 6b. Per-KB instance access. PRE-FLIGHT, NOT the enforcement point: the
+  // minted token carries no `kbId` claim and its audience is the shared KB
+  // origin, so a token gated here is structurally valid for every other KB on
+  // that host, and the resulting 24h cookie carries no capability snapshot.
+  // apps/kb re-checks on every request (`apps/kb/src/server/kb-access.ts`) —
+  // that is the gate. This one only denies at the front door instead of after
+  // the bounce, so the user gets the right message.
+  const capabilities = await getCapabilities(session.user.id, kb.organizationId)
+  if (!capabilities.canViewInstance('kb', kb.id)) {
+    return NextResponse.redirect(new URL('/kb-auth/no-access?reason=restricted', WEBAPP_URL))
   }
 
   // 7. Issue login token bound to the KB's origin

--- a/apps/web/src/app/api/auth/login-token/route.ts
+++ b/apps/web/src/app/api/auth/login-token/route.ts
@@ -5,6 +5,7 @@ import { issueLoginToken, sanitizeReturnTo } from '@auxx/credentials/login-token
 import { database, schema } from '@auxx/database'
 import { isOrgMember } from '@auxx/lib/cache'
 import { getDemoEmailDomain } from '@auxx/lib/demo'
+import { getCapabilities } from '@auxx/lib/permissions'
 import { eq } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
@@ -72,6 +73,13 @@ export async function POST(request: NextRequest) {
     const member = await isOrgMember(kb.organizationId, session.user.id)
     if (!member) {
       return NextResponse.json({ error: 'Not a member of this knowledge base' }, { status: 403 })
+    }
+    // Per-KB instance access. PRE-FLIGHT, NOT the enforcement point — the token
+    // carries no `kbId` claim and its audience is the shared KB origin, so
+    // apps/kb's per-request gate is what actually protects the content.
+    const capabilities = await getCapabilities(session.user.id, kb.organizationId)
+    if (!capabilities.canViewInstance('kb', kb.id)) {
+      return NextResponse.json({ error: 'No access to this knowledge base' }, { status: 403 })
     }
   }
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -784,6 +784,12 @@
       "import": "./dist/permissions/capabilities/capability-set.mjs",
       "default": "./src/permissions/capabilities/capability-set.ts"
     },
+    "./permissions/capabilities/get-capabilities": {
+      "types": "./src/permissions/capabilities/get-capabilities.ts",
+      "source": "./src/permissions/capabilities/get-capabilities.ts",
+      "import": "./dist/permissions/capabilities/get-capabilities.mjs",
+      "default": "./src/permissions/capabilities/get-capabilities.ts"
+    },
     "./permissions/capabilities/instance-access": {
       "types": "./src/permissions/capabilities/instance-access.ts",
       "source": "./src/permissions/capabilities/instance-access.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,6 +848,15 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-tsconfig-paths:
+        specifier: 'catalog:'
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/lambda:
     dependencies:
@@ -14301,6 +14310,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       './apps/api/vitest.config.ts',
       './apps/worker/vitest.config.ts',
       './apps/web/vitest.config.ts',
+      './apps/kb/vitest.config.ts',
       './packages/billing/vitest.config.ts',
       './packages/lib/vitest.config.ts',
       './packages/services/vitest.config.ts',


### PR DESCRIPTION
Implements `plans/permissions/v2/34-kb-satellite-instance-access.md`.

## The hole

`apps/kb` contained **zero** per-instance access checks. A grep of `apps/kb/src` + `proxy.ts` + `next.config.ts` for the entire instance-access vocabulary (`canViewInstance` / `effectiveInstanceLevel` / `INSTANCE_ACCESS_RESOURCES` / `ResourceAccess` / …) returned nothing. Its whole authorization vocabulary was `isOrgMember`.

`kb` has been an `INSTANCE_ACCESS_RESOURCES` key since the instance-access slice, and apps/web enforces it on both trees (`assertViewInstance` on `byId`, a `canViewInstance` filter on `list`). The public-facing app that actually serves KB content to the internet never knew.

Concretely: an admin restricts an INTERNAL KB to the HR group. In apps/web the KB vanishes for everyone else — filtered out of the list, 403 on `byId`. Those same members open `kb.auxx.ai/<org>/<kb>` and read it in full. `GET /<org>/<kb>/search.json` returns the **entire body text of every article** as one MiniSearch index; `<slug>.md` returns clean Markdown. No token exchange needed — the 24h cookie from any KB on the shared host suffices.

Blast radius was wider than restricted members: because apps/kb checked no coarse key either, a member composing `knowledgeBase: None` — who has no KB access whatsoever in the admin app — also read everything.

## The fix

Gate at the `kb-data.ts` chokepoint with `getCapabilities(...).canViewInstance('kb', id)` **and** convert the six route-level pre-flights to the same predicate. Both halves, because:

- `/r/<articleId>` never calls the chokepoint — it queries `ArticlePlacement` directly. Chokepoint-only leaves it fully ungated.
- The pre-flights would otherwise disagree with the chokepoint: the layout admits, renders the shell, then `loadKBPayload` returns `kb: null` and the member gets a bare 404 mid-layout.
- Pre-flights-only discards the defense in depth that makes a seventh route hard to add ungated.

`canViewKB` **subsumes** the membership check it replaces — a non-member has no `memberRoleMap` entry, so capabilities compose to `Level.None` and `effectiveInstanceLevel` returns `undefined`. Cross-org denial is preserved and the coarse-`None` hole closes for free.

## Notable decisions

**`isOrgMember` survives as a copy-picker, not a gate.** One boolean merges two populations: a member restricted from this KB, and a stranger holding a live KB session from another org on the shared host. Sending `reason=restricted` to both tells the stranger to ask an admin for a grant; sending the default to both tells a three-year employee to get invited to their own org. The membership read runs only on the denial path and only to choose wording — it cannot reopen the hole.

**`accessDenied` is now consumed.** It was returned by the chokepoint and forwarded by `loadKBPayloadWithContent` but read by nothing, so every chokepoint denial degenerated to `notFound()`. The three HTML gates now redirect on `'forbidden'`, which covers a grant revoked between the pre-flight and the chokepoint.

**`/r/<id>` unauthenticated `returnTo` is now `/r/<id>`** rather than the resolved canonical URL. `buildSlugPath` previously ran pre-auth and embedded org handle + KB slug + title-derived path in the login redirect, disclosing all three to anyone holding an article id. Re-resolving after login preserves the deep link and discloses nothing.

**Deep import, never the barrel.** `@auxx/lib/permissions` re-exports `overage-handler` → `NotificationService` → `../realtime`; this satellite has no `bullmq` and the realtime barrel is a known cycle hazard. The subpath was minted by `pnpm --filter @auxx/lib generate:exports`, not hand-edited.

**No `user:capabilities:vN` bump.** No new `PermissionKey`, area, rung, `INSTANCE_ACCESS_RESOURCES` entry, or `UserCapabilities` field; no composition code touched. This adds a *reader* in a second process running the identical parser over the identical blob. Applying the "would the current parser read a blob the old code wrote?" test: yes — it's the same blob apps/web is reading right now.

**Not feature-gated.** `requirePermission` has no per-instance path, and a plan downgrade must not dark an already-published internal KB mid-billing-cycle. Documented at the call site.

## PUBLIC path untouched — falsifiable and checked

The gate lives entirely inside `if (kb.visibility === 'INTERNAL')`. `git diff` on `kb-data.ts` shows exactly three hunks: the import swap, a doc comment, and that block's body. Nothing outside it. So a PUBLIC KB evaluates no capability read, no Redis hit, no extra DB hit, and the cached public payloads keep hashing identically. An anonymous caller on an INTERNAL KB still short-circuits before `getCapabilities`.

The `'use cache'` boundary holds by construction: the session is a *parameter* of `loadKBPayload`, never an ambient `cookies()` read, and every cached caller reaches it via `getPublicKBPayload*` which passes no `opts`. That invariant is now an explicit doc comment on `loadKBPayload` and both wrappers — it was previously true but invisible, and it's the most likely way a future edit reintroduces this bug in a worse form (a per-user capability baked into a scope keyed on `(orgSlug, kbSlug)`).

## Tests

apps/kb had **zero** tests and no vitest config — which is arguably why it went four surfaces deep with no gate. Adds the config, scripts, vitest dep, and `kb-access.test.ts`:

- **8 predicate tests** against a real `CapabilitySet`, no DB mock: explicit `none` row, coarse `None` with no row, non-member, OWNER short-circuit, and an explicit `view` grant beating a `None` area floor.
- **5 wiring tests** through `loadKBPayload` with a mocked `@auxx/database`: PUBLIC never calls the gate, unauthenticated short-circuits before it, DRAFT outranks access.

**Mutation-verified.** Reverting the chokepoint to `isOrgMember` (stubbed permissive) fails exactly one test — the wiring test asserting `getCapabilities` was called. All 8 predicate tests stay green, which is the concrete demonstration that predicate-only coverage would have been testing nothing.

## Verification

- 13/13 tests pass; also via `pnpm exec vitest run --project kb` from root.
- `pnpm --filter @auxx/kb build` exit 0. `grep -rl "overage-handler|NotificationService" .next/server/app` → nothing, confirming the import didn't drag realtime into the bundle.
- `apps/kb` typecheck: 2 errors, both pre-existing in files not touched (`api/revalidate/route.ts`, `lib/auth.ts`).
- `apps/web` typecheck: zero lines matching the changed files against the existing baseline.
- Biome clean.

## Not done — needs a live stack

The manual matrix: restricted member → `no-access?reason=restricted` with the new copy; `curl` `search.json` → 404 with no article text (**the highest-value single check** — it's the densest leak surface); `.md` → 404; `/r/<id>` → 403; anonymous visitor on a PUBLIC KB completely unchanged including a cache-hit render; revocation propagating cross-process in ~100ms; restore-grant without a restart.

## Follow-ups deliberately left out

- **A seventh `isOrgMember` gate** at `auth/verify/route.ts:67` — dead today (`proxy.ts` 404s every non-root host) but it goes live already-ungated the day custom domains ship. Belongs on the `TODO(custom-domains)` list.
- **`kb-search-dialog.tsx` uses `credentials: 'omit'`**, so internal-KB search 404s and the dialog spins forever. Fail-closed, not a leak — and it was correctly *not* fixed before this gate existed, since `credentials: 'include'` would have handed the leak a one-click UI. Safe to fix now; should be the immediate follow-up.
- Slug/handle rename orphaning a cached public payload, and `search.json`'s uncached `getKBVisibility` asymmetry — both need their own plan.