### PR TITLE
fix(channels): report an in-flight sync instead of failing the click

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
@@ -246,7 +246,7 @@ export default function IntegrationRouting({
                 loading={syncMessages.isPending}
                 loadingText='Starting...'>
                 <RefreshCw />
-                Sync Messages
+                {integration.syncStatus === 'SYNCING' ? 'Syncing…' : 'Sync Messages'}
               </Button>
             </AdminGate>
           }>

--- a/apps/web/src/components/channels/ui/channel-card.tsx
+++ b/apps/web/src/components/channels/ui/channel-card.tsx
@@ -64,12 +64,18 @@ export function ChannelCard({ channel, inboxes }: { channel: Channel; inboxes: I
     channel.provider === 'email' &&
     (channel.metadata as { channelType?: string } | null)?.channelType === 'forwarding-address'
 
+  const isSyncing = channel.syncStatus === 'SYNCING'
+
   const toggle = api.channel.toggle.useMutation({
     onSuccess: () => utils.channel.list.invalidate(),
     onError: (error) => toastError({ title: 'Error updating channel', description: error.message }),
   })
 
+  // Refetch so the card picks up the SYNCING status dot — this also covers the
+  // `alreadyInProgress` reply, where a background poll is already running and no
+  // new job was started.
   const syncMessages = api.channel.syncMessages.useMutation({
+    onSuccess: () => utils.channel.list.invalidate(),
     onError: (error) => toastError({ title: 'Error starting sync', description: error.message }),
   })
 
@@ -114,9 +120,14 @@ export function ChannelCard({ channel, inboxes }: { channel: Channel; inboxes: I
       onClick: () => router.push(`${DETAIL_BASE}/${channel.id}`),
     },
     {
-      label: 'Sync messages',
+      label: isSyncing ? 'Syncing…' : 'Sync messages',
       icon: <RefreshCw />,
-      disabled: !canManage || channel.provider === 'chat' || isForwarding,
+      disabled:
+        !canManage ||
+        channel.provider === 'chat' ||
+        isForwarding ||
+        isSyncing ||
+        syncMessages.isPending,
       onClick: () => syncMessages.mutate({ integrationId: channel.id, days: 7 }),
     },
     {

--- a/packages/lib/src/channels/sync.ts
+++ b/packages/lib/src/channels/sync.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/channels/sync.ts
 
-import { BadRequestError, type NotFoundError } from '../errors'
+import { AuxxError, BadRequestError } from '../errors'
 import { createScopedLogger } from '../logger'
 import { SyncMessages } from '../messages/sync-messages'
 import { Result, type TypedResult } from '../result'
@@ -17,9 +17,7 @@ export async function syncMessages(
   ctx: ChannelCtx & { userId: string },
   channelId: string,
   days: number
-): Promise<
-  TypedResult<Awaited<ReturnType<SyncMessages['sync']>>, NotFoundError | BadRequestError>
-> {
+): Promise<TypedResult<Awaited<ReturnType<SyncMessages['sync']>>, AuxxError>> {
   const validated = await validateChannelOwnership(ctx, channelId)
   if (!validated.ok) return validated
   const channel = validated.value
@@ -50,8 +48,16 @@ export async function syncMessages(
   })
 
   const syncer = new SyncMessages(ctx.db, ctx.organizationId, ctx.userId)
-  const result = await syncer.sync({ integrationId: channelId, since })
-  return Result.ok(result)
+  try {
+    const result = await syncer.sync({ integrationId: channelId, since })
+    return Result.ok(result)
+  } catch (error) {
+    // `SyncMessages.sync` throws (already-syncing, throttled, missing channel).
+    // Funnel those into the Result contract so the router maps them to a real
+    // status instead of letting an unrecognized throw become a generic 500.
+    if (error instanceof AuxxError) return Result.error(error)
+    throw error
+  }
 }
 
 /**

--- a/packages/lib/src/messages/sync-messages.ts
+++ b/packages/lib/src/messages/sync-messages.ts
@@ -3,6 +3,7 @@ import { SYNC_STATUS } from '@auxx/database/enums'
 import type { SYNC_STATUS as SyncStatus } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray, isNull, lt, or } from 'drizzle-orm'
+import { NotFoundError, RateLimitError } from '../errors'
 import { type MessageSyncFailedEvent, type MessageSyncPendingEvent, publisher } from '../events'
 // Import from the defining job modules, not the '../jobs' barrel — the barrel
 // pulls every job handler into the module graph (heavy, breaks mocked tests).
@@ -21,7 +22,8 @@ type SyncInputProps = {
   since?: Date
 }
 type SyncOutputProps = {
-  syncJobId: string
+  /** Null when an in-flight sync was detected without a SyncJob row backing it. */
+  syncJobId: string | null
   status: SyncStatus
   message: string
   alreadyInProgress: boolean
@@ -81,6 +83,28 @@ export class SyncMessages {
         alreadyInProgress: true,
       }
     }
+    // --- 1b. Check the integration's own sync state ---
+    // A background poll (`messageListFetchJob`) flips Integration.syncStatus to
+    // SYNCING without creating a SyncJob row, so an in-flight sync can be invisible
+    // to the check above. Resolve it here, *before* creating a job, and report it
+    // the same way — an already-running sync is not a failure.
+    const integrationToSync = integrationId
+      ? await this.findSyncableIntegration(integrationId, organizationId)
+      : undefined
+
+    if (integrationToSync?.syncStatus === 'SYNCING') {
+      logger.info(
+        `Integration ${integrationId} is already syncing — reporting in-progress to caller`,
+        { userId, organizationId }
+      )
+      return {
+        syncJobId: null,
+        status: SYNC_STATUS.IN_PROGRESS,
+        message: 'A message sync is already in progress.',
+        alreadyInProgress: true,
+      }
+    }
+
     // --- 2. If no active sync, create a new SyncJob record (initial state: PENDING) ---
     // We create the job regardless of whether it's a single or all sync.
     // We set the integrationId if it's a single sync.
@@ -119,25 +143,7 @@ export class SyncMessages {
         `Initiating single integration sync for job ${syncJobId}, integration ${integrationId}.`,
         { userId, organizationId }
       )
-      // Validate the provided integrationId: check if it exists, is enabled, and belongs to the org
-      const [integrationToSync] = await this.db
-        .select({
-          id: schema.Integration.id,
-          provider: schema.Integration.provider,
-          metadata: schema.Integration.metadata,
-          syncStatus: schema.Integration.syncStatus,
-          throttleRetryAfter: schema.Integration.throttleRetryAfter,
-        })
-        .from(schema.Integration)
-        .where(
-          and(
-            eq(schema.Integration.id, integrationId),
-            eq(schema.Integration.organizationId, organizationId),
-            eq(schema.Integration.enabled, true),
-            isNull(schema.Integration.deletedAt)
-          )
-        )
-        .limit(1)
+      // `integrationToSync` was resolved above, before the SyncJob row was created.
       if (!integrationToSync) {
         logger.error(
           `Requested integration ${integrationId} not found, not enabled, or does not belong to organization ${organizationId}.`,
@@ -168,29 +174,10 @@ export class SyncMessages {
             errorDetails: `Integration ${integrationId} not found, not enabled, or unauthorized.`,
           },
         } as MessageSyncFailedEvent)
-        throw new Error(`Integration ${integrationId} not found or enabled for this organization.`)
+        throw new NotFoundError(
+          `Integration ${integrationId} not found or enabled for this organization.`
+        )
       }
-      // Hard reject if integration is currently syncing
-      if (integrationToSync.syncStatus === 'SYNCING') {
-        logger.warn(`Integration ${integrationId} is already syncing — rejecting sync request`, {
-          organizationId,
-        })
-        await this.db
-          .update(schema.SyncJob)
-          .set({
-            status: SYNC_STATUS.FAILED,
-            endTime: new Date(),
-            error: `Integration ${integrationId} is already syncing.`,
-            totalRecords: 0,
-            processedRecords: 0,
-            failedRecords: 0,
-            integrationSyncJobIds: [],
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.SyncJob.id, syncJobId))
-        throw new Error(`Integration ${integrationId} is already syncing.`)
-      }
-
       // Hard reject if integration is throttled
       if (
         integrationToSync.throttleRetryAfter &&
@@ -214,7 +201,13 @@ export class SyncMessages {
             updatedAt: new Date(),
           })
           .where(eq(schema.SyncJob.id, syncJobId))
-        throw new Error(`Integration ${integrationId} is throttled. Retry after ${retryAfter}.`)
+        throw new RateLimitError(
+          `This channel is rate limited by the provider. Retry after ${retryAfter}.`,
+          Math.max(
+            0,
+            Math.ceil((integrationToSync.throttleRetryAfter.getTime() - Date.now()) / 1000)
+          )
+        )
       }
 
       // Prepare job data for the single sync job
@@ -352,7 +345,7 @@ export class SyncMessages {
       .limit(1)
 
     if (!syncJob) {
-      throw new Error('Sync job not found or unauthorized')
+      throw new NotFoundError('Sync job not found or unauthorized')
     }
 
     // 2. Check if cancellable (not already in terminal state)
@@ -427,6 +420,33 @@ export class SyncMessages {
       success: true,
       message: 'Sync cancelled successfully',
     }
+  }
+
+  /**
+   * Load an enabled, non-deleted channel owned by the org, with the fields the
+   * pre-flight guards need. Returns undefined when no such channel exists.
+   */
+  private async findSyncableIntegration(integrationId: string, organizationId: string) {
+    const [integration] = await this.db
+      .select({
+        id: schema.Integration.id,
+        provider: schema.Integration.provider,
+        metadata: schema.Integration.metadata,
+        syncStatus: schema.Integration.syncStatus,
+        throttleRetryAfter: schema.Integration.throttleRetryAfter,
+      })
+      .from(schema.Integration)
+      .where(
+        and(
+          eq(schema.Integration.id, integrationId),
+          eq(schema.Integration.organizationId, organizationId),
+          eq(schema.Integration.enabled, true),
+          isNull(schema.Integration.deletedAt)
+        )
+      )
+      .limit(1)
+
+    return integration
   }
 
   /**


### PR DESCRIPTION
## What happened

Clicking **Sync now** on a Gmail channel returned an `Internal server error` toast. A refresh then showed the channel syncing — because it genuinely was. Traced from production logs (integration `y7x75gqcc4yuf9wj98icafg4`):

| time | event |
|---|---|
| 03:51:32 | polling scanner enqueued `messageListFetchJob`, which sets `Integration.syncStatus = 'SYNCING'` |
| 03:52:40 | user clicked Sync now → hard reject → 500 |
| 03:54:43 | the background poll finished normally |

## Root cause

Three defects lined up:

1. **`sync-messages.ts` threw bare `Error`s.** A plain `Error` has no `statusCode`, so `auxxErrorMiddleware` (`trpc.ts:245`) could not map it and fell through to `INTERNAL_SERVER_ERROR`.
2. **`channels/sync.ts` did not honor its own contract.** It declares `Promise<TypedResult<…>>` but called `syncer.sync()` unguarded, so the throw bypassed the Result and surfaced at the router's `await` on `channel.ts:243` — `if (!result.ok) throw result.error` on line 248 never ran.
3. **Two guards for one condition disagreed.** `sync-messages.ts:69` already answers "already in progress" with `alreadyInProgress: true` (a success). The guard that fired instead checked `Integration.syncStatus` and threw — and `messageListFetchJob` flips that flag *without* writing a `SyncJob` row, so the friendly guard never saw it.

## Changes

**`packages/lib/src/messages/sync-messages.ts`**
- The `syncStatus === 'SYNCING'` check moves ahead of the `SyncJob` insert and returns the same `alreadyInProgress: true` shape as its sibling. No orphan `FAILED` SyncJob row is written per click anymore.
- Remaining throws carry real statuses: `NotFoundError` (404) for a missing/disabled channel and for a missing sync job on cancel; `RateLimitError` (429) for throttling, passing remaining seconds so `Retry-After` is populated.
- Integration lookup extracted to `findSyncableIntegration` so hoisting it costs no extra query.
- `SyncOutputProps.syncJobId` widened to `string | null` (nothing outside the file reads it).

**`packages/lib/src/channels/sync.ts`** — wraps `syncer.sync()`; any `AuxxError` becomes `Result.error(...)`, non-`AuxxError` still propagates. Error type param widened to `AuxxError`.

**UI** — `channel-card.tsx` invalidates `channel.list` on success and relabels its menu item to "Syncing…" while a sync runs; `integration-routing.tsx`'s button does the same. The existing `SyncStatusToastManager` then surfaces the running sync.

## Verification

- 42 lib tests pass (`src/channels`, `src/messages`).
- `packages/lib` typecheck: **zero new errors**. The 6 in `channels/sync.ts` and the `timeout`-in-`JobsOptions` one are pre-existing — confirmed by temporarily restoring the original signature and re-running, which produced the identical set. They stem from `TypedResult`'s `ok` being a plain `boolean` getter rather than a type predicate.
- `apps/web` typecheck clean on both UI files.

## Known limitation

The read-then-insert race is **unchanged**: a poll can flip the flag between the check and the insert, and two simultaneous clicks can both pass. Closing it needs a conditional update or advisory lock — out of scope here.

## Out of scope, found while investigating

- **Gmail push is dead in production.** `403 PERMISSION_DENIED` publishing to `projects/auxxai/topics/email-notifications`, so every Gmail channel silently falls back to 30s polling. Infra fix on the Google Cloud side.
- **Outlook webhook renewal is broken.** `apps/web/src/app/api/outlook/webhook/route.ts:79` calls `await req.json()` on Graph's empty validation POST → 500, so Graph refuses the subscription. Only `GET` handles `validationToken`.
- **`integration-settings.tsx` is dead code** — no importers; superseded by `integration-routing.tsx` + `integration-settings-advanced.tsx`. Left in place.
