### PR TITLE
fix(workflows): gate the webhook test surface on instance edit

### DIFF
--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/events/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/events/route.ts
@@ -1,19 +1,63 @@
 // apps/web/src/app/api/workflows/[workflowId]/webhook/events/route.ts
 
 import { WorkflowApp } from '@auxx/database'
+import { getCapabilities } from '@auxx/lib/permissions'
 import { and, eq } from 'drizzle-orm'
 import { createSsePollRoute } from '~/lib/sse/create-sse-poll-route'
 
+/**
+ * SSE replay of the inbound webhook payloads captured by the sibling
+ * `../webhook/route.ts` in test mode (`?test=true`) — the method, headers, query
+ * string and **body** of real external calls, buffered on
+ * `webhook:test:<workflowId>:events`.
+ *
+ * Gated on instance **`edit`** of the workflow. `[workflowId]` here is a
+ * `WorkflowApp.id` — the id space per-workflow instance access keys on directly
+ * (the sibling webhook ingress resolves the same segment via
+ * `db.query.WorkflowApp`), so unlike `run/route.ts` and `files/[fileId]` there is
+ * no version id to walk up from.
+ *
+ * `edit` rather than the `view` its read-only siblings use (`workflow/run/[runId]/events`,
+ * `workflows/[workflowId]/files/[fileId]` GET): this buffer is written **only**
+ * in test mode and read by exactly one client — the builder's webhook node panel,
+ * whose "Test Webhook" button is `disabled={isReadOnly}`, and `useReadOnly()`
+ * folds in `instanceReadOnly` = holds `view` but not `edit` (plan 30 §4). The
+ * client already treats capturing test payloads as an authoring affordance, and
+ * plan 30 §4 lists "Run single node / test" at the Edit tier, matching the
+ * sibling test-run route's `canEditInstance`. Gating at `view` would leave the
+ * server looser than the UI it serves.
+ *
+ * Before this, `authorize` returned true for **any** org member whose
+ * `defaultOrganizationId` matched the workflow's org, so a member restricted from
+ * this workflow — or composing `workflows: None` — could still replay its
+ * captured payloads.
+ *
+ * `createSsePollRoute` collapses a `false` here to a clean **403** (there is no
+ * 404 path), so a workflow in another org, a workflow that never existed, a
+ * system-owned one and one the caller is restricted from are all indistinguishable
+ * — `WorkflowApp.id`s stay unprobeable across orgs.
+ *
+ * No `FeatureKey.workflows` plan-AND, following the read-only REST precedent
+ * (plan 32): an org mid-downgrade should not have a live SSE reconnect fail.
+ */
 export const GET = createSsePollRoute({
   getRedisKey: ({ workflowId }) => `webhook:test:${workflowId}:events`,
   authorize: async (session, params, db) => {
+    const { workflowId } = params
+    if (!workflowId) return false
+
+    const organizationId = session.user.defaultOrganizationId
+
     const workflow = await db.query.WorkflowApp.findFirst({
-      where: and(
-        eq(WorkflowApp.id, params.workflowId),
-        eq(WorkflowApp.organizationId, session.user.defaultOrganizationId)
-      ),
-      columns: { id: true },
+      where: and(eq(WorkflowApp.id, workflowId), eq(WorkflowApp.organizationId, organizationId)),
+      columns: { id: true, ownerType: true },
     })
-    return !!workflow
+
+    // System-owned apps (Sequences plan §3.4) are never addressable by org users,
+    // regardless of how much workflow access the caller holds.
+    if (!workflow || workflow.ownerType) return false
+
+    const capabilities = await getCapabilities(session.user.id, organizationId)
+    return capabilities.canEditInstance('workflow', workflow.id)
   },
 })

--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/events/webhook-events-instance-access.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/events/webhook-events-instance-access.test.ts
@@ -1,0 +1,244 @@
+// apps/web/src/app/api/workflows/[workflowId]/webhook/events/webhook-events-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 32, the `createSsePollRoute` instance of the class — the webhook
+ * test-capture replay.
+ *
+ * Its `authorize` returned true for **any** org member whose
+ * `defaultOrganizationId` matched the workflow's org, then streamed every
+ * captured inbound webhook payload (method, headers, query, **body** of real
+ * external calls) off `webhook:test:<workflowId>:events`. Since plan 30 shipped
+ * per-workflow instance access, org membership is the wrong bar: a member
+ * restricted from this workflow, or composing `workflows: None`, still got the
+ * stream.
+ *
+ * Behavioral: the REAL route (the real `createSsePollRoute` factory, the real
+ * `authorize`) runs with a REAL `CapabilitySet`. The Redis `lrange` is the
+ * observed side effect — "did the captured payloads actually get read?" is the
+ * whole assertion.
+ */
+
+const { getCapabilities, getSession, findFirst, getRedisClient, lrange, eq, and } = vi.hoisted(
+  () => ({
+    getCapabilities: vi.fn(),
+    getSession: vi.fn(),
+    findFirst: vi.fn(),
+    getRedisClient: vi.fn(),
+    lrange: vi.fn(),
+    eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+    and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+  })
+)
+
+vi.mock('@auxx/database', () => ({
+  database: { query: { WorkflowApp: { findFirst } } },
+  WorkflowApp: { id: 'WorkflowApp.id', organizationId: 'WorkflowApp.organizationId' },
+}))
+
+vi.mock('drizzle-orm', () => ({ and, eq }))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest (get-capabilities,
+// record-view-scope, overage-*) — stub it, keep the enums real via `/client`.
+vi.mock('@auxx/lib/permissions', () => ({ getCapabilities }))
+
+vi.mock('@auxx/redis', () => ({ getRedisClient }))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+/** A `WorkflowApp.id` — this route's segment IS the instance-access key. */
+const WF_ID = 'wf_cuid0000000000000000000'
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/** A real `CapabilitySet` holding `permission` on {@link WF_ID} via an explicit row. */
+function capabilitiesFor(permission: ResourcePermission, areaLevel = AREA_LEVEL_OF[permission]) {
+  const instances = { [WF_ID]: permission }
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.workflows]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/** A real `CapabilitySet` with NO instance rows anywhere — the absent-row fallback. */
+function areaOnly(level: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.workflows]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+function signedIn(capabilities: InstanceType<typeof CapabilitySet>) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
+  })
+  getCapabilities.mockResolvedValue(capabilities)
+}
+
+const params = { params: Promise.resolve({ workflowId: WF_ID }) }
+
+const request = (signal: AbortSignal) => ({ headers: new Headers(), signal }) as never
+
+/**
+ * Reads the first SSE chunk, lets `start()` finish its Redis catch-up, then
+ * aborts so neither the poll nor the heartbeat interval leaks into the next test.
+ */
+async function firstChunk(res: Response, controller: AbortController) {
+  const reader = res.body?.getReader()
+  if (!reader) throw new Error('no body')
+  const { value } = await reader.read()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  controller.abort()
+  await reader.cancel()
+  // `createSsePollRoute` enqueues plain strings, not encoded bytes.
+  return typeof value === 'string' ? value : new TextDecoder().decode(value)
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  findFirst.mockReset().mockResolvedValue({ id: WF_ID, ownerType: null })
+  lrange.mockReset().mockResolvedValue([])
+  getRedisClient.mockReset().mockResolvedValue({ lrange })
+  eq.mockClear()
+  and.mockClear()
+})
+
+describe('GET /api/workflows/[workflowId]/webhook/events — the captured-payload replay', () => {
+  it('401s without a session, before any DB or capability read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(new AbortController().signal), params)
+    expect(res.status).toBe(401)
+    expect(findFirst).not.toHaveBeenCalled()
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(getRedisClient).not.toHaveBeenCalled()
+  })
+
+  it('403s a member composing `workflows: None`, without reading the payloads', async () => {
+    signedIn(areaOnly(Level.None))
+    const res = await GET(request(new AbortController().signal), params)
+    expect(res.status).toBe(403)
+    expect(getCapabilities).toHaveBeenCalledWith(USER_ID, ORG_ID)
+    expect(getRedisClient).not.toHaveBeenCalled()
+    expect(lrange).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding an explicit `none` restriction on this workflow', async () => {
+    // THE case this fix exists for: the area is wide open (Full), and only the
+    // per-instance `none` row stands between the caller and the payloads. Before
+    // the fix, org membership alone got them the full stream.
+    signedIn(capabilitiesFor(ResourcePermission.none, Level.Full))
+    const res = await GET(request(new AbortController().signal), params)
+    expect(res.status).toBe(403)
+    expect(getRedisClient).not.toHaveBeenCalled()
+    expect(lrange).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding only instance `view` — capturing test payloads is Edit', async () => {
+    // The tier decision: this buffer is written only in test mode and read only by
+    // the builder's webhook panel, whose "Test Webhook" button is disabled for a
+    // `view`-without-`edit` holder (`useReadOnly()` → `instanceReadOnly`).
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(new AbortController().signal), params)
+    expect(res.status).toBe(403)
+    expect(getRedisClient).not.toHaveBeenCalled()
+    expect(lrange).not.toHaveBeenCalled()
+  })
+
+  it('streams the captured payloads for a member holding instance `edit`', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.edit))
+    const controller = new AbortController()
+    const res = await GET(request(controller.signal), params)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(await firstChunk(res, controller)).toContain('event: connected')
+    expect(lrange).toHaveBeenCalledWith(`webhook:test:${WF_ID}:events`, 0, 49)
+  })
+
+  it('streams for an instance `admin` holder', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    const controller = new AbortController()
+    const res = await GET(request(controller.signal), params)
+    expect(res.status).toBe(200)
+    await firstChunk(res, controller)
+    expect(lrange).toHaveBeenCalledTimes(1)
+  })
+
+  it('streams for a row-less workflow at the area Edit rung (baselineAtCreate: false)', async () => {
+    // Workflows are org-shared by default (plan 30 §3): with no `ResourceAccess`
+    // row anywhere, the absent-row fallback IS the area level.
+    signedIn(areaOnly(Level.Edit))
+    const controller = new AbortController()
+    const res = await GET(request(controller.signal), params)
+    expect(res.status).toBe(200)
+    await firstChunk(res, controller)
+    expect(lrange).toHaveBeenCalledTimes(1)
+  })
+
+  it('403s a row-less workflow at the area Read rung', async () => {
+    // Same absent-row fallback, one rung lower — proves the gate reads `edit`,
+    // not `view`, on the org-shared default path too.
+    signedIn(areaOnly(Level.Read))
+    const res = await GET(request(new AbortController().signal), params)
+    expect(res.status).toBe(403)
+    expect(getRedisClient).not.toHaveBeenCalled()
+  })
+
+  it('403s a foreign-org or absent workflow id before any capability read', async () => {
+    // The lookup is org-scoped, so another org's `WorkflowApp.id` is `undefined`
+    // here too — identical to one that never existed, and identical (403) to one
+    // the caller is restricted from. `createSsePollRoute` has no 404 path, so
+    // workflow ids stay unprobeable across orgs.
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    findFirst.mockResolvedValue(undefined)
+    const res = await GET(request(new AbortController().signal), params)
+    expect(res.status).toBe(403)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(getRedisClient).not.toHaveBeenCalled()
+  })
+
+  it('403s a system-owned workflow even for an instance `admin`', async () => {
+    // Sequences compile to hidden `WorkflowApp` rows (plan §3.4) that must stay
+    // unaddressable by org users regardless of workflow access.
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    findFirst.mockResolvedValue({ id: WF_ID, ownerType: 'sequence' })
+    const res = await GET(request(new AbortController().signal), params)
+    expect(res.status).toBe(403)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(getRedisClient).not.toHaveBeenCalled()
+  })
+
+  it('scopes the workflow lookup to the caller organization', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.edit))
+    const controller = new AbortController()
+    const res = await GET(request(controller.signal), params)
+    expect(res.status).toBe(200)
+    expect(eq).toHaveBeenCalledWith('WorkflowApp.organizationId', ORG_ID)
+    expect(eq).toHaveBeenCalledWith('WorkflowApp.id', WF_ID)
+    await firstChunk(res, controller)
+  })
+})

--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts
@@ -14,6 +14,11 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { v4 as uuidv4 } from 'uuid'
 import type { WebhookTestEvent } from '~/components/workflow/nodes/core/webhook/types'
 import { validateAgainstSchema } from '~/components/workflow/utils/schema-to-variable'
+import {
+  isWebhookTestWindowArmed,
+  WEBHOOK_TEST_WINDOW_TTL_SECONDS,
+  webhookTestEventsKey,
+} from '~/server/lib/webhook-test-window'
 
 const logger = createScopedLogger('api.webhook')
 
@@ -22,7 +27,15 @@ const workflowEngine = new WorkflowEngine()
 const engineInitPromise = workflowEngine.getNodeRegistry().initializeWithDefaults()
 
 /**
- * Common webhook handler for both GET and POST requests
+ * Common webhook handler for both GET and POST requests.
+ *
+ * The PRODUCTION path is intentionally unauthenticated — URL secrecy is the
+ * normal webhook contract and external callers have no session. The `?test=true`
+ * path is different: it resolves the org's **draft** graph, answers from that
+ * unpublished node's response config, and appends the caller's headers/query/body
+ * to the author's live event log. That is only allowed while an editor-armed
+ * listening window is open (see `webhook-test-window.ts` and the
+ * `workflow.armWebhookTest` mutation that opens it).
  */
 async function handleWebhookRequest(
   req: NextRequest,
@@ -58,6 +71,16 @@ async function handleWebhookRequest(
 
   try {
     logger.info(`Webhook ${method} request received`, { workflowId, isTest })
+
+    // Draft execution requires an open listening window. Answering with the
+    // SAME 404 the missing-draft case already returns keeps the endpoint from
+    // becoming an oracle for "this workflow id exists" — and it runs BEFORE the
+    // workflow lookup, so an unarmed caller can neither execute the draft nor
+    // push an entry into the author's event log.
+    if (isTest && !(await isWebhookTestWindowArmed(workflowId))) {
+      logger.warn('Webhook test request rejected — no listening window armed', { workflowId })
+      return NextResponse.json({ error: 'No draft workflow found' }, { status: 404 })
+    }
 
     // Find the workflow app with appropriate workflow (draft for test, published for production)
     const workflowApp = await db.query.WorkflowApp.findFirst({
@@ -110,9 +133,9 @@ async function handleWebhookRequest(
           webhookTestEvent.responseStatus = 500
           webhookTestEvent.responseTime = Date.now() - startTime
 
-          await redis.lpush(`webhook:test:${workflowId}:events`, JSON.stringify(webhookTestEvent))
-          await redis.ltrim(`webhook:test:${workflowId}:events`, 0, 49)
-          await redis.expire(`webhook:test:${workflowId}:events`, 300)
+          await redis.lpush(webhookTestEventsKey(workflowId), JSON.stringify(webhookTestEvent))
+          await redis.ltrim(webhookTestEventsKey(workflowId), 0, 49)
+          await redis.expire(webhookTestEventsKey(workflowId), WEBHOOK_TEST_WINDOW_TTL_SECONDS)
         }
       }
 
@@ -156,9 +179,9 @@ async function handleWebhookRequest(
             webhookTestEvent.responseStatus = 400
             webhookTestEvent.responseTime = Date.now() - startTime
 
-            await redis.lpush(`webhook:test:${workflowId}:events`, JSON.stringify(webhookTestEvent))
-            await redis.ltrim(`webhook:test:${workflowId}:events`, 0, 49)
-            await redis.expire(`webhook:test:${workflowId}:events`, 300)
+            await redis.lpush(webhookTestEventsKey(workflowId), JSON.stringify(webhookTestEvent))
+            await redis.ltrim(webhookTestEventsKey(workflowId), 0, 49)
+            await redis.expire(webhookTestEventsKey(workflowId), WEBHOOK_TEST_WINDOW_TTL_SECONDS)
           }
         }
 
@@ -214,9 +237,9 @@ async function handleWebhookRequest(
         webhookTestEvent.responseStatus = responseStatus
         webhookTestEvent.responseTime = Date.now() - startTime
 
-        await redis.lpush(`webhook:test:${workflowId}:events`, JSON.stringify(webhookTestEvent))
-        await redis.ltrim(`webhook:test:${workflowId}:events`, 0, 49)
-        await redis.expire(`webhook:test:${workflowId}:events`, 300)
+        await redis.lpush(webhookTestEventsKey(workflowId), JSON.stringify(webhookTestEvent))
+        await redis.ltrim(webhookTestEventsKey(workflowId), 0, 49)
+        await redis.expire(webhookTestEventsKey(workflowId), WEBHOOK_TEST_WINDOW_TTL_SECONDS)
       }
 
       return new NextResponse(responseConfig?.body || 'OK', {
@@ -258,12 +281,9 @@ async function handleWebhookRequest(
         webhookTestEvent.responseStatus = 500
         webhookTestEvent.responseTime = Date.now() - startTime
 
-        await redis.lpush(
-          `webhook:test:${params.workflowId}:events`,
-          JSON.stringify(webhookTestEvent)
-        )
-        await redis.ltrim(`webhook:test:${params.workflowId}:events`, 0, 49)
-        await redis.expire(`webhook:test:${params.workflowId}:events`, 300)
+        await redis.lpush(webhookTestEventsKey(workflowId), JSON.stringify(webhookTestEvent))
+        await redis.ltrim(webhookTestEventsKey(workflowId), 0, 49)
+        await redis.expire(webhookTestEventsKey(workflowId), WEBHOOK_TEST_WINDOW_TTL_SECONDS)
       }
     }
 

--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/webhook-draft-test-window.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/webhook-draft-test-window.test.ts
@@ -1,0 +1,284 @@
+// apps/web/src/app/api/workflows/[workflowId]/webhook/webhook-draft-test-window.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The anonymous draft-test hole on `/api/workflows/[workflowId]/webhook`.
+ *
+ * The PRODUCTION path is unauthenticated by design — URL secrecy is the normal
+ * webhook contract — and nothing here may change it. `?test=true` is different:
+ * it swaps `publishedWorkflow` for `draftWorkflow`, echoes the DRAFT node's
+ * configured response, and appends an attacker-controlled entry (headers, query,
+ * body) to `webhook:test:<id>:events`, which the author's editor renders live.
+ * Before this slice the route contained no secret, token, signature or session
+ * check of any kind, so a workflow id was the whole of the authorisation.
+ *
+ * It is now gated on a TTL'd listening window that an editor arms via
+ * `workflow.armWebhookTest` (instance `edit`). Unarmed, the route must behave as
+ * if no draft test path existed — including returning the SAME 404 as a missing
+ * draft, so it never becomes an oracle for "this workflow id exists".
+ *
+ * Behavioural: the real handlers are driven, and the REAL
+ * `isWebhookTestWindowArmed` runs against a fake Redis. The observed side
+ * effects are the draft lookup (`findFirst`), the event-log write (`lpush`), and
+ * the response body/status, which is read off whichever graph the route
+ * resolved.
+ */
+
+const { redis, getRedisClient, findFirst, executeWorkflow, initializeWithDefaults } = vi.hoisted(
+  () => {
+    const store = new Map<string, string | string[]>()
+    const client = {
+      store,
+      /** Flip to model an unreachable Redis (the fail-closed case). */
+      available: true,
+      set: vi.fn(async (key: string, value: string) => {
+        store.set(key, value)
+        return 'OK'
+      }),
+      exists: vi.fn(async (key: string) => (store.has(key) ? 1 : 0)),
+      lpush: vi.fn(async (key: string, ...values: string[]) => {
+        const list = (store.get(key) as string[] | undefined) ?? []
+        list.unshift(...values)
+        store.set(key, list)
+        return list.length
+      }),
+      ltrim: vi.fn(async () => 'OK'),
+      expire: vi.fn(async () => 1),
+    }
+    return {
+      redis: client,
+      // Mirrors the real contract: `required` throws, optional hands back undefined.
+      getRedisClient: vi.fn(async (required = true) => {
+        if (client.available) return client
+        if (required) throw new Error('Redis connection required but failed')
+        return undefined
+      }),
+      findFirst: vi.fn(),
+      executeWorkflow: vi.fn(async () => ({ executionId: 'exec_1', status: 'completed' })),
+      initializeWithDefaults: vi.fn(async () => undefined),
+    }
+  }
+)
+
+vi.mock('@auxx/redis', () => ({ getRedisClient }))
+vi.mock('@auxx/database', () => ({ database: { query: { WorkflowApp: { findFirst } } } }))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('@auxx/lib/workflow-engine', () => ({
+  WorkflowEngine: class {
+    getNodeRegistry() {
+      return { initializeWithDefaults }
+    }
+    executeWorkflow = executeWorkflow
+  },
+}))
+vi.mock('@auxx/lib/workflow-engine/types', () => ({
+  WorkflowNodeType: { WEBHOOK: 'webhook' },
+  WorkflowTriggerType: { WEBHOOK: 'webhook' },
+}))
+vi.mock('~/components/workflow/utils/schema-to-variable', () => ({
+  validateAgainstSchema: vi.fn(() => true),
+}))
+
+const { webhookTestArmKey, webhookTestEventsKey, WEBHOOK_TEST_WINDOW_TTL_SECONDS } = await import(
+  '~/server/lib/webhook-test-window'
+)
+const { GET, POST } = await import('./route')
+
+const WF_ID = 'wf_cuid0000000000000000000'
+const ORG_ID = 'org_cuid000000000000000000000'
+
+const webhookNode = (method: 'GET' | 'POST', body: string, statusCode: number) => ({
+  nodes: [{ id: 'n1', data: { type: 'webhook', method, responseConfig: { body, statusCode } } }],
+  edges: [],
+})
+
+/**
+ * Draft and published carry DIFFERENT response bodies on purpose — the body the
+ * route hands back is the proof of which graph it resolved.
+ */
+const workflowApp = {
+  id: WF_ID,
+  organizationId: ORG_ID,
+  createdById: 'usr_cuid000000000000000000000',
+  draftWorkflow: {
+    id: 'wfv_draft0000000000000000',
+    name: 'Draft',
+    version: 2,
+    graph: webhookNode('POST', 'DRAFT-BODY', 201),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  publishedWorkflow: {
+    id: 'wfv_published000000000000',
+    name: 'Published',
+    version: 1,
+    graph: webhookNode('POST', 'PUBLISHED-BODY', 200),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+}
+
+const params = { params: Promise.resolve({ workflowId: WF_ID }) }
+
+function postRequest(test: boolean, body: Record<string, unknown> = { hello: 'world' }) {
+  return {
+    url: `http://localhost/api/workflows/${WF_ID}/webhook${test ? '?test=true' : ''}`,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+  } as never
+}
+
+function getRequest(test: boolean) {
+  return {
+    url: `http://localhost/api/workflows/${WF_ID}/webhook${test ? '?test=true' : ''}`,
+    headers: new Headers(),
+  } as never
+}
+
+/** What `workflow.armWebhookTest` writes — the real key, the real TTL. */
+const arm = (workflowId = WF_ID) => redis.store.set(webhookTestArmKey(workflowId), '1')
+/** Model the TTL elapsing: Redis drops the key, nothing else changes. */
+const expireWindow = (workflowId = WF_ID) => redis.store.delete(webhookTestArmKey(workflowId))
+
+beforeEach(() => {
+  redis.store.clear()
+  redis.available = true
+  redis.set.mockClear()
+  redis.exists.mockClear()
+  redis.lpush.mockClear()
+  getRedisClient.mockClear()
+  executeWorkflow.mockClear()
+  findFirst.mockReset().mockResolvedValue(workflowApp)
+})
+
+describe('?test=true without an armed window — the hole', () => {
+  it('404s and never resolves the draft', async () => {
+    const res = await POST(postRequest(true), params)
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'No draft workflow found' })
+    expect(findFirst).not.toHaveBeenCalled()
+  })
+
+  it('does not pollute the author’s event log', async () => {
+    // The other half of the harm: an unarmed caller could push arbitrary
+    // headers/query/body into `webhook:test:<id>:events`, which the editor renders.
+    await POST(postRequest(true), params)
+    expect(redis.lpush).not.toHaveBeenCalled()
+    expect(redis.store.has(webhookTestEventsKey(WF_ID))).toBe(false)
+  })
+
+  it('is not an oracle — an unknown workflow id answers identically', async () => {
+    findFirst.mockResolvedValue(undefined)
+    const unknown = await POST(postRequest(true), params)
+    findFirst.mockResolvedValue(workflowApp)
+    const known = await POST(postRequest(true), params)
+
+    expect(unknown.status).toBe(known.status)
+    await expect(unknown.json()).resolves.toEqual(await known.json())
+  })
+
+  it('closes the GET path too', async () => {
+    const res = await GET(getRequest(true), params)
+    expect(res.status).toBe(404)
+    expect(findFirst).not.toHaveBeenCalled()
+  })
+})
+
+describe('?test=true with an armed window', () => {
+  it('resolves the DRAFT graph and answers with its configured response', async () => {
+    arm()
+    const res = await POST(postRequest(true), params)
+    expect(res.status).toBe(201)
+    await expect(res.text()).resolves.toBe('DRAFT-BODY')
+    expect(findFirst).toHaveBeenCalledTimes(1)
+  })
+
+  it('captures the event into the author’s log at the shared TTL', async () => {
+    arm()
+    await POST(postRequest(true), params)
+    expect(redis.lpush).toHaveBeenCalledTimes(1)
+    expect(redis.lpush.mock.calls[0]?.[0]).toBe(webhookTestEventsKey(WF_ID))
+    expect(redis.expire).toHaveBeenCalledWith(
+      webhookTestEventsKey(WF_ID),
+      WEBHOOK_TEST_WINDOW_TTL_SECONDS
+    )
+    const captured = JSON.parse((redis.lpush.mock.calls[0]?.[1] as string) ?? '{}')
+    expect(captured.body).toEqual({ hello: 'world' })
+  })
+
+  it('a window on ANOTHER workflow does not open this one', async () => {
+    arm('wf_othercuid0000000000000')
+    const res = await POST(postRequest(true), params)
+    expect(res.status).toBe(404)
+    expect(findFirst).not.toHaveBeenCalled()
+  })
+
+  it('an EXPIRED window behaves exactly like an unarmed one', async () => {
+    arm()
+    await expect(POST(postRequest(true), params).then((r) => r.status)).resolves.toBe(201)
+    expireWindow()
+    findFirst.mockClear()
+    const res = await POST(postRequest(true), params)
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'No draft workflow found' })
+    expect(findFirst).not.toHaveBeenCalled()
+  })
+})
+
+describe('the PUBLISHED path is unaffected — with and without a window', () => {
+  it('executes the published graph with no window armed', async () => {
+    const res = await POST(postRequest(false), params)
+    expect(res.status).toBe(200)
+    await expect(res.text()).resolves.toBe('PUBLISHED-BODY')
+    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+  })
+
+  it('behaves identically while a window IS armed', async () => {
+    arm()
+    const res = await POST(postRequest(false), params)
+    expect(res.status).toBe(200)
+    await expect(res.text()).resolves.toBe('PUBLISHED-BODY')
+    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+  })
+
+  it('never consults the arm key when there is no `test` param', async () => {
+    // The gate must cost the production path nothing — not even a round trip.
+    arm()
+    await POST(postRequest(false), params)
+    expect(redis.exists).not.toHaveBeenCalled()
+  })
+
+  it('a missing published workflow still says so (its own 404 shape is untouched)', async () => {
+    findFirst.mockResolvedValue({ ...workflowApp, publishedWorkflow: null })
+    const res = await POST(postRequest(false), params)
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'No published workflow found' })
+  })
+
+  it('an unknown workflow app still 404s with its own shape on the production path', async () => {
+    findFirst.mockResolvedValue(undefined)
+    const res = await POST(postRequest(false), params)
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'Workflow app not found' })
+  })
+})
+
+describe('an unavailable Redis fails CLOSED', () => {
+  it('refuses the draft path rather than reinstating the hole', async () => {
+    redis.available = false
+    const res = await POST(postRequest(true), params)
+    expect(res.status).toBe(404)
+    expect(findFirst).not.toHaveBeenCalled()
+  })
+
+  it('still serves the production path', async () => {
+    // Failing closed must not take the real webhook surface down with it.
+    redis.available = false
+    const res = await POST(postRequest(false), params)
+    expect(res.status).toBe(200)
+    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/components/workflow/nodes/core/webhook/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/webhook/panel.tsx
@@ -17,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
-import { toastSuccess } from '@auxx/ui/components/toast'
+import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { produce } from 'immer'
 import { Copy, FileJson, Trash2 } from 'lucide-react'
@@ -29,6 +29,7 @@ import { useWorkflowStore } from '~/components/workflow/store/workflow-store'
 import type { SchemaRoot } from '~/components/workflow/ui/json-schema-types'
 import { OutputVariablesDisplay } from '~/components/workflow/ui/output-variables'
 import Section from '~/components/workflow/ui/section'
+import { api } from '~/trpc/react'
 import { webhookDefinition } from './schema'
 import type { WebhookNodeData } from './types'
 import { WebhookTestEvents } from './webhook-test-events'
@@ -56,6 +57,23 @@ const WebhookPanelComponent: React.FC<WebhookPanelProps> = ({ nodeId, data }) =>
   // Use webhook test listener hook
   const { events, isListening, connectionStatus, startListening, stopListening, clearEvents } =
     useWebhookTestListener(workflowId)
+
+  // The `?test=true` webhook endpoint is anonymous, so it only resolves the
+  // DRAFT graph while this window is open. Arming is gated on instance `edit`
+  // server-side and expires with the captured-event list.
+  const armWebhookTest = api.workflow.armWebhookTest.useMutation()
+
+  const handleStartListening = async () => {
+    try {
+      await armWebhookTest.mutateAsync({ workflowId })
+      startListening()
+    } catch (error) {
+      toastError({
+        title: 'Could not start webhook test',
+        description: error instanceof Error ? error.message : 'Failed to open the test window',
+      })
+    }
+  }
 
   // Generate webhook URLs
   const baseWebhookUrl = `${window.location.origin}/api/workflows/${workflowId}/webhook`
@@ -190,10 +208,10 @@ const WebhookPanelComponent: React.FC<WebhookPanelProps> = ({ nodeId, data }) =>
                   isListening &&
                     'bg-bad-200 hover:bg-bad-200 text-bad-500 hover:text-bad-500 border-bad-300'
                 )}
-                loading={isListening}
-                loadingText='Listening...'
-                disabled={isReadOnly}
-                onClick={() => (isListening ? stopListening() : startListening())}>
+                loading={isListening || armWebhookTest.isPending}
+                loadingText={armWebhookTest.isPending ? 'Starting...' : 'Listening...'}
+                disabled={isReadOnly || armWebhookTest.isPending}
+                onClick={() => (isListening ? stopListening() : handleStartListening())}>
                 {isListening ? 'Stop Listening' : 'Test Webhook'}
               </Button>
             )}

--- a/apps/web/src/lib/sse/create-sse-poll-route.ts
+++ b/apps/web/src/lib/sse/create-sse-poll-route.ts
@@ -13,9 +13,13 @@ interface SsePollRouteOptions {
    * Optional authorization check. Receives session + route params.
    * Return true to allow, false to reject with 403.
    * If omitted, only session presence is checked.
+   *
+   * `user.id` is exposed so a callback can resolve the caller's
+   * `CapabilitySet` — org membership alone is not an authorization answer for
+   * a resource carrying per-instance access (plan 30 / plan 32).
    */
   authorize?: (
-    session: { user: { defaultOrganizationId: string } },
+    session: { user: { id: string; defaultOrganizationId: string } },
     params: Record<string, string>,
     db: typeof database
   ) => Promise<boolean>

--- a/apps/web/src/server/api/routers/workflow-arm-webhook-test.test.ts
+++ b/apps/web/src/server/api/routers/workflow-arm-webhook-test.test.ts
@@ -1,0 +1,285 @@
+// apps/web/src/server/api/routers/workflow-arm-webhook-test.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `workflow.armWebhookTest` — the authenticated half of the webhook draft-test
+ * pair.
+ *
+ * Arming opens a TTL'd window during which the ANONYMOUS
+ * `/api/workflows/<id>/webhook?test=true` route will resolve and answer from the
+ * org's unpublished draft graph. That is a delegation of authoring authority to
+ * an unauthenticated caller, so it sits at instance `edit` — the same tier as
+ * `workflow.test` and the SSE `/api/workflows/[workflowId]/run` route, and NOT
+ * the `view` tier that merely "may run it".
+ *
+ * Behavioural: the real router is driven through a tRPC caller with a REAL
+ * `CapabilitySet`, and the real `armWebhookTestWindow` runs against a fake
+ * Redis. The written key is the observed side effect.
+ */
+
+const { redis, getRedisClient, workflowService, guards, featureService, appRows } = vi.hoisted(
+  () => {
+    const store = new Map<string, string>()
+    const client = {
+      store,
+      set: vi.fn(async (key: string, value: string, ..._args: unknown[]) => {
+        store.set(key, value)
+        return 'OK'
+      }),
+      exists: vi.fn(async (key: string) => (store.has(key) ? 1 : 0)),
+    }
+    return {
+      redis: client,
+      getRedisClient: vi.fn(async () => client),
+      /** Rows `db.select()...limit(1)` hands back — empty models "not in this org". */
+      appRows: { value: [{ id: 'wf_cuid0000000000000000000' }] as { id: string }[] },
+      workflowService: { test: vi.fn(async () => ({ success: true })) },
+      guards: { app: vi.fn(async () => undefined) },
+      featureService: { requireAccess: vi.fn(async () => undefined) },
+    }
+  }
+)
+
+vi.mock('@auxx/redis', () => ({ getRedisClient }))
+
+// Real drizzle columns come back undefined under vitest, and `eq()` on them is
+// not worth the setup — the router's org predicate is exercised through the
+// rows the fake query builder returns, not through generated SQL.
+vi.mock('@auxx/database', () => ({
+  schema: {
+    WorkflowApp: { id: 'WorkflowApp.id', organizationId: 'WorkflowApp.organizationId' },
+  },
+}))
+
+vi.mock('@auxx/lib/workflows', () => ({
+  WorkflowService: class {
+    test = workflowService.test
+  },
+  WorkflowVersionService: class {},
+  WorkflowStatsService: class {},
+  WorkflowExecutionService: class {},
+  assertWorkflowAppNotSystemOwned: guards.app,
+  assertWorkflowRunNotSystemOwned: vi.fn(async () => 'wf_cuid0000000000000000000'),
+  getWorkflowRunCreatorId: vi.fn(async () => null),
+  buildTemplateWorkflowData: vi.fn(async () => ({})),
+  toWorkflowAppResponse: (app: unknown) => app,
+  WORKFLOW_TRIGGER_TYPE_VALUES: ['manual', 'form', 'scheduled'] as const,
+  checkEntityReadiness: vi.fn(async () => ({ ready: true })),
+  listFileTemplates: vi.fn(() => []),
+}))
+
+vi.mock('@auxx/lib/workflow-engine', () => ({
+  triggerManualResourceWorkflow: vi.fn(),
+  triggerManualResourceWorkflowBulk: vi.fn(),
+}))
+
+vi.mock('@auxx/services/workflows', () => ({ getWorkflowAppsByTrigger: vi.fn(async () => []) }))
+vi.mock('@auxx/services/workflow-templates', () => ({
+  getAllTemplates: vi.fn(async () => ({ isErr: () => false, value: [] })),
+  getTemplateById: vi.fn(async () => ({ isErr: () => false, value: null })),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedWorkflowAppCount: vi.fn(async () => 0),
+  getAppCache: () => ({ getOrRecompute: vi.fn(async () => ({})) }),
+}))
+
+vi.mock('@auxx/lib/demo', () => ({ DemoGuard: { requireNotDemo: vi.fn(async () => undefined) } }))
+vi.mock('~/server/api/audit-context', () => ({ recordAuditFromCtx: vi.fn(async () => undefined) }))
+vi.mock('~/server/api/workflow-template-resolver', () => ({
+  resolveTemplateById: vi.fn(async () => null),
+}))
+
+// The `@auxx/lib/permissions` barrel reaches redis/db at import time and hangs
+// under vitest — see `dataset-instance-access.test.ts`. Real registry, stub
+// feature service.
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+      requireLimit = featureService.requireAccess
+    },
+  }
+})
+
+/** Mirrors the real `permissionProcedure` gate — a plain `capabilities.assert(key)`. */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
+        return next()
+      }),
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  }
+})
+
+// Deep path on purpose — the permissions barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { webhookTestArmKey, WEBHOOK_TEST_WINDOW_TTL_SECONDS } = await import(
+  '~/server/lib/webhook-test-window'
+)
+const { workflowRouter } = await import('./workflow')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const WF_ID = 'wf_cuid0000000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+function capabilitiesFor(
+  permission: ResourcePermission,
+  opts: { instances?: Record<string, ResourcePermission>; areaPermission?: ResourcePermission } = {}
+) {
+  const instances = opts.instances ?? { [WF_ID]: permission }
+  const derived = Object.values(instances).some((p) => p !== ResourcePermission.none)
+    ? [PermissionKey.workflowsView]
+    : []
+  return new CapabilitySet(
+    new Set(
+      expandLevelsToKeys({ [Area.workflows]: AREA_LEVEL_OF[opts.areaPermission ?? permission] })
+    ),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived)
+  )
+}
+
+/** `db.select().from().where().limit()` — resolves to {@link appRows}. */
+function fakeDb() {
+  const chain: Record<string, unknown> = {}
+  chain.select = () => chain
+  chain.from = () => chain
+  chain.where = () => chain
+  chain.limit = async () => appRows.value
+  return chain
+}
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return workflowRouter.createCaller({
+    db: fakeDb(),
+    capabilities,
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      isSuperAdmin: false,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, email: 'a@b.c', name: 'A' },
+    },
+  } as never)
+}
+
+beforeEach(() => {
+  redis.store.clear()
+  redis.set.mockClear()
+  guards.app.mockClear().mockResolvedValue(undefined)
+  appRows.value = [{ id: WF_ID }]
+})
+
+describe('workflow.armWebhookTest — instance `edit`', () => {
+  it('arms the window for an instance `edit` holder', async () => {
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit)).armWebhookTest({ workflowId: WF_ID })
+    ).resolves.toEqual({ expiresInSeconds: WEBHOOK_TEST_WINDOW_TTL_SECONDS })
+    expect(redis.store.get(webhookTestArmKey(WF_ID))).toBe('1')
+  })
+
+  it('refuses an instance `view` holder — `view` may RUN it, not open it up', async () => {
+    // The tier claim under test: `view` is enough to trigger a workflow (plan 30
+    // §2), but arming hands draft execution to anonymous callers, so it tracks
+    // `workflow.test` at `edit`.
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view)).armWebhookTest({ workflowId: WF_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(redis.set).not.toHaveBeenCalled()
+  })
+
+  it('refuses a member restricted from the workflow entirely', async () => {
+    await expect(
+      caller(
+        capabilitiesFor(ResourcePermission.none, {
+          areaPermission: ResourcePermission.admin,
+          instances: { [WF_ID]: ResourcePermission.none },
+        })
+      ).armWebhookTest({ workflowId: WF_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(redis.set).not.toHaveBeenCalled()
+  })
+
+  it('writes the arm key at the SHARED TTL, so it cannot drift from the event list', async () => {
+    await caller(capabilitiesFor(ResourcePermission.edit)).armWebhookTest({ workflowId: WF_ID })
+    expect(redis.set).toHaveBeenCalledWith(
+      webhookTestArmKey(WF_ID),
+      '1',
+      'EX',
+      WEBHOOK_TEST_WINDOW_TTL_SECONDS
+    )
+  })
+
+  it('404s a workflow outside the caller’s org before arming', async () => {
+    // `workflow` is `baselineAtCreate: false`, so a row-less (foreign) id falls
+    // back to the caller's AREA level and would otherwise sail through the
+    // instance assert — letting a member open a draft window on another org's
+    // workflow.
+    appRows.value = []
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin, { instances: {} })).armWebhookTest({
+        workflowId: 'wf_someotherorg000000000',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(redis.set).not.toHaveBeenCalled()
+  })
+
+  it('refuses a system-owned workflow', async () => {
+    const { ForbiddenError } = await import('@auxx/lib/errors')
+    guards.app.mockRejectedValueOnce(new ForbiddenError('system-owned'))
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.admin)).armWebhookTest({ workflowId: WF_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(redis.set).not.toHaveBeenCalled()
+  })
+
+  it('a row-less workflow still needs the AREA at Edit', async () => {
+    // No `ResourceAccess` row anywhere: the area level decides. Read is not enough.
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.view, { instances: {} })).armWebhookTest({
+        workflowId: WF_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    await expect(
+      caller(capabilitiesFor(ResourcePermission.edit, { instances: {} })).armWebhookTest({
+        workflowId: WF_ID,
+      })
+    ).resolves.toBeDefined()
+  })
+})

--- a/apps/web/src/server/api/routers/workflow.ts
+++ b/apps/web/src/server/api/routers/workflow.ts
@@ -37,6 +37,10 @@ import {
   permissionProcedure,
 } from '~/server/api/trpc'
 import { resolveTemplateById } from '~/server/api/workflow-template-resolver'
+import {
+  armWebhookTestWindow,
+  WEBHOOK_TEST_WINDOW_TTL_SECONDS,
+} from '~/server/lib/webhook-test-window'
 import { mayStopWorkflowRun } from '~/server/lib/workflow-run-stop-access'
 import { workflowTemplatesRouter } from './workflow-templates'
 
@@ -540,6 +544,50 @@ export const workflowRouter = createTRPCRouter({
         }
         throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to test workflow' })
       }
+    }),
+  /**
+   * Open a TTL'd listening window so `POST /api/workflows/<id>/webhook?test=true`
+   * will resolve the DRAFT graph — answering from the draft webhook node's
+   * configured response and appending the request to the author's captured-event
+   * log.
+   *
+   * That route is anonymous by design (external callers have no session), so
+   * without a window anyone holding a workflow id could read an org's
+   * unpublished response config out of it and inject arbitrary headers, query and
+   * body into the log the editor renders. Arming is the authenticated half of
+   * the pair.
+   */
+  armWebhookTest: permissionProcedure(PermissionKey.workflowsView)
+    .input(z.object({ workflowId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      // Write — arming delegates draft execution to an unauthenticated caller
+      // for the next TTL, so it carries the same authority as running the draft
+      // yourself: instance `edit`, matching `workflow.test` and the SSE
+      // `/api/workflows/[workflowId]/run` route.
+      ctx.capabilities.assertEditInstance('workflow', input.workflowId)
+      // Instance access alone does NOT prove the workflow is ours: `workflow` is
+      // `baselineAtCreate: false`, so a row-less (i.e. foreign) id falls back to
+      // the caller's AREA level and would sail through. Pin it to the org.
+      const [workflowApp] = await ctx.db
+        .select({ id: schema.WorkflowApp.id })
+        .from(schema.WorkflowApp)
+        .where(
+          and(
+            eq(schema.WorkflowApp.id, input.workflowId),
+            eq(schema.WorkflowApp.organizationId, ctx.session.organizationId)
+          )
+        )
+        .limit(1)
+      if (!workflowApp) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Workflow not found' })
+      }
+      await assertWorkflowAppNotSystemOwned(ctx.db, {
+        workflowAppId: input.workflowId,
+        organizationId: ctx.session.organizationId,
+        isSuperAdmin: ctx.session.isSuperAdmin,
+      })
+      await armWebhookTestWindow(input.workflowId)
+      return { expiresInSeconds: WEBHOOK_TEST_WINDOW_TTL_SECONDS }
     }),
   /**
    * Get workflow execution statistics

--- a/apps/web/src/server/lib/webhook-test-window.ts
+++ b/apps/web/src/server/lib/webhook-test-window.ts
@@ -1,0 +1,58 @@
+// apps/web/src/server/lib/webhook-test-window.ts
+
+import { getRedisClient } from '@auxx/redis'
+
+/**
+ * Lifetime of a webhook draft-test session, in seconds.
+ *
+ * Deliberately ONE constant for two things that must agree: the captured-event
+ * list (`webhook:test:<id>:events`, which the route re-expires on every write)
+ * and the arm window below. A window that outlived the event list would accept
+ * draft executions nobody is watching; a shorter one would stop accepting while
+ * the editor still shows a live list.
+ */
+export const WEBHOOK_TEST_WINDOW_TTL_SECONDS = 300
+
+/** Redis list of captured test events — read by the editor's SSE poll route. */
+export const webhookTestEventsKey = (workflowId: string) => `webhook:test:${workflowId}:events`
+
+/** Redis flag that a listening window is currently open for this workflow. */
+export const webhookTestArmKey = (workflowId: string) => `webhook:test:${workflowId}:armed`
+
+/**
+ * Open a draft-test listening window for `workflowId`.
+ *
+ * Callers MUST have already asserted instance `edit` on the workflow — arming
+ * is what makes the otherwise-anonymous `POST /api/workflows/<id>/webhook?test=true`
+ * execute the org's unpublished graph, so it carries the same authority as
+ * running the draft yourself.
+ *
+ * Uses the *required* Redis client on purpose: if Redis is down, arming must
+ * fail loudly rather than hand the user a button that appears to work while
+ * {@link isWebhookTestWindowArmed} keeps answering `false`.
+ */
+export async function armWebhookTestWindow(workflowId: string): Promise<void> {
+  const redis = await getRedisClient(true)
+  await redis?.set(webhookTestArmKey(workflowId), '1', 'EX', WEBHOOK_TEST_WINDOW_TTL_SECONDS)
+}
+
+/**
+ * Is a draft-test listening window currently open for `workflowId`?
+ *
+ * **Fails CLOSED.** An unreachable Redis answers `false`, so `?test=true` falls
+ * back to behaving as if no draft test path existed. Failing open would restore
+ * the exact hole this gate closes — anonymous execution of an org's unpublished
+ * graph — under a condition (Redis unavailable) that is neither rare nor
+ * something a caller has to be trusted to avoid. Nothing of value is lost by
+ * closing: the whole test surface is Redis-backed, so with Redis down the
+ * captured events could not be stored or streamed to the editor anyway.
+ */
+export async function isWebhookTestWindowArmed(workflowId: string): Promise<boolean> {
+  try {
+    const redis = await getRedisClient(false)
+    if (!redis) return false
+    return (await redis.exists(webhookTestArmKey(workflowId))) > 0
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Both halves of the webhook **test** surface were reachable without the access the editor UI already requires for it. The **published** webhook path is untouched and stays credential-free — URL secrecy is the normal webhook model, and external callers legitimately have no session.

## Ingress: anonymous access to the draft

`api/workflows/[workflowId]/webhook/route.ts` had no `secret`, `token`, `signature`, `auth` or `session` anywhere in its 294 lines. `?test=true` resolved the **draft** workflow instead of the published one, so anyone holding a workflow id could:

- make the endpoint answer with an **unpublished** node's configured response body and status
- validate payloads against the draft's body schema
- write attacker-controlled headers, query and body into the author's `webhook:test:<id>:events` log, which the editor renders

**It does not execute the draft graph** — the test branch returns before `executeWorkflow`. So this is an unreviewed-config leak plus log poisoning, not remote execution. (An earlier reading of this as draft execution was wrong.)

The draft path now requires an **armed listening window**. The editor's existing "Test Webhook" button arms it via a new `workflow.armWebhookTest` mutation gated on instance `edit`; the TTL is shared with the event list so the two windows can't disagree. Unarmed, the route returns the same 404 it already returns for a missing draft, so it doesn't become an oracle for "this id exists".

The arm check is deliberately **fail-closed** when Redis is unavailable. Failing open would reinstate the hole under a condition that is neither rare nor caller-controlled, and nothing is lost — the whole test surface is Redis-backed, so with Redis down the events couldn't be captured or streamed anyway.

> Known limitation, not fixed here: the window is a fixed TTL while the listening session is open-ended, so a session left open past it stops accepting draft requests with the button still reading "Listening...". A periodic re-arm in `panel.tsx` is the one-line follow-up if that proves annoying.

## Egress: any org member could read the captured payloads

`webhook/events/route.ts` replays those captured payloads — real external callers' headers and bodies — and authorized on **org membership alone**. Since plan 30 shipped per-workflow instance access, that is the wrong bar: a member restricted from the workflow, or composing `workflows: None`, could read them. It now resolves a `CapabilitySet` and requires instance `edit`.

## A gap neither half started with

Both now pin `WorkflowApp.id + organizationId` and refuse system-owned rows. `workflow` is `baselineAtCreate: false`, so a **foreign** workflow id has no `ResourceAccess` row and falls back to the caller's own area level — an org-Edit member could otherwise have armed a window on another org's workflow.

## Why `edit` and not `view`

The three read-only SSE routes gated in #1349 all chose `view`, but each mirrored an existing tRPC **read** procedure sitting at `view`. This has none. Its only sibling is the test flow, which plan 30 §4 puts at Edit, and `panel.tsx` already gates the button on `isReadOnly` — so `view` on the server would be **looser than the UI it serves**. The arm and read halves were built independently and landed on the identical triple (`assertEditInstance` + org pin + system-owned guard).

## Tests

**44 new tests** across three files, all behavioural — real handler, real router via a tRPC caller, real `CapabilitySet`, real arm/read helpers, fake Redis:

- `webhook-draft-test-window.test.ts` (15) — armed vs unarmed, the non-oracle 404, the published path unaffected either way, expired window, and that a request with no `test` param never consults the arm key
- `workflow-arm-webhook-test.test.ts` (7) — tier, cross-org, system-owned
- `webhook-events-instance-access.test.ts` (11) — `None` area, explicit `none` under area `Full`, `view` denied, `edit`/`admin` stream, the row-less `baselineAtCreate: false` fallback at area Edit vs Read

**15 mutations verified, all caught**, each against an unmutated control — including a comment-only negative control to prove the harness doesn't fire on noise. Notable: moving the gate *below* the workflow lookup fails the no-oracle case, and making Redis fail *open* fails its own test.

`createSsePollRoute` already maps a falsy `authorize` to a flat **403** with no 404 path, so foreign-org, nonexistent, system-owned and restricted all collapse to one status — stricter-than-required indistinguishability. No `AuxxError → status` mapping was needed.

## Verification

- The three suites plus `workflow-instance-access` and `run-instance-access`: **135/135 pass**
- `apps/web` tsc: zero hits for the changed files. The SSE type widening also *removed* a pre-existing `noUncheckedIndexedAccess` error in the events route.
- Biome clean.

## Follow-ups found, not fixed

Two sibling `createSsePollRoute` consumers have the same org-membership-only `authorize`, and neither is the same class:

- `app-triggers/[installationId]/[triggerId]/events` — keys on `AppInstallation`, not an instance-access resource, so any fix is a coarse key. Plan 32 cleared its `/test` producer but **never triaged this consumer**.
- `webhook-endpoints/[endpointId]/events` — keys on `WebhookEndpoint`, also not instance-access, and its tRPC read siblings are bare `protectedProcedure`. The route is exactly as strict as its siblings, so that's a question about the procedures, not a route bug.