### PR TITLE
fix(messaging): clear the channel/messaging type errors and the bugs they were hiding

### DIFF
--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -565,6 +565,7 @@ export const IntegrationProviderTypeValues = [
   'chat',
   'email',
   'shopify',
+  'imap',
 ] as const
 
 export const InvitationStatusValues = ['PENDING', 'ACCEPTED', 'EXPIRED', 'CANCELLED'] as const

--- a/packages/lib/src/channels/personal-connection.ts
+++ b/packages/lib/src/channels/personal-connection.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/channels/personal-connection.ts
 
 import { database as db, schema } from '@auxx/database'
-import type { IntegrationProviderType } from '@auxx/database/enums'
 import { ResourceGranteeType } from '@auxx/database/enums'
+import type { IntegrationProviderType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
 import { and, eq, isNull } from 'drizzle-orm'

--- a/packages/lib/src/email/__tests__/mailgun-transport.test.ts
+++ b/packages/lib/src/email/__tests__/mailgun-transport.test.ts
@@ -63,7 +63,7 @@ describe('createMailgunTransport', () => {
     } as unknown as Mail.Options
 
     const info = await new Promise<any>((resolve, reject) => {
-      transport.send(mail, (err, response) => {
+      transport.send(mail, (err: Error | null, response?: unknown) => {
         if (err) {
           reject(err)
         } else {
@@ -74,7 +74,7 @@ describe('createMailgunTransport', () => {
 
     expect(info).toEqual(expect.objectContaining({ messageId: 'queued@example.com' }))
     expect(messagesCreateMock).toHaveBeenCalledTimes(1)
-    const payload = messagesCreateMock.mock.calls[0][1]
+    const payload = messagesCreateMock.mock.calls[0]?.[1]
     expect(payload).toMatchObject({
       from: 'Support <support@example.com>',
       to: 'User <user@example.com>',
@@ -101,7 +101,7 @@ describe('createMailgunTransport', () => {
     } as unknown as Mail.Options
 
     await new Promise<void>((resolve, reject) => {
-      transport.send(mail, (err) => {
+      transport.send(mail, (err: Error | null) => {
         if (err) {
           reject(err)
         } else {
@@ -111,7 +111,7 @@ describe('createMailgunTransport', () => {
     })
 
     expect(messagesCreateMock).toHaveBeenCalledTimes(1)
-    expect(messagesCreateMock.mock.calls[0][1]).toMatchObject({
+    expect(messagesCreateMock.mock.calls[0]?.[1]).toMatchObject({
       from: 'Support <support@example.com>',
       to: 'user@example.com',
       subject: 'Hello',

--- a/packages/lib/src/email/email-templates.ts
+++ b/packages/lib/src/email/email-templates.ts
@@ -14,9 +14,12 @@ Handlebars.registerHelper('formatDate', (date: Date, format: string) => {
   return d.toLocaleDateString()
 })
 
-Handlebars.registerHelper('ifEquals', function (arg1: any, arg2: any, options: any) {
-  return arg1 === arg2 ? options.fn(this) : options.inverse(this)
-})
+Handlebars.registerHelper(
+  'ifEquals',
+  function (this: unknown, arg1: unknown, arg2: unknown, options: Handlebars.HelperOptions) {
+    return arg1 === arg2 ? options.fn(this) : options.inverse(this)
+  }
+)
 
 export interface TemplateData {
   [key: string]: any
@@ -171,6 +174,10 @@ export class EmailTemplateService {
         } as any)
         .returning()
 
+      if (!template) {
+        throw new Error('Failed to create email template')
+      }
+
       logger.info('Template created:', { templateId: template.id, organizationId })
       return template
     } catch (error) {
@@ -220,6 +227,10 @@ export class EmailTemplateService {
           organizationId,
         } as any)
         .returning()
+
+      if (!newTemplate) {
+        throw new Error('Failed to copy email template')
+      }
 
       logger.info('Template copied:', { sourceId: templateId, newId: newTemplate.id })
       return newTemplate

--- a/packages/lib/src/email/labels/gmail-label-provider.ts
+++ b/packages/lib/src/email/labels/gmail-label-provider.ts
@@ -15,6 +15,18 @@ import type { LabelProvider, ProviderLabel } from './label-provider.interface'
 
 const logger = createScopedLogger('gmail-label-provider')
 
+/** Shape googleapis errors take: an Error decorated with the HTTP response. */
+interface GoogleApiError {
+  code?: number | string
+  message?: string
+  response?: { status?: number; data?: { error?: string; error_subtype?: string } }
+}
+
+/** Narrows an unknown catch value to the loosely-shaped googleapis error object. */
+function asGoogleApiError(error: unknown): GoogleApiError {
+  return typeof error === 'object' && error !== null ? (error as GoogleApiError) : {}
+}
+
 export class GmailLabelProvider implements LabelProvider {
   private gmail: any
   private client: any
@@ -82,7 +94,8 @@ export class GmailLabelProvider implements LabelProvider {
       return await operation()
     } catch (error) {
       // Check for token expiration (normal 401)
-      if (error.code === 401 || (error.response && error.response.status === 401)) {
+      const apiError = asGoogleApiError(error)
+      if (apiError.code === 401 || apiError.response?.status === 401) {
         try {
           logger.info('Access token expired, refreshing and retrying operation')
 
@@ -93,10 +106,11 @@ export class GmailLabelProvider implements LabelProvider {
           return await operation()
         } catch (refreshError) {
           // Check for the specific invalid_grant/invalid_rapt error
+          const refreshApiError = asGoogleApiError(refreshError)
           if (
-            refreshError.response?.data?.error === 'invalid_grant' &&
-            (refreshError.response?.data?.error_subtype === 'invalid_rapt' ||
-              refreshError.message?.includes('invalid_rapt'))
+            refreshApiError.response?.data?.error === 'invalid_grant' &&
+            (refreshApiError.response?.data?.error_subtype === 'invalid_rapt' ||
+              refreshApiError.message?.includes('invalid_rapt'))
           ) {
             // This is a re-authentication required error
             logger.warn('Re-authentication required, refresh token no longer valid', {

--- a/packages/lib/src/email/labels/outlook-label-provider.ts
+++ b/packages/lib/src/email/labels/outlook-label-provider.ts
@@ -14,6 +14,18 @@ import type { LabelProvider, ProviderLabel } from './label-provider.interface'
 
 const logger = createScopedLogger('outlook-label-provider')
 
+/** Shape Microsoft Graph client errors take: an Error decorated with HTTP details. */
+interface GraphApiError {
+  code?: string
+  statusCode?: number
+  message?: string
+}
+
+/** Narrows an unknown catch value to the loosely-shaped Graph error object. */
+function asGraphApiError(error: unknown): GraphApiError {
+  return typeof error === 'object' && error !== null ? (error as GraphApiError) : {}
+}
+
 export class OutlookLabelProvider implements LabelProvider {
   private client: Client | null = null
   private organizationId: string
@@ -76,7 +88,8 @@ export class OutlookLabelProvider implements LabelProvider {
       return await operation()
     } catch (error) {
       // If token expired, refresh token and try once more
-      if (error.statusCode === 401 || (error.code && error.code === 'InvalidAuthenticationToken')) {
+      const apiError = asGraphApiError(error)
+      if (apiError.statusCode === 401 || apiError.code === 'InvalidAuthenticationToken') {
         try {
           logger.info('Access token expired, refreshing and retrying operation')
 
@@ -87,9 +100,10 @@ export class OutlookLabelProvider implements LabelProvider {
           return await operation()
         } catch (refreshError) {
           // Check for invalid_grant errors that might indicate re-auth needed
+          const refreshApiError = asGraphApiError(refreshError)
           if (
-            refreshError.message?.includes('invalid_grant') ||
-            refreshError.message?.includes('AADSTS70000')
+            refreshApiError.message?.includes('invalid_grant') ||
+            refreshApiError.message?.includes('AADSTS70000')
           ) {
             logger.warn('Re-authentication required, refresh token no longer valid', {
               refreshError,

--- a/packages/lib/src/email/message-service.ts
+++ b/packages/lib/src/email/message-service.ts
@@ -3,6 +3,7 @@
 import { createScopedLogger } from '@auxx/logger'
 import { MessageSenderService } from '../messages/message-sender.service'
 import { MessageSyncService } from '../messages/message-sync-service'
+import type { ParticipantInput } from '../messages/types/message-sending.types'
 import type { ChannelProvider, SendMessageOptions } from '../providers/channel-provider.interface'
 import { ProviderRegistryService } from '../providers/provider-registry-service'
 import { WebhookManagerService } from '../providers/webhook-manager-service'
@@ -15,11 +16,20 @@ import { ChannelProviderType, MessageType } from '../providers/types'
 // Re-export for backward compatibility
 export { ChannelProviderType, MessageType }
 
+/** Email addresses -> the participant shape MessageSenderService expects. */
+function toParticipants(addresses: string | string[]): ParticipantInput[] {
+  return (Array.isArray(addresses) ? addresses : [addresses]).map((identifier) => ({
+    identifier,
+    identifierType: 'EMAIL' as const,
+  }))
+}
+
 export interface ActiveIntegration {
   type: ChannelProviderType
   id: string
   details: { identifier?: string; provider: string }
-  metadata?: { email?: string; phoneNumber?: string; pageId?: string } | null
+  /** Raw `Integration.metadata` jsonb — shape varies per provider. */
+  metadata?: Record<string, unknown> | null
 }
 
 export interface ProviderInstance {
@@ -27,7 +37,8 @@ export interface ProviderInstance {
   type: ChannelProviderType
   integrationId: string
   details: { identifier?: string; provider: string }
-  metadata?: { email?: string; phoneNumber?: string; pageId?: string } | null
+  /** Raw `Integration.metadata` jsonb — shape varies per provider. */
+  metadata?: Record<string, unknown> | null
 }
 
 /**
@@ -102,28 +113,32 @@ export class MessageService {
 
   async sendMessage(
     options: SendMessageOptions & {
-      providerType?: ChannelProviderType
-      integrationId?: string
+      /** Sending user — required by MessageSenderService for attribution. */
+      userId: string
+      integrationId: string
+      /** Internal thread to reply on. Omit to start a new thread. */
+      threadId?: string
     }
   ): Promise<{ id?: string; success: boolean; threadId?: string }> {
-    // Determine provider and delegate to MessageSenderService
     const sendResult = await this.messageSender.sendMessage({
-      to: Array.isArray(options.to) ? options.to : [options.to],
-      from: options.from || '',
-      subject: options.subject,
+      userId: options.userId,
+      organizationId: this.organizationId,
+      integrationId: options.integrationId,
+      threadId: options.threadId,
+      messageId: options.messageId,
+      subject: options.subject ?? '',
       textHtml: options.html,
       textPlain: options.text,
-      references: options.references,
-      inReplyTo: options.inReplyTo,
-      externalThreadId: options.externalThreadId,
-      providerType: options.providerType || 'google',
-      integrationId: options.integrationId || '',
+      to: toParticipants(options.to),
+      cc: options.cc ? toParticipants(options.cc) : undefined,
+      bcc: options.bcc ? toParticipants(options.bcc) : undefined,
+      attachmentIds: options.attachmentIds,
     })
 
     return {
       id: sendResult.id,
-      success: sendResult.success,
-      threadId: (sendResult as any).threadId,
+      success: sendResult.sendStatus === 'SENT',
+      threadId: sendResult.threadId,
     }
   }
 

--- a/packages/lib/src/email/polling-import-cache.ts
+++ b/packages/lib/src/email/polling-import-cache.ts
@@ -122,7 +122,7 @@ export async function clearImportCache(integrationId: string): Promise<void> {
   const redis = await getRedisClient()
   if (!redis) return
 
-  await redis.del(cacheKey(integrationId), processingKey(integrationId))
+  await redis.del([cacheKey(integrationId), processingKey(integrationId)])
 
   logger.debug('Cleared import cache', { integrationId })
 }

--- a/packages/lib/src/identity/types.ts
+++ b/packages/lib/src/identity/types.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/identity/types.ts
 
+import type { RecordId } from '@auxx/types/resource'
+
 /**
  * Fields needed to write or mirror one identity link into `RecordIdentity`.
  * Upserts on the record+kind unique key
@@ -37,6 +39,7 @@ export interface FindRecordByIdentityInput {
 }
 
 export interface RecordIdentityMatch {
-  recordId: string
+  /** Built by `findRecordByIdentity` via `toRecordId`, so it is always branded. */
+  recordId: RecordId
   displayName: string | null
 }

--- a/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
@@ -104,7 +104,7 @@ describe('findOrCreateContactFromJwt — chat (app-less) visitor', () => {
       contact_status: 'ACTIVE',
     })
     // No external_id array in the create payload.
-    expect(create.mock.calls[0][1]).not.toHaveProperty('external_id')
+    expect(create.mock.calls[0]?.[1]).not.toHaveProperty('external_id')
     expect(upsertRecordIdentity).toHaveBeenCalledWith(
       expect.objectContaining({
         entityInstanceId: 'new_contact',

--- a/packages/lib/src/ingest/contacts/find-or-create.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create.ts
@@ -11,6 +11,13 @@ import { getOwnDomains } from '../domain/classifier'
 import { getNamesFromParticipant } from '../participants/display'
 import { hasOrganizationSentToParticipant } from './has-sent-to'
 
+/** Roles that make a participant a recipient of an outbound message. */
+const OUTBOUND_RECIPIENT_ROLES: readonly ParticipantRole[] = [
+  ParticipantRoleEnum.TO,
+  ParticipantRoleEnum.CC,
+  ParticipantRoleEnum.BCC,
+]
+
 /**
  * Find (or create, depending on integration record-creation mode) a contact
  * EntityInstance for a participant. Uses UnifiedCrudHandler for the underlying
@@ -91,10 +98,7 @@ export async function findOrCreateContactForParticipant(
       }
 
       const isOutboundRecipient =
-        !messageContext.isInbound &&
-        [ParticipantRoleEnum.TO, ParticipantRoleEnum.CC, ParticipantRoleEnum.BCC].includes(
-          messageContext.role
-        )
+        !messageContext.isInbound && OUTBOUND_RECIPIENT_ROLES.includes(messageContext.role)
 
       if (!isOutboundRecipient) {
         const hasSentBefore = await hasOrganizationSentToParticipant(ctx, {

--- a/packages/lib/src/ingest/delete-messages.ts
+++ b/packages/lib/src/ingest/delete-messages.ts
@@ -96,7 +96,9 @@ export async function deleteMessagesByExternalIds(
       .from(schema.Message)
       .where(eq(schema.Message.threadId, threadId))
 
-    if (remaining.count === 0) {
+    // An aggregate always returns a row; when in doubt fall to the non-empty
+    // branch so a missing count can never delete a thread.
+    if (remaining?.count === 0) {
       await ctx.db.delete(schema.Thread).where(eq(schema.Thread.id, threadId))
       ctx.logger.debug('Deleted empty thread after message removal', { threadId })
 

--- a/packages/lib/src/ingest/filtering/store-ignored.ts
+++ b/packages/lib/src/ingest/filtering/store-ignored.ts
@@ -2,13 +2,22 @@
 
 import { schema } from '@auxx/database'
 import { ThreadStatus } from '@auxx/database/enums'
+import { sql } from 'drizzle-orm'
 import type { IngestContext } from '../context'
+import { findOrCreateParticipantRecord } from '../participants/find-or-create'
+import { determineIdentifierType } from '../participants/normalize'
 import type { MessageData } from '../types'
 
 /**
  * Insert a minimal Thread + Message pair purely for dedup purposes.
- * No participants, contacts, body, or attachments — the message was matched
- * by an ignore rule, we only need enough shape to keep future sync idempotent.
+ * No contacts, body, attachments, recipients, or events — the message was
+ * matched by an ignore rule, we only need enough shape to keep future sync
+ * idempotent.
+ *
+ * The sender Participant is the one exception: `Message.fromId` is NOT NULL
+ * with an FK to `Participant`, so the row cannot exist without it. Contact
+ * creation is explicitly suppressed, so an ignored sender still never enters
+ * the contact graph.
  */
 export async function storeIgnoredMessage(
   ctx: IngestContext,
@@ -28,20 +37,50 @@ export async function storeIgnoredMessage(
       participantCount: 0,
     })
     .onConflictDoUpdate({
+      // Nothing to change on a hit — we only need `RETURNING` to yield the
+      // existing row's id (DO NOTHING returns none). Drizzle rejects an empty
+      // `set`, so assign the conflict-target column to itself: `excluded` holds
+      // the same value the matched row already has, making this a no-op write.
       target: [schema.Thread.integrationId, schema.Thread.externalId],
-      set: {},
+      set: { externalId: sql`excluded."externalId"` },
     })
     .returning({ id: schema.Thread.id })
+
+  if (!thread) {
+    throw new Error(
+      `Ignored-message thread upsert returned no row for externalThreadId ${messageData.externalThreadId} (integration ${messageData.integrationId})`
+    )
+  }
+
+  const senderIdentifierType = await determineIdentifierType(
+    ctx,
+    messageData.from.identifier,
+    messageData.integrationId
+  )
+  const sender = await findOrCreateParticipantRecord(
+    ctx,
+    messageData.from,
+    senderIdentifierType,
+    // No messageContext: an ignored message must not move interaction state.
+    undefined,
+    null,
+    true
+  )
 
   const [message] = await ctx.db
     .insert(schema.Message)
     .values({
       externalId: messageData.externalId,
+      fromId: sender.id,
       externalThreadId: messageData.externalThreadId,
       threadId: thread.id,
       organizationId: messageData.organizationId,
       integrationId: messageData.integrationId,
       internetMessageId: messageData.internetMessageId,
+      // Both are NOT NULL with no column default — omitting them makes Postgres
+      // reject the row outright. Mirrors `storeMessage`'s insert.
+      createdAt: messageData.createdTime,
+      updatedAt: new Date(),
       sentAt: messageData.sentAt,
       receivedAt: messageData.receivedAt,
       subject: messageData.subject ?? '',

--- a/packages/lib/src/ingest/participants/find-or-create.ts
+++ b/packages/lib/src/ingest/participants/find-or-create.ts
@@ -21,6 +21,13 @@ import type { ParticipantInputData } from '../types'
 import { calculateDisplayName, calculateInitials } from './display'
 import { normalizeIdentifier } from './normalize'
 
+/** Roles that make a participant a recipient of an outbound message. */
+const OUTBOUND_RECIPIENT_ROLES: readonly ParticipantRole[] = [
+  ParticipantRoleEnum.TO,
+  ParticipantRoleEnum.CC,
+  ParticipantRoleEnum.BCC,
+]
+
 /**
  * Compute whether an email identifier belongs to the org. Returns true when
  * the address matches one of the active integration's own addresses
@@ -113,9 +120,7 @@ export async function findOrCreateParticipantRecord(
     const isOutboundRecipient =
       messageContext &&
       !messageContext.isInbound &&
-      [ParticipantRoleEnum.TO, ParticipantRoleEnum.CC, ParticipantRoleEnum.BCC].includes(
-        messageContext.role
-      )
+      OUTBOUND_RECIPIENT_ROLES.includes(messageContext.role)
 
     const isInternal = await classifyIsInternal(ctx, normalizedIdentifier, identifierType)
 
@@ -192,7 +197,15 @@ export async function findOrCreateParticipantRecord(
       })
       .returning()
 
+    // `INSERT … ON CONFLICT DO UPDATE … RETURNING` always yields exactly one
+    // row, so this is a shape assertion. Throwing keeps the caller from linking
+    // a message to a participant that was never written.
     const participant = participantData[0]
+    if (!participant) {
+      throw new Error(
+        `Participant upsert returned no row for ${identifierType} ${normalizedIdentifier}`
+      )
+    }
 
     // Emit `participant:updated` only when this was an UPDATE (previous row
     // existed) AND at least one tracked column actually changed. New rows
@@ -202,7 +215,10 @@ export async function findOrCreateParticipantRecord(
       const patch: Partial<ParticipantMeta> = {}
       if (participant.name !== previous.name) patch.name = participant.name
       if (participant.displayName !== previous.displayName) {
-        patch.displayName = participant.displayName
+        // `ParticipantMeta.displayName` is `string | undefined`; the column is
+        // nullable. The insert/update path always writes a computed display
+        // name (it falls back to the identifier), so null is unreachable here.
+        patch.displayName = participant.displayName ?? undefined
       }
       if (participant.hasReceivedMessage !== previous.hasReceivedMessage) {
         patch.hasReceivedMessage = participant.hasReceivedMessage
@@ -239,7 +255,16 @@ export async function findOrCreateParticipantRecord(
           .set({ entityInstanceId, updatedAt: new Date() })
           .where(eq(schema.Participant.id, participant.id))
           .returning()
-        return updatedParticipants[0]
+        const updated = updatedParticipants[0]
+        if (updated) return updated
+        // Zero rows back means the row we just upserted disappeared between the
+        // two statements (concurrent delete/merge). Return the in-memory row
+        // carrying the link we tried to write rather than an undefined record.
+        ctx.logger.warn('Participant row missing when linking its contact; using in-memory row', {
+          participantId: participant.id,
+          entityInstanceId,
+        })
+        return { ...participant, entityInstanceId }
       }
     }
 

--- a/packages/lib/src/ingest/reconciliation/merge-provider-data.ts
+++ b/packages/lib/src/ingest/reconciliation/merge-provider-data.ts
@@ -10,12 +10,16 @@ import type { MessageData } from '../types'
  * Merge provider-sourced data into an existing message row. Preserves any
  * user-authored fields on the row (text, html, snippet) when the provider
  * update would blank them, and marks metadata as reconciled.
+ *
+ * Returns `null` when the row disappeared between the match read and this
+ * write (concurrent delete/merge) — the caller then treats it as "no match"
+ * and stores the message fresh rather than reporting a merge that never landed.
  */
 export async function mergeProviderData(
   ctx: IngestContext,
   existing: Message,
   providerData: MessageData
-): Promise<Message> {
+): Promise<Message | null> {
   const mergedMetadata = {
     ...((existing.metadata as any) || {}),
     ...((providerData.metadata as any) || {}),
@@ -37,6 +41,14 @@ export async function mergeProviderData(
     })
     .where(eq(schema.Message.id, existing.id))
     .returning()
+
+  if (!row) {
+    ctx.logger.warn('Message row disappeared before provider-data merge could be applied', {
+      messageId: existing.id,
+      externalId: providerData.externalId,
+    })
+    return null
+  }
 
   return row
 }

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -2,7 +2,11 @@
 
 import { schema } from '@auxx/database'
 import { ParticipantRole as ParticipantRoleEnum, ThreadStatus } from '@auxx/database/enums'
-import type { ParticipantEntity as Participant, ParticipantRole } from '@auxx/database/types'
+import type {
+  ParticipantEntity as Participant,
+  ParticipantRole,
+  ThreadStatus as ThreadStatusValue,
+} from '@auxx/database/types'
 import { toRecordId } from '@auxx/types/resource'
 import { and, eq, isNull, sql } from 'drizzle-orm'
 import { touchActivityForThreadLinks } from '../entity-instances/activity'
@@ -34,7 +38,7 @@ import type { IntegrationSettings, MessageData, ParticipantInputData } from './t
  * state); TRASH/SPAM map straight through. Shared inboxes never call this — they
  * keep everything-open helpdesk semantics.
  */
-function deriveThreadStatusFromLabels(labelIds: string[]): ThreadStatus {
+function deriveThreadStatusFromLabels(labelIds: string[]): ThreadStatusValue {
   if (labelIds.includes('TRASH')) return ThreadStatus.TRASH
   if (labelIds.includes('SPAM')) return ThreadStatus.SPAM
   return labelIds.includes('INBOX') ? ThreadStatus.OPEN : ThreadStatus.ARCHIVED
@@ -116,7 +120,7 @@ export async function storeMessage(
           metadata: reconciledMetadata,
           receivedAt: messageData.receivedAt,
           sentAt: messageData.sentAt,
-          historyId: messageData.historyId ? BigInt(messageData.historyId) : null,
+          historyId: messageData.historyId ? Number(messageData.historyId) : null,
           isInbound: messageData.isInbound,
           updatedAt: new Date(),
         })
@@ -356,9 +360,10 @@ export async function storeMessage(
     const senderParticipantId = senderParticipant.id
 
     let firstReplyToParticipantId: string | null = null
-    if (messageData.replyTo && messageData.replyTo.length > 0) {
+    const firstReplyTo = messageData.replyTo?.[0]
+    if (firstReplyTo) {
       const replyToParticipant = await processAndCacheParticipant(
-        messageData.replyTo[0],
+        firstReplyTo,
         ParticipantRoleEnum.REPLY_TO
       )
       firstReplyToParticipantId = replyToParticipant?.id ?? null
@@ -407,7 +412,17 @@ export async function storeMessage(
           participantCount: schema.Thread.participantCount,
         })
 
+      // `INSERT … ON CONFLICT DO UPDATE … RETURNING` always yields exactly one
+      // row (unlike DO NOTHING, which returns none on a conflict), so this is a
+      // shape assertion, not a recoverable case. Throwing rolls the whole write
+      // set back rather than proceeding with a half-built thread.
       const thread = threadData[0]
+      if (!thread) {
+        throw new Error(
+          `Thread upsert returned no row for externalThreadId ${messageData.externalThreadId} (integration ${messageData.integrationId})`
+        )
+      }
+
       const isNewThread =
         (thread.messageCount ?? 0) === 1 &&
         thread.firstMessageAt?.getTime() === messageData.sentAt.getTime()
@@ -495,9 +510,17 @@ export async function storeMessage(
         })
         .returning({ id: schema.Message.id })
 
+      // Same guarantee as the thread upsert above — DO UPDATE always returns
+      // the row. Asserted here so the MessageParticipant / ThreadParticipant
+      // writes below can't insert links against an undefined messageId.
       const messageRecord = messageRecords[0]
+      if (!messageRecord) {
+        throw new Error(
+          `Message upsert returned no row for externalId ${messageData.externalId} (integration ${messageData.integrationId})`
+        )
+      }
 
-      if (isNewThread && messageRecord?.id) {
+      if (isNewThread && messageRecord.id) {
         await tx
           .update(schema.Thread)
           .set({ latestMessageId: messageRecord.id })

--- a/packages/lib/src/mail-query/__tests__/client.test.ts
+++ b/packages/lib/src/mail-query/__tests__/client.test.ts
@@ -300,6 +300,6 @@ describe('filterThreads', () => {
     ]
 
     const result = filterThreads(extended, { status: 'OPEN' })
-    expect(result[0].customField).toBe('test')
+    expect(result[0]?.customField).toBe('test')
   })
 })

--- a/packages/lib/src/mail-query/condition-query-builder.ts
+++ b/packages/lib/src/mail-query/condition-query-builder.ts
@@ -23,6 +23,7 @@ import {
   type SQL,
   sql,
 } from 'drizzle-orm'
+import type { AnyPgColumn } from 'drizzle-orm/pg-core'
 import type { Operator } from '../conditions/operator-definitions'
 import type { Condition, ConditionGroup } from '../conditions/types'
 import {
@@ -40,6 +41,18 @@ import {
 } from './visibility-scope'
 
 const logger = createScopedLogger('condition-query-builder')
+
+/**
+ * Normalize drizzle's "no clause" (`undefined`, returned by `and()` / `or()`
+ * when every operand is undefined) onto this builder's own sentinel (`null`).
+ *
+ * Both are falsy, so the `.filter(Boolean)` call sites in `buildGroupQuery` /
+ * `buildConditionGroupsQuery` behave identically — this is a type-level
+ * normalization at the drizzle boundary, not a change to which clauses survive.
+ */
+function toClause(built: SQL<unknown> | undefined): SQL<unknown> | null {
+  return built ?? null
+}
 
 /**
  * Build Drizzle WHERE condition from ConditionGroup[].
@@ -93,8 +106,11 @@ function buildGroupQuery(
     .filter(Boolean) as SQL<unknown>[]
 
   if (conditions.length === 0) return null
-  if (conditions.length === 1) return conditions[0]
+  if (conditions.length === 1) return conditions[0] ?? null
 
+  // Group-level operator: every surviving condition in the group is combined
+  // with the SAME operator, so dropping a condition above can never shift which
+  // operator a later clause is joined with.
   return group.logicalOperator === 'AND' ? and(...conditions)! : or(...conditions)!
 }
 
@@ -286,6 +302,7 @@ function buildInboxQuery(operator: Operator, value: any): SQL<unknown> | null {
   const inboxIds: string[] = raw.map((v: string) =>
     isRecordId(v) ? getInstanceId(v as RecordId) : v
   )
+  const [onlyInboxId] = inboxIds
 
   switch (operator) {
     case 'empty':
@@ -294,14 +311,15 @@ function buildInboxQuery(operator: Operator, value: any): SQL<unknown> | null {
       return isNotNull(Thread.inboxId)
     case 'is':
       if (inboxIds.length === 0) return null
-      if (inboxIds.length === 1) return eq(Thread.inboxId, inboxIds[0])
+      if (inboxIds.length === 1 && onlyInboxId !== undefined) return eq(Thread.inboxId, onlyInboxId)
       return inArray(Thread.inboxId, inboxIds)
     case 'in':
       if (inboxIds.length === 0) return null
       return inArray(Thread.inboxId, inboxIds)
     case 'is not':
       if (inboxIds.length === 0) return null
-      if (inboxIds.length === 1) return not(eq(Thread.inboxId, inboxIds[0]))
+      if (inboxIds.length === 1 && onlyInboxId !== undefined)
+        return not(eq(Thread.inboxId, onlyInboxId))
       return not(inArray(Thread.inboxId, inboxIds))
     case 'not in':
       if (inboxIds.length === 0) return null
@@ -374,7 +392,7 @@ function buildStatusQuery(operator: Operator, value: any): SQL<unknown> | null {
   if (operator === 'in' && Array.isArray(value)) {
     const conditions = value.map((v) => getStatusCondition(v)).filter(Boolean) as SQL<unknown>[]
     if (conditions.length === 0) return null
-    return or(...conditions)
+    return toClause(or(...conditions))
   }
 
   const condition = getStatusCondition(value)
@@ -421,7 +439,7 @@ function buildDateQuery(operator: Operator, value: any, field?: string): SQL<unk
       startOfDay.setHours(0, 0, 0, 0)
       const endOfDay = new Date(isDate)
       endOfDay.setHours(23, 59, 59, 999)
-      return and(gte(dateColumn, startOfDay), lte(dateColumn, endOfDay))
+      return toClause(and(gte(dateColumn, startOfDay), lte(dateColumn, endOfDay)))
     }
     case 'is not':
     case 'not_on_date': {
@@ -431,7 +449,7 @@ function buildDateQuery(operator: Operator, value: any, field?: string): SQL<unk
       startOfDay.setHours(0, 0, 0, 0)
       const endOfDay = new Date(isNotDate)
       endOfDay.setHours(23, 59, 59, 999)
-      return or(lt(dateColumn, startOfDay), gt(dateColumn, endOfDay))
+      return toClause(or(lt(dateColumn, startOfDay), gt(dateColumn, endOfDay)))
     }
     case 'empty':
       return isNull(dateColumn)
@@ -579,9 +597,9 @@ function buildSubjectQuery(operator: Operator, value: any): SQL<unknown> | null 
     case 'not contains':
       return not(ilike(Thread.subject, `%${value}%`))
     case 'empty':
-      return or(isNull(Thread.subject), eq(Thread.subject, ''))
+      return toClause(or(isNull(Thread.subject), eq(Thread.subject, '')))
     case 'not empty':
-      return and(isNotNull(Thread.subject), not(eq(Thread.subject, '')))
+      return toClause(and(isNotNull(Thread.subject), not(eq(Thread.subject, ''))))
     default:
       return null
   }
@@ -829,8 +847,10 @@ function buildFreeTextQuery(
     scopes.body
   )
 
-  // Search in subject OR body (textPlain / textHtml)
-  return or(subjectMatch!, bodyMatch!)
+  // Search in subject OR body (textPlain / textHtml). Both halves are built from
+  // a non-null `ilike` / `exists`, so `withScope` always returns a clause here.
+  if (!subjectMatch || !bodyMatch) return subjectMatch ?? bodyMatch
+  return toClause(or(subjectMatch, bodyMatch))
 }
 
 /**
@@ -883,14 +903,24 @@ function buildSentQuery(operator: Operator, value: any): SQL<unknown> | null {
 /**
  * Build condition for a direct string/ID column on Thread.
  * Supports: is, is not, contains, not contains, starts with, ends with,
- * in, not in, empty, not empty, exists, not exists
+ * in, not in, empty, not empty.
+ *
+ * `exists` / `not exists` are commented out of `OPERATOR_DEFINITIONS` (so they
+ * are not in the `Operator` union) but can still turn up in conditions that were
+ * persisted as jsonb before they were retired. They are aliased onto their
+ * surviving equivalents rather than falling through to `default` — dropping the
+ * clause would silently widen an AND group's result set.
  */
 function buildDirectColumnQuery(
   operator: Operator,
   value: any,
-  column: typeof Thread.id
+  column: AnyPgColumn
 ): SQL<unknown> | null {
-  switch (operator) {
+  const legacyOperator: string = operator
+  const op: Operator =
+    legacyOperator === 'exists' ? 'not empty' : legacyOperator === 'not exists' ? 'empty' : operator
+
+  switch (op) {
     case 'is':
       if (value === null || value === undefined) return isNull(column)
       return eq(column, String(value))
@@ -914,11 +944,9 @@ function buildDirectColumnQuery(
       return values.length > 0 ? not(inArray(column, values)) : null
     }
     case 'empty':
-    case 'not exists':
-      return or(isNull(column), eq(column, ''))
+      return toClause(or(isNull(column), eq(column, '')))
     case 'not empty':
-    case 'exists':
-      return and(isNotNull(column), not(eq(column, '')))
+      return toClause(and(isNotNull(column), not(eq(column, ''))))
     default:
       return null
   }

--- a/packages/lib/src/mail-query/context-to-conditions.ts
+++ b/packages/lib/src/mail-query/context-to-conditions.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/mail-query/context-to-conditions.ts
 
+import type { Operator } from '../conditions/operator-definitions'
 import type { Condition, ConditionGroup } from '../conditions/types'
 import { SEARCH_SCOPE_FIELD_ID } from '../mail-views/mail-view-field-definitions'
 
@@ -295,7 +296,7 @@ export function buildContextConditionGroups(params: ContextConditionParams): Con
  */
 export function buildConditionGroups(
   contextParams: ContextConditionParams,
-  searchConditions?: { id: string; fieldId: string; operator: string; value: any }[]
+  searchConditions?: { id: string; fieldId: string; operator: Operator; value: any }[]
 ): ConditionGroup[] {
   const groups: ConditionGroup[] = []
 
@@ -336,7 +337,12 @@ export function buildConditionGroups(
           group.conditions = []
         }
       } else if (searchFieldIds.size > 0) {
-        group.conditions = group.conditions.filter((c) => !searchFieldIds.has(c.fieldId))
+        // `searchFieldIds` only ever holds plain string fieldIds, so a
+        // relationship-path fieldId (ResourceFieldId[]) could never match and is
+        // always kept.
+        group.conditions = group.conditions.filter(
+          (c) => typeof c.fieldId !== 'string' || !searchFieldIds.has(c.fieldId)
+        )
       }
       if (group.conditions.length > 0) {
         groups.push(group)

--- a/packages/lib/src/mail-query/search-query-parser.ts
+++ b/packages/lib/src/mail-query/search-query-parser.ts
@@ -172,7 +172,10 @@ export function parseSearchQuery(query: string): ParsedSearchQuery {
     const operatorMatch = actualSegment.match(/^([a-zA-Z-]+):(.*)$/)
 
     if (operatorMatch) {
-      const [, operator, rawValue] = operatorMatch
+      // Both groups are non-optional in the regex above, so the fallbacks are
+      // unreachable — they only satisfy `noUncheckedIndexedAccess`.
+      const operator = operatorMatch[1] ?? ''
+      const rawValue = operatorMatch[2] ?? ''
 
       // Handle quoted values
       let value = rawValue

--- a/packages/lib/src/messages/message-attachment.service.ts
+++ b/packages/lib/src/messages/message-attachment.service.ts
@@ -89,7 +89,7 @@ export class MessageAttachmentService {
     }
 
     // Update message hasAttachments flag using Drizzle
-    const [{ cnt }] = await this.db
+    const [countRow] = await this.db
       .select({ cnt: count() })
       .from(schema.Attachment)
       .where(
@@ -100,7 +100,7 @@ export class MessageAttachmentService {
         )
       )
 
-    const hasAny = Number((cnt as any) ?? 0) > 0
+    const hasAny = Number(countRow?.cnt ?? 0) > 0
 
     await this.db
       .update(schema.Message)
@@ -145,7 +145,7 @@ export class MessageAttachmentService {
    * @returns Number of attachments
    */
   async getAttachmentCount(messageId: string): Promise<number> {
-    const [{ cnt }] = await this.db
+    const [countRow] = await this.db
       .select({ cnt: count() })
       .from(schema.Attachment)
       .where(
@@ -155,7 +155,7 @@ export class MessageAttachmentService {
           eq(schema.Attachment.organizationId, this.organizationId)
         )
       )
-    return Number((cnt as any) ?? 0)
+    return Number(countRow?.cnt ?? 0)
   }
 
   /**

--- a/packages/lib/src/messages/message-composer.service.ts
+++ b/packages/lib/src/messages/message-composer.service.ts
@@ -254,10 +254,11 @@ export class MessageComposerService {
 
     for (let i = 0; i < ids.length; i++) {
       const id = ids[i]
+      if (id === undefined) continue
       // Try MediaAsset first
       const asset = await this.db.query.MediaAsset.findFirst({
         where: (assets, { eq, and }) =>
-          and(eq(assets.id, id!), eq(assets.organizationId, organizationId)),
+          and(eq(assets.id, id), eq(assets.organizationId, organizationId)),
         columns: { id: true, name: true },
       })
       if (asset) {
@@ -272,7 +273,7 @@ export class MessageComposerService {
       // Try FolderFile
       const file = await this.db.query.FolderFile.findFirst({
         where: (files, { eq, and }) =>
-          and(eq(files.id, id!), eq(files.organizationId, organizationId)),
+          and(eq(files.id, id), eq(files.organizationId, organizationId)),
         columns: { id: true, name: true },
       })
       if (file) {
@@ -332,9 +333,12 @@ export class MessageComposerService {
           textPlain: textPlain,
           snippet: textPlain ? textPlain.slice(0, 280) : null,
 
-          // Update references
-          inReplyTo: input.inReplyTo,
-          references: input.references,
+          // NOTE: `Message.inReplyTo` / `Message.references` were dropped in
+          // migration 0028 and are NOT persisted. RFC threading headers are
+          // re-derived at send time from the thread's `internetMessageId`s
+          // (`MessageSenderService#getInReplyTo` / `#getReferences`), so
+          // `input.inReplyTo` / `input.references` only ride out on the returned
+          // `ComposedMessage`.
 
           // Update signature
           signatureId: input.signatureId,
@@ -478,9 +482,8 @@ export class MessageComposerService {
           textPlain: textPlain,
           snippet: textPlain ? textPlain.slice(0, 280) : null,
 
-          // Update references
-          inReplyTo: input.inReplyTo,
-          references: input.references,
+          // NOTE: `inReplyTo` / `references` are not columns — see the comment in
+          // `updateExistingDraft`. They travel on the returned `ComposedMessage`.
 
           // Update signature
           signatureId: input.signatureId,

--- a/packages/lib/src/messages/message-query.service.ts
+++ b/packages/lib/src/messages/message-query.service.ts
@@ -144,7 +144,7 @@ export class MessageQueryService {
         attempts: m.attempts ?? 0,
         attachments: attachmentsByMessage.get(m.id) ?? [],
       }
-      return redactMessage(meta as unknown as Record<string, unknown>, threadLens) as MessageMeta
+      return redactMessage(meta, threadLens)
     })
 
     return { messages, total: messages.length }
@@ -243,10 +243,7 @@ export class MessageQueryService {
           attempts: m.attempts ?? 0,
           attachments: attachmentsByMessage.get(m.id) ?? [],
         }
-        const redacted = redactMessage(
-          meta as unknown as Record<string, unknown>,
-          lensByThread.get(m.threadId) ?? 'none'
-        ) as MessageMeta
+        const redacted = redactMessage(meta, lensByThread.get(m.threadId) ?? 'none')
         return [m.id, redacted]
       })
     )

--- a/packages/lib/src/messages/message-reconciler.service.ts
+++ b/packages/lib/src/messages/message-reconciler.service.ts
@@ -243,9 +243,11 @@ export class MessageReconcilerService {
         historyId: providerData.historyId ? Number(providerData.historyId) : undefined,
         hasAttachments: providerData.hasAttachments,
 
-        // Threading
-        inReplyTo: providerData.inReplyTo || undefined,
-        references: providerData.references || undefined,
+        // Threading: `Message.inReplyTo` / `Message.references` were dropped in
+        // migration 0028, so there is nowhere to store the provider's copies.
+        // Outbound threading headers are re-derived from the thread's
+        // `internetMessageId`s at send time (`MessageSenderService#getInReplyTo`),
+        // and inbound ones stay in `metadata.headers` (see `ingest/store-message`).
 
         // Merge metadata
         metadata: {

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -14,6 +14,10 @@ import { ParticipantService } from '../participants/participant-service'
 import type { MailViewer } from '../permissions/visibility/context'
 import { isSystemViewer } from '../permissions/visibility/context'
 import { getThreadLens } from '../permissions/visibility/thread-lens'
+// Type-only (erased at runtime) so the lazy `await import()` of the error
+// normalizer below stays lazy. Aliased because the dynamic import destructures a
+// *value* binding of the same name into the same scope.
+import type { NormalizedEmailError as NormalizedEmailErrorInstance } from '../providers/error-normalization'
 import type { AttachmentFile } from '../providers/message-provider-interface'
 import type { ProviderRegistryService } from '../providers/provider-registry-service'
 import { getRealtimeService, publishMessageCreated } from '../realtime'
@@ -41,6 +45,27 @@ import type {
 } from './types/message-sending.types'
 
 const logger = createScopedLogger('message-sender')
+
+/** Module default connection, reachable from inside the constructor where the
+ *  `db` parameter shadows the `database as db` import. */
+const defaultDb: Database = db
+
+/**
+ * What providers actually return from `sendMessage`.
+ *
+ * `ChannelProvider.sendMessage` declares only `{ id?, success }`, but the email
+ * providers return more — Google returns `threadId` (see
+ * `google-provider.ts#sendMessage`) and Gmail additionally returns `historyId` /
+ * `labelIds`. Widening the shared interface belongs in `providers/`; this local
+ * shape at least keeps the extra reads named instead of `(result as any).x`.
+ */
+type ProviderSendResult = {
+  success: boolean
+  id?: string
+  threadId?: string
+  historyId?: string
+  labelIds?: string[]
+}
 
 /** Providers where "recipient" means an email address — suppression + List-Unsubscribe
  * apply here and nowhere else (chat/SMS/social DMs have no unsubscribe concept). */
@@ -81,12 +106,16 @@ export class MessageSenderService {
     viewer?: MailViewer
   ) {
     this.viewer = viewer
-    this.threadManager = new ThreadManagerService(organizationId, db)
-    this.composer = new MessageComposerService(organizationId, db)
-    this.reconciler = new MessageReconcilerService(organizationId, this.threadManager, db)
-    this.participantService = new ParticipantService(organizationId, db)
-    this.mediaAssetService = new MediaAssetService(organizationId, undefined, db)
-    this.fileService = new FileService(organizationId, undefined, db)
+    // `MessageComposerService` / `MessageReconcilerService` take a non-optional
+    // `Database` and dereference it eagerly, so callers that omit `db` (e.g.
+    // `email/message-service.ts`) must still get a real connection here.
+    const conn = db ?? defaultDb
+    this.threadManager = new ThreadManagerService(organizationId, conn)
+    this.composer = new MessageComposerService(organizationId, conn)
+    this.reconciler = new MessageReconcilerService(organizationId, this.threadManager, conn)
+    this.participantService = new ParticipantService(organizationId, conn)
+    this.mediaAssetService = new MediaAssetService(organizationId, undefined, conn)
+    this.fileService = new FileService(organizationId, undefined, conn)
     this.socketId = socketId
   }
   /**
@@ -235,7 +264,7 @@ export class MessageSenderService {
         internetMessageId: composed.messageId,
       })
       // Step 4: Apply signature if needed
-      let finalContent = {
+      let finalContent: { html?: string | null; plain?: string | null } = {
         html: composed.textHtml,
         plain: composed.textPlain,
       }
@@ -441,6 +470,7 @@ export class MessageSenderService {
     requiresRecipients: boolean
     countsAgainstOutboundEmailsQuota: boolean
     triggersPostSendSync: boolean
+    requiresSendReconciliation: boolean
   }> {
     const [integration] = await (this.db ?? db)
       .select({ provider: schema.Integration.provider })
@@ -458,6 +488,7 @@ export class MessageSenderService {
       requiresRecipients: caps.requiresRecipients,
       countsAgainstOutboundEmailsQuota: caps.countsAgainstOutboundEmailsQuota,
       triggersPostSendSync: caps.triggersPostSendSync,
+      requiresSendReconciliation: caps.requiresSendReconciliation,
     }
   }
   /**
@@ -687,7 +718,7 @@ export class MessageSenderService {
         ? undefined
         : input.threadContext.externalId
       // Call provider's sendMessage method
-      const result = await provider.sendMessage({
+      const result: ProviderSendResult = await provider.sendMessage({
         messageId: input.composed.messageId,
         internalMessageId: input.composed.id,
         from: input.participants.from.identifier,
@@ -708,8 +739,8 @@ export class MessageSenderService {
         success: result.success,
         messageId: result.id,
         threadId: result.threadId,
-        historyId: (result as any).historyId,
-        labelIds: (result as any).labelIds,
+        historyId: result.historyId,
+        labelIds: result.labelIds,
         timestamp: new Date(),
         metadata: result,
       }
@@ -720,7 +751,7 @@ export class MessageSenderService {
       )
       // Determine provider type for normalization
       const providerType = (provider as any).getProviderName?.() || 'unknown'
-      let normalizedError: NormalizedEmailError
+      let normalizedError: NormalizedEmailErrorInstance
       // Check if already normalized
       if (error && typeof error === 'object' && error.name === 'NormalizedEmailError') {
         normalizedError = error
@@ -752,9 +783,14 @@ export class MessageSenderService {
       return {
         success: false,
         error: userMessage,
-        errorCode: normalizedError.code,
-        retryable: normalizedError.details?.retryable,
         timestamp: new Date(),
+        // `ProviderSendResponse` carries only `error`; the structured code and
+        // retryability ride along in `metadata` (nothing reads them off the
+        // response today — they exist for the failure log / future retry logic).
+        metadata: {
+          errorCode: normalizedError.code,
+          retryable: normalizedError.details?.retryable,
+        },
       }
     }
   }
@@ -815,30 +851,40 @@ export class MessageSenderService {
     }
     return {
       id: message.id,
-      externalId: message.externalId,
+      // Both columns are nullable in the schema but always populated on the send
+      // path (`createPendingMessage` writes a `pending_<token>` externalId and a
+      // subject); `SentMessage` declares them non-null.
+      externalId: message.externalId ?? '',
       threadId: message.threadId,
-      subject: message.subject,
+      subject: message.subject ?? '',
       sendStatus: message.sendStatus || 'PENDING',
       sentAt: message.sentAt,
       error: message.providerError,
     }
   }
   /**
-   * Checks if we can send messages for an integration
+   * Checks if we can send messages for an integration.
+   *
+   * NOTE: currently has no callers anywhere in `packages/` or `apps/`.
+   *
+   * `Integration.settings` was dropped in migration 0028; integration settings
+   * now live under `Integration.metadata.settings` (same read as
+   * `google-provider.ts#initialize`). The gate is deliberately fail-open — an
+   * integration with no settings blob can send.
    */
   async canSendMessages(integrationId: string): Promise<boolean> {
     const [integration] = await db
       .select({
         id: schema.Integration.id,
         provider: schema.Integration.provider,
-        settings: schema.Integration.settings,
+        metadata: schema.Integration.metadata,
       })
       .from(schema.Integration)
       .where(eq(schema.Integration.id, integrationId))
       .limit(1)
     if (!integration) return false
     // Check if integration is configured for sending
-    const settings = integration.settings as any
+    const settings = (integration.metadata as { settings?: { canSend?: boolean } } | null)?.settings
     return settings?.canSend !== false
   }
   /**
@@ -1184,14 +1230,17 @@ export class MessageSenderService {
     const cc: ProcessedParticipant[] = []
     const bcc: ProcessedParticipant[] = []
     for (const mp of message.participants) {
+      // `initials` is on the `Participant` row but not on `ProcessedParticipant`
+      // — nothing on the send path reads it, so it is not carried through.
       const participant: ProcessedParticipant = {
         id: mp.participant.id,
         identifier: mp.participant.identifier,
         identifierType: mp.participant.identifierType,
         name: mp.participant.name,
         displayName: mp.participant.displayName,
-        initials: mp.participant.initials,
-        contactId: mp.participant.contactId,
+        // The linked CRM contact is `Participant.entityInstanceId`; there is no
+        // `contactId` column, so the old key read `undefined` and dropped it.
+        entityInstanceId: mp.participant.entityInstanceId,
         role: mp.role,
       }
       switch (mp.role) {
@@ -1206,7 +1255,7 @@ export class MessageSenderService {
           break
       }
     }
-    return { from, to, cc, bcc }
+    return { from, to, cc, bcc, all: [from, ...to, ...cc, ...bcc] }
   }
   /**
    * Extracts attachments from a message for retry
@@ -1257,7 +1306,7 @@ export class MessageSenderService {
       const sanitizedExternalThreadId = this.isPlaceholderThreadId(params.threadContext.externalId)
         ? undefined
         : params.threadContext.externalId
-      const result = await provider.sendMessage({
+      const result: ProviderSendResult = await provider.sendMessage({
         messageId: params.internetMessageId, // Use original Message-ID
         from: params.participants.from.identifier,
         to: params.participants.to.map((p: any) => p.identifier),
@@ -1275,8 +1324,8 @@ export class MessageSenderService {
         success: result.success,
         messageId: result.id,
         threadId: result.threadId,
-        historyId: (result as any).historyId,
-        labelIds: (result as any).labelIds,
+        historyId: result.historyId,
+        labelIds: result.labelIds,
         timestamp: new Date(),
         metadata: result,
       }
@@ -1286,7 +1335,7 @@ export class MessageSenderService {
         '../providers/error-normalization'
       )
       const providerType = (provider as any).getProviderName?.() || 'unknown'
-      let normalizedError: NormalizedEmailError
+      let normalizedError: NormalizedEmailErrorInstance
       if (error && typeof error === 'object' && error.name === 'NormalizedEmailError') {
         normalizedError = error
       } else if (providerType === 'google' || providerType === 'gmail') {

--- a/packages/lib/src/messages/message-sync-service.ts
+++ b/packages/lib/src/messages/message-sync-service.ts
@@ -319,20 +319,19 @@ export class MessageSyncService {
 
     // Log detailed results for failures
     results.forEach((result, index) => {
+      // `results` comes from settling `providerInstances.map(...)`, so the two
+      // arrays are index-aligned; the fallback label only guards the type.
       const providerInstance = providerInstances[index]
+      const label = providerInstance
+        ? `${providerInstance.type} - ${providerInstance.integrationId}`
+        : `unknown provider #${index}`
       if (result.status === 'rejected') {
-        logger.warn(
-          `Sync failed for: ${providerInstance.type} - ${providerInstance.integrationId}`,
-          {
-            reason: result.reason,
-            organizationId: this.organizationId,
-          }
-        )
+        logger.warn(`Sync failed for: ${label}`, {
+          reason: result.reason,
+          organizationId: this.organizationId,
+        })
       } else {
-        logger.debug(
-          `Sync succeeded for: ${providerInstance.type} - ${providerInstance.integrationId}`,
-          { organizationId: this.organizationId }
-        )
+        logger.debug(`Sync succeeded for: ${label}`, { organizationId: this.organizationId })
       }
     })
 

--- a/packages/lib/src/messages/sync-messages.ts
+++ b/packages/lib/src/messages/sync-messages.ts
@@ -231,7 +231,9 @@ export class SyncMessages {
           removeOnFail: false, // Keep failed jobs for inspection
           attempts: 3, // Retry attempts for this specific integration sync
           backoff: { type: 'exponential', delay: 1000 },
-          timeout: 300000, // 5 minutes - prevents runaway jobs even if lock is maintained
+          // NOTE: BullMQ removed the per-job `timeout` option (it was Bull v3);
+          // it has been silently ignored here. Runaway jobs are bounded by the
+          // worker's `lockDuration` / `stalledInterval`, not by job options.
         }
       )
       logger.info(

--- a/packages/lib/src/messages/thread-manager.service.ts
+++ b/packages/lib/src/messages/thread-manager.service.ts
@@ -42,10 +42,11 @@ export class ThreadManagerService {
     organizationId: string
   }): Promise<ThreadContext> {
     // If threadId provided, retrieve existing thread
-    if (input.threadId) {
+    const { threadId, organizationId } = input
+    if (threadId) {
       const thread = await this.db.query.Thread.findFirst({
         where: (threads, { and, eq }) =>
-          and(eq(threads.id, input.threadId), eq(threads.organizationId, input.organizationId)),
+          and(eq(threads.id, threadId), eq(threads.organizationId, organizationId)),
         columns: {
           id: true,
           organizationId: true,

--- a/packages/lib/src/messages/types/message-query.types.ts
+++ b/packages/lib/src/messages/types/message-query.types.ts
@@ -29,8 +29,13 @@ export interface AttachmentMeta {
 /**
  * Message metadata for display.
  * Simplified structure using ParticipantId[] for all participant references.
+ *
+ * Declared as a type alias rather than an interface on purpose: only object-type
+ * aliases get an implicit index signature, which is what lets a `MessageMeta`
+ * be passed to the generic `redactMessage<T extends Record<string, unknown>>`
+ * and come back still typed as `MessageMeta` — no double cast through `unknown`.
  */
-export interface MessageMeta {
+export type MessageMeta = {
   id: string
   threadId: string
   subject: string | null

--- a/packages/lib/src/messages/types/message-sending.types.ts
+++ b/packages/lib/src/messages/types/message-sending.types.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/messages/types/message-sending.types.ts
-import type { IdentifierType, ParticipantRole, SendStatus } from '@auxx/database/enums'
+// `@auxx/database/enums` exports these as const *objects* (values); the matching
+// string-literal union *types* live in `@auxx/database/types`.
+import type { IdentifierType, ParticipantRole, SendStatus } from '@auxx/database/types'
 
 /**
  * Input for sending a message

--- a/packages/lib/src/providers/__tests__/provider-capabilities.test.ts
+++ b/packages/lib/src/providers/__tests__/provider-capabilities.test.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/providers/__tests__/provider-capabilities.test.ts
 
 import { IntegrationProviderType } from '@auxx/database/enums'
+import type { IntegrationProviderType as ProviderType } from '@auxx/database/types'
 import { describe, expect, it, vi } from 'vitest'
 import { getProviderCapabilities, PROVIDER_CAPABILITIES } from '../provider-capabilities'
 import { ProviderRegistryService } from '../provider-registry-service'
@@ -70,6 +71,19 @@ vi.mock('../openphone/openphone-provider', () => ({
   OpenPhoneProvider: vi.fn().mockImplementation(() => ({ ...mockProvider })),
 }))
 
+/**
+ * Reads a provider's capability preset and fails loudly when it is missing, so
+ * a dropped preset surfaces as one explicit error instead of every downstream
+ * assertion quietly comparing against `undefined`.
+ */
+function capabilitiesFor(providerType: ProviderType) {
+  const capabilities = PROVIDER_CAPABILITIES[providerType]
+  if (!capabilities) {
+    throw new Error(`No capability preset registered for provider "${providerType}"`)
+  }
+  return capabilities
+}
+
 describe('Provider Capabilities', () => {
   describe('PROVIDER_CAPABILITIES constants', () => {
     it('should have capabilities defined for all provider types', () => {
@@ -126,7 +140,7 @@ describe('Provider Capabilities', () => {
   })
 
   describe('Email Provider Capabilities', () => {
-    const emailCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.email]
+    const emailCapabilities = capabilitiesFor(IntegrationProviderType.email)
 
     it('should support full email operations', () => {
       expect(emailCapabilities.canSend).toBe(true)
@@ -159,7 +173,7 @@ describe('Provider Capabilities', () => {
   })
 
   describe('Facebook Provider Capabilities', () => {
-    const facebookCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.facebook]
+    const facebookCapabilities = capabilitiesFor(IntegrationProviderType.facebook)
 
     it('should support basic messaging', () => {
       expect(facebookCapabilities.canSend).toBe(true)
@@ -189,7 +203,7 @@ describe('Provider Capabilities', () => {
   })
 
   describe('Instagram Provider Capabilities', () => {
-    const instagramCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.instagram]
+    const instagramCapabilities = capabilitiesFor(IntegrationProviderType.instagram)
 
     it('should support basic messaging but not labels', () => {
       expect(instagramCapabilities.canSend).toBe(true)
@@ -214,8 +228,8 @@ describe('Provider Capabilities', () => {
   })
 
   describe('SMS/OpenPhone Provider Capabilities', () => {
-    const smsCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.sms]
-    const openPhoneCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.openphone]
+    const smsCapabilities = capabilitiesFor(IntegrationProviderType.sms)
+    const openPhoneCapabilities = capabilitiesFor(IntegrationProviderType.openphone)
 
     it('should support basic SMS operations', () => {
       expect(smsCapabilities.canSend).toBe(true)
@@ -243,7 +257,7 @@ describe('Provider Capabilities', () => {
   })
 
   describe('WhatsApp Provider Capabilities', () => {
-    const whatsappCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.whatsapp]
+    const whatsappCapabilities = capabilitiesFor(IntegrationProviderType.whatsapp)
 
     it('should support messaging with attachments', () => {
       expect(whatsappCapabilities.canSend).toBe(true)
@@ -267,7 +281,7 @@ describe('Provider Capabilities', () => {
   })
 
   describe('Shopify Provider Capabilities', () => {
-    const shopifyCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.shopify]
+    const shopifyCapabilities = capabilitiesFor(IntegrationProviderType.shopify)
 
     it('should not support any messaging operations', () => {
       expect(shopifyCapabilities.canSend).toBe(false)
@@ -284,7 +298,7 @@ describe('Provider Capabilities', () => {
   })
 
   describe('Outlook Provider Capabilities', () => {
-    const outlookCapabilities = PROVIDER_CAPABILITIES[IntegrationProviderType.outlook]
+    const outlookCapabilities = capabilitiesFor(IntegrationProviderType.outlook)
 
     it('should support full email operations like Gmail', () => {
       expect(outlookCapabilities.canSend).toBe(true)
@@ -383,10 +397,7 @@ describe('Provider Capabilities', () => {
       commonActions.forEach((action) => {
         Object.keys(PROVIDER_CAPABILITIES).forEach((providerType) => {
           expect(() => {
-            providerRegistry.isActionSupportedByProvider(
-              action,
-              providerType as keyof typeof IntegrationProviderType
-            )
+            providerRegistry.isActionSupportedByProvider(action, providerType as ProviderType)
           }).not.toThrow()
         })
       })

--- a/packages/lib/src/providers/__tests__/provider-channel.test.ts
+++ b/packages/lib/src/providers/__tests__/provider-channel.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { IntegrationProviderType } from '@auxx/database/enums'
+import type { IntegrationProviderType as ProviderType } from '@auxx/database/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { FacebookProvider } from '../facebook/facebook-provider'
 import { GoogleProvider } from '../google/google-provider'
@@ -414,7 +415,7 @@ describe('Provider Integration Tests', () => {
   describe('Error Handling and Edge Cases', () => {
     it('should handle unknown provider types gracefully', () => {
       // Should return default minimal capabilities for unknown types
-      const unknownCaps = getProviderCapabilities('unknown' as IntegrationProviderType)
+      const unknownCaps = getProviderCapabilities('unknown' as ProviderType)
       expect(unknownCaps.canSend).toBe(false)
       expect(unknownCaps.canReply).toBe(false)
       expect(unknownCaps.labelScope).toBe('none')

--- a/packages/lib/src/providers/__tests__/provider-registry-service.test.ts
+++ b/packages/lib/src/providers/__tests__/provider-registry-service.test.ts
@@ -218,6 +218,19 @@ function makeGetProviderRow(overrides: Record<string, unknown> = {}, requiresRea
   return { integration: makeIntegrationRow(overrides), requiresReauth }
 }
 
+/**
+ * Returns the first element of a result array, failing loudly when the array is
+ * empty so an unexpectedly empty result reads as an explicit error rather than
+ * a `TypeError` on `undefined` (or, worse, a silently skipped assertion).
+ */
+function firstOf<T>(items: readonly T[]): T {
+  const [item] = items
+  if (item === undefined) {
+    throw new Error('Expected at least one item in the result, but it was empty')
+  }
+  return item
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -285,7 +298,7 @@ describe('ProviderRegistryService', () => {
       const result = await service.getAllIntegrations()
 
       expect(result).toHaveLength(1)
-      expect(result[0].details.identifier).toBe('+15551234567')
+      expect(firstOf(result).details.identifier).toBe('+15551234567')
     })
 
     it('should filter out unknown provider types', async () => {
@@ -298,7 +311,7 @@ describe('ProviderRegistryService', () => {
       const result = await service.getAllIntegrations()
 
       expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('int-1')
+      expect(firstOf(result).id).toBe('int-1')
     })
 
     it('should return an empty array when no integrations exist', async () => {
@@ -376,7 +389,7 @@ describe('ProviderRegistryService', () => {
       // Only the outlook provider should be cached
       const instances = service.getAllProviderInstances()
       expect(instances).toHaveLength(1)
-      expect(instances[0].integrationId).toBe('int-ok')
+      expect(firstOf(instances).integrationId).toBe('int-ok')
     })
 
     it('should clear previously cached providers before re-initializing', async () => {
@@ -391,7 +404,7 @@ describe('ProviderRegistryService', () => {
 
       const instances = service.getAllProviderInstances()
       expect(instances).toHaveLength(1)
-      expect(instances[0].integrationId).toBe('int-2')
+      expect(firstOf(instances).integrationId).toBe('int-2')
     })
   })
 
@@ -688,8 +701,8 @@ describe('ProviderRegistryService', () => {
       const providers = await service.getProvidersWithCapability('canReact')
 
       expect(providers).toHaveLength(1)
-      expect(providers[0].integrationId).toBe('int-fb')
-      expect(providers[0].type).toBe(IntegrationProviderType.facebook)
+      expect(firstOf(providers).integrationId).toBe('int-fb')
+      expect(firstOf(providers).type).toBe(IntegrationProviderType.facebook)
     })
 
     it('should return empty array when no providers support the capability', async () => {

--- a/packages/lib/src/providers/chat/chat-provider.ts
+++ b/packages/lib/src/providers/chat/chat-provider.ts
@@ -332,7 +332,6 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
             latestMessageId: finalId,
             messageCount: sql`${schema.Thread.messageCount} + 1`,
             status: ThreadStatus.OPEN,
-            updatedAt: now,
           })
           .where(eq(schema.Thread.id, thread.id))
 

--- a/packages/lib/src/providers/facebook/facebook-provider.ts
+++ b/packages/lib/src/providers/facebook/facebook-provider.ts
@@ -6,6 +6,7 @@ import { IntegrationProviderType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import {
+  type IntegrationSettings, // Per-integration record-creation/filter settings
   type MessageData, // Data structure expected by storage service
   MessageStorageService,
   type ParticipantInputData, // Structure for participant info from provider
@@ -56,6 +57,33 @@ interface FacebookWebhookMessage {
 interface FacebookGraphParticipant {
   id: string // PSID or Page ID
   name?: string
+}
+/** Generic shape of a paginated Graph API edge response. */
+interface FacebookGraphListResponse<T> {
+  data?: T[]
+  paging?: {
+    next?: string | null
+  }
+  error?: {
+    message?: string
+    code?: number
+  }
+}
+/** Conversation node returned by the /{page-id}/conversations edge. */
+interface FacebookGraphConversation {
+  id?: string
+  updated_time?: string
+  participants?: {
+    data?: FacebookGraphParticipant[]
+  }
+}
+/** Message node returned by the /{conversation-id}/messages edge. */
+interface FacebookGraphMessage {
+  id?: string
+  created_time?: string
+  from?: FacebookGraphParticipant
+  to?: unknown
+  message?: unknown
 }
 // --- End Interfaces ---
 export class FacebookProvider
@@ -147,10 +175,14 @@ export class FacebookProvider
       })
       throw new Error(`Invalid metadata format for Facebook integration ${integrationId}`)
     }
-    // Pass integration settings to storage service
-    if (integration.settings) {
-      this.storageService.setIntegrationSettings(integration.settings as any)
-      logger.info(`Integration settings loaded for selective mode: ${integration.settings}`)
+    // Pass integration settings to storage service (they live in metadata)
+    const settings = (integration.metadata as { settings?: IntegrationSettings }).settings
+    if (settings) {
+      this.storageService.setIntegrationSettings(settings)
+      logger.info('Integration settings loaded for selective mode', {
+        integrationId,
+        hasSettings: true,
+      })
     }
     logger.info(`FacebookProvider initialized successfully for Page ID: ${this.pageId}`, {
       integrationId,
@@ -289,7 +321,8 @@ export class FacebookProvider
           { integrationId: this.integrationId }
         )
         const convoRes = await fetch(conversationsLink)
-        const convoData = await convoRes.json()
+        const convoData =
+          (await convoRes.json()) as FacebookGraphListResponse<FacebookGraphConversation>
         if (!convoRes.ok || convoData.error) {
           logger.error('Failed to fetch conversations', {
             status: convoRes.status,
@@ -353,7 +386,7 @@ export class FacebookProvider
               { integrationId: this.integrationId }
             )
             const msgRes = await fetch(messagesLink)
-            const msgData = await msgRes.json()
+            const msgData = (await msgRes.json()) as FacebookGraphListResponse<FacebookGraphMessage>
             if (!msgRes.ok || msgData.error) {
               logger.error(`Failed to fetch messages for conversation ${conversationId}`, {
                 status: msgRes.status,
@@ -379,7 +412,7 @@ export class FacebookProvider
                 messagesToStore.push(converted)
               }
             }
-            messagesLink = msgData.paging?.next // Get next page link for messages
+            messagesLink = msgData.paging?.next ?? null // Get next page link for messages
           } // End message pagination loop
           // --- Store fetched messages for this conversation ---
           if (messagesToStore.length > 0) {
@@ -392,7 +425,7 @@ export class FacebookProvider
             )
           }
         } // End conversation loop
-        conversationsLink = convoData.paging?.next // Get next page link for conversations
+        conversationsLink = convoData.paging?.next ?? null // Get next page link for conversations
       } // End conversation pagination loop
       // Update last synced time after successful completion
       await db
@@ -409,9 +442,11 @@ export class FacebookProvider
         integrationId: this.integrationId,
       })
       // Update last synced time even on failure to mark the attempt? Optional.
-      await db.integration
-        .update({ where: { id: this.integrationId! }, data: { lastSyncedAt: new Date() } })
-        .catch((updateErr) =>
+      await db
+        .update(schema.Integration)
+        .set({ lastSyncedAt: new Date() })
+        .where(eq(schema.Integration.id, this.integrationId!))
+        .catch((updateErr: unknown) =>
           logger.error('Failed to update lastSyncedAt after sync error', { updateErr })
         )
       throw error // Re-throw the error
@@ -502,8 +537,13 @@ export class FacebookProvider
         cc: [],
         bcc: [],
         replyTo: [],
-        hasAttachments: attachments.length > 0,
-        attachments: attachments,
+        // Facebook has no inbound attachment ingestor, so no MessageAttachment
+        // rows are ever created and `providerAttachments` is never populated.
+        // `hasAttachments` is a workflow trigger filter (see
+        // workflow-engine/nodes/trigger-nodes/message-received.ts), so claiming
+        // true here fires attachment rules for bytes that were never fetched.
+        // The `attachments` local below still drives the snippet fallback.
+        hasAttachments: false,
         textPlain: message.message, //text,
         textHtml: undefined, // No HTML support
         snippet: message.message

--- a/packages/lib/src/providers/google/drafts/create-draft.ts
+++ b/packages/lib/src/providers/google/drafts/create-draft.ts
@@ -76,7 +76,7 @@ export async function createGmailDraft(
 
     return {
       id: response.data.id,
-      messageId: response.data.message?.id,
+      messageId: response.data.message?.id ?? undefined,
     }
   } catch (error) {
     throw await handleGmailError(error, 'createDraft', integrationId)

--- a/packages/lib/src/providers/google/drafts/send-draft.ts
+++ b/packages/lib/src/providers/google/drafts/send-draft.ts
@@ -65,7 +65,7 @@ export async function sendGmailDraft(input: SendGmailDraftInput): Promise<SendGm
 
     return {
       id: response.data.id,
-      threadId: response.data.threadId,
+      threadId: response.data.threadId ?? undefined,
     }
   } catch (error) {
     throw await handleGmailError(error, 'sendDraft', integrationId)

--- a/packages/lib/src/providers/google/messages/batch-fetch.ts
+++ b/packages/lib/src/providers/google/messages/batch-fetch.ts
@@ -395,7 +395,7 @@ function parseBatchResponse(batchResponseText: string, contentTypeHeader: string
   const results: any[] = []
 
   for (let i = 1; i < parts.length - 1; i++) {
-    const part = parts[i].trim()
+    const part = parts[i]?.trim()
     if (!part) continue
 
     const jsonStartIndex = part.indexOf('{')

--- a/packages/lib/src/providers/google/messages/parse-message.ts
+++ b/packages/lib/src/providers/google/messages/parse-message.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/providers/google/messages/parse-message.ts
 
+import type { EmailLabel as EmailLabelType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { extractEmailAddress, isUserEmail } from '@auxx/utils'
 import parse from 'gmail-api-parse-message'
@@ -217,15 +218,6 @@ export function convertMessagesToMessageData(
           embeddedData: att.embeddedData,
         }))
 
-        // Legacy attachments array (for hasAttachments and backward compat)
-        const attachments = payloadAttachments.map((att) => ({
-          filename: att.filename,
-          mimeType: att.mimeType,
-          size: att.size,
-          inline: att.inline,
-          contentId: att.contentId,
-        }))
-
         return {
           externalId: message.id,
           externalThreadId: message.threadId,
@@ -241,8 +233,7 @@ export function convertMessagesToMessageData(
           cc: ccInputs,
           bcc: bccInputs,
           replyTo: replyToInputs,
-          hasAttachments: attachments.length > 0,
-          attachments,
+          hasAttachments: payloadAttachments.length > 0,
           providerAttachments,
           textHtml: message.textHtml || '',
           textPlain: message.textPlain || '',
@@ -255,7 +246,7 @@ export function convertMessagesToMessageData(
           references: message.headers['references'],
           metadata: { headers: message.headers },
           isInbound,
-        } as MessageData
+        } satisfies MessageData
       } catch (error: any) {
         logger.error('Error converting Gmail message to MessageData:', {
           error: error.message,
@@ -298,7 +289,7 @@ function determineIsInbound(message: ParsedGmailMessage, userEmails: string[]): 
 /**
  * Determine the email label based on Gmail labels
  */
-function determineEmailLabel(labelIds: string[]): EmailLabel {
+function determineEmailLabel(labelIds: string[]): EmailLabelType {
   if (labelIds.includes('DRAFT')) return EmailLabel.draft
   if (labelIds.includes('SENT')) return EmailLabel.sent
   // Note: EmailLabel enum doesn't have spam/trash, so we map them to inbox

--- a/packages/lib/src/providers/google/threads/update-status.ts
+++ b/packages/lib/src/providers/google/threads/update-status.ts
@@ -29,20 +29,23 @@ export async function updateThreadStatus(options: UpdateThreadStatusOptions): Pr
 
   logger.info(`Updating Gmail thread ${externalThreadId} status to ${status}`)
 
-  const reqBody: gmail_v1.Schema$ModifyThreadRequest = { addLabelIds: [], removeLabelIds: [] }
+  const reqBody: { addLabelIds: string[]; removeLabelIds: string[] } = {
+    addLabelIds: [],
+    removeLabelIds: [],
+  }
 
   switch (status) {
     case MessageStatus.READ:
-      reqBody.removeLabelIds?.push('UNREAD')
+      reqBody.removeLabelIds.push('UNREAD')
       break
     case MessageStatus.UNREAD:
-      reqBody.addLabelIds?.push('UNREAD')
+      reqBody.addLabelIds.push('UNREAD')
       break
     case MessageStatus.IMPORTANT:
-      reqBody.addLabelIds?.push('IMPORTANT')
+      reqBody.addLabelIds.push('IMPORTANT')
       break
     case MessageStatus.STARRED:
-      reqBody.addLabelIds?.push('STARRED')
+      reqBody.addLabelIds.push('STARRED')
       break
     // Archive/Spam/Trash handled by specific methods
     default:
@@ -50,7 +53,7 @@ export async function updateThreadStatus(options: UpdateThreadStatusOptions): Pr
       return false
   }
 
-  if (reqBody.addLabelIds?.length === 0 && reqBody.removeLabelIds?.length === 0) return true // No change
+  if (reqBody.addLabelIds.length === 0 && reqBody.removeLabelIds.length === 0) return true // No change
 
   try {
     await modifyWithThrottling(gmail, 'thread', externalThreadId, reqBody, integrationId, throttler)

--- a/packages/lib/src/providers/google/webhooks/remove-webhook.ts
+++ b/packages/lib/src/providers/google/webhooks/remove-webhook.ts
@@ -25,19 +25,21 @@ export async function removeWebhook(params: {
     logger.info('Gmail watch stopped successfully', { integrationId })
 
     // Clear watch metadata from database
-    await db
-      .update(schema.Integration)
-      .set({
-        metadata: db.raw(`
-          CASE
-            WHEN metadata IS NOT NULL
-            THEN jsonb_set(metadata, '{watchExpiration}', 'null'::jsonb)
-            ELSE NULL
-          END
-        `),
-      })
+    const [integration] = await db
+      .select({ metadata: schema.Integration.metadata })
+      .from(schema.Integration)
       .where(eq(schema.Integration.id, integrationId))
-      .catch((err) => logger.error('Failed to clear watch metadata after stop', { err }))
+      .limit(1)
+
+    const metadata = integration?.metadata
+    if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+      const { watchExpiration: _cleared, ...rest } = metadata as Record<string, unknown>
+      await db
+        .update(schema.Integration)
+        .set({ metadata: rest })
+        .where(eq(schema.Integration.id, integrationId))
+        .catch((err) => logger.error('Failed to clear watch metadata after stop', { err }))
+    }
   } catch (error: any) {
     const gaxiosError = error as GaxiosError
 

--- a/packages/lib/src/providers/imap/imap-get-messages.ts
+++ b/packages/lib/src/providers/imap/imap-get-messages.ts
@@ -109,11 +109,6 @@ export class ImapGetMessagesService {
                 name: addr.name,
               })),
               hasAttachments: parsed.attachments.length > 0,
-              attachments: parsed.attachments.map((att) => ({
-                filename: att.filename,
-                mimeType: att.mimeType,
-                size: att.size,
-              })),
               internetMessageId: parsed.messageId || null,
               inReplyTo: parsed.inReplyTo || null,
               references: parsed.references || null,

--- a/packages/lib/src/providers/imap/imap-message-parser.ts
+++ b/packages/lib/src/providers/imap/imap-message-parser.ts
@@ -8,6 +8,15 @@ import type { ParsedEmail } from './types'
 
 const logger = createScopedLogger('imap-parser')
 
+/**
+ * PostalMime hands attachment bodies back as an ArrayBuffer by default, but as a
+ * string when a text/base64 encoding is requested. Measure both correctly.
+ */
+function attachmentByteLength(content: ArrayBuffer | string | undefined): number {
+  if (!content) return 0
+  return typeof content === 'string' ? Buffer.byteLength(content) : content.byteLength
+}
+
 export class ImapMessageParserService {
   /** Fetch and parse a single message by UID from an already-locked mailbox */
   async parseMessage(client: ImapFlow, uid: number): Promise<ParsedEmail | null> {
@@ -58,7 +67,7 @@ export class ImapMessageParserService {
         attachments: (parsed.attachments || []).map((att) => ({
           filename: att.filename || 'unnamed',
           mimeType: att.mimeType || 'application/octet-stream',
-          size: att.content?.byteLength || 0,
+          size: attachmentByteLength(att.content),
         })),
       }
     } catch (error) {

--- a/packages/lib/src/providers/instagram/instagram-provider.ts
+++ b/packages/lib/src/providers/instagram/instagram-provider.ts
@@ -6,7 +6,7 @@ import { IntegrationProviderType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import {
-  EmailLabel, // Still needed for MessageData structure
+  type IntegrationSettings, // Per-integration record-creation/filter settings
   type MessageData, // Data structure expected by storage service
   MessageStorageService,
   type ParticipantInputData, // Structure for participant info from provider
@@ -50,6 +50,33 @@ interface InstagramGraphMessageContent {
 interface InstagramGraphParticipant {
   id: string // IGSID or IGBID
   username?: string // Instagram username
+}
+/** Generic shape of a paginated Graph API edge response. */
+interface InstagramGraphListResponse<T> {
+  data?: T[]
+  paging?: {
+    next?: string | null
+  }
+  error?: {
+    message?: string
+    code?: number
+  }
+}
+/** Conversation node returned by the /{page-id}/conversations edge (platform=instagram). */
+interface InstagramGraphConversation {
+  id?: string
+  updated_time?: string
+  participants?: {
+    data?: InstagramGraphParticipant[]
+  }
+}
+/** Message node returned by the /{conversation-id}/messages edge. */
+interface InstagramGraphMessage {
+  id?: string
+  created_time?: string
+  from?: InstagramGraphParticipant
+  to?: unknown
+  message?: unknown
 }
 // --- End Interfaces ---
 export class InstagramProvider
@@ -138,10 +165,14 @@ export class InstagramProvider
       })
       throw new Error(`Invalid metadata format for Instagram integration ${integrationId}`)
     }
-    // Pass integration settings to storage service
-    if (integration.settings) {
-      this.storageService.setIntegrationSettings(integration.settings as any)
-      logger.info(`Integration settings loaded for selective mode: ${integration.settings}`)
+    // Pass integration settings to storage service (they live in metadata)
+    const settings = (integration.metadata as { settings?: IntegrationSettings }).settings
+    if (settings) {
+      this.storageService.setIntegrationSettings(settings)
+      logger.info('Integration settings loaded for selective mode', {
+        integrationId,
+        hasSettings: true,
+      })
     }
     logger.info(
       `InstagramProvider initialized successfully for IGBID: ${this.instagramBusinessAccountId}, Page ID: ${this.pageId}`,
@@ -287,7 +318,8 @@ export class InstagramProvider
           { integrationId: this.integrationId }
         )
         const convoRes = await fetch(conversationsLink)
-        const convoData = await convoRes.json()
+        const convoData =
+          (await convoRes.json()) as InstagramGraphListResponse<InstagramGraphConversation>
         if (!convoRes.ok || convoData.error) {
           logger.error('Failed to fetch Instagram conversations', {
             status: convoRes.status,
@@ -350,7 +382,8 @@ export class InstagramProvider
               { integrationId: this.integrationId }
             )
             const msgRes = await fetch(messagesLink)
-            const msgData = await msgRes.json()
+            const msgData =
+              (await msgRes.json()) as InstagramGraphListResponse<InstagramGraphMessage>
             if (!msgRes.ok || msgData.error) {
               logger.error(`Failed to fetch messages for IG conversation ${conversationId}`, {
                 status: msgRes.status,
@@ -376,7 +409,7 @@ export class InstagramProvider
                 messagesToStore.push(converted)
               }
             }
-            messagesLink = msgData.paging?.next // Next page link for messages
+            messagesLink = msgData.paging?.next ?? null // Next page link for messages
           } // End message pagination
           // --- Store fetched messages ---
           if (messagesToStore.length > 0) {
@@ -388,7 +421,7 @@ export class InstagramProvider
             )
           }
         } // End conversation loop
-        conversationsLink = convoData.paging?.next // Next page link for conversations
+        conversationsLink = convoData.paging?.next ?? null // Next page link for conversations
       } // End conversation pagination
       // Update last synced time on successful completion
       await db
@@ -504,8 +537,13 @@ export class InstagramProvider
         cc: [],
         bcc: [],
         replyTo: [],
-        hasAttachments: attachments.length > 0,
-        attachments: attachments,
+        // Instagram has no inbound attachment ingestor, so no MessageAttachment
+        // rows are ever created and `providerAttachments` is never populated.
+        // `hasAttachments` is a workflow trigger filter (see
+        // workflow-engine/nodes/trigger-nodes/message-received.ts), so claiming
+        // true here fires attachment rules for bytes that were never fetched.
+        // The `attachments` local below still drives the snippet fallback.
+        hasAttachments: false,
         textPlain: text,
         textHtml: undefined, // No HTML
         snippet: text ? text.substring(0, 100) : attachments[0]?.filename || '',
@@ -520,7 +558,6 @@ export class InstagramProvider
         // Default values for non-applicable fields
         keywords: [],
         labelIds: [],
-        emailLabel: EmailLabel.inbox,
       }
       return messageData
     } catch (error: any) {

--- a/packages/lib/src/providers/mailgun/mailgun-api-service.ts
+++ b/packages/lib/src/providers/mailgun/mailgun-api-service.ts
@@ -261,11 +261,13 @@ export class MailgunApiService implements EmailProvider {
 
     // Add attachments if provided
     if (options.attachments && options.attachments.length > 0) {
-      messageData.attachment = options.attachments.map((attachment) => ({
-        filename: attachment.filename,
-        data: attachment.data,
-        contentType: attachment.contentType,
-      }))
+      messageData.attachment = options.attachments.map(
+        (attachment: { filename: string; data: Buffer; contentType: string }) => ({
+          filename: attachment.filename,
+          data: attachment.data,
+          contentType: attachment.contentType,
+        })
+      )
     }
 
     try {

--- a/packages/lib/src/providers/message-provider-interface.ts
+++ b/packages/lib/src/providers/message-provider-interface.ts
@@ -1,14 +1,14 @@
 // packages/lib/src/providers/message-provider-interface.ts
 
-import type { IntegrationProviderType } from '@auxx/database/types'
 import type { ProviderCapabilities } from './provider-capabilities'
+import type { ChannelProviderType } from './types'
 
 /**
  * Extended interface for message providers with capability support
  */
 export interface MessageProvider {
   // Provider identification
-  type: IntegrationProviderType
+  type: ChannelProviderType
   integrationId: string | null
   organizationId: string
 
@@ -273,7 +273,7 @@ export interface ShareOptions {
  */
 export abstract class BaseMessageProvider implements MessageProvider {
   constructor(
-    public type: IntegrationProviderType,
+    public type: ChannelProviderType,
     public integrationId: string | null,
     public organizationId: string
   ) {}

--- a/packages/lib/src/providers/openphone/openphone-provider.ts
+++ b/packages/lib/src/providers/openphone/openphone-provider.ts
@@ -6,9 +6,10 @@ import { IntegrationProviderType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import {
-  EmailLabel, // Keep for MessageData structure
+  type IntegrationSettings, // Per-integration record-creation/filter settings
   type MessageData,
   MessageStorageService,
+  type ParticipantInputData,
 } from '../../email/email-storage' // Adjust path
 import type {
   ChannelProvider,
@@ -18,7 +19,6 @@ import type {
 import { BaseMessageProvider, type MessageProvider } from '../message-provider-interface'
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
 import type {
-  OpenPhoneAttachment,
   OpenPhoneConversation,
   OpenPhoneIntegrationMetadata,
   OpenPhoneMessage,
@@ -106,10 +106,14 @@ export class OpenPhoneProvider
       })
       throw new Error(`Invalid metadata format for OpenPhone integration ${integrationId}`)
     }
-    // Pass integration settings to storage service
-    if (integration.settings) {
-      this.storageService.setIntegrationSettings(integration.settings as any)
-      logger.info(`Integration settings loaded for selective mode: ${integration.settings}`)
+    // Pass integration settings to storage service (they live in metadata)
+    const settings = (integration.metadata as { settings?: IntegrationSettings }).settings
+    if (settings) {
+      this.storageService.setIntegrationSettings(settings)
+      logger.info('Integration settings loaded for selective mode', {
+        integrationId,
+        hasSettings: true,
+      })
     }
     logger.info(
       `OpenphoneProvider initialized successfully for Number: ${this.phoneNumber} (ID: ${this.phoneNumberId})`,
@@ -417,16 +421,11 @@ export class OpenPhoneProvider
         logger.warn(`Missing recipient number for message ${externalId}`)
         toNumber = 'unknown_recipient'
       }
-      const fromParticipant = { address: fromNumber, identifierType: IdentifierType.PHONE } // No name info directly on message sender/recipient
-      const toParticipant = { address: toNumber, identifierType: IdentifierType.PHONE }
-      const attachments = (message.attachments || []).map((att: OpenPhoneAttachment) => ({
-        id: att.id, // Store OpenPhone attachment ID
-        filename: att.file_name,
-        mimeType: att.content_type,
-        size: att.size_bytes,
-        inline: false, // Assume not inline for SMS/MMS attachments
-        contentLocation: att.url,
-      }))
+      // No name info directly on message sender/recipient. The ingest pipeline derives the
+      // IdentifierType from the integration's provider (openphone -> PHONE), so the raw
+      // identifier is all that is passed here.
+      const fromParticipant: ParticipantInputData = { identifier: fromNumber }
+      const toParticipant: ParticipantInputData = { identifier: toNumber }
       const messageData: MessageData = {
         externalId: externalId,
         externalThreadId: externalThreadId,
@@ -441,15 +440,20 @@ export class OpenPhoneProvider
         cc: [],
         bcc: [],
         replyTo: [],
-        hasAttachments: attachments.length > 0,
-        attachments: attachments,
+        // OpenPhone has no inbound attachment ingestor, so no MessageAttachment
+        // rows are ever created and `providerAttachments` is never populated.
+        // `hasAttachments` is a workflow trigger filter (see
+        // workflow-engine/nodes/trigger-nodes/message-received.ts), so claiming
+        // true here fires attachment rules for bytes that were never fetched.
+        // The raw MMS payload — including each attachment's `url` — is retained
+        // in `metadata.openphone_message` for a future backfill.
+        hasAttachments: false,
         textPlain: message.body,
         snippet: message.body?.substring(0, 100),
         isInbound: isInbound,
         metadata: { openphone_message: message, openphone_conversation: conversation }, // Store raw event
         keywords: [],
         labelIds: [],
-        emailLabel: EmailLabel.inbox,
         // Fields from Message model defaults
         isFirstInThread: false, // Cannot easily determine from single message
         isAIGenerated: false, // Assume false

--- a/packages/lib/src/providers/outlook/outlook-provider.ts
+++ b/packages/lib/src/providers/outlook/outlook-provider.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'node:crypto'
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { IntegrationProviderType } from '@auxx/database/enums'
-import type { IntegrationEntity } from '@auxx/database/types'
+import type { EmailLabel as EmailLabelType, IntegrationEntity } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { getAttachmentByteSize, sanitizeFilename, toGraphRecipients } from '@auxx/utils'
 import {
@@ -523,10 +523,14 @@ export class OutlookProvider
         })
       }
       // Store/update subscription ID and potentially the secret used in metadata
+      const storedMetadata = this.integration?.metadata as
+        | Record<string, unknown>
+        | null
+        | undefined
       if (
-        (this.integrationId &&
-          (this.integration?.metadata as any)?.graphSubscriptionId !== response.id) ||
-        (this.integration?.metadata as any)?.webhookSecret !== webhookSecret
+        this.integrationId &&
+        (storedMetadata?.graphSubscriptionId !== response.id ||
+          storedMetadata?.webhookSecret !== webhookSecret)
       ) {
         const updatedMetadata = {
           ...(this.integration?.metadata || {}),
@@ -800,7 +804,7 @@ export class OutlookProvider
           const senderEmail = fromInput.identifier?.toLowerCase()
           const isInbound = allAddresses.size > 0 ? !allAddresses.has(senderEmail || '') : true
           // Determine EmailLabel based on standard folder names (case-insensitive check might be needed)
-          let _emailLabel = EmailLabel.inbox // Default
+          let _emailLabel: EmailLabelType = EmailLabel.inbox // Default
           const folderIdLower = message.parentFolderId?.toLowerCase()
           if (folderIdLower === 'sentitems' || folderIdLower?.includes('sent')) {
             // Simple checks
@@ -837,7 +841,6 @@ export class OutlookProvider
             bcc: bccInputs,
             replyTo: replyToInputs,
             hasAttachments: message.hasAttachments || false,
-            attachments: [], // Processed separately if needed
             textHtml:
               message.body?.contentType?.toLowerCase() === 'html'
                 ? message.body?.content

--- a/packages/lib/src/providers/provider-capabilities.ts
+++ b/packages/lib/src/providers/provider-capabilities.ts
@@ -1,13 +1,16 @@
 // packages/lib/src/providers/provider-capabilities.ts
 
+// `IntegrationProviderType` from `@auxx/database/enums` is a const *object* — usable
+// for keys/values only. `ChannelProviderType` (providers/types.ts) is the matching
+// union *type*, aliased onto the same enum object.
 import { IntegrationProviderType } from '@auxx/database/enums'
-import type { ProviderCapabilities } from './types'
+import type { ChannelProviderType, ProviderCapabilities } from './types'
 
 export type { ProviderCapabilities } from './types'
 /**
  * Provider capability presets
  */
-export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapabilities> = {
+export const PROVIDER_CAPABILITIES: Record<ChannelProviderType, ProviderCapabilities> = {
   [IntegrationProviderType.google]: {
     supportsPersonalConnection: true,
     supportsBidirectionalStatusSync: true,
@@ -463,9 +466,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
 /**
  * Helper function to get provider capabilities with defaults
  */
-export function getProviderCapabilities(
-  providerType: IntegrationProviderType
-): ProviderCapabilities {
+export function getProviderCapabilities(providerType: ChannelProviderType): ProviderCapabilities {
   return (
     PROVIDER_CAPABILITIES[providerType] || {
       // Default minimal capabilities

--- a/packages/lib/src/providers/provider-registry-service.ts
+++ b/packages/lib/src/providers/provider-registry-service.ts
@@ -53,6 +53,15 @@ export class ProviderRegistryService {
     }
   }
   /**
+   * Narrow the raw `Integration.metadata` jsonb column (typed `unknown`) to a
+   * plain object, or null when it is absent / not an object.
+   */
+  private static asMetadataRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null
+  }
+  /**
    * Get identifier from metadata (helper extracted from MessageService)
    */
   private static getIdentifierFromMetadata(metadata: any | null): string | undefined {
@@ -96,7 +105,7 @@ export class ProviderRegistryService {
             type: providerType,
             id: integration.id,
             details: { identifier: identifier, provider: integration.provider },
-            metadata: integration.metadata,
+            metadata: ProviderRegistryService.asMetadataRecord(integration.metadata),
           })
         } else {
           logger.warn(`Skipping unknown integration provider type: ${integration.provider}`, {
@@ -196,7 +205,15 @@ export class ProviderRegistryService {
           provider = new EmailForwardingProvider(this.organizationId)
           break
         case IntegrationProviderEnum.chat:
-          provider = new ChatProvider(this.organizationId)
+          // ChatProvider deliberately implements the narrower `MessageProvider`
+          // (send/receive) rather than the fat legacy `ChannelProvider`: chat has
+          // no webhooks, no external mailbox to sync and no labels. The registry
+          // itself only calls `initialize()`, and every ChannelProvider-only path
+          // excludes chat explicitly (`channels/toggle` skips webhook register /
+          // unregister for chat, `channels/sync` rejects it), so none of the
+          // legacy members are reachable on a chat instance. Splitting
+          // `ChannelProvider` is the real fix — see the registry TODO.
+          provider = new ChatProvider(this.organizationId) as unknown as ChannelProvider
           break
         default:
           logger.error('Attempted to initialize unsupported provider type', { type, integrationId })
@@ -393,7 +410,7 @@ export class ProviderRegistryService {
   async getBestProviderForAction(actionType: string): Promise<{
     type: IntegrationProviderType
     integrationId: string
-    provider: IntegrationProvider
+    provider: ChannelProvider
   } | null> {
     // Get all available providers and check which ones support the action
     for (const [key, instance] of this.providers) {

--- a/packages/lib/src/providers/provider-utils.ts
+++ b/packages/lib/src/providers/provider-utils.ts
@@ -42,8 +42,9 @@ export function parseParticipantString(participantStr: string): ParticipantInput
   try {
     const parsed = addressparser(trimmedStr)
 
-    if (parsed && parsed.length > 0) {
-      const { address, name } = parsed[0]
+    const first = parsed?.[0]
+    if (first) {
+      const { address, name } = first
 
       if (address) {
         const cleanName = name ? stripBoundaryQuotes(name) || undefined : undefined
@@ -81,7 +82,7 @@ export function parseMultipleParticipants(participantsStr: string): ParticipantI
     const parsedAddresses = addressparser(participantsStr)
 
     return parsedAddresses
-      .map(({ address, name }) => {
+      .map(({ address, name }): ParticipantInputData | null => {
         if (!address) {
           logger.debug(
             `Skipping invalid address in multiple participants: ${JSON.stringify({ address, name })}`

--- a/packages/lib/src/providers/type-utils.ts
+++ b/packages/lib/src/providers/type-utils.ts
@@ -8,8 +8,8 @@
 
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
-import { eq } from 'drizzle-orm'
-import type { ChannelProviderType, MessageType } from './types'
+import { eq, inArray } from 'drizzle-orm'
+import { ChannelProviderType, MessageType } from './types'
 
 /**
  * Derives the primary message type from a provider.
@@ -26,20 +26,21 @@ import type { ChannelProviderType, MessageType } from './types'
  */
 export function getMessageTypeFromProvider(provider: ChannelProviderType): MessageType {
   const mapping: Record<ChannelProviderType, MessageType> = {
-    google: 'EMAIL',
-    outlook: 'EMAIL',
-    mailgun: 'EMAIL',
-    email: 'EMAIL',
-    facebook: 'FACEBOOK',
-    instagram: 'INSTAGRAM',
-    openphone: 'SMS',
-    sms: 'SMS',
-    whatsapp: 'WHATSAPP',
-    chat: 'CHAT',
-    shopify: 'EMAIL', // Shopify uses email notifications
+    google: MessageType.EMAIL,
+    outlook: MessageType.EMAIL,
+    mailgun: MessageType.EMAIL,
+    email: MessageType.EMAIL,
+    imap: MessageType.EMAIL,
+    facebook: MessageType.FACEBOOK,
+    instagram: MessageType.INSTAGRAM,
+    openphone: MessageType.SMS,
+    sms: MessageType.SMS,
+    whatsapp: MessageType.WHATSAPP,
+    chat: MessageType.CHAT,
+    shopify: MessageType.EMAIL, // Shopify uses email notifications
   }
 
-  return mapping[provider] || 'EMAIL'
+  return mapping[provider] || MessageType.EMAIL
 }
 
 /**
@@ -67,7 +68,7 @@ export async function getProviderForMessage(
     .where(eq(schema.Message.id, messageId))
     .limit(1)
 
-  return result[0]?.provider || 'google'
+  return result[0]?.provider ?? ChannelProviderType.google
 }
 
 /**
@@ -95,7 +96,7 @@ export async function getProviderForThread(
     .where(eq(schema.Thread.id, threadId))
     .limit(1)
 
-  return result[0]?.provider || 'google'
+  return result[0]?.provider ?? ChannelProviderType.google
 }
 
 /**
@@ -127,7 +128,7 @@ export async function getProvidersForMessages(
     })
     .from(schema.Message)
     .innerJoin(schema.Integration, eq(schema.Message.integrationId, schema.Integration.id))
-    .where(eq(schema.Message.id, messageIds[0])) // This needs inArray for multiple IDs
+    .where(inArray(schema.Message.id, messageIds))
 
   const map = new Map<string, ChannelProviderType>()
   for (const result of results) {
@@ -166,7 +167,7 @@ export async function getProvidersForThreads(
     })
     .from(schema.Thread)
     .innerJoin(schema.Integration, eq(schema.Thread.integrationId, schema.Integration.id))
-    .where(eq(schema.Thread.id, threadIds[0])) // This needs inArray for multiple IDs
+    .where(inArray(schema.Thread.id, threadIds))
 
   const map = new Map<string, ChannelProviderType>()
   for (const result of results) {

--- a/packages/lib/src/providers/types.ts
+++ b/packages/lib/src/providers/types.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/providers/types.ts
 
+import { IntegrationProviderType } from '@auxx/database/enums'
+
 /**
  * Centralized provider type definitions for consistent usage across the codebase
  * This file serves as the single source of truth for provider type mapping
@@ -85,23 +87,20 @@ export interface ProviderCapabilities {
 }
 
 /**
- * Channel Provider Types Enum
- * These correspond to the provider strings stored in the database
+ * Channel Provider Types
+ *
+ * Aliased directly onto the generated `IntegrationProviderType` enum object so
+ * this can never drift from the `IntegrationProviderType` pgEnum backing
+ * `Integration.provider`. Usable as a value (`ChannelProviderType.google`) and
+ * as a type, and — unlike a TS `enum` — a bare `'google'` read straight off a
+ * Drizzle row is assignable to it.
+ *
+ * Members: google | outlook | facebook | instagram | openphone | mailgun |
+ * sms | whatsapp | chat | email | shopify | imap.
  */
-export enum ChannelProviderType {
-  google = 'google',
-  outlook = 'outlook',
-  facebook = 'facebook',
-  instagram = 'instagram',
-  openphone = 'openphone',
-  mailgun = 'mailgun',
-  sms = 'sms', // Generic SMS provider
-  whatsapp = 'whatsapp', // WhatsApp Business API
-  chat = 'chat', // Internal chat system
-  email = 'email', // Generic email provider
-  shopify = 'shopify', // Shopify integration (not a messaging provider)
-  imap = 'imap', // Generic IMAP/SMTP email (self-hosted, enterprise)
-}
+export const ChannelProviderType = IntegrationProviderType
+export type ChannelProviderType =
+  (typeof IntegrationProviderType)[keyof typeof IntegrationProviderType]
 
 /**
  * Message Type Categories

--- a/packages/lib/src/providers/vendor-modules.d.ts
+++ b/packages/lib/src/providers/vendor-modules.d.ts
@@ -1,0 +1,24 @@
+// packages/lib/src/providers/vendor-modules.d.ts
+
+/**
+ * Ambient declarations for provider dependencies that ship no types.
+ *
+ * Without these, `tsc` reports TS7016 and the import resolves to `any`, which
+ * per the §2.10 suppression rule hides every error derived from it. Both are
+ * declared as narrowly as their single call site allows.
+ */
+
+declare module 'gmail-api-parse-message' {
+  /**
+   * Flattens a `gmail_v1.Schema$Message` into headers/textPlain/textHtml.
+   * The real return shape is untyped; callers assert it to `ParsedGmailMessage`.
+   */
+  export default function parse(message: unknown): unknown
+}
+
+declare module 'planer' {
+  /** Strips quoted reply chains from a message body. */
+  export function extractFrom(text: string, contentType: string): string
+  const planer: { extractFrom: typeof extractFrom }
+  export default planer
+}

--- a/packages/lib/src/threads/__tests__/thread-action-access.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-action-access.test.ts
@@ -84,12 +84,15 @@ const THREAD_B = 'thr_cuid00000000000000000b'
 function viewer(): UserInstanceGrants {
   return {
     userId: USER_ID,
-    role: 'MEMBER',
+    // `OrganizationRole` is OWNER | ADMIN | USER — 'USER' is the plain-member rank.
+    role: 'USER',
     isAdmin: false,
     isMailAdmin: false,
     inboxLens: {},
     personalInboxIds: {},
     grants: {},
+    // Empty = fail-closed: no def is ticket-like, so nothing derives.
+    defEntityTypes: {},
   }
 }
 

--- a/packages/lib/src/threads/__tests__/thread-assignee-patch-format.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-assignee-patch-format.test.ts
@@ -110,12 +110,15 @@ function makeDb(selectResults: unknown[][], updateResult: unknown[]) {
 function viewer(): UserInstanceGrants {
   return {
     userId: ACTOR_ID,
-    role: 'MEMBER',
+    // `OrganizationRole` is OWNER | ADMIN | USER — 'USER' is the plain-member rank.
+    role: 'USER',
     isAdmin: false,
     isMailAdmin: false,
     inboxLens: {},
     personalInboxIds: {},
     grants: {},
+    // Empty = fail-closed: no def is ticket-like, so nothing derives.
+    defEntityTypes: {},
   }
 }
 

--- a/packages/lib/src/threads/__tests__/thread-query.service.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-query.service.test.ts
@@ -3,6 +3,7 @@
 import { getRedisClient } from '@auxx/redis'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { InternalFilterContextType } from '../../mail-query/types'
+import type { UserInstanceGrants } from '../../permissions/visibility/context'
 import { createMockRedis } from '../../test/utils'
 import { ThreadQueryService } from '../thread-query.service'
 
@@ -142,6 +143,21 @@ const mockDb = {
   ),
 }
 
+/** A plain member viewer — no grants, no admin short-circuit. */
+function viewer(): UserInstanceGrants {
+  return {
+    userId: 'user-123',
+    role: 'USER',
+    isAdmin: false,
+    isMailAdmin: false,
+    inboxLens: {},
+    personalInboxIds: {},
+    grants: {},
+    // Empty = fail-closed: no def is ticket-like, so nothing derives.
+    defEntityTypes: {},
+  }
+}
+
 describe('ThreadQueryService', () => {
   let service: ThreadQueryService
   const organizationId = 'test-org-id'
@@ -153,10 +169,13 @@ describe('ThreadQueryService', () => {
     mockRedis.keys.mockResolvedValue([])
     mockRedis.del.mockResolvedValue(0)
     mockRedis.setex.mockResolvedValue('OK')
-    vi.mocked(getRedisClient).mockResolvedValue(mockRedis)
+    // `createMockRedis` only stubs the handful of commands this suite exercises.
+    vi.mocked(getRedisClient).mockResolvedValue(
+      mockRedis as unknown as Awaited<ReturnType<typeof getRedisClient>>
+    )
 
     mockDb.execute.mockResolvedValue({ rows: [] })
-    service = new ThreadQueryService(organizationId, mockDb as any)
+    service = new ThreadQueryService(organizationId, mockDb as any, viewer())
   })
 
   describe('Phase 1: Thread ID Query', () => {

--- a/packages/lib/src/threads/links.service.ts
+++ b/packages/lib/src/threads/links.service.ts
@@ -314,7 +314,9 @@ export async function getWorkItemsForThread(
 // ---------------------------------------------------------------------------
 
 async function upsertSecondaryLink(
-  trx: Database,
+  // Called from inside `db.transaction()` callbacks as well as with a plain
+  // connection — hence `DbOrTx`, not `Database`.
+  trx: DbOrTx,
   params: {
     threadId: string
     entityInstanceId: string

--- a/packages/lib/src/threads/thread-merge.service.ts
+++ b/packages/lib/src/threads/thread-merge.service.ts
@@ -240,13 +240,15 @@ export class ThreadMergeService {
       // sources it had previously absorbed (`mergeData.sources[]`); those
       // descendants need their pointer / target rewritten too so the
       // flatten invariant holds (no two-hop chains).
-      const directSourceEntries: ThreadMergeSourceEntry[] = sources.map((src, i) => ({
-        threadId: src.id,
-        subject: src.subject,
+      // Built from `snapshots` (itself `sources.map(...)`, so same order and
+      // length) rather than zipping the two arrays by index.
+      const directSourceEntries: ThreadMergeSourceEntry[] = snapshots.map((snap) => ({
+        threadId: snap.sourceThreadId,
+        subject: snap.sourceSubject,
         mergedAt: now.toISOString(),
         mergedById: input.actorUserId,
         batchId,
-        messageCount: snapshots[i].movedMessageIds.length,
+        messageCount: snap.movedMessageIds.length,
       }))
       const descendantEntries: ThreadMergeSourceEntry[] = sources.flatMap(
         (src) => (src.mergeData as ThreadMergeData | null)?.sources ?? []

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -279,7 +279,8 @@ export class ThreadMutationService {
           assigneeId: schema.Thread.assigneeId,
         })
 
-      if (result.length === 0) {
+      const [updatedThread] = result
+      if (!updatedThread) {
         throw new Error(`Thread ${threadId} not found`)
       }
 
@@ -320,9 +321,9 @@ export class ThreadMutationService {
           this.organizationId,
           {
             threadId,
-            inboxId: result[0].inboxId ?? null,
+            inboxId: updatedThread.inboxId ?? null,
             previousInboxId: previous?.inboxId ?? null,
-            assigneeId: result[0].assigneeId ?? null,
+            assigneeId: updatedThread.assigneeId ?? null,
             patch,
           },
           { excludeSocketId: this.socketId }
@@ -1326,12 +1327,11 @@ export class ThreadMutationService {
       ),
     ]
 
+    // `Thread.participantIds` was dropped in migration 0028 — only the count is
+    // a column. Matches `ThreadManagerService#updateThreadParticipants`.
     await this.db
       .update(schema.Thread)
-      .set({
-        participantIds,
-        participantCount: participantIds.length,
-      })
+      .set({ participantCount: participantIds.length })
       .where(eq(schema.Thread.id, threadId))
 
     logger.debug('Updated thread participants', {

--- a/packages/lib/src/threads/thread-query.service.ts
+++ b/packages/lib/src/threads/thread-query.service.ts
@@ -8,7 +8,6 @@ import { toRecordId } from '@auxx/types/resource'
 import {
   and,
   asc,
-  type Column,
   count,
   desc,
   eq,
@@ -21,6 +20,7 @@ import {
   type SQL,
   sql,
 } from 'drizzle-orm'
+import type { PgColumn } from 'drizzle-orm/pg-core'
 import { getCachedEntityDefId, requireCachedEntityDefId } from '../cache'
 import { resolveConditionContext } from '../conditions/resolve-context'
 import { batchGetThreadTagIds } from '../field-values/relationship-queries'
@@ -201,7 +201,8 @@ export class ThreadQueryService {
     return undefined
   }
 
-  private getSortValueSelection(sort: ThreadSortDescriptor): Column {
+  /** Sender sorting is a correlated subquery, not a column — hence the union. */
+  private getSortValueSelection(sort: ThreadSortDescriptor): PgColumn | SQL {
     if (sort.field === 'subject') {
       return schema.Thread.subject
     }
@@ -542,8 +543,8 @@ export class ThreadQueryService {
 
     // Build next cursor from last item
     let nextCursor: string | null = null
-    if (hasMore && items.length > 0) {
-      const lastItem = items[items.length - 1]
+    const lastItem = items.at(-1)
+    if (hasMore && lastItem) {
       nextCursor = this.encodeMixedCursor({
         sortValue: lastItem.sortDate,
         entityType: lastItem.entityType as 'thread' | 'draft',
@@ -1076,7 +1077,7 @@ export class ThreadQueryService {
 
     // Note: Integration JOIN is added automatically by Drizzle when using
     // whereThreadMessageType/whereThreadProvider helpers in the WHERE clause
-    let query = this.db
+    const baseQuery = this.db
       .select({
         id: schema.Thread.id,
         lastMessageAt: schema.Thread.lastMessageAt,
@@ -1084,9 +1085,9 @@ export class ThreadQueryService {
       })
       .from(schema.Thread)
 
-    if (finalWhereCondition) {
-      query = query.where(finalWhereCondition)
-    }
+    // Applied as a ternary rather than `query = query.where(...)`: each chained
+    // method narrows the builder's own type, so reassignment doesn't typecheck.
+    const query = finalWhereCondition ? baseQuery.where(finalWhereCondition) : baseQuery
 
     const orderByExpressions = orderBy.length > 0 ? orderBy : this.createOrderByFromDescriptor(sort)
     const finalQuery =

--- a/packages/redis/src/client.ts
+++ b/packages/redis/src/client.ts
@@ -114,6 +114,9 @@ export function getConnectionOptions(): RedisConnectionOptions {
  * @param {boolean} required - If true, will throw error when connection fails
  * @returns {Promise<RedisClient|null>} - Redis client or null if not required and connection fails
  */
+export async function getRedisClient(required?: true): Promise<RedisClient>
+export async function getRedisClient(required: false): Promise<RedisClient | undefined>
+export async function getRedisClient(required: boolean): Promise<RedisClient | undefined>
 export async function getRedisClient(required = true): Promise<RedisClient | undefined> {
   // Fast-fail during cooldown period after a connection failure.
   // Prevents burning 5s per call when Redis is unreachable (e.g., Lambda cold start).


### PR DESCRIPTION
Takes `packages/lib`'s channel/messaging block — `providers`, `ingest`, `messages`, `threads`, `mail-query`, `email` — from **358 type errors to 0**. Six agents partitioned by directory, with the shared provider contracts frozen to a single owner.

| package | before | after |
|---|---|---|
| `packages/lib` | 1 455 | **1 081** |
| `apps/web` | 2 207 | **1 928** |
| `apps/worker` | 952 | **703** |
| `apps/api` | 765 | **520** |
| `apps/kb` | 761 | **476** |

The four ungated apps fell without being edited — lib fixes re-reporting.

## Live bugs found

Each verified at the read site, not just the write site.

**`storeIgnoredMessage` could never have succeeded.** `onConflictDoUpdate({ set: {} })` throws `"No values to set"` at query-build time in drizzle 0.44.5 (`drizzle-orm/utils.js:89`) — unconditionally, not on conflict. So every ignore-filtered message threw on its first statement, wrote no dedup row, and was re-fetched on every subsequent sync cycle. Two more fatal defects sat behind it: the `Message` insert omitted `createdAt`/`updatedAt` (`notNull`, no default) and `fromId` (`notNull`, FK to `Participant`). The file has no test coverage and dates to the original ingest pipeline.

**OpenPhone sync has never ingested a message.** `IdentifierType` was referenced at `openphone-provider.ts:420-421` but never imported, so conversion threw a `ReferenceError` on the first message. That aborts the whole sync loop (one `try` spans it), and the catch then stamps `lastSyncedAt` before rethrowing — so a total failure records a fresh successful-looking sync timestamp.

**`requiresSendReconciliation` was never in the projection.** `getCapabilitiesForIntegration` returned an explicit 4-field literal that omitted it, while `message-sender.service.ts:296` read it. `message-reconciler.service.ts:29` reads `input.reconcileThread !== false` — fail-open — so `undefined` became `true` for every provider. Chat's `sendMessage` returns `threadId: thread.id`, our *internal* id, so `reconcileThread` wrote it into `Thread.externalId` — precisely what the comment three lines above the gate says must not happen. #669 added the capability flags and the call site in the same commit but not the projection field, so **that chat fix never took effect for chat**. Of the five providers flagged `false`, only chat clears the second gate (`&& providerResponse.threadId`); openphone returns no `threadId`, and sms/whatsapp/shopify have no implementation.

**`type IntegrationProviderType` was narrower than its own column.** `IntegrationProviderTypeValues` (`enums.ts:556`) listed 11 providers; the `pgEnum` (`_shared.ts:255`) and the const object (`enums.ts:1251`) both have 12. Since the type derives from the array, `imap` was denied at the type level while the database accepted it. **Type-level only — no migration needed.** Per the standing note, `generate-client-enums.ts` was *not* re-run (it would delete 21 hand-maintained enums); this is a targeted hand edit.

**Facebook's `syncMessages` catch throws its own `TypeError`** — a leftover Prisma `db.integration.update(...)`; `db` is Drizzle, so `db.integration` is `undefined` and the original error is destroyed before it can be rethrown.

**`getProvidersForMessages`/`ForThreads` returned one row for an N-id input** — `eq(Message.id, messageIds[0])`, with a `// This needs inArray` comment beside it. Latent: no call sites.

## Behavior changes

- **`hasAttachments` is now `false` for facebook, instagram and openphone.** None populate `providerAttachments`, and no inbound attachment ingestor exists for them, so the flag asserted bytes nobody could retrieve. It is not cosmetic — it gates a workflow trigger filter (`trigger-nodes/message-received.ts:315-343`). Raw payloads are retained in `metadata` for a future backfill. **IMAP is deliberately unchanged**: it already parses the bytes via postal-mime and the existing `raw-email-parser` → `InboundAttachmentIngestService` path handles that exact shape, so it is a wiring gap rather than a missing feature.
- **`ChannelProviderType` is a const-object union** aliased onto `IntegrationProviderType` instead of a nominal TS enum. A nominal enum can never accept a bare string off a Drizzle row; this removes ~110 errors and makes drift from the pgEnum impossible.
- **`getRedisClient(required: true)` gains an overload** returning `Promise<RedisClient>`. It already threw when required, so callers were guarding a value that could not be undefined.

## Verification

- Full 12-project suite: **718 passed / 2 failed / 9 089 tests, no `Errors` line**. Both failures are the live-API provider suites (vendor `402 Insufficient Balance`, `404 not a chat model`) — zero assertion failures.
- Ratchet: `web: no new type errors`. `lib` reports one new key, `wire-format-conversion.test.ts TS2554 16 -> 18`, which is **not from this branch** — #1459 changed `partsToWireFormat` to a 1-arg signature and left the test calling it with 2. No file under `packages/lib/src/ai/` is touched here.
- `@auxx/database` and `packages/redis` typecheck unchanged by the enum and overload edits.

## Not included

- A backfill for rows already carrying the stale `hasAttachments` flag.
- Wiring IMAP attachments through the existing inbound ingest path.
- Facebook/Instagram/OpenPhone inbound attachment ingestors (a feature, not a fix).