### PR TITLE
fix(homepage): start the agent run instantly and stop clipping the procedure ring

### DIFF
--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-run-illustration.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-run-illustration.tsx
@@ -56,10 +56,19 @@ const TOOL_ICONS: Record<string, ToolPillIcon> = {
 /* Playback                                                                    */
 /* -------------------------------------------------------------------------- */
 
+/**
+ * Playback starts with the first entry already on screen. `step` is a count of
+ * revealed entries, so starting at 0 leaves the run column blank for a whole
+ * dwell after every chip click — the switch reads as a stall. Every script
+ * opens on its trigger (a user message or a system line), which is exactly the
+ * thing that should be there the instant you pick an agent.
+ */
+const FIRST_STEP = 1
+
 function useRunPlayback(scripts: AgentScript[]) {
   const reduceMotion = useReducedMotion()
   const [agentIndex, setAgentIndex] = useState(0)
-  const [step, setStep] = useState(0)
+  const [step, setStep] = useState(FIRST_STEP)
   const [paused, setPaused] = useState(false)
 
   const script = scripts[agentIndex] ?? scripts[0]!
@@ -77,14 +86,21 @@ function useRunPlayback(scripts: AgentScript[]) {
 
     const timer = setTimeout(() => {
       setAgentIndex((i) => (i + 1) % scripts.length)
-      setStep(0)
+      setStep(FIRST_STEP)
     }, AGENT_HOLD_MS)
     return () => clearTimeout(timer)
   }, [step, total, paused, reduceMotion, script, scripts.length])
 
+  /**
+   * Picking an agent also lifts the hover pause. The cursor is inside the
+   * illustration by definition when you click a chip, so `onMouseEnter` has
+   * already paused playback — without this the run you just asked for sits on
+   * its first entry until you move the mouse back out of the section.
+   */
   const selectAgent = useCallback((index: number) => {
     setAgentIndex(index)
-    setStep(0)
+    setStep(FIRST_STEP)
+    setPaused(false)
   }, [])
 
   /** Scrub to the last entry belonging to a procedure line. */

--- a/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-panel.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-panel.tsx
@@ -291,7 +291,11 @@ export function MockAgentPanel({
           Step-by-step playbooks the agent follows for specific situations.
         </p>
 
-        <div className='flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto'>
+        {/* `p-px`: `overflow-y-auto` promotes overflow-x to `auto` too, so this
+            box clips on all four sides at its padding edge. The rows' `ring-1`
+            paints outside their border box, so without the pad the ring loses
+            its left/right edges and the first and last row lose theirs. */}
+        <div className='flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-px'>
           {procedures.map((link) => {
             const isOpen = link.id === openedId
             const isCandidate = openedId == null


### PR DESCRIPTION
Two fixes to the agents-page run illustration (`platform/ai/agents`).

## Switching agents took ~a second to start, then stalled

Two separate causes:

- `step` counts *revealed* entries and reset to `0` on select, so the run column rendered empty for a full dwell (950ms) before the first entry appeared. It now starts with the trigger entry (the user message / `Schedule fired · 08:00`) already on screen. No script sets a `dwell` on its first entry, so nothing else repaces.
- The real stall: `onMouseEnter={pause}` had already frozen playback — the cursor is inside the illustration by definition when you click a chip, so the run sat on its first entry until the mouse left the whole section. `selectAgent` now clears `paused`; an explicit click beats hover-pause.

## Procedure rows' ring was clipped

The procedures list is `overflow-y-auto`. CSS promotes the other axis from `visible` to `auto`, so the box clips on all four sides at its padding edge — and `ring-1` paints *outside* the border box. Rows lost their left/right ring edges, and the first and last row lost top/bottom. A `p-px` on the scroll container gives the ring room.

## Testing

- `pnpm exec tsc --noEmit` in `apps/homepage` — clean
- Biome clean