### PR TITLE
fix: drop the packages/services project reference and fix the 50 errors it hid

### DIFF
--- a/apps/api/src/routes/organizations/apps.ts
+++ b/apps/api/src/routes/organizations/apps.ts
@@ -243,7 +243,9 @@ apps.post('/:appSlug/install', requireOrganizationRole(['ADMIN', 'OWNER']), asyn
     )
   }
 
-  const { type, versionId } = bodyResult.data
+  // The request schema's field is `deploymentId`; destructuring `versionId` yielded
+  // undefined, so pinning an install to a specific deployment was silently ignored.
+  const { type, deploymentId } = bodyResult.data
 
   // Resolve slug from cache
   const cachedApp = await getCachedAppBySlug(appSlug)
@@ -256,7 +258,7 @@ apps.post('/:appSlug/install', requireOrganizationRole(['ADMIN', 'OWNER']), asyn
     appId: cachedApp.id,
     organizationId,
     installationType: type!,
-    deploymentId: versionId,
+    deploymentId,
     installedById: userId,
   })
 

--- a/apps/api/src/routes/workflows/share/auth-status.ts
+++ b/apps/api/src/routes/workflows/share/auth-status.ts
@@ -14,7 +14,9 @@ const authStatusRoute = new Hono()
  * Check authentication status for a shared workflow
  */
 authStatusRoute.get('/', async (c) => {
-  const shareToken = c.req.param('shareToken')
+  // Non-null: the parent router only mounts this under `/:shareToken/auth-status`,
+  // which Hono can't see from a sub-app. Same as site.ts.
+  const shareToken = c.req.param('shareToken')!
 
   // Get passport from query or header
   const passportToken = c.req.query('passport') || c.req.header('x-workflow-passport')

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,12 +2,8 @@
   "extends": "@auxx/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": ".",
-    "paths": {
-      "@auxx/services/*": ["../../packages/services/src/*"]
-    }
+    "baseUrl": "."
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
-  "references": [{ "path": "../../packages/services" }]
+  "exclude": ["node_modules", "dist"]
 }

--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -120,7 +120,7 @@ export default function IntegrationList() {
   // Filter categories based on whether they have apps
   const categoriesToDisplay = SHOW_EMPTY_CATEGORIES
     ? allCategories
-    : allCategories.filter((cat) => appsByCategory[cat.value]?.length > 0)
+    : allCategories.filter((cat) => (appsByCategory[cat.value]?.length ?? 0) > 0)
 
   // Create refs for each category section
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({})

--- a/apps/web/src/components/apps/providers/apps-provider.tsx
+++ b/apps/web/src/components/apps/providers/apps-provider.tsx
@@ -41,6 +41,29 @@ interface AppsProviderProps {
 }
 
 /**
+ * `connectionDefinitions` is a projection of the ConnectionDefinition row, so its
+ * `label`/`global` are nullable and `connectionType` is an open string. The host props
+ * want the narrowed client view, so the boundary is normalised here rather than by
+ * loosening what MessageClientWrapper accepts — `connectionType` drives real branching
+ * (OAuth vs secret) downstream.
+ */
+function toHostConnectionDefinition(
+  def: { label: string | null; global: boolean | null; connectionType: string } | undefined
+):
+  | { label: string; global: boolean; connectionType: 'oauth2-code' | 'secret' | 'none' }
+  | undefined {
+  if (!def) return undefined
+  return {
+    label: def.label ?? '',
+    global: def.global ?? false,
+    connectionType:
+      def.connectionType === 'oauth2-code' || def.connectionType === 'secret'
+        ? def.connectionType
+        : 'none',
+  }
+}
+
+/**
  * Main orchestrator for extension loading and management.
  *
  * 1. Fetches installed extensions for organization via tRPC
@@ -179,10 +202,10 @@ export function AppsProvider({ children }: AppsProviderProps) {
                       appTitle={installation.app.title}
                       organizationId={organizationId}
                       clientBundleSha={installation.currentDeployment!.clientBundleSha}
-                      connectionDefinition={
+                      connectionDefinition={toHostConnectionDefinition(
                         installation.connectionDefinitions?.user ??
-                        installation.connectionDefinitions?.organization
-                      }
+                          installation.connectionDefinitions?.organization
+                      )}
                     />
 
                     {/* 2. Set up data handlers for this extension (Plan 4) */}

--- a/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
+++ b/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
@@ -145,8 +145,11 @@ export function useCustomFieldMutations({ entityDefinitionId }: UseCustomFieldMu
 
       // Determine base type from field type — CALC follows its result type
       // (see the create-onMutate note above).
+      // Passed as `type` (which accepts `FieldType | string`) rather than `fieldType`:
+      // the stored column is the wider `ContactFieldType`, which still carries the
+      // legacy `PHONE` value the TS `FieldType` vocabulary dropped.
       const baseType = mapFieldTypeToBaseType(
-        getEffectiveFieldType({ fieldType: result.type, options: result.options })
+        getEffectiveFieldType({ type: result.type, options: result.options })
       )
 
       // Build capabilities from server response

--- a/apps/web/src/components/dynamic-table/hooks/use-view-store-persistence.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-view-store-persistence.ts
@@ -7,7 +7,7 @@ import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 import { api } from '~/trpc/react'
 import { DYNAMIC_TABLE_CONFIG } from '../config/table-config'
 import { useDynamicTableStore } from '../stores/dynamic-table-store'
-import type { TableView } from '../types'
+import type { TableView, ViewConfig } from '../types'
 import { tableViewPreferenceKey } from '../utils/constants'
 import {
   hasPresentationPreference,
@@ -125,7 +125,10 @@ export function useViewStorePersistence(view: TableView | null, tableId: string)
         config: mergedConfig,
       })
 
-      confirmSave(viewId, result.config)
+      // This hook only ever persists table `ViewConfig`s. The endpoint's return type is
+      // the wider `ViewConfig | FieldViewConfig` because the same route also serves
+      // panel/dialog field configs, which this store never drives.
+      confirmSave(viewId, result.config as ViewConfig)
       lastSavedRef.current = JSON.stringify(result.config)
 
       if (view?.isShared) {

--- a/apps/web/src/components/favorites/ui/items/table-view-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/table-view-item.tsx
@@ -21,7 +21,9 @@ export function TableViewItem({ favorite }: { favorite: FavoriteEntity<'TABLE_VI
   if (code === 'NOT_FOUND' || code === 'FORBIDDEN' || (!isLoading && !data)) {
     return <PrivateItem favoriteId={favorite.id} />
   }
-  if (isLoading) return <FavoriteItemSkeleton favoriteId={favorite.id} />
+  // `!data` here can only mean the query is still in flight — the guard above already
+  // returned for a settled-but-empty result.
+  if (isLoading || !data) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   // Most table views live under /app/<apiSlug>?view=<id>; we don't have apiSlug
   // here, so we route through tableId which is a system table or entityDefinitionId.

--- a/apps/web/src/components/kopilot/hooks/use-kopilot-sessions.ts
+++ b/apps/web/src/components/kopilot/hooks/use-kopilot-sessions.ts
@@ -100,7 +100,10 @@ export function useLoadSession() {
     // renders the sender chip non-interactive.
     setActiveSessionAgentId((data as any)?.agentId ?? null)
 
-    const raw = (data?.messages ?? []) as PersistedMessage[]
+    // The session `messages` column is untyped `Record<string, unknown>[]` jsonb; the
+    // agent engine is its only writer. The two shapes don't overlap enough for a direct
+    // assertion, hence the hop through `unknown`.
+    const raw = (data?.messages ?? []) as unknown as PersistedMessage[]
 
     // Persisted shape == render-ready shape. No filter, no reparent loop,
     // no _pendingToolCall re-emit, no reconstructThinkingGroups.

--- a/apps/web/src/server/api/routers/procedure.ts
+++ b/apps/web/src/server/api/routers/procedure.ts
@@ -280,7 +280,10 @@ export const procedureRouter = createTRPCRouter({
       )
       if (!draft) throw new TRPCError({ code: 'NOT_FOUND', message: 'Draft version not found' })
 
-      const { compiled, errors } = compileProcedure(draft.doc as TiptapDoc)
+      // `ProcedureVersion.doc` is untyped `Record<string, unknown>` jsonb and the editor
+      // is its only writer, so the two shapes don't overlap enough for a direct assertion.
+      const draftDoc = draft.doc as unknown as TiptapDoc
+      const { compiled, errors } = compileProcedure(draftDoc)
       if (errors && errors.length > 0) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -292,7 +295,7 @@ export const procedureRouter = createTRPCRouter({
         await publishProcedure({
           organizationId,
           procedureId: input.id,
-          doc: draft.doc as TiptapDoc,
+          doc: draftDoc,
           compiled,
           editorId: ctx.session.userId,
         }),

--- a/apps/web/src/server/api/routers/quick-actions.ts
+++ b/apps/web/src/server/api/routers/quick-actions.ts
@@ -4,6 +4,7 @@ import { QuickActionExecutor } from '@auxx/lib/quick-actions'
 import { TicketEventType, TimelineActorType, TimelineEntityType } from '@auxx/lib/timeline'
 import { createScopedLogger } from '@auxx/logger'
 import { createTimelineEvent } from '@auxx/services/timeline'
+import { toRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
@@ -76,17 +77,16 @@ export const quickActionRouter = createTRPCRouter({
         if (!action || !input.context.ticketId) continue
 
         try {
+          // `createTimelineEvent` takes a `recordId` plus a flat actor pair. This call
+          // still passed the retired `{ entityType, entityId, actor }` shape, so the
+          // service destructured `recordId` as undefined and every quick-action
+          // timeline event threw into the catch below instead of being written.
           await createTimelineEvent({
             organizationId,
-            entityType: TimelineEntityType.TICKET,
-            entityId: input.context.ticketId,
+            recordId: toRecordId(TimelineEntityType.TICKET, input.context.ticketId),
             eventType: TicketEventType.QUICK_ACTION_EXECUTED,
-            actor: {
-              type: TimelineActorType.USER,
-              id: userId,
-              name: user?.name ?? undefined,
-              email: user?.email ?? undefined,
-            },
+            actorType: TimelineActorType.USER,
+            actorId: userId,
             eventData: {
               appId: action.appId,
               actionId: action.actionId,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,7 +22,6 @@
     "skipLibCheck": true,
     "module": "esnext"
   },
-  "references": [{ "path": "../../packages/services" }],
   "include": [
     "next-env.d.ts",
     "**/*.ts",

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -83,6 +83,11 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   }
   const session = sessionResult.value
 
+  // The `messages` column is untyped `Record<string, unknown>[]` jsonb. The engine is
+  // its only writer, so the stored rows ARE `SessionMessage`s — but the two shapes do
+  // not overlap enough for a direct assertion, hence the hop through `unknown`.
+  const sessionMessages = (session.messages ?? []) as unknown as SessionMessage[]
+
   // Prefer the agentId persisted on the session row; the job payload's
   // `agentId` is only authoritative on the very first turn before the row
   // is read back.
@@ -173,7 +178,7 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   }
 
   const engine = new AgentEngine(engineConfig, {
-    messages: (session.messages ?? []) as SessionMessage[],
+    messages: sessionMessages,
     domainState: (session.domainState ?? {}) as Record<string, unknown>,
   })
 
@@ -245,7 +250,7 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   if (hasProcedures && type !== 'approval') {
     const subject: Subject = { anchors: {}, identityVerified: false }
     const conversation: ConversationMessage[] = [
-      ...sessionMessagesToConversation((session.messages ?? []) as SessionMessage[]),
+      ...sessionMessagesToConversation(sessionMessages),
       { role: 'user', content: message },
     ]
     const buildCtx = (): ToolContext => {

--- a/packages/lib/src/ai/agent-framework/sessions/find-or-create-thread-session.ts
+++ b/packages/lib/src/ai/agent-framework/sessions/find-or-create-thread-session.ts
@@ -11,8 +11,12 @@ const logger = createScopedLogger('find-or-create-thread-session')
  * The `triggerContext` shape stored on chat sessions. Mirrors the audit
  * answer to "why did this agent fire?" for chat — there is no `AgentTrigger`
  * row (chat binds via `ChatWidget.agentId`). See plans/chat/v5 phase-3.
+ *
+ * A type alias, not an interface: `createSession` stores this in a
+ * `Record<string, unknown>` jsonb column, and only aliases get an implicit
+ * index signature.
  */
-export interface ChatTriggerContext {
+export type ChatTriggerContext = {
   kind: 'chat'
   threadId: string
   contactId: string | null

--- a/packages/lib/src/apps/get-app-details.ts
+++ b/packages/lib/src/apps/get-app-details.ts
@@ -372,7 +372,8 @@ function deriveConnectionDescriptor(
   methods: ConnectionMethod[],
   hasOauth: boolean
 ): { label: string } | null {
-  if (methods.length === 1) return { label: methods[0].label }
+  const only = methods.length === 1 ? methods[0] : undefined
+  if (only) return { label: only.label }
   if (methods.length > 1) return { label: 'Connection' }
   if (hasOauth) return { label: 'OAuth connection' }
   return null

--- a/packages/lib/src/cache/providers/build-organizations-provider.ts
+++ b/packages/lib/src/cache/providers/build-organizations-provider.ts
@@ -17,11 +17,18 @@ export const buildOrganizationsProvider: CacheProvider<BuildCachedOrganization[]
       throw new Error(`Failed to fetch organizations: ${result.error.message}`)
     }
 
-    return result.value.map((org) => ({
-      id: org.id,
-      name: org.name,
-      handle: org.handle,
-      slug: org.handle,
-    }))
+    return (
+      result.value
+        // `Organization.handle` is nullable, but every consumer of this list addresses an
+        // org BY its handle — the build portal renders it as `@slug` and uses it as a
+        // SelectItem value. An org without one cannot be selected, so it is not listed.
+        .filter((org): org is typeof org & { handle: string } => org.handle !== null)
+        .map((org) => ({
+          id: org.id,
+          name: org.name,
+          handle: org.handle,
+          slug: org.handle,
+        }))
+    )
   },
 }

--- a/packages/lib/src/custom-fields/custom-field-service.ts
+++ b/packages/lib/src/custom-fields/custom-field-service.ts
@@ -2,7 +2,7 @@
 
 import { type Database, database } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
-import type { DisplayOptions, FileOptions, SelectOption } from '@auxx/services/custom-fields'
+import type { CustomFieldOptionsInput } from '@auxx/services/custom-fields'
 import {
   createCustomField,
   deleteCustomField,
@@ -10,9 +10,18 @@ import {
   type RelationshipOptions,
   updateCustomField,
 } from '@auxx/services/custom-fields'
-import type { AiOptions } from '@auxx/types/custom-field'
 import type { ResourceFieldId } from '@auxx/types/field'
 import { onCacheEvent } from '../cache/invalidate'
+
+/**
+ * Only the database-backed service errors carry a `cause`; the not-found,
+ * access-denied and validation shapes are just a code and a message. Reading it
+ * off the union directly does not typecheck, and at runtime it was always
+ * `undefined` for those.
+ */
+function errorCause(error: { message: string; cause?: unknown }): unknown {
+  return error.cause
+}
 
 /**
  * Service for managing custom fields and their values across different models
@@ -56,11 +65,7 @@ export class CustomFieldService {
     description?: string
     required?: boolean
     defaultValue?: string
-    options?:
-      | SelectOption[]
-      | { file: FileOptions }
-      | { options: SelectOption[]; ai?: AiOptions }
-      | (DisplayOptions & { ai?: AiOptions })
+    options?: CustomFieldOptionsInput
     addressComponents?: string[]
     /** ADDRESS_STRUCT input variant — see addressFieldOptionsSchema. */
     inputMode?: 'single' | 'structured'
@@ -95,11 +100,7 @@ export class CustomFieldService {
     description?: string
     required?: boolean
     defaultValue?: string
-    options?:
-      | SelectOption[]
-      | { file: FileOptions }
-      | { options: SelectOption[]; ai?: AiOptions }
-      | (DisplayOptions & { ai?: AiOptions })
+    options?: CustomFieldOptionsInput
     addressComponents?: string[]
     /** ADDRESS_STRUCT input variant — see addressFieldOptionsSchema. */
     inputMode?: 'single' | 'structured'
@@ -117,7 +118,7 @@ export class CustomFieldService {
 
     if (result.isErr()) {
       // Preserve the cause for better error debugging
-      throw new Error(result.error.message, { cause: result.error.cause })
+      throw new Error(result.error.message, { cause: errorCause(result.error) })
     }
 
     await onCacheEvent('custom-field.updated', { orgId: this.organizationId })
@@ -137,7 +138,7 @@ export class CustomFieldService {
 
     if (result.isErr()) {
       // Preserve the cause for better error debugging
-      throw new Error(result.error.message, { cause: result.error.cause })
+      throw new Error(result.error.message, { cause: errorCause(result.error) })
     }
 
     await onCacheEvent('custom-field.deleted', { orgId: this.organizationId })
@@ -158,7 +159,7 @@ export class CustomFieldService {
 
     if (result.isErr()) {
       // Preserve the cause for better error debugging
-      throw new Error(result.error.message, { cause: result.error.cause })
+      throw new Error(result.error.message, { cause: errorCause(result.error) })
     }
 
     return result.value

--- a/packages/lib/src/entity-definitions/entity-definition-service.ts
+++ b/packages/lib/src/entity-definitions/entity-definition-service.ts
@@ -100,7 +100,13 @@ export class EntityDefinitionService {
       entityType: input.entityType ?? null,
       standardType: input.standardType ?? null,
     })
-    const value = unwrapResult(result)
+    // Narrowed inline rather than through `unwrapResult`: this service returns a UNION
+    // of `Err`s with different error shapes, and inferring `E` from a union argument
+    // only picks up some of its members.
+    if (result.isErr()) {
+      throw new Error(result.error.message)
+    }
+    const value = result.value
     await notifyEntityDefChanged(this.organizationId, value.id, 'created')
     return value
   }

--- a/packages/lib/src/groups/group-functions.ts
+++ b/packages/lib/src/groups/group-functions.ts
@@ -26,8 +26,10 @@ import { hasGroupPermission, requireGroupPermission } from './permissions'
 // Group Metadata Type
 // ============================================================================
 
-/** Metadata stored on EntityInstance for entity_group type */
-interface GroupMetadata {
+/** Metadata stored on EntityInstance for entity_group type.
+ *  A type alias, not an interface: `createEntityInstance` takes
+ *  `Record<string, unknown>`, and only aliases get an implicit index signature. */
+type GroupMetadata = {
   memberType?: 'any' | string
   visibility?: GroupVisibility
   color?: string

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -9,6 +9,7 @@ import {
   getEntityInstance,
   updateEntityInstance,
 } from '@auxx/services/entity-instances'
+import type { Result } from 'neverthrow'
 import { findCachedResource } from '../../cache'
 import { CommentService } from '../../comments'
 import { UnprocessableEntityError } from '../../errors'
@@ -101,13 +102,13 @@ export interface CreateEntityResult {
 }
 
 /**
- * Helper to unwrap neverthrow Result and throw on error
+ * Helper to unwrap neverthrow Result and throw on error.
+ *
+ * Typed against `Result`, not structurally: an `Err` carries no `value` and an
+ * `Ok` carries no `error`, so a `{ isErr, error, value }` parameter matches
+ * neither arm and silently degraded `T` to `unknown`.
  */
-function unwrapResult<T, E extends { message: string; cause?: unknown }>(result: {
-  isErr: () => boolean
-  error: E
-  value: T
-}): T {
+function unwrapResult<T>(result: Result<T, { message: string; cause?: unknown }>): T {
   if (result.isErr()) {
     // Preserve `cause` so route-level logs can see the underlying DB error
     // (constraint violation, missing column, etc.) instead of the generic
@@ -782,7 +783,10 @@ export async function bulkUpdateEntities(
 
   for (const { recordId, values } of updates) {
     try {
-      await updateEntity(ctx, recordId, values, {
+      // `updateEntity` takes `modes` fourth and `options` fifth — the options object
+      // was landing in the `modes` slot, so `skipEvents` was silently dropped and a
+      // bulk update published per-record events regardless.
+      await updateEntity(ctx, recordId, values, undefined, {
         skipEvents: options.skipEvents,
       })
       updated++

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -13,6 +13,7 @@ import { createTypedValueInput } from '@auxx/types/field-value'
 import { isEntityDefinitionType } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { type AnyColumn, and, eq, type SQL } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
 import { findCachedResource, getCachedCustomFields, getCachedFieldMap } from '../../cache'
 import { type ConditionGroup, resolveConditionContext } from '../../conditions'
 import { BadRequestError } from '../../errors'
@@ -125,13 +126,13 @@ export type LookupByFieldResult = {
 }
 
 /**
- * Helper to unwrap neverthrow Result and throw on error
+ * Helper to unwrap neverthrow Result and throw on error.
+ *
+ * Typed against `Result`, not structurally: an `Err` carries no `value` and an
+ * `Ok` carries no `error`, so a `{ isErr, error, value }` parameter matches
+ * neither arm and silently degraded `T` to `unknown`.
  */
-function unwrapResult<T, E extends { message: string }>(result: {
-  isErr: () => boolean
-  error: E
-  value: T
-}): T {
+function unwrapResult<T, E extends { message: string }>(result: Result<T, E>): T {
   if (result.isErr()) {
     throw new Error(result.error.message)
   }

--- a/packages/services/src/app-connections/get-app-connection.ts
+++ b/packages/services/src/app-connections/get-app-connection.ts
@@ -2,6 +2,7 @@
 
 import { findCredential, revealSecrets } from '@auxx/credentials/store'
 import { err, ok } from 'neverthrow'
+import type { DecryptedConnectionData } from './types'
 
 /**
  * Get connection for app (used when executing app functions)
@@ -84,6 +85,11 @@ export async function getAppConnection(appId: string, organizationId: string, us
   if (revealed.isErr()) return err(revealed.error)
 
   // Preserve the legacy "full data" shape: non-secret companion fields flattened to the top
-  // level, secrets layered on top (secrets win on key collisions).
-  return ok({ ...revealed.value.record.metadata, ...revealed.value.secrets })
+  // level, secrets layered on top (secrets win on key collisions). Spreading two
+  // index-signature types erases every named key, so the shape is asserted once here
+  // rather than at each call site.
+  return ok({
+    ...revealed.value.record.metadata,
+    ...revealed.value.secrets,
+  } as DecryptedConnectionData)
 }

--- a/packages/services/src/app-versions/list-deployments.ts
+++ b/packages/services/src/app-versions/list-deployments.ts
@@ -30,7 +30,7 @@ export async function listDeployments(params: {
           columns: { id: true, name: true, email: true },
         },
         targetOrganization: {
-          columns: { id: true, name: true, slug: true },
+          columns: { id: true, name: true, handle: true },
         },
       },
     }),

--- a/packages/services/src/custom-fields/create-field.ts
+++ b/packages/services/src/custom-fields/create-field.ts
@@ -13,9 +13,8 @@ import { and, desc, eq, isNull } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
 import { fromDatabase } from '../shared/utils'
 import {
+  type CustomFieldOptionsInput,
   canFieldBeUnique,
-  type DisplayOptions,
-  type FileOptions,
   isDisplayOptions,
   type ModelType,
   ModelTypes,
@@ -67,13 +66,7 @@ export interface CreateCustomFieldInput {
   defaultValue?: string
   /** Field options - select options, file config, flat display options
    *  (incl. CURRENCY), actor/calc bags, or `{ options, ai }` for AI-enabled selects. */
-  options?:
-    | SelectOption[]
-    | { file: FileOptions }
-    | { actor: ActorOptions }
-    | { calc: CalcOptions }
-    | { options: SelectOption[]; ai?: AiOptions }
-    | (DisplayOptions & { ai?: AiOptions })
+  options?: CustomFieldOptionsInput
   addressComponents?: string[]
   /** ADDRESS_STRUCT input variant: single free-text input (default, omitted
    *  from storage) vs. separate structured sub-fields. */
@@ -213,10 +206,16 @@ async function resolveUniqueFieldName(
  * For RELATIONSHIP type, automatically creates the inverse field
  *
  * @param input - Field data
- * @param tx - Optional transaction context (defaults to global database)
+ * @param tx - Optional database or transaction context (defaults to global database).
+ *             Every helper this hands it to already takes `Database | Transaction`, and
+ *             the relationship path opens its own transaction when handed the global
+ *             database — so a plain `Database` has always been valid here.
  * @returns Result with created field (or primary field for relationships)
  */
-export async function createCustomField(input: CreateCustomFieldInput, tx?: Transaction) {
+export async function createCustomField(
+  input: CreateCustomFieldInput,
+  tx?: Database | Transaction
+) {
   const {
     organizationId,
     name,

--- a/packages/services/src/custom-fields/index.ts
+++ b/packages/services/src/custom-fields/index.ts
@@ -32,6 +32,7 @@ export type { RelationshipConfig, RelationshipOptions } from './types'
 // Types - unified types from @auxx/database
 // Consolidated field option types (single source of truth)
 export {
+  type CustomFieldOptionsInput,
   canFieldBeUnique,
   DEFAULT_SELECT_OPTION_COLOR,
   type DisplayOptions,

--- a/packages/services/src/custom-fields/types.ts
+++ b/packages/services/src/custom-fields/types.ts
@@ -1,5 +1,29 @@
 // packages/services/src/custom-fields/types.ts
 
+import type {
+  ActorOptions,
+  AiOptions,
+  CalcOptions,
+  DisplayOptions,
+  FileOptions,
+  SelectOption,
+} from '@auxx/types/custom-field'
+
+/**
+ * The `options` payload a create/update accepts, in one place.
+ *
+ * Create and update each used to spell this union out, and they had drifted:
+ * update omitted `{ actor }` even though `updateCustomField` merges actor options,
+ * so the tRPC router's `fieldOptionsUnionSchema` input did not typecheck against it.
+ */
+export type CustomFieldOptionsInput =
+  | SelectOption[]
+  | { file: FileOptions }
+  | { actor: ActorOptions }
+  | { calc: CalcOptions }
+  | { options: SelectOption[]; ai?: AiOptions }
+  | (DisplayOptions & { ai?: AiOptions })
+
 // Re-export all types from @auxx/types/custom-field (single source of truth)
 export {
   type ActorOptions,

--- a/packages/services/src/custom-fields/update-field.ts
+++ b/packages/services/src/custom-fields/update-field.ts
@@ -13,9 +13,8 @@ import type { CustomFieldNotFoundError } from './errors'
 import { isProtectedField } from './ownership'
 import {
   type ActorOptions,
+  type CustomFieldOptionsInput,
   canFieldBeUnique,
-  type DisplayOptions,
-  type FileOptions,
   getInverseFieldId,
   isDisplayOptions,
   mergeDisplayOptions,
@@ -52,13 +51,8 @@ export interface UpdateCustomFieldInput {
   required?: boolean
   defaultValue?: string
   /** Field options - select options, file config, flat display options
-   *  (incl. CURRENCY), or `{ options, ai }` for AI-enabled selects. */
-  options?:
-    | SelectOption[]
-    | { file: FileOptions }
-    | { calc: CalcOptions }
-    | { options: SelectOption[]; ai?: AiOptions }
-    | (DisplayOptions & { ai?: AiOptions })
+   *  (incl. CURRENCY), actor/calc bags, or `{ options, ai }` for AI-enabled selects. */
+  options?: CustomFieldOptionsInput
   addressComponents?: string[]
   /** ADDRESS_STRUCT input variant: single free-text input (default, omitted
    *  from storage) vs. separate structured sub-fields. */

--- a/packages/services/src/custom-fields/validate-ai-options.ts
+++ b/packages/services/src/custom-fields/validate-ai-options.ts
@@ -1,7 +1,7 @@
 // packages/services/src/custom-fields/validate-ai-options.ts
 
 import { database, schema } from '@auxx/database'
-import type { FieldType } from '@auxx/database/types'
+import type { CustomFieldEntity } from '@auxx/database/types'
 import {
   type AiOptions,
   extractFieldIdsFromPrompt,
@@ -19,7 +19,10 @@ export interface AiOptionsValidationError {
 
 export interface ValidateAiOptionsInput {
   organizationId: string
-  type: FieldType
+  /** The STORED field type. Wider than `FieldType`: the `ContactFieldType`
+   *  column still carries the legacy `PHONE` value that the TS vocabulary
+   *  dropped in favour of `PHONE_INTL`, so an existing row can present one. */
+  type: CustomFieldEntity['type']
   /** `options.ai` parsed from the incoming create/update payload. `undefined`
    *  when the caller did not set an AI block — no validation runs. */
   ai: AiOptions | undefined

--- a/packages/services/src/shared/error-maps.ts
+++ b/packages/services/src/shared/error-maps.ts
@@ -86,7 +86,6 @@ export const ERROR_TRPC_MAP: Record<
  */
 export type AnyServiceError =
   | import('../apps/errors').AppError
-  | import('../app-versions/errors').AppVersionError
   | import('../app-bundles/errors').AppBundleError
   | import('../app-installations/errors').AppInstallationError
   | import('../organizations/errors').OrganizationError

--- a/packages/services/src/table-view/create-view.ts
+++ b/packages/services/src/table-view/create-view.ts
@@ -67,7 +67,8 @@ export async function createView(input: CreateViewInput) {
 
   if (existingResult.isErr()) return existingResult
   if (existingResult.value.length > 0) {
-    return err<ViewAlreadyExistsError>({
+    // `err<T, E>` — the FIRST slot is the ok-value type; see get-view.ts.
+    return err<never, ViewAlreadyExistsError>({
       code: 'VIEW_ALREADY_EXISTS',
       message: 'A view with this name already exists',
       name,

--- a/packages/services/src/table-view/get-view.ts
+++ b/packages/services/src/table-view/get-view.ts
@@ -73,7 +73,10 @@ export async function getView(input: GetViewInput) {
 
   const view = dbResult.value[0]
   if (!view) {
-    return err<ViewNotFoundError>({
+    // `err<T, E>` — the FIRST slot is the ok-value type. Naming only one argument
+    // leaves `E` on its `unknown` default, which erases the error type for every
+    // caller that narrows on `isErr()`.
+    return err<never, ViewNotFoundError>({
       code: 'VIEW_NOT_FOUND',
       message: notFoundMessage,
       viewId: id,

--- a/packages/services/src/timeline/create-timeline-event.ts
+++ b/packages/services/src/timeline/create-timeline-event.ts
@@ -16,10 +16,13 @@ export interface CreateTimelineEventInput {
   actorType: string
   actorId: string
   eventData?: Record<string, any>
+  /** Persisted verbatim into a `jsonb` column. `oldValue`/`newValue` are the legacy raw
+   *  pair — writers now send server-resolved `oldDisplay`/`newDisplay` snapshots instead
+   *  (see `TimelineChange` in `@auxx/lib/timeline`), so neither is required. */
   changes?: Array<{
     field: string
-    oldValue: any
-    newValue: any
+    oldValue?: unknown
+    newValue?: unknown
   }> | null
   metadata?: Record<string, any> | null
   organizationId: string

--- a/packages/services/src/workflow-share/types.ts
+++ b/packages/services/src/workflow-share/types.ts
@@ -27,6 +27,9 @@ export interface WorkflowShareConfig {
   hideBranding?: boolean
   showWorkflowPreview?: boolean
   showInputForm?: boolean
+  /** Stream per-node workflow events to the public runner. Default false (privacy) —
+   *  written by the access-settings panel, read by the shared-run route. */
+  showWorkflowDetails?: boolean
   submitButtonText?: string
   successMessage?: string
   maxConcurrentRuns?: number


### PR DESCRIPTION
## What

`apps/web` and `apps/api` both carried `"references": [{ "path": "../../packages/services" }]`. A TS project reference redirects imports of that project to its **built** `dist/*.d.ts`, which nothing builds before a typecheck — so every `TS6305` traced to that one line, and every symbol behind it resolved as `any`, suppressing the errors underneath (`plans/testing/HANDOFF.md` §2.10, §5.1).

`apps/api` also needed its `paths` mapping to `../../packages/services/src/*` removed: resolving through an explicit path instead of the `node_modules` symlink put 91 files outside its composite `rootDir` and traded the TS6305s for TS6307 + TS6059.

## Numbers (clean worktree at `df968f541`)

| | before | after |
|---|---|---|
| `apps/web` | 3887 | **3703** |
| `apps/api` | 1407 | **1309** |
| `packages/lib` | 2796 | **2769** |
| TS6305 (web / api) | 90 / 74 | **0 / 0** |
| TS6307 fallout | — | **0** |

Ratchet green for both watched packages (lib 2769 / baseline 2807, web 3703 / baseline 3986). `apps/api` and `packages/billing` add no new `file::code` keys.

## Real defects the resolution revealed

- **`quick-actions.ts`** called `createTimelineEvent` with the retired `{ entityType, entityId, actor }` shape, so the service read `recordId` as `undefined` and **every quick-action timeline event threw into its catch** instead of being written.
- **`bulkUpdateEntities`** passed its options object in `updateEntity`'s `modes` slot (4th, not 5th), so `skipEvents` was dropped and bulk updates published per-record events regardless.
- **`apps/api` install route** destructured `versionId` from a schema whose field is `deploymentId`, so pinning an install to a specific deployment was silently ignored.
- **`err<ViewNotFoundError>(...)`** names `err`'s *first* type slot, which is the ok-value type — `E` stayed on its `unknown` default and erased the error type for every `tableView` caller that narrows on `isErr()`.
- **`list-deployments`** selected a `slug` column `Organization` does not have, which also silently untyped the `clientBundle`/`serverBundle` relations.
- **`WorkflowShareConfig`** was missing `showWorkflowDetails`, which the access-settings panel writes and the shared-run route reads.
- **`getAppConnection`** spread two index-signature types, which erases every named key — both Shopify billing callers got `{}` for `accessToken`.
- **`unwrapResult`** in both `unified-handler` files was typed structurally as `{ isErr, error, value }`; an `Err` has no `value` and an `Ok` has no `error`, so it matched neither arm and degraded `T` to `unknown`.
- **create/update custom-field inputs** each spelled out the `options` union and had drifted — update omitted `{ actor }` even though `updateCustomField` merges actor options. Both now share `CustomFieldOptionsInput`.

The rest are ordinary narrowing/nullability fixes and jsonb-boundary casts (`Record<string, unknown>` → `SessionMessage[]` / `TiptapDoc` / `PersistedMessage[]`), each commented at the site.

## Verification

- `node scripts/ci/typecheck-ratchet.js` — green, both packages
- `apps/api`, `packages/services`, `packages/billing` — no new `file::code` keys vs pristine
- Full 12-project vitest: **695 files / 8786 tests passed**, 4 files + 69 tests skipped (the live-API provider suites), exit 0

All measurement done in a detached clean worktree per HANDOFF §2.1/§2.9 — same-state key-set deltas, never a local total against the committed baseline. The baseline is **not** re-recorded; the weekly job tightens it.