### PR TITLE
fix(mail): gate the sidebar's Edit Inbox on the manage rung

### DIFF
--- a/apps/web/src/components/global/sidebar/inbox-edit-menu-item.test.tsx
+++ b/apps/web/src/components/global/sidebar/inbox-edit-menu-item.test.tsx
@@ -1,0 +1,129 @@
+// apps/web/src/components/global/sidebar/inbox-edit-menu-item.test.tsx
+
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The sidebar's "Edit Inbox" gate.
+ *
+ * The row and the authority come from DIFFERENT places, which is the whole bug
+ * this pins: `record.listAll` hands back every inbox in the org (both inbox defs
+ * are exempt from instance-access routing on the READ arm), so a member whose
+ * only reach into a mailbox is one shared thread still gets a sidebar row for
+ * it. Rendering an edit affordance off the row's existence offers a settings
+ * page the server will refuse.
+ *
+ * The three cases that matter, and none of them show up in a screenshot of the
+ * happy path:
+ *
+ *  - **No admin rung ⇒ no item**, even though the row renders.
+ *  - **The RecordId is minted from the inbox's OWN definition.** A personal
+ *    mailbox is asked about under `personal_inbox:`; one still on the shared def
+ *    during the 060 window is asked about under `inbox:`. Deriving the key from
+ *    `isPersonal` would ask the wrong keyspace and hide the owner's own item.
+ *  - **An inbox with no definition discriminator fails CLOSED** and is never
+ *    even asked about.
+ */
+
+const h = vi.hoisted(() => ({
+  admin: new Set<string>(),
+  asked: [] as string[],
+}))
+
+vi.mock('~/providers/capabilities-provider', () => ({
+  useAccess: () => ({
+    canAdminInstance: (recordId: string) => {
+      h.asked.push(recordId)
+      return h.admin.has(recordId)
+    },
+  }),
+}))
+
+// Radix's item throws outside a menu root; the component under test is the gate,
+// not the menu chrome.
+vi.mock('@auxx/ui/components/dropdown-menu', () => ({
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+const { InboxEditMenuItem } = await import('./inbox-edit-menu-item')
+
+beforeEach(() => {
+  h.admin = new Set()
+  h.asked = []
+})
+
+const SHARED = {
+  id: 'ibx_1',
+  name: 'Support',
+  color: 'indigo',
+  entityDefinitionKey: 'inbox' as const,
+}
+const PERSONAL = {
+  id: 'ibx_2',
+  name: 'markus@auxx.ai',
+  color: 'indigo',
+  isPersonal: true,
+  ownerUserId: 'u_1',
+  entityDefinitionKey: 'personal_inbox' as const,
+}
+
+describe('InboxEditMenuItem', () => {
+  it('renders nothing for an inbox the viewer only sees because a thread was shared', () => {
+    render(<InboxEditMenuItem inbox={SHARED} />)
+
+    expect(screen.queryByText('Edit Inbox')).toBeNull()
+    expect(h.asked).toEqual(['inbox:ibx_1'])
+  })
+
+  it('renders the settings link for an inbox the viewer administers', () => {
+    h.admin.add('inbox:ibx_1')
+    render(<InboxEditMenuItem inbox={SHARED} />)
+
+    expect(screen.getByText('Edit Inbox').closest('a')).toHaveAttribute(
+      'href',
+      '/app/settings/inbox/ibx_1?tab=settings'
+    )
+  })
+
+  it('asks about a personal mailbox in the personal keyspace, not the shared one', () => {
+    h.admin.add('personal_inbox:ibx_2')
+    render(<InboxEditMenuItem inbox={PERSONAL} />)
+
+    expect(h.asked).toEqual(['personal_inbox:ibx_2'])
+    expect(screen.getByText('Edit Inbox')).toBeTruthy()
+  })
+
+  it('asks in the SHARED keyspace for a personal mailbox still on the shared def', () => {
+    // Pre-060: the def is `inbox`, so that is where its grant rows live. Keying
+    // off `isPersonal` here would ask `personal_inbox:` and hide the owner's item.
+    h.admin.add('inbox:ibx_3')
+    render(
+      <InboxEditMenuItem
+        inbox={{
+          id: 'ibx_3',
+          name: 'legacy@auxx.ai',
+          color: 'indigo',
+          isPersonal: true,
+          ownerUserId: 'u_1',
+          entityDefinitionKey: 'inbox',
+        }}
+      />
+    )
+
+    expect(h.asked).toEqual(['inbox:ibx_3'])
+    expect(screen.getByText('Edit Inbox')).toBeTruthy()
+  })
+
+  it('fails closed — and asks nothing — when the definition is unknown', () => {
+    render(<InboxEditMenuItem inbox={{ id: 'ibx_4', name: 'Mystery', color: 'indigo' }} />)
+
+    expect(screen.queryByText('Edit Inbox')).toBeNull()
+    expect(h.asked).toEqual([])
+  })
+})

--- a/apps/web/src/components/global/sidebar/inbox-edit-menu-item.tsx
+++ b/apps/web/src/components/global/sidebar/inbox-edit-menu-item.tsx
@@ -1,0 +1,51 @@
+// ~/components/global/sidebar/inbox-edit-menu-item.tsx
+'use client'
+
+import { toRecordId } from '@auxx/types/resource'
+import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
+import { PencilIcon } from 'lucide-react'
+import Link from 'next/link'
+import type { Inbox } from '~/components/global/sidebar/shared-inbox-group'
+import { useAccess } from '~/providers/capabilities-provider'
+
+/**
+ * The sidebar row's "Edit Inbox" entry, rendered only for members who may
+ * actually manage that mailbox.
+ *
+ * **A sidebar row is not evidence of authority.** The list comes from
+ * `record.listAll` on the two inbox definitions, which are exempt from the
+ * instance-access routing on the READ arm — so every inbox in the org is
+ * returned to any member holding the def's view rung, including inboxes whose
+ * only reach into the viewer's world is a thread somebody shared with them.
+ * The gate here is the same `admin` rung the server enforces on every inbox
+ * mutation (`requireInboxManageAccess` → `InboxService.canManageInboxAccess`
+ * → `hasPermission(recordId, 'admin')`), read off the instance lane. It also
+ * matches the Edit affordance on the inbox detail page and the `canManage`
+ * flag `inbox.settingsList` computes, so the three cannot disagree.
+ *
+ * A personal mailbox's owner is granted `admin` on it at provisioning
+ * (`provisionPersonalInbox`), so their own inbox keeps the affordance without
+ * a second branch.
+ *
+ * ⚠ The RecordId MUST be minted from the inbox's own definition. A personal
+ * mailbox still sitting on the shared def during the 060 migration window
+ * carries its grant rows in the `inbox` keyspace; deriving the key from
+ * `isPersonal` would look them up under `personal_inbox` and find nothing.
+ * An inbox with no definition discriminator is treated as unknown, not as
+ * allowed.
+ */
+export function InboxEditMenuItem({ inbox }: { inbox: Inbox }) {
+  const { canAdminInstance } = useAccess()
+
+  if (!inbox.entityDefinitionKey) return null
+  if (!canAdminInstance(toRecordId(inbox.entityDefinitionKey, inbox.id))) return null
+
+  return (
+    <DropdownMenuItem asChild>
+      <Link href={`/app/settings/inbox/${inbox.id}?tab=settings`}>
+        <PencilIcon />
+        Edit Inbox
+      </Link>
+    </DropdownMenuItem>
+  )
+}

--- a/apps/web/src/components/global/sidebar/personal-mail-group.tsx
+++ b/apps/web/src/components/global/sidebar/personal-mail-group.tsx
@@ -24,6 +24,7 @@ import { usePathname } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import { CollapsibleSidebarSection } from '~/components/global/sidebar/collapsible-sidebar-section'
 import { EditableSidebarItem } from '~/components/global/sidebar/editable-sidebar-item'
+import { InboxEditMenuItem } from '~/components/global/sidebar/inbox-edit-menu-item'
 import type { Inbox } from '~/components/global/sidebar/shared-inbox-group'
 import { SidebarNavItem } from '~/components/global/sidebar/sidebar-nav-item'
 import { useMailCountsStore } from '~/components/mail/store'
@@ -282,6 +283,11 @@ export function PersonalMailItems({
                         !!pathname?.startsWith(`/app/mail/personal/${inbox.id}`) &&
                         !pathname?.startsWith(`/app/mail/personal/${inbox.id}/sent`)
                       }
+                      // Owner-only list (§11), and provisioning grants the owner
+                      // `admin` on their mailbox — so this renders. The gate is
+                      // still asked rather than assumed: a claimed or re-granted
+                      // inbox answers to its rows like any other.
+                      editItems={<InboxEditMenuItem inbox={inbox} />}
                       onToggleEditMode={onToggleEditMode}
                     />
                   </SidebarMenuSubItem>

--- a/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
+++ b/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
@@ -23,15 +23,16 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { Inbox as InboxIcon, Mail } from 'lucide-react'
-import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useCallback, useMemo, useState } from 'react'
 import { useDndState } from '~/app/context/dnd-state-context'
 import { CollapsibleSidebarSection } from '~/components/global/sidebar/collapsible-sidebar-section'
 import { EditableSidebarItem } from '~/components/global/sidebar/editable-sidebar-item'
+import { InboxEditMenuItem } from '~/components/global/sidebar/inbox-edit-menu-item'
 import { SidebarNavItem } from '~/components/global/sidebar/sidebar-nav-item'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
 import { useMailCountsStore } from '~/components/mail/store'
+import type { InboxDefKey } from '~/components/threads/hooks/use-inbox'
 
 export interface Inbox {
   id: string
@@ -42,6 +43,14 @@ export interface Inbox {
   /** Personal-account inbox (mail-permissions §11) — renders the owner affordance. */
   isPersonal?: boolean
   ownerUserId?: string | null
+  /**
+   * Which of the two inbox definitions this row lives on — THE key for minting
+   * its access `RecordId` ({@link InboxEditMenuItem}). Cannot be derived from
+   * `isPersonal`: a personal mailbox awaiting data migration 060 is still on the
+   * shared def and its grants are keyed there. Optional because this shape is
+   * reused for mail views, which have no definition.
+   */
+  entityDefinitionKey?: InboxDefKey
 }
 
 interface SharedInboxesSectionProps {
@@ -86,12 +95,6 @@ const DroppableInboxSidebarItem = ({
   const pathname = usePathname()
   const isActive = pathname?.startsWith(`/app/mail/inboxes/${inbox.id}`)
 
-  const editItems = (
-    <DropdownMenuItem asChild>
-      <Link href={`/app/settings/inbox/${inbox.id}?tab=settings`}>Edit Inbox</Link>
-    </DropdownMenuItem>
-  )
-
   return (
     <div
       ref={setNodeRef}
@@ -108,7 +111,7 @@ const DroppableInboxSidebarItem = ({
         color={inbox.color || 'indigo'}
         isSubmenu={true}
         isActive={isActive}
-        editItems={editItems}
+        editItems={<InboxEditMenuItem inbox={inbox} />}
         onToggleEditMode={onToggleEditMode}
       />
     </div>

--- a/apps/web/src/hooks/use-mail-sidebar.tsx
+++ b/apps/web/src/hooks/use-mail-sidebar.tsx
@@ -61,6 +61,9 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
           color: inbox.color ?? 'indigo',
           isPersonal: true,
           ownerUserId: inbox.ownerUserId,
+          // Carried, never derived from `isPersonal` — the row's "Edit Inbox"
+          // gate mints its access RecordId from this.
+          entityDefinitionKey: inbox.entityDefinitionKey,
         })),
     [rawInboxes, userId]
   )
@@ -92,6 +95,7 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
           isVisible: inboxVisibilitySettings[inbox.id] !== false, // Default true
           isPersonal: inbox.isPersonal,
           ownerUserId: inbox.ownerUserId,
+          entityDefinitionKey: inbox.entityDefinitionKey,
         })
         processedIds.add(id)
       }
@@ -107,6 +111,7 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
           isVisible: inboxVisibilitySettings[inbox.id] !== false, // Default true
           isPersonal: inbox.isPersonal,
           ownerUserId: inbox.ownerUserId,
+          entityDefinitionKey: inbox.entityDefinitionKey,
         })
       }
     })


### PR DESCRIPTION
## The bug

The mail sidebar's inbox list comes from `record.listAll`, and both inbox definitions are exempt from instance-access routing on the READ arm — so **every** inbox in the org comes back to any member holding the def's view rung, including one that only surfaced because a thread from it was shared with them.

The row's 3-dot dropdown then offered **"Edit Inbox"** unconditionally, linking to a settings page the server refuses. Nothing in the row's data said anything about manage authority; the item had no gate at all.

## The fix

Extract the item into `InboxEditMenuItem`, gated on `useAccess().canAdminInstance(...)` — the client mirror of the `admin` rung every inbox mutation enforces (`requireInboxManageAccess` → `InboxService.canManageInboxAccess` → `hasPermission(recordId, 'admin')`), and the same predicate behind `inbox.settingsList`'s `canManage` and the inbox detail page's Edit button. The three now cannot disagree.

**Personal inboxes get the item too** (they had none). Their owner is granted `admin` at provisioning (`provisionPersonalInbox`), so it renders — but asked through the gate rather than assumed, so a claimed or re-granted mailbox answers to its rows like any other. Rendered with a `PencilIcon`, matching the "Edit Sidebar" item below it.

## The subtle part

The access RecordId is minted from the inbox's **own definition**, threaded through `use-mail-sidebar` rather than derived from `isPersonal`. A personal mailbox awaiting data migration 060 is still on the shared def and its grant rows are keyed `inbox:` — deriving `personal_inbox:` from `isPersonal` would search an empty keyspace and hide the owner's own item. An inbox with no definition discriminator fails closed and isn't asked about at all.

## Tests

5 new tests in `inbox-edit-menu-item.test.tsx`, covering the shared-thread case (row renders, item does not), both keyspace-minting cases, and the unknown-def fail-closed path.

## Verification

- `apps/web` vitest: 5/5 pass
- `biome check`: clean on all touched files
- `apps/web` tsc: nothing new (the pre-existing errors in `personal-mail-group.tsx` / `use-mail-sidebar.tsx` are the icon-strip and mail-view-shape ones, untouched here)

## Not in this PR

- The personal **Sent** sub-rows render the same mailboxes and have no Edit item — a second entry there reads as noise, but it's a one-line addition if wanted.
- `/app/settings/inbox/[inboxId]` is still guarded only by `CapabilityPageGuard permissionKey='inboxes.view'`. Hiding the link removes the accidental path; someone typing the URL still reaches the page (with its Edit button correctly absent). Closing that needs an instance-level page guard.
