### PR TITLE
fix(onboarding): bind team invites to the seeded permission profiles

### DIFF
--- a/apps/web/src/app/(protected)/onboarding/_components/onboarding-provider.tsx
+++ b/apps/web/src/app/(protected)/onboarding/_components/onboarding-provider.tsx
@@ -7,6 +7,10 @@ import { createContext, type ReactNode, useContext, useEffect, useState } from '
 
 /**
  * Team invite interface
+ *
+ * Carries the rank only. The seeded permission profile it binds to is resolved
+ * at submit time from the org's system profiles — see `INVITE_RANKS` in
+ * `onboarding/team/page.tsx`.
  */
 interface TeamInvite {
   email: string

--- a/apps/web/src/app/(protected)/onboarding/team/page.tsx
+++ b/apps/web/src/app/(protected)/onboarding/team/page.tsx
@@ -17,6 +17,7 @@ import { Copy, Plus, Trash2, Users } from 'lucide-react'
 import { motion } from 'motion/react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { useInvitableProfiles } from '~/app/(protected)/app/settings/members/_components/invite-profile-select'
 import { useAnalytics } from '~/hooks/use-analytics'
 import {
   useDehydratedOrganization,
@@ -30,6 +31,22 @@ interface TeamInvite {
   email: string
   role: OrganizationRole
 }
+
+/**
+ * The two ranks onboarding offers, each mapped to the system permission profile
+ * it binds to. Both slugs are seeded into every org by `ensureSystemProfiles`,
+ * inside the same transaction that creates the org at signup — so they always
+ * exist by the time this step renders.
+ *
+ * Onboarding deliberately offers only these two rather than the full profile
+ * select the members settings page uses: a brand-new org has no custom profiles
+ * yet, so the picker would show nothing but these anyway. Field seats and custom
+ * profiles are invited from settings once onboarding is done.
+ */
+const INVITE_RANKS = [
+  { role: OrganizationRoleEnum.USER, slug: 'member', label: 'Member' },
+  { role: OrganizationRoleEnum.ADMIN, slug: 'admin', label: 'Admin' },
+] as const
 export default function TeamOnboardingPage() {
   const router = useRouter()
   const posthog = useAnalytics()
@@ -48,6 +65,14 @@ export default function TeamOnboardingPage() {
   // API mutations
   const updateOrganization = api.organization.update.useMutation()
   const inviteBatch = api.member.inviteBatch.useMutation()
+
+  // The org's seeded system profiles, so each invited rank binds to a real
+  // profile instead of relying on the null-binding fallback.
+  const { profiles } = useInvitableProfiles()
+  const profileIdForRole = (role: OrganizationRole): string | undefined => {
+    const slug = INVITE_RANKS.find((rank) => rank.role === role)?.slug
+    return profiles.find((profile) => profile.slug === slug)?.id
+  }
   // Add new invite row
   const addInvite = () => {
     setInvites([...invites, { email: '', role: OrganizationRoleEnum.USER }])
@@ -98,7 +123,17 @@ export default function TeamOnboardingPage() {
       if (!skipInvites && invites.length > 0) {
         const validInvites = invites.filter((i) => i.email)
         if (validInvites.length > 0) {
-          const results = await inviteBatch.mutateAsync({ invites: validInvites })
+          // Bind each invite to the seeded profile for its rank. `role` rides
+          // along as the fallback: `inviteMember` lets a bound profile's declared
+          // seat and role supersede it, and uses it only when no profile resolved
+          // (i.e. the profile list failed to load), so onboarding can never be
+          // blocked by this lookup.
+          const results = await inviteBatch.mutateAsync({
+            invites: validInvites.map((invite) => ({
+              ...invite,
+              permissionProfileId: profileIdForRole(invite.role),
+            })),
+          })
           // Check for any failed invites
           const failedInvites = results.filter((r) => !r.success)
           if (failedInvites.length > 0) {
@@ -221,8 +256,11 @@ export default function TeamOnboardingPage() {
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value={OrganizationRoleEnum.USER}>Member</SelectItem>
-                            <SelectItem value={OrganizationRoleEnum.ADMIN}>Admin</SelectItem>
+                            {INVITE_RANKS.map((rank) => (
+                              <SelectItem key={rank.role} value={rank.role}>
+                                {rank.label}
+                              </SelectItem>
+                            ))}
                           </SelectContent>
                         </Select>
                       </InputGroupAddon>


### PR DESCRIPTION
## What

The onboarding team step was the last surviving surface in the app that authored `OrganizationRole` directly for an org member. It sent `{email, role}` to `member.inviteBatch` with no `permissionProfileId`, so every onboarding invite bound nothing — exactly the case `inviteBatch`'s own input docstring describes:

> Without it a batch invitation binds nothing and the accepted member falls back to the system template for their role (§1.3).

Every other invite surface (`invite-popover`, `invite-many-dialog`, `invite-form`) had already moved to a profile select with **no role control at all**, and `members-tab.tsx` notes that "rank changes ride the permission profile (plan 21 §2.0)". So onboarding and settings spoke two different vocabularies, which diverge the moment an org creates its first custom profile.

## Why the seeded profiles are safe to point at

`ensureSystemProfiles` runs **inside the same transaction that creates the org at signup** — `packages/lib/src/seed/new-user.ts:80`, whose comment reads *"an org must never commit without the system profiles a null binding resolves to"*. The org is created by better-auth's `user.create.after` hook, not by the onboarding steps themselves, so all 8 profiles (including `member` and `admin`) are committed long before `/onboarding/team` renders.

`loadInvitableProfile` has no `isSystem` guard — its only rejections are missing / cross-org / `appliesTo: 'agent'` — so both slugs are directly invitable.

## How

The dropdown keeps its shape and its `Member`/`Admin` labels. The options now come from one table mapping each rank to its profile slug:

```ts
const INVITE_RANKS = [
  { role: OrganizationRoleEnum.USER, slug: 'member', label: 'Member' },
  { role: OrganizationRoleEnum.ADMIN, slug: 'admin', label: 'Admin' },
] as const
```

and the id resolves at submit through the shared `useInvitableProfiles()` hook.

**Two design calls worth reviewing:**

1. **Resolved at submit, not on selection.** The profile list loads async, so binding on pick would need an effect to backfill rows the user selected before the query settled, and would still miss invites restored from `sessionStorage` by an older build. One lookup at submit covers both.

2. **`role` still rides along in the payload.** `inviteMember` (`invitations.ts:83-87`) lets a bound profile's declared `seat`/`role` supersede the caller's values and only falls back to `role` when nothing resolved. So sending both is a free self-healing fallback — a failed `listProfiles` degrades to the previous behavior rather than blocking onboarding. This is why `role` was *not* removed from the `invite`/`inviteBatch` inputs: it is now load-bearing as the fallback rather than as the primary path.

## Verification

- Biome clean on both files.
- `tsc` on `apps/web`: three errors touch these files, all three **byte-identical to HEAD on lines never edited** (`updated[index].email = email` etc. — pre-existing `noUncheckedIndexedAccess`), shifted by exactly the +25/+4 line offsets. **Zero new errors.**
- No server behavior changed — this is a client-only payload change plus a doc comment.

**Not browser-verified.** Worth a pass before merge: invite one Member + one Admin during onboarding, confirm `OrganizationInvitation.permissionProfileId` is non-null for both, and that the members list shows the profile instead of "Pending ADMIN".

## Deliberately out of scope

- **Field seats still can't be invited during onboarding.** `field_tech` is seeded and invitable — it's one more row in `INVITE_RANKS` — but it needs a seat-cap story and a label decision.
- **`member.updateRole`** (`member.ts:184-221` → `member-mutations.ts:100`) is still a live role-only write path with **zero UI callers repo-wide** that skips the `permissionsManage` requirement and the §6.1 escalation guard `assignProfile` runs, and leaves `permissionProfileId` untouched. Unrelated to this change, but the higher-severity of the two.