### PR TITLE
fix(ci): unbreak the web and lib test suites, and record the typecheck baseline on a runner

### DIFF
--- a/.github/workflows/typecheck-baseline.yml
+++ b/.github/workflows/typecheck-baseline.yml
@@ -1,0 +1,137 @@
+# .github/workflows/typecheck-baseline.yml
+#
+# Re-records `scripts/ci/typecheck-baseline.json` ON A RUNNER and opens a PR when
+# the floor has dropped.
+#
+# WHY THIS EXISTS. The baseline is a record of pre-existing type errors, and it
+# only means anything if it was measured in the same environment that checks it.
+# It was not. It was recorded on a laptop, where `dist/` directories and a
+# generated `next-env.d.ts` are lying around, and a CI runner has neither — so
+# `apps/web` reported two TS2307s that existed nowhere else and #1412 merged red
+# on 2026-07-30. #1413 patched that by teaching the job to build what web needs,
+# but the underlying asymmetry stayed: a human still types `--update` on a
+# machine that does not resemble CI, and nothing stops the next drift.
+#
+# This closes it from the other end. The authoritative baseline is whatever a
+# runner measures, and a contributor who fixes type errors never has to think
+# about the file at all — the tightening arrives as a reviewable PR.
+#
+# The two ratchet invocations are deliberate and in this order:
+#
+#   1. CHECK mode fails if any `<file>::<code>` count went UP. On `main` that
+#      should be impossible (the PR that raised it could not have merged), so a
+#      failure here is real news: an error that only appears in a cold
+#      environment, i.e. exactly the class that caused #1412.
+#   2. Only once check has passed is `--update` allowed to write. That ordering
+#      is what makes the diff safe to merge unread: every change in it is a
+#      count that fell.
+#
+# The second `tsc` reuses the first one's `.tsbuildinfo`, so it costs seconds.
+
+name: Typecheck baseline
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays, 06:00 UTC. Deliberately not per-merge: the baseline only moves
+    # when someone actually deletes errors, and a PR after every merge would be
+    # noise that trains people to ignore it.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: typecheck-baseline
+  cancel-in-progress: true
+
+jobs:
+  tighten:
+    name: Re-record on a runner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Same preparation the `web` leg of CI does — see the comment there. Run
+      # unconditionally because this job measures both packages in one go.
+      - name: Prepare workspace for typecheck
+        run: |
+          pnpm --filter @auxx/chat build
+          pnpm --filter @auxx/web exec next typegen
+
+      - name: Fail if anything regressed
+        env:
+          TYPECHECK_HEAP_MB: 6144
+        run: node scripts/ci/typecheck-ratchet.js
+
+      - name: Re-record the baseline
+        env:
+          TYPECHECK_HEAP_MB: 6144
+        run: node scripts/ci/typecheck-ratchet.js --update
+
+      - name: Open a PR if the floor dropped
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BASELINE=scripts/ci/typecheck-baseline.json
+
+          if git diff --quiet -- "$BASELINE"; then
+            echo "Baseline unchanged — nothing to tighten."
+            exit 0
+          fi
+
+          # HEAD still holds the pre-update file; the working tree holds the new one.
+          SUMMARY=$(node -e '
+            const { execSync } = require("node:child_process")
+            const now = require("./scripts/ci/typecheck-baseline.json").packages
+            const before = JSON.parse(
+              execSync("git show HEAD:scripts/ci/typecheck-baseline.json", { encoding: "utf8" })
+            ).packages
+            const total = (o) => Object.values(o ?? {}).reduce((s, n) => s + n, 0)
+            for (const name of Object.keys(now)) {
+              const [a, b] = [total(before[name]), total(now[name])]
+              if (a !== b) console.log(`| \`${name}\` | ${a} | ${b} | ${b - a} |`)
+            }
+          ')
+
+          BRANCH=chore/typecheck-baseline
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add "$BASELINE"
+          git commit -m "chore(ci): tighten the typecheck baseline"
+          git push -f -u origin "$BRANCH"
+
+          BODY=$(printf '%s\n' \
+            "Re-recorded by \`.github/workflows/typecheck-baseline.yml\` on a runner." \
+            "" \
+            "| package | was | now | delta |" \
+            "|---|---|---|---|" \
+            "$SUMMARY" \
+            "" \
+            "Every change here is a count that **fell** — the ratchet ran in check mode first" \
+            "and would have failed the job before writing if anything had risen. Safe to merge" \
+            "on the strength of that; the diff itself is 3k lines of generated JSON." \
+            "" \
+            "Tightening matters because unclaimed headroom is where a new error hides: an" \
+            "untouched baseline lets a regression land in a file that already had a budget.")
+
+          if gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            gh pr edit "$BRANCH" --body "$BODY"
+            echo "Updated the existing baseline PR."
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore(ci): tighten the typecheck baseline" --body "$BODY"
+          fi

--- a/apps/web/src/app/api/attachments/attachment-visibility.test.ts
+++ b/apps/web/src/app/api/attachments/attachment-visibility.test.ts
@@ -284,9 +284,9 @@ describe('canViewAttachment — the attachment row itself', () => {
 })
 
 describe('canViewAttachment — MESSAGE (unchanged; must not regress)', () => {
-  it('grants a caller holding the `full` lens on the parent thread', async () => {
+  it('grants a caller holding the `read` lens on the parent thread', async () => {
     queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [{ threadId: THREAD_ID }])
-    getThreadLens.mockResolvedValue('full')
+    getThreadLens.mockResolvedValue('read')
     await expect(canView()).resolves.toBe(true)
     expect(getThreadLens).toHaveBeenCalledWith(
       expect.anything(),
@@ -296,9 +296,12 @@ describe('canViewAttachment — MESSAGE (unchanged; must not regress)', () => {
     )
   })
 
-  it('denies the `read` lens — mail attachments are full-tier', async () => {
+  // `read` is the TOP mail lens after the v3 rename (`full`->`read`,
+  // `subject`->`identity`), so the tier below it is `identity`. Attachments are
+  // body-tier: seeing that a thread exists must not hand over its files.
+  it('denies the `identity` lens — mail attachments are body-tier', async () => {
     queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [{ threadId: THREAD_ID }])
-    getThreadLens.mockResolvedValue('read')
+    getThreadLens.mockResolvedValue('identity')
     await expect(canView()).resolves.toBe(false)
   })
 
@@ -316,7 +319,7 @@ describe('canViewAttachment — MESSAGE (unchanged; must not regress)', () => {
 
   it('reads no capabilities at all on the mail path', async () => {
     queueRows(attachmentRow('MESSAGE', MESSAGE_ID), [{ threadId: THREAD_ID }])
-    getThreadLens.mockResolvedValue('full')
+    getThreadLens.mockResolvedValue('read')
     await canView()
     expect(getCapabilities).not.toHaveBeenCalled()
   })

--- a/apps/web/src/app/api/attachments/attachment-visibility.ts
+++ b/apps/web/src/app/api/attachments/attachment-visibility.ts
@@ -54,7 +54,7 @@ export async function canViewAttachment(
 
   switch (attachment.entityType) {
     // Mail attachments are `full`-tier (mail-permissions §7): the caller must hold
-    // the `full` lens on the parent thread.
+    // the `read` lens (the top tier) on the parent thread.
     case 'MESSAGE': {
       const [message] = await database
         .select({ threadId: schema.Message.threadId })

--- a/apps/web/src/app/api/kb/articles/[articleId]/events/kb-article-instance-access.test.ts
+++ b/apps/web/src/app/api/kb/articles/[articleId]/events/kb-article-instance-access.test.ts
@@ -64,6 +64,7 @@ vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
 
 // Deep path on purpose — the barrel hangs (see above).
 const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
 const { GET } = await import('./route')
 
 const ORG_ID = 'org_cuid000000000000000000000'
@@ -81,7 +82,7 @@ const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
 
 /** A real `CapabilitySet` holding `permission` on {@link KB_ID} via an explicit row. */
 function capabilitiesFor(permission: ResourcePermission, areaLevel = AREA_LEVEL_OF[permission]) {
-  const instances = { [KB_ID]: permission }
+  const instances = { [KB_ID]: permissionToRung(permission) }
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.knowledgeBase]: areaLevel })),
     {},

--- a/apps/web/src/app/api/workflow/run/[runId]/events/run-trace-instance-access.test.ts
+++ b/apps/web/src/app/api/workflow/run/[runId]/events/run-trace-instance-access.test.ts
@@ -74,6 +74,7 @@ vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
 
 // Deep path on purpose — the barrel hangs (see above).
 const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
 const { GET } = await import('./route')
 
 const ORG_ID = 'org_cuid000000000000000000000'
@@ -91,7 +92,7 @@ const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
 
 /** A real `CapabilitySet` holding `permission` on {@link WF_ID} via an explicit row. */
 function capabilitiesFor(permission: ResourcePermission, areaLevel = AREA_LEVEL_OF[permission]) {
-  const instances = { [WF_ID]: permission }
+  const instances = { [WF_ID]: permissionToRung(permission) }
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.workflows]: areaLevel })),
     {},

--- a/apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/file-instance-access.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/files/[fileId]/file-instance-access.test.ts
@@ -75,6 +75,7 @@ vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
 
 // Deep path on purpose — the barrel hangs (see above).
 const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
 const { GET, DELETE } = await import('./route')
 
 const ORG_ID = 'org_cuid000000000000000000000'
@@ -102,7 +103,7 @@ function capabilitiesFor(
     extraInstances = {},
   }: { areaLevel?: Level; extraInstances?: Record<string, ResourcePermission> } = {}
 ) {
-  const instances = { [WF_ID]: permission, ...extraInstances }
+  const instances = { [WF_ID]: permissionToRung(permission), ...extraInstances }
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.workflows]: areaLevel })),
     {},

--- a/apps/web/src/app/api/workflows/[workflowId]/run/run-instance-access.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/run-instance-access.test.ts
@@ -93,6 +93,7 @@ vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
 
 // Deep path on purpose — see the note in `segment-instance-access.test.ts`.
 const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
 const { POST, DELETE } = await import('./route')
 
 const ORG_ID = 'org_cuid000000000000000000000'
@@ -114,7 +115,7 @@ function capabilitiesFor(
   permission: ResourcePermission,
   extraInstances: Record<string, ResourcePermission> = {}
 ) {
-  const instances = { [WF_ID]: permission, ...extraInstances }
+  const instances = { [WF_ID]: permissionToRung(permission), ...extraInstances }
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.workflows]: AREA_LEVEL_OF[permission] })),
     {},

--- a/apps/web/src/components/icons/__tests__/brands.test.ts
+++ b/apps/web/src/components/icons/__tests__/brands.test.ts
@@ -6,9 +6,10 @@ import path from 'node:path'
 // would drag server-only modules (db, queues) into jsdom.
 import { mcpTemplates } from '@auxx/lib/ai/mcp/templates/catalog'
 import { describe, expect, it } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 import { BRAND_ICONS } from '../brands'
 
-const BRANDS_DIR = path.resolve(process.cwd(), 'public/icons/brands')
+const BRANDS_DIR = path.resolve(APP_ROOT, 'public/icons/brands')
 
 const files = fs.readdirSync(BRANDS_DIR).filter((f) => f.endsWith('.svg'))
 const baseFiles = files.filter((f) => !f.endsWith('-dark.svg'))

--- a/apps/web/src/components/permissions/ui/area-access-copy.test.ts
+++ b/apps/web/src/components/permissions/ui/area-access-copy.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { describe, expect, it } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 import { AREA_ACCESS_ROW_COPY, areaRungHelper, areaRungLabel } from './area-access-copy'
 import { INSTANCE_ROW_COPY, INSTANCE_SHARE_COPY } from './instance-share-copy'
 import { RUNG_LABELS_LONG } from './level-labels'
@@ -242,7 +243,7 @@ describe('the Restricted helper claims no admin bypass (§5.5.3)', () => {
   // string was wrong in the DANGEROUS direction — it told an admin a group still
   // had access when it did not.
   const source = readFileSync(
-    resolve(process.cwd(), 'src/components/permissions/ui/instance-share-card.tsx'),
+    resolve(APP_ROOT, 'src/components/permissions/ui/instance-share-card.tsx'),
     'utf8'
   )
 

--- a/apps/web/src/server/api/routers/inbox-channel-routing-access.test.ts
+++ b/apps/web/src/server/api/routers/inbox-channel-routing-access.test.ts
@@ -7,6 +7,7 @@ import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 40 phase 0a — the channels↔inboxes seam, driven for real.
@@ -773,10 +774,7 @@ describe('the mail front door (§5.3) — `inboxes: None` closes the working rea
  * Pin it in source, the idiom `snippet-instance-access.test.ts` uses.
  */
 describe('inbox router — structural invariants', () => {
-  const src = fs.readFileSync(
-    path.resolve(process.cwd(), 'src/server/api/routers/inbox.ts'),
-    'utf8'
-  )
+  const src = fs.readFileSync(path.resolve(APP_ROOT, 'src/server/api/routers/inbox.ts'), 'utf8')
 
   it.each([
     'create',

--- a/apps/web/src/server/api/routers/inbox-routing-recordid-canonicalization.test.ts
+++ b/apps/web/src/server/api/routers/inbox-routing-recordid-canonicalization.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 40 §5.1 / 40a §5.1 — the CLIENT-MINTED half of the inbox RecordId bug,
@@ -409,10 +410,7 @@ describe('the definition is resolved from the instance, not from the caller', ()
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('inbox router — canonicalization is applied where a RecordId crosses the wire', () => {
-  const src = fs.readFileSync(
-    path.resolve(process.cwd(), 'src/server/api/routers/inbox.ts'),
-    'utf8'
-  )
+  const src = fs.readFileSync(path.resolve(APP_ROOT, 'src/server/api/routers/inbox.ts'), 'utf8')
 
   it('no gate is handed a raw client RecordId any more', () => {
     // The bug in one line: `input.recordId` / `input.*InboxRecordId` reaching a

--- a/apps/web/src/server/api/routers/mail-gap-closures.test.ts
+++ b/apps/web/src/server/api/routers/mail-gap-closures.test.ts
@@ -8,6 +8,7 @@ import { isGoverningInstanceRow } from '@auxx/lib/cache/providers/governing-inst
 import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 40 phase 3 — the three gaps phase 3 left behind.
@@ -659,10 +660,7 @@ describe('gap 3 — `assertViewInstance` and mail visibility now AGREE on the ma
  * pre-fix state was exactly that: eight bare `protectedProcedure`s.
  */
 describe('draft router — structural invariants', () => {
-  const src = fs.readFileSync(
-    path.resolve(process.cwd(), 'src/server/api/routers/draft.ts'),
-    'utf8'
-  )
+  const src = fs.readFileSync(path.resolve(APP_ROOT, 'src/server/api/routers/draft.ts'), 'utf8')
 
   const PROCEDURES = [
     'delete',

--- a/apps/web/src/server/api/routers/mail-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/mail-instance-access.test.ts
@@ -8,6 +8,7 @@ import { isGoverningInstanceRow } from '@auxx/lib/cache/providers/governing-inst
 import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 40 phase 3 — the enforcement surface, driven for real.
@@ -1044,10 +1045,7 @@ describe('positive controls — over-denial is the failure mode this slice risks
  * the same idiom as `snippet-instance-access.test.ts`.
  */
 describe('thread router — structural invariants', () => {
-  const src = fs.readFileSync(
-    path.resolve(process.cwd(), 'src/server/api/routers/thread.ts'),
-    'utf8'
-  )
+  const src = fs.readFileSync(path.resolve(APP_ROOT, 'src/server/api/routers/thread.ts'), 'utf8')
 
   const PROCEDURES = [
     'cancelScheduledMessage',
@@ -1104,7 +1102,7 @@ describe('thread router — structural invariants', () => {
 })
 
 describe('page guards (§5.3)', () => {
-  const read = (p: string) => fs.readFileSync(path.resolve(process.cwd(), p), 'utf8')
+  const read = (p: string) => fs.readFileSync(path.resolve(APP_ROOT, p), 'utf8')
 
   it('/app/mail is guarded on inboxes.view, at the LAYOUT', () => {
     // On the layout, not the index page: every nested mailbox route

--- a/apps/web/src/server/api/routers/mail-router-front-door.test.ts
+++ b/apps/web/src/server/api/routers/mail-router-front-door.test.ts
@@ -7,6 +7,7 @@ import type { OrganizationRole, SeatType } from '@auxx/database/types'
 import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 40 phase 3 — the FOUR routers §5.3's table never enumerated.
@@ -769,7 +770,7 @@ describe('attachment router — gated by HOST, not by a mail key', () => {
  */
 describe('structural invariants — the builder itself', () => {
   const read = (name: string) =>
-    fs.readFileSync(path.resolve(process.cwd(), `src/server/api/routers/${name}`), 'utf8')
+    fs.readFileSync(path.resolve(APP_ROOT, `src/server/api/routers/${name}`), 'utf8')
 
   const GATED: Array<[string, string[]]> = [
     [

--- a/apps/web/src/server/api/routers/resource-access-instance-baseline.test.ts
+++ b/apps/web/src/server/api/routers/resource-access-instance-baseline.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { ResourceGranteeType, type ResourcePermission } from '@auxx/database/enums'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 24 §B.4 — the **instance baseline picker round-trip** at the router that
@@ -297,7 +298,7 @@ describe('grantInstance — authorizeInstanceTarget gates on THIS instance (§B.
  */
 describe('resourceAccess — structural invariants', () => {
   const src = fs.readFileSync(
-    path.resolve(process.cwd(), 'src/server/api/routers/resourceAccess.ts'),
+    path.resolve(APP_ROOT, 'src/server/api/routers/resourceAccess.ts'),
     'utf8'
   )
 

--- a/apps/web/src/server/api/routers/resource-access-plan-gate.test.ts
+++ b/apps/web/src/server/api/routers/resource-access-plan-gate.test.ts
@@ -3,6 +3,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan-23 §2.1 regression guard: per-def (type-level) record-access EDITING is
@@ -17,7 +18,7 @@ import { describe, expect, it } from 'vitest'
  */
 
 const src = fs.readFileSync(
-  path.resolve(process.cwd(), 'src/server/api/routers/resourceAccess.ts'),
+  path.resolve(APP_ROOT, 'src/server/api/routers/resourceAccess.ts'),
   'utf8'
 )
 

--- a/apps/web/src/server/api/routers/segment-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/segment-instance-access.test.ts
@@ -6,6 +6,7 @@ import { schema } from '@auxx/database'
 import type { ResourcePermission } from '@auxx/database/enums'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 24 §A.2.1 / §A.4 — the one genuine **privilege hole** this plan closed:
@@ -318,10 +319,7 @@ describe('segment router — how the dataset is resolved', () => {
  * same idiom as `resource-access-plan-gate.test.ts`.
  */
 describe('segment router — structural invariants', () => {
-  const src = fs.readFileSync(
-    path.resolve(process.cwd(), 'src/server/api/routers/segment.ts'),
-    'utf8'
-  )
+  const src = fs.readFileSync(path.resolve(APP_ROOT, 'src/server/api/routers/segment.ts'), 'utf8')
 
   const PROCEDURES = [
     'updateContent',

--- a/apps/web/src/server/api/routers/snippet-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/snippet-instance-access.test.ts
@@ -8,6 +8,7 @@ import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
 import { SEAT_CEILINGS } from '@auxx/lib/permissions/capabilities/seat-policy'
 import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_ROOT } from '../../../test/app-root'
 
 /**
  * Plan 36 §10 — the snippet router at the tier boundary, driven for real.
@@ -943,10 +944,7 @@ describe('snippet sharing goes through resourceAccess.grantInstance', () => {
  * source, the same idiom as `segment-instance-access.test.ts`.
  */
 describe('snippet router — structural invariants', () => {
-  const src = fs.readFileSync(
-    path.resolve(process.cwd(), 'src/server/api/routers/snippet.ts'),
-    'utf8'
-  )
+  const src = fs.readFileSync(path.resolve(APP_ROOT, 'src/server/api/routers/snippet.ts'), 'utf8')
 
   it('every procedure is a capabilityProcedure — no bare protectedProcedure', () => {
     for (const name of PROCEDURES) {

--- a/apps/web/src/test/app-root.ts
+++ b/apps/web/src/test/app-root.ts
@@ -1,0 +1,23 @@
+// apps/web/src/test/app-root.ts
+
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Absolute path to `apps/web`, anchored to THIS FILE rather than to the process
+ * working directory.
+ *
+ * A handful of tests assert on router source as text — that a mail procedure is
+ * wrapped in the right permission gate, that a share card spells an area the
+ * same way the copy does — so they read `.ts` files off disk. They used to do it
+ * with `path.resolve(process.cwd(), 'src/…')`, which quietly depends on where
+ * vitest was invoked from: `pnpm --filter @auxx/web test` puts the cwd at
+ * `apps/web` and the reads succeed, while `vitest --project web` from the
+ * monorepo root puts it two levels up and every one of them throws ENOENT.
+ *
+ * That is why these files were failing the moment CI began running the `web`
+ * project (#1415) — the tests were fine, the anchor was not. Vitest does not
+ * chdir its workers into the project root, and no config option makes it: the
+ * path has to come from the module, not the environment.
+ */
+export const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { loadEnv } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
@@ -55,14 +56,15 @@ export default defineConfig(({ mode }) => {
     },
 
     resolve: {
+      // The shared map, not a bespoke subset. The subset that used to live here
+      // was missing most of the workspace AND pointed `@auxx/database` at the
+      // package ROOT rather than `src`, which sent resolution straight back
+      // through the package.json `import` condition to `dist/`. On a laptop that
+      // directory exists and nothing looks wrong; on a fresh checkout 105 of 148
+      // files fail to resolve before a single assertion runs.
       alias: {
         '~': path.resolve(__dirname, './src'),
-        '@auxx/database/enums': path.resolve(__dirname, '../../packages/database/src/enums.ts'),
-        '@auxx/database': path.resolve(__dirname, '../../packages/database'),
-        '@auxx/logger': path.resolve(__dirname, '../../packages/logger/src'),
-        '@auxx/lib': path.resolve(__dirname, '../../packages/lib/src'),
-        '@auxx/config': path.resolve(__dirname, '../../packages/config/src'),
-        '@auxx/workflow-nodes': path.resolve(__dirname, '../../packages/workflow-nodes/src'),
+        ...auxxSourceAlias,
       },
     },
 

--- a/packages/billing/vitest.config.ts
+++ b/packages/billing/vitest.config.ts
@@ -3,6 +3,7 @@
 import path from 'path'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   root: __dirname,
@@ -24,12 +25,12 @@ export default defineConfig({
     },
   },
   resolve: {
+    // The last of the bespoke subsets folded into the shared map. This one was
+    // not broken — billing is the project that has always passed cold — but a
+    // partial map is only ever one new import away from becoming the next
+    // `apps/web`, and there is no reason for five copies of the same table.
     alias: {
-      '@auxx/billing': path.resolve(__dirname, './src'),
-      '@auxx/credentials': path.resolve(__dirname, '../credentials/src'),
-      '@auxx/database': path.resolve(__dirname, '../database/src'),
-      '@auxx/logger': path.resolve(__dirname, '../logger/src'),
-      '@auxx/lib': path.resolve(__dirname, '../lib/src'),
+      ...auxxSourceAlias,
       '~/': path.resolve(__dirname, './src/'),
     },
   },

--- a/packages/lib/src/ai/agent-framework/context/__tests__/context-store.test.ts
+++ b/packages/lib/src/ai/agent-framework/context/__tests__/context-store.test.ts
@@ -15,8 +15,12 @@ import {
 
 // Stub the v8 field resolver so field reads are deterministic and call-counted.
 const { resolveSpy } = vi.hoisted(() => ({ resolveSpy: vi.fn() }))
+// A factory REPLACES the module, so every export the graph reaches for has to
+// be listed: `context/sources/field-source.ts` picked up `buildSubjectFieldResolver`
+// after this mock was written, and its absence throws before any test runs.
 vi.mock('../../../../agents/bindings/resolve', () => ({
   buildResolveVarSource: () => resolveSpy,
+  buildSubjectFieldResolver: () => resolveSpy,
 }))
 
 function makeCtx(overrides: Partial<ToolContext> = {}): ToolContext {

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { loadEnv, type Plugin } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 /**
  * Loads `.md` imports as default-exported strings so source-level imports
@@ -76,17 +77,12 @@ export default defineConfig(({ mode }) => {
     },
 
     resolve: {
+      // The shared map covers all fifteen workspace packages by prefix, which
+      // subsumes the bespoke `@auxx/credentials/store` and `/crypto` entries
+      // that used to sit here. The subset it replaces covered eight, and on a
+      // checkout with no `dist` that left 304 of 507 files unable to resolve.
       alias: {
-        '@auxx/database': path.resolve(__dirname, '../database/src'),
-        // The credentials store/crypto subpaths have no built `dist` (added post-build);
-        // resolve them to source so cross-package imports work under Vitest.
-        '@auxx/credentials/store': path.resolve(__dirname, '../credentials/src/store'),
-        '@auxx/credentials/crypto': path.resolve(__dirname, '../credentials/src/crypto'),
-        '@auxx/lib': path.resolve(__dirname, './src'),
-        '@auxx/utils': path.resolve(__dirname, '../utils/src'),
-        '@auxx/logger': path.resolve(__dirname, '../logger/src'),
-        '@auxx/config': path.resolve(__dirname, '../config/src'),
-        '@auxx/workflow-nodes': path.resolve(__dirname, '../workflow-nodes/src'),
+        ...auxxSourceAlias,
         '~/': path.resolve(__dirname, './src/'),
       },
     },


### PR DESCRIPTION
Three things, all downstream of the same discovery: **nothing in this repo was being measured in the environment that runs it.**

## 1. The typecheck baseline is recorded on a laptop

`.github/workflows/typecheck-baseline.yml` re-records it on a runner (weekly + `workflow_dispatch`) and opens a PR when the floor drops.

The two ratchet invocations are ordered deliberately: **check** mode runs first and fails if any count rose — on `main` that should be impossible, so a failure there is real news about a cold-only error. Only once check passes is `--update` allowed to write, which is what makes the resulting 3k-line generated diff safe to merge unread: every change in it is a count that fell.

It also means a contributor who deletes type errors never has to know the file exists.

## 2. The web suite was broken, and nobody could see it

`web` isn't in the CI test job, so its 2,031 tests went unwatched. 24 files were failing. **24 → 8**, and 378 more tests now actually execute (2,031 → 2,409) because eleven of those files were failing *at collection*.

| cause | files | what it was |
|---|---|---|
| wrong anchor | 11 | `path.resolve(process.cwd(), 'src/…')` in tests that read router source as text. Depends on where vitest was invoked — fine from `apps/web`, ENOENT from the repo root. Vitest doesn't chdir workers and no config option makes it, so the anchor now comes from a module. |
| `ResourcePermission` in the `Rung` lane | 4 | v3 split the axes and `instanceAccess` became `Record<string, Rung>`; `'view'` has no meaning there, so every "member holds an explicit grant" case denied. The tell was which cases still *passed*: `'none'` is spelled the same in both vocabularies, and area-level `Read` never touches the rung lane. |
| mail lens rename, inverted | 1 | `attachment-visibility.test.ts` granted on the retired `'full'` and denied on `'read'` — which is now the *top* lens. The handler had been updated; the test hadn't. |

## 3. Cold checkouts fail catastrophically, and #1417 only fixed part of it

Verifying on a clean `git worktree` with no `dist`:

| project | before | after |
|---|---|---|
| `lib` | **304 of 507 files failing** | 25 files / 24 tests |
| `web` | **105 of 148 files failing** | 8 files / 16 tests |
| `billing` | 13/13 | 13/13 |

Both carried partial hand-rolled alias maps — `lib` covered 8 packages of 15, `web` covered 5 **and pointed `@auxx/database` at the package root rather than `src/`**, which hands resolution straight back to the `import` condition and lands on `dist/`. Correct on a laptop, absent on a runner. All folded into the shared `vitest.alias.ts` from #1417, including `billing`, which was not broken but was one new import away from becoming the next `web`.

Had `web` been wired into the CI test job without this, it would have gone red instantly.

## Left failing, deliberately

- `records-import-access` (7) — genuine route drift: the handler grew an `innerJoin` on `ImportMapping` and a `{ job, entityDefinitionId }` projection the mock never learned. The fixtures need rebuilding, not a rename, and it gates a security boundary — worth an owner's eyes.
- eval + kopilot per-agent access (3), and assertion drift in 5 more.
- lib's 25: the `agents/bindings/resolve` mock fix here cleared 13 of 16 in `src/ai/agent-framework`; the rest are individual.

`web` and `lib` stay out of the CI test job until those are resolved. Wiring them in green is the follow-up.

## Note on measurement

Every local number was wrong, in both directions: `web` and `lib` looked far better locally than cold, while lib's provider tests looked *worse* locally — they're already guarded with `describe.skipIf(!API_KEY)` and never run in CI, but a local `.env` supplies real keys and those accounts return 402. Cold shows 69 skipped against 3 warm. A local run of this monorepo is not a proxy for CI in either direction.