### PR TITLE
fix(files): gate attachment download and thumbnail on the owning record

### DIFF
--- a/apps/web/src/app/api/attachments/[attachmentId]/download/route.ts
+++ b/apps/web/src/app/api/attachments/[attachmentId]/download/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return new Response('Organization required', { status: 400 })
     }
 
-    // Message attachments are `full`-tier (mail-permissions §7).
+    // Resolves the attachment's owning record and applies that record's own gate.
     const { canViewAttachment } = await import('../../attachment-visibility')
     if (!(await canViewAttachment(attachmentId, session.user.id, organizationId))) {
       return new Response('Not found', { status: 404 })
@@ -36,12 +36,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // Use AttachmentService to get download ref (lazy import to avoid bundling sharp unnecessarily)
     const { AttachmentService } = await import('@auxx/lib/files/server')
     const attachmentService = new AttachmentService(organizationId, session.user.id)
-
-    // Check if attachment exists and user has access
-    const attachment = await attachmentService.get(attachmentId)
-    if (!attachment) {
-      return new Response('Not found', { status: 404 })
-    }
 
     // Get download reference (handles both files and assets)
     const downloadRef = await attachmentService.getDownloadRef(attachmentId)

--- a/apps/web/src/app/api/attachments/[attachmentId]/thumbnail/route.ts
+++ b/apps/web/src/app/api/attachments/[attachmentId]/thumbnail/route.ts
@@ -77,19 +77,9 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       })
     }
 
-    // Message attachments are `full`-tier (mail-permissions §7).
+    // Resolves the attachment's owning record and applies that record's own gate.
     const { canViewAttachment } = await import('../../attachment-visibility')
     if (!(await canViewAttachment(attachmentId, session.user.id, organizationId))) {
-      return new Response('Not found', { status: 404 })
-    }
-
-    // Use same service initialization as download route
-    const { AttachmentService } = await import('@auxx/lib/files/server')
-    const attachmentService = new AttachmentService(organizationId, session.user.id)
-
-    // Reuse same access check logic as download route
-    const attachment = await attachmentService.get(attachmentId)
-    if (!attachment) {
       return new Response('Not found', { status: 404 })
     }
 

--- a/apps/web/src/app/api/attachments/attachment-visibility.test.ts
+++ b/apps/web/src/app/api/attachments/attachment-visibility.test.ts
@@ -1,0 +1,546 @@
+// apps/web/src/app/api/attachments/attachment-visibility.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `canViewAttachment` — the gate behind `api/attachments/[attachmentId]/download`
+ * and `/thumbnail`, and the largest untested authorization predicate in the
+ * permissions plan.
+ *
+ * It used to be `if (attachment.entityType !== 'MESSAGE') return true`: every
+ * non-mail attachment in the org was readable by any authenticated member, and
+ * an unknown `entityType` (the column is free text) was readable too. It is now
+ * a fail-closed switch that resolves the owning parent row inside the caller's
+ * org and defers to that parent's own gate.
+ *
+ * Two invariants are what these tests exist to pin:
+ *  - **Fails closed** — unknown `entityType`, missing attachment, and a parent
+ *    that does not resolve *in this org* all return `false`.
+ *  - **Capability-first, DB-second** — each arm runs its free predicate before
+ *    issuing a parent lookup, and `getCapabilities` is lazy, so `MESSAGE` /
+ *    `CUSTOM_FIELD` / the unknown default never read capabilities at all.
+ *
+ * Behavioral: every check runs against a REAL `CapabilitySet`. Only the DB, the
+ * capability fetch, and the four collaborators the arms delegate to are stubbed.
+ * The observed side effect is the SECOND `database.select` — the parent lookup —
+ * so "no parent read happened" is an assertion, not an implementation detail.
+ */
+
+const {
+  select,
+  getCapabilities,
+  getCachedUserMailVisibility,
+  getThreadLens,
+  assertWorkflowRunNotSystemOwned,
+  loadOwnVisit,
+  and,
+  eq,
+} = vi.hoisted(() => ({
+  select: vi.fn(),
+  getCapabilities: vi.fn(),
+  getCachedUserMailVisibility: vi.fn(),
+  getThreadLens: vi.fn(),
+  assertWorkflowRunNotSystemOwned: vi.fn(),
+  loadOwnVisit: vi.fn(),
+  and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+  eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: { select },
+  schema: {
+    Attachment: {
+      id: 'Attachment.id',
+      entityType: 'Attachment.entityType',
+      entityId: 'Attachment.entityId',
+      createdById: 'Attachment.createdById',
+      organizationId: 'Attachment.organizationId',
+    },
+    Message: {
+      id: 'Message.id',
+      threadId: 'Message.threadId',
+      organizationId: 'Message.organizationId',
+    },
+    Comment: {
+      id: 'Comment.id',
+      entityDefinitionId: 'Comment.entityDefinitionId',
+      organizationId: 'Comment.organizationId',
+    },
+    FieldValue: {
+      id: 'FieldValue.id',
+      entityDefinitionId: 'FieldValue.entityDefinitionId',
+      organizationId: 'FieldValue.organizationId',
+    },
+    EntityInstance: {
+      id: 'EntityInstance.id',
+      entityDefinitionId: 'EntityInstance.entityDefinitionId',
+      organizationId: 'EntityInstance.organizationId',
+    },
+    Article: {
+      id: 'Article.id',
+      homeKnowledgeBaseId: 'Article.homeKnowledgeBaseId',
+      organizationId: 'Article.organizationId',
+    },
+    KnowledgeBase: { id: 'KnowledgeBase.id', organizationId: 'KnowledgeBase.organizationId' },
+    ChatWidget: { id: 'ChatWidget.id', organizationId: 'ChatWidget.organizationId' },
+    VisitQcItem: {
+      id: 'VisitQcItem.id',
+      visitId: 'VisitQcItem.visitId',
+      organizationId: 'VisitQcItem.organizationId',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({ and, eq }))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest (get-capabilities,
+// record-view-scope, overage-*) — stub it, but keep `PermissionKey` REAL via the
+// deep registry path, because the `visit_qc_item` arm reads a key off it.
+vi.mock('@auxx/lib/permissions', async () => {
+  const { PermissionKey } = await import('@auxx/lib/permissions/capabilities/registry')
+  return { PermissionKey, getCapabilities }
+})
+
+vi.mock('@auxx/lib/cache', () => ({ getCachedUserMailVisibility }))
+vi.mock('@auxx/lib/permissions/visibility', () => ({ getThreadLens }))
+// Both of these are `await import(...)`ed INSIDE their arm — `vi.mock`
+// intercepts dynamic imports the same as static ones.
+vi.mock('@auxx/lib/workflows', () => ({ assertWorkflowRunNotSystemOwned }))
+vi.mock('@auxx/lib/dispatch', () => ({ loadOwnVisit }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { canViewAttachment } = await import('./attachment-visibility')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+/** A second member of the SAME org — the `CUSTOM_FIELD` non-uploader. */
+const OTHER_USER_ID = 'usr_cuid111111111111111111111'
+const ATTACHMENT_ID = 'att_cuid000000000000000000000'
+
+const MESSAGE_ID = 'msg_cuid000000000000000000000'
+const THREAD_ID = 'thr_cuid000000000000000000000'
+const COMMENT_ID = 'cmt_cuid000000000000000000000'
+const FIELD_VALUE_ID = 'fvl_cuid000000000000000000000'
+const INSTANCE_ID = 'ins_cuid000000000000000000000'
+const ARTICLE_ID = 'art_cuid000000000000000000000'
+const KB_ID = 'kb_cuid0000000000000000000000'
+const WIDGET_ID = 'wgt_cuid000000000000000000000'
+const RUN_ID = 'run_cuid000000000000000000000'
+const WORKFLOW_APP_ID = 'wfa_cuid000000000000000000000'
+const QC_ITEM_ID = 'qci_cuid000000000000000000000'
+const VISIT_ID = 'vis_cuid000000000000000000000'
+/** The `entityDefinitionId` the COMMENT / FIELD_VALUE / TICKET arms gate on. */
+const DEF_ID = 'edf_cuid000000000000000000000'
+
+/**
+ * Rows handed to successive `.limit(1)` calls, IN ORDER. Most arms issue TWO
+ * selects (the attachment, then its parent) off the same `database.select`
+ * stub — a single `mockResolvedValue` would serve the attachment row twice and
+ * make every test pass for the wrong reason.
+ */
+let selectQueue: unknown[][] = []
+/** The `.from(table)` `id` sentinel of each select, in order — proves WHICH reads ran. */
+const fromTables: string[] = []
+
+/** Queue one result set per upcoming `database.select(...)` chain. */
+function queueRows(...rows: unknown[][]) {
+  selectQueue.push(...rows)
+}
+
+/** The `Attachment` projection row the first select always resolves. */
+function attachmentRow(entityType: string, entityId: string, createdById = OTHER_USER_ID) {
+  return [{ entityType, entityId, createdById }]
+}
+
+/**
+ * A real `CapabilitySet` composing `levels`, optionally with explicit
+ * instance-access rows. No shared factory exists in this repo — the sibling
+ * permission tests each hand-roll one, and this mirrors theirs.
+ */
+function capabilitiesWith(
+  levels: Partial<Record<Area, Level>>,
+  opts: {
+    role?: 'OWNER' | 'ADMIN' | 'USER'
+    instances?: Record<string, ResourcePermission>
+  } = {}
+) {
+  const instances = opts.instances ?? {}
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys(levels)),
+    {},
+    opts.role ?? 'USER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/** Make `getCapabilities` resolve a real `CapabilitySet` composing `levels`. */
+function memberHolding(
+  levels: Partial<Record<Area, Level>>,
+  opts: Parameters<typeof capabilitiesWith>[1] = {}
+) {
+  getCapabilities.mockResolvedValue(capabilitiesWith(levels, opts))
+}
+
+/** The call under test, always as {@link USER_ID} inside {@link ORG_ID}. */
+const canView = () => canViewAttachment(ATTACHMENT_ID, USER_ID, ORG_ID)
+
+beforeEach(() => {
+  selectQueue = []
+  fromTables.length = 0
+  eq.mockClear()
+  and.mockClear()
+  select.mockReset().mockImplementation(() => ({
+    from: (table: { id: string }) => {
+      fromTables.push(table.id)
+      return { where: () => ({ limit: async () => selectQueue.shift() ?? [] }) }
+    },
+  }))
+  // Default to a member with nothing — every grant test opts in explicitly.
+  getCapabilities.mockReset().mockResolvedValue(capabilitiesWith({}))
+  getCachedUserMailVisibility.mockReset().mockResolvedValue({ userId: USER_ID })
+  getThreadLens.mockReset().mockResolvedValue('none')
+  assertWorkflowRunNotSystemOwned.mockReset().mockResolvedValue(WORKFLOW_APP_ID)
+  loadOwnVisit.mockReset().mockResolvedValue({ id: VISIT_ID })
+})
+
+describe('canViewAttachment — the attachment row itself', () => {
+  it('denies an attachment id that does not resolve in this org', async () => {
+    // The read is org-scoped, so a foreign-org attachment id is absent here too.
+    // Invisible ≍ nonexistent keeps attachment ids unprobeable across orgs.
+    queueRows([])
+    await expect(canView()).resolves.toBe(false)
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('scopes the attachment lookup by organization', async () => {
+    queueRows(attachmentRow('CUSTOM_FIELD', 'field-logo', USER_ID))
+    await canView()
+    expect(eq).toHaveBeenCalledWith('Attachment.id', ATTACHMENT_ID)
+    expect(eq).toHaveBeenCalledWith('Attachment.organizationId', ORG_ID)
+  })
+
+  it('denies an unknown entityType — the fail-closed default', async () => {
+    // `Attachment.entityType` is a free-text column. Before the rewrite the
+    // predicate was `entityType !== 'MESSAGE' → true`, so any value a future
+    // writer invents shipped WORLD-READABLE inside the org. It must now ship
+    // denied until an arm is added for it.
+    queueRows(attachmentRow('SOMETHING_NEW', 'whatever-id'))
+    await expect(canView()).resolves.toBe(false)
+    // No parent lookup, and not even a capability read — the switch falls
+    // through before either.
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})
+
+describe('canViewAttachment — MESSAGE (unchanged; must not regress)', () => {
+  it('grants a caller holding the `full` lens on the parent thread', async () => {
+    queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [{ threadId: THREAD_ID }])
+    getThreadLens.mockResolvedValue('full')
+    await expect(canView()).resolves.toBe(true)
+    expect(getThreadLens).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG_ID,
+      { userId: USER_ID },
+      THREAD_ID
+    )
+  })
+
+  it('denies the `read` lens — mail attachments are full-tier', async () => {
+    queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [{ threadId: THREAD_ID }])
+    getThreadLens.mockResolvedValue('read')
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies the `none` lens', async () => {
+    queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [{ threadId: THREAD_ID }])
+    getThreadLens.mockResolvedValue('none')
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a message that does not resolve in this org, before the lens read', async () => {
+    queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [])
+    await expect(canView()).resolves.toBe(false)
+    expect(getThreadLens).not.toHaveBeenCalled()
+  })
+
+  it('reads no capabilities at all on the mail path', async () => {
+    queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [{ threadId: THREAD_ID }])
+    getThreadLens.mockResolvedValue('full')
+    await canView()
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})
+
+describe('canViewAttachment — COMMENT', () => {
+  it('denies a member composing `records: None` / `comments: None` — Finding A', async () => {
+    // THE leak this rewrite closes. `COMMENT` fell into the old
+    // `entityType !== 'MESSAGE' → true` branch, so ANY authenticated org member
+    // got the bytes of any comment attachment they could name — including a
+    // member with no records access whatsoever. Comment attachments are the
+    // richest of these (customers' documents pasted into internal notes).
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [{ entityDefinitionId: DEF_ID }])
+    memberHolding({ [Area.records]: Level.None, [Area.comments]: Level.None })
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('grants a member who can view the commented-on definition', async () => {
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [{ entityDefinitionId: DEF_ID }])
+    memberHolding({ [Area.records]: Level.Read })
+    await expect(canView()).resolves.toBe(true)
+  })
+
+  it('denies a comment that does not resolve in this org, before any capability read', async () => {
+    // The parent lookup — not just the attachment lookup — is what fails closed.
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [])
+    memberHolding({ [Area.records]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    expect(fromTables).toEqual(['Attachment.id', 'Comment.id'])
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('scopes the comment lookup by organization', async () => {
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [{ entityDefinitionId: DEF_ID }])
+    memberHolding({ [Area.records]: Level.Read })
+    await canView()
+    expect(eq).toHaveBeenCalledWith('Comment.id', COMMENT_ID)
+    expect(eq).toHaveBeenCalledWith('Comment.organizationId', ORG_ID)
+  })
+})
+
+describe('canViewAttachment — FIELD_VALUE', () => {
+  it('grants a member who can view the owning definition', async () => {
+    queueRows(attachmentRow('FIELD_VALUE', FIELD_VALUE_ID), [{ entityDefinitionId: DEF_ID }])
+    memberHolding({ [Area.records]: Level.Read })
+    await expect(canView()).resolves.toBe(true)
+  })
+
+  it('denies a member composing `records: None`', async () => {
+    queueRows(attachmentRow('FIELD_VALUE', FIELD_VALUE_ID), [{ entityDefinitionId: DEF_ID }])
+    memberHolding({ [Area.records]: Level.None })
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a field value that does not resolve in this org', async () => {
+    queueRows(attachmentRow('FIELD_VALUE', FIELD_VALUE_ID), [])
+    memberHolding({ [Area.records]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+  })
+})
+
+describe('canViewAttachment — CUSTOM_FIELD (transient staging uploads)', () => {
+  it('grants the uploader without any parent lookup', async () => {
+    // `entityId` is the synthetic `field-${fieldRef}` of an in-progress form —
+    // there is no owning record to resolve, so the uploader is the only viewer.
+    queueRows(attachmentRow('CUSTOM_FIELD', 'field-contract', USER_ID))
+    await expect(canView()).resolves.toBe(true)
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(fromTables).toEqual(['Attachment.id'])
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('denies a DIFFERENT member of the same org, still without a parent lookup', async () => {
+    queueRows(attachmentRow('CUSTOM_FIELD', 'field-contract', OTHER_USER_ID))
+    memberHolding({ [Area.records]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    // The arm has nothing to look up: a second select here would mean it grew a
+    // parent resolution that the synthetic `entityId` cannot possibly satisfy.
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(fromTables).toEqual(['Attachment.id'])
+  })
+})
+
+describe('canViewAttachment — TICKET (retired)', () => {
+  // `TicketProcessor` and the `Ticket` table are both gone. Tickets are ordinary
+  // `EntityInstance` records now, and the processor's `validateEntityAccess` read a
+  // `schema.Ticket` that no longer existed — so it threw rather than writing, and no
+  // `TICKET` attachment has ever been produced (confirmed: zero rows). The arm was
+  // removed with the processor; this pins that removal to the fail-closed default.
+  it('denies — the arm is gone, so it falls through to the fail-closed default', async () => {
+    queueRows(attachmentRow('TICKET', INSTANCE_ID))
+    memberHolding({ [Area.records]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    expect(fromTables).toEqual(['Attachment.id'])
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})
+
+describe('canViewAttachment — ARTICLE (inherits the home KB)', () => {
+  it('grants a member holding `knowledgeBase: Read` on the article home KB', async () => {
+    queueRows(attachmentRow('ARTICLE', ARTICLE_ID), [{ homeKnowledgeBaseId: KB_ID }])
+    memberHolding({ [Area.knowledgeBase]: Level.Read })
+    await expect(canView()).resolves.toBe(true)
+  })
+
+  it('denies a member composing `knowledgeBase: None`', async () => {
+    queueRows(attachmentRow('ARTICLE', ARTICLE_ID), [{ homeKnowledgeBaseId: KB_ID }])
+    memberHolding({ [Area.knowledgeBase]: Level.None })
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a member holding an explicit `none` row on the home KB', async () => {
+    // Area wide open, and only the per-instance restriction stands between the
+    // caller and the attachment — the gate must key on the HOME KB, not the
+    // article id.
+    queueRows(attachmentRow('ARTICLE', ARTICLE_ID), [{ homeKnowledgeBaseId: KB_ID }])
+    memberHolding(
+      { [Area.knowledgeBase]: Level.Full },
+      { instances: { [KB_ID]: ResourcePermission.none } }
+    )
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies an article that does not resolve in this org, before any capability read', async () => {
+    queueRows(attachmentRow('ARTICLE', ARTICLE_ID), [])
+    memberHolding({ [Area.knowledgeBase]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    expect(fromTables).toEqual(['Attachment.id', 'Article.id'])
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})
+
+describe('canViewAttachment — KNOWLEDGE_BASE', () => {
+  it('grants a member holding `knowledgeBase: Read` on an existing KB', async () => {
+    queueRows(attachmentRow('KNOWLEDGE_BASE', KB_ID), [{ id: KB_ID }])
+    memberHolding({ [Area.knowledgeBase]: Level.Read })
+    await expect(canView()).resolves.toBe(true)
+  })
+
+  it('denies a member holding an explicit `none` row on that KB', async () => {
+    queueRows(attachmentRow('KNOWLEDGE_BASE', KB_ID), [{ id: KB_ID }])
+    memberHolding(
+      { [Area.knowledgeBase]: Level.Full },
+      { instances: { [KB_ID]: ResourcePermission.none } }
+    )
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a forged KB id before probing instance access', async () => {
+    // The existence check runs first on purpose: without it a forged id would
+    // fall through to `canViewInstance`, which answers from the area fallback
+    // and would happily grant a KB that is not in this org.
+    queueRows(attachmentRow('KNOWLEDGE_BASE', KB_ID), [])
+    memberHolding({ [Area.knowledgeBase]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})
+
+describe('canViewAttachment — CHAT_WIDGET (org membership only, deliberately)', () => {
+  it('grants any member when the widget exists in the org', async () => {
+    // Matches the tRPC sibling `getChatWidgetIntegration`, a bare
+    // `protectedProcedure`; these assets are `fileVisibility: PUBLIC` because
+    // the logo renders on the public widget.
+    queueRows(attachmentRow('CHAT_WIDGET', WIDGET_ID), [{ id: WIDGET_ID }])
+    await expect(canView()).resolves.toBe(true)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('denies a widget id from another org', async () => {
+    queueRows(attachmentRow('CHAT_WIDGET', WIDGET_ID), [])
+    await expect(canView()).resolves.toBe(false)
+    expect(fromTables).toEqual(['Attachment.id', 'ChatWidget.id'])
+  })
+})
+
+describe('canViewAttachment — WORKFLOW_RUN', () => {
+  it('grants a member holding `workflows: Read` on the run parent app', async () => {
+    queueRows(attachmentRow('WORKFLOW_RUN', RUN_ID))
+    memberHolding({ [Area.workflows]: Level.Read })
+    await expect(canView()).resolves.toBe(true)
+    expect(assertWorkflowRunNotSystemOwned).toHaveBeenCalledWith(expect.anything(), {
+      runId: RUN_ID,
+      organizationId: ORG_ID,
+      isSuperAdmin: false,
+      allowSuperAdminRead: false,
+    })
+  })
+
+  it('denies a member composing `workflows: None`', async () => {
+    queueRows(attachmentRow('WORKFLOW_RUN', RUN_ID))
+    memberHolding({ [Area.workflows]: Level.None })
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a system-owned run instead of throwing a 500', async () => {
+    // The guard signals system ownership by THROWING, not by returning false.
+    // An uncaught throw here would surface as a 500 on the download route —
+    // and, worse, the arm would never reach its own capability check.
+    queueRows(attachmentRow('WORKFLOW_RUN', RUN_ID))
+    assertWorkflowRunNotSystemOwned.mockRejectedValue(new Error('System-owned run'))
+    memberHolding({ [Area.workflows]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('denies a run that does not exist in this org (guard returns undefined)', async () => {
+    queueRows(attachmentRow('WORKFLOW_RUN', RUN_ID))
+    assertWorkflowRunNotSystemOwned.mockResolvedValue(undefined)
+    memberHolding({ [Area.workflows]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('gates on the parent WorkflowApp id the guard returns, not the run id', async () => {
+    // Instance access keys on `WorkflowApp.id`; an explicit `none` row there
+    // must deny even at `workflows: Full`.
+    queueRows(attachmentRow('WORKFLOW_RUN', RUN_ID))
+    memberHolding(
+      { [Area.workflows]: Level.Full },
+      { instances: { [WORKFLOW_APP_ID]: ResourcePermission.none } }
+    )
+    await expect(canView()).resolves.toBe(false)
+  })
+})
+
+describe('canViewAttachment — visit_qc_item', () => {
+  it('grants a `dispatchBoardManage` holder with zero parent queries', async () => {
+    // The office/dispatcher short-circuit: the board capability sees the whole
+    // board, so the visit lookup is a cost only a field seat should pay.
+    queueRows(attachmentRow('visit_qc_item', QC_ITEM_ID))
+    memberHolding({ [Area.dispatchBoard]: Level.Full })
+    await expect(canView()).resolves.toBe(true)
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(fromTables).toEqual(['Attachment.id'])
+    expect(loadOwnVisit).not.toHaveBeenCalled()
+  })
+
+  it('grants a non-holder whose own visit resolves', async () => {
+    queueRows(attachmentRow('visit_qc_item', QC_ITEM_ID), [{ visitId: VISIT_ID }])
+    memberHolding({ [Area.dispatchBoard]: Level.Read })
+    await expect(canView()).resolves.toBe(true)
+    expect(fromTables).toEqual(['Attachment.id', 'VisitQcItem.id'])
+    expect(loadOwnVisit).toHaveBeenCalledWith(ORG_ID, USER_ID, VISIT_ID)
+  })
+
+  it('denies a non-holder whose visit lookup throws (not assigned to them)', async () => {
+    // `loadOwnVisit` throws Forbidden/NotFound rather than returning a boolean.
+    queueRows(attachmentRow('visit_qc_item', QC_ITEM_ID), [{ visitId: VISIT_ID }])
+    loadOwnVisit.mockRejectedValue(new Error('This visit is not assigned to you'))
+    memberHolding({ [Area.dispatchBoard]: Level.Read })
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a non-holder when the QC item does not resolve in this org', async () => {
+    queueRows(attachmentRow('visit_qc_item', QC_ITEM_ID), [])
+    memberHolding({ [Area.dispatchBoard]: Level.Read })
+    await expect(canView()).resolves.toBe(false)
+    expect(loadOwnVisit).not.toHaveBeenCalled()
+  })
+
+  it('denies a member with no dispatch access at all', async () => {
+    queueRows(attachmentRow('visit_qc_item', QC_ITEM_ID), [{ visitId: VISIT_ID }])
+    loadOwnVisit.mockRejectedValue(new Error('This visit is not assigned to you'))
+    memberHolding({})
+    await expect(canView()).resolves.toBe(false)
+  })
+})

--- a/apps/web/src/app/api/attachments/attachment-visibility.ts
+++ b/apps/web/src/app/api/attachments/attachment-visibility.ts
@@ -2,15 +2,27 @@
 
 import { database, schema } from '@auxx/database'
 import { getCachedUserMailVisibility } from '@auxx/lib/cache'
+import { getCapabilities, PermissionKey } from '@auxx/lib/permissions'
 import { getThreadLens } from '@auxx/lib/permissions/visibility'
 import { and, eq } from 'drizzle-orm'
 
 /**
- * Mail-permissions gate for the attachment content routes: attachments on a
- * MESSAGE are `full`-tier (§7) — the caller must hold `full` lens on the
- * parent thread. Attachments on other entities pass through to the routes'
- * existing authorization. A missing attachment/message also returns false
- * (invisible ≍ nonexistent).
+ * Authorization gate for the attachment content routes (`download`, `thumbnail`).
+ *
+ * The attachment itself carries no access level — its parent does. So this resolves
+ * `Attachment.entityType` to the owning record and defers to that record's own gate:
+ * the mail lens for `MESSAGE`, `canViewEntity` for record-shaped parents, instance
+ * `view` for KB/workflow parents, and the dispatch board capability for QC items.
+ *
+ * Two invariants hold everywhere below:
+ *  - **Fails closed.** An unrecognized `entityType` returns `false`, as does a parent
+ *    row that does not resolve inside the caller's organization.
+ *  - **Capability-first, DB-second.** Each arm runs its free predicate before issuing
+ *    a parent lookup, so a denial costs no extra round trip, and `getCapabilities` is
+ *    resolved lazily so `MESSAGE`/`CUSTOM_FIELD` stay at zero capability reads.
+ *
+ * A missing attachment returns `false` too (invisible ≍ nonexistent), which keeps
+ * attachment ids unprobeable across orgs.
  */
 export async function canViewAttachment(
   attachmentId: string,
@@ -21,6 +33,7 @@ export async function canViewAttachment(
     .select({
       entityType: schema.Attachment.entityType,
       entityId: schema.Attachment.entityId,
+      createdById: schema.Attachment.createdById,
     })
     .from(schema.Attachment)
     .where(
@@ -31,20 +44,180 @@ export async function canViewAttachment(
     )
     .limit(1)
   if (!attachment) return false
-  if (attachment.entityType !== 'MESSAGE') return true
 
-  const [message] = await database
-    .select({ threadId: schema.Message.threadId })
-    .from(schema.Message)
-    .where(
-      and(
-        eq(schema.Message.id, attachment.entityId),
-        eq(schema.Message.organizationId, organizationId)
-      )
-    )
-    .limit(1)
-  if (!message) return false
+  let caps: Awaited<ReturnType<typeof getCapabilities>> | undefined
+  const capabilities = async () => (caps ??= await getCapabilities(userId, organizationId))
 
-  const viewer = await getCachedUserMailVisibility(userId, organizationId)
-  return (await getThreadLens(database, organizationId, viewer, message.threadId)) === 'full'
+  switch (attachment.entityType) {
+    // Mail attachments are `full`-tier (mail-permissions §7): the caller must hold
+    // the `full` lens on the parent thread.
+    case 'MESSAGE': {
+      const [message] = await database
+        .select({ threadId: schema.Message.threadId })
+        .from(schema.Message)
+        .where(
+          and(
+            eq(schema.Message.id, attachment.entityId),
+            eq(schema.Message.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      if (!message) return false
+
+      const viewer = await getCachedUserMailVisibility(userId, organizationId)
+      return (await getThreadLens(database, organizationId, viewer, message.threadId)) === 'full'
+    }
+
+    // `Comment.entityDefinitionId` is a denormalized column, so the comment's own row
+    // resolves the gate's subject without joining `EntityInstance`.
+    case 'COMMENT': {
+      const [comment] = await database
+        .select({ entityDefinitionId: schema.Comment.entityDefinitionId })
+        .from(schema.Comment)
+        .where(
+          and(
+            eq(schema.Comment.id, attachment.entityId),
+            eq(schema.Comment.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      if (!comment) return false
+
+      return (await capabilities()).canViewEntity(comment.entityDefinitionId)
+    }
+
+    // Same shape as COMMENT — `FieldValue.entityDefinitionId` is likewise a column.
+    case 'FIELD_VALUE': {
+      const [fieldValue] = await database
+        .select({ entityDefinitionId: schema.FieldValue.entityDefinitionId })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.id, attachment.entityId),
+            eq(schema.FieldValue.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      if (!fieldValue) return false
+
+      return (await capabilities()).canViewEntity(fieldValue.entityDefinitionId)
+    }
+
+    // Transient staging rows with no owning record: the uploader writes `entityId` as
+    // the synthetic `field-${fieldRef}`
+    // (`apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts`) and the
+    // asset is a 24h `TEMP_UPLOAD`. There is nothing to look up, so the uploader is the
+    // only viewer.
+    case 'CUSTOM_FIELD':
+      return attachment.createdById === userId
+
+    // Articles inherit their home KB's access level, matching the tRPC sibling
+    // `kb.getArticleById` and the article SSE route.
+    case 'ARTICLE': {
+      const [article] = await database
+        .select({ homeKnowledgeBaseId: schema.Article.homeKnowledgeBaseId })
+        .from(schema.Article)
+        .where(
+          and(
+            eq(schema.Article.id, attachment.entityId),
+            eq(schema.Article.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      if (!article) return false
+
+      return (await capabilities()).canViewInstance('kb', article.homeKnowledgeBaseId)
+    }
+
+    // `entityId` IS the KB id. Confirm the row exists in this org first so a forged id
+    // fails closed instead of probing instance access.
+    case 'KNOWLEDGE_BASE': {
+      const [knowledgeBase] = await database
+        .select({ id: schema.KnowledgeBase.id })
+        .from(schema.KnowledgeBase)
+        .where(
+          and(
+            eq(schema.KnowledgeBase.id, attachment.entityId),
+            eq(schema.KnowledgeBase.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      if (!knowledgeBase) return false
+
+      return (await capabilities()).canViewInstance('kb', attachment.entityId)
+    }
+
+    // Deliberately org-membership only. The sole chat-widget read procedure,
+    // `getChatWidgetIntegration` (`apps/web/src/server/api/routers/channel.ts`), is a bare
+    // `protectedProcedure`, and `ChatWidgetProcessor` marks these assets
+    // `fileVisibility: 'PUBLIC'` because the logo renders on the public widget. Gating
+    // harder here would be stricter than the tRPC sibling — a separate decision, not this
+    // fix.
+    case 'CHAT_WIDGET': {
+      const [widget] = await database
+        .select({ id: schema.ChatWidget.id })
+        .from(schema.ChatWidget)
+        .where(
+          and(
+            eq(schema.ChatWidget.id, attachment.entityId),
+            eq(schema.ChatWidget.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      return Boolean(widget)
+    }
+
+    // The instance key is the parent **`WorkflowApp.id`** (via `WorkflowRun.workflowAppId`),
+    // not a `Workflow.id`. The guard throws on system-owned runs rather than returning a
+    // boolean, and returns `undefined` when no such run exists in the org.
+    case 'WORKFLOW_RUN': {
+      const { assertWorkflowRunNotSystemOwned } = await import('@auxx/lib/workflows')
+      let workflowAppId: string | undefined
+      try {
+        workflowAppId = await assertWorkflowRunNotSystemOwned(database, {
+          runId: attachment.entityId,
+          organizationId,
+          isSuperAdmin: false,
+          allowSuperAdminRead: false,
+        })
+      } catch {
+        return false
+      }
+      if (!workflowAppId) return false
+
+      return (await capabilities()).canViewInstance('workflow', workflowAppId)
+    }
+
+    // Office/dispatcher path first — `dispatchBoardManage` sees the whole board and costs
+    // zero queries. Only a field (worker) seat pays the visit lookup, and `loadOwnVisit`
+    // throws Forbidden/NotFound rather than returning a boolean.
+    case 'visit_qc_item': {
+      if ((await capabilities()).can(PermissionKey.dispatchBoardManage)) return true
+
+      const [item] = await database
+        .select({ visitId: schema.VisitQcItem.visitId })
+        .from(schema.VisitQcItem)
+        .where(
+          and(
+            eq(schema.VisitQcItem.id, attachment.entityId),
+            eq(schema.VisitQcItem.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      if (!item) return false
+
+      const { loadOwnVisit } = await import('@auxx/lib/dispatch')
+      try {
+        await loadOwnVisit(organizationId, userId, item.visitId)
+        return true
+      } catch {
+        return false
+      }
+    }
+
+    // Fail closed. `Attachment.entityType` is a free-text column, so the next writer that
+    // invents a value ships denied until an arm is added for it.
+    default:
+      return false
+  }
 }

--- a/apps/web/src/components/file-upload/stores/__tests__/session-isolation.test.ts
+++ b/apps/web/src/components/file-upload/stores/__tests__/session-isolation.test.ts
@@ -27,9 +27,9 @@ describe('Session Isolation', () => {
         },
       })
 
-      // Create session 2 with different config (TICKET is a valid entity type)
+      // Create session 2 with different config (COMMENT is a valid entity type)
       const session2Id = await store.createSession({
-        entityType: 'TICKET',
+        entityType: 'COMMENT',
         validationConfig: {
           maxFiles: 1,
           maxFileSize: 2 * 1024 * 1024, // 2MB
@@ -51,7 +51,7 @@ describe('Session Isolation', () => {
       expect(session1.validationConfig?.maxFileSize).toBe(10 * 1024 * 1024)
       expect(session1.behaviorConfig?.allowMultiple).toBe(true)
 
-      expect(session2.entityType).toBe('TICKET')
+      expect(session2.entityType).toBe('COMMENT')
       expect(session2.validationConfig?.maxFiles).toBe(1)
       expect(session2.validationConfig?.maxFileSize).toBe(2 * 1024 * 1024)
       expect(session2.behaviorConfig?.allowMultiple).toBe(false)
@@ -76,8 +76,8 @@ describe('Session Isolation', () => {
       const store = useUploadStore.getState()
 
       // Create sessions with different valid entity types
-      const ticketSession = await store.createSession({
-        entityType: 'TICKET',
+      const commentSession = await store.createSession({
+        entityType: 'COMMENT',
         validationConfig: { maxFiles: 1, maxFileSize: 2 * 1024 * 1024 },
       })
 
@@ -88,9 +88,9 @@ describe('Session Isolation', () => {
 
       // Sessions should be independent
       const state = useUploadStore.getState()
-      expect(state.sessions[ticketSession]).toBeDefined()
+      expect(state.sessions[commentSession]).toBeDefined()
       expect(state.sessions[messageSession]).toBeDefined()
-      expect(state.sessions[ticketSession].entityType).toBe('TICKET')
+      expect(state.sessions[commentSession].entityType).toBe('COMMENT')
       expect(state.sessions[messageSession].entityType).toBe('MESSAGE')
     })
   })

--- a/packages/database/drizzle/0311_agent_version_permission_policy.sql
+++ b/packages/database/drizzle/0311_agent_version_permission_policy.sql
@@ -6,16 +6,29 @@
 -- depend on a runtime DataMigration having already run).
 --
 -- The backfilled value is EXACT for existing rows, not a placeholder: every agent
--- composes all-`full` today (plan 14 §0.3 — `composeAgentLevels` returns
--- `Level.Full` for any area with no explicit grant row, and enforcement is
--- dormant at that default). Preserving current behavior therefore IS the all-full
--- policy. The stricter `chat_agent` seed applies only to newly authored chat
--- agents, never retroactively (plan 19 §5.2 step 4).
+-- composes all-top-rung today (plan 14 §0.3 — `composeAgentLevels` returns the
+-- highest rung for any area with no explicit grant row, and enforcement is
+-- dormant at that default). Preserving current behavior therefore IS the
+-- all-`admin` policy. The stricter `chat_agent` seed applies only to newly
+-- authored chat agents, never retroactively (plan 19 §5.2 step 4).
 --
--- Mirrors `LEGACY_FULL_AGENT_PERMISSION_POLICY` in
--- packages/database/src/db/schema/agent-version.ts. Data migration 042 then
--- honors any per-agent AGENT-grantee `PermissionGrant` rows this flat default
--- would have overwritten, and recomputes `configHash` to include the snapshot.
+-- The literal below is written in the CURRENT shape of
+-- `PublishedAgentPermissionPolicy` (packages/database/src/db/schema/agent-version.ts),
+-- NOT the shape this file originally shipped with. Two later slices moved the
+-- target after this hand-edit was written, and a migration that has not yet run
+-- anywhere but dev must land already-correct rather than land wrong and wait for
+-- a runtime DataMigration to repair it:
+--   * #1351 / data migration 054 renamed the rung vocabulary
+--     (`read → view`, `read_write → edit`, `full → admin`). `parsePublishedAgentPolicy`
+--     DROPS a rung it no longer recognizes, so a blob written as `"full"` composes
+--     the version to all-`none` for the whole window between `db:migrate` and the
+--     worker draining its boot-enqueued data-migrations job.
+--   * #1364 / data migration 055 retired `resourceDefault`. A resource type with
+--     no rule of its own now falls through to its own L2 `areas` rung, so an empty
+--     `resources` map under `areas.default = "admin"` is the same authority the
+--     retired `"resourceDefault": "full"` carried.
+-- Both migrations stay idempotent no-ops over this literal, so the ledger is
+-- unaffected in environments where they have already run.
 ALTER TABLE "AgentVersion" ADD COLUMN "permissionPolicy" jsonb;
 --> statement-breakpoint
 UPDATE "AgentVersion"
@@ -24,9 +37,8 @@ SET "permissionPolicy" = '{
   "sourceProfileUpdatedAt": null,
   "publishedByUserId": null,
   "clamp": [],
-  "areas": { "default": "full", "overrides": {} },
-  "definitions": { "default": "full", "overrides": {} },
-  "resourceDefault": "full",
+  "areas": { "default": "admin", "overrides": {} },
+  "definitions": { "default": "admin", "overrides": {} },
   "resources": {}
 }'::jsonb
 WHERE "permissionPolicy" IS NULL;

--- a/packages/lib/src/files/core/types.ts
+++ b/packages/lib/src/files/core/types.ts
@@ -21,7 +21,6 @@ export type EntityType =
   | 'TASK'
   | 'ORDER'
   | 'PRODUCT'
-  | 'TICKET'
   | 'ARTICLE'
   | 'WORKFLOW_RUN'
   | 'DATASET'

--- a/packages/lib/src/files/types/entities.ts
+++ b/packages/lib/src/files/types/entities.ts
@@ -12,7 +12,6 @@
 export const ENTITY_TYPES = {
   FILE: 'FILE',
   DATASET: 'DATASET',
-  TICKET: 'TICKET',
   ARTICLE: 'ARTICLE',
   USER_PROFILE: 'USER_PROFILE',
   WORKFLOW_RUN: 'WORKFLOW_RUN',
@@ -341,56 +340,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
     maxConcurrentUploads: 5,
     enableBatchUpload: true,
     supportedFeatures: { progress: true, preview: true, retry: true, pause: true, resume: true },
-  },
-
-  [ENTITY_TYPES.TICKET]: {
-    entityType: ENTITY_TYPES.TICKET,
-    displayName: 'Ticket Attachment',
-    description: 'Attach files to support tickets',
-    stages: [
-      { name: 'validation', displayName: 'Validation', weight: 50, estimatedDuration: 1 },
-      {
-        name: 'attachment-creation',
-        displayName: 'Attachment Creation',
-        weight: 50,
-        estimatedDuration: 2,
-      },
-    ],
-    validation: {
-      maxFileSize: 25 * 1024 * 1024, // 25MB
-      allowedMimeTypes: [
-        'image/*',
-        'text/*',
-        'application/pdf',
-        // 'text/plain',
-        // 'text/csv',
-        'application/msword',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        'application/zip',
-        'application/x-zip-compressed',
-      ],
-      allowedExtensions: [
-        '.jpg',
-        '.jpeg',
-        '.png',
-        '.gif',
-        '.bmp',
-        '.webp',
-        '.pdf',
-        '.txt',
-        '.csv',
-        '.doc',
-        '.docx',
-        '.zip',
-      ],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
-    defaultVisibility: 'private',
-    maxConcurrentUploads: 3,
-    enableBatchUpload: true,
-    supportedFeatures: { progress: true, preview: true, retry: true, pause: false, resume: false },
   },
 
   [ENTITY_TYPES.ARTICLE]: {

--- a/packages/lib/src/files/upload/__tests__/unified-processor-system.test.ts
+++ b/packages/lib/src/files/upload/__tests__/unified-processor-system.test.ts
@@ -64,7 +64,7 @@ describe('Unified Processor System', () => {
   describe('Processor Registry', () => {
     it('should have simplified EntityType mapping', () => {
       // Test that registry supports EntityType directly
-      const entityTypes: EntityType[] = ['FILE', 'DATASET', 'TICKET']
+      const entityTypes: EntityType[] = ['FILE', 'DATASET', 'ARTICLE']
 
       entityTypes.forEach((entityType) => {
         expect(() => {

--- a/packages/lib/src/files/upload/__tests__/unified-upload-integration.test.ts
+++ b/packages/lib/src/files/upload/__tests__/unified-upload-integration.test.ts
@@ -3,13 +3,13 @@
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
 import { StorageManager } from '../../storage/storage-manager'
 import type { UploadInitConfig, UploadPreparedConfig } from '../init-types'
-import { TicketProcessor } from '../processors/entity-processors'
+import { ArticleProcessor } from '../processors/entity-processors'
 import { FileProcessor } from '../processors/file-processor'
 import { ProcessorRegistry } from '../processors/processor-registry'
 import { SessionManager } from '../session-manager'
 
 const { ticketSelectRowsRef, createSelectBuilder, selectMock } = vi.hoisted(() => {
-  // Maintains the mocked Ticket rows returned from the Drizzle select builder
+  // Maintains the mocked entity rows returned from the Drizzle select builder
   const ticketSelectRowsRef = {
     value: [{ id: 'ticket123' }],
   }
@@ -75,7 +75,6 @@ vi.mock('@auxx/redis', () => ({
 // Mock database and services
 vi.mock('@auxx/database', () => ({
   schema: {
-    Ticket: { id: 'id', organizationId: 'organizationId' },
     Article: { id: 'id', organizationId: 'organizationId' },
     WorkflowRun: { id: 'id', organizationId: 'organizationId' },
     User: { id: 'id' },
@@ -110,7 +109,7 @@ vi.mock('@auxx/database', () => ({
       })
     ),
     query: {
-      Ticket: {
+      Article: {
         findFirst: vi.fn(async () => ticketSelectRowsRef.value[0] ?? null),
       },
     },
@@ -190,7 +189,7 @@ describe('Unified Upload Integration Tests', () => {
 
     // Register processors using canonical EntityType values
     ProcessorRegistry.registerForEntity('FILE', (orgId) => new FileProcessor(orgId))
-    ProcessorRegistry.registerForEntity('TICKET', (orgId) => new TicketProcessor(orgId))
+    ProcessorRegistry.registerForEntity('ARTICLE', (orgId) => new ArticleProcessor(orgId))
   })
 
   describe('Complete Upload Flow', () => {
@@ -254,34 +253,6 @@ describe('Unified Upload Integration Tests', () => {
       )
       expect(session.policy).toEqual(config.policy)
       expect(session.uploadPlan).toEqual(config.uploadPlan)
-    })
-
-    it('should complete ticket attachment upload flow with validation', async () => {
-      // Step 1: Get processor for ticket attachment
-      const processor = ProcessorRegistry.getForEntityType('TICKET', 'org123')
-      expect(processor).toBeInstanceOf(TicketProcessor)
-
-      // Step 2: Process configuration with entity validation
-      const init: UploadInitConfig = {
-        organizationId: 'org123',
-        userId: 'user123',
-        fileName: 'support-document.pdf',
-        mimeType: 'application/pdf',
-        expectedSize: 5 * 1024 * 1024, // 5MB
-        entityType: 'TICKET',
-        entityId: 'ticket123',
-      }
-
-      const { config } = await processor.processConfig(init)
-
-      expect(config.policy.allowedMimeTypes).toContain('application/pdf')
-      expect(config.policy.allowedMimeTypes).not.toContain('*/*')
-
-      // Step 3: Create session
-      const session = await SessionManager.createSessionFromConfig(config)
-
-      expect(session.entityType).toBe('TICKET') // ✅ Use canonical EntityType
-      expect(session.entityId).toBe('ticket123')
     })
 
     it('should handle multipart upload for large files', async () => {
@@ -485,7 +456,7 @@ describe('Unified Upload Integration Tests', () => {
     })
 
     it('should handle validation failures', async () => {
-      const processor = ProcessorRegistry.getForEntityType('TICKET', 'org123')
+      const processor = ProcessorRegistry.getForEntityType('ARTICLE', 'org123')
 
       // Mock database to return null (entity not found)
       ticketSelectRowsRef.value = []
@@ -497,12 +468,12 @@ describe('Unified Upload Integration Tests', () => {
         fileName: 'test.pdf',
         mimeType: 'application/pdf',
         expectedSize: 1024 * 1024,
-        entityType: 'TICKET',
-        entityId: 'nonexistent-ticket',
+        entityType: 'ARTICLE',
+        entityId: 'nonexistent-article',
       }
 
       await expect(processor.processConfig(init)).rejects.toThrow(
-        'Entity validation failed: Ticket not found or access denied'
+        'Entity validation failed: Article not found or access denied'
       )
     })
 

--- a/packages/lib/src/files/upload/processors/__tests__/unified-processor-system.test.ts
+++ b/packages/lib/src/files/upload/processors/__tests__/unified-processor-system.test.ts
@@ -1,10 +1,10 @@
 // packages/lib/src/files/upload/processors/__tests__/unified-processor-system.test.ts
 
-import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EntityType } from '../../../types/entities'
 import { ENTITY_TYPES } from '../../../types/entities'
 import type { UploadInitConfig } from '../../init-types'
-import { TicketProcessor, UserProfileProcessor, WorkflowRunProcessor } from '../entity-processors'
+import { UserProfileProcessor, WorkflowRunProcessor } from '../entity-processors'
 import { FileProcessor } from '../file-processor'
 import { ProcessorRegistry } from '../processor-registry'
 
@@ -30,10 +30,6 @@ vi.mock('@auxx/database', () => ({
   database: {
     select: vi.fn(() => createSelectBuilder(ticketSelectRowsRef)),
     query: {
-      Ticket: {
-        findFirst: vi.fn(),
-        findMany: vi.fn(),
-      },
       Article: {
         findFirst: vi.fn(),
         findMany: vi.fn(),
@@ -56,7 +52,6 @@ vi.mock('@auxx/database', () => ({
     delete: vi.fn(),
   },
   schema: {
-    Ticket: { id: 'id', organizationId: 'organizationId' },
     Article: { id: 'id', organizationId: 'organizationId' },
     WorkflowRun: { id: 'id', organizationId: 'organizationId' },
     User: { id: 'id' },
@@ -143,7 +138,7 @@ describe('Unified Processor System', () => {
       ProcessorRegistry.registerForEntity(ENTITY_TYPES.FILE, (orgId) => new FileProcessor(orgId))
 
       expect(ProcessorRegistry.hasProcessor(ENTITY_TYPES.FILE)).toBe(true)
-      expect(ProcessorRegistry.hasProcessor(ENTITY_TYPES.TICKET)).toBe(false)
+      expect(ProcessorRegistry.hasProcessor(ENTITY_TYPES.ARTICLE)).toBe(false)
     })
 
     it('should return processor instance for registered EntityType', () => {
@@ -227,7 +222,7 @@ describe('Unified Processor System', () => {
     it('should warn when entityType suggests attachment processor', async () => {
       const attachmentConfig = {
         ...baseConfig,
-        entityType: ENTITY_TYPES.TICKET as EntityType,
+        entityType: ENTITY_TYPES.COMMENT as EntityType,
       }
 
       const result = await processor.processConfig(attachmentConfig)
@@ -243,92 +238,6 @@ describe('Unified Processor System', () => {
       expect(() => {
         ;(result.config as any).provider = 'GOOGLE_DRIVE'
       }).toThrow()
-    })
-  })
-
-  describe('TicketProcessor processConfig', () => {
-    let processor: TicketProcessor
-
-    beforeEach(async () => {
-      processor = new TicketProcessor('org123')
-
-      // Set up ticket rows for the select builder to return
-      ticketSelectRowsRef.value = [{ id: 'ticket123' }]
-
-      // Also reset the database.select mock to use ticket rows
-      const { database } = await import('@auxx/database')
-      vi.mocked(database.select).mockImplementation(
-        () => createSelectBuilder(ticketSelectRowsRef) as any
-      )
-    })
-
-    it('should process config with ticket-specific policies', async () => {
-      const config: UploadInitConfig = {
-        organizationId: 'org123',
-        userId: 'user123',
-        fileName: 'attachment.pdf',
-        mimeType: 'application/pdf',
-        expectedSize: 5 * 1024 * 1024, // 5MB
-        entityType: ENTITY_TYPES.TICKET,
-        entityId: 'ticket123',
-      }
-
-      const result = await processor.processConfig(config)
-
-      expect(result.config.policy.allowedMimeTypes).toContain('application/pdf')
-      expect(result.config.policy.allowedMimeTypes).toContain('image/*')
-      expect(result.warnings).toHaveLength(0)
-    })
-
-    it('should throw error when entityId is missing', async () => {
-      const config: UploadInitConfig = {
-        organizationId: 'org123',
-        userId: 'user123',
-        fileName: 'attachment.pdf',
-        mimeType: 'application/pdf',
-        expectedSize: 5 * 1024 * 1024,
-        entityType: ENTITY_TYPES.TICKET,
-        // entityId missing
-      }
-
-      await expect(processor.processConfig(config)).rejects.toThrow(
-        'Entity ID is required for TICKET attachments'
-      )
-    })
-
-    it('should throw error when file exceeds size limit', async () => {
-      const config: UploadInitConfig = {
-        organizationId: 'org123',
-        userId: 'user123',
-        fileName: 'huge-file.pdf',
-        mimeType: 'application/pdf',
-        expectedSize: 30 * 1024 * 1024, // 30MB (exceeds 25MB limit)
-        entityType: ENTITY_TYPES.TICKET,
-        entityId: 'ticket123',
-      }
-
-      await expect(processor.processConfig(config)).rejects.toThrow(
-        'File exceeds allowed size of 25MB'
-      )
-    })
-
-    it('should throw error when entity access fails', async () => {
-      // Return empty rows to simulate ticket not found
-      ticketSelectRowsRef.value = []
-
-      const config: UploadInitConfig = {
-        organizationId: 'org123',
-        userId: 'user123',
-        fileName: 'attachment.pdf',
-        mimeType: 'application/pdf',
-        expectedSize: 5 * 1024 * 1024,
-        entityType: ENTITY_TYPES.TICKET,
-        entityId: 'nonexistent-ticket',
-      }
-
-      await expect(processor.processConfig(config)).rejects.toThrow(
-        'Entity validation failed: Ticket not found or access denied'
-      )
     })
   })
 

--- a/packages/lib/src/files/upload/processors/entity-processors.ts
+++ b/packages/lib/src/files/upload/processors/entity-processors.ts
@@ -14,63 +14,6 @@ import type { PresignedUploadSession } from '../session-types'
 import { BaseAssetProcessor } from './base-asset-processor'
 import { BaseAttachmentProcessor } from './base-attachment-processor'
 import type { ProcessorResult } from './types'
-// ============= Ticket Processor =============
-export class TicketProcessor extends BaseAttachmentProcessor {
-  protected readonly entityType = 'TICKET'
-  protected readonly fileVisibility = 'PRIVATE'
-  protected readonly preferredProvider = 'S3'
-  protected readonly maxFileSize = 25 * 1024 * 1024 // 25MB
-  protected readonly allowedMimeTypes = [
-    'image/*',
-    'application/pdf',
-    'text/plain',
-    'text/csv',
-    'application/msword',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    'application/vnd.ms-excel',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    'application/zip',
-    'application/x-zip-compressed',
-  ]
-  protected readonly assetKind: AssetKind = 'EMAIL_ATTACHMENT'
-  /**
-   * Override processConfig for ticket-specific validation and policies
-   */
-  async processConfig(init: UploadInitConfig): Promise<ProcessorConfigResult> {
-    const base = await super.processConfig(init)
-    const warnings = [...base.warnings]
-    // Ticket-specific validations and warnings
-    if (init.expectedSize > this.maxFileSize) {
-      throw new Error(
-        `File size exceeds maximum allowed for ticket attachments (${this.maxFileSize / 1024 / 1024}MB)`
-      )
-    }
-    return {
-      config: base.config,
-      warnings,
-    }
-  }
-  protected async validateEntityAccess(
-    entityId: string,
-    organizationId: string,
-    userId: string
-  ): Promise<void> {
-    const [ticket] = await db
-      .select({ id: schema.Ticket.id })
-      .from(schema.Ticket)
-      .where(
-        and(
-          eq(schema.Ticket.id, entityId),
-          eq(schema.Ticket.organizationId, organizationId)
-          // Add user access validation based on your business rules
-        )
-      )
-      .limit(1)
-    if (!ticket) {
-      throw new Error('Ticket not found or access denied')
-    }
-  }
-}
 // ============= User Profile Processor =============
 export class UserProfileProcessor extends BaseAssetProcessor {
   protected readonly entityType = 'USER_PROFILE'

--- a/packages/lib/src/files/upload/processors/index.ts
+++ b/packages/lib/src/files/upload/processors/index.ts
@@ -9,7 +9,6 @@ import {
   CustomFieldProcessor,
   KnowledgeBaseProcessor,
   MessageProcessor,
-  TicketProcessor,
   UserProfileProcessor,
   WorkflowRunProcessor,
 } from './entity-processors'
@@ -36,7 +35,6 @@ export function initializeProcessors(): void {
   // Register processors directly by EntityType
   ProcessorRegistry.registerForEntity('FILE', (orgId) => new FileProcessor(orgId))
   ProcessorRegistry.registerForEntity('DATASET', (orgId) => new DatasetAssetProcessor(orgId))
-  ProcessorRegistry.registerForEntity('TICKET', (orgId) => new TicketProcessor(orgId))
   ProcessorRegistry.registerForEntity('ARTICLE', (orgId) => new ArticleProcessor(orgId))
   ProcessorRegistry.registerForEntity('USER_PROFILE', (orgId) => new UserProfileProcessor(orgId))
   ProcessorRegistry.registerForEntity('WORKFLOW_RUN', (orgId) => new WorkflowRunProcessor(orgId))

--- a/packages/lib/src/permissions/profiles/agent-policy.ts
+++ b/packages/lib/src/permissions/profiles/agent-policy.ts
@@ -287,11 +287,17 @@ export function authorizationOnlyPolicy(policy: PublishedAgentPermissionPolicy):
  * `packages/database/drizzle/0311_agent_version_permission_policy.sql`, and is what
  * data migration 050 treats as "the flat DDL default that may need correcting".
  *
- * **The SQL literal still spells that rung `"full"` and is deliberately left
- * that way**: it is a shipped, already-applied migration, and rewriting an
- * applied file changes nothing for anyone who ran it. It only ever backfilled
- * rows that existed at the time, so a fresh database writes it never; the rows it
- * DID write are re-spelled by data migration 054 (plan 26 Phase 2).
+ * **The SQL literal is kept byte-equivalent to this function, and was corrected
+ * in place once** (2026-07-28) after #1351 renamed the rung vocabulary and #1364
+ * retired `resourceDefault`. The earlier reasoning for leaving it spelled `"full"`
+ * — "already applied, and a fresh database writes it never" — held only for the
+ * two environments it was checked against. It is false for any environment that
+ * still has `AgentVersion` rows AND has not yet reached 0311: there, the DDL
+ * writes a blob `parsePublishedAgentPolicy` cannot read, and every version
+ * composes to all-`none` until the worker drains its boot-enqueued
+ * data-migrations job. Correcting the file is safe because Drizzle's migrator
+ * selects by `folderMillis > lastDbMigration.created_at`, never by hash — an
+ * environment that already applied 0311 will not re-run it.
  *
  * Deliberately NOT the fallback for an unreadable policy — that is
  * {@link emptyAgentPolicy}.


### PR DESCRIPTION
## The leak

`canViewAttachment` returned `true` for every non-`MESSAGE` attachment:

```ts
if (attachment.entityType !== 'MESSAGE') return true
```

The `download` and `thumbnail` routes performed no other authorization — both construct `AttachmentService` without its optional `authorize` callback, so the service's `ensureAuth` hook early-returns and is dead. Any authenticated org member could fetch any other member's attachment bytes (302 → presigned S3) given only an id.

Ids were harvestable in one request: `comment.getByRecordId` is a bare `protectedProcedure` whose only guard compares organization ids, and it splices full attachment records into its response. Cross-org access was never possible — both halves filter on the session org. This is an intra-org unauthorized-member boundary.

`content/route.ts` was already safe by accident: it delegates to a service whose WHERE hard-filters `entityType = 'MESSAGE'`.

## The fix

A fail-closed switch on `entityType` that resolves the owning record and defers to that record's own gate. No caller-supplied scope is involved — the `Attachment` row already carries `entityType` + `entityId` — so there is no confused-deputy surface to prove.

| entityType | gate |
| --- | --- |
| `MESSAGE` | mail thread lens (unchanged) |
| `COMMENT` | `canViewEntity(Comment.entityDefinitionId)` |
| `FIELD_VALUE` | `canViewEntity(FieldValue.entityDefinitionId)` |
| `CUSTOM_FIELD` | uploader identity — synthetic `field-` id, no owning record |
| `ARTICLE` | `canViewInstance('kb', Article.homeKnowledgeBaseId)` |
| `KNOWLEDGE_BASE` | `canViewInstance('kb', entityId)` |
| `CHAT_WIDGET` | org membership |
| `WORKFLOW_RUN` | `canViewInstance('workflow', WorkflowRun.workflowAppId)` |
| `visit_qc_item` | `dispatchBoardManage`, else the visit assignee guard |
| default | `false` |

`Attachment.entityType` is free-text, not a pg enum, so the default arm is genuinely reachable — the next writer that invents a value ships denied.

### Why not simply gate the routes on `filesView`

It would blank the worker seat's own photos. `SEAT_CEILINGS.worker` is `Level.None` for everything outside `WORKER_AREAS`, which does not include `files`, and the ceiling is the last `min` in composition — so a field tech composes `files: None` unliftably. The QC photo strip renders `AttachmentThumbnail`, which hits `/thumbnail`. A blanket gate closes no boundary and breaks the checklist.

## Query cost

Unchanged or lower, despite adding a parent lookup.

- Capability checks are free: `getCapabilities` is entirely cache-backed (its `db` param is unused) and every `CapabilityView` member is in-memory.
- `Comment` and `FieldValue` both carry `entityDefinitionId` as a column, so each parent resolves in one PK select — no `EntityInstance` join.
- Capabilities resolve lazily and each arm runs its free predicate first, so `MESSAGE`, `CUSTOM_FIELD`, `CHAT_WIDGET`, the default arm and every parent-miss denial cost zero capability reads. A dispatcher short-circuits `visit_qc_item` with no `VisitQcItem` select.
- Both routes re-read the attachment row through an `attachmentService.get()` whose null check cannot fail once the gate has passed. Removed from both — net zero for `COMMENT`/`FIELD_VALUE`, net −1 elsewhere.

For reference, the already-shipping `MESSAGE` arm costs 3–4 queries, so every new arm is cheaper than what runs on the hottest mail path today.

## TicketProcessor retired

`schema.Ticket` no longer exists, so `TicketProcessor.validateEntityAccess` selected from `undefined` and would throw rather than write. Tickets are ordinary `EntityInstance` records now, and a DB check confirms **zero** `Attachment` rows with `entityType='TICKET'`. Removed the class, its registry entry, the `ENTITY_TYPES`/`EntityType` members, and the corresponding gate arm.

Its tests only passed because they mocked the missing table into existence (`Ticket: { id: 'id', ... }` in the hand-written `schema` stub). Those mocks are gone; the error-path test was retargeted to `ArticleProcessor` rather than deleted.

## Tests

`attachment-visibility.test.ts` — **37 cases, up from zero.** This was the largest untested authorization predicate in the permissions plan. Every arm gets a grant and a deny, plus the fail-closed default, org-scoped parent misses, and assertions that the capability-first short-circuits actually skip their queries.

Mutation-verified: reverting the `default` arm to `return true` kills exactly the fail-closed test; reverting the `COMMENT` arm kills exactly the regression test named for this leak.

## Not in scope

- The `public, max-age=31536000, immutable` header on `thumbnail/route.ts` — wrong on its own terms (it caches a 302 to a presigned URL that expires far sooner) and worth fixing, but it is a separate ticket.
- `comment.getByRecordId`'s org-only check. Closing the harvest surface is worth its own pass; the route is what must not honour a leaked id regardless.
- `CHAT_WIDGET` is the one arm that restricts nothing beyond the old behavior. Deliberate: the only chat-widget read procedure is a bare `protectedProcedure` and these assets are `fileVisibility: 'PUBLIC'` because the logo renders on the public widget. Gating harder would be stricter than the tRPC sibling.

## Also carried

In-flight work from a parallel session, included at the author's request: the `0311` migration literal rewritten into the current `PublishedAgentPermissionPolicy` shape (`full` → `admin`, `resourceDefault` retired), and `agent-policy.ts` clamp changes.

## Verification

- `attachment-visibility.test.ts` + `session-isolation.test.ts`: 40 passing.
- Scoped `tsc --noEmit` on `apps/web`: zero errors in `attachment-visibility.ts`. The two reported in `download/route.ts` are pre-existing in the untouched `stream` branch, shifted by the deleted lines.
- `unified-upload-integration.test.ts` and `unified-processor-system.test.ts` (`processors/__tests__`) fail at collection on `resource-access-service.ts:166` — **pre-existing**, proven by running the unmodified `HEAD` copies, which fail identically. These suites were written against a much smaller module graph and need their own rework.