### PR TITLE
fix(web): flash ring on the approvals row card, default the panel to unread

### DIFF
--- a/apps/web/src/components/global/notifications/notification-panel-store.ts
+++ b/apps/web/src/components/global/notifications/notification-panel-store.ts
@@ -4,7 +4,11 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-/** `all` / `unread` filter the notification feed; `approvals` swaps the source entirely. */
+/**
+ * `unread` / `all` filter the notification feed; `approvals` swaps the source
+ * entirely. `unread` is the default — opening the bell should show what still
+ * needs attention, not the whole archive.
+ */
 export type NotificationPanelMode = 'all' | 'unread' | 'approvals'
 
 interface NotificationPanelState {
@@ -38,7 +42,7 @@ export const useNotificationPanelStore = create<NotificationPanelState>()(
     (set) => ({
       open: false,
       width: 420,
-      mode: 'all',
+      mode: 'unread',
       highlightApprovalId: undefined,
       bellPulse: 0,
       toggle: () => set((state) => ({ open: !state.open })),

--- a/apps/web/src/components/global/notifications/notification-panel.tsx
+++ b/apps/web/src/components/global/notifications/notification-panel.tsx
@@ -228,9 +228,6 @@ export function NotificationPanel() {
           size='sm'
           className='w-full border border-primary-200'
           radioGroupClassName='w-full'>
-          <RadioTabItem value='all' size='sm' className='gap-1 px-2'>
-            All
-          </RadioTabItem>
           <RadioTabItem value='unread' size='sm' className='gap-1 px-2'>
             Unread
             {unreadData?.count ? (
@@ -238,6 +235,9 @@ export function NotificationPanel() {
                 {unreadData.count}
               </Badge>
             ) : null}
+          </RadioTabItem>
+          <RadioTabItem value='all' size='sm' className='gap-1 px-2'>
+            All
           </RadioTabItem>
           <RadioTabItem value='approvals' size='sm' className='gap-1 px-2'>
             Approvals

--- a/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
@@ -11,7 +11,6 @@ import {
   EmptyTitle,
 } from '@auxx/ui/components/empty'
 import InfiniteScroll from '@auxx/ui/components/infinite-scroll'
-import { cn } from '@auxx/ui/lib/utils'
 import { CircleCheck, TriangleAlert } from 'lucide-react'
 import type { RefObject } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -117,7 +116,7 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
       return
     }
     const element = document.querySelector(
-      `[data-approval-id="${CSS.escape(highlightApprovalId)}"]`
+      `[data-notification-id="${CSS.escape(highlightApprovalId)}"]`
     )
     element?.scrollIntoView({ block: 'center', behavior: 'smooth' })
     setFlashedId(highlightApprovalId)
@@ -190,25 +189,29 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
       {confirmationItems.length ? (
         <section>
           <SectionHeader label='Needs a decision' count={confirmationItems.length} />
-          {confirmationItems.map((request) => (
-            <div
-              key={request.id}
-              data-approval-id={request.id}
-              className={cn(
-                'scroll-mt-2 rounded-md transition-shadow',
-                flashedId === request.id && 'ring-2 ring-info ring-inset'
-              )}>
-              {/* Both kinds live in one section, ordered by deadline together
-                  (plan 28 H1 is what makes access rows appear here at all). They
-                  get different rows because the payload and the cost of Deny are
-                  different — see `AccessRequestRow`. */}
-              {request.kind === 'access' ? (
-                <AccessRequestRow request={request} onResolved={onResolved} />
-              ) : (
-                <ConfirmationRow request={request} onResolved={onResolved} />
-              )}
-            </div>
-          ))}
+          {/* Both kinds live in one section, ordered by deadline together (plan 28
+              H1 is what makes access rows appear here at all). They get different
+              rows because the payload and the cost of Deny are different — see
+              `AccessRequestRow`. No wrapper element: the flash ring and the scroll
+              anchor both belong on the card `NotificationRow` draws, which is inset
+              from the section by its own margins. */}
+          {confirmationItems.map((request) =>
+            request.kind === 'access' ? (
+              <AccessRequestRow
+                key={request.id}
+                request={request}
+                onResolved={onResolved}
+                highlighted={flashedId === request.id}
+              />
+            ) : (
+              <ConfirmationRow
+                key={request.id}
+                request={request}
+                onResolved={onResolved}
+                highlighted={flashedId === request.id}
+              />
+            )
+          )}
         </section>
       ) : null}
 

--- a/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
@@ -43,9 +43,12 @@ function formatTimestamp(value: Date | string | null | undefined): string {
 export function AccessRequestRow({
   request,
   onResolved,
+  highlighted,
 }: {
   request: PendingApprovalRequest
   onResolved: () => void
+  /** Flashes the card when the tab was opened pointing at this request. */
+  highlighted?: boolean
 }) {
   const [expanded, setExpanded] = useState(false)
   const [comment, setComment] = useState('')
@@ -222,6 +225,7 @@ export function AccessRequestRow({
       <NotificationRow
         id={request.id}
         createdAt={request.createdAt}
+        highlighted={highlighted}
         label='Access'
         icon={<LockKeyhole className='size-4' />}
         subtitle={subtitle}

--- a/apps/web/src/components/global/notifications/ui/items/confirmation-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/confirmation-row.tsx
@@ -44,9 +44,12 @@ function formatTimestamp(value: Date | string | null | undefined): string {
 export function ConfirmationRow({
   request,
   onResolved,
+  highlighted,
 }: {
   request: PendingApprovalRequest
   onResolved: () => void
+  /** Flashes the card when the tab was opened pointing at this request. */
+  highlighted?: boolean
 }) {
   const [expanded, setExpanded] = useState(false)
   const [comment, setComment] = useState('')
@@ -183,6 +186,7 @@ export function ConfirmationRow({
       <NotificationRow
         id={request.id}
         createdAt={request.createdAt}
+        highlighted={highlighted}
         // The body carries the "Approval required" lead — the header names the kind.
         label='Workflow'
         icon={<StatusIndicator status='pending' />}

--- a/apps/web/src/components/global/notifications/ui/notification-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/notification-row.tsx
@@ -43,6 +43,12 @@ interface NotificationRowProps {
   actionLabel?: React.ReactNode
   /** Detail drawer, rendered below the footer so the actions never move. */
   expanded?: React.ReactNode
+  /**
+   * Flashes a ring on the card. Set while a caller is pointing the viewer at this
+   * one row — it belongs on the card so the ring follows the card's own bounds,
+   * not on a wrapper, which would trace a full-width rectangle beside it.
+   */
+  highlighted?: boolean
 }
 
 function formatNotificationType(type: string): string {
@@ -75,6 +81,7 @@ export function NotificationRow({
   actions,
   actionLabel,
   expanded,
+  highlighted,
 }: NotificationRowProps) {
   const iconConfig = type ? (NOTIFICATION_ICON_MAP[type] ?? DEFAULT_NOTIFICATION_ICON) : null
   const headerLabel = label ?? (type ? formatNotificationType(type) : null)
@@ -100,10 +107,15 @@ export function NotificationRow({
 
   return (
     <div
+      data-notification-id={id}
       className={cn(
-        'group/item mx-2 mb-2 rounded-lg border-[0.5px] border-border shadow-xs last-of-type:mb-0',
+        'group/item mx-2 mb-2 rounded-lg border-[0.5px] border-border shadow-xs transition-shadow last-of-type:mb-0',
         isRead ? 'bg-secondary/20 opacity-80' : 'bg-secondary/30',
-        onOpen && 'hover:bg-secondary/50 hover:ring-1 hover:ring-blue-500'
+        onOpen && 'hover:bg-secondary/50 hover:ring-1 hover:ring-blue-500',
+        // Not `ring-inset`: an inset ring paints under the header band's own
+        // background, so it would only show along the body. The card's mx-2
+        // leaves room for the outer ring.
+        highlighted && 'ring-2 ring-info'
       )}>
       <div className='flex h-9 items-center gap-1.5 rounded-t-lg bg-primary-150/50 px-2 text-muted-foreground text-xs font-medium'>
         {icon ?? (iconConfig ? <EntityIcon {...iconConfig} size='sm' /> : null)}


### PR DESCRIPTION
Two small notification-center changes.

## 1. The approvals flash ring is drawn on the row card

The highlight ring (`openApprovals(id)` → scroll + flash) sat on a wrapper `div` around `NotificationRow`, but the card `NotificationRow` draws is inset from that wrapper by its own `mx-2 mb-2 rounded-lg`. The ring therefore traced a full-width rectangle beside the card instead of around it. It now lives on the card, behind a `highlighted` prop threaded through `AccessRequestRow` / `ConfirmationRow`.

`ring-inset` is also gone: an inset box-shadow paints below its descendants' backgrounds, and the header band is a child with `bg-primary-150/50` — so the inset ring was covered along the top and only showed beside the body. The outer ring sits in the gutter `mx-2` already provides, so nothing shifts.

**Incidental spacing fix.** That wrapper was breaking the card's `last-of-type:mb-0`. Each card was the only `div` inside its own wrapper, so *every* confirmation matched `last-of-type` and rendered with `mb-0` — confirmations stacked flush while suggestion rows (rendered without a wrapper) kept their `mb-2`. Removing the wrapper restores the 8px gap between confirmation cards and flushes only the actual last one.

The scroll anchor moved with the ring: `NotificationRow` now emits `data-notification-id={id}`, replacing the wrapper's `data-approval-id`, and `ApprovalsTab`'s `querySelector` follows.

## 2. Unread is the default tab

Tab order is now **Unread · All · Approvals**, and the store's initial `mode` is `'unread'` — opening the bell should show what still needs attention rather than the whole archive.

Initial state only. `partialize` still persists `width` alone, and `close()` does not reset `mode`, so switching to All sticks for the rest of the session and resets on the next load. `openApprovals()` still forces the Approvals tab, so kbar and the approval-notification deep links are unaffected. The feed query already keyed off this correctly (`includeRead: mode === 'all'`), and the empty state reads "No unread notifications" on first open.

## Testing

Biome clean on all six files; TS diagnostics empty. Not exercised in a running browser — the ring geometry and the tab default are worth a quick look when the panel is next open.
