### PR TITLE
fix(web): green the last 8 vitest files and wire web into the CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,11 @@ jobs:
 
       # Every vitest project that is currently 100% green, so none of them can
       # rot the way `lib` did — 49 failures accumulated there unnoticed because
-      # only `billing` and `workflow-nodes` were ever run. The whole list costs
-      # ~3s; the reason to enumerate rather than run everything is that four
-      # projects cannot pass here yet:
+      # only `billing` and `workflow-nodes` were ever run. The reason to
+      # enumerate rather than run everything is that three projects cannot pass
+      # here yet:
       #
-      #   lib          26 files / 49 tests failing
-      #   web          24 files / 40 tests failing (19 are permissions/mail
-      #                specs stale since the v3 rename — the regression tests
-      #                for the outage that shipped 2026-07-30)
+      #   lib          25 files / 24 tests failing
       #   integration  (packages/test-utils) needs a live database
       #   database     sets no `name:` in its vitest.config.ts, so it is
       #                unreachable by `--project` and runs nowhere
@@ -157,6 +154,12 @@ jobs:
       # `--project='!lib'`-style negation is NOT a substitute: it selects the
       # `integration` project, which then fails on a missing database. Adding a
       # project here is the deliberate act that puts it under watch.
+      #
+      # `web` joined the list once its last 8 failing files were fixed — all of
+      # them stale specs, mostly the permissions-v3 rename (`full`→`read`, and
+      # `ResourcePermission` handed to a `Rung` slot). It is 150 files / 2437
+      # tests and runs in ~25s, so it dominates this job's wall-clock; the other
+      # ten together are ~3s.
       - name: Run tests
         run: |
           npx vitest run \
@@ -169,7 +172,8 @@ jobs:
             --project credentials \
             --project redis \
             --project utils \
-            --project ui
+            --project ui \
+            --project web
 
       # `lib` as a whole is not green yet, so keep running the one subpath that is.
       - name: Validate workflow templates

--- a/apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
+++ b/apps/web/src/app/api/eval/run/[runId]/events/agent-access.test.ts
@@ -68,6 +68,7 @@ vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
 vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
 
 const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
 const { GET } = await import('./route')
 
 const ORG_ID = 'org_cuid000000000000000000000'
@@ -83,6 +84,11 @@ const AGENT_ID = 'agt_cuid000000000000000000000'
  *   `instanceAccess` is keyed by bare instance id and `restrictedInstanceIds`
  *   marks which ids carry an explicit row — both are needed, or the row is
  *   invisible to `effectiveInstanceLevel`.
+ *
+ *   The row is stated as a `ResourcePermission` and converted to a `Rung` on the
+ *   way in: permissions v3 split the two axes, and `instanceAccess` takes rungs.
+ *   A bare `view` in a rung slot evaluates to NO access — it fails exactly the
+ *   explicit-grant cases while the `none` and area-level ones keep passing.
  */
 function signedIn(agentsLevel: Level, instance?: ResourcePermission) {
   getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
@@ -104,7 +110,7 @@ function signedIn(agentsLevel: Level, instance?: ResourcePermission) {
       (id) => id,
       new Set(),
       (id) => id,
-      instance === undefined ? {} : { [AGENT_ID]: instance },
+      instance === undefined ? {} : { [AGENT_ID]: permissionToRung(instance) },
       instance === undefined ? new Set() : new Set([AGENT_ID]),
       {},
       derived

--- a/apps/web/src/app/api/kopilot/stream/agent-access.test.ts
+++ b/apps/web/src/app/api/kopilot/stream/agent-access.test.ts
@@ -200,6 +200,7 @@ vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
 
 // Deep path on purpose — the barrel above is mocked, and it hangs under vitest.
 const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
 const { POST } = await import('./route')
 
 const ORG_ID = 'org_cuid000000000000000000000'
@@ -217,11 +218,21 @@ const SESSION_ID = 'ses_cuid000000000000000000000'
  * `composeUserCapabilities` synthesizes for any member holding a ≥`view` grant —
  * without it an `agents: None` grantee would be refused at the coarse front door
  * and the `include` regime would be untestable.
+ *
+ * The rows are stated in the `ResourcePermission` vocabulary the share dialog
+ * writes, and converted to `Rung`s on the way into `instanceAccess` — that
+ * parameter is `Record<string, Rung>`, and permissions v3 split the two axes
+ * apart. Handing it a bare `view` puts a non-rung in a rung slot, where it
+ * evaluates to NO access and every "member holds an explicit grant" case fails
+ * while the `none` and area-level ones keep passing.
  */
 function capabilitiesWith(agentsLevel: Level, instances: Record<string, ResourcePermission> = {}) {
   const derived = Object.values(instances).some((p) => p !== ResourcePermission.none)
     ? [PermissionKey.agentsView]
     : []
+  const instanceRungs = Object.fromEntries(
+    Object.entries(instances).map(([id, permission]) => [id, permissionToRung(permission)])
+  )
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.agents]: agentsLevel }) as PermissionKeyType[]),
     {},
@@ -230,7 +241,7 @@ function capabilitiesWith(agentsLevel: Level, instances: Record<string, Resource
     undefined,
     undefined,
     undefined,
-    instances,
+    instanceRungs,
     new Set(Object.keys(instances)),
     undefined,
     new Set(derived as PermissionKeyType[])

--- a/apps/web/src/components/global/comments/use-comment-access.test.ts
+++ b/apps/web/src/components/global/comments/use-comment-access.test.ts
@@ -1,7 +1,5 @@
 // apps/web/src/components/global/comments/use-comment-access.test.ts
 
-// apps/web/src/components/global/comments/use-comment-access.test.ts
-
 import { describe, expect, it } from 'vitest'
 import { resolveCommentAccess } from './use-comment-access'
 
@@ -24,7 +22,7 @@ describe('resolveCommentAccess', () => {
     })
   })
 
-  it('lets a visible subject-lens thread read and compose without full-lens moderation', () => {
+  it('lets a visible identity-lens thread read and compose without read-lens moderation', () => {
     expect(
       resolveCommentAccess({
         parentKind: 'thread',
@@ -32,7 +30,7 @@ describe('resolveCommentAccess', () => {
         commentsManage: true,
         canViewParent: true,
         canAdministerParent: false,
-        threadLens: 'subject',
+        threadLens: 'identity',
         canAdministerInbox: true,
       })
     ).toMatchObject({
@@ -44,7 +42,9 @@ describe('resolveCommentAccess', () => {
     })
   })
 
-  it('requires a full thread lens and inbox administration to moderate other authors', () => {
+  // `read` is the TOP mail lens since permissions v3 — the value this used to
+  // spell `full`.
+  it('requires the top (read) thread lens and inbox administration to moderate other authors', () => {
     expect(
       resolveCommentAccess({
         parentKind: 'thread',
@@ -52,7 +52,7 @@ describe('resolveCommentAccess', () => {
         commentsManage: true,
         canViewParent: true,
         canAdministerParent: false,
-        threadLens: 'full',
+        threadLens: 'read',
         canAdministerInbox: true,
       })
     ).toMatchObject({
@@ -69,7 +69,7 @@ describe('resolveCommentAccess', () => {
         commentsManage: true,
         canViewParent: true,
         canAdministerParent: true,
-        threadLens: 'full',
+        threadLens: 'read',
         canAdministerInbox: true,
       })
     ).toEqual({

--- a/apps/web/src/components/global/http-request/utils.test.ts
+++ b/apps/web/src/components/global/http-request/utils.test.ts
@@ -116,7 +116,10 @@ describe('HTTP utils serialization', () => {
     expect(parsed[0].value).toBe('')
   })
 
-  it('should filter out empty rows when serializing', () => {
+  // Blank rows are PRESERVED as a bare ':' so a row the user just added does not
+  // vanish from the editor mid-edit; they round-trip back as a blank row, and
+  // `keyValueToRecord` is what drops them before anything is persisted.
+  it('should keep empty rows when serializing, as a bare colon', () => {
     const keyValue: KeyValue[] = [
       { id: '1', key: 'Header1', value: 'Value1' },
       { id: '2', key: '', value: '' },
@@ -126,9 +129,18 @@ describe('HTTP utils serialization', () => {
     const serialized = keyValueToString(keyValue)
     const lines = serialized.split('\n')
 
-    expect(lines).toHaveLength(2)
+    expect(lines).toHaveLength(3)
     expect(lines[0]).toBe('Header1:Value1')
-    expect(lines[1]).toBe('Header3:Value3')
+    expect(lines[1]).toBe(':')
+    expect(lines[2]).toBe('Header3:Value3')
+
+    // The blank row survives the round-trip rather than being dropped...
+    const parsed = parseHeadersToKeyValue(serialized)
+    expect(parsed).toHaveLength(3)
+    expect(parsed[1]).toMatchObject({ key: '', value: '' })
+
+    // ...and is dropped only at the point of persistence.
+    expect(keyValueToRecord(parsed)).toEqual({ Header1: 'Value1', Header3: 'Value3' })
   })
 })
 

--- a/apps/web/src/components/mail/thread-display-read-gate.test.tsx
+++ b/apps/web/src/components/mail/thread-display-read-gate.test.tsx
@@ -7,8 +7,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * Plan 44 §1 — the detail pane's auto-mark-read must not fire a write it knows
  * will be refused.
  *
- * Read-state is `full`-tier: `UnreadService.setReadStatus` throws
- * `ForbiddenError` unless every target is at `full` lens. The pane marked read
+ * Read-state is top-tier: `UnreadService.setReadStatus` throws
+ * `ForbiddenError` unless every target is at the `read` lens (spelled `full`
+ * before the permissions-v3 rename — `read` is now the TOP lens). The pane marked read
  * on mount regardless, and `useThreadReadStatus` defaulted an unknown thread to
  * unread — so a share recipient following the MESSAGE_SHARED deep link (no list
  * load in front of it, store not yet hydrated) got a rejection toast on open.
@@ -55,7 +56,7 @@ const { ThreadDisplay } = await import('./thread-display')
 const THREAD_ID = 'thr_1'
 
 /** A hydrated, unread thread at the given lens. */
-function hydrated(myLens: 'full' | 'subject' | 'metadata') {
+function hydrated(myLens: 'read' | 'identity' | 'metadata') {
   h.thread = { id: THREAD_ID, subject: 'Hello', myLens, isUnread: true }
   h.isUnread = true
 }
@@ -67,15 +68,15 @@ beforeEach(() => {
 })
 
 describe('ThreadDisplay auto-mark-read gate', () => {
-  it('marks read at `full` lens (positive control)', () => {
-    hydrated('full')
+  it('marks read at `read` lens (positive control)', () => {
+    hydrated('read')
     render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
 
     expect(h.markAsRead).toHaveBeenCalled()
   })
 
-  it('does NOT mark read at `subject` lens', () => {
-    hydrated('subject')
+  it('does NOT mark read at `identity` lens', () => {
+    hydrated('identity')
     render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
 
     expect(h.markAsRead).not.toHaveBeenCalled()
@@ -106,7 +107,7 @@ describe('ThreadDisplay auto-mark-read gate', () => {
   })
 
   it('does not mark an already-read thread', () => {
-    h.thread = { id: THREAD_ID, subject: 'Hello', myLens: 'full', isUnread: false }
+    h.thread = { id: THREAD_ID, subject: 'Hello', myLens: 'read', isUnread: false }
     h.isUnread = false
     render(<ThreadDisplay expectedThreadId={THREAD_ID} />)
 

--- a/apps/web/src/components/permissions/ui/agent-policy-editor.test.tsx
+++ b/apps/web/src/components/permissions/ui/agent-policy-editor.test.tsx
@@ -173,6 +173,17 @@ async function pick(user: UserEvent, title: string, option: RegExp) {
   await user.click(screen.getByRole('option', { name: option }))
 }
 
+/**
+ * The resolved rung a CONTROLLESS area header states at its end (`RungBadge`).
+ *
+ * Distinct from {@link hintOf}: an instance-access header drops the muted
+ * fall-through hint entirely (its access row states the same thing, in the
+ * control, one row down) and states the resolved rung as a badge instead.
+ */
+function badgeOf(title: string): string {
+  return row(title).querySelector('div.mr-2.whitespace-nowrap')?.textContent?.trim() ?? ''
+}
+
 /** An area row's muted fall-through hint (`LevelControl`'s `unsetHint`). */
 function hintOf(title: string): string {
   const el = row(title).querySelector('span.text-xs.text-muted-foreground.whitespace-nowrap')
@@ -783,9 +794,11 @@ describe('plan 43 §8 item 19 (grid 3 of 4) — the agent policy renders the acc
     expect(row('Records').querySelector('[role="radio"]')).not.toBeNull()
 
     await toggleArea(user, 'Datasets')
-    // Raising the access row moves the header text with it.
+    // Raising the access row moves the header's resolved-rung badge with it.
     await pick(user, 'Dataset access', /^Full access/)
-    expect(hintOf('Datasets')).toBe('Full')
+    expect(badgeOf('Datasets')).toBe('Full')
+    // ...and the muted fall-through hint stays absent on a controlless header.
+    expect(hintOf('Datasets')).toBe('')
   })
 
   it('sits directly above the "All X" row it is the default for', async () => {

--- a/apps/web/src/components/threads/hooks/use-inbox-def-union.test.tsx
+++ b/apps/web/src/components/threads/hooks/use-inbox-def-union.test.tsx
@@ -209,8 +209,10 @@ describe('useInboxes — isPersonal is derived, both eras', () => {
     // `inbox-picker.tsx` / `inbox-destination-field.tsx` filter exactly like this.
     const routingTargets = result.current.inboxes.filter((i) => !i.isPersonal)
     expect(routingTargets.map((i) => i.id)).toEqual([SHARED_ID])
-    // No baseline row ⇒ the org-shared default.
-    expect(routingTargets[0]?.defaultLens).toBe('full')
+    // No baseline row ⇒ the org-shared default, which is the TOP lens: `read`
+    // since permissions v3 (the `inbox_default_lens: ['full']` above is a stale
+    // stored value in the retired vocabulary, and is deliberately not read).
+    expect(routingTargets[0]?.defaultLens).toBe('read')
   })
 })
 
@@ -221,13 +223,13 @@ describe('useInboxes — `defaultLens` is the ROW-derived floor (plan 40 §6)', 
     // rows. Rendering it would show the org the floor it had before its last
     // edit — the access badge, the detail card and the share popover's
     // inherited-access footer all read this value.
-    useMyInboxLenses.mockReturnValue({ lenses: {}, floors: { [SHARED_ID]: 'subject' } })
+    useMyInboxLenses.mockReturnValue({ lenses: {}, floors: { [SHARED_ID]: 'identity' } })
     mockArms({
       inbox: arm([rec(SHARED_ID, 'inbox', { inbox_default_lens: ['full'] })]),
       personal_inbox: arm([]),
     })
     const { result } = renderHook(() => useInboxes())
-    expect(result.current.inboxes[0]?.defaultLens).toBe('subject')
+    expect(result.current.inboxes[0]?.defaultLens).toBe('identity')
   })
 
   it('defaults a personal mailbox to `none` — it has no org-wide floor at all', () => {

--- a/apps/web/src/lib/agents/bindings/arg-to-field-type.test.ts
+++ b/apps/web/src/lib/agents/bindings/arg-to-field-type.test.ts
@@ -54,12 +54,24 @@ describe('argToFieldType', () => {
 describe('isVarFieldTypeCompatible', () => {
   it('matches exact field types', () => {
     expect(isVarFieldTypeCompatible(FieldType.NUMBER, FieldType.NUMBER)).toBe(true)
-    expect(isVarFieldTypeCompatible(FieldType.NUMBER, FieldType.TEXT)).toBe(false)
+    expect(isVarFieldTypeCompatible(FieldType.TEXT, FieldType.TEXT)).toBe(true)
   })
 
   it('treats TEXT args as compatible with text-like var types', () => {
     expect(isVarFieldTypeCompatible(FieldType.TEXT, FieldType.EMAIL)).toBe(true)
     expect(isVarFieldTypeCompatible(FieldType.TEXT, FieldType.URL)).toBe(true)
-    expect(isVarFieldTypeCompatible(FieldType.TEXT, FieldType.NUMBER)).toBe(false)
+  })
+
+  // Delegates to the workflow engine's coercion-aware matrix (#794), so the
+  // scalar pairs the workflow var picker allows are allowed here too: STRING is
+  // the most permissive destination, and NUMBER accepts parseable strings.
+  it('allows the scalar coercions the workflow variable picker allows', () => {
+    expect(isVarFieldTypeCompatible(FieldType.TEXT, FieldType.NUMBER)).toBe(true)
+    expect(isVarFieldTypeCompatible(FieldType.NUMBER, FieldType.TEXT)).toBe(true)
+  })
+
+  it('rejects structured var types for scalar args', () => {
+    expect(isVarFieldTypeCompatible(FieldType.NUMBER, FieldType.MULTI_SELECT)).toBe(false)
+    expect(isVarFieldTypeCompatible(FieldType.TEXT, FieldType.MULTI_SELECT)).toBe(false)
   })
 })

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -95,6 +95,15 @@ global.IntersectionObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }))
 
+// Mock the Web Animations API — jsdom implements none of it. `@base-ui-components`'
+// ScrollArea calls `viewport.getAnimations({ subtree: true })` from a timer, so the
+// resulting throw lands OUTSIDE any test as an UNHANDLED error, which fails the whole
+// run while every assertion in the file still passes. An empty list is what a viewport
+// with nothing animating returns.
+if (!Element.prototype.getAnimations) {
+  Element.prototype.getAnimations = () => []
+}
+
 // Mock matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
The `web` vitest project was out of CI with 8 failing files. This greens it and adds it to the
`Run tests` step, leaving `lib` as the last suite outside CI.

**All 8 were stale specs.** In every case the source was right and the test encoded a contract
that had since been replaced. There are no product code changes in this PR.

### Five were the permissions-v3 rename (#1406)

| file | what was wrong |
|---|---|
| `api/kopilot/stream/agent-access.test.ts` | `ResourcePermission.view` passed into a `Rung` slot |
| `api/eval/run/[runId]/events/agent-access.test.ts` | same defect, same fix |
| `comments/use-comment-access.test.ts` | lens `'full'` / `'subject'` |
| `mail/thread-display-read-gate.test.tsx` | lens `'full'` / `'subject'` |
| `threads/hooks/use-inbox-def-union.test.tsx` | expected `'full'`; the org-shared default is `'read'` |

The two `agent-access` files are the substantive ones. Their fixtures passed
`ResourcePermission.view` into `CapabilitySet`'s `instanceAccess`, which is `Record<string, Rung>`.
`'view'` is not a rung, so the grant evaluated to **no access** and the routes returned 403 where
the real system returns 200. Both now convert with `permissionToRung` at the boundary. The tell
held exactly as documented: the `none` cases and the area-level cases passed throughout, and only
the "member holds an explicit grant" cases failed.

### The other three had a later commit on the source

- **`agent-policy-editor`** — the helper read the muted-span hint that #1420 replaced with
  `RungBadge` on controlless area headers. Added a `badgeOf` helper; the test now also pins that
  the muted hint stays *absent* there.
- **`http-request/utils`** — asserted blank-row filtering that was deliberately dropped before
  #893. Blank rows are preserved as a bare `:` so a row being typed does not vanish;
  `keyValueToRecord` drops them at persistence instead. The test now asserts that whole path.
- **`arg-to-field-type`** — asserted the strict type matching that #794 deliberately replaced with
  the workflow engine's coercion-aware matrix, so binding and workflow type-matching cannot
  diverge. Negative controls swapped to a genuinely incompatible pair (`MULTI_SELECT` → `ARRAY`).

### One extra fix that was required

`grantee-add-panel.test.tsx` passed **every assertion** while emitting **7 unhandled errors**:
base-ui's `ScrollArea` calls `viewport.getAnimations()` from a timer, and jsdom implements no Web
Animations API. Unhandled errors are a nonzero vitest exit even with zero failed tests, so this
alone would have turned the job red on the first PR while the summary line still read "8 failed"
and never mentioned it. Polyfilled to `[]` in `src/test/setup.ts`.

## Test plan

Verified on a **clean worktree** (fresh `git worktree` + `pnpm install --frozen-lockfile`), with
the fixes applied as a patch, running the exact command from `ci.yml`:

```
Test Files  193 passed (193)
     Tests  2869 passed (2869)
    Errors  0
      exit  0
```

Run twice — `main` moved mid-session when #1422 landed and added a web test file, so it was redone
at `3e2d68800`. A local run in a dirty tree is not evidence here; the alias/`dist` asymmetry means
it disagrees with CI in both directions.

Also: `biome check` clean on all 10 files, and `node scripts/ci/typecheck-ratchet.js --package web`
reports no new type errors.

## Note on cost

The test job goes from ~3s to ~23s. `web` is essentially all of that — 150 of the 193 files.
