### PR TITLE
refactor(search): extract keyset primitives and record why records paging stays OFFSET

### DIFF
--- a/packages/lib/src/resources/crud/unified-handler-queries.ts
+++ b/packages/lib/src/resources/crud/unified-handler-queries.ts
@@ -600,6 +600,53 @@ function describeFilterProblems(
  * `hasMore` comes from the `limit + 1` probe row, never from `offset + ids.length < total`
  * — the probe stays honest under concurrent inserts/deletes, a stored total drifts.
  *
+ * ## 🔴 `OFFSET` is deliberate here. Keyset pagination was tried and REJECTED.
+ *
+ * The ranked-search case (`search` set, no explicit `sorting`) is the obvious
+ * candidate for a keyset cursor: the rank is recomputed over the whole matched
+ * set on every page, and `OFFSET` makes Postgres produce and discard rows it has
+ * already sorted. **It was implemented, measured against live Postgres, and
+ * backed out.** Do not re-attempt it without new information — specifically,
+ * without the rewrite named at the bottom of this comment.
+ *
+ * A correct three-part `(rank DESC, updatedAt DESC, id ASC)` keyset — cursor and
+ * `ORDER BY` rendered from one term list via `keysetOrderBy` / `keysetAfter` in
+ * `search/text-search-sql.ts` — was **slower than `OFFSET` at every depth and
+ * every scale measured**, on the dev database:
+ *
+ * | matched | depth   | OFFSET | KEYSET  |
+ * |---------|---------|--------|---------|
+ * | 1,161   | 0       | 16 ms  | 15 ms   |
+ * | 1,161   | 1,000   | 16 ms  | 24 ms   |
+ * | 92,526  | 0       | 133 ms | 135 ms  |
+ * | 92,526  | 50,000  | 155 ms | 214 ms  |
+ * | 370,096 | 150,000 | 889 ms | 1208 ms |
+ *
+ * (Correctness was never the problem: full sweeps over 1,161 and 92,526 matched
+ * rows — with 778- and 62,067-row blocks of *tied* rank — reproduced the offset
+ * sequence exactly, no skips, no duplicates.)
+ *
+ * `EXPLAIN ANALYZE` says why, and it is the opposite of the usual keyset story.
+ * The rank is a computed expression, so no index can serve the ordering and the
+ * **scan + rank evaluation dominates** — 138 ms of a 165 ms page at 92k rows.
+ * Against that the `OFFSET` skip is nearly free: the rows are already sorted, so
+ * discarding 50,000 of them costs ~16 ms, showing up only as a full
+ * `external merge Disk: 3496kB` sort instead of a `top-N heapsort Memory: 32kB`.
+ * The keyset does buy that sort back — but its `WHERE` recomputes `similarity()`
+ * + `ts_rank_cd()` **twice more per candidate row** (once for the `<` arm, once
+ * for the `=` arm), costing ~70 ms at the same scale. Net loss.
+ *
+ * Worse, the loss **grows with depth**, for the same reason the three-part key
+ * was needed at all: most rows score 0 on trigram, so a deep cursor lands inside
+ * the huge zero-score tie block, where `rank < r0` is false for every row and the
+ * `rank = r0` arm therefore always runs.
+ *
+ * The only version that could win computes the rank **once** — a materialized CTE
+ * or `OFFSET 0` subquery projecting the score, with the keyset filtering on the
+ * alias — which caps the win at the sort difference (~15% at 92k rows / depth
+ * 50k) and is a different query shape from this one. Measure that before
+ * reopening; a keyset bolted onto the current shape is a regression.
+ *
  * @returns `ids` (length ≤ limit), `hasMore`, and `total` only when `includeTotal`.
  */
 export async function queryEntityInstanceIdsPaged(params: {

--- a/packages/lib/src/resources/search/record-search-sql.ts
+++ b/packages/lib/src/resources/search/record-search-sql.ts
@@ -103,9 +103,25 @@ export function recordSearchPredicate(
 }
 
 /**
- * The record relevance score. Use as `desc(recordSearchRank(q))` — and keep
- * `updatedAt DESC, id DESC` under it, because most rows score 0 on trigram and
- * an unbroken tie pages erratically.
+ * The record relevance score. Use as `desc(recordSearchRank(q))` — and keep a
+ * recency tier under it, because most rows score 0 on trigram and an unbroken tie
+ * pages erratically.
+ *
+ * ⚠️ **The two ranked record surfaces do NOT agree on the tiers below the rank,
+ * and both spellings are load-bearing.**
+ *
+ * - The **records list** (`crud/unified-handler-queries.ts`) orders
+ *   `rank DESC, updatedAt DESC, id ASC`. That last tier is **ASC**, not DESC — it
+ *   is the `asc(EntityInstance.id)` that lane has always appended as its
+ *   deterministic tie-break. Anything reasoning about this ordering (a cursor, a
+ *   resumable scan, an "is this page stable" argument) that assumes DESC
+ *   throughout walks every tied block backwards.
+ * - The **picker** (`picker/record-picker-service.ts`) orders
+ *   `combined_score DESC, "updatedAt" DESC, id DESC`.
+ *
+ * An ordering is therefore only safe to pair with a cursor when the cursor was
+ * written against that surface's exact tier list *and* directions — see
+ * {@link recordSearchCursor}.
  */
 export function recordSearchRank(
   query: string,
@@ -114,7 +130,30 @@ export function recordSearchRank(
   return textSearchRank(query, cols)
 }
 
-/** The keyset filter for a `score|id` cursor over ranked record results. */
+/**
+ * The keyset filter for a **two-part** `(score DESC, id DESC)` cursor over ranked
+ * record results.
+ *
+ * 🔴 **Two parts. Only ever pair it with a two-part `ORDER BY`.** A keyset that
+ * disagrees with its own ordering does not error — it silently skips rows and
+ * repeats others, and only inside a block of equal scores, which here is *most*
+ * of a result set: every row matching only the `ILIKE` fallback scores 0 on
+ * trigram. So the failure is common and invisible, not a corner case.
+ *
+ * ⚠️ **`record-picker-service.ts` currently pairs this with a THREE-part ordering**
+ * (`combined_score DESC, ei."updatedAt" DESC, ei.id DESC`) while advancing the
+ * cursor on `(score, id)` alone. Inside a tied-score block that admits rows the
+ * `ORDER BY` places *after* the page (skips) and re-admits rows it placed before
+ * it (duplicates). Noticed while measuring the records-list keyset; not fixed
+ * here because it is a separate surface with its own paging contract. The fix is
+ * a three-term `keysetOrderBy` / `keysetAfter` pair
+ * (`search/text-search-sql.ts`) with the picker's own directions —
+ * `[rank desc, updatedAt desc, id desc]` — rendering both halves from one array.
+ *
+ * The **records list** does not use this at all: it pages by `OFFSET` on purpose
+ * (see `queryEntityInstanceIdsPaged`, which records why a keyset was measured and
+ * rejected there).
+ */
 export function recordSearchCursor(
   query: string,
   score: number,

--- a/packages/lib/src/search/text-search-sql.test.ts
+++ b/packages/lib/src/search/text-search-sql.test.ts
@@ -20,6 +20,9 @@ import { PgDialect } from 'drizzle-orm/pg-core'
 import { describe, expect, it } from 'vitest'
 
 import {
+  type KeysetTerm,
+  keysetAfter,
+  keysetOrderBy,
   type TextSearchColumns,
   TS_RANK_SATURATING,
   textSearchCursor,
@@ -175,5 +178,59 @@ describe('textSearchCursor', () => {
     // rows, silently and only on ties.
     const { sql: text } = render(textSearchCursor('acme', COLS, 0.75, 'inst_9'))
     expect(text).not.toContain(' % ')
+  })
+})
+
+describe('keysetOrderBy / keysetAfter', () => {
+  /** `rank DESC, updatedAt DESC, id ASC` — the records list's ordering, in miniature. */
+  const TERMS: KeysetTerm[] = [
+    { expr: sql.raw('r'), direction: 'desc' },
+    { expr: sql.raw('u'), direction: 'desc' },
+    { expr: sql.raw('i'), direction: 'asc' },
+  ]
+
+  it('renders each term with its OWN direction', () => {
+    const rendered = keysetOrderBy(TERMS).map((clause) => render(clause).sql)
+    expect(rendered).toEqual(['r desc', 'u desc', 'i asc'])
+  })
+
+  it('nests the comparison, and flips the operator per direction', () => {
+    // The `>` on the last term is the whole reason this is not a DESC-only
+    // helper: the records list tie-breaks `id ASC`, and a `<` there would page
+    // backwards through every block of equal rank — silently, and only on ties.
+    const { sql: text } = render(keysetAfter(TERMS, [0.5, 'T', 'x']))
+    expect(text).toBe('(r < $1 OR (r = $2 AND (u < $3 OR (u = $4 AND i > $5))))')
+  })
+
+  it('binds one cursor value per term, in term order', () => {
+    const { params } = render(keysetAfter(TERMS, [0.5, 'T', 'x']))
+    expect(params).toEqual([0.5, 0.5, 'T', 'T', 'x'])
+  })
+
+  it('degenerates to a bare comparison for a single term', () => {
+    expect(render(keysetAfter(TERMS.slice(0, 1), [0.5])).sql).toBe('r < $1')
+  })
+
+  it('refuses a value list that does not match the terms', () => {
+    // The failure this guards is not a crash — it is a cursor that compares the
+    // wrong column against the wrong value and pages plausibly-but-wrongly.
+    expect(() => keysetAfter(TERMS, [0.5, 'T'])).toThrow(/one cursor value per ordering term/)
+    expect(() => keysetAfter([], [])).toThrow(/one cursor value per ordering term/)
+  })
+
+  it('is what textSearchKeyset is built from — one comparison in the codebase', () => {
+    const rank = textSearchRank('acme', COLS)
+    const direct = render(textSearchKeyset(rank, COLS.id, 0.75, 'inst_9'))
+    const composed = render(
+      keysetAfter(
+        [
+          { expr: rank, direction: 'desc' },
+          { expr: COLS.id, direction: 'desc' },
+        ],
+        [0.75, 'inst_9']
+      )
+    )
+    expect(direct.sql).toBe(composed.sql)
+    expect(direct.params).toEqual(composed.params)
   })
 })

--- a/packages/lib/src/search/text-search-sql.ts
+++ b/packages/lib/src/search/text-search-sql.ts
@@ -18,7 +18,7 @@
 // is the ranking formula, the OR-block predicate, the keyset cursor, and the
 // index strategy — nothing that decides who may read a row.
 
-import { type SQL, sql } from 'drizzle-orm'
+import { asc, bindIfParam, desc, type SQL, sql } from 'drizzle-orm'
 import type { PgColumn } from 'drizzle-orm/pg-core'
 
 /**
@@ -320,6 +320,14 @@ export function textSearchCursor(
  * structurally incapable of drifting from its own ordering: `threadSearchCursor`
  * calls `threadSearchRank`, the same function `ORDER BY` calls.
  *
+ * It is the two-part specialization of {@link keysetAfter} — `(rank DESC, id DESC)`
+ * — and nothing more. A domain whose `ORDER BY` has a third tier (records keep
+ * `updatedAt DESC` under the rank, because most rows score 0 on trigram and an
+ * unbroken tie pages erratically) must NOT reach for this: pairing a two-part
+ * cursor with a three-part ordering is the silent skip/duplicate this whole module
+ * is written to prevent. Build a {@link KeysetTerm} list instead and render both
+ * halves from it.
+ *
  * @param rank - the ordering expression, rendered twice (a `WHERE` cannot see a
  *   `SELECT` alias, so the recomputation is unavoidable)
  * @param id - the tie-break column
@@ -332,5 +340,117 @@ export function textSearchKeyset(
   score: number,
   cursorId: string
 ): SQL {
-  return sql`(${rank} < ${score} OR (${rank} = ${score} AND ${id} < ${cursorId}))`
+  return keysetAfter(
+    [
+      { expr: rank, direction: 'desc' },
+      { expr: id, direction: 'desc' },
+    ],
+    [score, cursorId]
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE GENERIC N-PART KEYSET
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A sort direction, in the two forms an ORDER BY can take. */
+export type KeysetDirection = 'asc' | 'desc'
+
+/**
+ * One term of a keyset ordering: an expression and the direction it is sorted
+ * in.
+ *
+ * 🔴 **A term list is the SINGLE definition of an ordering.** {@link keysetOrderBy}
+ * renders it as the `ORDER BY` and {@link keysetAfter} renders it as the cursor
+ * predicate, so the two cannot disagree — which is the entire failure mode this
+ * shape exists to make unrepresentable. A cursor whose comparison does not match
+ * its own `ORDER BY` does not error: it silently skips rows and repeats others,
+ * and only on the pages where the leading term ties.
+ *
+ * Build the list once, hand the SAME array to both functions, and never restate
+ * either half.
+ *
+ * @typeParam E - narrowed by domain bindings so a caller can also project the
+ *   expression (`terms[0].expr`) into its `SELECT` without rebuilding it — the
+ *   `SELECT`, the `ORDER BY` and the cursor then share one object.
+ */
+export interface KeysetTerm<E extends TextSearchRef = TextSearchRef> {
+  /** The ordering expression. */
+  expr: E
+  /** Its direction in the `ORDER BY`. */
+  direction: KeysetDirection
+}
+
+/**
+ * The `ORDER BY` clauses for a term list, in order.
+ *
+ * Pair with {@link keysetAfter} over the same array. Nothing may be appended to
+ * the result — an extra tie-break the cursor does not know about reintroduces
+ * exactly the disagreement the shared list prevents, so the *last* term must
+ * already be unique (a primary key).
+ */
+export function keysetOrderBy(terms: readonly KeysetTerm[]): SQL[] {
+  return terms.map((term) => (term.direction === 'desc' ? desc(term.expr) : asc(term.expr)))
+}
+
+/**
+ * The "strictly after the cursor row" predicate for a term list — the lexicographic
+ * comparison, nested rather than flattened:
+ *
+ * ```sql
+ * (a < a0 OR (a = a0 AND (b < b0 OR (b = b0 AND c > c0))))
+ * ```
+ *
+ * Each term's operator follows its OWN direction (`<` for `desc`, `>` for `asc`),
+ * which is why the mixed `rank DESC, updatedAt DESC, id ASC` ordering the records
+ * list uses is expressible at all. A `desc`-only keyset paired with an ascending
+ * tie-break skips and duplicates within every tied block.
+ *
+ * ⚠️ **Every term must be NOT NULL.** Postgres orders `NULL` first under `DESC`
+ * and last under `ASC`, but `NULL < x` is `NULL` — so a nullable term makes the
+ * comparison unsatisfiable for exactly the rows the `ORDER BY` places at the
+ * boundary. The record binding's terms are a `COALESCE`d score and two `NOT NULL`
+ * columns.
+ *
+ * 🔴 **Values are bound through Drizzle's own {@link bindIfParam}, and that is
+ * not a stylistic choice — it is what keeps a `timestamp` cursor correct.** A
+ * term backed by a `PgColumn` gets that column's driver encoding, exactly as
+ * `eq()` would; a term backed by a raw `SQL` expression falls through to a plain
+ * parameter. Interpolating the value directly (`sql`${expr} < ${value}`) skips
+ * the encoder and is wrong for dates.
+ *
+ * The trap, measured on this repo's `EntityInstance.updatedAt`
+ * (`timestamp` **without** time zone): Drizzle reads such a column as UTC
+ * (`PgTimestamp.mapFromDriverValue`), while node-postgres' *default* parser reads
+ * the same bytes as **local** time. Round-tripping a cursor value therefore only
+ * works if it stays inside Drizzle's mapping on the way out AND the way back in.
+ * A stored `05:20:16.787` comes back from Drizzle as `05:20:16.787Z` and from raw
+ * `pg` as `12:20:16.787Z` — feed the second one to a keyset and the cursor lands
+ * hours away from the row it names, matching nothing or everything. (Observed
+ * while benchmarking: the sweep paged forever until the bench harness was made to
+ * mirror Drizzle's parser.) Anything reading rows outside Drizzle — a raw
+ * `db.execute`, a hand-written `pg` query — must normalize before building a
+ * cursor value.
+ *
+ * @param terms - the SAME array handed to {@link keysetOrderBy}
+ * @param values - the previous page's last row, one value per term, in term order
+ */
+export function keysetAfter(terms: readonly KeysetTerm[], values: readonly unknown[]): SQL {
+  if (terms.length === 0 || terms.length !== values.length) {
+    throw new Error(
+      `keysetAfter: expected one cursor value per ordering term (got ${values.length} for ${terms.length})`
+    )
+  }
+
+  const build = (index: number): SQL => {
+    const term = terms[index]
+    if (!term) throw new Error(`keysetAfter: missing ordering term at index ${index}`)
+    const { expr, direction } = term
+    const op = sql.raw(direction === 'desc' ? '<' : '>')
+    const value = bindIfParam(values[index], expr)
+    if (index === terms.length - 1) return sql`${expr} ${op} ${value}`
+    return sql`(${expr} ${op} ${value} OR (${expr} = ${value} AND ${build(index + 1)}))`
+  }
+
+  return build(0)
 }


### PR DESCRIPTION
Follow-up **#4** asked for keyset pagination on the ranked records list. It was built in full, measured against live Postgres, and **rejected**. This PR keeps only what earns its place.

**Net: 269 insertions across 4 files, of which 2 are comment-only.**

## Why it was rejected

| depth (1,161 matched, 778 tied) | OFFSET | KEYSET | | depth (92,526 matched, 62,067 tied) | OFFSET | KEYSET |
|---|---|---|---|---|---|---|
| 0 | 15.6 ms | 15.4 ms | | 0 | 133 ms | 135 ms |
| 200 | 15.5 ms | **21.7 ms** | | 20,000 | 151 ms | **187 ms** |
| 1,000 | 16.3 ms | **24.2 ms** | | 50,000 | 155 ms | **214 ms** |

The keyset is *correct* — full sweeps (24 pages of 50, then 186 pages of 500) produced an id sequence identical to offset's, 0 skips, 0 duplicates, straight through the tie blocks. It is simply slower.

`EXPLAIN ANALYZE`: the sort genuinely gets cheap (`external merge Disk: 3496kB` → `top-N heapsort Memory: 32kB`), but the scan goes **138 ms → 208 ms** because the keyset `WHERE` recomputes `similarity()` + `ts_rank_cd()` **twice more per candidate row** (the `<` arm and the `=` arm).

**The premise was wrong, not just the result.** Deep pages don't get progressively slower under `OFFSET` here — the scan is the cost, not the skip (~16 ms of a 165 ms query). And the tie block, the very reason a three-part key is needed, makes keyset *worse* with depth: a deep cursor's rank equals the huge zero-score block, so the `=` arm always runs.

## What's kept

- **`keysetOrderBy` / `keysetAfter`** in `search/text-search-sql.ts`, with `textSearchKeyset` rebuilt on top of `keysetAfter` — byte-identical rendering, mail and picker tests untouched. One keyset comparison in the codebase instead of two.
- **The measured table** on `queryEntityInstanceIdsPaged`, leading with the conclusion so nobody re-attempts this without new information, and naming the one rewrite that would justify reopening (compute the rank once in a CTE — ceiling ~15%).
- **Two hazards that hold regardless of paging mode:**
  - The list's third sort tier is **`id ASC`, not DESC** — a DESC-only keyset pages *backwards* through every tied block. The two ranked record surfaces do not agree.
  - **`EntityInstance.updatedAt` is `timestamp` WITHOUT time zone.** Drizzle reads it as UTC, node-postgres' default parser as local — a stored `05:20:16.787` returns `…Z` from Drizzle and `12:20:16.787Z` from raw `pg`. Documented on `keysetAfter`, since binding through `bindIfParam` is *why* it's safe there.

## What's deleted rather than left to rot

All cursor plumbing (`cursor.key`, `nextKey`, `cursorKey`, the ranked projection), `recordSearchOrderTerms` and friends (zero callers once the list stopped cursoring), and `list-filtered-keyset.test.ts` — 10 of its 12 tests exercised removed plumbing, and the shared-`WHERE` `toBe` identity assertion it also carried **already exists at `HEAD`** in `list-filtered-search.test.ts:145`, so no coverage was lost.

`record.ts` and `use-record-list.ts` are **byte-identical to `HEAD`**. The `unified-handler-queries.ts` diff is **comment-only** (47 insertions, 0 deletions).

## ⚠️ A live bug found while measuring — not fixed here

`record-picker-service.ts:1187` orders `combined_score DESC, ei."updatedAt" DESC, ei.id DESC` but advances its cursor with the **two-part** `recordSearchCursor`.

Inside a tied-score block that admits rows the `ORDER BY` places *after* the page (skips) and re-admits rows it placed *before* it (duplicates). **Tied scores are the common case** — every ILIKE-only match scores 0. So the record picker's infinite scroll silently skips and repeats rows today.

Not fixed here: separate surface, its own paging contract, and out of scope for a strip-back. Documented at `recordSearchCursor` with the file, the mismatch and the fix — a three-term `keysetOrderBy`/`keysetAfter` pair with the picker's own directions. That is also the real caller for `keysetOrderBy`, which currently has only test callers.

## Testing

`lib` project: **558 files / 6660 tests** green. Targeted `search` + `resources` + `mail-query`: 36 files / 399 tests, confirming mail's `threadSearchCursor` and the picker binding are unaffected by the `textSearchKeyset` rebuild. Biome clean. `packages/lib` tsc: zero errors in the touched files.