### PR TITLE
fix(workflow): stop human-in-the-loop auto-approving production runs

### DIFF
--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-test-mode.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-test-mode.test.ts
@@ -1,0 +1,158 @@
+// packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-test-mode.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkflowNode } from '../../../core/types'
+import { NodeRunningStatus } from '../../../core/types'
+
+vi.mock('@auxx/config/server', () => ({ WEBAPP_URL: 'http://localhost:3000' }))
+vi.mock('@auxx/database', () => ({
+  database: {},
+  schema: {
+    ApprovalRequest: {},
+    WorkflowRun: {},
+    User: { id: {}, email: {}, name: {}, userType: {} },
+    OrganizationMember: { userId: {}, organizationId: {} },
+  },
+}))
+vi.mock('../../../../cache/workflow-app-queries', () => ({
+  getCachedWorkflowApp: vi.fn(async () => ({ name: 'Human in the loop' })),
+}))
+vi.mock('../../../../events/publisher', () => ({
+  publisher: { publishLater: vi.fn(async () => undefined) },
+}))
+vi.mock('../../../../jobs/email', () => ({ enqueueEmailJob: vi.fn(async () => undefined) }))
+vi.mock('../../../../jobs/queues', () => ({
+  Queues: { workflowDelayQueue: 'workflowDelayQueue' },
+  getQueue: vi.fn(() => ({ add: vi.fn(async () => undefined) })),
+}))
+vi.mock('../../../../notifications/notification-service', () => ({
+  NotificationService: class {
+    sendNotification = vi.fn(async () => ({ id: 'n1' }))
+  },
+}))
+vi.mock('../../../services/approval-response-service', () => ({
+  ApprovalResponseService: class {
+    generateApprovalToken = vi.fn(async () => 'tok')
+  },
+}))
+
+const { HumanConfirmationProcessor } = await import('../human-confirmation')
+
+/** Captures the ApprovalRequest insert and swallows the WorkflowRun pause update. */
+function makeMockDb() {
+  const inserted: any[] = []
+  const db: any = {
+    insert: () => ({
+      values: (v: any) => {
+        inserted.push(v)
+        return { returning: async () => [{ ...v, expiresAt: v.expiresAt }] }
+      },
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+    select: () => {
+      const builder: any = {
+        from: () => builder,
+        where: async () => [],
+      }
+      return builder
+    },
+  }
+  return { db, inserted }
+}
+
+function makeNode(testBehavior?: string): WorkflowNode {
+  return {
+    nodeId: 'human-confirmation-1',
+    name: 'Human Review',
+    data: {
+      type: 'human-confirmation',
+      message: 'Do you like the name?',
+      assignees: { actorIds: ['user:u1'] },
+      notification_methods: { in_app: false, email: false },
+      timeout: { duration: 24, unit: 'hours' },
+      require_login: true,
+      ...(testBehavior ? { test_behavior: testBehavior } : {}),
+    },
+  } as unknown as WorkflowNode
+}
+
+function makeContextManager(db: any, debug: boolean) {
+  return {
+    getContext: () => ({
+      organizationId: 'org1',
+      workflowId: 'wf1',
+      executionId: 'run1',
+      userId: 'u1',
+      db,
+    }),
+    getOptions: () => ({ workflowRunId: 'run1', workflowAppId: 'app1' }),
+    isDebugMode: () => debug,
+    log: vi.fn(),
+    getAllVariables: () => ({}),
+    serialize: () => ({}),
+  } as any
+}
+
+const preprocessed = {
+  inputs: {
+    message: 'Do you like the name?',
+    assignees: { userIds: ['u1'], groups: [] },
+    expiresAt: new Date(Date.now() + 86_400_000),
+  },
+  metadata: {},
+} as any
+
+describe('HumanConfirmationProcessor test-mode gating', () => {
+  let processor: any
+
+  beforeEach(() => {
+    processor = new HumanConfirmationProcessor()
+  })
+
+  const run = (testBehavior: string | undefined, debug: boolean) => {
+    const { db, inserted } = makeMockDb()
+    const node = makeNode(testBehavior)
+    return processor
+      .executeNode(node, makeContextManager(db, debug), preprocessed)
+      .then((result: any) => ({ result, inserted }))
+  }
+
+  it('does NOT auto-approve a production run carrying the default always_approve setting', async () => {
+    const { result, inserted } = await run('always_approve', false)
+    expect(result.output?.test_mode).toBeUndefined()
+    expect(result.status).toBe(NodeRunningStatus.Paused)
+    expect(inserted).toHaveLength(1)
+    expect(inserted[0].status).toBe('pending')
+  })
+
+  it('creates a real approval request in production when no test_behavior is set', async () => {
+    const { result, inserted } = await run(undefined, false)
+    expect(result.status).toBe(NodeRunningStatus.Paused)
+    expect(inserted).toHaveLength(1)
+  })
+
+  it('auto-approves a builder test run with always_approve', async () => {
+    const { result, inserted } = await run('always_approve', true)
+    expect(result.status).toBe(NodeRunningStatus.Succeeded)
+    expect(result.outputHandle).toBe('approved')
+    expect(result.output?.test_mode).toBe(true)
+    expect(inserted).toHaveLength(0)
+  })
+
+  it('auto-denies a builder test run with always_deny', async () => {
+    const { result } = await run('always_deny', true)
+    expect(result.outputHandle).toBe('denied')
+  })
+
+  it('takes the real approval path on a test run when test_behavior is live', async () => {
+    const { result, inserted } = await run('live', true)
+    expect(result.status).toBe(NodeRunningStatus.Paused)
+    expect(inserted).toHaveLength(1)
+    expect(inserted[0].metadata?.isTestMode).toBe(true)
+  })
+
+  it('does not flag a production approval request as test data', async () => {
+    const { inserted } = await run('live', false)
+    expect(inserted[0].metadata?.isTestMode).toBeUndefined()
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/human-confirmation.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/human-confirmation.ts
@@ -100,15 +100,14 @@ export class HumanConfirmationProcessor extends BaseNodeProcessor {
     const db = context.db ?? database
     const isDryRun = contextManager.isDebugMode()
     try {
-      // Handle test/dry run mode (except for 'live' which acts like production)
-      // If test_behavior is 'live', always act like production regardless of isDryRun
-      if (config.test_behavior === 'live') {
-        // Continue to live mode execution below
-      } else if (isDryRun || config.test_behavior) {
+      // test_behavior ONLY applies to builder test runs. A production run always creates a real
+      // approval request and pauses — never auto-approve because the node carries the default
+      // 'always_approve' test setting. 'live' opts a test run into the real approval path too.
+      if (isDryRun && config.test_behavior !== 'live') {
         return await this.handleTestMode(node, config, contextManager)
       }
-      // Check if we're running in 'live' test mode
-      const isTestMode = config.test_behavior === 'live'
+      // A debug run that reaches the real approval path is flagged as test data
+      const isTestMode = isDryRun
       // Use preprocessed data if available, otherwise compute on the fly
       let message: string | undefined
       let assignees: {


### PR DESCRIPTION
## Problem

A published workflow with a human-in-the-loop node completed instantly without anyone approving.

Two things combined:

1. `apps/web/src/components/workflow/nodes/core/human/schema.ts` seeds every new human node with `test_behavior: 'always_approve'` via `DEFAULT_HUMAN_CONFIRMATION_CONFIG`, so it gets persisted into the published graph.
2. The processor entered test mode on the *presence* of that field rather than on whether the run was a test run:

```ts
} else if (isDryRun || config.test_behavior) {
  return await this.handleTestMode(...)   // Succeeded, outputHandle 'approved'
}
```

Result: any human node built in the UI auto-approved on every production run — no `ApprovalRequest` row, no pause, no notification.

Observed on run `yp5cxbzrfdp3iwmpurk8usgf` (`triggeredFrom: PUBLIC_SHARE`, so `debug` was false):

| node | outputs |
|---|---|
| `human-confirmation-HcN552…` | `{outcome: "approved", test_mode: true, test_behavior: "always_approve"}` |
| `end-yV4E6…` | `"Yes we like the name."` |

## Fix

Gate on the debug flag instead:

```ts
if (isDryRun && config.test_behavior !== 'live') {
  return await this.handleTestMode(node, config, contextManager)
}
const isTestMode = isDryRun
```

`test_behavior` now applies only to builder test runs (`triggeredFrom = DEBUGGING`), `'live'` opts a test run into the real approval path, and production always creates the approval request and pauses. This matches what the panel already tells users — the section is labelled "Behavior during workflow testing".

Also corrects `isTestMode`, previously `test_behavior === 'live'`, which would have stamped genuine production approval requests as test data.

## Migration

None. The stored `always_approve` is now ignored outside debug runs.

## Tests

New `human-confirmation-test-mode.test.ts` — 6 cases across production vs. debug × `always_approve` / `always_deny` / `live` / unset. Verified it catches the original bug: reverting the gate makes "does NOT auto-approve a production run carrying the default always_approve setting" fail.

## Note for reviewers

`@auxx/lib`'s compiled `dist/` still carried the old logic, so a rebuild is required for the worker to pick this up.