### PR TITLE
fix(ci): exclude vitest.config.ts from the web project, and fail ci-ok on cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,22 +181,31 @@ jobs:
     needs: [changes, lint, typecheck, test]
     runs-on: ubuntu-latest
     steps:
+      # `success` and `skipped` pass; EVERYTHING else fails. The earlier version
+      # tested only for `failure`, which let `cancelled` through as green — and
+      # that is not hypothetical. On 2026-07-30 a push superseded an in-flight
+      # run, `Typecheck (web)` was cancelled mid-job, `ci-ok` reported success,
+      # and a TS6307 that job would have caught sat on `main` until an unrelated
+      # commit tripped it.
+      #
+      # A superseded run reporting failure is the correct reading: it verified
+      # nothing. The run that replaced it is the one that speaks for the commit.
       - name: Check results
         run: |
-          if [[ "${{ needs.changes.result }}" == "failure" ]]; then
-            echo "::error::changes job failed"
-            exit 1
-          fi
-          if [[ "${{ needs.lint.result }}" == "failure" ]]; then
-            echo "::error::lint job failed"
-            exit 1
-          fi
-          if [[ "${{ needs.typecheck.result }}" == "failure" ]]; then
-            echo "::error::typecheck job failed"
-            exit 1
-          fi
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
-            echo "::error::test job failed"
+          failed=0
+          for job in changes lint typecheck test; do
+            case "$job" in
+              changes)   result="${{ needs.changes.result }}" ;;
+              lint)      result="${{ needs.lint.result }}" ;;
+              typecheck) result="${{ needs.typecheck.result }}" ;;
+              test)      result="${{ needs.test.result }}" ;;
+            esac
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "::error::$job job did not pass (result: $result)"
+              failed=1
+            fi
+          done
+          if [[ "$failed" == "1" ]]; then
             exit 1
           fi
           echo "All checks passed or were skipped"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -36,6 +36,12 @@
     "**/*.test.tsx",
     "**/*.spec.ts",
     "**/*.spec.tsx",
-    "**/__tests__/**"
+    "**/__tests__/**",
+    // Vitest's own config is not app code, and `packages/lib` already excludes
+    // it for that reason. It matters here because the config imports the shared
+    // alias map from the REPO ROOT: under `composite: true` every file in the
+    // program must be listed by the project, and `../../vitest.alias.ts` cannot
+    // be — so tsc reported TS6307 against a file Next never compiles.
+    "vitest.config.*"
   ]
 }


### PR DESCRIPTION
`main` is red on `Typecheck (web)`:

```
web: 1 NEW type error location(s)
  vitest.config.ts  TS6307  0 -> 1
```

Mine, from #1418.

## The error

That commit gave `apps/web/vitest.config.ts` an import of the shared alias map at the **repo root**. `apps/web` is `composite: true`, and a composite project must list every file in its program — `../../vitest.alias.ts` is outside `apps/web` and cannot be listed.

So tsc reported an error against a file Next never compiles. `packages/lib` already excludes `vitest.config.*` for exactly this reason; `apps/web` now does too. Its `include` is `**/*.ts`, which was sweeping a test-runner config into the app's type program in the first place.

**web: 3986 → 3985.**

## Why CI didn't catch it on #1418

Because the job that would have caught it was **cancelled**, and `ci-ok` read that as green.

The check tested each job for `== "failure"` and nothing else, so `cancelled` — along with `timed_out` and `action_required` — passed straight through. A push superseded #1418's in-flight run, `Typecheck (web)` died mid-job, `ci-ok` reported success, and the error sat on `main` until an unrelated commit tripped it.

`ci-ok` now passes only `success` and `skipped`.

**The tradeoff, stated plainly:** superseded runs will now show a red `ci-ok`. I think that's the correct reading — a cancelled run verified nothing, and the run that replaced it is the one that speaks for the commit. The alternative is what just happened: a green tick over a job that never finished. If you'd rather not have that noise on superseded runs, the narrower version is to fail only on `cancelled` for the `typecheck` and `test` jobs and leave the rest, but I'd argue against special-casing.

## My part in it

Two things I got wrong, both worth naming:

1. I added a root-level import to a `composite: true` project and didn't re-run the web ratchet afterwards — I'd run it earlier in that PR, before making this edit.
2. I saw the cancelled `Typecheck (web)` on #1418's run, said it was "benign in practice" because a newer run would cover the tree, and moved on. It wasn't benign. The newer runs were also cancelled or didn't re-check, and the failure surfaced hours later on an unrelated commit.