### PR TITLE
fix(web): declare the neverthrow dependency apps/web already imports

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -124,6 +124,7 @@
     "lucide-react": "catalog:",
     "maplibre-gl": "^5.24.0",
     "motion": "^12.23.16",
+    "neverthrow": "^6.2.2",
     "next": "catalog:",
     "next-themes": "^0.4.4",
     "nodemailer": "catalog:",

--- a/apps/web/src/components/workflow/store/workflow-store.ts
+++ b/apps/web/src/components/workflow/store/workflow-store.ts
@@ -88,7 +88,20 @@ interface WorkflowStore extends DragState {
   duplicateWorkflow: (workflowId: string) => Promise<Workflow>
 
   // Export/Import
-  exportWorkflow: () => string
+  /**
+   * Serialize the workflow for download.
+   *
+   * `nodes` is a PARAMETER because this store cannot reach them: they live in
+   * React Flow's store, which is only reachable through `useStoreApi()` inside
+   * the provider (see `use-workflow-save.ts`). The body used to read a
+   * `useNodeStore` that is now an empty stub file — the import was commented
+   * out in the initial commit and the local `const nodes` with it, leaving the
+   * object literal below referencing an undeclared `nodes`. That is a
+   * ReferenceError for any caller, and it is why the compiler has flagged this
+   * line (TS18004) since day one. There are no callers today; a future one
+   * passes `useStoreApi().getState().nodes`.
+   */
+  exportWorkflow: (nodes: Node[]) => string
   importWorkflow: (data: string) => Promise<void>
 
   // Helpline actions
@@ -387,15 +400,16 @@ export const useWorkflowStore = create<WorkflowStore>()(
       }
     },
 
-    exportWorkflow: () => {
+    exportWorkflow: (nodes) => {
       const { workflow, metadata } = get()
 
       if (!workflow || !metadata) {
         throw new Error('No workflow to export')
       }
 
-      // Get current nodes and edges from stores
-      // const nodes = useNodeStore.getState().nodes
+      // `nodes` arrives from the caller — see the interface declaration for why
+      // it cannot be read here. Edges, vars and viewport DO live in stores this
+      // one can reach.
       const edges = useEdgeStore.getState().edges
       const envVariables = Array.from(useVarStore.getState().environmentVariables.values())
       const viewport = useCanvasStore.getState().viewport

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1189,6 +1189,9 @@ importers:
       motion:
         specifier: ^12.23.16
         version: 12.34.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      neverthrow:
+        specifier: ^6.2.2
+        version: 6.2.2
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
Follow-up to #1424, which found the bug this PR explains the *cause* of.

## The problem

`dashboard.ts`, `favorite.ts` and `sequence.ts` all do:

```ts
import type { Result } from 'neverthrow'
```

…but `apps/web/package.json` never declared `neverthrow`. Under pnpm's strict layout the
specifier doesn't resolve from `apps/web` at all, so `tsc` reported TS2307 — and typed `Result`
as `any`.

**That `any` propagates.** Every `unwrap()` in those routers returned `any`, everything derived
from one was `any`, and each of those silently suppressed the errors underneath it. `ci.yml`
already documents this exact mechanism for the cold-checkout case:

> an unresolved module makes every import from it `any`, which SUPPRESSES downstream errors — so a
> cold typecheck is more permissive than a warm one and would let real breakage through

## The payoff

Declaring the dependency removes **82** errors from `apps/web` — **3986 → 3904**, the largest single
drop since #1415. Only 3 of those are the TS2307s themselves; the other 79 are real diagnostics the
`any` was hiding.

One of them was the permissions bug fixed in #1424: a `ResourcePermission` handed to a `Rung`
parameter, which hard-denied `sequence.get` / `listRuns` / `stats` for every caller including org
admins. **It was invisible until this dependency resolved** — I only found it because I added the dep
locally while investigating.

Pinned to `^6.2.2` to match `packages/lib`, so `Result` is one type across the boundary rather than
two structurally-similar ones.

## Why `workflow-store.ts` is in this PR

It has to be. `exportWorkflow` builds `graph: { nodes, edges, viewport }` while the `const nodes`
above it sits commented out:

```ts
// Get current nodes and edges from stores
// const nodes = useNodeStore.getState().nodes
const edges = useEdgeStore.getState().edges
```

`useNodeStore` is now an **empty stub file** (`node-store.ts` is one line — just its path comment)
and the import was commented out in the initial commit. So this is a `ReferenceError` for any
caller, and the compiler has flagged the shorthand as **TS18004** since day one.

Resolving `neverthrow` shifts TypeScript's *code* for that same line to **TS2552** (it can now
suggest `Node`). The ratchet keys on `<file>::<TScode>`, so it reads that as a new error — the fix
can't ship without addressing it.

Fixed rather than papered over: **`nodes` is now a parameter.** The store genuinely cannot reach
them — they live in React Flow's store, reachable only through `useStoreApi()` inside the provider
(see `use-workflow-save.ts`). `exportWorkflow` has **no callers**, so this breaks nothing; a future
one passes `useStoreApi().getState().nodes`.

I first tried wiring it back to `useNodeStore` via the lazy-require pattern `edge-store.ts` uses,
and that was wrong — the store doesn't exist any more. Recording it here so nobody retries it.

## Test plan

Clean worktree at `73211684e`, fresh `pnpm install`:

- `typecheck-ratchet.js --package web` → **no new type errors** (3904 vs baseline 3986, 82 fixed)
- 11 CI vitest projects → **193 files / 2869 tests / exit 0**

The baseline is deliberately **not** re-recorded here — the weekly `typecheck-baseline.yml` job
tightens it on a runner, which is what keeps that diff safe to merge unread.
