### PR TITLE
fix(ai): clear the kopilot and provider type errors and the bugs they were hiding

### DIFF
--- a/apps/web/src/components/kopilot/context/kopilot-context-chip-strip.tsx
+++ b/apps/web/src/components/kopilot/context/kopilot-context-chip-strip.tsx
@@ -4,7 +4,7 @@
 
 import { cn } from '@auxx/ui/lib/utils'
 import { useHotkey } from '@tanstack/react-hotkeys'
-import { Book, Bot, Building2, FileText, Inbox, Mail, User, X } from 'lucide-react'
+import { Book, Bot, Building2, FileText, Inbox, Mail, Table2, User, X } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
 import { recordBadgeVariants } from '~/components/resources/ui/record-badge'
@@ -15,6 +15,8 @@ import type { SessionRef, SessionRefKind } from './types'
 const KIND_ICONS: Record<SessionRefKind, typeof Mail> = {
   thread: Mail,
   record: FileText,
+  // An entity TYPE (the records table the user is on), not one row on it.
+  resource: Table2,
   kb: Book,
   article: FileText,
   actor: User,

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -532,7 +532,13 @@ export const FileVisibilityValues = ['PUBLIC', 'PRIVATE', 'INTERNAL'] as const
 
 export const INVENTORY_POLICYValues = ['CONTINUE', 'DENY'] as const
 
-export const IdentifierTypeValues = ['EMAIL', 'PHONE', 'FACEBOOK_PSID', 'INSTAGRAM_IGSID'] as const
+export const IdentifierTypeValues = [
+  'EMAIL',
+  'PHONE',
+  'FACEBOOK_PSID',
+  'INSTAGRAM_IGSID',
+  'CHAT_VISITOR',
+] as const
 
 export const InboxStatusValues = ['ACTIVE', 'ARCHIVED', 'PAUSED'] as const
 
@@ -1213,6 +1219,7 @@ export const IdentifierType = {
   PHONE: 'PHONE',
   FACEBOOK_PSID: 'FACEBOOK_PSID',
   INSTAGRAM_IGSID: 'INSTAGRAM_IGSID',
+  CHAT_VISITOR: 'CHAT_VISITOR',
 } as const
 
 export const InboxStatus = {

--- a/packages/lib/src/ai/agent-framework/__test-helpers.ts
+++ b/packages/lib/src/ai/agent-framework/__test-helpers.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/ai/agent-framework/__test-helpers.ts
+//
+// Shared test-only helpers for exercising `AgentToolDefinition`s.
+//
+// Two things every tool test needs and nothing provided before:
+//
+//  1. A `ToolContext`. Tools receive a `ToolContext`, not an `AgentDeps` —
+//     `db` and `context` are required on top. Tests that hand-rolled an
+//     `AgentDeps` literal were passing an incomplete context.
+//  2. A way to await `execute()`. Its return type is
+//     `Promise<AgentToolResult> | AsyncGenerator<ToolProgressPayload, AgentToolResult, void>`,
+//     so `(await tool.execute(...)).success` does not typecheck — the union has
+//     to be narrowed and the streaming branch drained.
+
+import type { Database } from '@auxx/database'
+import type { ContextManager } from './context/context-manager'
+import type { ToolContext } from './tool-context'
+import type { AgentToolDefinition, AgentToolResult, ToolProgressPayload } from './types'
+
+/** In-memory {@link ContextManager} — reads back whatever was written. */
+export function createContextManagerMock(initial: Record<string, unknown> = {}): ContextManager {
+  const store = new Map<string, unknown>(Object.entries(initial))
+  const manager: ContextManager = {
+    read: async (ref) => store.get(String(ref)),
+    interpolate: async (text) => text,
+    write: async (ref, value) => {
+      store.set(String(ref), value)
+    },
+    captureToolResult: () => {},
+    list: () => [],
+  }
+  return manager
+}
+
+/**
+ * Build a {@link ToolContext} for a tool test. Defaults cover the identity
+ * fields every tool reads; pass overrides for anything the case asserts on.
+ */
+export function createToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    organizationId: 'org-1',
+    userId: 'u-1',
+    sessionId: 's-1',
+    db: {} as Database,
+    context: createContextManagerMock(),
+    ...overrides,
+  }
+}
+
+function isAsyncGenerator(
+  value: unknown
+): value is AsyncGenerator<ToolProgressPayload, AgentToolResult, void> {
+  return typeof (value as AsyncGenerator | undefined)?.[Symbol.asyncIterator] === 'function'
+}
+
+/**
+ * Invoke a tool and return its final {@link AgentToolResult}, draining the
+ * streaming variant if the tool returns a generator. Progress payloads are
+ * discarded — use {@link runToolWithProgress} when a case asserts on them.
+ */
+export async function runTool(
+  tool: Pick<AgentToolDefinition, 'execute'>,
+  args: Record<string, unknown>,
+  ctx: ToolContext = createToolContext()
+): Promise<AgentToolResult> {
+  const { result } = await runToolWithProgress(tool, args, ctx)
+  return result
+}
+
+/** As {@link runTool}, but also returns every progress payload yielded. */
+export async function runToolWithProgress(
+  tool: Pick<AgentToolDefinition, 'execute'>,
+  args: Record<string, unknown>,
+  ctx: ToolContext = createToolContext()
+): Promise<{ result: AgentToolResult; progress: ToolProgressPayload[] }> {
+  const returned = tool.execute(args, ctx)
+  if (!isAsyncGenerator(returned)) return { result: await returned, progress: [] }
+
+  const progress: ToolProgressPayload[] = []
+  for (;;) {
+    const step = await returned.next()
+    if (step.done) return { result: step.value, progress }
+    progress.push(step.value)
+  }
+}

--- a/packages/lib/src/ai/clients/base/types.ts
+++ b/packages/lib/src/ai/clients/base/types.ts
@@ -206,6 +206,14 @@ export interface EmbeddingParams {
   model: string
   dimensions?: number
   user?: string
+  /**
+   * What the embedding is for. Providers that distinguish asymmetric embedding
+   * roles map this onto their own field — Voyage `input_type`, Cohere
+   * `inputType`, Google `taskType`. Recognized values (case-insensitive):
+   * `search` / `retrieval` (document side), `query`, `classification`,
+   * `clustering`. Anything else falls back to the provider's document default.
+   */
+  purpose?: string
 }
 
 export interface EmbeddingResponse {
@@ -220,6 +228,8 @@ export interface BatchEmbeddingParams {
   dimensions?: number
   batchSize?: number
   user?: string
+  /** See `EmbeddingParams.purpose` — forwarded to each per-batch request. */
+  purpose?: string
 }
 
 export interface BatchEmbeddingResponse {

--- a/packages/lib/src/ai/kopilot/capabilities/__tests__/registry.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/__tests__/registry.test.ts
@@ -7,6 +7,7 @@ import { createCapabilityRegistry } from '../registry'
 function tool(name: string): AgentToolDefinition {
   return {
     name,
+    displayName: name,
     description: name,
     parameters: { type: 'object', properties: {}, additionalProperties: false },
     execute: async () => ({ success: true, output: null }),

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/agent-authoring-instance-access.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/agent-authoring-instance-access.test.ts
@@ -131,7 +131,7 @@ function capsWithInstance(rung: Rung, areaLevel: Level = Level.Full): Capability
   return new CapabilitySet(
     new Set(expandLevelsToKeys({ [Area.agents]: areaLevel }) as PermissionKey[]),
     {},
-    'MEMBER',
+    'USER',
     'full',
     (id) => id,
     new Set(),

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/create-eval-case.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/create-eval-case.test.ts
@@ -8,7 +8,7 @@
 
 import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
-import type { AgentDeps } from '../../../../../agent-framework/types'
+import { createToolContext, runTool } from '../../../../../agent-framework/__test-helpers'
 import type { GetToolDeps } from '../../../types'
 
 vi.mock('../procedure-authoring-guard', () => ({
@@ -48,7 +48,7 @@ const getDeps: GetToolDeps = () =>
     userId: 'u-1',
     sessionId: 's-1',
   }) as never
-const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+const ctx = createToolContext({ organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' })
 
 const tool = createCreateEvalCaseTool(getDeps)
 
@@ -100,7 +100,7 @@ describe('tool flags', () => {
 
 describe('agent-scoped create', () => {
   it('persists an agent-scoped case when no procedureId is given', async () => {
-    const result = await tool.execute(validArgs as never, agentDeps)
+    const result = await runTool(tool, validArgs, ctx)
     expect(result.success).toBe(true)
     expect(listProcsMock).not.toHaveBeenCalled()
     const arg = createMock.mock.calls[0]?.[0]
@@ -119,7 +119,7 @@ describe('agent-scoped create', () => {
   })
 
   it('forwards the authored shape to the shared builder', async () => {
-    await tool.execute(validArgs as never, agentDeps)
+    await runTool(tool, validArgs, ctx)
     const authored = buildMock.mock.calls[0]?.[0]
     expect(authored).toMatchObject({
       name: 'Missing order number',
@@ -131,7 +131,7 @@ describe('agent-scoped create', () => {
 
 describe('procedure-scoped create — version pinning', () => {
   it('pins the active version when published', async () => {
-    const result = await tool.execute({ ...validArgs, procedureId: 'p1' } as never, agentDeps)
+    const result = await runTool(tool, { ...validArgs, procedureId: 'p1' }, ctx)
     expect(result.success).toBe(true)
     expect(createMock.mock.calls[0]?.[0].target).toEqual({
       kind: 'agent_simulation',
@@ -147,7 +147,7 @@ describe('procedure-scoped create — version pinning', () => {
     listProcsMock.mockResolvedValue(
       ok([{ procedureId: 'p1', activeVersionId: null, draftVersionId: 'v-draft' }])
     )
-    const result = await tool.execute({ ...validArgs, procedureId: 'p1' } as never, agentDeps)
+    const result = await runTool(tool, { ...validArgs, procedureId: 'p1' }, ctx)
     expect(result.success).toBe(true)
     expect(createMock.mock.calls[0]?.[0].target.procedureVersionId).toBe('v-draft')
   })
@@ -156,7 +156,7 @@ describe('procedure-scoped create — version pinning', () => {
     listProcsMock.mockResolvedValue(
       ok([{ procedureId: 'p1', activeVersionId: null, draftVersionId: null }])
     )
-    const result = await tool.execute({ ...validArgs, procedureId: 'p1' } as never, agentDeps)
+    const result = await runTool(tool, { ...validArgs, procedureId: 'p1' }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('no version')
     expect(createMock).not.toHaveBeenCalled()
@@ -164,7 +164,7 @@ describe('procedure-scoped create — version pinning', () => {
 
   it('errors (no write) when the procedure is not attached to the agent', async () => {
     listProcsMock.mockResolvedValue(ok([{ procedureId: 'other', activeVersionId: 'v' }]))
-    const result = await tool.execute({ ...validArgs, procedureId: 'p1' } as never, agentDeps)
+    const result = await runTool(tool, { ...validArgs, procedureId: 'p1' }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('not attached')
     expect(createMock).not.toHaveBeenCalled()
@@ -174,7 +174,7 @@ describe('procedure-scoped create — version pinning', () => {
 describe('validation + guard', () => {
   it('surfaces a builder validation failure without writing', async () => {
     buildMock.mockReturnValue(err('unknown mock tool "frobnicate"'))
-    const result = await tool.execute(validArgs as never, agentDeps)
+    const result = await runTool(tool, validArgs, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('frobnicate')
     expect(createMock).not.toHaveBeenCalled()
@@ -182,7 +182,7 @@ describe('validation + guard', () => {
 
   it('surfaces guard failures without touching the runtime or DB', async () => {
     guardMock.mockResolvedValueOnce({ ok: false, error: 'Not allowed' })
-    const result = await tool.execute(validArgs as never, agentDeps)
+    const result = await runTool(tool, validArgs, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toBe('Not allowed')
     expect(resolveCtxMock).not.toHaveBeenCalled()
@@ -191,7 +191,7 @@ describe('validation + guard', () => {
 
   it('surfaces a failed persist', async () => {
     createMock.mockResolvedValue(err({ code: 'EVAL_VALIDATION', message: 'Bad config' }))
-    const result = await tool.execute(validArgs as never, agentDeps)
+    const result = await runTool(tool, validArgs, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('Bad config')
   })

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-case-mock-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-case-mock-tools.test.ts
@@ -7,7 +7,7 @@
 
 import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
-import type { AgentDeps } from '../../../../../agent-framework/types'
+import { createToolContext, runTool } from '../../../../../agent-framework/__test-helpers'
 import type { GetToolDeps } from '../../../types'
 
 vi.mock('../procedure-authoring-guard', () => ({
@@ -40,7 +40,7 @@ const getDeps: GetToolDeps = () =>
     userId: 'u-1',
     sessionId: 's-1',
   }) as never
-const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+const ctx = createToolContext({ organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' })
 
 const readTool = createGetEvalCaseTool(getDeps)
 const writeTool = createUpdateEvalCaseMockTool(getDeps)
@@ -91,7 +91,7 @@ describe('tool flags', () => {
 
 describe('get_eval_case', () => {
   it('returns config (with mocks) and read-only assertions', async () => {
-    const result = await readTool.execute({ caseId: 'c1' } as never, agentDeps)
+    const result = await runTool(readTool, { caseId: 'c1' }, ctx)
     expect(result.success).toBe(true)
     const output = result.output as {
       config: { connectorMocks: unknown[] }
@@ -105,7 +105,7 @@ describe('get_eval_case', () => {
 
   it("reads another agent's case as not-found", async () => {
     getCaseMock.mockResolvedValue(ok({ ...caseRow, agentId: 'other-agent' }))
-    const result = await readTool.execute({ caseId: 'c1' } as never, agentDeps)
+    const result = await runTool(readTool, { caseId: 'c1' }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('not found')
   })
@@ -113,14 +113,15 @@ describe('get_eval_case', () => {
 
 describe('update_eval_case_mock', () => {
   it('replaces a mock in place after schema validation', async () => {
-    const result = await writeTool.execute(
+    const result = await runTool(
+      writeTool,
       {
         caseId: 'c1',
         upsertMocks: [
           { id: 'm1', toolName: 'order_lookup', output: { id: '10427' }, usage: 'repeat' },
         ],
-      } as never,
-      agentDeps
+      },
+      ctx
     )
     expect(result.success).toBe(true)
     expect(validateMock).toHaveBeenCalledWith({
@@ -139,7 +140,8 @@ describe('update_eval_case_mock', () => {
   })
 
   it('appends a new mock with a generated id and removes by id', async () => {
-    const result = await writeTool.execute(
+    const result = await runTool(
+      writeTool,
       {
         caseId: 'c1',
         upsertMocks: [
@@ -150,8 +152,8 @@ describe('update_eval_case_mock', () => {
           },
         ],
         removeMockIds: ['m1'],
-      } as never,
-      agentDeps
+      },
+      ctx
     )
     expect(result.success).toBe(true)
     const saved = updateCaseMock.mock.calls[0]?.[0]?.patch.config.connectorMocks
@@ -167,9 +169,10 @@ describe('update_eval_case_mock', () => {
 
   it('rejects an invalid mock output without writing', async () => {
     validateMock.mockResolvedValue({ ok: false, error: 'Expected string for `status`' })
-    const result = await writeTool.execute(
-      { caseId: 'c1', upsertMocks: [{ toolName: 'order_lookup', output: {} }] } as never,
-      agentDeps
+    const result = await runTool(
+      writeTool,
+      { caseId: 'c1', upsertMocks: [{ toolName: 'order_lookup', output: {} }] },
+      ctx
     )
     expect(result.success).toBe(false)
     expect(result.error).toContain('Expected string')
@@ -177,37 +180,32 @@ describe('update_eval_case_mock', () => {
   })
 
   it('rejects unknown mock ids (replace and remove) without writing', async () => {
-    const replace = await writeTool.execute(
+    const replace = await runTool(
+      writeTool,
       {
         caseId: 'c1',
         upsertMocks: [{ id: 'nope', toolName: 'order_lookup', output: {} }],
-      } as never,
-      agentDeps
+      },
+      ctx
     )
     expect(replace.success).toBe(false)
     expect(replace.error).toContain('No mock with id "nope"')
 
-    const remove = await writeTool.execute(
-      { caseId: 'c1', removeMockIds: ['nope'] } as never,
-      agentDeps
-    )
+    const remove = await runTool(writeTool, { caseId: 'c1', removeMockIds: ['nope'] }, ctx)
     expect(remove.success).toBe(false)
     expect(remove.error).toContain('No mock with id "nope"')
     expect(updateCaseMock).not.toHaveBeenCalled()
   })
 
   it('requires at least one operation', async () => {
-    const result = await writeTool.execute({ caseId: 'c1' } as never, agentDeps)
+    const result = await runTool(writeTool, { caseId: 'c1' }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('at least one')
   })
 
   it("writes to another agent's case read as not-found", async () => {
     getCaseMock.mockResolvedValue(ok({ ...caseRow, agentId: 'other-agent' }))
-    const result = await writeTool.execute(
-      { caseId: 'c1', removeMockIds: ['m1'] } as never,
-      agentDeps
-    )
+    const result = await runTool(writeTool, { caseId: 'c1', removeMockIds: ['m1'] }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('not found')
     expect(updateCaseMock).not.toHaveBeenCalled()
@@ -215,10 +213,7 @@ describe('update_eval_case_mock', () => {
 
   it('surfaces guard failures without touching the DB', async () => {
     guardMock.mockResolvedValueOnce({ ok: false, error: 'Not allowed' })
-    const result = await writeTool.execute(
-      { caseId: 'c1', removeMockIds: ['m1'] } as never,
-      agentDeps
-    )
+    const result = await runTool(writeTool, { caseId: 'c1', removeMockIds: ['m1'] }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toBe('Not allowed')
     expect(getCaseMock).not.toHaveBeenCalled()
@@ -226,10 +221,7 @@ describe('update_eval_case_mock', () => {
 
   it('surfaces a failed save', async () => {
     updateCaseMock.mockResolvedValue(err({ code: 'EVAL_VALIDATION', message: 'Invalid config' }))
-    const result = await writeTool.execute(
-      { caseId: 'c1', removeMockIds: ['m1'] } as never,
-      agentDeps
-    )
+    const result = await runTool(writeTool, { caseId: 'c1', removeMockIds: ['m1'] }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('Invalid config')
   })

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-read-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-read-tools.test.ts
@@ -5,7 +5,7 @@
 
 import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
-import type { AgentDeps } from '../../../../../agent-framework/types'
+import { createToolContext, runTool } from '../../../../../agent-framework/__test-helpers'
 import type { GetToolDeps } from '../../../types'
 
 vi.mock('../procedure-authoring-guard', () => ({
@@ -45,10 +45,10 @@ const getDeps: GetToolDeps = () =>
     userId: 'u-1',
     sessionId: 's-1',
   }) as never
-const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+const ctx = createToolContext({ organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' })
 
 const listTool = createListEvalCasesTool(getDeps)
-const runTool = createGetEvalRunTool(getDeps)
+const getRunTool = createGetEvalRunTool(getDeps)
 const diffTool = createGetSuiteDiffTool(getDeps)
 
 beforeEach(() => {
@@ -59,7 +59,7 @@ beforeEach(() => {
 describe('eval read tools — shared safety properties', () => {
   it.each([
     ['list_eval_cases', listTool],
-    ['get_eval_run', runTool],
+    ['get_eval_run', getRunTool],
     ['get_suite_diff', diffTool],
   ])('%s is read-only: idempotent, no approval gate', (_name, tool) => {
     expect(tool.idempotent).toBe(true)
@@ -70,11 +70,11 @@ describe('eval read tools — shared safety properties', () => {
 
   it.each([
     ['list_eval_cases', listTool, {}],
-    ['get_eval_run', runTool, { runId: 'r1' }],
+    ['get_eval_run', getRunTool, { runId: 'r1' }],
     ['get_suite_diff', diffTool, { baselineSuiteRunId: 'b', candidateSuiteRunId: 'c' }],
   ])('%s surfaces a guard failure without touching the DB', async (_name, tool, args) => {
     guardMock.mockResolvedValueOnce({ ok: false, error: 'Not allowed' })
-    const result = await tool.execute(args as never, agentDeps)
+    const result = await runTool(tool, args, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toBe('Not allowed')
     expect(listCasesMock).not.toHaveBeenCalled()
@@ -121,7 +121,7 @@ describe('list_eval_cases', () => {
       ])
     )
 
-    const result = await listTool.execute({ procedureId: 'p1' } as never, agentDeps)
+    const result = await runTool(listTool, { procedureId: 'p1' }, ctx)
     expect(result.success).toBe(true)
     expect(listCasesMock).toHaveBeenCalledWith({
       organizationId: 'org-1',
@@ -155,7 +155,7 @@ describe('get_eval_run', () => {
         error: null,
       })
     )
-    const result = await runTool.execute({ runId: 'r1' } as never, agentDeps)
+    const result = await runTool(getRunTool, { runId: 'r1' }, ctx)
     expect(result.success).toBe(true)
     expect(getRunMock).toHaveBeenCalledWith({ organizationId: 'org-1', runId: 'r1' })
     expect((result.output as { caseName: string }).caseName).toBe('Refund case')
@@ -164,7 +164,7 @@ describe('get_eval_run', () => {
 
   it('returns not-found for a cross-org run id without leaking', async () => {
     getRunMock.mockResolvedValue(ok(null))
-    const result = await runTool.execute({ runId: 'foreign' } as never, agentDeps)
+    const result = await runTool(getRunTool, { runId: 'foreign' }, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('not found')
   })
@@ -202,9 +202,10 @@ describe('get_suite_diff', () => {
       })
     )
 
-    const result = await diffTool.execute(
-      { baselineSuiteRunId: 'b', candidateSuiteRunId: 'c' } as never,
-      agentDeps
+    const result = await runTool(
+      diffTool,
+      { baselineSuiteRunId: 'b', candidateSuiteRunId: 'c' },
+      ctx
     )
     expect(result.success).toBe(true)
     expect(compareMock).toHaveBeenCalledWith({
@@ -225,9 +226,10 @@ describe('get_suite_diff', () => {
     compareMock.mockResolvedValue(
       err({ code: 'SUITE_NOT_TERMINAL', message: 'Suite run is not terminal: c (running)' })
     )
-    const result = await diffTool.execute(
-      { baselineSuiteRunId: 'b', candidateSuiteRunId: 'c' } as never,
-      agentDeps
+    const result = await runTool(
+      diffTool,
+      { baselineSuiteRunId: 'b', candidateSuiteRunId: 'c' },
+      ctx
     )
     expect(result.success).toBe(false)
     expect(result.error).toContain('not terminal')

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-tool-registry.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-tool-registry.test.ts
@@ -8,6 +8,7 @@
 
 import { ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentToolDefinition } from '../../../../../agent-framework/types'
 import type { GetToolDeps } from '../../../types'
 
 vi.mock('../../../../../../agents/procedures/authoring', async (importOriginal) => ({
@@ -38,7 +39,7 @@ const getDeps: GetToolDeps = () =>
 
 describe('agents-builder eval tool registry (phase 5C/5E)', () => {
   let names: string[] = []
-  let byName: Map<string, { requiresApproval?: boolean; idempotent?: boolean }>
+  let byName: Map<string, AgentToolDefinition>
 
   beforeEach(async () => {
     const capability = await createAgentsBuilderCapabilities(getDeps, 'org-1')

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/procedure-create.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/procedure-create.test.ts
@@ -2,7 +2,7 @@
 
 import { ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
-import type { AgentDeps } from '../../../../../agent-framework/types'
+import { createToolContext, runTool } from '../../../../../agent-framework/__test-helpers'
 import type { GetToolDeps } from '../../../types'
 
 // Force the auth guard to pass so we can exercise the tool's own logic.
@@ -33,7 +33,7 @@ const getDeps: GetToolDeps = () =>
     userId: 'u-1',
     sessionId: 's-1',
   }) as never
-const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+const ctx = createToolContext({ organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' })
 const tool = createCreateProcedureTool(getDeps)
 
 beforeEach(() => {
@@ -43,9 +43,10 @@ beforeEach(() => {
 
 describe('create_procedure', () => {
   it('rejects an invalid body BEFORE any DB write', async () => {
-    const result = await tool.execute(
-      { name: 'Bad', body: { steps: [{ id: 'x', kind: 'nonsense' }] } } as never,
-      agentDeps
+    const result = await runTool(
+      tool,
+      { name: 'Bad', body: { steps: [{ id: 'x', kind: 'nonsense' }] } },
+      ctx
     )
     expect(result.success).toBe(false)
     expect((result.output as { errors?: unknown[] }).errors?.length).toBeGreaterThan(0)
@@ -53,12 +54,13 @@ describe('create_procedure', () => {
   })
 
   it('rejects an opaque step on create (no prior draft to carry through)', async () => {
-    const result = await tool.execute(
+    const result = await runTool(
+      tool,
       {
         name: 'X',
         body: { steps: [{ id: 'opaque:body:#0', kind: 'opaque', label: 'code block: X' }] },
-      } as never,
-      agentDeps
+      },
+      ctx
     )
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/opaque\/read-only/)
@@ -66,10 +68,7 @@ describe('create_procedure', () => {
   })
 
   it('creates a draft (no body) and attaches it', async () => {
-    const result = await tool.execute(
-      { name: 'Refunds', whenToUse: 'refund asks' } as never,
-      agentDeps
-    )
+    const result = await runTool(tool, { name: 'Refunds', whenToUse: 'refund asks' }, ctx)
     expect(result.success).toBe(true)
     expect((result.output as { procedureId: string }).procedureId).toBe('p1')
     expect(createDraftMock).toHaveBeenCalledOnce()
@@ -83,7 +82,7 @@ describe('create_procedure', () => {
         { id: 's2', kind: 'route', outcome: 'finished' },
       ],
     }
-    const result = await tool.execute({ name: 'Greeter', body } as never, agentDeps)
+    const result = await runTool(tool, { name: 'Greeter', body }, ctx)
     expect(result.success).toBe(true)
     expect((result.output as { stepCount: number }).stepCount).toBeGreaterThan(0)
     // The DB write received a built doc (not the raw DSL).

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/procedure-tools-ref.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/procedure-tools-ref.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/procedure-tools-ref.test.ts
 
 import { describe, expect, it } from 'vitest'
-import type { AgentDeps } from '../../../../../agent-framework/types'
+import { createToolContext, runTool } from '../../../../../agent-framework/__test-helpers'
 import type { GetToolDeps } from '../../../types'
 import { createCreateProcedureTool } from '../procedure-create'
 import { createReadProcedureTool } from '../procedure-read'
@@ -19,7 +19,7 @@ const getDeps: GetToolDeps = () =>
     sessionId: 's-1',
   }) as never
 
-const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+const ctx = createToolContext({ organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' })
 
 const tools = [
   ['create_procedure', createCreateProcedureTool(getDeps), { name: 'X' }],
@@ -39,7 +39,7 @@ const tools = [
 describe('procedure tools — agent-ref resolution', () => {
   for (const [name, tool, args] of tools) {
     it(`${name} refuses when no agent is in session context`, async () => {
-      const result = await tool.execute(args as never, agentDeps)
+      const result = await runTool(tool, args, ctx)
       expect(result.success).toBe(false)
       expect(result.error).toMatch(/No agent in session context/)
     })

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/run-eval-suite.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/run-eval-suite.test.ts
@@ -2,7 +2,7 @@
 
 import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
-import type { AgentDeps } from '../../../../../agent-framework/types'
+import { createToolContext, runTool } from '../../../../../agent-framework/__test-helpers'
 import type { GetToolDeps } from '../../../types'
 
 // Force the auth guard to pass so we can exercise the tool's own logic.
@@ -29,7 +29,7 @@ const getDeps: GetToolDeps = () =>
     userId: 'u-1',
     sessionId: 's-1',
   }) as never
-const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+const ctx = createToolContext({ organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' })
 const tool = createRunEvalSuiteTool(getDeps)
 
 beforeEach(() => {
@@ -47,7 +47,7 @@ describe('run_eval_suite', () => {
   })
 
   it('starts the suite for the session agent and returns a taskNotification ref', async () => {
-    const result = await tool.execute({ useDraft: true } as never, agentDeps)
+    const result = await runTool(tool, { useDraft: true }, ctx)
     expect(result.success).toBe(true)
     expect(startMock).toHaveBeenCalledOnce()
     expect(startMock.mock.calls[0]![0]).toMatchObject({
@@ -71,7 +71,7 @@ describe('run_eval_suite', () => {
   })
 
   it('passes procedureId and filters caseIds to strings', async () => {
-    await tool.execute({ procedureId: 'p1', caseIds: ['c1', 42, '', 'c2'] } as never, agentDeps)
+    await runTool(tool, { procedureId: 'p1', caseIds: ['c1', 42, '', 'c2'] }, ctx)
     expect(startMock.mock.calls[0]![0]).toMatchObject({
       procedureId: 'p1',
       caseIds: ['c1', 'c2'],
@@ -80,7 +80,7 @@ describe('run_eval_suite', () => {
 
   it('surfaces the guard failure without starting anything', async () => {
     guardMock.mockResolvedValueOnce({ ok: false, error: 'Not allowed' })
-    const result = await tool.execute({} as never, agentDeps)
+    const result = await runTool(tool, {}, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toBe('Not allowed')
     expect(startMock).not.toHaveBeenCalled()
@@ -90,7 +90,7 @@ describe('run_eval_suite', () => {
     startMock.mockResolvedValueOnce(
       err({ code: 'EVAL_VALIDATION', message: 'No eval cases selected' })
     )
-    const result = await tool.execute({} as never, agentDeps)
+    const result = await runTool(tool, {}, ctx)
     expect(result.success).toBe(false)
     expect(result.error).toContain('No eval cases selected')
   })

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
@@ -155,8 +155,7 @@ has two, send all three in the call.`,
       // slugs resolve through the org resources cache so the LLM never has
       // to pass cuid-style ids.
       const resolved: Array<{ input: AgentTriggerInput; instructions?: string }> = []
-      for (let i = 0; i < rawTriggers.length; i++) {
-        const t = rawTriggers[i]
+      for (const [i, t] of rawTriggers.entries()) {
         const built = await buildTriggerInput(t, agentDeps.organizationId, i)
         if ('error' in built) return { success: false, output: null, error: built.error }
         resolved.push({ input: built.input, instructions: built.instructions })

--- a/packages/lib/src/ai/kopilot/capabilities/apps/__tests__/bridge.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/__tests__/bridge.test.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/apps/__tests__/bridge.test.ts
 
 import { describe, expect, it, vi } from 'vitest'
+import { runTool } from '../../../../agent-framework/__test-helpers'
 import { buildAppToolDigest } from '../digest'
 
 vi.mock('../../../../../cache', () => ({
@@ -151,7 +152,7 @@ describe('createAppCapabilities — execute() posts tool event to lambda', () =>
     })
 
     const args = { timeMin: '2026-05-14T00:00:00Z', timeMax: '2026-05-14T23:59:00Z' }
-    const result = await capability.tools[0]!.execute(args, {} as never)
+    const result = await runTool(capability.tools[0]!, args)
 
     expect(result.success).toBe(true)
     expect(invokeLambdaExecutor).toHaveBeenCalledWith(

--- a/packages/lib/src/ai/kopilot/capabilities/entities/enrich-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/enrich-entity-fields.ts
@@ -7,6 +7,7 @@ import { isArrayReturnFieldType } from '@auxx/types/field-value'
 import type { RecordId } from '@auxx/types/resource'
 import { and, eq, inArray } from 'drizzle-orm'
 import { getCachedResource } from '../../../../cache/org-cache-helpers'
+import type { FieldOptions } from '../../../../custom-fields/field-options'
 import { rowsToTypedValues } from '../../../../field-values/field-value-helpers'
 import { formatToDisplayValue, formatToRawValue } from '../../../../field-values/formatter'
 import type { FieldValueRow } from '../../../../field-values/types'
@@ -22,7 +23,7 @@ export interface EnrichedField {
   displayValue: unknown
   rawValue: unknown
   fieldType: FieldType
-  options?: Record<string, unknown>
+  options?: FieldOptions
 }
 
 /**

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/create-entity-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/create-entity-capabilities.test.ts
@@ -53,8 +53,11 @@ vi.mock('../../../../../../resources/crud', () => ({
   },
 }))
 
+import type { Rung } from '@auxx/database/enums'
 import { ForbiddenError } from '../../../../../../errors'
 import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import { Level } from '../../../../../../permissions/capabilities/registry'
+import { satisfiesRung } from '../../../../../../permissions/capabilities/rung'
 import type { ToolContext } from '../../../../../agent-framework/tool-context'
 import type { AgentToolResult } from '../../../../../agent-framework/types'
 import { createCreateEntityTool } from '../create-entity'
@@ -63,10 +66,11 @@ import { createCreateEntityTool } from '../create-entity'
 function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
   const yes = () => true
   const noop = () => {}
-  return {
+  const view: CapabilityView = {
     can: yes,
     has: yes,
     assert: noop,
+    areaLevel: () => Level.Full,
     canWriteEntity: yes,
     assertWriteEntity: noop,
     canEditEntity: yes,
@@ -84,8 +88,15 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     assertViewInstance: noop,
     assertEditInstance: noop,
     assertAdminInstance: noop,
+    hasDefPresence: (id: string) => view.canViewEntity(id),
+    hasRecordGrantsOn: () => false,
+    recordDefRung: (id: string) => (view.canViewEntity(id) ? 'admin' : undefined),
+    recordAccessAt: (id: string) => (view.canViewEntity(id) ? 'admin' : 'none'),
+    canDeleteRecordAt: (access: Rung) => satisfiesRung(access, 'admin'),
+    canEditRecordAt: (access: Rung) => satisfiesRung(access, 'edit'),
     ...overrides,
   }
+  return view
 }
 
 function runTool(capabilities?: CapabilityView) {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/list-entity-fields-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/list-entity-fields-capabilities.test.ts
@@ -53,8 +53,10 @@ vi.mock('../../../../../../cache/org-cache-helpers', () => ({
   getCachedResources: vi.fn(async () => RESOURCES),
 }))
 
+import type { Rung } from '@auxx/database/enums'
 import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
 import { Level } from '../../../../../../permissions/capabilities/registry'
+import { satisfiesRung } from '../../../../../../permissions/capabilities/rung'
 import type { ToolContext } from '../../../../../agent-framework/tool-context'
 import type { AgentToolResult } from '../../../../../agent-framework/types'
 import { createListEntityFieldsTool } from '../list-entity-fields'
@@ -63,7 +65,7 @@ import { createListEntityFieldsTool } from '../list-entity-fields'
 function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
   const yes = () => true
   const noop = () => {}
-  return {
+  const view: CapabilityView = {
     can: yes,
     has: yes,
     assert: noop,
@@ -85,8 +87,15 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     assertViewInstance: noop,
     assertEditInstance: noop,
     assertAdminInstance: noop,
+    hasDefPresence: (id: string) => view.canViewEntity(id),
+    hasRecordGrantsOn: () => false,
+    recordDefRung: (id: string) => (view.canViewEntity(id) ? 'admin' : undefined),
+    recordAccessAt: (id: string) => (view.canViewEntity(id) ? 'admin' : 'none'),
+    canDeleteRecordAt: (access: Rung) => satisfiesRung(access, 'admin'),
+    canEditRecordAt: (access: Rung) => satisfiesRung(access, 'edit'),
     ...overrides,
   }
+  return view
 }
 
 /** Denies exactly one def, mirroring a published policy of `None` on it. */

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/record-adjacent-reads-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/record-adjacent-reads-capabilities.test.ts
@@ -27,8 +27,10 @@ vi.mock('../../../../../../cache/org-cache-helpers', () => ({
   getCachedMembersByUserIds: vi.fn(async () => []),
 }))
 
+import type { Rung } from '@auxx/database/enums'
 import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
 import { Level } from '../../../../../../permissions/capabilities/registry'
+import { satisfiesRung } from '../../../../../../permissions/capabilities/rung'
 import type { ToolContext } from '../../../../../agent-framework/tool-context'
 import type { AgentToolResult } from '../../../../../agent-framework/types'
 import { createGetTranscriptTool } from '../get-transcript'
@@ -40,7 +42,7 @@ import { createListTranscriptsForEntityTool } from '../list-transcripts-for-enti
 function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityView {
   const yes = () => true
   const noop = () => {}
-  return {
+  const view: CapabilityView = {
     can: yes,
     has: yes,
     assert: noop,
@@ -62,8 +64,15 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     assertViewInstance: noop,
     assertEditInstance: noop,
     assertAdminInstance: noop,
+    hasDefPresence: (id: string) => view.canViewEntity(id),
+    hasRecordGrantsOn: () => false,
+    recordDefRung: (id: string) => (view.canViewEntity(id) ? 'admin' : undefined),
+    recordAccessAt: (id: string) => (view.canViewEntity(id) ? 'admin' : 'none'),
+    canDeleteRecordAt: (access: Rung) => satisfiesRung(access, 'admin'),
+    canEditRecordAt: (access: Rung) => satisfiesRung(access, 'edit'),
     ...overrides,
   }
+  return view
 }
 
 /** Denies exactly one def, mirroring a published policy of `None` on it. */

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/resolve-actor-values.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/resolve-actor-values.test.ts
@@ -29,7 +29,10 @@ const members: OrgMemberInfo[] = [
     userId: USER_ME,
     organizationId: 'org_1',
     role: 'OWNER',
-    status: 'active',
+    status: 'ACTIVE',
+    seatType: 'full',
+    onChatDuty: false,
+    permissionProfileId: null,
     user: {
       id: USER_ME,
       name: 'Me Myself',
@@ -43,7 +46,10 @@ const members: OrgMemberInfo[] = [
     userId: USER_SARAH_1,
     organizationId: 'org_1',
     role: 'USER',
-    status: 'active',
+    status: 'ACTIVE',
+    seatType: 'full',
+    onChatDuty: false,
+    permissionProfileId: null,
     user: {
       id: USER_SARAH_1,
       name: 'Sarah Chen',
@@ -57,7 +63,10 @@ const members: OrgMemberInfo[] = [
     userId: USER_SARAH_2,
     organizationId: 'org_1',
     role: 'USER',
-    status: 'active',
+    status: 'ACTIVE',
+    seatType: 'full',
+    onChatDuty: false,
+    permissionProfileId: null,
     user: {
       id: USER_SARAH_2,
       name: 'Sarah',
@@ -71,7 +80,10 @@ const members: OrgMemberInfo[] = [
     userId: USER_MARKUS,
     organizationId: 'org_1',
     role: 'ADMIN',
-    status: 'active',
+    status: 'ACTIVE',
+    seatType: 'full',
+    onChatDuty: false,
+    permissionProfileId: null,
     user: {
       id: USER_MARKUS,
       name: 'Sarah', // second "Sarah" → ambiguous on exact name
@@ -235,8 +247,8 @@ describe('resolveActorValues', () => {
     const result = await resolveActorValues({ assignee: 'Sarah' }, resource, ctx)
 
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0].reason).toBe('ambiguous')
-    expect(result.errors[0].candidates.map((c) => c.actorId)).toEqual([
+    expect(result.errors[0]?.reason).toBe('ambiguous')
+    expect(result.errors[0]?.candidates.map((c) => c.actorId)).toEqual([
       toActorId('user', USER_SARAH_2),
       toActorId('user', USER_MARKUS),
     ])
@@ -250,8 +262,8 @@ describe('resolveActorValues', () => {
     const result = await resolveActorValues({ assignee: bogus }, resource, ctx)
 
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0].reason).toBe('not_found')
-    expect(result.errors[0].candidates.length).toBeGreaterThan(0)
+    expect(result.errors[0]?.reason).toBe('not_found')
+    expect(result.errors[0]?.candidates.length ?? 0).toBeGreaterThan(0)
   })
 
   it('does not touch non-actor fields', async () => {
@@ -300,7 +312,7 @@ describe('resolveActorValues', () => {
     const result = await resolveActorValues({ team: 'me' }, resource, ctx)
 
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0].reason).toBe('not_found')
+    expect(result.errors[0]?.reason).toBe('not_found')
   })
 
   it('resolves a group by name when target is group', async () => {
@@ -347,6 +359,6 @@ describe('resolveActorValues', () => {
     )
 
     expect(result.errors).toEqual([])
-    expect(result.pairs[0].value).toBe(toActorId('user', USER_ME))
+    expect(result.pairs[0]?.value).toBe(toActorId('user', USER_ME))
   })
 })

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
@@ -8,7 +8,7 @@ import { FieldValueService } from '../../../../../field-values/field-value-servi
 // only `errors`, the RecordId parser and types; the picker sits behind a lazy
 // `import()` inside it and is only paid for on the def-denied path.
 import { assertRecordRowsEditableWithDb } from '../../../../../resources/crud/record-row-access'
-import { getDefinitionId, type RecordId } from '../../../../../resources/resource-id'
+import { getDefinitionId, isRecordId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArrayArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
@@ -120,7 +120,16 @@ Example (ids match list_entity_fields output):
     },
     execute: async (args, agentDeps) => {
       const { db, capabilities } = getDeps()
-      const allRecordIds = args.recordIds as string[]
+      const rawRecordIds: unknown[] = Array.isArray(args.recordIds) ? args.recordIds : []
+      const allRecordIds = rawRecordIds.filter(isRecordId)
+      if (allRecordIds.length !== rawRecordIds.length) {
+        return {
+          success: false,
+          output: null,
+          error:
+            "Every recordIds entry must have the form '<entityDefinitionId>:<entityInstanceId>'.",
+        }
+      }
       const values = args.values as Array<{ fieldId: string; value: unknown }>
 
       // inputAmendment._approvedRecordIds filters which records to actually update
@@ -129,7 +138,8 @@ Example (ids match list_entity_fields output):
         ? allRecordIds.filter((id) => approvedIds.includes(id))
         : allRecordIds
 
-      if (recordIds.length === 0) {
+      const firstRecordId = recordIds[0]
+      if (!firstRecordId) {
         return {
           success: false,
           output: null,
@@ -178,10 +188,9 @@ Example (ids match list_entity_fields output):
         organizationId: agentDeps.organizationId,
         userId: agentDeps.userId,
         capabilities,
-        recordIds: recordIds as RecordId[],
+        recordIds,
       })
 
-      const firstRecordId = recordIds[0] as string
       const resource = await findCachedResource(
         agentDeps.organizationId,
         getDefinitionId(firstRecordId)
@@ -224,7 +233,7 @@ Example (ids match list_entity_fields output):
 
       try {
         const result = await service.setBulkValues({
-          recordIds: recordIds as `${string}:${string}`[],
+          recordIds,
           values: resolvedPairs,
         })
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity.ts
@@ -5,7 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { RecordPickerService } from '../../../../../resources/picker'
-import { parseRecordId } from '../../../../../resources/resource-id'
+import { isRecordId, parseRecordId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
@@ -94,7 +94,14 @@ export function createGetEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
     },
     execute: async (args, agentDeps) => {
       const { db, capabilities } = getDeps()
-      const recordId = args.recordId as string
+      const recordId = args.recordId
+      if (!isRecordId(recordId)) {
+        return {
+          success: false,
+          output: null,
+          error: "recordId must have the form '<entityDefinitionId>:<entityInstanceId>'.",
+        }
+      }
 
       // Read enforcement (§3): the picker drops non-viewable defs, so `item` is
       // absent for a restricted record. The gate is re-applied before the

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
@@ -8,6 +8,7 @@ import {
   UnifiedCrudHandler,
 } from '../../../../../resources/crud'
 import type { TableId } from '../../../../../resources/registry/field-registry'
+import type { ResourceField } from '../../../../../resources/registry/field-types'
 import type { Resource } from '../../../../../resources/registry/types'
 import { toRecordId } from '../../../../../resources/resource-id'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
@@ -377,23 +378,23 @@ function extractKeyFields(
   let extras = 0
 
   // 1. ALWAYS include every filtered field, even if the stored value is null.
-  const filterFieldKeys = new Set(filters.map((f) => f.field.split('.')[0]))
+  const filterFieldKeys = new Set(
+    filters.map((f) => f.field.split('.')[0]).filter((k): k is string => Boolean(k))
+  )
   for (const key of filterFieldKeys) {
-    const field = resource.fields.find((f) => (f.systemAttribute ?? f.key) === key)
-    const label = field?.label ?? key
-    result[label] = data[key] ?? null
+    const field = resource.fields.find((f) => f.systemAttribute === key || f.key === key)
+    result[field?.label ?? key] = readRowValue(data, field, key) ?? null
   }
 
   // 2. Status/stage field (commonly useful)
-  const statusField = resource.fields.find(
-    (f) => f.systemAttribute === 'status' || f.key === 'status' || f.key === 'stage'
-  )
+  const statusField = resource.fields.find((f) => f.key === 'status' || f.key === 'stage')
   if (
     extras < MAX_EXTRAS &&
     statusField &&
-    !filterFieldKeys.has(statusField.systemAttribute ?? statusField.key)
+    !filterFieldKeys.has(statusField.key) &&
+    !(statusField.systemAttribute && filterFieldKeys.has(statusField.systemAttribute))
   ) {
-    const value = data[statusField.systemAttribute ?? statusField.key]
+    const value = readRowValue(data, statusField, statusField.key)
     if (value != null) {
       result[statusField.label] = value
       extras++
@@ -406,4 +407,24 @@ function extractKeyFields(
   }
 
   return result
+}
+
+/**
+ * Read one field's value out of a picker row.
+ *
+ * `RecordPickerItem.data` is the raw row, so a system resource is keyed by its
+ * DB column / field `key` (`status`), never by the namespaced `systemAttribute`
+ * (`ticket_status`). The LLM, meanwhile, may have named the field by either.
+ * Try every alias the field carries rather than committing to one.
+ */
+function readRowValue(
+  data: Record<string, unknown>,
+  field: ResourceField | undefined,
+  fallbackKey: string
+): unknown {
+  const aliases = field ? [field.systemAttribute, field.key, field.dbColumn] : [fallbackKey]
+  for (const alias of aliases) {
+    if (alias && data[alias] !== undefined) return data[alias]
+  }
+  return undefined
 }

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/resolve-actor-values.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/resolve-actor-values.ts
@@ -297,8 +297,9 @@ function lookupByString(
     if (byEmail) return toActorId('user', byEmail.userId)
 
     const byName = memberIndex.byName.get(lower)
-    if (byName && byName.length === 1) {
-      return toActorId('user', byName[0].userId)
+    const onlyMember = byName?.length === 1 ? byName[0] : undefined
+    if (onlyMember) {
+      return toActorId('user', onlyMember.userId)
     }
     if (byName && byName.length > 1) {
       errors.push({
@@ -317,8 +318,9 @@ function lookupByString(
 
   if (target !== 'user' && groupIndex) {
     const byGroupName = groupIndex.byName.get(lower)
-    if (byGroupName && byGroupName.length === 1) {
-      return toActorId('group', byGroupName[0].id)
+    const onlyGroup = byGroupName?.length === 1 ? byGroupName[0] : undefined
+    if (onlyGroup) {
+      return toActorId('group', onlyGroup.id)
     }
     if (byGroupName && byGroupName.length > 1) {
       errors.push({

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod'
 import { findCachedResource } from '../../../../../cache/org-cache-helpers'
 import { UnifiedCrudHandler } from '../../../../../resources/crud'
-import { getDefinitionId } from '../../../../../resources/resource-id'
+import { getDefinitionId, isRecordId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
@@ -91,7 +91,14 @@ Example (ids match list_entity_fields output):
     },
     execute: async (args, agentDeps) => {
       const { db, capabilities } = getDeps()
-      const recordId = args.recordId as string
+      const recordId = args.recordId
+      if (!isRecordId(recordId)) {
+        return {
+          success: false,
+          output: null,
+          error: "recordId must have the form '<entityDefinitionId>:<entityInstanceId>'.",
+        }
+      }
 
       // The LLM may nest field values under `values` or flatten them at the top level.
       const values =

--- a/packages/lib/src/ai/kopilot/capabilities/kb/snapshot-pipeline.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/snapshot-pipeline.ts
@@ -205,7 +205,8 @@ function buildOutline(content: ArticleNodeJSON[]): BlockOutlineEntry[] {
       pushTable(node)
       for (const row of node.content) {
         for (const cell of row.content) {
-          for (const block of cell.content) pushBlock(block, 'tableCell', node.attrs?.id)
+          for (const block of cell.content)
+            pushBlock(block, 'tableCell', node.attrs?.id ?? undefined)
         }
       }
     }

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/markdown-replace-integration.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/markdown-replace-integration.test.ts
@@ -64,13 +64,27 @@ const para = (id: string, text: string): BlockJSON => ({
 const textOf = (node: ArticleNodeJSON): string =>
   node.type === 'block' ? (node.content ?? []).map((n) => n.text ?? '').join('') : `<${node.type}>`
 
+/** The node at `index`, asserted to be a leaf `block` (not a container). */
+const blockAt = (content: ArticleNodeJSON[], index: number): BlockJSON => {
+  const node = content[index]
+  if (node?.type !== 'block') throw new Error(`expected a block at index ${index}`)
+  return node
+}
+
+/** The node at `index`, asserted to exist. */
+const nodeAt = (content: ArticleNodeJSON[], index: number): ArticleNodeJSON => {
+  const node = content[index]
+  if (!node) throw new Error(`expected a node at index ${index}`)
+  return node
+}
+
 describe('markdown replace_block — pipeline integration', () => {
   it('1→1: replaces content in place, preserves the id, leaves siblings alone', () => {
     const doc = [para('a', 'first'), para('b', 'OLD body'), para('c', 'third')]
     const next = runReplace(doc, 'b', 'NEW body with **bold**.')
 
     expect(next.map((n) => n.type === 'block' && n.attrs.id)).toEqual(['a', 'b', 'c'])
-    expect(textOf(next[1])).toBe('NEW body with bold.')
+    expect(textOf(nodeAt(next, 1))).toBe('NEW body with bold.')
 
     // The diff guarantee: 'b' shows as modified, not removed+added.
     const { stats, blocks } = diffBlocks(doc, next)
@@ -110,9 +124,7 @@ describe('markdown replace_block — pipeline integration', () => {
     const doc = [para('a', 'intro'), para('b', 'plain warning text')]
     const next = runReplace(doc, 'b', ':::warn\nBack up before upgrading.\n:::')
 
-    const callout = next[1]
-    expect(callout.type).toBe('block')
-    if (callout.type !== 'block') return
+    const callout = blockAt(next, 1)
     expect(callout.attrs.id).toBe('b')
     expect(callout.attrs.blockType).toBe('callout')
     expect(callout.attrs.calloutVariant).toBe('warn')
@@ -158,8 +170,7 @@ describe('markdown replace_block — pipeline integration', () => {
     const doc = [para('b', 'see the field')]
     const next = runReplace(doc, 'b', 'Current status: @[field:ticket:status] — check it.')
 
-    const block = next[0]
-    if (block.type !== 'block') throw new Error('expected block')
+    const block = blockAt(next, 0)
     expect(block.attrs.id).toBe('b')
     const ref = (block.content ?? []).find((n) => n.type === 'reference')
     expect(ref).toBeDefined()

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/plan-markdown-replace.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/plan-markdown-replace.test.ts
@@ -1,11 +1,28 @@
 // packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/plan-markdown-replace.test.ts
 
 import { describe, expect, it } from 'vitest'
+import type { ArticlePatch } from '../../../../../../kb/blocks/patch-types'
 import { mdToBlocks } from '../../../../../../kb/markdown/md-to-blocks'
-import type { ArticleNodeJSON, BlockJSON } from '../../../../../../kb/markdown/types'
+import type { BlockJSON } from '../../../../../../kb/markdown/types'
 import { planMarkdownReplace } from '../replace-plan'
 
 const TARGET = 'blk_target'
+
+/**
+ * Narrow the patch at `index` to the arm named by `op`, throwing when the
+ * plan produced a shorter sequence or a different op — the assertion and the
+ * `ArticlePatch` discriminated-union narrowing in one step.
+ */
+function patchAt<TOp extends ArticlePatch['op']>(
+  patches: ArticlePatch[],
+  index: number,
+  op: TOp
+): Extract<ArticlePatch, { op: TOp }> {
+  const patch = patches[index]
+  if (!patch) throw new Error(`expected a patch at index ${index}, got ${patches.length} patches`)
+  if (patch.op !== op) throw new Error(`expected patch ${index} to be "${op}", got "${patch.op}"`)
+  return patch as Extract<ArticlePatch, { op: TOp }>
+}
 
 describe('planMarkdownReplace', () => {
   it('zero blocks → a single delete patch (replace-with-nothing = remove)', () => {
@@ -13,10 +30,7 @@ describe('planMarkdownReplace', () => {
     // (runMarkdownReplace); the planner's contract is just "no nodes → delete".
     const patches = planMarkdownReplace(TARGET, [])
     expect(patches).toHaveLength(1)
-    const [del] = patches
-    expect(del.op).toBe('delete')
-    if (del.op !== 'delete') return
-    expect(del.blockIds).toEqual([TARGET])
+    expect(patchAt(patches, 0, 'delete').blockIds).toEqual([TARGET])
   })
 
   it('1→1: a single leaf block keeps the target id with no insert op', () => {
@@ -26,9 +40,7 @@ describe('planMarkdownReplace', () => {
     const patches = planMarkdownReplace(TARGET, nodes)
     expect(patches).toHaveLength(1)
 
-    const [replace] = patches
-    expect(replace.op).toBe('replace')
-    if (replace.op !== 'replace') return
+    const replace = patchAt(patches, 0, 'replace')
     expect(replace.blockId).toBe(TARGET)
     expect(replace.block.attrs.id).toBe(TARGET)
   })
@@ -40,13 +52,9 @@ describe('planMarkdownReplace', () => {
     const patches = planMarkdownReplace(TARGET, nodes)
     expect(patches).toHaveLength(2)
 
-    const [replace, insert] = patches
-    expect(replace.op).toBe('replace')
-    if (replace.op !== 'replace') return
-    expect(replace.block.attrs.id).toBe(TARGET)
+    expect(patchAt(patches, 0, 'replace').block.attrs.id).toBe(TARGET)
 
-    expect(insert.op).toBe('insert')
-    if (insert.op !== 'insert') return
+    const insert = patchAt(patches, 1, 'insert')
     expect(insert.anchor).toEqual({ at: 'after', blockId: TARGET })
     expect(insert.blocks).toHaveLength(2)
     // Extras keep their own (non-target) ids so they diff as "added".
@@ -58,19 +66,12 @@ describe('planMarkdownReplace', () => {
 
   it('container-first: splices the rewrite before the target then deletes it (id churn accepted)', () => {
     const nodes = mdToBlocks('| a | b |\n| --- | --- |\n| 1 | 2 |')
-    const first = nodes[0] as ArticleNodeJSON
-    expect(first.type).toBe('table')
+    expect(nodes[0]?.type).toBe('table')
 
     const patches = planMarkdownReplace(TARGET, nodes)
     expect(patches).toHaveLength(2)
 
-    const [insert, del] = patches
-    expect(insert.op).toBe('insert')
-    if (insert.op !== 'insert') return
-    expect(insert.anchor).toEqual({ at: 'before', blockId: TARGET })
-
-    expect(del.op).toBe('delete')
-    if (del.op !== 'delete') return
-    expect(del.blockIds).toEqual([TARGET])
+    expect(patchAt(patches, 0, 'insert').anchor).toEqual({ at: 'before', blockId: TARGET })
+    expect(patchAt(patches, 1, 'delete').blockIds).toEqual([TARGET])
   })
 })

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/write-helpers-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/write-helpers-capabilities.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../../../../../kb/kb-service', () => ({
 
 import { ForbiddenError } from '../../../../../../errors'
 import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import { Level } from '../../../../../../permissions/capabilities/registry'
 import type { AgentDeps } from '../../../../../agent-framework/types'
 import type { ToolDeps } from '../../../types'
 import { runBlockCrudOp } from '../write-helpers'
@@ -45,6 +46,7 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     can: yes,
     has: yes,
     assert: noop,
+    areaLevel: () => Level.Full,
     canWriteEntity: yes,
     assertWriteEntity: noop,
     canEditEntity: yes,
@@ -53,6 +55,14 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     canViewEntity: yes,
     assertViewEntity: noop,
     filterViewableDefIds: (ids: string[]) => ids,
+    // Record lane (plan v3/03 P5) — all-permissive: every def is present and
+    // every row folds to `admin`.
+    hasDefPresence: yes,
+    hasRecordGrantsOn: yes,
+    recordDefRung: () => 'admin',
+    recordAccessAt: () => 'admin',
+    canDeleteRecordAt: yes,
+    canEditRecordAt: yes,
     viewAccessFor: () => undefined,
     canAdministerDef: yes,
     assertAdministerDef: noop,

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article-section.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/get-article-section.ts
@@ -89,12 +89,12 @@ export function createGetArticleSectionTool(getDeps: GetToolDeps): AgentToolDefi
       let startLevel = Number.POSITIVE_INFINITY
       for (let i = 0; i < content.length; i++) {
         const node = content[i]
-        if (node.type !== 'block') continue
+        if (node?.type !== 'block') continue
         if (node.attrs.blockType !== 'heading') continue
         const text = extractText(node).toLowerCase()
         if (text.startsWith(headingText)) {
           startIdx = i
-          startLevel = (node.attrs.level as number | null) ?? 1
+          startLevel = node.attrs.level ?? 1
           break
         }
       }
@@ -108,9 +108,9 @@ export function createGetArticleSectionTool(getDeps: GetToolDeps): AgentToolDefi
       let endIdx = content.length
       for (let i = startIdx + 1; i < content.length; i++) {
         const node = content[i]
-        if (node.type !== 'block') continue
+        if (node?.type !== 'block') continue
         if (node.attrs.blockType !== 'heading') continue
-        const lvl = (node.attrs.level as number | null) ?? 1
+        const lvl = node.attrs.level ?? 1
         if (lvl <= startLevel) {
           endIdx = i
           break
@@ -118,12 +118,12 @@ export function createGetArticleSectionTool(getDeps: GetToolDeps): AgentToolDefi
       }
       const slice = content.slice(startIdx, endIdx)
       const sectionMarkdown = articleToMarkdown({ contentJson: slice })
+      const startNode = content[startIdx]
       return {
         success: true,
         output: {
           headingText: args.headingText as string,
-          startBlockId:
-            content[startIdx]?.type === 'block' ? (content[startIdx] as BlockJSON).attrs.id : null,
+          startBlockId: startNode?.type === 'block' ? startNode.attrs.id : null,
           markdown: sectionMarkdown,
           blockCount: slice.length,
         },

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-capabilities.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../../../../../datasets/services/search.service', () => ({
 }))
 
 import type { CapabilityView } from '../../../../../../permissions/capabilities/capability-view'
+import { Level } from '../../../../../../permissions/capabilities/registry'
 import type { ToolContext } from '../../../../../agent-framework/tool-context'
 import type { AgentToolResult } from '../../../../../agent-framework/types'
 import { createSearchKnowledgeTool } from '../search-knowledge'
@@ -58,6 +59,7 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     can: yes,
     has: yes,
     assert: noop,
+    areaLevel: () => Level.Full,
     canWriteEntity: yes,
     assertWriteEntity: noop,
     canEditEntity: yes,
@@ -66,6 +68,14 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     canViewEntity: yes,
     assertViewEntity: noop,
     filterViewableDefIds: (ids: string[]) => ids,
+    // Record lane (plan v3/03 P5) — all-permissive: every def is present and
+    // every row folds to `admin`.
+    hasDefPresence: yes,
+    hasRecordGrantsOn: yes,
+    recordDefRung: () => 'admin',
+    recordAccessAt: () => 'admin',
+    canDeleteRecordAt: yes,
+    canEditRecordAt: yes,
     viewAccessFor: () => undefined,
     canAdministerDef: yes,
     assertAdministerDef: noop,

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge.test.ts
@@ -63,8 +63,8 @@ describe('search_knowledge chat clamp', () => {
     expect(fromTables).toContain(schema.KnowledgeBase)
     expect(fromTables).not.toContain(schema.Dataset)
     expect(searchSpy).toHaveBeenCalledTimes(1)
-    const [searchArgs] = searchSpy.mock.calls[0]
-    expect(searchArgs.datasetIds).toEqual(['ds_public'])
+    const searchArgs = searchSpy.mock.calls[0]?.[0] as { datasetIds?: string[] } | undefined
+    expect(searchArgs?.datasetIds).toEqual(['ds_public'])
   })
 
   it('without a subject (internal kopilot), searches all managed + RAG datasets', async () => {

--- a/packages/lib/src/ai/kopilot/capabilities/kopilot/__tests__/plan-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kopilot/__tests__/plan-tools.test.ts
@@ -1,30 +1,29 @@
 // packages/lib/src/ai/kopilot/capabilities/kopilot/__tests__/plan-tools.test.ts
 
+import type { Database } from '@auxx/database'
 import { describe, expect, it } from 'vitest'
+import { createToolContext, runTool } from '../../../../agent-framework/__test-helpers'
 import { KopilotContextStore } from '../../../../agent-framework/context'
 import type { ToolContext } from '../../../../agent-framework/tool-context'
-import type { PlanState } from '../../../types'
+import type { PlanState, PlanStep } from '../../../types'
 import type { GetToolDeps } from '../../types'
 import { createPlanCreateTool } from '../tools/plan-create'
 import { createPlanUpdateStepTool } from '../tools/plan-update-step'
 
-const FAKE_DEPS: GetToolDeps = () =>
-  ({
-    db: {} as never,
-    organizationId: 'org-1',
-    userId: 'user-1',
-    sessionId: 'sess-1',
-  }) as ReturnType<GetToolDeps>
+const FAKE_DEPS: GetToolDeps = () => ({
+  // Plan tools never touch the DB — they only read/write `var:plan` via ctx.context.
+  db: {} as Database,
+  organizationId: 'org-1',
+  userId: 'user-1',
+  sessionId: 'sess-1',
+  sessionContext: {},
+  capabilities: undefined,
+})
 
 /** A ToolContext carrying a real (empty) context store — plan state lives in var:plan. */
 function makeCtx(): ToolContext {
-  const baseCtx = {
-    organizationId: 'org-1',
-    userId: 'user-1',
-    sessionId: 'sess-1',
-    db: {} as never,
-  } as unknown as ToolContext
-  return { ...baseCtx, context: new KopilotContextStore({ ctx: baseCtx }) } as ToolContext
+  const baseCtx = createToolContext({ userId: 'user-1', sessionId: 'sess-1' })
+  return { ...baseCtx, context: new KopilotContextStore({ ctx: baseCtx }) }
 }
 
 describe('plan_create.execute', () => {
@@ -32,25 +31,20 @@ describe('plan_create.execute', () => {
 
   it('returns canonical plan with generated step ids and pending status, and persists var:plan', async () => {
     const ctx = makeCtx()
-    const result = await tool.execute(
+    const result = await runTool(
+      tool,
       { steps: [{ label: 'List tickets' }, { label: 'Reply to each', detail: 'send each one' }] },
       ctx
     )
 
     expect(result.success).toBe(true)
-    const plan = (
-      result.output as { plan: { steps: unknown[]; createdAt: number; updatedAt: number } }
-    ).plan
+    const plan = (result.output as { plan: PlanState }).plan
     expect(plan.steps).toHaveLength(2)
     expect(plan.createdAt).toBeTypeOf('number')
     expect(plan.updatedAt).toBe(plan.createdAt)
 
-    const [s1, s2] = plan.steps as Array<{
-      id: string
-      label: string
-      status: string
-      detail?: string
-    }>
+    const [s1, s2] = plan.steps
+    if (!s1 || !s2) throw new Error('expected two plan steps')
     expect(s1.id).toMatch(/^plan-step-/)
     expect(s2.id).toMatch(/^plan-step-/)
     expect(s1.id).not.toBe(s2.id)
@@ -64,23 +58,23 @@ describe('plan_create.execute', () => {
   })
 
   it('rejects an empty step list', async () => {
-    const result = await tool.execute({ steps: [] }, makeCtx())
+    const result = await runTool(tool, { steps: [] }, makeCtx())
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/at least one step/i)
   })
 
   it('rejects more than 30 steps', async () => {
     const steps = Array.from({ length: 31 }, (_, i) => ({ label: `Step ${i + 1}` }))
-    const result = await tool.execute({ steps }, makeCtx())
+    const result = await runTool(tool, { steps }, makeCtx())
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/exceeds max 30 steps/i)
   })
 
   it('truncates labels longer than 200 chars', async () => {
     const longLabel = 'a'.repeat(250)
-    const result = await tool.execute({ steps: [{ label: longLabel }] }, makeCtx())
+    const result = await runTool(tool, { steps: [{ label: longLabel }] }, makeCtx())
     expect(result.success).toBe(true)
-    const plan = (result.output as { plan: { steps: Array<{ label: string }> } }).plan
+    const plan = (result.output as { plan: PlanState }).plan
     expect(plan.steps[0]?.label).toHaveLength(200)
   })
 })
@@ -107,13 +101,13 @@ describe('plan_update_step.execute', () => {
   it('patches the step status by id, bumps updatedAt, and writes back', async () => {
     const ctx = await ctxWithPlan(basePlan())
     const before = Date.now()
-    const result = await tool.execute({ stepId: 's1', status: 'running' }, ctx)
+    const result = await runTool(tool, { stepId: 's1', status: 'running' }, ctx)
     const after = Date.now()
 
     expect(result.success).toBe(true)
     const plan = (result.output as { plan: PlanState }).plan
-    expect(plan.steps[0]).toEqual({ id: 's1', label: 'A', status: 'running' })
-    expect(plan.steps[1]).toEqual({ id: 's2', label: 'B', status: 'pending' }) // untouched
+    expect(plan.steps[0]).toEqual<PlanStep>({ id: 's1', label: 'A', status: 'running' })
+    expect(plan.steps[1]).toEqual<PlanStep>({ id: 's2', label: 'B', status: 'pending' }) // untouched
     expect(plan.createdAt).toBe(1000)
     expect(plan.updatedAt).toBeGreaterThanOrEqual(before)
     expect(plan.updatedAt).toBeLessThanOrEqual(after)
@@ -127,7 +121,7 @@ describe('plan_update_step.execute', () => {
       createdAt: 1000,
       updatedAt: 1000,
     })
-    const result = await tool.execute({ stepId: 's1', status: 'completed', detail: 'done' }, ctx)
+    const result = await runTool(tool, { stepId: 's1', status: 'completed', detail: 'done' }, ctx)
     expect(result.success).toBe(true)
     expect((result.output as { plan: PlanState }).plan.steps[0]).toMatchObject({
       id: 's1',
@@ -137,7 +131,8 @@ describe('plan_update_step.execute', () => {
   })
 
   it('rejects invalid status values', async () => {
-    const result = await tool.execute(
+    const result = await runTool(
+      tool,
       { stepId: 's1', status: 'bogus' },
       await ctxWithPlan(basePlan())
     )
@@ -146,7 +141,7 @@ describe('plan_update_step.execute', () => {
   })
 
   it('errors with a recoverable message when there is no active plan', async () => {
-    const result = await tool.execute({ stepId: 's1', status: 'running' }, makeCtx())
+    const result = await runTool(tool, { stepId: 's1', status: 'running' }, makeCtx())
     expect(result.success).toBe(false)
     expect(result.output).toEqual({ plan: null })
     expect(result.error).toMatch(/no active plan/i)
@@ -154,7 +149,8 @@ describe('plan_update_step.execute', () => {
 
   it('errors and attaches the current plan for an unknown stepId', async () => {
     const plan = basePlan()
-    const result = await tool.execute(
+    const result = await runTool(
+      tool,
       { stepId: 'bogus', status: 'running' },
       await ctxWithPlan(plan)
     )

--- a/packages/lib/src/ai/kopilot/capabilities/learned/tools/__tests__/upsert-learned-article.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/learned/tools/__tests__/upsert-learned-article.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../../../../../kb/articles/publish-article', () => ({
   publishArticle: (...args: unknown[]) => publishArticleSpy(...args),
 }))
 
+import { runTool } from '../../../../../agent-framework/__test-helpers'
 import type { ToolContext } from '../../../../../agent-framework/tool-context'
 import { createUpsertLearnedArticleTool, withRecordChip } from '../upsert-learned-article'
 
@@ -102,12 +103,12 @@ describe('validateInputs', () => {
 describe('execute — create path', () => {
   it('files the article under the category and publishes it', async () => {
     const tool = makeTool(makeFakeDb(undefined))
-    const result = await tool.execute({ ...baseArgs, category: 'policies' }, agentDeps)
+    const result = await runTool(tool, { ...baseArgs, category: 'policies' }, agentDeps)
 
     expect(result.success).toBe(true)
     expect(result.output).toMatchObject({ articleId: 'art_new', created: true, published: true })
 
-    const [, kbId, input, authorId] = createArticleSpy.mock.calls[0]
+    const [, kbId, input, authorId] = createArticleSpy.mock.calls[0] ?? []
     expect(kbId).toBe('kb_learned')
     expect(input).toMatchObject({
       articleKind: 'page',
@@ -132,7 +133,7 @@ describe('execute — update path', () => {
     const tool = makeTool(
       makeFakeDb({ id: 'art_42', homeKnowledgeBaseId: 'kb_other', articleKind: 'page' })
     )
-    const result = await tool.execute({ ...baseArgs, articleId: 'art_42' }, agentDeps)
+    const result = await runTool(tool, { ...baseArgs, articleId: 'art_42' }, agentDeps)
     expect(result.success).toBe(false)
     expect(result.error).toContain('not in the learned knowledge base')
     expect(updateArticleDraftSpy).not.toHaveBeenCalled()
@@ -142,7 +143,7 @@ describe('execute — update path', () => {
     const tool = makeTool(
       makeFakeDb({ id: 'art_pol', homeKnowledgeBaseId: 'kb_learned', articleKind: 'category' })
     )
-    const result = await tool.execute({ ...baseArgs, articleId: 'art_pol' }, agentDeps)
+    const result = await runTool(tool, { ...baseArgs, articleId: 'art_pol' }, agentDeps)
     expect(result.success).toBe(false)
     expect(result.error).toContain('category')
   })
@@ -151,12 +152,12 @@ describe('execute — update path', () => {
     const tool = makeTool(
       makeFakeDb({ id: 'art_42', homeKnowledgeBaseId: 'kb_learned', articleKind: 'page' })
     )
-    const result = await tool.execute({ ...baseArgs, articleId: 'art_42' }, agentDeps)
+    const result = await runTool(tool, { ...baseArgs, articleId: 'art_42' }, agentDeps)
 
     expect(result.success).toBe(true)
     expect(result.output).toMatchObject({ articleId: 'art_42', created: false, published: true })
 
-    const [, articleId, fields, editorId, kbId] = updateArticleDraftSpy.mock.calls[0]
+    const [, articleId, fields, editorId, kbId] = updateArticleDraftSpy.mock.calls[0] ?? []
     expect(articleId).toBe('art_42')
     expect(fields).toMatchObject({ title: 'Refund policy' })
     expect(fields.contentJson).toBeTruthy()

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
@@ -266,8 +266,8 @@ export function createFindThreadsTool(getDeps: GetToolDeps): AgentToolDefinition
           subject: t.subject,
           status: t.status,
           assigneeId: t.assigneeId,
-          lastMessageAt:
-            t.lastMessageAt instanceof Date ? t.lastMessageAt.toISOString() : t.lastMessageAt,
+          // `ThreadMeta.lastMessageAt` is already an ISO string.
+          lastMessageAt: t.lastMessageAt,
           messageCount: t.messageCount,
           isUnread: t.isUnread,
           tagIds: instanceIds,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
@@ -207,10 +207,8 @@ export function createGetThreadDetailTool(getDeps: GetToolDeps): AgentToolDefini
             subject: thread.subject,
             status: thread.status,
             assigneeId: thread.assigneeId,
-            lastMessageAt:
-              thread.lastMessageAt instanceof Date
-                ? thread.lastMessageAt.toISOString()
-                : thread.lastMessageAt,
+            // `ThreadMeta.lastMessageAt` is already an ISO string.
+            lastMessageAt: thread.lastMessageAt,
             messageCount: thread.messageCount,
             isUnread: thread.isUnread,
             tagIds: tagInstanceIds,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-drafts.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-drafts.ts
@@ -186,8 +186,8 @@ export function createListDraftsTool(getDeps: GetToolDeps): AgentToolDefinition 
             subject: t.subject || null,
             snippet: null,
             recipientSummary: null,
-            updatedAt:
-              t.lastMessageAt instanceof Date ? t.lastMessageAt.toISOString() : t.lastMessageAt,
+            // `ThreadMeta.lastMessageAt` is already an ISO string.
+            updatedAt: t.lastMessageAt,
             scheduledAt: null,
             threadId: t.id,
           })

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/reply-to-thread.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/reply-to-thread.ts
@@ -7,6 +7,7 @@ import { DraftService } from '../../../../../drafts'
 import { MessageQueryService, MessageSenderService } from '../../../../../messages'
 import { ParticipantService } from '../../../../../participants'
 import { getThreadLens } from '../../../../../permissions/visibility/thread-lens'
+import { Result } from '../../../../../result'
 import { ThreadQueryService } from '../../../../../threads'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
@@ -165,13 +166,14 @@ export function createReplyToThreadTool(getDeps: GetToolDeps): AgentToolDefiniti
       const mode: 'draft' | 'send' = args.mode === 'send' ? 'send' : 'draft'
 
       // Kopilot acts as the invoking user (§8.1): replying/drafting requires
-      // `full` lens on the thread (§7) — sub-full viewers get a typed error.
+      // the top `read` lens on the thread (§7) — narrower viewers get a typed
+      // error. (`read` is the renamed `full`; see permissions/visibility/lens.)
       const viewer = await getCachedUserInstanceGrants(agentDeps.userId, agentDeps.organizationId)
       const lens = await getThreadLens(db, agentDeps.organizationId, viewer, threadId)
       if (lens === 'none') {
         return { success: false, output: null, error: `Thread ${threadId} not found` }
       }
-      if (lens !== 'full') {
+      if (lens !== 'read') {
         return {
           success: false,
           output: null,
@@ -210,7 +212,7 @@ export function createReplyToThreadTool(getDeps: GetToolDeps): AgentToolDefiniti
           integration,
           { ...agentDeps, db }
         )
-        if (!result.ok) {
+        if (!Result.isOk(result)) {
           return { success: false, output: null, error: result.error.message }
         }
         resolved = result.value

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/start-new-conversation.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/start-new-conversation.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { getCachedIntegrationCatalog } from '../../../../../cache/integration-catalog'
 import { DraftService } from '../../../../../drafts'
 import { MessageSenderService } from '../../../../../messages'
+import { Result } from '../../../../../result'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 import { resolveRecipients } from '../recipient-resolver'
@@ -212,7 +213,7 @@ export function createStartNewConversationTool(getDeps: GetToolDeps): AgentToolD
         integration,
         { ...agentDeps, db }
       )
-      if (!resolvedResult.ok) {
+      if (!Result.isOk(resolvedResult)) {
         return { success: false, output: null, error: resolvedResult.error.message }
       }
       const resolved = resolvedResult.value

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/update-thread.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/update-thread.ts
@@ -142,7 +142,7 @@ export function createUpdateThreadTool(getDeps: GetToolDeps): AgentToolDefinitio
         if (assigneeId) {
           updates.assigneeId = assigneeId === 'unassign' ? null : `user:${assigneeId}`
         }
-        await service.update(`thread:${threadId}`, updates)
+        await service.update(toRecordId('thread', threadId), updates)
         if (status) changes.status = status
         if (assigneeId) changes.assigneeId = assigneeId
       }

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/__tests__/preview-record-view-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/__tests__/preview-record-view-capabilities.test.ts
@@ -54,6 +54,14 @@ function makeCapabilities(overrides: Partial<CapabilityView> = {}): CapabilityVi
     canViewEntity: yes,
     assertViewEntity: noop,
     filterViewableDefIds: (ids: string[]) => ids,
+    // Record lane (plan v3/03 P5) — all-permissive: every def is present and
+    // every row folds to `admin`.
+    hasDefPresence: yes,
+    hasRecordGrantsOn: yes,
+    recordDefRung: () => 'admin',
+    recordAccessAt: () => 'admin',
+    canDeleteRecordAt: yes,
+    canEditRecordAt: yes,
     viewAccessFor: () => undefined,
     canAdministerDef: yes,
     assertAdministerDef: noop,

--- a/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
 
-import { toActorId } from '@auxx/types/actor'
+import { type ActorId, toActorId } from '@auxx/types/actor'
+import type { RecordId } from '@auxx/types/resource'
 import type { AbsoluteDate, RelativeDate } from '@auxx/types/task'
 import { z } from 'zod'
 import { createTaskService } from '../../../../../tasks/task-service'
@@ -174,10 +175,13 @@ export function createCreateTaskTool(getDeps: GetToolDeps): AgentToolDefinition 
       const description = args.description as string | undefined
       const deadline = args.deadline as AbsoluteDate | RelativeDate | undefined
       const priority = args.priority as 'low' | 'medium' | 'high' | undefined
-      const assigneeIds = (args.assigneeIds as string[] | undefined) ?? [
+      // Both arrays were canonicalized + brand-checked by `validateInputs`
+      // (`normalizeActorIdArrayArg` / `normalizeRecordIdArrayArg`); the engine
+      // hands `args` back as an untyped bag, so the brands are re-asserted here.
+      const assigneeIds = (args.assigneeIds as ActorId[] | undefined) ?? [
         toActorId('user', agentDeps.userId),
       ]
-      const linkedRecordIds = args.linkedRecordIds as string[] | undefined
+      const linkedRecordIds = args.linkedRecordIds as RecordId[] | undefined
 
       // Bundle-approval replay (Today/AI suggestions) tags 'ai'; every other
       // caller (live Kopilot chat, headless capture-mode prediction) is 'kopilot'.

--- a/packages/lib/src/ai/kopilot/prompts/__tests__/cache-tiers.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/__tests__/cache-tiers.test.ts
@@ -46,8 +46,8 @@ describe('buildKopilotPromptBlocks', () => {
     const blocks = buildKopilotPromptBlocks(baseArgs)
     const lastStatic = blocks.map((b) => b.stability).lastIndexOf('static')
     const lastOrg = blocks.map((b) => b.stability).lastIndexOf('org')
-    if (lastStatic >= 0) expect(blocks[lastStatic].cache).toEqual({ type: 'ephemeral' })
-    if (lastOrg >= 0) expect(blocks[lastOrg].cache).toEqual({ type: 'ephemeral' })
+    if (lastStatic >= 0) expect(blocks[lastStatic]?.cache).toEqual({ type: 'ephemeral' })
+    if (lastOrg >= 0) expect(blocks[lastOrg]?.cache).toEqual({ type: 'ephemeral' })
     // Turn-tier blocks never cached
     for (const b of blocks) {
       if (b.stability === 'turn') expect(b.cache).toBeUndefined()

--- a/packages/lib/src/ai/kopilot/prompts/__tests__/resolve-instruction-references.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/__tests__/resolve-instruction-references.test.ts
@@ -15,6 +15,7 @@ const toolCatalog: FlatToolCatalogEntry[] = [
     toolsetIconId: 'message-square',
     toolsetColor: 'teal',
     path: ['Auxx.ai', 'Comments'],
+    toolsetImplicit: false,
   },
 ]
 
@@ -24,6 +25,7 @@ const toolsetCatalog: ToolsetCatalogEntry[] = [
     label: 'Comments — Write',
     appId: 'auxx',
     isDefault: false,
+    implicit: false,
     tools: [{ name: 'create_note', displayName: 'Add note', description: 'Add a note.' }],
   },
   {
@@ -31,6 +33,7 @@ const toolsetCatalog: ToolsetCatalogEntry[] = [
     label: 'Mail — Compose',
     appId: 'auxx',
     isDefault: false,
+    implicit: false,
     tools: [
       { name: 'reply_to_thread', displayName: 'Reply to thread', description: 'Reply.' },
       {

--- a/packages/lib/src/ai/kopilot/prompts/sections/active-refs.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/active-refs.ts
@@ -6,6 +6,9 @@ import { ALL_MODES, type PromptSection } from './types'
 const REF_KIND_LABEL: Record<SessionRefKind, string> = {
   thread: 'thread',
   record: 'record',
+  // `resource` refs carry an entityDefinitionId — the records-table page the
+  // user is looking at, not one row on it.
+  resource: 'record type',
   kb: 'knowledge base',
   article: 'article',
   actor: 'actor',

--- a/packages/lib/src/ai/kopilot/prompts/sections/render.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/render.ts
@@ -85,20 +85,14 @@ export function renderSectionsToBlocks(
 
   // Mark the last block of each cached tier with an ephemeral cache marker.
   for (const tier of ['static', 'org'] as const) {
-    const lastIdx = lastIndexOf(blocks, (b) => b.stability === tier)
-    if (lastIdx >= 0) {
-      blocks[lastIdx] = { ...blocks[lastIdx], cache: { type: 'ephemeral' } }
+    const lastIdx = blocks.reduce((acc, b, i) => (b.stability === tier ? i : acc), -1)
+    const last = blocks[lastIdx]
+    if (last) {
+      blocks[lastIdx] = { ...last, cache: { type: 'ephemeral' } }
     }
   }
 
   return blocks
-}
-
-function lastIndexOf<T>(arr: readonly T[], pred: (x: T) => boolean): number {
-  for (let i = arr.length - 1; i >= 0; i--) {
-    if (pred(arr[i])) return i
-  }
-  return -1
 }
 
 /**
@@ -161,7 +155,7 @@ export function summarizePromptBlocks(blocks: readonly PromptBlock[]): {
   // Cached = every block up to and including the last block carrying a cache
   // marker (the cacheable prefix), since cache breakpoints are cumulative.
   const lastCachedIdx = (() => {
-    for (let i = tiers.length - 1; i >= 0; i--) if (tiers[i].cached) return i
+    for (let i = tiers.length - 1; i >= 0; i--) if (tiers[i]?.cached) return i
     return -1
   })()
   const cachedChars =

--- a/packages/lib/src/ai/kopilot/types.ts
+++ b/packages/lib/src/ai/kopilot/types.ts
@@ -78,10 +78,19 @@ export interface PlanState {
  *
  * The active multi-step plan now lives in `var:plan` (chat v9 context store),
  * managed by the plan tools via `ctx.context` — not on domainState.
+ *
+ * The index signature is load-bearing, not laziness: the engine also stashes
+ * bare-keyed slices on this bag (`__proc_step` / `__proc` from
+ * `agents/procedures/persist`, `__context` for the context store), and every
+ * slice reader is typed against `Record<string, unknown>`. Without it a
+ * `KopilotDomainState` is not assignable to `Record<string, unknown>` at all
+ * (interfaces get no implicit index signature) and each read needs a cast.
  */
 export interface KopilotDomainState {
   /** UI context — replaced wholesale on each message via applyContext */
   context: SessionContext
   /** Human-friendly capability descriptions surfaced when the user asks what Kopilot can do */
   capabilities?: string[]
+  /** Engine-managed slices keyed by bare string constants (see above). */
+  [slice: string]: unknown
 }

--- a/packages/lib/src/ai/providers/anthropic/__tests__/anthropic-llm-client.test.ts
+++ b/packages/lib/src/ai/providers/anthropic/__tests__/anthropic-llm-client.test.ts
@@ -5,6 +5,13 @@ import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
 import { AnthropicLLMClient, STRUCTURED_OUTPUT_TOOL_NAME } from '../anthropic-llm-client'
 
+/** Outbound payload of the first recorded `messages.create()` call. */
+function sentPayload(mock: { mock: { calls: unknown[][] } }): Record<string, any> {
+  const call = mock.mock.calls[0]
+  if (!call) throw new Error('expected messages.create() to have been called')
+  return call[0] as Record<string, any>
+}
+
 /**
  * Integration tests for the Anthropic LLM client.
  * These hit the real Anthropic API — requires ANTHROPIC_API_KEY in .env.
@@ -67,9 +74,12 @@ describe.skipIf(!apiKey)('AnthropicLLMClient integration', () => {
 
     expect(response.tool_calls).toBeDefined()
     expect(response.tool_calls!.length).toBeGreaterThan(0)
-    expect(response.tool_calls![0].function.name).toBe('get_weather')
 
-    const args = JSON.parse(response.tool_calls![0].function.arguments as string)
+    const [toolCall] = response.tool_calls ?? []
+    if (!toolCall) throw new Error('expected at least one tool call')
+    expect(toolCall.function.name).toBe('get_weather')
+
+    const args = JSON.parse(toolCall.function.arguments as string)
     expect(args.location).toBeTruthy()
   }, 15_000)
 
@@ -187,7 +197,7 @@ describe('AnthropicLLMClient sampling-parameter stripping', () => {
       parameters: { max_tokens: 32, temperature: 0, top_p: 0.9 },
     })
 
-    const sent = create.mock.calls[0][0]
+    const sent = sentPayload(create)
     expect(sent.temperature).toBeUndefined()
     expect(sent.top_p).toBeUndefined()
   })
@@ -202,7 +212,7 @@ describe('AnthropicLLMClient sampling-parameter stripping', () => {
         parameters: { max_tokens: 32, temperature: 0.7, top_p: 0.95 },
       })
 
-      const sent = create.mock.calls[0][0]
+      const sent = sentPayload(create)
       expect(sent.temperature, model).toBeUndefined()
       expect(sent.top_p, model).toBeUndefined()
     }
@@ -217,7 +227,7 @@ describe('AnthropicLLMClient sampling-parameter stripping', () => {
       parameters: { max_tokens: 32, temperature: 0.5, top_p: 0.9 },
     })
 
-    const sent = create.mock.calls[0][0]
+    const sent = sentPayload(create)
     expect(sent.temperature).toBe(0.5)
     expect(sent.top_p).toBe(0.9)
   })
@@ -274,7 +284,7 @@ describe('AnthropicLLMClient forced tool-use structured output', () => {
       json_schema: JSON.stringify(schema),
     })
 
-    const sent = create.mock.calls[0][0]
+    const sent = sentPayload(create)
     expect(sent.tools).toHaveLength(1)
     expect(sent.tools[0].name).toBe(STRUCTURED_OUTPUT_TOOL_NAME)
     expect(sent.tools[0].input_schema.type).toBe('object')
@@ -344,7 +354,7 @@ describe('AnthropicLLMClient forced tool-use structured output', () => {
       json_schema: JSON.stringify(schema),
     })
 
-    const sent = create.mock.calls[0][0]
+    const sent = sentPayload(create)
     // User tools kept as-is; no synthetic tool, no forced tool_choice.
     expect(sent.tools).toHaveLength(1)
     expect(sent.tools[0].name).toBe('get_weather')
@@ -366,7 +376,7 @@ describe('AnthropicLLMClient forced tool-use structured output', () => {
       json_schema: JSON.stringify({ type: 'string' }),
     })
 
-    const sent = create.mock.calls[0][0]
+    const sent = sentPayload(create)
     expect(sent.tools).toBeUndefined()
     expect(sent.tool_choice).toBeUndefined()
 

--- a/packages/lib/src/ai/providers/anthropic/__tests__/build-system-blocks.test.ts
+++ b/packages/lib/src/ai/providers/anthropic/__tests__/build-system-blocks.test.ts
@@ -30,8 +30,7 @@ describe('buildSystemBlocks', () => {
     const input = `static-tier\n\n${SENTINEL}\n\norg-tier\n\n${SENTINEL}`
     const out = buildSystemBlocks(input)
     expect(out).toHaveLength(2)
-    expect(out[0].cache_control).toEqual({ type: 'ephemeral' })
-    expect(out[1].cache_control).toEqual({ type: 'ephemeral' })
+    expect(out.map((b) => b.cache_control)).toEqual([{ type: 'ephemeral' }, { type: 'ephemeral' }])
   })
 
   it('caps cache markers at 4 (Anthropic API limit)', () => {

--- a/packages/lib/src/ai/providers/anthropic/anthropic-llm-client.ts
+++ b/packages/lib/src/ai/providers/anthropic/anthropic-llm-client.ts
@@ -171,7 +171,6 @@ export class AnthropicLLMClient extends LLMClient {
                 model: params.model,
                 content: fullContent,
                 delta,
-                finishReason: null,
                 toolCalls: [],
                 metadata: {
                   chunkIndex: chunkCount,
@@ -238,7 +237,9 @@ export class AnthropicLLMClient extends LLMClient {
       // without combing through delta events.
       if (stopReason === 'max_tokens') {
         const truncatedToolNames = toolCalls
-          .filter((tc) => !isValidJson(tc.function.arguments))
+          .filter(
+            (tc) => typeof tc.function.arguments === 'string' && !isValidJson(tc.function.arguments)
+          )
           .map((tc) => tc.function.name)
         this.logger.warn('Anthropic stream truncated by max_tokens', {
           model: params.model,
@@ -434,7 +435,7 @@ export class AnthropicLLMClient extends LLMClient {
         structuredInstruction = this.createSchemaBasedInstruction(schema)
       } catch (error) {
         this.logger.warn('Failed to parse JSON schema, falling back to basic JSON', {
-          error: error.message,
+          error: error instanceof Error ? error.message : String(error),
           schema: params.json_schema,
         })
         structuredInstruction = this.createBasicJsonInstruction()
@@ -516,12 +517,14 @@ export class AnthropicLLMClient extends LLMClient {
       const updatedMessages = [...messages]
       const systemMessage = updatedMessages[systemMessageIndex]
 
-      updatedMessages[systemMessageIndex] = {
-        ...systemMessage,
-        content:
-          typeof systemMessage.content === 'string'
-            ? systemMessage.content + instruction
-            : systemMessage.content, // For multi-modal content, we'd need more complex handling
+      if (systemMessage) {
+        updatedMessages[systemMessageIndex] = {
+          ...systemMessage,
+          content:
+            typeof systemMessage.content === 'string'
+              ? systemMessage.content + instruction
+              : systemMessage.content, // For multi-modal content, we'd need more complex handling
+        }
       }
 
       return updatedMessages
@@ -831,7 +834,7 @@ export class AnthropicLLMClient extends LLMClient {
         const firstSystemMessage = systemMessages[0]
         anthropicMessages.push({
           role: 'user',
-          content: this.convertContentToAnthropicFormat(firstSystemMessage.content),
+          content: this.convertContentToAnthropicFormat(firstSystemMessage?.content ?? null),
         })
 
         // Remove the converted message from system message if there were multiple
@@ -864,7 +867,14 @@ export class AnthropicLLMClient extends LLMClient {
   /**
    * Convert content to Anthropic format (supports multi-modal)
    */
-  private convertContentToAnthropicFormat(content: string | MultiModalContent[]): any {
+  private convertContentToAnthropicFormat(content: string | MultiModalContent[] | null): any {
+    // `Message.content` is nullable: an assistant turn that only carries
+    // tool_calls has none. Those are handled by the tool_use branch above, but a
+    // null-content message with no tool_calls still reaches here — return an
+    // empty string rather than dereferencing null.
+    if (content == null) {
+      return ''
+    }
     if (typeof content === 'string') {
       return content
     }
@@ -1091,7 +1101,8 @@ export class AnthropicLLMClient extends LLMClient {
   /**
    * Extract text content from multi-modal content array
    */
-  private extractTextFromContent(content: MultiModalContent[]): string {
+  private extractTextFromContent(content: MultiModalContent[] | null): string {
+    if (!content) return ''
     return content
       .filter((item) => item.type === 'text')
       .map((item) => item.data)
@@ -1204,8 +1215,9 @@ export class AnthropicLLMClient extends LLMClient {
           if (Array.isArray(msg.content)) {
             const filteredContent = msg.content.filter((content) => content.type !== 'image')
             // Convert back to string if only text content remains
-            if (filteredContent.length === 1 && filteredContent[0].type === 'text') {
-              return { ...msg, content: filteredContent[0].data }
+            const onlyItem = filteredContent.length === 1 ? filteredContent[0] : undefined
+            if (onlyItem?.type === 'text') {
+              return { ...msg, content: onlyItem.data }
             }
             return { ...msg, content: filteredContent }
           }
@@ -1240,8 +1252,9 @@ export class AnthropicLLMClient extends LLMClient {
                 ],
               }
             }
-            if (filteredContent.length === 1 && filteredContent[0].type === 'text') {
-              return { ...msg, content: filteredContent[0].data }
+            const onlyItem = filteredContent.length === 1 ? filteredContent[0] : undefined
+            if (onlyItem?.type === 'text') {
+              return { ...msg, content: onlyItem.data }
             }
             return { ...msg, content: filteredContent }
           }

--- a/packages/lib/src/ai/providers/anthropic/voyage-embedding-client.ts
+++ b/packages/lib/src/ai/providers/anthropic/voyage-embedding-client.ts
@@ -39,7 +39,12 @@ export class VoyageEmbeddingClient extends TextEmbeddingClient {
         async () => {
           const texts = Array.isArray(params.text) ? params.text : [params.text]
 
-          const requestBody = {
+          const requestBody: {
+            input: string[]
+            model: string
+            input_type: string
+            truncate?: boolean
+          } = {
             input: texts,
             model: params.model,
             input_type: this.getInputType(params.purpose),

--- a/packages/lib/src/ai/providers/base/index.ts
+++ b/packages/lib/src/ai/providers/base/index.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/ai/providers/base/index.ts
 
 // Abstract base class
-export { ProviderClient } from './provider-client'
+export { ProviderClient, type ProviderClientConstructor } from './provider-client'
 // Types and interfaces
 export * from './types'
 

--- a/packages/lib/src/ai/providers/base/provider-client.ts
+++ b/packages/lib/src/ai/providers/base/provider-client.ts
@@ -8,6 +8,20 @@ import type { ConnectionTestResult, ProviderCredentials, ValidationResult } from
 import { ValidationUtils } from './validation'
 
 /**
+ * Constructor signature every concrete provider client exposes.
+ *
+ * `typeof ProviderClient` cannot be used for this: `ProviderClient` is abstract
+ * (so `new` on it is a type error) and its own constructor takes `capabilities`
+ * first, which subclasses supply themselves. Registries hold this type instead.
+ */
+export type ProviderClientConstructor = new (
+  organizationId: string,
+  userId: string,
+  cache?: any,
+  db?: Database
+) => ProviderClient
+
+/**
  * Abstract base class for all AI provider clients
  * Each provider must extend this class and implement the abstract methods
  */

--- a/packages/lib/src/ai/providers/cohere/cohere-client.ts
+++ b/packages/lib/src/ai/providers/cohere/cohere-client.ts
@@ -5,26 +5,35 @@ import type { BaseSpecializedClient } from '../../clients/base/base-specialized-
 import { DEFAULT_CLIENT_CONFIG } from '../../clients/base/types'
 import { ProviderClient } from '../base/provider-client'
 import type { ConnectionTestResult, ProviderCredentials, ValidationResult } from '../base/types'
-import { type ModelCapabilities, ModelType } from '../types'
+import { FetchFrom, type ModelCapabilities, ModelType, type ProviderCapabilities } from '../types'
 import { CohereTextEmbeddingClient } from './cohere-embedding-client'
 
 // Define Cohere capabilities and models
-const COHERE_CAPABILITIES = {
+const COHERE_CAPABILITIES: ProviderCapabilities = {
   id: 'cohere',
-  name: 'Cohere',
+  displayName: 'Cohere',
   description: 'Cohere AI platform for embeddings and language models',
   icon: 'cohere',
   color: '#FF6B35',
-  supported_model_types: [ModelType.TEXT_EMBEDDING],
-  configurable: true,
-  credential_form_schema: {
-    apiKey: {
-      type: 'secret-input',
-      required: true,
+  supportedModelTypes: [ModelType.TEXT_EMBEDDING],
+  defaultModel: 'embed-english-v3.0',
+  requiresApiKey: true,
+  toolFormat: 'custom',
+  configurateMethods: ['predefined-model'],
+  connectionVariables: [
+    {
+      key: 'apiKey',
       label: 'API Key',
       placeholder: 'Enter your Cohere API key',
+      required: true,
+      secret: true,
+      description: 'Your Cohere API key from https://dashboard.cohere.com/api-keys',
     },
+  ],
+  fieldMeta: {
+    apiKey: { scope: 'both', priority: 'model-override' },
   },
+  documentationUrl: 'https://docs.cohere.com/reference/embed',
 }
 
 const COHERE_MODELS: Record<string, ModelCapabilities> = {
@@ -37,7 +46,7 @@ const COHERE_MODELS: Record<string, ModelCapabilities> = {
     contextLength: 512,
     maxTokens: 512,
     modelType: ModelType.TEXT_EMBEDDING,
-    fetchFrom: 'predefined-model' as any,
+    fetchFrom: FetchFrom.PREDEFINED_MODEL,
     features: ['high-performance', 'english-optimized'],
     supports: {
       streaming: false,
@@ -59,7 +68,7 @@ const COHERE_MODELS: Record<string, ModelCapabilities> = {
     contextLength: 512,
     maxTokens: 512,
     modelType: ModelType.TEXT_EMBEDDING,
-    fetchFrom: 'predefined-model' as any,
+    fetchFrom: FetchFrom.PREDEFINED_MODEL,
     features: ['multilingual', 'high-performance'],
     supports: {
       streaming: false,

--- a/packages/lib/src/ai/providers/cohere/cohere-embedding-client.ts
+++ b/packages/lib/src/ai/providers/cohere/cohere-embedding-client.ts
@@ -48,7 +48,11 @@ export class CohereTextEmbeddingClient extends TextEmbeddingClient {
             truncate: 'END', // Truncate from end if text is too long
           })
 
-          const embeddings = response.embeddings.float || []
+          // `embeddingTypes: ['float']` puts the vectors under `.float`; the SDK
+          // still types the field as the legacy bare `number[][]` union.
+          const embeddings = Array.isArray(response.embeddings)
+            ? response.embeddings
+            : (response.embeddings.float ?? [])
           const usage = this.convertCohereUsage(response.meta)
 
           return {

--- a/packages/lib/src/ai/providers/config/assemble.ts
+++ b/packages/lib/src/ai/providers/config/assemble.ts
@@ -323,8 +323,11 @@ function buildCustomConfiguration(
   const customModels: CustomModelConfiguration[] = modelConfigurations.map((mc) => ({
     model: mc.model,
     modelType: mc.modelType as ModelType,
-    credentials: undefined,
-    parameters: mc.config ? [mc.config] : [],
+    // Model rows carry params/enabled only — the BYO key lives on the CUSTOM
+    // provider record in the unified store, never on the model row.
+    credentials: {},
+    // `config` is a jsonb column, so Drizzle types it `unknown`.
+    parameters: (mc.config as Record<string, any> | null) ?? undefined,
   }))
 
   return { provider: customProvider, models: customModels }
@@ -335,22 +338,26 @@ function buildCustomConfiguration(
  * model type. Credentials live in the unified store; this display shape carries identity only.
  */
 function buildModelSettings(loadBalancingConfigs: LoadBalancingConfigModel[]): ModelSettings[] {
+  // Group on a composite key but keep the identity on the rows — model ids can
+  // themselves contain ':' (e.g. `llama3:8b`), so the key is not safely splittable.
   const modelGroups = new Map<string, LoadBalancingConfigModel[]>()
   for (const config of loadBalancingConfigs) {
-    const key = `${config.model}:${config.modelType}`
-    if (!modelGroups.has(key)) modelGroups.set(key, [])
-    modelGroups.get(key)!.push(config)
+    const key = `${config.model} ${config.modelType}`
+    const group = modelGroups.get(key)
+    if (group) group.push(config)
+    else modelGroups.set(key, [config])
   }
 
   const modelSettings: ModelSettings[] = []
-  for (const [key, configs] of modelGroups) {
-    const [model, modelType] = key.split(':')
+  for (const configs of modelGroups.values()) {
+    const [first] = configs
+    if (!first) continue
     const loadBalancingConfigurations: ModelLoadBalancingConfiguration[] = configs.map(
       (config) => ({ id: config.id, name: config.name, credentials: {} })
     )
     modelSettings.push({
-      model,
-      modelType: modelType as ModelType,
+      model: first.model,
+      modelType: first.modelType as ModelType,
       enabled: configs.every((c) => c.enabled),
       loadBalancingConfigs: loadBalancingConfigurations,
     })
@@ -516,19 +523,27 @@ function createCustomModelCapabilities(
 ): ModelCapabilities {
   return {
     provider,
+    modelId: modelName,
     displayName: modelName,
     icon: providerCapabilities?.icon || '',
     color: providerCapabilities?.color || '',
     modelType,
     fetchFrom: FetchFrom.CUSTOMIZABLE_MODEL,
-    contextLength: undefined,
-    maxTokens: undefined,
+    // 0 means "unknown" — every consumer guards on truthiness before using these.
+    contextLength: 0,
+    maxTokens: 0,
     features: [],
-    supports: {},
-    costPer1kTokens: undefined,
+    // Nothing is known about a model that isn't in the registry, so every
+    // capability stays off until the user's own registry entry says otherwise.
+    supports: {
+      streaming: false,
+      structured: false,
+      vision: false,
+      toolCalling: false,
+      systemMessages: false,
+      fileInput: false,
+    },
     deprecated: false,
-    releaseDate: undefined,
-    description: undefined,
     parameterRules: [],
-  } as ModelCapabilities
+  }
 }

--- a/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-llm-client.test.ts
+++ b/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-llm-client.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/ai/providers/deepseek/__tests__/deepseek-llm-client.test.ts
 
 import { describe, expect, it, vi } from 'vitest'
-import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
+import { DEFAULT_CLIENT_CONFIG, type Message } from '../../../clients/base/types'
 import { DeepSeekLLMClient } from '../deepseek-llm-client'
 
 describe('DeepSeekLLMClient', () => {
@@ -13,6 +13,13 @@ describe('DeepSeekLLMClient', () => {
         },
       },
     } as any
+  }
+
+  /** Payload the client handed to the OpenAI-compatible SDK on its first call. */
+  function firstCallPayload(createMock: ReturnType<typeof vi.fn>): { messages: Message[] } {
+    const call = createMock.mock.calls[0]
+    if (!call) throw new Error('expected the API client to have been called')
+    return call[0]
   }
 
   it('completes a basic request using OpenAI-compatible API', async () => {
@@ -57,10 +64,11 @@ describe('DeepSeekLLMClient', () => {
     })
 
     expect(createMock).toHaveBeenCalledTimes(1)
-    const sentMessages = createMock.mock.calls[0][0].messages
-    const assistantMsg = sentMessages.find((m: any) => m.role === 'assistant')
-    expect(assistantMsg.content).toBe('4')
-    expect(assistantMsg.reasoning_content).toBeUndefined()
+    const sentMessages = firstCallPayload(createMock).messages
+    const assistantMsg = sentMessages.find((m) => m.role === 'assistant')
+    expect(assistantMsg).toBeDefined()
+    expect(assistantMsg?.content).toBe('4')
+    expect(assistantMsg?.reasoning_content).toBeUndefined()
   })
 
   it('preserves messages without reasoning_content unchanged', async () => {
@@ -82,7 +90,7 @@ describe('DeepSeekLLMClient', () => {
       ],
     })
 
-    const sentMessages = createMock.mock.calls[0][0].messages
+    const sentMessages = firstCallPayload(createMock).messages
     expect(sentMessages).toHaveLength(4)
     expect(sentMessages[0]).toEqual({ role: 'system', content: 'You are helpful.' })
     expect(sentMessages[2]).toEqual({ role: 'assistant', content: 'Hello!' })

--- a/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-model-restrictions.test.ts
+++ b/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-model-restrictions.test.ts
@@ -2,18 +2,27 @@
 
 import { describe, expect, it } from 'vitest'
 import { ModelConfigService } from '../../../model-config-service'
-import { ModelType } from '../../types'
+import { type ModelCapabilities, ModelType } from '../../types'
 import { DEEPSEEK_MODELS } from '../deepseek-defaults'
 
 const DEEPSEEK_LLM_MODELS = Object.entries(DEEPSEEK_MODELS).filter(
   ([_, capabilities]) => capabilities.modelType === ModelType.LLM
 )
 
-function getAllowedParameterNames(modelId: string): Set<string> {
+/**
+ * Registry lookup that fails the test loudly when a model is missing, instead of
+ * letting every downstream assertion read as `undefined`.
+ */
+function getModel(modelId: string): ModelCapabilities {
   const capabilities = DEEPSEEK_MODELS[modelId]
   if (!capabilities) {
     throw new Error(`Missing model capabilities for ${modelId}`)
   }
+  return capabilities
+}
+
+function getAllowedParameterNames(modelId: string): Set<string> {
+  const capabilities = getModel(modelId)
 
   const names = new Set(capabilities.parameterRules.map((rule) => rule.name))
 
@@ -30,15 +39,13 @@ describe('DeepSeek model restrictions', () => {
   // ── Registration ────────────────────────────────────────────────
 
   it('registers deepseek-chat', () => {
-    const model = DEEPSEEK_MODELS['deepseek-chat']
-    expect(model).toBeDefined()
+    const model = getModel('deepseek-chat')
     expect(model.modelId).toBe('deepseek-chat')
     expect(model.provider).toBe('deepseek')
   })
 
   it('registers deepseek-reasoner', () => {
-    const model = DEEPSEEK_MODELS['deepseek-reasoner']
-    expect(model).toBeDefined()
+    const model = getModel('deepseek-reasoner')
     expect(model.modelId).toBe('deepseek-reasoner')
     expect(model.provider).toBe('deepseek')
   })
@@ -46,13 +53,13 @@ describe('DeepSeek model restrictions', () => {
   // ── Context & token limits ─────────────────────────────────────
 
   it('deepseek-chat has 128k context and 8192 max output', () => {
-    const model = DEEPSEEK_MODELS['deepseek-chat']
+    const model = getModel('deepseek-chat')
     expect(model.contextLength).toBe(128000)
     expect(model.maxTokens).toBe(8192)
   })
 
   it('deepseek-reasoner has 128k context and 64k max output', () => {
-    const model = DEEPSEEK_MODELS['deepseek-reasoner']
+    const model = getModel('deepseek-reasoner')
     expect(model.contextLength).toBe(128000)
     expect(model.maxTokens).toBe(64000)
   })
@@ -60,34 +67,34 @@ describe('DeepSeek model restrictions', () => {
   // ── Capabilities ───────────────────────────────────────────────
 
   it('both models support tool calling', () => {
-    expect(DEEPSEEK_MODELS['deepseek-chat'].supports.toolCalling).toBe(true)
-    expect(DEEPSEEK_MODELS['deepseek-reasoner'].supports.toolCalling).toBe(true)
+    expect(getModel('deepseek-chat').supports.toolCalling).toBe(true)
+    expect(getModel('deepseek-reasoner').supports.toolCalling).toBe(true)
   })
 
   it('both models support structured output', () => {
-    expect(DEEPSEEK_MODELS['deepseek-chat'].supports.structured).toBe(true)
-    expect(DEEPSEEK_MODELS['deepseek-reasoner'].supports.structured).toBe(true)
+    expect(getModel('deepseek-chat').supports.structured).toBe(true)
+    expect(getModel('deepseek-reasoner').supports.structured).toBe(true)
   })
 
   it('both models support streaming', () => {
-    expect(DEEPSEEK_MODELS['deepseek-chat'].supports.streaming).toBe(true)
-    expect(DEEPSEEK_MODELS['deepseek-reasoner'].supports.streaming).toBe(true)
+    expect(getModel('deepseek-chat').supports.streaming).toBe(true)
+    expect(getModel('deepseek-reasoner').supports.streaming).toBe(true)
   })
 
   it('neither model supports vision', () => {
-    expect(DEEPSEEK_MODELS['deepseek-chat'].supports.vision).toBe(false)
-    expect(DEEPSEEK_MODELS['deepseek-reasoner'].supports.vision).toBe(false)
+    expect(getModel('deepseek-chat').supports.vision).toBe(false)
+    expect(getModel('deepseek-reasoner').supports.vision).toBe(false)
   })
 
   // ── Pricing ────────────────────────────────────────────────────
 
   it('both models have cost per 1k tokens', () => {
-    expect(DEEPSEEK_MODELS['deepseek-chat'].costPer1kTokens).toEqual({
+    expect(getModel('deepseek-chat').costPer1kTokens).toEqual({
       input: 0.00014,
       output: 0.00028,
       cachedInput: 0.0000028,
     })
-    expect(DEEPSEEK_MODELS['deepseek-reasoner'].costPer1kTokens).toEqual({
+    expect(getModel('deepseek-reasoner').costPer1kTokens).toEqual({
       input: 0.00014,
       output: 0.00028,
       cachedInput: 0.0000028,
@@ -97,17 +104,17 @@ describe('DeepSeek model restrictions', () => {
   // ── Reasoning model restrictions ───────────────────────────────
 
   it('deepseek-reasoner is marked as reasoning model', () => {
-    const caps = DEEPSEEK_MODELS['deepseek-reasoner']
+    const caps = getModel('deepseek-reasoner')
     expect(caps.parameterRestrictions?.isReasoningModel).toBe(true)
   })
 
   it('deepseek-chat is NOT marked as reasoning model', () => {
-    const caps = DEEPSEEK_MODELS['deepseek-chat']
+    const caps = getModel('deepseek-chat')
     expect(caps.parameterRestrictions?.isReasoningModel).toBeUndefined()
   })
 
   it('deepseek-reasoner unsupported params include sampling params', () => {
-    const caps = DEEPSEEK_MODELS['deepseek-reasoner']
+    const caps = getModel('deepseek-reasoner')
     expect(caps.parameterRestrictions?.unsupportedParams).toContain('temperature')
     expect(caps.parameterRestrictions?.unsupportedParams).toContain('top_p')
     expect(caps.parameterRestrictions?.unsupportedParams).toContain('presence_penalty')
@@ -115,23 +122,21 @@ describe('DeepSeek model restrictions', () => {
   })
 
   it('deepseek-reasoner only allows max_tokens as supported param', () => {
-    const caps = DEEPSEEK_MODELS['deepseek-reasoner']
+    const caps = getModel('deepseek-reasoner')
     expect(caps.parameterRestrictions?.supportedParams).toEqual(['max_tokens'])
   })
 
   // ── Parameter rules ────────────────────────────────────────────
 
   it('deepseek-chat has temperature with max 2', () => {
-    const rule = DEEPSEEK_MODELS['deepseek-chat'].parameterRules.find(
-      (r) => r.name === 'temperature'
-    )
+    const rule = getModel('deepseek-chat').parameterRules.find((r) => r.name === 'temperature')
     expect(rule).toBeDefined()
     expect(rule?.max).toBe(2)
     expect(rule?.default).toBe(1)
   })
 
   it('deepseek-chat has all sampling parameters', () => {
-    const ruleNames = DEEPSEEK_MODELS['deepseek-chat'].parameterRules.map((r) => r.name)
+    const ruleNames = getModel('deepseek-chat').parameterRules.map((r) => r.name)
     expect(ruleNames).toContain('temperature')
     expect(ruleNames).toContain('topP')
     expect(ruleNames).toContain('frequencyPenalty')
@@ -140,12 +145,12 @@ describe('DeepSeek model restrictions', () => {
   })
 
   it('deepseek-reasoner only has maxOutputTokens parameter rule', () => {
-    const ruleNames = DEEPSEEK_MODELS['deepseek-reasoner'].parameterRules.map((r) => r.name)
+    const ruleNames = getModel('deepseek-reasoner').parameterRules.map((r) => r.name)
     expect(ruleNames).toEqual(['maxOutputTokens'])
   })
 
   it('deepseek-reasoner maxOutputTokens has correct range', () => {
-    const rule = DEEPSEEK_MODELS['deepseek-reasoner'].parameterRules.find(
+    const rule = getModel('deepseek-reasoner').parameterRules.find(
       (r) => r.name === 'maxOutputTokens'
     )
     expect(rule?.max).toBe(64000)
@@ -176,7 +181,7 @@ describe('DeepSeek model restrictions', () => {
   })
 
   it('deepseek-reasoner strips sampling params via filterParameters', () => {
-    const capabilities = DEEPSEEK_MODELS['deepseek-reasoner']
+    const capabilities = getModel('deepseek-reasoner')
     const filtered = ModelConfigService.filterParameters(
       capabilities,
       {
@@ -198,10 +203,10 @@ describe('DeepSeek model restrictions', () => {
   // ── Features ───────────────────────────────────────────────────
 
   it('deepseek-chat has chat and code features', () => {
-    expect(DEEPSEEK_MODELS['deepseek-chat'].features).toEqual(['chat', 'code'])
+    expect(getModel('deepseek-chat').features).toEqual(['chat', 'code'])
   })
 
   it('deepseek-reasoner has chat, reasoning, and code features', () => {
-    expect(DEEPSEEK_MODELS['deepseek-reasoner'].features).toEqual(['chat', 'reasoning', 'code'])
+    expect(getModel('deepseek-reasoner').features).toEqual(['chat', 'reasoning', 'code'])
   })
 })

--- a/packages/lib/src/ai/providers/deepseek/deepseek-llm-client.ts
+++ b/packages/lib/src/ai/providers/deepseek/deepseek-llm-client.ts
@@ -4,6 +4,21 @@ import type { Message } from '../../clients/base/types'
 import { OpenAILLMClient } from '../openai/openai-llm-client'
 
 /**
+ * Index of the last assistant message carrying `reasoning_content`, or -1.
+ *
+ * A manual reverse scan rather than `Array.prototype.findLastIndex` — the
+ * package compiles against the shared `target: ES2022` lib, which does not
+ * declare the ES2023 array methods.
+ */
+function findLastAssistantWithReasoningIndex(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message?.role === 'assistant' && message.reasoning_content) return i
+  }
+  return -1
+}
+
+/**
  * DeepSeek LLM client that extends OpenAI's client.
  *
  * DeepSeek's API is OpenAI-compatible, but the `deepseek-reasoner` model
@@ -41,9 +56,7 @@ export class DeepSeekLLMClient extends OpenAILLMClient {
    *   [user, assistant(reasoning), user]              → turn closed,  strip
    */
   protected override prepareReasoningContent(messages: Message[]): Message[] {
-    const lastAssistantWithReasoningIdx = messages.findLastIndex(
-      (m) => m.role === 'assistant' && m.reasoning_content
-    )
+    const lastAssistantWithReasoningIdx = findLastAssistantWithReasoningIndex(messages)
 
     if (lastAssistantWithReasoningIdx === -1) return messages
 

--- a/packages/lib/src/ai/providers/google/__tests__/google-defaults.test.ts
+++ b/packages/lib/src/ai/providers/google/__tests__/google-defaults.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest'
 import { ModelType } from '../../types'
 import { GOOGLE_CAPABILITIES, GOOGLE_MODELS } from '../google-defaults'
+import { requireGoogleModel } from '../test-helpers'
 
 describe('GOOGLE_CAPABILITIES', () => {
   it('has correct provider identity', () => {
@@ -29,12 +30,13 @@ describe('GOOGLE_CAPABILITIES', () => {
   it('has valid connection variables', () => {
     expect(GOOGLE_CAPABILITIES.connectionVariables).toHaveLength(1)
 
-    const apiKeyField = GOOGLE_CAPABILITIES.connectionVariables[0]
-    expect(apiKeyField.key).toBe('apiKey')
-    expect(apiKeyField.secret).toBe(true)
-    expect(apiKeyField.required).toBe(true)
-    expect(apiKeyField.validation?.pattern).toBe('^AIza[0-9A-Za-z-_]{35}$')
-    expect(GOOGLE_CAPABILITIES.fieldMeta.apiKey.scope).toBe('both')
+    const [apiKeyField] = GOOGLE_CAPABILITIES.connectionVariables
+    expect(apiKeyField).toBeDefined()
+    expect(apiKeyField?.key).toBe('apiKey')
+    expect(apiKeyField?.secret).toBe(true)
+    expect(apiKeyField?.required).toBe(true)
+    expect(apiKeyField?.validation?.pattern).toBe('^AIza[0-9A-Za-z-_]{35}$')
+    expect(GOOGLE_CAPABILITIES.fieldMeta.apiKey?.scope).toBe('both')
   })
 
   it('has rate limits configured', () => {
@@ -77,7 +79,7 @@ describe('GOOGLE_MODELS', () => {
     ]
 
     it.each(currentLlmModels)('%s has correct base properties', (modelId) => {
-      const model = GOOGLE_MODELS[modelId]
+      const model = requireGoogleModel(modelId)
       expect(model.provider).toBe('google')
       expect(model.modelId).toBe(modelId)
       expect(model.modelType).toBe(ModelType.LLM)
@@ -86,7 +88,7 @@ describe('GOOGLE_MODELS', () => {
     })
 
     it.each(currentLlmModels)('%s supports full LLM capabilities', (modelId) => {
-      const model = GOOGLE_MODELS[modelId]
+      const model = requireGoogleModel(modelId)
       expect(model.supports.streaming).toBe(true)
       expect(model.supports.structured).toBe(true)
       expect(model.supports.vision).toBe(true)
@@ -96,13 +98,13 @@ describe('GOOGLE_MODELS', () => {
     })
 
     it.each(currentLlmModels)('%s has thinking capabilities', (modelId) => {
-      const model = GOOGLE_MODELS[modelId]
+      const model = requireGoogleModel(modelId)
       expect(model.features).toContain('thinking')
       expect(model.parameterRestrictions?.isReasoningModel).toBe(true)
     })
 
     it.each(currentLlmModels)('%s has thinking parameter rules', (modelId) => {
-      const model = GOOGLE_MODELS[modelId]
+      const model = requireGoogleModel(modelId)
       const paramNames = model.parameterRules?.map((r) => r.name) ?? []
       expect(paramNames).toContain('temperature')
       expect(paramNames).toContain('topP')
@@ -112,11 +114,11 @@ describe('GOOGLE_MODELS', () => {
     })
 
     it.each(currentLlmModels)('%s is not deprecated', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].deprecated).toBeFalsy()
+      expect(requireGoogleModel(modelId).deprecated).toBeFalsy()
     })
 
     it.each(currentLlmModels)('%s has pricing defined', (modelId) => {
-      const model = GOOGLE_MODELS[modelId]
+      const model = requireGoogleModel(modelId)
       expect(model.costPer1kTokens).toBeDefined()
       expect(model.costPer1kTokens!.input).toBeGreaterThan(0)
       expect(model.costPer1kTokens!.output).toBeGreaterThan(0)
@@ -127,15 +129,15 @@ describe('GOOGLE_MODELS', () => {
     const deprecatedModels = ['gemini-2.0-flash', 'gemini-2.0-flash-lite']
 
     it.each(deprecatedModels)('%s is marked as deprecated', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].deprecated).toBe(true)
+      expect(requireGoogleModel(modelId).deprecated).toBe(true)
     })
 
     it.each(deprecatedModels)('%s has a replacement', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].replacement).toBeTruthy()
+      expect(requireGoogleModel(modelId).replacement).toBeTruthy()
     })
 
     it.each(deprecatedModels)('%s has deprecation notice in description', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].description).toContain('Deprecated')
+      expect(requireGoogleModel(modelId).description).toContain('Deprecated')
     })
   })
 
@@ -143,15 +145,15 @@ describe('GOOGLE_MODELS', () => {
     const retiredModels = ['gemini-1.5-pro-latest', 'gemini-1.5-flash-latest']
 
     it.each(retiredModels)('%s is marked as retired', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].retired).toBe(true)
+      expect(requireGoogleModel(modelId).retired).toBe(true)
     })
 
     it.each(retiredModels)('%s has a replacement', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].replacement).toBeTruthy()
+      expect(requireGoogleModel(modelId).replacement).toBeTruthy()
     })
 
     it.each(retiredModels)('%s is not marked as deprecated', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].deprecated).toBeFalsy()
+      expect(requireGoogleModel(modelId).deprecated).toBeFalsy()
     })
   })
 
@@ -159,17 +161,17 @@ describe('GOOGLE_MODELS', () => {
     const retiredEmbeddings = ['text-embedding-004', 'textembedding-gecko@003']
 
     it.each(retiredEmbeddings)('%s is marked as retired', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].retired).toBe(true)
+      expect(requireGoogleModel(modelId).retired).toBe(true)
     })
 
     it.each(retiredEmbeddings)('%s has a replacement', (modelId) => {
-      expect(GOOGLE_MODELS[modelId].replacement).toBe('gemini-embedding-001')
+      expect(requireGoogleModel(modelId).replacement).toBe('gemini-embedding-001')
     })
   })
 
   describe('embedding models', () => {
     it('gemini-embedding-2-preview has correct config', () => {
-      const model = GOOGLE_MODELS['gemini-embedding-2-preview']
+      const model = requireGoogleModel('gemini-embedding-2-preview')
       expect(model.modelType).toBe(ModelType.TEXT_EMBEDDING)
       expect(model.contextLength).toBe(8192)
       expect(model.features).toContain('text-embedding')
@@ -178,7 +180,7 @@ describe('GOOGLE_MODELS', () => {
     })
 
     it('gemini-embedding-001 has correct config', () => {
-      const model = GOOGLE_MODELS['gemini-embedding-001']
+      const model = requireGoogleModel('gemini-embedding-001')
       expect(model.modelType).toBe(ModelType.TEXT_EMBEDDING)
       expect(model.contextLength).toBe(2048)
       expect(model.features).toContain('text-embedding')
@@ -187,7 +189,7 @@ describe('GOOGLE_MODELS', () => {
 
     it('embedding models have no streaming/tool support', () => {
       for (const modelId of ['gemini-embedding-2-preview', 'gemini-embedding-001']) {
-        const model = GOOGLE_MODELS[modelId]
+        const model = requireGoogleModel(modelId)
         expect(model.supports.streaming).toBe(false)
         expect(model.supports.toolCalling).toBe(false)
         expect(model.supports.structured).toBe(false)
@@ -196,7 +198,7 @@ describe('GOOGLE_MODELS', () => {
 
     it('embedding models have dimension parameter rules', () => {
       for (const modelId of ['gemini-embedding-2-preview', 'gemini-embedding-001']) {
-        const model = GOOGLE_MODELS[modelId]
+        const model = requireGoogleModel(modelId)
         const dimParam = model.parameterRules?.find((r) => r.name === 'dimensions')
         expect(dimParam).toBeDefined()
         expect(dimParam!.options).toContain('768')

--- a/packages/lib/src/ai/providers/google/__tests__/google-embedding-client.test.ts
+++ b/packages/lib/src/ai/providers/google/__tests__/google-embedding-client.test.ts
@@ -30,7 +30,9 @@ describe.skipIf(!apiKey)('GoogleTextEmbeddingClient integration', () => {
     })
 
     expect(response.embeddings).toHaveLength(1)
-    expect(response.embeddings[0].length).toBeGreaterThan(0)
+    const [vector] = response.embeddings
+    expect(vector).toBeDefined()
+    expect(vector?.length).toBeGreaterThan(0)
     expect(response.model).toBe('gemini-embedding-001')
     expect(response.usage.prompt_tokens).toBeGreaterThan(0)
     expect(response.usage.completion_tokens).toBe(0)
@@ -45,9 +47,11 @@ describe.skipIf(!apiKey)('GoogleTextEmbeddingClient integration', () => {
     })
 
     // gemini-embedding-001 returns a valid embedding vector
-    expect(response.embeddings[0].length).toBeGreaterThan(0)
+    const [vector] = response.embeddings
+    expect(vector).toBeDefined()
+    expect(vector?.length).toBeGreaterThan(0)
     // Should be one of the valid dimension sizes
-    expect([128, 256, 512, 768, 1536, 3072]).toContain(response.embeddings[0].length)
+    expect([128, 256, 512, 768, 1536, 3072]).toContain(vector?.length)
   }, 15_000)
 })
 

--- a/packages/lib/src/ai/providers/google/__tests__/google-llm-client.test.ts
+++ b/packages/lib/src/ai/providers/google/__tests__/google-llm-client.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
 import { GoogleLLMClient } from '../google-llm-client'
+import { firstCallArg } from '../test-helpers'
 
 describe('GoogleLLMClient', () => {
   function createMockApiClient(createMock: ReturnType<typeof vi.fn>) {
@@ -47,14 +48,16 @@ describe('GoogleLLMClient', () => {
       model: 'gemini-2.5-flash',
       messages: [{ role: 'user', content: 'Say hello' }],
       response_format: 'json_schema',
-      json_schema: {
+      // Production (llm-orchestrator) always serializes the schema before it
+      // reaches the client, so the string form is what's under test.
+      json_schema: JSON.stringify({
         type: 'object',
         properties: { message: { type: 'string' } },
         required: ['message'],
-      },
+      }),
     })
 
-    const sent = createMock.mock.calls[0][0]
+    const sent = firstCallArg(createMock, 'chat.completions.create')
     expect(sent.response_format.type).toBe('json_schema')
     expect(sent.response_format.json_schema.strict).toBe(true)
     expect(sent.response_format.json_schema.schema.properties.message).toEqual({ type: 'string' })
@@ -78,7 +81,7 @@ describe('GoogleLLMClient', () => {
       parameters: { temperature: 0.5 },
     })
 
-    const sent = createMock.mock.calls[0][0]
+    const sent = firstCallArg(createMock, 'chat.completions.create')
     expect(sent.temperature).toBe(0.5)
     expect(sent.top_p).toBeDefined()
     expect(sent.max_tokens).toBeDefined()
@@ -114,6 +117,6 @@ describe('GoogleLLMClient', () => {
     } while (!result.done)
 
     expect(result.value.content).toBe('Hello')
-    expect(createMock.mock.calls[0][0].stream).toBe(true)
+    expect(firstCallArg(createMock, 'chat.completions.create').stream).toBe(true)
   })
 })

--- a/packages/lib/src/ai/providers/google/google-client.ts
+++ b/packages/lib/src/ai/providers/google/google-client.ts
@@ -156,7 +156,7 @@ export class GoogleClient extends ProviderClient {
       case ModelType.TEXT_EMBEDDING:
         return new GoogleTextEmbeddingClient(
           this.getApiClient(credentials),
-          { timeout: 30000, maxRetries: 3 },
+          DEFAULT_CLIENT_CONFIG,
           this.logger
         )
 

--- a/packages/lib/src/ai/providers/google/google-embedding-client.ts
+++ b/packages/lib/src/ai/providers/google/google-embedding-client.ts
@@ -52,16 +52,20 @@ export class GoogleTextEmbeddingClient extends TextEmbeddingClient {
 
           for (let i = 0; i < texts.length; i += batchSize) {
             const batch = texts.slice(i, i + batchSize)
+            const [onlyText] = batch
 
-            if (batch.length === 1) {
+            if (batch.length === 1 && onlyText !== undefined) {
               // Single text embedding
-              const result = await model.embedContent(batch[0])
+              const result = await model.embedContent(onlyText)
               embeddings.push(result.embedding.values)
             } else {
-              // Batch embedding
-              const results = await model.batchEmbedContents(
-                batch.map((text) => ({ content: { parts: [{ text }] } }))
-              )
+              // Batch embedding — the SDK reads `requests` off this object and
+              // injects the model into each entry, so a bare array throws.
+              const results = await model.batchEmbedContents({
+                requests: batch.map((text) => ({
+                  content: { role: 'user', parts: [{ text }] },
+                })),
+              })
 
               for (const result of results.embeddings) {
                 embeddings.push(result.values)

--- a/packages/lib/src/ai/providers/google/google-llm-client.ts
+++ b/packages/lib/src/ai/providers/google/google-llm-client.ts
@@ -62,7 +62,10 @@ export class GoogleLLMClient extends OpenAILLMClient {
     const normalized: Record<string, any> = {}
 
     for (const [key, value] of Object.entries(parameters)) {
-      const translated = key in PARAM_TRANSLATIONS ? PARAM_TRANSLATIONS[key] : key
+      // `undefined` means "not in the table" (pass through); an explicit `null`
+      // entry means "drop" — so this can't collapse to `?? key`.
+      const mapped = PARAM_TRANSLATIONS[key]
+      const translated = mapped === undefined ? key : mapped
       if (translated === null) continue
       if (!SUPPORTED_PARAMS.has(translated)) continue
       normalized[translated] = value

--- a/packages/lib/src/ai/providers/google/test-helpers.ts
+++ b/packages/lib/src/ai/providers/google/test-helpers.ts
@@ -1,0 +1,33 @@
+// packages/lib/src/ai/providers/google/test-helpers.ts
+//
+// Test-only helpers for the Google provider suites. Lives beside the source
+// rather than in `__tests__/` because vitest's `src/**/__tests__/**/*.ts`
+// include glob treats every file in that directory as a test suite.
+
+import type { ModelCapabilities } from '../types'
+import { GOOGLE_MODELS } from './google-defaults'
+
+/**
+ * Look up a model in the Google registry, failing loudly when it is missing.
+ * Keeps assertions on registry entries from silently becoming `undefined`
+ * property reads when a model id is renamed or dropped.
+ */
+export function requireGoogleModel(modelId: string): ModelCapabilities {
+  const model = GOOGLE_MODELS[modelId]
+  if (!model) {
+    throw new Error(`GOOGLE_MODELS has no entry for "${modelId}"`)
+  }
+  return model
+}
+
+/**
+ * Read the first recorded argument of a mocked call, failing loudly when the
+ * mock was never invoked (rather than throwing an opaque index error).
+ */
+export function firstCallArg<T = any>(mock: { mock: { calls: any[][] } }, label = 'mock'): T {
+  const call = mock.mock.calls[0]
+  if (!call) {
+    throw new Error(`Expected ${label} to have been called at least once`)
+  }
+  return call[0] as T
+}

--- a/packages/lib/src/ai/providers/groq/__tests__/groq-llm-client.test.ts
+++ b/packages/lib/src/ai/providers/groq/__tests__/groq-llm-client.test.ts
@@ -1,8 +1,15 @@
 // packages/lib/src/ai/providers/groq/__tests__/groq-llm-client.test.ts
 
 import { describe, expect, it, vi } from 'vitest'
-import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
+import { DEFAULT_CLIENT_CONFIG, type LLMInvokeParams } from '../../../clients/base/types'
 import { GroqLLMClient } from '../groq-llm-client'
+
+/** Shape the OpenAI-compatible SDK receives after the client processes params. */
+interface SentPayload {
+  messages: { role: string; content: string }[]
+  response_format?: { type: string; json_schema?: { strict?: boolean } }
+  json_schema?: unknown
+}
 
 describe('GroqLLMClient', () => {
   function createMockApiClient(createMock: ReturnType<typeof vi.fn>) {
@@ -15,17 +22,26 @@ describe('GroqLLMClient', () => {
     } as any
   }
 
-  function jsonSchemaParams(model: string) {
+  // `json_schema` travels as a JSON string — that is what the orchestrator sends
+  // (`JSON.stringify(request.structuredOutput.schema)`).
+  function jsonSchemaParams(model: string): LLMInvokeParams {
     return {
       model,
-      messages: [{ role: 'user' as const, content: 'Say hello' }],
-      response_format: 'json_schema' as const,
-      json_schema: {
+      messages: [{ role: 'user', content: 'Say hello' }],
+      response_format: 'json_schema',
+      json_schema: JSON.stringify({
         type: 'object',
         properties: { message: { type: 'string' } },
         required: ['message'],
-      },
+      }),
     }
+  }
+
+  /** Payload the client handed to the OpenAI-compatible SDK on its first call. */
+  function firstCallPayload(createMock: ReturnType<typeof vi.fn>): SentPayload {
+    const call = createMock.mock.calls[0]
+    if (!call) throw new Error('expected the API client to have been called')
+    return call[0]
   }
 
   it('completes a basic request using the OpenAI-compatible API', async () => {
@@ -60,12 +76,12 @@ describe('GroqLLMClient', () => {
     // exercises the model-aware strict-schema gate directly.
     await client.invoke(jsonSchemaParams('llama-3.1-8b-instant'))
 
-    const sent = createMock.mock.calls[0][0]
+    const sent = firstCallPayload(createMock)
     expect(sent.response_format).toEqual({ type: 'json_object' })
     expect(sent.json_schema).toBeUndefined()
     // Schema is injected into the system prompt on the downgrade path
-    expect(sent.messages[0].role).toBe('system')
-    expect(sent.messages[0].content).toContain('JSON Schema')
+    expect(sent.messages[0]?.role).toBe('system')
+    expect(sent.messages[0]?.content).toContain('JSON Schema')
   })
 
   it('keeps strict json_schema for openai/gpt-oss models', async () => {
@@ -79,8 +95,8 @@ describe('GroqLLMClient', () => {
     const client = new GroqLLMClient(createMockApiClient(createMock), DEFAULT_CLIENT_CONFIG)
     await client.invoke(jsonSchemaParams('openai/gpt-oss-120b'))
 
-    const sent = createMock.mock.calls[0][0]
-    expect(sent.response_format.type).toBe('json_schema')
-    expect(sent.response_format.json_schema.strict).toBe(true)
+    const sent = firstCallPayload(createMock)
+    expect(sent.response_format?.type).toBe('json_schema')
+    expect(sent.response_format?.json_schema?.strict).toBe(true)
   })
 })

--- a/packages/lib/src/ai/providers/openai/__tests__/openai-llm-client.test.ts
+++ b/packages/lib/src/ai/providers/openai/__tests__/openai-llm-client.test.ts
@@ -4,6 +4,13 @@ import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
 import { OpenAILLMClient } from '../openai-llm-client'
 
+/** Outbound payload of the nth recorded `create()` call, or a loud failure. */
+function payloadAt(mock: { mock: { calls: unknown[][] } }, index: number): Record<string, any> {
+  const call = mock.mock.calls[index]
+  if (!call) throw new Error(`expected a create() call at index ${index}`)
+  return call[0] as Record<string, any>
+}
+
 describe('OpenAILLMClient request shaping', () => {
   it('retries once without reasoning-only params when reasoning_effort is rejected', async () => {
     const createMock = vi
@@ -37,9 +44,9 @@ describe('OpenAILLMClient request shaping', () => {
 
     expect(response.content).toBe('ok')
     expect(createMock).toHaveBeenCalledTimes(2)
-    expect(createMock.mock.calls[0][0].reasoning_effort).toBe('medium')
-    expect(createMock.mock.calls[1][0].reasoning_effort).toBeUndefined()
-    expect(createMock.mock.calls[1][0].verbosity).toBeUndefined()
+    expect(payloadAt(createMock, 0).reasoning_effort).toBe('medium')
+    expect(payloadAt(createMock, 1).reasoning_effort).toBeUndefined()
+    expect(payloadAt(createMock, 1).verbosity).toBeUndefined()
   })
 
   it('drops stale unsupported params for non-reasoning models before dispatch', async () => {
@@ -73,7 +80,7 @@ describe('OpenAILLMClient request shaping', () => {
     expect(response.content).toBe('ok')
     expect(createMock).toHaveBeenCalledTimes(1)
 
-    const outboundPayload = createMock.mock.calls[0][0]
+    const outboundPayload = payloadAt(createMock, 0)
     expect(outboundPayload.reasoning_effort).toBeUndefined()
     expect(outboundPayload.__unknown__).toBeUndefined()
     expect(outboundPayload.temperature).toBe(0.25)

--- a/packages/lib/src/ai/providers/openai/__tests__/openai-model-restrictions.test.ts
+++ b/packages/lib/src/ai/providers/openai/__tests__/openai-model-restrictions.test.ts
@@ -10,6 +10,15 @@ const OPENAI_LLM_MODELS = Object.entries(OPENAI_MODELS).filter(
   ([_, capabilities]) => capabilities.modelType === ModelType.LLM
 )
 
+/** Registry lookup that fails loudly instead of yielding `undefined`. */
+function modelCaps(modelId: string) {
+  const capabilities = OPENAI_MODELS[modelId]
+  if (!capabilities) {
+    throw new Error(`Missing model capabilities for ${modelId}`)
+  }
+  return capabilities
+}
+
 /** Returns the strict allowlist of parameter names for a model. */
 function getAllowedParameterNames(modelId: string): Set<string> {
   const capabilities = OPENAI_MODELS[modelId]
@@ -227,7 +236,7 @@ describe('OpenAI model restrictions', () => {
   })
 
   it('GPT-5.4-pro has structured: false and restricted reasoning levels', () => {
-    const pro = OPENAI_MODELS['gpt-5.4-pro']
+    const pro = modelCaps('gpt-5.4-pro')
     expect(pro.supports.structured).toBe(false)
 
     // Only medium/high/xhigh — no none or low
@@ -236,7 +245,7 @@ describe('OpenAI model restrictions', () => {
   })
 
   it('GPT-5.3-codex has no none reasoning level', () => {
-    const codex = OPENAI_MODELS['gpt-5.3-codex']
+    const codex = modelCaps('gpt-5.3-codex')
     const reasoningRule = codex.parameterRules.find((r) => r.name === 'reasoning_effort')
     expect(reasoningRule?.options).toEqual(['low', 'medium', 'high', 'xhigh'])
     expect(reasoningRule?.options).not.toContain('none')
@@ -263,14 +272,13 @@ describe('OpenAI model restrictions', () => {
   it.each(
     O_SERIES_MODELS
   )('%s has isReasoningModel and max_completion_tokens mapping', (modelId) => {
-    const caps = OPENAI_MODELS[modelId]
-    expect(caps).toBeDefined()
+    const caps = modelCaps(modelId)
     expect(caps.parameterRestrictions?.isReasoningModel).toBe(true)
     expect(caps.parameterRestrictions?.parameterMapping?.max_tokens).toBe('max_completion_tokens')
   })
 
   it.each(O_SERIES_MODELS)('%s strips temperature/top_p via unsupportedParams', (modelId) => {
-    const caps = OPENAI_MODELS[modelId]
+    const caps = modelCaps(modelId)
     expect(caps.parameterRestrictions?.unsupportedParams).toContain('temperature')
     expect(caps.parameterRestrictions?.unsupportedParams).toContain('top_p')
   })
@@ -286,31 +294,30 @@ describe('OpenAI model restrictions', () => {
   // ── Deprecated models ──────────────────────────────────────────
 
   it.each(DEPRECATED_MODELS)('%s is marked as deprecated or retired', (modelId) => {
-    const caps = OPENAI_MODELS[modelId]
-    expect(caps).toBeDefined()
+    const caps = modelCaps(modelId)
     expect(caps.deprecated === true || caps.retired === true).toBe(true)
   })
 
   // ── GPT-5.4 pricing ────────────────────────────────────────────
 
   it('GPT-5.4 models have correct pricing', () => {
-    expect(OPENAI_MODELS['gpt-5.4'].costPer1kTokens).toEqual({
+    expect(modelCaps('gpt-5.4').costPer1kTokens).toEqual({
       input: 0.0025,
       output: 0.015,
       cachedInput: 0.00025,
       longContext: [{ over: 272000, input: 0.005, output: 0.0225, cachedInput: 0.0005 }],
     })
-    expect(OPENAI_MODELS['gpt-5.4-mini'].costPer1kTokens).toEqual({
+    expect(modelCaps('gpt-5.4-mini').costPer1kTokens).toEqual({
       input: 0.00075,
       output: 0.0045,
       cachedInput: 0.000075,
     })
-    expect(OPENAI_MODELS['gpt-5.4-nano'].costPer1kTokens).toEqual({
+    expect(modelCaps('gpt-5.4-nano').costPer1kTokens).toEqual({
       input: 0.0002,
       output: 0.00125,
       cachedInput: 0.00002,
     })
-    expect(OPENAI_MODELS['gpt-5.4-pro'].costPer1kTokens).toEqual({
+    expect(modelCaps('gpt-5.4-pro').costPer1kTokens).toEqual({
       input: 0.03,
       output: 0.18,
       longContext: [{ over: 272000, input: 0.06, output: 0.27 }],

--- a/packages/lib/src/ai/providers/openai/openai-llm-client.ts
+++ b/packages/lib/src/ai/providers/openai/openai-llm-client.ts
@@ -117,7 +117,10 @@ export class OpenAILLMClient extends LLMClient {
       // Spread order matters: restParams may contain response_format from handleResponseFormat,
       // so it must come AFTER parameters to avoid model defaults overwriting structured output config
       const { parameters, ...restParams } = processedParams
-      const flattenedParams = {
+      // Untyped on purpose: this is the outbound wire payload, assembled from
+      // provider-neutral params and then pruned of keys the Chat Completions
+      // API rejects (see the deletes below).
+      const flattenedParams: Record<string, any> = {
         ...parameters, // Spread parameters (model defaults) first
         ...restParams, // Then overlay rest (includes response_format from handleResponseFormat)
         stream: true,
@@ -158,8 +161,13 @@ export class OpenAILLMClient extends LLMClient {
             : flattenedParams.response_format,
       })
 
+      // The cast picks the SDK's *streaming* `create` overload. Without it the
+      // payload's `Record<string, any>` type resolves to the non-streaming
+      // overload and the awaited value is typed `ChatCompletion` — not iterable.
       const stream = await this.createWithReasoningFallback(flattenedParams, (payload) =>
-        this.apiClient.chat.completions.create(payload as any)
+        this.apiClient.chat.completions.create(
+          payload as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
+        )
       )
 
       for await (const chunk of stream) {
@@ -170,9 +178,9 @@ export class OpenAILLMClient extends LLMClient {
           if (finished) continue
         }
 
-        if (chunk.choices.length === 0) continue
-
         const delta = chunk.choices[0]
+        if (!delta) continue
+
         const typedDelta = delta.delta as ReasoningDelta
         const deltaContent = typedDelta.content || ''
         const deltaReasoningContent = typedDelta.reasoning_content || ''
@@ -236,7 +244,9 @@ export class OpenAILLMClient extends LLMClient {
           model: chunk.model,
           content: deltaContent,
           delta: deltaContent,
-          finishReason: finishReason,
+          // OpenAI sends `null` on every non-terminal chunk; the neutral chunk
+          // type uses absence for "not finished".
+          finishReason: finishReason ?? undefined,
           toolCalls: finishReason ? toolCalls : [],
           usage: finishReason ? finalUsage : undefined,
           reasoning_delta: deltaReasoningContent || undefined,
@@ -279,7 +289,6 @@ export class OpenAILLMClient extends LLMClient {
         model: params.model,
         content: '',
         delta: '',
-        finishReason: null,
         toolCalls: undefined,
         usage: finalUsage,
         metadata: {
@@ -308,7 +317,8 @@ export class OpenAILLMClient extends LLMClient {
     // Spread order matters: restParams may contain response_format from handleResponseFormat,
     // so it must come AFTER parameters to avoid model defaults overwriting structured output config
     const { parameters, ...restParams } = params
-    const flattenedParams = {
+    // Untyped on purpose — see the note in streamInvoke.
+    const flattenedParams: Record<string, any> = {
       ...parameters, // Spread parameters (model defaults) first
       ...restParams, // Then overlay rest (includes response_format from handleResponseFormat)
     }
@@ -343,7 +353,9 @@ export class OpenAILLMClient extends LLMClient {
     })
 
     const completion = await this.createWithReasoningFallback(flattenedParams, (payload) =>
-      this.apiClient.chat.completions.create(payload as any)
+      this.apiClient.chat.completions.create(
+        payload as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming
+      )
     )
 
     // Check for refusal (OpenAI structured outputs feature)
@@ -692,7 +704,8 @@ export class OpenAILLMClient extends LLMClient {
 
   getBaseModel(model: string): string {
     if (model.startsWith('ft:')) {
-      return model.split(':')[1]
+      // ft:<base-model>:<org>::<id> — fall back to the raw id if it's malformed.
+      return model.split(':')[1] || model
     }
     return model
   }
@@ -812,11 +825,22 @@ export class OpenAILLMClient extends LLMClient {
     }
   }
 
+  /**
+   * Rewrite multi-modal message content into OpenAI Chat Completions wire parts
+   * (`text` / `image_url` / `file`).
+   *
+   * The result is no longer provider-neutral: `content` now holds SDK payload
+   * objects, not `MultiModalContent`. It is still typed `Message[]` because the
+   * remaining pipeline steps (`clearIllegalPromptMessages`,
+   * `prepareReasoningContent`) only read `role` and `reasoning_content` and pass
+   * `content` through untouched, and the list goes straight onto the request
+   * body from there.
+   */
   private async processMultiModalContentInternal(messages: Message[]): Promise<Message[]> {
     // Process multi-modal content for OpenAI format
     return messages.map((message) => {
       if (Array.isArray(message.content)) {
-        const openAIContent = message.content.map((item) => {
+        const openAIContent: unknown[] = message.content.map((item) => {
           switch (item.type) {
             case 'text':
               return { type: 'text', text: item.data }
@@ -844,7 +868,7 @@ export class OpenAILLMClient extends LLMClient {
           }
         })
 
-        return { ...message, content: openAIContent }
+        return { ...message, content: openAIContent as MultiModalContent[] }
       }
 
       return message

--- a/packages/lib/src/ai/providers/openai/openai-moderation-client.ts
+++ b/packages/lib/src/ai/providers/openai/openai-moderation-client.ts
@@ -81,7 +81,7 @@ export class OpenAIModerationClient extends ModerationClient {
     }
   }
 
-  private normalizeCategories(categories: Record<string, boolean>): Record<string, boolean> {
+  protected normalizeCategories(categories: Record<string, boolean>): Record<string, boolean> {
     // OpenAI categories are already in the correct format
     return categories
   }
@@ -224,6 +224,11 @@ export class OpenAIModerationClient extends ModerationClient {
 
     return texts.map((text, index) => {
       const result = response.results[index]
+      if (!result) {
+        throw new Error(
+          `OpenAI moderation returned ${response.results.length} results for ${texts.length} inputs`
+        )
+      }
       const customCategories = this.applyCustomThresholds(
         result.category_scores,
         categoryThresholds

--- a/packages/lib/src/ai/providers/openai/openai-speech2text-client.ts
+++ b/packages/lib/src/ai/providers/openai/openai-speech2text-client.ts
@@ -88,7 +88,9 @@ export class OpenAISpeech2TextClient extends Speech2TextClient {
       // rather than hardcoding mp3.
       const resolvedType = mimeType || 'audio/webm'
       const resolvedName = filename || `audio.${this.extensionForMime(resolvedType)}`
-      return new File([audio], resolvedName, { type: resolvedType })
+      // Node's Buffer is typed `Uint8Array<ArrayBufferLike>`, which `BlobPart`
+      // rejects (it only admits ArrayBuffer-backed views). Re-view the bytes.
+      return new File([new Uint8Array(audio)], resolvedName, { type: resolvedType })
     } else {
       // Assume it's a file path - this would need proper file handling in real implementation
       throw new Error('File path audio input not supported in this implementation')

--- a/packages/lib/src/ai/providers/openai/openai-tts-client.ts
+++ b/packages/lib/src/ai/providers/openai/openai-tts-client.ts
@@ -196,9 +196,8 @@ export class OpenAITTSClient extends TTSClient {
       'tts-1-hd': 0.03,
     }
 
-    const pricePerK = pricing[model] || pricing['tts-1']
+    const costPer1K = pricing[model] ?? 0.015 // tts-1 rate as the fallback
     const characters = text.length
-    const costPer1K = pricePerK
 
     return (characters / 1000) * costPer1K
   }

--- a/packages/lib/src/ai/providers/provider-registry.ts
+++ b/packages/lib/src/ai/providers/provider-registry.ts
@@ -2,7 +2,7 @@
 
 import { createScopedLogger } from '../../logger'
 import { ANTHROPIC_CAPABILITIES, ANTHROPIC_MODELS } from './anthropic/anthropic-defaults'
-import type { ProviderClient } from './base/provider-client'
+import type { ProviderClient, ProviderClientConstructor } from './base/provider-client'
 import { ProviderError } from './base/types'
 import { DEEPSEEK_CAPABILITIES, DEEPSEEK_MODELS } from './deepseek/deepseek-defaults'
 import { GOOGLE_CAPABILITIES, GOOGLE_MODELS } from './google/google-defaults'
@@ -47,11 +47,16 @@ export const providerPositions: string[] = [
 
 export interface ProviderRegistration {
   // Static metadata (from ModelRegistry)
-  capabilities: ProviderCapabilities
+  /**
+   * Undefined for a provider that has a client but no entry in
+   * `staticProviders`; `getProviderCapabilities` then falls back to asking the
+   * client instance itself.
+   */
+  capabilities?: ProviderCapabilities
   models: Record<string, ModelCapabilities>
 
   // Dynamic factory info (from ProviderFactory)
-  clientClass?: typeof ProviderClient
+  clientClass?: ProviderClientConstructor
   isRegistered: boolean
   lastValidated?: Date
 }
@@ -191,7 +196,7 @@ export class ProviderRegistry {
    */
   private static async loadClientClass(
     definition: ProviderDefinition
-  ): Promise<typeof ProviderClient | undefined> {
+  ): Promise<ProviderClientConstructor | undefined> {
     if (!ProviderRegistry.isServerEnvironment()) {
       logger.debug('Skipping provider load outside Node server', { providerId: definition.id })
       return undefined
@@ -289,9 +294,9 @@ export class ProviderRegistry {
   }
 
   static getAllModelsForProvider(provider: string): string[] {
-    return Object.keys(ProviderRegistry.models).filter(
-      (model) => ProviderRegistry.models[model].provider === provider
-    )
+    return Object.entries(ProviderRegistry.models)
+      .filter(([, capabilities]) => capabilities.provider === provider)
+      .map(([model]) => model)
   }
 
   static getAllModels(): Record<string, ModelCapabilities> {
@@ -320,15 +325,14 @@ export class ProviderRegistry {
   static getModelOptionsForProvider(
     provider: string
   ): Array<{ label: string; value: string; icon?: string; color?: string }> {
-    return ProviderRegistry.getAllModelsForProvider(provider).map((model) => {
-      const capabilities = ProviderRegistry.models[model]
-      return {
+    return Object.entries(ProviderRegistry.models)
+      .filter(([, capabilities]) => capabilities.provider === provider)
+      .map(([model, capabilities]) => ({
         label: capabilities.displayName,
         value: model,
         icon: capabilities.icon,
         color: capabilities.color,
-      }
-    })
+      }))
   }
 
   // ===== PROVIDER REGISTRY METHODS =====
@@ -431,10 +435,8 @@ export class ProviderRegistry {
     if (typeof window !== 'undefined' || !ProviderRegistry.isServerEnvironment()) {
       return providerId in ProviderRegistry.staticProviders
     }
-    return (
-      ProviderRegistry.providers[providerId]?.isRegistered &&
-      !!ProviderRegistry.providers[providerId]?.clientClass
-    )
+    const registration = ProviderRegistry.providers[providerId]
+    return !!registration?.isRegistered && !!registration.clientClass
   }
 
   static async getAllProviderCapabilities(): Promise<Record<string, ProviderCapabilities>> {
@@ -511,7 +513,7 @@ export class ProviderRegistry {
 
   // ===== ADDITIONAL UTILITY METHODS =====
 
-  static async register(providerId: string, clientClass: typeof ProviderClient): Promise<void> {
+  static async register(providerId: string, clientClass: ProviderClientConstructor): Promise<void> {
     await ProviderRegistry.initialize()
 
     if (ProviderRegistry.providers[providerId]) {
@@ -519,7 +521,7 @@ export class ProviderRegistry {
     }
 
     const registration: ProviderRegistration = {
-      capabilities: ProviderRegistry.staticProviders[providerId] || ({} as ProviderCapabilities),
+      capabilities: ProviderRegistry.staticProviders[providerId],
       models: ProviderRegistry.getModelsForProvider(providerId),
       clientClass,
       isRegistered: true,

--- a/packages/lib/src/ai/providers/qwen/qwen-llm-client.ts
+++ b/packages/lib/src/ai/providers/qwen/qwen-llm-client.ts
@@ -4,6 +4,21 @@ import type { Message } from '../../clients/base/types'
 import { OpenAILLMClient } from '../openai/openai-llm-client'
 
 /**
+ * Index of the last assistant message carrying `reasoning_content`, or -1.
+ *
+ * A manual reverse scan rather than `Array.prototype.findLastIndex` — the
+ * package compiles against the shared `target: ES2022` lib, which does not
+ * declare the ES2023 array methods.
+ */
+function findLastAssistantWithReasoningIndex(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message?.role === 'assistant' && message.reasoning_content) return i
+  }
+  return -1
+}
+
+/**
  * Qwen LLM client that extends OpenAI's client.
  *
  * Qwen's DashScope API is OpenAI-compatible. The Qwen 3.6/3.7 models support a
@@ -30,9 +45,7 @@ export class QwenLLMClient extends OpenAILLMClient {
   }
 
   protected override prepareReasoningContent(messages: Message[]): Message[] {
-    const lastAssistantWithReasoningIdx = messages.findLastIndex(
-      (m) => m.role === 'assistant' && m.reasoning_content
-    )
+    const lastAssistantWithReasoningIdx = findLastAssistantWithReasoningIndex(messages)
 
     if (lastAssistantWithReasoningIdx === -1) return messages
 

--- a/packages/lib/src/ai/providers/utility-model.ts
+++ b/packages/lib/src/ai/providers/utility-model.ts
@@ -60,6 +60,7 @@ export function resolveUtilityModel(primary: ResolvedModel): ResolvedModel {
   )
 
   const cheapest = candidates[0]
+  if (!cheapest) return primary
   // Primary is already at/below the cheapest sibling → keep it.
   if (blendedCostPer1kTokens(cheapest.caps.costPer1kTokens!) >= primaryBlended) return primary
   return { provider: primary.provider, model: cheapest.id }

--- a/packages/lib/src/ai/providers/zai/zai-llm-client.ts
+++ b/packages/lib/src/ai/providers/zai/zai-llm-client.ts
@@ -4,6 +4,21 @@ import type { Message } from '../../clients/base/types'
 import { OpenAILLMClient } from '../openai/openai-llm-client'
 
 /**
+ * Index of the last assistant message carrying `reasoning_content`, or -1.
+ *
+ * A manual reverse scan rather than `Array.prototype.findLastIndex` — the
+ * package compiles against the shared `target: ES2022` lib, which does not
+ * declare the ES2023 array methods.
+ */
+function findLastAssistantWithReasoningIndex(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message?.role === 'assistant' && message.reasoning_content) return i
+  }
+  return -1
+}
+
+/**
  * Z.AI (GLM) LLM client that extends OpenAI's client.
  *
  * Z.AI's API is OpenAI-compatible. GLM models have thinking enabled by default and
@@ -27,9 +42,7 @@ export class ZaiLLMClient extends OpenAILLMClient {
   }
 
   protected override prepareReasoningContent(messages: Message[]): Message[] {
-    const lastAssistantWithReasoningIdx = messages.findLastIndex(
-      (m) => m.role === 'assistant' && m.reasoning_content
-    )
+    const lastAssistantWithReasoningIdx = findLastAssistantWithReasoningIndex(messages)
 
     if (lastAssistantWithReasoningIdx === -1) return messages
 

--- a/packages/lib/src/result.ts
+++ b/packages/lib/src/result.ts
@@ -11,7 +11,14 @@ export class Ok<V> {
     return this.value
   }
 
-  public get ok(): boolean {
+  /**
+   * Typed as the literal `true` (not `boolean`) on purpose: it is the
+   * discriminant that makes {@link TypedResult} a discriminated union, so
+   * `if (result.ok)` narrows to `Ok<V>` and `result.value` is `V` rather than
+   * `V | undefined`. Widening this back to `boolean` silently un-narrows every
+   * `.value` / `.error` access in the codebase.
+   */
+  public get ok(): true {
     return true
   }
 }
@@ -29,7 +36,8 @@ export class ErrorResult<E extends Error> {
     throw this.error
   }
 
-  public get ok(): boolean {
+  /** Literal `false` — see {@link Ok.ok}. */
+  public get ok(): false {
     return false
   }
 }


### PR DESCRIPTION
`lib` **1930 → 1453**. `src/ai/kopilot` **263 → 0**, `src/ai/providers` **173 → 0**.

The three ungated apps fell without being touched — the leverage argument made concrete again:

| | before | after | |
|---|---|---|---|
| `packages/lib` | 1 930 | **1 453** | −477 |
| `apps/web` (ratchet) | 2 375 | **2 207** | −168 |
| `apps/worker` | 1 101 | **952** | −149 |
| `apps/api` | 909 | **765** | −144 |
| `apps/kb` | 859 | **761** | −98 |

Both ratchets report **no new type errors**. Suppressors (TS2307/TS2305/TS6305) stay at 0 in lib.

## Two thirds of kopilot was one shape

93 errors were reads of `success`/`error`/`output` off an unnarrowed `AgentToolResult | AsyncGenerator<ToolProgressPayload, AgentToolResult, void>` — `execute()`'s return type — and 35 more were `AgentDeps` literals passed where the parameter is `ToolContext` (a strict superset adding `db` + `context`). Grouping the raw `tsc` output by error *message* rather than by path surfaced that up front; one shared helper absorbs both:

`packages/lib/src/ai/agent-framework/__test-helpers.ts` — `createToolContext()`, `createContextManagerMock()`, `runTool()` (drains the streaming branch), `runToolWithProgress()`. Use it for any new tool test.

## Live bugs found and fixed

The two worst were both **TS2367s the compiler had been reporting all along**:

- **`reply_to_thread` was 100% dead.** It gated on `lens !== 'full'`, but since permissions v3 `Lens = Extract<Rung, 'none' | 'metadata' | 'identity' | 'read'>` — `'full'` is not a member, so the comparison was **always true** and every reply/draft returned *"You have restricted visibility on this thread and cannot reply or draft on it."*, for every user including owners.
- **`query_records` never inlined Status/Stage.** `extractKeyFields` read `data[field.systemAttribute ?? field.key]`, but `RecordPickerItem.data` is the raw DB row keyed by `dbColumn`/`key`, never by `systemAttribute`. It contradicted the tool's own `exampleOutput` and forced a follow-up `get_entity` on every query.

Plus:

- **Google embeddings dead on arrival** — `google-client.ts` passed `{ timeout, maxRetries }` as `ClientConfig`; the real shape is `{ retries, circuitBreaker, timeouts }`, and `withRetryAndCircuitBreaker` reads `config.retries.maxAttempts` → `TypeError` on every embedding call.
- **Google multi-text embedding batches always threw** — `batchEmbedContents()` got a bare array where the SDK does `params.requests.map(...)`. Batch size is 100, so any `invoke()` with 2–100 texts crashed; only single-text worked.
- **Anthropic null-content crash** — `convertContentToAnthropicFormat` called `.map()` after only checking `typeof content === 'string'`, but `Message.content` is legitimately `null` for an assistant turn carrying only `tool_calls`.
- **Model ids containing `:` were corrupted** — `config/assemble.ts` grouped on `` `${model}:${modelType}` `` then recovered identity via `key.split(':')`, so `llama3:8b` became `model: 'llama3'`, `modelType: '8b'`.
- **An `as ModelCapabilities` cast hid a malformed object** — required `modelId` omitted entirely and `supports: {}` where six booleans are required, so `supports.streaming` read `undefined` for every custom model.
- **Entity tools re-asserted `args.recordId as string`** in `execute()` instead of validating, so a malformed id reached `parseRecordId`, which `console.error`s and returns `entityInstanceId: ''` — a silent wrong-record read/write.

## `TypedResult` was never a discriminated union

`Ok.ok` / `ErrorResult.ok` were getters typed `boolean`, so `if (result.ok)` narrowed **nothing** and every `.value`/`.error` after it stayed `T | undefined`. Typing them as literal `true`/`false` paid **−41 lib, −40 api, −45 worker** with zero new errors anywhere. Type-only change; getter bodies untouched.

## Smaller correctness items

- `IdentifierTypeValues` was missing `'CHAT_VISITOR'`, which the `identifierType` pgEnum has had all along — the exported type was narrower than every Drizzle-inferred column.
- `EmbeddingParams` gained the `purpose` field that Voyage, Cohere and Google all already read but nothing declared.
- The kopilot chip strip's `KIND_ICONS` was missing the `resource` key. Cosmetic — the read site is `KIND_ICONS[kind] ?? Inbox` — but the `Record<SessionRefKind, …>` type was lying about totality.

## Shapes worth remembering

- **A cascade can masquerade as a missing union arm.** All 30+ `Property 'blockIds' does not exist on type 'ArticlePatch'` came from `const [del] = patches` yielding `ArticlePatch | undefined` under `noUncheckedIndexedAccess`, breaking the `del.op !== 'delete'` discriminant check one step earlier. `ArticlePatch` was complete — widening it would have been the wrong fix.
- **`?? fallback` on an indexed read can be a regression.** In `google-llm-client.ts`, `PARAM_TRANSLATIONS[key] ?? key` looks like the obvious fix, but `null` entries are deliberate drop-markers (`topK`, `thinkingBudget`) and `null ?? key` resurrects them — Gemini then 400s on unknown fields.
- **Spreading a `Partial<T>` hides missing members.** Several all-permissive `CapabilityView` test doubles were missing up to 7 members the interface had grown. The new members now derive from `canViewEntity` so a denied def stays denied across record-level gates.

## Verification

- Both ratchets: **no new type errors**.
- Full 12-project suite: **718 passed / 9 066 tests**, no `Errors` line.
- The 2 failing files are the live-API provider suites — 11 failures, all vendor **402/404**, **zero assertion failures**, in `skipIf(!API_KEY)` files that never run in CI.

## Follow-ups recorded in the handoff, not done here

- **`scripts/generate-client-enums.ts` is now destructive** — 67 of 123 enums have drifted bidirectionally; re-running it would delete `RungValues`, `ResourcePermission`, `SeatType`, `FieldType` and 17 other in-use enums. `enums.ts` is hand-maintained in practice now.
- **`zai-llm-client.ts` / `qwen-llm-client.ts` don't implement their own docstring** — they keep `reasoning_content` on the last assistant message unconditionally, including after the turn closed. That is the payload DeepSeek 400s on, and GLM has thinking on by default. Left deliberately: the file flags the decision as pending real-API evidence.
- `KopilotDomainState` gained `[slice: string]: unknown` — the one type *loosened* this round (A/B-verified as zero new errors, but it costs excess-property checking).