### PR TITLE
fix(outlook): correlate the sent-items echo by an x- header, exactly

### DIFF
--- a/packages/lib/src/ingest/types.ts
+++ b/packages/lib/src/ingest/types.ts
@@ -61,6 +61,19 @@ export interface MessageData {
   labelIds?: string[]
   inReplyTo?: string | null
   references?: string | null
+  /**
+   * Our own `Message.id`, echoed back by the provider on the Sent-folder copy of a
+   * message we sent, via the `X-AuxxAi-Message-Id` header.
+   *
+   * Microsoft Graph mints its own `Message-ID` and returns nothing from
+   * `/me/sendMail`, so a Sent Items copy shares no identifier with the row we
+   * created — it used to reconcile only by a subject-and-time heuristic, and
+   * otherwise arrived as a duplicate in a forked thread. Custom `x-` headers are
+   * the one thing Graph both accepts on send and preserves on the copy (verified
+   * 2026-08-01: the copy came back carrying `X-AuxxAi-Message` and nothing else),
+   * so this is an exact, latency-independent correlation key.
+   */
+  echoedMessageId?: string | null
   threadIndex?: string | null
   folderId?: string | null
   internetHeaders?: JsonArray | null

--- a/packages/lib/src/messages/__tests__/message-reconciler.echo.test.ts
+++ b/packages/lib/src/messages/__tests__/message-reconciler.echo.test.ts
@@ -1,0 +1,408 @@
+// packages/lib/src/messages/__tests__/message-reconciler.echo.test.ts
+
+import type { Database } from '@auxx/database'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MessageData } from '../../ingest/types'
+import { MessageReconcilerService } from '../message-reconciler.service'
+import type { ThreadManagerService } from '../thread-manager.service'
+
+/**
+ * Strategy 0 of `reconcileIncomingSync` — exact correlation by the echoed
+ * `Message.id`.
+ *
+ * We stamp `X-AuxxAi-Message-Id: <our Message.id>` on outbound mail. Graph strips
+ * every transport header from the Sent Items copy but preserves custom `x-` names,
+ * so the provider can read ours back into `MessageData.echoedMessageId`. That makes
+ * the copy correlate by primary key instead of by the subject + time heuristic, and
+ * it must run FIRST because it is exact.
+ *
+ * The header is attacker-controllable input, so the lookup is scoped to the
+ * ingesting organization and requires `sendToken IS NOT NULL` (i.e. the row is one
+ * WE sent). These tests assert both guards, and that any miss falls through to the
+ * old strategies rather than throwing.
+ *
+ * Same harness as `message-reconciler.window.test.ts`: the fake `db` invokes the
+ * `where` / `orderBy` callbacks the service passes and evaluates them against
+ * in-memory rows, honouring `columns` strictly — so a wrong predicate fails here
+ * the same way it fails in Postgres.
+ */
+
+type Row = Record<string, any>
+type Predicate = (row: Row) => boolean
+
+/** `messages.organizationId` → `'organizationId'`, so predicates close over column names. */
+const columnRefs = new Proxy({} as Record<string, string>, {
+  get: (_target, key: string) => key,
+})
+
+/** Dates compare by epoch; everything else by value. */
+function comparable(value: unknown): unknown {
+  return value instanceof Date ? value.getTime() : value
+}
+
+const whereOperators = {
+  eq:
+    (col: string, value: unknown): Predicate =>
+    (row) =>
+      comparable(row[col]) === comparable(value),
+  ne:
+    (col: string, value: unknown): Predicate =>
+    (row) =>
+      comparable(row[col]) !== comparable(value),
+  gt:
+    (col: string, value: unknown): Predicate =>
+    (row) =>
+      (comparable(row[col]) as number) > (comparable(value) as number),
+  gte:
+    (col: string, value: unknown): Predicate =>
+    (row) =>
+      (comparable(row[col]) as number) >= (comparable(value) as number),
+  lt:
+    (col: string, value: unknown): Predicate =>
+    (row) =>
+      (comparable(row[col]) as number) < (comparable(value) as number),
+  lte:
+    (col: string, value: unknown): Predicate =>
+    (row) =>
+      (comparable(row[col]) as number) <= (comparable(value) as number),
+  inArray:
+    (col: string, values: unknown[]): Predicate =>
+    (row) =>
+      values.includes(row[col]),
+  notInArray:
+    (col: string, values: unknown[]): Predicate =>
+    (row) =>
+      !values.includes(row[col]),
+  isNull:
+    (col: string): Predicate =>
+    (row) =>
+      row[col] === null || row[col] === undefined,
+  isNotNull:
+    (col: string): Predicate =>
+    (row) =>
+      row[col] !== null && row[col] !== undefined,
+  and:
+    (...predicates: (Predicate | undefined)[]): Predicate =>
+    (row) =>
+      predicates.every((predicate) => (predicate ? predicate(row) : true)),
+  or:
+    (...predicates: (Predicate | undefined)[]): Predicate =>
+    (row) =>
+      predicates.some((predicate) => (predicate ? predicate(row) : false)),
+  not:
+    (predicate: Predicate): Predicate =>
+    (row) =>
+      !predicate(row),
+}
+
+type OrderSpec = { col: string; direction: 1 | -1 }
+const orderOperators = {
+  asc: (col: string): OrderSpec => ({ col, direction: 1 }),
+  desc: (col: string): OrderSpec => ({ col, direction: -1 }),
+}
+
+function project(row: Row, columns?: Record<string, boolean>): Row {
+  if (!columns) return { ...row }
+  const out: Row = {}
+  for (const [key, wanted] of Object.entries(columns)) {
+    if (wanted) out[key] = row[key]
+  }
+  return out
+}
+
+function createTable(rows: Row[]) {
+  const select = (args: any): Row[] => {
+    const predicate: Predicate | undefined = args?.where?.(columnRefs, whereOperators)
+    let matched = predicate ? rows.filter(predicate) : [...rows]
+
+    const ordering = args?.orderBy?.(columnRefs, orderOperators)
+    if (ordering) {
+      const specs: OrderSpec[] = Array.isArray(ordering) ? ordering : [ordering]
+      matched = [...matched].sort((a, b) => {
+        for (const spec of specs) {
+          const left = comparable(a[spec.col]) as number
+          const right = comparable(b[spec.col]) as number
+          if (left !== right) return (left < right ? -1 : 1) * spec.direction
+        }
+        return 0
+      })
+    }
+
+    return matched.map((row) => project(row, args?.columns))
+  }
+
+  return {
+    findFirst: vi.fn(async (args: any) => select(args)[0]),
+    findMany: vi.fn(async (args: any) => select(args)),
+  }
+}
+
+function createDb(messageRows: Row[], threadRows: Row[]) {
+  const updateWhere = vi.fn(async () => undefined)
+  const updateSet = vi.fn(() => ({ where: updateWhere }))
+  const update = vi.fn(() => ({ set: updateSet }))
+  const deleteWhere = vi.fn(async () => undefined)
+
+  return {
+    update,
+    updateSet,
+    updateWhere,
+    delete: vi.fn(() => ({ where: deleteWhere })),
+    query: {
+      Message: createTable(messageRows),
+      Thread: createTable(threadRows),
+    },
+  }
+}
+
+const ORG_ID = 'org-1'
+const OTHER_ORG_ID = 'org-2'
+const INTEGRATION_ID = 'int-1'
+const SUBJECT = 'Re: Hello'
+const SENT_AT = new Date('2026-08-01T06:28:02.744Z')
+
+function localSentRow(overrides: Row = {}): Row {
+  return {
+    id: 'msg-local',
+    organizationId: ORG_ID,
+    integrationId: INTEGRATION_ID,
+    subject: SUBJECT,
+    sendStatus: 'PENDING',
+    sendToken: 'send-token-1',
+    internetMessageId: '<auxx.1785562832447.af29126a@localhost>',
+    threadId: 'thread-1',
+    createdAt: SENT_AT,
+    textPlain: 'hello',
+    textHtml: '<p>hello</p>',
+    snippet: 'hello',
+    ...overrides,
+  }
+}
+
+/** The Sent-Items copy Graph hands back: new externalId, no shared Message-ID. */
+function sentItemsEcho(overrides: Partial<MessageData> = {}): MessageData {
+  return {
+    externalId: 'AAMkAGE1M2_echo',
+    externalThreadId: 'ofcUygcDWUy-bMGbiGNRrA==',
+    integrationId: INTEGRATION_ID,
+    organizationId: ORG_ID,
+    isInbound: false,
+    subject: SUBJECT,
+    createdTime: SENT_AT,
+    sentAt: SENT_AT,
+    receivedAt: SENT_AT,
+    from: { identifier: 'auxx-shopify@outlook.com' } as any,
+    to: [],
+    hasAttachments: false,
+    internetMessageId: '<SA1PR19MB7062B22F6EB06B5FEE53F48A97D72@outlook.com>',
+    ...overrides,
+  } as MessageData
+}
+
+const THREADS = [
+  { id: 'thread-1', externalId: 'ext-real' },
+  { id: 'thread-other', externalId: 'ext-other' },
+]
+
+function createService(db: ReturnType<typeof createDb>) {
+  const threadManager = {
+    updateThreadMetadata: vi.fn(async () => undefined),
+    reconcileThread: vi.fn(async () => undefined),
+  } as unknown as ThreadManagerService
+
+  return new MessageReconcilerService(ORG_ID, threadManager, db as unknown as Database)
+}
+
+/** Simulates the echo being ingested `seconds` after the send. */
+function ingestAt(seconds: number): void {
+  vi.setSystemTime(new Date(SENT_AT.getTime() + seconds * 1000))
+}
+
+beforeEach(() => {
+  // Only `Date` is faked — faking timers wholesale would stall unrelated async
+  // work in the module graph.
+  vi.useFakeTimers({ toFake: ['Date'] })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('reconcileIncomingSync — Strategy 0, echoed X-AuxxAi-Message-Id', () => {
+  it('reconciles onto exactly the row named by `echoedMessageId`', async () => {
+    const db = createDb([localSentRow()], THREADS)
+    // Far outside every heuristic window, to prove the match is the header alone.
+    ingestAt(3 * 60 * 60)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ echoedMessageId: 'msg-local' })
+    )
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+  })
+
+  it('wins over a different row that the subject/time heuristic would have matched', async () => {
+    // `msg-decoy` is newer, so `orderBy desc(createdAt)` in Strategy 2 would pick it.
+    const decoy = localSentRow({
+      id: 'msg-decoy',
+      sendToken: 'send-token-decoy',
+      internetMessageId: '<auxx.decoy@localhost>',
+      threadId: 'thread-other',
+      createdAt: new Date(SENT_AT.getTime() + 10_000),
+    })
+    const db = createDb([localSentRow(), decoy], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ echoedMessageId: 'msg-local' })
+    )
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+  })
+
+  it('runs before Strategy 1, so it beats an `internetMessageId` match on another row', async () => {
+    const byMessageId = localSentRow({
+      id: 'msg-by-message-id',
+      sendToken: 'send-token-mid',
+      internetMessageId: '<shared-id@auxx.ai>',
+      threadId: 'thread-other',
+    })
+    const db = createDb([byMessageId, localSentRow()], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({
+        echoedMessageId: 'msg-local',
+        internetMessageId: '<shared-id@auxx.ai>',
+      })
+    )
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+  })
+
+  it('does not reconcile onto a row in another organization (security guard)', async () => {
+    // Same id, different tenant: a header lifted across orgs must not resolve. The
+    // subject heuristic cannot rescue it either, because it is org-scoped too.
+    const foreign = localSentRow({ organizationId: OTHER_ORG_ID })
+    const db = createDb([foreign], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ echoedMessageId: 'msg-local' })
+    )
+
+    expect(result).toEqual({ isReconciled: false })
+  })
+
+  it('does not reconcile onto a row on another integration (security guard)', async () => {
+    // Same org, different channel. An echo always arrives on the integration that
+    // sent it, so a header naming a message from another mailbox is either forged
+    // or wrong — and merging across channels crosses an inbox permission boundary,
+    // the same hazard the thread-resolution ladder is scoped against.
+    const otherChannel = localSentRow({ integrationId: 'int-other' })
+    const db = createDb([otherChannel], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ echoedMessageId: 'msg-local', internetMessageId: null })
+    )
+
+    expect(result).toEqual({ isReconciled: false })
+  })
+
+  it('does not reconcile onto a row with a null `sendToken` (spoof guard)', async () => {
+    // A spoofed header must not be able to graft an inbound message onto a row we
+    // never sent. Everything else about this row matches.
+    const notSentByUs = localSentRow({ sendToken: null })
+    const db = createDb([notSentByUs], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ echoedMessageId: 'msg-local', internetMessageId: null })
+    )
+
+    expect(result).toEqual({ isReconciled: false })
+  })
+
+  it('falls through to the existing strategies when the id does not exist', async () => {
+    const db = createDb([localSentRow()], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ echoedMessageId: 'msg-does-not-exist' })
+    )
+
+    // Strategy 2 still matches by subject + time — no throw, no lost reconciliation.
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+  })
+
+  it('falls through to Strategy 1 when the id does not exist', async () => {
+    const byMessageId = localSentRow({
+      id: 'msg-by-message-id',
+      subject: 'Something else entirely',
+      sendToken: null,
+      internetMessageId: '<shared-id@auxx.ai>',
+      threadId: 'thread-other',
+    })
+    const db = createDb([byMessageId], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({
+        echoedMessageId: 'msg-does-not-exist',
+        internetMessageId: '<shared-id@auxx.ai>',
+      })
+    )
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-by-message-id' })
+  })
+
+  it('issues no Strategy 0 query at all when `echoedMessageId` is absent', async () => {
+    const db = createDb([localSentRow()], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(sentItemsEcho())
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+
+    // The first lookup must be Strategy 1's `internetMessageId` predicate, not an id
+    // lookup: a row whose `id` matches but whose `internetMessageId` does not is
+    // rejected by it.
+    const firstPredicate = db.query.Message.findFirst.mock.calls[0]?.[0]?.where?.(
+      columnRefs,
+      whereOperators
+    )
+    expect(firstPredicate(localSentRow({ internetMessageId: '<not-the-echo@localhost>' }))).toBe(
+      false
+    )
+    expect(
+      firstPredicate(localSentRow({ internetMessageId: sentItemsEcho().internetMessageId }))
+    ).toBe(true)
+  })
+
+  it('behaves exactly as today when `echoedMessageId` is null', async () => {
+    const db = createDb([localSentRow()], THREADS)
+    ingestAt(6 * 60 + 47)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ echoedMessageId: null })
+    )
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+  })
+
+  it('does not reconcile an unrelated inbound message that carries no echo header', async () => {
+    const db = createDb([localSentRow()], THREADS)
+    ingestAt(77)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({
+        subject: 'A completely different subject',
+        internetMessageId: '<inbound-from-a-stranger@example.com>',
+        isInbound: true,
+      })
+    )
+
+    expect(result).toEqual({ isReconciled: false })
+  })
+})

--- a/packages/lib/src/messages/__tests__/message-reconciler.window.test.ts
+++ b/packages/lib/src/messages/__tests__/message-reconciler.window.test.ts
@@ -14,6 +14,12 @@ import type { ThreadManagerService } from '../thread-manager.service'
  * candidate row's `createdAt`, so it only ever fired when the provider happened
  * to poll within 60s of the send. Outlook polls every ~3 minutes.
  *
+ * Fixing that comparison was not enough: the SQL candidate filter only looked
+ * back 5 minutes from INGEST time, so on a measured live case (row created
+ * 06:28:02.744, echo ingested 06:34:50 — 6m47s) the candidate was never even
+ * SELECTED. That window is now 30 minutes; precision still comes from the 60s
+ * relative-skew check, not from the SQL bound.
+ *
  * These tests drive the real relational-query predicate: the fake `db` below
  * invokes the `where` / `orderBy` callbacks the service passes and evaluates
  * them against in-memory rows, so a wrong predicate fails here the same way it
@@ -246,9 +252,31 @@ describe('reconcileIncomingSync — Strategy 2 time window', () => {
     expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
   })
 
-  it('does not reconcile an echo ingested 10 minutes later (outside the SQL window)', async () => {
+  it('reconciles an echo ingested 6m47s after the send (the measured live failure)', async () => {
+    // Our row was created at 06:28:02.744 and the echo ingested at 06:34:50 — a
+    // 6m47s gap. The old SQL window was 5 minutes measured from INGEST time, so the
+    // candidate was never SELECTED and the corrected skew check never ran. This is
+    // the regression guard for that window.
+    const db = createDb([localSentRow()], [{ id: 'thread-1', externalId: 'ext-real' }])
+    ingestAt(6 * 60 + 47)
+
+    const result = await createService(db).reconcileIncomingSync(sentItemsEcho())
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+  })
+
+  it('reconciles an echo ingested 25 minutes after the send (inside the widened window)', async () => {
+    const db = createDb([localSentRow()], [{ id: 'thread-1', externalId: 'ext-real' }])
+    ingestAt(25 * 60)
+
+    const result = await createService(db).reconcileIncomingSync(sentItemsEcho())
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-local' })
+  })
+
+  it('does not reconcile an echo ingested 45 minutes later (outside the SQL window)', async () => {
     const db = createDb([localSentRow()], [])
-    ingestAt(600)
+    ingestAt(45 * 60)
 
     const result = await createService(db).reconcileIncomingSync(sentItemsEcho())
 

--- a/packages/lib/src/messages/message-reconciler.service.ts
+++ b/packages/lib/src/messages/message-reconciler.service.ts
@@ -128,6 +128,61 @@ export class MessageReconcilerService {
   }> {
     // Check multiple strategies to find recently sent messages
 
+    // Strategy 0: Check by the echoed `Message.id` (exact, and the cheapest).
+    //
+    // We stamp `X-AuxxAi-Message-Id: <our Message.id>` on every outbound message.
+    // Microsoft Graph strips every transport header from the Sent Items copy but
+    // preserves custom `x-` names (verified 2026-08-01: the copy came back carrying
+    // only `X-AuxxAi-Message`), so when the provider reads that header back into
+    // `echoedMessageId` we have an EXACT primary-key correlation — no subject
+    // guessing, no time window, no dependence on the poll interval. That is why it
+    // runs before Strategy 1.
+    //
+    // Two guards, because a header is attacker-controllable input, not our own state:
+    //   - `organizationId` scope: an id lifted from another tenant must never
+    //     resolve. This is a security boundary, not a nicety.
+    //   - `sendToken IS NOT NULL`: only a message WE sent can have a Sent-folder
+    //     echo. Without this, a spoofed header could graft an arbitrary inbound
+    //     message onto any row in the org.
+    // A miss on either guard (or a bogus id) falls through to the strategies below
+    // rather than failing the ingest.
+    const byEchoedId = messageData.echoedMessageId
+      ? await this.db.query.Message.findFirst({
+          // Every predicate here is a guard, because the id arrives in a header and
+          // headers are attacker-controllable. The org and integration both come
+          // from the INGESTING side, never from the header, so a forged id cannot
+          // reach another tenant or another channel — an echo always arrives on the
+          // same integration that sent it. `sendToken IS NOT NULL` means only a
+          // message WE sent can be a reconcile target, so a forged header cannot
+          // graft inbound mail onto an arbitrary row.
+          where: (messages, { eq, and, isNotNull }) =>
+            and(
+              eq(messages.id, messageData.echoedMessageId!),
+              eq(messages.organizationId, messageData.organizationId),
+              eq(messages.integrationId, messageData.integrationId),
+              isNotNull(messages.sendToken)
+            ),
+          columns: {
+            id: true,
+            sendToken: true,
+            threadId: true,
+          },
+        })
+      : null
+
+    if (byEchoedId) {
+      logger.info('Found sent message by echoed X-AuxxAi-Message-Id, reconciling', {
+        messageId: byEchoedId.id,
+        externalId: messageData.externalId,
+      })
+
+      await this.mergeIncomingProviderData(byEchoedId.id, messageData)
+      return {
+        isReconciled: true,
+        existingMessageId: byEchoedId.id,
+      }
+    }
+
     // Strategy 1: Check by internetMessageId (most reliable)
     const byMessageId = messageData.internetMessageId
       ? await this.db.query.Message.findFirst({
@@ -177,7 +232,15 @@ export class MessageReconcilerService {
           eq(messages.subject, messageData.subject || ''),
           inArray(messages.sendStatus, [SendStatus.PENDING, SendStatus.SENT]),
           isNotNull(messages.sendToken),
-          gte(messages.createdAt, new Date(Date.now() - 300000)) // Within last 5 minutes
+          // 30 minutes, measured from INGEST time. This only bounds the scan — it is
+          // NOT the precision control. Precision comes from the `< 60000` relative-skew
+          // check against `recentlySent.createdAt` below, plus the integration /
+          // `sendToken` / subject predicates and `orderBy desc(createdAt)`.
+          // The previous 5 minutes was too short: Outlook polls every ~5-7 minutes, and
+          // a measured live case had our row created at 06:28:02.744 and the echo
+          // ingested at 06:34:50 — a 6m47s gap, so the candidate was never even
+          // SELECTED and the skew check never got to run.
+          gte(messages.createdAt, new Date(Date.now() - 30 * 60 * 1000))
         ),
       orderBy: (messages, { desc }) => [desc(messages.createdAt)],
       columns: {

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -1358,6 +1358,10 @@ export class MessageSenderService {
         : params.threadContext.externalId
       const result: ProviderSendResult = await provider.sendMessage({
         messageId: params.internetMessageId, // Use original Message-ID
+        // Same `Message` row as the original attempt, so a retried Outlook send still
+        // carries `X-AuxxAi-Message-Id` and its Sent Items copy reconciles onto this
+        // row instead of duplicating into a forked thread.
+        internalMessageId: params.messageId,
         from: params.participants.from.identifier,
         to: params.participants.to.map((p: any) => p.identifier),
         cc: params.participants.cc?.map((p: any) => p.identifier),

--- a/packages/lib/src/providers/channel-provider.interface.ts
+++ b/packages/lib/src/providers/channel-provider.interface.ts
@@ -43,6 +43,27 @@ export interface SendMessageOptions {
   messageId?: string // Provider-specific ID for outgoing message if available
   externalThreadId?: string // Link to existing thread if applicable
 
+  /**
+   * Row id of the freshly composed `Message` (already committed by
+   * `MessageComposerService` before the provider is called).
+   *
+   * Outlook stamps it on the wire as `X-AuxxAi-Message-Id`. Microsoft Graph
+   * returns nothing from `/me/sendMail` and mints its own `Message-ID`, so the
+   * Sent Items copy that syncs back otherwise shares NO identifier with the row
+   * we created — it duplicated into a forked thread. Custom `x-` headers are the
+   * one thing Graph both accepts on send and preserves on the copy, so echoing
+   * this id back is an exact, latency-independent correlation key
+   * (`MessageData.echoedMessageId`).
+   *
+   * `Message.id` deliberately, NOT `sendToken`: the token is an idempotency
+   * capability and must never leave our systems on a header every recipient can
+   * read. The row id is an opaque cuid with no capability attached.
+   *
+   * Also consumed by chat providers that write side rows after the composer
+   * commits (see `SendMessageParams.internalMessageId`).
+   */
+  internalMessageId?: string
+
   // Attachments
   attachmentIds?: string[] // References to stored attachments (used by our system)
   attachments?: AttachmentFile[] // Direct attachment objects (used by providers)

--- a/packages/lib/src/providers/outlook/__tests__/outlook-provider.send.test.ts
+++ b/packages/lib/src/providers/outlook/__tests__/outlook-provider.send.test.ts
@@ -1,0 +1,217 @@
+// packages/lib/src/providers/outlook/__tests__/outlook-provider.send.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SendMessageOptions } from '../../channel-provider.interface'
+import { OutlookProvider } from '../outlook-provider'
+
+/**
+ * Every call recorded off the fake Graph client, so a test can assert on the exact
+ * payload handed to `/me/sendMail` rather than on our own intermediate state.
+ */
+interface RecordedPost {
+  path: string
+  body: any
+}
+
+interface GraphHeader {
+  name: string
+  value: string
+}
+
+function makeProvider() {
+  const posts: RecordedPost[] = []
+  const provider = new OutlookProvider('org_1')
+  provider.integrationId = 'int_1'
+  ;(provider as any).integration = {
+    id: 'int_1',
+    metadata: { email: 'us@example.com', emailAliases: [] },
+  }
+  ;(provider as any).client = {
+    api: (path: string) => ({
+      post: async (body: any) => {
+        posts.push({ path, body })
+        return { id: 'graph_draft_1' }
+      },
+    }),
+  }
+  // The real one hits the DB to upsert contacts for recipients; irrelevant here.
+  ;(provider as any).storageService = {
+    ensureContactsForRecipients: vi.fn().mockResolvedValue(undefined),
+    setInitialSyncMode: vi.fn(),
+  }
+  return { provider, posts }
+}
+
+function baseOptions(overrides: Partial<SendMessageOptions> = {}): SendMessageOptions {
+  return {
+    from: 'us@example.com',
+    to: ['them@example.com'],
+    subject: 'Re: Hello',
+    html: '<p>hello</p>',
+    ...overrides,
+  }
+}
+
+function headersOf(posts: RecordedPost[]): GraphHeader[] {
+  const sendMail = posts.find((p) => p.path === '/me/sendMail')
+  expect(sendMail).toBeDefined()
+  return sendMail?.body?.message?.internetMessageHeaders ?? []
+}
+
+describe('OutlookProvider.sendMessage — internetMessageHeaders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('stamps X-AuxxAi-Message-Id with our own Message.id', async () => {
+    const { provider, posts } = makeProvider()
+
+    const result = await provider.sendMessage(
+      baseOptions({ internalMessageId: 'cm_local_row_123' })
+    )
+
+    expect(result.success).toBe(true)
+    expect(headersOf(posts)).toContainEqual({
+      name: 'X-AuxxAi-Message-Id',
+      value: 'cm_local_row_123',
+    })
+  })
+
+  it('omits X-AuxxAi-Message-Id when no local message id is supplied', async () => {
+    const { provider, posts } = makeProvider()
+
+    await provider.sendMessage(baseOptions())
+
+    const names = headersOf(posts).map((h) => h.name.toLowerCase())
+    expect(names).not.toContain('x-auxxai-message-id')
+    // The unconditional marker still rides along.
+    expect(names).toContain('x-auxxai-message')
+  })
+
+  it('never posts a header whose name is not x- prefixed', async () => {
+    // Regression guard for the 400 InvalidInternetMessageHeader outage: Graph rejects
+    // the WHOLE request for any non-`x-` custom header name, so a single stray header
+    // breaks every Outlook send rather than being silently dropped.
+    const { provider, posts } = makeProvider()
+
+    await provider.sendMessage(
+      baseOptions({
+        internalMessageId: 'cm_local_row_123',
+        automated: true,
+        inReplyTo: '<parent@example.com>',
+        references: '<root@example.com> <parent@example.com>',
+        unsubscribe: { url: 'https://auxx.ai/u/tok' },
+      })
+    )
+
+    const headers = headersOf(posts)
+    expect(headers.length).toBeGreaterThan(0)
+    for (const header of headers) {
+      expect(header.name.toLowerCase().startsWith('x-')).toBe(true)
+    }
+  })
+
+  it('does not emit In-Reply-To/References even when threading options are set', async () => {
+    const { provider, posts } = makeProvider()
+
+    await provider.sendMessage(
+      baseOptions({
+        inReplyTo: '<parent@example.com>',
+        references: '<root@example.com> <parent@example.com>',
+      })
+    )
+
+    const names = headersOf(posts).map((h) => h.name.toLowerCase())
+    expect(names).not.toContain('in-reply-to')
+    expect(names).not.toContain('references')
+  })
+
+  it('emits X-Auto-Response-Suppress for automated sends only', async () => {
+    const automated = makeProvider()
+    await automated.provider.sendMessage(baseOptions({ automated: true }))
+    expect(headersOf(automated.posts)).toContainEqual({
+      name: 'X-Auto-Response-Suppress',
+      value: 'All',
+    })
+
+    const human = makeProvider()
+    await human.provider.sendMessage(baseOptions())
+    expect(headersOf(human.posts).map((h) => h.name.toLowerCase())).not.toContain(
+      'x-auto-response-suppress'
+    )
+  })
+})
+
+describe('OutlookProvider — echoedMessageId round trip', () => {
+  /**
+   * `convertMessagesToMessageData` is private and every public entry point to it
+   * (syncMessages / importMessages) requires a paged Graph client plus the full
+   * storage pipeline. Calling the mapper directly on a fully-populated instance is
+   * the smallest seam that still exercises the real header-reading code.
+   */
+  function mapOne(graphMessage: Record<string, unknown>) {
+    const { provider } = makeProvider()
+    const [messageData] = (provider as any).convertMessagesToMessageData([
+      {
+        id: 'graph_msg_1',
+        conversationId: 'conv_1',
+        subject: 'Re: Hello',
+        from: { emailAddress: { address: 'us@example.com', name: 'Us' } },
+        toRecipients: [{ emailAddress: { address: 'them@example.com' } }],
+        sentDateTime: '2026-08-01T05:40:33Z',
+        receivedDateTime: '2026-08-01T05:41:50Z',
+        body: { contentType: 'html', content: '<p>hello</p>' },
+        internetMessageId: '<SA1PR19MB7062@example.com>',
+        parentFolderId: 'sentitems',
+        ...graphMessage,
+      },
+    ])
+    return messageData
+  }
+
+  it('reads X-AuxxAi-Message-Id back off the Sent Items copy', () => {
+    const messageData = mapOne({
+      internetMessageHeaders: [{ name: 'X-AuxxAi-Message-Id', value: 'cm_local_row_123' }],
+    })
+    expect(messageData.echoedMessageId).toBe('cm_local_row_123')
+  })
+
+  it('matches the header name case-insensitively', () => {
+    // Graph guarantees the `x-` prefix round-trips, not the casing it returns.
+    expect(
+      mapOne({
+        internetMessageHeaders: [{ name: 'x-auxxai-message-id', value: 'cm_local_row_123' }],
+      }).echoedMessageId
+    ).toBe('cm_local_row_123')
+
+    expect(
+      mapOne({
+        internetMessageHeaders: [{ name: 'X-AUXXAI-MESSAGE-ID', value: 'cm_local_row_123' }],
+      }).echoedMessageId
+    ).toBe('cm_local_row_123')
+  })
+
+  it('is null when the header is absent, empty, or there are no headers at all', () => {
+    expect(mapOne({}).echoedMessageId).toBeNull()
+    expect(mapOne({ internetMessageHeaders: [] }).echoedMessageId).toBeNull()
+    expect(
+      mapOne({
+        internetMessageHeaders: [
+          { name: 'X-AuxxAi-Message', value: 'true' },
+          { name: 'In-Reply-To', value: '<parent@example.com>' },
+        ],
+      }).echoedMessageId
+    ).toBeNull()
+    expect(
+      mapOne({ internetMessageHeaders: [{ name: 'X-AuxxAi-Message-Id', value: '  ' }] })
+        .echoedMessageId
+    ).toBeNull()
+  })
+
+  it('does not persist the echoed id into metadata.headers', () => {
+    const messageData = mapOne({
+      internetMessageHeaders: [{ name: 'X-AuxxAi-Message-Id', value: 'cm_local_row_123' }],
+    })
+    expect(JSON.stringify(messageData.metadata?.headers ?? {})).not.toContain('cm_local_row_123')
+  })
+})

--- a/packages/lib/src/providers/outlook/outlook-provider.ts
+++ b/packages/lib/src/providers/outlook/outlook-provider.ts
@@ -50,6 +50,32 @@ import {
 
 const logger = createScopedLogger('outlook-provider')
 
+/** Custom `x-` header `sendMessage` stamps with our own `Message.id`. */
+const ECHOED_MESSAGE_ID_HEADER = 'x-auxxai-message-id'
+
+/**
+ * Reads our own `Message.id` back off a Graph message's `internetMessageHeaders`.
+ *
+ * Deliberately case-insensitive: Graph does not guarantee the casing it returns a
+ * custom header in, only that it round-trips the `x-` prefixed name. First
+ * occurrence wins.
+ *
+ * Kept out of `MACHINE_MAIL_HEADER_ALLOWLIST` on purpose — that allowlist defines
+ * the input contract of `detectMachineMail`, and this value is transient
+ * (reconciliation only), never persisted into `metadata.headers`.
+ */
+function pickEchoedMessageId(
+  entries: Array<{ name?: string | null; value?: string | null }> | undefined
+): string | null {
+  if (!entries?.length) return null
+  for (const entry of entries) {
+    if (entry?.name?.toLowerCase().trim() !== ECHOED_MESSAGE_ID_HEADER) continue
+    const value = entry.value?.trim()
+    if (value) return value
+  }
+  return null
+}
+
 /** Microsoft Graph /$batch endpoint limit. */
 const GRAPH_BATCH_LIMIT = 20
 const OUTLOOK_MAX_PAGE_SIZE = 999
@@ -350,6 +376,21 @@ export class OutlookProvider
         name: 'X-AuxxAi-Message',
         value: 'true',
       })
+      // Correlation key for the Sent Items copy. `/me/sendMail` returns no id and Graph
+      // mints its own `Message-ID`, so without this the copy that syncs back shares NO
+      // identifier with the row we just wrote — it stored a second time, in a forked
+      // thread (plans/channels/outlook/outbound-duplicate-and-fork.md). Verified
+      // 2026-08-01: Graph strips every transport header off the copy but PRESERVES our
+      // `x-` headers, so this survives the round trip where `Message-ID` cannot.
+      // `Message.id`, never `sendToken` — the token is an idempotency capability and
+      // this header is readable by every recipient. Read back in
+      // `convertMessagesToMessageData` as `MessageData.echoedMessageId`.
+      if (options.internalMessageId) {
+        message.internetMessageHeaders.push({
+          name: 'X-AuxxAi-Message-Id',
+          value: options.internalMessageId,
+        })
+      }
       // RFC 3834 loop prevention for automated sends (machine-mail plan Phase 2). Graph
       // only accepts `x-` custom headers (see the List-Unsubscribe note below), so
       // `Auto-Submitted` can't ride along — but X-Auto-Response-Suppress is Microsoft's
@@ -879,6 +920,9 @@ export class OutlookProvider
             isInbound: isInbound,
             inReplyTo: threading.inReplyTo ?? null,
             references: threading.references ?? null,
+            // Transient — read by the reconciler off `messageData`, deliberately NOT
+            // merged into `metadata.headers` below.
+            echoedMessageId: pickEchoedMessageId(message.internetMessageHeaders),
             metadata: {
               conversationId: message.conversationId,
               parentFolderId: message.parentFolderId,


### PR DESCRIPTION
Supersedes the heuristic approach. Driven by a live probe against a real Outlook mailbox.

## The problem

Graph mints its own `Message-ID` and `/me/sendMail` returns no id, so the Sent Items copy of a message we sent shares **no identifier** with the row we created. Every Auxx-sent Outlook message was stored twice, the copy landing in a new thread (Exchange gives it a fresh `conversationId` and strips every transport header). The next inbound reply then correctly threaded onto the *copy*, splitting the live conversation.

#1479 was meant to catch this via subject+time. It didn't — see below.

## The probe that settled it

Instrumented the mapper and sent a real message. The Sent Items copy came back as:

```json
{ "headerCount": 1, "headerNames": ["X-AuxxAi-Message"] }
```

**One header, and it's ours.** Graph strips every transport header but preserves custom `x-` names — which are also the only names it *accepts* on send (that restriction is what caused the original 400 outage). That's an exact correlation channel hiding in plain sight.

## The fix

Stamp `X-AuxxAi-Message-Id: <our Message.id>` outbound, read it back into `MessageData.echoedMessageId`, and reconcile on it as **Strategy 0**, before any heuristic. Exact primary-key correlation — no subject guessing, no time window, no dependence on poll interval.

Notably the main send path needed **no change**: `internalMessageId` was already flowing to the provider via an `as any` cast. This gives it a type, and adds it to the retry path, which was missing it.

### `Message.id`, not `sendToken`

Deliberate. `sendToken` is an idempotency capability guarding send requests; putting it in an outbound header exposes it to every recipient. `Message.id` is an opaque cuid carrying no capability.

### The echoed id is untrusted input

It arrives in a header, so the lookup is guarded by three predicates, **all taken from the ingesting side, never from the header**:

| guard | stops |
| --- | --- |
| `organizationId` | an id lifted from another tenant |
| `integrationId` | crossing channels — which crosses an inbox permission boundary |
| `sendToken IS NOT NULL` | grafting inbound mail onto a row we never sent |

A miss falls through to the existing strategies rather than failing ingest.

The `integrationId` guard was added on review — Strategy 2 already scoped to it, Strategy 0 didn't, and an echo always arrives on the integration that sent it, so the scope is free.

## Also: #1479's window was still too short

#1479 fixed the comparison's *operand* but not the SQL filter, which selects candidates created within 5 minutes of **ingest**:

- row created `06:28:02.744`
- echo ingested `06:34:50`
- **6m47s** → candidate never selected → corrected comparison never ran → duplicate recurred

Widened to 30 minutes. Precision still comes from the 60s relative-skew check plus the `integrationId` / `sendToken` / subject predicates; the SQL bound only bounds the scan.

## What this supersedes

`Message.externalId` (Phase 2) and `/createReply` (Phase 3) are **no longer needed to fix duplication**. `createReply` remains worth doing, but only to restore recipient-side RFC 5322 threading. Plan updated accordingly.

## Verification

- `packages/lib`: **6668 passed**, 0 failed
- typecheck: zero errors in all 8 touched files (baseline is broken; grepped per convention)
- Biome clean

**Every guard mutation-verified:**
- drop `organizationId`/`sendToken` → exactly those two security tests red
- drop `integrationId` → exactly the cross-channel test red
- restore the 5-minute window → the 6m47s regression guard red

Includes a regression test asserting **every** posted header is `x-` prefixed, guarding the original `400 InvalidInternetMessageHeader` outage, and that `In-Reply-To`/`References` never come back.

## Not verified

Graph round-tripping a *second* custom `x-` header is inferred from the probe (which observed one). Same prefix, same mechanism, but only a live send proves it. Worth watching on the first real send after deploy.