### PR TITLE
fix(permissions): restore personal-channel manage authority

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
@@ -1,7 +1,7 @@
 // ~/app/(protected)/app/settings/channels/_components/integration-routing.tsx
 'use client'
 import type { IntegrationSyncStatus } from '@auxx/database/types'
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -26,13 +26,14 @@ import {
   UserRound,
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { AdminGate } from '~/components/global/admin-gate'
 import { DangerZone } from '~/components/global/danger-zone'
 import { SettingsSection } from '~/components/global/settings-page'
 import { InboxPicker } from '~/components/pickers/inbox-picker'
-import { toRecordId, useRecord, useResource } from '~/components/resources'
+import { useInboxByInstanceId } from '~/components/threads/hooks'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { CalendarSyncToggle } from './calendar-sync-toggle'
@@ -82,23 +83,20 @@ export default function IntegrationRouting({
     ? ((integration.metadata as any)?.allowedSenders ?? [])
     : []
 
-  // Get inbox resource definition
-  const { resource: inboxResource } = useResource('inboxes')
-
-  // Build recordId for the connected inbox
-  const connectedInboxRecordId = useMemo(() => {
-    if (!inboxResource?.id || !integration.inboxId) return undefined
-    return toRecordId(inboxResource.id, integration.inboxId)
-  }, [inboxResource?.id, integration.inboxId])
-
-  // Get connected inbox via useRecord
-  const { record: connectedInbox, isLoading: isConnectedInboxLoading } = useRecord({
-    recordId: connectedInboxRecordId,
-    enabled: !!connectedInboxRecordId,
-  })
-
-  // Determine if we're loading the connected inbox
-  const isLoadingConnectedInbox = !!connectedInboxRecordId && isConnectedInboxLoading
+  /**
+   * The connected inbox, resolved DEF-AWARE (plan 40a §5.1). This used to mint
+   * `toRecordId(useResource('inboxes').id, integration.inboxId)` — always the
+   * SHARED `inbox` def — which after migration 060 addresses a personal mailbox
+   * under a definition that no longer owns it. `record.getByIds` then returned
+   * nothing (`Some entity instances not found`) and the routing card rendered a
+   * nameless inbox. `useInboxes` fetches both defs and mints each inbox's
+   * RecordId from its own, so this is correct for shared and personal alike.
+   */
+  const { inbox: connectedInbox, isLoading: isConnectedInboxLoading } = useInboxByInstanceId(
+    integration.inboxId
+  )
+  const connectedInboxRecordId = connectedInbox?.recordId
+  const isLoadingConnectedInbox = !!integration.inboxId && isConnectedInboxLoading
 
   const moveThreads = api.inbox.moveIntegrationThreads.useMutation({
     onSuccess: () => {
@@ -322,7 +320,7 @@ export default function IntegrationRouting({
                     {isLoadingConnectedInbox ? (
                       <Skeleton className='h-3 w-24' />
                     ) : (
-                      <span className='text-sm font-medium'>{connectedInbox?.displayName}</span>
+                      <span className='text-sm font-medium'>{connectedInbox?.name}</span>
                     )}
                     <span className='text-xs text-muted-foreground'>
                       {isPersonalChannel
@@ -468,6 +466,9 @@ function AllowedSendersSection({
 }) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const hasEntries = allowedSenders.length > 0
+  // `channel.updateAllowedSenders` gates on `channels.manage`, so mirror the
+  // capability rather than the legacy ADMIN/OWNER role.
+  const { can } = useAccess()
 
   return (
     <SettingsSection
@@ -508,8 +509,8 @@ function AllowedSendersSection({
             )}
           </div>
         </div>
-        {/* Forwarding channels are always shared — admin-only regardless of canManage. */}
-        <AdminGate action='edit allowed senders'>
+        {/* Forwarding channels are always shared — `channels.manage` regardless of canManage. */}
+        <AdminGate action='edit allowed senders' allow={can(PermissionKey.channelsManage)}>
           <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
             {hasEntries ? <Edit /> : <Plus />}
             {hasEntries ? 'Edit' : 'Add senders'}

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-tabs.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-tabs.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
@@ -7,7 +8,6 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation'
 // ~/app/(protected)/app/settings/channels/_components/integration-tabs.tsx
 import { useState } from 'react'
 import { useChannel, useChannelsLoading } from '~/components/channels/hooks/use-channels'
-import { useAdminGate } from '~/components/global/admin-gate'
 import {
   getIntegrationStatus,
   IntegrationStatusIndicator,
@@ -15,6 +15,8 @@ import {
 import { ReauthBanner } from '~/components/global/reauth-banner'
 import SettingsPage from '~/components/global/settings-page'
 import { useInboxes } from '~/components/threads/hooks'
+import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 import IntegrationRouting from './integration-routing'
 import IntegrationSettingsAdvanced from './integration-settings-advanced'
 
@@ -32,14 +34,19 @@ export default function IntegrationTabs() {
   const isIntegrationsLoading = useChannelsLoading()
   const integration = useChannel(integrationId)
 
-  // Admin, or owner of this personal channel (mirrors requireChannelManageAccess).
-  const { isAdminOrOwner, userId } = useAdminGate()
+  // `channels.manage`, or the owner of this personal channel — the client mirror
+  // of `requireChannelManageAccess`. Keyed on the CAPABILITY, not the legacy
+  // ADMIN/OWNER role: the server gate is `channels.manage`, so a member granted
+  // it through a permission profile must not land on a read-only page.
+  const { can } = useAccess()
+  const { userId } = useUser()
+  const canManageAnyChannel = can(PermissionKey.channelsManage)
   const { inboxes } = useInboxes()
   const linkedInbox = integration?.inboxId
     ? inboxes.find((inbox) => inbox.id === integration.inboxId)
     : undefined
   const canManage =
-    isAdminOrOwner || (!!linkedInbox?.isPersonal && linkedInbox.ownerUserId === userId)
+    canManageAnyChannel || (!!linkedInbox?.isPersonal && linkedInbox.ownerUserId === userId)
 
   // Handle tab change
   const handleTabChange = (value: string) => {
@@ -47,9 +54,21 @@ export default function IntegrationTabs() {
     router.push(`/app/settings/channels/${integrationId}?tab=${value}`, { scroll: false })
   }
 
-  // Handle back button click
+  /**
+   * Where "back" goes. The Channels list page is guarded on `channels.manage`
+   * (`settings/channels/page.tsx`), so a personal-channel owner who reached this
+   * page from their inbox would be bounced by the page guard. Send them back to
+   * the inbox they came from instead.
+   */
+  const parentCrumb = canManageAnyChannel
+    ? { title: 'Channels', href: '/app/settings/channels' }
+    : {
+        title: linkedInbox?.name ?? 'Inboxes',
+        href: linkedInbox ? `/app/settings/inbox/${linkedInbox.id}` : '/app/settings/inbox',
+      }
+
   const handleBack = () => {
-    router.push('/app/settings/channels')
+    router.push(parentCrumb.href)
   }
 
   // Loading state
@@ -60,7 +79,7 @@ export default function IntegrationTabs() {
         description={'Manage your integration settings'}
         breadcrumbs={[
           { title: 'Settings', href: '/app/settings' },
-          { title: 'Channels', href: '/app/settings/channels' },
+          parentCrumb,
           { title: 'Loading...' },
         ]}>
         <div className='space-y-6 p-3 sm:p-6'>
@@ -76,7 +95,7 @@ export default function IntegrationTabs() {
       <div className='space-y-6'>
         <Button variant='outline' size='sm' onClick={handleBack}>
           <ArrowLeft className='mr-2 h-4 w-4' />
-          Back to Channels
+          Back to {parentCrumb.title}
         </Button>
         <div className='rounded-md border p-8 text-center'>
           <h2 className='text-xl font-bold'>Integration not found</h2>
@@ -84,7 +103,7 @@ export default function IntegrationTabs() {
             The requested integration could not be found. It may have been removed.
           </p>
           <Button className='mt-4' onClick={handleBack}>
-            Return to Channels
+            Return to {parentCrumb.title}
           </Button>
         </div>
       </div>
@@ -107,11 +126,7 @@ export default function IntegrationTabs() {
       <SettingsPage
         title={title}
         description={integration.identifier || 'Manage your integration settings'}
-        breadcrumbs={[
-          { title: 'Settings', href: '/app/settings' },
-          { title: 'Channels', href: '/app/settings/channels' },
-          { title },
-        ]}
+        breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, parentCrumb, { title }]}
         button={
           <div className='flex items-center gap-3'>
             <IntegrationStatusIndicator

--- a/apps/web/src/components/channels/ui/channel-card.tsx
+++ b/apps/web/src/components/channels/ui/channel-card.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/channels/ui/channel-card.tsx
 'use client'
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import {
   ListCard,
   type ListCardBadgeChip,
@@ -12,9 +13,10 @@ import { toastError } from '@auxx/ui/components/toast'
 import { format } from 'date-fns'
 import { ExternalLink, Plug, Power, RefreshCw, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useAdminGate } from '~/components/global/admin-gate'
 import type { InboxItem } from '~/components/threads/hooks'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { useChannelReconnect } from '../hooks/use-channel-reconnect'
 import type { Channel } from '../store/channel-store'
@@ -47,11 +49,16 @@ export function ChannelCard({ channel, inboxes }: { channel: Channel; inboxes: I
     ? inboxes.find((inbox) => inbox.id === channel.inboxId)
     : undefined
 
-  // Members manage their own personal channels; shared channels are admin-only
-  // (mirrors the server's requireChannelManageAccess).
-  const { isAdminOrOwner, userId } = useAdminGate()
+  // Members manage their own personal channels; shared channels need
+  // `channels.manage` (mirrors the server's requireChannelManageAccess). Keyed on
+  // the capability, not the legacy ADMIN/OWNER role — the server gate is the
+  // capability, so a profile-granted member would otherwise see every action
+  // disabled on a page they are allowed to use.
+  const { can } = useAccess()
+  const { userId } = useUser()
   const canManage =
-    isAdminOrOwner || (!!linkedInbox?.isPersonal && linkedInbox.ownerUserId === userId)
+    can(PermissionKey.channelsManage) ||
+    (!!linkedInbox?.isPersonal && linkedInbox.ownerUserId === userId)
 
   const isForwarding =
     channel.provider === 'email' &&

--- a/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
+++ b/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { KbdSubmit } from '@auxx/ui/components/kbd'
@@ -18,10 +19,10 @@ import {
 } from '~/components/apps/hooks/use-connect-flow'
 import { platformScope, platformTarget } from '~/components/connections/ui/connection-targets'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { useAdminGate } from '~/components/global/admin-gate'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { TemplateGalleryDialog } from '~/components/templates/ui'
 import { BaseType } from '~/components/workflow/types'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { CHANNEL_CATALOG, CHANNEL_CATEGORIES, type ChannelCatalogItem } from '../catalog'
 import { getIntegrationProviderIcon } from './channel-icon'
@@ -56,7 +57,11 @@ export function ChannelGalleryDialog({
 }: ChannelGalleryDialogProps) {
   const router = useRouter()
   const utils = api.useUtils()
-  const { isAdminOrOwner } = useAdminGate()
+  // `channel.prepareConnect` requires `channels.manage` for a SHARED connect and
+  // is open to every member for a personal one, so gate the catalog on that same
+  // capability rather than the legacy ADMIN/OWNER role.
+  const { can } = useAccess()
+  const canConnectShared = can(PermissionKey.channelsManage)
 
   // Members can only connect personal email accounts — everything else in the
   // catalog is a shared (admin-only) channel.
@@ -64,12 +69,12 @@ export function ChannelGalleryDialog({
     () =>
       personalOnly
         ? CHANNEL_CATALOG.filter((item) => item.kind === 'oauth-email')
-        : isAdminOrOwner
+        : canConnectShared
           ? CHANNEL_CATALOG
           : CHANNEL_CATALOG.map((item) =>
               item.kind === 'oauth-email' ? item : { ...item, disabled: true }
             ),
-    [isAdminOrOwner, personalOnly]
+    [canConnectShared, personalOnly]
   )
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -81,7 +86,7 @@ export function ChannelGalleryDialog({
   // Shared detail state, reset on detail exit. Non-admins start on (and are
   // effectively limited to) the personal scope.
   const defaultScope: 'shared' | 'personal' =
-    personalOnly || !isAdminOrOwner ? 'personal' : 'shared'
+    personalOnly || !canConnectShared ? 'personal' : 'shared'
   const inbox = useInboxDestination(initialInboxId, { enabled: !personalOnly })
   const [scope, setScope] = useState<'shared' | 'personal'>(defaultScope)
   const [clientId, setClientId] = useState('')

--- a/apps/web/src/components/inbox/inbox-detail.tsx
+++ b/apps/web/src/components/inbox/inbox-detail.tsx
@@ -14,6 +14,7 @@ import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { OrphanedPersonalInboxBanner } from '~/components/mail-permissions/ui/orphaned-inbox-banner'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useUser } from '~/hooks/use-user'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { Channel } from '../channels/store/channel-store'
@@ -32,6 +33,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
   const router = useRouter()
   const utils = api.useUtils()
   const { can, canAdminInstance, isLoading: isLoadingCapabilities } = useAccess()
+  const { userId } = useUser()
   const [confirm, ConfirmDialog] = useConfirm()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [galleryOpen, setGalleryOpen] = useState(false)
@@ -48,7 +50,26 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
   // The dehydrated instance snapshot is the source of truth for settings
   // authority. Use the stable access key, not the record layer's def UUID.
   const canManageInbox = inbox ? canAdminInstance(toInboxAccessRecordId(inbox)) : false
-  const canManageChannels = canManageInbox && can(PermissionKey.channelsManage)
+
+  /**
+   * Three DIFFERENT server gates, previously collapsed into one flag — which
+   * left a member who owns a personal inbox with no way to reach their own
+   * channel (no `channels.manage`, so the tile lost its link AND its menu):
+   *
+   * - Opening the channel's settings page answers to `requireChannelManageAccess`
+   *   (`manage-access.ts`): `channels.manage` OR the owner of a PERSONAL channel.
+   *   Inbox Manager is not part of it, and the ownership carve-out is the half
+   *   that matters here (§11).
+   * - Unrouting answers to `inbox.removeIntegration`: `channels.manage` AND
+   *   inbox Manager, no carve-out.
+   * - Connecting additionally cannot target a personal inbox at all —
+   *   `addIntegration` and `assertSharedConnectInbox` both reject one — so those
+   *   affordances stay off there instead of offering a guaranteed 400.
+   */
+  const canOpenChannel =
+    can(PermissionKey.channelsManage) || (!!inbox?.isPersonal && inbox.ownerUserId === userId)
+  const canRouteChannels = canManageInbox && can(PermissionKey.channelsManage)
+  const canConnectChannels = canRouteChannels && !inbox?.isPersonal
 
   const isLoading = isLoadingInbox || isLoadingIntegrations || isLoadingCapabilities
 
@@ -85,7 +106,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
   /** Connect an already-connected channel to this inbox, offering to move its threads. */
   const handleConnectExisting = async (channel: Channel) => {
     setPickerOpen(false)
-    if (!inbox || !canManageChannels || channel.inboxId === inbox.id) return
+    if (!inbox || !canConnectChannels || channel.inboxId === inbox.id) return
 
     const hasDefault = (integrations ?? []).some((i) => i.isDefault)
     try {
@@ -125,7 +146,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
 
   /** Remove a channel from this inbox after confirmation (unassigns routing). */
   const handleRemove = async (integration: InboxIntegration) => {
-    if (!canManageChannels) return
+    if (!canRouteChannels) return
 
     const confirmed = await confirm({
       title: 'Remove channel?',
@@ -186,10 +207,11 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
                         integration={integration}
                         onRemove={handleRemove}
                         removePending={removeIntegration.isPending}
-                        canManage={canManageChannels}
+                        canOpen={canOpenChannel}
+                        canRemove={canRouteChannels}
                       />
                     ))}
-                    {canManageChannels && (
+                    {canConnectChannels && (
                       <InboxChannelPlaceholderCard
                         onConnectNew={() => setGalleryOpen(true)}
                         onConnectExisting={() => setPickerOpen(true)}
@@ -224,14 +246,14 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
           onOpenChange={setDialogOpen}
           recordId={inbox.recordId}
           inboxSummary={inbox}
-          canDelete={canManageChannels && !inbox.isPersonal}
+          canDelete={canRouteChannels && !inbox.isPersonal}
           onSuccess={() => utils.inbox.getIntegrations.invalidate({ inboxId })}
           onDeleted={() => router.replace('/app/settings/inbox')}
         />
       )}
 
       {/* Connect gallery, pre-scoped to this inbox as the delivery destination */}
-      {inbox && canManageChannels && (
+      {inbox && canConnectChannels && (
         <ChannelGalleryDialog
           open={galleryOpen}
           onOpenChange={setGalleryOpen}
@@ -240,7 +262,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
       )}
 
       {/* Connect an existing channel — reassigns it onto this inbox */}
-      {inbox && canManageChannels && (
+      {inbox && canConnectChannels && (
         <ConnectExistingChannelDialog
           open={pickerOpen}
           onOpenChange={setPickerOpen}

--- a/apps/web/src/components/inbox/ui/inbox-channel-card.test.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-channel-card.test.tsx
@@ -48,8 +48,15 @@ beforeEach(() => {
 })
 
 describe('InboxChannelCard channel-management affordances', () => {
-  it('is read-only for an inbox Manager without channels.manage', () => {
-    render(<InboxChannelCard integration={integration} onRemove={vi.fn()} canManage={false} />)
+  it('is fully read-only when the viewer may neither open nor unroute', () => {
+    render(
+      <InboxChannelCard
+        integration={integration}
+        onRemove={vi.fn()}
+        canOpen={false}
+        canRemove={false}
+      />
+    )
 
     expect(listCard).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -61,7 +68,7 @@ describe('InboxChannelCard channel-management affordances', () => {
 
   it('keeps channel navigation and removal for a channel manager', () => {
     const onRemove = vi.fn()
-    render(<InboxChannelCard integration={integration} onRemove={onRemove} canManage />)
+    render(<InboxChannelCard integration={integration} onRemove={onRemove} canOpen canRemove />)
 
     const props = listCard.mock.calls[0]?.[0]
     expect(props.href).toBe('/app/settings/channels/channel_1')
@@ -69,5 +76,30 @@ describe('InboxChannelCard channel-management affordances', () => {
 
     props.menuItems[1].onClick()
     expect(onRemove).toHaveBeenCalledWith(integration)
+  })
+
+  // The personal-inbox owner case: `requireChannelManageAccess` lets them manage
+  // their own channel, but `inbox.removeIntegration` still wants `channels.manage`.
+  // Collapsing both into one flag left them with no link and no menu at all.
+  it('keeps the channel reachable when the viewer may open but not unroute', () => {
+    render(
+      <InboxChannelCard integration={integration} onRemove={vi.fn()} canOpen canRemove={false} />
+    )
+
+    const props = listCard.mock.calls[0]?.[0]
+    expect(props.href).toBe('/app/settings/channels/channel_1')
+    expect(props.menuItems).toHaveLength(1)
+    expect(props.menuItems[0].label).toBe('Open')
+  })
+
+  it('offers only removal when the viewer may unroute but not open', () => {
+    render(
+      <InboxChannelCard integration={integration} onRemove={vi.fn()} canOpen={false} canRemove />
+    )
+
+    const props = listCard.mock.calls[0]?.[0]
+    expect(props.href).toBeUndefined()
+    expect(props.menuItems).toHaveLength(1)
+    expect(props.menuItems[0].label).toBe('Remove from inbox')
   })
 })

--- a/apps/web/src/components/inbox/ui/inbox-channel-card.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-channel-card.tsx
@@ -32,8 +32,14 @@ interface InboxChannelCardProps {
   integration: InboxIntegration
   onRemove: (integration: InboxIntegration) => void
   removePending?: boolean
-  /** Whether channel navigation and routing controls should be available. */
-  canManage: boolean
+  /**
+   * Whether the viewer may open the channel's own settings page — the client
+   * mirror of `requireChannelManageAccess`, which carves out the owner of a
+   * personal channel. NOT the same gate as {@link canRemove}.
+   */
+  canOpen: boolean
+  /** Whether the viewer may unroute the channel from this inbox. */
+  canRemove: boolean
 }
 
 /**
@@ -41,12 +47,18 @@ interface InboxChannelCardProps {
  * provider/email subtitle, a live status dot (from the channel store, falling
  * back to "Connected"), and a "Default" chip. The three-dot menu opens the
  * channel detail or removes the channel from this inbox (unassign, not disconnect).
+ *
+ * The two affordances answer to two different server gates, so they take two
+ * props: opening follows `requireChannelManageAccess` (`channels.manage` OR
+ * personal-channel owner), while removal follows `inbox.removeIntegration`
+ * (`channels.manage` AND inbox Manager, with no ownership carve-out).
  */
 export function InboxChannelCard({
   integration,
   onRemove,
   removePending,
-  canManage,
+  canOpen,
+  canRemove,
 }: InboxChannelCardProps) {
   const router = useRouter()
   const { integrationId } = integration
@@ -58,22 +70,23 @@ export function InboxChannelCard({
 
   const providerName = getChannelProviderName(provider)
 
-  const menuItems: ListCardMenuItem[] | undefined = canManage
-    ? [
-        {
-          label: 'Open',
-          icon: <ExternalLink />,
-          onClick: () => router.push(`${DETAIL_BASE}/${integrationId}`),
-        },
-        {
-          label: 'Remove from inbox',
-          icon: <Trash2 />,
-          destructive: true,
-          disabled: removePending,
-          onClick: () => onRemove(integration),
-        },
-      ]
-    : undefined
+  const menuItems: ListCardMenuItem[] = []
+  if (canOpen) {
+    menuItems.push({
+      label: 'Open',
+      icon: <ExternalLink />,
+      onClick: () => router.push(`${DETAIL_BASE}/${integrationId}`),
+    })
+  }
+  if (canRemove) {
+    menuItems.push({
+      label: 'Remove from inbox',
+      icon: <Trash2 />,
+      destructive: true,
+      disabled: removePending,
+      onClick: () => onRemove(integration),
+    })
+  }
 
   return (
     <ListCard
@@ -82,8 +95,8 @@ export function InboxChannelCard({
       subtitle={email ? `${providerName} · ${email}` : providerName}
       status={status}
       headerEnd={integration.isDefault ? renderBadgeChips([{ label: 'Default' }]) : undefined}
-      href={canManage ? `${DETAIL_BASE}/${integrationId}` : undefined}
-      menuItems={menuItems}
+      href={canOpen ? `${DETAIL_BASE}/${integrationId}` : undefined}
+      menuItems={menuItems.length > 0 ? menuItems : undefined}
       descriptionLines={0}
     />
   )

--- a/apps/web/src/server/api/routers/label-channel-authority.test.ts
+++ b/apps/web/src/server/api/routers/label-channel-authority.test.ts
@@ -1,0 +1,237 @@
+// apps/web/src/server/api/routers/label-channel-authority.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The label router's three channel-scoped procedures, driven for real.
+ *
+ * The hole (found while testing personal inboxes, 2026-07-29): `getIntegrationLabels`,
+ * `toggleLabelEnabled` and `discoverFolders` were `permissionProcedure(channels.manage)`
+ * — a COARSE org-wide assert with no per-channel path. The channel settings page is
+ * reachable by the owner of a personal channel (§11: `requireChannelManageAccess`
+ * carves them out, and they hold no `channels.manage` at all), so opening the Routing
+ * tab on their own Gmail/Outlook channel fired
+ * `label.getIntegrationLabels` and got a hard 403 —
+ * "You don't have permission to Manage Channels" — on a channel they own.
+ *
+ * They now authorize on the CHANNEL via `requireChannelManageAccess`, which is the
+ * same authority `channel.toggle` / `syncMessages` / `updateSettings` / `disconnect`
+ * already use, so all of a channel's write surfaces answer to one predicate.
+ *
+ * `toggleLabelEnabled` takes only a `labelId`, so it resolves the label ORG-SCOPED
+ * first and authorizes on the channel that label belongs to. Order matters and is
+ * asserted: a foreign-org label id must 404 before any authorization decision, and a
+ * label whose channel the caller may not manage must be refused before the UPDATE.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_member00000000000000000'
+/** The member's OWN personal channel — `requireChannelManageAccess` allows it. */
+const OWN_CHANNEL = 'int_personal000000000000000'
+/** A shared channel the member has no authority over. */
+const SHARED_CHANNEL = 'int_shared00000000000000000'
+const OWN_LABEL = 'lbl_own00000000000000000000'
+const SHARED_LABEL = 'lbl_shared00000000000000000'
+
+const { world, requireChannelManageAccess, dbCalls, db } = vi.hoisted(() => {
+  const world = {
+    /** Channels this caller may manage (the predicate's answer, stated as a premise). */
+    manageable: new Set<string>(),
+    /** labelId → the channel it belongs to. Absent ⇒ no such label in this org. */
+    labels: {} as Record<string, string | undefined>,
+  }
+
+  const requireChannelManageAccess = vi.fn(async (_ctx: unknown, integrationId: string) => {
+    if (world.manageable.has(integrationId)) return
+    const error = new Error("You don't have permission to Manage Channels.")
+    error.name = 'ForbiddenError'
+    ;(error as Error & { statusCode: number }).statusCode = 403
+    throw error
+  })
+
+  /** Every db operation the router reached, in order — the ordering assertions read this. */
+  const dbCalls: string[] = []
+
+  /**
+   * Minimal drizzle stand-in. `select` serves the label lookup and the label list;
+   * `update` records that the write was reached. The chain's TERMINAL methods
+   * (`orderBy` / `limit` / `returning` — the ones the router awaits) resolve to the
+   * rows the current `world` implies, so a test never stubs a call sequence.
+   */
+  const selectRows: unknown[] = []
+  const chain = (kind: string) => {
+    const settle = async () => {
+      dbCalls.push(kind)
+      return kind === 'update' ? [{ id: OWN_LABEL }] : (selectRows.shift() ?? [])
+    }
+    const self: Record<string, unknown> = {}
+    for (const m of ['from', 'where', 'set']) self[m] = () => self
+    for (const m of ['orderBy', 'limit', 'returning']) self[m] = settle
+    return self
+  }
+
+  const db = {
+    select: () => chain('select'),
+    update: () => chain('update'),
+    __queueSelect: (rows: unknown) => selectRows.push(rows),
+    __reset: () => {
+      selectRows.length = 0
+      dbCalls.length = 0
+    },
+  }
+
+  return { world, requireChannelManageAccess, dbCalls, db }
+})
+
+vi.mock('@auxx/database', () => ({
+  database: db,
+  schema: {
+    Label: {
+      id: 'Label.id',
+      name: 'Label.name',
+      enabled: 'Label.enabled',
+      updatedAt: 'Label.updatedAt',
+      integrationId: 'Label.integrationId',
+      organizationId: 'Label.organizationId',
+    },
+    Integration: {
+      id: 'Integration.id',
+      organizationId: 'Integration.organizationId',
+      deletedAt: 'Integration.deletedAt',
+      provider: 'Integration.provider',
+    },
+  },
+}))
+vi.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => parts,
+  eq: (a: unknown, b: unknown) => [a, b],
+  isNull: (a: unknown) => a,
+}))
+
+vi.mock('@auxx/lib/channels', () => ({ requireChannelManageAccess }))
+vi.mock('@auxx/lib/email', () => ({
+  FolderDiscoveryService: class {
+    discoverAndUpsert = vi.fn(async () => undefined)
+  },
+  LabelService: class {},
+  ReauthenticationRequiredError: class extends Error {},
+  getUserOrganizationId: () => ORG_ID,
+}))
+vi.mock('@auxx/lib/providers', () => ({
+  ProviderRegistryService: class {
+    getProvider = vi.fn(async () => ({ discoverLabels: async () => [] }))
+  },
+}))
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    protectedProcedure: t.procedure,
+    // Present so an accidental revert to the coarse gate is visible: it asserts
+    // nothing, so a reverted procedure would let an unauthorized caller through
+    // and the "refused" cases below would fail.
+    permissionProcedure: () => t.procedure,
+  }
+})
+
+const { labelRouter } = await import('./label')
+
+const caller = () =>
+  labelRouter.createCaller({
+    db: {},
+    session: { userId: USER_ID, organizationId: ORG_ID, user: { id: USER_ID } },
+  } as never)
+
+/** The shape `auxxErrorMiddleware` maps to a 403. */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+beforeEach(() => {
+  world.manageable.clear()
+  world.labels = { [OWN_LABEL]: OWN_CHANNEL, [SHARED_LABEL]: SHARED_CHANNEL }
+  requireChannelManageAccess.mockClear()
+  db.__reset()
+})
+
+describe('label router — per-channel authority', () => {
+  describe('getIntegrationLabels', () => {
+    it('serves the owner of a personal channel, who holds no channels.manage', async () => {
+      world.manageable.add(OWN_CHANNEL)
+      db.__queueSelect([{ id: OWN_LABEL, name: 'Inbox' }])
+
+      const result = await caller().getIntegrationLabels({ integrationId: OWN_CHANNEL })
+
+      expect(result.labels).toHaveLength(1)
+      expect(requireChannelManageAccess).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: ORG_ID, userId: USER_ID }),
+        OWN_CHANNEL
+      )
+    })
+
+    it('refuses a channel the caller may not manage, before reading any label', async () => {
+      await expect(
+        caller().getIntegrationLabels({ integrationId: SHARED_CHANNEL })
+      ).rejects.toMatchObject(FORBIDDEN)
+
+      expect(dbCalls).toEqual([])
+    })
+  })
+
+  describe('toggleLabelEnabled', () => {
+    it('authorizes on the channel the label belongs to, then writes', async () => {
+      world.manageable.add(OWN_CHANNEL)
+      db.__queueSelect([{ integrationId: OWN_CHANNEL }])
+
+      await caller().toggleLabelEnabled({ labelId: OWN_LABEL, enabled: false })
+
+      expect(requireChannelManageAccess).toHaveBeenCalledWith(expect.anything(), OWN_CHANNEL)
+      // Resolve the label FIRST, authorize, and only then update.
+      expect(dbCalls).toEqual(['select', 'update'])
+    })
+
+    it('refuses before the update when the label belongs to another channel', async () => {
+      world.manageable.add(OWN_CHANNEL)
+      db.__queueSelect([{ integrationId: SHARED_CHANNEL }])
+
+      await expect(
+        caller().toggleLabelEnabled({ labelId: SHARED_LABEL, enabled: true })
+      ).rejects.toMatchObject(FORBIDDEN)
+
+      expect(dbCalls).toEqual(['select'])
+      expect(dbCalls).not.toContain('update')
+    })
+
+    it('404s an unknown label id without making an authorization decision', async () => {
+      world.manageable.add(OWN_CHANNEL)
+      db.__queueSelect([])
+
+      await expect(
+        caller().toggleLabelEnabled({ labelId: 'lbl_foreign', enabled: true })
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+
+      expect(requireChannelManageAccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('discoverFolders', () => {
+    it('refuses a channel the caller may not manage, before touching the provider', async () => {
+      await expect(
+        caller().discoverFolders({ integrationId: SHARED_CHANNEL })
+      ).rejects.toMatchObject(FORBIDDEN)
+
+      expect(dbCalls).toEqual([])
+    })
+
+    it('runs for a channel the caller manages', async () => {
+      world.manageable.add(OWN_CHANNEL)
+      db.__queueSelect([{ id: OWN_CHANNEL, provider: 'google' }])
+      db.__queueSelect([{ id: OWN_LABEL, name: 'Inbox' }])
+
+      const result = await caller().discoverFolders({ integrationId: OWN_CHANNEL })
+
+      expect(result.labels).toHaveLength(1)
+      expect(requireChannelManageAccess).toHaveBeenCalledWith(expect.anything(), OWN_CHANNEL)
+    })
+  })
+})

--- a/apps/web/src/server/api/routers/label.ts
+++ b/apps/web/src/server/api/routers/label.ts
@@ -1,19 +1,19 @@
 // server/api/routers/labels.ts
 
 import { database as db, schema } from '@auxx/database'
+import { requireChannelManageAccess } from '@auxx/lib/channels'
 import {
   FolderDiscoveryService,
   getUserOrganizationId,
   LabelService,
   ReauthenticationRequiredError,
 } from '@auxx/lib/email'
-import { PermissionKey } from '@auxx/lib/permissions'
 import { ProviderRegistryService } from '@auxx/lib/providers'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { and, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
+import { createTRPCRouter, protectedProcedure } from '../trpc'
 
 const logger = createScopedLogger('labels-router')
 
@@ -308,11 +308,22 @@ export const labelRouter = createTRPCRouter({
       }
     }),
 
-  // Get labels for an integration (reads DB directly, bypasses LabelProviderFactory)
-  getIntegrationLabels: permissionProcedure(PermissionKey.channelsManage)
+  /**
+   * Get labels for an integration (reads DB directly, bypasses LabelProviderFactory).
+   *
+   * Per-CHANNEL authority, so it takes `requireChannelManageAccess` rather than a
+   * bare `channels.manage` assert: a member who owns a personal channel manages
+   * its label/folder sync scope (§11), and the coarse key alone 403'd them out of
+   * their own channel's settings page.
+   */
+  getIntegrationLabels: protectedProcedure
     .input(z.object({ integrationId: z.string() }))
     .query(async ({ ctx, input }) => {
       const organizationId = getUserOrganizationId(ctx.session)
+      await requireChannelManageAccess(
+        { db: ctx.db, organizationId, userId: ctx.session.userId },
+        input.integrationId
+      )
       const labels = await db
         .select()
         .from(schema.Label)
@@ -326,11 +337,30 @@ export const labelRouter = createTRPCRouter({
       return { labels }
     }),
 
-  // Toggle Label.enabled (channelsManage — changes sync scope)
-  toggleLabelEnabled: permissionProcedure(PermissionKey.channelsManage)
+  /**
+   * Toggle `Label.enabled` — changes what the channel syncs, so it is authorized
+   * on the CHANNEL the label belongs to (same carve-out as
+   * {@link getIntegrationLabels}). The label is resolved org-scoped first, so an
+   * id from another org is a 404 before any authorization decision is made.
+   */
+  toggleLabelEnabled: protectedProcedure
     .input(z.object({ labelId: z.string(), enabled: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = getUserOrganizationId(ctx.session)
+      const [label] = await db
+        .select({ integrationId: schema.Label.integrationId })
+        .from(schema.Label)
+        .where(
+          and(eq(schema.Label.id, input.labelId), eq(schema.Label.organizationId, organizationId))
+        )
+        .limit(1)
+      if (!label?.integrationId) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Label not found' })
+      }
+      await requireChannelManageAccess(
+        { db: ctx.db, organizationId, userId: ctx.session.userId },
+        label.integrationId
+      )
       const [updated] = await db
         .update(schema.Label)
         .set({ enabled: input.enabled, updatedAt: new Date() })
@@ -341,11 +371,16 @@ export const labelRouter = createTRPCRouter({
       return updated
     }),
 
-  // Discover folders from provider and upsert into Label table (channelsManage)
-  discoverFolders: permissionProcedure(PermissionKey.channelsManage)
+  // Discover folders from provider and upsert into Label table. Per-channel
+  // authority, same carve-out as `getIntegrationLabels`.
+  discoverFolders: protectedProcedure
     .input(z.object({ integrationId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const organizationId = getUserOrganizationId(ctx.session)
+      await requireChannelManageAccess(
+        { db: ctx.db, organizationId, userId: ctx.session.userId },
+        input.integrationId
+      )
 
       // Get integration to find provider type
       const [integration] = await db


### PR DESCRIPTION
A member who owns a personal inbox could not view or edit its channel. Found while testing personal inboxes on `/app/settings/inbox/<id>`: the inbox rendered fine, but its channel tile had no link and no menu.

The carve-out `requireChannelManageAccess` makes for a personal channel's owner (§11) was missing at four points along the path.

## 1. One flag for three different gates — `inbox-detail.tsx`

```ts
const canManageChannels = canManageInbox && can(PermissionKey.channelsManage)
```

A personal-inbox owner holds `canAdminInstance` on their inbox but no `channels.manage`, so this was `false` — and `InboxChannelCard` used it for **both** the menu and the `href`. Dead end. Split into three, each mirroring its actual server gate:

| flag | server authority |
|---|---|
| `canOpenChannel` | `requireChannelManageAccess` — the key **OR** personal-channel owner |
| `canRouteChannels` | `inbox.removeIntegration` — the key **AND** inbox Manager |
| `canConnectChannels` | the above **AND** not personal |

The last one is a deliberate tightening: `inbox.addIntegration` throws `BAD_REQUEST` on a personal inbox at either end, and `assertSharedConnectInbox` rejects one too, so the connect placeholder and both connect dialogs were offering admins a guaranteed 400.

## 2. The dead end past it — `integration-tabs.tsx`

`/app/settings/channels/[integrationId]` carries no page guard, but its breadcrumb and back button pointed at `/app/settings/channels`, which **is** guarded on `channels.manage`. Reaching the channel page only moved the wall. Both now point back at the originating inbox for a viewer without the key.

## 3. The 403 — `label.ts`

`getIntegrationLabels`, `toggleLabelEnabled` and `discoverFolders` were `permissionProcedure(channels.manage)` — coarse, no per-instance path — so opening the Routing tab on your own channel produced:

```
❌ tRPC failed on label.getIntegrationLabels: You don't have permission to Manage Channels.
```

They now authorize on the **channel** via `requireChannelManageAccess`, the same authority `channel.toggle`/`syncMessages`/`updateSettings`/`disconnect`/`resetSyncState` already use, so every write surface on a channel answers to one predicate.

`toggleLabelEnabled` takes only a `labelId`, so it resolves the label **org-scoped first** and authorizes on that label's channel. Order is asserted in tests: a foreign-org id 404s before any authorization decision, and an unauthorized channel is refused before the `UPDATE`.

Moving off `permissionProcedure` was required, not cosmetic — it asserts in middleware, before the handler body, so there is no place to put a per-instance check. `channels.manage` carries no `featureKey`, so no plan-AND was lost.

## 4. Wrong def for a personal inbox — `integration-routing.tsx`

Not a permission bug — plan 40a §5.1. The routing card minted `toRecordId(useResource('inboxes').id, integration.inboxId)`, i.e. always the **shared** `inbox` def, so after migration 060 a personal mailbox was addressed under a definition that no longer owns it:

```
Some entity instances not found by getResourcesByIds
  entityDefinitionId: qiramlz5m0cswo4n4v10mxkz
  missingIds: [ u9byz0ma6yhyhw3z7onbifdr ]
```

The card rendered a nameless inbox. Now resolved through `useInboxByInstanceId`, which fetches both defs and mints each inbox's RecordId from its own. Also drops a `record.getByIds` roundtrip — `useInboxes` is already loaded by the parent.

## Role residue (plan 39)

Four `isAdminOrOwner` reads swapped for `can(PermissionKey.channelsManage)` in `channel-card.tsx`, `integration-tabs.tsx`, `channel-gallery-dialog.tsx` and the allowed-senders gate. The server gates on the capability (`requireChannelManageAccess`, `prepareConnect`, `updateAllowedSenders`), so a member granted `channels.manage` through a permission profile was seeing a read-only page on a surface they are allowed to use.

## Verification

- **240 tests pass** across `components/inbox`, `components/threads/hooks`, and the six mail/inbox router suites, re-run on top of #1395.
- **7 new tests** in `label-channel-authority.test.ts` — the first coverage for any of those three procedures. All three asserts **mutation-verified**: dropping each produces 2 failures, restoring returns green. Unmutated control run confirmed.
- `inbox-channel-card.test.tsx` updated for the split props, **+2 cases** for the open-vs-remove matrix (the personal-owner case is `canOpen && !canRemove`, which the old single flag could not express).
- **No new tsc errors.** The 4 in `integration-tabs.tsx` are pre-existing null-vs-undefined on untouched `IntegrationStatusIndicator`/`ReauthBanner` props — verified present at HEAD on the same lines before my edits shifted them.
- Biome clean on all 9 files.

## Found but deliberately not changed

Both are outside this fix's scope and want their own decision:

- **`label.ts`'s other seven procedures** (`getLabels`, `syncLabels`, `createLabel`, `updateLabel`, `deleteLabel`, `all`, `syncAllLabels`) are bare `protectedProcedure` with **no capability gate at all** — any member can create, rename or delete labels on any channel.
- **`InboxService.removeIntegration` has no personal guard**, so `channels.manage` + inbox Manager can unroute a personal channel from its personal inbox and orphan it. §11 says the only sanctioned exits are admin claim or delete. The UI affordance is left as-is rather than make that product call here.

## Still owed

The browser pass for the shared-inbox side. This was verified live for the personal-inbox owner (the reported case), but an admin's view of the connect affordances on a personal inbox changed and has not been clicked through.