### PR TITLE
fix(web): three router bugs found by typechecking src/server/api

### DIFF
--- a/apps/web/src/server/api/routers/mediaAsset.ts
+++ b/apps/web/src/server/api/routers/mediaAsset.ts
@@ -26,16 +26,13 @@ export const mediaAssetRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const mediaAssetService = new MediaAssetService(
-        ctx.session.organization.id,
-        ctx.session.user.id,
-        ctx.db
-      )
+      const { organizationId, userId } = ctx.session
+      const mediaAssetService = new MediaAssetService(organizationId, userId, ctx.db)
 
       await mediaAssetService.convertTempToPermanent(
         input.mediaAssetId,
         input.newKind,
-        ctx.session.organization.id
+        organizationId
       )
 
       return { success: true }

--- a/apps/web/src/server/api/routers/sequence.ts
+++ b/apps/web/src/server/api/routers/sequence.ts
@@ -2,12 +2,19 @@
 // tRPC surface for Sequences (outbound email cadences — Sequences plan Phase 3).
 // Thin, validated edge over @auxx/lib/sequences: every procedure resolves org via
 // ctx.session, unwraps the domain layer's neverthrow Results into TRPCErrors, and
-// enforces per-sequence ResourceAccess (plan §10 — reads need 'view', step/settings
+// enforces per-sequence ResourceAccess (plan §10 — reads need 'read', step/settings
 // mutations 'edit', delete 'admin'; only the org OWNER short-circuits, inside
 // checkSequenceAccess/hasPermission; `create` is open to all members).
+//
+// The levels below are `Rung`s, NOT `ResourcePermission`s. The two vocabularies
+// overlap on 'none'/'edit'/'admin' and diverge on exactly one value — v3's
+// 'read' is v2's 'view' — so passing a `ResourcePermission` here type-checks
+// against nothing and silently DENIES: `satisfiesRung` looks 'view' up in
+// `RUNG_ORDER`, gets `undefined`, and `rank >= undefined` is false for every
+// caller including an admin. That is what this file did until #1423's follow-up.
 
 import { type Database, schema } from '@auxx/database'
-import { ResourcePermission } from '@auxx/database/enums'
+import type { Rung } from '@auxx/database/enums'
 import { getOrgCache } from '@auxx/lib/cache'
 import { conditionGroupsSchema } from '@auxx/lib/conditions'
 import { AuxxError } from '@auxx/lib/errors'
@@ -119,7 +126,7 @@ type SequenceSessionCtx = {
 async function requireSequenceAccess(
   ctx: SequenceSessionCtx,
   sequenceId: string,
-  required: ResourcePermission
+  required: Rung
 ): Promise<void> {
   const allowed = await checkSequenceAccess(
     { db: ctx.db, organizationId: ctx.session.organizationId },
@@ -230,7 +237,7 @@ export const sequenceRouter = createTRPCRouter({
 
   /** A sequence + its ordered steps in one payload. */
   get: sequenceProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
-    await requireSequenceAccess(ctx, input.id, ResourcePermission.view)
+    await requireSequenceAccess(ctx, input.id, 'read')
 
     const sequence = unwrap(
       await getSequence(ctx.db, {
@@ -283,7 +290,7 @@ export const sequenceRouter = createTRPCRouter({
   update: sequenceProcedure
     .input(z.object({ id: z.string(), fields: updateSequenceFieldsSchema }))
     .mutation(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.id, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, input.id, 'edit')
       // Instance access (plan 36 §5) — pinning a signature to a sequence is a
       // USER-INITIATED act, so it needs `view` on the signature. Sequence
       // EXECUTION stays uncapped: `sequence-send-email` runs as the system and
@@ -349,7 +356,7 @@ export const sequenceRouter = createTRPCRouter({
 
   /** Delete a sequence (and its hidden workflow) — admin grant required, no active runs. */
   delete: sequenceProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
-    await requireSequenceAccess(ctx, input.id, ResourcePermission.admin)
+    await requireSequenceAccess(ctx, input.id, 'admin')
     unwrap(
       await deleteSequence(ctx.db, {
         sequenceId: input.id,
@@ -366,7 +373,7 @@ export const sequenceRouter = createTRPCRouter({
   createStep: sequenceProcedure
     .input(z.object({ sequenceId: z.string(), afterStepId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, input.sequenceId, 'edit')
 
       const created = unwrap(
         await createStep(ctx.db, {
@@ -407,7 +414,7 @@ export const sequenceRouter = createTRPCRouter({
     .input(z.object({ stepId: z.string(), fields: updateStepFieldsSchema }))
     .mutation(async ({ ctx, input }) => {
       const sequenceId = await getStepSequenceId(ctx, input.stepId)
-      await requireSequenceAccess(ctx, sequenceId, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, sequenceId, 'edit')
 
       return unwrap(
         await updateStep(ctx.db, {
@@ -423,7 +430,7 @@ export const sequenceRouter = createTRPCRouter({
     .input(z.object({ stepId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const sequenceId = await getStepSequenceId(ctx, input.stepId)
-      await requireSequenceAccess(ctx, sequenceId, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, sequenceId, 'edit')
 
       unwrap(
         await deleteStep(ctx.db, {
@@ -445,7 +452,7 @@ export const sequenceRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, input.sequenceId, 'edit')
 
       return unwrap(
         await reorderStep(ctx.db, {
@@ -462,7 +469,7 @@ export const sequenceRouter = createTRPCRouter({
   publish: sequenceProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.id, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, input.id, 'edit')
 
       return unwrap(
         await publishSequence(ctx.db, {
@@ -481,7 +488,7 @@ export const sequenceRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, input.sequenceId, 'edit')
 
       return unwrap(
         await enrollRecipients(ctx.db, {
@@ -497,7 +504,7 @@ export const sequenceRouter = createTRPCRouter({
   listRuns: sequenceProcedure
     .input(z.object({ sequenceId: z.string(), status: runStatusSchema.optional() }))
     .query(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.view)
+      await requireSequenceAccess(ctx, input.sequenceId, 'read')
 
       return unwrap(
         await listRuns(ctx.db, {
@@ -520,7 +527,7 @@ export const sequenceRouter = createTRPCRouter({
         columns: { sequenceId: true },
       })
       if (!run) throw new TRPCError({ code: 'NOT_FOUND', message: 'Sequence run not found' })
-      await requireSequenceAccess(ctx, run.sequenceId, ResourcePermission.edit)
+      await requireSequenceAccess(ctx, run.sequenceId, 'edit')
 
       unwrap(
         await manualExitRun(ctx.db, {
@@ -535,7 +542,7 @@ export const sequenceRouter = createTRPCRouter({
   stats: sequenceProcedure
     .input(z.object({ sequenceId: z.string() }))
     .query(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.view)
+      await requireSequenceAccess(ctx, input.sequenceId, 'read')
 
       return unwrap(
         await getSequenceStats(ctx.db, {

--- a/apps/web/src/server/api/routers/workflow.ts
+++ b/apps/web/src/server/api/routers/workflow.ts
@@ -1068,11 +1068,11 @@ export const workflowRouter = createTRPCRouter({
           })
         }
 
-        if (
-          error.code === 'WORKFLOW_NOT_ENABLED' ||
-          error.code === 'WORKFLOW_TYPE_MISMATCH' ||
-          error.code === 'WORKFLOW_NOT_PUBLISHED'
-        ) {
+        // No `WORKFLOW_NOT_ENABLED` arm here: only the BULK variant emits that
+        // code. Testing for it on the single-record path was dead (TS2367) and
+        // read as coverage this branch never had. The bulk mutation below keeps
+        // its arm, where the code is real.
+        if (error.code === 'WORKFLOW_TYPE_MISMATCH' || error.code === 'WORKFLOW_NOT_PUBLISHED') {
           throw new TRPCError({
             code: 'BAD_REQUEST',
             message: error.message,


### PR DESCRIPTION
Started burning down `apps/web/src/server/api`'s 177 type errors expecting mostly
`possibly undefined` noise. Three of them were real defects. None would have shown up in
review of any recent diff — the compiler had been flagging all three the whole time, which is
the argument for the ratchet in the first place.

### 1. `sequence.ts` — three endpoints denied *everyone*, admins included 🔴

`requireSequenceAccess` declared `required: ResourcePermission` and handed it straight to
`checkSequenceAccess`, which takes a **`Rung`**. The two ladders overlap on `none`/`edit`/`admin`
and diverge on exactly one value — v3's `read` is v2's `view`:

```ts
// before
async function requireSequenceAccess(ctx, sequenceId, required: ResourcePermission)
...
await requireSequenceAccess(ctx, input.id, ResourcePermission.view)   // 'view' → a Rung slot
```

Downstream that reaches `satisfiesRung(have, need)`, which is `RUNG_ORDER[have] >= RUNG_ORDER[need]`.
`RUNG_ORDER['view']` is `undefined`, and `5 >= undefined` is `false` — so the check failed for
**every caller at every rung, including an org admin**.

Hard-denied: **`sequence.get`, `sequence.listRuns`, `sequence.stats`.**

The eight `.edit`/`.admin` call sites in the same file worked purely because those two words are
spelled the same in both vocabularies — the exact "tell" the testing handoff describes for this
class of v3 bug. `required` is now `Rung` and the call sites pass rung literals.

### 2. `mediaAsset.ts` — `convertTempToPermanent` threw on every call 🔴

```ts
new MediaAssetService(ctx.session.organization.id, ctx.session.user.id, ctx.db)
```

The protected-procedure context builds `session` as `{ ...session, user, organizationId, userId }`.
There is no `organization` key, so this is `undefined.id` — a `TypeError` before the mutation does
anything. It was the only one of 52 routers not reading `ctx.session.organizationId`. Now uses the
destructured form.

### 3. `workflow.ts` — dead error branch (TS2367) 🟡

`triggerManualResource` tested for `WORKFLOW_NOT_ENABLED`, a code only the **bulk** variant emits.
Harmless in effect — the two live conditions beside it still caught what they should — but it read
as coverage this path never had. Removed; the bulk mutation below keeps its arm, where the code is real.

## Test plan

Clean worktree at `1b7668929`, fresh install:

- `typecheck-ratchet.js --package web` → **no new type errors** (3981 vs baseline 3986)
- 11 CI vitest projects → **193 files / 2869 tests / exit 0**

## Follow-up (deliberately not in this PR)

`apps/web` imports `neverthrow` in three routers (`dashboard`, `favorite`, `sequence`) but never
declares it in its `package.json`, so `Result` resolves to `any`. That suppresses **~74** further
errors in `apps/web` — bug 1 above was one of them, and was invisible until I added the dep locally
to check. Adding it properly touches `pnpm-lock.yaml` and re-codes a pre-existing `TS18004` in
`workflow-store.ts` into `TS2552` (a day-one `exportWorkflow` bug referencing a `useNodeStore` that
is now an empty stub file), so it deserves its own PR rather than riding along here.
