### PR TITLE
fix(approvals): load pending approvals, and render form-input variables in the message

### DIFF
--- a/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
+import { Button } from '@auxx/ui/components/button'
 import {
   Empty,
   EmptyDescription,
@@ -11,7 +12,7 @@ import {
 } from '@auxx/ui/components/empty'
 import InfiniteScroll from '@auxx/ui/components/infinite-scroll'
 import { cn } from '@auxx/ui/lib/utils'
-import { CircleCheck } from 'lucide-react'
+import { CircleCheck, TriangleAlert } from 'lucide-react'
 import type { RefObject } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
@@ -130,6 +131,35 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
         <NotificationRowSkeleton />
         <NotificationRowSkeleton />
       </>
+    )
+  }
+
+  // A failed query must not read as "no work to do". Both sources returning
+  // nothing looks identical to both sources erroring, and an approval inbox that
+  // quietly claims to be empty is worse than one that admits it is broken.
+  const loadError = confirmations.error ?? (suggestionsEnabled ? suggestions.error : null)
+  if (loadError && !confirmationItems.length && !suggestionItems.length) {
+    return (
+      <div className='flex flex-1 items-center justify-center'>
+        <Empty className='border-0'>
+          <EmptyHeader>
+            <EmptyMedia variant='icon'>
+              <TriangleAlert />
+            </EmptyMedia>
+            <EmptyTitle>Couldn't load approvals</EmptyTitle>
+            <EmptyDescription>{loadError.message}</EmptyDescription>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => {
+                void confirmations.refetch()
+                if (suggestionsEnabled) void suggestions.refetch()
+              }}>
+              Try again
+            </Button>
+          </EmptyHeader>
+        </Empty>
+      </div>
     )
   }
 

--- a/apps/web/src/server/api/routers/approval.ts
+++ b/apps/web/src/server/api/routers/approval.ts
@@ -29,8 +29,8 @@ export const approvalRouter = createTRPCRouter({
   getPendingRequests: protectedProcedure.query(async ({ ctx }) => {
     const queryService = new ApprovalQueryService(ctx.db)
     return await queryService.getPendingApprovalsForUser(
-      ctx.session.user.id,
-      ctx.session.user.organizationId
+      ctx.session.userId,
+      ctx.session.organizationId
     )
   }),
 
@@ -41,9 +41,12 @@ export const approvalRouter = createTRPCRouter({
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       const queryService = new ApprovalQueryService(ctx.db)
-      const canApprove = await queryService.canUserApprove(ctx.session.user.id, input.id)
+      // View, not approve: an approver may read a request they already decided or
+      // one that expired. Gating reads on `canUserApprove` 403s the moment the
+      // request goes terminal, which is exactly when you want to look at it.
+      const canView = await queryService.canUserViewApproval(ctx.session.userId, input.id)
 
-      if (!canApprove) {
+      if (!canView) {
         throw new TRPCError({
           code: 'FORBIDDEN',
           message: 'You are not authorized to view this approval request',
@@ -58,7 +61,7 @@ export const approvalRouter = createTRPCRouter({
    */
   getPendingCount: protectedProcedure.query(async ({ ctx }) => {
     const queryService = new ApprovalQueryService(ctx.db)
-    return await queryService.getPendingCount(ctx.session.user.id, ctx.session.user.organizationId)
+    return await queryService.getPendingCount(ctx.session.userId, ctx.session.organizationId)
   }),
 
   /**
@@ -76,7 +79,7 @@ export const approvalRouter = createTRPCRouter({
       const queryService = new ApprovalQueryService(ctx.db)
 
       // Verify user can approve this request
-      const canApprove = await queryService.canUserApprove(ctx.session.user.id, input.id)
+      const canApprove = await queryService.canUserApprove(ctx.session.userId, input.id)
 
       if (!canApprove) {
         throw new TRPCError({
@@ -87,7 +90,7 @@ export const approvalRouter = createTRPCRouter({
 
       return await responseService.processApprovalResponse(
         input.id,
-        ctx.session.user.id,
+        ctx.session.userId,
         'approve',
         input.comment
       )
@@ -108,7 +111,7 @@ export const approvalRouter = createTRPCRouter({
       const queryService = new ApprovalQueryService(ctx.db)
 
       // Verify user can deny this request
-      const canApprove = await queryService.canUserApprove(ctx.session.user.id, input.id)
+      const canApprove = await queryService.canUserApprove(ctx.session.userId, input.id)
 
       if (!canApprove) {
         throw new TRPCError({
@@ -119,7 +122,7 @@ export const approvalRouter = createTRPCRouter({
 
       return await responseService.processApprovalResponse(
         input.id,
-        ctx.session.user.id,
+        ctx.session.userId,
         'deny',
         input.comment
       )
@@ -132,7 +135,7 @@ export const approvalRouter = createTRPCRouter({
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       const queryService = new ApprovalQueryService(ctx.db)
-      return await queryService.canUserApprove(ctx.session.user.id, input.id)
+      return await queryService.canUserApprove(ctx.session.userId, input.id)
     }),
 
   /**
@@ -148,7 +151,7 @@ export const approvalRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const queryService = new ApprovalQueryService(ctx.db)
       return await queryService.getApprovalMetrics(
-        ctx.session.user.organizationId,
+        ctx.session.organizationId,
         input.startDate,
         input.endDate
       )

--- a/packages/lib/src/workflow-engine/nodes/form-input/form-input-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/form-input/form-input-processor.ts
@@ -16,7 +16,7 @@ const logger = createScopedLogger('form-input-processor')
 /**
  * Select option for ENUM type
  */
-interface EnumOption {
+export interface EnumOption {
   label: string
   value: string
 }
@@ -24,7 +24,7 @@ interface EnumOption {
 /**
  * File options for FILE type
  */
-interface FileTypeOptions {
+export interface FileTypeOptions {
   allowMultiple: boolean
   maxFiles?: number
   maxFileSize?: number
@@ -39,7 +39,7 @@ interface FileTypeOptions {
 /**
  * Currency options for CURRENCY type (flat — matches CurrencyFieldOptions)
  */
-interface CurrencyTypeOptions {
+export interface CurrencyTypeOptions {
   currencyCode: string
   decimals?: number
   useGrouping?: boolean
@@ -49,14 +49,14 @@ interface CurrencyTypeOptions {
 /**
  * Address options for ADDRESS type
  */
-interface AddressTypeOptions {
+export interface AddressTypeOptions {
   components: string[]
 }
 
 /**
  * Type-specific options union
  */
-interface TypeOptions {
+export interface TypeOptions {
   enum?: EnumOption[]
   file?: FileTypeOptions
   currency?: CurrencyTypeOptions
@@ -73,6 +73,33 @@ interface FormInputNodeConfig {
   required?: boolean
   defaultValue?: string | number | boolean | null
   typeOptions?: TypeOptions
+}
+
+/**
+ * Apply the output variables a form-input node declares — `value` (expanded per
+ * type), plus the common `label` / `inputType` / `isEmpty`.
+ *
+ * Lives at module scope with two callers on purpose. Form-input nodes wired into
+ * a trigger are NON_EXECUTABLE, so `FormInputNodeProcessor.execute` never runs for
+ * them and `ManualTriggerProcessor` has to publish the same contract. Two copies
+ * of this switch is how `{{node.value}}` silently resolved to empty.
+ */
+export function applyFormInputOutputVariables(params: {
+  nodeId: string
+  value: unknown
+  inputType: BaseType
+  typeOptions?: TypeOptions
+  /** Omitted when the caller cannot resolve it — better absent than wrong. */
+  label?: string
+  ctx: ExecutionContextManager
+}): void {
+  const { nodeId, value, inputType, typeOptions, label, ctx } = params
+
+  setTypedOutputVariables(nodeId, value, inputType, typeOptions, ctx)
+
+  if (label !== undefined) ctx.setNodeVariable(nodeId, 'label', label)
+  ctx.setNodeVariable(nodeId, 'inputType', inputType)
+  ctx.setNodeVariable(nodeId, 'isEmpty', value === undefined || value === null || value === '')
 }
 
 /**
@@ -156,13 +183,16 @@ export class FormInputNodeProcessor implements NodeProcessor {
       // Note: Required validation is now handled pre-execution at the API layer
       const isEmpty = value === undefined || value === null || value === ''
 
-      // 4. Set output variables based on type
-      this.setOutputVariables(nodeId, value, inputType, typeOptions, contextManager)
-
-      // 5. Set common outputs
-      contextManager.setNodeVariable(nodeId, 'label', label)
-      contextManager.setNodeVariable(nodeId, 'inputType', inputType)
-      contextManager.setNodeVariable(nodeId, 'isEmpty', isEmpty)
+      // 4/5. Set the declared output variables — same contract the manual trigger
+      // publishes for form-input nodes that never execute.
+      applyFormInputOutputVariables({
+        nodeId,
+        value,
+        inputType,
+        typeOptions,
+        label,
+        ctx: contextManager,
+      })
 
       logger.debug('Form-input node executed successfully', { nodeId, inputType, isEmpty })
 
@@ -205,139 +235,138 @@ export class FormInputNodeProcessor implements NodeProcessor {
 
     return { valid: errors.length === 0, errors, warnings }
   }
+}
 
-  /**
-   * Set output variables based on input type
-   */
-  private setOutputVariables(
-    nodeId: string,
-    value: unknown,
-    inputType: BaseType,
-    typeOptions: TypeOptions | undefined,
-    ctx: ExecutionContextManager
-  ): void {
-    switch (inputType) {
-      case BaseType.ADDRESS:
-        this.setAddressOutputs(nodeId, value, ctx)
-        break
+/**
+ * Set the type-specific `value` output(s) for a form-input node.
+ */
+function setTypedOutputVariables(
+  nodeId: string,
+  value: unknown,
+  inputType: BaseType,
+  typeOptions: TypeOptions | undefined,
+  ctx: ExecutionContextManager
+): void {
+  switch (inputType) {
+    case BaseType.ADDRESS:
+      setAddressOutputs(nodeId, value, ctx)
+      break
 
-      case BaseType.FILE:
-        this.setFileOutputs(nodeId, value, typeOptions?.file?.allowMultiple ?? false, ctx)
-        break
+    case BaseType.FILE:
+      setFileOutputs(nodeId, value, typeOptions?.file?.allowMultiple ?? false, ctx)
+      break
 
-      case BaseType.TAGS:
-        this.setArrayOutputs(nodeId, value, ctx)
-        break
+    case BaseType.TAGS:
+      setArrayOutputs(nodeId, value, ctx)
+      break
 
-      case BaseType.CURRENCY:
-        this.setCurrencyOutputs(nodeId, value, typeOptions?.currency?.currencyCode ?? 'USD', ctx)
-        break
+    case BaseType.CURRENCY:
+      setCurrencyOutputs(nodeId, value, typeOptions?.currency?.currencyCode ?? 'USD', ctx)
+      break
 
-      default:
-        // Simple types: STRING, NUMBER, BOOLEAN, EMAIL, URL, PHONE, DATE, DATETIME, TIME, ENUM
-        ctx.setNodeVariable(nodeId, 'value', value)
+    default:
+      // Simple types: STRING, NUMBER, BOOLEAN, EMAIL, URL, PHONE, DATE, DATETIME, TIME, ENUM
+      ctx.setNodeVariable(nodeId, 'value', value)
+  }
+}
+
+/**
+ * Set ADDRESS type outputs (nested structure)
+ */
+function setAddressOutputs(nodeId: string, value: unknown, ctx: ExecutionContextManager): void {
+  const addr = typeof value === 'object' && value !== null ? (value as Record<string, string>) : {}
+
+  ctx.setNodeVariable(nodeId, 'value', addr)
+  ctx.setNodeVariable(nodeId, 'value.street1', addr.street1 || '')
+  ctx.setNodeVariable(nodeId, 'value.street2', addr.street2 || '')
+  ctx.setNodeVariable(nodeId, 'value.city', addr.city || '')
+  ctx.setNodeVariable(nodeId, 'value.state', addr.state || '')
+  ctx.setNodeVariable(nodeId, 'value.zipCode', addr.zipCode || '')
+  ctx.setNodeVariable(nodeId, 'value.country', addr.country || '')
+}
+
+/**
+ * Set FILE type outputs
+ * NOTE: ManualTriggerProcessor already structures file data
+ */
+function setFileOutputs(
+  nodeId: string,
+  value: unknown,
+  allowMultiple: boolean,
+  ctx: ExecutionContextManager
+): void {
+  interface FileData {
+    id?: string
+    fileId?: string
+    filename?: string
+    size?: number
+    mimeType?: string
+    url?: string
+  }
+
+  if (allowMultiple) {
+    const files = Array.isArray(value)
+      ? (value as FileData[])
+      : (value as { files?: FileData[] })?.files || []
+    ctx.setNodeVariable(nodeId, 'files', files)
+    ctx.setNodeVariable(nodeId, 'files.count', files.length)
+    ctx.setNodeVariable(
+      nodeId,
+      'files.totalSize',
+      files.reduce((sum: number, f: FileData) => sum + (f.size || 0), 0)
+    )
+  } else {
+    const file = Array.isArray(value)
+      ? (value as FileData[])[0]
+      : (value as { file?: FileData })?.file || (value as FileData)
+    ctx.setNodeVariable(nodeId, 'file', file || null)
+    if (file) {
+      ctx.setNodeVariable(nodeId, 'file.id', file.id || file.fileId || '')
+      ctx.setNodeVariable(nodeId, 'file.filename', file.filename || '')
+      ctx.setNodeVariable(nodeId, 'file.size', file.size || 0)
+      ctx.setNodeVariable(nodeId, 'file.mimeType', file.mimeType || '')
+      ctx.setNodeVariable(nodeId, 'file.url', file.url || '')
     }
   }
+}
 
-  /**
-   * Set ADDRESS type outputs (nested structure)
-   */
-  private setAddressOutputs(nodeId: string, value: unknown, ctx: ExecutionContextManager): void {
-    const addr =
-      typeof value === 'object' && value !== null ? (value as Record<string, string>) : {}
+/**
+ * Set TAGS/array type outputs
+ */
+function setArrayOutputs(nodeId: string, value: unknown, ctx: ExecutionContextManager): void {
+  const values = Array.isArray(value) ? value : []
+  ctx.setNodeVariable(nodeId, 'values', values)
+  ctx.setNodeVariable(nodeId, 'count', values.length)
+}
 
-    ctx.setNodeVariable(nodeId, 'value', addr)
-    ctx.setNodeVariable(nodeId, 'value.street1', addr.street1 || '')
-    ctx.setNodeVariable(nodeId, 'value.street2', addr.street2 || '')
-    ctx.setNodeVariable(nodeId, 'value.city', addr.city || '')
-    ctx.setNodeVariable(nodeId, 'value.state', addr.state || '')
-    ctx.setNodeVariable(nodeId, 'value.zipCode', addr.zipCode || '')
-    ctx.setNodeVariable(nodeId, 'value.country', addr.country || '')
+/**
+ * Set CURRENCY type outputs
+ */
+function setCurrencyOutputs(
+  nodeId: string,
+  value: unknown,
+  currencyCode: string,
+  ctx: ExecutionContextManager
+): void {
+  let amount: number
+  let currency: string
+
+  if (typeof value === 'object' && value !== null) {
+    const currencyValue = value as { amount?: number; currency?: string }
+    amount = currencyValue.amount || 0
+    currency = currencyValue.currency || currencyCode
+  } else {
+    amount = typeof value === 'number' ? value : parseFloat(String(value)) || 0
+    currency = currencyCode
   }
 
-  /**
-   * Set FILE type outputs
-   * NOTE: ManualTriggerProcessor already structures file data
-   */
-  private setFileOutputs(
-    nodeId: string,
-    value: unknown,
-    allowMultiple: boolean,
-    ctx: ExecutionContextManager
-  ): void {
-    interface FileData {
-      id?: string
-      fileId?: string
-      filename?: string
-      size?: number
-      mimeType?: string
-      url?: string
-    }
+  const formatted = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(amount)
 
-    if (allowMultiple) {
-      const files = Array.isArray(value)
-        ? (value as FileData[])
-        : (value as { files?: FileData[] })?.files || []
-      ctx.setNodeVariable(nodeId, 'files', files)
-      ctx.setNodeVariable(nodeId, 'files.count', files.length)
-      ctx.setNodeVariable(
-        nodeId,
-        'files.totalSize',
-        files.reduce((sum: number, f: FileData) => sum + (f.size || 0), 0)
-      )
-    } else {
-      const file = Array.isArray(value)
-        ? (value as FileData[])[0]
-        : (value as { file?: FileData })?.file || (value as FileData)
-      ctx.setNodeVariable(nodeId, 'file', file || null)
-      if (file) {
-        ctx.setNodeVariable(nodeId, 'file.id', file.id || file.fileId || '')
-        ctx.setNodeVariable(nodeId, 'file.filename', file.filename || '')
-        ctx.setNodeVariable(nodeId, 'file.size', file.size || 0)
-        ctx.setNodeVariable(nodeId, 'file.mimeType', file.mimeType || '')
-        ctx.setNodeVariable(nodeId, 'file.url', file.url || '')
-      }
-    }
-  }
-
-  /**
-   * Set TAGS/array type outputs
-   */
-  private setArrayOutputs(nodeId: string, value: unknown, ctx: ExecutionContextManager): void {
-    const values = Array.isArray(value) ? value : []
-    ctx.setNodeVariable(nodeId, 'values', values)
-    ctx.setNodeVariable(nodeId, 'count', values.length)
-  }
-
-  /**
-   * Set CURRENCY type outputs
-   */
-  private setCurrencyOutputs(
-    nodeId: string,
-    value: unknown,
-    currencyCode: string,
-    ctx: ExecutionContextManager
-  ): void {
-    let amount: number
-    let currency: string
-
-    if (typeof value === 'object' && value !== null) {
-      const currencyValue = value as { amount?: number; currency?: string }
-      amount = currencyValue.amount || 0
-      currency = currencyValue.currency || currencyCode
-    } else {
-      amount = typeof value === 'number' ? value : parseFloat(String(value)) || 0
-      currency = currencyCode
-    }
-
-    const formatted = new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency,
-    }).format(amount)
-
-    ctx.setNodeVariable(nodeId, 'value', { amount, currency, formatted })
-    ctx.setNodeVariable(nodeId, 'value.amount', amount)
-    ctx.setNodeVariable(nodeId, 'value.currency', currency)
-    ctx.setNodeVariable(nodeId, 'value.formatted', formatted)
-  }
+  ctx.setNodeVariable(nodeId, 'value', { amount, currency, formatted })
+  ctx.setNodeVariable(nodeId, 'value.amount', amount)
+  ctx.setNodeVariable(nodeId, 'value.currency', currency)
+  ctx.setNodeVariable(nodeId, 'value.formatted', formatted)
 }

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/manual.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/manual.ts
@@ -3,9 +3,10 @@
 import { createScopedLogger } from '../../../logger'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
-import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
+import { BaseType, NodeRunningStatus, WorkflowNodeType } from '../../core/types'
 import type { WorkflowFileData } from '../../types/file-variable'
 import { BaseNodeProcessor } from '../base-node'
+import { applyFormInputOutputVariables, type TypeOptions } from '../form-input/form-input-processor'
 
 const logger = createScopedLogger('manual-trigger-processor')
 
@@ -77,11 +78,53 @@ export class ManualTriggerProcessor extends BaseNodeProcessor {
       if (files.length > 0) {
         this.setFileVariables(nodeId, files, contextManager)
       } else {
+        // The bare key stays for `{{nodeId}}` and back-compat...
         contextManager.setVariable(nodeId, value)
+        // ...but the picker emits `{{nodeId.value}}`, and nothing else publishes
+        // it: the form-input node is wired into this trigger, so it is
+        // NON_EXECUTABLE and its own processor never runs. Without this, every
+        // simple-type input interpolated to an empty string.
+        const config = await this.findFormInputConfig(nodeId, contextManager)
+        applyFormInputOutputVariables({
+          nodeId,
+          value,
+          inputType: config?.inputType ?? BaseType.STRING,
+          typeOptions: config?.typeOptions,
+          label: config?.label,
+          ctx: contextManager,
+        })
       }
     }
 
     contextManager.setVariable('manualInputs', triggerData)
+  }
+
+  /**
+   * Find the form-input node this trigger input came from, for its declared type.
+   *
+   * `triggerData` is keyed by form-input node id, but carries no type information.
+   * Returns null when the graph is unavailable or the id is not a form-input node,
+   * in which case the caller falls back to STRING — the default branch of the
+   * output contract, and the shape a bare scalar already has.
+   */
+  private async findFormInputConfig(
+    nodeId: string,
+    contextManager: ExecutionContextManager
+  ): Promise<{ inputType?: BaseType; typeOptions?: TypeOptions; label?: string } | null> {
+    const workflow = (await contextManager.getVariable('sys.workflow')) as
+      | { graph?: { nodes?: Array<Record<string, any>> } }
+      | undefined
+    const nodes = workflow?.graph?.nodes
+    if (!Array.isArray(nodes)) return null
+
+    const node = nodes.find((candidate) => (candidate?.nodeId ?? candidate?.id) === nodeId)
+    if (!node || node.type !== 'form-input') return null
+
+    return {
+      inputType: node.data?.inputType as BaseType | undefined,
+      typeOptions: node.data?.typeOptions as TypeOptions | undefined,
+      label: node.data?.label as string | undefined,
+    }
   }
 
   /**

--- a/packages/lib/src/workflow-engine/services/approval-query-service.ts
+++ b/packages/lib/src/workflow-engine/services/approval-query-service.ts
@@ -3,7 +3,21 @@ import { type Database, schema } from '@auxx/database'
 import { ApprovalStatus, MemberType } from '@auxx/database/enums'
 import type { ApprovalStatus as ApprovalStatusType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, count, desc, eq, gt, gte, inArray, lt, lte, or, sql } from 'drizzle-orm'
+import {
+  and,
+  arrayContains,
+  arrayOverlaps,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  lt,
+  lte,
+  or,
+  sql,
+} from 'drizzle-orm'
 import { getCachedUserGroupIds } from '../../cache'
 import { NotificationService } from '../../notifications/notification-service'
 
@@ -49,9 +63,12 @@ export class ApprovalQueryService {
           eq(schema.ApprovalRequest.status, 'pending' as any),
           gt(schema.ApprovalRequest.expiresAt, new Date()),
           or(
-            sql`${userId} = ANY(${schema.ApprovalRequest.assigneeUsers})`,
+            arrayContains(schema.ApprovalRequest.assigneeUsers, [userId]),
+            // arrayOverlaps, not a hand-written `&&`: the `sql` template flattens
+            // a JS array into one parameter per element, so Postgres received a
+            // bare string where it wanted an array literal and threw 22P02.
             userGroups.length > 0
-              ? sql`${schema.ApprovalRequest.assigneeGroups} && ${userGroups}`
+              ? arrayOverlaps(schema.ApprovalRequest.assigneeGroups, userGroups)
               : sql`false`
           ),
           inArray(schema.WorkflowRun.status, ['RUNNING', 'WAITING'])
@@ -75,28 +92,37 @@ export class ApprovalQueryService {
           eq(schema.ApprovalRequest.status, ApprovalStatus.pending),
           gt(schema.ApprovalRequest.expiresAt, new Date()),
           or(
-            sql`${userId} = ANY(${schema.ApprovalRequest.assigneeUsers})`,
+            arrayContains(schema.ApprovalRequest.assigneeUsers, [userId]),
+            // arrayOverlaps, not a hand-written `&&`: the `sql` template flattens
+            // a JS array into one parameter per element, so Postgres received a
+            // bare string where it wanted an array literal and threw 22P02.
             userGroups.length > 0
-              ? sql`${schema.ApprovalRequest.assigneeGroups} && ${userGroups}`
+              ? arrayOverlaps(schema.ApprovalRequest.assigneeGroups, userGroups)
               : sql`false`
           ),
           inArray(schema.WorkflowRun.status, ['RUNNING', 'WAITING'])
         )
       )
-    return count
+    // `count(*)` is int8, which pg hands back as a string. The caller adds this
+    // to the suggestion count for the tab badge, so leaving it would concatenate.
+    return Number(count ?? 0)
   }
   /**
-   * Check if a user can approve a specific request
+   * Check if a user is an approver on a request — an org member who is named
+   * directly or through one of their groups.
+   *
+   * This is the *audience* check, deliberately separate from {@link canUserApprove}:
+   * it says nothing about whether the request is still actionable. Reading a
+   * request you already decided, or one that expired, is legitimate; only acting
+   * on it is not.
    */
-  async canUserApprove(userId: string, approvalRequestId: string): Promise<boolean> {
+  async canUserViewApproval(userId: string, approvalRequestId: string): Promise<boolean> {
     const [request] = await this.db
       .select()
       .from(schema.ApprovalRequest)
       .where(eq(schema.ApprovalRequest.id, approvalRequestId))
       .limit(1)
-    if (!request || request.status !== 'pending' || request!.expiresAt < new Date()) {
-      return false
-    }
+    if (!request) return false
     // Check if user is a member of the organization
     const [userMembership] = await this.db
       .select()
@@ -114,6 +140,21 @@ export class ApprovalQueryService {
       request.assigneeUsers.includes(userId) ||
       request.assigneeGroups.some((groupId) => userGroupIds.includes(groupId))
     )
+  }
+  /**
+   * Check if a user can approve a specific request — an approver (see
+   * {@link canUserViewApproval}) on a request that is still pending and unexpired.
+   */
+  async canUserApprove(userId: string, approvalRequestId: string): Promise<boolean> {
+    const [request] = await this.db
+      .select()
+      .from(schema.ApprovalRequest)
+      .where(eq(schema.ApprovalRequest.id, approvalRequestId))
+      .limit(1)
+    if (!request || request.status !== 'pending') return false
+    // Nullable in the schema — a request with no expiry never expires.
+    if (request.expiresAt && request.expiresAt < new Date()) return false
+    return await this.canUserViewApproval(userId, approvalRequestId)
   }
   /**
    * Get approval request with full context including workflow run data


### PR DESCRIPTION
Four bugs found while testing the Approvals tab from #1372. **None were introduced by that PR** — three predate it entirely and the fourth was latent behind the first. The tab made them reachable for the first time.

Verified working against a live workflow run before opening this.

## 1. Wrong session property → the tab was always empty

`approval.ts` read `ctx.session.user.organizationId`. But `protectedProcedure` puts the org at `session.organizationId`, sourced from `user.defaultOrganizationId` (`trpc.ts:353`), and the `User` table has **no `organizationId` column at all**. So the value was `undefined`, Drizzle bound it as NULL, and `WHERE "organizationId" = NULL` matched nothing — silently, with no error.

Hit `getPendingRequests` (the section), `getPendingCount` (so the badge read 0 too) and `getMetrics`.

Invisible before because clicking a notification opened `getApprovalDetails(id)`, which is keyed by id and never filtered on org — the list query was never the path anyone used. The sibling `approvals.ts` router uses `session.userId` / `session.organizationId`; the two shapes coexisting in one file is what caused this, so `approval.ts` is normalised throughout.

## 2. Malformed array literal → 500

Fixing #1 meant `getCachedUserGroupIds` returned a real group, so the group branch finally executed — straight into `22P02: malformed array literal`. The predicate was hand-written:

```ts
sql`${assigneeGroups} && ${userGroups}`   // flattens the array into one param per element
```

Postgres received a bare string where it wanted `{...}`. Replaced with Drizzle's `arrayOverlaps` / `arrayContains`, which bind a single typed array parameter. Verified against the database — the corrected predicate returns the live pending request.

## 3. `getApprovalDetails` 403'd on any decided request

It gated reads on `canUserApprove`, which requires `status === 'pending'` — an *act* check used as a *view* check. Deciding a request locked you out of viewing it, and the standalone approval page's `"This request has already been {status}"` branch was dead code sitting behind the 403.

Split out `canUserViewApproval` (org member + named assignee, **any** status) for reads; the pending/expiry check stays on the mutations. Identical audience, so no gate is widened.

## 4. `{{form-input.value}}` rendered empty in approval messages

A human-in-the-loop message of `Do you like the name: {{form-input-id-x.value}} ?` arrived as `Do you like the name:  ?`.

A form-input node wired into a trigger is NON_EXECUTABLE — the run goes manual → human-confirmation and the form-input node never executes. But `FormInputNodeProcessor.execute` is the only code that calls `setNodeVariable(nodeId, 'value', …)`, so the context held only the raw scalar the trigger injected under the bare node id. `.value` on a string is `undefined`, and interpolation renders an unresolved reference as an empty string.

`ManualTriggerProcessor`'s own doc comment already claims this job — *"since form-input nodes are NON_EXECUTABLE, this processor is responsible for setting all output variables that the frontend declares in output-variables.ts"* — and it honoured it for **file** inputs only. Every simple type fell through to a bare `setVariable`.

The type switch is hoisted out of `FormInputNodeProcessor` into a shared `applyFormInputOutputVariables` called by both, rather than written a second time — two copies is how this drifted. The trigger resolves the declared type from `sys.workflow.graph.nodes`, falling back to `STRING`. The bare `{{nodeId}}` key is still set, so workflows referencing it keep working.

## Two latent bugs fixed in passing

- `canUserApprove` compared a **nullable** `expiresAt` with `<`, so `null` coerced to `0 < now` → a request configured with no expiry could never be approved.
- `getPendingCount` returned `count(*)` (int8) as a **string**, so the tab badge would have concatenated — `1 + 0` rendering as `"10"`.

## And one that was mine

`ApprovalsTab` rendered "Nothing needs your approval" whenever a query *errored*, since it only read `data ?? []`. A failed load was indistinguishable from an empty inbox, which is most of why this looked like a UI problem. It now shows a "Couldn't load approvals" state with the message and a retry.

## Verification

- Confirmed working end to end on a live run — the approval now loads and the message interpolates.
- `apps/web` typecheck: no errors in touched files. `approval.ts(11,3)` `maxTokens` is pre-existing (rate-limiter config, untouched).
- `packages/lib` typecheck: no new errors, and one pre-existing error removed by the `expiresAt` null guard.
- Biome clean.

Existing approval rows keep their empty message text — `message` is snapshotted at creation, so only new runs are affected.

## Worth doing separately

`interpolateVariables` renders an unresolved `{{…}}` as an empty string with no warning. That silence is why #4 shipped unnoticed; a `logger.warn` on unresolved references would make the next one obvious.