### PR TITLE
fix(mail): thread read-state gate and count identity normalization (plan 44)

### DIFF
--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -77,7 +77,8 @@ export const CompactThreadItem = memo(function CompactThreadItem({
   // Redacted rendering (mail-permissions): below `full` the row never looks
   // unread (isUnread is full-tier); at `metadata` the subject is absent.
   const myLens = thread?.myLens ?? 'full'
-  const isUnread = myLens === 'full' && readStatusUnread
+  // Not-yet-loaded rows render bold; see the note in `mail-thread-item`.
+  const isUnread = myLens === 'full' && (readStatusUnread ?? true)
 
   const toggleSelection = useThreadSelectionStore((s) => s.toggleSelection)
   const setActiveThread = useThreadSelectionStore((s) => s.setActiveThread)

--- a/apps/web/src/components/mail/hooks/count-identity.test.tsx
+++ b/apps/web/src/components/mail/hooks/count-identity.test.tsx
@@ -1,0 +1,143 @@
+// apps/web/src/components/mail/hooks/count-identity.test.tsx
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 44 §3 — the identity-format mismatch in the optimistic count layer.
+ *
+ * `ThreadCountContext` documented `assigneeId` as "Plain user ID (not ActorId
+ * format)" and every consumer then filled it straight from the thread store,
+ * where it is an `ActorId`. So `thread.assigneeId === currentUserId` was
+ * **always false** and the "Assigned to me" badge never moved optimistically.
+ * The same shape repeats for `inboxId`: the store holds a RecordId while
+ * `counts.sharedInboxes` is keyed by the bare instance id (`mail-counts.ts`
+ * writes `si:{inboxId}`; `toResponse` strips the prefix), so that debit had
+ * never matched either.
+ *
+ * These tests feed contexts from the REAL producer, `buildThreadCountContext`.
+ * A hand-written literal is the test that passed all along — and it can no
+ * longer be written by accident, because the fields are now named
+ * `assigneeUserId` / `inboxInstanceId` and a raw `thread.assigneeId` does not
+ * assign to them.
+ */
+
+const h = vi.hoisted(() => ({
+  batchUpdate: vi.fn(),
+  saveSnapshot: vi.fn(),
+  restoreSnapshot: vi.fn(),
+}))
+
+const ME = 'usr_me'
+const OTHER = 'usr_other'
+const SHARED_INBOX = 'ibx_shared'
+const PERSONAL_INBOX = 'ibx_personal'
+
+vi.mock('~/auth/auth-client', () => ({
+  useSession: () => ({ data: { user: { id: 'usr_me' } } }),
+}))
+
+vi.mock('../store', () => ({
+  useMailCountsStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      batchUpdate: h.batchUpdate,
+      saveSnapshot: h.saveSnapshot,
+      restoreSnapshot: h.restoreSnapshot,
+      incrementDrafts: vi.fn(),
+      decrementDrafts: vi.fn(),
+    }),
+}))
+
+const { useCountUpdates } = await import('./use-count-updates')
+const { buildThreadCountContext } = await import('../utils/thread-count-context')
+
+type StoreThread = Parameters<typeof buildThreadCountContext>[0]
+
+/** A store row exactly as `thread-query.service` mints it: prefixed on both ids. */
+function storeThread(overrides: Partial<StoreThread> = {}): StoreThread {
+  return {
+    id: 't_1',
+    isUnread: true,
+    status: 'OPEN',
+    assigneeId: `user:${ME}`,
+    inboxId: `inbox:${SHARED_INBOX}`,
+    ...overrides,
+  } as StoreThread
+}
+
+/** Drive the real hook and hand back the deltas it batched. */
+function markAsRead(thread: StoreThread) {
+  const { result } = renderHook(() => useCountUpdates())
+  result.current.onMarkAsRead([buildThreadCountContext(thread)], ME)
+  return h.batchUpdate.mock.calls.at(-1)?.[0] as {
+    inbox?: number
+    sharedInboxes?: Record<string, number>
+  }
+}
+
+beforeEach(() => {
+  h.batchUpdate.mockReset()
+  h.saveSnapshot.mockReset()
+  h.restoreSnapshot.mockReset()
+})
+
+describe('buildThreadCountContext — the one normalization boundary', () => {
+  it('parses the ActorId down to the bare user id', () => {
+    expect(buildThreadCountContext(storeThread()).assigneeUserId).toBe(ME)
+  })
+
+  it('parses the inbox RecordId down to the bare instance id', () => {
+    expect(buildThreadCountContext(storeThread()).inboxInstanceId).toBe(SHARED_INBOX)
+  })
+
+  it('handles a personal mailbox without mangling it', () => {
+    const ctx = buildThreadCountContext(
+      storeThread({ inboxId: `personal_inbox:${PERSONAL_INBOX}` as never })
+    )
+
+    expect(ctx.inboxInstanceId).toBe(PERSONAL_INBOX)
+    expect(ctx.inboxInstanceId).not.toBe(`personal_${PERSONAL_INBOX}`)
+  })
+
+  it('leaves an unassigned / uninboxed thread null', () => {
+    const ctx = buildThreadCountContext(storeThread({ assigneeId: null, inboxId: null }))
+
+    expect(ctx.assigneeUserId).toBeNull()
+    expect(ctx.inboxInstanceId).toBeNull()
+  })
+})
+
+describe('useCountUpdates — "Assigned to me" badge (§3.1)', () => {
+  it('decrements the personal inbox when the thread is assigned to me', () => {
+    expect(markAsRead(storeThread()).inbox).toBe(-1)
+  })
+
+  it('does NOT decrement for a thread assigned to someone else', () => {
+    expect(markAsRead(storeThread({ assigneeId: `user:${OTHER}` as never })).inbox).toBe(0)
+  })
+
+  it('increments again when the thread is marked unread', () => {
+    const { result } = renderHook(() => useCountUpdates())
+    result.current.onMarkAsUnread([buildThreadCountContext(storeThread({ isUnread: false }))], ME)
+
+    expect(h.batchUpdate.mock.calls.at(-1)?.[0].inbox).toBe(1)
+  })
+})
+
+describe('useCountUpdates — shared-inbox keyspace (§3.3)', () => {
+  it('debits the BARE instance id for a shared mailbox', () => {
+    expect(markAsRead(storeThread()).sharedInboxes).toEqual({ [SHARED_INBOX]: -1 })
+  })
+
+  it('debits the BARE instance id for a personal mailbox', () => {
+    const deltas = markAsRead(storeThread({ inboxId: `personal_inbox:${PERSONAL_INBOX}` as never }))
+
+    expect(deltas.sharedInboxes).toEqual({ [PERSONAL_INBOX]: -1 })
+  })
+
+  it('never files a delta under a whole RecordId', () => {
+    const keys = Object.keys(markAsRead(storeThread()).sharedInboxes ?? {})
+
+    expect(keys.some((k) => k.includes(':'))).toBe(false)
+  })
+})

--- a/apps/web/src/components/mail/hooks/index.ts
+++ b/apps/web/src/components/mail/hooks/index.ts
@@ -1,9 +1,5 @@
 // apps/web/src/components/mail/hooks/index.ts
 
-export {
-  type ThreadCountContext,
-  useCountUpdates,
-  type ViewDefinition,
-} from './use-count-updates'
+export { useCountUpdates, type ViewDefinition } from './use-count-updates'
 export { useHtmlBody } from './use-html-body'
 export { type ThreadCounterparty, useThreadCounterparty } from './use-thread-counterparty'

--- a/apps/web/src/components/mail/hooks/use-count-updates.ts
+++ b/apps/web/src/components/mail/hooks/use-count-updates.ts
@@ -1,26 +1,15 @@
 // apps/web/src/components/mail/hooks/use-count-updates.ts
 
 import { type ConditionGroup, evaluateConditions } from '@auxx/lib/conditions/client'
+import { safeParseActorId } from '@auxx/types/actor'
 import { useCallback, useMemo } from 'react'
 import { useSession } from '~/auth/auth-client'
 import { type CountUpdates, useMailCountsStore } from '../store'
+import type { ThreadCountContext } from '../utils/thread-count-context'
 
 // ═══════════════════════════════════════════════════════════════════════════
 // TYPES
 // ═══════════════════════════════════════════════════════════════════════════
-
-/**
- * Context about a thread needed to calculate which counts to update.
- * This should be derived from the thread's current state before mutation.
- */
-export interface ThreadCountContext {
-  isUnread: boolean
-  inboxId: string | null
-  assigneeId: string | null // Plain user ID (not ActorId format)
-  status: 'OPEN' | 'ARCHIVED' | 'TRASH' | 'CLOSED' | 'SPAM'
-  /** Full thread data for view filter evaluation */
-  threadData?: Record<string, unknown>
-}
 
 /**
  * View definition for filter evaluation.
@@ -78,7 +67,13 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
       case 'inbox':
         return thread.inboxId
       case 'assignee':
-        return thread.assigneeId
+        // Bare user id, not the store's ActorId. A view filter's
+        // `valueSource: 'currentUser'` is substituted with the BARE session id
+        // (`resolveConditionContext`) and the server evaluates the same filter
+        // in SQL against the bare `Thread.assigneeId` column — so an ActorId
+        // here makes every "assignee is me" view delta silently miss, which is
+        // exactly the filter people actually build (plan 44 §3.3).
+        return safeParseActorId(thread.assigneeId)?.id ?? thread.assigneeId
       case 'tags':
         return thread.tagIds
       case 'tag':
@@ -126,13 +121,14 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
         if (thread.status !== 'OPEN') continue // Only OPEN threads affect counts
 
         // Decrement personal inbox if assigned to current user
-        if (thread.assigneeId === currentUserId) {
+        if (thread.assigneeUserId === currentUserId) {
           updates.inbox! -= 1
         }
 
         // Decrement shared inbox count
-        if (thread.inboxId) {
-          updates.sharedInboxes![thread.inboxId] = (updates.sharedInboxes![thread.inboxId] ?? 0) - 1
+        if (thread.inboxInstanceId) {
+          updates.sharedInboxes![thread.inboxInstanceId] =
+            (updates.sharedInboxes![thread.inboxInstanceId] ?? 0) - 1
         }
 
         // Decrement view counts using filter evaluation
@@ -163,13 +159,14 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
         if (thread.status !== 'OPEN') continue // Only OPEN threads affect counts
 
         // Increment personal inbox if assigned to current user
-        if (thread.assigneeId === currentUserId) {
+        if (thread.assigneeUserId === currentUserId) {
           updates.inbox! += 1
         }
 
         // Increment shared inbox count
-        if (thread.inboxId) {
-          updates.sharedInboxes![thread.inboxId] = (updates.sharedInboxes![thread.inboxId] ?? 0) + 1
+        if (thread.inboxInstanceId) {
+          updates.sharedInboxes![thread.inboxInstanceId] =
+            (updates.sharedInboxes![thread.inboxInstanceId] ?? 0) + 1
         }
 
         // Increment view counts using filter evaluation
@@ -189,6 +186,9 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
   /**
    * Update counts when moving thread to a different inbox.
    * Only updates if thread is unread and OPEN.
+   *
+   * @param toInboxId - BARE destination inbox instance id (parse the RecordId
+   *   with `getInstanceId` first; the count keyspace is unprefixed).
    */
   const onMoveToInbox = useCallback(
     (thread: ThreadCountContext, toInboxId: string) => {
@@ -199,8 +199,8 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
       const updates: CountUpdates = { sharedInboxes: {}, views: {} }
 
       // Decrement source inbox
-      if (thread.inboxId) {
-        updates.sharedInboxes![thread.inboxId] = -1
+      if (thread.inboxInstanceId) {
+        updates.sharedInboxes![thread.inboxInstanceId] = -1
       }
 
       // Increment destination inbox
@@ -235,13 +235,16 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
   /**
    * Update counts when assigning thread to a user.
    * Only updates personal inbox count if thread is unread and OPEN.
+   *
+   * @param toUserId - BARE destination user id (parse the ActorId with
+   *   `safeParseActorId` first).
    */
   const onAssignThread = useCallback(
     (thread: ThreadCountContext, toUserId: string | null, currentUserId: string) => {
       if (!thread.isUnread) return // Read threads don't affect counts
       if (thread.status !== 'OPEN') return
 
-      const wasAssignedToMe = thread.assigneeId === currentUserId
+      const wasAssignedToMe = thread.assigneeUserId === currentUserId
       const isAssigningToMe = toUserId === currentUserId
 
       if (wasAssignedToMe === isAssigningToMe) return // No change for current user
@@ -294,13 +297,14 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
         if (thread.status !== 'OPEN') continue // Already not OPEN
 
         // Decrement personal inbox if assigned to current user
-        if (thread.assigneeId === currentUserId) {
+        if (thread.assigneeUserId === currentUserId) {
           updates.inbox! -= 1
         }
 
         // Decrement shared inbox count
-        if (thread.inboxId) {
-          updates.sharedInboxes![thread.inboxId] = (updates.sharedInboxes![thread.inboxId] ?? 0) - 1
+        if (thread.inboxInstanceId) {
+          updates.sharedInboxes![thread.inboxInstanceId] =
+            (updates.sharedInboxes![thread.inboxInstanceId] ?? 0) - 1
         }
 
         // Decrement all matching view counts
@@ -330,13 +334,13 @@ export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
       const updates: CountUpdates = { inbox: 0, sharedInboxes: {}, views: {} }
 
       // Increment personal inbox if assigned to current user
-      if (thread.assigneeId === currentUserId) {
+      if (thread.assigneeUserId === currentUserId) {
         updates.inbox! += 1
       }
 
       // Increment shared inbox count
-      if (thread.inboxId) {
-        updates.sharedInboxes![thread.inboxId] = 1
+      if (thread.inboxInstanceId) {
+        updates.sharedInboxes![thread.inboxInstanceId] = 1
       }
 
       // Increment all matching view counts

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -234,7 +234,10 @@ export const MailThreadItem = memo(function MailThreadItem({
   // Redacted rendering (mail-permissions): below `full` the row never looks
   // unread (isUnread is full-tier); at `metadata` the subject is absent.
   const myLens = thread?.myLens ?? 'full'
-  const isUnread = myLens === 'full' && readStatusUnread
+  // A row whose thread hasn't landed yet renders bold — a list-row concern
+  // only, which is why the hook now hands back `undefined` instead of baking
+  // this default in for the detail pane too (plan 44 §1.3).
+  const isUnread = myLens === 'full' && (readStatusUnread ?? true)
 
   // --- Selection store actions ---
   const toggleSelection = useThreadSelectionStore((s) => s.toggleSelection)

--- a/apps/web/src/components/mail/thread-display-read-gate.test.tsx
+++ b/apps/web/src/components/mail/thread-display-read-gate.test.tsx
@@ -1,0 +1,124 @@
+// apps/web/src/components/mail/thread-display-read-gate.test.tsx
+
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 44 §1 — the detail pane's auto-mark-read must not fire a write it knows
+ * will be refused.
+ *
+ * Read-state is `full`-tier: `UnreadService.setReadStatus` throws
+ * `ForbiddenError` unless every target is at `full` lens. The pane marked read
+ * on mount regardless, and `useThreadReadStatus` defaulted an unknown thread to
+ * unread — so a share recipient following the MESSAGE_SHARED deep link (no list
+ * load in front of it, store not yet hydrated) got a rejection toast on open.
+ *
+ * The assertion is `expect(markAsRead).not.toHaveBeenCalled()`. A test that
+ * only checked "no toast" would pass with the gate deleted, because the toast
+ * is downstream of the request.
+ */
+
+const h = vi.hoisted(() => ({
+  markAsRead: vi.fn(),
+  thread: null as Record<string, unknown> | null,
+  isUnread: undefined as boolean | undefined,
+}))
+
+vi.mock('~/components/threads/hooks', () => ({
+  useThread: () => ({
+    thread: h.thread,
+    isLoading: false,
+    isNotFound: false,
+    isDeleted: false,
+  }),
+  useThreadReadStatus: () => ({ isUnread: h.isUnread, markAsRead: h.markAsRead }),
+}))
+
+vi.mock('~/components/threads/store', () => ({
+  useActiveThreadId: () => null,
+  useHasMultipleSelected: () => false,
+}))
+
+vi.mock('./mail-filter-context', () => ({ useMailFilter: () => ({ viewMode: 'list' }) }))
+vi.mock('~/hooks/use-compose', () => ({ useCompose: () => ({ openCompose: vi.fn() }) }))
+vi.mock('~/hooks/use-user', () => ({ useUser: () => ({ hasOnlyForwardingChannel: false }) }))
+
+// Heavy children — none of them participate in the gate.
+vi.mock('~/components/kopilot/context', () => ({ KopilotContext: () => null }))
+vi.mock('~/components/kopilot/suggestions', () => ({ KopilotSuggestion: () => null }))
+vi.mock('./thread-details', () => ({ default: () => null }))
+vi.mock('./thread-provider', () => ({ ThreadProvider: () => null }))
+vi.mock('../global/empty-state', () => ({ EmptyState: () => null }))
+
+const { ThreadDisplay } = await import('./thread-display')
+
+const THREAD_ID = 'thr_1'
+
+/** A hydrated, unread thread at the given lens. */
+function hydrated(myLens: 'full' | 'subject' | 'metadata') {
+  h.thread = { id: THREAD_ID, subject: 'Hello', myLens, isUnread: true }
+  h.isUnread = true
+}
+
+beforeEach(() => {
+  h.markAsRead.mockReset()
+  h.thread = null
+  h.isUnread = undefined
+})
+
+describe('ThreadDisplay auto-mark-read gate', () => {
+  it('marks read at `full` lens (positive control)', () => {
+    hydrated('full')
+    render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
+
+    expect(h.markAsRead).toHaveBeenCalled()
+  })
+
+  it('does NOT mark read at `subject` lens', () => {
+    hydrated('subject')
+    render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
+
+    expect(h.markAsRead).not.toHaveBeenCalled()
+  })
+
+  it('does NOT mark read at `metadata` lens', () => {
+    hydrated('metadata')
+    render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
+
+    expect(h.markAsRead).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The actual reported path (§1.2): the URL supplies the id, the pane renders
+   * before `getThreadMetaBatch` returns, and the lens is simply not knowable
+   * yet. `useThreadReadStatus` used to default this to unread and turn it into
+   * a write — a "log in and click a thread" manual pass never reproduces it.
+   */
+  it('does NOT mark read while the store is empty', () => {
+    h.thread = null
+    // `true` on purpose: that is what the hook used to synthesize for an
+    // unknown thread (`isUnread ?? true`), so this pins the component's
+    // `!!thread` half rather than riding on the hook's new `undefined`.
+    h.isUnread = true
+    render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
+
+    expect(h.markAsRead).not.toHaveBeenCalled()
+  })
+
+  it('does not mark an already-read thread', () => {
+    h.thread = { id: THREAD_ID, subject: 'Hello', myLens: 'full', isUnread: false }
+    h.isUnread = false
+    render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
+
+    expect(h.markAsRead).not.toHaveBeenCalled()
+  })
+
+  /** Pre-lens cached payloads carry no `myLens`; those must keep working. */
+  it('marks read when the payload predates `myLens`', () => {
+    h.thread = { id: THREAD_ID, subject: 'Hello', isUnread: true }
+    h.isUnread = true
+    render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
+
+    expect(h.markAsRead).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/mail/thread-display.tsx
+++ b/apps/web/src/components/mail/thread-display.tsx
@@ -50,13 +50,21 @@ export function ThreadDisplay({ centered, expectedThreadId }: ThreadDisplayProps
   const { thread, isLoading, isNotFound, isDeleted } = useThread({ threadId })
   const { isUnread, markAsRead } = useThreadReadStatus(threadId)
 
+  // Read-state is `full`-tier (`UnreadService.setReadStatus` refuses anything
+  // below it), so the auto-mark must know the lens before it writes. Both
+  // halves matter: `!thread` is the reported path — a share recipient follows
+  // the MESSAGE_SHARED deep link, the pane renders from the URL id before the
+  // batched meta fetch returns, and firing here earns a rejection toast on
+  // open (plan 44 §1.2). This is UX; the server check stays authoritative.
+  const canMarkRead = !!thread && (thread.myLens ?? 'full') === 'full'
+
   // Mark thread as read when displayed. Skip in edit mode — the thread isn't
   // rendered, the user is just multi-selecting.
   useEffect(() => {
-    if (threadId && isUnread && viewMode !== 'edit') {
+    if (threadId && isUnread && canMarkRead && viewMode !== 'edit') {
       markAsRead()
     }
-  }, [threadId, isUnread, markAsRead, viewMode])
+  }, [threadId, isUnread, canMarkRead, markAsRead, viewMode])
 
   // BulkActionToolbar is self-managing (renders only when it has selection / edit mode).
   // The detail pane follows the *active* thread: whenever the user has opened one,

--- a/apps/web/src/components/mail/utils/thread-count-context.ts
+++ b/apps/web/src/components/mail/utils/thread-count-context.ts
@@ -1,0 +1,50 @@
+// apps/web/src/components/mail/utils/thread-count-context.ts
+
+import { safeParseActorId } from '@auxx/types/actor'
+import { getInstanceId } from '@auxx/types/resource'
+import type { ThreadMeta } from '~/components/threads/store'
+
+/**
+ * Context about a thread needed to calculate which counts to update.
+ * Derived from the thread's current state BEFORE the mutation is applied.
+ *
+ * Both identity fields are **bare instance ids**, because that is the keyspace
+ * the sidebar badges live in: `counts.inbox` is compared against the session's
+ * bare user id, and `counts.sharedInboxes` is keyed by the bare inbox instance
+ * id (`mail-counts.ts` writes `si:{inboxId}`; `toResponse` strips the prefix).
+ *
+ * The thread store carries neither format — `ThreadMeta.assigneeId` is an
+ * `ActorId` and `ThreadMeta.inboxId` is a `RecordId` — so a context must always
+ * come from {@link buildThreadCountContext}. The names say `UserId` /
+ * `InstanceId` on purpose: a raw `thread.assigneeId` no longer assigns cleanly,
+ * which turns the old comment-only contract into a type error (plan 44 §3.5).
+ */
+export interface ThreadCountContext {
+  isUnread: boolean
+  /** Bare inbox instance id — NOT the `inbox:` / `personal_inbox:` RecordId. */
+  inboxInstanceId: string | null
+  /** Bare user id — NOT the `user:` ActorId. */
+  assigneeUserId: string | null
+  status: 'OPEN' | 'ARCHIVED' | 'TRASH' | 'CLOSED' | 'SPAM'
+  /** Full thread data for view filter evaluation */
+  threadData?: Record<string, unknown>
+}
+
+/**
+ * The single producer of a {@link ThreadCountContext}.
+ *
+ * Normalization goes through the parsers, never a `.replace('user:', '')` /
+ * `.replace('inbox:', '')` string strip: the strip matches mid-word and mangles
+ * `personal_inbox:<id>` into `personal_<id>`, filing the delta under a key
+ * nothing reads — no error, no toast, the badge just stops moving
+ * (plan 40 §3 / plan 44 §3.5).
+ */
+export function buildThreadCountContext(thread: ThreadMeta): ThreadCountContext {
+  return {
+    isUnread: thread.isUnread,
+    inboxInstanceId: thread.inboxId ? getInstanceId(thread.inboxId) : null,
+    assigneeUserId: safeParseActorId(thread.assigneeId)?.id ?? null,
+    status: thread.status as ThreadCountContext['status'],
+    threadData: thread as unknown as Record<string, unknown>,
+  }
+}

--- a/apps/web/src/components/threads/hooks/use-thread-mutation-assignee-identity.test.tsx
+++ b/apps/web/src/components/threads/hooks/use-thread-mutation-assignee-identity.test.tsx
@@ -1,0 +1,136 @@
+// apps/web/src/components/threads/hooks/use-thread-mutation-assignee-identity.test.tsx
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 44 §3.1 — the one-directional "Assigned to me" badge.
+ *
+ * `applyCountUpdates` stripped `user:` off the INCOMING assignee but compared
+ * the stored one — an `ActorId` — straight against the bare session id. So
+ * `isAssigningToMe` worked while `wasAssignedToMe` never did: assigning a
+ * thread to myself incremented the badge, unassigning it never decremented.
+ * The optimistic count could only move up.
+ *
+ * Both sides now come from the same keyspace: the incoming id through
+ * `safeParseActorId`, the stored one through `buildThreadCountContext`.
+ */
+
+const h = vi.hoisted(() => ({
+  batchUpdate: vi.fn(),
+  saveSnapshot: vi.fn(),
+  restoreSnapshot: vi.fn(),
+  updateMutate: vi.fn(),
+  updateBulkMutate: vi.fn(),
+  threads: {} as Record<string, unknown>,
+}))
+
+const ME = 'usr_me'
+const OTHER = 'usr_other'
+
+vi.mock('~/hooks/use-user', () => ({ useUser: () => ({ userId: 'usr_me' }) }))
+
+vi.mock('~/components/mail/hooks', () => ({
+  useCountUpdates: () => ({
+    onMarkAsRead: vi.fn(),
+    onMarkAsUnread: vi.fn(),
+    onArchiveOrTrash: vi.fn(),
+  }),
+}))
+
+vi.mock('~/components/mail/store', () => ({
+  useMailCountsStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      saveSnapshot: h.saveSnapshot,
+      restoreSnapshot: h.restoreSnapshot,
+      batchUpdate: h.batchUpdate,
+    }),
+}))
+
+vi.mock('../store', () => ({
+  useThreadStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      updateThreadOptimistic: vi.fn(() => 1),
+      confirmOptimistic: vi.fn(),
+      rollbackOptimistic: vi.fn(),
+      removeThread: vi.fn(),
+      undeleteThread: vi.fn(),
+      getThread: (id: string) => h.threads[id],
+    }),
+  useThreadSelectionStore: Object.assign(
+    (selector: (s: unknown) => unknown) => selector({ setActiveThread: vi.fn() }),
+    { getState: () => ({ activeThreadId: null }) }
+  ),
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    thread: {
+      update: { useMutation: () => ({ mutate: h.updateMutate }) },
+      updateBulk: { useMutation: () => ({ mutate: h.updateBulkMutate }) },
+      remove: { useMutation: () => ({ mutate: vi.fn() }) },
+      removeBulk: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}))
+
+const { useThreadMutation } = await import('./use-thread-mutation')
+
+/** An unread OPEN thread currently assigned to `assignee`, as the store holds it. */
+function seed(assignee: string | null) {
+  h.threads = {
+    t_1: {
+      id: 't_1',
+      isUnread: true,
+      status: 'OPEN',
+      inboxId: 'inbox:ibx_shared',
+      assigneeId: assignee,
+    },
+  }
+}
+
+/** The personal-inbox delta the reassignment batched. */
+function inboxDelta(newAssignee: string | null): number {
+  const { result } = renderHook(() => useThreadMutation())
+  result.current.update('t_1', { assigneeId: newAssignee as never })
+  return (h.batchUpdate.mock.calls.at(-1)?.[0] as { inbox: number }).inbox
+}
+
+beforeEach(() => {
+  h.batchUpdate.mockReset()
+  h.saveSnapshot.mockReset()
+  h.restoreSnapshot.mockReset()
+  h.updateMutate.mockReset()
+})
+
+describe('useThreadMutation assignee deltas — the badge moves both ways', () => {
+  it('DECREMENTS when unassigning a thread from me', () => {
+    seed(`user:${ME}`)
+
+    expect(inboxDelta(null)).toBe(-1)
+  })
+
+  it('DECREMENTS when reassigning my thread to someone else', () => {
+    seed(`user:${ME}`)
+
+    expect(inboxDelta(`user:${OTHER}`)).toBe(-1)
+  })
+
+  it('increments when assigning to me (the half that always worked)', () => {
+    seed(`user:${OTHER}`)
+
+    expect(inboxDelta(`user:${ME}`)).toBe(1)
+  })
+
+  it('does not move when the reassignment never involves me', () => {
+    seed(`user:${OTHER}`)
+
+    expect(inboxDelta(null)).toBe(0)
+  })
+
+  it('does not move when the thread stays mine', () => {
+    seed(`user:${ME}`)
+
+    expect(inboxDelta(`user:${ME}`)).toBe(0)
+  })
+})

--- a/apps/web/src/components/threads/hooks/use-thread-mutation-inbox-def.test.tsx
+++ b/apps/web/src/components/threads/hooks/use-thread-mutation-inbox-def.test.tsx
@@ -92,23 +92,28 @@ beforeEach(() => {
   }
 })
 
-/**
- * The key the DESTINATION credit landed under.
- *
- * Only the credit is asserted. The matching source DEBIT keys off the thread's
- * stored `inboxId`, i.e. a whole RecordId, and so has never matched the badge's
- * bare-id keyspace — a separate, definition-independent pre-existing bug that
- * `use-count-updates.ts` repeats. Pinning it here would lock it in.
- */
-function creditedKey(inboxRecordId: string): string {
+/** Every `sharedInboxes` delta the move batched, keyed as the store filed it. */
+function inboxDeltas(inboxRecordId: string): Record<string, number> {
   const { result } = renderHook(() => useThreadMutation())
   result.current.updateBulk(['t_1'], { inboxId: inboxRecordId as never })
   const { sharedInboxes } = h.batchUpdate.mock.calls.at(-1)?.[0] as {
     sharedInboxes: Record<string, number>
   }
-  const credited = Object.entries(sharedInboxes).filter(([, delta]) => delta > 0)
+  return sharedInboxes
+}
+
+/** The key the DESTINATION credit landed under. */
+function creditedKey(inboxRecordId: string): string {
+  const credited = Object.entries(inboxDeltas(inboxRecordId)).filter(([, delta]) => delta > 0)
   expect(credited).toHaveLength(1)
   return credited[0]![0]
+}
+
+/** The key the SOURCE debit landed under. */
+function debitedKey(inboxRecordId: string): string {
+  const debited = Object.entries(inboxDeltas(inboxRecordId)).filter(([, delta]) => delta < 0)
+  expect(debited).toHaveLength(1)
+  return debited[0]![0]
 }
 
 describe('useThreadMutation inbox move — RecordId round trip (plan 40a §5.1)', () => {
@@ -130,6 +135,27 @@ describe('useThreadMutation inbox move — RecordId round trip (plan 40a §5.1)'
 
   it('never produces a mangled `personal_…` key', () => {
     expect(creditedKey(`personal_inbox:${PERSONAL_INBOX}`)).not.toBe(`personal_${PERSONAL_INBOX}`)
+  })
+
+  /**
+   * Plan 44 §3.3. The source debit used to key off `context.inboxId`, the whole
+   * stored RecordId, so it never matched the badge's bare-id keyspace — this
+   * file previously said so and declined to pin it. The context producer now
+   * parses it, so both halves of a move land in the same keyspace.
+   */
+  it('debits the BARE instance id of the source mailbox', () => {
+    expect(debitedKey(`personal_inbox:${PERSONAL_INBOX}`)).toBe(SHARED_INBOX)
+  })
+
+  it('debits the bare instance id when the source is a personal mailbox', () => {
+    h.threads.t_1 = {
+      id: 't_1',
+      isUnread: true,
+      status: 'OPEN',
+      inboxId: `personal_inbox:${PERSONAL_INBOX}`,
+    }
+
+    expect(debitedKey(`inbox:${SHARED_INBOX}`)).toBe(PERSONAL_INBOX)
   })
 
   it('still forwards the full RecordId to the server mutation', () => {

--- a/apps/web/src/components/threads/hooks/use-thread-mutation.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-mutation.ts
@@ -1,10 +1,15 @@
 // apps/web/src/components/threads/hooks/use-thread-mutation.ts
 
+import { safeParseActorId } from '@auxx/types/actor'
 import { getInstanceId, toRecordId } from '@auxx/types/resource'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback } from 'react'
-import { type ThreadCountContext, useCountUpdates } from '~/components/mail/hooks'
+import { useCountUpdates } from '~/components/mail/hooks'
 import { type CountUpdates, useMailCountsStore } from '~/components/mail/store'
+import {
+  buildThreadCountContext,
+  type ThreadCountContext,
+} from '~/components/mail/utils/thread-count-context'
 import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
 import { type ThreadMeta, useThreadSelectionStore, useThreadStore } from '../store'
@@ -87,19 +92,12 @@ export function useThreadMutation() {
 
   /**
    * Build thread context for count updates from current store state.
+   * Id normalization lives in the shared producer — see `thread-count-context`.
    */
   const buildThreadContext = useCallback(
     (threadId: string): ThreadCountContext | null => {
       const thread = getThread(threadId)
-      if (!thread) return null
-
-      return {
-        isUnread: thread.isUnread,
-        inboxId: thread.inboxId ?? null,
-        assigneeId: thread.assigneeId ?? null,
-        status: thread.status as 'OPEN' | 'ARCHIVED' | 'TRASH' | 'CLOSED' | 'SPAM',
-        threadData: thread as unknown as Record<string, unknown>,
-      }
+      return thread ? buildThreadCountContext(thread) : null
     },
     [getThread]
   )
@@ -157,16 +155,13 @@ export function useThreadMutation() {
         for (const context of contexts) {
           if (!context.isUnread || context.status !== 'OPEN') continue
 
-          // Decrement old inbox.
-          // PRE-EXISTING, definition-independent: `context.inboxId` is the
-          // thread's stored RecordId, while `counts.sharedInboxes` is keyed by
-          // the BARE instance id (`mail-counts.ts` `si:{inboxId}`), so this
-          // debit has never matched. `use-count-updates.ts` repeats the shape.
-          // Left alone here — fixing it changes shared-inbox badges too, which
-          // is outside the plan-40 RecordId sweep.
-          if (context.inboxId) {
-            countUpdates.sharedInboxes![context.inboxId] =
-              (countUpdates.sharedInboxes![context.inboxId] ?? 0) - 1
+          // Decrement old inbox. `inboxInstanceId` is already parsed off the
+          // stored RecordId by the shared context producer (plan 44 §3.3) — the
+          // debit used to key off the whole RecordId and so never matched the
+          // badge's bare-id keyspace.
+          if (context.inboxInstanceId) {
+            countUpdates.sharedInboxes![context.inboxInstanceId] =
+              (countUpdates.sharedInboxes![context.inboxInstanceId] ?? 0) - 1
           }
           // Increment new inbox
           countUpdates.sharedInboxes![newInboxId] =
@@ -176,11 +171,12 @@ export function useThreadMutation() {
 
       // Handle assignee changes
       if (updates.assigneeId !== undefined) {
-        const newAssigneeId = updates.assigneeId?.replace('user:', '') ?? null
+        // Parse, don't strip — same rule as the inbox RecordId above.
+        const newAssigneeId = safeParseActorId(updates.assigneeId)?.id ?? null
         for (const context of contexts) {
           if (!context.isUnread || context.status !== 'OPEN') continue
 
-          const wasAssignedToMe = context.assigneeId === currentUserId
+          const wasAssignedToMe = context.assigneeUserId === currentUserId
           const isAssigningToMe = newAssigneeId === currentUserId
 
           if (wasAssignedToMe && !isAssigningToMe) {
@@ -300,11 +296,11 @@ export function useThreadMutation() {
         const context = buildThreadContext(threadId)
         if (context?.isUnread && context.status === 'OPEN') {
           const countUpdates: CountUpdates = { inbox: 0, sharedInboxes: {} }
-          if (context.assigneeId === currentUserId) {
+          if (context.assigneeUserId === currentUserId) {
             countUpdates.inbox = -1
           }
-          if (context.inboxId) {
-            countUpdates.sharedInboxes![context.inboxId] = -1
+          if (context.inboxInstanceId) {
+            countUpdates.sharedInboxes![context.inboxInstanceId] = -1
           }
           batchUpdate(countUpdates)
         }
@@ -360,12 +356,12 @@ export function useThreadMutation() {
         const countUpdates: CountUpdates = { inbox: 0, sharedInboxes: {} }
         for (const context of contexts) {
           if (!context.isUnread || context.status !== 'OPEN') continue
-          if (context.assigneeId === currentUserId) {
+          if (context.assigneeUserId === currentUserId) {
             countUpdates.inbox! -= 1
           }
-          if (context.inboxId) {
-            countUpdates.sharedInboxes![context.inboxId] =
-              (countUpdates.sharedInboxes![context.inboxId] ?? 0) - 1
+          if (context.inboxInstanceId) {
+            countUpdates.sharedInboxes![context.inboxInstanceId] =
+              (countUpdates.sharedInboxes![context.inboxInstanceId] ?? 0) - 1
           }
         }
         batchUpdate(countUpdates)

--- a/apps/web/src/components/threads/hooks/use-thread-read-status-default.test.tsx
+++ b/apps/web/src/components/threads/hooks/use-thread-read-status-default.test.tsx
@@ -1,0 +1,71 @@
+// apps/web/src/components/threads/hooks/use-thread-read-status-default.test.tsx
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 44 §1.3 — `useThreadReadStatus` must not invent read state.
+ *
+ * It used to return `isUnread ?? true`, so a thread the store has never seen
+ * read as unread. That default exists for *list rows* (a not-yet-loaded row
+ * renders bold); the detail pane's auto-mark effect turned it into a WRITE,
+ * against a thread whose lens it could not yet know. The unknown case is now
+ * `undefined` and each caller decides.
+ */
+
+const h = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  threads: new Map<string, unknown>(),
+}))
+
+vi.mock('~/hooks/use-user', () => ({ useUser: () => ({ userId: 'usr_me' }) }))
+
+vi.mock('~/components/mail/hooks', () => ({
+  useCountUpdates: () => ({
+    onMarkAsRead: vi.fn(),
+    onMarkAsUnread: vi.fn(),
+    rollback: vi.fn(),
+  }),
+}))
+
+vi.mock('../store', () => ({
+  useThreadStore: (selector: (s: unknown) => unknown) =>
+    selector({ threads: h.threads, updateThread: vi.fn() }),
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: { thread: { update: { useMutation: () => ({ mutate: h.mutate }) } } },
+}))
+
+const { useThreadReadStatus } = await import('./use-thread-read-status')
+
+beforeEach(() => {
+  h.mutate.mockReset()
+  h.threads = new Map()
+})
+
+describe('useThreadReadStatus.isUnread', () => {
+  it('is `undefined` for a thread the store has not hydrated', () => {
+    const { result } = renderHook(() => useThreadReadStatus('thr_unknown'))
+
+    expect(result.current.isUnread).toBeUndefined()
+  })
+
+  it('is `undefined` when no thread is selected', () => {
+    const { result } = renderHook(() => useThreadReadStatus(null))
+
+    expect(result.current.isUnread).toBeUndefined()
+  })
+
+  it('reports the stored value once hydrated', () => {
+    h.threads.set('thr_1', { id: 'thr_1', isUnread: false })
+
+    expect(renderHook(() => useThreadReadStatus('thr_1')).result.current.isUnread).toBe(false)
+  })
+
+  it('reports unread when the stored thread is unread', () => {
+    h.threads.set('thr_1', { id: 'thr_1', isUnread: true })
+
+    expect(renderHook(() => useThreadReadStatus('thr_1')).result.current.isUnread).toBe(true)
+  })
+})

--- a/apps/web/src/components/threads/hooks/use-thread-read-status.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-read-status.ts
@@ -3,13 +3,20 @@
 import { toRecordId } from '@auxx/types/resource'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useRef } from 'react'
-import { type ThreadCountContext, useCountUpdates } from '~/components/mail/hooks'
+import { useCountUpdates } from '~/components/mail/hooks'
+import { buildThreadCountContext } from '~/components/mail/utils/thread-count-context'
 import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
 import { useThreadStore } from '../store'
 
 interface UseThreadReadStatusResult {
-  isUnread: boolean
+  /**
+   * `undefined` while the thread is not in the store — the caller decides what
+   * an unknown thread looks like. A list row may render it bold (`?? true`);
+   * the detail pane must NOT, because its auto-mark effect turns that default
+   * into a write against a thread whose lens it cannot know yet (plan 44 §1.2).
+   */
+  isUnread: boolean | undefined
   markAsRead: () => void
   markAsUnread: () => void
 }
@@ -53,14 +60,9 @@ export function useThreadReadStatus(threadId: string | null): UseThreadReadStatu
     onMutate: ({ updates }) => {
       if (!threadId || !thread || !currentUserId || updates.isUnread === undefined) return
 
-      // Build context from current thread state
-      const context: ThreadCountContext = {
-        isUnread: thread.isUnread,
-        inboxId: thread.inboxId ?? null,
-        assigneeId: thread.assigneeId ?? null,
-        status: thread.status as 'OPEN' | 'ARCHIVED' | 'TRASH' | 'CLOSED' | 'SPAM',
-        threadData: thread as unknown as Record<string, unknown>,
-      }
+      // Build context from current thread state (the shared producer is what
+      // normalizes ActorId/RecordId into the bare count keyspaces).
+      const context = buildThreadCountContext(thread)
 
       // Update ThreadStore (for UI)
       updateThread(threadId, { isUnread: updates.isUnread })
@@ -88,7 +90,7 @@ export function useThreadReadStatus(threadId: string | null): UseThreadReadStatu
   mutateRef.current = readStatus.mutate
 
   return {
-    isUnread: isUnread ?? true,
+    isUnread,
     markAsRead: useCallback(() => {
       if (threadId) {
         mutateRef.current({

--- a/apps/web/src/server/api/routers/mail-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/mail-instance-access.test.ts
@@ -304,8 +304,14 @@ vi.mock('@auxx/lib/permissions', async () => {
  */
 vi.mock('~/server/api/trpc', async () => {
   const { initTRPC } = await import('@trpc/server')
+  const { AuxxError } = await import('@auxx/lib/errors')
   const t = initTRPC.context<Record<string, unknown>>().create()
   return {
+    // The REAL predicate: `thread.ts`'s `handleServiceError` uses it to let an
+    // AuxxError through untouched instead of flattening it to a 500 (plan 44).
+    isAuxxError: (error: unknown) =>
+      error instanceof AuxxError ||
+      (error instanceof Error && typeof (error as { statusCode?: number }).statusCode === 'number'),
     createTRPCRouter: t.router,
     capabilityProcedure: t.procedure,
     protectedProcedure: t.procedure,

--- a/apps/web/src/server/api/routers/thread-error-status.test.ts
+++ b/apps/web/src/server/api/routers/thread-error-status.test.ts
@@ -1,0 +1,269 @@
+// apps/web/src/server/api/routers/thread-error-status.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan 44 §1.3 / §1.4 — a thread-service refusal must surface as its own
+ * status, never as a 500.
+ *
+ * `thread.ts` catches broadly and re-wraps. Two shapes existed:
+ *
+ *  - `handleServiceError`, reached from ~20 procedures, re-wrapped as
+ *    `INTERNAL_SERVER_ERROR` but PASSED the original on `cause` — which
+ *    `auxxErrorMiddleware` reads, so those already recovered the right code.
+ *    It now rethrows the `AuxxError` untouched, so the recovery no longer
+ *    depends on one `cause:` argument staying in place.
+ *  - `linkToTicket` and `retryMessage` re-wrap with **no `cause` at all**.
+ *    There is nothing for the middleware to read, so an authorization refusal
+ *    genuinely reached the client as a 500 with a message-sniffed status.
+ *
+ * Every assertion below is on the CODE. "It rejected" is the assertion that
+ * passes against the bug — HANDOFF's standing gotcha, where one mutation
+ * failed with literally `expected 500 to be 403`.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const THREAD_ID = 'thr_cuid00000000000000000a'
+const TICKET_ID = 'tkt_cuid00000000000000000a'
+
+const { svc } = vi.hoisted(() => ({
+  svc: {
+    setReadStatus: vi.fn(async () => undefined),
+    threadUpdate: vi.fn(async () => ({ id: 'thr_1', success: true, updatedFields: {} })),
+    linkEntityToThread: vi.fn(async () => undefined),
+  },
+}))
+
+vi.mock('@auxx/lib/threads', () => ({
+  ThreadQueryService: class {
+    listThreadIds = vi.fn(async () => ({ ids: [], nextCursor: null }))
+    getThreadMetaBatch = vi.fn(async () => [])
+  },
+  ThreadMutationService: class {
+    update = svc.threadUpdate
+    updateBulk = vi.fn(async () => ({ count: 0 }))
+    remove = vi.fn()
+    removeBulk = vi.fn()
+    tagThreadsBulk = vi.fn()
+  },
+  ThreadMergeService: class {
+    unmergeBatch = vi.fn()
+  },
+  UnreadService: class {
+    setReadStatus = svc.setReadStatus
+  },
+  getMailCounts: vi.fn(async () => ({})),
+  canLinkThread: vi.fn(async () => true),
+  linkEntityToThread: svc.linkEntityToThread,
+  returnThreadToAi: vi.fn(),
+  takeOverThread: vi.fn(),
+  assertCanActOnThreads: vi.fn(async () => undefined),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedUserMailVisibility: vi.fn(async () => ({ userId: USER_ID })),
+  getCachedEntityDefId: vi.fn(async () => null),
+  getCachedResources: vi.fn(async () => []),
+}))
+vi.mock('@auxx/lib/email', () => ({ getUserOrganizationId: () => ORG_ID }))
+vi.mock('@auxx/lib/drafts', () => ({ DraftService: class {} }))
+vi.mock('@auxx/lib/messages', () => ({ MessageSenderService: class {} }))
+vi.mock('@auxx/lib/providers', () => ({ ProviderRegistryService: class {} }))
+vi.mock('@auxx/lib/money', () => ({
+  markInvoiceSent: vi.fn(),
+  markQuoteSent: vi.fn(),
+  recordDocumentSendSignal: vi.fn(),
+}))
+vi.mock('@auxx/lib/placeholders', () => ({
+  buildPlaceholderContextForThread: vi.fn(),
+  resolvePlaceholdersInHtml: vi.fn(),
+}))
+vi.mock('@auxx/lib/mail-schedule', () => ({
+  cancelScheduledMessage: vi.fn(),
+  createScheduledMessage: vi.fn(),
+  enqueueScheduledMessageJob: vi.fn(),
+  findPendingByDraftId: vi.fn(),
+  findScheduledMessagesByThreadId: vi.fn(),
+  updateScheduledMessage: vi.fn(),
+  updateScheduledMessageStatus: vi.fn(),
+}))
+vi.mock('~/server/lib/signature-instance-access', () => ({
+  assertSignatureUsable: vi.fn(),
+}))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = vi.fn(async () => undefined)
+    },
+  }
+})
+
+/**
+ * `trpc.ts` itself reaches redis/db at import time and hangs under vitest, so
+ * the procedure builder is stubbed — but `auxxErrorMiddleware` is transcribed
+ * FAITHFULLY from it, including the `HTTP_TO_TRPC` table and the tRPC v11
+ * detail the real comment calls out: `next()` RESOLVES with `{ok:false}` for a
+ * downstream throw rather than rejecting. `isAuxxError` is the real predicate's
+ * duck-type, since the transpiled `@auxx/lib` copy defeats `instanceof`.
+ */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC, TRPCError } = await import('@trpc/server')
+  const { AuxxError, AuxxErrorCodes } = await import('@auxx/lib/errors')
+  const HTTP_TO_TRPC: Record<number, string> = {
+    400: 'BAD_REQUEST',
+    401: 'UNAUTHORIZED',
+    403: 'FORBIDDEN',
+    404: 'NOT_FOUND',
+    409: 'CONFLICT',
+    422: 'UNPROCESSABLE_CONTENT',
+    429: 'TOO_MANY_REQUESTS',
+  }
+  const NAMES = new Set<string>(Object.values(AuxxErrorCodes))
+  const isAuxxError = (error: unknown): error is InstanceType<typeof AuxxError> =>
+    error instanceof AuxxError ||
+    (error instanceof Error &&
+      typeof (error as { statusCode?: number }).statusCode === 'number' &&
+      NAMES.has(error.name))
+
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  const auxxErrorMiddleware = t.middleware(async ({ next }) => {
+    const result = await next()
+    if (!result.ok && isAuxxError(result.error.cause)) {
+      const cause = result.error.cause
+      throw new TRPCError({
+        code: (HTTP_TO_TRPC[cause.statusCode] ?? 'INTERNAL_SERVER_ERROR') as 'FORBIDDEN',
+        message: cause.message,
+        cause,
+      })
+    }
+    return result
+  })
+  const base = t.procedure.use(auxxErrorMiddleware)
+  return {
+    isAuxxError,
+    createTRPCRouter: t.router,
+    capabilityProcedure: base,
+    protectedProcedure: base,
+    permissionProcedure: () => base,
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  }
+})
+
+const { ForbiddenError, NotFoundError } = await import('@auxx/lib/errors')
+const { threadRouter } = await import('./thread')
+
+const REFUSAL = 'You do not have full access to the selected threads.'
+
+function caller() {
+  return threadRouter.createCaller({
+    db: {},
+    headers: { get: () => null },
+    session: { user: { id: USER_ID }, userId: USER_ID, organizationId: ORG_ID },
+  } as never)
+}
+
+/** The tRPC error code the procedure actually surfaced. */
+async function codeOf(run: () => Promise<unknown>): Promise<{ code: string; message: string }> {
+  try {
+    await run()
+  } catch (error) {
+    const e = error as { code: string; message: string }
+    return { code: e.code, message: e.message }
+  }
+  throw new Error('expected the procedure to reject')
+}
+
+beforeEach(() => {
+  svc.setReadStatus.mockReset().mockResolvedValue(undefined)
+  svc.threadUpdate.mockReset().mockResolvedValue({ id: THREAD_ID, success: true })
+  svc.linkEntityToThread.mockReset().mockResolvedValue(undefined)
+})
+
+describe('thread.update — read-state refusal below `full` lens (§1.1)', () => {
+  it('surfaces FORBIDDEN, not INTERNAL_SERVER_ERROR', async () => {
+    svc.setReadStatus.mockRejectedValue(new ForbiddenError(REFUSAL))
+
+    expect(
+      await codeOf(() =>
+        caller().update({
+          recordId: `thread:${THREAD_ID}` as never,
+          updates: { isUnread: false },
+        })
+      )
+    ).toEqual({ code: 'FORBIDDEN', message: REFUSAL })
+  })
+
+  it('does not name a service that never ran', async () => {
+    svc.setReadStatus.mockRejectedValue(new ForbiddenError(REFUSAL))
+    const { message } = await codeOf(() =>
+      caller().update({ recordId: `thread:${THREAD_ID}` as never, updates: { isUnread: false } })
+    )
+
+    // The throw came from UnreadService; `threadMutation.update` is never
+    // reached when `isUnread` is the only field in the payload.
+    expect(message).not.toContain('threadMutation.update')
+    expect(svc.threadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('passes a NotFoundError through as NOT_FOUND', async () => {
+    svc.threadUpdate.mockRejectedValue(new NotFoundError('Thread not found'))
+
+    expect(
+      await codeOf(() =>
+        caller().update({
+          recordId: `thread:${THREAD_ID}` as never,
+          updates: { status: 'ARCHIVED' },
+        })
+      )
+    ).toEqual({ code: 'NOT_FOUND', message: 'Thread not found' })
+  })
+
+  it('still 500s on a genuinely unexpected error (negative control)', async () => {
+    svc.setReadStatus.mockRejectedValue(new Error('connection reset'))
+
+    expect(
+      (
+        await codeOf(() =>
+          caller().update({
+            recordId: `thread:${THREAD_ID}` as never,
+            updates: { isUnread: false },
+          })
+        )
+      ).code
+    ).toBe('INTERNAL_SERVER_ERROR')
+  })
+})
+
+/**
+ * `linkToTicket`'s catch re-wraps with NO `cause`, so before the guard there
+ * was nothing for the middleware to recover the status from — this is the shape
+ * that genuinely produced a 403-wearing-a-500.
+ */
+describe('thread.linkToTicket — causeless re-wrap (§1.4)', () => {
+  it('surfaces FORBIDDEN for an authorization refusal', async () => {
+    svc.linkEntityToThread.mockRejectedValue(new ForbiddenError(REFUSAL))
+
+    expect(
+      await codeOf(() => caller().linkToTicket({ threadId: THREAD_ID, ticketId: TICKET_ID }))
+    ).toEqual({ code: 'FORBIDDEN', message: REFUSAL })
+  })
+
+  it('keeps mapping a plain "not found" Error to NOT_FOUND', async () => {
+    svc.linkEntityToThread.mockRejectedValue(new Error('Ticket not found'))
+
+    expect(
+      (await codeOf(() => caller().linkToTicket({ threadId: THREAD_ID, ticketId: TICKET_ID }))).code
+    ).toBe('NOT_FOUND')
+  })
+})

--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -39,7 +39,7 @@ import { getInstanceId, recordIdSchema } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, notDemo, permissionProcedure } from '~/server/api/trpc'
+import { createTRPCRouter, isAuxxError, notDemo, permissionProcedure } from '~/server/api/trpc'
 import { assertSignatureUsable } from '~/server/lib/signature-instance-access'
 
 const logger = createScopedLogger('thread-router')
@@ -185,6 +185,14 @@ const getServiceDependencies = async (
 /**
  * Centralized error handler for service calls.
  * Logs the error and throws an appropriate TRPCError.
+ *
+ * Every `thread.*` catch funnels through here, so the `AuxxError` passthrough
+ * below is the whole file's fix (plan 44 §1.3 / §1.4): a service refusal —
+ * `UnreadService.setReadStatus`'s `ForbiddenError` on a sub-`full` thread, and
+ * every other authorization throw in the thread services — used to be flattened
+ * into `INTERNAL_SERVER_ERROR` right here, so a 403 reached the client as
+ * "An unexpected error occurred in <procedure>". Rethrown untouched, it reaches
+ * `auxxErrorMiddleware`, which maps `statusCode` to the real tRPC code.
  */
 const handleServiceError = (
   error: unknown,
@@ -194,6 +202,7 @@ const handleServiceError = (
   const message = error instanceof Error ? error.message : 'Unknown error'
   const stack = error instanceof Error ? error.stack : undefined
   logger.error(`Error in ${procedureName}`, { ...context, error: message, stack })
+  if (isAuxxError(error)) throw error
   if (error instanceof Error) {
     if (message.includes('not found')) {
       throw new TRPCError({ code: 'NOT_FOUND', message, cause: error })
@@ -1019,6 +1028,11 @@ export const threadRouter = createTRPCRouter({
           error: error instanceof Error ? error.message : error,
           stack: error instanceof Error ? error.stack : undefined,
         })
+        // Already-typed throws pass straight through: the `chat_retry_unsupported`
+        // BAD_REQUEST above matches none of the message sniffs below and would
+        // otherwise be re-wrapped as a 500 (plan 44 §1.4).
+        if (error instanceof TRPCError) throw error
+        if (isAuxxError(error)) throw error
         // Map service errors to tRPC codes
         if (error instanceof Error) {
           const message = error.message.toLowerCase()
@@ -1075,6 +1089,7 @@ export const threadRouter = createTRPCRouter({
           actorId: userId,
         })
       } catch (error) {
+        if (isAuxxError(error)) throw error
         const message = error instanceof Error ? error.message : String(error)
         if (message.includes('not found')) {
           throw new TRPCError({ code: 'NOT_FOUND', message })

--- a/packages/lib/src/threads/__tests__/thread-assignee-patch-format.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-assignee-patch-format.test.ts
@@ -1,0 +1,202 @@
+// packages/lib/src/threads/__tests__/thread-assignee-patch-format.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UserMailVisibility } from '../../permissions/visibility/context'
+
+/**
+ * Plan 44 §3.4 — the realtime assign patch must carry an `ActorId`.
+ *
+ * The fetch path (`thread-query.service.ts`) returns
+ * `toActorId('user', assigneeId)`, and `ThreadMeta.assigneeId` is typed
+ * `ActorId | null` all the way into the store. The realtime publisher shipped
+ * `dbUpdates.assigneeId` — the BARE column value — so after a realtime assign
+ * the store held a bare id under an `ActorId` field until the next refetch.
+ * `parseActorId` is strict and throws, so creating a ticket from that thread
+ * failed with `Invalid ActorId: <bare-id>`, and every assignee chip rendered
+ * nothing. The sibling `inboxId` line two rows below was already def-resolved;
+ * assignee was simply missed.
+ *
+ * One format on the wire — fixed at the publisher, not by teaching the store to
+ * accept both. `update` and `updateBulk` each have their own copy of the line,
+ * so both are pinned here.
+ */
+
+const { lensFixture, getThreadLensBatch } = vi.hoisted(() => {
+  const lensFixture: { lenses: Record<string, string> } = { lenses: {} }
+  return {
+    lensFixture,
+    getThreadLensBatch: vi.fn(async (_db: unknown, _o: string, _v: unknown, ids: string[]) => {
+      const map = new Map<string, string>()
+      for (const id of ids) map.set(id, lensFixture.lenses[id] ?? 'none')
+      return map
+    }),
+  }
+})
+
+vi.mock('../../permissions/visibility/thread-lens', () => ({
+  getThreadLensBatch,
+  getThreadLens: vi.fn(),
+}))
+
+const { publisher, realtime, orgCache } = vi.hoisted(() => ({
+  publisher: { publish: vi.fn(async () => undefined), publishLater: vi.fn(async () => undefined) },
+  realtime: {
+    publishThreadUpdated: vi.fn(async () => undefined),
+    publishThreadDeleted: vi.fn(async () => undefined),
+    getRealtimeService: vi.fn(() => ({})),
+  },
+  orgCache: {
+    get: vi.fn(async () => []),
+    from: vi.fn(() => ({ bySystemAttribute: async () => null })),
+  },
+}))
+
+vi.mock('../../events/publisher', () => ({ publisher }))
+vi.mock('../../realtime', () => realtime)
+vi.mock('../../field-values', () => ({
+  FieldValueService: class {
+    setValueWithBuiltIn = vi.fn(async () => undefined)
+    addRelationValuesBulk = vi.fn(async () => ({ inserted: 0, skipped: 0 }))
+    removeRelationValuesBulk = vi.fn(async () => ({ removed: 0 }))
+  },
+}))
+vi.mock('../../cache', () => ({
+  getOrgCache: () => orgCache,
+  getCachedResources: vi.fn(async () => []),
+  getCachedMembers: vi.fn(async () => []),
+}))
+vi.mock('../mail-counts', () => ({
+  applyMailCountDeltas: vi.fn(async () => undefined),
+  markMailCountsStale: vi.fn(async () => undefined),
+  markMailCountsStaleForOrgMembers: vi.fn(async () => undefined),
+}))
+
+const { ThreadMutationService } = await import('../thread-mutation.service')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const ACTOR_ID = 'usr_cuid000000000000000000000'
+const THREAD_ID = 'thr_cuid00000000000000000a'
+const OLD_ASSIGNEE = 'usr_previousassignee0000000'
+const NEW_ASSIGNEE = 'usr_newassignee00000000000a'
+
+/** The row shape each `db.select(...)` in the update path resolves to, in order. */
+function makeDb(selectResults: unknown[][], updateResult: unknown[]) {
+  let call = 0
+  const selectChain = (result: unknown[]) => {
+    const chain: Record<string, unknown> = {}
+    Object.assign(chain, {
+      from: () => chain,
+      leftJoin: () => chain,
+      where: () => chain,
+      limit: () => Promise.resolve(result),
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable query-builder mock
+      then: (ok: (v: unknown) => unknown, err?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(ok, err),
+    })
+    return chain
+  }
+  const updateChain: Record<string, unknown> = {}
+  Object.assign(updateChain, {
+    set: () => updateChain,
+    where: () => updateChain,
+    returning: () => Promise.resolve(updateResult),
+  })
+  return {
+    select: () => selectChain(selectResults[call++] ?? []),
+    update: () => updateChain,
+  } as never
+}
+
+function viewer(): UserMailVisibility {
+  return {
+    userId: ACTOR_ID,
+    role: 'MEMBER',
+    isAdmin: false,
+    isMailAdmin: false,
+    inboxLens: {},
+    personalInboxIds: {},
+    threadGrants: {},
+    contactGrants: {},
+    entityGrants: {},
+  }
+}
+
+/** The `patch` the service handed to `publishThreadUpdated`. */
+function publishedPatch(): Record<string, unknown> {
+  const args = realtime.publishThreadUpdated.mock.calls.at(-1) as unknown as unknown[]
+  return (args[2] as { patch: Record<string, unknown> }).patch
+}
+
+beforeEach(() => {
+  lensFixture.lenses = { [THREAD_ID]: 'full' }
+  getThreadLensBatch.mockClear()
+  for (const fn of Object.values(realtime)) fn.mockClear()
+  publisher.publishLater.mockClear()
+})
+
+describe('ThreadMutationService.update — assignee patch format', () => {
+  function service() {
+    const db = makeDb(
+      [
+        [{ inboxId: null, status: 'OPEN', assigneeId: OLD_ASSIGNEE, integrationId: null }],
+        [], // read-status rows for the count deltas
+      ],
+      [{ id: THREAD_ID, inboxId: null, assigneeId: NEW_ASSIGNEE }]
+    )
+    return new ThreadMutationService(ORG_ID, db, undefined, ACTOR_ID, viewer())
+  }
+
+  it('publishes an ActorId, not the bare column value', async () => {
+    await service().update(`thread:${THREAD_ID}` as never, {
+      assigneeId: `user:${NEW_ASSIGNEE}` as never,
+    })
+
+    expect(publishedPatch().assigneeId).toBe(`user:${NEW_ASSIGNEE}`)
+    expect(publishedPatch().assigneeId).not.toBe(NEW_ASSIGNEE)
+  })
+
+  it('publishes null when the thread is unassigned', async () => {
+    const db = makeDb(
+      [[{ inboxId: null, status: 'OPEN', assigneeId: OLD_ASSIGNEE, integrationId: null }], []],
+      [{ id: THREAD_ID, inboxId: null, assigneeId: null }]
+    )
+    await new ThreadMutationService(ORG_ID, db, undefined, ACTOR_ID, viewer()).update(
+      `thread:${THREAD_ID}` as never,
+      { assigneeId: null }
+    )
+
+    expect(publishedPatch().assigneeId).toBeNull()
+  })
+
+  /**
+   * The envelope's own `assigneeId` is a ROOM KEY, not store data — the
+   * per-user full-payload fanout targets `user:<id>` rooms by bare id
+   * (`publish-helpers.ts`). Prefixing it would silently misroute the fanout.
+   */
+  it('leaves the envelope assigneeId bare', async () => {
+    await service().update(`thread:${THREAD_ID}` as never, {
+      assigneeId: `user:${NEW_ASSIGNEE}` as never,
+    })
+
+    const args = realtime.publishThreadUpdated.mock.calls.at(-1) as unknown as unknown[]
+    expect((args[2] as { assigneeId: string }).assigneeId).toBe(NEW_ASSIGNEE)
+  })
+})
+
+describe('ThreadMutationService.updateBulk — assignee patch format', () => {
+  it('publishes an ActorId for every thread in the batch', async () => {
+    const db = makeDb(
+      [
+        [{ id: THREAD_ID, inboxId: null, status: 'OPEN', integrationId: null }],
+        [], // read-status rows
+      ],
+      [{ id: THREAD_ID, inboxId: null, assigneeId: NEW_ASSIGNEE }]
+    )
+    await new ThreadMutationService(ORG_ID, db, undefined, ACTOR_ID, viewer()).updateBulk(
+      [`thread:${THREAD_ID}` as never],
+      { assigneeId: `user:${NEW_ASSIGNEE}` as never }
+    )
+
+    expect(publishedPatch().assigneeId).toBe(`user:${NEW_ASSIGNEE}`)
+  })
+})

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -2,7 +2,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { type ActorId, parseActorId } from '@auxx/types/actor'
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
 import { getInstanceId, parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { and, eq, exists, ilike, inArray, notExists, or, sql } from 'drizzle-orm'
 import { getCachedResources, getOrgCache } from '../cache'
@@ -289,7 +289,15 @@ export class ThreadMutationService {
       const patch: Partial<ThreadMeta> = {}
       if ('status' in dbUpdates) patch.status = dbUpdates.status
       if ('subject' in dbUpdates) patch.subject = dbUpdates.subject
-      if ('assigneeId' in dbUpdates) patch.assigneeId = dbUpdates.assigneeId
+      if ('assigneeId' in dbUpdates) {
+        // ActorId on the wire, same as the fetch path
+        // (`thread-query.service.ts` `toActorId('user', …)`). `dbUpdates` holds
+        // the BARE column value, and publishing that put a bare id into a store
+        // field typed `ActorId | null` until the next refetch — enough for
+        // `parseActorId` to throw on ticket creation and for every assignee
+        // chip to render nothing (plan 44 §3.4). One format on the wire.
+        patch.assigneeId = dbUpdates.assigneeId ? toActorId('user', dbUpdates.assigneeId) : null
+      }
       if ('inboxId' in dbUpdates) {
         // The destination may be a personal mailbox, which lives on the
         // `personal_inbox` definition (plan 40 §3 / 40a §5.1) — resolve the def
@@ -670,7 +678,10 @@ export class ThreadMutationService {
 
       const patch: Partial<ThreadMeta> = {}
       if ('status' in dbUpdates) patch.status = dbUpdates.status
-      if ('assigneeId' in dbUpdates) patch.assigneeId = dbUpdates.assigneeId
+      if ('assigneeId' in dbUpdates) {
+        // ActorId on the wire, same as the single-thread patch above (§3.4).
+        patch.assigneeId = dbUpdates.assigneeId ? toActorId('user', dbUpdates.assigneeId) : null
+      }
       if ('inboxId' in dbUpdates) {
         // Def-resolved, same as the single-thread patch above (40a §5.1). The
         // whole batch moves to ONE destination inbox, so this is one lookup.


### PR DESCRIPTION
Plan 44 phases A–C. **Option A** on the one product question: read-state stays `full`-tier, so the client learns the rule rather than the tier moving. Phase D is dropped.

## Correction to the plan first

**§1.1's diagnosis is wrong, and I verified it empirically.** `handleServiceError` passes the original error on `cause:`, and `auxxErrorMiddleware` maps on `result.error.cause` — so the read-state refusal *already* surfaced as `FORBIDDEN` with the service's own message, not a 500 reading "An unexpected error occurred in threadMutation.update." Mutation check confirms it: removing the `isAuxxError` guard from `handleServiceError` fails **nothing**.

The catches that genuinely flatten a 403 into a 500 are the two that re-wrap with **no `cause` at all** — `linkToTicket` and `retryMessage` — and `retryMessage` additionally swallowed its own `chat_retry_unsupported` BAD_REQUEST. Those are fixed and pinned.

The reported symptom is real regardless: opening a `subject`-lens shared thread produced an error toast, and phase A is what stops it.

## Phase A — the reported failure

A share recipient follows the `MESSAGE_SHARED` deep link, so the detail pane renders from the URL id before the batched meta fetch returns — no list load in front of it. The auto-mark-read effect fired into exactly that window, because `useThreadReadStatus` defaulted an unhydrated thread to unread and `UnreadService.setReadStatus` correctly refuses below `full`.

- `thread-display.tsx` gates on `!!thread && (thread.myLens ?? 'full') === 'full'`
- `useThreadReadStatus` returns `isUnread: boolean | undefined`; the bold-placeholder `?? true` moves into the two list rows, the only place it was ever a *rendering* concern
- `setReadStatus`'s gate is untouched — the server check stays authoritative, the client gate is UX

## Phase B — identity normalization

`ThreadCountContext.assigneeId` was documented as "Plain user ID (not ActorId format)" and then filled from the store — where it is an `ActorId` — by every caller. So `assigneeId === currentUserId` was **always false** and the "Assigned to me" badge never moved optimistically. Worse, it was one-directional: the incoming assignee *was* stripped, so "assign to me" incremented while "unassign from me" never decremented.

The same shape hid in `inboxId`: the store holds a RecordId, `counts.sharedInboxes` is keyed by the bare instance id (`si:{inboxId}`), so that debit had never matched either.

- New `mail/utils/thread-count-context.ts` — the single producer, normalizing both ids through the **parsers**, never a `.replace('user:', '')` strip (which mangles `personal_inbox:<id>` into `personal_<id>` and files the delta under a key nothing reads)
- Fields renamed `assigneeUserId` / `inboxInstanceId`, so a raw `thread.assigneeId` is now a **type error** instead of a comment violation — the thing that stops the fourth recurrence
- View-filter `assignee` resolver returns the bare id, matching what `resolveConditionContext` substitutes and what the server evaluates in SQL
- `thread-mutation.service.ts` publishes `toActorId('user', …)` in **both** `update` and `updateBulk` patches. It shipped the bare column value under a field typed `ActorId | null` — enough for `parseActorId` to throw `Invalid ActorId: <bare-id>` on ticket creation, and for every assignee chip to silently render nothing. Fixed at the publisher; one format on the wire.

## Phase C — status codes

`isAuxxError` passthrough in `handleServiceError` (hardening — it stops the correct status depending on one `cause:` argument staying in place), plus the two causeless catches above.

## Tests — 6 files, 34 cases, all mutation-verified

Every defect here fails *silently*: a badge that doesn't move, a delta under a dead key, a 403 wearing a 500. So each assertion was checked by reverting its fix and confirming red.

| File | Pins |
|---|---|
| `thread-error-status.test.ts` | Codes, never "it rejected". Includes a negative control that a real failure still 500s |
| `thread-display-read-gate.test.tsx` | No write at `subject`/`metadata`, none with an empty store, positive control at `full` |
| `use-thread-read-status-default.test.tsx` | `undefined` for an unhydrated thread |
| `count-identity.test.tsx` | Contexts from the **real producer** — a hand-written literal with a bare id is the test that passed all along |
| `use-thread-mutation-assignee-identity.test.tsx` | The badge now moves **down** too |
| `thread-assignee-patch-format.test.ts` | ActorId in the patch for `update` and `updateBulk`; envelope `assigneeId` stays bare (it is a room key) |

`use-thread-mutation-inbox-def.test.tsx` now asserts the source **debit** key — it previously documented that debit as knowingly broken and declined to pin it.

## Verification

- Typecheck clean for every touched file in both `apps/web` and `packages/lib` (remaining errors in `thread.ts:449` and `thread-mutation.service.ts:323/325` are pre-existing, on lines untouched here)
- Biome clean
- `packages/lib` threads: 42 passed. `apps/web` mail + threads + routers: 1241 passed, including the pre-existing `mail-instance-access` suite

## Not done

- §5.7's two-user browser pass
- The `message.includes('not found')` status sniffing at `thread.ts:198`, which §6 gives its own pass