### PR TITLE
fix(demo): unlock dashboards for demo orgs and drop the empty single-tab bar

### DIFF
--- a/apps/web/src/app/api/demo/create-session/route.ts
+++ b/apps/web/src/app/api/demo/create-session/route.ts
@@ -186,6 +186,19 @@ export async function POST(request: NextRequest) {
           })
           .where(eq(schema.OrganizationAiQuota.organizationId, organizationId))
       }
+
+      // 7c. Bust the plan-derived caches for the swapped subscription.
+      //
+      // The delete + insert above is raw Drizzle, so nothing fired the invalidation
+      // the billing service paths would have. `org.updated` at step 6b only reaches
+      // `orgProfile`; the per-org `features` map is a SEPARATE key, and it is what
+      // every feature gate reads (`FeaturePermissionService.hasAccess`,
+      // `useFeatureFlags`). A `features` entry warmed during seeding — before this
+      // route existed to swap the plan — describes the now-deleted TRIAL
+      // subscription, and boolean gates fail closed, so the demo org would spend its
+      // whole hour with Demo-plan surfaces such as dashboards silently locked.
+      // `plan.changed` fans out to `features` + `subscription` + `overages`.
+      await onCacheEvent('plan.changed', { orgId: organizationId })
     }
 
     // 8. Enqueue async demo data seeding job (customers, tickets, etc.)

--- a/packages/ui/src/components/main-page-tabs.tsx
+++ b/packages/ui/src/components/main-page-tabs.tsx
@@ -65,7 +65,11 @@ function MainPageTabs({ items, value, onValueChange, size = 'sm', className }: M
   const router = useRouter()
 
   const visible = items.filter((item) => !item.hidden)
-  if (visible.length === 0) return null
+  // A switcher with a single choice is not a switcher — it renders as a full-width
+  // bar with one permanently-selected tab and dead space beside it. Feature gating
+  // (`hidden`) routinely collapses a two-tab header down to one, so drop the whole
+  // control rather than leaving the empty half behind.
+  if (visible.length < 2) return null
 
   const isRouteMode = value === undefined
   const activeValue = isRouteMode ? longestPrefixMatch(visible, pathname) : value

--- a/packages/ui/src/components/radio-tab.tsx
+++ b/packages/ui/src/components/radio-tab.tsx
@@ -132,6 +132,8 @@ function RadioTab({
   // Generate grid classes and indicator positioning
   const getGridClasses = () => {
     switch (totalItems) {
+      case 1:
+        return 'grid-cols-1'
       case 2:
         return 'grid-cols-2'
       case 3:
@@ -153,17 +155,19 @@ function RadioTab({
     )
 
     const widthClass =
-      totalItems === 2
-        ? 'after:w-1/2'
-        : totalItems === 3
-          ? 'after:w-1/3'
-          : totalItems === 4
-            ? 'after:w-1/4'
-            : totalItems === 5
-              ? 'after:w-1/5'
-              : totalItems === 6
-                ? 'after:w-1/6'
-                : 'after:w-1/2'
+      totalItems === 1
+        ? 'after:w-full'
+        : totalItems === 2
+          ? 'after:w-1/2'
+          : totalItems === 3
+            ? 'after:w-1/3'
+            : totalItems === 4
+              ? 'after:w-1/4'
+              : totalItems === 5
+                ? 'after:w-1/5'
+                : totalItems === 6
+                  ? 'after:w-1/6'
+                  : 'after:w-1/2'
 
     const translateClass =
       index === 0


### PR DESCRIPTION
## What

Two bugs kept dashboards hidden on the demo workspace even though #1452 already opened the `dashboards` boolean gate on every plan (seed + migration `065-dashboards-all-plans`).

### 1. The demo session never invalidates its plan-derived caches

`apps/web/src/app/api/demo/create-session/route.ts` deletes the seeded trial subscription and inserts the Demo one with raw Drizzle, so nothing fired the invalidation the billing service paths would have. The `org.updated` event it *does* fire runs **before** the swap and only reaches `orgProfile` — the per-org `features` map is a separate key, and it is what every gate reads (`FeaturePermissionService.hasAccess`, `useFeatureFlags`).

A `features` entry warmed during seeding therefore describes the now-deleted **trial** subscription for the org's whole hour, and boolean gates fail closed (`false` and `undefined` both deny). Fixed by firing `plan.changed` after the swap, which fans out to `features` + `subscription` + `overages`.

This affects every boolean gate and numeric limit on a demo org, not just dashboards.

### 2. `RadioTab` renders dead space with a single item

`getGridClasses()` fell through `switch (totalItems)` to `default: 'grid-cols-2'`, and the indicator to `after:w-1/2`. So when `EntityRouteLayout` hides the Dashboard tab via `hidden: !hasAccess(FeatureKey.dashboards)`, `MainPageTabs` rendered a `w-full` two-column grid holding one label — a bar with an empty half.

- `radio-tab.tsx` — added the `totalItems === 1` cases (`grid-cols-1`, `after:w-full`) so the primitive is correct for any caller.
- `main-page-tabs.tsx` — bail at `visible.length < 2` instead of `=== 0`. A switcher with one choice is not a switcher.

## Blast radius

The other three `MainPageTabs` call sites (dispatch, workflows, kb-editor-header) pass fixed 2–3 item arrays and are unaffected. Tickets keeps its bar (Settings extra tab); contacts/companies/custom drop the control entirely when dashboards is gated off.

## Not covered by this PR

If dashboards is still locked on prod after this ships, check `/admin/data-migrations` for `065-dashboards-all-plans`. `Plan.featureLimits` is stored JSONB and the seeder is not run on deploy, so the seed-file change from #1452 does nothing to a live DB without that migration. A `failed` row also blocks `066` behind it.

## Test plan

- [ ] Start a demo session, confirm the Dashboard tab appears on contacts/companies/tickets
- [ ] On a plan with dashboards gated off, confirm the tab bar disappears entirely rather than showing an empty half