### PR TITLE
fix(ci): prepare the workspace before the web typecheck ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # A fresh checkout is COLD and `apps/web` cannot be typechecked in that
+      # state. `@auxx/chat` resolves through `dist/`, and `next-env.d.ts` (which
+      # declares `*.png` and friends) is gitignored and generated — so both are
+      # present on a dev laptop and absent here. Without this step the ratchet
+      # reports two phantom TS2307s that exist only in CI.
+      #
+      # This is not cosmetic. An unresolved module makes every import from it
+      # `any`, which SUPPRESSES downstream errors — so a cold typecheck is more
+      # permissive than a warm one and would let real breakage through. The
+      # baseline is recorded warm; CI has to match.
+      #
+      # Targeted rather than `turbo build --filter=@auxx/web^...` to keep the job
+      # short. If a NEW dist-consuming dependency is added to web, this step is
+      # where to add it — the ratchet will name the unresolved file.
+      - name: Prepare workspace for typecheck
+        if: matrix.package == 'web'
+        run: |
+          pnpm --filter @auxx/chat build
+          pnpm --filter @auxx/web exec next typegen
+
       - name: Typecheck ratchet
         env:
           # Under the ~7GB of a standard runner. Raising this above physical RAM


### PR DESCRIPTION
🔴 **`main` is red.** #1412's ratchet failed on its first run with two `TS2307`s that exist only in CI. This fixes it forward.

```
src/components/global/login/logo.tsx      TS2307
src/server/api/routers/chat.ts            TS2307
```

## Diagnosis

Neither is a code error — both are **cold-checkout artifacts**:

- `@auxx/chat` resolves through `dist/`, and CI never builds it (`pnpm install --frozen-lockfile` only).
- `next-env.d.ts` — which pulls in `next/image-types/global`, the declaration behind `import LogoImg from '*.png'` — is **gitignored and generated**.

Both are present on a dev laptop, which is where I recorded the baseline, and absent on a runner. My mistake in #1412: I validated the ratchet's logic but recorded its baseline warm and never simulated a cold tree.

**Good news from that run:** it was *not* an OOM. `apps/web` completed in ~2 minutes inside the 6144MB heap, and both jobs got runners — so the two risks I flagged in #1412 are both retired.

## Why prepare the workspace instead of re-recording the baseline

Re-recording would have been one line and green immediately. It's the wrong fix: **a cold typecheck is unsound, not just noisy.** An unresolved module makes every import from it `any`, which *suppresses* downstream errors — so the cold run is strictly more permissive than the local one. Baking that in would make CI weaker than the check developers run, and permanently divergent from it. The ratchet would then be quietly worth less than it appears, which is the exact failure mode it was built to end.

## The fix

```yaml
- name: Prepare workspace for typecheck
  if: matrix.package == 'web'
  run: |
    pnpm --filter @auxx/chat build
    pnpm --filter @auxx/web exec next typegen
```

Targeted rather than `turbo build --filter=@auxx/web^...` to keep the job short. If a new dist-consuming dependency reaches web, this step is where to add it — the ratchet names the unresolved file, so the signal points right at it.

`lib` passed cold at exactly its 3716 baseline, so it gets no build step — adding one might shift its count for no benefit.

## Verification

- `pnpm --filter @auxx/chat build` → exit 0
- `pnpm --filter @auxx/web exec next typegen` → exit 0, **and regenerates `next-env.d.ts`** — confirmed by deleting the file first and watching it come back carrying the `next/image-types/global` reference. That was the load-bearing check; without it the `logo.tsx` error would have survived and this would be a second red run.

⚠️ Worth letting this one's CI go green before merging — that is the only place the cold path actually runs.