### PR TITLE
fix(resources): report dropped filters on counts, aggregates and the AI boundary

### DIFF
--- a/apps/web/src/components/dashboard/hooks/use-record-list-data.ts
+++ b/apps/web/src/components/dashboard/hooks/use-record-list-data.ts
@@ -17,12 +17,16 @@ import {
   MAX_RECORD_LIST_PAGE_SIZE,
   type RecordListConfig,
 } from '@auxx/lib/dashboards/client'
+import type { DroppedFilterNotice } from '@auxx/lib/resources/client'
 import { toRecordId } from '@auxx/lib/resources/client'
 import type { RecordId } from '@auxx/types/resource'
 import { keepPreviousData } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { api } from '~/trpc/react'
 import { useDashboardStore } from '../stores/dashboard-draft-store'
+
+/** Stable empty array — a fresh `[]` per render would churn every consumer's memo. */
+const NO_DROPPED_CONDITIONS: DroppedFilterNotice[] = []
 
 /** The entity def id / system table id the widget's source points at. */
 function sourceId(config: RecordListConfig): string {
@@ -59,12 +63,23 @@ export function useRecordListData(config: RecordListConfig, _widgetId?: string) 
     [query.data?.ids, entityDefinitionId]
   )
 
+  // A widget's filters are STORED — the config outlives the fields it names, so
+  // this is the surface most likely to end up quietly widened (a renamed field,
+  // a deleted select option). `total` below is exactly the number a dropped
+  // condition inflates, so the widget renders the notice beside it.
+  const droppedConditions = query.data?.droppedConditions ?? NO_DROPPED_CONDITIONS
+  const droppedConditionCount = query.data?.droppedConditionCount ?? droppedConditions.length
+
   return {
     entityDefinitionId,
     /** Raw entity-instance ids (the `{ id }` rows the DynamicTable renders). */
     ids: query.data?.ids ?? [],
     recordIds,
     total: query.data?.total ?? 0,
+    /** Server-capped filter conditions that produced no SQL (usually empty). */
+    droppedConditions,
+    /** Uncapped total behind {@link droppedConditions}. */
+    droppedConditionCount,
     isLoading: query.isLoading,
     isError: query.isError,
     error: query.error,

--- a/apps/web/src/components/dashboard/ui/widget/chart-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/chart-widget.tsx
@@ -25,6 +25,7 @@ import { formatMetricValue, formatMetricValueCompact } from '../../lib/format-va
 import { BarChartWidget } from './bar-chart-widget'
 import { LineChartWidget } from './line-chart-widget'
 import { PieChartWidget } from './pie-chart-widget'
+import { WidgetDroppedFilters } from './widget-dropped-filters'
 import { WidgetEmpty, WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
 
 type GroupedChartConfig = BarChartConfig | LineChartConfig | PieChartConfig
@@ -118,6 +119,13 @@ export function ChartWidget({
           Top {rows.length} shown
         </p>
       )}
+      {/* A dropped widget filter does not add visible rows here — it inflates
+          every bar. This strip is the only tell. */}
+      <WidgetDroppedFilters
+        source={config.source}
+        droppedConditions={data.droppedConditions}
+        droppedConditionCount={data.droppedConditionCount}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/dashboard/ui/widget/gauge-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/gauge-widget.tsx
@@ -17,6 +17,7 @@ import { useKpiData } from '../../hooks/use-kpi-data'
 import { useMetricFieldMeta } from '../../hooks/use-metric-field'
 import { seriesColors } from '../../lib/chart-palettes'
 import { formatMetricValue } from '../../lib/format-value'
+import { WidgetDroppedFilters } from './widget-dropped-filters'
 import { WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
 
 const GAUGE_CONFIG: ChartConfig = { value: { label: 'Value' } }
@@ -55,29 +56,38 @@ export function GaugeWidget({
   const fill = seriesColors(normalizePaletteId(config.color), 1)[0]
 
   return (
-    <div className='relative flex flex-1 min-h-0 items-end justify-center'>
-      <ChartContainer config={GAUGE_CONFIG} className='aspect-square h-full w-full max-h-full'>
-        <RadialBarChart
-          data={[{ value: clamped, fill }]}
-          startAngle={180}
-          endAngle={0}
-          innerRadius='70%'
-          outerRadius='100%'>
-          <PolarAngleAxis type='number' domain={[min, max]} angleAxisId={0} tick={false} />
-          <RadialBar dataKey='value' angleAxisId={0} background cornerRadius={8} />
-        </RadialBarChart>
-      </ChartContainer>
-      <div className='absolute inset-x-0 bottom-[15%] flex flex-col items-center'>
-        <span className='font-semibold text-2xl tabular-nums leading-none'>
-          {formatMetricValue(data.value, config.metric.op, meta)}
-        </span>
-        {config.showDataLabels && (
-          <span className='mt-1 text-muted-foreground text-xs tabular-nums'>
-            {formatMetricValue(min, config.metric.op, meta)} –{' '}
-            {formatMetricValue(max, config.metric.op, meta)}
+    <div className='flex flex-1 min-h-0 flex-col'>
+      <div className='relative flex flex-1 min-h-0 items-end justify-center'>
+        <ChartContainer config={GAUGE_CONFIG} className='aspect-square h-full w-full max-h-full'>
+          <RadialBarChart
+            data={[{ value: clamped, fill }]}
+            startAngle={180}
+            endAngle={0}
+            innerRadius='70%'
+            outerRadius='100%'>
+            <PolarAngleAxis type='number' domain={[min, max]} angleAxisId={0} tick={false} />
+            <RadialBar dataKey='value' angleAxisId={0} background cornerRadius={8} />
+          </RadialBarChart>
+        </ChartContainer>
+        <div className='absolute inset-x-0 bottom-[15%] flex flex-col items-center'>
+          <span className='font-semibold text-2xl tabular-nums leading-none'>
+            {formatMetricValue(data.value, config.metric.op, meta)}
           </span>
-        )}
+          {config.showDataLabels && (
+            <span className='mt-1 text-muted-foreground text-xs tabular-nums'>
+              {formatMetricValue(min, config.metric.op, meta)} –{' '}
+              {formatMetricValue(max, config.metric.op, meta)}
+            </span>
+          )}
+        </div>
       </div>
+      {/* Outside the arc's positioning context so the absolute value overlay
+          keeps its geometry — the gauge is unchanged when nothing dropped. */}
+      <WidgetDroppedFilters
+        source={config.source}
+        droppedConditions={data.droppedConditions}
+        droppedConditionCount={data.droppedConditionCount}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/dashboard/ui/widget/kpi-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/kpi-widget.tsx
@@ -18,6 +18,7 @@ import { Info, Minus, TrendingDown, TrendingUp } from 'lucide-react'
 import { useKpiData } from '../../hooks/use-kpi-data'
 import { useMetricFieldMeta } from '../../hooks/use-metric-field'
 import { computeTrendDelta, formatMetricValue, formatTrendPercent } from '../../lib/format-value'
+import { WidgetDroppedFilters } from './widget-dropped-filters'
 import { WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
 
 export function KpiWidget({
@@ -70,6 +71,14 @@ export function KpiWidget({
           </SimpleTooltip>
         )
       )}
+
+      {/* The single-number case: nothing on this tile hints that a filter was
+          ignored, and the trend arrow is computed off the same widened set. */}
+      <WidgetDroppedFilters
+        source={config.source}
+        droppedConditions={data.droppedConditions}
+        droppedConditionCount={data.droppedConditionCount}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/dashboard/ui/widget/record-list-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/record-list-widget.tsx
@@ -19,6 +19,8 @@ import { toRecordId } from '@auxx/lib/resources/client'
 import type { RecordId } from '@auxx/types/resource'
 import { useCallback, useMemo } from 'react'
 import { DynamicTable } from '~/components/dynamic-table'
+import { DroppedFiltersNotice } from '~/components/dynamic-table/components/dropped-filters-notice'
+import { useResourceFields } from '~/components/resources'
 import { type RecordListRow, useRecordListColumns } from '../../hooks/use-record-list-columns'
 import { useRecordListData } from '../../hooks/use-record-list-data'
 import { WidgetEmpty, WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
@@ -37,10 +39,21 @@ export function RecordListWidget({
   /** Opens the record in the dashboard's page-level docked/overlay drawer. */
   onOpenRecord?: (recordId: RecordId) => void
 }) {
-  const { ids, entityDefinitionId, total, isLoading, isError, error } = useRecordListData(
-    config,
-    widgetId
-  )
+  const {
+    ids,
+    entityDefinitionId,
+    total,
+    droppedConditions,
+    droppedConditionCount,
+    isLoading,
+    isError,
+    error,
+  } = useRecordListData(config, widgetId)
+
+  // Only to name the offending field in the notice's tooltip — the fields are
+  // already loaded for this def by the column builder below, so this is a cache
+  // read, not a second fetch.
+  const { fields } = useResourceFields(entityDefinitionId)
 
   const openRecord = useCallback(
     (instanceId: string) => onOpenRecord?.(toRecordId(entityDefinitionId, instanceId)),
@@ -92,6 +105,14 @@ export function RecordListWidget({
 
       <p className='shrink-0 border-t pt-1.5 text-muted-foreground text-xs'>
         Showing {rows.length} of {total}
+        {/* Beside the count on purpose — `total` is exactly what a stored
+            widget filter naming a retired field inflates. Renders nothing in
+            the normal case. */}
+        <DroppedFiltersNotice
+          droppedConditions={droppedConditions}
+          droppedConditionCount={droppedConditionCount}
+          fields={fields}
+        />
       </p>
     </div>
   )

--- a/apps/web/src/components/dashboard/ui/widget/widget-dropped-filters.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/widget-dropped-filters.tsx
@@ -1,0 +1,54 @@
+// apps/web/src/components/dashboard/ui/widget/widget-dropped-filters.tsx
+'use client'
+
+import type { WidgetSource } from '@auxx/lib/dashboards/client'
+import type { DroppedFilterNotice } from '@auxx/lib/resources/client'
+import { DroppedFiltersNotice } from '~/components/dynamic-table/components/dropped-filters-notice'
+import { useResourceFields } from '~/components/resources'
+
+/** The entity def id / system table id a widget's source points at. */
+function sourceId(source: WidgetSource | undefined): string {
+  if (!source) return ''
+  return source.kind === 'entity' ? source.entityDefinitionId : source.tableId
+}
+
+interface WidgetDroppedFiltersProps {
+  /** The widget's data source — used only to name the offending field. */
+  source: WidgetSource | undefined
+  /** Server-capped conditions that produced no SQL. */
+  droppedConditions: DroppedFilterNotice[] | undefined
+  /** Uncapped total behind {@link droppedConditions}. */
+  droppedConditionCount: number | undefined
+}
+
+/**
+ * The aggregate engine's half of {@link DroppedFiltersNotice} — same primitive,
+ * same wording, wrapped in the tiny footer strip the chart widgets already use
+ * for "Top N shown".
+ *
+ * A widget's filters are STORED, so they outlive the fields they name; and
+ * unlike a list, a chart or KPI that loses a filter does not show extra rows —
+ * it shows a number that is simply too HIGH. `runAggregate` logs the drop but
+ * the person reading the tile never sees the log, which is what this closes.
+ *
+ * Renders nothing in the overwhelmingly common clean case.
+ */
+export function WidgetDroppedFilters({
+  source,
+  droppedConditions,
+  droppedConditionCount,
+}: WidgetDroppedFiltersProps) {
+  const { fields } = useResourceFields(sourceId(source))
+
+  if (!droppedConditionCount) return null
+
+  return (
+    <div className='shrink-0 pt-1 text-center text-[10px] text-muted-foreground'>
+      <DroppedFiltersNotice
+        droppedConditions={droppedConditions ?? []}
+        droppedConditionCount={droppedConditionCount}
+        fields={fields}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/dynamic-table/components/calendar/calendar-view-body.tsx
+++ b/apps/web/src/components/dynamic-table/components/calendar/calendar-view-body.tsx
@@ -7,10 +7,12 @@ import type { EventCalendarItem, SlotCreateIntent } from '@auxx/ui/components/ev
 import { EventCalendar } from '@auxx/ui/components/event-calendar'
 import { useCallback } from 'react'
 import { useCalendarRange } from '~/components/calendar/core/use-calendar-range'
+import { useResourceFields } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useTableConfig } from '../../context/table-config-context'
 import { useViewMetadata } from '../../context/view-metadata-context'
 import { useCalendarConfig, useTableFilters } from '../../stores/store-selectors'
+import { DroppedFiltersNotice } from '../dropped-filters-notice'
 import { useCalendarEvents } from './use-calendar-events'
 
 /**
@@ -31,12 +33,10 @@ export function CalendarViewBody() {
   // quantizes the week stream), so the hook's Monday default is fine unwired.
   const { date, setDate, range, handleRangeChange } = useCalendarRange('month')
 
-  const { events, dateField, endField } = useCalendarEvents(
-    entityDefinitionId,
-    calendarConfig,
-    range,
-    viewFilters
-  )
+  const { events, dateField, endField, droppedConditions, droppedConditionCount } =
+    useCalendarEvents(entityDefinitionId, calendarConfig, range, viewFilters)
+
+  const { fields } = useResourceFields(entityDefinitionId)
 
   // Drag to reschedule (plan §3.3) — `event` is the pre-drag original item (its
   // `start`/`end` are untouched), `newStart`/`newEnd` are the drop's computed,
@@ -117,6 +117,19 @@ export function CalendarViewBody() {
         hideToolbar
         className='flex-1 min-h-0'
       />
+      {/* The calendar branch of `DynamicView` renders no `DynamicTableFooter`,
+          so this is its own strip — present only when something was dropped,
+          which is the overwhelmingly uncommon case. A widened calendar has no
+          count to sit beside; the tell is chips outside the month window. */}
+      {droppedConditionCount > 0 && (
+        <div className='shrink-0 border-t px-4 py-1.5 text-sm'>
+          <DroppedFiltersNotice
+            droppedConditions={droppedConditions}
+            droppedConditionCount={droppedConditionCount}
+            fields={fields}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.test.ts
+++ b/apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.test.ts
@@ -1,0 +1,69 @@
+// apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.test.ts
+//
+// The calendar is the one surface that drains MULTIPLE `listFiltered` pages for
+// a single view, so it is the one place the dropped-filter report has to be
+// FOLDED rather than read. Getting that fold wrong reproduces, in the notice
+// itself, exactly the kind of wrong number the notice exists to report.
+
+import type { DroppedFilterNotice } from '@auxx/lib/resources/client'
+import { describe, expect, it } from 'vitest'
+import { mergeDroppedFilterPages } from './use-calendar-events'
+
+const notice = (n: number): DroppedFilterNotice => ({
+  conditionId: `c${n}`,
+  fieldRef: `contact:cf_${n}`,
+  operator: 'is',
+  reason: 'unresolved-field-or-operator',
+})
+
+describe('mergeDroppedFilterPages', () => {
+  it('reports nothing when every page was clean', () => {
+    expect(mergeDroppedFilterPages([{}, {}, {}])).toEqual({
+      droppedConditions: [],
+      droppedConditionCount: 0,
+    })
+  })
+
+  it('counts one ignored filter ONCE across identical pages', () => {
+    // The expected production shape: same filters, same fields, same drop on
+    // every page. Concatenating would say "4 filters were ignored" for one
+    // filter, purely because the month needed four pages.
+    const page = { droppedConditions: [notice(1)], droppedConditionCount: 1 }
+
+    expect(mergeDroppedFilterPages([page, page, page, page])).toEqual({
+      droppedConditions: [notice(1)],
+      droppedConditionCount: 1,
+    })
+  })
+
+  it('unions distinct conditions if pages ever disagree', () => {
+    // They should not — but the fold must not silently lose one if they do.
+    const merged = mergeDroppedFilterPages([
+      { droppedConditions: [notice(1)], droppedConditionCount: 1 },
+      { droppedConditions: [notice(2)], droppedConditionCount: 1 },
+    ])
+
+    expect(merged.droppedConditions).toEqual([notice(1), notice(2)])
+  })
+
+  it('takes the MAX count, not the sum — each page total is already uncapped', () => {
+    const merged = mergeDroppedFilterPages([
+      { droppedConditions: [notice(1)], droppedConditionCount: 3 },
+      { droppedConditions: [notice(1)], droppedConditionCount: 3 },
+    ])
+
+    expect(merged.droppedConditionCount).toBe(3)
+  })
+
+  it('keeps a count that exceeds the delivered array — the server cap survives the fold', () => {
+    // 25 delivered, 40 dropped, on every page. The uncapped total has to come
+    // through, or the notice undercounts exactly where it matters most.
+    const delivered = Array.from({ length: 25 }, (_, i) => notice(i))
+    const page = { droppedConditions: delivered, droppedConditionCount: 40 }
+
+    const merged = mergeDroppedFilterPages([page, page])
+
+    expect(merged.droppedConditions).toHaveLength(25)
+    expect(merged.droppedConditionCount).toBe(40)
+  })
+})

--- a/apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.ts
+++ b/apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.ts
@@ -4,7 +4,7 @@
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { getOptionColorHex } from '@auxx/lib/custom-fields/client'
 import { formatToDisplayValue, formatToRawValue } from '@auxx/lib/field-values/client'
-import type { ResourceField } from '@auxx/lib/resources/client'
+import type { DroppedFilterNotice, ResourceField } from '@auxx/lib/resources/client'
 import { toRecordId } from '@auxx/lib/resources/client'
 import { toResourceFieldId } from '@auxx/types/field'
 import type { TypedFieldValue } from '@auxx/types/field-value'
@@ -48,6 +48,46 @@ function buildRangeFilterGroup(dateFieldId: string, range: DateRange): Condition
   }
 }
 
+/** Stable empty array — a fresh `[]` per render would churn every consumer's memo. */
+const NO_DROPPED_CONDITIONS: DroppedFilterNotice[] = []
+
+/** One page's slice of the dropped-filter report, as `record.listFiltered` returns it. */
+type DroppedFilterPage = {
+  droppedConditions?: DroppedFilterNotice[]
+  droppedConditionCount?: number
+}
+
+/**
+ * Fold the per-page dropped-filter reports the drain loop collects into one.
+ *
+ * Every page compiles the SAME filters against the same fields, so every page
+ * reports the same drops — but this does not *assume* that. Concatenating would
+ * turn one ignored filter into "10 filters ignored" purely as a function of how
+ * many pages the month needed, which is the same class of wrong number the
+ * notice exists to stop, so notices are deduped by `conditionId`.
+ *
+ * The count is the MAX rather than a sum for the matching reason: each page's
+ * `droppedConditionCount` is already that page's UNCAPPED total, so summing
+ * would multiply it — and the max still exceeds the deduped array whenever the
+ * server cap truncated the notices.
+ */
+export function mergeDroppedFilterPages(pages: DroppedFilterPage[]): {
+  droppedConditions: DroppedFilterNotice[]
+  droppedConditionCount: number
+} {
+  const byConditionId = new Map<string, DroppedFilterNotice>()
+  let droppedConditionCount = 0
+
+  for (const page of pages) {
+    for (const dropped of page.droppedConditions ?? []) {
+      if (!byConditionId.has(dropped.conditionId)) byConditionId.set(dropped.conditionId, dropped)
+    }
+    droppedConditionCount = Math.max(droppedConditionCount, page.droppedConditionCount ?? 0)
+  }
+
+  return { droppedConditions: [...byConditionId.values()], droppedConditionCount }
+}
+
 /**
  * Record ids on the calendar's date axis within `range`, honoring the view's own saved
  * filters (`viewFilters`) plus an injected range condition group. Pure `(entityDefinitionId,
@@ -55,14 +95,25 @@ function buildRangeFilterGroup(dateFieldId: string, range: DateRange): Condition
  * "source" for the personal calendar would reuse this shape unchanged).
  *
  * A range query doesn't fit `useRecordList`'s infinite-query shape (the range itself changes
- * under the cursor), so this drains `record.listFiltered` offset pages directly.
+ * under the cursor), so this drains `record.listFiltered` offset pages directly — which is
+ * also why the dropped-filter report has to be **aggregated** here rather than read off one
+ * page; see the drain loop.
+ *
+ * The injected range group matters for the report: if `after`/`before` on the configured date
+ * field ever fail to compile, every record on the axis shows regardless of the month being
+ * viewed. That is the one drop on this surface a user would otherwise read as a data bug.
  */
 export function useCalendarRecordIds(
   entityDefinitionId: string | undefined,
   config: CalendarViewConfig | undefined,
   range: DateRange,
   viewFilters: ConditionGroup[]
-): { ids: string[]; isLoading: boolean } {
+): {
+  ids: string[]
+  isLoading: boolean
+  droppedConditions: DroppedFilterNotice[]
+  droppedConditionCount: number
+} {
   const utils = api.useUtils()
   const dateFieldId = config?.dateFieldId
 
@@ -83,6 +134,9 @@ export function useCalendarRecordIds(
     ],
     queryFn: async () => {
       const ids: string[] = []
+      // Collected per page and folded once — see `mergeDroppedFilterPages` for
+      // why this dedupes rather than concatenates.
+      const droppedPages: DroppedFilterPage[] = []
       let offset = 0
       for (let page = 0; page < MAX_PAGES; page++) {
         const result = await utils.record.listFiltered.fetch({
@@ -92,16 +146,22 @@ export function useCalendarRecordIds(
           offset,
         })
         ids.push(...result.ids)
+        droppedPages.push(result)
         if (!result.hasMore) break
         offset += result.ids.length
       }
-      return ids
+      return { ids, ...mergeDroppedFilterPages(droppedPages) }
     },
     enabled: Boolean(entityDefinitionId && dateFieldId),
     staleTime: 30_000,
   })
 
-  return { ids: query.data ?? [], isLoading: query.isFetching }
+  return {
+    ids: query.data?.ids ?? [],
+    isLoading: query.isFetching,
+    droppedConditions: query.data?.droppedConditions ?? NO_DROPPED_CONDITIONS,
+    droppedConditionCount: query.data?.droppedConditionCount ?? 0,
+  }
 }
 
 /**
@@ -125,11 +185,24 @@ export function useCalendarEvents(
   dateField: ResourceField | undefined
   /** The resolved end-date field, if `config.endDateFieldId` is set. */
   endField: ResourceField | undefined
+  /**
+   * Filter conditions the server could not compile, deduped across the drained
+   * pages. Non-empty ⇒ the calendar is showing MORE than the view's filters (or
+   * the month window) ask for.
+   */
+  droppedConditions: DroppedFilterNotice[]
+  /** Uncapped total behind {@link droppedConditions}. */
+  droppedConditionCount: number
 } {
   const { fields } = useResourceFields(entityDefinitionId)
   const { resource } = useResource(entityDefinitionId)
 
-  const { ids, isLoading } = useCalendarRecordIds(entityDefinitionId, config, range, viewFilters)
+  const { ids, isLoading, droppedConditions, droppedConditionCount } = useCalendarRecordIds(
+    entityDefinitionId,
+    config,
+    range,
+    viewFilters
+  )
 
   const dateField = useMemo(
     () => fields?.find((f) => f.id === config?.dateFieldId),
@@ -271,5 +344,5 @@ export function useCalendarEvents(
     primaryField,
   ])
 
-  return { events, isLoading, dateField, endField }
+  return { events, isLoading, dateField, endField, droppedConditions, droppedConditionCount }
 }

--- a/packages/lib/src/ai/kopilot/capabilities/entities/shared/record-filters.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/shared/record-filters.ts
@@ -10,6 +10,8 @@ import {
   OPERATOR_DEFINITIONS,
   type Operator,
 } from '../../../../../conditions/operator-definitions'
+import { UnprocessableEntityError } from '../../../../../errors'
+import type { CountFilteredResult } from '../../../../../resources/crud'
 import { getFieldOptions } from '../../../../../resources/registry/option-helpers'
 import type { Resource } from '../../../../../resources/registry/types'
 import { isAiBlockedResource } from './ai-entity-visibility'
@@ -59,6 +61,13 @@ export type QueryWarning =
   | { kind: 'multi_hop_dot_notation'; field: string; hint: string }
   | { kind: 'entity_name_normalized'; from: string; to: string; hint: string }
   | { kind: 'invalid_value'; field: string; operator: string; value: unknown; hint: string }
+  /**
+   * A filter that passed {@link validateFilters} and then produced no SQL in the
+   * query builder. Distinct from every other kind here: those are front-door
+   * rejections the LLM can fix from the hint alone, this one means the number
+   * the tool is about to report counts MORE records than were asked for.
+   */
+  | { kind: 'filter_not_applied'; field: string; operator: string; hint: string }
 
 /** Zod mirror of {@link QueryWarning} for tool output schemas. */
 export const QueryWarningSchema = z.object({
@@ -292,6 +301,62 @@ export function validateFilters(
   }
 
   return { valid, warnings }
+}
+
+/** A dropped condition's field reference as one readable token. */
+function describeFieldRef(fieldRef: string | string[]): string {
+  return Array.isArray(fieldRef) ? fieldRef.join('.') : fieldRef
+}
+
+/**
+ * The AI boundary's verdict on a count whose filters did not all compile.
+ *
+ * `validateFilters` is the front door and catches malformed input; this is the
+ * back door, where a filter that looked fine produced no SQL anyway (a retired
+ * field, an operator the field's builder cannot express, an unresolvable
+ * `valueSource`). The list lane treats that as "wider, and said so" — correct
+ * there, because the extra rows are visible on screen. A count has no such tell:
+ * it is one number that reads exactly as authoritative when it is the unfiltered
+ * total, and an agent will state it as fact.
+ *
+ * So the rule is asymmetric, and deliberately so:
+ *
+ * - **Every** condition dropped ⇒ throw. The answer would not be a wider answer
+ *   to the question asked, it would be the answer to a different question
+ *   ("how many tickets exist" for "how many open tickets"). This is the same
+ *   line `inspectFilterConditions` draws, and `allConditionsDropped` is the
+ *   same discriminant — `false` for the genuine no-filter case, so an unfiltered
+ *   `countOnly: true` still answers.
+ * - **Some** conditions dropped ⇒ answer, with a warning per drop. The count is
+ *   still too high, but the surviving conditions did narrow it, and the model
+ *   can see exactly which one to fix.
+ *
+ * @param resourceLabel - Human label of the counted resource, for the message.
+ * @returns One `filter_not_applied` warning per reported drop; empty when clean.
+ * @throws UnprocessableEntityError when every requested condition was dropped.
+ */
+export function assertCountFiltersApplied(
+  count: CountFilteredResult,
+  resourceLabel: string
+): QueryWarning[] {
+  const notices = count.droppedConditions ?? []
+  const named = notices.map((d) => `'${describeFieldRef(d.fieldRef)}' ${d.operator}`).join(', ')
+
+  if (count.allConditionsDropped) {
+    throw new UnprocessableEntityError(
+      `None of the ${count.droppedConditionCount ?? notices.length} filter condition(s) could be applied${
+        named ? ` (${named})` : ''
+      }, so this count would be the UNFILTERED total for "${resourceLabel}" reported as a filtered one. ` +
+        'Call list_entity_fields to check field ids and operators, then retry.'
+    )
+  }
+
+  return notices.map((d) => ({
+    kind: 'filter_not_applied' as const,
+    field: describeFieldRef(d.fieldRef),
+    operator: d.operator,
+    hint: `Filter "${describeFieldRef(d.fieldRef)} ${d.operator}" could not be applied (${d.reason}) and was ignored — the count above is HIGHER than the filters ask for. Call list_entity_fields to check the field id and operator.`,
+  }))
 }
 
 /**

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/count-drops-refusal.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/count-drops-refusal.test.ts
@@ -1,0 +1,248 @@
+// packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/count-drops-refusal.test.ts
+//
+// The AI boundary for a WIDENED COUNT.
+//
+// `countEntityInstances` / `countSystemResource` fail open: a filter condition
+// the builder cannot compile is dropped and the `COUNT(*)` runs anyway. For a
+// list that is the right call and the reporting channel is enough — the extra
+// rows are on screen. For a count it is not: the answer is a single number that
+// reads exactly as authoritative when it is the unfiltered total, and an agent
+// will state it as fact ("you have 6,470 open tickets").
+//
+// So the rule, and it is asymmetric on purpose:
+//
+//   • EVERY condition dropped ⇒ refuse. Not a wider answer to the question
+//     asked — the answer to a different question. Same line
+//     `inspectFilterConditions` draws, same `allConditionsDropped` discriminant,
+//     which is `false` for the genuine no-filter case so an unfiltered
+//     `countOnly` still answers.
+//   • SOME conditions dropped ⇒ answer, with a warning naming each ignored one.
+//     The survivors did narrow the count, and the model can see what to fix.
+
+import { describe, expect, it, vi } from 'vitest'
+
+const CONTACT = {
+  id: 'def_contact',
+  entityDefinitionId: 'def_contact',
+  entityType: 'contact',
+  apiSlug: 'contacts',
+  label: 'Contact',
+  plural: 'Contacts',
+  isVisible: true,
+  fields: [{ id: 'contact_status', key: 'status', label: 'Status', fieldType: 'TEXT' }],
+}
+
+/** A system-table-backed resource, to prove the other count lane refuses too. */
+const ARTICLE = {
+  id: 'article',
+  entityDefinitionId: 'article',
+  entityType: 'article',
+  apiSlug: 'articles',
+  label: 'Article',
+  plural: 'Articles',
+  isVisible: true,
+  fields: [{ id: 'article_status', key: 'status', label: 'Status', fieldType: 'TEXT' }],
+}
+
+const RESOURCES = [CONTACT, ARTICLE]
+
+vi.mock('../../../../../../cache/org-cache-helpers', () => ({
+  findCachedResource: vi.fn(
+    async (_orgId: string, key: string) =>
+      RESOURCES.find((r) => r.id === key || r.entityType === key || r.apiSlug === key) ?? null
+  ),
+  getCachedResources: vi.fn(async () => RESOURCES),
+}))
+
+/**
+ * Full factory, not `importOriginal` + spread: this is a LOCAL barrel whose
+ * transitive graph re-enters the modules under test, and a partial mock there
+ * binds the real helper and silently no-ops (see the sibling crud tests).
+ */
+const countEntity = vi.fn()
+const countSystem = vi.fn()
+
+vi.mock('../../../../../../resources/crud', () => ({
+  countEntityInstances: (...args: unknown[]) => countEntity(...args),
+  countSystemResource: (...args: unknown[]) => countSystem(...args),
+  isSystemResource: (id: string) => id === 'article',
+  UnifiedCrudHandler: class {
+    listFiltered() {
+      return { ids: [], hasMore: false, total: 0 }
+    }
+    getByIds() {
+      return {}
+    }
+  },
+}))
+
+import { UnprocessableEntityError } from '../../../../../../errors'
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../../agent-framework/types'
+import { countRecordMatches } from '../../../record-views/count-matches'
+import { createQueryRecordsTool } from '../query-records'
+
+const CTX = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+
+/** One condition that passes the front door, so only the BUILDER can drop it. */
+const STATUS_FILTER = [{ field: 'status', operator: 'is', value: 'OPEN' }]
+
+/** The count-lane result shape, with the drop report the builder produced. */
+function countResult(over: { count: number; allConditionsDropped: boolean; dropped?: number }) {
+  const dropped = over.dropped ?? 0
+  return {
+    count: over.count,
+    allConditionsDropped: over.allConditionsDropped,
+    ...(dropped > 0
+      ? {
+          droppedConditionCount: dropped,
+          droppedConditions: Array.from({ length: dropped }, (_, i) => ({
+            conditionId: `filter-${i}`,
+            fieldRef: 'contacts:status',
+            operator: 'is',
+            reason: 'unresolved-field-or-operator' as const,
+          })),
+        }
+      : {}),
+  }
+}
+
+function runCount(args: Record<string, unknown>) {
+  const tool = createQueryRecordsTool(() => ({ db: {}, capabilities: undefined }) as never)
+  return tool.execute({ countOnly: true, ...args }, CTX) as Promise<AgentToolResult>
+}
+
+describe('query_records countOnly — every condition dropped', () => {
+  it('refuses instead of reporting the unfiltered total', async () => {
+    countEntity.mockResolvedValue(
+      countResult({ count: 6470, allConditionsDropped: true, dropped: 1 })
+    )
+
+    const result = await runCount({ entity: 'contact', filters: STATUS_FILTER })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('UNFILTERED')
+    expect(result.error).toContain('Contact')
+  })
+
+  it('leaks the widened number nowhere in the refusal', async () => {
+    countEntity.mockResolvedValue(
+      countResult({ count: 6470, allConditionsDropped: true, dropped: 1 })
+    )
+
+    const result = await runCount({ entity: 'contact', filters: STATUS_FILTER })
+
+    // A refusal that still prints the number is not a refusal — the model would
+    // read it out of the error string.
+    expect(JSON.stringify(result)).not.toContain('6470')
+    expect(JSON.stringify(result)).not.toContain('total_matching')
+  })
+
+  it('refuses on the system-table lane identically', async () => {
+    countSystem.mockResolvedValue(
+      countResult({ count: 900, allConditionsDropped: true, dropped: 1 })
+    )
+
+    const result = await runCount({ entity: 'article', filters: STATUS_FILTER })
+
+    expect(countSystem).toHaveBeenCalled()
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('UNFILTERED')
+  })
+
+  it('names the ignored condition so the model can fix it in one turn', async () => {
+    countEntity.mockResolvedValue(
+      countResult({ count: 6470, allConditionsDropped: true, dropped: 1 })
+    )
+
+    const result = await runCount({ entity: 'contact', filters: STATUS_FILTER })
+
+    expect(result.error).toContain('status')
+    expect(result.error).toContain('list_entity_fields')
+  })
+
+  it('returns a failed result rather than throwing out of execute', async () => {
+    countEntity.mockResolvedValue(
+      countResult({ count: 6470, allConditionsDropped: true, dropped: 1 })
+    )
+
+    // The tool's own idiom for a caller-caused refusal is `success: false` — the
+    // same shape as its ambiguous / not-found / blocked branches. A thrown tool
+    // is logged as an internal fault, which this is not.
+    await expect(runCount({ entity: 'contact', filters: STATUS_FILTER })).resolves.toMatchObject({
+      success: false,
+    })
+  })
+})
+
+describe('query_records countOnly — a partial drop still answers', () => {
+  it('returns the count and warns about the condition that was ignored', async () => {
+    countEntity.mockResolvedValue(
+      countResult({ count: 88, allConditionsDropped: false, dropped: 1 })
+    )
+
+    const result = await runCount({ entity: 'contact', filters: STATUS_FILTER })
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ total_matching: 88 })
+    const warnings = (result.output as { warnings?: Array<{ kind: string; hint: string }> })
+      .warnings
+    expect(warnings?.some((w) => w.kind === 'filter_not_applied')).toBe(true)
+    expect(warnings?.find((w) => w.kind === 'filter_not_applied')?.hint).toContain('HIGHER')
+  })
+
+  it('answers a clean count with no warnings at all', async () => {
+    countEntity.mockResolvedValue(countResult({ count: 12, allConditionsDropped: false }))
+
+    const result = await runCount({ entity: 'contact', filters: STATUS_FILTER })
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ total_matching: 12, warnings: undefined })
+  })
+
+  it('answers a genuinely UNFILTERED count — the no-filter case is not a drop', async () => {
+    // `allConditionsDropped` is false when nothing was asked for, which is the
+    // only reason "count every contact" is still a legal question here.
+    countEntity.mockResolvedValue(countResult({ count: 6470, allConditionsDropped: false }))
+
+    const result = await runCount({ entity: 'contact' })
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ total_matching: 6470 })
+  })
+})
+
+describe('countRecordMatches — the record-view preview lane', () => {
+  const args = {
+    db: {} as never,
+    organizationId: 'org_1',
+    resource: CONTACT as never,
+    entityDefinitionId: 'def_contact',
+    filters: [{ field: 'status', operator: 'is', value: 'OPEN' }],
+    logicalOperator: 'AND' as const,
+  }
+
+  it('throws an AuxxError when every condition dropped', async () => {
+    countEntity.mockResolvedValue(
+      countResult({ count: 6470, allConditionsDropped: true, dropped: 1 })
+    )
+
+    // `UnprocessableEntityError`, not a `TRPCError`: this is lib code, reached
+    // from a worker-hosted agent as often as from a request.
+    await expect(countRecordMatches(args)).rejects.toBeInstanceOf(UnprocessableEntityError)
+  })
+
+  it('still answers on a partial drop', async () => {
+    countEntity.mockResolvedValue(
+      countResult({ count: 88, allConditionsDropped: false, dropped: 1 })
+    )
+
+    await expect(countRecordMatches(args)).resolves.toBe(88)
+  })
+
+  it('answers a clean count', async () => {
+    countEntity.mockResolvedValue(countResult({ count: 5, allConditionsDropped: false }))
+
+    await expect(countRecordMatches(args)).resolves.toBe(5)
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
@@ -16,6 +16,7 @@ import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 import { blockedEntityError } from '../shared/ai-entity-visibility'
 import {
+  assertCountFiltersApplied,
   convertToConditionGroup,
   type QueryWarning,
   QueryWarningSchema,
@@ -123,6 +124,7 @@ Response shape:
 - returned_count: number of items in this page
 - total_matching: total records that match the filters
 - warnings[]: present only when a filter was dropped (unknown field/operator, invalid option value, etc.). Read the hint and retry with the fix.
+- countOnly: if NONE of your filters could be applied the tool errors instead of returning the unfiltered total; if only some were dropped you get the count plus a warning per ignored filter.
 
 Operator notes:
 - "is not X" matches records without a value too (including unset). To exclude only set values ≠ X, combine "not empty" AND "is not X".
@@ -293,7 +295,7 @@ Examples:
 
       // Count-only mode — short-circuit: run just `SELECT COUNT(*)`, skip id fetch + hydration.
       if (countOnly) {
-        const total = isSystemResource(entityDefId)
+        const counted = isSystemResource(entityDefId)
           ? await countSystemResource({
               db,
               tableId: entityDefId as TableId,
@@ -307,11 +309,28 @@ Examples:
               filters: conditionGroups,
             })
 
+        // The query lane fails OPEN and reports; this boundary refuses when
+        // nothing survived — "6,470" for "how many open tickets" is worse than
+        // an error, because the model states it as fact. A partial drop still
+        // answers, with one warning per ignored condition. `assertCountFiltersApplied`
+        // throws an `AuxxError`; the tool's own idiom for a refusal the caller
+        // caused is `success: false`, same as the branches above, so it is
+        // translated rather than allowed to surface as a thrown tool.
+        try {
+          warnings.push(...assertCountFiltersApplied(counted, resource.label))
+        } catch (error) {
+          return {
+            success: false,
+            output: { warnings },
+            error: error instanceof Error ? error.message : String(error),
+          }
+        }
+
         return {
           success: true,
           output: {
             entityType: resource.label,
-            total_matching: total,
+            total_matching: counted.count,
             warnings: warnings.length > 0 ? warnings : undefined,
           },
         }

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/__tests__/preview-record-view-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/__tests__/preview-record-view-capabilities.test.ts
@@ -31,6 +31,7 @@ vi.mock('../target', () => ({
   })),
 }))
 
+import { UnprocessableEntityError } from '../../../../../errors'
 import type { CapabilityView } from '../../../../../permissions/capabilities/capability-view'
 import { Level } from '../../../../../permissions/capabilities/registry'
 import type { ToolContext } from '../../../../agent-framework/tool-context'
@@ -118,5 +119,33 @@ describe('preview_table_view — read enforcement', () => {
 
     expect(JSON.stringify(result)).not.toContain('_kopilotRecordView')
     expect(JSON.stringify(result)).not.toContain('matched')
+  })
+})
+
+// The count is best-effort here — a failed `COUNT(*)` has always degraded to
+// "no match count" and still previewed. An ALL-DROPPED filter set is a
+// different animal: it is not a missing number, it is the tool being told that
+// the view it is about to push onto the user's table narrows nothing, and that
+// the count it would print is the definition's full row count.
+describe('preview_table_view — an all-dropped filter set is a refusal, not a missing count', () => {
+  it('refuses rather than previewing a filter set that narrows nothing', async () => {
+    countSpy.mockRejectedValue(new UnprocessableEntityError('None of the 2 filter condition(s)…'))
+
+    const result = await runTool(makeCapabilities())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('filter condition')
+    // No preview side-channel: applying it would leave the user looking at an
+    // unfiltered table the assistant just called filtered.
+    expect(JSON.stringify(result)).not.toContain('_kopilotRecordView')
+  })
+
+  it('still degrades to a countless preview for any OTHER count failure', async () => {
+    countSpy.mockRejectedValue(new Error('statement timeout'))
+
+    const result = await runTool(makeCapabilities())
+
+    expect(result.success).toBe(true)
+    expect(JSON.stringify(result)).toContain('_kopilotRecordView')
   })
 })

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/count-matches.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/count-matches.ts
@@ -8,12 +8,25 @@ import {
 } from '../../../../resources/crud'
 import type { TableId } from '../../../../resources/registry/field-registry'
 import type { Resource } from '../../../../resources/registry/types'
-import { convertToConditionGroup, type SimplifiedFilter } from '../entities/shared/record-filters'
+import {
+  assertCountFiltersApplied,
+  convertToConditionGroup,
+  type SimplifiedFilter,
+} from '../entities/shared/record-filters'
 
 /**
  * Count records matching a filter set, via the same read path `query_records`
  * uses (apiSlug-prefixed `ConditionGroup` → `UnifiedCrudHandler` count). Lets
  * the preview tool tell the user "matches N records" without fetching rows.
+ *
+ * **Refuses rather than answering wider.** The count lane fails open — a filter
+ * the builder cannot compile is dropped and the `COUNT(*)` runs anyway — so a
+ * preview whose every condition dropped would report the definition's full row
+ * count as "matching your filters". `assertCountFiltersApplied` throws on that;
+ * a partial drop still answers, and the previewed table surfaces those drops
+ * itself through `DroppedFiltersNotice` on its own `listFiltered` page.
+ *
+ * @throws UnprocessableEntityError when every requested condition was dropped.
  */
 export async function countRecordMatches(args: {
   db: Database
@@ -27,12 +40,15 @@ export async function countRecordMatches(args: {
   const group = convertToConditionGroup(filters, resource, logicalOperator)
   const groups = group ? [group] : []
 
-  return isSystemResource(entityDefinitionId)
-    ? countSystemResource({
+  const counted = isSystemResource(entityDefinitionId)
+    ? await countSystemResource({
         db,
         tableId: entityDefinitionId as TableId,
         organizationId,
         filters: groups,
       })
-    : countEntityInstances({ db, entityDefinitionId, organizationId, filters: groups })
+    : await countEntityInstances({ db, entityDefinitionId, organizationId, filters: groups })
+
+  assertCountFiltersApplied(counted, resource.label)
+  return counted.count
 }

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/preview-record-view.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/preview-record-view.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/record-views/tools/preview-record-view.ts
 
+import { UnprocessableEntityError } from '../../../../../errors'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 import { buildViewConfig, type ViewSpec } from '../build-view-config'
@@ -66,7 +67,15 @@ Examples:
           filters: built.validFilters,
           logicalOperator: built.logicalOperator,
         })
-      } catch {
+      } catch (error) {
+        // An all-dropped filter set is a REFUSAL, not a missing count: the
+        // preview would push filters onto the user's table that narrow nothing
+        // and report the definition's full row count as the match. Every other
+        // failure keeps the pre-existing best-effort behaviour — the count is a
+        // nicety, the preview is the tool's actual job.
+        if (error instanceof UnprocessableEntityError) {
+          return { success: false, output: null, error: error.message }
+        }
         matched = undefined
       }
 

--- a/packages/lib/src/resources/aggregate/dropped-widget-filters.test.ts
+++ b/packages/lib/src/resources/aggregate/dropped-widget-filters.test.ts
@@ -1,0 +1,173 @@
+// packages/lib/src/resources/aggregate/dropped-widget-filters.test.ts
+//
+// `AggregateResult` / `KpiResult` carry the dropped-filter report.
+//
+// The aggregate engine has always LOGGED a dropped widget filter and returned
+// nothing about it, which is the fail-open at its most misleading: on a list a
+// dropped filter shows extra rows, on an aggregate it shows no extra anything —
+// the bar is just taller and the KPI is just bigger. Nobody reading the tile can
+// tell, and the widget's filters are STORED, so they outlive the fields they
+// name by design.
+//
+// Same projection, same cap, same exact count as the list lane, because a UI
+// must not have to branch on which engine produced the number it annotates.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ fields: [] as unknown[] }))
+
+// Partial mock — a full replacement of `../../cache` breaks at collection time
+// as the import graph grows (matching the sibling aggregate test).
+vi.mock('../../cache', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getCachedResourceFields: async () => h.fields,
+    // Reads must miss: a cached hit would return a result shaped before this
+    // change and the assertions would describe the cache, not the engine.
+    getAggregateCache: () => ({ read: async () => null, write: async () => undefined }),
+  }
+})
+
+import type { Database } from '@auxx/database'
+import type { ConditionGroup } from '../../conditions'
+import { BaseType } from '../../workflow-engine/core/types'
+import { MAX_REPORTED_DROPPED_CONDITIONS } from '../crud/unified-handler-queries'
+import { systemConditionBuilder } from '../query-builder/system-condition-builder'
+import type { ResourceField } from '../registry/field-types'
+import { runAggregate, runKpi } from './run-aggregate'
+import type { AggregateQuery } from './types'
+
+const MERGED_FIELDS: ResourceField[] = [
+  {
+    id: 'cf_article_status_00000001',
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: 'SINGLE_SELECT',
+    dbColumn: 'status',
+    systemAttribute: 'article_status',
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+  } as unknown as ResourceField,
+]
+
+function stubDb(): Database {
+  return {
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({ execute: async () => ({ rows: [{ value: 7 }] }) }),
+  } as unknown as Database
+}
+
+/** One internal drop record, in the shape `BaseConditionBuilder` produces. */
+function drop(n: number) {
+  return {
+    conditionId: `c${n}`,
+    fieldRef: `article:cf_retired_${n}`,
+    operator: 'is',
+    reason: 'unresolved-field-or-operator' as const,
+    // Builder internals — must never reach a dashboard viewer.
+    detail: 'SystemConditionBuilder',
+  }
+}
+
+const filters: ConditionGroup[] = [
+  {
+    id: 'g1',
+    logicalOperator: 'AND',
+    conditions: [{ id: 'c1', fieldId: 'cf_retired_1', operator: 'is', value: 'PUBLISHED' }],
+  },
+]
+
+const articleCount: AggregateQuery = {
+  source: { kind: 'system', tableId: 'article' },
+  metric: { op: 'count' },
+  timezone: 'UTC',
+  filters,
+}
+
+/** Point the mocked builder at a given drop list. */
+function mockBuild(dropped: ReturnType<typeof drop>[]) {
+  return vi.spyOn(systemConditionBuilder, 'buildGroupedQueryWithDiagnostics').mockReturnValue({
+    sql: undefined,
+    requestedConditions: Math.max(dropped.length, 1),
+    droppedConditions: dropped,
+    allConditionsDropped: dropped.length > 0,
+  })
+}
+
+beforeEach(() => {
+  h.fields = MERGED_FIELDS
+  vi.restoreAllMocks()
+})
+
+describe('runAggregate reports the widget filters it could not apply', () => {
+  it('omits both keys entirely when every condition compiled', async () => {
+    mockBuild([])
+    const result = await runAggregate(stubDb(), 'org_1', undefined, articleCount)
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    // Absent, not `undefined` — an existing widget consumer must see the
+    // pre-change shape.
+    expect(Object.keys(value).sort()).toEqual(['groups', 'hasMoreGroups', 'totalValue'])
+  })
+
+  it('reports the drop alongside the number it inflated', async () => {
+    mockBuild([drop(1)])
+    const result = await runAggregate(stubDb(), 'org_1', undefined, articleCount)
+
+    const value = result._unsafeUnwrap()
+    // Still ok(): the widget renders, as it did before. It just says so now.
+    expect(value.totalValue).toBe(7)
+    expect(value.droppedConditionCount).toBe(1)
+    expect(value.droppedConditions).toEqual([
+      {
+        conditionId: 'c1',
+        fieldRef: 'article:cf_retired_1',
+        operator: 'is',
+        reason: 'unresolved-field-or-operator',
+      },
+    ])
+  })
+
+  it('withholds builder internals', async () => {
+    mockBuild([drop(1)])
+    const result = await runAggregate(stubDb(), 'org_1', undefined, articleCount)
+
+    expect(JSON.stringify(result._unsafeUnwrap())).not.toContain('SystemConditionBuilder')
+  })
+
+  it(`caps the array at ${MAX_REPORTED_DROPPED_CONDITIONS} and keeps the count exact`, async () => {
+    mockBuild(Array.from({ length: MAX_REPORTED_DROPPED_CONDITIONS + 4 }, (_, i) => drop(i)))
+    const result = await runAggregate(stubDb(), 'org_1', undefined, articleCount)
+
+    const value = result._unsafeUnwrap()
+    expect(value.droppedConditions).toHaveLength(MAX_REPORTED_DROPPED_CONDITIONS)
+    expect(value.droppedConditionCount).toBe(MAX_REPORTED_DROPPED_CONDITIONS + 4)
+  })
+})
+
+describe('runKpi reports too — the worst case for a silent drop', () => {
+  it('carries the report on a single-value result', async () => {
+    mockBuild([drop(1)])
+    const result = await runKpi(stubDb(), 'org_1', undefined, { base: articleCount })
+
+    const value = result._unsafeUnwrap()
+    // One big number, no rows to eyeball. Without this there is no tell at all.
+    expect(value.value).toBe(7)
+    expect(value.droppedConditionCount).toBe(1)
+  })
+
+  it('stays byte-identical on a clean KPI', async () => {
+    mockBuild([])
+    const result = await runKpi(stubDb(), 'org_1', undefined, { base: articleCount })
+
+    expect(Object.keys(result._unsafeUnwrap()).sort()).toEqual(['value'])
+  })
+})

--- a/packages/lib/src/resources/aggregate/run-aggregate.ts
+++ b/packages/lib/src/resources/aggregate/run-aggregate.ts
@@ -29,8 +29,12 @@ import {
 } from '../../dashboards/client'
 import { ForbiddenError, UnprocessableEntityError } from '../../errors'
 import { BaseType } from '../../workflow-engine/core/types'
-import { extractRequiredRelatedEntities } from '../crud/unified-handler-queries'
+import {
+  extractRequiredRelatedEntities,
+  reportDroppedConditions,
+} from '../crud/unified-handler-queries'
 import { isMailLensTableId, MAIL_LENS_REFUSAL } from '../picker/mail-lens-tables'
+import type { DroppedCondition } from '../query-builder/base-condition-builder'
 import { canonicalizeSystemConditions } from '../query-builder/canonicalize-system-fields'
 import {
   type EntityQueryContext,
@@ -251,6 +255,13 @@ type PreparedAggregate = {
   fetchCap: number
   timezone: string
   limit: number
+  /**
+   * Filter conditions that produced no SQL. Returned rather than only logged:
+   * a dropped widget filter makes the rendered number too HIGH, and a log line
+   * cannot tell the person looking at the chart. Projected onto the result by
+   * `computeAggregate` / `computeKpi`.
+   */
+  dropped: DroppedCondition[]
 }
 
 async function prepareAggregate(
@@ -349,6 +360,7 @@ async function prepareAggregate(
   const filters = resolvedFilters
 
   let conditionsWhere: SQL | undefined
+  let dropped: DroppedCondition[] = []
   if (query.source.kind === 'entity') {
     const relatedEntityFields: Record<string, ResourceField[]> = {}
     for (const relatedDefId of extractRequiredRelatedEntities(filters, rootFields)) {
@@ -364,6 +376,7 @@ async function prepareAggregate(
     }
     const built = entityConditionBuilder.buildGroupedQueryWithDiagnostics(filters, context)
     conditionsWhere = built.sql
+    dropped = built.droppedConditions
     if (built.droppedConditions.length > 0) {
       // Structured so "how often is a widget filter silently ignored" is a query.
       // A widget deliberately still renders (wider) rather than erroring.
@@ -394,6 +407,7 @@ async function prepareAggregate(
       rootDefId as TableId
     )
     conditionsWhere = built.sql
+    dropped = built.droppedConditions
     if (built.droppedConditions.length > 0) {
       // Same shape as the entity branch above — a dropped widget filter makes a
       // KPI/chart number too HIGH, so "how often is a widget filter silently
@@ -452,6 +466,7 @@ async function prepareAggregate(
     fetchCap,
     timezone,
     limit: groupBy?.limit ?? limit,
+    dropped,
   })
 }
 
@@ -633,13 +648,19 @@ async function computeAggregate(
     fetchCap,
     timezone,
     limit,
+    dropped,
   } = prepared.value
+
+  // Every value below describes a set the widget's filters did NOT narrow as
+  // asked when this is non-empty. Reported, not thrown — the widget still
+  // renders, as it did before.
+  const droppedReport = reportDroppedConditions(dropped)
 
   const rows = await executeAggregate(db, buildSql(windowBounds))
 
   if (!groupBy) {
     const value = toNumber(rows[0]?.value)
-    return ok({ groups: [], totalValue: value, hasMoreGroups: false })
+    return ok({ groups: [], totalValue: value, hasMoreGroups: false, ...droppedReport })
   }
 
   const overflow = rows.length > fetchCap
@@ -730,7 +751,7 @@ async function computeAggregate(
   const totalValue = sorted.reduce((sum, g) => sum + g.value, 0)
   const hasMoreGroups = overflow || sorted.length > limit
 
-  return ok({ groups: sorted.slice(0, limit), totalValue, hasMoreGroups })
+  return ok({ groups: sorted.slice(0, limit), totalValue, hasMoreGroups, ...droppedReport })
 }
 
 /**
@@ -791,7 +812,11 @@ async function computeKpi(
 ): Promise<Result<KpiResult, Error>> {
   const prepared = await prepareAggregate(organizationId, resolvedFilters, base)
   if (prepared.isErr()) return err(prepared.error)
-  const { buildSql, windowBounds, timezone } = prepared.value
+  const { buildSql, windowBounds, timezone, dropped } = prepared.value
+
+  // A KPI is the worst case for a silently dropped filter: one big number, no
+  // rows to eyeball, and a trend arrow computed from the same widened set.
+  const droppedReport = reportDroppedConditions(dropped)
 
   const trendWindows = trend
     ? deriveTrendWindows(windowBounds ?? {}, trend.compare, timezone)
@@ -799,7 +824,7 @@ async function computeKpi(
 
   if (!trendWindows) {
     const rows = await executeAggregate(db, buildSql(windowBounds))
-    return ok({ value: toNumber(rows[0]?.value) })
+    return ok({ value: toNumber(rows[0]?.value), ...droppedReport })
   }
 
   const [currentRows, previousRows] = await Promise.all([
@@ -809,5 +834,6 @@ async function computeKpi(
   return ok({
     value: toNumber(currentRows[0]?.value),
     previousValue: toNumber(previousRows[0]?.value),
+    ...droppedReport,
   })
 }

--- a/packages/lib/src/resources/aggregate/types.ts
+++ b/packages/lib/src/resources/aggregate/types.ts
@@ -17,6 +17,7 @@ import type {
   WidgetFieldRef,
   WidgetSource,
 } from '../../dashboards/client'
+import type { DroppedFilterNotice } from '../crud/unified-handler-queries'
 import type { ResourceField } from '../registry/field-types'
 
 // ── Query contract (input) ──────────────────────────────────────────────────
@@ -66,16 +67,34 @@ export type AggregateGroup = {
   series?: Array<{ key: string | null; label: string; value: number }>
 }
 
+/**
+ * Widget filter conditions the builder could not compile, and therefore did not
+ * apply. Present only when at least one dropped.
+ *
+ * **On an aggregate a dropped filter does not widen a list, it inflates a
+ * number** — the chart bar or KPI reads too HIGH, with nothing on screen to say
+ * so. The engine still renders (a stored widget naming a retired field must not
+ * blank out the dashboard), so this is the only channel that can tell a viewer.
+ *
+ * Same caller-facing projection, same cap, same exact `droppedConditionCount`
+ * past the cap as `ListFilteredResult` — a UI must not branch on which engine
+ * produced the number it is annotating.
+ */
+type WidgetDroppedFilters = {
+  droppedConditions?: DroppedFilterNotice[]
+  droppedConditionCount?: number
+}
+
 export type AggregateResult = {
   groups: AggregateGroup[]
   /** Sum of all group values (before the limit slice). Not meaningful for avg/percent ops. */
   totalValue: number
   /** True when more groups existed than the requested limit. */
   hasMoreGroups: boolean
-}
+} & WidgetDroppedFilters
 
 /** `previousValue` filled by the trend run; absent when the window is unbounded. */
-export type KpiResult = { value: number; previousValue?: number }
+export type KpiResult = { value: number; previousValue?: number } & WidgetDroppedFilters
 
 // ── Resolved shapes (internal — builders consume these) ─────────────────────
 

--- a/packages/lib/src/resources/crud/__tests__/list-filtered-dropped-conditions.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/list-filtered-dropped-conditions.test.ts
@@ -78,6 +78,8 @@ vi.mock('../../query-builder/system-condition-builder', () => ({
 import { systemConditionBuilder } from '../../query-builder/system-condition-builder'
 import { RESOURCE_FIELD_REGISTRY } from '../../registry/field-registry'
 import {
+  countEntityInstances,
+  countSystemResource,
   inspectFilterConditions,
   MAX_REPORTED_DROPPED_CONDITIONS,
   queryEntityInstanceIdsPaged,
@@ -279,6 +281,158 @@ describe('reporting does not change the query', () => {
 
     expect(r.total).toBe(6470)
     expect(r.droppedConditionCount).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE COUNT LANE
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The counts build their WHERE through the same dropping path as the list and
+// used to return a bare `number`, which is the worse half of the same failure:
+// a widened LIST shows the extra rows, a widened COUNT is one number that reads
+// exactly as authoritative when it is the unfiltered total. Unread badges,
+// "matches N records" previews and every `countOnly` AI answer come out of here.
+//
+// Same projection, same cap, same exact count as the list lane — asserted
+// against it rather than restated, because two shapes is one more than a UI can
+// absorb. Plus the one field the list does NOT carry: `allConditionsDropped`,
+// the discriminant the AI boundary refuses on.
+
+const countEntityBase = {
+  entityDefinitionId: 'edf000000000000000000001',
+  organizationId: 'org_1',
+  filters: [],
+}
+const countSystemBase = {
+  tableId: 'article' as const,
+  organizationId: 'org_1',
+  filters: [],
+}
+
+/** The single `[{ count: n }]` row a `SELECT count(*)` resolves to. */
+const counted = (n: number) => [{ count: n }]
+
+describe('the count lane reports what it could not apply', () => {
+  it('stays byte-identical on a clean count — no drop key appears at all', async () => {
+    const { db } = fakeDb(counted(42))
+    const r = await countEntityInstances({ ...countEntityBase, db })
+
+    expect(r.count).toBe(42)
+    // `allConditionsDropped` is always present (the shape is new, there is no
+    // additive contract to keep); the two drop keys are absent, not undefined.
+    expect(Object.keys(r).sort()).toEqual(['allConditionsDropped', 'count'])
+    expect(r.allConditionsDropped).toBe(false)
+  })
+
+  it('omits both keys on a clean system count too', async () => {
+    const { db } = fakeDb(counted(3))
+    const r = await countSystemResource({ ...countSystemBase, db })
+
+    expect(Object.keys(r).sort()).toEqual(['allConditionsDropped', 'count'])
+  })
+
+  it('reports drops on countEntityInstances', async () => {
+    setDrops(entityBuild, [drop(1)])
+    const { db } = fakeDb(counted(6470))
+    const r = await countEntityInstances({ ...countEntityBase, db })
+
+    // The number is still the widened one — the count fails OPEN exactly like
+    // the list. It just no longer does it silently.
+    expect(r.count).toBe(6470)
+    expect(r.droppedConditionCount).toBe(1)
+    expect(r.droppedConditions).toEqual([
+      {
+        conditionId: 'cond_1',
+        fieldRef: 'article:field_1',
+        operator: 'equals',
+        reason: 'unresolved-field-or-operator',
+      },
+    ])
+  })
+
+  it('reports drops on countSystemResource', async () => {
+    setDrops(systemBuild, [drop(1)])
+    const { db } = fakeDb(counted(9))
+    const r = await countSystemResource({ ...countSystemBase, db })
+
+    expect(r.count).toBe(9)
+    expect(r.droppedConditionCount).toBe(1)
+  })
+
+  it('produces the SAME notice a list would for the same drop', async () => {
+    setDrops(entityBuild, [drop(4)])
+    setDrops(systemBuild, [drop(4)])
+
+    const listed = await queryEntityInstanceIdsPaged({ ...entityBase, db: fakeDb(ids('i0')).db })
+    const entityCount = await countEntityInstances({
+      ...countEntityBase,
+      db: fakeDb(counted(1)).db,
+    })
+    const systemCount = await countSystemResource({
+      ...countSystemBase,
+      db: fakeDb(counted(1)).db,
+    })
+
+    // Four call sites, one payload shape. A UI annotating "12 unread" must not
+    // have to reshape what it renders under a table.
+    expect(entityCount.droppedConditions).toEqual(listed.droppedConditions)
+    expect(systemCount.droppedConditions).toEqual(listed.droppedConditions)
+    expect(entityCount.droppedConditionCount).toBe(listed.droppedConditionCount)
+  })
+
+  it('strips `detail` — builder internals never ride a count either', async () => {
+    setDrops(systemBuild, [drop(1)])
+    const { db } = fakeDb(counted(5))
+    const r = await countSystemResource({ ...countSystemBase, db })
+
+    expect(Object.keys(r.droppedConditions?.[0] as object).sort()).toEqual([
+      'conditionId',
+      'fieldRef',
+      'operator',
+      'reason',
+    ])
+    expect(JSON.stringify(r)).not.toContain('SystemConditionBuilder')
+  })
+
+  it(`caps the array at ${MAX_REPORTED_DROPPED_CONDITIONS} but keeps the count EXACT`, async () => {
+    const many = Array.from({ length: MAX_REPORTED_DROPPED_CONDITIONS + 9 }, (_, i) => drop(i))
+    setDrops(entityBuild, many)
+    const { db } = fakeDb(counted(100))
+    const r = await countEntityInstances({ ...countEntityBase, db })
+
+    expect(r.droppedConditions).toHaveLength(MAX_REPORTED_DROPPED_CONDITIONS)
+    // Counting the truncated array would understate a warning about a number
+    // that is already overstated. Twice wrong, in the same direction.
+    expect(r.droppedConditionCount).toBe(MAX_REPORTED_DROPPED_CONDITIONS + 9)
+  })
+
+  it('carries `allConditionsDropped` — and it is FALSE for the genuine no-filter count', async () => {
+    // The whole point of the flag: `sql: undefined` looks identical for "no
+    // filters" and "every filter dropped", and only the second may refuse.
+    const { db } = fakeDb(counted(6470))
+    const unfiltered = await countEntityInstances({ ...countEntityBase, db })
+    expect(unfiltered.allConditionsDropped).toBe(false)
+
+    setDrops(entityBuild, [drop(1)])
+    const dropped = await countEntityInstances({
+      ...countEntityBase,
+      db: fakeDb(counted(6470)).db,
+    })
+    expect(dropped.allConditionsDropped).toBe(true)
+  })
+
+  it('is FALSE when some conditions survived — a partial drop still answers', async () => {
+    setDrops(entityBuild, [drop(1)])
+    entityBuild.requestedConditions = 3
+    entityBuild.allConditionsDropped = false
+
+    const { db } = fakeDb(counted(88))
+    const r = await countEntityInstances({ ...countEntityBase, db })
+
+    expect(r.allConditionsDropped).toBe(false)
+    expect(r.droppedConditionCount).toBe(1)
+    expect(r.count).toBe(88)
   })
 })
 

--- a/packages/lib/src/resources/crud/__tests__/list-filtered-mail-lens.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/list-filtered-mail-lens.test.ts
@@ -191,7 +191,7 @@ describe('every other system table is unaffected', () => {
     const { db, select } = leakyDb()
     await expect(
       countSystemResource({ db, tableId: 'article', organizationId: 'org_1', filters: [] })
-    ).resolves.toBe(3)
+    ).resolves.toMatchObject({ count: 3 })
     expect(select).toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/resources/crud/__tests__/list-filtered-search.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/list-filtered-search.test.ts
@@ -191,7 +191,7 @@ describe('countEntityInstances — free-text search', () => {
     const { db, captured } = fakeDb(total(7))
     const n = await countEntityInstances({ ...base, db, search: 'acme' })
 
-    expect(n).toBe(7)
+    expect(n.count).toBe(7)
     expect(render(captured.wheres[0])).toContain('to_tsvector(')
   })
 
@@ -199,7 +199,7 @@ describe('countEntityInstances — free-text search', () => {
     const { db, captured } = fakeDb(total(42))
     const n = await countEntityInstances({ ...base, db })
 
-    expect(n).toBe(42)
+    expect(n.count).toBe(42)
     expect(render(captured.wheres[0])).not.toContain('to_tsvector(')
   })
 })

--- a/packages/lib/src/resources/crud/__tests__/list-filtered-system-search.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/list-filtered-system-search.test.ts
@@ -229,7 +229,7 @@ describe('countSystemResource — free-text search', () => {
       search: 'mcp attio',
     })
 
-    expect(n).toBe(7)
+    expect(n.count).toBe(7)
     expect(render(captured.wheres[0])).toContain('to_tsvector(')
   })
 
@@ -243,7 +243,7 @@ describe('countSystemResource — free-text search', () => {
       search: 'mcp attio',
     })
 
-    expect(n).toBe(7)
+    expect(n.count).toBe(7)
     expect(render(captured.wheres[0])).not.toContain('to_tsvector(')
   })
 })

--- a/packages/lib/src/resources/crud/index.ts
+++ b/packages/lib/src/resources/crud/index.ts
@@ -23,6 +23,7 @@ export { UnifiedCrudHandler } from './unified-handler'
 // Mutation utilities (for advanced use cases)
 export type { CreateEntityResult, MutationContext } from './unified-handler-mutations'
 export type {
+  CountFilteredResult,
   DroppedFilterNotice,
   ListAllFieldInfo,
   ListAllInput,

--- a/packages/lib/src/resources/crud/unified-handler-queries.ts
+++ b/packages/lib/src/resources/crud/unified-handler-queries.ts
@@ -174,6 +174,47 @@ export interface ListFilteredResult {
   droppedConditionCount?: number
 }
 
+/**
+ * Result of a count-only query — {@link countEntityInstances} /
+ * {@link countSystemResource}.
+ *
+ * These used to return a bare `number`, and that was the last blind spot in the
+ * fail-open: both build their `WHERE` clause through the *same* dropping path as
+ * the list, so an unread badge or a "how many match" answer could silently widen
+ * with nothing anywhere able to tell. A count is in fact the worse case — a list
+ * that widens shows the extra rows, a count that widens is a single number that
+ * looks exactly as authoritative as a correct one.
+ *
+ * `droppedConditions` / `droppedConditionCount` carry the same caller-facing
+ * projection, under the same cap and the same exact-count rule, as
+ * {@link ListFilteredResult}: a UI must not have to branch on whether it counted
+ * or listed.
+ */
+export interface CountFilteredResult {
+  /** Rows matching the WHERE clause that actually ran. */
+  count: number
+  /**
+   * Conditions the builder could not compile, and therefore did not apply.
+   * Present only when at least one was dropped — **a non-empty list means
+   * {@link count} is HIGHER than the caller asked for.** Capped at
+   * {@link MAX_REPORTED_DROPPED_CONDITIONS}.
+   */
+  droppedConditions?: DroppedFilterNotice[]
+  /** Uncapped total behind {@link droppedConditions}. Present exactly when it is. */
+  droppedConditionCount?: number
+  /**
+   * `true` only when conditions were requested and **none** of them produced
+   * SQL — i.e. {@link count} is the unfiltered total wearing a filtered label.
+   * `false` for the genuine no-filter case, so a caller can refuse on this alone
+   * (see {@link import('../../ai/kopilot/capabilities/entities/shared/record-filters').assertCountFiltersApplied}).
+   *
+   * Deliberately absent from {@link ListFilteredResult}: the list lane reports
+   * and renders, the AI count lane refuses, and only the latter needs the
+   * discriminant.
+   */
+  allConditionsDropped: boolean
+}
+
 /** The caller-facing projection of a build's drop diagnostics, or `{}` when clean. */
 type DroppedConditionReport = Pick<
   ListFilteredResult,
@@ -186,8 +227,13 @@ type DroppedConditionReport = Pick<
  * Spread into a list result: `{ ids, hasMore, ...reportDroppedConditions(dropped) }`.
  * An empty input yields `{}`, so the two absent keys never appear on a clean
  * response and no existing consumer sees a shape change.
+ *
+ * Exported for the aggregate engine (`resources/aggregate/run-aggregate.ts`),
+ * which has its own builder call sites and must report drops in the SAME shape
+ * under the SAME cap — a second, hand-rolled projection there is how the cap and
+ * the exact-count rule drift apart.
  */
-function reportDroppedConditions(dropped: DroppedCondition[]): DroppedConditionReport {
+export function reportDroppedConditions(dropped: DroppedCondition[]): DroppedConditionReport {
   if (dropped.length === 0) return {}
   return {
     droppedConditionCount: dropped.length,
@@ -284,6 +330,13 @@ async function buildEntityInstanceQueryParts(params: {
    * {@link ListFilteredResult.droppedConditions}.
    */
   dropped: DroppedCondition[]
+  /**
+   * `true` only when conditions were requested and none survived. Forwarded from
+   * the builder rather than re-derived from `dropped.length`, which cannot tell
+   * "no filters" from "every filter dropped" — the two produce the same empty
+   * WHERE. Only the count path reads it; see {@link CountFilteredResult}.
+   */
+  allConditionsDropped: boolean
 }> {
   const { organizationId, entityDefinitionId, filters, sorting } = params
   const search = params.search?.trim() || undefined
@@ -332,7 +385,12 @@ async function buildEntityInstanceQueryParts(params: {
         ? [desc(recordSearchRank(search)), desc(schema.EntityInstance.updatedAt)]
         : undefined
 
-  return { whereClause, orderByClauses, dropped: built.droppedConditions }
+  return {
+    whereClause,
+    orderByClauses,
+    dropped: built.droppedConditions,
+    allConditionsDropped: built.allConditionsDropped,
+  }
 }
 
 /**
@@ -626,6 +684,11 @@ export async function queryEntityInstanceIdsPaged(params: {
  * Takes the same `search` as {@link queryEntityInstanceIdsPaged} so a caller
  * counting "how many rows would this list show" cannot silently count the
  * unsearched set.
+ *
+ * Reports dropped conditions exactly as the paged query does — see
+ * {@link CountFilteredResult}. Like the paged query it **fails open**: a count
+ * behind a retired field still answers, just wider, and says so. Callers that
+ * must not answer wider (the AI tools) refuse on `allConditionsDropped`.
  */
 export async function countEntityInstances(params: {
   db: Database
@@ -634,10 +697,10 @@ export async function countEntityInstances(params: {
   filters: ConditionGroup[]
   /** Free-text search, ANDed into the WHERE clause exactly as the page query does. */
   search?: string
-}): Promise<number> {
+}): Promise<CountFilteredResult> {
   const { db, entityDefinitionId, organizationId, filters } = params
 
-  const { whereClause } = await buildEntityInstanceQueryParts({
+  const { whereClause, dropped, allConditionsDropped } = await buildEntityInstanceQueryParts({
     organizationId,
     entityDefinitionId,
     filters,
@@ -657,7 +720,13 @@ export async function countEntityInstances(params: {
       )
     )
 
-  return Number(result[0]?.count ?? 0)
+  return {
+    count: Number(result[0]?.count ?? 0),
+    allConditionsDropped,
+    // Same projection, same cap, same exact count as the list lane — a dropped
+    // condition makes this number too HIGH and that must be sayable.
+    ...reportDroppedConditions(dropped),
+  }
 }
 
 /**
@@ -801,7 +870,7 @@ export async function countSystemResource(params: {
   filters: ConditionGroup[]
   /** Free-text search, ANDed into the WHERE clause exactly as the page query does. */
   search?: string
-}): Promise<number> {
+}): Promise<CountFilteredResult> {
   const { db, tableId, organizationId, filters } = params
 
   assertNotMailLensTable(tableId)
@@ -815,7 +884,11 @@ export async function countSystemResource(params: {
   // would report the WIDER set the page no longer shows.
   const fields = await getCachedResourceFields(organizationId, tableId)
 
-  const { sql: whereClause } = buildSystemWhereClause(tableId, organizationId, filters, fields)
+  const {
+    sql: whereClause,
+    dropped,
+    allConditionsDropped,
+  } = buildSystemWhereClause(tableId, organizationId, filters, fields)
   const { searchWhere } = buildSystemSearchParts(tableId, params.search)
 
   const result = await db
@@ -823,7 +896,14 @@ export async function countSystemResource(params: {
     .from(tableSchema)
     .where(and(eq(tableSchema.organizationId, organizationId), whereClause, searchWhere))
 
-  return Number(result[0]?.count ?? 0)
+  return {
+    count: Number(result[0]?.count ?? 0),
+    allConditionsDropped,
+    // Identical shape to the EntityInstance twin — the KB articles table's
+    // cuid-addressed filters drop on THIS lane, so a widened count here is not
+    // hypothetical.
+    ...reportDroppedConditions(dropped),
+  }
 }
 
 /**
@@ -895,7 +975,12 @@ function buildSystemWhereClause(
   organizationId: string,
   filters: ConditionGroup[],
   fields: ResourceField[]
-): { sql: SQL<unknown> | undefined; dropped: DroppedCondition[] } {
+): {
+  sql: SQL<unknown> | undefined
+  dropped: DroppedCondition[]
+  /** See {@link CountFilteredResult.allConditionsDropped} — only the count path reads it. */
+  allConditionsDropped: boolean
+} {
   const canonicalFilters = canonicalizeSystemConditions(filters, tableId, fields)
   const built = systemConditionBuilder.buildGroupedQueryWithDiagnostics(canonicalFilters, tableId)
 
@@ -910,7 +995,11 @@ function buildSystemWhereClause(
     })
   }
 
-  return { sql: built.sql, dropped: built.droppedConditions }
+  return {
+    sql: built.sql,
+    dropped: built.droppedConditions,
+    allConditionsDropped: built.allConditionsDropped,
+  }
 }
 
 /**


### PR DESCRIPTION
Follow-up **#2b** from the retrieval plan. #1475 gave `listFiltered` a channel for filters it could not compile; three gaps remained where the same fail-open stayed invisible. Independent of #1480 (already merged) and #4 (not started).

## (a) Counts had no channel at all

`countEntityInstances` / `countSystemResource` returned a bare `number` while building their WHERE through the same fail-open path — so **unread counts and totals could silently widen with nothing able to say so.**

```ts
countEntityInstances(...): Promise<number> → Promise<CountFilteredResult>
countSystemResource(...):  Promise<number> → Promise<CountFilteredResult>
```

Both reuse `listFiltered`'s own `reportDroppedConditions` rather than a second projection, so #1475's two invariants are **structurally shared, not re-implemented**: the array is capped, `droppedConditionCount` stays **exact past the cap** (counting the truncated array would make the notice undercount — the quiet lie the field exists to end), and the payload is `{conditionId, fieldRef, operator, reason}` only. The internal `detail` carries `this.constructor.name` and never reaches a client.

## (b) The AI count tools refuse when every condition dropped

A silently widened count is the **confidently wrong number** case — an agent states it as fact. Refusal is scoped to `allConditionsDropped`; a partial drop still answers and reports, via a new `filter_not_applied` warning per drop.

`UnprocessableEntityError` (422), not 400: the request was well-formed and the filters passed `validateFilters` — what failed is that they could not be *processed* into SQL. Same class `run-aggregate.ts` already throws for an unresolvable field ref. `AuxxError`, never `TRPCError`, since both call sites also run in the worker.

> **`preview-record-view.ts` is in this diff although it isn't a count caller.** Its `catch { matched = undefined }` would have swallowed the refusal whole — the guard would have existed and done nothing. It now re-raises `UnprocessableEntityError` only, keeping best-effort degradation for everything else.

## (c) Consumers that received the field and ignored it

- **Record-list widget** — notice beside "Showing N of M", the number a drop inflates.
- **Calendar** — drains multiple pages, so drops fold via `mergeDroppedFilterPages`: **dedupe by `conditionId`, count = MAX across pages.** Concatenating would report "10 filters ignored" for one filter purely as a function of page count; summing per-page counts (each already uncapped) would multiply it. Max still exceeds the deduped array when the server cap truncated. The calendar branch renders no `DynamicTableFooter`, so it gets its own bottom strip.

## (d) Aggregates carried nothing

`run-aggregate.ts` **logged** dropped widget filters and returned nothing, so a chart or KPI silently reported a too-**high** number. `AggregateResult` / `KpiResult` gained the same two optional fields through the same shared helper.

The UI half turned out to be 3 small edits rather than a new surface — `WidgetDroppedFilters` wrapping the existing primitive in the chart, KPI and gauge widgets. No router change. (The gauge got a wrapper div so its absolutely-positioned value overlay keeps its geometry.)

## Testing

`lib` **556 files / 6632 tests** green; web dashboard + dynamic-table **142 tests** green. Biome clean on all 24 files.

Typecheck: `apps/web` 1658 total, and the only two hits in a touched file (`use-calendar-events.ts:292,302`) are **byte-identical to `HEAD`** — verified line-by-line against the pre-change file, only the line numbers shifted.

**Non-vacuity — 8 separate neutralizations, each confirmed red then restored:**

| Neutralized | Result |
|---|---|
| count `...reportDroppedConditions(dropped)` | 6 failed |
| `droppedConditionCount` → truncated length | 3 failed |
| `allConditionsDropped` hardcoded false | 1 failed |
| `query_records` guard removed | 6 failed |
| `countRecordMatches` guard removed | 1 failed |
| preview refusal branch removed | 1 failed |
| aggregate `...droppedReport` dropped | 3 failed |
| calendar fold → concat + sum | 3 failed |

## Note for the reviewer

One instruction given during implementation was wrong and is worth recording: `inspectFilterConditions` was cited as the precedent to imitate, but it has **no non-test consumers** — only a doc reference in `record.ts:676` and two test files. The error class was chosen from the module's own conventions instead.