### PR TITLE
fix(ci): resolve @auxx packages to source in vitest, not dist

### DIFF
--- a/apps/kb/vitest.config.ts
+++ b/apps/kb/vitest.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { loadEnv } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig(({ mode }) => {
   const monorepoRoot = path.resolve(__dirname, '../..')
@@ -26,12 +27,12 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '~': path.resolve(__dirname, './src'),
-        // Resolve @auxx/lib to SOURCE, not the built dist — a stale dist would
-        // silently test old permission composition code.
-        '@auxx/database/enums': path.resolve(monorepoRoot, 'packages/database/src/enums.ts'),
-        '@auxx/database': path.resolve(monorepoRoot, 'packages/database/src'),
-        '@auxx/lib': path.resolve(monorepoRoot, 'packages/lib/src'),
-        '@auxx/config': path.resolve(monorepoRoot, 'packages/config/src'),
+        // Resolve every @auxx package to SOURCE, not the built dist — a stale
+        // dist would silently test old permission composition code, and on a
+        // cold CI checkout there is no dist to resolve at all. The bespoke
+        // subset that used to live here missed `@auxx/types`, which is what
+        // `capability-set` reaches for.
+        ...auxxSourceAlias,
       },
     },
 

--- a/packages/credentials/vitest.config.ts
+++ b/packages/credentials/vitest.config.ts
@@ -2,6 +2,7 @@
 
 import path from 'path'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   root: __dirname,
@@ -23,6 +24,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      ...auxxSourceAlias,
       '@auxx/credentials': path.resolve(__dirname, './src'),
     },
   },

--- a/packages/redis/vitest.config.ts
+++ b/packages/redis/vitest.config.ts
@@ -1,7 +1,7 @@
 // packages/redis/vitest.config.ts
 
-import path from 'node:path'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   root: __dirname,
@@ -13,9 +13,6 @@ export default defineConfig({
     exclude: ['node_modules/**', 'dist/**', '**/*.config.*'],
   },
   resolve: {
-    alias: {
-      '@auxx/logger': path.resolve(__dirname, '../logger/src'),
-      '@auxx/config': path.resolve(__dirname, '../config/src'),
-    },
+    alias: auxxSourceAlias,
   },
 })

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -2,6 +2,7 @@
 
 import path from 'path'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   root: __dirname,
@@ -14,6 +15,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      ...auxxSourceAlias,
       '@auxx/services': path.resolve(__dirname, './src'),
     },
   },

--- a/vitest.alias.ts
+++ b/vitest.alias.ts
@@ -1,0 +1,81 @@
+// vitest.alias.ts
+
+import path from 'node:path'
+
+/**
+ * Every `@auxx/*` workspace package, mapped to its SOURCE directory.
+ *
+ * ## Why this has to exist
+ *
+ * Each workspace package exports four conditions:
+ *
+ * ```json
+ * "types":   "./src/index.ts",
+ * "source":  "./src/index.ts",
+ * "import":  "./dist/index.mjs",
+ * "default": "./src/index.ts"
+ * ```
+ *
+ * `tsc` picks `types` and reads source. Vite — and therefore Vitest — resolves
+ * ESM through `import`, so it picks **`dist`**. On a developer machine that
+ * directory exists and everything works; on a fresh CI checkout it does not, and
+ * the suite dies with `Failed to resolve entry for package "@auxx/database"`
+ * before a single test runs. The two toolchains disagree about the same
+ * package.json, and only one of them is affected by a cold checkout.
+ *
+ * Aliasing to source settles it: CI and a laptop resolve identically, tests
+ * always exercise the code as written rather than the last build, and no test
+ * job needs a build step to precede it.
+ *
+ * This cost a red `main` on 2026-07-30. `packages/billing` and `packages/lib`
+ * had hand-rolled partial versions of this map, which is why those two projects
+ * were the ones that had always passed in CI — the projects added alongside them
+ * (`services`, `credentials`, `redis`, `kb`) had no aliases and failed instantly.
+ *
+ * ## Using it
+ *
+ * ```ts
+ * import { auxxSourceAlias } from '../../vitest.alias'
+ * export default defineConfig({
+ *   resolve: { alias: { ...auxxSourceAlias, '~/': path.resolve(__dirname, './src/') } },
+ * })
+ * ```
+ *
+ * Imported by RELATIVE path on purpose. A `@auxx/…` specifier here would have to
+ * be resolved by the very mechanism this file exists to work around.
+ *
+ * ## Rules
+ *
+ * Vite alias keys are PREFIX matches, so `@auxx/database` also rewrites
+ * `@auxx/database/enums` → `packages/database/src/enums`. Every package keeps
+ * its subpaths under `src/` with matching names, so one entry covers a package
+ * whole — except `@auxx/types`, whose subpaths live at the package root and
+ * which is therefore mapped without `src`.
+ *
+ * A package added to the workspace belongs here even if nothing imports it
+ * across a package boundary yet. The entry is inert until something does, and
+ * adding it now is what stops the next cold-CI failure.
+ */
+// `__dirname`, not `import.meta.dirname`: Vite bundles a config and its relative
+// imports together, injecting file-scope `__dirname` per module — so this
+// resolves against the repo root here, not against whichever config imported it.
+const workspace = (pkg: string, dir = 'src') => path.resolve(__dirname, 'packages', pkg, dir)
+
+export const auxxSourceAlias: Record<string, string> = {
+  '@auxx/billing': workspace('billing'),
+  '@auxx/config': workspace('config'),
+  '@auxx/credentials': workspace('credentials'),
+  '@auxx/database': workspace('database'),
+  '@auxx/deployment': workspace('deployment'),
+  '@auxx/email': workspace('email'),
+  '@auxx/lib': workspace('lib'),
+  '@auxx/logger': workspace('logger'),
+  '@auxx/redis': workspace('redis'),
+  '@auxx/seed': workspace('seed'),
+  '@auxx/services': workspace('services'),
+  // Sources sit at the package root, not under `src/`.
+  '@auxx/types': workspace('types', '.'),
+  '@auxx/ui': workspace('ui'),
+  '@auxx/utils': workspace('utils'),
+  '@auxx/workflow-nodes': workspace('workflow-nodes'),
+}


### PR DESCRIPTION
Fixes the red `main` caused by #1415. 12 of 43 test files failed on a cold runner before running a single test:

```
services, credentials  Failed to resolve entry for package "@auxx/database"
redis                  Failed to resolve entry for package "@auxx/credentials"
kb                     Cannot find package '@auxx/types/permissions'
```

## Why

Every workspace package exports the same four conditions:

```json
"types":   "./src/index.ts",
"source":  "./src/index.ts",
"import":  "./dist/index.mjs",     ← vitest picks this
"default": "./src/index.ts"
```

`tsc` picks `types` and reads source — which is why both Typecheck jobs stayed green. Vite, and therefore Vitest, resolves ESM through `import`, so it picks `dist`. That directory exists on a developer machine and does not exist on a fresh checkout. One package.json, two toolchains, and only one of them notices a cold runner.

`billing` and `workflow-nodes` were never exposed to this because their configs carry hand-rolled alias maps pointing at source (`lib` has one too). That is exactly why the two projects CI had always run were the two that could not reveal the problem.

## The fix

`vitest.alias.ts` at the repo root maps every `@auxx/*` package to its source directory once; the four failing configs spread it.

Aliasing beats adding a build step ahead of the tests — a build would leave CI exercising compiled output while a laptop exercises source, a worse divergence than the one being fixed.

It also closes a live footgun in `apps/kb`, whose bespoke subset aliased `@auxx/lib` to source specifically so a stale dist could not silently test old permission-composition code — but missed `@auxx/types`, which `capability-set` reaches for.

## Verification

Run in a throwaway `git worktree --detach` with **0 `dist` directories** before and after `pnpm install --frozen-lockfile` — the cold-CI reproduction that should have gated #1415:

```
Run tests                    Test Files  43 passed (43)     Tests  432 passed (432)
Validate workflow templates  Test Files   1 passed (1)      Tests   79 passed (79)
```

## Follow-up worth doing

`packages/lib` and `packages/billing` keep their own partial alias maps. They work today, so they are left alone here rather than widening a hotfix — but folding them into the shared map would remove the last places this can silently drift.