### PR TITLE
fix: harden rate limiter and rule tests

### DIFF
--- a/packages/lib/src/record-rules/record-rules.test.ts
+++ b/packages/lib/src/record-rules/record-rules.test.ts
@@ -5,12 +5,14 @@
 // vitest (project memory), so the store is exercised at the function level only.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { executeRuleAction } from './actions'
 import { legacyActionTextToDoc } from './client'
+import type { insertRecordRuleRun } from './store'
 import type { CachedRecordRule } from './types'
 
 const h = vi.hoisted(() => ({
-  executeRuleAction: vi.fn(async () => 'ok' as const),
-  insertRecordRuleRun: vi.fn(async () => {}),
+  executeRuleAction: vi.fn<typeof executeRuleAction>(async () => 'ok'),
+  insertRecordRuleRun: vi.fn<typeof insertRecordRuleRun>(async () => undefined),
   fetchResourceById: vi.fn(),
   getCachedResourceFields: vi.fn(async () => [
     { id: 'fld_status', key: 'status', systemAttribute: null },
@@ -52,6 +54,14 @@ const baseCtx = {
   entityInstanceId: 'inst_1',
   source: 'interactive' as const,
   userId: 'user_1',
+}
+
+/** Assert a mock was called before returning its first typed argument tuple. */
+function firstMockCall<TArgs extends unknown[]>(calls: TArgs[]): TArgs {
+  const call = calls[0]
+  expect(call).toBeDefined()
+  if (!call) throw new Error('Expected mock to have been called')
+  return call
 }
 
 beforeEach(() => {
@@ -139,10 +149,10 @@ describe('fireRecordRules', () => {
     await fireRecordRules([r], { ...baseCtx, fieldId: 'fld_status', oldValue: 'a', newValue: 'b' })
 
     expect(h.executeRuleAction).toHaveBeenCalledTimes(2)
-    expect(h.executeRuleAction.mock.calls[0][0]).toMatchObject({ type: 'notify' })
-    expect(h.executeRuleAction.mock.calls[1][0]).toMatchObject({ type: 'set-field' })
+    expect(firstMockCall(h.executeRuleAction.mock.calls)[0]).toMatchObject({ type: 'notify' })
+    expect(h.executeRuleAction.mock.calls[1]?.[0]).toMatchObject({ type: 'set-field' })
     expect(h.insertRecordRuleRun).toHaveBeenCalledTimes(1)
-    const run = h.insertRecordRuleRun.mock.calls[0][1]
+    const run = firstMockCall(h.insertRecordRuleRun.mock.calls)[1]
     expect(run.status).toBe('ok')
     expect(run.outcomes).toHaveLength(2)
   })
@@ -158,7 +168,7 @@ describe('fireRecordRules', () => {
     await fireRecordRules([r], { ...baseCtx })
 
     expect(h.executeRuleAction).toHaveBeenCalledTimes(2)
-    const run = h.insertRecordRuleRun.mock.calls[0][1]
+    const run = firstMockCall(h.insertRecordRuleRun.mock.calls)[1]
     expect(run.status).toBe('partial')
     expect(run.outcomes[0]).toMatchObject({ status: 'failed', error: 'boom' })
     expect(run.outcomes[1]).toMatchObject({ status: 'ok' })
@@ -167,7 +177,7 @@ describe('fireRecordRules', () => {
   it('all actions failing yields status = failed', async () => {
     h.executeRuleAction.mockRejectedValue(new Error('down'))
     await fireRecordRules([rule()], { ...baseCtx })
-    expect(h.insertRecordRuleRun.mock.calls[0][1].status).toBe('failed')
+    expect(firstMockCall(h.insertRecordRuleRun.mock.calls)[1].status).toBe('failed')
   })
 
   it('gates on conditions using the record snapshot', async () => {

--- a/packages/lib/src/utils/rate-limiter/__tests__/integration.test.ts
+++ b/packages/lib/src/utils/rate-limiter/__tests__/integration.test.ts
@@ -66,7 +66,7 @@ describe('Rate Limiter Integration Tests', () => {
       expect(bucket.tryAcquire(1)).toBe(true)
     })
 
-    it('should protect service with circuit breaker', () => {
+    it('should protect service with circuit breaker', async () => {
       const breaker = new CircuitBreaker({
         failureThreshold: 3,
         resetTimeout: 1000,
@@ -83,7 +83,7 @@ describe('Rate Limiter Integration Tests', () => {
 
       // Service fails 3 times and circuit opens
       for (let i = 0; i < 3; i++) {
-        expect(() => breaker.execute(() => Promise.resolve(callService()))).rejects.toThrow()
+        await expect(breaker.execute(() => Promise.resolve(callService()))).rejects.toThrow()
       }
 
       expect(breaker.getState()).toBe('open')
@@ -173,8 +173,9 @@ describe('Rate Limiter Integration Tests', () => {
       expect(attempts).toBe(3)
 
       // Verify backoff delays are increasing
-      if (delays.length >= 2) {
-        expect(delays[1]).toBeGreaterThan(delays[0])
+      const [firstDelay, secondDelay] = delays
+      if (firstDelay !== undefined && secondDelay !== undefined) {
+        expect(secondDelay).toBeGreaterThan(firstDelay)
       }
     })
 
@@ -195,7 +196,7 @@ describe('Rate Limiter Integration Tests', () => {
             { queue: false } // Don't queue, fail immediately
           )
           results.push({ success: true, ...result })
-        } catch (error) {
+        } catch (_error) {
           results.push({ success: false, id: i })
         }
       }
@@ -227,7 +228,7 @@ describe('Rate Limiter Integration Tests', () => {
             { cost: op.cost }
           )
           results.push({ success: true, ...result })
-        } catch (error) {
+        } catch (_error) {
           results.push({ success: false, type: op.type })
         }
       }

--- a/packages/lib/src/utils/rate-limiter/config-manager.ts
+++ b/packages/lib/src/utils/rate-limiter/config-manager.ts
@@ -268,10 +268,11 @@ export class RateLimiterConfigManager {
    */
   private getCircuitBreakerConfig(providerType: IntegrationProviderType) {
     return {
-      failureThreshold: configService.get<number>('CIRCUIT_BREAKER_FAILURE_THRESHOLD', 5),
-      resetTimeout: configService.get<number>('CIRCUIT_BREAKER_RESET_TIMEOUT', 60000),
-      halfOpenRequests: configService.get<number>('CIRCUIT_BREAKER_HALF_OPEN_REQUESTS', 2),
-      monitoringWindow: configService.get<number>('CIRCUIT_BREAKER_MONITORING_WINDOW', 300000),
+      failureThreshold: configService.get<number>('CIRCUIT_BREAKER_FAILURE_THRESHOLD', 5) ?? 5,
+      resetTimeout: configService.get<number>('CIRCUIT_BREAKER_RESET_TIMEOUT', 60000) ?? 60000,
+      halfOpenRequests: configService.get<number>('CIRCUIT_BREAKER_HALF_OPEN_REQUESTS', 2) ?? 2,
+      monitoringWindow:
+        configService.get<number>('CIRCUIT_BREAKER_MONITORING_WINDOW', 300000) ?? 300000,
     }
   }
 
@@ -304,7 +305,7 @@ export class RateLimiterConfigManager {
    * @returns Coalescing window in milliseconds
    */
   getCoalescingWindow(): number {
-    return configService.get<number>('RATE_LIMITER_COALESCING_WINDOW', 100)
+    return configService.get<number>('RATE_LIMITER_COALESCING_WINDOW', 100) ?? 100
   }
 
   /**

--- a/packages/lib/src/utils/rate-limiter/metrics-collector.ts
+++ b/packages/lib/src/utils/rate-limiter/metrics-collector.ts
@@ -326,13 +326,6 @@ export class MetricsCollector {
       })
     }
 
-    if (metrics.errorRate > 0.1) {
-      this.logger.warn('High error rate detected', {
-        errorRate: metrics.errorRate,
-        failedRequests: metrics.failedRequests,
-      })
-    }
-
     // Check error rate
     const errorRate = this.getErrorRate()
     if (errorRate > 0.1) {

--- a/packages/lib/src/utils/rate-limiter/priority-queue.ts
+++ b/packages/lib/src/utils/rate-limiter/priority-queue.ts
@@ -27,7 +27,8 @@ export class PriorityQueue<T = any> {
     if (this.heap.length === 0) return undefined
 
     const result = this.heap[0]
-    const end = this.heap.pop()!
+    const end = this.heap.pop()
+    if (!result || !end) return undefined
 
     if (this.heap.length > 0) {
       this.heap[0] = end
@@ -43,10 +44,12 @@ export class PriorityQueue<T = any> {
    */
   private bubbleUp(index: number): void {
     const element = this.heap[index]
+    if (!element) return
 
     while (index > 0) {
       const parentIndex = Math.floor((index - 1) / 2)
       const parent = this.heap[parentIndex]
+      if (!parent) return
 
       if (this.compare(element, parent) >= 0) break
 
@@ -63,6 +66,7 @@ export class PriorityQueue<T = any> {
   private bubbleDown(index: number): void {
     const length = this.heap.length
     const element = this.heap[index]
+    if (!element) return
 
     while (true) {
       const leftChildIndex = 2 * index + 1
@@ -70,21 +74,25 @@ export class PriorityQueue<T = any> {
       let swapIndex = -1
 
       if (leftChildIndex < length) {
-        if (this.compare(this.heap[leftChildIndex], element) < 0) {
+        const leftChild = this.heap[leftChildIndex]
+        if (leftChild && this.compare(leftChild, element) < 0) {
           swapIndex = leftChildIndex
         }
       }
 
       if (rightChildIndex < length) {
+        const rightChild = this.heap[rightChildIndex]
         const compareWith = swapIndex === -1 ? element : this.heap[swapIndex]
-        if (this.compare(this.heap[rightChildIndex], compareWith) < 0) {
+        if (rightChild && compareWith && this.compare(rightChild, compareWith) < 0) {
           swapIndex = rightChildIndex
         }
       }
 
       if (swapIndex === -1) break
 
-      this.heap[index] = this.heap[swapIndex]
+      const swap = this.heap[swapIndex]
+      if (!swap) return
+      this.heap[index] = swap
       this.heap[swapIndex] = element
       index = swapIndex
     }
@@ -151,10 +159,12 @@ export class PriorityQueue<T = any> {
     if (index === -1) return false
 
     const request = this.heap[index]
+    if (!request) return false
     request.reject(new Error('Request cancelled'))
 
     // Remove the element and reheapify
-    const end = this.heap.pop()!
+    const end = this.heap.pop()
+    if (!end) return false
     if (index < this.heap.length) {
       this.heap[index] = end
       // Try both bubble up and down to maintain heap property
@@ -209,8 +219,11 @@ export class PriorityQueue<T = any> {
     const index = this.heap.findIndex((req) => req.id === id)
     if (index === -1) return false
 
-    const oldPriority = this.heap[index].priority
-    this.heap[index].priority = newPriority
+    const request = this.heap[index]
+    if (!request) return false
+
+    const oldPriority = request.priority
+    request.priority = newPriority
 
     // Reheapify based on whether priority increased or decreased
     if (newPriority < oldPriority) {

--- a/packages/lib/src/utils/rate-limiter/provider-configs.ts
+++ b/packages/lib/src/utils/rate-limiter/provider-configs.ts
@@ -199,29 +199,6 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
     },
   },
 
-  [IntegrationProviderTypeEnum.telegram]: {
-    // Telegram Bot API limits
-    requestsPerSecond: 30, // 30 messages per second per bot
-    requestsPerMinute: 1000,
-    concurrentRequests: 10,
-    batchSize: 100,
-
-    contexts: {
-      messages: {
-        maxRequests: 30,
-        perInterval: 1000,
-      },
-      bulk: {
-        maxRequests: 20, // Bulk notifications
-        perInterval: 60000,
-      },
-      media: {
-        maxRequests: 10,
-        perInterval: 1000,
-      },
-    },
-  },
-
   [IntegrationProviderTypeEnum.shopify]: {
     // Shopify API limits (REST)
     requestsPerSecond: 2, // 2 requests per second
@@ -244,29 +221,6 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
       },
       bulk: {
         maxRequests: 10,
-        perInterval: 60000,
-      },
-    },
-  },
-
-  [IntegrationProviderTypeEnum.sendgrid]: {
-    // SendGrid API limits
-    requestsPerSecond: 600,
-    requestsPerMinute: 3000,
-    concurrentRequests: 10,
-    batchSize: 1000, // Batch send limit
-
-    contexts: {
-      send: {
-        maxRequests: 600,
-        perInterval: 1000,
-      },
-      batch: {
-        maxRequests: 100,
-        perInterval: 60000,
-      },
-      stats: {
-        maxRequests: 100,
         perInterval: 60000,
       },
     },


### PR DESCRIPTION
## Summary
- type record-rule test mocks and assertions against real function signatures
- guard priority-queue invariants and rate-limiter configuration defaults
- remove stale unsupported provider configurations and repair integration assertions

## Validation
- pnpm exec biome check on all 6 changed files
- pnpm vitest run record-rules and rate-limiter integration tests (24 passed)
- filtered lib TypeScript check: no diagnostics in either target area