### PR TITLE
fix(mail): restore mail reading after the v3 lens rename (#1406 fallout)

### DIFF
--- a/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
@@ -84,7 +84,7 @@ export function AccessRequestRow({
 
   const requesterName = request.requester?.name ?? 'A teammate'
   const levelLabel = (
-    LENS_LABELS[(request.requestedLens ?? 'full') as keyof typeof LENS_LABELS]?.label ??
+    LENS_LABELS[(request.requestedLens ?? 'read') as keyof typeof LENS_LABELS]?.label ??
     'Full access'
   ).toLowerCase()
   const trimmedComment = comment.trim()

--- a/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
+++ b/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
@@ -72,7 +72,13 @@ export function ThreadSharePopover({ threadId }: { threadId: string }) {
     return myLens !== 'read' ? <RequestAccessPopover threadId={threadId} variant='icon' /> : null
   }
 
-  const floor = inbox?.defaultLens ?? 'read'
+  // `?? 'read'` covers an ABSENT floor; `LENS_LABELS[...]` covers an UNKNOWN one.
+  // Both are needed: the floor is served from the `org:inboxes` cache verbatim, so
+  // a blob written before a vocabulary rename holds a retired value (`full`,
+  // `subject`) that is a string — non-null, so `??` sails past it — with no entry
+  // in `LENS_LABELS`. That threw here. Same defence as `LensSelect`'s `safeValue`.
+  const rawFloor = inbox?.defaultLens ?? 'read'
+  const floor = LENS_LABELS[rawFloor] ? rawFloor : 'read'
 
   const button = (
     <Button variant='ghost' size='icon' className='rounded-full hover:bg-foreground/10'>

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -76,9 +76,9 @@ export const CompactThreadItem = memo(function CompactThreadItem({
 
   // Redacted rendering (mail-permissions): below `full` the row never looks
   // unread (isUnread is full-tier); at `metadata` the subject is absent.
-  const myLens = thread?.myLens ?? 'full'
+  const myLens = thread?.myLens ?? 'read'
   // Not-yet-loaded rows render bold; see the note in `mail-thread-item`.
-  const isUnread = myLens === 'full' && (readStatusUnread ?? true)
+  const isUnread = myLens === 'read' && (readStatusUnread ?? true)
 
   const toggleSelection = useThreadSelectionStore((s) => s.toggleSelection)
   const setActiveThread = useThreadSelectionStore((s) => s.setActiveThread)

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -233,11 +233,11 @@ export const MailThreadItem = memo(function MailThreadItem({
 
   // Redacted rendering (mail-permissions): below `full` the row never looks
   // unread (isUnread is full-tier); at `metadata` the subject is absent.
-  const myLens = thread?.myLens ?? 'full'
+  const myLens = thread?.myLens ?? 'read'
   // A row whose thread hasn't landed yet renders bold — a list-row concern
   // only, which is why the hook now hands back `undefined` instead of baking
   // this default in for the detail pane too (plan 44 §1.3).
-  const isUnread = myLens === 'full' && (readStatusUnread ?? true)
+  const isUnread = myLens === 'read' && (readStatusUnread ?? true)
 
   // --- Selection store actions ---
   const toggleSelection = useThreadSelectionStore((s) => s.toggleSelection)

--- a/apps/web/src/components/mail/thread-details.tsx
+++ b/apps/web/src/components/mail/thread-details.tsx
@@ -190,7 +190,7 @@ export default function ThreadDetails({
 
   // Below `full` lens the viewer may not act — reply/forward affordances are
   // hidden (the server rejects the sends anyway; the UI just doesn't offer).
-  const canReply = (thread?.myLens ?? 'full') === 'full'
+  const canReply = (thread?.myLens ?? 'read') === 'read'
 
   // Keyboard shortcuts: R to reply, F to forward the last message
   useHotkey(

--- a/apps/web/src/components/mail/thread-display.tsx
+++ b/apps/web/src/components/mail/thread-display.tsx
@@ -56,7 +56,7 @@ export function ThreadDisplay({ centered, expectedThreadId }: ThreadDisplayProps
   // the MESSAGE_SHARED deep link, the pane renders from the URL id before the
   // batched meta fetch returns, and firing here earns a rejection toast on
   // open (plan 44 §1.2). This is UX; the server check stays authoritative.
-  const canMarkRead = !!thread && (thread.myLens ?? 'full') === 'full'
+  const canMarkRead = !!thread && (thread.myLens ?? 'read') === 'read'
 
   // Mark thread as read when displayed. Skip in edit mode — the thread isn't
   // rendered, the user is just multi-selecting.

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -176,18 +176,23 @@ export function ThreadMessages() {
 
   if (!thread) return null
 
-  // Redacted rendering (mail-permissions): below `full`, message content is
-  // blanked server-side. `subject` shows envelope rows under a locked-body
+  // Redacted rendering (mail-permissions): below `read`, message content is
+  // blanked server-side. `identity` shows envelope rows under a locked-body
   // notice; `metadata` has no messages at all — the notice is the whole pane.
-  const myLens = thread.myLens ?? 'full'
-  if (myLens !== 'full') {
+  //
+  // ⚠ The tiers here are `Rung` names. Permissions v3 (#1406) renamed
+  // `full`→`read` and `subject`→`identity`; this file predates that PR and was
+  // missed, so it compared a v3 `myLens` ('read') against 'full', took the
+  // redacted branch for EVERY full-access viewer, and blanked the reading pane.
+  const myLens = thread.myLens ?? 'read'
+  if (myLens !== 'read') {
     const notice = (
       <div className='px-4 pt-2'>
         <Alert className='flex items-center gap-2'>
           <Lock className='size-4 shrink-0' />
           <AlertDescription>
             Message content is hidden — you have{' '}
-            {myLens === 'subject' ? 'subject-only' : 'activity-only'} access to this conversation.
+            {myLens === 'identity' ? 'subject-only' : 'activity-only'} access to this conversation.
           </AlertDescription>
           {/* Plan 42 §6.1 mount 1 — the request trigger belongs beside the copy
               that already explains the problem. It renders itself away for anyone

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -687,6 +687,22 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   // `profiles` v3 → v4 above. A v3 blob's retired rungs are dropped by
   // `parsePublishedAgentPolicy`, so the version composes to all-`none`.
   agents: { prefix: 'org:agents:v4', ttlSeconds: ONE_DAY, localTtlMs: 5_000 },
+  // v8: the LENS VOCABULARY changed under this blob (plan v3/03, PR #1406):
+  // `full`→`read` and `subject`→`identity`. `defaultLens` is stored VERBATIM
+  // here, and #1406 bumped the two USER caches (`user:capabilities:v17`,
+  // `user:instance-grants:v1`) while missing this ORG one — so a blob written
+  // before migration 0319 still says `full`, and every reader that keys off it
+  // gets `undefined`. `LENS_LABELS['full']` is `undefined` and the share
+  // popover's inherited-access footer threw
+  // `Cannot read properties of undefined (reading 'label')` on it; the lens
+  // evaluator is worse, because `rungRank('full')` is `undefined` and every
+  // `>=` comparison against it is FALSE, so a stale floor silently reads as no
+  // floor at all. The recompute is already correct (`InboxService.floorFor`
+  // reads the migrated `rung` column) — only the cached copy was wrong, which
+  // is why it presents intermittently: the ONE_DAY TTL heals it within a day of
+  // the org's last inbox write.
+  // ⚠ The v7 note below still says "an absent row meaning `full`" — read that
+  // as `read`. It is left in place as the record of what the old blobs contain.
   // v7: `defaultLens` is DERIVED FROM `ResourceAccess` ROWS (plan 40 §6) — the
   // `role:org_member` baseline row, with an absent row meaning `full` and a
   // `personal_inbox` entry always reporting `none`. The SHAPE is unchanged, which
@@ -709,7 +725,7 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   // poisoned strict lens comparisons). v4: + ownerUserId (§11 personal
   // accounts). v3: + isPersonal. v2: + defaultLens (mail-permissions §2.2).
   // Bump on shape changes.
-  inboxes: { prefix: 'org:inboxes:v7', ttlSeconds: ONE_DAY },
+  inboxes: { prefix: 'org:inboxes:v8', ttlSeconds: ONE_DAY },
   // Reverse thread/contact/inbox grant index for realtime publish fanout
   // (§3.1) + ingest count-delta audiences (§10.1). v2: + inboxes bucket.
   mailGrantIndex: { prefix: 'org:mail-grant-index:v2', ttlSeconds: ONE_DAY },


### PR DESCRIPTION
🔴 **Regression currently on `main`, shipped by #1406 this morning.** Every member sees "Message content is hidden" on every thread, cannot reply, and cannot mark read.

Found while investigating a `Cannot read properties of undefined (reading 'label')` crash in the thread share popover. That crash and this regression are the same root cause — permissions v3's lens rename (`full`→`read`, `subject`→`identity`) was applied incompletely.

## Commit 1 — six unconverted client sites

The rename touched none of these files, so each compares a v3 `myLens` against the retired `'full'`. That is **always false**, so every full-access viewer fell into the sub-`read` branch. The server sends `myLens: 'read'` (`thread-query.service.ts:1000`, typed `'metadata' | 'identity' | 'read'`).

| File | Effect |
|---|---|
| `thread-messages.tsx` | "Message content is hidden" over the whole reading pane; identity-tier viewers also mislabelled "activity-only" |
| `thread-details.tsx` | `canReply` false — **replying disabled** |
| `thread-display.tsx` | `canMarkRead` false — mark-as-read disabled |
| `compact-thread-item.tsx`, `mail-thread-item.tsx` | `isUnread` false — unread state never rendered |
| `access-request-row.tsx` | wrong default label (guarded by `?.label ??`, cosmetic only) |

Not scoped to a def, an inbox, or a share — it hit everyone, everywhere. `myLens === 'metadata'` is untouched; that tier kept its name.

Each candidate was checked rather than bulk-replaced: `seatType ?? 'full'`, `seat ?? 'full'`, kanban `mode === 'full'` and `sortBy === 'subject'` are **different vocabularies** and are correct as they stand.

## Commit 2 — the crash: `org:inboxes` never bumped

`defaultLens` is stored verbatim in that blob. #1406 bumped the two *user* caches and missed this *org* one, so a blob written before migration 0319 still says `full`. The shape is unchanged, which is precisely why the bump is needed — a v7 blob parses fine and serves a value no reader understands. `LENS_LABELS['full']` is `undefined` → the crash.

The lens evaluator degrades worse but more quietly: `rungRank('full')` is `undefined`, so every `>=` against it is false and a stale floor reads as **no floor at all**.

Recompute was already correct (`InboxService.floorFor` reads the migrated `rung` column) — only the cached copy was wrong, which is why it presented intermittently: the `ONE_DAY` TTL heals it a day after the org's last inbox write. Also guards the popover, since `?? 'read'` catches an absent floor but not an unknown one.

## The part worth discussing

**`tsc` caught all six of these and they shipped anyway.** Each is a `TS2367` — *"types 'Lens' and '\"full\"' have no overlap"*. I verified this against a minimal repro rather than assuming, because the `?? 'full'` fallback looked like it might widen the union and suppress the error. It does not; the errors were always there.

They were invisible because `apps/web` carries ~2192 pre-existing type errors, and the standing workflow is *"the exit code is meaningless, grep the output for your own files."* #1406 touched none of these files, so they were nobody's files to grep for.

The broken baseline was the delivery mechanism here, not a nuisance. Same story on the test side: the full `packages/lib` suite sits at 49 failures across AI providers, workflow-engine, files, tags and references, untracked by anyone. Worth prioritising.

## Testing

- `packages/lib` `src/permissions/visibility src/inboxes src/cache` → **283 pass / 0 fail**
- `apps/web` typecheck: zero errors on any changed line (the two remaining in these files are pre-existing `Actor.image` and `ThreadStatus`)
- Biome clean on all 8 files
- ⚠ **Not verified in a browser** — the Playwright profile was locked by another instance. This is verified by code, types and tests only. The cache bump takes effect on next read (new prefix ⇒ miss ⇒ recompute), so a reload is enough; no flush needed.