### PR TITLE
fix(workflows): resolve the org system user for authorless scheduled runs

### DIFF
--- a/packages/lib/src/jobs/workflow/scheduled-trigger-job.test.ts
+++ b/packages/lib/src/jobs/workflow/scheduled-trigger-job.test.ts
@@ -1,0 +1,300 @@
+// packages/lib/src/jobs/workflow/scheduled-trigger-job.test.ts
+// Regression guard for the FK that used to drop every scheduled run of a workflow
+// whose author had been offboarded.
+//
+// `WorkflowApp.createdById` is `ON DELETE SET NULL`, so deleting a workflow's author
+// nulls it. This job used to paper over that with `workflowApp.createdById || 'system'`.
+// `'system'` is truthy, so `createWorkflowRun`'s own
+// `userId || getSystemUserForActions(orgId)` fallback never fired, and the literal
+// landed in `WorkflowRun.createdBy` — itself an FK to `User.id`, with no `'system'`
+// row to point at. The insert 23503'd and the run was never created.
+//
+// The assertion is therefore on the value that reaches the INSERT, not on what the
+// job hands to `createRun`: the whole point is that no layer between the two invents
+// an id. `createWorkflowRun` runs for real here; only the engine, the queue-side
+// reporter and the two collaborators that would need a live database
+// (`SystemUserService`, the usage guard) are faked.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+const APP = 'app_1'
+const WORKFLOW = 'wf_1'
+const NODE = 'node_1'
+const AUTHOR = 'user_alice'
+/** What `SystemUserService.getSystemUserForActions` resolves to for {@link ORG}. */
+const SYSTEM_USER = 'user_org_system'
+
+/** A column reference as the local `@auxx/database` mock materialises it. */
+interface ColumnMarker {
+  table: string
+  column: string
+}
+
+/**
+ * One `db` response, in call order. `from` is asserted rather than assumed so a
+ * reordered/extra query surfaces as a failure instead of silently reusing rows.
+ */
+interface Response {
+  from: string
+  rows: unknown[]
+}
+
+/** What the fake `db` recorded about the single `INSERT` the run creation issued. */
+interface InsertSpy {
+  into?: string
+  values?: Record<string, unknown>
+}
+
+const insertSpy: InsertSpy = {}
+let responses: Response[] = []
+let workflowRow: Record<string, unknown> | undefined
+
+const getSystemUserForActions = vi.fn(async (_orgId: string) => SYSTEM_USER)
+
+vi.mock('@auxx/database', () => {
+  const tables = new Map<string, Record<string, ColumnMarker>>()
+  const table = (name: string) => {
+    let columns = tables.get(name)
+    if (!columns) {
+      columns = new Proxy({} as Record<string, ColumnMarker>, {
+        get: (_t, column: string) =>
+          column === '__table' ? name : ({ table: name, column } satisfies ColumnMarker),
+      })
+      tables.set(name, columns)
+    }
+    return columns
+  }
+
+  /**
+   * A select builder answering from {@link responses}. Every read under test ends
+   * at `.limit(n)`, so that is where it resolves — no thenable needed.
+   */
+  const selectChain = () => {
+    let from = ''
+    const chain: Record<string, unknown> = {
+      from: (t: { __table: string }) => {
+        from = t.__table
+        return chain
+      },
+      leftJoin: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      limit: async () => {
+        const next = responses.shift()
+        if (!next) throw new Error(`unexpected db.select from ${from}`)
+        if (next.from !== from) {
+          throw new Error(`expected db.select from ${next.from}, got ${from}`)
+        }
+        return next.rows
+      },
+    }
+    return chain
+  }
+
+  const database = {
+    select: () => selectChain(),
+    insert: (t: { __table: string }) => ({
+      values: (values: Record<string, unknown>) => {
+        insertSpy.into = t.__table
+        insertSpy.values = values
+        return {
+          returning: async () => [{ id: 'run_1', ...values }],
+        }
+      },
+    }),
+    query: {
+      Workflow: { findFirst: async () => workflowRow },
+    },
+  }
+
+  return { database, schema: new Proxy({}, { get: (_t, name: string) => table(name) }) }
+})
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return {
+    ...actual,
+    eq: (left: unknown, right: unknown) => ({ __eq: [left, right] }),
+    and: (...args: unknown[]) => ({ __and: args }),
+    desc: (col: unknown) => ({ __desc: col }),
+  }
+})
+
+vi.mock('../../users/system-user-service', () => ({
+  SystemUserService: { getSystemUserForActions },
+}))
+
+// No plan/quota lookup — the guard needs a live database and is not what is under test.
+vi.mock('../../usage/create-usage-guard', () => ({ createUsageGuard: async () => null }))
+
+vi.mock('../../workflow-engine', () => ({
+  RedisWorkflowExecutionReporter: class {
+    constructor(readonly runId: string) {}
+  },
+}))
+
+vi.mock('../../workflow-engine/core/workflow-engine', () => ({
+  WorkflowEngine: class {
+    getNodeRegistry() {
+      return { initializeWithDefaults: async () => {} }
+    }
+  },
+}))
+
+vi.mock('../../workflows/scheduled-trigger-service', () => ({
+  ScheduledTriggerService: class {
+    unscheduleWorkflowTriggers = vi.fn()
+  },
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+const { WorkflowExecutionService } = await import('../../workflows/workflow-execution-service')
+const { executeScheduledTrigger } = await import('./scheduled-trigger-job')
+
+const graph = {
+  nodes: [{ id: NODE, type: 'scheduled', data: { type: 'scheduled', isEnabled: true } }],
+  edges: [],
+}
+
+/** Queue the three reads the happy path makes, for a workflow authored by `createdById`. */
+function arrangeHappyPath(createdById: string | null) {
+  workflowRow = {
+    id: WORKFLOW,
+    workflowAppId: APP,
+    organizationId: ORG,
+    triggerType: 'scheduled',
+    version: 3,
+    graph,
+  }
+  responses = [
+    // 1. existence probe
+    { from: 'WorkflowApp', rows: [{ id: APP, enabled: true }] },
+    // 2. published + enabled join
+    {
+      from: 'WorkflowApp',
+      rows: [
+        {
+          workflowApp: { id: APP, organizationId: ORG, createdById },
+          publishedWorkflow: { id: WORKFLOW, graph },
+          organization: { name: 'Acme' },
+        },
+      ],
+    },
+    // 3. last sequence number, inside createWorkflowRun
+    { from: 'WorkflowRun', rows: [{ sequenceNumber: 7 }] },
+  ]
+}
+
+function ctx() {
+  const data = {
+    workflowAppId: APP,
+    organizationId: ORG,
+    nodeId: NODE,
+    triggerConfig: { cron: '0 * * * *' } as never,
+  }
+  return { throwIfCancelled: () => {}, data, job: { id: 'job_1', data } } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSystemUserForActions.mockResolvedValue(SYSTEM_USER)
+  vi.spyOn(WorkflowExecutionService.prototype, 'executeWorkflowAsync').mockResolvedValue(undefined)
+  insertSpy.into = undefined
+  insertSpy.values = undefined
+})
+
+describe('executeScheduledTrigger — WorkflowRun.createdBy', () => {
+  it('stores the resolved org system user when the workflow author was deleted', async () => {
+    arrangeHappyPath(null)
+
+    const result = await executeScheduledTrigger(ctx())
+
+    // The run exists at all — the FK violation used to abort the whole job.
+    expect(result).toMatchObject({ success: true, workflowRunId: 'run_1' })
+    expect(insertSpy.into).toBe('WorkflowRun')
+    // A real `User.id`, resolved for THIS org — not a literal, not null, not absent.
+    expect(getSystemUserForActions).toHaveBeenCalledWith(ORG)
+    expect(insertSpy.values?.createdBy).toBe(SYSTEM_USER)
+  })
+
+  it('never substitutes a placeholder id for the absent author', async () => {
+    arrangeHappyPath(null)
+    // A distinct id per org proves the value is resolved, not a constant that
+    // happens to equal the fixture.
+    getSystemUserForActions.mockResolvedValue('user_other_org_system')
+
+    await executeScheduledTrigger(ctx())
+
+    expect(insertSpy.values?.createdBy).toBe('user_other_org_system')
+    expect(insertSpy.values?.createdBy).not.toBe('system')
+  })
+
+  it('passes a surviving author through verbatim, resolving nothing', async () => {
+    arrangeHappyPath(AUTHOR)
+
+    await executeScheduledTrigger(ctx())
+
+    expect(insertSpy.values?.createdBy).toBe(AUTHOR)
+    // The org system user is a fallback, not an override.
+    expect(getSystemUserForActions).not.toHaveBeenCalled()
+  })
+
+  it('creates the run against the published workflow either way', async () => {
+    arrangeHappyPath(null)
+
+    await executeScheduledTrigger(ctx())
+
+    expect(insertSpy.values).toMatchObject({
+      organizationId: ORG,
+      workflowAppId: APP,
+      workflowId: WORKFLOW,
+      sequenceNumber: 8,
+      type: 'scheduled',
+    })
+  })
+})
+
+describe('createWorkflowRun — the sink that owns the resolution', () => {
+  const workflow = {
+    id: WORKFLOW,
+    workflowAppId: APP,
+    triggerType: 'scheduled' as string | null,
+    version: 3,
+    graph,
+  }
+
+  async function create(userId: string | null | undefined) {
+    const { createWorkflowRun } = await import('../../workflows/workflow-execution-service')
+    const { database } = await import('@auxx/database')
+    responses = [{ from: 'WorkflowRun', rows: [] }]
+    return createWorkflowRun(database as never, {
+      workflow,
+      organizationId: ORG,
+      inputs: {},
+      mode: 'production',
+      userId,
+    })
+  }
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('accepts %s as a legal "no acting user" and resolves the org system user', async (_l, id) => {
+    await create(id as null | undefined)
+
+    expect(getSystemUserForActions).toHaveBeenCalledWith(ORG)
+    expect(insertSpy.values?.createdBy).toBe(SYSTEM_USER)
+  })
+
+  it('does not resolve anything when an acting user is supplied', async () => {
+    await create(AUTHOR)
+
+    expect(insertSpy.values?.createdBy).toBe(AUTHOR)
+    expect(getSystemUserForActions).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/jobs/workflow/scheduled-trigger-job.ts
+++ b/packages/lib/src/jobs/workflow/scheduled-trigger-job.ts
@@ -217,7 +217,11 @@ export async function executeScheduledTrigger(ctx: JobContext<ScheduledTriggerJo
         trigger_config: triggerConfig,
       },
       mode: 'production',
-      userId: workflowApp.createdById || 'system', // Use workflow creator or system
+      // The workflow's author, or absent when their `User` row was deleted
+      // (`WorkflowApp.createdById` is `ON DELETE SET NULL`). `createRun` resolves
+      // the org's system user for the absent case — inventing an id here would
+      // violate `WorkflowRun.createdBy`'s FK and drop the run.
+      userId: workflowApp.createdById,
       organizationId,
       // Note: no user email/name for scheduled triggers
     })

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/ai-v2-capabilities.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/ai-v2-capabilities.test.ts
@@ -168,7 +168,7 @@ describe('AI node tool execution is bound by the workflow author', () => {
   })
 
   it('warns into the run log when the principal is not an active member', async () => {
-    // The scheduled-trigger fallback: `workflowApp.createdById || 'system'`.
+    // E.g. a headless run, whose principal is the org system user rather than a member.
     capsByUser.set(AUTHOR, NONE_VIEW)
 
     const ctxManager = fakeContextManager()

--- a/packages/lib/src/workflows/workflow-app-access-guard.test.ts
+++ b/packages/lib/src/workflows/workflow-app-access-guard.test.ts
@@ -1,0 +1,537 @@
+// packages/lib/src/workflows/workflow-app-access-guard.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ForbiddenError } from '../errors'
+
+/**
+ * Lockdown guard for system-owned `WorkflowApp` rows (Sequences plan §3.4/§21.4,
+ * permissions v2 plan 30).
+ *
+ * Two things are under test and they need different machinery:
+ *
+ *  1. **The decision** — `ownerType IS NOT NULL` forbids, the super-admin escape
+ *     needs BOTH halves, a missing row is a deliberate no-op. A rows-in/result-out
+ *     fake covers this.
+ *
+ *  2. **The query the decision is made from** — every one of these reads is
+ *     org-scoped, and org scope is the security property. HANDOFF.md's standing
+ *     lesson applies here verbatim: *a fake that models the return value but not
+ *     the REQUEST cannot fail on the request.* `fakeDb` below hands back whatever
+ *     rows the test declared no matter what was asked for, so deleting
+ *     `eq(...organizationId...)` — a cross-org read of another tenant's workflow —
+ *     would leave every behavioural test green.
+ *
+ * So the WHERE clause is asserted directly, following the precedent in
+ * `../permissions/capabilities/grantee-access.test.ts` (which spies `or` and
+ * counts disjuncts). Two things make that possible here:
+ *
+ *  - `drizzle-orm`'s `eq`/`and` are replaced with recorders returning inspectable
+ *    plain objects, and `fakeDb` keeps the tree it was handed;
+ *  - `@auxx/database` is re-mocked locally. The global `src/test/setup.ts` proxies
+ *    `schema` to a FRESH `{}` per access, so a column ref carries no identity at
+ *    all (see the standing "drizzle columns undefined in vitest" gotcha). Stable,
+ *    self-describing markers restore exactly the identity these assertions need —
+ *    which also lets the version guard's SELECT projection be pinned to
+ *    `WorkflowApp.id` rather than trusted.
+ */
+
+const ORG = 'org_1'
+const OTHER_APP = 'app_1'
+const VERSION = 'wf_v1'
+const RUN = 'run_1'
+const USER = 'user_alice'
+
+/** A column reference as the local `@auxx/database` mock materialises it. */
+interface ColumnMarker {
+  table: string
+  column: string
+}
+
+/** `eq(left, right)` as the local `drizzle-orm` mock records it. */
+interface EqNode {
+  __eq: [ColumnMarker, unknown]
+}
+
+vi.mock('@auxx/database', () => {
+  const tables = new Map<string, Record<string, ColumnMarker>>()
+  const table = (name: string) => {
+    let columns = tables.get(name)
+    if (!columns) {
+      columns = new Proxy({} as Record<string, ColumnMarker>, {
+        get: (_t, column: string) =>
+          column === '__table' ? name : ({ table: name, column } satisfies ColumnMarker),
+      })
+      tables.set(name, columns)
+    }
+    return columns
+  }
+  return { schema: new Proxy({}, { get: (_t, name: string) => table(name) }) }
+})
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return {
+    ...actual,
+    eq: (left: unknown, right: unknown) => ({ __eq: [left, right] }),
+    and: (...args: unknown[]) => ({ __and: args }),
+  }
+})
+
+const {
+  assertWorkflowAppNotSystemOwned,
+  assertWorkflowRunNotSystemOwned,
+  assertWorkflowVersionNotSystemOwned,
+  getWorkflowRunCreatorId,
+} = await import('./workflow-app-access-guard')
+
+const SYSTEM_OWNED_MESSAGE =
+  'This workflow is managed by the system and cannot be accessed directly.'
+
+/** What `fakeDb` observed about the single query the guard issued. */
+interface QuerySpy {
+  projection: Record<string, ColumnMarker>
+  from?: string
+  joins: { table: string; on: unknown }[]
+  where?: unknown
+  limit?: number
+}
+
+/**
+ * A drizzle select builder that returns the declared rows and, crucially,
+ * remembers what it was asked. `limit()` resolves because every guard here
+ * awaits the builder at `.limit(1)`.
+ */
+function fakeDb(rows: unknown[]) {
+  const spy: QuerySpy = { projection: {}, joins: [] }
+  const chain = {
+    from: (t: { __table: string }) => {
+      spy.from = t.__table
+      return chain
+    },
+    innerJoin: (t: { __table: string }, on: unknown) => {
+      spy.joins.push({ table: t.__table, on })
+      return chain
+    },
+    where: (condition: unknown) => {
+      spy.where = condition
+      return chain
+    },
+    limit: (n: number) => {
+      spy.limit = n
+      return Promise.resolve(rows)
+    },
+  }
+  const db = {
+    select: (projection: Record<string, ColumnMarker>) => {
+      spy.projection = projection
+      return chain
+    },
+  } as never
+  return { db, spy }
+}
+
+/** Every `eq(column, value)` leaf inside a recorded WHERE tree. */
+function eqLeaves(node: unknown): EqNode['__eq'][] {
+  if (!node || typeof node !== 'object') return []
+  if ('__eq' in node) return [(node as EqNode).__eq]
+  if ('__and' in node) return (node as { __and: unknown[] }).__and.flatMap(eqLeaves)
+  return []
+}
+
+/** How many predicates the WHERE tree ANDs together. */
+function whereArity(node: unknown): number {
+  if (node && typeof node === 'object' && '__and' in node) {
+    return (node as { __and: unknown[] }).__and.length
+  }
+  return node === undefined ? 0 : 1
+}
+
+/**
+ * The assertion the behavioural tests cannot make: this query is org-scoped, on
+ * the table it claims to be scoping, against the caller's org — and the WHERE is
+ * exactly the identity predicate plus that one, so the scope cannot have been
+ * traded away for a second identity check either.
+ */
+function expectOrgScoped(spy: QuerySpy, table: string, organizationId: string) {
+  const leaves = eqLeaves(spy.where)
+  expect(whereArity(spy.where)).toBe(2)
+  expect(leaves).toContainEqual([{ table, column: 'organizationId' }, organizationId])
+}
+
+let db: ReturnType<typeof fakeDb>
+
+beforeEach(() => {
+  db = fakeDb([])
+})
+
+describe('assertWorkflowAppNotSystemOwned', () => {
+  it('allows an ordinary org-owned app (ownerType null)', async () => {
+    db = fakeDb([{ ownerType: null }])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, { workflowAppId: OTHER_APP, organizationId: ORG })
+    ).resolves.toBeUndefined()
+  })
+
+  it('allows an app whose row carries no ownerType key at all', async () => {
+    db = fakeDb([{}])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, { workflowAppId: OTHER_APP, organizationId: ORG })
+    ).resolves.toBeUndefined()
+  })
+
+  it('forbids a system-owned app', async () => {
+    db = fakeDb([{ ownerType: 'sequence' }])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, { workflowAppId: OTHER_APP, organizationId: ORG })
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('forbids with the system-owned message and a 403', async () => {
+    db = fakeDb([{ ownerType: 'sequence' }])
+
+    const error = await assertWorkflowAppNotSystemOwned(db.db, {
+      workflowAppId: OTHER_APP,
+      organizationId: ORG,
+    }).catch((e) => e)
+
+    expect(error).toBeInstanceOf(ForbiddenError)
+    expect(error.message).toBe(SYSTEM_OWNED_MESSAGE)
+    expect(error.statusCode).toBe(403)
+  })
+
+  it('forbids any non-null ownerType, not just the sequence domain', async () => {
+    db = fakeDb([{ ownerType: 'some-future-owner' }])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, { workflowAppId: OTHER_APP, organizationId: ORG })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+  })
+
+  /**
+   * A no-op, NOT a NOT_FOUND. Documented and deliberate: the guard only ever
+   * narrows access, so the caller's own lookup is what reports a missing row —
+   * making this throw would turn every guarded surface's 404 into a 403.
+   */
+  it('no-ops when the row does not exist rather than throwing', async () => {
+    db = fakeDb([])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, { workflowAppId: 'nope', organizationId: ORG })
+    ).resolves.toBeUndefined()
+  })
+
+  it('lets a super admin read a system-owned app', async () => {
+    db = fakeDb([{ ownerType: 'sequence' }])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, {
+        workflowAppId: OTHER_APP,
+        organizationId: ORG,
+        allowSuperAdminRead: true,
+        isSuperAdmin: true,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  /**
+   * The pair a sloppy `||` would break, split so each half fails on its own:
+   * a mutate surface never opts in, so a super admin must still be refused there;
+   * and a read surface that opts in must not open up for a non-super-admin.
+   */
+  it('still forbids a super admin on a surface that did not opt in', async () => {
+    db = fakeDb([{ ownerType: 'sequence' }])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, {
+        workflowAppId: OTHER_APP,
+        organizationId: ORG,
+        isSuperAdmin: true,
+      })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+  })
+
+  it('still forbids a non-super-admin on a surface that did opt in', async () => {
+    db = fakeDb([{ ownerType: 'sequence' }])
+
+    await expect(
+      assertWorkflowAppNotSystemOwned(db.db, {
+        workflowAppId: OTHER_APP,
+        organizationId: ORG,
+        allowSuperAdminRead: true,
+      })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+  })
+
+  it('scopes the lookup to the caller org', async () => {
+    db = fakeDb([{ ownerType: null }])
+
+    await assertWorkflowAppNotSystemOwned(db.db, {
+      workflowAppId: OTHER_APP,
+      organizationId: ORG,
+    })
+
+    expect(db.spy.from).toBe('WorkflowApp')
+    expectOrgScoped(db.spy, 'WorkflowApp', ORG)
+    expect(eqLeaves(db.spy.where)).toContainEqual([
+      { table: 'WorkflowApp', column: 'id' },
+      OTHER_APP,
+    ])
+  })
+})
+
+describe('assertWorkflowVersionNotSystemOwned', () => {
+  it('returns the parent app id for an ordinary version', async () => {
+    db = fakeDb([{ ownerType: null, workflowAppId: OTHER_APP }])
+
+    await expect(
+      assertWorkflowVersionNotSystemOwned(db.db, { workflowId: VERSION, organizationId: ORG })
+    ).resolves.toBe(OTHER_APP)
+  })
+
+  it('forbids a version of a system-owned app', async () => {
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+
+    await expect(
+      assertWorkflowVersionNotSystemOwned(db.db, { workflowId: VERSION, organizationId: ORG })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+  })
+
+  it('returns the parent app id for a super-admin read', async () => {
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+
+    await expect(
+      assertWorkflowVersionNotSystemOwned(db.db, {
+        workflowId: VERSION,
+        organizationId: ORG,
+        allowSuperAdminRead: true,
+        isSuperAdmin: true,
+      })
+    ).resolves.toBe(OTHER_APP)
+  })
+
+  it('still forbids each half of the super-admin escape alone', async () => {
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+    await expect(
+      assertWorkflowVersionNotSystemOwned(db.db, {
+        workflowId: VERSION,
+        organizationId: ORG,
+        isSuperAdmin: true,
+      })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+    await expect(
+      assertWorkflowVersionNotSystemOwned(db.db, {
+        workflowId: VERSION,
+        organizationId: ORG,
+        allowSuperAdminRead: true,
+      })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+  })
+
+  /** `undefined`, not a throw — same narrowing-only contract as the app guard. */
+  it('returns undefined for a version that does not exist in the org', async () => {
+    db = fakeDb([])
+
+    await expect(
+      assertWorkflowVersionNotSystemOwned(db.db, { workflowId: 'nope', organizationId: ORG })
+    ).resolves.toBeUndefined()
+  })
+
+  it('scopes the lookup to the caller org', async () => {
+    db = fakeDb([{ ownerType: null, workflowAppId: OTHER_APP }])
+
+    await assertWorkflowVersionNotSystemOwned(db.db, { workflowId: VERSION, organizationId: ORG })
+
+    expect(db.spy.from).toBe('Workflow')
+    expect(db.spy.joins.map((j) => j.table)).toEqual(['WorkflowApp'])
+    expectOrgScoped(db.spy, 'Workflow', ORG)
+    expect(eqLeaves(db.spy.where)).toContainEqual([{ table: 'Workflow', column: 'id' }, VERSION])
+  })
+
+  /**
+   * The returned id is the PARENT app's, which instance access keys on — a row
+   * fake cannot tell `WorkflowApp.id` from `Workflow.id`, so the projection is
+   * asserted instead of trusted.
+   */
+  it('projects the parent app id, not the version id', async () => {
+    db = fakeDb([{ ownerType: null, workflowAppId: OTHER_APP }])
+
+    await assertWorkflowVersionNotSystemOwned(db.db, { workflowId: VERSION, organizationId: ORG })
+
+    expect(db.spy.projection.workflowAppId).toEqual({ table: 'WorkflowApp', column: 'id' })
+    expect(db.spy.projection.ownerType).toEqual({ table: 'WorkflowApp', column: 'ownerType' })
+  })
+})
+
+describe('assertWorkflowRunNotSystemOwned', () => {
+  it('returns the parent app id for an ordinary run', async () => {
+    db = fakeDb([{ ownerType: null, workflowAppId: OTHER_APP }])
+
+    await expect(
+      assertWorkflowRunNotSystemOwned(db.db, { runId: RUN, organizationId: ORG })
+    ).resolves.toBe(OTHER_APP)
+  })
+
+  it('forbids a run of a system-owned app', async () => {
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+
+    await expect(
+      assertWorkflowRunNotSystemOwned(db.db, { runId: RUN, organizationId: ORG })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+  })
+
+  it('returns the parent app id for a super-admin read', async () => {
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+
+    await expect(
+      assertWorkflowRunNotSystemOwned(db.db, {
+        runId: RUN,
+        organizationId: ORG,
+        allowSuperAdminRead: true,
+        isSuperAdmin: true,
+      })
+    ).resolves.toBe(OTHER_APP)
+  })
+
+  it('still forbids each half of the super-admin escape alone', async () => {
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+    await expect(
+      assertWorkflowRunNotSystemOwned(db.db, {
+        runId: RUN,
+        organizationId: ORG,
+        isSuperAdmin: true,
+      })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+
+    db = fakeDb([{ ownerType: 'sequence', workflowAppId: OTHER_APP }])
+    await expect(
+      assertWorkflowRunNotSystemOwned(db.db, {
+        runId: RUN,
+        organizationId: ORG,
+        allowSuperAdminRead: true,
+      })
+    ).rejects.toThrow(SYSTEM_OWNED_MESSAGE)
+  })
+
+  it('returns undefined for a run that does not exist in the org', async () => {
+    db = fakeDb([])
+
+    await expect(
+      assertWorkflowRunNotSystemOwned(db.db, { runId: 'nope', organizationId: ORG })
+    ).resolves.toBeUndefined()
+  })
+
+  it('scopes the lookup to the caller org', async () => {
+    db = fakeDb([{ ownerType: null, workflowAppId: OTHER_APP }])
+
+    await assertWorkflowRunNotSystemOwned(db.db, { runId: RUN, organizationId: ORG })
+
+    expect(db.spy.from).toBe('WorkflowRun')
+    expect(db.spy.joins.map((j) => j.table)).toEqual(['WorkflowApp'])
+    expectOrgScoped(db.spy, 'WorkflowRun', ORG)
+    expect(eqLeaves(db.spy.where)).toContainEqual([{ table: 'WorkflowRun', column: 'id' }, RUN])
+  })
+
+  it('projects the parent app id', async () => {
+    db = fakeDb([{ ownerType: null, workflowAppId: OTHER_APP }])
+
+    await assertWorkflowRunNotSystemOwned(db.db, { runId: RUN, organizationId: ORG })
+
+    expect(db.spy.projection.workflowAppId).toEqual({ table: 'WorkflowApp', column: 'id' })
+  })
+})
+
+describe('getWorkflowRunCreatorId', () => {
+  it("returns the run's creator", async () => {
+    db = fakeDb([{ createdBy: USER }])
+
+    await expect(getWorkflowRunCreatorId(db.db, { runId: RUN, organizationId: ORG })).resolves.toBe(
+      USER
+    )
+  })
+
+  it('returns null when the run does not exist', async () => {
+    db = fakeDb([])
+
+    await expect(
+      getWorkflowRunCreatorId(db.db, { runId: 'nope', organizationId: ORG })
+    ).resolves.toBeNull()
+  })
+
+  /** `ON DELETE SET NULL` when the creator's `User` row went away. */
+  it('returns null when createdBy was nulled by the creator being deleted', async () => {
+    db = fakeDb([{ createdBy: null }])
+
+    await expect(
+      getWorkflowRunCreatorId(db.db, { runId: RUN, organizationId: ORG })
+    ).resolves.toBeNull()
+  })
+
+  it('returns null when the column was never written', async () => {
+    db = fakeDb([{}])
+
+    await expect(
+      getWorkflowRunCreatorId(db.db, { runId: RUN, organizationId: ORG })
+    ).resolves.toBeNull()
+  })
+
+  /**
+   * The contract the "a `view` holder may stop a run THEY started" rule rests
+   * on: a stored id comes back verbatim, and `null` is reserved for *absence*.
+   * Nothing in between is mapped, invented or collapsed — so the caller's rule
+   * is a plain id comparison and a headless run, whatever id it stored, fails
+   * it without any sentinel handling.
+   *
+   * This asserts that verbatim contract rather than any story about which values
+   * upstream can produce. `WorkflowRun.createdBy` FKs `User.id`, so in a live
+   * database a non-user literal cannot be stored at all — but this function is
+   * not the thing enforcing that, and must not start pretending to. The third
+   * case therefore feeds it a literal that no writer produces (until 2026-07-28
+   * `../jobs/workflow/scheduled-trigger-job.ts` passed
+   * `userId: workflowApp.createdById || 'system'`, which FK-violated on a deleted
+   * author) purely to pin that nothing here maps, collapses or special-cases it.
+   */
+  it.each([
+    ['a human creator', USER],
+    ['the org system user resolved by a headless start', 'user_org_system'],
+    ['an arbitrary non-user literal, special-casing nothing', 'system'],
+  ])('returns %s verbatim, mapping nothing', async (_label, storedId) => {
+    db = fakeDb([{ createdBy: storedId }])
+
+    const creator = await getWorkflowRunCreatorId(db.db, { runId: RUN, organizationId: ORG })
+
+    expect(creator).toBe(storedId)
+    // Distinguishable from a deleted creator, whose absence IS `null`.
+    expect(creator).not.toBeNull()
+  })
+
+  it('denies a stopping caller who did not start the run, by id alone', async () => {
+    db = fakeDb([{ createdBy: 'user_org_system' }])
+
+    const creator = await getWorkflowRunCreatorId(db.db, { runId: RUN, organizationId: ORG })
+
+    expect(creator === USER).toBe(false)
+  })
+
+  it('scopes the lookup to the caller org', async () => {
+    db = fakeDb([{ createdBy: USER }])
+
+    await getWorkflowRunCreatorId(db.db, { runId: RUN, organizationId: ORG })
+
+    expect(db.spy.from).toBe('WorkflowRun')
+    expectOrgScoped(db.spy, 'WorkflowRun', ORG)
+    expect(eqLeaves(db.spy.where)).toContainEqual([{ table: 'WorkflowRun', column: 'id' }, RUN])
+  })
+
+  it('reads a single row', async () => {
+    db = fakeDb([{ createdBy: USER }])
+
+    await getWorkflowRunCreatorId(db.db, { runId: RUN, organizationId: ORG })
+
+    expect(db.spy.limit).toBe(1)
+  })
+})

--- a/packages/lib/src/workflows/workflow-app-access-guard.ts
+++ b/packages/lib/src/workflows/workflow-app-access-guard.ts
@@ -98,10 +98,14 @@ export async function assertWorkflowVersionNotSystemOwned(
  *    row went away,
  *  - the column was never written.
  *
- * Headless runs are NOT `null`: every programmatic start resolves
- * `SystemUserService.getSystemUserForActions(orgId)` and writes that system
- * `User.id`, so an id comparison against the caller already excludes them — no
- * `'system'` sentinel to special-case.
+ * A headless run's `createdBy` is a real `User.id` like any other, so a plain id
+ * comparison against the caller already excludes it. That is a property of the
+ * column, not of the callers: `WorkflowRun.createdBy` FKs `User.id`, so the only
+ * values that can ever be stored are a real user's id or `null`. `createWorkflowRun`
+ * — the sole writer — resolves `SystemUserService.getSystemUserForActions(orgId)`
+ * whenever a caller supplies no user, and a caller that invented a placeholder id
+ * instead would not reach this function at all: its insert would fail the FK. So
+ * there is no sentinel to special-case here, whatever a caller passes.
  */
 export async function getWorkflowRunCreatorId(
   db: Database,

--- a/packages/lib/src/workflows/workflow-execution-service.ts
+++ b/packages/lib/src/workflows/workflow-execution-service.ts
@@ -71,6 +71,12 @@ const logger = createScopedLogger('workflow-execution-service')
  * Create a workflow run record directly without instantiating WorkflowExecutionService.
  * Accepts optional overrides for status, error, finishedAt, elapsedTime to support
  * creating runs in terminal states (e.g., FAILED polling trigger runs).
+ *
+ * The only writer of `WorkflowRun.createdBy`, which is an FK to `User.id`. `userId`
+ * is therefore deliberately nullable: headless starts (schedulers, pollers, app
+ * triggers) have no acting user and must pass the absence through, so this resolves
+ * the org's system user. Callers must never substitute a placeholder id of their own
+ * — no such `User` row exists and the insert would fail its FK constraint.
  */
 export async function createWorkflowRun(
   db: Database,
@@ -85,7 +91,8 @@ export async function createWorkflowRun(
     organizationId: string
     inputs: Record<string, any>
     mode: 'test' | 'production'
-    userId: string | null
+    /** Acting user, or `null`/`undefined` for a headless run (resolves to the org system user). */
+    userId: string | null | undefined
     status?: WorkflowRunStatus
     error?: string
     finishedAt?: Date
@@ -211,13 +218,17 @@ export class WorkflowExecutionService {
   }
 
   /**
-   * Create a new workflow run without executing it
+   * Create a new workflow run without executing it.
+   *
+   * `userId` is nullable — see {@link createWorkflowRun}, which resolves the org
+   * system user when no acting user is supplied.
    */
   async createRun(params: {
     workflowId: string
     inputs: Record<string, any>
     mode: 'test' | 'production'
-    userId: string
+    /** Acting user, or `null`/`undefined` for a headless run (resolves to the org system user). */
+    userId: string | null | undefined
     organizationId: string
     userEmail?: string
     userName?: string


### PR DESCRIPTION
## The bug

`WorkflowApp.createdById` is an FK to `User.id` with `onDelete: 'set null'`. So when a workflow's author is deleted:

1. `scheduled-trigger-job.ts` passed `userId: workflowApp.createdById || 'system'`
2. `createWorkflowRun`'s own fallback is `userId || getSystemUserForActions(orgId)` — and **`'system'` is truthy**, so the fallback never fired
3. The literal reached `createdBy` unsanitised, and `WorkflowRun.createdBy` is itself an FK to `User.id`
4. Dev has zero `User` rows with id `'system'`, so the insert violates the constraint and the run is never created

**Every scheduled run of that workflow stops firing, silently.** Latent today — all 169 dev `WorkflowApp` rows have a non-null `createdById` — and it arms the first time someone offboards a workflow author.

Worth noting this is the same claim plan 30 §7's manual pass exists to check ("a restricted workflow still fires headlessly"), failing for a reason that has nothing to do with permissions. That is exactly how it would have been misdiagnosed.

## The fix

- **Call site** stops inventing an id: `userId: workflowApp.createdById`, letting the sink resolve the real org system user.
- **Sink** types `userId` as `string | null | undefined`, making "no user" a legal input rather than something callers paper over. No sentinel-string sniffing was added — that would guess at values; the fix is that callers stop inventing ids.

Audited the other `|| 'system'` sites. `create-timeline-event.ts:261` is **not** the same bug (`TimelineEvent.actorId` is plain `text()` with no `.references()`, the same write sets `actorType: SYSTEM`, and `:213` already writes `actorId: 'email-sync'` — deliberately non-FK). The cache-key sites are non-FK.

> One instance found and **not** fixed here, filed separately: `field-values/field-value-helpers.ts:1155` passes `userId ?? 'system'` into `ensureThumbnailPresets`, reaching `MediaAsset.createdById` (FK, `schema/media-asset.ts:41`). It is swallowed by a `try/catch` in a worker, so it fails silently — the avatar stays on its fallback icon.

## Tests

`workflow-app-access-guard.ts` had **no test file anywhere in the repo**. It has 34 now, and `scheduled-trigger-job.test.ts` (7) is the first test for **any** workflow headless job.

The guard tests assert the **WHERE clause**, not just the returned rows. Every one of these guards filters on `organizationId`, and a fake that models the return value but not the request cannot fail when that predicate is dropped — which would be a cross-org read. The `or`-spy precedent from `grantee-access.test.ts` does not transfer (these use `and`/`eq`, and arity-counting alone would miss "org filter swapped for a second id filter"), so `eq`/`and` are recorded as inspectable nodes and `@auxx/database` is re-mocked locally to give column refs stable identity.

**24 mutations verified across the two suites, all caught**, each against an unmutated control. The one that matters most: swapping the org predicate for a second identity predicate, keeping arity at 2 — pure counting would have passed it.

## Verification

- `src/workflows` + `src/jobs`: **184/184 pass**
- `packages/lib` tsc: 3459 → **3458** src errors. The single removal is a pre-existing `TS2322` at `workflow-engine/execution/trigger-app-workflow.ts` that the type widening fixes (that caller already passed `null`). **Zero new errors.**
- Biome clean on all six files.
- `src/workflow-engine`'s 12 pre-existing failures are unchanged — proven by re-running with HEAD versions of these three files swapped in (identical 7 failed / 19 passed).

**Not verified:** the fix against a live database. The tests prove the resolved id reaches the `INSERT`; they do not exercise Postgres accepting it. The FK direction is read from the schema.