### PR TITLE
fix(kopilot): repair field chips, page context, and wire ordering

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -945,8 +945,16 @@ async function runInProcessPath(params: {
     engine.interrupt()
   })
 
-  // Build session context from request
-  const sessionContext = { page, ...context }
+  // Build session context from request.
+  //
+  // `page` LAST, deliberately: it is the server's `resolvedPage`, which is what
+  // the toolset was actually resolved from (see the `registry.getTools` call and
+  // the tool-deps `sessionContext` above, which already order it this way). The
+  // client also sends its surface page inside `context`, and on the DM path
+  // `resolvedPage` is forced to `agents.dm` — so letting `context.page` win here
+  // told the model it was on one page while it held another page's tools, and it
+  // then reported the missing tools to the user as a broken connection.
+  const sessionContext = { ...context, page }
 
   // Run the engine
   const generator =

--- a/apps/web/src/components/evals/ui/eval-tool-responses.tsx
+++ b/apps/web/src/components/evals/ui/eval-tool-responses.tsx
@@ -33,8 +33,15 @@ import { ToolSelect } from './tool-select'
  * seeded from the current live value, and Reset to default drops the literal
  * again. Tools without an example seed from a client-side JSON-Schema scaffold
  * (`scaffoldFromJsonSchema` over `outputsJsonSchema`). Literal output validates
- * against the server's Zod `outputSchema` on edit. One `repeat` response per
- * tool in v1 (arg-matched multi-response is a follow-up).
+ * against the server's Zod `outputSchema` on edit.
+ *
+ * A tool may carry SEVERAL responses, each with an optional `args` matcher
+ * (`subset`, where the configured keys must be present and deep-equal, or
+ * `exact`). Stored order is match order: the resolver returns the first whose
+ * matcher accepts the call, so a matcher-less response shadows everything after
+ * it (flagged inline). Without this, a tool could only be pinned to one frozen
+ * output for every call, which is why "order 1234 → found, 9999 → not found"
+ * previously had to be authored through Kopilot's `update_eval_case_mock`.
  *
  * `control` tools never reach the catalog; `system` (platform read) toolsets
  * sort to the bottom and collapse by default. See
@@ -42,6 +49,18 @@ import { ToolSelect } from './tool-select'
  */
 
 type ToolEntry = ToolCatalogEntry
+
+/**
+ * Does this response fire for every call to its tool?
+ *
+ * Not just "has no `args`": an `args` matcher whose `value` is `{}` is ALSO a
+ * catch-all, because `argsMatch` runs `Object.entries(value).every(...)`, and
+ * over no entries that is vacuously true, for `subset` and `exact` alike. Both
+ * shapes shadow every response beneath them, so both have to count.
+ */
+function isCatchAll(mock: SimulationToolMock): boolean {
+  return !mock.args || Object.keys(mock.args.value).length === 0
+}
 
 /**
  * Tool names referenced by `tool:<name>` chips anywhere in a procedure's draft.
@@ -124,15 +143,20 @@ export function EvalToolResponses({ agentId, target, mocks, onChange }: EvalTool
   // runtime will return.
   const isDefault = (tool: ToolEntry) => !hasMock(tool.name) && tool.exampleOutput !== undefined
 
-  const upsert = (toolName: string, output: unknown) => {
-    const existing = mocks.find((m) => m.toolName === toolName)
-    if (existing) {
-      onChange(mocks.map((m) => (m.toolName === toolName ? { ...m, output } : m)))
-    } else {
-      onChange([...mocks, { id: generateId('mock'), toolName, output, usage: 'repeat' }])
-    }
+  const mocksFor = (toolName: string) => mocks.filter((m) => m.toolName === toolName)
+
+  /** Append a new response for a tool. Stored order IS match order. */
+  const addMock = (toolName: string, output: unknown, args?: SimulationToolMock['args']) => {
+    onChange([
+      ...mocks,
+      { id: generateId('mock'), toolName, output, usage: 'repeat', ...(args ? { args } : {}) },
+    ])
   }
-  const remove = (toolName: string) => onChange(mocks.filter((m) => m.toolName !== toolName))
+  const patchMock = (mockId: string, patch: Partial<SimulationToolMock>) => {
+    onChange(mocks.map((m) => (m.id === mockId ? { ...m, ...patch } : m)))
+  }
+  const removeMock = (mockId: string) => onChange(mocks.filter((m) => m.id !== mockId))
+  const removeAllFor = (toolName: string) => onChange(mocks.filter((m) => m.toolName !== toolName))
 
   // Default: open the first non-system (capability) group; system groups and the
   // "Other" bucket stay collapsed until the user expands them.
@@ -186,11 +210,13 @@ export function EvalToolResponses({ agentId, target, mocks, onChange }: EvalTool
       key={tool.name}
       agentId={agentId}
       tool={tool}
-      mock={mocks.find((m) => m.toolName === tool.name) ?? null}
+      mocks={mocksFor(tool.name)}
       isOpen={openTool === tool.name}
       onToggle={() => setOpenTool((t) => (t === tool.name ? null : tool.name))}
-      onUpsert={(output) => upsert(tool.name, output)}
-      onRemove={() => remove(tool.name)}
+      onAdd={(output, args) => addMock(tool.name, output, args)}
+      onPatch={patchMock}
+      onRemoveMock={removeMock}
+      onRemoveAll={() => removeAllFor(tool.name)}
     />
   )
 
@@ -214,7 +240,7 @@ export function EvalToolResponses({ agentId, target, mocks, onChange }: EvalTool
         <EmptySection
           icon={<Wrench className='size-4' />}
           title={isLoading ? 'Loading tools…' : 'No tools to mock'}
-          description={isLoading ? undefined : 'This agent has no tools — add one to mock it.'}
+          description={isLoading ? undefined : 'This agent has no tools. Add one to mock it.'}
           loading={isLoading}
         />
       ) : (
@@ -300,28 +326,27 @@ function ToolGroupRow({
 interface ToolResponseRowProps {
   agentId: string
   tool: ToolEntry
-  mock: SimulationToolMock | null
+  /** Every response authored for this tool, in stored (= match) order. */
+  mocks: SimulationToolMock[]
   isOpen: boolean
   onToggle: () => void
-  onUpsert: (output: unknown) => void
-  onRemove: () => void
+  onAdd: (output: unknown, args?: SimulationToolMock['args']) => void
+  onPatch: (mockId: string, patch: Partial<SimulationToolMock>) => void
+  onRemoveMock: (mockId: string) => void
+  onRemoveAll: () => void
 }
 
 function ToolResponseRow({
   agentId,
   tool,
-  mock,
+  mocks,
   isOpen,
   onToggle,
-  onUpsert,
-  onRemove,
+  onAdd,
+  onPatch,
+  onRemoveMock,
+  onRemoveAll,
 }: ToolResponseRowProps) {
-  const utils = api.useUtils()
-  const [draft, setDraft] = useState(() => (mock ? JSON.stringify(mock.output, null, 2) : ''))
-  const [parseError, setParseError] = useState<string | null>(null)
-  const [validation, setValidation] = useState<{ error?: string; warning?: string } | null>(null)
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
   const hasExample = tool.exampleOutput !== undefined
   // Empty-but-correctly-shaped seed, derived at render time from the entry's
   // JSON Schema — never stored. Tools without a schema author freely.
@@ -331,7 +356,171 @@ function ToolResponseRow({
   )
   const seedScaffold = scaffold !== undefined && scaffold !== null
   // No literal mock + a declared example ⇒ the runtime serves the live default.
-  const onDefault = !mock && hasExample
+  const onDefault = mocks.length === 0 && hasExample
+
+  const seedValue = hasExample ? tool.exampleOutput : seedScaffold ? scaffold : {}
+
+  const status =
+    mocks.length > 0
+      ? hasExample
+        ? `override${mocks.length > 1 ? ` · ${mocks.length}` : ''}`
+        : `mocked${mocks.length > 1 ? ` · ${mocks.length}` : ''}`
+      : hasExample
+        ? 'default'
+        : 'no response'
+
+  return (
+    <TreeRow
+      depth={1}
+      icon={<span className='size-1.5 rounded-full bg-muted-foreground/40' />}
+      title={tool.displayName}
+      secondary={
+        <span className='flex items-center gap-1.5 text-xs'>
+          <span
+            className={cn(
+              mocks.length > 0
+                ? 'text-green-600'
+                : hasExample
+                  ? 'text-blue-600'
+                  : 'text-muted-foreground'
+            )}>
+            {status}
+          </span>
+          {tool.idempotent ? <span className='text-muted-foreground/70'>· read-only</span> : null}
+        </span>
+      }
+      expandable
+      isOpen={isOpen}
+      onToggleOpen={onToggle}
+      actions={
+        mocks.length > 0 ? (
+          <TreeRowButton
+            variant='destructive'
+            tooltipText={hasExample ? 'Reset to default' : 'Clear responses'}
+            onClick={onRemoveAll}>
+            <Trash2 />
+          </TreeRowButton>
+        ) : undefined
+      }>
+      <div className='space-y-2 py-1.5 pe-2 ps-12'>
+        {onDefault ? (
+          <>
+            <div className='flex items-center justify-between gap-2'>
+              <span className='text-xs text-muted-foreground'>
+                Tool default (live) · stays in sync with the tool's example
+              </span>
+              <Button variant='outline' size='xs' onClick={() => onAdd(tool.exampleOutput)}>
+                <Sparkles />
+                Override
+              </Button>
+            </div>
+            <CodeEditor
+              language={CodeLanguage.json}
+              value={JSON.stringify(tool.exampleOutput, null, 2)}
+              readOnly
+              minHeight={120}
+            />
+          </>
+        ) : (
+          <>
+            {mocks.length === 0 ? (
+              <div className='flex flex-wrap items-center gap-2'>
+                {seedScaffold ? (
+                  <Button variant='outline' size='xs' onClick={() => onAdd(scaffold)}>
+                    <Wand2 />
+                    Scaffold
+                  </Button>
+                ) : null}
+                <Button variant='ghost' size='xs' onClick={() => onAdd({})}>
+                  Start blank
+                </Button>
+              </div>
+            ) : null}
+
+            {mocks.map((mock, idx) => (
+              <MockResponseEditor
+                key={mock.id}
+                agentId={agentId}
+                toolName={tool.name}
+                mock={mock}
+                index={idx}
+                total={mocks.length}
+                // A response is dead code when an EARLIER response for the same
+                // tool matches every call. The resolver takes the first match,
+                // so nothing below it can ever fire.
+                shadowedBy={mocks.findIndex((m, i) => i < idx && isCatchAll(m))}
+                onPatch={(patch) => onPatch(mock.id, patch)}
+                onRemove={() => onRemoveMock(mock.id)}
+              />
+            ))}
+
+            {mocks.length > 0 ? (
+              <div className='flex flex-wrap items-center justify-between gap-2 pt-0.5'>
+                <span className='min-w-0 flex-1 text-xs text-muted-foreground'>
+                  {mocks.length > 1
+                    ? 'Checked top to bottom. The first matching response wins.'
+                    : hasExample
+                      ? 'Unmatched calls fall back to the tool default.'
+                      : 'Unmatched calls fail closed.'}
+                </span>
+                <div className='flex shrink-0 items-center gap-1'>
+                  {hasExample ? (
+                    <Button variant='ghost' size='xs' onClick={onRemoveAll}>
+                      Reset to default
+                    </Button>
+                  ) : null}
+                  <Button variant='outline' size='xs' onClick={() => onAdd(seedValue)}>
+                    <Plus />
+                    Add response
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+    </TreeRow>
+  )
+}
+
+// ── One authored response (args matcher + output) ────────────────────────────
+
+interface MockResponseEditorProps {
+  agentId: string
+  toolName: string
+  mock: SimulationToolMock
+  index: number
+  total: number
+  /** Index of an earlier catch-all response that shadows this one, or -1. */
+  shadowedBy: number
+  onPatch: (patch: Partial<SimulationToolMock>) => void
+  onRemove: () => void
+}
+
+function MockResponseEditor({
+  agentId,
+  toolName,
+  mock,
+  index,
+  total,
+  shadowedBy,
+  onPatch,
+  onRemove,
+}: MockResponseEditorProps) {
+  const utils = api.useUtils()
+  const [draft, setDraft] = useState(() => JSON.stringify(mock.output, null, 2))
+  const [parseError, setParseError] = useState<string | null>(null)
+  const [validation, setValidation] = useState<{ error?: string; warning?: string } | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Args matcher is opt-in: an existing `args` opens it, otherwise the author
+  // reveals it with "Only when args match". A response with no matcher fires for
+  // every call — which is exactly the v1 behavior, so the default stays familiar.
+  const [argsDraft, setArgsDraft] = useState(() =>
+    mock.args ? JSON.stringify(mock.args.value, null, 2) : ''
+  )
+  const [argsOpen, setArgsOpen] = useState(() => mock.args !== undefined)
+  const [argsError, setArgsError] = useState<string | null>(null)
 
   const applyDraft = (text: string) => {
     setDraft(text)
@@ -347,16 +536,47 @@ function ToolResponseRow({
       return
     }
     setParseError(null)
-    onUpsert(parsed)
+    onPatch({ output: parsed })
 
     // Debounced schema validation against the tool's declared outputSchema.
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
       void utils.eval.validateMock
-        .fetch({ agentId, toolName: tool.name, output: parsed })
+        .fetch({ agentId, toolName, output: parsed })
         .then((res) => setValidation(res.ok ? { warning: res.warning } : { error: res.error }))
         .catch(() => setValidation(null))
     }, 500)
+  }
+
+  const applyArgs = (text: string) => {
+    setArgsDraft(text)
+    if (text.trim() === '') {
+      setArgsError(null)
+      onPatch({ args: undefined })
+      return
+    }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      setArgsError('Invalid JSON')
+      return
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      setArgsError('Matcher must be a JSON object of argument names to values')
+      return
+    }
+    setArgsError(null)
+    onPatch({
+      args: { mode: mock.args?.mode ?? 'subset', value: parsed as Record<string, unknown> },
+    })
+  }
+
+  const clearArgs = () => {
+    setArgsOpen(false)
+    setArgsDraft('')
+    setArgsError(null)
+    onPatch({ args: undefined })
   }
 
   useEffect(() => {
@@ -365,125 +585,101 @@ function ToolResponseRow({
     }
   }, [])
 
-  const seed = (value: unknown) => {
-    const text = JSON.stringify(value, null, 2)
-    applyDraft(text)
-  }
-
-  // Drop the literal mock AND the local draft — `draft` alone keeps the editor
-  // mounted, so without clearing it the row never returns to the default view.
-  const clearMock = () => {
-    setDraft('')
-    setParseError(null)
-    setValidation(null)
-    onRemove()
-  }
-
-  const status = mock
-    ? hasExample
-      ? 'override'
-      : 'mocked'
-    : hasExample
-      ? 'default'
-      : 'no response'
-
   return (
-    <TreeRow
-      depth={1}
-      icon={<span className='size-1.5 rounded-full bg-muted-foreground/40' />}
-      title={tool.displayName}
-      secondary={
-        <span className='flex items-center gap-1.5 text-xs'>
-          <span
-            className={cn(
-              mock ? 'text-green-600' : hasExample ? 'text-blue-600' : 'text-muted-foreground'
-            )}>
-            {status}
-          </span>
-          {tool.idempotent ? <span className='text-muted-foreground/70'>· read-only</span> : null}
+    <div className='space-y-1.5 rounded-md border border-border/60 p-2'>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <span className='min-w-0 flex-1 text-xs text-muted-foreground'>
+          {total > 1 ? `Response ${index + 1}` : 'Response'}
+          {mock.args && !isCatchAll(mock) ? (
+            <span className='ms-1 text-muted-foreground/70'>
+              · when args {mock.args.mode}-match
+            </span>
+          ) : total > 1 ? (
+            <span className='ms-1 text-muted-foreground/70'>· any call</span>
+          ) : null}
         </span>
-      }
-      expandable
-      isOpen={isOpen}
-      onToggleOpen={onToggle}
-      actions={
-        mock ? (
-          <TreeRowButton
-            variant='destructive'
-            tooltipText={hasExample ? 'Reset to default' : 'Clear response'}
-            onClick={clearMock}>
-            <Trash2 />
-          </TreeRowButton>
-        ) : undefined
-      }>
-      <div className='space-y-2 py-1.5 pe-2 ps-12'>
-        {onDefault ? (
-          <>
-            <div className='flex items-center justify-between gap-2'>
-              <span className='text-xs text-muted-foreground'>
-                Tool default (live) — stays in sync with the tool's example
-              </span>
-              <Button variant='outline' size='xs' onClick={() => seed(tool.exampleOutput)}>
-                <Sparkles />
-                Override
+        <div className='flex shrink-0 items-center gap-1'>
+          {argsOpen ? null : (
+            <Button variant='ghost' size='xs' onClick={() => setArgsOpen(true)}>
+              Only when args match
+            </Button>
+          )}
+          {total > 1 ? (
+            <Button variant='ghost' size='xs' onClick={onRemove}>
+              <Trash2 />
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {shadowedBy >= 0 ? (
+        <Alert variant='warning'>
+          <AlertDescription>
+            Never runs: response {shadowedBy + 1} matches every call. Give that one an args matcher,
+            or move this above it.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {argsOpen ? (
+        <div className='space-y-1'>
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <span className='min-w-0 flex-1 text-xs text-muted-foreground'>
+              Match when the call args {mock.args?.mode === 'exact' ? 'equal' : 'contain'}:
+            </span>
+            <div className='flex shrink-0 items-center gap-1'>
+              <Button
+                variant='ghost'
+                size='xs'
+                onClick={() =>
+                  onPatch({
+                    args: {
+                      mode: mock.args?.mode === 'exact' ? 'subset' : 'exact',
+                      value: mock.args?.value ?? {},
+                    },
+                  })
+                }>
+                {mock.args?.mode === 'exact' ? 'Exact' : 'Subset'}
+              </Button>
+              <Button variant='ghost' size='xs' onClick={clearArgs}>
+                Any call
               </Button>
             </div>
-            <CodeEditor
-              language={CodeLanguage.json}
-              value={JSON.stringify(tool.exampleOutput, null, 2)}
-              readOnly
-              minHeight={120}
-            />
-          </>
-        ) : (
-          <>
-            {!mock && draft.trim() === '' ? (
-              <div className='flex flex-wrap items-center gap-2'>
-                {seedScaffold ? (
-                  <Button variant='outline' size='xs' onClick={() => seed(scaffold)}>
-                    <Wand2 />
-                    Scaffold
-                  </Button>
-                ) : null}
-                <Button variant='ghost' size='xs' onClick={() => applyDraft('{}')}>
-                  Start blank
-                </Button>
-              </div>
-            ) : null}
+          </div>
+          <CodeEditor
+            language={CodeLanguage.json}
+            value={argsDraft}
+            onChange={applyArgs}
+            minHeight={60}
+            placeholder='{ "query": "jordan.lee@example.com" }'
+          />
+          {argsError ? (
+            <Alert variant='bad'>
+              <AlertDescription>{argsError}</AlertDescription>
+            </Alert>
+          ) : null}
+        </div>
+      ) : null}
 
-            {mock && hasExample ? (
-              <div className='flex items-center justify-between gap-2'>
-                <span className='text-xs text-muted-foreground'>Override (pinned)</span>
-                <Button variant='ghost' size='xs' onClick={clearMock}>
-                  Reset to default
-                </Button>
-              </div>
-            ) : null}
+      <CodeEditor
+        language={CodeLanguage.json}
+        value={draft}
+        onChange={applyDraft}
+        minHeight={120}
+        placeholder='{}'
+      />
 
-            {draft.trim() !== '' || mock ? (
-              <CodeEditor
-                language={CodeLanguage.json}
-                value={draft}
-                onChange={applyDraft}
-                minHeight={120}
-                placeholder='{}'
-              />
-            ) : null}
-
-            {parseError ? (
-              <Alert variant='bad'>
-                <AlertDescription>{parseError}</AlertDescription>
-              </Alert>
-            ) : validation?.error ? (
-              <Alert variant='bad'>
-                <AlertDescription>{validation.error}</AlertDescription>
-              </Alert>
-            ) : validation?.warning ? (
-              <p className='text-xs text-muted-foreground'>{validation.warning}</p>
-            ) : null}
-          </>
-        )}
-      </div>
-    </TreeRow>
+      {parseError ? (
+        <Alert variant='bad'>
+          <AlertDescription>{parseError}</AlertDescription>
+        </Alert>
+      ) : validation?.error ? (
+        <Alert variant='bad'>
+          <AlertDescription>{validation.error}</AlertDescription>
+        </Alert>
+      ) : validation?.warning ? (
+        <p className='text-xs text-muted-foreground'>{validation.warning}</p>
+      ) : null}
+    </div>
   )
 }

--- a/packages/lib/src/ai/agent-framework/__tests__/wire-format-conversion.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/wire-format-conversion.test.ts
@@ -320,13 +320,47 @@ describe('partsToWireFormat — interleaved text/tool/text', () => {
       { type: 'text', text: 'Post-tool conclusion.' },
     ]
     const wire = partsToWireFormat(parts, messageId)
-    // Wire format collapses text into a single assistant content string. The
-    // tool boundary is preserved by the trailing tool message, not by
-    // splitting text into multiple assistant messages.
-    const assistantMessages = wire.filter((m) => m.role === 'assistant')
-    expect(assistantMessages).toHaveLength(1)
-    expect(assistantMessages[0]?.content).toBe('Pre-tool: Post-tool conclusion.')
-    // The follow-up tool message comes after the assistant.
-    expect(wire[wire.length - 1]?.role).toBe('tool')
+    // Text written AFTER the last tool call is the conclusion drawn from that
+    // call, so it is replayed after the tool result — not concatenated onto the
+    // leading assistant message.
+    //
+    // This assertion was inverted before: the old contract folded both text
+    // parts together, which put the answer in front of its own evidence and led
+    // the model to contradict tool results that appeared to postdate it.
+    expect(wire.map((m) => m.role)).toEqual(['assistant', 'tool', 'assistant'])
+    expect(wire[0]?.content).toBe('Pre-tool: ')
+    expect(wire[0]?.tool_calls?.[0]?.id).toBe('tc_1')
+    expect(wire[2]?.content).toBe('Post-tool conclusion.')
+  })
+
+  it('keeps one assistant message when there is no tool call to order against', () => {
+    const parts: ContentPart[] = [
+      { type: 'text', text: 'Just ' },
+      { type: 'text', text: 'prose.' },
+    ]
+    const wire = partsToWireFormat(parts, messageId)
+    expect(wire).toHaveLength(1)
+    expect(wire[0]?.content).toBe('Just prose.')
+  })
+
+  it('does not emit assistant→assistant while a tool call is still pending', () => {
+    // No tool result yet (awaiting approval), so there is nothing to separate a
+    // trailing assistant message from the leading one. Anthropic rejects two
+    // adjacent assistant messages, so the text stays folded.
+    const parts: ContentPart[] = [
+      { type: 'text', text: 'Working on it. ' },
+      {
+        type: 'tool_call',
+        toolCallId: 'tc_pending',
+        name: 'send',
+        args: {},
+        status: 'awaiting-approval',
+      },
+      { type: 'text', text: 'Pending your approval.' },
+    ]
+    const wire = partsToWireFormat(parts, messageId)
+    expect(wire.map((m) => m.role)).toEqual(['assistant'])
+    expect(wire[0]?.content).toBe('Working on it. Pending your approval.')
+    expect(wire[0]?.tool_calls?.[0]?.id).toBe('tc_pending')
   })
 })

--- a/packages/lib/src/ai/agent-framework/llm-adapter.ts
+++ b/packages/lib/src/ai/agent-framework/llm-adapter.ts
@@ -40,6 +40,10 @@ export function createCallModel(config: LLMAdapterConfig) {
     })
 
     // Full message contents — info so they land in the per-session run log.
+    // `toolCalls`/`toolCallId` are projected too: without them an assistant
+    // message that DOES carry tool_calls reads as bare and the tool messages
+    // after it read as orphaned, which makes the log actively misleading about
+    // call/result pairing and ordering.
     logger.info('LLM messages', {
       model,
       messages: messages.map((m, i) => ({
@@ -47,6 +51,15 @@ export function createCallModel(config: LLMAdapterConfig) {
         role: m.role,
         contentLength: m.content?.length ?? 0,
         content: typeof m.content === 'string' ? m.content : '[non-string content]',
+        ...(m.tool_calls
+          ? {
+              toolCalls: m.tool_calls.map((c) => ({
+                id: c.id,
+                name: c.function?.name,
+              })),
+            }
+          : {}),
+        ...(m.tool_call_id ? { toolCallId: m.tool_call_id } : {}),
       })),
     })
 

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -185,8 +185,11 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   // 5. Create event publisher
   const publisher = createAgentEventPublisher(sessionId)
 
-  // 6. Run engine and publish events
-  const sessionContext = { page, ...(context ?? {}) }
+  // 6. Run engine and publish events.
+  // `page` last — it is the page the toolset was resolved from, and it must win
+  // over any stale `context.page` the caller carried in. See the matching order
+  // in `apps/web/src/app/api/kopilot/stream/route.ts`.
+  const sessionContext = { ...(context ?? {}), page }
   const usageEntries: UsageTrackingRequest[] = []
 
   // Drain one engine pass: publish every event, accumulate per-call usage, and

--- a/packages/lib/src/ai/agent-framework/query-loop.ts
+++ b/packages/lib/src/ai/agent-framework/query-loop.ts
@@ -1182,20 +1182,34 @@ export function dropRestatedTextParts(parts: ContentPart[]): void {
 
 /**
  * Collapse every `text` part into a single canonical `text` part holding
- * the post-processed content. Placed at the index of the first text part;
- * subsequent text parts are removed. Tool_call and thinking parts are
+ * the post-processed content. Placed at the index of the LAST text part;
+ * earlier text parts are removed. Tool_call and thinking parts are
  * preserved in order.
+ *
+ * Last, not first: `finalText` is the answer the model produced AFTER its tool
+ * calls resolved. Parking it at the first text part hoisted it in front of the
+ * `tool_call` parts, so the replayed history showed the conclusion before the
+ * evidence it came from — and the model, reading its own transcript back, would
+ * contradict tool results that appear to postdate the answer.
  */
 function collapseTextParts(parts: ContentPart[], finalText: string, agentName: string): void {
-  const firstTextIdx = parts.findIndex((p) => p.type === 'text')
-  if (firstTextIdx === -1) {
+  // Manual reverse scan: `findLastIndex` needs lib es2023, which this package's
+  // tsconfig target predates.
+  let lastTextIdx = -1
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i]!.type === 'text') {
+      lastTextIdx = i
+      break
+    }
+  }
+  if (lastTextIdx === -1) {
     parts.push({ type: 'text', text: finalText, agent: agentName })
     return
   }
-  // Replace the first text part with the canonical text.
-  ;(parts[firstTextIdx] as TextPart).text = finalText
-  // Remove every other text part.
-  for (let i = parts.length - 1; i > firstTextIdx; i--) {
+  // Replace the last text part with the canonical text.
+  ;(parts[lastTextIdx] as TextPart).text = finalText
+  // Remove every earlier text part.
+  for (let i = lastTextIdx - 1; i >= 0; i--) {
     if (parts[i]!.type === 'text') {
       parts.splice(i, 1)
     }

--- a/packages/lib/src/ai/agent-framework/utils.ts
+++ b/packages/lib/src/ai/agent-framework/utils.ts
@@ -220,14 +220,32 @@ export async function executeToolWithProgress(
  * splices it into the message list in place of the source assistant.
  */
 export function partsToWireFormat(parts: ContentPart[]): Message[] {
+  // Text written after the last tool call is the answer the model reached FROM
+  // those results, so it has to be replayed after them. Folding every text part
+  // into the single leading assistant message put the conclusion in front of its
+  // own evidence, and the model would then contradict tool output that appeared
+  // to postdate its answer. Text before (or between) tool calls is a preamble and
+  // stays on the leading message.
+  // Manual reverse scan: `findLastIndex` needs lib es2023, which this package's
+  // tsconfig target predates.
+  let lastToolIdx = -1
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i]!.type === 'tool_call') {
+      lastToolIdx = i
+      break
+    }
+  }
+
   let textContent = ''
+  let trailingText = ''
   const reasoningChunks: string[] = []
   const toolCalls: ToolCall[] = []
   const toolMessages: Message[] = []
 
-  for (const part of parts) {
+  for (const [idx, part] of parts.entries()) {
     if (part.type === 'text') {
-      textContent += part.text
+      if (lastToolIdx !== -1 && idx > lastToolIdx) trailingText += part.text
+      else textContent += part.text
       continue
     }
     if (part.type === 'thinking') {
@@ -281,7 +299,21 @@ export function partsToWireFormat(parts: ContentPart[]): Message[] {
   // it, but OpenAI-compatible providers (Kimi, DeepSeek, …) reject an empty
   // assistant message ("the message at position N with role 'assistant' must
   // not be empty"). Emit nothing so it never reaches the wire.
-  if (textContent.length === 0 && toolCalls.length === 0 && reasoningChunks.length === 0) {
+  // A trailing assistant message is only safe once at least one tool message
+  // separates it from the leading one — otherwise (every tool call still
+  // running / awaiting approval) we'd emit assistant→assistant back to back,
+  // which Anthropic rejects. In that case keep the old single-message shape.
+  if (toolMessages.length === 0 && trailingText.length > 0) {
+    textContent += trailingText
+    trailingText = ''
+  }
+
+  if (
+    textContent.length === 0 &&
+    trailingText.length === 0 &&
+    toolCalls.length === 0 &&
+    reasoningChunks.length === 0
+  ) {
     return []
   }
 
@@ -292,7 +324,8 @@ export function partsToWireFormat(parts: ContentPart[]): Message[] {
   if (toolCalls.length > 0) assistant.tool_calls = toolCalls
   if (reasoningChunks.length > 0) assistant.reasoning_content = reasoningChunks.join('')
 
-  return [assistant, ...toolMessages]
+  if (trailingText.length === 0) return [assistant, ...toolMessages]
+  return [assistant, ...toolMessages, { role: 'assistant', content: trailingText }]
 }
 
 /**

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/schema-references.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/schema-references.test.ts
@@ -1,0 +1,171 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/schema-references.test.ts
+//
+// `validateSchemaReferences` gates every `@[entity:…]` / `@[field:…]` chip an
+// agent prompt or procedure body can carry.
+//
+// The regression this file exists for: the predicate used to test ONLY storage
+// identity (`CustomField.id` CUID / `<defCUID>:<fieldCUID>`), while every
+// producer of a field chip — `list_entity_fields`, the `set_agent_prompt`
+// guidance, the client renderer — speaks the human-readable identity
+// (`systemAttribute ?? key`). The two never met, so every system-attributed
+// field (`contact_status`, `ticket_priority`, …) was permanently unresolvable
+// and no agent in the database ever stored a single field chip.
+//
+// This loosens a validator, so the negative cases below matter as much as the
+// positive ones.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ResourceField } from '../../../../../../resources/registry/field-types'
+import type { Resource } from '../../../../../../resources/registry/types'
+import { validateSchemaReferences } from '../schema-references'
+
+const findCachedResource = vi.fn()
+const getCachedResources = vi.fn()
+
+vi.mock('../../../../../../cache/org-cache-helpers', () => ({
+  findCachedResource: (...args: unknown[]) => findCachedResource(...args),
+  getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+}))
+
+const ORG = 'org_1'
+const CONTACTS_DEF = 'mzxt3cxyzhm3cbtgcbpmeir1'
+
+/** Chip node as the editor stores it. */
+const chip = (id: string) => ({ type: 'reference', attrs: { id } })
+const doc = (...ids: string[]) => ({ type: 'doc', content: ids.map(chip) })
+
+/**
+ * A seeded system field: identity is the CustomField CUID, `key` is the static
+ * registry key, and `systemAttribute` is what `list_entity_fields` returns.
+ * All three differ — which is the whole point.
+ */
+const statusField = {
+  id: 'cf_cuid_status',
+  key: 'status',
+  systemAttribute: 'contact_status',
+  resourceFieldId: `${CONTACTS_DEF}:cf_cuid_status`,
+  label: 'Status',
+} as unknown as ResourceField
+
+/** A pure custom field: `key` IS the CUID, no systemAttribute. */
+const customField = {
+  id: 'cf_cuid_custom',
+  key: 'cf_cuid_custom',
+  resourceFieldId: `${CONTACTS_DEF}:cf_cuid_custom`,
+  label: 'Loyalty Tier',
+} as unknown as ResourceField
+
+const contacts = {
+  id: CONTACTS_DEF,
+  apiSlug: 'contacts',
+  entityType: 'contact',
+  label: 'Contact',
+  fields: [statusField, customField],
+} as unknown as Resource
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getCachedResources.mockResolvedValue([contacts])
+  findCachedResource.mockImplementation(async (_org: string, key: string) =>
+    key === CONTACTS_DEF || key === 'contacts' || key === 'contact' ? contacts : null
+  )
+})
+
+describe('validateSchemaReferences — field chips', () => {
+  it('accepts the systemAttribute form with an apiSlug entity key', async () => {
+    // The exact chip the builder emitted and the server rejected three times.
+    const r = await validateSchemaReferences(doc('field:contacts:contact_status'), ORG)
+    expect(r.unresolvedReferences).toEqual([])
+    expect(r.errorMessage).toBeUndefined()
+  })
+
+  it('accepts the systemAttribute form with a definition-id entity key', async () => {
+    const r = await validateSchemaReferences(doc(`field:${CONTACTS_DEF}:contact_status`), ORG)
+    expect(r.unresolvedReferences).toEqual([])
+  })
+
+  it('accepts the static registry key', async () => {
+    const r = await validateSchemaReferences(doc('field:contacts:status'), ORG)
+    expect(r.unresolvedReferences).toEqual([])
+  })
+
+  it('still accepts the storage identity (CustomField id)', async () => {
+    const r = await validateSchemaReferences(doc('field:contacts:cf_cuid_status'), ORG)
+    expect(r.unresolvedReferences).toEqual([])
+  })
+
+  it('still accepts a pure custom field, whose key is its CUID', async () => {
+    // Regression guard: this is the ONE case that worked before the widening.
+    const r = await validateSchemaReferences(doc('field:contacts:cf_cuid_custom'), ORG)
+    expect(r.unresolvedReferences).toEqual([])
+  })
+
+  it('accepts the fully-qualified resourceFieldId form', async () => {
+    const r = await validateSchemaReferences(doc(`field:${CONTACTS_DEF}:cf_cuid_status`), ORG)
+    expect(r.unresolvedReferences).toEqual([])
+  })
+
+  it('validates only the root segment of a relationship traversal', async () => {
+    const r = await validateSchemaReferences(
+      doc('field:contacts:contact_status::orders:total'),
+      ORG
+    )
+    expect(r.unresolvedReferences).toEqual([])
+  })
+})
+
+describe('validateSchemaReferences — still rejects what it should', () => {
+  it('rejects a field id that does not exist on a valid entity', async () => {
+    const r = await validateSchemaReferences(doc('field:contacts:nope_not_a_field'), ORG)
+    expect(r.unresolvedReferences).toEqual(['field:contacts:nope_not_a_field'])
+    expect(r.errorMessage).toBeDefined()
+  })
+
+  it('does not let a field id leak across entities', async () => {
+    // `contact_status` is real, but not on `orders`.
+    findCachedResource.mockImplementation(async (_o: string, key: string) =>
+      key === 'orders'
+        ? ({
+            id: 'orders_def',
+            apiSlug: 'orders',
+            label: 'Order',
+            fields: [],
+          } as unknown as Resource)
+        : key === 'contacts'
+          ? contacts
+          : null
+    )
+    const r = await validateSchemaReferences(doc('field:orders:contact_status'), ORG)
+    expect(r.unresolvedReferences).toEqual(['field:orders:contact_status'])
+  })
+
+  it('rejects an unresolvable entity key', async () => {
+    const r = await validateSchemaReferences(doc('entity:not_a_real_slug'), ORG)
+    expect(r.unresolvedReferences).toEqual(['entity:not_a_real_slug'])
+  })
+
+  it('rejects a malformed field chip with no field segment', async () => {
+    const r = await validateSchemaReferences(doc('field:contacts'), ORG)
+    expect(r.unresolvedReferences).toEqual(['field:contacts'])
+  })
+})
+
+describe('validateSchemaReferences — rejection message is actionable', () => {
+  it('tells a bad-field caller NOT to swap the entity key form', async () => {
+    // The old message sent callers around the apiSlug <-> definition-id loop
+    // forever. Both forms resolve; saying so is what terminates the retry.
+    const r = await validateSchemaReferences(doc('field:contacts:nope_not_a_field'), ORG)
+    expect(r.errorMessage).toContain('will NOT help')
+    expect(r.errorMessage).toContain('list_entity_fields')
+  })
+
+  it('does not dump the whole apiSlug list when only a field id is wrong', async () => {
+    const r = await validateSchemaReferences(doc('field:contacts:nope_not_a_field'), ORG)
+    expect(r.errorMessage).not.toContain("don't resolve")
+  })
+
+  it('lists the valid entity keys when an entity chip is wrong', async () => {
+    const r = await validateSchemaReferences(doc('entity:not_a_real_slug'), ORG)
+    expect(r.errorMessage).toContain('contacts')
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/schema-references.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/schema-references.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/schema-references.ts
 
 import { findCachedResource, getCachedResources } from '../../../../../cache/org-cache-helpers'
+import { getFieldOutputKey } from '../../../../../resources/registry/field-types'
 import type { Resource } from '../../../../../resources/registry/types'
 
 /**
@@ -87,6 +88,12 @@ export async function validateSchemaReferences(
     if (!resolvedByKey.get(key)) unresolved.push(chip)
   }
 
+  // Field chips fail for two different reasons and the rejection message has to
+  // tell them apart — "your entityDef is wrong" and "your fieldId is wrong" call
+  // for opposite corrections.
+  const fieldChipsWithBadEntity: string[] = []
+  const fieldChipsWithBadField: string[] = []
+
   for (const chip of fieldChips) {
     const payload = chip.slice('field:'.length)
     const head = payload.split('::')[0] ?? payload
@@ -95,17 +102,31 @@ export async function validateSchemaReferences(
     const fieldKey = parts[1]
     if (!entityKey || !fieldKey) {
       unresolved.push(chip)
+      fieldChipsWithBadEntity.push(chip)
       continue
     }
     const resource = resolvedByKey.get(entityKey)
     if (!resource) {
       unresolved.push(chip)
+      fieldChipsWithBadEntity.push(chip)
       continue
     }
+    // Match BOTH field-id conventions. `f.id`/`resourceFieldId` are the storage
+    // identity (CustomField.id CUID); `getFieldOutputKey` (systemAttribute ?? key)
+    // is what `list_entity_fields` returns and therefore what chip authors write.
+    // Checking only storage identity made every system-attributed field
+    // (`contact_status`, `ticket_priority`, …) permanently unresolvable.
     const found = resource.fields.some(
-      (f) => f.id === fieldKey || f.resourceFieldId === `${entityKey}:${fieldKey}`
+      (f) =>
+        f.id === fieldKey ||
+        f.key === fieldKey ||
+        getFieldOutputKey(f) === fieldKey ||
+        f.resourceFieldId === `${entityKey}:${fieldKey}`
     )
-    if (!found) unresolved.push(chip)
+    if (!found) {
+      unresolved.push(chip)
+      fieldChipsWithBadField.push(chip)
+    }
   }
 
   // Warning: a field-bearing entity mentioned in prose with no @[entity:…] chip.
@@ -142,8 +163,33 @@ export async function validateSchemaReferences(
 
   if (unresolved.length === 0) return { unresolvedReferences: [], warnings }
 
-  const slugList = allResources.map((r) => r.apiSlug).join(', ')
-  const errorMessage = `Rejected — ${unresolved.length} unresolved schema chip(s): ${unresolved.map((c) => `\`${c}\``).join(', ')}. For \`@[entity:<key>]\` chips, key must be one of the apiSlugs: ${slugList}. For \`@[field:<entityDef>:<fieldId>]\` chips, call \`list_entity_fields\` on the entityDef first and use a real field id from the response. Fix and retry.`
+  // Name the ACCEPTED forms. The previous message prescribed
+  // "call list_entity_fields and use a real field id" — the exact procedure a
+  // caller has usually already followed — which turned a rejection into a
+  // non-terminating repair loop. Only surface the guidance for the chip kind
+  // that actually failed, so a bad field id doesn't dump the whole slug list.
+  const badEntityChips = unresolved.filter((c) => c.startsWith('entity:'))
+
+  const guidance: string[] = []
+  if (badEntityChips.length > 0 || fieldChipsWithBadEntity.length > 0) {
+    const slugList = allResources.map((r) => r.apiSlug).join(', ')
+    guidance.push(
+      `These entity keys don't resolve. Key must be one of the apiSlugs (or the entity definition id): ${slugList}.`
+    )
+  }
+  if (fieldChipsWithBadField.length > 0) {
+    guidance.push(
+      `These field chips have a valid entityDef but a fieldId that doesn't exist on it: ${fieldChipsWithBadField
+        .map((c) => `\`${c}\``)
+        .join(
+          ', '
+        )}. fieldId must be the \`id\` of a field in the \`list_entity_fields\` response for that entityDef. Copy it verbatim, don't derive it from the label. Changing the entityDef between apiSlug and definition id will NOT help; both forms resolve.`
+    )
+  }
+
+  const errorMessage = `Rejected. ${unresolved.length} unresolved schema chip(s): ${unresolved
+    .map((c) => `\`${c}\``)
+    .join(', ')}. ${guidance.join(' ')} Fix and retry.`
 
   return { unresolvedReferences: unresolved, warnings, errorMessage }
 }

--- a/packages/lib/src/evals/simulation/__tests__/subject-mocks.test.ts
+++ b/packages/lib/src/evals/simulation/__tests__/subject-mocks.test.ts
@@ -1,0 +1,153 @@
+// packages/lib/src/evals/simulation/__tests__/subject-mocks.test.ts
+//
+// Derived subject mocks: make a simulation's identity lookups agree with the
+// customer the simulation configures, instead of the tool's schema-doc
+// `exampleOutput` (which always answers "Jane Cooper").
+//
+// The properties that matter are the ones about NOT overreaching: an
+// author-written mock must still win, and a search for something unrelated must
+// still fall through to the existing default.
+
+import type { SimulationConfig, SimulationToolMock } from '@auxx/types/evals'
+import { describe, expect, it } from 'vitest'
+import { createMockResolver } from '../mock-tools'
+import { buildSubjectMocks } from '../subject-mocks'
+
+const config = (over: Partial<SimulationConfig> = {}): SimulationConfig =>
+  ({
+    openingMessage: 'hi',
+    customerContext: '',
+    channel: 'chat',
+    maxCustomerTurns: 8,
+    connectorMocks: [],
+    unmatchedToolPolicy: 'fail_closed',
+    startingFields: {},
+    subject: { claimed: { name: 'Jordan Lee', email: 'jordan.lee@example.com' } },
+    ...over,
+  }) as unknown as SimulationConfig
+
+describe('buildSubjectMocks', () => {
+  it('returns nothing when there is no claimed identity', () => {
+    expect(buildSubjectMocks(config({ subject: {} } as Partial<SimulationConfig>))).toEqual([])
+  })
+
+  it('returns nothing for a blank-but-present identity', () => {
+    const c = config({
+      subject: { claimed: { name: '  ', email: '' } },
+    } as Partial<SimulationConfig>)
+    expect(buildSubjectMocks(c)).toEqual([])
+  })
+
+  it('answers a search for the customer name with the customer', () => {
+    const resolver = createMockResolver(buildSubjectMocks(config()))
+    const hit = resolver.resolve('search_entities', { query: 'Jordan Lee' })
+    expect(hit?.output).toMatchObject({
+      count: 1,
+      items: [{ displayName: 'Jordan Lee', secondaryInfo: 'jordan.lee@example.com' }],
+    })
+  })
+
+  it('answers a search for the customer email with the customer', () => {
+    const resolver = createMockResolver(buildSubjectMocks(config()))
+    const hit = resolver.resolve('search_entities', { query: 'jordan.lee@example.com' })
+    expect(hit?.output).toMatchObject({ count: 1 })
+  })
+
+  it('matches even when the call carries extra args', () => {
+    // `subset` — an accompanying entityDefinitionId/limit must not defeat it.
+    const resolver = createMockResolver(buildSubjectMocks(config()))
+    const hit = resolver.resolve('search_entities', {
+      query: 'Jordan Lee',
+      entityDefinitionId: 'contacts',
+      limit: 10,
+    })
+    expect(hit).not.toBeNull()
+  })
+
+  it('does NOT hijack a search for something unrelated', () => {
+    // Must fall through to the existing exampleOutput behavior, not force-feed
+    // the customer into every lookup.
+    const resolver = createMockResolver(buildSubjectMocks(config()))
+    expect(resolver.resolve('search_entities', { query: 'blender' })).toBeNull()
+  })
+
+  it('answers a contact query_records with the customer', () => {
+    // Regression guard from a live verification run: query_records was left
+    // uncovered, the agent called it FIRST, anchored on the example's contact,
+    // and then wrote its note to the wrong record.
+    const resolver = createMockResolver(buildSubjectMocks(config()))
+    for (const entity of ['contacts', 'contact']) {
+      const hit = resolver.resolve('query_records', { entity, filters: [{ field: 'x' }] })
+      expect(hit?.output).toMatchObject({
+        returned_count: 1,
+        items: [{ displayName: 'Jordan Lee' }],
+      })
+    }
+  })
+
+  it('leaves a query_records for another entity type alone', () => {
+    const resolver = createMockResolver(buildSubjectMocks(config()))
+    expect(resolver.resolve('query_records', { entity: 'tickets' })).toBeNull()
+  })
+
+  it('hands query_records and search_entities the SAME recordId', () => {
+    // Both entry points must anchor the run on one record, or a later
+    // get_entity/create_note lands on a different one.
+    const resolver = createMockResolver(buildSubjectMocks(config()))
+    const viaQuery = resolver.resolve('query_records', { entity: 'contacts' })
+    const viaSearch = resolver.resolve('search_entities', { query: 'Jordan Lee' })
+    const idOf = (r: unknown) => (r as { items: Array<{ recordId: string }> }).items[0]!.recordId
+    expect(idOf(viaQuery?.output)).toBe(idOf(viaSearch?.output))
+  })
+
+  it('reads back the same recordId it handed out', () => {
+    const mocks = buildSubjectMocks(config())
+    const resolver = createMockResolver(mocks)
+    const found = resolver.resolve('search_entities', { query: 'Jordan Lee' })
+    const recordId = (found?.output as { items: Array<{ recordId: string }> }).items[0]!.recordId
+    const read = resolver.resolve('get_entity', { recordId })
+    expect(read?.output).toMatchObject({ recordId, displayName: 'Jordan Lee' })
+  })
+
+  it('prefers a linked real record over the synthetic id', () => {
+    const c = config({
+      subject: {
+        claimed: { name: 'Jordan Lee', email: 'jordan.lee@example.com' },
+        recordIds: ['contacts:real_instance_1'],
+      },
+    } as Partial<SimulationConfig>)
+    const resolver = createMockResolver(buildSubjectMocks(c))
+    const hit = resolver.resolve('search_entities', { query: 'Jordan Lee' })
+    expect((hit?.output as { items: Array<{ recordId: string }> }).items[0]!.recordId).toBe(
+      'contacts:real_instance_1'
+    )
+  })
+
+  it('works from an email alone', () => {
+    const c = config({
+      subject: { claimed: { email: 'solo@example.com' } },
+    } as Partial<SimulationConfig>)
+    const resolver = createMockResolver(buildSubjectMocks(c))
+    const hit = resolver.resolve('search_entities', { query: 'solo@example.com' })
+    expect(hit?.output).toMatchObject({ items: [{ displayName: 'solo@example.com' }] })
+  })
+})
+
+describe('precedence against author-written mocks', () => {
+  it('an explicit mock wins over the derived one', () => {
+    // The executor composes [...connectorMocks, ...subjectMocks] and the
+    // resolver takes the FIRST match in stored order. If that order is ever
+    // flipped, an author who deliberately mocked "customer not found" would be
+    // silently overridden — which is exactly the bug this ordering prevents.
+    const authored: SimulationToolMock = {
+      id: 'authored',
+      toolName: 'search_entities',
+      output: { items: [], count: 0 },
+      usage: 'repeat',
+    }
+    const resolver = createMockResolver([authored, ...buildSubjectMocks(config())])
+    const hit = resolver.resolve('search_entities', { query: 'Jordan Lee' })
+    expect(hit?.mock.id).toBe('authored')
+    expect(hit?.output).toMatchObject({ count: 0 })
+  })
+})

--- a/packages/lib/src/evals/simulation/executor.ts
+++ b/packages/lib/src/evals/simulation/executor.ts
@@ -51,6 +51,7 @@ import { buildSimulationTriggerContext } from './customer-envelope'
 import { buildSimulationFieldResolver } from './field-resolver'
 import { type ToolInvocationRecord, wrapToolsWithMocks } from './mock-tools'
 import { LlmPersonaConversationSource } from './persona'
+import { buildSubjectMocks } from './subject-mocks'
 
 const logger = createScopedLogger('eval-executor')
 
@@ -129,9 +130,15 @@ export async function runAgentSimulation(
   const toolInvocations: ToolInvocationRecord[] = []
   let unmatchedOccurred = false
   let nonOffline = false
+  // Identity lookups answer with the simulation's own customer instead of the
+  // tool's schema-doc `exampleOutput`. Author-written mocks are listed FIRST
+  // because the resolver takes the first match in stored order — an explicit
+  // mock must always beat a derived one. Anything unmatched still falls through
+  // to `exampleOutput` exactly as before.
+  const subjectMocks = buildSubjectMocks(config)
   const wrapTools = (tools: Parameters<typeof wrapToolsWithMocks>[0]) =>
     wrapToolsWithMocks(tools, {
-      mocks: config.connectorMocks,
+      mocks: [...config.connectorMocks, ...subjectMocks],
       unmatchedPolicy: config.unmatchedToolPolicy,
       onInvocation: (rec) => {
         toolInvocations.push(rec)

--- a/packages/lib/src/evals/simulation/subject-mocks.ts
+++ b/packages/lib/src/evals/simulation/subject-mocks.ts
@@ -1,0 +1,120 @@
+// packages/lib/src/evals/simulation/subject-mocks.ts
+
+import type { SimulationConfig, SimulationToolMock } from '@auxx/types/evals'
+
+/**
+ * Derive tool mocks that make identity lookups agree with the simulation's own
+ * customer.
+ *
+ * Why this exists: an unmocked tool falls back to its `exampleOutput` (see
+ * `mock-tools.ts` and `plans/evals/live-tool-default-mocks-plan.md`) — a static
+ * literal written to document the output schema, e.g. `search_entities` always
+ * answers "Jane Cooper / Jane Doe". A simulation that configures a customer and
+ * then has the agent look them up therefore gets contradicted by its own
+ * fixtures: the agent correctly concludes the customer isn't on file, and the
+ * run can never reach a terminal outcome. The failure reads as an agent defect.
+ *
+ * This does NOT change the resolution precedence. It prepends ordinary literal
+ * mocks, so:
+ *   - author-written mocks in `connectorMocks` still win (stored order),
+ *   - anything not matched still falls through to `exampleOutput` exactly as before.
+ *
+ * Matching is deliberately narrow. `argsMatch` supports only deep equality, not
+ * substring predicates, so these mocks fire only for a lookup that uses the
+ * literal name or email the simulation was given. A search for anything else
+ * (a product, an order) is left alone rather than being force-fed the customer.
+ */
+
+/** Stable synthetic record id for a claimed-only customer. */
+const SUBJECT_RECORD_ID = 'contact:sim-subject'
+
+/**
+ * Entity keys that mean "the contact record type". `query_records` takes an
+ * apiSlug, but the tool description shows the singular form, so models emit
+ * either — cover both rather than guessing.
+ */
+const CONTACT_ENTITY_KEYS = ['contacts', 'contact'] as const
+
+/**
+ * Build the mocks for a simulation's customer. Returns `[]` when there is no
+ * claimed identity to key off — nothing is inferred from an empty subject.
+ */
+export function buildSubjectMocks(config: SimulationConfig): SimulationToolMock[] {
+  const claimed = config.subject?.claimed
+  const name = claimed?.name?.trim()
+  const email = claimed?.email?.trim()
+  if (!name && !email) return []
+
+  // Prefer a real linked record so the id the agent sees matches the one the
+  // rest of the run (field overlay, assertions) is talking about.
+  const recordId = config.subject?.recordIds?.[0] ?? SUBJECT_RECORD_ID
+  const displayName = name ?? email ?? 'Customer'
+  const secondaryInfo = email ?? null
+
+  const searchItem = {
+    recordId,
+    displayName,
+    entityType: 'contact',
+    secondaryInfo,
+  }
+  const searchOutput = { items: [searchItem], count: 1 }
+
+  const mocks: SimulationToolMock[] = []
+
+  // One mock per literal the agent plausibly searches with. `subset` so an
+  // accompanying `entityDefinitionId`/`limit` doesn't defeat the match.
+  for (const term of [name, email]) {
+    if (!term) continue
+    mocks.push({
+      id: `sim-subject-search-${term}`,
+      toolName: 'search_entities',
+      args: { mode: 'subset', value: { query: term } },
+      output: searchOutput,
+      usage: 'repeat',
+    })
+  }
+
+  // `query_records` is the structured-filter sibling of `search_entities`, and
+  // agents reach for it FIRST when narrowing a record type. Left uncovered it
+  // hands back the example's contacts, the agent anchors on that record id, and
+  // every later read/write in the run targets the wrong person — which is worse
+  // than the original symptom, because it looks like it succeeded.
+  //
+  // Matched on the entity key rather than the filters: filter arrays are far too
+  // variable for deep equality, but a query against the contact type is
+  // unambiguously a query about the subject in a customer simulation. Queries
+  // for any other entity type fall through untouched.
+  for (const entityKey of CONTACT_ENTITY_KEYS) {
+    mocks.push({
+      id: `sim-subject-query-${entityKey}`,
+      toolName: 'query_records',
+      args: { mode: 'subset', value: { entity: entityKey } },
+      output: {
+        entityType: 'Contact',
+        items: [{ recordId, displayName, secondaryInfo, ...(email ? { Email: email } : {}) }],
+        returned_count: 1,
+        total_matching: 1,
+        hasMore: false,
+      },
+      usage: 'repeat',
+    })
+  }
+
+  // Close the loop: the agent that found the subject above will read it back by
+  // the recordId we just handed out.
+  mocks.push({
+    id: 'sim-subject-get-entity',
+    toolName: 'get_entity',
+    args: { mode: 'subset', value: { recordId } },
+    output: {
+      recordId,
+      displayName,
+      secondaryInfo,
+      avatarUrl: null,
+      fields: email ? { Email: { text: email, type: 'email' } } : {},
+    },
+    usage: 'repeat',
+  })
+
+  return mocks
+}


### PR DESCRIPTION
Five defects found by reading `.logs/agent-sessions/` (119 sessions, 2026-07-23 to 2026-07-31), then reproducing the first one live by driving the agent builder through the UI twice.

## 1. Field chips have never persisted

`validateSchemaReferences` compared a chip's field segment only against **storage identity** (`CustomField.id` CUID, or `<defCUID>:<fieldCUID>`), while every producer of a `field:` chip speaks the **human-readable identity** (`systemAttribute ?? key`): `list_entity_fields` (`list-entity-fields-output.ts:85`), the `set_agent_prompt` guidance, and the client renderer. Pure custom fields passed by luck, since their `key` IS the CUID. Every system-attributed field (`contact_status`, `ticket_priority`, `ticket_status`, `ticket_type`) was permanently unresolvable.

The rejection message then told the caller to *"call `list_entity_fields` and use a real field id"*, the exact procedure they had just followed. Live, the builder oscillated:

```
attempt 1: "field chips need the internal entity definition IDs, not the apiSlugs"
attempt 2: "the server needs the apiSlug as the entity key, not the definition ID"
attempt 3: "rejecting BOTH ... let me drop all @[field:…] chips"
```

It only ever succeeded by discarding them. Across the whole `Agent` table: **6 agents, 0 with field chips**, 4 with entity chips.

**Fix:** widen the predicate to also accept `f.key` and `getFieldOutputKey(f)`, and split the message so a bad `entityDef` and a bad `fieldId` get opposite advice (it now states that swapping the entityDef form will not help, which is what terminates the loop).

**Verified:** a fresh build with the same prompt stores **19 field chips**, 0 rejections, session log 2108K to 772K. The stored chips include `field:contacts:contact_status` and `field:tickets:ticket_priority`, rejected 3x before.

## 2. Simulations contradicted their own customer

An unmocked tool falls back to `exampleOutput`, a literal written to document the output schema, so `search_entities` always answered "Jane Cooper" regardless of the query. A simulation that configures a customer and then has the agent look them up got contradicted by its own fixtures, the agent correctly concluded the customer was not on file, and the run could never reach a terminal outcome. It read as an agent defect.

New `subject-mocks.ts` derives literal mocks from `config.subject.claimed` for `search_entities`, `get_entity` and `query_records`. No schema change, no precedence change, resolver untouched.

- author-written mocks are listed **first** so they still win on stored order
- unmatched calls still fall through to `exampleOutput` exactly as before
- matching is narrow on purpose: a search for an unrelated term is left alone

**Verified:** 5/5 identity lookups now resolve to the configured customer (`resolution: "mock"` in the trace); run status improved from `error / TURN_CAP_EXCEEDED` to completing.

## 3. DM from another surface loaded the wrong page's tools

`route.ts` had opposite precedence on two lines in the same function:

```ts
:753   sessionContext: { ...(context ?? {}), page }   // page wins        -> tool deps
:949   const sessionContext = { page, ...context }    // context.page wins -> prompt
```

With `resolvedPage` forced to `agents.dm` on the DM path, the model was told it was on `mail` while holding 18 non-mail tools, then reported the gap to the user as *"I can't access your messages ... the connected account isn't available"*, which is false. Both now use `{ ...context, page }`. Tool loading is unchanged; this only makes the prompt tell the truth.

Narrow in practice: 5 turns across 119 sessions, only when a DM is opened from a non-DM surface.

## 4. The answer was replayed before the tool results it came from

`collapseTextParts` parked finalized prose at the **first** text part, hoisting it ahead of the `tool_call` parts, and `partsToWireFormat` then folded all text into the single leading assistant message. Replayed history showed the conclusion before its evidence, which is what made a follow-up turn answer *"I only found one latest message thread"* with 10 threads sitting in its own history.

Now: final text parks at the last text part, and text after the last tool call is emitted as a trailing assistant message. Guarded so a turn whose tool calls are all pending never emits adjacent assistant messages, which Anthropic rejects.

## 5. Args matchers in the tool-responses editor

The data model (`SimulationToolMock.args`), resolver and validation already supported several arg-matched responses per tool. Only the UI was limited to one frozen output per tool, so "order 1234 found, 9999 not found" had to be authored through Kopilot's `update_eval_case_mock`. Adds Add response, a subset/exact matcher, and an inline flag for a response that can never run behind an earlier catch-all.

## Also

`llm-adapter.ts` now logs `toolCalls`/`toolCallId`. Without them an assistant message carrying `tool_calls` reads as bare and the tool messages after it read as orphaned, which made these logs actively misleading about call/result pairing. That gap produced a wrong first reading during this investigation.

## Testing

- 700 tests pass across `src/ai/agent-framework`, `src/ai/kopilot`, `src/evals`
- 14 new tests for the chip predicate. Verified non-vacuous by reverting the predicate: exactly the 4 bug-targeting tests fail while every negative case still passes
- 13 tests for the derived subject mocks, including that an author mock still wins and that an unrelated search is not hijacked
- One pre-existing test in `wire-format-conversion.test.ts` asserted the old ordering (its comment rationalized putting the conclusion before the tool result); rewritten to the corrected contract plus two edge cases
- Typecheck clean for all changed files; the remaining errors in `process-agent-job.ts` and `query-loop.ts` are pre-existing baseline
- Lint clean

## Notes for review

- Fix 4 changes the prompt prefix of existing sessions, so expect a one-time prompt-cache miss. Sessions stored before it keep the old part order; no backfill, given the user base.
- Whether a DM opened from the mail page *should* carry mail tools is still an open product question. Fix 3 is correct under any answer.
