### PR TITLE
fix(permissions): key inbox grants by slug so mail visibility reads them

### DIFF
--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -530,159 +530,167 @@ export function InboxForm({
   // (not part of the FieldPanel look) keeps native keyboard-submit working in the
   // palette host, which has no Dialog shell to run the Cmd+Enter handler. In the
   // dialog host plain Enter is suppressed by DialogContent and Cmd+Enter clicks the
-  // `data-dialog-submit` button. When the members drill is on, the form pads itself
-  // inside the flush `p-0` DialogNav shell; the palette host supplies its own padding.
+  // `data-dialog-submit` button. When the members drill is on, the BODY pads itself
+  // inside the flush `p-0` DialogNav shell — the padding must stay off the `<form>`
+  // so the footer remains an unpadded sibling of the body, which is what
+  // `DialogNavPages` re-gutters via its `[data-slot=dialog-footer]` rule. Padding the
+  // form instead stacks both gutters and indents the buttons past the fields.
+  // The palette host supplies its own padding.
   const configurePage = (
     <form
       onSubmit={(e) => {
         e.preventDefault()
         void handleSubmit()
       }}
-      className={enableMembersPage ? 'flex flex-col gap-4 p-4' : 'flex flex-col gap-4'}>
-      <FieldPanel
-        orientation='responsive'
-        breakpoint='md'
-        resizeId='inbox-form'
-        defaultLabelWidth={200}
-        className='p-0'>
-        {/* Name */}
-        <FieldPanelRow
-          title='Name'
-          type={BaseType.STRING}
-          showIcon
-          isRequired
-          validationError={errors.name}
-          validationType='error'>
-          <FieldInputAdapter
-            fieldType={FieldType.TEXT}
-            value={values.name}
-            onChange={(val) => handleChange('name', (val as string) ?? '')}
-            placeholder='Enter inbox name'
-            disabled={isPending}
-          />
-        </FieldPanelRow>
-
-        {/* Description */}
-        <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
-          <FieldInputAdapter
-            fieldType={FieldType.TEXT}
-            value={values.description}
-            onChange={(val) => handleChange('description', (val as string) ?? '')}
-            placeholder='Optional description'
-            disabled={isPending}
-            fieldOptions={{ multiline: true }}
-          />
-        </FieldPanelRow>
-
-        {/* Color */}
-        <FieldPanelRow title='Color' type={BaseType.ENUM} showIcon>
-          <div className='py-2'>
-            <FormColorTagPicker
-              value={values.color}
-              onChange={(color) => handleChange('color', color)}
+      className='flex flex-col'>
+      {/* `pt-4` not `p-4` on the bottom edge: the footer supplies its own `pt-4`,
+          so padding the body bottom too would double the gap above the buttons. */}
+      <div className={enableMembersPage ? 'flex flex-col gap-4 px-4 pt-4' : 'flex flex-col gap-4'}>
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='inbox-form'
+          defaultLabelWidth={200}
+          className='p-0'>
+          {/* Name */}
+          <FieldPanelRow
+            title='Name'
+            type={BaseType.STRING}
+            showIcon
+            isRequired
+            validationError={errors.name}
+            validationType='error'>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={values.name}
+              onChange={(val) => handleChange('name', (val as string) ?? '')}
+              placeholder='Enter inbox name'
+              disabled={isPending}
             />
-          </div>
-        </FieldPanelRow>
+          </FieldPanelRow>
 
-        {/* Access section — org admins and inbox Managers only */}
-        {canManageAccess &&
-          (isPersonalInbox ? (
-            <FieldPanelRow title='Access' showIcon icon={<Shield />} className='@md:flex-col!'>
-              <div className='space-y-2 rounded-[13px] border p-3 mb-1 me-1 -ms-1'>
-                {ownerActorId && (
-                  <div className='flex items-center justify-between'>
-                    <ActorBadge actorId={ownerActorId} />
-                    <span className='text-muted-foreground text-xs'>Owner</span>
-                  </div>
-                )}
-                <p className='text-muted-foreground text-xs'>
-                  Personal account: mail here is private to its owner. Admins can see activity only;
-                  assignment and shares grant access per thread.
-                </p>
-              </div>
-            </FieldPanelRow>
-          ) : (
-            <>
-              <FieldPanelRow title='Access' showIcon icon={<Shield />} className='@md:flex-col!'>
-                <RadioGroup
-                  value={values.accessType}
-                  onValueChange={handleAccessTypeChange}
-                  className='grid gap-2 py-2 pe-2 sm:grid-cols-2'>
-                  <RadioGroupItemCard
-                    value='anyone'
-                    label='Everyone'
-                    icon={<UsersIcon />}
-                    description='Everyone in the organization, at a chosen level'
-                  />
-                  <RadioGroupItemCard
-                    value='restricted'
-                    label='Restricted'
-                    icon={<Lock />}
-                    description='Only people and groups you add below'
-                  />
-                </RadioGroup>
-              </FieldPanelRow>
+          {/* Description */}
+          <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={values.description}
+              onChange={(val) => handleChange('description', (val as string) ?? '')}
+              placeholder='Optional description'
+              disabled={isPending}
+              fieldOptions={{ multiline: true }}
+            />
+          </FieldPanelRow>
 
-              {values.accessType === 'anyone' && (
-                <FieldPanelRow title='Everyone can see' showIcon icon={<Eye />}>
-                  <LensSelect
-                    value={values.floorLens}
-                    onChange={(choice) =>
-                      choice !== 'manager' &&
-                      handleChange('floorLens', choice as Exclude<Lens, 'none'>)
-                    }
-                    size='default'
-                    variant='transparent'
-                    className='w-full'
-                  />
-                </FieldPanelRow>
-              )}
-            </>
-          ))}
-      </FieldPanel>
-
-      {/* People & groups — a standalone section below the panel (like the webhook
-          Topics drill), not a FieldPanelRow. */}
-      {canManageAccess && (
-        <div className='flex flex-col gap-2'>
-          <div className='flex items-center gap-1.5 px-1 text-muted-foreground text-xs font-medium'>
-            <UsersIcon className='size-3.5' />
-            People &amp; groups
-          </div>
-          {enableMembersPage ? (
-            // Drill into the members page (webhook-topics style).
-            <button
-              type='button'
-              onClick={() => setPage('members')}
-              className='flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-muted/50'>
-              <span className='flex items-center gap-2 text-muted-foreground'>
-                {membersSummary}
-              </span>
-              <ChevronRight className='size-4 text-muted-foreground' />
-            </button>
-          ) : (
-            <>
-              <MailGranteeList
-                grants={values.grants}
-                onGrant={updateGrant}
-                onChangeLens={updateGrant}
-                onRevoke={removeGrant}
-                includeManager
-                disabled={isPending}
-                lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
-                unmanageableGrants={unmanageableGrants}
-                emptyHint={membersEmptyHint}
+          {/* Color */}
+          <FieldPanelRow title='Color' type={BaseType.ENUM} showIcon>
+            <div className='py-2'>
+              <FormColorTagPicker
+                value={values.color}
+                onChange={(color) => handleChange('color', color)}
               />
+            </div>
+          </FieldPanelRow>
+
+          {/* Access section — org admins and inbox Managers only */}
+          {canManageAccess &&
+            (isPersonalInbox ? (
+              <FieldPanelRow title='Access' showIcon icon={<Shield />} className='@md:flex-col!'>
+                <div className='space-y-2 rounded-[13px] border p-3 mb-1 me-1 -ms-1'>
+                  {ownerActorId && (
+                    <div className='flex items-center justify-between'>
+                      <ActorBadge actorId={ownerActorId} />
+                      <span className='text-muted-foreground text-xs'>Owner</span>
+                    </div>
+                  )}
+                  <p className='text-muted-foreground text-xs'>
+                    Personal account: mail here is private to its owner. Admins can see activity
+                    only; assignment and shares grant access per thread.
+                  </p>
+                </div>
+              </FieldPanelRow>
+            ) : (
+              <>
+                <FieldPanelRow title='Access' showIcon icon={<Shield />} className='@md:flex-col!'>
+                  <RadioGroup
+                    value={values.accessType}
+                    onValueChange={handleAccessTypeChange}
+                    className='grid gap-2 py-2 pe-2 sm:grid-cols-2'>
+                    <RadioGroupItemCard
+                      value='anyone'
+                      label='Everyone'
+                      icon={<UsersIcon />}
+                      description='Everyone in the organization, at a chosen level'
+                    />
+                    <RadioGroupItemCard
+                      value='restricted'
+                      label='Restricted'
+                      icon={<Lock />}
+                      description='Only people and groups you add below'
+                    />
+                  </RadioGroup>
+                </FieldPanelRow>
+
+                {values.accessType === 'anyone' && (
+                  <FieldPanelRow title='Everyone can see' showIcon icon={<Eye />}>
+                    <LensSelect
+                      value={values.floorLens}
+                      onChange={(choice) =>
+                        choice !== 'manager' &&
+                        handleChange('floorLens', choice as Exclude<Lens, 'none'>)
+                      }
+                      size='default'
+                      variant='transparent'
+                      className='w-full'
+                    />
+                  </FieldPanelRow>
+                )}
+              </>
+            ))}
+        </FieldPanel>
+
+        {/* People & groups — a standalone section below the panel (like the webhook
+          Topics drill), not a FieldPanelRow. */}
+        {canManageAccess && (
+          <div className='flex flex-col gap-2'>
+            <div className='flex items-center gap-1.5 px-1 text-muted-foreground text-xs font-medium'>
+              <UsersIcon className='size-3.5' />
+              People &amp; groups
+            </div>
+            {enableMembersPage ? (
+              // Drill into the members page (webhook-topics style).
               <button
                 type='button'
-                className='mt-1 self-start text-muted-foreground text-xs underline-offset-2 hover:underline'
-                onClick={() => setGuideOpen(true)}>
-                Learn about access levels
+                onClick={() => setPage('members')}
+                className='flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-muted/50'>
+                <span className='flex items-center gap-2 text-muted-foreground'>
+                  {membersSummary}
+                </span>
+                <ChevronRight className='size-4 text-muted-foreground' />
               </button>
-            </>
-          )}
-        </div>
-      )}
+            ) : (
+              <>
+                <MailGranteeList
+                  grants={values.grants}
+                  onGrant={updateGrant}
+                  onChangeLens={updateGrant}
+                  onRevoke={removeGrant}
+                  includeManager
+                  disabled={isPending}
+                  lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
+                  unmanageableGrants={unmanageableGrants}
+                  emptyHint={membersEmptyHint}
+                />
+                <button
+                  type='button'
+                  className='mt-1 self-start text-muted-foreground text-xs underline-offset-2 hover:underline'
+                  onClick={() => setGuideOpen(true)}>
+                  Learn about access levels
+                </button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
 
       <DialogFooter className='flex sm:justify-between!'>
         {isEditing ? (

--- a/apps/web/src/components/inbox/inbox-members-page.tsx
+++ b/apps/web/src/components/inbox/inbox-members-page.tsx
@@ -104,7 +104,12 @@ export function InboxMembersPage({
         )}
       </Section>
 
-      <DialogFooter className='py-2 pe-3'>
+      {/* The bangs are required, not stylistic: `DialogNavPages` gutters nested
+          footers with `[&_[data-slot=dialog-footer]]:px-4 …:pb-4`, and that
+          descendant selector outranks a plain utility. Without them this compact
+          footer silently renders at the standard 4-gutter, misaligned with the
+          Section's `p-3` above it. */}
+      <DialogFooter className='px-3! py-2!'>
         <Button variant='outline' size='sm' type='button' onClick={onBack}>
           Done
         </Button>

--- a/apps/web/src/components/webhooks/ui/webhook-endpoint-configure-form.tsx
+++ b/apps/web/src/components/webhooks/ui/webhook-endpoint-configure-form.tsx
@@ -184,125 +184,134 @@ export function WebhookEndpointConfigureForm({
         e.preventDefault()
         handleSubmit()
       }}
-      className='flex flex-col gap-4 p-4'>
-      {isEdit && endpoint && <CopyRow label='Webhook URL' value={endpoint.url} icon={<Link />} />}
+      className='flex flex-col'>
+      {/* The gutter lives on the body, not the `<form>`: `DialogNavPages` re-gutters a
+          nested `[data-slot=dialog-footer]` on the assumption that the footer is an
+          unpadded sibling of the padded body. Padding the form instead stacks both
+          gutters and indents the buttons past the fields. The bottom edge is left to
+          the footer's own `pt-4`; only the footer-less host pads it here. */}
+      <div className={showFooter ? 'flex flex-col gap-4 px-4 pt-4' : 'flex flex-col gap-4 p-4'}>
+        {isEdit && endpoint && <CopyRow label='Webhook URL' value={endpoint.url} icon={<Link />} />}
 
-      <div className='flex flex-col gap-2'>
-        <div className='text-xs font-medium text-muted-foreground'>Configuration</div>
-        <FieldPanel
-          orientation='responsive'
-          breakpoint='md'
-          resizeId='webhook-endpoint'
-          defaultLabelWidth={200}
-          className='p-0'>
-          <ConnectionVariableFields
-            variables={endpointVars(values.topicSourceKind, {
-              includeStripeSecret: mode === 'create',
-            })}
-            values={values}
-            onValueChange={setValue}
-            errors={errors}
-            disabled={pending}
-          />
-        </FieldPanel>
-      </div>
-
-      {values.verification === 'none' && (
-        <div className='flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5 text-xs text-amber-800'>
-          <TriangleAlert className='size-4 shrink-0 text-amber-600' />
-          <span>
-            Anyone with the URL can trigger this endpoint. Use a token or HMAC in production.
-          </span>
+        <div className='flex flex-col gap-2'>
+          <div className='text-xs font-medium text-muted-foreground'>Configuration</div>
+          <FieldPanel
+            orientation='responsive'
+            breakpoint='md'
+            resizeId='webhook-endpoint'
+            defaultLabelWidth={200}
+            className='p-0'>
+            <ConnectionVariableFields
+              variables={endpointVars(values.topicSourceKind, {
+                includeStripeSecret: mode === 'create',
+              })}
+              values={values}
+              onValueChange={setValue}
+              errors={errors}
+              disabled={pending}
+            />
+          </FieldPanel>
         </div>
-      )}
 
-      {isEdit && endpoint?.hasSecret && (
-        <FieldPanel
-          orientation='responsive'
-          breakpoint='md'
-          resizeId='webhook-endpoint'
-          defaultLabelWidth={200}
-          className='p-0'>
-          <FieldPanelRow title='Signing secret' icon={<KeyRound />} showIcon>
-            {isStripeEdit && replacingSecret ? (
-              <div className='flex min-h-8 items-center gap-2 pe-1'>
-                <Input
-                  type='password'
-                  value={newSecret}
-                  onChange={(e) => setNewSecret(e.target.value)}
-                  placeholder='whsec_…'
-                  className='h-8 font-mono text-xs'
-                  autoFocus
-                />
-                <Button
-                  variant='outline'
-                  size='xs'
-                  type='button'
-                  onClick={handleRotate}
-                  disabled={!newSecret.trim()}
-                  loading={rotateSecret.isPending}
-                  loadingText='Saving...'>
-                  Save
-                </Button>
-                <Button
-                  variant='ghost'
-                  size='xs'
-                  type='button'
-                  onClick={() => {
-                    setReplacingSecret(false)
-                    setNewSecret('')
-                  }}>
-                  Cancel
-                </Button>
-              </div>
-            ) : (
-              <div className='flex min-h-8 items-center justify-between gap-2 pe-1'>
-                <span className='font-mono text-xs text-muted-foreground'>••••••••••••</span>
-                <Button
-                  variant='ghost'
-                  size='xs'
-                  type='button'
-                  onClick={() => (isStripeEdit ? setReplacingSecret(true) : handleRotate())}
-                  loading={rotateSecret.isPending && !isStripeEdit}
-                  loadingText='Rotating...'>
-                  {isStripeEdit ? 'Replace' : 'Rotate'}
-                </Button>
-              </div>
-            )}
-          </FieldPanelRow>
-        </FieldPanel>
-      )}
-
-      {isEdit &&
-        (endpoint?.topicSource ? (
-          <div className='flex flex-col gap-2'>
-            <Button
-              variant='outline'
-              size='sm'
-              type='button'
-              className='w-full justify-between'
-              onClick={onOpenTopics}>
-              <span className='flex items-center gap-2'>
-                <Tags />
-                {endpoint.topics.length > 0 ? `Topics (${endpoint.topics.length})` : 'Setup topics'}
-              </span>
-              <ChevronRight />
-            </Button>
-            {endpoint.topics.length > 0 && (
-              <div className='flex flex-wrap gap-1'>
-                {endpoint.topics.map((topic) => (
-                  <Badge key={topic.id} variant='outline' className='font-mono text-[11px]'>
-                    {topic.key}
-                  </Badge>
-                ))}
-              </div>
-            )}
+        {values.verification === 'none' && (
+          <div className='flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5 text-xs text-amber-800'>
+            <TriangleAlert className='size-4 shrink-0 text-amber-600' />
+            <span>
+              Anyone with the URL can trigger this endpoint. Use a token or HMAC in production.
+            </span>
           </div>
-        ) : (
-          <p className='text-xs text-muted-foreground'>
-            Set a topic source above to define topics and capture their schemas.
-          </p>
-        ))}
+        )}
+
+        {isEdit && endpoint?.hasSecret && (
+          <FieldPanel
+            orientation='responsive'
+            breakpoint='md'
+            resizeId='webhook-endpoint'
+            defaultLabelWidth={200}
+            className='p-0'>
+            <FieldPanelRow title='Signing secret' icon={<KeyRound />} showIcon>
+              {isStripeEdit && replacingSecret ? (
+                <div className='flex min-h-8 items-center gap-2 pe-1'>
+                  <Input
+                    type='password'
+                    value={newSecret}
+                    onChange={(e) => setNewSecret(e.target.value)}
+                    placeholder='whsec_…'
+                    className='h-8 font-mono text-xs'
+                    autoFocus
+                  />
+                  <Button
+                    variant='outline'
+                    size='xs'
+                    type='button'
+                    onClick={handleRotate}
+                    disabled={!newSecret.trim()}
+                    loading={rotateSecret.isPending}
+                    loadingText='Saving...'>
+                    Save
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    size='xs'
+                    type='button'
+                    onClick={() => {
+                      setReplacingSecret(false)
+                      setNewSecret('')
+                    }}>
+                    Cancel
+                  </Button>
+                </div>
+              ) : (
+                <div className='flex min-h-8 items-center justify-between gap-2 pe-1'>
+                  <span className='font-mono text-xs text-muted-foreground'>••••••••••••</span>
+                  <Button
+                    variant='ghost'
+                    size='xs'
+                    type='button'
+                    onClick={() => (isStripeEdit ? setReplacingSecret(true) : handleRotate())}
+                    loading={rotateSecret.isPending && !isStripeEdit}
+                    loadingText='Rotating...'>
+                    {isStripeEdit ? 'Replace' : 'Rotate'}
+                  </Button>
+                </div>
+              )}
+            </FieldPanelRow>
+          </FieldPanel>
+        )}
+
+        {isEdit &&
+          (endpoint?.topicSource ? (
+            <div className='flex flex-col gap-2'>
+              <Button
+                variant='outline'
+                size='sm'
+                type='button'
+                className='w-full justify-between'
+                onClick={onOpenTopics}>
+                <span className='flex items-center gap-2'>
+                  <Tags />
+                  {endpoint.topics.length > 0
+                    ? `Topics (${endpoint.topics.length})`
+                    : 'Setup topics'}
+                </span>
+                <ChevronRight />
+              </Button>
+              {endpoint.topics.length > 0 && (
+                <div className='flex flex-wrap gap-1'>
+                  {endpoint.topics.map((topic) => (
+                    <Badge key={topic.id} variant='outline' className='font-mono text-[11px]'>
+                      {topic.key}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className='text-xs text-muted-foreground'>
+              Set a topic source above to define topics and capture their schemas.
+            </p>
+          ))}
+      </div>
 
       {showFooter && (
         <DialogFooter>

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -1,9 +1,11 @@
 // apps/web/src/server/api/routers/resourceAccess.ts
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { getCachedResources } from '@auxx/lib/cache'
 import { BadRequestError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import {
+  buildDefIdToSlug,
   FeatureKey,
   FeaturePermissionService,
   getCapabilities,
@@ -31,7 +33,7 @@ import {
   setTypeAccess,
 } from '@auxx/lib/resource-access'
 import type { RecordId } from '@auxx/types/resource'
-import { parseRecordId } from '@auxx/types/resource'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
@@ -40,6 +42,30 @@ import { createTRPCRouter, protectedProcedure } from '../trpc'
 
 /** Visibility lens on mail grants (mail-permissions §2.1). Optional everywhere. */
 const lensSchema = z.enum(['metadata', 'subject', 'full']).nullish()
+
+/**
+ * Mail grants live in the entity-SLUG keyspace (`inbox:<id>`, `contact:<id>`):
+ * `composeUserMailVisibility` buckets rows by `entityDefinitionId === 'inbox'`,
+ * and `isMailSharingDef` gates authorization on the same literal. Record-layer
+ * callers mint RecordIds from the EntityDefinition id instead (the inbox
+ * settings page builds `toRecordId(inboxResource.id, inboxId)`), so their grants
+ * landed under a key mail visibility never reads — a `subject` share silently did
+ * nothing — AND skipped both `assertCanManageMailSharing` and the enterprise gate.
+ *
+ * Resolve the def part through the existing `buildDefIdToSlug` resolver and
+ * rewrite ONLY when it lands on a mail-sharing def. Every other resource keeps
+ * the key it was called with: instance rows for custom defs have no stable slug
+ * (`entityType` is null, so the resolver falls back to the renameable apiSlug).
+ */
+async function canonicalMailRecordId(
+  organizationId: string,
+  recordId: RecordId
+): Promise<RecordId> {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  if (isMailSharingDef(entityDefinitionId)) return recordId
+  const slug = buildDefIdToSlug(await getCachedResources(organizationId))(entityDefinitionId)
+  return isMailSharingDef(slug) ? toRecordId(slug, entityInstanceId) : recordId
+}
 
 /** Convert tRPC context to ResourceAccessContext */
 function toContext(ctx: {
@@ -146,7 +172,10 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const context = toContext(ctx)
-      const recordId = input.recordId as RecordId
+      const recordId = await canonicalMailRecordId(
+        ctx.session.organizationId,
+        input.recordId as RecordId
+      )
       // `none` is the instance-access baseline lockdown marker (§1.4). The enum
       // permits it, but it must never land on a mail-share target — reject it for
       // any non-instance-access recordId (defense in depth; mail pickers never
@@ -177,7 +206,7 @@ export const resourceAccessRouter = createTRPCRouter({
         category: 'security',
         action: 'permission.granted',
         targetType: 'Resource',
-        targetId: input.recordId,
+        targetId: recordId,
         metadata: {
           scope: 'instance',
           granteeType: input.granteeType,
@@ -241,14 +270,18 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const context = toContext(ctx)
-      if (!(await authorizeInstanceTarget(ctx, input.recordId))) {
-        await assertCanManageMailSharing(context, input.recordId as RecordId, {
+      const recordId = await canonicalMailRecordId(
+        ctx.session.organizationId,
+        input.recordId as RecordId
+      )
+      if (!(await authorizeInstanceTarget(ctx, recordId))) {
+        await assertCanManageMailSharing(context, recordId, {
           selfRevokeGranteeId: input.granteeId,
           selfRevokeGranteeType: input.granteeType,
         })
       }
       const revoked = await revokeInstanceAccess(context, {
-        recordId: input.recordId as RecordId,
+        recordId,
         granteeType: input.granteeType,
         granteeId: input.granteeId,
       })
@@ -256,7 +289,7 @@ export const resourceAccessRouter = createTRPCRouter({
         category: 'security',
         action: 'permission.revoked',
         targetType: 'Resource',
-        targetId: input.recordId,
+        targetId: recordId,
         metadata: {
           scope: 'instance',
           granteeType: input.granteeType,
@@ -313,7 +346,10 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const context = toContext(ctx)
-      const recordId = input.recordId as RecordId
+      const recordId = await canonicalMailRecordId(
+        ctx.session.organizationId,
+        input.recordId as RecordId
+      )
       await assertProfileGranteesAuthorable(
         ctx.session.organizationId,
         input.granteeType,
@@ -328,7 +364,7 @@ export const resourceAccessRouter = createTRPCRouter({
         category: 'security',
         action: 'permission.set',
         targetType: 'Resource',
-        targetId: input.recordId,
+        targetId: recordId,
         newState: { granteeType: input.granteeType, grants: input.grants },
         metadata: { scope: 'instance' },
       })
@@ -426,7 +462,10 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .query(
       async ({ ctx, input }): Promise<Array<ResourceAccessInfo & { granteeAreaLevel?: Level }>> => {
-        const recordId = input.recordId as RecordId
+        const recordId = await canonicalMailRecordId(
+          ctx.session.organizationId,
+          input.recordId as RecordId
+        )
         const rows = await getInstanceAccess(toContext(ctx), recordId)
         const { entityDefinitionId } = parseRecordId(recordId)
         if (!isInstanceAccessKey(entityDefinitionId)) return rows

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -50,6 +50,7 @@ export {
   parseAreaLevels,
 } from './capabilities/registry'
 export { requirePermission } from './capabilities/require'
+export { buildDefIdToSlug } from './capabilities/resolve-capability-inputs'
 export {
   ALL_KEYS,
   ENTITY_WRITE_KEYS,

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -719,7 +719,7 @@ function SidebarGroupLabel({
     <Comp
       data-sidebar='group-label'
       className={cn(
-        'flex h-6 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'flex h-6 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 focus-visible:ring-inset [&>svg]:size-4 [&>svg]:shrink-0',
         className
       )}
       {...props}
@@ -798,7 +798,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-inset active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -978,7 +978,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-inset active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',


### PR DESCRIPTION
## The bug

Granting a member **Subject only** on an inbox from `/app/settings/inbox/<id>` does nothing — their lens stays whatever `inbox_default_lens` says. Setting the same level via **Everyone → Subject only** works, which is what makes it look like a lens problem rather than a keying one.

## Root cause

`ResourceAccess` rows for inboxes exist in two key forms:

```
34 rows  entityDefinitionId = 'inbox'                    ← the slug (what mail reads)
 2 rows  entityDefinitionId = 'qiramlz5m0cswo4n4v10mxkz' ← the inbox EntityDefinition cuid
```

`inbox-detail.tsx:39` builds `recordId = toRecordId(inboxResource?.id, inboxId)` — the def **cuid** — and `grantInstanceAccess` writes `entityDefinitionId` verbatim from `parseRecordId`. But `composeUserMailVisibility` buckets grants with a strict slug test:

```ts
if (row.entityDefinitionId === 'inbox') raise(inboxGrants, row.entityInstanceId, lens)
```

so the cuid row falls through into `entityGrants` — a primary-entity grant keyed by an inbox id, which derives to nothing. The same component's **create** path uses `toRecordId('inbox', created.id)`, so grants set at creation work and grants set by editing don't.

Two more consequences of the same mismatch:

- `isMailSharingDef` tests the slug set `{inbox, thread, contact}`, so both `assertCanManageMailSharing` (the inbox-Manager check) and `assertMailSharingFeature` (the Enterprise `mailPermissions` gate) returned early on these writes.
- `forInstance` read the cuid keyspace, so the legacy slug-keyed rows — including the creator's Manager row — were invisible in the form, and `setInstance`'s replace-all only replaced within the cuid keyspace.

The audit log shows cuid-keyed writes since at least 2026-07-07, including an `admin` (Manager) grant that never took effect for mail.

## Fix

Resolve the def part of instance RecordIds through the existing `buildDefIdToSlug` resolver in `grantInstance` / `setInstance` / `revokeInstance` / `forInstance`, rewriting **only** when it lands on a mail-sharing def. Every other resource keeps the key it was called with — instance rows for custom defs have no stable slug (`entityType` is null, so the resolver falls back to the renameable `apiSlug`), so they must not move keyspace.

No new normalizer; `buildDefIdToSlug` is just re-exported from the permissions barrel.

## Not in scope

- **Existing cuid-keyed rows are not re-keyed** (no data migration, per request). They are dead data after this change; the affected grants need re-saving from the inbox form once, which now writes the correct key.
- Plan 40's `Area.inboxes` work is untouched. Worth noting that `authorizeInstanceTarget`'s `isInstanceAccessKey` check is slug-based too, so it would have hit this same wall once `inbox` becomes an instance-access key.

## Also included

Unrelated UI fixes from a parallel session, in their own commit: dialog footers in the inbox/webhook forms were double-guttered because the padding sat on the `<form>` rather than a body wrapper, and sidebar buttons gained `focus-visible:ring-inset` so the keyboard ring is not clipped by the rail's overflow.

## Testing

- `tsc --noEmit` for `apps/web` and `packages/lib` — no new errors in the touched files.
- Not yet exercised in the browser.