### PR TITLE
feat(records): one shared record-actions menu across page, drawer and row

### DIFF
--- a/apps/web/src/components/detail-view/components/app-record-actions.tsx
+++ b/apps/web/src/components/detail-view/components/app-record-actions.tsx
@@ -7,6 +7,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { Blocks, MoreHorizontal } from 'lucide-react'
@@ -33,16 +36,14 @@ interface AppRecordActionsProps {
  * applicability inside their own dialog. The overflow menu keeps N installed
  * apps from crowding the header.
  */
-export function AppRecordActions({ recordId, recordType, compact }: AppRecordActionsProps) {
+function useAppRecordActions({ recordId, recordType }: AppRecordActionsProps) {
   const { store } = useInternalAppsContext()
   const { data: actions } = useSurfaces({
     surfaceType: 'record-action',
     context: { recordId, recordType },
   })
 
-  if (actions.length === 0) return null
-
-  const handleTrigger = (appId: string, appInstallationId: string, surfaceId: string) => {
+  const trigger = (appId: string, appInstallationId: string, surfaceId: string) => {
     void store.triggerSurface({
       appId,
       appInstallationId,
@@ -51,6 +52,61 @@ export function AppRecordActions({ recordId, recordType, compact }: AppRecordAct
       payload: { recordId, recordType },
     })
   }
+
+  return { actions, trigger }
+}
+
+/** One app-declared record action as a menu row. */
+function AppActionItem({
+  surface,
+  onSelect,
+}: {
+  surface: { id: string; label?: string; icon?: unknown }
+  onSelect: () => void
+}) {
+  return (
+    <DropdownMenuItem onSelect={onSelect} className='flex items-center gap-2'>
+      {typeof surface.icon === 'string' && surface.icon.length <= 2 && <span>{surface.icon}</span>}
+      <span className='truncate'>{surface.label ?? surface.id}</span>
+    </DropdownMenuItem>
+  )
+}
+
+/**
+ * App actions as a SUBMENU of a caller-owned dropdown (`RecordActionsMenu`).
+ *
+ * Deliberately renders a DISABLED branch when no installed app declares a
+ * record action, where {@link AppRecordActions} returns `null` — same reasoning
+ * as `WorkflowSubMenu`. On a stock org that standalone "… More" button
+ * simply never appeared, so nothing on this surface ever told a user that apps
+ * can contribute actions here at all.
+ */
+export function AppRecordActionsSubmenu({ recordId, recordType }: AppRecordActionsProps) {
+  const { actions, trigger } = useAppRecordActions({ recordId, recordType })
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger disabled={actions.length === 0}>
+        <Blocks />
+        App actions
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className='w-56'>
+        {actions.map(({ surface, appId, appInstallationId }) => (
+          <AppActionItem
+            key={`${appId}:${appInstallationId}:${surface.id}`}
+            surface={surface}
+            onSelect={() => trigger(appId, appInstallationId, surface.id)}
+          />
+        ))}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}
+
+export function AppRecordActions({ recordId, recordType, compact }: AppRecordActionsProps) {
+  const { actions, trigger: handleTrigger } = useAppRecordActions({ recordId, recordType })
+
+  if (actions.length === 0) return null
 
   return (
     <DropdownMenu>

--- a/apps/web/src/components/detail-view/components/detail-view-actions.test.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.test.tsx
@@ -13,6 +13,12 @@
 // behind the capabilities provider, `canEditRecordAtRung` inside the hook) over
 // a real record-store stamp, so a change to either half breaks a test rather
 // than to a stub of `useRecordAccess`.
+//
+// The controls now live in the shared `RecordActionsMenu`, so every assertion
+// OPENS the menu first. That is not incidental to the test — Radix does not
+// mount `DropdownMenuContent`'s subtree until then, which is exactly what keeps
+// the access-request preflight from running for a member who never opens it
+// (§8.5 / D6), and what the zero-queries case below pins.
 
 import type { Rung } from '@auxx/database/enums'
 import type { ClientCapabilities } from '@auxx/lib/permissions/client'
@@ -25,7 +31,9 @@ import {
   toResolvedRecordAccess,
 } from '@auxx/lib/permissions/client'
 import { toRecordId } from '@auxx/lib/resources/client'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /** A def the member can see and edit — the ordinary lane. */
@@ -53,12 +61,16 @@ const h = vi.hoisted(() => ({
 
 // The provider half of the fold — the same two functions `useRecordAccessAt`
 // reads, wired to the shipped implementations rather than to booleans.
+// `canEditEntity` is here only because `useEntityInstanceOperations` reads it;
+// it is pinned FALSE so a test that passes could never be passing because of the
+// def-level gate the menu is required to ignore.
 vi.mock('~/providers/capabilities-provider', async () => {
   const perms = await import('@auxx/lib/permissions/client')
   return {
     useAccess: () => {
       const resolved = perms.toResolvedRecordAccess(h.caps as ClientCapabilities)
       return {
+        canEditEntity: () => false,
         recordDefRung: (defId: string) => perms.recordDefRung(resolved, defId),
         canDeleteRecordAt: (access: Rung) => perms.canDeleteRecordAtRung(resolved, access),
       }
@@ -70,11 +82,24 @@ vi.mock('~/providers/feature-flag-provider', () => ({
   useFeatureFlags: () => ({ hasAccess: () => true }),
 }))
 
-// Mount 2 of the record access-request lane (plan v3/04 §8.2) lives in this row.
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+// Mount 2 of the record access-request lane (plan v3/04 §8.2) lives in this menu.
 // Its preflight is LAZY, so an enabled query is what a "call" means here.
 vi.mock('~/trpc/react', () => ({
   api: {
-    useUtils: () => ({ approval: { recordAccessRequestPreflight: { invalidate: vi.fn() } } }),
+    useUtils: () => ({
+      approval: { recordAccessRequestPreflight: { invalidate: vi.fn() } },
+      favorite: { list: { invalidate: vi.fn() } },
+    }),
+    // The star's toggle is mutation-only — `useFavoriteToggle` reads its
+    // favourited state from the Zustand store, never a query — so wiring these
+    // keeps the real button mounted without adding anything the ZERO-queries
+    // assertion below would count.
+    favorite: {
+      add: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      remove: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
     approval: {
       recordAccessRequestPreflight: {
         useQuery: (input: unknown, opts: { enabled: boolean }) => {
@@ -88,28 +113,49 @@ vi.mock('~/trpc/react', () => ({
   },
 }))
 
-// Dialog bodies and the app-actions row pull tRPC/query graphs that have
-// nothing to do with the gate.
+// The archive/delete MUTATIONS are the records-table's shipped ones and are
+// tested there; what matters here is which items the gate renders at all.
+vi.mock('~/hooks/use-entity-instance-operations', () => ({
+  useEntityInstanceOperations: () => ({
+    canEdit: false,
+    handleArchive: vi.fn(),
+    handleDelete: vi.fn(),
+    ConfirmDeleteDialog: () => null,
+    ConfirmArchiveDialog: () => null,
+  }),
+}))
+
+// Dialog bodies and the two submenus pull tRPC/query graphs that have nothing to
+// do with the gate. The submenus decide their own enabled-ness from their own
+// queries, which is covered where they live.
 vi.mock('~/components/merge', () => ({ MergeDialog: () => null }))
+vi.mock('~/components/permissions/ui/instance-share-dialog', () => ({
+  InstanceShareDialog: () => null,
+}))
+// Issues its own per-record `resourceAccess.forInstance` query, which has
+// nothing to do with the gate under test.
+vi.mock('~/components/permissions/ui/instance-share-avatars', () => ({
+  InstanceShareAvatars: () => null,
+}))
 vi.mock('~/components/sequences/ui/add-to-sequence-dialog', () => ({
   AddToSequenceDialog: () => null,
 }))
-vi.mock('./app-record-actions', () => ({ AppRecordActions: () => null }))
+vi.mock('~/components/workflow/workflow-submenu', () => ({ WorkflowSubMenu: () => null }))
+vi.mock('~/components/detail-view/components/app-record-actions', () => ({
+  AppRecordActionsSubmenu: () => null,
+}))
 
 import { useRecordStore } from '~/components/resources/store/record-store'
 import { DetailViewActions } from './detail-view-actions'
-
-const ACTIONS = {
-  enableMerge: true,
-  enableArchive: true,
-  enableSpam: true,
-  enableDelete: true,
-}
 
 /**
  * Render the header for one row, stamping the store the way `record.getByIds`
  * does. `stamp: undefined` leaves the row unstamped, which is the def-fallback
  * case.
+ *
+ * `TooltipProvider` mirrors the app shell (`auxx-app-providers.tsx`), which
+ * wraps every `/app` route — the favourite star and the menu trigger both use a
+ * tooltip and throw without it.
  */
 function renderActions(defId: string, stamp: Rung | undefined) {
   useRecordStore.setState({ records: {}, attemptedIds: new Set() })
@@ -122,16 +168,24 @@ function renderActions(defId: string, stamp: Rung | undefined) {
     },
   ])
   return render(
-    <DetailViewActions
-      entityType={defId}
-      recordId={toRecordId(defId, ROW)}
-      record={{ status: 'ACTIVE' }}
-      config={{ actions: ACTIONS } as never}
-    />
+    <TooltipProvider>
+      <DetailViewActions
+        entityType={defId}
+        recordId={toRecordId(defId, ROW)}
+        record={{ status: 'ACTIVE' }}
+        backUrl='/app/contacts'
+      />
+    </TooltipProvider>
   )
 }
 
-const button = (name: RegExp) => screen.queryByRole('button', { name })
+/** Render, then open the overflow menu — nothing inside it exists until then. */
+async function openMenu(defId: string, stamp: Rung | undefined) {
+  renderActions(defId, stamp)
+  await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+}
+
+const item = (name: RegExp) => screen.queryByRole('menuitem', { name })
 
 beforeEach(() => {
   h.caps = snapshot(Level.Full)
@@ -139,78 +193,73 @@ beforeEach(() => {
 })
 
 describe('the row stamp, not the def, gates the detail-view header', () => {
-  it('withholds Archive/Spam/Delete from a `read` row of an otherwise editable def', () => {
+  it('withholds Archive/Delete/Merge from a `read` row of an otherwise editable def', async () => {
     // Records: Full — `canEditEntity(def)` is true, which is exactly what the
     // old gate asked. The row says `read`.
     h.caps = snapshot(Level.Full)
 
-    renderActions(OPEN_DEF, 'read')
+    await openMenu(OPEN_DEF, 'read')
 
-    expect(button(/archive/i)).toBeNull()
-    expect(button(/spam/i)).toBeNull()
-    expect(button(/delete/i)).toBeNull()
-    expect(button(/merge/i)).toBeNull()
+    expect(item(/archive/i)).toBeNull()
+    expect(item(/delete/i)).toBeNull()
+    expect(item(/merge/i)).toBeNull()
   })
 
-  it('offers Archive on an `edit` row of a def the member cannot otherwise see', () => {
+  it('offers Archive on an `edit` row of a def the member cannot otherwise see', async () => {
     // The mirror case: no def rung at all, `edit` by grant. Under the def gate
     // this member could open the row and do nothing to it.
     h.caps = snapshot(Level.None, { restrictedEntityDefIds: [CLOSED_DEF] })
 
-    renderActions(CLOSED_DEF, 'edit')
+    await openMenu(CLOSED_DEF, 'edit')
 
-    expect(button(/archive/i)).toBeTruthy()
-    expect(button(/spam/i)).toBeTruthy()
+    expect(item(/archive/i)).toBeTruthy()
   })
 
-  it('keeps the def answer for an UNSTAMPED row — the honest pre-P5 fallback', () => {
+  it('keeps the def answer for an UNSTAMPED row — the honest pre-P5 fallback', async () => {
     h.caps = snapshot(Level.Full)
 
-    renderActions(OPEN_DEF, undefined)
+    await openMenu(OPEN_DEF, undefined)
 
-    expect(button(/archive/i)).toBeTruthy()
-    expect(button(/delete/i)).toBeTruthy()
+    expect(item(/archive/i)).toBeTruthy()
+    expect(item(/delete/i)).toBeTruthy()
   })
 })
 
 describe('the DESTRUCTIVE pair is a narrower rule than edit, not the same flag', () => {
-  it('shows Archive but NOT Delete for an `edit` row without the delete verb', () => {
+  it('shows Archive but NOT Delete for an `edit` row without the delete verb', async () => {
     // Records: Edit carries no `recordsDelete`; the stamp is `edit`, not
     // `admin`. Collaboration, not destruction.
     h.caps = snapshot(Level.Edit, { restrictedEntityDefIds: [CLOSED_DEF] })
 
-    renderActions(CLOSED_DEF, 'edit')
+    await openMenu(CLOSED_DEF, 'edit')
 
-    expect(button(/archive/i)).toBeTruthy()
-    expect(button(/delete/i)).toBeNull()
+    expect(item(/archive/i)).toBeTruthy()
+    expect(item(/delete/i)).toBeNull()
   })
 
-  it('shows Archive but NOT MERGE for an `edit` row without the delete verb', () => {
+  it('shows Archive but NOT MERGE for an `edit` row without the delete verb', async () => {
     // Merge rides the DELETE verb, not the edit floor: it permanently removes
     // the source rows, and the server asserts `assertCanDeleteRows` over the
-    // target and every source (`routers/record.ts:996`). Gating it with
-    // Archive/Spam — as plan v3/04 §10.4 says — shows this member a button the
-    // mutation refuses.
+    // target and every source (`routers/record.ts`). Gating it with Archive — as
+    // plan v3/04 §10.4 says — shows this member an item the mutation refuses.
     h.caps = snapshot(Level.Edit, { restrictedEntityDefIds: [CLOSED_DEF] })
 
-    renderActions(CLOSED_DEF, 'edit')
+    await openMenu(CLOSED_DEF, 'edit')
 
-    expect(button(/archive/i)).toBeTruthy()
-    expect(button(/spam/i)).toBeTruthy()
-    expect(button(/merge/i)).toBeNull()
-    expect(button(/delete/i)).toBeNull()
+    expect(item(/archive/i)).toBeTruthy()
+    expect(item(/merge/i)).toBeNull()
+    expect(item(/delete/i)).toBeNull()
   })
 
-  it('shows Delete AND Merge for an `admin` row even without the org-wide delete verb', () => {
+  it('shows Delete for an `admin` row even without the org-wide delete verb', async () => {
     h.caps = snapshot(Level.None, { restrictedEntityDefIds: [CLOSED_DEF] })
 
-    renderActions(CLOSED_DEF, 'admin')
+    await openMenu(CLOSED_DEF, 'admin')
 
-    expect(button(/delete/i)).toBeTruthy()
-    expect(button(/merge/i)).toBeTruthy()
+    expect(item(/delete/i)).toBeTruthy()
   })
 
-  it('pins the two rules apart at the source, so the buttons cannot be collapsed', () => {
+  it('pins the two rules apart at the source, so the items cannot be collapsed', () => {
     const edit = toResolvedRecordAccess(snapshot(Level.Edit))
     expect(canDeleteRecordAtRung(edit, 'edit')).toBe(false)
     // …and the def fallback the header leans on is the shipped one.
@@ -218,29 +267,103 @@ describe('the DESTRUCTIVE pair is a narrower rule than edit, not the same flag',
   })
 })
 
+describe('Delete is no longer withheld by a per-type config flag', () => {
+  it('offers Delete on an `admin` CONTACT row', async () => {
+    // The regression this pins: `DETAIL_VIEW_CONFIG_REGISTRY.contact.actions`
+    // carried no `enableDelete`, so a contact was deletable from its table row
+    // and its drawer but NOT from its own detail page — while `record.delete`
+    // accepted it the whole time. `enableDelete` is gone; the rung decides.
+    h.caps = snapshot(Level.Full)
+
+    await openMenu(OPEN_DEF, 'admin')
+
+    expect(item(/delete/i)).toBeTruthy()
+  })
+})
+
 describe('the access-request mount (plan v3/04 §8.2, mount 2)', () => {
-  it('offers `read → edit` on a `read` row, where every other control is withheld', () => {
+  // PROMOTED out of the menu on this surface: it is the one control that ADDS
+  // capability, and the record's own page is where a member who cannot edit it
+  // ends up. Burying the way out of a dead end behind a kebab is backwards.
+  it('is a top-level BUTTON on a `read` row, where every write control is withheld', async () => {
     h.caps = snapshot(Level.Full)
     renderActions(OPEN_DEF, 'read')
 
-    // FIRST in the row: everything after it is destructive-leaning, and this is
-    // the one control that ADDS capability.
-    expect(button(/Request edit access/)).toBeTruthy()
-    expect(button(/archive/i)).toBeNull()
+    expect(screen.getByRole('button', { name: /Request edit access/ })).toBeTruthy()
+
+    // …and it is NOT also duplicated inside the menu.
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    expect(item(/Request/)).toBeNull()
+    expect(item(/archive/i)).toBeNull()
   })
 
   it('renders NO trigger on an `edit` row — nothing left to ask for', () => {
     h.caps = snapshot(Level.None, { restrictedEntityDefIds: [CLOSED_DEF] })
     renderActions(CLOSED_DEF, 'edit')
 
-    expect(button(/Request/)).toBeNull()
+    expect(screen.queryByRole('button', { name: /Request/ })).toBeNull()
   })
 
   it('costs ZERO queries to decide the label (§8.5 / D6)', () => {
+    // The label comes from the rung the client already holds; the preflight is
+    // lazy and only fires once the popover itself opens. Promoting the trigger
+    // to a always-rendered button is what makes this worth pinning — it now
+    // mounts for every `read` viewer, so a non-lazy preflight would be a query
+    // on every such page load.
     h.caps = snapshot(Level.Full)
     renderActions(OPEN_DEF, 'read')
 
-    expect(button(/Request edit access/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Request edit access/ })).toBeTruthy()
     expect(h.preflightCalls).toHaveLength(0)
+  })
+
+  it('mounts no menu items at all while the menu stays CLOSED', () => {
+    // Radix does not mount `DropdownMenuContent`'s subtree until opened — the
+    // same property the table relies on per row.
+    h.caps = snapshot(Level.Full)
+    renderActions(OPEN_DEF, 'read')
+
+    expect(screen.queryByRole('menuitem')).toBeNull()
+  })
+})
+
+describe('Share is promoted beside the shared-with avatars, not buried', () => {
+  it('renders a labelled Share button on an `admin` row, and NOT a menu item', async () => {
+    h.caps = snapshot(Level.Full)
+    renderActions(OPEN_DEF, 'admin')
+
+    expect(screen.getByRole('button', { name: /Share/ })).toBeTruthy()
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    expect(item(/Share/)).toBeNull()
+  })
+
+  it('withholds Share entirely below `admin` — sharing is not an edit affordance', () => {
+    h.caps = snapshot(Level.Edit, { restrictedEntityDefIds: [CLOSED_DEF] })
+    renderActions(CLOSED_DEF, 'edit')
+
+    expect(screen.queryByRole('button', { name: /Share/ })).toBeNull()
+  })
+})
+
+describe('the favourite star is deliberately UNGATED and OUTSIDE the menu', () => {
+  it('renders on a `read` row, where every write control is withheld', () => {
+    // Favouriting is a personal bookmark keyed to the viewer, not a write on the
+    // record — the same reason the drawer's and the table row's menu items carry
+    // no rung check. Pinned so a future pass that sweeps rung gates across this
+    // cluster doesn't quietly take it with them.
+    h.caps = snapshot(Level.Full)
+    renderActions(OPEN_DEF, 'read')
+
+    expect(screen.getByRole('button', { name: /Add to favorites/i })).toBeTruthy()
+  })
+
+  it('is reachable WITHOUT opening the menu — it reports state, so it must be visible', () => {
+    h.caps = snapshot(Level.Full)
+    renderActions(CLOSED_DEF, 'read')
+
+    // Two buttons, no menu open: the star and the overflow trigger.
+    expect(screen.getByRole('button', { name: /Add to favorites/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'More actions' })).toBeTruthy()
   })
 })

--- a/apps/web/src/components/detail-view/components/detail-view-actions.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.tsx
@@ -1,198 +1,116 @@
 // apps/web/src/components/detail-view/components/detail-view-actions.tsx
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
 import { parseRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
-import { Archive, Ban, Merge, Send, Trash2, Users, Zap } from 'lucide-react'
+import { Share2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
 import { GranularPermissionsGate } from '~/components/mail-permissions/ui/granular-permissions-gate'
-import { MergeDialog } from '~/components/merge'
+import { InstanceShareAvatars } from '~/components/permissions/ui/instance-share-avatars'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { RecordRequestAccessPopover } from '~/components/permissions/ui/record-request-access-popover'
+import { RECORD_HEADER_GHOST, RecordActionsMenu } from '~/components/records/record-actions-menu'
 import { useRecordAccess } from '~/components/resources'
-import { AddToSequenceDialog } from '~/components/sequences/ui/add-to-sequence-dialog'
-import { useConfirm } from '~/hooks/use-confirm'
-import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import type { DetailViewActionsProps } from '../types'
-import { AppRecordActions } from './app-record-actions'
 
 /**
- * DetailViewActions - action buttons for the detail view header
- * Actions are enabled/disabled based on config.actions
+ * The detail page's header action cluster:
+ * `[who it's shared with + Share | Request access] [★] [⋮]`
+ *
+ * This used to be a row of eight outline buttons, five of which did nothing:
+ * Archive, Delete, Spam and Run Workflow were `console.log` stubs behind confirm
+ * dialogs that led nowhere, and Groups set a `useState` no JSX read (no
+ * group-assignment dialog exists anywhere in the app). Spam had no server
+ * mutation at all. Everything real now lives in the shared
+ * {@link RecordActionsMenu}, which the drawer and the records-table row use too,
+ * so the three surfaces can no longer disagree about what a record type offers.
+ *
+ * Three controls stay OUT of the menu, each for its own reason:
+ *
+ * - **Share**, with the shared-with avatars to its left. Both are gated on
+ *   `canShare` (an `admin` row), which also keeps the avatars' per-record query
+ *   off every other viewer — who else can see a record is not something a `read`
+ *   member should be able to enumerate.
+ * - **Request access**, because it is the one control that ADDS capability, and
+ *   burying the way out of a dead end behind a kebab is exactly backwards. It
+ *   and Share are mutually exclusive in practice: the ask only appears at `read`,
+ *   sharing only at `admin`.
+ * - **The favourite star**, because it REPORTS state (a filled star means
+ *   favourited) and state you must open a menu to read is state you may as well
+ *   not show. It is also deliberately ungated — favouriting is a personal
+ *   bookmark keyed to the viewer, not a write on the record.
+ *
+ * Both promoted items are passed to the menu as `omitItems` so they are not also
+ * offered inside it.
  */
 export function DetailViewActions({
   entityType,
   recordId,
   record,
-  config,
+  backUrl,
 }: DetailViewActionsProps) {
-  const { hasAccess } = useFeatureFlags()
-  const sequencesEnabled = hasAccess(FeatureKey.sequences)
-
-  /**
-   * **The per-ROW write gate** (plan v3/04 §10.4 / D5, plan v3/03 §5.2).
-   *
-   * This header used to ask `canEditEntity(def)` — the DEF question, which is
-   * wrong for a row in both directions since P5: a member holding `edit` on one
-   * row via a grant saw no Archive on that row's own page, and a member holding
-   * only `read` on a row of a def they otherwise edit saw Delete. The `_access`
-   * stamp riding the row is the answer, read through the same verbs the server
-   * applies.
-   *
-   * `canEdit` and `canDelete` are deliberately NOT one flag: `canDelete` is the
-   * `edit` floor **plus** (`records.delete` OR `admin`), strictly narrower.
-   *
-   * ⚠ **Merge is on `canDelete`, with Delete — not on `canEdit` with
-   * Archive/Spam.** A merge permanently removes the source rows, and the
-   * destructive half is the binding one: the server asserts the DELETE verb for
-   * the target AND every source (`assertCanDeleteRows`,
-   * `routers/record.ts:996`), which is also what `RecordRowAccess.canDelete`
-   * means by "deleted or merged away". Archive and Spam are reversible status
-   * writes and stay on the `edit` floor. Plan v3/04 §10.4 groups Merge with
-   * Archive/Spam; that grouping is wrong against the shipped mutation and is
-   * not followed here.
-   */
-  const { access, canEdit, canDelete } = useRecordAccess(recordId)
-  const [confirm, ConfirmDialog] = useConfirm()
-  const [isGroupDialogOpen, setIsGroupDialogOpen] = useState(false)
-  const [mergeDialogOpen, setMergeDialogOpen] = useState(false)
-  const [addToSequenceDialogOpen, setAddToSequenceDialogOpen] = useState(false)
-
-  const { actions } = config
-
-  // Check if record is in a state that prevents actions
-  const status = record.status as string | undefined
-  const isMerged = status === 'MERGED'
-  const isSpam = status === 'SPAM'
-  const isArchived = status === 'ARCHIVED'
-
-  // Don't show actions for merged records
-  if (isMerged) return null
-
-  /** Handle archive action */
-  const handleArchive = async () => {
-    const confirmed = await confirm({
-      title: 'Archive record?',
-      description: 'This record will be archived and hidden from default views.',
-      confirmText: 'Archive',
-      cancelText: 'Cancel',
-    })
-    if (confirmed) {
-      // TODO: Implement archive mutation
-      console.log('Archive:', recordId)
-    }
-  }
-
-  /** Handle delete action */
-  const handleDelete = async () => {
-    const confirmed = await confirm({
-      title: 'Delete record?',
-      description:
-        'This action cannot be undone. The record and all its data will be permanently deleted.',
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      destructive: true,
-    })
-    if (confirmed) {
-      // TODO: Implement delete mutation
-      console.log('Delete:', recordId)
-    }
-  }
-
-  /** Handle spam action */
-  const handleSpam = async () => {
-    const confirmed = await confirm({
-      title: 'Mark as spam?',
-      description: 'This record will be marked as spam.',
-      confirmText: 'Mark as Spam',
-      cancelText: 'Cancel',
-      destructive: true,
-    })
-    if (confirmed) {
-      // TODO: Implement spam mutation
-      console.log('Spam:', recordId)
-    }
-  }
+  const router = useRouter()
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  const { access, canShare } = useRecordAccess(recordId)
+  const [shareOpen, setShareOpen] = useState(false)
 
   return (
-    <>
-      <div className='flex gap-2'>
-        {/* Ask for the next rung (plan v3/04 §8.2, mount 2). FIRST in the row on
-            purpose: everything after it is destructive-leaning, and this is the
-            one control that ADDS capability. Only at `read` — reaching this page
-            already proves it, and `edit`/`admin` have nothing left to ask for. */}
-        {access === 'read' && (
-          <GranularPermissionsGate>
-            <RecordRequestAccessPopover
-              entityDefinitionId={parseRecordId(recordId).entityDefinitionId}
-              entityInstanceId={parseRecordId(recordId).entityInstanceId}
-            />
-          </GranularPermissionsGate>
-        )}
-
-        {actions.enableGroups && (
-          <Button variant='outline' size='sm' onClick={() => setIsGroupDialogOpen(true)}>
-            <Users /> Groups
-          </Button>
-        )}
-
-        {actions.enableMerge && canDelete && (
-          <Button variant='outline' size='sm' onClick={() => setMergeDialogOpen(true)}>
-            <Merge /> Merge
-          </Button>
-        )}
-
-        {actions.enableWorkflowTrigger && (
-          <Button variant='outline' size='sm' onClick={() => console.log('Workflow:', recordId)}>
-            <Zap /> Run Workflow
-          </Button>
-        )}
-
-        {actions.enableAddToSequence && sequencesEnabled && (
-          <Button variant='outline' size='sm' onClick={() => setAddToSequenceDialogOpen(true)}>
-            <Send /> Add to sequence
-          </Button>
-        )}
-
-        {actions.enableArchive && canEdit && !isArchived && (
-          <Button variant='outline' size='sm' onClick={handleArchive}>
-            <Archive /> Archive
-          </Button>
-        )}
-
-        {actions.enableSpam && canEdit && !isSpam && (
-          <Button variant='destructive' size='sm' onClick={handleSpam}>
-            <Ban /> Spam
-          </Button>
-        )}
-
-        {actions.enableDelete && canDelete && (
-          <Button variant='destructive' size='sm' onClick={handleDelete}>
-            <Trash2 /> Delete
-          </Button>
-        )}
-
-        <AppRecordActions recordId={recordId} recordType={entityType} />
-      </div>
-
-      <ConfirmDialog />
-
-      {mergeDialogOpen && recordId && (
-        <MergeDialog
-          open={mergeDialogOpen}
-          onOpenChange={setMergeDialogOpen}
-          baseRecordIds={[recordId]}
-          onMergeComplete={() => setMergeDialogOpen(false)}
-        />
+    <div className='flex items-center gap-2'>
+      {canShare && (
+        <GranularPermissionsGate>
+          <div className='flex items-center gap-1.5'>
+            {/* Avatars lead: they are the STATE (who can see this), the button
+                is the action on it. Reading left-to-right you learn the answer
+                before you're offered the way to change it. */}
+            <InstanceShareAvatars recordId={recordId} />
+            <Button
+              variant='ghost'
+              size='sm'
+              className={RECORD_HEADER_GHOST}
+              onClick={() => setShareOpen(true)}>
+              <Share2 />
+              Share
+            </Button>
+          </div>
+        </GranularPermissionsGate>
       )}
 
-      {sequencesEnabled && addToSequenceDialogOpen && recordId && (
-        <AddToSequenceDialog
-          open={addToSequenceDialogOpen}
-          onOpenChange={setAddToSequenceDialogOpen}
-          recipientEntityInstanceIds={[parseRecordId(recordId).entityInstanceId]}
-        />
+      {/* Label follows the ladder rather than this call site: `none → "Request
+          access"`, `read → "Request edit access"`. `edit`/`admin` render nothing
+          — there is nothing left to ask for. */}
+      {access === 'read' && (
+        <GranularPermissionsGate>
+          <RecordRequestAccessPopover
+            entityDefinitionId={entityDefinitionId}
+            entityInstanceId={entityInstanceId}
+            variant='header'
+          />
+        </GranularPermissionsGate>
       )}
-    </>
+
+      <FavoriteStarButton
+        targetType='ENTITY_INSTANCE'
+        targetIds={{ entityDefinitionId, entityInstanceId }}
+        size='icon-xs'
+        className={RECORD_HEADER_GHOST}
+      />
+
+      <RecordActionsMenu
+        recordId={recordId}
+        entityType={entityType}
+        record={record}
+        surface='page'
+        omitItems={['share', 'request-access']}
+        // The record this page IS was just deleted — staying here would render
+        // the not-found screen for a row the member deleted themselves.
+        onDeleted={() => backUrl && router.push(backUrl)}
+      />
+
+      {shareOpen && (
+        <InstanceShareDialog recordId={recordId} open={shareOpen} onOpenChange={setShareOpen} />
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/detail-view/detail-view.tsx
+++ b/apps/web/src/components/detail-view/detail-view.tsx
@@ -203,7 +203,7 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
               entityType={entityType}
               recordId={recordId}
               record={record}
-              config={config}
+              backUrl={backUrl}
             />
           </div>
         }>

--- a/apps/web/src/components/detail-view/types.ts
+++ b/apps/web/src/components/detail-view/types.ts
@@ -101,14 +101,18 @@ export interface DetailViewCardHeaderProps {
  * Props for DetailViewActions component
  */
 export interface DetailViewActionsProps {
-  /** Entity type for action configuration */
+  /** Entity type — resolves the offered actions via the shared `getRecordActions`. */
   entityType: string
   /** RecordId for entity operations */
   recordId: RecordId
   /** Record data */
   record: Record<string, unknown>
-  /** Detail view configuration */
-  config: DetailViewConfig
+  /**
+   * Where to land after the record is deleted. No `config` here any more: the
+   * action set moved to the one shared `record-actions-config.ts` registry, so
+   * there is nothing per-surface left to pass.
+   */
+  backUrl?: string
 }
 
 /**

--- a/apps/web/src/components/permissions/ui/instance-share-avatars.tsx
+++ b/apps/web/src/components/permissions/ui/instance-share-avatars.tsx
@@ -1,0 +1,71 @@
+// apps/web/src/components/permissions/ui/instance-share-avatars.tsx
+'use client'
+
+import type { RecordId } from '@auxx/types/resource'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+import { useInstanceShare } from '~/components/permissions/hooks/use-instance-share'
+import { useActors } from '~/components/resources/hooks/use-actor'
+import { ActorAvatar } from '~/components/resources/ui/actor-badge'
+
+/** How many faces before the rest collapse into a "+N". */
+const MAX_FACES = 3
+
+/**
+ * Who a record is shared with, as a compact overlapping avatar stack — the
+ * at-a-glance answer to "is this private?" that otherwise costs opening the
+ * share dialog.
+ *
+ * ⚠ **Mount this only behind `canShare`.** It issues
+ * `resourceAccess.forInstance`, a per-record query, and the grantee list is
+ * itself information a non-admin has no business reading — who else can see a
+ * record is not something a `read` member should be able to enumerate. Gating at
+ * the CALL SITE rather than inside keeps the query from being issued at all,
+ * where an internal early-return would still have paid for it.
+ *
+ * Renders nothing when the record has no explicit grants (the common case), so
+ * an unshared record shows a bare Share button rather than an empty slot.
+ */
+export function InstanceShareAvatars({
+  recordId,
+  className,
+}: {
+  recordId: RecordId
+  className?: string
+}) {
+  const { grants, isLoading } = useInstanceShare({ recordId })
+  // Pure store read — no query of its own; the actor store is hydrated once per
+  // org by its provider.
+  const actors = useActors(grants.map((g) => g.actorId))
+
+  if (isLoading || grants.length === 0) return null
+
+  const shown = grants.slice(0, MAX_FACES)
+  const overflow = grants.length - shown.length
+  const names = grants.map((g) => actors.get(g.actorId)?.name ?? 'Someone')
+
+  return (
+    <SimpleTooltip content={`Shared with ${names.join(', ')}`}>
+      {/* `-space-x-1.5` overlaps the faces; each carries the page background as
+          a ring so the overlap reads as a stack rather than a smudge. */}
+      <div className={cn('-space-x-1.5 flex items-center', className)}>
+        {shown.map((grant) => {
+          const actor = actors.get(grant.actorId)
+          return (
+            <ActorAvatar
+              key={grant.actorId}
+              type={actor?.type ?? 'user'}
+              avatarUrl={actor?.avatarUrl}
+              className='size-5 ring-2 ring-background'
+            />
+          )
+        })}
+        {overflow > 0 && (
+          <span className='flex size-5 items-center justify-center rounded-full bg-neutral-200 text-[9px] text-neutral-700 ring-2 ring-background dark:bg-neutral-700 dark:text-neutral-200'>
+            +{overflow}
+          </span>
+        )}
+      </div>
+    </SimpleTooltip>
+  )
+}

--- a/apps/web/src/components/permissions/ui/record-request-access-popover.tsx
+++ b/apps/web/src/components/permissions/ui/record-request-access-popover.tsx
@@ -46,10 +46,10 @@ export function RecordRequestAccessPopover({
   entityDefinitionId: string
   entityInstanceId: string
   /**
-   * `inline` is the detail-page action row, `icon` the drawer header's lock slot,
-   * `menu-item` the table row's kebab menu.
+   * `header` is the detail-page action row, `inline` the not-found screen's CTA,
+   * `icon` the drawer header's lock slot, `menu-item` the table row's kebab menu.
    */
-  variant?: 'inline' | 'icon' | 'menu-item'
+  variant?: 'inline' | 'header' | 'icon' | 'menu-item'
   /**
    * Treat the viewer as holding nothing on this record — the full-page not-found
    * mount, where the row is not in the store and the def fallback would answer

--- a/apps/web/src/components/permissions/ui/request-access-popover.tsx
+++ b/apps/web/src/components/permissions/ui/request-access-popover.tsx
@@ -45,14 +45,18 @@ export interface RequestAccessPopoverProps extends RequestAccessState {
    */
   footer?: (close: () => void) => ReactNode
   /**
-   * `inline` is a labelled button in a banner or action row; `icon` is a lock for
-   * a header slot; `menu-item` is a row inside an already-open dropdown menu.
+   * `inline` is a labelled OUTLINE button for a banner or an empty state (the
+   * not-found screen, the mail thread body) where it is the page's one CTA;
+   * `header` is the same label as a ghost button with the lock icon, for a
+   * record header's action row where an outline would out-shout Share and the
+   * favourite star beside it; `icon` is the bare lock for a tight header slot;
+   * `menu-item` is a row inside an already-open dropdown menu.
    *
    * `menu-item` prevents the menu's own `select`, so the dropdown stays open
    * behind the popover rather than unmounting the trigger the popover is
    * anchored to.
    */
-  variant?: 'inline' | 'icon' | 'menu-item'
+  variant?: 'inline' | 'header' | 'icon' | 'menu-item'
   /**
    * Notified whenever the popover opens or closes — **the lazy-preflight seam**
    * (plan v3/04 §8.5 / D6).
@@ -121,7 +125,7 @@ export function RequestAccessPopover({
     // A refusal is worth saying in a banner or an action row, where there is room
     // for a sentence. In a header's icon slot there is not, and a tooltip nobody
     // hovers is not communication — so that mount stays silent.
-    if (refusalCopy && variant === 'inline') {
+    if (refusalCopy && (variant === 'inline' || variant === 'header')) {
       return <span className='text-muted-foreground text-xs'>{refusalCopy}</span>
     }
     return null
@@ -167,6 +171,19 @@ export function RequestAccessPopover({
         <LockKeyhole />
         {label}
       </DropdownMenuItem>
+    ) : variant === 'header' ? (
+      // Ghost + the record header's shared hover treatment, which is spelled out
+      // rather than imported: `RECORD_HEADER_GHOST` lives in
+      // `components/records/record-actions-menu.tsx`, and the permissions lane
+      // must not depend on the records lane for a style token. Keep the two in
+      // step. `data-[state=open]` holds the tint while the popover is open.
+      <Button
+        variant='ghost'
+        size='sm'
+        className='hover:bg-foreground/10 data-[state=open]:bg-foreground/10'>
+        <LockKeyhole />
+        {label}
+      </Button>
     ) : (
       <Button variant='outline' size='sm'>
         {label}

--- a/apps/web/src/components/records/record-action-registry.tsx
+++ b/apps/web/src/components/records/record-action-registry.tsx
@@ -1,0 +1,68 @@
+// apps/web/src/components/records/record-action-registry.tsx
+'use client'
+
+import type { Resource } from '@auxx/lib/resources/client'
+import type { RecordId } from '@auxx/types/resource'
+import type { ComponentType } from 'react'
+import type { RecordRowAccess } from '~/components/resources'
+
+/**
+ * Props every custom record-menu item receives. An item renders its own
+ * `<DropdownMenuItem>` (or a `<DropdownMenuSub>`), so it owns its icon, label,
+ * gating and dialog.
+ *
+ * `access` is the resolved per-ROW verdict, already folded — an item must gate
+ * on this, never on a def-level `canEditEntity`, or it will disagree with every
+ * built-in item sitting beside it in the same menu.
+ */
+export interface RecordMenuActionProps {
+  recordId: RecordId
+  entityDefinitionId: string
+  entityInstanceId: string
+  /** ModelType — `'entity'` for every custom definition. */
+  entityType: string
+  record?: Record<string, unknown>
+  resource?: Resource
+  access: RecordRowAccess
+}
+
+type Registry = Record<string, ComponentType<RecordMenuActionProps>[]>
+
+/**
+ * Custom menu items keyed by **ModelType** — the coarse tier, for behaviour that
+ * belongs to every record of a system type.
+ */
+const BY_ENTITY_TYPE: Registry = {}
+
+/**
+ * Custom menu items keyed by **entityDefinitionId** — the precise tier.
+ *
+ * This tier is why the drawer's `getHeaderActions` could not simply be reused:
+ * it keys on ModelType alone, and EVERY custom definition reports
+ * `entityType: 'entity'`, so a Shipments-only action registered there would
+ * appear on every other custom definition in the org.
+ */
+const BY_DEFINITION_ID: Registry = {}
+
+/**
+ * Resolve the custom menu items for a record. The per-definition tier WINS
+ * outright rather than concatenating: a definition that registers items is
+ * stating what it wants, and a silent union with the type-level list is the kind
+ * of thing nobody can predict from the call site.
+ *
+ * Both maps start empty — this is the extension point the detail view never had
+ * (`detail-view-config.ts` notes "no per-entity extension point exists yet"),
+ * not a migration of anything. Note the drawer's `drawer-action-registry.tsx`
+ * stays where it is and is NOT superseded: it registers primary header BUTTONS
+ * (Compose, Reply, Schedule) that belong outside a menu, the same tier as the
+ * favourite star.
+ */
+export function getRecordMenuActions(
+  entityType: string,
+  entityDefinitionId?: string
+): ComponentType<RecordMenuActionProps>[] {
+  if (entityDefinitionId && BY_DEFINITION_ID[entityDefinitionId]) {
+    return BY_DEFINITION_ID[entityDefinitionId]
+  }
+  return BY_ENTITY_TYPE[entityType] ?? []
+}

--- a/apps/web/src/components/records/record-actions-menu.tsx
+++ b/apps/web/src/components/records/record-actions-menu.tsx
@@ -1,0 +1,352 @@
+// apps/web/src/components/records/record-actions-menu.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { getRecordActions } from '@auxx/lib/resources/client'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  Archive,
+  Expand,
+  Link as LinkIcon,
+  Merge,
+  MoreVertical,
+  Send,
+  Share2,
+  SquarePen,
+  TextCursorInput,
+  Trash2,
+} from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import * as React from 'react'
+import { AppRecordActionsSubmenu } from '~/components/detail-view/components/app-record-actions'
+import { GranularPermissionsGate } from '~/components/mail-permissions/ui/granular-permissions-gate'
+import { MergeDialog } from '~/components/merge'
+import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
+import { RecordRequestAccessPopover } from '~/components/permissions/ui/record-request-access-popover'
+import { useRecordAccess, useRecordLink, useResource } from '~/components/resources'
+import { AddToSequenceDialog } from '~/components/sequences/ui/add-to-sequence-dialog'
+import { WorkflowSubMenu } from '~/components/workflow/workflow-submenu'
+import { useEntityInstanceOperations } from '~/hooks/use-entity-instance-operations'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { getRecordMenuActions } from './record-action-registry'
+
+/**
+ * Which surface is rendering the menu. Drives the trigger's shape and the two
+ * items whose relevance depends on where you already are.
+ */
+export type RecordActionsSurface = 'page' | 'drawer' | 'row'
+
+export interface RecordActionsMenuProps {
+  recordId: RecordId
+  /** ModelType from `resource.entityType` — `'entity'` for custom definitions. */
+  entityType: string
+  record?: Record<string, unknown>
+  surface: RecordActionsSurface
+  /**
+   * Open this surface's record-editor dialog. The item hides when omitted, so a
+   * surface without an editor doesn't advertise one — the editor's shape differs
+   * per surface, which is why the menu takes a callback instead of owning it.
+   */
+  onEdit?: () => void
+  /** Focus this surface's inline title input. Drawer-only; item hides when omitted. */
+  onRename?: () => void
+  /** Link this record to another. Item hides when omitted. */
+  onLink?: () => void
+  /** After a successful delete — close the drawer, navigate away from the page. */
+  onDeleted?: () => void
+  /**
+   * Items this surface renders as its OWN control, outside the menu, so the
+   * menu must not also offer them.
+   *
+   * The detail page promotes both: Share sits in the header beside the
+   * shared-with avatars, and the access request is a labelled button (the ask
+   * that ADDS capability should not be buried behind a kebab on the record's
+   * own page). The drawer and the table row keep them in here, where there is
+   * no room to promote anything.
+   */
+  omitItems?: RecordActionKey[]
+  /** Extra items, rendered after the registry's custom ones and before the destructive group. */
+  children?: React.ReactNode
+}
+
+/** Built-in items a surface may render itself instead — see `omitItems`. */
+export type RecordActionKey = 'share' | 'request-access'
+
+/**
+ * Ghost buttons in a record header override their hover: `MainPage`'s background
+ * is the same value as `ghost`'s own hover, so the default reads as nothing
+ * happening. `data-[state=open]` holds the tint while a menu/dialog the button
+ * owns is open. Exported so the sibling controls (Share, the favourite star)
+ * match the menu trigger exactly.
+ */
+export const RECORD_HEADER_GHOST = 'hover:bg-foreground/10 data-[state=open]:bg-foreground/10'
+
+const TRIGGER_BY_SURFACE: Record<
+  RecordActionsSurface,
+  { variant: 'outline' | 'ghost'; size: 'sm' | 'icon-sm' | 'icon-xs'; className?: string }
+> = {
+  page: { variant: 'ghost', size: 'icon-xs', className: RECORD_HEADER_GHOST },
+  drawer: {
+    variant: 'ghost',
+    size: 'icon-xs',
+    className: 'rounded-full data-[state=open]:bg-foreground/10',
+  },
+  // Hover-revealed, matching the surrounding `PrimaryCell` chrome.
+  row: {
+    variant: 'ghost',
+    size: 'icon-xs',
+    className:
+      'rounded-md sm:opacity-0 sm:group-hover/primary:opacity-100 transition-opacity data-[state=open]:opacity-100!',
+  },
+}
+
+/**
+ * **The one record-action menu**, shared by the detail page, the record drawer
+ * and the records-table row.
+ *
+ * Before this, each of the three surfaces hand-rolled its own list against its
+ * own permission helpers and its own `actions` config, and they disagreed in
+ * ways users could see: a contact was deletable from its table row but not from
+ * its own detail page, "Run workflow" existed in the drawer and not on the page,
+ * and half the detail page's buttons were `console.log` stubs (Archive, Delete,
+ * Spam, Groups, Run Workflow) behind confirm dialogs that led nowhere.
+ *
+ * Two rules hold the consolidation together:
+ *
+ * 1. **Authorization is the per-ROW `_access` stamp**, resolved once by
+ *    `useRecordAccess`. Config flags say what a record TYPE offers; they never
+ *    say what a member may do. `canEdit` and `canDelete` are deliberately not
+ *    one flag — delete is the edit floor PLUS the delete verb.
+ * 2. **Favourite is not here.** Every surface renders `FavoriteStarButton`
+ *    beside the trigger instead: it is the one control that reports state
+ *    (filled = favourited), and state you have to open a menu to read is state
+ *    you may as well not show.
+ *
+ * ⚠ Dialogs are siblings of `<DropdownMenu>`, never children of
+ * `<DropdownMenuContent>` — Radix unmounts the content when the menu closes, and
+ * selecting an item closes the menu, so a dialog mounted inside would be torn
+ * down in the same tick it was opened.
+ */
+export function RecordActionsMenu({
+  recordId,
+  entityType,
+  record,
+  surface,
+  onEdit,
+  onRename,
+  onLink,
+  onDeleted,
+  omitItems = [],
+  children,
+}: RecordActionsMenuProps) {
+  const router = useRouter()
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  const { resource } = useResource(entityDefinitionId)
+  const access = useRecordAccess(recordId)
+  const { hasAccess } = useFeatureFlags()
+  const sequencesEnabled = hasAccess(FeatureKey.sequences)
+  const fullPageLink = useRecordLink(recordId)
+
+  const omitted = new Set(omitItems)
+  const actions = getRecordActions(entityType)
+  const customItems = getRecordMenuActions(entityType, entityDefinitionId)
+
+  const [mergeOpen, setMergeOpen] = React.useState(false)
+  const [shareOpen, setShareOpen] = React.useState(false)
+  const [sequenceOpen, setSequenceOpen] = React.useState(false)
+
+  // The REAL archive/delete path, shared with the records table. Only the
+  // handlers and their dialogs are taken — NOT this hook's `canEdit`, which is
+  // the def-level `canEditEntity` and would undo the per-row gate above.
+  const { handleArchive, handleDelete, ConfirmDeleteDialog, ConfirmArchiveDialog } =
+    useEntityInstanceOperations({
+      entityDefinitionId,
+      resourceLabel: resource?.label,
+      resourcePlural: resource?.plural,
+      onDrawerClose: onDeleted,
+      onRefetch: onDeleted,
+    })
+
+  const status = record?.status as string | undefined
+  // A merged record is a tombstone — nothing here applies to it.
+  if (status === 'MERGED') return null
+  const isArchived = status === 'ARCHIVED'
+
+  const trigger = TRIGGER_BY_SURFACE[surface]
+  const noun = resource?.label?.toLowerCase() ?? 'record'
+
+  return (
+    <>
+      {/* `modal={false}` so the menu doesn't lock scroll or steal focus from the
+          page/drawer behind it.
+
+          ⚠ NO tooltip on this trigger. Wrapping a `DropdownMenuTrigger` in a
+          Radix tooltip leaves the tooltip mounted over the open menu — it hangs
+          around because the trigger keeps hover/focus while the menu owns
+          pointer events. The label lives on `aria-label` instead, which is what
+          names the button for assistive tech anyway, and matches the drawer's
+          and the table row's kebabs — neither ever had one. */}
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant={trigger.variant}
+            size={trigger.size}
+            aria-label='More actions'
+            title='More actions'
+            className={cn(trigger.className)}>
+            <MoreVertical />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align='end' className='w-56'>
+          {/* Ask for the next rung. FIRST on purpose: everything below is
+              destructive-leaning and this is the one item that ADDS capability.
+              Only at `read` — below that the surface never opened, and at
+              `edit`/`admin` there is nothing left to ask for. */}
+          {access.access === 'read' && !omitted.has('request-access') && (
+            <GranularPermissionsGate>
+              <RecordRequestAccessPopover
+                entityDefinitionId={entityDefinitionId}
+                entityInstanceId={entityInstanceId}
+                variant='menu-item'
+              />
+            </GranularPermissionsGate>
+          )}
+
+          {actions.enableEdit && onEdit && access.canEdit && (
+            <DropdownMenuItem onSelect={onEdit}>
+              <SquarePen />
+              Edit {noun}
+            </DropdownMenuItem>
+          )}
+
+          {actions.enableRename && onRename && access.canEdit && (
+            <DropdownMenuItem onSelect={onRename}>
+              <TextCursorInput />
+              Rename
+            </DropdownMenuItem>
+          )}
+
+          {surface !== 'page' && fullPageLink && (
+            <DropdownMenuItem onSelect={() => router.push(fullPageLink)}>
+              <Expand />
+              Open full page
+            </DropdownMenuItem>
+          )}
+
+          {access.canShare && !omitted.has('share') && (
+            <GranularPermissionsGate>
+              <DropdownMenuItem onSelect={() => setShareOpen(true)}>
+                <Share2 />
+                Share
+              </DropdownMenuItem>
+            </GranularPermissionsGate>
+          )}
+
+          <DropdownMenuSeparator />
+
+          {/* Neither submenu vanishes when empty. `WorkflowSubMenu` always
+              carries a "Create workflow" item wired to this entity definition,
+              so it is never a dead end; app actions disables its branch. A menu
+              whose rows appear and disappear by org configuration is a menu
+              nobody can learn. */}
+          <WorkflowSubMenu recordId={recordId} />
+          <AppRecordActionsSubmenu recordId={recordId} recordType={entityType} />
+
+          {actions.enableAddToSequence && sequencesEnabled && access.canEdit && (
+            <DropdownMenuItem onSelect={() => setSequenceOpen(true)}>
+              <Send />
+              Add to sequence
+            </DropdownMenuItem>
+          )}
+
+          {actions.enableLink && onLink && access.canEdit && (
+            <DropdownMenuItem onSelect={onLink}>
+              <LinkIcon />
+              Link {noun}
+            </DropdownMenuItem>
+          )}
+
+          {/* ⚠ Merge rides the DELETE verb, not the edit floor: it permanently
+              removes the source rows and the server asserts `assertCanDeleteRows`
+              over the target AND every source. */}
+          {actions.enableMerge && access.canDelete && (
+            <DropdownMenuItem onSelect={() => setMergeOpen(true)}>
+              <Merge />
+              Merge
+            </DropdownMenuItem>
+          )}
+
+          {customItems.map((Item, i) => (
+            <Item
+              key={i}
+              recordId={recordId}
+              entityDefinitionId={entityDefinitionId}
+              entityInstanceId={entityInstanceId}
+              entityType={entityType}
+              record={record}
+              resource={resource}
+              access={access}
+            />
+          ))}
+          {children}
+
+          {actions.enableArchive && access.canEdit && !isArchived && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => void handleArchive(entityInstanceId)}>
+                <Archive />
+                Archive
+              </DropdownMenuItem>
+            </>
+          )}
+
+          {access.canDelete && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant='destructive'
+                onSelect={() => void handleDelete(entityInstanceId)}>
+                <Trash2 />
+                Delete
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ConfirmArchiveDialog />
+      <ConfirmDeleteDialog />
+
+      {mergeOpen && (
+        <MergeDialog
+          open={mergeOpen}
+          onOpenChange={setMergeOpen}
+          baseRecordIds={[recordId]}
+          onMergeComplete={() => setMergeOpen(false)}
+        />
+      )}
+
+      {shareOpen && (
+        <InstanceShareDialog recordId={recordId} open={shareOpen} onOpenChange={setShareOpen} />
+      )}
+
+      {sequencesEnabled && sequenceOpen && (
+        <AddToSequenceDialog
+          open={sequenceOpen}
+          onOpenChange={setSequenceOpen}
+          recipientEntityInstanceIds={[entityInstanceId]}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/records/record-drawer-request-access.test.tsx
+++ b/apps/web/src/components/records/record-drawer-request-access.test.tsx
@@ -83,6 +83,22 @@ vi.mock('~/components/permissions/ui/instance-share-dialog', () => ({
 }))
 vi.mock('~/components/records/record-editor-dialog', () => ({ RecordEditorDialog: () => null }))
 vi.mock('~/components/workflow/manual-trigger-button', () => ({ ManualTriggerButton: () => null }))
+vi.mock('~/components/workflow/workflow-submenu', () => ({ WorkflowSubMenu: () => null }))
+vi.mock('~/components/detail-view/components/app-record-actions', () => ({
+  AppRecordActionsSubmenu: () => null,
+}))
+vi.mock('~/components/favorites/ui/favorite-star-button', () => ({
+  FavoriteStarButton: () => null,
+}))
+vi.mock('~/hooks/use-entity-instance-operations', () => ({
+  useEntityInstanceOperations: () => ({
+    canEdit: false,
+    handleArchive: vi.fn(),
+    handleDelete: vi.fn(),
+    ConfirmDeleteDialog: () => null,
+    ConfirmArchiveDialog: () => null,
+  }),
+}))
 vi.mock('~/components/favorites/ui/favorite-toggle-menu-item', () => ({
   FavoriteToggleMenuItem: () => null,
 }))
@@ -94,6 +110,7 @@ vi.mock('~/components/resources/hooks/use-field-values', () => ({
 }))
 vi.mock('~/components/resources', () => ({
   resourceHasDetailPage: () => false,
+  useRecordLink: () => null,
   useRecord: () => ({ record: null, isLoading: false }),
   useResource: () => ({
     resource: {
@@ -150,21 +167,30 @@ beforeEach(() => {
 })
 
 describe('the drawer header pays NOTHING to render the request trigger (§8.5 / D6)', () => {
-  it('fires no preflight on open, and exactly one when the popover is opened', async () => {
+  // The trigger now lives inside the shared `RecordActionsMenu`, which makes the
+  // laziness STRICTER, not weaker: Radix does not mount `DropdownMenuContent`'s
+  // subtree until the menu is opened, so the popover's body cannot run for a
+  // member who never opens the menu at all.
+  it('fires no preflight on open, none on opening the menu, and exactly one on the item', async () => {
     render(<RecordDrawer open recordId={RECORD_ID as never} />)
+    expect(h.preflightCalls).toHaveLength(0)
 
-    const trigger = screen.getByRole('button', { name: 'Request edit access' })
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    // The item is mounted and labelled — still without asking the server.
+    const trigger = screen.getByRole('menuitem', { name: 'Request edit access' })
     expect(h.preflightCalls).toHaveLength(0)
 
     await userEvent.click(trigger)
     expect(h.preflightCalls).toEqual([{ entityDefinitionId: DEF, entityInstanceId: ROW }])
   })
 
-  it('does not mount the trigger at all for an `edit` row — and still asks nothing', () => {
+  it('does not mount the trigger at all for an `edit` row — and still asks nothing', async () => {
     h.access = 'edit'
     render(<RecordDrawer open recordId={RECORD_ID as never} />)
 
-    expect(screen.queryByRole('button', { name: /Request/ })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+
+    expect(screen.queryByRole('menuitem', { name: /Request/ })).not.toBeInTheDocument()
     expect(h.preflightCalls).toHaveLength(0)
   })
 })

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -4,56 +4,28 @@
 import { formatToDisplayValue, parseRecordId, type RecordId } from '@auxx/lib/field-values/client'
 import { getEntityDrawerConfig } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@auxx/ui/components/dropdown-menu'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { formatDistanceToNow } from 'date-fns'
-import {
-  Archive,
-  Edit,
-  Expand,
-  Link as LinkIcon,
-  Merge,
-  MoreHorizontal,
-  Share2,
-  TextCursorInput,
-  Trash,
-  Trash2,
-} from 'lucide-react'
+import { Expand } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import * as React from 'react'
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
 import { getHeaderActions } from '~/components/drawers/drawer-action-registry'
-import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
+import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
 import { ConnectorSourceBadge } from '~/components/fields/connector-source-badge'
 import { Tooltip } from '~/components/global/tooltip'
 import { CommandContext, RecordCommandActions } from '~/components/kbar/contextual'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
-import { GranularPermissionsGate } from '~/components/mail-permissions/ui/granular-permissions-gate'
-import { MergeDialog } from '~/components/merge'
-import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
-import { RecordRequestAccessPopover } from '~/components/permissions/ui/record-request-access-popover'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
-import {
-  resourceHasDetailPage,
-  useRecord,
-  useRecordAccess,
-  useResource,
-} from '~/components/resources'
+import { resourceHasDetailPage, useRecord, useResource } from '~/components/resources'
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
 import { AvatarUploadIcon } from '~/components/resources/ui/avatar-upload-icon'
 import { RecordIcon } from '~/components/resources/ui/record-icon'
-import { ManualTriggerButton } from '~/components/workflow/manual-trigger-button'
-import { useConfirm } from '~/hooks/use-confirm'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useDockStore } from '~/stores/dock-store'
+import { RecordActionsMenu } from './record-actions-menu'
 import { useRecordDrawerReadOnly } from './use-record-drawer-read-only'
 
 /** Props for RecordDrawer */
@@ -112,7 +84,7 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   )
 
   // Get drawer config for entity-type-aware actions
-  const drawerConfig = React.useMemo(() => {
+  const _drawerConfig = React.useMemo(() => {
     return entityType ? getEntityDrawerConfig(entityType, entityDefinitionId || undefined) : null
   }, [entityType, entityDefinitionId])
 
@@ -201,36 +173,23 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   // Edit dialog state
   const [editDialogOpen, setEditDialogOpen] = React.useState(false)
 
-  // Merge dialog state
-  const [mergeDialogOpen, setMergeDialogOpen] = React.useState(false)
+  // Merge, share and delete-confirm all moved into `RecordActionsMenu`, which
+  // owns the dialogs it opens. Per-record sharing keeps its `_access` gate
+  // there (plan v3/03 §6.2) — it is a different question from `readOnly`, since
+  // an editable row that is NOT re-shareable is the common case.
 
-  // Per-record sharing (plan v3/03 §6.2). Keyed off the row's `_access` stamp,
-  // NOT off `readOnly`: a member may hold `admin` on a row and still be looking
-  // at it read-only is impossible (admin implies edit), but the reverse — an
-  // editable row that is NOT re-shareable — is the common case, so the two gates
-  // are genuinely different questions.
-  const [shareDialogOpen, setShareDialogOpen] = React.useState(false)
-  const { access, canShare } = useRecordAccess(recordId)
-
-  // Confirm dialog for delete
-  const [confirm, ConfirmDialog] = useConfirm()
-
-  // In restricted mode every mutating action is forced off — this collapses
-  // `hasMoreActions` and the standalone delete button below, matching the
-  // read-only fields (§11.4, deliverable #4).
-  const actions = React.useMemo(() => {
-    const base = drawerConfig?.actions
-    if (!readOnly) return base
-    return {
-      ...base,
-      enableEdit: false,
-      enableRename: false,
-      enableArchive: false,
-      enableLink: false,
-      enableMerge: false,
-      enableDelete: false,
-    }
-  }, [drawerConfig?.actions, readOnly])
+  /**
+   * Focus the inline title input for the Rename item.
+   *
+   * Drawer-only: nothing else in the app has a `#drawer-title-input`, which is
+   * why {@link RecordActionsMenu} takes this as a callback rather than owning
+   * it — an item whose target does not exist on a surface must not render there.
+   */
+  const handleRename = React.useCallback(() => {
+    const input = document.getElementById('drawer-title-input') as HTMLInputElement | null
+    input?.focus()
+    input?.select()
+  }, [])
 
   /** Handle close */
   const handleClose = React.useCallback(() => {
@@ -241,21 +200,6 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   const handleCreateNoteClick = React.useCallback(() => {
     setFocusComposerTrigger((prev) => prev + 1)
   }, [])
-
-  /** Handle delete with confirmation */
-  const handleDelete = React.useCallback(async () => {
-    if (!onDeleteInstance || !entityInstanceId) return
-    const confirmed = await confirm({
-      title: `Delete ${resource?.label?.toLowerCase() || 'record'}`,
-      description: 'Are you sure? This action cannot be undone.',
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      destructive: true,
-    })
-    if (confirmed) {
-      await onDeleteInstance(entityInstanceId)
-    }
-  }, [confirm, onDeleteInstance, entityInstanceId, resource?.label])
 
   /** Handle expand to full page */
   const handleExpand = React.useCallback(() => {
@@ -275,18 +219,6 @@ export const RecordDrawer = React.memo(function RecordDrawer({
         : null,
     [cachedRecord?.createdAt]
   )
-
-  // Check if we need a "more actions" dropdown (for edit, rename, archive, link, merge)
-  const hasMoreActions =
-    actions?.enableEdit ||
-    actions?.enableRename ||
-    actions?.enableArchive ||
-    actions?.enableLink ||
-    actions?.enableMerge ||
-    // Sharing is not a WRITE on the record, so it survives `readOnly` (which
-    // forces every `enable*` above to false). Without this term a row shared at
-    // `admin` on an otherwise-uneditable def would have no dropdown to host it.
-    canShare
 
   if (!open || !recordId) return null
 
@@ -343,133 +275,31 @@ export const RecordDrawer = React.memo(function RecordDrawer({
                 />
               ))}
 
-            {/* Run workflow — hidden in restricted mode (a mutating trigger). */}
-            {!readOnly && (
-              <ManualTriggerButton
-                recordId={recordId}
-                buttonVariant='ghost'
-                buttonSize='icon-xs'
-                buttonClassName='rounded-full'
-                tooltipContent='Run workflow'
-              />
-            )}
+            {/* Everything else — run workflow, app actions, share, request
+                access, rename, merge, archive, delete — is the SHARED menu, the
+                same component the detail page and the records-table row render.
+                It resolves its own per-row gate from the `_access` stamp, which
+                is the same question `readOnly` above answers, so no extra
+                restricted-mode term is needed here.
 
-            {/* Ask for the next rung (plan v3/04 §8.2, mount 1). Only at `read`:
-                below that the drawer never opened, and at `edit`/`admin` there is
-                nothing left to ask for. Gated because an approved request writes
-                a grant the org's plan must be able to honour (§3.5 / §8.4). */}
-            {access === 'read' && entityDefinitionId && entityInstanceId && (
-              <GranularPermissionsGate>
-                <RecordRequestAccessPopover
-                  entityDefinitionId={entityDefinitionId}
-                  entityInstanceId={entityInstanceId}
-                  variant='icon'
-                />
-              </GranularPermissionsGate>
-            )}
-
-            {/* More actions dropdown */}
-            {hasMoreActions && (
-              <DropdownMenu modal={false}>
-                <DropdownMenuTrigger asChild>
-                  <Button variant='ghost' size='icon-xs' className='rounded-full'>
-                    <MoreHorizontal />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align='end' className='w-48'>
-                  {actions?.enableEdit && (
-                    <DropdownMenuItem onClick={() => setEditDialogOpen(true)}>
-                      <Edit />
-                      Edit {resource?.label?.toLowerCase() || 'record'}
-                    </DropdownMenuItem>
-                  )}
-
-                  {entityDefinitionId && entityInstanceId && (
-                    <FavoriteToggleMenuItem
-                      targetType='ENTITY_INSTANCE'
-                      targetIds={{ entityDefinitionId, entityInstanceId }}
-                    />
-                  )}
-
-                  {canShare && (
-                    <GranularPermissionsGate>
-                      <DropdownMenuItem onClick={() => setShareDialogOpen(true)}>
-                        <Share2 />
-                        Share
-                      </DropdownMenuItem>
-                    </GranularPermissionsGate>
-                  )}
-
-                  {actions?.enableRename && (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        // Focus the title input if it exists
-                        const input = document.getElementById(
-                          'drawer-title-input'
-                        ) as HTMLInputElement
-                        if (input) {
-                          input.focus()
-                          input.select()
-                        }
-                      }}>
-                      <TextCursorInput />
-                      Rename
-                    </DropdownMenuItem>
-                  )}
-
-                  {actions?.enableArchive && (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        // Archive handled by parent via onDeleteInstance pattern
-                      }}>
-                      <Archive />
-                      Archive
-                    </DropdownMenuItem>
-                  )}
-
-                  {(actions?.enableEdit || actions?.enableRename || actions?.enableArchive) &&
-                    (actions?.enableMerge || actions?.enableLink || actions?.enableDelete) && (
-                      <DropdownMenuSeparator />
-                    )}
-
-                  {actions?.enableMerge && recordId && (
-                    <DropdownMenuItem onClick={() => setMergeDialogOpen(true)}>
-                      <Merge />
-                      Merge
-                    </DropdownMenuItem>
-                  )}
-
-                  {actions?.enableLink && (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        // Link dialog is rendered via tab card (relationships card has its own link button)
-                      }}>
-                      <LinkIcon />
-                      Link {resource?.label?.toLowerCase() || 'record'}
-                    </DropdownMenuItem>
-                  )}
-
-                  {actions?.enableDelete && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem variant='destructive' onClick={handleDelete}>
-                        <Trash2 />
-                        Delete
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-
-            {/* Delete (if no more actions dropdown, show standalone delete button) */}
-            {!hasMoreActions && actions?.enableDelete !== false && (
-              <Tooltip content={`Delete ${resource?.label?.toLowerCase() || 'record'}`}>
-                <Button variant='outline' size='icon-xs' onClick={handleDelete}>
-                  <Trash className='text-bad-500' />
-                </Button>
-              </Tooltip>
-            )}
+                Gone with it: an Archive item and a Link item whose onClick
+                bodies were empty comments, and a standalone delete button that
+                only appeared when the dropdown didn't. */}
+            <FavoriteStarButton
+              targetType='ENTITY_INSTANCE'
+              targetIds={{ entityDefinitionId, entityInstanceId }}
+              size='icon-xs'
+              className='rounded-full'
+            />
+            <RecordActionsMenu
+              recordId={recordId}
+              entityType={entityType ?? ''}
+              record={cachedRecord}
+              surface='drawer'
+              onEdit={() => setEditDialogOpen(true)}
+              onRename={handleRename}
+              onDeleted={handleClose}
+            />
 
             {/* Expand to full page — only for types that have a detail page
                 (no catch-all route; page-less system types would 404) */}
@@ -546,31 +376,6 @@ export const RecordDrawer = React.memo(function RecordDrawer({
           }}
         />
       )}
-
-      {/* Merge Dialog */}
-      {mergeDialogOpen && recordId && (
-        <MergeDialog
-          open={mergeDialogOpen}
-          onOpenChange={setMergeDialogOpen}
-          baseRecordIds={[recordId]}
-          onMergeComplete={() => {
-            setMergeDialogOpen(false)
-            onMutationSuccess?.()
-          }}
-        />
-      )}
-
-      {/* Per-record sharing (plan v3/03 §6.2). The server re-asserts
-          `_access >= admin` on every grant write; this only decides the UI. */}
-      {shareDialogOpen && recordId && (
-        <InstanceShareDialog
-          recordId={recordId}
-          open={shareDialogOpen}
-          onOpenChange={setShareDialogOpen}
-        />
-      )}
-
-      <ConfirmDialog />
     </>
   )
 })

--- a/apps/web/src/components/resources/index.ts
+++ b/apps/web/src/components/resources/index.ts
@@ -33,6 +33,8 @@ export {
   useResources,
   useViewableResources,
 } from './hooks'
+/** The resolved per-ROW verdict every record affordance gates on. */
+export type { RecordRowAccess } from './hooks/use-record-access'
 // Provider
 export { clearResourceCaches, ResourceProvider } from './providers/resource-provider'
 

--- a/apps/web/src/components/workflow/manual-trigger-button.tsx
+++ b/apps/web/src/components/workflow/manual-trigger-button.tsx
@@ -70,25 +70,26 @@ interface ManualTriggerButtonProps {
   children?: ReactNode
 }
 
+/** A manually-triggerable workflow as the picker renders it. */
+interface ManualWorkflow {
+  id: string
+  name: string
+}
+
 /**
- * ManualTriggerButton component for triggering workflows on resources
+ * The query + trigger half of the manual-workflow picker, without any chrome.
+ *
+ * Kept separate from the component body so the query/trigger pair reads on its
+ * own. The submenu form lives in `workflow-submenu.tsx` (`WorkflowSubMenu`),
+ * which predates this file's involvement and is what `RecordActionsMenu` uses —
+ * a Radix `DropdownMenu` cannot nest inside a `DropdownMenuItem`, so the two
+ * genuinely are different components rather than one with a variant.
  */
-export function ManualTriggerButton({
-  // entityDefinitionId,
-  recordId,
-  buttonVariant = 'ghost',
-  buttonSize = 'icon-sm',
-  tooltipContent = 'Trigger workflow',
-  buttonClassName,
-  onSuccess,
-  children,
-}: ManualTriggerButtonProps) {
-  const { entityDefinitionId, entityInstanceId } = recordId
-    ? parseRecordId(recordId)
-    : { entityDefinitionId: '', entityInstanceId: '' }
+function useManualTrigger(recordId: RecordId, onSuccess?: () => void) {
+  const { entityDefinitionId } = recordId ? parseRecordId(recordId) : { entityDefinitionId: '' }
 
   // Store ref to selected workflow for use in onSuccess
-  const selectedWorkflowRef = useRef<{ id: string; name: string } | null>(null)
+  const selectedWorkflowRef = useRef<ManualWorkflow | null>(null)
   // Query available workflows for this entity
   const { data: workflows, isLoading: workflowsLoading } = api.workflow.getManualWorkflows.useQuery(
     { entityDefinitionId },
@@ -120,23 +121,43 @@ export function ManualTriggerButton({
       },
     })
 
+  const trigger = (workflow: ManualWorkflow) => {
+    selectedWorkflowRef.current = workflow
+    triggerWorkflow({ workflowAppId: workflow.id, recordId })
+  }
+
+  return {
+    workflows: workflows as ManualWorkflow[] | undefined,
+    isLoading: workflowsLoading || triggerLoading,
+    trigger,
+  }
+}
+
+/**
+ * ManualTriggerButton component for triggering workflows on resources
+ */
+export function ManualTriggerButton({
+  // entityDefinitionId,
+  recordId,
+  buttonVariant = 'ghost',
+  buttonSize = 'icon-sm',
+  tooltipContent = 'Trigger workflow',
+  buttonClassName,
+  onSuccess,
+  children,
+}: ManualTriggerButtonProps) {
+  const {
+    workflows,
+    isLoading,
+    trigger: handleTriggerWorkflow,
+  } = useManualTrigger(recordId, onSuccess)
+
   // Show button only if workflows exist
   const shouldShow = useMemo(() => {
     return workflows && workflows.length > 0
   }, [workflows])
 
   if (!shouldShow) return null
-
-  const isLoading = workflowsLoading || triggerLoading
-
-  /** Handle workflow selection from dropdown */
-  const handleTriggerWorkflow = (workflow: { id: string; name: string }) => {
-    selectedWorkflowRef.current = workflow
-    triggerWorkflow({
-      workflowAppId: workflow.id,
-      recordId,
-    })
-  }
 
   /** Default button trigger */
   const defaultTrigger = (

--- a/apps/web/src/components/workflow/workflow-submenu.tsx
+++ b/apps/web/src/components/workflow/workflow-submenu.tsx
@@ -2,17 +2,21 @@
 
 // apps/web/src/components/workflow/workflow-submenu.tsx
 
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import {
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { toastError } from '@auxx/ui/components/toast'
-import { Loader2, Play } from 'lucide-react'
+import { Loader2, Play, Plus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useRef } from 'react'
 import { createWorkflowInvalidator } from '~/components/workflow/utils/invalidate-resource'
+import { useAccess } from '~/providers/capabilities-provider'
 import { useWorkflowRunStatusStore } from '~/stores/workflow-run-status-store'
 import { api } from '~/trpc/react'
 import { showWorkflowProgressToast } from './workflow-progress-toast'
@@ -35,9 +39,14 @@ interface WorkflowSubMenuProps {
  * Shows "No workflows available" if none exist.
  */
 export function WorkflowSubMenu({ recordId, onSuccess }: WorkflowSubMenuProps) {
-  const { entityDefinitionId, entityInstanceId } = recordId
-    ? parseRecordId(recordId)
-    : { entityDefinitionId: '', entityInstanceId: '' }
+  const router = useRouter()
+  const { entityDefinitionId } = recordId ? parseRecordId(recordId) : { entityDefinitionId: '' }
+
+  // Running a workflow is the `view` rung, so the list itself needs no gate.
+  // CREATING one is a different action on a different area — coarse
+  // `workflows.manage`, the same key `mass-workflow-trigger-dialog` uses.
+  const { can } = useAccess()
+  const canCreateWorkflow = can(PermissionKey.workflowsManage)
 
   // Store ref to selected workflow for use in onSuccess
   const selectedWorkflowRef = useRef<{ id: string; name: string } | null>(null)
@@ -72,6 +81,18 @@ export function WorkflowSubMenu({ recordId, onSuccess }: WorkflowSubMenuProps) {
         title: 'Failed to trigger workflow',
         description: error.message,
       })
+    },
+  })
+
+  // Creates a manual-trigger workflow already wired to this entity definition
+  // and drops the user into the builder — the same mutation the bulk dialog's
+  // "Create Workflow" escape hatch calls.
+  const createForResource = api.workflow.createForResource.useMutation({
+    onSuccess: (created) => {
+      if (created?.id) router.push(`/app/workflows/${created.id}`)
+    },
+    onError: (error) => {
+      toastError({ title: 'Failed to create workflow', description: error.message })
     },
   })
 
@@ -113,6 +134,22 @@ export function WorkflowSubMenu({ recordId, onSuccess }: WorkflowSubMenuProps) {
             No workflows available
           </DropdownMenuItem>
         )}
+
+        {/* Always present, so the submenu is never a dead end — an entity with
+            no manual workflows is the case where "create one" is MOST useful,
+            and it is exactly the case where the list above says nothing
+            actionable. Disabled rather than hidden without `workflows.manage`:
+            the capability exists, this member just lacks it, and a row that
+            silently vanishes teaches nothing. */}
+        {hasWorkflows ? <DropdownMenuSeparator /> : null}
+        <DropdownMenuItem
+          disabled={
+            !canCreateWorkflow || createForResource.isPending || entityDefinitionId.length === 0
+          }
+          onSelect={() => createForResource.mutate({ entityDefinitionId })}>
+          {createForResource.isPending ? <Loader2 className='animate-spin' /> : <Plus />}
+          Create workflow
+        </DropdownMenuItem>
       </DropdownMenuSubContent>
     </DropdownMenuSub>
   )

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -81,12 +81,31 @@ process.env.APP_URL = 'http://localhost:3000'
 process.env.NEXT_PUBLIC_ENV = 'development'
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test'
 
-// Mock ResizeObserver
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}))
+/**
+ * Mock ResizeObserver — a real CLASS, not `vi.fn().mockImplementation(...)`.
+ *
+ * floating-ui's `autoUpdate` does `new ResizeObserver(...)`, and a mock whose
+ * implementation returns an object literal is not a valid constructor there, so
+ * every Radix popper (dropdown, popover, tooltip content) threw
+ * "is not a constructor" the moment it opened. `records-view-request-access.test.tsx`
+ * carried a local `NoopResizeObserver` + `vi.stubGlobal` workaround for exactly
+ * this; hoisting it here means the next test that opens a menu doesn't have to
+ * rediscover it.
+ */
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = NoopResizeObserver
+
+// jsdom implements none of the Pointer Capture API, which Radix menus call on
+// pointer-down. Without these, opening a menu with `userEvent` throws.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+  Element.prototype.setPointerCapture = () => {}
+  Element.prototype.releasePointerCapture = () => {}
+}
 
 // Mock IntersectionObserver
 global.IntersectionObserver = vi.fn().mockImplementation(() => ({

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -36,7 +36,6 @@ export {
   hasDetailViewConfig,
 } from './registry/detail-view-config'
 export type {
-  DetailViewActions,
   DetailViewConfig,
   DetailViewConfigRegistry,
   DetailViewEntityType,
@@ -56,7 +55,6 @@ export {
   hasDrawerConfig,
 } from './registry/drawer-config'
 export type {
-  DrawerActions,
   DrawerConfig,
   DrawerConfigRegistry,
   DrawerTabCardDefinition,
@@ -99,6 +97,12 @@ export {
 } from './registry/field-utils'
 // Hover-card field defaults
 export { getHoverCardFieldKeys, HOVER_CARD_FIELDS } from './registry/hover-card-fields'
+export {
+  DEFAULT_RECORD_ACTIONS,
+  getRecordActions,
+  RECORD_ACTIONS_REGISTRY,
+} from './registry/record-actions-config'
+export type { RecordActions } from './registry/record-actions-types'
 export type {
   CustomResource,
   CustomResourceId,

--- a/packages/lib/src/resources/registry/detail-view-config-types.ts
+++ b/packages/lib/src/resources/registry/detail-view-config-types.ts
@@ -48,24 +48,11 @@ export interface SidebarTabDefinition {
 }
 
 /**
- * Header action capabilities for detail views
- */
-export interface DetailViewActions {
-  enableGroups?: boolean
-  enableMerge?: boolean
-  enableSpam?: boolean
-  enableArchive?: boolean
-  enableDelete?: boolean
-  enableWorkflowTrigger?: boolean
-  /** Sequences plan §17 — "Add to sequence" opens `AddToSequenceDialog` for this record. */
-  enableAddToSequence?: boolean
-}
-
-/**
  * Complete detail view configuration for an entity type
  * NOTE: Does NOT include entity metadata (label, icon, color, etc.)
  * That comes from the Resource via useResourceProperty hook.
- * This ONLY contains detail-view-specific config (tabs, actions).
+ * This ONLY contains detail-view-specific config (tabs, layout). Record ACTIONS
+ * are not here — they are one shared registry, `record-actions-config.ts`.
  */
 export interface DetailViewConfig {
   /** Entity type identifier (ModelType: 'contact', 'ticket', 'part', 'entity') */
@@ -74,8 +61,6 @@ export interface DetailViewConfig {
   mainTabs: MainTabDefinition[]
   /** Tabs shown in sidebar (Overview, Comments) */
   sidebarTabs: SidebarTabDefinition[]
-  /** Header actions */
-  actions: DetailViewActions
   /** Default main tab to select */
   defaultTab?: string
   /** Default sidebar tab to select */

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -35,12 +35,6 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],
     sidebarTabs: DEFAULT_SIDEBAR_TABS,
-    actions: {
-      enableGroups: true,
-      enableMerge: true,
-      enableSpam: true,
-      enableAddToSequence: true,
-    },
     defaultTab: 'tickets',
     defaultSidebarTab: 'overview',
     // Renders nothing when the contact has no external identities (card
@@ -63,10 +57,6 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],
     sidebarTabs: DEFAULT_SIDEBAR_TABS,
-    actions: {
-      enableArchive: true,
-      enableMerge: true,
-    },
     defaultTab: 'conversation',
     defaultSidebarTab: 'overview',
     sidebarCards: [
@@ -89,10 +79,6 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],
     sidebarTabs: DEFAULT_SIDEBAR_TABS,
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-    },
     defaultTab: 'inventory',
     defaultSidebarTab: 'overview',
   },
@@ -124,7 +110,6 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // line-items tab's own header strip — see quote-line-items-tab.tsx (money
     // MQ1 build spec §H.3: DetailViewActions only exposes generic capability
     // flags, no per-entity extension point exists yet).
-    actions: {},
     defaultTab: 'line-items',
     defaultSidebarTab: 'overview',
     sidebarCards: [
@@ -173,7 +158,6 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],
     sidebarTabs: DEFAULT_SIDEBAR_TABS,
-    actions: {},
     defaultTab: 'schedule',
     defaultSidebarTab: 'overview',
     sidebarCards: [
@@ -190,11 +174,6 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],
     sidebarTabs: DEFAULT_SIDEBAR_TABS,
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-      enableWorkflowTrigger: true,
-    },
     defaultTab: 'timeline',
     defaultSidebarTab: 'overview',
   },

--- a/packages/lib/src/resources/registry/drawer-config-types.ts
+++ b/packages/lib/src/resources/registry/drawer-config-types.ts
@@ -25,20 +25,6 @@ export interface DrawerTabDefinition {
 }
 
 /**
- * Drawer action capabilities
- */
-export interface DrawerActions {
-  enableMerge?: boolean
-  enableGroups?: boolean
-  enableAssign?: boolean
-  enableArchive?: boolean
-  enableDelete?: boolean
-  enableLink?: boolean
-  enableRename?: boolean
-  enableEdit?: boolean
-}
-
-/**
  * Card definition injected into base drawer tabs (overview, timeline, comments, tasks)
  */
 export interface DrawerTabCardDefinition {
@@ -76,15 +62,14 @@ export interface DrawerTabCardDefinition {
  * Complete drawer configuration for an entity type
  * NOTE: Does NOT include entity metadata (label, icon, color, etc.)
  * That comes from the Resource via useResource hook.
- * This ONLY contains drawer-specific config (tabs, actions).
+ * This ONLY contains drawer-specific config (tabs, cards). Record ACTIONS are
+ * not here — they are one shared registry, `record-actions-config.ts`.
  */
 export interface DrawerConfig {
   /** Entity type identifier (for system entities: 'contact', 'ticket', etc.) */
   entityType: string
   /** Additional tabs beyond Overview, Timeline, Comments */
   additionalTabs: DrawerTabDefinition[]
-  /** Action capabilities */
-  actions: DrawerActions
   /** Cards injected into base tabs (overview, timeline, comments, tasks). Key is tab value. */
   tabCards?: Record<string, DrawerTabCardDefinition[]>
 }

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -4,7 +4,8 @@ import type { DrawerConfig, DrawerConfigRegistry } from './drawer-config-types'
 
 /**
  * Drawer configuration registry
- * ONLY contains drawer-specific config (tabs, actions)
+ * ONLY contains drawer-specific config (tabs, cards) — record actions live in
+ * `record-actions-config.ts`
  * - Tab metadata (value, label, icon) - NOT React components
  * - Action capabilities
  *
@@ -18,12 +19,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       { value: 'tickets', label: 'Tickets', icon: 'ticket', recordResource: 'ticket' },
       { value: 'conversations', label: 'Conversations', icon: 'mail' },
     ],
-    actions: {
-      enableMerge: true,
-      enableGroups: true,
-      enableArchive: true,
-      enableDelete: true,
-    },
     tabCards: {
       overview: [
         {
@@ -41,23 +36,11 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     additionalTabs: [
       { value: 'parts', label: 'Parts', icon: 'package', recordResource: 'vendor_part' },
     ],
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-    },
   },
 
   ticket: {
     entityType: 'ticket',
     additionalTabs: [{ value: 'conversation', label: 'Conversation', icon: 'mail' }],
-    actions: {
-      enableEdit: true,
-      enableRename: true,
-      enableMerge: true,
-      enableArchive: true,
-      enableLink: true,
-      enableDelete: true,
-    },
     tabCards: {
       overview: [
         { value: 'metrics', label: 'Metrics', position: 'before', fullBleed: true },
@@ -73,10 +56,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       { value: 'subparts', label: 'Subparts', icon: 'layers', recordResource: 'subpart' },
       { value: 'vendors', label: 'Suppliers', icon: 'truck', recordResource: 'vendor_part' },
     ],
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-    },
     tabCards: {
       overview: [{ value: 'inventory', label: 'Inventory' }],
     },
@@ -85,10 +64,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
   service_request: {
     entityType: 'service_request',
     additionalTabs: [],
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-    },
     // Related work orders + quotes rendered as uniform overview blocks (styled like
     // the ticket customer block). The `workOrders`/`quotes` inverse fields are hidden
     // from the Details field panel (showInPanel:false) so they only appear here.
@@ -108,10 +83,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
   work_order: {
     entityType: 'work_order',
     additionalTabs: [],
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-    },
     // Schedule (visits + schedule popover) and Invoices (list + gather dialog) as
     // uniform overview blocks — the quote/line-items relationship fields are hidden
     // from the Details panel (showInPanel:false) so they only surface here.
@@ -148,10 +119,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     // cards and detail-page sidebarCards are independent lists, so this
     // never leaks onto the detail page.
     additionalTabs: [],
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-    },
     tabCards: {
       overview: [
         {
@@ -175,12 +142,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     // Drawer-only entity (01-ui #10 lock, hasDetailPage: false) — no additionalTabs, the
     // entire lifecycle/line/payment UI lives in overview tabCards (money MI1 build spec §J.1).
     additionalTabs: [],
-    actions: {
-      // No enableArchive — invoices are ledger records, delete is the only removal path
-      // (the §G.5 override in use-entity-instance-operations.tsx routes it to
-      // `money.deleteInvoice`, which enforces the payments guard + source-line unstamp).
-      enableDelete: true,
-    },
     tabCards: {
       overview: [
         {
@@ -208,7 +169,7 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
 
 /**
  * Get drawer configuration for entity type
- * Returns ONLY drawer-specific config (tabs, actions)
+ * Returns ONLY drawer-specific config (tabs, cards)
  * Entity metadata comes from Resource object
  */
 export function getEntityDrawerConfig(
@@ -224,10 +185,6 @@ export function getEntityDrawerConfig(
   return {
     entityType: entityDefinitionId ?? entityType,
     additionalTabs: [],
-    actions: {
-      enableArchive: true,
-      enableDelete: true,
-    },
   }
 }
 

--- a/packages/lib/src/resources/registry/index.ts
+++ b/packages/lib/src/resources/registry/index.ts
@@ -198,7 +198,6 @@ export {
   hasDetailViewConfig,
 } from './detail-view-config'
 export type {
-  DetailViewActions,
   DetailViewConfig,
   DetailViewConfigRegistry,
   DetailViewEntityType,
@@ -211,7 +210,6 @@ export { RESOURCE_DISPLAY_CONFIG } from './display-config'
 // Re-export drawer configuration
 export { DRAWER_CONFIG_REGISTRY, getEntityDrawerConfig, hasDrawerConfig } from './drawer-config'
 export type {
-  DrawerActions,
   DrawerConfig,
   DrawerConfigRegistry,
   DrawerTabCardDefinition,
@@ -236,6 +234,12 @@ export {
   setResourceVariables,
   sortFieldsForDisplay,
 } from './field-utils'
+export {
+  DEFAULT_RECORD_ACTIONS,
+  getRecordActions,
+  RECORD_ACTIONS_REGISTRY,
+} from './record-actions-config'
+export type { RecordActions } from './record-actions-types'
 // Re-export resource computation and service
 export { computeAllResources } from './resource-registry-compute'
 export { ResourceRegistryService } from './resource-registry-service'

--- a/packages/lib/src/resources/registry/record-actions-config.ts
+++ b/packages/lib/src/resources/registry/record-actions-config.ts
@@ -1,0 +1,60 @@
+// packages/lib/src/resources/registry/record-actions-config.ts
+
+import type { RecordActions } from './record-actions-types'
+
+/**
+ * **The single answer to "which actions does this record type offer?"**
+ *
+ * Previously this lived twice — `DrawerConfig.actions` and
+ * `DetailViewConfig.actions` — and the two disagreed. The drawer gave every type
+ * archive and delete; the detail view gave delete to `part` and `entity` only,
+ * archive to `ticket`/`part`/`entity` only, and workflow-trigger to `entity`
+ * only. Nothing reconciled them, so the same contact was deletable from its
+ * table row and its drawer but not from its own detail page, and offered "Run
+ * workflow" in the drawer but not on the page.
+ *
+ * Keeping one registry is the point: a surface cannot disagree with another
+ * surface about a record type if there is only one place to read the answer.
+ *
+ * Values below are the union of the two old registries, taking the drawer's
+ * answer wherever they conflicted — it was the complete one, and the detail
+ * view's gaps read as unfinished rather than intentional (`contact` had neither
+ * archive nor delete while carrying a Spam button that had no mutation behind
+ * it).
+ */
+export const RECORD_ACTIONS_REGISTRY: Record<string, RecordActions> = {
+  contact: { enableMerge: true, enableAddToSequence: true, enableArchive: true },
+  company: { enableArchive: true },
+  ticket: {
+    enableEdit: true,
+    enableRename: true,
+    enableMerge: true,
+    enableLink: true,
+    enableArchive: true,
+  },
+  part: { enableArchive: true },
+  service_request: { enableArchive: true },
+  work_order: { enableArchive: true },
+  quote: { enableArchive: true },
+  /**
+   * No `enableArchive` — invoices are ledger records and delete is the only
+   * removal path. This is the one entry that makes `enableArchive` a real flag
+   * rather than a constant; treat it as load-bearing.
+   */
+  invoice: {},
+}
+
+/**
+ * Fallback for custom definitions (every one reports `entityType: 'entity'`) and
+ * for any system type not listed above.
+ */
+export const DEFAULT_RECORD_ACTIONS: RecordActions = { enableArchive: true }
+
+/**
+ * Resolve the offered actions for a record type.
+ *
+ * @param entityType - ModelType from `resource.entityType`; `'entity'` for custom definitions.
+ */
+export function getRecordActions(entityType: string): RecordActions {
+  return RECORD_ACTIONS_REGISTRY[entityType] ?? DEFAULT_RECORD_ACTIONS
+}

--- a/packages/lib/src/resources/registry/record-actions-types.ts
+++ b/packages/lib/src/resources/registry/record-actions-types.ts
@@ -1,0 +1,57 @@
+// packages/lib/src/resources/registry/record-actions-types.ts
+
+/**
+ * The record-action flags, shared by the detail view, the record drawer and the
+ * records-table row menu — every surface that renders `RecordActionsMenu`.
+ *
+ * This replaces two near-duplicate interfaces (`DetailViewActions`,
+ * `DrawerActions`) that overlapped on only four names and disagreed about the
+ * rest, which is how the same contact ended up deletable from the table row and
+ * not from its own detail page.
+ *
+ * ⚠ **A flag here means "this record type offers the action at all", never "this
+ * member may perform it."** Authorization is the per-ROW `_access` stamp,
+ * resolved once in `useRecordAccess` and applied by the menu. A flag that tries
+ * to encode permission just adds a second, quieter authority that drifts from
+ * the server's.
+ *
+ * Deliberately ABSENT, and why:
+ * - **Delete / Share / Open full page / App actions** — universal.
+ *   `useEntityInstanceOperations` routes every type through the generic
+ *   `record.delete`, with per-type safety in the server's `deleteEntity`
+ *   pre-delete hooks, so a flag could only withhold an action the member is
+ *   entitled to. The old `enableDelete` is exactly why a contact was deletable
+ *   from the table row and not from its own detail page.
+ * - **Run workflow** — `ManualTriggerSubmenu` already disables itself when the
+ *   definition has no manual workflows, which is the same question a flag would
+ *   be answering, only from stale hand-maintained data.
+ * - **Groups** — the button set state nothing read, and no group-assignment
+ *   dialog exists anywhere in the app.
+ * - **Spam** — no mutation exists to write it. SPAM is a mail/thread status;
+ *   `Contact.status` carries the value but nothing in the product sets it.
+ */
+export interface RecordActions {
+  /**
+   * Offer Archive. NOT universal, unlike Delete: `invoice` withholds it because
+   * invoices are ledger records for which delete is the only removal path.
+   */
+  enableArchive?: boolean
+  /**
+   * Merge this record into another.
+   *
+   * ⚠ Gated on the DELETE verb, not edit: a merge permanently removes the source
+   * rows and the server asserts `assertCanDeleteRows` over the target and every
+   * source (`routers/record.ts`).
+   */
+  enableMerge?: boolean
+  /** Open the surface's record-editor dialog. */
+  enableEdit?: boolean
+  /** Focus the surface's inline title input. Drawer-only — nothing else has one. */
+  enableRename?: boolean
+  /** Link this record to another. */
+  enableLink?: boolean
+  /** Assign the record to a member. */
+  enableAssign?: boolean
+  /** Sequences plan §17 — "Add to sequence" opens `AddToSequenceDialog`. */
+  enableAddToSequence?: boolean
+}


### PR DESCRIPTION
## The problem

Three surfaces — the detail page, the record drawer, the records-table row — each hand-rolled their own record-action list, against their own permission helpers and their own `actions` config. They disagreed in ways users could see:

- **A contact was deletable from its table row and its drawer, but not from its own detail page.** `DETAIL_VIEW_CONFIG_REGISTRY.contact.actions` simply never got an `enableDelete`, while `record.delete` accepted it the whole time.
- "Run workflow" existed in the drawer and not on the page.
- Merge was gated on the delete verb in one place (correctly — it removes the source rows) and on **nothing at all** in the other.

And **five of the detail page's eight buttons did nothing**:

| Control | State |
|---|---|
| Archive, Delete, Run Workflow | `console.log` stubs — behind confirm dialogs that led nowhere |
| Groups | set a `useState` no JSX read; no group-assignment dialog exists anywhere in the app |
| Spam | `console.log`, **and no server mutation exists at all** — SPAM is a mail/thread status |

The drawer had two of its own: Archive and Link, both with empty `onClick` bodies.

## The menu

`RecordActionsMenu` is now the single menu for all three surfaces. Two rules hold it together:

1. **Authorization is the per-ROW `_access` stamp**, resolved once by `useRecordAccess`. Config says what a record *type* offers; it never says what a member may do. `canEdit` and `canDelete` stay separate — delete is the edit floor **plus** the delete verb.
2. **Favourite is not in it.** Every surface renders `FavoriteStarButton` beside the trigger: it is the one control that *reports* state (filled = favourited), and state you must open a menu to read is state you may as well not show. It is also deliberately ungated — a personal bookmark keyed to the viewer, not a write on the record.

Archive and Delete now actually run, through the records table's own `useEntityInstanceOperations`. Its handlers and dialogs are taken but **not** its `canEdit` — that one is the def-level `canEditEntity` and would undo the per-row gate.

⚠️ Dialogs are siblings of `<DropdownMenu>`, never children of `<DropdownMenuContent>`: Radix unmounts the content when the menu closes, and selecting an item closes the menu, so a dialog mounted inside would be torn down in the tick it opened.

## One config registry instead of two

`DetailViewActions` (7 flags) and `DrawerActions` (8 flags), overlapping on 4 names, collapse into one `RecordActions` in `record-actions-config.ts`. `actions` comes off both `DrawerConfig` and `DetailViewConfig` — surfaces cannot disagree about a record type when there is one place to read the answer.

Removed: `enableDelete`, `enableWorkflowTrigger`, `enableGroups`, `enableSpam`.

**`enableArchive` stays**, and this is the one to check: `invoice` withholds it deliberately — *"invoices are ledger records, delete is the only removal path"*. That single entry is what makes it a real flag rather than a constant. I had started removing it and backed out.

## Also in here

- **Per-definition custom items** (`record-action-registry.tsx`), keyed by `entityType` with an `entityDefinitionId` override. The override tier is the point: the drawer's existing `getHeaderActions` keys on `entityType` alone, and *every* custom definition reports `'entity'` — so a Shipments-only item registered there would show up on every custom definition in the org. Both maps start empty; this is the extension point `detail-view-config.ts` notes never existed.
- **"Create workflow"** added to the existing `WorkflowSubMenu` (not a new component — mine was a duplicate and got deleted), wired to `workflow.createForResource`. Always present so the submenu is never a dead end: an entity with no manual workflows is exactly where creating one is most useful. Disabled rather than hidden without `workflows.manage`. Mail threads and datasets get it for free.
- **App actions as a submenu** that disables when empty. The standalone "… More" button returned `null` unless an installed app declared a surface, so on a stock org nothing ever told a user apps could contribute actions here.
- **Share and the access request promoted out of the menu** on the detail page — Share beside a shared-with avatar stack (`InstanceShareAvatars`), the request as a labelled ghost button with the lock icon. Burying the one control that *adds* capability behind a kebab is backwards. `omitItems` stops them being offered twice.
  - The avatars are gated on `canShare` **at the call site**, not internally: they issue a per-record `resourceAccess.forInstance` query, and who else can see a record is not something a `read` member should enumerate. An internal early-return would still have paid for the query.
  - The request popover gained a `header` variant rather than changing `inline` — `inline` is also the not-found screen's and the mail thread body's CTA, where an outline button is right.
- **`test/setup.ts` stubs ResizeObserver as a real class.** floating-ui does `new ResizeObserver(...)` and the `vi.fn().mockImplementation(...)` mock is not constructible there, which is why four test files carried their own local `NoopResizeObserver` workaround. Pointer-capture stubs hoisted alongside it.

## Not in here

The **records-table row** still hand-rolls its list. It isn't broken (it never read `config.actions`), but it needs `PrimaryCell` to accept a whole menu rather than items-as-children — the menu's dialogs must be siblings of the `DropdownMenu`, and `PrimaryCell` currently owns that wrapper itself. Follow-up.

## Test plan

- [x] `apps/web` suite: **159 files / 2510 tests green**
- [x] `tsc --noEmit` on `apps/web` and `packages/lib` — no new errors (the 4 in `record-drawer.tsx` and the `ResourceDisplayConfig` one in the lib barrel are pre-existing)
- [x] Biome clean on every changed file
- [x] `detail-view-actions.test.tsx` rewritten — 16 tests, now opening the menu before asserting, incl. new coverage that Delete is offered on a contact, that Share/Request-access are promoted and *not* duplicated inside the menu, and that the favourite star stays ungated
- [x] `record-drawer-request-access.test.tsx` updated — the §8.5 lazy-preflight property is now *stricter*, since the trigger lives inside content Radix doesn't mount until opened
- [ ] Manual: contact detail page — Delete present; Share + avatars; Run workflow ▸ with Create workflow
- [ ] Manual: invoice drawer — no Archive
- [ ] Manual: a `read` row — Request access button, no write items