### PR TITLE
feat(records): keyboard shortcuts, and the table row joins the shared actions menu

### DIFF
--- a/apps/web/src/components/detail-view/components/detail-view-actions.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.tsx
@@ -3,16 +3,18 @@
 
 import { parseRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
+import { Kbd } from '@auxx/ui/components/kbd'
 import { Share2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
 import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
 import { GranularPermissionsGate } from '~/components/mail-permissions/ui/granular-permissions-gate'
 import { InstanceShareAvatars } from '~/components/permissions/ui/instance-share-avatars'
 import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
 import { RecordRequestAccessPopover } from '~/components/permissions/ui/record-request-access-popover'
+import { useRecordShortcuts } from '~/components/records/hooks/use-record-shortcuts'
 import { RECORD_HEADER_GHOST, RecordActionsMenu } from '~/components/records/record-actions-menu'
 import { useRecordAccess } from '~/components/resources'
+import { MassWorkflowTriggerDialog } from '~/components/workflow/mass-workflow-trigger-dialog'
 import type { DetailViewActionsProps } from '../types'
 
 /**
@@ -44,6 +46,12 @@ import type { DetailViewActionsProps } from '../types'
  *
  * Both promoted items are passed to the menu as `omitItems` so they are not also
  * offered inside it.
+ *
+ * This is also the detail page's ONE mount of {@link useRecordShortcuts} — `R`,
+ * `F`, `W` and `Shift+S`. It goes here rather than in the page shell because the
+ * anchors those keys need (the request trigger, the star, the share dialog) are
+ * all already rendered here, and a second mount anywhere would double-fire every
+ * key.
  */
 export function DetailViewActions({
   entityType,
@@ -54,7 +62,21 @@ export function DetailViewActions({
   const router = useRouter()
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
   const { access, canShare } = useRecordAccess(recordId)
-  const [shareOpen, setShareOpen] = useState(false)
+
+  /**
+   * `R` / `F` / `W` / `Shift+S` for the record this page is about. `E` is not
+   * bound — this page IS the expanded view. Mounted HERE rather than in the page
+   * shell because this component already renders every anchor the keys need:
+   * the request-access trigger, the share dialog and the favourite star.
+   */
+  const {
+    requestAccessOpen,
+    setRequestAccessOpen,
+    shareOpen,
+    setShareOpen,
+    workflowOpen,
+    setWorkflowOpen,
+  } = useRecordShortcuts({ recordId, enabled: true })
 
   return (
     <div className='flex items-center gap-2'>
@@ -72,6 +94,9 @@ export function DetailViewActions({
               onClick={() => setShareOpen(true)}>
               <Share2 />
               Share
+              <Kbd variant='outline' size='sm'>
+                ⇧S
+              </Kbd>
             </Button>
           </div>
         </GranularPermissionsGate>
@@ -86,6 +111,9 @@ export function DetailViewActions({
             entityDefinitionId={entityDefinitionId}
             entityInstanceId={entityInstanceId}
             variant='header'
+            shortcut='R'
+            open={requestAccessOpen}
+            onOpenChange={setRequestAccessOpen}
           />
         </GranularPermissionsGate>
       )}
@@ -95,6 +123,7 @@ export function DetailViewActions({
         targetIds={{ entityDefinitionId, entityInstanceId }}
         size='icon-xs'
         className={RECORD_HEADER_GHOST}
+        shortcut='F'
       />
 
       <RecordActionsMenu
@@ -110,6 +139,17 @@ export function DetailViewActions({
 
       {shareOpen && (
         <InstanceShareDialog recordId={recordId} open={shareOpen} onOpenChange={setShareOpen} />
+      )}
+
+      {/* `W`'s target. The menu's own "Run workflow" submenu triggers a chosen
+          workflow directly; the shortcut has nothing chosen yet, so it opens the
+          picker — the same dialog mail's `W` opens for a thread. */}
+      {workflowOpen && (
+        <MassWorkflowTriggerDialog
+          open={workflowOpen}
+          onOpenChange={setWorkflowOpen}
+          recordIds={[recordId]}
+        />
       )}
     </div>
   )

--- a/apps/web/src/components/detail-view/tabs/ticket-conversation-tab.tsx
+++ b/apps/web/src/components/detail-view/tabs/ticket-conversation-tab.tsx
@@ -12,7 +12,7 @@ import { EmptyState } from '~/components/global/empty-state'
 import { MailFilterProvider } from '~/components/mail/mail-filter-context'
 import { MailThreadItem } from '~/components/mail/mail-thread-item'
 import ThreadDetails from '~/components/mail/thread-details'
-import { ThreadProvider } from '~/components/mail/thread-provider'
+import { NestedThreadProvider, ThreadProvider } from '~/components/mail/thread-provider'
 import { useThreadMutation, useTicketThreads } from '~/components/threads/hooks'
 import type { ThreadMeta } from '~/components/threads/store'
 import type { DetailViewTabProps } from '../types'
@@ -81,12 +81,28 @@ export function TicketConversationTab({ entityInstanceId, recordId, record }: De
         />
       )}
 
-      {/* Thread detail view */}
+      {/* Thread detail view.
+
+          ⚠ **`NestedThreadProvider`** — this was the ONE embedded `ThreadDetails`
+          mount without it (`ThreadDetailsDialog` has always had it), and all
+          three things it suppresses are right here:
+
+          1. **`R` / `F`.** `ThreadDetails` binds them to reply-all and forward.
+             The ticket detail page's header binds the same two letters to
+             request-access and favourite (`useRecordShortcuts`), and
+             `conflictBehavior: 'allow'` runs BOTH handlers — it does not pick a
+             winner. On a record's own page, the record's keys win.
+          2. **The linked-ticket badge**, whose own comment calls out this exact
+             recursion: the thread's ticket IS the ticket this page is about, so
+             the picker pointed at itself.
+          3. **Overscroll containment**, which is what an embedded pane wants. */}
       <div className='flex-1 min-h-0'>
         {selectedThreadId && (
-          <ThreadProvider threadId={selectedThreadId}>
-            <ThreadDetails />
-          </ThreadProvider>
+          <NestedThreadProvider value={true}>
+            <ThreadProvider threadId={selectedThreadId}>
+              <ThreadDetails />
+            </ThreadProvider>
+          </NestedThreadProvider>
         )}
       </div>
     </div>

--- a/apps/web/src/components/dynamic-table/cells/primary-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-cell.tsx
@@ -29,8 +29,26 @@ export interface PrimaryCellProps {
   /**
    * Dropdown menu items passed as children for maximum flexibility. When
    * omitted, the hover kebab menu is not rendered at all (widget/read-only use).
+   *
+   * ⚠ Items only — this cell owns the `DropdownMenu` wrapper, so anything passed
+   * here is mounted inside `DropdownMenuContent` and is unmounted with it. A menu
+   * that opens dialogs cannot be a child; pass it as {@link actions} instead.
    */
   children?: React.ReactNode
+
+  /**
+   * A COMPLETE menu (its own trigger, content and dialogs) rendered in the
+   * trailing slot instead of this cell's built-in kebab.
+   *
+   * Needed because a menu whose items open dialogs must mount those dialogs as
+   * SIBLINGS of its `DropdownMenu` — selecting an item closes the menu, and Radix
+   * unmounts the content with it, tearing down a dialog in the same tick it
+   * opened. `children` cannot express that; this can.
+   *
+   * Mutually exclusive with `children` in practice: when both are given, `actions`
+   * wins and the built-in kebab is not rendered.
+   */
+  actions?: React.ReactNode
 
   /** Optional inline node rendered right after the title (e.g. a source badge). */
   suffix?: React.ReactNode
@@ -53,19 +71,21 @@ export function PrimaryCell({
   prefixIcon,
   onTitleClick,
   children,
+  actions,
   suffix,
   fontWeight = 'medium',
   titleClassName = '',
 }: PrimaryCellProps) {
   const displayValue = value || fallbackText
   const fontWeightClass = fontWeight === 'normal' ? '' : `font-${fontWeight}`
+  const hasTrailing = !!actions || !!children
 
   return (
     <div className='flex items-center justify-between w-full min-h-9 pl-3 pr-1 text-sm group/primary'>
       <div
         className={cn(
           'flex items-center gap-1.5 min-w-0',
-          children ? 'max-w-[calc(100%-40px)]' : 'max-w-full'
+          hasTrailing ? 'max-w-[calc(100%-40px)]' : 'max-w-full'
         )}>
         <button
           className={cn(
@@ -83,19 +103,23 @@ export function PrimaryCell({
         {suffix}
       </div>
 
-      {children && (
+      {/* The stopPropagation wrapper is shared: either menu sits inside a row
+          whose own click opens the record, and neither should trigger it. */}
+      {hasTrailing && (
         <div onClick={(e) => e.stopPropagation()} className='shrink-0'>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant='ghost'
-                size='icon-xs'
-                className='rounded-md sm:opacity-0 sm:group-hover/primary:opacity-100 transition-opacity data-[state=open]:opacity-100!'>
-                <MoreVertical />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align='end'>{children}</DropdownMenuContent>
-          </DropdownMenu>
+          {actions ?? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant='ghost'
+                  size='icon-xs'
+                  className='rounded-md sm:opacity-0 sm:group-hover/primary:opacity-100 transition-opacity data-[state=open]:opacity-100!'>
+                  <MoreVertical />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>{children}</DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
@@ -35,6 +35,11 @@ interface PrimaryFieldCellProps {
    * is not rendered (widget/read-only use).
    */
   children?: ReactNode
+  /**
+   * A complete menu rendered instead of the built-in kebab — for menus that own
+   * their own dialogs. See {@link PrimaryCell}'s `actions`.
+   */
+  actions?: ReactNode
 }
 
 /**
@@ -50,6 +55,7 @@ export const PrimaryFieldCell = memo(function PrimaryFieldCell({
   rowId,
   onTitleClick,
   children,
+  actions,
 }: PrimaryFieldCellProps) {
   // Extract entityDefinitionId and fieldId from ResourceFieldId
   const { entityDefinitionId, fieldId } = useMemo(
@@ -133,6 +139,7 @@ export const PrimaryFieldCell = memo(function PrimaryFieldCell({
           inverse
         />
       }
+      actions={actions}
       suffix={
         <ConnectorSourceBadge sources={record?.sources} variant='icon' className='shrink-0' />
       }>

--- a/apps/web/src/components/favorites/ui/favorite-star-button.tsx
+++ b/apps/web/src/components/favorites/ui/favorite-star-button.tsx
@@ -14,6 +14,12 @@ interface Props<T extends FavoriteTargetType> extends Omit<ButtonProps, 'onClick
   /** Tailwind class(es) that reveal the button on hover of an ancestor group
    *  (e.g. 'group-hover/kb-item:flex') when not favorited. Omit to always show. */
   revealOnHoverClassName?: string
+  /**
+   * Key hint shown in the tooltip. Only pass it where the key is actually bound
+   * — this button appears in a dozen places and only the record surfaces bind
+   * `F`. A hint for a key that does nothing here is worse than no hint.
+   */
+  shortcut?: string
 }
 
 /** Reusable favorite/unfavorite star toggle for any favoritable target. */
@@ -22,12 +28,15 @@ export function FavoriteStarButton<T extends FavoriteTargetType>({
   targetIds,
   className,
   revealOnHoverClassName,
+  shortcut,
   ...props
 }: Props<T>) {
   const { toggle, isFavorited, isPending } = useFavoriteToggle(targetType, targetIds)
 
   return (
-    <SimpleTooltip content={isFavorited ? 'Remove from favorites' : 'Add to favorites'}>
+    <SimpleTooltip
+      content={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+      shortcut={shortcut}>
       <Button
         type='button'
         variant='ghost'

--- a/apps/web/src/components/permissions/ui/record-request-access-popover.tsx
+++ b/apps/web/src/components/permissions/ui/record-request-access-popover.tsx
@@ -42,6 +42,9 @@ export function RecordRequestAccessPopover({
   entityInstanceId,
   variant = 'inline',
   assumeNoAccess = false,
+  open: controlledOpen,
+  onOpenChange,
+  shortcut,
 }: {
   entityDefinitionId: string
   entityInstanceId: string
@@ -56,10 +59,25 @@ export function RecordRequestAccessPopover({
    * for a record the member demonstrably cannot reach (§8.3).
    */
   assumeNoAccess?: boolean
+  /**
+   * Optional controlled open state — how the `R` shortcut opens this popover on
+   * a surface that already renders its trigger. Omit for click-driven mounts.
+   */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  /** Key hint for the trigger — `'R'` where `useRecordShortcuts` is mounted. */
+  shortcut?: string
 }) {
   // Owned here, not in the shell, because it is the LAZY-PREFLIGHT gate: the
-  // hook only issues its query while the popover is open (§8.5 / D6).
-  const [open, setOpen] = useState(false)
+  // hook only issues its query while the popover is open (§8.5 / D6). A
+  // controlled parent replaces this value but NOT the gate — the preflight still
+  // keys off "is it open", so opening by keyboard costs exactly what clicking does.
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const open = controlledOpen ?? uncontrolledOpen
+  const setOpen = (next: boolean) => {
+    setUncontrolledOpen(next)
+    onOpenChange?.(next)
+  }
 
   const {
     currentRung,
@@ -96,6 +114,8 @@ export function RecordRequestAccessPopover({
       isWithdrawing={isWithdrawing}
       copy={copy}
       variant={variant}
+      shortcut={shortcut}
+      open={controlledOpen}
       onOpenChange={setOpen}
     />
   )

--- a/apps/web/src/components/permissions/ui/request-access-popover.tsx
+++ b/apps/web/src/components/permissions/ui/request-access-popover.tsx
@@ -4,6 +4,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Button } from '@auxx/ui/components/button'
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
+import { Kbd } from '@auxx/ui/components/kbd'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Textarea } from '@auxx/ui/components/textarea'
@@ -68,6 +69,26 @@ export interface RequestAccessPopoverProps extends RequestAccessState {
    * the query on this instead.
    */
   onOpenChange?: (open: boolean) => void
+  /**
+   * Optional controlled open state. Omit and the shell owns it (the default, and
+   * what every click-driven mount wants).
+   *
+   * Passing it is how a KEYBOARD shortcut reaches this popover: the trigger must
+   * still be mounted and visible for Radix to anchor to, but the thing that opens
+   * it lives outside. `onOpenChange` stays the notification either way, so the
+   * lazy-preflight seam behaves identically for both paths.
+   */
+  open?: boolean
+  /**
+   * Key hint for the trigger. Rendered as an inline `Kbd` on the labelled
+   * `header` variant and as a tooltip hint on the icon-only one — an icon button
+   * has no room for a key cap, and a key cap on a button with no label names
+   * nothing.
+   *
+   * Only pass it where the key is bound: `useRecordShortcuts` binds `R` on the
+   * record detail page and drawer, and nowhere else.
+   */
+  shortcut?: string
 }
 
 function initials(name: string | null): string {
@@ -109,15 +130,19 @@ export function RequestAccessPopover({
   footer,
   variant = 'inline',
   onOpenChange,
+  open: controlledOpen,
+  shortcut,
 }: RequestAccessPopoverProps) {
-  const [open, setOpen] = useState(false)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
   const [noteOpen, setNoteOpen] = useState(false)
   const [note, setNote] = useState('')
   const noteRef = useRef<HTMLTextAreaElement>(null)
 
+  const open = controlledOpen ?? uncontrolledOpen
+
   /** Every open/close path goes through here, so a lane cannot miss one. */
   const setOpenAndNotify = (next: boolean) => {
-    setOpen(next)
+    setUncontrolledOpen(next)
     onOpenChange?.(next)
   }
 
@@ -160,10 +185,12 @@ export function RequestAccessPopover({
 
   const trigger =
     variant === 'icon' ? (
-      <Button variant='ghost' size='icon' className='rounded-full hover:bg-foreground/10'>
-        <LockKeyhole />
-        <span className='sr-only'>{label}</span>
-      </Button>
+      <Tooltip content={label} shortcut={shortcut}>
+        <Button variant='ghost' size='icon' className='rounded-full hover:bg-foreground/10'>
+          <LockKeyhole />
+          <span className='sr-only'>{label}</span>
+        </Button>
+      </Tooltip>
     ) : variant === 'menu-item' ? (
       // `onSelect` is prevented so the host dropdown does NOT close: closing it
       // unmounts this trigger, and Radix anchors the popover to it.
@@ -183,6 +210,11 @@ export function RequestAccessPopover({
         className='hover:bg-foreground/10 data-[state=open]:bg-foreground/10'>
         <LockKeyhole />
         {label}
+        {shortcut && (
+          <Kbd variant='outline' size='sm'>
+            {shortcut}
+          </Kbd>
+        )}
       </Button>
     ) : (
       <Button variant='outline' size='sm'>

--- a/apps/web/src/components/records/hooks/use-record-shortcuts.ts
+++ b/apps/web/src/components/records/hooks/use-record-shortcuts.ts
@@ -1,0 +1,140 @@
+// apps/web/src/components/records/hooks/use-record-shortcuts.ts
+'use client'
+
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import { useHotkey } from '@tanstack/react-hotkeys'
+import { useCallback, useState } from 'react'
+import { useFavoriteToggle } from '~/components/favorites/hooks/use-favorite-toggle'
+import { useRecordAccess } from '~/components/resources'
+
+/**
+ * The record counterpart of mail's `use-focused-thread-shortcuts`.
+ *
+ * ## The bindings, and why each one is that key
+ *
+ * | Key | Action | Gate |
+ * |---|---|---|
+ * | `R` | Request access | `access === 'read'` — below it the surface never opened, above it there is nothing left to ask for |
+ * | `F` | Toggle favourite | none; a favourite is a personal bookmark keyed to the viewer, not a write on the record |
+ * | `W` | Run workflow | none; running one is the `view` rung (same reasoning as `WorkflowSubMenu`) |
+ * | `Shift+S` | Share | `canShare` — an `admin` row |
+ * | `E` | Expand to full page | `onExpand` provided (drawer only) |
+ *
+ * 🔴 **`Shift+S`, not `S`.** Fifteen command-palette chords begin with `s`
+ * (`s,g`, `s,m`, `s,w`, …), and `@tanstack/hotkeys` runs its `HotkeyManager` and
+ * `SequenceManager` as two independent `keydown` listeners with no cross-talk —
+ * so a plain `S` binding fires immediately AND leaves the chord buffer armed.
+ * Pressing `S`→`G` for Settings → General would open the share dialog on the way
+ * past. `floating-compose-root.tsx` solves the same collision for `C` by
+ * deferring 500ms and cancelling on a `c`-chord; that latency is worth paying for
+ * compose and is not worth paying for a share dialog.
+ *
+ * ## What this hook does NOT own
+ *
+ * `R` and `Shift+S` return controlled state rather than rendering anything,
+ * because both targets need a mounted anchor or an existing dialog:
+ * `RecordRequestAccessPopover` must anchor to a visible trigger, and the share
+ * dialog already exists on both surfaces. Only the workflow dialog is created
+ * here, since it has neither constraint.
+ *
+ * ## Mounting rule
+ *
+ * **Exactly one mount per visible record**, or every key fires twice —
+ * `conflictBehavior: 'allow'` means "both handlers run", not "one wins". The
+ * detail page mounts it in `DetailViewActions`; the drawer mounts it in
+ * `RecordDrawer`. Those two never coexist (the record detail page does not mount
+ * a `RecordDrawer`).
+ *
+ * ⚠ **In the mailbox the caller MUST pass `enabled: false`.** `mail-box.tsx`
+ * docks a `RecordDrawer` (the ticket drawer) beside a live thread, and mail binds
+ * `R` to reply-all (`thread-details.tsx:196`), `F` to forward
+ * (`thread-details.tsx:204`) and `W` to its own workflow dialog. All three would
+ * double-fire. `useIsNestedThread()` is the signal — `NestedThreadProvider`
+ * exists for exactly this and already wraps that mount.
+ */
+export interface RecordShortcutsOptions {
+  /**
+   * Undefined disables every binding, so a surface whose record resolves a beat
+   * after mount can still call this hook unconditionally (React requires it).
+   */
+  recordId: RecordId | undefined
+  /**
+   * False suppresses every binding. Pass `open && !useIsNestedThread()` from a
+   * drawer; a detail page can usually pass `true`.
+   */
+  enabled: boolean
+  /** Open the full page. `E` is not bound when omitted — the detail page IS the full page. */
+  onExpand?: () => void
+}
+
+export interface RecordShortcuts {
+  /** Controlled open for this surface's `RecordRequestAccessPopover` (`R`). */
+  requestAccessOpen: boolean
+  setRequestAccessOpen: (open: boolean) => void
+  /** Controlled open for this surface's `InstanceShareDialog` (`Shift+S`). */
+  shareOpen: boolean
+  setShareOpen: (open: boolean) => void
+  /** Controlled open for the workflow dialog (`W`). The surface renders it. */
+  workflowOpen: boolean
+  setWorkflowOpen: (open: boolean) => void
+}
+
+export function useRecordShortcuts({
+  recordId,
+  enabled,
+  onExpand,
+}: RecordShortcutsOptions): RecordShortcuts {
+  const parsed = recordId ? parseRecordId(recordId) : null
+  const { access, canShare } = useRecordAccess(recordId)
+  const active = enabled && !!parsed
+
+  const [requestAccessOpen, setRequestAccessOpen] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
+  const [workflowOpen, setWorkflowOpen] = useState(false)
+
+  const { toggle: toggleFavorite, isPending: isFavoritePending } = useFavoriteToggle(
+    'ENTITY_INSTANCE',
+    parsed
+      ? { entityDefinitionId: parsed.entityDefinitionId, entityInstanceId: parsed.entityInstanceId }
+      : null
+  )
+
+  // R — request the next rung. Same gate as the visible trigger, so the key can
+  // never open a popover the surface decided not to render.
+  useHotkey('R', () => setRequestAccessOpen(true), {
+    enabled: active && access === 'read',
+    conflictBehavior: 'allow',
+  })
+
+  // F — toggle favourite. Guarded on `isPending` so a held key cannot queue an
+  // add and a remove against the same row.
+  const onFavorite = useCallback(() => {
+    if (!isFavoritePending) toggleFavorite()
+  }, [isFavoritePending, toggleFavorite])
+  useHotkey('F', onFavorite, { enabled: active, conflictBehavior: 'allow' })
+
+  // W — run a workflow. Matches mail's `W` on threads; the two never coexist
+  // while `enabled` is false in the mailbox.
+  useHotkey('W', () => setWorkflowOpen(true), { enabled: active, conflictBehavior: 'allow' })
+
+  // Shift+S — share. See the 🔴 note above for why it is not plain `S`.
+  useHotkey('Shift+S', () => setShareOpen(true), {
+    enabled: active && canShare,
+    conflictBehavior: 'allow',
+  })
+
+  // E — expand to the full page.
+  useHotkey('E', () => onExpand?.(), {
+    enabled: active && !!onExpand,
+    conflictBehavior: 'allow',
+  })
+
+  return {
+    requestAccessOpen,
+    setRequestAccessOpen,
+    shareOpen,
+    setShareOpen,
+    workflowOpen,
+    setWorkflowOpen,
+  }
+}

--- a/apps/web/src/components/records/record-actions-menu.tsx
+++ b/apps/web/src/components/records/record-actions-menu.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { cn } from '@auxx/ui/lib/utils'
@@ -74,6 +75,16 @@ export interface RecordActionsMenuProps {
    * no room to promote anything.
    */
   omitItems?: RecordActionKey[]
+  /**
+   * Optional controlled state for the share dialog this menu owns.
+   *
+   * A surface that also opens sharing by KEYBOARD (`Shift+S`, via
+   * `useRecordShortcuts`) passes its state in, so both paths drive the SAME
+   * dialog. Without it the surface would need a second `InstanceShareDialog`
+   * mount, and two dialogs over one record is one too many.
+   */
+  shareOpen?: boolean
+  onShareOpenChange?: (open: boolean) => void
   /** Extra items, rendered after the registry's custom ones and before the destructive group. */
   children?: React.ReactNode
 }
@@ -146,6 +157,8 @@ export function RecordActionsMenu({
   onLink,
   onDeleted,
   omitItems = [],
+  shareOpen: controlledShareOpen,
+  onShareOpenChange,
   children,
 }: RecordActionsMenuProps) {
   const router = useRouter()
@@ -161,8 +174,14 @@ export function RecordActionsMenu({
   const customItems = getRecordMenuActions(entityType, entityDefinitionId)
 
   const [mergeOpen, setMergeOpen] = React.useState(false)
-  const [shareOpen, setShareOpen] = React.useState(false)
+  const [uncontrolledShareOpen, setUncontrolledShareOpen] = React.useState(false)
   const [sequenceOpen, setSequenceOpen] = React.useState(false)
+
+  const shareOpen = controlledShareOpen ?? uncontrolledShareOpen
+  const setShareOpen = (next: boolean) => {
+    setUncontrolledShareOpen(next)
+    onShareOpenChange?.(next)
+  }
 
   // The REAL archive/delete path, shared with the records table. Only the
   // handlers and their dialogs are taken — NOT this hook's `canEdit`, which is
@@ -240,6 +259,9 @@ export function RecordActionsMenu({
             <DropdownMenuItem onSelect={() => router.push(fullPageLink)}>
               <Expand />
               Open full page
+              {/* `E` is bound by the DRAWER's `useRecordShortcuts` mount only —
+                  the table row has no shortcut context, so it gets no hint. */}
+              {surface === 'drawer' && <DropdownMenuShortcut>E</DropdownMenuShortcut>}
             </DropdownMenuItem>
           )}
 
@@ -248,6 +270,7 @@ export function RecordActionsMenu({
               <DropdownMenuItem onSelect={() => setShareOpen(true)}>
                 <Share2 />
                 Share
+                {surface === 'drawer' && <DropdownMenuShortcut>⇧S</DropdownMenuShortcut>}
               </DropdownMenuItem>
             </GranularPermissionsGate>
           )}
@@ -259,7 +282,7 @@ export function RecordActionsMenu({
               so it is never a dead end; app actions disables its branch. A menu
               whose rows appear and disappear by org configuration is a menu
               nobody can learn. */}
-          <WorkflowSubMenu recordId={recordId} />
+          <WorkflowSubMenu recordId={recordId} shortcut={surface === 'row' ? undefined : 'W'} />
           <AppRecordActionsSubmenu recordId={recordId} recordType={entityType} />
 
           {actions.enableAddToSequence && sequencesEnabled && access.canEdit && (

--- a/apps/web/src/components/records/record-drawer-request-access.test.tsx
+++ b/apps/web/src/components/records/record-drawer-request-access.test.tsx
@@ -102,6 +102,17 @@ vi.mock('~/hooks/use-entity-instance-operations', () => ({
 vi.mock('~/components/favorites/ui/favorite-toggle-menu-item', () => ({
   FavoriteToggleMenuItem: () => null,
 }))
+// `useRecordShortcuts` binds `F` through this; the favourite lane has its own
+// tRPC surface and nothing to do with the preflight gate under test.
+vi.mock('~/components/favorites/hooks/use-favorite-toggle', () => ({
+  useFavoriteToggle: () => ({ toggle: vi.fn(), isFavorited: false, isPending: false }),
+}))
+vi.mock('~/components/workflow/mass-workflow-trigger-dialog', () => ({
+  MassWorkflowTriggerDialog: () => null,
+}))
+// The drawer asks whether it is nested inside a mail thread to decide whether to
+// bind its shortcuts at all. Standalone here.
+vi.mock('~/components/mail/thread-provider', () => ({ useIsNestedThread: () => false }))
 vi.mock('~/components/fields/connector-source-badge', () => ({ ConnectorSourceBadge: () => null }))
 vi.mock('~/components/resources/ui/avatar-upload-icon', () => ({ AvatarUploadIcon: () => null }))
 vi.mock('~/components/resources/ui/record-icon', () => ({ RecordIcon: () => null }))
@@ -167,17 +178,20 @@ beforeEach(() => {
 })
 
 describe('the drawer header pays NOTHING to render the request trigger (§8.5 / D6)', () => {
-  // The trigger now lives inside the shared `RecordActionsMenu`, which makes the
-  // laziness STRICTER, not weaker: Radix does not mount `DropdownMenuContent`'s
-  // subtree until the menu is opened, so the popover's body cannot run for a
-  // member who never opens the menu at all.
-  it('fires no preflight on open, none on opening the menu, and exactly one on the item', async () => {
+  // The trigger sits in the drawer HEADER again (the `icon` variant), not inside
+  // `RecordActionsMenu`. That was a deliberate reversal of PR #1438's placement:
+  // the `R` shortcut has to anchor to something, and Radix does not mount
+  // `DropdownMenuContent` until the menu opens.
+  //
+  // 🔴 **The laziness this file exists to protect is UNAFFECTED**, because it was
+  // never about mounting. `useRecordRequestAccess` gates its query on the popover
+  // being OPEN. Being back in the header costs one more mounted button and zero
+  // more requests — which is exactly what the first case below asserts.
+  it('fires no preflight on mount, and exactly one when the trigger is used', async () => {
     render(<RecordDrawer open recordId={RECORD_ID as never} />)
-    expect(h.preflightCalls).toHaveLength(0)
 
-    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
-    // The item is mounted and labelled — still without asking the server.
-    const trigger = screen.getByRole('menuitem', { name: 'Request edit access' })
+    // Mounted and labelled in the header — still without asking the server.
+    const trigger = screen.getByRole('button', { name: 'Request edit access' })
     expect(h.preflightCalls).toHaveLength(0)
 
     await userEvent.click(trigger)
@@ -188,9 +202,28 @@ describe('the drawer header pays NOTHING to render the request trigger (§8.5 / 
     h.access = 'edit'
     render(<RecordDrawer open recordId={RECORD_ID as never} />)
 
+    expect(screen.queryByRole('button', { name: /Request/ })).not.toBeInTheDocument()
+    expect(h.preflightCalls).toHaveLength(0)
+  })
+
+  // The menu must not ALSO offer it — `omitItems={['request-access']}`. Two ways
+  // to ask for the same rung on one surface is how the three surfaces drifted
+  // apart in the first place.
+  it('does not duplicate the ask inside the actions menu', async () => {
+    render(<RecordDrawer open recordId={RECORD_ID as never} />)
+
     await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
 
     expect(screen.queryByRole('menuitem', { name: /Request/ })).not.toBeInTheDocument()
+  })
+
+  // `R` is a keyboard path to the SAME popover, so it must obey the same gate.
+  it('opens the popover on `R`, and only then asks', async () => {
+    render(<RecordDrawer open recordId={RECORD_ID as never} />)
     expect(h.preflightCalls).toHaveLength(0)
+
+    await userEvent.keyboard('r')
+
+    expect(h.preflightCalls).toEqual([{ entityDefinitionId: DEF, entityInstanceId: ROW }])
   })
 })

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -18,13 +18,23 @@ import { Tooltip } from '~/components/global/tooltip'
 import { CommandContext, RecordCommandActions } from '~/components/kbar/contextual'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
+import { useIsNestedThread } from '~/components/mail/thread-provider'
+import { GranularPermissionsGate } from '~/components/mail-permissions/ui/granular-permissions-gate'
+import { RecordRequestAccessPopover } from '~/components/permissions/ui/record-request-access-popover'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
-import { resourceHasDetailPage, useRecord, useResource } from '~/components/resources'
+import {
+  resourceHasDetailPage,
+  useRecord,
+  useRecordAccess,
+  useResource,
+} from '~/components/resources'
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
 import { AvatarUploadIcon } from '~/components/resources/ui/avatar-upload-icon'
 import { RecordIcon } from '~/components/resources/ui/record-icon'
+import { MassWorkflowTriggerDialog } from '~/components/workflow/mass-workflow-trigger-dialog'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useDockStore } from '~/stores/dock-store'
+import { useRecordShortcuts } from './hooks/use-record-shortcuts'
 import { RecordActionsMenu } from './record-actions-menu'
 import { useRecordDrawerReadOnly } from './use-record-drawer-read-only'
 
@@ -211,6 +221,31 @@ export const RecordDrawer = React.memo(function RecordDrawer({
     router.push(`/app/custom/${resource.apiSlug}/${entityInstanceId}`)
   }, [resource?.apiSlug, resource?.entityType, entityInstanceId, router])
 
+  /**
+   * `R` / `F` / `W` / `Shift+S` / `E` for the record in this drawer.
+   *
+   * ⚠ **`isNestedThread` is what keeps the mailbox sane.** `mail-box.tsx` docks
+   * this drawer (the ticket drawer) BESIDE a live thread rather than over it, and
+   * mail binds `R` to reply-all, `F` to forward and `W` to its own workflow
+   * dialog. Every one of those would double-fire — `conflictBehavior: 'allow'`
+   * runs both handlers, it does not pick a winner. `NestedThreadProvider` already
+   * wraps that mount and exists for exactly this class of collision.
+   */
+  const { access } = useRecordAccess(recordId)
+  const isNestedThread = useIsNestedThread()
+  const {
+    requestAccessOpen,
+    setRequestAccessOpen,
+    shareOpen,
+    setShareOpen,
+    workflowOpen,
+    setWorkflowOpen,
+  } = useRecordShortcuts({
+    recordId,
+    enabled: !!open && !isNestedThread,
+    onExpand: resource && resourceHasDetailPage(resource) ? handleExpand : undefined,
+  })
+
   // Memoize the createdAt text to avoid recalculating on every render
   const createdAtText = React.useMemo(
     () =>
@@ -285,11 +320,41 @@ export const RecordDrawer = React.memo(function RecordDrawer({
                 Gone with it: an Archive item and a Link item whose onClick
                 bodies were empty comments, and a standalone delete button that
                 only appeared when the dropdown didn't. */}
+
+            {/* Request access is PROMOTED back out of the menu, using the `icon`
+                variant this shell always had for the drawer header's lock slot.
+                Two reasons, and only the second is new:
+
+                1. It is the one control here that ADDS capability, which is the
+                   same argument that promoted it on the detail page.
+                2. `R` has to anchor to it. Radix does not mount
+                   `DropdownMenuContent` until the menu opens, so while the
+                   trigger lived inside the kebab there was nothing on screen for
+                   a keyboard-opened popover to attach to.
+
+                ⚠ The lazy preflight (plan v3/04 §8.5 / D6) is UNCHANGED: the
+                query keys off the popover being OPEN, never off this being
+                mounted, so a member who never presses `R` or clicks still costs
+                the server nothing. */}
+            {access === 'read' && (
+              <GranularPermissionsGate>
+                <RecordRequestAccessPopover
+                  entityDefinitionId={entityDefinitionId}
+                  entityInstanceId={entityInstanceId}
+                  variant='icon'
+                  shortcut='R'
+                  open={requestAccessOpen}
+                  onOpenChange={setRequestAccessOpen}
+                />
+              </GranularPermissionsGate>
+            )}
+
             <FavoriteStarButton
               targetType='ENTITY_INSTANCE'
               targetIds={{ entityDefinitionId, entityInstanceId }}
               size='icon-xs'
               className='rounded-full'
+              shortcut='F'
             />
             <RecordActionsMenu
               recordId={recordId}
@@ -299,12 +364,16 @@ export const RecordDrawer = React.memo(function RecordDrawer({
               onEdit={() => setEditDialogOpen(true)}
               onRename={handleRename}
               onDeleted={handleClose}
+              omitItems={['request-access']}
+              // One share dialog for both paths — the menu item and `Shift+S`.
+              shareOpen={shareOpen}
+              onShareOpenChange={setShareOpen}
             />
 
             {/* Expand to full page — only for types that have a detail page
                 (no catch-all route; page-less system types would 404) */}
             {resource && resourceHasDetailPage(resource) && (
-              <Tooltip content='Open full page'>
+              <Tooltip content='Open full page' shortcut='E'>
                 <Button variant='ghost' size='icon-xs' onClick={handleExpand}>
                   <Expand />
                 </Button>
@@ -374,6 +443,18 @@ export const RecordDrawer = React.memo(function RecordDrawer({
             setEditDialogOpen(false)
             onMutationSuccess?.()
           }}
+        />
+      )}
+
+      {/* `W`'s target. The menu's "Run Workflow" submenu triggers a workflow the
+          member has already picked; the shortcut has picked nothing yet, so it
+          opens the picker — the same dialog mail's `W` opens for a thread. */}
+      {workflowOpen && (
+        <MassWorkflowTriggerDialog
+          open={workflowOpen}
+          onOpenChange={setWorkflowOpen}
+          recordIds={[recordId]}
+          onSuccess={onMutationSuccess}
         />
       )}
     </>

--- a/apps/web/src/components/records/records-view-request-access.test.tsx
+++ b/apps/web/src/components/records/records-view-request-access.test.tsx
@@ -118,6 +118,10 @@ vi.mock('~/providers/capabilities-provider', () => ({
     // This is what keeps the def-level `readOnly` degrade from short-circuiting
     // the per-row predicate — see `records-view.tsx`'s `hasRowGrants`.
     hasRecordGrantsOn: () => true,
+    // The row renders the shared `RecordActionsMenu` now, whose `WorkflowSubMenu`
+    // asks for the coarse `workflows.manage` key to decide whether "Create
+    // workflow" is clickable. Nothing here turns on the answer.
+    can: () => false,
   }),
 }))
 vi.mock('~/providers/feature-flag-provider', () => ({
@@ -172,6 +176,12 @@ vi.mock('~/components/data-export/ui/export-progress-dialog', () => ({
 vi.mock('~/components/print/ui/print-wizard-dialog', () => ({ PrintWizardDialog: () => null }))
 vi.mock('~/components/sequences/ui/add-to-sequence-dialog', () => ({
   AddToSequenceDialog: () => null,
+}))
+// Both submenus of the shared `RecordActionsMenu` the row now renders. They own
+// their own tRPC surfaces and say nothing about the preflight property here.
+vi.mock('~/components/workflow/workflow-submenu', () => ({ WorkflowSubMenu: () => null }))
+vi.mock('~/components/detail-view/components/app-record-actions', () => ({
+  AppRecordActionsSubmenu: () => null,
 }))
 vi.mock('~/components/workflow/mass-workflow-trigger-dialog', () => ({
   MassWorkflowTriggerDialog: () => null,

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -1,17 +1,15 @@
 // apps/web/src/components/records/records-view.tsx
 'use client'
 
-import type { Rung } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
 import { isAiEligible } from '@auxx/lib/custom-fields/client'
 import { converters } from '@auxx/lib/field-values/client'
-import { canEditRecordAtRung, FeatureKey, satisfiesRung } from '@auxx/lib/permissions/client'
+import { canEditRecordAtRung, FeatureKey } from '@auxx/lib/permissions/client'
 import type { RecordId, ResourceField } from '@auxx/lib/resources/client'
 import type { ActorId } from '@auxx/types/actor'
 import type { AiOptions } from '@auxx/types/custom-field'
 import { toFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
-import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
 import { Kbd, KbdGroup } from '@auxx/ui/components/kbd'
 import { MainPageAction } from '@auxx/ui/components/main-page'
 import { useQueryClient } from '@tanstack/react-query'
@@ -19,12 +17,10 @@ import {
   Archive,
   Combine,
   Database,
-  Expand,
   Play,
   Plus,
   Printer,
   Send,
-  Share2,
   SquarePen,
   Trash2,
 } from 'lucide-react'
@@ -49,17 +45,13 @@ import { getCreateHotkey } from '~/components/global-create/system-hotkeys'
 import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
 import { KopilotContext } from '~/components/kopilot/context'
-import { GranularPermissionsGate } from '~/components/mail-permissions/ui/granular-permissions-gate'
 import { MergeDialog } from '~/components/merge'
-import { InstanceShareDialog } from '~/components/permissions/ui/instance-share-dialog'
-import { RecordRequestAccessPopover } from '~/components/permissions/ui/record-request-access-popover'
 import { PrintWizardDialog } from '~/components/print/ui/print-wizard-dialog'
+import { RecordActionsMenu } from '~/components/records/record-actions-menu'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import {
-  getRecordLink,
   getRecordStoreState,
   type RecordMeta,
-  resourceHasDetailPage,
   toRecordId,
   useResource,
 } from '~/components/resources'
@@ -129,8 +121,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
   // who can view but not edit this def (Read-only grantee / field seat). The
   // server enforces regardless; this just avoids a click-then-403. Keyed by
   // `entityDefinitionId` (the defAccess keyspace), not `resource.id`.
-  const { canEditEntity, canAdministerDef, recordDefRung, canDeleteRecordAt, hasRecordGrantsOn } =
-    useAccess()
+  const { canEditEntity, canAdministerDef, recordDefRung, hasRecordGrantsOn } = useAccess()
   const canEdit = resource ? canEditEntity(resource.entityDefinitionId) : false
   /**
    * Whether ANY row of this def may be more permissive than the def level —
@@ -149,17 +140,14 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
   // it, so the fallback is the honest one rather than a guess.
   const defRung = resource ? recordDefRung(resource.entityDefinitionId) : undefined
   /**
-   * **The per-ROW affordance rung** (plan v3/03 §5.2/§6.2). `canEdit` above is
-   * the DEF question and stays where it belongs — New, bulk, view management.
-   * Row edit / archive / delete / share read THIS instead, because a member can
-   * hold `edit` on one row of a definition they otherwise cannot see, and only
-   * `read` on a row whose siblings they edit freely.
+   * The per-ROW affordance rung used to live here as `rowRung`, feeding a
+   * hand-rolled kebab menu. Both are gone: the row renders `RecordActionsMenu`,
+   * which resolves the same stamp through `useRecordAccess` — the ONE per-row
+   * gate the page and the drawer already shared.
+   *
+   * What stays is the fold from a bare row id, because the inline cell editors
+   * have no `RecordActionsMenu` to ask.
    */
-  const rowRung = useCallback(
-    (row: { _access?: Rung }): Rung => row._access ?? defRung ?? 'none',
-    [defRung]
-  )
-  /** The same fold from a bare row id — the inline-editor entry points. */
   const isRowReadOnly = useCallback(
     (rowId: string) => {
       if (!entityDefinitionId) return true
@@ -216,9 +204,9 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
   const [isWorkflowDialogOpen, setIsWorkflowDialogOpen] = useState(false)
   const [isMergeDialogOpen, setIsMergeDialogOpen] = useState(false)
   const [isAddToSequenceDialogOpen, setIsAddToSequenceDialogOpen] = useState(false)
-  // The row whose sharing dialog is open (plan v3/03 §6.2) — one hoisted dialog
-  // for the whole table rather than one per row.
-  const [shareRecordId, setShareRecordId] = useState<RecordId | null>(null)
+  // No hoisted per-row share dialog any more: `RecordActionsMenu` owns the one
+  // it opens, which is the whole reason `PrimaryCell` had to learn to take a
+  // complete menu instead of items (its dialogs must outlive the closing menu).
 
   // Print wizard (bulk-action entry — scope pinned to the frozen selection) + its progress
   // dialog, wired exactly like the CSV export flow (`table-toolbar.tsx`'s toolbar entry).
@@ -249,8 +237,6 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
   }, [])
 
   const {
-    handleArchive,
-    handleDelete,
     handleDrawerDelete,
     handleBulkDelete,
     handleBulkArchive,
@@ -316,7 +302,18 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
     [setIsCreateDialogOpen]
   )
 
-  // Primary cell renderer — title + Edit / Favorite / Archive / Delete dropdown.
+  /**
+   * The menu's record TYPE key, derived exactly as `RecordDrawer` derives it —
+   * both surfaces must resolve the same `RECORD_ACTIONS_REGISTRY` entry or the
+   * row and the drawer start disagreeing about what a record offers again, which
+   * is the drift PR #1438 existed to end.
+   */
+  const menuEntityType = useMemo(
+    () => resource?.entityType ?? (resource?.type === 'system' ? resource?.id : 'custom'),
+    [resource?.entityType, resource?.type, resource?.id]
+  )
+
+  // Primary cell renderer — title + the SHARED record-actions menu.
   const primaryFieldId = resource?.display.primaryDisplayField?.id ?? resource?.fields[0]?.id
   const primaryResourceFieldId = useMemo(() => {
     if (!entityDefinitionId || !primaryFieldId) return null
@@ -330,83 +327,43 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
         <PrimaryFieldCell
           resourceFieldId={primaryResourceFieldId}
           rowId={row.id}
-          onTitleClick={() => handleOpenDrawer(row)}>
-          {canEditRecordAtRung(rowRung(row)) && (
-            <DropdownMenuItem onClick={() => handleOpenEditDialog(row)}>
-              <SquarePen />
-              Edit
-            </DropdownMenuItem>
-          )}
-          {resource && resourceHasDetailPage(resource) && (
-            <DropdownMenuItem
-              onClick={() => {
-                const href = getRecordLink(toRecordId(entityDefinitionId, row.id), resource)
-                if (href) router.push(href)
-              }}>
-              <Expand />
-              Open full page
-            </DropdownMenuItem>
-          )}
-          <FavoriteToggleMenuItem
-            targetType='ENTITY_INSTANCE'
-            targetIds={{
-              entityDefinitionId,
-              entityInstanceId: row.id,
-            }}
-          />
-          {satisfiesRung(rowRung(row), 'admin') && (
-            <GranularPermissionsGate>
-              <DropdownMenuItem
-                onClick={() => setShareRecordId(toRecordId(entityDefinitionId, row.id))}>
-                <Share2 />
-                Share
-              </DropdownMenuItem>
-            </GranularPermissionsGate>
-          )}
-          {/* Ask for the next rung (plan v3/04 §8.2, mount 3). The only per-row
-              cost is this rung read — Radix does not mount the dropdown subtree
-              until the menu opens, so the hook inside runs once per OPENED menu,
-              never once per row (§8.5). */}
-          {rowRung(row) === 'read' && (
-            <GranularPermissionsGate>
-              <RecordRequestAccessPopover
-                entityDefinitionId={entityDefinitionId}
-                entityInstanceId={row.id}
-                variant='menu-item'
+          onTitleClick={() => handleOpenDrawer(row)}
+          // The LAST of the three record surfaces to join the shared menu
+          // (HANDOFF §1, "Still owed"). It hand-rolled its own list against its
+          // own helpers until `PrimaryCell` learned to take a whole menu — the
+          // menu's dialogs must be siblings of its `DropdownMenu`, which
+          // items-as-`children` could not express.
+          actions={
+            <RecordActionsMenu
+              recordId={toRecordId(entityDefinitionId, row.id)}
+              entityType={menuEntityType ?? ''}
+              record={row}
+              surface='row'
+              onEdit={() => handleOpenEditDialog(row)}
+              // Archive and Delete live inside the menu now, and its own
+              // `useEntityInstanceOperations` only refetches through this
+              // callback — without it the deleted row stays on screen.
+              onDeleted={refresh}>
+              {/* Favourite stays an ITEM here, unlike the page and the drawer,
+                  which promote it to a star beside the trigger. A table row has
+                  nowhere to put a persistent control, and a star that appears
+                  only on hover reports its state to nobody. */}
+              <FavoriteToggleMenuItem
+                targetType='ENTITY_INSTANCE'
+                targetIds={{ entityDefinitionId, entityInstanceId: row.id }}
               />
-            </GranularPermissionsGate>
-          )}
-          {canEditRecordAtRung(rowRung(row)) && (
-            <>
-              <DropdownMenuItem onClick={() => handleArchive(row.id)}>
-                <Archive />
-                Archive
-              </DropdownMenuItem>
-              {canDeleteRecordAt(rowRung(row)) && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem variant='destructive' onClick={() => handleDelete(row.id)}>
-                    <Trash2 />
-                    Delete
-                  </DropdownMenuItem>
-                </>
-              )}
-            </>
-          )}
-        </PrimaryFieldCell>
+            </RecordActionsMenu>
+          }
+        />
       )
     },
     [
-      rowRung,
-      canDeleteRecordAt,
       entityDefinitionId,
       primaryResourceFieldId,
-      resource,
-      router,
+      menuEntityType,
       handleOpenDrawer,
       handleOpenEditDialog,
-      handleArchive,
-      handleDelete,
+      refresh,
     ]
   )
 
@@ -1120,18 +1077,6 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
           onMergeComplete={() => {
             setSelectedRowIds(new Set())
             refresh()
-          }}
-        />
-      )}
-
-      {/* Per-record sharing (plan v3/03 §6.2). Only ever opened from a row whose
-          `_access` stamp is `admin`; the server re-asserts on the grant write. */}
-      {shareRecordId && (
-        <InstanceShareDialog
-          recordId={shareRecordId}
-          open={!!shareRecordId}
-          onOpenChange={(open) => {
-            if (!open) setShareRecordId(null)
           }}
         />
       )}

--- a/apps/web/src/components/workflow/workflow-submenu.tsx
+++ b/apps/web/src/components/workflow/workflow-submenu.tsx
@@ -7,6 +7,7 @@ import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import {
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -29,6 +30,12 @@ interface WorkflowSubMenuProps {
   recordId: RecordId
   /** Called after successful trigger */
   onSuccess?: () => void
+  /**
+   * Key hint shown on the submenu trigger. Only pass it where the key is
+   * actually bound (the record detail page and drawer, via `useRecordShortcuts`)
+   * — a hint for a dead key is worse than none.
+   */
+  shortcut?: string
 }
 
 /**
@@ -38,7 +45,7 @@ interface WorkflowSubMenuProps {
  * Shows loading state while fetching, then displays available workflows.
  * Shows "No workflows available" if none exist.
  */
-export function WorkflowSubMenu({ recordId, onSuccess }: WorkflowSubMenuProps) {
+export function WorkflowSubMenu({ recordId, onSuccess, shortcut }: WorkflowSubMenuProps) {
   const router = useRouter()
   const { entityDefinitionId } = recordId ? parseRecordId(recordId) : { entityDefinitionId: '' }
 
@@ -112,6 +119,7 @@ export function WorkflowSubMenu({ recordId, onSuccess }: WorkflowSubMenuProps) {
       <DropdownMenuSubTrigger>
         <Play />
         Run Workflow
+        {shortcut && <DropdownMenuShortcut className='mr-1'>{shortcut}</DropdownMenuShortcut>}
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className='w-48'>
         {workflowsLoading ? (


### PR DESCRIPTION
Two related pieces of record-surface work.

## 1. `PrimaryCell` learns to take a whole menu

Closes the item PR #1438 left owed. The records-table row was the last of the three record surfaces still hand-rolling its own action list, because `PrimaryCell` owned the `DropdownMenu` wrapper and only took items as `children`.

`RecordActionsMenu` can't be a child of that wrapper — it mounts its dialogs (Merge, Share, Add-to-sequence, the two confirms) as **siblings** of its menu, since selecting an item closes the menu and Radix unmounts the content with it. So `PrimaryCell` gains an `actions` prop that renders a complete menu in the trailing slot instead of the built-in kebab. The four other tables that pass items keep working through `children`.

The row's local copies go with it: `rowRung`, the hoisted per-table share dialog, and the `handleArchive`/`handleDelete` pair the menu now owns. Favourite is passed via the menu's `children` — the page and drawer promote it to a persistent star, and a table row has nowhere to put one.

## 2. Keyboard shortcuts on the record page and drawer

| Key | Action | Gate |
|---|---|---|
| `R` | Request access | `access === 'read'` |
| `F` | Toggle favourite | none — a personal bookmark, not a write |
| `W` | Run workflow | none — running one is the `view` rung |
| `⇧S` | Share | `canShare` (an `admin` row) |
| `E` | Expand to full page | drawer only |

One `useRecordShortcuts` mount per surface. `conflictBehavior: 'allow'` runs *every* matching handler rather than picking a winner, so a second mount double-fires each key.

### Why Share is `⇧S` and not `S`

Fifteen command-palette chords begin with `s`, and `@tanstack/hotkeys` runs its `HotkeyManager` and `SequenceManager` as two independent `keydown` listeners with no cross-talk. A plain `S` binding fires immediately **and** leaves the chord buffer armed, so `S` → `G` would open the share dialog on its way to Settings → General. `floating-compose-root.tsx` pays a 500ms defer to keep plain `C` for compose; that latency is worth it there and isn't worth it for a dialog opened this rarely.

### Two collisions with mail

Mail binds `R` to reply-all and `F` to forward (`thread-details.tsx:196-210`).

- **The mailbox** docks this drawer *beside* a live thread, so the drawer gates its bindings on `useIsNestedThread()` — the mechanism `NestedThreadProvider` already exists for, and which already wraps that mount.
- **The ticket detail page's Conversation tab** was the one embedded `ThreadDetails` mount *not* wrapped in that provider (`ThreadDetailsDialog` always has been). Wrapping it also drops a linked-ticket picker that pointed at the very ticket the page is about — the recursion its own comment warns about.

### Request access moves back to the drawer header

`R` has to anchor to a mounted trigger, and Radix doesn't mount `DropdownMenuContent` until the menu opens. This uses the `icon` variant the shell always carried for that slot, partially reversing #1438's drawer placement — and matching the reasoning that promoted it on the detail page, since it's the one control that ADDS capability.

🔴 **The lazy preflight (plan v3/04 §8.5 / D6) is unchanged**, and is now pinned more directly than before: the query keys off the popover being **open**, never off the trigger being mounted. `record-drawer-request-access.test.tsx` asserts zero preflights on mount, exactly one on use, none duplicated in the menu, and that `R` obeys the same gate.

## Display

Hints render only where a key is actually bound: `Kbd variant='outline'` inside the Share and Request access buttons, `DropdownMenuShortcut` on the menu rows, and the tooltip's existing `shortcut` prop on the icon-only star and expand buttons.

## Verification

- `apps/web` `src/components` — **1009 pass / 0 fail**; records + detail-view + permissions re-run on the committed state, **298 pass / 0 fail**.
- Biome clean on every changed file.
- `tsc` shows only pre-existing errors, all on lines outside these hunks. (Note the `apps/web` baseline is now ~3597, not the ~2192 in `plans/permissions/v3/HANDOFF.md` §9 — the TS 7 migration moved it.)

No server, schema, or permission-evaluation changes: authorization is still the per-row `_access` stamp via `useRecordAccess`, untouched.