### PR TITLE
fix(search): rank mail subject hits above body hits

### DIFF
--- a/packages/lib/src/mail-query/__tests__/thread-search-sql.test.ts
+++ b/packages/lib/src/mail-query/__tests__/thread-search-sql.test.ts
@@ -1,0 +1,255 @@
+// packages/lib/src/mail-query/__tests__/thread-search-sql.test.ts
+//
+// The MAIL ranking formula — its shape, asserted on rendered SQL, and its
+// ordering behaviour, asserted on a model of that SQL.
+//
+// Two kinds of test here, and the split is deliberate:
+//
+//  1. **Rendered-SQL tests.** These pin the expression the database actually
+//     receives — above all that the keyset cursor and the `ORDER BY` are the
+//     same bytes. A cursor that disagrees with its ordering does not error, it
+//     skips and duplicates rows on page 2, and mail's ranked list is full of
+//     ties, so this is a live bug rather than a corner.
+//  2. **Model tests.** Vitest has no Postgres, so `ts_rank_cd` and `similarity`
+//     cannot be evaluated here. The model below reproduces the formula in
+//     TypeScript from constants MEASURED against the dev database (see each
+//     constant), and its weights are asserted against the generated SQL, so it
+//     cannot silently drift from the source. What it proves is the ordering
+//     property the weight was chosen for — not that Postgres implements
+//     `ts_rank_cd` as documented, which the measurements already established.
+//
+// `schema` is mocked rather than used: under this package's Vitest setup
+// `@auxx/database`'s `schema` is a Proxy whose COLUMNS read `undefined`, so a
+// Drizzle-column-bound fragment renders to nonsense. The mock below is PARTIAL —
+// it keeps `createSchemaMock`'s auto-vivification, because a full replacement
+// makes any table another module touches at import time `undefined` and kills
+// the file at collection.
+
+import type { sql } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  const { sql: raw } = await import('drizzle-orm')
+  return {
+    database: createChainableDatabaseMock(),
+    schema: createSchemaMock({
+      Thread: {
+        id: raw.raw('"Thread"."id"'),
+        subject: raw.raw('"Thread"."subject"'),
+        searchText: raw.raw('"Thread"."searchText"'),
+      },
+    }),
+  }
+})
+
+const { threadSearchCursor, threadSearchRank, threadSubjectSearchPredicate } = await import(
+  '../thread-search-sql'
+)
+
+const dialect = new PgDialect()
+const render = (fragment: ReturnType<typeof sql>) => dialect.sqlToQuery(fragment)
+
+/**
+ * The weights the formula is built from. Asserted against the generated SQL in
+ * the first test below, so the model cannot outlive a change to the source.
+ */
+const TRIGRAM_WEIGHT = 2
+const SUBJECT_WEIGHT = 11
+
+/**
+ * `ts_rank_cd`'s score for ONE cover of one unlabelled lexeme.
+ *
+ * Measured, not assumed: Postgres returns 0.1 for a single cover, 0.2 for two
+ * and 0.3 for three, and — the part that matters — the same 0.1 whether the
+ * document is one word or 800, because the default normalization does not divide
+ * by length. That is the whole reason the body arm needs saturating.
+ */
+const PER_COVER = 0.1
+
+/** `ts_rank_cd(…, 32)` — verified against the database as exactly `r / (r + 1)`. */
+const saturate = (rank: number) => rank / (rank + 1)
+
+/** The TypeScript model of {@link threadSearchRank}. */
+const rank = (row: { similarity?: number; subjectCovers?: number; bodyCovers?: number }) =>
+  (row.similarity ?? 0) * TRIGRAM_WEIGHT +
+  saturate(PER_COVER * (row.subjectCovers ?? 0)) * SUBJECT_WEIGHT +
+  saturate(PER_COVER * (row.bodyCovers ?? 0))
+
+/** The formula as it stood before the subject arm — for the regression tests. */
+const previousRank = (row: { similarity?: number; bodyCovers?: number }) =>
+  (row.similarity ?? 0) * TRIGRAM_WEIGHT + PER_COVER * (row.bodyCovers ?? 0)
+
+describe('threadSearchRank shape', () => {
+  it('is three arms: trigram x2, saturated subject x11, saturated body x1', () => {
+    const { sql: text, params } = render(threadSearchRank('invoice'))
+
+    expect(text).toBe(
+      '(COALESCE(similarity("Thread"."subject", $1), 0) * 2 + ' +
+        `COALESCE(ts_rank_cd(to_tsvector('english', COALESCE("Thread"."subject", '')), ` +
+        `plainto_tsquery('english', $2), 32), 0) * 11 + ` +
+        `COALESCE(ts_rank_cd(to_tsvector('english', COALESCE("Thread"."searchText", '')), ` +
+        `plainto_tsquery('english', $3), 32), 0))`
+    )
+    expect(params).toEqual(['invoice', 'invoice', 'invoice'])
+  })
+
+  it('uses the same weights the model below reasons about', () => {
+    // The one thread tying the rendered SQL to the arithmetic tests. If someone
+    // retunes a weight without revisiting the derivation, this fails first.
+    const { sql: text } = render(threadSearchRank('invoice'))
+    expect(text).toContain(`, 0) * ${TRIGRAM_WEIGHT} +`)
+    expect(text).toContain(`, 0) * ${SUBJECT_WEIGHT} +`)
+  })
+
+  it('saturates BOTH ts_rank_cd arms, not just one', () => {
+    // Saturating only the body arm would leave subject covers unbounded, letting
+    // a subject that repeats the term outrank an exact subject match. Saturating
+    // only the subject arm would leave the 30x scale gap the weight is supposed
+    // to close. The flag has to be on both.
+    const { sql: text } = render(threadSearchRank('invoice'))
+    expect(text.match(/, 32\), 0\)/g)).toHaveLength(2)
+  })
+
+  it('scores the subject even though the body is the shared binding’s document', () => {
+    // The bug this file exists for: the rank used to read `Thread.searchText` as
+    // its only tsvector, so the subject contributed through whole-string
+    // `similarity()` alone.
+    const { sql: text } = render(threadSearchRank('invoice'))
+    expect(text).toContain(`to_tsvector('english', COALESCE("Thread"."subject", ''))`)
+    expect(text).toContain(`to_tsvector('english', COALESCE("Thread"."searchText", ''))`)
+  })
+
+  it('is a score, never a match — no % operator can leak into the ordering', () => {
+    // `%` belongs to the predicate. In the rank it would make the cursor and the
+    // ORDER BY compare different things.
+    const { sql: text } = render(threadSearchRank('invoice'))
+    expect(text).not.toContain(' % ')
+    expect(text).not.toContain('ILIKE')
+  })
+})
+
+describe('threadSearchCursor / ORDER BY agreement', () => {
+  it('restates the ORDER BY expression identically, twice', () => {
+    // 🔴 The load-bearing test. `threads/thread-query.service.ts` orders by
+    // `desc(threadSearchRank(term))` and resumes with `threadSearchCursor`; a
+    // WHERE cannot see a SELECT alias, so the cursor recomputes the rank. If the
+    // two ever differ — by a COALESCE, by a normalization flag, by a weight —
+    // page 2 silently drops and repeats rows instead of failing.
+    //
+    // "Identically" is asserted modulo PLACEHOLDER ORDINALS, and only those: the
+    // same fragment rendered at offset 0 binds $1..$3 while the copy after the
+    // score binds $5..$7. That is Drizzle numbering parameters positionally, not
+    // the expressions differing — the params test below pins that every one of
+    // those slots receives the same term.
+    const ordinalFree = (text: string) => text.replace(/\$\d+/g, '$?')
+    const ordering = ordinalFree(render(threadSearchRank('invoice')).sql)
+    const cursor = ordinalFree(render(threadSearchCursor('invoice', 0.75, 'thr_9')).sql)
+
+    expect(cursor.split(ordering)).toHaveLength(3)
+    expect(cursor).toBe(`(${ordering} < $? OR (${ordering} = $? AND "Thread"."id" < $?))`)
+  })
+
+  it('changes with the rank — the two cannot be edited apart', () => {
+    // The structural guarantee behind the test above: the cursor is
+    // `textSearchKeyset` applied to `threadSearchRank`, so there is no second
+    // copy of the formula to forget to update. Re-derive the expected cursor
+    // from the rank alone and it must match what the cursor actually emits.
+    const ordinalFree = (text: string) => text.replace(/\$\d+/g, '$?')
+    const rankSql = ordinalFree(render(threadSearchRank('refund')).sql)
+    const cursorSql = ordinalFree(render(threadSearchCursor('refund', 0.5, 'thr_1')).sql)
+
+    expect(cursorSql).toBe(`(${rankSql} < $? OR (${rankSql} = $? AND "Thread"."id" < $?))`)
+  })
+
+  it('binds the term once per rank occurrence, in cursor order', () => {
+    const { params } = render(threadSearchCursor('invoice', 0.75, 'thr_9'))
+    expect(params).toEqual([
+      'invoice',
+      'invoice',
+      'invoice',
+      0.75,
+      'invoice',
+      'invoice',
+      'invoice',
+      0.75,
+      'thr_9',
+    ])
+  })
+
+  it('tie-breaks on the thread id, the same column the ORDER BY tie-breaks on', () => {
+    const { sql: cursor } = render(threadSearchCursor('invoice', 0.75, 'thr_9'))
+    expect(cursor).toContain('AND "Thread"."id" < ')
+  })
+})
+
+describe('ranking behaviour', () => {
+  it('ranks a subject hit above a body-only match at equal textual strength', () => {
+    expect(rank({ subjectCovers: 1 })).toBeGreaterThan(rank({ bodyCovers: 1 }))
+  })
+
+  it('ranks a weak subject hit above the strongest body-only match', () => {
+    // The property the weight was derived for, at the extreme observed on the dev
+    // org: a body mentioning the term 31 times (raw ts_rank_cd 3.1, the real
+    // maximum for `invoice`) still loses to a subject that mentions it once.
+    expect(rank({ subjectCovers: 1 })).toBeGreaterThan(rank({ bodyCovers: 31 }))
+    expect(rank({ subjectCovers: 1 })).toBeGreaterThan(rank({ bodyCovers: 93 }))
+  })
+
+  it('caps the body arm strictly below the weakest subject arm, at any length', () => {
+    // The derivation, stated as an assertion: saturation bounds the body arm on
+    // [0, 1), and 11 x (0.1/1.1) is exactly 1.0. No body corpus can close that.
+    const weakestSubjectArm = saturate(PER_COVER) * SUBJECT_WEIGHT
+    expect(weakestSubjectArm).toBeCloseTo(1, 10)
+    for (const covers of [1, 10, 100, 10_000]) {
+      expect(saturate(PER_COVER * covers)).toBeLessThan(weakestSubjectArm)
+    }
+  })
+
+  it('still lets an exact subject match dominate', () => {
+    const exact = rank({ similarity: 1, subjectCovers: 1 })
+    expect(exact).toBeGreaterThan(rank({ similarity: 0.42, subjectCovers: 1, bodyCovers: 10 }))
+    expect(exact).toBeGreaterThan(rank({ bodyCovers: 1000 }))
+    // Including against a subject that pads its cover count — saturating the
+    // subject arm is what keeps repetition from beating exactness.
+    expect(exact).toBeGreaterThan(rank({ similarity: 0.23, subjectCovers: 3 }))
+  })
+
+  it('still ranks a body-only match above no match — no regression to zero', () => {
+    expect(rank({ bodyCovers: 1 })).toBeGreaterThan(0)
+    expect(rank({})).toBe(0)
+  })
+
+  it('preserves the ordering WITHIN each arm, which is what saturation costs nothing', () => {
+    // `r / (r + 1)` is strictly increasing, so a thread whose body says it more
+    // still outranks one that says it less. Only the cross-arm scale changed.
+    expect(rank({ bodyCovers: 5 })).toBeGreaterThan(rank({ bodyCovers: 2 }))
+    expect(rank({ subjectCovers: 2 })).toBeGreaterThan(rank({ subjectCovers: 1 }))
+  })
+
+  it('fixes the ordering the previous formula got wrong', () => {
+    // Regression pin, with the real numbers from the dev org. Under the old
+    // formula a 31-cover body scored 3.1 and beat an exact subject match's 2.0 —
+    // which is why a search for `invoice` returned six threads with no "invoice"
+    // in the subject before the first one that had it.
+    const exactSubject = { similarity: 1, subjectCovers: 1 }
+    const longBody = { bodyCovers: 31 }
+
+    expect(previousRank(longBody)).toBeGreaterThan(previousRank(exactSubject))
+    expect(rank(exactSubject)).toBeGreaterThan(rank(longBody))
+  })
+})
+
+describe('the lens split is untouched', () => {
+  it('leaves the subject predicate a subject-only expression', () => {
+    // The rank now reads both columns; the PREDICATES must not. Subject
+    // visibility (`identity`) and body visibility (`read`) are separate tiers,
+    // scoped separately by `condition-query-builder.ts`, and a body reference
+    // leaking into the subject predicate would let a subject-only viewer MATCH
+    // on text they cannot read.
+    const { sql: text } = render(threadSubjectSearchPredicate('invoice'))
+    expect(text).toContain('"Thread"."subject"')
+    expect(text).not.toContain('"Thread"."searchText"')
+  })
+})

--- a/packages/lib/src/mail-query/thread-search-sql.ts
+++ b/packages/lib/src/mail-query/thread-search-sql.ts
@@ -1,9 +1,19 @@
 // packages/lib/src/mail-query/thread-search-sql.ts
 //
 // The MAIL binding of the shared ranked-search builder (`search/text-search-sql.ts`).
-// It names `Thread` columns and nothing else — the ranking formula, the OR-block
-// predicate and the keyset cursor all come from the shared module, so mail and
-// records (`resources/search/record-search-sql.ts`) cannot drift apart.
+// It names `Thread` columns and nothing else — the OR-block predicate, every
+// scoring primitive and the keyset shape all come from the shared module, so mail
+// and records (`resources/search/record-search-sql.ts`) cannot drift apart.
+//
+// The one thing mail does NOT take from the shared module is the assembled
+// ranking formula. `textSearchRank` blends ONE document score with ONE trigram
+// score, and mail has two documents: a subject and a body corpus, deliberately
+// kept apart (see below). {@link threadSearchRank} therefore composes the shared
+// *parts* — `textSearchTrigramScore`, `textSearchDocumentScore` — into a
+// three-arm score with a subject `ts_rank_cd` weighted above the body one,
+// because people search mail by what they remember of the subject line. That arm
+// has no meaning on the records side, where there is no second corpus and no
+// tier split to reflect, which is why it lives here and not there.
 //
 // 🔴 **No lens, no visibility predicate lives here.** Mail narrows with the
 // §5.3 search scopes from `visibility-scope.ts`, AND-ed around each block by
@@ -19,13 +29,62 @@
 // body text.
 
 import { schema } from '@auxx/database'
-import type { SQL } from 'drizzle-orm'
+import { type SQL, sql } from 'drizzle-orm'
 import {
   type TextSearchColumns,
-  textSearchCursor,
+  TRIGRAM_WEIGHT,
+  TS_RANK_SATURATING,
+  textSearchDocumentScore,
+  textSearchKeyset,
   textSearchPredicate,
-  textSearchRank,
+  textSearchTrigramScore,
 } from '../search/text-search-sql'
+
+/**
+ * How much a subject `ts_rank_cd` hit outweighs a body one, in
+ * {@link threadSearchRank}.
+ *
+ * 🔴 **`11` is derived, not tuned.** Both `ts_rank_cd` arms of the thread rank
+ * are saturated with {@link TS_RANK_SATURATING} (`r / (r + 1)`), which bounds the
+ * BODY arm on `[0, 1)` — supremum 1, never attained. The weakest possible SUBJECT
+ * hit is a single cover of a single lexeme, which unnormalized `ts_rank_cd`
+ * scores at exactly `0.1` (measured, and it is length-independent), saturating to
+ * `0.1 / 1.1 = 1/11`. So `11 × 1/11 = 1.0 >` every attainable body score:
+ *
+ * > **no amount of body text can outweigh a single subject hit.**
+ *
+ * That is the property the constant buys, and it is checkable rather than a
+ * matter of taste. Raise it and nothing changes qualitatively; lower it below 11
+ * and the guarantee silently becomes "…outweighs *most* body text", failing first
+ * on the longest threads — the ones a mailbox has fewest of and a test fixture
+ * never contains.
+ *
+ * ⚠️ **Stated precisely, because the tempting stronger claim is false.** The
+ * guarantee is arm-to-arm, not row-to-row: the trigram arm is shared, so a
+ * body-only row whose subject merely *resembles* the query still collects up to
+ * `2 × similarity` and can in principle total above a weak subject hit's `1.0`.
+ * That is not body text winning — the trigram arm scores the SUBJECT, so such a
+ * row is one whose subject nearly is the query without stemming to it, which is a
+ * subject signal too. And above `similarity ≥ 0.3` the row matches the subject
+ * predicate outright. Measured across six real terms on the dev org the crossover
+ * never occurred (weakest subject hit `1.10`–`1.19`, strongest body-only
+ * `0.72`–`1.06`), but the window exists and is deliberate rather than overlooked.
+ *
+ * **Why saturation was needed to state a weight at all.** Unnormalized
+ * `ts_rank_cd` is ~0.1 per cover with no length division, so on the dev org the
+ * body arm reaches `9.3` for `order` and `3.1` for `invoice` while the subject
+ * arm — capped by how short subjects are — never exceeds `0.3`. Blending those
+ * raw numbers, a weight below ~30 leaves long bodies winning and a weight above
+ * it is an unfalsifiable guess. Saturating first replaces the guess with the
+ * arithmetic above; because `r / (r + 1)` is strictly increasing it does not
+ * reorder rows *within* either arm, so nothing is lost but the scale gap.
+ *
+ * **What it does NOT do:** it does not let subject covers outrank an exact
+ * subject match. Exact scores `2 × similarity = 2.0` from the trigram arm plus
+ * `1.0` from its own subject cover — `3.0` — while a 3-cover subject arm reaches
+ * `11 × 0.3/1.3 = 2.54`, so the trigram arm still decides the top of the list.
+ */
+const SUBJECT_RANK_WEIGHT = sql.raw('11')
 
 /**
  * The **subject** arm: `Thread.subject`, the short human-facing column.
@@ -64,7 +123,11 @@ export function threadSubjectSearchColumns(): TextSearchColumns {
  * The **body** arm: `Thread.searchText`, the maintained message-body corpus
  * (`thread-search-text.ts`). Backed by `Thread_org_searchText_gin_idx`.
  *
- * `rank` names `Thread.subject` rather than the corpus deliberately. Trigram
+ * `rank` here feeds the PREDICATE's trigram arm only — {@link threadSearchRank}
+ * takes its trigram score from the subject binding instead, so this field no
+ * longer influences ordering.
+ *
+ * It names `Thread.subject` rather than the corpus deliberately. Trigram
  * similarity between a 6-character query and a 40 KB document is ~0 by
  * construction, and a `gin_trgm_ops` index over that column would be enormous —
  * so there is no body column worth ranking fuzzily. Pointing `rank` at the
@@ -114,7 +177,35 @@ export function threadBodySearchPredicate(query: string): SQL {
 }
 
 /**
- * The thread relevance score over the body corpus.
+ * The thread relevance score — three arms, subject-weighted:
+ *
+ * ```text
+ *   2  × similarity(subject, q)                    -- exact/near-exact subject
+ * + 11 × ts_rank_cd(tsv(subject),    q, 32)        -- subject stem hit
+ * +  1 × ts_rank_cd(tsv(searchText), q, 32)        -- body stem hit
+ * ```
+ *
+ * each `COALESCE`d to 0, so a row matching only one arm still ranks.
+ *
+ * The subject arm is the point (see {@link SUBJECT_RANK_WEIGHT} for why the
+ * weight is 11 and why both `ts_rank_cd`s are saturated). Before it existed the
+ * only subject signal was whole-string `similarity()`, which is ~0.15 for a short
+ * query against a long subject — so on the dev org a search for `invoice`
+ * returned six threads with no "invoice" in the subject at all before the first
+ * one that had it.
+ *
+ * ⚠️ **The score reads body text; the two PREDICATES do not blend.** Subject
+ * visibility (`identity`) and body visibility (`read`) are separate lens tiers,
+ * scoped separately by `condition-query-builder.ts`'s `withScope`, and this
+ * function does not touch that: a subject-only viewer still cannot MATCH on body
+ * text, so no row enters their result set because of a body they cannot read.
+ * What the body arm can do is influence the ORDER of rows they can already see.
+ * That is pre-existing — the previous formula's document score was the body
+ * corpus and nothing else — and the subject arm strictly reduces its reach,
+ * since any subject hit now outranks any body-only contribution. Making the rank
+ * lens-aware would mean two rank expressions and two cursors; it is not worth it
+ * for an ordering signal, but it is a real (if narrow) inference channel and
+ * should be stated rather than discovered.
  *
  * Consumed by `threads/thread-query.service.ts`, which orders by
  * `relevance DESC, id DESC` when a free-text term is present and falls back to
@@ -126,18 +217,28 @@ export function threadBodySearchPredicate(query: string): SQL {
  * Anything else needing a thread score must call this rather than restate the
  * formula — the reason the shared module exists is that the expression was
  * written out six times on the records side before it did.
- *
- * Known limitation: `document` is the body corpus (subject is excluded from it
- * for the identity/read lens split) and `rank` scores `Thread.subject` by
- * whole-string `similarity()`, so a short query against a long subject scores
- * low and can sink below body matches. An exact subject match scores ~2.0 and
- * dominates as intended; a subject `ts_rank_cd` arm would be the real fix.
  */
 export function threadSearchRank(query: string): SQL<number> {
-  return textSearchRank(query, threadBodySearchColumns())
+  const subject = threadSubjectSearchColumns()
+  const trigramScore = textSearchTrigramScore(query, subject)
+  const subjectScore = textSearchDocumentScore(query, subject, TS_RANK_SATURATING)
+  const bodyScore = textSearchDocumentScore(query, threadBodySearchColumns(), TS_RANK_SATURATING)
+
+  return sql<number>`(COALESCE(${trigramScore}, 0) * ${TRIGRAM_WEIGHT} + COALESCE(${subjectScore}, 0) * ${SUBJECT_RANK_WEIGHT} + COALESCE(${bodyScore}, 0))`
 }
 
-/** The keyset filter for a `score|id` cursor over ranked thread results. */
+/**
+ * The keyset filter for a `score|id` cursor over ranked thread results.
+ *
+ * 🔴 **Calls {@link threadSearchRank}, the same function the `ORDER BY` calls.**
+ * The rank expression appears twice in the rendered SQL because a `WHERE` cannot
+ * see a `SELECT` alias — but it is *generated* twice from one definition, never
+ * written twice. A cursor and an `ORDER BY` that disagree by a single `COALESCE`
+ * skip and duplicate rows across pages instead of erroring, and mail pages by
+ * exactly this keyset (`threads/thread-query.service.ts`), where ranked ties are
+ * the common case rather than the corner. `text-search-sql.test.ts` pins the two
+ * as textually identical.
+ */
 export function threadSearchCursor(query: string, score: number, id: string): SQL {
-  return textSearchCursor(query, threadBodySearchColumns(), score, id)
+  return textSearchKeyset(threadSearchRank(query), threadBodySearchColumns().id, score, id)
 }

--- a/packages/lib/src/search/text-search-sql.test.ts
+++ b/packages/lib/src/search/text-search-sql.test.ts
@@ -21,7 +21,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   type TextSearchColumns,
+  TS_RANK_SATURATING,
   textSearchCursor,
+  textSearchDocumentScore,
+  textSearchKeyset,
   textSearchPredicate,
   textSearchRank,
   textSearchTrigramMatch,
@@ -104,6 +107,28 @@ describe('textSearchRank', () => {
   })
 })
 
+describe('textSearchDocumentScore', () => {
+  it('emits no normalization argument by default, so the record score is unchanged', () => {
+    // The optional flag was added for mail's two-corpus rank. Records project
+    // this score raw to the picker, and a stray third argument would silently
+    // rescale every record relevance score in the product.
+    const { sql: text } = render(textSearchDocumentScore('acme', COLS))
+    expect(text).toBe(
+      `ts_rank_cd(to_tsvector('english', COALESCE(ei."searchText", '')), plainto_tsquery('english', $1))`
+    )
+  })
+
+  it('appends the saturating flag when asked', () => {
+    // Flag 32 is `r / (r + 1)`. Verified against the database rather than the
+    // docs: ts_rank_cd(…, 32) returns 0.09090909 for a raw 0.1 and 0.23076923
+    // for a raw 0.3 — exactly r/(r+1) in both cases.
+    const { sql: text } = render(textSearchDocumentScore('acme', COLS, TS_RANK_SATURATING))
+    expect(text).toBe(
+      `ts_rank_cd(to_tsvector('english', COALESCE(ei."searchText", '')), plainto_tsquery('english', $1), 32)`
+    )
+  })
+})
+
 describe('textSearchTrigramMatch', () => {
   it('ANDs the indexable % operator with the explicit threshold', () => {
     const { sql: text, params } = render(textSearchTrigramMatch('acme', COLS))
@@ -131,6 +156,17 @@ describe('textSearchCursor', () => {
     expect(text).toContain(rank)
     expect(text).toContain(`AND ei."id" < `)
     expect(params).toEqual(['acme', 'acme', 0.75, 'acme', 'acme', 0.75, 'inst_9'])
+  })
+
+  it('is textSearchKeyset over textSearchRank — one definition, not two', () => {
+    // The structural version of the assertion above: the cursor is not merely
+    // *similar* to the keyset shape applied to the rank, it IS that, so a change
+    // to either can only ever move both.
+    const composed = render(textSearchKeyset(textSearchRank('acme', COLS), COLS.id, 0.75, 'inst_9'))
+    const direct = render(textSearchCursor('acme', COLS, 0.75, 'inst_9'))
+
+    expect(direct.sql).toBe(composed.sql)
+    expect(direct.params).toEqual(composed.params)
   })
 
   it('carries no match operator — the cursor is a score comparison, not a filter', () => {

--- a/packages/lib/src/search/text-search-sql.ts
+++ b/packages/lib/src/search/text-search-sql.ts
@@ -115,8 +115,32 @@ const TRIGRAM_THRESHOLD = sql.raw('0.3')
  * How much a name hit outweighs a document hit. `ts_rank_cd` returns small
  * fractions, so this is what keeps "the record actually called Acme" above "a
  * record whose blob mentions Acme".
+ *
+ * Exported so a domain that composes its own rank out of these parts —
+ * `mail-query/thread-search-sql.ts` does — weights the trigram arm with the same
+ * number rather than retyping `2`.
  */
-const TRIGRAM_WEIGHT = sql.raw('2')
+export const TRIGRAM_WEIGHT = sql.raw('2')
+
+/**
+ * `ts_rank_cd`'s normalization flag `32`: "divide the rank by itself + 1".
+ *
+ * 🔴 **This is the only thing that makes a cover-density score comparable across
+ * two columns of different length.** Unnormalized `ts_rank_cd` is ~0.1 per cover
+ * and is NOT divided by document length, so it grows without bound in a long
+ * document: measured on the dev org, `ts_rank_cd` over `Thread."searchText"`
+ * reaches **9.3** for `order` and 3.1 for `invoice`, while the same expression
+ * over `Thread."subject"` caps at **0.3** — a 30x scale gap that has nothing to
+ * do with relevance and everything to do with the corpus being longer. Any fixed
+ * weight blending those two raw numbers is a guess that the longer column wins.
+ *
+ * Flag 32 maps `r` to `r / (r + 1)`, which is strictly increasing (so it never
+ * reorders rows within one arm) and bounded on `[0, 1)` (so a weight on ANOTHER
+ * arm can be derived against a known supremum instead of guessed). Verified
+ * against the database: `ts_rank_cd(…, 32)` returns exactly `r / (r + 1)`
+ * (`0.1 → 0.09090909`, `0.3 → 0.23076923`).
+ */
+export const TS_RANK_SATURATING = sql.raw('32')
 
 /**
  * `to_tsvector(config, COALESCE(document, ''))` — the indexed expression.
@@ -134,9 +158,26 @@ export function textSearchQuery(query: string): SQL {
   return sql`plainto_tsquery(${TS_CONFIG}, ${query})`
 }
 
-/** The full-text half of the score: `ts_rank_cd(document, query)`. */
-export function textSearchDocumentScore(query: string, cols: TextSearchColumns): SQL<number> {
-  return sql<number>`ts_rank_cd(${textSearchDocument(cols)}, ${textSearchQuery(query)})`
+/**
+ * The full-text half of the score: `ts_rank_cd(document, query)`.
+ *
+ * @param normalization - an optional `ts_rank_cd` normalization flag, e.g.
+ *   {@link TS_RANK_SATURATING}. Omitted by default, and deliberately so: the
+ *   record binding's score is projected raw to the picker and pinned by test, and
+ *   a domain with a single document column has nothing to make it comparable
+ *   *to*. Pass one only when two differently-sized corpora are being blended.
+ */
+export function textSearchDocumentScore(
+  query: string,
+  cols: TextSearchColumns,
+  normalization?: SQL
+): SQL<number> {
+  const document = textSearchDocument(cols)
+  const parsed = textSearchQuery(query)
+  if (!normalization) {
+    return sql<number>`ts_rank_cd(${document}, ${parsed})`
+  }
+  return sql<number>`ts_rank_cd(${document}, ${parsed}, ${normalization})`
 }
 
 /** The fuzzy half of the score: `similarity(rank, q)`, `pg_trgm`. */
@@ -242,8 +283,16 @@ export function textSearchPredicate(query: string, cols: TextSearchColumns): SQL
  * Note that {@link textSearchTrigramMatch} deliberately did **not** change this:
  * `%` is a *match* operator, not a score, so the fuzzy arm's indexability fix
  * left {@link textSearchRank} — and therefore this cursor and the `ORDER BY` it
- * mirrors — byte-identical. Any future change that touches the score must touch
- * both, which is why they are one function.
+ * mirrors — identical. Any future change that touches the score must touch both,
+ * which is why the rank is built by one function and the comparison by another
+ * ({@link textSearchKeyset}); neither is restated anywhere.
+ *
+ * ⚠️ "Identical" means *identical modulo placeholder ordinals*, which is the only
+ * form achievable: the rank appears twice, so Drizzle numbers the first copy's
+ * parameters `$1…` and the second's from wherever the score left off. The
+ * expressions are the same and each slot receives the same term — the tests
+ * normalize `$\d+` before comparing and pin the params array separately. Do not
+ * "fix" a rendered-SQL test by making the two copies share ordinals.
  *
  * @param score - the last row's combined score, from the previous page's cursor
  * @param id - the last row's id, the tie-break
@@ -254,6 +303,34 @@ export function textSearchCursor(
   score: number,
   id: string
 ): SQL {
-  const rank = textSearchRank(query, cols)
-  return sql`(${rank} < ${score} OR (${rank} = ${score} AND ${cols.id} < ${id}))`
+  return textSearchKeyset(textSearchRank(query, cols), cols.id, score, id)
+}
+
+/**
+ * The keyset filter for an ARBITRARY rank expression — the shape
+ * {@link textSearchCursor} is made of, exposed so a domain that composes its own
+ * score can reuse the shape without restating the comparison.
+ *
+ * 🔴 **Pass the expression the `ORDER BY` uses, from the same function call.**
+ * The whole hazard this module exists to prevent is a cursor and an `ORDER BY`
+ * that disagree — which does not error, it skips and duplicates rows on page 2.
+ * Taking the rank as a *parameter* rather than rebuilding it from columns is what
+ * lets `mail-query/thread-search-sql.ts` bind a rank this module knows nothing
+ * about (it carries a subject arm records have no equivalent for) and still be
+ * structurally incapable of drifting from its own ordering: `threadSearchCursor`
+ * calls `threadSearchRank`, the same function `ORDER BY` calls.
+ *
+ * @param rank - the ordering expression, rendered twice (a `WHERE` cannot see a
+ *   `SELECT` alias, so the recomputation is unavoidable)
+ * @param id - the tie-break column
+ * @param score - the last row's score, from the previous page's cursor
+ * @param cursorId - the last row's id
+ */
+export function textSearchKeyset(
+  rank: SQL<number>,
+  id: TextSearchRef,
+  score: number,
+  cursorId: string
+): SQL {
+  return sql`(${rank} < ${score} OR (${rank} = ${score} AND ${id} < ${cursorId}))`
 }


### PR DESCRIPTION
Follow-up #3 from the retrieval plan. Independent of #2b and #4, which follow separately.

## The bug

`threadSearchRank` scored `Thread.subject` by whole-string `similarity()` while its document score came from the body corpus. A short query against a long subject scored ~0.15, so **subject matches sank below body matches**.

Measured on the dev org (6,475 threads), searching `invoice`: **the top six results had no "invoice" in the subject at all.** The sharpest case — a 31-cover body scored **3.100**, ranking *above an exact subject match* at **2.000**.

## The fix

```
   2 × similarity(subject, q)                 -- exact/near-exact subject
+ 11 × ts_rank_cd(tsv(subject),    q, 32)     -- subject stem hit
+  1 × ts_rank_cd(tsv(searchText), q, 32)     -- body stem hit
```

**The weight is arithmetic, not a guess.** `ts_rank_cd` is not divided by document length, so the arms are nowhere near comparable — on real data the body arm reaches **9.3** while the subject arm never exceeds **0.3**. Simply "weighting subject higher" would have changed nothing visible.

Normalization flag `32` (`r/(r+1)`) saturates both onto `[0,1)`, which makes the weight derivable: the weakest possible subject hit is one cover — `0.1` raw, `1/11` saturated — so `11 × 1/11 = 1.0` clears every attainable body score. Saturation is monotonic, so ordering **within** each arm is unchanged.

**After:** exact subject `3.000`, that same 31-cover body `0.756`. Every top `invoice` result is now a subject hit.

The guarantee is stated **arm-to-arm, not absolutely** — the trigram arm is shared, so a body-only row whose subject merely *resembles* the query can total 1.06 against a weakest subject hit of 1.10. An earlier draft of the comment overclaimed; the data disproved it.

## Rank and cursor cannot drift

`textSearchKeyset` is extracted in the shared module, and `threadSearchCursor` calls `threadSearchRank` — **the same function the ORDER BY calls**. There is no second copy of the formula.

This matters more than it looks: mail pages by this keyset and ranked ties are the common case, where a cursor disagreeing with its ORDER BY *skips and duplicates rows instead of erroring*. Paged all **628** `invoice` matches in pages of 50 → **628 distinct, 0 skipped**.

## Scope

The assembled formula stays **mail-only**. `textSearchRank` blends one document with one trigram score; mail has two documents and two lens tiers, and a "subject arm" has no meaning on the records side. Mail composes the shared *primitives* instead. Two domain-neutral additions to the shared module: an optional `normalization` param (omitted by default — **records rendering pinned byte-identical by a new test**) and `textSearchKeyset`.

Predicates are untouched — no arm added to `textSearchPredicate`. `EXPLAIN ANALYZE` confirms the four-arm `BitmapOr` intact, 458 ms vs 472 ms (noise, both dominated by detoasting `searchText`).

## On the lens

The score reads body text, so a body match can influence the **order** of rows a subject-only viewer already sees. **This is pre-existing** — the old document score was the body corpus and nothing else — and the subject arm strictly *reduces* its reach. No row enters their result set because of a body they cannot read, because the two predicates remain separately scoped. Now documented at `threadSearchRank` rather than left to be discovered.

## Also fixed

An imprecise claim in the shared module: the rank and cursor copies are **not** byte-identical — Drizzle numbers their placeholders `$1–$3` vs `$5–$7`. The pinning test normalizes placeholders and asserts params separately. This surfaced as a genuine test failure, not a review catch.

## Testing

98 tests green across `search/` + `mail-query/`. Biome clean. `packages/lib` tsc unchanged at 715, none in these files.

Beyond the suite, validated against the live dev DB: before/after orderings on six real terms, the full 628-row keyset pagination sweep, and `EXPLAIN ANALYZE` on the predicate.