### PR TITLE
fix(ingest): never let the thread-alias write roll back a message

### DIFF
--- a/packages/lib/src/ingest/__tests__/store-message.threading.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message.threading.test.ts
@@ -20,6 +20,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const h = vi.hoisted(() => ({
   store: {} as Record<string, Array<Record<string, any>>>,
   seq: 0,
+  /** Table whose INSERT should blow up, standing in for a table the migration has not created yet. */
+  failInsertOn: null as string | null,
 }))
 
 vi.mock('@auxx/database', async () => {
@@ -162,6 +164,9 @@ function insertChain(table: string) {
   let updateSet: Record<string, unknown> = {}
 
   const run = () => {
+    if (h.failInsertOn === table) {
+      throw new Error(`relation "${table}" does not exist`)
+    }
     const out: Array<Record<string, any>> = []
     for (const value of values) {
       const existing = target.length
@@ -294,6 +299,7 @@ const aliasKeysFor = (threadId: string) =>
     .sort()
 
 beforeEach(() => {
+  h.failInsertOn = null
   h.store = {
     Integration: [
       { id: OUTLOOK, provider: 'outlook', deletedAt: null, metadata: {} },
@@ -389,6 +395,41 @@ describe('storeMessage — Outlook conversationId fork (thread-splitting plan)',
 
     const threadId = rows('Thread')[0]?.id
     expect(aliasKeysFor(threadId)).toEqual(['convA'])
+  })
+
+  // Regression: this exact failure took down ingest for EVERY provider in dev when
+  // the code ran before migration 0323 created the table. The alias write used to
+  // live inside the write transaction, and Postgres aborts the whole transaction on
+  // any statement error — so the message was rolled back too. A missing alias must
+  // cost us thread merging, never the message.
+  it('still stores the message when the alias write fails', async () => {
+    const c = ctx()
+    h.failInsertOn = 'ThreadExternalKey'
+
+    await expect(
+      storeMessage(c, messageData({ internetMessageId: '<survives@x>' }))
+    ).resolves.toBeDefined()
+
+    expect(messages()).toHaveLength(1)
+    expect(rows('Thread')).toHaveLength(1)
+    expect(rows('ThreadExternalKey')).toHaveLength(0)
+    expect(c.logger.error).toHaveBeenCalled()
+  })
+
+  it('falls back to the conversation key when the alias table is unreadable', async () => {
+    const c = ctx()
+    h.failInsertOn = 'ThreadExternalKey'
+
+    await storeMessage(c, messageData({ internetMessageId: '<a@x>' }))
+    await storeMessage(
+      c,
+      messageData({ externalThreadId: 'convA', internetMessageId: '<b@x>', isInbound: true })
+    )
+
+    // Both still land on one thread via the unchanged `(integrationId, externalId)`
+    // upsert — i.e. exactly the behaviour that shipped before the alias table.
+    expect(rows('Thread')).toHaveLength(1)
+    expect(messages()).toHaveLength(2)
   })
 })
 

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -46,6 +46,51 @@ function deriveThreadStatusFromLabels(labelIds: string[]): ThreadStatusValue {
 }
 
 /**
+ * Records the provider conversation key this message arrived under as an alias of
+ * `threadId`, so the NEXT message in a forked conversation resolves at rung 1
+ * without needing a resolvable parent of its own. This is what makes a merge stick.
+ * Idempotent via the unique index on `(integrationId, externalId)`.
+ *
+ * Runs AFTER the write transaction commits, and swallows its own failures, for a
+ * reason that is easy to get wrong: Postgres aborts an entire transaction on any
+ * statement error, so a `try/catch` around this INSERT *inside* the transaction
+ * would not save it — every later statement would fail with "current transaction
+ * is aborted" and the message would still be lost. Keeping it inside cost us a
+ * real outage: when the code shipped before `0323` created the table, the alias
+ * INSERT rolled back the whole write set and ingest failed for EVERY provider,
+ * not just Outlook.
+ *
+ * A missing alias is cheap — thread resolution simply falls back to the provider
+ * conversation key, i.e. the behaviour that shipped before the alias table. A lost
+ * message is not. Never let this fail ingestion.
+ */
+async function recordThreadExternalKey(
+  ctx: IngestContext,
+  messageData: MessageData,
+  threadId: string
+): Promise<void> {
+  if (!messageData.externalThreadId || !messageData.integrationId) return
+
+  try {
+    await ctx.db
+      .insert(schema.ThreadExternalKey)
+      .values({
+        threadId,
+        integrationId: messageData.integrationId,
+        externalId: messageData.externalThreadId,
+      })
+      .onConflictDoNothing()
+  } catch (error) {
+    ctx.logger.error('Failed to record thread external key; thread merging may not stick', {
+      threadId,
+      integrationId: messageData.integrationId,
+      externalThreadId: messageData.externalThreadId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
  * Store a single inbound/outbound message with full ingest pipeline:
  * reconciliation → participants → thread upsert → message upsert →
  * message-participant links → thread metadata update.
@@ -468,20 +513,8 @@ export async function storeMessage(
         : (thread.messageCount ?? 0) === 1 &&
           thread.firstMessageAt?.getTime() === messageData.sentAt.getTime()
 
-      // Record the incoming conversation key so the NEXT message in a forked
-      // conversation resolves at rung 1, without needing a resolvable parent of
-      // its own. This is what makes a merge stick. Idempotent by the unique
-      // index on `(integrationId, externalId)`.
-      if (messageData.externalThreadId && messageData.integrationId) {
-        await tx
-          .insert(schema.ThreadExternalKey)
-          .values({
-            threadId: thread.id,
-            integrationId: messageData.integrationId,
-            externalId: messageData.externalThreadId,
-          })
-          .onConflictDoNothing()
-      }
+      // NOTE: the `ThreadExternalKey` alias write deliberately does NOT live in
+      // this transaction — see `recordThreadExternalKey` after the commit.
 
       // Gmail parity: a thread with any INBOX message belongs in the inbox.
       // Reopen an ARCHIVED personal-channel thread when this message carries
@@ -632,6 +665,8 @@ export async function storeMessage(
       return { thread, isNewThread, messageRecord, flippedUserIds, didReopen }
     })
     const { thread, isNewThread, messageRecord, flippedUserIds, didReopen } = txResult
+
+    await recordThreadExternalKey(ctx, messageData, thread.id)
 
     // Reply-detection hook (Sequences plan §3.3/Phase 2; client-notifications plan §4.4 gates
     // it on `Sequence.exitOnReply`) — an inbound message on a thread with an active


### PR DESCRIPTION
Follow-up to #1476. Found by running it against a real Outlook mailbox in dev.

## The bug

The `ThreadExternalKey` alias insert added in #1476 lived **inside** the message write transaction. When the code ran before migration `0323` created the table, the alias INSERT failed and took the whole transaction with it:

```
outlook-inbound-content-ingestor  Outlook batch store with ingest completed: 0 stored, 9 failed (9 retriable).
ingest  Error storing message (Revised Schema v2):
  Failed query: insert into "ThreadExternalKey" ... on conflict do nothing
```

**Blast radius is every provider, not just Outlook** — the alias write is unconditional in `store-message.ts`, the hottest write path in the system. A deploy that lands before `db:migrate` takes down all mail ingest.

`resolveThreadId` was already defensive and degraded to `null` exactly as designed. Only the alias write was fatal.

It got worse than a transient failure: `messages-import-job.ts:97` calls `acknowledgeImportBatch` regardless of `result.failed`, so the 9 failures were dropped from the Redis import cache and the stage went `IDLE`. Recovery required manually clearing `Label.providerCursor`. (That ack behaviour is pre-existing and not changed here — but it's why this bug wasn't self-healing.)

## The fix

Move the alias write **out** of the transaction, after the commit, and swallow its own failure.

A `try/catch` *inside* the transaction would not have worked, which is the subtle part worth stating: Postgres aborts the entire transaction on any statement error, so catching it in JS still leaves every later statement failing with `current transaction is aborted`, and the message is lost anyway. The write has to leave the transaction.

Trade-off, taken deliberately: a missing alias costs thread **merging**, which falls back to the provider conversation key — i.e. exactly pre-#1476 behaviour. A rolled-back transaction costs the **message**. The first is cheap and self-correcting; the second is not.

This does not make the migration optional. It stops a migration-ordering mistake from becoming a total mail outage.

## Tests

Two regression tests, both driving the real failure through the in-memory harness via a new `failInsertOn` injection hook:
- `still stores the message when the alias write fails` — message + thread persist, alias table empty, error logged
- `falls back to the conversation key when the alias table is unreadable` — two messages still land on one thread via the unchanged `(integrationId, externalId)` upsert

**Mutation-verified:** re-adding `throw` to the catch fails both. They are not vacuous.

## Verification

- `packages/lib`: 6574 passed, 0 failed
- `packages/lib` typecheck: zero errors under `src/ingest` (baseline 715, unchanged)
- Biome clean

Confirmed fixed against the live mailbox after migrating: `9 stored, 0 failed`, and `textPlain` is now 8/8 with 0 empty snippets — the exact inverse of the production baseline in the plan README.