### PR TITLE
fix(mail): gap the thread header's two sides and centre the left one

### DIFF
--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -315,9 +315,13 @@ export function ThreadHeader() {
       <div
         data-slot='thread-header'
         className='flex items-center px-4 py-2 sticky inset-x-0 top-0 z-1 bg-secondary dark:bg-muted-50 pb-3 mask-b-from-80% mask-b-to-100% w-full'>
-        <div className='flex  w-full justify-between shrink-0 overflow-x-auto no-scrollbar '>
-          <div className='flex shrink-0 flex-col sm:flex-row sm:items-start gap-2 pt-0.5 ps-0.5'>
-            <div className='flex items-start gap-2'>
+        {/* `gap-3` is the floor, not the spacing: `justify-between` already
+            spreads the two sides while there is room, so the gap is invisible
+            until width runs out — at which point both sides are `shrink-0` and
+            would otherwise touch before the scroll kicks in. */}
+        <div className='no-scrollbar flex w-full shrink-0 items-center justify-between gap-3 overflow-x-auto'>
+          <div className='flex shrink-0 flex-col gap-2 ps-0.5 sm:flex-row sm:items-center'>
+            <div className='flex items-center gap-2'>
               <InboxPicker
                 onChange={handleInboxChange}
                 selected={thread?.inboxId ? [thread.inboxId] : undefined}


### PR DESCRIPTION
Two layout problems in `thread-header.tsx`, both only visible as the header narrows.

## The two sides touched before the scroll took over

The participant/subject block and the action buttons share a `justify-between` row, **both marked `shrink-0`**, inside an `overflow-x-auto` container — and the row had no gap. So as width ran out they met and butted right up against each other before the horizontal scroll kicked in.

`gap-3` here is a **floor, not spacing**: `justify-between` already spreads the two sides while there is room, so the gap is invisible at normal widths and only becomes load-bearing at the point it is needed.

## The left side sat against the top edge

The left block pinned itself with `sm:items-start` + a `pt-0.5` nudge while the actions side was `items-center`, and the row itself defaulted to `stretch`. The row's height is set by the taller icon buttons, so the short badges hugged its top.

Row and left block are both `items-center` now. `pt-0.5` goes with them — centring yields more headroom than the 2px ever did. `ps-0.5` stays: that one is horizontal ring space against the scroll container's edge, a different problem.

The inner `RecordBadge` / `ThreadTicketControl` / `LensBadge` group moves to `items-center` as well, so those align to each other rather than to their tops.

Also normalised the stray double-spaces in that class string.

## Test plan

- [x] Biome clean on the file (3 warnings, all pre-existing unused-variable ones on untouched lines)
- [x] `apps/web` test suite green
- [ ] Manual: narrow a mail thread until it scrolls — action icons keep their size, a visible gap remains between the two sides
- [ ] Manual: badges sit vertically centred against the action buttons, not against the top edge