### PR TITLE
fix(members): bind an invited signup to the invited address

### DIFF
--- a/apps/web/src/app/(auth)/_components/signup-form.tsx
+++ b/apps/web/src/app/(auth)/_components/signup-form.tsx
@@ -20,7 +20,7 @@ import { Turnstile } from '@marsidev/react-turnstile'
 import { Mail, Smartphone } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import type React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -31,6 +31,7 @@ import { GithubIcon, GoogleIcon } from '~/constants/icons'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { useTurnstile } from '~/hooks/use-turnstile'
 import { useEnv } from '~/providers/dehydrated-state-provider'
+import { api } from '~/trpc/react'
 import { GeneralSubmitButton } from './submit-button'
 
 // Schema for email-based signup validation
@@ -80,6 +81,17 @@ export function SignUpForm() {
     defaultValues: { phone: '' },
   })
 
+  // An invite link carries its token here (`/signup?invitationToken=...`). When
+  // it resolves, the account being created is bound to the invited address:
+  // prefilled, locked, and re-checked server-side on submit.
+  const searchParams = useSearchParams()
+  const invitationToken = searchParams.get('invitationToken')
+  const { data: invitation } = api.member.invitationPreview.useQuery(
+    { token: invitationToken ?? '' },
+    { enabled: !!invitationToken, staleTime: 5 * 60 * 1000, retry: false }
+  )
+  const invitedEmail = invitation?.valid ? invitation.email : null
+
   const [step, setStep] = useState<'initial' | 'email' | 'phone' | 'otp'>('initial')
   const [contact, setContact] = useState('') // Email or phone number
   const [password, setPassword] = useState('')
@@ -89,6 +101,16 @@ export function SignUpForm() {
   const [resendTimeout, setResendTimeout] = useState(0)
   const [contentHeight, setContentHeight] = useState<number | undefined>(undefined)
   const contentRef = useRef<HTMLDivElement>(null)
+
+  // Once the invitation resolves, jump straight to the email step with the
+  // invited address in place — phone signup is skipped entirely, since an
+  // account created without an email can never satisfy an email-bound invite.
+  useEffect(() => {
+    if (!invitedEmail) return
+    emailForm.setValue('email', invitedEmail)
+    setContact(invitedEmail)
+    setStep((current) => (current === 'initial' ? 'email' : current))
+  }, [invitedEmail, emailForm])
 
   useEffect(() => {
     if (!contentRef.current) return
@@ -210,11 +232,20 @@ export function SignUpForm() {
 
     try {
       const { data: _data, error } = await client.signUp.email({
-        email: values.email,
+        // The invited address wins over anything in the field — the server
+        // rejects a mismatch, so sending the invited value keeps a stale form
+        // state from producing a confusing error instead of a signup.
+        email: invitedEmail ?? values.email,
         password: values.password,
         name: '',
-        callbackURL: callbackUrl || '/app',
+        // Land an invited signup back on the invitation so it completes, rather
+        // than on an empty /app they have no organization for yet.
+        callbackURL:
+          callbackUrl || (invitationToken ? `/accept-invitation?token=${invitationToken}` : '/app'),
         signupSource,
+        // Not persisted on the user — read by the auth before-hook to bind this
+        // account to the invitation. See auth/server.ts.
+        ...(invitationToken ? { invitationToken } : {}),
         fetchOptions: {
           headers: turnstileToken ? { 'x-captcha-response': turnstileToken } : {},
         },
@@ -260,6 +291,19 @@ export function SignUpForm() {
         <Card variant='translucent' className='border-transparent px-4 py-6'>
           <CardContent className='flex flex-col gap-4 overflow-hidden '>
             {error && <div className='text-sm font-medium text-destructive'>{error}</div>}
+
+            {/* A dead invite link must say so. Falling through to a plain signup
+                looks like it worked, and lands them in their own new org. */}
+            {invitation && !invitation.valid && (
+              <div className='text-sm text-destructive'>
+                {invitation.reason === 'expired'
+                  ? 'This invitation has expired.'
+                  : invitation.reason === 'used'
+                    ? 'This invitation has already been used.'
+                    : 'This invitation link is not valid.'}{' '}
+                Ask an admin to send you a new one.
+              </div>
+            )}
 
             <motion.div
               animate={{ height: contentHeight }}
@@ -346,9 +390,21 @@ export function SignUpForm() {
                       variants={variants}
                       transition={{ duration: 0.3 }}>
                       <div className='pb-4'>
-                        <div className='font-semibold leading-none tracking-tight pb-6 text-xl text-center'>
+                        <div className='font-semibold leading-none tracking-tight pb-2 text-xl text-center'>
                           Create your account
                         </div>
+                        {invitedEmail ? (
+                          <p className='pb-6 text-center text-sm text-white/60'>
+                            You've been invited to join{' '}
+                            <span className='text-white'>
+                              {(invitation?.valid && invitation.organizationName) || 'a team'}
+                            </span>{' '}
+                            as <span className='text-white'>{invitedEmail}</span>. Your account must
+                            use this address.
+                          </p>
+                        ) : (
+                          <div className='pb-4' />
+                        )}
 
                         <Form {...emailForm}>
                           <form
@@ -365,8 +421,9 @@ export function SignUpForm() {
                                       size='lg'
                                       type='email'
                                       placeholder='your@email.com'
-                                      autoFocus
+                                      autoFocus={!invitedEmail}
                                       {...field}
+                                      readOnly={!!invitedEmail}
                                       disabled={isLoading}
                                       onChange={(e) => {
                                         field.onChange(e)
@@ -432,14 +489,18 @@ export function SignUpForm() {
                         .
                       </p>
 
-                      <div className='text-right flex items-center mt-4'>
-                        <Button
-                          variant='link'
-                          className='h-auto p-0 font-normal text-white'
-                          onClick={() => setStep('initial')}>
-                          Back
-                        </Button>
-                      </div>
+                      {/* An invited signup has nowhere to go back TO — the other
+                          methods can't be bound to the invited address. */}
+                      {!invitedEmail && (
+                        <div className='text-right flex items-center mt-4'>
+                          <Button
+                            variant='link'
+                            className='h-auto p-0 font-normal text-white'
+                            onClick={() => setStep('initial')}>
+                            Back
+                          </Button>
+                        </div>
+                      )}
                     </motion.div>
                   )}
 

--- a/apps/web/src/auth/server.ts
+++ b/apps/web/src/auth/server.ts
@@ -146,6 +146,43 @@ export const auth = betterAuth({
   trustedOrigins,
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
+      // An invited signup must create the account under the invited address.
+      // This runs BEFORE the user row exists, which is the point: once the user
+      // is created, `seedNewUserDatabase` has already committed an organization
+      // and a Stripe trial, and a mismatch can only be cleaned up after the
+      // fact. Enforced server-side because locking the form field is cosmetic —
+      // and because letting the invitee redirect the grant to an address of
+      // their choosing would make the link a bearer token for the organization.
+      // `invitationToken` is not a declared `user.additionalFields` entry, so
+      // better-auth strips it before the insert; it exists only for this check.
+      if (ctx.path === '/sign-up/email') {
+        const body = ctx.body as { email?: unknown; invitationToken?: unknown } | undefined
+        const invitationToken =
+          typeof body?.invitationToken === 'string' ? body.invitationToken : null
+        if (invitationToken) {
+          const { getInvitationPreview, normalizeEmail } = await import('@auxx/lib/members')
+          const preview = await getInvitationPreview({ token: invitationToken })
+          if (!preview.valid) {
+            logger.warn('Rejecting signup: invitation token not usable', {
+              reason: preview.reason,
+            })
+            throw new APIError('BAD_REQUEST', {
+              message:
+                preview.reason === 'expired'
+                  ? 'This invitation has expired. Ask an admin to send a new one.'
+                  : 'This invitation link is no longer valid. Ask an admin to send a new one.',
+            })
+          }
+          const submitted = typeof body?.email === 'string' ? normalizeEmail(body.email) : ''
+          if (submitted !== preview.email) {
+            logger.warn('Rejecting signup: email does not match the invitation')
+            throw new APIError('BAD_REQUEST', {
+              message: `This invitation is for ${preview.email}. Create your account with that address, or ask an admin to invite ${submitted || 'your address'} instead.`,
+            })
+          }
+        }
+      }
+
       // `ctx.request` is only populated for HTTP-driven calls. Server-side
       // `auth.api.*` invocations (e.g. the demo create-session route) pass only
       // `headers`, leaving `ctx.request` undefined — so resolve from `ctx.headers`.

--- a/apps/web/src/components/global/notifications/ui/notification-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/notification-row.tsx
@@ -85,12 +85,15 @@ export function NotificationRow({
     onOpen?.()
   }
 
+  // Both lines are `div`, not `p`: they host `NotificationRecord` / `NotificationActor`
+  // chips, which bottom out in `EntityIcon` — a `div`, so not phrasing content. A `p`
+  // cannot contain one, and React fails hydration on it.
   const body = (
     <>
       {/* leading-6 keeps a wrapped message clear of the h-5 chips it may contain. */}
-      <p className='text-sm leading-6'>{children}</p>
+      <div className='text-sm leading-6'>{children}</div>
       {subtitle ? (
-        <p className='mt-0.5 line-clamp-2 text-muted-foreground text-xs'>{subtitle}</p>
+        <div className='mt-0.5 line-clamp-2 text-muted-foreground text-xs'>{subtitle}</div>
       ) : null}
     </>
   )

--- a/apps/web/src/server/api/routers/member.ts
+++ b/apps/web/src/server/api/routers/member.ts
@@ -12,6 +12,7 @@ import {
   findMemberByUser,
   getActiveMemberCount,
   getInvitationLink,
+  getInvitationPreview,
   getMyPendingInvitations,
   getPendingInvitations,
   inviteMember,
@@ -24,7 +25,7 @@ import { TRPCError } from '@trpc/server'
 import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, notDemo, protectedProcedure, publicProcedure } from '~/server/api/trpc'
 
 /**
  * Member router handles organization member and invitation operations
@@ -499,4 +500,13 @@ export const memberRouter = createTRPCRouter({
       )
       return { link }
     }),
+
+  /**
+   * Resolve the invitation a signup link carries, so the signup form can show
+   * who is inviting and bind the email field. Public because the invitee has no
+   * account yet — the token is the credential.
+   */
+  invitationPreview: publicProcedure
+    .input(z.object({ token: z.string().min(1) }))
+    .query(async ({ ctx, input }) => getInvitationPreview({ token: input.token }, ctx.db)),
 })

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1066,6 +1066,12 @@
       "import": "./dist/snippets/index.mjs",
       "default": "./src/snippets/index.ts"
     },
+    "./snippets/snippet-mutations": {
+      "types": "./src/snippets/snippet-mutations.ts",
+      "source": "./src/snippets/snippet-mutations.ts",
+      "import": "./dist/snippets/snippet-mutations.mjs",
+      "default": "./src/snippets/snippet-mutations.ts"
+    },
     "./tags": {
       "types": "./src/tags/index.ts",
       "source": "./src/tags/index.ts",

--- a/packages/lib/src/members/email-match.ts
+++ b/packages/lib/src/members/email-match.ts
@@ -1,0 +1,28 @@
+// packages/lib/src/members/email-match.ts
+
+import { type SQL, sql } from 'drizzle-orm'
+import type { PgColumn } from 'drizzle-orm/pg-core'
+
+/**
+ * Canonical form of an email used as a matching key.
+ *
+ * `User.email` is normalized to lowercase by better-auth on signup, but
+ * `OrganizationInvitation.email` is stored exactly as the inviting admin typed
+ * it. Comparing the two raw makes `Foo@bar.com` and `foo@bar.com` read as two
+ * different people, which strands the invitee: the invite is never matched at
+ * signup, so they silently get a throwaway organization instead of joining.
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+/**
+ * Case-insensitive equality against an email column.
+ *
+ * Deliberately `lower(col) = <normalized>` rather than `ilike`: the value is
+ * user-supplied, and `ilike` would treat any `%` or `_` inside it as a
+ * wildcard — turning a lookup for one address into a pattern match over many.
+ */
+export function emailEquals(column: PgColumn, email: string): SQL {
+  return sql`lower(${column}) = ${normalizeEmail(email)}`
+}

--- a/packages/lib/src/members/index.ts
+++ b/packages/lib/src/members/index.ts
@@ -8,6 +8,7 @@ export {
   type AssignMemberProfileResult,
   assignMemberProfile,
 } from './assign-profile'
+export { emailEquals, normalizeEmail } from './email-match'
 export {
   INVITATION_PROFILE_BOUND_ACTION,
   INVITATION_PROFILE_MISSING_ACTION,
@@ -20,8 +21,10 @@ export {
 export {
   cancelInvitation,
   getInvitationLink,
+  getInvitationPreview,
   getMyPendingInvitations,
   getPendingInvitations,
+  type InvitationPreview,
   inviteMember,
   resendInvitation,
 } from './invitations'

--- a/packages/lib/src/members/invitation-links.ts
+++ b/packages/lib/src/members/invitation-links.ts
@@ -19,3 +19,21 @@ export function generateSignupLink(token: string): string {
   const signupPath = '/signup' // Point to the signup page
   return `${baseUrl.replace(/\/$/, '')}${signupPath}?invitationToken=${token}`
 }
+
+/**
+ * Build the entry-point link for an invitee, based on whether they already have
+ * an account.
+ *
+ * An existing user signs in and accepts directly. A brand-new invitee has no
+ * account to sign in with, so they get the signup link — which carries the
+ * token, letting signup bind the new account to the invited address. Handing a
+ * new invitee the accept link instead strands them on the login page with the
+ * token reduced to an opaque `callbackUrl`, which is how an invitee ends up
+ * signing up under a different address and seeding a throwaway organization.
+ *
+ * Every surface that hands out an invitation link must go through here so the
+ * emailed, resent, and copied links cannot disagree.
+ */
+export function generateInvitationEntryLink(token: string, hasAccount: boolean): string {
+  return hasAccount ? generateAcceptLink(token) : generateSignupLink(token)
+}

--- a/packages/lib/src/members/invitation-profile.test.ts
+++ b/packages/lib/src/members/invitation-profile.test.ts
@@ -21,6 +21,10 @@ vi.mock('./invitation-links', () => ({
   INVITATION_EXPIRATION_HOURS: 72,
   generateAcceptLink: () => 'http://localhost:3000/accept-invitation?token=t',
   generateSignupLink: () => 'http://localhost:3000/signup?token=t',
+  generateInvitationEntryLink: (_token: string, hasAccount: boolean) =>
+    hasAccount
+      ? 'http://localhost:3000/accept-invitation?token=t'
+      : 'http://localhost:3000/signup?token=t',
 }))
 vi.mock('./guards', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./guards')>()),

--- a/packages/lib/src/members/invitations.ts
+++ b/packages/lib/src/members/invitations.ts
@@ -1,20 +1,16 @@
 // packages/lib/src/members/invitations.ts
 
-import { WEBAPP_URL } from '@auxx/config/server'
 import { type Database, database, schema } from '@auxx/database'
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import crypto from 'crypto'
-import { and, asc, eq, gt, ilike } from 'drizzle-orm'
+import { and, asc, eq, gt } from 'drizzle-orm'
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from '../errors'
 import { publisher } from '../events'
 import { enqueueEmailJob } from '../jobs/email'
+import { emailEquals, normalizeEmail } from './email-match'
 import { rankOf, requireMemberManage } from './guards'
-import {
-  generateAcceptLink,
-  generateSignupLink,
-  INVITATION_EXPIRATION_HOURS,
-} from './invitation-links'
+import { generateInvitationEntryLink, INVITATION_EXPIRATION_HOURS } from './invitation-links'
 import {
   type InvitableProfile,
   loadInvitableProfile,
@@ -54,14 +50,13 @@ export async function inviteMember(
   },
   db: Database = database
 ): Promise<{ success: true; message: string; existingUser: boolean }> {
-  const {
-    organizationId,
-    inviterUserId,
-    inviterName,
-    organizationName,
-    email,
-    permissionProfileId,
-  } = params
+  const { organizationId, inviterUserId, inviterName, organizationName, permissionProfileId } =
+    params
+
+  // Store and match on the canonical form. Everything downstream — the invite
+  // row, the duplicate check, the signup-time lookup — keys on this address, so
+  // normalizing once here is what keeps them all agreeing.
+  const email = normalizeEmail(params.email)
 
   logger.info('Attempting to invite member', {
     organizationId,
@@ -117,7 +112,7 @@ export async function inviteMember(
     .from(schema.User)
     .where(
       and(
-        eq(schema.User.email, email),
+        emailEquals(schema.User.email, email),
         eq(schema.User.userType, 'USER') // Only regular users can be invited
       )
     )
@@ -140,7 +135,7 @@ export async function inviteMember(
     .where(
       and(
         eq(schema.OrganizationInvitation.organizationId, organizationId),
-        eq(schema.OrganizationInvitation.email, email),
+        emailEquals(schema.OrganizationInvitation.email, email),
         eq(schema.OrganizationInvitation.status, 'PENDING'),
         gt(schema.OrganizationInvitation.expiresAt, new Date())
       )
@@ -224,10 +219,13 @@ export async function inviteMember(
   const senderName = inviterName || 'A team member'
   const orgName = organizationName || 'our organization'
 
+  // One rule for every surface that hands out this invitation: an existing user
+  // accepts directly, a new invitee is sent to signup so the token can bind the
+  // account they create to the invited address.
+  const invitationLink = generateInvitationEntryLink(token, !!existingUser)
+
   try {
     if (existingUser) {
-      const acceptLink = `${WEBAPP_URL}/accept-invitation?token=${token}` // Ensure URL is defined
-
       publisher.publishLater({
         type: 'membership:created',
         data: {
@@ -249,7 +247,7 @@ export async function inviteMember(
         inviterName: senderName,
         organizationName: orgName,
         role: role.toString(),
-        acceptLink,
+        acceptLink: invitationLink,
         invitedUserName: existingUser.name!,
         source: 'member-service',
         organizationId,
@@ -261,8 +259,6 @@ export async function inviteMember(
       return { success: true, message: 'Invitation sent to existing user.', existingUser: true }
     } else {
       // Send email tailored for new users
-      const signupLink = generateSignupLink(token) // Generate signup link for new users
-
       publisher.publishLater({
         type: 'membership:created',
         data: {
@@ -283,7 +279,7 @@ export async function inviteMember(
         inviterName: senderName,
         organizationName: orgName,
         role: role.toString(),
-        acceptLink: signupLink,
+        acceptLink: invitationLink,
         source: 'member-service',
         organizationId,
       })
@@ -304,7 +300,7 @@ export async function inviteMember(
         .where(
           and(
             eq(schema.OrganizationInvitation.organizationId, organizationId),
-            eq(schema.OrganizationInvitation.email, email),
+            emailEquals(schema.OrganizationInvitation.email, email),
             eq(schema.OrganizationInvitation.token, token)
           )
         )
@@ -473,29 +469,31 @@ export async function resendInvitation(
   }
 
   // 6. Send the email using the NEW token
-  const newAcceptLink = generateAcceptLink(newToken)
   const inviterName = invitation.invitedBy?.name || 'A team member' // Use original inviter's name
   const orgName = invitation.organization.name || 'our organization'
 
-  try {
-    // Check if the invited email corresponds to an existing user to send correct template
-    const existingUser = await db.query.User.findFirst({
-      where: and(
-        eq(schema.User.email, invitation.email),
-        eq(schema.User.userType, 'USER') // Only regular users
-      ),
-      columns: {
-        name: true,
-      },
-    })
+  // Check if the invited email corresponds to an existing user. This picks BOTH
+  // the email template and the link — a resend must not downgrade a new invitee
+  // from the signup link to the accept link.
+  const existingUser = await db.query.User.findFirst({
+    where: and(
+      emailEquals(schema.User.email, invitation.email),
+      eq(schema.User.userType, 'USER') // Only regular users
+    ),
+    columns: {
+      name: true,
+    },
+  })
+  const newInvitationLink = generateInvitationEntryLink(newToken, !!existingUser)
 
+  try {
     if (existingUser) {
       await enqueueEmailJob('join-organization', {
         recipient: { email: invitation.email, name: existingUser.name! },
         inviterName,
         organizationName: orgName,
         role: invitation.role.toString(),
-        acceptLink: newAcceptLink,
+        acceptLink: newInvitationLink,
         invitedUserName: existingUser.name!,
         source: 'member-service',
         organizationId: invitation.organizationId,
@@ -510,7 +508,7 @@ export async function resendInvitation(
         inviterName,
         organizationName: orgName,
         role: invitation.role.toString(),
-        acceptLink: newAcceptLink,
+        acceptLink: newInvitationLink,
         source: 'member-service',
         organizationId: invitation.organizationId,
       })
@@ -562,6 +560,7 @@ export async function getInvitationLink(
       id: true,
       status: true,
       token: true, // Need the token to build the link
+      email: true, // Decides whether the link points at signup or accept
       expiresAt: true,
       organizationId: true,
     },
@@ -592,10 +591,64 @@ export async function getInvitationLink(
     throw new BadRequestError('This invitation has expired.')
   }
 
-  // 4. Construct and return the link
-  const link = generateAcceptLink(invitation.token)
-  logger.info('Invitation link retrieved successfully', { invitationId })
+  // 4. Construct and return the link. A copied link is handed to the same person
+  //    the email would have reached, so it must resolve the same way — an
+  //    unconditional accept link drops a brand-new invitee on the login page.
+  const existingUser = await db.query.User.findFirst({
+    where: and(
+      emailEquals(schema.User.email, invitation.email),
+      eq(schema.User.userType, 'USER') // Only regular users
+    ),
+    columns: { id: true },
+  })
+
+  const link = generateInvitationEntryLink(invitation.token, !!existingUser)
+  logger.info('Invitation link retrieved successfully', {
+    invitationId,
+    hasAccount: !!existingUser,
+  })
   return link
+}
+
+/**
+ * What a signup page may learn about the invitation its link carries.
+ *
+ * `email` is the address the account MUST be created under — the invitation
+ * binds to it, and signup is rejected if the two disagree (§ the invited email
+ * is the whole of the grant; letting it drift turns the link into a bearer
+ * token that anyone it is forwarded to could redeem).
+ */
+export type InvitationPreview =
+  | { valid: true; email: string; organizationName: string | null }
+  | { valid: false; reason: 'not_found' | 'used' | 'expired' }
+
+/**
+ * Resolve an invitation token for an UNAUTHENTICATED signup page.
+ *
+ * The token itself is the credential, so this is deliberately public — but it
+ * returns only what the signup form needs to show who is being invited and to
+ * bind the email field. Never widen this to the profile, role, or seat: those
+ * are the grant's contents, and a forwarded link should not disclose them.
+ */
+export async function getInvitationPreview(
+  params: { token: string },
+  db: Database = database
+): Promise<InvitationPreview> {
+  const invitation = await db.query.OrganizationInvitation.findFirst({
+    where: eq(schema.OrganizationInvitation.token, params.token),
+    columns: { email: true, status: true, expiresAt: true },
+    with: { organization: { columns: { name: true } } },
+  })
+
+  if (!invitation) return { valid: false, reason: 'not_found' }
+  if (invitation.status !== 'PENDING') return { valid: false, reason: 'used' }
+  if (invitation.expiresAt < new Date()) return { valid: false, reason: 'expired' }
+
+  return {
+    valid: true,
+    email: normalizeEmail(invitation.email),
+    organizationName: invitation.organization?.name || null,
+  }
 }
 
 /**
@@ -659,7 +712,7 @@ export async function getMyPendingInvitations(userEmail: string | null, db: Data
     .innerJoin(schema.User, eq(schema.OrganizationInvitation.invitedById, schema.User.id))
     .where(
       and(
-        ilike(schema.OrganizationInvitation.email, userEmail),
+        emailEquals(schema.OrganizationInvitation.email, userEmail),
         eq(schema.OrganizationInvitation.status, 'PENDING'),
         gt(schema.OrganizationInvitation.expiresAt, new Date())
       )

--- a/packages/lib/src/seed/new-user.ts
+++ b/packages/lib/src/seed/new-user.ts
@@ -10,7 +10,7 @@ import {
 import type { UserEntity } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, gt, ne } from 'drizzle-orm'
-import { acceptInvitationById } from '../members'
+import { acceptInvitationById, emailEquals } from '../members'
 import { ensureSystemProfiles } from '../permissions/profiles'
 import { SystemUserService } from '../users/system-user-service'
 import { OrganizationSeeder } from './organization-seeder'
@@ -208,7 +208,10 @@ async function getPendingInvite(email: string): Promise<PendingInvite | null> {
     .from(schema.OrganizationInvitation)
     .where(
       and(
-        eq(schema.OrganizationInvitation.email, email.toLowerCase()),
+        // Case-insensitive on BOTH sides: lowercasing only the incoming address
+        // still missed an invitation stored with the casing the admin typed,
+        // which drops the invitee into a throwaway org instead of their team.
+        emailEquals(schema.OrganizationInvitation.email, email),
         eq(schema.OrganizationInvitation.status, InvitationStatus.PENDING),
         gt(schema.OrganizationInvitation.expiresAt, new Date())
       )


### PR DESCRIPTION
## Problem

An invitee who created an account under a different email silently became the OWNER of a brand-new empty organization — with a Stripe trial attached — while their invitation sat `PENDING` forever. Neither they nor the admin got any signal.

Reproduced from real data: an invite went out for one address, an account was created under another 48s later, and the result was a phantom org (`name: ''`, `completedOnboarding: false`) plus an orphaned invite.

## Three causes, fixed together

**1. Copy Invite Link and resend handed out the wrong URL.** `getInvitationLink` and `resendInvitation` both returned the *accept* link regardless of whether the invitee had an account, so a brand-new invitee landed on `/login` with the token reduced to an opaque `callbackUrl` — no prefill, no context. A single helper, `generateInvitationEntryLink`, now decides signup-vs-accept for every surface that emits a link, so the emailed, resent, and copied links cannot disagree.

**2. Invitation emails were case-sensitive in one direction.** They were stored exactly as the admin typed them but looked up lowercased, so any mixed-case invite could never be matched at signup. Emails are now normalized on write and compared case-insensitively on read across all seven comparison sites.

Uses `lower(col) = $1` rather than `ilike` deliberately — the value is user-supplied, and `ilike` would treat a `%` or `_` inside an address as a wildcard. This also removes an existing `ilike` on `getMyPendingInvitations`.

**3. The signup form dropped the `invitationToken` it was already being handed.** New-user invite emails have always pointed at `/signup?invitationToken=...`; the form only read `callbackUrl` and `ref`. It now resolves the invitation, prefills and locks the email, names the inviting org, and reports a dead link instead of quietly degrading into an ordinary signup.

## Design note

**The invited email is deliberately not changeable by the invitee.** An invite that can be re-pointed at an address of the holder's choosing is a bearer token for the organization — a forwarded link would redeem just as well as the intended one, and the audit trail would record a grant the admin never made. Email verification does not close that: it proves control of the new address, not that you are the invitee. Re-targeting is an admin action.

The binding is enforced in the **auth `before` hook, not the form** — locking a field is cosmetic. The hook runs before the user row exists, which is the point: once created, `seedNewUserDatabase` has already committed an organization and a Stripe trial that could only be cleaned up after the fact.

**No migration.** `invitationToken` is not a declared `user.additionalFields` entry, so better-auth's signup body schema (which ends in `.and(z.record(z.string(), z.any()))`) passes it to the hook, and `parseInputData` strips it before the insert.

## Verification

- Biome clean on all changed files
- 60 tests pass in `packages/lib/src/members`
- `tsc` on `packages/lib` and `apps/web`: no new errors in changed files (both baselines are known-broken, so filtered per-file; the `signupSource` TS2353 already exists at HEAD and the new field rides in via a spread, which isn't subject to excess-property checks)
- Verified the generated SQL is parameterized: `lower("OrganizationInvitation"."email") = $1` / `["m4rkuskk+admin@gmail.com"]`
- Confirmed `TRPCReactProvider` wraps the root layout, so tRPC is available on `/signup` (the `(auth)` layout alone does not provide it)
- Case-insensitive match confirmed against live data

## Known gap

`signIn.social` carries no request body, so an invited user who picks a different Google account is still unpinnable — the hook only guards `/sign-up/email`. Invited signups now land directly on the email step so they don't see those buttons, but `/signup` reached another way still exposes them. The mismatch-recovery screen and admin re-target are follow-ups; re-target becomes **required** now that locking turns an admin typo into a hard block for the invitee.

## Unrelated commits included

Two leftovers from already-merged work, kept as separate commits:

- `fix(lib): export the snippet-mutations subpath its test imports` — #1378 added `snippet-mutations.ts` and a test importing `@auxx/lib/snippets/snippet-mutations`, but never committed the regenerated exports map, so **that subpath does not resolve on main today**.
- `fix(notifications): stop nesting chip divs inside p tags` — the row body wrapped chips (which bottom out in a `div`) in `p` tags, breaking hydration.