### PR TITLE
perf(web): batch FILE ref resolution behind a shared hydration store

### DIFF
--- a/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
+++ b/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
@@ -21,10 +21,10 @@ import { CheckSquare } from 'lucide-react'
 import { useMemo } from 'react'
 import { FileIcon } from '~/components/files/utils/file-icon'
 import { VisualIcon } from '~/components/icons/ui/visual-icon'
+import { useFileRefs } from '~/components/resources'
 import { ActorBadge, RecordBadge, RestrictedRelationshipChip } from '~/components/resources/ui'
 import { ItemsCellView } from '~/components/ui/items-list-view'
 import { TagsCellView } from '~/components/ui/tags-view'
-import { api } from '~/trpc/react'
 import { CopyableLinkCell } from '../components/copyable-link-cell'
 import { ExpandableCell } from '../components/expandable-cell'
 import type { CellConfig } from '../components/formatted-cell'
@@ -516,7 +516,9 @@ export function renderRichTextValue(value: unknown): React.ReactNode {
 
 /**
  * File cell content — resolves refs and renders file badges.
- * Same pattern as RelationshipCellContent / ActorCellContent.
+ * Same pattern as RelationshipCellContent / ActorCellContent: refs go through
+ * the shared hydration store, so a viewport's worth of FILE cells resolves in
+ * one batched request instead of one `file.resolveFileRefs` query per cell.
  */
 function FileCellContent({ value }: { value: unknown }) {
   const refs = useMemo(() => {
@@ -529,19 +531,17 @@ function FileCellContent({ value }: { value: unknown }) {
     return value.filter((v) => v?.ref).map((v: { ref: string }) => v.ref)
   }, [value])
 
-  const { data: fileDetails, isLoading } = api.file.resolveFileRefs.useQuery(
-    { refs },
-    { enabled: refs.length > 0 }
-  )
+  const { details, isLoading } = useFileRefs(refs)
 
-  const items = useMemo(() => {
-    if (!fileDetails) return []
-    return fileDetails.map((d) => ({
-      id: d.ref,
-      name: d.name,
-      mimeType: d.mimeType || 'application/octet-stream',
-    }))
-  }, [fileDetails])
+  const items = useMemo(
+    () =>
+      details.map((d) => ({
+        id: d.ref,
+        name: d.name,
+        mimeType: d.mimeType || 'application/octet-stream',
+      })),
+    [details]
+  )
 
   if (refs.length === 0) return <EmptyCell />
 

--- a/apps/web/src/components/fields/displays/display-file.tsx
+++ b/apps/web/src/components/fields/displays/display-file.tsx
@@ -7,8 +7,8 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { EyeOff } from 'lucide-react'
 import { useMemo } from 'react'
 import { FileIcon } from '~/components/files/utils/file-icon'
+import { useFileRefs } from '~/components/resources'
 import { type ItemsListItem, ItemsListView } from '~/components/ui/items-list-view'
-import { api } from '~/trpc/react'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 
@@ -38,15 +38,12 @@ export function DisplayFile() {
   }, [value])
   const refs = useMemo(() => envelopes.map((v) => v.ref), [envelopes])
 
-  const { data: fileDetails, isLoading } = api.file.resolveFileRefs.useQuery(
-    { refs },
-    { enabled: refs.length > 0 }
-  )
+  const { details, isLoading } = useFileRefs(refs)
+
   // Build file items for ItemsListView
   const fileItems = useMemo<DisplayFileItem[]>(() => {
-    if (!fileDetails) return []
     const envelopeMap = new Map(envelopes.map((v) => [v.ref, v]))
-    return fileDetails.map((detail) => ({
+    return details.map((detail) => ({
       id: detail.ref,
       ref: detail.ref,
       name: detail.name,
@@ -54,7 +51,7 @@ export function DisplayFile() {
       caption: envelopeMap.get(detail.ref)?.caption,
       internal: envelopeMap.get(detail.ref)?.internal,
     }))
-  }, [fileDetails, envelopes])
+  }, [details, envelopes])
 
   if (isLoading && refs.length > 0) {
     return (

--- a/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
+++ b/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
@@ -8,7 +8,6 @@ import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { JsonFieldValue, TypedFieldValue } from '@auxx/types/field-value'
 import { type FileRef, getFileRefDownloadUrl } from '@auxx/types/file-ref'
 import { toastError } from '@auxx/ui/components/toast'
-import { keepPreviousData } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { FileOptions } from '~/components/custom-fields/ui/file-options-editor'
@@ -16,6 +15,7 @@ import type { FileState } from '~/components/file-upload/stores'
 import { useUploadStore } from '~/components/file-upload/stores'
 import type { FileItem } from '~/components/files/files-store'
 import { convertHeicFiles } from '~/components/files/utils/convert-heic'
+import { useFileRefs } from '~/components/resources/hooks/use-file-refs'
 import {
   buildFieldValueKey,
   useFieldValueStore,
@@ -457,39 +457,45 @@ export function useFieldFileUpload({
     [typedValues]
   )
 
-  // Fetch display details for all file refs
+  // Resolve display details through the shared hydration store — one batched
+  // request per viewport instead of a query per hook instance (LinePhotoPopover
+  // mounts this for every line row).
   const refs = useMemo(() => fileRefs.map((fr) => fr.ref), [fileRefs])
-  const { data: fileDetails } = api.file.resolveFileRefs.useQuery(
-    { refs },
-    { enabled: refs.length > 0, placeholderData: keepPreviousData }
-  )
+  const { details: fileDetails, isLoading: isResolvingRefs } = useFileRefs(refs)
 
   // Build display files by joining fileRefs with details
   const displayFiles = useMemo(() => {
-    if (!fileDetails || fileRefs.length === 0) return []
+    if (fileRefs.length === 0) return []
+    // Nothing resolved yet — render nothing rather than a row of "Unknown file"
+    // placeholders (matches the old `!fileDetails` guard).
+    if (isResolvingRefs && fileDetails.length === 0) return []
+
     const detailMap = new Map(fileDetails.map((d) => [d.ref, d]))
-    return fileRefs
-      .map((fr) => {
-        const detail = detailMap.get(fr.ref)
-        return {
-          id: fr.fieldValueId,
-          ref: fr.ref as FileRef,
-          name: detail?.name ?? 'Unknown file',
-          mimeType: detail?.mimeType ?? null,
-          size: detail?.size ?? null,
-          caption: fr.caption,
-          internal: fr.internal,
-        }
-      })
-      .filter((f) => f.name !== 'Unknown file' || fileDetails.length < fileRefs.length)
-  }, [fileRefs, fileDetails])
+    return (
+      fileRefs
+        .map((fr) => {
+          const detail = detailMap.get(fr.ref)
+          return {
+            id: fr.fieldValueId,
+            ref: fr.ref as FileRef,
+            name: detail?.name ?? 'Unknown file',
+            mimeType: detail?.mimeType ?? null,
+            size: detail?.size ?? null,
+            caption: fr.caption,
+            internal: fr.internal,
+          }
+        })
+        // Drop refs that resolved to nothing (deleted file), but keep the ones
+        // still in flight so a freshly uploaded file doesn't blink out.
+        .filter((f) => f.name !== 'Unknown file' || isResolvingRefs)
+    )
+  }, [fileRefs, fileDetails, isResolvingRefs])
 
   // Set of asset IDs fully absorbed into displayFiles (store entry + resolved details).
-  // Only mark as absorbed once fileDetails has the ref — prevents the upload entry
+  // Only mark as absorbed once the ref has resolved — prevents the upload entry
   // from disappearing before displayFiles can render it.
   const absorbedAssetIds = useMemo(() => {
     const ids = new Set<string>()
-    if (!fileDetails) return ids
     const resolvedRefs = new Set(fileDetails.map((d) => d.ref))
     for (const fr of fileRefs) {
       if (fr.sourceType === 'asset' && resolvedRefs.has(fr.ref)) {

--- a/apps/web/src/components/files/hooks/use-filesystem.tsx
+++ b/apps/web/src/components/files/hooks/use-filesystem.tsx
@@ -8,6 +8,7 @@ import { keepPreviousData } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useFileUpload } from '~/components/file-upload/hooks/use-file-upload'
 import { useUploadStore } from '~/components/file-upload/stores'
+import { invalidateFileRefs } from '~/components/resources/store/file-ref-store'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { type FileItem, type FolderTreeNode, useFileSystemStore } from '../files-store'
@@ -502,6 +503,10 @@ export function useFilesystem() {
           ...folderIds.map((id) => deleteFolderMutation.mutateAsync({ folderId: id })),
         ])
 
+        // Drop cached FILE-field display details for the deleted files —
+        // the hydration store caches for the session.
+        invalidateFileRefs(fileIds.map((id) => `file:${id}`))
+
         // O(1) optimistic update using Maps
         removeItems(itemIds)
         clearSelection()
@@ -570,6 +575,9 @@ export function useFilesystem() {
           await renameFolderMutation.mutateAsync({ folderId: itemId, newName: newName })
         } else {
           await renameMutation.mutateAsync({ fileId: itemId, newName: newName })
+          // Drop the cached FILE-field display name — the hydration store
+          // caches for the session, so it won't pick the rename up on its own.
+          invalidateFileRefs([`file:${itemId}`])
         }
 
         // O(1) optimistic update

--- a/apps/web/src/components/resources/hooks/index.ts
+++ b/apps/web/src/components/resources/hooks/index.ts
@@ -27,6 +27,8 @@ export {
 } from './use-field'
 // Field value hooks (extracted from store)
 export { useFieldCellState, useFieldValue, useFieldValues } from './use-field-values'
+// FILE ref hydration (batched — see file-ref-store)
+export { type FileRefDetail, useFileRefs } from './use-file-refs'
 export { useIsRecordLoading, useIsRecordPending, useRecord } from './use-record'
 // Per-ROW record affordances, from the `_access` stamp (plan v3/03 §5.2)
 export type { RecordRowAccess } from './use-record-access'

--- a/apps/web/src/components/resources/hooks/use-file-refs.ts
+++ b/apps/web/src/components/resources/hooks/use-file-refs.ts
@@ -1,0 +1,63 @@
+// apps/web/src/components/resources/hooks/use-file-refs.ts
+
+import { useEffect, useMemo } from 'react'
+import {
+  type FileRefDetail,
+  getFileRefStoreState,
+  useHydratedFileRefs,
+  useIsLoadingFileRefs,
+} from '../store/file-ref-store'
+
+interface UseFileRefsResult {
+  /**
+   * Resolved details in the input `refs` order. Refs that resolved to nothing
+   * (deleted file, another org) are omitted — same as the rows
+   * `file.resolveFileRefs` used to drop.
+   */
+  details: FileRefDetail[]
+  /** Per-ref lookup: detail (found), null (not found), undefined (not loaded). */
+  detailsByRef: Map<string, FileRefDetail | null | undefined>
+  /** True while any ref is still unresolved. */
+  isLoading: boolean
+}
+
+/**
+ * Hook for requesting and subscribing to FILE ref display details.
+ *
+ * Replaces per-component `api.file.resolveFileRefs.useQuery` calls: refs are
+ * queued in a shared store and `ResourceProvider` resolves the whole pending
+ * set in one batched request, so a records table with a FILE column costs one
+ * query per viewport instead of one per cell.
+ *
+ * @param refs - File refs (`"file:<id>"` / `"asset:<id>"`). Memoize this array.
+ *
+ * @example
+ * const refs = useMemo(() => value.map((v) => v.ref), [value])
+ * const { details, isLoading } = useFileRefs(refs)
+ */
+export function useFileRefs(refs: string[]): UseFileRefsResult {
+  // Request hydration on mount/change. No flicker despite the effect running
+  // after the first paint: `isLoading` reports "unresolved", not "in flight",
+  // so the first render already shows the skeleton.
+  useEffect(() => {
+    if (refs.length === 0) return
+    getFileRefStoreState().requestHydration(refs)
+  }, [refs])
+
+  const hydrated = useHydratedFileRefs(refs)
+  const isLoading = useIsLoadingFileRefs(refs)
+
+  const details = useMemo(
+    () => hydrated.filter((detail): detail is FileRefDetail => !!detail),
+    [hydrated]
+  )
+
+  const detailsByRef = useMemo(
+    () => new Map(refs.map((ref, idx) => [ref, hydrated[idx]])),
+    [refs, hydrated]
+  )
+
+  return { details, detailsByRef, isLoading }
+}
+
+export type { FileRefDetail }

--- a/apps/web/src/components/resources/index.ts
+++ b/apps/web/src/components/resources/index.ts
@@ -4,6 +4,7 @@
 export {
   // Types
   type FieldInfo,
+  type FileRefDetail,
   // Per-definition read gate for `recordResource` surfaces (tabs, cards)
   useCanViewRecordResource,
   // Entity field values
@@ -11,6 +12,8 @@ export {
   useField,
   useFieldByKey,
   useFields,
+  // Batched FILE ref hydration
+  useFileRefs,
   useIsRecordLoading,
   useIsRecordPending,
   useRecord,

--- a/apps/web/src/components/resources/providers/resource-provider.tsx
+++ b/apps/web/src/components/resources/providers/resource-provider.tsx
@@ -17,6 +17,7 @@ import {
 import { initComputedFieldSync } from '../store/computed-field-registry'
 import { fieldValueFetchQueue } from '../store/field-value-fetch-queue'
 import { useFieldValueStore } from '../store/field-value-store'
+import { getFileRefStoreState, useFileRefStore } from '../store/file-ref-store'
 import { getResourceStoreState } from '../store/resource-store'
 import { usePrefixEpoch } from '../utils/normalize-record-id'
 
@@ -30,6 +31,9 @@ function RecordBatchFetcher() {
 
 const BATCH_DELAY = 50
 const MAX_RELATIONSHIP_BATCH = 100
+// Queries go out as GET with the input in the URL, so keep a batch well inside
+// the ~8KB URL ceiling common proxies enforce (a ref is ~35 chars encoded).
+const MAX_FILE_REF_BATCH = 100
 
 /**
  * ResourceProvider - Centralized resource data management
@@ -173,6 +177,47 @@ export function ResourceProvider({ children }: { children: React.ReactNode }) {
     setRelationshipBatch([])
   }, [relationshipError, relationshipBatch])
 
+  // === FILE REF BATCHING ===
+  // FILE cells/displays queue refs instead of each firing their own
+  // `file.resolveFileRefs`, so a table viewport resolves in one request.
+  const [fileRefBatch, setFileRefBatch] = useState<string[]>([])
+  const fileRefPendingSize = useFileRefStore((s) => s.pendingIds.size)
+
+  useEffect(() => {
+    if (fileRefPendingSize === 0 || fileRefBatch.length > 0) return
+    const timeout = setTimeout(() => {
+      const refs = getFileRefStoreState().startBatch(MAX_FILE_REF_BATCH)
+      if (refs.length === 0) return
+      setFileRefBatch(refs)
+    }, BATCH_DELAY)
+    return () => clearTimeout(timeout)
+  }, [fileRefPendingSize, fileRefBatch.length])
+
+  const { data: fileRefData, error: fileRefError } = api.file.resolveFileRefs.useQuery(
+    { refs: fileRefBatch },
+    { enabled: fileRefBatch.length > 0, staleTime: Infinity, refetchOnWindowFocus: false }
+  )
+
+  useEffect(() => {
+    if (!fileRefData || fileRefBatch.length === 0) return
+    const state = getFileRefStoreState()
+    // Org-switch guard: reset() empties loadingIds, so a response landing after
+    // clearResourceCaches() must not publish into the new org's store.
+    if (!fileRefBatch.some((ref) => state.loadingIds.has(ref))) {
+      setFileRefBatch([])
+      return
+    }
+    state.completeBatch(fileRefData, fileRefBatch)
+    setFileRefBatch([])
+  }, [fileRefData, fileRefBatch])
+
+  useEffect(() => {
+    if (!fileRefError || fileRefBatch.length === 0) return
+    console.error('Failed to resolve file refs:', fileRefError)
+    getFileRefStoreState().markError(fileRefBatch)
+    setFileRefBatch([])
+  }, [fileRefError, fileRefBatch])
+
   return (
     <>
       <RecordBatchFetcher />
@@ -194,4 +239,5 @@ export function clearResourceCaches() {
   getRecordStoreState().clearAll()
   useFieldValueStore.getState().clearAll()
   getActorStoreState().reset()
+  getFileRefStoreState().reset()
 }

--- a/apps/web/src/components/resources/store/file-ref-store.test.ts
+++ b/apps/web/src/components/resources/store/file-ref-store.test.ts
@@ -1,0 +1,95 @@
+// apps/web/src/components/resources/store/file-ref-store.test.ts
+// FILE cells/displays share one hydration store instead of each firing its own
+// `file.resolveFileRefs` — these pin the drain contract the provider relies on.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getFileRefStoreState, invalidateFileRefs, useFileRefStore } from './file-ref-store'
+
+const REF_A = 'file:cmfilea1234567890'
+const REF_B = 'asset:cmassetb123456789'
+
+const detail = (ref: string, name: string) => ({ ref, name, mimeType: 'image/png', size: 1024 })
+
+beforeEach(() => {
+  getFileRefStoreState().reset()
+})
+
+describe('fileRefStore.requestHydration', () => {
+  it('collapses duplicate refs from separate cells into one pending slot', () => {
+    // Two rows referencing the same attachment — the whole point of the store.
+    getFileRefStoreState().requestHydration([REF_A, REF_B])
+    getFileRefStoreState().requestHydration([REF_A])
+
+    expect(useFileRefStore.getState().pendingIds.size).toBe(2)
+    expect(getFileRefStoreState().startBatch(100).sort()).toEqual([REF_B, REF_A].sort())
+  })
+
+  it('drops malformed refs instead of burning a roundtrip on them', () => {
+    // `resolveFileRefs` skips anything without a `<type>:<id>` shape, so a
+    // queued bare id could only ever come back as the not-found sentinel.
+    getFileRefStoreState().requestHydration(['not-a-ref', REF_A])
+
+    expect(getFileRefStoreState().startBatch(100)).toEqual([REF_A])
+  })
+
+  it('does not re-queue refs already hydrated or in flight', () => {
+    getFileRefStoreState().requestHydration([REF_A, REF_B])
+    getFileRefStoreState().startBatch(100)
+    // Both are loading now — a newly mounted cell must not queue them again.
+    getFileRefStoreState().requestHydration([REF_A, REF_B])
+    expect(useFileRefStore.getState().pendingIds.size).toBe(0)
+
+    getFileRefStoreState().completeBatch(
+      [detail(REF_A, 'a.png'), detail(REF_B, 'b.png')],
+      [REF_A, REF_B]
+    )
+    getFileRefStoreState().requestHydration([REF_A, REF_B])
+    expect(useFileRefStore.getState().pendingIds.size).toBe(0)
+  })
+})
+
+describe('fileRefStore.startBatch', () => {
+  it('caps the batch and leaves the remainder pending for the next drain', () => {
+    const refs = Array.from({ length: 5 }, (_, i) => `file:cmfile${i}`)
+    getFileRefStoreState().requestHydration(refs)
+
+    expect(getFileRefStoreState().startBatch(3)).toHaveLength(3)
+    expect(useFileRefStore.getState().pendingIds.size).toBe(2)
+    expect(getFileRefStoreState().startBatch(3)).toHaveLength(2)
+    expect(getFileRefStoreState().startBatch(3)).toEqual([])
+  })
+})
+
+describe('fileRefStore.completeBatch', () => {
+  it('records a null sentinel for refs the server dropped', () => {
+    // A deleted file resolves to nothing. Without the sentinel the ref would
+    // sit unresolved forever and every remount would re-request it.
+    getFileRefStoreState().requestHydration([REF_A, REF_B])
+    getFileRefStoreState().startBatch(100)
+    getFileRefStoreState().completeBatch([detail(REF_A, 'a.png')], [REF_A, REF_B])
+
+    const { dataMap, loadingIds } = useFileRefStore.getState()
+    expect(dataMap[REF_A]?.name).toBe('a.png')
+    expect(dataMap[REF_B]).toBeNull()
+    expect(loadingIds.size).toBe(0)
+
+    getFileRefStoreState().requestHydration([REF_B])
+    expect(useFileRefStore.getState().pendingIds.size).toBe(0)
+  })
+})
+
+describe('invalidateFileRefs', () => {
+  it('lets a renamed file resolve again', () => {
+    // Batches are cached for the session (staleTime: Infinity), so the file
+    // manager has to evict explicitly or FILE cells show the stale name.
+    getFileRefStoreState().requestHydration([REF_A])
+    getFileRefStoreState().startBatch(100)
+    getFileRefStoreState().completeBatch([detail(REF_A, 'old.png')], [REF_A])
+
+    invalidateFileRefs([REF_A])
+    expect(useFileRefStore.getState().dataMap[REF_A]).toBeUndefined()
+
+    getFileRefStoreState().requestHydration([REF_A])
+    expect(getFileRefStoreState().startBatch(100)).toEqual([REF_A])
+  })
+})

--- a/apps/web/src/components/resources/store/file-ref-store.ts
+++ b/apps/web/src/components/resources/store/file-ref-store.ts
@@ -1,0 +1,102 @@
+// apps/web/src/components/resources/store/file-ref-store.ts
+
+import { useMemo } from 'react'
+import { createHydrationStore, type HydrationStore } from '~/stores'
+
+/**
+ * Resolved display details for a single file ref ("file:<id>" / "asset:<id>").
+ * Mirrors the `file.resolveFileRefs` row shape.
+ */
+export interface FileRefDetail {
+  ref: string
+  name: string
+  mimeType: string | null
+  size: number | null
+}
+
+/**
+ * Zustand store for FILE ref hydration.
+ *
+ * Every FILE surface (table cells, read-only displays) requests refs here
+ * instead of firing its own `file.resolveFileRefs` query. `ResourceProvider`
+ * drains the pending set on a debounce and resolves the whole viewport in one
+ * request — same shape as the relationship/actor stores.
+ */
+export const useFileRefStore = createHydrationStore<FileRefDetail>({
+  name: 'file-ref',
+  getKeyFromValue: (detail) => detail.ref,
+})
+
+/** Extended state type with convenience methods. */
+export interface FileRefStoreState extends HydrationStore<FileRefDetail> {
+  /** Queue refs for the next batch. Already-hydrated/in-flight refs are ignored. */
+  requestHydration: (refs: string[]) => void
+  /** Drain up to `max` pending refs into loadingIds and return the batch. */
+  startBatch: (max: number) => string[]
+  /**
+   * Publish a resolved batch. `requestedRefs` is required so refs the server
+   * dropped (deleted file, another org, malformed ref) get a null sentinel
+   * instead of staying pending forever.
+   */
+  completeBatch: (details: FileRefDetail[], requestedRefs: string[]) => void
+}
+
+/** Get the file-ref store state with convenience methods. */
+export function getFileRefStoreState(): FileRefStoreState {
+  const state = useFileRefStore.getState()
+
+  return {
+    ...state,
+    requestHydration: (refs: string[]) => {
+      // Drop malformed refs up front — `resolveFileRefs` skips anything without
+      // a `<type>:<id>` shape, so queueing them would only ever resolve to the
+      // not-found sentinel after a wasted roundtrip.
+      state.request(refs.filter((ref) => ref.includes(':')))
+    },
+    startBatch: (max: number) => {
+      const refs = Array.from(state.pendingIds).slice(0, max)
+      if (refs.length === 0) return []
+      state.markLoading(refs)
+      return refs
+    },
+    completeBatch: (details, requestedRefs) => {
+      state.addItems(
+        Object.fromEntries(details.map((detail) => [detail.ref, detail])),
+        requestedRefs
+      )
+    },
+  }
+}
+
+/**
+ * Drop cached details for these refs so the next request refetches them.
+ *
+ * Batches are cached for the session (`staleTime: Infinity` in the provider),
+ * so renames/deletes in the file manager must invalidate explicitly.
+ */
+export function invalidateFileRefs(refs: string[]): void {
+  useFileRefStore.getState().invalidate(refs)
+}
+
+/**
+ * Selector hook for hydrated file details.
+ * Returns: FileRefDetail (found), null (not found/deleted), or undefined (not loaded).
+ */
+export function useHydratedFileRefs(refs: string[]): (FileRefDetail | null | undefined)[] {
+  const dataMap = useFileRefStore((state) => state.dataMap)
+  return useMemo(() => refs.map((ref) => dataMap[ref]), [refs, dataMap])
+}
+
+/**
+ * Selector hook for whether any of `refs` is still unresolved.
+ *
+ * Deliberately "not in dataMap and not errored" rather than "in pendingIds or
+ * loadingIds": the request is queued in an effect, so the first render after a
+ * cell mounts has the ref in neither set and would otherwise report a false
+ * `isLoading: false` and flash an empty cell before the skeleton.
+ */
+export function useIsLoadingFileRefs(refs: string[]): boolean {
+  return useFileRefStore((state) =>
+    refs.some((ref) => state.dataMap[ref] === undefined && !state.errorIds.has(ref))
+  )
+}

--- a/apps/web/src/components/resources/store/index.ts
+++ b/apps/web/src/components/resources/store/index.ts
@@ -10,6 +10,15 @@ export {
 
 export { fieldValueFetchQueue } from './field-value-fetch-queue'
 export {
+  type FileRefDetail,
+  type FileRefStoreState,
+  getFileRefStoreState,
+  invalidateFileRefs,
+  useFileRefStore,
+  useHydratedFileRefs,
+  useIsLoadingFileRefs,
+} from './file-ref-store'
+export {
   createListKey,
   EMPTY_FILTERS,
   EMPTY_SORTING,

--- a/apps/web/src/components/sequences/ui/detail/sequence-step-attachments.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-step-attachments.tsx
@@ -8,7 +8,7 @@ import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
 import type { FileItem } from '~/components/files/files-store'
 import { MessageFile } from '~/components/mail/email-editor/message-file'
 import { FileSelectPicker } from '~/components/pickers/file-select-picker'
-import { api } from '~/trpc/react'
+import { useFileRefs } from '~/components/resources'
 
 interface SequenceStepAttachmentsProps {
   stepId: string
@@ -21,7 +21,7 @@ interface SequenceStepAttachmentsProps {
  * Per-step attachment chips + an "Attach files" picker, reusing the mail
  * composer's upload path (`useFileSelect` with the MESSAGE entity config +
  * `FileSelectPicker` for upload / browse-library). Persisted ids resolve their
- * display names via `file.resolveFileRefs`; a fresh upload's name comes from
+ * display names via the batched `useFileRefs` store; a fresh upload's name comes from
  * the in-flight file-select item until it lands in the persisted list.
  */
 export function SequenceStepAttachments({
@@ -54,18 +54,15 @@ export function SequenceStepAttachments({
     () => attachmentIds.flatMap((id) => [`file:${id}`, `asset:${id}`]),
     [attachmentIds]
   )
-  const { data: resolved } = api.file.resolveFileRefs.useQuery(
-    { refs },
-    { enabled: refs.length > 0 }
-  )
+  const { details } = useFileRefs(refs)
   const metaById = useMemo(() => {
     const map = new Map<string, { name: string; mimeType: string | null; size: number | null }>()
-    for (const entry of resolved ?? []) {
+    for (const entry of details) {
       const id = entry.ref.slice(entry.ref.indexOf(':') + 1)
       if (!map.has(id)) map.set(id, entry)
     }
     return map
-  }, [resolved])
+  }, [details])
 
   // Session names for ids the resolver hasn't caught up with yet.
   const sessionNameById = useMemo(() => {


### PR DESCRIPTION
## Problem

FILE cells were the one field type never wired into the batching `ResourceProvider` does for everything else in a records table. `FileCellContent` fired its own `file.resolveFileRefs` query per cell, so a 50-row table with a FILE column cost up to 50 procedure calls and ~100 DB queries.

React Query only dedupes identical keys and every row has different file ids, so nothing collapsed. `unstable_httpBatchStreamLink` merged the HTTP requests but not the work behind them. Virtualization made it recur on every scroll.

Everything else in the same table already batches through a 50ms-debounced coalescing store:

| Data | Store | Batched call |
|---|---|---|
| Field values | `fieldValueFetchQueue` | `fieldValue.batchGet` |
| Relationships | `useRelationshipStore` | `record.getByIds` |
| Actors | `useActorStore` | `actor.getByIds` |
| Records | `useRecordStore` | via `RecordBatchFetcher` |
| **Files** | **none** | **per-cell `file.resolveFileRefs`** |

The comment above `FileCellContent` claimed "Same pattern as RelationshipCellContent / ActorCellContent" — those two don't fetch at all, they render badges backed by the stores.

## Change

- **`store/file-ref-store.ts`** — built on the existing `createHydrationStore` primitive (same base as the relationship store), so it's ~100 lines rather than a hand-rolled store. Adds `requestHydration` / `startBatch(max)` / `completeBatch` / `invalidateFileRefs`.
- **`hooks/use-file-refs.ts`** — `useFileRefs(refs)` → `{ details, detailsByRef, isLoading }`.
- **`ResourceProvider`** — drains on the same `BATCH_DELAY` as the other batchers, with the same org-switch guard (`loadingIds` check) and `markError` path. Reset added to `clearResourceCaches()`.

No server change: `resolveFileRefs` was already batch-shaped (`{ refs: string[] }` → `inArray`).

### Migrated callers

No component calls `file.resolveFileRefs` directly anymore:

- `cell-renderers.tsx` — the records table
- `display-file.tsx` — read-only FILE display
- `use-field-file-upload.ts` — **mattered as much as the table**: `LinePhotoPopover` mounts it per line row unconditionally (not gated on `open`), so the money line builder had the same N-per-list problem
- `sequence-step-attachments.tsx`

## Behavior notes

- **Files now render in field-value order.** The router pushed all assets before all files, so mixed-source cells were previously reordered.
- **Batches cache for the session** (`staleTime: Infinity`) where the query had a 30s stale window, so renames/deletes now invalidate explicitly via `invalidateFileRefs` in `use-filesystem.tsx`. If MediaAssets are renamed on a path I didn't find, it needs the same call.
- **Batch capped at 100** — tRPC queries go out as GET with input in the URL, keeping it inside the ~8KB ceiling proxies commonly enforce.

In `use-field-file-upload.ts` the upload-settling handshake is preserved rather than simplified: `displayFiles` still returns `[]` before the first batch lands (instead of a row of "Unknown file" placeholders) and still keeps unresolved entries visible while in flight so a fresh upload doesn't blink out.

## Testing

- `file-ref-store.test.ts` — 6 tests: cross-cell dedupe, malformed-ref rejection, no re-queue when hydrated/in-flight, batch cap + remainder, null sentinel for server-dropped refs, invalidate-then-refetch.
- `vitest run src/components/resources src/components/records` — 94 passed.
- Biome clean on all touched files.
- `tsc --noEmit` in `apps/web`: zero errors in the new files; pre-existing errors in `cell-renderers` / `use-field-file-upload` / `use-filesystem` are all on untouched lines (that package has a broken baseline).

The upload-settling path was verified by reading, not by exercising an actual upload — that's the part worth a manual pass.