### PR TITLE
fix(kb): register the proxy from src, fix markdown caching, send search credentials

### DIFF
--- a/apps/kb/src/app/md/[orgSlug]/[kbSlug]/[...articleSlug]/route.ts
+++ b/apps/kb/src/app/md/[orgSlug]/[kbSlug]/[...articleSlug]/route.ts
@@ -1,4 +1,4 @@
-// apps/kb/src/app/_md/[orgSlug]/[kbSlug]/[...articleSlug]/route.ts
+// apps/kb/src/app/md/[orgSlug]/[kbSlug]/[...articleSlug]/route.ts
 
 import { articleToMarkdown } from '@auxx/lib/kb/markdown'
 import {
@@ -37,7 +37,11 @@ export async function GET(req: Request, { params }: RouteParams): Promise<Respon
   }
 
   if (visibility.visibility === 'PUBLIC') {
-    return renderPublic(req, orgSlug, kbSlug, articleSlug)
+    return toResponse(
+      await loadPublicMarkdown(orgSlug, kbSlug, articleSlug),
+      req.url,
+      'public, s-maxage=31536000, stale-while-revalidate=60'
+    )
   }
 
   // Denials stay an opaque 404 for the same reason as `search.json`.
@@ -50,69 +54,81 @@ export async function GET(req: Request, { params }: RouteParams): Promise<Respon
   const { articles } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
     session: { userId: session.userId },
   })
-  return renderArticleMarkdown({
-    requestUrl: req.url,
-    orgSlug,
-    kbSlug,
-    articleSlug,
-    articles,
-    cacheControl: 'private, no-store',
-  })
+  return toResponse(
+    resolveArticleMarkdown({ orgSlug, kbSlug, articleSlug, articles }),
+    req.url,
+    'private, no-store'
+  )
 }
 
-async function renderPublic(
-  req: Request,
+/**
+ * The PUBLIC branch's cached half.
+ *
+ * Everything crossing a `'use cache'` boundary must be serializable, in BOTH
+ * directions — which is why this returns a {@link MarkdownResult} descriptor
+ * rather than a `Response`, and why it takes no `Request`. It previously did
+ * both: the `Response` could not be written into a cache entry (the route 500'd
+ * on every public hit), and passing the whole request made the cache key vary
+ * per URL, so the entry could never have been reused even if it had serialized.
+ * Nobody noticed because `proxy.ts` sat at the package root and never rewrote
+ * `.md` onto this path at all.
+ */
+async function loadPublicMarkdown(
   orgSlug: string,
   kbSlug: string,
   articleSlug: string[]
-): Promise<Response> {
+): Promise<MarkdownResult> {
   'use cache'
   const slugPath = articleSlug.join('/')
   cacheTag(kbTag(orgSlug, kbSlug), kbArticleTag(orgSlug, kbSlug, slugPath))
   cacheLife('max')
 
   const { articles } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
-  return renderArticleMarkdown({
-    requestUrl: req.url,
-    orgSlug,
-    kbSlug,
-    articleSlug,
-    articles,
-    cacheControl: 'public, s-maxage=31536000, stale-while-revalidate=60',
-  })
+  return resolveArticleMarkdown({ orgSlug, kbSlug, articleSlug, articles })
 }
 
-interface RenderInput {
-  requestUrl: string
+/** Serializable outcome of resolving one `.md` request — safe to cache. */
+type MarkdownResult =
+  | { kind: 'notFound' }
+  | { kind: 'redirect'; target: string }
+  | { kind: 'markdown'; body: string }
+
+interface ResolveInput {
   orgSlug: string
   kbSlug: string
   articleSlug: string[]
   articles: PublicArticleFull[]
-  cacheControl: string
 }
 
-function renderArticleMarkdown({
-  requestUrl,
+function resolveArticleMarkdown({
   orgSlug,
   kbSlug,
   articleSlug,
   articles,
-  cacheControl,
-}: RenderInput): Response {
+}: ResolveInput): MarkdownResult {
   const article = findArticleBySlugPath(articles, articleSlug)
-  if (!article) return new Response('Not Found', { status: 404 })
+  if (!article) return { kind: 'notFound' }
 
   if (article.articleKind === 'tab' || article.articleKind === 'header') {
     const first = findFirstNavigableUnder(article.id, articles, { publishedOnly: true })
-    if (!first) return new Response('Not Found', { status: 404 })
-    const target = `/${orgSlug}/${kbSlug}/${getFullSlugPath(first, articles)}.md`
-    return Response.redirect(new URL(target, requestUrl), 308)
+    if (!first) return { kind: 'notFound' }
+    return {
+      kind: 'redirect',
+      target: `/${orgSlug}/${kbSlug}/${getFullSlugPath(first, articles)}.md`,
+    }
   }
 
   const body = articleToMarkdown({ title: article.title, contentJson: article.contentJson })
-  const md = article.title?.trim() ? `# ${article.title}\n\n${body}` : body
+  return { kind: 'markdown', body: article.title?.trim() ? `# ${article.title}\n\n${body}` : body }
+}
 
-  return new Response(md, {
+function toResponse(result: MarkdownResult, requestUrl: string, cacheControl: string): Response {
+  if (result.kind === 'notFound') return new Response('Not Found', { status: 404 })
+  if (result.kind === 'redirect') {
+    return Response.redirect(new URL(result.target, requestUrl), 308)
+  }
+
+  return new Response(result.body, {
     headers: {
       'content-type': 'text/markdown; charset=utf-8',
       'cache-control': cacheControl,

--- a/apps/kb/src/proxy.ts
+++ b/apps/kb/src/proxy.ts
@@ -1,4 +1,10 @@
-// apps/kb/proxy.ts
+// apps/kb/src/proxy.ts
+//
+// MUST live under `src/`: Next resolves the proxy at `src/proxy.ts` whenever the
+// app uses a `src` directory, and silently registers nothing when the file sits
+// at the package root. It lived at the root from #517/#535 until 2026-07-28, so
+// none of this ever ran — `.md` URLs fell through to the HTML article page and
+// foreign hosts were served normally. `apps/web/src/proxy.ts` is the precedent.
 
 import { type NextRequest, NextResponse } from 'next/server'
 

--- a/packages/ui/src/components/kb/search/kb-search-dialog.tsx
+++ b/packages/ui/src/components/kb/search/kb-search-dialog.tsx
@@ -51,7 +51,13 @@ export function KBSearchDialog({
       try {
         const [{ default: MiniSearch }, res] = await Promise.all([
           import('minisearch'),
-          fetch(searchOrigin, { credentials: 'omit' }),
+          // `searchOrigin` is always a same-origin relative path, and an INTERNAL
+          // KB's `search.json` is gated on the caller's capabilities — so the
+          // session cookie has to ride along or the request 404s and the dialog
+          // never populates. `same-origin` rather than `include`: if this ever
+          // takes an absolute URL (custom domains), it must fail closed rather
+          // than start sending the session cookie cross-origin.
+          fetch(searchOrigin, { credentials: 'same-origin' }),
         ])
         if (!res.ok || cancelled) return
         const docs = (await res.json()) as KBSearchDoc[]


### PR DESCRIPTION
Three fixes on the `apps/kb` satellite, all found while running the verification pass plan 34 (#1366) never got. None is a leak — two of the three were failing closed, which is why nobody noticed.

## 1. The search dialog never sent its session cookie

`kb-search-dialog.tsx` fetched `search.json` with `credentials: 'omit'`. For an INTERNAL knowledge base that request arrived unauthenticated, 404'd, and the failure was swallowed — the dialog spun forever with no results. Internal-KB search has been broken for every user.

Uses `same-origin`, not `include`: `searchOrigin` is always the relative path `/<orgSlug>/<kbSlug>/search.json`, so the request is same-origin by construction, and `same-origin` fails closed if that prop ever becomes an absolute URL rather than sending the session cookie cross-origin.

This was deliberately held until the per-KB access gate landed in #1366 — sending credentials beforehand would have handed an ungated surface a one-click UI.

## 2. `apps/kb`'s proxy has never run

`apps/kb/proxy.ts` sat at the package root while the app lives under `apps/kb/src/`. Next resolves the proxy at `src/proxy.ts` whenever an app uses a `src` directory and silently registers nothing otherwise. `middleware-manifest.json` was `{"middleware":{}}`. `apps/web/src/proxy.ts` is the correct precedent.

Two consequences, both fail-closed:

- **`.md` article URLs were dead.** Never rewritten onto `/md/...`, so they fell through to the HTML article page with `.md` as part of the slug and rendered a 200 "Not found" page.
- **Foreign hosts were served normally** instead of being rewritten to the `/_custom/<host>` stub, so the controlled 404 for unshipped custom domains never happened.

## 3. The markdown route's `'use cache'` boundary was wrong in both directions

Moving the proxy alone would have turned `.md` from wrong-content-200 into a 500, so this had to land with it.

- **Return value** — `renderPublic` returned a `Response`, which cannot be serialized into a cache entry.
- **Argument** — it also took the whole `Request`, so the cache key varied per URL; the entry could never have been reused even had it serialized.

It now takes no `Request` and returns a serializable `MarkdownResult` descriptor, with `Response` construction moved outside the cache scope.

## Verification

Driven against the kb dev server:

| Check | Before | After |
| --- | --- | --- |
| PUBLIC `.md` | 200 `text/html`, 64 KB, "Not found" | 200 `text/markdown`, real content |
| HTML article page | 78,670 B | 78,670 B — unchanged |
| Foreign `Host:` header | 307 landing redirect | 404 |
| INTERNAL/DRAFT `.md` | 404 | 404 |
| `search.json` / `/r/<id>` | 200 / 308 + slug path | unchanged |

The proxy's matcher is broad (`/((?!api|_next/static|_next/image|favicon.ico).*)`) and is now live for the first time, so static serving was checked explicitly: four **real** `_next/static` chunk URLs pulled from the rendered page all return 200 with correct content-type and full byte counts.

`pnpm --filter @auxx/kb typecheck` is unchanged at exactly 2 errors, both pre-existing and documented (`api/revalidate/route.ts:23`, `lib/auth.ts:14`).

## Reviewer note — one thing to check before merging

The custom-domain arm is now live. Dev has 31 KBs, 1 with a `customDomain` set and **0 verified**, so `trusted-apps.ts:42`'s `customDomain && customDomainVerifiedAt` gate never fires here. **If prod has a *verified* custom domain, that arm will now rewrite it to `/_custom/<host>` and 404 the KB.** That is the one way this change can regress something real, and dev cannot answer it.

Also worth knowing: this corrects plan 34 §9 row G, which says custom domains fail closed *because* `proxy.ts:25-32` 404s every non-`KB_ROOT_HOST` host. That code never executed. The conclusion held; the mechanism did not.

## Not included

The verification pass that prompted this is still incomplete, and the blocker is data rather than effort: the dev DB has **no INTERNAL knowledge base with `kind = 'standard'`** — all 27 standard KBs are PUBLIC. So `canViewKB` has never actually been exercised, and every "INTERNAL → 404" result above is produced by the `kind`/DRAFT filters rather than by the gate #1366 shipped. Seeding one is the prerequisite for the restricted-member pass.