### PR TITLE
fix(web): permissions tree row polish — empty-state indent, ladder badges, picker width

### DIFF
--- a/apps/web/src/components/agents/ui/detail/permissions/agent-access-level.ts
+++ b/apps/web/src/components/agents/ui/detail/permissions/agent-access-level.ts
@@ -2,7 +2,11 @@
 
 import type { ResourcePermission } from '@auxx/database/enums'
 import type { BadgeProps } from '@auxx/ui/components/badge'
-import { permissionLabel } from '~/components/permissions/ui/level-labels'
+import {
+  LEVEL_OF_PERMISSION,
+  permissionLabel,
+  RUNG_BADGE_VARIANT,
+} from '~/components/permissions/ui/level-labels'
 
 /**
  * The four exact rungs an agent policy can express, ascending
@@ -23,22 +27,30 @@ interface AgentRungMeta {
 }
 
 /**
- * Rung names come from the shared ladder vocabulary; only the helper line and
- * badge colour are agent-specific. What plan 19 §0.5/§7 actually forbids is
- * showing `None` as "Inherit" (the doc 16 §10 bug, one screen over) — an agent
- * never inherits, so a deny must never read as an unset default.
+ * Rung names AND badge colours come from the shared ladder vocabulary; only the
+ * helper line is agent-specific — it is the one thing here that describes what
+ * an AGENT may do with the rung rather than where the rung sits on the ladder.
+ * The colours used to be spelled out again below, which is how the same rung
+ * could have drifted to a different colour here than on the permissions page.
+ * What plan 19 §0.5/§7 actually forbids is showing `None` as "Inherit" (the doc
+ * 16 §10 bug, one screen over) — an agent never inherits, so a deny must never
+ * read as an unset default.
  */
 export const AGENT_ACCESS_LEVEL_META: Record<ResourcePermission, AgentRungMeta> = {
   none: {
     label: permissionLabel('none'),
     helper: 'Denied — cannot discover or use',
-    variant: 'outline',
+    variant: RUNG_BADGE_VARIANT[LEVEL_OF_PERMISSION.none],
   },
-  view: { label: permissionLabel('view'), helper: 'List, read, and search', variant: 'sky' },
+  view: {
+    label: permissionLabel('view'),
+    helper: 'List, read, and search',
+    variant: RUNG_BADGE_VARIANT[LEVEL_OF_PERMISSION.view],
+  },
   edit: {
     label: permissionLabel('edit'),
     helper: 'Read plus create, update, and delete',
-    variant: 'amber',
+    variant: RUNG_BADGE_VARIANT[LEVEL_OF_PERMISSION.edit],
   },
   admin: {
     // Schema administration rides on this rung but has no native tool yet, so the
@@ -46,7 +58,7 @@ export const AGENT_ACCESS_LEVEL_META: Record<ResourcePermission, AgentRungMeta> 
     label: permissionLabel('admin'),
     helper:
       'Read and write, plus administration and settings — schema administration has no tool yet',
-    variant: 'green',
+    variant: RUNG_BADGE_VARIANT[LEVEL_OF_PERMISSION.admin],
   },
 }
 

--- a/apps/web/src/components/permissions/ui/access-tree-row.tsx
+++ b/apps/web/src/components/permissions/ui/access-tree-row.tsx
@@ -89,5 +89,5 @@ export function AccessTreeRow({
 export function AccessRowSelect(
   props: Omit<ComponentProps<typeof AccessLevelSelect>, 'size' | 'variant' | 'className'>
 ) {
-  return <AccessLevelSelect {...props} size='sm' variant='transparent' className='h-7 w-44' />
+  return <AccessLevelSelect {...props} size='sm' variant='transparent' className='h-7 w-60' />
 }

--- a/apps/web/src/components/permissions/ui/def-baseline-rows.tsx
+++ b/apps/web/src/components/permissions/ui/def-baseline-rows.tsx
@@ -3,8 +3,7 @@
 
 import type { ResourcePermission } from '@auxx/database/enums'
 import { EntityIcon } from '@auxx/ui/components/icons'
-import { EmptySection } from '@auxx/ui/components/section'
-import { TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { TreeRowEmpty, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
 import { Lock, ShieldCheck } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Tooltip } from '~/components/global/tooltip'
@@ -55,8 +54,8 @@ export function DefBaselineRows({
 
   if (rows.length === 0) {
     return (
-      <EmptySection
-        orientation='horizontal'
+      <TreeRowEmpty
+        depth={CHILD_DEPTH}
         icon={<ShieldCheck />}
         title='No matches'
         description='No record types match your search.'

--- a/apps/web/src/components/permissions/ui/grantee-def-access-rows.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-def-access-rows.tsx
@@ -4,8 +4,7 @@
 import type { ResourcePermission } from '@auxx/database/enums'
 import { Badge } from '@auxx/ui/components/badge'
 import { EntityIcon } from '@auxx/ui/components/icons'
-import { EmptySection } from '@auxx/ui/components/section'
-import { TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { TreeRowEmpty, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { Lock, ShieldCheck, Table2 } from 'lucide-react'
 import type { ReactNode } from 'react'
@@ -121,8 +120,8 @@ export function GranteeDefAccessRows({
           <TreeRowSkeleton depth={depth} />
         </>
       ) : rows.length === 0 ? (
-        <EmptySection
-          orientation='horizontal'
+        <TreeRowEmpty
+          depth={depth}
           icon={emptyState.icon}
           title={emptyState.title}
           description={emptyState.description}

--- a/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-instance-rows.tsx
@@ -4,8 +4,7 @@
 import { ResourcePermission } from '@auxx/database/enums'
 import { type InstanceAccessKey, Level } from '@auxx/lib/permissions/client'
 import { type RecordId, toRecordId } from '@auxx/types/resource'
-import { EmptySection } from '@auxx/ui/components/section'
-import { TreeRowButton, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { TreeRowButton, TreeRowEmpty, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { AlertTriangle, Library, Users } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
@@ -205,8 +204,8 @@ export function GranteeInstanceRows({
           <TreeRowSkeleton depth={depth} />
         </>
       ) : rows.length === 0 ? (
-        <EmptySection
-          orientation='horizontal'
+        <TreeRowEmpty
+          depth={depth}
           icon={emptyState.icon}
           title={emptyState.title}
           description={emptyState.description}

--- a/apps/web/src/components/permissions/ui/instance-baseline-rows.tsx
+++ b/apps/web/src/components/permissions/ui/instance-baseline-rows.tsx
@@ -5,8 +5,7 @@ import type { ResourcePermission } from '@auxx/database/enums'
 import type { InstanceAccessKey } from '@auxx/lib/permissions/client'
 import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
-import { EmptySection } from '@auxx/ui/components/section'
-import { TreeRow, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { TreeRow, TreeRowEmpty, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
 import { Library } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
 import type { InstanceBaselineRow } from '../hooks/use-instance-baseline-rows'
@@ -86,8 +85,8 @@ export function InstanceBaselineRows({
     return (
       <div className='flex flex-col gap-0.5'>
         {leadingRow}
-        <EmptySection
-          orientation='horizontal'
+        <TreeRowEmpty
+          depth={CHILD_DEPTH}
           icon={<Library />}
           title='No matches'
           description='No items match your search.'

--- a/apps/web/src/components/permissions/ui/level-labels.ts
+++ b/apps/web/src/components/permissions/ui/level-labels.ts
@@ -2,6 +2,7 @@
 
 import { ResourcePermission, type Rung } from '@auxx/database/enums'
 import { Level, rungToPermission } from '@auxx/lib/permissions/client'
+import type { BadgeProps } from '@auxx/ui/components/badge'
 
 /**
  * The single display vocabulary for the four-rung access ladder (plan 26 §2.1).
@@ -43,6 +44,27 @@ export const RUNG_LABELS_LONG: Record<Level, string> = {
 
 /** Which form of the label a caller wants. */
 export type LabelForm = 'short' | 'long'
+
+/**
+ * Badge colour per rung — the ladder's one palette, ascending from a neutral
+ * outline through sky and amber to green.
+ *
+ * It is here for the same reason the label maps are: this exact mapping was
+ * already written out twice (the agent policy's rung meta and
+ * `ResolvedAccessDialog`'s fallback meta), and a rung that is amber on one
+ * permissions surface and yellow on the next teaches the reader nothing. Both
+ * of those maps now read their `variant` from here and keep only what is
+ * genuinely theirs — the helper sentence describing what the rung authorizes.
+ *
+ * `None` is `outline` rather than a red: it is the bottom of a ladder, not a
+ * failure, and it renders beside rungs an admin deliberately chose.
+ */
+export const RUNG_BADGE_VARIANT: Record<Level, NonNullable<BadgeProps['variant']>> = {
+  [Level.None]: 'outline',
+  [Level.Read]: 'sky',
+  [Level.Edit]: 'amber',
+  [Level.Full]: 'green',
+}
 
 /**
  * The rung as it appears in an **effective-access line** (plan 31 §2.5) — what a

--- a/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/leveled-area-grid.tsx
@@ -14,6 +14,7 @@ import { AreaAccessRow, hasAreaAccessRow } from './area-access-row'
 import { clampToArea, LevelControl } from './level-control'
 import { effectiveLevelLabel } from './level-labels'
 import { PROFILE_AREA_GROUPS } from './profile-copy'
+import { RungBadge } from './rung-badge'
 
 /** The grid's live filter, handed to {@link LeveledAreaGridProps.renderChildren}. */
 export interface AreaChildFilter {
@@ -259,9 +260,7 @@ export function LeveledAreaGrid({
                               <AlertTriangle className='size-3.5 text-amber-500' />
                             </Tooltip>
                           ) : null}
-                          <span className='text-xs text-muted-foreground whitespace-nowrap'>
-                            {effectiveLevelLabel(clampToArea(meta, value ?? inherited))}
-                          </span>
+                          <RungBadge level={clampToArea(meta, value ?? inherited)} />
                         </>
                       ) : undefined
                     }

--- a/apps/web/src/components/permissions/ui/profile-area-grid.tsx
+++ b/apps/web/src/components/permissions/ui/profile-area-grid.tsx
@@ -13,7 +13,6 @@ import { type ReactNode, useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { AreaAccessRow, hasAreaAccessRow } from './area-access-row'
 import { clampToArea, LevelControl } from './level-control'
-import { effectiveLevelLabel } from './level-labels'
 import type { AreaChildFilter, AreaChildren } from './leveled-area-grid'
 import {
   PROFILE_AREA_GROUPS,
@@ -21,6 +20,7 @@ import {
   WORKER_LOCK_REASON,
   WORKER_SEAT_AREAS,
 } from './profile-copy'
+import { RungBadge } from './rung-badge'
 
 interface ProfileAreaGridProps {
   /**
@@ -418,15 +418,11 @@ function ProfileAreaRow({
       // §2.1b — a collapsed header must still be scannable. Nine of ~15 rows now
       // hide their control inside a child block, so without this an admin cannot
       // read a profile without expanding everything: 0.7 would trade one
-      // legibility problem for another. `effectiveLevelLabel` spells the bottom
-      // rung "No access" rather than "None", so it never reads as a missing value.
+      // legibility problem for another. `RungBadge` spells the bottom rung
+      // "No access" rather than "None", so it never reads as a missing value.
       actions={
         hasAccessRow ? (
-          <span className='text-xs text-muted-foreground whitespace-nowrap'>
-            {effectiveLevelLabel(
-              clampToArea(meta, isSeatLocked ? Level.None : (value ?? inherited))
-            )}
-          </span>
+          <RungBadge level={clampToArea(meta, isSeatLocked ? Level.None : (value ?? inherited))} />
         ) : undefined
       }
       trailing={

--- a/apps/web/src/components/permissions/ui/resolved-access-dialog.tsx
+++ b/apps/web/src/components/permissions/ui/resolved-access-dialog.tsx
@@ -15,7 +15,7 @@ import { EmptySection } from '@auxx/ui/components/section'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { ShieldQuestion } from 'lucide-react'
 import { useState } from 'react'
-import { RUNG_LABELS } from './level-labels'
+import { RUNG_BADGE_VARIANT, RUNG_LABELS } from './level-labels'
 
 /** Shared row chrome — same shape the leveled grids use. */
 const ROW_CLASS = 'bg-primary-50 hover:bg-primary-100'
@@ -41,15 +41,30 @@ export type ResolvedAccessLevelMetaMap = Record<ResolvedAccessLevel, ResolvedAcc
 /**
  * Last-resort names, used only when a caller's map is missing a rung. `none`
  * reads as an explicit denial, never as "inherit" or an empty cell (doc 19 §7).
+ * Labels and colours both come from the shared ladder vocabulary — a fallback
+ * that invented its own would be the hardest kind of drift to notice, since it
+ * only ever renders where a caller already forgot a rung.
  */
 const FALLBACK_LEVEL_META: ResolvedAccessLevelMetaMap = {
-  none: { label: RUNG_LABELS[Level.None], helper: 'Denied', variant: 'outline' },
-  read: { label: RUNG_LABELS[Level.Read], helper: 'Read only', variant: 'sky' },
-  write: { label: RUNG_LABELS[Level.Edit], helper: 'Read plus write', variant: 'amber' },
+  none: {
+    label: RUNG_LABELS[Level.None],
+    helper: 'Denied',
+    variant: RUNG_BADGE_VARIANT[Level.None],
+  },
+  read: {
+    label: RUNG_LABELS[Level.Read],
+    helper: 'Read only',
+    variant: RUNG_BADGE_VARIANT[Level.Read],
+  },
+  write: {
+    label: RUNG_LABELS[Level.Edit],
+    helper: 'Read plus write',
+    variant: RUNG_BADGE_VARIANT[Level.Edit],
+  },
   full: {
     label: RUNG_LABELS[Level.Full],
     helper: 'Read and write, plus administration',
-    variant: 'green',
+    variant: RUNG_BADGE_VARIANT[Level.Full],
   },
 }
 

--- a/apps/web/src/components/permissions/ui/rung-badge.tsx
+++ b/apps/web/src/components/permissions/ui/rung-badge.tsx
@@ -1,0 +1,32 @@
+// apps/web/src/components/permissions/ui/rung-badge.tsx
+'use client'
+
+import type { Level } from '@auxx/lib/permissions/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { effectiveLevelLabel, RUNG_BADGE_VARIANT } from './level-labels'
+
+/**
+ * A rung as it reads at the END of an area row — the resolved level a collapsed
+ * header states when its control lives one row down (plan 26 §2.1b).
+ *
+ * It was `<span className='text-xs text-muted-foreground'>` on both grids, which
+ * put the one thing a reader scans a collapsed profile FOR in the same grey as
+ * the fall-through hints beside it. A badge is scannable at a glance and, colour
+ * coded off {@link RUNG_BADGE_VARIANT}, distinguishes the rungs without being
+ * read — which is the whole point of a label that exists so the tree does not
+ * have to be expanded.
+ *
+ * Copy is unchanged: {@link effectiveLevelLabel}, so the bottom rung stays
+ * *No access* rather than a bare "None" that reads as a missing value.
+ *
+ * `mr-2` because `TreeRow`'s actions cluster has no padding of its own: the rows
+ * that end in a picker get their inset from the control's own box, and a bare
+ * badge would otherwise sit hard against the row's right edge.
+ */
+export function RungBadge({ level }: { level: Level }) {
+  return (
+    <Badge variant={RUNG_BADGE_VARIANT[level]} size='xs' className='mr-2 whitespace-nowrap'>
+      {effectiveLevelLabel(level)}
+    </Badge>
+  )
+}

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -1,6 +1,7 @@
 // packages/ui/src/components/tree-row.tsx
 'use client'
 
+import { EmptySection, type EmptySectionProps } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SimpleTooltip, TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
@@ -424,6 +425,27 @@ export function TreeRowSkeleton({ depth = 0 }: { depth?: number }) {
         <Skeleton className='size-4 shrink-0 rounded' />
         <Skeleton className='h-4 w-40 max-w-full' />
       </div>
+    </div>
+  )
+}
+
+/**
+ * The empty twin of {@link TreeRowSkeleton}: a horizontal {@link EmptySection}
+ * carrying the same indent its sibling rows have, so a list that empties out
+ * (a search miss, a filter) keeps sitting at its own level instead of jumping
+ * back to the parent's.
+ *
+ * `depth` is the only reason this exists — `EmptySection` is a card primitive
+ * with no tree awareness, and the three states of one list (loading, empty,
+ * populated) must all read the same indent from the same `INDENT_REM` step.
+ */
+export function TreeRowEmpty({
+  depth = 0,
+  ...props
+}: { depth?: number } & Omit<EmptySectionProps, 'orientation'>) {
+  return (
+    <div style={{ paddingLeft: `${depth * INDENT_REM}rem` }}>
+      <EmptySection orientation='horizontal' {...props} />
     </div>
   )
 }


### PR DESCRIPTION
Three presentation fixes on `/app/settings/permissions`, found while looking at the Profiles tab.

## 1. The empty state sat at the wrong indent

The empty branch of the permissions access lists rendered a bare `EmptySection` — a card primitive with no tree awareness — so it sat flush at depth 0 while the **loading** branch (`TreeRowSkeleton depth={depth}`) and the **populated** branch (`AccessTreeRow depth={depth}`) both indented one level under their area row. Three states of one list, two of them indented.

Adds `TreeRowEmpty` beside `TreeRowSkeleton` in `@auxx/ui` — same `depth * INDENT_REM` padding, so all three states read the same indent from the same step — and swaps it in at the **four** permissions call sites that had the bug (`grantee-instance-rows`, `grantee-def-access-rows`, `instance-baseline-rows`, `def-baseline-rows`).

Measured after: empty box left `615` = `Agent access` row left `615`. Its text lands at `652` vs an icon-bearing sibling's `651` — `EmptySection`'s `px-3` + `gap-2` happens to equal `TreeRow`'s icon box + padding.

`grantee-list.tsx` already applied this offset by hand, with a comment naming the hazard. It stays on `EmptySection` because it uses the `vertical` orientation, which `TreeRowEmpty` does not cover.

## 2. Ladder labels are badges

A collapsed area row states its resolved rung as text, because the control lives one row down. It rendered in `text-muted-foreground` — putting the one thing an admin scans a collapsed profile *for* in the same grey as the fall-through hints beside it. `RungBadge` renders it as `<Badge size='xs'>` instead, so the rung is distinguishable without being read.

**Copy is unchanged** — still `effectiveLevelLabel`, so the bottom rung stays *No access* rather than a bare "None" that reads as a missing value.

**The colours are not new.** `RUNG_BADGE_VARIANT` (`None` outline / `Read` sky / `Edit` amber / `Full` green) was already spelled out twice — the agent policy's rung meta and `ResolvedAccessDialog`'s fallback meta. It moves into `level-labels.ts`, the file that already holds the one rung vocabulary, and both maps now read `variant` from there, keeping only their own helper sentences. A rung that is amber on one permissions surface and something else on the next teaches the reader nothing.

Left as text on purpose:
- **`N set`** — a count, not a rung; already a `secondary` badge.
- **`Not set · …`** and **`Effective · …`** — both sit beside the *title*, not at the row end. Badging them would put two coloured chips on one row competing for the same read.
- **`grantee-list.tsx`'s locked label** — generic over the choice type, and its other caller is mail's 4-tier lens ladder. Converting only the instance side would split the two.

## 3. Picker width

`AccessRowSelect`'s `w-44` clipped the wider fall-through triggers (`Inherit · Full access` runs longer than any bare rung label). `w-60` sizes the slot to the longest option the picker can show.

## Verification

- Driven in the browser on `/app/settings/permissions`. All four badge variants confirmed rendering on Group overrides: Inboxes `No access`, Datasets `Read`, Knowledge Base `Edit`, Signatures/Snippets/Dashboards/Workflows/Agents `Full`.
- `biome check` clean on every touched file.
- `apps/web` typecheck: no errors in any touched file. Grepped rather than trusting the exit code — that project carries a ~2.2k pre-existing baseline.
- No tests added: presentation-only, no behaviour or authorization change.