### PR TITLE
fix(channels): dismiss the sync toast on logout

### DIFF
--- a/apps/web/src/app/(auth)/deactivated/page.tsx
+++ b/apps/web/src/app/(auth)/deactivated/page.tsx
@@ -6,12 +6,12 @@ import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@auxx/
 import { ShieldOff } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
-import { client } from '~/auth/auth-client'
+import { signOutAndClear } from '~/auth/sign-out'
 import { Logo } from '~/components/global/login/logo'
 
 export default function DeactivatedPage() {
   useEffect(() => {
-    client.signOut({ fetchOptions: { onSuccess: () => {} } })
+    signOutAndClear({ fetchOptions: { onSuccess: () => {} } })
   }, [])
 
   return (

--- a/apps/web/src/app/(auth)/demo-expired/page.tsx
+++ b/apps/web/src/app/(auth)/demo-expired/page.tsx
@@ -6,13 +6,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx
 import { Check } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
-import { client } from '~/auth/auth-client'
+import { signOutAndClear } from '~/auth/sign-out'
 import { Logo } from '~/components/global/login/logo'
 
 export default function DemoExpiredPage() {
   // Sign out the expired demo user so they can sign up or log in fresh
   useEffect(() => {
-    client.signOut({ fetchOptions: { onSuccess: () => {} } })
+    signOutAndClear({ fetchOptions: { onSuccess: () => {} } })
   }, [])
   return (
     <div className='flex min-h-screen w-screen items-center justify-center p-4 bg-white/10'>

--- a/apps/web/src/app/(auth)/kb-auth/no-access/page.tsx
+++ b/apps/web/src/app/(auth)/kb-auth/no-access/page.tsx
@@ -14,7 +14,7 @@ import { Lock } from 'lucide-react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { Suspense } from 'react'
-import { client } from '~/auth/auth-client'
+import { signOutAndClear } from '~/auth/sign-out'
 import { Logo } from '~/components/global/login/logo'
 
 function NoAccessContent() {
@@ -64,7 +64,7 @@ function NoAccessContent() {
         <Button
           variant='outline'
           onClick={() =>
-            client.signOut({
+            signOutAndClear({
               fetchOptions: {
                 onSuccess: () => {
                   window.location.href = '/login'

--- a/apps/web/src/app/(protected)/app/settings/account/_components/account-settings.tsx
+++ b/apps/web/src/app/(protected)/app/settings/account/_components/account-settings.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { UAParser } from 'ua-parser-js'
 import { client } from '~/auth/auth-client'
+import { signOutAndClear } from '~/auth/sign-out'
 import { UserRegistrationInfo } from '~/components/auth/user-registration-info'
 import { SettingsSection } from '~/components/global/settings-page'
 import { Tooltip } from '~/components/global/tooltip'
@@ -50,7 +51,7 @@ export function AccountSettings(): JSX.Element {
    * Handle sign out - uses the same implementation as nav-user.tsx
    */
   const handleSignOut = () => {
-    client.signOut({
+    signOutAndClear({
       fetchOptions: {
         onSuccess: () => {
           router.push('/') // redirect to login page

--- a/apps/web/src/auth/sign-out.ts
+++ b/apps/web/src/auth/sign-out.ts
@@ -1,0 +1,31 @@
+// apps/web/src/auth/sign-out.ts
+
+'use client'
+
+import { clearSessionCaches } from '~/lib/clear-session-caches'
+import { client } from './auth-client'
+
+type SignOutOptions = Parameters<typeof client.signOut>[0]
+type SignOutFetchOptions = NonNullable<NonNullable<SignOutOptions>['fetchOptions']>
+type SignOutSuccessContext = Parameters<NonNullable<SignOutFetchOptions['onSuccess']>>[0]
+
+/**
+ * Sign out and clear all session-scoped client caches.
+ *
+ * Prefer this over calling `client.signOut()` directly — nothing else drops the
+ * singleton stores on logout. Caches are cleared once the server has destroyed the
+ * session but before the caller's own `onSuccess` runs, so no in-flight query can
+ * repopulate them and the redirect happens against already-empty stores.
+ */
+export function signOutAndClear(options?: SignOutOptions) {
+  return client.signOut({
+    ...options,
+    fetchOptions: {
+      ...options?.fetchOptions,
+      onSuccess: (context: SignOutSuccessContext) => {
+        clearSessionCaches()
+        options?.fetchOptions?.onSuccess?.(context)
+      },
+    },
+  })
+}

--- a/apps/web/src/components/channels/ui/sync-status-toast.tsx
+++ b/apps/web/src/components/channels/ui/sync-status-toast.tsx
@@ -46,6 +46,15 @@ export function SyncStatusToastManager() {
     prevCountRef.current = totalCount
   }, [syncingChannels, authErrorChannels, totalCount])
 
+  // The Toaster lives at the root layout, above the auth boundary, while this manager
+  // only mounts inside the protected app shell. Logout is a client-side nav, so without
+  // this the `duration: Infinity` toast is orphaned and keeps rendering on the login page.
+  useEffect(() => {
+    return () => {
+      sonnerToast.dismiss(SYNC_TOAST_ID)
+    }
+  }, [])
+
   return null
 }
 

--- a/apps/web/src/components/global/create-org-dialog.tsx
+++ b/apps/web/src/components/global/create-org-dialog.tsx
@@ -34,9 +34,7 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { client as authClient } from '~/auth/auth-client'
-import { clearChannelCaches } from '~/components/channels/providers/channel-provider'
-import { clearRecordListContext } from '~/components/records/nav/record-list-context-store'
-import { clearResourceCaches } from '~/components/resources'
+import { clearSessionCaches } from '~/lib/clear-session-caches'
 import { api } from '~/trpc/react'
 
 const formSchema = z.object({
@@ -144,9 +142,7 @@ export function CreateOrganizationDialog({ open, onOpenChange }: CreateOrganizat
       setHandleAvailable(null)
 
       // Clear client-side caches before navigation
-      clearResourceCaches()
-      clearChannelCaches()
-      clearRecordListContext()
+      clearSessionCaches()
 
       // Force session cache refresh to get updated defaultOrganizationId
       await authClient.getSession({ query: { disableCookieCache: true } })

--- a/apps/web/src/components/global/sidebar/app-footer.tsx
+++ b/apps/web/src/components/global/sidebar/app-footer.tsx
@@ -43,7 +43,7 @@ import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
-import { client } from '~/auth/auth-client'
+import { signOutAndClear } from '~/auth/sign-out'
 import { useDemo } from '~/hooks/use-demo'
 import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
 import { useSubscription } from '~/hooks/use-subscription'
@@ -302,7 +302,7 @@ function DemoSidebarBanner() {
         className='mt-2 relative h-8.5 rounded-full'
         tooltip='Demo time remaining'
         onClick={() => {
-          client.signOut({
+          signOutAndClear({
             fetchOptions: { onSuccess: () => router.push('/signup?from=demo') },
           })
         }}>

--- a/apps/web/src/components/global/sidebar/nav-user.tsx
+++ b/apps/web/src/components/global/sidebar/nav-user.tsx
@@ -44,7 +44,7 @@ import { useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { useCallback, useEffect, useState } from 'react'
 // import { signOut } from 'next-auth/react'
-import { client } from '~/auth/auth-client' // Use the correct import for your auth library
+import { signOutAndClear } from '~/auth/sign-out'
 import { Tooltip } from '~/components/global/tooltip'
 import { useKopilotStore } from '~/components/kopilot/stores/kopilot-store'
 import { PresenceDot } from '~/components/users/presence-dot'
@@ -333,7 +333,7 @@ export function NavUser({ user }: Prop) {
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => {
-                client.signOut({
+                signOutAndClear({
                   fetchOptions: {
                     onSuccess: () => {
                       posthog?.reset()

--- a/apps/web/src/components/layouts/layout-footer.tsx
+++ b/apps/web/src/components/layouts/layout-footer.tsx
@@ -5,7 +5,7 @@ import type { DehydratedOrganization } from '@auxx/lib/dehydration'
 import { Button } from '@auxx/ui/components/button'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { client } from '~/auth/auth-client'
+import { signOutAndClear } from '~/auth/sign-out'
 import { useDehydratedOrganizations, useEnv } from '~/providers/dehydrated-state-provider'
 import { useOrganizationIdContext } from '~/providers/feature-flag-provider'
 
@@ -35,7 +35,7 @@ export function LayoutFooter({ showBackToDashboard = true }: LayoutFooterProps) 
 
   const handleLogout = async () => {
     try {
-      await client.signOut()
+      await signOutAndClear()
       router.push('/login')
     } catch (error) {
       console.error('Error during logout:', error)

--- a/apps/web/src/components/organization/organization-item.tsx
+++ b/apps/web/src/components/organization/organization-item.tsx
@@ -17,11 +17,9 @@ import { EllipsisVertical, LogOut, Shield, ShieldAlert, Trash2, UserCircle2 } fr
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useSession } from '~/auth/auth-client'
-import { clearChannelCaches } from '~/components/channels/providers/channel-provider'
 import { SeatTypeBadge } from '~/components/permissions/ui/seat-type-badge'
-import { clearRecordListContext } from '~/components/records/nav/record-list-context-store'
-import { clearResourceCaches } from '~/components/resources'
 import { useUser } from '~/hooks/use-user'
+import { clearSessionCaches } from '~/lib/clear-session-caches'
 import { useDehydratedOrganizationId } from '~/providers/dehydrated-state-provider'
 import { api } from '~/trpc/react'
 import { DeleteOrganizationDialog } from './delete-organization-dialog'
@@ -76,9 +74,7 @@ export function OrganizationItem({
       setIsDeleteDialogOpen(false)
 
       if (isDeletingCurrentOrg) {
-        clearResourceCaches()
-        clearChannelCaches()
-        clearRecordListContext()
+        clearSessionCaches()
         await utils.invalidate()
         router.push('/organizations')
       } else {

--- a/apps/web/src/components/subscriptions/limit-reached-dialog.tsx
+++ b/apps/web/src/components/subscriptions/limit-reached-dialog.tsx
@@ -7,7 +7,7 @@ import { Sparkles, UserPlus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import type React from 'react'
 import { useState } from 'react'
-import { client } from '~/auth/auth-client'
+import { signOutAndClear } from '~/auth/sign-out'
 import { EmptyState } from '~/components/global/empty-state'
 import { useDemo } from '~/hooks/use-demo'
 import { PlanChangeSummary } from './plan-change-summary'
@@ -48,7 +48,7 @@ export function LimitReachedDialog({
                 <Button
                   onClick={() => {
                     onOpenChange(false)
-                    client.signOut({
+                    signOutAndClear({
                       fetchOptions: { onSuccess: () => router.push('/signup?from=demo') },
                     })
                   }}>

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -6,10 +6,8 @@ import type { FeatureMapObject } from '@auxx/lib/types'
 import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useMemo } from 'react'
 import { client as authClient } from '~/auth/auth-client'
-import { clearChannelCaches } from '~/components/channels/providers/channel-provider'
-import { clearRecordListContext } from '~/components/records/nav/record-list-context-store'
-import { clearResourceCaches } from '~/components/resources'
 import { useOrgDeepLink } from '~/hooks/use-org-deep-link'
+import { clearSessionCaches } from '~/lib/clear-session-caches'
 import {
   useDehydratedOrganization,
   useDehydratedOrganizations,
@@ -171,9 +169,7 @@ export function useUser(options: UseUserOptions = {}): UseUserResult {
     if (dehydratedUser.memberships.some((m) => m.organizationId === newOrganizationId)) {
       // Optimistic: update org ID immediately — features, settings, org reads all update
       setOrganizationId(newOrganizationId)
-      clearResourceCaches()
-      clearChannelCaches()
-      clearRecordListContext()
+      clearSessionCaches()
 
       // Persist to server
       switchOrganizationMutation.mutate(

--- a/apps/web/src/lib/clear-session-caches.ts
+++ b/apps/web/src/lib/clear-session-caches.ts
@@ -1,0 +1,23 @@
+// apps/web/src/lib/clear-session-caches.ts
+
+'use client'
+
+import { clearChannelCaches } from '~/components/channels/providers/channel-provider'
+import { clearRecordListContext } from '~/components/records/nav/record-list-context-store'
+import { clearResourceCaches } from '~/components/resources'
+
+/**
+ * Drop every client cache scoped to the signed-in user or their active organization.
+ *
+ * Call on logout, organization switch, and deletion of the active organization —
+ * anything that changes which (user, org) pair the client is looking at.
+ *
+ * These stores are module singletons, so they survive the client-side navigation
+ * those flows perform. Without this the next session in the same tab inherits the
+ * previous one's channels, records and personal list overlays.
+ */
+export function clearSessionCaches(): void {
+  clearResourceCaches()
+  clearChannelCaches()
+  clearRecordListContext()
+}

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -546,7 +546,9 @@ export const IndexStatusValues = ['PENDING', 'INDEXED', 'ERROR'] as const
 
 export const IntegrationSyncStageValues = [
   'IDLE',
+  'MESSAGE_LIST_FETCH_PENDING',
   'MESSAGE_LIST_FETCH',
+  'MESSAGES_IMPORT_PENDING',
   'MESSAGES_IMPORT',
   'FAILED',
 ] as const
@@ -1237,7 +1239,9 @@ export const IndexStatus = {
 
 export const IntegrationSyncStage = {
   IDLE: 'IDLE',
+  MESSAGE_LIST_FETCH_PENDING: 'MESSAGE_LIST_FETCH_PENDING',
   MESSAGE_LIST_FETCH: 'MESSAGE_LIST_FETCH',
+  MESSAGES_IMPORT_PENDING: 'MESSAGES_IMPORT_PENDING',
   MESSAGES_IMPORT: 'MESSAGES_IMPORT',
   FAILED: 'FAILED',
 } as const


### PR DESCRIPTION
## The bug

The channel sync toast kept rendering on the login page after signing out.

`<Toaster />` is mounted in `ClientProviders` at the **root** layout, above the auth boundary. `SyncStatusToastManager` mounts much deeper, inside `ChannelProvider` in the protected app shell. Logout is a client-side navigation, so the manager unmounted while the Toaster stayed alive — leaving a `duration: Infinity` toast that nothing was left to dismiss. Its `Reconnect` button stayed live and fired tRPC mutations with no session.

## Changes

**Dismiss on unmount** — `sync-status-toast.tsx` gets a cleanup effect. Deliberately a separate mount-only effect: the data effect's deps change on every 5-second poll, so a cleanup there would dismiss and re-show the toast on each refetch.

**Clear caches on logout** — logout previously cleared nothing. The resource/channel/record-list stores are module singletons that survive client-side navigation, so the next login in the same tab inherited the previous session's channels, records and personal list overlays. New `signOutAndClear()` clears them once the server has destroyed the session but *before* the caller's own `onSuccess` runs — clearing earlier would let a still-authenticated in-flight query repopulate them. All eight `client.signOut()` call sites now route through it; there is no remaining direct `client.signOut(` in `apps/web/src` outside the helper.

**Deduped the cache-clear trio** — `clearResourceCaches()` + `clearChannelCaches()` + `clearRecordListContext()` was inlined at three org-switch sites. Now `clearSessionCaches()` in `~/lib/clear-session-caches.ts`, shared by org switch, org create, active-org delete, and logout. It lives outside `~/auth/` so an org-switch site isn't importing from a sign-out module.

**Widened `IntegrationSyncStage`** — `enums.ts` is generated from the pgEnums in `_shared.ts` but had drifted: the pgEnum has six values, the generated list had four, missing `MESSAGE_LIST_FETCH_PENDING` and `MESSAGES_IMPORT_PENDING`. So `formatSyncStage` couldn't accept states the DB actually stores, and its own `case` clauses for them were typed unreachable. Cleared three type errors.

## Why the enum was edited by hand

`scripts/generate-client-enums.ts` overwrites `enums.ts` **and** `types.ts` wholesale. `types.ts` has ~75 hand-written lines (the `export type { XEntity } from './db/schema/…'` re-exports, `EntityType`/`StandardType` with `| null`) that it would delete, and `enums.ts` has 21 hand-added client enums with no pgEnum (`Rung`, `SeatType`, `ResourcePermission`, `ActorTarget`, …). Running it is destructive, so this is the targeted edit it *would* have produced for the one enum.

## Known drift, not addressed here

While diagnosing, I diffed all pgEnums against `enums.ts`: **44 of 123 are drifted**. 41 pgEnums have no client enum at all (`SequenceStatus`, `EvalRunStatus`, `RecordingStatus`, `ContactFieldType`, `ImportJobStatus`, …), `SettingScope` is missing 5 values, and `ModelType` is two unrelated enums sharing a name. Combined with the 21 hand-added enums, the generator is effectively unrunnable — it needs to either be retired or taught to merge. Out of scope for a toast fix; flagging it for a follow-up.

## Testing

- `pnpm --filter @auxx/database typecheck` — clean
- `apps/web` `tsc --noEmit` — no new errors in any touched file; the three targeted errors are gone
- `integration-status-indicator.test.ts` — 23 passed, including the `MESSAGE_LIST_FETCH_PENDING` label assertion
- Biome clean on all changed files

**Not verified in a browser.** The original symptom is a runtime lifecycle issue and deserves a manual pass: sign out with a channel syncing and confirm the toast disappears.