### PR TITLE
feat(notifications): count approvals on the bell and stop double-surfacing them

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/general/_components/notification-preferences.tsx
+++ b/apps/web/src/app/(protected)/app/settings/general/_components/notification-preferences.tsx
@@ -5,7 +5,8 @@ import { FieldPanel } from '~/components/global/forms/field-panel'
 import { SettingsFieldRow } from '~/components/settings/settings-field-row'
 
 /**
- * Notification preferences: sound toggles + dispatch (field-service) email prefs
+ * Notification preferences: sound toggles + the email prefs a recipient controls —
+ * workflow approvals (plans/today/05-bell-and-feed-dedupe.md §7) and dispatch
  * (plans/dispatch/19-client-notifications.md §4.9). Renders only these chosen keys — the
  * rest of the NOTIFICATION scope (emailDigest, future keys) stays UI-less by design. Values
  * are stored per-user via the settings service.
@@ -20,6 +21,10 @@ export function NotificationPreferences(): JSX.Element {
       <FieldPanel className='mt-1 p-0' resizeId='notification-preferences' defaultLabelWidth={220}>
         <SettingsFieldRow settingKey='notification.sound.newMessage' title='New message sound' />
         <SettingsFieldRow settingKey='notification.sound.bell' title='Notification sound' />
+        <SettingsFieldRow
+          settingKey='notification.approval.email'
+          title='Approval request emails'
+        />
         <SettingsFieldRow
           settingKey='notification.dispatch.email'
           title='Dispatch reschedule/cancel/reassign emails'

--- a/apps/web/src/components/global/notifications/hooks/use-approvals-count.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-approvals-count.ts
@@ -1,0 +1,48 @@
+// apps/web/src/components/global/notifications/hooks/use-approvals-count.ts
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
+
+export interface ApprovalsCount {
+  /** Pending workflow confirmations + fresh suggestion bundles. */
+  count: number
+  /**
+   * At least one of the two queries failed. A badge that fails to load and a
+   * badge that is zero look identical, so callers must render the difference
+   * rather than falling through to "you're all caught up"
+   * (plans/today/05-bell-and-feed-dedupe.md §10).
+   */
+  isError: boolean
+}
+
+/**
+ * The Approvals count, shared by the sidebar bell and the panel's tab badge so
+ * the two cannot drift.
+ *
+ * The suggestion filters MUST match `ApprovalsTab`'s list query — including its
+ * `FeatureKey.todayInbox` gate. A badge that counts a different set than the tab
+ * renders is a bug, not a tuning knob.
+ *
+ * No `enabled` gate: the bell needs this with the panel closed. Both queries
+ * refetch on window focus, which is what keeps the badge honest if the realtime
+ * ping is ever missed.
+ */
+export function useApprovalsCount(): ApprovalsCount {
+  const { hasAccess } = useFeatureFlags()
+  const suggestionsEnabled = hasAccess(FeatureKey.todayInbox)
+
+  const confirmations = api.approval.getPendingCount.useQuery(undefined, {
+    refetchOnWindowFocus: true,
+  })
+  const suggestions = api.approvals.count.useQuery(
+    { filters: { ownerScope: 'mine_and_unassigned', status: ['FRESH'] } },
+    { enabled: suggestionsEnabled, refetchOnWindowFocus: true }
+  )
+
+  return {
+    count: (confirmations.data ?? 0) + (suggestions.data?.count ?? 0),
+    isError: !!confirmations.error || (suggestionsEnabled && !!suggestions.error),
+  }
+}

--- a/apps/web/src/components/global/notifications/hooks/use-notification-subscription.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-notification-subscription.ts
@@ -38,7 +38,42 @@ export function useNotificationSubscription(userId: string) {
           void utils.notification.getUnreadCount.invalidate()
           void utils.notification.getNotifications.invalidate()
           break
+        // A workflow approval wants this user — new request or reminder re-ping.
+        case 'approval': {
+          const orgId = (payload as { organizationId?: string } | undefined)?.organizationId
+          if (orgId && organizationId && orgId !== organizationId) break
+          invalidateApprovals(utils)
+          // Pulse explicitly: a reminder re-pings a request that is already
+          // counted, so the bell's count-went-up pulse would never fire.
+          useNotificationPanelStore.getState().pulseBell()
+          if (bellSoundRef.current) playNotificationSound(NEW_MESSAGE_SOUND)
+          break
+        }
+        // Decided, cancelled, timed out, or cleaned up with its run — the count
+        // drops without a refocus. No pulse, no sound.
+        case 'approval:resolved':
+          invalidateApprovals(utils)
+          break
       }
     },
   })
+}
+
+/**
+ * Refetch both approval counts and both approval lists.
+ *
+ * Invalidate, never `setData`: a reminder re-publishes `approval` for a request
+ * that is already counted, and `getPendingCount` filters on `expiresAt > now`
+ * plus the run still being RUNNING/WAITING — predicates the client cannot
+ * reproduce. An optimistic increment would inflate the badge on every reminder
+ * tick and drift from the server (plans/today/05-bell-and-feed-dedupe.md §5).
+ *
+ * The lists are cheap to invalidate here: react-query only refetches active
+ * queries, so they no-op unless the Approvals tab is actually open.
+ */
+function invalidateApprovals(utils: ReturnType<typeof api.useUtils>) {
+  void utils.approval.getPendingCount.invalidate()
+  void utils.approval.getPendingRequests.invalidate()
+  void utils.approvals.count.invalidate()
+  void utils.approvals.list.invalidate()
 }

--- a/apps/web/src/components/global/notifications/notification-panel-store.ts
+++ b/apps/web/src/components/global/notifications/notification-panel-store.ts
@@ -14,6 +14,14 @@ interface NotificationPanelState {
   mode: NotificationPanelMode
   /** Approval whose row should be scrolled to and flashed once the tab renders. */
   highlightApprovalId?: string
+  /**
+   * Monotonic counter the sidebar bell watches to flash itself.
+   *
+   * The bell's own pulse keys off the count going *up*, which a reminder never
+   * does — it re-pings a request that is already counted. This is the explicit
+   * channel for "flash even though the number did not move".
+   */
+  bellPulse: number
   toggle: () => void
   close: () => void
   setWidth: (width: number) => void
@@ -21,6 +29,8 @@ interface NotificationPanelState {
   /** Opens the panel on the Approvals tab, optionally highlighting one entry. */
   openApprovals: (highlightApprovalId?: string) => void
   clearHighlight: () => void
+  /** Flash the sidebar bell once. */
+  pulseBell: () => void
 }
 
 export const useNotificationPanelStore = create<NotificationPanelState>()(
@@ -30,6 +40,7 @@ export const useNotificationPanelStore = create<NotificationPanelState>()(
       width: 420,
       mode: 'all',
       highlightApprovalId: undefined,
+      bellPulse: 0,
       toggle: () => set((state) => ({ open: !state.open })),
       close: () => set({ open: false }),
       setWidth: (width) => set({ width }),
@@ -37,6 +48,7 @@ export const useNotificationPanelStore = create<NotificationPanelState>()(
       openApprovals: (highlightApprovalId) =>
         set({ open: true, mode: 'approvals', highlightApprovalId }),
       clearHighlight: () => set({ highlightApprovalId: undefined }),
+      pulseBell: () => set((state) => ({ bellPulse: state.bellPulse + 1 })),
     }),
     {
       name: 'auxx:notifications:panel',

--- a/apps/web/src/components/global/notifications/notification-panel.tsx
+++ b/apps/web/src/components/global/notifications/notification-panel.tsx
@@ -32,6 +32,7 @@ import { useRouter } from 'next/navigation'
 import { useRef, useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
+import { useApprovalsCount } from './hooks/use-approvals-count'
 import { useNotifications } from './hooks/use-notifications'
 import { type NotificationPanelMode, useNotificationPanelStore } from './notification-panel-store'
 import { ApprovalsTab } from './ui/approvals-tab'
@@ -108,17 +109,10 @@ export function NotificationPanel() {
     refetchOnWindowFocus: true,
   })
 
-  // Tab badge = pending workflow confirmations + fresh suggestion bundles. Both
-  // run while the panel is open so the badge is right before the tab is clicked.
-  const { data: pendingConfirmationCount } = api.approval.getPendingCount.useQuery(undefined, {
-    enabled: open,
-    refetchOnWindowFocus: true,
-  })
-  const { data: freshSuggestionData } = api.approvals.count.useQuery(
-    { filters: { ownerScope: 'mine_and_unassigned', status: ['FRESH'] } },
-    { enabled: open, refetchOnWindowFocus: true }
-  )
-  const approvalsCount = (pendingConfirmationCount ?? 0) + (freshSuggestionData?.count ?? 0)
+  // Tab badge = pending workflow confirmations + fresh suggestion bundles. Shared
+  // with the sidebar bell through one hook (and so one cache entry) — two copies
+  // of these queries could drift apart on filters or gating.
+  const { count: approvalsCount } = useApprovalsCount()
 
   const invalidate = () => {
     void utils.notification.getNotifications.invalidate()

--- a/apps/web/src/components/global/notifications/notification-trigger.tsx
+++ b/apps/web/src/components/global/notifications/notification-trigger.tsx
@@ -11,28 +11,48 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Bell } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { api } from '~/trpc/react'
+import { useApprovalsCount } from './hooks/use-approvals-count'
 import { useNotificationPanelStore } from './notification-panel-store'
+
+/** How long the badge stays flashed after a bump. */
+const PULSE_MS = 500
 
 export function NotificationTrigger() {
   const toggle = useNotificationPanelStore((state) => state.toggle)
   const open = useNotificationPanelStore((state) => state.open)
+  const bellPulse = useNotificationPanelStore((state) => state.bellPulse)
   const { isMobile, setOpenMobile } = useSidebar()
-  const { data } = api.notification.getUnreadCount.useQuery(undefined, {
+  const unread = api.notification.getUnreadCount.useQuery(undefined, {
     refetchOnWindowFocus: true,
   })
-  const unreadCount = data?.count ?? 0
-  const previousUnreadCount = useRef(unreadCount)
+  // Approvals are state-derived (`ApprovalRequest`), not row-derived — nothing
+  // pending mints a notification, so the two sources never double-count the same
+  // item (plans/today/05-bell-and-feed-dedupe.md §1).
+  const approvals = useApprovalsCount()
+  const total = (unread.data?.count ?? 0) + approvals.count
+  // A badge that failed to load and a badge that is zero look identical. Say so.
+  const isError = !!unread.error || approvals.isError
+  const previousTotal = useRef(total)
   const [badgePulse, setBadgePulse] = useState(false)
 
   useEffect(() => {
-    if (unreadCount > previousUnreadCount.current) {
+    if (total > previousTotal.current) {
       setBadgePulse(true)
-      const timer = setTimeout(() => setBadgePulse(false), 500)
-      previousUnreadCount.current = unreadCount
+      const timer = setTimeout(() => setBadgePulse(false), PULSE_MS)
+      previousTotal.current = total
       return () => clearTimeout(timer)
     }
-    previousUnreadCount.current = unreadCount
-  }, [unreadCount])
+    previousTotal.current = total
+  }, [total])
+
+  // Explicit pulses (an approval reminder re-pinging a request that is already
+  // counted) never move the total, so they get their own channel.
+  useEffect(() => {
+    if (!bellPulse) return
+    setBadgePulse(true)
+    const timer = setTimeout(() => setBadgePulse(false), PULSE_MS)
+    return () => clearTimeout(timer)
+  }, [bellPulse])
 
   return (
     <SidebarMenuItem>
@@ -47,13 +67,19 @@ export function NotificationTrigger() {
         <Bell />
         <span>Notifications</span>
       </SidebarMenuButton>
-      {unreadCount > 0 ? (
+      {isError ? (
+        <SidebarMenuBadge
+          className='text-destructive'
+          title="Couldn't load notification counts — open the panel to retry">
+          !
+        </SidebarMenuBadge>
+      ) : total > 0 ? (
         <SidebarMenuBadge
           className={cn(
             'transition-colors',
             badgePulse && 'animate-in zoom-in-50 text-blue-500 duration-300'
           )}>
-          {unreadCount > 99 ? '99+' : unreadCount}
+          {total > 99 ? '99+' : total}
         </SidebarMenuBadge>
       ) : null}
     </SidebarMenuItem>

--- a/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
@@ -57,8 +57,10 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
   const clearHighlight = useNotificationPanelStore((state) => state.clearHighlight)
   const [flashedId, setFlashedId] = useState<string>()
 
-  // Refetch on focus so a confirmation answered elsewhere (email link, another
-  // tab) does not linger here — neither source publishes realtime in v1.
+  // Confirmations publish `approval` / `approval:resolved` on the viewer's user
+  // room (`useNotificationSubscription`), which invalidates this query. Focus
+  // refetch stays as the backstop for a missed frame and for suggestions, which
+  // are still refetch-driven pending the `ownerScope` call (plan §6).
   const confirmations = api.approval.getPendingRequests.useQuery(undefined, {
     refetchOnWindowFocus: true,
   })
@@ -87,8 +89,9 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
   )
 
   /**
-   * No realtime for v1 — a resolved row refetches both lists and both badge
-   * counts, so the tab badge cannot drift from what the sections show.
+   * The acting client refetches both lists and both badge counts itself rather
+   * than waiting for its own `approval:resolved` frame, so the tab badge cannot
+   * drift from what the sections show.
    */
   const onResolved = () => {
     void utils.approval.getPendingRequests.invalidate()

--- a/apps/web/src/components/workflow/nodes/core/human/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/human/panel.tsx
@@ -199,10 +199,12 @@ export const HumanConfirmationNodePanel = memo<HumanConfirmationNodePanelProps>(
               </VarEditorField>
             </Field>
             {/* Notification Methods */}
-            <Field title='Notification Methods' description='How to notify assignees'>
+            <Field
+              title='Notification Methods'
+              description='How to alert assignees. Either way the request appears in their Approvals tab and counts on their bell.'>
               <div className='space-y-2'>
                 <div className='flex items-center justify-between'>
-                  <Label htmlFor='in-app'>In-app notification</Label>
+                  <Label htmlFor='in-app'>Live alert (bell pulse and sound)</Label>
                   <Switch
                     id='in-app'
                     size='sm'
@@ -221,7 +223,7 @@ export const HumanConfirmationNodePanel = memo<HumanConfirmationNodePanelProps>(
                   />
                 </div>
                 <div className='flex items-center justify-between'>
-                  <Label htmlFor='email'>Email notification</Label>
+                  <Label htmlFor='email'>Email (if the recipient allows it)</Label>
                   <Switch
                     id='email'
                     size='sm'

--- a/apps/web/src/components/workflow/nodes/core/human/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/human/types.ts
@@ -22,9 +22,13 @@ export interface HumanConfirmationNodeData extends BaseNodeData {
   // Notification settings
   /** Methods to notify assignees about the confirmation request */
   notification_methods: {
-    /** Send in-app notifications */
+    /**
+     * Ping assignees live (bell pulse + sound). Not "surface this in-app" — the
+     * Approvals tab and bell badge read `ApprovalRequest` directly, so turning
+     * this off hides nothing (plans/today/05-bell-and-feed-dedupe.md §2).
+     */
     in_app: boolean
-    /** Send email notifications */
+    /** Send email notifications, if the recipient's own email preference allows. */
     email: boolean
   }
 

--- a/packages/lib/src/jobs/workflow/approval-reminder-job.ts
+++ b/packages/lib/src/jobs/workflow/approval-reminder-job.ts
@@ -5,7 +5,10 @@ import { database as db, schema } from '@auxx/database'
 import { ApprovalStatus } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray } from 'drizzle-orm'
-import { NotificationService } from '../../notifications/notification-service'
+import {
+  approvalEmailEnabled,
+  getApprovalAssigneeUserIds,
+} from '../../workflow-engine/services/approval-recipients'
 import { enqueueEmailJob } from '../email'
 import type { JobContext } from '../types'
 
@@ -99,13 +102,12 @@ async function sendReminderNotifications(
   approvalRequest: any,
   reminderNumber: number
 ): Promise<void> {
-  const notificationService = new NotificationService(db)
   // Get all assignee user IDs
-  const allUserIds = await getAllAssigneeUserIds(
-    approvalRequest.assigneeUsers,
-    approvalRequest.assigneeGroups,
-    approvalRequest.organizationId
-  )
+  const allUserIds = await getApprovalAssigneeUserIds(db, {
+    assigneeUsers: approvalRequest.assigneeUsers,
+    assigneeGroups: approvalRequest.assigneeGroups,
+    organizationId: approvalRequest.organizationId,
+  })
   // Calculate time remaining
   const timeRemaining = approvalRequest.expiresAt.getTime() - Date.now()
   const hoursRemaining = Math.floor(timeRemaining / (1000 * 60 * 60))
@@ -120,34 +122,25 @@ async function sendReminderNotifications(
   } else {
     timeRemainingStr = `${minutesRemaining} minute${minutesRemaining > 1 ? 's' : ''}`
   }
-  // Send in-app notifications
-  for (const userId of allUserIds) {
-    try {
-      await notificationService.sendNotification({
-        type: 'WORKFLOW_APPROVAL_REMINDER' as any,
-        userId,
-        targetType: 'APPROVAL',
-        targetIds: { approvalRequestId: approvalRequest.id },
-        message: `Reminder #${reminderNumber}: Approval still pending for "${approvalRequest.workflow.name}" - ${timeRemainingStr} remaining`,
-        organizationId: approvalRequest.organizationId,
-        metadata: {
-          kind: 'WORKFLOW_APPROVAL_REMINDER',
-          workflowName: approvalRequest.workflow.name,
-          workflowId: approvalRequest.workflowId,
-          workflowRunId: approvalRequest.workflowRunId,
-          nodeId: approvalRequest.nodeId,
-          reminderNumber,
-          timeRemaining: timeRemainingStr,
-          expiresAt: approvalRequest.expiresAt.toISOString(),
-        },
-      })
-    } catch (error) {
-      logger.warn('Failed to send in-app reminder notification', {
-        userId,
-        approvalRequestId: approvalRequest.id,
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
+  // Live re-ping, not a notification row. The request is still pending in
+  // `ApprovalRequest` and therefore already counted on the bell — a reminder row
+  // would push a single approval to 2, and the next one to 3
+  // (plans/today/05-bell-and-feed-dedupe.md §1).
+  try {
+    // Lazy import — see the realtime barrel cycle note in the confirmation node.
+    const { getRealtimeService, publishApprovalPing } = await import('../../realtime')
+    await publishApprovalPing(getRealtimeService(), allUserIds, {
+      approvalRequestId: approvalRequest.id,
+      organizationId: approvalRequest.organizationId,
+      workflowName: approvalRequest.workflow?.name ?? approvalRequest.workflowName,
+      expiresAt: approvalRequest.expiresAt?.toISOString() ?? null,
+      reminderNumber,
+    })
+  } catch (error) {
+    logger.warn('Failed to ping approval assignees', {
+      approvalRequestId: approvalRequest.id,
+      error: error instanceof Error ? error.message : String(error),
+    })
   }
   // Send email reminders
   await sendEmailReminders(approvalRequest, allUserIds, reminderNumber, timeRemainingStr)
@@ -174,6 +167,10 @@ async function sendEmailReminders(
   const approvalUrl = `${WEBAPP_URL}/workflows/${approvalRequest.workflowId}/approval/${approvalRequest.id}`
   for (const user of users) {
     try {
+      // Same recipient gate as the request email — one key for both, so nobody
+      // can end up receiving reminders for an email they never got (§7).
+      if (!(await approvalEmailEnabled(approvalRequest.organizationId, user.id))) continue
+
       await enqueueEmailJob('approval-reminder', {
         recipient: { email: user.email, name: user.name || 'User' },
         workflowName: approvalRequest.workflow.name,
@@ -194,29 +191,6 @@ async function sendEmailReminders(
       })
     }
   }
-}
-/**
- * Get all users assigned to an approval (direct + groups)
- */
-async function getAllAssigneeUserIds(
-  directUsers: string[],
-  groupIds: string[],
-  organizationId: string
-): Promise<string[]> {
-  const userIds = new Set(directUsers)
-  if (groupIds.length > 0) {
-    // Note: This complex many-to-many relationship query would require joins
-    // For now, using a simpler approach - this may need refinement based on schema
-    const groupMembers = await db
-      .select({
-        userId: schema.OrganizationMember.userId,
-      })
-      .from(schema.OrganizationMember)
-      .where(eq(schema.OrganizationMember.organizationId, organizationId))
-    // TODO: Add proper group filtering when schema structure is clarified
-    groupMembers.forEach((member) => userIds.add(member.userId))
-  }
-  return Array.from(userIds)
 }
 /**
  * Cancel all reminder jobs for an approval

--- a/packages/lib/src/jobs/workflow/approval-timeout-job.ts
+++ b/packages/lib/src/jobs/workflow/approval-timeout-job.ts
@@ -6,6 +6,7 @@ import type { ApprovalRequestEntity as ApprovalRequest } from '@auxx/database/ty
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { publisher } from '../../events/publisher'
+import { getApprovalAssigneeUserIds } from '../../workflow-engine/services/approval-recipients'
 import { WorkflowExecutionService } from '../../workflows/workflow-execution-service'
 import type { JobContext } from '../types'
 
@@ -89,22 +90,27 @@ async function sendTimeoutNotifications(approvalRequest: ApprovalRequest): Promi
     // Import notification service dynamically to avoid circular dependencies
     const { NotificationService } = await import('../../notifications/notification-service')
     const notificationService = new NotificationService(db)
-    // Get all assignee user IDs
-    const userIds = new Set<string>((approvalRequest.assigneeUsers ?? []) as string[])
-    // Add users from groups
-    if (approvalRequest.assigneeGroups && approvalRequest.assigneeGroups.length > 0) {
-      // Note: This complex many-to-many relationship query would require joins
-      // For now, using a simpler approach - this may need refinement based on schema
-      const groupMembers = await db
-        .select({
-          userId: schema.OrganizationMember.userId,
-        })
-        .from(schema.OrganizationMember)
-        .where(eq(schema.OrganizationMember.organizationId, approvalRequest.organizationId))
-      // TODO: Add proper group filtering when schema structure is clarified
-      groupMembers.forEach((member) => userIds.add(member.userId))
+    const userIds = await getApprovalAssigneeUserIds(db, {
+      assigneeUsers: (approvalRequest.assigneeUsers ?? []) as string[],
+      assigneeGroups: (approvalRequest.assigneeGroups ?? []) as string[],
+      organizationId: approvalRequest.organizationId,
+    })
+    // Drop the expired request out of everyone's bell count without a refresh.
+    try {
+      const { getRealtimeService, publishApprovalResolved } = await import('../../realtime')
+      await publishApprovalResolved(getRealtimeService(), userIds, {
+        approvalRequestId: approvalRequest.id,
+        organizationId: approvalRequest.organizationId,
+      })
+    } catch (error) {
+      logger.warn('Failed to publish approval:resolved on timeout', {
+        approvalRequestId: approvalRequest.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
     }
-    // Send notifications
+    // `WORKFLOW_APPROVAL_COMPLETED` is the one approval notification that is not
+    // a duplicate: the request is gone from the Approvals tab by the time this
+    // mints, so without the row nothing says it resolved.
     for (const userId of userIds) {
       try {
         await notificationService.sendNotification({

--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -478,3 +478,42 @@ export interface TableViewChangedEvent {
   event: 'tableView:changed'
   data: { tableId?: string; kind: 'created' | 'updated' | 'defaultChanged' | 'deleted' }
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// Workflow approval events (per-assignee user channel)
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * A workflow approval wants this assignee's attention — a freshly created
+ * request, or a reminder re-ping on one that is still undecided
+ * (plans/today/05-bell-and-feed-dedupe.md §5). Replaces the
+ * `WORKFLOW_APPROVAL_REQUIRED` / `_REMINDER` notification rows, which
+ * double-counted against a bell badge derived from `ApprovalRequest`.
+ *
+ * Refresh signal only: the client **invalidates** the two approval counts
+ * rather than incrementing them. A reminder re-pings a request that is already
+ * counted, and the server's pending predicate (unexpired + run still
+ * RUNNING/WAITING) is not reproducible client-side.
+ */
+export interface ApprovalPingEvent {
+  event: 'approval'
+  data: {
+    approvalRequestId: string
+    organizationId: string
+    workflowName?: string | null
+    /** ISO string. */
+    expiresAt?: string | null
+    /** Set only when the ping is a reminder rather than the first request. */
+    reminderNumber?: number
+  }
+}
+
+/**
+ * A workflow approval left the pending set — decided, cancelled, timed out, or
+ * cleaned up with its workflow run. The client invalidates the approval counts
+ * and lists; no sound, no pulse.
+ */
+export interface ApprovalResolvedEvent {
+  event: 'approval:resolved'
+  data: { approvalRequestId: string; organizationId: string }
+}

--- a/packages/lib/src/realtime/index.ts
+++ b/packages/lib/src/realtime/index.ts
@@ -17,6 +17,8 @@ export type {
   AgentUpdatedEvent,
   AiStatus,
   AiValueMetadata,
+  ApprovalPingEvent,
+  ApprovalResolvedEvent,
   DataConnectorSyncEvent,
   DataExportJobEvent,
   EvalCaseChangedEvent,
@@ -51,6 +53,8 @@ export { shapeMailEventForLens } from './mail-event-shaping'
 export {
   flushMailBatch,
   publishAgentUpdated,
+  publishApprovalPing,
+  publishApprovalResolved,
   publishCapabilitiesChanged,
   publishCountsChanged,
   publishDataConnectorSync,

--- a/packages/lib/src/realtime/publish-helpers.ts
+++ b/packages/lib/src/realtime/publish-helpers.ts
@@ -4,6 +4,8 @@ import { database, schema } from '@auxx/database'
 import { and, eq, isNotNull } from 'drizzle-orm'
 import { type Lens, maxLens } from '../permissions/visibility/lens'
 import type {
+  ApprovalPingEvent,
+  ApprovalResolvedEvent,
   DataConnectorSyncEvent,
   DataExportJobEvent,
   FieldValueUpdateEntry,
@@ -540,6 +542,53 @@ export async function flushMailBatch(
     }
   }
   await Promise.allSettled(promises)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Workflow approval helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Ping each assignee's private room that a workflow approval wants them
+ * (plans/today/05-bell-and-feed-dedupe.md §5). Used for both the first request
+ * and every reminder — the client invalidates its counts either way, so a
+ * re-ping on an already-counted request is harmless.
+ *
+ * Confirmations are assignee-scoped, so this fans out over `rooms.user` rather
+ * than the org room; no unassigned audience exists for them.
+ *
+ * Fire-and-forget: errors are swallowed so a Pusher hiccup never fails the
+ * workflow run or the reminder job.
+ */
+export async function publishApprovalPing(
+  realtimeService: RealtimeService,
+  userIds: string[],
+  data: ApprovalPingEvent['data']
+) {
+  if (userIds.length === 0) return
+  await Promise.allSettled(
+    userIds.map((userId) =>
+      realtimeService.publish(rooms.user(userId), 'approval', data).catch(() => {})
+    )
+  )
+}
+
+/**
+ * Tell each assignee that an approval left the pending set — decided,
+ * cancelled, timed out, or cleaned up with its run. Same fan-out and the same
+ * fire-and-forget contract as {@link publishApprovalPing}.
+ */
+export async function publishApprovalResolved(
+  realtimeService: RealtimeService,
+  userIds: string[],
+  data: ApprovalResolvedEvent['data']
+) {
+  if (userIds.length === 0) return
+  await Promise.allSettled(
+    userIds.map((userId) =>
+      realtimeService.publish(rooms.user(userId), 'approval:resolved', data).catch(() => {})
+    )
+  )
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -165,6 +165,15 @@ export const SETTINGS_CATALOG = {
     defaultValue: true,
     description: 'Play a sound for notification-bell alerts (mentions, approvals)',
   },
+  'notification.approval.email': {
+    scope: 'NOTIFICATION',
+    access: 'user',
+    fieldType: 'CHECKBOX',
+    options: { variant: 'switch' },
+    defaultValue: true,
+    description:
+      'Email me when a workflow needs my approval, and when it is about to expire (it still appears in Approvals either way)',
+  },
   'notification.dispatch.email': {
     scope: 'NOTIFICATION',
     access: 'user',

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-notify.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-notify.test.ts
@@ -1,0 +1,177 @@
+// packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-notify.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkflowNode } from '../../../core/types'
+
+const mocks = vi.hoisted(() => ({
+  publishApprovalPing: vi.fn(async () => undefined),
+  enqueueEmailJob: vi.fn(async () => undefined),
+  getUserSetting: vi.fn(async () => true as unknown),
+  sendNotification: vi.fn(async () => ({ id: 'n1' })),
+}))
+
+vi.mock('@auxx/config/server', () => ({ WEBAPP_URL: 'http://localhost:3000' }))
+vi.mock('@auxx/database', () => ({
+  database: {},
+  schema: {
+    ApprovalRequest: {},
+    WorkflowRun: {},
+    User: { id: {}, email: {}, name: {}, userType: {} },
+    OrganizationMember: { userId: {}, organizationId: {} },
+    EntityGroupMember: { groupInstanceId: {}, memberType: {}, memberRefId: {} },
+  },
+}))
+vi.mock('../../../../cache/workflow-app-queries', () => ({
+  getCachedWorkflowApp: vi.fn(async () => ({ name: 'Human in the loop' })),
+}))
+vi.mock('../../../../events/publisher', () => ({
+  publisher: { publishLater: vi.fn(async () => undefined) },
+}))
+vi.mock('../../../../jobs/email', () => ({ enqueueEmailJob: mocks.enqueueEmailJob }))
+vi.mock('../../../../jobs/queues', () => ({
+  Queues: { workflowDelayQueue: 'workflowDelayQueue' },
+  getQueue: vi.fn(() => ({ add: vi.fn(async () => undefined) })),
+}))
+vi.mock('../../../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishApprovalPing: mocks.publishApprovalPing,
+  publishApprovalResolved: vi.fn(async () => undefined),
+}))
+vi.mock('../../../../settings', () => ({ getUserSetting: mocks.getUserSetting }))
+vi.mock('../../../../notifications/notification-service', () => ({
+  NotificationService: class {
+    sendNotification = mocks.sendNotification
+  },
+}))
+vi.mock('../../../services/approval-response-service', () => ({
+  ApprovalResponseService: class {
+    generateApprovalToken = vi.fn(async () => 'tok')
+  },
+}))
+
+const { HumanConfirmationProcessor } = await import('../human-confirmation')
+
+const USERS = [{ id: 'u1', email: 'approver@example.com', name: 'Approver' }]
+
+/**
+ * The assignee resolution ends in an `innerJoin`; the email fan-out doesn't.
+ * That's enough to tell the two selects apart and hand each the right shape.
+ */
+function makeMockDb() {
+  const db: any = {
+    insert: () => ({
+      values: (value: any) => ({ returning: async () => [{ ...value, id: 'ar1' }] }),
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+    select: () => {
+      let joined = false
+      const builder: any = {
+        from: () => builder,
+        innerJoin: () => {
+          joined = true
+          return builder
+        },
+        where: async () => (joined ? USERS.map((user) => ({ id: user.id })) : USERS),
+      }
+      return builder
+    },
+  }
+  return db
+}
+
+function makeNode(methods: { in_app: boolean; email: boolean }): WorkflowNode {
+  return {
+    nodeId: 'human-confirmation-1',
+    name: 'Human Review',
+    data: {
+      type: 'human-confirmation',
+      message: 'Ship it?',
+      assignees: { actorIds: ['user:u1'] },
+      notification_methods: methods,
+      timeout: { duration: 24, unit: 'hours' },
+      require_login: true,
+    },
+  } as unknown as WorkflowNode
+}
+
+function makeContextManager(db: any) {
+  return {
+    getContext: () => ({
+      organizationId: 'org1',
+      workflowId: 'wf1',
+      executionId: 'run1',
+      userId: 'u1',
+      db,
+    }),
+    getOptions: () => ({ workflowRunId: 'run1', workflowAppId: 'app1' }),
+    isDebugMode: () => false,
+    log: vi.fn(),
+    getAllVariables: () => ({}),
+    serialize: () => ({}),
+  } as any
+}
+
+const preprocessed = {
+  inputs: {
+    message: 'Ship it?',
+    assignees: { userIds: ['u1'], groups: [] },
+    expiresAt: new Date(Date.now() + 86_400_000),
+  },
+  metadata: {},
+} as any
+
+const run = (methods: { in_app: boolean; email: boolean }) =>
+  new HumanConfirmationProcessor().executeNode(
+    makeNode(methods),
+    makeContextManager(makeMockDb()),
+    preprocessed
+  )
+
+describe('HumanConfirmationProcessor assignee notification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getUserSetting.mockResolvedValue(true)
+  })
+
+  it('pings assignees over realtime and mints NO notification row', async () => {
+    await run({ in_app: true, email: false })
+
+    expect(mocks.publishApprovalPing).toHaveBeenCalledTimes(1)
+    expect(mocks.publishApprovalPing).toHaveBeenCalledWith(
+      expect.anything(),
+      ['u1'],
+      expect.objectContaining({ approvalRequestId: 'ar1', organizationId: 'org1' })
+    )
+    // The bell counts `unread notifications + pending approvals`. A row for a
+    // still-pending request would make one approval read as 2.
+    expect(mocks.sendNotification).not.toHaveBeenCalled()
+  })
+
+  it('sends no live ping when in_app is off', async () => {
+    await run({ in_app: false, email: false })
+    expect(mocks.publishApprovalPing).not.toHaveBeenCalled()
+    expect(mocks.sendNotification).not.toHaveBeenCalled()
+  })
+
+  it('emails the assignee when the node and the recipient both allow it', async () => {
+    await run({ in_app: false, email: true })
+    expect(mocks.enqueueEmailJob).toHaveBeenCalledTimes(1)
+    expect(mocks.enqueueEmailJob).toHaveBeenCalledWith(
+      'approval-request',
+      expect.objectContaining({ recipient: { email: 'approver@example.com', name: 'Approver' } })
+    )
+  })
+
+  it('skips the email when the recipient turned notification.approval.email off', async () => {
+    mocks.getUserSetting.mockResolvedValue(false)
+    await run({ in_app: false, email: true })
+    expect(mocks.enqueueEmailJob).not.toHaveBeenCalled()
+  })
+
+  it('still emails when the preference was never set', async () => {
+    // `value !== false`, not `value === true` — an untouched preference sends.
+    mocks.getUserSetting.mockResolvedValue(null)
+    await run({ in_app: false, email: true })
+    expect(mocks.enqueueEmailJob).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-test-mode.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/human-confirmation-test-mode.test.ts
@@ -12,6 +12,7 @@ vi.mock('@auxx/database', () => ({
     WorkflowRun: {},
     User: { id: {}, email: {}, name: {}, userType: {} },
     OrganizationMember: { userId: {}, organizationId: {} },
+    EntityGroupMember: { groupInstanceId: {}, memberType: {}, memberRefId: {} },
   },
 }))
 vi.mock('../../../../cache/workflow-app-queries', () => ({
@@ -52,6 +53,7 @@ function makeMockDb() {
     select: () => {
       const builder: any = {
         from: () => builder,
+        innerJoin: () => builder,
         where: async () => [],
       }
       return builder

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/human-confirmation.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/human-confirmation.ts
@@ -4,13 +4,12 @@ import { WEBAPP_URL } from '@auxx/config/server'
 import { type Database, database, schema } from '@auxx/database'
 import { ApprovalStatus } from '@auxx/database/enums'
 import { type ActorId, parseActorId } from '@auxx/types/actor'
-import { and, eq, inArray } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import { v4 as uuidv4 } from 'uuid'
 import { getCachedWorkflowApp } from '../../../cache/workflow-app-queries'
 import { publisher } from '../../../events/publisher'
 import { enqueueEmailJob } from '../../../jobs/email'
 import { getQueue, Queues } from '../../../jobs/queues'
-import { NotificationService } from '../../../notifications/notification-service'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type {
   NodeExecutionResult,
@@ -19,6 +18,10 @@ import type {
   WorkflowNode,
 } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
+import {
+  approvalEmailEnabled,
+  getApprovalAssigneeUserIds,
+} from '../../services/approval-recipients'
 import { ApprovalResponseService } from '../../services/approval-response-service'
 import { BaseNodeProcessor } from '../base-node'
 
@@ -29,7 +32,18 @@ interface HumanConfirmationNodeData {
     actorIds?: string[] // ActorId format: ["user:abc", "group:xyz"]
     variable?: { id: string } // Variable reference (resolved at execution time)
   }
-  // Notification settings
+  /**
+   * Notification settings.
+   *
+   * `in_app` means **"ping me live"**, not "surface this in-app": the Approvals
+   * tab and the bell badge both derive from `ApprovalRequest`, so turning it off
+   * hides nothing — the request still appears and still counts. It suppresses
+   * the realtime pulse/sound alone (plans/today/05-bell-and-feed-dedupe.md §2,
+   * decision 5).
+   *
+   * `email` is the workflow author's half of the email decision; each recipient
+   * holds the other half in `notification.approval.email`. Both must be on.
+   */
   notification_methods: {
     in_app: boolean
     email: boolean
@@ -365,46 +379,34 @@ export class HumanConfirmationProcessor extends BaseNodeProcessor {
     requireLogin: boolean
   ): Promise<void> {
     const db = contextManager.getContext().db ?? database
-    const notificationService = new NotificationService(db)
     // Get all users (direct + from groups)
-    const allUserIds = await this.getAllAssigneeUserIds(
-      db,
-      assignees,
-      approvalRequest.organizationId
-    )
-    // Send in-app notifications
+    const allUserIds = await getApprovalAssigneeUserIds(db, {
+      assigneeUsers: assignees.userIds,
+      assigneeGroups: assignees.groups,
+      organizationId: approvalRequest.organizationId,
+    })
+    // Live ping — deliberately NOT a `Notification` row. The bell badge counts
+    // `unread notifications + pending approvals`, so a row describing a request
+    // that is simultaneously pending in `ApprovalRequest` would make one item
+    // read as 2 (plans/today/05-bell-and-feed-dedupe.md §1).
     if (methods.in_app) {
-      for (const userId of allUserIds) {
-        try {
-          const result = await notificationService.sendNotification({
-            type: 'WORKFLOW_APPROVAL_REQUIRED' as any,
-            userId,
-            targetType: 'APPROVAL',
-            targetIds: { approvalRequestId: approvalRequest.id },
-            message: `Approval required for workflow "${approvalRequest.workflowName}"`,
-            actorId: approvalRequest.createdById,
-            organizationId: approvalRequest.organizationId,
-            metadata: {
-              kind: 'WORKFLOW_APPROVAL_REQUIRED',
-              workflowName: approvalRequest.workflowName,
-              workflowId: approvalRequest.workflowId,
-              workflowRunId: approvalRequest.workflowRunId,
-              nodeId: approvalRequest.nodeId,
-              expiresAt: approvalRequest.expiresAt.toISOString(),
-            },
-          })
-          contextManager.log('INFO', approvalRequest.nodeId, 'Sent approval notification', {
-            userId,
-            notificationId: result.id,
-          })
-        } catch (error) {
-          contextManager.log(
-            'ERROR',
-            approvalRequest.nodeId,
-            `Failed to send in-app notification to user ${userId}`,
-            { error: error instanceof Error ? error.message : String(error) }
-          )
-        }
+      try {
+        // Lazy import — the realtime barrel must not be pulled into the node
+        // module graph statically (see the app-runtime/vitest cycle notes).
+        const { getRealtimeService, publishApprovalPing } = await import('../../../realtime')
+        await publishApprovalPing(getRealtimeService(), allUserIds, {
+          approvalRequestId: approvalRequest.id,
+          organizationId: approvalRequest.organizationId,
+          workflowName: approvalRequest.workflowName,
+          expiresAt: approvalRequest.expiresAt?.toISOString() ?? null,
+        })
+        contextManager.log('INFO', approvalRequest.nodeId, 'Pinged approval assignees', {
+          userCount: allUserIds.length,
+        })
+      } catch (error) {
+        contextManager.log('ERROR', approvalRequest.nodeId, 'Failed to ping approval assignees', {
+          error: error instanceof Error ? error.message : String(error),
+        })
       }
     }
     // Send email notifications
@@ -440,6 +442,10 @@ export class HumanConfirmationProcessor extends BaseNodeProcessor {
 
     for (const user of users) {
       try {
+        // Recipient's half of the email decision — ANDs with the node's
+        // `methods.email` (§7). Unset still sends.
+        if (!(await approvalEmailEnabled(approvalRequest.organizationId, user.id, db))) continue
+
         let approvalUrl = baseUrl
 
         if (!requireLogin) {
@@ -465,30 +471,6 @@ export class HumanConfirmationProcessor extends BaseNodeProcessor {
         )
       }
     }
-  }
-  private async getAllAssigneeUserIds(
-    db: Database,
-    assignees: { userIds: string[]; groups: string[] },
-    organizationId: string
-  ): Promise<string[]> {
-    const allUserIds = new Set(assignees.userIds)
-    if (assignees.groups.length > 0) {
-      // TODO: Filter by group when group membership schema is finalized
-      const groupMembers = await db
-        .select({ userId: schema.OrganizationMember.userId })
-        .from(schema.OrganizationMember)
-        .where(eq(schema.OrganizationMember.organizationId, organizationId))
-      groupMembers.forEach((member) => allUserIds.add(member.userId))
-    }
-    if (allUserIds.size === 0) return []
-
-    // Exclude agent (synthetic) users — approval notifications must never
-    // fan out to an agent's sentinel email.
-    const humans = await db
-      .select({ id: schema.User.id })
-      .from(schema.User)
-      .where(and(inArray(schema.User.id, Array.from(allUserIds)), eq(schema.User.userType, 'USER')))
-    return humans.map((u) => u.id)
   }
   private async scheduleTimeout(
     approvalRequestId: string,

--- a/packages/lib/src/workflow-engine/services/approval-query-service.ts
+++ b/packages/lib/src/workflow-engine/services/approval-query-service.ts
@@ -20,6 +20,7 @@ import {
 } from 'drizzle-orm'
 import { getCachedUserGroupIds } from '../../cache'
 import { NotificationService } from '../../notifications/notification-service'
+import { getApprovalAssigneeUserIds } from './approval-recipients'
 
 const logger = createScopedLogger('approval-query-service')
 /**
@@ -420,6 +421,8 @@ export class ApprovalQueryService {
       .select({
         id: schema.ApprovalRequest.id,
         organizationId: schema.ApprovalRequest.organizationId,
+        assigneeUsers: schema.ApprovalRequest.assigneeUsers,
+        assigneeGroups: schema.ApprovalRequest.assigneeGroups,
       })
       .from(schema.ApprovalRequest)
       .where(
@@ -472,6 +475,29 @@ export class ApprovalQueryService {
               : String(notificationError),
         })
         // Don't throw - approval cleanup succeeded, notification cleanup is best effort
+      }
+
+      // Drop the cleaned-up requests out of every assignee's bell count live.
+      try {
+        // Lazy import — keeps the realtime barrel out of this module's static graph.
+        const { getRealtimeService, publishApprovalResolved } = await import('../../realtime')
+        const realtimeService = getRealtimeService()
+        for (const approval of approvalsToCleanup) {
+          const userIds = await getApprovalAssigneeUserIds(this.db, {
+            assigneeUsers: approval.assigneeUsers ?? [],
+            assigneeGroups: approval.assigneeGroups ?? [],
+            organizationId: approval.organizationId,
+          })
+          await publishApprovalResolved(realtimeService, userIds, {
+            approvalRequestId: approval.id,
+            organizationId: approval.organizationId,
+          })
+        }
+      } catch (publishError) {
+        logger.warn('Failed to publish approval:resolved during run cleanup', {
+          workflowRunId,
+          error: publishError instanceof Error ? publishError.message : String(publishError),
+        })
       }
     }
     if (updated.length > 0) {

--- a/packages/lib/src/workflow-engine/services/approval-recipients.ts
+++ b/packages/lib/src/workflow-engine/services/approval-recipients.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/workflow-engine/services/approval-recipients.ts
+
+import { type Database, database, schema } from '@auxx/database'
+import { MemberType } from '@auxx/database/enums'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getUserSetting } from '../../settings'
+
+/** The assignee columns of an `ApprovalRequest`, plus the org they live in. */
+export interface ApprovalAudience {
+  assigneeUsers: string[]
+  assigneeGroups: string[]
+  organizationId: string
+}
+
+/**
+ * Resolve an approval's assignees to the human users who should be told about
+ * it — the directly named users plus the members of every assigned group.
+ *
+ * This is the single implementation. It previously existed three times over
+ * (the confirmation node, the reminder job, and inline in the timeout job), and
+ * all three resolved groups by selecting **every** `OrganizationMember` in the
+ * org — so one group-assigned approval notified the entire workspace. Groups
+ * resolve through `EntityGroupMember` here, the same table the approvals list
+ * already trusts.
+ *
+ * Agent (synthetic) users are dropped: an approval must never fan out to an
+ * agent's sentinel email or user room.
+ */
+export async function getApprovalAssigneeUserIds(
+  db: Database,
+  audience: ApprovalAudience
+): Promise<string[]> {
+  const userIds = new Set(audience.assigneeUsers ?? [])
+
+  if (audience.assigneeGroups?.length) {
+    const groupMembers = await db
+      .select({ memberRefId: schema.EntityGroupMember.memberRefId })
+      .from(schema.EntityGroupMember)
+      .where(
+        and(
+          inArray(schema.EntityGroupMember.groupInstanceId, audience.assigneeGroups),
+          eq(schema.EntityGroupMember.memberType, MemberType.user)
+        )
+      )
+    for (const member of groupMembers) userIds.add(member.memberRefId)
+  }
+
+  if (userIds.size === 0) return []
+
+  const humans = await db
+    .select({ id: schema.User.id })
+    .from(schema.User)
+    .innerJoin(schema.OrganizationMember, eq(schema.OrganizationMember.userId, schema.User.id))
+    .where(
+      and(
+        inArray(schema.User.id, Array.from(userIds)),
+        eq(schema.User.userType, 'USER'),
+        eq(schema.OrganizationMember.organizationId, audience.organizationId)
+      )
+    )
+  return humans.map((user) => user.id)
+}
+
+/**
+ * `notification.approval.email` gate — the recipient's own say over approval
+ * request and reminder emails. Default true, so only an explicit `false` skips;
+ * an untouched preference still sends.
+ *
+ * ANDs with the node's `notification_methods.email`: the node switch is the
+ * workflow author saying "this is worth emailing about", this is the recipient
+ * saying "I want email". Both must be on.
+ */
+export async function approvalEmailEnabled(
+  organizationId: string,
+  userId: string,
+  db?: Database
+): Promise<boolean> {
+  const value = await getUserSetting({
+    organizationId,
+    userId,
+    key: 'notification.approval.email',
+    db: db ?? database,
+  })
+  return value !== false
+}

--- a/packages/lib/src/workflow-engine/services/approval-response-service.ts
+++ b/packages/lib/src/workflow-engine/services/approval-response-service.ts
@@ -7,6 +7,7 @@ import { publisher } from '../../events/publisher'
 import { getQueue, Queues } from '../../jobs/queues'
 import { NotificationService } from '../../notifications/notification-service'
 import { WorkflowExecutionService } from '../../workflows/workflow-execution-service'
+import { type ApprovalAudience, getApprovalAssigneeUserIds } from './approval-recipients'
 
 const logger = createScopedLogger('approval-response-service')
 interface ApprovalResponseResult {
@@ -30,6 +31,7 @@ export class ApprovalResponseService {
     ipAddress?: string
   ): Promise<ApprovalResponseResult> {
     let organizationId: string | undefined
+    let audience: ApprovalAudience | undefined
     // Start transaction
     const result = await this.db.transaction(async (tx) => {
       // Get the approval request with responses using relational query API
@@ -43,6 +45,11 @@ export class ApprovalResponseService {
         throw new Error('Approval request not found')
       }
       organizationId = approvalRequest.organizationId
+      audience = {
+        assigneeUsers: approvalRequest.assigneeUsers ?? [],
+        assigneeGroups: approvalRequest.assigneeGroups ?? [],
+        organizationId: approvalRequest.organizationId,
+      }
       const responses = approvalRequest.responses
       if (approvalRequest.status !== 'pending') {
         return {
@@ -124,7 +131,10 @@ export class ApprovalResponseService {
         nextPath,
       }
     })
-    // Clean up approval notifications after successful response (non-critical)
+    // Clean up approval notifications after successful response (non-critical).
+    // Near-dead now that REQUIRED/REMINDER no longer mint — only legacy rows are
+    // left to retract. Deliberately NOT widened to `WORKFLOW_APPROVAL_COMPLETED`,
+    // which is supposed to persist (plans/today/05-bell-and-feed-dedupe.md §8.4).
     if (result.success) {
       try {
         const notificationService = new NotificationService(this.db)
@@ -139,8 +149,35 @@ export class ApprovalResponseService {
           error: error instanceof Error ? error.message : String(error),
         })
       }
+      await this.publishResolved(approvalRequestId, audience)
     }
     return result
+  }
+
+  /**
+   * Drop a no-longer-pending approval out of every assignee's bell count without
+   * waiting for a refocus. Best-effort — a failed publish only costs the other
+   * assignees a stale badge until their next refetch, never the decision itself.
+   */
+  private async publishResolved(
+    approvalRequestId: string,
+    audience: ApprovalAudience | undefined
+  ): Promise<void> {
+    if (!audience) return
+    try {
+      const userIds = await getApprovalAssigneeUserIds(this.db, audience)
+      // Lazy import — keeps the realtime barrel out of this module's static graph.
+      const { getRealtimeService, publishApprovalResolved } = await import('../../realtime')
+      await publishApprovalResolved(getRealtimeService(), userIds, {
+        approvalRequestId,
+        organizationId: audience.organizationId,
+      })
+    } catch (error) {
+      logger.warn('Failed to publish approval:resolved', {
+        approvalRequestId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
   }
   /**
    * Process approval via email link (with token validation)
@@ -236,6 +273,12 @@ export class ApprovalResponseService {
         error: error instanceof Error ? error.message : String(error),
       })
     }
+
+    await this.publishResolved(approvalRequestId, {
+      assigneeUsers: approvalRequest.assigneeUsers ?? [],
+      assigneeGroups: approvalRequest.assigneeGroups ?? [],
+      organizationId: approvalRequest.organizationId,
+    })
 
     logger.info('Approval request cancelled', {
       approvalRequestId,


### PR DESCRIPTION
Implements `plans/today/05-bell-and-feed-dedupe.md` phases 1–3 and 5. Closes the bell-badge and realtime items left open in that plan's `README.md` §5.

## The constraint

If the bell is `unread notifications + pending approvals`, then no `Notification` row may represent a still-pending approval — or one item counts twice. `WORKFLOW_APPROVAL_REQUIRED` and `_REMINDER` did exactly that: unread rows describing a request simultaneously sitting in `ApprovalRequest` with `status = pending`. A reminder on an undecided request made one approval read as **2**, a second reminder as **3**.

So those two stop minting and become a realtime ping instead. `_COMPLETED` keeps minting — by then the request has left the tab, so the row is the only surface saying it resolved. The pg enum values stay and `approval-notification.tsx` keeps its branches; existing rows still render.

## What changed

**Bell counts approvals** — new `useApprovalsCount` sums `approval.getPendingCount` + `approvals.count` with no `enabled` gate, and carries the tab's `FeatureKey.todayInbox` gate so the badge counts exactly what the tab renders. Consumed by both the trigger and the panel, so the two badges share one cache entry and cannot drift; the panel's inline copies are deleted.

**Realtime for confirmations** — new `approval` / `approval:resolved` events on the assignee's user room. `approval:resolved` fires from all four resolve paths (decide, cancel, timeout, run cleanup).

Counts are **invalidated, never optimistically incremented**. A reminder re-pings a request that is already counted, and `getPendingCount` filters on `expiresAt > now` plus `WorkflowRun.status IN ('RUNNING','WAITING')` — predicates the client cannot reproduce. The trade is one roundtrip before the badge pulses.

Reminders needed their own pulse channel (`bellPulse` on the panel store): the bell's pulse keys off the count going *up*, which a re-ping never does.

**Recipient email opt-out** — `notification.approval.email` gates both the request email and the reminder email, ANDing with the node's `methods.email` (author says "worth emailing about", recipient says "I want email"). `value !== false`, so an untouched preference still sends.

**`in_app` redefined** — it already did not mean what it said: the Approvals tab reads `ApprovalRequest` directly, so turning it off never hid the request. It now controls the live ping alone, and the node-settings copy says so.

## Pre-existing bugs fixed along the way

- **Group-assigned approvals spammed the entire workspace.** `getAllAssigneeUserIds` existed three times over (`human-confirmation.ts`, `approval-reminder-job.ts`, inline in `approval-timeout-job.ts`), and all three resolved groups by selecting *every* `OrganizationMember` in the org under a `TODO: Add proper group filtering`. One implementation now resolves through `EntityGroupMember`, filters to human users, and checks org membership.
- **The reminder email had no preference check at all** — it was unconditional. Now gated.

## Not included

Phase 4 (suggestion realtime) is deliberately out. Unassigned bundles have no user-room audience, so it needs `rooms.orgEvents`, which forces the `ownerScope` product question — and unassigned is not an edge case: `learned-extraction-job.ts:105-109` mints null-owner bundles on purpose whenever a thread has no *human* assignee. Suggestions stay refetch-driven; `refetchOnWindowFocus` keeps the badge honest. Also skipped per the plan: removing the enum values, and wiring `_COMPLETED` into the decide path (§8.1).

## Testing

- New `human-confirmation-notify.test.ts` — asserts the realtime ping fires with the resolved assignee list and that **zero** notification rows are minted, plus all three email-gate combinations (node on + pref off → no email; pref unset → sends; node off → no email).
- `human-confirmation-test-mode.test.ts` updated for the new assignee query shape. 11 tests green across both files.
- `tsc` clean for every touched file in `packages/lib` and `apps/web`.