### PR TITLE
feat(billing): meter sequences with a sequencesLimit plan limit

### DIFF
--- a/apps/web/src/components/sequences/ui/list/create-sequence-button.tsx
+++ b/apps/web/src/components/sequences/ui/list/create-sequence-button.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/sequences/ui/list/create-sequence-button.tsx
 'use client'
 
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import {
   SEQUENCE_TRIGGER_LABELS,
   SEQUENCE_TRIGGER_TYPES,
@@ -26,9 +27,11 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { toastError } from '@auxx/ui/components/toast'
-import { Plus } from 'lucide-react'
+import { MailPlus, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useRef, useState } from 'react'
+import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 
 /**
@@ -41,9 +44,19 @@ export function CreateSequenceButton() {
   const router = useRouter()
   const utils = api.useUtils()
   const [open, setOpen] = useState(false)
+  const [limitDialogOpen, setLimitDialogOpen] = useState(false)
   const [name, setName] = useState('')
   const [triggerType, setTriggerType] = useState<SequenceTriggerType>('manual')
   const nameInputRef = useRef<HTMLInputElement>(null)
+  const { isAtLimit, getLimit } = useFeatureFlags()
+
+  // Same query the list uses (React Query dedupes it). Seeded templates are
+  // filtered out to match `countSequencesUsed` on the server — they are
+  // undeletable, so counting them here would show a limit the user cannot act on.
+  const sequences = api.sequence.list.useQuery()
+  const used = sequences.data?.filter((s) => !s.templateKey).length ?? 0
+  const atLimit = isAtLimit(FeatureKey.sequencesLimit, used)
+  const sequenceLimit = getLimit(FeatureKey.sequencesLimit)
 
   const createSequence = api.sequence.create.useMutation({
     onSuccess: (created) => {
@@ -74,6 +87,24 @@ export function CreateSequenceButton() {
       return
     }
     createSequence.mutate({ name: trimmed, triggerType })
+  }
+
+  if (atLimit) {
+    return (
+      <>
+        <Button size='sm' onClick={() => setLimitDialogOpen(true)}>
+          <Plus />
+          New sequence
+        </Button>
+        <LimitReachedDialog
+          open={limitDialogOpen}
+          onOpenChange={setLimitDialogOpen}
+          icon={MailPlus}
+          title='Sequence Limit Reached'
+          description={`You've reached the maximum of ${sequenceLimit} sequences on your current plan.`}
+        />
+      </>
+    )
   }
 
   return (

--- a/apps/web/src/server/api/routers/sequence.ts
+++ b/apps/web/src/server/api/routers/sequence.ts
@@ -21,6 +21,7 @@ import { AuxxError } from '@auxx/lib/errors'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import {
   checkSequenceAccess,
+  countSequencesUsed,
   createSequence,
   createStep,
   deleteSequence,
@@ -267,6 +268,11 @@ export const sequenceRouter = createTRPCRouter({
   create: sequenceProcedure
     .input(z.object({ name: z.string().min(1), triggerType: triggerTypeSchema.optional() }))
     .mutation(async ({ ctx, input }) => {
+      await new FeaturePermissionService().requireLimit(
+        ctx.session.organizationId,
+        FeatureKey.sequencesLimit,
+        () => countSequencesUsed(ctx.db, ctx.session.organizationId)
+      )
       // integrationId stays null while drafting — the settings drawer sets the
       // mailbox and publish refuses to compile without one.
       return unwrap(

--- a/packages/lib/src/data-migrations/migrations/064-sequences-limit.test.ts
+++ b/packages/lib/src/data-migrations/migrations/064-sequences-limit.test.ts
@@ -1,0 +1,82 @@
+// packages/lib/src/data-migrations/migrations/064-sequences-limit.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { applySequencesLimit } from './064-sequences-limit'
+
+/**
+ * `sequencesLimit` is a NEW static-limit key, so unlike migration 063's fold there is
+ * nothing in the stored data to derive it from — the migration writes a target matrix.
+ * What matters is that it writes the target exactly, appends the key when a
+ * hand-edited plan lacks it, and reports `changed: false` on a second pass so the
+ * runner does not rewrite every plan row on every deploy.
+ *
+ * The DB plumbing is deliberately not exercised here (that needs a live Postgres).
+ */
+
+/** A plan's stored array as it stood BEFORE this migration (gate present, no limit key). */
+function before(gate: boolean) {
+  return [
+    { key: 'workflowsLimit', limit: 15 },
+    { key: 'sequences', limit: gate },
+    { key: 'savedViews', limit: 20 },
+  ]
+}
+
+describe('applySequencesLimit', () => {
+  it('appends the limit key when the plan does not carry it', () => {
+    const { limits, changed } = applySequencesLimit(before(false), { gate: true, limit: 3 })
+
+    expect(changed).toBe(true)
+    expect(limits).toContainEqual({ key: 'sequencesLimit', limit: 3 })
+  })
+
+  it('opens the gate on a plan that had sequences off', () => {
+    const { limits } = applySequencesLimit(before(false), { gate: true, limit: 3 })
+
+    expect(limits).toContainEqual({ key: 'sequences', limit: true })
+  })
+
+  it('leaves Free closed at a zero limit', () => {
+    const { limits } = applySequencesLimit(before(false), { gate: false, limit: 0 })
+
+    expect(limits).toContainEqual({ key: 'sequences', limit: false })
+    expect(limits).toContainEqual({ key: 'sequencesLimit', limit: 0 })
+  })
+
+  it('carries -1 through unchanged for Enterprise (the features provider maps it to "+")', () => {
+    const { limits } = applySequencesLimit(before(true), { gate: true, limit: -1 })
+
+    expect(limits).toContainEqual({ key: 'sequencesLimit', limit: -1 })
+  })
+
+  it('preserves every unrelated key and its order', () => {
+    const { limits } = applySequencesLimit(before(true), { gate: true, limit: 25 })
+
+    expect(limits.slice(0, 3).map((d) => d.key)).toEqual([
+      'workflowsLimit',
+      'sequences',
+      'savedViews',
+    ])
+    expect(limits).toContainEqual({ key: 'workflowsLimit', limit: 15 })
+    expect(limits).toContainEqual({ key: 'savedViews', limit: 20 })
+  })
+
+  it('is idempotent — a second pass reports no change', () => {
+    const target = { gate: true, limit: 3 }
+    const first = applySequencesLimit(before(false), target)
+    const second = applySequencesLimit(first.limits, target)
+
+    expect(first.changed).toBe(true)
+    expect(second.changed).toBe(false)
+    expect(second.limits).toEqual(first.limits)
+  })
+
+  it('rewrites a stale limit that drifted from the target', () => {
+    const stale = [...before(true), { key: 'sequencesLimit', limit: 99 }]
+    const { limits, changed } = applySequencesLimit(stale, { gate: true, limit: 25 })
+
+    expect(changed).toBe(true)
+    expect(limits).toContainEqual({ key: 'sequencesLimit', limit: 25 })
+    expect(limits.filter((d) => d.key === 'sequencesLimit')).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/064-sequences-limit.ts
+++ b/packages/lib/src/data-migrations/migrations/064-sequences-limit.ts
@@ -1,0 +1,160 @@
+// packages/lib/src/data-migrations/migrations/064-sequences-limit.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { invalidatePlans, onCacheEvent } from '../../cache/invalidate'
+import type { FeatureDefinition } from '../../permissions/types'
+import { parseFeatureLimits } from '../../permissions/types'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-064')
+
+/** Static-limit key this migration introduces. */
+const LIMIT_KEY = 'sequencesLimit'
+/** Boolean gate it pairs with (already present on every plan). */
+const GATE_KEY = 'sequences'
+
+/**
+ * Target state per plan, keyed by `Plan.name` — the same matrix the seeder now
+ * carries in `STATIC_LIMITS`/`BOOLEAN_GATES` (packages/seed/src/domains/billing.domain.ts).
+ *
+ * Unlike migration 063's fold, this one CANNOT be derived from the existing data:
+ * `sequencesLimit` did not exist before, so there is nothing to compute it from, and
+ * the Demo/Starter gate flip is a pricing decision rather than arithmetic. Hard-coding
+ * by plan name is therefore the honest form. A plan whose name is not in this map (a
+ * hand-created custom plan) is deliberately left ALONE — it keeps whatever `sequences`
+ * gate it has and simply gains no limit key, which reads as unlimited via `getLimit`.
+ */
+const TARGET: Record<string, { gate: boolean; limit: number }> = {
+  Demo: { gate: true, limit: 3 },
+  Free: { gate: false, limit: 0 },
+  Starter: { gate: true, limit: 3 },
+  Growth: { gate: true, limit: 25 },
+  Enterprise: { gate: true, limit: -1 },
+}
+
+/**
+ * Apply the target `sequences` gate + `sequencesLimit` to one plan's stored feature
+ * array. Returns the array unchanged with `changed: false` when it already matches, so
+ * a second pass rewrites nothing.
+ *
+ * Exported so a test checks the merge rule rather than the JSONB plumbing.
+ */
+export function applySequencesLimit(
+  limitsJson: unknown,
+  target: { gate: boolean; limit: number }
+): { limits: FeatureDefinition[]; changed: boolean } {
+  const defs = parseFeatureLimits(limitsJson)
+
+  let changed = false
+  let sawLimit = false
+  const limits: FeatureDefinition[] = []
+
+  for (const def of defs) {
+    if (def.key === LIMIT_KEY) {
+      sawLimit = true
+      if (def.limit !== target.limit) changed = true
+      limits.push({ key: LIMIT_KEY, limit: target.limit })
+      continue
+    }
+    if (def.key === GATE_KEY) {
+      if (def.limit !== target.gate) changed = true
+      limits.push({ key: GATE_KEY, limit: target.gate })
+      continue
+    }
+    limits.push(def)
+  }
+
+  // Append rather than assume a slot: `composeFeatureLimits` guarantees key order
+  // only for freshly seeded plans, and a plan edited in the admin panel may be
+  // missing keys entirely (same reasoning as migration 063).
+  if (!sawLimit) {
+    limits.push({ key: LIMIT_KEY, limit: target.limit })
+    changed = true
+  }
+
+  return { limits, changed }
+}
+
+/**
+ * Add the `sequencesLimit` static limit to every seeded `Plan`, and open the
+ * `sequences` boolean gate on Demo and Starter.
+ *
+ * **Why a migration at all.** `Plan.featureLimits` is stored JSONB and the seeder only
+ * rewrites a plan it is re-seeding, so editing `billing.domain.ts` alone leaves every
+ * existing environment with no `sequencesLimit` key. Absent, `getLimit` returns `null`
+ * and `requireLimit` returns early — i.e. sequences would stay silently UNCAPPED on
+ * Growth, which is the tier the cap is for.
+ *
+ * The counting side is `countSequencesUsed`, which excludes the five seeded
+ * client-notification templates; they are undeletable, so counting them would strand
+ * an org over its cap with no way back under. No backfill of org data is needed here —
+ * only the plan catalog changes.
+ *
+ * Raw Drizzle on purpose (project convention): the plan/feature service paths fire
+ * subscription and overage side effects that a catalog fixup has no business entering.
+ * The cache busting those paths would have done is performed explicitly below —
+ * `features` is a PER-ORG key derived from the plan, so `invalidatePlans()` alone would
+ * leave every org serving a stale feature map until its TTL.
+ */
+export const migration064SequencesLimit: DataMigrationDef = {
+  id: '064-sequences-limit',
+  description:
+    'Add the sequencesLimit static limit to every plan and open sequences on Demo/Starter',
+  async run(db: Database): Promise<void> {
+    const plans = await db
+      .select({
+        id: schema.Plan.id,
+        name: schema.Plan.name,
+        featureLimits: schema.Plan.featureLimits,
+        trialFeatureLimits: schema.Plan.trialFeatureLimits,
+      })
+      .from(schema.Plan)
+
+    let updated = 0
+    for (const plan of plans) {
+      const target = TARGET[plan.name]
+      if (!target) {
+        logger.info('Plan not in the target matrix — left untouched', { plan: plan.name })
+        continue
+      }
+
+      const features = applySequencesLimit(plan.featureLimits, target)
+      // `trialFeatureLimits` is nullable and, when present, is a FULL replacement array
+      // read instead of `featureLimits`, so it needs the same treatment.
+      const trial =
+        plan.trialFeatureLimits == null
+          ? { limits: [], changed: false }
+          : applySequencesLimit(plan.trialFeatureLimits, target)
+      if (!features.changed && !trial.changed) continue
+
+      await db
+        .update(schema.Plan)
+        .set({
+          ...(features.changed ? { featureLimits: features.limits } : {}),
+          ...(trial.changed ? { trialFeatureLimits: trial.limits } : {}),
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.Plan.id, plan.id))
+      updated += 1
+      logger.info('Applied sequences limit', { plan: plan.name, ...target })
+    }
+
+    if (updated === 0) {
+      logger.info('Every plan already carried the target sequences limit — nothing to do')
+      return
+    }
+
+    // The global plan catalog first, then the per-org `features` map derived from it.
+    // `plan.changed` fans out to `features` + `subscription` + `overages`.
+    await invalidatePlans()
+    const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+    for (const org of orgs) {
+      await onCacheEvent('plan.changed', { orgId: org.id })
+    }
+
+    logger.info('Seeded the sequencesLimit feature key', { plans: updated, orgs: orgs.length })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -30,6 +30,7 @@ import { migration058ReopenPersonalOnboarding } from './migrations/058-reopen-pe
 import { migration060PersonalInboxMove } from './migrations/060-personal-inbox-move'
 import { migration061InboxesMemberBaselineBackfill } from './migrations/061-inboxes-member-baseline-backfill'
 import { migration063RetireMailPermissionsFeatureKey } from './migrations/063-retire-mail-permissions-feature-key'
+import { migration064SequencesLimit } from './migrations/064-sequences-limit'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -82,6 +83,7 @@ function buildRegistry(): DataMigrationDef[] {
     // and arrives via ALL_ENTITY_MIGRATIONS above; it owns 062 in the shared id
     // sequence.
     migration063RetireMailPermissionsFeatureKey,
+    migration064SequencesLimit,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/permissions/overage-detection-service.ts
+++ b/packages/lib/src/permissions/overage-detection-service.ts
@@ -7,6 +7,7 @@ import { getAppCache } from '../cache'
 import { getOrgCache } from '../cache/singletons'
 import { countBillableChannels } from '../channels'
 import { createScopedLogger } from '../logger'
+import { countSequencesUsed } from '../sequences/sequence-limits'
 import { countSavedViewsUsed } from '../table-views/saved-view-limits'
 import type { FeatureDefinition } from './types'
 import { FEATURE_REGISTRY_MAP, FeatureKey, parseFeatureLimits } from './types'
@@ -270,6 +271,13 @@ export class OverageDetectionService {
             )
           )
         return result?.value ?? 0
+      }
+
+      case FeatureKey.sequencesLimit: {
+        // Org-authored sequences only — the 5 seeded client-notification templates are
+        // undeletable, so counting them would strand every org over its cap. See
+        // `countSequencesUsed`.
+        return countSequencesUsed(this.db, organizationId)
       }
 
       case FeatureKey.savedViews: {

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -55,6 +55,7 @@ export enum FeatureKey {
   workerSeats = 'workerSeats',
   channels = 'channels',
   workflowsLimit = 'workflowsLimit',
+  sequencesLimit = 'sequencesLimit',
   savedViews = 'savedViews',
   kbPublishedArticles = 'kbPublishedArticles',
   knowledgeBases = 'knowledgeBases',
@@ -238,6 +239,15 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     label: 'Workflows',
     group: 'Automation',
     unit: 'workflows',
+  },
+  {
+    key: FeatureKey.sequencesLimit,
+    type: 'static',
+    label: 'Sequences',
+    description:
+      'Org-authored outbound email cadences. The seeded client-notification templates are excluded — they cannot be deleted, so counting them would strand an org over its limit.',
+    group: 'Automation',
+    unit: 'sequences',
   },
   {
     key: FeatureKey.savedViews,

--- a/packages/lib/src/sequences/index.ts
+++ b/packages/lib/src/sequences/index.ts
@@ -67,6 +67,8 @@ export { buildSequenceUnsubscribeUrl, exitActiveRunsForSequence, exitSequenceRun
 // Seed templates (client-notifications plan §4.6) — new-org path (organization-seeder.ts) +
 // existing-org backfill (scripts/backfill-client-notification-sequences.ts)
 export { SEQUENCE_SEED_TEMPLATES, seedClientNotificationSequences } from './seed-templates'
+// Plan-limit counter — shared by the create gate and OverageDetectionService
+export { countSequencesUsed } from './sequence-limits'
 export type { GetSequenceStatsInput } from './stats'
 // Stats
 export { getSequenceStats } from './stats'

--- a/packages/lib/src/sequences/sequence-limits.ts
+++ b/packages/lib/src/sequences/sequence-limits.ts
@@ -1,0 +1,34 @@
+// packages/lib/src/sequences/sequence-limits.ts
+
+import { type Database, schema } from '@auxx/database'
+import { and, count, eq, isNull } from 'drizzle-orm'
+
+/**
+ * The single counter behind the `sequencesLimit` plan limit.
+ *
+ * Counts **org-authored** sequences only — rows with a `templateKey` are the five
+ * client-notification templates `seedClientNotificationSequences` writes into every
+ * new org, and they are excluded for a reason that is not merely cosmetic:
+ * {@link deleteSequence} *forbids* deleting a `templateKey` row. Counting them would
+ * put every org 5 toward its cap on day one with **no action available to get back
+ * under it** — the org would be permanently blocked from creating a sequence. (Same
+ * class of bug as the seeded views/sequences that broke `savedViews` and
+ * `workflowsLimit`; see `table-views/saved-view-limits.ts`.)
+ *
+ * Note this counts DRAFT sequences too. A draft still occupies the surface, still
+ * holds a compiled `WorkflowApp`, and is one publish away from sending — metering
+ * only `enabled` rows would let an org stage unlimited cadences and flip them all on.
+ *
+ * Exported so the create gate (`sequence.create`) and `OverageDetectionService` read
+ * one number rather than growing two queries that drift.
+ */
+export async function countSequencesUsed(db: Database, organizationId: string): Promise<number> {
+  const [result] = await db
+    .select({ value: count() })
+    .from(schema.Sequence)
+    .where(
+      and(eq(schema.Sequence.organizationId, organizationId), isNull(schema.Sequence.templateKey))
+    )
+
+  return result?.value ?? 0
+}

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -50,6 +50,7 @@ const STATIC_LIMITS = {
     workerSeats: 0,
     channels: 1,
     workflowsLimit: 3,
+    sequencesLimit: 3,
     savedViews: 10,
     knowledgeBases: 1,
     kbPublishedArticles: 5,
@@ -63,6 +64,7 @@ const STATIC_LIMITS = {
     workerSeats: 0,
     channels: 1,
     workflowsLimit: 3,
+    sequencesLimit: 0,
     savedViews: 10,
     knowledgeBases: 1,
     kbPublishedArticles: 8,
@@ -76,6 +78,7 @@ const STATIC_LIMITS = {
     workerSeats: 2,
     channels: 3,
     workflowsLimit: 15,
+    sequencesLimit: 3,
     savedViews: 20,
     knowledgeBases: 1,
     kbPublishedArticles: 50,
@@ -89,6 +92,7 @@ const STATIC_LIMITS = {
     workerSeats: 10,
     channels: -1,
     workflowsLimit: -1,
+    sequencesLimit: 25,
     savedViews: -1,
     knowledgeBases: -1,
     kbPublishedArticles: -1,
@@ -102,6 +106,7 @@ const STATIC_LIMITS = {
     workerSeats: -1,
     channels: -1,
     workflowsLimit: -1,
+    sequencesLimit: -1,
     savedViews: -1,
     knowledgeBases: -1,
     kbPublishedArticles: -1,
@@ -135,7 +140,12 @@ const BOOLEAN_GATES = {
     dataConnectors: true,
     dashboards: false,
     dispatch: false,
-    sequences: false,
+    // Sequences is metered by `sequencesLimit`, not bundled with `dispatch` — the
+    // dispatch-triggered client-notification templates stay unreachable without the
+    // `dispatch` gate (see client-notifications-settings-page.tsx, which requires
+    // both), but manual/CRM outbound cadences are the general-purpose half and demo
+    // should show them off.
+    sequences: true,
     // Demo carried `mailPermissions: true` before plan v3/03 §7.6 folded that key
     // into this one, so the demo org keeps demoing sharing (D9).
     granularPermissions: true,
@@ -185,7 +195,8 @@ const BOOLEAN_GATES = {
     dataConnectors: true,
     dashboards: false,
     dispatch: false,
-    sequences: false,
+    // On at a metered 3 (`sequencesLimit`) — the upgrade lever into Growth's 25.
+    sequences: true,
     granularPermissions: false,
   },
   growth: {


### PR DESCRIPTION
Follow-up to #1444. Removing the hidden system-owned `WorkflowApp` rows from `workflowsLimit` left sequences counting toward **nothing** — so give them their own static limit rather than folding them back into the workflow bucket, where they never belonged (they're invisible in the workflows list and excluded from its create gate).

## Proposed counts

| Plan | `sequences` gate | `sequencesLimit` | Change |
|---|---|---|---|
| Demo | `false` → **`true`** | **3** | gate flip |
| Free | `false` | **0** | limit only |
| Starter | `false` → **`true`** | **3** | gate flip |
| Growth | `true` | **25** | limit only |
| Enterprise | `true` | **-1** | limit only |

Sequences was previously bundled with `dispatch` at Growth+ only. A count limit that exists solely on Growth — where every other static limit is already `-1` — barely does anything, so demo and starter get the gate opened and the count becomes the actual upgrade lever. Starter's outbound cap is 1,000 emails/mo and Growth's is 10,000, which is the real cost ceiling; 25 on Growth bounds a runaway without touching legitimate use (the most any org in the DB has authored is 3).

The dispatch-triggered client-notification templates stay unreachable without the `dispatch` gate — `client-notifications-settings-page.tsx` requires both — so what demo and starter actually gain is the manual/CRM outbound half.

## What counts

`countSequencesUsed` counts **org-authored** sequences only.

- **Seeded templates are excluded, and this is not cosmetic.** `deleteSequence` *forbids* deleting a `templateKey` row. If the 5 seeded client-notification templates counted, every org would start 5 toward its cap **with no action available to get back under it** — strictly worse than the bug #1444 fixed, because there'd be no remedy.
- **Drafts do count.** A draft still holds a compiled `WorkflowApp` and is one publish away from sending; metering only `enabled` rows would let an org stage unlimited cadences and flip them all on at once.

One counter, shared by the create gate and `OverageDetectionService` — same discipline as `countSeatsUsed` and `countSavedViewsUsed`.

## Why migration 064 is load-bearing

Not cleanup. `Plan.featureLimits` is stored JSONB and the seeder only rewrites a plan it is re-seeding, so editing `billing.domain.ts` alone leaves every existing environment with **no `sequencesLimit` key**. An absent key makes `getLimit` return `null`, which `requireLimit` returns early on — i.e. sequences would stay silently **uncapped on Growth**, the one tier the cap is for.

Unlike #1444's migration 063 (a fold derivable from existing data), this writes a target matrix keyed by plan name: `sequencesLimit` didn't exist before, and the Demo/Starter gate flip is a pricing decision, not arithmetic. Plans not in the matrix (hand-created custom plans) are deliberately left alone.

## UI

`CreateSequenceButton` gets the `LimitReachedDialog` / `isAtLimit` treatment the workflows tab already has. Without it a Starter user at 3 would fill in the entire create dialog and get a red toast, while the button one tab over degrades gracefully. The client-side count filters `templateKey` rows to match the server.

## Verification

- New migration test: **7/7**. Full `data-migrations` suite: **86/86**. Permissions suite: **964/964**.
- `tsc --noEmit` clean for `packages/lib`, `apps/web`, and `packages/seed` on the changed files (grepped, given the known-broken repo baselines).
- Biome clean on all 10 files.
- **Migration 064 has already run end-to-end against a real database** — the local dev stack picked it up and applied it in 192ms (`DataMigration: 064-sequences-limit / applied`), producing exactly the matrix above in the `Plan` rows. Nothing ran against production.

## Notes

- No org in the DB exceeds its proposed cap, so this introduces no new overage banners.
- Demo/starter will now show the 5 seeded templates in the sequences list: disabled, inert (their trigger events can't occur without `dispatch`), and undeletable. Filtering them from `listSequences` when the dispatch gate is off would clean that up — deliberately left out of this PR.
- Unrelated, spotted while verifying: `billing_test_starter` / `billing_test_pro` / `billing_test_enterprise` carry **zero** feature keys, so an org on one gets no features at all, and their `hierarchyLevel` values collide with the real Starter/Growth/Enterprise.