### PR TITLE
fix(permissions): close the two fail-closed gaps left by v3/03 P5

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
@@ -143,9 +143,9 @@ async function collectNativeTools(): Promise<AgentToolDefinition[]> {
  * either half without the other.
  */
 const KNOWN_UNENFORCED: readonly string[] = [
-  // 19b G3 — record-adjacent write, deliberately ungated to match the human
-  // comment routers (doc 14 §8.3). The four G3 *reads* were fixed; this is the pair's survivor.
-  'create_note',
+  // 19b G3 is GONE from this list: `create_note` was the pair's last survivor and
+  // it now enforces (`CommentService` asserts `commentsManage` plus parent view,
+  // with thread hosts branching to inbox view + the mail lens — plan 41).
   // 19b G7 — the residue of the coarse org-wide reads. `list_table_views` and
   // `list_tags` are GONE from this list: both found a real rung (the page's def /
   // the `tag` def) and now assert `canViewEntity`. These two did not, and the

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/agent-authoring-instance-access.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/agent-authoring-instance-access.test.ts
@@ -19,7 +19,7 @@
 // of its 63 cases passes even when the per-instance assert is replaced with an
 // unconditional throw — verified before writing this.
 
-import { ResourcePermission } from '@auxx/database/enums'
+import type { Rung } from '@auxx/database/enums'
 import { ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ForbiddenError } from '../../../../../../errors'
@@ -38,7 +38,20 @@ type ToolExecContext = Parameters<AgentToolDefinition['execute']>[1]
 const ORG = 'org-1'
 const AGENT_ID = 'a1'
 
-/** Tool name → the per-agent tier it must require. */
+/**
+ * Tool name → the per-agent tier it must require.
+ *
+ * ⚠ Two vocabularies meet in this file and they are NOT the same axis. A tier is
+ * an `AgentAuthoringTier` label (`view`/`edit`/`admin`) naming which assert runs
+ * — `view` maps to `assertViewInstance`. What goes INTO `CapabilitySet` is a
+ * `Rung` (`none < metadata < identity < read < edit < admin`), where the read
+ * tier is spelled **`read`**, not `view`. This file used to pass
+ * `ResourcePermission.view` as the stored grant; permissions v3 (#1406) renamed
+ * that rung `view`→`read` and left the stub behind, so `rungRank('view')` came
+ * back `undefined`, every ordinal comparison went false, and the `view` case
+ * failed CLOSED. Only that case: `edit`/`admin` are spelled identically in both
+ * vocabularies, which is exactly why the breakage looked so narrow.
+ */
 const TIERS: Record<string, 'view' | 'edit' | 'admin'> = {
   // Reads
   get_eval_case: 'view',
@@ -114,10 +127,7 @@ const agentDeps = { organizationId: ORG, userId: 'member-1', sessionId: 's-1' } 
  * per-instance row. A test that lowered the area level too would pass even if
  * the instance check were deleted.
  */
-function capsWithInstance(
-  permission: ResourcePermission,
-  areaLevel: Level = Level.Full
-): CapabilitySet {
+function capsWithInstance(rung: Rung, areaLevel: Level = Level.Full): CapabilitySet {
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.agents]: areaLevel }) as PermissionKey[]),
     {},
@@ -126,7 +136,7 @@ function capsWithInstance(
     (id) => id,
     new Set(),
     (id) => id,
-    { [AGENT_ID]: permission },
+    { [AGENT_ID]: rung },
     new Set([AGENT_ID])
   )
 }
@@ -147,13 +157,13 @@ async function deniedByGuard(tool: AgentToolDefinition): Promise<boolean> {
 }
 
 beforeEach(() => {
-  capsRef.caps = capsWithInstance(ResourcePermission.admin)
+  capsRef.caps = capsWithInstance('admin')
   getCachedAgentById.mockClear()
 })
 
 describe('agents.builder tools — every tool declares a per-agent tier', () => {
   it('TIERS covers the registry exactly, so a new tool cannot ship without one', async () => {
-    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    capsRef.caps = capsWithInstance('admin')
     const names = (await builderTools()).map((t) => t.name).sort()
     expect(names).toEqual(Object.keys(TIERS).sort())
   })
@@ -161,11 +171,11 @@ describe('agents.builder tools — every tool declares a per-agent tier', () => 
 
 describe('agents.builder tools — an explicit `none` row beats the whole area', () => {
   it('denies EVERY tool for a member holding agents: Full but restricted on this agent', async () => {
-    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    capsRef.caps = capsWithInstance('admin')
     const tools = await builderTools()
     expect(tools.length).toBeGreaterThan(0)
 
-    capsRef.caps = capsWithInstance(ResourcePermission.none)
+    capsRef.caps = capsWithInstance('none')
     for (const tool of tools) {
       expect(await deniedByGuard(tool), tool.name).toBe(true)
     }
@@ -174,12 +184,12 @@ describe('agents.builder tools — an explicit `none` row beats the whole area',
 
 describe('agents.builder tools — each tier admits exactly its own rung and above', () => {
   for (const [grant, granted] of [
-    [ResourcePermission.view, 'view'],
-    [ResourcePermission.edit, 'edit'],
-    [ResourcePermission.admin, 'admin'],
+    ['read', 'view'],
+    ['edit', 'edit'],
+    ['admin', 'admin'],
   ] as const) {
     it(`an instance \`${granted}\` holder reaches the ${granted}-and-below tools and no others`, async () => {
-      capsRef.caps = capsWithInstance(ResourcePermission.admin)
+      capsRef.caps = capsWithInstance('admin')
       const tools = await builderTools()
 
       capsRef.caps = capsWithInstance(grant)
@@ -201,12 +211,12 @@ describe('agents.builder tools — the Kopilot path is no cheaper than the tRPC 
     // `assertAdminInstance` on the router because they make the agent act
     // autonomously on its own credentials, so an instance-`edit` holder must not
     // reach them through chat instead.
-    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    capsRef.caps = capsWithInstance('admin')
     const tools = await builderTools()
     const triggers = tools.find((t) => t.name === 'set_agent_triggers')
     if (!triggers) throw new Error('set_agent_triggers is not registered')
 
-    capsRef.caps = capsWithInstance(ResourcePermission.edit)
+    capsRef.caps = capsWithInstance('edit')
     expect(await deniedByGuard(triggers)).toBe(true)
   })
 
@@ -217,26 +227,26 @@ describe('agents.builder tools — the Kopilot path is no cheaper than the tRPC 
     // `agentsManage` there survives. This is the case that kills it: a member
     // whose AREA level is only Read must still reach the read tools, exactly as
     // `agentToolset.listTools` moved to `agentsView` on the router side.
-    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    capsRef.caps = capsWithInstance('admin')
     const tools = await builderTools()
     const read = tools.find((t) => t.name === 'get_eval_case')
     const write = tools.find((t) => t.name === 'set_agent_prompt')
     if (!read || !write) throw new Error('expected tools are not registered')
 
-    capsRef.caps = capsWithInstance(ResourcePermission.admin, Level.Read)
+    capsRef.caps = capsWithInstance('admin', Level.Read)
     expect(await deniedByGuard(read)).toBe(false)
     // …and the area rung still binds upward: Read is not enough to author.
     expect(await deniedByGuard(write)).toBe(true)
   })
 
   it('lets an instance `view` holder read an eval case but not create one', async () => {
-    capsRef.caps = capsWithInstance(ResourcePermission.admin)
+    capsRef.caps = capsWithInstance('admin')
     const tools = await builderTools()
     const read = tools.find((t) => t.name === 'get_eval_case')
     const write = tools.find((t) => t.name === 'create_eval_case')
     if (!read || !write) throw new Error('eval tools are not registered')
 
-    capsRef.caps = capsWithInstance(ResourcePermission.view)
+    capsRef.caps = capsWithInstance('read')
     expect(await deniedByGuard(read)).toBe(false)
     expect(await deniedByGuard(write)).toBe(true)
   })

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
@@ -1,14 +1,28 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
 //
-// Permissions v2 §3.3 (Phase C1): `bulk_update_entity` bypasses
-// `UnifiedCrudHandler` and writes straight through `FieldValueService`, so it
-// carries its own copy of the handler's `assertEditDistinctDefs` — one
-// `assertEditEntity` per DISTINCT def among the recordIds. Absent capabilities
-// (the un-threaded workflow AI node) must behave byte-for-byte as before.
+// Plan v3/03 §5.3 — `bulk_update_entity` bypasses `UnifiedCrudHandler` and
+// writes straight through `FieldValueService`, so it carries its OWN copy of the
+// write gate. That copy used to be a def-only loop (`assertEditEntity` per
+// DISTINCT def) and is now the same per-ROW gate the handler calls, so these
+// tests assert the gate's four properties end-to-end through the tool:
+//
+//   1. the def gate is the fast path — an all-def-editable batch reads no rows;
+//   2. only def-DENIED ids are stamped, and a row shared at `edit` IS writable;
+//   3. a missing row or a missing stamp DENIES, and the batch fails WHOLE;
+//   4. absent capabilities ⇒ unrestricted, byte-for-byte as before.
+//
+// The stamped read is scripted with a GRANT RANK rather than a canned `_access`
+// string wherever the fold matters, because that is what the picker actually
+// hands `recordAccessAt` (`record-picker-service.ts` — `caps.recordAccessAt(
+// scopeKey, grantRank)`); it is also the only way the agent case below can say
+// anything true, since `AgentPolicyCapabilities` DISCARDS the grant half.
 
+import type { Rung } from '@auxx/database/enums'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const setBulkValuesSpy = vi.fn()
+/** Stands in for `RecordPickerService.getResourcesByIds` — the `_access` read. */
+const stampedRead = vi.fn<(ids: string[]) => Promise<Record<string, { _access?: Rung }>>>()
 
 vi.mock('../../../../../../cache/org-cache-helpers', () => ({
   // `null` ⇒ the tool skips field-key validation and actor resolution, which
@@ -24,61 +38,100 @@ vi.mock('../../../../../../field-values/field-value-service', () => ({
   },
 }))
 
+// The gate lazy-imports the picker for the def-denied remainder only. Mocking it
+// keeps the picker's Drizzle graph out of this suite AND makes the stamped read
+// scriptable — under the default Vitest config `@auxx/database`'s schema columns
+// are `undefined`, so a real picker query could not answer anything here.
+vi.mock('../../../../../../resources/picker/record-picker-service', () => ({
+  RecordPickerService: class {
+    async getResourcesByIds(ids: string[]) {
+      return stampedRead(ids)
+    }
+  },
+}))
+
+import type { PublishedAgentPermissionPolicy } from '@auxx/database'
 import { ForbiddenError } from '../../../../../../errors'
+import { CapabilitySet } from '../../../../../../permissions/capabilities/capability-set'
 import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import { RUNG_ORDER } from '../../../../../../permissions/capabilities/rung'
+import { Area, expandLevelsToKeys, Level } from '../../../../../../permissions/client'
+import { emptyAgentPolicy } from '../../../../../../permissions/profiles/agent-policy'
+import {
+  AgentPolicyCapabilities,
+  buildDefIdToApiSlug,
+  buildDefIdToEntitySlug,
+  type PolicyResourceRef,
+} from '../../../../../../permissions/profiles/agent-policy-capabilities'
 import type { ToolContext } from '../../../../../agent-framework/tool-context'
 import type { AgentToolResult } from '../../../../../agent-framework/types'
 import { createBulkUpdateEntityTool } from '../bulk-update-entity'
 
-/** All-permissive `CapabilityView`; override just the gate under test. */
-function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
-  const yes = () => true
-  const noop = () => {}
-  return {
-    can: yes,
-    has: yes,
-    assert: noop,
-    canWriteEntity: yes,
-    assertWriteEntity: noop,
-    canEditEntity: yes,
-    assertEditEntity: noop,
-    filterEditableDefIds: (ids: string[]) => ids,
-    canViewEntity: yes,
-    assertViewEntity: noop,
-    filterViewableDefIds: (ids: string[]) => ids,
-    viewAccessFor: () => undefined,
-    canAdministerDef: yes,
-    assertAdministerDef: noop,
-    canViewInstance: yes,
-    canEditInstance: yes,
-    canAdminInstance: yes,
-    assertViewInstance: noop,
-    assertEditInstance: noop,
-    assertAdminInstance: noop,
-    ...overrides,
+/** A def the member may edit at the DEF level — the ordinary lane. */
+const OPEN_DEF = 'edf_contact00000000000000000'
+/** A def with no def-level access — reachable only through a per-row grant. */
+const CLOSED_DEF = 'edf_deals0000000000000000000'
+
+const OPEN_A = `${OPEN_DEF}:ins_a00000000000000000000`
+const OPEN_B = `${OPEN_DEF}:ins_b00000000000000000000`
+const CLOSED_A = `${CLOSED_DEF}:ins_c00000000000000000000`
+const CLOSED_B = `${CLOSED_DEF}:ins_d00000000000000000000`
+
+/**
+ * A real `CapabilitySet` for a MEMBER whose Records area is `level`, with an
+ * explicit restricted-def set so `CLOSED_DEF` is shut while `OPEN_DEF` stays
+ * open. The shipped arithmetic, not a stub — the previous version of this file
+ * hand-rolled a `CapabilityView` literal, which went stale the moment the
+ * interface grew `recordAccessAt` / `canEditRecordAt`.
+ */
+function member(level: Level, restrictedDefs: string[] = []): CapabilitySet {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.records]: level })),
+    // `none` is a restriction marker and never seeds `defAccess`, so a closed def
+    // is expressed by membership in `restrictedDefIds` with NO grant entry.
+    {} as Record<string, never>,
+    'USER',
+    'full',
+    (id) => id,
+    new Set(restrictedDefs),
+    (id) => id
+  )
+}
+
+const AGENT_RESOURCES: PolicyResourceRef[] = [
+  { id: 'r-contacts', apiSlug: 'contacts', entityDefinitionId: OPEN_DEF },
+  { id: 'r-deals', apiSlug: 'deals', entityDefinitionId: CLOSED_DEF },
+]
+
+/** A pure AGENT principal: `contacts` at `edit`, `deals` denied outright. */
+function agent(): AgentPolicyCapabilities {
+  const policy: PublishedAgentPermissionPolicy = {
+    ...emptyAgentPolicy(),
+    areas: { default: 'none', overrides: { [Area.records]: 'admin' } },
+    definitions: { default: 'none', overrides: { contacts: 'edit' } },
   }
+  return new AgentPolicyCapabilities(
+    policy,
+    buildDefIdToApiSlug(AGENT_RESOURCES),
+    buildDefIdToEntitySlug(AGENT_RESOURCES)
+  )
 }
 
-/** Records every def id the tool asserted on, in call order. */
-function makeRecordingCapabilities(deniedDefIds: string[] = []) {
-  const asserted: string[] = []
-  const capabilities = makeCapabilities({
-    canEditEntity: (defId: string) => !deniedDefIds.includes(defId),
-    assertEditEntity: (defId: string) => {
-      asserted.push(defId)
-      if (deniedDefIds.includes(defId)) {
-        throw new ForbiddenError("You don't have permission to edit records.")
-      }
-    },
-  })
-  return { capabilities, asserted }
+/** The row a stamped read returns for `recordId` given its aggregated grant rank. */
+function stampedAt(capabilities: CapabilityView, recordId: string, grantRank: number | null) {
+  const defId = recordId.slice(0, recordId.indexOf(':'))
+  return { _access: capabilities.recordAccessAt(defId, grantRank) }
 }
 
-function runTool(recordIds: string[], capabilities?: CapabilityView) {
+function runTool(recordIds: string[], capabilities?: CapabilityView, approvedRecordIds?: string[]) {
   const tool = createBulkUpdateEntityTool(() => ({ db: {}, capabilities }) as never)
   const ctx = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
   return tool.execute(
-    { recordIds, values: [{ fieldId: 'ticket_status', value: 'COMPLETED' }] },
+    {
+      recordIds,
+      ...(approvedRecordIds ? { _approvedRecordIds: approvedRecordIds } : {}),
+      values: [{ fieldId: 'ticket_status', value: 'COMPLETED' }],
+    },
     ctx
   ) as Promise<AgentToolResult>
 }
@@ -86,51 +139,144 @@ function runTool(recordIds: string[], capabilities?: CapabilityView) {
 beforeEach(() => {
   setBulkValuesSpy.mockReset()
   setBulkValuesSpy.mockResolvedValue({ count: 2 })
+  stampedRead.mockReset()
+  stampedRead.mockResolvedValue({})
 })
 
-describe('bulk_update_entity — write enforcement', () => {
-  it('without capabilities, writes as before with no gating', async () => {
-    const result = await runTool(['def_a:i_1', 'def_b:i_2'], undefined)
+describe('absent capabilities ⇒ unrestricted', () => {
+  it('writes as before, gating nothing and reading no rows', async () => {
+    const result = await runTool([OPEN_A, CLOSED_A], undefined)
 
     expect(result.success).toBe(true)
     expect(result.output).toMatchObject({ total: 2, approved: 2, updated: 2 })
     expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
+    expect(stampedRead).not.toHaveBeenCalled()
   })
+})
 
-  it('asserts once per DISTINCT def, not once per record', async () => {
-    const { capabilities, asserted } = makeRecordingCapabilities()
-
-    const result = await runTool(['def_a:i_1', 'def_a:i_2', 'def_b:i_3', 'def_a:i_4'], capabilities)
+describe('the def gate is the fast path', () => {
+  it('an all-def-editable batch writes with ZERO extra I/O', async () => {
+    const result = await runTool([OPEN_A, OPEN_B], member(Level.Edit))
 
     expect(result.success).toBe(true)
-    expect(asserted).toEqual(['def_a', 'def_b'])
+    expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
+    expect(stampedRead).not.toHaveBeenCalled()
+  })
+
+  it('asks the def gate ONCE per DISTINCT def, not once per record', async () => {
+    const capabilities = member(Level.Edit)
+    const canEditEntity = vi.spyOn(capabilities, 'canEditEntity')
+
+    const result = await runTool([OPEN_A, OPEN_B, OPEN_A, OPEN_B], capabilities)
+
+    expect(result.success).toBe(true)
+    expect(canEditEntity).toHaveBeenCalledTimes(1)
+    expect(canEditEntity).toHaveBeenCalledWith(OPEN_DEF)
+  })
+
+  it('gates the APPROVED subset, not the originally requested ids', async () => {
+    // `CLOSED_A` was requested but not approved, so it must never reach the gate
+    // — no def question about it, and no row read for it.
+    const result = await runTool([OPEN_A, CLOSED_A], member(Level.Edit, [CLOSED_DEF]), [OPEN_A])
+
+    expect(result.success).toBe(true)
+    expect(stampedRead).not.toHaveBeenCalled()
+    expect(setBulkValuesSpy).toHaveBeenCalledWith(expect.objectContaining({ recordIds: [OPEN_A] }))
+  })
+})
+
+describe('§5.3 — a row the def gate refuses is judged on its own `_access`', () => {
+  it('a row shared at `edit` IS writable — the case the def loop got wrong', async () => {
+    const capabilities = member(Level.Edit, [CLOSED_DEF])
+    const row = stampedAt(capabilities, CLOSED_A, RUNG_ORDER.edit)
+    expect(row._access).toBe('edit')
+    stampedRead.mockResolvedValue({ [CLOSED_A]: row })
+
+    const result = await runTool([CLOSED_A], capabilities)
+
+    expect(result.success).toBe(true)
+    expect(stampedRead).toHaveBeenCalledWith([CLOSED_A])
     expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('throws ForbiddenError before any write when one def is not editable', async () => {
-    const { capabilities } = makeRecordingCapabilities(['def_b'])
+  it('only the def-DENIED remainder is stamped in a MIXED batch', async () => {
+    const capabilities = member(Level.Edit, [CLOSED_DEF])
+    stampedRead.mockResolvedValue({
+      [CLOSED_B]: stampedAt(capabilities, CLOSED_B, RUNG_ORDER.admin),
+    })
 
-    await expect(runTool(['def_a:i_1', 'def_b:i_2'], capabilities)).rejects.toBeInstanceOf(
+    const result = await runTool([OPEN_A, CLOSED_B], capabilities)
+
+    expect(result.success).toBe(true)
+    // `OPEN_A` passed the def gate, so it was never read back.
+    expect(stampedRead).toHaveBeenCalledWith([CLOSED_B])
+  })
+
+  it('a row shared at `read` is refused and the WHOLE batch fails', async () => {
+    const capabilities = member(Level.Edit, [CLOSED_DEF])
+    stampedRead.mockResolvedValue({
+      [CLOSED_A]: stampedAt(capabilities, CLOSED_A, RUNG_ORDER.edit),
+      [CLOSED_B]: stampedAt(capabilities, CLOSED_B, RUNG_ORDER.read),
+    })
+
+    await expect(runTool([CLOSED_A, CLOSED_B], capabilities)).rejects.toBeInstanceOf(ForbiddenError)
+    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+  })
+
+  it('a row denied by BOTH routes throws before any write', async () => {
+    // No grant at all: the def gate says no and the stamp folds to `none`.
+    const capabilities = member(Level.Edit, [CLOSED_DEF])
+    stampedRead.mockResolvedValue({ [CLOSED_A]: stampedAt(capabilities, CLOSED_A, null) })
+
+    await expect(runTool([OPEN_A, CLOSED_A], capabilities)).rejects.toBeInstanceOf(ForbiddenError)
+    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('§5.2 — non-enumeration: an id the read path hid DENIES', () => {
+  it('a row that does not come back from the stamped read is refused', async () => {
+    // The read path drops unauthorized ids SILENTLY, so "absent" is the strongest
+    // denial signal there is.
+    stampedRead.mockResolvedValue({})
+
+    await expect(runTool([CLOSED_A], member(Level.Full, [CLOSED_DEF]))).rejects.toBeInstanceOf(
       ForbiddenError
     )
     expect(setBulkValuesSpy).not.toHaveBeenCalled()
   })
 
-  it('gates the APPROVED subset, not the originally requested ids', async () => {
-    const { capabilities, asserted } = makeRecordingCapabilities(['def_b'])
+  it('a row that comes back WITHOUT a stamp is refused', async () => {
+    // An unenforced read carries no `_access`; "no stamp" must never read as
+    // "no objection".
+    stampedRead.mockResolvedValue({ [CLOSED_A]: {} })
 
-    // `def_b` was requested but not approved, so it must not be asserted on.
-    const tool = createBulkUpdateEntityTool(() => ({ db: {}, capabilities }) as never)
-    const result = (await tool.execute(
-      {
-        recordIds: ['def_a:i_1', 'def_b:i_2'],
-        _approvedRecordIds: ['def_a:i_1'],
-        values: [{ fieldId: 'ticket_status', value: 'COMPLETED' }],
-      },
-      { organizationId: 'org_1', userId: 'u_1' } as ToolContext
-    )) as AgentToolResult
+    await expect(runTool([CLOSED_A], member(Level.Full, [CLOSED_DEF]))).rejects.toBeInstanceOf(
+      ForbiddenError
+    )
+    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('a pure AGENT principal behaves exactly as it did under the def loop', () => {
+  it('a def the published policy allows writes with no row read', async () => {
+    const result = await runTool([OPEN_A, OPEN_B], agent())
 
     expect(result.success).toBe(true)
-    expect(asserted).toEqual(['def_a'])
+    expect(stampedRead).not.toHaveBeenCalled()
+  })
+
+  it('a def the policy denies is refused even with an `admin`-rank grant row', async () => {
+    // `AgentPolicyCapabilities.recordAccessAt` DISCARDS `grantRank` — an agent's
+    // stamp is its own published def rung — and `hasRecordGrantsOn` is
+    // unconditionally `false`, so no share on the agent's synthetic user can
+    // lift it. The row gate can only ever re-ask the policy question.
+    const capabilities = agent()
+    expect(capabilities.hasRecordGrantsOn(CLOSED_DEF)).toBe(false)
+    const row = stampedAt(capabilities, CLOSED_A, RUNG_ORDER.admin)
+    expect(row._access).toBe('none')
+    stampedRead.mockResolvedValue({ [CLOSED_A]: row })
+
+    await expect(runTool([CLOSED_A], capabilities)).rejects.toBeInstanceOf(ForbiddenError)
+    expect(setBulkValuesSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
@@ -3,6 +3,11 @@
 import { z } from 'zod'
 import { findCachedResource } from '../../../../../cache/org-cache-helpers'
 import { FieldValueService } from '../../../../../field-values/field-value-service'
+// Deep subpath, NOT the `resources` barrel — the barrel reaches the picker →
+// the files service → `@auxx/database`'s `database` export. This module imports
+// only `errors`, the RecordId parser and types; the picker sits behind a lazy
+// `import()` inside it and is only paid for on the def-denied path.
+import { assertRecordRowsEditableWithDb } from '../../../../../resources/crud/record-row-access'
 import { getDefinitionId, type RecordId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArrayArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
@@ -30,7 +35,7 @@ export function createBulkUpdateEntityTool(getDeps: GetToolDeps): AgentToolDefin
       target: 'definition',
       level: 'edit',
       enforcement: 'enforced',
-      note: 'Own per-def assertEditEntity before any DB work (bypasses UnifiedCrudHandler by design).',
+      note: 'Own copy of the per-row edit gate — canEditEntity fast path, then an `_access` stamp read of the def-denied remainder (bypasses UnifiedCrudHandler by design).',
     },
     displayName: 'Bulk update records',
     toolsetSlug: 'auxx:entities:write',
@@ -141,32 +146,40 @@ Example (ids match list_entity_fields output):
         }
       }
 
-      // Write enforcement (permissions v2 §3.3). This tool bypasses
-      // `UnifiedCrudHandler` and writes straight through `FieldValueService`,
-      // so it carries its own copy of the handler's write gate: one
-      // `assertEditEntity` per DISTINCT def among the recordIds, in-memory,
-      // before any DB work. Absent capabilities ⇒ unrestricted, as before.
+      // Write enforcement (plan v3/03 §5.3). This tool bypasses
+      // `UnifiedCrudHandler` and writes straight through `FieldValueService`, so
+      // it carries its own copy of the handler's write gate — and that copy is
+      // now the SAME per-ROW gate the handler calls, not the def-only loop it
+      // used to be (P5 skipped this one site; this is the catch-up).
       //
-      // ⚠ **Still DEF-only — plan v3/03 P5 did NOT convert this one.** The
-      // handler's gate moved to a per-row `_access` judgement
-      // (`assertRecordRowsEditableWithDb`); this copy did not follow. For a pure
-      // AGENT principal that is behaviour-identical, because
-      // `AgentPolicyCapabilities.hasRecordGrantsOn` is unconditionally `false`
-      // and an agent therefore has no per-record grants for a row gate to find.
-      // The gap is a Kopilot run clamped against a HUMAN capability set: a row
-      // that member holds an `edit` share on is refused here. Converting it
-      // needs this file's capability tests rewritten around a stamped read
-      // (they assert `assertEditEntity` call ORDER today), which is why it was
-      // left rather than half-done.
-      if (capabilities) {
-        const seenDefIds = new Set<string>()
-        for (const recordId of recordIds) {
-          const entityDefinitionId = getDefinitionId(recordId as RecordId)
-          if (seenDefIds.has(entityDefinitionId)) continue
-          seenDefIds.add(entityDefinitionId)
-          capabilities.assertEditEntity(entityDefinitionId)
-        }
-      }
+      // The shape is inherited wholesale, so it costs nothing on the ordinary
+      // path: the def gate runs FIRST and short-circuits, memoized per
+      // definition, so a 50-row single-def batch asks `canEditEntity` once and
+      // never reads a row. Only def-DENIED ids are read back with their
+      // `_access` stamp and re-judged against the row-effective `edit` floor. A
+      // missing row or a missing stamp DENIES, and the batch fails WHOLE — a
+      // partial bulk write is not something a user can reason about.
+      //
+      // Absent capabilities ⇒ unrestricted, as before (the gate returns early).
+      //
+      // For a pure AGENT principal this is outcome-identical to the old def
+      // loop, and the reason is `AgentPolicyCapabilities.recordAccessAt`, which
+      // DISCARDS `grantRank` (see its `_grantRank` parameter): an agent's stamp
+      // is always its own published def rung, so a `ResourceAccess` row sitting
+      // on the agent's synthetic user cannot lift it. Note the gate judges via
+      // `canEditRecordAt` and never consults `hasRecordGrantsOn` — that flag
+      // being `false` for agents is true but NOT what closes this hole.
+      //
+      // What changes is the case the old loop got wrong: a run clamped against
+      // a HUMAN capability set may now write a row that member holds an `edit`
+      // share on.
+      await assertRecordRowsEditableWithDb({
+        db,
+        organizationId: agentDeps.organizationId,
+        userId: agentDeps.userId,
+        capabilities,
+        recordIds: recordIds as RecordId[],
+      })
 
       const firstRecordId = recordIds[0] as string
       const resource = await findCachedResource(

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
@@ -171,13 +171,22 @@ export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinit
           limit,
         }
       } else {
-        // Global search — all visible entity types. Layer the per-user def grant
-        // (§3) on top of the org-wide `isVisible` UI flag; they are independent.
+        // Global search — every entity type the principal has PRESENCE on. Layer
+        // the per-user def grant (§3) on top of the org-wide `isVisible` UI flag;
+        // they are independent.
+        //
+        // `hasDefPresence`, not `canViewEntity` (plan v3/03 §6.1): a def reached
+        // only through per-record grants belongs in the search SCOPE, because the
+        // picker's def-list arm partitions the list into viewable / grant-only and
+        // narrows the grant-only half per ROW in SQL. Filtering on `canViewEntity`
+        // here would drop such a def before that partition ever runs, so a record
+        // shared with the principal would be unfindable. This widens the scope,
+        // never the answer.
         const visibleDefIds = allResources
           .filter(
             (r) =>
               r.isVisible !== false &&
-              (!capabilities || capabilities.canViewEntity(r.entityDefinitionId ?? r.id))
+              (!capabilities || capabilities.hasDefPresence(r.entityDefinitionId ?? r.id))
           )
           .map((r) => r.entityDefinitionId ?? r.id)
 

--- a/packages/lib/src/permissions/capabilities/index.ts
+++ b/packages/lib/src/permissions/capabilities/index.ts
@@ -56,6 +56,7 @@ export {
   recordScopeArm,
   recordScopeArmFor,
   recordSearchVisibilitySql,
+  recordUnionVisibilitySql,
   recordVisibilityScope,
   resolveRecordVisibilityScope,
   rungsAtOrAbove,

--- a/packages/lib/src/permissions/capabilities/record-visibility-scope.test.ts
+++ b/packages/lib/src/permissions/capabilities/record-visibility-scope.test.ts
@@ -16,7 +16,13 @@ import {
   deriveThreadRungFromRecordGrant,
   recordThreadDerivationCap,
 } from './record-thread-derivation'
-import { recordScopeArm, recordScopeArmFor, rungsAtOrAbove } from './record-visibility-scope'
+import {
+  recordScopeArm,
+  recordScopeArmFor,
+  recordSearchVisibilitySql,
+  recordUnionVisibilitySql,
+  rungsAtOrAbove,
+} from './record-visibility-scope'
 import { PermissionKey } from './registry'
 import { foldRecordAccess, RUNG_ORDER, rankToRung } from './rung'
 
@@ -100,6 +106,73 @@ describe('rungsAtOrAbove — the threshold constants', () => {
     }
     // ≤ 6 constants, always — the predicate can never grow with the data.
     expect(rungsAtOrAbove('none').length).toBeLessThanOrEqual(6)
+  })
+})
+
+describe('§5.1 — the two multi-def search shapes', () => {
+  // Only the ABSENT/PRESENT decision is asserted, not the built predicate: the
+  // `schema` Proxy makes a rendered Drizzle condition vacuous here (see the file
+  // header). The predicate's effect is covered end-to-end by
+  // `resources/picker/global-union-record-grants.test.ts`.
+  const grantees = { userId: 'user_1', groupIds: [], profileId: null } as never
+  const columns = { instanceIdColumn: 'ei.id', defIdColumn: 'ei.def' }
+
+  it('def-list arm: nothing reachable ⇒ null (the caller must not query)', () => {
+    expect(
+      recordSearchVisibilitySql({
+        organizationId: 'org_1',
+        grantees,
+        fullyViewableDefIds: [],
+        grantOnlyDefIds: [],
+        ...columns,
+      })
+    ).toBeNull()
+  })
+
+  it('def-list arm: every def fully viewable ⇒ undefined (no narrowing, no cost)', () => {
+    expect(
+      recordSearchVisibilitySql({
+        organizationId: 'org_1',
+        grantees,
+        fullyViewableDefIds: [DEF],
+        grantOnlyDefIds: [],
+        ...columns,
+      })
+    ).toBeUndefined()
+  })
+
+  it('def-list arm: a grant-only def in the list ⇒ a predicate', () => {
+    expect(
+      recordSearchVisibilitySql({
+        organizationId: 'org_1',
+        grantees,
+        fullyViewableDefIds: [DEF],
+        grantOnlyDefIds: ['edf_other'],
+        ...columns,
+      })
+    ).toBeDefined()
+  })
+
+  it('union arm: no grant-only def ⇒ undefined — the common member pays NOTHING', () => {
+    expect(
+      recordUnionVisibilitySql({
+        organizationId: 'org_1',
+        grantees,
+        grantOnlyDefIds: [],
+        ...columns,
+      })
+    ).toBeUndefined()
+  })
+
+  it('union arm: a grant-only def ⇒ a predicate (additive, so no viewable list)', () => {
+    expect(
+      recordUnionVisibilitySql({
+        organizationId: 'org_1',
+        grantees,
+        grantOnlyDefIds: [DEF],
+        ...columns,
+      })
+    ).toBeDefined()
   })
 })
 

--- a/packages/lib/src/permissions/capabilities/record-visibility-scope.ts
+++ b/packages/lib/src/permissions/capabilities/record-visibility-scope.ts
@@ -265,6 +265,36 @@ export function recordVisibilityScope(
 }
 
 /**
+ * `EXISTS (… a `read`-or-better grant addressed to this member on the correlated
+ * row …)`, **def-agnostic** — it correlates on org, instance id and the grantee
+ * union, but not on `entityDefinitionId`.
+ *
+ * That is sound for the same reason `instanceListScope` states for its own id
+ * lists: instance ids are globally-unique cuid2s, so a grant row belonging to a
+ * different def can never match another def's instance. Making it def-aware
+ * would need one `EXISTS` per def, i.e. SQL whose size grows with the org's
+ * schema — which is exactly what a multi-def search cannot afford.
+ *
+ * The def-SCOPED twin is {@link grantExistsSql}; both search shapes below share
+ * this one so the two cannot drift.
+ */
+function anyDefGrantExistsSql(input: {
+  organizationId: string
+  grantees: ResourceAccessGrantees
+  instanceIdColumn: SQL | unknown
+}): SQL {
+  const grantee = or(...resourceAccessGranteeConditions(input.grantees))
+  const rungs = rungsAtOrAbove(RECORD_READ_FLOOR)
+  return sql`EXISTS (
+    SELECT 1 FROM "ResourceAccess"
+    WHERE "ResourceAccess"."organizationId" = ${input.organizationId}
+      AND "ResourceAccess"."entityInstanceId" = ${input.instanceIdColumn}
+      AND "ResourceAccess"."rung" IN ${rungs}
+      AND ${grantee}
+  )`
+}
+
+/**
  * The MULTI-DEF form of the scope, for a search that spans several definitions
  * at once (§5.1: *"`search` — all three arms; the def-list arm additionally
  * unions grant-only defs"*).
@@ -275,13 +305,6 @@ export function recordVisibilityScope(
  *   ei."entityDefinitionId" = ANY(<grant-only>) AND EXISTS(<my grant ≥ read on ei.id>)
  * )
  * ```
- *
- * The inner `EXISTS` is **def-agnostic** — it correlates on org, instance id and
- * the grantee union, but not on `entityDefinitionId`. That is sound for the same
- * reason `instanceListScope` states for its own id lists: instance ids are
- * globally-unique cuid2s, so a grant row belonging to a different def can never
- * match another def's instance. Making it def-aware would need one `EXISTS` per
- * def, i.e. SQL whose size grows with the org's schema.
  *
  * Returns `undefined` when every def in scope is fully viewable (nothing to
  * narrow) and `null` when NOTHING is reachable (the caller must return empty
@@ -300,23 +323,66 @@ export function recordSearchVisibilitySql(input: {
   if (input.fullyViewableDefIds.length === 0 && input.grantOnlyDefIds.length === 0) return null
   if (input.grantOnlyDefIds.length === 0) return undefined
 
-  const grantee = or(...resourceAccessGranteeConditions(input.grantees))
-  const rungs = rungsAtOrAbove(RECORD_READ_FLOOR)
   const grantOnly = `{${input.grantOnlyDefIds.join(',')}}`
   const grantOnlyArm = sql`(
     ${input.defIdColumn} = ANY(${grantOnly}::text[])
-    AND EXISTS (
-      SELECT 1 FROM "ResourceAccess"
-      WHERE "ResourceAccess"."organizationId" = ${input.organizationId}
-        AND "ResourceAccess"."entityInstanceId" = ${input.instanceIdColumn}
-        AND "ResourceAccess"."rung" IN ${rungs}
-        AND ${grantee}
-    )
+    AND ${anyDefGrantExistsSql(input)}
   )`
 
   if (input.fullyViewableDefIds.length === 0) return grantOnlyArm
   const viewable = `{${input.fullyViewableDefIds.join(',')}}`
   return sql`(${input.defIdColumn} = ANY(${viewable}::text[]) OR ${grantOnlyArm})`
+}
+
+/**
+ * The **UNSCOPED-UNION** form of the scope, for the global search that takes no
+ * def scope at all (`record.search` with neither `entityDefinitionId` nor
+ * `entityDefinitionIds` — the cross-type union of the system tables and
+ * `EntityInstance`).
+ *
+ * ```
+ *   NOT (ei."entityDefinitionId" = ANY(<grant-only>))   -- unchanged rows
+ * OR EXISTS(<my grant ≥ read on ei.id>)                 -- the newly admitted ones
+ * ```
+ *
+ * ## Why this is the complement of {@link recordSearchVisibilitySql}, not a copy
+ *
+ * The def-list arm knows its whole universe — the caller named every def — so it
+ * can enumerate the fully-viewable half and write `= ANY(<viewable>)`. The union
+ * arm has no such list: it reads EVERY `EntityInstance` row in the org and hands
+ * the result to a `canViewEntity` post-filter. Enumerating "every def I may view"
+ * to feed the positive form would replace that post-filter with a list built from
+ * the org cache, so a def missing from the cache would silently stop appearing —
+ * a fail-closed regression, but a regression.
+ *
+ * So this predicate is **purely additive**: it names only the grant-only defs and
+ * leaves every other row exactly as reachable as it was, for the post-filter to
+ * judge as before. The caller must therefore keep that post-filter and widen it
+ * to `canViewEntity(def) || grantOnlyDefIds.has(def)` — rows of a grant-only def
+ * have already been narrowed here, and `canViewEntity` is `false` for them by
+ * construction.
+ *
+ * `NOT (x = ANY(…))` rather than `x <> ALL(…)`: identical semantics for a
+ * NOT NULL column and a NULL-free array, and it reads as the negation it is.
+ *
+ * Returns `undefined` when the member has no grant-only def — the overwhelmingly
+ * common case, which must cost nothing.
+ */
+export function recordUnionVisibilitySql(input: {
+  organizationId: string
+  grantees: ResourceAccessGrantees
+  grantOnlyDefIds: string[]
+  /** The outer instance-id column, e.g. `sql.raw('ei."id"')`. */
+  instanceIdColumn: SQL | unknown
+  /** The outer def column, e.g. `sql.raw('ei."entityDefinitionId"')`. */
+  defIdColumn: SQL | unknown
+}): SQL | undefined {
+  if (input.grantOnlyDefIds.length === 0) return undefined
+  const grantOnly = `{${input.grantOnlyDefIds.join(',')}}`
+  return sql`(
+    NOT (${input.defIdColumn} = ANY(${grantOnly}::text[]))
+    OR ${anyDefGrantExistsSql(input)}
+  )`
 }
 
 /**

--- a/packages/lib/src/permissions/index.ts
+++ b/packages/lib/src/permissions/index.ts
@@ -51,6 +51,7 @@ export {
   recordScopeArm,
   recordScopeArmFor,
   recordSearchVisibilitySql,
+  recordUnionVisibilitySql,
   recordVisibilityScope,
   resolveRecordVisibilityScope,
   rungsAtOrAbove,

--- a/packages/lib/src/resources/picker/global-union-record-grants.test.ts
+++ b/packages/lib/src/resources/picker/global-union-record-grants.test.ts
@@ -1,0 +1,189 @@
+// packages/lib/src/resources/picker/global-union-record-grants.test.ts
+//
+// Plan v3/03 §5.1, the UNSCOPED arm — `RecordPickerService.search()` called with
+// neither `entityDefinitionId` nor `entityDefinitionIds` (the cross-type union
+// behind the global record search). Closes the "⚠ KNOWN GAP" that arm carried: a
+// def reachable ONLY through per-record grants contributed nothing to it.
+//
+// The predicate is asserted by OBJECT IDENTITY, never by rendered SQL: under this
+// package's Vitest config `@auxx/database`'s `schema` is a Proxy whose columns are
+// `undefined`, so a rendered Drizzle predicate is meaningless
+// (`project_drizzle_columns_undefined_in_vitest`). The fake `db` instead checks
+// whether the exact `SQL` object `recordUnionVisibilitySql` built reached the
+// query, and when it did, answers the way a database that applied it would.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const VIEWABLE_DEF = 'edf000000000000000000001' // seen wholesale
+const GRANTED_DEF = 'edf000000000000000000002' // reachable only via a row grant
+const INVISIBLE_DEF = 'edf000000000000000000003' // neither
+const CONTACT_DEF = 'edf000000000000000000004' // mail keyspace — never the record lane
+
+/** The one row of `GRANTED_DEF` actually shared with the member. */
+const GRANTED_ROW_ID = 'inst_granted'
+
+const getCachedResources = vi.hoisted(() => vi.fn())
+const unionSqlCalls = vi.hoisted(() => [] as unknown[])
+/** The SQL object the real builder returned on the most recent call, if any. */
+const lastUnionSql = vi.hoisted(() => ({ value: undefined as unknown }))
+
+vi.mock('../../cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../cache')>()
+  return { ...actual, getCachedResources }
+})
+
+vi.mock('../../resource-access/grantee-resolution', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../resource-access/grantee-resolution')>()
+  return {
+    ...actual,
+    resolveResourceAccessGrantees: vi.fn(async () => ({
+      userId: 'user_1',
+      groupIds: [],
+      profileId: null,
+    })),
+  }
+})
+
+// Call-THROUGH wrapper: the real predicate is still what the query carries, so
+// these tests fail if the builder stops being reached or stops being embedded.
+vi.mock('../../permissions/capabilities/record-visibility-scope', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../permissions/capabilities/record-visibility-scope')>()
+  return {
+    ...actual,
+    recordUnionVisibilitySql: (input: Parameters<typeof actual.recordUnionVisibilitySql>[0]) => {
+      unionSqlCalls.push(input)
+      lastUnionSql.value = actual.recordUnionVisibilitySql(input)
+      return lastUnionSql.value as never
+    },
+  }
+})
+
+import { RecordPickerService } from './record-picker-service'
+
+/** Every EntityInstance row the org holds, as the fake DB would return them. */
+const ROWS = [
+  { defId: VIEWABLE_DEF, id: 'inst_viewable' },
+  { defId: GRANTED_DEF, id: GRANTED_ROW_ID },
+  { defId: GRANTED_DEF, id: 'inst_sibling' }, // same def, NOT shared
+  { defId: INVISIBLE_DEF, id: 'inst_invisible' },
+  { defId: CONTACT_DEF, id: 'inst_contact' },
+].map((row) => ({
+  id: row.id,
+  entityDefinitionId: row.defId,
+  displayName: `Acme ${row.id}`,
+  secondaryDisplayValue: null,
+  avatarUrl: null,
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+}))
+
+const RESOURCES = [
+  { id: VIEWABLE_DEF, entityDefinitionId: VIEWABLE_DEF, entityType: null },
+  { id: GRANTED_DEF, entityDefinitionId: GRANTED_DEF, entityType: null },
+  { id: INVISIBLE_DEF, entityDefinitionId: INVISIBLE_DEF, entityType: null },
+  { id: CONTACT_DEF, entityDefinitionId: CONTACT_DEF, entityType: 'contact' },
+]
+
+/** Does `outer` embed `needle` anywhere in its chunk tree? (object identity). */
+function embeds(outer: unknown, needle: unknown): boolean {
+  if (needle === undefined) return false
+  if (outer === needle) return true
+  const chunks = (outer as { queryChunks?: unknown[] } | null)?.queryChunks
+  if (!Array.isArray(chunks)) return false
+  return chunks.some((chunk) => embeds(chunk, needle))
+}
+
+/** A `CapabilityView` stub with only the two members the union arm reads. */
+function view(viewable: string[], granted: string[]) {
+  return {
+    canViewEntity: (def: string) => viewable.includes(def),
+    hasRecordGrantsOn: (def: string) => granted.includes(def),
+  } as never
+}
+
+/**
+ * Run the unscoped union search.
+ *
+ * The `db` answers the EntityInstance leg only: when the visibility predicate is
+ * embedded in the query it behaves like Postgres would, and rows of a grant-only
+ * def survive only if they carry a grant. The system-table legs have no `query`
+ * API here, so they throw and are swallowed by the union's per-kind catch — they
+ * are not the subject of these tests.
+ */
+async function searchUnscoped(capabilities: unknown) {
+  const db = {
+    execute: async (query: unknown) => {
+      const narrowed = embeds(query, lastUnionSql.value)
+      const rows = narrowed
+        ? ROWS.filter((row) => row.entityDefinitionId !== GRANTED_DEF || row.id === GRANTED_ROW_ID)
+        : ROWS
+      return { rows }
+    },
+  } as never
+
+  const service = new RecordPickerService('org_1', 'user_1', db, capabilities as never)
+  const result = await service.search({ query: 'Acme', limit: 20 })
+  return { result, recordIds: result.items.map((item) => item.recordId), calls: unionSqlCalls }
+}
+
+describe('§5.1 UNSCOPED arm — grant-only defs reach the global search', () => {
+  beforeEach(() => {
+    unionSqlCalls.length = 0
+    lastUnionSql.value = undefined
+    getCachedResources.mockReset()
+    getCachedResources.mockResolvedValue(RESOURCES)
+  })
+
+  it('a def-viewable member sees every matching row of that def', async () => {
+    const { recordIds } = await searchUnscoped(view([VIEWABLE_DEF], []))
+    expect(recordIds).toContain(`${VIEWABLE_DEF}:inst_viewable`)
+  })
+
+  it('a grant-only member sees the SHARED row and NOT its siblings', async () => {
+    const { recordIds, calls } = await searchUnscoped(view([], [GRANTED_DEF]))
+
+    // The narrowing is a SQL predicate naming exactly the grant-only defs…
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ grantOnlyDefIds: [GRANTED_DEF], organizationId: 'org_1' })
+
+    // …so the shared row surfaces and the sibling on the same def does not.
+    expect(recordIds).toContain(`${GRANTED_DEF}:${GRANTED_ROW_ID}`)
+    expect(recordIds).not.toContain(`${GRANTED_DEF}:inst_sibling`)
+  })
+
+  it('a member with neither the def nor a grant on it sees nothing of it', async () => {
+    const { recordIds } = await searchUnscoped(view([VIEWABLE_DEF], [GRANTED_DEF]))
+    expect(recordIds).not.toContain(`${INVISIBLE_DEF}:inst_invisible`)
+    // …while the two doors they DO hold both open.
+    expect(recordIds).toContain(`${VIEWABLE_DEF}:inst_viewable`)
+    expect(recordIds).toContain(`${GRANTED_DEF}:${GRANTED_ROW_ID}`)
+  })
+
+  it('a member with NOTHING sees nothing at all', async () => {
+    const { recordIds, calls } = await searchUnscoped(view([], []))
+    expect(calls).toHaveLength(0)
+    expect(recordIds).toEqual([])
+  })
+
+  it('contacts stay OUT of the record lane even when a grant names one', async () => {
+    // A `contact` grant canonicalizes into the MAIL keyspace and would fan a full
+    // lens across that contact's whole conversation history (§10.1).
+    const { recordIds, calls } = await searchUnscoped(view([], [CONTACT_DEF, GRANTED_DEF]))
+    expect(calls[0]).toMatchObject({ grantOnlyDefIds: [GRANTED_DEF] })
+    expect(recordIds).not.toContain(`${CONTACT_DEF}:inst_contact`)
+  })
+
+  it('a member holding no per-record grant pays for NO predicate at all', async () => {
+    const { calls, recordIds } = await searchUnscoped(view([VIEWABLE_DEF], []))
+    expect(calls).toHaveLength(0)
+    expect(recordIds).toEqual([`${VIEWABLE_DEF}:inst_viewable`])
+  })
+
+  it('an internal caller (no capabilities) stays unfiltered, as before', async () => {
+    const { recordIds, calls } = await searchUnscoped(undefined)
+    expect(calls).toHaveLength(0)
+    expect(recordIds).toContain(`${INVISIBLE_DEF}:inst_invisible`)
+    expect(recordIds).toContain(`${CONTACT_DEF}:inst_contact`)
+  })
+})

--- a/packages/lib/src/resources/picker/record-picker-service.ts
+++ b/packages/lib/src/resources/picker/record-picker-service.ts
@@ -4,17 +4,25 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { isEntityDefinitionType, type RecordId } from '@auxx/types/resource'
 import { and, asc, desc, eq, ilike, inArray, or, type SQL, sql } from 'drizzle-orm'
-import { getCachedEntityDefId, getCachedResource, getOrgCache } from '../../cache'
+import {
+  getCachedEntityDefId,
+  getCachedResource,
+  getCachedResources,
+  getOrgCache,
+} from '../../cache'
 import { getRecordIdentitiesForRecords } from '../../identity'
 import type { CapabilityView } from '../../permissions/capabilities/capability-view'
+import { isDeclaredInstanceDomain } from '../../permissions/capabilities/instance-access'
 import {
   type RecordVisibilityScope,
   recordAccessRankSql,
   recordScopeArmFor,
   recordSearchVisibilitySql,
+  recordUnionVisibilitySql,
   resolveRecordVisibilityScope,
 } from '../../permissions/capabilities/record-visibility-scope'
 import { resolveResourceAccessGrantees } from '../../resource-access/grantee-resolution'
+import { isMailSharingDef } from '../../resource-access/mail-sharing-defs'
 import {
   type CustomResource,
   isCustomResource,
@@ -953,8 +961,10 @@ export class RecordPickerService {
     //    query, arms 2/3 contribute `scopedVisibility` to the WHERE below.
     //  - Multi-def list → keep every def the member has PRESENCE on (viewable
     //    OR grant-only), then narrow the grant-only half per row.
-    //  - Global union (no scope) → still the `canViewEntity` post-filter. See
-    //    the note at that branch for why grant-only defs are excluded there.
+    //  - Global union (no scope) → enforces itself inside `searchGlobalUnion`:
+    //    the grant-only arm is pushed into the EntityInstance leg in SQL, and the
+    //    system-table legs keep a `canViewEntity` post-filter widened to admit
+    //    grant-only defs. Grant-only defs are NO LONGER excluded there.
     let scopedVisibility: SQL | undefined
     let listVisibility: SQL | undefined
     if (this.capabilities) {
@@ -1004,26 +1014,10 @@ export class RecordPickerService {
     // Unpaginated in v1; each kind contributes up to perKindCap items merge-sorted
     // by updatedAt desc.
     if (!entityDefinitionId && (!entityDefinitionIds || entityDefinitionIds.length === 0)) {
-      const union = await this.searchGlobalUnion(trimmedQuery, limit, startTime)
-      if (!this.capabilities) return union
-      // Post-filter cross-type union rows by per-user def visibility.
-      //
-      // ⚠ KNOWN GAP (plan v3/03 P5): this arm still keys on `canViewEntity`
-      // alone, so a def a member reaches ONLY through per-record grants
-      // contributes nothing to the unscoped global search. That is fail-CLOSED —
-      // a shared record is missing from ⌘K, never wrongly present — and it is a
-      // deliberate scope line: `searchGlobalUnion` merges several system tables
-      // with EntityInstance under a per-kind cap, so a correct grant-only arm
-      // means pushing the predicate into that union's EntityInstance leg and
-      // re-reasoning about the cap's fairness across kinds. Every SCOPED search
-      // (single def and def-list, i.e. every record surface's own search box)
-      // is fully scoped above.
-      return {
-        ...union,
-        items: union.items.filter((item) =>
-          this.capabilities!.canViewEntity(parseRecordId(item.recordId).entityDefinitionId)
-        ),
-      }
+      // The UNSCOPED union — its own visibility lives inside `searchGlobalUnion`
+      // (§5.1's grant-only arm pushed into the EntityInstance leg, plus the
+      // `canViewEntity` post-filter the system-table legs still need).
+      return this.searchGlobalUnion(trimmedQuery, limit, startTime)
     }
 
     // Build entity definition filter
@@ -1326,9 +1320,61 @@ export class RecordPickerService {
   }
 
   /**
+   * The record defs this member reaches **only** through per-record grants —
+   * `hasDefPresence(def) && !canViewEntity(def)`, resolved against the org's def
+   * catalog and therefore bounded by DEF COUNT, never by grant count. No grant-id
+   * set is materialized here or anywhere else; the per-ROW answer stays in SQL.
+   *
+   * The two exclusions are the record-lane test spelled out in
+   * `computeGrantedDefIds`, restated at the site where getting it wrong would be
+   * worst. `hasRecordGrantsOn` already reads a `grantedDefIds` map the composer
+   * built with the same two exclusions applied, so this is belt-and-braces — but
+   * this arm merges the MAIL system tables into its result, and a `contact` grant
+   * canonicalizes into the mail keyspace and fans a full lens across that
+   * contact's entire conversation history (§10.1). `isInstanceAccessKey` alone is
+   * NOT the test: it is blob-lane only, so it answers `false` for `thread`.
+   *
+   * Empty (and free) for the overwhelmingly common member who holds no per-record
+   * grant at all.
+   */
+  private async grantOnlyRecordDefIds(): Promise<string[]> {
+    const capabilities = this.capabilities
+    if (!capabilities) return []
+    const resources = await getCachedResources(this.organizationId)
+    const grantOnly: string[] = []
+    for (const resource of resources) {
+      const defId = resource.entityDefinitionId ?? resource.id
+      const laneKey = resource.entityType ?? defId
+      if (isDeclaredInstanceDomain(laneKey) || isMailSharingDef(laneKey)) continue
+      if (capabilities.canViewEntity(defId)) continue
+      if (!capabilities.hasRecordGrantsOn(defId)) continue
+      grantOnly.push(defId)
+    }
+    return grantOnly
+  }
+
+  /**
    * Global union search across system tables + EntityInstance.
    * Each kind contributes up to perKindCap items (capped at limit overall).
    * Merge-sorted by updatedAt desc. Unpaginated in v1.
+   *
+   * **Read enforcement lives here, not in the caller** (plan v3/03 §5.1, the
+   * UNSCOPED arm). Two halves, because the union has two kinds of leg:
+   *
+   *  - The **EntityInstance** leg is narrowed IN SQL by
+   *    {@link recordUnionVisibilitySql} — rows of a grant-only def survive only
+   *    with a `read`-or-better grant addressed to this member. Applied before the
+   *    per-kind cap, so a grant-only row competes for the bucket on equal terms
+   *    instead of being fetched and then discarded.
+   *  - The **system-table** legs (thread, user, …) are not `EntityInstance` rows
+   *    and carry no record grants, so they keep the `canViewEntity` post-filter
+   *    they have always had.
+   *
+   * The post-filter is widened to `canViewEntity(def) || <grant-only def>` for the
+   * same reason: `canViewEntity` is `false` for a grant-only def by construction,
+   * so leaving it as the sole test would discard exactly the rows the SQL just
+   * authorized. It now runs BEFORE the final slice rather than in the caller after
+   * it, so a page is no longer shortened by rows the member could never see.
    */
   private async searchGlobalUnion(
     trimmedQuery: string,
@@ -1338,6 +1384,19 @@ export class RecordPickerService {
     const tableIds = Object.keys(RESOURCE_TABLE_MAP) as TableId[]
     const kindCount = tableIds.length + 1 // +1 for EntityInstance bucket
     const perKindCap = Math.max(1, Math.ceil(limit / kindCount))
+
+    const grantOnlyDefIds = await this.grantOnlyRecordDefIds()
+    const grantOnlyDefSet = new Set(grantOnlyDefIds)
+    const eiVisibility =
+      grantOnlyDefIds.length > 0
+        ? recordUnionVisibilitySql({
+            organizationId: this.organizationId,
+            grantees: await resolveResourceAccessGrantees(this.organizationId, this.userId ?? ''),
+            grantOnlyDefIds,
+            instanceIdColumn: sql.raw('ei."id"'),
+            defIdColumn: sql.raw('ei."entityDefinitionId"'),
+          })
+        : undefined
 
     // System tables: use their existing direct-fetch path (respects display config).
     const systemPromises = tableIds.map(async (tableId) => {
@@ -1364,7 +1423,11 @@ export class RecordPickerService {
     // ed IDs via the underlying SQL path by stripping the union guard).
     const eiPromise = (async (): Promise<RecordPickerItem[]> => {
       try {
-        const eiResult = await this.searchEntityInstancesOnly(trimmedQuery, perKindCap)
+        const eiResult = await this.searchEntityInstancesOnly(
+          trimmedQuery,
+          perKindCap,
+          eiVisibility
+        )
         return eiResult
       } catch (err) {
         logger.warn('searchGlobalUnion: EntityInstance fetch failed', {
@@ -1385,7 +1448,15 @@ export class RecordPickerService {
       return b.id.localeCompare(a.id)
     })
 
-    const items = merged.slice(0, limit)
+    const capabilities = this.capabilities
+    const visible = capabilities
+      ? merged.filter((item) => {
+          const defId = parseRecordId(item.recordId).entityDefinitionId
+          return capabilities.canViewEntity(defId) || grantOnlyDefSet.has(defId)
+        })
+      : merged
+
+    const items = visible.slice(0, limit)
     const processingTimeMs = performance.now() - startTime
 
     logger.debug('Global union search completed', {
@@ -1410,11 +1481,19 @@ export class RecordPickerService {
    * EntityInstance-only search slice. Mirrors `search()` but unconditionally
    * scopes to EntityInstance, used by `searchGlobalUnion` for the EntityInstance
    * bucket without re-entering the union branch.
+   *
+   * `visibilityFilter` is the union arm's §5.1 predicate, already built against
+   * the `ei` alias by {@link searchGlobalUnion}. Applied to BOTH the empty-query
+   * and the full-text query — a search box that reveals rows when you clear it is
+   * the classic shape of this bug, and `getRecentEntityInstances` carries the
+   * same note for the same reason.
    */
   private async searchEntityInstancesOnly(
     trimmedQuery: string,
-    limit: number
+    limit: number,
+    visibilityFilter?: SQL
   ): Promise<RecordPickerItem[]> {
+    const visibility = visibilityFilter ? sql`AND ${visibilityFilter}` : sql``
     if (!trimmedQuery) {
       const recent = (
         await this.db.execute(sql`
@@ -1429,6 +1508,7 @@ export class RecordPickerService {
           FROM "EntityInstance" ei
           WHERE ei."organizationId" = ${this.organizationId}
             AND ei."archivedAt" IS NULL
+            ${visibility}
           ORDER BY ei."updatedAt" DESC, ei.id DESC
           LIMIT ${limit}
         `)
@@ -1479,6 +1559,7 @@ export class RecordPickerService {
             OR ei."displayName" ILIKE ${`%${trimmedQuery}%`}
             OR ei."secondaryDisplayValue" ILIKE ${`%${trimmedQuery}%`}
           )
+          ${visibility}
         ORDER BY ei."updatedAt" DESC, ei.id DESC
         LIMIT ${limit}
       `)

--- a/packages/lib/src/test/setup.ts
+++ b/packages/lib/src/test/setup.ts
@@ -73,7 +73,19 @@ vi.mock('@auxx/database', () => ({
       },
     },
   },
-  schema: new Proxy({}, { get: () => ({}) }),
+  // MEMOIZED per key, deliberately. An un-memoized `get: () => ({})` hands out a
+  // FRESH object on every access, so `schema.Foo !== schema.Foo` and any test
+  // that identifies a table by reference silently misbehaves: `toContain` never
+  // matches and — worse — the paired `not.toContain` passes vacuously, so the
+  // test looks green while asserting nothing. Stable identity costs nothing
+  // (columns are still `{}`, so column-level refs remain unassertable — see the
+  // Drizzle-under-vitest note) and lets `.from(table)` be compared by reference.
+  schema: new Proxy({} as Record<string, object>, {
+    get: (target, key: string) => {
+      if (!(key in target)) target[key] = {}
+      return target[key]
+    },
+  }),
   IntegrationProviderTypeValues: ['google', 'outlook'],
 }))
 


### PR DESCRIPTION
Closes the last two behavioral leftovers from permissions plan v3/03 P5 (shipped as #1406), plus the test debt that surfaced while closing them.

**Both fixes are fail-CLOSED repairs.** Each wrongly *excluded* rows a member had been granted. Nothing here widens access beyond what per-record sharing already intends, and `canViewEntity` is untouched.

## 1. Kopilot `bulk_update_entity` — def-only write gate

It carried its own copy of the handler's write gate, and P5 moved the handler to a per-row `_access` judgement without following here. A Kopilot run clamped against a **human** capability set therefore refused a row that member holds an `edit` share on.

It now calls the same `assertRecordRowsEditableWithDb` as every other mutation site. The contract is inherited wholesale, so the ordinary path costs nothing: def fast path memoized per definition (a 50-row single-def batch asks once and reads no rows), only def-denied ids stamped and re-judged, missing row or missing stamp denies, batch fails whole.

For a pure agent principal this is outcome-identical — `AgentPolicyCapabilities.recordAccessAt` discards `grantRank`, so an agent's stamp is always its own published def rung and a `ResourceAccess` row on the agent's synthetic user cannot lift it. Note the gate judges via `canEditRecordAt` and never consults `hasRecordGrantsOn`; that flag being `false` for agents is true but is *not* what closes this.

Two deliberate consequences: a def-denied row now costs one picker read before the 403 (denial path only, inherited from the reference gate), and the denial message becomes the gate's own string.

## 2. Unscoped union arm of `record.search` — grant-only defs excluded

The handoff filed this as "⌘K excludes grant-only defs." That was wrong about the surface: the command palette goes through the def-**list** arm, which already partitions `canViewEntity`/`hasRecordGrantsOn` and narrows in SQL. The real hole was the **unscoped union** arm — `record.search` with neither `entityDefinitionId` nor `entityDefinitionIds` — which post-filtered on `canViewEntity` alone. Its consumers are the global reference/mention pickers and SDK callers. The code had self-flagged it with `⚠ KNOWN GAP (plan v3/03 P5)`.

Adds `recordUnionVisibilitySql`, written as a **complement**: `NOT (def = ANY(<grant-only>)) OR EXISTS(<my grant ≥ read>)`. It names only the grant-only defs and leaves every other row exactly as reachable as before. The positive form would require enumerating "every def I may view" from the org cache, where anything missing silently vanishes from search; the complement fails toward the status quo instead. It returns `undefined` when the member holds no grant-only def, so the common path pays nothing.

The predicate goes into the EntityInstance leg **before** the per-kind cap, so a granted row competes for the cap on equal terms. The system-table legs keep a post-filter, widened to `canViewEntity(def) || <grant-only def>` and moved before the final slice — it previously ran in the caller *after* slicing, which could short a page.

Kopilot's `search_entities` global branch had the identical `canViewEntity` predicate and moves to `hasDefPresence`. That widens the scope, never the answer, since the picker still narrows per row in SQL.

No grant-id set is materialized or cached; all row narrowing is a SQL `EXISTS`. Contacts and mail defs stay out of the record lane via `!isDeclaredInstanceDomain && !isMailSharingDef` (the keyspace hazard), pinned by test.

## 3. Test repairs (second commit — review separately)

`src/test/setup.ts` mocked `schema` as `new Proxy({}, { get: () => ({}) })`, handing out a **fresh object per access**. So `schema.Foo !== schema.Foo`, `toContain` never matched, and the paired `not.toContain` passed vacuously — green tests asserting nothing. Now memoized per key.

**This is shared setup for all 507 lib test files**, so the effect was measured rather than assumed: full lib suite **51 failures → 49**. Fixed two, broke none.

Also: `agent-authoring-instance-access` was feeding `ResourcePermission.view` into a `Rung` slot (v3 renamed that rung `view`→`read`, so it failed closed — only the `view` case, since `edit`/`admin` are spelled the same in both vocabularies; production was never affected). And `create_note` was retired from the curated `KNOWN_UNENFORCED` list now that it enforces.

## Testing

- `permissions`, `resource-access`, `cache`, `resources`, `field-values`, `ai/kopilot/capabilities`: **1527 pass / 1 fail** — the fail is the known-stale `system-table-resolver.test.ts` (byte-identical to HEAD, unrelated).
- New: `global-union-record-grants.test.ts` (7 tests, incl. grant-only sees the shared row but not its sibling, and contacts excluded even holding a grant), +5 on `record-visibility-scope`, and the Kopilot gate suite rebuilt around a real `CapabilitySet` (12 tests replacing 4).
- The Kopilot gate rewrite was mutation-checked: restoring the old def-only gate fails exactly the 2 discriminating tests.
- Typecheck: zero errors in any touched file or line region (lib baseline is broken repo-wide, so this was verified by grep, not exit code).

## Known-unrelated

The wider lib suite has 49 pre-existing failures in AI providers, workflow-engine, files, providers, tags and references. The v3 handoff only ever baselined five directories, which is why that was invisible. Not addressed here.