### PR TITLE
fix(permissions): run the escalation guard on user-tier grants

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/permissions/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/permissions/page.tsx
@@ -34,8 +34,10 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
  *
  * Until this change "Member baseline" was a fifth surface that ALSO wrote the
  * `member` profile's area levels, through a `role:org_member` bridge and
- * `setGranteeLevels` — a path with no escalation guard. Its grid is gone; the
- * tab kept only the `ResourceAccess` rows it was the sole host of.
+ * `setGranteeLevels` — which ran no escalation guard at the time. Its grid is
+ * gone; the tab kept only the `ResourceAccess` rows it was the sole host of.
+ * (`setGranteeLevels` is guarded on its `user` tier since plan 37, but a profile
+ * base still belongs to the Profiles tab: it moves every holder at once.)
  */
 export default function PermissionsPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })

--- a/apps/web/src/components/permissions/hooks/use-permission-grants.ts
+++ b/apps/web/src/components/permissions/hooks/use-permission-grants.ts
@@ -55,8 +55,9 @@ export function useRoleDefaults() {
  * grantee LIST, and the profile surfaces.
  *
  * Reaches the **override** tiers only (`group`, `user`). A profile's base is
- * written by `permissions.saveProfile`, the only path that runs the doc 19 §6.1
- * escalation guard over each holder's resulting effective state.
+ * written by `permissions.saveProfile`, the path that runs the doc 19 §6.1
+ * escalation guard over every PROFILE holder's resulting effective state; since
+ * plan 37 the `user` override tier runs the same guard over its single holder.
  *
  * Two optimistic patches, both predictable-by-construction because the server
  * stores exactly the sparse map we send: the `listGrants` row (for the overrides
@@ -135,8 +136,9 @@ export function useGrantWrites() {
    *
    * Narrowed to the two raise-only tiers, matching `permissions.grant`'s input
    * enum. `'profile'` and the legacy `'role'` are both excluded server-side
-   * because `setGranteeLevels` runs no escalation guard; a profile base is
-   * written through `permissions.saveProfile` instead.
+   * because `setGranteeLevels` cannot enumerate their holders, so the escalation
+   * guard it now runs (plan 37, `user` tier) has nothing to compare for them; a
+   * profile base is written through `permissions.saveProfile` instead.
    */
   const save = useCallback(
     (granteeType: OverrideGranteeType, granteeId: string, levels: Partial<Record<Area, Level>>) => {

--- a/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
+++ b/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
@@ -43,9 +43,12 @@ const RECORDS_ID = 'records'
  * This tab deliberately carries **no area-level grid**. Member area levels are
  * the `member` permission profile's `PermissionGrant` row, edited in exactly one
  * place — Profiles → Member — because that save is the only path that runs the
- * doc 19 §6.1 escalation guard over the resulting state of every holder. The
- * grid that used to live here wrote per-area through `setGranteeLevels`, which
- * runs no such guard, so it could reach a state the profile editor refuses.
+ * doc 19 §6.1 escalation guard over the resulting state of every PROFILE holder.
+ * The grid that used to live here wrote per-area through `setGranteeLevels`,
+ * which at the time ran no guard at all, so it could reach a state the profile
+ * editor refuses. Plan 37 has since put the same guard on `setGranteeLevels`'
+ * `user` tier, but that does not reopen this grid: a profile base moves every
+ * holder at once, which is the comparison `savePermissionProfile` owns.
  *
  * Each row's **Inherit** option still names what it falls through to (the Member
  * profile's level for that area, or No Access for resources born private), so

--- a/apps/web/src/server/api/routers/permissions-profile-base-write-path.test.ts
+++ b/apps/web/src/server/api/routers/permissions-profile-base-write-path.test.ts
@@ -10,8 +10,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * `savePermissionProfile` runs the §6.1 escalation guard: it snapshots every
  * affected holder's effective state inside one transaction, applies the writes,
  * re-composes, and rolls back on any raise the actor does not hold themselves.
- * `setGranteeLevels` runs **no** such guard — only `assertGrantableLevels`, which
- * today rejects the single `adminOnly` area (`settings`) and nothing else.
+ *
+ * `setGranteeLevels` ran **no** such guard when these tests were written — only
+ * `assertGrantableLevels`, which rejects the single `adminOnly` area (`settings`)
+ * and nothing else. Plan 37 phase 1 put the same guard on its `user` tier; its
+ * `group` tier is still unguarded. That does not weaken anything below: these
+ * tests pin that `'profile'` and `'role'` are off the wire, and the reason is
+ * holder enumeration, not the presence of a guard.
  *
  * Until this change the Member-baseline tab wrote the org's `member` profile
  * through `setGranteeLevels`, addressed as `role:org_member` and redirected onto

--- a/apps/web/src/server/api/routers/permissions.ts
+++ b/apps/web/src/server/api/routers/permissions.ts
@@ -27,12 +27,18 @@ import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
  *
  * `'profile'` is absent because a profile is the composition BASE, not a raise
  * above it, and every base write must go through {@link
- * permissionsRouter.saveProfile}: that is the only path running the §6.1
- * escalation guard over each holder's resulting effective state.
- * `setGranteeLevels` runs `assertGrantableLevels` alone, which today blocks only
- * the single `adminOnly` area (`settings`) — so a `profile` grantee here would
- * let a non-admin `permissionsManage` holder write `billing`/`members`/
- * `permissions` into a profile's base with no authority check at all.
+ * permissionsRouter.saveProfile}: that is the path running the §6.1 escalation
+ * guard over each PROFILE holder's resulting effective state. `setGranteeLevels`
+ * resolves holders per grantee tier, and a profile's holder set is not among them
+ * — so a `profile` grantee here would skip the guard entirely and let a non-admin
+ * `permissionsManage` holder write `billing`/`members`/`permissions` into a
+ * profile's base with no authority check at all.
+ *
+ * Since plan 37 phase 1 the `user` tier of this very mutation runs that same
+ * guard over its single holder, which is what stops the actor naming themselves
+ * as the grantee. **The `group` tier is still unguarded** (plan 37 §4 — the
+ * >`HOLDER_GUARD_CAP` fallback is an open decision), so a `permissionsManage`
+ * holder can still raise a group they belong to.
  *
  * `'role'` is absent for the same reason, one step removed: plan 19 §0.8 deleted
  * the `role:org_member` `PermissionGrant` tier (no composer reads it — see

--- a/packages/lib/scripts/check-grant-escalation-guard.ts
+++ b/packages/lib/scripts/check-grant-escalation-guard.ts
@@ -1,0 +1,142 @@
+// packages/lib/scripts/check-grant-escalation-guard.ts
+//
+// Dev util: prove plan 37 phase 1 against REAL postgres, without a browser.
+//
+// The escalation this guards is API-only — both grant surfaces gate on a
+// client-side `useUser({ requireRoles: ['ADMIN','OWNER'] })`, and an admin
+// already holds everything, so there is no UI repro. This drives
+// `setGranteeLevels` directly with a chosen actor instead.
+//
+// It asserts three things and writes nothing durable:
+//   1. a weak actor granting THEMSELVES `billing: Full` is refused
+//   2. the refusal ROLLED BACK — no `PermissionGrant` row survives
+//   3. the owner can still make the same grant (the §0.10 recovery guarantee)
+//
+// Requires: the org on a plan with `granularPermissions` (Growth/Enterprise),
+// and an actor holding `permissions` but NOT `billing`. Pass ids as env vars:
+//
+//   ORG_ID=... ACTOR_ID=... OWNER_ID=... \
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/check-grant-escalation-guard.ts
+
+import { database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { Area, Level, setGranteeLevels } from '../src/permissions/capabilities'
+import { computeEffectiveStatesUncached } from '../src/permissions/profiles/effective-state'
+
+const ORG_ID = process.env.ORG_ID
+const ACTOR_ID = process.env.ACTOR_ID
+const OWNER_ID = process.env.OWNER_ID
+/**
+ * The area to attempt a raise on. Must be one the actor does NOT already hold at
+ * `Full` — composition is `max(base, maxOverGroups, user)`, so an area supplied
+ * by ANY tier (a group grant is the easy one to miss) makes the attempt a no-op
+ * raise that the guard correctly allows. The check below prints the composed
+ * level first for exactly that reason.
+ */
+const AREA = (process.env.AREA ?? Area.members) as Area
+
+async function grantRow(granteeId: string) {
+  const [row] = await database
+    .select({ levels: schema.PermissionGrant.levels })
+    .from(schema.PermissionGrant)
+    .where(
+      and(
+        eq(schema.PermissionGrant.organizationId, ORG_ID as string),
+        eq(schema.PermissionGrant.granteeType, 'user'),
+        eq(schema.PermissionGrant.granteeId, granteeId)
+      )
+    )
+    .limit(1)
+  return row?.levels
+}
+
+async function main() {
+  if (!ORG_ID || !ACTOR_ID || !OWNER_ID) {
+    console.error('Set ORG_ID, ACTOR_ID and OWNER_ID.')
+    process.exit(1)
+  }
+
+  const before = await grantRow(ACTOR_ID)
+  console.log('actor grant row BEFORE:', before ?? '(none)')
+
+  // Fixture check FIRST. A raise the actor already composes is not an
+  // escalation, and the guard allowing it is correct — so read the composed
+  // level before concluding anything from a non-denial.
+  const states = await computeEffectiveStatesUncached({
+    organizationId: ORG_ID,
+    userIds: [ACTOR_ID],
+    tx: database,
+  })
+  const composed = states.get(ACTOR_ID)?.areas[AREA]
+  console.log(`actor composes '${AREA}' at level ${composed} (0=None 1=Read 2=Edit 3=Full)`)
+  if (composed === Level.Full) {
+    console.error(
+      `\nBAD FIXTURE: the actor already holds '${AREA}' at Full, so asking for Full raises\n` +
+        'nothing and the guard will (correctly) allow it. Pick an area no profile, group\n' +
+        'or user grant supplies — check their group memberships, not just their own row.'
+    )
+    process.exit(1)
+  }
+
+  // 1 + 2 — the self-grant must be refused, and must leave nothing behind.
+  let denied: string | null = null
+  try {
+    await setGranteeLevels({
+      organizationId: ORG_ID,
+      granteeType: 'user',
+      granteeId: ACTOR_ID,
+      grantedById: ACTOR_ID,
+      levels: { ...(before ?? {}), [AREA]: Level.Full },
+    })
+  } catch (error) {
+    denied = error instanceof Error ? error.message : String(error)
+  }
+
+  const after = await grantRow(ACTOR_ID)
+  console.log('actor grant row AFTER: ', after ?? '(none)')
+  console.log(denied ? `DENIED  ✅  ${denied}` : 'NOT DENIED  ❌  the guard did not fire')
+
+  const rolledBack = JSON.stringify(before ?? null) === JSON.stringify(after ?? null)
+  console.log(rolledBack ? 'ROLLED BACK  ✅' : 'ROW SURVIVED  ❌  the throw did not undo the write')
+
+  // 3 — an owner must still be able to make the same grant, or a mis-shaped
+  // grant would be unrepairable by anyone.
+  try {
+    await setGranteeLevels({
+      organizationId: ORG_ID,
+      granteeType: 'user',
+      granteeId: ACTOR_ID,
+      grantedById: OWNER_ID,
+      levels: { ...(before ?? {}), [AREA]: Level.Full },
+    })
+    console.log('OWNER GRANT ALLOWED  ✅')
+  } catch (error) {
+    console.log('OWNER GRANT REFUSED  ❌ ', error instanceof Error ? error.message : error)
+  }
+
+  // Restore whatever was there, so the script leaves no trace.
+  if (before === undefined) {
+    await database
+      .delete(schema.PermissionGrant)
+      .where(
+        and(
+          eq(schema.PermissionGrant.organizationId, ORG_ID),
+          eq(schema.PermissionGrant.granteeType, 'user'),
+          eq(schema.PermissionGrant.granteeId, ACTOR_ID)
+        )
+      )
+  } else {
+    await setGranteeLevels({
+      organizationId: ORG_ID,
+      granteeType: 'user',
+      granteeId: ACTOR_ID,
+      grantedById: OWNER_ID,
+      levels: before,
+    })
+  }
+  console.log('restored the original grant row.')
+  process.exit(0)
+}
+
+void main()

--- a/packages/lib/src/permissions/capabilities/grant-service.test.ts
+++ b/packages/lib/src/permissions/capabilities/grant-service.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/permissions/capabilities/grant-service.test.ts
 
 import type { Database } from '@auxx/database'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const roleMap: Record<
   string,
@@ -46,30 +46,154 @@ vi.mock('../feature-permission-service', () => ({
   },
 }))
 
+/**
+ * The effective-state module, faked but **live**: `composeFakeState` reads the
+ * grant store at call time, so the `after` snapshot genuinely reflects the row
+ * written earlier in the transaction. A frozen fake would make every escalation
+ * assertion pass vacuously — which is precisely the failure mode plan 37 §6.3's
+ * second mutation exists to catch.
+ *
+ * `loadActorRole`'s own query is not exercised here; `profile-save.test.ts`
+ * drives the real function against a fake `OrganizationMember` table.
+ */
+vi.mock('../profiles/effective-state', () => ({
+  computeEffectiveStatesUncached: vi.fn(
+    async ({ userIds, tx }: { userIds: string[]; tx: unknown }) => {
+      composedWith.push(tx)
+      const out = new Map<string, unknown>()
+      for (const userId of userIds) out.set(userId, composeFakeState(userId))
+      return out
+    }
+  ),
+  loadActorRole: vi.fn(async (_tx: unknown, _organizationId: string, userId: string) => {
+    const member = store.members[userId]
+    if (!member) throw new ForbiddenError('You are not a member of this organization.')
+    return member.role
+  }),
+}))
+
+import type { OrganizationRole } from '@auxx/database/types'
+import { ForbiddenError } from '../../errors'
 import { composeUserCapabilities } from './compose-user-capabilities'
 import { setGranteeLevels } from './grant-service'
-import { Area, Level, PermissionKey, parseAreaLevels } from './registry'
+import { AREA_ORDER, Area, Level, PermissionKey, parseAreaLevels } from './registry'
 import { MEMBER_BASELINE_LEVELS } from './seat-policy'
 
 const ORG = 'org_1'
 
+interface FakeMember {
+  role: OrganizationRole
+  /** The member's own composed base, before any `PermissionGrant` row applies. */
+  base: Partial<Record<Area, Level>>
+}
+
+/**
+ * The `tx` every `computeEffectiveStatesUncached` call was handed, in order.
+ *
+ * Composing either snapshot through anything other than the open transaction —
+ * the org cache, or the outer `db` — returns PRE-write values on both sides, so
+ * the guard compares a state to itself and passes unconditionally. The fake
+ * composer reads a module-level store and would not notice, so the runner
+ * identity is pinned directly instead.
+ */
+let composedWith: unknown[]
+
+/** The transaction runner the fake db hands to the callback. */
+let txRunner: unknown
+
+/** What the fake composer and the fake db both read. */
+let store: {
+  members: Record<string, FakeMember | undefined>
+  /** Written grant rows, keyed `<granteeType>:<granteeId>`. */
+  grants: Record<string, Partial<Record<Area, Level>>>
+}
+
+function resetStore() {
+  composedWith = []
+  txRunner = undefined
+  store = {
+    members: {
+      // The default actor: an admin, so the seven storability cases below are
+      // never denied by the guard and keep testing what they were written for.
+      u_admin: { role: 'ADMIN', base: allAreas(Level.Full) },
+      u_owner: { role: 'OWNER', base: allAreas(Level.Full) },
+      u_human: { role: 'USER', base: {} },
+      u_agent: { role: 'USER', base: {} },
+      u_peer: { role: 'USER', base: {} },
+    },
+    grants: {},
+  }
+}
+
+function allAreas(level: Level): Record<Area, Level> {
+  const areas = {} as Record<Area, Level>
+  for (const area of AREA_ORDER) areas[area] = level
+  return areas
+}
+
+/**
+ * Compose one principal the way the real composer does, to the depth this suite
+ * needs: a non-member holds nothing, and everyone else is `max(base, userGrant)`
+ * — the raise-only user tier.
+ *
+ * OWNER is deliberately NOT special-cased here. An owner's all-Full state comes
+ * from `ROLE_DEFAULTS.OWNER` landing in their base, exactly as it does in
+ * composition — so a test can hand an owner a degraded base and prove the
+ * guard's OWNER short-circuit holds on its own rather than riding on the base.
+ */
+function composeFakeState(userId: string) {
+  const member = store.members[userId]
+  if (!member) return { userId, areas: allAreas(Level.None), defs: {}, instances: {} }
+
+  const granted = store.grants[`user:${userId}`] ?? {}
+  const areas = {} as Record<Area, Level>
+  for (const area of AREA_ORDER) {
+    areas[area] = Math.max(member.base[area] ?? Level.None, granted[area] ?? Level.None)
+  }
+  return { userId, areas, defs: {}, instances: {} }
+}
+
 /**
  * Minimal chainable drizzle stub covering only the shapes `setGranteeLevels`
- * touches; captures the `levels` payload that reaches the upsert.
+ * touches; captures the `levels` payload that reaches the upsert and applies it
+ * to the store so the post-write snapshot can see it.
+ *
+ * `transaction` restores the store on a throw — the rollback is the entire undo
+ * mechanism for a denied grant, so a test asserting "no row was written" is
+ * testing the real property only if this restores.
  */
 function fakeDb(sink: { levels?: Record<string, number> }): Database {
-  const db = {
+  const runner = {
     insert: () => ({
-      values: (row: { levels: Record<string, number> }) => {
+      values: (row: { granteeType: string; granteeId: string; levels: Record<string, number> }) => {
         sink.levels = row.levels
+        store.grants[`${row.granteeType}:${row.granteeId}`] = row.levels as Partial<
+          Record<Area, Level>
+        >
         return {
           onConflictDoUpdate: () => ({ returning: async () => [row] }),
         }
       },
     }),
   }
-  return db as unknown as Database
+  txRunner = runner
+  return {
+    ...runner,
+    transaction: async <T>(fn: (tx: typeof runner) => Promise<T>): Promise<T> => {
+      const snapshot = structuredClone(store.grants)
+      try {
+        return await fn(runner)
+      } catch (error) {
+        store.grants = snapshot
+        throw error
+      }
+    },
+  } as unknown as Database
 }
+
+beforeEach(() => {
+  resetStore()
+})
 
 describe('setGranteeLevels — Level.None storability (v2 §1)', () => {
   it('KEEPS Level.None for an AGENT user grantee (the only way to lock an area down)', async () => {
@@ -194,5 +318,241 @@ describe('setGranteeLevels — Level.None storability (v2 §1)', () => {
       db: fakeDb(sink),
     })
     expect(sink.levels).toEqual({})
+  })
+})
+
+/**
+ * Plan 37 phase 1 — the §6.1 escalation guard on the `user` grantee tier.
+ *
+ * `permissions.grant` is gated on `permissionsManage` alone and its input places
+ * no per-area restriction, so before this guard a holder could name THEMSELVES
+ * as the grantee and write `{billing: Full, members: Full, permissions: Full}`.
+ * `assertGrantableLevels` never caught it: `adminOnly` is `settings` alone, and
+ * all three of those areas are deliberately grantable.
+ */
+describe('setGranteeLevels — the escalation guard (plan 37 §3)', () => {
+  /** Register a member with an explicit composed base. */
+  function member(userId: string, role: OrganizationRole, base: Partial<Record<Area, Level>> = {}) {
+    store.members[userId] = { role, base }
+  }
+
+  it('DENIES an actor granting themselves an area they do not hold', async () => {
+    member('u_weak', 'USER', { [Area.records]: Level.Full })
+    const sink: { levels?: Record<string, number> } = {}
+
+    await expect(
+      setGranteeLevels({
+        organizationId: ORG,
+        granteeType: 'user',
+        granteeId: 'u_weak',
+        grantedById: 'u_weak',
+        levels: { [Area.billing]: Level.Full },
+        db: fakeDb(sink),
+      })
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('ROLLS BACK the row on denial — the throw is the whole undo mechanism', async () => {
+    member('u_weak', 'USER', {})
+    const sink: { levels?: Record<string, number> } = {}
+
+    await expect(
+      setGranteeLevels({
+        organizationId: ORG,
+        granteeType: 'user',
+        granteeId: 'u_weak',
+        grantedById: 'u_weak',
+        levels: { [Area.permissions]: Level.Full },
+        db: fakeDb(sink),
+      })
+    ).rejects.toThrow(ForbiddenError)
+
+    // The insert DID run — the guard is post-write by design, so "denied" has to
+    // mean "rolled back", not "never attempted".
+    expect(sink.levels).toEqual({ [Area.permissions]: Level.Full })
+    expect(store.grants['user:u_weak']).toBeUndefined()
+  })
+
+  it('ALLOWS granting an area the actor holds themselves, to someone else', async () => {
+    member('u_strong', 'USER', { [Area.billing]: Level.Full })
+    const sink: { levels?: Record<string, number> } = {}
+
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_peer',
+      grantedById: 'u_strong',
+      levels: { [Area.billing]: Level.Full },
+      db: fakeDb(sink),
+    })
+
+    expect(store.grants['user:u_peer']).toEqual({ [Area.billing]: Level.Full })
+  })
+
+  it('DENIES a raise above the actor even when the grantee is someone else', async () => {
+    member('u_mid', 'USER', { [Area.billing]: Level.Read })
+    const sink: { levels?: Record<string, number> } = {}
+
+    await expect(
+      setGranteeLevels({
+        organizationId: ORG,
+        granteeType: 'user',
+        granteeId: 'u_peer',
+        grantedById: 'u_mid',
+        levels: { [Area.billing]: Level.Full },
+        db: fakeDb(sink),
+      })
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('an OWNER actor short-circuits past the guard (the §0.10 recovery guarantee)', async () => {
+    const sink: { levels?: Record<string, number> } = {}
+
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_peer',
+      grantedById: 'u_owner',
+      levels: { [Area.billing]: Level.Full, [Area.permissions]: Level.Full },
+      db: fakeDb(sink),
+    })
+
+    expect(store.grants['user:u_peer']).toEqual({
+      [Area.billing]: Level.Full,
+      [Area.permissions]: Level.Full,
+    })
+  })
+
+  it('an OWNER actor passes even when their own composed state is NOT all-Full', async () => {
+    // The short-circuit is doc 19 §0.10's recovery guarantee and must hold
+    // structurally, not because an owner happens to compose all-Full. Give this
+    // owner an empty base: without the early return the grant below raises
+    // `billing` above the actor's own `None` and would be denied, locking the
+    // org out of repairing a mis-shaped grant.
+    member('u_owner_clamped', 'OWNER', {})
+    const sink: { levels?: Record<string, number> } = {}
+
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_peer',
+      grantedById: 'u_owner_clamped',
+      levels: { [Area.billing]: Level.Full },
+      db: fakeDb(sink),
+    })
+
+    expect(store.grants['user:u_peer']).toEqual({ [Area.billing]: Level.Full })
+  })
+
+  it('an OWNER GRANTEE is vacuous — they compose all-Full, so nothing is raised', async () => {
+    member('u_weak', 'USER', {})
+    const sink: { levels?: Record<string, number> } = {}
+
+    // A weak actor granting an owner everything is not an escalation: the owner
+    // already composes all-Full from their role, so after === before.
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_owner',
+      grantedById: 'u_weak',
+      levels: { [Area.billing]: Level.Full },
+      db: fakeDb(sink),
+    })
+
+    expect(store.grants['user:u_owner']).toEqual({ [Area.billing]: Level.Full })
+  })
+
+  it('a NON-MEMBER grantee composes empty, so the grant raises nobody', async () => {
+    member('u_weak', 'USER', {})
+    const sink: { levels?: Record<string, number> } = {}
+
+    // Fails closed rather than denying: the row is written, but a user with no
+    // membership composes nothing from it, so there is no raise to refuse.
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_ghost',
+      grantedById: 'u_weak',
+      levels: { [Area.billing]: Level.Full },
+      db: fakeDb(sink),
+    })
+
+    expect(composeFakeState('u_ghost').areas[Area.billing]).toBe(Level.None)
+  })
+
+  it('a DECREASE is permitted even by an actor who no longer holds the area', async () => {
+    member('u_faded', 'USER', {})
+    store.grants['user:u_peer'] = { [Area.billing]: Level.Full }
+    const sink: { levels?: Record<string, number> } = {}
+
+    // Nothing is denied unless `after > before` — so an admin whose own access
+    // was narrowed can still clean up. Mirrors `clearGranteeLevels` not being
+    // plan-gated: removal only tightens.
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_peer',
+      grantedById: 'u_faded',
+      levels: {},
+      db: fakeDb(sink),
+    })
+
+    expect(store.grants['user:u_peer']).toEqual({})
+  })
+
+  it('DENIES an actor with no membership row at all', async () => {
+    const sink: { levels?: Record<string, number> } = {}
+
+    await expect(
+      setGranteeLevels({
+        organizationId: ORG,
+        granteeType: 'user',
+        granteeId: 'u_peer',
+        grantedById: 'u_nobody',
+        levels: { [Area.billing]: Level.Full },
+        db: fakeDb(sink),
+      })
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('composes BOTH snapshots through the open transaction, never the outer db', async () => {
+    member('u_strong', 'USER', { [Area.billing]: Level.Full })
+    const sink: { levels?: Record<string, number> } = {}
+    const db = fakeDb(sink)
+
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'user',
+      granteeId: 'u_peer',
+      grantedById: 'u_strong',
+      levels: { [Area.billing]: Level.Full },
+      db,
+    })
+
+    expect(composedWith).toHaveLength(2)
+    for (const tx of composedWith) {
+      expect(tx).toBe(txRunner)
+      expect(tx).not.toBe(db)
+    }
+  })
+
+  it('does NOT yet guard a GROUP grantee — pins the phase 2 hole so it fails loudly when closed', async () => {
+    member('u_weak', 'USER', {})
+    const sink: { levels?: Record<string, number> } = {}
+
+    // `resolveHolderIds` returns null for `group`, which skips the guard. This
+    // is plan 37 §4's open decision (the >HOLDER_GUARD_CAP fallback), NOT an
+    // oversight — a `permissionsManage` holder can still raise a group they are
+    // in. When phase 2 lands this must flip to `rejects.toThrow`.
+    await setGranteeLevels({
+      organizationId: ORG,
+      granteeType: 'group',
+      granteeId: 'grp_weak',
+      grantedById: 'u_weak',
+      levels: { [Area.billing]: Level.Full },
+      db: fakeDb(sink),
+    })
+
+    expect(store.grants['group:grp_weak']).toEqual({ [Area.billing]: Level.Full })
   })
 })

--- a/packages/lib/src/permissions/capabilities/grant-service.ts
+++ b/packages/lib/src/permissions/capabilities/grant-service.ts
@@ -7,6 +7,13 @@ import { getOrgCache, onCacheEvent } from '../../cache'
 import { DehydrationCacheService } from '../../dehydration/cache'
 import { ForbiddenError } from '../../errors'
 import { FeaturePermissionService } from '../feature-permission-service'
+import {
+  computeEffectiveStatesUncached,
+  type EffectiveState,
+  loadActorRole,
+  type QueryRunner,
+} from '../profiles/effective-state'
+import { type ActorAuthority, assertNoEscalation } from '../profiles/escalation-guard'
 import { FeatureKey } from '../types'
 import { type Area, Level, PERMISSION_AREAS, parseAreaLevels } from './registry'
 
@@ -51,7 +58,9 @@ export interface GranteeRef {
  * `MEMBER_BASELINE_LEVELS` in seat-policy.ts (plan 22). §6.1.5's parenthetical
  * listing all four as blocked here does not match the registry; the §6.1
  * escalation guard, not this check, is what keeps `billing`/`members`/
- * `permissions` from being handed out by someone who does not hold them.
+ * `permissions` from being handed out by someone who does not hold them —
+ * and since plan 37 that guard runs on {@link setGranteeLevels}'s own `user`
+ * path, not only on the profile save. `group` grants remain unguarded (phase 2).
  *
  * The seeded `owner`/`admin` system profiles express "everything" via
  * `PermissionProfile.baseLevel`, NOT an all-Full grant row, so system seeding
@@ -124,6 +133,81 @@ async function granteeKeepsNoneLevels(grantee: GranteeRef): Promise<boolean> {
   return roleMap[grantee.granteeId]?.userType === 'AGENT'
 }
 
+/**
+ * Every member whose composed capabilities this grant moves — the holder set the
+ * §6.1 escalation guard snapshots either side of the write (plan 37 §3).
+ *
+ * `null` means "this tier's holders are not resolved here", which **skips the
+ * guard**, so every arm returning it owes a reason:
+ *
+ *  - **`group`** — resolvable and free (invert the cached `groupMembers` map,
+ *    plan 37 §2), but the >`HOLDER_GUARD_CAP`-holder fallback is an open
+ *    decision (plan 37 §4). Deliberately phase 2; **this is a known open hole**,
+ *    not an oversight — a `permissionsManage` holder can still raise a group they
+ *    belong to.
+ *  - **`profile`** — a profile base is written by `savePermissionProfile`, which
+ *    runs the guard over the profile's real holder set. Nothing reaches this
+ *    function with a `profile` grantee: #1350 narrowed the router input to
+ *    `['group','user']`.
+ *  - **`role`** — the legacy `role:org_member` row. No composer reads it, so it
+ *    moves nobody's state; it is also off the wire since #1350.
+ *
+ * The `switch` is exhaustive over {@link GrantGranteeType} on purpose: a new
+ * grantee tier is a compile error here rather than a silently unguarded one.
+ */
+function resolveHolderIds(granteeType: GrantGranteeType, granteeId: string): string[] | null {
+  switch (granteeType) {
+    case 'user':
+      return [granteeId]
+    case 'group':
+    case 'profile':
+    case 'role':
+      return null
+    default: {
+      const unreachable: never = granteeType
+      return unreachable
+    }
+  }
+}
+
+/** The pre-write half of the guard: who the actor is, and where the holders stood. */
+interface GuardSnapshot {
+  actor: ActorAuthority
+  before: Map<string, EffectiveState>
+}
+
+/**
+ * Snapshot the actor's authority and every holder's state **inside the
+ * transaction, before the write** (plan 37 §3.1).
+ *
+ * Both properties are load-bearing and neither is obvious from the call site:
+ *
+ *  - The actor's authority is their **PRE-write** state, so a grant can never
+ *    authorize itself by first raising the actor. `permissions.grant` is gated on
+ *    `permissionsManage` alone — nothing stops the actor naming themselves as the
+ *    grantee, which is exactly the escalation this closes.
+ *  - The snapshots come from `computeEffectiveStatesUncached`, which reads
+ *    transaction-locally. Composing through the org cache would return pre-write
+ *    values on BOTH sides, the guard would compare a state to itself, and it
+ *    would pass unconditionally — green tests over a guard that does nothing.
+ */
+async function snapshotBeforeWrite(
+  tx: QueryRunner,
+  organizationId: string,
+  holderIds: string[],
+  actorUserId: string
+): Promise<GuardSnapshot> {
+  const actorRole = await loadActorRole(tx, organizationId, actorUserId)
+  const before = await computeEffectiveStatesUncached({
+    organizationId,
+    userIds: [...holderIds, actorUserId],
+    tx,
+  })
+  const actorState = before.get(actorUserId)
+  if (!actorState) throw new ForbiddenError('You are not a member of this organization.')
+  return { actor: { userId: actorUserId, role: actorRole, state: actorState }, before }
+}
+
 /** Enterprise gate — writing override grants requires the plan feature (§2.H/§8). */
 async function requireGranularPermissions(db: Database, organizationId: string): Promise<void> {
   await new FeaturePermissionService(db).requireAccess(
@@ -194,6 +278,13 @@ async function emitGrantChanged(grantee: GranteeRef): Promise<void> {
  * (human users, groups) and kept for `profile` grantees (the composition base),
  * the legacy `role:org_member` policy, and AGENT user grantees — see
  * {@link stripInertNoneLevels}.
+ *
+ * **The write runs inside a transaction carrying the §6.1 escalation guard**
+ * (plan 37) for every grantee tier {@link resolveHolderIds} can enumerate —
+ * today `user`. `assertGrantableLevels` blocks only the single `adminOnly` area,
+ * so without this a `permissionsManage` holder could grant themselves
+ * `billing`/`members`/`permissions` outright. `group` grants are **not guarded
+ * yet** — see {@link resolveHolderIds}.
  */
 export async function setGranteeLevels(
   input: GranteeRef & {
@@ -207,36 +298,57 @@ export async function setGranteeLevels(
 
   const parsed = parseAreaLevels(input.levels)
   assertGrantableLevels(parsed)
+  // Both of these read Redis. They are resolved BEFORE the transaction opens:
+  // a cache round trip inside one holds the grant row's lock for a network hop.
   const levels = stripInertNoneLevels(
     parsed,
     await granteeKeepsNoneLevels({ organizationId, granteeType, granteeId })
   )
   await requireGranularPermissions(db, organizationId)
+  const holderIds = resolveHolderIds(granteeType, granteeId)
 
-  const [row] = await db
-    .insert(schema.PermissionGrant)
-    .values({
-      id: generateId(),
-      organizationId,
-      granteeType,
-      granteeId,
-      levels,
-      grantedById,
-    })
-    .onConflictDoUpdate({
-      target: [
-        schema.PermissionGrant.organizationId,
-        schema.PermissionGrant.granteeType,
-        schema.PermissionGrant.granteeId,
-      ],
-      set: {
+  const row = await db.transaction(async (tx) => {
+    const guard = holderIds
+      ? await snapshotBeforeWrite(tx, organizationId, holderIds, grantedById)
+      : null
+
+    const [written] = await tx
+      .insert(schema.PermissionGrant)
+      .values({
+        id: generateId(),
+        organizationId,
+        granteeType,
+        granteeId,
         levels,
         grantedById,
-        updatedAt: new Date(),
-      },
-    })
-    .returning()
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.PermissionGrant.organizationId,
+          schema.PermissionGrant.granteeType,
+          schema.PermissionGrant.granteeId,
+        ],
+        set: {
+          levels,
+          grantedById,
+          updatedAt: new Date(),
+        },
+      })
+      .returning()
 
+    if (guard && holderIds) {
+      const after = await computeEffectiveStatesUncached({ organizationId, userIds: holderIds, tx })
+      // The throw IS the rollback — there is no compensating write. A raise the
+      // actor does not hold themselves leaves no row behind.
+      assertNoEscalation({ actor: guard.actor, before: guard.before, after })
+    }
+
+    return written
+  })
+
+  // Outside the transaction on purpose: this fires cache invalidation and
+  // realtime, so running it inside would leave the org's caches busted for a
+  // write the guard rolled back.
   await emitGrantChanged({ organizationId, granteeType, granteeId })
   return row as PermissionGrantEntity
 }

--- a/packages/lib/src/permissions/profiles/effective-state.ts
+++ b/packages/lib/src/permissions/profiles/effective-state.ts
@@ -5,6 +5,7 @@ import { MemberType, type ResourcePermission } from '@auxx/database/enums'
 import type { OrganizationRole, SeatType, UserType } from '@auxx/database/types'
 import { and, eq, inArray, isNotNull, isNull } from 'drizzle-orm'
 import { getCachedResources } from '../../cache'
+import { ForbiddenError } from '../../errors'
 import type { Resource } from '../../resources/registry/types'
 import { isCustomResourceId } from '../../resources/registry/types'
 import { composeUserCapabilities } from '../capabilities/compose-user-capabilities'
@@ -405,6 +406,41 @@ export async function computeEffectiveStatesUncached(input: {
   const inputs = await readUncachedInputs(organizationId, userIds, tx)
   for (const userId of userIds) out.set(userId, composeState(userId, inputs, organizationId))
   return out
+}
+
+/**
+ * The actor's org role, read transaction-locally — the other half of an
+ * {@link ActorAuthority}, beside the state {@link computeEffectiveStatesUncached}
+ * composes.
+ *
+ * Every escalation-guarded write path needs this and needs it from the SAME
+ * snapshot as the state, so it lives here rather than being re-implemented per
+ * call site: the role drives the OWNER short-circuit
+ * (`escalation-guard.ts`'s early return), which is doc 19 §0.10's recovery
+ * guarantee. A hand-copied second reader is how that guarantee drifts — the
+ * two copies of `effectiveInstanceLevel` had already silently diverged once.
+ *
+ * Throws rather than returning `undefined`: a caller with no membership row has
+ * no authority to compare against, and every branch below the guard assumes one.
+ */
+export async function loadActorRole(
+  tx: QueryRunner,
+  organizationId: string,
+  actorUserId: string
+): Promise<OrganizationRole> {
+  const [row] = await tx
+    .select({ role: schema.OrganizationMember.role })
+    .from(schema.OrganizationMember)
+    .where(
+      and(
+        eq(schema.OrganizationMember.organizationId, organizationId),
+        eq(schema.OrganizationMember.userId, actorUserId)
+      )
+    )
+    .limit(1)
+
+  if (!row) throw new ForbiddenError('You are not a member of this organization.')
+  return row.role
 }
 
 /**

--- a/packages/lib/src/permissions/profiles/profile-save.ts
+++ b/packages/lib/src/permissions/profiles/profile-save.ts
@@ -1,7 +1,6 @@
 // packages/lib/src/permissions/profiles/profile-save.ts
 
 import { type Database, database, type PermissionProfileEntity, schema } from '@auxx/database'
-import type { OrganizationRole } from '@auxx/database/types'
 import { generateId } from '@auxx/utils'
 import { and, eq } from 'drizzle-orm'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../../errors'
@@ -10,7 +9,7 @@ import { type Area, type Level, parseAreaLevels } from '../capabilities/registry
 import { FeaturePermissionService } from '../feature-permission-service'
 import { FeatureKey } from '../types'
 import { parseAgentPolicy } from './agent-policy'
-import { computeEffectiveStatesUncached, type QueryRunner } from './effective-state'
+import { computeEffectiveStatesUncached, loadActorRole, type QueryRunner } from './effective-state'
 import {
   type ActorAuthority,
   assertNoEscalation,
@@ -268,27 +267,6 @@ async function loadProfile(
 
   if (!row) throw new NotFoundError('Permission profile not found in this organization.')
   return row as ProfileRow
-}
-
-/** The actor's org role — the §6.1.1 OWNER short-circuit and the agent gate. */
-async function loadActorRole(
-  tx: QueryRunner,
-  organizationId: string,
-  actorUserId: string
-): Promise<OrganizationRole> {
-  const [row] = await tx
-    .select({ role: schema.OrganizationMember.role })
-    .from(schema.OrganizationMember)
-    .where(
-      and(
-        eq(schema.OrganizationMember.organizationId, organizationId),
-        eq(schema.OrganizationMember.userId, actorUserId)
-      )
-    )
-    .limit(1)
-
-  if (!row) throw new ForbiddenError('You are not a member of this organization.')
-  return row.role
 }
 
 /** Read the profile's currently stored area levels (for the strict fallback). */


### PR DESCRIPTION
Plan 37 phase 1. **Note:** this branch was authored in a parallel session sharing the worktree; I verified, linted and committed it as found — the design decisions are that session's, recorded in the code comments.

## The hole

`setGranteeLevels` wrote a `PermissionGrant` row behind `assertGrantableLevels` alone, which rejects only the single `adminOnly` area (`settings`). Nothing stopped a `permissionsManage` holder from **naming themselves as the grantee** — so they could hand themselves `billing`, `members` or `permissions` outright. The doc 19 §6.1 escalation guard ran only on the profile-save path (#1350), never here.

## The fix

The write now runs inside a transaction that snapshots the actor's authority and every holder's effective state before the write, re-composes after, and lets `assertNoEscalation` throw. **The throw IS the rollback** — no compensating write, so a refused raise leaves no row behind.

Two details that look incidental and are load-bearing:

- The actor's authority is their **PRE-write** state, so a grant can never authorize itself by raising the actor first.
- Both snapshots come from `computeEffectiveStatesUncached`, which reads **transaction-locally**. Composing through the org cache would return pre-write values on *both* sides — the guard would compare a state to itself and pass unconditionally, giving a green suite over a guard that does nothing.

## Scope — one tier, deliberately

Holder resolution is per grantee tier, and the `switch` is **exhaustive over `GrantGranteeType`**, so a new tier is a compile error rather than a silently unguarded write.

| tier | guarded | why |
|---|---|---|
| `user` | ✅ | holder set is the grantee |
| `group` | ❌ **known open hole** | phase 2 — the >`HOLDER_GUARD_CAP` fallback is an open decision (plan 37 §4). A `permissionsManage` holder **can still raise a group they belong to.** |
| `profile` | n/a | unreachable — #1350 narrowed the router input; base writes go through `saveProfile` |
| `role` | n/a | legacy `role:org_member`; no composer reads it |

The `group` gap is documented at the function, in the router, and in this PR rather than left to be discovered.

## Refactor

`loadActorRole` moves from `profile-save.ts` into `effective-state.ts`. Both guarded write paths need the role from the *same snapshot* as the state, and it drives the OWNER short-circuit that is doc 19 §0.10's recovery guarantee. A hand-copied second reader is how that guarantee drifts — the two copies of `effectiveInstanceLevel` had already diverged once.

`emitGrantChanged` stays **outside** the transaction; inside, it would bust the org's caches for a write the guard rolled back.

## Dev script

The escalation is **API-only** — both grant surfaces gate on a client-side `useUser({ requireRoles: ['ADMIN','OWNER'] })`, and an admin already holds everything, so there is no browser repro. `packages/lib/scripts/check-grant-escalation-guard.ts` drives `setGranteeLevels` with a chosen actor against real postgres and asserts refusal + rollback + that an owner can still make the same grant, then restores the original row.

It checks the fixture first and bails if the actor already composes the target area at `Full` — a raise you already hold is not an escalation, and the guard allowing it is correct, so a non-denial would otherwise read as a failure.

## Doc corrections

Five call sites claimed `setGranteeLevels` runs no guard. Each is corrected in place, and each keeps the reason `profile`/`role` stay off the wire — **holder enumeration, not the absence of a guard**. That distinction is what stops someone reopening the Member-baseline grid now that a guard exists: a profile base moves every holder at once, which is the comparison `savePermissionProfile` owns.

## Verification

- `packages/lib` permissions: **473 pass** (21 files; `grant-service.test.ts` gains ~372 lines).
- `apps/web` permissions + the profile-base-write-path test: **123 pass** (11 files).
- Biome clean on all ten files.
- Zero new tsc errors — `packages/lib` **3526** and `apps/web` **4034**, both unchanged, and all changed files grep clean.

Not run: the dev script against postgres (needs an org on a `granularPermissions` plan plus a `permissions`-but-not-`billing` actor).