### PR TITLE
fix(conditions): resolve system-resource filter fields addressed by cuid

### DIFF
--- a/packages/lib/src/resources/aggregate/canonicalize-filter-wiring.test.ts
+++ b/packages/lib/src/resources/aggregate/canonicalize-filter-wiring.test.ts
@@ -1,0 +1,161 @@
+// packages/lib/src/resources/aggregate/canonicalize-filter-wiring.test.ts
+//
+// 🔴 READ BEFORE DELETING THIS FILE AS REDUNDANT.
+//
+// This test asserts only that `prepareAggregate` hands CANONICALIZED conditions
+// to `systemConditionBuilder` — it inspects the builder's INPUT, not its output.
+// On its own that is a weak assertion: it would stay green even if the canonical
+// form resolved to nothing. It is acceptable here only because it composes with
+// two stronger tests that already exist:
+//
+//   - `query-builder/__tests__/canonicalize-system-fields.test.ts` proves the
+//     rewrite itself is correct (registry key, idempotence, no invented
+//     resolutions).
+//   - `run-aggregate.int.test.ts` proves the end-to-end narrowing against real
+//     Article rows — 3 articles, 2 PUBLISHED, and a cuid-addressed filter
+//     returning 2 rather than the unfiltered 3.
+//
+// Its narrow job is to make the WIRING itself impossible to delete silently.
+// The integration file is the only end-to-end proof and CI does not run it: the
+// workflow enumerates vitest projects and omits `integration`, which needs a
+// live database. So without this file, removing the `canonicalizeSystemConditions`
+// call from `run-aggregate.ts` is a green CI and a dashboard that quietly reports
+// numbers that are too HIGH (a dropped filter does not narrow).
+//
+// Asserting on the builder's input is also the only option under the unit
+// config: it mocks `@auxx/database` with a proxy whose table columns are `{}`,
+// so `schema.Article.status` is undefined and no real predicate can be built
+// here. That is precisely why the DB-backed proof lives in the `.int` file.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  fields: [] as unknown[],
+}))
+
+// Partial mock — a full replacement of the `../../cache` module breaks at
+// collection time as the import graph grows.
+vi.mock('../../cache', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getCachedResourceFields: async () => h.fields,
+    getAggregateCache: () => ({
+      read: async () => null,
+      write: async () => undefined,
+    }),
+  }
+})
+
+import type { Database } from '@auxx/database'
+import type { ConditionGroup } from '../../conditions'
+import { BaseType } from '../../workflow-engine/core/types'
+import { systemConditionBuilder } from '../query-builder/system-condition-builder'
+import type { ResourceField } from '../registry/field-types'
+import { runAggregate } from './run-aggregate'
+import type { AggregateQuery } from './types'
+
+/** The org's materialized `CustomField` row id for the static `article:status` field. */
+const STATUS_CUID = 'cf_article_status_00000001'
+/** A cuid that matches no merged field — e.g. a widget saved against a retired one. */
+const UNKNOWN_CUID = 'cf_retired_field_000000001'
+
+/**
+ * The merged shape `mergeSystemAndCustomFields` produces for a system resource:
+ * `id` is the DB `CustomField.id` (the cuid the filter UIs send), while `key`
+ * stays the static registry key the condition builder looks up.
+ */
+const MERGED_FIELDS: ResourceField[] = [
+  {
+    id: STATUS_CUID,
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: 'SINGLE_SELECT',
+    dbColumn: 'status',
+    systemAttribute: 'article_status',
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+  } as unknown as ResourceField,
+]
+
+/** Nothing here reaches Postgres for real — the aggregate SQL is never executed. */
+function stubDb(): Database {
+  return {
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({ execute: async () => ({ rows: [{ value: 0 }] }) }),
+  } as unknown as Database
+}
+
+const filterOn = (fieldRef: string): ConditionGroup[] => [
+  {
+    id: 'g1',
+    logicalOperator: 'AND',
+    conditions: [{ id: 'c1', fieldId: fieldRef, operator: 'is', value: 'PUBLISHED' }],
+  },
+]
+
+const articleCount = (filters: ConditionGroup[]): AggregateQuery => ({
+  source: { kind: 'system', tableId: 'article' },
+  metric: { op: 'count' },
+  timezone: 'UTC',
+  filters,
+})
+
+describe('the system filter branch canonicalizes before the builder sees it', () => {
+  let spy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    h.fields = MERGED_FIELDS
+    spy = vi.spyOn(systemConditionBuilder, 'buildGroupedQueryWithDiagnostics').mockReturnValue({
+      sql: undefined,
+      requestedConditions: 1,
+      droppedConditions: [],
+      allConditionsDropped: false,
+    })
+  })
+
+  /** The `fieldId` of the first condition of the first group the builder received. */
+  async function fieldIdSeenByBuilder(fieldRef: string): Promise<unknown> {
+    const result = await runAggregate(
+      stubDb(),
+      'org_1',
+      undefined,
+      articleCount(filterOn(fieldRef))
+    )
+    expect(result.isOk()).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
+    const groups = spy.mock.calls[0]?.[0] as ConditionGroup[]
+    return groups[0]?.conditions[0]?.fieldId
+  }
+
+  it('rewrites a `<defId>:<cuid>` ref to the static registry key', async () => {
+    // The shape the table filter builder sends. `RESOURCE_FIELD_REGISTRY.article`
+    // is keyed by 'status', so this is the only form the builder can resolve.
+    expect(await fieldIdSeenByBuilder(`article:${STATUS_CUID}`)).toBe('status')
+  })
+
+  it('rewrites a bare cuid too — the records searchbar shape', async () => {
+    expect(await fieldIdSeenByBuilder(STATUS_CUID)).toBe('status')
+  })
+
+  it('passes an already-canonical ref through untouched', async () => {
+    expect(await fieldIdSeenByBuilder('status')).toBe('status')
+  })
+
+  it('leaves an unresolvable cuid unchanged, so the builder still drops it visibly', async () => {
+    // Deliberate: rewriting a guess here would trade today's recorded
+    // `DroppedCondition` for a silent, confidently wrong predicate.
+    expect(await fieldIdSeenByBuilder(UNKNOWN_CUID)).toBe(UNKNOWN_CUID)
+  })
+
+  it('still targets the article table', async () => {
+    await fieldIdSeenByBuilder(STATUS_CUID)
+    expect(spy.mock.calls[0]?.[1]).toBe('article')
+  })
+})

--- a/packages/lib/src/resources/aggregate/run-aggregate.int.test.ts
+++ b/packages/lib/src/resources/aggregate/run-aggregate.int.test.ts
@@ -26,7 +26,35 @@ const h = vi.hoisted(() => ({
   agents: [] as unknown[],
   groups: [] as unknown[],
   aggCache: new Map<string, { result: unknown; computedAt: number }>(),
+  /** `logger.warn` calls made by the `aggregate-engine` scope only. */
+  warnings: [] as Array<{ message: string; meta: Record<string, unknown> | undefined }>,
 }))
+
+// Partial mock: `@auxx/logger`'s barrel registers sinks at module load, so a full
+// replacement breaks whichever file loads it first. Every other scope keeps the
+// real logger — only `aggregate-engine`'s `warn` is teed into `h.warnings`,
+// because "a dropped widget filter is still REPORTED" is a behaviour under test
+// (a silently ignored filter makes a KPI number too high).
+vi.mock('@auxx/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@auxx/logger')>()
+  return {
+    ...actual,
+    createScopedLogger: (
+      scope: string,
+      options?: Parameters<typeof actual.createScopedLogger>[1]
+    ) => {
+      const real = actual.createScopedLogger(scope, options)
+      if (scope !== 'aggregate-engine') return real
+      return {
+        ...real,
+        warn: (message: string, ...args: unknown[]) => {
+          h.warnings.push({ message, meta: args[0] as Record<string, unknown> | undefined })
+          real.warn(message, ...args)
+        },
+      }
+    },
+  }
+})
 
 vi.mock('../../cache', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
@@ -68,6 +96,7 @@ function makeField(
     relationship?: Record<string, unknown>
     isSystem?: boolean
     dbColumn?: string
+    systemAttribute?: string
   }
 ): ResourceField {
   return {
@@ -81,6 +110,7 @@ function makeField(
     relationship: args.relationship,
     isSystem: args.isSystem,
     dbColumn: args.dbColumn,
+    systemAttribute: args.systemAttribute,
     capabilities: caps,
   } as ResourceField
 }
@@ -949,5 +979,159 @@ describe('runAggregate — system source', () => {
       })
       expect(kpi._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
     }
+  })
+})
+
+// ── System-source filters addressed by the merged CustomField cuid ───────────
+//
+// The filter surfaces address a field on a system resource by the org's merged
+// `CustomField` cuid, while `SystemConditionBuilder` resolves against
+// `RESOURCE_FIELD_REGISTRY['article']`, which is keyed by the STATIC key
+// ('status'). Untranslated, the condition never resolved and was DROPPED — and a
+// dropped filter does not narrow, so the widget answered with the unfiltered
+// total. `prepareAggregate` now runs `canonicalizeSystemConditions` over the
+// filters first, against the same merged `rootFields` it already loaded.
+//
+// Asserted through counts against real rows, never through SQL strings: 3
+// articles exist, 2 are PUBLISHED, so "did the filter apply" is the difference
+// between 2 and 3 and the pre-fix behaviour is a failing 3.
+
+describe('runAggregate — system-source filters addressed by CustomField cuid', () => {
+  /** The org's materialized `CustomField` row id for the static `article:status` field. */
+  const STATUS_CUID = 'cf_article_status_00000001'
+  /** A cuid that matches no merged field — e.g. a widget saved against a retired one. */
+  const UNKNOWN_CUID = 'cf_retired_field_000000001'
+
+  /**
+   * 3 articles (2 PUBLISHED, 1 DRAFT) plus the merged field shape
+   * `mergeSystemAndCustomFields` produces for a system resource: `id` is the DB
+   * `CustomField.id`, `key` stays the static registry key.
+   */
+  async function seedArticles() {
+    h.aggCache.clear()
+    h.warnings.length = 0
+    h.fieldsByDef.clear()
+
+    const org = await createTestOrganization()
+    const user = await createTestUser()
+    const kbRows = await db()
+      .insert(schema.KnowledgeBase)
+      .values({
+        organizationId: org.id,
+        name: 'kb',
+        slug: `kb-${generateId().slice(0, 8)}`,
+        createdById: user.id,
+        updatedAt: new Date(),
+      })
+      .returning()
+    const kb = kbRows[0]!
+
+    for (const [title, status] of [
+      ['a', 'PUBLISHED'],
+      ['b', 'PUBLISHED'],
+      ['c', 'DRAFT'],
+    ] as const) {
+      await db().insert(schema.Article).values({
+        title,
+        organizationId: org.id,
+        homeKnowledgeBaseId: kb.id,
+        status,
+        updatedAt: new Date(),
+      })
+    }
+
+    h.fieldsByDef.set('article', [
+      makeField('article', {
+        id: STATUS_CUID,
+        key: 'status',
+        type: BaseType.ENUM,
+        fieldType: 'SINGLE_SELECT',
+        dbColumn: 'status',
+        systemAttribute: 'article_status',
+        isSystem: true,
+      }),
+    ])
+
+    return org
+  }
+
+  const statusFilter = (fieldRef: string): AggregateQuery['filters'] => [
+    {
+      id: 'g1',
+      logicalOperator: 'AND',
+      conditions: [{ id: 'c1', fieldId: fieldRef, operator: 'is', value: 'PUBLISHED' }],
+    },
+  ]
+
+  const countArticles = (orgId: string, filters?: AggregateQuery['filters']) =>
+    runAggregate(db(), orgId, undefined, {
+      source: { kind: 'system', tableId: 'article' },
+      metric: { op: 'count' },
+      timezone: 'UTC',
+      filters,
+    })
+
+  it('narrows on a `<defId>:<cuid>` filter — the table filter builder shape', async () => {
+    const org = await seedArticles()
+
+    expect((await countArticles(org.id))._unsafeUnwrap().totalValue).toBe(3)
+    const filtered = await countArticles(
+      org.id,
+      statusFilter(toResourceFieldId('article', STATUS_CUID))
+    )
+    expect(filtered._unsafeUnwrap().totalValue).toBe(2)
+    expect(h.warnings).toEqual([])
+  })
+
+  it('narrows on a bare cuid too — the records searchbar shape', async () => {
+    const org = await seedArticles()
+
+    const filtered = await countArticles(org.id, statusFilter(STATUS_CUID))
+    expect(filtered._unsafeUnwrap().totalValue).toBe(2)
+    expect(h.warnings).toEqual([])
+  })
+
+  it('still narrows when the filter already names the static key', async () => {
+    const org = await seedArticles()
+
+    // Idempotence where it matters: stored widgets hold both shapes.
+    expect((await countArticles(org.id, statusFilter('status')))._unsafeUnwrap().totalValue).toBe(2)
+    expect(
+      (await countArticles(org.id, statusFilter('article:status')))._unsafeUnwrap().totalValue
+    ).toBe(2)
+    expect(h.warnings).toEqual([])
+  })
+
+  it('narrows a KPI the same way — runKpi shares prepareAggregate', async () => {
+    const org = await seedArticles()
+
+    const kpi = await runKpi(db(), org.id, undefined, {
+      base: {
+        source: { kind: 'system', tableId: 'article' },
+        metric: { op: 'count' },
+        timezone: 'UTC',
+        filters: statusFilter(STATUS_CUID),
+      },
+    })
+    expect(kpi._unsafeUnwrap().value).toBe(2)
+  })
+
+  it('an unresolvable cuid still fails open, and says so', async () => {
+    const org = await seedArticles()
+
+    // Deliberate contract for a widget: render WIDER rather than error. The
+    // canonicalizer returns an unknown ref unchanged precisely so the builder
+    // keeps dropping it visibly instead of compiling a confident guess.
+    const result = await countArticles(org.id, statusFilter(UNKNOWN_CUID))
+    expect(result._unsafeUnwrap().totalValue).toBe(3)
+
+    expect(h.warnings).toHaveLength(1)
+    expect(h.warnings[0]?.message).toBe('Dropped widget filter conditions')
+    expect(h.warnings[0]?.meta).toMatchObject({
+      entityDefinitionId: 'article',
+      droppedCount: 1,
+      requestedConditions: 1,
+      allConditionsDropped: true,
+    })
   })
 })

--- a/packages/lib/src/resources/aggregate/run-aggregate.ts
+++ b/packages/lib/src/resources/aggregate/run-aggregate.ts
@@ -31,6 +31,7 @@ import { ForbiddenError, UnprocessableEntityError } from '../../errors'
 import { BaseType } from '../../workflow-engine/core/types'
 import { extractRequiredRelatedEntities } from '../crud/unified-handler-queries'
 import { isMailLensTableId, MAIL_LENS_REFUSAL } from '../picker/mail-lens-tables'
+import { canonicalizeSystemConditions } from '../query-builder/canonicalize-system-fields'
 import {
   type EntityQueryContext,
   entityConditionBuilder,
@@ -376,8 +377,20 @@ async function prepareAggregate(
       })
     }
   } else if (filters.length) {
+    // The filter surfaces address a field on a system resource by the org's
+    // merged `CustomField` cuid, while `SystemConditionBuilder` resolves against
+    // `RESOURCE_FIELD_REGISTRY[tableId]`, which is keyed by the STATIC key. Left
+    // untranslated every such condition dropped — and on an aggregate a dropped
+    // filter does not narrow, so the widget reported a number that was too HIGH.
+    //
+    // `rootFields` is the merged field set for exactly this resource, already
+    // loaded above, so this adds no I/O; the call is pure and idempotent (stored
+    // widgets hold either shape). Unresolvable refs come back unchanged on
+    // purpose, so they still land in `droppedConditions` below rather than being
+    // compiled into a confidently wrong lookup.
+    const canonicalFilters = canonicalizeSystemConditions(filters, rootDefId as TableId, rootFields)
     const built = systemConditionBuilder.buildGroupedQueryWithDiagnostics(
-      filters,
+      canonicalFilters,
       rootDefId as TableId
     )
     conditionsWhere = built.sql

--- a/packages/lib/src/resources/crud/__tests__/list-filtered-dropped-conditions.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/list-filtered-dropped-conditions.test.ts
@@ -24,10 +24,21 @@
 //   4. It never changes the SQL. Reporting a drop must not also start filtering
 //      on it — the whole contract is "widened, and said so".
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The org's merged fields for `article`, swapped per test. Hoisted because the
+ * `cache` factory closes over it.
+ *
+ * A FULL factory, never `importOriginal` + spread: the real `cache` barrel's
+ * transitive graph re-enters `unified-handler-queries` while the factory is
+ * still running, so a spread-based override binds the REAL helper in the module
+ * under test and silently does nothing.
+ */
+const mergedFields = vi.hoisted(() => ({ current: [] as unknown[] }))
 
 vi.mock('../../../cache', () => ({
-  getCachedResourceFields: vi.fn(async () => []),
+  getCachedResourceFields: vi.fn(async () => mergedFields.current),
   findCachedResource: vi.fn(async () => undefined),
   getCachedEntityDefId: vi.fn(async () => undefined),
   getOrgCache: vi.fn(() => ({ get: vi.fn(async () => ({})) })),
@@ -57,11 +68,17 @@ vi.mock('../../query-builder/entity-condition-builder', () => ({
 vi.mock('../../query-builder/system-condition-builder', () => ({
   systemConditionBuilder: {
     buildGroupedQueryWithDiagnostics: vi.fn(() => systemBuild),
+    // `inspectFilterConditions` reads this one; its errors reach `message`, so it
+    // is as capable of a false refusal as the build is.
+    validateConditionGroups: vi.fn(() => ({ valid: true, errors: [] })),
     buildOrderBySql: vi.fn(() => undefined),
   },
 }))
 
+import { systemConditionBuilder } from '../../query-builder/system-condition-builder'
+import { RESOURCE_FIELD_REGISTRY } from '../../registry/field-registry'
 import {
+  inspectFilterConditions,
   MAX_REPORTED_DROPPED_CONDITIONS,
   queryEntityInstanceIdsPaged,
   querySystemResourceIdsPaged,
@@ -262,5 +279,337 @@ describe('reporting does not change the query', () => {
 
     expect(r.total).toBe(6470)
     expect(r.droppedConditionCount).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE CUID DROP ITSELF — the bug the reporting above made visible
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The filter UIs address a field on a system resource by the org's merged
+// `CustomField` **cuid**; the builder resolves against
+// `RESOURCE_FIELD_REGISTRY[tableId]`, keyed by the STATIC key. So the KB
+// articles table filtered by Tag / Status / Kind dropped every condition and
+// returned everything. `canonicalizeSystemConditions` now runs first.
+//
+// These tests keep the builder mocked — the point is what this lane HANDS the
+// builder — but the mock is made registry-aware, so a drop here is produced by
+// the same rule the real `SystemConditionBuilder` applies (`custom_` prefix, or
+// a hit in the registry after the `<defId>:` prefix is stripped). Asserting only
+// on the forwarded arguments would pass even if the canonical form were one the
+// builder still cannot resolve.
+
+/** cuid of the org's materialized `CustomField` row for the static `tags` field. */
+const TAGS_CUID = 'cf_tags_0000000000000001'
+/** …and for `status`, which is also SORTABLE — the second half of the same bug. */
+const STATUS_CUID = 'cf_status_00000000000001'
+/** A cuid the org has no field for at all. */
+const GHOST_CUID = 'cf_ghost_000000000000001'
+
+const ARTICLE_DEF_ID = 'edf000000000000000000009'
+
+/** The merged shape `mergeSystemAndCustomFields` produces: DB id, static key. */
+const ARTICLE_MERGED_FIELDS = [
+  { id: TAGS_CUID, key: 'tags', label: 'Tags', systemAttribute: 'article_tags' },
+  { id: STATUS_CUID, key: 'status', label: 'Status', systemAttribute: 'article_status' },
+]
+
+/** `SystemConditionBuilder`'s actual resolution rule, in four lines. */
+function resolves(fieldRef: unknown, tableId: string): boolean {
+  const ref = Array.isArray(fieldRef) ? fieldRef[0] : fieldRef
+  if (typeof ref !== 'string') return false
+  if (ref.startsWith('custom_')) return true
+  const stripped = ref.includes(':') ? ref.slice(ref.indexOf(':') + 1) : ref
+  return Boolean(RESOURCE_FIELD_REGISTRY[tableId as never]?.[stripped])
+}
+
+/** Registry-aware stand-in for `buildGroupedQueryWithDiagnostics`. */
+function registryAwareBuild(groups: { conditions: unknown[] }[], tableId: string) {
+  const conditions = groups.flatMap((g) => g.conditions) as {
+    id: string
+    fieldId: unknown
+    operator: string
+  }[]
+  const droppedConditions = conditions
+    .filter((c) => !resolves(c.fieldId, tableId))
+    .map((c) => ({
+      conditionId: c.id,
+      fieldRef: c.fieldId,
+      operator: c.operator,
+      reason: 'unresolved-field-or-operator' as const,
+      detail: 'SystemConditionBuilder',
+    }))
+
+  return {
+    sql: undefined,
+    requestedConditions: conditions.length,
+    droppedConditions,
+    allConditionsDropped: conditions.length > 0 && droppedConditions.length === conditions.length,
+  }
+}
+
+/** Registry-aware stand-in for `validateConditionGroups`. */
+function registryAwareValidate(groups: { conditions: unknown[] }[], tableId: string) {
+  const errors = (groups.flatMap((g) => g.conditions) as { fieldId: unknown }[])
+    .filter((c) => !resolves(c.fieldId, tableId))
+    .map((c) => `Group 1: Unknown field: ${String(c.fieldId)}`)
+
+  return { valid: errors.length === 0, errors }
+}
+
+/** One `article` filter group holding a single condition on `fieldId`. */
+const articleFilter = (fieldId: unknown) => [
+  {
+    id: 'g1',
+    logicalOperator: 'AND' as const,
+    conditions: [{ id: 'c1', fieldId, operator: 'is', value: 'x' }],
+  },
+]
+
+describe('a cuid-addressed filter on a system table now RESOLVES', () => {
+  const build = vi.mocked(systemConditionBuilder.buildGroupedQueryWithDiagnostics)
+
+  beforeEach(() => {
+    mergedFields.current = ARTICLE_MERGED_FIELDS
+    build.mockImplementation(registryAwareBuild as never)
+  })
+
+  // Restore the fixed-diagnostics stub the rest of the file drives by hand.
+  afterEach(() => {
+    mergedFields.current = []
+    build.mockImplementation((() => systemBuild) as never)
+  })
+
+  it.each([
+    ['bare cuid, as the records searchbar sends it', TAGS_CUID],
+    ['prefixed cuid, as the table filter builder sends it', `${ARTICLE_DEF_ID}:${STATUS_CUID}`],
+    ['relationship path head', [TAGS_CUID, 'tag:name']],
+  ])('drops nothing for a %s', async (_label, fieldId) => {
+    const { db } = fakeDb(ids('a0'))
+    const r = await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      filters: articleFilter(fieldId) as never,
+    })
+
+    // Before the canonicalizer this was exactly one drop — and one drop means
+    // the KB articles list returned every article in the org.
+    expect(r.droppedConditions).toBeUndefined()
+    expect(r.droppedConditionCount).toBeUndefined()
+  })
+
+  it('hands the builder the STATIC key, not the cuid', async () => {
+    const { db } = fakeDb(ids('a0'))
+    await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      filters: articleFilter(TAGS_CUID) as never,
+    })
+
+    const [groups, tableId] = build.mock.calls.at(-1) as [
+      { conditions: { fieldId: unknown }[] }[],
+      string,
+    ]
+    expect(groups[0]?.conditions[0]?.fieldId).toBe('tags')
+    expect(tableId).toBe('article')
+  })
+
+  it('still resolves a condition already written in the static shape', async () => {
+    // Stored views hold either shape; the pre-pass runs over both forever.
+    const { db } = fakeDb(ids('a0'))
+    const r = await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      filters: articleFilter('status') as never,
+    })
+
+    expect(r.droppedConditions).toBeUndefined()
+  })
+
+  it('reports an unresolvable cuid EXACTLY once — the fail-open stays visible', async () => {
+    const { db, wheres } = fakeDb(ids('a0', 'a1'))
+    const r = await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      filters: articleFilter(`${ARTICLE_DEF_ID}:${GHOST_CUID}`) as never,
+    })
+
+    // Canonicalization must not invent a resolution: a cuid the org has no field
+    // for comes back unchanged, so the builder still drops it and still says so.
+    expect(r.droppedConditionCount).toBe(1)
+    expect(r.droppedConditions).toEqual([
+      {
+        conditionId: 'c1',
+        fieldRef: `${ARTICLE_DEF_ID}:${GHOST_CUID}`,
+        operator: 'is',
+        reason: 'unresolved-field-or-operator',
+      },
+    ])
+    // …and the page is still the WIDER one. Reported, not thrown.
+    expect(r.ids).toEqual(['a0', 'a1'])
+    expect(wheres).toHaveLength(1)
+  })
+
+  it('keeps the count exact when only SOME conditions resolve', async () => {
+    const { db } = fakeDb(ids('a0'))
+    const r = await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      filters: [
+        {
+          id: 'g1',
+          logicalOperator: 'AND' as const,
+          conditions: [
+            { id: 'c1', fieldId: TAGS_CUID, operator: 'is', value: 'x' },
+            { id: 'c2', fieldId: GHOST_CUID, operator: 'is', value: 'y' },
+            { id: 'c3', fieldId: STATUS_CUID, operator: 'is', value: 'z' },
+          ],
+        },
+      ] as never,
+    })
+
+    // Two of three now compile. A count of 3 here would mean the canonicalizer
+    // ran but the builder still could not read what it produced.
+    expect(r.droppedConditionCount).toBe(1)
+    expect(r.droppedConditions?.[0]?.conditionId).toBe('c2')
+  })
+})
+
+describe('SORT — a cuid column header reaches the builder canonicalized', () => {
+  const orderBy = vi.mocked(systemConditionBuilder.buildOrderBySql)
+
+  beforeEach(() => {
+    mergedFields.current = ARTICLE_MERGED_FIELDS
+  })
+  afterEach(() => {
+    mergedFields.current = []
+  })
+
+  it('translates the cuid to the static key', async () => {
+    const { db } = fakeDb(ids('a0'))
+    await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      sorting: [{ id: STATUS_CUID, desc: true }],
+    })
+
+    // `buildOrderBySql` reads the same registry as the conditions, so the same
+    // cuid mismatch made it return `undefined` — clicking a column header on a
+    // system table silently did nothing at all.
+    expect(orderBy).toHaveBeenCalledWith('status', 'desc', 'article')
+  })
+
+  it('strips the `<defId>:` prefix the table filter builder adds', async () => {
+    const { db } = fakeDb(ids('a0'))
+    await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      sorting: [{ id: `${ARTICLE_DEF_ID}:${TAGS_CUID}`, desc: false }],
+    })
+
+    expect(orderBy).toHaveBeenCalledWith('tags', 'asc', 'article')
+  })
+
+  it('passes an unresolvable sort id through untouched', async () => {
+    // No dropped-sort channel exists, and inventing one here is out of scope —
+    // an unsorted list is visibly odd in a way a widened one is not.
+    const { db } = fakeDb(ids('a0'))
+    await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      sorting: [{ id: GHOST_CUID, desc: false }],
+    })
+
+    expect(orderBy).toHaveBeenCalledWith(GHOST_CUID, 'asc', 'article')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE AI BOUNDARY MUST AGREE WITH THE QUERY LANE
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `inspectFilterConditions` is the fail-CLOSED half of this module: the list
+// widens and says so, an AI tool refuses. That only works while preflight and
+// the query lane answer identically for every input — the two are separate call
+// sites into the same builder, so canonicalizing one and not the other is a bug
+// in BOTH directions:
+//
+//   • preflight silent where the query drops  ⇒ a widened answer ships as fact;
+//   • preflight refusing where the query applies ⇒ a working filter is rejected.
+//
+// The second is the one this change could introduce, so it is asserted first —
+// and then the equivalence itself is asserted over the whole input space rather
+// than sampled, because "both happen to be right about `tags`" is not the
+// property.
+
+describe('inspectFilterConditions agrees with the query lane', () => {
+  const build = vi.mocked(systemConditionBuilder.buildGroupedQueryWithDiagnostics)
+  const validate = vi.mocked(systemConditionBuilder.validateConditionGroups)
+
+  beforeEach(() => {
+    mergedFields.current = ARTICLE_MERGED_FIELDS
+    build.mockImplementation(registryAwareBuild as never)
+    validate.mockImplementation(registryAwareValidate as never)
+  })
+
+  afterEach(() => {
+    mergedFields.current = []
+    build.mockImplementation((() => systemBuild) as never)
+    validate.mockImplementation((() => ({ valid: true, errors: [] })) as never)
+  })
+
+  const preflight = (fieldId: unknown) =>
+    inspectFilterConditions({
+      organizationId: 'org_1',
+      entityDefinitionId: 'article',
+      filters: articleFilter(fieldId) as never,
+    })
+
+  it('does NOT refuse a cuid the query lane successfully applies', async () => {
+    const report = await preflight(TAGS_CUID)
+
+    expect(report.dropped).toEqual([])
+    // Validation is canonicalized too, or its `Unknown field:` error would refuse
+    // via `message` even with an empty `dropped`.
+    expect(report.validationErrors).toEqual([])
+    expect(report.message).toBeUndefined()
+  })
+
+  it('does NOT refuse a `<defId>:`-prefixed cuid either', async () => {
+    const report = await preflight(`${ARTICLE_DEF_ID}:${STATUS_CUID}`)
+
+    expect(report.message).toBeUndefined()
+    expect(report.allConditionsDropped).toBe(false)
+  })
+
+  it('STILL refuses a garbage cuid — the fail-closed contract is unchanged', async () => {
+    const report = await preflight(GHOST_CUID)
+
+    expect(report.dropped).toHaveLength(1)
+    expect(report.allConditionsDropped).toBe(true)
+    expect(report.message).toContain('do NOT match')
+    expect(report.validationErrors).toEqual([`Group 1: Unknown field: ${GHOST_CUID}`])
+  })
+
+  it.each([
+    ['a merged-field cuid', TAGS_CUID],
+    ['a prefixed merged-field cuid', `${ARTICLE_DEF_ID}:${STATUS_CUID}`],
+    ['an already-static key', 'status'],
+    ['a garbage cuid', GHOST_CUID],
+    ['a prefixed garbage cuid', `${ARTICLE_DEF_ID}:${GHOST_CUID}`],
+    ['a relationship path head', [TAGS_CUID, 'tag:name']],
+  ])('reports exactly what the query lane drops for %s', async (_label, fieldId) => {
+    const report = await preflight(fieldId)
+    const { db } = fakeDb(ids('a0'))
+    const listed = await querySystemResourceIdsPaged({
+      ...systemBase,
+      db,
+      filters: articleFilter(fieldId) as never,
+    })
+
+    // The invariant, stated directly: same inputs, same verdict. Refusing is
+    // allowed; refusing where the list would have filtered correctly is not.
+    expect(report.dropped).toHaveLength(listed.droppedConditionCount ?? 0)
+    expect(Boolean(report.message)).toBe(Boolean(listed.droppedConditions))
   })
 })

--- a/packages/lib/src/resources/crud/__tests__/list-filtered-mail-lens.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/list-filtered-mail-lens.test.ts
@@ -31,13 +31,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const DEF_ID = vi.hoisted(() => 'edf000000000000000000001')
 
-vi.mock('../../../cache', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../cache')>()
-  return {
-    ...actual,
-    findCachedResource: vi.fn(async () => ({ id: DEF_ID, entityDefinitionId: DEF_ID })),
-  }
-})
+// A FULL factory, not `importOriginal` + spread. `importOriginal` loads the real
+// `cache` barrel, whose transitive graph re-enters `unified-handler-queries`
+// *while the factory is still running* — so the module under test binds the REAL
+// helper and the override never takes effect. That was latent until the system
+// path started reading `getCachedResourceFields`; the sibling files in this
+// directory all use the full-factory shape for the same reason.
+vi.mock('../../../cache', () => ({
+  findCachedResource: vi.fn(async () => ({ id: DEF_ID, entityDefinitionId: DEF_ID })),
+  // The system path resolves the org's merged fields to canonicalize filter field
+  // refs. Empty is the honest stub here: this file is about the mail-lens
+  // refusal, and the real helper would reach the DB.
+  getCachedResourceFields: vi.fn(async () => []),
+  getCachedEntityDefId: vi.fn(async () => undefined),
+  getOrgCache: vi.fn(() => ({ get: vi.fn(async () => ({})) })),
+}))
 
 vi.mock('../../query-builder/system-condition-builder', () => ({
   systemConditionBuilder: {

--- a/packages/lib/src/resources/crud/unified-handler-queries.ts
+++ b/packages/lib/src/resources/crud/unified-handler-queries.ts
@@ -30,6 +30,13 @@ import type {
   DroppedCondition,
   DroppedConditionReason,
 } from '../query-builder/base-condition-builder'
+// Imported from the module, NOT the `query-builder` barrel: the barrel also
+// pulls in `condition-query-builder`, and this module is already the hub every
+// crud test mocks piecemeal.
+import {
+  canonicalizeSystemConditions,
+  canonicalizeSystemFieldRef,
+} from '../query-builder/canonicalize-system-fields'
 import {
   type EntityQueryContext,
   entityConditionBuilder,
@@ -115,7 +122,12 @@ export const MAX_REPORTED_DROPPED_CONDITIONS = 25
 export interface DroppedFilterNotice {
   /** The condition's `id`, exactly as the caller sent it. */
   conditionId: string
-  /** The condition's `fieldId` — an array for relationship paths. Caller-supplied. */
+  /**
+   * The condition's `fieldId` — an array for relationship paths. Caller-supplied
+   * for an unresolvable reference, which is the case a UI needs to name; a
+   * reference that resolved to a field and dropped for another reason (an
+   * operator the field does not support) reports its canonical key instead.
+   */
   fieldRef: string | string[]
   /** The condition's operator, as sent. */
   operator: string
@@ -433,6 +445,18 @@ export interface FilterConditionReport {
  * Dispatches on {@link isSystemResource}, so the same call covers entity
  * definitions and system tables.
  *
+ * **Answers identically to the query lane, by construction.** On the system-table
+ * branch this runs the *same* `canonicalizeSystemConditions` over the *same*
+ * merged fields as {@link buildSystemWhereClause}, because the two diverging is a
+ * bug in both directions: preflight missing a drop the query makes would let a
+ * widened answer through, and preflight inventing one the query does not make
+ * would refuse a filter that works. Canonicalization feeds `validateConditionGroups`
+ * too — its `Unknown field:` errors reach `message`, so validating the raw shape
+ * would refuse a cuid the build resolved.
+ *
+ * A genuinely unresolvable reference is untouched by all of this: it canonicalizes
+ * to itself, drops, and is still reported.
+ *
  * @param params.entityDefinitionId - Entity definition id, or a system `TableId`
  */
 export async function inspectFilterConditions(params: {
@@ -443,16 +467,15 @@ export async function inspectFilterConditions(params: {
   const { organizationId, entityDefinitionId, filters } = params
 
   const { built, validation } = isSystemResource(entityDefinitionId)
-    ? {
-        built: systemConditionBuilder.buildGroupedQueryWithDiagnostics(
-          filters,
-          entityDefinitionId as TableId
-        ),
-        validation: systemConditionBuilder.validateConditionGroups(
-          filters,
-          entityDefinitionId as TableId
-        ),
-      }
+    ? await (async () => {
+        const tableId = entityDefinitionId as TableId
+        const fields = await getCachedResourceFields(organizationId, tableId)
+        const canonicalFilters = canonicalizeSystemConditions(filters, tableId, fields)
+        return {
+          built: systemConditionBuilder.buildGroupedQueryWithDiagnostics(canonicalFilters, tableId),
+          validation: systemConditionBuilder.validateConditionGroups(canonicalFilters, tableId),
+        }
+      })()
     : await (async () => {
         const context = await buildEntityQueryContext(organizationId, entityDefinitionId, filters)
         return {
@@ -702,14 +725,28 @@ export async function querySystemResourceIdsPaged(params: {
     throw new Error(`Unknown table: ${tableId}`)
   }
 
-  const { sql: whereClause, dropped } = buildSystemWhereClause(tableId, organizationId, filters)
+  // For a system resource the `tableId` IS the resource key, so this is the same
+  // hydrated per-org cache entry the rest of the request already read.
+  const fields = await getCachedResourceFields(organizationId, tableId)
+
+  const { sql: whereClause, dropped } = buildSystemWhereClause(
+    tableId,
+    organizationId,
+    filters,
+    fields
+  )
   const { searchWhere, searchOrderBy } = buildSystemSearchParts(tableId, params.search)
   const baseWhere = and(eq(tableSchema.organizationId, organizationId), whereClause, searchWhere)
 
+  // The sort column arrives from the same UIs as the filters and carries the
+  // same cuid, so `buildOrderBySql` resolved nothing and returned `undefined` —
+  // clicking a column header on a system table silently did nothing. There is
+  // deliberately no drop reporting for sorts: an unsorted list is visibly odd,
+  // unlike a widened one.
   const orderByClauses =
     sorting.length > 0
       ? systemConditionBuilder.buildOrderBySql(
-          sorting[0].id,
+          canonicalizeSystemFieldRef(sorting[0].id, tableId, fields),
           sorting[0].desc ? 'desc' : 'asc',
           tableId
         )
@@ -774,7 +811,11 @@ export async function countSystemResource(params: {
     throw new Error(`Unknown table: ${tableId}`)
   }
 
-  const { sql: whereClause } = buildSystemWhereClause(tableId, organizationId, filters)
+  // Same merged-field resolution as the paged query — a count that skipped it
+  // would report the WIDER set the page no longer shows.
+  const fields = await getCachedResourceFields(organizationId, tableId)
+
+  const { sql: whereClause } = buildSystemWhereClause(tableId, organizationId, filters, fields)
   const { searchWhere } = buildSystemSearchParts(tableId, params.search)
 
   const result = await db
@@ -835,13 +876,28 @@ function buildSystemSearchParts(
  * old signature computed the full drop list, logged it, and then returned only
  * `.sql`, which is precisely why every fail-open on this lane had to be found by
  * accident. Callers surface it as {@link ListFilteredResult.droppedConditions}.
+ *
+ * Conditions are canonicalized first: the filter UIs address a system field by
+ * the org's merged `CustomField` **cuid**, while `SystemConditionBuilder`
+ * resolves against `RESOURCE_FIELD_REGISTRY[tableId]`, which is keyed by the
+ * STATIC key — so every such condition dropped and the list widened. The
+ * pre-pass is pure, synchronous and idempotent, which is why it lives here
+ * rather than inside the builder, and why `fields` is a **parameter**: this
+ * function must stay sync, so the (cached) field read belongs to the async
+ * callers.
+ *
+ * @param fields - The org's merged fields for `tableId`. Pass `[]` only when the
+ *   caller genuinely has none; an empty list restores the old cuid-drops-silently
+ *   behaviour for merged fields, reported as usual via `dropped`.
  */
 function buildSystemWhereClause(
   tableId: TableId,
   organizationId: string,
-  filters: ConditionGroup[]
+  filters: ConditionGroup[],
+  fields: ResourceField[]
 ): { sql: SQL<unknown> | undefined; dropped: DroppedCondition[] } {
-  const built = systemConditionBuilder.buildGroupedQueryWithDiagnostics(filters, tableId)
+  const canonicalFilters = canonicalizeSystemConditions(filters, tableId, fields)
+  const built = systemConditionBuilder.buildGroupedQueryWithDiagnostics(canonicalFilters, tableId)
 
   if (built.droppedConditions.length > 0) {
     logger.warn('Dropped filter conditions', {

--- a/packages/lib/src/resources/query-builder/__tests__/canonicalize-system-fields.test.ts
+++ b/packages/lib/src/resources/query-builder/__tests__/canonicalize-system-fields.test.ts
@@ -1,0 +1,311 @@
+// packages/lib/src/resources/query-builder/__tests__/canonicalize-system-fields.test.ts
+//
+// The filter UIs address a field on a system resource by the org's merged
+// `CustomField` cuid; `SystemConditionBuilder` resolves fields against
+// `RESOURCE_FIELD_REGISTRY[tableId]`, which is keyed by the STATIC key. Every
+// filter on article/kb/dataset/user/... therefore dropped, and a dropped
+// condition widens the result set.
+//
+// This canonicalizer is the translation layer, run before the builder sees the
+// conditions. Four properties matter:
+//
+//   1. It maps to `key`, never to `systemAttribute` — the registry is keyed by
+//      the static field's id (`tags`), not its attribute (`article_tags`).
+//   2. It is idempotent. Stored views hold either shape, and the pre-pass will
+//      run over already-canonical conditions forever.
+//   3. It never invents a resolution. An unknown reference is returned
+//      unchanged so the builder keeps dropping it *visibly*, rather than
+//      compiling a confidently wrong FieldValue lookup.
+//   4. The no-op path allocates nothing — asserted by reference identity, not
+//      by deep equality.
+//
+// Uses the real `article` registry (it genuinely has tags/status/kind), so no
+// module mocking is involved.
+
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { describe, expect, it } from 'vitest'
+import { RESOURCE_FIELD_REGISTRY } from '../../registry/field-registry'
+import type { ResourceField } from '../../registry/field-types'
+import { BaseType } from '../../types'
+import type { ConditionGroup, GenericCondition } from '../base-condition-builder'
+import {
+  canonicalizeSystemConditions,
+  canonicalizeSystemFieldRef,
+} from '../canonicalize-system-fields'
+
+const ENTITY_DEF_ID = 'entdef_article'
+
+/** cuid of the org's materialized `CustomField` row for the static `tags` field. */
+const TAGS_CUID = 'cf_tags_0000000000000001'
+/** cuid of a genuine custom field added to Article by the org. */
+const CUSTOM_CUID = 'cf_custom_000000000000001'
+/** A cuid that resolves to nothing at all. */
+const UNKNOWN_CUID = 'cf_unknown_00000000000001'
+
+function field(overrides: Partial<ResourceField> & Pick<ResourceField, 'key'>): ResourceField {
+  return {
+    id: toFieldId(overrides.key),
+    label: overrides.key,
+    type: BaseType.STRING,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    ...overrides,
+  }
+}
+
+/**
+ * The merged shape `mergeSystemAndCustomFields` produces for system resources:
+ * `id` is the DB `CustomField.id`, `key` stays the static registry key.
+ */
+const MERGED_FIELDS: ResourceField[] = [
+  field({
+    id: toFieldId(TAGS_CUID),
+    key: 'tags',
+    label: 'Tags',
+    type: BaseType.RELATION,
+    systemAttribute: 'article_tags',
+  }),
+  field({
+    id: toFieldId(CUSTOM_CUID),
+    key: 'Severity',
+    label: 'Severity',
+  }),
+  field({
+    id: toFieldId('cf_retired_0000000000001'),
+    key: 'retiredField',
+    label: 'Retired',
+    systemAttribute: 'article_slug',
+  }),
+]
+
+function condition(overrides: Partial<GenericCondition> = {}): GenericCondition {
+  return { id: 'cond-1', fieldId: 'status', operator: 'is', value: 'PUBLISHED', ...overrides }
+}
+
+function group(conditions: GenericCondition[], id = 'group-1'): ConditionGroup {
+  return { id, conditions, logicalOperator: 'AND' }
+}
+
+const canonicalize = (fieldRef: string) =>
+  canonicalizeSystemFieldRef(fieldRef, 'article', MERGED_FIELDS)
+
+describe('canonicalizeSystemFieldRef', () => {
+  describe('case A — already a static registry key', () => {
+    it('returns a bare static key unchanged', () => {
+      expect(canonicalize('tags')).toBe('tags')
+      expect(canonicalize('status')).toBe('status')
+      expect(canonicalize('kind')).toBe('kind')
+    })
+
+    it('returns a `<defId>:<key>` reference unchanged (the builder strips it itself)', () => {
+      expect(canonicalize(`${ENTITY_DEF_ID}:status`)).toBe(`${ENTITY_DEF_ID}:status`)
+    })
+
+    it('leaves an already-`custom_`-prefixed reference alone', () => {
+      expect(canonicalize(`custom_${CUSTOM_CUID}`)).toBe(`custom_${CUSTOM_CUID}`)
+    })
+  })
+
+  describe('case B — merged system field cuid', () => {
+    it('rewrites a bare cuid to the static key', () => {
+      expect(canonicalize(TAGS_CUID)).toBe('tags')
+    })
+
+    it('resolves the `<defId>:<cuid>` form identically to the bare cuid', () => {
+      expect(canonicalize(`${ENTITY_DEF_ID}:${TAGS_CUID}`)).toBe(canonicalize(TAGS_CUID))
+      expect(canonicalize(`${ENTITY_DEF_ID}:${TAGS_CUID}`)).toBe('tags')
+    })
+
+    it('maps to `key`, not `systemAttribute` — the registry is keyed by key', () => {
+      const registryKeys = Object.keys(RESOURCE_FIELD_REGISTRY.article ?? {})
+
+      expect(canonicalize(TAGS_CUID)).not.toBe('article_tags')
+      expect(registryKeys).toContain('tags')
+      expect(registryKeys).not.toContain('article_tags')
+    })
+
+    it('lands on a key the builder can actually resolve', () => {
+      expect(RESOURCE_FIELD_REGISTRY.article?.[canonicalize(TAGS_CUID)]).toBeDefined()
+    })
+
+    it('leaves a system field whose key is absent from the registry unchanged', () => {
+      expect(canonicalize('cf_retired_0000000000001')).toBe('cf_retired_0000000000001')
+    })
+  })
+
+  describe('case C — genuine custom field on a system resource', () => {
+    it('rewrites a bare cuid to the `custom_` form the builder routes on', () => {
+      expect(canonicalize(CUSTOM_CUID)).toBe(`custom_${CUSTOM_CUID}`)
+    })
+
+    it('resolves the `<defId>:<cuid>` form identically to the bare cuid', () => {
+      expect(canonicalize(`${ENTITY_DEF_ID}:${CUSTOM_CUID}`)).toBe(`custom_${CUSTOM_CUID}`)
+    })
+
+    it('round-trips back to the cuid the builder queries `FieldValue.fieldId` with', () => {
+      expect(canonicalize(CUSTOM_CUID).replace(/^custom_/, '')).toBe(CUSTOM_CUID)
+    })
+  })
+
+  describe('case D — unresolvable', () => {
+    it('returns an unknown cuid unchanged', () => {
+      expect(canonicalize(UNKNOWN_CUID)).toBe(UNKNOWN_CUID)
+    })
+
+    it('returns an unknown prefixed reference unchanged', () => {
+      expect(canonicalize(`${ENTITY_DEF_ID}:${UNKNOWN_CUID}`)).toBe(
+        `${ENTITY_DEF_ID}:${UNKNOWN_CUID}`
+      )
+    })
+
+    it('resolves static keys and drops nothing when the org has no merged fields', () => {
+      expect(canonicalizeSystemFieldRef('status', 'article', [])).toBe('status')
+      expect(canonicalizeSystemFieldRef(TAGS_CUID, 'article', [])).toBe(TAGS_CUID)
+    })
+
+    it('returns an empty reference unchanged', () => {
+      expect(canonicalize('')).toBe('')
+    })
+  })
+
+  describe('idempotence', () => {
+    it.each([
+      ['static key', 'tags'],
+      ['prefixed static key', `${ENTITY_DEF_ID}:status`],
+      ['system field cuid', TAGS_CUID],
+      ['prefixed system field cuid', `${ENTITY_DEF_ID}:${TAGS_CUID}`],
+      ['custom field cuid', CUSTOM_CUID],
+      ['prefixed custom field cuid', `${ENTITY_DEF_ID}:${CUSTOM_CUID}`],
+      ['unknown cuid', UNKNOWN_CUID],
+    ])('canonicalizing a %s twice equals canonicalizing it once', (_label, fieldRef) => {
+      const once = canonicalize(fieldRef)
+      expect(canonicalize(once)).toBe(once)
+    })
+  })
+})
+
+describe('canonicalizeSystemConditions', () => {
+  it('rewrites cuid conditions across groups', () => {
+    const groups = [
+      group([condition({ id: 'c1', fieldId: TAGS_CUID, operator: 'is', value: 'tag_1' })], 'g1'),
+      group(
+        [condition({ id: 'c2', fieldId: `${ENTITY_DEF_ID}:${CUSTOM_CUID}`, value: 'high' })],
+        'g2'
+      ),
+    ]
+
+    const result = canonicalizeSystemConditions(groups, 'article', MERGED_FIELDS)
+
+    expect(result[0]?.conditions[0]?.fieldId).toBe('tags')
+    expect(result[1]?.conditions[0]?.fieldId).toBe(`custom_${CUSTOM_CUID}`)
+  })
+
+  it('preserves everything on a condition except its fieldId', () => {
+    const original = condition({ id: 'c1', fieldId: TAGS_CUID, operator: 'in', value: ['a', 'b'] })
+    const result = canonicalizeSystemConditions([group([original])], 'article', MERGED_FIELDS)
+
+    expect(result[0]?.conditions[0]).toEqual({ ...original, fieldId: 'tags' })
+  })
+
+  it('rewrites element 0 of an array fieldId and preserves the rest', () => {
+    const path = [TAGS_CUID, 'tag:name', 'name:value'] as ResourceFieldId[]
+    const result = canonicalizeSystemConditions(
+      [group([condition({ fieldId: path })])],
+      'article',
+      MERGED_FIELDS
+    )
+
+    expect(result[0]?.conditions[0]?.fieldId).toEqual(['tags', 'tag:name', 'name:value'])
+  })
+
+  it('leaves an array fieldId reference-identical when element 0 is already canonical', () => {
+    const path = ['tags', 'tag:name'] as ResourceFieldId[]
+    const original = condition({ fieldId: path })
+    const result = canonicalizeSystemConditions([group([original])], 'article', MERGED_FIELDS)
+
+    expect(result[0]?.conditions[0]?.fieldId).toBe(path)
+  })
+
+  it('canonicalizes subConditions', () => {
+    const original = condition({
+      id: 'c1',
+      fieldId: 'status',
+      subConditions: [condition({ id: 'sub-1', fieldId: TAGS_CUID })],
+    })
+
+    const result = canonicalizeSystemConditions([group([original])], 'article', MERGED_FIELDS)
+
+    expect(result[0]?.conditions[0]?.subConditions?.[0]?.fieldId).toBe('tags')
+    expect(result[0]?.conditions[0]?.fieldId).toBe('status')
+  })
+
+  it('never mutates the input', () => {
+    const original = condition({ id: 'c1', fieldId: TAGS_CUID })
+    const groups = [group([original])]
+    const snapshot = structuredClone(groups)
+
+    canonicalizeSystemConditions(groups, 'article', MERGED_FIELDS)
+
+    expect(groups).toEqual(snapshot)
+    expect(original.fieldId).toBe(TAGS_CUID)
+  })
+
+  describe('reference identity', () => {
+    it('returns the very same array, groups and conditions when nothing changes', () => {
+      const first = condition({ id: 'c1', fieldId: 'status' })
+      const second = condition({ id: 'c2', fieldId: `${ENTITY_DEF_ID}:kind` })
+      const groups = [group([first, second])]
+
+      const result = canonicalizeSystemConditions(groups, 'article', MERGED_FIELDS)
+
+      expect(result).toBe(groups)
+      expect(result[0]).toBe(groups[0])
+      expect(result[0]?.conditions).toBe(groups[0]?.conditions)
+      expect(result[0]?.conditions[0]).toBe(first)
+      expect(result[0]?.conditions[1]).toBe(second)
+    })
+
+    it('returns the same array for an unresolvable reference (case D allocates nothing)', () => {
+      const groups = [group([condition({ fieldId: UNKNOWN_CUID })])]
+
+      expect(canonicalizeSystemConditions(groups, 'article', MERGED_FIELDS)).toBe(groups)
+    })
+
+    it('allocates only for the entries that actually change', () => {
+      const untouchedGroup = group([condition({ id: 'c0', fieldId: 'status' })], 'g0')
+      const sibling = condition({ id: 'c1', fieldId: 'kind', value: 'ARTICLE' })
+      const rewritten = condition({ id: 'c2', fieldId: TAGS_CUID })
+      const groups = [untouchedGroup, group([sibling, rewritten], 'g1')]
+
+      const result = canonicalizeSystemConditions(groups, 'article', MERGED_FIELDS)
+
+      expect(result).not.toBe(groups)
+      expect(result[0]).toBe(untouchedGroup)
+      expect(result[1]).not.toBe(groups[1])
+      expect(result[1]?.conditions[0]).toBe(sibling)
+      expect(result[1]?.conditions[1]).not.toBe(rewritten)
+      expect(result[1]?.conditions[1]?.fieldId).toBe('tags')
+    })
+  })
+
+  it('is idempotent over whole condition groups', () => {
+    const groups = [
+      group([
+        condition({ id: 'c1', fieldId: TAGS_CUID }),
+        condition({ id: 'c2', fieldId: `${ENTITY_DEF_ID}:${CUSTOM_CUID}` }),
+        condition({ id: 'c3', fieldId: UNKNOWN_CUID }),
+      ]),
+    ]
+
+    const once = canonicalizeSystemConditions(groups, 'article', MERGED_FIELDS)
+    const twice = canonicalizeSystemConditions(once, 'article', MERGED_FIELDS)
+
+    expect(twice).toBe(once)
+    expect(twice).toEqual(once)
+  })
+})

--- a/packages/lib/src/resources/query-builder/canonicalize-system-fields.ts
+++ b/packages/lib/src/resources/query-builder/canonicalize-system-fields.ts
@@ -1,0 +1,186 @@
+// packages/lib/src/resources/query-builder/canonicalize-system-fields.ts
+
+import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import { RESOURCE_FIELD_REGISTRY, type TableId } from '../registry/field-registry'
+import type { ResourceField } from '../registry/field-types'
+import type { ConditionGroup, GenericCondition } from './base-condition-builder'
+
+/** The static registry slice for one system table, keyed by static field key. */
+type RegistrySlice = Record<string, ResourceField> | undefined
+
+/** Merged org fields indexed by `CustomField.id` (the cuid the filter UIs send). */
+type FieldsById = Map<string, ResourceField>
+
+/**
+ * Strip a `<entityDefinitionId>:` prefix, matching
+ * `SystemConditionBuilder.stripFieldPrefix` exactly — including its
+ * "only the first colon separates" behaviour, which comes from
+ * `parseResourceFieldId`.
+ */
+function stripFieldPrefix(fieldRef: string): string {
+  return fieldRef.includes(':')
+    ? parseResourceFieldId(fieldRef as ResourceFieldId).fieldId
+    : fieldRef
+}
+
+function indexFieldsById(fields: ResourceField[]): FieldsById {
+  const byId: FieldsById = new Map()
+  for (const field of fields) byId.set(field.id, field)
+  return byId
+}
+
+/**
+ * Resolve one field reference against the static registry and the org's merged
+ * fields. Shared by both public entry points so they can never disagree.
+ */
+function canonicalizeRef(fieldRef: string, registry: RegistrySlice, byId: FieldsById): string {
+  const stripped = stripFieldPrefix(fieldRef)
+
+  // (A) Already a static registry key — the shape the builder understands.
+  // Checked first, which is what makes the whole function idempotent: the
+  // output of (B) lands here on a second pass and is returned untouched.
+  if (registry?.[stripped]) return fieldRef
+
+  const merged = byId.get(stripped)
+
+  // (D) Unresolvable. Deliberately returned unchanged rather than guessed at:
+  // an invented FieldValue lookup would trade today's visible fail-open (the
+  // builder drops it and records a `DroppedCondition`) for a silent
+  // fail-closed wrong answer.
+  if (!merged) return fieldRef
+
+  // (B) A materialized system field. Map to `key`, NEVER to `systemAttribute`:
+  // `RESOURCE_FIELD_REGISTRY[tableId]` is keyed by the static field's id, which
+  // for these fields equals `key` (`tags`, not `article_tags`).
+  if (merged.systemAttribute) {
+    return registry?.[merged.key] ? merged.key : fieldRef
+  }
+
+  // (C) A genuine custom field on a system resource. `custom_` routes
+  // `conditionToSql` into `buildCustomFieldSubquery`, which strips the prefix
+  // back off and matches `FieldValue.fieldId` — which is this cuid.
+  return `custom_${stripped}`
+}
+
+/** Map an array, returning the input reference when every element is untouched. */
+function mapPreservingIdentity<T>(items: T[], map: (item: T) => T): T[] {
+  let changed = false
+  const next = new Array<T>(items.length)
+
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index] as T
+    const mapped = map(item)
+    if (mapped !== item) changed = true
+    next[index] = mapped
+  }
+
+  return changed ? next : items
+}
+
+/**
+ * Rewrite a condition's `fieldId`. Only element 0 of a relationship path is
+ * canonicalized — that is the only element `conditionToSql` reads — and the
+ * remaining hops are carried through untouched.
+ */
+function canonicalizeConditionFieldId(
+  fieldId: GenericCondition['fieldId'],
+  registry: RegistrySlice,
+  byId: FieldsById
+): GenericCondition['fieldId'] {
+  if (Array.isArray(fieldId)) {
+    const head = fieldId[0]
+    if (!head) return fieldId
+    const canonical = canonicalizeRef(head, registry, byId)
+    if (canonical === head) return fieldId
+    return [canonical as ResourceFieldId, ...fieldId.slice(1)]
+  }
+
+  return canonicalizeRef(fieldId, registry, byId)
+}
+
+function canonicalizeCondition(
+  condition: GenericCondition,
+  registry: RegistrySlice,
+  byId: FieldsById
+): GenericCondition {
+  const fieldId = canonicalizeConditionFieldId(condition.fieldId, registry, byId)
+  const subConditions = condition.subConditions
+    ? mapPreservingIdentity(condition.subConditions, (sub) =>
+        canonicalizeCondition(sub, registry, byId)
+      )
+    : condition.subConditions
+
+  if (fieldId === condition.fieldId && subConditions === condition.subConditions) return condition
+
+  const next: GenericCondition = { ...condition, fieldId }
+  if (subConditions !== condition.subConditions) next.subConditions = subConditions
+  return next
+}
+
+function canonicalizeGroup(
+  group: ConditionGroup,
+  registry: RegistrySlice,
+  byId: FieldsById
+): ConditionGroup {
+  const conditions = mapPreservingIdentity(group.conditions, (condition) =>
+    canonicalizeCondition(condition, registry, byId)
+  )
+
+  return conditions === group.conditions ? group : { ...group, conditions }
+}
+
+/**
+ * Rewrite one filter field reference into the form `SystemConditionBuilder`
+ * resolves.
+ *
+ * The filter UIs address a field on a system resource by the org's merged
+ * `CustomField` **cuid** (bare from the records searchbar, `<defId>:<cuid>`
+ * from the table filter builder), while the builder looks fields up in
+ * `RESOURCE_FIELD_REGISTRY[tableId]`, which is keyed by the *static* key. The
+ * mismatch made every such condition drop, widening the list.
+ *
+ * Pure and idempotent — canonicalizing twice equals canonicalizing once, so it
+ * is safe to run over a stored view that already holds either shape. Anything
+ * unresolvable is returned unchanged, which leaves the builder's existing
+ * `DroppedCondition` reporting as the failure channel.
+ *
+ * @param fieldRef - Bare or `<entityDefinitionId>:`-prefixed field reference.
+ * @param tableId - System table the filter runs against.
+ * @param fields - The org's merged fields for that resource.
+ * @returns The canonical reference, or `fieldRef` unchanged when unresolvable.
+ */
+export function canonicalizeSystemFieldRef(
+  fieldRef: string,
+  tableId: TableId,
+  fields: ResourceField[]
+): string {
+  return canonicalizeRef(fieldRef, RESOURCE_FIELD_REGISTRY[tableId], indexFieldsById(fields))
+}
+
+/**
+ * Canonicalize every condition in every group, ahead of
+ * `SystemConditionBuilder` — which is left untouched.
+ *
+ * Never mutates the input, and allocates only for entries that actually
+ * change: an all-static filter set comes back as the very same array, group
+ * and condition references, so the no-op path costs nothing.
+ *
+ * `ConditionGroup` has no nested groups (`conditions: Condition[]` only), but a
+ * `Condition` may carry `subConditions`; those are canonicalized too, so the
+ * output is uniform regardless of which consumer reads them.
+ *
+ * @param groups - Condition groups as sent by the filter surfaces.
+ * @param tableId - System table the filter runs against.
+ * @param fields - The org's merged fields for that resource.
+ * @returns Canonicalized groups, or `groups` itself when nothing changed.
+ */
+export function canonicalizeSystemConditions(
+  groups: ConditionGroup[],
+  tableId: TableId,
+  fields: ResourceField[]
+): ConditionGroup[] {
+  const registry = RESOURCE_FIELD_REGISTRY[tableId]
+  const byId = indexFieldsById(fields)
+
+  return mapPreservingIdentity(groups, (group) => canonicalizeGroup(group, registry, byId))
+}

--- a/packages/lib/src/resources/query-builder/index.ts
+++ b/packages/lib/src/resources/query-builder/index.ts
@@ -10,6 +10,11 @@ export {
   type GenericCondition,
   type ValidationResult,
 } from './base-condition-builder'
+// System field-reference canonicalization (runs before the system builder)
+export {
+  canonicalizeSystemConditions,
+  canonicalizeSystemFieldRef,
+} from './canonicalize-system-fields'
 // Backward compatibility (deprecated)
 export { ConditionQueryBuilder } from './condition-query-builder'
 


### PR DESCRIPTION
Follow-on to #1475. That PR made the dropped-filter notice visible; this fixes the thing it was being honest about.

## The bug

The filter UIs address a field on a system resource by the org's merged `CustomField` **cuid**. `SystemConditionBuilder` resolves against `RESOURCE_FIELD_REGISTRY`, keyed by the **static registry key**. So the condition never resolved, was dropped, and the query ran **fail-open** — the list silently widened.

**Confirmed user-visible:** filtering the KB articles table by Tag, Status or Kind returned the full baseline set.

Not a search bug — it breaks *every* filter on a system resource (`article`, `kb`, `dataset`, `user`, `participant`, `visit`, `inbox`) and would be true if free-text search didn't exist. The asymmetry that hid it: the same UI works on *entity* resources, because `EntityConditionBuilder` resolves from `context.fields`, which **is** cuid-keyed.

## The fix

Rewrite condition field refs into the form the builder already understands, **before** the builder sees them. `SystemConditionBuilder` is not modified at all — its behaviour and tests are unchanged by construction.

`canonicalizeSystemFieldRef` / `canonicalizeSystemConditions` are pure, synchronous, idempotent, and identity-preserving on the no-op path:

| Case | → | Why |
|---|---|---|
| already a registry key | unchanged | checked **first**, which is what makes it idempotent — stored views may hold either shape |
| cuid + `systemAttribute` | the field's `key` | `'tags'`, never `'article_tags'` — `systemAttribute` is not a registry key and would resolve nothing |
| cuid, no `systemAttribute` | `custom_<cuid>` | a genuine custom field on a system resource, routed into the existing `FieldValue` subquery |
| unresolvable | unchanged | builder still drops it → still a recorded `DroppedCondition` |

That last row is why this needs **no new diagnostics plumbing**. Resolving an unknown ref into a `FieldValue` lookup would trade today's visible fail-open for a silent fail-**closed** — same bug class, opposite direction, and worse.

Wired into **list, count and aggregate**. **Sort is fixed too** — `buildOrderBySql` took a fieldId from the same UIs and silently no-op'd.

## The regression this introduced, and closed

`inspectFilterConditions` is the AI boundary and built from **raw** filters. Canonicalizing the query lane alone would have made it **refuse conditions the query lane applies** — a false refusal created by this fix.

Both of its refusal channels needed it: `validateConditionGroups` emits `Unknown field: <cuid>` into `message` independently of `dropped`, so fixing only the build would have hidden the divergence rather than removed it.

Pinned as an **equivalence in both directions** (a 6-case `it.each` running preflight and the query lane over identical input). Refusal on genuinely unresolvable refs is unchanged and separately asserted.

## No data migration

0 of 1061 `TableView` rows target a system resource; of 5 stored system-source dashboard widgets, **none** carry a `fieldId`. Live-UI-only. The UIs are deliberately left alone — "fix them to send `key`" would break the entity lane, which resolves by cuid.

## Reviewer notes

- **`list-filtered-mail-lens.test.ts` had a silently-dead mock.** It used `importOriginal` + spread; the cache barrel's transitive graph re-enters `unified-handler-queries` *while the factory is still running*, so the module under test bound the **real** `getCachedResourceFields`. Latent until the system path started reading fields. Converted to a full factory, matching its three siblings. Inverse of the usual gotcha — here the *partial* mock was the broken one.
- **CI omits the `integration` vitest project** (needs a live DB), so the aggregate fix's real proof in `run-aggregate.int.test.ts` doesn't run there. `aggregate/canonicalize-filter-wiring.test.ts` is a deliberately weak unit guard for the wiring only — it asserts on the builder's *input*, documents why that's weak, and opens with "READ BEFORE DELETING THIS FILE AS REDUNDANT".
- **Group-by / measure never had this bug.** `findField` probes `f.id` first, which for a materialized system field **is** the cuid. Verified, not assumed.
- **Aggregate blast radius is one table** — `SYSTEM_AGGREGATE_TABLE_IDS` is `['article']`.
- **Accepted, not fixed:** aggregate cache keys are computed before canonicalization, so a cuid and a static key form two entries for the same logical filter. Deterministic, same result. Deliberate.

## Testing

`lib` project: **552 files / 6574 tests green**. Integration lane (local, DB-backed): 30 passed. Biome clean on all 9 files. **Zero new type errors** — 715 total, matching baseline; the 5 in `unified-handler-queries.ts` are pre-existing (confirmed the `sorting[0]` indexed access already exists at those sites on `main`).

Each batch was checked for non-vacuity by neutralizing the fix and confirming the new tests go red: 7/10 list lane, 5/9 preflight, 3/5 aggregate integration, 2/5 CI guard. Survivors in each case are named controls asserting refs that must arrive *unchanged*.

## Still needs a human

The KB articles table and a dashboard widget both want an eye against a real org — automated coverage proves the SQL, not the UX.