### PR TITLE
feat(records): walk the list you came from on the record detail page

### DIFF
--- a/apps/web/src/components/detail-view/detail-view.tsx
+++ b/apps/web/src/components/detail-view/detail-view.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { getDetailViewConfig, type ModelType } from '@auxx/lib/resources/client'
+import { BreadcrumbItem } from '@auxx/ui/components/breadcrumb'
 import { Button } from '@auxx/ui/components/button'
 import { Drawer, DrawerContent, DrawerHandle, DrawerTitle } from '@auxx/ui/components/drawer'
 import {
@@ -15,6 +16,7 @@ import { PanelRight } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
 import { NoAccess } from '~/components/permissions/ui/no-access'
+import { RecordNavButtons, RecordSwitcherList, useRecordNavContext } from '~/components/records/nav'
 import { getRecordDrillPanels } from '~/components/records/record-drill-panels'
 import {
   toRecordId,
@@ -73,6 +75,12 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
     recordId,
     enabled: !resourceLoading && canViewDefinition,
   })
+
+  // Which list this record was opened from — drives the breadcrumb switcher and
+  // the prev/next arrows. `null` until something resolves (or forever, if the
+  // record was reached from a surface with no list behind it), in which case the
+  // breadcrumb keeps its plain terminal label.
+  const navContext = useRecordNavContext(recordId)
 
   // Get config from registry based on entityType
   const config = getDetailViewConfig(entityType)
@@ -209,7 +217,23 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
         }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title={plural ?? label ?? 'Records'} href={backUrl} />
-          <MainPageBreadcrumbItem title={displayName} />
+          {navContext ? (
+            <>
+              <RecordSwitcherList
+                context={navContext}
+                activeRecordId={recordId}
+                activeLabel={displayName}
+              />
+              {/* Own BreadcrumbItem: the crumb body is an <ol>, so raw buttons
+                  are invalid there. No separator — the arrows belong to the
+                  record crumb rather than forming a crumb of their own. */}
+              <BreadcrumbItem>
+                <RecordNavButtons context={navContext} />
+              </BreadcrumbItem>
+            </>
+          ) : (
+            <MainPageBreadcrumbItem title={displayName} />
+          )}
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
@@ -16,6 +16,9 @@ import {
   useRef,
 } from 'react'
 import { MainPageLoading } from '~/components/global/main-page-states'
+// Leaf import, not the `records/nav` barrel — that barrel pulls the switcher and
+// the record editor dialog, which import back into dynamic-table.
+import { useRecordListContextPublisher } from '~/components/records/nav/use-record-list-context-publisher'
 import { type RecordMeta, toRecordId, useRecordList, useResource } from '~/components/resources'
 import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-value-syncer'
 import type {
@@ -27,7 +30,13 @@ import { DynamicTableFooter } from './components/dynamic-table-footer'
 import { getIconForFieldType } from './custom-field-column-factory'
 import { DynamicView } from './dynamic-view'
 import { useDefaultTablePersistence } from './hooks/use-default-table-persistence'
-import { useColumnVisibility, useTableFilters, useTableSorting } from './stores/store-selectors'
+import {
+  useActiveView,
+  useActiveViewId,
+  useColumnVisibility,
+  useTableFilters,
+  useTableSorting,
+} from './stores/store-selectors'
 import type { BulkAction, CellSelectionConfig, ExtendedColumnDef } from './types'
 
 /** Page size for the infinite query. Matches the prior records-view page size. */
@@ -102,6 +111,19 @@ export interface DynamicResourceViewProps<TRow extends RecordMeta = RecordMeta> 
   onSelectedKanbanCardIdsChange?: (ids: Set<string>) => void
   /** Optional import page URL surfaced in the toolbar. */
   importHref?: string
+  /**
+   * Label for the list context this view publishes (see
+   * {@link useRecordListContextPublisher}). Embedded tables that are not "the
+   * definition's list" should name themselves — a contact's Tickets tab is
+   * "Tickets of Acme Corp", not "Tickets". Defaults to the active view's name.
+   */
+  listContextLabel?: string
+  /**
+   * Publish the list being shown, so a detail page opened from it can walk the
+   * same records. Default `true`; opt out for a surface that must not claim the
+   * definition's navigation context.
+   */
+  publishListContext?: boolean
 }
 
 export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
@@ -125,6 +147,8 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
   selectedKanbanCardIds,
   onSelectedKanbanCardIdsChange,
   importHref,
+  listContextLabel,
+  publishListContext = true,
 }: DynamicResourceViewProps<TRow>) {
   const { resource, isLoading } = useResource(slug)
 
@@ -147,6 +171,8 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
   const viewFilters = useTableFilters(tableId)
   const viewSorting = useTableSorting(tableId)
   const storeColumnVisibility = useColumnVisibility(tableId)
+  const activeView = useActiveView(tableId)
+  const activeViewId = useActiveViewId(tableId)
 
   // Baseline + store filters. Baseline stays a separate ConditionGroup so the
   // filter UI cannot see or edit it; the query layer ANDs groups together.
@@ -164,6 +190,7 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
 
   const {
     records,
+    recordIds: listIds,
     isLoading: instancesLoading,
     isLoadingRecords,
     isFetchingNextPage,
@@ -176,6 +203,21 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
     sorting: sortingForQuery,
     limit: PAGE_SIZE,
     enabled: !!entityDefinitionId && isConfigReady,
+  })
+
+  // Publish what this view is showing — the merged filters, the sorting and the
+  // loaded ids — so a detail page opened from any row can offer prev/next and a
+  // switcher over the same list. This is the only place that holds all three
+  // together, which is why no navigation call site has to be touched.
+  useRecordListContextPublisher({
+    entityDefinitionId,
+    tableId,
+    filters: filtersForQuery,
+    sorting: sortingForQuery,
+    viewId: activeViewId,
+    label: listContextLabel ?? activeView?.name ?? resource?.plural,
+    ids: listIds,
+    enabled: publishListContext && isConfigReady,
   })
 
   const handleScrollToBottom = useCallback(() => {

--- a/apps/web/src/components/global/create-org-dialog.tsx
+++ b/apps/web/src/components/global/create-org-dialog.tsx
@@ -35,6 +35,7 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { client as authClient } from '~/auth/auth-client'
 import { clearChannelCaches } from '~/components/channels/providers/channel-provider'
+import { clearRecordListContext } from '~/components/records/nav/record-list-context-store'
 import { clearResourceCaches } from '~/components/resources'
 import { api } from '~/trpc/react'
 
@@ -145,6 +146,7 @@ export function CreateOrganizationDialog({ open, onOpenChange }: CreateOrganizat
       // Clear client-side caches before navigation
       clearResourceCaches()
       clearChannelCaches()
+      clearRecordListContext()
 
       // Force session cache refresh to get updated defaultOrganizationId
       await authClient.getSession({ query: { disableCookieCache: true } })

--- a/apps/web/src/components/organization/organization-item.tsx
+++ b/apps/web/src/components/organization/organization-item.tsx
@@ -19,6 +19,7 @@ import { useState } from 'react'
 import { useSession } from '~/auth/auth-client'
 import { clearChannelCaches } from '~/components/channels/providers/channel-provider'
 import { SeatTypeBadge } from '~/components/permissions/ui/seat-type-badge'
+import { clearRecordListContext } from '~/components/records/nav/record-list-context-store'
 import { clearResourceCaches } from '~/components/resources'
 import { useUser } from '~/hooks/use-user'
 import { useDehydratedOrganizationId } from '~/providers/dehydrated-state-provider'
@@ -77,6 +78,7 @@ export function OrganizationItem({
       if (isDeletingCurrentOrg) {
         clearResourceCaches()
         clearChannelCaches()
+        clearRecordListContext()
         await utils.invalidate()
         router.push('/organizations')
       } else {

--- a/apps/web/src/components/records/index.ts
+++ b/apps/web/src/components/records/index.ts
@@ -1,6 +1,15 @@
 // apps/web/src/components/records/index.ts
 
 export { EntityRouteLayout } from './entity-route-layout'
+export {
+  clearRecordListContext,
+  type RecordListDescriptor,
+  RecordNavButtons,
+  type RecordNavContext,
+  RecordSwitcherList,
+  useRecordListContextPublisher,
+  useRecordNavContext,
+} from './nav'
 export { RecordDrawer } from './record-drawer'
 export { RecordRouteGuard } from './record-route-guard'
 export { type EntityRow, RecordsView } from './records-view'

--- a/apps/web/src/components/records/nav/index.ts
+++ b/apps/web/src/components/records/nav/index.ts
@@ -1,0 +1,14 @@
+// apps/web/src/components/records/nav/index.ts
+
+export {
+  clearRecordListContext,
+  getRecordListContext,
+  type RecordListContextEntry,
+  type RecordListDescriptor,
+  useRecordListContext,
+  useRecordListContextStore,
+} from './record-list-context-store'
+export { RecordNavButtons } from './record-nav-buttons'
+export { RecordSwitcherList } from './record-switcher-list'
+export { useRecordListContextPublisher } from './use-record-list-context-publisher'
+export { type RecordNavContext, useRecordNavContext } from './use-record-nav-context'

--- a/apps/web/src/components/records/nav/record-list-context-store.test.ts
+++ b/apps/web/src/components/records/nav/record-list-context-store.test.ts
@@ -1,0 +1,131 @@
+// apps/web/src/components/records/nav/record-list-context-store.test.ts
+//
+// The store is written on EVERY table render (the publisher effect runs whenever
+// filters/sorting/ids change identity), so the de-dupe in `capture` is what keeps
+// it from re-notifying every subscriber on a no-op. These tests pin that, plus
+// the two rules the rest of the feature leans on: entries are keyed per
+// definition, and a changed query REPLACES rather than merges.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearRecordListContext,
+  getRecordListContext,
+  type RecordListDescriptor,
+  useRecordListContextStore,
+} from './record-list-context-store'
+
+const DEF_A = 'edf_contact00000000000000000'
+const DEF_B = 'edf_ticket000000000000000000'
+
+function descriptor(overrides: Partial<RecordListDescriptor> = {}): RecordListDescriptor {
+  return {
+    entityDefinitionId: DEF_A,
+    filters: [],
+    sorting: [],
+    tableId: `entity-${DEF_A}`,
+    viewId: 'tv_default',
+    label: 'All contacts',
+    ...overrides,
+  }
+}
+
+const capture = (d: RecordListDescriptor, ids: string[]) =>
+  useRecordListContextStore.getState().capture(d, ids)
+
+beforeEach(() => {
+  clearRecordListContext()
+})
+
+describe('capture', () => {
+  it('stores the descriptor and ids for a definition', () => {
+    capture(descriptor(), ['a', 'b', 'c'])
+
+    const entry = getRecordListContext(DEF_A)
+    expect(entry?.ids).toEqual(['a', 'b', 'c'])
+    expect(entry?.descriptor.label).toBe('All contacts')
+  })
+
+  it('is a no-op when nothing moved — same query, no new ids', () => {
+    capture(descriptor(), ['a', 'b', 'c'])
+    const first = getRecordListContext(DEF_A)
+
+    capture(descriptor(), ['a', 'b', 'c'])
+
+    // Identity, not equality: a fresh object here would re-render every consumer
+    // on every table render.
+    expect(getRecordListContext(DEF_A)).toBe(first)
+  })
+
+  it('is a no-op when the incoming ids are a truncation of what we hold', () => {
+    capture(descriptor(), ['a', 'b', 'c'])
+    const first = getRecordListContext(DEF_A)
+
+    // A remount that has only rendered its first page must not shrink the list
+    // out from under the arrows.
+    capture(descriptor(), ['a'])
+
+    expect(getRecordListContext(DEF_A)).toBe(first)
+  })
+
+  it('writes when the surface has loaded more rows', () => {
+    capture(descriptor(), ['a', 'b'])
+    capture(descriptor(), ['a', 'b', 'c', 'd'])
+
+    expect(getRecordListContext(DEF_A)?.ids).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('replaces rather than merges when the filters change', () => {
+    capture(descriptor(), ['a', 'b', 'c'])
+    capture(
+      descriptor({
+        filters: [
+          {
+            id: 'g1',
+            logicalOperator: 'AND',
+            conditions: [{ id: 'c1', fieldId: 'fld_x', operator: 'is', value: 'open' }],
+          },
+        ],
+      }),
+      ['x', 'y']
+    )
+
+    // A different query is a different list. Carrying `a`/`b`/`c` across would
+    // let the arrows walk rows the filter excludes.
+    expect(getRecordListContext(DEF_A)?.ids).toEqual(['x', 'y'])
+  })
+
+  it('writes when only the label changed — the popover header would go stale', () => {
+    capture(descriptor(), ['a'])
+    capture(descriptor({ label: 'My hot leads' }), ['a'])
+
+    expect(getRecordListContext(DEF_A)?.descriptor.label).toBe('My hot leads')
+  })
+
+  it('keys entries per definition', () => {
+    capture(descriptor(), ['a', 'b'])
+    capture(descriptor({ entityDefinitionId: DEF_B, tableId: `entity-${DEF_B}` }), ['t1'])
+
+    // Opening a ticket from the contacts table must not inherit the contacts list.
+    expect(getRecordListContext(DEF_A)?.ids).toEqual(['a', 'b'])
+    expect(getRecordListContext(DEF_B)?.ids).toEqual(['t1'])
+  })
+})
+
+describe('clearRecordListContext', () => {
+  it('drops every definition', () => {
+    capture(descriptor(), ['a'])
+    capture(descriptor({ entityDefinitionId: DEF_B, tableId: `entity-${DEF_B}` }), ['t1'])
+
+    clearRecordListContext()
+
+    expect(getRecordListContext(DEF_A)).toBeUndefined()
+    expect(getRecordListContext(DEF_B)).toBeUndefined()
+  })
+})
+
+describe('getRecordListContext', () => {
+  it('returns undefined for an unknown or absent definition', () => {
+    expect(getRecordListContext(undefined)).toBeUndefined()
+    expect(getRecordListContext('edf_nope')).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/records/nav/record-list-context-store.ts
+++ b/apps/web/src/components/records/nav/record-list-context-store.ts
@@ -1,0 +1,121 @@
+// apps/web/src/components/records/nav/record-list-context-store.ts
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { create } from 'zustand'
+import { createListKey } from '~/components/resources/store/record-store'
+
+/**
+ * The value that identifies "the list I am inside".
+ *
+ * It is exactly what `useRecordList` consumes, which is the point: feeding this
+ * back in on the detail page produces the same `listKey` the table produced, so
+ * the ids come from the record store's list cache with no request at all.
+ *
+ * `filters` is the FULLY MERGED set — baseline (the records search bar) + view
+ * filters + personal overlays + session filters. A saved `viewId` alone is not
+ * the list; reconstructing from it silently walks a different one.
+ */
+export interface RecordListDescriptor {
+  entityDefinitionId: string
+  filters: ConditionGroup[]
+  sorting: Array<{ id: string; desc: boolean }>
+  /** `entity-${entityDefinitionId}` for the records table; embedded surfaces differ. */
+  tableId: string
+  /** Saved view backing this list, when there is one. Drives the `?list=` token. */
+  viewId: string | null
+  /** Human label for the popover trigger — "My hot leads", "Tickets of Acme Corp". */
+  label: string
+}
+
+export interface RecordListContextEntry {
+  descriptor: RecordListDescriptor
+  /** The ids the source surface had loaded at capture time. */
+  ids: string[]
+  capturedAt: number
+}
+
+interface RecordListContextState {
+  /**
+   * Keyed by `entityDefinitionId` — opening a ticket from the contacts table
+   * must not inherit the contacts descriptor.
+   */
+  byDefinitionId: Record<string, RecordListContextEntry>
+  capture: (descriptor: RecordListDescriptor, ids: string[]) => void
+  clear: () => void
+}
+
+/**
+ * Identity of a descriptor for change detection. `createListKey` already hashes
+ * (def, filters, sorting) — the tuple that decides the QUERY — and `viewId` +
+ * `label` cover the presentation bits that do not affect it.
+ */
+function descriptorKey(descriptor: RecordListDescriptor): string {
+  const listKey = createListKey(
+    descriptor.entityDefinitionId,
+    descriptor.filters,
+    descriptor.sorting
+  )
+  return `${listKey}|${descriptor.viewId ?? ''}|${descriptor.label}`
+}
+
+/** Whether `next` is `prev` truncated — i.e. it carries nothing new. */
+function isPrefixOf(next: string[], prev: string[]): boolean {
+  if (next.length > prev.length) return false
+  return next.every((id, i) => prev[i] === id)
+}
+
+export const useRecordListContextStore = create<RecordListContextState>((set, get) => ({
+  byDefinitionId: {},
+
+  capture: (descriptor, ids) => {
+    const existing = get().byDefinitionId[descriptor.entityDefinitionId]
+    // The publisher runs on every table render. Writing an identical entry would
+    // re-notify every subscriber for nothing, so bail unless something moved:
+    // the query/label changed, or the surface loaded rows we do not have yet.
+    if (
+      existing &&
+      descriptorKey(existing.descriptor) === descriptorKey(descriptor) &&
+      isPrefixOf(ids, existing.ids)
+    ) {
+      return
+    }
+    set((state) => ({
+      byDefinitionId: {
+        ...state.byDefinitionId,
+        [descriptor.entityDefinitionId]: { descriptor, ids, capturedAt: Date.now() },
+      },
+    }))
+  },
+
+  clear: () => set({ byDefinitionId: {} }),
+}))
+
+/**
+ * Drop every captured list context.
+ *
+ * Called alongside `clearResourceCaches()` on logout and org switch. Stale
+ * entries from another ORG are inert (EntityDefinition ids are per-org rows and
+ * would never resolve), but a different USER on the same browser and org would
+ * otherwise inherit the previous user's personal filter overlays.
+ */
+export function clearRecordListContext(): void {
+  useRecordListContextStore.getState().clear()
+}
+
+/** Non-reactive read, for callbacks and effects. */
+export function getRecordListContext(
+  entityDefinitionId: string | undefined
+): RecordListContextEntry | undefined {
+  if (!entityDefinitionId) return undefined
+  return useRecordListContextStore.getState().byDefinitionId[entityDefinitionId]
+}
+
+/** Reactive read for a single definition. */
+export function useRecordListContext(
+  entityDefinitionId: string | undefined
+): RecordListContextEntry | undefined {
+  return useRecordListContextStore((s) =>
+    entityDefinitionId ? s.byDefinitionId[entityDefinitionId] : undefined
+  )
+}

--- a/apps/web/src/components/records/nav/record-nav-buttons.tsx
+++ b/apps/web/src/components/records/nav/record-nav-buttons.tsx
@@ -1,0 +1,63 @@
+// apps/web/src/components/records/nav/record-nav-buttons.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { useHotkey } from '@tanstack/react-hotkeys'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
+import type { RecordNavContext } from './use-record-nav-context'
+
+interface RecordNavButtonsProps {
+  context: RecordNavContext
+  /** Whether J/K are active. Defaults to true. */
+  hotkeysEnabled?: boolean
+}
+
+/**
+ * Previous / next within the list the detail page was opened from — the record
+ * counterpart of `mail/thread-nav-toolbar.tsx`, minus its back button (the
+ * breadcrumb parent already is the way back).
+ *
+ * `J`/`K` match mail's bindings. The two surfaces never coexist, and nothing
+ * else on the records detail page claims either key.
+ */
+export function RecordNavButtons({ context, hotkeysEnabled = true }: RecordNavButtonsProps) {
+  const { hasPrev, hasNext, goPrev, goNext, index, descriptor } = context
+
+  useHotkey('K', goPrev, { enabled: hotkeysEnabled, conflictBehavior: 'allow' })
+  useHotkey('J', goNext, { enabled: hotkeysEnabled, conflictBehavior: 'allow' })
+
+  // The record is not in the list — it was filtered out after an edit, or it sits
+  // beyond the window a deep link could load. Say so rather than leaving two
+  // dead buttons with no explanation.
+  const orphaned = index < 0
+  const prevTip = orphaned ? `Not in ${descriptor.label}` : 'Previous'
+  const nextTip = orphaned ? `Not in ${descriptor.label}` : 'Next'
+
+  return (
+    <div className='flex items-center'>
+      <Tooltip content={prevTip} shortcut={orphaned ? undefined : 'K'}>
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          className='rounded-lg hover:bg-primary-200'
+          disabled={!hasPrev}
+          onClick={goPrev}
+          aria-label='Previous record'>
+          <ChevronUp />
+        </Button>
+      </Tooltip>
+      <Tooltip content={nextTip} shortcut={orphaned ? undefined : 'J'}>
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          className='rounded-lg hover:bg-primary-200'
+          disabled={!hasNext}
+          onClick={goNext}
+          aria-label='Next record'>
+          <ChevronDown />
+        </Button>
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/web/src/components/records/nav/record-switcher-list.tsx
+++ b/apps/web/src/components/records/nav/record-switcher-list.tsx
@@ -1,0 +1,383 @@
+// apps/web/src/components/records/nav/record-switcher-list.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import type { RecordPickerItem } from '@auxx/lib/resources/client'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandPlaceholder,
+  CommandSeparator,
+} from '@auxx/ui/components/command'
+import { MainPageBreadcrumbDropdown } from '@auxx/ui/components/main-page'
+import { keepPreviousData } from '@tanstack/react-query'
+import { ArrowLeft, ListFilter, Plus } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useDynamicTableStore } from '~/components/dynamic-table/stores/dynamic-table-store'
+import type { TableView } from '~/components/dynamic-table/types'
+import { RecordItem } from '~/components/pickers/record-picker/record-item'
+import { useRelationship, useResource } from '~/components/resources'
+import { useDebouncedValue } from '~/hooks/use-debounced-value'
+import { useAccess } from '~/providers/capabilities-provider'
+import { api } from '~/trpc/react'
+import { RecordEditorDialog } from '../record-editor-dialog'
+import type { RecordNavContext } from './use-record-nav-context'
+
+/** How many rows to render at once. Grows as the user scrolls. */
+const RENDER_WINDOW = 60
+/** Max rows a search returns — searching narrows, so this is generous. */
+const SEARCH_LIMIT = 50
+
+/**
+ * Height cap for the scrolling row area.
+ *
+ * Passed as `scrollAreaStyle` rather than a Tailwind class on purpose: a
+ * `max-h-[…]` arbitrary value cannot express `calc()` without underscore
+ * escaping, and an invalid arbitrary value is worse than none — tailwind-merge
+ * still drops `CommandList`'s default `max-h-[300px]` for it, leaving the
+ * popover with no cap at all and rendering full height.
+ *
+ * The Radix variable clamps the list on short viewports; the `100vh` fallback
+ * keeps the expression valid if the popover ever renders outside a Radix
+ * popper, and the 320px floor is what it settles at on a normal screen.
+ */
+const listHeightStyle = (headerAllowance: string) => ({
+  maxHeight: `min(320px, calc(var(--radix-popover-content-available-height, 100vh) - ${headerAllowance}))`,
+})
+
+interface RecordSwitcherListProps {
+  context: RecordNavContext
+  /** The record whose detail page is open. */
+  activeRecordId: RecordId
+  /** Its display name — the breadcrumb trigger label. */
+  activeLabel: string
+}
+
+/**
+ * The breadcrumb record switcher: browse, search and jump within the same list
+ * the detail page was opened from.
+ *
+ * Deliberately not built on `RecordPickerContent`, whose rows come only from
+ * `record.search` — that procedure takes no filters and no sorting, so it would
+ * offer a different set in a different order than the list being walked. What is
+ * reused instead is the leaf: {@link RecordItem} (so a record row looks the same
+ * here as in every picker) and `useRelationship` for batched hydration.
+ */
+export function RecordSwitcherList({
+  context,
+  activeRecordId,
+  activeLabel,
+}: RecordSwitcherListProps) {
+  const [open, setOpen] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
+  const { entityDefinitionId } = parseRecordId(activeRecordId)
+
+  return (
+    <>
+      <MainPageBreadcrumbDropdown
+        label={<span className='max-w-[24ch] truncate'>{activeLabel}</span>}
+        popover
+        open={open}
+        onOpenChange={setOpen}
+        align='start'
+        contentClassName='w-80 p-0'>
+        {/* Radix unmounts popover content when closed, so every query below
+            only runs while the switcher is actually open. */}
+        <SwitcherBody
+          context={context}
+          activeRecordId={activeRecordId}
+          onClose={() => setOpen(false)}
+          onCreate={() => {
+            setOpen(false)
+            setCreateOpen(true)
+          }}
+        />
+      </MainPageBreadcrumbDropdown>
+
+      {/* Sibling of the popover, which has already closed itself by now — the
+          same arrangement DashboardSwitcherList uses for its settings dialog. */}
+      {createOpen && (
+        <RecordEditorDialog
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          entityDefinitionId={entityDefinitionId}
+        />
+      )}
+    </>
+  )
+}
+
+function SwitcherBody({
+  context,
+  activeRecordId,
+  onClose,
+  onCreate,
+}: {
+  context: RecordNavContext
+  activeRecordId: RecordId
+  onClose: () => void
+  onCreate: () => void
+}) {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(activeRecordId)
+  const { resource } = useResource(entityDefinitionId)
+  const { canEditEntity } = useAccess()
+  const canEdit = canEditEntity(entityDefinitionId)
+
+  const [mode, setMode] = useState<'records' | 'views'>('records')
+  const [search, setSearch] = useState('')
+  const [debouncedSearch] = useDebouncedValue(search, 300)
+  const [visibleCount, setVisibleCount] = useState(RENDER_WINDOW)
+
+  const { descriptor, ids, loadMore, hasMore, isLoadingMore, total, isReconstructed, selectView } =
+    context
+
+  // ─── SEARCH WITHIN THE LIST ──────────────────────────────────────────────
+  // `record.search` is deliberately not used: it accepts no filters, so it would
+  // surface records outside the list being walked. ANDing a `contains` condition
+  // onto the descriptor's own filters keeps results a strict subset, under the
+  // same access scoping and the same query path.
+  const primaryFieldId = resource?.display?.primaryDisplayField?.id
+  const query = debouncedSearch.trim()
+
+  const searchFilters = useMemo((): ConditionGroup[] | undefined => {
+    if (!query || !primaryFieldId) return undefined
+    return [
+      ...descriptor.filters,
+      {
+        id: 'nav-search',
+        logicalOperator: 'AND',
+        conditions: [
+          { id: 'nav-search-q', fieldId: primaryFieldId, operator: 'contains', value: query },
+        ],
+      } as ConditionGroup,
+    ]
+  }, [query, primaryFieldId, descriptor.filters])
+
+  const searchQuery = api.record.listFiltered.useQuery(
+    {
+      entityDefinitionId: descriptor.entityDefinitionId,
+      filters: searchFilters,
+      sorting: descriptor.sorting.length > 0 ? descriptor.sorting : undefined,
+      limit: SEARCH_LIMIT,
+    },
+    {
+      enabled: !!searchFilters,
+      staleTime: 30_000,
+      placeholderData: keepPreviousData,
+    }
+  )
+
+  const isSearching = !!searchFilters && (searchQuery.isFetching || search !== debouncedSearch)
+  const listIds = searchFilters ? (searchQuery.data?.ids ?? []) : ids
+
+  // Reset the render window whenever the row source changes under it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on source change, not on row growth
+  useEffect(() => {
+    setVisibleCount(RENDER_WINDOW)
+  }, [query, descriptor.viewId])
+
+  // ─── HYDRATION ───────────────────────────────────────────────────────────
+  // The active record leads, so its row renders even when it is not in the list
+  // (filtered out after an edit, or opened from outside the list entirely).
+  const visibleIds = useMemo(() => listIds.slice(0, visibleCount), [listIds, visibleCount])
+
+  const recordIdsToHydrate = useMemo(() => {
+    const out: RecordId[] = [activeRecordId]
+    for (const id of visibleIds) {
+      if (id !== entityInstanceId) out.push(toRecordId(entityDefinitionId, id))
+    }
+    return out
+  }, [activeRecordId, visibleIds, entityInstanceId, entityDefinitionId])
+
+  const { itemsMap, isLoading: isHydrating } = useRelationship(recordIdsToHydrate)
+
+  const activeItem = itemsMap.get(entityInstanceId) ?? null
+  const rows = useMemo(() => {
+    const out: RecordPickerItem[] = []
+    for (const id of visibleIds) {
+      if (id === entityInstanceId) continue
+      const item = itemsMap.get(id)
+      if (item) out.push(item)
+    }
+    return out
+  }, [visibleIds, itemsMap, entityInstanceId])
+
+  // ─── INFINITE SCROLL ─────────────────────────────────────────────────────
+  // Grow the render window first; only ask the server once every loaded id is
+  // on screen. Searching has its own single page, so it never pages.
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const onReachEnd = useCallback(() => {
+    if (searchFilters) return
+    if (visibleCount < listIds.length) {
+      setVisibleCount((c) => c + RENDER_WINDOW)
+      return
+    }
+    if (hasMore) loadMore()
+  }, [searchFilters, visibleCount, listIds.length, hasMore, loadMore])
+
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node) return
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) onReachEnd()
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [onReachEnd])
+
+  // ─── VIEW SWITCHING ──────────────────────────────────────────────────────
+  // Rendered as a mode of the same Command rather than a nested dropdown: a
+  // second Radix portal over a cmdk body is exactly the arrow-key fight the
+  // popover host exists to avoid.
+  const views = useDynamicTableStore((s) => s.viewsByTableId[descriptor.tableId])
+  const availableViews = views ?? []
+
+  const goTo = context.goTo
+  const handlePick = useCallback(
+    (recordId: RecordId) => {
+      const { entityInstanceId: target } = parseRecordId(recordId)
+      onClose()
+      // Reuse the context's own navigation so `?tab=` / `?list=` survive the hop
+      // exactly as they do for the arrows.
+      if (target !== entityInstanceId) goTo(target)
+    },
+    [entityInstanceId, onClose, goTo]
+  )
+
+  if (mode === 'views') {
+    return (
+      <Command shouldFilter={false} className='overflow-hidden rounded-2xl'>
+        <div className='flex items-center gap-1 border-b px-2 py-1.5'>
+          <Button variant='ghost' size='icon-sm' onClick={() => setMode('records')}>
+            <ArrowLeft />
+          </Button>
+          <span className='text-xs font-medium text-muted-foreground'>Switch list</span>
+        </div>
+        <CommandList scrollAreaStyle={listHeightStyle('5rem')}>
+          {availableViews.length === 0 ? (
+            <CommandPlaceholder>No saved views</CommandPlaceholder>
+          ) : (
+            <CommandGroup aria-label='Saved views'>
+              {availableViews.map((view: TableView) => (
+                <CommandItem
+                  key={view.id}
+                  value={view.id}
+                  onSelect={() => {
+                    selectView(view)
+                    setMode('records')
+                  }}>
+                  <ListFilter />
+                  <span className='truncate'>{view.name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    )
+  }
+
+  return (
+    <Command shouldFilter={false} className='overflow-hidden rounded-2xl'>
+      <div className='flex items-center justify-between gap-2 border-b px-3 py-1.5'>
+        <span className='min-w-0 truncate text-xs text-muted-foreground'>
+          {isReconstructed ? 'Showing' : 'From'}{' '}
+          <span className='font-medium text-foreground'>{descriptor.label}</span>
+        </span>
+        {availableViews.length > 0 && (
+          <Button
+            variant='ghost'
+            size='sm'
+            className='h-6 px-1.5 text-xs'
+            onClick={() => setMode('views')}>
+            Switch
+          </Button>
+        )}
+      </div>
+
+      <CommandInput
+        placeholder='Search in this list...'
+        value={search}
+        onValueChange={setSearch}
+        loading={isSearching}
+      />
+
+      {/* Header + input + pinned create footer are all outside this scroller, so
+          the allowance below keeps the popover inside the viewport on a short
+          screen instead of pushing the create row off it. */}
+      <CommandList scrollAreaStyle={listHeightStyle('9rem')}>
+        {activeItem && !searchFilters && (
+          <>
+            <CommandGroup aria-label='Current record'>
+              <RecordItem
+                item={activeItem}
+                isSelected
+                multi={false}
+                onToggle={() => onClose()}
+                showSecondary
+              />
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
+
+        {rows.length === 0 && !isHydrating && !isSearching && (
+          <CommandPlaceholder>
+            {searchFilters ? 'No matches in this list' : 'No other records'}
+          </CommandPlaceholder>
+        )}
+
+        {rows.length > 0 && (
+          <CommandGroup aria-label='Records'>
+            {rows.map((item) => (
+              <RecordItem
+                key={item.recordId}
+                item={item}
+                isSelected={false}
+                multi={false}
+                onToggle={handlePick}
+                showSecondary
+              />
+            ))}
+          </CommandGroup>
+        )}
+
+        {/* Scroll sentinel — grows the render window, then pages the server. */}
+        <div ref={sentinelRef} aria-hidden className='h-px' />
+
+        {!searchFilters && (
+          <div className='px-3 py-1.5 text-xs text-muted-foreground'>
+            {isLoadingMore
+              ? 'Loading…'
+              : hasMore || listIds.length < total
+                ? `Showing ${Math.min(visibleCount, listIds.length)} of ${total}`
+                : `${listIds.length} record${listIds.length === 1 ? '' : 's'}`}
+          </div>
+        )}
+      </CommandList>
+
+      {/* Pinned OUTSIDE CommandList: the list scrolls to hundreds of rows, so a
+          nested create row (as the record picker and EntitySwitcherList both
+          have) would be unreachable at the bottom of the scroller.
+
+          NOTE: cmdk scopes its item registry to the list element, so this item is
+          not reached by arrow keys or `End` — `End` lands on the last row inside
+          the scroller. Click works (CommandItem binds its own onClick). If the
+          keyboard gap matters, swap this for a plain `<button>`, which is at
+          least Tab-focusable. */}
+      {canEdit && resource && (
+        <CommandGroup aria-label='Create' className='border-t'>
+          <CommandItem value='__create__' onSelect={onCreate}>
+            <Plus />
+            Create {resource.label}
+          </CommandItem>
+        </CommandGroup>
+      )}
+    </Command>
+  )
+}

--- a/apps/web/src/components/records/nav/use-record-list-context-publisher.ts
+++ b/apps/web/src/components/records/nav/use-record-list-context-publisher.ts
@@ -1,0 +1,63 @@
+// apps/web/src/components/records/nav/use-record-list-context-publisher.ts
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { useEffect } from 'react'
+import { useRecordListContextStore } from './record-list-context-store'
+
+interface UseRecordListContextPublisherOptions {
+  entityDefinitionId: string | undefined
+  tableId: string
+  /** The merged filters actually sent to `record.listFiltered`. */
+  filters: ConditionGroup[] | undefined
+  sorting: Array<{ id: string; desc: boolean }> | undefined
+  viewId: string | null
+  label: string | undefined
+  /** Loaded ids in display order. */
+  ids: string[]
+  /** False while the table's own config is still hydrating. */
+  enabled: boolean
+}
+
+const EMPTY_FILTERS: ConditionGroup[] = []
+const EMPTY_SORTING: Array<{ id: string; desc: boolean }> = []
+
+/**
+ * Publish the list a surface is currently showing, so a detail page opened from
+ * it can walk the same records in the same order.
+ *
+ * Mounted once inside `DynamicResourceView`, which is the only place that holds
+ * the merged filters, the sorting and the loaded ids together. Capturing there
+ * means no navigation call site has to be touched — the primary cell's "Open
+ * full page", the drawer's fullscreen button and a pasted link all inherit it.
+ *
+ * The store de-dupes identical captures, so the effect firing on every table
+ * render is cheap.
+ */
+export function useRecordListContextPublisher({
+  entityDefinitionId,
+  tableId,
+  filters,
+  sorting,
+  viewId,
+  label,
+  ids,
+  enabled,
+}: UseRecordListContextPublisherOptions): void {
+  const capture = useRecordListContextStore((s) => s.capture)
+
+  useEffect(() => {
+    if (!enabled || !entityDefinitionId || ids.length === 0) return
+    capture(
+      {
+        entityDefinitionId,
+        filters: filters ?? EMPTY_FILTERS,
+        sorting: sorting ?? EMPTY_SORTING,
+        tableId,
+        viewId,
+        label: label ?? 'List',
+      },
+      ids
+    )
+  }, [capture, enabled, entityDefinitionId, filters, sorting, tableId, viewId, label, ids])
+}

--- a/apps/web/src/components/records/nav/use-record-nav-context.test.tsx
+++ b/apps/web/src/components/records/nav/use-record-nav-context.test.tsx
@@ -1,0 +1,338 @@
+// apps/web/src/components/records/nav/use-record-nav-context.test.tsx
+//
+// The hook decides which list a detail page is inside. Everything visible —
+// the switcher's rows, whether the arrows work, what a shared link restores —
+// falls out of that decision, so what is pinned here is the resolution ORDER
+// and the two invariants the rest of the feature assumes:
+//
+//   * ids are append-only for the life of a descriptor (a record edited out of
+//     the filter it was found under must not vanish from under the arrows), and
+//   * navigation carries the query string (losing `?tab=` on every arrow press
+//     would be the loudest possible regression).
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const DEF = 'edf_contact00000000000000000'
+const TABLE_ID = `entity-${DEF}`
+
+const h = vi.hoisted(() => ({
+  push: vi.fn(),
+  /** Current URL query, controlled per test. */
+  searchParams: new URLSearchParams(),
+  /** `?list=` value, controlled per test. */
+  listToken: null as string | null,
+  setListToken: vi.fn(),
+  /** Inputs every `listFiltered.fetch` was called with. */
+  fetchCalls: [] as Array<{ offset?: number; limit?: number }>,
+  /** Pages the fake server hands back, in order. */
+  pages: [] as Array<{ ids: string[]; total?: number; hasMore: boolean }>,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: h.push, replace: vi.fn(), refresh: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => h.searchParams,
+  usePathname: () => '/app/contacts/ein_a',
+}))
+
+vi.mock('nuqs', () => ({
+  useQueryState: () => [h.listToken, h.setListToken],
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      record: {
+        listFiltered: {
+          fetch: (input: { offset?: number; limit?: number }) => {
+            h.fetchCalls.push({ offset: input.offset, limit: input.limit })
+            const page = h.pages.shift() ?? { ids: [], hasMore: false }
+            return Promise.resolve(page)
+          },
+        },
+      },
+    }),
+  },
+}))
+
+// The link builder needs a resource; the shape below is the only part read.
+vi.mock('~/components/resources', () => ({
+  useResource: () => ({
+    resource: { id: DEF, apiSlug: 'contacts', entityType: 'contact', entityDefinitionId: DEF },
+  }),
+}))
+
+vi.mock('~/components/resources/utils/get-record-link', () => ({
+  getRecordLink: (recordId: string) => `/app/contacts/${recordId.split(':')[1]}`,
+}))
+
+import { useDynamicTableStore } from '~/components/dynamic-table/stores/dynamic-table-store'
+import type { TableView } from '~/components/dynamic-table/types'
+import {
+  clearRecordListContext,
+  type RecordListDescriptor,
+  useRecordListContextStore,
+} from './record-list-context-store'
+import { useRecordNavContext } from './use-record-nav-context'
+
+const recordId = (instanceId: string) => `${DEF}:${instanceId}` as never
+
+function descriptor(overrides: Partial<RecordListDescriptor> = {}): RecordListDescriptor {
+  return {
+    entityDefinitionId: DEF,
+    filters: [],
+    sorting: [],
+    tableId: TABLE_ID,
+    viewId: 'tv_captured',
+    label: 'My hot leads',
+    ...overrides,
+  }
+}
+
+function seedViews(views: TableView[]) {
+  useDynamicTableStore.setState({
+    viewsByTableId: { [TABLE_ID]: views },
+    viewFilters: {},
+    viewConfigs: {},
+    initialized: true,
+  })
+}
+
+const view = (id: string, name: string, extra: Partial<TableView> = {}): TableView =>
+  ({ id, name, tableId: TABLE_ID, config: { filters: [], sorting: [] }, ...extra }) as TableView
+
+/**
+ * A captured page long enough that the open record sits outside the prefetch
+ * margin. Short lists legitimately trigger a "is there more?" fetch on mount —
+ * `hasMore` starts optimistic because a capture cannot say whether the surface
+ * had reached the end — so tests that are not about paging use this.
+ */
+const IDS_20 = Array.from({ length: 20 }, (_, i) => `ein_${i}`)
+
+beforeEach(() => {
+  h.push.mockClear()
+  h.setListToken.mockClear()
+  h.searchParams = new URLSearchParams()
+  h.listToken = null
+  h.fetchCalls = []
+  h.pages = []
+  clearRecordListContext()
+  useDynamicTableStore.setState({
+    viewsByTableId: {},
+    viewFilters: {},
+    viewConfigs: {},
+    initialized: false,
+  })
+})
+
+describe('resolution order', () => {
+  it('prefers the descriptor captured by a real table', () => {
+    seedViews([view('tv_default', 'All contacts', { isDefault: true, isShared: true })])
+    h.listToken = 'v:tv_default'
+    useRecordListContextStore.getState().capture(descriptor(), IDS_20)
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_0')))
+
+    // The captured one wins over BOTH the URL token and the default view — it is
+    // the only source that carries the search bar and unsaved overlays.
+    expect(result.current?.descriptor.label).toBe('My hot leads')
+    expect(result.current?.isReconstructed).toBe(false)
+    expect(result.current?.ids).toEqual(IDS_20)
+    // A warm capture costs nothing: the ids came straight off it.
+    expect(h.fetchCalls).toHaveLength(0)
+  })
+
+  it('falls back to the `?list=` token when nothing was captured', async () => {
+    seedViews([
+      view('tv_default', 'All contacts', { isDefault: true, isShared: true }),
+      view('tv_shared', 'Shared with me'),
+    ])
+    h.listToken = 'v:tv_shared'
+    h.pages = [{ ids: ['ein_a'], total: 1, hasMore: false }]
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_a')))
+
+    await waitFor(() => expect(result.current?.descriptor.label).toBe('Shared with me'))
+    expect(result.current?.isReconstructed).toBe(true)
+  })
+
+  it('falls back to the definition default view when there is no token', async () => {
+    seedViews([view('tv_default', 'All contacts', { isDefault: true, isShared: true })])
+    h.pages = [{ ids: ['ein_a'], total: 1, hasMore: false }]
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_a')))
+
+    await waitFor(() => expect(result.current?.descriptor.label).toBe('All contacts'))
+    expect(result.current?.isReconstructed).toBe(true)
+  })
+
+  it('returns null while the view store is still hydrating', () => {
+    // `initialized: false` — a cold load must show the static breadcrumb label
+    // rather than flashing an empty switcher.
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_a')))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when the definition has no views and nothing was captured', () => {
+    seedViews([])
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_a')))
+    expect(result.current).toBeNull()
+  })
+})
+
+describe('cold start', () => {
+  it('asks for one wide window, so a deep link can locate its own index', async () => {
+    seedViews([view('tv_default', 'All contacts', { isDefault: true, isShared: true })])
+    h.pages = [{ ids: ['ein_a', 'ein_b', 'ein_c'], total: 3, hasMore: false }]
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_b')))
+
+    await waitFor(() => expect(result.current?.ids).toHaveLength(3))
+    expect(h.fetchCalls[0]).toEqual({ offset: 0, limit: 500 })
+    expect(result.current?.index).toBe(1)
+    expect(result.current?.total).toBe(3)
+  })
+})
+
+describe('append-only ids', () => {
+  it('keeps a record that the source list dropped', () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    useRecordListContextStore.getState().capture(descriptor(), IDS_20)
+
+    const { result, rerender } = renderHook(() => useRecordNavContext(recordId('ein_5')))
+    expect(result.current?.index).toBe(5)
+
+    // The table refetched and `ein_5` no longer matches the filter — e.g. the
+    // user just edited its status on this very page.
+    act(() => {
+      useRecordListContextStore.getState().capture(
+        descriptor(),
+        IDS_20.filter((id) => id !== 'ein_5')
+      )
+    })
+    rerender()
+
+    // Membership is frozen for the life of the descriptor, so the arrows keep
+    // working instead of dying under the user mid-session.
+    expect(result.current?.ids).toEqual(IDS_20)
+    expect(result.current?.index).toBe(5)
+    expect(result.current?.hasPrev).toBe(true)
+    expect(result.current?.hasNext).toBe(true)
+  })
+})
+
+describe('arrows', () => {
+  it('disables both ends when the record is not in the list', () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    useRecordListContextStore.getState().capture(descriptor(), IDS_20)
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_zzz')))
+
+    expect(result.current?.index).toBe(-1)
+    expect(result.current?.hasPrev).toBe(false)
+    expect(result.current?.hasNext).toBe(false)
+  })
+
+  it('disables prev at the head', () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    useRecordListContextStore.getState().capture(descriptor(), IDS_20)
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_0')))
+    expect(result.current?.hasPrev).toBe(false)
+    expect(result.current?.hasNext).toBe(true)
+  })
+
+  it('disables next at the tail, once the server confirms there is no more', async () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    useRecordListContextStore.getState().capture(descriptor(), IDS_20)
+    h.pages = [{ ids: [], hasMore: false }]
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_19')))
+
+    // Standing on the last loaded row asks for the next page first — only an
+    // empty answer turns the arrow off.
+    await waitFor(() => expect(result.current?.hasMore).toBe(false))
+    expect(result.current?.hasNext).toBe(false)
+  })
+
+  it('carries the whole query string across the hop', () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    useRecordListContextStore.getState().capture(descriptor(), IDS_20)
+    h.searchParams = new URLSearchParams('tab=activity&list=v%3Atv_captured')
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_0')))
+    act(() => result.current?.goNext())
+
+    // `?tab=` surviving is the difference between the arrows being usable and
+    // being a trap that resets the page on every press.
+    expect(h.push).toHaveBeenCalledWith('/app/contacts/ein_1?tab=activity&list=v%3Atv_captured')
+  })
+
+  it('does nothing at a dead end', async () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    useRecordListContextStore.getState().capture(descriptor(), ['ein_only'])
+    h.pages = [{ ids: [], hasMore: false }]
+
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_only')))
+    await waitFor(() => expect(result.current?.hasMore).toBe(false))
+
+    act(() => result.current?.goPrev())
+    act(() => result.current?.goNext())
+
+    expect(h.push).not.toHaveBeenCalled()
+  })
+})
+
+describe('prefetch', () => {
+  it('pulls the next page when the open record nears the loaded edge', async () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    const ids = Array.from({ length: 10 }, (_, i) => `ein_${i}`)
+    useRecordListContextStore.getState().capture(descriptor(), ids)
+    h.pages = [{ ids: ['ein_10', 'ein_11'], hasMore: false }]
+
+    // Index 7 of 10 — inside the 5-row margin.
+    const { result } = renderHook(() => useRecordNavContext(recordId('ein_7')))
+
+    await waitFor(() => expect(h.fetchCalls).toHaveLength(1))
+    // Extending an existing list uses the normal page size, and resumes at the
+    // end of what we already hold rather than refetching from zero.
+    expect(h.fetchCalls[0]).toEqual({ offset: 10, limit: 100 })
+    await waitFor(() => expect(result.current?.ids).toHaveLength(12))
+  })
+
+  it('stays quiet while the record is far from the edge', async () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    const ids = Array.from({ length: 30 }, (_, i) => `ein_${i}`)
+    useRecordListContextStore.getState().capture(descriptor(), ids)
+
+    renderHook(() => useRecordNavContext(recordId('ein_0')))
+
+    await new Promise((r) => setTimeout(r, 20))
+    expect(h.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('the ?list= token', () => {
+  it('is written for a descriptor backed by a saved view', async () => {
+    seedViews([view('tv_captured', 'My hot leads')])
+    useRecordListContextStore.getState().capture(descriptor(), IDS_20)
+
+    renderHook(() => useRecordNavContext(recordId('ein_0')))
+
+    await waitFor(() => expect(h.setListToken).toHaveBeenCalledWith('v:tv_captured'))
+  })
+
+  it('is NOT written for a session-filtered list', async () => {
+    seedViews([view('tv_default', 'All contacts', { isDefault: true, isShared: true })])
+    // `viewId: null` — filters that live only in this tab's session. A token
+    // here would promise a reload that restores something it cannot restore.
+    useRecordListContextStore
+      .getState()
+      .capture(descriptor({ viewId: null, label: 'Filtered' }), IDS_20)
+
+    renderHook(() => useRecordNavContext(recordId('ein_0')))
+
+    await new Promise((r) => setTimeout(r, 20))
+    expect(h.setListToken).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/records/nav/use-record-nav-context.ts
+++ b/apps/web/src/components/records/nav/use-record-nav-context.ts
@@ -1,0 +1,321 @@
+// apps/web/src/components/records/nav/use-record-nav-context.ts
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useQueryState } from 'nuqs'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useDynamicTableStore } from '~/components/dynamic-table/stores/dynamic-table-store'
+import { useViewStoreInitialized } from '~/components/dynamic-table/stores/store-selectors'
+import type { TableView, ViewConfig } from '~/components/dynamic-table/types'
+import { useResource } from '~/components/resources'
+import { getRecordLink } from '~/components/resources/utils/get-record-link'
+import { api } from '~/trpc/react'
+import {
+  type RecordListDescriptor,
+  useRecordListContext,
+  useRecordListContextStore,
+} from './record-list-context-store'
+
+/** Page size when extending a list we already have rows for. */
+const PAGE_SIZE = 100
+/**
+ * Page size for the FIRST fetch of a reconstructed list. A deep link has no
+ * captured ids, so this single window is the only chance to locate the open
+ * record's index without walking dozens of pages — see the plan's "cold-start
+ * index problem". 500 is `record.listFiltered`'s ceiling.
+ */
+const COLD_PAGE_SIZE = 500
+/** Distance from the loaded edge at which we start pulling the next page. */
+const PREFETCH_MARGIN = 5
+
+const EMPTY_FILTERS: ConditionGroup[] = []
+const EMPTY_SORTING: Array<{ id: string; desc: boolean }> = []
+
+export interface RecordNavContext {
+  descriptor: RecordListDescriptor
+  /** Loaded ids in list order. Append-only for the life of a descriptor. */
+  ids: string[]
+  /** Position of the open record, or -1 when it is not in the list. */
+  index: number
+  /** Total matching rows, when the server reported one (first page only). */
+  total: number
+  hasPrev: boolean
+  hasNext: boolean
+  goPrev: () => void
+  goNext: () => void
+  /** Navigate to any record of this definition, preserving the query string. */
+  goTo: (entityInstanceId: string) => void
+  /** Pull the next page. The switcher calls this on scroll-end. */
+  loadMore: () => void
+  hasMore: boolean
+  isLoadingMore: boolean
+  /**
+   * True when the descriptor was rebuilt from the `?list=` token or the def's
+   * default view rather than captured from a real table. Ad-hoc search-bar
+   * conditions are lost in that case, which is why the popover names the list.
+   */
+  isReconstructed: boolean
+  /** Swap to a different saved view of the same definition. */
+  selectView: (view: TableView) => void
+}
+
+/** Build a descriptor from a saved view row. */
+function descriptorFromView(
+  entityDefinitionId: string,
+  tableId: string,
+  view: TableView,
+  filters: ConditionGroup[] | undefined,
+  sorting: Array<{ id: string; desc: boolean }> | undefined
+): RecordListDescriptor {
+  return {
+    entityDefinitionId,
+    filters: filters ?? (view.config as ViewConfig)?.filters ?? EMPTY_FILTERS,
+    sorting: sorting ?? (view.config as ViewConfig)?.sorting ?? EMPTY_SORTING,
+    tableId,
+    viewId: view.id,
+    label: view.name,
+  }
+}
+
+/**
+ * Resolve which list the open record belongs to, and expose prev/next over it.
+ *
+ * Resolution order — first hit wins:
+ *   1. The descriptor captured by a table this session (authoritative: it carries
+ *      the search bar and any unsaved filter/sort overlays).
+ *   2. `?list=v:<viewId>` from the URL — a reload or a shared link.
+ *   3. The definition's default saved view — arrived from a relationship cell,
+ *      Kopilot, a dashboard widget or mail.
+ *   4. Nothing → returns `null`, and the caller renders a plain breadcrumb.
+ *
+ * Returns `null` while the view store is still hydrating, so a cold load shows
+ * the static label rather than flashing an empty switcher.
+ */
+export function useRecordNavContext(recordId: RecordId): RecordNavContext | null {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  const tableId = `entity-${entityDefinitionId}`
+
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const utils = api.useUtils()
+  const { resource } = useResource(entityDefinitionId)
+
+  const storeInitialized = useViewStoreInitialized()
+  const captured = useRecordListContext(entityDefinitionId)
+  const capture = useRecordListContextStore((s) => s.capture)
+  const [listToken, setListToken] = useQueryState('list', { history: 'replace' })
+
+  // ─── RESOLVE THE DESCRIPTOR ──────────────────────────────────────────────
+  // Views for this definition's table, plus the raw filter/sort slices, so a
+  // reconstructed descriptor matches what the table itself would have run.
+  const views = useDynamicTableStore((s) => s.viewsByTableId[tableId])
+  const viewFilters = useDynamicTableStore((s) => s.viewFilters)
+  const viewConfigs = useDynamicTableStore((s) => s.viewConfigs)
+
+  const tokenViewId = listToken?.startsWith('v:') ? listToken.slice(2) : null
+
+  const resolved = useMemo((): {
+    descriptor: RecordListDescriptor
+    reconstructed: boolean
+  } | null => {
+    // 1 — captured from a real table this session.
+    if (captured) return { descriptor: captured.descriptor, reconstructed: false }
+    if (!storeInitialized) return null
+
+    const candidates = views ?? []
+    // 2 — the URL token.
+    const fromToken = tokenViewId ? candidates.find((v) => v.id === tokenViewId) : undefined
+    // 3 — the definition's default view. Prefer the org default; fall back to
+    //     any personal default, then to the first view that exists.
+    const fallback =
+      candidates.find((v) => v.isDefault && v.isShared) ??
+      candidates.find((v) => v.isDefault) ??
+      candidates[0]
+
+    const view = fromToken ?? fallback
+    if (!view) return null
+
+    return {
+      descriptor: descriptorFromView(
+        entityDefinitionId,
+        tableId,
+        view,
+        viewFilters[view.id],
+        viewConfigs[view.id]?.sorting
+      ),
+      reconstructed: true,
+    }
+  }, [
+    captured,
+    storeInitialized,
+    views,
+    tokenViewId,
+    viewFilters,
+    viewConfigs,
+    entityDefinitionId,
+    tableId,
+  ])
+
+  const descriptor = resolved?.descriptor ?? null
+  const isReconstructed = resolved?.reconstructed ?? false
+
+  // Identity of the current list. Everything below resets when it changes.
+  const descriptorKey = useMemo(
+    () =>
+      descriptor
+        ? JSON.stringify([descriptor.entityDefinitionId, descriptor.filters, descriptor.sorting])
+        : null,
+    [descriptor]
+  )
+
+  // ─── IDS: APPEND-ONLY ────────────────────────────────────────────────────
+  // Membership and order freeze on entry; paging appends. A record edited out of
+  // the filter it was found under must not vanish from under the arrows.
+  const [ids, setIds] = useState<string[]>(() => captured?.ids ?? [])
+  const [total, setTotal] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+
+  const idsRef = useRef(ids)
+  idsRef.current = ids
+  const hasMoreRef = useRef(hasMore)
+  hasMoreRef.current = hasMore
+  const loadingRef = useRef(false)
+  const seededKeyRef = useRef<string | null>(null)
+
+  // Reset on a genuinely different list — not on a data refetch.
+  useEffect(() => {
+    if (descriptorKey === null || seededKeyRef.current === descriptorKey) return
+    seededKeyRef.current = descriptorKey
+    const seed = captured?.ids ?? []
+    setIds(seed)
+    setTotal(0)
+    setHasMore(true)
+    loadingRef.current = false
+  }, [descriptorKey, captured?.ids])
+
+  const loadMore = useCallback(() => {
+    if (!descriptor || loadingRef.current || !hasMoreRef.current) return
+    loadingRef.current = true
+    setIsLoadingMore(true)
+    const offset = idsRef.current.length
+    void utils.record.listFiltered
+      .fetch({
+        entityDefinitionId: descriptor.entityDefinitionId,
+        filters: descriptor.filters.length > 0 ? descriptor.filters : undefined,
+        sorting: descriptor.sorting.length > 0 ? descriptor.sorting : undefined,
+        limit: offset === 0 ? COLD_PAGE_SIZE : PAGE_SIZE,
+        offset,
+      })
+      .then((result) => {
+        setIds((prev) => {
+          const seen = new Set(prev)
+          const next = [...prev]
+          for (const id of result.ids) {
+            if (!seen.has(id)) next.push(id)
+          }
+          return next
+        })
+        // `total` rides on the first page only — the server skips the COUNT for
+        // offset > 0, so a later page must not clobber it with 0.
+        if (typeof result.total === 'number' && result.total > 0) setTotal(result.total)
+        setHasMore(result.hasMore)
+      })
+      .finally(() => {
+        loadingRef.current = false
+        setIsLoadingMore(false)
+      })
+  }, [descriptor, utils])
+
+  // Initial fill for a reconstructed list — nothing captured it, so ask for the
+  // one wide window that decides whether the arrows can work at all.
+  useEffect(() => {
+    if (!descriptor || ids.length > 0 || !hasMore || loadingRef.current) return
+    loadMore()
+  }, [descriptor, ids.length, hasMore, loadMore])
+
+  const index = useMemo(() => ids.indexOf(entityInstanceId), [ids, entityInstanceId])
+
+  // Pull the next page before the user reaches the edge, so holding J does not
+  // stall at row 100.
+  useEffect(() => {
+    if (index < 0 || !hasMore) return
+    if (index >= ids.length - PREFETCH_MARGIN) loadMore()
+  }, [index, ids.length, hasMore, loadMore])
+
+  // ─── NAVIGATION ──────────────────────────────────────────────────────────
+  const goTo = useCallback(
+    (targetInstanceId: string) => {
+      if (!targetInstanceId || !resource) return
+      const href = getRecordLink(toRecordId(entityDefinitionId, targetInstanceId), resource)
+      if (!href) return
+      // Carry the whole query string across the hop — losing `?tab=` on every
+      // arrow press would be the most irritating possible regression here.
+      const qs = searchParams.toString()
+      router.push(qs ? `${href}?${qs}` : href)
+    },
+    [resource, entityDefinitionId, router, searchParams]
+  )
+
+  const hasPrev = index > 0
+  const hasNext = index >= 0 && index < ids.length - 1
+
+  const goPrev = useCallback(() => {
+    const target = hasPrev ? ids[index - 1] : undefined
+    if (target) goTo(target)
+  }, [hasPrev, goTo, ids, index])
+
+  const goNext = useCallback(() => {
+    const target = hasNext ? ids[index + 1] : undefined
+    if (target) goTo(target)
+  }, [hasNext, goTo, ids, index])
+
+  // ─── SWITCHING LISTS ─────────────────────────────────────────────────────
+  const selectView = useCallback(
+    (view: TableView) => {
+      const next = descriptorFromView(
+        entityDefinitionId,
+        tableId,
+        view,
+        viewFilters[view.id],
+        viewConfigs[view.id]?.sorting
+      )
+      // Capture with no ids: the picked view has never been rendered here, so
+      // the seed effect refills it from the server.
+      capture(next, [])
+      void setListToken(`v:${view.id}`)
+    },
+    [entityDefinitionId, tableId, viewFilters, viewConfigs, capture, setListToken]
+  )
+
+  // ─── THE `?list=` TOKEN ──────────────────────────────────────────────────
+  // Written here rather than at every navigation call site. Only descriptors
+  // backed by a saved view are reconstructable; a token for a session-filtered
+  // list would lie about what reload restores, so those write nothing.
+  const desiredToken = descriptor?.viewId ? `v:${descriptor.viewId}` : null
+  useEffect(() => {
+    if (!desiredToken || listToken === desiredToken) return
+    void setListToken(desiredToken)
+  }, [desiredToken, listToken, setListToken])
+
+  if (!descriptor) return null
+
+  return {
+    descriptor,
+    ids,
+    index,
+    total: total || ids.length,
+    hasPrev,
+    hasNext,
+    goPrev,
+    goNext,
+    goTo,
+    loadMore,
+    hasMore,
+    isLoadingMore,
+    isReconstructed,
+    selectView,
+  }
+}

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -7,6 +7,7 @@ import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useMemo } from 'react'
 import { client as authClient } from '~/auth/auth-client'
 import { clearChannelCaches } from '~/components/channels/providers/channel-provider'
+import { clearRecordListContext } from '~/components/records/nav/record-list-context-store'
 import { clearResourceCaches } from '~/components/resources'
 import { useOrgDeepLink } from '~/hooks/use-org-deep-link'
 import {
@@ -172,6 +173,7 @@ export function useUser(options: UseUserOptions = {}): UseUserResult {
       setOrganizationId(newOrganizationId)
       clearResourceCaches()
       clearChannelCaches()
+      clearRecordListContext()
 
       // Persist to server
       switchOrganizationMutation.mutate(


### PR DESCRIPTION
The record detail page's breadcrumb tail becomes a **record switcher** plus **prev/next arrows**, over the same records, in the same order, under the same filters and sorting as the table the page was opened from.

`Contacts › [Russell Winfield ▾] [↑] [↓]`

## The actual problem

Not the UI — answering *"which list am I inside?"* for every way a user can arrive at a detail page:

| Arrival | Resolves to |
|---|---|
| Clicked a row in a table | The captured descriptor — authoritative, carries the search bar and unsaved filter/sort overlays |
| Reload / shared link | `?list=v:<viewId>`, rebuilt from the global table store |
| Relationship cell, Kopilot, dashboard widget, mail | The definition's default saved view |
| Nothing resolves | Breadcrumb keeps its plain terminal label — no switcher, no arrows |

A `RecordListDescriptor` (merged filters + sorting + view id + label) is captured by `DynamicResourceView` — the one place that holds all of it at once — so **no navigation call site had to be touched**. "Open full page", the drawer's fullscreen button and a pasted link all inherit it.

An embedded table publishes too, so opening a ticket from a contact's Tickets tab walks *that contact's* tickets. `listContextLabel` names such a list; `publishListContext={false}` opts out.

## Decisions worth reviewing

**Ids are append-only for the life of a descriptor.** Filters here are real — edit a record so it stops matching "My open leads" and a live list drops the row out from under the arrows mid-session. Names and values stay live; only membership freezes.

**The switcher is not built on `RecordPickerContent`.** Its rows come only from `record.search`, which takes no filters and no sorting, so it would offer a different set in a different order than the list being walked. Search here ANDs a `contains` condition onto the descriptor's own filters — a strict subset, same query path, same access scoping. What *is* reused is the leaf: `RecordItem` stays the single definition of what a record row looks like, and `useRelationship` does the batched hydration.

**Paging drains `listFiltered` imperatively** rather than going through `useRecordList`. That hook's `shouldFetch = enabled && !cachedList` disables its infinite query inside the list cache's 5-minute TTL — exactly the warm client-nav case — so `fetchNextPage()` would have had no pages to derive an offset from and refetched page 1. Same pattern `use-calendar-events.ts` already uses.

**Create is pinned below the scroll area,** not inside it — the list pages to hundreds of rows, so a nested create row (as the record picker and `EntitySwitcherList` both have) scrolls out of reach. Verified in-browser: cmdk scopes its item registry to the list element, so that row is **click-only** — arrow keys and `End` stop at the last row inside the scroller. Noted in a comment; swap for a plain `<button>` if the keyboard gap matters.

## Deliberately not built

A `record.listNeighbors` procedure. It is the only fully correct answer for a deep link landing at offset 4,000 of 40,000, and it duplicates `UnifiedCrudHandler`'s ordering in SQL including custom-field sorts. Instead a deep link gets one 500-row `listFiltered` window to locate its own index; outside it the switcher still browses and the arrows disable with a tooltip naming the list. Same treatment when a record is edited out of its own filter.

## Test plan

- 25 unit tests: `record-list-context-store.test.ts` (capture de-dupe, per-definition keying, replace-not-merge on filter change) and `use-record-nav-context.test.tsx` (resolution order, append-only ids, cold-start window, query-string preservation, prefetch margin, `?list=` write rules)
- Typecheck: zero errors in every touched file; repo-wide count unchanged from baseline
- Verified live: breadcrumb renders, popover lists the view's records with the active one pinned and checked, `?list=` written, popover height capped at 320px list / 429px total

## Note on the unrelated diff

`use-user.ts`, `create-org-dialog.tsx` and `organization-item.tsx` each gain one `clearRecordListContext()` call beside the existing `clearResourceCaches()` / `clearChannelCaches()` pair. `useViewStoreClear` — the hook that looks like the right home for this — has zero callers and is dead code. Stale entries across an *org* switch are inert (definition ids are per-org rows), but a different *user* on the same browser and org would otherwise inherit the previous user's personal filter overlays.