### PR TITLE
feat(billing): make dashboards available on every plan

### DIFF
--- a/packages/lib/src/data-migrations/migrations/065-dashboards-all-plans.test.ts
+++ b/packages/lib/src/data-migrations/migrations/065-dashboards-all-plans.test.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/data-migrations/migrations/065-dashboards-all-plans.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { openDashboardsGate } from './065-dashboards-all-plans'
+
+/**
+ * The target is a constant (`dashboards: true`) rather than a per-plan matrix, so
+ * what matters is that the gate ends up open regardless of what the plan carried,
+ * that a hand-edited plan missing the key gains it, and that a second pass reports
+ * `changed: false` so the runner does not rewrite every plan row on every deploy.
+ *
+ * The DB plumbing is deliberately not exercised here (that needs a live Postgres).
+ */
+
+/** A plan's stored array as it stood BEFORE this migration. */
+function before(gate: boolean) {
+  return [
+    { key: 'workflowsLimit', limit: 15 },
+    { key: 'dashboards', limit: gate },
+    { key: 'savedViews', limit: 20 },
+  ]
+}
+
+describe('openDashboardsGate', () => {
+  it('opens the gate on a plan that had dashboards off', () => {
+    const { limits, changed } = openDashboardsGate(before(false))
+
+    expect(changed).toBe(true)
+    expect(limits).toContainEqual({ key: 'dashboards', limit: true })
+  })
+
+  it('appends the key when a hand-edited plan does not carry it', () => {
+    const { limits, changed } = openDashboardsGate([{ key: 'savedViews', limit: 20 }])
+
+    expect(changed).toBe(true)
+    expect(limits).toContainEqual({ key: 'dashboards', limit: true })
+  })
+
+  it('reports no change on a plan that already had it open', () => {
+    const { changed } = openDashboardsGate(before(true))
+
+    expect(changed).toBe(false)
+  })
+
+  it('preserves every unrelated key and its order', () => {
+    const { limits } = openDashboardsGate(before(false))
+
+    expect(limits.map((d) => d.key)).toEqual(['workflowsLimit', 'dashboards', 'savedViews'])
+    expect(limits).toContainEqual({ key: 'workflowsLimit', limit: 15 })
+    expect(limits).toContainEqual({ key: 'savedViews', limit: 20 })
+  })
+
+  it('is idempotent — a second pass reports no change', () => {
+    const first = openDashboardsGate(before(false))
+    const second = openDashboardsGate(first.limits)
+
+    expect(first.changed).toBe(true)
+    expect(second.changed).toBe(false)
+    expect(second.limits).toEqual(first.limits)
+  })
+
+  it('never emits the key twice', () => {
+    const { limits } = openDashboardsGate(before(false))
+
+    expect(limits.filter((d) => d.key === 'dashboards')).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/065-dashboards-all-plans.ts
+++ b/packages/lib/src/data-migrations/migrations/065-dashboards-all-plans.ts
@@ -1,0 +1,135 @@
+// packages/lib/src/data-migrations/migrations/065-dashboards-all-plans.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { invalidatePlans, onCacheEvent } from '../../cache/invalidate'
+import type { FeatureDefinition } from '../../permissions/types'
+import { parseFeatureLimits } from '../../permissions/types'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-065')
+
+/** The boolean gate this migration opens. */
+const GATE_KEY = 'dashboards'
+
+/**
+ * Force the `dashboards` boolean gate open in one plan's stored feature array,
+ * appending the key when a hand-edited plan lacks it entirely.
+ *
+ * Unlike migration 064 there is no per-plan target matrix: dashboards is now on
+ * for EVERY tier, so the target is the same constant everywhere and custom
+ * plans get it too. Returns `changed: false` when the array already says `true`,
+ * so a second pass rewrites nothing.
+ *
+ * Exported so a test checks the merge rule rather than the JSONB plumbing.
+ */
+export function openDashboardsGate(limitsJson: unknown): {
+  limits: FeatureDefinition[]
+  changed: boolean
+} {
+  const defs = parseFeatureLimits(limitsJson)
+
+  let changed = false
+  let sawGate = false
+  const limits: FeatureDefinition[] = []
+
+  for (const def of defs) {
+    if (def.key === GATE_KEY) {
+      sawGate = true
+      if (def.limit !== true) changed = true
+      limits.push({ key: GATE_KEY, limit: true })
+      continue
+    }
+    limits.push(def)
+  }
+
+  // Append rather than assume a slot: `composeFeatureLimits` guarantees key order
+  // only for freshly seeded plans, and a plan edited in the admin panel may be
+  // missing keys entirely (same reasoning as migrations 063/064).
+  if (!sawGate) {
+    limits.push({ key: GATE_KEY, limit: true })
+    changed = true
+  }
+
+  return { limits, changed }
+}
+
+/**
+ * Open the `dashboards` boolean gate on every `Plan` — dashboards ships on all
+ * tiers, not just Growth and Enterprise.
+ *
+ * **Why a migration at all.** `Plan.featureLimits` is stored JSONB and the seeder
+ * only rewrites a plan it is re-seeding, so flipping `BOOLEAN_GATES` in
+ * `packages/seed/src/domains/billing.domain.ts` alone leaves every existing
+ * environment with Demo/Free/Starter still reading `dashboards: false`. Booleans
+ * fail CLOSED in `FeaturePermissionService.hasAccess` (`false` and `undefined`
+ * both deny), so the stale rows would keep the locked upgrade state on the
+ * dashboards surfaces indefinitely.
+ *
+ * Applied unconditionally to every plan row, including hand-created custom ones:
+ * "available on all plans" has no exceptions to carve out, which is why this one
+ * needs no name-keyed target matrix.
+ *
+ * Raw Drizzle on purpose (project convention): the plan/feature service paths fire
+ * subscription and overage side effects that a catalog fixup has no business entering.
+ * The cache busting those paths would have done is performed explicitly below —
+ * `features` is a PER-ORG key derived from the plan, so `invalidatePlans()` alone would
+ * leave every org serving a stale feature map until its TTL.
+ */
+export const migration065DashboardsAllPlans: DataMigrationDef = {
+  id: '065-dashboards-all-plans',
+  description: 'Open the dashboards boolean gate on every plan',
+  async run(db: Database): Promise<void> {
+    const plans = await db
+      .select({
+        id: schema.Plan.id,
+        name: schema.Plan.name,
+        featureLimits: schema.Plan.featureLimits,
+        trialFeatureLimits: schema.Plan.trialFeatureLimits,
+      })
+      .from(schema.Plan)
+
+    let updated = 0
+    for (const plan of plans) {
+      const features = openDashboardsGate(plan.featureLimits)
+      // `trialFeatureLimits` is nullable and, when present, is a FULL replacement array
+      // read instead of `featureLimits`, so it needs the same treatment.
+      const trial =
+        plan.trialFeatureLimits == null
+          ? { limits: [], changed: false }
+          : openDashboardsGate(plan.trialFeatureLimits)
+      if (!features.changed && !trial.changed) continue
+
+      await db
+        .update(schema.Plan)
+        .set({
+          ...(features.changed ? { featureLimits: features.limits } : {}),
+          ...(trial.changed ? { trialFeatureLimits: trial.limits } : {}),
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.Plan.id, plan.id))
+      updated += 1
+      logger.info('Opened the dashboards gate', { plan: plan.name })
+    }
+
+    if (updated === 0) {
+      logger.info('Every plan already had dashboards open — nothing to do')
+      return
+    }
+
+    // The global plan catalog first, then the per-org `features` map derived from it.
+    // `plan.changed` fans out to `features` + `subscription` + `overages`.
+    await invalidatePlans()
+    const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+    for (const org of orgs) {
+      await onCacheEvent('plan.changed', { orgId: org.id })
+    }
+
+    logger.info('Dashboards is now available on every plan', {
+      plans: updated,
+      orgs: orgs.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -31,6 +31,7 @@ import { migration060PersonalInboxMove } from './migrations/060-personal-inbox-m
 import { migration061InboxesMemberBaselineBackfill } from './migrations/061-inboxes-member-baseline-backfill'
 import { migration063RetireMailPermissionsFeatureKey } from './migrations/063-retire-mail-permissions-feature-key'
 import { migration064SequencesLimit } from './migrations/064-sequences-limit'
+import { migration065DashboardsAllPlans } from './migrations/065-dashboards-all-plans'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -84,6 +85,7 @@ function buildRegistry(): DataMigrationDef[] {
     // sequence.
     migration063RetireMailPermissionsFeatureKey,
     migration064SequencesLimit,
+    migration065DashboardsAllPlans,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -138,7 +138,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
-    dashboards: false,
+    dashboards: true,
     dispatch: false,
     // Sequences is metered by `sequencesLimit`, not bundled with `dispatch` — the
     // dispatch-triggered client-notification templates stay unreachable without the
@@ -169,7 +169,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
-    dashboards: false,
+    dashboards: true,
     dispatch: false,
     sequences: false,
     granularPermissions: false,
@@ -193,7 +193,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
-    dashboards: false,
+    dashboards: true,
     dispatch: false,
     // On at a metered 3 (`sequencesLimit`) — the upgrade lever into Growth's 25.
     sequences: true,


### PR DESCRIPTION
Dashboards was a Growth+ boolean gate. This opens it on every tier.

## Changes

- **`packages/seed/src/domains/billing.domain.ts`** — `BOOLEAN_GATES`: `dashboards: false → true` on `demo`, `free`, `starter`. Growth and Enterprise were already `true`.
- **`packages/lib/src/data-migrations/migrations/065-dashboards-all-plans.ts`** (new) — opens the stored `dashboards` gate on every `Plan` row, then busts the caches.
- **`…/065-dashboards-all-plans.test.ts`** (new) — 6 tests on the merge rule.
- **`packages/lib/src/data-migrations/registry.ts`** — registered.

## Why a data migration is required

`Plan.featureLimits` is stored JSONB and the seeder only rewrites a plan it is re-seeding, so editing `billing.domain.ts` alone leaves every existing environment with Demo/Free/Starter still reading `dashboards: false`. Booleans fail **closed** in `FeaturePermissionService.hasAccess` (`false` and `undefined` both deny), so those orgs would keep seeing the locked upgrade state on the dashboards surfaces indefinitely.

The migration writes both `featureLimits` and `trialFeatureLimits` (the latter is a full replacement array when present, not a delta), appends the key when a hand-edited plan lacks it, and reports no change on a second pass so the runner does not rewrite every plan row on every deploy. Cache busting is explicit: `invalidatePlans()` for the global catalog, then `plan.changed` per org, because `features` is a per-org key derived from the plan.

Applied unconditionally to every plan row, including hand-created custom ones — "available on all plans" has no exceptions to carve out, which is why this one needs no name-keyed target matrix (unlike migration 064).

## Notes

- The `dashboards` `FeatureKey` and its three registry `featureKey` bindings are kept, now inert — same shape as `knowledgeBase` / `workflows` / `files`, which are already `true` on every tier. Keeps the lever if we ever want to re-gate.
- Pre-existing and unchanged here: the dashboard tRPC router uses `capabilityProcedure` + capability asserts and never calls `requirePermission`, so it never enforced the plan feature server-side — the gate was UI-only (`hasAccess(FeatureKey.dashboards)` in the list view, entity dashboard page, sidebar, kbar). That gap is now moot rather than fixed; if we re-gate, the server assert has to land with it.
- Per-user availability inside an org is unaffected: the Member profile baseline is already `dashboards: Full`, and `dashboard` is `baselineAtCreate: true` with `isPrivate` defaulting to `false`, so a new dashboard is org-visible unless made private.

## Testing

- `vitest run src/data-migrations/migrations/065-dashboards-all-plans.test.ts` — 6 passed
- `vitest run src/data-migrations/data-migrations.test.ts` — 10 passed (id uniqueness / ordering)
- `tsc --noEmit` in `packages/lib` and `packages/seed` — no new errors in the touched files