### PR TITLE
feat(homepage): add sequences platform page and expand sitemap

### DIFF
--- a/apps/homepage/src/app/_components/main/footer-section.tsx
+++ b/apps/homepage/src/app/_components/main/footer-section.tsx
@@ -20,6 +20,10 @@ const links = [
         href: '/platform/dispatch',
       },
       {
+        title: 'Sequences',
+        href: '/platform/sequences',
+      },
+      {
         title: 'Getting started',
         href: urls.signup,
       },

--- a/apps/homepage/src/app/_components/main/header.tsx
+++ b/apps/homepage/src/app/_components/main/header.tsx
@@ -15,6 +15,7 @@ import {
   MessagesSquare,
   Newspaper,
   Plug,
+  Send,
   Shield,
   ShoppingBag,
   Sparkles,
@@ -102,6 +103,12 @@ const platformGroups: PlatformGroup[] = [
         name: 'Workflow',
         description: 'Automate your processes',
         icon: <GitBranch className='stroke-foreground fill-purple-500/15' />,
+      },
+      {
+        href: '/platform/sequences',
+        name: 'Sequences',
+        description: 'Reminders & follow-ups on autopilot',
+        icon: <Send className='stroke-foreground fill-blue-500/15' />,
       },
       {
         href: '/platform/integration',

--- a/apps/homepage/src/app/platform/dispatch/_components/platform-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/platform-section.tsx
@@ -1,6 +1,6 @@
 // apps/homepage/src/app/platform/dispatch/_components/platform-section.tsx
 
-import { Bot, GitBranch, LineChart, Users } from 'lucide-react'
+import { Bot, GitBranch, LineChart, Send, Users } from 'lucide-react'
 import Link from 'next/link'
 
 const links = [
@@ -10,6 +10,13 @@ const links = [
     description: 'Ask AI about any job, customer, or invoice.',
     href: '/platform/ai/kopilot',
     tone: 'text-violet-600 dark:text-violet-400',
+  },
+  {
+    icon: Send,
+    name: 'Sequences',
+    description: 'Visit reminders and invoice chasers that send themselves.',
+    href: '/platform/sequences',
+    tone: 'text-blue-600 dark:text-blue-400',
   },
   {
     icon: GitBranch,

--- a/apps/homepage/src/app/platform/sequences/_components/delivery-section.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/delivery-section.tsx
@@ -1,0 +1,139 @@
+// apps/homepage/src/app/platform/sequences/_components/delivery-section.tsx
+
+import { Ban, Clock, MessagesSquare, Reply } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+const DAYS = [
+  { label: 'Mon', business: true },
+  { label: 'Tue', business: true },
+  { label: 'Wed', business: true },
+  { label: 'Thu', business: true },
+  { label: 'Fri', business: true },
+  { label: 'Sat', business: false },
+  { label: 'Sun', business: false },
+]
+
+/** Rows of the hour axis, 0–24 mapped to percentages. */
+const WINDOW_START = 8
+const WINDOW_END = 20
+const pct = (hour: number) => `${(hour / 24) * 100}%`
+
+const guarantees = [
+  {
+    icon: Clock,
+    name: 'Delivery window & timezone',
+    description:
+      'Pick the hours, pick the IANA timezone, and flip on business-days-only. Anything that comes due outside the window waits.',
+  },
+  {
+    icon: MessagesSquare,
+    name: 'One thread, not six',
+    description:
+      'Step one opens the thread; every later step replies into it. Your customer sees a conversation, not a pile of unrelated mail.',
+  },
+  {
+    icon: Reply,
+    name: 'Replies end it',
+    description:
+      'An inbound reply exits the run on the spot. Nobody gets nudged about an invoice they already answered.',
+  },
+  {
+    icon: Ban,
+    name: 'Unsubscribe means everywhere',
+    description:
+      'One click suppresses that address across the whole workspace — every sequence, now and later.',
+  },
+]
+
+/** A week of send windows: lit inside the hours, hatched on non-business days. */
+function DeliveryWindowIllustration() {
+  return (
+    <div aria-hidden className='rounded-2xl border bg-card p-5 ring-1 ring-foreground/5 sm:p-6'>
+      <div className='flex items-baseline justify-between text-xs'>
+        <span className='font-medium'>08:00 – 20:00</span>
+        <span className='text-muted-foreground'>America/Los_Angeles · business days only</span>
+      </div>
+
+      <div className='mt-5 flex gap-2'>
+        {/* Hour ticks */}
+        <div className='flex w-8 shrink-0 flex-col justify-between pb-5 text-[9px] text-muted-foreground'>
+          <span>00:00</span>
+          <span>12:00</span>
+          <span>24:00</span>
+        </div>
+
+        <div className='grid flex-1 grid-cols-7 gap-1.5'>
+          {DAYS.map((day) => (
+            <div key={day.label} className='flex flex-col items-center gap-1.5'>
+              <div className='relative h-40 w-full overflow-hidden rounded-md bg-muted/60'>
+                {day.business ? (
+                  <div
+                    className='absolute inset-x-0 rounded-md bg-gradient-to-b from-blue-500/70 to-blue-500/40'
+                    style={{ top: pct(WINDOW_START), bottom: `${100 - (WINDOW_END / 24) * 100}%` }}
+                  />
+                ) : (
+                  <div className='absolute inset-0 bg-[repeating-linear-gradient(45deg,transparent,transparent_4px,var(--color-foreground)_4px,var(--color-foreground)_5px)] opacity-[0.08]' />
+                )}
+              </div>
+              <span
+                className={cn(
+                  'text-[10px]',
+                  day.business ? 'text-muted-foreground' : 'text-muted-foreground/50'
+                )}>
+                {day.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className='mt-4 flex flex-wrap items-center gap-2 border-t pt-4 text-[11px]'>
+        <span className='inline-flex items-center gap-1.5 rounded-full border border-dashed px-2 py-1 text-muted-foreground'>
+          Came due Fri 11:14 PM
+        </span>
+        <span className='text-muted-foreground'>→</span>
+        <span className='inline-flex items-center gap-1.5 rounded-full bg-blue-500/10 px-2 py-1 font-medium text-blue-600 dark:text-blue-400'>
+          Sends Mon 8:00 AM
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The trust story for customer-facing mail: when it sends, how it threads, and
+ * how it stops.
+ */
+export default function DeliverySection() {
+  return (
+    <section className='border-b bg-muted/30'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='grid items-center gap-12 lg:grid-cols-2 lg:gap-16'>
+          <div>
+            <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+              It won&apos;t email your customer at 11pm.
+            </h2>
+            <p className='mt-4 text-balance text-lg text-muted-foreground'>
+              A delivery window, a timezone, and business days only. A step that comes due at
+              midnight on a Friday waits for Monday morning — because that&apos;s when a person
+              would have sent it.
+            </p>
+          </div>
+          <DeliveryWindowIllustration />
+        </div>
+
+        <div className='mt-16 grid gap-x-6 gap-y-8 border-t pt-12 sm:grid-cols-2 lg:grid-cols-4'>
+          {guarantees.map((guarantee) => (
+            <div key={guarantee.name} className='space-y-2'>
+              <div className='flex items-center gap-2'>
+                <guarantee.icon className='size-4 fill-foreground/10 text-foreground' />
+                <h3 className='text-sm font-medium'>{guarantee.name}</h3>
+              </div>
+              <p className='text-sm text-muted-foreground'>{guarantee.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_components/personalization-section.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/personalization-section.tsx
@@ -1,0 +1,108 @@
+// apps/homepage/src/app/platform/sequences/_components/personalization-section.tsx
+'use client'
+
+import { AnimatePresence, motion } from 'motion/react'
+import { useState } from 'react'
+import { cn } from '~/lib/utils'
+import { MockStepEditor, type StepEditorVariant } from '../_mocks'
+
+const items: {
+  key: StepEditorVariant
+  title: string
+  description: string
+}[] = [
+  {
+    key: 'placeholders',
+    title: 'Fields drop straight in',
+    description:
+      'First name, invoice number, job title, due date — pulled from the record at send time, with a fallback for when a field is empty.',
+  },
+  {
+    key: 'snippets',
+    title: 'Snippets and attachments',
+    description:
+      'Insert a saved snippet, attach the quote or the service report. Set per step, so the right file rides along with the right email.',
+  },
+  {
+    key: 'sender',
+    title: 'Your mailbox, your signature',
+    description:
+      'Sends from a mailbox you pin, with a signature that mailbox is allowed to use. Replies land in your inbox, not a void.',
+  },
+]
+
+/**
+ * Sticky copy on the left, a slice of the real step editor on the right that
+ * swaps with the selected item.
+ */
+export default function PersonalizationSection() {
+  const [active, setActive] = useState<StepEditorVariant>('placeholders')
+
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='grid gap-12 lg:grid-cols-2 lg:gap-16'>
+          <div className='lg:sticky lg:top-32 lg:self-start'>
+            <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+              It reads like you wrote it.
+              <span className='text-muted-foreground'> Because you did — once.</span>
+            </h2>
+
+            <div className='mt-10 space-y-1'>
+              {items.map((item) => {
+                const isActive = item.key === active
+                return (
+                  <button
+                    key={item.key}
+                    type='button'
+                    onClick={() => setActive(item.key)}
+                    className='block w-full border-t py-4 text-left'>
+                    <div
+                      className={cn(
+                        'font-medium transition-colors',
+                        isActive ? 'text-foreground' : 'text-muted-foreground'
+                      )}>
+                      {item.title}
+                    </div>
+                    <AnimatePresence initial={false}>
+                      {isActive && (
+                        <motion.p
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: 'auto' }}
+                          exit={{ opacity: 0, height: 0 }}
+                          transition={{ duration: 0.25 }}
+                          className='overflow-hidden text-sm text-muted-foreground'>
+                          <span className='block pt-2'>{item.description}</span>
+                        </motion.p>
+                      )}
+                    </AnimatePresence>
+                  </button>
+                )
+              })}
+              <div className='border-t' />
+            </div>
+          </div>
+
+          <div className='relative flex min-h-[380px] items-center'>
+            <div
+              aria-hidden
+              className='pointer-events-none absolute inset-0 rounded-2xl bg-[radial-gradient(circle,var(--color-foreground)_1px,transparent_1px)] [background-size:20px_20px] opacity-[0.07] [mask-image:radial-gradient(ellipse_at_center,black_40%,transparent_75%)]'
+            />
+            <div className='relative w-full'>
+              <AnimatePresence mode='wait'>
+                <motion.div
+                  key={active}
+                  initial={{ opacity: 0, y: 12, filter: 'blur(6px)' }}
+                  animate={{ opacity: 1, y: 0, filter: 'blur(0)' }}
+                  exit={{ opacity: 0, y: -12, filter: 'blur(6px)' }}
+                  transition={{ duration: 0.3 }}>
+                  <MockStepEditor variant={active} />
+                </motion.div>
+              </AnimatePresence>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_components/platform-cross-links.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/platform-cross-links.tsx
@@ -1,0 +1,84 @@
+// apps/homepage/src/app/platform/sequences/_components/platform-cross-links.tsx
+
+import { BarChart3, GitBranch, MessagesSquare, Truck, Users } from 'lucide-react'
+import Link from 'next/link'
+
+const links = [
+  {
+    icon: GitBranch,
+    name: 'Workflow',
+    description: 'Every sequence compiles down to a workflow the engine runs and retries.',
+    href: '/platform/workflow',
+    tone: 'text-purple-600 dark:text-purple-400',
+  },
+  {
+    icon: Truck,
+    name: 'Dispatch',
+    description: 'Scheduled visits, en-route crews, and completed jobs are the events that enroll.',
+    href: '/platform/dispatch',
+    tone: 'text-orange-600 dark:text-orange-400',
+  },
+  {
+    icon: Users,
+    name: 'CRM',
+    description: 'Recipients are real contacts, and the fields you merge in are their fields.',
+    href: '/platform/crm',
+    tone: 'text-emerald-600 dark:text-emerald-400',
+  },
+  {
+    icon: MessagesSquare,
+    name: 'Messaging',
+    description: 'Sends from a connected mailbox — and their reply lands in your shared inbox.',
+    href: '/platform/messaging',
+    tone: 'text-blue-600 dark:text-blue-400',
+  },
+  {
+    icon: BarChart3,
+    name: 'Reporting',
+    description: 'Sequence activity reports alongside everything else in your dashboards.',
+    href: '/platform/reporting',
+    tone: 'text-sky-600 dark:text-sky-400',
+  },
+]
+
+/** Cross-links to the platform pages a sequence actually touches. */
+export default function PlatformCrossLinks() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Sequences don&apos;t run alone.
+          </h2>
+          <p className='mt-4 text-balance text-lg text-muted-foreground'>
+            They compile down to a workflow, enroll off dispatch and billing events, and report into
+            the same dashboards as everything else.
+          </p>
+        </div>
+
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-4 sm:grid-cols-2'>
+          {links.map((link, index) => (
+            <li key={link.name}>
+              <Link
+                href={link.href}
+                className='flex h-full items-start gap-3.5 rounded-xl border bg-card p-5 ring-1 ring-foreground/10 transition-shadow hover:shadow-sm hover:ring-foreground/15'>
+                <div className='flex size-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-foreground/10'>
+                  <link.icon className={`size-4 ${link.tone}`} />
+                </div>
+                <div className='space-y-0.5'>
+                  <div className='flex items-center gap-2'>
+                    <span className='font-mono text-xs text-muted-foreground'>
+                      [{String(index + 1).padStart(2, '0')}]
+                    </span>
+                    <span className='font-medium text-foreground'>{link.name}</span>
+                  </div>
+                  <p className='text-sm text-muted-foreground'>{link.description}</p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_components/sequence-rail-illustration.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/sequence-rail-illustration.tsx
@@ -1,0 +1,492 @@
+// apps/homepage/src/app/platform/sequences/_components/sequence-rail-illustration.tsx
+'use client'
+
+import { Ban, Check, Clock, MailX, Reply, Send, UserRoundPlus, Zap } from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useEffect, useState } from 'react'
+import { cn } from '~/lib/utils'
+
+const CYCLE_DURATION = 5200
+
+/** Desktop container width. Fixed so the branch geometry below is exact pixel math. */
+const RAIL_WIDTH = 600
+const CENTER = RAIL_WIDTH / 2
+
+/** Exit reasons — colors match the run-status vocabulary the hero mock uses. */
+const EXITS = {
+  replied: {
+    label: 'Replied',
+    icon: Reply,
+    dot: 'var(--color-emerald-400)',
+    chip: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+    ring: 'ring-emerald-500/20',
+  },
+  unsubscribed: {
+    label: 'Unsubscribed',
+    icon: Ban,
+    dot: 'var(--color-amber-400)',
+    chip: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+    ring: 'ring-amber-500/20',
+  },
+  bounced: {
+    label: 'Bounced',
+    icon: MailX,
+    dot: 'var(--color-rose-400)',
+    chip: 'bg-rose-500/10 text-rose-600 dark:text-rose-400',
+    ring: 'ring-rose-500/20',
+  },
+} as const
+
+type ExitKey = keyof typeof EXITS
+
+/**
+ * The two seeded three-step templates, transcribed from
+ * `packages/lib/src/sequences/seed-templates.ts`. The whole story cycles
+ * together — trigger, subjects, and timings — because a `visit:scheduled`
+ * trigger above a run of invoice emails would be a lie. Both have exactly
+ * three steps, which keeps the rail height fixed across the swap.
+ */
+const TEMPLATES = [
+  {
+    event: 'invoice:sent',
+    trigger: 'Invoice sent',
+    steps: [
+      { subject: 'Your invoice is due soon', timing: '2 days before the due date at 9:00 AM' },
+      { subject: 'Your invoice is overdue', timing: '3 days after the due date at 9:00 AM' },
+      { subject: 'Invoice still outstanding', timing: '10 days after the due date at 9:00 AM' },
+    ],
+  },
+  {
+    event: 'visit:scheduled',
+    trigger: 'Visit scheduled',
+    steps: [
+      { subject: 'Your visit is booked', timing: 'Right away' },
+      {
+        subject: 'Reminder: your visit is coming up',
+        timing: '2 days before the visit at 9:00 AM',
+      },
+      { subject: "We'll see you today", timing: 'Same day as the visit at 7:30 AM' },
+    ],
+  },
+] as const
+
+type Template = (typeof TEMPLATES)[number]
+
+/** Fades new copy in when the template swaps. */
+function Swap({ id, children }: { id: number; children: React.ReactNode }) {
+  return (
+    <motion.span
+      key={id}
+      initial={{ opacity: 0, filter: 'blur(5px)' }}
+      animate={{ opacity: 1, filter: 'blur(0px)' }}
+      transition={{ duration: 0.4 }}
+      className='block truncate'>
+      {children}
+    </motion.span>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Nodes                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Which template the whole rail is currently telling. Cycling the head instead
+ * of fanning several static sources into a hub is what keeps this from being a
+ * re-skin of `mcp-flow-illustration`.
+ */
+function useTemplateCycle() {
+  const reduceMotion = useReducedMotion()
+  const [active, setActive] = useState(0)
+
+  useEffect(() => {
+    if (reduceMotion) return
+    const interval = setInterval(() => {
+      setActive((prev) => (prev + 1) % TEMPLATES.length)
+    }, CYCLE_DURATION)
+    return () => clearInterval(interval)
+  }, [reduceMotion])
+
+  return { active, template: TEMPLATES[active] ?? TEMPLATES[0]! }
+}
+
+function TriggerNode({
+  active,
+  template,
+  compact = false,
+}: {
+  active: number
+  template: Template
+  compact?: boolean
+}) {
+  return (
+    <div className='relative'>
+      <div aria-hidden className='absolute inset-0 opacity-50 dark:opacity-20'>
+        <div className='absolute inset-1 animate-pulse rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 blur-md' />
+      </div>
+      <div
+        className={cn(
+          'relative overflow-hidden rounded-xl bg-card shadow-md shadow-black/[.065] ring-1 ring-foreground/15 backdrop-blur',
+          compact ? 'w-52' : 'w-56'
+        )}>
+        <AnimatePresence initial={false} mode='popLayout'>
+          <motion.div
+            key={active}
+            initial={{ opacity: 0, filter: 'blur(10px)', y: -28 }}
+            animate={{ opacity: 1, filter: 'blur(0)', y: 0 }}
+            exit={{ opacity: 0, filter: 'blur(10px)', y: 28 }}
+            transition={{ duration: 0.45, type: 'spring', bounce: 0.15 }}
+            className='flex items-center gap-2 p-2.5'>
+            <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-amber-500/10'>
+              <Zap className='size-3.5 text-amber-500' />
+            </span>
+            <div className='min-w-0'>
+              <div className='truncate text-[11px] font-semibold'>{template.trigger}</div>
+              <code className='block truncate font-mono text-[9px] text-foreground/60'>
+                {template.event}
+              </code>
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}
+
+function EnrollNode({ compact = false }: { compact?: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 rounded-xl bg-illustration p-2.5 shadow-md shadow-black/[.065] ring-1 ring-border-illustration',
+        compact ? 'w-52' : 'w-56'
+      )}>
+      <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-blue-500/10'>
+        <UserRoundPlus className='size-3.5 text-blue-500' />
+      </span>
+      <div className='min-w-0 flex-1'>
+        <div className='truncate text-[11px] font-semibold'>Contact enrolled</div>
+        <div className='text-[9px] text-foreground/60'>Filters checked once, at enrollment</div>
+      </div>
+    </div>
+  )
+}
+
+function StepNode({
+  n,
+  subject,
+  active,
+  compact = false,
+}: {
+  n: number
+  subject: string
+  active: number
+  compact?: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-xl bg-card shadow-md shadow-black/[.065] ring-1 ring-border-illustration',
+        compact ? 'w-60' : 'w-72'
+      )}>
+      <div className='flex items-center gap-2 px-2.5 py-2'>
+        <span className='flex size-5 shrink-0 items-center justify-center rounded-md bg-foreground text-[9px] font-semibold text-background'>
+          {n}
+        </span>
+        <Send className='size-3 shrink-0 text-foreground/50' />
+        <span className='min-w-0 flex-1 text-[11px] font-semibold'>
+          <Swap id={active}>{subject}</Swap>
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function CompletedNode() {
+  return (
+    <div className='inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-3 py-1.5 text-[11px] font-semibold text-emerald-600 ring-1 ring-emerald-500/20 dark:text-emerald-400'>
+      <Check className='size-3' />
+      Completed
+    </div>
+  )
+}
+
+function DelayPill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className='inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-dashed border-foreground/20 bg-background px-2.5 py-1 text-[10px] text-muted-foreground'>
+      <Clock className='size-2.5' />
+      {children}
+    </span>
+  )
+}
+
+function ExitPill({ exit }: { exit: ExitKey }) {
+  const meta = EXITS[exit]
+  return (
+    <span
+      className={cn(
+        'inline-flex w-32 items-center gap-1.5 rounded-lg px-2 py-1.5 text-[10px] font-medium ring-1',
+        meta.chip,
+        meta.ring
+      )}>
+      <meta.icon className='size-3 shrink-0' />
+      <span className='truncate'>{meta.label}</span>
+      <span className='ml-auto text-[9px] opacity-70'>exit</span>
+    </span>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Desktop connector — vertical rail + optional side branch                     */
+/* -------------------------------------------------------------------------- */
+
+interface ConnectorProps {
+  height: number
+  delay?: string
+  /** Active template index — drives the delay pill's crossfade on swap. */
+  active?: number
+  exit?: ExitKey
+  side?: 'left' | 'right'
+  /** Beam start offset so the pulses cascade down the spine. */
+  beamDelay?: number
+}
+
+/**
+ * One segment of the spine. The container is a fixed {@link RAIL_WIDTH} on
+ * desktop, so the branch curve can terminate exactly at the exit pill's inner
+ * edge (pills are `w-32` = 128px) with no responsive guesswork.
+ */
+function Connector({
+  height,
+  delay,
+  active = 0,
+  exit,
+  side = 'left',
+  beamDelay = 0,
+}: ConnectorProps) {
+  const reduceMotion = useReducedMotion()
+  const branchY = height - 26
+  const branchEndX = side === 'left' ? 140 : RAIL_WIDTH - 140
+  const branchPath = `M ${CENTER} ${height * 0.34} C ${CENTER} ${branchY}, ${
+    side === 'left' ? CENTER - 110 : CENTER + 110
+  } ${branchY}, ${branchEndX} ${branchY}`
+
+  return (
+    <div className='relative w-full' style={{ height }}>
+      <svg
+        aria-hidden
+        width={RAIL_WIDTH}
+        height={height}
+        viewBox={`0 0 ${RAIL_WIDTH} ${height}`}
+        fill='none'
+        className='absolute inset-0'>
+        <path
+          d={`M ${CENTER} 0 V ${height}`}
+          stroke='currentColor'
+          strokeLinecap='round'
+          strokeDasharray='2 5'
+          className='text-foreground/15'
+        />
+        {!reduceMotion && (
+          <motion.path
+            d={`M ${CENTER} 0 V ${height}`}
+            stroke='var(--color-foreground)'
+            strokeLinecap='round'
+            strokeWidth={1.5}
+            strokeDasharray='0.18 0.82'
+            pathLength='1'
+            initial={{ strokeDashoffset: 0 }}
+            animate={{ strokeDashoffset: -1 }}
+            transition={{ duration: 2, ease: 'linear', delay: beamDelay, repeat: Infinity }}
+          />
+        )}
+
+        {exit && (
+          <>
+            <path
+              d={branchPath}
+              stroke='currentColor'
+              strokeLinecap='round'
+              strokeDasharray='2 5'
+              className='text-foreground/15'
+            />
+            {!reduceMotion && (
+              <motion.path
+                d={branchPath}
+                stroke={EXITS[exit].dot}
+                strokeLinecap='round'
+                strokeWidth={1.5}
+                strokeDasharray='0.2 0.8'
+                pathLength='1'
+                initial={{ strokeDashoffset: 0 }}
+                animate={{ strokeDashoffset: -1 }}
+                transition={{
+                  duration: 2.6,
+                  ease: 'linear',
+                  delay: beamDelay + 0.4,
+                  repeat: Infinity,
+                }}
+              />
+            )}
+          </>
+        )}
+      </svg>
+
+      {delay && (
+        <div
+          className='absolute left-1/2 -translate-x-1/2 -translate-y-1/2'
+          style={{ top: height * 0.34 }}>
+          <DelayPill>
+            <Swap id={active}>{delay}</Swap>
+          </DelayPill>
+        </div>
+      )}
+
+      {exit && (
+        <div
+          className={cn('absolute -translate-y-1/2', side === 'left' ? 'left-0' : 'right-0')}
+          style={{ top: branchY }}>
+          <ExitPill exit={exit} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+
+function DesktopRail({ active, template }: { active: number; template: Template }) {
+  const [one, two, three] = template.steps
+
+  return (
+    <div className='relative mx-auto flex flex-col items-center' style={{ width: RAIL_WIDTH }}>
+      <TriggerNode active={active} template={template} />
+      <Connector height={56} beamDelay={0} />
+      <EnrollNode />
+      <Connector height={104} delay={one.timing} active={active} beamDelay={0.2} />
+      <StepNode n={1} subject={one.subject} active={active} />
+      <Connector
+        height={112}
+        delay={two.timing}
+        active={active}
+        exit='replied'
+        side='left'
+        beamDelay={0.4}
+      />
+      <StepNode n={2} subject={two.subject} active={active} />
+      <Connector
+        height={112}
+        delay={three.timing}
+        active={active}
+        exit='unsubscribed'
+        side='right'
+        beamDelay={0.6}
+      />
+      <StepNode n={3} subject={three.subject} active={active} />
+      <Connector height={96} exit='bounced' side='left' beamDelay={0.8} />
+      <CompletedNode />
+    </div>
+  )
+}
+
+/**
+ * Mobile keeps the same spine — the composition is already vertical — but drops
+ * the side branches, which have nowhere to go at phone width. The exits are
+ * summarised in one row below instead.
+ */
+function MobileRail({ active, template }: { active: number; template: Template }) {
+  const reduceMotion = useReducedMotion()
+  const [one, two, three] = template.steps
+  /** Drop the "at 9:00 AM" tail — the pill has no room for it at phone width. */
+  const short = (timing: string) => timing.split(' at ')[0]!
+
+  const rail = (key: string, height: number, delay?: string) => (
+    <div key={key} className='relative w-full' style={{ height }}>
+      <svg
+        aria-hidden
+        width='100%'
+        height={height}
+        viewBox={`0 0 2 ${height}`}
+        preserveAspectRatio='none'
+        fill='none'
+        className='absolute inset-x-0 mx-auto'
+        style={{ width: 2 }}>
+        <path
+          d={`M 1 0 V ${height}`}
+          stroke='currentColor'
+          strokeLinecap='round'
+          strokeDasharray='2 5'
+          className='text-foreground/15'
+        />
+        {!reduceMotion && (
+          <motion.path
+            d={`M 1 0 V ${height}`}
+            stroke='var(--color-foreground)'
+            strokeLinecap='round'
+            strokeWidth={1.5}
+            strokeDasharray='0.18 0.82'
+            pathLength='1'
+            initial={{ strokeDashoffset: 0 }}
+            animate={{ strokeDashoffset: -1 }}
+            transition={{ duration: 2, ease: 'linear', repeat: Infinity }}
+          />
+        )}
+      </svg>
+      {delay && (
+        <div className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'>
+          <DelayPill>
+            <Swap id={active}>{delay}</Swap>
+          </DelayPill>
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <div className='flex flex-col items-center'>
+      <TriggerNode active={active} template={template} compact />
+      {rail('a', 48)}
+      <EnrollNode compact />
+      {rail('b', 64, short(one.timing))}
+      <StepNode n={1} subject={one.subject} active={active} compact />
+      {rail('c', 64, short(two.timing))}
+      <StepNode n={2} subject={two.subject} active={active} compact />
+      {rail('d', 64, short(three.timing))}
+      <StepNode n={3} subject={three.subject} active={active} compact />
+      {rail('e', 48)}
+      <CompletedNode />
+
+      <div className='mt-8 w-full border-t pt-5'>
+        <div className='mb-2.5 text-center text-[10px] uppercase tracking-wide text-muted-foreground'>
+          A run can exit at any point
+        </div>
+        <div className='flex flex-wrap items-center justify-center gap-2'>
+          <ExitPill exit='replied' />
+          <ExitPill exit='unsubscribed' />
+          <ExitPill exit='bounced' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Trigger → enrollment → timed steps → exits, drawn as a spine rather than the
+ * fan-in/hub/fan-out used by `mcp-flow-illustration` and
+ * `ingestion-flow-illustration`. A sequence is linear, so the illustration is.
+ */
+export function SequenceRailIllustration() {
+  const { active, template } = useTemplateCycle()
+
+  return (
+    <div aria-hidden>
+      <div className='hidden md:block'>
+        <DesktopRail active={active} template={template} />
+      </div>
+      <div className='md:hidden'>
+        <MobileRail active={active} template={template} />
+      </div>
+    </div>
+  )
+}
+
+export default SequenceRailIllustration

--- a/apps/homepage/src/app/platform/sequences/_components/sequences-final-cta.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/sequences-final-cta.tsx
@@ -1,0 +1,35 @@
+// apps/homepage/src/app/platform/sequences/_components/sequences-final-cta.tsx
+
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+
+export default function SequencesFinalCta() {
+  return (
+    <section
+      data-theme='dark'
+      className='relative overflow-hidden border-b border-foreground/10 bg-zinc-950 text-zinc-50'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_rgba(255,255,255,0.08),_transparent_60%)]'
+      />
+      <div className='relative z-10 mx-auto max-w-4xl px-6 py-24 text-center md:py-32'>
+        <h2 className='text-balance text-5xl font-semibold tracking-tight md:text-6xl'>
+          Set it once. Stop chasing.
+        </h2>
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button
+            asChild
+            size='sm'
+            variant='outline'
+            className='border-zinc-700 bg-transparent text-zinc-50 hover:bg-zinc-900'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_components/sequences-hero.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/sequences-hero.tsx
@@ -1,0 +1,68 @@
+// apps/homepage/src/app/platform/sequences/_components/sequences-hero.tsx
+
+import { Clock } from 'lucide-react'
+import Link from 'next/link'
+import { SectionBottomFade } from '~/app/_components/main/section-bottom-fade'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+import { cn } from '~/lib/utils'
+import { SequencesBrowserDemo } from '../_mocks'
+
+interface SequencesHeroProps {
+  as?: 'h1' | 'h2'
+  /**
+   * When set, renders a `SectionBottomFade` that blends the gradient into the
+   * next section's color. Drops the hard `border-b` when active.
+   */
+  bottomFadeColor?: string
+}
+
+/**
+ * Timing-led hero: centered copy over a dot grid, flowing into a mock of the
+ * real sequence detail surface (stats strip + Recipients tab).
+ */
+export default function SequencesHero({ as: Heading = 'h1', bottomFadeColor }: SequencesHeroProps) {
+  return (
+    <section className={cn('relative overflow-hidden', !bottomFadeColor && 'border-b')}>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle,var(--color-foreground)_1px,transparent_1px)] [background-size:24px_24px] opacity-[0.06] [mask-image:radial-gradient(ellipse_at_top,black_45%,transparent_90%)]'
+      />
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-x-0 top-0 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/8,_transparent_60%)]'
+      />
+      {bottomFadeColor && <SectionBottomFade toColor={bottomFadeColor} />}
+
+      <div className='relative mx-auto max-w-6xl px-6 pb-20 pt-24 md:pt-32 lg:pt-36'>
+        <div className='relative z-10 mx-auto max-w-2xl text-center'>
+          <div className='mx-auto inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-muted/40 px-3 py-1 text-xs'>
+            <Clock className='size-3.5 text-blue-500' />
+            <span className='text-muted-foreground'>Automation · Sequences</span>
+          </div>
+
+          <Heading className='mt-6 text-balance text-4xl font-semibold tracking-tight md:text-5xl lg:text-6xl'>
+            The right email.
+            <br />
+            The right day.
+          </Heading>
+          <p className='mx-auto mt-4 max-w-xl text-balance text-lg text-muted-foreground'>
+            Reminders, follow-ups, and invoice chasers that fire off real events — and stop the
+            moment someone replies.
+          </p>
+
+          <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+            <Button asChild size='sm'>
+              <Link href={config.urls.signup}>Start for free</Link>
+            </Button>
+            <Button asChild size='sm' variant='outline'>
+              <Link href={config.urls.demo}>Talk to sales</Link>
+            </Button>
+          </div>
+        </div>
+
+        <SequencesBrowserDemo className='relative z-10 mt-14' />
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_components/templates-section.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/templates-section.tsx
@@ -1,0 +1,163 @@
+// apps/homepage/src/app/platform/sequences/_components/templates-section.tsx
+
+import { CalendarCheck, CalendarClock, Receipt, ThumbsUp, Truck, Zap } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+type Timing = { kind: 'now' | 'relative' | 'anchor'; label: string }
+
+interface Template {
+  name: string
+  trigger: string
+  icon: typeof Zap
+  tone: string
+  steps: { subject: string; timing: Timing }[]
+}
+
+/**
+ * The five sequences seeded into every workspace. Names, triggers, subjects and
+ * timings are transcribed from `packages/lib/src/sequences/seed-templates.ts` —
+ * keep them in sync if the seed changes.
+ */
+const templates: Template[] = [
+  {
+    name: 'Visit reminders',
+    trigger: 'Visit scheduled',
+    icon: CalendarClock,
+    tone: 'text-blue-500',
+    steps: [
+      { subject: 'Your visit is booked', timing: { kind: 'now', label: 'Right away' } },
+      {
+        subject: 'Reminder: your visit is coming up',
+        timing: { kind: 'anchor', label: '2 days before the visit · 9:00 AM' },
+      },
+      {
+        subject: "We'll see you today",
+        timing: { kind: 'anchor', label: 'Same day as the visit · 7:30 AM' },
+      },
+    ],
+  },
+  {
+    name: 'Invoice reminders',
+    trigger: 'Invoice sent',
+    icon: Receipt,
+    tone: 'text-amber-500',
+    steps: [
+      {
+        subject: 'Your invoice is due soon',
+        timing: { kind: 'anchor', label: '2 days before the due date · 9:00 AM' },
+      },
+      {
+        subject: 'Your invoice is overdue',
+        timing: { kind: 'anchor', label: '3 days after the due date · 9:00 AM' },
+      },
+      {
+        subject: 'Invoice still outstanding',
+        timing: { kind: 'anchor', label: '10 days after the due date · 9:00 AM' },
+      },
+    ],
+  },
+  {
+    name: 'Job follow-up',
+    trigger: 'Job completed',
+    icon: ThumbsUp,
+    tone: 'text-emerald-500',
+    steps: [
+      { subject: 'Thank you!', timing: { kind: 'now', label: 'Right away' } },
+      { subject: 'How did everything go?', timing: { kind: 'relative', label: '10 days later' } },
+    ],
+  },
+  {
+    name: 'On our way',
+    trigger: 'Visit en route',
+    icon: Truck,
+    tone: 'text-indigo-500',
+    steps: [{ subject: "We're on our way", timing: { kind: 'now', label: 'Right away' } }],
+  },
+  {
+    name: 'Visit follow-up',
+    trigger: 'Visit completed',
+    icon: CalendarCheck,
+    tone: 'text-purple-500',
+    steps: [
+      { subject: 'Thanks — see you next time', timing: { kind: 'now', label: 'Right away' } },
+    ],
+  },
+]
+
+/**
+ * Anchored timings get a distinct pill from relative ones — the same visual
+ * split the real `SequenceDelayPill` makes between its two modes.
+ */
+function TimingPill({ timing }: { timing: Timing }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium',
+        timing.kind === 'anchor'
+          ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+          : 'border border-dashed border-foreground/20 text-muted-foreground'
+      )}>
+      {timing.label}
+    </span>
+  )
+}
+
+export default function TemplatesSection() {
+  return (
+    <section className='border-b bg-muted/30'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Five sequences, already written.
+          </h2>
+          <p className='mt-4 text-balance text-lg text-muted-foreground'>
+            Every workspace ships with them, switched off. Read the emails, pick a mailbox, turn
+            them on.
+          </p>
+        </div>
+
+        <ul className='mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+          {templates.map((template) => (
+            <li
+              key={template.name}
+              className='flex flex-col rounded-xl border bg-card p-5 ring-1 ring-foreground/5'>
+              <div className='flex items-center gap-3'>
+                <div className='flex size-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-foreground/10'>
+                  <template.icon className={cn('size-4', template.tone)} />
+                </div>
+                <div className='min-w-0'>
+                  <div className='truncate font-medium text-foreground'>{template.name}</div>
+                  <div className='flex items-center gap-1 text-xs text-muted-foreground'>
+                    <Zap className='size-3 text-amber-500' />
+                    {template.trigger}
+                  </div>
+                </div>
+              </div>
+
+              <ol className='mt-4 space-y-2.5 border-t pt-4'>
+                {template.steps.map((step, index) => (
+                  <li key={step.subject} className='flex gap-2.5'>
+                    <span className='mt-0.5 flex size-4 shrink-0 items-center justify-center rounded bg-foreground text-[9px] font-semibold text-background'>
+                      {index + 1}
+                    </span>
+                    <div className='min-w-0 space-y-1'>
+                      <div className='text-sm leading-snug'>{step.subject}</div>
+                      <TimingPill timing={step.timing} />
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </li>
+          ))}
+
+          <li className='flex flex-col justify-center rounded-xl border border-dashed p-5 text-sm text-muted-foreground'>
+            <p>
+              Or write your own. A sequence is an ordered list of emails, a delay between each, and
+              a mailbox to send from — nothing to wire up.
+            </p>
+          </li>
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_components/tracking-grid.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/tracking-grid.tsx
@@ -1,0 +1,140 @@
+// apps/homepage/src/app/platform/sequences/_components/tracking-grid.tsx
+
+import { Pencil, Send, UserRoundX } from 'lucide-react'
+import { cn } from '~/lib/utils'
+import { MOCK_RUNS, MOCK_STATS, MockRunRow } from '../_mocks'
+
+/** `[01]` — the monospace index this page uses for numbered lists. */
+function Index({ n }: { n: number }) {
+  return (
+    <span className='font-mono text-xs text-muted-foreground'>[{String(n).padStart(2, '0')}]</span>
+  )
+}
+
+function RunsPreview() {
+  return (
+    <div className='space-y-0.5 rounded-lg border bg-card p-2 ring-1 ring-foreground/5'>
+      {MOCK_RUNS.slice(0, 4).map((run) => (
+        <MockRunRow key={run.email} run={run} className='px-1.5 py-1.5' />
+      ))}
+    </div>
+  )
+}
+
+function StatsPreview() {
+  return (
+    <div className='grid grid-cols-3 gap-1.5'>
+      {MOCK_STATS.slice(0, 6).map((stat) => (
+        <div key={stat.label} className='rounded-lg border bg-card p-2.5 ring-1 ring-foreground/5'>
+          <div className='text-lg font-semibold leading-none'>{stat.value}</div>
+          <div className='mt-1 truncate text-[10px] text-muted-foreground'>{stat.label}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function RemovePreview() {
+  return (
+    <div className='space-y-2'>
+      <div className='rounded-lg border bg-card p-2 ring-1 ring-foreground/5'>
+        <MockRunRow run={MOCK_RUNS[0]!} className='px-1.5 py-1.5' />
+      </div>
+      <div className='flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-[11px] text-muted-foreground'>
+        <UserRoundX className='size-3.5 shrink-0 text-red-500/70' />
+        Remove from sequence — pending steps are cancelled immediately.
+      </div>
+    </div>
+  )
+}
+
+function PublishPreview() {
+  return (
+    <div className='space-y-3 rounded-lg border bg-card p-3 ring-1 ring-foreground/5'>
+      <div className='flex flex-wrap items-center gap-2'>
+        <span className='inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-2 py-1 text-[10px] font-medium text-amber-600 dark:text-amber-400'>
+          <Pencil className='size-3' />
+          Unpublished changes
+        </span>
+        <span className='inline-flex items-center gap-1 rounded-md bg-foreground px-2 py-1 text-[10px] font-medium text-background'>
+          <Send className='size-3' />
+          Publish
+        </span>
+      </div>
+      <div className='space-y-1.5 border-t pt-2.5 text-[11px] text-muted-foreground'>
+        <div className='flex items-center justify-between'>
+          <span>128 runs already in flight</span>
+          <span className='text-foreground'>keep v3</span>
+        </div>
+        <div className='flex items-center justify-between'>
+          <span>Enrolled after publish</span>
+          <span className='text-foreground'>get v4</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const cells = [
+  {
+    title: 'Where everyone stands',
+    description: 'Every enrollment, which step it reached, and how it ended.',
+    preview: <RunsPreview />,
+  },
+  {
+    title: 'The numbers, live',
+    description: 'Enrolled, active, completed, exited, failed — plus reply and bounce rate.',
+    preview: <StatsPreview />,
+  },
+  {
+    title: 'Pull someone out',
+    description: 'Remove a recipient and their run stops on the spot.',
+    preview: <RemovePreview />,
+  },
+  {
+    title: 'Publish when you mean it',
+    description: 'Edit the draft freely — in-flight runs keep the version they started on.',
+    preview: <PublishPreview />,
+  },
+]
+
+/**
+ * Attio-style numbered grid: mini illustration on top, index + title + one line
+ * underneath, dashed cell separators over a dot grid.
+ */
+export default function TrackingGrid() {
+  return (
+    <section className='relative overflow-hidden border-b'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle,var(--color-foreground)_1px,transparent_1px)] [background-size:24px_24px] opacity-[0.05]'
+      />
+      <div className='relative mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Every send, accounted for.
+          </h2>
+          <p className='mt-4 text-balance text-lg text-muted-foreground'>
+            Who&apos;s in, where they got to, and why they left — without opening a single email
+            client.
+          </p>
+        </div>
+
+        <div className='mt-12 grid gap-px overflow-hidden rounded-2xl border bg-border/60 sm:grid-cols-2'>
+          {cells.map((cell, index) => (
+            <div
+              key={cell.title}
+              className={cn('flex flex-col bg-background p-6 md:p-8', 'min-h-[300px]')}>
+              <Index n={index + 1} />
+              <div className='my-6 flex flex-1 items-center'>
+                <div className='w-full'>{cell.preview}</div>
+              </div>
+              <h3 className='font-medium text-foreground'>{cell.title}</h3>
+              <p className='mt-1 text-sm text-muted-foreground'>{cell.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_components/triggers-section.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/triggers-section.tsx
@@ -1,0 +1,63 @@
+// apps/homepage/src/app/platform/sequences/_components/triggers-section.tsx
+
+import { Filter, UserRoundPlus, Zap } from 'lucide-react'
+import SequenceRailIllustration from './sequence-rail-illustration'
+
+const capabilities = [
+  {
+    icon: Zap,
+    name: 'Real events, not cron jobs',
+    description:
+      'Visit scheduled, crew en route, job completed, invoice sent. The event fires, the sequence enrolls the contact — nobody opens a spreadsheet.',
+  },
+  {
+    icon: Filter,
+    name: 'Filter who gets in',
+    description:
+      'Condition groups run once, at enrollment. Only overdue invoices, only first-time customers, only the jobs you actually want followed up.',
+  },
+  {
+    icon: UserRoundPlus,
+    name: 'Or enroll them yourself',
+    description:
+      'Pick contacts from a list, or add someone straight from their record. Up to 50 at a time, into any published sequence.',
+  },
+]
+
+/**
+ * The enrollment story — what starts a sequence and how a run ends — anchored
+ * by the vertical rail illustration.
+ */
+export default function TriggersSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-5xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-3xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Nobody has to remember.
+          </h2>
+          <p className='mt-4 text-balance text-lg text-muted-foreground'>
+            A booking, a finished job, a sent invoice — the sequence starts itself, sends on the
+            days you picked, and bows out the moment the customer answers.
+          </p>
+        </div>
+
+        <div className='mt-14 w-full'>
+          <SequenceRailIllustration />
+        </div>
+
+        <div className='mt-16 grid gap-x-6 gap-y-8 border-t pt-12 sm:grid-cols-3'>
+          {capabilities.map((capability) => (
+            <div key={capability.name} className='space-y-2'>
+              <div className='flex items-center gap-2'>
+                <capability.icon className='size-4 fill-foreground/10 text-foreground' />
+                <h3 className='text-sm font-medium'>{capability.name}</h3>
+              </div>
+              <p className='text-sm text-muted-foreground'>{capability.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_mocks/index.ts
+++ b/apps/homepage/src/app/platform/sequences/_mocks/index.ts
@@ -1,0 +1,17 @@
+// apps/homepage/src/app/platform/sequences/_mocks/index.ts
+
+export { MockRunRow } from './mock-run-row'
+export { MockSequenceHeader } from './mock-sequence-header'
+export { MockStatsStrip } from './mock-stats-strip'
+export { MockStepEditor, type StepEditorVariant } from './mock-step-editor'
+export {
+  MOCK_RUNS,
+  MOCK_STATS,
+  type MockExitReason,
+  type MockRun,
+  type MockRunStatus,
+  RUN_STATUS_CLASS,
+  RUN_STATUS_LABEL,
+  TOTAL_STEPS,
+} from './runs'
+export { SequencesBrowserDemo } from './sequences-browser-demo'

--- a/apps/homepage/src/app/platform/sequences/_mocks/mock-run-row.tsx
+++ b/apps/homepage/src/app/platform/sequences/_mocks/mock-run-row.tsx
@@ -1,0 +1,46 @@
+// apps/homepage/src/app/platform/sequences/_mocks/mock-run-row.tsx
+
+import { UserRound, UserRoundX } from 'lucide-react'
+import { cn } from '~/lib/utils'
+import { type MockRun, RUN_STATUS_CLASS, RUN_STATUS_LABEL, TOTAL_STEPS } from './runs'
+
+/**
+ * One enrollment row. Mirrors the `TreeRow` in `sequence-recipients.tsx`:
+ * avatar, name + email, status badge, exit reason, `Step n/total`, enrolled-at,
+ * and the destructive remove action that only active runs get.
+ *
+ * Deliberately a flat single-column list — the real Recipients tab has no
+ * master-detail pane, so neither does the mock.
+ */
+export function MockRunRow({ run, className }: { run: MockRun; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-lg px-2.5 py-2 text-mock-window-foreground',
+        className
+      )}>
+      <span className='flex size-6 shrink-0 items-center justify-center rounded-full bg-mock-bubble'>
+        <UserRound className='size-3.5 text-mock-window-muted' />
+      </span>
+
+      <div className='min-w-0 flex-1'>
+        <div className='truncate text-xs font-medium'>{run.name}</div>
+        <div className='truncate text-[11px] text-mock-window-muted'>{run.email}</div>
+      </div>
+
+      <div className='flex shrink-0 items-center gap-2 text-[11px] text-mock-window-muted'>
+        <span className={cn('rounded-md px-1.5 py-0.5 font-medium', RUN_STATUS_CLASS[run.status])}>
+          {RUN_STATUS_LABEL[run.status]}
+        </span>
+        {run.exitReason ? <span className='hidden lg:inline'>{run.exitReason}</span> : null}
+        <span className='hidden sm:inline'>
+          Step {run.step}/{TOTAL_STEPS}
+        </span>
+        <span className='hidden w-20 text-right md:inline'>{run.enrolledAt}</span>
+        <span className='flex size-5 items-center justify-center'>
+          {run.status === 'active' ? <UserRoundX className='size-3.5 text-red-500/70' /> : null}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_mocks/mock-sequence-header.tsx
+++ b/apps/homepage/src/app/platform/sequences/_mocks/mock-sequence-header.tsx
@@ -1,0 +1,67 @@
+// apps/homepage/src/app/platform/sequences/_mocks/mock-sequence-header.tsx
+
+import { ChevronRight, PanelLeft, Send, Settings, Zap } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+interface MockSequenceHeaderProps {
+  trail: string[]
+  title: string
+  /** Shorter title rendered below `sm:` so the header stays on one line. */
+  titleMobile?: string
+  /** Trigger badge label — omitted for `manual` sequences, like the real header. */
+  trigger?: string
+  className?: string
+}
+
+/**
+ * Breadcrumb + actions header above the sequence panel frame. Mirrors
+ * `apps/web/src/components/sequences/ui/detail/sequence-detail-view.tsx`'s
+ * `MainPageHeader`: trail, trigger badge, Publish, settings gear.
+ */
+export function MockSequenceHeader({
+  trail,
+  title,
+  titleMobile,
+  trigger,
+  className,
+}: MockSequenceHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-3 pb-2 text-xs text-mock-window-foreground',
+        className
+      )}>
+      <div className='flex min-w-0 items-center gap-2 text-mock-window-muted'>
+        <PanelLeft className='size-3.5 shrink-0' />
+        {trail.map((label) => (
+          <span key={label} className='hidden items-center gap-2 sm:flex'>
+            <span>{label}</span>
+            <ChevronRight className='size-3' />
+          </span>
+        ))}
+        <span className='hidden max-w-[28ch] truncate text-mock-window-foreground sm:inline'>
+          {title}
+        </span>
+        <span className='max-w-[18ch] truncate text-mock-window-foreground sm:hidden'>
+          {titleMobile ?? title}
+        </span>
+      </div>
+
+      <div className='flex shrink-0 items-center gap-1.5'>
+        {trigger ? (
+          <span className='hidden items-center gap-1 rounded-md border border-mock-window-border px-2 py-1 text-mock-window-muted md:inline-flex'>
+            <Zap className='size-3 text-amber-500' />
+            {trigger}
+          </span>
+        ) : null}
+        <span className='inline-flex items-center gap-1 rounded-md border border-mock-window-border px-2 py-1 text-mock-window-foreground'>
+          <Send className='size-3' />
+          Publish
+        </span>
+        <span className='inline-flex size-6 items-center justify-center rounded-md text-mock-window-muted'>
+          <Settings className='size-3.5' />
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_mocks/mock-stats-strip.tsx
+++ b/apps/homepage/src/app/platform/sequences/_mocks/mock-stats-strip.tsx
@@ -1,0 +1,45 @@
+// apps/homepage/src/app/platform/sequences/_mocks/mock-stats-strip.tsx
+
+import { CheckCircle, MailWarning, Play, Reply, UserRound, UserRoundX, XCircle } from 'lucide-react'
+import { cn } from '~/lib/utils'
+import { MOCK_STATS } from './runs'
+
+const ICONS = [UserRound, Play, CheckCircle, UserRoundX, XCircle, Reply, MailWarning]
+
+/**
+ * Static facsimile of `sequence-stats-strip.tsx` — the same seven stats in the
+ * same order, laid out as the real `StatCards` does (borderless columns split
+ * by `border-l`). The last two collapse below `lg` so the strip never wraps
+ * inside the mock browser.
+ */
+export function MockStatsStrip({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-3 border-b border-mock-window-border sm:grid-cols-5 lg:grid-cols-7',
+        className
+      )}>
+      {MOCK_STATS.map((stat, index) => {
+        const Icon = ICONS[index] ?? UserRound
+        return (
+          <div
+            key={stat.label}
+            className={cn(
+              'px-3 py-2.5',
+              index > 0 && 'border-l border-mock-window-border',
+              index >= 3 && 'hidden sm:block',
+              index >= 5 && 'hidden lg:block'
+            )}>
+            <div className='flex items-center gap-1.5 text-[11px] font-medium text-mock-window-muted'>
+              <Icon className={cn('size-3.5', stat.tone)} />
+              <span className='truncate'>{stat.label}</span>
+            </div>
+            <div className='mt-1 text-lg font-semibold text-mock-window-foreground'>
+              {stat.value}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_mocks/mock-step-editor.tsx
+++ b/apps/homepage/src/app/platform/sequences/_mocks/mock-step-editor.tsx
@@ -1,0 +1,143 @@
+// apps/homepage/src/app/platform/sequences/_mocks/mock-step-editor.tsx
+
+import { ChevronDown, Mail, Mails, Paperclip, PenLine, Plus } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+export type StepEditorVariant = 'placeholders' | 'snippets' | 'sender'
+
+/** Placeholder span — mirrors the TipTap placeholder node's chip rendering. */
+function Token({ label, fallback }: { label: string; fallback?: string }) {
+  return (
+    <span className='mx-0.5 inline-flex items-center gap-1 rounded bg-blue-500/12 px-1.5 py-0.5 align-baseline text-[11px] font-medium text-blue-600 dark:text-blue-300'>
+      {label}
+      {fallback ? (
+        <span className='rounded bg-blue-500/15 px-1 text-[9px] font-normal opacity-80'>
+          {fallback}
+        </span>
+      ) : null}
+    </span>
+  )
+}
+
+function EditorShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='rounded-xl border border-border/60 bg-card p-3 shadow-sm ring-1 ring-foreground/5'>
+      {children}
+    </div>
+  )
+}
+
+function SubjectRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='flex items-center gap-2 border-b pb-2 text-xs'>
+      <span className='shrink-0 text-muted-foreground'>Subject</span>
+      <span className='truncate font-medium'>{children}</span>
+    </div>
+  )
+}
+
+/**
+ * The three personalization visuals. Each is a slice of the real step editor
+ * (`sequence-step-editor.tsx` / `sequence-body-editor.tsx` / the settings
+ * drawer), not a generic illustration.
+ */
+export function MockStepEditor({
+  variant,
+  className,
+}: {
+  variant: StepEditorVariant
+  className?: string
+}) {
+  return (
+    <div className={cn('space-y-3', className)}>
+      {variant === 'placeholders' && (
+        <>
+          <EditorShell>
+            <SubjectRow>
+              Your invoice <Token label='invoice.number' /> is due soon
+            </SubjectRow>
+            <div className='space-y-2 pt-2.5 text-xs leading-relaxed'>
+              <p>
+                Hi <Token label='contact.firstName' fallback='there' />,
+              </p>
+              <p className='text-muted-foreground'>
+                A quick reminder that invoice <Token label='invoice.number' /> for{' '}
+                <Token label='invoice.total' /> is due on <Token label='invoice.dueDate' />.
+              </p>
+              <p className='text-muted-foreground'>Let us know if you have any questions.</p>
+            </div>
+          </EditorShell>
+          <div className='flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-[11px] text-muted-foreground'>
+            <PenLine className='size-3.5 shrink-0' />
+            Resolved per recipient at send time — empty fields fall back to what you set.
+          </div>
+        </>
+      )}
+
+      {variant === 'snippets' && (
+        <>
+          <EditorShell>
+            <SubjectRow>How did everything go?</SubjectRow>
+            <div className='space-y-2 pt-2.5 text-xs leading-relaxed'>
+              <p>
+                Hi <Token label='contact.firstName' fallback='there' />,
+              </p>
+              <p className='text-muted-foreground'>
+                Thanks again for having us out for{' '}
+                <Token label='work_order.title' fallback='your service' />.
+              </p>
+            </div>
+            <div className='mt-3 flex flex-wrap items-center gap-1.5 border-t pt-2.5'>
+              <span className='inline-flex items-center gap-1 rounded-md border px-1.5 py-1 text-[10px] text-muted-foreground'>
+                <Plus className='size-3' />
+                Insert snippet
+              </span>
+              <span className='inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-1 text-[10px]'>
+                <Paperclip className='size-3' />
+                service-report.pdf
+              </span>
+              <span className='inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-1 text-[10px]'>
+                <Paperclip className='size-3' />
+                warranty.pdf
+              </span>
+            </div>
+          </EditorShell>
+          <div className='flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-[11px] text-muted-foreground'>
+            <Mails className='size-3.5 shrink-0' />
+            Snippets and attachments are set per step, not per sequence.
+          </div>
+        </>
+      )}
+
+      {variant === 'sender' && (
+        <EditorShell>
+          <div className='space-y-3'>
+            <div className='space-y-1.5'>
+              <div className='text-[11px] font-medium text-muted-foreground'>Sending mailbox</div>
+              <div className='flex items-center justify-between rounded-lg border px-2.5 py-2 text-xs'>
+                <span className='flex items-center gap-2'>
+                  <Mail className='size-3.5 text-muted-foreground' />
+                  billing@northfield.co
+                </span>
+                <ChevronDown className='size-3.5 text-muted-foreground' />
+              </div>
+            </div>
+            <div className='space-y-1.5'>
+              <div className='text-[11px] font-medium text-muted-foreground'>Signature</div>
+              <div className='flex items-center justify-between rounded-lg border px-2.5 py-2 text-xs'>
+                <span>Northfield — Billing</span>
+                <ChevronDown className='size-3.5 text-muted-foreground' />
+              </div>
+            </div>
+            <div className='rounded-lg bg-muted/60 p-2.5 text-[11px] leading-relaxed text-muted-foreground'>
+              <div className='font-medium text-foreground'>Sarah Whitfield</div>
+              Northfield Mechanical · Billing
+              <br />
+              billing@northfield.co · (503) 555-0142
+            </div>
+          </div>
+        </EditorShell>
+      )}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/_mocks/runs.ts
+++ b/apps/homepage/src/app/platform/sequences/_mocks/runs.ts
@@ -1,0 +1,99 @@
+// apps/homepage/src/app/platform/sequences/_mocks/runs.ts
+
+/**
+ * Fixture data for the Sequences product mocks. Mirrors the real shapes in
+ * `packages/lib/src/sequences/types.ts` — `SequenceRunListItem` (status +
+ * exitReason + lastCompletedStep) and `SequenceStats` — so the marketing mock
+ * can't drift into showing states the product doesn't have.
+ */
+
+export type MockRunStatus = 'active' | 'completed' | 'exited' | 'failed'
+
+/** Matches `EXIT_REASON_LABEL` in `sequence-recipients.tsx`. */
+export type MockExitReason = 'Replied' | 'Bounced' | 'Unsubscribed' | 'Removed manually'
+
+export interface MockRun {
+  name: string
+  email: string
+  status: MockRunStatus
+  exitReason?: MockExitReason
+  /** `lastCompletedStep` — rendered as `Step {n}/{total}`. */
+  step: number
+  enrolledAt: string
+}
+
+/** Badge variants copied from `STATUS_META` in `sequence-recipients.tsx`. */
+export const RUN_STATUS_CLASS: Record<MockRunStatus, string> = {
+  active: 'bg-blue-500/12 text-blue-600 dark:text-blue-400',
+  completed: 'bg-emerald-500/12 text-emerald-600 dark:text-emerald-400',
+  exited: 'bg-zinc-500/12 text-zinc-600 dark:text-zinc-400',
+  failed: 'bg-red-500/12 text-red-600 dark:text-red-400',
+}
+
+export const RUN_STATUS_LABEL: Record<MockRunStatus, string> = {
+  active: 'Active',
+  completed: 'Completed',
+  exited: 'Exited',
+  failed: 'Failed',
+}
+
+export const TOTAL_STEPS = 3
+
+export const MOCK_RUNS: MockRun[] = [
+  {
+    name: 'Dana Whitfield',
+    email: 'dana@northfield.co',
+    status: 'active',
+    step: 2,
+    enrolledAt: '2h ago',
+  },
+  {
+    name: 'Marcus Bell',
+    email: 'm.bell@bellworks.com',
+    status: 'exited',
+    exitReason: 'Replied',
+    step: 1,
+    enrolledAt: '5h ago',
+  },
+  {
+    name: 'Priya Raman',
+    email: 'priya@ramanhvac.com',
+    status: 'active',
+    step: 1,
+    enrolledAt: '6h ago',
+  },
+  {
+    name: 'Owen Castillo',
+    email: 'owen.castillo@gmail.com',
+    status: 'completed',
+    step: 3,
+    enrolledAt: 'Yesterday',
+  },
+  {
+    name: 'Lena Fischer',
+    email: 'lena@fischerbau.de',
+    status: 'exited',
+    exitReason: 'Unsubscribed',
+    step: 2,
+    enrolledAt: 'Yesterday',
+  },
+  {
+    name: 'Tomás Reyes',
+    email: 't.reyes@reyesplumbing.net',
+    status: 'exited',
+    exitReason: 'Bounced',
+    step: 1,
+    enrolledAt: '2 days ago',
+  },
+]
+
+/** Mirrors the 7 cards in `sequence-stats-strip.tsx`, in the same order. */
+export const MOCK_STATS = [
+  { label: 'Enrolled', value: '152', tone: 'text-blue-500' },
+  { label: 'Active', value: '128', tone: 'text-indigo-500' },
+  { label: 'Completed', value: '18', tone: 'text-emerald-500' },
+  { label: 'Exited', value: '6', tone: 'text-muted-foreground' },
+  { label: 'Failed', value: '0', tone: 'text-red-500' },
+  { label: 'Reply rate', value: '12%', tone: 'text-emerald-500' },
+  { label: 'Bounce rate', value: '1%', tone: 'text-amber-500' },
+]

--- a/apps/homepage/src/app/platform/sequences/_mocks/sequences-browser-demo.tsx
+++ b/apps/homepage/src/app/platform/sequences/_mocks/sequences-browser-demo.tsx
@@ -1,0 +1,69 @@
+// apps/homepage/src/app/platform/sequences/_mocks/sequences-browser-demo.tsx
+
+import { Mails, UserRoundPlus, UsersRound } from 'lucide-react'
+import { MockAppSidebar, MockBrowserChrome, MockMainPage } from '~/app/platform/ai/_mocks'
+import { cn } from '~/lib/utils'
+import { MockRunRow } from './mock-run-row'
+import { MockSequenceHeader } from './mock-sequence-header'
+import { MockStatsStrip } from './mock-stats-strip'
+import { MOCK_RUNS } from './runs'
+
+/**
+ * The hero mock: the real `/app/workflows/sequences/[id]` surface — stats strip,
+ * `Editor | Recipients` tabs, and the enrollment list — inside a browser frame.
+ */
+export function SequencesBrowserDemo({ className }: { className?: string }) {
+  return (
+    <div className={cn('text-left', className)}>
+      <MockBrowserChrome variant='regular' url='app.auxx.ai/app/workflows/sequences'>
+        <div className='flex h-[560px]'>
+          <MockAppSidebar activeKey='workflows' className='hidden md:flex' />
+          <MockMainPage
+            header={
+              <MockSequenceHeader
+                trail={['Workflows', 'Sequences']}
+                title='Invoice reminders'
+                titleMobile='Invoices'
+                trigger='Invoice sent'
+              />
+            }>
+            <div className='flex h-full min-h-0 flex-col'>
+              <MockStatsStrip />
+
+              {/* Tabs — mirrors the real TabsList (border-b, outline triggers). */}
+              <div className='flex items-center gap-1 border-b border-mock-window-border px-2 py-1.5'>
+                <span className='inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs text-mock-window-muted'>
+                  <Mails className='size-3.5' />
+                  Editor
+                </span>
+                <span className='inline-flex items-center gap-1.5 rounded-md border border-mock-window-border bg-mock-window px-2.5 py-1 text-xs font-medium text-mock-window-foreground shadow-sm'>
+                  <UsersRound className='size-3.5' />
+                  Recipients
+                </span>
+              </div>
+
+              <div className='flex min-h-0 flex-1 flex-col gap-2 px-3 py-3'>
+                {/* Toolbar — status filter + enroll action. */}
+                <div className='flex items-center gap-2'>
+                  <span className='inline-flex h-7 items-center rounded-md border border-mock-window-border px-2.5 text-[11px] text-mock-window-muted'>
+                    All
+                  </span>
+                  <span className='ml-auto inline-flex h-7 items-center gap-1.5 rounded-md border border-mock-window-border px-2.5 text-[11px] font-medium text-mock-window-foreground'>
+                    <UserRoundPlus className='size-3.5' />
+                    Enroll contacts
+                  </span>
+                </div>
+
+                <div className='divide-y divide-mock-window-border/70'>
+                  {MOCK_RUNS.map((run) => (
+                    <MockRunRow key={run.email} run={run} />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </MockMainPage>
+        </div>
+      </MockBrowserChrome>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/sequences/page.tsx
+++ b/apps/homepage/src/app/platform/sequences/page.tsx
@@ -1,0 +1,46 @@
+// apps/homepage/src/app/platform/sequences/page.tsx
+import type { Metadata } from 'next'
+import { config } from '~/lib/config'
+import FooterSection from '../../_components/main/footer-section'
+import Header from '../../_components/main/header'
+import { BreadcrumbJsonLd } from '../../_components/seo/breadcrumb-json-ld'
+import DeliverySection from './_components/delivery-section'
+import PersonalizationSection from './_components/personalization-section'
+import PlatformCrossLinks from './_components/platform-cross-links'
+import SequencesFinalCta from './_components/sequences-final-cta'
+import SequencesHero from './_components/sequences-hero'
+import TemplatesSection from './_components/templates-section'
+import TrackingGrid from './_components/tracking-grid'
+import TriggersSection from './_components/triggers-section'
+
+export const metadata: Metadata = {
+  alternates: { canonical: '/platform/sequences' },
+  title: `Email Sequences & Automated Follow-Ups | ${config.shortName}`,
+  description: `Automated reminders, follow-ups, and invoice chasers. ${config.shortName} sends each email on the day it matters — pinned to a visit or due date — and exits the moment a customer replies.`,
+}
+
+export default function SequencesPage() {
+  return (
+    <div id='root' className='bg-background relative h-screen overflow-y-auto'>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', href: 'https://auxx.ai' },
+          { name: 'Platform', href: 'https://auxx.ai/platform' },
+          { name: 'Sequences' },
+        ]}
+      />
+      <Header />
+      <main>
+        <SequencesHero />
+        <TriggersSection />
+        <TemplatesSection />
+        <PersonalizationSection />
+        <DeliverySection />
+        <TrackingGrid />
+        <PlatformCrossLinks />
+        <SequencesFinalCta />
+      </main>
+      <FooterSection />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/sitemap.ts
+++ b/apps/homepage/src/app/sitemap.ts
@@ -2,7 +2,8 @@
 
 import { getHomepageUrl } from '@auxx/config/client'
 import type { MetadataRoute } from 'next'
-import { getAllPosts } from '~/lib/blog'
+import { getAllCategories, getAllPosts } from '~/lib/blog'
+import { VERTICALS } from './industries/_data/verticals'
 
 // Re-render hourly so future-dated posts appear on their release date.
 export const revalidate = 3600
@@ -18,6 +19,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
+    ...getAllCategories().map((category) => ({
+      url: `${baseUrl}/blog/category/${category.slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.5,
+    })),
     ...posts.map((post) => ({
       url: `${baseUrl}/blog/${post.slug}`,
       lastModified: new Date(post.date),
@@ -25,6 +32,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     })),
   ]
+
+  // Derived from the same data `industries/[vertical]/page.tsx` builds from, so a new
+  // vertical can never ship without its sitemap entry.
+  const industryEntries: MetadataRoute.Sitemap = Object.values(VERTICALS).map((vertical) => ({
+    url: `${baseUrl}/industries/${vertical.slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }))
 
   return [
     {
@@ -87,24 +103,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.6,
     },
-    {
-      url: `${baseUrl}/industries/hvac`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/industries/plumbing`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/industries/pest-control`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
+    ...industryEntries,
     {
       url: `${baseUrl}/platform/live-chat`,
       lastModified: new Date(),
@@ -131,6 +130,30 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: `${baseUrl}/platform/workflow`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/platform/sequences`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/platform/reporting`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/platform/knowledge-base`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/startups`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.7,


### PR DESCRIPTION
## Summary

- New `/platform/sequences` marketing page — hero, triggers, personalization, delivery, templates, tracking grid, cross-links and final CTA, with supporting mock UI (browser demo, step editor, run rows, stats strip).
- Linked Sequences from the header platform nav, the footer, and the dispatch page's platform section.
- Sitemap: industry entries are now derived from `VERTICALS` so a new vertical can't ship without its entry; added the missing `/blog/category/*`, `/platform/reporting`, `/platform/knowledge-base`, `/platform/sequences` and `/startups` routes.

## Test plan

- [ ] `/platform/sequences` renders and is reachable from header, footer and dispatch cross-links
- [ ] `/sitemap.xml` lists all industry verticals, blog categories and the new platform routes