### PR TITLE
feat(mail): let a member delete their own personal inbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,15 +131,6 @@ Before writing an import, check the target package's `package.json` `exports` fi
 
 ## API & Data Handling
 
-### tRPC Procedure Types
-
-| Procedure             | Use for                                                                  |
-| --------------------- | ------------------------------------------------------------------------ |
-| `publicProcedure`     | Unauthenticated routes                                                   |
-| `protectedProcedure`  | Authenticated routes (verifies session + organization)                   |
-| `adminProcedure`      | Admin/owner only (checks via `OrganizationMemberModel.isAdminOrOwner()`) |
-| `superAdminProcedure` | Super admin only (checks `isSuperAdmin` flag)                            |
-
 ### tRPC Context
 
 ```typescript
@@ -183,7 +174,11 @@ called from a worker, seed script, or another lib module. Throw the matching `Au
 router wraps a service call in its own `try/catch`, guard rethrows with `isAuxxError(e)` (exported from
 `~/server/api/trpc`), **not** `e instanceof TRPCError`, or the AuxxError gets flattened into a generic 500.
 
-### Result Pattern (`@auxx/lib/result`)
+### Result Pattern (`@auxx/lib/result`) — LEGACY
+
+New lib code returns `neverthrow` `Result<T, Error>`. See `docs/lib-module-guide.md`.
+`TypedResult` below is only what existing `BaseModel` subclasses still return — don't
+introduce it in new code.
 
 Database models return `TypedResult<V, E>` instead of throwing:
 
@@ -217,9 +212,25 @@ import {
 
 Cached keys (`OrgCacheDataMap`): `entityDefs`, `entityDefSlugs`, `systemUser`, `channelProviders`, `members`, `memberRoleMap`, `features`, `subscription`, `orgProfile`, `resources`, `customFields`, `groups`, `agents`, `inboxes`, `channels`, `overages`, `orgSettings`, `installedApps`, `workflowApps`, `aiProviderConfigs`, `aiCredentials`, `aiDefaultModels`. For anything in this list, prefer `getOrgCache().get(orgId, '<key>')` over a fresh query. Only hit the DB when the data isn't cached or you need a write-after-read consistency guarantee.
 
-## Database Models
+## `packages/lib` Feature Modules
 
-Models extend `BaseModel` with typed CRUD operations and org-scoped queries:
+**Before adding or extending a module in `packages/lib/src/<feature>/`, read
+`docs/lib-module-guide.md`.** `packages/lib` is mixed — newer modules are
+functional Drizzle + `neverthrow`, older ones are service classes with `db` in a
+constructor. The guide names the reference modules to copy (`snippets/` for small,
+`sequences/` for large, `dashboards/`, `signals/`) and the legacy ones not to,
+plus the rules on signatures, file layout, `client.ts`, and why permission checks
+never live in lib.
+
+Short version: exported `async function`s with `db` first (no service classes),
+`Promise<Result<T, Error>>` from `neverthrow`, `AuxxError` subclasses only,
+reads and writes in separate files, explicit named exports, and zero access
+checks in lib — the router asserts and list scopes are applied in SQL.
+
+## Database Models — LEGACY
+
+Existing models extend `BaseModel`. Do NOT add new model classes; put query code
+in `packages/lib` as functions (see above).
 
 ```typescript
 export class ApiKeyModel extends BaseModel<typeof ApiKey, CreateInput, Entity, UpdateInput> {

--- a/apps/web/src/components/inbox/inbox-detail.tsx
+++ b/apps/web/src/components/inbox/inbox-detail.tsx
@@ -71,6 +71,17 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
   const canRouteChannels = canManageInbox && can(PermissionKey.channelsManage)
   const canConnectChannels = canRouteChannels && !inbox?.isPersonal
 
+  /**
+   * Delete mirrors `inbox.delete`'s own branch: a personal mailbox answers to
+   * its OWNER (who holds no `channels.manage`), a shared one to the inventory
+   * key plus Manager. Same shape as the settings list's server-side `canDelete`
+   * (`inbox-settings-access.ts`) — this page has no `settingsList` row to read
+   * it off, so it re-derives it from the capability blob.
+   */
+  const canDeleteInbox = inbox?.isPersonal
+    ? inbox.ownerUserId === userId
+    : !!inbox && canRouteChannels
+
   const isLoading = isLoadingInbox || isLoadingIntegrations || isLoadingCapabilities
 
   const removeIntegration = api.inbox.removeIntegration.useMutation({
@@ -246,7 +257,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
           onOpenChange={setDialogOpen}
           recordId={inbox.recordId}
           inboxSummary={inbox}
-          canDelete={canRouteChannels && !inbox.isPersonal}
+          canDelete={canDeleteInbox}
           onSuccess={() => utils.inbox.getIntegrations.invalidate({ inboxId })}
           onDeleted={() => router.replace('/app/settings/inbox')}
         />

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -434,6 +434,10 @@ export function InboxForm({
   const deleteInbox = api.inbox.delete.useMutation({
     onSuccess: () => {
       invalidateInboxes()
+      // Deleting a PERSONAL inbox disconnects its account and destroys its
+      // mail, so the channel inventory and the sidebar counters move with it.
+      utils.channel.list.invalidate()
+      utils.thread.getCounts.invalidate()
       onClose()
       onDeleted?.()
     },
@@ -497,10 +501,13 @@ export function InboxForm({
   const handleDelete = async () => {
     if (!inboxId) return
 
+    // A personal mailbox is a one-account container, so deleting it also
+    // disconnects that account and destroys its mail — say so before the click.
     const confirmed = await confirm({
-      title: 'Delete inbox?',
-      description:
-        'This will permanently delete this inbox and all its settings. This action cannot be undone.',
+      title: isPersonalInbox ? 'Delete personal inbox?' : 'Delete inbox?',
+      description: isPersonalInbox
+        ? 'This disconnects the connected account and permanently deletes this inbox with all of its mail. This action cannot be undone.'
+        : 'This will permanently delete this inbox and all its settings. This action cannot be undone.',
       confirmText: 'Delete',
       cancelText: 'Cancel',
       destructive: true,

--- a/apps/web/src/components/inbox/inbox-list.tsx
+++ b/apps/web/src/components/inbox/inbox-list.tsx
@@ -58,6 +58,11 @@ export function InboxList() {
   const deleteInbox = api.inbox.delete.useMutation({
     onSuccess: () => {
       void utils.inbox.settingsList.invalidate()
+      void utils.inbox.myLenses.invalidate()
+      // Deleting a PERSONAL inbox disconnects its account and destroys its
+      // mail, so the channel inventory and the sidebar counters move with it.
+      void utils.channel.list.invalidate()
+      void utils.thread.getCounts.invalidate()
     },
     onError: (mutationError) => {
       toastError({ title: 'Error deleting inbox', description: mutationError.message })
@@ -81,8 +86,10 @@ export function InboxList() {
   const handleDeleteInbox = async (inbox: SettingsInboxItem) => {
     if (!inbox.canDelete) return
     const confirmed = await confirm({
-      title: 'Delete inbox?',
-      description: `This will permanently delete "${inbox.name}" and all its settings. This action cannot be undone.`,
+      title: inbox.isPersonal ? 'Delete personal inbox?' : 'Delete inbox?',
+      description: inbox.isPersonal
+        ? `This disconnects the connected account and permanently deletes "${inbox.name}" with all of its mail. This action cannot be undone.`
+        : `This will permanently delete "${inbox.name}" and all its settings. This action cannot be undone.`,
       confirmText: 'Delete',
       cancelText: 'Cancel',
       destructive: true,

--- a/apps/web/src/server/api/routers/inbox-access-floor.test.ts
+++ b/apps/web/src/server/api/routers/inbox-access-floor.test.ts
@@ -86,6 +86,7 @@ vi.mock('@auxx/lib/inbox-record-ids', () => recordIds)
 vi.mock('@auxx/lib/threads', () => ({ ThreadMutationService: class {} }))
 vi.mock('@auxx/lib/channels', () => ({
   claimPersonalInbox: vi.fn(),
+  deleteOwnPersonalInbox: vi.fn(),
   deletePersonalInbox: vi.fn(),
 }))
 vi.mock('~/server/api/audit-context', () => ({ recordAuditFromCtx: vi.fn(async () => undefined) }))

--- a/apps/web/src/server/api/routers/inbox-channel-routing-access.test.ts
+++ b/apps/web/src/server/api/routers/inbox-channel-routing-access.test.ts
@@ -101,7 +101,7 @@ const { world, service } = vi.hoisted(() => {
       integrations: [{ id: 'lnk_1', integrationId: SUPPORT_CHANNEL }],
     })),
     createInbox: vi.fn(async () => ({ id: 'ibx_new0000000000000000000' })),
-    deleteInboxById: vi.fn(async () => undefined),
+    deleteInbox: vi.fn(async () => undefined),
     addIntegration: vi.fn(async () => ({ id: 'lnk_new' })),
     removeIntegration: vi.fn(async () => true),
   }
@@ -117,7 +117,7 @@ vi.mock('@auxx/lib/inboxes', () => ({
     getIntegrationInbox = service.getIntegrationInbox
     getInboxWithIntegrationsById = service.getInboxWithIntegrationsById
     createInbox = service.createInbox
-    deleteInboxById = service.deleteInboxById
+    deleteInbox = service.deleteInbox
     addIntegration = service.addIntegration
     removeIntegration = service.removeIntegration
   },
@@ -130,6 +130,7 @@ const { threadMutation, channels, recordAuditFromCtx } = vi.hoisted(() => ({
   },
   channels: {
     claimPersonalInbox: vi.fn(async () => undefined),
+    deleteOwnPersonalInbox: vi.fn(async () => undefined),
     deletePersonalInbox: vi.fn(async () => undefined),
   },
   recordAuditFromCtx: vi.fn(async () => undefined),
@@ -259,7 +260,7 @@ const PLAIN_MEMBER = () => capabilitiesFor({ channels: Level.None })
 type Caller = ReturnType<typeof caller>
 const CHANNEL_KEYED = [
   ['create', (c: Caller) => c.create({ name: 'Mine' }), () => service.createInbox],
-  ['delete', (c: Caller) => c.delete({ inboxId: OWN_INBOX }), () => service.deleteInboxById],
+  ['delete', (c: Caller) => c.delete({ inboxId: OWN_INBOX }), () => service.deleteInbox],
   [
     'addIntegration',
     (c: Caller) =>
@@ -310,7 +311,7 @@ beforeEach(() => {
     integrations: [{ id: 'lnk_1', integrationId: SUPPORT_CHANNEL }],
   }))
   service.createInbox.mockResolvedValue({ id: 'ibx_new0000000000000000000' } as never)
-  service.deleteInboxById.mockResolvedValue(undefined as never)
+  service.deleteInbox.mockResolvedValue(undefined as never)
   service.addIntegration.mockResolvedValue({ id: 'lnk_new' } as never)
   service.removeIntegration.mockResolvedValue(true as never)
 
@@ -545,7 +546,7 @@ describe('delete keeps its instance assert alongside the new key', () => {
     await expect(caller(CHANNEL_ADMIN()).delete({ inboxId: SUPPORT_INBOX })).rejects.toMatchObject(
       FORBIDDEN_INSTANCE
     )
-    expect(service.deleteInboxById).not.toHaveBeenCalled()
+    expect(service.deleteInbox).not.toHaveBeenCalled()
   })
 
   it('and can delete one they do', async () => {
@@ -553,7 +554,8 @@ describe('delete keeps its instance assert alongside the new key', () => {
     await expect(caller(CHANNEL_ADMIN()).delete({ inboxId: OWN_INBOX })).resolves.toEqual({
       success: true,
     })
-    expect(service.deleteInboxById).toHaveBeenCalledWith(OWN_INBOX)
+    // The RecordId the Manager assert ran against — one resolution, one key.
+    expect(service.deleteInbox).toHaveBeenCalledWith(`inbox:${OWN_INBOX}`)
   })
 })
 
@@ -778,7 +780,6 @@ describe('inbox router — structural invariants', () => {
 
   it.each([
     'create',
-    'delete',
     'addIntegration',
     'removeIntegration',
     'moveIntegrationThreads',
@@ -786,6 +787,16 @@ describe('inbox router — structural invariants', () => {
     'deletePersonal',
   ])('%s builds on permissionProcedure(channelsManage)', (name) => {
     expect(src).toContain(`${name}: permissionProcedure(PermissionKey.channelsManage)`)
+  })
+
+  it('delete keeps the same key, asserted in the BODY so it can branch on the def', () => {
+    // `permissionProcedure` asserts in middleware, before the handler runs, so a
+    // def-aware procedure cannot use it: the personal branch has to be reachable
+    // by an owner who holds no `channels.manage` at all. The key is not dropped
+    // — it moves inside the shared branch. `channelsManage` carries no
+    // `featureKey`, so no plan gate is lost in the swap.
+    expect(src).toContain('delete: capabilityProcedure')
+    expect(src).toContain('ctx.capabilities.assert(PermissionKey.channelsManage)')
   })
 
   it('the mail-side procedures build on the inboxes front door', () => {
@@ -804,7 +815,9 @@ describe('inbox router — structural invariants', () => {
 
   it('the procedure list is exhaustive — a NEW procedure must be gated too', () => {
     const declared = [
-      ...src.matchAll(/^ {2}([a-zA-Z][a-zA-Z0-9]*): (mailProcedure|permissionProcedure)/gm),
+      ...src.matchAll(
+        /^ {2}([a-zA-Z][a-zA-Z0-9]*): (mailProcedure|permissionProcedure|capabilityProcedure)/gm
+      ),
     ].map((m) => m[1] as string)
     expect(declared.sort()).toEqual(
       [
@@ -812,6 +825,9 @@ describe('inbox router — structural invariants', () => {
         'claimPersonal',
         'countMovableThreads',
         'create',
+        // `capabilityProcedure` — the coarse assert lives in the handler body
+        // (see the delete test above) or, for `settingsList`, in the per-row
+        // scoping it returns.
         'delete',
         'deletePersonal',
         'getIntegrations',
@@ -819,6 +835,7 @@ describe('inbox router — structural invariants', () => {
         'myLenses',
         'removeIntegration',
         'setAccessFloor',
+        'settingsList',
       ].sort()
     )
   })

--- a/apps/web/src/server/api/routers/inbox-personal-def-recordid.test.ts
+++ b/apps/web/src/server/api/routers/inbox-personal-def-recordid.test.ts
@@ -30,7 +30,7 @@ const PERSONAL_INBOX = 'ibx_personal000000000000000'
 const SHARED_INBOX = 'ibx_shared00000000000000000'
 const CHANNEL = 'int_channel0000000000000000'
 
-const { world, service } = vi.hoisted(() => {
+const { world, service, channels } = vi.hoisted(() => {
   const world = {
     /** RecordId STRINGS, exactly as the ResourceAccess rows are keyed. */
     manage: new Set<string>(),
@@ -46,11 +46,18 @@ const { world, service } = vi.hoisted(() => {
       id: inboxId,
       integrations: [{ id: 'lnk_1', integrationId: CHANNEL }],
     })),
+    deleteInbox: vi.fn(async () => undefined),
     deleteInboxById: vi.fn(async () => undefined),
     removeIntegration: vi.fn(async () => true),
   }
 
-  return { world, service }
+  const channels = {
+    claimPersonalInbox: vi.fn(async () => undefined),
+    deleteOwnPersonalInbox: vi.fn(async () => undefined),
+    deletePersonalInbox: vi.fn(async () => undefined),
+  }
+
+  return { world, service, channels }
 })
 
 vi.mock('@auxx/lib/inboxes', () => ({
@@ -58,6 +65,7 @@ vi.mock('@auxx/lib/inboxes', () => ({
     canManageInboxAccess = service.canManageInboxAccess
     hasUserAccess = service.hasUserAccess
     getInboxWithIntegrationsById = service.getInboxWithIntegrationsById
+    deleteInbox = service.deleteInbox
     deleteInboxById = service.deleteInboxById
     removeIntegration = service.removeIntegration
     // Unused by the three procedures under test, present so the class shape
@@ -77,10 +85,7 @@ vi.mock('@auxx/lib/cache', () => ({
 }))
 
 vi.mock('@auxx/lib/threads', () => ({ ThreadMutationService: class {} }))
-vi.mock('@auxx/lib/channels', () => ({
-  claimPersonalInbox: vi.fn(),
-  deletePersonalInbox: vi.fn(),
-}))
+vi.mock('@auxx/lib/channels', () => channels)
 vi.mock('~/server/api/audit-context', () => ({ recordAuditFromCtx: vi.fn(async () => undefined) }))
 vi.mock('@auxx/lib/permissions/visibility', () => ({ inboxLensFor: () => 'none' }))
 
@@ -164,8 +169,10 @@ beforeEach(() => {
   // implementation passed to `vi.fn`, so the fixture-backed behaviour survives.
   service.canManageInboxAccess.mockReset()
   service.hasUserAccess.mockReset()
+  service.deleteInbox.mockReset()
   service.deleteInboxById.mockReset()
   service.removeIntegration.mockReset()
+  channels.deleteOwnPersonalInbox.mockReset()
 })
 
 describe('inbox router RecordId minting after migration 060 (plan 40a §5.1 item B)', () => {
@@ -176,14 +183,23 @@ describe('inbox router RecordId minting after migration 060 (plan 40a §5.1 item
       world.view.add(`personal_inbox:${PERSONAL_INBOX}`)
     })
 
-    it('can still DELETE it', async () => {
+    it('can still DELETE it — routed to the owner path, not the inventory one', async () => {
       await expect(caller().delete({ inboxId: PERSONAL_INBOX })).resolves.toEqual({ success: true })
 
-      expect(service.canManageInboxAccess).toHaveBeenCalledWith(
-        `personal_inbox:${PERSONAL_INBOX}`,
-        USER_ID
-      )
-      expect(service.deleteInboxById).toHaveBeenCalledWith(PERSONAL_INBOX)
+      // The def resolved off the org cache picks the BRANCH, so this is the same
+      // minting invariant the rest of the file pins, one level up: a stray
+      // `inbox:` prefix here would send a personal mailbox down the shared path
+      // and 403 its own owner on `channels.manage`.
+      expect(channels.deleteOwnPersonalInbox).toHaveBeenCalledWith({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        inboxId: PERSONAL_INBOX,
+      })
+      // Authority moved INTO the lib function (ownership of the mailbox, which a
+      // shareable `admin` grant does not confer) — the router must not also run
+      // the Manager gate, or a personal inbox stays undeletable by design.
+      expect(service.canManageInboxAccess).not.toHaveBeenCalled()
+      expect(service.deleteInbox).not.toHaveBeenCalled()
     })
 
     it('can still REMOVE AN INTEGRATION from it', async () => {
@@ -226,19 +242,21 @@ describe('inbox router RecordId minting after migration 060 (plan 40a §5.1 item
       await expect(caller().getIntegrations({ inboxId: SHARED_INBOX })).resolves.toHaveLength(1)
 
       expect(service.canManageInboxAccess).toHaveBeenCalledWith(`inbox:${SHARED_INBOX}`, USER_ID)
+      expect(service.deleteInbox).toHaveBeenCalledWith(`inbox:${SHARED_INBOX}`)
+      expect(channels.deleteOwnPersonalInbox).not.toHaveBeenCalled()
     })
   })
 
   describe('the gates still refuse', () => {
     it('a member with no grant on the personal mailbox', async () => {
-      await expect(caller().delete({ inboxId: PERSONAL_INBOX })).rejects.toMatchObject(
-        FORBIDDEN_INSTANCE
-      )
       await expect(
         caller().removeIntegration({ inboxId: PERSONAL_INBOX, integrationId: CHANNEL })
       ).rejects.toMatchObject(FORBIDDEN_INSTANCE)
-      expect(service.deleteInboxById).not.toHaveBeenCalled()
       expect(service.removeIntegration).not.toHaveBeenCalled()
+      // `delete` is deliberately absent here: since the personal branch landed,
+      // its authority is OWNERSHIP inside `deleteOwnPersonalInbox` rather than a
+      // grant the router can see, and that assert has its own test in
+      // `packages/lib/src/channels/delete-own-personal-inbox.test.ts`.
     })
 
     it('THE FAIL-OPEN CASE: a non-owner is refused the personal mailbox’s channel list', async () => {
@@ -280,9 +298,10 @@ describe('inbox router RecordId minting after migration 060 (plan 40a §5.1 item
       // The pre-060 row, left behind. It must NOT authorize the new keyspace.
       world.manage.add(`inbox:${PERSONAL_INBOX}`)
 
-      await expect(caller().delete({ inboxId: PERSONAL_INBOX })).rejects.toMatchObject(
-        FORBIDDEN_INSTANCE
-      )
+      await expect(
+        caller().removeIntegration({ inboxId: PERSONAL_INBOX, integrationId: CHANNEL })
+      ).rejects.toMatchObject(FORBIDDEN_INSTANCE)
+      expect(service.removeIntegration).not.toHaveBeenCalled()
     })
   })
 
@@ -292,5 +311,10 @@ describe('inbox router RecordId minting after migration 060 (plan 40a §5.1 item
     await expect(caller().delete({ inboxId: 'ibx_unknown0000000000000000' })).resolves.toEqual({
       success: true,
     })
+    // Closed fallback: an unknown id takes the SHARED branch, which still has to
+    // clear `channels.manage` + Manager. Sending it down the personal one would
+    // skip both gates on an id the cache cannot vouch for.
+    expect(channels.deleteOwnPersonalInbox).not.toHaveBeenCalled()
+    expect(service.deleteInbox).toHaveBeenCalledWith('inbox:ibx_unknown0000000000000000')
   })
 })

--- a/apps/web/src/server/api/routers/inbox-routing-recordid-canonicalization.test.ts
+++ b/apps/web/src/server/api/routers/inbox-routing-recordid-canonicalization.test.ts
@@ -126,6 +126,7 @@ vi.mock('@auxx/lib/threads', () => ({
 }))
 vi.mock('@auxx/lib/channels', () => ({
   claimPersonalInbox: vi.fn(),
+  deleteOwnPersonalInbox: vi.fn(),
   deletePersonalInbox: vi.fn(),
 }))
 vi.mock('~/server/api/audit-context', () => ({ recordAuditFromCtx }))

--- a/apps/web/src/server/api/routers/inbox.ts
+++ b/apps/web/src/server/api/routers/inbox.ts
@@ -1,7 +1,7 @@
 // apps/web/src/server/api/routers/inbox.ts
 
 import { getCachedUserMailVisibility, getOrgCache } from '@auxx/lib/cache'
-import { claimPersonalInbox, deletePersonalInbox } from '@auxx/lib/channels'
+import { claimPersonalInbox, deleteOwnPersonalInbox, deletePersonalInbox } from '@auxx/lib/channels'
 import {
   inboxDefKeyOf,
   loadInboxDefKeys,
@@ -335,27 +335,56 @@ export const inboxRouter = createTRPCRouter({
     }),
 
   /**
-   * Delete an inbox. Inventory (`channels.manage`, §1.0) AND this inbox's
+   * Delete an inbox — ONE entry point for both definitions, branching on the
+   * one the instance actually lives on.
+   *
+   * **Shared** (`inbox`): inventory (`channels.manage`, §1.0) AND this inbox's
    * Manager — the coarse key says you may shape the org's inbox inventory, the
-   * instance assert says you may shape THIS inbox.
+   * instance assert says you may shape THIS inbox. Refuses while an active
+   * channel is still routed here (`InboxService.deleteInbox`); re-route or
+   * disconnect first.
+   *
+   * **Personal** (`personal_inbox`): neither gate applies and both would deny.
+   * `channels.manage` governs shared inventory, so the owner — an ordinary
+   * member — never holds it; and `personal_inbox` is `baselineAtCreate: true`,
+   * so an admin who does hold it carries no grant row on somebody else's private
+   * mailbox. That is why nothing could delete a live personal inbox at all
+   * before this branch: every caller failed one half or the other, and the
+   * `deletePersonal` procedure below refuses until its owner leaves the org.
+   * Authority here is OWNERSHIP, asserted inside `deleteOwnPersonalInbox`, which
+   * also cascades to the account (a personal mailbox is a one-channel
+   * container — see its doc comment).
+   *
+   * The procedure is therefore `capabilityProcedure` with the coarse assert
+   * moved INTO the shared branch. `permissionProcedure` asserts in middleware,
+   * before the body runs, so it cannot be made def-aware; `channelsManage`
+   * carries no `featureKey` (`permissions/capabilities/registry.ts:396-402`), so
+   * the swap loses no plan gate.
    */
-  delete: permissionProcedure(PermissionKey.channelsManage)
+  delete: capabilityProcedure
     .input(z.object({ inboxId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
       const userId = ctx.session.user.id
-      const inboxService = new InboxService(ctx.db, organizationId, userId)
 
-      await requireInboxManageAccess(
-        inboxService,
-        await toInboxRecordId(organizationId, input.inboxId),
-        userId
-      )
+      // Resolved from the INSTANCE, never from the caller's def part — the
+      // branch below decides which authority applies, so guessing it wrong
+      // would pick the wrong gate as well as the wrong grant keyspace.
+      const recordId = await toInboxRecordId(organizationId, input.inboxId)
+      const isPersonal = parseRecordId(recordId).entityDefinitionId === 'personal_inbox'
 
-      await inboxService.deleteInboxById(input.inboxId)
+      if (isPersonal) {
+        await deleteOwnPersonalInbox({ organizationId, userId, inboxId: input.inboxId })
+      } else {
+        ctx.capabilities.assert(PermissionKey.channelsManage)
+        const inboxService = new InboxService(ctx.db, organizationId, userId)
+        await requireInboxManageAccess(inboxService, recordId, userId)
+        await inboxService.deleteInbox(recordId)
+      }
+
       await recordAuditFromCtx(ctx, {
         category: 'integrations',
-        action: 'inbox.deleted',
+        action: isPersonal ? 'inbox.personal.deleted' : 'inbox.deleted',
         targetType: 'Inbox',
         targetId: input.inboxId,
       })

--- a/apps/web/src/server/lib/inbox-settings-access.test.ts
+++ b/apps/web/src/server/lib/inbox-settings-access.test.ts
@@ -77,8 +77,51 @@ describe('settingsInboxesForUser', () => {
     expect(result[0]).toMatchObject({
       id: 'mine',
       canManage: true,
-      canDelete: false,
+      // Own personal mailbox: deletable, and NOT because of `canManageChannels`
+      // — the next case proves the owner needs no coarse key at all.
+      canDelete: true,
     })
+  })
+
+  it('lets the owner delete their own personal inbox without channels.manage', () => {
+    const result = settingsInboxesForUser({
+      inboxes: [
+        inbox('mine', {
+          entityDefinitionKey: 'personal_inbox',
+          isPersonal: true,
+          ownerUserId: USER_ID,
+        }),
+        inbox('shared', { entityDefinitionKey: 'inbox', isPersonal: false }),
+      ],
+      userId: USER_ID,
+      canManageChannels: false,
+      access: access({ mine: 'admin', shared: 'admin' }) as never,
+    })
+
+    expect(result.find((i) => i.id === 'mine')).toMatchObject({ canDelete: true })
+    // The shared inbox still needs the inventory key, admin grant or not.
+    expect(result.find((i) => i.id === 'shared')).toMatchObject({ canDelete: false })
+  })
+
+  it("never offers delete on another member's personal inbox that was shared with them", () => {
+    const result = settingsInboxesForUser({
+      inboxes: [
+        inbox('theirs', {
+          entityDefinitionKey: 'personal_inbox',
+          isPersonal: true,
+          ownerUserId: 'user_2',
+        }),
+      ],
+      userId: USER_ID,
+      canManageChannels: true,
+      // A Manager grant handed out by the owner — enough to manage, never
+      // enough to destroy their mail (`deleteOwnPersonalInbox` asserts the same
+      // thing server-side).
+      access: access({ theirs: 'admin' }) as never,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ id: 'theirs', canManage: true, canDelete: false })
   })
 
   it('fails closed for another personal inbox still on the shared definition', () => {

--- a/apps/web/src/server/lib/inbox-settings-access.ts
+++ b/apps/web/src/server/lib/inbox-settings-access.ts
@@ -63,9 +63,12 @@ export function settingsInboxesForUser(args: {
         isPersonal: inbox.isPersonal,
         ownerUserId: inbox.ownerUserId,
         canManage,
-        // Personal mailbox lifecycle is disconnect/claim/delete, not the
-        // generic shared-inbox inventory delete.
-        canDelete: !inbox.isPersonal && canManage && canManageChannels,
+        // `inbox.delete` branches on the definition, so the affordance mirrors
+        // the two authorities it applies. A personal mailbox answers to its
+        // OWNER (not `channels.manage`, which its owner never holds, and not an
+        // `admin` grant, which they can hand out by sharing) and deleting it
+        // disconnects its account. A shared one is org inventory.
+        canDelete: inbox.isPersonal ? inbox.ownerUserId === userId : canManage && canManageChannels,
       },
     ]
   })

--- a/docs/lib-module-guide.md
+++ b/docs/lib-module-guide.md
@@ -1,0 +1,275 @@
+# `packages/lib` Module Guide
+
+How a feature module in `packages/lib/src/<feature>/` should be written.
+
+`packages/lib` is ~110 modules deep and **mixed**: the newer ones are functional
+Drizzle + `neverthrow`, the older ones are service classes holding `db` in a
+constructor. This document names the modules that represent where we're going, so
+new work has something concrete to copy instead of averaging over the whole
+folder. The legacy shape is not a style preference we're still debating — it's
+debt. Don't add to it.
+
+---
+
+## 1. The reference modules
+
+Read these before writing a new module. In priority order:
+
+| Module | Read it for |
+| --- | --- |
+| **`snippets/`** | The canonical small module. Start here. `guard.ts` + `snippet-queries.ts` / `snippet-mutations.ts` / `snippet-folder-mutations.ts` / `index.ts`. ~950 LOC, nothing clever. |
+| **`sequences/`** | The canonical *large* module. 25 files split by verb (`crud`, `enroll`, `publish`, `steps`, `runs`, `sweep`, `suppression`, `reanchor`), plus `types.ts`, `client.ts`, `access.ts`. Shows how to grow past one file without growing a class. |
+| **`dashboards/`** | Queries/mutations split where writes have two axes (identity vs. version content: `dashboard-mutations.ts` vs. `version-mutations.ts`), zod config schemas (`config-schemas.ts`), and a substantial client-safe surface (`client.ts`). |
+| **`signals/`** | A module that owns background work: `retention-job.ts`, `rollup-sweep-job.ts`, `rollup.ts`, plus a `email/` subfolder for one cohesive concern. |
+| **`approvals/`, `groups/`, `favorites/`** | Smaller supporting examples of the same shape. |
+
+**Do not copy** (legacy service classes, kept working, not extended):
+`notifications/notification-service.ts`, `inboxes/inbox-service.ts`,
+`timeline/timeline-service.ts`, `tags/tag-service.ts`, `datasets/services/*`,
+`messages/*.service.ts`, `kb/kb-service.ts`, `email/inbound/*.service.ts`.
+
+---
+
+## 2. Functions, not classes
+
+Every exported unit of work is a plain `async function` whose first parameter is
+`db`.
+
+```ts
+// packages/lib/src/snippets/snippet-mutations.ts
+export async function createSnippet(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: CreateSnippetInput
+) { … }
+```
+
+Why this and not a service class:
+
+- **No hidden `db`.** `notifications/notification-service.ts` does
+  `constructor(private database = db)` over a module-level
+  `import { database as db }`. That default silently binds every caller to the
+  app-level pool — a worker, a transaction, or a test that wants to pass its own
+  `tx` can't, and the import alone drags the connection into any bundle that
+  touches the module.
+- **No god objects.** `InboxService` has 20+ methods and two id conventions
+  (`updateInbox(recordId)` *and* `updateInboxById(id)`) because a class makes
+  adding a method cheaper than deciding where it belongs. Files force that
+  decision.
+- **Tree-shaking and testability.** `import { createSnippet }` pulls one
+  function; `new TagService(orgId, userId, db)` pulls the whole surface plus its
+  private helpers' dependencies.
+
+**Legitimate class exceptions** (these are fine, and exist for a reason):
+
+- `Error` subclasses — `RecallApiError`, `PermanentProcessingError`, everything in `errors.ts`.
+- Provider adapters implementing a shared interface — `geo/providers/*`,
+  `email/labels/*-label-provider.ts`, `realtime/providers/pusher.ts`. See the
+  Manager pattern in `ai/providers/provider-manager.ts`.
+- Primitives with genuine internal state — `utils/rate-limiter/token-bucket.ts`,
+  `circuit-breaker.ts`, `priority-queue.ts`.
+- Value objects whose behavior *is* the point — `CapabilitySet` /
+  `AgentPolicyCapabilities` in `permissions/`.
+
+If you're reaching for a class to avoid threading `db` and `organizationId`
+through four calls, use a context object instead (§4).
+
+---
+
+## 3. Errors and results: `neverthrow`, and one `guard`
+
+Two Result flavors exist in the repo. Use the right one:
+
+| | Use |
+| --- | --- |
+| `neverthrow` — `Result<T, Error>`, `ok()`, `err()`, `.isErr()`, `.value` | **All new lib code.** |
+| `@auxx/lib/result` — `TypedResult`, `Result.ok()`, `.ok`, `.value` | Legacy. Only `BaseModel` subclasses in `@auxx/database` still return it. Don't introduce it. |
+
+Never throw `TRPCError` from lib — it's meaningless when the same function runs
+in a worker or a seed script. Throw the matching `AuxxError` subclass from
+`../errors`; `apps/web`'s `auxxErrorMiddleware` maps it to the right status.
+
+Two working styles, both correct:
+
+**A. Imperative body + a module `guard()`** — best when a function has several
+early-exit business rules. `snippets/guard.ts` is the whole pattern in 31 lines:
+
+```ts
+// packages/lib/src/snippets/guard.ts
+export async function guard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error(logMessage, { error, ...meta })
+    return err(new AuxxError('Internal error'))
+  }
+}
+```
+
+Inside the body you just `throw new NotFoundError(...)` and read like normal
+code; the wrapper converts. Copy this file into a new module — it's small enough
+that duplicating it beats a shared abstraction, and it lets each module bind its
+own `createScopedLogger` scope.
+
+**B. Explicit `err()` returns** — best when the failure set is small and the
+signature should document it. `sequences/crud.ts`:
+
+```ts
+export async function deleteSequence(
+  db: Database,
+  params: { sequenceId: string; organizationId: string }
+): Promise<Result<void, Error>> {
+  const sequence = await db.query.Sequence.findFirst({ … })
+  if (!sequence) return err(new NotFoundError('Sequence not found'))
+  if (sequence.templateKey) return err(new ForbiddenError("Built-in sequences can't be deleted"))
+  …
+  return ok(undefined)
+}
+```
+
+Always annotate the return type as `Promise<Result<T, E>>` explicitly. Inference
+works, but the annotation is what makes the failure mode visible at the call site.
+
+---
+
+## 4. Signatures
+
+- `db: Database` first, always. Accept `Transaction` instead when the function is
+  transaction-only (see `insertInstanceAccessBaseline` in `dashboards/dashboard-mutations.ts`).
+- Then scope: `organizationId`, `userId`.
+- Then one `input` / `params` object for everything else. Never more than ~4
+  positional params.
+- Once three or more functions in a file need the same ambient trio, define a
+  context interface: `SequenceAccessContext`, `ResourceAccessContext`,
+  `ChannelCtx`, `KBContext` are the precedents.
+
+```ts
+export interface SequenceAccessContext {
+  db: Database
+  organizationId: string
+}
+export async function grantSequenceCreatorAccess(
+  ctx: SequenceAccessContext & { userId: string },
+  sequenceId: string
+): Promise<void>
+```
+
+---
+
+## 5. File layout
+
+```
+packages/lib/src/<feature>/
+  index.ts                  server entrypoint — explicit named exports only
+  client.ts                 client-safe constants/types/pure fns (see §7)
+  types.ts                  entity aliases + input/output shapes
+  guard.ts                  the neverthrow wrapper, if using style A
+  <noun>-queries.ts         reads
+  <noun>-mutations.ts       writes
+  access.ts                 the ONLY file that touches resource-access
+  <verb>.ts                 one file per verb once the module grows (sequences/)
+  <thing>-job.ts            BullMQ-facing entrypoints (signals/)
+  __tests__/*.test.ts       or co-located <file>.test.ts
+```
+
+Rules that actually bite:
+
+- **`index.ts` uses explicit named exports**, never `export *`. Re-export types
+  with `export type { … }` / inline `type` specifiers so they're erasable.
+- **Split reads from writes.** A file that both queries and mutates is the first
+  step back toward a service class.
+- **`packages/lib/package.json`'s `exports` field is generated** —
+  `pnpm --filter @auxx/lib generate:exports` scans consumer imports. Never
+  hand-edit it. If a new subpath doesn't resolve, add the import in the consumer
+  and regenerate.
+- **Tests:** `__tests__/` for a group (majority of lib), co-located `*.test.ts`
+  for a single-file unit. Either is accepted; don't mix both inside one module.
+
+---
+
+## 6. Access control does not live in lib
+
+This is the rule most easily broken and hardest to unwind. Lib write/read
+helpers carry **no permission checks**. The router asserts, then calls.
+
+```ts
+// apps/web/src/server/api/routers/snippet.ts
+byId: capabilityProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
+  assertSnippetAccess(ctx.capabilities, input.id, 'view')
+  const result = await getSnippetWithShares(ctx.db, ctx.session.organizationId, ctx.session.userId, input.id)
+  if (result.isErr()) throw result.error
+  return { ...result.value, canEdit: ctx.capabilities.canEditInstance('snippet', input.id) }
+}),
+```
+
+The only guards left inside lib are **identity/integrity** ones: org scope,
+soft-delete, system-row immutability, FK ownership. `snippets/snippet-mutations.ts`
+documents exactly this boundary at the top of the file — read that comment.
+
+Two consequences:
+
+- **List endpoints filter in SQL, not in memory.** The router computes an
+  `InstanceListScope` from capabilities and hands it down; the module turns it
+  into a `WHERE` fragment. See `scopeFilter()` in `snippets/snippet-queries.ts`.
+  A post-read `.filter()` leaks counts and volume even when it hides content —
+  which is what `listSnippetFoldersWithCounts` had to fix.
+- **Sharing funnels through `resourceAccess.grantInstance`**, never a bespoke
+  writer. A per-module share path re-implements the notification and audit
+  behavior badly. A module's own `access.ts` is a *thin* wrapper over
+  `grantInstanceAccess` / `hasPermission` (`sequences/access.ts`, 67 lines).
+
+Current procedures in `apps/web/src/server/api/trpc.ts`: `publicProcedure`,
+`protectedProcedure`, `capabilityProcedure`, `permissionProcedure(key)`,
+`ownerProcedure`, `superAdminProcedure`. Most feature routers want
+`capabilityProcedure`.
+
+---
+
+## 7. `client.ts`
+
+Anything the UI needs — string unions, labels, zod-free constants, pure derive
+functions — goes in `client.ts`, importing nothing server-only. Client code must
+import `@auxx/lib/<feature>/client`, never the barrel; the barrel pulls bullmq,
+sharp, and friends and breaks the build.
+
+**No `'use client'` directive in `client.ts`.** Server code imports these files
+too, and the directive turns every export into a client-reference proxy there.
+`sequences/client.ts` carries that warning at the top for exactly this reason.
+
+---
+
+## 8. Transactions, cache, events
+
+- Multi-row invariants go in one `db.transaction()`. A resource with
+  `baselineAtCreate: true` **must** write its `ResourceAccess` baseline in the
+  same transaction as the row — without it the creator can't see what they just
+  created (`createSnippet`, `insertInstanceAccessBaseline` in dashboards).
+- **Bust caches after the transaction commits**, never inside. Mid-transaction
+  invalidation repopulates from a snapshot the commit hasn't reached yet — see
+  the `emitResourceAccessInstanceChanged` placement in `createSnippet`.
+- Read through `@auxx/lib/cache` (`getCachedResources`, `getCachedMembers`, …)
+  before adding a query for anything in `OrgCacheDataMap`. A fresh query defeats
+  invalidation.
+- Realtime publishes always carry a composed `value`; a value-less entry is
+  silently dropped.
+
+---
+
+## 9. Checklist for a new module
+
+- [ ] Exported functions, `db` first, no class
+- [ ] `Promise<Result<T, Error>>` from `neverthrow`, annotated explicitly
+- [ ] `AuxxError` subclasses only — no `TRPCError`, no `@auxx/lib/result`
+- [ ] Reads and writes in separate files
+- [ ] `index.ts` explicit named exports; `client.ts` for anything the UI imports
+- [ ] Zero permission checks; router asserts, list scope applied in SQL
+- [ ] File-path comment on line 1 of every file
+- [ ] JSDoc on every export explaining *why*, not *what*
+- [ ] `pnpm --filter @auxx/lib generate:exports` after adding a consumed subpath
+- [ ] `pnpm lint:fix`, then `cd packages/lib && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --noEmit` (grep for your own files — there's a large pre-existing baseline)

--- a/packages/lib/src/channels/delete-own-personal-inbox.test.ts
+++ b/packages/lib/src/channels/delete-own-personal-inbox.test.ts
@@ -1,0 +1,202 @@
+// packages/lib/src/channels/delete-own-personal-inbox.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `deleteOwnPersonalInbox` — the member-facing half of the personal mailbox
+ * lifecycle, and the only authority behind `inbox.delete`'s personal branch.
+ *
+ * It exists because nothing could delete a LIVE personal inbox at all: the
+ * router's shared gates are `channels.manage` (which the owner, an ordinary
+ * member, never holds) AND an inbox Manager grant (which an admin holding the
+ * key never has on a `baselineAtCreate: true` mailbox), so every caller failed
+ * one half or the other, while `deletePersonalInbox` refuses until the owner
+ * leaves the org. Disconnecting the account did not help — it destroyed the
+ * threads and soft-deleted the `Integration` but left the inbox instance
+ * standing forever.
+ *
+ * Three properties are pinned, and each is a way this could ship wrong:
+ *
+ *  - **Authority is OWNERSHIP, not a grant.** A `personal_inbox` `admin`
+ *    `ResourceAccess` row is something the owner hands out by sharing, so
+ *    reusing `canManageInboxAccess` (as the shared branch does) would let a
+ *    Manager grantee destroy the owner's mail.
+ *  - **The def, not `isPersonal`.** The derived flag is `def OR legacy marker`
+ *    and the two disagree by design across the 059 → 060 window; only def
+ *    membership proves the data was never org-visible.
+ *  - **The channel goes with it.** `InboxService.deleteInbox` refuses while an
+ *    active channel is routed here, so skipping the cascade turns the whole
+ *    feature into a `ConflictError` — the exact dead end it was written to fix.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  getInboxById: vi.fn(),
+  deleteInbox: vi.fn(async () => undefined),
+  // `disconnect` returns a `TypedResult`, so the fake has to be able to resolve
+  // BOTH arms — an inferred `{ ok: true; value }` would reject the error case.
+  disconnect: vi.fn(
+    async (): Promise<{ ok: boolean; value?: unknown; error?: unknown }> => ({
+      ok: true,
+      value: { success: true },
+    })
+  ),
+  onCacheEvent: vi.fn(async () => undefined),
+  links: [] as Array<{ integrationId: string }>,
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: { query: { InboxIntegration: { findMany: async () => hoisted.links } } },
+  schema: { InboxIntegration: { inboxId: 'inboxId' } },
+}))
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ get: async () => ({}) }),
+  onCacheEvent: hoisted.onCacheEvent,
+}))
+vi.mock('../email/polling-import-cache', () => ({ clearImportCache: vi.fn() }))
+vi.mock('../jobs/maintenance/storage-cleanup-job', () => ({ enqueueStorageCleanupJob: vi.fn() }))
+vi.mock('../providers/google/google-oauth', () => ({
+  GoogleOAuthService: { revokeAccess: vi.fn() },
+}))
+vi.mock('../providers/outlook/outlook-oauth', () => ({
+  OutlookOAuthService: { revokeAccess: vi.fn() },
+}))
+vi.mock('../providers/provider-capabilities', () => ({ PROVIDER_CAPABILITIES: {} }))
+vi.mock('./channel-connection-def', () => ({ CHANNEL_PROVIDER_TO_KEY: {} }))
+vi.mock('./disconnect', () => ({
+  deleteChannelData: vi.fn(),
+  disconnect: hoisted.disconnect,
+}))
+vi.mock('../resource-access/resource-access-service', () => ({ setInstanceAccess: vi.fn() }))
+vi.mock('../inboxes/inbox-floor', () => ({ setInboxFloor: vi.fn() }))
+vi.mock('../inboxes/inbox-def-move', () => ({
+  moveInboxInstance: vi.fn(),
+  rekeyInboxGrants: vi.fn(),
+  buildDefFieldIdMap: vi.fn(),
+}))
+vi.mock('../seed/entity-migrations/helpers', () => ({ loadExistingState: vi.fn() }))
+vi.mock('../inboxes/inbox-service', () => ({
+  InboxService: class {
+    getInboxById = hoisted.getInboxById
+    deleteInbox = hoisted.deleteInbox
+  },
+}))
+
+const { deleteOwnPersonalInbox } = await import('./personal-connection')
+
+const ORG = 'org_1'
+const OWNER = 'usr_owner'
+const OTHER = 'usr_other'
+const INBOX = 'ibx_personal'
+const CHANNEL = 'int_channel'
+
+const personalInbox = (over: Record<string, unknown> = {}) => ({
+  id: INBOX,
+  recordId: `personal_inbox:${INBOX}`,
+  entityDefinitionKey: 'personal_inbox',
+  isPersonal: true,
+  ownerUserId: OWNER,
+  ...over,
+})
+
+beforeEach(() => {
+  hoisted.getInboxById.mockReset()
+  hoisted.deleteInbox.mockReset()
+  hoisted.disconnect.mockReset()
+  hoisted.onCacheEvent.mockReset()
+  hoisted.getInboxById.mockResolvedValue(personalInbox())
+  hoisted.deleteInbox.mockResolvedValue(undefined)
+  hoisted.disconnect.mockResolvedValue({ ok: true, value: { success: true } })
+  hoisted.links = [{ integrationId: CHANNEL }]
+})
+
+describe('deleteOwnPersonalInbox', () => {
+  it('disconnects the account, then deletes the mailbox on its own def', async () => {
+    await deleteOwnPersonalInbox({ organizationId: ORG, userId: OWNER, inboxId: INBOX })
+
+    expect(hoisted.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: ORG, userId: OWNER }),
+      CHANNEL
+    )
+    // The RecordId carries `personal_inbox`, not the shared slug — `deleteInbox`
+    // deletes the entity instance through it, and a wrong def would delete
+    // nothing while reporting success.
+    expect(hoisted.deleteInbox).toHaveBeenCalledWith(`personal_inbox:${INBOX}`)
+    expect(hoisted.onCacheEvent).toHaveBeenCalledWith('channel.disconnected', { orgId: ORG })
+  })
+
+  it('disconnects BEFORE deleting — the other order hits the active-channel guard', async () => {
+    const order: string[] = []
+    hoisted.disconnect.mockImplementation(async () => {
+      order.push('disconnect')
+      return { ok: true, value: { success: true } }
+    })
+    hoisted.deleteInbox.mockImplementation(async () => {
+      order.push('deleteInbox')
+    })
+
+    await deleteOwnPersonalInbox({ organizationId: ORG, userId: OWNER, inboxId: INBOX })
+
+    expect(order).toEqual(['disconnect', 'deleteInbox'])
+  })
+
+  it('refuses a member who is not the owner, however privileged', async () => {
+    await expect(
+      deleteOwnPersonalInbox({ organizationId: ORG, userId: OTHER, inboxId: INBOX })
+    ).rejects.toMatchObject({ statusCode: 403 })
+
+    expect(hoisted.disconnect).not.toHaveBeenCalled()
+    expect(hoisted.deleteInbox).not.toHaveBeenCalled()
+  })
+
+  it('refuses an ownerless personal mailbox — that is the orphan path, not this one', async () => {
+    hoisted.getInboxById.mockResolvedValue(personalInbox({ ownerUserId: null }))
+
+    await expect(
+      deleteOwnPersonalInbox({ organizationId: ORG, userId: OWNER, inboxId: INBOX })
+    ).rejects.toMatchObject({ statusCode: 403 })
+    expect(hoisted.deleteInbox).not.toHaveBeenCalled()
+  })
+
+  it('refuses a SHARED inbox even when the caller is stamped as its owner', async () => {
+    // The legacy `inbox_is_personal` marker still resolves `isPersonal: true` on
+    // the shared def between migrations 059 and 060. Only def membership proves
+    // the mail was never org-visible, so this path must read the def.
+    hoisted.getInboxById.mockResolvedValue(
+      personalInbox({ entityDefinitionKey: 'inbox', recordId: `inbox:${INBOX}` })
+    )
+
+    await expect(
+      deleteOwnPersonalInbox({ organizationId: ORG, userId: OWNER, inboxId: INBOX })
+    ).rejects.toMatchObject({ statusCode: 403 })
+    expect(hoisted.deleteInbox).not.toHaveBeenCalled()
+  })
+
+  it('refuses an inbox that does not exist', async () => {
+    hoisted.getInboxById.mockResolvedValue(null)
+
+    await expect(
+      deleteOwnPersonalInbox({ organizationId: ORG, userId: OWNER, inboxId: INBOX })
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('still deletes the mailbox when its channel is already gone', async () => {
+    // Half-run offboarding, or a prior disconnect: `validateChannelOwnership`
+    // no longer finds a soft-deleted Integration. Aborting here would recreate
+    // the undeletable-empty-inbox state this function exists to end.
+    hoisted.disconnect.mockResolvedValue({ ok: false, error: new Error('Channel not found') })
+
+    await deleteOwnPersonalInbox({ organizationId: ORG, userId: OWNER, inboxId: INBOX })
+
+    expect(hoisted.deleteInbox).toHaveBeenCalledWith(`personal_inbox:${INBOX}`)
+  })
+
+  it('deletes a mailbox with no channels at all and skips the inventory event', async () => {
+    hoisted.links = []
+
+    await deleteOwnPersonalInbox({ organizationId: ORG, userId: OWNER, inboxId: INBOX })
+
+    expect(hoisted.disconnect).not.toHaveBeenCalled()
+    expect(hoisted.deleteInbox).toHaveBeenCalledWith(`personal_inbox:${INBOX}`)
+    expect(hoisted.onCacheEvent).not.toHaveBeenCalledWith('channel.disconnected', { orgId: ORG })
+  })
+})

--- a/packages/lib/src/channels/index.ts
+++ b/packages/lib/src/channels/index.ts
@@ -11,9 +11,15 @@ export { assertSharedConnectInbox } from './connect-inbox'
 export { disconnect } from './disconnect'
 export { type CreateChannelInput, createChannel, linkChannelToInbox } from './lifecycle'
 export { countBillableChannels, getProviderType, list } from './list'
-export { canManageChannel, requireChannelManageAccess } from './manage-access'
+export {
+  type ChannelManageScope,
+  canManageChannel,
+  listManageableChannelIds,
+  requireChannelManageAccess,
+} from './manage-access'
 export {
   claimPersonalInbox,
+  deleteOwnPersonalInbox,
   deletePersonalInbox,
   disconnectPersonalChannelsForUser,
   provisionPersonalInbox,

--- a/packages/lib/src/channels/personal-connection.ts
+++ b/packages/lib/src/channels/personal-connection.ts
@@ -19,7 +19,7 @@ import { PROVIDER_CAPABILITIES } from '../providers/provider-capabilities'
 import { setInstanceAccess } from '../resource-access/resource-access-service'
 import { loadExistingState } from '../seed/entity-migrations/helpers'
 import { CHANNEL_PROVIDER_TO_KEY } from './channel-connection-def'
-import { deleteChannelData } from './disconnect'
+import { deleteChannelData, disconnect } from './disconnect'
 
 const logger = createScopedLogger('personal-connection')
 
@@ -353,4 +353,82 @@ export async function deletePersonalInbox(args: {
   await bumpMailCountsEpoch(organizationId)
 
   logger.info('Personal inbox deleted', { inboxId, adminUserId, channels: links.length })
+}
+
+/**
+ * Delete YOUR OWN personal inbox — the member-facing sibling of
+ * {@link deletePersonalInbox}, which is the ADMIN path and only ever fires once
+ * the owner has left the org.
+ *
+ * **Deleting the mailbox disconnects its account**, deliberately. A personal
+ * inbox is a one-account container: it exists only because a member connected a
+ * personal channel, nothing else may ever route into it
+ * (`assertSharedConnectInbox` and `addIntegration` both reject one as a target),
+ * and no other member can see it. So "delete my inbox" and "disconnect my
+ * account" are the same act — and if they weren't, `deleteInbox`'s
+ * active-channel guard would refuse and leave the member holding a mailbox they
+ * have no way to remove. That was the state before this existed: `disconnect`
+ * destroys the threads and soft-deletes the `Integration` but never touches the
+ * inbox instance, so an empty personal inbox outlived every account it ever had.
+ *
+ * **Authority is OWNERSHIP, not a grant.** `inbox_owner_user_id` is admin-only
+ * data no member can write, whereas a `personal_inbox` `admin` `ResourceAccess`
+ * row is something the owner can hand out by sharing — so `canManageInboxAccess`
+ * would let a Manager grantee destroy the owner's mail. Nor does this open an
+ * admin door: `channels.manage` deletes SHARED inbox inventory, and a current
+ * member's private mailbox is only reachable through the orphan path above.
+ *
+ * Reuses `disconnect` per channel — provider revoke, threads/messages/attachment
+ * assets, `Integration` soft-delete, polling cache, mail-count epoch, S3 cleanup
+ * — rather than {@link deletePersonalInbox}'s open-coded bulk posture, which
+ * exists because offboarding has ALREADY soft-deleted those integrations and
+ * `disconnect`'s `validateChannelOwnership` would no longer find them.
+ */
+export async function deleteOwnPersonalInbox(args: {
+  organizationId: string
+  userId: string
+  inboxId: string
+}): Promise<void> {
+  const { organizationId, userId, inboxId } = args
+  const inboxService = new InboxService(db, organizationId, userId)
+
+  const inbox = await inboxService.getInboxById(inboxId)
+  if (!inbox) throw new NotFoundError('Inbox not found')
+  if (inbox.entityDefinitionKey !== 'personal_inbox') {
+    throw new ForbiddenError('Not a personal inbox')
+  }
+  if (!inbox.ownerUserId || inbox.ownerUserId !== userId) {
+    throw new ForbiddenError('Only the owner of a personal inbox can delete it')
+  }
+
+  const links = await db.query.InboxIntegration.findMany({
+    where: eq(schema.InboxIntegration.inboxId, inboxId),
+  })
+  for (const link of links) {
+    // Already soft-deleted (an offboarding half-run, a prior disconnect) reads
+    // as NotFound — there is nothing left to revoke and the link row dies with
+    // the inbox below, so this must not abort the delete.
+    const result = await disconnect({ db, organizationId, userId }, link.integrationId)
+    if (!result.ok) {
+      logger.warn('Personal channel already gone, continuing inbox delete', {
+        inboxId,
+        integrationId: link.integrationId,
+      })
+    }
+  }
+
+  await inboxService.deleteInbox(inbox.recordId)
+
+  // `deleteInbox` broadcasts `inbox.deleted` + `channel.inbox-link.changed`;
+  // the channel INVENTORY change is this path's own (the disconnect router
+  // fires the same event beside its own `disconnect` call).
+  if (links.length > 0) {
+    await onCacheEvent('channel.disconnected', { orgId: organizationId })
+  }
+
+  logger.info('Personal inbox deleted by its owner', {
+    inboxId,
+    userId,
+    channels: links.length,
+  })
 }

--- a/packages/lib/src/channels/personal-inbox-lifecycle.test.ts
+++ b/packages/lib/src/channels/personal-inbox-lifecycle.test.ts
@@ -56,7 +56,7 @@ vi.mock('../providers/outlook/outlook-oauth', () => ({
 }))
 vi.mock('../providers/provider-capabilities', () => ({ PROVIDER_CAPABILITIES: {} }))
 vi.mock('./channel-connection-def', () => ({ CHANNEL_PROVIDER_TO_KEY: {} }))
-vi.mock('./disconnect', () => ({ deleteChannelData: vi.fn() }))
+vi.mock('./disconnect', () => ({ deleteChannelData: vi.fn(), disconnect: vi.fn() }))
 vi.mock('../resource-access/resource-access-service', () => ({
   setInstanceAccess: hoisted.setInstanceAccess,
 }))


### PR DESCRIPTION
## The gap

There was no way to delete a **live** personal inbox — by anyone.

- `inbox.delete` was `permissionProcedure(channelsManage)` **and** `requireInboxManageAccess`. Both halves fail for a personal mailbox: the owner is an ordinary member and never holds `channels.manage`; an admin who does hold it carries no `ResourceAccess` row on a `baselineAtCreate: true` instance. Every caller failed one half or the other.
- `inbox.deletePersonal` works, but `loadOrphanedPersonalInbox` refuses while the owner is still a member. Its only UI is the orphan banner, which renders `null` until they leave the org.
- Disconnecting the account didn't help: `channels/disconnect.ts` destroys the threads and soft-deletes the `Integration` but never touches the inbox instance. An empty personal inbox outlived every account it ever had.
- The UI matched: `canDelete` was `!isPersonal && …` in both hosts, and the detail page had no delete of its own — only the one threaded into `InboxDialog`.

## The change

`inbox.delete` stays the single entry point and **branches on the definition resolved from the instance**.

**Shared** — unchanged: `channels.manage` + inbox Manager, still refuses while an active channel is routed there.

**Personal** — new `deleteOwnPersonalInbox` in `packages/lib/src/channels/personal-connection.ts`:

- Asserts the instance is on the `personal_inbox` **definition**, not the derived `isPersonal` (which is `def OR legacy marker` and disagrees by design across the 059→060 window).
- Asserts **ownership**, deliberately not `canManageInboxAccess`: a `personal_inbox` `admin` row is something the owner hands out by sharing, so reusing the shared gate would let a Manager grantee destroy the owner's mail.
- **Cascades to the account.** A personal mailbox is a one-channel container — nothing may ever route into it, nobody else can see it — so "delete my inbox" and "disconnect my account" are the same act. It calls the existing `disconnect()` per linked channel (provider revoke, threads/messages/attachment assets, `Integration` soft-delete, polling cache, mail-count epoch, S3 cleanup), then `deleteInbox`. **That order is required**: `deleteInbox` refuses while an active channel is routed there, which is the dead end this fixes.

### Procedure type

Moved from `permissionProcedure(channelsManage)` to `capabilityProcedure` with the coarse assert **inside the shared branch**. `permissionProcedure` asserts in middleware, before the body runs, so it cannot be made def-aware. `channelsManage` carries no `featureKey` (`permissions/capabilities/registry.ts:396-402`), so no plan gate is lost. An id the org cache does not know falls back to the **shared** branch, keeping both gates.

### Client

`canDelete` now mirrors the same two authorities instead of hard-excluding personal — settings list (`inbox-settings-access.ts`), detail page, edit dialog. Confirm copy says the account goes too. Both mutations also invalidate `channel.list` and `thread.getCounts`.

## What this does NOT change

- **An admin still cannot delete a current member's personal inbox** — only the owner, or the orphan path after they leave. Plan 40's privacy posture is unchanged.
- The paused-channel hole in `deleteInbox`'s guard (`enabled: true` only, so a toggled-off channel slips past and gets silently unrouted) is **pre-existing and untouched**.

## Also included

`docs/lib-module-guide.md` and its `CLAUDE.md` pointers, written alongside this work — documentation only, no code impact.

## Verification

- **148 web + 113 lib tests pass** across the inbox/channel slices. 8 new lib tests (`delete-own-personal-inbox.test.ts`), 2 new web tests.
- **3 asserts mutation-verified**: removing the ownership assert → 2 failures; removing the def check → 1 failure; forcing `isPersonal = false` in the router → 1 failure.
- **Zero new tsc errors.** The 2 lib hits (`personal-connection.ts:27,30`) and 3 web hits (`inbox-form.tsx`) in changed files are byte-identical at HEAD, confirmed by diffing the HEAD copies.
- Biome clean.
- `label-channel-authority.test.ts` fails to collect on `main` — that's the parallel email/labels refactor, and none of these files appear in its import graph.