### PR TITLE
fix(billing): stop counting seeded rows against plan limits

### DIFF
--- a/apps/web/src/server/api/routers/mailView.ts
+++ b/apps/web/src/server/api/routers/mailView.ts
@@ -1,12 +1,11 @@
 // apps/web/src/server/api/routers/mailView.ts
 
-import { schema } from '@auxx/database'
 import { getCachedUserInstanceGrants, onCacheEvent } from '@auxx/lib/cache'
 import { conditionGroupsSchema } from '@auxx/lib/conditions/client'
 import { MailViewService } from '@auxx/lib/mail-views'
 import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
+import { countSavedViewsUsed } from '@auxx/lib/table-views'
 import { TRPCError } from '@trpc/server'
-import { and, count, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 
@@ -83,15 +82,7 @@ export const mailViewRouter = createTRPCRouter({
       const featureService = new FeaturePermissionService(ctx.db)
       const viewLimit = await featureService.getLimit(organizationId, FeatureKey.savedViews)
       if (typeof viewLimit === 'number' && viewLimit >= 0) {
-        const [{ value: current }] = await ctx.db
-          .select({ value: count() })
-          .from(schema.MailView)
-          .where(
-            and(
-              eq(schema.MailView.organizationId, organizationId),
-              eq(schema.MailView.isShared, true)
-            )
-          )
+        const current = await countSavedViewsUsed(ctx.db, organizationId)
         if (current >= viewLimit) {
           throw new TRPCError({
             code: 'FORBIDDEN',

--- a/apps/web/src/server/api/routers/tableView.ts
+++ b/apps/web/src/server/api/routers/tableView.ts
@@ -16,6 +16,7 @@ import { ForbiddenError } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import type { CapabilitySet } from '@auxx/lib/permissions'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { countSavedViewsUsed } from '@auxx/lib/table-views'
 import {
   createView,
   deleteView,
@@ -25,7 +26,7 @@ import {
   updateView,
 } from '@auxx/services/table-view'
 import { TRPCError } from '@trpc/server'
-import { and, count, eq, isNull } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
 import { isStructural, resolveDefId } from './table-view-helpers'
@@ -301,16 +302,8 @@ export const tableViewRouter = createTRPCRouter({
         const featureService = new FeaturePermissionService(ctx.db)
         const viewLimit = await featureService.getLimit(organizationId, FeatureKey.savedViews)
         if (typeof viewLimit === 'number' && viewLimit >= 0) {
-          const [countRow] = await ctx.db
-            .select({ value: count() })
-            .from(schema.TableView)
-            .where(
-              and(
-                eq(schema.TableView.organizationId, organizationId),
-                eq(schema.TableView.isShared, true)
-              )
-            )
-          if ((countRow?.value ?? 0) >= viewLimit) {
+          const current = await countSavedViewsUsed(ctx.db, organizationId)
+          if (current >= viewLimit) {
             throw new TRPCError({
               code: 'FORBIDDEN',
               message: `You have reached your saved view limit (${viewLimit}). Upgrade your plan to create more views.`,

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1138,6 +1138,12 @@
       "import": "./dist/snippets/snippet-mutations.mjs",
       "default": "./src/snippets/snippet-mutations.ts"
     },
+    "./table-views": {
+      "types": "./src/table-views/index.ts",
+      "source": "./src/table-views/index.ts",
+      "import": "./dist/table-views/index.mjs",
+      "default": "./src/table-views/index.ts"
+    },
     "./tags": {
       "types": "./src/tags/index.ts",
       "source": "./src/tags/index.ts",

--- a/packages/lib/src/permissions/overage-detection-service.ts
+++ b/packages/lib/src/permissions/overage-detection-service.ts
@@ -7,6 +7,7 @@ import { getAppCache } from '../cache'
 import { getOrgCache } from '../cache/singletons'
 import { countBillableChannels } from '../channels'
 import { createScopedLogger } from '../logger'
+import { countSavedViewsUsed } from '../table-views/saved-view-limits'
 import type { FeatureDefinition } from './types'
 import { FEATURE_REGISTRY_MAP, FeatureKey, parseFeatureLimits } from './types'
 
@@ -253,34 +254,29 @@ export class OverageDetectionService {
         return countBillableChannels(this.db, organizationId)
 
       case FeatureKey.workflowsLimit: {
+        // Only org-authored workflows count. A sequence compiles to a hidden,
+        // system-owned `WorkflowApp` (`ownerType = 'sequence'`) — every new org is
+        // seeded with 5 of them (`seedClientNotificationSequences`), and they are
+        // invisible in the workflows list and excluded from the create gate's
+        // `getCachedWorkflowAppCount`. Counting them here reported every fresh org
+        // as 5/3 over its workflow limit before a single workflow existed.
         const [result] = await this.db
           .select({ value: count() })
           .from(schema.WorkflowApp)
-          .where(eq(schema.WorkflowApp.organizationId, organizationId))
+          .where(
+            and(
+              eq(schema.WorkflowApp.organizationId, organizationId),
+              isNull(schema.WorkflowApp.ownerType)
+            )
+          )
         return result?.value ?? 0
       }
 
       case FeatureKey.savedViews: {
-        // Sum user-created views from both TableView and MailView, excluding default (system) views
-        const [tableResult] = await this.db
-          .select({ value: count() })
-          .from(schema.TableView)
-          .where(
-            and(
-              eq(schema.TableView.organizationId, organizationId),
-              eq(schema.TableView.isDefault, false)
-            )
-          )
-        const [mailResult] = await this.db
-          .select({ value: count() })
-          .from(schema.MailView)
-          .where(
-            and(
-              eq(schema.MailView.organizationId, organizationId),
-              eq(schema.MailView.isDefault, false)
-            )
-          )
-        return (tableResult?.value ?? 0) + (mailResult?.value ?? 0)
+        // Shared, member-created views across TableView + MailView. Delegates to the
+        // one shared counter the create gates use — see `countSavedViewsUsed` for why
+        // system-seeded views are excluded.
+        return countSavedViewsUsed(this.db, organizationId)
       }
 
       case FeatureKey.kbPublishedArticles: {

--- a/packages/lib/src/table-views/index.ts
+++ b/packages/lib/src/table-views/index.ts
@@ -2,6 +2,7 @@
 
 export type { CreateTableViewInput, CreateTableViewResult } from './create-table-view'
 export { createTableView } from './create-table-view'
+export { countSavedViewsUsed } from './saved-view-limits'
 export type { SetDefaultTableViewInput, SetDefaultTableViewResult } from './set-default-table-view'
 export { setDefaultTableView } from './set-default-table-view'
 export { computeUserTableViews } from './table-view-queries'

--- a/packages/lib/src/table-views/saved-view-limits.ts
+++ b/packages/lib/src/table-views/saved-view-limits.ts
@@ -1,0 +1,60 @@
+// packages/lib/src/table-views/saved-view-limits.ts
+
+import { type Database, schema } from '@auxx/database'
+import { and, count, eq, ne } from 'drizzle-orm'
+
+/**
+ * The single counter behind the `savedViews` plan limit.
+ *
+ * A "saved view" for billing purposes is a **shared** view a **member** created —
+ * across both `TableView` (records) and `MailView` (mail). Two exclusions matter:
+ *
+ * 1. **System-seeded views don't count.** `entity-seeder/create-default-views.ts`,
+ *    `create-field-views.ts` and the `ensureDefaultTableViews`/`ensureFieldViews`
+ *    entity-migration helpers all write their rows as the org's system user
+ *    (`Organization.systemUserId`). A fresh org lands with ~34 shared `TableView`
+ *    rows before anyone touches anything — counting those put every new org
+ *    instantly over the Demo/Free limit of 10 and made the create gate
+ *    permanently closed.
+ * 2. **Personal views don't count.** Only `isShared` views consume the limit;
+ *    that's what the create gates have always enforced.
+ *
+ * Exported so the create gates (`tableView.create`, `mailView.create`) and
+ * `OverageDetectionService` read one number — three independent counters for one
+ * billing invariant is exactly how they drifted apart (the overage detector
+ * counted `isDefault = false` on both tables, the table gate counted every
+ * `isShared` row including seeds, the mail gate counted `MailView` alone).
+ */
+export async function countSavedViewsUsed(db: Database, organizationId: string): Promise<number> {
+  const [org] = await db
+    .select({ systemUserId: schema.Organization.systemUserId })
+    .from(schema.Organization)
+    .where(eq(schema.Organization.id, organizationId))
+    .limit(1)
+
+  const systemUserId = org?.systemUserId
+
+  const [tableResult] = await db
+    .select({ value: count() })
+    .from(schema.TableView)
+    .where(
+      and(
+        eq(schema.TableView.organizationId, organizationId),
+        eq(schema.TableView.isShared, true),
+        ...(systemUserId ? [ne(schema.TableView.userId, systemUserId)] : [])
+      )
+    )
+
+  const [mailResult] = await db
+    .select({ value: count() })
+    .from(schema.MailView)
+    .where(
+      and(
+        eq(schema.MailView.organizationId, organizationId),
+        eq(schema.MailView.isShared, true),
+        ...(systemUserId ? [ne(schema.MailView.userId, systemUserId)] : [])
+      )
+    )
+
+  return (tableResult?.value ?? 0) + (mailResult?.value ?? 0)
+}


### PR DESCRIPTION
## Problem

A fresh demo account hit **"Plan limits exceeded — Workflows (5/3), Saved Views (14/10)"** before creating a single workflow or view. Both numbers were 100% seed data.

Verified against the DB — every org, without exception:

```
wf_all=6   wf_user=1   tv_nondefault=14   tv_shared=34
```

- **Workflows 5/3** — a sequence compiles to a hidden `WorkflowApp` with `ownerType='sequence'`, and `seedClientNotificationSequences` gives every new org 5 of them. The workflows list filters those out, and so does the create gate (`getCachedWorkflowAppCount` → `list()`), but `OverageDetectionService` counted every `WorkflowApp` row. A demo org gets 5 sequences and no example workflow → exactly 5/3.
- **Saved Views 14/10** — `DEFAULT_VIEW_CONFIGS` seeds 14 non-default shared views (Active Contacts, Open Tickets, Low Stock, …). The detector counted `isDefault = false`, i.e. all 14.

### The worse bug behind it

Three counters existed for one billing invariant and all three disagreed:

| Site | Counted |
|---|---|
| `OverageDetectionService` | `isDefault = false` on `TableView` + `MailView` |
| `tableView.create` gate | `isShared = true` on `TableView` |
| `mailView.create` gate | `isShared = true` on `MailView` |

The table gate's `isShared = true` is **34–46 rows** on a fresh org (14 shared views + 8 defaults + 12 field views). Every Demo/Free/Starter org was permanently unable to create a shared table view — the gate was closed from day one and would never open.

## Fix

Raising the limits would paper over the bug, so instead the seeded rows stop counting.

- **`packages/lib/src/table-views/saved-view-limits.ts`** (new) — `countSavedViewsUsed(db, orgId)`: shared views across `TableView` + `MailView`, excluding rows written by the org's system user. Every seeder (`createDefaultViews`, `createFieldViews`, `ensureDefaultTableViews`, `ensureFieldViews`) writes as `Organization.systemUserId`, so this needs no schema change. Follows the `countSeatsUsed` precedent already documented in `overage-detection-service.ts`.
- **`overage-detection-service.ts`** — `workflowsLimit` filters `ownerType IS NULL`; `savedViews` delegates to the shared counter.
- **`tableView.ts` / `mailView.ts`** — both create gates call the same function, so the banner and the gate can't drift again.

## Verification

- Ran the new predicates against the real DB: `tv_user_shared` and `mv_user_shared` are `0` for every org, and `wf_user` is `1` for regular orgs / `0` for demo. Post-deploy a fresh demo reads 0/3 workflows and 0/10 views.
- `tsc --noEmit` clean for both changed routers and both lib files (grepped, given the known-broken repo baselines).
- Biome clean on all touched files.
- `packages/lib/src/members/seat-limits.test.ts` passes (25 tests).
- Ran `pnpm generate:exports` — `@auxx/lib/table-views` is a new consumer subpath.

## Notes

- The `overages` cache has a 15-min TTL with no version in the key, so existing orgs' stale banners clear themselves after deploy. No cache bump needed.
- Sequences now count toward nothing. If they should be metered, that wants its own `sequencesLimit` rather than sharing the workflow bucket — not done here.
- `duplicateView` in `@auxx/services` bypasses the saved-view limit entirely. Pre-existing and untouched, but it's a hole in the same feature.