### PR TITLE
fix: report dropped filter conditions + gate single-host field-value reads

### DIFF
--- a/apps/web/src/components/dynamic-table/components/dropped-filters-notice.test.tsx
+++ b/apps/web/src/components/dynamic-table/components/dropped-filters-notice.test.tsx
@@ -1,0 +1,52 @@
+// apps/web/src/components/dynamic-table/components/dropped-filters-notice.test.tsx
+//
+// The notice is the only place a user ever learns that the list they are looking
+// at is WIDER than the filters they set. Two properties are worth pinning:
+//
+//   1. It is silent on a clean list. Every records table and the KB articles
+//      table mount this on every render; a false positive would be worse than
+//      the silence it replaces.
+//   2. The count it renders is the UNCAPPED one. The array is server-capped, so
+//      counting the array would make the warning itself understate the problem —
+//      the exact failure mode this whole change exists to end.
+
+import type { DroppedFilterNotice } from '@auxx/lib/resources/client'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, expect, it } from 'vitest'
+import { DroppedFiltersNotice } from './dropped-filters-notice'
+
+const notice = (n: number): DroppedFilterNotice => ({
+  conditionId: `cond_${n}`,
+  fieldRef: `article:cf_${n}`,
+  operator: 'equals',
+  reason: 'unresolved-field-or-operator',
+})
+
+/** `TooltipProvider` mirrors the app shell (`global/auxx-app-providers.tsx`). */
+const renderInShell = (ui: ReactElement) => render(<TooltipProvider>{ui}</TooltipProvider>)
+
+describe('DroppedFiltersNotice', () => {
+  it('renders nothing when no filter was dropped', () => {
+    const { container } = renderInShell(
+      <DroppedFiltersNotice droppedConditions={[]} droppedConditionCount={0} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('names one dropped filter in the singular', () => {
+    renderInShell(
+      <DroppedFiltersNotice droppedConditions={[notice(1)]} droppedConditionCount={1} />
+    )
+    expect(screen.getByText('1 filter was ignored')).toBeInTheDocument()
+  })
+
+  it('reports the UNCAPPED count, not the length of the capped array', () => {
+    // 25 delivered, 40 dropped. Rendering "25" would be the same class of quiet
+    // undercount the notice exists to surface.
+    const delivered = Array.from({ length: 25 }, (_, i) => notice(i))
+    renderInShell(<DroppedFiltersNotice droppedConditions={delivered} droppedConditionCount={40} />)
+    expect(screen.getByText('40 filters were ignored')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/dynamic-table/components/dropped-filters-notice.tsx
+++ b/apps/web/src/components/dynamic-table/components/dropped-filters-notice.tsx
@@ -1,0 +1,92 @@
+// apps/web/src/components/dynamic-table/components/dropped-filters-notice.tsx
+'use client'
+
+import type { DroppedFilterNotice, ResourceField } from '@auxx/lib/resources/client'
+import { isResourceFieldId, parseResourceFieldId } from '@auxx/types/field'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { FunnelX } from 'lucide-react'
+
+/**
+ * Human sentence per drop reason. Deliberately vague about the *mechanism* —
+ * there is nothing the user can do about a cuid-vs-registry-key mismatch, and
+ * the actionable half ("this list is showing more than you asked for") is the
+ * same either way.
+ */
+const REASON_TEXT: Record<DroppedFilterNotice['reason'], string> = {
+  'unresolved-field-or-operator': 'this field or operator could not be applied',
+  'unresolved-value-source': 'its value could not be resolved',
+}
+
+interface DroppedFiltersNoticeProps {
+  /** Server-capped list of conditions that produced no SQL. */
+  droppedConditions: DroppedFilterNotice[]
+  /** Uncapped total — may exceed `droppedConditions.length`. */
+  droppedConditionCount: number
+  /** Resource fields, used to turn a field id into the label the user picked. */
+  fields?: ResourceField[]
+}
+
+/**
+ * Quiet footer affordance: "1 filter ignored".
+ *
+ * Exists because the list query **fails open** — a filter condition the builder
+ * cannot compile is dropped and the query runs anyway, so the list silently
+ * widens. That is the right behaviour for saved views and stored dashboard
+ * widgets (a view naming a retired field must still render), but it made a whole
+ * class of bugs invisible: KB free-text search matching everything, the KB
+ * Tag/Status/Kind filters matching everything, dashboard thread widgets returning
+ * org-wide lists. Every one of those was found by accident.
+ *
+ * It is **not** an error state and there is nothing for the user to fix, so this
+ * is a muted inline label with the detail on hover — not a banner, not a toast,
+ * and not a modal. Rendering nothing when the list is clean is the common case.
+ */
+export function DroppedFiltersNotice({
+  droppedConditions,
+  droppedConditionCount,
+  fields,
+}: DroppedFiltersNoticeProps) {
+  // Silence is the overwhelmingly common case, and it is load-bearing: this
+  // mounts under every records table on every render.
+  if (!droppedConditionCount) return null
+
+  const label = (ref: string | string[]): string => {
+    // Relationship paths arrive as a hop array; the last hop is the field the
+    // user actually chose, which is the one worth naming.
+    const leaf = Array.isArray(ref) ? (ref[ref.length - 1] ?? '') : ref
+    // A cuid falls through as itself — which is exactly the visible symptom of
+    // the tracked cuid-vs-registry-key resolution bug on the KB filters, and is
+    // still more useful than saying nothing.
+    const fieldId = isResourceFieldId(leaf) ? parseResourceFieldId(leaf).fieldId : leaf
+    const field = fields?.find((f) => f.id === fieldId || f.key === fieldId)
+    return field?.name || field?.label || fieldId || 'Unknown field'
+  }
+
+  return (
+    <SimpleTooltip
+      side='top'
+      contentComponent={
+        <div className='max-w-xs space-y-1'>
+          <p className='font-medium'>This list is showing more than your filters ask for.</p>
+          <ul className='space-y-0.5'>
+            {droppedConditions.map((d) => (
+              <li key={d.conditionId}>
+                <span className='font-medium'>{label(d.fieldRef)}</span> {d.operator} — was not
+                applied because {REASON_TEXT[d.reason]}.
+              </li>
+            ))}
+          </ul>
+          {droppedConditionCount > droppedConditions.length && (
+            <p>and {droppedConditionCount - droppedConditions.length} more.</p>
+          )}
+        </div>
+      }>
+      <span className='ml-2 inline-flex cursor-default items-center gap-1 text-muted-foreground'>
+        <FunnelX className='size-3.5' />
+        {droppedConditionCount === 1
+          ? '1 filter was ignored'
+          : `${droppedConditionCount} filters were ignored`}
+      </span>
+    </SimpleTooltip>
+  )
+}

--- a/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
@@ -26,6 +26,7 @@ import type {
   StoredFieldValue,
 } from '~/components/resources/store/field-value-store'
 import { CustomFieldCell } from './components/custom-field-cell'
+import { DroppedFiltersNotice } from './components/dropped-filters-notice'
 import { DynamicTableFooter } from './components/dynamic-table-footer'
 import { getIconForFieldType } from './custom-field-column-factory'
 import { DynamicView } from './dynamic-view'
@@ -199,6 +200,8 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
   const {
     records,
     recordIds: listIds,
+    droppedConditions,
+    droppedConditionCount,
     isLoading: instancesLoading,
     isLoadingRecords,
     isFetchingNextPage,
@@ -396,6 +399,13 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
               {records.length}{' '}
               {records.length === 1 ? resource.label.toLowerCase() : resource.plural.toLowerCase()}
               {hasNextPage && <span className='ml-2'>(more available)</span>}
+              {/* Sits next to the count on purpose: the count is exactly what a
+                  dropped filter inflates. Renders nothing in the normal case. */}
+              <DroppedFiltersNotice
+                droppedConditions={droppedConditions}
+                droppedConditionCount={droppedConditionCount}
+                fields={resource.fields}
+              />
             </div>
             {isFetchingNextPage && (
               <div className='flex items-center gap-2'>

--- a/apps/web/src/components/resources/hooks/use-record-list.ts
+++ b/apps/web/src/components/resources/hooks/use-record-list.ts
@@ -1,7 +1,7 @@
 // apps/web/src/components/resources/hooks/use-record-list.ts
 
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
-import { toRecordId } from '@auxx/lib/resources/client'
+import { type DroppedFilterNotice, toRecordId } from '@auxx/lib/resources/client'
 import { useCallback, useEffect, useMemo } from 'react'
 import { api } from '~/trpc/react'
 import {
@@ -16,6 +16,9 @@ import { useNormalizedDefinitionId } from '../utils/normalize-record-id'
 
 /** Stable empty array for default return */
 const EMPTY_IDS: string[] = []
+
+/** Stable empty array so a clean list never hands consumers a fresh identity. */
+const EMPTY_DROPPED: DroppedFilterNotice[] = []
 
 interface UseRecordListOptions {
   /** EntityDefinition UUID. Alias forms (entityType/apiSlug) are normalized internally. */
@@ -39,6 +42,18 @@ interface UseRecordListOptions {
 interface UseRecordListResult<T = RecordMeta> {
   /** Record IDs for current page - rows use useRecord(id) individually */
   recordIds: string[]
+  /**
+   * Filter conditions the server could not compile and therefore did NOT apply.
+   * Empty in the normal case.
+   *
+   * **Non-empty means this list is WIDER than the filters say it is.** The query
+   * lane fails open on purpose so a saved view naming a retired field still
+   * renders; this is the channel that stops that being invisible. Render it
+   * quietly — it is not an error state and there is nothing for the user to fix.
+   */
+  droppedConditions: DroppedFilterNotice[]
+  /** Uncapped total behind {@link droppedConditions} (the array is server-capped). */
+  droppedConditionCount: number
   /** Resolved records from record store (may be partial while loading) */
   records: T[]
   /** True if records are still being fetched */
@@ -173,6 +188,10 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
       total: data.pages[0]?.total ?? allIds.length,
       fetchedAt: Date.now(),
       nextCursor,
+      // Same story as `total`: every page carries the identical drop diagnostics
+      // (they come from the same filter build), so the first page is the source.
+      droppedConditions: data.pages[0]?.droppedConditions,
+      droppedConditionCount: data.pages[0]?.droppedConditionCount,
     })
 
     // Queue record fetches for IDs not in cache
@@ -215,6 +234,16 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
   )
   const total = cachedList?.total ?? data?.pages?.[0]?.total ?? 0
 
+  // Read through the store cache exactly like `ids`/`total` do — the cache is
+  // served INSTEAD of the query for 5 minutes, so sourcing this from `data` alone
+  // would drop the warning on remount while the list stayed just as wide.
+  const droppedConditions =
+    (cachedList ? cachedList.droppedConditions : data?.pages?.[0]?.droppedConditions) ??
+    EMPTY_DROPPED
+  const droppedConditionCount =
+    (cachedList ? cachedList.droppedConditionCount : data?.pages?.[0]?.droppedConditionCount) ??
+    droppedConditions.length
+
   // ─── RESOLVE RECORDS FROM RECORD STORE ─────────────────────────────────
   // Subscribe to record cache for this entity definition
   const recordCache = useRecordStore((s) => s.records[entityDefinitionId])
@@ -245,6 +274,8 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
 
   return {
     recordIds,
+    droppedConditions,
+    droppedConditionCount,
     records,
     isLoadingRecords,
     listKey,

--- a/apps/web/src/components/resources/store/record-store.ts
+++ b/apps/web/src/components/resources/store/record-store.ts
@@ -4,6 +4,7 @@ import '~/lib/immer-config' // Enables Map/Set support for immer
 import type { Rung } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import {
+  type DroppedFilterNotice,
   parseRecordId,
   type RecordId,
   type RecordSourceChip,
@@ -75,6 +76,16 @@ interface ListCache {
   fetchedAt: number
   /** Presence marker for "more pages exist" (the real cursor is the page offset) */
   nextCursor: string | null
+  /**
+   * Filters the server could not compile and therefore did NOT apply, from
+   * `record.listFiltered`. Cached alongside the ids on purpose: this cache is
+   * served *instead of* the query for 5 minutes, so leaving the notice on the
+   * query response alone would make the warning vanish on the next mount while
+   * the list stayed just as wrong.
+   */
+  droppedConditions?: DroppedFilterNotice[]
+  /** Uncapped total behind {@link ListCache.droppedConditions}. */
+  droppedConditionCount?: number
 }
 
 export interface RecordStoreState {

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -666,6 +666,19 @@ export const recordRouter = createTRPCRouter({
    *
    * One call = one page (`LIMIT n + 1 OFFSET m`); `hasMore` is the probe row.
    * `total` comes back on the first page only — the client keeps it.
+   *
+   * **`droppedConditions` / `droppedConditionCount` ride on the page** whenever a
+   * filter could not be compiled into SQL. They are optional and additive: this
+   * lane fails open by design (a saved view naming a retired field still
+   * renders), so the page is simply *wider* than the caller asked for and no
+   * error is raised. A surface that wants to be honest about that renders the
+   * notice; a surface that ignores it behaves exactly as before. The AI boundary
+   * does the opposite and refuses — see `inspectFilterConditions` in
+   * `@auxx/lib/resources`.
+   *
+   * The payload is the caller's own `conditionId` / `fieldId` / `operator` plus a
+   * coarse reason, capped at `MAX_REPORTED_DROPPED_CONDITIONS`. No SQL, no column
+   * or table names, no builder internals.
    */
   listFiltered: capabilityProcedure
     .input(

--- a/packages/lib/src/field-values/__tests__/single-host-mail-lens.test.ts
+++ b/packages/lib/src/field-values/__tests__/single-host-mail-lens.test.ts
@@ -1,0 +1,239 @@
+// packages/lib/src/field-values/__tests__/single-host-mail-lens.test.ts
+
+/**
+ * `getValue` / `getValues` — the single-entity siblings of `batchGetValues` —
+ * apply the SAME mail lens gate (`mail-lens-gate.ts`), so the two shapes cannot
+ * drift. The batch gate's own unit tests live in `mail-lens-gate.test.ts`; this
+ * file proves the wiring: a viewer below `identity` cannot read a thread's
+ * subject through either function, a `metadata` viewer keeps the metadata-tier
+ * fields, and non-mail / no-capability callers pay nothing and change nothing.
+ */
+
+import type { RecordId } from '@auxx/types/resource'
+import { toRecordId } from '@auxx/types/resource'
+
+const { findCachedResource, getCachedUserInstanceGrants, getThreadLensBatch } = vi.hoisted(() => ({
+  findCachedResource: vi.fn(),
+  getCachedUserInstanceGrants: vi.fn(),
+  getThreadLensBatch: vi.fn(),
+}))
+
+// Partial-mock the cache barrel: it is DB/Redis-backed, and a wholesale
+// replacement would drop the entries `field-value-helpers` reaches. Only these
+// two are on the code path under test.
+vi.mock('../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  findCachedResource,
+  getCachedUserInstanceGrants,
+}))
+vi.mock('../../permissions/visibility/thread-lens', () => ({ getThreadLensBatch }))
+
+import type { Lens } from '../../permissions/visibility/lens'
+import type { CachedField, FieldValueContext } from '../field-value-helpers'
+import { getValue, getValues } from '../field-value-queries'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const THREAD_ID = 'thr_a'
+const THREAD = toRecordId('thread', THREAD_ID)
+const CONTACT = toRecordId('contact', 'con_1')
+
+/** Field ids as the FieldValue rows store them, and their resource keys. */
+const SUBJECT = 'fld_subject'
+const TAGS = 'fld_tags'
+
+const THREAD_RESOURCE = {
+  id: 'thread',
+  fields: [
+    { id: SUBJECT, key: 'subject' },
+    { id: TAGS, key: 'tags' },
+  ],
+}
+
+/** Rows are whatever `orderBy` resolves to — the builder shape is not asserted. */
+function fakeDb(rows: unknown[]): FieldValueContext['db'] {
+  const chain: Record<string, unknown> = {}
+  for (const method of ['select', 'from', 'innerJoin', 'where']) {
+    chain[method] = () => chain
+  }
+  chain.orderBy = () => Promise.resolve(rows)
+  return chain as unknown as FieldValueContext['db']
+}
+
+function context(overrides: Partial<FieldValueContext> = {}): FieldValueContext {
+  return {
+    db: fakeDb([]),
+    organizationId: ORG,
+    userId: USER,
+    fieldCache: new Map(),
+    batchRelationshipValidationCache: new Map(),
+    validator: {} as FieldValueContext['validator'],
+    bypassFieldGuards: new Set(),
+    capabilities: {} as FieldValueContext['capabilities'],
+    ...overrides,
+  }
+}
+
+/** A stored TEXT value — what a `thread:subject` read would hand back. */
+function textRow(fieldId: string, value: string) {
+  return {
+    id: `fv_${fieldId}`,
+    entityId: THREAD_ID,
+    fieldId,
+    sortKey: 0,
+    valueText: value,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  }
+}
+
+const TEXT_FIELD = { id: SUBJECT, type: 'TEXT', options: {} } as unknown as CachedField
+
+function lensIs(lens: Lens | null) {
+  getThreadLensBatch.mockResolvedValue(
+    lens === null ? new Map<string, Lens>() : new Map<string, Lens>([[THREAD_ID, lens]])
+  )
+}
+
+beforeEach(() => {
+  findCachedResource.mockReset().mockImplementation(async (_org: string, key: string) => {
+    return key === 'thread' ? THREAD_RESOURCE : null
+  })
+  getCachedUserInstanceGrants.mockReset().mockResolvedValue({ userId: USER })
+  getThreadLensBatch.mockReset().mockResolvedValue(new Map<string, Lens>())
+})
+
+describe('getValue — mail lens gate', () => {
+  it('withholds a thread subject from a metadata-lens viewer', async () => {
+    lensIs('metadata')
+    const ctx = context({ db: fakeDb([textRow(SUBJECT, 'Refund for order 1042')]) })
+
+    // `subject` is unlisted in the metadata allowlist ⇒ `identity`.
+    expect(await getValue(ctx, { recordId: THREAD, fieldId: SUBJECT }, TEXT_FIELD)).toBeNull()
+  })
+
+  it('withholds it from a viewer with no lens on the thread at all', async () => {
+    lensIs(null)
+    const ctx = context({ db: fakeDb([textRow(SUBJECT, 'Refund for order 1042')]) })
+
+    expect(await getValue(ctx, { recordId: THREAD, fieldId: SUBJECT }, TEXT_FIELD)).toBeNull()
+  })
+
+  it('serves the subject at identity', async () => {
+    lensIs('identity')
+    const ctx = context({ db: fakeDb([textRow(SUBJECT, 'Refund for order 1042')]) })
+
+    const result = await getValue(ctx, { recordId: THREAD, fieldId: SUBJECT }, TEXT_FIELD)
+    expect(result).toMatchObject({ type: 'text', value: 'Refund for order 1042' })
+  })
+
+  it('keeps a metadata-tier field for a metadata viewer', async () => {
+    lensIs('metadata')
+    const ctx = context({ db: fakeDb([textRow(TAGS, 'billing')]) })
+
+    const result = await getValue(ctx, { recordId: THREAD, fieldId: TAGS }, {
+      ...TEXT_FIELD,
+      id: TAGS,
+    } as CachedField)
+    expect(result).toMatchObject({ type: 'text', value: 'billing' })
+  })
+
+  it('withholds a message host outright, without reading a lens', async () => {
+    const ctx = context({ db: fakeDb([textRow('fld_textPlain', 'the raw email body')]) })
+
+    const message = toRecordId('message', 'msg_1') as RecordId
+    expect(
+      await getValue(ctx, { recordId: message, fieldId: 'fld_textPlain' }, TEXT_FIELD)
+    ).toBeNull()
+    expect(getThreadLensBatch).not.toHaveBeenCalled()
+  })
+
+  it('leaves a non-mail host untouched and pays no I/O', async () => {
+    const ctx = context({ db: fakeDb([textRow('fld_email', 'ada@acme.io')]) })
+
+    const result = await getValue(ctx, { recordId: CONTACT, fieldId: 'fld_email' }, TEXT_FIELD)
+    expect(result).toMatchObject({ type: 'text', value: 'ada@acme.io' })
+    expect(getThreadLensBatch).not.toHaveBeenCalled()
+    expect(findCachedResource).not.toHaveBeenCalled()
+  })
+
+  it('does not gate an internal caller — no capabilities, no lens read', async () => {
+    lensIs('metadata')
+    const ctx = context({
+      capabilities: undefined,
+      db: fakeDb([textRow(SUBJECT, 'Refund for order 1042')]),
+    })
+
+    const result = await getValue(ctx, { recordId: THREAD, fieldId: SUBJECT }, TEXT_FIELD)
+    expect(result).toMatchObject({ type: 'text', value: 'Refund for order 1042' })
+    expect(getThreadLensBatch).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when enforcement is on but no viewer is resolvable', async () => {
+    const ctx = context({
+      userId: undefined,
+      db: fakeDb([textRow(SUBJECT, 'Refund for order 1042')]),
+    })
+
+    expect(await getValue(ctx, { recordId: THREAD, fieldId: SUBJECT }, TEXT_FIELD)).toBeNull()
+    expect(getThreadLensBatch).not.toHaveBeenCalled()
+  })
+})
+
+describe('getValues — mail lens gate', () => {
+  /** `getValues` joins CustomField, so its rows are `{ FieldValue, CustomField }`. */
+  function joined(fieldId: string, value: string) {
+    return {
+      FieldValue: textRow(fieldId, value),
+      CustomField: { id: fieldId, type: 'TEXT', options: {} },
+    }
+  }
+
+  it('drops the subject but keeps the tags for a metadata viewer', async () => {
+    lensIs('metadata')
+    const ctx = context({
+      db: fakeDb([joined(SUBJECT, 'Refund for order 1042'), joined(TAGS, 'billing')]),
+    })
+
+    const values = await getValues(ctx, { recordId: THREAD })
+
+    expect(values.has(SUBJECT)).toBe(false)
+    expect(values.get(TAGS)).toMatchObject({ type: 'text', value: 'billing' })
+  })
+
+  it('returns nothing at all for an invisible thread', async () => {
+    lensIs(null)
+    const ctx = context({ db: fakeDb([joined(TAGS, 'billing')]) })
+
+    expect(await getValues(ctx, { recordId: THREAD })).toEqual(new Map())
+  })
+
+  it('serves both fields at identity', async () => {
+    lensIs('identity')
+    const ctx = context({
+      db: fakeDb([joined(SUBJECT, 'Refund for order 1042'), joined(TAGS, 'billing')]),
+    })
+
+    const values = await getValues(ctx, { recordId: THREAD })
+    expect([...values.keys()].sort()).toEqual([TAGS, SUBJECT].sort())
+  })
+
+  it('leaves a non-mail host untouched and pays no I/O', async () => {
+    const ctx = context({ db: fakeDb([joined('fld_email', 'ada@acme.io')]) })
+
+    const values = await getValues(ctx, { recordId: CONTACT })
+    expect(values.get('fld_email')).toMatchObject({ type: 'text', value: 'ada@acme.io' })
+    expect(getThreadLensBatch).not.toHaveBeenCalled()
+  })
+
+  it('does not gate an internal caller', async () => {
+    lensIs('metadata')
+    const ctx = context({
+      capabilities: undefined,
+      db: fakeDb([joined(SUBJECT, 'Refund for order 1042')]),
+    })
+
+    const values = await getValues(ctx, { recordId: THREAD })
+    expect(values.get(SUBJECT)).toMatchObject({ type: 'text', value: 'Refund for order 1042' })
+  })
+})

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -34,7 +34,7 @@ import {
   rowToTypedValue,
   validateFieldReferences,
 } from './field-value-helpers'
-import { resolveMailLensGate } from './mail-lens-gate'
+import { resolveMailHostGate, resolveMailLensGate } from './mail-lens-gate'
 import {
   batchFetchSystemRelationships,
   isVirtualField,
@@ -75,6 +75,16 @@ export async function getValue(
   cachedField?: CachedField
 ): Promise<TypedFieldValue | TypedFieldValue[] | null> {
   const { entityInstanceId } = parseRecordId(params.recordId)
+
+  // MAIL enforcement — the single-host twin of the gate `batchGetValues` applies
+  // (see {@link resolveMailHostGate}). `thread` / `message` are
+  // `NON_RECORD_DEF_SLUGS`, so the def-presence test this path's siblings rely on
+  // passes them for every member. `null` is already this function's "no value"
+  // answer, so a withheld host or field blanks rather than throws — every caller
+  // (the mutation re-reads, the geocoding stale-write guard, the dispatch and
+  // money readers) already handles it. Non-mail hosts short-circuit with no I/O.
+  const mailGate = await resolveMailHostGate(ctx, params.recordId)
+  if (mailGate && (mailGate.hidden || !mailGate.admitsField(params.fieldId))) return null
 
   // Use cached field if provided (avoids redundant CustomField join)
   const field = cachedField ?? (await getField(ctx, params.fieldId))
@@ -125,6 +135,13 @@ export async function getValues(
 ): Promise<Map<string, TypedFieldValue | TypedFieldValue[]>> {
   const { entityInstanceId } = parseRecordId(params.recordId)
 
+  // MAIL enforcement — see {@link getValue}. `params.fieldIds` is optional, so
+  // this path can be asked for EVERY field a thread has; the per-field test runs
+  // over the grouped results below rather than over the request. An empty Map is
+  // already the legal "nothing stored" answer, so a withheld host blanks.
+  const mailGate = await resolveMailHostGate(ctx, params.recordId)
+  if (mailGate?.hidden) return new Map()
+
   const query = ctx.db
     .select()
     .from(schema.FieldValue)
@@ -151,6 +168,8 @@ export async function getValues(
 
   // Convert and store results
   for (const [fieldId, fieldRows] of groupedByField) {
+    // FIELD visibility: drop values above the viewer's lens on this thread.
+    if (mailGate && !mailGate.admitsField(fieldId)) continue
     const fieldType = fieldRows[0]!.CustomField.type as FieldType
     const fieldOptions = fieldRows[0]!.CustomField.options as FieldOptions | undefined
     const fieldValueRows = fieldRows.map((r) => r.FieldValue as unknown as FieldValueRow)

--- a/packages/lib/src/field-values/mail-lens-gate.ts
+++ b/packages/lib/src/field-values/mail-lens-gate.ts
@@ -224,6 +224,104 @@ export async function resolveMailLensGate(
 }
 
 /**
+ * The gate for a SINGLE-host read — `getValue` / `getValues`. `null` when it does
+ * not apply, on exactly the same two triggers as {@link resolveMailLensGate}.
+ */
+export interface MailHostGate {
+  /**
+   * The host is withheld in full: a `message` (refused outright — see
+   * {@link MAIL_DEF_KEYS}), or a thread the viewer holds below `metadata`.
+   * Return the caller's empty answer without issuing the read, so nothing about
+   * the row — not even its existence — is observable.
+   */
+  hidden: boolean
+  /**
+   * Whether the viewer's lens on this host admits the field. **Synchronous**:
+   * the whole `fieldId | fieldKey → Lens` map is built once when the gate is,
+   * so `getValues` can filter a result set of unknown size without a lookup per
+   * field. Accepts either the stored row id or the static key, because
+   * `getValue`/`getValues` are keyed on `FieldValue.fieldId` while the
+   * classification is keyed on the resource field's `key`.
+   */
+  admitsField(fieldId: string): boolean
+}
+
+/** The one shared "withheld" answer — no per-call allocation, no I/O. */
+const WITHHELD_HOST: MailHostGate = { hidden: true, admitsField: () => false }
+
+/**
+ * {@link resolveMailLensGate}'s single-entity sibling, for the two reads that
+ * take one `recordId` instead of a list.
+ *
+ * `getValue` / `getValues` read `FieldValue` rows only — they never reach
+ * `resolveSystemTableFields` or the virtual-field resolvers, so what they expose
+ * on a thread today is the `FieldValue`-backed slice (`tags`, the `visit*`
+ * visitor telemetry) rather than `subject` or `body`. They are gated anyway, and
+ * with the *same* classification: they are not router-exposed today, and the
+ * next router that exposes them must not have to rediscover that
+ * `hasDefPresence` authorizes nothing for `thread`. The two functions share the
+ * `FieldValue.fieldId` keyspace with the batch path, so a divergent answer here
+ * would be a second mechanism to keep in sync.
+ *
+ * **Cost.** Nothing when it does not apply: the applicability test is one
+ * `Map.get` on the parsed def part, no I/O, so every non-mail caller
+ * (`UnifiedCrudHandler.getFieldValues`, `captureEventData`, the dispatch and
+ * money readers, the geocoding stale-write guard, and `field-value-mutations`'
+ * own re-reads) is byte-identical. When it DOES apply: one cached
+ * `userInstanceGrants` read, one single-id {@link getThreadLensBatch} `Thread`
+ * query, and one cache-only `findCachedResource` — **per call**, since a
+ * single-entity read has nothing to amortise across. That is accepted rather
+ * than cached: no caller reaches this on a thread host today (thread and message
+ * are blocked from the generic record path), so there is no N+1 to solve, and a
+ * cache here would be a guess.
+ */
+export async function resolveMailHostGate(
+  ctx: FieldValueContext,
+  recordId: RecordId
+): Promise<MailHostGate | null> {
+  // Same trigger as the batch gate: no capabilities ⇒ internal caller.
+  if (!ctx.capabilities) return null
+
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  const kind = MAIL_DEF_KEYS.get(entityDefinitionId) ?? null
+  if (kind === null) return null
+  if (kind === MESSAGE_DEF) return WITHHELD_HOST
+
+  // Fail closed on a capability-scoped call with no viewer, exactly as the batch
+  // gate does — a caller that half-configured enforcement gets nothing.
+  const lens: Lens = ctx.userId
+    ? ((
+        await getThreadLensBatch(
+          ctx.db,
+          ctx.organizationId,
+          await getCachedUserInstanceGrants(ctx.userId, ctx.organizationId),
+          [entityInstanceId]
+        )
+      ).get(entityInstanceId) ?? 'none')
+    : 'none'
+
+  // `metadata` is where a thread becomes visible at all; below it the whole host
+  // is withheld rather than blanked field by field.
+  if (!satisfiesRung(lens, 'metadata')) return WITHHELD_HOST
+
+  const resource = await findCachedResource(ctx.organizationId, entityDefinitionId)
+  const minLensByFieldKey = new Map<string, Lens>()
+  for (const field of resource?.fields ?? []) {
+    const need = threadFieldMinLens(field.key)
+    minLensByFieldKey.set(field.id, need)
+    minLensByFieldKey.set(field.key, need)
+  }
+
+  return {
+    hidden: false,
+    // An unresolvable field id is unclassified, and unclassified means
+    // `identity` — the same default {@link threadFieldMinLens} applies, so a
+    // field added tomorrow hides from `metadata` viewers instead of leaking.
+    admitsField: (fieldId) => satisfiesRung(lens, minLensByFieldKey.get(fieldId) ?? 'identity'),
+  }
+}
+
+/**
  * The minimum lens each requested reference needs, keyed by {@link refKey}.
  *
  * A PATH is keyed on its first hop: that hop is the only segment that reads

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -18,6 +18,10 @@ export {
   type EntityDefinitionType,
   isEntityDefinitionType,
 } from '@auxx/types/resource'
+// Filter diagnostics returned by `record.listFiltered`. Type-only re-export, so
+// the server-side module it lives in is erased and never enters a client bundle
+// (same treatment as the picker types below).
+export type { DroppedFilterNotice } from './crud/unified-handler-queries'
 export type { MergeFieldInput, MergeFieldResult } from './merge/client'
 // Merge utilities (client-safe)
 export { mergeFieldValue } from './merge/client'

--- a/packages/lib/src/resources/crud/__tests__/list-filtered-dropped-conditions.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/list-filtered-dropped-conditions.test.ts
@@ -1,0 +1,266 @@
+// packages/lib/src/resources/crud/__tests__/list-filtered-dropped-conditions.test.ts
+//
+// `ListFilteredResult.droppedConditions` — the observability channel for this
+// lane's deliberate fail-open.
+//
+// A filter condition the builder cannot compile is DROPPED and the query runs
+// anyway, so the list silently widens. That is the right call for saved views,
+// the mail list, unread counts and the workflow Find node, all of which depend on
+// `baseScope` for a genuine empty filter — but it made the failure invisible by
+// construction, and four separate fail-open bugs hid behind it (KB free-text
+// search, the KB Tag/Status/Kind filters, dashboard thread widgets, and an
+// unknown operator compiling to `eq(col, value)`).
+//
+// Four properties, and all four are the point:
+//
+//   1. Both lanes report. The `EntityInstance` path and the system-table path are
+//      separate functions with separate builders; a UI must not have to branch on
+//      which one served it, so the SHAPE is asserted identical for both.
+//   2. Strictly additive. A clean build must not put the keys on the response at
+//      all — an existing caller spreading the result must see no shape change.
+//   3. Bounded. A pathological filter set must not put an unbounded array on
+//      every list response, and the COUNT must stay exact past the cap so a UI
+//      that renders it never *undercounts* what it is warning about.
+//   4. It never changes the SQL. Reporting a drop must not also start filtering
+//      on it — the whole contract is "widened, and said so".
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../cache', () => ({
+  getCachedResourceFields: vi.fn(async () => []),
+  findCachedResource: vi.fn(async () => undefined),
+  getCachedEntityDefId: vi.fn(async () => undefined),
+  getOrgCache: vi.fn(() => ({ get: vi.fn(async () => ({})) })),
+}))
+
+/** Diagnostics the two builder mocks below hand back, swapped per test. */
+const entityBuild = {
+  sql: undefined as unknown,
+  requestedConditions: 0,
+  droppedConditions: [] as unknown[],
+  allConditionsDropped: false,
+}
+const systemBuild = {
+  sql: undefined as unknown,
+  requestedConditions: 0,
+  droppedConditions: [] as unknown[],
+  allConditionsDropped: false,
+}
+
+vi.mock('../../query-builder/entity-condition-builder', () => ({
+  entityConditionBuilder: {
+    buildGroupedQueryWithDiagnostics: vi.fn(() => entityBuild),
+    buildOrderBySql: vi.fn(() => undefined),
+  },
+}))
+
+vi.mock('../../query-builder/system-condition-builder', () => ({
+  systemConditionBuilder: {
+    buildGroupedQueryWithDiagnostics: vi.fn(() => systemBuild),
+    buildOrderBySql: vi.fn(() => undefined),
+  },
+}))
+
+import {
+  MAX_REPORTED_DROPPED_CONDITIONS,
+  queryEntityInstanceIdsPaged,
+  querySystemResourceIdsPaged,
+} from '../unified-handler-queries'
+
+/** One internal drop record, in the shape `BaseConditionBuilder` produces. */
+function drop(n: number) {
+  return {
+    conditionId: `cond_${n}`,
+    fieldRef: `article:field_${n}`,
+    operator: 'equals',
+    reason: 'unresolved-field-or-operator' as const,
+    // Builder internals — the class name that gave up. Must NOT reach a client.
+    detail: 'SystemConditionBuilder',
+  }
+}
+
+function setDrops(target: typeof entityBuild, drops: ReturnType<typeof drop>[]) {
+  target.droppedConditions = drops
+  target.requestedConditions = drops.length
+  target.allConditionsDropped = drops.length > 0
+}
+
+/** Drizzle stand-in that records every `where()` argument; each chain is a thenable. */
+function fakeDb(...results: unknown[][]) {
+  const wheres: unknown[] = []
+  const chain = (result: unknown[]) => {
+    const c: Record<string, unknown> = {}
+    c.from = () => c
+    c.where = (w: unknown) => {
+      wheres.push(w)
+      return c
+    }
+    c.orderBy = () => c
+    c.limit = () => c
+    c.offset = () => c
+    // biome-ignore lint/suspicious/noThenProperty: a Drizzle builder IS a thenable; faking it needs `then`
+    c.then = (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(res, rej)
+    return c
+  }
+  let n = 0
+  return { db: { select: () => chain(results[n++] ?? []) } as never, wheres }
+}
+
+const ids = (...v: string[]) => v.map((id) => ({ id }))
+
+const entityBase = {
+  entityDefinitionId: 'edf000000000000000000001',
+  organizationId: 'org_1',
+  filters: [],
+  sorting: [],
+  limit: 10,
+  offset: 0,
+}
+const systemBase = {
+  tableId: 'article' as const,
+  organizationId: 'org_1',
+  filters: [],
+  sorting: [],
+  limit: 10,
+  offset: 0,
+}
+
+beforeEach(() => {
+  setDrops(entityBuild, [])
+  setDrops(systemBuild, [])
+})
+
+describe('a clean build stays byte-identical — no key appears at all', () => {
+  it('omits both keys on the EntityInstance path', async () => {
+    const { db } = fakeDb(ids('i0'))
+    const r = await queryEntityInstanceIdsPaged({ ...entityBase, db })
+
+    expect(r.droppedConditions).toBeUndefined()
+    expect(r.droppedConditionCount).toBeUndefined()
+    // Not just `undefined` — ABSENT. A caller doing `'droppedConditions' in r`,
+    // or serializing the page, must see the pre-change shape.
+    expect(Object.keys(r).sort()).toEqual(['hasMore', 'ids'])
+  })
+
+  it('omits both keys on the system-resource path', async () => {
+    const { db } = fakeDb(ids('a0'))
+    const r = await querySystemResourceIdsPaged({ ...systemBase, db })
+
+    expect(Object.keys(r).sort()).toEqual(['hasMore', 'ids'])
+  })
+})
+
+describe('both lanes report the same shape', () => {
+  it('reports drops on the EntityInstance path', async () => {
+    setDrops(entityBuild, [drop(1)])
+    const { db } = fakeDb(ids('i0'))
+    const r = await queryEntityInstanceIdsPaged({ ...entityBase, db })
+
+    expect(r.droppedConditionCount).toBe(1)
+    expect(r.droppedConditions).toEqual([
+      {
+        conditionId: 'cond_1',
+        fieldRef: 'article:field_1',
+        operator: 'equals',
+        reason: 'unresolved-field-or-operator',
+      },
+    ])
+  })
+
+  it('reports drops on the system-resource path — the lane where the KB filters drop today', async () => {
+    setDrops(systemBuild, [drop(1)])
+    const { db } = fakeDb(ids('a0'))
+    const r = await querySystemResourceIdsPaged({ ...systemBase, db })
+
+    expect(r.droppedConditionCount).toBe(1)
+    expect(r.droppedConditions).toEqual([
+      {
+        conditionId: 'cond_1',
+        fieldRef: 'article:field_1',
+        operator: 'equals',
+        reason: 'unresolved-field-or-operator',
+      },
+    ])
+  })
+
+  it('produces key-for-key identical notices from the two builders', async () => {
+    setDrops(entityBuild, [drop(7)])
+    setDrops(systemBuild, [drop(7)])
+
+    const entity = await queryEntityInstanceIdsPaged({ ...entityBase, db: fakeDb(ids('i0')).db })
+    const system = await querySystemResourceIdsPaged({ ...systemBase, db: fakeDb(ids('a0')).db })
+
+    // The two paths are separate functions; drift between them is exactly what a
+    // UI cannot absorb, so this asserts equality rather than "both non-empty".
+    expect(entity.droppedConditions).toEqual(system.droppedConditions)
+    expect(entity.droppedConditionCount).toBe(system.droppedConditionCount)
+  })
+})
+
+describe('client-facing projection withholds builder internals', () => {
+  it('strips `detail` — the builder class name / raw valueSource token', async () => {
+    setDrops(systemBuild, [drop(1)])
+    const { db } = fakeDb(ids('a0'))
+    const r = await querySystemResourceIdsPaged({ ...systemBase, db })
+
+    const notice = r.droppedConditions?.[0]
+    expect(notice).toBeDefined()
+    expect(Object.keys(notice as object).sort()).toEqual([
+      'conditionId',
+      'fieldRef',
+      'operator',
+      'reason',
+    ])
+    expect(JSON.stringify(r)).not.toContain('SystemConditionBuilder')
+  })
+})
+
+describe('the payload is bounded', () => {
+  it(`caps the array at ${MAX_REPORTED_DROPPED_CONDITIONS} but keeps the count exact`, async () => {
+    const many = Array.from({ length: MAX_REPORTED_DROPPED_CONDITIONS + 12 }, (_, i) => drop(i))
+    setDrops(systemBuild, many)
+    const { db } = fakeDb(ids('a0'))
+    const r = await querySystemResourceIdsPaged({ ...systemBase, db })
+
+    expect(r.droppedConditions).toHaveLength(MAX_REPORTED_DROPPED_CONDITIONS)
+    // The count is the number a UI renders. Truncating it would make the notice
+    // itself understate the problem — the same silence this field exists to end.
+    expect(r.droppedConditionCount).toBe(MAX_REPORTED_DROPPED_CONDITIONS + 12)
+  })
+
+  it('keeps the array intact when it is under the cap', async () => {
+    setDrops(entityBuild, [drop(1), drop(2), drop(3)])
+    const { db } = fakeDb(ids('i0'))
+    const r = await queryEntityInstanceIdsPaged({ ...entityBase, db })
+
+    expect(r.droppedConditions).toHaveLength(3)
+    expect(r.droppedConditionCount).toBe(3)
+  })
+})
+
+describe('reporting does not change the query', () => {
+  it('still returns the WIDER page — the fail-open is preserved, not converted to an error', async () => {
+    setDrops(systemBuild, [drop(1), drop(2)])
+    const { db, wheres } = fakeDb(ids('a0', 'a1', 'a2'))
+
+    // No throw, and the rows the dropped filters would have excluded still come
+    // back. Callers that must refuse (AI tools) use `inspectFilterConditions`.
+    const r = await querySystemResourceIdsPaged({ ...systemBase, db })
+
+    expect(r.ids).toEqual(['a0', 'a1', 'a2'])
+    expect(r.droppedConditionCount).toBe(2)
+    // One WHERE was still built and issued — the org scope. Nothing about the
+    // reporting path added or removed a predicate.
+    expect(wheres).toHaveLength(1)
+  })
+
+  it('leaves `total` alone — it still describes the widened set the query actually ran', async () => {
+    setDrops(entityBuild, [drop(1)])
+    const { db } = fakeDb(ids('i0'), [{ count: 6470 }])
+    const r = await queryEntityInstanceIdsPaged({ ...entityBase, db, includeTotal: true })
+
+    expect(r.total).toBe(6470)
+    expect(r.droppedConditionCount).toBe(1)
+  })
+})

--- a/packages/lib/src/resources/crud/index.ts
+++ b/packages/lib/src/resources/crud/index.ts
@@ -23,6 +23,7 @@ export { UnifiedCrudHandler } from './unified-handler'
 // Mutation utilities (for advanced use cases)
 export type { CreateEntityResult, MutationContext } from './unified-handler-mutations'
 export type {
+  DroppedFilterNotice,
   ListAllFieldInfo,
   ListAllInput,
   ListAllItem,
@@ -38,6 +39,7 @@ export {
   getTableSchema,
   isSystemResource,
   listAll,
+  MAX_REPORTED_DROPPED_CONDITIONS,
   queryEntityInstanceIdsPaged,
   querySystemResourceIdsPaged,
   resolveEntityId,

--- a/packages/lib/src/resources/crud/unified-handler-queries.ts
+++ b/packages/lib/src/resources/crud/unified-handler-queries.ts
@@ -26,7 +26,10 @@ import type { CapabilityView } from '../../permissions/capabilities/capability-v
 import { textSearchPredicate, textSearchRank } from '../../search/text-search-sql'
 import { BaseType } from '../../workflow-engine/core/types'
 import { isMailLensTableId, MAIL_LENS_REFUSAL } from '../picker/mail-lens-tables'
-import type { DroppedCondition } from '../query-builder/base-condition-builder'
+import type {
+  DroppedCondition,
+  DroppedConditionReason,
+} from '../query-builder/base-condition-builder'
 import {
   type EntityQueryContext,
   entityConditionBuilder,
@@ -86,6 +89,41 @@ export interface ListFilteredInput {
 }
 
 /**
+ * Upper bound on {@link ListFilteredResult.droppedConditions}. A pathological
+ * filter set (a stored view against a wholesale-renamed resource, a generated
+ * `in` fan-out) must not put an unbounded array on every list response — the
+ * payload is a diagnostic, not a data channel. `droppedConditionCount` stays
+ * exact past the cap so a UI never *undercounts* what it is warning about.
+ *
+ * 25 is far above any hand-built filter set; the filter UI tops out around a
+ * dozen conditions.
+ */
+export const MAX_REPORTED_DROPPED_CONDITIONS = 25
+
+/**
+ * A filter condition the query builder could not turn into SQL, in the shape a
+ * **client** is allowed to see.
+ *
+ * Deliberately narrower than the internal {@link DroppedCondition}: `detail` is
+ * dropped, because it carries builder internals (the builder class name via
+ * `this.constructor.name`, or the raw unresolved `valueSource` token) that say
+ * nothing to a user and everything to someone probing the server. What survives
+ * is what a UI needs to name the offender — the caller's own `conditionId` (so a
+ * filter chip can be highlighted), the `fieldId` the caller itself sent, its
+ * operator, and a coarse reason. No SQL, no column names, no table names.
+ */
+export interface DroppedFilterNotice {
+  /** The condition's `id`, exactly as the caller sent it. */
+  conditionId: string
+  /** The condition's `fieldId` — an array for relationship paths. Caller-supplied. */
+  fieldRef: string | string[]
+  /** The condition's operator, as sent. */
+  operator: string
+  /** Why it produced no SQL. Coarse by design — see {@link DroppedConditionReason}. */
+  reason: DroppedConditionReason
+}
+
+/**
  * Result from listFiltered query
  */
 export interface ListFilteredResult {
@@ -98,6 +136,56 @@ export interface ListFilteredResult {
   total?: number
   /** Whether more results exist, derived from a `limit + 1` probe row */
   hasMore: boolean
+  /**
+   * Filter conditions the builder could not compile, and therefore **did not
+   * apply**. Present only when at least one was dropped; `undefined` means every
+   * requested condition made it into the `WHERE` clause.
+   *
+   * **A non-empty list means this page is WIDER than the caller asked for.** The
+   * query lane fails open on purpose — a stored view naming a retired field must
+   * still render — but that made the failure invisible by construction, which is
+   * how KB free-text search, the KB Tag/Status/Kind filters, unfiltered dashboard
+   * thread widgets and an unknown operator compiling to `eq(col, value)` all hid
+   * in plain sight. This field is the observability channel for that whole class;
+   * the AI boundary still *refuses* instead, via {@link inspectFilterConditions}.
+   *
+   * Purely additive: a caller that ignores it gets byte-identical behaviour.
+   * Capped at {@link MAX_REPORTED_DROPPED_CONDITIONS} — read
+   * {@link droppedConditionCount} for the true total.
+   */
+  droppedConditions?: DroppedFilterNotice[]
+  /**
+   * How many conditions were dropped in total, uncapped. Equals
+   * `droppedConditions.length` unless the cap truncated the list. Present exactly
+   * when {@link droppedConditions} is.
+   */
+  droppedConditionCount?: number
+}
+
+/** The caller-facing projection of a build's drop diagnostics, or `{}` when clean. */
+type DroppedConditionReport = Pick<
+  ListFilteredResult,
+  'droppedConditions' | 'droppedConditionCount'
+>
+
+/**
+ * Project internal builder diagnostics onto the caller-facing subset, bounded.
+ *
+ * Spread into a list result: `{ ids, hasMore, ...reportDroppedConditions(dropped) }`.
+ * An empty input yields `{}`, so the two absent keys never appear on a clean
+ * response and no existing consumer sees a shape change.
+ */
+function reportDroppedConditions(dropped: DroppedCondition[]): DroppedConditionReport {
+  if (dropped.length === 0) return {}
+  return {
+    droppedConditionCount: dropped.length,
+    droppedConditions: dropped.slice(0, MAX_REPORTED_DROPPED_CONDITIONS).map((d) => ({
+      conditionId: d.conditionId,
+      fieldRef: d.fieldRef,
+      operator: d.operator,
+      reason: d.reason,
+    })),
+  }
 }
 
 /**
@@ -178,6 +266,12 @@ async function buildEntityInstanceQueryParts(params: {
 }): Promise<{
   whereClause: SQL<unknown> | undefined
   orderByClauses: SQL<unknown>[] | undefined
+  /**
+   * Conditions that produced no SQL. Returned rather than only logged so the
+   * paged query can hand them to its caller — see
+   * {@link ListFilteredResult.droppedConditions}.
+   */
+  dropped: DroppedCondition[]
 }> {
   const { organizationId, entityDefinitionId, filters, sorting } = params
   const search = params.search?.trim() || undefined
@@ -191,7 +285,9 @@ async function buildEntityInstanceQueryParts(params: {
     // in production" has to be a query on `droppedCount` / `droppedConditions`,
     // not a grep. This path deliberately proceeds: the records list and stored
     // views must still render when a filter names a retired field. The AI
-    // boundary escalates instead, via `inspectFilterConditions`.
+    // boundary escalates instead, via `inspectFilterConditions`, and the UI gets
+    // the same diagnostics back on the response (`dropped`, below) so a list can
+    // say it widened rather than leaving it to whoever reads the logs.
     logger.warn('Dropped filter conditions', {
       entityDefinitionId,
       organizationId,
@@ -224,7 +320,7 @@ async function buildEntityInstanceQueryParts(params: {
         ? [desc(recordSearchRank(search)), desc(schema.EntityInstance.updatedAt)]
         : undefined
 
-  return { whereClause, orderByClauses }
+  return { whereClause, orderByClauses, dropped: built.droppedConditions }
 }
 
 /**
@@ -451,10 +547,10 @@ export async function queryEntityInstanceIdsPaged(params: {
    * predicate is added and the query is byte-identical to the pre-P5 one.
    */
   visibilityWhere?: SQL
-}): Promise<{ ids: string[]; total?: number; hasMore: boolean }> {
+}): Promise<ListFilteredResult> {
   const { db, entityDefinitionId, organizationId, filters, sorting, limit, offset } = params
 
-  const { whereClause, orderByClauses } = await buildEntityInstanceQueryParts({
+  const { whereClause, orderByClauses, dropped } = await buildEntityInstanceQueryParts({
     organizationId,
     entityDefinitionId,
     filters,
@@ -495,6 +591,9 @@ export async function queryEntityInstanceIdsPaged(params: {
     ids: idsResult.slice(0, limit).map((r) => r.id),
     ...(countResult ? { total: Number(countResult[0]?.count ?? 0) } : {}),
     hasMore: idsResult.length > limit,
+    // `total` and `ids` both describe a WIDER set than the caller asked for when
+    // this is non-empty. Reported, not thrown — see the field's JSDoc.
+    ...reportDroppedConditions(dropped),
   }
 }
 
@@ -593,7 +692,7 @@ export async function querySystemResourceIdsPaged(params: {
   search?: string
   /** Run the parallel `COUNT(*)`. Callers pay for it on the first page only. */
   includeTotal?: boolean
-}): Promise<{ ids: string[]; total?: number; hasMore: boolean }> {
+}): Promise<ListFilteredResult> {
   const { db, tableId, organizationId, filters, sorting, limit, offset } = params
 
   assertNotMailLensTable(tableId)
@@ -603,7 +702,7 @@ export async function querySystemResourceIdsPaged(params: {
     throw new Error(`Unknown table: ${tableId}`)
   }
 
-  const whereClause = buildSystemWhereClause(tableId, organizationId, filters)
+  const { sql: whereClause, dropped } = buildSystemWhereClause(tableId, organizationId, filters)
   const { searchWhere, searchOrderBy } = buildSystemSearchParts(tableId, params.search)
   const baseWhere = and(eq(tableSchema.organizationId, organizationId), whereClause, searchWhere)
 
@@ -639,6 +738,11 @@ export async function querySystemResourceIdsPaged(params: {
     ids: idsResult.slice(0, limit).map((r: { id: string }) => r.id),
     ...(countResult ? { total: Number(countResult[0]?.count ?? 0) } : {}),
     hasMore: idsResult.length > limit,
+    // Identical shape to the EntityInstance twin above — the two paths must not
+    // report the same failure differently, or a UI has to branch on which lane
+    // served it. This is the lane where the KB articles table's Tag/Status/Kind
+    // filters currently drop (cuid vs registry key), so it is not hypothetical.
+    ...reportDroppedConditions(dropped),
   }
 }
 
@@ -670,7 +774,7 @@ export async function countSystemResource(params: {
     throw new Error(`Unknown table: ${tableId}`)
   }
 
-  const whereClause = buildSystemWhereClause(tableId, organizationId, filters)
+  const { sql: whereClause } = buildSystemWhereClause(tableId, organizationId, filters)
   const { searchWhere } = buildSystemSearchParts(tableId, params.search)
 
   const result = await db
@@ -726,12 +830,17 @@ function buildSystemSearchParts(
  * System-table twin of the entity WHERE build: same fail-open (a dropped
  * condition widens rather than errors, because stored views must still render)
  * and the same structured warn so the rate is queryable.
+ *
+ * Returns the diagnostics alongside the clause rather than discarding them — the
+ * old signature computed the full drop list, logged it, and then returned only
+ * `.sql`, which is precisely why every fail-open on this lane had to be found by
+ * accident. Callers surface it as {@link ListFilteredResult.droppedConditions}.
  */
 function buildSystemWhereClause(
   tableId: TableId,
   organizationId: string,
   filters: ConditionGroup[]
-): SQL<unknown> | undefined {
+): { sql: SQL<unknown> | undefined; dropped: DroppedCondition[] } {
   const built = systemConditionBuilder.buildGroupedQueryWithDiagnostics(filters, tableId)
 
   if (built.droppedConditions.length > 0) {
@@ -745,7 +854,7 @@ function buildSystemWhereClause(
     })
   }
 
-  return built.sql
+  return { sql: built.sql, dropped: built.droppedConditions }
 }
 
 /**

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -974,6 +974,14 @@ export class UnifiedCrudHandler {
    * `COUNT(*)` runs on the first page only (or when `includeTotal` is forced), so an
    * infinite scroll doesn't pay a count per tick — see plan v3/02 §2.2.
    *
+   * **This lane fails open on a filter it cannot compile** — the condition is
+   * dropped and the query runs wider — because saved views, the mail list, unread
+   * counts and the workflow Find node all depend on `baseScope` for the genuine
+   * empty-filter case. That is deliberate, but it used to be *invisible*. Both
+   * branches below now return {@link ListFilteredResult.droppedConditions}, so a
+   * caller can say "1 filter was ignored" instead of quietly showing more rows.
+   * Ignoring the field leaves behaviour byte-identical.
+   *
    * @param params - Filter parameters
    */
   async listFiltered(params: {


### PR DESCRIPTION
Follow-ups #1 and #2 from the retrieval-fixes plan, after #1470 and #1473. Two independent changes, one commit each.

## 1. Report dropped filter conditions (`fix(resources)`)

`listFiltered` fails open on a filter it cannot compile — the condition is dropped and the query runs wider. That contract stays (saved views, the mail list, unread counts and the workflow Find node all depend on `baseScope` for the genuine empty-filter case); it was the **silence** that was wrong.

Both lanes now return `droppedConditions` + `droppedConditionCount` on `ListFilteredResult`, and `DroppedFiltersNotice` renders them in the dynamic-table footer — so it lights up on the KB articles table (where Tag/Status/Kind currently drop on cuid-vs-registry-key) and every records table. **Ignoring the field leaves behaviour byte-identical.**

Three decisions worth preserving:

- The reported array is capped at `MAX_REPORTED_DROPPED_CONDITIONS`, but `droppedConditionCount` stays **exact past the cap**. Counting the truncated array would make the notice undercount — the same quiet lie this field exists to end.
- The notice is cached in the record store's `ListCache`, not only on the query response. That cache is served *instead of* the query for 5 min, so the warning would otherwise vanish while the list stayed wide.
- The client payload is `{conditionId, fieldRef, operator, reason}` only. The internal `detail` carries `this.constructor.name`; a test asserts the payload never contains `SystemConditionBuilder`.

The AI boundary keeps doing the opposite and refuses, via `inspectFilterConditions`.

## 2. Gate single-host field-value reads on the mail lens (`fix(permissions)`)

`getValue` / `getValues` had no mail enforcement. `resolveMailHostGate` is the single-entity twin of the existing `resolveMailLensGate`, reusing the same classification table so the two paths cannot give different answers for the same `FieldValue.fieldId`.

**Preventive, not a live exposure.** Both functions read the `FieldValue` table only — they never reach `resolveSystemTableFields` or the virtual-field resolvers — so what they could expose on a thread is the `FieldValue`-backed slice (`tags`, `visit*`), never `subject` or `body`. Gated anyway: they are not router-exposed today, and the next router that exposes them must not have to rediscover that `hasDefPresence` authorizes nothing for `thread` (`canViewEntity('thread')` is an unconditional pass-through for `NON_RECORD_DEF_SLUGS` — the root cause behind every mail-lens hole closed in #1470/#1473).

The resolvers are imported by `field-value-queries.ts` and nothing else, so gating these two entry points covers every thread-capable read behind them. `relationship-queries.ts`'s thread-tag helpers stay ungated deliberately — no `ctx` to key on, callers sit inside mail's own lens layer, payload is `metadata`-tier.

A withheld host blanks rather than throws (`null` / empty `Map` are already each function's legal "no value" answer), and non-mail hosts short-circuit on one `Map.get` with no I/O.

## Testing

- `list-filtered-dropped-conditions.test.ts` — 10 tests
- `single-host-mail-lens.test.ts` — 13 tests
- `dropped-filters-notice.test.tsx` — 3 tests

26 passing. Biome clean on all 14 files.

## Not in scope

Follow-up #2b (`countEntityInstances`/`countSystemResource` return a bare `number`, so unread counts and totals can still silently widen; the dashboard record-list widget and calendar receive the field but ignore it) is left for a separate PR.