### PR TITLE
refactor(members): retire the standalone role write and audit rank as a transition

### DIFF
--- a/apps/web/src/server/api/routers/member.ts
+++ b/apps/web/src/server/api/routers/member.ts
@@ -3,7 +3,7 @@
 import { schema } from '@auxx/database'
 import { MemberType, OrganizationRole, SeatType } from '@auxx/database/enums'
 import { getCachedMembers, onCacheEvent } from '@auxx/lib/cache'
-import { DehydrationCacheService, DehydrationService } from '@auxx/lib/dehydration'
+import { DehydrationService } from '@auxx/lib/dehydration'
 import {
   acceptInvitation,
   acceptInvitationById,
@@ -18,7 +18,6 @@ import {
   inviteMember,
   removeMember,
   resendInvitation,
-  updateMemberRole,
   updateMemberSeatType,
 } from '@auxx/lib/members'
 import { TRPCError } from '@trpc/server'
@@ -180,46 +179,6 @@ export const memberRouter = createTRPCRouter({
       return result
     }),
 
-  /** Update a member's role */
-  updateRole: protectedProcedure
-    .input(
-      z.object({
-        memberId: z.string(),
-        role: z.enum(OrganizationRole),
-      })
-    )
-    .use(notDemo('change member roles'))
-    .mutation(async ({ ctx, input }) => {
-      const result = await updateMemberRole(
-        {
-          organizationId: ctx.session.organizationId,
-          updaterUserId: ctx.session.user.id,
-          memberToUpdateId: input.memberId,
-          newRole: input.role,
-        },
-        ctx.db
-      )
-
-      await onCacheEvent('member.role.changed', {
-        orgId: ctx.session.organizationId,
-        userId: input.memberId,
-      })
-      // The composed capability set rides in dehydrated state — bust it so the
-      // member's caps recompose on their next page load (graph now busts
-      // userCapabilities on role change too).
-      await new DehydrationCacheService().invalidateUser(input.memberId)
-
-      await recordAuditFromCtx(ctx, {
-        category: 'members',
-        action: 'member.role_changed',
-        targetType: 'OrganizationMember',
-        targetId: input.memberId,
-        newState: { role: input.role },
-      })
-
-      return result
-    }),
-
   /** Change a member's seat type (full ⇄ field seat) */
   updateSeatType: protectedProcedure
     .input(
@@ -284,11 +243,16 @@ export const memberRouter = createTRPCRouter({
         ctx.db
       )
 
+      // Assignment is the only path that writes a rank, so this row is also the
+      // rank-change record (there is no `member.role_changed` action — see
+      // AUDIT_ACTIONS). `previousState.role` is what makes a promotion or
+      // demotion visible rather than just the landing state.
       await recordAuditFromCtx(ctx, {
         category: 'members',
         action: 'member.profile_assigned',
         targetType: 'OrganizationMember',
         targetId: input.memberId,
+        previousState: { role: result.previousRole },
         newState: { permissionProfileId: result.permissionProfileId, role: result.role },
       })
 

--- a/packages/lib/src/audit-log/audit-actions.ts
+++ b/packages/lib/src/audit-log/audit-actions.ts
@@ -23,6 +23,8 @@ export const AUDIT_ACTIONS = {
   permissionGranted: 'permission.granted',
   permissionRevoked: 'permission.revoked',
   permissionSet: 'permission.set',
+  permissionProfileCreated: 'permission.profile.created',
+  permissionProfileUpdated: 'permission.profile.updated',
   sessionsInvalidated: 'sessions.invalidated',
   twoFactorEnabled: '2fa.enabled',
   twoFactorDisabled: '2fa.disabled',
@@ -43,7 +45,12 @@ export const AUDIT_ACTIONS = {
   // ── members ─────────────────────────────────────────────────────────────
   memberInvited: 'member.invited',
   memberRemoved: 'member.removed',
-  memberRoleChanged: 'member.role_changed',
+  // NOTE: no `member.role_changed`. Rank is no longer authorable on its own
+  // (plan 21 §2.0.1) — the only path that writes it is profile assignment, which
+  // records `member.profile_assigned` with the role transition in
+  // previous/newState. Filter on that action to find rank changes.
+  memberProfileAssigned: 'member.profile_assigned',
+  memberSeatTypeChanged: 'member.seat_type_changed',
   memberLeft: 'member.left',
   invitationAccepted: 'invitation.accepted',
   invitationCanceled: 'invitation.canceled',

--- a/packages/lib/src/members/assign-profile.test.ts
+++ b/packages/lib/src/members/assign-profile.test.ts
@@ -4,9 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * `member.assignProfile`'s guard set (plan 21 §7). Assignment writes the
- * member's rank from the profile's declared role, so it inherits every guard
- * `updateMemberRole` owns — each case below is what keeps the profile picker
- * from becoming a privilege-escalation control.
+ * member's rank from the profile's declared role, and is now the only path that
+ * writes a rank at all — so every guard the removed standalone role mutation
+ * owned lives here. Each case below is what keeps the profile picker from
+ * becoming a privilege-escalation control.
  */
 
 // ── An introspectable `drizzle-orm`: conditions become plain objects the fake
@@ -362,7 +363,8 @@ describe('assignMemberProfile — the §7 guard set', () => {
   it('fires last-owner protection when the only Owner is moved off Owner rank', async () => {
     // The actor is an Owner per the membership lookup (the org cache in
     // production) while the org's live OWNER count is 1 — the drift this guard
-    // is defence in depth against. The error is `updateMemberRole`'s, verbatim.
+    // is defence in depth against. The error matches the remove-member path's
+    // last-owner refusal verbatim.
     membershipOverrides.u_owner2 = {
       id: 'm_owner2',
       userId: 'u_owner2',
@@ -516,6 +518,10 @@ describe('assignMemberProfile — the write', () => {
     )
 
     expect(result).toMatchObject({ success: true, permissionProfileId: 'p_admin', role: 'ADMIN' })
+    // The promotion is legible as a transition, not just a landing state — this
+    // is the audit row's `previousState.role`, and the only record of a rank
+    // change now that `member.role_changed` has no writer.
+    expect(result.previousRole).toBe('USER')
     expect(rowOf('u_target')).toMatchObject({ permissionProfileId: 'p_admin', role: 'ADMIN' })
     expect(patches).toHaveLength(1)
     expect(patches[0]).toMatchObject({ permissionProfileId: 'p_admin', role: 'ADMIN' })
@@ -536,6 +542,8 @@ describe('assignMemberProfile — the write', () => {
     )
 
     expect(result.role).toBe('USER')
+    // The demotion direction of the same audit contract.
+    expect(result.previousRole).toBe('ADMIN')
     expect(rowOf('u_admin')).toMatchObject({ permissionProfileId: 'p_support', role: 'USER' })
   })
 

--- a/packages/lib/src/members/assign-profile.ts
+++ b/packages/lib/src/members/assign-profile.ts
@@ -34,15 +34,23 @@ export interface AssignMemberProfileResult {
   success: true
   permissionProfileId: string | null
   role: OrganizationRole
+  /**
+   * The rank the member held before this assignment. Assignment is the only
+   * path that writes a rank, so this is what makes a promotion or demotion
+   * visible in the audit trail — the caller records it as `previousState`.
+   * Equal to `role` when the binding changed but the declared rank did not.
+   */
+  previousRole: OrganizationRole
 }
 
 /**
  * Bind a permission profile to a member, writing the member's rank from the
  * profile's declared `role` (plan 21 §2.a.3).
  *
- * Assignment is a **role write**, so it inherits every guard `updateMemberRole`
- * owns (§7) — missing one turns the profile picker into a privilege-escalation
- * control. In order:
+ * Assignment is a **role write**, and since the standalone role mutation was
+ * removed it is the ONLY one — so every guard that path owned lives here (§7).
+ * Missing one turns the profile picker into a privilege-escalation control.
+ * In order:
  *
  * 1. `members.manage` **and** `permissions.manage` (a profile is an access shape,
  *    so assigning one is a permissions write as much as a member write).
@@ -56,8 +64,8 @@ export interface AssignMemberProfileResult {
  * 5. No self-service, the Owner-only lever, the admin-peer refusal, and the
  *    `canManageTarget` + `rankOf` rank guard — the last run against the
  *    profile's DECLARED role, not the caller's wish.
- * 6. Last-owner protection, failing with the same error `updateMemberRole`
- *    produces.
+ * 6. Last-owner protection — reassigning the only Owner off Owner rank fails
+ *    with the same message the remove-member path uses.
  * 7. The doc 19 §6.1 escalation guard over the member's **resulting effective
  *    state**, snapshotted before and after the write inside one transaction, so
  *    a refusal rolls the binding back.
@@ -127,9 +135,15 @@ export async function assignMemberProfile(
     )
   }
 
+  // Snapshot the rank BEFORE the write. `targetMembership` may alias the row the
+  // update mutates, so reading it after the transaction can report the new rank
+  // as the old one — which would silently make every audit row claim no rank
+  // change occurred.
+  const previousRole: OrganizationRole = targetMembership.role
+
   // The rank the member will actually hold. Guarding anything else would let a
   // profile-declared rank slip past the guards below (plan 21 §2.a.3).
-  const nextRole: OrganizationRole = profile ? profile.role : targetMembership.role
+  const nextRole: OrganizationRole = profile ? profile.role : previousRole
 
   // 5. §2.A invariant: a field (worker) seat can never hold ADMIN/OWNER
   //    authority. Unreachable from the UI (§3.5 makes such a profile
@@ -141,7 +155,7 @@ export async function assignMemberProfile(
     )
   }
 
-  // 6. Role-relative escalation guards, ported verbatim from `updateMemberRole`.
+  // 6. Role-relative escalation guards (§5.2).
   //    Owner-only lever: only an OWNER may grant OWNER rank or touch an OWNER.
   if (
     actorMembership.role !== 'OWNER' &&
@@ -175,7 +189,7 @@ export async function assignMemberProfile(
   }
 
   // 7. Last-owner protection — reassigning the only Owner off Owner rank must
-  //    fail identically to `updateMemberRole`.
+  //    fail identically to the remove-member path's last-owner check.
   if (targetMembership.role === 'OWNER' && nextRole !== 'OWNER') {
     const [ownerCount] = await db
       .select({ value: count() })
@@ -230,7 +244,7 @@ export async function assignMemberProfile(
   })
 
   // Recompose caches + nudge the client: the binding AND the rank both shift the
-  // member's composed capability set. Same tail as `updateMemberRole`; lazy
+  // member's composed capability set. Same tail as the seat-type path; lazy
   // imports keep members off the cache / dehydration / realtime stacks at load.
   const { onCacheEvent } = await import('../cache')
   await onCacheEvent('member.role.changed', { orgId: organizationId, userId: memberUserId })
@@ -248,5 +262,10 @@ export async function assignMemberProfile(
     actorUserId,
   })
 
-  return { success: true, permissionProfileId, role: nextRole }
+  return {
+    success: true,
+    permissionProfileId,
+    role: nextRole,
+    previousRole,
+  }
 }

--- a/packages/lib/src/members/index.ts
+++ b/packages/lib/src/members/index.ts
@@ -28,7 +28,7 @@ export {
   inviteMember,
   resendInvitation,
 } from './invitations'
-export { removeMember, updateMemberRole, updateMemberSeatType } from './member-mutations'
+export { removeMember, updateMemberSeatType } from './member-mutations'
 export {
   findMemberByUser,
   getActiveMemberCount,

--- a/packages/lib/src/members/member-mutations.ts
+++ b/packages/lib/src/members/member-mutations.ts
@@ -1,11 +1,11 @@
 // packages/lib/src/members/member-mutations.ts
 
 import { type Database, database, schema } from '@auxx/database'
-import type { OrganizationRole, SeatType } from '@auxx/database/types'
+import type { SeatType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, count, eq } from 'drizzle-orm'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../errors'
-import { canManageTarget, rankOf, requireMemberManage } from './guards'
+import { canManageTarget, requireMemberManage } from './guards'
 import { findMemberByUser } from './member-queries'
 import { assertSeatAvailable } from './seat-limits'
 
@@ -91,140 +91,6 @@ export async function removeMember(
   }
 
   logger.info('Member removed successfully', { organizationId, memberToRemoveId, removerUserId })
-  return { success: true }
-}
-
-/**
- * Updates a member's role within the organization.
- */
-export async function updateMemberRole(
-  params: {
-    organizationId: string
-    updaterUserId: string
-    memberToUpdateId: string
-    newRole: OrganizationRole
-  },
-  db: Database = database
-): Promise<{ success: true }> {
-  const { organizationId, updaterUserId, memberToUpdateId, newRole } = params
-
-  logger.info('Attempting to update member role', {
-    organizationId,
-    memberToUpdateId,
-    newRole,
-    updaterUserId,
-  })
-
-  // 1. Base gate — the actor must hold `members.manage`.
-  await requireMemberManage(updaterUserId, organizationId, db)
-
-  const updaterMembership = await findMemberByUser(organizationId, updaterUserId, db)
-  if (!updaterMembership) {
-    throw new ForbiddenError('You are not a member of this organization.')
-  }
-
-  // 2. Get the membership of the user being updated
-  const targetMembership = await findMemberByUser(organizationId, memberToUpdateId, db)
-  if (!targetMembership) {
-    throw new NotFoundError('Member not found.')
-  }
-
-  // §2.A invariant: a field (worker) seat can never hold ADMIN/OWNER authority
-  // (`seatType='worker'` ⇒ `role='USER'`). The seat type must be switched to
-  // 'full' before the member can be promoted.
-  if (targetMembership.seatType === 'worker' && newRole !== 'USER') {
-    throw new BadRequestError(
-      'This member holds a field seat, which is limited to the Member role. ' +
-        "Change their seat type to 'full' before promoting them to Admin or Owner."
-    )
-  }
-
-  // Cannot update own role
-  if (updaterUserId === memberToUpdateId) {
-    throw new BadRequestError('You cannot change your own role.')
-  }
-
-  // 3. Role-relative escalation guards (§5.2)
-  // Owner-only lever: only an OWNER may promote to OWNER or touch an OWNER.
-  if (
-    updaterMembership.role !== 'OWNER' &&
-    (newRole === 'OWNER' || targetMembership.role === 'OWNER')
-  ) {
-    logger.warn('Permission denied for managing owner roles', {
-      updaterRole: updaterMembership.role,
-      targetRole: targetMembership.role,
-      newRole,
-      updaterUserId,
-      memberToUpdateId,
-    })
-    throw new ForbiddenError('Only Owners can manage Owner roles.')
-  }
-  // Admin peers cannot change each other's role.
-  if (updaterMembership.role === 'ADMIN' && targetMembership.role === 'ADMIN') {
-    throw new ForbiddenError('Admins cannot change the role of other Admins.')
-  }
-  // Rank guard: an actor may only act on a manageable target and may not mint a
-  // role above their own rank (blocks a USER-rank `members.manage` grantee from
-  // touching ADMIN/OWNER or promoting anyone above USER).
-  if (
-    !canManageTarget(updaterMembership.role, targetMembership.role) ||
-    rankOf(newRole) > rankOf(updaterMembership.role)
-  ) {
-    logger.warn('Permission denied for updating roles', {
-      updaterRole: updaterMembership.role,
-      updaterUserId,
-    })
-    throw new ForbiddenError("You don't have permission to update member roles.")
-  }
-
-  // 4. Prevent removing the last owner by changing their role
-  if (targetMembership.role === 'OWNER' && newRole !== 'OWNER') {
-    const [ownerCount] = await db
-      .select({ value: count() })
-      .from(schema.OrganizationMember)
-      .where(
-        and(
-          eq(schema.OrganizationMember.organizationId, organizationId),
-          eq(schema.OrganizationMember.role, 'OWNER')
-        )
-      )
-
-    if ((ownerCount?.value ?? 0) <= 1) {
-      logger.warn('Attempted to change role of the last owner', {
-        organizationId,
-        memberToUpdateId,
-      })
-      throw new BadRequestError(
-        'Cannot change the role of the only Owner. Transfer ownership first.'
-      )
-    }
-  }
-
-  // 5. Update the role
-  await db
-    .update(schema.OrganizationMember)
-    .set({ role: newRole, updatedAt: new Date() })
-    .where(eq(schema.OrganizationMember.id, targetMembership.id))
-
-  // Recompose caches + nudge the client: a role change shifts the member's
-  // composed capability set (role defaults). Mirrors the seat-type path.
-  const { onCacheEvent } = await import('../cache')
-  await onCacheEvent('member.role.changed', {
-    orgId: organizationId,
-    userId: memberToUpdateId,
-  })
-  const { DehydrationCacheService } = await import('../dehydration/cache')
-  await new DehydrationCacheService().invalidateUser(memberToUpdateId)
-  // UX-only live merge for the affected member's open clients.
-  const { getRealtimeService, publishCapabilitiesChanged } = await import('../realtime')
-  await publishCapabilitiesChanged(getRealtimeService(), { userId: memberToUpdateId })
-
-  logger.info('Member role updated successfully', {
-    organizationId,
-    memberToUpdateId,
-    newRole,
-    updaterUserId,
-  })
   return { success: true }
 }
 


### PR DESCRIPTION
## Why

`member.updateRole` had **zero callers anywhere in the repo**, and its lib function `updateMemberRole` was called only from that one procedure. It was also the weaker of the two role-write paths:

| | `member.updateRole` (removed) | `member.assignProfile` (kept) |
|---|---|---|
| `members.manage` | ✅ | ✅ |
| `permissions.manage` | ❌ | ✅ |
| doc 19 §6.1 escalation guard | ❌ | ✅ |
| writes `permissionProfileId` | ❌ leaves it stale | ✅ |

So a direct API call could desynchronize a member's rank from the profile it is supposed to derive from, while skipping the guard the profile path was built around. Rank has not been authorable on its own since plan 21 §2.0.1.

## What

**Deleted:** the procedure (`member.ts:183-221`), `updateMemberRole` (`member-mutations.ts`, 134 lines), its barrel export, and the imports each orphaned (`rankOf`, `OrganizationRole`, `DehydrationCacheService`).

**Rewritten:** the six prose references in `assign-profile.ts` / its test that cited `updateMemberRole` as the guard precedent — they'd have become pointers to nothing. The lead docstring now states the fact the deletion creates:

> Assignment is a **role write**, and since the standalone role mutation was removed it is the ONLY one — so every guard that path owned lives here (§7).

## Auditing

This is the half worth reviewing. Deleting the procedure left `member.role_changed` with **no writer** — it was a live audited event, written as a raw string rather than via the constant, which is why it initially looked already-dead.

Rather than resurrect it, the audit consolidates onto the one remaining role-write path. But `member.profile_assigned` recorded only `newState`, so **a promotion and a no-op rebinding were indistinguishable**. `assignMemberProfile` now returns `previousRole` and the router records it as `previousState`. Since `ListAuditEventsInput` filters by action string, this keeps rank changes findable under one action rather than none.

Catalog additions — actions already being written, just never recorded in the vocabulary (`AuditAction` permits ad-hoc strings, so the catalog is autocomplete + documentation, not enforcement):

- `permission.profile.created` / `permission.profile.updated` (written by `permissions.ts`)
- `member.profile_assigned`, `member.seat_type_changed` (written by `member.ts`)

Every entry added has exactly one writer; the removed entry had zero.

## One bug caught in review

`previousRole` is snapshotted **before** the write rather than read off `targetMembership` at return time. That object can alias the row the update mutates, so the first version returned the *new* role as the old one — making every audit row claim no rank change occurred. The two new assertions fail without the snapshot, which is how it was found.

## Verification

- `packages/lib` members suite: **60/60 pass** (2 new assertions, both directions — promotion and demotion).
- `git grep` for `updateMemberRole` / `member.updateRole`: no matches; only the deliberate explanatory comments mention `member.role_changed`.
- Biome clean on all six files.
- Zero new tsc errors in either package. `apps/web` total unchanged at **4034**; `member.ts`'s four errors are pre-existing and shift by exactly the line delta (327→286→291 across the two stages).

## Not included

The larger gap found while mapping this: **`agent.ts` has 10 mutations and zero audit calls**, and no agent action exists in the catalog at all. `agent.update` writes `runAsUserId` and `permissionProfileId` — what its own doc calls *"the authority-shaped pair"* — which is a privilege delegation to a non-human actor and currently leaves no trace. Same shape but lower severity in `dashboard.ts` (10), `kb.ts` (25), `dataset.ts` (6), `segment.ts` (5), `document.ts` (5). Worth its own PR.