### PR TITLE
Enforce comment scope and moderation permissions

### DIFF
--- a/apps/web/src/app/api/attachments/attachment-visibility.test.ts
+++ b/apps/web/src/app/api/attachments/attachment-visibility.test.ts
@@ -31,21 +31,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   select,
   getCapabilities,
+  getCachedResources,
   getCachedUserMailVisibility,
   getThreadLens,
   assertWorkflowRunNotSystemOwned,
   loadOwnVisit,
   and,
   eq,
+  isNull,
 } = vi.hoisted(() => ({
   select: vi.fn(),
   getCapabilities: vi.fn(),
+  getCachedResources: vi.fn(),
   getCachedUserMailVisibility: vi.fn(),
   getThreadLens: vi.fn(),
   assertWorkflowRunNotSystemOwned: vi.fn(),
   loadOwnVisit: vi.fn(),
   and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
   eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+  isNull: vi.fn((value: unknown) => ({ op: 'isNull', value })),
 }))
 
 vi.mock('@auxx/database', () => ({
@@ -66,7 +70,9 @@ vi.mock('@auxx/database', () => ({
     Comment: {
       id: 'Comment.id',
       entityDefinitionId: 'Comment.entityDefinitionId',
+      entityId: 'Comment.entityId',
       organizationId: 'Comment.organizationId',
+      deletedAt: 'Comment.deletedAt',
     },
     FieldValue: {
       id: 'FieldValue.id',
@@ -93,17 +99,20 @@ vi.mock('@auxx/database', () => ({
   },
 }))
 
-vi.mock('drizzle-orm', () => ({ and, eq }))
+vi.mock('drizzle-orm', () => ({ and, eq, isNull }))
 
 // The `@auxx/lib/permissions` barrel HANGS under vitest (get-capabilities,
 // record-view-scope, overage-*) — stub it, but keep `PermissionKey` REAL via the
 // deep registry path, because the `visit_qc_item` arm reads a key off it.
 vi.mock('@auxx/lib/permissions', async () => {
   const { PermissionKey } = await import('@auxx/lib/permissions/capabilities/registry')
-  return { PermissionKey, getCapabilities }
+  const { buildDefIdToDefinitionId, buildDefIdToSlug } = await import(
+    '@auxx/lib/permissions/capabilities/resolve-capability-inputs'
+  )
+  return { buildDefIdToDefinitionId, buildDefIdToSlug, PermissionKey, getCapabilities }
 })
 
-vi.mock('@auxx/lib/cache', () => ({ getCachedUserMailVisibility }))
+vi.mock('@auxx/lib/cache', () => ({ getCachedResources, getCachedUserMailVisibility }))
 vi.mock('@auxx/lib/permissions/visibility', () => ({ getThreadLens }))
 // Both of these are `await import(...)`ed INSIDE their arm — `vi.mock`
 // intercepts dynamic imports the same as static ones.
@@ -134,6 +143,36 @@ const QC_ITEM_ID = 'qci_cuid000000000000000000000'
 const VISIT_ID = 'vis_cuid000000000000000000000'
 /** The `entityDefinitionId` the COMMENT / FIELD_VALUE / TICKET arms gate on. */
 const DEF_ID = 'edf_cuid000000000000000000000'
+const THREAD_DEF_ID = 'edf_thread00000000000000000000'
+const INBOX_DEF_ID = 'edf_inbox000000000000000000000'
+const PERSONAL_INBOX_DEF_ID = 'edf_personal000000000000000000'
+
+const RESOURCES = [
+  {
+    id: 'res_record',
+    apiSlug: 'work-orders',
+    entityDefinitionId: DEF_ID,
+    entityType: 'work_order',
+  },
+  {
+    id: 'res_thread',
+    apiSlug: 'threads',
+    entityDefinitionId: THREAD_DEF_ID,
+    entityType: 'thread',
+  },
+  {
+    id: 'res_inbox',
+    apiSlug: 'inboxes',
+    entityDefinitionId: INBOX_DEF_ID,
+    entityType: 'inbox',
+  },
+  {
+    id: 'res_personal_inbox',
+    apiSlug: 'personal-inboxes',
+    entityDefinitionId: PERSONAL_INBOX_DEF_ID,
+    entityType: 'personal_inbox',
+  },
+]
 
 /**
  * Rows handed to successive `.limit(1)` calls, IN ORDER. Most arms issue TWO
@@ -197,6 +236,7 @@ beforeEach(() => {
   fromTables.length = 0
   eq.mockClear()
   and.mockClear()
+  isNull.mockClear()
   select.mockReset().mockImplementation(() => ({
     from: (table: { id: string }) => {
       fromTables.push(table.id)
@@ -205,6 +245,7 @@ beforeEach(() => {
   }))
   // Default to a member with nothing — every grant test opts in explicitly.
   getCapabilities.mockReset().mockResolvedValue(capabilitiesWith({}))
+  getCachedResources.mockReset().mockResolvedValue(RESOURCES)
   getCachedUserMailVisibility.mockReset().mockResolvedValue({ userId: USER_ID })
   getThreadLens.mockReset().mockResolvedValue('none')
   assertWorkflowRunNotSystemOwned.mockReset().mockResolvedValue(WORKFLOW_APP_ID)
@@ -282,7 +323,7 @@ describe('canViewAttachment — MESSAGE (unchanged; must not regress)', () => {
 })
 
 describe('canViewAttachment — COMMENT', () => {
-  it('denies a member composing `records: None` / `comments: None` — Finding A', async () => {
+  it('denies `comments: None` before reading the comment row', async () => {
     // THE leak this rewrite closes. `COMMENT` fell into the old
     // `entityType !== 'MESSAGE' → true` branch, so ANY authenticated org member
     // got the bytes of any comment attachment they could name — including a
@@ -291,29 +332,135 @@ describe('canViewAttachment — COMMENT', () => {
     queueRows(attachmentRow('COMMENT', COMMENT_ID), [{ entityDefinitionId: DEF_ID }])
     memberHolding({ [Area.records]: Level.None, [Area.comments]: Level.None })
     await expect(canView()).resolves.toBe(false)
+    expect(fromTables).toEqual(['Attachment.id'])
   })
 
-  it('grants a member who can view the commented-on definition', async () => {
-    queueRows(attachmentRow('COMMENT', COMMENT_ID), [{ entityDefinitionId: DEF_ID }])
-    memberHolding({ [Area.records]: Level.Read })
+  it('grants a member with comments read and a visible, existing record parent', async () => {
+    queueRows(
+      attachmentRow('COMMENT', COMMENT_ID),
+      [{ entityDefinitionId: DEF_ID, entityId: INSTANCE_ID }],
+      [{ id: INSTANCE_ID }]
+    )
+    memberHolding({ [Area.comments]: Level.Read, [Area.records]: Level.Read })
     await expect(canView()).resolves.toBe(true)
+    expect(fromTables).toEqual(['Attachment.id', 'Comment.id', 'EntityInstance.id'])
   })
 
-  it('denies a comment that does not resolve in this org, before any capability read', async () => {
-    // The parent lookup — not just the attachment lookup — is what fails closed.
-    queueRows(attachmentRow('COMMENT', COMMENT_ID), [])
-    memberHolding({ [Area.records]: Level.Full })
+  it('canonicalizes an apiSlug comment host before checking the parent definition', async () => {
+    queueRows(
+      attachmentRow('COMMENT', COMMENT_ID),
+      [{ entityDefinitionId: 'work-orders', entityId: INSTANCE_ID }],
+      [{ id: INSTANCE_ID }]
+    )
+    memberHolding({ [Area.comments]: Level.Read, [Area.records]: Level.Read })
+
+    await expect(canView()).resolves.toBe(true)
+    expect(eq).toHaveBeenCalledWith('EntityInstance.entityDefinitionId', DEF_ID)
+  })
+
+  it('denies a record parent hidden by the definition gate before reading that record', async () => {
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [
+      { entityDefinitionId: DEF_ID, entityId: INSTANCE_ID },
+    ])
+    memberHolding({ [Area.comments]: Level.Read, [Area.records]: Level.None })
     await expect(canView()).resolves.toBe(false)
     expect(fromTables).toEqual(['Attachment.id', 'Comment.id'])
-    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('denies an orphaned record comment even when its definition is visible', async () => {
+    queueRows(
+      attachmentRow('COMMENT', COMMENT_ID),
+      [{ entityDefinitionId: DEF_ID, entityId: INSTANCE_ID }],
+      []
+    )
+    memberHolding({ [Area.comments]: Level.Read, [Area.records]: Level.Read })
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a comment that does not resolve in this org after the area front door', async () => {
+    // The parent lookup — not just the attachment lookup — is what fails closed.
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [])
+    memberHolding({ [Area.comments]: Level.Read, [Area.records]: Level.Full })
+    await expect(canView()).resolves.toBe(false)
+    expect(fromTables).toEqual(['Attachment.id', 'Comment.id'])
+    expect(getCapabilities).toHaveBeenCalledOnce()
   })
 
   it('scopes the comment lookup by organization', async () => {
-    queueRows(attachmentRow('COMMENT', COMMENT_ID), [{ entityDefinitionId: DEF_ID }])
-    memberHolding({ [Area.records]: Level.Read })
+    queueRows(
+      attachmentRow('COMMENT', COMMENT_ID),
+      [{ entityDefinitionId: DEF_ID, entityId: INSTANCE_ID }],
+      [{ id: INSTANCE_ID }]
+    )
+    memberHolding({ [Area.comments]: Level.Read, [Area.records]: Level.Read })
     await canView()
     expect(eq).toHaveBeenCalledWith('Comment.id', COMMENT_ID)
     expect(eq).toHaveBeenCalledWith('Comment.organizationId', ORG_ID)
+  })
+
+  it('excludes soft-deleted comments from attachment visibility', async () => {
+    queueRows(
+      attachmentRow('COMMENT', COMMENT_ID),
+      [{ entityDefinitionId: DEF_ID, entityId: INSTANCE_ID }],
+      [{ id: INSTANCE_ID }]
+    )
+    memberHolding({ [Area.comments]: Level.Read, [Area.records]: Level.Read })
+
+    await expect(canView()).resolves.toBe(true)
+    expect(isNull).toHaveBeenCalledWith('Comment.deletedAt')
+  })
+
+  it('grants a comment on a thread definition CUID at any visible lens', async () => {
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [
+      { entityDefinitionId: THREAD_DEF_ID, entityId: THREAD_ID },
+    ])
+    memberHolding({ [Area.comments]: Level.Read, [Area.inboxes]: Level.Read })
+    getThreadLens.mockResolvedValue('metadata')
+
+    await expect(canView()).resolves.toBe(true)
+    expect(getThreadLens).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG_ID,
+      { userId: USER_ID },
+      THREAD_ID
+    )
+  })
+
+  it('denies a thread comment at the `none` lens', async () => {
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [
+      { entityDefinitionId: THREAD_DEF_ID, entityId: THREAD_ID },
+    ])
+    memberHolding({ [Area.comments]: Level.Read, [Area.inboxes]: Level.Read })
+    getThreadLens.mockResolvedValue('none')
+
+    await expect(canView()).resolves.toBe(false)
+  })
+
+  it('denies a thread comment at `inboxes: None` before reading the lens', async () => {
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [
+      { entityDefinitionId: THREAD_DEF_ID, entityId: THREAD_ID },
+    ])
+    memberHolding({ [Area.comments]: Level.Read, [Area.inboxes]: Level.None })
+
+    await expect(canView()).resolves.toBe(false)
+    expect(getCachedUserMailVisibility).not.toHaveBeenCalled()
+    expect(getThreadLens).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    INBOX_DEF_ID,
+    PERSONAL_INBOX_DEF_ID,
+  ])('denies unsupported inbox comment host %s', async (entityDefinitionId) => {
+    queueRows(attachmentRow('COMMENT', COMMENT_ID), [{ entityDefinitionId, entityId: INSTANCE_ID }])
+    memberHolding({
+      [Area.comments]: Level.Read,
+      [Area.inboxes]: Level.Full,
+      [Area.records]: Level.Full,
+    })
+
+    await expect(canView()).resolves.toBe(false)
+    expect(getThreadLens).not.toHaveBeenCalled()
+    expect(fromTables).toEqual(['Attachment.id', 'Comment.id'])
   })
 })
 

--- a/apps/web/src/app/api/attachments/attachment-visibility.ts
+++ b/apps/web/src/app/api/attachments/attachment-visibility.ts
@@ -1,10 +1,14 @@
 // apps/web/src/app/api/attachments/attachment-visibility.ts
 
 import { database, schema } from '@auxx/database'
-import { getCachedUserMailVisibility } from '@auxx/lib/cache'
+import { getCachedResources, getCachedUserMailVisibility } from '@auxx/lib/cache'
 import { getCapabilities, PermissionKey } from '@auxx/lib/permissions'
+import {
+  buildDefIdToDefinitionId,
+  buildDefIdToSlug,
+} from '@auxx/lib/permissions/capabilities/resolve-capability-inputs'
 import { getThreadLens } from '@auxx/lib/permissions/visibility'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 
 /**
  * Authorization gate for the attachment content routes (`download`, `thumbnail`).
@@ -69,21 +73,56 @@ export async function canViewAttachment(
     }
 
     // `Comment.entityDefinitionId` is a denormalized column, so the comment's own row
-    // resolves the gate's subject without joining `EntityInstance`.
+    // resolves the gate's subject. Comment attachments inherit both the comments-area
+    // front door and the canonical host gate used for the comment body.
     case 'COMMENT': {
+      const commentCaps = await capabilities()
+      if (!commentCaps.can(PermissionKey.commentsView)) return false
+
       const [comment] = await database
-        .select({ entityDefinitionId: schema.Comment.entityDefinitionId })
+        .select({
+          entityDefinitionId: schema.Comment.entityDefinitionId,
+          entityId: schema.Comment.entityId,
+        })
         .from(schema.Comment)
         .where(
           and(
             eq(schema.Comment.id, attachment.entityId),
-            eq(schema.Comment.organizationId, organizationId)
+            eq(schema.Comment.organizationId, organizationId),
+            isNull(schema.Comment.deletedAt)
           )
         )
         .limit(1)
       if (!comment) return false
 
-      return (await capabilities()).canViewEntity(comment.entityDefinitionId)
+      const resources = await getCachedResources(organizationId)
+      const toSlug = buildDefIdToSlug(resources)
+      const hostSlug = toSlug(comment.entityDefinitionId)
+
+      if (hostSlug === 'inbox' || hostSlug === 'personal_inbox') return false
+
+      if (hostSlug === 'thread') {
+        if (!commentCaps.can(PermissionKey.inboxesView)) return false
+
+        const viewer = await getCachedUserMailVisibility(userId, organizationId)
+        return (await getThreadLens(database, organizationId, viewer, comment.entityId)) !== 'none'
+      }
+
+      const canonicalDefinitionId = buildDefIdToDefinitionId(resources)(comment.entityDefinitionId)
+      if (!commentCaps.canViewEntity(canonicalDefinitionId)) return false
+
+      const [record] = await database
+        .select({ id: schema.EntityInstance.id })
+        .from(schema.EntityInstance)
+        .where(
+          and(
+            eq(schema.EntityInstance.id, comment.entityId),
+            eq(schema.EntityInstance.entityDefinitionId, canonicalDefinitionId),
+            eq(schema.EntityInstance.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      return Boolean(record)
     }
 
     // Same shape as COMMENT — `FieldValue.entityDefinitionId` is likewise a column.

--- a/apps/web/src/components/contacts/drawer/contact-drawer.tsx
+++ b/apps/web/src/components/contacts/drawer/contact-drawer.tsx
@@ -10,6 +10,7 @@ import { Expand, Mail, MessagesSquare, Trash, User } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import * as React from 'react'
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
+import { useCommentAccess } from '~/components/global/comments/use-comment-access'
 import { Tooltip } from '~/components/global/tooltip'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
@@ -55,6 +56,7 @@ export function ContactDrawer({
     () => (contactId ? toRecordId('contact', contactId) : null),
     [contactId]
   )
+  const { canCompose } = useCommentAccess(recordId)
 
   // Get record data for contact-specific UI
   const { record: contact } = useRecord({
@@ -140,11 +142,13 @@ export function ContactDrawer({
               <Mail />
               Compose
             </Button>
-            <Tooltip content='Create note'>
-              <Button variant='ghost' size='icon-xs' onClick={handleCreateNoteClick}>
-                <MessagesSquare />
-              </Button>
-            </Tooltip>
+            {canCompose && (
+              <Tooltip content='Create note'>
+                <Button variant='ghost' size='icon-xs' onClick={handleCreateNoteClick}>
+                  <MessagesSquare />
+                </Button>
+              </Tooltip>
+            )}
             <Tooltip content='View full page'>
               <Button
                 variant='ghost'

--- a/apps/web/src/components/detail-view/detail-view-sidebar.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sidebar.tsx
@@ -10,6 +10,7 @@ import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { getTabCardComponent } from '~/components/drawers/drawer-tab-registry'
 import EntityFields from '~/components/fields/entity-fields'
 import DrawerComments from '~/components/global/comments/drawer-comments'
+import { useCommentAccess } from '~/components/global/comments/use-comment-access'
 import { useCanViewRecordResource } from '~/components/resources'
 import { useAccess } from '~/providers/capabilities-provider'
 import { DetailViewCardHeader } from './components/detail-view-card-header'
@@ -34,6 +35,7 @@ export function DetailViewSidebar({
 }: DetailViewSidebarProps) {
   const { entityInstanceId } = parseRecordId(recordId)
   const { can } = useAccess()
+  const { canViewComments } = useCommentAccess(recordId)
   const canViewRecordResource = useCanViewRecordResource()
   const entityType = config.entityType
   // Layer-2 capability gate — drop cards (header included) the viewer lacks the
@@ -46,6 +48,12 @@ export function DetailViewSidebar({
 
   const beforeCards = sidebarCards?.filter((c) => c.position === 'before') ?? []
   const afterCards = sidebarCards?.filter((c) => (c.position ?? 'after') === 'after') ?? []
+  const visibleSidebarTabs = config.sidebarTabs.filter(
+    (tab) => tab.value !== 'comments' || canViewComments
+  )
+  const visibleActiveTab = visibleSidebarTabs.some((tab) => tab.value === activeTab)
+    ? activeTab
+    : (visibleSidebarTabs[0]?.value ?? activeTab)
 
   return (
     <div className='h-full flex flex-col'>
@@ -53,11 +61,14 @@ export function DetailViewSidebar({
       <DetailViewCardHeader icon={icon} color={color} displayName={displayName} record={record} />
 
       {/* Sidebar tabs */}
-      <Tabs value={activeTab} onValueChange={onTabChange} className='flex-1 flex flex-col min-h-0'>
+      <Tabs
+        value={visibleActiveTab}
+        onValueChange={onTabChange}
+        className='flex-1 flex flex-col min-h-0'>
         <TabsList
           className='border-b w-full justify-start rounded-b-none bg-primary-100'
           variant='outline'>
-          {config.sidebarTabs.map((tab) => (
+          {visibleSidebarTabs.map((tab) => (
             <TabsTrigger key={tab.value} value={tab.value} variant='outline'>
               {tab.label}
             </TabsTrigger>
@@ -86,9 +97,11 @@ export function DetailViewSidebar({
           />
         </TabsContent>
 
-        <TabsContent value='comments' className='flex-1 overflow-y-auto'>
-          <DrawerComments recordId={recordId} />
-        </TabsContent>
+        {canViewComments && (
+          <TabsContent value='comments' className='flex-1 overflow-y-auto'>
+            <DrawerComments recordId={recordId} />
+          </TabsContent>
+        )}
       </Tabs>
     </div>
   )

--- a/apps/web/src/components/drawers/actions/create-note-action.tsx
+++ b/apps/web/src/components/drawers/actions/create-note-action.tsx
@@ -4,19 +4,23 @@
 import { Button } from '@auxx/ui/components/button'
 import { MessagesSquare } from 'lucide-react'
 import { useQueryState } from 'nuqs'
+import { useCommentAccess } from '~/components/global/comments/use-comment-access'
 import { Tooltip } from '~/components/global/tooltip'
 import type { DrawerActionProps } from '../drawer-action-registry'
 
 /**
  * Generic header action: switches to the Comments tab and focuses the composer.
  */
-export function CreateNoteAction({ onCreateNote }: DrawerActionProps) {
+export function CreateNoteAction({ recordId, onCreateNote }: DrawerActionProps) {
   const [, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' })
+  const { canCompose } = useCommentAccess(recordId)
 
   const handleClick = () => {
     void setActiveTab('comments')
     onCreateNote()
   }
+
+  if (!canCompose) return null
 
   return (
     <Tooltip content='Create note' allowInteraction>

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -38,6 +38,7 @@ import * as React from 'react'
 import { AppRecordActions } from '~/components/detail-view/components/app-record-actions'
 import EntityFields from '~/components/fields/entity-fields'
 import DrawerComments from '~/components/global/comments/drawer-comments'
+import { useCommentAccess } from '~/components/global/comments/use-comment-access'
 import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
 import {
@@ -179,6 +180,7 @@ function DrawerRecordFrame({
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' })
   const { hasAccess } = useFeatureFlags()
   const { can } = useAccess()
+  const { canViewComments } = useCommentAccess(recordId)
   const canViewRecordResource = useCanViewRecordResource()
   const organizationId = useDehydratedOrganizationId()
   const user = useDehydratedUser()
@@ -269,6 +271,7 @@ function DrawerRecordFrame({
     ]
       // Restricted mode drops the communication/comment tabs (§11.4).
       .filter((tab) => !readOnly || !isRestrictedDrawerTab(entityType ?? '', tab.value))
+      .filter((tab) => tab.value !== 'comments' || canViewComments)
 
     const additionalTabs = visibleAdditionalTabs.map((tab) => ({
       value: tab.value,
@@ -278,7 +281,7 @@ function DrawerRecordFrame({
 
     // Overview first, then entity-specific tabs, then the shared timeline/comments/tasks tabs
     return [overviewTab, ...additionalTabs, ...trailingTabs]
-  }, [drawerConfig, visibleAdditionalTabs, readOnly, entityType])
+  }, [drawerConfig, visibleAdditionalTabs, readOnly, entityType, canViewComments])
 
   // Tab order persistence
   const tabOrderStorageKey = React.useMemo(() => {
@@ -426,7 +429,7 @@ function DrawerRecordFrame({
             {/* Comments tab is dropped from the tab bar in restricted mode; keep
                 its content unmounted too so a stale `?tab=comments` deep link
                 can't surface it. */}
-            {!readOnly && (
+            {!readOnly && canViewComments && (
               <TabsContent value='comments' className='w-full h-full mt-0'>
                 <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
                   <DrawerComments recordId={recordId} focusComposerTrigger={focusComposerTrigger} />

--- a/apps/web/src/components/global/comments/comment-composer.tsx
+++ b/apps/web/src/components/global/comments/comment-composer.tsx
@@ -33,6 +33,7 @@ import {
   useComments,
 } from '~/hooks/use-comments'
 import { CommentFile } from './comment-file'
+import { useCommentAccess } from './use-comment-access'
 
 // Frontend file type distinction
 interface FileAttachment {
@@ -158,7 +159,15 @@ export const SubmitOnEnter = Extension.create<SubmitOnEnterOptions>({
 /**
  * CommentComposer renders the shared rich text composer used in drawers.
  */
-const CommentComposer = ({
+const CommentComposer = ({ recordId, ...props }: CommentComposerProps) => {
+  const { canCompose } = useCommentAccess(recordId)
+
+  if (!canCompose) return null
+
+  return <CommentComposerEditor recordId={recordId} {...props} />
+}
+
+const CommentComposerEditor = ({
   recordId,
   parentId,
   commentId,

--- a/apps/web/src/components/global/comments/comment-item.tsx
+++ b/apps/web/src/components/global/comments/comment-item.tsx
@@ -14,9 +14,11 @@ import { AttachmentDisplay } from '~/components/files/utils/attachment-display'
 import { useActor } from '~/components/resources/hooks/use-actor'
 import { type Comment as CommentType, useComments } from '~/hooks/use-comments'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useDehydratedUser } from '~/providers/dehydrated-state-provider'
 import { Tooltip } from '../tooltip'
 import CommentComposer from './comment-composer'
 import { CommentContent } from './comment-content'
+import { useCommentAccess } from './use-comment-access'
 
 /** Helper to convert userId to ActorId format */
 const toUserActorId = (userId: string): ActorId => `user:${userId}` as ActorId
@@ -62,6 +64,8 @@ export function CommentItem({
 }: CommentItemProps) {
   // Use our custom hook
   const [confirm, ConfirmDialog] = useConfirm()
+  const user = useDehydratedUser()
+  const access = useCommentAccess(recordId ?? (initialComment?.recordId as RecordId | undefined))
   const {
     isFetchingComments,
     editingCommentId,
@@ -121,6 +125,9 @@ export function CommentItem({
   }
   const isEditing = editingCommentId === comment.id
   const isReplying = replyingToId === comment.id
+  const isAuthor = comment.actorId === `user:${user?.id}`
+  const canEditOrDelete = access.canCompose && (isAuthor || access.canModerateOthers)
+  const canShowActions = access.canReact || access.canPin || access.canCompose || canEditOrDelete
   return (
     <>
       <div
@@ -177,7 +184,7 @@ export function CommentItem({
           row-start-2: Positions this element to start at the second row in the
           grid */}
           <div className='col-start-2 row-span-2 row-start-2 grid w-full break-words'>
-            {isEditing && (
+            {isEditing && canEditOrDelete && (
               <div className='mb-4 w-[400px]'>
                 <CommentComposer
                   recordId={recordId!}
@@ -196,7 +203,7 @@ export function CommentItem({
                 />
               </div>
             )}
-            {!isEditing && (
+            {(!isEditing || !canEditOrDelete) && (
               <div className='block h-full w-fit max-w-full rounded-[15px] bg-primary-200 text-sm font-normal text-foreground'>
                 <div className='cursor-text select-text px-3 py-1 leading-[22px]'>
                   <CommentContent doc={comment.contentJson} />
@@ -222,8 +229,16 @@ export function CommentItem({
                       <Badge
                         key={emoji}
                         variant='outline'
-                        className='flex cursor-pointer gap-1 rounded-lg bg-primary-300 border-0 hover:bg-info/80 hover:text-info-foreground'
-                        onClick={() => handleToggleEmoji(comment.id, emoji, data.userReacted)}>
+                        className={cn(
+                          'flex gap-1 rounded-lg bg-primary-300 border-0',
+                          access.canReact &&
+                            'cursor-pointer hover:bg-info/80 hover:text-info-foreground'
+                        )}
+                        onClick={
+                          access.canReact
+                            ? () => handleToggleEmoji(comment.id, emoji, data.userReacted)
+                            : undefined
+                        }>
                         <span>{emoji}</span>
                         {data.count > 0 && <span>{data.count}</span>}
                       </Badge>
@@ -235,7 +250,7 @@ export function CommentItem({
           </div>
 
           <div className='col-start-3 row-start-2 ml-px flex w-full min-w-0'>
-            {!isEditing && (
+            {!isEditing && canShowActions && (
               <div
                 className={cn(
                   'flex items-center',
@@ -243,62 +258,72 @@ export function CommentItem({
                   // Keep visible when any action is in progress for this comment or when replying
                   (isUpdating(comment.id) || isReplying) && 'visible'
                 )}>
-                <div className='min-w-0'>
-                  <EmojiPicker onChange={(emoji) => handleAddEmoji(comment.id, emoji)}>
+                {access.canReact && (
+                  <div className='min-w-0'>
+                    <EmojiPicker onChange={(emoji) => handleAddEmoji(comment.id, emoji)}>
+                      <Button
+                        variant={'ghost'}
+                        size='icon'
+                        className='size-7 rounded-full p-0 hover:bg-foreground/10'
+                        loading={addingEmojiToCommentId === comment.id}
+                        disabled={addingEmojiToCommentId === comment.id}>
+                        <SmilePlus />
+                      </Button>
+                    </EmojiPicker>
+                  </div>
+                )}
+
+                {access.canPin && (
+                  <div className='min-w-0'>
                     <Button
                       variant={'ghost'}
                       size='icon'
                       className='size-7 rounded-full p-0 hover:bg-foreground/10'
-                      loading={addingEmojiToCommentId === comment.id}
-                      disabled={addingEmojiToCommentId === comment.id}>
-                      <SmilePlus />
+                      onClick={() => handleTogglePin(comment.id, comment.isPinned)}
+                      loading={pinningCommentId === comment.id}
+                      disabled={pinningCommentId === comment.id}>
+                      {comment.isPinned ? <PinOff /> : <Pin />}
                     </Button>
-                  </EmojiPicker>
-                </div>
-
-                <div className='min-w-0'>
-                  <Button
-                    variant={'ghost'}
-                    size='icon'
-                    className='size-7 rounded-full p-0 hover:bg-foreground/10'
-                    onClick={() => handleTogglePin(comment.id, comment.isPinned)}
-                    loading={pinningCommentId === comment.id}
-                    disabled={pinningCommentId === comment.id}>
-                    {comment.isPinned ? <PinOff /> : <Pin />}
-                  </Button>
-                </div>
-                <div className='min-w-0'>
-                  <Button
-                    variant={'ghost'}
-                    size='icon'
-                    className={cn(
-                      'size-7 rounded-full p-0 hover:bg-foreground/10',
-                      isReplying && 'bg-bad-100 hover:bg-bad-200 text-bad-500 hover:text-bad-600'
-                    )}
-                    onClick={() => setReplyingToId(isReplying ? null : comment.id)}>
-                    {isReplying ? <X /> : <Reply />}
-                  </Button>
-                </div>
-                <div className='min-w-0'>
-                  <Button
-                    variant={'ghost'}
-                    size='icon'
-                    className='size-7 rounded-full p-0 hover:bg-foreground/10'
-                    onClick={() => setEditingCommentId(comment.id)}>
-                    <Pencil />
-                  </Button>
-                </div>
-                <div className='min-w-0'>
-                  <Button
-                    variant={'ghost'}
-                    size='icon'
-                    className='size-7 rounded-full p-0 hover:bg-foreground/10'
-                    onClick={handleDeleteWithConfirmation}
-                    loading={deletingCommentId === comment.id}
-                    disabled={deletingCommentId === comment.id}>
-                    <Trash />
-                  </Button>
-                </div>
+                  </div>
+                )}
+                {access.canCompose && (
+                  <div className='min-w-0'>
+                    <Button
+                      variant={'ghost'}
+                      size='icon'
+                      className={cn(
+                        'size-7 rounded-full p-0 hover:bg-foreground/10',
+                        isReplying && 'bg-bad-100 hover:bg-bad-200 text-bad-500 hover:text-bad-600'
+                      )}
+                      onClick={() => setReplyingToId(isReplying ? null : comment.id)}>
+                      {isReplying ? <X /> : <Reply />}
+                    </Button>
+                  </div>
+                )}
+                {canEditOrDelete && (
+                  <>
+                    <div className='min-w-0'>
+                      <Button
+                        variant={'ghost'}
+                        size='icon'
+                        className='size-7 rounded-full p-0 hover:bg-foreground/10'
+                        onClick={() => setEditingCommentId(comment.id)}>
+                        <Pencil />
+                      </Button>
+                    </div>
+                    <div className='min-w-0'>
+                      <Button
+                        variant={'ghost'}
+                        size='icon'
+                        className='size-7 rounded-full p-0 hover:bg-foreground/10'
+                        onClick={handleDeleteWithConfirmation}
+                        loading={deletingCommentId === comment.id}
+                        disabled={deletingCommentId === comment.id}>
+                        <Trash />
+                      </Button>
+                    </div>
+                  </>
+                )}
               </div>
             )}
             <div className='flex flex-1 justify-end overflow-hidden text-ellipsis whitespace-nowrap text-[11px] leading-[30px]  opacity-100'>
@@ -319,7 +344,7 @@ export function CommentItem({
       </div>
 
       {/* Reply composer - appears below comment when replying */}
-      {isReplying && !disableReplies && (
+      {isReplying && !disableReplies && access.canCompose && (
         <div className='ms-8 mt-2 mb-2 max-w-[400px]'>
           <CommentComposer
             recordId={recordId!}

--- a/apps/web/src/components/global/comments/comment-list.tsx
+++ b/apps/web/src/components/global/comments/comment-list.tsx
@@ -3,6 +3,7 @@ import type { RecordId } from '@auxx/lib/field-values/client'
 import { getGroupPosition, groupConsecutiveComments } from '@auxx/utils'
 import { type Comment, useComments } from '~/hooks/use-comments'
 import { CommentItem, CommentSkeleton } from './comment-item'
+import { useCommentAccess } from './use-comment-access'
 
 interface CommentListProps {
   // Required props
@@ -14,14 +15,26 @@ interface CommentListProps {
   className?: string
 }
 
-export function CommentList({
+export function CommentList({ recordId, ...props }: CommentListProps) {
+  const { canViewComments } = useCommentAccess(recordId)
+
+  if (!canViewComments) return null
+
+  return <AccessibleCommentList recordId={recordId} {...props} />
+}
+
+function AccessibleCommentList({
   recordId,
   initialComments,
   onCommentAdded,
   className,
 }: CommentListProps) {
   // Use the hook directly
-  const { comments, isFetchingComments } = useComments({ recordId, onCommentAdded })
+  const { comments, isFetchingComments } = useComments({
+    recordId,
+    initialComments,
+    onCommentAdded,
+  })
 
   if (isFetchingComments) {
     return (
@@ -49,7 +62,7 @@ export function CommentList({
             return (
               <CommentItem
                 key={comment.id}
-                comment={comment as Comment}
+                comment={comment as unknown as Comment}
                 recordId={recordId}
                 isReply={false}
                 disableReplies={false}

--- a/apps/web/src/components/global/comments/drawer-comments.tsx
+++ b/apps/web/src/components/global/comments/drawer-comments.tsx
@@ -8,6 +8,7 @@ import CommentComposer from '~/components/global/comments/comment-composer'
 import { CommentList } from '~/components/global/comments/comment-list'
 import { EmptyState } from '~/components/global/empty-state'
 import { api } from '~/trpc/react'
+import { useCommentAccess } from './use-comment-access'
 
 /**
  * Props for the DrawerComments wrapper component.
@@ -27,7 +28,15 @@ interface DrawerCommentsProps {
  * with the ability to add new comments via CommentComposer.
  * Supports Contact, Ticket, Thread, and custom entity types.
  */
-const DrawerComments = ({
+const DrawerComments = ({ recordId, ...props }: DrawerCommentsProps) => {
+  const { canViewComments } = useCommentAccess(recordId)
+
+  if (!canViewComments) return null
+
+  return <AccessibleDrawerComments recordId={recordId} {...props} />
+}
+
+const AccessibleDrawerComments = ({
   recordId,
   emptyTitle,
   emptyDescription,
@@ -35,6 +44,7 @@ const DrawerComments = ({
   composerPlaceholder,
   focusComposerTrigger,
 }: DrawerCommentsProps) => {
+  const { canCompose } = useCommentAccess(recordId)
   const defaultEmptyTitle = emptyTitle || 'No comments yet'
   const defaultEmptyDescription = emptyDescription || 'Start a conversation about this record'
   const defaultHeaderTitle = headerTitle || 'Comments'
@@ -84,20 +94,21 @@ const DrawerComments = ({
         </div>
       )}
 
-      {/* Comment Composer - always visible at bottom */}
-      <div className='px-4 pb-4 pt-2'>
-        <CommentComposer
-          recordId={recordId}
-          expanded
-          expandHeight='100px'
-          focusTrigger={focusComposerTrigger}
-          placeholder={defaultPlaceholder}
-          onSubmitted={() => {
-            // Refetch comments after submission
-            // tRPC will handle this automatically with cache invalidation
-          }}
-        />
-      </div>
+      {canCompose && (
+        <div className='px-4 pb-4 pt-2'>
+          <CommentComposer
+            recordId={recordId}
+            expanded
+            expandHeight='100px'
+            focusTrigger={focusComposerTrigger}
+            placeholder={defaultPlaceholder}
+            onSubmitted={() => {
+              // Refetch comments after submission
+              // tRPC will handle this automatically with cache invalidation
+            }}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/global/comments/use-comment-access.test.ts
+++ b/apps/web/src/components/global/comments/use-comment-access.test.ts
@@ -1,0 +1,84 @@
+// apps/web/src/components/global/comments/use-comment-access.test.ts
+
+// apps/web/src/components/global/comments/use-comment-access.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { resolveCommentAccess } from './use-comment-access'
+
+describe('resolveCommentAccess', () => {
+  it('requires comment read and record view for the comments surface', () => {
+    expect(
+      resolveCommentAccess({
+        parentKind: 'record',
+        commentsView: false,
+        commentsManage: true,
+        canViewParent: true,
+        canAdministerParent: true,
+      })
+    ).toMatchObject({
+      canViewComments: false,
+      canCompose: false,
+      canReact: false,
+      canPin: false,
+      canModerateOthers: false,
+    })
+  })
+
+  it('lets a visible subject-lens thread read and compose without full-lens moderation', () => {
+    expect(
+      resolveCommentAccess({
+        parentKind: 'thread',
+        commentsView: true,
+        commentsManage: true,
+        canViewParent: true,
+        canAdministerParent: false,
+        threadLens: 'subject',
+        canAdministerInbox: true,
+      })
+    ).toMatchObject({
+      canViewComments: true,
+      canCompose: true,
+      canReact: true,
+      canPin: false,
+      canModerateOthers: false,
+    })
+  })
+
+  it('requires a full thread lens and inbox administration to moderate other authors', () => {
+    expect(
+      resolveCommentAccess({
+        parentKind: 'thread',
+        commentsView: true,
+        commentsManage: true,
+        canViewParent: true,
+        canAdministerParent: false,
+        threadLens: 'full',
+        canAdministerInbox: true,
+      })
+    ).toMatchObject({
+      canPin: true,
+      canModerateOthers: true,
+    })
+  })
+
+  it('never exposes comments for inbox parents', () => {
+    expect(
+      resolveCommentAccess({
+        parentKind: 'unsupported',
+        commentsView: true,
+        commentsManage: true,
+        canViewParent: true,
+        canAdministerParent: true,
+        threadLens: 'full',
+        canAdministerInbox: true,
+      })
+    ).toEqual({
+      parentKind: 'unsupported',
+      canViewComments: false,
+      canCompose: false,
+      canReact: false,
+      canPin: false,
+      canModerateOthers: false,
+    })
+  })
+})

--- a/apps/web/src/components/global/comments/use-comment-access.ts
+++ b/apps/web/src/components/global/comments/use-comment-access.ts
@@ -1,0 +1,128 @@
+// apps/web/src/components/global/comments/use-comment-access.ts
+'use client'
+
+import { PermissionKey } from '@auxx/lib/permissions/client'
+import { parseRecordId, type RecordId, resolveStaticPrefix } from '@auxx/lib/resources/client'
+import { useResource } from '~/components/resources'
+import { useThread } from '~/components/threads/hooks'
+import { useAccess } from '~/providers/capabilities-provider'
+
+export type CommentParentKind = 'record' | 'thread' | 'unsupported'
+export type CommentThreadLens = 'none' | 'metadata' | 'subject' | 'full'
+
+export interface ResolveCommentAccessInput {
+  parentKind: CommentParentKind
+  commentsView: boolean
+  commentsManage: boolean
+  canViewParent: boolean
+  canAdministerParent: boolean
+  threadLens?: CommentThreadLens
+  canAdministerInbox?: boolean
+}
+
+export interface CommentAccess {
+  parentKind: CommentParentKind
+  canViewComments: boolean
+  canCompose: boolean
+  canReact: boolean
+  canPin: boolean
+  canModerateOthers: boolean
+}
+
+/**
+ * Resolve comment affordances from the area, parent, and moderation gates.
+ */
+export function resolveCommentAccess({
+  parentKind,
+  commentsView,
+  commentsManage,
+  canViewParent,
+  canAdministerParent,
+  threadLens = 'none',
+  canAdministerInbox = false,
+}: ResolveCommentAccessInput): CommentAccess {
+  if (parentKind === 'unsupported') {
+    return {
+      parentKind,
+      canViewComments: false,
+      canCompose: false,
+      canReact: false,
+      canPin: false,
+      canModerateOthers: false,
+    }
+  }
+
+  const canViewComments = commentsView && canViewParent
+  const canCompose = commentsView && commentsManage && canViewParent
+
+  if (parentKind === 'thread') {
+    const hasFullLens = threadLens === 'full'
+    return {
+      parentKind,
+      canViewComments,
+      canCompose,
+      canReact: canViewComments,
+      canPin: canCompose && hasFullLens,
+      canModerateOthers: canCompose && hasFullLens && canAdministerInbox,
+    }
+  }
+
+  return {
+    parentKind,
+    canViewComments,
+    canCompose,
+    canReact: canViewComments,
+    canPin: canCompose,
+    canModerateOthers: canCompose && canAdministerParent,
+  }
+}
+
+/**
+ * Client-side comment capability hint for a record or thread parent.
+ *
+ * Inbox records are deliberately unsupported comment parents. Thread access
+ * follows the mail lens rather than the records definition gate.
+ */
+export function useCommentAccess(recordId: RecordId | null | undefined): CommentAccess {
+  const safeRecordId = recordId ?? ('__missing__:__missing__' as RecordId)
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(safeRecordId)
+  const { resource } = useResource(entityDefinitionId)
+  const { can, canViewEntity, canAdministerDef, canAdminInstance } = useAccess()
+
+  const canonicalDefinition =
+    resolveStaticPrefix(entityDefinitionId) ?? resource?.entityType ?? entityDefinitionId
+  const parentKind: CommentParentKind =
+    canonicalDefinition === 'thread'
+      ? 'thread'
+      : canonicalDefinition === 'inbox' || canonicalDefinition === 'personal_inbox'
+        ? 'unsupported'
+        : 'record'
+
+  const commentsView = can(PermissionKey.commentsView)
+  const commentsManage = can(PermissionKey.commentsManage)
+  const canViewInboxArea = can(PermissionKey.inboxesView)
+  const shouldLoadThread =
+    parentKind === 'thread' && canViewInboxArea && (commentsView || commentsManage)
+  const { thread } = useThread({
+    threadId: parentKind === 'thread' ? entityInstanceId : null,
+    enabled: shouldLoadThread,
+  })
+
+  const threadLens: CommentThreadLens = thread ? (thread.myLens ?? 'full') : 'none'
+  const canViewParent =
+    parentKind === 'thread'
+      ? canViewInboxArea && threadLens !== 'none'
+      : parentKind === 'record' && !!resource && canViewEntity(resource.entityDefinitionId)
+
+  return resolveCommentAccess({
+    parentKind,
+    commentsView,
+    commentsManage,
+    canViewParent,
+    canAdministerParent:
+      parentKind === 'record' && !!resource && canAdministerDef(resource.entityDefinitionId),
+    threadLens,
+    canAdministerInbox:
+      parentKind === 'thread' && !!thread?.inboxId && canAdminInstance(thread.inboxId),
+  })
+}

--- a/apps/web/src/components/mail/thread-details.tsx
+++ b/apps/web/src/components/mail/thread-details.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { useEffect, useMemo, useRef } from 'react'
+import { useCommentAccess } from '~/components/global/comments/use-comment-access'
 import { useMessageParticipants, useMessages, useThread } from '~/components/threads/hooks'
 import { getThreadStoreState } from '~/components/threads/store/thread-store'
 import { useCompose } from '~/hooks/use-compose'
@@ -40,6 +41,8 @@ export default function ThreadDetails({
   const { threadId, replyBox, handlers, emailActions } = useThreadContext()
   const isNested = useIsNestedThread()
   const { thread, isLoading, isNotFound } = useThread({ threadId })
+  const commentRecordId = toRecordId('thread', threadId)
+  const { canViewComments } = useCommentAccess(commentRecordId)
   const { openInline, close: closeCompose } = useCompose()
   const instanceIdRef = useRef<string | null>(null)
   const justCreatedRef = useRef(false)
@@ -239,9 +242,11 @@ export default function ThreadDetails({
           <div className='flex-1'>
             <ThreadMessages />
 
-            <div className='px-4 pb-6 pt-4 md:px-6 md:pb-10'>
-              <CommentList recordId={toRecordId('thread', thread.id)} />
-            </div>
+            {canViewComments && (
+              <div className='px-4 pb-6 pt-4 md:px-6 md:pb-10'>
+                <CommentList recordId={commentRecordId} />
+              </div>
+            )}
 
             <div className='grow'></div>
           </div>

--- a/apps/web/src/components/mail/thread-footer.tsx
+++ b/apps/web/src/components/mail/thread-footer.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { toRecordId } from '@auxx/lib/field-values/client'
+import { useCommentAccess } from '~/components/global/comments/use-comment-access'
 import CommentComposer from '../global/comments/comment-composer'
 import { useThreadContext } from './thread-provider'
 
@@ -10,14 +11,16 @@ import { useThreadContext } from './thread-provider'
  */
 export function ThreadFooter() {
   const { threadId } = useThreadContext()
+  const recordId = toRecordId('thread', threadId)
+  const { canCompose } = useCommentAccess(recordId)
 
-  if (!threadId) return null
+  if (!threadId || !canCompose) return null
   return (
     <div className='flex-0 sticky bottom-0 left-0 right-0 flex flex-col py-4'>
       <div className='padding-[16px 14px 0px 6px] flex flex-[1_1_auto] flex-row px-5'>
         <CommentComposer
           key={`composer-${threadId}`} // Reset composer if thread changes
-          recordId={toRecordId('thread', threadId)}
+          recordId={recordId}
         />
       </div>
     </div>

--- a/apps/web/src/server/api/routers/comment-permissions.test.ts
+++ b/apps/web/src/server/api/routers/comment-permissions.test.ts
@@ -1,0 +1,200 @@
+// apps/web/src/server/api/routers/comment-permissions.test.ts
+
+// apps/web/src/server/api/routers/comment-permissions.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const COMMENT_ID = 'cmt_cuid000000000000000000000'
+const RECORD_ID = 'contact:rec_cuid00000000000000000000'
+
+const { service, constructorArgs } = vi.hoisted(() => ({
+  service: {
+    createComment: vi.fn(),
+    updateComment: vi.fn(),
+    deleteComment: vi.fn(),
+    getById: vi.fn(),
+    getCommentsByRecordId: vi.fn(),
+    pinComment: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+  },
+  constructorArgs: [] as unknown[][],
+}))
+
+vi.mock('@auxx/lib/comments', () => ({
+  CommentService: class {
+    constructor(...args: unknown[]) {
+      constructorArgs.push(args)
+    }
+
+    createComment = service.createComment
+    updateComment = service.updateComment
+    deleteComment = service.deleteComment
+    getById = service.getById
+    getCommentsByRecordId = service.getCommentsByRecordId
+    pinComment = service.pinComment
+    addReaction = service.addReaction
+    removeReaction = service.removeReaction
+  },
+}))
+
+vi.mock('@auxx/lib/permissions', async () => {
+  const { PermissionKey } = await import('@auxx/lib/permissions/capabilities/registry')
+  return { PermissionKey }
+})
+
+vi.mock('@auxx/lib/tiptap', () => ({ isNonEmptyDoc: () => true }))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}))
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    isAuxxError: (error: unknown) =>
+      typeof error === 'object' &&
+      error !== null &&
+      'statusCode' in (error as Record<string, unknown>),
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        ;(ctx as { capabilities: { assert: (permission: string) => void } }).capabilities.assert(
+          key
+        )
+        return next()
+      }),
+  }
+})
+
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { commentRouter } = await import('./comment')
+
+type Capabilities = InstanceType<typeof CapabilitySet>
+
+function capabilitiesFor(comments: Level): Capabilities {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.comments]: comments })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+const db = { marker: 'comment-router-db' }
+
+function caller(capabilities: Capabilities) {
+  return commentRouter.createCaller({
+    capabilities,
+    db,
+    headers: new Headers(),
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, isAdmin: false },
+    },
+  } as never)
+}
+
+const comment = {
+  id: COMMENT_ID,
+  entityDefinitionId: 'contact',
+  entityId: 'rec_cuid00000000000000000000',
+  createdById: USER_ID,
+  replies: [],
+}
+
+const contentJson = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }],
+}
+
+const READ_CALLS = [
+  ['getById', (c: ReturnType<typeof caller>) => c.getById({ id: COMMENT_ID })],
+  ['getByRecordId', (c: ReturnType<typeof caller>) => c.getByRecordId({ recordId: RECORD_ID })],
+  [
+    'addReaction',
+    (c: ReturnType<typeof caller>) =>
+      c.addReaction({ commentId: COMMENT_ID, type: 'like', emoji: null }),
+  ],
+  [
+    'removeReaction',
+    (c: ReturnType<typeof caller>) =>
+      c.removeReaction({ commentId: COMMENT_ID, type: 'like', emoji: null }),
+  ],
+] as const
+
+const WRITE_CALLS = [
+  [
+    'create',
+    (c: ReturnType<typeof caller>) =>
+      c.create({ contentJson, recordId: RECORD_ID, parentId: null }),
+  ],
+  ['update', (c: ReturnType<typeof caller>) => c.update({ id: COMMENT_ID, contentJson })],
+  ['delete', (c: ReturnType<typeof caller>) => c.delete({ id: COMMENT_ID })],
+  ['togglePin', (c: ReturnType<typeof caller>) => c.togglePin({ id: COMMENT_ID, pin: true })],
+] as const
+
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+beforeEach(() => {
+  constructorArgs.length = 0
+  for (const method of Object.values(service)) method.mockReset()
+
+  service.createComment.mockResolvedValue(comment)
+  service.updateComment.mockResolvedValue(comment)
+  service.deleteComment.mockResolvedValue(undefined)
+  service.getById.mockResolvedValue(comment)
+  service.getCommentsByRecordId.mockResolvedValue([comment])
+  service.pinComment.mockResolvedValue(comment)
+  service.addReaction.mockResolvedValue({ id: 'reaction_1' })
+  service.removeReaction.mockResolvedValue(undefined)
+})
+
+describe('comment router permissions', () => {
+  it.each(
+    READ_CALLS
+  )('%s denies comments: None before constructing the service', async (_name, call) => {
+    await expect(call(caller(capabilitiesFor(Level.None)))).rejects.toMatchObject(FORBIDDEN)
+    expect(constructorArgs).toHaveLength(0)
+  })
+
+  it.each(READ_CALLS)('%s allows comments: Read', async (_name, call) => {
+    const capabilities = capabilitiesFor(Level.Read)
+    await expect(call(caller(capabilities))).resolves.toBeDefined()
+    expect(constructorArgs.at(-1)).toEqual([ORG_ID, USER_ID, db, capabilities])
+  })
+
+  it.each(
+    WRITE_CALLS
+  )('%s denies comments: Read before constructing the service', async (_name, call) => {
+    await expect(call(caller(capabilitiesFor(Level.Read)))).rejects.toMatchObject(FORBIDDEN)
+    expect(constructorArgs).toHaveLength(0)
+  })
+
+  it.each(WRITE_CALLS)('%s allows comments: Full', async (_name, call) => {
+    const capabilities = capabilitiesFor(Level.Full)
+    await expect(call(caller(capabilities))).resolves.toBeDefined()
+    expect(constructorArgs.at(-1)).toEqual([ORG_ID, USER_ID, db, capabilities])
+  })
+
+  it('preserves a service AuxxError instead of flattening it to a 500', async () => {
+    const forbidden = Object.assign(new Error('Parent record is not visible'), {
+      name: 'ForbiddenError',
+      statusCode: 403,
+    })
+    service.getById.mockRejectedValue(forbidden)
+
+    await expect(
+      caller(capabilitiesFor(Level.Read)).getById({ id: COMMENT_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+})

--- a/apps/web/src/server/api/routers/comment.ts
+++ b/apps/web/src/server/api/routers/comment.ts
@@ -9,7 +9,7 @@ import { type ActorId, toActorId } from '@auxx/types/actor'
 import { toRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { createTRPCRouter, permissionProcedure, protectedProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, isAuxxError, permissionProcedure } from '~/server/api/trpc'
 
 const logger = createScopedLogger('comment-router')
 
@@ -76,7 +76,7 @@ export const commentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       try {
         const { userId, organizationId } = ctx.session
-        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
         const { contentJson, recordId, parentId, fileAttachments } = input
 
         // Create the comment
@@ -93,7 +93,7 @@ export const commentRouter = createTRPCRouter({
         const message = error instanceof Error ? error.message : 'Failed to create comment'
         logger.error('Error creating comment', { error, input })
 
-        if (error instanceof TRPCError) {
+        if (error instanceof TRPCError || isAuxxError(error)) {
           throw error
         }
 
@@ -110,7 +110,7 @@ export const commentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       try {
         const { userId, organizationId } = ctx.session
-        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
         const { id, contentJson, fileAttachments } = input
 
         // Update the comment
@@ -125,7 +125,7 @@ export const commentRouter = createTRPCRouter({
         logger.error('Error updating comment', { error, input })
         // const message = error instanceof Error ? error.message : 'Failed to update comment'
 
-        if (error instanceof TRPCError) {
+        if (error instanceof TRPCError || isAuxxError(error)) {
           throw error
         }
 
@@ -144,14 +144,14 @@ export const commentRouter = createTRPCRouter({
         const { userId, organizationId } = ctx.session
         const { id } = input
 
-        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
         await commentService.deleteComment(id)
 
         return { success: true }
       } catch (error: unknown) {
         logger.error('Error deleting comment', { error, input })
 
-        if (error instanceof TRPCError) {
+        if (error instanceof TRPCError || isAuxxError(error)) {
           throw error
         }
 
@@ -161,36 +161,38 @@ export const commentRouter = createTRPCRouter({
         })
       }
     }),
-  getById: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
-    try {
-      const { userId, organizationId } = ctx.session
-      const commentService = new CommentService(organizationId, userId, ctx.db)
+  getById: permissionProcedure(PermissionKey.commentsView)
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const { userId, organizationId } = ctx.session
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
 
-      const comment = await commentService.getById(input.id)
+        const comment = await commentService.getById(input.id)
 
-      if (!comment) {
+        if (!comment) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Comment not found',
+          })
+        }
+
+        return { comment: transformCommentResponse(comment) }
+      } catch (error: unknown) {
+        logger.error('Error fetching comment', { error, input })
+
+        if (error instanceof TRPCError || isAuxxError(error)) {
+          throw error
+        }
+
         throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Comment not found',
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to fetch comment',
         })
       }
-
-      return { comment: transformCommentResponse(comment) }
-    } catch (error: unknown) {
-      logger.error('Error fetching comment', { error, input })
-
-      if (error instanceof TRPCError) {
-        throw error
-      }
-
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to fetch comment',
-      })
-    }
-  }),
+    }),
   // Get comments for an entity
-  getByRecordId: protectedProcedure
+  getByRecordId: permissionProcedure(PermissionKey.commentsView)
     .input(
       z.object({
         recordId: recordIdSchema,
@@ -201,7 +203,7 @@ export const commentRouter = createTRPCRouter({
         const { userId, organizationId } = ctx.session
         const { recordId } = input
 
-        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
 
         // Use efficient single query from CommentService
         const comments = await commentService.getCommentsByRecordId(recordId)
@@ -210,7 +212,7 @@ export const commentRouter = createTRPCRouter({
       } catch (error: unknown) {
         logger.error('Error fetching comments', { error, input })
 
-        if (error instanceof TRPCError) {
+        if (error instanceof TRPCError || isAuxxError(error)) {
           throw error
         }
 
@@ -222,21 +224,21 @@ export const commentRouter = createTRPCRouter({
     }),
 
   // Pin/unpin a comment
-  togglePin: protectedProcedure
+  togglePin: permissionProcedure(PermissionKey.commentsManage)
     .input(z.object({ id: z.string(), pin: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       try {
         const { userId, organizationId } = ctx.session
         const { id, pin } = input
 
-        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
         const comment = await commentService.pinComment(id, userId, pin)
 
         return comment
       } catch (error: unknown) {
         logger.error('Error toggling pin status', { error, input })
 
-        if (error instanceof TRPCError) {
+        if (error instanceof TRPCError || isAuxxError(error)) {
           throw error
         }
 
@@ -248,7 +250,7 @@ export const commentRouter = createTRPCRouter({
     }),
 
   // Add a reaction to a comment
-  addReaction: protectedProcedure
+  addReaction: permissionProcedure(PermissionKey.commentsView)
     .input(
       z.object({
         commentId: z.string(),
@@ -260,7 +262,7 @@ export const commentRouter = createTRPCRouter({
       try {
         const { userId, organizationId } = ctx.session
 
-        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
         const reaction = await commentService.addReaction({
           commentId: input.commentId,
           userId,
@@ -272,7 +274,7 @@ export const commentRouter = createTRPCRouter({
       } catch (error: unknown) {
         logger.error('Error adding reaction', { error, input })
 
-        if (error instanceof TRPCError) {
+        if (error instanceof TRPCError || isAuxxError(error)) {
           throw error
         }
 
@@ -284,7 +286,7 @@ export const commentRouter = createTRPCRouter({
     }),
 
   // Remove a reaction from a comment
-  removeReaction: protectedProcedure
+  removeReaction: permissionProcedure(PermissionKey.commentsView)
     .input(
       z.object({
         commentId: z.string(),
@@ -296,14 +298,14 @@ export const commentRouter = createTRPCRouter({
       try {
         const { userId, organizationId } = ctx.session
 
-        const commentService = new CommentService(organizationId, userId, ctx.db)
+        const commentService = new CommentService(organizationId, userId, ctx.db, ctx.capabilities)
         await commentService.removeReaction(input.commentId, userId, input.type, input.emoji)
 
         return { success: true }
       } catch (error: unknown) {
         logger.error('Error removing reaction', { error, input })
 
-        if (error instanceof TRPCError) {
+        if (error instanceof TRPCError || isAuxxError(error)) {
           throw error
         }
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-note.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-note.ts
@@ -24,9 +24,9 @@ export function createCreateNoteTool(getDeps: GetToolDeps): AgentToolDefinition 
     name: 'create_note',
     permission: {
       target: 'definition',
-      level: 'edit',
-      enforcement: 'unenforced',
-      note: 'KNOWN GAP (19b G3). Deliberate: the human comment routers are ungated too (doc 14 §8.3), so gating only the agent path would diverge from the product. A def published None still accepts notes. Do not "fix" without the matching human-router decision.',
+      level: 'view',
+      enforcement: 'enforced',
+      note: 'CommentService enforces commentsManage plus parent view; thread hosts branch to inbox view and the mail lens (plan 41).',
     },
     displayName: 'Add note',
     toolsetSlug: 'auxx:comments:write',
@@ -81,23 +81,22 @@ export function createCreateNoteTool(getDeps: GetToolDeps): AgentToolDefinition 
       }
     },
     execute: async (args, agentDeps) => {
-      // KNOWN GAP (plan 19b, G3): deliberately ungated. The *human* comment
-      // routers are ungated too (doc 14 §8.3), so gating only the agent path
-      // would diverge from the surface it mirrors. The four record-adjacent
-      // READS (`list_notes`, `list_field_changes`, `get_transcript`,
-      // `list_transcripts_for_entity`) do NOT share this reasoning and are
-      // gated on `canViewEntity`. Close this together with the human routers.
-      const { db } = getDeps()
+      const { db, capabilities } = getDeps()
       const recordId = args.recordId as string
       const content = args.content as string
 
-      const service = new CommentService(agentDeps.organizationId, agentDeps.userId, db)
+      const service = new CommentService(
+        agentDeps.organizationId,
+        agentDeps.userId,
+        db,
+        capabilities ?? null
+      )
       const contentJson = textToDoc(content, { parseReferences: true })
 
       try {
         const comment = await service.createComment({
           recordId: recordId as RecordId,
-          contentJson,
+          contentJson: contentJson as unknown as Record<string, unknown>,
           createdById: agentDeps.userId,
         })
         return {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-notes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-notes.ts
@@ -3,6 +3,8 @@
 import { z } from 'zod'
 import { getCachedMembersByUserIds } from '../../../../../cache/org-cache-helpers'
 import { CommentService } from '../../../../../comments'
+import { ForbiddenError } from '../../../../../errors'
+import { PermissionKey } from '../../../../../permissions/capabilities/registry'
 import { getDefinitionId, type RecordId } from '../../../../../resources/resource-id'
 import { docToText } from '../../../../../tiptap'
 import { getKnownDefIds, normalizeRecordIdArg } from '../../../../agent-framework/tool-inputs'
@@ -62,7 +64,7 @@ export function createListNotesTool(getDeps: GetToolDeps): AgentToolDefinition {
       target: 'definition',
       level: 'view',
       enforcement: 'enforced',
-      note: 'canViewEntity on the def parsed out of the recordId; silent-empty on denial (19b G3).',
+      note: 'commentsView plus parent view; thread hosts branch to inbox view and the mail lens. Silent-empty on denial (plan 41).',
     },
     displayName: 'List notes',
     toolsetSlug: 'auxx:comments:read',
@@ -139,11 +141,20 @@ export function createListNotesTool(getDeps: GetToolDeps): AgentToolDefinition {
       // Read enforcement (§3): notes are record content, so a def the principal
       // can't view reads as a record with no notes — never as a denial that
       // confirms the record exists.
-      if (capabilities && !capabilities.canViewEntity(getDefinitionId(recordId))) {
+      if (
+        capabilities &&
+        (!capabilities.can(PermissionKey.commentsView) ||
+          !capabilities.canViewEntity(getDefinitionId(recordId)))
+      ) {
         return { success: true, output: { notes: [], hasMore: false } }
       }
 
-      const service = new CommentService(agentDeps.organizationId, agentDeps.userId, db)
+      const service = new CommentService(
+        agentDeps.organizationId,
+        agentDeps.userId,
+        db,
+        capabilities ?? null
+      )
 
       let comments
       try {
@@ -154,6 +165,9 @@ export function createListNotesTool(getDeps: GetToolDeps): AgentToolDefinition {
           limit: limit + 1,
         })
       } catch (err) {
+        if (err instanceof ForbiddenError) {
+          return { success: true, output: { notes: [], hasMore: false } }
+        }
         return {
           success: false,
           output: null,

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -289,5 +289,9 @@ export const USER_CACHE_KEY_CONFIG: Record<
   // nothing.
   // NOTE: bump this whenever the registry's area/key set or the UserCapabilities
   // shape changes, so a rollout can't leave members on a stale key set.
-  userCapabilities: { prefix: 'user:capabilities:v14', ttlSeconds: ONE_DAY },
+  // v15 (plan 41): Area.comments gained a Read rung / comments.view key.
+  // A stale v14 blob for a Full member holds comments.manage without the new
+  // prerequisite key, so direct reads fail closed while writes may still pass.
+  // Bump to keep the ladder coherent across a rolling deploy.
+  userCapabilities: { prefix: 'user:capabilities:v15', ttlSeconds: ONE_DAY },
 }

--- a/packages/lib/src/comments/comment-service.test.ts
+++ b/packages/lib/src/comments/comment-service.test.ts
@@ -1,0 +1,378 @@
+// packages/lib/src/comments/comment-service.test.ts
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ForbiddenError } from '../errors'
+import type { CapabilityView } from '../permissions/capabilities/capability-view'
+import { toRecordId } from '../resources/resource-id'
+
+const {
+  assertCanActOnThreads,
+  getCachedResources,
+  getCachedUserMailVisibility,
+  getThreadLens,
+  inboxAccessRecordId,
+} = vi.hoisted(() => ({
+  assertCanActOnThreads: vi.fn(),
+  getCachedResources: vi.fn(),
+  getCachedUserMailVisibility: vi.fn(),
+  getThreadLens: vi.fn(),
+  inboxAccessRecordId: vi.fn(),
+}))
+
+vi.mock('../cache/org-cache-helpers', () => ({ getCachedResources }))
+vi.mock('../cache/user-cache-helpers', () => ({
+  getCachedUserMailVisibility,
+}))
+vi.mock('../events', () => ({
+  publisher: { publishLater: vi.fn() },
+}))
+vi.mock('../files/core/attachment-service', () => ({
+  AttachmentService: class {
+    fetchAttachmentsForEntities = vi.fn().mockResolvedValue(new Map())
+  },
+}))
+vi.mock('../files/core/media-asset-service', () => ({
+  MediaAssetService: class {},
+}))
+vi.mock('../notifications/notification-service', () => ({
+  NotificationService: class {},
+}))
+vi.mock('../permissions/visibility/thread-lens', () => ({ getThreadLens }))
+vi.mock('../resource-access/mail-sharing-guard', () => ({ inboxAccessRecordId }))
+vi.mock('../threads/thread-action-access', () => ({ assertCanActOnThreads }))
+
+const { CommentService } = await import('./comment-service')
+
+const organizationId = 'org_1'
+const userId = 'user_1'
+
+function structuralCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
+  return {
+    can: () => true,
+    has: () => true,
+    assert: () => undefined,
+    areaLevel: () => 0,
+    canWriteEntity: () => true,
+    assertWriteEntity: () => undefined,
+    canEditEntity: () => true,
+    assertEditEntity: () => undefined,
+    filterEditableDefIds: (ids) => ids,
+    canViewEntity: () => true,
+    assertViewEntity: () => undefined,
+    filterViewableDefIds: (ids) => ids,
+    viewAccessFor: () => undefined,
+    canAdministerDef: () => false,
+    assertAdministerDef: () => undefined,
+    canViewInstance: () => false,
+    canEditInstance: () => false,
+    canAdminInstance: () => false,
+    assertViewInstance: () => undefined,
+    assertEditInstance: () => undefined,
+    assertAdminInstance: () => undefined,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getCachedUserMailVisibility.mockResolvedValue({
+    userId,
+    isAdmin: false,
+  })
+  getThreadLens.mockResolvedValue('full')
+  assertCanActOnThreads.mockResolvedValue(undefined)
+  inboxAccessRecordId.mockResolvedValue('inbox:inbox_1')
+  getCachedResources.mockResolvedValue([
+    {
+      id: 'contact',
+      apiSlug: 'contact',
+      entityDefinitionId: 'def_contact',
+      entityType: 'contact',
+    },
+    {
+      id: 'inbox',
+      apiSlug: 'inbox',
+      entityDefinitionId: 'def_inbox',
+      entityType: 'inbox',
+    },
+    {
+      id: 'thread',
+      apiSlug: 'thread',
+      entityDefinitionId: 'def_thread',
+      entityType: 'thread',
+    },
+    {
+      id: 'deal',
+      apiSlug: 'deal',
+      entityDefinitionId: 'def_deal',
+      entityType: 'deal',
+    },
+  ])
+})
+
+describe('CommentService authorization', () => {
+  it('accepts a structural CapabilityView and returns 403 for an inaccessible known comment', async () => {
+    const entityFindFirst = vi.fn().mockResolvedValue({ organizationId })
+    const db = {
+      query: {
+        Comment: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: 'comment_1',
+            organizationId,
+            entityDefinitionId: 'def_contact',
+            entityId: 'record_1',
+            reactions: [],
+          }),
+        },
+        EntityInstance: {
+          findFirst: entityFindFirst,
+        },
+      },
+    } as unknown as Database
+    const capabilities = structuralCapabilities({ canViewEntity: () => false })
+    const service = new CommentService(organizationId, userId, db, capabilities)
+
+    await expect(service.getById('comment_1')).rejects.toMatchObject({
+      name: 'ForbiddenError',
+      statusCode: 403,
+    })
+    expect(entityFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('checks the inbox front door before reading a thread row', async () => {
+    const threadFindFirst = vi.fn()
+    let assertionCount = 0
+    const capabilities = structuralCapabilities({
+      assert: () => {
+        assertionCount += 1
+        if (assertionCount === 2) throw new ForbiddenError('Inbox access denied')
+      },
+    })
+    const db = {
+      query: {
+        Thread: { findFirst: threadFindFirst },
+      },
+    } as unknown as Database
+    const service = new CommentService(organizationId, userId, db, capabilities)
+
+    await expect(
+      service.getCommentsByRecordId(toRecordId('def_thread', 'thread_1'))
+    ).rejects.toMatchObject({
+      name: 'ForbiddenError',
+      statusCode: 403,
+    })
+    expect(threadFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unsupported inbox host even in explicit unrestricted mode', async () => {
+    const service = new CommentService(organizationId, userId, {} as Database, null)
+
+    await expect(
+      service.getCommentsByRecordId(toRecordId('inbox', 'inbox_1'))
+    ).rejects.toMatchObject({
+      name: 'BadRequestError',
+      statusCode: 400,
+    })
+  })
+
+  it('allows the explicit null cascade to purge unreachable historical inbox comments', async () => {
+    const where = vi.fn().mockResolvedValue(undefined)
+    const deleteRows = vi.fn().mockReturnValue({ where })
+    const db = {
+      query: {
+        EntityInstance: {
+          findFirst: vi.fn().mockResolvedValue({
+            organizationId,
+            entityDefinitionId: 'def_inbox',
+          }),
+        },
+      },
+      delete: deleteRows,
+    } as unknown as Database
+    const service = new CommentService(organizationId, userId, db, null)
+
+    await expect(
+      service.deleteCommentsByRecordId(toRecordId('def_inbox', 'inbox_1'))
+    ).resolves.toBeUndefined()
+    expect(deleteRows).toHaveBeenCalledOnce()
+    expect(where).toHaveBeenCalledOnce()
+  })
+
+  it('rejects an instance paired with a different visible definition prefix', async () => {
+    const db = {
+      query: {
+        EntityInstance: {
+          findFirst: vi.fn().mockResolvedValue({
+            organizationId,
+            entityDefinitionId: 'def_deal',
+          }),
+        },
+      },
+    } as unknown as Database
+    const service = new CommentService(organizationId, userId, db, structuralCapabilities())
+
+    await expect(
+      service.getCommentsByRecordId(toRecordId('def_contact', 'record_1'))
+    ).rejects.toMatchObject({
+      name: 'NotFoundError',
+      statusCode: 404,
+    })
+  })
+
+  it('rejects a reply parent on another record without confirming that parent', async () => {
+    const db = {
+      query: {
+        EntityInstance: {
+          findFirst: vi.fn().mockResolvedValue({
+            organizationId,
+            entityDefinitionId: 'def_contact',
+          }),
+        },
+        Comment: {
+          findFirst: vi.fn().mockResolvedValue({
+            createdById: 'user_2',
+            entityId: 'record_2',
+            entityDefinitionId: 'def_contact',
+          }),
+        },
+      },
+    } as unknown as Database
+    const service = new CommentService(organizationId, userId, db, structuralCapabilities())
+
+    await expect(
+      service.createComment({
+        contentJson: { type: 'doc', content: [] },
+        recordId: toRecordId('def_contact', 'record_1'),
+        createdById: userId,
+        parentId: 'comment_2',
+      })
+    ).rejects.toMatchObject({
+      name: 'NotFoundError',
+      statusCode: 404,
+    })
+  })
+
+  it.each([
+    ['the author', userId, false, true],
+    ['a definition administrator', 'user_2', true, true],
+    ['a plain non-author', 'user_2', false, false],
+  ] as const)('allows record moderation for %s', async (_label, createdById, canAdministerDef, allowed) => {
+    const db = {
+      query: {
+        Comment: {
+          findFirst: vi.fn().mockResolvedValue({
+            createdById,
+            entityId: 'record_1',
+            entityDefinitionId: 'def_contact',
+            organizationId,
+          }),
+        },
+        EntityInstance: {
+          findFirst: vi.fn().mockResolvedValue({
+            organizationId,
+            entityDefinitionId: 'def_contact',
+          }),
+        },
+      },
+    } as unknown as Database
+    const service = new CommentService(
+      organizationId,
+      userId,
+      db,
+      structuralCapabilities({ canAdministerDef: () => canAdministerDef })
+    )
+    const moderate = (
+      service as unknown as {
+        assertCanModifyComment: (id: string, message: string) => Promise<unknown>
+      }
+    ).assertCanModifyComment.bind(service)
+    const result = moderate('comment_1', 'Moderation denied')
+
+    if (allowed) {
+      await expect(result).resolves.toMatchObject({ createdById })
+    } else {
+      await expect(result).rejects.toMatchObject({
+        name: 'ForbiddenError',
+        statusCode: 403,
+      })
+    }
+  })
+
+  it('requires full thread access before pinning', async () => {
+    assertCanActOnThreads.mockRejectedValueOnce(new ForbiddenError('Full lens required'))
+    const update = vi.fn()
+    const db = {
+      query: {
+        Comment: {
+          findFirst: vi.fn().mockResolvedValue({
+            entityId: 'thread_1',
+            entityDefinitionId: 'def_thread',
+            organizationId,
+          }),
+        },
+        Thread: {
+          findFirst: vi.fn().mockResolvedValue({ organizationId, inboxId: 'inbox_1' }),
+        },
+      },
+      update,
+    } as unknown as Database
+    const service = new CommentService(organizationId, userId, db, structuralCapabilities())
+
+    await expect(service.pinComment('comment_1', userId, true)).rejects.toMatchObject({
+      name: 'ForbiddenError',
+      statusCode: 403,
+    })
+    expect(assertCanActOnThreads).toHaveBeenCalledWith(
+      db,
+      organizationId,
+      expect.objectContaining({ isAdmin: false }),
+      ['thread_1']
+    )
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['an inbox manager', true, true],
+    ['a non-manager', false, false],
+  ] as const)('moderates another author’s full-lens thread note as %s', async (_label, canAdminInstance, allowed) => {
+    const db = {
+      query: {
+        Comment: {
+          findFirst: vi.fn().mockResolvedValue({
+            createdById: 'user_2',
+            entityId: 'thread_1',
+            entityDefinitionId: 'def_thread',
+            organizationId,
+          }),
+        },
+        Thread: {
+          findFirst: vi.fn().mockResolvedValue({ organizationId, inboxId: 'inbox_1' }),
+        },
+      },
+    } as unknown as Database
+    const service = new CommentService(
+      organizationId,
+      userId,
+      db,
+      structuralCapabilities({ canAdminInstance: () => canAdminInstance })
+    )
+    const moderate = (
+      service as unknown as {
+        assertCanModifyComment: (id: string, message: string) => Promise<unknown>
+      }
+    ).assertCanModifyComment.bind(service)
+    const result = moderate('comment_1', 'Moderation denied')
+
+    if (allowed) {
+      await expect(result).resolves.toMatchObject({ createdById: 'user_2' })
+    } else {
+      await expect(result).rejects.toMatchObject({
+        name: 'ForbiddenError',
+        statusCode: 403,
+      })
+    }
+    expect(assertCanActOnThreads).toHaveBeenCalled()
+    expect(inboxAccessRecordId).toHaveBeenCalledWith(organizationId, 'inbox_1')
+  })
+})

--- a/packages/lib/src/comments/comment-service.ts
+++ b/packages/lib/src/comments/comment-service.ts
@@ -1,13 +1,15 @@
 // packages/lib/src/comments/comment-service.ts
-import { type Database, database, schema, type Transaction } from '@auxx/database'
+import { type Database, schema, type Transaction } from '@auxx/database'
 import type {
   CommentEntity as Comment,
   CommentReactionEntity as CommentReaction,
 } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { TRPCError } from '@trpc/server'
-import { and, desc, eq, isNull } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNull } from 'drizzle-orm'
+import { getCachedResources } from '../cache/org-cache-helpers'
+import { getCachedUserMailVisibility } from '../cache/user-cache-helpers'
 import { touchActivityForThreadLinks, touchEntityActivity } from '../entity-instances/activity'
+import { BadRequestError, ForbiddenError, NotFoundError } from '../errors'
 import { publisher } from '../events'
 import type {
   CommentCreatedEvent,
@@ -18,10 +20,18 @@ import type {
 } from '../events/types'
 import { AttachmentService, type GroupedAttachmentInfo } from '../files/core/attachment-service'
 import { MediaAssetService } from '../files/core/media-asset-service'
-import { isAdminOrOwner } from '../members/member-queries'
 import { NotificationService } from '../notifications/notification-service'
+import type { CapabilityView } from '../permissions/capabilities/capability-view'
+import { PermissionKey } from '../permissions/capabilities/registry'
+import {
+  buildDefIdToDefinitionId,
+  buildDefIdToSlug,
+} from '../permissions/capabilities/resolve-capability-inputs'
+import { getThreadLens } from '../permissions/visibility/thread-lens'
 import { collectReferenceIds } from '../references'
+import { inboxAccessRecordId } from '../resource-access/mail-sharing-guard'
 import { parseRecordId, type RecordId, toRecordId } from '../resources/resource-id'
+import { assertCanActOnThreads } from '../threads/thread-action-access'
 import { docToText } from '../tiptap'
 
 // Define reaction types
@@ -80,6 +90,14 @@ export interface AggregatedReactions {
 const logger = createScopedLogger('comment-service')
 // Define storage location selector
 
+type ResolvedCommentParent = {
+  entityDefinitionId: string
+  entityInstanceId: string
+  canonicalDefinitionId: string
+  slug: string
+  inboxId: string | null
+}
+
 export class CommentService {
   private db: Database
   private userId: string
@@ -87,14 +105,50 @@ export class CommentService {
   private notificationService: NotificationService
   private mediaAssetService: MediaAssetService
   private attachmentService: AttachmentService
-  constructor(organizationId: string, userId: string, db: Database = database) {
+  private readonly capabilities: CapabilityView | null
+
+  /**
+   * @param capabilities Required nullable authorization view. Pass `null` only for
+   * parent-delete cascades and explicitly reviewed headless callers.
+   */
+  constructor(
+    organizationId: string,
+    userId: string,
+    db: Database,
+    capabilities: CapabilityView | null
+  ) {
     this.organizationId = organizationId
     this.userId = userId
     this.db = db
+    this.capabilities = capabilities
 
     this.notificationService = new NotificationService(db)
     this.mediaAssetService = new MediaAssetService(organizationId, userId, db)
     this.attachmentService = new AttachmentService(organizationId, userId, db)
+  }
+
+  /** All RecordId definition spellings that resolve to the same canonical host. */
+  private async equivalentDefinitionKeys(entityDefinitionId: string): Promise<string[]> {
+    const resources = await getCachedResources(this.organizationId)
+    const toSlug = buildDefIdToSlug(resources)
+    const toDefinitionId = buildDefIdToDefinitionId(resources)
+    const slug = toSlug(entityDefinitionId)
+    const canonicalDefinitionId = toDefinitionId(entityDefinitionId)
+    const keys = new Set<string>([entityDefinitionId, canonicalDefinitionId, slug])
+
+    for (const resource of resources) {
+      const sameHost =
+        slug === 'thread'
+          ? toSlug(resource.entityDefinitionId) === 'thread'
+          : toDefinitionId(resource.entityDefinitionId) === canonicalDefinitionId
+      if (!sameHost) continue
+      keys.add(resource.id)
+      keys.add(resource.apiSlug)
+      keys.add(resource.entityDefinitionId)
+      if (resource.entityType) keys.add(resource.entityType)
+    }
+
+    return [...keys]
   }
 
   /** Resolve stable fallback copy for a comment notification. */
@@ -103,12 +157,13 @@ export class CommentService {
     recordName: string
   }> {
     const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+    const toSlug = buildDefIdToSlug(await getCachedResources(this.organizationId))
     const [actor, recordName] = await Promise.all([
       this.db.query.User.findFirst({
         where: eq(schema.User.id, this.userId),
         columns: { name: true },
       }),
-      entityDefinitionId === 'thread'
+      toSlug(entityDefinitionId) === 'thread'
         ? this.db.query.Thread.findFirst({
             where: eq(schema.Thread.id, entityInstanceId),
             columns: { subject: true },
@@ -125,57 +180,133 @@ export class CommentService {
     }
   }
 
-  /**
-   * Verify the host record (Thread or EntityInstance) belongs to this user's org.
-   * `protectedProcedure` already binds the user to one org per session, so this is the
-   * only access check needed for now. When ResourceAccess grants are wired across all
-   * commentable entity types, swap for `hasPermission(ctx, recordId, view)`.
-   */
-  private async assertCanAccessRecord(recordId: RecordId, message: string): Promise<void> {
+  /** Resolve a comment host and prove organization ownership plus parent visibility. */
+  private async assertCanAccessRecord(
+    recordId: RecordId,
+    message: string,
+    options: { allowUnsupportedParent?: boolean } = {}
+  ): Promise<ResolvedCommentParent> {
     const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+    const resources = await getCachedResources(this.organizationId)
+    const toSlug = buildDefIdToSlug(resources)
+    const toDefinitionId = buildDefIdToDefinitionId(resources)
+    const slug = toSlug(entityDefinitionId)
+    const canonicalDefinitionId = toDefinitionId(entityDefinitionId)
+
+    if ((slug === 'inbox' || slug === 'personal_inbox') && !options.allowUnsupportedParent) {
+      throw new BadRequestError('Comments are not supported on inboxes.')
+    }
+
+    if (this.capabilities) {
+      if (slug === 'thread') {
+        // The mail front door answers before any thread row is read.
+        this.capabilities.assert(PermissionKey.inboxesView)
+      } else if (!this.capabilities.canViewEntity(canonicalDefinitionId)) {
+        throw new ForbiddenError(message)
+      }
+    }
 
     let recordOrgId: string | undefined
-    if (entityDefinitionId === 'thread') {
+    let recordDefinitionId: string | undefined
+    let inboxId: string | null = null
+    if (slug === 'thread') {
       const t = await this.db.query.Thread.findFirst({
         where: eq(schema.Thread.id, entityInstanceId),
-        columns: { organizationId: true },
+        columns: { organizationId: true, inboxId: true },
       })
       recordOrgId = t?.organizationId
+      inboxId = t?.inboxId ?? null
     } else {
       const i = await this.db.query.EntityInstance.findFirst({
         where: eq(schema.EntityInstance.id, entityInstanceId),
-        columns: { organizationId: true },
+        columns: { organizationId: true, entityDefinitionId: true },
       })
       recordOrgId = i?.organizationId
+      recordDefinitionId = i?.entityDefinitionId
     }
 
     if (!recordOrgId) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Record not found' })
+      throw new NotFoundError('Record not found')
     }
     if (recordOrgId !== this.organizationId) {
-      throw new TRPCError({ code: 'FORBIDDEN', message })
+      throw new ForbiddenError(message)
+    }
+    if (slug !== 'thread' && toDefinitionId(recordDefinitionId ?? '') !== canonicalDefinitionId) {
+      throw new NotFoundError('Record not found')
+    }
+
+    if (this.capabilities) {
+      if (slug === 'thread') {
+        const viewer = await getCachedUserMailVisibility(this.userId, this.organizationId)
+        const lens = await getThreadLens(this.db, this.organizationId, viewer, entityInstanceId)
+        if (lens === 'none') throw new ForbiddenError(message)
+      }
+    }
+
+    return {
+      entityDefinitionId,
+      entityInstanceId,
+      canonicalDefinitionId,
+      slug,
+      inboxId,
     }
   }
 
   /**
-   * Verify the user can modify (update / delete) a comment: they're either the author
-   * or an org OWNER/ADMIN.
+   * Verify update/delete authority after the area and parent gates.
    */
-  private async assertCanModifyComment(commentId: string, message: string): Promise<void> {
+  private async assertCanModifyComment(
+    commentId: string,
+    message: string
+  ): Promise<{
+    createdById: string
+    entityId: string
+    entityDefinitionId: string
+    organizationId: string
+  }> {
+    this.capabilities?.assert(PermissionKey.commentsManage)
     const comment = await this.db.query.Comment.findFirst({
       where: eq(schema.Comment.id, commentId),
-      columns: { createdById: true, organizationId: true },
+      columns: {
+        createdById: true,
+        entityId: true,
+        entityDefinitionId: true,
+        organizationId: true,
+      },
     })
     if (!comment) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Comment not found' })
+      throw new NotFoundError('Comment not found')
     }
     if (comment.organizationId !== this.organizationId) {
-      throw new TRPCError({ code: 'FORBIDDEN', message })
+      throw new ForbiddenError(message)
     }
-    if (comment.createdById === this.userId) return
-    // Author || admin ownership carve-out, not a gate (plan 21 §5.2).
-    if (await isAdminOrOwner(this.organizationId, this.userId, this.db)) return
-    throw new TRPCError({ code: 'FORBIDDEN', message })
+
+    const parent = await this.assertCanAccessRecord(
+      toRecordId(comment.entityDefinitionId, comment.entityId),
+      message
+    )
+    if (!this.capabilities || comment.createdById === this.userId) return comment
+
+    if (parent.slug === 'thread') {
+      const viewer = await getCachedUserMailVisibility(this.userId, this.organizationId)
+      await assertCanActOnThreads(this.db, this.organizationId, viewer, [parent.entityInstanceId])
+      if (viewer.isAdmin) return comment
+      if (parent.inboxId) {
+        const { entityDefinitionId, entityInstanceId } = parseRecordId(
+          await inboxAccessRecordId(this.organizationId, parent.inboxId)
+        )
+        if (
+          (entityDefinitionId === 'inbox' || entityDefinitionId === 'personal_inbox') &&
+          this.capabilities.canAdminInstance(entityDefinitionId, entityInstanceId)
+        ) {
+          return comment
+        }
+      }
+      throw new ForbiddenError('Only admins or inbox managers can moderate this note.')
+    }
+
+    if (this.capabilities.canAdministerDef(parent.canonicalDefinitionId)) return comment
+    throw new ForbiddenError(message)
   }
 
   /**
@@ -183,6 +314,7 @@ export class CommentService {
    */
   async createComment(data: CreateCommentInput): Promise<Comment> {
     try {
+      this.capabilities?.assert(PermissionKey.commentsManage)
       data.organizationId = this.organizationId
 
       // Parse recordId to get components
@@ -190,7 +322,49 @@ export class CommentService {
       const entityId = entityInstanceId
       const entityType = entityDefinitionId
 
-      await this.assertCanAccessRecord(data.recordId, `You don't have access to this record`)
+      const resolvedParent = await this.assertCanAccessRecord(
+        data.recordId,
+        `You don't have access to this record`
+      )
+
+      let replyParent:
+        | {
+            createdById: string
+            entityId: string
+            entityDefinitionId: string
+          }
+        | undefined
+      if (data.parentId) {
+        replyParent = await this.db.query.Comment.findFirst({
+          where: and(
+            eq(schema.Comment.id, data.parentId),
+            eq(schema.Comment.organizationId, this.organizationId),
+            isNull(schema.Comment.deletedAt)
+          ),
+          columns: {
+            createdById: true,
+            entityId: true,
+            entityDefinitionId: true,
+          },
+        })
+
+        if (replyParent) {
+          const resources = await getCachedResources(this.organizationId)
+          const toSlug = buildDefIdToSlug(resources)
+          const toDefinitionId = buildDefIdToDefinitionId(resources)
+          const replySlug = toSlug(replyParent.entityDefinitionId)
+          const sameDefinition =
+            resolvedParent.slug === 'thread'
+              ? replySlug === 'thread'
+              : toDefinitionId(replyParent.entityDefinitionId) ===
+                resolvedParent.canonicalDefinitionId
+          if (replyParent.entityId !== entityId || !sameDefinition) replyParent = undefined
+        }
+
+        if (!replyParent) {
+          throw new NotFoundError('Parent comment not found')
+        }
+      }
 
       // Verify file access if provided
       if (data.fileAttachments && data.fileAttachments.length > 0) {
@@ -238,7 +412,7 @@ export class CommentService {
         }
 
         // Update Thread.latestCommentId if this is a thread comment
-        if (entityType === 'thread') {
+        if (resolvedParent.slug === 'thread') {
           await tx
             .update(schema.Thread)
             .set({ latestCommentId: comment!.id })
@@ -261,15 +435,11 @@ export class CommentService {
       const { actorName, recordName } = await this.getNotificationCopy(data.recordId)
 
       // Trigger reply notification outside the transaction
-      if (data.parentId) {
-        const parentComment = await this.db.query.Comment.findFirst({
-          where: eq(schema.Comment.id, data.parentId),
-          columns: { createdById: true },
-        })
-        if (parentComment && parentComment.createdById !== this.userId) {
+      if (data.parentId && replyParent) {
+        if (replyParent.createdById !== this.userId) {
           await this.notificationService.sendNotification({
             type: 'COMMENT_REPLY',
-            userId: parentComment.createdById,
+            userId: replyParent.createdById,
             organizationId: this.organizationId,
             targetType: 'COMMENT',
             targetIds: { commentId: result.id, recordId: data.recordId },
@@ -481,7 +651,7 @@ export class CommentService {
   /**
    * Delete all comments for an entity (hard delete)
    * Used when deleting parent entities like Contact, EntityInstance, etc.
-   * Note: Ticket/Thread comments are handled via FK cascade in the database
+   * This is a parent-delete cascade and intentionally skips per-comment moderation.
    */
   async deleteCommentsByRecordId(recordId: RecordId): Promise<void> {
     try {
@@ -490,18 +660,25 @@ export class CommentService {
       const entityId = entityInstanceId
       const entityType = entityDefinitionId
 
+      await this.assertCanAccessRecord(recordId, `You don't have access to this record`, {
+        // Parent deletion must not be blocked by unreachable historical inbox comments.
+        // The explicit null mode still proves organization and exact host identity.
+        allowUnsupportedParent: this.capabilities === null,
+      })
+      const equivalentDefinitionKeys = await this.equivalentDefinitionKeys(entityType)
+
       await this.db
         .delete(schema.Comment)
         .where(
           and(
             eq(schema.Comment.entityId, entityId),
-            eq(schema.Comment.entityDefinitionId, entityType),
+            inArray(schema.Comment.entityDefinitionId, equivalentDefinitionKeys),
             eq(schema.Comment.organizationId, this.organizationId)
           )
         )
 
       // Set Thread.latestCommentId to null if deleting all thread comments
-      if (entityType === 'thread') {
+      if (equivalentDefinitionKeys.includes('thread')) {
         await this.db
           .update(schema.Thread)
           .set({ latestCommentId: null })
@@ -520,12 +697,10 @@ export class CommentService {
    */
   async deleteComment(id: string): Promise<void> {
     try {
-      await this.assertCanModifyComment(id, `You don't have permission to delete this comment`)
-
-      // Get the comment to recalculate Thread.latestCommentId if needed.
-      const comment = await this.db.query.Comment.findFirst({
-        where: eq(schema.Comment.id, id),
-      })
+      const comment = await this.assertCanModifyComment(
+        id,
+        `You don't have permission to delete this comment`
+      )
 
       // Soft delete by setting deletedAt
       await this.db
@@ -534,7 +709,8 @@ export class CommentService {
         .where(eq(schema.Comment.id, id))
 
       // Recalculate Thread.latestCommentId if this was a thread comment
-      if (comment && comment.entityDefinitionId === 'thread') {
+      const toSlug = buildDefIdToSlug(await getCachedResources(this.organizationId))
+      if (comment && toSlug(comment.entityDefinitionId) === 'thread') {
         await this.recalculateLatestCommentId(comment.entityId)
       }
 
@@ -566,11 +742,13 @@ export class CommentService {
     } = {}
   ): Promise<Comment[]> {
     try {
+      this.capabilities?.assert(PermissionKey.commentsView)
       await this.assertCanAccessRecord(recordId, `You don't have access to this record`)
 
       const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
       const entityId = entityInstanceId
       const entityType = entityDefinitionId
+      const equivalentDefinitionKeys = await this.equivalentDefinitionKeys(entityType)
 
       const { includeReplies = true, page = 1, limit = 20 } = options
       // Calculate skip value for pagination
@@ -580,7 +758,8 @@ export class CommentService {
       const comments = await this.db.query.Comment.findMany({
         where: and(
           eq(schema.Comment.entityId, entityId),
-          eq(schema.Comment.entityDefinitionId, entityType),
+          inArray(schema.Comment.entityDefinitionId, equivalentDefinitionKeys),
+          eq(schema.Comment.organizationId, this.organizationId),
           isNull(schema.Comment.parentId), // Only get top-level comments (replies are nested)
           isNull(schema.Comment.deletedAt) // Exclude soft-deleted comments
         ),
@@ -590,7 +769,10 @@ export class CommentService {
           ...(includeReplies
             ? {
                 replies: {
-                  where: isNull(schema.Comment.deletedAt), // Exclude soft-deleted replies
+                  where: and(
+                    eq(schema.Comment.organizationId, this.organizationId),
+                    isNull(schema.Comment.deletedAt)
+                  ),
                   with: {
                     references: true,
                     reactions: true, // Include all reactions for processing
@@ -635,18 +817,23 @@ export class CommentService {
   }
   async getCommentById(id: string): Promise<Comment> {
     try {
+      this.capabilities?.assert(PermissionKey.commentsView)
       // Get the comment with all related data
       // Note: createdBy/pinnedBy removed - frontend uses useActor hook to resolve user info
       const comment = await this.db.query.Comment.findFirst({
         where: and(
           eq(schema.Comment.id, id),
+          eq(schema.Comment.organizationId, this.organizationId),
           isNull(schema.Comment.deletedAt) // Exclude soft-deleted comments
         ),
         with: {
           references: true,
           reactions: true, // Include all reactions for processing
           replies: {
-            where: isNull(schema.Comment.deletedAt), // Exclude soft-deleted replies
+            where: and(
+              eq(schema.Comment.organizationId, this.organizationId),
+              isNull(schema.Comment.deletedAt)
+            ),
             with: {
               references: true,
               reactions: true, // Include all reactions for processing
@@ -655,7 +842,7 @@ export class CommentService {
         },
       })
       if (!comment) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Comment not found' })
+        throw new NotFoundError('Comment not found')
       }
       await this.assertCanAccessRecord(
         toRecordId(comment.entityDefinitionId, comment.entityId),
@@ -696,17 +883,25 @@ export class CommentService {
    */
   async pinComment(commentId: string, userId: string, pin: boolean) {
     try {
+      this.capabilities?.assert(PermissionKey.commentsManage)
       const comment = await this.db.query.Comment.findFirst({
         where: eq(schema.Comment.id, commentId),
         columns: { entityId: true, entityDefinitionId: true, organizationId: true },
       })
       if (!comment) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Comment not found' })
+        throw new NotFoundError('Comment not found')
       }
-      await this.assertCanAccessRecord(
+      if (comment.organizationId !== this.organizationId) {
+        throw new ForbiddenError(`You don't have permission to pin this comment`)
+      }
+      const parent = await this.assertCanAccessRecord(
         toRecordId(comment.entityDefinitionId, comment.entityId),
         `You don't have permission to pin this comment`
       )
+      if (this.capabilities && parent.slug === 'thread') {
+        const viewer = await getCachedUserMailVisibility(this.userId, this.organizationId)
+        await assertCanActOnThreads(this.db, this.organizationId, viewer, [parent.entityInstanceId])
+      }
       const [updatedComment] = await this.db
         .update(schema.Comment)
         .set({
@@ -729,13 +924,22 @@ export class CommentService {
    */
   async addReaction(data: AddReactionInput) {
     try {
+      this.capabilities?.assert(PermissionKey.commentsView)
       const { commentId, userId, type, emoji } = data
       const comment = await this.db.query.Comment.findFirst({
         where: eq(schema.Comment.id, commentId),
-        columns: { entityId: true, entityDefinitionId: true, createdById: true },
+        columns: {
+          entityId: true,
+          entityDefinitionId: true,
+          createdById: true,
+          organizationId: true,
+        },
       })
       if (!comment) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Comment not found' })
+        throw new NotFoundError('Comment not found')
+      }
+      if (comment.organizationId !== this.organizationId) {
+        throw new ForbiddenError(`You don't have access to this comment`)
       }
       await this.assertCanAccessRecord(
         toRecordId(comment.entityDefinitionId, comment.entityId),
@@ -792,12 +996,16 @@ export class CommentService {
     emoji?: string | null
   ): Promise<void> {
     try {
+      this.capabilities?.assert(PermissionKey.commentsView)
       const comment = await this.db.query.Comment.findFirst({
         where: eq(schema.Comment.id, commentId),
-        columns: { entityId: true, entityDefinitionId: true },
+        columns: { entityId: true, entityDefinitionId: true, organizationId: true },
       })
       if (!comment) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Comment not found' })
+        throw new NotFoundError('Comment not found')
+      }
+      if (comment.organizationId !== this.organizationId) {
+        throw new ForbiddenError(`You don't have access to this comment`)
       }
       await this.assertCanAccessRecord(
         toRecordId(comment.entityDefinitionId, comment.entityId),
@@ -914,54 +1122,41 @@ export class CommentService {
    * Get single comment by ID with attachments
    */
   async getById(commentId: string): Promise<CommentWithAttachments | null> {
-    try {
-      logger.info('Fetching comment with attachments', {
-        commentId,
-        organizationId: this.organizationId,
-      })
-      // Get the comment with all related data including reactions and mentions
-      // Note: createdBy/pinnedBy removed - frontend uses useActor hook to resolve user info
-      const comment = await this.db.query.Comment.findFirst({
-        where: and(
-          eq(schema.Comment.id, commentId),
-          eq(schema.Comment.organizationId, this.organizationId),
-          isNull(schema.Comment.deletedAt)
-        ),
-        with: {
-          mentions: {
-            with: {
-              user: {
-                columns: {
-                  id: true,
-                  name: true,
-                },
-              },
-            },
-          },
-          reactions: true, // Include all reactions for processing
-        },
-      })
-      if (!comment) {
-        return null
-      }
-      await this.assertCanAccessRecord(
-        toRecordId(comment.entityDefinitionId, comment.entityId),
-        `You don't have access to this comment`
-      )
-      // Fetch attachments for this single comment
-      const attachmentMap = await this.fetchAttachmentsForComments([commentId])
-      // Process and optimize the reaction data
-      const processedReactions = this.aggregateReactions(comment.reactions, this.userId)
-      // Convert to CommentWithAttachments format
-      return {
-        ...comment,
-        reactions: processedReactions,
-        attachments: attachmentMap.get(commentId) || [],
-      } as CommentWithAttachments
-    } catch (error) {
-      logger.error('Error in getById', { error, commentId, organizationId: this.organizationId })
+    logger.info('Fetching comment with attachments', {
+      commentId,
+      organizationId: this.organizationId,
+    })
+    this.capabilities?.assert(PermissionKey.commentsView)
+    // Get the comment with all related data including reactions and references.
+    // Note: createdBy/pinnedBy removed - frontend uses useActor hook to resolve user info
+    const comment = await this.db.query.Comment.findFirst({
+      where: and(
+        eq(schema.Comment.id, commentId),
+        eq(schema.Comment.organizationId, this.organizationId),
+        isNull(schema.Comment.deletedAt)
+      ),
+      with: {
+        references: true,
+        reactions: true, // Include all reactions for processing
+      },
+    })
+    if (!comment) {
       return null
     }
+    await this.assertCanAccessRecord(
+      toRecordId(comment.entityDefinitionId, comment.entityId),
+      `You don't have access to this comment`
+    )
+    // Fetch attachments for this single comment
+    const attachmentMap = await this.fetchAttachmentsForComments([commentId])
+    // Process and optimize the reaction data
+    const processedReactions = this.aggregateReactions(comment.reactions, this.userId)
+    // Convert to CommentWithAttachments format
+    return {
+      ...comment,
+      reactions: processedReactions,
+      attachments: attachmentMap.get(commentId) || [],
+    } as CommentWithAttachments
   }
   /**
    * Verify access to file attachments
@@ -977,10 +1172,7 @@ export class CommentService {
           columns: { id: true },
         })
         if (!asset) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message: `MediaAsset not found or you don't have access to it`,
-          })
+          throw new ForbiddenError(`MediaAsset not found or you don't have access to it`)
         }
       } else if (attachment.type === 'file') {
         const folderFile = await this.db.query.FolderFile.findFirst({
@@ -991,10 +1183,7 @@ export class CommentService {
           columns: { id: true },
         })
         if (!folderFile) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message: `FolderFile not found or access denied: ${attachment.id}`,
-          })
+          throw new ForbiddenError(`FolderFile not found or access denied: ${attachment.id}`)
         }
       }
     }
@@ -1053,10 +1242,11 @@ export class CommentService {
    */
   private async recalculateLatestCommentId(threadId: string): Promise<void> {
     try {
+      const threadDefinitionKeys = await this.equivalentDefinitionKeys('thread')
       const latest = await this.db.query.Comment.findFirst({
         where: and(
           eq(schema.Comment.entityId, threadId),
-          eq(schema.Comment.entityDefinitionId, 'thread'),
+          inArray(schema.Comment.entityDefinitionId, threadDefinitionKeys),
           isNull(schema.Comment.deletedAt)
         ),
         columns: { id: true },

--- a/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
+++ b/packages/lib/src/permissions/capabilities/compose-user-capabilities.test.ts
@@ -127,6 +127,37 @@ describe('composeUserCapabilities (leveled model, sparse jsonb)', () => {
     expect(sorted(caps.keys)).toEqual(sorted(WORKER_SEAT_KEYS))
   })
 
+  it('splits comments into Read and Full without changing the Member baseline', () => {
+    const readOnly = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      profileLevels: { [Area.comments]: Level.Read },
+      typeAccessRows: [],
+    })
+    expect(readOnly.keys).toContain(PermissionKey.commentsView)
+    expect(readOnly.keys).not.toContain(PermissionKey.commentsManage)
+
+    const member = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'full',
+      profileLevels: MEMBER_BASELINE_LEVELS,
+      typeAccessRows: [],
+    })
+    expect(member.keys).toContain(PermissionKey.commentsView)
+    expect(member.keys).toContain(PermissionKey.commentsManage)
+  })
+
+  it('keeps comments unliftably disabled for worker seats', () => {
+    const caps = composeUserCapabilities({
+      role: 'USER',
+      seatType: 'worker',
+      profileLevels: { [Area.comments]: Level.Full },
+      typeAccessRows: [],
+    })
+    expect(caps.keys).not.toContain(PermissionKey.commentsView)
+    expect(caps.keys).not.toContain(PermissionKey.commentsManage)
+  })
+
   it('the profile base falls through PER AREA: sets records=Read, workflows unset now composes None (plan 22 §2.5)', () => {
     const caps = composeUserCapabilities({
       role: 'USER',

--- a/packages/lib/src/permissions/capabilities/registry.ts
+++ b/packages/lib/src/permissions/capabilities/registry.ts
@@ -31,6 +31,7 @@ export enum PermissionKey {
   agentsManage = 'agents.manage',
 
   // collaboration
+  commentsView = 'comments.view',
   commentsManage = 'comments.manage',
 
   // dispatch
@@ -184,6 +185,12 @@ export const PERMISSION_REGISTRY: PermissionMetadata[] = [
   },
 
   // ── Collaboration ──
+  {
+    key: PermissionKey.commentsView,
+    label: 'View Comments',
+    description: 'Read comments on records.',
+    group: 'Collaboration',
+  },
   {
     key: PermissionKey.commentsManage,
     label: 'Manage Comments',
@@ -713,9 +720,12 @@ export const PERMISSION_AREAS: Record<Area, AreaMetadata> = {
   [Area.comments]: {
     area: Area.comments,
     label: 'Comments',
-    description: 'Write, edit, and delete comments on records.',
+    description: 'Read, write, edit, and delete comments on records.',
     group: 'Collaboration',
-    rungs: [{ level: Level.Full, keys: [PermissionKey.commentsManage] }],
+    rungs: [
+      { level: Level.Read, keys: [PermissionKey.commentsView] },
+      { level: Level.Full, keys: [PermissionKey.commentsManage] },
+    ],
   },
   [Area.dispatchBoard]: {
     area: Area.dispatchBoard,

--- a/packages/lib/src/resource-access/index.ts
+++ b/packages/lib/src/resource-access/index.ts
@@ -20,6 +20,7 @@ export {
   assertCanManageMailSharing,
   assertCanManageMailTypeAccess,
   assertMailSharingFeature,
+  inboxAccessRecordId,
   isMailSharingDef,
 } from './mail-sharing-guard'
 // Service functions

--- a/packages/lib/src/resource-access/mail-sharing-guard.ts
+++ b/packages/lib/src/resource-access/mail-sharing-guard.ts
@@ -44,7 +44,10 @@ export { isMailSharingDef } from './mail-sharing-defs'
  * pre-split behaviour for every input and fails CLOSED for a personal mailbox
  * (its slug-keyed rows simply don't match).
  */
-async function inboxAccessRecordId(organizationId: string, inboxId: string): Promise<RecordId> {
+export async function inboxAccessRecordId(
+  organizationId: string,
+  inboxId: string
+): Promise<RecordId> {
   const inboxes = await getOrgCache().get(organizationId, 'inboxes')
   const defKey = inboxes.find((i) => i.id === inboxId)?.entityDefinitionKey
   return toRecordId(defKey && isInboxDef(defKey) ? defKey : 'inbox', inboxId)

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -712,7 +712,7 @@ export async function deleteEntity(
   }
 
   // Delete comments using RecordId
-  const commentService = new CommentService(ctx.organizationId, ctx.userId, ctx.db)
+  const commentService = new CommentService(ctx.organizationId, ctx.userId, ctx.db, null)
   await commentService.deleteCommentsByRecordId(recordId)
 
   const deleteResult = await deleteEntityInstance({

--- a/packages/lib/src/threads/__tests__/thread-comment-cascade.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-comment-cascade.test.ts
@@ -1,0 +1,129 @@
+// packages/lib/src/threads/__tests__/thread-comment-cascade.test.ts
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getCachedResources,
+  inArrayBatches,
+  markMailCountsStaleForOrgMembers,
+  publishThreadDeleted,
+} = vi.hoisted(() => ({
+  getCachedResources: vi.fn(),
+  inArrayBatches: [] as string[][],
+  markMailCountsStaleForOrgMembers: vi.fn(),
+  publishThreadDeleted: vi.fn(),
+}))
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return {
+    ...actual,
+    inArray: (_column: unknown, values: unknown[] | readonly unknown[]) => {
+      inArrayBatches.push([...values] as string[])
+      return actual.sql`true`
+    },
+  }
+})
+vi.mock('../../cache', () => ({
+  getCachedResources,
+  getOrgCache: vi.fn(),
+}))
+vi.mock('../../events/publisher', () => ({
+  publisher: { publishLater: vi.fn() },
+}))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: vi.fn(() => ({ marker: 'realtime' })),
+  publishThreadDeleted,
+  publishThreadUpdated: vi.fn(),
+}))
+vi.mock('../mail-counts', () => ({ markMailCountsStaleForOrgMembers }))
+
+const { ThreadMutationService } = await import('../thread-mutation.service')
+
+const organizationId = 'org_1'
+
+function databaseWithDeletedThreads(
+  deletedThreads: Array<{ id: string; inboxId: string | null; assigneeId: string | null }>
+): {
+  db: Database
+  operations: string[]
+  transaction: ReturnType<typeof vi.fn>
+} {
+  const operations: string[] = []
+  let deleteCount = 0
+  const tx = {
+    delete: vi.fn(() => {
+      deleteCount += 1
+      if (deleteCount === 1) {
+        operations.push('thread')
+        return {
+          where: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue(deletedThreads),
+          })),
+        }
+      }
+      if (deleteCount === 2) {
+        operations.push('comment')
+        return { where: vi.fn().mockResolvedValue(undefined) }
+      }
+      throw new Error('Unexpected delete table')
+    }),
+  }
+  const transaction = vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+    callback(tx)
+  )
+  return {
+    db: { transaction } as unknown as Database,
+    operations,
+    transaction,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  inArrayBatches.length = 0
+  getCachedResources.mockResolvedValue([
+    {
+      id: 'thread',
+      apiSlug: 'thread',
+      entityDefinitionId: 'def_thread',
+      entityType: 'thread',
+    },
+  ])
+  publishThreadDeleted.mockResolvedValue(undefined)
+  markMailCountsStaleForOrgMembers.mockResolvedValue(undefined)
+})
+
+describe('thread permanent-delete comment cascade', () => {
+  it('does not delete comments when the single thread does not exist', async () => {
+    const { db, operations, transaction } = databaseWithDeletedThreads([])
+    const service = new ThreadMutationService(organizationId, db, undefined, undefined, {
+      kind: 'system',
+    })
+
+    await expect(service.deletePermanently('thread_missing')).rejects.toThrow(
+      'Thread thread_missing not found for deletion'
+    )
+    expect(transaction).toHaveBeenCalledOnce()
+    expect(operations).toEqual(['thread'])
+    expect(publishThreadDeleted).not.toHaveBeenCalled()
+  })
+
+  it('bulk-deletes comments only for threads actually deleted in the transaction', async () => {
+    const deleted = [{ id: 'thread_1', inboxId: 'inbox_1', assigneeId: null }]
+    const { db, operations, transaction } = databaseWithDeletedThreads(deleted)
+    const service = new ThreadMutationService(organizationId, db, undefined, undefined, {
+      kind: 'system',
+    })
+
+    await expect(service.bulkDeletePermanently(['thread_1', 'thread_missing'])).resolves.toEqual({
+      count: 1,
+    })
+    expect(transaction).toHaveBeenCalledOnce()
+    expect(operations).toEqual(['thread', 'comment'])
+    expect(inArrayBatches[0]).toEqual(['thread_1', 'thread_missing'])
+    expect(inArrayBatches[1]).toEqual(['thread_1'])
+    expect(publishThreadDeleted).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -5,11 +5,12 @@ import { createScopedLogger } from '@auxx/logger'
 import { type ActorId, parseActorId } from '@auxx/types/actor'
 import { getInstanceId, parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { and, eq, exists, ilike, inArray, notExists, or, sql } from 'drizzle-orm'
-import { getOrgCache } from '../cache'
+import { getCachedResources, getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import { publisher } from '../events/publisher'
 import { FieldValueService } from '../field-values'
 import { toInboxRecordId } from '../inbox-record-ids'
+import { buildDefIdToSlug } from '../permissions/capabilities/resolve-capability-inputs'
 import type { MailViewer } from '../permissions/visibility/context'
 import { getRealtimeService, publishThreadDeleted, publishThreadUpdated } from '../realtime'
 import type { ThreadMeta } from '../realtime/events'
@@ -116,6 +117,21 @@ export class ThreadMutationService {
    */
   private async assertCanActOnThreads(threadIds: string[]): Promise<void> {
     await assertCanActOnThreads(this.db, this.organizationId, this.viewer, threadIds)
+  }
+
+  /** Comment host spellings that canonicalize to the thread definition. */
+  private async threadCommentDefinitionKeys(): Promise<string[]> {
+    const resources = await getCachedResources(this.organizationId)
+    const toSlug = buildDefIdToSlug(resources)
+    const keys = new Set<string>(['thread'])
+    for (const resource of resources) {
+      if (toSlug(resource.entityDefinitionId) !== 'thread') continue
+      keys.add(resource.id)
+      keys.add(resource.apiSlug)
+      keys.add(resource.entityDefinitionId)
+      if (resource.entityType) keys.add(resource.entityType)
+    }
+    return [...keys]
   }
 
   // ═══════════════════════════════════════════════════════════════
@@ -1081,29 +1097,48 @@ export class ThreadMutationService {
     })
 
     try {
-      const result = await this.db
-        .delete(schema.Thread)
-        .where(
-          and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, this.organizationId))
-        )
-        .returning({
-          id: schema.Thread.id,
-          inboxId: schema.Thread.inboxId,
-          assigneeId: schema.Thread.assigneeId,
-        })
+      const threadDefinitionKeys = await this.threadCommentDefinitionKeys()
+      const result = await this.db.transaction(async (tx) => {
+        const deletedThreads = await tx
+          .delete(schema.Thread)
+          .where(
+            and(
+              eq(schema.Thread.id, threadId),
+              eq(schema.Thread.organizationId, this.organizationId)
+            )
+          )
+          .returning({
+            id: schema.Thread.id,
+            inboxId: schema.Thread.inboxId,
+            assigneeId: schema.Thread.assigneeId,
+          })
 
-      if (result.length === 0) {
-        logger.error('Thread not found for permanent deletion.', { threadId })
-        throw new Error(`Thread ${threadId} not found for deletion.`)
-      }
+        if (deletedThreads.length === 0) {
+          throw new Error(`Thread ${threadId} not found for deletion.`)
+        }
+
+        await tx
+          .delete(schema.Comment)
+          .where(
+            and(
+              eq(schema.Comment.entityId, deletedThreads[0]!.id),
+              inArray(schema.Comment.entityDefinitionId, threadDefinitionKeys),
+              eq(schema.Comment.organizationId, this.organizationId)
+            )
+          )
+
+        return deletedThreads
+      })
+
+      const deletedThread = result[0]!
 
       await publishThreadDeleted(
         getRealtimeService(),
         this.organizationId,
         {
           threadId,
-          inboxId: result[0].inboxId ?? null,
-          assigneeId: result[0].assigneeId ?? null,
+          inboxId: deletedThread.inboxId ?? null,
+          assigneeId: deletedThread.assigneeId ?? null,
         },
         { excludeSocketId: this.socketId }
       )
@@ -1135,19 +1170,37 @@ export class ThreadMutationService {
     })
 
     try {
-      const result = await this.db
-        .delete(schema.Thread)
-        .where(
-          and(
-            inArray(schema.Thread.id, threadIds),
-            eq(schema.Thread.organizationId, this.organizationId)
+      const threadDefinitionKeys = await this.threadCommentDefinitionKeys()
+      const result = await this.db.transaction(async (tx) => {
+        const deletedThreads = await tx
+          .delete(schema.Thread)
+          .where(
+            and(
+              inArray(schema.Thread.id, threadIds),
+              eq(schema.Thread.organizationId, this.organizationId)
+            )
           )
-        )
-        .returning({
-          id: schema.Thread.id,
-          inboxId: schema.Thread.inboxId,
-          assigneeId: schema.Thread.assigneeId,
-        })
+          .returning({
+            id: schema.Thread.id,
+            inboxId: schema.Thread.inboxId,
+            assigneeId: schema.Thread.assigneeId,
+          })
+
+        if (deletedThreads.length > 0) {
+          await tx.delete(schema.Comment).where(
+            and(
+              inArray(
+                schema.Comment.entityId,
+                deletedThreads.map((thread) => thread.id)
+              ),
+              inArray(schema.Comment.entityDefinitionId, threadDefinitionKeys),
+              eq(schema.Comment.organizationId, this.organizationId)
+            )
+          )
+        }
+
+        return deletedThreads
+      })
 
       logger.info('Threads permanently deleted in bulk', {
         requestedCount: threadIds.length,


### PR DESCRIPTION
## Summary

- add a read-only comments capability rung while preserving Full for writes
- enforce parent visibility, authorship, record administration, and mail lens/inbox moderation in the shared comment service
- protect comment routes, attachments, Kopilot tools, client affordances, and thread deletion cascades
- reject direct inbox and personal-inbox comments while preserving parent deletion cleanup

## Verification

- 81 focused `packages/lib` tests passed
- 67 focused `apps/web` tests passed
- staged Biome checks completed in the commit hook
- `git diff --check` passed
- Docker PostgreSQL data check found 28 Full comment grants and zero direct inbox comments; no migration required

## Notes

- notification snippets intentionally remain visible to recipients even when parent access changes
- `comment.getById` returns 403 for an existing comment behind an inaccessible parent