### PR TITLE
fix: resolve KB, planning, and date parser type errors

### DIFF
--- a/packages/lib/src/import/planning/assign-row-to-strategy.ts
+++ b/packages/lib/src/import/planning/assign-row-to-strategy.ts
@@ -33,6 +33,10 @@ export async function assignRowToStrategy(
     })
     .returning()
 
+  if (!result) {
+    throw new Error('Failed to assign import row to strategy')
+  }
+
   return {
     id: result.id,
     importPlanStrategyId: result.importPlanStrategyId,

--- a/packages/lib/src/import/planning/create-plan.ts
+++ b/packages/lib/src/import/planning/create-plan.ts
@@ -21,6 +21,10 @@ export async function createPlan(db: Database, jobId: string): Promise<ImportPla
     })
     .returning()
 
+  if (!result) {
+    throw new Error('Failed to create import plan')
+  }
+
   return {
     id: result.id,
     importJobId: result.importJobId,

--- a/packages/lib/src/import/planning/create-strategy.ts
+++ b/packages/lib/src/import/planning/create-strategy.ts
@@ -35,6 +35,10 @@ export async function createStrategy(
     })
     .returning()
 
+  if (!result) {
+    throw new Error('Failed to create import plan strategy')
+  }
+
   return {
     id: result.id,
     importPlanId: result.importPlanId,

--- a/packages/lib/src/import/planning/get-plan.ts
+++ b/packages/lib/src/import/planning/get-plan.ts
@@ -13,6 +13,15 @@ export interface PlanWithEstimates {
   estimates: PlanEstimates
 }
 
+function getPlannedCount(statistics: unknown): number {
+  if (typeof statistics !== 'object' || statistics === null || Array.isArray(statistics)) {
+    return 0
+  }
+
+  const planned = (statistics as Record<string, unknown>).planned
+  return typeof planned === 'number' && Number.isFinite(planned) && planned >= 0 ? planned : 0
+}
+
 /**
  * Get import plan with calculated estimates.
  *
@@ -46,7 +55,7 @@ export async function getPlanWithEstimates(
   let withErrors = 0
 
   for (const strategy of plan.strategies) {
-    const count = strategy.rowCount ?? 0
+    const count = getPlannedCount(strategy.statistics)
     switch (strategy.strategy) {
       case 'create':
         toCreate = count
@@ -56,7 +65,7 @@ export async function getPlanWithEstimates(
         break
       case 'skip':
         toSkip = count
-        withErrors = strategy.errorCount ?? 0
+        withErrors = count
         break
     }
   }

--- a/packages/lib/src/kb/blocks/__tests__/apply-patch.test.ts
+++ b/packages/lib/src/kb/blocks/__tests__/apply-patch.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/kb/blocks/__tests__/apply-patch.test.ts
 
 import { describe, expect, it } from 'vitest'
-import type { ArticleNodeJSON, BlockJSON } from '../../markdown/types'
+import type { ArticleNodeJSON, BlockJSON, TableJSON, TabsJSON } from '../../markdown/types'
 import { applyPatch, PatchError } from '../apply-patch'
 
 const block = (id: string, text = ''): BlockJSON => ({
@@ -15,6 +15,31 @@ const heading = (id: string, level: number, text: string): BlockJSON => ({
   attrs: { id, blockType: 'heading', level },
   content: [{ type: 'text', text }],
 })
+
+function expectTabs(node: ArticleNodeJSON | undefined): TabsJSON {
+  expect(node?.type).toBe('tabs')
+  if (!node || node.type !== 'tabs') throw new Error('expected a tabs node')
+  return node
+}
+
+function expectTable(node: ArticleNodeJSON | undefined): TableJSON {
+  expect(node?.type).toBe('table')
+  if (!node || node.type !== 'table') throw new Error('expected a table node')
+  return node
+}
+
+function expectBlock(node: ArticleNodeJSON | undefined): BlockJSON {
+  expect(node?.type).toBe('block')
+  if (!node || node.type !== 'block') throw new Error('expected a block node')
+  return node
+}
+
+function expectAt<T>(items: readonly T[], index: number): T {
+  const item = items[index]
+  expect(item).toBeDefined()
+  if (item === undefined) throw new Error(`expected item at index ${index}`)
+  return item
+}
 
 describe('applyPatch — insert', () => {
   it('inserts at start', () => {
@@ -95,10 +120,8 @@ describe('applyPatch — insert', () => {
       anchor: { at: 'startOf', containerId: 'p1' },
       blocks: [block('new')],
     })
-    const tabs = out.content[0]
-    if (tabs.type === 'tabs') {
-      expect(tabs.content[0].content.map((b) => b.attrs.id)).toEqual(['new', 'b-in'])
-    }
+    const tabs = expectTabs(out.content[0])
+    expect(expectAt(tabs.content, 0).content.map((b) => b.attrs.id)).toEqual(['new', 'b-in'])
   })
 
   it('inserts inside a panel via endOf', () => {
@@ -120,10 +143,8 @@ describe('applyPatch — insert', () => {
       anchor: { at: 'endOf', containerId: 'p1' },
       blocks: [block('new')],
     })
-    const tabs = out.content[0]
-    if (tabs.type === 'tabs') {
-      expect(tabs.content[0].content.map((b) => b.attrs.id)).toEqual(['b-in', 'new'])
-    }
+    const tabs = expectTabs(out.content[0])
+    expect(expectAt(tabs.content, 0).content.map((b) => b.attrs.id)).toEqual(['b-in', 'new'])
   })
 
   it('inserts before a block that lives inside a panel', () => {
@@ -145,10 +166,8 @@ describe('applyPatch — insert', () => {
       anchor: { at: 'before', blockId: 'b' },
       blocks: [block('new')],
     })
-    const tabs = out.content[0]
-    if (tabs.type === 'tabs') {
-      expect(tabs.content[0].content.map((b) => b.attrs.id)).toEqual(['a', 'new', 'b', 'c'])
-    }
+    const tabs = expectTabs(out.content[0])
+    expect(expectAt(tabs.content, 0).content.map((b) => b.attrs.id)).toEqual(['a', 'new', 'b', 'c'])
   })
 
   it('throws on missing anchor block', () => {
@@ -230,12 +249,10 @@ describe('applyPatch — replace', () => {
       blockId: 'b1',
       block: heading('ignored-id', 1, 'New title'),
     })
-    const first = out.content[0]
-    if (first.type === 'block') {
-      expect(first.attrs.id).toBe('b1')
-      expect(first.attrs.blockType).toBe('heading')
-      expect(first.attrs.level).toBe(1)
-    }
+    const first = expectBlock(out.content[0])
+    expect(first.attrs.id).toBe('b1')
+    expect(first.attrs.blockType).toBe('heading')
+    expect(first.attrs.level).toBe(1)
   })
 
   it('replaces a block inside a table cell', () => {
@@ -255,12 +272,12 @@ describe('applyPatch — replace', () => {
       blockId: 'cell-b',
       block: heading('x', 2, 'new'),
     })
-    const table = out.content[0]
-    if (table.type === 'table') {
-      const replaced = table.content[0].content[0].content[0]
-      expect(replaced.attrs.id).toBe('cell-b')
-      expect(replaced.attrs.blockType).toBe('heading')
-    }
+    const table = expectTable(out.content[0])
+    const row = expectAt(table.content, 0)
+    const cell = expectAt(row.content, 0)
+    const replaced = expectAt(cell.content, 0)
+    expect(replaced.attrs.id).toBe('cell-b')
+    expect(replaced.attrs.blockType).toBe('heading')
   })
 })
 
@@ -272,11 +289,9 @@ describe('applyPatch — updateText', () => {
       blockId: 'b1',
       content: [{ type: 'text', text: 'new text' }],
     })
-    const first = out.content[0]
-    if (first.type === 'block') {
-      expect(first.content?.[0]).toMatchObject({ type: 'text', text: 'new text' })
-      expect(first.attrs.blockType).toBe('text')
-    }
+    const first = expectBlock(out.content[0])
+    expect(first.content?.[0]).toMatchObject({ type: 'text', text: 'new text' })
+    expect(first.attrs.blockType).toBe('text')
   })
 })
 
@@ -296,11 +311,9 @@ describe('applyPatch — updateAttrs', () => {
         id?: string
       },
     })
-    const first = out.content[0]
-    if (first.type === 'block') {
-      expect(first.attrs.id).toBe('cb1')
-      expect(first.attrs.calloutVariant).toBe('warn')
-    }
+    const first = expectBlock(out.content[0])
+    expect(first.attrs.id).toBe('cb1')
+    expect(first.attrs.calloutVariant).toBe('warn')
   })
 })
 
@@ -327,10 +340,8 @@ describe('applyPatch — delete', () => {
       },
     ]
     const out = applyPatch(doc, { op: 'delete', blockIds: ['b'] })
-    const tabs = out.content[0]
-    if (tabs.type === 'tabs') {
-      expect(tabs.content[0].content.map((b) => b.attrs.id)).toEqual(['a', 'c'])
-    }
+    const tabs = expectTabs(out.content[0])
+    expect(expectAt(tabs.content, 0).content.map((b) => b.attrs.id)).toEqual(['a', 'c'])
   })
 
   it('throws on missing block', () => {

--- a/packages/lib/src/kb/blocks/__tests__/diff-blocks.test.ts
+++ b/packages/lib/src/kb/blocks/__tests__/diff-blocks.test.ts
@@ -17,6 +17,13 @@ const block = (id: string, text = ''): BlockJSON => ({
   content: text ? [{ type: 'text', text }] : [],
 })
 
+function expectAt<T>(items: readonly T[], index: number): T {
+  const item = items[index]
+  expect(item).toBeDefined()
+  if (item === undefined) throw new Error(`expected item at index ${index}`)
+  return item
+}
+
 describe('diffBlocks — top level', () => {
   it('detects added / removed / unchanged', () => {
     const before: ArticleNodeJSON[] = [block('a', 'one'), block('b', 'two')]
@@ -48,7 +55,7 @@ describe('diffBlocks — top level', () => {
     const { blocks, stats } = diffBlocks(before, after)
 
     expect(blocks).toHaveLength(1)
-    const d = blocks[0]
+    const d = expectAt(blocks, 0)
     expect(d.status).toBe('modified')
     expect(d.prevBlock).toBeDefined()
     // 'quick' deleted, 'slow' inserted; surrounding words unchanged.
@@ -126,8 +133,9 @@ describe('diffBlocks — top level', () => {
       content: [{ type: 'text', text: 'hello', marks: [{ type: 'bold' }] }],
     }
     const { blocks } = diffBlocks([before], [after])
-    expect(blocks[0].status).toBe('modified')
-    expect(blocks[0].inline).toEqual([])
+    const diff = expectAt(blocks, 0)
+    expect(diff.status).toBe('modified')
+    expect(diff.inline).toEqual([])
   })
 })
 
@@ -156,8 +164,9 @@ describe('diffBlocks — nested containers', () => {
     const { blocks, stats } = diffBlocks(before, after)
 
     expect(blocks).toHaveLength(1)
-    expect(blocks[0].status).toBe('modified')
-    expect(blocks[0].children?.map((c) => [c.status, c.id])).toEqual([['modified', 'leaf']])
+    const diff = expectAt(blocks, 0)
+    expect(diff.status).toBe('modified')
+    expect(diff.children?.map((c) => [c.status, c.id])).toEqual([['modified', 'leaf']])
     // The container itself defers to its children for counting.
     expect(stats.modified).toBe(1)
   })
@@ -166,15 +175,17 @@ describe('diffBlocks — nested containers', () => {
     const before: ArticleNodeJSON[] = [accordion('ac', [block('x', 'old')])]
     const after: ArticleNodeJSON[] = [accordion('ac', [block('x', 'new')])]
     const { blocks } = diffBlocks(before, after)
-    expect(blocks[0].children?.[0].status).toBe('modified')
+    const diff = expectAt(blocks, 0)
+    expect(expectAt(diff.children ?? [], 0).status).toBe('modified')
   })
 
   it('recurses into a table cell', () => {
     const before: ArticleNodeJSON[] = [table('tbl', [block('cellblk', 'v1')])]
     const after: ArticleNodeJSON[] = [table('tbl', [block('cellblk', 'v2')])]
     const { blocks } = diffBlocks(before, after)
-    expect(blocks[0].status).toBe('modified')
-    expect(blocks[0].children?.map((c) => [c.status, c.id])).toEqual([['modified', 'cellblk']])
+    const diff = expectAt(blocks, 0)
+    expect(diff.status).toBe('modified')
+    expect(diff.children?.map((c) => [c.status, c.id])).toEqual([['modified', 'cellblk']])
   })
 })
 
@@ -190,8 +201,10 @@ describe('diffBlockList — single slot (cell / panel)', () => {
       ['modified', 'c'],
     ])
     // The removed block carries its old side; the modified one carries inline spans.
-    expect(diffs[1].block).toMatchObject({ attrs: { id: 'b' } })
-    expect(diffs[2].inline?.some((s) => s.type === 'ins' && s.text === 'edited')).toBe(true)
+    expect(expectAt(diffs, 1).block).toMatchObject({ attrs: { id: 'b' } })
+    expect(expectAt(diffs, 2).inline?.some((s) => s.type === 'ins' && s.text === 'edited')).toBe(
+      true
+    )
   })
 
   it('treats null / empty slot content as an empty list', () => {

--- a/packages/lib/src/kb/blocks/apply-patch.ts
+++ b/packages/lib/src/kb/blocks/apply-patch.ts
@@ -198,7 +198,13 @@ function applyMove(
     const missing = blockIds.filter((id) => !plucked.has(id))
     throw new PatchError(`blocks not found: ${missing.join(', ')}`, 'block_not_found')
   }
-  const orderedBlocks = blockIds.map((id) => plucked.get(id)!)
+  const orderedBlocks = blockIds.map((id) => {
+    const block = plucked.get(id)
+    if (!block) {
+      throw new PatchError(`block '${id}' not found`, 'block_not_found')
+    }
+    return block
+  })
   // Containers can only land at the top level. Reject if the resolved
   // anchor would put them inside a panel or table cell.
   const hasContainer = orderedBlocks.some((n) => n.type !== 'block')
@@ -325,8 +331,10 @@ function mutateBlockById(
     const idx = arr.findIndex((b) => b.attrs.id === blockId)
     if (idx < 0) return arr
     foundNested = true
+    const existing = arr[idx]
+    if (!existing) return arr
     const out = [...arr]
-    out[idx] = transform(arr[idx])
+    out[idx] = transform(existing)
     return out
   })
   if (!foundNested) {

--- a/packages/lib/src/kb/blocks/diff-blocks.ts
+++ b/packages/lib/src/kb/blocks/diff-blocks.ts
@@ -72,36 +72,40 @@ function diffLevel(oldNodes: ArticleNodeJSON[], newNodes: ArticleNodeJSON[]): Bl
 
   while (oi < oldNodes.length || nj < newNodes.length) {
     const anchor = li < lcs.length ? lcs[li] : undefined
+    const oldNode = oldNodes[oi]
+    const oldId = oldIds[oi]
+    const newNode = newNodes[nj]
+    const newId = newIds[nj]
 
     // Old block that isn't the next stable anchor → removed, or the source
     // slot of a moved block (emitted at its new position, so skip here).
-    if (oi < oldNodes.length && oldIds[oi] !== anchor) {
-      if (newMap.has(oldIds[oi])) {
+    if (oldNode && oldId !== undefined && oldId !== anchor) {
+      if (newMap.has(oldId)) {
         oi++
         continue
       }
-      result.push({ status: 'removed', id: oldIds[oi], block: oldNodes[oi] })
+      result.push({ status: 'removed', id: oldId, block: oldNode })
       oi++
       continue
     }
 
     // New block that isn't the next anchor → added, or a moved block's
     // destination (present on both sides but out of stable order).
-    if (nj < newNodes.length && newIds[nj] !== anchor) {
-      const prev = oldMap.get(newIds[nj])
+    if (newNode && newId !== undefined && newId !== anchor) {
+      const prev = oldMap.get(newId)
       if (prev) {
-        result.push(classify(prev, newNodes[nj], true))
+        result.push(classify(prev, newNode, true))
         nj++
         continue
       }
-      result.push({ status: 'added', id: newIds[nj], block: newNodes[nj] })
+      result.push({ status: 'added', id: newId, block: newNode })
       nj++
       continue
     }
 
     // Both sit on the stable anchor.
-    if (anchor !== undefined) {
-      result.push(classify(oldNodes[oi], newNodes[nj], false))
+    if (anchor !== undefined && oldNode && newNode) {
+      result.push(classify(oldNode, newNode, false))
       oi++
       nj++
       li++
@@ -193,22 +197,35 @@ function lcsIds(a: string[], b: string[]): string[] {
   const m = b.length
   const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
   for (let i = n - 1; i >= 0; i--) {
+    const row = dp[i]
+    const nextRow = dp[i + 1]
+    if (!row || !nextRow) throw new Error('invalid LCS table')
     for (let j = m - 1; j >= 0; j--) {
-      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+      const next = nextRow[j + 1] ?? 0
+      const below = nextRow[j] ?? 0
+      const right = row[j + 1] ?? 0
+      row[j] = a[i] === b[j] ? next + 1 : Math.max(below, right)
     }
   }
   const seq: string[] = []
   let i = 0
   let j = 0
   while (i < n && j < m) {
-    if (a[i] === b[j]) {
-      seq.push(a[i])
+    const aId = a[i]
+    const bId = b[j]
+    if (aId === undefined || bId === undefined) break
+    if (aId === bId) {
+      seq.push(aId)
       i++
       j++
-    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
-      i++
     } else {
-      j++
+      const below = dp[i + 1]?.[j] ?? 0
+      const right = dp[i]?.[j + 1] ?? 0
+      if (below >= right) {
+        i++
+      } else {
+        j++
+      }
     }
   }
   return seq

--- a/packages/lib/src/tasks/date-patterns.ts
+++ b/packages/lib/src/tasks/date-patterns.ts
@@ -57,7 +57,8 @@ const NUMBER_PATTERN = `(\\d+|${TEXT_NUMBER_PATTERN})`
 /**
  * Parse a number from either digit string or text ("3" or "three" → 3)
  */
-function parseNumber(value: string): number {
+function parseNumber(value: string | undefined): number {
+  if (value === undefined) return 0
   const num = parseInt(value, 10)
   if (!Number.isNaN(num)) return num
   return TEXT_NUMBERS[value.toLowerCase()] ?? 0
@@ -142,7 +143,8 @@ function getDaysUntilEndOfWeek(baseDate: Date): number {
 /**
  * Get full weekday name from abbreviation or full name
  */
-function getWeekdayName(input: string): string {
+function getWeekdayName(input: string | undefined): string {
+  if (input === undefined) return ''
   return WEEKDAY_FULL_NAMES[input.toLowerCase()] || input
 }
 
@@ -279,8 +281,8 @@ export const DATE_PATTERNS: DatePattern[] = [
     id: 'next-weekday',
     pattern: new RegExp(`\\bnext\\s+(${WEEKDAY_PATTERN})\\b`, 'i'),
     extractor: (match, baseDate) => {
-      const dayName = match[1].toLowerCase()
-      const targetDay = WEEKDAY_MAP[dayName]
+      const dayName = match[1]?.toLowerCase()
+      const targetDay = dayName === undefined ? undefined : WEEKDAY_MAP[dayName]
       if (targetDay === undefined) return { days: 7 }
       const days = getDaysUntilWeekday(targetDay, baseDate, true)
       return { days }
@@ -299,8 +301,8 @@ export const DATE_PATTERNS: DatePattern[] = [
     id: 'this-weekday',
     pattern: new RegExp(`\\bthis\\s+(${WEEKDAY_PATTERN})\\b`, 'i'),
     extractor: (match, baseDate) => {
-      const dayName = match[1].toLowerCase()
-      const targetDay = WEEKDAY_MAP[dayName]
+      const dayName = match[1]?.toLowerCase()
+      const targetDay = dayName === undefined ? undefined : WEEKDAY_MAP[dayName]
       if (targetDay === undefined) return { days: 0 }
       const days = getDaysUntilWeekday(targetDay, baseDate, false)
       return { days: days > 0 ? days : 0 }
@@ -319,8 +321,8 @@ export const DATE_PATTERNS: DatePattern[] = [
     id: 'by-weekday',
     pattern: new RegExp(`\\b(?:by|on|due)\\s+(${WEEKDAY_PATTERN})\\b`, 'i'),
     extractor: (match, baseDate) => {
-      const dayName = match[1].toLowerCase()
-      const targetDay = WEEKDAY_MAP[dayName]
+      const dayName = match[1]?.toLowerCase()
+      const targetDay = dayName === undefined ? undefined : WEEKDAY_MAP[dayName]
       if (targetDay === undefined) return { days: 7 }
       const days = getDaysUntilWeekday(targetDay, baseDate, false)
       return { days }
@@ -340,8 +342,8 @@ export const DATE_PATTERNS: DatePattern[] = [
     id: 'standalone-weekday',
     pattern: /\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
     extractor: (match, baseDate) => {
-      const dayName = match[1].toLowerCase()
-      const targetDay = WEEKDAY_MAP[dayName]
+      const dayName = match[1]?.toLowerCase()
+      const targetDay = dayName === undefined ? undefined : WEEKDAY_MAP[dayName]
       if (targetDay === undefined) return { days: 7 }
       const days = getDaysUntilWeekday(targetDay, baseDate, false)
       return { days }
@@ -541,8 +543,8 @@ export const DATE_PATTERNS: DatePattern[] = [
     id: 'last-weekday',
     pattern: new RegExp(`\\blast\\s+(${WEEKDAY_PATTERN})\\b`, 'i'),
     extractor: (match, baseDate) => {
-      const dayName = match[1].toLowerCase()
-      const targetDay = WEEKDAY_MAP[dayName]
+      const dayName = match[1]?.toLowerCase()
+      const targetDay = dayName === undefined ? undefined : WEEKDAY_MAP[dayName]
       if (targetDay === undefined) return { days: -7 }
       const currentDay = baseDate.getDay()
       let daysSince = currentDay - targetDay


### PR DESCRIPTION
## Summary
- harden KB patch/diff lookups and test assertions
- guard import-planning write results and derive estimates from strategy statistics
- handle incomplete date-parser regex captures safely

## Validation
- pnpm exec biome check on all 9 changed files
- focused KB blocks tests: 46 passed
- lib TypeScript check: no diagnostics in KB blocks or date patterns; import planning retains one intentional inbox storage-model issue