### PR TITLE
feat(onboarding): give invited members the personal step

### DIFF
--- a/apps/web/src/app/(protected)/onboarding/_components/onboarding-progress.tsx
+++ b/apps/web/src/app/(protected)/onboarding/_components/onboarding-progress.tsx
@@ -9,6 +9,10 @@ import {
   StepperTitle,
   StepperTrigger,
 } from '@auxx/ui/components/stepper'
+import {
+  useDehydratedOrganization,
+  useDehydratedOrganizationId,
+} from '~/providers/dehydrated-state-provider'
 import { useOnboarding } from './onboarding-provider'
 
 /**
@@ -27,6 +31,13 @@ const steps = [
 export function OnboardingProgress() {
   const { state } = useOnboarding()
   const { currentStep, completedSteps } = state
+
+  // An invited member joins an already-onboarded org, so the personal step is the
+  // whole of their onboarding. Steps 2-4 never run for them — "step 1 of 4" would
+  // promise three screens that don't exist.
+  const organizationId = useDehydratedOrganizationId()
+  const org = useDehydratedOrganization(organizationId)
+  if (org?.completedOnboarding) return null
 
   return (
     <div className='dark w-full pt-4 px-6 text-foreground'>

--- a/apps/web/src/app/(protected)/onboarding/page.tsx
+++ b/apps/web/src/app/(protected)/onboarding/page.tsx
@@ -58,8 +58,19 @@ export default async function OnboardingPage() {
     userCompletedOnboarding,
   })
 
+  // The personal step is a USER-level gate and is checked first, deliberately above
+  // the org short-circuit below. An invited member joins an org that is already
+  // onboarded, so any check that starts with the org can never express "the org is
+  // done but this person isn't" — it bounces them straight to /app with no name.
+  if (!userCompletedOnboarding) {
+    console.log('[Onboarding] User has not completed personal step, redirecting to /personal')
+    redirect('/onboarding/personal')
+  }
+
   // If organization onboarding is complete, route to /app — unless this user landed
   // here mid-Shopify-App-Store install, in which case finish the claim flow first.
+  // Must stay BELOW the user check: an App Store install by a user who hasn't done
+  // the personal step goes personal → back here → claim, never straight to /app.
   if (org?.completedOnboarding) {
     const cookieStore = await cookies()
     const claimToken = cookieStore.get('shopify_claim_token')?.value
@@ -71,17 +82,14 @@ export default async function OnboardingPage() {
     redirect('/app')
   }
 
-  if (!userCompletedOnboarding) {
-    // User hasn't completed personal info - start at step 1
-    console.log('[Onboarding] Redirecting to /onboarding/personal')
-    redirect('/onboarding/personal')
-  } else if (!org?.handle) {
-    // User completed personal but org needs handle - start at step 2
+  // Personal step is done by here. Remaining routing is purely org-shaped.
+  if (!org?.handle) {
+    // Org needs a handle - step 2
     console.log('[Onboarding] Redirecting to /onboarding/organization')
     redirect('/onboarding/organization')
-  } else {
-    // Both user personal and org handle done - skip to connections (step 3)
-    console.log('[Onboarding] Redirecting to /onboarding/connections')
-    redirect('/onboarding/connections')
   }
+
+  // Handle already set (create-org dialog, Shopify claim) - skip to connections (step 3)
+  console.log('[Onboarding] Redirecting to /onboarding/connections')
+  redirect('/onboarding/connections')
 }

--- a/apps/web/src/app/(protected)/onboarding/personal/page.tsx
+++ b/apps/web/src/app/(protected)/onboarding/personal/page.tsx
@@ -11,15 +11,20 @@ import {
   FormMessage,
 } from '@auxx/ui/components/form'
 import { Input } from '@auxx/ui/components/input'
+import { toastError } from '@auxx/ui/components/toast'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { motion } from 'motion/react'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { AvatarUpload } from '~/components/file-upload/ui/avatar-upload'
 import { useAnalytics } from '~/hooks/use-analytics'
-import { useDehydratedUser } from '~/providers/dehydrated-state-provider'
+import {
+  useDehydratedOrganization,
+  useDehydratedOrganizationId,
+  useDehydratedUser,
+} from '~/providers/dehydrated-state-provider'
+import { api } from '~/trpc/react'
 import { OnboardingNavigation } from '../_components/onboarding-navigation'
 import { useOnboarding } from '../_components/onboarding-provider'
 
@@ -29,13 +34,20 @@ const formSchema = z.object({
 })
 
 export default function PersonalOnboardingPage() {
-  const router = useRouter()
   const posthog = useAnalytics()
   const { state, updatePersonal, markStepCompleted, setCurrentStep } = useOnboarding()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   // Get existing user data from dehydrated state
   const userData = useDehydratedUser()!
+
+  // An invited member joins an org that is already onboarded, so this screen is the
+  // whole of their onboarding — there is no step 2 to send them to.
+  const organizationId = useDehydratedOrganizationId()
+  const org = useDehydratedOrganization(organizationId)
+  const isSoloStep = org?.completedOnboarding ?? false
+
+  const updateUserProfile = api.user.updateProfile.useMutation()
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: standardSchemaResolver(formSchema),
@@ -49,6 +61,20 @@ export default function PersonalOnboardingPage() {
     setIsSubmitting(true)
 
     try {
+      // Persist here rather than deferring to the wizard's final step: this step is
+      // a gate of its own now, and a member who only ever sees this screen would
+      // otherwise save nothing. Also stops a founder who abandons the wizard at
+      // step 2 from losing their name.
+      //
+      // `completedOnboarding` rides along on THIS mutation on purpose — it is the
+      // only write that fires `onCacheEvent('user.updated')`, which the `/app` gate
+      // depends on. See routers/user.ts.
+      await updateUserProfile.mutateAsync({
+        firstName: values.firstName,
+        lastName: values.lastName,
+        completedOnboarding: true,
+      })
+
       // Save to context
       updatePersonal({
         firstName: values.firstName,
@@ -59,10 +85,24 @@ export default function PersonalOnboardingPage() {
       markStepCompleted(1)
       posthog?.capture('onboarding_step_completed', { step: 'personal' })
 
+      if (isSoloStep) {
+        posthog?.capture('onboarding_completed')
+        // Redirect through /onboarding rather than to /app directly, so the entry
+        // point stays the single place that decides where a finished user lands
+        // (it also owns the Shopify-claim branch). Full reload to rebuild the
+        // dehydrated state the /app gate reads.
+        window.location.href = '/onboarding'
+        return
+      }
+
       // Navigate to next step
       setCurrentStep(2)
     } catch (error) {
       console.error('Failed to save personal information:', error)
+      toastError({
+        title: 'Error saving your details',
+        description: error instanceof Error ? error.message : 'Please try again.',
+      })
       setIsSubmitting(false)
     }
   }
@@ -156,6 +196,7 @@ export default function PersonalOnboardingPage() {
                   <OnboardingNavigation
                     showBack={false}
                     onContinue={form.handleSubmit(onSubmit)}
+                    continueText={isSoloStep ? 'Get started' : 'Continue'}
                     continueDisabled={!form.formState.isValid}
                     continueLoading={isSubmitting}
                   />
@@ -186,14 +227,16 @@ export default function PersonalOnboardingPage() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.5 }}>
-            Welcome to Auxx.ai
+            {isSoloStep && org?.name ? `Welcome to ${org.name}` : 'Welcome to Auxx.ai'}
           </motion.h2>
           <motion.p
             className='text-white/50'
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.6 }}>
-            Let's set up your account and get you started with AI-powered customer support.
+            {isSoloStep
+              ? 'Your team is already set up — just tell us who you are and you’re in.'
+              : "Let's set up your account and get you started with AI-powered customer support."}
           </motion.p>
         </motion.div>
       </div>

--- a/apps/web/src/app/(protected)/onboarding/team/page.tsx
+++ b/apps/web/src/app/(protected)/onboarding/team/page.tsx
@@ -17,7 +17,6 @@ import { Copy, Plus, Trash2, Users } from 'lucide-react'
 import { motion } from 'motion/react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import { updateUser } from '~/auth/auth-client'
 import { useAnalytics } from '~/hooks/use-analytics'
 import {
   useDehydratedOrganization,
@@ -48,7 +47,6 @@ export default function TeamOnboardingPage() {
   )
   // API mutations
   const updateOrganization = api.organization.update.useMutation()
-  const updateUserProfile = api.user.updateProfile.useMutation()
   const inviteBatch = api.member.inviteBatch.useMutation()
   // Add new invite row
   const addInvite = () => {
@@ -85,14 +83,10 @@ export default function TeamOnboardingPage() {
   const completeOnboarding = async (skipInvites: boolean = false) => {
     setIsSubmitting(true)
     try {
-      // 1. Update user profile with firstName/lastName
-      if (state.personal.firstName || state.personal.lastName) {
-        await updateUserProfile.mutateAsync({
-          firstName: state.personal.firstName,
-          lastName: state.personal.lastName,
-        })
-      }
-      // 2. Update organization with handle and mark onboarding complete
+      // 1. Update organization with handle and mark onboarding complete.
+      //    The user's own profile (firstName/lastName + completedOnboarding) is
+      //    persisted by step 1 now — it is a gate of its own, so it can't wait
+      //    until here.
       // Use dehydrated state as fallback for values not in sessionStorage
       await updateOrganization.mutateAsync({
         name: state.organization.name || currentOrg?.name || undefined,
@@ -100,7 +94,7 @@ export default function TeamOnboardingPage() {
         website: state.organization.website || currentOrg?.website || undefined,
         completedOnboarding: true,
       })
-      // 3. Send team invites if any (skip if no valid emails or skipped)
+      // 2. Send team invites if any (skip if no valid emails or skipped)
       if (!skipInvites && invites.length > 0) {
         const validInvites = invites.filter((i) => i.email)
         if (validInvites.length > 0) {
@@ -120,17 +114,21 @@ export default function TeamOnboardingPage() {
           }
         }
       }
-      // 4. Track completion
+      // 3. Track completion
       posthog?.capture('onboarding_step_completed', { step: 'team' })
       posthog?.capture('onboarding_completed')
 
-      // 5. Clear sessionStorage
+      // 4. Clear sessionStorage
       resetState()
-      // 6. Update auth session to reflect completedOnboarding
-      await updateUser({ completedOnboarding: true })
-      // 7. Redirect through /onboarding so the entry-point routes to /app or to
+      // 5. Redirect through /onboarding so the entry-point routes to /app or to
       //    /shopify/claim (App-Store-initiated installs) in one place.
       //    Full reload to get fresh dehydrated state.
+      //
+      //    No `updateUser({ completedOnboarding: true })` here: step 1 already set
+      //    the user flag through `user.updateProfile`, which is the only write that
+      //    invalidates the cached `userProfile` the /app gate reads. better-auth's
+      //    `updateUser` has no `user.update` databaseHook, so it would write the row
+      //    and leave that cache stale.
       window.location.href = '/onboarding'
     } catch (error) {
       console.error('Failed to complete onboarding:', error)

--- a/apps/web/src/app/api/demo/create-session/route.ts
+++ b/apps/web/src/app/api/demo/create-session/route.ts
@@ -1,6 +1,7 @@
 // apps/web/src/app/api/demo/create-session/route.ts
 
 import { database as db, schema } from '@auxx/database'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { DEMO_SESSION_DURATION_MS, generateDemoEmail, isDemoEnabled } from '@auxx/lib/demo'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
 import { RedisRateLimiter } from '@auxx/lib/utils/rate-limiter/redis-rate-limiter'
@@ -126,6 +127,15 @@ export async function POST(request: NextRequest) {
         updatedAt: new Date(),
       })
       .where(eq(schema.Organization.id, organizationId))
+
+    // 6b. Both onboarding flags above were written with direct Drizzle updates, which
+    // bypass the cache. `seedNewUserDatabase` ran in the auth hook first and set the
+    // user flag to `false`, so any warm `userProfile`/`orgProfile` entry now disagrees
+    // with the row — and both flags gate `/app` (dashboard.tsx), which reads them out
+    // of the cached dehydrated state. Without these, a demo user loops into
+    // `/onboarding` forever.
+    await onCacheEvent('user.updated', { orgId: organizationId, userId })
+    await onCacheEvent('org.updated', { orgId: organizationId })
 
     // 7. The auth hook (seedNewUserDatabase) already called OrganizationSeeder.seedNewOrganization,
     // but it used the default (non-demo) path which creates a trial subscription.

--- a/apps/web/src/components/global/dashboard.tsx
+++ b/apps/web/src/components/global/dashboard.tsx
@@ -32,6 +32,7 @@ import { useOverages } from '~/hooks/use-overages'
 import {
   useDehydratedOrganization,
   useDehydratedOrganizationId,
+  useDehydratedUser,
 } from '~/providers/dehydrated-state-provider'
 
 type Props = {
@@ -53,10 +54,16 @@ export const Dashboard = ({
   const pathname = usePathname()
   const router = useRouter()
 
-  // Get organization's onboarding status from dehydrated state
+  // Get onboarding status from dehydrated state. Two INDEPENDENT gates: the org
+  // gate covers workspace setup, the user gate covers the personal step (name +
+  // avatar). An invited member joins an already-onboarded org, so only the user
+  // gate ever catches them — without it they land in the app with no name.
   const organizationId = useDehydratedOrganizationId()
   const currentOrg = useDehydratedOrganization(organizationId)
+  const dehydratedUser = useDehydratedUser()
   const orgCompletedOnboarding = currentOrg?.completedOnboarding ?? false
+  const userCompletedOnboarding = dehydratedUser?.completedOnboarding ?? false
+  const needsOnboarding = !orgCompletedOnboarding || !userCompletedOnboarding
   const overages = useOverages(organizationId)
 
   const [activeDragId, setActiveDragId] = useState<string | null>(null)
@@ -72,16 +79,17 @@ export const Dashboard = ({
     setActiveDndItem(event.active)
   }, [])
 
-  // Redirect to onboarding if org hasn't completed it.
+  // Redirect to onboarding if either gate is open. `/onboarding` is the single
+  // place that decides WHICH step is missing.
   // Uses full navigation since onboarding is in a separate route group.
   React.useEffect(() => {
-    if (!orgCompletedOnboarding) {
+    if (needsOnboarding) {
       window.location.href = '/onboarding'
     }
-  }, [orgCompletedOnboarding])
+  }, [needsOnboarding])
 
   // Show nothing while redirecting to onboarding
-  if (!orgCompletedOnboarding) {
+  if (needsOnboarding) {
     return null
   }
 

--- a/apps/web/src/server/api/routers/organization.ts
+++ b/apps/web/src/server/api/routers/organization.ts
@@ -159,13 +159,13 @@ export const organizationRouter = createTRPCRouter({
         })
       }
 
-      // Also update user onboarding status if marking org as complete
-      if (completedOnboarding) {
-        await ctx.db
-          .update(schema.User)
-          .set({ completedOnboarding: true, updatedAt: new Date() })
-          .where(eq(schema.User.id, userId))
-      }
+      // Deliberately does NOT touch `User.completedOnboarding`. The user-level flag
+      // is owned by the onboarding personal step (`user.updateProfile`), which is
+      // the only write that fires `onCacheEvent('user.updated')`. This handler emits
+      // `org.updated` → ['orgProfile'] only, so writing the user flag here updated
+      // the row while leaving the cached `userProfile` stale — which loops the user
+      // between `/app` (reads the cache) and `/onboarding` (reads the DB).
+      // Organization onboarding and personal onboarding are independent gates.
 
       // Invalidate dehydration cache for all org members (org data visible to all)
       await onCacheEvent('org.updated', { orgId: organizationId })

--- a/apps/web/src/server/api/routers/user.ts
+++ b/apps/web/src/server/api/routers/user.ts
@@ -23,6 +23,15 @@ export const userRouter = createTRPCRouter({
         name: z.string().min(1).optional(),
         firstName: z.string().min(1).optional(),
         lastName: z.string().min(1).optional(),
+        /**
+         * Set by the onboarding personal step. It belongs on THIS mutation rather
+         * than better-auth's `updateUser` because only this path fires
+         * `onCacheEvent('user.updated')` below — and `completedOnboarding` is read
+         * back out of the cached `userProfile` to build the dehydrated state that
+         * gates `/app`. Writing it anywhere else leaves that cache stale and loops
+         * the user between `/app` and `/onboarding`.
+         */
+        completedOnboarding: z.boolean().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -34,6 +43,8 @@ export const userRouter = createTRPCRouter({
       // Update separate fields
       if (input.firstName !== undefined) updates.firstName = input.firstName
       if (input.lastName !== undefined) updates.lastName = input.lastName
+      if (input.completedOnboarding !== undefined)
+        updates.completedOnboarding = input.completedOnboarding
 
       // Update full name field as well for display purposes (only if name wasn't directly set)
       if (

--- a/packages/lib/src/data-migrations/migrations/058-reopen-personal-onboarding.ts
+++ b/packages/lib/src/data-migrations/migrations/058-reopen-personal-onboarding.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/data-migrations/migrations/058-reopen-personal-onboarding.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNotNull, isNull, or } from 'drizzle-orm'
+import { onCacheEvent } from '../../cache'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-057')
+
+/**
+ * Reopen the personal onboarding step for users who were marked done without ever
+ * being asked for a name.
+ *
+ * `seedNewUserDatabase`'s invite branch used to set `completedOnboarding: true` the
+ * moment an invited account was created, and signup sends `name: ''` — so an invited
+ * member landed in the app with no name, no avatar, and no screen that would ever ask
+ * for one. The org-level gate can't catch them (they join an org that is already
+ * onboarded) and the user-level gate was never armed. That flag is now `false` for
+ * new invitees; this migration retroactively opens the gate for the ones already in
+ * the database.
+ *
+ * Targets only genuinely nameless accounts. `userType = 'USER'` is load-bearing:
+ * AGENT and system users carry `completedOnboarding: true` deliberately
+ * (`system-user-service.ts`, `createAgent`) and must never be gated — they never sign
+ * in, so a redirect they can't satisfy would be invisible until something breaks.
+ * Demo users are seeded with a name and are excluded by the name predicate.
+ *
+ * Busts each affected user's `userProfile` cache: `completedOnboarding` is read back
+ * out of that key to build the dehydrated state the `/app` gate reads
+ * (`user-profile-provider.ts`), so a row-only update would leave the gate looking at
+ * the pre-migration value.
+ *
+ * Idempotent: re-running matches strictly fewer rows each time (a user who completes
+ * the step gains a name and drops out of the predicate), and writing `false` onto a
+ * row that already reads `false` is a no-op.
+ */
+export const migration058ReopenPersonalOnboarding: DataMigrationDef = {
+  id: '058-reopen-personal-onboarding',
+  description:
+    'Reopen the personal onboarding step for nameless users marked complete by the old invite path',
+  async run(db: Database): Promise<void> {
+    const nameless = and(
+      eq(schema.User.userType, 'USER'),
+      eq(schema.User.banned, false),
+      eq(schema.User.completedOnboarding, true),
+      // Load-bearing: the personal step submits through `user.updateProfile`, a
+      // `protectedProcedure`, which throws UNAUTHORIZED without a default org
+      // (trpc.ts). Reopening the gate for a user who has none would strand them on
+      // a screen they can never get past.
+      isNotNull(schema.User.defaultOrganizationId),
+      isNull(schema.User.firstName),
+      isNull(schema.User.lastName),
+      or(isNull(schema.User.name), eq(schema.User.name, ''))
+    )
+
+    const affected = await db
+      .select({ id: schema.User.id, defaultOrganizationId: schema.User.defaultOrganizationId })
+      .from(schema.User)
+      .where(nameless)
+
+    if (affected.length === 0) {
+      logger.info('No nameless users to reopen onboarding for')
+      return
+    }
+
+    await db
+      .update(schema.User)
+      .set({ completedOnboarding: false, updatedAt: new Date() })
+      .where(nameless)
+
+    for (const user of affected) {
+      // `defaultOrganizationId` is non-null by the predicate above.
+      await onCacheEvent('user.updated', {
+        orgId: user.defaultOrganizationId!,
+        userId: user.id,
+      })
+    }
+
+    logger.info('Reopened personal onboarding for nameless users', { count: affected.length })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -26,6 +26,7 @@ import { migration053SeedAgentPresetProfiles } from './migrations/053-seed-agent
 import { migration054AgentPolicyVocabulary } from './migrations/054-agent-policy-vocabulary'
 import { migration055AgentPolicyResourceAreaFallthrough } from './migrations/055-agent-policy-resource-area-fallthrough'
 import { migration056SignaturesSnippetsInstanceAccess } from './migrations/056-signatures-snippets-instance-access'
+import { migration058ReopenPersonalOnboarding } from './migrations/058-reopen-personal-onboarding'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -68,6 +69,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration054AgentPolicyVocabulary,
     migration055AgentPolicyResourceAreaFallthrough,
     migration056SignaturesSnippetsInstanceAccess,
+    migration058ReopenPersonalOnboarding,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/seed/new-user.ts
+++ b/packages/lib/src/seed/new-user.ts
@@ -129,11 +129,17 @@ export async function seedNewUserDatabase(user: {
         db
       )
 
+      // `false`, not `true`: an invitee joins an org that is already onboarded, so
+      // the org-level gate never fires for them and nobody ever asks for their name.
+      // Signup sends `name: ''` (signup-form.tsx), so marking them done here is what
+      // landed invited members in the app as a blank. The user-level gate
+      // (dashboard.tsx + onboarding/page.tsx) now walks them through the personal
+      // step alone.
       const [updatedUser] = await db
         .update(schema.User)
         .set({
           defaultOrganizationId: organizationId,
-          completedOnboarding: true,
+          completedOnboarding: false,
           ...(shouldAutoPromote && { isSuperAdmin: true, emailVerified: true }),
         })
         .where(eq(schema.User.id, user.id))
@@ -144,6 +150,12 @@ export async function seedNewUserDatabase(user: {
       await userSeeder.seedNewUser()
       return updatedUser
     } else {
+      // Stays `true`, unlike the invite branch above. This branch leaves
+      // `defaultOrganizationId` null, and `protectedProcedure` hard-requires it
+      // (trpc.ts) — so gating these users on the personal step would strand them:
+      // they'd be redirected to a screen whose `user.updateProfile` submit can only
+      // ever 401. Fixing that means giving this branch a default org, which is a
+      // separate question about a path that shouldn't normally be reachable.
       const [updatedUser] = await db
         .update(schema.User)
         .set({


### PR DESCRIPTION
Onboarding was gated entirely on the **organization**, so a member joining an already-onboarded org could never reach it — and email signup never asks for a name (it sends `name: ''`). Invited members landed in the app blank: no name, no avatar, and no screen that would ever ask for one.

Follows #1379, which fixed *getting* an invitee into the right organization. This fixes what happens the moment after.

## Why it needed four changes, not one

All four of these had to be true, and all four were:

| Where | What it did |
|---|---|
| `seed/new-user.ts:136` | Invite branch set `completedOnboarding: true` at signup, before any screen |
| `onboarding/page.tsx:63` | Short-circuited on the **org** flag before reading the user flag — so an invitee sent to `/onboarding` bounced straight back to `/app` |
| `global/dashboard.tsx:78` | The only live gate, and it read the org flag |
| `hooks/use-user.ts:149` | Read the *user* flag correctly — but no caller anywhere passed `requireOnboarding`, so it had never run |

The second is the structural one: the entry point could not express *"the org is done but this person isn't."*

## The model

The personal step belongs to the **user**; the other three steps belong to the **organization**. Two independent gates.

The step now persists on submit (`user.updateProfile`) instead of stashing in sessionStorage until step 4. That also fixes a second symptom for free: **a founder who abandoned the wizard at step 2 lost their name.**

## Two stale-cache writes had to go with it

`completedOnboarding` is read back out of the cached `userProfile` to build the dehydrated state `/app` gates on (`user-profile-provider.ts:84`). Neither existing write invalidated it:

- better-auth's `updateUser` in `team/page.tsx` — there is no `user.update` databaseHook in `auth/server.ts`
- `organization.update` — emits `org.updated` → `['orgProfile']`, not `userProfile`

Both were harmless while nothing read the user flag. **Arming the gate on top of them would have looped the founder path** between `/app` (reads cache) and `/onboarding` (reads DB). The flag now rides on `user.updateProfile`, the one write that fires `user.updated`. The demo route's direct writes get the cache events they were missing.

## Two judgment calls worth review

**`new-user.ts`'s third branch stays `true`.** It leaves `defaultOrganizationId` null and `protectedProcedure` hard-requires it (`trpc.ts:342`), so gating those users would strand them on a screen whose submit can only ever 401. Migration `058` carries the same `defaultOrganizationId IS NOT NULL` guard.

**`058`, not `057`.** Ledger numbering is shared with `seed/entity-migrations/`, which already holds `057-remove-signature-visibility-field` — `wrapEntityMigration` carries entity ids into the same ledger verbatim. Note `assertUniqueMigrationIds` compares *full id strings*, so it would **not** have caught a duplicate `057-` prefix with a different slug.

## Testing

Highest-risk path is the **founder** one, not the invited one: complete the 4-step wizard and confirm `/app` renders rather than bouncing back to `/onboarding`. That is the regression guard for deleting the `User` write from `organization.update`.

Then: invited email signup (single screen, no stepper, "Get started"); existing named user accepting a second org's invite (no screen); create-org dialog (lands on step 3, not personal); demo session (no redirect).

Migration `058` is a **no-op on the current dev DB** — every nameless user there has a `name` set, so it matches zero rows. It needs a constructed row to exercise.

## Known rough edge (not fixed here)

OAuth invitees get a **gated but empty** form: Google/GitHub populate `User.name` but leave `firstName`/`lastName` null, and the form prefills from those. Not a break, but a pointless screen. Splitting `name` as a prefill fallback is the obvious follow-up — skipping the gate entirely would mean never asking for the avatar either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
