### PR TITLE
feat(homepage): fill blog cards with the post image

### DIFF
--- a/apps/homepage/src/app/blog/_components/post-card.tsx
+++ b/apps/homepage/src/app/blog/_components/post-card.tsx
@@ -5,6 +5,7 @@ import { RandomGradient } from '@auxx/ui/components/random-gradient'
 import { ChevronRight } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { getPostImage } from '~/lib/blog-image'
 import { formatDate } from '~/lib/format-date'
 import type { BlogPost } from '~/types/blog'
 
@@ -26,36 +27,36 @@ function pickPalette(slug: string): GradientPaletteName {
 }
 
 export function PostCard({ post, priority }: { post: BlogPost; priority?: boolean }) {
-  const hasImage = Boolean(post.image) && post.image !== '/blog/default-og.jpg'
+  const image = getPostImage(post)
 
   return (
     <article className='bg-card hover:bg-card/75 group relative flex flex-col space-y-4 rounded-md p-6 duration-200'>
       <div className='before:border-foreground/15 before:inset-ring-1 before:inset-ring-background/10 relative aspect-[3/2] overflow-hidden rounded-[10px] shadow-md shadow-black/10 before:absolute before:inset-0 before:rounded-[10px] before:border'>
-        <RandomGradient
-          colors={[...GRADIENT_PALETTES[pickPalette(post.slug)]]}
-          mode='mesh'
-          animationDuration={4}
-        />
-        {hasImage && (
-          <div className='absolute left-1/2 top-4 w-[65%] -translate-x-1/2 overflow-hidden rounded-md shadow-lg shadow-black/30 ring-1 ring-black/10'>
-            <div className='relative aspect-video w-full'>
-              <Image
-                src={post.image}
-                alt={post.title}
-                fill
-                className='object-cover'
-                sizes='(min-width: 1024px) 20vw, (min-width: 640px) 30vw, 60vw'
-                priority={priority}
-              />
-            </div>
-          </div>
+        {image ? (
+          <Image
+            src={image}
+            alt={post.title}
+            fill
+            className='object-cover'
+            sizes='(min-width: 1024px) 25vw, (min-width: 640px) 45vw, 90vw'
+            priority={priority}
+          />
+        ) : (
+          <RandomGradient
+            colors={[...GRADIENT_PALETTES[pickPalette(post.slug)]]}
+            mode='mesh'
+            animationDuration={4}
+          />
         )}
+        {/* Scrim so the title stays legible over artwork or a pale palette. Both
+            treatments get it, and the title is pinned white, so the tile reads
+            the same in either theme. */}
+        <div
+          aria-hidden
+          className='absolute inset-x-0 bottom-0 h-2/3 bg-linear-to-t from-black/80 via-black/30 to-transparent'
+        />
         <div className='relative z-10 flex h-full items-end p-4'>
-          <h2 className='text-foreground text-balance text-lg font-semibold'>
-            <Link href={`/blog/${post.slug}`} className='before:absolute before:inset-0'>
-              {post.title}
-            </Link>
-          </h2>
+          <h2 className='text-balance text-lg font-semibold text-white'>{post.title}</h2>
         </div>
       </div>
 
@@ -85,8 +86,10 @@ export function PostCard({ post, priority }: { post: BlogPost; priority?: boolea
           ))}
         </div>
         <div className='flex h-6 items-center'>
+          {/* Decorative — the stretched link below is the real target, so this
+              must not announce itself as a second control. */}
           <span
-            aria-label={`Read ${post.title}`}
+            aria-hidden='true'
             className='text-primary group-hover:text-foreground flex items-center gap-1 text-sm font-medium transition-colors duration-200'>
             Read
             <ChevronRight
@@ -97,6 +100,14 @@ export function PostCard({ post, priority }: { post: BlogPost; priority?: boolea
           </span>
         </div>
       </div>
+
+      {/* One stretched target so the whole card — artwork, title, and the "Read"
+          affordance the group-hover styling already telegraphs — navigates. */}
+      <Link
+        href={`/blog/${post.slug}`}
+        className='focus-visible:ring-ring absolute inset-0 z-10 rounded-md focus-visible:outline-none focus-visible:ring-2'>
+        <span className='sr-only'>Read {post.title}</span>
+      </Link>
     </article>
   )
 }

--- a/apps/homepage/src/app/blog/_components/post-header.tsx
+++ b/apps/homepage/src/app/blog/_components/post-header.tsx
@@ -2,10 +2,13 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { getPostImage } from '~/lib/blog-image'
 import { formatDate } from '~/lib/format-date'
 import type { BlogPost } from '~/types/blog'
 
 export function PostHeader({ post }: { post: BlogPost }) {
+  const image = getPostImage(post)
+
   return (
     <div className='relative mx-auto max-w-5xl px-6'>
       <header className='mx-auto mb-8 max-w-2xl text-center'>
@@ -34,10 +37,10 @@ export function PostHeader({ post }: { post: BlogPost }) {
         </h1>
       </header>
 
-      {post.image && post.image !== '/blog/default-og.jpg' && (
+      {image && (
         <div className='relative overflow-hidden rounded-xl border shadow shadow-black/5'>
           <Image
-            src={post.image}
+            src={image}
             alt={post.title}
             width={1200}
             height={675}

--- a/apps/homepage/src/lib/blog-image.ts
+++ b/apps/homepage/src/lib/blog-image.ts
@@ -1,0 +1,19 @@
+// apps/homepage/src/lib/blog-image.ts
+
+import type { BlogPost } from '~/types/blog'
+
+/**
+ * Placeholder assigned to posts whose frontmatter omits `image`. No such file
+ * exists in `public/blog` — it is a sentinel meaning "this post has no artwork",
+ * which the card and header treatments check before rendering an `<Image>`.
+ */
+export const DEFAULT_OG_IMAGE = '/blog/default-og.jpg'
+
+/**
+ * The post's artwork, or `null` when it has none. Kept free of `node:fs` imports
+ * so components can use it without pulling in the content loader.
+ */
+export function getPostImage(post: Pick<BlogPost, 'image'>): string | null {
+  if (!post.image || post.image === DEFAULT_OG_IMAGE) return null
+  return post.image
+}

--- a/apps/homepage/src/lib/blog.ts
+++ b/apps/homepage/src/lib/blog.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import matter from 'gray-matter'
 import readingTime from 'reading-time'
+import { DEFAULT_OG_IMAGE } from '~/lib/blog-image'
 import type { BlogPost, Category } from '~/types/blog'
 
 const CONTENT_DIR = path.join(process.cwd(), 'content', 'blog')
@@ -30,7 +31,7 @@ function parseMdxFile(filePath: string): BlogPost | null {
     description: data.description,
     slug: data.slug,
     date: data.date,
-    image: data.image ?? '/blog/default-og.jpg',
+    image: data.image ?? DEFAULT_OG_IMAGE,
     category: {
       slug: data.category?.slug ?? 'uncategorized',
       title: data.category?.title ?? 'Uncategorized',
@@ -74,7 +75,7 @@ export function getPostBySlug(slug: string): { post: BlogPost; content: string }
           description: data.description,
           slug: data.slug,
           date: data.date,
-          image: data.image ?? '/blog/default-og.jpg',
+          image: data.image ?? DEFAULT_OG_IMAGE,
           category: {
             slug: data.category?.slug ?? 'uncategorized',
             title: data.category?.title ?? 'Uncategorized',


### PR DESCRIPTION
## What

The blog card tile always painted a slug-hashed mesh gradient, and when a post had artwork it was layered on top as a small floating thumbnail (`w-[65%]`, `aspect-video`). Now the image fills the tile, and the gradient is the fallback for posts that have none.

66 of 80 posts have an image; the 14 without are the dev-blog series (agent-engine, connections, data-connectors, self-hosted-realtime, …), which keep the gradient.

Everything funnels through `PostCard`, so `/blog` and `/blog/category/[slug]` both pick this up. The article page (`post-header.tsx`) already rendered the image full-width with no gradient — unchanged apart from the helper.

## Contrast

Both treatments now get a bottom scrim and a white title.

This fixes an existing bug rather than just serving the new layout: the title was `text-foreground`, which flips to white in dark mode, while the palettes don't flip. White-on-pale-`meadow` was close to unreadable. Pinning the title white over a scrim makes the tile a self-contained media surface that reads the same in either theme.

## Also in here

- **`getPostImage` helper.** `/blog/default-og.jpg` is a sentinel for "no artwork" — no such file exists in `public/blog` — and it was string-compared in three places. One helper now, no magic string at the call sites.
- **`sizes` corrected.** Was `20vw`, tuned for the 65%-wide thumbnail. The tile measures 361px on a 1440 viewport = 25vw, so filled images would have rendered soft.
- **Whole card is one stretched link.** The title link's `before:inset-0` resolved against the tile, so only the artwork was clickable and the "Read" row did nothing despite its `group-hover` styling. One overlay link now covers the card; "Read" is `aria-hidden` decoration and the link carries the accessible name, so it stays a single tab stop.

## Note

Against the 3:2 tile, the 16:9 dev-blog diagram PNGs lose ~6% off the top and bottom to `object-cover`. Centered crop is the safer default across a mixed set of photos and diagrams, but the diagrams are the case where the old contained treatment flattered them more. Easy to revisit if it bothers you in practice.

## Testing

Verified in the browser at 1440px in both themes: filled artwork, gradient fallback, and title legibility on both. Click-target probed with `elementFromPoint` across artwork / title / description / footer — all resolve to the post href, one link per card.