### PR TITLE
perf(realtime): batch pusher channel auth into one signed request

### DIFF
--- a/apps/web/src/app/api/pusher/auth/batch/route.test.ts
+++ b/apps/web/src/app/api/pusher/auth/batch/route.test.ts
@@ -1,0 +1,168 @@
+// apps/web/src/app/api/pusher/auth/batch/route.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { POST } from './route'
+
+/**
+ * The batch endpoint's contract (plan v3/05 §2.4). Authorization itself is
+ * `RealtimeService.authorizeMany`'s job and is covered in
+ * `packages/lib/src/realtime/authorize-many.test.ts`; what is pinned here is
+ * the SHAPE, because the shape is what the custom pusher-js authorizer parses:
+ *
+ * - a denial is `null` inside a 200, never an HTTP error — per-channel verdicts
+ *   cannot ride the status when the request carries many channels;
+ * - the status describes only whether the REQUEST was well-formed;
+ * - a session-less caller gets a full sheet of `null`, not a 401 — the
+ *   per-channel route never distinguished "anonymous" from "not yours", and
+ *   introducing that distinction here would answer a question the ACL refuses
+ *   to answer.
+ */
+
+const { getSession, authorizeMany, ensureWebAppInitialized } = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  authorizeMany: vi.fn(),
+  ensureWebAppInitialized: vi.fn(async () => undefined),
+}))
+
+vi.mock('@auxx/lib/realtime', () => ({
+  getRealtimeService: () => ({ authorizeMany }),
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+vi.mock('~/server/bootstrap', () => ({ ensureWebAppInitialized }))
+
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+const USER = '0D5csE1ejLpyv3rKq3wLQm33dCPNslir'
+const SOCKET = '6189518247.123456'
+const ALLOWED = `private-org-${ORG}-records-i5aezsg4bc6n8gof2uan3wcf`
+const DENIED = `private-org-${ORG}-records-xrbtfl7syi3sm4mqf5wiayuz`
+
+const request = (body: unknown) =>
+  ({
+    headers: new Headers(),
+    json: async () => {
+      if (typeof body === 'string') throw new SyntaxError('Unexpected token')
+      return body
+    },
+  }) as never
+
+const session = {
+  user: { id: USER, defaultOrganizationId: ORG, name: 'Markus', email: 'm@example.com' },
+}
+
+beforeEach(() => {
+  getSession.mockReset().mockResolvedValue(session)
+  authorizeMany
+    .mockReset()
+    .mockImplementation(async (_socket: string, channels: string[]) =>
+      Object.fromEntries(channels.map((c) => [c, c === ALLOWED ? { auth: 'key:sig' } : null]))
+    )
+})
+
+describe('POST /api/pusher/auth/batch', () => {
+  it('returns 200 with a per-channel verdict for a mixed batch', async () => {
+    const res = await POST(request({ socket_id: SOCKET, channels: [ALLOWED, DENIED] }))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      results: { [ALLOWED]: { auth: 'key:sig' }, [DENIED]: null },
+    })
+  })
+
+  it('passes the socket id and the session-derived ctx through to authorizeMany', async () => {
+    await POST(request({ socket_id: SOCKET, channels: [ALLOWED] }))
+
+    expect(authorizeMany).toHaveBeenCalledWith(
+      SOCKET,
+      [ALLOWED],
+      { session: { userId: USER, organizationId: ORG } },
+      expect.objectContaining({ id: USER })
+    )
+  })
+
+  it('collapses duplicate channel names before authorizing', async () => {
+    const res = await POST(request({ socket_id: SOCKET, channels: [ALLOWED, ALLOWED, DENIED] }))
+
+    expect(authorizeMany.mock.calls[0][1]).toEqual([ALLOWED, DENIED])
+    await expect(res.json()).resolves.toEqual({
+      results: { [ALLOWED]: { auth: 'key:sig' }, [DENIED]: null },
+    })
+  })
+
+  it('answers a session-less caller with a full sheet of null, not a 401', async () => {
+    getSession.mockResolvedValue(null)
+    authorizeMany.mockImplementation(async (_socket: string, channels: string[]) =>
+      Object.fromEntries(channels.map((c) => [c, null]))
+    )
+
+    const res = await POST(request({ socket_id: SOCKET, channels: [ALLOWED, DENIED] }))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ results: { [ALLOWED]: null, [DENIED]: null } })
+    expect(authorizeMany).toHaveBeenCalledWith(
+      SOCKET,
+      [ALLOWED, DENIED],
+      { session: null },
+      undefined
+    )
+  })
+
+  it('treats a session with no default organization as anonymous', async () => {
+    getSession.mockResolvedValue({ user: { id: USER, defaultOrganizationId: null } })
+
+    await POST(request({ socket_id: SOCKET, channels: [ALLOWED] }))
+
+    expect(authorizeMany.mock.calls[0][2]).toEqual({ session: null })
+  })
+
+  it('400s a missing socket_id', async () => {
+    const res = await POST(request({ channels: [ALLOWED] }))
+    expect(res.status).toBe(400)
+    expect(authorizeMany).not.toHaveBeenCalled()
+  })
+
+  it('400s a missing or empty channel list', async () => {
+    expect((await POST(request({ socket_id: SOCKET }))).status).toBe(400)
+    expect((await POST(request({ socket_id: SOCKET, channels: [] }))).status).toBe(400)
+    expect((await POST(request({ socket_id: SOCKET, channels: ALLOWED }))).status).toBe(400)
+    expect(authorizeMany).not.toHaveBeenCalled()
+  })
+
+  it('400s a batch above the cap, without authorizing any of it', async () => {
+    const channels = Array.from({ length: 65 }, (_, i) => `private-org-${ORG}-records-def${i}`)
+
+    const res = await POST(request({ socket_id: SOCKET, channels }))
+
+    expect(res.status).toBe(400)
+    expect(authorizeMany).not.toHaveBeenCalled()
+  })
+
+  it('accepts a batch at the cap', async () => {
+    const channels = Array.from({ length: 64 }, (_, i) => `private-org-${ORG}-records-def${i}`)
+
+    const res = await POST(request({ socket_id: SOCKET, channels }))
+
+    expect(res.status).toBe(200)
+    expect(authorizeMany.mock.calls[0][1]).toHaveLength(64)
+  })
+
+  it('400s an unparseable body', async () => {
+    const res = await POST(request('not json'))
+    expect(res.status).toBe(400)
+    expect(authorizeMany).not.toHaveBeenCalled()
+  })
+
+  it('500s when authorization throws, without leaking the reason', async () => {
+    authorizeMany.mockRejectedValue(new Error('cache down'))
+
+    const res = await POST(request({ socket_id: SOCKET, channels: [ALLOWED] }))
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Internal server error' })
+  })
+})

--- a/apps/web/src/app/api/pusher/auth/batch/route.ts
+++ b/apps/web/src/app/api/pusher/auth/batch/route.ts
@@ -1,0 +1,109 @@
+// ~/app/api/pusher/auth/batch/route.ts
+
+import { getRealtimeService } from '@auxx/lib/realtime'
+import { createScopedLogger } from '@auxx/logger'
+import { headers } from 'next/headers'
+import { type NextRequest, NextResponse } from 'next/server'
+import { auth } from '~/auth/server'
+import { ensureWebAppInitialized } from '~/server/bootstrap'
+
+const logger = createScopedLogger('pusher-auth-batch')
+
+/**
+ * Batched Pusher private/presence channel auth (plan v3/05).
+ *
+ * The sibling `../route.ts` signs ONE channel per request because that is what
+ * pusher-js's AJAX transport sends. The admin client instead runs a coalescing
+ * `channelAuthorization.customHandler`, which posts the whole subscribe burst
+ * here as JSON — so a page load that binds ~40 channels resolves the session
+ * once instead of forty times.
+ *
+ * Authorization is unchanged: `authorizeMany` delegates to the same
+ * `RealtimeService.authorize` and therefore the same room-registry ACL.
+ *
+ * **A denied channel is `null` in `results`, not an HTTP error.** Per-channel
+ * verdicts cannot ride the response status when the request carries many
+ * channels, so the status describes only whether the REQUEST was well-formed.
+ */
+
+/**
+ * Above the client's own `maxBatch` of 50, so a legitimate flush can never trip
+ * this while a hand-rolled request can't ask for unbounded ACL work.
+ */
+const MAX_CHANNELS = 64
+
+interface BatchAuthRequestBody {
+  socket_id?: unknown
+  channels?: unknown
+}
+
+export async function POST(req: NextRequest) {
+  await ensureWebAppInitialized()
+  try {
+    let body: BatchAuthRequestBody
+    try {
+      body = (await req.json()) as BatchAuthRequestBody
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    const socketId = typeof body?.socket_id === 'string' ? body.socket_id : null
+    const channels = Array.isArray(body?.channels)
+      ? body.channels.filter((c): c is string => typeof c === 'string')
+      : null
+
+    if (!socketId || !channels || channels.length === 0) {
+      logger.warn('Missing required parameters', {
+        socketId: !!socketId,
+        channels: channels?.length ?? null,
+      })
+      return NextResponse.json({ error: 'Missing socket_id or channels' }, { status: 400 })
+    }
+    if (channels.length > MAX_CHANNELS) {
+      logger.warn('Batch too large', { requested: channels.length, max: MAX_CHANNELS })
+      return NextResponse.json({ error: `At most ${MAX_CHANNELS} channels` }, { status: 400 })
+    }
+
+    const unique = [...new Set(channels)]
+
+    const session = await auth.api.getSession({ headers: await headers() })
+    const realtimeService = getRealtimeService()
+
+    // Identical construction to the single-channel route. A caller with no
+    // session gets `session: null`, which every registry ACL reads as a denial
+    // — so the answer is a full sheet of `null`, NOT a 401. The per-channel
+    // route never made that distinction and introducing it here would report
+    // "you are anonymous" separately from "you may not have this channel".
+    const ctx = {
+      session: session?.user?.defaultOrganizationId
+        ? { userId: session.user.id, organizationId: session.user.defaultOrganizationId }
+        : null,
+    }
+
+    const userData = session?.user
+      ? {
+          id: session.user.id,
+          name: session.user.name || undefined,
+          email: session.user.email || undefined,
+          image: session.user.image || undefined,
+        }
+      : undefined
+
+    const results = await realtimeService.authorizeMany(socketId, unique, ctx, userData)
+
+    // ONE line per burst. The per-channel route logs a warn per denial, which
+    // is what put ~25 lines in the terminal on every refresh.
+    const denied = unique.filter((c) => !results[c])
+    logger.debug('Pusher batch auth', {
+      userId: session?.user?.id,
+      requested: unique.length,
+      authorized: unique.length - denied.length,
+      denied,
+    })
+
+    return NextResponse.json({ results })
+  } catch (error) {
+    logger.error('Unexpected error in Pusher batch auth', { error })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/apps/web/src/realtime/use-realtime-lifecycle.ts
+++ b/apps/web/src/realtime/use-realtime-lifecycle.ts
@@ -31,6 +31,10 @@ export function useRealtimeLifecycle() {
       key: config.key,
       cluster: config.cluster,
       authEndpoint: '/api/pusher/auth',
+      // Coalesces the subscribe burst into one signed request (plan v3/05).
+      // `authEndpoint` above stays as the fallback seam — dropping this line
+      // restores one request per channel with no other change.
+      batchAuthEndpoint: '/api/pusher/auth/batch',
       wsHost: config.wsHost,
       wsPort: config.wsPort,
       forceTLS: config.forceTLS,

--- a/packages/lib/src/realtime/authorize-many.test.ts
+++ b/packages/lib/src/realtime/authorize-many.test.ts
@@ -1,0 +1,152 @@
+// packages/lib/src/realtime/authorize-many.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RealtimeService } from './realtime-service'
+import type { AuthorizeCtx } from './rooms'
+import { rooms, toPusherChannel } from './rooms'
+import type { RealtimeProvider } from './types'
+
+/**
+ * `authorizeMany` is a TRANSPORT optimization (plan v3/05) — it must agree with
+ * `authorize` on every channel, always. That equivalence is the whole test:
+ * the batch route is the only caller, and the moment the two disagree the ACL
+ * has two answers depending on which endpoint the client happened to use.
+ */
+
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+const VIEWABLE_DEF = 'i5aezsg4bc6n8gof2uan3wcf'
+const RESTRICTED_DEF = 'xrbtfl7syi3sm4mqf5wiayuz'
+const USER = '0D5csE1ejLpyv3rKq3wLQm33dCPNslir'
+
+const hooks = vi.hoisted(() => ({
+  roleMap: {} as Record<string, { role?: string } | undefined>,
+  viewable: new Set<string>(),
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({
+    get: async (_orgId: string, key: string) => (key === 'memberRoleMap' ? hooks.roleMap : {}),
+  }),
+}))
+
+vi.mock('../permissions/capabilities/get-capabilities', () => ({
+  getCapabilities: async () => ({ canViewEntity: (defId: string) => hooks.viewable.has(defId) }),
+}))
+
+vi.mock('../members', () => ({ findMemberByUser: async () => ({ id: 'member-1' }) }))
+
+/** Signs anything it is handed — the ACL decides, not the provider. */
+function fakeProvider(): RealtimeProvider {
+  return {
+    publish: vi.fn(async () => true),
+    authenticate: vi.fn((socketId: string, channel: string) => ({
+      auth: `key:${socketId}:${channel}`,
+    })),
+  } as unknown as RealtimeProvider
+}
+
+const SOCKET = '6189518247.123456'
+const ctx: AuthorizeCtx = { session: { userId: USER, organizationId: ORG } }
+
+const channel = (roomKey: string): string => toPusherChannel(roomKey) as string
+
+beforeEach(() => {
+  hooks.roleMap = { [USER]: { role: 'USER' } }
+  // `getCapabilities` is faked to a bare predicate, so the mail-infra
+  // short-circuit that the real `CapabilitySet.canViewEntity` applies to
+  // `thread` is not modelled here — it is stated explicitly instead. What this
+  // file tests is that `authorizeMany` returns whatever `authorize` returns,
+  // for slug-keyed and CUID-keyed record rooms alike.
+  hooks.viewable = new Set([VIEWABLE_DEF, 'thread'])
+})
+
+describe('RealtimeService.authorizeMany', () => {
+  it('returns the same verdict per channel as N authorize() calls', async () => {
+    const service = new RealtimeService(fakeProvider())
+    const viewable = channel(rooms.orgRecords(ORG, VIEWABLE_DEF))
+    const restricted = channel(rooms.orgRecords(ORG, RESTRICTED_DEF))
+    const slugKeyedDef = channel(rooms.orgRecords(ORG, 'thread'))
+    const presence = channel(rooms.orgPresence(ORG))
+    const ownUser = channel(rooms.user(USER))
+    const otherUser = channel(rooms.user('someone-else'))
+    const unknownKey = 'private-not-a-room-key-at-all'
+    // Prefix/kind mismatch: a presence room asked for as a private channel.
+    const wrongPrefix = `private-${rooms.orgPresence(ORG)}`
+    const names = [
+      viewable,
+      restricted,
+      slugKeyedDef,
+      presence,
+      ownUser,
+      otherUser,
+      unknownKey,
+      wrongPrefix,
+    ]
+
+    const batch = await service.authorizeMany(SOCKET, names, ctx)
+
+    const single: Record<string, unknown> = {}
+    for (const name of names) {
+      single[name] = await service.authorize(SOCKET, name, ctx)
+    }
+
+    expect(batch).toEqual(single)
+    // Sanity — the set is genuinely mixed, not all-allow or all-deny.
+    expect(batch[viewable]).not.toBeNull()
+    expect(batch[slugKeyedDef]).not.toBeNull()
+    expect(batch[restricted]).toBeNull()
+    expect(batch[otherUser]).toBeNull()
+    expect(batch[unknownKey]).toBeNull()
+    expect(batch[wrongPrefix]).toBeNull()
+  })
+
+  it('answers every requested channel, denials included', async () => {
+    const service = new RealtimeService(fakeProvider())
+    const names = [
+      channel(rooms.orgRecords(ORG, VIEWABLE_DEF)),
+      channel(rooms.orgRecords(ORG, RESTRICTED_DEF)),
+    ]
+
+    const results = await service.authorizeMany(SOCKET, names, ctx)
+
+    expect(Object.keys(results).sort()).toEqual([...names].sort())
+  })
+
+  it('signs each channel against the socket it was asked for', async () => {
+    const service = new RealtimeService(fakeProvider())
+    const name = channel(rooms.orgRecords(ORG, VIEWABLE_DEF))
+
+    const results = await service.authorizeMany(SOCKET, [name], ctx)
+
+    expect(results[name]).toEqual({ auth: `key:${SOCKET}:${name}` })
+  })
+
+  it('collapses duplicates to one authorization', async () => {
+    const provider = fakeProvider()
+    const service = new RealtimeService(provider)
+    const name = channel(rooms.orgRecords(ORG, VIEWABLE_DEF))
+
+    const results = await service.authorizeMany(SOCKET, [name, name, name], ctx)
+
+    expect(Object.keys(results)).toEqual([name])
+    expect(provider.authenticate).toHaveBeenCalledTimes(1)
+  })
+
+  it('denies everything for a session-less caller', async () => {
+    const service = new RealtimeService(fakeProvider())
+    const names = [
+      channel(rooms.orgRecords(ORG, VIEWABLE_DEF)),
+      channel(rooms.orgPresence(ORG)),
+      channel(rooms.user(USER)),
+    ]
+
+    const results = await service.authorizeMany(SOCKET, names, { session: null })
+
+    expect(Object.values(results)).toEqual([null, null, null])
+  })
+
+  it('returns an empty sheet for an empty request', async () => {
+    const service = new RealtimeService(fakeProvider())
+    expect(await service.authorizeMany(SOCKET, [], ctx)).toEqual({})
+  })
+})

--- a/packages/lib/src/realtime/client/adapters/batch-channel-authorizer.test.ts
+++ b/packages/lib/src/realtime/client/adapters/batch-channel-authorizer.test.ts
@@ -1,0 +1,267 @@
+// packages/lib/src/realtime/client/adapters/batch-channel-authorizer.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChannelAuthorizationData } from './batch-channel-authorizer'
+import { createBatchChannelAuthorizer } from './batch-channel-authorizer'
+
+/**
+ * The batcher is pure — no pusher-js, no socket, no DOM — so these run against
+ * the real implementation with only `fetch` injected.
+ *
+ * What matters here is not that batching happens but that it is INVISIBLE:
+ * every callback must receive exactly what the per-channel AJAX transport would
+ * have handed it, including a 403-carrying error on denial (which is what
+ * pusher-js reads to emit `pusher:subscription_error`).
+ */
+
+const ENDPOINT = '/api/pusher/auth/batch'
+const SOCKET = '6189518247.123456'
+const CHANNEL_A = 'private-org-abgwpa1l81reht2zmwrcihfu-records-xrbtfl7syi3sm4mqf5wiayuz'
+const CHANNEL_B = 'private-org-abgwpa1l81reht2zmwrcihfu-records-elppl4chr8dhnjfibwryu5to'
+const CHANNEL_C = 'presence-org-abgwpa1l81reht2zmwrcihfu'
+
+/** A `fetch` stub that answers from a channel → auth-data map. */
+function okFetch(results: Record<string, ChannelAuthorizationData | null>) {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ results }),
+  })) as unknown as typeof fetch
+}
+
+type MockFn = ReturnType<typeof vi.fn>
+
+/** Nth recorded call's arguments, asserted present so the tests stay flat. */
+function callArgs(fn: unknown, index = 0): unknown[] {
+  const calls = (fn as MockFn).mock.calls
+  const args = calls[index]
+  if (!args) throw new Error(`expected at least ${index + 1} call(s), saw ${calls.length}`)
+  return args
+}
+
+function bodyOf(fetchMock: typeof fetch, call = 0): { socket_id: string; channels: string[] } {
+  const [, init] = callArgs(fetchMock, call) as [string, { body: string }]
+  return JSON.parse(init.body)
+}
+
+/** The `(error, authData)` pair a channel's callback was invoked with. */
+function verdict(callback: unknown): [Error | null, ChannelAuthorizationData | null] {
+  return callArgs(callback) as [Error | null, ChannelAuthorizationData | null]
+}
+
+const auth = (sig: string): ChannelAuthorizationData => ({ auth: sig })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createBatchChannelAuthorizer', () => {
+  it('coalesces one tick of subscriptions into a single request', async () => {
+    const fetchImpl = okFetch({
+      [CHANNEL_A]: auth('a'),
+      [CHANNEL_B]: auth('b'),
+      [CHANNEL_C]: auth('c'),
+    })
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const cbA = vi.fn()
+    const cbB = vi.fn()
+    const cbC = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, cbA)
+    authorize({ socketId: SOCKET, channelName: CHANNEL_B }, cbB)
+    authorize({ socketId: SOCKET, channelName: CHANNEL_C }, cbC)
+    expect(fetchImpl).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(bodyOf(fetchImpl)).toEqual({
+      socket_id: SOCKET,
+      channels: [CHANNEL_A, CHANNEL_B, CHANNEL_C],
+    })
+    expect(cbA).toHaveBeenCalledWith(null, auth('a'))
+    expect(cbB).toHaveBeenCalledWith(null, auth('b'))
+    expect(cbC).toHaveBeenCalledWith(null, auth('c'))
+  })
+
+  it('opens a fresh batch after the window closes', async () => {
+    const fetchImpl = okFetch({ [CHANNEL_A]: auth('a'), [CHANNEL_B]: auth('b') })
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, vi.fn())
+    await vi.advanceTimersByTimeAsync(20)
+    authorize({ socketId: SOCKET, channelName: CHANNEL_B }, vi.fn())
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(bodyOf(fetchImpl, 0).channels).toEqual([CHANNEL_A])
+    expect(bodyOf(fetchImpl, 1).channels).toEqual([CHANNEL_B])
+  })
+
+  it('sends one entry for a duplicated channel and answers every waiter', async () => {
+    const fetchImpl = okFetch({ [CHANNEL_A]: auth('a') })
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const first = vi.fn()
+    const second = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, first)
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, second)
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(bodyOf(fetchImpl).channels).toEqual([CHANNEL_A])
+    expect(first).toHaveBeenCalledWith(null, auth('a'))
+    expect(second).toHaveBeenCalledWith(null, auth('a'))
+  })
+
+  /**
+   * The reconnect guard. A callback queued before a reconnect must never be
+   * signed against the socket id minted after it — that signature is VALID, so
+   * the subscription fails with nothing to log.
+   */
+  it('never mixes two socket ids into one request', async () => {
+    const RECONNECTED = '9911223344.998877'
+    const fetchImpl = vi.fn(async (_url: string, init: { body: string }) => {
+      const { socket_id, channels } = JSON.parse(init.body)
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          results: Object.fromEntries(channels.map((c: string) => [c, auth(`${socket_id}:${c}`)])),
+        }),
+      }
+    }) as unknown as typeof fetch
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const stale = vi.fn()
+    const fresh = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, stale)
+    authorize({ socketId: RECONNECTED, channelName: CHANNEL_A }, fresh)
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(bodyOf(fetchImpl, 0).socket_id).toBe(SOCKET)
+    expect(bodyOf(fetchImpl, 1).socket_id).toBe(RECONNECTED)
+    expect(stale).toHaveBeenCalledWith(null, auth(`${SOCKET}:${CHANNEL_A}`))
+    expect(fresh).toHaveBeenCalledWith(null, auth(`${RECONNECTED}:${CHANNEL_A}`))
+  })
+
+  it('fails a denied channel with a 403 error and still authorizes its siblings', async () => {
+    const fetchImpl = okFetch({ [CHANNEL_A]: auth('a'), [CHANNEL_B]: null })
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const allowed = vi.fn()
+    const denied = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, allowed)
+    authorize({ socketId: SOCKET, channelName: CHANNEL_B }, denied)
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(allowed).toHaveBeenCalledWith(null, auth('a'))
+    const [error, data] = verdict(denied)
+    expect(data).toBeNull()
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error & { status?: number }).status).toBe(403)
+  })
+
+  /** A channel the server omits entirely is a denial, not a hang. */
+  it('treats an absent result as a denial', async () => {
+    const fetchImpl = okFetch({})
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const callback = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, callback)
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(verdict(callback)[1]).toBeNull()
+  })
+
+  it('retries a failed request once, then fails every callback in the group', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('offline')
+    }) as unknown as typeof fetch
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const cbA = vi.fn()
+    const cbB = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, cbA)
+    authorize({ socketId: SOCKET, channelName: CHANNEL_B }, cbB)
+    await vi.advanceTimersByTimeAsync(20)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(cbA).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(verdict(cbA)[0]).toBeInstanceOf(Error)
+    expect(verdict(cbA)[1]).toBeNull()
+    expect(verdict(cbB)[0]).toBeInstanceOf(Error)
+  })
+
+  it('recovers when the retry succeeds', async () => {
+    let attempt = 0
+    const fetchImpl = vi.fn(async () => {
+      attempt += 1
+      if (attempt === 1) throw new Error('offline')
+      return { ok: true, status: 200, json: async () => ({ results: { [CHANNEL_A]: auth('a') } }) }
+    }) as unknown as typeof fetch
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const callback = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, callback)
+    await vi.advanceTimersByTimeAsync(20)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(callback).toHaveBeenCalledWith(null, auth('a'))
+  })
+
+  it('treats a non-2xx response as a request failure', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'nope' }),
+    })) as unknown as typeof fetch
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+    const callback = vi.fn()
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, callback)
+    await vi.advanceTimersByTimeAsync(20)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(verdict(callback)[0]).toBeInstanceOf(Error)
+    expect(verdict(callback)[1]).toBeNull()
+  })
+
+  it('flushes immediately once maxBatch is reached', async () => {
+    const fetchImpl = okFetch({ [CHANNEL_A]: auth('a'), [CHANNEL_B]: auth('b') })
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl, maxBatch: 2 })
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, vi.fn())
+    authorize({ socketId: SOCKET, channelName: CHANNEL_B }, vi.fn())
+
+    // No timer advance — the cap, not the window, released this one.
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(bodyOf(fetchImpl).channels).toEqual([CHANNEL_A, CHANNEL_B])
+
+    await vi.advanceTimersByTimeAsync(20)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('posts JSON to the configured endpoint with same-origin credentials', async () => {
+    const fetchImpl = okFetch({ [CHANNEL_A]: auth('a') })
+    const authorize = createBatchChannelAuthorizer({ endpoint: ENDPOINT, fetchImpl })
+
+    authorize({ socketId: SOCKET, channelName: CHANNEL_A }, vi.fn())
+    await vi.advanceTimersByTimeAsync(20)
+
+    const [url, init] = callArgs(fetchImpl) as [string, RequestInit & { headers: HeadersInit }]
+    expect(url).toBe(ENDPOINT)
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('same-origin')
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+})

--- a/packages/lib/src/realtime/client/adapters/batch-channel-authorizer.ts
+++ b/packages/lib/src/realtime/client/adapters/batch-channel-authorizer.ts
@@ -1,0 +1,194 @@
+// @auxx/lib/realtime/client/adapters/batch-channel-authorizer.ts
+
+/**
+ * Coalescing channel authorizer for pusher-js (plan v3/05).
+ *
+ * `pusher-js` authorizes ONE channel per HTTP request, always — there is no
+ * batching in its `ajax` transport and no option that adds it. A page load that
+ * subscribes ~36 per-def record channels (plan v3/03 §8.1) therefore costs ~40
+ * `POST /api/pusher/auth`, each paying its own `auth.api.getSession`. The ACL
+ * itself is cheap (a cached capability blob + map math); the session lookup is
+ * the cost, and it is paid once per channel for one answer.
+ *
+ * The only seam the library offers is `channelAuthorization.customHandler` — a
+ * per-channel callback invoked instead of its own AJAX, whose TIMING we own. So
+ * the fix is forced into this shape: buffer the per-channel callbacks for a
+ * short window, send one request, fan the results back out.
+ *
+ * Deliberately free of any `pusher-js` import: the library types below are
+ * mirrored structurally so this module is unit-testable without a Pusher
+ * instance, a socket, or a DOM.
+ */
+
+/** Mirror of pusher-js `ChannelAuthorizationData`. */
+export interface ChannelAuthorizationData {
+  auth: string
+  channel_data?: string
+}
+
+/** Mirror of pusher-js `ChannelAuthorizationRequestParams`. */
+export interface ChannelAuthorizationRequestParams {
+  socketId: string
+  channelName: string
+}
+
+/** Mirror of pusher-js `ChannelAuthorizationCallback`. */
+export type ChannelAuthorizationCallback = (
+  error: Error | null,
+  authData: ChannelAuthorizationData | null
+) => void
+
+/** Mirror of pusher-js `ChannelAuthorizationHandler`. */
+export type ChannelAuthorizationHandler = (
+  params: ChannelAuthorizationRequestParams,
+  callback: ChannelAuthorizationCallback
+) => void
+
+/** Wire shape of the batch endpoint's response body. */
+export interface BatchAuthResponseBody {
+  results: Record<string, ChannelAuthorizationData | null>
+}
+
+export interface BatchAuthorizerConfig {
+  /** Batch endpoint, e.g. `/api/pusher/auth/batch`. */
+  endpoint: string
+  /** Coalesce window in ms. */
+  windowMs?: number
+  /** Hard cap per request; the group flushes early once reached. */
+  maxBatch?: number
+  /** Injected for tests. Resolved lazily so a test can install a stub late. */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Long enough to catch a subscribe burst that spans a few React commits, short
+ * enough that a lone subscription doesn't feel delayed.
+ */
+const DEFAULT_WINDOW_MS = 15
+
+/**
+ * Bounded so one flush can't ask the server for unbounded work. The route caps
+ * at 64, above this, so a legitimate flush can never trip the server guard.
+ */
+const DEFAULT_MAX_BATCH = 50
+
+const RETRY_DELAY_MS = 250
+
+/** An in-flight coalesce group. One per socket id — see {@link createBatchChannelAuthorizer}. */
+interface AuthGroup {
+  /** channel name → every callback waiting on it (deduped subscribers). */
+  channels: Map<string, ChannelAuthorizationCallback[]>
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+/**
+ * `pusher:subscription_error` reads `status` off the error the callback is
+ * handed, so a denial must carry 403 to stay observationally identical to what
+ * the per-channel AJAX transport produced.
+ */
+function deniedError(channelName: string): Error {
+  return Object.assign(new Error(`Channel authorization denied: ${channelName}`), { status: 403 })
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Build a batching `channelAuthorization.customHandler`.
+ *
+ * Groups are keyed by **socket id, not globally**: a reconnect mints a new
+ * socket id, and signing a callback queued before the reconnect against the new
+ * id yields a VALID signature for the wrong socket — the subscription then fails
+ * with nothing to log. Each queued entry carries its own `params.socketId` and
+ * only ever ships with its own group.
+ */
+export function createBatchChannelAuthorizer(
+  config: BatchAuthorizerConfig
+): ChannelAuthorizationHandler {
+  const windowMs = config.windowMs ?? DEFAULT_WINDOW_MS
+  const maxBatch = config.maxBatch ?? DEFAULT_MAX_BATCH
+  const groups = new Map<string, AuthGroup>()
+
+  const post = async (
+    socketId: string,
+    channels: string[]
+  ): Promise<Record<string, ChannelAuthorizationData | null>> => {
+    const doFetch = config.fetchImpl ?? globalThis.fetch
+    const response = await doFetch(config.endpoint, {
+      method: 'POST',
+      // Matches the AJAX transport — the session cookie must ride along.
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ socket_id: socketId, channels }),
+    })
+    if (!response.ok) {
+      throw Object.assign(new Error(`Batch channel auth failed (${response.status})`), {
+        status: response.status,
+      })
+    }
+    const body = (await response.json()) as BatchAuthResponseBody | null
+    return body?.results ?? {}
+  }
+
+  const send = async (socketId: string, channels: AuthGroup['channels']): Promise<void> => {
+    const names = [...channels.keys()]
+    let results: Record<string, ChannelAuthorizationData | null>
+    try {
+      results = await post(socketId, names)
+    } catch {
+      // One retry, then fail the whole group. No per-channel fallback to the
+      // single-channel endpoint: a second code path that runs only on failure
+      // is a path that is never exercised and never right. Pusher's own
+      // reconnect is the real retry.
+      try {
+        await delay(RETRY_DELAY_MS)
+        results = await post(socketId, names)
+      } catch (error) {
+        const failure = error instanceof Error ? error : new Error(String(error))
+        for (const callbacks of channels.values()) {
+          for (const callback of callbacks) callback(failure, null)
+        }
+        return
+      }
+    }
+
+    for (const [name, callbacks] of channels) {
+      const data = results[name] ?? null
+      for (const callback of callbacks) {
+        if (data) callback(null, data)
+        else callback(deniedError(name), null)
+      }
+    }
+  }
+
+  const flush = (socketId: string): void => {
+    const group = groups.get(socketId)
+    if (!group) return
+    groups.delete(socketId)
+    if (group.timer) clearTimeout(group.timer)
+    void send(socketId, group.channels)
+  }
+
+  return (params, callback) => {
+    let group = groups.get(params.socketId)
+    if (!group) {
+      group = { channels: new Map(), timer: null }
+      groups.set(params.socketId, group)
+    }
+
+    // Two components racing to subscribe the same room cost one entry and both
+    // get answered.
+    const waiting = group.channels.get(params.channelName)
+    if (waiting) waiting.push(callback)
+    else group.channels.set(params.channelName, [callback])
+
+    if (group.channels.size >= maxBatch) {
+      flush(params.socketId)
+      return
+    }
+    if (!group.timer) {
+      group.timer = setTimeout(() => flush(params.socketId), windowMs)
+    }
+  }
+}

--- a/packages/lib/src/realtime/client/adapters/pusher.ts
+++ b/packages/lib/src/realtime/client/adapters/pusher.ts
@@ -9,6 +9,7 @@ import type {
   SubscribeHandlers,
   Subscription,
 } from '../types'
+import { createBatchChannelAuthorizer } from './batch-channel-authorizer'
 
 interface RoomEntry {
   channel: Pusher.Channel
@@ -62,12 +63,27 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
     key: string
     cluster: string
     authEndpoint: string
+    batchAuthEndpoint?: string
     wsHost?: string
     wsPort?: number
     forceTLS?: boolean
   }) {
     if (this.pusher) return
     this.authEndpoint = config.authEndpoint
+    // One HTTP round-trip for the whole subscribe burst (plan v3/05). Absent
+    // `batchAuthEndpoint` ⇒ the plain per-channel `authEndpoint`, which is what
+    // the widget's own client keeps using.
+    const auth = config.batchAuthEndpoint
+      ? {
+          channelAuthorization: {
+            // `transport` and `endpoint` are required by pusher-js's option
+            // type even though `customHandler` replaces both.
+            transport: 'ajax' as const,
+            endpoint: config.batchAuthEndpoint,
+            customHandler: createBatchChannelAuthorizer({ endpoint: config.batchAuthEndpoint }),
+          },
+        }
+      : { authEndpoint: config.authEndpoint }
     this.pusher = new Pusher(
       config.key,
       config.wsHost
@@ -82,13 +98,13 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
             enabledTransports: config.forceTLS === false ? ['ws'] : ['ws', 'wss'],
             disableStats: true,
             cluster: '',
-            authEndpoint: config.authEndpoint,
+            ...auth,
           }
         : {
             // Hosted Pusher cloud (kept fallback seam).
             cluster: config.cluster,
             forceTLS: true,
-            authEndpoint: config.authEndpoint,
+            ...auth,
           }
     )
     this.pusher.connection.bind('connected', () => {

--- a/packages/lib/src/realtime/client/types.ts
+++ b/packages/lib/src/realtime/client/types.ts
@@ -49,6 +49,12 @@ export interface RealtimeAdapter {
     key: string
     cluster: string
     authEndpoint: string
+    /**
+     * Batch channel-auth endpoint (plan v3/05). When set, every channel
+     * authorization is coalesced into one request against this URL and
+     * `authEndpoint` goes unused. Absent → one request per channel.
+     */
+    batchAuthEndpoint?: string
     /** Self-hosted Sockudo host. Absent → hosted Pusher cloud (cluster). */
     wsHost?: string
     wsPort?: number

--- a/packages/lib/src/realtime/realtime-service.ts
+++ b/packages/lib/src/realtime/realtime-service.ts
@@ -76,6 +76,39 @@ export class RealtimeService {
   }
 
   /**
+   * Authorize many channels for ONE socket in a single pass (plan v3/05).
+   *
+   * Returns a verdict per requested channel — the signed payload, or `null` for
+   * a denial. Channel names are answered in the order given; duplicates are the
+   * caller's to collapse.
+   *
+   * This is a transport optimization and nothing else: it delegates to
+   * {@link authorize} per channel rather than reimplementing the
+   * `fromPusherChannel` → `findRoom` → prefix-check → `def.authorize` dispatch,
+   * because a second copy of that sequence is exactly how the batch path and
+   * the single path drift into disagreeing about who may subscribe to what.
+   *
+   * The win is already in the caller: one `getSession` instead of N. The loop
+   * is deliberately SEQUENTIAL — the first call warms the `memberRoleMap` /
+   * `getCapabilities` caches every later one reads, and firing N concurrent
+   * cache misses is the one way this could come out slower than the per-channel
+   * route it replaces.
+   */
+  async authorizeMany(
+    socketId: string,
+    channelNames: string[],
+    ctx: AuthorizeCtx,
+    userData?: { id: string; name?: string; email?: string; image?: string }
+  ): Promise<Record<string, { auth: string; channel_data?: string } | null>> {
+    const results: Record<string, { auth: string; channel_data?: string } | null> = {}
+    for (const channelName of channelNames) {
+      if (channelName in results) continue
+      results[channelName] = await this.authorize(socketId, channelName, ctx, userData)
+    }
+    return results
+  }
+
+  /**
    * Raw Pusher authentication — used by the widget auth route which does its
    * own visitor-passport check upstream. Prefer `authorize(...)` everywhere
    * else.


### PR DESCRIPTION
## The problem

`pusher-js` authorizes **one channel per HTTP request** — there is no batching in its `ajax` transport and no option that adds it. The admin client subscribes a per-def record channel for every definition in the catalog (plan v3/03 §8.1), plus the org presence/events, `user-{id}` and per-lens inbox rooms.

Measured on a dev refresh of `/app/tickets` (31 entity defs + the table-backed resources): **~40 `POST /api/pusher/auth` per page load**, each at 24–370 ms of application-code.

```
POST /api/pusher/auth 200 in 823ms … application-code: 790ms
POST /api/pusher/auth 403 in 232ms … application-code: 128ms
   … ×40
```

Every one of them independently runs `ensureWebAppInitialized` + `auth.api.getSession` before evaluating an ACL that is already cheap — `getCapabilities` is a cached blob and the room predicate is pure map math. **The session lookup is the cost, and it is paid 40 times for one answer.** The burst repeats on every reconnect, since pusher-js refires the authorizer for every channel it resubscribes.

## The fix

The only seam the library exposes is `channelAuthorization.customHandler` — a per-channel callback whose *timing* we own. So: buffer the callbacks for 15 ms, send one request, fan the results back out.

- **`batch-channel-authorizer.ts`** — the coalescing authorizer. No `pusher-js` import; the library types are mirrored structurally so it is unit-testable without a Pusher instance, a socket or a DOM.
- **`RealtimeService.authorizeMany`** — signs N channels for one socket.
- **`POST /api/pusher/auth/batch`** — one `getSession`, a verdict per channel.

## Three decisions worth reviewing

**Groups are keyed by socket id, not globally.** A reconnect mints a new socket id, and signing a callback queued before it against the new id yields a *valid* signature for the wrong socket — the subscription then fails with nothing to log. Pinned by a test.

**`authorizeMany` delegates to `authorize`, sequentially.** It does not reimplement the `fromPusherChannel → findRoom → prefix-check → def.authorize` dispatch: a second copy of that sequence is how the batch path and the single path drift into disagreeing about who may subscribe to what. `authorize-many.test.ts` asserts the two return identical verdicts over a mixed set. The loop is sequential on purpose — the first call warms the caches the rest read, and N concurrent cache misses is the one way this could come out *slower*.

**A denial is `null` inside a `200`, never an HTTP error.** Per-channel verdicts cannot ride the response status when the request carries many channels. Consequently a session-less caller gets a full sheet of `null` rather than a `401` — the per-channel route never distinguished "anonymous" from "not yours", and introducing that distinction here would answer a question the ACL refuses to answer.

## Authorization is unchanged

Same `findRoom` → `def.authorize` dispatch, same `canViewEntity(defId)`, same fail-closed branches. No schema, no migration, no capabilities-cache bump. The 32 pre-existing `src/realtime` tests pass **unmodified** — needing to edit one would have meant the ACL moved.

## ⚠ Reviewer trap

The terminal will stop printing a `403` line per denied channel, because a denial is now `null` inside a `200`. **That is not the denials disappearing.** On the measured org, 25 of 36 record channels are correctly denied: the viewer is `role=USER` on the `Member` profile, whose grant carries no `records` key, so `Area.records = None` and every def without an explicit `ResourceAccess` row resolves to no access. Confirm verdicts via `[realtime.sub]` in the browser console or the `denied` count in the route's debug line.

## Verification

- lib `src/realtime`: **49 passed** (32 pre-existing, unmodified + 17 new).
- web: `route.test.ts` 11 passed; `hooks.test.ts` unchanged and passing.
- `tsc --noEmit` scoped per package, grepped to the touched files: clean. (The 4 `TS2702 'Pusher' … used as a namespace` errors in `pusher.ts` are pre-existing on untouched lines.)
- Biome clean; the remaining `useExhaustiveDependencies` warning in `use-realtime-lifecycle.ts` is pre-existing (`config.wsPort`).
- Live against the dev server: `{"socket_id":"1.1","channels":["private-org-x-records-y"]}` → `200 {"results":{"private-org-x-records-y":null}}`; malformed bodies → `400`; the legacy route still → `403`.

Expect **1–3 batch POSTs** where there were ~40 (the org/user rooms bind at layout mount, the record channels after `resource.list` resolves).

## Escape hatch

Deleting the one `batchAuthEndpoint` line in `use-realtime-lifecycle.ts` restores per-channel auth with no other change. The single-channel route stays for the widget and as the fallback seam.

## Not in this PR

- **Client-side channel pre-filter** — would skip ~25 of 36 requests for the measured member, but needs its own decision: the unfiltered catalog is documented as deliberate, and the client mirror `canViewEntity` has no mail-infra carve-out, so a naive filter would silently kill realtime for `thread` / `message` / `inbox` / `kb`. Batching helps every member, including an owner for whom nothing is filterable.
- **`signature` is missing from `ENTITY_BASE_AREAS`** — found while measuring. Plan 36 §7.6 removed `signature` from `NON_RECORD_DEF_SLUGS` but never added it to `ENTITY_BASE_AREAS`, so the signature def's record base resolves from `Area.records`. A member with `signatures: Full` is denied the signature def's record channel while `signature.ts` publishes to it through `UnifiedCrudHandler.create`. Kept out deliberately — it changes an authorization answer.