### PR TITLE
feat(kb): make site access one choice instead of two disagreeing ones

### DIFF
--- a/apps/web/src/components/kb/ui/editor/kb-publish-cluster.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-publish-cluster.tsx
@@ -118,6 +118,11 @@ export function KBPublishCluster({ kbId }: KBPublishClusterProps) {
   const isPublished = kb?.publishStatus === 'PUBLISHED'
   const isUnlisted = kb?.publishStatus === 'UNLISTED'
   const isLive = isPublished || isUnlisted
+  // `visibility: INTERNAL` outranks publishStatus for what a reader experiences,
+  // so the Public/Unlisted shortcuts below would be lying if we offered them —
+  // "Make public" on an INTERNAL KB writes publishStatus and leaves it internal.
+  // Access is edited in one place (the publish dialog) when internal.
+  const isInternal = kb?.visibility === 'INTERNAL'
 
   return (
     <>
@@ -138,7 +143,7 @@ export function KBPublishCluster({ kbId }: KBPublishClusterProps) {
               className='gap-2 border-r-0'
               onClick={() => setIsMenuOpen((prev) => !prev)}>
               <span className='inline-block size-2 rounded-full bg-emerald-500' />
-              {isUnlisted ? 'Live · Unlisted' : 'Live'}
+              {isInternal ? 'Live · Internal' : isUnlisted ? 'Live · Unlisted' : 'Live'}
             </Button>
             {hasPending && (
               <>
@@ -187,15 +192,16 @@ export function KBPublishCluster({ kbId }: KBPublishClusterProps) {
             <DropdownMenuItem onClick={() => setIsPublishDialogOpen(true)}>
               <Settings /> Publish settings
             </DropdownMenuItem>
-            {isPublished ? (
-              <DropdownMenuItem onClick={() => handleSwitchVisibility('UNLISTED')}>
-                <Lock /> Make unlisted
-              </DropdownMenuItem>
-            ) : (
-              <DropdownMenuItem onClick={() => handleSwitchVisibility('PUBLISHED')}>
-                <Globe /> Make public
-              </DropdownMenuItem>
-            )}
+            {!isInternal &&
+              (isPublished ? (
+                <DropdownMenuItem onClick={() => handleSwitchVisibility('UNLISTED')}>
+                  <Lock /> Make unlisted
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={() => handleSwitchVisibility('PUBLISHED')}>
+                  <Globe /> Make public
+                </DropdownMenuItem>
+              ))}
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleUnpublish} variant='destructive'>
               <Trash2 /> Unpublish site

--- a/apps/web/src/components/kb/ui/preview/kb-site-publish-dialog.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-site-publish-dialog.tsx
@@ -21,7 +21,7 @@ import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { useCopy } from '@auxx/ui/hooks/use-copy'
-import { Check, Copy, ExternalLink, Globe, Link, Lock } from 'lucide-react'
+import { Check, Copy, ExternalLink, Globe, Link, Link2Off, Lock } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { useKbPublicUrl } from '~/components/kb/hooks/use-kb-public-url'
@@ -33,7 +33,33 @@ interface KBSitePublishDialogProps {
   kbId: string
 }
 
-type PublishMode = 'PUBLISHED' | 'UNLISTED'
+/**
+ * One user-facing choice over two stored columns.
+ *
+ * `publishStatus` (is the site live / indexable) and `visibility` (must a
+ * reader sign in) are orthogonal in the schema but answer one question, and
+ * splitting them across two screens let the copy lie — the old "Public" card
+ * claimed "anyone can find and read this" even for an INTERNAL KB.
+ *
+ * `UNLISTED + INTERNAL` is deliberately unreachable: once sign-in is required,
+ * unlisted adds nothing, because a crawler cannot authenticate either way.
+ */
+type AccessMode = 'public' | 'unlisted' | 'internal'
+
+const MODE_WRITES: Record<
+  AccessMode,
+  { status: 'PUBLISHED' | 'UNLISTED'; visibility: 'PUBLIC' | 'INTERNAL' }
+> = {
+  public: { status: 'PUBLISHED', visibility: 'PUBLIC' },
+  unlisted: { status: 'UNLISTED', visibility: 'PUBLIC' },
+  internal: { status: 'PUBLISHED', visibility: 'INTERNAL' },
+}
+
+function modeOf(publishStatus?: string | null, visibility?: string | null): AccessMode {
+  // Visibility wins: an INTERNAL KB is internal whatever its publish status.
+  if (visibility === 'INTERNAL') return 'internal'
+  return publishStatus === 'UNLISTED' ? 'unlisted' : 'public'
+}
 
 export function KBSitePublishDialog({ open, onOpenChange, kbId }: KBSitePublishDialogProps) {
   const utils = api.useUtils()
@@ -43,15 +69,13 @@ export function KBSitePublishDialog({ open, onOpenChange, kbId }: KBSitePublishD
     { enabled: open }
   )
 
-  const [mode, setMode] = useState<PublishMode>('PUBLISHED')
+  const [mode, setMode] = useState<AccessMode>('public')
   const { copied: copiedLink, copy: copyLink } = useCopy({
     toastMessage: 'Public URL copied to clipboard',
   })
 
   useEffect(() => {
-    if (open && kb) {
-      setMode(kb.publishStatus === 'UNLISTED' ? 'UNLISTED' : 'PUBLISHED')
-    }
+    if (open && kb) setMode(modeOf(kb.publishStatus, kb.visibility))
   }, [open, kb])
 
   const publishMutation = api.kb.publishSite.useMutation()
@@ -60,15 +84,22 @@ export function KBSitePublishDialog({ open, onOpenChange, kbId }: KBSitePublishD
   const pendingSections = draftedSections((kb?.draftSettings ?? null) as never)
   const pendingCount = pendingSections.size
 
+  // The draft flush happens server-side only when going live from DRAFT, so the
+  // warning below must not promise it on an already-live site.
+  const willFlushDraft = kb?.publishStatus === 'DRAFT'
+
+  const MODE_TOAST: Record<AccessMode, string> = {
+    public: 'Knowledge base is now public',
+    unlisted: 'Knowledge base set to unlisted',
+    internal: 'Knowledge base set to internal',
+  }
+
   const handleConfirm = async () => {
     try {
-      await publishMutation.mutateAsync({ id: kbId, status: mode })
+      await publishMutation.mutateAsync({ id: kbId, ...MODE_WRITES[mode] })
       utils.kb.byId.invalidate({ id: kbId })
       utils.kb.list.invalidate()
-      toastSuccess({
-        title:
-          mode === 'PUBLISHED' ? 'Knowledge base is now public' : 'Knowledge base set to unlisted',
-      })
+      toastSuccess({ title: MODE_TOAST[mode] })
       onOpenChange(false)
     } catch (error) {
       toastError({
@@ -90,9 +121,10 @@ export function KBSitePublishDialog({ open, onOpenChange, kbId }: KBSitePublishD
         <DialogHeader>
           <DialogTitle>Publish knowledge base</DialogTitle>
           <DialogDescription>
-            {publishedCount === 1
-              ? '1 article will be visible at the public URL.'
-              : `${publishedCount} articles will be visible at the public URL.`}
+            {publishedCount === 1 ? '1 article' : `${publishedCount} articles`}{' '}
+            {mode === 'internal'
+              ? 'will be visible to signed-in members of your organization.'
+              : 'will be visible at the public URL.'}
           </DialogDescription>
         </DialogHeader>
 
@@ -132,7 +164,7 @@ export function KBSitePublishDialog({ open, onOpenChange, kbId }: KBSitePublishD
             </InputGroup>
           )}
 
-          {pendingCount > 0 && (
+          {pendingCount > 0 && willFlushDraft && (
             <p className='text-xs text-amber-700 dark:text-amber-400'>
               Publishing will also apply{' '}
               {pendingCount === 1
@@ -142,20 +174,27 @@ export function KBSitePublishDialog({ open, onOpenChange, kbId }: KBSitePublishD
             </p>
           )}
 
-          <RadioGroup value={mode} onValueChange={(v) => setMode(v as PublishMode)}>
+          <RadioGroup value={mode} onValueChange={(v) => setMode(v as AccessMode)}>
             <RadioGroupItemCard
-              value='PUBLISHED'
+              value='public'
               id='kb-publish-public'
               icon={<Globe />}
               label='Public'
               description='Anyone can find and read this knowledge base. Search engines may index it.'
             />
             <RadioGroupItemCard
-              value='UNLISTED'
+              value='unlisted'
               id='kb-publish-unlisted'
-              icon={<Lock />}
+              icon={<Link2Off />}
               label='Unlisted'
               description="Accessible by direct link only. Search engines won't index it."
+            />
+            <RadioGroupItemCard
+              value='internal'
+              id='kb-publish-internal'
+              icon={<Lock />}
+              label='Internal'
+              description='Visitors must sign in and be a member of your organization. Never indexed.'
             />
           </RadioGroup>
         </div>

--- a/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
@@ -1,131 +1,117 @@
 // apps/web/src/components/kb/ui/settings/general/identity-section.tsx
 'use client'
 
-import { FieldType } from '@auxx/database/enums'
-import { Form, FormField } from '@auxx/ui/components/form'
+import { mergeDraftOverLive } from '@auxx/lib/kb/client'
+import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
-import { z } from 'zod'
-import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { Pencil } from 'lucide-react'
+import { useState } from 'react'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
 import { useKnowledgeBaseMutations } from '../../../hooks/use-knowledge-base-mutations'
 import type { KnowledgeBase } from '../../../store/knowledge-base-store'
-import { registerSettingsSubmit } from '../settings-submit-registry'
+import {
+  KnowledgeBaseDialog,
+  type KnowledgeBaseFormValues,
+} from '../../dialogs/kb-knowledge-base-dialog'
 
-const identitySchema = z.object({
-  slug: z
-    .string()
-    .min(1, 'Slug is required')
-    .regex(/^[a-z0-9-]+$/, 'Slug can only contain lowercase letters, numbers, and hyphens'),
-  customDomain: z.string().nullish(),
-  visibility: z.enum(['PUBLIC', 'INTERNAL']).default('PUBLIC'),
-})
-
-type IdentityFormValues = z.infer<typeof identitySchema>
-
-const VISIBILITY_OPTIONS = [
-  { label: 'Public', value: 'PUBLIC' },
-  { label: 'Internal — sign-in required', value: 'INTERNAL' },
-]
+/** Mirrors the publish dialog's three-way access choice. Display only. */
+const ACCESS_LABEL = {
+  public: 'Public — anyone can read it',
+  unlisted: 'Unlisted — direct link only',
+  internal: 'Internal — sign-in required',
+} as const
 
 interface IdentitySectionProps {
   knowledgeBaseId: string
   knowledgeBase: KnowledgeBase
 }
 
-function buildDefaults(kb: KnowledgeBase): IdentityFormValues {
-  return {
-    slug: kb.slug,
-    customDomain: kb.customDomain || '',
-    visibility: (kb.visibility as IdentityFormValues['visibility']) ?? 'PUBLIC',
-  }
-}
-
+/**
+ * Name and slug.
+ *
+ * Unlike every other settings section this one does NOT autosave into the draft
+ * envelope: `slug` is the live public URL and renaming it has a known
+ * cache-busting hazard, so it is read-only here and changed deliberately
+ * through the existing edit dialog rather than by a debounce. `name` IS
+ * draftable and rides along in that same dialog — the split write is the one
+ * `knowledge-base-card.tsx` already established.
+ *
+ * Access is shown read-only. `publishStatus` and `visibility` are one user
+ * choice and are edited together in `KBSitePublishDialog`; duplicating an
+ * editor here would let the two screens disagree, which is the bug that
+ * motivated merging them.
+ */
 export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySectionProps) {
-  const { updateKnowledgeBase, isUpdating } = useKnowledgeBaseMutations()
+  const { updateKnowledgeBase, updateDraftSettings, isUpdating, isUpdatingDraft } =
+    useKnowledgeBaseMutations()
+  const [editOpen, setEditOpen] = useState(false)
 
-  const form = useForm<IdentityFormValues>({
-    resolver: standardSchemaResolver(identitySchema),
-    defaultValues: buildDefaults(knowledgeBase),
-  })
+  const accessMode: keyof typeof ACCESS_LABEL =
+    knowledgeBase.visibility === 'INTERNAL'
+      ? 'internal'
+      : knowledgeBase.publishStatus === 'UNLISTED'
+        ? 'unlisted'
+        : 'public'
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: only re-hydrate on KB switch
-  useEffect(() => {
-    form.reset(buildDefaults(knowledgeBase))
-  }, [knowledgeBase.id, form])
+  // Sibling sections all read through the draft, so a staged name shows here too.
+  const merged = mergeDraftOverLive(knowledgeBase as Record<string, unknown>) as KnowledgeBase
 
-  const onSubmit = async (data: IdentityFormValues) => {
-    await updateKnowledgeBase(knowledgeBaseId, {
-      slug: data.slug,
-      visibility: data.visibility,
-    })
+  const handleEditSubmit = async (values: KnowledgeBaseFormValues) => {
+    // Same split as `knowledge-base-card.tsx`: slug is live, name is drafted.
+    if (values.slug !== knowledgeBase.slug) {
+      await updateKnowledgeBase(knowledgeBaseId, { slug: values.slug })
+    }
+    if (values.name !== merged.name) {
+      await updateDraftSettings(knowledgeBaseId, { name: values.name })
+    }
+    setEditOpen(false)
   }
-
-  // Register with the global Save button — only triggers a submit if the form
-  // is currently dirty so we don't fire spurious requests for the live API.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: form.handleSubmit / form.formState are stable enough for this side effect
-  useEffect(() => {
-    return registerSettingsSubmit(`${knowledgeBaseId}:identity`, async () => {
-      if (!form.formState.isDirty) return
-      await form.handleSubmit(onSubmit)()
-    })
-  }, [knowledgeBaseId])
 
   return (
     <Section title='Identity' description='URL and access for this knowledge base.'>
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)}>
-          <FieldPanel orientation='responsive' className='p-0' resizeId='kb-settings'>
-            <FormField
-              control={form.control}
-              name='slug'
-              render={({ field, fieldState }) => (
-                <FieldPanelRow
-                  title='URL slug'
-                  description='Used in the URL of your knowledge base.'
-                  type={BaseType.STRING}
-                  showIcon
-                  isRequired
-                  validationError={fieldState.error?.message}>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
-                    value={field.value}
-                    onChange={(v) => field.onChange(v ?? '')}
-                    placeholder='my-knowledge-base'
-                    disabled={isUpdating}
-                  />
-                </FieldPanelRow>
-              )}
-            />
+      <FieldPanel orientation='responsive' className='p-0' resizeId='kb-settings'>
+        <FieldPanelRow
+          title='URL slug'
+          description='Used in the URL of your knowledge base. Changing it breaks existing links.'
+          type={BaseType.STRING}
+          showIcon>
+          <div className='flex min-h-8 w-full items-center justify-between gap-2'>
+            <span className='truncate font-mono text-muted-foreground text-sm'>
+              /{knowledgeBase.slug}
+            </span>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => setEditOpen(true)}
+              disabled={isUpdating || isUpdatingDraft}
+              aria-label='Edit name and slug'>
+              <Pencil />
+            </Button>
+          </div>
+        </FieldPanelRow>
 
-            <FormField
-              control={form.control}
-              name='visibility'
-              render={({ field, fieldState }) => (
-                <FieldPanelRow
-                  title='Visibility'
-                  description='Public knowledge bases are accessible to anyone with the link. Internal knowledge bases require visitors to sign in and be a member of your organization.'
-                  type={BaseType.ENUM}
-                  showIcon
-                  validationError={fieldState.error?.message}>
-                  <FieldInputAdapter
-                    fieldType={FieldType.SINGLE_SELECT}
-                    fieldOptions={{ options: VISIBILITY_OPTIONS }}
-                    value={field.value ?? 'PUBLIC'}
-                    onChange={(v) => field.onChange((v as string[])[0] ?? 'PUBLIC')}
-                    placeholder='Public'
-                    disabled={isUpdating}
-                    triggerProps={{ className: 'ps-0 pe-1 w-full' }}
-                  />
-                </FieldPanelRow>
-              )}
-            />
-          </FieldPanel>
-        </form>
-      </Form>
+        <FieldPanelRow
+          title='Access'
+          description='Changed from the Publish menu, which sets who can see the site in one place.'
+          type={BaseType.ENUM}
+          showIcon>
+          <span className='flex min-h-8 items-center text-muted-foreground text-sm'>
+            {ACCESS_LABEL[accessMode]}
+          </span>
+        </FieldPanelRow>
+      </FieldPanel>
+
+      {editOpen && (
+        <KnowledgeBaseDialog
+          open
+          onOpenChange={setEditOpen}
+          onSubmit={handleEditSubmit}
+          initialValues={{ name: merged.name, slug: knowledgeBase.slug }}
+          isSubmitting={isUpdating || isUpdatingDraft}
+          mode='edit'
+        />
+      )}
     </Section>
   )
 }

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -284,14 +284,29 @@ export const knowledgeBaseRouter = createTRPCRouter({
       return result
     }),
 
+  // `status` and `visibility` are one user-facing choice ("who can see this
+  // site"), so they are written together. The draft flush is NOT client
+  // controlled — the service flushes only when the site is going live from
+  // DRAFT, so editing access on a live site cannot ship unrelated presentation
+  // drafts. Pending settings publish through `publishPendingSettings`.
   publishSite: capabilityProcedure
-    .input(z.object({ id: z.string(), status: z.enum(['PUBLISHED', 'UNLISTED']) }))
+    .input(
+      z.object({
+        id: z.string(),
+        status: z.enum(['PUBLISHED', 'UNLISTED']),
+        visibility: z.enum(['PUBLIC', 'INTERNAL']).optional(),
+      })
+    )
     .use(notDemo('publish knowledge base'))
     .mutation(async ({ ctx, input }) => {
       // Full — turning the whole public KB site on (governance, §0.6).
       ctx.capabilities.assertAdminInstance('kb', input.id)
-      const result = await getKBService(ctx).publishKnowledgeBase(input.id, input.status)
+      const result = await getKBService(ctx).publishKnowledgeBase(input.id, input.status, {
+        visibility: input.visibility,
+      })
       void fireKBRevalidate(input.id)
+      // Visibility feeds the agent-prompt KB catalog, same as `update`.
+      await onCacheEvent('kb.updated', { orgId: getUserOrganizationId(ctx.session) })
       return result
     }),
 

--- a/packages/lib/src/kb/kb-service.ts
+++ b/packages/lib/src/kb/kb-service.ts
@@ -40,6 +40,7 @@ import {
 } from './knowledge-base/draft-settings-ops'
 import { getKnowledgeBaseById, listKnowledgeBases } from './knowledge-base/get-knowledge-base'
 import {
+  type PublishKBOptions,
   publishKnowledgeBase,
   unpublishKnowledgeBase,
 } from './knowledge-base/publish-knowledge-base'
@@ -92,8 +93,12 @@ export class KBService {
   deleteKnowledgeBase(id: string) {
     return deleteKnowledgeBase(this.ctx, id)
   }
-  publishKnowledgeBase(id: string, status: 'PUBLISHED' | 'UNLISTED') {
-    return publishKnowledgeBase(this.ctx, id, status)
+  publishKnowledgeBase(
+    id: string,
+    status: 'PUBLISHED' | 'UNLISTED',
+    options: PublishKBOptions = {}
+  ) {
+    return publishKnowledgeBase(this.ctx, id, status, options)
   }
   unpublishKnowledgeBase(id: string) {
     return unpublishKnowledgeBase(this.ctx, id)

--- a/packages/lib/src/kb/knowledge-base/publish-knowledge-base.ts
+++ b/packages/lib/src/kb/knowledge-base/publish-knowledge-base.ts
@@ -9,27 +9,55 @@ import type { KBContext } from '../types'
 
 type KnowledgeBase = typeof schema.KnowledgeBase.$inferSelect
 
+export interface PublishKBOptions {
+  /**
+   * Written in the same atomic update as `status`. The two are one user-facing
+   * choice — "who can see this site" — so a UI that offers both must not have
+   * to make two round trips that can half-fail.
+   */
+  visibility?: 'PUBLIC' | 'INTERNAL'
+  /**
+   * Whether to flush the pending settings draft onto the live row.
+   *
+   * Defaults to "only when the site is going live from DRAFT", because that is
+   * the only case the user is performing a *publish*. Editing access on an
+   * already-live site is not a publish, and flushing there would silently ship
+   * half-finished presentation drafts as a side effect of locking a KB down —
+   * exactly when nobody wants unrelated changes going out. Already-live sites
+   * publish drafts through the dedicated `publishPendingSettings` path, which
+   * the editor's "Publish changes · N" button calls.
+   *
+   * Pass `true` explicitly to force the old unconditional behaviour.
+   */
+  flushDraft?: boolean
+}
+
 /**
- * Toggle KB publish state. Updates publishedAt the first time it goes live;
- * lastPublishedAt every time it transitions to PUBLISHED/UNLISTED. Also
- * flushes any pending settings draft onto the live row in the same write,
- * so "Publish site" ships pending presentation changes too.
+ * Toggle KB publish state, and optionally its visibility, in one write.
+ * Updates publishedAt the first time it goes live; lastPublishedAt every time
+ * it transitions to PUBLISHED/UNLISTED. See {@link PublishKBOptions.flushDraft}
+ * for the draft-flush rule.
  */
 export async function publishKnowledgeBase(
   ctx: KBContext,
   id: string,
-  status: 'PUBLISHED' | 'UNLISTED'
+  status: 'PUBLISHED' | 'UNLISTED',
+  options: PublishKBOptions = {}
 ): Promise<KnowledgeBase> {
   const db = resolveDb(ctx)
   try {
     const kb = await verifyKnowledgeBaseExists(db, ctx.organizationId, id)
-    const draft = kb.draftSettings as KBDraftSettings | null
+    const shouldFlush = options.flushDraft ?? kb.publishStatus === 'DRAFT'
+    const draft = shouldFlush ? (kb.draftSettings as KBDraftSettings | null) : null
     const now = new Date()
     const [updated] = await db
       .update(schema.KnowledgeBase)
       .set({
         ...(draft ?? {}),
-        draftSettings: null,
+        ...(shouldFlush ? { draftSettings: null } : {}),
+        // After the draft spread: `visibility` is a live column and is never a
+        // draftable key, but ordering makes that independent of KBDraftSettings.
+        ...(options.visibility ? { visibility: options.visibility } : {}),
         publishStatus: status,
         publishedAt: kb.publishedAt ?? now,
         lastPublishedAt: now,


### PR DESCRIPTION
## The problem

`publishStatus` (is the site live and indexable) and `visibility` (must a reader sign in) are orthogonal columns that answer one user question, and they were edited on two different screens — the publish dialog and KB Settings → Identity.

The result was copy that lied. The publish dialog's **Public** card promised *"anyone can find and read this knowledge base"* for a KB whose visibility was `INTERNAL`, because the dialog had no idea visibility existed.

## The change

The publish dialog is now the single access control:

| Card | Writes | Means |
| --- | --- | --- |
| Public | `PUBLISHED` + `PUBLIC` | anyone, indexed |
| Unlisted | `UNLISTED` + `PUBLIC` | direct link only |
| Internal | `PUBLISHED` + `INTERNAL` | org members must sign in |

`UNLISTED + INTERNAL` is deliberately unreachable — once sign-in is required, unlisted adds nothing, because a crawler cannot authenticate either way. Both columns are written in one atomic update, so the two halves of one choice cannot half-fail.

## Decoupling the draft flush was a prerequisite

`publishKnowledgeBase` unconditionally flushed the pending settings draft onto the live row:

```ts
.set({ ...(draft ?? {}), draftSettings: null, publishStatus: status, ... })
```

So putting visibility behind that button would have meant **locking a KB down also shipped whatever half-finished branding was staged** — exactly the moment nobody wants unrelated changes going out.

It now flushes only when the site is going live from `DRAFT`, the one case that is genuinely a *publish*. Already-live sites publish drafts through the existing `publishPendingSettings` path that the editor's "Publish changes · N" button already calls, so nothing is stranded. `flushDraft: true` forces the old behaviour if a caller ever needs it.

This also fixes the same latent bug in the publish menu's **Make public** / **Make unlisted** shortcuts, which flushed drafts silently. Those are now hidden when the KB is `INTERNAL` — where they would have written `publishStatus` and left the site internal while toasting "is public" — and the live pill reads `Live · Internal`.

## A real bug fixed along the way

KB Settings → Identity gated its registered save handler on `isDirty` read **only inside a callback**:

```ts
registerSettingsSubmit(`${kbId}:identity`, async () => {
  if (!form.formState.isDirty) return   // always false
  await form.handleSubmit(onSubmit)()
})
```

React Hook Form only subscribes a `formState` key when it is read **during render** — that is what sets `_proxyFormState`. This component never read `formState` in its render body, so `isDirty` was permanently `false`, the handler always returned early, and **changing slug or visibility there saved nothing**. Every other `isDirty` consumer in the repo reads it during render (`plan-form.tsx:44`, `snippet-form.tsx:53`, `custom-field-form.tsx:335`, `settings-form-renderer.tsx:89`); this was the only exception.

Rather than patch the guard, the form is gone:

- **Slug** is read-only with a pencil button opening the existing `KnowledgeBaseDialog` (`mode='edit'`), reusing the live/draft split write already established in `knowledge-base-card.tsx:65-74` — slug live, name drafted. Renaming a slug changes the live public URL and has a known cache-busting hazard, so it should be deliberate rather than debounced.
- **Access** is displayed read-only and points at the publish menu, instead of offering a second editor that can disagree with the first.
- The vestigial `customDomain` field — in the schema and `buildDefaults`, but never rendered and never submitted — is dropped.

The dialog is also gated behind `{editOpen && …}` so it does not mount when closed.

## Verification

`pnpm exec tsc --noEmit` per package, judged by per-file grep against the documented baselines:

- **`packages/lib`** — 2 errors in `publish-knowledge-base.ts`, both pre-existing `noUncheckedIndexedAccess` on `const [updated]`. Verified identical at HEAD (same 2 occurrences, shifted line numbers); one of the two is inside `unpublishKnowledgeBase`, which this PR never touches.
- **`apps/web`** — 2 errors in `routers/kb.ts`, both present verbatim at HEAD (lines 223 and 488; the second shifted to 503 by exactly the 15 lines added here). Zero in `identity-section.tsx`, `kb-site-publish-dialog.tsx`, `kb-publish-cluster.tsx`.

Biome clean on all six files.

## Reviewer notes

- **This changes existing behaviour deliberately**: hitting Save in the publish dialog on an already-live site no longer publishes pending settings drafts. That is the point, but it is worth a second opinion — the alternative is to keep the flush and warn harder.
- **Not browser-verified.** The three-way selection, the `Live · Internal` pill and the read-only Identity rows want an eyeball.
- `visibility` now rides `publishSite`, so that mutation fires `onCacheEvent('kb.updated')` like `update` already did — it feeds the agent-prompt KB catalog.