### PR TITLE
feat(homepage): agents platform page with procedure runs and evals

### DIFF
--- a/apps/homepage/src/app/_components/main/footer-section.tsx
+++ b/apps/homepage/src/app/_components/main/footer-section.tsx
@@ -24,6 +24,10 @@ const links = [
         href: '/platform/sequences',
       },
       {
+        title: 'Agents',
+        href: '/platform/ai/agents',
+      },
+      {
         title: 'Getting started',
         href: urls.signup,
       },

--- a/apps/homepage/src/app/_components/main/header.tsx
+++ b/apps/homepage/src/app/_components/main/header.tsx
@@ -2,6 +2,7 @@
 import {
   BarChart3,
   BookOpen,
+  Bot,
   Bug,
   Cloud,
   Code,
@@ -80,6 +81,12 @@ const platformGroups: PlatformGroup[] = [
         name: 'Kopilot',
         description: 'AI grounded in your data',
         icon: <Sparkles className='stroke-foreground fill-amber-500/15' />,
+      },
+      {
+        href: '/platform/ai/agents',
+        name: 'Agents',
+        description: 'AI workers that follow your playbook',
+        icon: <Bot className='stroke-foreground fill-violet-500/15' />,
       },
       {
         href: '/platform/data-model',

--- a/apps/homepage/src/app/page.tsx
+++ b/apps/homepage/src/app/page.tsx
@@ -10,7 +10,7 @@ import IntegrationSection from './_components/sections/integration-section'
 import KopilotHomeSection from './_components/sections/kopilot-home-section'
 import StatsSection from './_components/sections/stats-section'
 import TestimonialsSection from './_components/sections/testimonials-section'
-import WorkflowAnimationSection from './_components/sections/workflow-animation/workflow-animation-section'
+import AgentRunSection from './platform/ai/agents/_components/agent-run-section'
 import KopilotAgentsCta from './platform/ai/kopilot/_components/kopilot-agents-cta'
 import AccessSection from './platform/crm/_components/access-section'
 import CrmHero from './platform/crm/_components/crm-hero'
@@ -18,7 +18,6 @@ import DataConnectorsSection from './platform/data-model/_components/data-connec
 import DataModelWallHero from './platform/data-model/_components/data-model-wall-hero'
 import IngestionFlowSection from './platform/data-model/_components/ingestion-flow-section'
 import BuildDashboardsSection from './platform/reporting/_components/build-dashboards-section'
-import WorkflowContent from './platform/workflow/_components/workflow-content'
 
 export const metadata: Metadata = {
   alternates: { canonical: '/' },
@@ -69,13 +68,14 @@ export default function MainPage() {
       <SoftwareApplicationJsonLd />
       <Header />
       <HeroSection />
-      <LogoCloudTwo />
-      <WorkflowAnimationSection />
-      <WorkflowContent />
+      {/* <LogoCloudTwo /> */}
+      {/* The h1 promises an agent, so the agent runs before anything else. */}
+      <AgentRunSection bordered />
+      <CrmHero as='h2' />
 
       <DataModelWallHero as='h2' />
       <IngestionFlowSection />
-      <CrmHero as='h2' />
+
       <DataConnectorsSection />
       <KopilotHomeSection />
       {/* <ProblemSolutionSection /> */}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
@@ -1,6 +1,7 @@
 // apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
 
 import {
+  Bot,
   Building2,
   Calendar,
   ChevronDown,
@@ -25,6 +26,7 @@ export type SidebarKey =
   | 'drafts'
   | 'today'
   | 'kopilot'
+  | 'agents'
   | 'workflows'
   | 'datasets'
   | 'kb'
@@ -104,6 +106,7 @@ const SIDEBAR_GROUPS: SidebarGroup[] = [
     items: [
       { key: 'today', label: 'Today', icon: Calendar },
       { key: 'kopilot', label: 'Chats', icon: MessagesSquare },
+      { key: 'agents', label: 'Agents', icon: Bot },
       { key: 'workflows', label: 'Workflows', icon: Workflow },
     ],
   },

--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-cast.ts
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-cast.ts
@@ -1,0 +1,193 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agent-cast.ts
+
+/**
+ * The five agents this page casts, and the one place their identity lives.
+ *
+ * Every section reads from here: the hero list mock, the roster cards, the run
+ * illustration's chips and reply avatars, and the eval suite header. Swapping a
+ * portrait or an accent colour is a single edit in this file.
+ *
+ * Accent classes are written out in full because Tailwind cannot see a class
+ * name assembled at runtime. Never build one by interpolation.
+ */
+
+export type AgentId = 'refund' | 'order-status' | 'invoice-chaser' | 'triage' | 'knowledge'
+
+export interface AgentAccent {
+  /** Ring on the active chip and the reply avatar. */
+  ring: string
+  /** Accent-tinted text, used on trigger chips and the procedure header. */
+  text: string
+  /** Accent-tinted chip background. */
+  chip: string
+  /** 2px left rule on the executing procedure line. */
+  rule: string
+  /** Soft highlight behind the executing procedure line. */
+  highlight: string
+  /** Blurred circle behind a roster portrait, so the cut-out does not float. */
+  wash: string
+}
+
+export interface AgentCastMember {
+  id: AgentId
+  /** Role name. Deliberately not a human first name: these are illustrations. */
+  name: string
+  /** What starts it, in the product's own trigger vocabulary. */
+  trigger: string
+  /** Its procedure, or null for the free-form persona case. */
+  procedure: string | null
+  toolsets: string
+  access: string
+  /** `Agent.description` — the card's clamped body line. */
+  description: string
+  /** Model pill on the card footer. */
+  model: string
+  /** `LastUpdated` subtitle on the card. */
+  updated: string
+  /** `chat` agents get the Chat badge and sit in the Chat agents section. */
+  kind: 'chat' | 'internal'
+  src: string
+  alt: string
+  /**
+   * `object-position` for the circular crop. The sources are 666x1024 waist-up
+   * portraits and the heads do not sit at identical heights, so each one gets
+   * its own value rather than sharing a single guess.
+   */
+  headOffset: string
+  accent: AgentAccent
+}
+
+const PURPLE: AgentAccent = {
+  ring: 'ring-purple-500/50',
+  text: 'text-purple-600 dark:text-purple-400',
+  chip: 'bg-purple-500/10 text-purple-700 dark:text-purple-300',
+  rule: 'bg-purple-500',
+  highlight: 'bg-purple-500/[0.06]',
+  wash: 'bg-purple-500/20 dark:bg-purple-500/10',
+}
+
+const BLUE: AgentAccent = {
+  ring: 'ring-blue-500/50',
+  text: 'text-blue-600 dark:text-blue-400',
+  chip: 'bg-blue-500/10 text-blue-700 dark:text-blue-300',
+  rule: 'bg-blue-500',
+  highlight: 'bg-blue-500/[0.06]',
+  wash: 'bg-blue-500/20 dark:bg-blue-500/10',
+}
+
+const ORANGE: AgentAccent = {
+  ring: 'ring-orange-500/50',
+  text: 'text-orange-600 dark:text-orange-400',
+  chip: 'bg-orange-500/10 text-orange-700 dark:text-orange-300',
+  rule: 'bg-orange-500',
+  highlight: 'bg-orange-500/[0.06]',
+  wash: 'bg-orange-500/20 dark:bg-orange-500/10',
+}
+
+const GREEN: AgentAccent = {
+  ring: 'ring-emerald-500/50',
+  text: 'text-emerald-600 dark:text-emerald-400',
+  chip: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  rule: 'bg-emerald-500',
+  highlight: 'bg-emerald-500/[0.06]',
+  wash: 'bg-emerald-500/20 dark:bg-emerald-500/10',
+}
+
+const PINK: AgentAccent = {
+  ring: 'ring-pink-500/50',
+  text: 'text-pink-600 dark:text-pink-400',
+  chip: 'bg-pink-500/10 text-pink-700 dark:text-pink-300',
+  rule: 'bg-pink-500',
+  highlight: 'bg-pink-500/[0.06]',
+  wash: 'bg-pink-500/20 dark:bg-pink-500/10',
+}
+
+export const AGENT_CAST: AgentCastMember[] = [
+  {
+    id: 'refund',
+    name: 'Refund handler',
+    trigger: 'Customer message',
+    procedure: 'Refund requests',
+    toolsets: '4 toolsets · 11 tools',
+    access: 'Support profile · Edit on Tickets',
+    description: 'Handles return and refund requests end to end, inside the policy window.',
+    model: 'claude-sonnet-5',
+    updated: '2 hours ago',
+    kind: 'chat',
+    src: '/images/ai-headshots/agent-purple-female-1.png',
+    alt: 'Refund handler agent',
+    headOffset: '50% 6%',
+    accent: PURPLE,
+  },
+  {
+    id: 'order-status',
+    name: 'Order status',
+    trigger: 'Customer message',
+    procedure: "Where's my order",
+    toolsets: '3 toolsets · 7 tools',
+    access: 'Support profile · Read on Orders',
+    description: 'Answers where-is-my-order questions and escalates anything late or damaged.',
+    model: 'claude-sonnet-5',
+    updated: '5 hours ago',
+    kind: 'chat',
+    src: '/images/ai-headshots/agent-blue-female.png',
+    alt: 'Order status agent',
+    headOffset: '50% 7%',
+    accent: BLUE,
+  },
+  {
+    id: 'invoice-chaser',
+    name: 'Invoice chaser',
+    trigger: 'Schedule · 08:00 daily',
+    procedure: 'Overdue invoices',
+    toolsets: '3 toolsets · 9 tools',
+    access: 'Billing profile · Edit on Invoices',
+    description: 'Chases overdue invoices every morning and flags the ones that need a human.',
+    model: 'claude-haiku-4-5',
+    updated: 'yesterday',
+    kind: 'internal',
+    src: '/images/ai-headshots/agent-orange-male.png',
+    alt: 'Invoice chaser agent',
+    headOffset: '50% 5%',
+    accent: ORANGE,
+  },
+  {
+    id: 'triage',
+    name: 'Ticket triage',
+    trigger: 'Event · Ticket created',
+    procedure: 'Triage & route',
+    toolsets: '4 toolsets · 10 tools',
+    access: 'Support profile · Edit on Tickets',
+    description: 'Reads every new ticket, sets priority, and routes it to the right group.',
+    model: 'claude-haiku-4-5',
+    updated: '3 days ago',
+    kind: 'internal',
+    src: '/images/ai-headshots/agent-green-male.png',
+    alt: 'Ticket triage agent',
+    headOffset: '50% 5%',
+    accent: GREEN,
+  },
+  {
+    id: 'knowledge',
+    name: 'Knowledge keeper',
+    trigger: '@mention in a comment',
+    procedure: null,
+    toolsets: '2 toolsets · 5 tools',
+    access: 'Read-only everywhere',
+    description: 'Answers product questions from the knowledge base when someone @mentions it.',
+    model: 'claude-sonnet-5',
+    updated: '6 days ago',
+    kind: 'internal',
+    src: '/images/ai-headshots/agent-pink-female.png',
+    alt: 'Knowledge keeper agent',
+    headOffset: '50% 8%',
+    accent: PINK,
+  },
+]
+
+/** Lookup by id. Throws at module scope if an id is ever mistyped in a script. */
+export function agentById(id: AgentId): AgentCastMember {
+  const found = AGENT_CAST.find((a) => a.id === id)
+  if (!found) throw new Error(`Unknown agent id: ${id}`)
+  return found
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-portrait.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-portrait.tsx
@@ -1,0 +1,75 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agent-portrait.tsx
+
+import Image from 'next/image'
+import { cn } from '~/lib/utils'
+import type { AgentCastMember } from './agent-cast'
+
+interface AgentPortraitProps {
+  agent: AgentCastMember
+  /** Rendered diameter in px. Also drives the `sizes` hint. */
+  size: number
+  /** Draw the accent ring (used for the active chip and reply avatars). */
+  ring?: boolean
+  className?: string
+}
+
+/**
+ * The shared cropped-circle avatar.
+ *
+ * The sources are waist-up watercolour portraits on transparent backgrounds, so
+ * a square container plus `object-cover` and a per-agent `object-position`
+ * (see `headOffset` in `agent-cast.ts`) is what lands the head in the circle.
+ * Decorative everywhere it is used: the adjacent text always carries the name.
+ */
+export function AgentPortrait({ agent, size, ring = false, className }: AgentPortraitProps) {
+  return (
+    <span
+      aria-hidden
+      style={{ width: size, height: size }}
+      className={cn(
+        'relative inline-block shrink-0 overflow-hidden rounded-full bg-muted/70',
+        ring && cn('ring-2', agent.accent.ring),
+        className
+      )}>
+      <Image
+        src={agent.src}
+        alt=''
+        fill
+        sizes={`${size}px`}
+        style={{ objectFit: 'cover', objectPosition: agent.headOffset }}
+      />
+    </span>
+  )
+}
+
+/**
+ * The roster-card portrait: a taller head-and-shoulders crop with a blurred
+ * accent wash behind it, so the cut-out reads as placed rather than floating.
+ */
+export function AgentPortraitCard({
+  agent,
+  className,
+}: {
+  agent: AgentCastMember
+  className?: string
+}) {
+  return (
+    <div className={cn('relative mx-auto aspect-[4/5] w-full max-w-[168px]', className)}>
+      <div
+        aria-hidden
+        className={cn(
+          'absolute left-1/2 top-[18%] size-[76%] -translate-x-1/2 rounded-full blur-2xl',
+          agent.accent.wash
+        )}
+      />
+      <Image
+        src={agent.src}
+        alt={agent.alt}
+        fill
+        sizes='(max-width: 640px) 45vw, (max-width: 1024px) 30vw, 168px'
+        style={{ objectFit: 'cover', objectPosition: '50% 8%' }}
+        className='relative [mask-image:linear-gradient(to_bottom,black_78%,transparent_100%)]'
+      />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-roster-section.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-roster-section.tsx
@@ -1,0 +1,81 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agent-roster-section.tsx
+
+import { Play, ShieldCheck, Wrench, Zap } from 'lucide-react'
+import { cn } from '~/lib/utils'
+import { AGENT_CAST } from './agent-cast'
+import { AgentPortraitCard } from './agent-portrait'
+
+/**
+ * The cast. Five faces, five jobs, five different ways of starting, before the
+ * run illustration puts one of them to work.
+ *
+ * Knowledge keeper carries no procedure on purpose: an agent without one runs in
+ * free-form persona mode, with no classifier call at all. It is also the only
+ * read-only agent here, which makes the permissions point before the next
+ * section states it.
+ */
+export default function AgentRosterSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Five hires. No onboarding.
+          </h2>
+          <p className='mt-4 text-balance text-lg text-muted-foreground'>
+            Each one gets a job, a set of tools, and an access level, the same three things you give
+            a person. Then it starts itself.
+          </p>
+        </div>
+
+        <ul className='mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-5'>
+          {AGENT_CAST.map((agent) => (
+            <li
+              key={agent.id}
+              className='flex flex-col overflow-hidden rounded-2xl border bg-card ring-1 ring-foreground/5'>
+              <div className='px-3 pt-4'>
+                <AgentPortraitCard agent={agent} />
+              </div>
+
+              <div className='flex flex-1 flex-col gap-3 px-4 pb-5'>
+                <div>
+                  <h3 className='font-medium text-foreground'>{agent.name}</h3>
+                  <span
+                    className={cn(
+                      'mt-1.5 inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium',
+                      agent.accent.chip
+                    )}>
+                    <Zap className='size-3' />
+                    {agent.trigger}
+                  </span>
+                </div>
+
+                <dl className='mt-auto space-y-1.5 border-t pt-3 text-[11px] text-muted-foreground'>
+                  <div className='flex items-start gap-1.5'>
+                    <Play className='mt-px size-3 shrink-0' />
+                    <dd className={cn(!agent.procedure && 'italic')}>
+                      {agent.procedure ?? 'No procedure'}
+                    </dd>
+                  </div>
+                  <div className='flex items-start gap-1.5'>
+                    <Wrench className='mt-px size-3 shrink-0' />
+                    <dd>{agent.toolsets}</dd>
+                  </div>
+                  <div className='flex items-start gap-1.5'>
+                    <ShieldCheck className='mt-px size-3 shrink-0' />
+                    <dd>{agent.access}</dd>
+                  </div>
+                </dl>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <p className='mx-auto mt-10 max-w-2xl text-balance text-center text-sm text-muted-foreground'>
+          Not every agent needs a playbook. One with no procedure just answers, using the persona
+          and the tools you gave it. No branching, no extra model call.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-run-illustration.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-run-illustration.tsx
@@ -1,0 +1,400 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agent-run-illustration.tsx
+'use client'
+
+import {
+  ArrowRight,
+  Code2,
+  Flag,
+  GitBranch,
+  Hand,
+  Info,
+  ListChecks,
+  Pause,
+  Square,
+  Zap,
+} from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  MockAssistantSlot,
+  MockToolStatusPill,
+  MockUserMessage,
+  type ToolPillIcon,
+} from '~/app/platform/ai/_mocks'
+import { cn } from '~/lib/utils'
+import { MockAgentPanel } from '../_mocks'
+import { type AgentCastMember, agentById } from './agent-cast'
+import { AgentPortrait } from './agent-portrait'
+import { AGENT_SCRIPTS, type AgentScript, type RunEntry } from './agent-scripts'
+
+/**
+ * Fixed height for both columns, so opening a procedure never moves the page
+ * below. Measured max content across the four agents is ~600px; the extra
+ * headroom keeps the tallest state off the boundary, and the panel's own list
+ * scrolls rather than clipping if copy ever grows past it.
+ */
+const COLUMN_H = 'min-h-[640px] lg:h-[640px]'
+
+/** Default per-entry dwell. Individual entries can override it. */
+const STEP_MS = 950
+/** Hold on the terminal entry before moving to the next agent. */
+const AGENT_HOLD_MS = 1900
+
+/** Maps our registered tool names onto the pill icon set the Kopilot mocks ship. */
+const TOOL_ICONS: Record<string, ToolPillIcon> = {
+  get_entity: 'Database',
+  search_entities: 'Search',
+  search_knowledge: 'BookOpen',
+  update_entity: 'Pencil',
+  reply_to_thread: 'Mail',
+  create_task: 'Plus',
+  create_note: 'FileText',
+}
+
+/* -------------------------------------------------------------------------- */
+/* Playback                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function useRunPlayback(scripts: AgentScript[]) {
+  const reduceMotion = useReducedMotion()
+  const [agentIndex, setAgentIndex] = useState(0)
+  const [step, setStep] = useState(0)
+  const [paused, setPaused] = useState(false)
+
+  const script = scripts[agentIndex] ?? scripts[0]!
+  const total = script.run.length
+  const revealed = reduceMotion ? total : step
+
+  useEffect(() => {
+    if (reduceMotion || paused) return
+
+    if (step < total) {
+      const entry = script.run[step]
+      const timer = setTimeout(() => setStep((s) => s + 1), entry?.dwell ?? STEP_MS)
+      return () => clearTimeout(timer)
+    }
+
+    const timer = setTimeout(() => {
+      setAgentIndex((i) => (i + 1) % scripts.length)
+      setStep(0)
+    }, AGENT_HOLD_MS)
+    return () => clearTimeout(timer)
+  }, [step, total, paused, reduceMotion, script, scripts.length])
+
+  const selectAgent = useCallback((index: number) => {
+    setAgentIndex(index)
+    setStep(0)
+  }, [])
+
+  /** Scrub to the last entry belonging to a procedure line. */
+  const scrubToLine = useCallback(
+    (lineId: string) => {
+      const last = script.run.reduce((acc, entry, i) => (entry.line === lineId ? i : acc), -1)
+      if (last >= 0) setStep(last + 1)
+    },
+    [script]
+  )
+
+  return {
+    agentIndex,
+    script,
+    revealed,
+    reduceMotion,
+    selectAgent,
+    scrubToLine,
+    pause: () => setPaused(true),
+    resume: () => setPaused(false),
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Run column                                                                  */
+/* -------------------------------------------------------------------------- */
+
+function RunRow({ entry, agent }: { entry: RunEntry; agent: AgentCastMember }) {
+  switch (entry.kind) {
+    case 'user':
+      return <MockUserMessage text={entry.text} />
+    case 'assistant':
+      return (
+        <MockAssistantSlot
+          thinking={null}
+          blocks={<AgentByline agent={agent} />}
+          content={entry.text}
+          streaming={false}
+        />
+      )
+    case 'tool':
+      return (
+        <MockToolStatusPill
+          step={{
+            status: 'completed',
+            icon: TOOL_ICONS[entry.name] ?? 'Wrench',
+            runningLabel: entry.name,
+            completedLabel: `${entry.name} · ${entry.detail}`,
+          }}
+        />
+      )
+    case 'signal':
+      return (
+        <div className='inline-flex items-center gap-1.5 rounded-lg border border-dashed px-2 py-1 text-xs text-muted-foreground'>
+          <Flag className='size-3 shrink-0' />
+          <span className='font-mono text-[11px]'>{entry.name}</span>
+        </div>
+      )
+    case 'select':
+      return (
+        <div className='flex flex-col gap-1'>
+          <div
+            className={cn(
+              'inline-flex w-fit items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium',
+              agent.accent.chip
+            )}>
+            <ListChecks className='size-3 shrink-0' />
+            Procedure selected
+          </div>
+          <p className='pl-1 text-[11px] italic text-muted-foreground'>{entry.note}</p>
+        </div>
+      )
+    case 'branch':
+      return (
+        <div className='inline-flex items-center gap-1.5 rounded-lg border bg-mock-window px-2 py-1 text-xs text-mock-window-foreground'>
+          <GitBranch className='size-3 shrink-0 text-muted-foreground' />
+          {entry.text}
+        </div>
+      )
+    case 'code':
+      return (
+        <div className='inline-flex items-center gap-1.5 rounded-lg border border-indigo-500/25 bg-indigo-500/10 px-2 py-1 text-xs text-indigo-700 dark:text-indigo-300'>
+          <Code2 className='size-3 shrink-0 opacity-70' />
+          {entry.text}
+        </div>
+      )
+    case 'approval':
+      return (
+        <div className='inline-flex items-center gap-1.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-xs text-amber-700 dark:text-amber-300'>
+          <Pause className='size-3 shrink-0' />
+          {entry.text}
+        </div>
+      )
+    case 'note':
+      return (
+        <div className='flex items-start gap-1.5 rounded-lg bg-muted/40 px-2 py-1.5 text-[11px] italic text-muted-foreground'>
+          <Info className='mt-px size-3 shrink-0' />
+          {entry.text}
+        </div>
+      )
+    case 'system':
+      return (
+        <div className='inline-flex items-center gap-1.5 text-[11px] text-muted-foreground'>
+          <Zap className='size-3 shrink-0' />
+          {entry.text}
+        </div>
+      )
+    case 'terminal':
+      return (
+        <div
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium',
+            entry.tone === 'handoff'
+              ? 'bg-red-500/10 text-red-700 dark:text-red-300'
+              : 'bg-foreground/10 text-foreground'
+          )}>
+          {entry.tone === 'handoff' ? (
+            <Hand className='size-3 shrink-0' />
+          ) : (
+            <Square className='size-3 shrink-0' />
+          )}
+          {entry.text}
+        </div>
+      )
+  }
+}
+
+/**
+ * The agent's face + name above its reply. `MockAssistantSlot` renders the
+ * generic Kopilot sparkle in its icon column; this says *which* agent is
+ * talking, which is the whole point of casting portraits in the chips.
+ */
+function AgentByline({ agent }: { agent: AgentCastMember }) {
+  return (
+    <div className='flex items-center gap-1.5 pb-0.5'>
+      <AgentPortrait agent={agent} size={18} ring />
+      <span className='text-[11px] font-medium text-muted-foreground'>{agent.name}</span>
+    </div>
+  )
+}
+
+function RunColumn({
+  script,
+  agent,
+  revealed,
+  reduceMotion,
+}: {
+  script: AgentScript
+  agent: AgentCastMember
+  revealed: number
+  reduceMotion: boolean | null
+}) {
+  return (
+    <div className='flex h-full min-h-0 flex-col overflow-hidden rounded-lg border bg-zinc-200/30 dark:bg-white/[0.03]'>
+      <div className='flex items-center justify-between px-3 pt-1 pb-2'>
+        <span className='text-xs font-semibold uppercase leading-4 text-zinc-500'>Run</span>
+        <span className='inline-flex items-center gap-1 text-[11px] text-muted-foreground'>
+          <span className='size-1.5 rounded-full bg-emerald-500' />
+          live
+        </span>
+      </div>
+
+      <div className='flex flex-1 flex-col items-start gap-1.5 p-3'>
+        <AnimatePresence initial={false}>
+          {script.run.slice(0, revealed).map((entry, i) => (
+            <motion.div
+              key={`${script.agentId}-${i}`}
+              layout={!reduceMotion}
+              initial={reduceMotion ? false : { opacity: 0, y: 6, filter: 'blur(4px)' }}
+              animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+              transition={{ duration: 0.28 }}
+              className='w-full'>
+              <RunRow entry={entry} agent={agent} />
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Chips                                                                       */
+/* -------------------------------------------------------------------------- */
+
+function AgentChips({
+  activeIndex,
+  onSelect,
+}: {
+  activeIndex: number
+  onSelect: (index: number) => void
+}) {
+  return (
+    <div className='-mx-6 flex snap-x gap-2 overflow-x-auto px-6 pb-2 lg:mx-0 lg:flex-wrap lg:justify-center lg:overflow-visible lg:px-0'>
+      {AGENT_SCRIPTS.map((script, index) => {
+        const agent = agentById(script.agentId)
+        const isActive = index === activeIndex
+        return (
+          <button
+            key={script.agentId}
+            type='button'
+            onClick={() => onSelect(index)}
+            aria-pressed={isActive}
+            className={cn(
+              'flex shrink-0 snap-start items-center gap-2.5 rounded-xl border px-3 py-2 text-left transition-all',
+              isActive
+                ? 'border-foreground/15 bg-card shadow-sm'
+                : 'border-transparent bg-transparent opacity-70 hover:opacity-100'
+            )}>
+            {/* The layout box is always 44px and the inactive state shrinks
+                with a transform, so the growth is purely visual and the chip
+                row's height never changes. It also keeps `sizes` stable, so
+                activating a chip doesn't request a second image. */}
+            <AgentPortrait
+              agent={agent}
+              size={44}
+              ring={isActive}
+              className={cn(
+                'origin-center transition-transform duration-300',
+                !isActive && 'scale-[0.818] grayscale-[0.35]'
+              )}
+            />
+            <span className='flex flex-col'>
+              <span className='text-sm font-medium text-foreground'>{agent.name}</span>
+              <span className='text-[11px] text-muted-foreground'>{agent.trigger}</span>
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The authored procedure on the left, the live run on the right, stepping in
+ * sync. Clicking a paragraph scrubs the run to that point; hovering pauses.
+ *
+ * Four agents, four trigger kinds, four procedure shapes. Knowledge keeper is
+ * deliberately absent: it has no procedure, so it has nothing to show here.
+ */
+export default function AgentRunIllustration() {
+  const { agentIndex, script, revealed, reduceMotion, selectAgent, scrubToLine, pause, resume } =
+    useRunPlayback(AGENT_SCRIPTS)
+
+  const agent = agentById(script.agentId)
+  const shown = script.run.slice(0, revealed)
+  // The procedure opens only once selection has actually been revealed, so the
+  // list stays closed for the opening beat.
+  const openedId = shown.some((e) => e.kind === 'select') ? script.selectedId : null
+  const activeLine = shown[shown.length - 1]?.line
+
+  return (
+    <div onMouseEnter={pause} onMouseLeave={resume} className='mx-auto w-full max-w-4xl text-left'>
+      <AgentChips activeIndex={agentIndex} onSelect={selectAgent} />
+
+      {/*
+       * Both columns are pinned to `COLUMN_H`. Without it the grid's height is
+       * driven by whichever column is taller, and that swings ~180px every time
+       * a procedure opens or collapses — which is what made the page below jump
+       * when you clicked a chip (a click resets to step 0, closing the
+       * procedure, and it then reopens a beat later).
+       */}
+      <div className={cn('mt-6 grid gap-4 lg:grid-cols-2', COLUMN_H)}>
+        <MockAgentPanel
+          agent={agent}
+          persona={script.persona}
+          procedures={script.procedures}
+          selectedId={script.selectedId}
+          version={script.version}
+          openedId={openedId}
+          activeLine={activeLine}
+          onSelectLine={scrubToLine}
+          reduceMotion={reduceMotion}
+          className='order-2 lg:order-1'
+        />
+
+        {/* Run first on a phone: it is the payoff, the document is context. */}
+        <div className='order-1 min-h-0 lg:order-2'>
+          <RunColumn
+            script={script}
+            agent={agent}
+            revealed={revealed}
+            reduceMotion={reduceMotion}
+          />
+        </div>
+      </div>
+
+      <div className='mt-4 min-h-[44px]'>
+        <AnimatePresence mode='wait'>
+          {script.caption && (
+            <motion.p
+              key={script.agentId}
+              initial={reduceMotion ? false : { opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={reduceMotion ? undefined : { opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              className='text-balance text-center text-sm text-muted-foreground'>
+              {script.caption.text}{' '}
+              <Link
+                href={script.caption.href}
+                className='inline-flex items-center gap-1 font-medium text-foreground underline-offset-4 hover:underline'>
+                {script.caption.linkLabel}
+                <ArrowRight className='size-3' />
+              </Link>
+            </motion.p>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-run-section.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-run-section.tsx
@@ -1,0 +1,91 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agent-run-section.tsx
+
+import { Settings2, ShieldCheck, Wrench, Zap } from 'lucide-react'
+import { cn } from '~/lib/utils'
+import AgentRunIllustration from './agent-run-illustration'
+
+interface AgentRunSectionProps {
+  /**
+   * Full-bleed top and bottom rules. Needed on the main homepage, where this
+   * sits between two `bg-background` sections and the muted band would
+   * otherwise float without an edge. The agents page doesn't set it: the
+   * roster above already ends in a `border-b`, so it would double up.
+   */
+  bordered?: boolean
+}
+
+const capabilities = [
+  {
+    icon: Wrench,
+    name: 'Only the tools you gave it',
+    description:
+      'Every agent carries an allow-list, down to individual tools. Mention a tool in the prompt and it switches itself on; nothing else is ever in reach.',
+  },
+  {
+    icon: ShieldCheck,
+    name: "It can't outrank you",
+    description:
+      'Access is snapshotted onto the published version and clamped by whoever published it. Run one on a colleague’s behalf and their access becomes a ceiling: delegation narrows, never widens.',
+  },
+  {
+    icon: Zap,
+    name: 'Seven ways to start',
+    description:
+      'A schedule, a record change, an installed app, an inbound webhook, an @mention, a ticket assignment, or a direct message.',
+  },
+]
+
+/**
+ * The procedure story: an authored document on the left, the run it produces on
+ * the right. Chrome follows `platform/crm/_components/access-section.tsx` (muted
+ * band, double `border-x` rail, hatch strip as the section-start marker) so the
+ * two permission-shaped sections across the site rhyme.
+ */
+export default function AgentRunSection({ bordered = false }: AgentRunSectionProps) {
+  return (
+    <section className={cn('relative bg-muted/30', bordered && 'border-y border-foreground/10')}>
+      <div className='relative z-10 mx-auto max-w-6xl border-x px-3'>
+        <div className='border-x'>
+          <div
+            aria-hidden
+            className='h-3 w-full border-b border-foreground/10 bg-[repeating-linear-gradient(-45deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_4px)] opacity-15'
+          />
+          <div className='px-6 py-16 md:py-24'>
+            <div className='mx-auto max-w-3xl text-center'>
+              <div className='mx-auto inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-background/60 px-3 py-1 text-xs'>
+                <Settings2 className='size-3.5 text-indigo-500' />
+                <span className='text-muted-foreground'>Procedures · Deterministic playbooks</span>
+              </div>
+              <h2 className='mt-6 text-balance text-4xl font-semibold md:text-5xl'>
+                The agent doesn&apos;t decide the steps.
+                <br />
+                You do.
+              </h2>
+              <p className='mx-auto mt-4 text-balance text-lg text-muted-foreground'>
+                A procedure is a document you write in plain language. Inline badges make it
+                executable: tools, code, branches, and where it ends. Pick an agent to watch one
+                run.
+              </p>
+            </div>
+
+            <div className='mt-14 w-full'>
+              <AgentRunIllustration />
+            </div>
+
+            <div className='mt-16 grid gap-x-6 gap-y-8 border-t pt-12 sm:grid-cols-3'>
+              {capabilities.map((capability) => (
+                <div key={capability.name} className='space-y-2'>
+                  <div className='flex items-center gap-2'>
+                    <capability.icon className='size-4 fill-foreground/10 text-foreground' />
+                    <h3 className='text-sm font-medium'>{capability.name}</h3>
+                  </div>
+                  <p className='text-sm text-muted-foreground'>{capability.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-scripts.ts
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-scripts.ts
@@ -1,0 +1,378 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agent-scripts.ts
+
+import type { AgentId } from './agent-cast'
+
+/**
+ * The four procedure runs, written as data so the illustration is a renderer.
+ *
+ * The shape follows what actually happens at run time: an agent has a persona
+ * and a list of attached procedures; a message arrives; `selectProcedure` picks
+ * ONE of them (sticky resume → ruleset prefilter → a single classifier call over
+ * `whenToUse`); that procedure opens and the stepper walks it. The left column
+ * therefore starts as persona + procedure list, not as an already-open document.
+ *
+ * A procedure is an authored *document*: prose carrying inline badges plus
+ * IF / ELSE condition arms. That is what `ProcedureLine` models.
+ *
+ * Every tool name below is a real registered name from
+ * `packages/lib/src/ai/kopilot/capabilities/`.
+ */
+
+/** An inline run of a procedure paragraph. */
+export type Segment =
+  | { t: 'text'; v: string }
+  /** `@[tool:…]` mention chip. Gray, like any other reference. */
+  | { t: 'tool'; v: string }
+  /** A field or record reference chip. */
+  | { t: 'ref'; v: string }
+  /** `code:<id>` badge. Indigo, its own deterministic step. */
+  | { t: 'code'; v: string }
+  /** `subprocedure:<id>` badge. Forest, drills into a named body. */
+  | { t: 'subprocedure'; v: string }
+  /** `route:<outcome>` badge. Red, terminal. */
+  | { t: 'route'; v: 'finished' | 'handoff' }
+
+export interface ProcedureLine {
+  id: string
+  segments: Segment[]
+  /** Renders the `If` / `Else` arm keyword ahead of the prose. */
+  arm?: 'if' | 'else'
+  /** Sits inside the arm above it. */
+  indent?: boolean
+}
+
+/** One row of the agent's Procedures section (`AgentProcedure` link). */
+export interface ProcedureLink {
+  id: string
+  name: string
+  /** The selection criteria the classifier reads. */
+  whenToUse: string
+  /** Only the opened one carries a body; the rest are list rows. */
+  lines?: ProcedureLine[]
+}
+
+type RunEntryBody =
+  | { kind: 'user'; text: string }
+  | { kind: 'assistant'; text: string }
+  | { kind: 'tool'; name: string; detail: string }
+  | { kind: 'signal'; name: string }
+  | { kind: 'select'; procedureId: string; note: string }
+  | { kind: 'branch'; text: string }
+  | { kind: 'code'; text: string }
+  | { kind: 'approval'; text: string }
+  | { kind: 'note'; text: string }
+  | { kind: 'system'; text: string }
+  | { kind: 'terminal'; text: string; tone: 'finished' | 'handoff' }
+
+export type RunEntry = RunEntryBody & {
+  /**
+   * Which procedure line is executing while this entry appears. Absent before a
+   * procedure is selected — the left column is still showing the list then.
+   */
+  line?: string
+  /** Overrides the default step duration, in ms. */
+  dwell?: number
+}
+
+export interface AgentScript {
+  agentId: AgentId
+  /** Short excerpt of the authored persona, shown above the procedure list. */
+  persona: string
+  /** Everything attached to this agent. Exactly one carries `lines`. */
+  procedures: ProcedureLink[]
+  /** The one this run opens. */
+  selectedId: string
+  version: string
+  run: RunEntry[]
+  /** Rendered under the illustration while this agent is active. */
+  caption?: { text: string; href: string; linkLabel: string }
+}
+
+const text = (v: string): Segment => ({ t: 'text', v })
+const tool = (v: string): Segment => ({ t: 'tool', v })
+const ref = (v: string): Segment => ({ t: 'ref', v })
+const code = (v: string): Segment => ({ t: 'code', v })
+
+export const AGENT_SCRIPTS: AgentScript[] = [
+  {
+    agentId: 'refund',
+    persona:
+      'You handle returns and refunds for Alder Supply. Be warm and brief. Never promise money back before you have checked the delivery date.',
+    selectedId: 'refund-requests',
+    version: 'v4',
+    procedures: [
+      {
+        id: 'refund-requests',
+        name: 'Refund requests',
+        whenToUse: 'The customer wants money back on something they already received.',
+        lines: [
+          {
+            id: 'confirm',
+            segments: [
+              text('Confirm which order and item the customer means.'),
+              tool('get_entity'),
+              tool('search_entities'),
+            ],
+          },
+          {
+            id: 'if',
+            arm: 'if',
+            segments: [
+              text('delivered within'),
+              ref('30 days'),
+              text('and not a'),
+              ref('final sale'),
+            ],
+          },
+          {
+            id: 'refund',
+            indent: true,
+            segments: [text('Issue the refund.'), tool('update_entity'), tool('reply_to_thread')],
+          },
+          { id: 'else', arm: 'else', segments: [] },
+          {
+            id: 'explain',
+            indent: true,
+            segments: [
+              text('Explain the window and offer store credit.'),
+              tool('search_knowledge'),
+            ],
+          },
+          { id: 'end', segments: [{ t: 'route', v: 'finished' }] },
+        ],
+      },
+      {
+        id: 'damaged',
+        name: 'Damaged on arrival',
+        whenToUse: 'The item arrived broken, or the wrong item shipped.',
+      },
+      {
+        id: 'label',
+        name: 'Return label reissue',
+        whenToUse: 'The customer lost the return label or it has expired.',
+      },
+    ],
+    run: [
+      { kind: 'user', text: 'I want to return the boots I ordered.' },
+      {
+        kind: 'select',
+        procedureId: 'refund-requests',
+        note: 'One classifier call over the three whenToUse lines.',
+        dwell: 2000,
+      },
+      { line: 'confirm', kind: 'tool', name: 'get_entity', detail: 'Order #4521' },
+      {
+        line: 'confirm',
+        kind: 'assistant',
+        text: "That's order #4521, the Alder boots, delivered Jul 12.",
+      },
+      { line: 'confirm', kind: 'signal', name: 'advance_procedure' },
+      { line: 'if', kind: 'branch', text: 'If → within 30 days · true' },
+      { line: 'refund', kind: 'user', text: "Wait, where's my other order?" },
+      { line: 'refund', kind: 'signal', name: 'digress' },
+      {
+        line: 'refund',
+        kind: 'note',
+        text: 'Answered, without losing the thread. The procedure is still on this step.',
+        dwell: 2300,
+      },
+      { line: 'refund', kind: 'approval', text: 'Approval needed · refund $189.00' },
+      { line: 'refund', kind: 'tool', name: 'update_entity', detail: 'Status → Refunded' },
+      { line: 'end', kind: 'terminal', text: 'End procedure', tone: 'finished' },
+    ],
+  },
+
+  {
+    agentId: 'order-status',
+    persona:
+      'You answer questions about orders in flight. Give a real date, never a range. If the carrier is running late, say so plainly and hand off.',
+    selectedId: 'wheres-my-order',
+    version: 'v2',
+    procedures: [
+      {
+        id: 'wheres-my-order',
+        name: "Where's my order",
+        whenToUse: 'The customer is asking where an order that has already shipped is.',
+        lines: [
+          {
+            id: 'find',
+            segments: [
+              text('Find the order the customer is asking about.'),
+              tool('search_entities'),
+              tool('get_entity'),
+            ],
+          },
+          { id: 'days', segments: [code('Days late')] },
+          { id: 'if', arm: 'if', segments: [ref('days late'), text('is more than 5')] },
+          { id: 'handoff', indent: true, segments: [{ t: 'route', v: 'handoff' }] },
+          { id: 'else', arm: 'else', segments: [] },
+          {
+            id: 'tracking',
+            indent: true,
+            segments: [text('Share the tracking link.'), tool('reply_to_thread')],
+          },
+        ],
+      },
+      {
+        id: 'address',
+        name: 'Change delivery address',
+        whenToUse: 'The customer wants the parcel sent somewhere else before it arrives.',
+      },
+    ],
+    run: [
+      { kind: 'user', text: "My order still hasn't arrived." },
+      {
+        kind: 'select',
+        procedureId: 'wheres-my-order',
+        note: 'Two candidates, one classifier call.',
+        dwell: 1800,
+      },
+      { line: 'find', kind: 'tool', name: 'search_entities', detail: 'Order #4390' },
+      { line: 'find', kind: 'tool', name: 'get_entity', detail: 'ETA was Jul 21' },
+      { line: 'find', kind: 'signal', name: 'advance_procedure' },
+      { line: 'days', kind: 'code', text: 'Days late → 7' },
+      {
+        line: 'days',
+        kind: 'note',
+        text: 'Deterministic. The stepper walks through it and never rests here.',
+        dwell: 2100,
+      },
+      { line: 'if', kind: 'branch', text: 'If → more than 5 · true' },
+      { line: 'handoff', kind: 'terminal', text: 'Hand off to human', tone: 'handoff' },
+      { line: 'handoff', kind: 'system', text: 'Assigned to Maya · agent stopped' },
+    ],
+  },
+
+  {
+    agentId: 'invoice-chaser',
+    persona:
+      'You chase invoices that are past due. Firm, never rude, one reminder per thread. Always link the invoice itself.',
+    selectedId: 'overdue-invoices',
+    version: 'v3',
+    procedures: [
+      {
+        id: 'overdue-invoices',
+        name: 'Overdue invoices',
+        whenToUse: 'Runs every morning across every invoice past its due date.',
+        lines: [
+          { id: 'load', segments: [code('Overdue invoices')] },
+          {
+            id: 'remind',
+            segments: [
+              text("For each invoice, write a short reminder in the customer's own thread."),
+              tool('reply_to_thread'),
+            ],
+          },
+          { id: 'if', arm: 'if', segments: [text("it's more than 30 days overdue")] },
+          {
+            id: 'flag',
+            indent: true,
+            segments: [
+              text('Flag it for the account owner.'),
+              tool('create_task'),
+              tool('update_entity'),
+            ],
+          },
+          { id: 'end', segments: [{ t: 'route', v: 'finished' }] },
+        ],
+      },
+      {
+        id: 'payment-failed',
+        name: 'Payment failed',
+        whenToUse: 'A card was declined and the invoice is still open.',
+      },
+    ],
+    run: [
+      { kind: 'system', text: 'Schedule fired · 08:00' },
+      {
+        kind: 'select',
+        procedureId: 'overdue-invoices',
+        note: 'A scheduled trigger names its procedure. No classifier call at all.',
+        dwell: 2200,
+      },
+      { line: 'load', kind: 'code', text: 'Overdue invoices → 14' },
+      { line: 'remind', kind: 'tool', name: 'reply_to_thread', detail: '14 threads' },
+      { line: 'remind', kind: 'signal', name: 'advance_procedure' },
+      { line: 'if', kind: 'branch', text: 'If → over 30 days · 3 of 14' },
+      { line: 'flag', kind: 'tool', name: 'create_task', detail: '3 account owners' },
+      { line: 'flag', kind: 'tool', name: 'update_entity', detail: 'Status → Escalated ×3' },
+      {
+        line: 'end',
+        kind: 'terminal',
+        text: 'End procedure · no customer in the loop',
+        tone: 'finished',
+      },
+    ],
+    caption: {
+      text: "A sequence sends three invoice reminders on a timer, and it's cheaper for that. An agent is for the ones that need a decision.",
+      href: '/platform/sequences',
+      linkLabel: 'See Sequences',
+    },
+  },
+
+  {
+    agentId: 'triage',
+    persona:
+      'You read every new ticket and route it. You never answer the customer yourself, and you never guess a group you are unsure about.',
+    selectedId: 'triage-route',
+    version: 'v6',
+    procedures: [
+      {
+        id: 'triage-route',
+        name: 'Triage & route',
+        whenToUse: 'Every newly created ticket, before a human sees it.',
+        lines: [
+          {
+            id: 'read',
+            segments: [
+              text("Read the ticket and decide what it's about."),
+              tool('get_entity'),
+              tool('search_knowledge'),
+            ],
+          },
+          { id: 'route', segments: [code('Route to group')] },
+          {
+            id: 'set',
+            segments: [
+              text('Set the priority, tag it, and assign the owner.'),
+              tool('update_entity'),
+              tool('create_note'),
+            ],
+          },
+          { id: 'end', segments: [{ t: 'route', v: 'finished' }] },
+        ],
+      },
+      {
+        id: 'duplicate',
+        name: 'Duplicate detection',
+        whenToUse: 'The same customer opened a second ticket about the same thing.',
+      },
+      {
+        id: 'vip',
+        name: 'VIP fast lane',
+        whenToUse: 'The contact is on an enterprise plan and the ticket looks urgent.',
+      },
+    ],
+    run: [
+      { kind: 'system', text: 'Ticket #8812 created' },
+      {
+        kind: 'select',
+        procedureId: 'triage-route',
+        note: 'Ruleset prefilter dropped VIP fast lane before the classifier ran.',
+        dwell: 2200,
+      },
+      { line: 'read', kind: 'tool', name: 'get_entity', detail: 'Ticket #8812' },
+      { line: 'read', kind: 'tool', name: 'search_knowledge', detail: '2 articles' },
+      { line: 'read', kind: 'signal', name: 'advance_procedure' },
+      { line: 'route', kind: 'code', text: 'Route to group → Billing' },
+      {
+        line: 'set',
+        kind: 'tool',
+        name: 'update_entity',
+        detail: 'Priority → High, Group → Billing',
+      },
+      { line: 'set', kind: 'tool', name: 'create_note', detail: 'triage rationale' },
+      { line: 'end', kind: 'terminal', text: 'End procedure · 0.9s', tone: 'finished' },
+    ],
+  },
+]

--- a/apps/homepage/src/app/platform/ai/agents/_components/agents-cross-links.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agents-cross-links.tsx
@@ -1,0 +1,84 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agents-cross-links.tsx
+
+import { GitBranch, Library, Send, Sparkles, Ticket } from 'lucide-react'
+import Link from 'next/link'
+
+const links = [
+  {
+    icon: Sparkles,
+    name: 'Kopilot',
+    description: 'The same engine, driven by you instead of a trigger. It also builds the agents.',
+    href: '/platform/ai/kopilot',
+    tone: 'text-amber-600 dark:text-amber-400',
+  },
+  {
+    icon: Library,
+    name: 'Knowledge base',
+    description: 'What an agent answers from, scoped per agent and searched at run time.',
+    href: '/platform/knowledge-base',
+    tone: 'text-yellow-600 dark:text-yellow-400',
+  },
+  {
+    icon: GitBranch,
+    name: 'Workflow',
+    description: 'For the deterministic parts. An AI node hands a turn to an agent mid-graph.',
+    href: '/platform/workflow',
+    tone: 'text-purple-600 dark:text-purple-400',
+  },
+  {
+    icon: Send,
+    name: 'Sequences',
+    description: 'Timed reminders that need no judgment. Cheaper than an agent, on purpose.',
+    href: '/platform/sequences',
+    tone: 'text-blue-600 dark:text-blue-400',
+  },
+  {
+    icon: Ticket,
+    name: 'Ticketing',
+    description: 'Where triage writes, where assignment fires, and where a handoff lands.',
+    href: '/platform/ticketing',
+    tone: 'text-teal-600 dark:text-teal-400',
+  },
+]
+
+/** Cross-links to the platform pages an agent actually touches. */
+export default function AgentsCrossLinks() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Agents don&apos;t run alone.
+          </h2>
+          <p className='mt-4 text-balance text-lg text-muted-foreground'>
+            They read the same records, answer from the same knowledge, and start off the same
+            events as everything else in the workspace.
+          </p>
+        </div>
+
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-4 sm:grid-cols-2'>
+          {links.map((link, index) => (
+            <li key={link.name}>
+              <Link
+                href={link.href}
+                className='flex h-full items-start gap-3.5 rounded-xl border bg-card p-5 ring-1 ring-foreground/10 transition-shadow hover:shadow-sm hover:ring-foreground/15'>
+                <div className='flex size-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-foreground/10'>
+                  <link.icon className={`size-4 ${link.tone}`} />
+                </div>
+                <div className='space-y-0.5'>
+                  <div className='flex items-center gap-2'>
+                    <span className='font-mono text-xs text-muted-foreground'>
+                      [{String(index + 1).padStart(2, '0')}]
+                    </span>
+                    <span className='font-medium text-foreground'>{link.name}</span>
+                  </div>
+                  <p className='text-sm text-muted-foreground'>{link.description}</p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/agents-final-cta.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agents-final-cta.tsx
@@ -1,0 +1,40 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agents-final-cta.tsx
+
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+
+/**
+ * Plain dark CTA, no portraits. The overlapping-lineup card is
+ * `KopilotAgentsCta`'s signature and that card is now the doorway *into* this
+ * page, so repeating it here would loop the two pages into each other.
+ */
+export default function AgentsFinalCta() {
+  return (
+    <section
+      data-theme='dark'
+      className='relative overflow-hidden border-b border-foreground/10 bg-zinc-950 text-zinc-50'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_rgba(255,255,255,0.08),_transparent_60%)]'
+      />
+      <div className='relative z-10 mx-auto max-w-4xl px-6 py-24 text-center md:py-32'>
+        <h2 className='text-balance text-5xl font-semibold tracking-tight md:text-6xl'>
+          Write the playbook. Let it run.
+        </h2>
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button
+            asChild
+            size='sm'
+            variant='outline'
+            className='border-zinc-700 bg-transparent text-zinc-50 hover:bg-zinc-900'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/agents-hero.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agents-hero.tsx
@@ -1,0 +1,57 @@
+// apps/homepage/src/app/platform/ai/agents/_components/agents-hero.tsx
+
+import { Bot } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+import { AgentsBrowserDemo } from '../_mocks'
+
+/**
+ * Centered copy over a dot grid, flowing into a mock of the agent *list*
+ * surface. Deliberately not the detail view: the run illustration dissects that
+ * one section down, and it should not be spent twice.
+ */
+export default function AgentsHero() {
+  return (
+    <section className='relative overflow-hidden border-b'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle,var(--color-foreground)_1px,transparent_1px)] [background-size:24px_24px] opacity-[0.06] [mask-image:radial-gradient(ellipse_at_top,black_45%,transparent_90%)]'
+      />
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-x-0 top-0 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/8,_transparent_60%)]'
+      />
+
+      <div className='relative mx-auto max-w-6xl px-6 pb-20 pt-24 md:pt-32 lg:pt-36'>
+        <div className='relative z-10 mx-auto max-w-2xl text-center'>
+          <div className='mx-auto inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-muted/40 px-3 py-1 text-xs'>
+            <Bot className='size-3.5 text-violet-500' />
+            <span className='text-muted-foreground'>AI CRM · Agents</span>
+          </div>
+
+          <h1 className='mt-6 text-balance text-4xl font-semibold tracking-tight md:text-5xl lg:text-6xl'>
+            Agents that follow
+            <br />
+            your process.
+          </h1>
+          <p className='mx-auto mt-4 max-w-xl text-balance text-lg text-muted-foreground'>
+            Write the playbook in plain language. The agent runs it step by step, calls only the
+            tools you gave it, and proves it before it ever talks to a customer.
+          </p>
+
+          <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+            <Button asChild size='sm'>
+              <Link href={config.urls.signup}>Start for free</Link>
+            </Button>
+            <Button asChild size='sm' variant='outline'>
+              <Link href={config.urls.demo}>Talk to sales</Link>
+            </Button>
+          </div>
+        </div>
+
+        <AgentsBrowserDemo className='relative z-10 mt-14' />
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/eval-detail-grid.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/eval-detail-grid.tsx
@@ -1,0 +1,172 @@
+// apps/homepage/src/app/platform/ai/agents/_components/eval-detail-grid.tsx
+
+import { Check, ShieldOff, TriangleAlert, X } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+/** `[01]` — the monospace index this page shares with the sequences grid. */
+function Index({ n }: { n: number }) {
+  return (
+    <span className='font-mono text-xs text-muted-foreground'>[{String(n).padStart(2, '0')}]</span>
+  )
+}
+
+function LayersPreview() {
+  return (
+    <div className='space-y-1.5'>
+      {['selection', 'stepper', 'engine'].map((layer) => (
+        <div
+          key={layer}
+          className='rounded-lg border bg-card px-3 py-2 text-[11px] font-medium text-foreground ring-1 ring-foreground/5'>
+          {layer}
+        </div>
+      ))}
+      <div className='flex items-center gap-1.5 rounded-lg border border-dashed px-3 py-2 text-[11px] text-muted-foreground'>
+        <ShieldOff className='size-3.5 shrink-0 text-amber-500' />
+        tools · stubbed, fail-closed
+      </div>
+    </div>
+  )
+}
+
+function AssertionsPreview() {
+  const deterministic = ['tool_called', 'terminal_outcome', 'crm_field', 'local_variable']
+  return (
+    <div className='flex flex-wrap gap-1.5'>
+      {deterministic.map((assertion) => (
+        <span
+          key={assertion}
+          className='rounded-md bg-muted px-1.5 py-1 font-mono text-[10px] text-muted-foreground'>
+          {assertion}
+        </span>
+      ))}
+      <span className='rounded-md bg-amber-500/10 px-1.5 py-1 font-mono text-[10px] text-amber-700 dark:text-amber-400'>
+        response_criteria · judged
+      </span>
+    </div>
+  )
+}
+
+function StatusPreview() {
+  const rows = [
+    {
+      icon: Check,
+      label: 'passed',
+      detail: 'every assertion held',
+      tone: 'text-emerald-700 dark:text-emerald-400',
+      bg: 'bg-emerald-500/10',
+    },
+    {
+      icon: X,
+      label: 'failed',
+      detail: 'it ran, and got it wrong',
+      tone: 'text-red-700 dark:text-red-400',
+      bg: 'bg-red-500/10',
+    },
+    {
+      icon: TriangleAlert,
+      label: 'error',
+      detail: 'UNMATCHED_MOCK',
+      tone: 'text-amber-700 dark:text-amber-400',
+      bg: 'bg-amber-500/10',
+    },
+  ]
+  return (
+    <div className='space-y-1.5'>
+      {rows.map((row) => (
+        <div key={row.label} className='flex items-center gap-2 text-[11px]'>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 font-medium',
+              row.bg,
+              row.tone
+            )}>
+            <row.icon className='size-3' />
+            {row.label}
+          </span>
+          <span className='truncate text-muted-foreground'>{row.detail}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ModePreview() {
+  return (
+    <div className='space-y-2'>
+      <div className='inline-flex rounded-lg border bg-card p-0.5 text-[11px]'>
+        <span className='rounded-md bg-foreground px-2 py-1 font-medium text-background'>
+          pinned v7
+        </span>
+        <span className='px-2 py-1 text-muted-foreground'>draft</span>
+      </div>
+      <div className='flex items-center gap-1.5 rounded-lg border border-dashed px-2.5 py-2 text-[10px] text-muted-foreground'>
+        <TriangleAlert className='size-3 shrink-0 text-amber-500' />
+        <span className='font-mono'>SNAPSHOT_INCOMPATIBLE</span>
+      </div>
+    </div>
+  )
+}
+
+const cells = [
+  {
+    title: 'The real loop, mocked at the edges',
+    description:
+      'Selection, stepper, and engine are the ones production runs. Only tools are stubbed, and an un-stubbed call errors the run instead of touching anything. No CRM writes, ever.',
+    preview: <LayersPreview />,
+  },
+  {
+    title: "Assertions that don't argue",
+    description:
+      'This tool with these arguments. This terminal outcome. This field ended up here. This variable equals that. Judged criteria only for prose.',
+    preview: <AssertionsPreview />,
+  },
+  {
+    title: 'error is not failed',
+    description:
+      "A judge that breaks, a mock that's missing, a run that times out: those are errors, not verdicts. Nothing passes quietly.",
+    preview: <StatusPreview />,
+  },
+  {
+    title: 'Pinned or draft',
+    description:
+      "Pin the published version and it's a regression gate. Point it at the draft and it's the iteration loop. A tool whose schema moved under a pinned run fails loudly.",
+    preview: <ModePreview />,
+  },
+]
+
+/**
+ * The four things that make the simulations trustworthy, in the numbered-grid
+ * shape `platform/sequences/_components/tracking-grid.tsx` established.
+ */
+export default function EvalDetailGrid() {
+  return (
+    <section className='relative overflow-hidden border-b'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle,var(--color-foreground)_1px,transparent_1px)] [background-size:24px_24px] opacity-[0.05]'
+      />
+      <div className='relative mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>Not a vibe check.</h2>
+          <p className='mt-4 text-balance text-lg text-muted-foreground'>
+            Simulations run the real agent loop against a synthetic customer, with every tool
+            stubbed at the edge.
+          </p>
+        </div>
+
+        <div className='mt-12 grid gap-px overflow-hidden rounded-2xl border bg-border/60 sm:grid-cols-2'>
+          {cells.map((cell, index) => (
+            <div key={cell.title} className='flex min-h-[300px] flex-col bg-background p-6 md:p-8'>
+              <Index n={index + 1} />
+              <div className='my-6 flex flex-1 items-center'>
+                <div className='w-full'>{cell.preview}</div>
+              </div>
+              <h3 className='font-medium text-foreground'>{cell.title}</h3>
+              <p className='mt-1 text-sm text-muted-foreground'>{cell.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/eval-loop-illustration.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/eval-loop-illustration.tsx
@@ -1,0 +1,299 @@
+// apps/homepage/src/app/platform/ai/agents/_components/eval-loop-illustration.tsx
+'use client'
+
+import { ArrowDown, ArrowRight, ArrowUp, Check, Sparkles, TriangleAlert, X } from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useEffect, useState } from 'react'
+import { cn } from '~/lib/utils'
+import { agentById } from './agent-cast'
+import { AgentPortrait } from './agent-portrait'
+import { type CaseStatus, EVAL_CASES, KOPILOT_FIX, RUN_LABELS, SUITE_DIFF } from './eval-scripts'
+
+type Phase = 'before' | 'fix' | 'after'
+
+const RESOLVE_MS = { before: 420, after: 220 }
+const HOLD_MS = { before: 1900, fix: 3400, after: 4200 }
+const TOTAL_CASES = EVAL_CASES.length
+
+/* -------------------------------------------------------------------------- */
+
+function useSuitePlayback() {
+  const reduceMotion = useReducedMotion()
+  const [phase, setPhase] = useState<Phase>('before')
+  const [resolved, setResolved] = useState(0)
+  const [scrubbed, setScrubbed] = useState(false)
+  const [paused, setPaused] = useState(false)
+
+  const frozen = reduceMotion || scrubbed
+
+  useEffect(() => {
+    if (frozen || paused) return
+
+    if (phase === 'fix') {
+      const timer = setTimeout(() => {
+        setPhase('after')
+        setResolved(0)
+      }, HOLD_MS.fix)
+      return () => clearTimeout(timer)
+    }
+
+    if (resolved < TOTAL_CASES) {
+      const timer = setTimeout(() => setResolved((r) => r + 1), RESOLVE_MS[phase])
+      return () => clearTimeout(timer)
+    }
+
+    const timer = setTimeout(
+      () => {
+        if (phase === 'before') {
+          setPhase('fix')
+        } else {
+          setPhase('before')
+          setResolved(0)
+        }
+      },
+      phase === 'before' ? HOLD_MS.before : HOLD_MS.after
+    )
+    return () => clearTimeout(timer)
+  }, [phase, resolved, frozen, paused])
+
+  /** Clicking a run tab pins that board and stops the loop. */
+  const scrubTo = (next: Phase) => {
+    setScrubbed(true)
+    setPhase(next)
+    setResolved(TOTAL_CASES)
+  }
+
+  return {
+    phase,
+    resolved: frozen ? TOTAL_CASES : resolved,
+    reduceMotion,
+    scrubTo,
+    pause: () => setPaused(true),
+    resume: () => setPaused(false),
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+function StatusChip({ status, errorCode }: { status: CaseStatus; errorCode?: string }) {
+  if (status === 'passed') {
+    return (
+      <span className='inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-1.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-400'>
+        <Check className='size-3' />
+        passed
+      </span>
+    )
+  }
+  if (status === 'failed') {
+    return (
+      <span className='inline-flex items-center gap-1 rounded-md bg-red-500/10 px-1.5 py-0.5 text-[11px] font-medium text-red-700 dark:text-red-400'>
+        <X className='size-3' />
+        failed
+      </span>
+    )
+  }
+  return (
+    <span className='inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-400'>
+      <TriangleAlert className='size-3' />
+      error
+      {errorCode && <span className='font-mono text-[10px] opacity-80'>· {errorCode}</span>}
+    </span>
+  )
+}
+
+function CaseRow({
+  name,
+  assertions,
+  status,
+  errorCode,
+  resolved,
+  reduceMotion,
+}: {
+  name: string
+  assertions: { label: string; judged?: boolean }[]
+  status: CaseStatus
+  errorCode?: string
+  resolved: boolean
+  reduceMotion: boolean | null
+}) {
+  return (
+    <div className='flex flex-col gap-1.5 px-3 py-2.5 sm:flex-row sm:items-center sm:gap-3'>
+      <span className='min-w-0 flex-1 truncate text-xs font-medium text-foreground'>{name}</span>
+
+      <span className='flex flex-wrap items-center gap-1'>
+        {assertions.map((assertion) => (
+          <span
+            key={assertion.label}
+            className={cn(
+              'rounded-md px-1.5 py-0.5 font-mono text-[10px]',
+              assertion.judged
+                ? 'bg-amber-500/10 text-amber-700 dark:text-amber-400'
+                : 'bg-muted text-muted-foreground'
+            )}>
+            {assertion.label}
+          </span>
+        ))}
+      </span>
+
+      <span className='flex w-[150px] shrink-0 items-center'>
+        <AnimatePresence mode='wait' initial={false}>
+          {resolved ? (
+            <motion.span
+              key='resolved'
+              initial={reduceMotion ? false : { scale: 0.7, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: 'spring', stiffness: 600, damping: 20 }}>
+              <StatusChip status={status} errorCode={errorCode} />
+            </motion.span>
+          ) : (
+            <motion.span
+              key='pending'
+              exit={{ opacity: 0 }}
+              className='h-1.5 w-16 overflow-hidden rounded-full bg-muted'>
+              <motion.span
+                className='block h-full w-1/2 rounded-full bg-foreground/20'
+                animate={reduceMotion ? undefined : { x: ['-100%', '200%'] }}
+                transition={{ repeat: Number.POSITIVE_INFINITY, duration: 1.1, ease: 'linear' }}
+              />
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </span>
+    </div>
+  )
+}
+
+function DiffHeader({ visible }: { visible: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-x-4 gap-y-1 px-3 py-2 text-[11px] transition-opacity duration-300',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}>
+      <span className='inline-flex items-center gap-1 font-medium text-emerald-700 dark:text-emerald-400'>
+        <ArrowUp className='size-3' />
+        {SUITE_DIFF.fixed} fixed
+      </span>
+      <span className='inline-flex items-center gap-1 text-muted-foreground'>
+        <ArrowRight className='size-3' />
+        {SUITE_DIFF.stillPassing} still passing
+      </span>
+      <span className='inline-flex items-center gap-1 text-muted-foreground'>
+        <ArrowDown className='size-3' />
+        {SUITE_DIFF.regressed} regressed
+      </span>
+      <span className='ml-auto text-muted-foreground'>
+        Pass rate {SUITE_DIFF.passRateBefore}% → {SUITE_DIFF.passRateAfter}%
+      </span>
+    </div>
+  )
+}
+
+function KopilotCard({ reduceMotion }: { reduceMotion: boolean | null }) {
+  return (
+    <motion.div
+      initial={reduceMotion ? false : { opacity: 0, y: 12, filter: 'blur(6px)' }}
+      animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+      exit={reduceMotion ? undefined : { opacity: 0, y: -8, filter: 'blur(6px)' }}
+      transition={{ duration: 0.35 }}
+      className='m-3 rounded-xl border bg-muted/40 p-3'>
+      <div className='flex items-center gap-1.5 text-xs font-medium text-foreground'>
+        <Sparkles className='size-3.5 text-amber-500' />
+        Kopilot
+      </div>
+      <p className='mt-1.5 text-xs leading-relaxed text-muted-foreground'>{KOPILOT_FIX.message}</p>
+      <div className='mt-2.5 flex flex-wrap gap-1'>
+        {KOPILOT_FIX.tools.map((toolName, i) => (
+          <motion.span
+            key={toolName}
+            initial={reduceMotion ? false : { opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ delay: reduceMotion ? 0 : 0.5 + i * 0.4, duration: 0.25 }}
+            className='inline-flex items-center gap-1 rounded-md border bg-card px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground'>
+            <Check className='size-2.5 text-emerald-500' />
+            {toolName}
+          </motion.span>
+        ))}
+      </div>
+    </motion.div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A suite that runs, fails, gets fixed by Kopilot, and re-runs into a diff.
+ *
+ * The `Run 12 / Run 13` tabs are the point of making this interactive rather
+ * than a looping video: they let you hold the before and after side by side.
+ * The board height is fixed across all three states so the page does not jump.
+ */
+export default function EvalLoopIllustration() {
+  const { phase, resolved, reduceMotion, scrubTo, pause, resume } = useSuitePlayback()
+  const agent = agentById('refund')
+  const showingAfter = phase === 'after'
+
+  return (
+    <div onMouseEnter={pause} onMouseLeave={resume} className='mx-auto w-full max-w-3xl text-left'>
+      <div className='mb-4 flex justify-center'>
+        <div className='inline-flex rounded-lg border bg-card p-0.5'>
+          {(['before', 'after'] as const).map((key) => (
+            <button
+              key={key}
+              type='button'
+              onClick={() => scrubTo(key)}
+              aria-pressed={phase === key}
+              className={cn(
+                'rounded-md px-3 py-1 text-xs font-medium transition-colors',
+                phase === key
+                  ? 'bg-foreground text-background'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}>
+              {RUN_LABELS[key]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className='flex min-h-[440px] flex-col overflow-hidden rounded-2xl border bg-card ring-1 ring-foreground/5'>
+        <div className='flex items-center gap-2 border-b px-3 py-2.5'>
+          <AgentPortrait agent={agent} size={28} ring />
+          <span className='text-xs font-medium text-foreground'>{agent.name}</span>
+          <span className='truncate text-[11px] text-muted-foreground'>
+            · Refund requests v4 · {EVAL_CASES.length} cases
+          </span>
+          <span className='ml-auto shrink-0 rounded-md bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground'>
+            {phase === 'fix' ? RUN_LABELS.before : RUN_LABELS[phase]}
+          </span>
+        </div>
+
+        <DiffHeader visible={showingAfter && resolved === EVAL_CASES.length} />
+
+        <div className='divide-y'>
+          {EVAL_CASES.map((evalCase, index) => (
+            <CaseRow
+              key={evalCase.id}
+              name={evalCase.name}
+              assertions={evalCase.assertions}
+              status={showingAfter ? evalCase.after : evalCase.before}
+              errorCode={showingAfter ? undefined : evalCase.errorCode}
+              resolved={phase === 'fix' ? true : index < resolved}
+              reduceMotion={reduceMotion}
+            />
+          ))}
+        </div>
+
+        <AnimatePresence mode='wait'>
+          {phase === 'fix' && <KopilotCard key='fix' reduceMotion={reduceMotion} />}
+        </AnimatePresence>
+
+        {phase === 'before' && resolved === EVAL_CASES.length && (
+          <p className='m-3 rounded-lg bg-amber-500/[0.07] px-3 py-2 text-[11px] italic text-muted-foreground'>
+            The last one didn&apos;t fail, it errored: a tool call had no stub, so the run
+            couldn&apos;t finish. Nothing passes on a technicality here.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_components/eval-scripts.ts
+++ b/apps/homepage/src/app/platform/ai/agents/_components/eval-scripts.ts
@@ -1,0 +1,85 @@
+// apps/homepage/src/app/platform/ai/agents/_components/eval-scripts.ts
+
+/**
+ * The eval suite the illustration runs twice, with a Kopilot fix in between.
+ *
+ * The amber row is deliberate: it did not fail, it errored, because a tool call
+ * had no stub. `error` and `failed` are different states in the real grader and
+ * the distinction is the most credible thing on this section.
+ */
+
+export type CaseStatus = 'passed' | 'failed' | 'error'
+
+export interface EvalAssertion {
+  label: string
+  /** Judged assertions get a distinct tint, so the split reads without a legend. */
+  judged?: boolean
+}
+
+export interface EvalCase {
+  id: string
+  name: string
+  assertions: EvalAssertion[]
+  before: CaseStatus
+  after: CaseStatus
+  /** Shown beside the status chip when the run errored. */
+  errorCode?: string
+}
+
+export const EVAL_CASES: EvalCase[] = [
+  {
+    id: 'inside',
+    name: 'Refund inside window',
+    assertions: [{ label: 'tool_called update_entity' }, { label: 'terminal_outcome finished' }],
+    before: 'passed',
+    after: 'passed',
+  },
+  {
+    id: 'outside',
+    name: 'Refund outside window',
+    assertions: [
+      { label: 'tool_not_called update_entity' },
+      { label: 'response_criteria "offers store credit"', judged: true },
+    ],
+    before: 'failed',
+    after: 'passed',
+  },
+  {
+    id: 'angry',
+    name: 'No order id, angry customer',
+    assertions: [{ label: 'terminal_outcome handoff' }],
+    before: 'passed',
+    after: 'passed',
+  },
+  {
+    id: 'shipping',
+    name: 'Asks about shipping mid-flow',
+    assertions: [{ label: 'local_variable step = 2' }],
+    before: 'passed',
+    after: 'passed',
+  },
+  {
+    id: 'duplicate',
+    name: 'Duplicate refund request',
+    assertions: [{ label: 'crm_field Status is Refunded' }],
+    before: 'error',
+    after: 'passed',
+    errorCode: 'UNMATCHED_MOCK',
+  },
+]
+
+export const KOPILOT_FIX = {
+  message:
+    "Refund outside window issued a refund it shouldn't have. The condition only checks final-sale, never the delivery date. I've added the 30-day check, and stubbed get_entity for the duplicate case. Re-running the suite.",
+  tools: ['set_procedure_body', 'update_eval_case_mock', 'run_eval_suite'],
+}
+
+export const SUITE_DIFF = {
+  fixed: 2,
+  stillPassing: 3,
+  regressed: 0,
+  passRateBefore: 60,
+  passRateAfter: 100,
+}
+
+export const RUN_LABELS = { before: 'Run 12', after: 'Run 13' }

--- a/apps/homepage/src/app/platform/ai/agents/_components/evals-section.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/evals-section.tsx
@@ -1,0 +1,34 @@
+// apps/homepage/src/app/platform/ai/agents/_components/evals-section.tsx
+
+import { FlaskConical } from 'lucide-react'
+import EvalLoopIllustration from './eval-loop-illustration'
+
+/**
+ * The regression-gate story. No feature columns here: `EvalDetailGrid` carries
+ * them, so this section is headline plus the interactive board.
+ */
+export default function EvalsSection() {
+  return (
+    <section className='border-b bg-background'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-3xl text-center'>
+          <div className='mx-auto inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-muted/40 px-3 py-1 text-xs'>
+            <FlaskConical className='size-3.5 text-emerald-500' />
+            <span className='text-muted-foreground'>Evals · Simulations</span>
+          </div>
+          <h2 className='mt-6 text-balance text-4xl font-semibold md:text-5xl'>
+            Ship agent changes like code.
+          </h2>
+          <p className='mx-auto mt-4 text-balance text-lg text-muted-foreground'>
+            A prompt tweak is a deploy. Run the suite, read the diff, and know exactly what you
+            fixed and what you broke, before a customer finds out.
+          </p>
+        </div>
+
+        <div className='mt-14'>
+          <EvalLoopIllustration />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_mocks/agents-browser-demo.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_mocks/agents-browser-demo.tsx
@@ -1,0 +1,78 @@
+// apps/homepage/src/app/platform/ai/agents/_mocks/agents-browser-demo.tsx
+
+import { ChevronRight, PanelLeft, Plus, Search } from 'lucide-react'
+import { MockAppSidebar, MockBrowserChrome, MockMainPage } from '~/app/platform/ai/_mocks'
+import { cn } from '~/lib/utils'
+import { AGENT_CAST } from '../_components/agent-cast'
+import { MockAgentCard } from './mock-agent-card'
+
+const chat = AGENT_CAST.filter((a) => a.kind === 'chat')
+const internal = AGENT_CAST.filter((a) => a.kind === 'internal')
+
+/**
+ * The hero mock: the real `/app/agents` surface.
+ *
+ * Mirrors `agents-page-content.tsx` (breadcrumb `Kopilot / Agents` + a
+ * `New agent` action, a search toolbar) and `agents-grid-view.tsx` (the
+ * `Chat agents` / `Internal agents` sections over a `ListCard` grid).
+ */
+export function AgentsBrowserDemo({ className }: { className?: string }) {
+  return (
+    <div className={cn('text-left', className)}>
+      <MockBrowserChrome variant='regular' url='app.auxx.ai/app/agents'>
+        <div className='flex h-[520px]'>
+          <MockAppSidebar activeKey='agents' className='hidden md:flex' />
+          <MockMainPage header={<MockAgentsHeader />}>
+            <div className='flex h-full min-h-0 flex-col'>
+              <div className='flex items-center gap-2 border-b border-mock-window-border px-3 py-2'>
+                <span className='inline-flex h-7 flex-1 items-center gap-1.5 rounded-md border border-mock-window-border px-2.5 text-[11px] text-mock-window-muted'>
+                  <Search className='size-3.5' />
+                  Search agents
+                </span>
+              </div>
+
+              <div className='flex flex-col gap-6 p-3'>
+                <Section title='Chat agents' agents={chat} />
+                <Section title='Internal agents' agents={internal} />
+              </div>
+            </div>
+          </MockMainPage>
+        </div>
+      </MockBrowserChrome>
+    </div>
+  )
+}
+
+function Section({ title, agents }: { title: string; agents: typeof AGENT_CAST }) {
+  return (
+    <section className='flex flex-col gap-3'>
+      <h3 className='text-sm font-semibold text-mock-window-muted'>{title}</h3>
+      <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+        {agents.map((agent) => (
+          <MockAgentCard key={agent.id} agent={agent} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+/** `MainPageHeader` with the `Kopilot / Agents` breadcrumb and the create action. */
+function MockAgentsHeader() {
+  return (
+    <div className='flex items-center justify-between gap-3 pb-2 text-xs text-mock-window-foreground'>
+      <div className='flex min-w-0 items-center gap-2 text-mock-window-muted'>
+        <PanelLeft className='size-3.5 shrink-0' />
+        <span className='hidden items-center gap-2 sm:flex'>
+          <span>Kopilot</span>
+          <ChevronRight className='size-3' />
+        </span>
+        <span className='truncate text-mock-window-foreground'>Agents</span>
+      </div>
+
+      <span className='inline-flex shrink-0 items-center gap-1 rounded-md bg-foreground px-2 py-1 text-background'>
+        <Plus className='size-3' />
+        New agent
+      </span>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_mocks/index.ts
+++ b/apps/homepage/src/app/platform/ai/agents/_mocks/index.ts
@@ -1,0 +1,5 @@
+// apps/homepage/src/app/platform/ai/agents/_mocks/index.ts
+
+export { AgentsBrowserDemo } from './agents-browser-demo'
+export { MockAgentCard } from './mock-agent-card'
+export { MockAgentPanel } from './mock-agent-panel'

--- a/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-card.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-card.tsx
@@ -1,0 +1,80 @@
+// apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-card.tsx
+
+import { MessageCircle } from 'lucide-react'
+import Image from 'next/image'
+import { cn } from '~/lib/utils'
+import type { AgentCastMember } from '../_components/agent-cast'
+
+/**
+ * Visual port of `packages/ui/src/components/list-card.tsx` in its default
+ * (vertical tile) layout, as `apps/web/src/components/agents/ui/list/agent-card.tsx`
+ * composes it: avatar media with a status dot, title + `LastUpdated` subtitle,
+ * a one-line description, and a footer of model / kind badges.
+ *
+ * The app's `primary-*` scale is a zinc ramp (`packages/ui/src/styles/global.css`)
+ * and the homepage has no such tokens, so the equivalent zinc values are written
+ * out here rather than imported.
+ */
+export function MockAgentCard({ agent }: { agent: AgentCastMember }) {
+  return (
+    <div className='group relative flex w-full flex-col gap-2 rounded-2xl border bg-mock-window p-3 text-left'>
+      {/* Header: media + heading */}
+      <div className='flex w-full flex-row items-start gap-2'>
+        <div className='relative shrink-0'>
+          <span className='relative flex size-8 items-center justify-center overflow-hidden rounded-xl border'>
+            <Image
+              src={agent.src}
+              alt=''
+              fill
+              sizes='32px'
+              style={{ objectFit: 'cover', objectPosition: agent.headOffset }}
+            />
+          </span>
+          {/* ListCard status dot: `-right-0.5 -top-0.5 size-2.5 border-2`. */}
+          <div className='absolute -right-0.5 -top-0.5 size-2.5 rounded-full border-2 border-mock-window bg-emerald-500' />
+        </div>
+
+        <div className='flex min-w-0 flex-1 flex-col'>
+          <p className='line-clamp-1 text-sm font-semibold text-mock-window-foreground'>
+            {agent.name}
+          </p>
+          <div className='text-xs text-mock-window-muted'>{agent.updated}</div>
+        </div>
+      </div>
+
+      <p className='line-clamp-1 min-h-4 text-sm text-mock-window-muted'>{agent.description}</p>
+
+      {/* Footer badges: model pill + Chat badge, mirroring `agent-card.tsx`. */}
+      <div className='mt-auto flex min-h-6 items-center gap-1'>
+        <MockBadge variant='pill'>{agent.model}</MockBadge>
+        {agent.kind === 'chat' && (
+          <MockBadge variant='outline'>
+            <MessageCircle className='size-3' />
+            Chat
+          </MockBadge>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** `packages/ui/src/components/badge.tsx`, `size='sm'`, pill + outline variants. */
+function MockBadge({
+  variant,
+  children,
+}: {
+  variant: 'pill' | 'outline'
+  children: React.ReactNode
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-[1px] text-xs font-normal',
+        variant === 'pill'
+          ? 'bg-neutral-100 text-neutral-600 ring-1 ring-neutral-300 dark:bg-mock-bubble dark:text-neutral-100 dark:ring-transparent'
+          : 'text-mock-window-foreground ring-1 ring-mock-window-border'
+      )}>
+      {children}
+    </span>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-panel.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-panel.tsx
@@ -1,0 +1,343 @@
+// apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-panel.tsx
+'use client'
+
+import {
+  ChevronRight,
+  Clipboard,
+  Code2,
+  FileText,
+  GitBranch,
+  Hand,
+  ListChecks,
+  Maximize2,
+  Square,
+  Workflow,
+} from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { cn } from '~/lib/utils'
+import type { AgentCastMember } from '../_components/agent-cast'
+import type { ProcedureLine, ProcedureLink, Segment } from '../_components/agent-scripts'
+
+/**
+ * The agent side of the run illustration: the `Persona` editor card, then the
+ * `Procedures` section, then — once selection has happened — the chosen
+ * procedure opening in place to reveal its steps.
+ *
+ * Ported from the real detail tab:
+ * - `persona-editor.tsx` / `prose-editor-card.tsx` for the card chrome: an
+ *   uppercase title in `text-xs font-semibold text-primary-500`, a character
+ *   count, a divider, then copy / expand buttons.
+ * - `procedures-section.tsx` for the section shell (`ListChecks`, the title and
+ *   its one-line description) and `procedure-row.tsx` for the rows (a `TreeRow`
+ *   with a `FileText` icon, the name, the `whenToUse` summary, and a chevron).
+ * - `PromptEditorContent`'s `alwaysShowLineNumbers` for the opened body's
+ *   right-aligned `tabular-nums` gutter.
+ *
+ * Everything is transcribed, not imported: the homepage has no `primary-*`
+ * scale and must not pull `@auxx/lib` into its bundle.
+ */
+
+/**
+ * Inline badges sit *inside* running prose, so they stay a notch smaller than
+ * the surrounding `text-sm` and carry almost no vertical padding. Anything
+ * heavier and the paragraphs read as a stack of chips instead of a sentence.
+ */
+const BADGE =
+  'mx-px inline-flex items-center gap-0.5 rounded border px-1 py-0 align-baseline text-[11px] leading-[18px]'
+
+/** Badge tones, copied from `custom-fields/client.ts`. */
+const TONES = {
+  indigo:
+    'bg-indigo-50 text-indigo-600 border-indigo-200 dark:bg-[#252058] dark:text-[#D0C8FF] dark:border-[#3b3578]',
+  forest:
+    'bg-green-100 text-green-900 border-green-500 dark:bg-[#0f2e21] dark:text-[#7ECFA6] dark:border-[#1a4631]',
+  red: 'bg-red-50 text-red-600 border-black/10 dark:bg-[#4e1b28] dark:text-[#FFD1D1] dark:border-[#692623]',
+  ref: 'bg-muted text-foreground/80 border-black/10 dark:border-white/10',
+} as const
+
+/* -------------------------------------------------------------------------- */
+/* Editor card chrome                                                          */
+/* -------------------------------------------------------------------------- */
+
+function EditorCard({
+  title,
+  count,
+  children,
+  className,
+}: {
+  title: string
+  count: number
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('me-1 rounded-[9px] p-0.5', className)}>
+      <div className='flex h-full flex-col rounded-lg border bg-zinc-200/30 dark:bg-white/[0.03]'>
+        <div className='flex items-center justify-between pl-3 pr-2 pt-1'>
+          <div className='text-xs font-semibold uppercase leading-4 text-zinc-500'>{title}</div>
+          <div className='flex items-center'>
+            <span className='text-xs text-muted-foreground'>{count}</span>
+            <div className='mx-2 h-3 w-px bg-zinc-200 dark:bg-white/15' />
+            <div className='flex items-center space-x-[2px]'>
+              <span className='flex size-6 items-center justify-center rounded-lg text-muted-foreground'>
+                <Clipboard className='size-4' />
+              </span>
+              <span className='flex size-6 items-center justify-center rounded-lg text-muted-foreground'>
+                <Maximize2 className='size-4' />
+              </span>
+            </div>
+          </div>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Procedure prose                                                             */
+/* -------------------------------------------------------------------------- */
+
+function SegmentRun({ segments }: { segments: Segment[] }) {
+  return (
+    <>
+      {segments.map((segment, i) => {
+        const key = `${segment.t}-${i}`
+        if (segment.t === 'text') return <span key={key}>{segment.v} </span>
+        if (segment.t === 'tool' || segment.t === 'ref') {
+          return (
+            <span key={key} className={cn(BADGE, TONES.ref)}>
+              {segment.v}
+            </span>
+          )
+        }
+        if (segment.t === 'code') {
+          return (
+            <span key={key} className={cn(BADGE, TONES.indigo)}>
+              <Code2 className='size-3 shrink-0 opacity-70' />
+              {segment.v}
+            </span>
+          )
+        }
+        if (segment.t === 'subprocedure') {
+          return (
+            <span key={key} className={cn(BADGE, TONES.forest)}>
+              <Workflow className='size-3 shrink-0 opacity-70' />
+              {segment.v}
+            </span>
+          )
+        }
+        return (
+          <span key={key} className={cn(BADGE, TONES.red)}>
+            {segment.v === 'handoff' ? (
+              <Hand className='size-3 shrink-0 opacity-70' />
+            ) : (
+              <Square className='size-3 shrink-0 opacity-70' />
+            )}
+            {segment.v === 'handoff' ? 'Hand off to human' : 'End procedure'}
+          </span>
+        )
+      })}
+    </>
+  )
+}
+
+function Line({
+  line,
+  index,
+  active,
+  agent,
+  onSelect,
+}: {
+  line: ProcedureLine
+  index: number
+  active: boolean
+  agent: AgentCastMember
+  onSelect: (id: string) => void
+}) {
+  const isArm = line.arm != null
+  return (
+    <button
+      type='button'
+      onClick={() => onSelect(line.id)}
+      className={cn(
+        'relative flex w-full gap-2 rounded-md py-0.5 pr-2 text-left transition-colors',
+        active && agent.accent.highlight
+      )}>
+      <span
+        aria-hidden
+        className={cn(
+          'absolute inset-y-0.5 left-0 w-0.5 rounded-full transition-opacity',
+          agent.accent.rule,
+          active ? 'opacity-100' : 'opacity-0'
+        )}
+      />
+      <span className='min-w-6 shrink-0 select-none pt-0.5 text-right text-xs leading-6 tabular-nums text-muted-foreground opacity-50'>
+        {index + 1}
+      </span>
+
+      {isArm && (
+        <>
+          <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-zinc-100 text-zinc-700 dark:bg-white/10 dark:text-zinc-200'>
+            <GitBranch className='size-3.5' />
+          </span>
+          <span className='shrink-0 pt-0.5 text-xs font-semibold uppercase leading-6 tracking-wide text-foreground'>
+            {line.arm === 'if' ? 'If' : 'Else'}
+          </span>
+        </>
+      )}
+
+      <span
+        className={cn(
+          'min-w-0 flex-1 text-sm leading-6',
+          active ? 'text-foreground' : 'text-foreground/75',
+          line.indent && !isArm && 'pl-8'
+        )}>
+        <SegmentRun segments={line.segments} />
+      </span>
+    </button>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Procedure rows                                                              */
+/* -------------------------------------------------------------------------- */
+
+/** A closed `TreeRow`, as `procedure-row.tsx` renders it. */
+function ProcedureRow({
+  link,
+  dimmed,
+  agent,
+  version,
+}: {
+  link: ProcedureLink
+  dimmed: boolean
+  agent: AgentCastMember
+  version: string
+}) {
+  const open = !dimmed
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-md px-2 py-1.5 transition-all',
+        dimmed ? 'opacity-40' : cn('bg-background/70 ring-1', agent.accent.ring)
+      )}>
+      <FileText className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-1.5'>
+          <span className='truncate text-sm font-medium text-foreground'>{link.name}</span>
+          {open && (
+            <span className='shrink-0 rounded bg-muted px-1 font-mono text-[10px] text-muted-foreground'>
+              {version}
+            </span>
+          )}
+        </div>
+        <p className='truncate text-xs text-muted-foreground'>{link.whenToUse}</p>
+      </div>
+      <ChevronRight
+        className={cn(
+          'mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform',
+          open && 'rotate-90'
+        )}
+      />
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+
+export function MockAgentPanel({
+  agent,
+  persona,
+  procedures,
+  selectedId,
+  version,
+  /** Null until `selectProcedure` has run — the list stays closed. */
+  openedId,
+  activeLine,
+  onSelectLine,
+  reduceMotion,
+  className,
+}: {
+  agent: AgentCastMember
+  persona: string
+  procedures: ProcedureLink[]
+  selectedId: string
+  version: string
+  openedId: string | null
+  activeLine: string | undefined
+  onSelectLine: (id: string) => void
+  reduceMotion: boolean | null
+  className?: string
+}) {
+  const opened = procedures.find((p) => p.id === openedId)
+
+  return (
+    // `min-h-0` + a scrollable list below: the panel absorbs the procedure
+    // opening inside its own box instead of growing and shoving the page down.
+    <div className={cn('flex min-h-0 flex-col gap-3', className)}>
+      <EditorCard title='Persona' count={persona.length} className='shrink-0'>
+        <p className='px-3 pb-3 pt-1 text-sm leading-6 text-foreground/75'>{persona}</p>
+      </EditorCard>
+
+      {/* `procedures-section.tsx`: ListChecks + title + one-line description. */}
+      <div className='me-1 flex min-h-0 flex-1 flex-col rounded-lg border bg-zinc-200/30 p-2 dark:bg-white/[0.03]'>
+        <div className='flex items-center gap-1.5 px-1 pb-0.5 pt-1'>
+          <ListChecks className='size-4 text-muted-foreground' />
+          <span className='text-sm font-medium text-foreground'>Procedures</span>
+          <span className='ml-auto text-xs text-muted-foreground'>{procedures.length}</span>
+        </div>
+        <p className='px-1 pb-2 text-xs text-muted-foreground'>
+          Step-by-step playbooks the agent follows for specific situations.
+        </p>
+
+        <div className='flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto'>
+          {procedures.map((link) => {
+            const isOpen = link.id === openedId
+            const isCandidate = openedId == null
+            return (
+              <div key={link.id}>
+                <ProcedureRow
+                  link={link}
+                  dimmed={!isOpen && !isCandidate}
+                  agent={agent}
+                  version={version}
+                />
+
+                <AnimatePresence initial={false}>
+                  {isOpen && opened?.lines && (
+                    <motion.div
+                      initial={reduceMotion ? false : { height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={reduceMotion ? undefined : { height: 0, opacity: 0 }}
+                      transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+                      style={{ overflow: 'hidden' }}>
+                      <div className='mt-1 rounded-md border bg-background/60 px-2 py-1.5'>
+                        {opened.lines.map((line, index) => (
+                          <Line
+                            key={line.id}
+                            line={line}
+                            index={index}
+                            active={line.id === activeLine}
+                            agent={agent}
+                            onSelect={onSelectLine}
+                          />
+                        ))}
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            )
+          })}
+        </div>
+
+        {openedId == null && (
+          <p className='mt-auto px-1 pt-3 text-[11px] italic text-muted-foreground'>
+            Waiting for a message. One of these will be picked, not all of them.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/agents/page.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/page.tsx
@@ -1,0 +1,45 @@
+// apps/homepage/src/app/platform/ai/agents/page.tsx
+import type { Metadata } from 'next'
+import { config } from '~/lib/config'
+import FooterSection from '../../../_components/main/footer-section'
+import Header from '../../../_components/main/header'
+import { BreadcrumbJsonLd } from '../../../_components/seo/breadcrumb-json-ld'
+import AgentRosterSection from './_components/agent-roster-section'
+import AgentRunSection from './_components/agent-run-section'
+import AgentsCrossLinks from './_components/agents-cross-links'
+import AgentsFinalCta from './_components/agents-final-cta'
+import AgentsHero from './_components/agents-hero'
+import EvalDetailGrid from './_components/eval-detail-grid'
+import EvalsSection from './_components/evals-section'
+
+export const metadata: Metadata = {
+  alternates: { canonical: '/platform/ai/agents' },
+  title: `AI Agents with Procedures & Evals | ${config.shortName}`,
+  description: `${config.shortName} agents follow a playbook you write in plain language, call only the tools you scope to them, and are proven by simulated evals before they reach a customer.`,
+}
+
+export default function AgentsPage() {
+  return (
+    <div id='root' className='bg-background relative h-screen overflow-y-auto'>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', href: 'https://auxx.ai' },
+          { name: 'Platform', href: 'https://auxx.ai/platform' },
+          { name: 'AI', href: 'https://auxx.ai/platform/ai/kopilot' },
+          { name: 'Agents' },
+        ]}
+      />
+      <Header />
+      <main>
+        <AgentsHero />
+        <AgentRosterSection />
+        <AgentRunSection />
+        <EvalsSection />
+        <EvalDetailGrid />
+        <AgentsCrossLinks />
+        <AgentsFinalCta />
+      </main>
+      <FooterSection />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-agents-cta.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-agents-cta.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link'
 import { type CSSProperties, type MouseEvent, useRef, useState } from 'react'
 import { ShaderGradientBg } from '~/app/_components/shader-gradient-bg'
 import { Button } from '~/components/ui/button'
-import { config } from '~/lib/config'
 
 interface Character {
   src: string
@@ -130,7 +129,7 @@ export default function KopilotAgentsCta() {
                 asChild
                 size='sm'
                 className='bg-white text-zinc-900 hover:bg-white/90 shadow-md'>
-                <Link href={config.urls.signup}>Get started</Link>
+                <Link href='/platform/ai/agents'>See what agents can do</Link>
               </Button>
             </div>
           </div>

--- a/apps/homepage/src/app/platform/crm/_components/crm-hero.tsx
+++ b/apps/homepage/src/app/platform/crm/_components/crm-hero.tsx
@@ -3,10 +3,18 @@
 import { Database } from 'lucide-react'
 import Link from 'next/link'
 import { SectionBottomFade } from '~/app/_components/main/section-bottom-fade'
+import { SectionTopFade } from '~/app/_components/main/section-top-fade'
 import { Button } from '~/components/ui/button'
 import { config } from '~/lib/config'
 import { cn } from '~/lib/utils'
 import { CrmBrowserDemo, EntityCanvas, EntityCardsGrid } from '../_mocks'
+
+/**
+ * `HeroSection`'s `bg-muted/30`, resolved to a flat colour so the fade has a
+ * real RGB triple to interpolate from. Same expression `CrmCenterSection` uses
+ * for the same neighbour.
+ */
+const HOME_HERO_COLOR = 'color-mix(in oklab, var(--color-muted) 30%, var(--color-background))'
 
 interface CrmHeroProps {
   as?: 'h1' | 'h2'
@@ -15,6 +23,13 @@ interface CrmHeroProps {
    * into the next section's color. Drops the hard `border-b` when active.
    */
   bottomFadeColor?: string
+  /**
+   * Colour of the section above. Only used when this renders as an `h2` (i.e.
+   * stacked under another page's hero) — as an `h1` it *is* the top of the
+   * page and has nothing to blend from. Defaults to the main homepage hero's
+   * colour, which is the only place it currently sits second.
+   */
+  topFadeColor?: string
 }
 
 /**
@@ -22,7 +37,12 @@ interface CrmHeroProps {
  * connected with dotted SVG relationship lines, flowing down into a mock
  * app browser showing a contacts records view.
  */
-export default function CrmHero({ as: Heading = 'h1', bottomFadeColor }: CrmHeroProps) {
+export default function CrmHero({
+  as: Heading = 'h1',
+  bottomFadeColor,
+  topFadeColor = HOME_HERO_COLOR,
+}: CrmHeroProps) {
+  const showTopFade = Heading === 'h2'
   return (
     <section className={cn('relative overflow-hidden', !bottomFadeColor && 'border-b')}>
       {/* Dot-grid background, faded toward the edges. */}
@@ -34,6 +54,7 @@ export default function CrmHero({ as: Heading = 'h1', bottomFadeColor }: CrmHero
         aria-hidden
         className='pointer-events-none absolute inset-x-0 top-0 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/8,_transparent_60%)]'
       />
+      {showTopFade && <SectionTopFade fromColor={topFadeColor} />}
       {bottomFadeColor && <SectionBottomFade toColor={bottomFadeColor} />}
 
       <div className='relative mx-auto max-w-6xl px-6 pb-20 pt-24 md:pt-32 lg:pt-36'>

--- a/apps/homepage/src/app/platform/sequences/_components/platform-cross-links.tsx
+++ b/apps/homepage/src/app/platform/sequences/_components/platform-cross-links.tsx
@@ -1,6 +1,6 @@
 // apps/homepage/src/app/platform/sequences/_components/platform-cross-links.tsx
 
-import { BarChart3, GitBranch, MessagesSquare, Truck, Users } from 'lucide-react'
+import { BarChart3, Bot, GitBranch, MessagesSquare, Truck, Users } from 'lucide-react'
 import Link from 'next/link'
 
 const links = [
@@ -31,6 +31,13 @@ const links = [
     description: 'Sends from a connected mailbox — and their reply lands in your shared inbox.',
     href: '/platform/messaging',
     tone: 'text-blue-600 dark:text-blue-400',
+  },
+  {
+    icon: Bot,
+    name: 'Agents',
+    description: 'When a reminder needs a decision instead of a timer, an agent takes it.',
+    href: '/platform/ai/agents',
+    tone: 'text-violet-600 dark:text-violet-400',
   },
   {
     icon: BarChart3,

--- a/apps/homepage/src/app/sitemap.ts
+++ b/apps/homepage/src/app/sitemap.ts
@@ -141,6 +141,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${baseUrl}/platform/ai/agents`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/platform/reporting`,
       lastModified: new Date(),
       changeFrequency: 'monthly',


### PR DESCRIPTION
New `/platform/ai/agents` marketing page, plus the procedure-run section reused on the main homepage.

## Sections

Hero over a mock of the real `/app/agents` list · five-portrait roster · interactive procedure run · eval suite loop · numbered detail grid · cross-links · CTA.

## Ported, not invented

Both interactives are transcriptions of real product surfaces, so they stay honest as the app changes:

| Mock | Ported from |
|---|---|
| Agent list | `agents-page-content.tsx` (Kopilot/Agents breadcrumb, search toolbar, Chat/Internal sections) + `ListCard` as `agent-card.tsx` composes it |
| Left panel | `persona-editor.tsx` + `procedures-section.tsx` + `procedure-row.tsx` |
| Opened procedure | `prose-editor-card.tsx` with its `alwaysShowLineNumbers` gutter, arms from `condition-case-node-view.tsx`, badge tones from `custom-fields/client.ts` |
| Run column | the existing Kopilot mocks (`MockUserMessage`, `MockAssistantSlot`, `MockToolStatusPill`) |

The homepage has no `primary-*` scale and must not pull `@auxx/lib` into its bundle, so those tones are literal class strings rather than imports.

## The run illustration follows the real selection contract

An agent holds several procedures and exactly one is picked per turn. The panel opens as persona + procedure list, and the selected procedure expands in place once selection is revealed. Each agent's note names the layer that actually did the work — a classifier call, a scheduled trigger that names its procedure, or a ruleset prefilter that dropped a candidate first.

## Copy grounding

Everything maps to `docs/agents-architecture-guide.md`. Deliberately **not** claimed: self-healing agents. What exists is Kopilot reading a suite diff, editing the procedure and re-running, in one conversation with a human watching — so the page says that instead.

## Homepage changes

- Run section moved directly after the hero (11% down, was 54%) so the h1's agent promise is paid off in the first scroll
- Dropped `WorkflowAnimationSection` + `WorkflowContent` (page went 17.8k → 16.2k px)
- `CrmHero` gains a `SectionTopFade` when rendered as an `h2` under another hero

## Wiring

Nav (AI CRM group), footer, sitemap, `KopilotAgentsCta` repointed to the new page, and a reciprocal Agents card on the sequences cross-links.

## Verification

`pnpm lint` and `tsc --noEmit` clean across `apps/homepage`; no console errors; rendered and checked at 1440px.

**Not verified:** dark mode, the 390/768 breakpoints, and the per-agent portrait crop offsets in `agent-cast.ts` (first guesses that want a side-by-side tuning pass).