### PR TITLE
fix(mail): visibility refresh and invalidation fan-out (plan 45)

### DIFF
--- a/apps/api/src/routes/chat/lib.ts
+++ b/apps/api/src/routes/chat/lib.ts
@@ -4,6 +4,7 @@ import { database, schema } from '@auxx/database'
 import { getCachedAgentById, getCachedOrgProfile } from '@auxx/lib/cache'
 import type { ChatAttachment } from '@auxx/lib/chat'
 import { listOnDutyUserIds } from '@auxx/lib/chat-duty'
+import { shapeThreadEventForVisitor } from '@auxx/lib/events'
 import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
 
@@ -64,11 +65,15 @@ export async function loadThreadEvents(
     .orderBy(asc(schema.Event.createdAt))
     .limit(THREAD_EVENT_LIMIT)
 
+  // Shaped for the visitor, exactly as the realtime publish is (plan 45 §1.5).
+  // Without this the allowlist would be cosmetic: `Event.data` is the complete
+  // internal payload and the widget fetches it straight back over HTTP, so
+  // `userId` / `previousState` would arrive by the history route instead.
   return rows.map((r) => ({
     id: r.id,
     type: r.type as WidgetThreadEventType,
     createdAt: r.createdAt,
-    data: (r.data ?? {}) as Record<string, unknown>,
+    data: shapeThreadEventForVisitor((r.data ?? {}) as Record<string, unknown>),
   }))
 }
 

--- a/apps/web/src/components/global/notifications/hooks/use-notification-subscription.test.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-notification-subscription.test.ts
@@ -1,0 +1,98 @@
+// apps/web/src/components/global/notifications/hooks/use-notification-subscription.test.ts
+//
+// Plan 45 §3.2 — the requester's "requested" chip after someone else decides.
+//
+// Deny and supersede write no grant, so they publish no `visibility:changed` —
+// correctly, since the requester's ACCESS did not change. What changed is their
+// REQUEST, and the signal for that is the `ACCESS_REQUEST_DECIDED` notification
+// `notifyRequesterDecided` already sends on all three outcomes. This file pins
+// that the handler acts on it, and only on it.
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  onEvent: undefined as undefined | ((event: string, payload: unknown) => void),
+  preflightInvalidate: vi.fn(),
+  approvalInvalidates: {
+    getPendingCount: vi.fn(),
+    getPendingRequests: vi.fn(),
+    count: vi.fn(),
+    list: vi.fn(),
+  },
+  unreadSetData: vi.fn(),
+  notificationInvalidates: { getUnreadCount: vi.fn(), getNotifications: vi.fn() },
+}))
+
+vi.mock('~/hooks/use-user', () => ({ useUser: () => ({ organizationId: 'org_1' }) }))
+
+vi.mock('~/providers/dehydrated-state-provider', () => ({
+  useDehydratedSettings: () => ({ 'notification.sound.bell': false }),
+}))
+
+vi.mock('~/lib/play-notification-sound', () => ({
+  NEW_MESSAGE_SOUND: 'sound',
+  playNotificationSound: vi.fn(),
+}))
+
+vi.mock('~/realtime/hooks', () => ({
+  useRealtimeRoom: (_room: string | null, opts: any) => {
+    h.onEvent = opts.onEvent
+  },
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      notification: {
+        getUnreadCount: {
+          setData: h.unreadSetData,
+          invalidate: h.notificationInvalidates.getUnreadCount,
+        },
+        getNotifications: { invalidate: h.notificationInvalidates.getNotifications },
+      },
+      approval: {
+        accessRequestPreflight: { invalidate: h.preflightInvalidate },
+        getPendingCount: { invalidate: h.approvalInvalidates.getPendingCount },
+        getPendingRequests: { invalidate: h.approvalInvalidates.getPendingRequests },
+      },
+      approvals: {
+        count: { invalidate: h.approvalInvalidates.count },
+        list: { invalidate: h.approvalInvalidates.list },
+      },
+    }),
+  },
+}))
+
+const { useNotificationSubscription } = await import('./use-notification-subscription')
+
+const notification = (type: string) => ({ type, organizationId: 'org_1' })
+
+beforeEach(() => {
+  h.onEvent = undefined
+  h.preflightInvalidate.mockClear()
+  renderHook(() => useNotificationSubscription('usr_me'))
+})
+
+describe('§3.2 — an access-request decision clears the pending chip', () => {
+  it('invalidates accessRequestPreflight on ACCESS_REQUEST_DECIDED', () => {
+    h.onEvent?.('notification', notification('ACCESS_REQUEST_DECIDED'))
+
+    // Covers approve, deny AND supersede: `notifyRequesterDecided` is the single
+    // funnel for all three, so there is no per-outcome branch to forget.
+    expect(h.preflightInvalidate).toHaveBeenCalled()
+  })
+
+  it('leaves it alone for any other notification type', () => {
+    h.onEvent?.('notification', notification('ACCESS_REQUESTED'))
+    h.onEvent?.('notification', notification('MESSAGE_SHARED'))
+
+    expect(h.preflightInvalidate).not.toHaveBeenCalled()
+  })
+
+  it('does not fire on a bare notification with no type', () => {
+    h.onEvent?.('notification', { organizationId: 'org_1' })
+
+    expect(h.preflightInvalidate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/global/notifications/hooks/use-notification-subscription.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-notification-subscription.ts
@@ -28,6 +28,23 @@ export function useNotificationSubscription(userId: string) {
             }))
             if (bellSoundRef.current) playNotificationSound(NEW_MESSAGE_SOUND)
           }
+          // An access request the viewer FILED was decided (plan 45 §1.2). The
+          // "requested" chip reads `accessRequestPreflight`, which is invalidated
+          // only by the viewer's own request/withdraw mutations and has
+          // `refetchOnWindowFocus: false` — so on a decision made by someone else
+          // it stays stuck until a thread switch or a reload.
+          //
+          // This is the LIFECYCLE half only. On approve the access itself arrives
+          // via `visibility:changed` (`use-mail-sync`), which is the funnel for
+          // all eleven causes of a lens change; deny and supersede write no grant
+          // and correctly publish no visibility event, so this notification —
+          // which `notifyRequesterDecided` sends on all three outcomes — is the
+          // signal they have. Un-keyed because the payload carries an
+          // `approvalRequestId`, not a thread id; only the open thread's preflight
+          // query is ever active, so it is one refetch.
+          if ((payload as { type?: string } | undefined)?.type === 'ACCESS_REQUEST_DECIDED') {
+            void utils.approval.accessRequestPreflight.invalidate()
+          }
           if (useNotificationPanelStore.getState().open) {
             void utils.notification.getNotifications.invalidate()
           }

--- a/apps/web/src/components/mail/hooks/use-html-body.ts
+++ b/apps/web/src/components/mail/hooks/use-html-body.ts
@@ -9,8 +9,44 @@ interface HtmlBodyState {
   error: string | null
 }
 
-/** In-memory cache keyed by messageId to survive collapse/expand cycles. */
+/**
+ * In-memory cache keyed by messageId to survive collapse/expand cycles.
+ *
+ * Bounded and clearable, both for the same reason (plan 45 §1.6): it holds full
+ * HTML bodies, it is module-level so it outlives every route change, and it is
+ * NOT keyed by lens — so without {@link clearHtmlBodyCache} a viewer who loses
+ * `full` keeps every body they had already opened for the tab's lifetime.
+ */
 const htmlBodyCache = new Map<string, string>()
+
+/**
+ * FIFO bound. Insertion-ordered `Map`, so the oldest key is the first one
+ * `keys()` yields. A single long thread can hold a few hundred KB per body;
+ * unbounded, a day of triage is a memory profile nobody has looked at.
+ */
+const HTML_BODY_CACHE_MAX = 50
+
+function cacheHtmlBody(messageId: string, html: string): void {
+  htmlBodyCache.set(messageId, html)
+  while (htmlBodyCache.size > HTML_BODY_CACHE_MAX) {
+    const oldest = htmlBodyCache.keys().next().value
+    if (oldest === undefined) break
+    htmlBodyCache.delete(oldest)
+  }
+}
+
+/**
+ * Drop every cached body. Called from `use-mail-sync`'s `visibility:changed`
+ * handler — a revoke has to take the bodies with it.
+ *
+ * This only stops a body being re-served on the next expand: a body already
+ * rendered lives in the hook's `useState`, and what actually removes it from the
+ * screen is the lens refresh in the same handler, which makes `thread-messages`
+ * render the redaction banner instead and unmount this hook.
+ */
+export function clearHtmlBodyCache(): void {
+  htmlBodyCache.clear()
+}
 
 /**
  * Lazy-loads an inbound message HTML body from object storage.
@@ -42,7 +78,7 @@ export function useHtmlBody(messageId: string | undefined) {
 
     try {
       const html = await fetchBodyHtml(messageId)
-      htmlBodyCache.set(messageId, html)
+      cacheHtmlBody(messageId, html)
       setState({ html, isLoading: false, error: null })
     } catch (err) {
       setState({

--- a/apps/web/src/components/threads/realtime/use-mail-sync-visibility.test.ts
+++ b/apps/web/src/components/threads/realtime/use-mail-sync-visibility.test.ts
@@ -1,0 +1,152 @@
+// apps/web/src/components/threads/realtime/use-mail-sync-visibility.test.ts
+//
+// Plan 45 §3.1 — what `visibility:changed` does to an OPEN conversation.
+//
+// The bar this file is written to: a test that only asserts "some invalidation
+// happened" passes against the pre-plan-45 handler, because that handler already
+// invalidated three things and still left the redaction banner on screen. So the
+// assertions here are about the two caches a tRPC invalidate provably cannot
+// reach — the thread-store entry that holds `myLens`, and the message list behind
+// `useMessages`' `!cachedList` gate.
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Captured room → onEvent, so a test can dispatch as the server would. */
+  handlers: new Map<string, (event: string, payload: unknown) => void>(),
+  invalidate: {
+    myLenses: vi.fn(),
+    listIds: vi.fn(),
+    getCounts: vi.fn(),
+  },
+  listByThreadFetch: vi.fn<(input: any, opts: any) => Promise<any>>(async () => ({
+    messages: [],
+    total: 0,
+  })),
+  clearHtmlBodyCache: vi.fn(),
+}))
+
+vi.mock('~/hooks/use-user', () => ({ useUser: () => ({ user: { id: 'usr_me' } }) }))
+
+vi.mock('../hooks', () => ({
+  useMyInboxLenses: () => ({ lenses: { support: 'full' }, isAdmin: false, isLoaded: true }),
+}))
+
+vi.mock('./use-message-arrival-cue', () => ({ useMessageArrivalCue: () => vi.fn() }))
+
+vi.mock('~/components/mail/hooks/use-html-body', () => ({
+  clearHtmlBodyCache: h.clearHtmlBodyCache,
+}))
+
+vi.mock('~/realtime/hooks', () => ({
+  useInboxChannels: (_entries: unknown, opts: any) => h.handlers.set('inbox', opts.onEvent),
+  useOrgChannel: (opts: any) => h.handlers.set('org', opts.onEvent),
+  useRealtimeRoom: (room: string | null, opts: any) => {
+    if (room) h.handlers.set('user', opts.onEvent)
+  },
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      inbox: { myLenses: { invalidate: h.invalidate.myLenses } },
+      thread: {
+        listIds: { invalidate: h.invalidate.listIds },
+        getCounts: { invalidate: h.invalidate.getCounts },
+      },
+      message: { listByThread: { fetch: h.listByThreadFetch } },
+    }),
+  },
+}))
+
+const { useMailSync } = await import('./use-mail-sync')
+const { useThreadStore } = await import('../store/thread-store')
+const { useThreadSelectionStore } = await import('../store/thread-selection-store')
+const { useMessageListStore } = await import('../store/message-list-store')
+const { useMessageStore } = await import('../store/message-store')
+
+const thread = (id: string, myLens: string) => ({ id, subject: '', myLens }) as any
+
+/** Dispatch `visibility:changed` on the viewer's own room, as a targeted grant does. */
+const dispatchVisibilityChanged = () =>
+  h.handlers.get('user')?.('visibility:changed', {
+    organizationId: 'org_1',
+  })
+
+beforeEach(() => {
+  h.handlers.clear()
+  h.invalidate.myLenses.mockClear()
+  h.invalidate.listIds.mockClear()
+  h.invalidate.getCounts.mockClear()
+  h.listByThreadFetch.mockClear()
+  h.clearHtmlBodyCache.mockClear()
+  useThreadStore.getState().reset()
+  useMessageListStore.getState().reset?.()
+  useMessageStore.getState().reset?.()
+  useThreadSelectionStore.getState().setActiveThread(null)
+})
+
+describe('§3.1 — visibility:changed on an open thread', () => {
+  it('re-requests the open thread META, which is the only source of myLens', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1', 'metadata')], [])
+    useThreadSelectionStore.getState().setActiveThread('thr_1')
+    renderHook(() => useMailSync())
+
+    dispatchVisibilityChanged()
+
+    // THE assertion. Delete `forceRequestThread` from the handler and this fails
+    // while every invalidation assertion below still passes — which is exactly
+    // how the banner survived before plan 45.
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(true)
+    // And it did not blank the pane to do it.
+    expect(useThreadStore.getState().threads.get('thr_1')).toBeDefined()
+  })
+
+  it('force-fetches the message list past the !cachedList gate', () => {
+    useThreadSelectionStore.getState().setActiveThread('thr_1')
+    renderHook(() => useMailSync())
+
+    dispatchVisibilityChanged()
+
+    expect(h.listByThreadFetch).toHaveBeenCalledWith({ threadId: 'thr_1' }, { staleTime: 0 })
+  })
+
+  it('clears the module-level HTML body cache — bodies must not survive a revoke', () => {
+    useThreadSelectionStore.getState().setActiveThread('thr_1')
+    renderHook(() => useMailSync())
+
+    dispatchVisibilityChanged()
+
+    expect(h.clearHtmlBodyCache).toHaveBeenCalled()
+  })
+
+  it('still does the three lens-wide invalidations', () => {
+    renderHook(() => useMailSync())
+
+    dispatchVisibilityChanged()
+
+    expect(h.invalidate.myLenses).toHaveBeenCalled()
+    expect(h.invalidate.listIds).toHaveBeenCalled()
+    expect(h.invalidate.getCounts).toHaveBeenCalled()
+  })
+
+  it('costs a viewer with no open thread nothing beyond the invalidations', () => {
+    renderHook(() => useMailSync())
+
+    dispatchVisibilityChanged()
+
+    expect(h.listByThreadFetch).not.toHaveBeenCalled()
+    expect(useThreadStore.getState().pendingIds.size).toBe(0)
+  })
+
+  it('fires on the ORG room too — a broadcast (inbox default-lens edit) refreshes as well', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1', 'metadata')], [])
+    useThreadSelectionStore.getState().setActiveThread('thr_1')
+    renderHook(() => useMailSync())
+
+    h.handlers.get('org')?.('visibility:changed', { organizationId: 'org_1' })
+
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(true)
+  })
+})

--- a/apps/web/src/components/threads/realtime/use-mail-sync.ts
+++ b/apps/web/src/components/threads/realtime/use-mail-sync.ts
@@ -17,6 +17,7 @@ import type {
 import { rooms } from '@auxx/lib/realtime/client'
 import { extractUniqueParticipantIds } from '@auxx/types'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { clearHtmlBodyCache } from '~/components/mail/hooks/use-html-body'
 import { useUser } from '~/hooks/use-user'
 import {
   type InboxChannelEntry,
@@ -60,6 +61,7 @@ export function useMailSync() {
 
   // Store actions (selectors to avoid re-renders).
   const requestThread = useThreadStore((s) => s.requestThread)
+  const forceRequestThread = useThreadStore((s) => s.forceRequestThread)
   const setThreadPatch = useThreadStore((s) => s.setThreadPatch)
   const removeThread = useThreadStore((s) => s.removeThread)
   const invalidateAllContexts = useThreadStore((s) => s.invalidateAllContexts)
@@ -294,36 +296,6 @@ export function useMailSync() {
     ]
   )
 
-  // The viewer's visibility changed (grant added/revoked, inbox lens moved,
-  // role changed). Refetch `inbox.myLenses` — the `entries` memo re-derives
-  // and `useInboxChannels` resubscribes to the new per-lens channel set — and
-  // refresh everything lens-dependent that's already on screen.
-  const handleVisibilityChanged = useCallback(() => {
-    utils.inbox.myLenses.invalidate()
-    utils.thread.listIds.invalidate()
-    utils.thread.getCounts.invalidate()
-    invalidateAllContexts()
-  }, [utils, invalidateAllContexts])
-
-  // Org-channel event dispatcher — broadcast visibility changes (e.g. an
-  // inbox default-lens edit) that fan out to every member.
-  const onOrgEvent = useCallback(
-    (event: string, _payload: unknown) => {
-      if (event === 'visibility:changed') handleVisibilityChanged()
-    },
-    [handleVisibilityChanged]
-  )
-
-  // User-channel event dispatcher: targeted visibility changes + the
-  // per-user grantee/assignee mail-event fanout (§6.3).
-  const onUserEvent = useCallback(
-    (event: string, payload: unknown) => {
-      if (event === 'visibility:changed') return handleVisibilityChanged()
-      onInboxEvent(event, payload)
-    },
-    [handleVisibilityChanged, onInboxEvent]
-  )
-
   // Catch-up on (re)subscribe. Pusher does NOT replay events published while a
   // channel was mid-subscribe — and inbox channels only bind after the async
   // `inbox.myLenses` query resolves, plus rebind on every reconnect and on
@@ -384,6 +356,59 @@ export function useMailSync() {
       if (catchUpTimerRef.current) clearTimeout(catchUpTimerRef.current)
     },
     []
+  )
+
+  // The viewer's visibility changed (grant added/revoked, inbox lens moved,
+  // role changed). Refetch `inbox.myLenses` — the `entries` memo re-derives
+  // and `useInboxChannels` resubscribes to the new per-lens channel set — and
+  // refresh everything lens-dependent that's already on screen.
+  //
+  // Declared AFTER `runCatchUp` because it calls it. The last three statements
+  // are the ones that do any work on a THREAD grant (plan 45 §1.1); the four
+  // above them cannot reach the open conversation at all. Thread meta has no
+  // query cache — `thread.getByIds` is a mutation, so the Zustand map holds the
+  // only copy of `myLens`, and that value *is* the redaction banner — and
+  // `useMessages` disables itself once `useMessageListStore` has a list. A thread
+  // grant also moves no inbox lens, so `myLenses` refetches byte-identically,
+  // `entryKey` is unchanged, nothing resubscribes, and the `onSubscribed` →
+  // `runCatchUp` self-heal never fires. Hence calling it directly.
+  const handleVisibilityChanged = useCallback(() => {
+    utils.inbox.myLenses.invalidate()
+    utils.thread.listIds.invalidate()
+    utils.thread.getCounts.invalidate()
+    invalidateAllContexts()
+
+    // Full HTML bodies otherwise survive a revoke — the map is module-level and
+    // not lens-keyed (plan 45 §1.6).
+    clearHtmlBodyCache()
+
+    // Thread META. `runCatchUp` refetches the message list and the thread LIST,
+    // and neither carries `myLens`, so without this the banner never clears.
+    const activeThreadId = getThreadSelectionState().activeThreadId
+    if (activeThreadId) forceRequestThread(activeThreadId)
+
+    // Message bodies: fetches past the `!cachedList` gate and OVERWRITES the
+    // store, so `subject`-blanked bodies get replaced rather than merged.
+    runCatchUp()
+  }, [utils, invalidateAllContexts, forceRequestThread, runCatchUp])
+
+  // Org-channel event dispatcher — broadcast visibility changes (e.g. an
+  // inbox default-lens edit) that fan out to every member.
+  const onOrgEvent = useCallback(
+    (event: string, _payload: unknown) => {
+      if (event === 'visibility:changed') handleVisibilityChanged()
+    },
+    [handleVisibilityChanged]
+  )
+
+  // User-channel event dispatcher: targeted visibility changes + the
+  // per-user grantee/assignee mail-event fanout (§6.3).
+  const onUserEvent = useCallback(
+    (event: string, payload: unknown) => {
+      if (event === 'visibility:changed') return handleVisibilityChanged()
+      onInboxEvent(event, payload)
+    },
+    [handleVisibilityChanged, onInboxEvent]
   )
 
   useInboxChannels(entries, {

--- a/apps/web/src/components/threads/store/thread-store-force-request.test.ts
+++ b/apps/web/src/components/threads/store/thread-store-force-request.test.ts
@@ -1,0 +1,98 @@
+// apps/web/src/components/threads/store/thread-store-force-request.test.ts
+//
+// Plan 45 §3.1 — `forceRequestThread`, the bypass `visibility:changed` needs.
+//
+// The two assertions that carry the design: it enqueues WITHOUT evicting (an
+// eviction blanks the pane mid-read, because `thread-messages` returns null on a
+// missing thread), and it clears `notFoundIds` (a thread that 404'd at `none` and
+// has just been granted is exactly the case a `threads.has(id)`-only bypass
+// misses — §5 hazard 2).
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type ThreadMeta, useThreadStore } from './thread-store'
+
+const thread = (id: string, myLens: ThreadMeta['myLens'] = 'metadata') =>
+  ({
+    id,
+    subject: '',
+    status: 'OPEN',
+    lastMessageAt: '2026-07-29T10:00:00.000Z',
+    myLens,
+  }) as unknown as ThreadMeta
+
+beforeEach(() => {
+  useThreadStore.getState().reset()
+})
+
+describe('forceRequestThread', () => {
+  it('enqueues a thread the store already holds — which requestThread refuses', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1')], [])
+
+    useThreadStore.getState().requestThread('thr_1')
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(false)
+
+    useThreadStore.getState().forceRequestThread('thr_1')
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(true)
+  })
+
+  it('does NOT evict — the old entry keeps rendering until the batch lands', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1', 'metadata')], [])
+
+    useThreadStore.getState().forceRequestThread('thr_1')
+
+    // The assertion that fails if someone reimplements this as evict-then-request.
+    expect(useThreadStore.getState().threads.get('thr_1')).toBeDefined()
+    expect(useThreadStore.getState().threads.get('thr_1')?.myLens).toBe('metadata')
+  })
+
+  it('replaces the entry in place once the forced batch completes', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1', 'metadata')], [])
+    useThreadStore.getState().forceRequestThread('thr_1')
+
+    expect(useThreadStore.getState().startBatch()).toContain('thr_1')
+    useThreadStore.getState().completeBatch([thread('thr_1', 'full')], [])
+
+    expect(useThreadStore.getState().threads.get('thr_1')?.myLens).toBe('full')
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(false)
+  })
+
+  it('clears notFoundIds — a thread that 404d at `none` must re-request', () => {
+    useThreadStore.getState().completeBatch([], ['thr_1'])
+    expect(useThreadStore.getState().notFoundIds.has('thr_1')).toBe(true)
+
+    useThreadStore.getState().requestThread('thr_1')
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(false)
+
+    useThreadStore.getState().forceRequestThread('thr_1')
+    expect(useThreadStore.getState().notFoundIds.has('thr_1')).toBe(false)
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(true)
+  })
+
+  it('refuses a deleted thread — a lens change does not resurrect it', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1')], [])
+    useThreadStore.getState().removeThread('thr_1')
+
+    useThreadStore.getState().forceRequestThread('thr_1')
+
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(false)
+  })
+
+  it('is a no-op when the id is already queued', () => {
+    useThreadStore.getState().requestThread('thr_1')
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(true)
+
+    useThreadStore.getState().forceRequestThread('thr_1')
+
+    expect(Array.from(useThreadStore.getState().pendingIds)).toEqual(['thr_1'])
+  })
+
+  it('still enqueues while a batch is in flight — that fetch may predate the change', () => {
+    useThreadStore.getState().requestThread('thr_1')
+    useThreadStore.getState().startBatch()
+    expect(useThreadStore.getState().loadingIds.has('thr_1')).toBe(true)
+
+    useThreadStore.getState().forceRequestThread('thr_1')
+
+    expect(useThreadStore.getState().pendingIds.has('thr_1')).toBe(true)
+  })
+})

--- a/apps/web/src/components/threads/store/thread-store.ts
+++ b/apps/web/src/components/threads/store/thread-store.ts
@@ -253,7 +253,16 @@ interface ThreadStoreState {
   invalidateAllContexts: () => void
 
   // Batch loading (threads)
+  /** Internal — the shared enqueue + batch-timer kick. Use the two below. */
+  enqueueThread: (id: string) => void
   requestThread: (id: string) => void
+  /**
+   * Re-fetch a thread the store already holds, for when the SERVER's answer
+   * changed rather than the id set — today only a `visibility:changed` lens move
+   * (plan 45 §1.1). Bypasses `requestThread`'s cache short-circuit without
+   * evicting the entry, so the open thread never blanks mid-read.
+   */
+  forceRequestThread: (id: string) => void
   startBatch: () => string[]
   completeBatch: (threads: ThreadMeta[], notFoundIds: string[]) => void
 
@@ -510,17 +519,8 @@ export const useThreadStore = create<ThreadStoreState>()(
       // BATCH LOADING ACTIONS
       // ═══════════════════════════════════════════════════════════════
 
-      requestThread: (id) => {
+      enqueueThread: (id) => {
         const state = get()
-        if (
-          state.threads.has(id) ||
-          state.loadingIds.has(id) ||
-          state.pendingIds.has(id) ||
-          state.notFoundIds.has(id) ||
-          state.deletedIds.has(id)
-        ) {
-          return
-        }
 
         set((s) => {
           s.pendingIds.add(id)
@@ -537,6 +537,49 @@ export const useThreadStore = create<ThreadStoreState>()(
             s.batchTimer = timer
           })
         }
+      },
+
+      requestThread: (id) => {
+        const state = get()
+        if (
+          state.threads.has(id) ||
+          state.loadingIds.has(id) ||
+          state.pendingIds.has(id) ||
+          state.notFoundIds.has(id) ||
+          state.deletedIds.has(id)
+        ) {
+          return
+        }
+
+        get().enqueueThread(id)
+      },
+
+      forceRequestThread: (id) => {
+        const state = get()
+
+        // A deleted thread stays deleted — a lens change doesn't resurrect it.
+        if (state.deletedIds.has(id)) return
+        // Already queued: that fetch is issued after this call, so it returns the
+        // post-change row anyway.
+        if (state.pendingIds.has(id)) return
+
+        // `notFoundIds` MUST be cleared, not respected: a thread that 404'd at
+        // `none` and has just been granted is precisely the case that has to
+        // re-request, and the one a `threads.has(id)`-only bypass misses
+        // (plan 45 §5 hazard 2).
+        if (state.notFoundIds.has(id)) {
+          set((s) => {
+            s.notFoundIds.delete(id)
+          })
+        }
+
+        // Deliberately NOT gated on `loadingIds`: a batch already in flight was
+        // issued before the lens moved and may answer from pre-change state.
+        // `useBatchDrain` serialises thread batches, so ours lands after it and
+        // wins. And deliberately no eviction — `completeBatch` replaces in place,
+        // so the pane keeps rendering the old lens for one batch window instead
+        // of blanking (`thread-messages.tsx` returns null on a missing thread).
+        get().enqueueThread(id)
       },
 
       startBatch: () => {

--- a/packages/chat/src/transport/thread-events.ts
+++ b/packages/chat/src/transport/thread-events.ts
@@ -28,50 +28,21 @@ export interface ThreadEvent {
   data: ThreadEventData
 }
 
-/** Per-event payload shapes — mirrored from `packages/lib/src/events/types.ts`. */
-export type ThreadEventData =
-  | ThreadTakenOverData
-  | ThreadReturnedToAiData
-  | ThreadArchivedData
-  | ThreadReopenedData
-  | ThreadAssigneeChangedData
-  | ThreadVisitorIdentifiedData
-
-export interface ThreadTakenOverData {
+/**
+ * What a visitor-facing thread event carries — ONE shape for all six types,
+ * because the server projects every one of them through
+ * `shapeThreadEventForVisitor`'s allowlist before it reaches this bundle
+ * (plan 45 §1.5). Both sinks are shaped: the public realtime channel and the
+ * history rows in `initialize` / `threads`.
+ *
+ * The internal payloads in `packages/lib/src/events/types.ts` are richer —
+ * `userId`, `previousState`, `fromUserId` / `toUserId`, `visitorEmail` — and
+ * those fields are deliberately NOT mirrored here. They never arrive, and
+ * `system-line.tsx` keys its copy off `type` alone, so nothing reads them.
+ *
+ * Adding a field to this interface is therefore not enough to receive it: it has
+ * to be classified into `VISITOR_THREAD_EVENT_FIELDS` server-side first.
+ */
+export interface ThreadEventData {
   threadId: string
-  organizationId: string
-  userId: string
-  previousState: 'ai' | 'human'
-}
-
-export interface ThreadReturnedToAiData {
-  threadId: string
-  organizationId: string
-  userId: string
-}
-
-export interface ThreadArchivedData {
-  threadId: string
-  organizationId: string
-  userId: string
-}
-
-export interface ThreadReopenedData {
-  threadId: string
-  organizationId: string
-  userId: string
-}
-
-export interface ThreadAssigneeChangedData {
-  threadId: string
-  organizationId: string
-  fromUserId: string | null
-  toUserId: string | null
-}
-
-export interface ThreadVisitorIdentifiedData {
-  threadId: string
-  organizationId: string
-  visitorEmail: string
-  participantId: string
 }

--- a/packages/lib/src/approval-requests/__tests__/access-requests.test.ts
+++ b/packages/lib/src/approval-requests/__tests__/access-requests.test.ts
@@ -941,6 +941,66 @@ describe('applyAccessDecision (plan 42 §4.2)', () => {
     ).rejects.toThrow(/not supported/i)
     expect(grantInstanceAccess).not.toHaveBeenCalled()
   })
+
+  // Plan 45 §3.2. The client clears the requester's "requested" chip off the
+  // `ACCESS_REQUEST_DECIDED` notification rather than off a second realtime
+  // event, precisely because ONE funnel already covers all three outcomes —
+  // `notifyRequesterDecided` publishes to `rooms.user(requesterId)` via
+  // `NotificationService.sendNotification`. Deny and supersede write no grant and
+  // so publish no `visibility:changed`, which is correct: their ACCESS did not
+  // change, only their REQUEST did.
+  //
+  // This is the assertion that fails if the funnel ever becomes two, which would
+  // silently strand the chip on whichever outcome lost its notification.
+  it.each([
+    ['approve', 'approved'],
+    ['deny', 'denied'],
+  ] as const)('EVERY terminal outcome notifies the REQUESTER (%s) — the single funnel §3.2 depends on', async (action, decision) => {
+    const { applyAccessDecision } = await import('../access-request-mutations')
+    const { db } = makeFakeDb({ threads: [THREAD_ROW] })
+
+    const out = await applyAccessDecision({
+      tx: db,
+      request: ACCESS_ROW as never,
+      approverUserId: 'manager1',
+      action,
+    })
+
+    sendNotification.mockClear()
+    await out.afterCommit?.(db as never)
+
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ACCESS_REQUEST_DECIDED',
+        userId: 'requester1',
+        metadata: expect.objectContaining({ decision }),
+      })
+    )
+  })
+
+  it('SUPERSEDE notifies the requester too — their chip is the stalest of the three', async () => {
+    const { applyAccessDecision } = await import('../access-request-mutations')
+    mailVisibility.requester1 = vis('requester1', { inboxLens: { [INBOX]: 'full' } })
+    const { db } = makeFakeDb({ threads: [THREAD_ROW] })
+
+    const out = await applyAccessDecision({
+      tx: db,
+      request: ACCESS_ROW as never,
+      approverUserId: 'manager1',
+      action: 'approve',
+    })
+
+    sendNotification.mockClear()
+    await out.afterCommit?.(db as never)
+
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ACCESS_REQUEST_DECIDED',
+        userId: 'requester1',
+        metadata: expect.objectContaining({ decision: 'superseded' }),
+      })
+    )
+  })
 })
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/packages/lib/src/cache/mail-visibility-invalidation.test.ts
+++ b/packages/lib/src/cache/mail-visibility-invalidation.test.ts
@@ -39,7 +39,8 @@ vi.mock('./singletons', () => ({
     invalidateAndRecompute: async (_org: string, keys: string[]) => {
       h.orgInvalidations.push(keys)
     },
-    get: async () => [],
+    // `invalidateOrgUsersForKeys` reads the member list through here (block 4).
+    get: async (_org: string, key: string) => (key === 'members' ? [{ userId: 'u_2' }] : []),
     flush: async () => {},
   }),
   getUserCache: () => ({
@@ -193,5 +194,115 @@ describe('§4.5 — compose order: every key is DELETED before any key recompute
     // Interleaving delete-with-recompute (the pre-fix shape) lets this read the
     // 30ms-slow-to-delete capability entry and observe 'Full'.
     expect(mail.sawLevel).toBe('None')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Plan 45 §3.4 — the recompute ORDER, instrumented rather than asserted.
+//
+//    Both orderings produce a correct blob (that is what block 2 above is for),
+//    so no behavioural test can see this. What is observable is a call COUNT:
+//    the dependent key composing its dependency itself, on top of the explicit
+//    recompute of the same key.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A service with both providers registered and their compute calls counted. */
+function makeCountingCache() {
+  const counts = { userCapabilities: 0, userMailVisibility: 0 }
+  const cache = new UserCacheService({} as never)
+  const anyCache = cache as unknown as {
+    register: (k: string, p: { compute: (sid: string) => Promise<unknown> }) => void
+    get: (u: string, k: string, o?: string) => Promise<unknown>
+    invalidateAndRecompute: (u: string, k: readonly string[], o?: string) => Promise<void>
+  }
+
+  anyCache.register('userCapabilities', {
+    compute: async () => {
+      counts.userCapabilities++
+      return { keys: ['Full'] }
+    },
+  })
+  anyCache.register('userMailVisibility', {
+    compute: async (sid: string) => {
+      counts.userMailVisibility++
+      const [userId, orgId] = sid.split(':')
+      // `computeUserMailVisibility` reads the sibling back through the cache.
+      await anyCache.get(userId!, 'userCapabilities', orgId)
+      return { ok: true }
+    },
+  })
+
+  return { anyCache, counts }
+}
+
+describe('§3.4 — capabilities compose ONCE per invalidation, not twice', () => {
+  it('recomputes the dependency before the dependent', async () => {
+    const { anyCache, counts } = makeCountingCache()
+
+    // The six-event shape: both keys in one batch, capability blob deleted, mail
+    // provider reading it back.
+    await anyCache.invalidateAndRecompute(USER, ['userCapabilities', 'userMailVisibility'], ORG)
+
+    // Was 2 before plan 45: the explicit recompute plus the mail provider's own
+    // read-through miss, racing each other. Drop `USER_KEY_RECOMPUTE_TIERS` back
+    // to one concurrent pass and this is the assertion that fails.
+    expect(counts.userCapabilities).toBe(1)
+    expect(counts.userMailVisibility).toBe(1)
+  })
+
+  it('holds when the graph declares the keys MAIL-FIRST — group.members.changed does', async () => {
+    const { anyCache, counts } = makeCountingCache()
+
+    // `invalidation-graph.ts` declares `['userMailVisibility', 'userCapabilities']`
+    // for `group.deleted` and `group.members.changed`. An implementation that
+    // ordered by the array it was handed would compose twice here and pass the
+    // test above — which is why this case exists separately.
+    await anyCache.invalidateAndRecompute(USER, ['userMailVisibility', 'userCapabilities'], ORG)
+
+    expect(counts.userCapabilities).toBe(1)
+    expect(counts.userMailVisibility).toBe(1)
+  })
+
+  it('still recomputes a key with no declared tier', async () => {
+    const { anyCache, counts } = makeCountingCache()
+
+    await anyCache.invalidateAndRecompute(USER, ['userMailVisibility'], ORG)
+
+    // `resource-access.changed`'s shape — mail alone. The capability read is a
+    // warm-blob hit in production; here it is the read-through, and the point is
+    // that the mail key itself was not skipped by the tier walk.
+    expect(counts.userMailVisibility).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Plan 45 §3.6 — the org-wide sweep DELETES and does not recompute.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('§3.6 — invalidateOrgUsersForKeys is delete-only', () => {
+  it('deletes every member’s keys without composing a single blob', async () => {
+    const { anyCache, counts } = makeCountingCache()
+    const sweep = anyCache as unknown as {
+      invalidateOrgUsersForKeys: (o: string, k: readonly string[]) => Promise<void>
+    }
+
+    // Seed one member so there is something to delete, then reset the counters:
+    // what matters is what the SWEEP composes, not the seeding.
+    await anyCache.get('u_2', 'userMailVisibility', ORG)
+    counts.userCapabilities = 0
+    counts.userMailVisibility = 0
+
+    await sweep.invalidateOrgUsersForKeys(ORG, ['userCapabilities', 'userMailVisibility'])
+
+    // THE assertion (plan 45 §1.7). Eagerly recomputing here cost a 200-member org
+    // 200 concurrent composes for an answer that was unchanged for nearly all of
+    // them; the delete is the half that makes the invalidation correct. Reinstate
+    // `invalidateAndRecompute` in the sweep and this fails.
+    expect(counts.userCapabilities).toBe(0)
+    expect(counts.userMailVisibility).toBe(0)
+
+    // And the entries really are gone — the next read composes fresh.
+    await anyCache.get('u_2', 'userMailVisibility', ORG)
+    expect(counts.userMailVisibility).toBe(1)
   })
 })

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -87,6 +87,36 @@ export const ORG_SCOPED_USER_KEYS = new Set<UserCacheKeyName>([
   'userCapabilities',
 ])
 
+/**
+ * Recompute tiers for `invalidateAndRecompute`'s Phase 2 (plan 45 §1.4).
+ *
+ * Keys in an EARLIER tier are recomputed before later ones; anything unlisted
+ * runs last, concurrently. This exists because user providers read each other:
+ * `computeUserMailVisibility` calls `getCachedUserCapabilities`, so recomputing
+ * both concurrently makes the mail provider miss (Phase 1 just deleted the key)
+ * and compose the capability blob a SECOND time, racing the explicit recompute.
+ * Capability composition is the expensive one in this system.
+ *
+ * Three things this deliberately is not:
+ *
+ * - **Not the `INVALIDATION_GRAPH` array order.** `group.deleted` and
+ *   `group.members.changed` declare `['userMailVisibility', 'userCapabilities']`
+ *   — the dependent first — and `invalidateAndRecompute`'s docstring already
+ *   rejected declared order as a mechanism for the older delete-ordering bug.
+ * - **Not a `PromiseMemoizer` on `recompute`.** Memoizing a write-after-write
+ *   barrier lets a later invalidation adopt an earlier one's in-flight promise,
+ *   which may have read the DB before the later mutation committed — caching a
+ *   value that predates its own write for the full TTL. Safe on `get`, unsafe
+ *   here.
+ * - **Not a correctness mechanism.** Phase 1 deletes everything before Phase 2
+ *   recomputes anything, so read-through already guarantees a fresh sibling. This
+ *   is purely about not composing it twice.
+ */
+export const USER_KEY_RECOMPUTE_TIERS: readonly (readonly UserCacheKeyName[])[] = [
+  ['userCapabilities'],
+  ['userMailVisibility'],
+]
+
 const ONE_DAY = 60 * 60 * 24
 
 /** Key configuration for user-scoped cache */

--- a/packages/lib/src/cache/user-cache-service.ts
+++ b/packages/lib/src/cache/user-cache-service.ts
@@ -8,9 +8,16 @@ import { LocalCache } from './local-cache'
 import type { CacheProvider } from './org-cache-provider'
 import { PromiseMemoizer } from './promise-memoizer'
 import type { UserCacheDataMap, UserCacheKeyName } from './user-cache-keys'
-import { ORG_SCOPED_USER_KEYS, USER_CACHE_KEY_CONFIG } from './user-cache-keys'
+import {
+  ORG_SCOPED_USER_KEYS,
+  USER_CACHE_KEY_CONFIG,
+  USER_KEY_RECOMPUTE_TIERS,
+} from './user-cache-keys'
 
 const logger = createScopedLogger('UserCache', { color: 'green' })
+
+/** Members whose keys are deleted concurrently during an org-wide sweep. */
+const ORG_SWEEP_CONCURRENCY = 25
 
 /**
  * User Cache Service — same multi-tier pattern as OrganizationCacheService
@@ -210,9 +217,60 @@ export class UserCacheService {
     keys: readonly UserCacheKeyName[],
     orgId?: string
   ): Promise<void> {
+    // Phase 1 — delete everything in the batch.
+    await this.deleteKeys(userId, keys, orgId)
+
+    // Phase 2 — recompute, in dependency tiers (plan 45 §1.4). Read-through has
+    // already made this correct in any order; the tiers stop the DEPENDENT key
+    // from composing its dependency a second time. `USER_KEY_RECOMPUTE_TIERS`
+    // carries the full reasoning, including why the graph's array order and the
+    // memoizer are both the wrong lever.
+    const remaining = new Set(keys)
+    for (const tier of USER_KEY_RECOMPUTE_TIERS) {
+      const batch = tier.filter((keyName) => remaining.has(keyName))
+      if (batch.length === 0) continue
+      for (const keyName of batch) remaining.delete(keyName)
+      await this.recomputeBatch(userId, batch, orgId)
+    }
+    // Unlisted keys have no declared dependency — one concurrent pass.
+    await this.recomputeBatch(userId, Array.from(remaining), orgId)
+  }
+
+  /** Recompute a set of keys concurrently; a failure warns and never rejects. */
+  private async recomputeBatch(
+    userId: string,
+    keys: readonly UserCacheKeyName[],
+    orgId?: string
+  ): Promise<void> {
+    if (keys.length === 0) return
+    await Promise.all(
+      keys.map(async (keyName) => {
+        if (!this.providers.has(keyName)) return
+        try {
+          await this.recompute(userId, keyName, orgId)
+        } catch (error) {
+          logger.warn(`Recompute failed for ${keyName}:${userId}`, {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      })
+    )
+  }
+
+  /**
+   * Drop a user's keys from local + Redis. No recompute — the next read
+   * composes.
+   *
+   * Extracted so the org-wide sweep can reuse it: the delete half is what makes
+   * an invalidation correct, and the recompute half is only a warm-up.
+   */
+  private async deleteKeys(
+    userId: string,
+    keys: readonly UserCacheKeyName[],
+    orgId?: string
+  ): Promise<void> {
     const redis = await this.getRedis()
 
-    // Phase 1 — delete everything in the batch.
     await Promise.all(
       keys.map(async (keyName) => {
         const sid = this.scopeId(userId, keyName, orgId)
@@ -225,21 +283,6 @@ export class UserCacheService {
           } catch {
             // Ignore
           }
-        }
-      })
-    )
-
-    // Phase 2 — recompute. Any provider that reads a sibling key now read-throughs
-    // to a freshly computed value rather than a surviving stale one.
-    await Promise.all(
-      keys.map(async (keyName) => {
-        if (!this.providers.has(keyName)) return
-        try {
-          await this.recompute(userId, keyName, orgId)
-        } catch (error) {
-          logger.warn(`Recompute failed for ${keyName}:${userId}`, {
-            error: error instanceof Error ? error.message : String(error),
-          })
         }
       })
     )
@@ -318,16 +361,41 @@ export class UserCacheService {
 
   /**
    * Invalidate org-scoped user cache keys for ALL members of an organization.
-   * Fetches the member list from org cache, then invalidates each member's keys.
-   * Call after org-level changes that affect user-scoped data (e.g. shared views, org settings).
+   * Fetches the member list from org cache, then deletes each member's keys.
+   * Call after org-level changes that affect user-scoped data (e.g. shared views,
+   * org settings, an inbox default-lens edit, a system-profile edit).
+   *
+   * **Deletes, does not recompute (plan 45 §1.7), and the two halves are not
+   * equally load-bearing.** The delete is what makes the invalidation correct;
+   * eagerly composing every member's blob was a warm-up that mostly warmed
+   * nothing — in a 200-member org, ~200 concurrent `computeUserMailVisibility`
+   * calls for a set of answers that is unchanged for nearly all of them. This is
+   * the same delete-only + lazy-read-through contract {@link flushKeyForAllUsers}
+   * already documents, and it is strictly SAFER than the eager version: with no
+   * explicit recompute there is nothing that can pin a stale sibling, and the
+   * double-compose of §1.4 cannot arise here at all.
+   *
+   * Ordering upstream survives: `onCacheEvent` awaits this before publishing
+   * `visibility:changed`, so every client refetch composes post-delete.
+   *
+   * The cost that remains moves to read-through for the members who are actually
+   * connected — a subset of the org, deduped per (key, user) by the memoizer —
+   * rather than scaling with member count.
+   *
+   * `flushKeyForAllUsers` is NOT the shortcut here: its prefix SCAN is key-wide,
+   * so it would bust every other org's entries too.
    */
   async invalidateOrgUsersForKeys(orgId: string, keys: readonly UserCacheKeyName[]): Promise<void> {
     const { getOrgCache } = await import('./index')
     const members = await getOrgCache().get(orgId, 'members')
 
-    await Promise.all(
-      members.map((member) => this.invalidateAndRecompute(member.userId, keys, orgId))
-    )
+    // Chunked rather than one unbounded `Promise.all`: an org-wide sweep is 2
+    // Redis DELs per member per key, and a 200-member org should not open 400
+    // round trips at once.
+    for (let i = 0; i < members.length; i += ORG_SWEEP_CONCURRENCY) {
+      const chunk = members.slice(i, i + ORG_SWEEP_CONCURRENCY)
+      await Promise.all(chunk.map((member) => this.deleteKeys(member.userId, keys, orgId)))
+    }
   }
 
   /** Flush org-scoped keys for a user in a specific org */

--- a/packages/lib/src/events/handlers/publish-thread-event-to-realtime.test.ts
+++ b/packages/lib/src/events/handlers/publish-thread-event-to-realtime.test.ts
@@ -1,0 +1,178 @@
+// packages/lib/src/events/handlers/publish-thread-event-to-realtime.test.ts
+// Plan 45 §3.5 — the two unshaped sinks of the thread-lifecycle publish.
+//
+// The negative assertions are the valuable ones. `rooms.visitor(...)` is a PUBLIC
+// Pusher channel, so the visitor payload must carry no internal principal id and
+// no handoff state; `rooms.chatThread(...)` admits a `metadata`-lens member, and
+// its payload deliberately DOES carry `visitorEmail` — the tier decision from
+// §1.5, pinned here so changing it is a deliberate act rather than a refactor.
+//
+// Schema is a Proxy (Drizzle-columns-undefined-under-vitest gotcha — see project
+// memory), which is fine: this handler's DB use is one insert whose return value
+// is all the assertions need.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  publish: vi.fn<(room: string, event: string, payload: any) => Promise<void>>(async () => {}),
+  insertReturning: [{ id: 'evt_1', createdAt: new Date('2026-07-29T10:00:00.000Z') }] as any[],
+  threadMetadataRows: [] as any[],
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: new Proxy(
+    {},
+    {
+      get: (_t, table) => new Proxy({}, { get: (_x, col) => `${String(table)}.${String(col)}` }),
+    }
+  ),
+  database: {
+    insert: () => ({
+      values: () => ({ returning: async () => h.insertReturning }),
+    }),
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => h.threadMetadataRows }) }),
+    }),
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({ eq: (col: any, val: any) => ({ col, val }) }))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() }),
+}))
+
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({ publish: h.publish }),
+  rooms: {
+    chatThread: (id: string) => `thread-${id}`,
+    visitor: (id: string) => `visitor-${id}`,
+  },
+}))
+
+const { publishThreadEventToRealtime } = await import('./publish-thread-event-to-realtime')
+
+const job = (type: string, data: Record<string, unknown>) => ({ data: { type, data } }) as any
+
+/** The payload published to the room whose key starts with `prefix`. */
+const payloadFor = (prefix: string) =>
+  h.publish.mock.calls.find(([room]) => room.startsWith(prefix))?.[2]
+
+beforeEach(() => {
+  h.publish.mockClear()
+  h.threadMetadataRows = []
+})
+
+describe('§3.5 — the public visitor channel', () => {
+  it('carries no internal user id and no handoff state on thread:taken_over', async () => {
+    await publishThreadEventToRealtime(
+      job('thread:taken_over', {
+        threadId: 'thr_1',
+        organizationId: 'org_1',
+        userId: 'usr_agent',
+        previousState: 'ai',
+        visitorParticipantId: 'part_v',
+      })
+    )
+
+    const visitor = payloadFor('visitor-')
+    expect(visitor).toBeDefined()
+    expect(visitor).not.toHaveProperty('userId')
+    expect(visitor).not.toHaveProperty('previousState')
+    expect(visitor).not.toHaveProperty('organizationId')
+    // Exactly the allowlist, so a field added to the event payload later cannot
+    // ride along: this is the assertion that fails if someone spreads `data` back.
+    expect(Object.keys(visitor as object).sort()).toEqual(['createdAt', 'id', 'threadId'])
+  })
+
+  it('carries neither assignee id on thread:assignee:changed', async () => {
+    await publishThreadEventToRealtime(
+      job('thread:assignee:changed', {
+        threadId: 'thr_1',
+        organizationId: 'org_1',
+        fromUserId: 'usr_a',
+        toUserId: 'usr_b',
+        visitorParticipantId: 'part_v',
+      })
+    )
+
+    const visitor = payloadFor('visitor-')
+    expect(visitor).not.toHaveProperty('fromUserId')
+    expect(visitor).not.toHaveProperty('toUserId')
+  })
+
+  it('does not leak the visitor email back over the public channel either', async () => {
+    await publishThreadEventToRealtime(
+      job('thread:visitor:identified', {
+        threadId: 'thr_1',
+        organizationId: 'org_1',
+        visitorEmail: 'someone@example.com',
+        participantId: 'part_v',
+      })
+    )
+
+    const visitor = payloadFor('visitor-')
+    expect(visitor).toBeDefined()
+    expect(visitor).not.toHaveProperty('visitorEmail')
+  })
+
+  it('keeps threadId, id and createdAt — the widget dedupes and scopes on them', async () => {
+    await publishThreadEventToRealtime(
+      job('thread:reopened', {
+        threadId: 'thr_1',
+        organizationId: 'org_1',
+        userId: 'usr_agent',
+        visitorParticipantId: 'part_v',
+      })
+    )
+
+    expect(payloadFor('visitor-')).toEqual({
+      threadId: 'thr_1',
+      id: 'evt_1',
+      createdAt: '2026-07-29T10:00:00.000Z',
+    })
+  })
+
+  it('publishes nothing to a visitor room for an email thread (no visitor participant)', async () => {
+    await publishThreadEventToRealtime(
+      job('thread:archived', { threadId: 'thr_1', organizationId: 'org_1', userId: 'usr_agent' })
+    )
+
+    expect(payloadFor('visitor-')).toBeUndefined()
+    expect(payloadFor('thread-')).toBeDefined()
+  })
+})
+
+describe('§3.5 — the metadata-lens member channel keeps the full payload', () => {
+  // The DELIBERATE positive. `rooms.chatThread` admits `satisfiesLens(lens,
+  // 'metadata')`, and participant email is metadata-visible: `participants` is a
+  // `THREAD_METADATA_FIELDS` entry and hydrates through the ungated
+  // `participant.getByIds` into `ParticipantMeta.identifier`. If that hydration
+  // ever gains a lens gate, THIS is the assertion that must be revisited and the
+  // publish routed through `shapeMailEventForLens`.
+  it('carries visitorEmail on thread:visitor:identified', async () => {
+    await publishThreadEventToRealtime(
+      job('thread:visitor:identified', {
+        threadId: 'thr_1',
+        organizationId: 'org_1',
+        visitorEmail: 'someone@example.com',
+        participantId: 'part_v',
+      })
+    )
+
+    expect(payloadFor('thread-')).toMatchObject({ visitorEmail: 'someone@example.com' })
+  })
+
+  it('carries actor identity and handoff state', async () => {
+    await publishThreadEventToRealtime(
+      job('thread:taken_over', {
+        threadId: 'thr_1',
+        organizationId: 'org_1',
+        userId: 'usr_agent',
+        previousState: 'ai',
+      })
+    )
+
+    expect(payloadFor('thread-')).toMatchObject({ userId: 'usr_agent', previousState: 'ai' })
+  })
+})

--- a/packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts
+++ b/packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts
@@ -14,6 +14,7 @@ import type {
   ThreadTakenOverEvent,
   ThreadVisitorIdentifiedEvent,
 } from '../types'
+import { shapeThreadEventForVisitor } from '../visitor-event-shaping'
 
 const logger = createScopedLogger('publish-thread-event-to-realtime')
 
@@ -88,6 +89,25 @@ export const publishThreadEventToRealtime = async (job: Job<AuxxEvent>) => {
 
   // Per-thread room: the admin conversation panel and the widget's per-thread
   // subscription both listen here. This is the primary delivery path.
+  //
+  // Deliberately NOT routed through `shapeMailEventForLens`, unlike every other
+  // mail publish path. `rooms.chatThread` admits an org member at
+  // `satisfiesLens(lens, 'metadata')`, and all six payloads are within that tier
+  // (plan 45 §1.5 audit, resolved 2026-07-29):
+  //
+  // - `userId` / `fromUserId` / `toUserId` / `previousState` map to `assigneeId`
+  //   and `handoffState`, both in `THREAD_METADATA_FIELDS`.
+  // - `visitorEmail` is the case that needed deciding, and it is metadata-tier:
+  //   `participants` is itself a metadata field, and the ParticipantId[] it
+  //   carries hydrates through `participant.getByIds` — a `mailProcedure` with
+  //   no per-thread lens gate — into a `ParticipantMeta.identifier`, which for
+  //   an EMAIL participant IS the address. A metadata-lens viewer can already
+  //   read it via the `participantId` this same event carries, so withholding
+  //   it here would hide nothing and only make the tiers disagree.
+  //
+  // Pinned by `__tests__/publish-thread-event-to-realtime.test.ts` — if the
+  // participant hydration path ever gains a lens gate, that assertion is the
+  // thing that has to change, and this publish becomes a shaping site.
   try {
     await getRealtimeService().publish(rooms.chatThread(threadId), event.type, payload)
   } catch (error) {
@@ -115,7 +135,14 @@ export const publishThreadEventToRealtime = async (job: Job<AuxxEvent>) => {
         : await resolveVisitorParticipantId(threadId)
   if (visitorParticipantId) {
     try {
-      await getRealtimeService().publish(rooms.visitor(visitorParticipantId), event.type, payload)
+      // Shaped, NOT spread: this room is a public channel (plan 45 §1.5). The
+      // widget keys its system lines off `type` alone, so the allowlist costs it
+      // nothing. `loadThreadEvents` applies the same shaping to the history rows.
+      await getRealtimeService().publish(
+        rooms.visitor(visitorParticipantId),
+        event.type,
+        shapeThreadEventForVisitor(payload)
+      )
     } catch (error) {
       logger.error('Failed to publish thread event to visitor channel', {
         type: event.type,

--- a/packages/lib/src/events/index.ts
+++ b/packages/lib/src/events/index.ts
@@ -1,2 +1,7 @@
 export { publisher } from './publisher'
 export * from './types'
+export {
+  shapeThreadEventForVisitor,
+  VISITOR_THREAD_EVENT_FIELDS,
+  type VisitorFacingThreadEventType,
+} from './visitor-event-shaping'

--- a/packages/lib/src/events/visitor-event-shaping.ts
+++ b/packages/lib/src/events/visitor-event-shaping.ts
@@ -1,0 +1,58 @@
+// packages/lib/src/events/visitor-event-shaping.ts
+
+import type { AuxxEvent } from './types'
+
+/**
+ * The ONLY fields of a thread lifecycle event that may reach a chat visitor
+ * (plan 45 §1.5).
+ *
+ * The visitor sink is a **public** Pusher channel — `rooms.visitor(...)` is
+ * connected by the widget before any session exists, so Pusher never asks the
+ * server to sign it (`realtime/rooms.ts`). Spreading the internal `typed.data`
+ * onto it sent `userId` / `fromUserId` / `toUserId` / `previousState` — internal
+ * principal ids and AI-handoff state — to an unauthenticated client.
+ *
+ * An ALLOWLIST rather than a denylist, for the same reason
+ * `THREAD_METADATA_FIELDS` is one: a field added to an event payload later is
+ * withheld from visitors until someone classifies it, instead of leaking by
+ * default.
+ *
+ * Nothing is lost. The widget renders these as centered system lines keyed on
+ * `type` alone and reads no payload field at all
+ * (`packages/chat/src/views/conversation/system-line.tsx`); `threadId` is kept
+ * because the widget scopes events to the open conversation, and `id` /
+ * `createdAt` because it dedupes the realtime delivery against the history
+ * fetch by `id` and orders by `createdAt`.
+ */
+export const VISITOR_THREAD_EVENT_FIELDS = ['threadId', 'id', 'createdAt'] as const
+
+/**
+ * Project a thread lifecycle event payload down to what a chat visitor may see.
+ *
+ * Applied at BOTH visitor-facing sinks or it is cosmetic: the realtime publish
+ * to `rooms.visitor(...)` and the history rows the widget fetches over HTTP
+ * (`loadThreadEvents` in `apps/api/src/routes/chat/lib.ts`), which read the same
+ * unshaped `Event.data` row back out of the database.
+ *
+ * The persisted `Event.data` row deliberately stays complete — it is the admin
+ * audit record, and `apps/web`'s own history endpoint serves the member sink
+ * from it.
+ */
+export function shapeThreadEventForVisitor(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const field of VISITOR_THREAD_EVENT_FIELDS) {
+    if (data[field] !== undefined) out[field] = data[field]
+  }
+  return out
+}
+
+/** Thread lifecycle event types with a visitor-facing sink. */
+export type VisitorFacingThreadEventType = Extract<
+  AuxxEvent['type'],
+  | 'thread:archived'
+  | 'thread:reopened'
+  | 'thread:taken_over'
+  | 'thread:returned_to_ai'
+  | 'thread:assignee:changed'
+  | 'thread:visitor:identified'
+>

--- a/packages/lib/src/resource-access/grantee-bidirectional-agreement.test.ts
+++ b/packages/lib/src/resource-access/grantee-bidirectional-agreement.test.ts
@@ -1,0 +1,209 @@
+// packages/lib/src/resource-access/grantee-bidirectional-agreement.test.ts
+//
+// Plan 45 §3.3 — the FORWARD grantee union and the REVERSE expansion must reach
+// the same users, per grantee kind.
+//
+// Why this matters for plan 45: item 3 narrows the group/team invalidation from an
+// org-wide broadcast to a targeted set, and narrowing is the fail-OPEN direction.
+// A user the forward resolver matches but the reverse expansion misses keeps a
+// stale `userMailVisibility` for the full ONE_DAY TTL, holding a share they cannot
+// see — the class `mail-grant-index-provider`'s docstring names of itself: "the
+// two must expand the same grantee kinds or a share is visible in one direction
+// only (19a finding 4)."
+//
+// Two things this file deliberately does NOT do:
+//
+//  1. It does not assert on `resourceAccessGranteeConditions`. Those are Drizzle
+//     predicates, and under the default Vitest config `schema` is a Proxy whose
+//     columns are `undefined` — the assertion would pass vacuously. `granteeMatchers`
+//     is the same union as data, which is why it was split out.
+//  2. It is not the safety mechanism for item 3. That is the `default: broadcast`
+//     branch in `resolveInvalidationTargets` (covered in
+//     `resource-access-service.test.ts`), which holds for kinds nobody has thought
+//     of yet. This file covers the kinds that ARE narrowed.
+
+import { ResourceGranteeType } from '@auxx/database/enums'
+import type { OrganizationRole, SeatType, UserType } from '@auxx/database/types'
+import { describe, expect, it, vi } from 'vitest'
+import type { MemberRoleEntry } from '../cache/org-cache-keys'
+import type { CachedPermissionProfile } from '../permissions/profiles/types'
+
+const ORG = 'org_1'
+
+/** A 10-member org: 3 in one group, one worker seat, one admin. */
+const GROUP_MEMBERS: Record<string, string[]> = {
+  u_1: ['grp_support'],
+  u_2: ['grp_support'],
+  u_3: ['grp_support', 'grp_other'],
+  u_4: ['grp_other'],
+}
+const MEMBER_IDS = ['u_1', 'u_2', 'u_3', 'u_4', 'u_5', 'u_6', 'u_7', 'u_8', 'u_9', 'u_10']
+
+function profile(over: Partial<CachedPermissionProfile> = {}): CachedPermissionProfile {
+  return {
+    id: 'prof_member',
+    slug: 'member',
+    name: 'Member',
+    description: null,
+    icon: null,
+    seat: 'full' as SeatType,
+    appliesTo: 'member',
+    role: 'USER' as OrganizationRole,
+    baseLevel: null,
+    ceiling: null,
+    agentPolicy: null,
+    isSystem: true,
+    updatedAt: null,
+    ...over,
+  }
+}
+
+function member(over: Partial<MemberRoleEntry> = {}): MemberRoleEntry {
+  return {
+    role: 'USER' as OrganizationRole,
+    seatType: 'full' as SeatType,
+    userType: 'USER' as UserType,
+    permissionProfileId: null,
+    ...over,
+  }
+}
+
+const PROFILES = [
+  profile({ id: 'prof_member', slug: 'member' }),
+  profile({ id: 'prof_field', slug: 'field_tech', seat: 'worker' as SeatType }),
+  profile({ id: 'prof_admin', slug: 'admin' }),
+]
+
+const ROLE_MAP: Record<string, MemberRoleEntry> = Object.fromEntries(
+  MEMBER_IDS.map((id) => [
+    id,
+    id === 'u_9'
+      ? member({ seatType: 'worker' as SeatType })
+      : id === 'u_10'
+        ? member({ role: 'ADMIN' as OrganizationRole })
+        : member(),
+  ])
+)
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({
+    get: async (_org: string, key: string) => {
+      if (key === 'members') return MEMBER_IDS.map((userId) => ({ userId }))
+      if (key === 'memberRoleMap') return ROLE_MAP
+      if (key === 'profiles') return PROFILES
+      if (key === 'groupMembers') return GROUP_MEMBERS
+      return []
+    },
+  }),
+  getCachedUserGroupIds: async (_org: string, userId: string) => GROUP_MEMBERS[userId] ?? [],
+}))
+
+const {
+  expandGranteeToUserIds,
+  granteeMatchers,
+  resolveResourceAccessGrantees,
+  ORG_MEMBER_GRANTEE_ID,
+} = await import('./grantee-resolution')
+
+/**
+ * FORWARD: which members' own grantee union matches this row. The in-memory
+ * stand-in for `or(...resourceAccessGranteeConditions(...))`.
+ */
+async function forwardReach(
+  row: { granteeType: string; granteeId: string },
+  opts: { treatTeamAsGroup?: boolean } = {}
+): Promise<string[]> {
+  const reached: string[] = []
+  for (const userId of MEMBER_IDS) {
+    const grantees = await resolveResourceAccessGrantees(ORG, userId)
+    const matchers = granteeMatchers(grantees, opts)
+    const matched = matchers.some(
+      (m) =>
+        m.granteeTypes.includes(row.granteeType as never) && m.granteeIds.includes(row.granteeId)
+    )
+    if (matched) reached.push(userId)
+  }
+  return reached.sort()
+}
+
+/** REVERSE: which users the invalidation path expands this row to. */
+async function reverseReach(row: { granteeType: string; granteeId: string }): Promise<string[]> {
+  const { userIds } = await expandGranteeToUserIds(ORG, row)
+  return [...userIds].sort()
+}
+
+describe('§3.3 — forward and reverse agree on every NARROWED grantee kind', () => {
+  it('group: the expansion is the exact inverse of the forward match', async () => {
+    const row = { granteeType: ResourceGranteeType.group, granteeId: 'grp_support' }
+
+    // Both sides read `groupMembers` — the forward side through
+    // `getCachedUserGroupIds` (`groupMembers[userId]`), the reverse through
+    // `resolveGroupHolders` inverting the same map. One projection, two directions.
+    expect(await reverseReach(row)).toEqual(['u_1', 'u_2', 'u_3'])
+    expect(await forwardReach(row)).toEqual(await reverseReach(row))
+  })
+
+  it('team: agrees under the mail evaluator’s treatTeamAsGroup', async () => {
+    const row = { granteeType: ResourceGranteeType.team, granteeId: 'grp_support' }
+
+    // `computeUserMailVisibility` passes `treatTeamAsGroup: true`, and the reverse
+    // expansion mirrors it by routing `team` through `resolveGroupHolders`. Drop
+    // the `team` case from EITHER side and this fails while every behavioural test
+    // still passes — the §3.3 mutation.
+    expect(await forwardReach(row, { treatTeamAsGroup: true })).toEqual(await reverseReach(row))
+    expect(await reverseReach(row)).toEqual(['u_1', 'u_2', 'u_3'])
+  })
+
+  it('team WITHOUT treatTeamAsGroup over-invalidates, which is the safe direction', async () => {
+    const row = { granteeType: ResourceGranteeType.team, granteeId: 'grp_support' }
+
+    // Non-mail readers (`checkAccess`, `getUserAccessibleInstances`) do not treat
+    // team as group, so a team row reaches nobody forward while the reverse still
+    // busts three users. Recorded deliberately: an over-broad bust costs a refetch,
+    // an under-broad one hides a share.
+    expect(await forwardReach(row)).toEqual([])
+    expect(await reverseReach(row)).toEqual(['u_1', 'u_2', 'u_3'])
+  })
+
+  it('user: trivially agrees', async () => {
+    const row = { granteeType: ResourceGranteeType.user, granteeId: 'u_5' }
+    expect(await forwardReach(row)).toEqual(['u_5'])
+    expect(await reverseReach(row)).toEqual(['u_5'])
+  })
+})
+
+describe('§3.3 — the kinds that stay broadcasts still agree, so the door is open later', () => {
+  it('role:org_member reaches every member on both sides', async () => {
+    const row = { granteeType: ResourceGranteeType.role, granteeId: ORG_MEMBER_GRANTEE_ID }
+
+    // Narrowing this one would trade 1 publish for N, which is why
+    // `resolveInvalidationTargets` keeps it a broadcast. The agreement is asserted
+    // anyway: if it ever stops holding, "broadcast" was hiding a real divergence.
+    expect(await forwardReach(row)).toEqual([...MEMBER_IDS].sort())
+    expect(await reverseReach(row)).toEqual([...MEMBER_IDS].sort())
+  })
+
+  it('an unrelated role grantee reaches nobody, rather than being read as a group id', async () => {
+    const row = { granteeType: ResourceGranteeType.role, granteeId: 'ADMIN' }
+    expect(await reverseReach(row)).toEqual([])
+    expect(await forwardReach(row)).toEqual([])
+  })
+
+  it('profile: the reverse holder sweep matches the forward resolved binding', async () => {
+    const row = { granteeType: ResourceGranteeType.profile, granteeId: 'prof_member' }
+
+    // Note this is `resolveProfileHolders`, which shares `resolveBaseProfile` with
+    // the forward resolver — NOT `resolveProfileAudience`, the invalidation sweep
+    // `resolveInvalidationTargets` actually calls for profiles, which may collapse
+    // to a broadcast by design. That collapse is the safe direction.
+    const expected = MEMBER_IDS.filter((id) => id !== 'u_9' && id !== 'u_10').sort()
+    expect(await reverseReach(row)).toEqual(expected)
+    expect(await forwardReach(row)).toEqual(expected)
+  })
+
+  it('an unknown grantee kind reaches nobody and is not reinterpreted as a group', async () => {
+    const row = { granteeType: 'future_kind', granteeId: 'grp_support' }
+    expect(await reverseReach(row)).toEqual([])
+    expect(await forwardReach(row)).toEqual([])
+  })
+})

--- a/packages/lib/src/resource-access/resource-access-service.test.ts
+++ b/packages/lib/src/resource-access/resource-access-service.test.ts
@@ -115,9 +115,12 @@ describe('resource-access cache-event emission', () => {
         permission: ResourcePermission.view,
       }
     )
+    // `userIds`, not `userId`: ONE cache event per audience (plan 45 §1.3). The
+    // targeted branch of `onCacheEvent` re-walks the graph, marks counts stale and
+    // publishes per call, so a per-user loop multiplied all three.
     expect(emit).toHaveBeenCalledWith('resource-access.changed', {
       orgId: ORG,
-      userId: 'u_target',
+      userIds: ['u_target'],
     })
   })
 
@@ -135,6 +138,106 @@ describe('resource-access cache-event emission', () => {
       orgId: ORG,
       broadcastUserKeys: true,
     })
+  })
+
+  // ── Plan 45 §3.3 — narrowing the group/team fan-out ──
+  //
+  // The load-bearing safety here is the `default` branch, not the agreement
+  // between resolvers: narrowing a broadcast is the fail-OPEN direction, so a
+  // grantee kind nobody classified must still bust everyone.
+
+  it('targets a GROUP grant at its members instead of the whole org (§1.3)', async () => {
+    expandGranteeToUserIds.mockResolvedValueOnce({
+      userIds: ['u_g1', 'u_g2', 'u_g3'],
+      capped: false,
+    } as never)
+
+    await grantInstanceAccess(
+      { db: fakeDb(), organizationId: ORG, userId: 'granter' },
+      {
+        recordId: RECORD,
+        granteeType: ResourceGranteeType.group,
+        granteeId: 'grp_support',
+        permission: ResourcePermission.view,
+      }
+    )
+
+    expect(emit).toHaveBeenCalledWith('resource-access.changed', {
+      orgId: ORG,
+      userIds: ['u_g1', 'u_g2', 'u_g3'],
+    })
+    // The whole point: a three-person group used to recompute every member's mail
+    // blob and make every connected client refetch three queries.
+    expect(emit).not.toHaveBeenCalledWith('resource-access.changed', {
+      orgId: ORG,
+      broadcastUserKeys: true,
+    })
+  })
+
+  it('narrows a legacy TEAM grantee too — the mail evaluator treats it as a group', async () => {
+    expandGranteeToUserIds.mockResolvedValueOnce({ userIds: ['u_t1'], capped: false } as never)
+
+    await grantInstanceAccess(
+      { db: fakeDb(), organizationId: ORG, userId: 'granter' },
+      {
+        recordId: RECORD,
+        granteeType: ResourceGranteeType.team,
+        granteeId: 'team_legacy',
+        permission: ResourcePermission.view,
+      }
+    )
+
+    // Drop the `team` case from the switch and this fails while every other test
+    // in the file still passes — the §3.3 mutation, made concrete.
+    expect(emit).toHaveBeenCalledWith('resource-access.changed', {
+      orgId: ORG,
+      userIds: ['u_t1'],
+    })
+  })
+
+  it('an UNCLASSIFIED grantee kind still broadcasts — the fail-safe default', async () => {
+    await grantInstanceAccess(
+      { db: fakeDb(), organizationId: ORG, userId: 'granter' },
+      {
+        recordId: RECORD,
+        // A kind that does not exist yet, standing in for the one added next year
+        // by someone who never reads this file.
+        granteeType: 'future_kind' as ResourceGranteeType,
+        granteeId: 'x_1',
+        permission: ResourcePermission.view,
+      }
+    )
+
+    // THE assertion of item 3. Make the switch exhaustive without a broadcasting
+    // `default` and a share becomes visible in one direction only, for the full
+    // ONE_DAY TTL (19a finding 4).
+    expect(emit).toHaveBeenCalledWith('resource-access.changed', {
+      orgId: ORG,
+      broadcastUserKeys: true,
+    })
+  })
+
+  it('collapses to ONE broadcast when a mixed set contains an unclassified kind', async () => {
+    expandGranteeToUserIds.mockResolvedValueOnce({ userIds: ['u_g1'], capped: false } as never)
+
+    await setInstanceAccess(
+      { db: fakeDb({ deleteReturning: [] }), organizationId: ORG, userId: 'g' },
+      RECORD,
+      ResourceGranteeType.group,
+      [{ granteeId: 'grp_a', permission: ResourcePermission.view }]
+    )
+    emit.mockClear()
+
+    await setInstanceAccess(
+      { db: fakeDb({ deleteReturning: [] }), organizationId: ORG, userId: 'g' },
+      RECORD,
+      'future_kind' as ResourceGranteeType,
+      [{ granteeId: 'x_1', permission: ResourcePermission.view }]
+    )
+
+    const changed = emit.mock.calls.filter((c) => c[0] === 'resource-access.changed')
+    expect(changed).toHaveLength(1)
+    expect(changed[0]?.[1]).toEqual({ orgId: ORG, broadcastUserKeys: true })
   })
 
   it('does not emit when a revoke deletes nothing', async () => {
@@ -175,7 +278,7 @@ describe('resource-access cache-event emission', () => {
     })
     const targeted = emit.mock.calls
       .filter((c) => c[0] === 'resource-access.changed')
-      .map((c) => c[1].userId)
+      .flatMap((c) => c[1].userIds ?? [])
       .sort()
     expect(targeted).toEqual(['u_holder_a', 'u_holder_b'])
     expect(emit).not.toHaveBeenCalledWith('resource-access.changed', {
@@ -299,7 +402,7 @@ describe('resource-access cache-event emission', () => {
     // `emit.mock.calls` sees each grantee twice.
     const targeted = emit.mock.calls
       .filter((c) => c[0] === 'resource-access.changed')
-      .map((c) => c[1].userId)
+      .flatMap((c) => c[1].userIds ?? [])
       .sort()
     expect(targeted).toEqual(['u_added', 'u_removed'])
   })
@@ -324,7 +427,7 @@ describe('resource-access cache-event emission', () => {
     )
     const instanceEvents = emit.mock.calls
       .filter((c) => c[0] === 'resource-access.instance.changed')
-      .map((c) => c[1].userId)
+      .flatMap((c) => c[1].userIds ?? [])
       .sort()
     expect(instanceEvents).toEqual(['u_added', 'u_removed'])
   })

--- a/packages/lib/src/resource-access/resource-access-service.ts
+++ b/packages/lib/src/resource-access/resource-access-service.ts
@@ -360,10 +360,27 @@ async function notifyNewInstanceShare(
  * `emitGrantChanged` uses, deliberately not a second implementation — which
  * resolves explicit holders plus the null-bound majority, and self-collapses to
  * a broadcast when the profile is unclassifiable or the holder set is large.
- * Everything else (role/group/team) still fans out org-wide: correct but
- * expensive, which is why profiles are worth narrowing.
+ * **Group / team** grants expand through `expandGranteeToUserIds` (plan 45 §1.3).
  *
- * Fails SAFE in both directions — the worst outcome is an over-broad bust.
+ * **The `default` is a BROADCAST, and that is the safety mechanism.** Narrowing a
+ * broadcast to a targeted set is the fail-OPEN direction: a user who matches the
+ * forward grantee resolver but is missed here keeps a stale `userMailVisibility`
+ * for the full ONE_DAY TTL, holding a share they cannot see — the class
+ * `mail-grant-index-provider`'s docstring names of itself ("the two must expand
+ * the same grantee kinds or a share is visible in one direction only", 19a
+ * finding 4). So the narrowing is an explicit ALLOWLIST of kinds whose two
+ * directions are known to agree, and a grantee kind added later broadcasts
+ * without anyone having to remember this file.
+ *
+ * Why `group`/`team` are safe to narrow: the forward matcher's group ids come from
+ * `getCachedUserGroupIds`, which is `groupMembers[userId]`, and the reverse
+ * expansion is `resolveGroupHolders` inverting that same cached map. One
+ * projection read two directions — they cannot disagree. `team` is covered because
+ * `expandGranteeToUserIds` sends it through `resolveGroupHolders` too, mirroring
+ * the mail evaluator's `treatTeamAsGroup`.
+ *
+ * `role:org_member` stays a broadcast on purpose: it IS every member, so expanding
+ * it would trade one publish for N.
  */
 async function resolveInvalidationTargets(
   organizationId: string,
@@ -373,22 +390,36 @@ async function resolveInvalidationTargets(
   let broadcast = false
 
   for (const g of grantees) {
-    if (g.granteeType === ResourceGranteeType.user) {
-      userIds.add(g.granteeId)
-      continue
+    switch (g.granteeType) {
+      case ResourceGranteeType.user:
+        userIds.add(g.granteeId)
+        break
+
+      case ResourceGranteeType.profile: {
+        // Lazy import — the profiles module pulls the cache + dehydration barrels,
+        // and the cache invalidation path imports back into this file's neighbours.
+        const { resolveProfileAudience } = await import(
+          '../permissions/profiles/profile-invalidation'
+        )
+        const audience = await resolveProfileAudience({ organizationId, profileId: g.granteeId })
+        if (audience.broadcast) broadcast = true
+        else for (const userId of audience.userIds) userIds.add(userId)
+        break
+      }
+
+      case ResourceGranteeType.group:
+      case ResourceGranteeType.team: {
+        // Cache-only, no query (#1400 dropped the `db` param). A group of three in
+        // a 200-member org used to recompute all 200 blobs and make every
+        // connected client refetch three queries.
+        const { userIds: holders } = await expandGranteeToUserIds(organizationId, g)
+        for (const userId of holders) userIds.add(userId)
+        break
+      }
+
+      default:
+        broadcast = true
     }
-    if (g.granteeType === ResourceGranteeType.profile) {
-      // Lazy import — the profiles module pulls the cache + dehydration barrels,
-      // and the cache invalidation path imports back into this file's neighbours.
-      const { resolveProfileAudience } = await import(
-        '../permissions/profiles/profile-invalidation'
-      )
-      const audience = await resolveProfileAudience({ organizationId, profileId: g.granteeId })
-      if (audience.broadcast) broadcast = true
-      else for (const userId of audience.userIds) userIds.add(userId)
-      continue
-    }
-    broadcast = true
   }
 
   // A single org-wide fan-out already covers every member — no need to also
@@ -404,6 +435,11 @@ async function resolveInvalidationTargets(
  *
  * Phase 0 of the mail-permissions plan wires the emission; Phase 1 attaches
  * the keys (`userMailVisibility`, `mailGrantIndex`) to the invalidation graph.
+ *
+ * ONE `onCacheEvent` for the whole audience, not one per user (plan 45 §1.3): the
+ * targeted branch re-walks the invalidation graph, marks mail counts stale and
+ * publishes per call, so a per-user loop turned a 20-member group share into 20
+ * of each. `userIds` is the field that exists for this.
  */
 async function emitResourceAccessChanged(
   organizationId: string,
@@ -419,11 +455,8 @@ async function emitResourceAccessChanged(
     return
   }
 
-  await Promise.all(
-    userIds.map((userId) =>
-      onCacheEvent('resource-access.changed', { orgId: organizationId, userId })
-    )
-  )
+  if (userIds.length === 0) return
+  await onCacheEvent('resource-access.changed', { orgId: organizationId, userIds })
 }
 
 /**
@@ -458,11 +491,12 @@ async function emitResourceAccessTypeChanged(
     return
   }
 
+  if (userIds.length === 0) return
+  // One cache event for the audience; the capability publish stays per-user
+  // because `publishCapabilitiesChanged` targets one room at a time.
+  await onCacheEvent('resource-access.type.changed', { orgId: organizationId, userIds })
   await Promise.all(
-    userIds.map(async (userId) => {
-      await onCacheEvent('resource-access.type.changed', { orgId: organizationId, userId })
-      await publishCapabilitiesChanged(getRealtimeService(), { userId })
-    })
+    userIds.map((userId) => publishCapabilitiesChanged(getRealtimeService(), { userId }))
   )
 }
 
@@ -499,11 +533,12 @@ export async function emitResourceAccessInstanceChanged(
     return
   }
 
+  if (userIds.length === 0) return
+  // One cache event for the audience (plan 45 §1.3); the capability publish stays
+  // per-user because it targets one room at a time.
+  await onCacheEvent('resource-access.instance.changed', { orgId: organizationId, userIds })
   await Promise.all(
-    userIds.map(async (userId) => {
-      await onCacheEvent('resource-access.instance.changed', { orgId: organizationId, userId })
-      await publishCapabilitiesChanged(getRealtimeService(), { userId })
-    })
+    userIds.map((userId) => publishCapabilitiesChanged(getRealtimeService(), { userId }))
   )
 }
 


### PR DESCRIPTION
Plan 45. Seven findings from reading the `visibility:changed` path end to end, prompted by one question: **when an approver approves a thread access request, what makes the requester's open thread stop showing the redaction banner?** Nothing did — F5 did.

Item 8 (grant upgrade notifies nobody) stays open pending a product call.

## What changed

**1 — the open thread never refreshed on grant.** `handleVisibilityChanged` did three tRPC invalidations, none of which can reach the caches holding the stale answer: thread meta has no query cache (`thread.getByIds` is a mutation, so the Zustand map is the only copy of `myLens` — the value that *is* the banner), and `useMessages` disables itself once a list is cached. The existing `runCatchUp` self-heal never fired either, because it hangs off `useInboxChannels`' `entryKey` (a `slug:lens` join) and a thread grant moves no *inbox* lens.

Adds `forceRequestThread` — bypasses `requestThread`'s five-condition guard, clears `notFoundIds` (a thread that 404'd at `none` and was just granted is the case a `threads.has(id)`-only bypass misses), refuses `deletedIds`, and does **not** evict, since `completeBatch` already replaces in place and evicting blanks the pane mid-read.

**2 — deny and supersede left the "requested" chip stuck.** The preflight query has `refetchOnWindowFocus: false`, so it never self-healed; only a thread switch or reload cleared it. No new server publish: `notifyRequesterDecided` already sends an `ACCESS_REQUEST_DECIDED` notification to the requester's own room on all three outcomes. Access state keeps riding `visibility:changed`, lifecycle state rides the notification — deny genuinely changed no access, so publishing a visibility event there would have been a semantic lie to reach a handler that clears a chip.

**3 — a group grantee broadcast to the whole org.** A three-person group share recomputed every member's mail blob and made every connected client refetch three queries. Routes `group`/`team` through `expandGranteeToUserIds` (already cache-only since #1400) and keeps `broadcast = true` as the `default` branch, so a grantee kind added later fails safe by construction rather than by someone remembering the file. Also batches all three emit functions into one `onCacheEvent` with `userIds` — otherwise the narrowing just trades one N for another.

**4 — `userCapabilities` composed twice per invalidation.** The mail provider read-throughs to a key Phase 1 just deleted, racing the explicit recompute. Fixed with declared recompute tiers — deliberately *not* by memoizing `recompute` (a write-after-write barrier; a later invalidation could adopt an earlier one's pre-commit read) and *not* by the graph's array order (`group.deleted` and `group.members.changed` declare the keys mail-first).

**5 — two publish paths bypassed lens shaping.** The `chatThread` room turns out fine, and that is now written down: participant email is metadata-tier, because `participants` is a `THREAD_METADATA_FIELDS` entry and hydrates through `participant.getByIds`, a `mailProcedure` with no per-thread lens gate. The `visitor` room is **not** fine — it is a public Pusher channel and was receiving `userId`, `fromUserId`/`toUserId` and `previousState`. Both visitor sinks are now shaped through an allowlist: the realtime publish *and* the `loadThreadEvents` history rows the widget re-fetches over HTTP (shaping only the former would have been cosmetic). The persisted `Event` row stays complete as the admin audit record.

**6 — `htmlBodyCache` survived a revoke.** Module-level, not lens-keyed, never evicted. Cleared from the same handler and FIFO-bounded.

**7 — the org-wide sweep eagerly recomputed every member's blob.** Now delete-only with lazy read-through — the mechanism `flushKeyForAllUsers` already documents — and chunked at 25. Strictly safer than the eager version: with no explicit recompute, nothing can pin a stale sibling.

No cache-version bump: no blob shape, key content or value vocabulary changed.

## Tests

6 new files, 3 extended suites. 251 lib tests pass across the four affected directories; 47 web tests pass.

Three mutation checks were run and confirmed to fail in the predicted place:

- Disabling `forceRequestThread` failed **only** the two thread-meta assertions while every invalidation assertion still passed — exactly the trap the test was written against, since the pre-change handler already invalidated three things and still left the banner up.
- Emptying `USER_KEY_RECOMPUTE_TIERS` produced `expected 2 to be 1` on the compose count.
- The visitor-payload assertion pins the allowlist exactly (`Object.keys(...).sort()`), so re-spreading `data` fails it.

The bidirectional-agreement test asserts against `granteeMatchers`, not `resourceAccessGranteeConditions` — the latter builds Drizzle predicates, and under the default Vitest config `schema` columns are `undefined`, so that assertion would pass vacuously.

## Not verified

**No browser pass yet.** The two scenarios worth driving before merge: a requester on a `metadata` thread while an approver approves in a second session (banner clears, bodies appear, no reload), and the same for deny (chip clears). Both are covered by unit tests at the handler seam, but the end-to-end wiring through Pusher is untested.

Pre-existing baselines, unrelated to this change: the full lib suite has 28 failing files (ai/, workflow-engine/, files/, providers/ — zero overlap with anything touched here), and lib/web/api carry known typecheck baselines. Verified my own files are clean by filtering rather than by exit code.