### PR TITLE
fix(mail): stop a revoked thread refetching itself in a loop

### DIFF
--- a/apps/web/src/components/threads/hooks/use-messages-notfound-gate.test.tsx
+++ b/apps/web/src/components/threads/hooks/use-messages-notfound-gate.test.tsx
@@ -1,0 +1,107 @@
+// apps/web/src/components/threads/hooks/use-messages-notfound-gate.test.tsx
+//
+// `listByThread` answers a lens denial with NOT_FOUND, and a 404 is not a state
+// this query recovers from by asking again. Its own `!cachedList` gate cannot
+// stop it — no list is cached precisely BECAUSE the fetch failed — so the query
+// stayed armed and refired on every focus, remount and realtime reconnect.
+//
+// The gate reads the thread store's tombstone rather than the query's own error,
+// because three of the four `useMessages` callers pass no `enabled` at all
+// (`chat-panel/messages`, `thread-messages`, `use-thread-counterparty`). Only
+// `thread-details` gates on `!!thread`, so the eviction alone would not disarm
+// the others.
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  lists: new Map<string, unknown>(),
+  notFoundIds: new Set<string>(),
+  lastOptions: undefined as { enabled?: boolean } | undefined,
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    message: {
+      listByThread: {
+        useQuery: (_input: unknown, options: { enabled?: boolean }) => {
+          h.lastOptions = options
+          return { data: undefined, isLoading: false, refetch: vi.fn() }
+        },
+      },
+    },
+  },
+}))
+
+vi.mock('../store', () => ({
+  useMessageListStore: (selector: (s: unknown) => unknown) =>
+    selector({ lists: h.lists, setList: vi.fn() }),
+  useMessageStore: (selector: (s: unknown) => unknown) =>
+    selector({ messages: new Map(), setMessages: vi.fn() }),
+  useParticipantStore: (selector: (s: unknown) => unknown) =>
+    selector({ requestParticipant: vi.fn() }),
+  useThreadStore: (selector: (s: unknown) => unknown) => selector({ notFoundIds: h.notFoundIds }),
+}))
+
+const { useMessages } = await import('./use-messages')
+
+beforeEach(() => {
+  h.lists = new Map()
+  h.notFoundIds = new Set()
+  h.lastOptions = undefined
+})
+
+describe('useMessages — the not-found gate', () => {
+  it('is enabled for a thread the store has no tombstone for', () => {
+    renderHook(() => useMessages({ threadId: 'thr_1' }))
+
+    expect(h.lastOptions?.enabled).toBe(true)
+  })
+
+  it('DISARMS once the thread is tombstoned — the retry loop this fixes', () => {
+    h.notFoundIds.add('thr_1')
+
+    renderHook(() => useMessages({ threadId: 'thr_1' }))
+
+    expect(h.lastOptions?.enabled).toBe(false)
+  })
+
+  it('disarms callers that pass no `enabled` of their own', () => {
+    h.notFoundIds.add('thr_1')
+
+    // `chat-panel/messages`, `thread-messages` and `use-thread-counterparty`
+    // all call it exactly like this.
+    renderHook(() => useMessages({ threadId: 'thr_1' }))
+
+    expect(h.lastOptions?.enabled).toBe(false)
+  })
+
+  it('tombstones one thread without disarming another', () => {
+    h.notFoundIds.add('thr_1')
+
+    renderHook(() => useMessages({ threadId: 'thr_2' }))
+
+    expect(h.lastOptions?.enabled).toBe(true)
+  })
+
+  it('re-arms when the tombstone clears — a re-grant must refetch', () => {
+    h.notFoundIds.add('thr_1')
+    const { rerender } = renderHook(() => useMessages({ threadId: 'thr_1' }))
+    expect(h.lastOptions?.enabled).toBe(false)
+
+    // `forceRequestThread` clears `notFoundIds`, then the batch repopulates.
+    h.notFoundIds = new Set()
+    rerender()
+
+    expect(h.lastOptions?.enabled).toBe(true)
+  })
+
+  it('still respects the caller `enabled` and the cached-list gate', () => {
+    renderHook(() => useMessages({ threadId: 'thr_1', enabled: false }))
+    expect(h.lastOptions?.enabled).toBe(false)
+
+    h.lists.set('thr_1', { messageIds: [], total: 0, fetchedAt: 0 })
+    renderHook(() => useMessages({ threadId: 'thr_1' }))
+    expect(h.lastOptions?.enabled).toBe(false)
+  })
+})

--- a/apps/web/src/components/threads/hooks/use-messages.ts
+++ b/apps/web/src/components/threads/hooks/use-messages.ts
@@ -9,6 +9,7 @@ import {
   useMessageListStore,
   useMessageStore,
   useParticipantStore,
+  useThreadStore,
 } from '../store'
 
 interface UseMessagesOptions {
@@ -45,6 +46,20 @@ export function useMessages({ threadId, enabled = true }: UseMessagesOptions): U
 
   const messageIds = cachedList?.messageIds ?? []
 
+  // The thread lane's tombstone, honoured here too. `listByThread` answers a
+  // lens denial with NOT_FOUND (deliberately — mail hides existence rather than
+  // admitting a thread it won't show), and a 404 is not a state this query can
+  // recover from by asking again. Without this the query stays armed forever:
+  // `!cachedList` is true precisely because the fetch failed, so every window
+  // focus, remount and realtime reconnect fires another round.
+  //
+  // Read from the store rather than the query's own error, because the three
+  // other `useMessages` callers pass no `enabled` gate at all — the tombstone
+  // has to disarm them too, not just `thread-details`.
+  const isThreadNotFound = useThreadStore(
+    useCallback((state) => (threadId ? state.notFoundIds.has(threadId) : false), [threadId])
+  )
+
   // Get all messages from store (useShallow prevents infinite loops)
   const messages = useMessageStore(
     useShallow((s) =>
@@ -61,7 +76,7 @@ export function useMessages({ threadId, enabled = true }: UseMessagesOptions): U
   const { data, isLoading, refetch } = api.message.listByThread.useQuery(
     { threadId: threadId! },
     {
-      enabled: enabled && !!threadId && !cachedList,
+      enabled: enabled && !!threadId && !cachedList && !isThreadNotFound,
       staleTime: 30_000,
     }
   )

--- a/apps/web/src/components/threads/providers/thread-data-provider.tsx
+++ b/apps/web/src/components/threads/providers/thread-data-provider.tsx
@@ -33,6 +33,7 @@ export function ThreadDataProvider({ children }: ThreadDataProviderProps) {
     startBatch: () => useThreadStore.getState().startBatch(),
     completeBatch: (items, notFoundIds) =>
       useThreadStore.getState().completeBatch(items, notFoundIds),
+    failBatch: (ids) => useThreadStore.getState().failBatch(ids),
     fetcher: (ids) => fetchThreads({ ids }),
     label: 'Thread',
   })

--- a/apps/web/src/components/threads/providers/use-batch-drain.ts
+++ b/apps/web/src/components/threads/providers/use-batch-drain.ts
@@ -10,6 +10,14 @@ export interface BatchDrainOpts<T extends { id: string }> {
   getPendingSize: () => number
   startBatch: () => string[]
   completeBatch: (items: T[], notFoundIds: string[]) => void
+  /**
+   * The batch fetch itself threw (network down, 500, rate limit) — which is NOT
+   * the same answer as "the server looked and these do not exist", even though
+   * the default below conflates them for back-compat. Supply this wherever the
+   * store does something irreversible with a not-found id: the thread store
+   * EVICTS on not-found, and a dropped connection must not empty the mailbox.
+   */
+  failBatch?: (ids: string[]) => void
   fetcher: (ids: string[]) => Promise<T[]>
   label: string
 }
@@ -50,7 +58,9 @@ export function useBatchDrain<T extends { id: string }>(opts: BatchDrainOpts<T>)
             optsRef.current.completeBatch(items, notFoundIds)
           } catch (error) {
             console.error(`${optsRef.current.label} batch fetch failed:`, error)
-            optsRef.current.completeBatch([], batch)
+            const { failBatch, completeBatch } = optsRef.current
+            if (failBatch) failBatch(batch)
+            else completeBatch([], batch)
           }
         }
       } finally {

--- a/apps/web/src/components/threads/store/thread-store-revoke-eviction.test.ts
+++ b/apps/web/src/components/threads/store/thread-store-revoke-eviction.test.ts
@@ -1,0 +1,128 @@
+// apps/web/src/components/threads/store/thread-store-revoke-eviction.test.ts
+//
+// A revoked thread must leave the store, and a broken connection must not.
+//
+// `thread.getByIds` answers a lens denial by simply omitting the thread, which
+// `use-batch-drain` turns into a not-found id. `completeBatch` used to tombstone
+// that id while LEAVING the stale row in `threads`, which had two consequences:
+// `thread-details` renders "Thread not found" only on `!thread`, so the revoked
+// viewer kept seeing the header/subject/participants; and `useMessages`' gate is
+// `enabled: !!thread`, so it refetched a 404 on every focus and reconnect.
+//
+// The hazard the eviction introduces is the second half of this file: the drain
+// reports a FAILED fetch as "the whole batch is not found", so without a
+// separate signal a dropped connection would empty the mailbox.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useMessageListStore } from './message-list-store'
+import { type ThreadMeta, useThreadStore } from './thread-store'
+
+const thread = (id: string, myLens: ThreadMeta['myLens'] = 'read') =>
+  ({
+    id,
+    subject: 'Refund request',
+    status: 'OPEN',
+    lastMessageAt: '2026-07-29T10:00:00.000Z',
+    myLens,
+  }) as unknown as ThreadMeta
+
+beforeEach(() => {
+  useThreadStore.getState().reset()
+  useMessageListStore.getState().invalidateAll()
+})
+
+describe('completeBatch — a thread that came back not-found', () => {
+  it('EVICTS the stale row, so `!thread` consumers stop rendering it', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1')], [])
+    expect(useThreadStore.getState().threads.get('thr_1')).toBeDefined()
+
+    // The revoke: `visibility:changed` → `forceRequestThread` → the thread is
+    // no longer in the response.
+    useThreadStore.getState().completeBatch([], ['thr_1'])
+
+    expect(useThreadStore.getState().threads.has('thr_1')).toBe(false)
+    expect(useThreadStore.getState().notFoundIds.has('thr_1')).toBe(true)
+  })
+
+  it('drops the message id list — what makes the bodies reachable', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1')], [])
+    useMessageListStore
+      .getState()
+      .setList('thr_1', { messageIds: ['msg_1', 'msg_2'], total: 2, fetchedAt: 0 })
+
+    useThreadStore.getState().completeBatch([], ['thr_1'])
+
+    expect(useMessageListStore.getState().lists.has('thr_1')).toBe(false)
+  })
+
+  it('leaves other threads in the same batch alone', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1'), thread('thr_2')], [])
+
+    useThreadStore.getState().completeBatch([thread('thr_2')], ['thr_1'])
+
+    expect(useThreadStore.getState().threads.has('thr_1')).toBe(false)
+    expect(useThreadStore.getState().threads.has('thr_2')).toBe(true)
+  })
+
+  it('clears loadingIds either way', () => {
+    useThreadStore.getState().requestThread('thr_1')
+    useThreadStore.getState().startBatch()
+    expect(useThreadStore.getState().loadingIds.has('thr_1')).toBe(true)
+
+    useThreadStore.getState().completeBatch([], ['thr_1'])
+
+    expect(useThreadStore.getState().loadingIds.has('thr_1')).toBe(false)
+  })
+
+  it('a re-grant repopulates — eviction is not a tombstone', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1')], [])
+    useThreadStore.getState().completeBatch([], ['thr_1'])
+
+    // `forceRequestThread` is the only bypass that clears `notFoundIds`.
+    useThreadStore.getState().forceRequestThread('thr_1')
+    expect(useThreadStore.getState().startBatch()).toContain('thr_1')
+    useThreadStore.getState().completeBatch([thread('thr_1', 'read')], [])
+
+    expect(useThreadStore.getState().threads.get('thr_1')?.myLens).toBe('read')
+    expect(useThreadStore.getState().notFoundIds.has('thr_1')).toBe(false)
+  })
+})
+
+describe('failBatch — the fetch itself threw', () => {
+  it('does NOT evict: a dropped connection is not a revoke', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1'), thread('thr_2')], [])
+    useThreadStore.getState().requestThread('thr_3')
+    useThreadStore.getState().startBatch()
+
+    // This is what `use-batch-drain` calls in its catch block. Routing it to
+    // `completeBatch([], batch)` — the old behaviour — is what this pins.
+    useThreadStore.getState().failBatch(['thr_1', 'thr_2', 'thr_3'])
+
+    expect(useThreadStore.getState().threads.has('thr_1')).toBe(true)
+    expect(useThreadStore.getState().threads.has('thr_2')).toBe(true)
+  })
+
+  it('does NOT tombstone, so the ids can be requested again', () => {
+    useThreadStore.getState().requestThread('thr_3')
+    useThreadStore.getState().startBatch()
+
+    useThreadStore.getState().failBatch(['thr_3'])
+
+    expect(useThreadStore.getState().notFoundIds.has('thr_3')).toBe(false)
+    expect(useThreadStore.getState().loadingIds.has('thr_3')).toBe(false)
+
+    useThreadStore.getState().requestThread('thr_3')
+    expect(useThreadStore.getState().pendingIds.has('thr_3')).toBe(true)
+  })
+
+  it('keeps the message list — nothing was revoked', () => {
+    useThreadStore.getState().completeBatch([thread('thr_1')], [])
+    useMessageListStore
+      .getState()
+      .setList('thr_1', { messageIds: ['msg_1'], total: 1, fetchedAt: 0 })
+
+    useThreadStore.getState().failBatch(['thr_1'])
+
+    expect(useMessageListStore.getState().lists.has('thr_1')).toBe(true)
+  })
+})

--- a/apps/web/src/components/threads/store/thread-store.ts
+++ b/apps/web/src/components/threads/store/thread-store.ts
@@ -10,6 +10,10 @@ import type { RecordId } from '@auxx/types/resource'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
+// Direct module import, NOT the `../store` barrel — the barrel re-exports this
+// file, so going through it would close an import cycle. `message-list-store`
+// imports nothing from here, so this direction is safe.
+import { useMessageListStore as messageListStore } from './message-list-store'
 
 /** Re-export filter type for convenience */
 export type { ThreadClientFilter as ThreadFilter }
@@ -265,6 +269,13 @@ interface ThreadStoreState {
   forceRequestThread: (id: string) => void
   startBatch: () => string[]
   completeBatch: (threads: ThreadMeta[], notFoundIds: string[]) => void
+  /**
+   * The batch fetch threw. Releases the ids so a later request can retry, and
+   * deliberately does NOT tombstone: `completeBatch`'s not-found arm evicts, and
+   * a dropped connection is not the server telling us the viewer may not see
+   * these threads.
+   */
+  failBatch: (ids: string[]) => void
 
   // Scheduled message CRUD
   setScheduledMessages: (messages: ScheduledMessageMeta[]) => void
@@ -607,7 +618,32 @@ export const useThreadStore = create<ThreadStoreState>()(
             state.loadingIds.delete(id)
             if (state.deletedIds.has(id)) continue
             state.notFoundIds.add(id)
+
+            // EVICT. `forceRequestThread`'s no-eviction rule covers the window
+            // BEFORE the answer lands (don't blank the pane mid-read); once the
+            // answer is "you may not see this", the entry it was protecting is
+            // the leak. A revoke re-requests through `visibility:changed` and
+            // comes back here, so without this delete the stale row lives
+            // forever: `thread-details` renders its "Thread not found" branch
+            // only on `!thread`, so the revoked viewer kept seeing the header,
+            // subject and participants — and `useMessages`' `enabled: !!thread`
+            // stayed true, refetching a 404 on every focus and reconnect.
+            // Re-granting is unaffected: `forceRequestThread` clears
+            // `notFoundIds` and re-fetches, which repopulates the map.
+            state.threads.delete(id)
+
+            // The id list is what makes the message bodies reachable. Bodies
+            // themselves are handled by `clearHtmlBodyCache()` on
+            // `visibility:changed` (plan 45 §1.6); this is the metadata twin.
+            // Dropping it also re-arms `useMessages`' `!cachedList` gate, which
+            // is safe only because that hook now also checks `notFoundIds`.
+            messageListStore.getState().invalidate(id)
           }
+        }),
+
+      failBatch: (ids) =>
+        set((state) => {
+          for (const id of ids) state.loadingIds.delete(id)
         }),
 
       // ═══════════════════════════════════════════════════════════════

--- a/apps/web/src/trpc/query-client.test.ts
+++ b/apps/web/src/trpc/query-client.test.ts
@@ -1,0 +1,72 @@
+// apps/web/src/trpc/query-client.test.ts
+//
+// The retry predicate used to exempt 401/403 only, so every other refusal cost
+// four round trips per trigger. Mail answers a lens denial with NOT_FOUND (it
+// hides existence rather than admitting a thread it won't show), so a revoked
+// thread left open re-asked `message.listByThread` four times on every window
+// focus, remount and realtime reconnect — and got the same 404 each time.
+
+import { describe, expect, it } from 'vitest'
+import { createQueryClient, errorStatus } from './query-client'
+
+/** The shape a tRPC HTTP link puts on a client error. */
+const trpcError = (httpStatus: number, code?: string) => ({ data: { httpStatus, code } })
+
+const retry = () => {
+  const fn = createQueryClient().getDefaultOptions().queries?.retry
+  if (typeof fn !== 'function') throw new Error('retry predicate is not a function')
+  return fn as (failureCount: number, error: unknown) => boolean
+}
+
+describe('retry predicate', () => {
+  it('does not retry a 404 — the bug this exists for', () => {
+    expect(retry()(0, trpcError(404, 'NOT_FOUND'))).toBe(false)
+  })
+
+  it.each([
+    [400, 'BAD_REQUEST'],
+    [401, 'UNAUTHORIZED'],
+    [403, 'FORBIDDEN'],
+    [404, 'NOT_FOUND'],
+    [409, 'CONFLICT'],
+    [422, 'UNPROCESSABLE_CONTENT'],
+  ])('does not retry %i — the server already considered it', (status, code) => {
+    expect(retry()(0, trpcError(status, code))).toBe(false)
+  })
+
+  it.each([
+    [408, 'TIMEOUT'],
+    [429, 'TOO_MANY_REQUESTS'],
+  ])('DOES retry %i — the two 4xx that mean "try again"', (status, code) => {
+    expect(retry()(0, trpcError(status, code))).toBe(true)
+  })
+
+  it('retries a 500 up to three times', () => {
+    const fn = retry()
+    expect(fn(0, trpcError(500, 'INTERNAL_SERVER_ERROR'))).toBe(true)
+    expect(fn(2, trpcError(500, 'INTERNAL_SERVER_ERROR'))).toBe(true)
+    expect(fn(3, trpcError(500, 'INTERNAL_SERVER_ERROR'))).toBe(false)
+  })
+
+  it('retries an error with no status at all — a network failure IS transient', () => {
+    expect(retry()(0, new Error('Failed to fetch'))).toBe(true)
+    expect(retry()(3, new Error('Failed to fetch'))).toBe(false)
+  })
+})
+
+describe('errorStatus', () => {
+  it('prefers httpStatus', () => {
+    expect(errorStatus({ data: { httpStatus: 404, code: 'NOT_FOUND' } })).toBe(404)
+  })
+
+  it('falls back to the code when httpStatus is absent (a server-side caller)', () => {
+    expect(errorStatus({ data: { code: 'NOT_FOUND' } })).toBe(404)
+    expect(errorStatus({ data: { code: 'FORBIDDEN' } })).toBe(403)
+  })
+
+  it('is undefined for a non-tRPC error, so those keep retrying', () => {
+    expect(errorStatus(new Error('boom'))).toBeUndefined()
+    expect(errorStatus(undefined)).toBeUndefined()
+    expect(errorStatus({ data: { code: 'NOT_A_REAL_CODE' } })).toBeUndefined()
+  })
+})

--- a/apps/web/src/trpc/query-client.ts
+++ b/apps/web/src/trpc/query-client.ts
@@ -13,6 +13,38 @@ import SuperJSON from 'superjson'
  */
 export const ORG_STATIC_STALE_TIME = 5 * 60 * 1000
 
+/**
+ * tRPC error code → HTTP status, for the fallback path only. `data.httpStatus`
+ * is present on anything that came back over the HTTP link; this covers the
+ * shapes that didn't (a server-side caller, a hand-thrown `TRPCError`), where
+ * `httpStatus` is absent and the code is all we have.
+ */
+const CODE_STATUS: Record<string, number> = {
+  BAD_REQUEST: 400,
+  PARSE_ERROR: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  METHOD_NOT_SUPPORTED: 405,
+  TIMEOUT: 408,
+  CONFLICT: 409,
+  PRECONDITION_FAILED: 412,
+  PAYLOAD_TOO_LARGE: 413,
+  UNPROCESSABLE_CONTENT: 422,
+  TOO_MANY_REQUESTS: 429,
+}
+
+/**
+ * Resolve a tRPC client error to an HTTP status, or `undefined` when it isn't
+ * one (a network failure, an aborted fetch) — those keep retrying.
+ */
+export function errorStatus(error: unknown): number | undefined {
+  const data = (error as { data?: { httpStatus?: unknown; code?: unknown } } | undefined)?.data
+  if (typeof data?.httpStatus === 'number') return data.httpStatus
+  if (typeof data?.code === 'string') return CODE_STATUS[data.code]
+  return undefined
+}
+
 export const createQueryClient = () =>
   new QueryClient({
     mutationCache: new MutationCache({
@@ -36,11 +68,17 @@ export const createQueryClient = () =>
         // above 0 to avoid refetching immediately on the client
         staleTime: 30 * 1000,
         retry: (failureCount, error) => {
-          const data = (error as any)?.data
-          const status =
-            data?.httpStatus ??
-            (data?.code === 'FORBIDDEN' ? 403 : data?.code === 'UNAUTHORIZED' ? 401 : undefined)
-          if (status === 401 || status === 403) return false
+          const status = errorStatus(error)
+          // Every 4xx is the server's considered answer, not a blip — asking a
+          // fourth time produces the same refusal. This used to exempt 401/403
+          // only, which meant a NOT_FOUND cost 4 round trips per trigger: mail
+          // answers a lens denial with 404 (it hides existence rather than
+          // admitting a thread it won't show), so a revoked thread left open
+          // hammered `message.listByThread` on every focus and reconnect.
+          // 408 and 429 are the two that genuinely mean "try again".
+          if (status && status >= 400 && status < 500 && status !== 408 && status !== 429) {
+            return false
+          }
           return failureCount < 3
         },
       },


### PR DESCRIPTION
Sharing a thread with a user and then unsharing it left their client asking for it forever — `message.listByThread` 404'ing on repeat, several requests per window focus and per realtime reconnect.

## Why it repeated

Three things had to line up.

**1. The retry predicate treated the refusal as retryable.** `query-client.ts` exempted 401/403 only. Mail answers a lens denial with `NOT_FOUND` — deliberately, it hides existence rather than admitting a thread it won't show — so a 404 fell through to `failureCount < 3` and cost **four** round trips per trigger. Every 4xx is now terminal except 408 and 429, the two that genuinely mean "try again". This is repo-wide, not mail-specific: any query that 404s or 409s was quadrupling.

**2. The revoked thread never left the store.** `completeBatch` added the id to `notFoundIds` but left the stale row in `threads`. The `forceRequestThread` no-eviction rule covers the window *before* an answer lands (don't blank the pane mid-read); there is no replacement when the answer is not-found, so the row lived forever. Two consequences:

- `thread-details.tsx` renders its "Thread not found" branch only on `!thread` — so the revoked viewer **kept seeing the header, subject and participants**.
- `useMessages`' `enabled: !!thread` stayed true, re-arming the query on every focus and reconnect.

It now evicts, and drops that thread's message-id list — the metadata twin of the `clearHtmlBodyCache()` that plan 45 §1.6 already did for bodies.

**3. `useMessages` had no tombstone of its own.** Its `!cachedList` gate cannot help: no list is cached *because* the fetch failed. It now reads the thread store's `notFoundIds`. Not redundant with the eviction — three of the four callers (`chat-panel/messages`, `thread-messages`, `use-thread-counterparty`) pass no `enabled` at all, so `!!thread` only ever disarmed `thread-details`.

## The prerequisite fix

`use-batch-drain.ts` reported a **failed fetch** as "the entire batch is not found". With eviction added, a dropped connection would have emptied the visible mailbox. The two signals are now split: `BatchDrainOpts.failBatch?` is optional and defaults to the old behaviour, so the four other stores are unchanged; the thread store's `failBatch` clears `loadingIds` without tombstoning or evicting.

⚠️ That conflation is a **pre-existing bug in the other four drains** and is left alone here. A transient batch failure tombstones every id, and `requestThread` refuses tombstoned ids — so a network blip currently wedges those messages/participants/tasks out of view until something calls a force-request. Worth a follow-up.

## Verification

- **20 new tests**, each mutation-checked: reverting the eviction fails 2, `failBatch` fails 3, the `useMessages` gate fails 3 — none pass vacuously.
- `biome check` on all 8 files: clean.
- Typecheck: the four changed source files add **zero** errors. `thread-data-provider.tsx` sits at exactly its recorded baseline (`scripts/ci/typecheck-baseline.json` → `thread-data-provider.tsx::TS2345: 5`, and 5 is what's observed).
- Suite `src/components/threads src/components/mail src/trpc`: **113 pass / 2 fail**. Both failures are pre-existing stale-vocabulary rot from the v3 rename — `use-inbox-def-union.test.tsx` and `thread-display-read-gate.test.tsx` still assert `myLens: 'full'`/`'subject'`, which became `read`/`identity`. Neither touches these files. Worth a separate cleanup.

## Not included

`runCatchUp` (`use-mail-sync.ts`) still fires its own `listByThread.fetch` for a known-not-found thread on every reconnect. It's now 1 request instead of 4, and its `.catch(() => {})` still swallows the reason.
