### PR TITLE
fix(permissions): clamp agent policy rungs to each area's own ladder

### DIFF
--- a/apps/web/src/components/permissions/hooks/use-agent-policy-clamp.test.ts
+++ b/apps/web/src/components/permissions/hooks/use-agent-policy-clamp.test.ts
@@ -1,0 +1,66 @@
+// apps/web/src/components/permissions/hooks/use-agent-policy-clamp.test.ts
+
+import { Area, PermissionKey } from '@auxx/lib/permissions/client'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { NormalizedAgentPolicy } from './use-agent-policy'
+
+/**
+ * The §2.4a clamp PREVIEW — "publishing would reduce this policy".
+ *
+ * The case that matters is the false positive. `Area.auditLog` offers a single
+ * rung (`Read`), so an owner composes `Read` there — the ceiling — while the
+ * seeded `agent` profile asks for `admin` on the flat four-rung vocabulary.
+ * Comparing those two spellings raw told an OWNER their publish would be reduced,
+ * for a difference `expandLevelsToKeys` erases: both sides compose to exactly
+ * `auditLogView`. The row beside the banner already read the clamped rung, so the
+ * screen contradicted itself.
+ */
+
+const { held } = vi.hoisted(() => ({ held: { current: [] as string[] } }))
+
+vi.mock('~/providers/capabilities-provider', () => ({
+  useAccess: () => ({
+    capabilities: held.current,
+    canViewEntity: () => true,
+    canEditEntity: () => true,
+    canAdministerDef: () => true,
+    isLoading: false,
+  }),
+}))
+
+import { useAgentPolicyClamp } from './use-agent-policy-clamp'
+
+/** The seeded `agent` system profile as the editor holds it: all-`admin`. */
+const ALL_ADMIN = {
+  areas: { default: 'admin', overrides: {} },
+  definitions: { default: 'admin', overrides: {} },
+  resources: {},
+} as unknown as NormalizedAgentPolicy
+
+function entriesFor(areas: readonly Area[], capabilities: PermissionKey[]) {
+  held.current = capabilities
+  return renderHook(() => useAgentPolicyClamp(ALL_ADMIN, areas, [])).result.current.entries
+}
+
+describe('the clamp preview on an area whose ladder is shorter than the policy', () => {
+  it('reports nothing when the viewer holds the area ceiling', () => {
+    // An owner: every key, which on `auditLog` composes to its only rung, `Read`.
+    const entries = entriesFor([Area.auditLog], Object.values(PermissionKey))
+    expect(entries).toEqual([])
+  })
+
+  it('still reports the area when the viewer holds nothing there', () => {
+    const entries = entriesFor([Area.auditLog], [])
+    expect(entries).toEqual([
+      expect.objectContaining({ key: Area.auditLog, from: 'view', to: 'none' }),
+    ])
+  })
+
+  it('reports a full-ladder area at the rung the viewer actually holds', () => {
+    const entries = entriesFor([Area.records], [PermissionKey.recordsView])
+    expect(entries).toEqual([
+      expect.objectContaining({ key: Area.records, from: 'admin', to: 'view' }),
+    ])
+  })
+})

--- a/apps/web/src/components/permissions/hooks/use-agent-policy-clamp.ts
+++ b/apps/web/src/components/permissions/hooks/use-agent-policy-clamp.ts
@@ -4,6 +4,7 @@
 import type { ResourcePermission } from '@auxx/database/enums'
 import {
   type Area,
+  clampLevelToArea,
   Level,
   PERMISSION_AREAS,
   PERMISSION_RANK,
@@ -11,6 +12,7 @@ import {
 } from '@auxx/lib/permissions/client'
 import { useMemo } from 'react'
 import { useAccess } from '~/providers/capabilities-provider'
+import { LEVEL_OF_PERMISSION } from '../ui/level-labels'
 import type { NormalizedAgentPolicy } from './use-agent-policy'
 
 /**
@@ -102,7 +104,14 @@ export function useAgentPolicyClamp(
     const reductions: AgentPolicyClampPreviewEntry[] = []
 
     for (const area of areas) {
-      const asked = lookup(policy.areas, area)
+      // On the area's OWN ladder, both sides. `areaLevelFromKeys` cannot return
+      // more than the area's top rung, so an authored rung above that ceiling
+      // (`Full` on the Read-only `auditLog`) has to be normalized the same way —
+      // otherwise the preview announces a reduction to every viewer including an
+      // owner, while the row beside it already reads the clamped rung.
+      const asked = toPermission(
+        clampLevelToArea(area, LEVEL_OF_PERMISSION[lookup(policy.areas, area)])
+      )
       const holds = toPermission(areaLevelFromKeys(area, held))
       if (PERMISSION_RANK[asked] > PERMISSION_RANK[holds]) {
         reductions.push({

--- a/apps/web/src/components/permissions/ui/level-control.tsx
+++ b/apps/web/src/components/permissions/ui/level-control.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/permissions/ui/level-control.tsx
 'use client'
 
-import { type AreaMetadata, Level } from '@auxx/lib/permissions/client'
+import { type AreaMetadata, clampLevelToArea, Level } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { cn } from '@auxx/ui/lib/utils'
@@ -11,17 +11,17 @@ import { Tooltip } from '~/components/global/tooltip'
 import { RUNG_LABELS } from './level-labels'
 
 /**
- * The highest rung `area` actually offers at or below `level` — what a level
- * from outside this area's ladder composes down to.
+ * {@link clampLevelToArea} for callers already holding the area's metadata — the
+ * highest rung `area` actually offers at or below `level`.
  *
  * Exported because callers need the same answer the control displays: an agent
  * policy's collection default is one rung for every area at once, so a row must
  * be able to name what that default resolves to *here* rather than repeating a
- * rung the area cannot express.
+ * rung the area cannot express. The rule itself lives in the registry, because
+ * the publish-time author clamp has to normalize by exactly the same ladder.
  */
 export function clampToArea(area: AreaMetadata, level: Level): Level {
-  const levels = [Level.None, ...area.rungs.map((r) => r.level)]
-  return levels.filter((l) => l <= level).at(-1) ?? Level.None
+  return clampLevelToArea(area.area, level)
 }
 
 interface LevelControlProps {

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -892,6 +892,35 @@ export function expandLevelsToKeys(levels: Partial<Record<Area, Level>>): Permis
 }
 
 /**
+ * The highest rung `area` actually offers at or below `level` — what a level
+ * authored on the generic four-rung ladder composes down to *here*.
+ *
+ * Ladders are per-area and sparse: `auditLog` stops at `Read`, `files` and
+ * `billing` jump `Read → Full` with no `Edit`. {@link expandLevelsToKeys} already
+ * behaves this way (it unions the rungs `≤ level`, so `Full` on `auditLog` yields
+ * exactly `auditLogView`), which means a stored `Full` there is not extra
+ * authority — it is an unrepresentable value that composes to `Read`.
+ *
+ * Anything that COMPARES an authored level against a composed one must normalize
+ * through this first, or it reports a difference the enforcement path does not
+ * have: the author clamp read a `Full` agent policy against an owner's composed
+ * `Read` on `auditLog` and announced a reduction that changes nothing.
+ */
+export function clampLevelToArea(area: Area, level: Level): Level {
+  let clamped = Level.None
+  for (const rung of PERMISSION_AREAS[area].rungs) {
+    if (rung.level <= level) clamped = rung.level
+    else break
+  }
+  return clamped
+}
+
+/** The top rung `area` offers — `Level.None` for an area with no rungs. */
+export function areaCeilingLevel(area: Area): Level {
+  return PERMISSION_AREAS[area].rungs.at(-1)?.level ?? Level.None
+}
+
+/**
  * The inverse of {@link expandLevelsToKeys} for a single area: recover the
  * member's effective {@link Level} for `area` from an already-materialized
  * (seat-clamped, composed) PermissionKey set. Walks the area's rungs in

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -43,7 +43,9 @@ export type { AreaMetadata, PermissionMetadata } from './capabilities/registry'
 export {
   AREA_ORDER,
   Area,
+  areaCeilingLevel,
   buildAreaLevels,
+  clampLevelToArea,
   expandLevelsToKeys,
   isPermissionKey,
   Level,

--- a/packages/lib/src/permissions/profiles/agent-policy-clamp.test.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-clamp.test.ts
@@ -5,7 +5,7 @@ import { ResourcePermission } from '@auxx/database/enums'
 import { describe, expect, it } from 'vitest'
 import type { CapabilityView } from '../capabilities/capability-view'
 import type { InstanceAccessKey } from '../capabilities/instance-access'
-import { Area, Level, type PermissionKey } from '../capabilities/registry'
+import { Area, areaCeilingLevel, Level, type PermissionKey } from '../capabilities/registry'
 import { emptyAgentPolicy, legacyFullAgentPolicy } from './agent-policy'
 import { type ClampDefinition, clampAgentPolicyToPublisher } from './agent-policy-clamp'
 
@@ -69,9 +69,18 @@ function publisher(spec: PublisherSpec): CapabilityView {
   } satisfies CapabilityView
 }
 
-/** An OWNER/ADMIN: every gate open, every area Full. */
+/**
+ * An OWNER/ADMIN: every gate open, every area at its CEILING.
+ *
+ * Not `Level.Full` everywhere — that is not what an owner composes.
+ * `CapabilitySet.areaLevel` recovers the rung from the held keys, so it can never
+ * exceed the area's own ladder: an owner reads `Read` on `auditLog`, whose only
+ * rung is `Read`. The stub used to say `Full` there, which is why the clamp's
+ * ladder mismatch (an all-`admin` policy reading as "reduced" for an owner)
+ * survived this suite.
+ */
 const ADMIN = publisher({
-  areas: Object.fromEntries(Object.values(Area).map((a) => [a, Level.Full])) as Partial<
+  areas: Object.fromEntries(Object.values(Area).map((a) => [a, areaCeilingLevel(a)])) as Partial<
     Record<Area, Level>
   >,
   defDefault: 'admin',
@@ -180,6 +189,68 @@ describe('the §9.1 author-clamp case', () => {
     // The OLD snapshot is untouched — a demotion must not silently break a running
     // automation; drift is bounded by the next publish, which is this one (§2.4a).
     expect(v1.definitions.overrides.deals).toBe('admin')
+  })
+})
+
+describe('an area whose ladder is shorter than the policy vocabulary', () => {
+  /**
+   * `Area.auditLog` offers ONE rung (`Read`). An all-`admin` policy therefore asks
+   * for a rung the area cannot express, and an owner composes `Read` — the
+   * ceiling. Comparing the two raw spellings announced *"Account activity reduced
+   * from Full to Read"* to an OWNER, for a publish that changes no enforcement:
+   * `expandLevelsToKeys` maps both to exactly `auditLogView`.
+   */
+  it('reports no reduction when the publisher sits at the area ceiling', () => {
+    const { policy, reductions } = clampAgentPolicyToPublisher({
+      resolved: allFullResolved(),
+      publisher: ADMIN,
+      publisherUserId: 'u-owner',
+      definitions: DEFS,
+    })
+
+    expect(reductions).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: Area.auditLog })])
+    )
+    // The snapshot states the rung the agent actually composes, not the one the
+    // flat vocabulary let the author type.
+    expect(policy.areas.overrides[Area.auditLog]).toBe('view')
+  })
+
+  it('does not let a short ladder cap the retained default for an owner', () => {
+    // `areas.default` answers for an area a FUTURE deploy adds. An owner who is at
+    // the ceiling everywhere is unbounded, so the §2.4a escape hatch must survive
+    // the existence of one Read-only area.
+    const { policy } = clampAgentPolicyToPublisher({
+      resolved: allFullResolved(),
+      publisher: ADMIN,
+      publisherUserId: 'u-owner',
+      definitions: DEFS,
+    })
+    expect(policy.areas.default).toBe('admin')
+  })
+
+  it('still reports a real reduction on the same area', () => {
+    // Someone who holds NOTHING on `auditLog` is genuinely reduced there.
+    const noAudit = publisher({
+      areas: Object.fromEntries(
+        Object.values(Area).map((a) => [a, a === Area.auditLog ? Level.None : areaCeilingLevel(a)])
+      ) as Partial<Record<Area, Level>>,
+      defDefault: 'admin',
+      instanceDefault: 'admin',
+    })
+    const { policy, reductions } = clampAgentPolicyToPublisher({
+      resolved: allFullResolved(),
+      publisher: noAudit,
+      publisherUserId: 'u-member',
+      definitions: DEFS,
+    })
+    expect(policy.areas.overrides[Area.auditLog]).toBe('none')
+    // Reported at the rung the area can express — `view`, never a phantom `admin`.
+    expect(reductions).toEqual(
+      expect.arrayContaining([{ domain: 'area', key: Area.auditLog, from: 'view', to: 'none' }])
+    )
+    // One area held below its ceiling DOES floor the retained default.
+    expect(policy.areas.default).toBe('none')
   })
 })
 

--- a/packages/lib/src/permissions/profiles/agent-policy-clamp.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy-clamp.ts
@@ -13,8 +13,13 @@ import {
   INSTANCE_ACCESS_RESOURCES,
   type InstanceAccessKey,
 } from '../capabilities/instance-access'
-import { AREA_ORDER } from '../capabilities/registry'
-import { areaLevelToPermission, lookupExactPolicy, minPermission } from './agent-policy'
+import { AREA_ORDER, areaCeilingLevel } from '../capabilities/registry'
+import {
+  areaLevelToPermission,
+  clampPermissionToArea,
+  lookupExactPolicy,
+  minPermission,
+} from './agent-policy'
 
 /**
  * A definition the clamp must bound, in the two keyspaces it needs: the policy is
@@ -172,18 +177,28 @@ export function clampAgentPolicyToPublisher(input: {
   }
 
   // ── Areas ────────────────────────────────────────────────────────────────
-  // Every area is materialized, so each current area's bound is exact. The
-  // retained `default` is clamped to the publisher's WEAKEST area rung, because
-  // it must answer for an area a future deploy adds and no probe can know that
-  // area's posture in advance. Conservative on purpose: a security clamp's
-  // unknown case belongs on the low side, and for an ADMIN publisher (all-Full)
-  // the minimum is `admin`, so the intended escape hatch is unaffected.
+  // Every area is materialized, so each current area's bound is exact. Both sides
+  // are read on the area's OWN ladder: `publisher.areaLevel` already tops out at
+  // the area's ceiling (`areaLevelFromKeys` returns the highest rung the area
+  // offers), so the authored rung must be normalized the same way or an area with
+  // a short ladder reports a reduction that changes no enforcement — an OWNER on
+  // `auditLog` (ceiling `Read`) read as "Full reduced to Read".
+  //
+  // The retained `default` is clamped to the publisher's WEAKEST area rung,
+  // because it must answer for an area a future deploy adds and no probe can know
+  // that area's posture in advance. Conservative on purpose — but an area where
+  // the publisher already sits at the CEILING is not evidence of a limit, so it
+  // contributes `admin` rather than dragging the floor down to its own short
+  // ladder. Without that, one `Read`-max area would cap every OWNER's retained
+  // default at `view` and quietly close the §2.4a escape hatch.
   const areaOverrides: Record<string, ResourcePermission> = {}
   let weakestPublisherArea: ResourcePermission = 'admin'
   for (const area of AREA_ORDER) {
-    const want = lookupExactPolicy(resolved.areas, area)
-    const bound = areaLevelToPermission(publisher.areaLevel(area))
-    weakestPublisherArea = minPermission(weakestPublisherArea, bound)
+    const want = clampPermissionToArea(area, lookupExactPolicy(resolved.areas, area))
+    const level = publisher.areaLevel(area)
+    const bound = areaLevelToPermission(level)
+    const saturated = level >= areaCeilingLevel(area)
+    weakestPublisherArea = minPermission(weakestPublisherArea, saturated ? 'admin' : bound)
     const got = minPermission(want, bound)
     areaOverrides[area] = got
     if (exceeds(want, got)) record('area', area, want, got)

--- a/packages/lib/src/permissions/profiles/agent-policy.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy.ts
@@ -10,7 +10,7 @@ import { type ResourcePermission, ResourcePermissionValues } from '@auxx/databas
 import { createScopedLogger } from '@auxx/logger'
 import { PERMISSION_RANK } from '../capabilities/compose-user-capabilities'
 import { INSTANCE_ACCESS_RESOURCES, type InstanceAccessKey } from '../capabilities/instance-access'
-import { AREA_ORDER, type Area, Level } from '../capabilities/registry'
+import { AREA_ORDER, type Area, clampLevelToArea, Level } from '../capabilities/registry'
 import { systemProfileForAgentKind } from './system-profiles'
 import type { CachedPermissionProfile } from './types'
 
@@ -69,6 +69,24 @@ export function permissionToAreaLevel(permission: ResourcePermission): Level {
 /** Inverse of {@link permissionToAreaLevel} — used by the publish-time clamp. */
 export function areaLevelToPermission(level: Level): ResourcePermission {
   return POLICY_LADDER[Math.min(POLICY_LADDER.length - 1, Math.max(0, level))] ?? 'none'
+}
+
+/**
+ * An authored rung expressed on the area's OWN ladder (plan 19 §2.3 + the
+ * registry's per-area rungs).
+ *
+ * The policy is authored on the flat four-rung vocabulary, but an area's ladder
+ * can be shorter: `auditLog` tops out at `Read`, `files`/`billing` skip `Edit`.
+ * `'admin'` on `auditLog` therefore is not authority the agent has and the human
+ * lacks — `expandLevelsToKeys` composes both to `auditLogView`. Normalizing here
+ * keeps the clamp comparing like with like, so an OWNER (whose composed rung on
+ * `auditLog` is `Read`, the ceiling) no longer reads as "reduced".
+ */
+export function clampPermissionToArea(
+  area: Area,
+  permission: ResourcePermission
+): ResourcePermission {
+  return areaLevelToPermission(clampLevelToArea(area, permissionToAreaLevel(permission)))
 }
 
 /**
@@ -325,9 +343,12 @@ function expandProfilePolicy(
 ): PublishedAgentPermissionPolicy {
   const parsed = parsePublishedAgentPolicy(agentPolicy)
 
+  // Materialized on the area's OWN ladder ({@link clampPermissionToArea}), so the
+  // snapshot states the rung the agent actually composes rather than the one the
+  // flat vocabulary let the author type.
   const areaOverrides: Record<string, ResourcePermission> = {}
   for (const area of AREA_ORDER) {
-    areaOverrides[area] = lookupExactPolicy(parsed.areas, area)
+    areaOverrides[area] = clampPermissionToArea(area, lookupExactPolicy(parsed.areas, area))
   }
 
   return {


### PR DESCRIPTION
An owner publishing an agent was told:

> **Publishing would reduce this policy**
> Account activity reduced from Full to Read (you hold Read)

It reduces nothing.

## What was wrong

Every area has its own ladder. `Area.auditLog` offers exactly **one** rung (`Read`) — there is nothing above "view the audit log" to grant. The agent policy is authored on the flat four-rung vocabulary, and the seeded `agent` system profile asks for `admin` everywhere.

The clamp compared those two spellings raw:

| | value |
|---|---|
| policy asks for on Account activity | `admin` |
| an OWNER composes there | `view` — because `Read` *is* the ceiling |

`admin > view` → a reduction is recorded and disclosed. But `expandLevelsToKeys` unions the rungs **at or below** the level, so `admin` and `view` on that area both expand to exactly `auditLogView`. Same authority, no reduction. The row beside the banner already rendered the clamped rung (it goes through `clampToArea`), so the screen contradicted itself.

## The sharper half

`areas.default` — the rung answering for an area a future deploy adds — is floored by the publisher's **weakest** area rung. One `Read`-max area therefore capped every owner's retained default at `view`, quietly closing the §2.4a "an owner publishing widens legitimately" escape hatch. An area where the publisher already sits at the **ceiling** is not evidence of a limit, so it now contributes `admin` to that floor.

## The fix

One rule: normalize an authored rung onto the area's own ladder before comparing it to a composed one.

- `registry.ts` — `clampLevelToArea()` + `areaCeilingLevel()`, beside the `expandLevelsToKeys` semantics they mirror. The editor's `clampToArea` now delegates instead of keeping a second copy.
- `agent-policy.ts` — `clampPermissionToArea()`; `expandProfilePolicy` materializes each area at the rung it actually composes.
- `agent-policy-clamp.ts` — normalizes the wanted rung; ceiling-saturated areas stop dragging the retained default down.
- `use-agent-policy-clamp.ts` — the live preview normalizes identically, so the banner and the row agree.

No enforcement change: every path that was gated before is gated the same way after. What changes is what the clamp *reports* and what the retained default is floored to.

## Why the suite missed it

The `ADMIN` stub set `Level.Full` on every area — not what an owner composes, since `areaLevelFromKeys` can never exceed an area's ladder. It now saturates each area's real ceiling, which makes the bug reproducible.

New coverage:
- lib — no reduction at the ceiling; `areas.default` stays `admin` for an owner; a **real** reduction on the same area still reports, as `view → none` rather than a phantom `admin → none`.
- web — `use-agent-policy-clamp.test.ts` for the preview hook: owner sees nothing, a viewer holding nothing there still sees it, and a full-ladder area (`records`) still reports at the rung actually held.

## Verification

- `packages/lib` — 428 permission tests pass
- `apps/web` — 112 permission component/hook tests pass
- typecheck clean on the touched files in both packages

## Not in scope

`assertProfileMapNoEscalation` (the human profile-save guard) compares authored levels the same raw way. There is no UI path to it — `LevelControl` only renders rungs the area offers — so reaching it takes a hand-crafted API call. Left alone deliberately; happy to normalize it in a follow-up.
