### PR TITLE
fix(data-connectors): clear both directories' type errors and the drift behind them

### DIFF
--- a/apps/web/src/components/agents/ui/detail/knowledge/agent-scope-actions.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/agent-scope-actions.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/agents/ui/detail/knowledge/agent-scope-actions.tsx
 'use client'
 
+import type { AgentScopeMode } from '@auxx/lib/agents/client'
 import { cn } from '@auxx/ui/lib/utils'
 import { Ban, Check, Trash2 } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
@@ -11,7 +12,12 @@ export interface AgentScopeActionsProps {
   effectiveMode: EffectiveScopeMode
   /** `true` when a `source='mention'` knowledge entry covers this record. */
   isMentionLocked: boolean
-  onSetMode: (mode: EffectiveScopeMode) => void
+  /**
+   * Receives only *storable* modes. `effectiveMode` may be an `inherited_*`
+   * variant, but clicking always writes an explicit row (or clears it with
+   * `'none'`) — the `inherited_*` variants are never emitted here.
+   */
+  onSetMode: (mode: AgentScopeMode | 'none') => void
 }
 
 /**
@@ -34,7 +40,7 @@ export function AgentScopeActions({
   onSetMode,
 }: AgentScopeActionsProps) {
   const isContainer = kind === 'container'
-  const includeMode: EffectiveScopeMode = isContainer ? 'include_descendants' : 'include_one'
+  const includeMode: AgentScopeMode = isContainer ? 'include_descendants' : 'include_one'
 
   const isExplicitExcluded = effectiveMode === 'exclude'
   const isExplicitIncluded =

--- a/apps/web/src/components/agents/ui/detail/knowledge/kb-branch.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/kb-branch.tsx
@@ -17,7 +17,7 @@ import {
 import { useMemo, useState } from 'react'
 import { RecordPicker } from '~/components/pickers/record-picker/record-picker'
 import { useRecord } from '~/components/resources/hooks/use-record'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import type { AgentDetail } from '../../../store/agent-store'
 import { AgentScopeActions } from './agent-scope-actions'
 import { deriveEffectiveMode } from './derive-scope-mode'
@@ -119,7 +119,7 @@ interface KbArticlesProps {
   kbRecordId: string
 }
 
-type ArticleListItem = NonNullable<ReturnType<typeof api.kb.getArticles.useQuery>['data']>[number]
+type ArticleListItem = NonNullable<RouterOutputs['kb']['getArticles']>[number]
 
 function KbArticles({ kbId, agent, mutations, depth, kbRecordId }: KbArticlesProps) {
   const { data: articles, isLoading } = api.kb.getArticles.useQuery(
@@ -131,9 +131,9 @@ function KbArticles({ kbId, agent, mutations, depth, kbRecordId }: KbArticlesPro
     if (!articles) return []
     // Archived articles aren't useful as scope targets — keep them out of
     // the tree so the agent picker doesn't surface decommissioned content.
-    const visible = articles.filter(
-      (a) => !('archivedAt' in a) || (a as { archivedAt?: Date | null }).archivedAt == null
-    )
+    // The list payload carries the archive state as `status` (`flattenForList`
+    // never projects the Article row's `archivedAt` column).
+    const visible = articles.filter((a) => a.status !== 'ARCHIVED')
     return buildArticleTree(visible)
   }, [articles])
 

--- a/apps/web/src/components/data-connectors/hooks/use-connector-commit.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-connector-commit.ts
@@ -3,9 +3,38 @@
 
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback } from 'react'
-import { api } from '~/trpc/react'
-import { type CommitPlan, diffConnectorDraft, isEmptyPlan } from '../lib/connector-commit-diff'
+import { api, type RouterInputs } from '~/trpc/react'
+import {
+  type CommitPlan,
+  type ConnectorUpdatePatch,
+  diffConnectorDraft,
+  isEmptyPlan,
+} from '../lib/connector-commit-diff'
 import { getConnectorDraftState, useConnectorDraftStore } from '../stores/connector-draft-store'
+
+type ConnectorUpdateInput = RouterInputs['dataConnector']['update']
+
+/**
+ * Widen the plan's connector patch into the `dataConnector.update` input.
+ *
+ * The draft holds `scheduleConfig` as an opaque `Record<string, unknown>` by design:
+ * `schedule-section` builds a real cadence and widens it on the way into the store, and
+ * `connector-commit-diff` is deliberately field-generic — it passes the blob through
+ * untouched (locked in by its own test, which uses a partial cadence). This mutation is
+ * the only place the blob meets the structured type, so the reconciliation belongs here.
+ * Asserting is safe rather than lax: `scheduleConfigSchema` validates the payload
+ * server-side, so a malformed blob still fails loudly instead of being silently dropped.
+ * `scheduleConfig` is re-attached only when the patch carries it, so an untouched
+ * schedule stays absent from the payload.
+ */
+function toConnectorUpdateInput(id: string, patch: ConnectorUpdatePatch): ConnectorUpdateInput {
+  const { scheduleConfig, ...rest } = patch
+  const input: ConnectorUpdateInput = { ...rest, id }
+  if ('scheduleConfig' in patch) {
+    input.scheduleConfig = scheduleConfig as ConnectorUpdateInput['scheduleConfig']
+  }
+  return input
+}
 
 /**
  * The commit/flush engine (plan §5) — the ONLY place connector configuration is
@@ -38,7 +67,9 @@ export function useConnectorCommit() {
       // 1. Connector-level + per-stream config — independent, fire in parallel.
       const independent: Array<Promise<unknown>> = []
       if (plan.connectorUpdate) {
-        independent.push(update.mutateAsync({ id: connectorId, ...plan.connectorUpdate }))
+        independent.push(
+          update.mutateAsync(toConnectorUpdateInput(connectorId, plan.connectorUpdate))
+        )
       }
       for (const r of plan.streamRenames) {
         independent.push(

--- a/apps/web/src/components/data-connectors/hooks/use-connector-sync-realtime.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-connector-sync-realtime.ts
@@ -6,6 +6,7 @@ import type { DataConnectorSyncEvent } from '@auxx/lib/realtime'
 import { useCallback } from 'react'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api, type RouterOutputs } from '~/trpc/react'
+import { asConnectorStatus } from '../ui/connector-status'
 
 type ConnectorStatusData = RouterOutputs['dataConnector']['getStatus']
 
@@ -60,7 +61,9 @@ function mergeProgress(
 ): ConnectorStatusData {
   return {
     ...prev,
-    status: data.connectorStatus,
+    // The frame carries the raw DB column value (typed `string` on the event) — normalize
+    // it to the lifecycle union the cached `getStatus` shape declares, as the event doc says.
+    status: asConnectorStatus(data.connectorStatus),
     lastSyncedAt: data.lastSyncedAt ? new Date(data.lastSyncedAt) : prev.lastSyncedAt,
     perStream: data.perStream,
     latestRun: prev.latestRun

--- a/apps/web/src/components/data-connectors/hooks/use-mapping-actions.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-mapping-actions.ts
@@ -240,20 +240,30 @@ export function useMappingActions({
     })
   }
 
+  // Narrow a `FieldReference` to exactly `[relationship, target]`. `FieldPath` is
+  // `[ResourceFieldId, ...ResourceFieldId[]]`, so a `length === 2` check alone leaves the
+  // second segment optional to the compiler — destructure and test it to get both segments
+  // as defined values. Toasts + returns null on a multi-hop (or non-path) ref.
+  const asSingleHop = (ref: FieldReference): [ResourceFieldId, ResourceFieldId] | null => {
+    if (isFieldPath(ref) && ref.length === 2) {
+      const [rel, targetRef] = ref
+      if (targetRef) return [rel, targetRef]
+    }
+    toastError({
+      title: 'Multi-hop links not supported yet',
+      description: 'Pick a field one relationship away from this record.',
+    })
+    return null
+  }
+
   // Bind a leaf ACROSS a relationship (unified picker §2/§4): drill the target graph to a
   // field on a related def — e.g. `email → Contact.Email`. Desugars to a FLAT contributing
   // child mapping (`rootPath ''` reads THIS mapping's subtree), reusing one child per
   // drilled relationship. v1 is single-hop (a 2-segment FieldPath).
   const assignDrilled = (node: SourceTreeNode, _field: ResourceField, ref: FieldReference) => {
-    if (!isFieldPath(ref) || ref.length !== 2) {
-      toastError({
-        title: 'Multi-hop links not supported yet',
-        description: 'Pick a field one relationship away from this record.',
-      })
-      return
-    }
-    const rel = ref[0]
-    const targetRef = ref[1]
+    const hop = asSingleHop(ref)
+    if (!hop) return
+    const [rel, targetRef] = hop
     const relatedDefId = getFieldDefinitionId(targetRef)
     const relKey = fieldRefToKey(rel)
     if (sourceToEntry.has(node.path)) {
@@ -329,17 +339,6 @@ export function useMappingActions({
   // child (a target a relationship away). Picking a target moves the entry to its desired
   // home, preserving the expression. The flat child is REUSED per relationship (shared with
   // drilled leaf binds) and GC'd when its last entry leaves.
-
-  const asSingleHop = (ref: FieldReference): [ResourceFieldId, ResourceFieldId] | null => {
-    if (!isFieldPath(ref) || ref.length !== 2) {
-      toastError({
-        title: 'Multi-hop links not supported yet',
-        description: 'Pick a field one relationship away from this record.',
-      })
-      return null
-    }
-    return [ref[0], ref[1]]
-  }
 
   // Upsert a (re-homed) formula entry into the flat child for `rel`, creating it if absent.
   const upsertFormulaIntoRelChild = (rel: ResourceFieldId, entry: FieldMapping) => {

--- a/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
@@ -4,11 +4,15 @@
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback } from 'react'
 import { api } from '~/trpc/react'
+import type { PaginationSpec } from '../lib/describe-pagination'
 
 /**
  * The request fields the stream config UI edits and persists — a subset of the
  * engine's `StreamRequestConfig`. The canonical client shape the draft store + commit
  * diff hold for a stream's request config.
+ *
+ * Keys outside this subset (`backfillWindow`, `webhookTrigger`) still round-trip: every
+ * writer merges onto the draft's full `requestConfig` through `Record<string, unknown>`.
  */
 export type UiRequestConfig = {
   path?: string
@@ -16,6 +20,8 @@ export type UiRequestConfig = {
   headers?: Record<string, string>
   params?: Record<string, unknown>
   body?: Record<string, unknown>
+  /** Written by `PaginationSection`'s "Use this" apply; `requestConfigSchema` accepts it. */
+  pagination?: PaginationSpec
 }
 
 /** Per-field merge strategy. Folded into each binding entry (absent ⇒ 'overwrite'). */

--- a/apps/web/src/components/data-connectors/lib/bind-installed-owned-defs.test.ts
+++ b/apps/web/src/components/data-connectors/lib/bind-installed-owned-defs.test.ts
@@ -1,7 +1,8 @@
 // apps/web/src/components/data-connectors/lib/bind-installed-owned-defs.test.ts
 
 import { describe, expect, it } from 'vitest'
-import type { DraftMapping, DraftStream, FieldMapping } from '../stores/connector-draft-store'
+import type { FieldMapping } from '../hooks/use-stream-mutations'
+import type { DraftMapping, DraftStream } from '../stores/connector-draft-store'
 import {
   bindInstalledOwnedDefs,
   type InstallResultLike,

--- a/apps/web/src/components/data-connectors/lib/bind-installed-owned-defs.ts
+++ b/apps/web/src/components/data-connectors/lib/bind-installed-owned-defs.ts
@@ -10,7 +10,8 @@
 // applies the returned bindings through the connector draft store.
 
 import { parseAppFieldRef, toAppFieldRef } from '@auxx/types/field'
-import type { DraftMapping, DraftStream, FieldMapping } from '../stores/connector-draft-store'
+import type { FieldMapping } from '../hooks/use-stream-mutations'
+import type { DraftMapping, DraftStream } from '../stores/connector-draft-store'
 
 /** One owned record type the connector declares — mirrors `dataConnector.ownedTargets`. */
 export interface OwnedTargetMeta {

--- a/apps/web/src/components/data-connectors/ui/connector-card.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-card.tsx
@@ -13,7 +13,7 @@ import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { Cable, FileText, FlaskConical, Pause, Play, RefreshCw, Trash } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { AppIcon } from '~/components/apps/ui/app-icon'
+import { VisualIcon } from '~/components/icons/ui/visual-icon'
 import {
   useBulkMode,
   useIsPending,
@@ -132,9 +132,13 @@ export function ConnectorCard({ connector, streamCount }: ConnectorCardProps) {
         pendingLabel={pendingLabel}
         title={connector.name}
         icon={
-          <AppIcon
-            iconId={iconIdForType(connector.type)}
+          // `AppIcon` is just `VisualIcon fit='contain'`, but `AppIconProps` doesn't
+          // declare `fallbackIconId` — same direct-VisualIcon shape as the sibling
+          // `ConnectorGlyph` in connector-breadcrumb-switcher.
+          <VisualIcon
+            value={iconIdForType(connector.type)}
             fallbackIconId={DEFAULT_CONNECTOR_ICON_ID}
+            fit='contain'
             size='sm'
           />
         }

--- a/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
@@ -9,7 +9,7 @@ import { CircleHelp, Clock, Layers, Plug } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { useScrollSpy } from '~/hooks/use-scroll-spy'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import { useConnectorCommit } from '../hooks/use-connector-commit'
 import { useConnectorDraftSync } from '../hooks/use-connector-draft-sync'
 import { ConnectionSection } from './connection-section'
@@ -22,7 +22,7 @@ import { StreamDetailBar } from './stream-detail-bar'
 import { StreamGuideDialog } from './stream-guide-dialog'
 import { StreamsSection } from './streams-section'
 
-type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
 
 const CONNECTOR_TABS = ['connection', 'streams', 'schedule'] as const
 type ConnectorTab = (typeof CONNECTOR_TABS)[number]

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -30,7 +30,7 @@ import { Tooltip } from '~/components/global/tooltip'
 import { useResources } from '~/components/resources/hooks/use-resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import { useConnectorMutations } from '../hooks/use-connector-mutations'
 import { useConnectorSyncRealtime } from '../hooks/use-connector-sync-realtime'
 import { resolveSyncStatus } from '../lib/resolve-sync-status'
@@ -47,7 +47,7 @@ import { asConnectorStatus, asRunStatus } from './connector-status'
 import { ConnectorStatusLine } from './connector-status-line'
 import { SampleReviewBanner } from './sample-review-banner'
 
-type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
 
 interface ConnectorDetailViewProps {
   connector: Connector

--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -258,9 +258,11 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
 
   // Guard: if the active step was filtered out (sample drops once streams load),
   // fall back to the first incomplete step in the current order.
-  const current = stepOrder.includes(active)
+  // `'run'` is the terminal fallback: only 'sample' is ever filtered out of STEPS, so
+  // `stepOrder` always ends with 'run' (same assumption as the `active` initializer).
+  const current: SetupStepId = stepOrder.includes(active)
     ? active
-    : (stepOrder.find((id) => !doneById[id]) ?? stepOrder[stepOrder.length - 1])
+    : (stepOrder.find((id) => !doneById[id]) ?? stepOrder[stepOrder.length - 1] ?? 'run')
 
   // A step is unlocked once every step before it is done.
   const isUnlocked = (id: SetupStepId) => {

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -273,7 +273,9 @@ export function MappingFieldPicker({
             seedType={sourceFieldType ?? inferFieldType(sourcePath, sourceType, sourceFormat)}
             onBack={() => setView('pick')}
             onCreated={(fieldRef) => {
-              onAssign(fieldRef)
+              // Optional like the pick path above — quick-create is only reachable via
+              // `canCreate`, which no caller sets without also passing `onAssign`.
+              onAssign?.(fieldRef)
               onOpenChange(false)
             }}
           />
@@ -290,14 +292,11 @@ function useFieldTypeGroups(): OptionGroup[] {
       Object.entries(FIELD_TYPE_GROUPS)
         .map(([groupName, types]) => ({
           label: groupName,
-          options: types
-            .filter((type) => type !== FieldType.RELATIONSHIP)
-            .map((type) => {
-              const opt = fieldTypeOptions[type]
-              if (!opt) return null
-              return { value: type, label: opt.label, iconId: opt.iconId }
-            })
-            .filter((o): o is Option => o !== null),
+          options: types.flatMap<Option>((type) => {
+            if (type === FieldType.RELATIONSHIP) return []
+            const opt = fieldTypeOptions[type]
+            return opt ? [{ value: type, label: opt.label, iconId: opt.iconId }] : []
+          }),
         }))
         .filter((g) => g.options.length > 0),
     []

--- a/apps/web/src/components/data-connectors/ui/pagination-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/pagination-section.tsx
@@ -168,12 +168,11 @@ function PaginationTooltip({
 /** Shallow spec equality — pagination specs are flat records of scalars. */
 function samePaginationSpec(a?: PaginationSpec, b?: PaginationSpec): boolean {
   if (!a || !b) return false
-  const ka = Object.keys(a).sort()
-  const kb = Object.keys(b).sort()
-  if (ka.length !== kb.length) return false
-  return ka.every(
-    (k, i) => k === kb[i] && (a as Record<string, unknown>)[k] === (b as Record<string, unknown>)[k]
-  )
+  const byKey = ([x]: [string, unknown], [y]: [string, unknown]) => x.localeCompare(y)
+  const ea = Object.entries(a).sort(byKey)
+  const eb = Object.entries(b).sort(byKey)
+  if (ea.length !== eb.length) return false
+  return ea.every(([k, v], i) => k === eb[i]?.[0] && v === eb[i]?.[1])
 }
 
 /** Pull a numeric page-size from common limit-style query params, for the size row. */

--- a/apps/web/src/components/data-connectors/ui/schedule-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/schedule-section.tsx
@@ -29,7 +29,7 @@ import {
   scheduledConfigFromState,
   scheduledStateFromConfig,
 } from '~/components/global/schedule'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import {
   getConnectorDraftState,
   selectIsDirty,
@@ -43,7 +43,7 @@ import {
 } from './webhook-signal-section'
 import { WebhookSteeringSection } from './webhook-steering-section'
 
-type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
 
 type SyncBehavior = 'manual' | 'scheduled' | 'webhook'
 type BackfillWindowSpan = 'all' | 'last_90_days' | 'last_12_months'

--- a/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
@@ -13,11 +13,14 @@ import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapte
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { type FieldEntry, readFieldNodes, seedDefaults } from '~/components/global/schema-form'
 import { BaseType } from '~/components/workflow/types'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import { getConnectorDraftState, useConnectorDraftStore } from '../stores/connector-draft-store'
 import { RecordKeyValueEditor, RequestEditorBlock, RevealChip } from './request-editors'
 
-type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
+
+/** `FieldType` is a const object, not a TS enum — its value union has to be spelled out. */
+type FieldTypeValue = (typeof FieldType)[keyof typeof FieldType]
 
 interface SourceConfigPanelProps {
   connector: Connector
@@ -180,7 +183,7 @@ function AppConfigSource({ connector }: { connector: Connector }) {
 }
 
 /** Map a JSON-Schema config node to the platform `FieldType` that renders it. */
-function fieldTypeFor(entry: FieldEntry): FieldType {
+function fieldTypeFor(entry: FieldEntry): FieldTypeValue {
   switch (entry.node.type) {
     case 'boolean':
       return FieldType.CHECKBOX
@@ -193,7 +196,7 @@ function fieldTypeFor(entry: FieldEntry): FieldType {
 }
 
 /** The row-label icon's base type for a given field type. */
-function baseTypeFor(fieldType: FieldType): BaseType {
+function baseTypeFor(fieldType: FieldTypeValue): BaseType {
   if (fieldType === FieldType.CHECKBOX) return BaseType.BOOLEAN
   if (fieldType === FieldType.NUMBER) return BaseType.NUMBER
   return BaseType.STRING

--- a/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
@@ -24,7 +24,8 @@ type SourceItem = {
   name: string
   description: string
   categories: string[]
-  iconKey: string | null
+  /** Template/app icon keys are optional at the source (`iconKey?: string`), so both empty forms land here. */
+  iconKey: string | null | undefined
 } & (
   | { kind: 'builtin'; type: 'generic-rest' }
   | { kind: 'template'; templateId: string; requiresConnection: boolean }

--- a/apps/web/src/components/data-connectors/ui/streams-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/streams-section.tsx
@@ -9,10 +9,10 @@ import TreeRow, { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { ArrowRight, Layers, Plus, Table2, Trash2 } from 'lucide-react'
 import { useResources } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 
-type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
-type Stream = NonNullable<ReturnType<typeof api.dataConnector.listStreams.useQuery>['data']>[number]
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
+type Stream = RouterOutputs['dataConnector']['listStreams'][number]
 
 interface StreamsSectionProps {
   connector: Connector

--- a/apps/web/src/components/resources/hooks/use-all-records.ts
+++ b/apps/web/src/components/resources/hooks/use-all-records.ts
@@ -6,7 +6,7 @@ import { toRecordId } from '@auxx/lib/resources/client'
 import type { FieldId } from '@auxx/types/field'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import {
   buildFieldValueKey,
   type CustomFieldValueState,
@@ -42,9 +42,7 @@ export interface FieldInfo {
 }
 
 /** Element shape of `api.record.listAll`'s `data.items` — what `appendRecord` expects. */
-export type AllRecordsItem = NonNullable<
-  ReturnType<typeof api.record.listAll.useQuery>['data']
->['items'][number]
+export type AllRecordsItem = NonNullable<RouterOutputs['record']['listAll']>['items'][number]
 
 /**
  * Result from useAllRecords hook

--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -8,12 +8,27 @@
 import type { FieldType } from '../../types'
 
 /**
+ * Structural re-declaration of `ResourceFieldId` from `@auxx/types/field`
+ * (`${entityDefinitionId}:${fieldId}`). `@auxx/types` depends on `@auxx/database`,
+ * so importing it here would be a cycle — but TypeScript brands are STRUCTURAL, so
+ * this alias IS the same type as far as assignability goes. Declaring it (instead of
+ * a bare `string`) is what lets a `FieldMapping` read off the column flow straight
+ * into the engine without a cast.
+ */
+type ResourceFieldId = string & { readonly __brand: 'ResourceFieldId' }
+
+/**
  * Connector kind — text-backed (not a pgEnum) so new connectors ship without an
  * enum-alter migration. Built-in ids plus the `app:${slug}` template literal, so
  * it can't be a fixed `as const` array. Mirrors {@link KnowledgeSourceType}.
  * Defined alongside the connector registry in sub-plan 03.
+ *
+ * MUST stay in sync with the engine `DataConnectorType` in
+ * `@auxx/lib/data-connectors/types` — `'fixture'` is a registered built-in
+ * (`connectors/registry.ts`) that the connector router accepts, so a union without
+ * it is narrower than the column it describes.
  */
-export type DataConnectorType = 'generic-rest' | `app:${string}`
+export type DataConnectorType = 'generic-rest' | 'fixture' | `app:${string}`
 
 /**
  * Pagination contract for a generic-REST endpoint. Refined in sub-plan 05a.
@@ -200,6 +215,12 @@ export interface StreamRequestConfig {
     deleteWhen?: { tokenTruthy?: string } | { topicEquals?: string }
     deleteExternalIdPath?: string
     resultShape?: 'single' | 'collection'
+    /**
+     * Coalesce same-record steer bursts (ms). Copied verbatim from the app catalog's
+     * `webhookTrigger` on install/restamp (`installAppConnector` / `restampWebhookBindings`)
+     * and read by the app-trigger dispatch job to key the delayed BullMQ steer job.
+     */
+    debounceMs?: number
   }
 }
 
@@ -217,11 +238,12 @@ export interface FieldMapping {
   /**
    * Canonical `ResourceFieldId` reference to the target field — concrete
    * (`${entityDefinitionId}:${fieldId}`) or the late-bound `@app:` form. `null` =
-   * unassigned draft / provisioned field awaiting its concrete ref. Branded
-   * `ResourceFieldId` in the engine `FieldMapping` (`@auxx/lib/data-connectors/types`);
-   * a plain string here (this package can't import tier-1 `@auxx/types`).
+   * unassigned draft / provisioned field awaiting its concrete ref. Every write path
+   * (the connector router's `resourceFieldIdSchema`, `toResourceFieldId`,
+   * `toAppFieldRef`) produces a branded ref, so the column is branded here too —
+   * see {@link ResourceFieldId} for why re-declaring the brand is sound.
    */
-  targetFieldRef: string | null
+  targetFieldRef: ResourceFieldId | null
   expression: string
   sourceFields: Record<string, string>
   /**
@@ -255,6 +277,10 @@ export interface FieldMapping {
     icon?: string
     isHidden?: boolean
     appFieldKey?: string
+    /** Predefined select options to provision (SINGLE_SELECT / MULTI_SELECT / TAGS). */
+    options?: Array<{ value: string; label?: string; color?: string }>
+    /** Sub-field set to provision for an ADDRESS_STRUCT field. */
+    addressComponents?: string[]
   }
 }
 

--- a/packages/lib/src/ai/providers/anthropic/__tests__/anthropic-llm-client.test.ts
+++ b/packages/lib/src/ai/providers/anthropic/__tests__/anthropic-llm-client.test.ts
@@ -2,6 +2,7 @@
 
 import Anthropic from '@anthropic-ai/sdk'
 import { describe, expect, it, vi } from 'vitest'
+import { canRunLiveApi } from '../../../../test/live-api'
 import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
 import { AnthropicLLMClient, STRUCTURED_OUTPUT_TOOL_NAME } from '../anthropic-llm-client'
 
@@ -19,7 +20,7 @@ function sentPayload(mock: { mock: { calls: unknown[][] } }): Record<string, any
 
 const apiKey = process.env.ANTHROPIC_API_KEY
 
-describe.skipIf(!apiKey)('AnthropicLLMClient integration', () => {
+describe.skipIf(!canRunLiveApi(apiKey))('AnthropicLLMClient integration', () => {
   function createClient() {
     const anthropic = new Anthropic({ apiKey: apiKey! })
     return new AnthropicLLMClient(anthropic, {

--- a/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-integration.test.ts
+++ b/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-integration.test.ts
@@ -4,6 +4,7 @@
 // Skipped when DEEPSEEK_API_KEY is not set.
 // Adding a model to DEEPSEEK_MODELS auto-generates tests.
 
+import { canRunLiveApi } from '../../../../test/live-api'
 import {
   DEFAULT_CLIENT_CONFIG,
   type LLMStreamChunk,
@@ -80,7 +81,7 @@ function buildParams(entry: TestModelEntry, overrides: Record<string, any> = {})
 
 const DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY
 
-describe.skipIf(!DEEPSEEK_API_KEY)('DeepSeek Integration Tests', () => {
+describe.skipIf(!canRunLiveApi(DEEPSEEK_API_KEY))('DeepSeek Integration Tests', () => {
   let client: DeepSeekLLMClient
 
   beforeAll(async () => {

--- a/packages/lib/src/ai/providers/google/__tests__/google-embedding-client.test.ts
+++ b/packages/lib/src/ai/providers/google/__tests__/google-embedding-client.test.ts
@@ -2,6 +2,7 @@
 
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { describe, expect, it } from 'vitest'
+import { canRunLiveApi } from '../../../../test/live-api'
 import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
 import { GoogleTextEmbeddingClient } from '../google-embedding-client'
 
@@ -12,7 +13,7 @@ import { GoogleTextEmbeddingClient } from '../google-embedding-client'
 
 const apiKey = process.env.GOOGLE_API_KEY
 
-describe.skipIf(!apiKey)('GoogleTextEmbeddingClient integration', () => {
+describe.skipIf(!canRunLiveApi(apiKey))('GoogleTextEmbeddingClient integration', () => {
   function createClient() {
     const genAI = new GoogleGenerativeAI(apiKey!)
     return new GoogleTextEmbeddingClient(genAI, {

--- a/packages/lib/src/ai/providers/google/__tests__/google-integration.test.ts
+++ b/packages/lib/src/ai/providers/google/__tests__/google-integration.test.ts
@@ -4,6 +4,7 @@
 // OpenAI-compatible endpoint. Skipped when GOOGLE_API_KEY is not set.
 // Adding a model to GOOGLE_MODELS auto-generates tests.
 
+import { canRunLiveApi } from '../../../../test/live-api'
 import {
   DEFAULT_CLIENT_CONFIG,
   type LLMStreamChunk,
@@ -82,7 +83,7 @@ function buildParams(entry: TestModelEntry, overrides: Record<string, any> = {})
 
 const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY
 
-describe.skipIf(!GOOGLE_API_KEY)('Google Integration Tests', () => {
+describe.skipIf(!canRunLiveApi(GOOGLE_API_KEY))('Google Integration Tests', () => {
   let client: GoogleLLMClient
 
   beforeAll(async () => {

--- a/packages/lib/src/ai/providers/groq/__tests__/groq-integration.test.ts
+++ b/packages/lib/src/ai/providers/groq/__tests__/groq-integration.test.ts
@@ -4,6 +4,7 @@
 // Skipped when GROQ_API_KEY is not set.
 // Adding a model to GROQ_MODELS auto-generates tests.
 
+import { canRunLiveApi } from '../../../../test/live-api'
 import {
   DEFAULT_CLIENT_CONFIG,
   type LLMStreamChunk,
@@ -80,7 +81,7 @@ function buildParams(entry: TestModelEntry, overrides: Record<string, any> = {})
 
 const GROQ_API_KEY = process.env.GROQ_API_KEY
 
-describe.skipIf(!GROQ_API_KEY)('Groq Integration Tests', () => {
+describe.skipIf(!canRunLiveApi(GROQ_API_KEY))('Groq Integration Tests', () => {
   let client: GroqLLMClient
 
   beforeAll(async () => {

--- a/packages/lib/src/ai/providers/openai/__tests__/openai-integration.test.ts
+++ b/packages/lib/src/ai/providers/openai/__tests__/openai-integration.test.ts
@@ -4,6 +4,7 @@
 // Skipped when OPENAI_API_KEY is not set (never runs in CI).
 // Tests a representative subset of models to avoid rate limiting.
 
+import { canRunLiveApi } from '../../../../test/live-api'
 import {
   DEFAULT_CLIENT_CONFIG,
   type LLMStreamChunk,
@@ -123,7 +124,7 @@ async function withRetry<T>(fn: () => Promise<T>, retries = 2, delayMs = 2000): 
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY
 
-describe.skipIf(!OPENAI_API_KEY)('OpenAI Integration Tests', () => {
+describe.skipIf(!canRunLiveApi(OPENAI_API_KEY))('OpenAI Integration Tests', () => {
   let client: OpenAILLMClient
 
   beforeAll(async () => {

--- a/packages/lib/src/data-connectors/__test-helpers.ts
+++ b/packages/lib/src/data-connectors/__test-helpers.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/data-connectors/__test-helpers.ts
+//
+// Shared test-only fixtures for the data-connector sync sinks.
+//
+// `SyncCtx` is the single object every sink entry point takes, and it keeps
+// growing (`manifest` in B2, `connectionMeta` in the identity plan, `sweep`,
+// `driftByMapping`). Each sink test used to hand-roll the whole thing, so every
+// new required member broke N fixtures at once — and the nine-field
+// `counters` block was copied verbatim in three files.
+//
+// Build one here instead. Defaults mirror what production supplies for a run
+// with nothing subscribed; pass overrides for whatever the case asserts on.
+
+import type { Database } from '@auxx/database'
+import type { ManifestCollector } from '../record-rules/sync-manifest-collector'
+import type { SyncCtx } from './sinks/types'
+
+/**
+ * The no-op {@link ManifestCollector} — a structural copy of the `NOOP_COLLECTOR`
+ * `createManifestCollector` returns when the org has no enabled record rules
+ * (that constant is module-private, so it cannot be imported).
+ */
+export function noopManifestCollector(): ManifestCollector {
+  return {
+    enabled: false,
+    subscriptionsFor: () => undefined,
+    recordChange: () => {},
+    recordCreated: () => {},
+    recordArchived: () => {},
+    toJson: () => null,
+  }
+}
+
+/** A zeroed {@link SyncCtx.counters} — mirrors `newRunCounters()` in `./service`. */
+export function zeroRunCounters(): SyncCtx['counters'] {
+  return {
+    fetched: 0,
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    archived: 0,
+    deleted: 0,
+    failed: 0,
+    relationshipWarnings: 0,
+    errorSample: [],
+  }
+}
+
+/**
+ * Build a {@link SyncCtx} for a sink test. Every required member gets a
+ * production-shaped default; `crud`/`ownedCrud` default to an empty stub, so a
+ * case that exercises writes must pass its own spies.
+ */
+export function makeSyncCtx(over: Partial<SyncCtx> = {}): SyncCtx {
+  return {
+    db: {} as Database,
+    orgId: 'org1',
+    connector: { id: 'dc1', credentialId: 'cred1' } as SyncCtx['connector'],
+    runId: 'run1',
+    crud: {} as SyncCtx['crud'],
+    ownedCrud: {} as SyncCtx['ownedCrud'],
+    counters: zeroRunCounters(),
+    manifest: noopManifestCollector(),
+    touchedDefs: new Set<string>(),
+    ...over,
+  }
+}

--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -13,6 +13,27 @@ import {
   overlayDeclaredFieldTypes,
 } from './app-catalog'
 
+/**
+ * Walk a JSON-schema tree by dotted path and return the node there, failing loudly
+ * when a segment is missing. Keeps the schema assertions below free of the
+ * `Record<string, …>` casts that only ever hid a typo in the path.
+ */
+function nodeAt(root: unknown, path: string): Record<string, unknown> {
+  let current: unknown = root
+  const walked: string[] = []
+  for (const segment of path.split('.')) {
+    if (typeof current !== 'object' || current === null) {
+      throw new Error(`not an object at "${walked.join('.')}" while walking "${path}"`)
+    }
+    current = (current as Record<string, unknown>)[segment]
+    walked.push(segment)
+  }
+  if (typeof current !== 'object' || current === null) {
+    throw new Error(`no schema node at "${path}"`)
+  }
+  return current as Record<string, unknown>
+}
+
 describe('buildSchemaFromFieldPaths', () => {
   it('nests dotted + array paths into an object/array schema with scalar leaf types', () => {
     const schema = buildSchemaFromFieldPaths([
@@ -136,11 +157,10 @@ describe('appCatalogStreamSchema', () => {
         shipping_address: { street1: '123 Main St', city: 'Austin', country: 'US' },
       },
     })
-    const props = (result.sourceSchema as { properties: Record<string, Record<string, unknown>> })
-      .properties
-    expect(props.shipping_address['x-auxx-fieldType']).toBe('ADDRESS_STRUCT')
+    const addr = nodeAt(result.sourceSchema, 'properties.shipping_address')
+    expect(addr['x-auxx-fieldType']).toBe('ADDRESS_STRUCT')
     // Components survive in the schema — only the CLIENT flatten stops descending.
-    expect(props.shipping_address.properties).toHaveProperty('city')
+    expect(addr.properties).toHaveProperty('city')
   })
 })
 
@@ -166,12 +186,12 @@ describe('overlayDeclaredFieldTypes', () => {
       { fieldKey: 'a', sourcePath: 'customer.address', type: 'ADDRESS_STRUCT', name: 'A' },
       { fieldKey: 'b', sourcePath: 'line_items[].ship', type: 'ADDRESS_STRUCT', name: 'B' },
     ])
-    const props = schema.properties as Record<string, Record<string, Record<string, unknown>>>
-    expect(props.customer.properties.address['x-auxx-fieldType']).toBe('ADDRESS_STRUCT')
-    const itemProps = (
-      props.line_items.items as { properties: Record<string, Record<string, unknown>> }
-    ).properties
-    expect(itemProps.ship['x-auxx-fieldType']).toBe('ADDRESS_STRUCT')
+    expect(nodeAt(schema, 'properties.customer.properties.address')['x-auxx-fieldType']).toBe(
+      'ADDRESS_STRUCT'
+    )
+    expect(nodeAt(schema, 'properties.line_items.items.properties.ship')['x-auxx-fieldType']).toBe(
+      'ADDRESS_STRUCT'
+    )
   })
 
   it('stamps non-struct declared types on scalar leaves, ignores absent paths', () => {
@@ -184,10 +204,9 @@ describe('overlayDeclaredFieldTypes', () => {
       { fieldKey: 'price', sourcePath: 'price', type: 'CURRENCY', name: 'Price' },
       { fieldKey: 'gone', sourcePath: 'missing', type: 'ADDRESS_STRUCT', name: 'Gone' },
     ])
-    const props = schema.properties as Record<string, Record<string, unknown>>
-    expect(props.name['x-auxx-fieldType']).toBe('TEXT')
-    expect(props.price['x-auxx-fieldType']).toBe('CURRENCY')
-    expect(props).not.toHaveProperty('missing')
+    expect(nodeAt(schema, 'properties.name')['x-auxx-fieldType']).toBe('TEXT')
+    expect(nodeAt(schema, 'properties.price')['x-auxx-fieldType']).toBe('CURRENCY')
+    expect(nodeAt(schema, 'properties')).not.toHaveProperty('missing')
   })
 
   it('never stamps a non-struct type on a branch (object or array-of-objects)', () => {
@@ -207,11 +226,10 @@ describe('overlayDeclaredFieldTypes', () => {
       { fieldKey: 'lines', sourcePath: 'line_items', type: 'JSON', name: 'Lines' },
       { fieldKey: 'tags', sourcePath: 'tags', type: 'TAGS', name: 'Tags' },
     ])
-    const props = schema.properties as Record<string, Record<string, unknown>>
     // Branches keep exploding — no stamp; an array of SCALARS is a value leaf — stamped.
-    expect(props.customer).not.toHaveProperty('x-auxx-fieldType')
-    expect(props.line_items).not.toHaveProperty('x-auxx-fieldType')
-    expect(props.tags['x-auxx-fieldType']).toBe('TAGS')
+    expect(nodeAt(schema, 'properties.customer')).not.toHaveProperty('x-auxx-fieldType')
+    expect(nodeAt(schema, 'properties.line_items')).not.toHaveProperty('x-auxx-fieldType')
+    expect(nodeAt(schema, 'properties.tags')['x-auxx-fieldType']).toBe('TAGS')
   })
 })
 

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -421,7 +421,9 @@ function findSchemaNode(root: MutableSchemaNode, sourcePath: string): MutableSch
   for (const rawSeg of sourcePath.split('.').filter(Boolean)) {
     const isArray = rawSeg.endsWith('[]')
     const seg = isArray ? rawSeg.slice(0, -2) : rawSeg
-    const child = node?.properties?.[seg]
+    // Annotated: `node` is reassigned from `child` below, so leaving `child`'s type to
+    // inference makes the two mutually circular and TS falls back to implicit `any`.
+    const child: MutableSchemaNode | undefined = node?.properties?.[seg]
     if (!child) return null
     // An array property carries its element shape under `items` — descend into it so a
     // path segment like `line_items[]` lands on the element, not the array container.

--- a/packages/lib/src/data-connectors/connector-webhook.test.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.test.ts
@@ -46,8 +46,11 @@ const {
     fetchFn: vi.fn(),
     deleteWhere: vi.fn(),
     resolveRelationships: vi.fn(),
-    foldRunManifest: vi.fn(async () => {}),
-    publishSyncRecordsChanged: vi.fn(async () => {}),
+    // Both are called with the real arity (`(db, runId, fragment)` /
+    // `(db, args)`) — declare a rest param so the pass-through mock factory
+    // below can forward whatever it receives.
+    foldRunManifest: vi.fn(async (..._a: unknown[]) => {}),
+    publishSyncRecordsChanged: vi.fn(async (..._a: unknown[]) => {}),
   }
 })
 

--- a/packages/lib/src/data-connectors/connectors/app-connector-adapter.test.ts
+++ b/packages/lib/src/data-connectors/connectors/app-connector-adapter.test.ts
@@ -15,7 +15,7 @@ import { decodeCursor } from './app-connector-state'
 import { type ConnectorRecord, type ConnectorYield, isConnectorCheckpoint } from './types'
 
 const invokeLambdaExecutor = vi.fn()
-const prepareLambdaContext = vi.fn((x: unknown) => x)
+const prepareLambdaContext = vi.fn((...args: unknown[]) => args[0])
 const resolveAppConnectionForRuntime = vi.fn()
 
 const RESOLVED_METADATA = { shopDomain: 'acme.myshopify.com' }

--- a/packages/lib/src/data-connectors/connectors/app-connector-adapter.ts
+++ b/packages/lib/src/data-connectors/connectors/app-connector-adapter.ts
@@ -247,10 +247,13 @@ export function appConnectorAdapter(
       // response — a finite batch + flat cursor. The adapter sends the FLAT app state
       // (`{ cursor, updatedSince }`), NOT the engine-shaped `{ backfillCursor, watermark }`,
       // so the app reads `state.cursor`/`state.updatedSince` per the SDK contract.
-      async function invokePage(flat: {
+      // An arrow const, not a hoisted `function` declaration: a declaration can be
+      // called before the `if (!catalog) throw` above runs, so TS refuses to carry that
+      // narrowing into its body and `catalog.id` reads as possibly-null.
+      const invokePage = async (flat: {
         cursor: unknown
         updatedSince?: string
-      }): Promise<AppExecuteResult> {
+      }): Promise<AppExecuteResult> => {
         const result = await invokeLambdaExecutor({
           caller: 'data-connector',
           payload: {

--- a/packages/lib/src/data-connectors/edit-impact.ts
+++ b/packages/lib/src/data-connectors/edit-impact.ts
@@ -224,10 +224,14 @@ export function classifyStreamRequestChange(
   return { level: levelFor(reasons), reasons }
 }
 
-/** Pick the higher of two impact levels (for merging an escalating pending state). */
-export function maxLevel(
-  a: StructuralChangeLevel,
-  b: StructuralChangeLevel
-): StructuralChangeLevel {
+/**
+ * Pick the higher of two impact levels (for merging an escalating pending state).
+ * Generic so the result stays within the levels actually passed in — merging two
+ * `ResyncPending.level`s (`'rebackfill' | 'rebind'`) can never produce `'cosmetic'`.
+ */
+export function maxLevel<A extends StructuralChangeLevel, B extends StructuralChangeLevel>(
+  a: A,
+  b: B
+): A | B {
   return LEVEL_RANK[a] >= LEVEL_RANK[b] ? a : b
 }

--- a/packages/lib/src/data-connectors/inventory-bridge-linking.test.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-linking.test.ts
@@ -5,8 +5,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
-  updateSpy: vi.fn(async () => ({})),
-  createSpy: vi.fn(async () => ({})),
+  // Params mirror `UnifiedCrudHandler.update/create` so `mock.calls[n]` destructures
+  // as the real tuple instead of an empty one.
+  updateSpy: vi.fn(async (_recordId: string, _values: Record<string, unknown>) => ({})),
+  createSpy: vi.fn(async (_defId: string, _values: Record<string, unknown>) => ({})),
   requireDefId: vi.fn(async () => 'def_part'),
   getDefId: vi.fn(async () => 'def_mv'),
   resolveSource: vi.fn(),
@@ -131,7 +133,7 @@ describe('linkInventorySource', () => {
     })
 
     expect(h.createSpy).toHaveBeenCalledTimes(1)
-    const [, values] = h.createSpy.mock.calls[0]
+    const [, values] = h.createSpy.mock.calls[0]! // guarded by the call-count assertion above
     expect(values).toMatchObject({
       stock_movement_type: 'adjust',
       stock_movement_quantity: 70,
@@ -166,7 +168,7 @@ describe('applyPendingInventoryDelta', () => {
 
     expect(h.advanceCAS).toHaveBeenCalledWith(db, 'lnk_1', 10, 6)
     expect(h.createSpy).toHaveBeenCalledTimes(1)
-    const [, values] = h.createSpy.mock.calls[0]
+    const [, values] = h.createSpy.mock.calls[0]! // guarded by the call-count assertion above
     expect(values).toMatchObject({
       stock_movement_type: 'sale',
       stock_movement_quantity: -4,

--- a/packages/lib/src/data-connectors/inventory-bridge-pass.test.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-pass.test.ts
@@ -8,7 +8,11 @@ import type { InventoryBridgeLinkEntity } from '@auxx/database'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
-  createSpy: vi.fn(async () => ({ recordId: 'rec_mv' })),
+  // Params mirror `UnifiedCrudHandler.create` so `mock.calls[n]` destructures as the
+  // real tuple instead of an empty one.
+  createSpy: vi.fn(async (_defId: string, _values: Record<string, unknown>) => ({
+    recordId: 'rec_mv',
+  })),
   getSystemUser: vi.fn(async () => 'sys_user'),
   getCachedEntityDefId: vi.fn(async (_org: string, slug: string) =>
     slug === 'part' ? 'def_part' : slug === 'stock_movement' ? 'def_mv' : undefined
@@ -123,7 +127,7 @@ describe('runInventoryBridgePass', () => {
 
     expect(h.advanceCAS).toHaveBeenCalledWith(db, 'lnk_1', 10, 7)
     expect(h.createSpy).toHaveBeenCalledTimes(1)
-    const [defId, values] = h.createSpy.mock.calls[0]
+    const [defId, values] = h.createSpy.mock.calls[0]! // guarded by the call-count assertion above
     expect(defId).toBe('def_mv')
     expect(values).toMatchObject({
       stock_movement_part: 'def_part:part_1',

--- a/packages/lib/src/data-connectors/inventory-bridge-provisioning.test.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-provisioning.test.ts
@@ -45,7 +45,7 @@ describe('provisionInventoryBridge', () => {
     const r = await provisionInventoryBridge(db, ORG, INPUT)
 
     expect(h.createField).toHaveBeenCalledTimes(1)
-    const [fieldInput] = h.createField.mock.calls[0]
+    const [fieldInput] = h.createField.mock.calls[0]! // guarded by the call-count assertion above
     expect(fieldInput).toMatchObject({
       organizationId: ORG,
       entityDefinitionId: 'def_variants',

--- a/packages/lib/src/data-connectors/inventory-bridge-rule-action.test.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-rule-action.test.ts
@@ -3,6 +3,7 @@
 // no-ops unlinked variants, and never throws on a bad link. Heavy deps are mocked; the fake db
 // answers the cell + linked-part reads (drizzle column refs are undefined under vitest).
 
+import { toRecordId } from '@auxx/types/resource'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const h = vi.hoisted(() => {
@@ -10,7 +11,12 @@ const h = vi.hoisted(() => {
     cell: null as number | null,
     linkedPart: null as string | null,
     getLink: vi.fn(),
-    deduct: vi.fn(async () => ({ outcome: 'movement', delta: 3 })),
+    // Params mirror `deductVariantInventory(db, input)` so `mock.calls[n]`
+    // destructures as the real tuple instead of an empty one.
+    deduct: vi.fn(async (_db: unknown, _input: Record<string, unknown>) => ({
+      outcome: 'movement',
+      delta: 3,
+    })),
     getSystemUser: vi.fn(async () => 'sys_user'),
     getCachedEntityDefId: vi.fn(async (_org: string, slug: string) =>
       slug === 'part' ? 'def_part' : slug === 'stock_movement' ? 'def_mv' : undefined
@@ -97,10 +103,10 @@ describe('deductInventory native handler', () => {
   it('fires the deduction core for a linked variant with the current cell + edge part', async () => {
     h.getLink.mockResolvedValue(link())
 
-    await handler({ recordIds: ['def_variants:var_1'], organizationId: ORG })
+    await handler({ recordIds: [toRecordId('def_variants', 'var_1')], organizationId: ORG })
 
     expect(h.deduct).toHaveBeenCalledTimes(1)
-    const [, arg] = h.deduct.mock.calls[0]
+    const [, arg] = h.deduct.mock.calls[0]! // guarded by the call-count assertion above
     expect(arg).toMatchObject({
       organizationId: ORG,
       dataConnectorId: 'dc_1',
@@ -114,14 +120,14 @@ describe('deductInventory native handler', () => {
 
   it('no-ops an unlinked variant (no InventoryBridgeLink)', async () => {
     h.getLink.mockResolvedValue(undefined)
-    await handler({ recordIds: ['def_variants:var_1'], organizationId: ORG })
+    await handler({ recordIds: [toRecordId('def_variants', 'var_1')], organizationId: ORG })
     expect(h.deduct).not.toHaveBeenCalled()
   })
 
   it('early-returns when the org has no part/movement def', async () => {
     h.getCachedEntityDefId.mockResolvedValue(undefined)
     h.getLink.mockResolvedValue(link())
-    await handler({ recordIds: ['def_variants:var_1'], organizationId: ORG })
+    await handler({ recordIds: [toRecordId('def_variants', 'var_1')], organizationId: ORG })
     expect(h.deduct).not.toHaveBeenCalled()
   })
 
@@ -129,7 +135,7 @@ describe('deductInventory native handler', () => {
     h.getLink.mockResolvedValue(link())
     h.deduct.mockRejectedValue(new Error('boom'))
     await expect(
-      handler({ recordIds: ['def_variants:var_1'], organizationId: ORG })
+      handler({ recordIds: [toRecordId('def_variants', 'var_1')], organizationId: ORG })
     ).resolves.toBeUndefined()
   })
 })

--- a/packages/lib/src/data-connectors/inventory-bridge-rule.test.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-rule.test.ts
@@ -3,13 +3,16 @@
 // are mocked; the db is unused (store fns are stubbed).
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CachedRecordRule } from '../record-rules/types'
 
 const h = vi.hoisted(() => ({
   findManaged: vi.fn(),
   createManaged: vi.fn(async () => ({ id: 'rule_new' })),
   deleteForDef: vi.fn(async () => 1),
   onCacheEvent: vi.fn(async () => {}),
-  getCachedRecordRules: vi.fn(async () => []),
+  // Typed to the real cache return so a fixture that isn't a rule row is a type error
+  // (a bare `async () => []` infers `never[]` and rejects every `mockResolvedValue`).
+  getCachedRecordRules: vi.fn(async (): Promise<CachedRecordRule[]> => []),
 }))
 
 vi.mock('../record-rules', () => ({
@@ -30,6 +33,23 @@ import {
 
 const db = {} as never
 const ORG = 'org_1'
+
+/** A cached rule row as `getCachedRecordRules` serves it; override what the case reads. */
+function rule(over: Partial<CachedRecordRule> = {}): CachedRecordRule {
+  return {
+    id: 'rule_1',
+    organizationId: ORG,
+    entityDefinitionId: 'def_variants',
+    fieldId: 'fld_qty',
+    name: 'Inventory deduction',
+    on: 'decreased',
+    condition: [],
+    actions: [{ type: 'native', handler: 'deductInventory' }],
+    enabled: true,
+    managed: 'inventory',
+    ...over,
+  }
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -92,9 +112,9 @@ describe('removeInventoryDeductionRule', () => {
 describe('listInventorySourceRules', () => {
   it('projects only managed inventory rules with a fieldId', async () => {
     h.getCachedRecordRules.mockResolvedValue([
-      { entityDefinitionId: 'def_variants', fieldId: 'fld_qty', managed: 'inventory' },
-      { entityDefinitionId: 'def_other', fieldId: 'fld_x', managed: null },
-      { entityDefinitionId: 'def_nofield', fieldId: null, managed: 'inventory' },
+      rule({ id: 'r_ok', entityDefinitionId: 'def_variants', fieldId: 'fld_qty' }),
+      rule({ id: 'r_unmanaged', entityDefinitionId: 'def_other', fieldId: 'fld_x', managed: null }),
+      rule({ id: 'r_nofield', entityDefinitionId: 'def_nofield', fieldId: null }),
     ])
     const r = await listInventorySourceRules(ORG)
     expect(r).toEqual([{ sourceDefId: 'def_variants', quantityFieldId: 'fld_qty' }])

--- a/packages/lib/src/data-connectors/inventory-bridge-rule.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-rule.ts
@@ -70,6 +70,7 @@ export async function ensureInventoryDeductionRule(
     actions: [{ type: 'native', handler: DEDUCT_INVENTORY_HANDLER }],
     managed: INVENTORY_MANAGED_MARKER,
   })
+  if (!row) throw new Error('Failed to create the managed inventory deduction rule')
   await onCacheEvent('record-rule.changed', { orgId: organizationId })
   return { id: row.id, created: true }
 }

--- a/packages/lib/src/data-connectors/inventory-bridge-store.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-store.ts
@@ -98,6 +98,9 @@ export async function upsertInventoryBridgeLink(
       },
     })
     .returning()
+  // `insert … onConflictDoUpdate … returning()` always yields exactly one row; the
+  // guard exists so the entity contract stays non-optional without an assertion.
+  if (!row) throw new Error('Failed to upsert the inventory bridge link')
   return row
 }
 

--- a/packages/lib/src/data-connectors/map-record.test.ts
+++ b/packages/lib/src/data-connectors/map-record.test.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/data-connectors/map-record.test.ts
 
+import { toResourceFieldId } from '@auxx/types/field'
 import { describe, expect, it } from 'vitest'
 import type { ConnectorRecord } from './connectors/types'
 import { mapRecord } from './map-record'
@@ -37,7 +38,7 @@ describe('mapRecord', () => {
       fieldMappings: [
         {
           id: 'e1',
-          targetFieldRef: 'def1:total',
+          targetFieldRef: toResourceFieldId('def1', 'total'),
           expression: '{total_price}',
           sourceFields: { total_price: 'total_price' },
         },
@@ -58,7 +59,12 @@ describe('mapRecord', () => {
       id: 'li',
       rootPath: 'line_items[]',
       fieldMappings: [
-        { id: 'e1', targetFieldRef: 'def1:sku', expression: '{sku}', sourceFields: { sku: 'sku' } },
+        {
+          id: 'e1',
+          targetFieldRef: toResourceFieldId('def1', 'sku'),
+          expression: '{sku}',
+          sourceFields: { sku: 'sku' },
+        },
       ],
     })
 
@@ -88,7 +94,7 @@ describe('mapRecord', () => {
         // rootPath 'customer') → target field 'contact_email', flagged `match`.
         {
           id: 'e1',
-          targetFieldRef: 'def1:contact_email',
+          targetFieldRef: toResourceFieldId('def1', 'contact_email'),
           expression: '{email}',
           sourceFields: { email: 'email' },
           identityRole: { kind: 'match', normalize: 'email' },
@@ -114,7 +120,7 @@ describe('mapRecord', () => {
         // EVALUATED expression, not an arbitrary single `sourceFields` path.
         {
           id: 'e1',
-          targetFieldRef: 'def1:order_key',
+          targetFieldRef: toResourceFieldId('def1', 'order_key'),
           expression: 'concat({store}, "-", {order_no})',
           sourceFields: { store: 'store', order_no: 'order_no' },
           identityRole: { kind: 'match', normalize: 'none' },
@@ -137,7 +143,7 @@ describe('mapRecord', () => {
       fieldMappings: [
         {
           id: 'e1',
-          targetFieldRef: 'def1:title',
+          targetFieldRef: toResourceFieldId('def1', 'title'),
           expression: '{title}',
           sourceFields: { title: 'title' },
         },
@@ -166,7 +172,12 @@ describe('mapRecord', () => {
       parentMappingId: 'order',
       relationshipFieldKey: 'line_items',
       fieldMappings: [
-        { id: 'e1', targetFieldRef: 'def1:sku', expression: '{sku}', sourceFields: { sku: 'sku' } },
+        {
+          id: 'e1',
+          targetFieldRef: toResourceFieldId('def1', 'sku'),
+          expression: '{sku}',
+          sourceFields: { sku: 'sku' },
+        },
       ],
     })
 
@@ -373,13 +384,13 @@ describe('mapRecord', () => {
       fieldMappings: [
         {
           id: 'e1',
-          targetFieldRef: 'def1:total',
+          targetFieldRef: toResourceFieldId('def1', 'total'),
           expression: '{total_price}',
           sourceFields: { total_price: 'total_price' },
         },
         {
           id: 'conn',
-          targetFieldRef: 'def1:@app:shopify:storeDomain',
+          targetFieldRef: toResourceFieldId('def1', '@app:shopify:storeDomain'),
           expression: '',
           sourceFields: {},
           connectionMetaKey: 'shopDomain',

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -424,7 +424,8 @@ export async function resolveSoleAppConnection(
     userId: null,
   })
   if (result.isErr()) return null
-  return result.value.length === 1 ? result.value[0].id : null
+  const [sole] = result.value
+  return result.value.length === 1 && sole ? sole.id : null
 }
 
 /**

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -427,11 +427,7 @@ export async function materializeConnectorTargets(
   // ── Provision `provision`-hint fields onto each mapping's existing def ─────────
   const fieldIdsByDef = new Map<string, Record<string, string>>()
   for (const row of pendingRows) {
-    // Raw-row `fieldMappings` are the DB mirror shape (plain-string refs); cast to the
-    // engine `FieldMapping` — `provisionSpecsForMapping` only reads `.provision`.
-    const fields = provisionSpecsForMapping({
-      fieldMappings: row.fieldMappings as unknown as FieldMapping[],
-    })
+    const fields = provisionSpecsForMapping({ fieldMappings: row.fieldMappings })
     if (fields.length === 0) continue
 
     const result = await provisionTarget(db, organizationId, dataConnectorId, {

--- a/packages/lib/src/data-connectors/reconcile-managed-markers.test.ts
+++ b/packages/lib/src/data-connectors/reconcile-managed-markers.test.ts
@@ -4,10 +4,11 @@
 // (the FK set-null only covers connector deletion). Owned mappings are skipped;
 // the keep-set is the union of currently-mapped concrete CustomField.ids per def.
 
-import { toResourceFieldId } from '@auxx/types/field'
+import { getFieldId, type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DecodedMapping } from './service'
 import type { SyncCtx } from './sinks/types'
+import type { FieldMapping } from './types'
 
 // Capture the keep-set passed to notInArray while keeping real drizzle behavior.
 const notInArrayIds: string[][] = []
@@ -59,6 +60,20 @@ function makeCtx(): SyncCtx {
   } as unknown as SyncCtx
 }
 
+/**
+ * One bound field. `expression`/`sourceFields` mirror the degenerate single-token
+ * form the mapping UI writes for a plain field→field binding; this pass reads only
+ * `targetFieldRef`, but the row it stands in for always carries all three.
+ */
+function binding(targetFieldRef: ResourceFieldId, sourcePath = 'src'): FieldMapping {
+  return {
+    id: `fm_${getFieldId(targetFieldRef)}`,
+    targetFieldRef,
+    expression: `{${sourcePath}}`,
+    sourceFields: { [sourcePath]: sourcePath },
+  }
+}
+
 function mapping(over: Partial<DecodedMapping>): DecodedMapping {
   return {
     row: { id: 'm1' },
@@ -87,7 +102,7 @@ describe('reconcileManagedMarkers', () => {
   it('clears markers and keeps only currently-mapped fields (drops fieldA)', async () => {
     // Mapping now only writes fieldB → keep-set = [fieldB]; fieldA's marker clears.
     resolveConnectorFieldRef.mockResolvedValue(toResourceFieldId('def1', 'fieldB'))
-    const m = mapping({ fieldMappings: [{ targetFieldRef: toResourceFieldId('def1', 'fieldB') }] })
+    const m = mapping({ fieldMappings: [binding(toResourceFieldId('def1', 'fieldB'))] })
 
     await reconcileManagedMarkers(makeCtx(), [{ syncMode: 'incremental', mappings: [m] }])
 
@@ -99,7 +114,7 @@ describe('reconcileManagedMarkers', () => {
   it('skips owned mappings entirely (no UPDATE)', async () => {
     const m = mapping({
       targetMode: 'owned',
-      fieldMappings: [{ targetFieldRef: toResourceFieldId('def1', 'fieldB') }],
+      fieldMappings: [binding(toResourceFieldId('def1', 'fieldB'))],
     })
 
     await reconcileManagedMarkers(makeCtx(), [{ syncMode: 'snapshot', mappings: [m] }])
@@ -112,7 +127,7 @@ describe('reconcileManagedMarkers', () => {
     // A currently-mapped ref that can't resolve (e.g. unbound @app: connection)
     // must NOT wipe the def's markers — the keep-set view is incomplete.
     resolveConnectorFieldRef.mockResolvedValue(null)
-    const m = mapping({ fieldMappings: [{ targetFieldRef: toResourceFieldId('def1', 'fieldB') }] })
+    const m = mapping({ fieldMappings: [binding(toResourceFieldId('def1', 'fieldB'))] })
 
     await reconcileManagedMarkers(makeCtx(), [{ syncMode: 'incremental', mappings: [m] }])
 
@@ -124,8 +139,8 @@ describe('reconcileManagedMarkers', () => {
     resolveConnectorFieldRef
       .mockResolvedValueOnce(toResourceFieldId('def1', 'fieldA'))
       .mockResolvedValueOnce(null)
-    const m1 = mapping({ fieldMappings: [{ targetFieldRef: toResourceFieldId('def1', 'fieldA') }] })
-    const m2 = mapping({ fieldMappings: [{ targetFieldRef: toResourceFieldId('def1', 'fieldB') }] })
+    const m1 = mapping({ fieldMappings: [binding(toResourceFieldId('def1', 'fieldA'))] })
+    const m2 = mapping({ fieldMappings: [binding(toResourceFieldId('def1', 'fieldB'))] })
 
     await reconcileManagedMarkers(makeCtx(), [{ syncMode: 'incremental', mappings: [m1, m2] }])
 
@@ -145,8 +160,8 @@ describe('reconcileManagedMarkers', () => {
     resolveConnectorFieldRef
       .mockResolvedValueOnce(toResourceFieldId('def1', 'fieldA'))
       .mockResolvedValueOnce(toResourceFieldId('def1', 'fieldB'))
-    const m1 = mapping({ fieldMappings: [{ targetFieldRef: toResourceFieldId('def1', 'fieldA') }] })
-    const m2 = mapping({ fieldMappings: [{ targetFieldRef: toResourceFieldId('def1', 'fieldB') }] })
+    const m1 = mapping({ fieldMappings: [binding(toResourceFieldId('def1', 'fieldA'))] })
+    const m2 = mapping({ fieldMappings: [binding(toResourceFieldId('def1', 'fieldB'))] })
 
     await reconcileManagedMarkers(makeCtx(), [{ syncMode: 'incremental', mappings: [m1, m2] }])
 

--- a/packages/lib/src/data-connectors/restamp-webhook-bindings.test.ts
+++ b/packages/lib/src/data-connectors/restamp-webhook-bindings.test.ts
@@ -46,6 +46,7 @@ function mockDb(
 const catalogWithBinding: CatalogDataConnector = {
   id: 'shopify.core',
   label: 'Shopify Core Data',
+  description: null,
   requiresConnection: true,
   iconKey: null,
   configJsonSchema: {},

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -655,7 +655,7 @@ export async function persistStreamState(
 // ── DataConnectorItem (the durable binding) ───────────────────────────────────
 
 /** Count bound items for a connector via SQL `count()` (G7 — O(1), not select-all). */
-export async function countConnectorItems(db: Database, dataConnectorId: string): Promise<number> {
+export async function countConnectorItems(db: DbOrTx, dataConnectorId: string): Promise<number> {
   const [row] = await db
     .select({ n: count() })
     .from(schema.DataConnectorItem)

--- a/packages/lib/src/data-connectors/sink-source-record.test.ts
+++ b/packages/lib/src/data-connectors/sink-source-record.test.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/data-connectors/sink-source-record.test.ts
 
+import { toFieldId, toResourceFieldId } from '@auxx/types/field'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ResourceField } from '../resources'
 import type { ConnectorRecord } from './connectors/types'
@@ -43,7 +44,7 @@ function mapping(over: Partial<DecodedMapping> & { id?: string }): DecodedMappin
   }
 }
 
-function relField(over: Partial<ResourceField> & { id: string }): ResourceField {
+function relField(over: Omit<Partial<ResourceField>, 'id'> & { id: string }): ResourceField {
   return {
     key: over.id,
     label: over.id,
@@ -51,6 +52,7 @@ function relField(over: Partial<ResourceField> & { id: string }): ResourceField 
     fieldType: 'RELATIONSHIP',
     capabilities: {} as ResourceField['capabilities'],
     ...over,
+    id: toFieldId(over.id),
   } as ResourceField
 }
 
@@ -68,7 +70,7 @@ describe('sinkSourceRecord — relationship edge resolution', () => {
     fieldsByDef.orderDef = [
       relField({
         id: 'cf_lineItems',
-        resourceFieldId: 'orderDef:cf_lineItems',
+        resourceFieldId: toResourceFieldId('orderDef', 'cf_lineItems'),
         appFieldKey: 'lineItems',
         relationship: {
           relationshipType: 'has_many',

--- a/packages/lib/src/data-connectors/sink-source-record.ts
+++ b/packages/lib/src/data-connectors/sink-source-record.ts
@@ -13,6 +13,7 @@ import {
   getFieldId,
   isAppFieldRef,
   isFieldPath,
+  isResourceFieldId,
   keyToFieldRef,
   parseAppFieldRef,
   type ResourceFieldId,
@@ -71,7 +72,9 @@ async function resolveEdge(
   // which matches a connector-provisioned RELATIONSHIP field's AUTO-GENERATED id by its
   // `appFieldKey`), so display + sync never diverge. Then use the field's REAL id.
   const ownerDef =
-    !isAppFieldRef(lastSeg) && lastSeg.includes(':') ? getFieldDefinitionId(lastSeg) : parentDef
+    !isAppFieldRef(lastSeg) && isResourceFieldId(lastSeg)
+      ? getFieldDefinitionId(lastSeg)
+      : parentDef
   const fields = await getFields(ownerDef)
   const field = resolveFieldRef(fields, ownerDef, lastSeg)?.field
   // Fall back to the authored id when nothing resolves (shouldn't happen post-install):

--- a/packages/lib/src/data-connectors/sinks/entity-sink-connection-app-fields.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-connection-app-fields.test.ts
@@ -7,6 +7,7 @@
 
 import { toResourceFieldId } from '@auxx/types/field'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSyncCtx } from '../__test-helpers'
 import type { DecodedMapping } from '../service'
 import type { ProjectedRecord, SyncCtx } from './types'
 
@@ -95,28 +96,13 @@ function makeDb() {
 }
 
 function makeCtx(over: Partial<SyncCtx> = {}): SyncCtx {
-  return {
+  return makeSyncCtx({
     db: makeDb() as never,
-    orgId: 'org1',
-    connector: { id: 'dc1', credentialId: 'cred1' } as SyncCtx['connector'],
-    runId: 'run1',
     crud: { update, create, getFieldValues } as never,
     ownedCrud: { update, create, getFieldValues } as never,
-    counters: {
-      fetched: 0,
-      created: 0,
-      updated: 0,
-      skipped: 0,
-      archived: 0,
-      deleted: 0,
-      failed: 0,
-      relationshipWarnings: 0,
-      errorSample: [],
-    } as SyncCtx['counters'],
-    touchedDefs: new Set<string>(),
     connectionMeta: { shopDomain: 'us.myshopify.com' },
     ...over,
-  }
+  })
 }
 
 beforeEach(() => {

--- a/packages/lib/src/data-connectors/sinks/entity-sink-identity.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-identity.test.ts
@@ -7,6 +7,7 @@
 import { toResourceFieldId } from '@auxx/types/field'
 import { stableHash } from '@auxx/utils/hash'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSyncCtx } from '../__test-helpers'
 import type { DecodedMapping } from '../service'
 import type { ProjectedRecord, SyncCtx } from './types'
 
@@ -86,26 +87,10 @@ const update = vi.fn().mockResolvedValue(undefined)
 const getFieldValues = vi.fn()
 
 function makeCtx(): SyncCtx {
-  return {
-    db: {} as never,
-    orgId: 'org1',
-    connector: { id: 'dc1', credentialId: 'cred1' } as SyncCtx['connector'],
-    runId: 'run1',
+  return makeSyncCtx({
     crud: { update, create, getFieldValues } as never,
     ownedCrud: { update, create, getFieldValues } as never,
-    counters: {
-      fetched: 0,
-      created: 0,
-      updated: 0,
-      skipped: 0,
-      archived: 0,
-      deleted: 0,
-      failed: 0,
-      relationshipWarnings: 0,
-      errorSample: [],
-    } as SyncCtx['counters'],
-    touchedDefs: new Set<string>(),
-  }
+  })
 }
 
 beforeEach(() => {

--- a/packages/lib/src/data-connectors/sinks/entity-sink-version-guard.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-version-guard.test.ts
@@ -7,6 +7,7 @@
 
 import { stableHash } from '@auxx/utils/hash'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSyncCtx } from '../__test-helpers'
 import type { DecodedMapping } from '../service'
 import type { ProjectedRecord, SyncCtx } from './types'
 
@@ -57,26 +58,11 @@ function record(over: Partial<ProjectedRecord> = {}): ProjectedRecord {
 
 const update = vi.fn().mockResolvedValue(undefined)
 function makeCtx(): SyncCtx {
-  return {
-    db: {} as never,
-    orgId: 'org1',
-    connector: { id: 'dc1', credentialId: 'cred1' } as SyncCtx['connector'],
+  return makeSyncCtx({
     runId: 'app-webhook:e1',
     crud: { update } as never,
     ownedCrud: { update } as never,
-    counters: {
-      fetched: 0,
-      created: 0,
-      updated: 0,
-      skipped: 0,
-      archived: 0,
-      deleted: 0,
-      failed: 0,
-      relationshipWarnings: 0,
-      errorSample: [],
-    } as SyncCtx['counters'],
-    touchedDefs: new Set<string>(),
-  }
+  })
 }
 
 const T1 = new Date('2026-06-21T00:00:00Z')

--- a/packages/lib/src/data-connectors/suggest-mappings.test.ts
+++ b/packages/lib/src/data-connectors/suggest-mappings.test.ts
@@ -2,13 +2,16 @@
 // Tier 2 mapping suggester (create-sync-flow §3.2): scalar-leaf extraction from a
 // source schema + the name/type heuristic that proposes source→field bindings.
 
+import { toFieldId } from '@auxx/types/field'
 import { describe, expect, it } from 'vitest'
 import { collectSchemaLeaves } from '../json-schema'
 import type { ResourceField } from '../resources'
 import { suggestFieldMappings } from './suggest-mappings'
 
 /** Minimal writable target field; override `capabilities`/`fieldType` per case. */
-function field(partial: Partial<ResourceField> & { id: string; key: string }): ResourceField {
+function field(
+  partial: Omit<Partial<ResourceField>, 'id'> & { id: string; key: string }
+): ResourceField {
   return {
     label: partial.key,
     type: 'string',
@@ -20,6 +23,7 @@ function field(partial: Partial<ResourceField> & { id: string; key: string }): R
       configurable: true,
     },
     ...partial,
+    id: toFieldId(partial.id),
   } as ResourceField
 }
 

--- a/packages/lib/src/test/live-api.ts
+++ b/packages/lib/src/test/live-api.ts
@@ -1,0 +1,35 @@
+// packages/lib/src/test/live-api.ts
+
+/**
+ * Opt-in gate for the provider suites that hit REAL vendor endpoints.
+ *
+ * These suites cost money and depend on a vendor's current model catalogue, so
+ * they are not part of a normal run. Set `LIVE_API_TESTS=1` in addition to the
+ * vendor's key:
+ *
+ * ```bash
+ * LIVE_API_TESTS=1 npx vitest run --project lib src/ai/providers
+ * ```
+ *
+ * **Why the key alone is not the gate.** These used to be
+ * `describe.skipIf(!VENDOR_API_KEY)`, which reads as "run when you can" — but a
+ * developer's `.env` supplies real keys, so they ran on every local `vitest run`
+ * and failed with vendor errors (402 "Insufficient Balance", "This is not a chat
+ * model"), while CI skipped them for lack of keys. That put two permanently-red
+ * files in every local full-suite result, which is exactly the noise that makes
+ * a real regression easy to wave away. **Holding a credential is not consent to
+ * spend it.**
+ *
+ * They are gated rather than excluded from the vitest config on purpose: an
+ * excluded file stops being collected and typechecked, and this repo has found
+ * three separate cases of dead code kept alive only by its own test suite.
+ */
+export const liveApiTestsEnabled = process.env.LIVE_API_TESTS === '1'
+
+/**
+ * True only when live-API tests are opted into AND the vendor key is present.
+ * Use as `describe.skipIf(!canRunLiveApi(VENDOR_API_KEY))(...)`.
+ */
+export function canRunLiveApi(apiKey: string | undefined): boolean {
+  return liveApiTestsEnabled && !!apiKey
+}


### PR DESCRIPTION
`packages/lib/src/data-connectors` (68) and `apps/web/src/components/data-connectors` (81) are both at **zero**.

| | before | after |
|---|---|---|
| `packages/lib` | 1 053 | **984** |
| `apps/web` | 1 915 | **~1 812** |
| lib `src/data-connectors` | 68 | **0** |
| web `components/data-connectors` | 81 | **0** |
| `packages/database` | 0 | 0 |

More than the 149 in the two directories, because lib fixes re-report outward — `apps/{worker,api,kb}` fall too without being touched.

Four agents in two waves. **Diagnosing by MESSAGE before partitioning decided the whole shape of the work** — two greps showed 80 of the 149 were three root causes rather than 80 problems, and wave 1 changed what wave 2 needed to be (web's target went 81 → 17 before wave 2 started).

## The three root causes

**1. 52 of web's 81 were one idiom.**

```ts
type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
```

`useQuery`'s generic is left at its default, so `['data']` resolves to `{}` and every property access fails. Nine sibling files already used the form that works — `RouterOutputs['dataConnector']['getById']`. Only 7 files repo-wide use the broken form; 5 were here.

**2. The lib ↔ database type mirror had drifted four ways.** `lib/data-connectors/types.ts` and `database/.../data-connector-types.ts` are hand-maintained copies (tier 1 cannot import tier 3), and that file's header says drift "is reconciled in code review". It wasn't:

- `FieldMapping.targetFieldRef` unbranded on the DB side
- `provision.options` / `addressComponents` missing, though `provisioning.ts:265` reads them
- `DataConnectorType` missing `'fixture'`, a registered built-in the router accepts
- `StreamRequestConfig.webhookTrigger` missing `debounceMs`, written at two sites and read in the dispatch job

Reconciled from the **write path**, not by preference. `'fixture'` alone was the sole cause of an opaque `TS2769 No overload matches this call`, where Drizzle fell through to the array overload and blamed `organizationId` — an error message pointing nowhere near its cause. Also removes the `as unknown as FieldMapping[]` that had been papering over the drift.

Worth noting for the tier problem: **brands are structural**, so the database package re-declaring `type ResourceFieldId = string & { readonly __brand: 'ResourceFieldId' }` locally gets the identical type without importing `@auxx/types` (which would be a cycle). That beats unbranding the shared contract to accommodate the lower tier.

**3. 28 of lib's 68 were test fixtures** — bare strings against branded ids, and `FieldMapping` literals missing required members. Uses the repo's existing `toResourceFieldId`/`toFieldId`/`toRecordId` constructors rather than casts, plus one `__test-helpers.ts` for `SyncCtx`.

## The live bug

`kb-branch.tsx` filtered archived articles with `!('archivedAt' in a) || a.archivedAt == null`. `flattenForList` returns an explicit object literal that projects `status` and has **no `archivedAt` key at all** — so `'archivedAt' in a` was false for every row and the filter was a guaranteed no-op. Archived articles have been appearing in the agent Knowledge-scope tree and can be pinned into an agent's retrieval scope.

Now `status !== 'ARCHIVED'`, the idiom `kb-catalog.ts:114` already used. **Not verified:** whether the retrieval pipeline actually serves archived content downstream — worth a separate look, and deliberately not claimed here.

## A fixture that silently disabled a code path

Three `SyncCtx` fixtures omitted `manifest`, which the type has required since B2. They passed because the only unguarded read sits behind `if (ctx.manifest?.enabled)` — `undefined?.enabled` is falsy, so **sync-change capture was never exercised by those suites**. The source docstring even admits it. Now explicit and disabled: behavior byte-identical, the omission unrepresentable.

## Live-API tests are now opt-in

The six provider suites were `describe.skipIf(!VENDOR_API_KEY)` — "run when you can". But a developer's `.env` supplies real keys, so they ran on every local run and failed with vendor errors (402 Insufficient Balance, "not a chat model"), while CI skipped them for lack of keys. **Holding a credential is not consent to spend it.** They now also require `LIVE_API_TESTS=1`:

```bash
LIVE_API_TESTS=1 npx vitest run --project lib src/ai/providers
```

Gated rather than excluded from the vitest config on purpose — an excluded file stops being collected and typechecked, and this repo has found three separate cases of dead code kept alive only by its own test suite. Verified in **both** directions: default run skips all 69, the flag runs them. A local full-suite result now matches CI instead of carrying two permanently-red files.

## Verification

Full 12-project suite: **712 passed / 4 skipped / 0 failed**, no `Errors` line. Same-state key-set deltas throughout (two `tsc` runs in one worktree, key sets diffed — not against the committed baseline), zero new keys attributable to this work.

## Known follow-ups, deliberately not in scope

- `AppIconProps` (`components/apps/ui/app-icon.tsx:8`) doesn't declare `fallbackIconId` although `AppIcon` spreads into `VisualIcon`, which handles it — still 2 errors in `fields/connector-source-badge.tsx`.
- `flat-record-list.tsx(56,58)` is the same over-wide `EffectiveScopeMode` shape that was fixed in `agent-scope-actions.tsx`; the producer lives in files outside this sweep. Three one-line annotations.
- `apps/web` keeps a **third** `FieldMapping` copy (`hooks/use-stream-mutations.ts:41`, unbranded). None of the errors here were caused by it; consolidating means touching ~14 casts across the connector UI.
- `packages/lib/src/data-connectors/provisioning.ts` contains a deliberate NUL byte as a composite map-key separator, so `file(1)` calls it binary and **plain `grep -r` silently skips it**. Use `grep -a` when auditing that module.