### PR TITLE
fix(ci): exclude generated .next output from the typecheck ratchet

### DIFF
--- a/scripts/ci/typecheck-ratchet.js
+++ b/scripts/ci/typecheck-ratchet.js
@@ -56,13 +56,23 @@ const PACKAGES = {
 /** `src/foo.ts(12,34): error TS2367: ...` → `{ file, code }`. */
 const ERROR_LINE = /^(.+?)\((\d+),(\d+)\): error (TS\d+):/
 
+/** Path segments whose errors are not source errors. See {@link collectErrors}. */
+const GENERATED = ['node_modules', '.next/']
+
 /**
  * Run `tsc --noEmit` in one package and tally errors by `<file>::<code>`.
  *
  * `tsc` exits non-zero whenever it reports anything, so the exit code is
- * discarded and stdout is parsed instead. Errors under `node_modules` are
- * dropped: they vary with the installed dependency tree rather than with the
- * code under review, and would make the baseline machine-dependent.
+ * discarded and stdout is parsed instead.
+ *
+ * GENERATED paths are dropped, and both exclusions are load-bearing:
+ *  - `node_modules` varies with the installed dependency tree, not the code
+ *    under review, and would make the baseline machine-dependent.
+ *  - `.next` is Next's own output. `.next/types/validator.ts` is written by
+ *    `next typegen` and its error count depends on WHEN it was generated, so a
+ *    laptop with a warm `.next` and a runner that just generated one disagree.
+ *    Nobody can fix those errors by editing them — they are a projection of the
+ *    route tree — so tracking them only produces unfixable red.
  */
 function collectErrors(name) {
   const { dir } = PACKAGES[name]
@@ -82,8 +92,9 @@ function collectErrors(name) {
     const match = ERROR_LINE.exec(line.trim())
     if (!match) continue
     const [, file, , , code] = match
-    if (file.includes('node_modules')) continue
-    const key = `${file.replaceAll('\\', '/')}::${code}`
+    const path = file.replaceAll('\\', '/')
+    if (GENERATED.some((segment) => path.includes(segment))) continue
+    const key = `${path}::${code}`
     counts[key] = (counts[key] ?? 0) + 1
   }
   return counts


### PR DESCRIPTION
🔴 **`main` is red again** — second failure of `Typecheck (web)`, different cause. This one is my script's bug, not the app's.

#1413's workspace-prepare step worked: both `TS2307`s are gone. But `next typegen` then writes `.next/types/validator.ts`, and the ratchet counted its 7 `TS2344`s as new.

```
.next/types/validator.ts  TS2344  0 -> 7
```

## Why it's excluded, not baselined

That file is **Next's own output, not source**:

- Its error count depends on *when* it was generated, so a laptop with a warm `.next` and a runner that just made one will always disagree.
- Nobody can fix those errors by editing them — the file is a projection of the route tree.

Tracking it produces permanently unfixable red. `node_modules` was already excluded for exactly this reason (machine-dependent, not the code under review); `.next` is the same idea and I only wrote half of it. Both now live in one `GENERATED` list with the reasoning stated at the parser.

## Validated against a cold tree this time

Two red merges came from recording the baseline on a warm laptop and never simulating a runner. So instead of guessing a third time, I cloned `main` to a temp dir and replayed CI exactly — `pnpm install --frozen-lockfile`, `@auxx/chat build`, `next typegen`, ratchet at `TYPECHECK_HEAP_MB=6144` — after confirming `.next`, `packages/chat/dist` and `next-env.d.ts` were all genuinely absent:

```
web: no new type errors (3986 total, baseline 3986)   exit 0
lib: no new type errors (3716 total, baseline 3716)   exit 0
```

That is the check that should have gated #1412.

## ⚠️ Note for whoever else is working on TypeScript right now

This ratchet is live on `main` and will affect your PRs:

- **Fixing errors never fails the build.** Improvements are reported, not enforced — you won't be asked to update `typecheck-baseline.json` just because you deleted errors. It prints the `--update` command if you want to tighten it.
- **Adding errors will fail your PR**, including in files you didn't touch — that is the whole point, since a shared-vocabulary rename breaks files no one edited.
- **If you land a large refactor that legitimately relocates existing errors between files**, re-record with `node scripts/ci/typecheck-ratchet.js --update --package <lib|web>` and say so in the PR. Do not re-record to silence genuinely new errors.
- **Baseline conflicts** are plain-JSON and sorted by key, so they merge predictably, but two people re-recording at once will still collide.