### PR TITLE
fix(mail): raise the bulk thread update cap and bound its fan-out

### DIFF
--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -852,7 +852,9 @@ export const threadRouter = createTRPCRouter({
   updateBulk: mailProcedure
     .input(
       z.object({
-        recordIds: z.array(recordIdSchema).max(50),
+        recordIds: z
+          .array(recordIdSchema)
+          .max(500, 'You can update up to 500 conversations at once.'),
         updates: z.object({
           status: z.enum(['OPEN', 'ARCHIVED', 'SPAM', 'TRASH', 'IGNORED']).optional(),
           assigneeId: z.string().nullable().optional(),

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -100,7 +100,10 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
       return {
         // Keep the original tRPC shape, but override `message` and `data`.
         ...shape,
-        message: 'Validation error',
+        // Surface the first issue's message — it's what lands in an error toast
+        // (`error.message`), and "Validation error" tells the user nothing.
+        // Forms still read the per-field map in `data.fieldErrors`.
+        message: zodError.issues[0]?.message ?? 'Validation error',
         data: {
           ...shape.data,
           // Expose a neat `fieldErrors` object to the client.

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -700,22 +700,26 @@ export class ThreadMutationService {
       }
       if (Object.keys(patch).length > 0) {
         const realtime = getRealtimeService()
-        await Promise.allSettled(
-          result.map((row) =>
-            publishThreadUpdated(
-              realtime,
-              this.organizationId,
-              {
-                threadId: row.id,
-                inboxId: row.inboxId ?? null,
-                previousInboxId: prevInboxIdById.get(row.id) ?? null,
-                assigneeId: row.assigneeId ?? null,
-                patch,
-              },
-              { excludeSocketId: this.socketId }
+        // The fan-out is one publish per thread; a 500-thread selection would
+        // otherwise open 500 concurrent publishes. Chunk to keep it bounded.
+        for (let i = 0; i < result.length; i += 50) {
+          await Promise.allSettled(
+            result.slice(i, i + 50).map((row) =>
+              publishThreadUpdated(
+                realtime,
+                this.organizationId,
+                {
+                  threadId: row.id,
+                  inboxId: row.inboxId ?? null,
+                  previousInboxId: prevInboxIdById.get(row.id) ?? null,
+                  assigneeId: row.assigneeId ?? null,
+                  patch,
+                },
+                { excludeSocketId: this.socketId }
+              )
             )
           )
-        )
+        }
       }
 
       if ('status' in dbUpdates || 'assigneeId' in dbUpdates || 'inboxId' in dbUpdates) {

--- a/packages/lib/src/threads/unread-service.ts
+++ b/packages/lib/src/threads/unread-service.ts
@@ -136,55 +136,57 @@ export class UnreadService {
       )
     const previousReadMap = new Map(previousReadRows.map((r) => [r.threadId, r.isRead]))
 
-    // Get latest message IDs only when marking as read
+    // Get latest message IDs only when marking as read. DISTINCT ON returns one
+    // row per thread instead of every message of every selected thread — the
+    // `(threadId, sentAt)` index covers the ordering. Unsent messages (null
+    // `sentAt`) sort last so a real message always wins the watermark; `id`
+    // breaks ties deterministically.
     const threadMessageMap = new Map<string, string | null>()
     if (isRead) {
       const messages = await db
-        .select({
+        .selectDistinctOn([schema.Message.threadId], {
           threadId: schema.Message.threadId,
           id: schema.Message.id,
         })
         .from(schema.Message)
         .where(inArray(schema.Message.threadId, threadIds))
-        .orderBy(sql`${schema.Message.sentAt} DESC`)
+        .orderBy(
+          schema.Message.threadId,
+          sql`${schema.Message.sentAt} DESC NULLS LAST`,
+          sql`${schema.Message.id} DESC`
+        )
 
-      // Keep only the first (latest) message per thread
       for (const msg of messages) {
-        if (!threadMessageMap.has(msg.threadId)) {
-          threadMessageMap.set(msg.threadId, msg.id)
-        }
+        threadMessageMap.set(msg.threadId, msg.id)
       }
     }
 
     const now = new Date()
 
-    await db.transaction(async (tx) => {
-      // Upsert read status for each thread
-      await Promise.all(
-        threads.map(async (thread) => {
-          const latestMessageId = threadMessageMap.get(thread.id) ?? null
-
-          await tx
-            .insert(schema.ThreadReadStatus)
-            .values({
-              threadId: thread.id,
-              userId: targetUserId,
-              organizationId: this.organizationId,
-              isRead,
-              lastReadAt: isRead ? now : null,
-              lastSeenMessageId: isRead ? latestMessageId : null,
-            })
-            .onConflictDoUpdate({
-              target: [schema.ThreadReadStatus.threadId, schema.ThreadReadStatus.userId],
-              set: {
-                isRead,
-                lastReadAt: isRead ? now : null,
-                ...(isRead && { lastSeenMessageId: latestMessageId }),
-              },
-            })
-        })
+    // One multi-row upsert, not one statement per thread — a bulk mark-read of
+    // a full selection would otherwise hold hundreds of round trips open in a
+    // single transaction. `lastSeenMessageId` is per-row, so the update side
+    // reads it back off `excluded`.
+    await db
+      .insert(schema.ThreadReadStatus)
+      .values(
+        threads.map((thread) => ({
+          threadId: thread.id,
+          userId: targetUserId,
+          organizationId: this.organizationId,
+          isRead,
+          lastReadAt: isRead ? now : null,
+          lastSeenMessageId: isRead ? (threadMessageMap.get(thread.id) ?? null) : null,
+        }))
       )
-    })
+      .onConflictDoUpdate({
+        target: [schema.ThreadReadStatus.threadId, schema.ThreadReadStatus.userId],
+        set: {
+          isRead,
+          lastReadAt: isRead ? now : null,
+          ...(isRead && { lastSeenMessageId: sql`excluded."lastSeenMessageId"` }),
+        },
+      })
 
     // Counter deltas (post-commit): ±1 per thread that actually flipped, only
     // while the thread is OPEN (counts include only OPEN threads). Marking an
@@ -215,21 +217,25 @@ export class UnreadService {
     // Publish per-thread `thread:updated` with `{ isUnread, userId }`. The FE
     // filters by userId so only the affected user's tabs apply the patch.
     const realtime = getRealtimeService()
-    await Promise.allSettled(
-      threads.map((thread) =>
-        publishThreadUpdated(
-          realtime,
-          this.organizationId,
-          {
-            threadId: thread.id,
-            inboxId: thread.inboxId ?? null,
-            assigneeId: thread.assigneeId ?? null,
-            patch: { isUnread: !isRead, userId: targetUserId },
-          },
-          { excludeSocketId: this.socketId }
+    // Chunked so a bulk mark-read doesn't open one publish per selected thread
+    // all at once.
+    for (let i = 0; i < threads.length; i += 50) {
+      await Promise.allSettled(
+        threads.slice(i, i + 50).map((thread) =>
+          publishThreadUpdated(
+            realtime,
+            this.organizationId,
+            {
+              threadId: thread.id,
+              inboxId: thread.inboxId ?? null,
+              assigneeId: thread.assigneeId ?? null,
+              patch: { isUnread: !isRead, userId: targetUserId },
+            },
+            { excludeSocketId: this.socketId }
+          )
         )
       )
-    )
+    }
 
     // Mirror the read state to Gmail for personal channels — only the mailbox
     // owner's read state pushes (it's their mailbox; requireOwnerUserId filters


### PR DESCRIPTION
## Problem

`thread.updateBulk` capped `recordIds` at 50, so any selection larger than that failed input validation:

```
❌ tRPC failed on thread.updateBulk: too_big — expected array to have <=50 items
```

The frontend happily selects hundreds (Cmd+A selects every loaded thread), so this was reachable from normal use. The cap was also arbitrary: `removeBulk` and the bulk tag path in the same router have no cap, and `fieldValue.updateBulk` allows 500.

The toast on top of it read **"Validation error"** — the `errorFormatter` hardcoded that string for every `ZodError`, so no Zod message ever reached the user.

## Fix — backend, not frontend chunking

The DB write is already a single `UPDATE … WHERE id IN (...)`; the per-thread cost was the realtime fan-out, which is now chunked inside the service (the inbox-move path already did this at 200/chunk). Looping on the frontend would mean N round trips each redoing `assertCanActOnThreads` + `markCountsStale`, N chances of partial failure, and a global `restoreSnapshot()` for counts that would roll back chunks that already succeeded — plus it wouldn't protect the endpoint at all.

- **Cap → 500**, with a human message on the schema (`'You can update up to 500 conversations at once.'`).
- **`errorFormatter`** surfaces the first Zod issue's message instead of the constant. `data.fieldErrors` is unchanged, so form-level consumers still work.
- **`updateBulk`**: the per-thread realtime publish was `Promise.allSettled` over the whole batch — now chunks of 50.
- **`setReadStatus`** (the `isUnread` path, which is where a bulk mark-read lands):
  - one multi-row upsert instead of one `INSERT … ON CONFLICT` **per thread inside a transaction** (500 selected = 500 round trips held open). `lastSeenMessageId` is per-row, so the update side reads it off `excluded`.
  - the latest-message lookup was "fetch every message of every selected thread, keep the first per thread in JS" — now `DISTINCT ON (threadId)`, served by the existing `thread_messages_idx (threadId, sentAt)`.
  - realtime publish chunked the same way.

### Two deliberate ordering changes in that lookup

- **`NULLS LAST`** — the old `ORDER BY sentAt DESC` used Postgres' DESC default of NULLS **FIRST**, so an unsent message (`sentAt` is nullable) would win and become the thread's `lastSeenMessageId` watermark. Now a real sent message always wins.
- **`id DESC` tiebreak** — `DISTINCT ON` needs a deterministic winner when two messages share a `sentAt`; the old code's winner depended on scan order.

## Verification

- Printed the generated SQL via Drizzle's `toSQL()` and ran that exact statement against the dev DB — one row per thread, so the `DISTINCT ON` / `ORDER BY` prefix rule holds.
- `packages/lib` thread tests: 42 passed. `apps/web` `thread-error-status` + `mail-instance-access`: 72 passed.
- Typecheck clean on all four files (the two errors reported in `thread.ts:449` and `trpc.ts:270` are pre-existing and untouched); biome clean.