### PR TITLE
fix(types): repair three stale comparisons and unblock the lib ratchet

### DIFF
--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -103,9 +103,15 @@ export interface ResyncPending {
  * Scheduled-trigger config (jsonb on {@link DataConnector}). Structural mirror of
  * `ScheduledTriggerConfig` from `@auxx/lib/workflows/cron-pattern` — re-declared
  * here because the database package cannot import lib (tier ordering).
+ *
+ * It is a SUPERSET of the workflow one: this column also stores `'off'`, the
+ * webhook-mode SWEEP cadence (v9 §5) that has no workflow equivalent. The
+ * connector router persists it and the sweep scheduler reads it, so a union
+ * without `'off'` is narrower than the column it describes.
  */
 export interface ScheduledTriggerConfig {
-  triggerInterval: 'minutes' | 'hours' | 'days' | 'weeks' | 'custom'
+  /** `'off'` is webhook-mode only — the delete-reconciliation sweep is opted out. */
+  triggerInterval: 'minutes' | 'hours' | 'days' | 'weeks' | 'custom' | 'off'
   timeBetweenTriggers: {
     minutes?: number | string
     hours?: number | string

--- a/packages/lib/src/ai/agent-framework/__tests__/wire-format-conversion.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/wire-format-conversion.test.ts
@@ -6,17 +6,18 @@ import type { ContentPart } from '../types'
 import { partsToWireFormat } from '../utils'
 
 /**
- * `partsToWireFormat(parts, messageId)` reconstructs the OpenAI / Anthropic
- * wire format from a persisted parts[] array. The model still expects an
- * assistant message followed by separate tool messages — this function
- * preserves that boundary while the persisted shape collapses everything
- * onto a single assistant message.
+ * `partsToWireFormat(parts)` reconstructs the OpenAI / Anthropic wire format from a
+ * persisted parts[] array. The model still expects an assistant message followed by
+ * separate tool messages — this function preserves that boundary while the persisted
+ * shape collapses everything onto a single assistant message.
  *
  * Returned shape: `Message[]` — one assistant Message, plus zero or more
  * trailing tool Messages (one per completed tool_call part).
+ *
+ * It took a `messageId` second argument until #1459 made the signature 1-arg without
+ * updating this file; the calls kept passing it (harmless at runtime, TS2554 to the
+ * compiler) and turned the lib ratchet red on `main`.
  */
-
-const messageId = 'msg_abc'
 
 describe('partsToWireFormat — assistant text only', () => {
   it('emits a single assistant message with concatenated text', () => {
@@ -24,7 +25,7 @@ describe('partsToWireFormat — assistant text only', () => {
       { type: 'text', text: 'Hello, ' },
       { type: 'text', text: 'world!' },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(1)
     expect(wire[0]?.role).toBe('assistant')
     expect(wire[0]?.content).toBe('Hello, world!')
@@ -33,7 +34,7 @@ describe('partsToWireFormat — assistant text only', () => {
 
   it('omits tool_calls entirely when there are no tool_call parts', () => {
     const parts: ContentPart[] = [{ type: 'text', text: 'plain reply' }]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(1)
     expect(wire[0]?.tool_calls).toBeUndefined()
   })
@@ -41,7 +42,7 @@ describe('partsToWireFormat — assistant text only', () => {
 
 describe('partsToWireFormat — empty placeholder', () => {
   it('emits nothing for an empty parts array (the iteration-1 in-progress placeholder)', () => {
-    const wire = partsToWireFormat([], messageId)
+    const wire = partsToWireFormat([])
     // An empty assistant message carries no information and is rejected by
     // OpenAI-compatible providers (Kimi: "the message ... must not be empty").
     expect(wire).toHaveLength(0)
@@ -52,13 +53,13 @@ describe('partsToWireFormat — empty placeholder', () => {
       { type: 'text', text: '' },
       { type: 'text', text: '' },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(0)
   })
 
   it('still emits a reasoning-only assistant message (Anthropic keeps thinking)', () => {
     const parts: ContentPart[] = [{ type: 'thinking', text: 'internal reasoning' }]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(1)
     expect(wire[0]?.role).toBe('assistant')
     expect(wire[0]?.reasoning_content).toContain('internal reasoning')
@@ -78,7 +79,7 @@ describe('partsToWireFormat — assistant + single tool', () => {
         output: { matches: [{ recordId: 'r1' }] },
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(2)
 
     const assistant = wire[0] as Message
@@ -123,7 +124,7 @@ describe('partsToWireFormat — multiple tool calls', () => {
         output: { messages: 12 },
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(3)
     expect(wire[0]?.role).toBe('assistant')
     expect(wire[0]?.tool_calls?.map((tc) => tc.id)).toEqual(['tc_1', 'tc_2'])
@@ -148,7 +149,7 @@ describe('partsToWireFormat — in-flight / awaiting / errored tools', () => {
         // no output yet
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     // The assistant message still carries the tool_call (the LLM client expects
     // every tool_call to have a result before being sent — so a still-running
     // tool would NOT typically be sent back to the LLM in a follow-up call.
@@ -170,7 +171,7 @@ describe('partsToWireFormat — in-flight / awaiting / errored tools', () => {
         status: 'awaiting-approval',
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     const toolMessages = wire.filter((m) => m.role === 'tool')
     expect(toolMessages).toHaveLength(0)
   })
@@ -187,7 +188,7 @@ describe('partsToWireFormat — in-flight / awaiting / errored tools', () => {
         error: 'boom',
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     const toolMsg = wire.find((m) => m.role === 'tool')
     expect(toolMsg).toBeDefined()
     expect(toolMsg?.tool_call_id).toBe('tc_1')
@@ -208,7 +209,7 @@ describe('partsToWireFormat — in-flight / awaiting / errored tools', () => {
         output: { rejected: true },
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     const toolMsg = wire.find((m) => m.role === 'tool')
     expect(toolMsg).toBeDefined()
     const parsed =
@@ -233,7 +234,7 @@ describe('partsToWireFormat — untrusted MCP output boundary', () => {
         outputBoundary: { server: 'demo', tool: 'list' },
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     const toolMsg = wire.find((m) => m.role === 'tool')
     expect(toolMsg).toBeDefined()
     const content = toolMsg?.content as string
@@ -255,7 +256,7 @@ describe('partsToWireFormat — untrusted MCP output boundary', () => {
         output: '<mcp_tool_output server="demo" tool="list">\n[]\n</mcp_tool_output>',
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     const toolMsg = wire.find((m) => m.role === 'tool')
     const content = toolMsg?.content as string
     // Exactly one fence — JSON.stringify of the already-fenced string, never double-wrapped.
@@ -275,7 +276,7 @@ describe('partsToWireFormat — untrusted MCP output boundary', () => {
         outputBoundary: { server: 'demo', tool: 'list' },
       },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     const toolMsg = wire.find((m) => m.role === 'tool')
     const parsed = JSON.parse(toolMsg?.content as string)
     expect(parsed.error).toBe('nope')
@@ -289,7 +290,7 @@ describe('partsToWireFormat — thinking parts', () => {
       { type: 'thinking', text: 'internal reasoning' },
       { type: 'text', text: 'public answer' },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(1)
     const assistant = wire[0] as Message
     // The user-visible `content` MUST NOT contain the thinking text. The wire
@@ -319,7 +320,7 @@ describe('partsToWireFormat — interleaved text/tool/text', () => {
       },
       { type: 'text', text: 'Post-tool conclusion.' },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     // Text written AFTER the last tool call is the conclusion drawn from that
     // call, so it is replayed after the tool result — not concatenated onto the
     // leading assistant message.
@@ -338,7 +339,7 @@ describe('partsToWireFormat — interleaved text/tool/text', () => {
       { type: 'text', text: 'Just ' },
       { type: 'text', text: 'prose.' },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire).toHaveLength(1)
     expect(wire[0]?.content).toBe('Just prose.')
   })
@@ -358,7 +359,7 @@ describe('partsToWireFormat — interleaved text/tool/text', () => {
       },
       { type: 'text', text: 'Pending your approval.' },
     ]
-    const wire = partsToWireFormat(parts, messageId)
+    const wire = partsToWireFormat(parts)
     expect(wire.map((m) => m.role)).toEqual(['assistant'])
     expect(wire[0]?.content).toBe('Working on it. Pending your approval.')
     expect(wire[0]?.tool_calls?.[0]?.id).toBe('tc_pending')

--- a/packages/lib/src/data-connectors/data-connector-scheduler.ts
+++ b/packages/lib/src/data-connectors/data-connector-scheduler.ts
@@ -9,8 +9,12 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, inArray, ne } from 'drizzle-orm'
 import { getQueue, Queues } from '../jobs/queues'
-import { convertToCronPattern, type ScheduledTriggerConfig } from '../workflows/cron-pattern'
+import {
+  type ScheduledTriggerConfig as CronTriggerConfig,
+  convertToCronPattern,
+} from '../workflows/cron-pattern'
 import type { DataConnectorRow } from './service'
+import type { ScheduledTriggerConfig } from './types'
 
 const logger = createScopedLogger('data-connector-scheduler')
 
@@ -31,6 +35,17 @@ function scheduleConfigOf(connector: DataConnectorRow): ScheduledTriggerConfig |
 }
 
 /**
+ * Narrow away `'off'`, which is a connector-only sweep cadence with no cron pattern
+ * behind it, so the rest fits `convertToCronPattern`. Returns null for `'off'`.
+ * (A property check alone would not narrow the object — the config is not a
+ * discriminated union.)
+ */
+function cronConfigOf(config: ScheduledTriggerConfig): CronTriggerConfig | null {
+  const { triggerInterval } = config
+  return triggerInterval === 'off' ? null : { ...config, triggerInterval }
+}
+
+/**
  * Register or remove this connector's SYNC scheduler to match its current state, then
  * unconditionally reconcile its SWEEP scheduler too (`syncConnectorSweepScheduler` —
  * independent of sync mode, own gate decides active/inactive; v9 §5 fix — a webhook
@@ -42,9 +57,13 @@ function scheduleConfigOf(connector: DataConnectorRow): ScheduledTriggerConfig |
 export async function syncConnectorScheduler(connector: DataConnectorRow): Promise<void> {
   const queue = getQueue(Queues.dataConnectorQueue)
   const config = scheduleConfigOf(connector)
-  const active = connector.syncBehavior === 'scheduled' && connector.status !== 'paused' && !!config
+  // `'off'` is a webhook-only sweep cadence and carries no cron pattern, so a
+  // 'scheduled' connector holding it has nothing to register.
+  const cronConfig = config ? cronConfigOf(config) : null
+  const active =
+    connector.syncBehavior === 'scheduled' && connector.status !== 'paused' && !!cronConfig
 
-  if (!active || !config) {
+  if (!active || !cronConfig) {
     try {
       await queue.removeJobScheduler(schedulerId(connector.id))
     } catch {
@@ -52,10 +71,10 @@ export async function syncConnectorScheduler(connector: DataConnectorRow): Promi
     }
   } else {
     try {
-      const pattern = convertToCronPattern(config)
+      const pattern = convertToCronPattern(cronConfig)
       await queue.upsertJobScheduler(
         schedulerId(connector.id),
-        { pattern, tz: config.timezone },
+        { pattern, tz: cronConfig.timezone },
         {
           name: 'data-connector-sync',
           data: {
@@ -108,8 +127,8 @@ export async function syncConnectorSweepScheduler(connector: DataConnectorRow): 
     return
   }
   try {
-    const pattern =
-      config && config.triggerInterval !== 'off' ? convertToCronPattern(config) : SWEEP_CRON
+    const cronConfig = config ? cronConfigOf(config) : null
+    const pattern = cronConfig ? convertToCronPattern(cronConfig) : SWEEP_CRON
     await queue.upsertJobScheduler(
       sweepSchedulerId(connector.id),
       { pattern, tz: config?.timezone },

--- a/packages/lib/src/data-connectors/schedule-info.ts
+++ b/packages/lib/src/data-connectors/schedule-info.ts
@@ -51,6 +51,12 @@ export function deriveConnectorScheduleInfo(input: DeriveScheduleInput): Connect
   if (triggerInterval === 'custom') {
     return { nextSyncAt: null, cadenceLabel: 'on a custom schedule' }
   }
+  // `'off'` is the webhook-mode sweep cadence (v9 §5) and carries no interval. It is
+  // unreachable behind the `syncBehavior === 'scheduled'` gate above, but the column
+  // can hold it, so there is no fixed interval to describe.
+  if (triggerInterval === 'off') {
+    return { nextSyncAt: null, cadenceLabel: null }
+  }
 
   const raw = scheduleConfig.timeBetweenTriggers[triggerInterval]
   const value = typeof raw === 'string' ? Number(raw) : raw

--- a/packages/lib/src/jobs/messages/monitor-message-sync-job.ts
+++ b/packages/lib/src/jobs/messages/monitor-message-sync-job.ts
@@ -128,17 +128,25 @@ export const monitorMessageSyncJob = async (ctx: JobContext<MonitorMessageSyncJo
       if (state === 'completed') {
         completedCount++
         jobsToCleanUp.push(childJob) // Mark for cleanup
-      } else if (state === 'failed' || state === 'stuck') {
+      } else if (state === 'failed') {
+        // A stalled job is not a state of its own in BullMQ (it was in Bull v3): the
+        // worker returns it to `waiting`, and only after `maxStalledCount` does it land
+        // here as `failed`. So there is nothing extra to detect — see the `'unknown'`
+        // note below for the case this loop genuinely cannot terminate on.
         failedCount++
         failedJobDetails.push({
           id: childJob.id!,
-          error: childJob.failedReason || (state === 'stuck' ? 'Job stuck' : 'Unknown error'),
+          error: childJob.failedReason || 'Unknown error',
         })
-        if (state === 'stuck')
-          logger.warn(`Child job ${childJob.id} for sync job ${syncJobId} is stuck.`)
         jobsToCleanUp.push(childJob) // Mark for cleanup
       } else {
-        activeCount++ // Job is still waiting, delayed, or active
+        // Waiting, delayed, active, prioritized, waiting-children — or `'unknown'`,
+        // which `getState()` returns for a job whose hash still exists but sits in no
+        // state set. That one never becomes terminal, and the monitor reschedules
+        // itself unbounded (`attempt` is incremented but never capped), so it would
+        // keep this sync job non-terminal forever. Left as-is: capping the retries is
+        // a behavior decision, not a typecheck fix.
+        activeCount++
       }
     }
 


### PR DESCRIPTION
Three `TS2367`/`TS2554` clusters, each a comparison or call the compiler had been reporting against a vocabulary that had moved. Per §2.4/§5.6 of the testing handoff, every `TS2367` found in this repo so far has been a live defect — these three are the exception in that they are **type-level only**. `TS2367` does not alter emit and extra JS arguments are ignored, so nothing behaves differently today. The value is that the compiler stops lying about the schedule vocabulary, and that `main`'s ratchet goes green.

## 1. `'off'` was missing from the persisted connector schedule vocabulary

`'off'` is the webhook-mode SWEEP cadence (v9 §5). It is written by the connector router's zod enum (`data-connectors.ts:123`) and read by `syncConnectorSweepScheduler`, but only `lib/data-connectors/types.ts` declared it — the DB column type and the workflow `ScheduledTriggerConfig` (which the scheduler imported *instead* of the connector one) both stopped at `'custom'`.

Same shape as #1461's `IntegrationProviderType`: a union narrower than the column it describes. Fix widens the DB type, points the scheduler at the connector type, and narrows `'off'` away through one helper before `convertToCronPattern` — a property check alone does not narrow the object, since the config is not a discriminated union.

**One behavior change falls out.** A `scheduled` connector holding `'off'` used to reach `convertToCronPattern` and throw `Invalid off value: undefined`, aborting before the sweep reconcile. It now registers no sync scheduler and continues, which is what "no cadence" should mean.

## 2. `state === 'stuck'` is a Bull v3 leftover

BullMQ has no `'stuck'` state — a stalled job returns to `waiting` and only lands as `failed` after `maxStalledCount`. So the branch in `monitor-message-sync-job.ts` was unreachable, and its `'Job stuck'` failure reason and warn log could never fire. Same family as the dead per-job `timeout` option #1461 removed (§9.44).

Replaced with a note on `'unknown'`, which is the state this loop genuinely cannot terminate on: `getState()` returns it for a job whose hash exists but sits in no state set, it counts as active forever, and the monitor reschedules itself uncapped (`attempt` is incremented, never bounded). Left alone — capping the retries is a behavior decision, not a typecheck fix.

## 3. The 2-key regression that has had `main` red since #1459

`wire-format-conversion.test.ts` still passed the `messageId` second argument #1459 removed from `partsToWireFormat`. Harmless at runtime, which is why the suite stayed green — but §4 of the handoff flagged it and nobody fixed it, so **the lib ratchet has been failing on `main` independently of any branch**, and the baseline-tightening job (`typecheck-baseline.yml`) cannot record a floor while it does. A dispatch of that job today failed on exactly this, with `lib: 1589 error(s) fixed 🎉` sitting right underneath. 18 call sites updated; all 18 tests still pass.

## Verification

| | before | after |
|---|---|---|
| `packages/lib` | 1 081 | **1 054** |

Same-state delta per §2.9 (two `tsc` runs in one worktree, key sets diffed — not against the committed baseline). **Zero new keys.** `apps/web` falls too. The one unrelated key that appeared mid-measurement belongs to another session editing `learned-extraction-job.ts` in the shared worktree (§2.3).

Tests: `data-connector-scheduler`, `schedule-info`, `update-connector-schedule-config` (19 passed) and `wire-format-conversion` (18 passed).

## Follow-up

Re-run **Typecheck baseline** once this merges — it should then tighten both packages off a ~3 200-key stale floor (§9.16), which is the widest it has ever been.