### PR TITLE
feat(demo): block app installs and realign the demo credit pool

### DIFF
--- a/apps/api/src/routes/organizations/apps.ts
+++ b/apps/api/src/routes/organizations/apps.ts
@@ -3,6 +3,7 @@
 import { database } from '@auxx/database'
 import { getAppWithInstallationStatus, getAvailableApps, installApp } from '@auxx/lib/apps'
 import { getCachedAppBySlug, resolveAppSlug } from '@auxx/lib/cache'
+import { DemoGuard } from '@auxx/lib/demo'
 import { getInstalledApps } from '@auxx/services/app-installations'
 import { listDeployments } from '@auxx/services/app-versions'
 import {
@@ -231,6 +232,17 @@ apps.post('/:appSlug/install', requireOrganizationRole(['ADMIN', 'OWNER']), asyn
   const appSlug = c.req.param('appSlug')
   const organizationId = c.get('organizationId')
   const userId = c.get('userId')
+
+  // Demo orgs cannot install apps. Unreachable in practice (demo plans have
+  // `apiAccess: false` and `apiKey.generate` is itself demo-blocked), but the guard is
+  // cheap and this is the only non-tRPC install entry point a token could reach.
+  // Mapped explicitly: `errorMiddleware` has no AuxxError branch, so a thrown
+  // ForbiddenError would surface as a generic 500.
+  try {
+    await DemoGuard.requireNotDemo(organizationId, 'install apps')
+  } catch (error) {
+    return c.json(errorResponse('DEMO_RESTRICTED', (error as Error).message), 403)
+  }
 
   // Parse and validate request body
   const body = await c.req.json()

--- a/apps/web/src/app/api/demo/create-session/route.ts
+++ b/apps/web/src/app/api/demo/create-session/route.ts
@@ -1,9 +1,11 @@
 // apps/web/src/app/api/demo/create-session/route.ts
 
 import { database as db, schema } from '@auxx/database'
+import { ProviderQuotaType } from '@auxx/lib/ai/providers/types'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { DEMO_SESSION_DURATION_MS, generateDemoEmail, isDemoEnabled } from '@auxx/lib/demo'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
+import { getNumericFeatureLimit } from '@auxx/lib/permissions/types'
 import { RedisRateLimiter } from '@auxx/lib/utils/rate-limiter/redis-rate-limiter'
 import { createScopedLogger } from '@auxx/logger'
 import { count, eq, gt } from 'drizzle-orm'
@@ -147,7 +149,7 @@ export async function POST(request: NextRequest) {
 
     // Find the Demo plan
     const [demoPlan] = await db
-      .select({ id: schema.Plan.id })
+      .select({ id: schema.Plan.id, featureLimits: schema.Plan.featureLimits })
       .from(schema.Plan)
       .where(eq(schema.Plan.name, 'Demo'))
       .limit(1)
@@ -162,6 +164,28 @@ export async function POST(request: NextRequest) {
         seats: 1,
         updatedAt: new Date(),
       })
+
+      // 7b. Realign the AI credit pool to the Demo plan.
+      //
+      // `seedAiProviderQuotas` (auth hook, step 4) writes DEFAULT_QUOTA_LIMITS[TRIAL] —
+      // 20,000 credits — into `OrganizationAiQuota` for EVERY new org, and the only code
+      // that reconciles that row with the plan's `monthlyAiCredits` is the Stripe
+      // `subscription.updated` webhook, which a demo org never receives. The row is keyed
+      // on `Organization.id`, so the subscription swap above does not touch it either.
+      // Without this write a demo session runs on the trial allowance, 4x what the Demo
+      // plan declares.
+      const demoCredits = getNumericFeatureLimit(demoPlan.featureLimits, 'monthlyAiCredits')
+      if (demoCredits != null) {
+        await db
+          .update(schema.OrganizationAiQuota)
+          .set({
+            quotaType: ProviderQuotaType.FREE,
+            quotaLimit: demoCredits,
+            quotaUsed: 0,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.OrganizationAiQuota.organizationId, organizationId))
+      }
     }
 
     // 8. Enqueue async demo data seeding job (customers, tickets, etc.)

--- a/apps/web/src/components/apps/ui/app-install-button.tsx
+++ b/apps/web/src/components/apps/ui/app-install-button.tsx
@@ -14,9 +14,18 @@ import { toastError } from '@auxx/ui/components/toast'
 import { format } from 'date-fns'
 import { Check, ChevronDown, Code, Download } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
+import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
 import { useAnalytics } from '~/hooks/use-analytics'
+import { useDemo } from '~/hooks/use-demo'
 import { api } from '~/trpc/react'
+
+/** Copy for the demo block, shared by both install buttons. */
+const DEMO_BLOCK = {
+  title: 'Not Available in Demo',
+  description: 'Installing apps is not available in demo mode. Sign up to connect your own tools.',
+} as const
 
 /**
  * Props for AppInstallButton component
@@ -46,6 +55,8 @@ export default function AppInstallButton({
   const router = useRouter()
   const utils = api.useUtils()
   const posthog = useAnalytics()
+  const { isDemo } = useDemo()
+  const [demoDialogOpen, setDemoDialogOpen] = useState(false)
 
   // Install mutation
   const install = api.apps.install.useMutation({
@@ -71,6 +82,11 @@ export default function AppInstallButton({
    * Handle install for a specific deployment
    */
   const handleInstall = async (deploymentId: string) => {
+    // Covers the split button and every dropdown entry — both route through here.
+    if (isDemo) {
+      setDemoDialogOpen(true)
+      return
+    }
     await install.mutateAsync({
       appSlug,
       deploymentId,
@@ -180,6 +196,14 @@ export default function AppInstallButton({
           })}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <LimitReachedDialog
+        open={demoDialogOpen}
+        onOpenChange={setDemoDialogOpen}
+        icon={Download}
+        title={DEMO_BLOCK.title}
+        description={DEMO_BLOCK.description}
+      />
     </div>
   )
 }
@@ -197,6 +221,8 @@ type InlineAppInstallButtonProps = {
 export function InlineAppInstallButton({ appSlug, children }: InlineAppInstallButtonProps) {
   const { appInstallations, refreshInstallations } = useAppsContext()
   const posthog = useAnalytics()
+  const { isDemo } = useDemo()
+  const [demoDialogOpen, setDemoDialogOpen] = useState(false)
 
   const isInstalled = appInstallations.some((inst) => inst.app.slug === appSlug)
 
@@ -220,22 +246,36 @@ export function InlineAppInstallButton({ appSlug, children }: InlineAppInstallBu
   }
 
   return (
-    <Button
-      variant='outline'
-      size='sm'
-      className='h-6 text-xs'
-      onClick={(e) => {
-        e.stopPropagation()
-        install.mutate({ appSlug })
-      }}
-      loading={install.isPending}
-      loadingText='Installing...'>
-      {children ?? (
-        <>
-          <Download className='size-3' />
-          Install
-        </>
-      )}
-    </Button>
+    <>
+      <Button
+        variant='outline'
+        size='sm'
+        className='h-6 text-xs'
+        onClick={(e) => {
+          e.stopPropagation()
+          if (isDemo) {
+            setDemoDialogOpen(true)
+            return
+          }
+          install.mutate({ appSlug })
+        }}
+        loading={install.isPending}
+        loadingText='Installing...'>
+        {children ?? (
+          <>
+            <Download className='size-3' />
+            Install
+          </>
+        )}
+      </Button>
+
+      <LimitReachedDialog
+        open={demoDialogOpen}
+        onOpenChange={setDemoDialogOpen}
+        icon={Download}
+        title={DEMO_BLOCK.title}
+        description={DEMO_BLOCK.description}
+      />
+    </>
   )
 }

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -247,6 +247,7 @@ export const appsRouter = createTRPCRouter({
         })
         .merge(installAppRequestSchema)
     )
+    .use(notDemo('install apps'))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
       const { appSlug, type, deploymentId } = input

--- a/packages/lib/src/data-migrations/migrations/066-demo-monthly-ai-credits.test.ts
+++ b/packages/lib/src/data-migrations/migrations/066-demo-monthly-ai-credits.test.ts
@@ -1,0 +1,82 @@
+// packages/lib/src/data-migrations/migrations/066-demo-monthly-ai-credits.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { applyDemoCreditLimit } from './066-demo-monthly-ai-credits'
+
+/**
+ * What matters is that the Demo plan lands on the target allowance whatever it carried
+ * before, that a hand-edited plan missing the key gains it, and that a second pass
+ * reports `changed: false` so the runner does not rewrite the row on every deploy.
+ *
+ * The DB plumbing is deliberately not exercised here (that needs a live Postgres).
+ */
+
+const TARGET = 5_000
+
+/** The Demo plan's stored array as it stood BEFORE this migration. */
+function before(credits: number) {
+  return [
+    { key: 'workflowRunsPerMonthHard', limit: 10 },
+    { key: 'monthlyAiCredits', limit: credits },
+    { key: 'aiCompletionsPerMonthHard', limit: 200 },
+  ]
+}
+
+describe('applyDemoCreditLimit', () => {
+  it('raises the allowance from the old 2,000', () => {
+    const { limits, changed } = applyDemoCreditLimit(before(2_000), TARGET)
+
+    expect(changed).toBe(true)
+    expect(limits).toContainEqual({ key: 'monthlyAiCredits', limit: TARGET })
+  })
+
+  it('appends the key when a hand-edited plan does not carry it', () => {
+    const { limits, changed } = applyDemoCreditLimit(
+      [{ key: 'aiCompletionsPerMonthHard', limit: 200 }],
+      TARGET
+    )
+
+    expect(changed).toBe(true)
+    expect(limits).toContainEqual({ key: 'monthlyAiCredits', limit: TARGET })
+  })
+
+  it('reports no change on a plan already at the target', () => {
+    const { changed } = applyDemoCreditLimit(before(TARGET), TARGET)
+
+    expect(changed).toBe(false)
+  })
+
+  it('preserves every unrelated key and its order', () => {
+    const { limits } = applyDemoCreditLimit(before(2_000), TARGET)
+
+    expect(limits.map((d) => d.key)).toEqual([
+      'workflowRunsPerMonthHard',
+      'monthlyAiCredits',
+      'aiCompletionsPerMonthHard',
+    ])
+    expect(limits).toContainEqual({ key: 'workflowRunsPerMonthHard', limit: 10 })
+    expect(limits).toContainEqual({ key: 'aiCompletionsPerMonthHard', limit: 200 })
+  })
+
+  it('is idempotent — a second pass reports no change', () => {
+    const first = applyDemoCreditLimit(before(2_000), TARGET)
+    const second = applyDemoCreditLimit(first.limits, TARGET)
+
+    expect(first.changed).toBe(true)
+    expect(second.changed).toBe(false)
+    expect(second.limits).toEqual(first.limits)
+  })
+
+  it('never emits the key twice', () => {
+    const { limits } = applyDemoCreditLimit(before(2_000), TARGET)
+
+    expect(limits.filter((d) => d.key === 'monthlyAiCredits')).toHaveLength(1)
+  })
+
+  it('lowers the allowance too — the merge is a set, not a raise-only', () => {
+    const { limits, changed } = applyDemoCreditLimit(before(20_000), TARGET)
+
+    expect(changed).toBe(true)
+    expect(limits).toContainEqual({ key: 'monthlyAiCredits', limit: TARGET })
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/066-demo-monthly-ai-credits.ts
+++ b/packages/lib/src/data-migrations/migrations/066-demo-monthly-ai-credits.ts
@@ -1,0 +1,140 @@
+// packages/lib/src/data-migrations/migrations/066-demo-monthly-ai-credits.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { invalidatePlans, onCacheEvent } from '../../cache/invalidate'
+import type { FeatureDefinition } from '../../permissions/types'
+import { parseFeatureLimits } from '../../permissions/types'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-066')
+
+/** Usage-limit key this migration retunes. */
+const LIMIT_KEY = 'monthlyAiCredits'
+
+/** Target allowance for the Demo plan, matching `USAGE_LIMITS.demo` in the seeder. */
+const DEMO_MONTHLY_AI_CREDITS = 5_000
+
+/** The only plan this migration touches — every other tier keeps its current value. */
+const TARGET_PLAN_NAME = 'Demo'
+
+/**
+ * Set `monthlyAiCredits` on one plan's stored feature array. Returns the array unchanged
+ * with `changed: false` when it already matches, so a second pass rewrites nothing.
+ *
+ * Exported so a test checks the merge rule rather than the JSONB plumbing.
+ */
+export function applyDemoCreditLimit(
+  limitsJson: unknown,
+  limit: number
+): { limits: FeatureDefinition[]; changed: boolean } {
+  const defs = parseFeatureLimits(limitsJson)
+
+  let changed = false
+  let sawLimit = false
+  const limits: FeatureDefinition[] = []
+
+  for (const def of defs) {
+    if (def.key === LIMIT_KEY) {
+      sawLimit = true
+      if (def.limit !== limit) changed = true
+      limits.push({ key: LIMIT_KEY, limit })
+      continue
+    }
+    limits.push(def)
+  }
+
+  // Append rather than assume a slot: a plan edited in the admin panel may be missing
+  // keys entirely (same reasoning as migrations 063/064).
+  if (!sawLimit) {
+    limits.push({ key: LIMIT_KEY, limit })
+    changed = true
+  }
+
+  return { limits, changed }
+}
+
+/**
+ * Retune the Demo plan's `monthlyAiCredits` from 2,000 to 5,000.
+ *
+ * **Why a migration at all.** `Plan.featureLimits` is stored JSONB and the seeder only
+ * rewrites a plan it is re-seeding, so editing `billing.domain.ts` alone leaves every
+ * existing environment on the old number.
+ *
+ * **Why this matters more than the catalog.** Until now the Demo plan's declared
+ * allowance was inert: `OrganizationSeeder.seedAiProviderQuotas` writes
+ * `DEFAULT_QUOTA_LIMITS[TRIAL]` (20,000) into `OrganizationAiQuota` for every new org,
+ * and the only code that reconciles that row against the plan is the Stripe
+ * `subscription.updated` webhook — which a demo org, having no Stripe subscription,
+ * never receives. Demo sessions therefore ran on 20,000 credits (≈ $2 of AI COGS)
+ * while the plan said 2,000. The companion fix in `/api/demo/create-session` now reads
+ * this key when it swaps the trial subscription for the Demo one, which is what makes
+ * the value below actually reach a demo org.
+ *
+ * Raw Drizzle on purpose (project convention): the plan/feature service paths fire
+ * subscription and overage side effects that a catalog fixup has no business entering.
+ * The cache busting those paths would have done is performed explicitly below —
+ * `features` is a PER-ORG key derived from the plan, so `invalidatePlans()` alone would
+ * leave every org serving a stale feature map until its TTL.
+ *
+ * No backfill of live demo orgs: demo sessions last one hour and `demoCleanupJob`
+ * deletes them on expiry, so the population self-drains well inside a deploy cycle.
+ */
+export const migration066DemoMonthlyAiCredits: DataMigrationDef = {
+  id: '066-demo-monthly-ai-credits',
+  description: 'Raise the Demo plan monthlyAiCredits limit to 5,000',
+  async run(db: Database): Promise<void> {
+    const plans = await db
+      .select({
+        id: schema.Plan.id,
+        name: schema.Plan.name,
+        featureLimits: schema.Plan.featureLimits,
+        trialFeatureLimits: schema.Plan.trialFeatureLimits,
+      })
+      .from(schema.Plan)
+      .where(eq(schema.Plan.name, TARGET_PLAN_NAME))
+
+    const plan = plans[0]
+    if (!plan) {
+      logger.info('No Demo plan in this environment — nothing to do')
+      return
+    }
+
+    const features = applyDemoCreditLimit(plan.featureLimits, DEMO_MONTHLY_AI_CREDITS)
+    // `trialFeatureLimits` is nullable and, when present, is a FULL replacement array
+    // read instead of `featureLimits`, so it needs the same treatment.
+    const trial =
+      plan.trialFeatureLimits == null
+        ? { limits: [], changed: false }
+        : applyDemoCreditLimit(plan.trialFeatureLimits, DEMO_MONTHLY_AI_CREDITS)
+
+    if (!features.changed && !trial.changed) {
+      logger.info('Demo plan already carried the target credit limit — nothing to do')
+      return
+    }
+
+    await db
+      .update(schema.Plan)
+      .set({
+        ...(features.changed ? { featureLimits: features.limits } : {}),
+        ...(trial.changed ? { trialFeatureLimits: trial.limits } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.Plan.id, plan.id))
+
+    // The global plan catalog first, then the per-org `features` map derived from it.
+    // `plan.changed` fans out to `features` + `subscription` + `overages`.
+    await invalidatePlans()
+    const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+    for (const org of orgs) {
+      await onCacheEvent('plan.changed', { orgId: org.id })
+    }
+
+    logger.info('Retuned the Demo plan credit allowance', {
+      limit: DEMO_MONTHLY_AI_CREDITS,
+      orgs: orgs.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -32,6 +32,7 @@ import { migration061InboxesMemberBaselineBackfill } from './migrations/061-inbo
 import { migration063RetireMailPermissionsFeatureKey } from './migrations/063-retire-mail-permissions-feature-key'
 import { migration064SequencesLimit } from './migrations/064-sequences-limit'
 import { migration065DashboardsAllPlans } from './migrations/065-dashboards-all-plans'
+import { migration066DemoMonthlyAiCredits } from './migrations/066-demo-monthly-ai-credits'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -86,6 +87,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration063RetireMailPermissionsFeatureKey,
     migration064SequencesLimit,
     migration065DashboardsAllPlans,
+    migration066DemoMonthlyAiCredits,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -266,7 +266,7 @@ const USAGE_LIMITS = {
     outboundEmailsPerMonthSoft: 0,
     workflowRunsPerMonthHard: 10,
     workflowRunsPerMonthSoft: 8,
-    monthlyAiCredits: 2_000,
+    monthlyAiCredits: 5_000,
     aiCompletionsPerMonthHard: 200,
     aiCompletionsPerMonthSoft: 160,
     aiTranscriptionsPerMonthHard: 50,
@@ -358,8 +358,13 @@ const USAGE_LIMITS = {
 
 /**
  * Trial credit override: trial users get 20,000 credits (≈ $2 of AI COGS)
- * regardless of which plan they are trialing. Read in the quota-service when a
- * trial starts.
+ * regardless of which plan they are trialing.
+ *
+ * NOTE: both constants are currently UNREFERENCED. The value that actually lands on a
+ * new org is `DEFAULT_QUOTA_LIMITS[ProviderQuotaType.TRIAL]`
+ * (packages/lib/src/ai/providers/types.ts), written unconditionally by
+ * `OrganizationSeeder.seedAiProviderQuotas`. `QuotaService` has no trial method — change
+ * that constant, not this one, until the two are reconciled.
  */
 export const TRIAL_MONTHLY_AI_CREDITS = 20_000
 export const TRIAL_AI_COMPLETIONS_HARD = 2000


### PR DESCRIPTION
## Summary

Two demo-mode gaps, found while checking why the demo workspace could install apps.

**1. Demo orgs could install apps.** `apps.install` was missing the `notDemo` middleware that `apps.uninstall` already carried, so the marketplace was fully live in a demo session.

**2. Demo sessions ran on 20,000 AI credits while the Demo plan declared 2,000.** `OrganizationSeeder.seedAiProviderQuotas` writes `DEFAULT_QUOTA_LIMITS[TRIAL]` (20,000) into `OrganizationAiQuota` for *every* new org, and the only code that reconciles that row against the plan's `monthlyAiCredits` is the Stripe `subscription.updated` webhook — which a demo org, having no Stripe subscription, never receives. The row is keyed on `Organization.id`, so the subscription swap in `/api/demo/create-session` didn't touch it either. The plan's declared allowance was effectively inert.

## Changes

### Blocking installs

| File | Change |
| --- | --- |
| `apps/web/src/server/api/routers/apps.ts` | `.use(notDemo('install apps'))` on `install`, matching `uninstall` |
| `apps/web/src/components/apps/ui/app-install-button.tsx` | both buttons intercept before the mutation and open `LimitReachedDialog` (already swaps its CTA to "Sign Up" when `isDemo`) |
| `apps/api/src/routes/organizations/apps.ts` | `DemoGuard.requireNotDemo` on the REST install |

The `AppInstallButton` intercept sits in `handleInstall`, so the split button **and** every deployment dropdown entry are covered. `InlineAppInstallButton` (QuickBooks settings, workflow-template dialog) got the same treatment.

The REST guard is mapped explicitly to 403 rather than thrown: apps/api's `errorMiddleware` has no `AuxxError` branch, so a bare throw would surface as a generic 500.

The developer-portal (`apps/build`) and CLI-deploy install paths are deliberately left alone — neither is reachable from a demo session (`devTools: false`, and both need an app you own).

### Credits: 20k → 5k

| File | Change |
| --- | --- |
| `packages/seed/src/domains/billing.domain.ts` | `USAGE_LIMITS.demo.monthlyAiCredits` `2_000` → `5_000` |
| `packages/lib/src/data-migrations/migrations/066-demo-monthly-ai-credits.ts` | applies it to the live `Plan` row |
| `apps/web/src/app/api/demo/create-session/route.ts` | realigns `OrganizationAiQuota` to the plan after swapping the subscription |

The migration is needed because `Plan.featureLimits` is stored JSONB and the seeder only rewrites a plan it is re-seeding — editing `billing.domain.ts` alone changes nothing in an existing environment. It handles `trialFeatureLimits`, appends the key if a hand-edited plan lacks it, is idempotent, and busts `plan.changed` per-org so the derived `features` map doesn't serve stale until TTL.

The route change is what makes the declared value actually reach a demo session: it reads `monthlyAiCredits` via `getNumericFeatureLimit` (not a hardcoded number, so the plan stays the single source of truth) and sets `quotaType` to `FREE` — a demo org isn't trialing a paid plan. Nothing branches on `quotaType`; the badge takes the prop and ignores it.

### Doc fix

`TRIAL_MONTHLY_AI_CREDITS` claimed to be "read in the quota-service when a trial starts". It's unreferenced dead code, and `QuotaService` has no trial method — the real trial number is the duplicate literal in `DEFAULT_QUOTA_LIMITS` in a different package. Docstring now says so. Constant left in place.

## Not done, deliberately

- **No backfill of live demo orgs.** Sessions last one hour and `demoCleanupJob` deletes them on expiry, so the 20k population self-drains inside a deploy cycle.
- **`seedAiProviderQuotas` is still not plan-aware.** That's the root fix, but it would also change what *trial* orgs get (currently 20k) — a separate pricing decision, worth its own change.

## Testing

- 7 new tests on the migration's merge rule (raise, lower, append-when-missing, idempotence, key-order preservation, no-duplicate-key), passing alongside the existing `data-migrations.test.ts` — 17 total.
- Biome clean on all 8 files.
- `tsc --noEmit` on `packages/lib`, `packages/seed`, `apps/web`, `apps/api`: no errors in any touched file. (The pre-existing repo-wide baselines are broken; the one hit in the demo route — `route.ts:83`, `auth.api.signUpEmail` overload — is pre-existing better-auth `additionalFields` typing, unrelated to this diff.)
