### PR TITLE
fix(dashboard): stop offering mail-lens sources and degrade stored ones cleanly

### DIFF
--- a/apps/web/src/components/dashboard/hooks/use-chart-data.ts
+++ b/apps/web/src/components/dashboard/hooks/use-chart-data.ts
@@ -21,6 +21,7 @@ import {
 import { keepPreviousData } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { api } from '~/trpc/react'
+import { isMailLensSource } from '../lib/widget-source'
 import { selectGlobalFilters, useDashboardStore } from '../stores/dashboard-draft-store'
 
 export function useChartData(configuration: ChartWidgetConfig, widgetId?: string) {
@@ -31,7 +32,13 @@ export function useChartData(configuration: ChartWidgetConfig, widgetId?: string
   return api.dashboard.chartData.useQuery(
     { dashboardId: dashboardId ?? '', widgetId, query, globalOverrides },
     {
-      enabled: Boolean(dashboardId) && isChartConfigured(configuration),
+      // A stored mail-sourced widget is refused by `prepareAggregate`, so the
+      // request is a guaranteed 403 — the body renders the unavailable state off
+      // the config alone and never needs the answer.
+      enabled:
+        Boolean(dashboardId) &&
+        isChartConfigured(configuration) &&
+        !isMailLensSource(configuration.source),
       staleTime: 30_000,
       placeholderData: keepPreviousData,
     }

--- a/apps/web/src/components/dashboard/hooks/use-kpi-data.ts
+++ b/apps/web/src/components/dashboard/hooks/use-kpi-data.ts
@@ -16,6 +16,7 @@ import {
 import { keepPreviousData } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { api } from '~/trpc/react'
+import { isMailLensSource } from '../lib/widget-source'
 import { selectGlobalFilters, useDashboardStore } from '../stores/dashboard-draft-store'
 
 export function useKpiData(configuration: KpiConfig | GaugeConfig, widgetId?: string) {
@@ -26,7 +27,12 @@ export function useKpiData(configuration: KpiConfig | GaugeConfig, widgetId?: st
   return api.dashboard.kpiData.useQuery(
     { dashboardId: dashboardId ?? '', widgetId, query, globalOverrides },
     {
-      enabled: Boolean(dashboardId) && isChartConfigured(configuration),
+      // See `use-chart-data`: a mail source is refused server-side, so this is a
+      // guaranteed 403 the KPI/gauge body already answers from the config.
+      enabled:
+        Boolean(dashboardId) &&
+        isChartConfigured(configuration) &&
+        !isMailLensSource(configuration.source),
       staleTime: 30_000,
       placeholderData: keepPreviousData,
     }

--- a/apps/web/src/components/dashboard/hooks/use-record-list-data.ts
+++ b/apps/web/src/components/dashboard/hooks/use-record-list-data.ts
@@ -23,6 +23,7 @@ import type { RecordId } from '@auxx/types/resource'
 import { keepPreviousData } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { api } from '~/trpc/react'
+import { isMailLensSource } from '../lib/widget-source'
 import { useDashboardStore } from '../stores/dashboard-draft-store'
 
 /** Stable empty array — a fresh `[]` per render would churn every consumer's memo. */
@@ -52,7 +53,11 @@ export function useRecordListData(config: RecordListConfig, _widgetId?: string) 
   const query = api.record.listFiltered.useQuery(
     { entityDefinitionId, filters: config.filters, sorting, limit: pageSize },
     {
-      enabled: Boolean(dashboardId) && Boolean(config.source),
+      // `listFiltered` refuses `thread` / `message` outright
+      // (`assertNotMailLensTable`), so a stored mail-sourced widget must not
+      // spend a request to be told 403 — the body renders the unavailable state
+      // straight from the config.
+      enabled: Boolean(dashboardId) && Boolean(config.source) && !isMailLensSource(config.source),
       staleTime: 30_000,
       placeholderData: keepPreviousData,
     }

--- a/apps/web/src/components/dashboard/lib/widget-source.ts
+++ b/apps/web/src/components/dashboard/lib/widget-source.ts
@@ -9,8 +9,17 @@
 
 import type { SystemTableId, WidgetSource } from '@auxx/lib/dashboards/client'
 
-/** System tables the aggregate engine can query (client-safe mirror). */
-export const SYSTEM_AGGREGATE_SOURCE_IDS = ['thread', 'message', 'article'] as const
+/**
+ * System tables the aggregate engine can query (client-safe mirror).
+ *
+ * 🔴 **`thread` and `message` were here and are gone**, tracking the same
+ * removal from `SYSTEM_AGGREGATE_TABLE_IDS` server-side: the aggregate builder
+ * emits `WHERE organizationId = $1` and nothing else, so a chart over `thread`
+ * counted the whole org mailbox and a high-cardinality group-by printed subject
+ * lines as its labels. `prepareAggregate` now throws `ForbiddenError` for both.
+ * Keeping them here offered a source that could only ever 403.
+ */
+export const SYSTEM_AGGREGATE_SOURCE_IDS = ['article'] as const
 
 export function isSystemAggregateSourceId(id: string): boolean {
   return (SYSTEM_AGGREGATE_SOURCE_IDS as readonly string[]).includes(id)
@@ -20,17 +29,46 @@ export function isSystemAggregateSourceId(id: string): boolean {
  * Mail-content tables (client-safe mirror of `MAIL_LENS_TABLE_IDS` in
  * `packages/lib/src/resources/picker/mail-lens-tables.ts`).
  *
- * A widget that lists ROWS from these is refused server-side: the metadata /
- * subject / body gradation lives only in `mail-query/`, and the generic record
- * path (`record.listFiltered`) applies none of it. Aggregate widgets still take
- * `thread` / `message` — a grouped count is a different disclosure than a row
- * list — so this is not subtracted from {@link SYSTEM_AGGREGATE_SOURCE_IDS};
- * only the record-list source picker excludes it.
+ * Every generic path to these refuses: rows (`record.listFiltered` →
+ * `assertNotMailLensTable`) **and** aggregates (`prepareAggregate` /
+ * `buildSystemAggregateSql`). The metadata / subject / body gradation lives only
+ * in `mail-query/`, and a row predicate would not substitute for it — it admits
+ * a row at `metadata` while reading a subject needs `identity`.
+ *
+ * Two uses, and they are different questions:
+ * - the source picker drops these from the offer list, so no NEW widget can name
+ *   one (`excludeMailLensTables`);
+ * - the widget bodies test a STORED source against it, so an existing widget
+ *   renders "data source unavailable" instead of a permission error.
  */
 export const MAIL_LENS_SOURCE_IDS = ['thread', 'message'] as const
 
 export function isMailLensSourceId(id: string): boolean {
   return (MAIL_LENS_SOURCE_IDS as readonly string[]).includes(id)
+}
+
+/**
+ * Does this widget's stored source point at a mail table? True ⇒ every server
+ * path behind the widget refuses, so the body must degrade rather than fetch.
+ */
+export function isMailLensSource(source: WidgetSource | undefined): boolean {
+  return !!source && isMailLensSourceId(sourceResourceId(source))
+}
+
+/**
+ * A `FORBIDDEN` answer from the widget's data query.
+ *
+ * The belt to {@link isMailLensSource}'s braces: that test reads a client-side
+ * MIRROR of the server's refusal list, and this file's history is that the
+ * mirror drifted (it still offered `thread` as an aggregate source for a release
+ * after the server stopped accepting it). A refusal the mirror does not predict
+ * must still land on the degraded state rather than a red error, so the
+ * degradation cannot rot into an error the day a table is added server-side.
+ */
+export function isForbiddenSourceError(
+  error: { data?: { code?: string | null } | null } | null | undefined
+): boolean {
+  return error?.data?.code === 'FORBIDDEN'
 }
 
 /**
@@ -44,12 +82,17 @@ export function sourceResourceId(source: WidgetSource): string {
 }
 
 /**
- * Build a `WidgetSource` from a picked resource id. System-aggregate tables map
- * to `{kind:'system'}`; everything else (contact/ticket/custom defs) to
+ * Build a `WidgetSource` from a picked resource id. System tables map to
+ * `{kind:'system'}`; everything else (contact/ticket/custom defs) to
  * `{kind:'entity'}`.
+ *
+ * Mail ids are unreachable here (the picker excludes them) but are still tagged
+ * `system` — mis-tagging one as an entity def would send it down the
+ * `EntityInstance` path, which is a different wrong answer than a refusal.
  */
 export function resourceIdToSource(id: string): WidgetSource {
-  if (isSystemAggregateSourceId(id)) return { kind: 'system', tableId: id as SystemTableId }
+  if (isSystemAggregateSourceId(id) || isMailLensSourceId(id))
+    return { kind: 'system', tableId: id as SystemTableId }
   return { kind: 'entity', entityDefinitionId: id }
 }
 

--- a/apps/web/src/components/dashboard/ui/config/data-source-section-mail-lens.test.tsx
+++ b/apps/web/src/components/dashboard/ui/config/data-source-section-mail-lens.test.tsx
@@ -1,0 +1,103 @@
+// apps/web/src/components/dashboard/ui/config/data-source-section-mail-lens.test.tsx
+//
+// Half two of the config gate (see `widget-config-mail-source.test.tsx` for half
+// one): `excludeMailLensTables` — and the aggregate allowlist mirror behind it —
+// actually removes `thread` / `message` from what the source picker offers.
+//
+// Separate file because the sibling stubs `./data-source-section` to read the
+// prop off each body, which would stub the component under test here.
+
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Props every `ResourcePicker` mount received. */
+  pickers: [] as Array<{ excludeIds?: string[] }>,
+}))
+
+vi.mock('~/components/pickers/resource-picker/resource-picker', () => ({
+  ResourcePicker: (props: { excludeIds?: string[] }) => {
+    h.pickers.push(props)
+    return <div data-testid='resource-picker' />
+  },
+}))
+
+/** Registry system tables + a custom entity def, in the `useResources` shape. */
+const RESOURCES = [
+  { id: 'thread', type: 'system' },
+  { id: 'message', type: 'system' },
+  { id: 'article', type: 'system' },
+  { id: 'user', type: 'system' },
+  { id: 'edf_contact', type: 'custom' },
+]
+
+vi.mock('~/components/resources', () => ({
+  useResources: () => ({ resources: RESOURCES, getResourceById: () => undefined }),
+}))
+
+import { MAIL_LENS_SOURCE_IDS, SYSTEM_AGGREGATE_SOURCE_IDS } from '../../lib/widget-source'
+import { DataSourceSection } from './data-source-section'
+
+/** `TooltipProvider` mirrors the app shell (`global/auxx-app-providers.tsx`) — a
+ *  `FieldPanelRow` label carries a Radix tooltip. */
+const renderSection = (props: { excludeMailLensTables?: boolean } = {}) =>
+  render(
+    <TooltipProvider>
+      <DataSourceSection
+        source={undefined}
+        hasDependentConfig={false}
+        onSelectSource={() => {}}
+        {...props}
+      />
+    </TooltipProvider>
+  )
+
+beforeEach(() => {
+  h.pickers.length = 0
+})
+
+describe('DataSourceSection', () => {
+  it('excludes thread and message when the flag is set', () => {
+    renderSection({ excludeMailLensTables: true })
+
+    expect(screen.getByTestId('resource-picker')).toBeInTheDocument()
+    for (const id of MAIL_LENS_SOURCE_IDS) {
+      expect(h.pickers[0]?.excludeIds).toContain(id)
+    }
+  })
+
+  it('still offers the aggregate-queryable system tables and entity defs', () => {
+    renderSection({ excludeMailLensTables: true })
+
+    // Without this the assertion above would also pass on a picker that
+    // excluded literally everything.
+    expect(h.pickers[0]?.excludeIds).not.toContain('article')
+    expect(h.pickers[0]?.excludeIds).not.toContain('edf_contact')
+    // A system table the aggregate engine cannot query stays hidden, as before.
+    expect(h.pickers[0]?.excludeIds).toContain('user')
+  })
+
+  it('excludes them even with the flag unset — the aggregate mirror dropped them', () => {
+    // Defence in depth, and the drift this file exists to catch: the server
+    // removed `thread` / `message` from `SYSTEM_AGGREGATE_TABLE_IDS` while this
+    // client-side mirror still listed them, so the chart bodies kept offering a
+    // source that could only ever 403.
+    renderSection()
+
+    for (const id of MAIL_LENS_SOURCE_IDS) {
+      expect(h.pickers[0]?.excludeIds).toContain(id)
+    }
+  })
+})
+
+describe('the client-side aggregate mirror', () => {
+  it('is disjoint from the mail tables', () => {
+    // The server asserts the same disjointness over its own two constants in
+    // `resources/aggregate/mail-lens-refusal.test.ts`; this is that assertion on
+    // the copy the config panel actually reads.
+    for (const id of MAIL_LENS_SOURCE_IDS) {
+      expect(SYSTEM_AGGREGATE_SOURCE_IDS as readonly string[]).not.toContain(id)
+    }
+  })
+})

--- a/apps/web/src/components/dashboard/ui/config/data-source-section.tsx
+++ b/apps/web/src/components/dashboard/ui/config/data-source-section.tsx
@@ -31,10 +31,12 @@ export function DataSourceSection({
   /** Whether any field-bound setting is set (drives the reset confirm). */
   hasDependentConfig: boolean
   /**
-   * Drop `thread` / `message` from the offer list. Set by the record-list body:
-   * listing thread ROWS through the generic record path is refused server-side
-   * (the mail lens lives in `mail-query/` only), so offering it would only ever
-   * produce a widget that renders a permission error.
+   * Drop `thread` / `message` from the offer list. Set by **every** data widget
+   * body (via `DataSourceBlock`): both generic server paths a widget can take
+   * refuse mail tables — rows through `record.listFiltered`
+   * (`assertNotMailLensTable`) and aggregates through `prepareAggregate` — because
+   * the metadata/subject/body lens lives only in `mail-query/`. Offering one
+   * would produce a widget that can only render the unavailable state.
    */
   excludeMailLensTables?: boolean
   onSelectSource: (source: WidgetSource) => void

--- a/apps/web/src/components/dashboard/ui/config/widget-config-bodies.tsx
+++ b/apps/web/src/components/dashboard/ui/config/widget-config-bodies.tsx
@@ -69,7 +69,15 @@ function hasDependentConfig(config: DataWidgetConfig): boolean {
 
 // ── Shared blocks ────────────────────────────────────────────────────────────
 
-/** Source picker; renders nothing else until a source is chosen. */
+/**
+ * Source picker; renders nothing else until a source is chosen.
+ *
+ * `excludeMailLensTables` is set for EVERY data widget kind, not just the record
+ * list that first needed it. `thread` / `message` are refused by both generic
+ * server paths a widget can take — rows (`record.listFiltered`) and aggregates
+ * (`prepareAggregate`) — so offering either would only ever build a widget that
+ * renders the "data source unavailable" state.
+ */
 function DataSourceBlock({
   config,
   onReset,
@@ -81,6 +89,7 @@ function DataSourceBlock({
     <DataSourceSection
       source={config.source}
       hasDependentConfig={hasDependentConfig(config)}
+      excludeMailLensTables
       onSelectSource={onReset}
     />
   )
@@ -614,14 +623,11 @@ function RecordListBody({
     <>
       <Section title='Data' icon={<Database className='size-3.5' />} collapsible={false}>
         <Panel>
-          <DataSourceSection
-            source={config.source}
-            hasDependentConfig={
-              (config.columns?.length ?? 0) > 0 || !!config.sort || !!config.filters?.length
-            }
-            excludeMailLensTables
-            onSelectSource={onReset}
-          />
+          {/* The shared block, not a second call site: its `hasDependentConfig`
+              already covers columns/sort/filters, and routing every kind through
+              one component is what keeps the mail-lens exclusion from being set
+              on some bodies and forgotten on others. */}
+          <DataSourceBlock config={config} onReset={onReset} />
           {source && (
             <>
               <ColumnsRow

--- a/apps/web/src/components/dashboard/ui/config/widget-config-mail-source.test.tsx
+++ b/apps/web/src/components/dashboard/ui/config/widget-config-mail-source.test.tsx
@@ -1,0 +1,73 @@
+// apps/web/src/components/dashboard/ui/config/widget-config-mail-source.test.tsx
+//
+// Half one of "no widget kind may OFFER a mail table as a data source": every
+// data body wires `excludeMailLensTables`.
+//
+// `thread` / `message` are refused by both generic server paths a widget can
+// take — rows (`record.listFiltered` → `assertNotMailLensTable`) and aggregates
+// (`prepareAggregate`) — so a source the picker still offers can only produce a
+// widget that renders "Data source unavailable". The record-list body was gated
+// first; this pins the other five, which is the half that was missing.
+//
+// Half two — that the flag actually removes them from the offer list — is
+// `data-source-section-mail-lens.test.tsx`, and it has to be a separate file:
+// this one stubs `./data-source-section` to read the prop, which would also stub
+// the component under test there. Asserting only this half would pass with a
+// no-op prop; asserting only the other would pass with five bodies that never
+// set it.
+
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Props every `DataSourceSection` mount received. */
+  sections: [] as Array<{ excludeMailLensTables?: boolean }>,
+}))
+
+vi.mock('./data-source-section', () => ({
+  DataSourceSection: (props: { excludeMailLensTables?: boolean }) => {
+    h.sections.push(props)
+    return null
+  },
+}))
+
+import type { WidgetConfiguration } from '@auxx/lib/dashboards/client'
+import { WidgetConfigBody } from './widget-config-bodies'
+
+/** Every kind that carries a `source` — i.e. every kind this gate must cover. */
+const DATA_WIDGET_CONFIGS = [
+  { kind: 'barChart', metric: { op: 'count' } },
+  { kind: 'lineChart', metric: { op: 'count' } },
+  { kind: 'pieChart', metric: { op: 'count' } },
+  { kind: 'kpi', metric: { op: 'count' } },
+  { kind: 'gauge', metric: { op: 'count' }, rangeMax: 100 },
+  { kind: 'recordList', columns: [] },
+] as unknown as WidgetConfiguration[]
+
+beforeEach(() => {
+  h.sections.length = 0
+})
+
+describe('widget config bodies', () => {
+  it.each(
+    DATA_WIDGET_CONFIGS.map((config) => [config.kind, config] as const)
+  )('%s excludes the mail tables from its source picker', (_kind, config) => {
+    render(<WidgetConfigBody config={config} onChange={() => {}} />)
+
+    expect(h.sections).toHaveLength(1)
+    expect(h.sections[0]?.excludeMailLensTables).toBe(true)
+  })
+
+  it('covers every data widget kind', () => {
+    // The list above is hand-written; if a seventh source-bearing kind lands,
+    // this is the assertion that notices the gate was never extended to it.
+    expect(DATA_WIDGET_CONFIGS.map((c) => c.kind).sort()).toEqual([
+      'barChart',
+      'gauge',
+      'kpi',
+      'lineChart',
+      'pieChart',
+      'recordList',
+    ])
+  })
+})

--- a/apps/web/src/components/dashboard/ui/widget/chart-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/chart-widget.tsx
@@ -22,11 +22,18 @@ import { useMetricFieldMeta } from '../../hooks/use-metric-field'
 import { remapGroupLabels, toChartRows } from '../../lib/chart-transform'
 import { effectiveFieldTypeOf } from '../../lib/field-meta'
 import { formatMetricValue, formatMetricValueCompact } from '../../lib/format-value'
+import { isForbiddenSourceError, isMailLensSource } from '../../lib/widget-source'
 import { BarChartWidget } from './bar-chart-widget'
 import { LineChartWidget } from './line-chart-widget'
 import { PieChartWidget } from './pie-chart-widget'
 import { WidgetDroppedFilters } from './widget-dropped-filters'
-import { WidgetEmpty, WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
+import {
+  WidgetDataSourceUnavailable,
+  WidgetEmpty,
+  WidgetError,
+  WidgetSkeleton,
+  WidgetUnconfigured,
+} from './widget-states'
 
 type GroupedChartConfig = BarChartConfig | LineChartConfig | PieChartConfig
 
@@ -56,6 +63,10 @@ export function ChartWidget({
   const groupFieldType = groupField ? effectiveFieldTypeOf(groupField) : undefined
   const isDateDim = groupFieldType === 'DATE' || groupFieldType === 'DATETIME'
 
+  // Ahead of `isChartConfigured`: a stored mail chart usually IS fully
+  // configured, and where it isn't, "Configure this widget" would send its owner
+  // to a panel that can no longer offer the source back.
+  if (isMailLensSource(config.source)) return <WidgetDataSourceUnavailable />
   if (!isChartConfigured(config)) {
     return (
       <WidgetUnconfigured
@@ -65,7 +76,13 @@ export function ChartWidget({
     )
   }
   if (isLoading && !data) return <WidgetSkeleton variant='chart' />
-  if (isError) return <WidgetError message={error?.message} />
+  if (isError) {
+    return isForbiddenSourceError(error) ? (
+      <WidgetDataSourceUnavailable detail='The data source behind this widget can no longer be aggregated.' />
+    ) : (
+      <WidgetError message={error?.message} />
+    )
+  }
   if (!data || data.groups.length === 0) return <WidgetEmpty />
 
   const cumulative = config.kind !== 'pieChart' ? config.cumulative : undefined

--- a/apps/web/src/components/dashboard/ui/widget/gauge-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/gauge-widget.tsx
@@ -17,8 +17,14 @@ import { useKpiData } from '../../hooks/use-kpi-data'
 import { useMetricFieldMeta } from '../../hooks/use-metric-field'
 import { seriesColors } from '../../lib/chart-palettes'
 import { formatMetricValue } from '../../lib/format-value'
+import { isForbiddenSourceError, isMailLensSource } from '../../lib/widget-source'
 import { WidgetDroppedFilters } from './widget-dropped-filters'
-import { WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
+import {
+  WidgetDataSourceUnavailable,
+  WidgetError,
+  WidgetSkeleton,
+  WidgetUnconfigured,
+} from './widget-states'
 
 const GAUGE_CONFIG: ChartConfig = { value: { label: 'Value' } }
 
@@ -36,6 +42,9 @@ export function GaugeWidget({
   const { data, isLoading, isError, error } = useKpiData(config, widgetId)
   const meta = useMetricFieldMeta(config.metric, config.valueFormat)
 
+  // Before every other branch — the query is disabled for a mail source, so
+  // `data` never arrives and the tile would hold a skeleton indefinitely.
+  if (isMailLensSource(config.source)) return <WidgetDataSourceUnavailable />
   // A gauge also needs a target (`rangeMax`) before it can draw its arc.
   if (!isChartConfigured(config) || config.rangeMax == null) {
     return (
@@ -46,7 +55,13 @@ export function GaugeWidget({
     )
   }
   if (isLoading && !data) return <WidgetSkeleton variant='value' />
-  if (isError) return <WidgetError message={error?.message} />
+  if (isError) {
+    return isForbiddenSourceError(error) ? (
+      <WidgetDataSourceUnavailable detail='The data source behind this widget can no longer be aggregated.' />
+    ) : (
+      <WidgetError message={error?.message} />
+    )
+  }
   if (!data) return <WidgetSkeleton variant='value' />
 
   const min = config.rangeMin ?? 0

--- a/apps/web/src/components/dashboard/ui/widget/kpi-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/kpi-widget.tsx
@@ -18,8 +18,14 @@ import { Info, Minus, TrendingDown, TrendingUp } from 'lucide-react'
 import { useKpiData } from '../../hooks/use-kpi-data'
 import { useMetricFieldMeta } from '../../hooks/use-metric-field'
 import { computeTrendDelta, formatMetricValue, formatTrendPercent } from '../../lib/format-value'
+import { isForbiddenSourceError, isMailLensSource } from '../../lib/widget-source'
 import { WidgetDroppedFilters } from './widget-dropped-filters'
-import { WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
+import {
+  WidgetDataSourceUnavailable,
+  WidgetError,
+  WidgetSkeleton,
+  WidgetUnconfigured,
+} from './widget-states'
 
 export function KpiWidget({
   config,
@@ -35,6 +41,9 @@ export function KpiWidget({
   const { data, isLoading, isError, error } = useKpiData(config, widgetId)
   const meta = useMetricFieldMeta(config.metric, config.valueFormat)
 
+  // Before every other branch — the query is disabled for a mail source, so
+  // `data` never arrives and the tile would hold a skeleton indefinitely.
+  if (isMailLensSource(config.source)) return <WidgetDataSourceUnavailable />
   if (!isChartConfigured(config)) {
     return (
       <WidgetUnconfigured
@@ -44,7 +53,13 @@ export function KpiWidget({
     )
   }
   if (isLoading && !data) return <WidgetSkeleton variant='value' />
-  if (isError) return <WidgetError message={error?.message} />
+  if (isError) {
+    return isForbiddenSourceError(error) ? (
+      <WidgetDataSourceUnavailable detail='The data source behind this widget can no longer be aggregated.' />
+    ) : (
+      <WidgetError message={error?.message} />
+    )
+  }
   if (!data) return <WidgetSkeleton variant='value' />
 
   const value = formatMetricValue(data.value, config.metric.op, meta)

--- a/apps/web/src/components/dashboard/ui/widget/record-list-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/record-list-widget.tsx
@@ -23,7 +23,14 @@ import { DroppedFiltersNotice } from '~/components/dynamic-table/components/drop
 import { useResourceFields } from '~/components/resources'
 import { type RecordListRow, useRecordListColumns } from '../../hooks/use-record-list-columns'
 import { useRecordListData } from '../../hooks/use-record-list-data'
-import { WidgetEmpty, WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
+import { isForbiddenSourceError, isMailLensSource } from '../../lib/widget-source'
+import {
+  WidgetDataSourceUnavailable,
+  WidgetEmpty,
+  WidgetError,
+  WidgetSkeleton,
+  WidgetUnconfigured,
+} from './widget-states'
 
 export function RecordListWidget({
   config,
@@ -77,8 +84,17 @@ export function RecordListWidget({
       />
     )
   }
+  // Ahead of the loading/error branches: a mail source never fetches, so it
+  // would otherwise sit on a skeleton forever.
+  if (isMailLensSource(config.source)) return <WidgetDataSourceUnavailable />
   if (isLoading) return <WidgetSkeleton variant='list' />
-  if (isError) return <WidgetError message={error?.message} />
+  if (isError) {
+    return isForbiddenSourceError(error) ? (
+      <WidgetDataSourceUnavailable detail='The data source behind this widget can no longer be read through the records API.' />
+    ) : (
+      <WidgetError message={error?.message} />
+    )
+  }
   if (rows.length === 0) return <WidgetEmpty />
 
   return (

--- a/apps/web/src/components/dashboard/ui/widget/widget-mail-source.test.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/widget-mail-source.test.tsx
@@ -1,0 +1,203 @@
+// apps/web/src/components/dashboard/ui/widget/widget-mail-source.test.tsx
+//
+// A STORED `thread` / `message` widget must degrade, not error.
+//
+// The query layer refuses mail tables outright (`assertNotMailLensTable` for
+// rows, `prepareAggregate` for aggregates) because row visibility is not content
+// authorization — `buildMailVisibilityPredicate` admits a row at `metadata`
+// while reading a subject needs `identity`. That refusal is correct and is not
+// what these tests exercise; what they pin is the consequence nobody sees until
+// a saved dashboard reloads: every widget kind that could name `thread` before
+// the gate landed still renders something a human can act on.
+//
+// Two assertions per kind, and the second is the one that rots first:
+//   1. the body renders the unavailable state (not a red error, and not a
+//      skeleton that never resolves — the query is disabled, so `data` never
+//      arrives);
+//   2. **no request is issued at all.** A guaranteed-403 fetch per mail widget
+//      per dashboard load is the failure mode a purely error-driven degradation
+//      would ship quietly.
+
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { render as rtlRender, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Every `useQuery` the widget bodies reached, with its `enabled` verdict. */
+  queries: [] as Array<{ endpoint: string; enabled: boolean }>,
+  /** Overrides the stubbed answer for one render (the FORBIDDEN suite). */
+  answer: undefined as
+    | undefined
+    | { data: undefined; isLoading: boolean; isError: boolean; error: unknown },
+}))
+
+/** Records the call, then answers as a disabled query does: pending, no data. */
+function stubQuery(endpoint: string) {
+  return (_input: unknown, opts?: { enabled?: boolean }) => {
+    const enabled = opts?.enabled !== false
+    h.queries.push({ endpoint, enabled })
+    if (h.answer) return h.answer
+    return { data: undefined, isLoading: enabled, isError: false, error: null }
+  }
+}
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    dashboard: {
+      chartData: { useQuery: stubQuery('dashboard.chartData') },
+      kpiData: { useQuery: stubQuery('dashboard.kpiData') },
+    },
+    record: { listFiltered: { useQuery: stubQuery('record.listFiltered') } },
+  },
+}))
+
+// The table and the record cells are not under test — they are the heaviest
+// thing in the record-list body's graph and they only mount on the happy path.
+vi.mock('~/components/dynamic-table', () => ({
+  DynamicTable: () => <div data-testid='dynamic-table' />,
+  PrimaryFieldCell: () => null,
+  CustomFieldCell: () => null,
+  getIconForFieldType: () => null,
+}))
+
+vi.mock('~/components/resources', () => ({
+  useResource: () => ({ resource: undefined }),
+  useResourceFields: () => ({ fields: [] }),
+}))
+
+vi.mock('~/components/resources/hooks/use-field', () => ({
+  useField: () => undefined,
+  useFields: () => [],
+}))
+
+import type {
+  BarChartConfig,
+  GaugeConfig,
+  KpiConfig,
+  RecordListConfig,
+  WidgetSource,
+} from '@auxx/lib/dashboards/client'
+import type { ReactElement } from 'react'
+import { useDashboardStore } from '../../stores/dashboard-draft-store'
+import { ChartWidget } from './chart-widget'
+import { GaugeWidget } from './gauge-widget'
+import { KpiWidget } from './kpi-widget'
+import { RecordListWidget } from './record-list-widget'
+
+const THREAD: WidgetSource = { kind: 'system', tableId: 'thread' }
+const MESSAGE: WidgetSource = { kind: 'system', tableId: 'message' }
+const CONTACT: WidgetSource = { kind: 'entity', entityDefinitionId: 'edf_contact' }
+
+const UNAVAILABLE = 'Data source unavailable'
+
+/** Fully configured widgets — the point is that config validity is irrelevant. */
+const bodies: Record<string, (source: WidgetSource) => ReactElement> = {
+  recordList: (source) => (
+    <RecordListWidget
+      config={{ kind: 'recordList', source, columns: [] } as RecordListConfig}
+      widgetId='wgt_1'
+      isEditMode={false}
+    />
+  ),
+  chart: (source) => (
+    <ChartWidget
+      config={
+        {
+          kind: 'barChart',
+          source,
+          metric: { op: 'count' },
+          groupBy: { fieldRef: 'thread:status' },
+        } as BarChartConfig
+      }
+      widgetId='wgt_2'
+      isEditMode={false}
+    />
+  ),
+  kpi: (source) => (
+    <KpiWidget
+      config={{ kind: 'kpi', source, metric: { op: 'count' } } as KpiConfig}
+      widgetId='wgt_3'
+      isEditMode={false}
+    />
+  ),
+  gauge: (source) => (
+    <GaugeWidget
+      config={{ kind: 'gauge', source, metric: { op: 'count' }, rangeMax: 100 } as GaugeConfig}
+      widgetId='wgt_4'
+      isEditMode={false}
+    />
+  ),
+}
+
+/** Mirrors the app shell (`global/auxx-app-providers.tsx`), which wraps every
+ *  protected page in a `TooltipProvider` — the unavailable state's hover
+ *  explanation is a Radix tooltip and needs one. */
+const render = (ui: ReactElement) => rtlRender(<TooltipProvider>{ui}</TooltipProvider>)
+
+const MAIL_SOURCES: Array<[string, WidgetSource]> = [
+  ['thread', THREAD],
+  ['message', MESSAGE],
+]
+
+beforeEach(() => {
+  h.queries.length = 0
+  h.answer = undefined
+  // The hooks gate on a seeded dashboard id; without it every query is disabled
+  // for an unrelated reason and the "no request" assertions pass vacuously.
+  useDashboardStore.setState({ dashboardId: 'dsh_1' })
+})
+
+describe.each(Object.keys(bodies))('%s widget', (kind) => {
+  const body = bodies[kind] as (source: WidgetSource) => ReactElement
+
+  it.each(MAIL_SOURCES)('renders the unavailable state for a stored %s source', (_id, source) => {
+    render(body(source))
+
+    expect(screen.getByText(UNAVAILABLE)).toBeInTheDocument()
+    expect(screen.queryByTestId('dynamic-table')).not.toBeInTheDocument()
+  })
+
+  it.each(MAIL_SOURCES)('issues no request for a stored %s source', (_id, source) => {
+    render(body(source))
+
+    expect(h.queries.filter((q) => q.enabled)).toEqual([])
+  })
+
+  it('leaves an entity source alone — it still fetches and shows no notice', () => {
+    render(body(CONTACT))
+
+    expect(screen.queryByText(UNAVAILABLE)).not.toBeInTheDocument()
+    expect(h.queries.filter((q) => q.enabled).length).toBeGreaterThan(0)
+  })
+
+  // The mirror in `lib/widget-source.ts` is a copy of a server allowlist and has
+  // already drifted once (it offered `thread` as an aggregate source for a
+  // release after the server stopped accepting it). A refusal the mirror does
+  // not predict must still degrade rather than turn the tile red.
+  it('falls back to the unavailable state on an unforeseen FORBIDDEN', () => {
+    h.answer = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: 'Threads and messages are not readable', data: { code: 'FORBIDDEN' } },
+    }
+
+    render(body(CONTACT))
+
+    expect(screen.getByText(UNAVAILABLE)).toBeInTheDocument()
+  })
+
+  it('still shows a real error for a non-FORBIDDEN failure', () => {
+    h.answer = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: 'boom', data: { code: 'INTERNAL_SERVER_ERROR' } },
+    }
+
+    render(body(CONTACT))
+
+    expect(screen.getByText('boom')).toBeInTheDocument()
+    expect(screen.queryByText(UNAVAILABLE)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/dashboard/ui/widget/widget-states.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/widget-states.tsx
@@ -1,15 +1,16 @@
 // apps/web/src/components/dashboard/ui/widget/widget-states.tsx
 'use client'
 
-// The four non-data states a widget body can render in place of content:
-// loading, empty, error, and unconfigured. All centered, muted, and sized to
-// fill the widget body (`flex-1 min-h-0`). Errors render here — never a toast —
-// so one broken widget stays contained (house rule: errors in place).
+// The non-data states a widget body can render in place of content: loading,
+// empty, error, unconfigured, and unavailable-source. All centered, muted, and
+// sized to fill the widget body (`flex-1 min-h-0`). Errors render here — never a
+// toast — so one broken widget stays contained (house rule: errors in place).
 
 import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
-import { AlertCircle, Settings2 } from 'lucide-react'
+import { AlertCircle, Settings2, Unplug } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 function StateShell({ children, className }: { children: ReactNode; className?: string }) {
@@ -61,6 +62,45 @@ export function WidgetError({ message }: { message?: string }) {
     <StateShell className='text-destructive'>
       <AlertCircle className='size-5' />
       <span>{message ?? 'Something went wrong'}</span>
+    </StateShell>
+  )
+}
+
+/**
+ * The widget's STORED data source can no longer be queried — today only the mail
+ * tables (`thread` / `message`), which every generic server path now refuses so
+ * that the mail lens in `mail-query/` stays the single authority on thread
+ * content.
+ *
+ * **Deliberately not {@link WidgetError}.** Nothing failed and nothing is
+ * broken: the widget is a valid document naming a source the platform withdrew,
+ * and a red `AlertCircle` would send its owner hunting a fault that does not
+ * exist. It is also not {@link WidgetEmpty} ("adjust filters" is advice that
+ * cannot work here) and not {@link WidgetUnconfigured} — there is nothing to
+ * configure that would bring the source back.
+ *
+ * So it borrows the shape the dashboard already uses for "this tile is telling
+ * you something, quietly": muted body text, a plain-language line, and the
+ * explanation on hover — the same restraint as `DroppedFiltersNotice`
+ * (`dynamic-table/components/dropped-filters-notice.tsx`), one level up because a
+ * missing source removes the whole body rather than qualifying a footer. The
+ * hover text is the only place mail is named, so the resting state does not
+ * accuse the viewer of lacking permission — this is not a per-viewer verdict.
+ */
+export function WidgetDataSourceUnavailable({
+  detail = 'Threads and messages are only searchable in Mail, where per-conversation visibility applies. Delete this widget or point it at another source.',
+}: {
+  /** Overrides the hover explanation; the resting line is fixed on purpose. */
+  detail?: string
+}) {
+  return (
+    <StateShell>
+      <Unplug className='size-5' />
+      <SimpleTooltip side='top' content={detail}>
+        <span className='cursor-default border-muted-foreground/40 border-b border-dashed'>
+          Data source unavailable
+        </span>
+      </SimpleTooltip>
     </StateShell>
   )
 }


### PR DESCRIPTION
The dashboard half of `plans/dashboard/18-mail-lens-widget-gating.md`. The query layer already refuses `thread`/`message` (#1470, #1473); the dashboard never caught up.

## The live bug: the client mirror had drifted

`SYSTEM_AGGREGATE_TABLE_IDS` is `['article']` server-side, and `mail-lens-refusal.test.ts` asserts it is disjoint from `MAIL_LENS_TABLE_IDS`. But `SYSTEM_AGGREGATE_SOURCE_IDS` in `dashboard/lib/widget-source.ts` **still listed `['thread','message','article']`** — so the chart/KPI/gauge pickers were offering a source the server had already stopped accepting, and its own doc comment still claimed aggregates legitimately took mail tables.

Re-synced to `['article']`. **That alone gates all six widget bodies.**

`excludeMailLensTables` becomes defence in depth: it moved onto the shared `DataSourceBlock`, and `RecordListBody` — the one body with its own inline `DataSourceSection` call site — now routes through it too. **One call site**, so the flag can't be set on some bodies and forgotten on others. Both layers tested independently.

## Stored widgets degrade instead of erroring

`WidgetDataSourceUnavailable` renders in all four bodies, and the three data hooks gate on `!isMailLensSource(source)` — so a stored mail widget issues **no request at all** rather than paying a guaranteed 403 per tile per dashboard load.

Why a new state rather than an existing one:

| Rejected | Because |
|---|---|
| `WidgetError` | Nothing failed. A red `AlertCircle` sends the owner hunting a fault that doesn't exist |
| `WidgetEmpty` | "Adjust filters" is advice that cannot work |
| `WidgetUnconfigured` | There is nothing to configure that brings the source back |

Muted line, detail on hover — `DroppedFiltersNotice`'s restraint, one level up, because a missing source removes the body rather than qualifying a footer. The resting line never mentions permission: this is not a per-viewer verdict.

`isForbiddenSourceError` maps any `FORBIDDEN` answer to the same state. **That exists precisely because the mirror drifted once** — a refusal the client can't predict must still degrade rather than turn red. Non-`FORBIDDEN` failures still render `WidgetError`, and that's tested.

## Correction to the plan

A stored mail widget was **not** producing an *unhandled* error. `record.listFiltered` has no try/catch, so the `ForbiddenError` mapped cleanly to `FORBIDDEN` and react-query rendered a red tile showing the raw refusal sentence — which told dashboard users to *"use the mail search tools (find_threads / get_thread_detail)"*. Misleading, not a crash.

## `PrimaryFieldCell` — verified safe on both routes

The plan flags it as unlensed. That predates #1473/#1475, so it was re-checked against current source, and it has **two** hydration routes rather than the one the plan names:

- `useFieldValue` → `fieldValue.batchGet` → gated by `resolveMailLensGate`. `subject` is unlisted in `threadFieldMinLens`, which defaults to `identity` — and `subject` is exactly what the cell requests (`display-config.ts` sets thread's `primaryDisplayFieldId`).
- `useRecord` → `record.getByIds` → gated by `RecordPickerService.getResourcesByIds` skipping mail ids.

The obvious bypass was probed: the `threads:<id>` apiSlug spelling misses `isMailLensTableId`, but then also misses `RESOURCE_TABLE_MAP`, so it fetches nothing.

## Audit

**Dev:** 5 affected widgets — 1 draft + 4 published snapshots, all `recordList` on `system:thread`, all one dashboard ("Support overview"). **Zero** chart/KPI/gauge.

**Production is unaudited** — not reachable from here. The exact read-only SQL is in the plan doc; worth running before this merges so the blast radius is known rather than discovered.

## Testing

`apps/web` `src/components/dashboard`: **170 passed / 13 files** (was 131). Query-layer refusals untouched and still green — `aggregate/mail-lens-refusal.test.ts` + `crud/__tests__/list-filtered-mail-lens.test.ts` + `picker/mail-lens-tables.test.ts` = 33 passed. Nothing was weakened to make a UI test pass.

Biome clean. `apps/web` tsc: zero hits in any touched file.

**Non-vacuity** — each neutralized, confirmed red, restored:

| Neutralized | Failures |
|---|---|
| mirror re-lists `thread`/`message` | 2 |
| `DataSourceBlock` drops `excludeMailLensTables` | 6 |
| widget bodies drop the mail early-return | 8 |
| hooks stop disabling the query | 8 |
| `isForbiddenSourceError` returns false | 4 |

## Open, and not for this PR

Whether **lens-aware mail aggregates** should exist ("thread volume by assignee") is a product decision — see the plan's item 4. It can't return through the generic path: grouping by `subject` prints subject lines as labels, and `runAggregate` caches without a user key, so a per-viewer predicate would poison the cache for everyone. If wanted, it belongs in `mail-query/` as a fixed set of metadata-only group keys.