### PR TITLE
fix(email): repair the mailer's log calls, expiry rendering and transport types

### DIFF
--- a/packages/email/src/mailer/index.ts
+++ b/packages/email/src/mailer/index.ts
@@ -143,7 +143,10 @@ export const sendEmail = async (options: SendEmailDataProps): Promise<boolean> =
       throw new Error(result.error || 'Failed to send email')
     }
 
-    return result
+    // Unreachable unless `success` — the guard above throws — so this is always
+    // `true`. Returned as the boolean the signature (and all 29 wrappers) declare,
+    // rather than leaking the `EmailResult` object callers cannot see through it.
+    return result.success
   } catch (error) {
     logger.error('Error sending system email:', { error })
     throw error
@@ -170,7 +173,7 @@ export const sendVerificationEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendVerificationEmail')
+    logger.error('Error in sendVerificationEmail', { error })
     throw error
   }
 }
@@ -201,7 +204,7 @@ export const sendEmailChangeVerificationEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendEmailChangeVerificationEmail')
+    logger.error('Error in sendEmailChangeVerificationEmail', { error })
     throw error
   }
 }
@@ -226,7 +229,7 @@ export const sendResetPasswordEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendResetPasswordEmail')
+    logger.error('Error in sendResetPasswordEmail', { error })
     throw error
   }
 }
@@ -249,7 +252,7 @@ export const sendPasswordResetNotifyEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendPasswordResetNotifyEmail')
+    logger.error('Error in sendPasswordResetNotifyEmail', { error })
     throw error
   }
 }
@@ -274,7 +277,7 @@ export const sendWelcomeEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendWelcomeEmail')
+    logger.error('Error in sendWelcomeEmail', { error })
     throw error
   }
 }
@@ -307,7 +310,7 @@ export const sendBillingEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendBillingEmail')
+    logger.error('Error in sendBillingEmail', { error })
     throw error
   }
 }
@@ -334,7 +337,7 @@ export const sendSystemEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendSystemEmail')
+    logger.error('Error in sendSystemEmail', { error })
     throw error
   }
 }
@@ -365,7 +368,7 @@ export const sendDeveloperInviteEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendDeveloperInviteEmail')
+    logger.error('Error in sendDeveloperInviteEmail', { error })
     throw error
   }
 }
@@ -421,7 +424,7 @@ export const sendVisitDispatchedEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendVisitDispatchedEmail')
+    logger.error('Error in sendVisitDispatchedEmail', { error })
     throw error
   }
 }
@@ -490,7 +493,7 @@ export const sendVisitRescheduledEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendVisitRescheduledEmail')
+    logger.error('Error in sendVisitRescheduledEmail', { error })
     throw error
   }
 }
@@ -542,7 +545,7 @@ export const sendVisitCanceledEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendVisitCanceledEmail')
+    logger.error('Error in sendVisitCanceledEmail', { error })
     throw error
   }
 }
@@ -601,7 +604,7 @@ export const sendVisitReassignedEmail = async ({
 
     return await sendEmail({ to: email, subject: formatSubject(subject), html, text })
   } catch (error) {
-    logger.error(error, 'Error in sendVisitReassignedEmail')
+    logger.error('Error in sendVisitReassignedEmail', { error })
     throw error
   }
 }
@@ -635,7 +638,7 @@ export const sendVisitDailyDigestEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendVisitDailyDigestEmail')
+    logger.error('Error in sendVisitDailyDigestEmail', { error })
     throw error
   }
 }
@@ -666,7 +669,7 @@ export const sendInviteEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendInviteEmail')
+    logger.error('Error in sendInviteEmail', { error })
     throw error
   }
 }
@@ -711,7 +714,7 @@ export const sendJoinOrganizationEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendJoinOrganizationEmail')
+    logger.error('Error in sendJoinOrganizationEmail', { error })
     throw error
   }
 }
@@ -729,7 +732,7 @@ export const sendApprovalRequestEmail = async ({
   workflowName: string
   message?: string
   approvalUrl: string
-  expiresAt: Date
+  expiresAt: string
 }): Promise<boolean> => {
   try {
     const html = await render(
@@ -744,7 +747,7 @@ export const sendApprovalRequestEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendApprovalRequestEmail')
+    logger.error('Error in sendApprovalRequestEmail', { error })
     throw error
   }
 }
@@ -766,7 +769,7 @@ export const sendApprovalReminderEmail = async ({
   approvalUrl: string
   reminderNumber: number
   timeRemaining: string
-  expiresAt: Date
+  expiresAt: string
 }): Promise<boolean> => {
   try {
     const html = await render(
@@ -797,7 +800,7 @@ export const sendApprovalReminderEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendApprovalReminderEmail')
+    logger.error('Error in sendApprovalReminderEmail', { error })
     throw error
   }
 }
@@ -817,10 +820,16 @@ export const sendSubscriptionWelcomeEmail = async ({
   dashboardUrl?: string
 }): Promise<boolean> => {
   try {
+    // The templates key off `'ANNUAL'`, this signature (and the job payload) use
+    // lowercase — so passing it through made `billingCycle === 'ANNUAL'` false for
+    // every caller and told annual subscribers "Billing Cycle: Monthly", in both
+    // the HTML and text versions. Latent today: nothing enqueues this email.
+    const cycle = billingCycle === 'annual' ? 'ANNUAL' : 'MONTHLY'
+
     const html = await render(
-      await SubscriptionWelcomeEmail({ name, planName, billingCycle, dashboardUrl })
+      await SubscriptionWelcomeEmail({ name, planName, billingCycle: cycle, dashboardUrl })
     )
-    const text = SubscriptionWelcomeText({ name, planName, billingCycle, dashboardUrl })
+    const text = SubscriptionWelcomeText({ name, planName, billingCycle: cycle, dashboardUrl })
 
     return await sendEmail({
       to: email,
@@ -829,7 +838,7 @@ export const sendSubscriptionWelcomeEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendSubscriptionWelcomeEmail')
+    logger.error('Error in sendSubscriptionWelcomeEmail', { error })
     throw error
   }
 }
@@ -859,7 +868,7 @@ export const sendTrialStartedEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendTrialStartedEmail')
+    logger.error('Error in sendTrialStartedEmail', { error })
     throw error
   }
 }
@@ -889,7 +898,7 @@ export const sendTrialEndingEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendTrialEndingEmail')
+    logger.error('Error in sendTrialEndingEmail', { error })
     throw error
   }
 }
@@ -917,7 +926,7 @@ export const sendTrialExpiredEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendTrialExpiredEmail')
+    logger.error('Error in sendTrialExpiredEmail', { error })
     throw error
   }
 }
@@ -949,7 +958,7 @@ export const sendSubscriptionCancelledEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendSubscriptionCancelledEmail')
+    logger.error('Error in sendSubscriptionCancelledEmail', { error })
     throw error
   }
 }
@@ -983,7 +992,7 @@ export const sendPaymentFailedEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendPaymentFailedEmail')
+    logger.error('Error in sendPaymentFailedEmail', { error })
     throw error
   }
 }
@@ -1013,7 +1022,7 @@ export const sendTrialDeletionWarningEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendTrialDeletionWarningEmail')
+    logger.error('Error in sendTrialDeletionWarningEmail', { error })
     throw error
   }
 }
@@ -1043,7 +1052,7 @@ export const sendTrialDeletionFinalEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendTrialDeletionFinalEmail')
+    logger.error('Error in sendTrialDeletionFinalEmail', { error })
     throw error
   }
 }
@@ -1093,7 +1102,7 @@ export const sendGettingStartedEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendGettingStartedEmail')
+    logger.error('Error in sendGettingStartedEmail', { error })
     throw error
   }
 }
@@ -1147,7 +1156,7 @@ export const sendMidTrialEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendMidTrialEmail')
+    logger.error('Error in sendMidTrialEmail', { error })
     throw error
   }
 }
@@ -1203,7 +1212,7 @@ export const sendTrialConversionEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendTrialConversionEmail')
+    logger.error('Error in sendTrialConversionEmail', { error })
     throw error
   }
 }
@@ -1241,7 +1250,7 @@ export const sendPaymentReceiptEmail = async ({
       text,
     })
   } catch (error) {
-    logger.error(error, 'Error in sendPaymentReceiptEmail')
+    logger.error('Error in sendPaymentReceiptEmail', { error })
     throw error
   }
 }

--- a/packages/email/src/mailer/nodemailer-service.ts
+++ b/packages/email/src/mailer/nodemailer-service.ts
@@ -135,7 +135,7 @@ export class NodemailerService {
         hasText: !!mailOptions.text,
         hasHtml: !!mailOptions.html,
         from: mailOptions.from,
-        fieldCount: Object.keys(mailOptions).filter((k) => mailOptions[k] !== undefined).length,
+        fieldCount: Object.values(mailOptions).filter((v) => v !== undefined).length,
       })
 
       const info = await this.transporter.sendMail(mailOptions)

--- a/packages/email/src/templates/workflow/approval-request-email.tsx
+++ b/packages/email/src/templates/workflow/approval-request-email.tsx
@@ -13,7 +13,7 @@ interface ApprovalRequestEmailProps {
   workflowName: string
   message?: string
   approvalUrl: string
-  expiresAt: Date
+  expiresAt: string
 }
 
 export async function ApprovalRequestEmail({

--- a/packages/email/src/transports/factory.ts
+++ b/packages/email/src/transports/factory.ts
@@ -90,8 +90,15 @@ export class TransportFactory {
       throw new Error('Invalid SYSTEM_FROM_EMAIL: must contain a valid domain')
     }
 
+    const apiKey = configService.get<string>('MAILGUN_API_KEY')
+    if (!apiKey) {
+      // Same shape as the `sendingDomain` guard above: fail at construction rather
+      // than handing the client an `undefined` key it only chokes on at send time.
+      throw new Error('MAILGUN_API_KEY is not configured')
+    }
+
     const auth = {
-      api_key: configService.get<string>('MAILGUN_API_KEY'),
+      api_key: apiKey,
       domain: sendingDomain,
     }
 

--- a/packages/email/src/transports/factory.ts
+++ b/packages/email/src/transports/factory.ts
@@ -90,10 +90,14 @@ export class TransportFactory {
       throw new Error('Invalid SYSTEM_FROM_EMAIL: must contain a valid domain')
     }
 
+    // Unreachable: the `missingVars` check above already throws when this is unset.
+    // It is here only to NARROW the type — TypeScript cannot see through
+    // `Object.entries(requiredVars).filter(...)`, so the key still reads as
+    // `string | undefined` while `MailgunTransportOptions.auth.api_key` wants a
+    // `string`. Re-reading and re-checking beats asserting non-null: if the
+    // validation above is ever reordered or dropped, this still fails loudly.
     const apiKey = configService.get<string>('MAILGUN_API_KEY')
     if (!apiKey) {
-      // Same shape as the `sendingDomain` guard above: fail at construction rather
-      // than handing the client an `undefined` key it only chokes on at send time.
       throw new Error('MAILGUN_API_KEY is not configured')
     }
 

--- a/packages/email/src/transports/mailgun-transport.ts
+++ b/packages/email/src/transports/mailgun-transport.ts
@@ -29,11 +29,14 @@ export interface MailgunTransportOptions {
  * Extended mail options with Mailgun-specific fields
  */
 interface ExtendedMailOptions extends Mail.Options {
+  /** `null` is meaningful, not merely absent: `renderTemplate` sets it to clear a
+   *  locally-rendered Handlebars template so the HTML is sent instead of asking
+   *  Mailgun to resolve a template by name. */
   template?: {
     name: string
     engine: 'handlebars'
     context?: Record<string, any>
-  }
+  } | null
   'o:tag'?: string | string[]
   'o:campaign'?: string
   'o:dkim'?: boolean | 'yes' | 'no'
@@ -188,12 +191,15 @@ function makeMailgunAttachments(attachments: Mail.Attachment[] = []): {
 function makeAllTextAddresses(mail: ExtendedMailOptions): Record<string, string> {
   const keys = ['from', 'to', 'cc', 'bcc', 'replyTo'] as const
 
-  const makeTextAddresses = (addresses: any): string => {
-    const validAddresses = [].concat(addresses).filter(Boolean)
+  const makeTextAddresses = (addresses: unknown): string => {
+    // Was `[].concat(addresses)`, whose `[]` is `never[]` — so every element typed
+    // as `never` and each property read on it was an error. Same one-level flatten.
+    const validAddresses = (Array.isArray(addresses) ? addresses : [addresses]).filter(Boolean)
 
     const textAddresses = validAddresses.map((item) => {
-      if (typeof item === 'object' && item.address) {
-        return item.name ? `${item.name} <${item.address}>` : item.address
+      if (typeof item === 'object' && item !== null && 'address' in item) {
+        const { address, name } = item as { address: string; name?: string }
+        return name ? `${name} <${address}>` : address
       } else if (typeof item === 'string') {
         return item
       }

--- a/packages/lib/src/jobs/email/send-email-job.ts
+++ b/packages/lib/src/jobs/email/send-email-job.ts
@@ -37,6 +37,26 @@ import type { EmailType, SendEmailJobData } from './types'
 
 const logger = createScopedLogger('job:send-email')
 
+/**
+ * Render an approval expiry for display in an email.
+ *
+ * The payload type says `Date`, and that is true at ENQUEUE time — but the job
+ * round-trips through Redis as JSON, so what arrives here is an ISO string. The
+ * templates take a preformatted `string` precisely because they cannot render a
+ * `Date` (React throws "Objects are not valid as a React child"), and without
+ * this the emails showed a raw `2026-08-02T10:00:00.000Z`.
+ *
+ * `new Date(value)` accepts either form, so this is correct whichever side of
+ * the queue it is called from.
+ */
+function formatExpiry(value: Date | string): string {
+  return `${new Date(value).toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  })} UTC`
+}
+
 const handlers: {
   [K in EmailType]: (payload: SendEmailJobData<K>['payload']) => Promise<boolean>
 } = {
@@ -89,7 +109,7 @@ const handlers: {
       workflowName: p.workflowName,
       message: p.message,
       approvalUrl: p.approvalUrl,
-      expiresAt: p.expiresAt,
+      expiresAt: formatExpiry(p.expiresAt),
     }),
   'approval-reminder': (p) =>
     sendApprovalReminderEmail({
@@ -100,7 +120,7 @@ const handlers: {
       approvalUrl: p.approvalUrl,
       reminderNumber: p.reminderNumber,
       timeRemaining: p.timeRemaining,
-      expiresAt: p.expiresAt,
+      expiresAt: formatExpiry(p.expiresAt),
     }),
   'getting-started': (p) =>
     sendGettingStartedEmail({

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -1,0 +1,38 @@
+// packages/utils/src/errors.ts
+
+/**
+ * Extract a human-readable message from a caught value.
+ *
+ * `catch (error)` gives you `unknown` under `useUnknownInCatchVariables`, and the
+ * repo answers that with `error instanceof Error ? error.message : String(error)`
+ * inlined in ~450 places. This is that expression, named once.
+ *
+ * ```ts
+ * catch (error) {
+ *   logger.error('Sync failed', { error })            // logger takes `unknown` args — no helper needed
+ *   throw new BadRequestError(getErrorMessage(error)) // but a `string` slot does
+ * }
+ * ```
+ *
+ * Note the first line: `@auxx/logger`'s methods are
+ * `(message: string, ...args: unknown[])`, so an error belongs in the ARGS slot
+ * raw — passing `getErrorMessage(error)` there would discard the stack. Reach for
+ * this only where a `string` is genuinely required.
+ *
+ * Not to be confused with `parseError` in `apps/lambda/src/utils.ts`, which is
+ * deliberately separate: it defaults the code to `EXECUTION_ERROR` and forwards
+ * the structured `@auxx/sdk` error fields across the sandbox boundary, and that
+ * app runs under Deno with only two dependencies on purpose.
+ */
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Coerce a caught value to an `Error`, preserving the original as `cause` when it
+ * was not one. Use when an API demands an `Error` — prefer rethrowing the original
+ * where you can, since wrapping costs you the original stack.
+ */
+export function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error), { cause: error })
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -76,6 +76,8 @@ export {
   toGraphRecipients,
   validateSendAsAddress,
 } from './email'
+// Error utilities
+export { getErrorMessage, toError } from './errors'
 
 // File utilities
 export {


### PR DESCRIPTION
`packages/email` **49 → 6**, `packages/lib` **984 → 941**. The six left are a product decision, not a typecheck one — see the end.

`packages/email/src/mailer/index.ts` was the single highest-leverage file in the repo by re-report weight: 40 own errors generating **150** error instances across web/api/worker/kb.

## The 29-error root cause was an observability bug, not just a type error

Every wrapper called `logger.error(error, 'Error in <fn>')` — pino's argument order. `@auxx/logger`'s signature is `(message: string, ...args: unknown[])`, so the Error landed in the `message` slot.

That matters more than it looks. `logAndWrite` puts `message` into the structured record **raw**, and:

```js
JSON.stringify({ message: new Error('smtp connection refused') })  // => {"message":{}}
```

Error's own properties are non-enumerable. So **every mailer failure has been shipping to OpenObserve as `message: {}`**, with the human-readable context demoted into `args` — and `message` is the field you search on. It survived because the dev console looked fine: `formatMessage` does `${message}`, and template-stringifying an Error gives `Error: smtp connection refused`.

The same file already used the correct order in two places, which settled which side was stale.

## Approval expiry was rendering as a raw ISO string

`expiresAt` was typed `Date` in the mailer and in `approval-request-email.tsx` — but the sibling `approval-reminder-email.tsx` already declared `string`, and the sibling was right. The payload crosses BullMQ, so it is JSON round-tripped through Redis and arrives as an ISO string. Recipients saw:

> This approval expires at 2026-08-02T10:00:00.000Z

Types now match what actually arrives, and `send-email-job.ts` formats at the boundary → `Aug 2, 2026, 10:00 AM UTC`. `new Date(value)` accepts either form, so it is correct on both sides of the queue.

Worth recording: a real `Date` reaching that template does **not** render. React throws *"Objects are not valid as a React child"*, and `render()` returns an SSR error document instead of throwing — so it would have been **sent as a contentless email**. Verified by probe; the string path renders 8 177 chars, the Date path 2 590 chars of React error payload with no approval text in it.

## Other fixes

- **`sendEmail` declared `Promise<boolean>` but returned the `EmailResult` object.** Harmless today — the `!success` branch throws before the return, so it was always a truthy object — but all 29 wrappers propagated it under a `boolean` type.
- **Billing-cycle case mismatch.** `subscription-welcome` passed lowercase `'annual'` to templates testing `=== 'ANNUAL'`, so annual subscribers would have been told *"Billing Cycle: Monthly"* in both the HTML and text versions. **Latent** — nothing in the repo enqueues that email.
- **`mailgun-transport`:** `[].concat(addresses)` types every element as `never` (`[]` is `never[]`), so each property read on it errored — replaced with an explicit one-level flatten. And `template: null` is *meaningful*, not merely absent: it is how `renderTemplate` says "send the HTML instead of asking Mailgun to resolve a template by name". Now declared.
- **`factory.ts`** narrows `MAILGUN_API_KEY` to `string`. **Correction to an earlier version of this description:** this is NOT a new runtime check — the `missingVars` block at the top of the function already throws when it is unset, so the guard is unreachable. It exists because TypeScript cannot see through `Object.entries(requiredVars).filter(...)`, so the key still reads `string | undefined` where `auth.api_key` wants `string`. Re-reading and re-checking beats a non-null assertion: if that validation is ever reordered or dropped, this still fails loudly.

## `getErrorMessage` / `toError` in `@auxx/utils`

`error instanceof Error ? error.message : String(error)` is inlined **~450 times** (397 in `packages/lib` alone). This gives it a home at a tier everything can reach.

**Deliberately not a move of `apps/lambda`'s `parseError`.** That app runs under **Deno** (`deno check`, `deno test`, `./build.sh`, SDK vendored by symlink) with exactly two dependencies on purpose, and `parseError` is lambda-shaped anyway — it defaults the code to `EXECUTION_ERROR` and forwards the structured `@auxx/sdk` error fields across the sandbox boundary. The docstring records why the two are separate, and warns that `@auxx/logger` takes `unknown` args, so passing `getErrorMessage(error)` there would **discard the stack**.

Existing call sites are left alone — converting 450 of them fixes zero type errors and is pure churn.

## Left for a product decision — the remaining 6

`mailer/index.ts` passes `upgradeUrl`, `integrationsUrl` and `organizationName` to templates that declare none of them and **use** none of them. `GettingStartedEmailProps` is `{name, organizationName?, dashboardUrl?}` with a single "Explore Your Dashboard" button; `MidTrialEmailProps` never mentions an org name.

Nothing is broken — the values are computed in the job, carried through the queue, and discarded. Whether those emails *should* carry integrations / knowledge-base / Shopify links is a product call, so the arguments stay put rather than being deleted (reported, not removed, per the standing rule).

## Verification

Tests: `email` + `utils` 13 files / 180 passing; `human-confirmation-notify` 5 passing. `packages/utils` holds at its 2 pre-existing errors — neither in the new file.