### PR TITLE
fix(permissions): choose the access level before writing a grant

### DIFF
--- a/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
+++ b/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
@@ -45,6 +45,7 @@ export function ContactSharedWithCard({ entityInstanceId }: DrawerTabProps) {
           disabled={!isAdminOrOwner}
           unmanageableGrants={unmanageableGrants}
           emptyHint='Not shared. Only inbox members see these conversations.'
+          stagedAdd
         />
       </EnterpriseGate>
       <button

--- a/apps/web/src/components/mail-permissions/ui/mail-grantee-list.tsx
+++ b/apps/web/src/components/mail-permissions/ui/mail-grantee-list.tsx
@@ -26,6 +26,7 @@ export function MailGranteeList({
   lockedActorIds,
   hideAddButton,
   unmanageableGrants,
+  stagedAdd,
 }: {
   grants: Array<{ actorId: ActorId; choice: LensChoice }>
   onGrant: (actorId: ActorId, choice: LensChoice) => void
@@ -38,6 +39,13 @@ export function MailGranteeList({
   hideAddButton?: boolean
   /** Grants on a kind this list can't address (e.g. `profile`) — disclosed, not dropped. */
   unmanageableGrants?: UnmanageableGrant[]
+  /**
+   * Drill into a staged add page instead of granting Full on pick. Set by the
+   * surfaces that persist immediately (thread share popover, contact card); the
+   * inbox form stages its grants in local form state and submits them with the
+   * inbox, so it never had the premature-notification problem to fix.
+   */
+  stagedAdd?: boolean
 }) {
   return (
     <GranteeList<LensChoice>
@@ -56,6 +64,17 @@ export function MailGranteeList({
           size='sm'
           variant='transparent'
           className='h-7 w-36'
+        />
+      )}
+      stagedAdd={stagedAdd}
+      renderBatchPicker={({ value, onChange, disabled: panelDisabled }) => (
+        <LensSelect
+          value={value}
+          onChange={onChange}
+          includeManager={includeManager}
+          disabled={panelDisabled}
+          size='sm'
+          className='h-8 w-40'
         />
       )}
       disabled={disabled}

--- a/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
+++ b/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
@@ -120,6 +120,7 @@ export function ThreadSharePopover({ threadId }: { threadId: string }) {
               disabled={!canShare || gated}
               unmanageableGrants={unmanageableGrants}
               emptyHint='Not shared with anyone yet.'
+              stagedAdd
             />
           </div>
           <div className='space-y-1 border-t px-3 py-2 text-muted-foreground text-xs'>

--- a/apps/web/src/components/permissions/ui/grantee-add-panel.test.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-add-panel.test.tsx
@@ -1,0 +1,232 @@
+// apps/web/src/components/permissions/ui/grantee-add-panel.test.tsx
+
+import type { ActorId } from '@auxx/types/actor'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The staged add flow, and specifically the two things whose failure mode is a
+ * WRONG NOTIFICATION rather than a visible defect.
+ *
+ * `grantInstanceAccess` gates its share notification on `xmax = 0` — insert
+ * only. So the level carried by the FIRST write is the level the recipient is
+ * told about, permanently: a later downgrade is an `ON CONFLICT UPDATE` and
+ * notifies nobody. That makes two asserts load-bearing, and both of them pass
+ * vacuously if written loosely:
+ *
+ *  - **Picking writes nothing.** `expect(onGrant).not.toHaveBeenCalled()` after
+ *    selecting. This is the whole bug; delete the staging and it fails.
+ *  - **Submit writes the CHOSEN level, not `defaultChoice`.** A test that only
+ *    asserts "onGrant was called" passes with the bug fully intact, because the
+ *    old code called it too — just with `'full'` at the wrong moment.
+ */
+
+const h = vi.hoisted(() => ({
+  /** Actors the fake picker offers. */
+  available: [
+    { actorId: 'user:u_sarah' as ActorId, name: 'Sarah Chen' },
+    { actorId: 'user:u_ben' as ActorId, name: 'Ben Ortiz' },
+    { actorId: 'group:g_support' as ActorId, name: 'Support team' },
+  ],
+  /** `excludeIds` the panel handed the picker on its last render. */
+  lastExcludeIds: [] as ActorId[],
+}))
+
+// The real content queries tRPC and the actor store. Stub it down to what the
+// panel's contract actually is: a multi-select over ActorIds.
+vi.mock('~/components/pickers/actor-picker', () => ({
+  ActorPickerContent: ({
+    value,
+    onChange,
+    excludeIds = [],
+  }: {
+    value: ActorId[]
+    onChange: (next: ActorId[]) => void
+    excludeIds?: ActorId[]
+  }) => {
+    h.lastExcludeIds = excludeIds
+    return (
+      <div>
+        {h.available
+          .filter((a) => !excludeIds.includes(a.actorId))
+          .map((a) => (
+            <button
+              key={a.actorId}
+              type='button'
+              onClick={() =>
+                onChange(
+                  value.includes(a.actorId)
+                    ? value.filter((v) => v !== a.actorId)
+                    : [...value, a.actorId]
+                )
+              }>
+              {a.name}
+            </button>
+          ))}
+      </div>
+    )
+  },
+}))
+
+vi.mock('~/components/resources/hooks/use-actor', () => ({
+  useActor: ({ actorId }: { actorId?: ActorId }) => ({
+    actor: actorId
+      ? { actorId, type: actorId.startsWith('group:') ? 'group' : 'user', name: 'Existing person' }
+      : undefined,
+    isLoading: false,
+    isNotFound: false,
+  }),
+}))
+
+// `LensSelect` opens an upgrade dialog for sub-`full` tiers when the org lacks
+// the feature — ungated here so the tier change under test actually lands.
+vi.mock('~/components/mail-permissions/ui/enterprise-gate', () => ({
+  useMailPermissionsGated: () => false,
+  MailPermissionsUpgradeDialog: () => null,
+}))
+
+const { MailGranteeList } = await import('~/components/mail-permissions/ui/mail-grantee-list')
+
+beforeAll(() => {
+  // `CommandBreadcrumb`'s ScrollArea and Radix Select's `autoUpdate` both
+  // CONSTRUCT observers; the global setup stubs ones that cannot be `new`ed.
+  // Same pattern as `request-access-popover.test.tsx`.
+  class NoopObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', NoopObserver)
+  vi.stubGlobal('IntersectionObserver', NoopObserver)
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+    Element.prototype.setPointerCapture = () => {}
+    Element.prototype.releasePointerCapture = () => {}
+  }
+  Element.prototype.scrollIntoView = () => {}
+})
+
+const onGrant = vi.fn()
+const onChangeLens = vi.fn()
+const onRevoke = vi.fn()
+
+function renderList(
+  grants: Array<{ actorId: ActorId; choice: 'full' | 'subject' | 'metadata' }> = []
+) {
+  // The grantee rows' remove button is a tooltip trigger — Radix throws without
+  // a provider, which the app supplies globally.
+  return render(
+    <TooltipProvider>
+      <MailGranteeList
+        grants={grants}
+        onGrant={onGrant}
+        onChangeLens={onChangeLens}
+        onRevoke={onRevoke}
+        stagedAdd
+      />
+    </TooltipProvider>
+  )
+}
+
+/** Open the drill-down page. */
+async function openAddPage(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /add people or groups/i }))
+}
+
+/** Pick the batch tier from the panel's `LensSelect`. */
+async function selectTier(user: ReturnType<typeof userEvent.setup>, label: RegExp) {
+  await user.click(screen.getByRole('combobox'))
+  await user.click(screen.getByRole('option', { name: label }))
+}
+
+describe('staged grantee add', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.lastExcludeIds = []
+  })
+
+  it('writes nothing when an actor is picked — only submit persists', async () => {
+    const user = userEvent.setup()
+    renderList()
+    await openAddPage(user)
+
+    await user.click(screen.getByRole('button', { name: 'Sarah Chen' }))
+    await user.click(screen.getByRole('button', { name: 'Ben Ortiz' }))
+
+    // The entire bug: the old flow had already granted Full to both by now, and
+    // notified them, before the admin ever saw the tier control.
+    expect(onGrant).not.toHaveBeenCalled()
+  })
+
+  it('submits at the chosen level, not the default', async () => {
+    const user = userEvent.setup()
+    renderList()
+    await openAddPage(user)
+
+    await user.click(screen.getByRole('button', { name: 'Sarah Chen' }))
+    await selectTier(user, /subject only/i)
+    await user.click(screen.getByRole('button', { name: /^add$/i }))
+
+    // `defaultChoice` for mail is 'full'. Asserting only "was called" would pass
+    // against the bug.
+    expect(onGrant).toHaveBeenCalledTimes(1)
+    expect(onGrant).toHaveBeenCalledWith('user:u_sarah', 'subject')
+  })
+
+  it('grants every selected actor at the same chosen level', async () => {
+    const user = userEvent.setup()
+    renderList()
+    await openAddPage(user)
+
+    await user.click(screen.getByRole('button', { name: 'Sarah Chen' }))
+    await user.click(screen.getByRole('button', { name: 'Support team' }))
+    await selectTier(user, /activity only/i)
+    await user.click(screen.getByRole('button', { name: /add 2/i }))
+
+    expect(onGrant.mock.calls).toEqual([
+      ['user:u_sarah', 'metadata'],
+      ['group:g_support', 'metadata'],
+    ])
+  })
+
+  it('returns to the list on submit', async () => {
+    const user = userEvent.setup()
+    renderList()
+    await openAddPage(user)
+    await user.click(screen.getByRole('button', { name: 'Sarah Chen' }))
+    await user.click(screen.getByRole('button', { name: /^add$/i }))
+
+    expect(screen.getByRole('button', { name: /add people or groups/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Sarah Chen' })).not.toBeInTheDocument()
+  })
+
+  it('discards the selection on cancel', async () => {
+    const user = userEvent.setup()
+    renderList()
+    await openAddPage(user)
+    await user.click(screen.getByRole('button', { name: 'Sarah Chen' }))
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onGrant).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /add people or groups/i })).toBeInTheDocument()
+  })
+
+  it('cannot submit an empty selection', async () => {
+    const user = userEvent.setup()
+    renderList()
+    await openAddPage(user)
+
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeDisabled()
+  })
+
+  it('excludes existing grantees from the picker', async () => {
+    const user = userEvent.setup()
+    renderList([{ actorId: 'user:u_sarah' as ActorId, choice: 'full' }])
+    await openAddPage(user)
+
+    expect(h.lastExcludeIds).toContain('user:u_sarah')
+    expect(screen.queryByRole('button', { name: 'Sarah Chen' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/permissions/ui/grantee-add-panel.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-add-panel.tsx
@@ -1,0 +1,97 @@
+// apps/web/src/components/permissions/ui/grantee-add-panel.tsx
+'use client'
+
+import type { ActorId } from '@auxx/types/actor'
+import { Button } from '@auxx/ui/components/button'
+import { type KeyboardEvent, type ReactNode, useState } from 'react'
+import { ActorPickerContent } from '~/components/pickers/actor-picker'
+
+export interface GranteeAddPanelProps<TChoice extends string> {
+  /** Grantees already on the list — excluded from the picker's results. */
+  excludeIds: ActorId[]
+  /** Level a fresh batch starts at. */
+  defaultChoice: TChoice
+  /**
+   * The level select for the batch. Deliberately NOT `GranteeList`'s
+   * `renderPicker`: that one is row-shaped (it takes an `actorId` so a picker can
+   * look up per-grantee data, e.g. the instance dead-grant warning) and none of
+   * that has meaning for a batch that has not been written yet.
+   */
+  renderLevelSelect: (args: {
+    value: TChoice
+    onChange: (choice: TChoice) => void
+    disabled: boolean
+  }) => ReactNode
+  /** Called once with the whole selection. The only thing that persists anything. */
+  onSubmit: (actorIds: ActorId[], choice: TChoice) => void
+  onCancel: () => void
+  disabled?: boolean
+}
+
+/**
+ * The staged "add grantees" page: an inline actor picker, one level select for
+ * the whole batch, and a submit. **Nothing is written until submit.**
+ *
+ * This exists because the immediate-persistence alternative sends a wrong
+ * notification that can never be corrected. `GranteeAddButton` granted on pick
+ * at `defaultChoice`, and `grantInstanceAccess` gates its share notification on
+ * `xmax = 0` — insert only. So picking someone told them *"shared a conversation
+ * with you"* at Full access, and the admin's next click, which downgrades them to
+ * Subject only, is an `ON CONFLICT UPDATE` that notifies nobody. Choosing the
+ * level before the first write is what makes the notification true.
+ *
+ * Host-agnostic and generic over the level vocabulary: mail drills into it as a
+ * `CommandNavigation` page inside the share popover, and it is shaped so the
+ * instance-access surfaces can adopt it without a second implementation.
+ */
+export function GranteeAddPanel<TChoice extends string>({
+  excludeIds,
+  defaultChoice,
+  renderLevelSelect,
+  onSubmit,
+  onCancel,
+  disabled = false,
+}: GranteeAddPanelProps<TChoice>) {
+  const [selected, setSelected] = useState<ActorId[]>([])
+  const [choice, setChoice] = useState<TChoice>(defaultChoice)
+
+  // Inside a Popover, Escape closes the whole popover — which on this page
+  // discards the host surface rather than the page, and reads as a crash. Take
+  // it as "go back" and stop it before Radix sees it.
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Escape') return
+    event.preventDefault()
+    event.stopPropagation()
+    onCancel()
+  }
+
+  return (
+    <div className='flex flex-col' onKeyDown={handleKeyDown}>
+      <ActorPickerContent
+        value={selected}
+        onChange={setSelected}
+        target='both'
+        multi
+        excludeIds={excludeIds}
+        disabled={disabled}
+        placeholder='Search people or groups...'
+        className='[&_[data-slot=command-list]]:max-h-[220px]'
+      />
+
+      <div className='flex items-center justify-between gap-2 border-t pt-2'>
+        {renderLevelSelect({ value: choice, onChange: setChoice, disabled })}
+        <div className='flex items-center gap-1'>
+          <Button variant='ghost' size='sm' onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            size='sm'
+            disabled={disabled || selected.length === 0}
+            onClick={() => onSubmit(selected, choice)}>
+            {selected.length > 1 ? `Add ${selected.length}` : 'Add'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/permissions/ui/grantee-list.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-list.tsx
@@ -3,6 +3,12 @@
 
 import type { ActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
+import {
+  CommandBreadcrumb,
+  CommandNavigation,
+  type NavigationItem,
+  useCommandNavigationOptional,
+} from '@auxx/ui/components/command'
 import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { INDENT_REM, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
@@ -15,6 +21,15 @@ import { ActorAvatar } from '~/components/resources/ui/actor-badge'
 import { actorAvatarType } from '~/components/resources/utils/actor-id'
 import type { UnmanageableGrant } from '../utils/grantee'
 import { unmanageableGrantsNote } from '../utils/grantee'
+import { GranteeAddPanel } from './grantee-add-panel'
+
+/** The one drill-down page this list owns. */
+interface GranteeNavItem extends NavigationItem {
+  id: 'add-grantee'
+  label: string
+}
+
+const ADD_PAGE: GranteeNavItem = { id: 'add-grantee', label: 'Add people' }
 
 /**
  * Render the level picker for one editable grantee row. The neutral list is
@@ -73,6 +88,32 @@ export interface GranteeListProps<TChoice extends string> {
    * belong to.
    */
   depth?: number
+  /**
+   * Opt into the staged add flow: the inline "Add people or groups" trigger
+   * drills down to a {@link GranteeAddPanel} page — picker, one level select,
+   * submit — instead of granting on pick at `defaultChoice`. Requires
+   * `renderBatchPicker`.
+   *
+   * Opt-IN rather than the default because granting on pick is what sends a
+   * wrong share notification that can never be corrected (see
+   * `grantee-add-panel.tsx`), and the fix is being rolled out one surface family
+   * at a time: mail first, the instance-access surfaces after. Two things block
+   * flipping this on for them — `instance-share-body`'s `renderPicker` returns a
+   * per-row dead-grant warning alongside its select (meaningless for a batch),
+   * and `instance-baseline-rows` mounts this list at `depth > 0` inside a tree,
+   * where swapping the whole body for a picker reads worse than a popover.
+   */
+  stagedAdd?: boolean
+  /**
+   * The level select for the staged add page. Separate from `renderPicker`
+   * because that one is row-shaped (it receives an `actorId`) and the staged
+   * batch has no rows yet.
+   */
+  renderBatchPicker?: (args: {
+    value: TChoice
+    onChange: (choice: TChoice) => void
+    disabled: boolean
+  }) => ReactNode
 }
 
 /**
@@ -85,8 +126,22 @@ export interface GranteeListProps<TChoice extends string> {
  * Lifted out of `mail-permissions/ui` (was mail-`LensSelect`-specific) to a
  * neutral home with a pluggable picker so both mail and instance-access sharing
  * share one list component with two pickers.
+ *
+ * With `stagedAdd`, provides the `CommandNavigation` stack the add page drills
+ * into. Self-providing rather than requiring one from the host so the two mail
+ * mounts don't each have to wire a stack; a host that already has one is reused
+ * instead (`useCommandNavigationOptional` in the body).
  */
-export function GranteeList<TChoice extends string>({
+export function GranteeList<TChoice extends string>(props: GranteeListProps<TChoice>) {
+  if (!props.stagedAdd) return <GranteeListBody {...props} />
+  return (
+    <CommandNavigation<GranteeNavItem>>
+      <GranteeListBody {...props} />
+    </CommandNavigation>
+  )
+}
+
+function GranteeListBody<TChoice extends string>({
   grants,
   onGrant,
   onChange,
@@ -100,17 +155,45 @@ export function GranteeList<TChoice extends string>({
   hideAddButton = false,
   unmanageableGrants,
   depth = 0,
+  stagedAdd = false,
+  renderBatchPicker,
 }: GranteeListProps<TChoice>) {
+  const nav = useCommandNavigationOptional<GranteeNavItem>()
   const locked = useMemo(() => new Set(lockedActorIds), [lockedActorIds])
   const hiddenNote = useMemo(
     () => unmanageableGrantsNote(unmanageableGrants ?? []),
     [unmanageableGrants]
   )
+  const currentActorIds = useMemo(() => grants.map((g) => g.actorId), [grants])
 
   // `TreeRow` indents itself from `depth`; the empty state, the disclosure note
   // and the add trigger are plain elements, so they take the same offset by hand
   // or they hang left of the rows they belong to.
   const indent = { paddingLeft: `${depth * INDENT_REM}rem` }
+
+  const staged = stagedAdd && nav !== null && renderBatchPicker !== undefined
+
+  if (staged && nav.current?.id === ADD_PAGE.id) {
+    return (
+      <div className='space-y-2' style={indent}>
+        <CommandBreadcrumb rootLabel='Shared with' className='border-b-0 px-0 py-0' />
+        <GranteeAddPanel<TChoice>
+          excludeIds={currentActorIds}
+          defaultChoice={defaultChoice}
+          renderLevelSelect={renderBatchPicker}
+          disabled={disabled}
+          onCancel={nav.pop}
+          onSubmit={(actorIds, choice) => {
+            // One write per actor at the level the admin just picked — the same
+            // per-grantee upsert the rows use, so each recipient's share
+            // notification names the access they actually got.
+            for (const actorId of actorIds) onGrant(actorId, choice)
+            nav.pop()
+          }}
+        />
+      </div>
+    )
+  }
 
   return (
     <div className='space-y-0.5'>
@@ -147,12 +230,24 @@ export function GranteeList<TChoice extends string>({
 
       {!hideAddButton && (
         <div style={indent}>
-          <GranteeAddButton
-            grants={grants}
-            onGrant={onGrant}
-            defaultChoice={defaultChoice}
-            disabled={disabled}
-          />
+          {staged ? (
+            <Button
+              variant='ghost'
+              size='sm'
+              className='text-muted-foreground'
+              disabled={disabled}
+              onClick={() => nav.push(ADD_PAGE)}>
+              <Plus />
+              Add people or groups
+            </Button>
+          ) : (
+            <GranteeAddButton
+              grants={grants}
+              onGrant={onGrant}
+              defaultChoice={defaultChoice}
+              disabled={disabled}
+            />
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Follow-up to #1401, found by exercising the Share conversation popover.

## The bug

Adding a member/group **announced Full access before the admin had picked a level**, and the correction was silent.

`GranteeAddButton` granted on pick at `defaultChoice` (mail: `full`):

```ts
for (const actorId of nextIds) {
  if (!existing.has(actorId)) onGrant(actorId, defaultChoice)
}
```

and `grantInstanceAccess` decides whether to notify from the upsert's `RETURNING xmax = 0` — **insert only**. So the pick sent *"X shared a conversation with you: &lt;subject&gt;"* with `metadata.lens = 'full'`, and the admin's next click — downgrading to Subject only — is an `ON CONFLICT UPDATE`, `isNewGrant === false`, **no correcting notification, ever**.

The notification is firing on the correct event. The **write was premature**. Nothing in `resource-access-service.ts` changes here — no schema, no migration, no tRPC signature.

The generalisable rule: an insert-gated notification makes the *first* write's value the permanent announcement, so any "assign a default, then let the user adjust" UI over such a write is wrong by construction — and it looks right in review, because both writes are individually correct.

## The fix

New `permissions/ui/grantee-add-panel.tsx` — inline `ActorPickerContent`, one level select for the batch, submit. **Nothing persists until submit.** Generic over the level vocabulary and host-agnostic.

`GranteeList` gained `stagedAdd` + `renderBatchPicker` and split into a `CommandNavigation` provider plus a body consuming it through `useCommandNavigationOptional`, so the inline add trigger drills down to that page instead of opening a nested `ActorPicker` popover. Submit writes one grant per actor at the chosen level and pops back to the list.

Two decisions worth flagging for review:

- **The root page is deliberately not wrapped in `<Command>`**, even though `column-manager.tsx`'s convention is `CommandNavigation → Command → CommandBreadcrumb → body`. That body is `CommandItem`s; this one is `TreeRow`s with a `Select` and a delete button, and cmdk would capture arrow keys and filtering. `CommandBreadcrumb` needs only the nav *context*, not a `Command` ancestor — page 2 brings its own via `ActorPickerContent`.
- **`stagedAdd` is opt-in.** Only `thread-share-popover.tsx` and `contact-shared-with-card.tsx` set it, so the ~18 `InstanceShareDialog` mounts, workflow access settings, the workspace-defaults tab and the inbox form are byte-for-byte unchanged.

## Scope — why not the instance lane too

Same bug, same component, `defaultChoice='view'` → `RESOURCE_SHARED` at `level: 'read'`. Two things block flipping it on, so it gets its own pass:

- `instance-share-body`'s `renderPicker` returns a per-row dead-grant `AlertTriangle` beside its select — meaningless for a batch not yet written. Hence `renderBatchPicker` as a second prop rather than reusing the row-shaped one.
- `instance-baseline-rows` mounts the list at `depth > 0` inside a tree, where swapping the whole body reads worse than `GranteeAddButton`'s own popover.

`inbox-form` / `InboxMembersPage` need nothing — they stage into local form state and persist with the inbox, so they never had the bug.

## Testing

`grantee-add-panel.test.tsx`, 7 tests. Mutation-checked, because this fix's failure mode is *silence*:

| Mutation | Result |
|---|---|
| submit `defaultChoice` instead of the chosen level | **2 fail** |
| re-introduce grant-on-pick | **5 fail** |

`expect(onGrant).not.toHaveBeenCalled()` after selecting is the whole bug. A test asserting only "onGrant was called" passes against it — the old code called it too, just at the wrong moment with the wrong value.

Neighbouring suites (`permissions` + `mail-permissions` + `inbox`): **212 passed / 16 files**. Biome clean. `tsc` on `apps/web` introduces no new errors in the touched files (the one hit, `thread-share-popover.tsx:28` `Property 'image' does not exist on type 'Actor'`, is pre-existing at HEAD in `MiniActorAvatar` and untouched by the one-line diff here).

## Still open

The **mirror gap**: the same `isNewGrant` gate means *upgrading* an existing grant (`metadata` → `full`) notifies nobody, so widening someone's access is never announced. Same shape, opposite direction. It needs a product call on whether a level *change* is an announceable event, and if so it lands in `notifyNewInstanceShare` — a change to the funnel every shareable resource writes through.