### PR TITLE
feat(permissions): mail access request UI (plan 42 phase 2)

### DIFF
--- a/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
@@ -18,6 +18,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { useNotificationPanelStore } from '../notification-panel-store'
+import { AccessRequestRow } from './items/access-request-row'
 import { ConfirmationRow } from './items/confirmation-row'
 import { SuggestionRow } from './items/suggestion-row'
 import { NotificationRowSkeleton } from './notification-row'
@@ -197,7 +198,15 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
                 'scroll-mt-2 rounded-md transition-shadow',
                 flashedId === request.id && 'ring-2 ring-info ring-inset'
               )}>
-              <ConfirmationRow request={request} onResolved={onResolved} />
+              {/* Both kinds live in one section, ordered by deadline together
+                  (plan 28 H1 is what makes access rows appear here at all). They
+                  get different rows because the payload and the cost of Deny are
+                  different — see `AccessRequestRow`. */}
+              {request.kind === 'access' ? (
+                <AccessRequestRow request={request} onResolved={onResolved} />
+              ) : (
+                <ConfirmationRow request={request} onResolved={onResolved} />
+              )}
             </div>
           ))}
         </section>

--- a/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
@@ -1,0 +1,256 @@
+// apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
+'use client'
+
+import { ACCESS_DENY_COOLDOWN_DAYS } from '@auxx/lib/approval-requests/client'
+import { LENS_LABELS } from '@auxx/lib/permissions/visibility/client'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import { format, formatDistanceToNowStrict } from 'date-fns'
+import { AlertTriangle, ChevronRight, LockKeyhole } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { useState } from 'react'
+import { BlockCardActionButton } from '~/components/kopilot/ui/blocks/block-card'
+import { useConfirm } from '~/hooks/use-confirm'
+import type { RouterOutputs } from '~/trpc/react'
+import { api } from '~/trpc/react'
+import { Emphasis } from '../notification-chips'
+import { NotificationRow } from '../notification-row'
+
+type PendingApprovalRequest = RouterOutputs['approval']['getPendingRequests'][number]
+
+const TIMESTAMP_FORMAT = 'MMM d, yyyy h:mm a'
+
+function formatTimestamp(value: Date | string | null | undefined): string {
+  return value ? format(new Date(value), TIMESTAMP_FORMAT) : 'No expiration'
+}
+
+/**
+ * A pending ACCESS request, rendered inline in the Approvals tab beside
+ * `ConfirmationRow` (plan 42 §7).
+ *
+ * A sibling rather than a mode of `ConfirmationRow`: the payload is *who · what ·
+ * what level* instead of *which workflow*, denying costs a teammate access rather
+ * than killing a live run, and the label is lens-gated. What is shared is the row
+ * chrome and the progressive-disclosure comment — the same pattern the requester
+ * side uses for its note.
+ *
+ * **Most requests carry no note** (§0.3), so the collapsed row must read completely
+ * on its own. `requester` and `subjectLabel` both ship on the pending list for that
+ * reason; the drawer adds only what needs the approver's own lens.
+ */
+export function AccessRequestRow({
+  request,
+  onResolved,
+}: {
+  request: PendingApprovalRequest
+  onResolved: () => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [comment, setComment] = useState('')
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  /**
+   * Lazy, and deliberately a SEPARATE query from `getApprovalDetails`: the
+   * hydration decision needs this approver's own mail lens on the target, which the
+   * generic details do not compute (and should not pay for on a workflow row).
+   */
+  const {
+    data: details,
+    isLoading: detailsLoading,
+    error: detailsError,
+  } = api.approval.accessRequestDetails.useQuery(
+    { id: request.id },
+    { enabled: expanded, retry: false, refetchOnWindowFocus: false }
+  )
+
+  const approve = api.approval.approve.useMutation({
+    onError: (error) => toastError({ title: 'Error granting access', description: error.message }),
+    onSettled: () => onResolved(),
+  })
+
+  const deny = api.approval.deny.useMutation({
+    onError: (error) => toastError({ title: 'Error declining', description: error.message }),
+    onSettled: () => onResolved(),
+  })
+
+  const isMutating = approve.isPending || deny.isPending
+  const isExpired = request.expiresAt ? new Date(request.expiresAt) < new Date() : false
+  // A target that has since been deleted or moved org would be refused by the
+  // decision handler (§4.2 step 1), so do not offer the click.
+  const targetGone = details?.targetAvailable === false
+  const actionsDisabled = isMutating || isExpired || targetGone
+
+  const requesterName = request.requester?.name ?? 'A teammate'
+  const levelLabel = (
+    LENS_LABELS[(request.requestedLens ?? 'full') as keyof typeof LENS_LABELS]?.label ??
+    'Full access'
+  ).toLowerCase()
+  const trimmedComment = comment.trim()
+
+  const handleApprove = () => {
+    approve.mutate({ id: request.id, comment: trimmedComment || undefined })
+  }
+
+  const handleDeny = async () => {
+    const confirmed = await confirm({
+      title: 'Decline this request?',
+      description: `${requesterName} keeps their current access and cannot ask again for ${ACCESS_DENY_COOLDOWN_DAYS} days.`,
+      confirmText: 'Decline',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    deny.mutate({ id: request.id, comment: trimmedComment || undefined })
+  }
+
+  const subtitle = isExpired ? (
+    <span className='inline-flex items-center gap-1 text-destructive'>
+      <AlertTriangle className='size-3 shrink-0' />
+      This request has expired
+    </span>
+  ) : request.expiresAt ? (
+    `Expires in ${formatDistanceToNowStrict(new Date(request.expiresAt))}`
+  ) : undefined
+
+  const drawer = (
+    <div className='space-y-2 rounded-md bg-secondary/40 p-2'>
+      {detailsLoading ? (
+        <div className='space-y-2'>
+          <Skeleton className='h-3 w-1/3' />
+          <Skeleton className='h-3 w-2/3' />
+        </div>
+      ) : detailsError ? (
+        <div className='flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-2 text-destructive text-xs'>
+          <AlertTriangle className='mt-px size-3.5 shrink-0' />
+          <span>
+            {detailsError.data?.code === 'FORBIDDEN'
+              ? 'You are not authorized to view this access request.'
+              : detailsError.message}
+          </span>
+        </div>
+      ) : details ? (
+        <>
+          <p className='text-muted-foreground text-xs'>
+            Conversation <span className='text-foreground'>{details.label}</span>
+          </p>
+          {/* §7's hydration rule, said out loud. Sharing authority and a reading
+              lens are different things: a downgraded admin or one deciding a
+              null-inbox request may be allowed to approve while unable to read the
+              conversation, and the row must show the durable snapshot rather than
+              quietly implying it is live. */}
+          {details.targetAvailable && !details.hydrated ? (
+            <p className='text-muted-foreground text-xs'>
+              You have {LENS_LABELS[details.approverLens]?.label.toLowerCase()} here, so this is the
+              summary captured when the request was filed.
+            </p>
+          ) : null}
+          {!details.targetAvailable ? (
+            <p className='flex items-center gap-1.5 text-destructive text-xs'>
+              <AlertTriangle className='size-3 shrink-0' />
+              This conversation is no longer available.
+            </p>
+          ) : null}
+          <p className='text-muted-foreground text-xs'>
+            {requesterName} has{' '}
+            <span className='text-foreground'>
+              {LENS_LABELS[details.requesterLens]?.label.toLowerCase() ?? 'no access'}
+            </span>{' '}
+            today
+            {details.remindCount > 0 ? ` · asked ${details.remindCount + 1} times` : ''}
+          </p>
+        </>
+      ) : null}
+
+      {request.message ? <p className='text-sm leading-6'>{request.message}</p> : null}
+
+      <dl className='grid grid-cols-2 gap-2 text-xs'>
+        <div>
+          <dt className='text-muted-foreground'>Requested</dt>
+          <dd className='font-medium'>{formatTimestamp(request.createdAt)}</dd>
+        </div>
+        <div>
+          <dt className='text-muted-foreground'>Expires</dt>
+          <dd className={cn('font-medium', isExpired && 'text-destructive')}>
+            {formatTimestamp(request.expiresAt)}
+          </dd>
+        </div>
+      </dl>
+
+      <div>
+        <label htmlFor={`access-comment-${request.id}`} className='text-muted-foreground text-xs'>
+          Comment (optional)
+        </label>
+        <Textarea
+          id={`access-comment-${request.id}`}
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          placeholder='Add a comment about your decision...'
+          rows={2}
+          disabled={isMutating}
+          className='mt-1 text-sm'
+        />
+      </div>
+    </div>
+  )
+
+  return (
+    <>
+      <NotificationRow
+        id={request.id}
+        createdAt={request.createdAt}
+        label='Access'
+        icon={<LockKeyhole className='size-4' />}
+        subtitle={subtitle}
+        actionLabel={
+          <button
+            type='button'
+            aria-expanded={expanded}
+            onClick={() => setExpanded((value) => !value)}
+            className='flex h-7 cursor-pointer items-center gap-1 rounded-full pr-2 font-medium text-foreground/65 text-xs hover:bg-foreground/5'>
+            <ChevronRight
+              className={cn('size-3.5 transition-transform', expanded && 'rotate-90')}
+              aria-hidden
+            />
+            {expanded ? 'Hide details' : 'Details'}
+          </button>
+        }
+        actions={
+          <>
+            <BlockCardActionButton
+              label='Decline'
+              destructive
+              disabled={actionsDisabled}
+              onClick={() => void handleDeny()}
+            />
+            <BlockCardActionButton
+              label='Grant'
+              primary
+              disabled={actionsDisabled}
+              onClick={handleApprove}
+            />
+          </>
+        }
+        expanded={
+          <AnimatePresence initial={false}>
+            {expanded && (
+              <motion.div
+                initial={{ height: 0, opacity: 0, filter: 'blur(3px)' }}
+                animate={{ height: 'auto', opacity: 1, filter: 'blur(0px)' }}
+                exit={{ height: 0, opacity: 0, filter: 'blur(3px)' }}
+                transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                style={{ overflow: 'hidden' }}>
+                <div className='pt-2'>{drawer}</div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        }>
+        <Emphasis>{requesterName}</Emphasis> asked for {levelLabel} to{' '}
+        <Emphasis>{request.subjectLabel}</Emphasis>
+      </NotificationRow>
+
+      <ConfirmDialog />
+    </>
+  )
+}

--- a/apps/web/src/components/global/notifications/ui/items/approval-notification.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/approval-notification.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/global/notifications/ui/items/approval-notification.tsx
 'use client'
 
-import { CircleCheck } from 'lucide-react'
+import { CircleCheck, LockKeyhole, LockKeyholeOpen } from 'lucide-react'
 import { useNotificationPanelStore } from '../../notification-panel-store'
 import { Emphasis } from '../notification-chips'
 import { notificationMetadata } from '../notification-metadata'
@@ -9,14 +9,18 @@ import { NotificationRow } from '../notification-row'
 import type { NotificationItemProps } from './item-props'
 
 /**
- * Workflow approval requests, reminders and completions.
+ * Everything that targets an `ApprovalRequest`: workflow confirmations, reminders
+ * and completions, plus the access lane's request / decided pair (plan 42 §8).
  *
- * There is no actor chip here — approvals are raised by the workflow engine, not a
- * teammate — so the row leads with the ask and names the workflow instead. The name
- * comes straight from metadata; there is nothing to fetch.
+ * There is no actor chip on the workflow variants — those approvals are raised by
+ * the engine, not a teammate — so the row leads with the ask and names the workflow
+ * instead. The name comes straight from metadata; there is nothing to fetch.
  *
  * Opening switches the panel to the Approvals tab and highlights the matching
- * request there, rather than launching a separate dialog.
+ * request there, rather than launching a separate dialog. For the requester's
+ * DECIDED notification there is nothing to highlight — they are not an approver —
+ * and `ApprovalsTab` clears an unlisted highlight silently, which is the intended
+ * degrade rather than a dead end.
  */
 export function ApprovalNotification({
   notification,
@@ -41,11 +45,24 @@ export function ApprovalNotification({
         ? 'Approval reminder'
         : null
 
+  // The access lane keeps its server-composed message (which already names the
+  // durable subject label) and only takes a truthful icon: an open padlock for a
+  // decision, a closed one for the ask. A green check on "your request was
+  // declined" is the kind of mismatch that reads as a bug.
+  const icon =
+    metadata?.kind === 'ACCESS_REQUESTED' ? (
+      <LockKeyhole className='size-4' />
+    ) : metadata?.kind === 'ACCESS_REQUEST_DECIDED' ? (
+      <LockKeyholeOpen className='size-4' />
+    ) : (
+      <CircleCheck className='size-4' />
+    )
+
   return (
     <NotificationRow
       {...notification}
       subtitle={lead ? undefined : workflowName}
-      icon={<CircleCheck className='size-4' />}
+      icon={icon}
       onOpen={() => openApprovals(notification.targetIds.approvalRequestId)}
       onDelete={onDelete}
       onRead={onRead}>

--- a/apps/web/src/components/mail-permissions/hooks/use-request-access.ts
+++ b/apps/web/src/components/mail-permissions/hooks/use-request-access.ts
@@ -1,0 +1,135 @@
+// apps/web/src/components/mail-permissions/hooks/use-request-access.ts
+'use client'
+
+import { ACCESS_REFUSAL_COPY, type AccessRefusalReason } from '@auxx/lib/approval-requests/client'
+import { toastError } from '@auxx/ui/components/toast'
+import { toInboxAccessRecordId, useInbox, useThread } from '~/components/threads/hooks'
+import { useUser } from '~/hooks/use-user'
+import { useAccess } from '~/providers/capabilities-provider'
+import { api } from '~/trpc/react'
+
+/**
+ * Refusals worth SAYING to the requester, rather than silently hiding the
+ * trigger (plan 42 §5.3).
+ *
+ * `worker_seat` and `front_door_closed` are the two that name a lever — and the
+ * seat one names a lever nobody can pull, which is exactly why it must be said
+ * instead of rendering a dead button. `deny_cooldown` is included because "nothing
+ * happened when I clicked" is a worse answer than "you asked recently".
+ *
+ * `already_full` and `target_unavailable` are deliberately absent: the client
+ * eligibility check has already hidden the trigger in both cases, and explaining
+ * why a control the user cannot see is missing is noise.
+ */
+const SPOKEN_REFUSALS: AccessRefusalReason[] = ['worker_seat', 'front_door_closed', 'deny_cooldown']
+
+export interface UseRequestAccessResult {
+  /**
+   * Whether this member administers sharing on the thread — org admin/owner, or a
+   * Manager of its inbox.
+   *
+   * **This is the hook's home for that expression, not a copy of it** (plan 42
+   * §6.1). It used to be inline in `thread-share-popover.tsx`, where it was half of
+   * the requester condition and unavailable to the redaction banner. A sub-`full`
+   * admin can grant themselves access directly and must never enter an approval
+   * flow, so both mounts and the share popover read the one implementation.
+   */
+  canShare: boolean
+  /** The viewer's composed lens on the thread, as the thread payload reports it. */
+  myLens: 'metadata' | 'subject' | 'full'
+  /** Render the trigger at all: sub-`full` and unable to just grant it themselves. */
+  eligible: boolean
+  /** Server-authoritative `false` — the ask would be refused. Presentation only. */
+  refusalCopy: string | null
+  /** An existing pending request of theirs, which swaps the trigger for a status view. */
+  pending: { id: string; createdAt: Date } | null
+  /** Who will decide it, named — "sent into the void" vs "Sarah will see this". */
+  approvers: Array<{ userId: string; name: string | null; image: string | null }>
+  /** Whether {@link approvers} are inbox Managers or the org-admin fallback. */
+  approversAre: 'managers' | 'admins' | null
+  /** Server-composed header label; degrades safely at `metadata` lens. */
+  subjectLabel: string | null
+  isLoading: boolean
+  send: (message?: string) => void
+  withdraw: () => void
+  isSending: boolean
+  isWithdrawing: boolean
+}
+
+/**
+ * Everything the "request access to this conversation" affordance needs
+ * (plan 42 §6.3), so no call site re-derives eligibility or authority.
+ *
+ * The client checks are **presentation only**. `requestAccess` repeats every one of
+ * them server-side — current lens, mail front door, org-scoped target, deny
+ * cooldown, pending state — which is where a direct API caller meets them too. The
+ * entry condition here is deliberately NOT plan 28 §4.6's generic
+ * `deniedBy() === 'permission'`: mail redaction is a lens, not a denied permission
+ * key, so the mail fork is `myLens !== 'full' && !canShare`.
+ *
+ * The preflight query is gated on that pair, so a full-lens member or a Manager
+ * pays nothing for this hook.
+ */
+export function useRequestAccess({
+  threadId,
+  enabled = true,
+}: {
+  threadId: string
+  enabled?: boolean
+}): UseRequestAccessResult {
+  const utils = api.useUtils()
+  const { thread } = useThread({ threadId })
+  const { inbox } = useInbox(thread?.inboxId)
+  const { isAdminOrOwner } = useUser()
+  const { canAdminInstance } = useAccess()
+
+  // Inbox Managers administer sharing without being org admins (delegation).
+  const canShare = isAdminOrOwner || (!!inbox && canAdminInstance(toInboxAccessRecordId(inbox)))
+  const myLens = thread?.myLens ?? 'full'
+  const clientEligible = !!thread && myLens !== 'full' && !canShare
+
+  const { data: preflight, isLoading } = api.approval.accessRequestPreflight.useQuery(
+    { threadId },
+    { enabled: enabled && clientEligible, refetchOnWindowFocus: false }
+  )
+
+  const invalidate = () => utils.approval.accessRequestPreflight.invalidate({ threadId })
+
+  const requestAccess = api.approval.requestAccess.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Error requesting access', description: error.message }),
+    onSettled: invalidate,
+  })
+
+  const withdrawRequest = api.approval.withdrawAccessRequest.useMutation({
+    onError: (error) => toastError({ title: 'Error withdrawing', description: error.message }),
+    onSettled: invalidate,
+  })
+
+  const refusalReason = preflight?.refusalReason ?? null
+  const pendingRow = preflight?.pending ?? null
+
+  return {
+    canShare,
+    myLens,
+    // Until the preflight answers, the client pair is the best available guess —
+    // and it is the conservative one, since the server can only narrow it.
+    eligible: clientEligible && (preflight ? preflight.eligible || !!pendingRow : true),
+    refusalCopy:
+      refusalReason && SPOKEN_REFUSALS.includes(refusalReason)
+        ? ACCESS_REFUSAL_COPY[refusalReason]
+        : null,
+    pending: pendingRow ? { id: pendingRow.id, createdAt: new Date(pendingRow.createdAt) } : null,
+    approvers: preflight?.approvers ?? [],
+    approversAre: preflight?.approversAre ?? null,
+    subjectLabel: preflight?.subjectLabel ?? null,
+    isLoading,
+    send: (message?: string) => requestAccess.mutate({ threadId, message: message || undefined }),
+    withdraw: () => {
+      if (!pendingRow) return
+      withdrawRequest.mutate({ id: pendingRow.id })
+    },
+    isSending: requestAccess.isPending,
+    isWithdrawing: withdrawRequest.isPending,
+  }
+}

--- a/apps/web/src/components/mail-permissions/ui/request-access-popover.test.tsx
+++ b/apps/web/src/components/mail-permissions/ui/request-access-popover.test.tsx
@@ -1,0 +1,236 @@
+// apps/web/src/components/mail-permissions/ui/request-access-popover.test.tsx
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 42 §6's requester side — the eligibility truth table and the pending swap.
+ *
+ * Both are gating rules whose failure mode is a control appearing where it makes no
+ * sense, which is exactly what does not show up in a screenshot of the happy path:
+ *
+ *  - A **full-lens** viewer has nothing to ask for.
+ *  - A **Manager or org admin** below `full` can grant themselves access directly and
+ *    must get the sharing path, never an approval flow (§6.1 — `canShare` is half of
+ *    the condition, and the half most likely to be dropped).
+ *  - A **worker seat** is refused with the SEAT named, because no permission change
+ *    lifts it (§5.3) — a dead button would imply one might.
+ *  - Once sent, the trigger must **swap**, or a one-click ask becomes one-click spam
+ *    (§6.4).
+ *
+ * The header label is asserted to come from the SERVER (`preflight.subjectLabel`).
+ * That is the `metadata`-lens case: the client has no subject to render there, and a
+ * client-composed header renders an empty string instead of degrading (§6.2).
+ */
+
+const h = vi.hoisted(() => ({
+  myLens: 'metadata' as 'metadata' | 'subject' | 'full',
+  isAdminOrOwner: false,
+  canAdminInstance: false,
+  preflight: {
+    eligible: true,
+    currentLens: 'metadata',
+    pending: null as { id: string; createdAt: Date; remindedAt: string | null } | null,
+    approvers: [{ userId: 'u_sarah', name: 'Sarah Chen', image: null }],
+    approversAre: 'managers' as 'managers' | 'admins' | null,
+    subjectLabel: 'Support · 2 participants · 4 messages',
+    refusalReason: null as string | null,
+  },
+  requestAccess: vi.fn(),
+  withdrawAccessRequest: vi.fn(),
+}))
+
+vi.mock('~/components/threads/hooks', () => ({
+  useThread: () => ({ thread: { id: 'thr_1', inboxId: 'ibx_1', myLens: h.myLens } }),
+  useInbox: () => ({ inbox: { id: 'ibx_1', entityDefinitionKey: 'inbox', name: 'Support' } }),
+  toInboxAccessRecordId: (inbox: { entityDefinitionKey: string; id: string }) =>
+    `${inbox.entityDefinitionKey}:${inbox.id}`,
+}))
+vi.mock('~/hooks/use-user', () => ({ useUser: () => ({ isAdminOrOwner: h.isAdminOrOwner }) }))
+vi.mock('~/providers/capabilities-provider', () => ({
+  useAccess: () => ({ canAdminInstance: () => h.canAdminInstance }),
+}))
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      approval: { accessRequestPreflight: { invalidate: vi.fn() } },
+    }),
+    approval: {
+      accessRequestPreflight: {
+        useQuery: (_input: unknown, opts: { enabled: boolean }) => ({
+          // The query is gated on the client pair, so a full-lens viewer or a
+          // Manager never even asks — mirroring that here keeps the test honest
+          // about WHY the trigger is absent.
+          data: opts.enabled ? h.preflight : undefined,
+          isLoading: false,
+        }),
+      },
+      requestAccess: { useMutation: () => ({ mutate: h.requestAccess, isPending: false }) },
+      withdrawAccessRequest: {
+        useMutation: () => ({ mutate: h.withdrawAccessRequest, isPending: false }),
+      },
+    },
+  },
+}))
+vi.mock('./access-levels-guide', () => ({ AccessLevelsGuide: () => null }))
+vi.mock('../../global/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const { RequestAccessPopover } = await import('./request-access-popover')
+
+beforeAll(() => {
+  // Radix/floating-ui's `autoUpdate` CONSTRUCTS a ResizeObserver; the global setup
+  // stubs one that cannot be `new`ed. Same pattern as `agent-instance-access.test.tsx`.
+  class NoopResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+    Element.prototype.setPointerCapture = () => {}
+    Element.prototype.releasePointerCapture = () => {}
+  }
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.myLens = 'metadata'
+  h.isAdminOrOwner = false
+  h.canAdminInstance = false
+  h.preflight = {
+    eligible: true,
+    currentLens: 'metadata',
+    pending: null,
+    approvers: [{ userId: 'u_sarah', name: 'Sarah Chen', image: null }],
+    approversAre: 'managers',
+    subjectLabel: 'Support · 2 participants · 4 messages',
+    refusalReason: null,
+  }
+})
+
+describe('eligibility truth table (plan 42 §6.3)', () => {
+  it('offers the request to a sub-full member who cannot share', () => {
+    render(<RequestAccessPopover threadId='thr_1' />)
+    expect(screen.getByRole('button', { name: 'Request access' })).toBeInTheDocument()
+  })
+
+  it('renders NOTHING for a full-lens viewer — there is nothing to ask for', () => {
+    h.myLens = 'full'
+    const { container } = render(<RequestAccessPopover threadId='thr_1' />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders NOTHING for a sub-full ORG ADMIN — they grant themselves access directly', () => {
+    h.isAdminOrOwner = true
+    const { container } = render(<RequestAccessPopover threadId='thr_1' />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders NOTHING for a sub-full INBOX MANAGER — the sharing path, not an approval', () => {
+    h.canAdminInstance = true
+    const { container } = render(<RequestAccessPopover threadId='thr_1' />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('refusals that name a lever (plan 42 §5.3)', () => {
+  it('names the SEAT for a worker seat instead of rendering a dead button', () => {
+    h.preflight = { ...h.preflight, eligible: false, refusalReason: 'worker_seat' }
+    render(<RequestAccessPopover threadId='thr_1' />)
+
+    expect(screen.queryByRole('button', { name: 'Request access' })).not.toBeInTheDocument()
+    // The copy must point at the seat, not the profile: naming a lever the approver
+    // cannot pull is worse than naming none.
+    expect(screen.getByText(/Field seats/i)).toBeInTheDocument()
+    expect(screen.queryByText(/permission profile/i)).not.toBeInTheDocument()
+  })
+
+  it('names the closed profile when that is the actual lever', () => {
+    h.preflight = { ...h.preflight, eligible: false, refusalReason: 'front_door_closed' }
+    render(<RequestAccessPopover threadId='thr_1' />)
+    expect(screen.getByText(/permission profile/i)).toBeInTheDocument()
+  })
+
+  it('stays silent in the header slot, where there is no room for a sentence', () => {
+    h.preflight = { ...h.preflight, eligible: false, refusalReason: 'worker_seat' }
+    const { container } = render(<RequestAccessPopover threadId='thr_1' variant='icon' />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('the popover body (plan 42 §6.2)', () => {
+  it('renders the SERVER-composed header and names the approver', async () => {
+    render(<RequestAccessPopover threadId='thr_1' />)
+    await userEvent.click(screen.getByRole('button', { name: 'Request access' }))
+
+    // Server-composed: at `metadata` the requester has no subject to render, so a
+    // client-composed header would be an empty string rather than this summary.
+    expect(screen.getByText('Support · 2 participants · 4 messages')).toBeInTheDocument()
+    expect(screen.getByText('Sarah Chen (inbox manager)')).toBeInTheDocument()
+  })
+
+  it('discloses the note behind a toggle whose label switches once written', async () => {
+    render(<RequestAccessPopover threadId='thr_1' />)
+    await userEvent.click(screen.getByRole('button', { name: 'Request access' }))
+
+    expect(screen.queryByPlaceholderText('Why do you need access?')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Add a note/ }))
+
+    const note = screen.getByPlaceholderText('Why do you need access?')
+    await userEvent.type(note, 'Covering for Sarah this week')
+    expect(screen.getByRole('button', { name: /Edit note/ })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(h.requestAccess).toHaveBeenCalledWith({
+      threadId: 'thr_1',
+      message: 'Covering for Sarah this week',
+    })
+  })
+
+  it('sends without a note — most requests carry none', async () => {
+    render(<RequestAccessPopover threadId='thr_1' />)
+    await userEvent.click(screen.getByRole('button', { name: 'Request access' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(h.requestAccess).toHaveBeenCalledWith({ threadId: 'thr_1', message: undefined })
+  })
+})
+
+describe('pending state (plan 42 §6.4)', () => {
+  beforeEach(() => {
+    h.preflight = {
+      ...h.preflight,
+      pending: { id: 'req_1', createdAt: new Date(Date.now() - 2 * 86_400_000), remindedAt: null },
+    }
+  })
+
+  it('SWAPS the trigger rather than offering Send again', async () => {
+    render(<RequestAccessPopover threadId='thr_1' />)
+    expect(screen.getByRole('button', { name: 'Access requested' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Request access' })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Access requested' }))
+    expect(screen.getByText(/2 days ago · waiting on Sarah Chen/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Send' })).not.toBeInTheDocument()
+  })
+
+  it('offers Withdraw, which is the requester cancelling their OWN ask', async () => {
+    render(<RequestAccessPopover threadId='thr_1' />)
+    await userEvent.click(screen.getByRole('button', { name: 'Access requested' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Withdraw' }))
+
+    expect(h.withdrawAccessRequest).toHaveBeenCalledWith({ id: 'req_1' })
+  })
+
+  it('still offers the pending view when the server reports NOT eligible', () => {
+    // A pending request is not a refusal — the trigger has to keep showing its
+    // status, or the row silently loses the only way to withdraw.
+    h.preflight = { ...h.preflight, eligible: false, refusalReason: 'deny_cooldown' }
+    render(<RequestAccessPopover threadId='thr_1' />)
+    expect(screen.getByRole('button', { name: 'Access requested' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/mail-permissions/ui/request-access-popover.tsx
+++ b/apps/web/src/components/mail-permissions/ui/request-access-popover.tsx
@@ -1,0 +1,255 @@
+// apps/web/src/components/mail-permissions/ui/request-access-popover.tsx
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { formatDistanceToNowStrict } from 'date-fns'
+import { LockKeyhole, Pencil, Plus } from 'lucide-react'
+import { useRef, useState } from 'react'
+import { useRequestAccess } from '~/components/mail-permissions/hooks/use-request-access'
+import { Tooltip } from '../../global/tooltip'
+import { AccessLevelsGuide } from './access-levels-guide'
+
+function initials(name: string | null): string {
+  return (name ?? '?')
+    .split(' ')
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+/** "Sarah Chen (inbox manager)" / "Sarah Chen and 2 others (inbox managers)". */
+function approverSummary(
+  approvers: Array<{ name: string | null }>,
+  approversAre: 'managers' | 'admins' | null
+): string | null {
+  if (approvers.length === 0) return null
+  const first = approvers[0]?.name ?? 'A teammate'
+  const noun =
+    approversAre === 'admins'
+      ? approvers.length > 1
+        ? 'administrators'
+        : 'administrator'
+      : approvers.length > 1
+        ? 'inbox managers'
+        : 'inbox manager'
+  const rest = approvers.length - 1
+  return rest > 0 ? `${first} and ${rest} other ${noun}` : `${first} (${noun})`
+}
+
+/**
+ * Ask for full access to one conversation (plan 42 §6.2).
+ *
+ * **Deliberately not a mode of `ThreadSharePopover`.** That popover's body is
+ * `MailGranteeList` — other people, immediate persistence, no submit. This has one
+ * implicit subject (me), no grantee list, and a submit-and-wait contract with a
+ * pending state afterwards. The interaction contracts are opposites and almost
+ * nothing in the body is common, so what is shared is the CHROME and the tier
+ * vocabulary: the popover shell, the footer guide link, and `AccessLevelsGuide`.
+ *
+ * There is no lens picker — thread requests are hardcoded `full` (§0.2), which is
+ * also what removes the Enterprise refusal case (§5.2). If a picker ever arrives it
+ * goes through `LensSelect`, "the one tier picker every mail-permission surface
+ * uses", rather than a second select.
+ *
+ * Renders nothing when the viewer has nothing to ask for. The two refusals that
+ * name a lever are spoken instead (§5.3) — a worker seat especially, because no
+ * permission change lifts it and a dead button would imply one might.
+ */
+export function RequestAccessPopover({
+  threadId,
+  variant = 'inline',
+}: {
+  threadId: string
+  /** `inline` sits in the redaction banner; `icon` fills the header's share slot. */
+  variant?: 'inline' | 'icon'
+}) {
+  const [open, setOpen] = useState(false)
+  const [guideOpen, setGuideOpen] = useState(false)
+  const [noteOpen, setNoteOpen] = useState(false)
+  const [note, setNote] = useState('')
+  const noteRef = useRef<HTMLTextAreaElement>(null)
+
+  const {
+    eligible,
+    refusalCopy,
+    pending,
+    approvers,
+    approversAre,
+    subjectLabel,
+    send,
+    withdraw,
+    isSending,
+    isWithdrawing,
+  } = useRequestAccess({ threadId })
+
+  if (!eligible) {
+    // A refusal is worth saying in the banner, where there is room for a sentence.
+    // In the header's icon slot there is not, and a tooltip nobody hovers is not
+    // communication — so that mount stays silent.
+    if (refusalCopy && variant === 'inline') {
+      return <span className='text-muted-foreground text-xs'>{refusalCopy}</span>
+    }
+    return null
+  }
+
+  const summary = approverSummary(approvers, approversAre)
+  const trimmedNote = note.trim()
+
+  /**
+   * The disclosed note (§6.2), following the `line-rows.tsx` precedent: the toggle
+   * reveals and autofocuses the field and switches its own label. A WRITTEN note is
+   * never hidden again — collapsing it would silently drop text the user typed, so
+   * the toggle re-focuses instead of closing once there is content.
+   */
+  const toggleNote = () => {
+    if (!noteOpen) {
+      setNoteOpen(true)
+      requestAnimationFrame(() => noteRef.current?.focus())
+      return
+    }
+    if (trimmedNote) {
+      noteRef.current?.focus()
+      return
+    }
+    setNoteOpen(false)
+  }
+
+  const handleSend = () => {
+    send(trimmedNote || undefined)
+    setOpen(false)
+  }
+
+  const trigger =
+    variant === 'icon' ? (
+      <Button variant='ghost' size='icon' className='rounded-full hover:bg-foreground/10'>
+        <LockKeyhole />
+        <span className='sr-only'>{pending ? 'Access requested' : 'Request access'}</span>
+      </Button>
+    ) : (
+      <Button variant='outline' size='sm'>
+        {pending ? 'Access requested' : 'Request access'}
+      </Button>
+    )
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          {variant === 'icon' ? (
+            <div>
+              <Tooltip content={pending ? 'Access requested' : 'Request access'}>{trigger}</Tooltip>
+            </div>
+          ) : (
+            trigger
+          )}
+        </PopoverTrigger>
+        <PopoverContent align='end' className='w-80 p-0'>
+          <div className='border-b px-3 py-2'>
+            <span className='font-medium text-sm'>
+              {pending ? 'Access requested' : 'Request access'}
+            </span>
+          </div>
+
+          <div className='space-y-2 px-3 py-2'>
+            {/* Server-composed, so a `metadata` viewer gets inbox + participants +
+                message count rather than an empty subject string (§6.2). */}
+            {subjectLabel ? <p className='text-sm leading-5'>{subjectLabel}</p> : null}
+
+            {/* Naming the approver is load-bearing: it is the difference between
+                "sent into the void" and "Sarah will see this". Resolved on the
+                server — the client never reconstructs inbox authority. */}
+            {summary ? (
+              <div className='flex items-center gap-2'>
+                <span className='-space-x-2 flex items-center'>
+                  {approvers.slice(0, 3).map((approver) => (
+                    <Avatar key={approver.userId} className='size-5 border-2 border-background'>
+                      <AvatarImage src={approver.image || undefined} alt={approver.name ?? ''} />
+                      <AvatarFallback className='text-[9px]'>
+                        {initials(approver.name)}
+                      </AvatarFallback>
+                    </Avatar>
+                  ))}
+                </span>
+                <span className='text-muted-foreground text-xs'>{summary}</span>
+              </div>
+            ) : null}
+
+            {pending ? (
+              <p className='text-muted-foreground text-xs'>
+                Requested {formatDistanceToNowStrict(pending.createdAt, { addSuffix: true })}
+                {approvers.length > 0
+                  ? ` · waiting on ${approvers[0]?.name ?? 'your team'}`
+                  : ' · waiting for a decision'}
+              </p>
+            ) : (
+              <>
+                <button
+                  type='button'
+                  onClick={toggleNote}
+                  className='flex items-center gap-1.5 text-muted-foreground text-xs underline-offset-2 hover:underline'>
+                  {noteOpen && trimmedNote ? (
+                    <Pencil className='size-3' />
+                  ) : (
+                    <Plus className='size-3' />
+                  )}
+                  {trimmedNote ? 'Edit note' : 'Add a note'}
+                </button>
+                {noteOpen ? (
+                  <Textarea
+                    ref={noteRef}
+                    value={note}
+                    onChange={(event) => setNote(event.target.value)}
+                    placeholder='Why do you need access?'
+                    rows={2}
+                    maxLength={2000}
+                    disabled={isSending}
+                    className='text-sm'
+                  />
+                ) : null}
+              </>
+            )}
+          </div>
+
+          <div className='flex items-center justify-between gap-2 border-t px-3 py-2'>
+            <button
+              type='button'
+              className='text-muted-foreground text-xs underline-offset-2 hover:underline'
+              onClick={() => {
+                setOpen(false)
+                setGuideOpen(true)
+              }}>
+              Learn about access levels
+            </button>
+            {pending ? (
+              <Button
+                variant='outline'
+                size='sm'
+                loading={isWithdrawing}
+                loadingText='Withdrawing...'
+                onClick={() => {
+                  withdraw()
+                  setOpen(false)
+                }}>
+                Withdraw
+              </Button>
+            ) : (
+              <div className='flex items-center gap-2'>
+                <Button variant='ghost' size='sm' onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button size='sm' loading={isSending} loadingText='Sending...' onClick={handleSend}>
+                  Send
+                </Button>
+              </div>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+      <AccessLevelsGuide open={guideOpen} onOpenChange={setGuideOpen} />
+    </>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
+++ b/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
@@ -10,14 +10,14 @@ import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/pop
 import { Info, Share2 } from 'lucide-react'
 import { useState } from 'react'
 import { useMailShare } from '~/components/mail-permissions/hooks/use-mail-share'
+import { useRequestAccess } from '~/components/mail-permissions/hooks/use-request-access'
 import { useActor } from '~/components/resources/hooks'
-import { toInboxAccessRecordId, useInbox, useThread } from '~/components/threads/hooks'
-import { useUser } from '~/hooks/use-user'
-import { useAccess } from '~/providers/capabilities-provider'
+import { useInbox, useThread } from '~/components/threads/hooks'
 import { Tooltip } from '../../global/tooltip'
 import { AccessLevelsGuide } from './access-levels-guide'
 import { EnterpriseGate, useMailPermissionsGated } from './enterprise-gate'
 import { MailGranteeList } from './mail-grantee-list'
+import { RequestAccessPopover } from './request-access-popover'
 
 /** A tiny stacked avatar for the share button's grantee cluster. */
 function MiniActorAvatar({ actorId }: { actorId: ActorId }) {
@@ -51,21 +51,26 @@ export function ThreadSharePopover({ threadId }: { threadId: string }) {
 
   const { thread } = useThread({ threadId })
   const { inbox } = useInbox(thread?.inboxId)
-  const { isAdminOrOwner } = useUser()
-  const { canAdminInstance } = useAccess()
   const gated = useMailPermissionsGated()
 
   const recordId = toRecordId('thread', threadId)
   const { grants, unmanageableGrants, grant, changeLens, revoke } = useMailShare({ recordId })
 
-  // Inbox Managers may share without being org admins (delegation).
-  const canShare = isAdminOrOwner || (!!inbox && canAdminInstance(toInboxAccessRecordId(inbox)))
+  // `canShare` (org admin/owner, or Manager of this thread's inbox) lives in
+  // `useRequestAccess` — it is half of the requester condition too, so plan 42 §6.1
+  // moved the expression there rather than leaving a copy at each mount.
+  const { canShare, myLens } = useRequestAccess({ threadId })
 
   const { actor: assignee } = useActor({ actorId: thread?.assigneeId ?? undefined })
 
   if (!thread) return null
-  // Non-sharers only get the read-only list once the thread has explicit grants.
-  if (!canShare && grants.length === 0) return null
+  // Non-sharers only get the read-only list once the thread has explicit grants —
+  // but plan 42 §6.1 mount 2 makes this the SECONDARY request slot rather than an
+  // empty header: being unable to administer sharing is not the same as lacking read
+  // access, so only a sub-`full` viewer gets the trigger here.
+  if (!canShare && grants.length === 0) {
+    return myLens !== 'full' ? <RequestAccessPopover threadId={threadId} variant='icon' /> : null
+  }
 
   const floor = inbox?.defaultLens ?? 'full'
 

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Ban, Lock } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useChannel } from '~/components/channels/hooks/use-channels'
+import { RequestAccessPopover } from '~/components/mail-permissions/ui/request-access-popover'
 import {
   useMessage,
   useMessageParticipants,
@@ -188,6 +189,12 @@ export function ThreadMessages() {
             Message content is hidden — you have{' '}
             {myLens === 'subject' ? 'subject-only' : 'activity-only'} access to this conversation.
           </AlertDescription>
+          {/* Plan 42 §6.1 mount 1 — the request trigger belongs beside the copy
+              that already explains the problem. It renders itself away for anyone
+              who can simply grant themselves access instead. */}
+          <div className='ml-auto shrink-0'>
+            <RequestAccessPopover threadId={thread.id} />
+          </div>
         </Alert>
       </div>
     )

--- a/apps/web/src/server/api/routers/approval.ts
+++ b/apps/web/src/server/api/routers/approval.ts
@@ -9,6 +9,7 @@ import {
   getApprovalRequestWithContext,
   getPendingApprovalsForUser,
   getPendingCount,
+  getThreadAccessRequestApproverView,
   preflightThreadAccessRequest,
   resolveApprovalByToken,
   resolveApprovalRequest,
@@ -194,6 +195,35 @@ export const approvalRouter = createTRPCRouter({
         if (isAuxxError(error)) throw error
         throw error
       }
+    }),
+
+  /**
+   * The approver-side detail for one thread access request (plan 42 §7).
+   *
+   * Separate from `getApprovalDetails` rather than folded into it: the hydration
+   * decision needs the acting approver's own mail lens on the target, and paying for
+   * two visibility reads plus a thread load on every WORKFLOW drawer open would be
+   * the wrong trade. Returns `null` for a non-thread-access request, so the row
+   * falls back to the generic details instead of rendering mail copy over it.
+   *
+   * Gated by `canUserViewApproval` — the same audience read the generic details use,
+   * for the same reason: an approver may read a request they already decided.
+   */
+  accessRequestDetails: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      if (!(await canUserViewApproval(ctx.db, ctx.session.userId, input.id))) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You are not authorized to view this access request',
+        })
+      }
+      return await getThreadAccessRequestApproverView(
+        ctx.db,
+        ctx.session.organizationId,
+        ctx.session.userId,
+        input.id
+      )
     }),
 
   /** The requester withdraws their own pending request. */

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -154,6 +154,12 @@
       "import": "./dist/approval-requests/index.mjs",
       "default": "./src/approval-requests/index.ts"
     },
+    "./approval-requests/client": {
+      "types": "./src/approval-requests/client.ts",
+      "source": "./src/approval-requests/client.ts",
+      "import": "./dist/approval-requests/client.mjs",
+      "default": "./src/approval-requests/client.ts"
+    },
     "./approvals": {
       "types": "./src/approvals/index.ts",
       "source": "./src/approvals/index.ts",

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -20,7 +20,15 @@ const textareaVariants = cva(
 
 export interface TextareaProps
   extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'>,
-    VariantProps<typeof textareaVariants> {}
+    VariantProps<typeof textareaVariants> {
+  /**
+   * React 19 passes `ref` to function components as an ordinary prop, but
+   * `TextareaHTMLAttributes` does not declare it — so a caller that needs to focus
+   * the field (a progressively-disclosed note, say) got a type error on a prop that
+   * works at runtime. Declared here rather than reached around with `getElementById`.
+   */
+  ref?: React.Ref<HTMLTextAreaElement>
+}
 
 function Textarea({ className, variant, ...props }: TextareaProps) {
   return <textarea className={cn(textareaVariants({ variant, className }))} {...props} />


### PR DESCRIPTION
Requester and approver surfaces for thread access requests. The backend landed in #1399 and nothing consumed it — plan 42's §6 and §7 were the outstanding half, so the feature was invisible.

Plan: `plans/permissions/v2/42-mail-access-requests.md` §6, §7.

## Requester side (§6)

- **`use-request-access`** owns the entry condition, and is where `thread-share-popover.tsx`'s inline `canShare` expression **moved to** — it is half of the requester condition, so the banner and the popover read one implementation instead of a copy each. The fork is `myLens !== 'full' && !canShare`, deliberately *not* plan 28 §4.6's generic `deniedBy() === 'permission'`: mail redaction is a lens, not a denied permission key.
- **`RequestAccessPopover`** shares the share popover's *chrome*, not its body. `MailGranteeList` is other-people-with-immediate-persistence; a request is one implicit subject with submit-and-wait. No lens picker — the lane is hardcoded `full`, which is also what removes the Enterprise refusal case.
- **Two mounts**: the redaction banner (primary — beside the copy that already explains the problem) and the share slot's previously `return null` empty state (secondary). Not the list rows, not the compose affordance.
- **Pending state swaps the trigger** and offers Withdraw. With a one-click ask, that plus the dedup index and the deny cooldown is what stops one-click spam.
- **Worker-seat and closed-profile refusals are spoken**, naming the actual lever. A dead button implies a lever exists; for a worker seat none does, because `Area.inboxes` is absent from `WORKER_AREAS` and the seat ceiling clamps last.

## Approver side (§7)

`AccessRequestRow`, a sibling to `ConfirmationRow` in the existing Approvals tab, dispatched on `request.kind`. **Live wins only when this approver can hydrate**: sharing authority and a mail-reading lens are different things, so a downgraded admin — or one deciding a null-inbox request — sees the durable snapshot rather than leaked live subject data. Declining names the cooldown; a deleted target disables the decision instead of offering an Approve the handler would refuse.

## Backend deltas the UI required

| Change | Why |
|---|---|
| preflight returns `subjectLabel` + `approversAre` | at `metadata` the redactor blanks `subject`, so a client-composed header renders an **empty string** instead of degrading to inbox + participants + count. Composed through the same `buildThreadSubjectLabel` the durable snapshot uses. |
| `getThreadAccessRequestApproverView` + `approval.accessRequestDetails` | the hydration decision needs the approver's own lens; folding it into `getApprovalDetails` would make every *workflow* drawer pay for two visibility reads and a thread load. |
| `getPendingApprovalsForUser` attaches `requester` | one member-cache read for the whole list, no `User` join. "Who asked" leads the collapsed row, so it cannot wait for the lazily-fetched drawer. |
| `TextareaProps` declares `ref` | React 19 passes it to function components; `TextareaHTMLAttributes` does not name it. |

Note: the lib-side half of these landed in main already — #1400 swept them up while cutting redundant queries in the same module.

## Tests

- **Eligibility truth table** (§13): a full-lens viewer, a sub-full **org admin** and a sub-full **inbox Manager** each get nothing — the last two have the direct sharing path and must never enter an approval flow.
- Both spoken refusals, with the worker-seat one asserted to name the **seat** and not the profile.
- Note disclosure (label switches, non-empty note is never hidden), send with and without a note.
- Pending swap: the trigger reads "Access requested", Send is gone, Withdraw calls through; a pending row still renders its status when the server reports not-eligible.
- **Approver hydration fallback in both directions** — a `full`-lens Manager gets the live subject, a `metadata`-lens admin gets the snapshot and the assertion pins that it does *not* contain the subject.

73 lib tests and 13 web tests pass. `tsc` clean on every touched file (per-file grep against the pre-change baseline; the web/lib baselines carry ~3.9k pre-existing errors).

## Still outstanding from §13

`apps/web` router tests for the new procedure, the notification-origin assert, and the browser pass (approve → thread readable without reload via `visibility:changed`).