### PR TITLE
fix(channels): answer the graph subscription handshake on post

### DIFF
--- a/apps/web/src/app/api/outlook/webhook/route.test.ts
+++ b/apps/web/src/app/api/outlook/webhook/route.test.ts
@@ -1,0 +1,89 @@
+// apps/web/src/app/api/outlook/webhook/route.test.ts
+
+import { describe, expect, it, vi } from 'vitest'
+import { GET, POST } from './route'
+
+/**
+ * The Microsoft Graph notificationUrl handshake, per
+ * https://learn.microsoft.com/graph/change-notifications-delivery — Graph POSTs
+ * to the endpoint with `?validationToken=` and an EMPTY body, and requires HTTP
+ * 200 + `text/plain` + the URL-decoded token as the whole body within 10s. Miss
+ * any of that and the subscription is silently never created.
+ *
+ * This is pinned because the handler previously answered `validationToken` only
+ * on GET: the POST handshake fell through to `await req.json()`, which throws on
+ * an empty body, so every create/renew got a 500 and Outlook push stayed dead.
+ */
+
+vi.mock('@auxx/database', () => ({ database: {}, schema: {} }))
+vi.mock('@auxx/lib/email', () => ({ MessageService: class {} }))
+vi.mock('@auxx/lib/webhooks', () => ({ timingSafeStringEqual: () => true }))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+const URL_BASE = 'https://app.auxx.ai/api/outlook/webhook'
+
+/** Graph's handshake: query param set, body genuinely empty. */
+const validationRequest = (rawToken: string) =>
+  new Request(`${URL_BASE}?validationToken=${rawToken}`, {
+    method: 'POST',
+    body: '',
+  }) as never
+
+describe('Graph subscription validation handshake', () => {
+  it('answers the POST handshake with 200, text/plain and the token', async () => {
+    const response = await POST(validationRequest('Validation%3A+Testing'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    await expect(response.text()).resolves.toBe('Validation: Testing')
+  })
+
+  it('URL-decodes the token rather than echoing the raw query value', async () => {
+    // Graph sends a percent-encoded token and compares against the DECODED form.
+    const response = await POST(validationRequest('a%2Bb%20c%26d'))
+
+    await expect(response.text()).resolves.toBe('a+b c&d')
+  })
+
+  it('still answers the handshake on GET', async () => {
+    const request = new Request(`${URL_BASE}?validationToken=tok`) as never
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    await expect(response.text()).resolves.toBe('tok')
+  })
+})
+
+describe('notification payloads', () => {
+  it('rejects an unparseable body with 400, not 500', async () => {
+    // 5xx makes Graph retry a payload that can never succeed.
+    const request = new Request(URL_BASE, { method: 'POST', body: 'not json' }) as never
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects a well-formed body with no `value` array with 400', async () => {
+    const request = new Request(URL_BASE, {
+      method: 'POST',
+      body: JSON.stringify({ nope: true }),
+    }) as never
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+  })
+
+  it('acknowledges an empty notification batch with 200', async () => {
+    const request = new Request(URL_BASE, {
+      method: 'POST',
+      body: JSON.stringify({ value: [] }),
+    }) as never
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ success: true, processed: 0 })
+  })
+})

--- a/apps/web/src/app/api/outlook/webhook/route.ts
+++ b/apps/web/src/app/api/outlook/webhook/route.ts
@@ -49,35 +49,59 @@ function verifyClientState(
 }
 
 /**
- * GET handler - Microsoft Graph subscription validation
- * During subscription setup, Microsoft sends a validationToken that must be echoed back
+ * Build the subscription-validation handshake response.
+ *
+ * Graph requires HTTP 200, `text/plain`, and the URL-decoded token as the entire
+ * body, within 10 seconds — anything else and the subscription is never created.
+ * `searchParams.get` already returns the decoded value.
+ */
+function validationResponse(validationToken: string): NextResponse {
+  logger.info('Received Microsoft Graph subscription validation request')
+  return new NextResponse(validationToken, {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  })
+}
+
+/**
+ * GET handler - health check, plus the validation handshake for good measure.
+ *
+ * Graph itself validates over POST (see the POST handler); this branch only
+ * covers manual pokes at the endpoint.
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const { searchParams } = new URL(req.url)
-  const validationToken = searchParams.get('validationToken')
-
-  if (validationToken) {
-    logger.info('Received Microsoft Graph subscription validation request')
-    // Echo back the validation token as plain text
-    return new NextResponse(validationToken, {
-      status: 200,
-      headers: { 'Content-Type': 'text/plain' },
-    })
-  }
+  const validationToken = new URL(req.url).searchParams.get('validationToken')
+  if (validationToken) return validationResponse(validationToken)
 
   // Health check if no validation token
   return NextResponse.json({ status: 'ok', timestamp: Date.now() })
 }
 
 /**
- * POST handler - Process Microsoft Graph webhook notifications
+ * POST handler - subscription validation, then change notifications.
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  // Graph performs the notificationUrl handshake as a POST carrying
+  // `?validationToken=` and an EMPTY body. This must be answered before any
+  // attempt to read the body — `req.json()` on an empty body throws, which used
+  // to surface as a 500 and made every subscription create/renew fail.
+  const validationToken = new URL(req.url).searchParams.get('validationToken')
+  if (validationToken) return validationResponse(validationToken)
+
   logger.info('Received Microsoft Graph webhook notification')
 
+  let body: GraphWebhookPayload
   try {
-    const body: GraphWebhookPayload = await req.json()
+    body = await req.json()
+  } catch (error) {
+    // Malformed body is the sender's bug — 400 so Graph stops retrying it.
+    logger.error('Could not parse Microsoft Graph webhook body as JSON', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: 'Invalid payload format' }, { status: 400 })
+  }
 
+  try {
     if (!body || !body.value || !Array.isArray(body.value)) {
       logger.error('Invalid Microsoft Graph webhook payload format', { body })
       return NextResponse.json({ error: 'Invalid payload format' }, { status: 400 })


### PR DESCRIPTION
## The bug

Outlook push notifications have been dead in production. Worker logs:

```
[outlook-provider]: Error creating/updating Microsoft Graph subscription:
  "Subscription validation request failed. HTTP status code is 'InternalServerError'.
   Notification endpoint must respond with 200 OK to validation request."
[webhook-renewal-job]: Failed to renew webhook { integrationId: aqiex34qi18o2suejret43p6 }
```

Per the [Graph docs](https://learn.microsoft.com/graph/change-notifications-delivery), Graph validates a `notificationUrl` by **POSTing** to it with `?validationToken=` and an **empty body**, and requires HTTP 200, `text/plain`, and the **URL-decoded** token within 10 seconds.

`route.ts` only handled `validationToken` on `GET`. The POST handshake fell through to `await req.json()` on line 79 — which throws `SyntaxError: Unexpected end of JSON input` on an empty body — hit the catch, and returned 500 from line 110. Graph saw `InternalServerError` and refused to create the subscription. The failing log line sits exactly one statement after `Received Microsoft Graph webhook notification`, which is how it turned up.

## Changes

- `POST` checks `validationToken` **before** touching the body. Extracted into a shared `validationResponse()` so `GET` and `POST` answer identically. `searchParams.get()` already URL-decodes, which is the form Graph compares against.
- Body parsing split into its own `try`/`catch` returning **400** instead of 500 — a 5xx makes Graph retry a payload that can never succeed.

## Tests

New `route.test.ts`, 6 tests: handshake status / content-type / URL-decoding / GET parity, plus 400 on unparseable body, 400 on missing `value`, 200 on empty batch.

I temporarily reverted the fix to confirm the tests are real regression guards. The two handshake assertions do fail against the old handler. That check also caught a **vacuous test** of mine — a `not.toBe(500)` assertion that passed even against the broken code, because the new body-parse catch turns that path into a 400. It proved nothing and duplicated another test's setup, so I removed it rather than ship a green-but-meaningless assertion.

Typecheck and Biome clean.

## This does not by itself restore push

The fix only makes the endpoint answer correctly. Integration `aqiex34qi18o2suejret43p6` currently has **no valid Graph subscription**, so after deploy either `webhook-renewal-job` needs to run or the channel needs reconnecting before push resumes. Worth confirming `Failed to renew webhook` stops appearing in worker logs.

## Related

Separate from, but found alongside, #1447 (channel sync reporting an in-flight sync instead of a 500). Still open and **not** addressed here: Gmail push is also dead — `403 PERMISSION_DENIED` publishing to `projects/auxxai/topics/email-notifications`, so every Gmail channel falls back to 30s polling. That one is a Google Cloud IAM fix, not a code change.
