### PR TITLE
fix: support scoped personal inbox settings

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -137,7 +137,7 @@ export function Mailbox({
         title='No channels found'
         description={<>Link your email account to get started.</>}
         button={
-          <Link href='/app/settings/channels?connect=1'>
+          <Link href='/app/settings/inbox?connect=personal'>
             <Button type='button' size='sm' variant='outline'>
               <Plus />
               Get started

--- a/apps/web/src/app/(protected)/app/settings/inbox/[inboxId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/inbox/[inboxId]/page.tsx
@@ -11,7 +11,7 @@ export default async function InboxDetailPage({
 
   return (
     <>
-      <CapabilityPageGuard permissionKey='channels.manage' />
+      <CapabilityPageGuard permissionKey='inboxes.view' />
       <InboxDetail inboxId={inboxId} />
     </>
   )

--- a/apps/web/src/app/(protected)/app/settings/inbox/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/inbox/page.tsx
@@ -1,12 +1,6 @@
 // apps/web/src/app/(protected)/app/settings/inbox/page.tsx
-import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
 import { InboxList } from '~/components/inbox'
 
 export default function InboxesPage() {
-  return (
-    <>
-      <CapabilityPageGuard permissionKey='channels.manage' />
-      <InboxList />
-    </>
-  )
+  return <InboxList />
 }

--- a/apps/web/src/components/apps/hooks/use-oauth-return.ts
+++ b/apps/web/src/components/apps/hooks/use-oauth-return.ts
@@ -46,6 +46,9 @@ export function useOAuthReturn() {
       // Channel reconnects (Gmail/Outlook) ride the same return path — refresh their list so a
       // cleared `requiresReauth` drops the "Auth required" badge without waiting out the staleTime.
       void utils.channel.list.invalidate()
+      // A personal channel provisions its inbox inside the post-connect hook.
+      void utils.inbox.settingsList.invalidate()
+      void utils.record.listAll.invalidate()
     }
 
     if (oauthError === 'true') {

--- a/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
+++ b/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
@@ -28,7 +28,7 @@ import { getIntegrationProviderIcon } from './channel-icon'
 import ImapConnectForm from './imap-connect-form'
 import { InboxDestinationField, useInboxDestination } from './inbox-destination-field'
 
-const RETURN_TO = '/app/settings/channels'
+const DEFAULT_RETURN_TO = '/app/settings/channels'
 const RESIZE_ID = 'channel-connect'
 
 interface ChannelGalleryDialogProps {
@@ -36,6 +36,10 @@ interface ChannelGalleryDialogProps {
   onOpenChange: (open: boolean) => void
   /** Preselect the delivery inbox (e.g. opened from an inbox's detail page). */
   initialInboxId?: string
+  /** Restrict the gallery to personal Gmail/Outlook connections. */
+  personalOnly?: boolean
+  /** OAuth return destination. */
+  returnTo?: string
 }
 
 /**
@@ -47,6 +51,8 @@ export function ChannelGalleryDialog({
   open,
   onOpenChange,
   initialInboxId,
+  personalOnly = false,
+  returnTo = DEFAULT_RETURN_TO,
 }: ChannelGalleryDialogProps) {
   const router = useRouter()
   const utils = api.useUtils()
@@ -56,12 +62,14 @@ export function ChannelGalleryDialog({
   // catalog is a shared (admin-only) channel.
   const items = useMemo(
     () =>
-      isAdminOrOwner
-        ? CHANNEL_CATALOG
-        : CHANNEL_CATALOG.map((item) =>
-            item.kind === 'oauth-email' ? item : { ...item, disabled: true }
-          ),
-    [isAdminOrOwner]
+      personalOnly
+        ? CHANNEL_CATALOG.filter((item) => item.kind === 'oauth-email')
+        : isAdminOrOwner
+          ? CHANNEL_CATALOG
+          : CHANNEL_CATALOG.map((item) =>
+              item.kind === 'oauth-email' ? item : { ...item, disabled: true }
+            ),
+    [isAdminOrOwner, personalOnly]
   )
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -72,8 +80,9 @@ export function ChannelGalleryDialog({
 
   // Shared detail state, reset on detail exit. Non-admins start on (and are
   // effectively limited to) the personal scope.
-  const defaultScope: 'shared' | 'personal' = isAdminOrOwner ? 'shared' : 'personal'
-  const inbox = useInboxDestination(initialInboxId)
+  const defaultScope: 'shared' | 'personal' =
+    personalOnly || !isAdminOrOwner ? 'personal' : 'shared'
+  const inbox = useInboxDestination(initialInboxId, { enabled: !personalOnly })
   const [scope, setScope] = useState<'shared' | 'personal'>(defaultScope)
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
@@ -92,12 +101,14 @@ export function ChannelGalleryDialog({
 
   // Quo (secret connection) rides the shared connect flow, carrying `{ inboxId }` as post-connect.
   const { data: providers = [] } = api.connections.listProviders.useQuery(undefined, {
-    enabled: open,
+    enabled: open && !personalOnly,
   })
   const flow = useConnectFlow({
     showName: true,
     onConnected: () => {
-      utils.channel.list.invalidate()
+      void utils.channel.list.invalidate()
+      void utils.inbox.settingsList.invalidate()
+      void utils.record.listAll.invalidate()
       onOpenChange(false)
     },
   })
@@ -155,7 +166,7 @@ export function ChannelGalleryDialog({
           scope: isPersonal ? 'user' : 'organization',
           personal: isPersonal,
           postConnect,
-          returnTo: RETURN_TO,
+          returnTo,
         },
         {
           // Submit BYO client id/secret only when the user is actually using their own
@@ -184,7 +195,7 @@ export function ChannelGalleryDialog({
       })
       utils.channel.list.invalidate()
       onOpenChange(false)
-      router.push(`${RETURN_TO}/${channelId}`)
+      router.push(`${returnTo}/${channelId}`)
     } catch (error) {
       toastError({
         title: 'Failed to create chat widget',
@@ -293,7 +304,7 @@ export function ChannelGalleryDialog({
           <p className='text-sm text-muted-foreground'>Loading…</p>
         ) : (
           <>
-            {personalEligible && (
+            {personalEligible && !personalOnly && (
               <RadioGroup
                 value={scope}
                 onValueChange={(v) => setScope(v as 'shared' | 'personal')}
@@ -423,9 +434,13 @@ export function ChannelGalleryDialog({
       <TemplateGalleryDialog<ChannelCatalogItem>
         open={open}
         onOpenChange={onOpenChange}
-        title='Add a channel'
-        description='Connect email, chat, social, and phone channels'
-        crumbLabel='Channels'
+        title={personalOnly ? 'Connect personal account' : 'Add a channel'}
+        description={
+          personalOnly
+            ? 'Connect Gmail or Outlook to create your private inbox'
+            : 'Connect email, chat, social, and phone channels'
+        }
+        crumbLabel={personalOnly ? 'Personal inboxes' : 'Channels'}
         crumbIcon={<Waypoints />}
         itemNoun='channel'
         items={items}

--- a/apps/web/src/components/channels/ui/inbox-destination-field.tsx
+++ b/apps/web/src/components/channels/ui/inbox-destination-field.tsx
@@ -59,8 +59,11 @@ export interface InboxDestinationController {
  * inbox or create one inline. State is reactive (the caller reads `isValid` for its Connect
  * button and calls `resolve()` on click). Pair with {@link InboxDestinationField} for the view.
  */
-export function useInboxDestination(initialInboxId?: string): InboxDestinationController {
-  const { inboxes } = useInboxes()
+export function useInboxDestination(
+  initialInboxId?: string,
+  options: { enabled?: boolean } = {}
+): InboxDestinationController {
+  const { inboxes } = useInboxes({ enabled: options.enabled })
   const shared = useMemo(() => inboxes.filter((i) => !i.isPersonal), [inboxes])
   const gated = useMailPermissionsGated()
 

--- a/apps/web/src/components/drawers/cards/related-record-row.tsx
+++ b/apps/web/src/components/drawers/cards/related-record-row.tsx
@@ -44,7 +44,7 @@ export function RelatedRecordRow({
   const { record } = useRecord({ recordId, enabled: true })
   const { resource } = useResource(getDefinitionId(recordId))
   const { values } = useSystemValues(recordId, [statusAttr], { autoFetch: true })
-  const statusField = useSystemField(statusAttr)
+  const statusField = useSystemField(statusAttr, getDefinitionId(recordId))
   const recordHref = useRecordLink(recordId)
   const href = hrefOverride ?? recordHref
   const openRecord = useOpenRecord()

--- a/apps/web/src/components/getting-started/client.ts
+++ b/apps/web/src/components/getting-started/client.ts
@@ -37,7 +37,7 @@ const GOALS: Record<MainGoalKey, Omit<GettingStartedGoal, 'key'>> = {
     iconId: 'mail',
     color: 'blue',
     ctaText: 'Connect inbox',
-    href: '/app/settings/channels',
+    href: '/app/settings/inbox?connect=personal',
     docsPath: '/help/getting-started/connect-inbox',
   },
   'setup-agent': {

--- a/apps/web/src/components/inbox/inbox-detail.tsx
+++ b/apps/web/src/components/inbox/inbox-detail.tsx
@@ -1,7 +1,9 @@
 // apps/web/src/components/inbox/inbox-detail.tsx
 'use client'
 
+import { ResourcePermission } from '@auxx/database/enums'
 import type { InboxIntegration } from '@auxx/lib/inboxes'
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
@@ -13,10 +15,11 @@ import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { OrphanedPersonalInboxBanner } from '~/components/mail-permissions/ui/orphaned-inbox-banner'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { Channel } from '../channels/store/channel-store'
-import { toRecordId, useResource } from '../resources'
-import { useInbox } from '../threads/hooks'
+import { toRecordId } from '../resources'
+import { useInboxByInstanceId } from '../threads/hooks'
 import { InboxDialog } from './inbox-dialog'
 import { ConnectExistingChannelDialog } from './ui/connect-existing-channel-dialog'
 import { InboxChannelCard } from './ui/inbox-channel-card'
@@ -29,27 +32,30 @@ const GRID_CLASS = 'grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'
 export function InboxDetail({ inboxId }: { inboxId: string }) {
   const router = useRouter()
   const utils = api.useUtils()
+  const { can } = useAccess()
   const [confirm, ConfirmDialog] = useConfirm()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [galleryOpen, setGalleryOpen] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
 
-  // Build RecordId from resource definition
-  const { resource: inboxResource, isLoading: isLoadingResource } = useResource('inboxes')
-  const recordId = toRecordId(inboxResource?.id, inboxId)
-
-  // Fetch inbox data from entity system
-  const { inbox, isLoading: isLoadingInbox } = useInbox(recordId)
+  // Resolve by the bare route id so personal inboxes retain their own
+  // definition-aware RecordId instead of being forced onto the shared def.
+  const { inbox, isLoading: isLoadingInbox } = useInboxByInstanceId(inboxId)
 
   // Fetch integrations separately (not part of entity system)
   const { data: integrations, isLoading: isLoadingIntegrations } =
     api.inbox.getIntegrations.useQuery({ inboxId }, { enabled: !!inbox })
 
-  // Include the resource-definition load: until it resolves, `recordId` is built
-  // from an undefined entityDefinitionId, so the inbox lookup can't match yet and
-  // `inbox` is transiently undefined. Gating on it prevents an "Inbox not found"
-  // flash on hard refresh when the records query resolves before the resource.
-  const isLoading = isLoadingResource || isLoadingInbox || isLoadingIntegrations
+  // The instance check is the source of truth for settings/access authority:
+  // it admits delegated Managers and does not treat org rank as a bypass.
+  const { data: myAccess, isLoading: isLoadingAccess } = api.resourceAccess.check.useQuery(
+    { recordId: inbox?.recordId ?? '' },
+    { enabled: !!inbox }
+  )
+  const canManageInbox = myAccess?.permission === ResourcePermission.admin
+  const canManageChannels = canManageInbox && can(PermissionKey.channelsManage)
+
+  const isLoading = isLoadingInbox || isLoadingIntegrations || isLoadingAccess
 
   const removeIntegration = api.inbox.removeIntegration.useMutation({
     onSuccess: () => {
@@ -84,12 +90,12 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
   /** Connect an already-connected channel to this inbox, offering to move its threads. */
   const handleConnectExisting = async (channel: Channel) => {
     setPickerOpen(false)
-    if (!inbox || channel.inboxId === inbox.id) return
+    if (!inbox || !canManageChannels || channel.inboxId === inbox.id) return
 
     const hasDefault = (integrations ?? []).some((i) => i.isDefault)
     try {
       await addIntegration.mutateAsync({
-        recordId,
+        recordId: inbox.recordId,
         integrationId: channel.id,
         isDefault: !hasDefault,
       })
@@ -100,7 +106,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
     utils.channel.list.invalidate() // keep the channel store's inboxId fresh
 
     if (!channel.inboxId) return // was unassigned → nothing to move
-    const fromInboxRecordId = toRecordId(inboxResource?.id, channel.inboxId)
+    const fromInboxRecordId = toRecordId('inbox', channel.inboxId)
     const { count } = await utils.inbox.countMovableThreads.fetch({
       integrationId: channel.id,
       fromInboxRecordId,
@@ -117,13 +123,15 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
       moveThreads.mutate({
         integrationId: channel.id,
         fromInboxRecordId,
-        toInboxRecordId: recordId,
+        toInboxRecordId: inbox.recordId,
       })
     }
   }
 
   /** Remove a channel from this inbox after confirmation (unassigns routing). */
   const handleRemove = async (integration: InboxIntegration) => {
+    if (!canManageChannels) return
+
     const confirmed = await confirm({
       title: 'Remove channel?',
       description:
@@ -146,10 +154,12 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
           { title: inbox?.name ?? 'Loading...' },
         ]}
         button={
-          <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
-            <PencilIcon />
-            Edit Inbox
-          </Button>
+          canManageInbox ? (
+            <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
+              <PencilIcon />
+              Edit Inbox
+            </Button>
+          ) : undefined
         }>
         <div className='p-3 sm:p-6'>
           {isLoading ? (
@@ -181,12 +191,15 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
                         integration={integration}
                         onRemove={handleRemove}
                         removePending={removeIntegration.isPending}
+                        canManage={canManageChannels}
                       />
                     ))}
-                    <InboxChannelPlaceholderCard
-                      onConnectNew={() => setGalleryOpen(true)}
-                      onConnectExisting={() => setPickerOpen(true)}
-                    />
+                    {canManageChannels && (
+                      <InboxChannelPlaceholderCard
+                        onConnectNew={() => setGalleryOpen(true)}
+                        onConnectExisting={() => setPickerOpen(true)}
+                      />
+                    )}
                   </div>
                 </div>
               </SettingsSection>
@@ -209,18 +222,20 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
         </div>
       </SettingsPage>
 
-      {/* Edit Dialog - pass recordId (already built above) */}
-      {dialogOpen && (
+      {/* Edit Dialog - pass the record layer's definition-aware RecordId. */}
+      {dialogOpen && inbox && (
         <InboxDialog
           open={dialogOpen}
           onOpenChange={setDialogOpen}
-          recordId={recordId}
+          recordId={inbox.recordId}
+          inboxSummary={inbox}
+          canDelete={canManageChannels && !inbox.isPersonal}
           onSuccess={() => utils.inbox.getIntegrations.invalidate({ inboxId })}
         />
       )}
 
       {/* Connect gallery, pre-scoped to this inbox as the delivery destination */}
-      {inbox && (
+      {inbox && canManageChannels && (
         <ChannelGalleryDialog
           open={galleryOpen}
           onOpenChange={setGalleryOpen}
@@ -229,7 +244,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
       )}
 
       {/* Connect an existing channel — reassigns it onto this inbox */}
-      {inbox && (
+      {inbox && canManageChannels && (
         <ConnectExistingChannelDialog
           open={pickerOpen}
           onOpenChange={setPickerOpen}

--- a/apps/web/src/components/inbox/inbox-dialog.tsx
+++ b/apps/web/src/components/inbox/inbox-dialog.tsx
@@ -14,6 +14,13 @@ interface InboxDialogProps {
   recordId?: RecordId | null
   /** Called after successful save */
   onSuccess?: (inbox: { id: string; name: string; recordId: RecordId }) => void
+  /** Scoped metadata for edit mode. */
+  inboxSummary?: {
+    isPersonal: boolean
+    ownerUserId: string | null
+  }
+  /** Whether the shared-inbox delete action should be rendered. */
+  canDelete?: boolean
 }
 
 /**
@@ -22,7 +29,14 @@ interface InboxDialogProps {
  * "People & groups" drill). The command palette hosts the same form as a single
  * page (inline grantee list). Public API is unchanged.
  */
-export function InboxDialog({ open, onOpenChange, recordId, onSuccess }: InboxDialogProps) {
+export function InboxDialog({
+  open,
+  onOpenChange,
+  recordId,
+  onSuccess,
+  inboxSummary,
+  canDelete,
+}: InboxDialogProps) {
   const isEditing = !!recordId
 
   return (
@@ -32,6 +46,8 @@ export function InboxDialog({ open, onOpenChange, recordId, onSuccess }: InboxDi
           open={open}
           recordId={recordId}
           onSuccess={onSuccess}
+          inboxSummary={inboxSummary}
+          canDelete={canDelete}
           onClose={() => onOpenChange(false)}
           enableMembersPage
           header={({ title, page, onBack }) => (

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -74,6 +74,14 @@ const DEFAULT_VALUES: InboxFormValues = {
   grants: [],
 }
 
+/**
+ * Hoisted so the reference is stable across renders — an inline literal makes
+ * `useSystemValues` rebuild its field refs every render and refetch.
+ *
+ * `inbox_default_lens` is deliberately absent: see the fetch site below.
+ */
+const INBOX_SYSTEM_ATTRS = ['inbox_name', 'inbox_description', 'inbox_color'] as const
+
 /** Props for the shell-free inbox form core. */
 export interface InboxFormProps {
   /** Whether the form is "open" — drives the init/reset cycle. In a dialog this is
@@ -98,6 +106,13 @@ export interface InboxFormProps {
   /** Host-specific header. Dialogs render a `DialogNav` (with a Back button on the
    *  members page); the palette omits it (the breadcrumb supplies the title). */
   header?: (ctx: { title: string; page: 'main' | 'members'; onBack: () => void }) => ReactNode
+  /** Scoped metadata supplied by the settings list to avoid loading every inbox. */
+  inboxSummary?: {
+    isPersonal: boolean
+    ownerUserId: string | null
+  }
+  /** Whether the generic shared-inbox delete action is available. */
+  canDelete?: boolean
 }
 
 /**
@@ -197,6 +212,8 @@ export function InboxForm({
   onCancel,
   enableMembersPage = false,
   header,
+  inboxSummary,
+  canDelete = false,
 }: InboxFormProps) {
   const cancel = onCancel ?? onClose
 
@@ -216,9 +233,12 @@ export function InboxForm({
 
   // Personal-account inbox (§11): the Access section swaps the floor controls
   // for an owner row + activity-only note; the owner's Manager row is locked.
-  const { inbox: inboxItem } = useInbox(recordId ?? undefined)
-  const isPersonalInbox = !!inboxItem?.isPersonal
-  const ownerActorId = inboxItem?.ownerUserId ? toActorId('user', inboxItem.ownerUserId) : null
+  const { inbox: inboxItem } = useInbox(recordId ?? undefined, {
+    enabled: isEditing && !inboxSummary,
+  })
+  const isPersonalInbox = inboxSummary?.isPersonal ?? !!inboxItem?.isPersonal
+  const ownerUserId = inboxSummary?.ownerUserId ?? inboxItem?.ownerUserId
+  const ownerActorId = ownerUserId ? toActorId('user', ownerUserId) : null
 
   // Fetch system field values for edit mode.
   //
@@ -228,7 +248,7 @@ export function InboxForm({
   // before its last edit.
   const { values: fieldValues, isLoading: isLoadingValues } = useSystemValues(
     recordId,
-    ['inbox_name', 'inbox_description', 'inbox_color'],
+    INBOX_SYSTEM_ATTRS,
     { autoFetch: true, enabled: isEditing && !!recordId }
   )
 
@@ -370,6 +390,7 @@ export function InboxForm({
   /** Invalidate inbox query caches + the viewer's lens map + grant rows. */
   const invalidateInboxes = () => {
     utils.inbox.myLenses.invalidate()
+    utils.inbox.settingsList.invalidate()
     invalidateInboxRecordLists(utils)
     if (recordId) utils.resourceAccess.forInstance.invalidate({ recordId })
   }
@@ -767,7 +788,7 @@ export function InboxForm({
       </div>
 
       <DialogFooter className='flex sm:justify-between!'>
-        {isEditing ? (
+        {isEditing && canDelete ? (
           <Button
             type='button'
             size='sm'

--- a/apps/web/src/components/inbox/inbox-list.tsx
+++ b/apps/web/src/components/inbox/inbox-list.tsx
@@ -5,23 +5,23 @@ import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { toastError } from '@auxx/ui/components/toast'
-import { Inbox as InboxIcon, PlusIcon, Users } from 'lucide-react'
-import { type ReactNode, useState } from 'react'
+import { Inbox as InboxIcon, Lock, PlusIcon } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { type ReactNode, useEffect, useState } from 'react'
+import { useOAuthReturn } from '~/components/apps/hooks/use-oauth-return'
+import { ChannelGalleryDialog } from '~/components/channels/ui/channel-gallery-dialog'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { useResource } from '~/components/resources'
-import { useInboxes } from '~/components/threads/hooks'
-import { type InboxItem, invalidateInboxRecordLists } from '~/components/threads/hooks/use-inbox'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useUser } from '~/hooks/use-user'
-import { useRequireCapability } from '~/providers/capabilities-provider'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { InboxDialog } from './inbox-dialog'
-import { InboxCard } from './ui/inbox-card'
-import { InboxPlaceholderCard } from './ui/inbox-placeholder-card'
+import { InboxCard, type SettingsInboxItem } from './ui/inbox-card'
+import { InboxPlaceholderCard, PersonalInboxPlaceholderCard } from './ui/inbox-placeholder-card'
 
 const BREADCRUMBS = [{ title: 'Settings', href: '/app/settings' }, { title: 'Inboxes' }]
-
 const GRID_CLASS = 'grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'
 
 /** Container-query wrapper so the grid's `@md`/`@2xl` breakpoints resolve. */
@@ -33,46 +33,53 @@ function InboxGrid({ children }: { children: ReactNode }) {
   )
 }
 
-/** Inbox settings list page — a responsive ListCard grid of shared and personal inboxes. */
+/** Member-scoped inbox settings: owned personal inboxes plus accessible shared inboxes. */
 export function InboxList() {
   const utils = api.useUtils()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { can } = useAccess()
+  const canManageChannels = can(PermissionKey.channelsManage)
   const [confirm, ConfirmDialog] = useConfirm()
   const [dialogOpen, setDialogOpen] = useState(false)
-  // recordId to edit; null opens the dialog in create mode.
-  const [editRecordId, setEditRecordId] = useState<InboxItem['recordId'] | null>(null)
+  const [personalGalleryOpen, setPersonalGalleryOpen] = useState(false)
+  const [selectedInbox, setSelectedInbox] = useState<SettingsInboxItem | null>(null)
 
   useUser({ requireOrganization: true })
-  useRequireCapability(PermissionKey.channelsManage)
+  useOAuthReturn()
 
-  // Read inboxes from the generic record store; field-value mutations flush
-  // this automatically, so no manual invalidation is required after edits.
-  const { inboxes, records, isLoading, refresh } = useInboxes()
+  const { data: inboxes = [], isLoading, error } = api.inbox.settingsList.useQuery()
   const { resource } = useResource('inbox')
+
+  useEffect(() => {
+    if (searchParams.get('connect') === 'personal') setPersonalGalleryOpen(true)
+  }, [searchParams])
 
   const deleteInbox = api.inbox.delete.useMutation({
     onSuccess: () => {
-      invalidateInboxRecordLists(utils)
-      refresh()
+      void utils.inbox.settingsList.invalidate()
     },
-    onError: (error) => {
-      toastError({ title: 'Error deleting inbox', description: error.message })
+    onError: (mutationError) => {
+      toastError({ title: 'Error deleting inbox', description: mutationError.message })
     },
   })
 
-  /** Open the create inbox dialog */
+  const shared = inboxes.filter((inbox) => !inbox.isPersonal)
+  const personal = inboxes.filter((inbox) => inbox.isPersonal)
+
   const handleCreateInbox = () => {
-    setEditRecordId(null)
+    setSelectedInbox(null)
     setDialogOpen(true)
   }
 
-  /** Open the inbox editor dialog for an existing inbox */
-  const handleEditInbox = (inbox: InboxItem) => {
-    setEditRecordId(inbox.recordId)
+  const handleEditInbox = (inbox: SettingsInboxItem) => {
+    if (!inbox.canManage) return
+    setSelectedInbox(inbox)
     setDialogOpen(true)
   }
 
-  /** Delete an inbox after confirmation */
-  const handleDeleteInbox = async (inbox: InboxItem) => {
+  const handleDeleteInbox = async (inbox: SettingsInboxItem) => {
+    if (!inbox.canDelete) return
     const confirmed = await confirm({
       title: 'Delete inbox?',
       description: `This will permanently delete "${inbox.name}" and all its settings. This action cannot be undone.`,
@@ -83,14 +90,20 @@ export function InboxList() {
     if (confirmed) deleteInbox.mutate({ inboxId: inbox.id })
   }
 
-  const shared = inboxes.filter((inbox) => !inbox.isPersonal)
-  const personal = inboxes.filter((inbox) => inbox.isPersonal)
+  const handlePersonalGalleryChange = (open: boolean) => {
+    setPersonalGalleryOpen(open)
+    if (!open && searchParams.get('connect') === 'personal') {
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('connect')
+      const query = params.toString()
+      router.replace(query ? `/app/settings/inbox?${query}` : '/app/settings/inbox')
+    }
+  }
 
-  const renderCard = (inbox: InboxItem) => (
+  const renderCard = (inbox: SettingsInboxItem) => (
     <InboxCard
       key={inbox.id}
       inbox={inbox}
-      record={records.find((r) => r.id === inbox.id)}
       resourceIcon={resource?.icon ?? undefined}
       resourceColor={resource?.color ?? undefined}
       onEdit={handleEditInbox}
@@ -100,66 +113,91 @@ export function InboxList() {
   )
 
   return (
-    <SettingsPage
-      title='Inboxes'
-      description='Manage your shared inboxes and their settings.'
-      breadcrumbs={BREADCRUMBS}
-      button={
-        <Button variant='outline' size='sm' onClick={handleCreateInbox}>
-          <PlusIcon />
-          Create Inbox
-        </Button>
-      }>
-      <div className='p-3 sm:p-6'>
-        {isLoading ? (
-          <SettingsSection icon={InboxIcon} title='Shared inboxes'>
-            <InboxGrid>
-              {[0, 1, 2].map((i) => (
-                <ListCard key={i} loading />
-              ))}
-            </InboxGrid>
-          </SettingsSection>
-        ) : inboxes.length === 0 ? (
-          <EmptyState
-            icon={InboxIcon}
-            title='Create your first inbox'
-            description={<>Inboxes help you organize your messages.</>}
-            button={
-              <Button size='sm' variant='outline' onClick={handleCreateInbox}>
-                <PlusIcon />
-                Create Inbox
-              </Button>
-            }
-          />
-        ) : (
-          <div className='space-y-6'>
-            <SettingsSection
+    <>
+      <SettingsPage
+        title='Inboxes'
+        description='Manage your personal accounts and the shared inboxes you can access.'
+        breadcrumbs={BREADCRUMBS}
+        button={
+          canManageChannels ? (
+            <Button variant='outline' size='sm' onClick={handleCreateInbox}>
+              <PlusIcon />
+              Create shared inbox
+            </Button>
+          ) : undefined
+        }>
+        <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
+          {error ? (
+            <EmptyState
               icon={InboxIcon}
-              title='Shared inboxes'
-              description='Inboxes shared across your workspace.'>
-              <InboxGrid>
-                {shared.map(renderCard)}
-                <InboxPlaceholderCard onClick={handleCreateInbox} />
-              </InboxGrid>
-            </SettingsSection>
-
-            {personal.length > 0 && (
+              title='Could not load inboxes'
+              description={error.message}
+            />
+          ) : (
+            <>
               <SettingsSection
-                icon={Users}
+                icon={Lock}
                 title='Personal inboxes'
-                description="Members' connected personal mailboxes.">
-                <InboxGrid>{personal.map(renderCard)}</InboxGrid>
+                description='Private mailboxes connected to your own Gmail or Outlook account.'>
+                <InboxGrid>
+                  {isLoading ? (
+                    <>
+                      <ListCard loading descriptionLines={0} />
+                      <ListCard loading descriptionLines={0} />
+                    </>
+                  ) : (
+                    <>
+                      {personal.map(renderCard)}
+                      <PersonalInboxPlaceholderCard onClick={() => setPersonalGalleryOpen(true)} />
+                    </>
+                  )}
+                </InboxGrid>
               </SettingsSection>
-            )}
-          </div>
-        )}
-      </div>
 
-      {/* Dialog only renders when open */}
+              {(isLoading || shared.length > 0 || canManageChannels) && (
+                <SettingsSection
+                  icon={InboxIcon}
+                  title='Shared inboxes'
+                  description='Team queues you can work in or manage.'>
+                  <InboxGrid>
+                    {isLoading ? (
+                      <>
+                        <ListCard loading descriptionLines={0} />
+                        <ListCard loading descriptionLines={0} />
+                      </>
+                    ) : (
+                      <>
+                        {shared.map(renderCard)}
+                        {canManageChannels && <InboxPlaceholderCard onClick={handleCreateInbox} />}
+                      </>
+                    )}
+                  </InboxGrid>
+                </SettingsSection>
+              )}
+            </>
+          )}
+        </div>
+      </SettingsPage>
+
       {dialogOpen && (
-        <InboxDialog open={dialogOpen} onOpenChange={setDialogOpen} recordId={editRecordId} />
+        <InboxDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          recordId={selectedInbox?.recordId}
+          inboxSummary={selectedInbox ?? undefined}
+          canDelete={selectedInbox?.canDelete ?? false}
+          onSuccess={() => void utils.inbox.settingsList.invalidate()}
+        />
       )}
+
+      <ChannelGalleryDialog
+        open={personalGalleryOpen}
+        onOpenChange={handlePersonalGalleryChange}
+        personalOnly
+        returnTo='/app/settings/inbox'
+      />
+
       <ConfirmDialog />
-    </SettingsPage>
+    </>
   )
 }

--- a/apps/web/src/components/inbox/ui/inbox-card.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-card.tsx
@@ -5,12 +5,15 @@ import { Badge } from '@auxx/ui/components/badge'
 import { ListCard, type ListCardMenuItem, type ListCardStatus } from '@auxx/ui/components/list-card'
 import { PencilIcon, Trash2Icon } from 'lucide-react'
 import { RecordIcon } from '~/components/resources/ui/record-icon'
-import type { InboxItem, InboxRecord } from '~/components/threads/hooks/use-inbox'
+import type { RouterOutputs } from '~/trpc/react'
 
 const DETAIL_BASE = '/app/settings/inbox'
 
+/** Scoped inbox row returned by `inbox.settingsList`. */
+export type SettingsInboxItem = RouterOutputs['inbox']['settingsList'][number]
+
 /** Corner status dot (tone + tooltip) from the inbox status field. */
-function inboxStatus(status: InboxItem['status']): ListCardStatus {
+function inboxStatus(status: SettingsInboxItem['status']): ListCardStatus {
   switch (status) {
     case 'ACTIVE':
       return { tone: 'good', label: 'Active' }
@@ -24,7 +27,7 @@ function inboxStatus(status: InboxItem['status']): ListCardStatus {
 }
 
 /** Access label from the org-wide floor lens. */
-function getAccessDisplay(defaultLens: InboxItem['defaultLens']): string {
+function getAccessDisplay(defaultLens: SettingsInboxItem['defaultLens']): string {
   switch (defaultLens) {
     case 'none':
       return 'Restricted'
@@ -38,14 +41,12 @@ function getAccessDisplay(defaultLens: InboxItem['defaultLens']): string {
 }
 
 interface InboxCardProps {
-  inbox: InboxItem
-  /** Raw record for the avatar (falls back to the entity-def icon/color). */
-  record?: InboxRecord
+  inbox: SettingsInboxItem
   /** Entity-def icon/color fallbacks from `useResource('inbox')`. */
   resourceIcon?: string
   resourceColor?: string
-  onEdit: (inbox: InboxItem) => void
-  onDelete: (inbox: InboxItem) => void
+  onEdit: (inbox: SettingsInboxItem) => void
+  onDelete: (inbox: SettingsInboxItem) => void
   deletePending?: boolean
 }
 
@@ -56,37 +57,34 @@ interface InboxCardProps {
  */
 export function InboxCard({
   inbox,
-  record,
   resourceIcon,
   resourceColor,
   onEdit,
   onDelete,
   deletePending,
 }: InboxCardProps) {
-  const menuItems: ListCardMenuItem[] = [
-    {
+  const menuItems: ListCardMenuItem[] = []
+  if (inbox.canManage) {
+    menuItems.push({
       label: 'Edit',
       icon: <PencilIcon />,
       onClick: () => onEdit(inbox),
-    },
-    {
+    })
+  }
+  if (inbox.canDelete) {
+    menuItems.push({
       label: 'Delete',
       icon: <Trash2Icon />,
       destructive: true,
       disabled: deletePending,
       onClick: () => onDelete(inbox),
-    },
-  ]
+    })
+  }
 
   return (
     <ListCard
       media={
-        <RecordIcon
-          avatarUrl={record?.avatarUrl}
-          iconId={resourceIcon ?? 'inbox'}
-          color={resourceColor ?? 'gray'}
-          size='lg'
-        />
+        <RecordIcon iconId={resourceIcon ?? 'inbox'} color={resourceColor ?? 'gray'} size='lg' />
       }
       title={inbox.name}
       subtitle={inbox.isPersonal ? 'Personal inbox' : 'Shared inbox'}
@@ -99,7 +97,7 @@ export function InboxCard({
         </Badge>
       }
       href={`${DETAIL_BASE}/${inbox.id}`}
-      menuItems={menuItems}
+      menuItems={menuItems.length > 0 ? menuItems : undefined}
     />
   )
 }

--- a/apps/web/src/components/inbox/ui/inbox-channel-card.test.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-channel-card.test.tsx
@@ -1,0 +1,73 @@
+// apps/web/src/components/inbox/ui/inbox-channel-card.test.tsx
+
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listCard, push, useChannelById } = vi.hoisted(() => ({
+  listCard: vi.fn(),
+  push: vi.fn(),
+  useChannelById: vi.fn(),
+}))
+
+vi.mock('@auxx/ui/components/list-card', () => ({
+  ListCard: (props: Record<string, unknown>) => {
+    listCard(props)
+    return null
+  },
+  renderBadgeChips: vi.fn(() => null),
+}))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }))
+vi.mock('~/components/channels/store/channel-store', () => ({ useChannelById }))
+vi.mock('~/components/channels/ui/channel-card', () => ({
+  channelStatus: vi.fn(() => ({ tone: 'good', label: 'Connected' })),
+}))
+vi.mock('~/components/channels/ui/channel-icon', () => ({
+  getChannelProviderName: vi.fn(() => 'Gmail'),
+  getIntegrationProviderIcon: vi.fn(() => null),
+}))
+
+const { InboxChannelCard } = await import('./inbox-channel-card')
+
+const integration = {
+  id: 'link_1',
+  integrationId: 'channel_1',
+  isDefault: true,
+  settings: {},
+  integration: {
+    id: 'channel_1',
+    name: 'Support',
+    email: 'support@example.com',
+    provider: 'google',
+  },
+} as never
+
+beforeEach(() => {
+  listCard.mockClear()
+  push.mockClear()
+  useChannelById.mockReturnValue(undefined)
+})
+
+describe('InboxChannelCard channel-management affordances', () => {
+  it('is read-only for an inbox Manager without channels.manage', () => {
+    render(<InboxChannelCard integration={integration} onRemove={vi.fn()} canManage={false} />)
+
+    expect(listCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        href: undefined,
+        menuItems: undefined,
+      })
+    )
+  })
+
+  it('keeps channel navigation and removal for a channel manager', () => {
+    const onRemove = vi.fn()
+    render(<InboxChannelCard integration={integration} onRemove={onRemove} canManage />)
+
+    const props = listCard.mock.calls[0]?.[0]
+    expect(props.href).toBe('/app/settings/channels/channel_1')
+    expect(props.menuItems).toHaveLength(2)
+
+    props.menuItems[1].onClick()
+    expect(onRemove).toHaveBeenCalledWith(integration)
+  })
+})

--- a/apps/web/src/components/inbox/ui/inbox-channel-card.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-channel-card.tsx
@@ -32,6 +32,8 @@ interface InboxChannelCardProps {
   integration: InboxIntegration
   onRemove: (integration: InboxIntegration) => void
   removePending?: boolean
+  /** Whether channel navigation and routing controls should be available. */
+  canManage: boolean
 }
 
 /**
@@ -40,7 +42,12 @@ interface InboxChannelCardProps {
  * back to "Connected"), and a "Default" chip. The three-dot menu opens the
  * channel detail or removes the channel from this inbox (unassign, not disconnect).
  */
-export function InboxChannelCard({ integration, onRemove, removePending }: InboxChannelCardProps) {
+export function InboxChannelCard({
+  integration,
+  onRemove,
+  removePending,
+  canManage,
+}: InboxChannelCardProps) {
   const router = useRouter()
   const { integrationId } = integration
   const { name, email, provider } = integration.integration
@@ -51,20 +58,22 @@ export function InboxChannelCard({ integration, onRemove, removePending }: Inbox
 
   const providerName = getChannelProviderName(provider)
 
-  const menuItems: ListCardMenuItem[] = [
-    {
-      label: 'Open',
-      icon: <ExternalLink />,
-      onClick: () => router.push(`${DETAIL_BASE}/${integrationId}`),
-    },
-    {
-      label: 'Remove from inbox',
-      icon: <Trash2 />,
-      destructive: true,
-      disabled: removePending,
-      onClick: () => onRemove(integration),
-    },
-  ]
+  const menuItems: ListCardMenuItem[] | undefined = canManage
+    ? [
+        {
+          label: 'Open',
+          icon: <ExternalLink />,
+          onClick: () => router.push(`${DETAIL_BASE}/${integrationId}`),
+        },
+        {
+          label: 'Remove from inbox',
+          icon: <Trash2 />,
+          destructive: true,
+          disabled: removePending,
+          onClick: () => onRemove(integration),
+        },
+      ]
+    : undefined
 
   return (
     <ListCard
@@ -73,7 +82,7 @@ export function InboxChannelCard({ integration, onRemove, removePending }: Inbox
       subtitle={email ? `${providerName} · ${email}` : providerName}
       status={status}
       headerEnd={integration.isDefault ? renderBadgeChips([{ label: 'Default' }]) : undefined}
-      href={`${DETAIL_BASE}/${integrationId}`}
+      href={canManage ? `${DETAIL_BASE}/${integrationId}` : undefined}
       menuItems={menuItems}
       descriptionLines={0}
     />

--- a/apps/web/src/components/inbox/ui/inbox-placeholder-card.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-placeholder-card.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { ListCard } from '@auxx/ui/components/list-card'
-import { Plus } from 'lucide-react'
+import { Lock, Plus } from 'lucide-react'
 
 /**
  * Dashed placeholder/add card matching the ListCard shape — opens the create
@@ -15,9 +15,24 @@ export function InboxPlaceholderCard({ onClick }: { onClick: () => void }) {
       variant='placeholder'
       classNames={{ icon: 'border-dashed' }}
       icon={<Plus className='size-4 text-muted-foreground' />}
-      title='Add an inbox'
-      subtitle='Shared or personal'
-      description='Create a new inbox to organize your messages.'
+      title='Create shared inbox'
+      subtitle='For your team'
+      description='Create a shared queue to organize team messages.'
+      onClick={onClick}
+    />
+  )
+}
+
+/** Personal-account connect tile for the member-facing inbox settings page. */
+export function PersonalInboxPlaceholderCard({ onClick }: { onClick: () => void }) {
+  return (
+    <ListCard
+      variant='placeholder'
+      classNames={{ icon: 'border-dashed' }}
+      icon={<Lock className='size-4 text-muted-foreground' />}
+      title='Connect personal account'
+      subtitle='Gmail or Outlook'
+      description='Create a private inbox connected to your own mailbox.'
       onClick={onClick}
     />
   )

--- a/apps/web/src/components/mail/thread-display.tsx
+++ b/apps/web/src/components/mail/thread-display.tsx
@@ -102,7 +102,7 @@ export function ThreadDisplay({ centered, expectedThreadId }: ThreadDisplayProps
           }
           button={
             hasOnlyForwardingChannel ? (
-              <Link href='/app/settings/channels?connect=1'>
+              <Link href='/app/settings/inbox?connect=personal'>
                 <Button variant='outline'>
                   <Plus size={16} />
                   <span>Setup Channel</span>

--- a/apps/web/src/components/resources/hooks/use-create-record.ts
+++ b/apps/web/src/components/resources/hooks/use-create-record.ts
@@ -7,6 +7,7 @@ import { toResourceFieldId } from '@auxx/types/field'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback } from 'react'
 import { useResourceStore } from '~/components/resources/store/resource-store'
+import { resolveSystemAttributeRef } from '~/components/resources/utils/resolve-system-attribute'
 import { api } from '~/trpc/react'
 import {
   type CreatedRecordInstance,
@@ -68,7 +69,7 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
     (values: Record<string, unknown>): SeedFieldValue[] => {
       const store = useResourceStore.getState()
       return Object.entries(values).map(([fieldId, value]) => {
-        const ref = store.systemAttributeMap[fieldId] ?? fieldId
+        const ref = resolveSystemAttributeRef(store, fieldId, entityDefinitionId) ?? fieldId
         const field =
           store.getFieldByRef(ref) ??
           store.getFieldByRef(toResourceFieldId(entityDefinitionId, fieldId))

--- a/apps/web/src/components/resources/hooks/use-field.ts
+++ b/apps/web/src/components/resources/hooks/use-field.ts
@@ -9,6 +9,7 @@ import { type ResourceFieldId, toFieldId, toResourceFieldId } from '@auxx/types/
 import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useResourceStore } from '../store/resource-store'
+import { resolveSystemAttributeRef } from '../utils/resolve-system-attribute'
 
 /**
  * Extended ResourceField with effectiveFieldType for CALC fields.
@@ -237,19 +238,25 @@ export function useFieldSelectOption(
  * @param systemAttribute - The system attribute (e.g., 'thread_tags', 'thread_created_at')
  * @returns ResourceFieldWithEffective or undefined if not found
  *
+ * Pass `entityDefinitionId` whenever one is in scope. Without it the attribute
+ * is resolved by name alone, which is a coin flip for an attribute owned by two
+ * definitions (`inbox_name` lives on both `inbox` and `personal_inbox`); such a
+ * lookup warns in dev.
+ *
  * @example
- * const tagsField = useSystemField('thread_tags')
+ * const tagsField = useSystemField('thread_tags', threadEntityDefId)
  * const emailField = useSystemField('primary_email')
  * const threadCreatedAt = useSystemField('thread_created_at')
  * const contactId = useSystemField('contact_id')
  */
 export function useSystemField(
-  systemAttribute: string | null | undefined
+  systemAttribute: string | null | undefined,
+  entityDefinitionId?: string | null
 ): ResourceFieldWithEffective | undefined {
-  // Look up the ResourceFieldId from systemAttributeMap
+  // Look up the ResourceFieldId, definition-scoped when one is available
   const resourceFieldId = useResourceStore((state) => {
     if (!systemAttribute) return undefined
-    return state.systemAttributeMap[systemAttribute]
+    return resolveSystemAttributeRef(state, systemAttribute, entityDefinitionId)
   })
 
   // Delegate to useField for actual field retrieval
@@ -277,7 +284,9 @@ export function useFieldByKey(
 ): ResourceFieldWithEffective | undefined {
   const resourceFieldId = useResourceStore((state) => {
     if (!key) return undefined
-    const sysRfId = state.systemAttributeMap[key]
+    // Definition-scoped FIRST: resolving the attribute by name before consulting
+    // `entityDefinitionId` discards the very argument that disambiguates it.
+    const sysRfId = resolveSystemAttributeRef(state, key, entityDefinitionId)
     if (sysRfId) return sysRfId
     if (!entityDefinitionId) return undefined
     // Canonicalize the def prefix — fieldMap is keyed by the canonical

--- a/apps/web/src/components/resources/hooks/use-save-field-value.ts
+++ b/apps/web/src/components/resources/hooks/use-save-field-value.ts
@@ -20,6 +20,7 @@ import {
 } from '~/components/resources/store/field-value-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { getNormalizedRecordId } from '~/components/resources/utils/normalize-record-id'
+import { resolveSystemAttributeForRecord } from '~/components/resources/utils/resolve-system-attribute'
 import { api } from '~/trpc/react'
 import {
   extractRelatedRecordIds,
@@ -40,9 +41,17 @@ interface SaveOptions {
  * If the identifier is a systemAttribute (e.g. 'vendor_part_vendor_sku'), returns
  * the corresponding ResourceFieldId (e.g. 'defId:vendorSku') so store keys match
  * what useSystemValues subscribes to. Otherwise returns the identifier as-is.
+ *
+ * `recordId` scopes the attribute to its own definition — without it a shared
+ * attribute resolves to whichever definition won the bare map, and the store key
+ * then disagrees with the one `useSystemValues` subscribes to.
  */
-function resolveFieldRef(fieldId: string): FieldReference {
-  const resourceFieldId = useResourceStore.getState().systemAttributeMap[fieldId]
+function resolveFieldRef(fieldId: string, recordId?: RecordId): FieldReference {
+  const resourceFieldId = resolveSystemAttributeForRecord(
+    useResourceStore.getState(),
+    fieldId,
+    recordId
+  )
   return (resourceFieldId ?? fieldId) as FieldReference
 }
 
@@ -78,7 +87,7 @@ function prepareOptimisticUpdate(
   getFieldMetadata?: (fieldId: FieldId) => FieldMetadata | undefined,
   ai?: boolean
 ): OptimisticUpdatePrep {
-  const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId))
+  const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId, recordId))
   const store = useFieldValueStore.getState()
 
   // Capture old value for relationship sync rollback
@@ -425,7 +434,10 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       // Build keys, capture versions, and apply optimistic updates
       const keyVersions: Array<{ key: string; version: number }> = []
       for (const { fieldId, value, fieldType } of fieldValues) {
-        const key = buildFieldValueKey(normalizedRecordId, resolveFieldRef(fieldId))
+        const key = buildFieldValueKey(
+          normalizedRecordId,
+          resolveFieldRef(fieldId, normalizedRecordId)
+        )
         const version = store.incrementMutationVersion(key)
         keyVersions.push({ key, version })
         if (ai) {
@@ -504,10 +516,11 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       const keyVersions: Array<{ key: FieldValueKey; version: number }> = []
       const typedValue = ai || !fieldType ? value : formatToTypedInput(value, fieldType)
 
-      const resolvedRef = resolveFieldRef(fieldId)
       const requestedAt = ai ? new Date().toISOString() : undefined
       for (const recordId of normalizedRecordIds) {
-        const key = buildFieldValueKey(recordId, resolvedRef)
+        // Resolved per record, not hoisted: a bulk set may span definitions, and
+        // a systemAttribute resolves to a different field on each of them.
+        const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId, recordId))
         const version = store.incrementMutationVersion(key)
         keyVersions.push({ key, version })
         if (ai) {
@@ -585,7 +598,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
 
       for (const recordId of normalizedRecordIds) {
         for (const { fieldId, value, fieldType } of fieldValues) {
-          const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId))
+          const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId, recordId))
           const version = store.incrementMutationVersion(key)
           keyVersions.push({ key, version })
           if (ai) {

--- a/apps/web/src/components/resources/hooks/use-save-system-values.ts
+++ b/apps/web/src/components/resources/hooks/use-save-system-values.ts
@@ -5,6 +5,7 @@ import type { RecordId } from '@auxx/lib/resources/client'
 import { parseResourceFieldId } from '@auxx/types/field'
 import { useCallback } from 'react'
 import { useResourceStore } from '../store/resource-store'
+import { resolveSystemAttributeForRecord } from '../utils/resolve-system-attribute'
 import { useSaveFieldValue } from './use-save-field-value'
 
 /**
@@ -23,6 +24,8 @@ import { useSaveFieldValue } from './use-save-field-value'
 export function useSaveSystemValues(recordId: RecordId | null | undefined) {
   // Get maps from store
   const systemAttributeMap = useResourceStore((state) => state.systemAttributeMap)
+  const systemAttributeByDef = useResourceStore((state) => state.systemAttributeByDef)
+  const ambiguousSystemAttributes = useResourceStore((state) => state.ambiguousSystemAttributes)
   const fieldMap = useResourceStore((state) => state.fieldMap)
 
   // Use existing save field value hook
@@ -40,8 +43,13 @@ export function useSaveSystemValues(recordId: RecordId | null | undefined) {
       // Resolve system attributes to field info
       const fieldValues: Array<{ fieldId: string; value: unknown; fieldType: FieldType }> = []
 
+      // Resolve against the record's own definition — a bare lookup can return
+      // a different definition's field, and writing THAT id lands a field value
+      // bound to the wrong definition.
+      const maps = { systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes }
+
       for (const [attr, value] of Object.entries(values)) {
-        const resourceFieldId = systemAttributeMap[attr]
+        const resourceFieldId = resolveSystemAttributeForRecord(maps, attr, recordId)
         if (!resourceFieldId) {
           console.warn(`[useSaveSystemValues] Unknown system attribute: ${attr}`)
           continue
@@ -67,7 +75,14 @@ export function useSaveSystemValues(recordId: RecordId | null | undefined) {
 
       return saveMultipleAsync(recordId, fieldValues)
     },
-    [recordId, systemAttributeMap, fieldMap, saveMultipleAsync]
+    [
+      recordId,
+      systemAttributeMap,
+      systemAttributeByDef,
+      ambiguousSystemAttributes,
+      fieldMap,
+      saveMultipleAsync,
+    ]
   )
 
   return { save, isPending }

--- a/apps/web/src/components/resources/hooks/use-seed-created-record.ts
+++ b/apps/web/src/components/resources/hooks/use-seed-created-record.ts
@@ -12,6 +12,7 @@ import {
 import { type RecordMeta, useRecordStore } from '~/components/resources/store/record-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { getNormalizedRecordId } from '~/components/resources/utils/normalize-record-id'
+import { resolveSystemAttributeForRecord } from '~/components/resources/utils/resolve-system-attribute'
 
 /** Minimal instance shape needed to seed a `RecordMeta` — the fields carried by
  *  `CreateEntityResult.instance` (`@auxx/lib` `unified-handler-mutations.ts`). */
@@ -79,9 +80,13 @@ export function useSeedCreatedRecord() {
       // `record.listAll` tRPC cache, pushed separately by the caller.
       if (listKey) recordStore.appendCreatedRecord(listKey, instance.id)
 
-      const systemAttributeMap = useResourceStore.getState().systemAttributeMap
+      const resourceState = useResourceStore.getState()
       const entries = values.map(({ fieldId, value, fieldType }) => {
-        const resourceFieldId = (systemAttributeMap[fieldId] ?? fieldId) as FieldReference
+        const resourceFieldId = (resolveSystemAttributeForRecord(
+          resourceState,
+          fieldId,
+          recordId
+        ) ?? fieldId) as FieldReference
         return {
           key: buildFieldValueKey(recordId, resourceFieldId),
           value: fieldType ? formatToTypedInput(value, fieldType) : value,

--- a/apps/web/src/components/resources/hooks/use-system-values.ts
+++ b/apps/web/src/components/resources/hooks/use-system-values.ts
@@ -2,10 +2,12 @@
 
 import { formatToRawValue, isMultiValueFieldType } from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/lib/resources/client'
+import { getDefinitionId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
 import { useMemo } from 'react'
 import { useResourceStore } from '../store/resource-store'
 import { useNormalizedRecordId } from '../utils/normalize-record-id'
+import { resolveSystemAttributeRef } from '../utils/resolve-system-attribute'
 import { useFieldValues } from './use-field-values'
 
 /**
@@ -32,7 +34,10 @@ interface FieldInfo {
  * Subscribe to system field values by attribute names.
  * Returns formatted values keyed by system attribute.
  *
- * All systemAttributes are globally unique:
+ * Attributes are resolved against the RECORD'S OWN definition, never by name
+ * alone: cloned field sets mean one attribute can belong to two definitions
+ * (`inbox` and `personal_inbox` both own `inbox_name`), and a bare lookup then
+ * reads the wrong definition's field and returns nothing.
  * - Most fields use their natural name: 'name', 'inbox_description', 'visibility'
  * - Universal fields use "{entityType}_{attribute}": 'thread_created_at', 'contact_id'
  *
@@ -49,35 +54,54 @@ interface FieldInfo {
  */
 export function useSystemValues<T extends string>(
   recordId: RecordId | null | undefined,
-  systemAttributes: T[],
+  systemAttributes: readonly T[],
   options: UseSystemValuesOptions = {}
 ): { values: Record<T, unknown>; isLoading: boolean } {
   const { autoFetch = false, enabled = true } = options
 
   // Get maps from store (stable references from zustand)
   const systemAttributeMap = useResourceStore((state) => state.systemAttributeMap)
+  const systemAttributeByDef = useResourceStore((state) => state.systemAttributeByDef)
+  const ambiguousSystemAttributes = useResourceStore((state) => state.ambiguousSystemAttributes)
   const fieldMap = useResourceStore((state) => state.fieldMap)
 
+  // Normalize the definition prefix to the real entityDefinitionId so reads
+  // match the keys used when field values are written — and so attributes
+  // resolve against THIS record's definition.
+  const normalizedRecordId = useNormalizedRecordId(recordId)
+  const entityDefinitionId = normalizedRecordId ? getDefinitionId(normalizedRecordId) : null
+
+  // Callers overwhelmingly pass an inline array literal, which is a new
+  // reference every render. Key the memo on the contents instead, or every
+  // render rebuilds `fieldRefs` and re-triggers the fetch below.
+  const attrsKey = JSON.stringify(systemAttributes)
+
   // Resolve system attributes to field info (memoized based on stable store references)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: attrsKey stands in for systemAttributes
   const fieldInfos = useMemo((): FieldInfo[] => {
     if (!enabled) return []
+    const maps = { systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes }
     const result: FieldInfo[] = []
     for (const attr of systemAttributes) {
-      const resourceFieldId = systemAttributeMap[attr]
+      const resourceFieldId = resolveSystemAttributeRef(maps, attr, entityDefinitionId)
       if (!resourceFieldId) continue
       const field = fieldMap[resourceFieldId]
       if (!field?.fieldType) continue
       result.push({ attr, resourceFieldId, fieldType: field.fieldType, options: field.options })
     }
     return result
-  }, [enabled, systemAttributes, systemAttributeMap, fieldMap])
+  }, [
+    enabled,
+    attrsKey,
+    entityDefinitionId,
+    systemAttributeMap,
+    systemAttributeByDef,
+    ambiguousSystemAttributes,
+    fieldMap,
+  ])
 
   // Build fieldRefs array (just the ResourceFieldIds)
   const fieldRefs = useMemo(() => fieldInfos.map((f) => f.resourceFieldId), [fieldInfos])
-
-  // Normalize the definition prefix to the real entityDefinitionId so reads
-  // match the keys used when field values are written.
-  const normalizedRecordId = useNormalizedRecordId(recordId)
 
   // Fetch values using useFieldValues with autoFetch
   const { values: rawValues, isLoading } = useFieldValues(

--- a/apps/web/src/components/resources/store/resource-store.ts
+++ b/apps/web/src/components/resources/store/resource-store.ts
@@ -117,8 +117,31 @@ interface ResourceStoreState {
   /** Field-level lookup map with optimistic overlay (O(1) lookups by ResourceFieldId) */
   fieldMap: Record<ResourceFieldId, ResourceField>
 
-  /** Global map for O(1) lookups: systemAttribute -> ResourceFieldId */
+  /**
+   * Global map for O(1) lookups: systemAttribute -> ResourceFieldId.
+   *
+   * Keyed by attribute ALONE, so it cannot distinguish two definitions that
+   * carry the same systemAttribute (`inbox` and `personal_inbox` both own
+   * `inbox_name`). Prefer {@link ResourceState.systemAttributeByDef} whenever a
+   * definition is in scope; consult {@link ResourceState.ambiguousSystemAttributes}
+   * before trusting a bare hit.
+   */
   systemAttributeMap: Record<string, ResourceFieldId>
+
+  /**
+   * Definition-scoped lookups: `${entityDefinitionId}:${systemAttribute}` ->
+   * ResourceFieldId. Registered under every prefix form a caller can arrive
+   * with (canonical def id and `resource.id` when they differ), so a hit here
+   * is always the right definition's field.
+   */
+  systemAttributeByDef: Record<string, ResourceFieldId>
+
+  /**
+   * systemAttributes owned by more than one definition. A bare lookup against
+   * {@link ResourceState.systemAttributeMap} for one of these is a coin flip —
+   * resolve it against a definition instead.
+   */
+  ambiguousSystemAttributes: Set<string>
 
   // ─────────────────────────────────────────────────────────────────
   // ACTIONS
@@ -436,6 +459,8 @@ const initialState = {
   serverFieldMap: {} as Record<ResourceFieldId, ResourceField>,
   fieldMap: {} as Record<ResourceFieldId, ResourceField>,
   systemAttributeMap: {} as Record<string, ResourceFieldId>,
+  systemAttributeByDef: {} as Record<string, ResourceFieldId>,
+  ambiguousSystemAttributes: new Set<string>(),
   // Field optimistic state
   pendingFieldUpdates: {} as Record<ResourceFieldId, PendingFieldUpdate>,
   optimisticNewFields: {} as Record<ResourceFieldId, ResourceField>,
@@ -486,29 +511,65 @@ export const useResourceStore = create<ResourceStoreState>()(
       // Filter custom resources
       const customResources = resources.filter(isCustomResource)
 
-      // Build server field map and systemAttribute lookup map
+      // Build server field map and systemAttribute lookup maps
       const serverFieldMap: Record<ResourceFieldId, ResourceField> = {}
       const systemAttributeMap: Record<string, ResourceFieldId> = {}
+      const systemAttributeByDef: Record<string, ResourceFieldId> = {}
+      const ambiguousSystemAttributes = new Set<string>()
+      // Which definition currently owns each bare key, so a second definition
+      // claiming the same attribute is detected rather than silently winning.
+      const bareKeyOwner: Record<string, string> = {}
       const UNIVERSAL_ATTRIBUTES = ['id', 'record_id', 'created_at', 'updated_at']
 
       resources.forEach((resource) => {
         // Get entityType for universal field mapping (e.g., 'thread', 'contact', 'ticket')
         const entityType = resource.entityType || resource.apiSlug
+        // `definitionIdByPrefix` resolves every alias to this id, so it is the
+        // form callers arrive with; `resource.id` is what the VALUE embeds.
+        const canonicalDefId = resource.entityDefinitionId || resource.id
 
         resource.fields.forEach((field) => {
           const resourceFieldId = field.resourceFieldId || toResourceFieldId(resource.id, field.id)
           serverFieldMap[resourceFieldId] = { ...field, resourceFieldId }
 
-          // Build systemAttribute lookup map
-          if (field.systemAttribute && entityType) {
-            if (UNIVERSAL_ATTRIBUTES.includes(field.systemAttribute)) {
-              // Universal fields: map to "{entityType}_{attribute}"
-              // e.g., "thread_created_at", "contact_id"
-              const mappedKey = `${entityType}_${field.systemAttribute}`
-              systemAttributeMap[mappedKey] = resourceFieldId
-            } else {
-              // Unique fields: use systemAttribute directly as key
-              systemAttributeMap[field.systemAttribute] = resourceFieldId
+          if (!field.systemAttribute) return
+
+          // Definition-scoped: always registered, no entityType required, under
+          // both the raw attribute and the entityType-mapped form so either
+          // spelling resolves.
+          const scopedKeys = new Set<string>([field.systemAttribute])
+          if (entityType && UNIVERSAL_ATTRIBUTES.includes(field.systemAttribute)) {
+            scopedKeys.add(`${entityType}_${field.systemAttribute}`)
+          }
+          for (const defPrefix of new Set([canonicalDefId, resource.id])) {
+            if (!defPrefix) continue
+            for (const key of scopedKeys) {
+              systemAttributeByDef[`${defPrefix}:${key}`] = resourceFieldId
+            }
+          }
+
+          // Build systemAttribute lookup map (bare — legacy, def-less callers)
+          if (entityType) {
+            const bareKey = UNIVERSAL_ATTRIBUTES.includes(field.systemAttribute)
+              ? // Universal fields: map to "{entityType}_{attribute}"
+                // e.g., "thread_created_at", "contact_id"
+                `${entityType}_${field.systemAttribute}`
+              : // Unique fields: use systemAttribute directly as key
+                field.systemAttribute
+            const owner = bareKeyOwner[bareKey]
+            if (owner === undefined) {
+              bareKeyOwner[bareKey] = canonicalDefId
+              systemAttributeMap[bareKey] = resourceFieldId
+            } else if (owner !== canonicalDefId) {
+              // Two definitions own this attribute. Break the tie on definition
+              // id rather than on `resources` iteration order, so an ambiguous
+              // attribute resolves the SAME way on every fetch — a stable wrong
+              // answer is debuggable, an intermittent one is not.
+              ambiguousSystemAttributes.add(bareKey)
+              if (canonicalDefId < owner) {
+                bareKeyOwner[bareKey] = canonicalDefId
+                systemAttributeMap[bareKey] = resourceFieldId
+              }
             }
           }
         })
@@ -606,6 +667,8 @@ export const useResourceStore = create<ResourceStoreState>()(
         serverFieldMap,
         fieldMap,
         systemAttributeMap,
+        systemAttributeByDef,
+        ambiguousSystemAttributes,
         // Field optimistic state
         pendingFieldUpdates: newPendingFieldUpdates,
         optimisticNewFields: newOptimisticNewFields,
@@ -1459,6 +1522,8 @@ export const useResourceStore = create<ResourceStoreState>()(
         serverFieldMap: {} as Record<ResourceFieldId, ResourceField>,
         fieldMap: {} as Record<ResourceFieldId, ResourceField>,
         systemAttributeMap: {} as Record<string, ResourceFieldId>,
+        systemAttributeByDef: {} as Record<string, ResourceFieldId>,
+        ambiguousSystemAttributes: new Set<string>(),
         // Field optimistic state
         pendingFieldUpdates: {} as Record<ResourceFieldId, PendingFieldUpdate>,
         optimisticNewFields: {} as Record<ResourceFieldId, ResourceField>,

--- a/apps/web/src/components/resources/ui/record-hover-card.tsx
+++ b/apps/web/src/components/resources/ui/record-hover-card.tsx
@@ -21,6 +21,7 @@ import { useRecord } from '~/components/resources/hooks/use-record'
 import { useResource } from '~/components/resources/hooks/use-resource'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { useRecordLink } from '~/components/resources/utils/get-record-link'
+import { resolveSystemAttributeRef } from '~/components/resources/utils/resolve-system-attribute'
 import { RecordHoverCardField } from './record-hover-card-field'
 import { RecordIcon } from './record-icon'
 
@@ -135,6 +136,8 @@ function RecordHoverCardBody({ recordId, fields, onOpenInDrawer, onEdit }: BodyP
   const { resource, isLoading: isLoadingResource } = useResource(entityDefinitionId)
   const href = useRecordLink(recordId)
   const systemAttributeMap = useResourceStore((s) => s.systemAttributeMap)
+  const systemAttributeByDef = useResourceStore((s) => s.systemAttributeByDef)
+  const ambiguousSystemAttributes = useResourceStore((s) => s.ambiguousSystemAttributes)
 
   // Secondary display lives on RecordMeta.secondaryInfo (populated by the batch
   // fetcher from EntityInstance.secondaryDisplayValue). Same path TicketBadge uses.
@@ -152,13 +155,21 @@ function RecordHoverCardBody({ recordId, fields, onOpenInDrawer, onEdit }: BodyP
     if (!resource?.entityType) return []
     const attrs = getHoverCardFieldKeys(resource.entityType)
     if (attrs.length === 0) return []
+    const maps = { systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes }
     const refs: ResourceFieldId[] = []
     for (const attr of attrs) {
-      const ref = systemAttributeMap[attr]
+      const ref = resolveSystemAttributeRef(maps, attr, entityDefinitionId)
       if (ref) refs.push(ref)
     }
     return refs
-  }, [fields, resource?.entityType, systemAttributeMap])
+  }, [
+    fields,
+    resource?.entityType,
+    entityDefinitionId,
+    systemAttributeMap,
+    systemAttributeByDef,
+    ambiguousSystemAttributes,
+  ])
 
   if (isNotFound) {
     return <div className='py-4 text-center text-sm text-muted-foreground'>Record not found</div>

--- a/apps/web/src/components/resources/utils/canonicalize-field-ref.ts
+++ b/apps/web/src/components/resources/utils/canonicalize-field-ref.ts
@@ -14,6 +14,7 @@ import {
 } from '@auxx/types/field'
 import { useResourceStore } from '../store/resource-store'
 import { getNormalizedDefinitionId, getNormalizedRecordId } from './normalize-record-id'
+import { resolveSystemAttributeRef } from './resolve-system-attribute'
 
 /**
  * Canonicalize a single ResourceFieldId — BOTH halves:
@@ -49,9 +50,11 @@ function canonicalizeSegment(segment: ResourceFieldId): ResourceFieldId {
     return field.resourceFieldId
   }
   if (!field) {
-    // Bare systemAttribute as the field half (e.g. `line_item_name`) —
-    // globally unique; only adopt it when it belongs to this definition.
-    const attrRfId = state.systemAttributeMap[fieldHalf]
+    // Bare systemAttribute as the field half (e.g. `line_item_name`). Resolved
+    // against THIS definition — a by-name lookup returns another definition's
+    // field for a shared attribute, which then fails the ownership check below
+    // and silently leaves the ref un-canonicalized.
+    const attrRfId = resolveSystemAttributeRef(state, fieldHalf, canonicalDef)
     if (attrRfId?.startsWith(`${canonicalDef}:`)) return attrRfId
   }
   return candidate

--- a/apps/web/src/components/resources/utils/resolve-system-attribute.ts
+++ b/apps/web/src/components/resources/utils/resolve-system-attribute.ts
@@ -1,0 +1,89 @@
+// apps/web/src/components/resources/utils/resolve-system-attribute.ts
+
+'use client'
+
+import { getDefinitionId, type RecordId } from '@auxx/lib/resources/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { useResourceStore } from '../store/resource-store'
+import { getNormalizedDefinitionId } from './normalize-record-id'
+
+/**
+ * The slice of resource state a systemAttribute lookup needs. Hooks select
+ * these three so they stay reactive; imperative callers read them off
+ * `useResourceStore.getState()`.
+ */
+export interface SystemAttributeMaps {
+  systemAttributeMap: Record<string, ResourceFieldId>
+  systemAttributeByDef: Record<string, ResourceFieldId>
+  ambiguousSystemAttributes: Set<string>
+}
+
+const warned = new Set<string>()
+
+/**
+ * Warn once per attribute, in dev only. An ambiguous bare lookup is a latent
+ * wrong-field read or write; the console line is what makes it findable before
+ * it becomes a data bug.
+ */
+function warnAmbiguous(attr: string): void {
+  if (process.env.NODE_ENV === 'production' || warned.has(attr)) return
+  warned.add(attr)
+  console.warn(
+    `[systemAttribute] "${attr}" is owned by more than one entity definition and was resolved ` +
+      'without one. Pass an entityDefinitionId (or a RecordId) to resolve it unambiguously.'
+  )
+}
+
+/**
+ * Resolve a systemAttribute to a ResourceFieldId, preferring the definition it
+ * belongs to.
+ *
+ * systemAttributes are only unique by CONVENTION — they encode their own
+ * definition as a prefix (`ticket_status`, `tag_color`). Cloned field sets
+ * break that convention: `personal_inbox` carries `inbox_name` verbatim, so a
+ * bare lookup can return the other definition's field. Resolution order:
+ *
+ * 1. `${definitionId}:${attr}` — exact, always correct when a definition is known.
+ * 2. bare `attr` — only when no definition was supplied, or the definition has
+ *    no such attribute AND the attribute is unambiguous.
+ *
+ * A bare fallback for an AMBIGUOUS attribute is deliberately refused: returning
+ * the other definition's field is how a wrong value gets written.
+ */
+export function resolveSystemAttributeRef(
+  maps: SystemAttributeMaps,
+  attr: string,
+  entityDefinitionId?: string | null
+): ResourceFieldId | undefined {
+  if (entityDefinitionId) {
+    const canonical = getNormalizedDefinitionId(entityDefinitionId)
+    const scoped =
+      maps.systemAttributeByDef[`${canonical}:${attr}`] ??
+      maps.systemAttributeByDef[`${entityDefinitionId}:${attr}`]
+    if (scoped) return scoped
+    // Definition known but attribute absent from it. Falling back to the bare
+    // map here would hand back a DIFFERENT definition's field — exactly the bug
+    // this resolver exists to prevent.
+    if (maps.ambiguousSystemAttributes.has(attr)) return undefined
+  } else if (maps.ambiguousSystemAttributes.has(attr)) {
+    warnAmbiguous(attr)
+  }
+  return maps.systemAttributeMap[attr]
+}
+
+/** {@link resolveSystemAttributeRef} against a RecordId's definition. */
+export function resolveSystemAttributeForRecord(
+  maps: SystemAttributeMaps,
+  attr: string,
+  recordId: RecordId | null | undefined
+): ResourceFieldId | undefined {
+  return resolveSystemAttributeRef(maps, attr, recordId ? getDefinitionId(recordId) : null)
+}
+
+/** Imperative variant for callers outside React render. */
+export function getSystemAttributeRef(
+  attr: string,
+  entityDefinitionId?: string | null
+): ResourceFieldId | undefined {
+  return resolveSystemAttributeRef(useResourceStore.getState(), attr, entityDefinitionId)
+}

--- a/apps/web/src/components/tags/hooks/use-thread-tags.ts
+++ b/apps/web/src/components/tags/hooks/use-thread-tags.ts
@@ -29,8 +29,9 @@ export function useThreadTags(threadId: string) {
   const { resource: threadResource } = useResource('thread')
   const threadEntityDefId = threadResource?.entityDefinitionId ?? null
 
-  // Get the tags field ID
-  const tagsField = useSystemField('thread_tags')
+  // Get the tags field ID — scoped to the thread def, since `tagsFieldId` below
+  // is written straight into `fieldValue.set`.
+  const tagsField = useSystemField('thread_tags', threadEntityDefId)
   const tagsFieldId = tagsField?.id ?? null
 
   // Direct tRPC mutation (not useSaveFieldValue)

--- a/apps/web/src/components/threads/hooks/index.ts
+++ b/apps/web/src/components/threads/hooks/index.ts
@@ -2,7 +2,13 @@
 
 export { appendOptimisticMessage } from './append-optimistic-message'
 export { useFocusedThreadShortcuts } from './use-focused-thread-shortcuts'
-export { type InboxItem, type InboxRecord, useInbox, useInboxes } from './use-inbox'
+export {
+  type InboxItem,
+  type InboxRecord,
+  useInbox,
+  useInboxByInstanceId,
+  useInboxes,
+} from './use-inbox'
 export { useMessage } from './use-message'
 export { useMessageParticipants } from './use-message-participants'
 export { useMessages } from './use-messages'

--- a/apps/web/src/components/threads/hooks/use-inbox-def-union.test.tsx
+++ b/apps/web/src/components/threads/hooks/use-inbox-def-union.test.tsx
@@ -35,7 +35,8 @@ vi.mock('~/trpc/react', () => ({
   },
 }))
 
-const { INBOX_DEF_KEYS, invalidateInboxRecordLists, useInboxes } = await import('./use-inbox')
+const { INBOX_DEF_KEYS, invalidateInboxRecordLists, useInboxByInstanceId, useInboxes } =
+  await import('./use-inbox')
 const { DYNAMIC_OPTIONS_REGISTRY } = await import(
   '~/components/fields/registries/dynamic-options-registry'
 )
@@ -121,6 +122,29 @@ describe('useInboxes — fetches and merges BOTH inbox definitions', () => {
     expect(result.current.inboxMap.get(`personal_inbox:${PERSONAL_ID}` as never)?.name).toBe(
       'me@example.com'
     )
+  })
+})
+
+describe('useInboxByInstanceId — route lookup across both definitions', () => {
+  it('returns a personal inbox with its definition-aware RecordId', () => {
+    mockArms({
+      inbox: arm([rec(SHARED_ID, 'inbox')]),
+      personal_inbox: arm([
+        rec(PERSONAL_ID, 'personal_inbox', {
+          inbox_name: 'me@example.com',
+          inbox_owner_user_id: OWNER,
+        }),
+      ]),
+    })
+
+    const { result } = renderHook(() => useInboxByInstanceId(PERSONAL_ID))
+
+    expect(result.current.inbox).toMatchObject({
+      id: PERSONAL_ID,
+      recordId: `personal_inbox:${PERSONAL_ID}`,
+      entityDefinitionKey: 'personal_inbox',
+      isPersonal: true,
+    })
   })
 })
 

--- a/apps/web/src/components/threads/hooks/use-inbox.ts
+++ b/apps/web/src/components/threads/hooks/use-inbox.ts
@@ -38,6 +38,7 @@ export function invalidateInboxRecordLists(utils: ReturnType<typeof api.useUtils
  * Field keys use inbox_ prefix (e.g., inbox_name, inbox_color).
  */
 export interface InboxRecord extends RecordMeta {
+  recordId: RecordId
   fieldValues: {
     inbox_name?: string
     inbox_description?: string
@@ -144,8 +145,9 @@ function scalarValue<T>(value: T | T[] | undefined): T | undefined {
  * personal mailboxes (routing pickers, chat-widget destinations) keep filtering
  * on `isPersonal`, as they do today.
  */
-export function useInboxes(): UseInboxesResult {
-  const shared = useAllRecords<InboxRecord>({ entityDefinitionId: 'inbox' })
+export function useInboxes(options: { enabled?: boolean } = {}): UseInboxesResult {
+  const enabled = options.enabled ?? true
+  const shared = useAllRecords<InboxRecord>({ entityDefinitionId: 'inbox', enabled })
   // The personal def only exists once entity migration 059 has run — it runs
   // for every org in one deploy-time pass, so the gap is a deploy race, not a
   // steady state. In that gap `record.listAll` rejects the key, and this arm's
@@ -155,8 +157,11 @@ export function useInboxes(): UseInboxesResult {
   // the def exist" probe on purpose — a wrong probe would make personal
   // mailboxes silently absent, which is the failure mode this whole plan is
   // about; a failing query is at least loud.
-  const personal = useAllRecords<InboxRecord>({ entityDefinitionId: 'personal_inbox' })
-  const { lenses, floors } = useMyInboxLenses()
+  const personal = useAllRecords<InboxRecord>({
+    entityDefinitionId: 'personal_inbox',
+    enabled,
+  })
+  const { lenses, floors } = useMyInboxLenses(enabled)
 
   const records = useMemo(
     () => [...shared.records, ...personal.records],
@@ -207,7 +212,7 @@ export function useInboxes(): UseInboxesResult {
     // (`inbox_name`, …) but have their own CustomField UUIDs, so merging them
     // would collide on every key and hand out the wrong id for saves.
     fields: shared.fields,
-    isLoading: shared.isLoading || personal.isLoading,
+    isLoading: enabled && (shared.isLoading || personal.isLoading),
     error: shared.error,
     refresh,
   }
@@ -225,13 +230,36 @@ interface UseInboxResult {
  * Hook to get a single inbox by RecordId.
  * Since thread.inboxId is now RecordId, lookup is direct.
  */
-export function useInbox(inboxId: RecordId | null | undefined): UseInboxResult {
-  const { inboxMap, isLoading } = useInboxes()
+export function useInbox(
+  inboxId: RecordId | null | undefined,
+  options: { enabled?: boolean } = {}
+): UseInboxResult {
+  const enabled = (options.enabled ?? true) && !!inboxId
+  const { inboxMap, isLoading } = useInboxes({ enabled })
 
   const inbox = useMemo(() => {
     if (!inboxId) return undefined
     return inboxMap.get(inboxId) // Direct lookup by recordId
   }, [inboxId, inboxMap])
+
+  return { inbox, isLoading }
+}
+
+/**
+ * Resolve an inbox from a route or API instance id while preserving the
+ * definition-aware RecordId returned by the record layer.
+ */
+export function useInboxByInstanceId(
+  inboxId: string | null | undefined,
+  options: { enabled?: boolean } = {}
+): UseInboxResult {
+  const enabled = (options.enabled ?? true) && !!inboxId
+  const { inboxes, isLoading } = useInboxes({ enabled })
+
+  const inbox = useMemo(() => {
+    if (!inboxId) return undefined
+    return inboxes.find((item) => item.id === inboxId)
+  }, [inboxId, inboxes])
 
   return { inbox, isLoading }
 }

--- a/apps/web/src/components/threads/hooks/use-my-inbox-lenses.ts
+++ b/apps/web/src/components/threads/hooks/use-my-inbox-lenses.ts
@@ -22,8 +22,9 @@ const EMPTY_FLOORS: Record<string, Lens> = {}
  * `resourceAccess.forInstance` query per inbox) would mean one round trip per
  * badge in the inbox list. It rides on this query instead.
  */
-export function useMyInboxLenses() {
+export function useMyInboxLenses(enabled = true) {
   const { data, isLoading } = api.inbox.myLenses.useQuery(undefined, {
+    enabled,
     staleTime: 5 * 60 * 1000,
   })
   return {
@@ -38,6 +39,6 @@ export function useMyInboxLenses() {
     /** Org admins additionally see the residual `none` (triage) channel. */
     isAdmin: data?.isAdmin ?? false,
     /** False until the first fetch lands — don't subscribe to anything yet. */
-    isLoaded: !isLoading && !!data,
+    isLoaded: enabled && !isLoading && !!data,
   }
 }

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -415,8 +415,8 @@ export const SETTINGS_MENU: SidebarProps[] = [
       },
     ],
   },
-  // Channels — member-visible: members connect/manage their own personal email
-  // accounts here; shared-channel actions are gated in-page. Inboxes stays admin.
+  // Inboxes is the member-facing home for owned personal mailboxes and accessible
+  // shared inboxes. Channels is the org-wide plumbing surface.
   {
     id: 'channels',
     label: 'Channels',
@@ -427,6 +427,7 @@ export const SETTINGS_MENU: SidebarProps[] = [
         label: 'Channels',
         slug: 'channels',
         icon: <Waypoints />,
+        permissionKey: 'channels.manage',
         description: 'Connect the accounts messages arrive on',
         keywords: ['gmail', 'outlook', 'imap', 'smtp', 'email account', 'sms', 'whatsapp'],
       },
@@ -435,9 +436,8 @@ export const SETTINGS_MENU: SidebarProps[] = [
         label: 'Inboxes',
         slug: 'inbox',
         icon: <Inbox />,
-        permissionKey: 'channels.manage',
-        description: 'Shared queues that route those messages to your team',
-        keywords: ['shared inbox', 'routing', 'assignment', 'queue'],
+        description: 'Manage your personal accounts and accessible shared queues',
+        keywords: ['personal inbox', 'shared inbox', 'routing', 'assignment', 'queue'],
       },
       {
         id: 'settings-signatures',

--- a/apps/web/src/server/api/routers/inbox-routing-recordid-canonicalization.test.ts
+++ b/apps/web/src/server/api/routers/inbox-routing-recordid-canonicalization.test.ts
@@ -10,13 +10,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * Plan 40 §5.1 / 40a §5.1 — the CLIENT-MINTED half of the inbox RecordId bug,
  * on the three channel-routing procedures whose RecordId arrives over the wire.
  *
- * `inbox-detail.tsx` and `settings/channels/_components/integration-routing.tsx`
- * build their inbox RecordId as `toRecordId(useResource('inboxes').id, inboxId)`
- * — the entity DEFINITION's **CUID**, never the `'inbox'` slug — and the inbox
- * picker hands back `record.recordId` from the record layer, which is CUID-keyed
- * too. `InboxService.canManageInboxAccess` forwards straight to `hasPermission`,
- * which matches `ResourceAccess.entityDefinitionId` **literally**, so a
- * CUID-keyed RecordId matches no grant row at all.
+ * `settings/channels/_components/integration-routing.tsx` builds its inbox
+ * RecordId as `toRecordId(useResource('inboxes').id, inboxId)` — the entity
+ * definition's **CUID**, never the `'inbox'` slug — and record-layer callers
+ * carry their owning definition's CUID too. `InboxService.canManageInboxAccess`
+ * forwards straight to `hasPermission`, which matches
+ * `ResourceAccess.entityDefinitionId` **literally**, so a CUID-keyed RecordId
+ * matches no grant row at all.
  *
  * **Why it was invisible, and why it is not any more.** Until plan 40 phase 2
  * the `vis.isAdmin` short-circuit inside `canManageInboxAccess` answered first,

--- a/apps/web/src/server/api/routers/inbox.ts
+++ b/apps/web/src/server/api/routers/inbox.ts
@@ -16,7 +16,8 @@ import { parseRecordId, type RecordId, recordIdSchema, toRecordId } from '@auxx/
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
+import { capabilityProcedure, createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
+import { settingsInboxesForUser } from '~/server/lib/inbox-settings-access'
 
 /**
  * The mail front door (plan 40 §5.3) — `Area.inboxes` at `Read`.
@@ -63,16 +64,15 @@ async function requireInboxManageAccess(
  * INSTANCE actually lives on (plan 40 §3 / 40a §5.1) — the funnel half of the
  * same invariant `canonicalMailRecordId` enforces in `resourceAccess.ts`.
  *
- * **The def part of an incoming inbox RecordId is not evidence.** The FE mints
- * it from `useResource('inboxes').id` (`inbox-detail.tsx`,
- * `settings/channels/_components/integration-routing.tsx`) and from the record
- * layer's `record.recordId` (`use-inbox.ts` → the inbox picker) — both the def
- * **CUID**, never the `'inbox'` slug. `canManageInboxAccess` → `hasPermission`
- * matches `ResourceAccess.entityDefinitionId` **literally**, so a CUID-keyed
- * RecordId matches no grant row at all. Until plan 40 phase 2 that was masked by
- * the `vis.isAdmin` short-circuit inside `canManageInboxAccess` and only bit a
- * non-admin inbox Manager; phase 2 deleted that short-circuit (§4.2), which
- * makes it deny **everyone**, admins included.
+ * **The def part of an incoming inbox RecordId is not evidence.** Some FE paths
+ * still mint it from `useResource('inboxes').id`
+ * (`settings/channels/_components/integration-routing.tsx`), while record-layer
+ * callers carry the owning definition's CUID. `canManageInboxAccess` →
+ * `hasPermission` matches `ResourceAccess.entityDefinitionId` **literally**, so
+ * either CUID keyspace matches no slug-keyed grant row at all. Until plan 40
+ * phase 2 that was masked by the `vis.isAdmin` short-circuit inside
+ * `canManageInboxAccess` and only bit a non-admin inbox Manager; phase 2 deleted
+ * that short-circuit (§4.2), which makes it deny **everyone**, admins included.
  *
  * Resolution is by INSTANCE, not by translating the caller's def part:
  * `buildDefIdToSlug` would faithfully resolve the shared def's CUID to
@@ -82,12 +82,10 @@ async function requireInboxManageAccess(
  * it is right for both defs and across the whole 059 → 060 window, and falls
  * back to `'inbox'` (closed) for an id the cache does not know.
  *
- * Fixed at the router rather than in the two components deliberately: the
- * components need the CUID-keyed RecordId anyway — it is what `useInbox` /
- * `useRecord` read the inbox's fields with — so a client-side fix would mean
- * carrying two RecordIds per inbox and would still leave the next caller free to
- * repeat the bug. Normalizing at the funnel covers the picker, both components
- * and anything added later.
+ * The detail page now resolves its route id through the merged inbox list and
+ * carries the owning definition's RecordId for record reads. Router
+ * normalization remains the authorization funnel: it covers every caller and
+ * prevents a future client from reintroducing a mismatched grant keyspace.
  *
  */
 async function canonicalInboxRecordId(
@@ -134,6 +132,27 @@ const integrationSchema = z.object({
 })
 
 export const inboxRouter = createTRPCRouter({
+  /**
+   * Scoped inventory for the combined Settings → Inboxes page.
+   *
+   * This procedure is intentionally open to every organization member so a
+   * profile at `Inboxes: None` can still start the ungated personal-account
+   * connect flow. The response itself is instance-filtered: shared inboxes
+   * require effective view access, and personal inboxes require their private
+   * instance row (normally the owner's Manager grant).
+   */
+  settingsList: capabilityProcedure.query(async ({ ctx }) => {
+    const { organizationId } = ctx.session
+    const inboxes = await getOrgCache().get(organizationId, 'inboxes')
+
+    return settingsInboxesForUser({
+      inboxes,
+      userId: ctx.session.user.id,
+      canManageChannels: ctx.capabilities.can(PermissionKey.channelsManage),
+      access: ctx.capabilities,
+    })
+  }),
+
   /**
    * The caller's effective lens per inbox (mail-permissions §6.4) — drives
    * the FE's per-lens realtime channel subscriptions and, later, redacted
@@ -473,8 +492,8 @@ export const inboxRouter = createTRPCRouter({
    *
    * No canonicalization here, deliberately: `countIntegrationThreadsInInbox`
    * reads `getInstanceId(fromInboxRecordId)` and never looks at the definition,
-   * so the client's CUID-keyed RecordId has always resolved correctly. Adding a
-   * re-key would be inert ceremony.
+   * so CUID- and slug-keyed RecordIds resolve identically. Adding a re-key would
+   * be inert ceremony.
    */
   countMovableThreads: mailProcedure
     .input(z.object({ integrationId: z.string(), fromInboxRecordId: recordIdSchema }))

--- a/apps/web/src/server/api/routers/mail-gap-closures.test.ts
+++ b/apps/web/src/server/api/routers/mail-gap-closures.test.ts
@@ -471,9 +471,9 @@ describe('resourceAccess.revokeInstance — self-revoke on an inbox (restored)',
   })
 
   it('it survives a CUID-keyed inbox RecordId (canonicalization runs first)', async () => {
-    // `inbox-detail.tsx` mints the RecordId from the def CUID. `canonicalMailRecordId`
-    // rewrites it to the slug BEFORE authorization, so the self-revoke test must
-    // see the canonical key — testing the raw input would miss this shape.
+    // Record-layer callers carry the def CUID. `canonicalMailRecordId` rewrites
+    // it to the slug BEFORE authorization, so the self-revoke test must see the
+    // canonical key — testing the raw input would miss this shape.
     getCapabilities.mockResolvedValue(capabilitiesFor())
     await expect(revoke(`${INBOX_DEF_ID}:${INBOX_ID}`, USER_ID)).resolves.toEqual({ revoked: true })
     expect(resourceAccess.revokeInstanceAccess).toHaveBeenCalledWith(

--- a/apps/web/src/server/lib/inbox-settings-access.test.ts
+++ b/apps/web/src/server/lib/inbox-settings-access.test.ts
@@ -1,0 +1,101 @@
+// apps/web/src/server/lib/inbox-settings-access.test.ts
+
+import type { Inbox } from '@auxx/lib/inboxes'
+import { toRecordId } from '@auxx/types/resource'
+import { describe, expect, it } from 'vitest'
+import { settingsInboxesForUser } from './inbox-settings-access'
+
+const USER_ID = 'user_1'
+
+function inbox(
+  id: string,
+  options: Partial<Inbox> & Pick<Inbox, 'entityDefinitionKey' | 'isPersonal'>
+): Inbox {
+  return {
+    id,
+    recordId: toRecordId(options.entityDefinitionKey, id),
+    name: id,
+    description: null,
+    color: 'indigo',
+    status: 'ACTIVE',
+    defaultLens: options.isPersonal ? 'none' : 'full',
+    ownerUserId: null,
+    settings: {},
+    organizationId: 'org_1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdById: null,
+    ...options,
+  }
+}
+
+function access(levels: Record<string, 'view' | 'admin'>) {
+  return {
+    canViewInstance: (_key: string, id: string) => id in levels,
+    canAdminInstance: (_key: string, id: string) => levels[id] === 'admin',
+  }
+}
+
+describe('settingsInboxesForUser', () => {
+  it('returns only accessible shared inboxes with effective actions', () => {
+    const result = settingsInboxesForUser({
+      inboxes: [
+        inbox('shared_view', { entityDefinitionKey: 'inbox', isPersonal: false }),
+        inbox('shared_admin', { entityDefinitionKey: 'inbox', isPersonal: false }),
+        inbox('shared_hidden', { entityDefinitionKey: 'inbox', isPersonal: false }),
+      ],
+      userId: USER_ID,
+      canManageChannels: true,
+      access: access({ shared_view: 'view', shared_admin: 'admin' }) as never,
+    })
+
+    expect(result.map((item) => item.id)).toEqual(['shared_view', 'shared_admin'])
+    expect(result[0]).toMatchObject({ canManage: false, canDelete: false })
+    expect(result[1]).toMatchObject({ canManage: true, canDelete: true })
+  })
+
+  it("does not return another member's personal inbox without explicit access", () => {
+    const result = settingsInboxesForUser({
+      inboxes: [
+        inbox('mine', {
+          entityDefinitionKey: 'personal_inbox',
+          isPersonal: true,
+          ownerUserId: USER_ID,
+        }),
+        inbox('theirs', {
+          entityDefinitionKey: 'personal_inbox',
+          isPersonal: true,
+          ownerUserId: 'user_2',
+        }),
+      ],
+      userId: USER_ID,
+      canManageChannels: true,
+      access: access({ mine: 'admin' }) as never,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      id: 'mine',
+      canManage: true,
+      canDelete: false,
+    })
+  })
+
+  it('fails closed for another personal inbox still on the shared definition', () => {
+    const result = settingsInboxesForUser({
+      inboxes: [
+        inbox('legacy_personal', {
+          entityDefinitionKey: 'inbox',
+          isPersonal: true,
+          ownerUserId: 'user_2',
+        }),
+      ],
+      userId: USER_ID,
+      canManageChannels: true,
+      // Simulates the shared-def area fallback saying admin.
+      access: access({ legacy_personal: 'admin' }) as never,
+    })
+
+    expect(result).toEqual([])
+  })
+})

--- a/apps/web/src/server/lib/inbox-settings-access.ts
+++ b/apps/web/src/server/lib/inbox-settings-access.ts
@@ -1,0 +1,72 @@
+// apps/web/src/server/lib/inbox-settings-access.ts
+
+import type { Inbox } from '@auxx/lib/inboxes'
+import type { InstanceAccessKey } from '@auxx/lib/permissions'
+
+type InboxAccessEvaluator = {
+  canViewInstance: (key: InstanceAccessKey, instanceId: string) => boolean
+  canAdminInstance: (key: InstanceAccessKey, instanceId: string) => boolean
+}
+
+/** Inbox metadata safe to return to the scoped settings list. */
+export type SettingsInbox = Pick<
+  Inbox,
+  | 'id'
+  | 'recordId'
+  | 'entityDefinitionKey'
+  | 'name'
+  | 'description'
+  | 'color'
+  | 'status'
+  | 'defaultLens'
+  | 'isPersonal'
+  | 'ownerUserId'
+> & {
+  canManage: boolean
+  canDelete: boolean
+}
+
+/**
+ * Scope the combined inbox settings page to instances the caller may open.
+ *
+ * Shared inboxes follow normal instance access. Personal inboxes additionally
+ * fail closed during the legacy-marker migration window: while a personal
+ * mailbox still lives on the shared definition, the shared area fallback must
+ * not make it visible to anyone except its owner.
+ */
+export function settingsInboxesForUser(args: {
+  inboxes: Inbox[]
+  userId: string
+  canManageChannels: boolean
+  access: InboxAccessEvaluator
+}): SettingsInbox[] {
+  const { inboxes, userId, canManageChannels, access } = args
+
+  return inboxes.flatMap((inbox) => {
+    const key = inbox.entityDefinitionKey
+    const legacyPersonalVisible =
+      !inbox.isPersonal || key === 'personal_inbox' || inbox.ownerUserId === userId
+
+    if (!legacyPersonalVisible || !access.canViewInstance(key, inbox.id)) return []
+
+    const canManage = access.canAdminInstance(key, inbox.id)
+    return [
+      {
+        id: inbox.id,
+        recordId: inbox.recordId,
+        entityDefinitionKey: inbox.entityDefinitionKey,
+        name: inbox.name,
+        description: inbox.description,
+        color: inbox.color,
+        status: inbox.status,
+        defaultLens: inbox.defaultLens,
+        isPersonal: inbox.isPersonal,
+        ownerUserId: inbox.ownerUserId,
+        canManage,
+        // Personal mailbox lifecycle is disconnect/claim/delete, not the
+        // generic shared-inbox inventory delete.
+        canDelete: !inbox.isPersonal && canManage && canManageChannels,
+      },
+    ]
+  })
+}


### PR DESCRIPTION
## Summary

- canonicalize duplicated system attributes against the owning entity definition so shared and personal inbox records resolve consistently
- enforce per-instance inbox settings and channel-management access on detail routes
- keep Settings > Inboxes available to members while returning only their accessible personal and shared inboxes
- let members connect Gmail or Outlook personal inboxes while reserving shared inbox creation and plumbing for channels.manage
- route OAuth returns and personal-inbox entry points through the unified inbox settings page

## Validation

- 146 focused Vitest tests passed across inbox access, RecordId canonicalization, mail permission gaps, and channel-card behavior
- Biome checked all 38 changed files; only two pre-existing warnings remain in mail-box.tsx and menu.tsx
- git diff --check passed