### PR TITLE
fix(ai): meter streamed llm usage and repair the ai memory pipeline

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -7,7 +7,6 @@ import {
   resolveAgentConfig,
   resolveAgentKnowledgeScope,
 } from '@auxx/lib/agents'
-import { type UsageTrackingRequest, UsageTrackingService } from '@auxx/lib/ai'
 import {
   AgentEngine,
   type AgentEngineConfig,
@@ -970,36 +969,12 @@ async function runInProcessPath(params: {
           userMessageMetadata ? { metadata: userMessageMetadata } : undefined
         )
 
-  const usageEntries: UsageTrackingRequest[] = []
-
+  // No usage drain here: `createCallModel` bills each LLM call as it completes
+  // (`ai/agent-framework/llm-adapter.ts`), which also covers the turns this loop
+  // abandons on `request.signal.aborted`. Draining `event.iterations` for
+  // billing again would double-charge.
   for await (const event of generator) {
     if (request.signal.aborted) break
-
-    // Per-LLM-call billing breakdown. One entry per agent iteration; restored
-    // SYSTEM-vs-CUSTOM credit gating means BYOK customers consume no credits.
-    // Drain on both `paused` and `finished` — see process-agent-job.ts for
-    // the symmetric worker-path version.
-    if (
-      (event.type === 'assistant-message-finished' || event.type === 'assistant-message-paused') &&
-      event.iterations?.length
-    ) {
-      for (const it of event.iterations) {
-        usageEntries.push({
-          organizationId,
-          userId,
-          provider: it.provider,
-          model: it.model,
-          usage: it.usage,
-          timestamp: new Date(),
-          source: 'agent',
-          sourceId: sessionId,
-          providerType: it.providerType,
-          credentialSource: it.credentialSource,
-          // creditsUsed omitted: metered from USD COGS per call (0 for BYO).
-        })
-      }
-    }
-
     send(event)
   }
 
@@ -1026,20 +1001,6 @@ async function runInProcessPath(params: {
     organizationId,
     domainState: domainStateToSave,
   })
-
-  // Batch usage tracking
-  if (usageEntries.length > 0) {
-    try {
-      const usageService = new UsageTrackingService()
-      await usageService.trackUsageBatch(usageEntries)
-    } catch (err) {
-      logger.error('Failed to track usage batch', {
-        sessionId,
-        entries: usageEntries.length,
-        error: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
 
   // Auto-title new sessions after first exchange. The promise was kicked off at
   // the top of this function so its latency overlaps with the engine run.

--- a/apps/web/src/components/global/notifications/ui/items/suggestion-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/suggestion-row.tsx
@@ -106,11 +106,19 @@ export function SuggestionRow({
       setOpen(false)
     },
     onError: (error) => {
+      // FORBIDDEN = the approver lacks a permission the actions need. The
+      // bundle stayed FRESH server-side, so the row must stay too — someone
+      // with the rung can still approve it.
+      const blocked = error.data?.code === 'FORBIDDEN'
       toastError({
-        title: error.data?.code === 'CONFLICT' ? 'Out of date' : 'Approve failed',
+        title: blocked
+          ? 'You cannot approve this'
+          : error.data?.code === 'CONFLICT'
+            ? 'Out of date'
+            : 'Approve failed',
         description: error.message,
       })
-      resolve()
+      if (!blocked) resolve()
     },
   })
 

--- a/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from '~/components/global/loading-content'
 import { useArticleList, useIsArticleListLoaded } from '../../hooks/use-article-list'
 import { useDiffParam } from '../../hooks/use-diff-param'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
+import { LearnedProvenanceNote } from '../memory/learned-provenance-note'
 import { KBPreview } from '../preview/kb-preview'
 import { ArticleDiffPane } from './article-diff-pane'
 import { ArticleEditor } from './article-editor'
@@ -85,6 +86,18 @@ function KBEditorBody({ knowledgeBaseId, slug, hasArticlesLoaded }: KBEditorBody
           diffValue={diffValue}
           onClose={() => setDiff(null)}
         />
+      )
+    }
+    // AI Memory only: show which conversations taught this article before the
+    // body, so a reader can judge it (and its deletion) on its evidence.
+    if (knowledgeBase?.kind === 'learned') {
+      return (
+        <div className='flex h-full flex-col'>
+          <LearnedProvenanceNote articleId={currentArticle.id} />
+          <div className='min-h-0 flex-1'>
+            <ArticleEditor article={currentArticle} knowledgeBaseId={knowledgeBaseId} />
+          </div>
+        </div>
       )
     }
     return <ArticleEditor article={currentArticle} knowledgeBaseId={knowledgeBaseId} />

--- a/apps/web/src/components/kb/ui/memory/ai-memory-section.tsx
+++ b/apps/web/src/components/kb/ui/memory/ai-memory-section.tsx
@@ -1,11 +1,12 @@
 // apps/web/src/components/kb/ui/memory/ai-memory-section.tsx
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { toastError } from '@auxx/ui/components/toast'
 import { Sparkles } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { useCapabilityGate } from '~/components/global/capability-gate'
 import { SettingsSection } from '~/components/global/settings-page'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
@@ -14,11 +15,14 @@ import { api } from '~/trpc/react'
  * "AI Memory" section on the Knowledge Bases tab — the human door into the
  * org's learned KB. Opening the card lazily provisions the KB (idempotent)
  * and lands in the memory-trimmed editor. Hidden without the `learnedMemory`
- * feature flag.
+ * feature flag, or without the `knowledgeBase` Edit rung that
+ * `kb.ensureLearnedMemory` asserts — showing a card that 403s on click is
+ * worse than not showing it.
  */
 export function AiMemorySection() {
   const router = useRouter()
   const { hasAccess } = useFeatureFlags()
+  const { allowed: canEditKb } = useCapabilityGate(PermissionKey.knowledgeBaseEdit)
 
   const ensureLearnedMemory = api.kb.ensureLearnedMemory.useMutation({
     onSuccess: ({ id }) => {
@@ -29,7 +33,7 @@ export function AiMemorySection() {
     },
   })
 
-  if (!hasAccess(FeatureKey.learnedMemory)) return null
+  if (!hasAccess(FeatureKey.learnedMemory) || !canEditKb) return null
 
   return (
     <SettingsSection icon={Sparkles} title='AI Memory' className='mt-8'>

--- a/apps/web/src/components/kb/ui/memory/learned-provenance-note.tsx
+++ b/apps/web/src/components/kb/ui/memory/learned-provenance-note.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/components/kb/ui/memory/learned-provenance-note.tsx
+'use client'
+
+import { Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import { threadHref } from '~/components/kbar/thread-href'
+import { api } from '~/trpc/react'
+
+/** Conversations listed inline before the rest collapse into a count. */
+const VISIBLE_SOURCES = 3
+
+/**
+ * "Learned from N conversations" strip above a memory article, linking the
+ * threads the extractor cited. Renders nothing for an article a human wrote
+ * by hand (no provenance) — which is itself the useful signal that the AI did
+ * not put it there.
+ */
+export function LearnedProvenanceNote({ articleId }: { articleId: string }) {
+  const { data: sources } = api.kb.learnedProvenance.useQuery({ articleId }, { staleTime: 60_000 })
+  if (!sources || sources.length === 0) return null
+
+  const visible = sources.slice(0, VISIBLE_SOURCES)
+  const remaining = sources.length - visible.length
+
+  return (
+    <div className='flex flex-wrap items-center gap-x-2 gap-y-1 border-b px-8 py-2 text-xs text-muted-foreground'>
+      <Sparkles className='size-3.5 shrink-0' />
+      <span>
+        Learned from {sources.length} conversation{sources.length === 1 ? '' : 's'}:
+      </span>
+      {visible.map((source) => (
+        <Link
+          key={source.threadId}
+          href={threadHref({ id: source.threadId })}
+          className='max-w-[16rem] truncate underline-offset-2 hover:text-foreground hover:underline'>
+          {source.subject?.trim() || 'Untitled conversation'}
+        </Link>
+      ))}
+      {remaining > 0 && <span>+{remaining} more</span>}
+    </div>
+  )
+}

--- a/apps/web/src/components/learned/ui/learned-article-preview.tsx
+++ b/apps/web/src/components/learned/ui/learned-article-preview.tsx
@@ -4,6 +4,7 @@
 import { cn } from '@auxx/ui/lib/utils'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { api } from '~/trpc/react'
 import '~/components/kopilot/styles/kopilot-prose.css'
 
 /** Args of a proposed `upsert_learned_article` call, as captured by the engine. */
@@ -22,10 +23,14 @@ const CATEGORY_LABELS: Record<string, string> = {
 }
 
 /**
- * Light preview of a proposed AI-memory write: title + category + description
- * plus the full proposed article markdown, rendered. Shared by the Today
- * bundle card and the in-chat kopilot approval card — the reviewer sees what
- * will be published (not a diff against the current article).
+ * Preview of a proposed AI-memory write: title + category + description, then
+ * the body.
+ *
+ * For a NEW article the body is the rendered proposal. For an UPDATE it is a
+ * line diff against the published article, because the tool replaces the whole
+ * body — the failure worth catching is a merge that quietly drops a line a
+ * human wrote, and a rendered proposal looks identical whether it kept that
+ * line or not.
  */
 export function LearnedArticlePreview({
   args,
@@ -34,8 +39,17 @@ export function LearnedArticlePreview({
   args: Record<string, unknown>
   className?: string
 }) {
-  const { category, title, description, markdown } = args as LearnedArticleArgs
+  const { articleId, category, title, description, markdown } = args as LearnedArticleArgs
   const categoryLabel = category ? (CATEGORY_LABELS[category] ?? category) : undefined
+
+  // Updates only — a create has nothing to diff against. `temp_<n>` ids belong
+  // to articles this same bundle is about to create, so they aren't real yet.
+  const isUpdate = !!articleId && !articleId.startsWith('temp_') && !!markdown
+  const { data: diff } = api.kb.learnedArticleDiff.useQuery(
+    { articleId: articleId ?? '', markdown: markdown ?? '' },
+    { enabled: isUpdate, staleTime: 60_000 }
+  )
+  const showDiff = isUpdate && diff?.found && diff.lines.length > 0
 
   return (
     <div className={cn('space-y-2 rounded-xl bg-background/60 p-3', className)}>
@@ -47,13 +61,45 @@ export function LearnedArticlePreview({
               {categoryLabel}
             </span>
           )}
+          {isUpdate && (
+            <span className='rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground'>
+              Update
+            </span>
+          )}
         </div>
         {description && <p className='text-xs text-muted-foreground'>{description}</p>}
       </div>
-      {markdown && (
-        <div className='kopilot-prose max-h-64 overflow-y-auto border-t pt-2'>
-          <Markdown remarkPlugins={[remarkGfm]}>{markdown}</Markdown>
+
+      {showDiff && diff ? (
+        <div className='space-y-1 border-t pt-2'>
+          <p className='text-[11px] text-muted-foreground'>
+            {diff.removedCount > 0
+              ? `${diff.addedCount} line${diff.addedCount === 1 ? '' : 's'} added, ${diff.removedCount} removed`
+              : `${diff.addedCount} line${diff.addedCount === 1 ? '' : 's'} added`}
+          </p>
+          <div className='max-h-64 overflow-y-auto rounded-lg bg-muted/40 p-2 font-mono text-[11px] leading-relaxed'>
+            {diff.lines.map((line, index) => (
+              <div
+                // Diff lines have no stable identity; index is the position.
+                key={`${line.type}-${index}`}
+                className={cn(
+                  'whitespace-pre-wrap',
+                  line.type === 'add' && 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+                  line.type === 'remove' && 'bg-red-500/10 text-red-700 dark:text-red-400',
+                  line.type === 'same' && 'text-muted-foreground'
+                )}>
+                {line.type === 'add' ? '+ ' : line.type === 'remove' ? '− ' : '  '}
+                {line.text}
+              </div>
+            ))}
+          </div>
         </div>
+      ) : (
+        markdown && (
+          <div className='kopilot-prose max-h-64 overflow-y-auto border-t pt-2'>
+            <Markdown remarkPlugins={[remarkGfm]}>{markdown}</Markdown>
+          </div>
+        )
       )}
     </div>
   )

--- a/apps/web/src/server/api/routers/approvals.ts
+++ b/apps/web/src/server/api/routers/approvals.ts
@@ -132,7 +132,15 @@ export const approvalsRouter = createTRPCRouter({
         userId: ctx.session.userId,
       })
       if (!result.ok) {
-        const code = result.error.name === 'ConflictError' ? 'CONFLICT' : 'INTERNAL_SERVER_ERROR'
+        // FORBIDDEN means every action was blocked by the approver's own
+        // permissions — the bundle is untouched and still FRESH, so the client
+        // must keep showing it rather than treating the row as resolved.
+        const code =
+          result.error.name === 'ConflictError'
+            ? 'CONFLICT'
+            : result.error.name === 'ForbiddenError'
+              ? 'FORBIDDEN'
+              : 'INTERNAL_SERVER_ERROR'
         throw new TRPCError({ code, message: result.error.message })
       }
       return result.value

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -6,7 +6,14 @@ import { ArticleStatus } from '@auxx/database/enums'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { NotFoundError } from '@auxx/lib/errors'
-import { articleToMarkdown, ensureLearnedKb, KBService, linkArticlesIntoKb } from '@auxx/lib/kb'
+import {
+  articleToMarkdown,
+  ensureLearnedKb,
+  getLearnedArticleDiff,
+  getLearnedProvenance,
+  KBService,
+  linkArticlesIntoKb,
+} from '@auxx/lib/kb'
 import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
 import { and, count, eq } from 'drizzle-orm'
@@ -195,10 +202,13 @@ export const knowledgeBaseRouter = createTRPCRouter({
     if (!organizationId) {
       throw new TRPCError({ code: 'UNAUTHORIZED', message: 'User organization context not found' })
     }
-    // Full — provisioning the org's AI Memory KB is a settings-adjacent action
-    // (doc 12 §3.1). No instance exists yet to key on, so gate on the coarse
-    // `knowledgeBase` Full rung (mirrors `create`).
-    ctx.capabilities.assert(PermissionKey.knowledgeBaseManage)
+    // Edit, not Full: this provisions ONE fixed, system-owned KB per org — it
+    // is not KB management, and AI Memory is org knowledge every teammate can
+    // read and correct (learned bundles likewise land unassigned in Today).
+    // Full would lock the entry point to admins while the Member baseline
+    // (`knowledgeBase: Edit`) is exactly the rung `upsert_learned_article`
+    // asserts to write a memory.
+    ctx.capabilities.assert(PermissionKey.knowledgeBaseEdit)
     await new FeaturePermissionService(ctx.db).requireAccess(
       organizationId,
       FeatureKey.learnedMemory
@@ -206,6 +216,51 @@ export const knowledgeBaseRouter = createTRPCRouter({
     const { kb } = await ensureLearnedKb({ db: ctx.db, organizationId })
     return { id: kb.id }
   }),
+
+  /**
+   * Diff a proposed AI-memory rewrite against the article as published, for the
+   * approval surfaces (Today card + in-chat card). A memory update replaces the
+   * whole body, so the reviewer needs to see what the merge DROPS — a rendered
+   * preview of the proposal alone cannot show that.
+   */
+  learnedArticleDiff: capabilityProcedure
+    .input(z.object({ articleId: z.string(), markdown: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const organizationId = getUserOrganizationId(ctx.session)
+      if (!organizationId) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'User organization context not found',
+        })
+      }
+      // Read-only over an article the viewer can already see in the memory
+      // editor; the Read rung is the right bar.
+      ctx.capabilities.assert(PermissionKey.knowledgeBaseView)
+      return getLearnedArticleDiff(ctx.db, {
+        organizationId,
+        articleId: input.articleId,
+        markdown: input.markdown,
+      })
+    }),
+
+  /**
+   * The conversations a memory article was learned from — the reader for
+   * `Article.learnedProvenance`. Answers "why does the AI believe this?", which
+   * is the question anyone asks before deleting a memory.
+   */
+  learnedProvenance: capabilityProcedure
+    .input(z.object({ articleId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const organizationId = getUserOrganizationId(ctx.session)
+      if (!organizationId) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'User organization context not found',
+        })
+      }
+      ctx.capabilities.assert(PermissionKey.knowledgeBaseView)
+      return getLearnedProvenance(ctx.db, { organizationId, articleId: input.articleId })
+    }),
 
   create: capabilityProcedure.input(kbCreateSchema).mutation(async ({ ctx, input }) => {
     const organizationId = getUserOrganizationId(ctx.session)

--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -828,7 +828,15 @@ export const threadRouter = createTRPCRouter({
           throw new TRPCError({ code: 'NOT_FOUND', message: 'Thread not found.' })
         }
         const { enqueueLearnedExtraction } = await import('@auxx/lib/jobs')
-        await enqueueLearnedExtraction({ organizationId, threadId, force: true })
+        // `requestedByUserId` is what makes the run possible at all: capture
+        // runs bind to a human member, and most threads have no assignee to
+        // derive one from. It also routes the proposal to this member's feed.
+        await enqueueLearnedExtraction({
+          organizationId,
+          threadId,
+          force: true,
+          requestedByUserId: userId,
+        })
         return { success: true }
       } catch (error: unknown) {
         if (error instanceof TRPCError) throw error

--- a/packages/lib/scripts/verify-learned-extraction.ts
+++ b/packages/lib/scripts/verify-learned-extraction.ts
@@ -1,0 +1,111 @@
+// packages/lib/scripts/verify-learned-extraction.ts
+//
+// One-off live verify for the AI Memory production-readiness fixes
+// (plans/ai-memory/ai-memory-production-readiness-plan.md). Drives the real
+// dev DB and a real LLM call:
+//   1. runs the extraction job against an UNASSIGNED archived thread — the
+//      case that silently no-op'd before the principal resolver
+//   2. reports the principal it resolved, the outcome, and the bundle
+//   3. checks the thread stamp and the AiUsage row the run should have billed
+//
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/verify-learned-extraction.ts <threadId>
+
+import { database as db, schema } from '@auxx/database'
+import { and, desc, eq } from 'drizzle-orm'
+import { learnedExtractionJob } from '../src/jobs/approvals/learned-extraction-job'
+import { resolveLearnedRunPrincipal } from '../src/jobs/approvals/learned-run-principal'
+
+async function main() {
+  const threadId = process.argv[2]
+  // Optional: `--force <requestedByUserId>` drives the "Remember this thread"
+  // path, which must bind to the requester and own the bundle for them.
+  const force = process.argv.includes('--force')
+  const requestedByUserId = force ? process.argv[process.argv.indexOf('--force') + 1] : undefined
+  if (!threadId)
+    throw new Error('usage: verify-learned-extraction.ts <threadId> [--force <userId>]')
+
+  const thread = await db.query.Thread.findFirst({
+    where: eq(schema.Thread.id, threadId),
+  })
+  if (!thread) throw new Error(`Thread ${threadId} not found`)
+  const organizationId = thread.organizationId
+
+  console.log('--- thread ---')
+  console.log({
+    id: thread.id,
+    subject: thread.subject,
+    status: thread.status,
+    assigneeId: thread.assigneeId,
+    messageCount: thread.messageCount,
+    learnedExtractedAt: thread.learnedExtractedAt,
+  })
+
+  const principal = await resolveLearnedRunPrincipal({
+    db,
+    organizationId,
+    threadId,
+    assigneeId: thread.assigneeId,
+    requestedByUserId,
+  })
+  console.log('--- resolved principal ---')
+  console.log(principal)
+
+  const data = { organizationId, threadId, force, requestedByUserId }
+  const result = await learnedExtractionJob({
+    job: { data },
+    data,
+    jobId: 'verify-learned-extraction',
+    jobName: 'learnedExtractionJob',
+  } as never)
+  console.log('--- job result ---')
+  console.log(result)
+
+  const after = await db.query.Thread.findFirst({
+    where: eq(schema.Thread.id, threadId),
+    columns: { learnedExtractedAt: true },
+  })
+  console.log('--- stamp after ---', after?.learnedExtractedAt)
+
+  const bundles = await db
+    .select({
+      id: schema.AiSuggestion.id,
+      status: schema.AiSuggestion.status,
+      ownerUserId: schema.AiSuggestion.ownerUserId,
+      actionCount: schema.AiSuggestion.actionCount,
+      bundle: schema.AiSuggestion.bundle,
+    })
+    .from(schema.AiSuggestion)
+    .where(
+      and(
+        eq(schema.AiSuggestion.threadId, threadId),
+        eq(schema.AiSuggestion.triggerSource, 'learned-extraction')
+      )
+    )
+  console.log('--- bundles ---')
+  console.log(JSON.stringify(bundles, null, 2))
+
+  const usage = await db
+    .select({
+      source: schema.AiUsage.source,
+      sourceId: schema.AiUsage.sourceId,
+      model: schema.AiUsage.model,
+      totalTokens: schema.AiUsage.totalTokens,
+      creditsUsed: schema.AiUsage.creditsUsed,
+      providerType: schema.AiUsage.providerType,
+      createdAt: schema.AiUsage.createdAt,
+    })
+    .from(schema.AiUsage)
+    .where(eq(schema.AiUsage.sourceId, threadId))
+    .orderBy(desc(schema.AiUsage.createdAt))
+    .limit(10)
+  console.log('--- usage rows for this thread ---')
+  console.log(usage)
+
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error('verify failed:', err)
+  process.exit(1)
+})

--- a/packages/lib/src/ai/agent-framework/__tests__/llm-adapter-metering.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/llm-adapter-metering.test.ts
@@ -1,0 +1,242 @@
+// packages/lib/src/ai/agent-framework/__tests__/llm-adapter-metering.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LLMStreamChunk, UsageMetrics } from '../../clients/base/types'
+import type { UsageTrackingRequest } from '../../orchestrator/types'
+import type { LLMCallParams } from '../types'
+
+/**
+ * `LLMOrchestrator.streamInvoke` enforces the quota gate but records nothing —
+ * it hands back `usage` / `providerType` / `credentialSource` and leaves billing
+ * to its caller. It has exactly one caller, `createCallModel`, so metering there
+ * is what covers every agent path (kopilot, agent worker, chat widget, workflow
+ * AI turns, evals, headless capture runs). These tests pin that contract:
+ * one `AiUsage` write per LLM call, including calls that error or are aborted.
+ */
+
+const USAGE: UsageMetrics = { prompt_tokens: 200, completion_tokens: 300, total_tokens: 500 }
+const ZERO_USAGE: UsageMetrics = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+
+const gateChunk = (
+  providerType = 'SYSTEM',
+  credentialSource = 'SYSTEM'
+): Partial<LLMStreamChunk> => ({
+  id: 'gate',
+  model: 'claude-opus-5',
+  content: '',
+  delta: '',
+  metadata: { chunkIndex: -1, totalLength: 0, providerType, credentialSource },
+})
+
+/** Per-test script for the faked orchestrator stream. */
+const state = vi.hoisted(() => ({
+  chunks: [] as unknown[],
+  response: undefined as unknown,
+  throwAfterChunks: false,
+  onChunk: undefined as ((index: number) => void) | undefined,
+}))
+
+vi.mock('../../orchestrator/llm-orchestrator', () => ({
+  LLMOrchestrator: class {
+    async *streamInvoke() {
+      let index = 0
+      for (const chunk of state.chunks) {
+        yield chunk
+        state.onChunk?.(index)
+        index++
+      }
+      if (state.throwAfterChunks) throw new Error('provider exploded')
+      return state.response
+    }
+  },
+}))
+
+const { createCallModel } = await import('../llm-adapter')
+
+const PARAMS: LLMCallParams = {
+  model: 'claude-opus-5',
+  provider: 'anthropic',
+  messages: [{ role: 'user', content: 'hi' }],
+}
+
+function makeUsageService() {
+  const calls: UsageTrackingRequest[] = []
+  return {
+    calls,
+    service: {
+      trackUsage: async (request: UsageTrackingRequest) => {
+        calls.push(request)
+      },
+    },
+  }
+}
+
+/** Drive `callModel` to completion, swallowing provider errors. */
+async function drain(gen: AsyncGenerator<unknown>): Promise<void> {
+  try {
+    for await (const _event of gen) {
+      // events are irrelevant here — only the billing side effect is asserted
+    }
+  } catch {
+    // provider failures are rethrown by the adapter; the billing assertion is the point
+  }
+}
+
+describe('createCallModel — usage metering', () => {
+  beforeEach(() => {
+    state.chunks = []
+    state.response = undefined
+    state.throwAfterChunks = false
+    state.onChunk = undefined
+  })
+
+  it('writes one usage entry per call, carrying the credential metadata', async () => {
+    state.chunks = [gateChunk(), { id: 'c1', model: 'claude-opus-5', content: '', delta: 'hi' }]
+    state.response = {
+      content: 'hi',
+      tool_calls: [],
+      usage: USAGE,
+      providerType: 'SYSTEM',
+      credentialSource: 'SYSTEM',
+    }
+    const { calls, service } = makeUsageService()
+
+    const callModel = createCallModel({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      source: 'learned_extraction',
+      sourceId: 'thread-1',
+      usageService: service,
+    })
+    await drain(callModel(PARAMS))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-opus-5',
+      usage: USAGE,
+      source: 'learned_extraction',
+      sourceId: 'thread-1',
+      providerType: 'SYSTEM',
+      credentialSource: 'SYSTEM',
+    })
+    // Credits are metered from real USD COGS downstream — never overridden here.
+    expect(calls[0]?.creditsUsed).toBeUndefined()
+  })
+
+  it('bills BYO calls too (0 credits is resolved downstream, not by skipping the row)', async () => {
+    state.chunks = [gateChunk('CUSTOM', 'MODEL_SPECIFIC')]
+    state.response = {
+      content: '',
+      tool_calls: [],
+      usage: USAGE,
+      providerType: 'CUSTOM',
+      credentialSource: 'MODEL_SPECIFIC',
+    }
+    const { calls, service } = makeUsageService()
+
+    const callModel = createCallModel({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      usageService: service,
+    })
+    await drain(callModel(PARAMS))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      providerType: 'CUSTOM',
+      credentialSource: 'MODEL_SPECIFIC',
+      // Default label for a caller that doesn't set one.
+      source: 'agent',
+    })
+  })
+
+  it('writes nothing when the provider reported no tokens', async () => {
+    state.chunks = [gateChunk()]
+    state.response = { content: '', tool_calls: [], usage: ZERO_USAGE, providerType: 'SYSTEM' }
+    const { calls, service } = makeUsageService()
+
+    const callModel = createCallModel({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      usageService: service,
+    })
+    await drain(callModel(PARAMS))
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('bills tokens spent before an aborted stream, with the gate credential type', async () => {
+    const controller = new AbortController()
+    state.chunks = [
+      gateChunk(),
+      { id: 'c1', model: 'claude-opus-5', content: '', delta: 'part', usage: USAGE },
+    ]
+    // Abort once the usage-bearing chunk has been consumed: the adapter checks
+    // the signal before its next `stream.next()` and returns early.
+    state.onChunk = (index) => {
+      if (index === 1) controller.abort()
+    }
+    const { calls, service } = makeUsageService()
+
+    const callModel = createCallModel({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      source: 'chat',
+      usageService: service,
+    })
+    await drain(callModel({ ...PARAMS, signal: controller.signal }))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      usage: USAGE,
+      source: 'chat',
+      // Without the orchestrator's synthetic gate chunk this would be undefined,
+      // and an aborted SYSTEM call would silently bill 0 credits.
+      providerType: 'SYSTEM',
+      credentialSource: 'SYSTEM',
+    })
+  })
+
+  it('bills tokens spent before a provider error', async () => {
+    state.chunks = [
+      gateChunk(),
+      { id: 'c1', model: 'claude-opus-5', content: '', delta: 'part', usage: USAGE },
+    ]
+    state.throwAfterChunks = true
+    const { calls, service } = makeUsageService()
+
+    const callModel = createCallModel({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      usageService: service,
+    })
+    await drain(callModel(PARAMS))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.usage).toEqual(USAGE)
+  })
+
+  it('bills once when the consumer abandons the stream mid-turn', async () => {
+    state.chunks = [
+      gateChunk(),
+      { id: 'c1', model: 'claude-opus-5', content: '', delta: 'first', usage: USAGE },
+      { id: 'c2', model: 'claude-opus-5', content: '', delta: 'second' },
+    ]
+    const { calls, service } = makeUsageService()
+
+    const callModel = createCallModel({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      usageService: service,
+    })
+    const gen = callModel(PARAMS)
+    for await (const _event of gen) {
+      break // closing the generator runs its `finally`
+    }
+
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/ai/agent-framework/llm-adapter.ts
+++ b/packages/lib/src/ai/agent-framework/llm-adapter.ts
@@ -4,7 +4,8 @@ import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { ToolCall, UsageMetrics } from '../clients/base/types'
 import { LLMOrchestrator } from '../orchestrator/llm-orchestrator'
-import type { LLMInvocationRequest, UsageTrackingService } from '../orchestrator/types'
+import type { LLMInvocationRequest, UsageSource, UsageTrackingService } from '../orchestrator/types'
+import { UsageTrackingService as DefaultUsageTrackingService } from '../usage/usage-tracking-service'
 import type { LLMCallParams, LLMStreamEvent } from './types'
 
 const logger = createScopedLogger('agent-llm')
@@ -13,9 +14,10 @@ export interface LLMAdapterConfig {
   organizationId: string
   userId: string
   db?: Database
+  /** Overrides the default {@link DefaultUsageTrackingService} (DI seam for tests). */
   usageService?: UsageTrackingService
-  /** Source label for usage tracking (default: 'agent') */
-  source?: string
+  /** `AiUsage.source` label for every call this adapter makes (default: 'agent'). */
+  source?: UsageSource
   sourceId?: string
   /** Default false. Forwarded to LLMInvocationRequest.forceSystem. */
   forceSystem?: boolean
@@ -24,9 +26,20 @@ export interface LLMAdapterConfig {
 /**
  * Create a callModel function that wraps LLMOrchestrator streaming.
  * This is the only file in the agent framework that knows about provider details.
+ *
+ * **It is also where streamed LLM usage is metered.** `LLMOrchestrator.invoke`
+ * records usage itself, but `streamInvoke` deliberately does not — it enforces
+ * the quota gate, hands back `usage`/`providerType`/`credentialSource`, and
+ * leaves recording to whoever consumed the stream. `streamInvoke` has exactly
+ * one caller (this file), so metering here covers every agent path by
+ * construction: kopilot, the agent worker, the customer chat widget, workflow
+ * AI turns, evals, and the headless capture runners. Runners must not drain
+ * usage themselves — that would double-bill.
  */
 export function createCallModel(config: LLMAdapterConfig) {
   const orchestrator = new LLMOrchestrator(config.usageService, config.db)
+  const usageService = config.usageService ?? new DefaultUsageTrackingService(config.db)
+  const source: UsageSource = config.source ?? 'agent'
 
   return async function* callModel(params: LLMCallParams): AsyncGenerator<LLMStreamEvent> {
     const { model, provider, messages, tools, parameters, responseFormat, signal } = params
@@ -91,6 +104,48 @@ export function createCallModel(config: LLMAdapterConfig) {
     let lastReasoningContent: string | undefined
     let lastFinishReason: string | undefined
     let lastStopReason: string | undefined
+
+    /**
+     * Write the `AiUsage` row for this call and deduct SYSTEM credits. Runs
+     * exactly once per call, from the stream loop's `finally` — so a turn that
+     * errors or is aborted mid-stream still bills the tokens it burned, which
+     * a caller-side per-turn drain could never do. Never throws: a billing
+     * failure must not take down the turn that earned it.
+     */
+    let usageRecorded = false
+    const recordUsage = async () => {
+      if (usageRecorded) return
+      usageRecorded = true
+      if (lastUsage.total_tokens <= 0) return
+      try {
+        await usageService.trackUsage({
+          organizationId: config.organizationId,
+          userId: config.userId,
+          provider,
+          model,
+          usage: lastUsage,
+          timestamp: new Date(),
+          source,
+          sourceId: config.sourceId,
+          providerType: lastProviderType as 'SYSTEM' | 'CUSTOM' | undefined,
+          credentialSource: lastCredentialSource as
+            | 'SYSTEM'
+            | 'CUSTOM'
+            | 'MODEL_SPECIFIC'
+            | 'LOAD_BALANCED'
+            | undefined,
+          // `creditsUsed` omitted: metered from real USD COGS per call (0 for BYO).
+        })
+      } catch (error) {
+        logger.error('Failed to track LLM usage', {
+          model,
+          provider,
+          source,
+          sourceId: config.sourceId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
 
     const stream = orchestrator.streamInvoke(request)
 
@@ -216,9 +271,19 @@ export function createCallModel(config: LLMAdapterConfig) {
         if (chunk.finishReason) {
           lastFinishReason = chunk.finishReason
         }
-        const chunkMeta = chunk.metadata as { stopReason?: unknown } | undefined
+        const chunkMeta = chunk.metadata as
+          | { stopReason?: unknown; providerType?: unknown; credentialSource?: unknown }
+          | undefined
         if (chunkMeta && typeof chunkMeta.stopReason === 'string') {
           lastStopReason = chunkMeta.stopReason
+        }
+        // Credential metadata from the orchestrator's synthetic gate chunk —
+        // the only way an aborted stream learns whether it spent SYSTEM credits.
+        if (chunkMeta && typeof chunkMeta.providerType === 'string') {
+          lastProviderType = chunkMeta.providerType
+        }
+        if (chunkMeta && typeof chunkMeta.credentialSource === 'string') {
+          lastCredentialSource = chunkMeta.credentialSource
         }
       }
     } catch (error) {
@@ -229,6 +294,8 @@ export function createCallModel(config: LLMAdapterConfig) {
       if (flushTimer) clearTimeout(flushTimer)
       if (reasoningFlushTimer) clearTimeout(reasoningFlushTimer)
       throw error
+    } finally {
+      await recordUsage()
     }
 
     // Yield any remaining buffered deltas

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -15,8 +15,6 @@ import type { JobContext } from '../../jobs/types'
 import { docToText } from '../../tiptap'
 import { buildInstructionReferenceResolver } from '../kopilot/prompts/resolve-instruction-references'
 import type { TriggerContext, TriggerKind } from '../kopilot/prompts/trigger-context'
-import type { UsageTrackingRequest } from '../orchestrator/types'
-import { UsageTrackingService } from '../usage/usage-tracking-service'
 import { resolveAgentRunCapabilities } from './agent-run-capabilities'
 import { KopilotContextStore, readContextSlice } from './context'
 import { type AgentRuntimeDomain, buildEffectiveAgentRuntime } from './effective-runtime'
@@ -150,7 +148,9 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   const callModel = createCallModel({
     organizationId,
     userId,
-    source: domain,
+    // `domain` is narrowed to 'kopilot' | 'builder' above; spelled out because
+    // `AiUsage.source` is a fixed vocabulary, not a passthrough of job data.
+    source: domain === 'builder' ? 'builder' : 'kopilot',
     sourceId: sessionId,
     forceSystem: domain === 'builder',
   })
@@ -190,45 +190,18 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   // over any stale `context.page` the caller carried in. See the matching order
   // in `apps/web/src/app/api/kopilot/stream/route.ts`.
   const sessionContext = { ...(context ?? {}), page }
-  const usageEntries: UsageTrackingRequest[] = []
 
-  // Drain one engine pass: publish every event, accumulate per-call usage, and
-  // return the final assistant text. Called once for a plain turn, or once per
-  // stepper phase by `runProcedureTurn` (each re-drain bills its own iterations).
+  // Drain one engine pass: publish every event and return the final assistant
+  // text. Called once for a plain turn, or once per stepper phase by
+  // `runProcedureTurn`. Usage is NOT drained here — `createCallModel` bills each
+  // LLM call as it completes (see `llm-adapter.ts`); draining `event.iterations`
+  // for billing again would double-charge.
   const drain = async (gen: AsyncGenerator<AgentEvent>): Promise<string> => {
     let text = ''
     for await (const event of gen) {
       if (signal?.aborted) {
         engine.interrupt()
         break
-      }
-
-      // Per-LLM-call billing breakdown lives on `event.iterations` (one entry
-      // per agent iteration). Iterate to push one usage record per call with
-      // correct SYSTEM-vs-CUSTOM credit gating — BYOK customers consume no
-      // credits. Drain on both `paused` and `finished`: pre-pause iterations
-      // ride on `paused`, post-resume iterations on `finished`. Each event
-      // carries only segment-fresh iterations so no double-billing.
-      if (
-        (event.type === 'assistant-message-finished' ||
-          event.type === 'assistant-message-paused') &&
-        event.iterations?.length
-      ) {
-        for (const it of event.iterations) {
-          usageEntries.push({
-            organizationId,
-            userId,
-            provider: it.provider,
-            model: it.model,
-            usage: it.usage,
-            timestamp: new Date(),
-            source: 'agent',
-            sourceId: sessionId,
-            providerType: it.providerType,
-            credentialSource: it.credentialSource,
-            // creditsUsed omitted: metered from USD COGS per call (0 for BYO).
-          })
-        }
       }
 
       if (event.type === 'assistant-message-finished') {
@@ -320,26 +293,7 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
     domainState: finalState.domainState as Record<string, unknown>,
   })
 
-  // 8. Batch usage tracking
-  if (usageEntries.length > 0) {
-    logger.info('Tracking agent usage batch', {
-      sessionId,
-      entries: usageEntries.length,
-      totalTokens: usageEntries.reduce((sum, e) => sum + (e.usage.total_tokens || 0), 0),
-    })
-    try {
-      const usageService = new UsageTrackingService()
-      await usageService.trackUsageBatch(usageEntries)
-    } catch (err) {
-      logger.error('Failed to track usage batch', {
-        sessionId,
-        entries: usageEntries.length,
-        error: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
-
-  // 9. Publish terminal event
+  // 8. Publish terminal event
   await publisher.publish({ type: 'done' })
 
   // 10. If this run was kicked off by a trigger, record a fire on the row.

--- a/packages/lib/src/ai/orchestrator/llm-orchestrator.ts
+++ b/packages/lib/src/ai/orchestrator/llm-orchestrator.ts
@@ -225,14 +225,16 @@ export class LLMOrchestrator {
    * method does NOT call `UsageTrackingService.trackUsage` internally — the
    * generator's return value (`LLMInvocationResponse`) carries `usage`,
    * `providerType`, and `credentialSource`, and the caller must forward those
-   * to `UsageTrackingService.trackUsage` or `trackUsageBatch` to (a) record
-   * the `AiUsage` row and (b) deduct SYSTEM credits via `QuotaService`.
+   * to `UsageTrackingService.trackUsage` to (a) record the `AiUsage` row and
+   * (b) deduct SYSTEM credits via `QuotaService`.
    *
-   * The current callers (`agent-framework/llm-adapter.ts` → kopilot route +
-   * `process-agent-job.ts`) batch usage per turn, which is cheaper than
-   * per-chunk tracking inside the orchestrator. If you add a new direct
-   * `streamInvoke` caller, do not skip this step or SYSTEM credits won't be
-   * deducted.
+   * There is exactly ONE caller — `agent-framework/llm-adapter.ts` — and it
+   * meters every call as the call completes (including aborted and failed
+   * ones). That single choke point is deliberate: it is what keeps every agent
+   * surface billed without each runner remembering to drain usage, which is
+   * how the chat widget and the headless capture runs went unbilled before.
+   * Do not add a second direct `streamInvoke` caller without metering it, and
+   * do not re-add per-turn drains in the runners — they would double-bill.
    */
   async *streamInvoke(
     request: LLMInvocationRequest
@@ -255,6 +257,20 @@ export class LLMOrchestrator {
     } = await this.enforceQuotaGate(provider, model, organizationId, userId, {
       forceSystem: request.forceSystem ?? false,
     })
+
+    // Credential metadata up front, as a synthetic zero-length chunk
+    // (`chunkIndex: -1`). The gate already resolved it, but it would otherwise
+    // only reach the caller on the generator's RETURN value — which an aborted
+    // stream never sees, leaving `llm-adapter`'s abort-path billing unable to
+    // tell a SYSTEM call from a BYO one and charging 0 credits for tokens that
+    // were really spent. Empty `delta`, so chunk consumers are unaffected.
+    yield {
+      id: 'gate',
+      model,
+      content: '',
+      delta: '',
+      metadata: { chunkIndex: -1, totalLength: 0, providerType, credentialSource },
+    }
 
     try {
       // Build invocation parameters

--- a/packages/lib/src/ai/orchestrator/types.ts
+++ b/packages/lib/src/ai/orchestrator/types.ts
@@ -137,13 +137,27 @@ export type CredentialSourceType = 'SYSTEM' | 'CUSTOM' | 'MODEL_SPECIFIC' | 'LOA
 /** Provider type for tracking system vs custom credentials */
 export type ProviderTypeValue = 'SYSTEM' | 'CUSTOM'
 
-/** Source of AI usage for tracking purposes */
+/**
+ * Source of AI usage for tracking purposes — the `AiUsage.source` label every
+ * cost query groups by. The streaming agent paths take theirs from
+ * `LLMAdapterConfig.source` (see `agent-framework/llm-adapter.ts`), so a new
+ * runner that wants its own cost line adds its label here and passes it to
+ * `createCallModel`. The column itself is free-form text; this union is what
+ * keeps the vocabulary from drifting into unqueryable one-offs.
+ */
 export type UsageSource =
   | 'compose'
   | 'workflow'
+  | 'workflow_ai_node'
+  | 'workflow_ai_node_structured'
   | 'dataset'
   | 'chat'
   | 'agent'
+  | 'kopilot'
+  | 'builder'
+  | 'eval'
+  | 'learned_extraction'
+  | 'stale_scanner'
   | 'autofill'
   | 'transcription'
   | 'other'

--- a/packages/lib/src/approvals/__tests__/approval-apply-capabilities.test.ts
+++ b/packages/lib/src/approvals/__tests__/approval-apply-capabilities.test.ts
@@ -22,10 +22,12 @@ vi.mock('../../permissions/capabilities/get-capabilities', () => ({
  * exists to ask: does the tool body see a `CapabilityView`, and does that view
  * decide the outcome?
  */
-const { seenDeps, probeCapability, emptyCapability } = vi.hoisted(() => {
+const { seenDeps, probeCapability, emptyCapability, probeState } = vi.hoisted(() => {
   const seen: unknown[] = []
+  const state = { throwForbidden: false }
   return {
     seenDeps: seen,
+    probeState: state,
     emptyCapability: () => ({ page: '__global__', tools: [] }),
     probeCapability: (getDeps: () => { capabilities?: unknown }) => ({
       page: '__global__',
@@ -37,6 +39,12 @@ const { seenDeps, probeCapability, emptyCapability } = vi.hoisted(() => {
           execute: async () => {
             const deps = getDeps()
             seen.push(deps)
+            // How the real instance gates throw: `assertEditInstance` raises a
+            // ForbiddenError rather than returning success=false.
+            if (state.throwForbidden) {
+              const { ForbiddenError } = await import('../../errors')
+              throw new ForbiddenError('You do not have permission to edit this knowledge base.')
+            }
             const view = deps.capabilities as CapabilityView | undefined
             if (!view) return { success: false, error: 'no_capability_view' }
             if (!view.canEditEntity('def-a')) return { success: false, error: 'denied' }
@@ -113,13 +121,16 @@ function bundleRow() {
   }
 }
 
-function fakeDb() {
+function fakeDb(updateSpy?: () => void) {
   return {
     query: {
       AiSuggestion: { findFirst: async () => bundleRow() },
       EntityInstance: { findFirst: async () => undefined },
     },
-    update: () => chain([]),
+    update: () => {
+      updateSpy?.()
+      return chain([])
+    },
   } as any
 }
 
@@ -127,6 +138,7 @@ beforeEach(() => {
   capsByUser.clear()
   seenDeps.length = 0
   getCapabilitiesSpy.mockClear()
+  probeState.throwForbidden = false
 })
 
 describe('approveBundle — apply-time replay is bound by the APPROVER', () => {
@@ -168,5 +180,26 @@ describe('approveBundle — apply-time replay is bound by the APPROVER', () => {
     }
     // And it was denied by a real view, not by the absence of one.
     expect((seenDeps[0] as ToolDeps).capabilities).toBe(NONE_VIEW)
+  })
+
+  it('leaves the bundle FRESH when every action is blocked by permissions', async () => {
+    capsByUser.set(APPROVER, ALLOW_VIEW)
+    probeState.throwForbidden = true
+    const updateSpy = vi.fn()
+
+    const out = await approveBundle(fakeDb(updateSpy), {
+      bundleId: 'sug-1',
+      organizationId: ORG,
+      userId: APPROVER,
+    })
+
+    // A 403 says something about the approver, not the proposal — resolving the
+    // bundle here would let anyone without the rung destroy it by clicking
+    // Approve, with no way to get it back.
+    expect(Result.isOk(out)).toBe(false)
+    if (!Result.isOk(out)) {
+      expect(out.error.name).toBe('ForbiddenError')
+    }
+    expect(updateSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/approvals/actions-service.ts
+++ b/packages/lib/src/approvals/actions-service.ts
@@ -21,7 +21,7 @@ import {
   type GetToolDeps,
 } from '../ai/kopilot/capabilities'
 import { createMcpCapabilities } from '../ai/mcp'
-import { ConflictError, NotFoundError } from '../errors'
+import { AuxxError, ConflictError, ForbiddenError, NotFoundError } from '../errors'
 import { appendLearnedProvenance } from '../kb/learned/provenance'
 import {
   createScheduledMessage,
@@ -188,15 +188,19 @@ export async function approveBundle(
         failedIndices.add(action.localIndex)
       }
     } catch (err) {
+      // A 403 is the approver's problem, not the proposal's — record it as
+      // `blocked` so an all-blocked bundle survives for someone who can act.
+      const blocked = err instanceof AuxxError && err.statusCode === 403
       logger.error('Approval tool execution threw', {
         bundleId: bundle.id,
         toolName: action.toolName,
         localIndex: action.localIndex,
+        blocked,
         error: err instanceof Error ? err.message : String(err),
       })
       outcomes.push({
         localIndex: action.localIndex,
-        status: 'failed',
+        status: blocked ? 'blocked' : 'failed',
         error: err instanceof Error ? err.message : String(err),
       })
       failedIndices.add(action.localIndex)
@@ -224,7 +228,24 @@ export async function approveBundle(
     }
   }
 
-  // 7. Resolve terminal status.
+  // 7. All-blocked: the approver couldn't run a single action, so the bundle
+  // stays FRESH and untouched. Resolving it to REJECTED here would let a member
+  // without the rung destroy a proposal by clicking Approve — a permission
+  // failure must not consume the thing it failed to apply.
+  if (outcomes.length > 0 && outcomes.every((o) => o.status === 'blocked')) {
+    logger.warn('Approval blocked by permissions; bundle left FRESH', {
+      bundleId: bundle.id,
+      userId: args.userId,
+      actionCount: outcomes.length,
+    })
+    return Result.error(
+      new ForbiddenError(
+        outcomes[0]?.error ?? 'You do not have permission to apply this suggestion.'
+      )
+    )
+  }
+
+  // 8. Resolve terminal status.
   const successCount = outcomes.filter((o) => o.status === 'success').length
   const terminal: BundleTerminalStatus =
     successCount === outcomes.length

--- a/packages/lib/src/approvals/types.ts
+++ b/packages/lib/src/approvals/types.ts
@@ -74,7 +74,14 @@ export interface HeadlessRunInput {
  */
 export interface ActionOutcome {
   localIndex: number
-  status: 'success' | 'failed' | 'skipped_dep_rejected'
+  /**
+   * `blocked` = the approver lacked a permission the tool enforces. Kept
+   * distinct from `failed` because it says nothing about the proposal: a
+   * bundle whose actions are ALL blocked stays FRESH so someone with the right
+   * rung can still approve it, instead of being consumed by the person who
+   * couldn't run it (see `approveBundle`).
+   */
+  status: 'success' | 'failed' | 'blocked' | 'skipped_dep_rejected'
   toolOutput?: Record<string, unknown>
   error?: string
 }

--- a/packages/lib/src/chat/agent/build-chat-engine-config.ts
+++ b/packages/lib/src/chat/agent/build-chat-engine-config.ts
@@ -211,7 +211,9 @@ export async function buildChatEngineConfig(
   const callModel = createCallModel({
     organizationId,
     userId: agentUserId,
-    source: 'kopilot',
+    // Visitor-facing widget turns bill under their own label, not 'kopilot' —
+    // customer chat is the one surface an org cannot rate-limit by hand.
+    source: 'chat',
     sourceId: sessionId,
   })
 

--- a/packages/lib/src/data-migrations/migrations/067-clear-dead-learned-stamps.ts
+++ b/packages/lib/src/data-migrations/migrations/067-clear-dead-learned-stamps.ts
@@ -1,0 +1,66 @@
+// packages/lib/src/data-migrations/migrations/067-clear-dead-learned-stamps.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNotNull, notInArray, sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-067')
+
+/**
+ * Clear `Thread.learnedExtractedAt` on threads the AI Memory extractor never
+ * actually read.
+ *
+ * **Why they exist.** Capture-mode runs bind to a human member and refuse to
+ * run for anyone else. The learned-extraction job used to fall back to
+ * `Organization.systemUserId` — deliberately NOT a member — so every thread
+ * without a human assignee produced an instant no-op that the job then
+ * recorded as "extracted". The stamp is the dedupe gate, so those threads were
+ * excluded from AI Memory permanently, and fixing the principal resolution
+ * alone would not bring them back.
+ *
+ * **Why `notInArray` over a bundle join.** A stamp is only trustworthy if a run
+ * produced something: threads that reached the model and returned `[noop]` are
+ * indistinguishable from the dead ones by timestamp alone. Threads that DID
+ * produce a proposal are identifiable — they have a learned bundle — so those
+ * keep their stamp and everything else is re-opened. Re-running an extraction
+ * on a handful of already-seen threads is cheap and gated; never re-running one
+ * is the failure this repairs.
+ *
+ * Raw Drizzle on purpose (project convention for data migrations): the thread
+ * service path fires realtime and reconciliation side effects that a column
+ * fixup has no business entering.
+ */
+export const migration067ClearDeadLearnedStamps: DataMigrationDef = {
+  id: '067-clear-dead-learned-stamps',
+  description: 'Clear learnedExtractedAt on threads that never produced a memory proposal',
+  async run(db: Database): Promise<void> {
+    const proposed = await db
+      .selectDistinct({ threadId: schema.AiSuggestion.threadId })
+      .from(schema.AiSuggestion)
+      .where(
+        and(
+          eq(schema.AiSuggestion.triggerSource, 'learned-extraction'),
+          isNotNull(schema.AiSuggestion.threadId)
+        )
+      )
+    const keep = proposed.map((row) => row.threadId).filter((id): id is string => id !== null)
+
+    const cleared = await db
+      .update(schema.Thread)
+      .set({ learnedExtractedAt: null })
+      .where(
+        and(
+          isNotNull(schema.Thread.learnedExtractedAt),
+          keep.length > 0 ? notInArray(schema.Thread.id, keep) : sql`true`
+        )
+      )
+      .returning({ id: schema.Thread.id })
+
+    logger.info('Cleared dead learned-extraction stamps', {
+      cleared: cleared.length,
+      keptWithProposals: keep.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -33,6 +33,7 @@ import { migration063RetireMailPermissionsFeatureKey } from './migrations/063-re
 import { migration064SequencesLimit } from './migrations/064-sequences-limit'
 import { migration065DashboardsAllPlans } from './migrations/065-dashboards-all-plans'
 import { migration066DemoMonthlyAiCredits } from './migrations/066-demo-monthly-ai-credits'
+import { migration067ClearDeadLearnedStamps } from './migrations/067-clear-dead-learned-stamps'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -88,6 +89,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration064SequencesLimit,
     migration065DashboardsAllPlans,
     migration066DemoMonthlyAiCredits,
+    migration067ClearDeadLearnedStamps,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/jobs/approvals/__tests__/learned-extraction-gates.test.ts
+++ b/packages/lib/src/jobs/approvals/__tests__/learned-extraction-gates.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/jobs/approvals/__tests__/learned-extraction-gates.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { learnedExtractionSkipReason } from '../learned-extraction-gates'
+import { hasHumanOutbound, learnedExtractionSkipReason } from '../learned-extraction-gates'
 
 function thread(
   overrides: Partial<Parameters<typeof learnedExtractionSkipReason>[0]> = {}
@@ -67,5 +67,23 @@ describe('learnedExtractionSkipReason', () => {
         })
       )
     ).toBe('already_extracted')
+  })
+})
+
+describe('hasHumanOutbound', () => {
+  it('is false when nobody replied', () => {
+    expect(hasHumanOutbound([])).toBe(false)
+  })
+
+  it('is false when every outbound message came from an agent', () => {
+    expect(hasHumanOutbound([{ authorUserType: 'AGENT' }, { authorUserType: 'AGENT' }])).toBe(false)
+  })
+
+  it('is true when a human replied alongside the agent', () => {
+    expect(hasHumanOutbound([{ authorUserType: 'AGENT' }, { authorUserType: 'USER' }])).toBe(true)
+  })
+
+  it('treats a provider-synced send (null author) as human', () => {
+    expect(hasHumanOutbound([{ authorUserType: null }])).toBe(true)
   })
 })

--- a/packages/lib/src/jobs/approvals/__tests__/learned-run-principal.test.ts
+++ b/packages/lib/src/jobs/approvals/__tests__/learned-run-principal.test.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/jobs/approvals/__tests__/learned-run-principal.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Capture-mode runs refuse to run for anyone who isn't an ACTIVE human member,
+ * so this chain is what decides whether a thread can be learned from at all —
+ * and the org fallback is what keeps unassigned threads (nearly all of them)
+ * from being permanently skipped.
+ */
+
+const state = vi.hoisted(() => ({
+  members: [] as Array<Record<string, unknown>>,
+  lastOutboundAuthorId: null as string | null,
+}))
+
+vi.mock('../../../cache/org-cache-helpers', () => ({
+  getCachedMembers: async () => state.members,
+}))
+
+const { resolveLearnedRunPrincipal } = await import('../learned-run-principal')
+
+const member = (
+  userId: string,
+  overrides: { role?: string; status?: string; userType?: string } = {}
+) => ({
+  userId,
+  role: overrides.role ?? 'USER',
+  status: overrides.status ?? 'ACTIVE',
+  user: { userType: overrides.userType ?? 'USER' },
+})
+
+/** Minimal db stand-in: only the last-outbound-author query is reached. */
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: async () =>
+            state.lastOutboundAuthorId ? [{ createdById: state.lastOutboundAuthorId }] : [],
+        }),
+      }),
+    }),
+  }),
+} as never
+
+const resolve = (params: { assigneeId?: string | null; requestedByUserId?: string }) =>
+  resolveLearnedRunPrincipal({
+    db,
+    organizationId: 'org-1',
+    threadId: 'thread-1',
+    assigneeId: params.assigneeId ?? null,
+    requestedByUserId: params.requestedByUserId,
+  })
+
+describe('resolveLearnedRunPrincipal', () => {
+  beforeEach(() => {
+    state.members = [
+      member('owner-1', { role: 'OWNER' }),
+      member('admin-1', { role: 'ADMIN' }),
+      member('human-1'),
+      member('agent-1', { userType: 'AGENT' }),
+      member('inactive-1', { status: 'INVITED' }),
+    ]
+    state.lastOutboundAuthorId = null
+  })
+
+  it('prefers the member who explicitly asked, and gives them the bundle', async () => {
+    state.lastOutboundAuthorId = 'human-1'
+    await expect(resolve({ assigneeId: 'admin-1', requestedByUserId: 'human-1' })).resolves.toEqual(
+      {
+        runAsUserId: 'human-1',
+        ownerUserId: 'human-1',
+      }
+    )
+  })
+
+  it('falls to the assignee when nobody asked', async () => {
+    await expect(resolve({ assigneeId: 'human-1' })).resolves.toEqual({
+      runAsUserId: 'human-1',
+      ownerUserId: 'human-1',
+    })
+  })
+
+  it('skips an agent assignee — a pseudo-user is not a principal', async () => {
+    state.lastOutboundAuthorId = 'human-1'
+    await expect(resolve({ assigneeId: 'agent-1' })).resolves.toEqual({
+      runAsUserId: 'human-1',
+      ownerUserId: 'human-1',
+    })
+  })
+
+  it('skips a non-ACTIVE requester', async () => {
+    await expect(resolve({ requestedByUserId: 'inactive-1' })).resolves.toEqual({
+      runAsUserId: 'owner-1',
+      ownerUserId: null,
+    })
+  })
+
+  it('uses the last outbound human author when the thread is unassigned', async () => {
+    state.lastOutboundAuthorId = 'human-1'
+    await expect(resolve({})).resolves.toEqual({
+      runAsUserId: 'human-1',
+      ownerUserId: 'human-1',
+    })
+  })
+
+  it('falls back to the org owner, leaving the bundle unassigned', async () => {
+    await expect(resolve({})).resolves.toEqual({
+      runAsUserId: 'owner-1',
+      ownerUserId: null,
+    })
+  })
+
+  it('falls back to an admin when there is no human owner', async () => {
+    state.members = [
+      member('owner-bot', { role: 'OWNER', userType: 'AGENT' }),
+      member('admin-1', { role: 'ADMIN' }),
+    ]
+    await expect(resolve({})).resolves.toEqual({
+      runAsUserId: 'admin-1',
+      ownerUserId: null,
+    })
+  })
+
+  it('returns null when the org has no ACTIVE human member', async () => {
+    state.members = [member('agent-1', { userType: 'AGENT' }), member('x', { status: 'INVITED' })]
+    await expect(resolve({})).resolves.toBeNull()
+  })
+})

--- a/packages/lib/src/jobs/approvals/learned-extraction-gates.ts
+++ b/packages/lib/src/jobs/approvals/learned-extraction-gates.ts
@@ -27,3 +27,23 @@ export function learnedExtractionSkipReason(
   }
   return undefined
 }
+
+/** One outbound message, reduced to what the authorship gate needs. */
+export interface OutboundAuthor {
+  /** `User.userType` of the sender, or null for provider-synced sends. */
+  authorUserType: string | null
+}
+
+/**
+ * Did a human answer this thread? A thread only teaches us how *we* answer if
+ * one of us wrote the answer — and now that agents reply autonomously, the old
+ * "≥1 outbound message" proxy let the AI learn from its own replies and feed
+ * them back to itself.
+ *
+ * A null `authorUserType` counts as human: it means the message was synced from
+ * the provider (someone replied in Gmail), not sent by an agent through the app.
+ */
+export function hasHumanOutbound(outbound: readonly OutboundAuthor[]): boolean {
+  if (outbound.length === 0) return false
+  return outbound.some((m) => m.authorUserType !== 'AGENT')
+}

--- a/packages/lib/src/jobs/approvals/learned-extraction-job.ts
+++ b/packages/lib/src/jobs/approvals/learned-extraction-job.ts
@@ -10,12 +10,26 @@ import { runLearnedExtraction } from '../../approvals/learned-extraction-runner'
 import { getCachedDefaultModel } from '../../cache/org-cache-helpers'
 import { FeaturePermissionService } from '../../permissions/feature-permission-service'
 import { FeatureKey } from '../../permissions/types'
+import { checkFixedWindowLimit } from '../../utils/rate-limiter/fixed-window'
 import { getQueue } from '../queues'
 import { Queues } from '../queues/types'
 import type { JobContext } from '../types'
-import { learnedExtractionSkipReason } from './learned-extraction-gates'
+import { hasHumanOutbound, learnedExtractionSkipReason } from './learned-extraction-gates'
+import { resolveLearnedRunPrincipal } from './learned-run-principal'
 
 const logger = createScopedLogger('job:learned-extraction')
+
+/**
+ * Extraction runs an org may spend per day. A guardrail against an inbox that
+ * archives hundreds of threads a day, not a billing control (credits are
+ * metered per call in `llm-adapter.ts`). Forced runs count toward the window
+ * but are never blocked by it — a human asking is worth a slot.
+ */
+export const LEARNED_EXTRACTION_DAILY_LIMIT = 100
+
+const DAY_MS = 24 * 60 * 60 * 1000
+/** Outbound messages sampled for the authorship gate. */
+const OUTBOUND_SAMPLE = 20
 
 export interface LearnedExtractionJobData {
   organizationId: string
@@ -25,6 +39,12 @@ export interface LearnedExtractionJobData {
    * `learnedExtractedAt` dedupe — an explicit ask always runs.
    */
   force?: boolean
+  /**
+   * The member who asked. Forced runs carry it so the run binds to THEIR
+   * capabilities and the proposal lands in THEIR Today feed, instead of being
+   * re-derived from a thread they may not be assigned to.
+   */
+  requestedByUserId?: string
 }
 
 /**
@@ -52,83 +72,124 @@ export async function enqueueLearnedExtraction(data: LearnedExtractionJobData): 
 
 /**
  * Learned-KB extraction — runs once per thread resolve (enqueued by
- * `ThreadMutationService` on transition to ARCHIVED). Cheap noise gates run
- * before any LLM call; most threads are skipped. A surviving thread gets one
- * capture-mode kopilot run whose proposed `upsert_learned_article` calls land
- * as a `triggerSource: 'learned-extraction'` AiSuggestion bundle in Today.
+ * `ThreadMutationService`) or on demand from "Remember this thread". Cheap
+ * row-local gates run before any LLM call; most threads are skipped. A
+ * surviving thread gets one capture-mode kopilot run whose proposed
+ * `upsert_learned_article` calls land as a `triggerSource: 'learned-extraction'`
+ * AiSuggestion bundle in Today.
  *
- * `Thread.learnedExtractedAt` is stamped after every successful run —
- * including [noop] — so a reopen→re-close with no new messages is skipped,
- * while a thread that accrues new conversation becomes eligible again. A
- * failed run does NOT stamp, so BullMQ's retry gets a clean slate.
+ * `Thread.learnedExtractedAt` is stamped ONLY after the model actually looked
+ * at the thread — including a `[noop]` verdict, since a thread that taught
+ * nothing shouldn't be re-read. Every pre-LLM exit (no principal, no anchor,
+ * daily cap) leaves the stamp alone: those are conditions that change, and a
+ * stamp would exclude the thread forever. A failed run doesn't stamp either, so
+ * BullMQ's retry gets a clean slate.
+ *
+ * Every exit funnels through `finish` so one structured line per invocation
+ * lands in the log — a dead pipeline and an idle one look identical otherwise.
  */
 export async function learnedExtractionJob(ctx: JobContext<LearnedExtractionJobData>) {
-  const { organizationId, threadId, force } = ctx.job.data
+  const { organizationId, threadId, force, requestedByUserId } = ctx.job.data
+  const startedAt = Date.now()
+
+  const finish = <T extends Record<string, unknown>>(outcome: string, result: T): T => {
+    logger.info('Learned extraction finished', {
+      organizationId,
+      threadId,
+      force: force ?? false,
+      outcome,
+      durationMs: Date.now() - startedAt,
+    })
+    return result
+  }
+  const skip = (reason: string) => finish(reason, { skipped: reason })
 
   const features = new FeaturePermissionService()
   const enabled = await features.hasAccess(organizationId, FeatureKey.learnedMemory)
-  if (!enabled) return { skipped: 'feature_disabled' }
+  if (!enabled) return skip('feature_disabled')
 
   const thread = await database.query.Thread.findFirst({
     where: and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, organizationId)),
   })
-  if (!thread) return { skipped: 'thread_not_found' }
+  if (!thread) return skip('thread_not_found')
 
   // Noise gates — all row-local; no LLM call unless they pass. A forced run
   // (explicit "remember this thread") bypasses them: the human is the gate.
   if (!force) {
     const skipReason = learnedExtractionSkipReason(thread)
-    if (skipReason) return { skipped: skipReason }
+    if (skipReason) return skip(skipReason)
 
-    // Require at least one outbound reply — a thread nobody answered teaches
-    // nothing about how we answer. (Human vs AI authorship isn't recorded on
-    // Message rows, so outbound presence is the v1 proxy.)
-    const outbound = await database.query.Message.findFirst({
-      where: and(
-        eq(schema.Message.threadId, threadId),
-        eq(schema.Message.organizationId, organizationId),
-        eq(schema.Message.isInbound, false)
-      ),
-      columns: { id: true },
+    // A thread nobody answered teaches nothing about how we answer — and one
+    // only an AI answered would teach us our own words back.
+    const outbound = await database
+      .select({ authorUserType: schema.User.userType })
+      .from(schema.Message)
+      .leftJoin(schema.User, eq(schema.User.id, schema.Message.createdById))
+      .where(
+        and(
+          eq(schema.Message.threadId, threadId),
+          eq(schema.Message.organizationId, organizationId),
+          eq(schema.Message.isInbound, false)
+        )
+      )
+      .limit(OUTBOUND_SAMPLE)
+    if (outbound.length === 0) return skip('no_outbound_reply')
+    if (!hasHumanOutbound(outbound)) return skip('ai_only')
+  }
+
+  // Per-org daily ceiling. Forced runs consume a slot but are never refused.
+  const window = await checkFixedWindowLimit({
+    key: `learned-extraction:${organizationId}:${new Date().toISOString().slice(0, 10)}`,
+    limit: LEARNED_EXTRACTION_DAILY_LIMIT,
+    windowMs: DAY_MS,
+  })
+  if (!window.allowed && !force) {
+    logger.warn('Learned extraction daily limit reached', {
+      organizationId,
+      threadId,
+      count: window.count,
+      limit: LEARNED_EXTRACTION_DAILY_LIMIT,
     })
-    if (!outbound) return { skipped: 'no_outbound_reply' }
+    return skip('daily_limit_reached')
   }
 
   const modelDefault = await getCachedDefaultModel(organizationId, ModelType.LLM)
-  if (!modelDefault) return { skipped: 'no_default_model' }
+  if (!modelDefault) return skip('no_default_model')
   const modelId = `${modelDefault.provider}:${modelDefault.model}`
 
-  const org = await database.query.Organization.findFirst({
-    where: eq(schema.Organization.id, organizationId),
-    columns: { systemUserId: true, createdById: true },
+  // Capture runs bind to a human member and refuse to run for anyone else, so
+  // the principal decides whether this thread can be learned from at all.
+  const principal = await resolveLearnedRunPrincipal({
+    db: database,
+    organizationId,
+    threadId,
+    assigneeId: thread.assigneeId,
+    requestedByUserId,
   })
-  // Bundle owner must be a HUMAN — threads are often assigned to AI agent
-  // pseudo-users (userType 'AGENT'), and Today only lists a member's own +
-  // unassigned bundles. Non-human assignee → unassigned (visible to all).
-  const humanAssigneeId = await resolveHumanUserId(thread.assigneeId)
-  const ownerUserId = humanAssigneeId ?? null
-  // The engine/LLM attribution user just needs to exist; system user is fine.
-  const runAsUserId = humanAssigneeId ?? org?.systemUserId ?? org?.createdById
-  if (!runAsUserId) return { skipped: 'no_owner' }
+  if (!principal) {
+    logger.warn('Learned extraction has no human principal', { organizationId, threadId })
+    return skip('no_human_principal')
+  }
 
   const anchor = await resolveAnchor(thread, organizationId)
-  if (!anchor) {
-    // No linked record to hang the bundle on — stamp so we don't re-evaluate
-    // this thread every reopen, and move on.
-    await stampExtractedAt(threadId)
-    return { skipped: 'no_anchor_record' }
-  }
+  if (!anchor) return skip('no_anchor_record')
 
   const callModel = createCallModel({
     organizationId,
-    userId: runAsUserId,
-    source: 'kopilot',
-    sourceId: 'headless-learned-extraction',
+    userId: principal.runAsUserId,
+    source: 'learned_extraction',
+    sourceId: threadId,
   })
 
   const result = await runLearnedExtraction(
     { db: database, callModel },
-    { organizationId, ownerUserId: runAsUserId, threadId, anchor, modelId }
+    {
+      organizationId,
+      ownerUserId: principal.runAsUserId,
+      threadId,
+      anchor,
+      modelId,
+    }
   )
   if (!result.ok) {
     logger.warn('Learned extraction run failed', {
@@ -142,18 +203,14 @@ export async function learnedExtractionJob(ctx: JobContext<LearnedExtractionJobD
   await stampExtractedAt(threadId)
 
   if (result.value.actions.length === 0) {
-    logger.info('Learned extraction noop', {
-      organizationId,
-      threadId,
-      noopReason: result.value.noopReason,
-    })
-    return { extracted: false, noopReason: result.value.noopReason }
+    await notifyForcedNoop({ organizationId, threadId, requestedByUserId, force })
+    return finish('noop', { extracted: false, noopReason: result.value.noopReason })
   }
 
   const insert = await createBundleFromHeadlessRun(database, {
     result: result.value,
     organizationId,
-    ownerUserId,
+    ownerUserId: principal.ownerUserId,
     entityInstanceId: anchor.entityInstanceId,
     entityDefinitionId: anchor.entityDefinitionId,
     threadId,
@@ -166,7 +223,7 @@ export async function learnedExtractionJob(ctx: JobContext<LearnedExtractionJobD
       threadId,
       error: insert.error.message,
     })
-    return { extracted: true, inserted: false }
+    return finish('bundle_conflict', { extracted: true, inserted: false })
   }
 
   logger.info('Learned extraction bundle created', {
@@ -175,10 +232,45 @@ export async function learnedExtractionJob(ctx: JobContext<LearnedExtractionJobD
     bundleId: insert.value?.id,
     actionCount: result.value.actions.length,
   })
-  return { extracted: true, inserted: insert.value !== undefined }
+  return finish('bundle_created', { extracted: true, inserted: insert.value !== undefined })
 }
 
 // ===== HELPERS =====
+
+/**
+ * Tell the requester when their explicit "Remember this thread" found nothing.
+ * A forced run feels like a foreground action but resolves in the background;
+ * without this it is indistinguishable from a broken pipeline — which is
+ * exactly how the dead-principal bug stayed invisible.
+ */
+async function notifyForcedNoop(params: {
+  organizationId: string
+  threadId: string
+  requestedByUserId?: string
+  force?: boolean
+}): Promise<void> {
+  const { organizationId, threadId, requestedByUserId, force } = params
+  if (!force || !requestedByUserId) return
+  try {
+    // Lazy: the notification service pulls the realtime barrel, which breaks
+    // module mocking for anything that imports this job statically.
+    const { NotificationService } = await import('../../notifications')
+    await new NotificationService(database).sendNotification({
+      type: 'SYSTEM_MESSAGE',
+      userId: requestedByUserId,
+      organizationId,
+      targetType: 'THREAD',
+      targetIds: { threadId },
+      message: 'Nothing new to remember from this conversation.',
+    })
+  } catch (error) {
+    logger.warn('Failed to notify forced-extraction noop', {
+      organizationId,
+      threadId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
 
 /**
  * Pick the record the bundle anchors to: the thread's primary entity when
@@ -219,16 +311,6 @@ async function resolveAnchor(
   })
   if (!instance || instance.archivedAt) return undefined
   return { entityInstanceId: instance.id, entityDefinitionId: instance.entityDefinitionId }
-}
-
-/** Resolve a user id to itself only when it belongs to a real human (userType 'USER'). */
-async function resolveHumanUserId(userId: string | null): Promise<string | null> {
-  if (!userId) return null
-  const user = await database.query.User.findFirst({
-    where: eq(schema.User.id, userId),
-    columns: { userType: true },
-  })
-  return user?.userType === 'USER' ? userId : null
 }
 
 async function stampExtractedAt(threadId: string): Promise<void> {

--- a/packages/lib/src/jobs/approvals/learned-run-principal.ts
+++ b/packages/lib/src/jobs/approvals/learned-run-principal.ts
@@ -1,0 +1,122 @@
+// packages/lib/src/jobs/approvals/learned-run-principal.ts
+
+import { type Database, schema } from '@auxx/database'
+import { and, desc, eq } from 'drizzle-orm'
+import { getCachedMembers } from '../../cache/org-cache-helpers'
+
+/**
+ * Who a learned-KB extraction runs as, and whose Today feed receives its
+ * proposal. The two are deliberately different questions — see
+ * {@link resolveLearnedRunPrincipal}.
+ */
+export interface LearnedRunPrincipal {
+  /** Human member the capture run binds its capabilities to. Always a real member. */
+  runAsUserId: string
+  /**
+   * Bundle owner. `null` = unassigned, which in the Today feed means "visible
+   * to every member" — the right answer when no specific human owns the thread.
+   */
+  ownerUserId: string | null
+}
+
+interface ResolveParams {
+  db: Database
+  organizationId: string
+  threadId: string
+  /** Thread assignee, which may be an AI-agent pseudo-user. */
+  assigneeId: string | null
+  /** Set for forced runs — the member who clicked "Remember this thread". */
+  requestedByUserId?: string
+}
+
+/**
+ * Resolve the human principal a learned extraction runs as.
+ *
+ * Capture-mode runs bind their capabilities to a human member
+ * (`resolveCaptureRunPrincipal`, doc 19 §2.3) and refuse to run at all for a
+ * non-member — and `Organization.systemUserId` is deliberately NOT a member.
+ * So a chain that fell back to the system user produced a permanent, silent
+ * no-op for every thread nobody happened to be assigned to, which in practice
+ * is nearly all of them.
+ *
+ * Order, first ACTIVE human member wins:
+ *
+ * 1. the member who explicitly asked ("Remember this thread"),
+ * 2. the thread's assignee (skipped when it's an agent pseudo-user),
+ * 3. whoever sent the last outbound message on the thread,
+ * 4. the org's owner (else an admin) — the standing principal for memory that
+ *    belongs to the org rather than to a person.
+ *
+ * `ownerUserId` only follows 1–3: a bundle produced under the org fallback has
+ * no personal owner, so it stays unassigned and every member sees it.
+ *
+ * Returns `null` when the org has no ACTIVE human member at all, which the job
+ * treats as a skip — NOT as a reason to stamp the thread.
+ *
+ * Running under an owner/admin view is safe here because the extractor's
+ * registry is three capabilities wide (knowledge search, KB read, and the
+ * approval-gated learned write door), so the widened view is KB and dataset
+ * reads, and every write it proposes still faces a human approval card.
+ */
+export async function resolveLearnedRunPrincipal(
+  params: ResolveParams
+): Promise<LearnedRunPrincipal | null> {
+  const { db, organizationId, threadId, assigneeId, requestedByUserId } = params
+  const members = await getCachedMembers(organizationId)
+  const isHuman = (userId: string | null | undefined): boolean => {
+    if (!userId) return false
+    const member = members.find((m) => m.userId === userId)
+    return member?.status === 'ACTIVE' && member.user?.userType === 'USER'
+  }
+
+  if (isHuman(requestedByUserId)) {
+    return { runAsUserId: requestedByUserId as string, ownerUserId: requestedByUserId as string }
+  }
+  if (isHuman(assigneeId)) {
+    return { runAsUserId: assigneeId as string, ownerUserId: assigneeId as string }
+  }
+
+  const lastOutboundAuthorId = await findLastOutboundAuthorId(db, organizationId, threadId)
+  if (isHuman(lastOutboundAuthorId)) {
+    return {
+      runAsUserId: lastOutboundAuthorId as string,
+      ownerUserId: lastOutboundAuthorId as string,
+    }
+  }
+
+  // Org fallback. Sorted by userId purely for stability across runs — it is a
+  // deterministic pick, not a meaningful ordering.
+  const humanMembers = members
+    .filter((m) => m.status === 'ACTIVE' && m.user?.userType === 'USER')
+    .sort((a, b) => a.userId.localeCompare(b.userId))
+  const orgPrincipal =
+    humanMembers.find((m) => m.role === 'OWNER') ?? humanMembers.find((m) => m.role === 'ADMIN')
+  if (orgPrincipal) return { runAsUserId: orgPrincipal.userId, ownerUserId: null }
+
+  return null
+}
+
+/**
+ * The `User` behind the most recent outbound message. Null for provider-synced
+ * sends (someone replied from Gmail), which simply falls through to the org
+ * principal.
+ */
+async function findLastOutboundAuthorId(
+  db: Database,
+  organizationId: string,
+  threadId: string
+): Promise<string | null> {
+  const [row] = await db
+    .select({ createdById: schema.Message.createdById })
+    .from(schema.Message)
+    .where(
+      and(
+        eq(schema.Message.threadId, threadId),
+        eq(schema.Message.organizationId, organizationId),
+        eq(schema.Message.isInbound, false)
+      )
+    )
+    .orderBy(desc(schema.Message.sentAt))
+    .limit(1)
+  return row?.createdById ?? null
+}

--- a/packages/lib/src/jobs/approvals/next-action-stale-scanner-job.ts
+++ b/packages/lib/src/jobs/approvals/next-action-stale-scanner-job.ts
@@ -79,8 +79,7 @@ export async function nextActionStaleScannerJob(ctx: JobContext<NextActionStaleS
     const callModel = createCallModel({
       organizationId: org.id,
       userId: org.systemUserId ?? org.createdById ?? '',
-      source: 'kopilot',
-      sourceId: 'headless-stale-scanner',
+      source: 'stale_scanner',
     })
 
     for (const slug of SCANNED_ENTITY_SLUGS) {

--- a/packages/lib/src/kb/index.ts
+++ b/packages/lib/src/kb/index.ts
@@ -81,6 +81,11 @@ export {
   readKopilotSnapshot,
 } from './kopilot-snapshot'
 export {
+  diffMarkdownLines,
+  type MarkdownDiff,
+  type MarkdownDiffLine,
+} from './learned/diff-markdown'
+export {
   ensureLearnedKb,
   LEARNED_CATEGORIES,
   LEARNED_CATEGORY_KEYS,
@@ -89,6 +94,14 @@ export {
   type LearnedCategoryKey,
   type LearnedKb,
 } from './learned/ensure-learned-kb'
+export {
+  getLearnedArticleDiff,
+  type LearnedArticleDiff,
+} from './learned/get-learned-article-diff'
+export {
+  getLearnedProvenance,
+  type LearnedProvenanceSource,
+} from './learned/get-learned-provenance'
 export {
   appendLearnedProvenance,
   type LearnedProvenanceEntry,

--- a/packages/lib/src/kb/learned/__tests__/diff-markdown.test.ts
+++ b/packages/lib/src/kb/learned/__tests__/diff-markdown.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/kb/learned/__tests__/diff-markdown.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { diffMarkdownLines } from '../diff-markdown'
+
+const text = (lines: string[]) => lines.join('\n')
+
+describe('diffMarkdownLines', () => {
+  it('reports no changes for identical bodies', () => {
+    const body = text(['# Refunds', 'We refund within 30 days.'])
+    const diff = diffMarkdownLines(body, body)
+    expect(diff.addedCount).toBe(0)
+    expect(diff.removedCount).toBe(0)
+    expect(diff.lines.every((l) => l.type === 'same')).toBe(true)
+  })
+
+  it('surfaces a dropped human line — the failure the diff exists to catch', () => {
+    const before = text([
+      '# Refunds',
+      'We refund within 30 days.',
+      'Dealers get 60 days (agreed with Mark).',
+    ])
+    const after = text(['# Refunds', 'We refund within 30 days.', 'Shipping is not refundable.'])
+
+    const diff = diffMarkdownLines(before, after)
+    expect(diff.removedCount).toBe(1)
+    expect(diff.addedCount).toBe(1)
+    expect(diff.lines).toContainEqual({
+      type: 'remove',
+      text: 'Dealers get 60 days (agreed with Mark).',
+    })
+    expect(diff.lines).toContainEqual({ type: 'add', text: 'Shipping is not refundable.' })
+  })
+
+  it('marks a pure append as added with nothing removed', () => {
+    const before = text(['# Refunds', 'We refund within 30 days.'])
+    const after = text(['# Refunds', 'We refund within 30 days.', 'Dealers get 60 days.'])
+
+    const diff = diffMarkdownLines(before, after)
+    expect(diff.removedCount).toBe(0)
+    expect(diff.addedCount).toBe(1)
+  })
+
+  it('ignores blank-line churn', () => {
+    const diff = diffMarkdownLines('# Refunds\n\nWe refund.', '# Refunds\nWe refund.\n\n\n')
+    expect(diff.addedCount).toBe(0)
+    expect(diff.removedCount).toBe(0)
+  })
+
+  it('treats an empty original as an all-added article', () => {
+    const diff = diffMarkdownLines('', text(['# New topic', 'Body.']))
+    expect(diff.removedCount).toBe(0)
+    expect(diff.addedCount).toBe(2)
+  })
+
+  it('keeps a rewritten line as one removal plus one addition', () => {
+    const diff = diffMarkdownLines('We refund within 30 days.', 'We refund within 45 days.')
+    expect(diff.removedCount).toBe(1)
+    expect(diff.addedCount).toBe(1)
+  })
+})

--- a/packages/lib/src/kb/learned/diff-markdown.ts
+++ b/packages/lib/src/kb/learned/diff-markdown.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/kb/learned/diff-markdown.ts
+// Line-level diff between an existing memory article and a proposed rewrite.
+// Pure and dependency-free so the approval surfaces can render it.
+
+/** One line of a rendered diff. */
+export interface MarkdownDiffLine {
+  type: 'add' | 'remove' | 'same'
+  text: string
+}
+
+export interface MarkdownDiff {
+  lines: MarkdownDiffLine[]
+  addedCount: number
+  removedCount: number
+}
+
+/**
+ * Diff two markdown bodies by line.
+ *
+ * `upsert_learned_article` replaces the whole article body and asks the model
+ * to merge existing content back in, so the one failure that matters is a
+ * merge that silently drops a human's correction. A rendered preview of the
+ * proposal cannot show that — only a diff can.
+ *
+ * Line granularity (not the KB's block diff) because the proposal is markdown
+ * with freshly minted block ids: `diffBlocks` keys on stable `attrs.id`, so
+ * every block of a re-parsed proposal would read as added, and the removals —
+ * the whole point — would be indistinguishable from a rewrite.
+ *
+ * Blank lines are dropped before comparison: markdown spacing is noise here,
+ * and keeping it doubles the diff for a one-word change.
+ */
+export function diffMarkdownLines(before: string, after: string): MarkdownDiff {
+  const oldLines = toLines(before)
+  const newLines = toLines(after)
+  const lcs = longestCommonSubsequence(oldLines, newLines)
+
+  const lines: MarkdownDiffLine[] = []
+  let i = 0
+  let j = 0
+
+  for (const common of lcs) {
+    while (i < oldLines.length && oldLines[i] !== common) {
+      lines.push({ type: 'remove', text: oldLines[i] as string })
+      i++
+    }
+    while (j < newLines.length && newLines[j] !== common) {
+      lines.push({ type: 'add', text: newLines[j] as string })
+      j++
+    }
+    lines.push({ type: 'same', text: common })
+    i++
+    j++
+  }
+  while (i < oldLines.length) {
+    lines.push({ type: 'remove', text: oldLines[i] as string })
+    i++
+  }
+  while (j < newLines.length) {
+    lines.push({ type: 'add', text: newLines[j] as string })
+    j++
+  }
+
+  return {
+    lines,
+    addedCount: lines.filter((l) => l.type === 'add').length,
+    removedCount: lines.filter((l) => l.type === 'remove').length,
+  }
+}
+
+function toLines(markdown: string): string[] {
+  return markdown
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0)
+}
+
+/**
+ * Classic LCS over whole lines. O(n·m) — bounded by the tool's 100k-char
+ * markdown cap, and memory articles are short by design.
+ */
+function longestCommonSubsequence(a: string[], b: string[]): string[] {
+  const table: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array(b.length + 1).fill(0)
+  )
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      const row = table[i] as number[]
+      const next = table[i + 1] as number[]
+      row[j] =
+        a[i] === b[j]
+          ? (next[j + 1] as number) + 1
+          : Math.max(next[j] as number, row[j + 1] as number)
+    }
+  }
+
+  const out: string[] = []
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      out.push(a[i] as string)
+      i++
+      j++
+      continue
+    }
+    const down = (table[i + 1] as number[])[j] as number
+    const right = (table[i] as number[])[j + 1] as number
+    if (down >= right) i++
+    else j++
+  }
+  return out
+}

--- a/packages/lib/src/kb/learned/get-learned-article-diff.ts
+++ b/packages/lib/src/kb/learned/get-learned-article-diff.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/kb/learned/get-learned-article-diff.ts
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { articleToMarkdown } from '../markdown/article-to-markdown'
+import type { ArticleNodeJSON } from '../markdown/types'
+import { diffMarkdownLines, type MarkdownDiff } from './diff-markdown'
+
+export interface LearnedArticleDiff extends MarkdownDiff {
+  /** False when the article no longer exists — the caller falls back to a flat preview. */
+  found: boolean
+  /** Current article title, so the reviewer sees a rename as a rename. */
+  currentTitle: string | null
+}
+
+/**
+ * Diff a proposed memory rewrite against the article as it stands today.
+ *
+ * Reads the PUBLISHED revision, because published is what AI Memory recalls
+ * and what a human would have been reading when they corrected it — an
+ * unpublished draft is not the thing the proposal is about to overwrite.
+ */
+export async function getLearnedArticleDiff(
+  db: Database,
+  params: { organizationId: string; articleId: string; markdown: string }
+): Promise<LearnedArticleDiff> {
+  const { organizationId, articleId, markdown } = params
+
+  const article = await db.query.Article.findFirst({
+    where: and(eq(schema.Article.id, articleId), eq(schema.Article.organizationId, organizationId)),
+    columns: { id: true, title: true, homeKnowledgeBaseId: true },
+  })
+  if (!article) {
+    return { found: false, currentTitle: null, lines: [], addedCount: 0, removedCount: 0 }
+  }
+
+  const placement = await db.query.ArticlePlacement.findFirst({
+    where: and(
+      eq(schema.ArticlePlacement.articleId, articleId),
+      eq(schema.ArticlePlacement.knowledgeBaseId, article.homeKnowledgeBaseId)
+    ),
+    columns: { publishedRevisionId: true },
+  })
+  const revision = placement?.publishedRevisionId
+    ? await db.query.ArticleRevision.findFirst({
+        where: eq(schema.ArticleRevision.id, placement.publishedRevisionId),
+        columns: { title: true, contentJson: true },
+      })
+    : undefined
+
+  const current = articleToMarkdown({
+    title: revision?.title ?? article.title,
+    contentJson: (revision?.contentJson as ArticleNodeJSON[] | null) ?? null,
+  })
+
+  return {
+    found: true,
+    currentTitle: revision?.title ?? article.title,
+    ...diffMarkdownLines(current, markdown),
+  }
+}

--- a/packages/lib/src/kb/learned/get-learned-provenance.ts
+++ b/packages/lib/src/kb/learned/get-learned-provenance.ts
@@ -1,0 +1,68 @@
+// packages/lib/src/kb/learned/get-learned-provenance.ts
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+import type { LearnedProvenanceEntry } from './provenance'
+
+/** One conversation a memory article was learned from. */
+export interface LearnedProvenanceSource {
+  threadId: string
+  subject: string | null
+  /** ISO timestamp of the most recent extraction that cited this thread. */
+  extractedAt: string
+}
+
+/**
+ * The conversations behind a memory article — "why does the AI believe this".
+ *
+ * `Article.learnedProvenance` has been an append-only audit column with no
+ * reader since it shipped; this is that reader. Deduped by thread (a reopened
+ * conversation can teach the same article twice), newest first.
+ */
+export async function getLearnedProvenance(
+  db: Database,
+  params: { organizationId: string; articleId: string }
+): Promise<LearnedProvenanceSource[]> {
+  const article = await db.query.Article.findFirst({
+    where: and(
+      eq(schema.Article.id, params.articleId),
+      eq(schema.Article.organizationId, params.organizationId)
+    ),
+    columns: { learnedProvenance: true },
+  })
+  const entries = (article?.learnedProvenance as LearnedProvenanceEntry[] | null) ?? []
+  if (entries.length === 0) return []
+
+  const latestByThread = new Map<string, string>()
+  for (const entry of entries) {
+    if (!entry?.threadId) continue
+    const seen = latestByThread.get(entry.threadId)
+    if (!seen || entry.extractedAt > seen) latestByThread.set(entry.threadId, entry.extractedAt)
+  }
+  const threadIds = [...latestByThread.keys()]
+  if (threadIds.length === 0) return []
+
+  const threads = await db
+    .select({ id: schema.Thread.id, subject: schema.Thread.subject })
+    .from(schema.Thread)
+    .where(
+      and(
+        inArray(schema.Thread.id, threadIds),
+        eq(schema.Thread.organizationId, params.organizationId)
+      )
+    )
+  const subjectById = new Map(threads.map((t) => [t.id, t.subject]))
+
+  return (
+    threadIds
+      .map((threadId) => ({
+        threadId,
+        subject: subjectById.get(threadId) ?? null,
+        extractedAt: latestByThread.get(threadId) as string,
+      }))
+      // A deleted thread keeps its entry: "learned from a conversation that no
+      // longer exists" is still the honest answer to why the article says what
+      // it says.
+      .sort((a, b) => b.extractedAt.localeCompare(a.extractedAt))
+  )
+}


### PR DESCRIPTION
Two clusters, both found while auditing whether AI Memory was ready to turn on for a real org. Neither was.

## 1. Streamed LLM usage was never metered

`LLMOrchestrator.streamInvoke` enforces the quota gate and then records nothing — its doc comment says usage tracking is the caller's job. It has exactly one caller, `createCallModel`, which has ten call sites, and **two** of them did it. Unmetered: the customer chat widget, agentic workflow AI nodes, eval runs, the Today stale scanner, and AI Memory. No `AiUsage` row, no SYSTEM credit deduction.

It looked healthy in the data for two reasons: `run-workflow-ai-turn` labels itself `workflow_ai_node` and `base-ai-node` (a different, metered orchestrator) writes rows under the same label; and the `source`/`sourceId` passed to `createCallModel` were decorative, because the two drains supplied their own labels.

Fixed at the choke point — `createCallModel` now bills each call as it completes, and both caller-side drains are deleted so nothing double-counts. Two details worth reviewing:

- `streamInvoke` now yields a synthetic zero-length gate chunk carrying `providerType`/`credentialSource`. They otherwise only reach the caller on the generator's return value, which an aborted stream never sees — so an aborted SYSTEM call billed as BYO at 0 credits.
- Tracking runs in a `finally`, so errored and aborted turns bill what they burned.

**Behaviour changes to expect:** paths that were free now consume credits (the chat widget is the notable one); `AiUsage.source` splits `agent` into `kopilot`/`builder`/`chat`/`learned_extraction`/`stale_scanner`; one row per LLM call instead of one grouped row per turn, so credits round per call (a sub-$0.00005 call rounds to zero — about 30 tokens).

## 2. AI Memory's automatic path had been dead since the permission slices

Capture runs bind to a human member and refuse to run for anyone else (`resolveCaptureRunPrincipal`, added in #1332/#1334). The extraction job's owner chain fell back to `Organization.systemUserId`, which is deliberately *not* a member — so any thread without a human assignee produced an instant no-op, which the job then recorded as "extracted". The stamp is the dedupe gate, so those threads were excluded permanently. In dev that is **151 of 153 archived threads**.

- **Principal resolver** — requester → assignee → last outbound human author → org owner/admin. `runAsUserId` and `ownerUserId` stay separate: an org-fallback run leaves the bundle unassigned rather than dropping it in an admin's feed.
- **No stamping on pre-LLM exits** — no principal, no anchor, or capped all leave the thread eligible. Today's `no_anchor_record` stamp was wrong too: a contact created later would never be learned from.
- **Migration 067** clears stamps on threads that never produced a proposal.
- **"Remember this thread"** now passes the requester through — it previously toasted success and did nothing on unassigned threads — and notifies them when a forced run finds nothing.
- **Entry point** moves from the `knowledgeBase` Full rung to Edit. Full locked the card to admins while the Member baseline is Edit, which is the rung `upsert_learned_article` itself asserts.
- **A 403 at approve time** now marks outcomes `blocked` and leaves the bundle FRESH. Previously a member without the rung who clicked Approve resolved it to REJECTED — a permission failure consumed the proposal it failed to apply.

Plus: a per-org daily extraction ceiling (100, forced runs exempt); a gate so the AI can't learn from its own agent-written replies; a line diff against the published article on update proposals (the tool replaces the whole body, so a dropped human correction is invisible in a flat preview); the first reader for `Article.learnedProvenance`, surfaced as "Learned from N conversations" in the memory editor; and one structured log line per job invocation, because a dead pipeline and an idle one looked identical.

## Verification

Tests: 25 new (principal chain 8, markdown diff 6, adapter metering 6, authorship 4, all-blocked 1); 511 pass across approvals/jobs/kb/agent-framework, 37 in the touched web areas. Typecheck shows no new errors on any touched file; biome clean.

Live on DemoOrg1 (real LLM calls):

| Check | Result |
| --- | --- |
| Extraction on an unassigned thread | runs; principal = org owner, bundle unassigned |
| Forced run as a plain member | principal and owner = the requester |
| Pre-LLM skips | `no_anchor_record` and `daily_limit_reached` left the thread unstamped |
| Daily cap | 101 > 100 → skipped before any LLM call |
| Metering | 33 calls / 95,439 tokens / 361 credits under `source='learned_extraction'` |
| Credit deduction | one run recorded 32 credits; org balance moved 979366 → 979334 |
| Provenance strip | renders and links the source thread |

**Not exercised live:** bundle creation under the new code — every candidate thread returned `[noop]`, which is the designed bias on a corpus of one-off support threads whose recurring topics already have articles. That path is unchanged apart from `ownerUserId`, which the forced run confirmed.

**Deliberate scope call:** F4 was specified with a UI pre-flight disabling Approve off tool permission metadata. Only the server half plus honest error surfacing is here — a coarse pre-flight can't see per-instance grants and would disable Approve for someone holding an explicit grant on that KB. Its justification was that clicking destroyed the proposal; it no longer does.

**Note:** the `learnedMemory` flag is still `false` in every seeded plan, so none of the AI Memory half is live for customers until it's enabled per-org. The metering half takes effect immediately.
