### PR TITLE
feat(permissions): stage every grid edit behind a save bar

### DIFF
--- a/apps/web/src/components/permissions/hooks/use-def-baselines.ts
+++ b/apps/web/src/components/permissions/hooks/use-def-baselines.ts
@@ -17,6 +17,7 @@ import { useCallback, useMemo } from 'react'
 import { useResources } from '~/components/resources/hooks'
 import { api } from '~/trpc/react'
 import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permission-grants'
+import { type AccessChoice, type StagedSurface, useStagedEdits } from './use-staged-edits'
 
 /** One CRM def's row under the Record types collection. */
 export interface DefBaselineRow {
@@ -46,16 +47,23 @@ export interface DefBaselineRow {
  * Reads `resourceAccess.allTypeAccess` (all type rows, org-wide) plus
  * `useResources`, and derives per def: the configured baseline (if any), the
  * level it inherits from the Member profile's Records rung, and whether it is
- * locked down. Writes go through `grantType` / `revokeType` with an optimistic
- * cache patch, so picking **No Access** shows its restriction lock without a
- * reload.
+ * locked down.
+ *
+ * **Edits are STAGED, not written** (see {@link useStagedEdits}). `setBaseline`
+ * only moves the select; `save()` flushes every staged row through
+ * `grantType` / `revokeType`, so this grid commits from the host's `FormSaveBar`
+ * exactly like the profile editor does.
  *
  * Unlike {@link useGranteeDefAccess} there is no first-touch baseline write to
  * make — this surface *is* the baseline. Invalidation is broadened to the whole
  * `resourceAccess` namespace because the per-def tab reads the same rows under a
  * different query key (`forType`). Errors surface via `toastError`.
  */
-export function useDefBaselines() {
+export function useDefBaselines(): {
+  isLoading: boolean
+  rows: DefBaselineRow[]
+  setBaseline: (entityDefinitionId: string, level: AccessChoice) => void
+} & StagedSurface {
   const utils = api.useUtils()
   const { resources, isLoading: resourcesLoading } = useResources()
   const { isLoading: grantsLoading, roleDefaults, baseline } = usePermissionGrants()
@@ -143,12 +151,29 @@ export function useDefBaselines() {
     return map
   }, [allRows])
 
+  const {
+    edits: staged,
+    entries: stagedEntries,
+    stage,
+    discard,
+    replace,
+    isDirty,
+  } = useStagedEdits<AccessChoice>()
+
   const rows = useMemo<DefBaselineRow[]>(
     () =>
       resources
         .filter(isAccessManageable)
         .map((resource) => {
-          const baselineLevel = baselineByDef.get(resource.entityDefinitionId)
+          // Staged edits win over the persisted row, so the select moves the
+          // instant it is clicked even though nothing has been written yet.
+          const choice = staged[resource.entityDefinitionId]
+          const baselineLevel =
+            choice === undefined
+              ? baselineByDef.get(resource.entityDefinitionId)
+              : choice === 'inherit'
+                ? undefined
+                : choice
           const baseArea = ENTITY_BASE_AREAS[resource.entityType ?? ''] ?? Area.records
           return {
             resource,
@@ -162,39 +187,67 @@ export function useDefBaselines() {
           }
         })
         .sort((a, b) => a.resource.plural.localeCompare(b.resource.plural)),
-    [resources, baselineByDef, inheritedPermissionByArea]
+    [resources, baselineByDef, inheritedPermissionByArea, staged]
   )
 
   /**
-   * Set a def's workspace baseline. `'inherit'` deletes the row so the def falls
-   * back to the Member profile's Records level; every explicit level (including `none`, the
-   * restriction marker) writes it.
+   * Stage a def's workspace baseline. `'inherit'` will delete the row so the def
+   * falls back to the Member profile's Records level; every explicit level
+   * (including `none`, the restriction marker) will write it. Nothing is sent
+   * until {@link save}.
    */
   const setBaseline = useCallback(
-    (entityDefinitionId: string, level: ResourcePermission | 'inherit') => {
-      if (level === 'inherit') {
-        patchLocal(entityDefinitionId)
-        revokeType.mutate({
-          entityDefinitionId,
-          granteeType: ResourceGranteeType.role,
-          granteeId: MEMBER_BASELINE_GRANTEE_ID,
-        })
-        return
-      }
-      patchLocal(entityDefinitionId, level)
-      grantType.mutate({
-        entityDefinitionId,
-        granteeType: ResourceGranteeType.role,
-        granteeId: MEMBER_BASELINE_GRANTEE_ID,
-        rung: permissionToRung(level),
-      })
+    (entityDefinitionId: string, level: AccessChoice) => {
+      stage(entityDefinitionId, level, baselineByDef.get(entityDefinitionId) ?? 'inherit')
     },
-    [grantType, revokeType, patchLocal]
+    [stage, baselineByDef]
   )
+
+  /**
+   * Flush every staged row, one write at a time.
+   *
+   * A row whose write fails STAYS staged (its `toastError` already fired), so the
+   * bar remains up and Save retries only what is left. The optimistic
+   * `patchLocal` still runs per row, and the trailing `invalidate` is awaited
+   * before the staging map is cleared — otherwise the select would flash back to
+   * the pre-save value in the window before the refetch lands.
+   */
+  const save = useCallback(async () => {
+    const failed: Record<string, AccessChoice> = {}
+    for (const [entityDefinitionId, level] of stagedEntries) {
+      try {
+        if (level === 'inherit') {
+          patchLocal(entityDefinitionId)
+          await revokeType.mutateAsync({
+            entityDefinitionId,
+            granteeType: ResourceGranteeType.role,
+            granteeId: MEMBER_BASELINE_GRANTEE_ID,
+          })
+        } else {
+          patchLocal(entityDefinitionId, level)
+          await grantType.mutateAsync({
+            entityDefinitionId,
+            granteeType: ResourceGranteeType.role,
+            granteeId: MEMBER_BASELINE_GRANTEE_ID,
+            rung: permissionToRung(level),
+          })
+        }
+      } catch {
+        failed[entityDefinitionId] = level
+      }
+    }
+    await invalidate()
+    replace(failed)
+    return Object.keys(failed).length === 0
+  }, [stagedEntries, patchLocal, grantType, revokeType, invalidate, replace])
 
   return {
     isLoading: resourcesLoading || rowsQuery.isLoading || grantsLoading,
     rows,
     setBaseline,
+    isDirty,
+    isSaving: grantType.isPending || revokeType.isPending,
+    save,
+    discard,
   }
 }

--- a/apps/web/src/components/permissions/hooks/use-grantee-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-access.ts
@@ -33,12 +33,15 @@ export type GranteeAccessData = RouterOutputs['permissions']['granteeAccess']
  * The `permission-grant.changed` realtime nudge does not cover this either: it
  * targets the AFFECTED member's own client so their `myCapabilities` refreshes,
  * not the admin's client sitting on that member's Permissions tab.
+ *
+ * Returns the invalidation promise so a staged flush can await the refetch before
+ * clearing its edits (`useStagedEdits`) — otherwise every select would flash back
+ * to its pre-save value for the length of the round-trip. `onSettled` callers
+ * ignore it, which is why it is `void`-ed at those call sites rather than here.
  */
 export function useInvalidateGranteeAccess() {
   const utils = api.useUtils()
-  return useCallback(() => {
-    void utils.permissions.granteeAccess.invalidate()
-  }, [utils])
+  return useCallback(() => utils.permissions.granteeAccess.invalidate(), [utils])
 }
 
 /**

--- a/apps/web/src/components/permissions/hooks/use-grantee-area-levels.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-area-levels.ts
@@ -1,0 +1,74 @@
+// apps/web/src/components/permissions/hooks/use-grantee-area-levels.ts
+'use client'
+
+import type { Area, Level } from '@auxx/lib/permissions/client'
+import { useCallback, useMemo } from 'react'
+import { type OverrideGranteeType, useGrantWrites } from './use-permission-grants'
+import { type StagedSurface, useStagedEdits } from './use-staged-edits'
+
+/**
+ * Staged Layer-2 area levels for one override grantee — the group/member twin of
+ * `useProfileEditor`'s draft, and the reason those two surfaces now commit the
+ * same way.
+ *
+ * Both hosts of the override grid (the permissions page's Group/Member overrides
+ * tab, and a member or team detail page's Access levels section) used to write
+ * `permissions.grant` on every select change while the profile editor next door
+ * drafted and saved from a `FormSaveBar`. Identical-looking controls, two commit
+ * models. This stages instead, and the host flushes it.
+ *
+ * `persisted` is the grantee's stored sparse map — from `listGrants` on the
+ * overrides tab, from `granteeAccess.own.areas` on a detail page. It stays the
+ * caller's to supply because those are different queries over the same rows.
+ *
+ * The flush is ONE `permissions.grant` write of the whole resulting map (that is
+ * the mutation's shape), so a failure keeps every staged area rather than a
+ * partial set — there is no partial success to reflect.
+ */
+export function useGranteeAreaLevels(
+  granteeType: OverrideGranteeType,
+  granteeId: string,
+  persisted: Partial<Record<Area, Level>>
+): {
+  /** `persisted` with the staged edits laid over it — what the grid renders. */
+  values: Partial<Record<Area, Level>>
+  /** Stage one area's level; `undefined` stages a fall-through to the baseline. */
+  setLevel: (area: Area, level: Level | undefined) => void
+} & StagedSurface {
+  const { saveAsync, isSaving } = useGrantWrites()
+  const { entries: stagedEntries, stage, discard, isDirty } = useStagedEdits<Level | 'inherit'>()
+
+  const values = useMemo(() => {
+    const next = { ...persisted }
+    for (const [area, level] of stagedEntries) {
+      // `'inherit'` DELETES the key — the area falls through to the member
+      // baseline. An explicit `Level.None` is `0` and must never be conflated
+      // with absent: it is the only way an override says "no access".
+      if (level === 'inherit') delete next[area as Area]
+      else next[area as Area] = level
+    }
+    return next
+  }, [persisted, stagedEntries])
+
+  const setLevel = useCallback(
+    (area: Area, level: Level | undefined) => {
+      stage(area, level ?? 'inherit', persisted[area] ?? 'inherit')
+    },
+    [stage, persisted]
+  )
+
+  const save = useCallback(async () => {
+    if (stagedEntries.length === 0) return true
+    try {
+      await saveAsync(granteeType, granteeId, values)
+    } catch {
+      // `useGrantWrites` already reported it; keep every edit staged so the bar
+      // stays up and Save retries the same map.
+      return false
+    }
+    discard()
+    return true
+  }, [stagedEntries, saveAsync, granteeType, granteeId, values, discard])
+
+  return { values, setLevel, isDirty, isSaving, save, discard }
+}

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.test.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.test.ts
@@ -2,7 +2,7 @@
 
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import { Area, Level } from '@auxx/lib/permissions/client'
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -21,6 +21,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * (`own.defs` for the grantee's grant, `baseline.defs` for the workspace
  * default), and that the optimistic write still lands — on `own`/`baseline`,
  * which the server stores verbatim, and NEVER on `effective`, which is composed.
+ *
+ * Since the staged-edits change, `setLevel` **writes nothing**: it stages, and
+ * `save()` flushes. Every write assertion below therefore drives both, and the
+ * dedicated `staging` block pins the half that has no mutation at all.
  */
 
 const {
@@ -56,8 +60,8 @@ vi.mock('~/trpc/react', () => ({
       roleDefaults: { useQuery: roleDefaultsQuery },
     },
     resourceAccess: {
-      grantType: { useMutation: () => ({ mutate: grantTypeMutate }) },
-      revokeType: { useMutation: () => ({ mutate: revokeTypeMutate }) },
+      grantType: { useMutation: () => ({ mutateAsync: grantTypeMutate, isPending: false }) },
+      revokeType: { useMutation: () => ({ mutateAsync: revokeTypeMutate, isPending: false }) },
     },
   },
 }))
@@ -116,6 +120,36 @@ function setup(data: Payload, granteeKind: 'user' | 'group' = 'user') {
   return renderHook(() => useGranteeDefAccess(granteeKind, USER)).result
 }
 
+/** Stage one level. Wrapped in `act` — staging is a state update now. */
+async function stage(
+  result: { current: { setLevel: (id: string, level: ResourcePermission | 'inherit') => void } },
+  entityDefinitionId: string,
+  level: ResourcePermission | 'inherit'
+) {
+  await act(async () => {
+    result.current.setLevel(entityDefinitionId, level)
+  })
+}
+
+/** Stage one level and flush it — the two halves of what `setLevel` used to do. */
+async function stageAndSave(
+  result: {
+    current: {
+      setLevel: (id: string, level: ResourcePermission | 'inherit') => void
+      save: () => Promise<boolean>
+    }
+  },
+  entityDefinitionId: string,
+  level: ResourcePermission | 'inherit'
+) {
+  await stage(result, entityDefinitionId, level)
+  let ok = false
+  await act(async () => {
+    ok = await result.current.save()
+  })
+  return ok
+}
+
 /** Run the last `setData` updater over `prev` and return what it produced. */
 function patched(prev: Payload) {
   const call = granteeAccessSetData.mock.calls.at(-1)
@@ -135,6 +169,9 @@ beforeEach(() => {
   ]) {
     fn.mockReset()
   }
+  // `save` awaits every write, so the mutation mocks must resolve.
+  grantTypeMutate.mockResolvedValue(undefined)
+  revokeTypeMutate.mockResolvedValue(undefined)
 })
 
 describe('rows are derived from the grantee-scoped payload', () => {
@@ -200,12 +237,12 @@ describe('writes patch own/baseline optimistically and never effective', () => {
     baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } },
   })
 
-  it("writes the new permission onto own.defs, addressed to this grantee's key", () => {
+  it("writes the new permission onto own.defs, addressed to this grantee's key", async () => {
     const result = setup(
       payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
     )
 
-    result.current.setLevel(TICKET, ResourcePermission.edit)
+    await stageAndSave(result, TICKET, ResourcePermission.edit)
 
     const { input, next } = patched(prev)
     expect(input).toEqual({ granteeType: 'user', granteeId: USER })
@@ -221,22 +258,22 @@ describe('writes patch own/baseline optimistically and never effective', () => {
     })
   })
 
-  it('leaves effective alone — it is composed, and the invalidation owns it', () => {
+  it('leaves effective alone — it is composed, and the invalidation owns it', async () => {
     const result = setup(
       payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
     )
 
-    result.current.setLevel(TICKET, ResourcePermission.edit)
+    await stageAndSave(result, TICKET, ResourcePermission.edit)
 
     expect(patched(prev).next.effective).toBe(prev.effective)
   })
 
-  it('drops the row from own.defs on Inherit, and revokes', () => {
+  it('drops the row from own.defs on Inherit, and revokes', async () => {
     const result = setup(
       payload({ own: { areas: {}, defs: { [CONTACT]: ResourcePermission.view } } })
     )
 
-    result.current.setLevel(CONTACT, 'inherit')
+    await stageAndSave(result, CONTACT, 'inherit')
 
     expect(patched(prev).next.own.defs).toEqual({})
     expect(revokeTypeMutate).toHaveBeenCalledWith({
@@ -252,10 +289,10 @@ describe('writes patch own/baseline optimistically and never effective', () => {
    * every other member out. The baseline write has to be patched too, or the row
    * re-renders as "Restricted" for the moment before the refetch lands.
    */
-  it('writes and patches the workspace baseline on first touch', () => {
+  it('writes and patches the workspace baseline on first touch', async () => {
     const result = setup(payload({ own: { areas: { [Area.records]: Level.Full }, defs: {} } }))
 
-    result.current.setLevel(CONTACT, ResourcePermission.admin)
+    await stageAndSave(result, CONTACT, ResourcePermission.admin)
 
     // Two `grantType` calls: the baseline first, then the grantee's own row.
     expect(grantTypeMutate).toHaveBeenNthCalledWith(1, {
@@ -277,12 +314,12 @@ describe('writes patch own/baseline optimistically and never effective', () => {
     expect(patched(prev).next.own.defs[CONTACT]).toBe(ResourcePermission.admin)
   })
 
-  it('does NOT re-write the baseline when the def already has one', () => {
+  it('does NOT re-write the baseline when the def already has one', async () => {
     const result = setup(
       payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
     )
 
-    result.current.setLevel(TICKET, ResourcePermission.admin)
+    await stageAndSave(result, TICKET, ResourcePermission.admin)
 
     expect(grantTypeMutate).toHaveBeenCalledTimes(1)
     expect(grantTypeMutate).toHaveBeenCalledWith(
@@ -290,15 +327,99 @@ describe('writes patch own/baseline optimistically and never effective', () => {
     )
   })
 
-  it('does not touch the cache when the grantee page is not mounted', () => {
+  it('does not touch the cache when the grantee page is not mounted', async () => {
     const result = setup(
       payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
     )
 
-    result.current.setLevel(TICKET, ResourcePermission.edit)
+    await stageAndSave(result, TICKET, ResourcePermission.edit)
 
     const updater = granteeAccessSetData.mock.calls.at(-1)?.[1] as (p: unknown) => unknown
     expect(updater(undefined)).toBeUndefined()
+  })
+})
+
+/**
+ * The staged-edits contract. Before this, every select change fired a mutation
+ * while the profile editor next door drafted and saved from a `FormSaveBar` —
+ * identical-looking controls, two commit models. `setLevel` now only stages.
+ */
+describe('edits stage until save', () => {
+  it('writes nothing on setLevel, and shows the staged value on the row', async () => {
+    const result = setup(
+      payload({ baseline: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
+    )
+
+    await stage(result, TICKET, ResourcePermission.edit)
+
+    expect(grantTypeMutate).not.toHaveBeenCalled()
+    expect(revokeTypeMutate).not.toHaveBeenCalled()
+    expect(granteeAccessSetData).not.toHaveBeenCalled()
+    expect(result.current.isDirty).toBe(true)
+    // The select still moves — the row reads the staged value, not the server's.
+    expect(
+      result.current.rows.find((r) => r.resource.entityDefinitionId === TICKET)?.grantLevel
+    ).toBe(ResourcePermission.edit)
+  })
+
+  it('is clean again when a row is staged back to its persisted value', async () => {
+    const result = setup(
+      payload({ own: { areas: {}, defs: { [TICKET]: ResourcePermission.view } } })
+    )
+
+    await stage(result, TICKET, ResourcePermission.edit)
+    expect(result.current.isDirty).toBe(true)
+
+    await stage(result, TICKET, ResourcePermission.view)
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('drops every staged edit on discard', async () => {
+    const result = setup(payload())
+
+    await stage(result, TICKET, ResourcePermission.edit)
+    await act(async () => {
+      result.current.discard()
+    })
+
+    expect(result.current.isDirty).toBe(false)
+    expect(
+      result.current.rows.find((r) => r.resource.entityDefinitionId === TICKET)?.grantLevel
+    ).toBeUndefined()
+  })
+
+  /**
+   * A failed write has to stay staged or the bar disappears and the admin
+   * believes a change landed that did not. The rows that DID land are dropped, so
+   * a retry does not re-send them.
+   */
+  it('keeps only the failed rows staged', async () => {
+    const result = setup(
+      payload({
+        baseline: {
+          areas: {},
+          defs: { [TICKET]: ResourcePermission.view, [CONTACT]: ResourcePermission.view },
+        },
+      })
+    )
+
+    await stage(result, TICKET, ResourcePermission.edit)
+    await stage(result, CONTACT, ResourcePermission.admin)
+
+    grantTypeMutate.mockImplementation(async (input: { entityDefinitionId: string }) => {
+      if (input.entityDefinitionId === CONTACT) throw new Error('nope')
+    })
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.save()
+    })
+
+    expect(ok).toBe(false)
+    expect(result.current.isDirty).toBe(true)
+    expect(
+      result.current.rows.find((r) => r.resource.entityDefinitionId === CONTACT)?.grantLevel
+    ).toBe(ResourcePermission.admin)
   })
 })
 

--- a/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
+++ b/apps/web/src/components/permissions/hooks/use-grantee-def-access.ts
@@ -23,6 +23,7 @@ import {
   usePatchGranteeAccess,
 } from './use-grantee-access'
 import { MEMBER_BASELINE_GRANTEE_ID, useRoleDefaults } from './use-permission-grants'
+import { type AccessChoice, type StagedSurface, useStagedEdits } from './use-staged-edits'
 
 /**
  * The grantee axis this section edits: an individual member, a team, or (doc 19
@@ -88,12 +89,19 @@ export interface GranteeDefAccessRow extends DefAccessRow {
  *
  * Derives per def: the baseline (`role:org_member` row), the locked-down flag
  * (baseline = No Access), this grantee's grant, and whether that grant is a
- * no-op (≤ baseline). Writes reuse `grantType`/`revokeType`.
+ * no-op (≤ baseline).
+ *
+ * **Edits are STAGED, not written** ({@link useStagedEdits}): `setLevel` moves the
+ * select, `save()` flushes through `grantType`/`revokeType`. Every host of this
+ * hook renders a `FormSaveBar`, so the nested per-def rows now commit with the
+ * area levels above them instead of firing a mutation per click.
  *
  * **First-touch rule (correctness, not polish):** setting an explicit grant on a
  * def with no baseline row yet ALSO writes `role:org_member @ edit`, so the def
- * doesn't silently become restricted and lock every other member out. Selecting
- * Inherit (revoke) never touches the baseline. Errors surface via `toastError`.
+ * doesn't silently become restricted and lock every other member out. It is
+ * evaluated at FLUSH time, against the baseline as it stands then — staging it
+ * would have to guess. Selecting Inherit (revoke) never touches the baseline.
+ * Errors surface via `toastError`.
  */
 export function useGranteeDefAccess(
   granteeKind: GranteeKind,
@@ -106,7 +114,11 @@ export function useGranteeDefAccess(
    * fall-through is this draft, not `usePermissionGrants()`'s persisted maps.
    */
   profileOwnLevels?: { levels: Partial<Record<Area, Level>>; baseLevel: Level | null }
-) {
+): {
+  isLoading: boolean
+  rows: GranteeDefAccessRow[]
+  setLevel: (entityDefinitionId: string, level: AccessChoice) => void
+} & StagedSurface {
   const utils = api.useUtils()
   const { resources, isLoading: resourcesLoading } = useResources()
   const granteeType = GRANTEE_TYPE[granteeKind]
@@ -153,10 +165,10 @@ export function useGranteeDefAccess(
   // `granteeAccess` rides along because a def write moves its COMPOSED
   // `effective` half, which no optimistic patch here can predict.
   const invalidateGranteeAccess = useInvalidateGranteeAccess()
-  const invalidate = useCallback(() => {
-    invalidateGranteeAccess()
-    return utils.resourceAccess.invalidate()
-  }, [utils, invalidateGranteeAccess])
+  const invalidate = useCallback(
+    () => Promise.all([invalidateGranteeAccess(), utils.resourceAccess.invalidate()]),
+    [utils, invalidateGranteeAccess]
+  )
 
   const patchGranteeAccess = usePatchGranteeAccess()
 
@@ -202,6 +214,15 @@ export function useGranteeDefAccess(
   /** This grantee's explicit grant per def, keyed by def id. */
   const grantByDef = useMemo(() => own?.defs ?? {}, [own])
 
+  const {
+    edits: staged,
+    entries: stagedEntries,
+    stage,
+    discard,
+    replace,
+    isDirty,
+  } = useStagedEdits<AccessChoice>()
+
   const rows = useMemo<GranteeDefAccessRow[]>(() => {
     return resources
       .filter(isAccessManageable)
@@ -209,7 +230,16 @@ export function useGranteeDefAccess(
         const configuredBaseline = baselineByDef[resource.entityDefinitionId]
         const baseArea = ENTITY_BASE_AREAS[resource.entityType ?? ''] ?? Area.records
         const baselineLevel = configuredBaseline ?? workspaceBasePermission(baseArea)
-        const grantLevel = grantByDef[resource.entityDefinitionId]
+        // Staged edits win over the persisted grant, so the select moves the
+        // instant it is clicked even though nothing has been written yet — and
+        // `isNoEffect` below judges what the admin is about to save.
+        const choice = staged[resource.entityDefinitionId]
+        const grantLevel =
+          choice === undefined
+            ? grantByDef[resource.entityDefinitionId]
+            : choice === 'inherit'
+              ? undefined
+              : choice
         // Configured def → inherit its workspace baseline; unconfigured → the
         // grantee's general Records level.
         const inheritedLevel = configuredBaseline ?? targetBasePermission(baseArea)
@@ -232,55 +262,85 @@ export function useGranteeDefAccess(
         }
       })
       .sort((a, b) => a.resource.plural.localeCompare(b.resource.plural))
-  }, [resources, baselineByDef, grantByDef, targetBasePermission, workspaceBasePermission])
+  }, [resources, baselineByDef, grantByDef, targetBasePermission, workspaceBasePermission, staged])
 
   /**
-   * Set this grantee's level for a def. `'inherit'` revokes the explicit row;
-   * a positive level writes it (auto-persisting the baseline on first touch).
+   * Stage this grantee's level for a def. `'inherit'` will revoke the explicit
+   * row; a positive level will write it. Nothing is sent until {@link save}.
    */
   const setLevel = useCallback(
-    (entityDefinitionId: string, level: ResourcePermission | 'inherit') => {
-      if (level === 'inherit') {
-        patchLocal(entityDefinitionId, 'own')
-        revokeType.mutate({ entityDefinitionId, granteeType, granteeId })
-        return
-      }
-      // First-touch: keep everyone at the default while this grantee is raised.
-      if (baselineByDef[entityDefinitionId] === undefined) {
-        const resource = resources.find((item) => item.entityDefinitionId === entityDefinitionId)
-        const baseArea = ENTITY_BASE_AREAS[resource?.entityType ?? ''] ?? Area.records
-        const defaultBaseline = workspaceBasePermission(baseArea)
-        patchLocal(entityDefinitionId, 'baseline', defaultBaseline)
-        grantType.mutate({
-          entityDefinitionId,
-          granteeType: ResourceGranteeType.role,
-          granteeId: MEMBER_BASELINE_GRANTEE_ID,
-          rung: permissionToRung(defaultBaseline),
-        })
-      }
-      patchLocal(entityDefinitionId, 'own', level)
-      grantType.mutate({
-        entityDefinitionId,
-        granteeType,
-        granteeId,
-        rung: permissionToRung(level),
-      })
+    (entityDefinitionId: string, level: AccessChoice) => {
+      stage(entityDefinitionId, level, grantByDef[entityDefinitionId] ?? 'inherit')
     },
-    [
-      baselineByDef,
-      resources,
-      workspaceBasePermission,
-      granteeType,
-      granteeId,
-      grantType,
-      revokeType,
-      patchLocal,
-    ]
+    [stage, grantByDef]
   )
+
+  /**
+   * Flush every staged def, one write at a time — including the first-touch
+   * baseline write, which is decided here rather than at stage time so it reads
+   * the baseline as it actually stands when the row is committed.
+   *
+   * A def whose write fails STAYS staged (its `toastError` already fired) so Save
+   * retries only what is left; the awaited `invalidate` keeps the select from
+   * flashing back before the refetch lands.
+   */
+  const save = useCallback(async () => {
+    const failed: Record<string, AccessChoice> = {}
+    for (const [entityDefinitionId, level] of stagedEntries) {
+      try {
+        if (level === 'inherit') {
+          patchLocal(entityDefinitionId, 'own')
+          await revokeType.mutateAsync({ entityDefinitionId, granteeType, granteeId })
+          continue
+        }
+        // First-touch: keep everyone at the default while this grantee is raised.
+        if (baselineByDef[entityDefinitionId] === undefined) {
+          const resource = resources.find((item) => item.entityDefinitionId === entityDefinitionId)
+          const baseArea = ENTITY_BASE_AREAS[resource?.entityType ?? ''] ?? Area.records
+          const defaultBaseline = workspaceBasePermission(baseArea)
+          patchLocal(entityDefinitionId, 'baseline', defaultBaseline)
+          await grantType.mutateAsync({
+            entityDefinitionId,
+            granteeType: ResourceGranteeType.role,
+            granteeId: MEMBER_BASELINE_GRANTEE_ID,
+            rung: permissionToRung(defaultBaseline),
+          })
+        }
+        patchLocal(entityDefinitionId, 'own', level)
+        await grantType.mutateAsync({
+          entityDefinitionId,
+          granteeType,
+          granteeId,
+          rung: permissionToRung(level),
+        })
+      } catch {
+        failed[entityDefinitionId] = level
+      }
+    }
+    await invalidate()
+    replace(failed)
+    return Object.keys(failed).length === 0
+  }, [
+    stagedEntries,
+    baselineByDef,
+    resources,
+    workspaceBasePermission,
+    granteeType,
+    granteeId,
+    grantType,
+    revokeType,
+    patchLocal,
+    invalidate,
+    replace,
+  ])
 
   return {
     isLoading: resourcesLoading || granteeLoading || roleDefaultsLoading,
     rows,
     setLevel,
+    isDirty,
+    isSaving: grantType.isPending || revokeType.isPending,
+    save,
+    discard,
   }
 }

--- a/apps/web/src/components/permissions/hooks/use-instance-baseline-rows.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-baseline-rows.ts
@@ -19,6 +19,13 @@ import { displayPermissionOfRung } from '../ui/level-labels'
 import { deriveInstanceBadge, type InstanceAccessBadge } from '../utils/instance-access-badge'
 import { type OpenInstanceTypes, useInstanceResourceLists } from './use-instance-resource-lists'
 import { MEMBER_BASELINE_GRANTEE_ID, usePermissionGrants } from './use-permission-grants'
+import {
+  type AccessChoice,
+  parseStagedInstanceKey,
+  type StagedSurface,
+  stagedInstanceKey,
+  useStagedEdits,
+} from './use-staged-edits'
 
 /**
  * Every instance-access key is always "open" here — see the hook doc below.
@@ -104,12 +111,25 @@ export interface InstanceAreaAccess {
  * unlike the agent-policy grid's own per-row expand toggle) plus the org-wide
  * `resourceAccess.allInstanceAccess` rows, and derives each instance's
  * workspace-baseline level and collapsed-row badge without a per-instance
- * query (§B.2.5). Writes reuse the same `grantInstance`/`revokeInstance`
+ * query (§B.2.5).
+ *
+ * **Edits are STAGED, not written** ({@link useStagedEdits}): `setBaseline` moves
+ * the select, `save()` flushes through the same `grantInstance`/`revokeInstance`
  * funnel the Share card and dialog already use, keyed to the `role:org_member`
  * grantee — "Inherit" REVOKES that row (no explicit baseline), "Restricted"
  * WRITES it at `'none'`, and Read/Write/Full write the matching permission.
+ *
+ * The collapsed-row **badge deliberately tracks the persisted rows**, not the
+ * staged ones: `Restricted` / `Shared · N` describe who can reach the item right
+ * now, which an unsaved select has not changed.
  */
-export function useInstanceBaselineRows() {
+export function useInstanceBaselineRows(): {
+  lists: ReturnType<typeof useInstanceResourceLists>
+  isLoading: boolean
+  rowsByKey: Record<InstanceAccessKey, InstanceBaselineRow[]>
+  areaAccessByKey: Record<InstanceAccessKey, InstanceAreaAccess>
+  setBaseline: (key: InstanceAccessKey, instanceId: string, level: AccessChoice) => void
+} & StagedSurface {
   const utils = api.useUtils()
   const { roleDefaults, baseline } = usePermissionGrants()
   const lists = useInstanceResourceLists(ALWAYS_OPEN)
@@ -117,14 +137,14 @@ export function useInstanceBaselineRows() {
   const allQuery = api.resourceAccess.allInstanceAccess.useQuery(undefined, { staleTime: 30_000 })
   const allRows = useMemo(() => allQuery.data ?? [], [allQuery.data])
 
-  const invalidate = useCallback(() => {
-    void utils.resourceAccess.allInstanceAccess.invalidate()
-  }, [utils])
+  // Returns the promise (rather than voiding it) so `save` can await the refetch
+  // before clearing its staged edits — see there.
+  const invalidate = useCallback(() => utils.resourceAccess.allInstanceAccess.invalidate(), [utils])
 
   const grantInstance = api.resourceAccess.grantInstance.useMutation({
     onError: (error) => toastError({ title: 'Error updating access', description: error.message }),
     onSettled: (_data, _error, variables) => {
-      invalidate()
+      void invalidate()
       if (variables)
         void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
     },
@@ -132,11 +152,38 @@ export function useInstanceBaselineRows() {
   const revokeInstance = api.resourceAccess.revokeInstance.useMutation({
     onError: (error) => toastError({ title: 'Error removing access', description: error.message }),
     onSettled: (_data, _error, variables) => {
-      invalidate()
+      void invalidate()
       if (variables)
         void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
     },
   })
+
+  const {
+    edits: staged,
+    entries: stagedEntries,
+    stage,
+    discard,
+    replace,
+    isDirty,
+  } = useStagedEdits<AccessChoice>()
+
+  /** The persisted `role:org_member` permission per `type:instanceId`. */
+  const persistedByRow = useMemo(() => {
+    const map = new Map<string, ResourcePermission>()
+    for (const r of allRows) {
+      if (
+        r.granteeType === ResourceGranteeType.role &&
+        r.granteeId === MEMBER_BASELINE_GRANTEE_ID &&
+        r.entityInstanceId
+      ) {
+        map.set(
+          stagedInstanceKey(r.entityDefinitionId, r.entityInstanceId),
+          displayPermissionOfRung(r.rung)
+        )
+      }
+    }
+    return map
+  }, [allRows])
 
   /**
    * The Member profile's area rung per resource type — the subject of the tab's
@@ -177,17 +224,20 @@ export function useInstanceBaselineRows() {
         const instanceRows = allRows.filter(
           (r) => r.entityDefinitionId === key && r.entityInstanceId === item.id
         )
-        const baselineRow = instanceRows.find(
-          (r) =>
-            r.granteeType === ResourceGranteeType.role && r.granteeId === MEMBER_BASELINE_GRANTEE_ID
-        )
+        const rowKey = stagedInstanceKey(key, item.id)
+        // Staged edits win over the persisted row, so the select moves the
+        // instant it is clicked even though nothing has been written yet.
+        const choice = staged[rowKey]
         return {
           key,
           id: item.id,
           name: item.name,
-          // Stored rung → the grid's def-axis display vocabulary (see
-          // `displayPermissionOfRung` for why this is a clamp, not a conversion).
-          baselineLevel: baselineRow ? displayPermissionOfRung(baselineRow.rung) : undefined,
+          baselineLevel:
+            choice === undefined
+              ? persistedByRow.get(rowKey)
+              : choice === 'inherit'
+                ? undefined
+                : choice,
           inheritedLevel,
           inheritLabelText: isPrivate ? PRIVATE_INHERIT_LABEL : undefined,
           inheritHelperText: isPrivate ? PRIVATE_INHERIT_HELPER : undefined,
@@ -196,29 +246,51 @@ export function useInstanceBaselineRows() {
       })
     }
     return result
-  }, [lists, allRows, baseline, roleDefaults])
+  }, [lists, allRows, baseline, roleDefaults, staged, persistedByRow])
 
-  /** Set (or, `'inherit'`, revoke) the `role:org_member` row for one instance. */
+  /** Stage (not write) the `role:org_member` row for one instance. */
   const setBaseline = useCallback(
-    (key: InstanceAccessKey, instanceId: string, level: ResourcePermission | 'inherit') => {
-      const recordId = toRecordId(key, instanceId)
-      if (level === 'inherit') {
-        revokeInstance.mutate({
-          recordId,
-          granteeType: ResourceGranteeType.role,
-          granteeId: MEMBER_BASELINE_GRANTEE_ID,
-        })
-        return
-      }
-      grantInstance.mutate({
-        recordId,
-        granteeType: ResourceGranteeType.role,
-        granteeId: MEMBER_BASELINE_GRANTEE_ID,
-        rung: permissionToRung(level),
-      })
+    (key: InstanceAccessKey, instanceId: string, level: AccessChoice) => {
+      const rowKey = stagedInstanceKey(key, instanceId)
+      stage(rowKey, level, persistedByRow.get(rowKey) ?? 'inherit')
     },
-    [grantInstance, revokeInstance]
+    [stage, persistedByRow]
   )
+
+  /**
+   * Flush every staged row, one write at a time. A row whose write fails STAYS
+   * staged (its `toastError` already fired) so Save retries only what is left.
+   * There is no optimistic patch on this lane, so the refetch is awaited before
+   * the staging map is cleared — otherwise the select would flash back.
+   */
+  const save = useCallback(async () => {
+    const failed: Record<string, AccessChoice> = {}
+    for (const [rowKey, level] of stagedEntries) {
+      const { key, instanceId } = parseStagedInstanceKey<InstanceAccessKey>(rowKey)
+      const recordId = toRecordId(key, instanceId)
+      try {
+        if (level === 'inherit') {
+          await revokeInstance.mutateAsync({
+            recordId,
+            granteeType: ResourceGranteeType.role,
+            granteeId: MEMBER_BASELINE_GRANTEE_ID,
+          })
+        } else {
+          await grantInstance.mutateAsync({
+            recordId,
+            granteeType: ResourceGranteeType.role,
+            granteeId: MEMBER_BASELINE_GRANTEE_ID,
+            rung: permissionToRung(level),
+          })
+        }
+      } catch {
+        failed[rowKey] = level
+      }
+    }
+    await invalidate()
+    replace(failed)
+    return Object.keys(failed).length === 0
+  }, [stagedEntries, grantInstance, revokeInstance, invalidate, replace])
 
   return {
     lists,
@@ -226,5 +298,9 @@ export function useInstanceBaselineRows() {
     rowsByKey,
     areaAccessByKey,
     setBaseline,
+    isDirty,
+    isSaving: grantInstance.isPending || revokeInstance.isPending,
+    save,
+    discard,
   }
 }

--- a/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
+++ b/apps/web/src/components/permissions/hooks/use-instance-grantee-rows.ts
@@ -17,6 +17,13 @@ import { displayPermissionOfRung } from '../ui/level-labels'
 import { useGranteeAccess, useInvalidateGranteeAccess } from './use-grantee-access'
 import type { GranteeKind } from './use-grantee-def-access'
 import { type OpenInstanceTypes, useInstanceResourceLists } from './use-instance-resource-lists'
+import {
+  type AccessChoice,
+  parseStagedInstanceKey,
+  type StagedSurface,
+  stagedInstanceKey,
+  useStagedEdits,
+} from './use-staged-edits'
 
 /** {@link displayPermissionOfRung}, pass-through on `undefined`. */
 const optionalDisplay = (rung: Rung | undefined): ResourcePermission | undefined =>
@@ -62,6 +69,14 @@ export interface InstanceGranteeRow extends InstanceAccessRow {
  * `grantInstance`/`revokeInstance` funnel the Share card uses, offering the full
  * Inherit / Read / Write / Full / No Access vocabulary.
  *
+ * **Edits are STAGED, not written** ({@link useStagedEdits}): `setGrant` moves the
+ * select, `save()` flushes. Every host renders a `FormSaveBar`, so these rows
+ * commit together with the area levels above them.
+ *
+ * `effectiveLevel` deliberately keeps reporting the PERSISTED composition — it is
+ * the server's answer about what this grantee can open today, and an unsaved
+ * select has not changed it.
+ *
  * **Reads one grantee, not the org** (plan 31 §2.4). It used to pull
  * `resourceAccess.allInstanceAccess` — every per-instance row for every grantee
  * — and narrow client-side. That was properly gated, so this is a SHAPE fix, not
@@ -69,7 +84,15 @@ export interface InstanceGranteeRow extends InstanceAccessRow {
  * cache is what made the §2.1 scope leak buildable, and is what the next row
  * would have reached for.
  */
-export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: string) {
+export function useInstanceGranteeRows(
+  granteeType: GranteeKind,
+  granteeId: string
+): {
+  lists: ReturnType<typeof useInstanceResourceLists>
+  isLoading: boolean
+  rowsByKey: Record<InstanceAccessKey, InstanceGranteeRow[]>
+  setGrant: (key: InstanceAccessKey, instanceId: string, level: AccessChoice) => void
+} & StagedSurface {
   const utils = api.useUtils()
   const lists = useInstanceResourceLists(ALWAYS_OPEN)
   const { isLoading, own, effective } = useGranteeAccess(granteeType, granteeId)
@@ -78,7 +101,7 @@ export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: stri
   const grantInstance = api.resourceAccess.grantInstance.useMutation({
     onError: (error) => toastError({ title: 'Error updating access', description: error.message }),
     onSettled: (_data, _error, variables) => {
-      invalidate()
+      void invalidate()
       if (variables)
         void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
     },
@@ -86,57 +109,123 @@ export function useInstanceGranteeRows(granteeType: GranteeKind, granteeId: stri
   const revokeInstance = api.resourceAccess.revokeInstance.useMutation({
     onError: (error) => toastError({ title: 'Error removing access', description: error.message }),
     onSettled: (_data, _error, variables) => {
-      invalidate()
+      void invalidate()
       if (variables)
         void utils.resourceAccess.forInstance.invalidate({ recordId: variables.recordId })
     },
   })
 
+  const {
+    edits: staged,
+    entries: stagedEntries,
+    stage,
+    discard,
+    replace,
+    isDirty,
+  } = useStagedEdits<AccessChoice>()
+
+  /** This grantee's persisted grant per `type:instanceId`. */
+  const persistedByRow = useMemo(() => {
+    const map = new Map<string, ResourcePermission>()
+    if (!own) return map
+    for (const key of INSTANCE_ACCESS_KEYS) {
+      for (const item of lists[key].items) {
+        const level = optionalDisplay(own.instances[item.id])
+        if (level !== undefined) map.set(stagedInstanceKey(key, item.id), level)
+      }
+    }
+    return map
+  }, [own, lists])
+
   const rowsByKey = useMemo(() => {
     const result = {} as Record<InstanceAccessKey, InstanceGranteeRow[]>
     for (const key of INSTANCE_ACCESS_KEYS) {
-      result[key] = lists[key].items.map((item) => ({
-        key,
-        id: item.id,
-        name: item.name,
-        // Scope-specific copy, so it is composed here rather than inside a row
-        // component four surfaces share — the agent policy's rows say something
-        // else entirely about the same instance.
-        description: INSTANCE_ROW_COPY.grantee.description(INSTANCE_SHARE_COPY[key].noun),
-        // Stored rung → this grid's def-axis DISPLAY vocabulary; see
-        // `displayPermissionOfRung`.
-        grantLevel: own ? optionalDisplay(own.instances[item.id]) : undefined,
-        // An instance absent from `effective.instances` has no row anywhere in
-        // the org, so its answer is the per-type row-less fallback. A pure
-        // lookup — §2.5 is explicit that re-deriving this client-side would put
-        // display and enforcement on separate implementations.
-        effectiveLevel: effective
-          ? (optionalDisplay(effective.instances[item.id] ?? undefined) ??
-            optionalDisplay(effective.instanceFallback[key] ?? undefined) ??
-            null)
-          : undefined,
-      }))
+      result[key] = lists[key].items.map((item) => {
+        const rowKey = stagedInstanceKey(key, item.id)
+        // Staged edits win over the persisted grant, so the select moves the
+        // instant it is clicked even though nothing has been written yet.
+        const choice = staged[rowKey]
+        return {
+          key,
+          id: item.id,
+          name: item.name,
+          // Scope-specific copy, so it is composed here rather than inside a row
+          // component four surfaces share — the agent policy's rows say something
+          // else entirely about the same instance.
+          description: INSTANCE_ROW_COPY.grantee.description(INSTANCE_SHARE_COPY[key].noun),
+          // Stored rung → this grid's def-axis DISPLAY vocabulary; see
+          // `displayPermissionOfRung`.
+          grantLevel:
+            choice === undefined
+              ? own
+                ? optionalDisplay(own.instances[item.id])
+                : undefined
+              : choice === 'inherit'
+                ? undefined
+                : choice,
+          // An instance absent from `effective.instances` has no row anywhere in
+          // the org, so its answer is the per-type row-less fallback. A pure
+          // lookup — §2.5 is explicit that re-deriving this client-side would put
+          // display and enforcement on separate implementations.
+          effectiveLevel: effective
+            ? (optionalDisplay(effective.instances[item.id] ?? undefined) ??
+              optionalDisplay(effective.instanceFallback[key] ?? undefined) ??
+              null)
+            : undefined,
+        }
+      })
     }
     return result
-  }, [lists, own, effective])
+  }, [lists, own, effective, staged])
 
-  /** Set (or, `'inherit'`, revoke) this grantee's own row for one instance. */
+  /** Stage (not write) this grantee's own row for one instance. */
   const setGrant = useCallback(
-    (key: InstanceAccessKey, instanceId: string, level: ResourcePermission | 'inherit') => {
-      const recordId = toRecordId(key, instanceId)
-      if (level === 'inherit') {
-        revokeInstance.mutate({ recordId, granteeType, granteeId })
-        return
-      }
-      grantInstance.mutate({ recordId, granteeType, granteeId, rung: permissionToRung(level) })
+    (key: InstanceAccessKey, instanceId: string, level: AccessChoice) => {
+      const rowKey = stagedInstanceKey(key, instanceId)
+      stage(rowKey, level, persistedByRow.get(rowKey) ?? 'inherit')
     },
-    [grantInstance, revokeInstance, granteeType, granteeId]
+    [stage, persistedByRow]
   )
+
+  /**
+   * Flush every staged row, one write at a time. A row whose write fails STAYS
+   * staged (its `toastError` already fired) so Save retries only what is left;
+   * the awaited `invalidate` keeps the select from flashing back before the
+   * refetch lands.
+   */
+  const save = useCallback(async () => {
+    const failed: Record<string, AccessChoice> = {}
+    for (const [rowKey, level] of stagedEntries) {
+      const { key, instanceId } = parseStagedInstanceKey<InstanceAccessKey>(rowKey)
+      const recordId = toRecordId(key, instanceId)
+      try {
+        if (level === 'inherit') {
+          await revokeInstance.mutateAsync({ recordId, granteeType, granteeId })
+        } else {
+          await grantInstance.mutateAsync({
+            recordId,
+            granteeType,
+            granteeId,
+            rung: permissionToRung(level),
+          })
+        }
+      } catch {
+        failed[rowKey] = level
+      }
+    }
+    await invalidate()
+    replace(failed)
+    return Object.keys(failed).length === 0
+  }, [stagedEntries, grantInstance, revokeInstance, granteeType, granteeId, invalidate, replace])
 
   return {
     lists,
     isLoading,
     rowsByKey,
     setGrant,
+    isDirty,
+    isSaving: grantInstance.isPending || revokeInstance.isPending,
+    save,
+    discard,
   }
 }

--- a/apps/web/src/components/permissions/hooks/use-permission-grants.ts
+++ b/apps/web/src/components/permissions/hooks/use-permission-grants.ts
@@ -148,13 +148,28 @@ export function useGrantWrites() {
     [grant]
   )
 
+  /**
+   * {@link save}, awaitable — what a staged surface's `FormSaveBar` flushes
+   * through (`useStagedEdits`), so it can report whether the write landed.
+   *
+   * A separate function rather than switching {@link save} to `mutateAsync`:
+   * `save` has fire-and-forget callers (the overrides tab persists an empty grant
+   * row the moment a grantee is added), and a rejected promise nobody awaits is
+   * an unhandled rejection. This one is only ever awaited.
+   */
+  const saveAsync = useCallback(
+    (granteeType: OverrideGranteeType, granteeId: string, levels: Partial<Record<Area, Level>>) =>
+      grant.mutateAsync({ granteeType, granteeId, levels: levels as Record<Area, Level> }),
+    [grant]
+  )
+
   const remove = useCallback(
     (granteeType: OverrideGranteeType, granteeId: string) =>
       revoke.mutate({ granteeType, granteeId }),
     [revoke]
   )
 
-  return { save, remove, isSaving: grant.isPending || revoke.isPending }
+  return { save, saveAsync, remove, isSaving: grant.isPending || revoke.isPending }
 }
 
 /**

--- a/apps/web/src/components/permissions/hooks/use-staged-edits.test.ts
+++ b/apps/web/src/components/permissions/hooks/use-staged-edits.test.ts
@@ -1,0 +1,143 @@
+// apps/web/src/components/permissions/hooks/use-staged-edits.test.ts
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  mergeStaged,
+  parseStagedInstanceKey,
+  type StagedSurface,
+  stagedInstanceKey,
+  useStagedEdits,
+} from './use-staged-edits'
+
+/**
+ * The primitive behind every grid on the permissions page. Its contract is small
+ * and two parts of it are load-bearing:
+ *
+ * - staging a row back to the persisted value must DROP the entry, or the Save
+ *   bar stays up after an edit is undone by hand and Save writes a no-op;
+ * - `mergeStaged` must run its surfaces **sequentially**, because they all write
+ *   into the same `ResourceAccess` space and each invalidates on settle.
+ */
+
+function surface(overrides: Partial<StagedSurface> = {}): StagedSurface {
+  return {
+    isDirty: false,
+    isSaving: false,
+    save: async () => true,
+    discard: () => {},
+    ...overrides,
+  }
+}
+
+describe('useStagedEdits', () => {
+  it('stages a value that differs from the persisted one', () => {
+    const { result } = renderHook(() => useStagedEdits<string>())
+
+    act(() => result.current.stage('a', 'edit', 'view'))
+
+    expect(result.current.isDirty).toBe(true)
+    expect(result.current.edits).toEqual({ a: 'edit' })
+  })
+
+  it('drops the entry when staged back to the persisted value', () => {
+    const { result } = renderHook(() => useStagedEdits<string>())
+
+    act(() => result.current.stage('a', 'edit', 'view'))
+    act(() => result.current.stage('a', 'view', 'view'))
+
+    expect(result.current.isDirty).toBe(false)
+    expect(result.current.edits).toEqual({})
+  })
+
+  /** Nothing staged for this key and nothing to stage — must not churn state. */
+  it('is a no-op when the value already matches and nothing was staged', () => {
+    const { result } = renderHook(() => useStagedEdits<string>())
+    const before = result.current.edits
+
+    act(() => result.current.stage('a', 'view', 'view'))
+
+    expect(result.current.edits).toBe(before)
+  })
+
+  it('clears everything on discard', () => {
+    const { result } = renderHook(() => useStagedEdits<string>())
+
+    act(() => result.current.stage('a', 'edit', 'view'))
+    act(() => result.current.stage('b', 'admin', 'view'))
+    act(() => result.current.discard())
+
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  /** How a flush keeps the rows whose write failed and forgets the ones that landed. */
+  it('keeps only what replace is given', () => {
+    const { result } = renderHook(() => useStagedEdits<string>())
+
+    act(() => result.current.stage('a', 'edit', 'view'))
+    act(() => result.current.stage('b', 'admin', 'view'))
+    act(() => result.current.replace({ b: 'admin' }))
+
+    expect(result.current.edits).toEqual({ b: 'admin' })
+  })
+})
+
+describe('mergeStaged', () => {
+  it('is dirty or saving when any surface is', () => {
+    expect(mergeStaged([surface(), surface({ isDirty: true })]).isDirty).toBe(true)
+    expect(mergeStaged([surface(), surface({ isSaving: true })]).isSaving).toBe(true)
+    expect(mergeStaged([surface(), surface()]).isDirty).toBe(false)
+  })
+
+  it('saves sequentially, in the order it was given', async () => {
+    const order: string[] = []
+    const slow = surface({
+      save: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        order.push('first')
+        return true
+      },
+    })
+    const fast = surface({
+      save: async () => {
+        order.push('second')
+        return true
+      },
+    })
+
+    await mergeStaged([slow, fast]).save()
+
+    expect(order).toEqual(['first', 'second'])
+  })
+
+  it('reports failure when any surface fails, and still runs the rest', async () => {
+    const later = vi.fn(async () => true)
+    const merged = mergeStaged([surface({ save: async () => false }), surface({ save: later })])
+
+    expect(await merged.save()).toBe(false)
+    expect(later).toHaveBeenCalled()
+  })
+
+  it('discards every surface', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+
+    mergeStaged([surface({ discard: a }), surface({ discard: b })]).discard()
+
+    expect(a).toHaveBeenCalled()
+    expect(b).toHaveBeenCalled()
+  })
+})
+
+describe('instance row keys', () => {
+  /** An instance id is only unique within its type, and every type renders at once. */
+  it('round-trips a type and an instance id', () => {
+    const key = stagedInstanceKey('dataset', 'ds_abc')
+    expect(parseStagedInstanceKey(key)).toEqual({ key: 'dataset', instanceId: 'ds_abc' })
+  })
+
+  it('splits at the FIRST colon, so an id containing one survives', () => {
+    const key = stagedInstanceKey('kb', 'a:b')
+    expect(parseStagedInstanceKey(key)).toEqual({ key: 'kb', instanceId: 'a:b' })
+  })
+})

--- a/apps/web/src/components/permissions/hooks/use-staged-edits.ts
+++ b/apps/web/src/components/permissions/hooks/use-staged-edits.ts
@@ -1,0 +1,118 @@
+// apps/web/src/components/permissions/hooks/use-staged-edits.ts
+'use client'
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import { useCallback, useMemo, useState } from 'react'
+
+/**
+ * What every access picker on the permissions surfaces writes: an explicit
+ * permission, or the fall-through sentinel that DELETES the row.
+ *
+ * `'inherit'` is a string rather than `undefined` on purpose — staged edits have
+ * to distinguish "this row is staged back to Inherit" from "this row has nothing
+ * staged", and `undefined` cannot say both.
+ */
+export type AccessChoice = ResourcePermission | 'inherit'
+
+/**
+ * A surface that stages its edits locally and flushes them from ONE Save button.
+ *
+ * Implemented by every hook behind the permissions page's grids, so a host that
+ * renders several of them can fold them into a single `FormSaveBar` through
+ * {@link mergeStaged} without knowing what any of them writes.
+ */
+export interface StagedSurface {
+  isDirty: boolean
+  isSaving: boolean
+  /** Flush every staged edit. Resolves `false` when at least one write failed. */
+  save: () => Promise<boolean>
+  discard: () => void
+}
+
+/**
+ * A staged map of row edits — `rowKey -> next choice` — held locally until the
+ * host's `FormSaveBar` flushes them.
+ *
+ * This is the permissions page's answer to the inconsistency the profile editor
+ * exposed: a profile's area levels were drafted and saved in one transactional
+ * mutation, while every neighbouring grid (workspace defaults, group and member
+ * overrides, and even the profile editor's own nested def/instance rows) fired a
+ * mutation per select change. Same-looking controls, two different commit
+ * models. Everything now stages.
+ *
+ * Deliberately NOT a general form library: rows are independent writes against
+ * independent `ResourceAccess` rows, so there is nothing to validate across them
+ * and the flush is a loop, not a payload.
+ */
+export function useStagedEdits<V>() {
+  const [edits, setEdits] = useState<Record<string, V>>({})
+
+  /**
+   * Stage one row's next value against what the server currently holds.
+   *
+   * Staging a row back to its persisted value DROPS the entry rather than
+   * queueing a no-op write — which is also what makes the Save bar disappear
+   * when an edit is undone by hand rather than through Discard.
+   */
+  const stage = useCallback((key: string, next: V, persisted: V) => {
+    setEdits((prev) => {
+      if (Object.is(next, persisted)) {
+        if (!(key in prev)) return prev
+        const { [key]: _dropped, ...rest } = prev
+        return rest
+      }
+      if (key in prev && Object.is(prev[key], next)) return prev
+      return { ...prev, [key]: next }
+    })
+  }, [])
+
+  const discard = useCallback(() => setEdits({}), [])
+
+  /** Keep only these edits — how a flush retains the rows whose write failed. */
+  const replace = useCallback((remaining: Record<string, V>) => setEdits(remaining), [])
+
+  const entries = useMemo(() => Object.entries(edits), [edits])
+
+  return { edits, entries, stage, discard, replace, isDirty: entries.length > 0 }
+}
+
+/**
+ * Fold several staged surfaces into the single Save/Discard pair a host renders.
+ *
+ * `save` runs them **sequentially**, not through `Promise.all`: every write lands
+ * in the same `ResourceAccess` / `PermissionGrant` space and invalidates on
+ * settle, so overlapping them would race a refetch against a later write.
+ */
+export function mergeStaged(surfaces: StagedSurface[]): StagedSurface {
+  return {
+    isDirty: surfaces.some((surface) => surface.isDirty),
+    isSaving: surfaces.some((surface) => surface.isSaving),
+    save: async () => {
+      let ok = true
+      for (const surface of surfaces) {
+        if (!(await surface.save())) ok = false
+      }
+      return ok
+    },
+    discard: () => {
+      for (const surface of surfaces) surface.discard()
+    },
+  }
+}
+
+/**
+ * The staging key for a per-instance row: an instance id is only unique WITHIN
+ * its resource type, and both per-instance surfaces render every type at once.
+ */
+export const stagedInstanceKey = (key: string, instanceId: string) => `${key}:${instanceId}`
+
+/**
+ * Split {@link stagedInstanceKey} back apart at flush time, where the write needs
+ * a `RecordId`. Splits at the FIRST colon — resource keys carry none, instance
+ * ids are cuids, and a `slice` is total where `split(':')[1]` would silently drop
+ * anything past a second one.
+ */
+export function parseStagedInstanceKey<K extends string>(rowKey: string) {
+  const at = rowKey.indexOf(':')
+  return { key: rowKey.slice(0, at) as K, instanceId: rowKey.slice(at + 1) }
+}

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.test.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.test.tsx
@@ -2,7 +2,7 @@
 
 import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { TooltipProvider } from '@auxx/ui/components/tooltip'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -14,20 +14,31 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
  * pre-scoped as `granteeAccess.own.areas`, and the *Inherit* fall-through as
  * `granteeAccess.baseline.areas`.
  *
- * The load-bearing part is not the read, it is `handleChange`: it edits a COPY
- * of that map and saves the whole thing, so a swap that pointed `values` at the
- * wrong half would silently wipe every other area the grantee holds on the next
- * click. That is the test worth having here.
+ * The load-bearing part is not the read, it is the flush: `useGranteeAreaLevels`
+ * lays the staged edits over that map and saves the whole thing, so a swap that
+ * pointed the persisted half at `baseline.areas` would silently wipe every other
+ * area the grantee holds. That is the test worth having here.
+ *
+ * Since the staged-edits change, clicking a rung writes nothing — the section
+ * commits from its `FormSaveBar`, like the Profiles tab always did.
  */
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = () => {}
 })
 
-const { granteeAccess, save, defAccess, instanceRows } = vi.hoisted(() => ({
+const { granteeAccess, saveAsync, defAccess, instanceRows } = vi.hoisted(() => ({
   granteeAccess: { current: undefined as unknown },
-  save: vi.fn(),
-  defAccess: { isLoading: false, rows: [], setLevel: vi.fn() },
+  saveAsync: vi.fn(),
+  defAccess: {
+    isLoading: false,
+    rows: [],
+    setLevel: vi.fn(),
+    isDirty: false,
+    isSaving: false,
+    save: async () => true,
+    discard: () => {},
+  },
   // One entry per `InstanceAccessKey`. `agent` joined the registry in the
   // 2026-07-28 agents slice, and because `AREA_TO_INSTANCE_KEY` is DERIVED from
   // that registry, the Agents area row immediately started nesting instance
@@ -61,6 +72,10 @@ const { granteeAccess, save, defAccess, instanceRows } = vi.hoisted(() => ({
       personal_inbox: [],
     },
     setGrant: vi.fn(),
+    isDirty: false,
+    isSaving: false,
+    save: async () => true,
+    discard: () => {},
   },
 }))
 
@@ -71,8 +86,10 @@ const ROLE_DEFAULTS = Object.fromEntries(
 vi.mock('../hooks/use-grantee-access', () => ({
   useGranteeAccess: () => granteeAccess.current,
 }))
+// `useGranteeAreaLevels` is deliberately NOT mocked — the staging it does is the
+// subject of the flush test below. Only the write it reaches for is.
 vi.mock('../hooks/use-permission-grants', () => ({
-  useGrantWrites: () => ({ save }),
+  useGrantWrites: () => ({ saveAsync, isSaving: false }),
   useRoleDefaults: () => ({ roleDefaults: ROLE_DEFAULTS, isLoading: false }),
 }))
 vi.mock('../hooks/use-grantee-def-access', () => ({
@@ -134,8 +151,14 @@ function rung(areaLabel: string, label: string): HTMLElement {
   return radio as HTMLElement
 }
 
+/** The `FormSaveBar`'s Save button — absent entirely while nothing is staged. */
+function saveButton(): HTMLElement | undefined {
+  return screen.queryAllByRole('button').find((el) => el.textContent === 'Save')
+}
+
 beforeEach(() => {
-  save.mockReset()
+  saveAsync.mockReset()
+  saveAsync.mockResolvedValue(undefined)
 })
 
 describe('the ladder reads the grantee-scoped payload', () => {
@@ -158,23 +181,63 @@ describe('the ladder reads the grantee-scoped payload', () => {
 
 describe('an area write keeps every other area the grantee holds', () => {
   /**
-   * The clobber case. `handleChange` spreads `values` and saves the whole map,
-   * so if `values` ever stopped being this grantee's own areas — pointing at
-   * `baseline.areas`, or at an empty object while the query was still settling —
-   * changing one area would silently revoke all the others. Server-side there is
-   * no guard against it: `setGranteeLevels` stores the sparse map verbatim.
+   * The clobber case. The flush lays the staged edits over `values` and saves the
+   * whole map, so if the persisted half ever stopped being this grantee's own
+   * areas — pointing at `baseline.areas`, or at an empty object while the query
+   * was still settling — changing one area would silently revoke all the others.
+   * Server-side there is no guard against it: `setGranteeLevels` stores the
+   * sparse map verbatim.
    */
-  it('saves the untouched areas alongside the changed one', () => {
+  it('saves the untouched areas alongside the changed one', async () => {
     setup({
       own: { [Area.files]: Level.Read, [Area.workflows]: Level.Edit },
       baseline: {},
     })
 
     fireEvent.click(rung(FILES_LABEL, 'Full'))
+    const button = saveButton()
+    if (!button) throw new Error('no Save button after staging an edit')
+    await act(async () => {
+      fireEvent.click(button)
+    })
 
-    expect(save).toHaveBeenCalledWith('user', GRANTEE, {
+    expect(saveAsync).toHaveBeenCalledWith('user', GRANTEE, {
       [Area.files]: Level.Full,
       [Area.workflows]: Level.Edit,
+    })
+  })
+})
+
+/**
+ * The staged-edits contract at the surface an admin actually touches. Before
+ * this, clicking a rung wrote immediately — while the Profiles tab next door
+ * drafted and saved from a bar. Same-looking controls, two commit models.
+ */
+describe('edits stage until the save bar is used', () => {
+  it('writes nothing on a rung click, and shows the bar instead', () => {
+    setup({ own: { [Area.files]: Level.Read }, baseline: {} })
+
+    expect(saveButton()).toBeUndefined()
+
+    fireEvent.click(rung(FILES_LABEL, 'Full'))
+
+    expect(saveAsync).not.toHaveBeenCalled()
+    expect(saveButton()).toBeTruthy()
+    // The ladder still moves — it renders the staged value.
+    expect(rung(FILES_LABEL, 'Full').getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('takes the bar away again when the edit is undone by hand', async () => {
+    setup({ own: { [Area.files]: Level.Read }, baseline: {} })
+
+    fireEvent.click(rung(FILES_LABEL, 'Full'))
+    expect(saveButton()).toBeTruthy()
+
+    fireEvent.click(rung(FILES_LABEL, 'Read'))
+    // `waitFor`, not a bare assertion: the bar is an `AnimatePresence` child, so
+    // it stays mounted for the length of its exit spring after going clean.
+    await waitFor(() => {
+      expect(saveButton()).toBeUndefined()
     })
   })
 })

--- a/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-levels-section.tsx
@@ -5,11 +5,15 @@ import { Area, Level, PERMISSION_AREAS } from '@auxx/lib/permissions/client'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SlidersHorizontal } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
 import { SettingsSection } from '~/components/global/settings-page'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useGranteeAccess } from '../hooks/use-grantee-access'
+import { useGranteeAreaLevels } from '../hooks/use-grantee-area-levels'
 import { type GranteeKind, useGranteeDefAccess } from '../hooks/use-grantee-def-access'
 import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
-import { useGrantWrites, useRoleDefaults } from '../hooks/use-permission-grants'
+import { useRoleDefaults } from '../hooks/use-permission-grants'
+import { mergeStaged } from '../hooks/use-staged-edits'
 import { GranteeDefAccessRows } from './grantee-def-access-rows'
 import { GranteeInstanceRows } from './grantee-instance-rows'
 import { AREA_TO_INSTANCE_KEY, deadGrantWarning } from './instance-share-copy'
@@ -58,9 +62,8 @@ function descriptionFor(granteeKind: string): string {
  * own area levels, the Member profile's baseline and the composed `effective`
  * line. It used to read the org-wide `usePermissionGrants` store — every grant
  * row in the org — and pick this grantee's out client-side. That hook survives
- * for the surfaces that genuinely are org-wide; only the writes
- * ({@link useGrantWrites}) and the role defaults ({@link useRoleDefaults}) are
- * still shared with it.
+ * for the surfaces that genuinely are org-wide; only the role defaults
+ * ({@link useRoleDefaults}) are still shared with it.
  *
  * Renders that sparse level map through {@link LeveledAreaGrid} in
  * `override` mode: every area
@@ -68,6 +71,11 @@ function descriptionFor(granteeKind: string): string {
  * (raise-only enforced server-side; an override that lifts nothing is flagged
  * "ignored"). Sits above the Layer-3 Record-access grid, which overrides the
  * Records area per record type.
+ *
+ * All three surfaces here — area levels, per-def overrides, per-instance grants
+ * — **stage** their edits and commit from one {@link FormSaveBar}
+ * ({@link useGranteeAreaLevels}, `useStagedEdits`). This is the same grid the
+ * permissions page's overrides tab renders, so the two had to move together.
  */
 export function GranteeLevelsSection({
   granteeKind,
@@ -79,7 +87,6 @@ export function GranteeLevelsSection({
   canEdit: boolean
 }) {
   const { roleDefaults, isLoading: roleDefaultsLoading } = useRoleDefaults()
-  const { save } = useGrantWrites()
   // One grantee, not the org (plan 31 §2.4). `useGranteeDefAccess` and
   // `useInstanceGranteeRows` below run the same query — React Query dedupes it,
   // so all three read one request. `effective` is null for a team, which is
@@ -94,7 +101,7 @@ export function GranteeLevelsSection({
   // Memoized: both feed `renderChildren`'s dependency list, and a fresh object
   // each render would rebuild every nested grid on every keystroke in the
   // grid's search box.
-  const values = useMemo(() => own?.areas ?? {}, [own])
+  const persistedLevels = useMemo(() => own?.areas ?? {}, [own])
   /** The org-wide member baseline per area — role default merged with org policy. */
   const effectiveBaseline = useMemo(
     () => ({ ...(roleDefaults ?? {}), ...(baseline?.areas ?? {}) }),
@@ -102,26 +109,33 @@ export function GranteeLevelsSection({
   )
   const isLoading = roleDefaultsLoading || granteeLoading
 
-  const {
-    isLoading: defAccessLoading,
-    rows: defRows,
-    setLevel: setDefLevel,
-  } = useGranteeDefAccess(granteeKind, granteeId)
+  const areaLevels = useGranteeAreaLevels(granteeKind, granteeId, persistedLevels)
+  const defAccess = useGranteeDefAccess(granteeKind, granteeId)
+  const instanceRows = useInstanceGranteeRows(granteeKind, granteeId)
+  const { isLoading: defAccessLoading, rows: defRows, setLevel: setDefLevel } = defAccess
   const {
     isLoading: instanceRowsLoadingAll,
     lists: instanceLists,
     rowsByKey: instanceRowsByKey,
     setGrant: setInstanceGrant,
-  } = useInstanceGranteeRows(granteeKind, granteeId)
+  } = instanceRows
+  const values = areaLevels.values
 
-  const handleChange = (area: Area, level: Level | undefined) => {
-    const next = { ...values }
-    // `undefined` DELETES the key (no grant → the grantee falls through to the
-    // member baseline); an explicit level — including `Level.None`, which is `0`
-    // and must not be conflated with absent — is stored as-is.
-    if (level === undefined) delete next[area]
-    else next[area] = level
-    save(granteeKind, granteeId, next)
+  // Area levels first: they are the base every nested def/instance row is
+  // measured against, so a half-applied save leaves the coarser value written and
+  // the finer one still staged, not the other way round.
+  const staged = mergeStaged([areaLevels, defAccess, instanceRows])
+  const [confirmDiscard, ConfirmDialog] = useConfirm()
+
+  const handleDiscard = async () => {
+    const confirmed = await confirmDiscard({
+      title: 'Discard changes?',
+      description: 'Your unsaved access changes will be lost.',
+      confirmText: 'Discard',
+      cancelText: 'Keep editing',
+      destructive: true,
+    })
+    if (confirmed) staged.discard()
   }
 
   /**
@@ -223,27 +237,41 @@ export function GranteeLevelsSection({
   )
 
   return (
-    <SettingsSection
-      icon={SlidersHorizontal}
-      title='Access levels'
-      description={descriptionFor(granteeKind)}>
-      {isLoading || !roleDefaults ? (
-        <div className='space-y-2'>
-          <Skeleton className='h-16 w-full rounded-lg' />
-          <Skeleton className='h-16 w-full rounded-lg' />
-        </div>
-      ) : (
-        <LeveledAreaGrid
-          mode='override'
-          values={values}
-          roleDefaults={roleDefaults}
-          baseline={effectiveBaseline}
-          onChange={handleChange}
-          disabled={!canEdit}
-          renderChildren={renderChildren}
-          effectiveLevels={effective?.areas}
-        />
-      )}
-    </SettingsSection>
+    <>
+      <ConfirmDialog />
+      <SettingsSection
+        icon={SlidersHorizontal}
+        title='Access levels'
+        description={descriptionFor(granteeKind)}>
+        {isLoading || !roleDefaults ? (
+          <div className='space-y-2'>
+            <Skeleton className='h-16 w-full rounded-lg' />
+            <Skeleton className='h-16 w-full rounded-lg' />
+          </div>
+        ) : (
+          <LeveledAreaGrid
+            mode='override'
+            values={values}
+            roleDefaults={roleDefaults}
+            baseline={effectiveBaseline}
+            onChange={areaLevels.setLevel}
+            disabled={!canEdit}
+            renderChildren={renderChildren}
+            effectiveLevels={effective?.areas}
+          />
+        )}
+      </SettingsSection>
+
+      {/* A fragment, not a child of the section: the bar pins to the bottom of
+          the page's scroll viewport, not inside the card. */}
+      <FormSaveBar
+        dirty={staged.isDirty}
+        isSaving={staged.isSaving}
+        onSave={() => void staged.save()}
+        onDiscard={() => void handleDiscard()}
+        label='Unsaved access changes'
+        saveDisabled={!canEdit}
+      />
+    </>
   )
 }

--- a/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
+++ b/apps/web/src/components/permissions/ui/grantee-overrides-tab.tsx
@@ -12,14 +12,18 @@ import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
 import { Folder, Plus, SlidersHorizontal, Trash2, Users } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useActor, useActors } from '~/components/resources/hooks/use-actor'
 import { ActorAvatar } from '~/components/resources/ui/actor-badge'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useUser } from '~/hooks/use-user'
 import { useGranteeAccess } from '../hooks/use-grantee-access'
+import { useGranteeAreaLevels } from '../hooks/use-grantee-area-levels'
 import { useGranteeDefAccess } from '../hooks/use-grantee-def-access'
 import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
 import { usePermissionGrants } from '../hooks/use-permission-grants'
+import { mergeStaged } from '../hooks/use-staged-edits'
 import { GranteeDefAccessRows } from './grantee-def-access-rows'
 import { GranteeInstanceRows } from './grantee-instance-rows'
 import { AREA_TO_INSTANCE_KEY, deadGrantWarning } from './instance-share-copy'
@@ -113,6 +117,15 @@ function useGranteeName(granteeType: OverrideType, granteeId: string) {
  * grantee immediately persists an empty grant row (composes to nothing but
  * survives reloads), and clearing every raised area keeps that row; only the
  * delete action removes the grant.
+ *
+ * **Level edits are STAGED and commit from a `FormSaveBar`** ({@link useStagedEdits}),
+ * matching the Profiles tab. Adding and removing a grantee stay immediate: those
+ * are list operations, not level edits, and the row they write composes to
+ * nothing on its own.
+ *
+ * Switching the selected grantee **discards** whatever was staged — the detail is
+ * keyed on the grantee id, so all three of its staged surfaces reset together.
+ * Same rule `useProfileEditor` already followed when the selected profile changed.
  */
 export function GranteeOverridesTab({
   granteeType,
@@ -166,15 +179,6 @@ export function GranteeOverridesTab({
     if (added.length > 0) setSelectedId(added[0] ?? null)
   }
 
-  const handleChange = (granteeId: string, area: Area, level: Level | undefined) => {
-    const current = persisted.find((g) => g.granteeId === granteeId)?.levels ?? {}
-    const next = { ...current }
-    if (level === undefined) delete next[area]
-    else next[area] = level
-
-    save(granteeType, granteeId, next)
-  }
-
   const handleRemove = (granteeId: string) => {
     remove(granteeType, granteeId)
     if (selectedId === granteeId) setSelectedId(null)
@@ -190,7 +194,7 @@ export function GranteeOverridesTab({
   }
 
   return (
-    <div className='flex flex-col p-3 sm:p-6'>
+    <div className='flex flex-1 flex-col p-3 sm:p-6'>
       <p className='mb-3 max-w-2xl text-sm text-muted-foreground'>{copy.empty}</p>
 
       {/* Grantee list */}
@@ -254,16 +258,20 @@ export function GranteeOverridesTab({
         )}
       </Section>
 
-      {/* Selected grantee's leveled grid */}
+      {/*
+        Selected grantee's leveled grid. `key` is the discard: every staged
+        surface inside lives in this subtree, so switching grantee drops the
+        unsaved edits rather than carrying them onto someone else's row.
+      */}
       {selectedGranteeId ? (
         <GranteeAccessDetail
+          key={selectedGranteeId}
           granteeType={granteeType}
           granteeId={selectedGranteeId}
-          values={persisted.find((g) => g.granteeId === selectedGranteeId)?.levels ?? {}}
+          persistedLevels={persisted.find((g) => g.granteeId === selectedGranteeId)?.levels ?? {}}
           roleDefaults={roleDefaults}
           baseline={effectiveBaseline}
           disabled={disabled}
-          onChange={(area, level) => handleChange(selectedGranteeId, area, level)}
         />
       ) : (
         <Section title='Access' icon={<SlidersHorizontal className='size-4' />} collapsible={false}>
@@ -324,40 +332,63 @@ function GranteeListRow({
   )
 }
 
-/** The selected grantee's leveled grid, headed by its resolved name. */
+/**
+ * The selected grantee's leveled grid, headed by its resolved name, with the Save
+ * bar for all three staged surfaces it hosts (area levels, per-def overrides,
+ * per-instance grants).
+ *
+ * Mounted with `key={granteeId}` by the tab, so the staging state is per-grantee
+ * by construction rather than by an effect that has to notice the id moved.
+ */
 function GranteeAccessDetail({
   granteeType,
   granteeId,
-  values,
+  persistedLevels,
   roleDefaults,
   baseline,
   disabled,
-  onChange,
 }: {
   granteeType: OverrideType
   granteeId: string
-  values: Partial<Record<Area, Level>>
+  /** The grantee's stored sparse map — staged edits are laid over it. */
+  persistedLevels: Partial<Record<Area, Level>>
   roleDefaults: Record<Area, Level>
   baseline: Partial<Record<Area, Level>>
   disabled: boolean
-  onChange: (area: Area, level: Level | undefined) => void
 }) {
   const { name } = useGranteeName(granteeType, granteeId)
-  const {
-    isLoading: defAccessLoading,
-    rows: defRows,
-    setLevel: setDefLevel,
-  } = useGranteeDefAccess(granteeType, granteeId)
+  const areaLevels = useGranteeAreaLevels(granteeType, granteeId, persistedLevels)
+  const defAccess = useGranteeDefAccess(granteeType, granteeId)
+  const instanceRows = useInstanceGranteeRows(granteeType, granteeId)
+  const { isLoading: defAccessLoading, rows: defRows, setLevel: setDefLevel } = defAccess
   const {
     isLoading: instanceRowsLoadingAll,
     lists: instanceLists,
     rowsByKey: instanceRowsByKey,
     setGrant: setInstanceGrant,
-  } = useInstanceGranteeRows(granteeType, granteeId)
+  } = instanceRows
+  const values = areaLevels.values
   // Deduped by React Query with the call inside `useInstanceGranteeRows`, so the
   // area rows' effective line costs no extra request. Null for a team, which is
   // exactly when it must not render.
   const { effective } = useGranteeAccess(granteeType, granteeId)
+
+  // Area levels first: they are the base every nested def/instance row is
+  // measured against, so a half-applied save leaves the coarser value written and
+  // the finer one still staged, not the other way round.
+  const staged = mergeStaged([areaLevels, defAccess, instanceRows])
+  const [confirmDiscard, ConfirmDialog] = useConfirm()
+
+  const handleDiscard = async () => {
+    const confirmed = await confirmDiscard({
+      title: 'Discard changes?',
+      description: `Your unsaved access changes for ${name} will be lost.`,
+      confirmText: 'Discard',
+      cancelText: 'Keep editing',
+      destructive: true,
+    })
+    if (confirmed) staged.discard()
+  }
 
   /**
    * Per-def overrides nested under Records (capability layer v2 Part B.0), and
@@ -462,20 +493,34 @@ function GranteeAccessDetail({
   )
 
   return (
-    <Section
-      title={`Access · ${name}`}
-      icon={<SlidersHorizontal className='size-4' />}
-      collapsible={false}>
-      <LeveledAreaGrid
-        mode='override'
-        values={values}
-        roleDefaults={roleDefaults}
-        baseline={baseline}
-        onChange={onChange}
-        disabled={disabled}
-        renderChildren={renderChildren}
-        effectiveLevels={effective?.areas}
+    <>
+      <ConfirmDialog />
+      <Section
+        title={`Access · ${name}`}
+        icon={<SlidersHorizontal className='size-4' />}
+        collapsible={false}>
+        <LeveledAreaGrid
+          mode='override'
+          values={values}
+          roleDefaults={roleDefaults}
+          baseline={baseline}
+          onChange={areaLevels.setLevel}
+          disabled={disabled}
+          renderChildren={renderChildren}
+          effectiveLevels={effective?.areas}
+        />
+      </Section>
+
+      {/* A fragment, not a child of the Section: the bar is the tab's last
+          element so it pins to the page bottom, not inside the card. */}
+      <FormSaveBar
+        dirty={staged.isDirty}
+        isSaving={staged.isSaving}
+        onSave={() => void staged.save()}
+        onDiscard={() => void handleDiscard()}
+        label={`Unsaved access changes · ${name}`}
+        saveDisabled={disabled}
       />
-    </Section>
+    </>
   )
 }

--- a/apps/web/src/components/permissions/ui/profile-editor.tsx
+++ b/apps/web/src/components/permissions/ui/profile-editor.tsx
@@ -16,6 +16,7 @@ import { useGranteeDefAccess } from '../hooks/use-grantee-def-access'
 import { useInstanceGranteeRows } from '../hooks/use-instance-grantee-rows'
 import { useProfileEditor } from '../hooks/use-profile-editor'
 import type { PermissionProfile } from '../hooks/use-profiles'
+import { mergeStaged } from '../hooks/use-staged-edits'
 import { AgentPolicyEditor } from './agent-policy-editor'
 import { BaseLevelSelect } from './base-level-select'
 import { GranteeDefAccessRows } from './grantee-def-access-rows'
@@ -45,7 +46,8 @@ interface ProfileEditorProps {
  * them (`ProcedureDetailBar`'s idiom). Unlike that bar, though, every one of them
  * writes to the **draft** via `patch` and never fires a mutation of its own,
  * because of the one-transaction rule above. The bottom `FormSaveBar` is the only
- * thing that saves.
+ * thing that saves — including the nested per-def and per-instance rows, which
+ * stage through `useStagedEdits` and flush after the profile's own transaction.
  *
  * Two things this screen deliberately does not offer:
  * - **The `owner` profile is not editable** (§0.10). It is the recovery guarantee:
@@ -157,20 +159,29 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
   // "expand Records and set the permissions for Companies", combined into
   // this same grid (not a separate section). Called unconditionally (rules of
   // hooks) even for an agent profile, which never renders `ProfileAreaGrid`.
-  const {
-    isLoading: defAccessLoading,
-    rows: defRows,
-    setLevel: setDefLevel,
-  } = useGranteeDefAccess('profile', profile.id, {
+  const defAccess = useGranteeDefAccess('profile', profile.id, {
     levels: draft.levels,
     baseLevel: draft.baseLevel,
   })
+  const instanceRows = useInstanceGranteeRows('profile', profile.id)
+  const { isLoading: defAccessLoading, rows: defRows, setLevel: setDefLevel } = defAccess
   const {
     isLoading: instanceRowsLoadingAll,
     lists: instanceLists,
     rowsByKey: instanceRowsByKey,
     setGrant: setInstanceGrant,
-  } = useInstanceGranteeRows('profile', profile.id)
+  } = instanceRows
+
+  /**
+   * The two nested lanes, folded into the same bar as the profile draft.
+   *
+   * They used to fire a mutation per select while the base map above them waited
+   * for Save — the inconsistency that made every other grid on this page look
+   * like it was the odd one out. They are NOT part of the profile's single
+   * transaction (they write `ResourceAccess`, not `PermissionGrant`), so `save`
+   * below runs the profile first and these after.
+   */
+  const nestedStaged = mergeStaged([defAccess, instanceRows])
 
   /**
    * `ProfileAreaGrid`'s `renderChildren` — the profile-authoring twin of
@@ -261,7 +272,16 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
       cancelText: 'Keep editing',
       destructive: true,
     })
-    if (confirmed) reset()
+    if (confirmed) {
+      reset()
+      nestedStaged.discard()
+    }
+  }
+
+  /** The profile's own transaction first, then the nested `ResourceAccess` rows. */
+  const handleSave = async () => {
+    if (isDirty) await save()
+    await nestedStaged.save()
   }
 
   return (
@@ -423,9 +443,9 @@ export function ProfileEditor({ profile, canEdit, onBack }: ProfileEditorProps) 
           `getProfile` lands would write a half-loaded draft.
         */}
         <FormSaveBar
-          dirty={isDirty}
-          isSaving={isSaving}
-          onSave={() => void save()}
+          dirty={isDirty || nestedStaged.isDirty}
+          isSaving={isSaving || nestedStaged.isSaving}
+          onSave={() => void handleSave()}
           onDiscard={() => void handleDiscard()}
           label='Unsaved profile changes'
           saveDisabled={!editable || isLoading}

--- a/apps/web/src/components/permissions/ui/workspace-defaults-tab.test.tsx
+++ b/apps/web/src/components/permissions/ui/workspace-defaults-tab.test.tsx
@@ -10,7 +10,7 @@ import {
 import { TooltipProvider } from '@auxx/ui/components/tooltip'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { InstanceAreaAccess, InstanceBaselineRow } from '../hooks/use-instance-baseline-rows'
 
 /**
@@ -32,10 +32,19 @@ import type { InstanceAreaAccess, InstanceBaselineRow } from '../hooks/use-insta
 const h = vi.hoisted(() => ({
   rowsByKey: {} as Record<InstanceAccessKey, InstanceBaselineRow[]>,
   areaAccessByKey: {} as Record<InstanceAccessKey, InstanceAreaAccess>,
+  // The two lanes' staged halves, per-test settable — the tab folds them into one
+  // `FormSaveBar` through `mergeStaged`, so both have to be modelled.
+  defStaged: { isDirty: false, isSaving: false, save: vi.fn(async () => true), discard: vi.fn() },
+  instanceStaged: {
+    isDirty: false,
+    isSaving: false,
+    save: vi.fn(async () => true),
+    discard: vi.fn(),
+  },
 }))
 
 vi.mock('../hooks/use-def-baselines', () => ({
-  useDefBaselines: () => ({ isLoading: false, rows: [], setBaseline: vi.fn() }),
+  useDefBaselines: () => ({ isLoading: false, rows: [], setBaseline: vi.fn(), ...h.defStaged }),
 }))
 vi.mock('../hooks/use-instance-baseline-rows', () => ({
   useInstanceBaselineRows: () => ({
@@ -46,6 +55,7 @@ vi.mock('../hooks/use-instance-baseline-rows', () => ({
     rowsByKey: h.rowsByKey,
     areaAccessByKey: h.areaAccessByKey,
     setBaseline: vi.fn(),
+    ...h.instanceStaged,
   }),
 }))
 vi.mock('./instance-share-body', () => ({
@@ -59,6 +69,13 @@ beforeAll(() => {
   Element.prototype.setPointerCapture = () => {}
   Element.prototype.releasePointerCapture = () => {}
   Element.prototype.scrollIntoView = () => {}
+})
+
+beforeEach(() => {
+  h.defStaged.isDirty = false
+  h.instanceStaged.isDirty = false
+  h.defStaged.save.mockClear()
+  h.instanceStaged.save.mockClear()
 })
 
 function seed(overrides: Partial<Record<InstanceAccessKey, Level>> = {}) {
@@ -165,6 +182,48 @@ describe('plan 43 §5.2 — the tab’s access row is READ-ONLY', () => {
     renderTab()
 
     expect(document.querySelector('[role="radio"]')).toBeNull()
+  })
+})
+
+/**
+ * This tab used to write on every select change while the Profiles tab next door
+ * drafted and saved from a bar — the inconsistency the staged-edits change
+ * removed. Both lanes here stage independently but commit from ONE bar, so the
+ * fold is the part worth pinning: a lane left out of `mergeStaged` would look
+ * saved and silently not be.
+ */
+describe('both lanes commit from one save bar', () => {
+  function saveButton(): HTMLElement | undefined {
+    return screen.queryAllByRole('button').find((el) => el.textContent === 'Save')
+  }
+
+  it('shows no bar while nothing is staged', () => {
+    seed()
+    renderTab()
+
+    expect(saveButton()).toBeUndefined()
+  })
+
+  it('raises the bar when EITHER lane is dirty', () => {
+    seed()
+    h.instanceStaged.isDirty = true
+    renderTab()
+
+    expect(saveButton()).toBeTruthy()
+  })
+
+  it('flushes both lanes from one click', async () => {
+    const user = userEvent.setup()
+    seed()
+    h.defStaged.isDirty = true
+    renderTab()
+
+    const button = saveButton()
+    if (!button) throw new Error('no Save button while a lane is dirty')
+    await user.click(button)
+
+    expect(h.defStaged.save).toHaveBeenCalledTimes(1)
+    expect(h.instanceStaged.save).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
+++ b/apps/web/src/components/permissions/ui/workspace-defaults-tab.tsx
@@ -10,9 +10,12 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { Shapes, SlidersHorizontal } from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useDefBaselines } from '../hooks/use-def-baselines'
 import type { InstanceAreaAccess } from '../hooks/use-instance-baseline-rows'
 import { useInstanceBaselineRows } from '../hooks/use-instance-baseline-rows'
+import { mergeStaged } from '../hooks/use-staged-edits'
 import { AreaAccessRow, hasAreaAccessRow } from './area-access-row'
 import { DefBaselineRows } from './def-baseline-rows'
 import { InstanceBaselineRows } from './instance-baseline-rows'
@@ -60,16 +63,27 @@ const RECORDS_ID = 'records'
  * headed by a **read-only** {@link AreaAccessRow} showing the Member profile's
  * rung for the area — see {@link areaAccessLeadingRow} for why read-only is the
  * only shape that does not reopen the hole this tab's missing grid closed.
+ *
+ * Both lanes STAGE their edits and commit from one {@link FormSaveBar}, matching
+ * the profile editor next door — see `useStagedEdits` for why every grid on this
+ * page now works that way.
  */
 export function WorkspaceDefaultsTab({ disabled = false }: { disabled?: boolean }) {
-  const { isLoading: defsLoading, rows: defRows, setBaseline: setDefBaseline } = useDefBaselines()
+  const defBaselines = useDefBaselines()
+  const instanceBaselines = useInstanceBaselineRows()
+  const { isLoading: defsLoading, rows: defRows, setBaseline: setDefBaseline } = defBaselines
   const {
     isLoading: instanceRowsLoadingAll,
     lists: instanceLists,
     rowsByKey: instanceRowsByKey,
     areaAccessByKey,
     setBaseline: setInstanceBaseline,
-  } = useInstanceBaselineRows()
+  } = instanceBaselines
+
+  // The two lanes write different endpoints but read as one grid, so they share
+  // one Save bar (plan: staged edits everywhere, `useStagedEdits`).
+  const staged = mergeStaged([defBaselines, instanceBaselines])
+  const [confirmDiscard, ConfirmDialog] = useConfirm()
 
   const [search, setSearch] = useState('')
   const [configuredOnly, setConfiguredOnly] = useState(false)
@@ -212,8 +226,20 @@ export function WorkspaceDefaultsTab({ disabled = false }: { disabled?: boolean 
     )
   }
 
+  const handleDiscard = async () => {
+    const confirmed = await confirmDiscard({
+      title: 'Discard changes?',
+      description: 'Your unsaved workspace defaults will be lost.',
+      confirmText: 'Discard',
+      cancelText: 'Keep editing',
+      destructive: true,
+    })
+    if (confirmed) staged.discard()
+  }
+
   return (
-    <div className='flex flex-col gap-3 p-3 sm:p-6'>
+    <div className='flex flex-1 flex-col gap-3 p-3 sm:p-6'>
+      <ConfirmDialog />
       <p className='max-w-2xl text-sm text-muted-foreground'>
         What every member gets on each individual record type, dataset, knowledge base, dashboard
         and workflow. Leave an item on Inherit to follow the Member profile, or set an explicit
@@ -268,6 +294,19 @@ export function WorkspaceDefaultsTab({ disabled = false }: { disabled?: boolean 
           })}
         </div>
       )}
+
+      {/*
+        `dirty` drives visibility, so a read-only org (no `granularPermissions`)
+        never sees the bar — its selects are disabled and nothing can stage.
+      */}
+      <FormSaveBar
+        dirty={staged.isDirty}
+        isSaving={staged.isSaving}
+        onSave={() => void staged.save()}
+        onDiscard={() => void handleDiscard()}
+        label='Unsaved workspace defaults'
+        saveDisabled={disabled}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Why

Only the **Profiles** tab drafted its changes and committed them from a `FormSaveBar`. Everything else on Settings → Permissions fired a mutation on every select change:

| Surface | Before |
|---|---|
| Profiles → area levels + identity | Save bar ✅ |
| Profiles → nested def/instance rows | immediate |
| Workspace defaults (record types + instances) | immediate |
| Group / Member overrides → areas | immediate |
| Group / Member overrides → nested rows | immediate |
| Member/group detail → Access levels | immediate |

Identical-looking controls, two commit models. Now everything stages and commits from one bar.

## How

**New primitives**

- `useStagedEdits<V>()` holds `rowKey -> next choice` until a flush. Staging a row back to its persisted value **drops** the entry, so undoing an edit by hand takes the bar away rather than queueing a no-op write.
- `mergeStaged(surfaces)` folds several staged surfaces into the single Save/Discard pair a host renders. Saves run **sequentially**, not `Promise.all` — they all write the same `ResourceAccess` space and each invalidates on settle, so overlapping them races a refetch against a later write.
- `useGranteeAreaLevels` does the same for one override grantee's Layer-2 area levels, flushing the whole sparse map through `permissions.grant`.

**The four row hooks stage instead of mutating** (`useDefBaselines`, `useInstanceBaselineRows`, `useGranteeDefAccess`, `useInstanceGranteeRows`). Rows overlay the staged value so the select still moves instantly; `save()` walks entries with `mutateAsync`, keeps failed rows staged for retry (their `toastError` already fired), and awaits the invalidation before clearing so nothing flashes back to the pre-save value.

**Four hosts got the bar:** Workspace defaults (both lanes, one bar), `GranteeAccessDetail` in the overrides tab, `GranteeLevelsSection` on the member/group detail pages, and the profile editor — whose nested def/instance rows now flush after its own transaction instead of firing per click.

## Decisions worth reviewing

- **`useGranteeDefAccess`'s first-touch baseline write moved to flush time**, where it reads the baseline as it actually stands. Staging it would have to guess.
- **Switching the selected grantee discards what was staged.** `GranteeAccessDetail` is mounted with `key={granteeId}`, so all three of its staged surfaces reset together — same rule `useProfileEditor` already followed on a profile switch, and by construction rather than by an effect that has to notice the id moved.
- **Adding and removing a grantee stay immediate.** Those are list operations, not level edits, and the row they write composes to nothing on its own.
- **`useGrantWrites` gains `saveAsync`** rather than switching `save` to `mutateAsync` — `save` has a fire-and-forget caller (`handleAdd`), and a rejected promise nobody awaits is an unhandled rejection.
- **`GranteeLevelsSection` had to move with the rest.** It's the member/group detail page's Permissions tab and shares the same hooks; leaving it out would have silently removed its ability to save.
- **Deliberately still persisted-only:** the workspace-defaults collapsed-row badge (`Restricted` / `Shared · N`) and the per-instance `Effective · …` line. Both describe what is true right now, which an unsaved select has not changed.

## Tests

`src/components/permissions` → **227 pass / 1 fail**.

New `use-staged-edits.test.ts`; the def-access, levels-section and workspace-defaults suites now drive stage-then-save and pin that a select click writes nothing, that the bar tracks dirtiness in both directions, that both workspace lanes flush from one click, and that only failed rows stay staged.

The one failure is `agent-policy-editor.test.tsx > leaves the header controlless and states the resolved rung as text` — **pre-existing on main**, not touched here: `agent-policy-editor.tsx` and its four `use-agent-policy*` hooks import nothing in this diff.

`tsc --noEmit` on `apps/web` reports zero errors under `components/permissions` (the repo-wide baseline is broken, so the exit code is meaningless — the output was grepped).