### PR TITLE
fix(deps): let next resolve typescript while typechecking on 7

### DIFF
--- a/apps/build/package.json
+++ b/apps/build/package.json
@@ -47,6 +47,6 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "tailwindcss": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:next-typescript"
   }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,6 +31,6 @@
     "@types/react-dom": "catalog:",
     "postcss": "catalog:",
     "tailwindcss": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:next-typescript"
   }
 }

--- a/apps/homepage/package.json
+++ b/apps/homepage/package.json
@@ -49,6 +49,6 @@
     "@types/react-dom": "catalog:",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "catalog:"
+    "typescript": "catalog:next-typescript"
   }
 }

--- a/apps/kb/package.json
+++ b/apps/kb/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "clean": "rm -rf .turbo node_modules .next",
     "start": "PORT=3002 node .next/standalone/apps/kb/server.js",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "node ../../node_modules/typescript7/bin/tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -43,7 +43,7 @@
     "prettier": "^3.8.1",
     "rimraf": "catalog:",
     "tailwindcss": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:next-typescript",
     "vite": "catalog:",
     "vite-tsconfig-paths": "catalog:",
     "vitest": "catalog:"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf .next .open-next .turbo node_modules *.tsbuildinfo",
     "preview": "next build --turbopack && next start",
     "start": "PORT=3000 node .next/standalone/apps/web/server.js",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "node ../../node_modules/typescript7/bin/tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
@@ -205,7 +205,7 @@
     "rimraf": "catalog:",
     "tailwindcss": "catalog:",
     "ts-node": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:next-typescript",
     "vite": "catalog:",
     "vite-tsconfig-paths": "catalog:",
     "vitest": "catalog:"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "tsx": "catalog:",
     "turbo": "2.5.2",
     "typescript": "catalog:",
+    "typescript7": "npm:typescript@7.0.2",
     "undici-types": "^7.16.0",
     "vitest": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,10 @@ catalogs:
     zod:
       specifier: 4.1.5
       version: 4.1.5
+  next-typescript:
+    typescript:
+      specifier: 5.9.2
+      version: 5.9.2
 
 overrides:
   dompurify: ^3.4.0
@@ -293,6 +297,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      typescript7:
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       undici-types:
         specifier: ^7.16.0
         version: 7.22.0
@@ -422,13 +429,13 @@ importers:
         version: 5.90.21(react@19.2.3)
       '@trpc/client':
         specifier: ^11.0.0-rc.446
-        version: 11.10.0(@trpc/server@11.10.0(typescript@7.0.2))(typescript@7.0.2)
+        version: 11.10.0(@trpc/server@11.10.0(typescript@5.9.2))(typescript@5.9.2)
       '@trpc/react-query':
         specifier: ^11.0.0-rc.446
-        version: 11.10.0(@tanstack/react-query@5.90.21(react@19.2.3))(@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@7.0.2))(typescript@7.0.2))(@trpc/server@11.10.0(typescript@7.0.2))(react@19.2.3)(typescript@7.0.2)
+        version: 11.10.0(@tanstack/react-query@5.90.21(react@19.2.3))(@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.10.0(typescript@5.9.2))(react@19.2.3)(typescript@5.9.2)
       '@trpc/server':
         specifier: 'catalog:'
-        version: 11.10.0(typescript@7.0.2)
+        version: 11.10.0(typescript@5.9.2)
       date-fns:
         specifier: 'catalog:'
         version: 4.1.0
@@ -497,8 +504,8 @@ importers:
         specifier: 'catalog:'
         version: 4.2.1
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:next-typescript
+        version: 5.9.2
 
   apps/docs:
     dependencies:
@@ -555,8 +562,8 @@ importers:
         specifier: 'catalog:'
         version: 4.2.1
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:next-typescript
+        version: 5.9.2
 
   apps/extension:
     dependencies:
@@ -755,8 +762,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:next-typescript
+        version: 5.9.2
 
   apps/kb:
     dependencies:
@@ -846,14 +853,14 @@ importers:
         specifier: 'catalog:'
         version: 4.2.1
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:next-typescript
+        version: 5.9.2
       vite:
         specifier: 'catalog:'
         version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@7.0.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1092,13 +1099,13 @@ importers:
         version: 2.11.9(@tiptap/core@2.11.9(@tiptap/pm@2.11.9))(@tiptap/pm@2.11.9)
       '@trpc/client':
         specifier: ^11.0.0-rc.446
-        version: 11.10.0(@trpc/server@11.10.0(typescript@7.0.2))(typescript@7.0.2)
+        version: 11.10.0(@trpc/server@11.10.0(typescript@5.9.2))(typescript@5.9.2)
       '@trpc/react-query':
         specifier: ^11.0.0-rc.446
-        version: 11.10.0(@tanstack/react-query@5.90.21(react@19.2.3))(@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@7.0.2))(typescript@7.0.2))(@trpc/server@11.10.0(typescript@7.0.2))(react@19.2.3)(typescript@7.0.2)
+        version: 11.10.0(@tanstack/react-query@5.90.21(react@19.2.3))(@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.10.0(typescript@5.9.2))(react@19.2.3)(typescript@5.9.2)
       '@trpc/server':
         specifier: 'catalog:'
-        version: 11.10.0(typescript@7.0.2)
+        version: 11.10.0(typescript@5.9.2)
       '@types/dagre':
         specifier: ^0.7.52
         version: 0.7.54
@@ -1426,16 +1433,16 @@ importers:
         version: 4.2.1
       ts-node:
         specifier: 'catalog:'
-        version: 10.9.2(@types/node@22.19.13)(typescript@7.0.2)
+        version: 10.9.2(@types/node@22.19.13)(typescript@5.9.2)
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:next-typescript
+        version: 5.9.2
       vite:
         specifier: 'catalog:'
         version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@7.0.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -22001,18 +22008,22 @@ snapshots:
 
   '@topoconfig/extends@0.16.2': {}
 
-  '@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@7.0.2))(typescript@7.0.2)':
+  '@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:
-      '@trpc/server': 11.10.0(typescript@7.0.2)
-      typescript: 7.0.2
+      '@trpc/server': 11.10.0(typescript@5.9.2)
+      typescript: 5.9.2
 
-  '@trpc/react-query@11.10.0(@tanstack/react-query@5.90.21(react@19.2.3))(@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@7.0.2))(typescript@7.0.2))(@trpc/server@11.10.0(typescript@7.0.2))(react@19.2.3)(typescript@7.0.2)':
+  '@trpc/react-query@11.10.0(@tanstack/react-query@5.90.21(react@19.2.3))(@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.10.0(typescript@5.9.2))(react@19.2.3)(typescript@5.9.2)':
     dependencies:
       '@tanstack/react-query': 5.90.21(react@19.2.3)
-      '@trpc/client': 11.10.0(@trpc/server@11.10.0(typescript@7.0.2))(typescript@7.0.2)
-      '@trpc/server': 11.10.0(typescript@7.0.2)
+      '@trpc/client': 11.10.0(@trpc/server@11.10.0(typescript@5.9.2))(typescript@5.9.2)
+      '@trpc/server': 11.10.0(typescript@5.9.2)
       react: 19.2.3
-      typescript: 7.0.2
+      typescript: 5.9.2
+
+  '@trpc/server@11.10.0(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
 
   '@trpc/server@11.10.0(typescript@7.0.2)':
     dependencies:
@@ -29047,6 +29058,24 @@ snapshots:
       '@ts-morph/common': 0.25.0
       code-block-writer: 13.0.3
 
+  ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.13
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
   ts-node@10.9.2(@types/node@22.19.13)(typescript@7.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -29064,6 +29093,7 @@ snapshots:
       typescript: 7.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
 
   tsc-esm-fix@3.1.2:
     dependencies:
@@ -29073,6 +29103,10 @@ snapshots:
       fs-extra: 11.3.3
       json5: 2.2.3
       type-flag: 3.0.0
+
+  tsconfck@3.1.6(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
 
   tsconfck@3.1.6(typescript@7.0.2):
     optionalDependencies:
@@ -29497,6 +29531,17 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.2)
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite-tsconfig-paths@5.1.4(typescript@7.0.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,18 @@ packages:
   - apps/*
   - packages/*
 
+# Next.js resolves `typescript/lib/typescript.js` directly, a path TypeScript 7's
+# `exports` map does not expose (ERR_PACKAGE_PATH_NOT_EXPORTED). Next then tries to
+# auto-install TypeScript, which throws on a CI runner — so `next typegen` dies,
+# `next-env.d.ts` is never written, and web's typecheck reports a phantom TS2307 for
+# every `*.png` import. Every Next app therefore stays on 5.9.2 for what Next itself
+# loads; they still TYPECHECK with 7 via the `typescript7` alias (see their
+# `typecheck` scripts and scripts/ci/typecheck-ratchet.js). Drop this catalog once
+# Next resolves TypeScript through its package exports.
+catalogs:
+  next-typescript:
+    typescript: 5.9.2
+
 catalog:
   '@aws-sdk/client-cloudfront': ^3.995.0
   '@aws-sdk/client-s3': ^3.995.0

--- a/scripts/ci/typecheck-ratchet.js
+++ b/scripts/ci/typecheck-ratchet.js
@@ -48,6 +48,20 @@ const BASELINE_PATH = join(ROOT, 'scripts', 'ci', 'typecheck-baseline.json')
  * if CI starts dying here, move to a larger runner rather than trimming this.
  */
 const HEAP_MB = Number(process.env.TYPECHECK_HEAP_MB) || 8192
+
+/**
+ * Always typecheck with TypeScript 7, resolved by PATH rather than through
+ * `pnpm exec tsc`.
+ *
+ * `apps/web` deliberately pins `typescript` to 5.9.2 — Next loads
+ * `typescript/lib/typescript.js`, which 7's `exports` map does not expose, and
+ * without it `next typegen` dies and the web run reports phantom TS2307s (see
+ * `pnpm-workspace.yaml`). That pin makes `apps/web/node_modules/.bin/tsc` 5.9.2,
+ * so `pnpm exec tsc` would silently measure web on a DIFFERENT compiler than the
+ * baseline was recorded with, and `lib` on 7. Naming the binary keeps both on 7.
+ */
+const TSC_BIN = join(ROOT, 'node_modules', 'typescript7', 'bin', 'tsc')
+
 const PACKAGES = {
   lib: { dir: 'packages/lib' },
   web: { dir: 'apps/web' },
@@ -76,7 +90,7 @@ const GENERATED = ['node_modules', '.next/']
  */
 function collectErrors(name) {
   const { dir } = PACKAGES[name]
-  const result = spawnSync('pnpm', ['exec', 'tsc', '--noEmit'], {
+  const result = spawnSync(process.execPath, [TSC_BIN, '--noEmit'], {
     cwd: join(ROOT, dir),
     encoding: 'utf8',
     maxBuffer: 128 * 1024 * 1024,


### PR DESCRIPTION
Fixes the red `Typecheck (web)` that #1440 left on `main`.

## Cause

Next loads `typescript/lib/typescript.js` **directly**. TypeScript 7's `exports` map does not expose that path:

```
require.resolve('typescript/lib/typescript.js', { paths: ['apps/web'] })
→ ERR_PACKAGE_PATH_NOT_EXPORTED
```

Next then falls back to auto-installing TypeScript. That succeeds on a laptop and throws on a runner:

```
Unhandled Rejection: Error: It looks like you're trying to use TypeScript
but do not have the required package(s) installed.
```

So `next typegen` died, `next-env.d.ts` was never written, `*.png` went undeclared, and `src/components/global/login/logo.tsx` reported a `TS2307` the baseline does not carry.

**Why #1440 looked green locally:** a stale `next-env.d.ts` from before the migration was sitting in the worktree. That is exactly the trap `plans/testing/HANDOFF.md` §2.9 documents, and I walked into it — the Docker checks missed it too, because only the `installer` stage was built and that never runs `next typegen`.

## Fix

A named catalog gives the five Next apps the TypeScript that Next itself can load, without moving the default catalog off 7:

```yaml
catalogs:
  next-typescript:
    typescript: 5.9.2
catalog:
  typescript: 7.0.2
```

`apps/{web,kb,docs,homepage,build}` → `catalog:next-typescript`. Everything else stays on 7.0.2.

**Typechecking still runs on 7**, via a root `typescript7` alias — so none of the speed is given up and the baseline recorded in #1440 stays valid.

The pin makes `apps/web/node_modules/.bin/tsc` 5.9.2, so `pnpm exec tsc` would have silently measured **web on 5.9 and lib on 7** against a baseline recorded on 7. The ratchet now names the `typescript7` binary explicitly, and `web`/`kb`'s `typecheck` scripts do the same.

All of this comes out once Next resolves TypeScript through package exports.

## Verified

- `next typegen` cold (no `next-env.d.ts`, no `.next/types`) — **rc=0, zero auto-install attempts**
- ratchet green on **TypeScript 7** for both packages — `lib 2668`, `web 3564`, matching the committed baseline
- CI's exact web prep sequence (`@auxx/chat build` + `next typegen`) — rc=0
- `turbo build --filter="@auxx/web^..."` and `check:exports` — clean
- resolution split confirmed: `apps/web` 5.9.2, `apps/kb` 5.9.2, `packages/lib` 7.0.2, `typescript7` 7.0.2

## Not caused by this or by #1440

The `web` **Docker** job is failing with `cannot allocate memory` during `next build`. It fails identically on every recent branch — `fix/thread-header-gap-alignment`, `feat/shared-record-actions-menu`, `docs/handoff-shared-record-actions` — so it is pre-existing and unrelated. `docs`/`homepage` are the known corepack failures in `plans/bug/dockerfile-corepack-pnpm-bin-path.md`. `api`, `worker`, `lambda`, `lambda-server` all built green on TypeScript 7.