### PR TITLE
fix(permissions): gate `record.getIdentities` behind per-row view authority

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-sidebar.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sidebar.tsx
@@ -4,15 +4,13 @@
 import { parseRecordId } from '@auxx/lib/field-values/client'
 import type { DrawerTabCardDefinition } from '@auxx/lib/resources/client'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { cn } from '@auxx/ui/lib/utils'
 import React from 'react'
-import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
-import { getTabCardComponent } from '~/components/drawers/drawer-tab-registry'
+import { TabCardSection } from '~/components/drawers/base-entity-drawer'
 import EntityFields from '~/components/fields/entity-fields'
 import DrawerComments from '~/components/global/comments/drawer-comments'
 import { useCommentAccess } from '~/components/global/comments/use-comment-access'
 import { useRecordDrawerReadOnly } from '~/components/records/use-record-drawer-read-only'
-import { useCanViewRecordResource } from '~/components/resources'
+import { type RecordId, useCanViewRecordResource } from '~/components/resources'
 import { useAccess } from '~/providers/capabilities-provider'
 import { DetailViewCardHeader } from './components/detail-view-card-header'
 import type { DetailViewSidebarProps } from './types'
@@ -134,7 +132,17 @@ export function DetailViewSidebar({
 }
 
 /**
- * Renders sidebar card components for the given card definitions
+ * Renders sidebar card components for the given card definitions, through the
+ * SAME `TabCardSection` wrapper the drawer uses (`base-entity-drawer.tsx`,
+ * exported for exactly this) rather than a local `<h4>` + lazy loader.
+ *
+ * The local copy diverged from the drawer in three ways that were all visible:
+ * it rendered a sentence-case heading with no Section chrome, so the same card
+ * (e.g. Billing) looked like a different component on the contact page than in
+ * the contact drawer; it ignored `card.icon`; and it provided no
+ * `DrawerCardActionsProvider`, so a card portaling header actions through
+ * `DrawerCardActions` silently rendered none — `quote:jobs` is a sidebar card
+ * and its "Create job" button simply did not exist on the quote detail page.
  */
 function SidebarCards({
   cards,
@@ -146,7 +154,7 @@ function SidebarCards({
   cards: DrawerTabCardDefinition[]
   entityType: string
   entityInstanceId: string
-  recordId: string
+  recordId: RecordId
   record: Record<string, unknown>
 }) {
   if (!cards.length) return null
@@ -154,46 +162,15 @@ function SidebarCards({
   return (
     <>
       {cards.map((card) => (
-        <div key={card.value} className={cn('space-y-1', card.fullBleed ? 'pt-4' : 'p-4')}>
-          <h4 className={cn('text-sm', card.fullBleed && 'px-4')}>{card.label}</h4>
-          <LazySidebarCard
-            entityType={entityType}
-            cardValue={card.value}
-            entityInstanceId={entityInstanceId}
-            recordId={recordId}
-            record={record}
-          />
-        </div>
+        <TabCardSection
+          key={card.value}
+          card={card}
+          entityType={entityType}
+          entityInstanceId={entityInstanceId}
+          recordId={recordId}
+          record={record}
+        />
       ))}
     </>
   )
-}
-
-/**
- * Lazy load and render a sidebar card component from the shared drawer tab card registry
- */
-function LazySidebarCard({
-  entityType,
-  cardValue,
-  entityInstanceId,
-  recordId,
-  record,
-}: {
-  entityType: string
-  cardValue: string
-  entityInstanceId: string
-  recordId: string
-  record: Record<string, unknown>
-}) {
-  const componentLoader = getTabCardComponent(entityType, cardValue)
-  const [Component, setComponent] = React.useState<React.ComponentType<DrawerTabProps> | null>(null)
-
-  React.useEffect(() => {
-    if (!componentLoader) return
-    componentLoader().then((mod) => setComponent(() => mod.default))
-  }, [componentLoader])
-
-  if (!componentLoader || !Component) return null
-
-  return <Component entityInstanceId={entityInstanceId} recordId={recordId} record={record} />
 }

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -14,6 +14,7 @@ import { NavStack, NavStackBar, NavStackPanel, NavStackPanels } from '@auxx/ui/c
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { OverflowTabsList, type TabDefinition, Tabs, TabsContent } from '@auxx/ui/components/tabs'
+import { cn } from '@auxx/ui/lib/utils'
 import {
   CalendarClock,
   Clock,
@@ -793,11 +794,29 @@ function TabCards({
 }
 
 /**
+ * A card that rendered NOTHING hides its whole Section, header included.
+ *
+ * The header lives outside the card, so a card that returns `null` — the
+ * documented behaviour of several of them (`ContactExternalIdentitiesCard` with
+ * no linked apps, `ContactSharedWithCard` for a non-admin with no shares) — left
+ * its title stranded above blank space. `detail-view-config.ts` even documents
+ * these cards as "renders nothing", which was only ever true of the BODY.
+ *
+ * Done in CSS rather than by asking cards to report emptiness upward: `:empty`
+ * is exactly the question ("did this card put any node on the page?"), it needs
+ * no cooperation from ~20 card components, and a card that renders a deliberate
+ * empty state (`EmptyRow`, `EmptySection`) is not empty and still shows its
+ * header. `collapsible={false}` keeps `section-content` mounted, so the match is
+ * stable rather than a side effect of the open state.
+ */
+const HIDE_WHEN_CARD_RENDERS_NOTHING = '[&:has([data-slot=section-content]:empty)]:hidden'
+
+/**
  * A single tab card wrapped in its Section. Owns the Section header's actions-slot
  * element and exposes it to the lazily-loaded card via `DrawerCardActionsProvider`,
  * so the card can portal buttons into the header (see `DrawerCardActions`).
  * Exported for surfaces that replay a drawer's card list outside the drawer
- * itself (e.g. `InvoiceDetailPanel`).
+ * itself (e.g. `InvoiceDetailPanel`, `DetailViewSidebar`).
  */
 export function TabCardSection({
   card,
@@ -825,11 +844,11 @@ export function TabCardSection({
       initialOpen
       collapsible={false}
       actions={<span ref={setActionsEl} className='contents' />}
-      className={
-        card.fullBleed
-          ? '[&>[data-slot=section]>[data-slot=section-content]]:-mx-3 [&>[data-slot=section]>[data-slot=section-content]]:-mb-4'
-          : undefined
-      }>
+      className={cn(
+        HIDE_WHEN_CARD_RENDERS_NOTHING,
+        card.fullBleed &&
+          '[&>[data-slot=section]>[data-slot=section-content]]:-mx-3 [&>[data-slot=section]>[data-slot=section-content]]:-mb-4'
+      )}>
       <DrawerCardActionsProvider value={actionsEl}>
         <LazyTabCard
           entityType={entityType}

--- a/apps/web/src/server/api/routers/record-identities-access.test.ts
+++ b/apps/web/src/server/api/routers/record-identities-access.test.ts
@@ -1,0 +1,211 @@
+// apps/web/src/server/api/routers/record-identities-access.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `record.getIdentities` — the per-ROW read gate.
+ *
+ * 🔴 **This procedure shipped with no view authority at all.** It was a
+ * `protectedProcedure` whose only guard was `assertNotInstanceAccessDefForRead`,
+ * and that is a ROUTING guard — it refuses defs owned by another router, it has
+ * never had an opinion about whether the caller may see a row. So any member of
+ * the org could ask for the `RecordIdentity` index of any row of any def:
+ * definitions they hold `none` on, rows nobody shared with them. What came back
+ * was `externalId`, the app field key/label, the app name and the connection
+ * label — the record's identity in every connected store.
+ *
+ * It is the only point read on this router that touches record-adjacent data
+ * WITHOUT going through `UnifiedCrudHandler`, which is precisely why it slipped:
+ * every sibling gets the visibility scope applied in SQL for free.
+ *
+ * Three properties, each independently breakable:
+ *
+ * 1. **A def-viewable row passes and pays NOTHING.** The def gate is the cheap
+ *    in-memory answer for the overwhelmingly common case; if it stopped
+ *    short-circuiting, every External-identities card mount would cost a row
+ *    read.
+ * 2. **A def-DENIED row is judged by the read path**, and a row it does not hand
+ *    back is refused — the same non-enumeration contract the delete gate relies
+ *    on. A grant-only row still works, which is what keeps the gate from being
+ *    an outage for shared records.
+ * 3. **A denial is a 403, not a 500.** The guard sits outside the procedure's
+ *    `try`, whose catch flattens unknown errors to `INTERNAL_SERVER_ERROR`. A
+ *    guard moved one line down turns every refusal into a 500, and a test that
+ *    only asserted "didn't succeed" would not notice.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+
+/** A def the member can see — the ordinary lane. */
+const OPEN_DEF = 'edf_contact00000000000000000'
+/** A def the member has NO def-level access to — reachable only by grant. */
+const CLOSED_DEF = 'edf_deals0000000000000000000'
+
+const ROW_A = 'ins_a000000000000000000000'
+
+const IDENTITY_ROWS = [
+  { id: 'rid_1', source: 'shopify', externalId: 'gid://shopify/Customer/1', connectionId: 'con_1' },
+]
+
+const { handler, cache, identity, fieldValues } = vi.hoisted(() => ({
+  handler: {
+    getByIds: vi.fn(async () => ({}) as Record<string, { _access?: string }>),
+  },
+  cache: {
+    getCachedResources: vi.fn(async () => [] as unknown[]),
+    getCachedResource: vi.fn(async () => undefined as unknown),
+  },
+  identity: { getRecordIdentityViews: vi.fn(async () => [] as unknown[]) },
+  fieldValues: { getDescendantIds: vi.fn(async () => []) },
+}))
+
+vi.mock('@auxx/lib/resources', () => ({
+  RESOURCE_TABLE_REGISTRY: [],
+  UnifiedCrudHandler: class {
+    getByIds = handler.getByIds
+  },
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedResources: cache.getCachedResources,
+  getCachedResource: cache.getCachedResource,
+}))
+vi.mock('@auxx/lib/identity', () => ({
+  getRecordIdentityViews: identity.getRecordIdentityViews,
+}))
+vi.mock('@auxx/lib/field-values', () => ({ getDescendantIds: fieldValues.getDescendantIds }))
+vi.mock('@auxx/lib/conditions', async () => {
+  const { z } = await import('zod')
+  return { conditionGroupSchema: z.any() }
+})
+
+// The barrel hangs under vitest — hand back the REAL guards from their deep
+// modules. Faking `isInstanceAccessKey` would make the file self-fulfilling.
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const instanceAccess = await import('@auxx/lib/permissions/capabilities/instance-access')
+  return {
+    PermissionKey: registry.PermissionKey,
+    isInstanceAccessKey: instanceAccess.isInstanceAccessKey,
+  }
+})
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    isAuxxError: (e: unknown): boolean =>
+      typeof e === 'object' && e !== null && 'statusCode' in e && 'name' in e,
+  }
+})
+
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { recordRouter } = await import('./record')
+
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+const RESOURCES = [
+  { id: OPEN_DEF, entityDefinitionId: OPEN_DEF, apiSlug: 'contacts', entityType: 'contact' },
+  { id: CLOSED_DEF, entityDefinitionId: CLOSED_DEF, apiSlug: 'deals', entityType: null },
+]
+
+/**
+ * A real `CapabilitySet` for a member whose Records area is `level`, with an
+ * explicit per-def override map so `CLOSED_DEF` can be shut while `OPEN_DEF`
+ * stays open. Same construction as `record-per-row-delete.test.ts` — the
+ * arithmetic under test is the shipped arithmetic.
+ */
+function member(level: Level, defAccess: Record<string, 'none' | 'view' | 'edit' | 'admin'> = {}) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.records]: level })),
+    // `none` is a restriction marker and never seeds `defAccess` — a closed def
+    // is expressed by membership in `restrictedDefIds` with NO grant entry.
+    Object.fromEntries(Object.entries(defAccess).filter(([, v]) => v !== 'none')) as Record<
+      string,
+      never
+    >,
+    'USER',
+    'full',
+    (id) => id,
+    new Set(Object.keys(defAccess)),
+    (id) => id
+  )
+}
+
+function caller(capabilities: unknown) {
+  return recordRouter.createCaller({
+    db: {},
+    headers: new Headers(),
+    capabilities,
+    session: { organizationId: ORG_ID, userId: USER_ID, user: { id: USER_ID } },
+  } as never)
+}
+
+beforeEach(() => {
+  handler.getByIds.mockReset()
+  handler.getByIds.mockResolvedValue({})
+  identity.getRecordIdentityViews.mockReset()
+  identity.getRecordIdentityViews.mockResolvedValue(IDENTITY_ROWS)
+  cache.getCachedResources.mockReset()
+  cache.getCachedResources.mockResolvedValue(RESOURCES)
+})
+
+describe('record.getIdentities — the def gate', () => {
+  it('a def-viewable row passes without a row read', async () => {
+    await expect(
+      caller(member(Level.Read)).getIdentities({ recordId: `${OPEN_DEF}:${ROW_A}` })
+    ).resolves.toEqual(IDENTITY_ROWS)
+    expect(handler.getByIds).not.toHaveBeenCalled()
+  })
+
+  it('a def the member cannot see is NOT waved through', async () => {
+    // The regression this file exists for: before the gate, this resolved with
+    // the row's external ids for any authenticated member of the org.
+    handler.getByIds.mockResolvedValue({})
+    await expect(
+      caller(member(Level.Full, { [CLOSED_DEF]: 'none' })).getIdentities({
+        recordId: `${CLOSED_DEF}:${ROW_A}`,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(identity.getRecordIdentityViews).not.toHaveBeenCalled()
+  })
+})
+
+describe('record.getIdentities — the per-row lane', () => {
+  it('a row of a closed def that WAS shared is readable', async () => {
+    // `getByIds` only hands back rows the visibility scope allows, so its
+    // handing this one back IS the read verdict — nothing else to judge.
+    handler.getByIds.mockResolvedValue({ [`${CLOSED_DEF}:${ROW_A}`]: { _access: 'read' } })
+    await expect(
+      caller(member(Level.Full, { [CLOSED_DEF]: 'none' })).getIdentities({
+        recordId: `${CLOSED_DEF}:${ROW_A}`,
+      })
+    ).resolves.toEqual(IDENTITY_ROWS)
+    expect(handler.getByIds).toHaveBeenCalledWith([`${CLOSED_DEF}:${ROW_A}`])
+  })
+
+  it('a row the read path hid is refused, not waved through', async () => {
+    // Non-enumeration: unauthorized ids are dropped SILENTLY, so "absent" is the
+    // strongest denial signal there is.
+    handler.getByIds.mockResolvedValue({})
+    await expect(
+      caller(member(Level.Full, { [CLOSED_DEF]: 'none' })).getIdentities({
+        recordId: `${CLOSED_DEF}:${ROW_A}`,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('the denial is a 403 — the guard is outside the try that flattens to 500', async () => {
+    handler.getByIds.mockResolvedValue({})
+    await expect(
+      caller(member(Level.Full, { [CLOSED_DEF]: 'none' })).getIdentities({
+        recordId: `${CLOSED_DEF}:${ROW_A}`,
+      })
+    ).rejects.toMatchObject({ cause: { statusCode: 403 } })
+  })
+})

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -263,6 +263,42 @@ async function assertCanDeleteRows(
 }
 
 /**
+ * **The PER-ROW read gate** — the view twin of {@link assertCanDeleteRows}, for a
+ * point read that does NOT flow through `UnifiedCrudHandler.getById` (which
+ * applies the visibility scope in SQL for free). Today's only caller is
+ * {@link recordRouter.getIdentities}.
+ *
+ * Same two-step shape, same reasons: the def gate runs first and short-circuits
+ * in memory (the common all-def-viewable read pays no extra I/O and the
+ * `NON_RECORD_DEF_SLUGS` / mail-infra branch of `canViewEntity` stays
+ * reachable), and only a def-DENIED id is read back.
+ *
+ * Unlike the delete gate there is NO second judgement on the returned stamp, and
+ * that is deliberate: `getByIds` is already scoped at the `read` floor
+ * (`recordVisibilityScope` / `RECORD_READ_FLOOR`) and drops unauthorized ids
+ * silently, so **a row coming back IS the read verdict**. Re-deriving that floor
+ * from the stamp here would put the same rule in two places, which is exactly
+ * how the two halves drift apart. A row that does not come back DENIES.
+ */
+async function assertCanViewRows(
+  handler: UnifiedCrudHandler,
+  capabilities: CapabilitySet,
+  recordIds: RecordId[]
+): Promise<void> {
+  const denied = recordIds.filter(
+    (recordId) => !capabilities.canViewEntity(parseRecordId(recordId).entityDefinitionId)
+  )
+  if (denied.length === 0) return
+
+  const visible = await handler.getByIds(denied)
+  for (const recordId of denied) {
+    if (!visible[recordId]) {
+      throw new ForbiddenError("You don't have permission to view this record.")
+    }
+  }
+}
+
+/**
  * Validate entity definition ID - accepts system TableId, new system entity type, or custom entity UUID
  */
 const entityDefinitionIdSchema = z.string().refine(
@@ -433,14 +469,39 @@ export const recordRouter = createTRPCRouter({
    * data source (RecordIdentity index, decorated from org cache). One batch
    * query, no N+1. Values themselves still render as normal FieldValues in the
    * field grid; this surfaces the cross-system/cross-store link set.
+   *
+   * 🔴 **This shipped as a `protectedProcedure` with NO view authority.**
+   * `assertNotInstanceAccessDefForRead` is a ROUTING guard — it refuses defs
+   * that belong to another router — and it was the only thing standing here, so
+   * any member of the org could read the identity index of any row of any def:
+   * defs they hold `none` on, rows they hold no grant on. It returned
+   * `externalId`, the app field key/label, the app name and the connection
+   * label — the linked customer's id in every connected store.
+   *
+   * It is now `capabilityProcedure` + {@link assertCanViewRows}, which is the
+   * same authority every other point read on this router gets for free through
+   * `UnifiedCrudHandler` (this one reads no record at all — hence the explicit
+   * gate). A def-viewable row costs zero extra I/O; only a def-denied row is
+   * read back through the scoped `getByIds`, where absent ⇒ 403.
    */
-  getIdentities: protectedProcedure
+  getIdentities: capabilityProcedure
     .input(z.object({ recordId: recordIdSchema }))
     .query(async ({ ctx, input }) => {
-      const { organizationId } = ctx.session
-      await assertNotInstanceAccessDefForRead(organizationId, recordIdDefParts([input.recordId]))
+      const { organizationId, user } = ctx.session
+      const recordId = input.recordId as RecordId
+      await assertNotInstanceAccessDefForRead(organizationId, recordIdDefParts([recordId]))
+      // Both guards sit OUTSIDE the try — the catch below flattens everything to
+      // a 500, and a denial must surface as a 403 (§3).
+      await assertCanViewRows(
+        new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
+          capabilities: ctx.capabilities,
+          requestPath: true,
+        }),
+        ctx.capabilities,
+        [recordId]
+      )
       try {
-        return await getRecordIdentityViews(organizationId, input.recordId as RecordId)
+        return await getRecordIdentityViews(organizationId, recordId)
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         throw new TRPCError({


### PR DESCRIPTION
## `record.getIdentities` had no view authority

The procedure shipped as a `protectedProcedure` whose only guard was `assertNotInstanceAccessDefForRead`. That is a **routing** guard — it refuses defs owned by another router — and has never had an opinion about whether the caller may see a row. So any authenticated member of the org could read the `RecordIdentity` index of **any row of any def**: definitions they hold `none` on, rows nobody shared with them.

What came back was `externalId`, the app field key/label, the app name and the connection label — the record's identity in every connected store.

It slipped because it is the only point read on this router that touches record-adjacent data **without** going through `UnifiedCrudHandler`, where every sibling gets the visibility scope applied in SQL for free.

### The gate

`assertCanViewRows` — the view twin of `assertCanDeleteRows`, same two-step shape:

1. **Def gate first, in memory.** The overwhelmingly common all-def-viewable read pays zero extra I/O, and the `NON_RECORD_DEF_SLUGS` / mail-infra branch of `canViewEntity` stays reachable.
2. **Only a def-denied id is read back** through `getByIds`, which is already scoped at the `read` floor and drops unauthorized ids silently — so a row coming back **is** the read verdict, and an absent one denies.

Unlike the delete gate there is deliberately no second judgement on the returned `_access` stamp: re-deriving the read floor here would put the same rule in two places, which is how the two halves drift apart.

Both guards sit **outside** the procedure's `try`, whose catch flattens unknown errors to `INTERNAL_SERVER_ERROR` — a guard moved one line down would turn every refusal into a 500.

### Tests

`record-identities-access.test.ts` — 5 tests over three independently breakable properties: a def-viewable row passes and pays nothing (`getByIds` never called); a def-denied row is judged by the read path, with the grant-only row still working so the gate isn't an outage for shared records; and the denial is asserted as a **403**, not merely "didn't succeed".

The permission guards are the real ones, imported from their deep modules rather than faked — a mocked `isInstanceAccessKey` would make the file self-fulfilling.

---

## Also: detail-view sidebar cards now render through the drawer's `TabCardSection`

`DetailViewSidebar` carried a local `<h4>` + lazy-loader copy of the drawer's card renderer, and it had diverged in three visible ways:

- no Section chrome, so the same card (e.g. Billing) looked like a different component on the contact page than in the contact drawer;
- `card.icon` was ignored;
- no `DrawerCardActionsProvider`, so a card portaling header actions through `DrawerCardActions` silently rendered none — **`quote:jobs` is a sidebar card and its "Create job" button simply did not exist on the quote detail page.**

`base-entity-drawer.tsx` already exports `TabCardSection` for exactly this (`InvoiceDetailPanel` uses it); the sidebar now does too.

**Empty cards no longer strand their header.** The header lives outside the card, so a card returning `null` — the documented behaviour of several (`ContactExternalIdentitiesCard` with no linked apps, `ContactSharedWithCard` for a non-admin with no shares) — left its title above blank space. `detail-view-config.ts` documents these as "renders nothing", which was only ever true of the *body*.

Done in CSS via `[&:has([data-slot=section-content]:empty)]:hidden` rather than by asking ~20 card components to report emptiness upward: `:empty` is exactly the question being asked, it needs no cooperation from the cards, and a card rendering a deliberate empty state (`EmptyRow`, `EmptySection`) is not empty and still shows its header. `collapsible={false}` keeps `section-content` mounted, so the match is stable rather than a side effect of the open state.

## Test plan

- [x] `pnpm exec vitest run src/server/api/routers/record-identities-access.test.ts` — 5/5 pass
- [ ] Manual: External identities card on a record you can see, and a 403 on one you can't
- [ ] Manual: quote detail page shows the "Create job" button on the Jobs sidebar card