### PR TITLE
fix(workflow): fail the find node on a dropped filter instead of widening it

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/find/validation.ts
+++ b/apps/web/src/components/workflow/nodes/core/find/validation.ts
@@ -1,11 +1,22 @@
 // apps/web/src/components/workflow/nodes/core/find/validation.ts
 
 import { isCustomResourceId } from '@auxx/lib/resources/client'
-import { FIND_RESOURCE_CONFIGS, getOperatorsForType } from '@auxx/lib/workflow-engine/client'
 import { createFindNodeDefaultData, type FindNodeData, type ValidationResult } from './types'
 
 /**
- * Validation function following the same pattern as other nodes
+ * Validation function following the same pattern as other nodes.
+ *
+ * Deliberately does **not** check field references. This function only receives
+ * `data`, so the only vocabulary available to it is the static
+ * `FIND_RESOURCE_CONFIGS[type].filterableFields` — which cannot see the org's
+ * `CustomField` rows, and therefore rejects fields the panel itself offers.
+ * (A ~180-line commented-out attempt at exactly that lived here until
+ * 2026-08-01; it was removed rather than revived, because reviving it would
+ * reintroduce a third field vocabulary alongside the panel's merged
+ * `fieldDefinitions` and the server's canonicalized refs.)
+ *
+ * Field validation belongs to `FindProcessor.validateNodeConfig`, which reads
+ * the same canonical references the query builders do.
  */
 export const validateFindNodeConfig = (data: FindNodeData): ValidationResult => {
   const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
@@ -68,178 +79,6 @@ export const validateFindNodeConfig = (data: FindNodeData): ValidationResult => 
 
     return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
   }
-
-  // System resource validation using FIND_RESOURCE_CONFIGS
-  // const resourceConfig = FIND_RESOURCE_CONFIGS[data.resourceType]
-  // if (!resourceConfig) {
-  //   errors.push({ field: 'resourceType', message: 'Invalid resource type', type: 'error' })
-  //   return { isValid: false, errors }
-  // }
-
-  // Validate conditions using generic validation
-  // if (data.conditions && resourceConfig) {
-  //   data.conditions.forEach((condition, index) => {
-  //     // Find the field definition for this condition
-  //     // FieldPath (relation drill-down) — skip static field validation,
-  //     // the field was selected from a valid resource via the picker
-  //     if (Array.isArray(condition.fieldId)) {
-  //       return
-  //     }
-
-  //     // ResourceFieldId: extract bare key for comparison
-  //     const bareKey =
-  //       typeof condition.fieldId === 'string' && condition.fieldId.includes(':')
-  //         ? condition.fieldId.split(':')[1]
-  //         : condition.fieldId
-
-  //     const fieldDef = resourceConfig.filterableFields.find((field) => field.key === bareKey)
-
-  //     if (!fieldDef) {
-  //       errors.push({
-  //         field: `conditions.${index}.fieldId`,
-  //         message: `Field "${condition.fieldId}" is not available for resource type "${data.resourceType}"`,
-  //         type: 'error',
-  //       })
-  //       return
-  //     }
-
-  //     // Convert to the format expected by validateCondition
-  //     const fieldDefinition = {
-  //       id: fieldDef.key,
-  //       label: fieldDef.label,
-  //       type: fieldDef.type,
-  //       operators: getOperatorsForType(fieldDef.type, fieldDef.operatorOverrides),
-  //       options: fieldDef.options,
-  //     } as const
-
-  //     const conditionValidation = validateCondition(condition, fieldDefinition)
-  //     if (!conditionValidation.isValid) {
-  //       conditionValidation.errors.forEach((error) => {
-  //         errors.push({
-  //           field: `conditions.${index}`,
-  //           message: error,
-  //           type: 'error',
-  //         })
-  //       })
-  //     }
-
-  //     // Additional validation for enum fields
-  //     if (fieldDef.type === 'enum' && fieldDef.options?.length && condition.value) {
-  //       const value = String(condition.value)
-  //       if (!['empty', 'not empty', 'exists', 'not exists'].includes(condition.operator)) {
-  //         // Check if value matches any value in the options
-  //         const validValues = fieldDef.options.map((opt) => opt.value)
-  //         if (!validValues.includes(value)) {
-  //           const validLabels = fieldDef.options.map((opt) => opt.label).join(', ')
-  //           errors.push({
-  //             field: `conditions.${index}.value`,
-  //             message: `Value "${value}" is not a valid option for field "${fieldDef.label}". Valid values: ${validLabels}`,
-  //             type: 'error',
-  //           })
-  //         }
-  //       }
-  //     }
-
-  //     // Validate operator is supported for the field
-  //     const validOperators = getOperatorsForType(fieldDef.type, fieldDef.operatorOverrides)
-  //     if (condition.operator && !validOperators.includes(condition.operator)) {
-  //       errors.push({
-  //         field: `conditions.${index}.operator`,
-  //         message: `Operator "${condition.operator}" is not supported for field "${fieldDef.label}"`,
-  //         type: 'error',
-  //       })
-  //     }
-  //   })
-  // }
-
-  // Validate condition groups using generic validation
-  // if (data.conditionGroups && resourceConfig) {
-  //   data.conditionGroups.forEach((group, groupIndex) => {
-  //     // Validate each condition in the group
-  //     group.conditions.forEach((condition, conditionIndex) => {
-  //       // FieldPath (relation drill-down) — skip static field validation
-  //       if (Array.isArray(condition.fieldId)) {
-  //         return
-  //       }
-
-  //       // ResourceFieldId: extract bare key for comparison
-  //       const bareKey =
-  //         typeof condition.fieldId === 'string' && condition.fieldId.includes(':')
-  //           ? condition.fieldId.split(':')[1]
-  //           : condition.fieldId
-
-  //       // Find the field definition for this condition
-  //       const fieldDef = resourceConfig.filterableFields.find((field) => field.key === bareKey)
-
-  //       if (!fieldDef) {
-  //         errors.push({
-  //           field: `conditionGroups.${groupIndex}.conditions.${conditionIndex}.fieldId`,
-  //           message: `Field "${condition.fieldId}" is not available for resource type "${data.resourceType}"`,
-  //           type: 'error',
-  //         })
-  //         return
-  //       }
-
-  //       // Convert to the format expected by validateCondition
-  //       const fieldDefinition = {
-  //         id: fieldDef.key,
-  //         label: fieldDef.label,
-  //         type: fieldDef.type,
-  //         operators: getOperatorsForType(fieldDef.type, fieldDef.operatorOverrides),
-  //         options: fieldDef.options,
-  //       }
-
-  //       const conditionValidation = validateCondition(condition, fieldDefinition)
-  //       if (!conditionValidation.isValid) {
-  //         conditionValidation.errors.forEach((error) => {
-  //           errors.push({
-  //             field: `conditionGroups.${groupIndex}.conditions.${conditionIndex}`,
-  //             message: error,
-  //             type: 'error',
-  //           })
-  //         })
-  //       }
-
-  //       // Additional validation for enum fields
-  //       if (fieldDef.type === 'enum' && fieldDef.options?.length && condition.value) {
-  //         const value = String(condition.value)
-  //         if (!['empty', 'not empty', 'exists', 'not exists'].includes(condition.operator)) {
-  //           const validValues = fieldDef.options.map((opt) => opt.value)
-  //           if (!validValues.includes(value)) {
-  //             const validLabels = fieldDef.options.map((opt) => opt.label).join(', ')
-  //             errors.push({
-  //               field: `conditionGroups.${groupIndex}.conditions.${conditionIndex}.value`,
-  //               message: `Value "${value}" is not a valid option for field "${fieldDef.label}". Valid values: ${validLabels}`,
-  //               type: 'error',
-  //             })
-  //           }
-  //         }
-  //       }
-
-  //       // Validate operator is supported for the field
-  //       const validOperators = getOperatorsForType(fieldDef.type, fieldDef.operatorOverrides)
-  //       if (condition.operator && !validOperators.includes(condition.operator)) {
-  //         errors.push({
-  //           field: `conditionGroups.${groupIndex}.conditions.${conditionIndex}.operator`,
-  //           message: `Operator "${condition.operator}" is not supported for field "${fieldDef.label}"`,
-  //           type: 'error',
-  //         })
-  //       }
-  //     })
-  //   })
-  // }
-
-  // Validate orderBy field
-  // if (data.orderBy) {
-  //   const sortableField = resourceConfig.sortableFields.find((f) => f.key === data.orderBy!.field)
-  //   if (!sortableField) {
-  //     errors.push({
-  //       field: 'orderBy.field',
-  //       message: `Field ${data.orderBy.field} is not sortable for ${resourceConfig.label}`,
-  //       type: 'error',
-  //     })
-  //   }
-  // }
 
   // Validate limit for findMany. A variable-bound limit is a reference string
   // that only resolves at run time, so there is nothing to check.

--- a/packages/lib/src/mail-query/__tests__/condition-query-builder.test.ts
+++ b/packages/lib/src/mail-query/__tests__/condition-query-builder.test.ts
@@ -170,6 +170,48 @@ describe('buildConditionGroupsQuery — UI callers keep the old contract', () =>
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
+// `tags` — the key every registry-driven surface sends
+//
+// `THREAD_FIELDS` declares the field as `tags`; this builder's own older name
+// is `tag`, still emitted by `context-to-conditions`. Until 2026-08-01 only
+// `tag` had a case, so a registry-driven filter — the workflow Find node's
+// panel among them — silently dropped and returned the whole visible mailbox.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('tag / tags', () => {
+  const tagCondition = (fieldId: string) =>
+    group([{ id: 'c1', fieldId, operator: 'is', value: 't1' }])
+
+  it('builds `tags` identically to `tag`', () => {
+    const byNewName = buildConditionGroupsQueryWithDiagnostics(
+      tagCondition('tags'),
+      'organization-1',
+      viewer()
+    )
+    const byOldName = buildConditionGroupsQueryWithDiagnostics(
+      tagCondition('tag'),
+      'organization-1',
+      viewer()
+    )
+
+    expect(byNewName.droppedConditions).toEqual([])
+    expect(toSql(byNewName.sql)).toBe(toSql(byOldName.sql))
+    expect(toParams(byNewName.sql)).toEqual(toParams(byOldName.sql))
+  })
+
+  it('narrows rather than falling back to the whole mailbox', () => {
+    const result = buildConditionGroupsQueryWithDiagnostics(
+      tagCondition('tags'),
+      'organization-1',
+      viewer()
+    )
+
+    expect(result.allConditionsDropped).toBe(false)
+    expect(toSql(result.sql)).not.toBe(baseScopeSql())
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Free text: tokenization (step 2.2 / R2a) over the ranked builder (step 3.1 / R2b)
 //
 // The tokenization guarantees from 2.2 are unchanged — one clause per term,

--- a/packages/lib/src/mail-query/condition-query-builder.ts
+++ b/packages/lib/src/mail-query/condition-query-builder.ts
@@ -291,6 +291,11 @@ function dispatchConditionQuery(
 ): SQL<unknown> | null | typeof UNKNOWN_FIELD {
   switch (fieldId) {
     case 'tag':
+    // `tags` is the key `THREAD_FIELDS` declares (and therefore what every
+    // registry-driven filter surface sends); `tag` is this builder's own older
+    // name, still emitted by `context-to-conditions`. Both mean the same
+    // filter.
+    case 'tags':
       return buildTagQuery(op, value, organizationId)
     case 'assignee':
       return buildAssigneeQuery(op, value)

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-condition-resolution.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-condition-resolution.test.ts
@@ -1,0 +1,509 @@
+// packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-condition-resolution.test.ts
+
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Condition, ConditionGroup } from '../../../../conditions/types'
+import { buildConditionGroupsQueryWithDiagnostics } from '../../../../mail-query/condition-query-builder'
+import { canonicalizeSystemConditions } from '../../../../resources/query-builder/canonicalize-system-fields'
+import { ConditionQueryBuilder } from '../../../../resources/query-builder/condition-query-builder'
+import type { ResourceField } from '../../../../resources/registry/field-types'
+import { createChainableDatabaseMock } from '../../../../test/database-mock'
+import type { ExecutionContextManager } from '../../../core/execution-context'
+import type { NodeExecutionResult, PreprocessedNodeData, WorkflowNode } from '../../../core/types'
+import { NodeRunningStatus, WorkflowNodeType } from '../../../core/types'
+import { FindProcessor } from '../find'
+
+/**
+ * Pins the Find node's *field resolution*: that a condition the panel can build
+ * either reaches the query builder in a form the builder resolves, or fails the
+ * node — never widens it silently.
+ *
+ * The regression these exist for is the thread lane. `THREAD_FIELDS` declares
+ * ten `filterable: true` fields the mail builder has no case for, so before
+ * this change "Find Many Threads where Visit City is Berlin" returned *every
+ * thread in the org's shared inboxes* — the dropped condition left the bare
+ * base scope behind, and `limit` is optional.
+ *
+ * **Non-vacuity** (re-run this if you extend the file — an assertion that a ref
+ * was *forwarded* passes even when it still fails to resolve). Each fix was
+ * neutralized in turn and the expected tests went red:
+ *
+ * | neutralized | red |
+ * |---|---|
+ * | canonicalizer off in `executeNode` | 5 — every cuid case |
+ * | drop-throws removed from both lanes | 6 — every `visit*`/`messages` case |
+ * | `tags` case removed from the mail dispatcher | 2 |
+ * | fold operator hard-coded to `AND` | 1 |
+ *
+ * The tests that survive all four are **controls**, and are named as such
+ * below: they assert refs that must keep working unchanged, and the
+ * system-lane "unresolvable reference" pair, which is caught by
+ * `validateConditionValues` before the builder ever runs.
+ */
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+const { threadSelect } = vi.hoisted(() => ({ threadSelect: vi.fn() }))
+
+/**
+ * `@auxx/database`'s `schema` is a Proxy of empty objects under this package's
+ * Vitest setup, so column-level SQL renders as nothing
+ * (`project_drizzle_columns_undefined_in_vitest`). Pin the four tables these
+ * assertions read through `createSchemaMock`, which keeps the auto-vivifying
+ * proxy for every other table in the import graph — the same arrangement
+ * `system-condition-builder.test.ts` uses.
+ */
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import(
+    '../../../../test/database-mock'
+  )
+  const { integer, pgTable, text, timestamp } = await import('drizzle-orm/pg-core')
+
+  // Several modules in this import graph build prepared statements at module
+  // scope (`db.select().from(…).where(…).prepare(…)`), so `select` must be
+  // chainable before any test runs.
+  threadSelect.mockImplementation(() => createChainableDatabaseMock())
+
+  return {
+    // `select` is the one method these tests drive (the thread lane awaits its
+    // `$dynamic()` chain directly); everything else keeps the chainable stub.
+    database: new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) => {
+        if (prop === 'then') return undefined
+        if (prop === 'select') return threadSelect
+        return createChainableDatabaseMock()
+      },
+    }),
+    schema: createSchemaMock({
+      Message: pgTable('Message', {
+        id: text('id').primaryKey(),
+        subject: text('subject'),
+        organizationId: text('organizationId'),
+      }),
+      Thread: pgTable('Thread', {
+        id: text('id').primaryKey(),
+        subject: text('subject'),
+        status: text('status'),
+        inboxId: text('inboxId'),
+        organizationId: text('organizationId'),
+        mergedIntoThreadId: text('mergedIntoThreadId'),
+        messageCount: integer('messageCount'),
+        lastMessageAt: timestamp('lastMessageAt'),
+      }),
+      FieldValue: pgTable('FieldValue', {
+        id: text('id').primaryKey(),
+        fieldId: text('fieldId'),
+        entityId: text('entityId'),
+        relatedEntityId: text('relatedEntityId'),
+        valueText: text('valueText'),
+      }),
+      CustomField: pgTable('CustomField', {
+        id: text('id').primaryKey(),
+        systemAttribute: text('systemAttribute'),
+      }),
+    }),
+    IntegrationProviderTypeValues: ['google', 'outlook'],
+  }
+})
+
+/**
+ * Merged fields as `mergeSystemAndCustomFields` emits them: a materialized
+ * system field keeps the static `key` and carries the org's `CustomField.id`
+ * as `id`. The filter UIs address the field by that cuid, which is the half of
+ * this plan that is preventive — zero rows on the dev DB today.
+ */
+const mergedField = (id: string, key: string, systemAttribute: string) =>
+  ({ id, key, systemAttribute }) as unknown as ResourceField
+
+const MESSAGE_SUBJECT_CUID = 'msgsubjectcuidaaaaaaaaaa'
+const THREAD_TAGS_CUID = 'thrtagscuidaaaaaaaaaaaaa'
+const THREAD_STATUS_CUID = 'thrstatuscuidaaaaaaaaaaa'
+
+const RESOURCES: Record<string, { plural: string; label: string; fields: ResourceField[] }> = {
+  message: {
+    plural: 'Messages',
+    label: 'Message',
+    fields: [mergedField(MESSAGE_SUBJECT_CUID, 'subject', 'message_subject')],
+  },
+  thread: {
+    plural: 'Threads',
+    label: 'Thread',
+    fields: [
+      mergedField(THREAD_TAGS_CUID, 'tags', 'thread_tags'),
+      mergedField(THREAD_STATUS_CUID, 'status', 'thread_status'),
+    ],
+  },
+}
+
+vi.mock('../../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../cache')>()),
+  findCachedResource: vi.fn(async (_organizationId: string, resourceType: string) => {
+    const resource = RESOURCES[resourceType]
+    return resource ? { id: resourceType, ...resource } : null
+  }),
+}))
+
+/** Configured automation: full on org inboxes, zero access to personal ones. */
+vi.mock('../../../../permissions/visibility/automation-visibility', () => ({
+  getAutomationVisibility: vi.fn(async () => ({
+    kind: 'automation' as const,
+    personalInboxIds: {},
+  })),
+}))
+
+const { executeResourceQuery } = vi.hoisted(() => ({
+  executeResourceQuery: vi.fn(async () => [] as unknown[]),
+}))
+
+vi.mock('../../../../resources/resource-fetcher', () => ({ executeResourceQuery }))
+
+// ── harness ──────────────────────────────────────────────────────────────────
+
+/** `executeNode` is the unit under test; `execute` wraps it in variable plumbing. */
+class TestableFindProcessor extends FindProcessor {
+  runNode(
+    node: WorkflowNode,
+    contextManager: ExecutionContextManager,
+    preprocessedData?: PreprocessedNodeData
+  ): Promise<Partial<NodeExecutionResult>> {
+    return this.executeNode(node, contextManager, preprocessedData)
+  }
+}
+
+const dialect = new PgDialect()
+const render = (clause: unknown) =>
+  clause === undefined ? undefined : dialect.sqlToQuery(clause as never).sql
+
+const condition = (fieldId: string, operator = 'is', value: unknown = 'x'): Condition =>
+  ({ id: `cond-${fieldId}`, fieldId, operator, value }) as Condition
+
+const group = (conditions: Condition[]): ConditionGroup[] => [
+  { id: 'g1', logicalOperator: 'AND', conditions },
+]
+
+const findNode = (resourceType: string): WorkflowNode =>
+  ({
+    id: 'find_1',
+    workflowId: 'workflow_1',
+    nodeId: 'find_1',
+    name: 'Find',
+    type: WorkflowNodeType.FIND,
+    data: { id: 'find_1', type: WorkflowNodeType.FIND, title: 'Find', resourceType },
+    metadata: { position: { x: 0, y: 0 } },
+  }) as unknown as WorkflowNode
+
+const contextManager = () =>
+  ({
+    getContext: () => ({ organizationId: 'org_1', userId: 'user_1' }),
+    getVariable: vi.fn(),
+    setNodeVariable: vi.fn(),
+    cacheRecordBase: vi.fn(),
+    log: vi.fn(),
+  }) as unknown as ExecutionContextManager
+
+/** Thread rows come back through a `$dynamic()` chain the node awaits directly. */
+let capturedThreadWhere: unknown
+function stubThreadSelect(rows: unknown[] = []) {
+  const chain: Record<string, unknown> = {}
+  Object.assign(chain, {
+    $dynamic: () => chain,
+    where: (clause: unknown) => {
+      capturedThreadWhere = clause
+      return chain
+    },
+    orderBy: () => chain,
+    limit: () => Promise.resolve(rows),
+    // biome-ignore lint/suspicious/noThenProperty: `findMany` awaits the drizzle chain itself (`const rows = await q`), so the stub has to be thenable to stand in for it.
+    then: (onFulfilled: (value: unknown[]) => unknown) => Promise.resolve(rows).then(onFulfilled),
+  })
+  threadSelect.mockReturnValue({ from: () => chain })
+}
+
+/** Configured automation viewer, matching the mocked `getAutomationVisibility`. */
+const AUTOMATION_VIEWER = { kind: 'automation' as const, personalInboxIds: {} }
+
+/**
+ * The clause a fully-dropped thread filter collapses to — the viewer's whole
+ * visible mailbox. Any built condition must render to something else; that
+ * comparison is what tells "filtered" from "silently widened" apart, and it
+ * holds whether or not a column name renders.
+ */
+const threadBaseScopeSql = () =>
+  render(buildConditionGroupsQueryWithDiagnostics([], 'org_1', AUTOMATION_VIEWER).sql)
+
+interface RunOptions {
+  conditions?: Condition[]
+  conditionGroups?: ConditionGroup[]
+  orderBy?: { field: string; direction: 'asc' | 'desc' }
+  findMode?: 'findOne' | 'findMany'
+}
+
+async function run(resourceType: string, options: RunOptions = {}) {
+  const processor = new TestableFindProcessor()
+  return processor.runNode(findNode(resourceType), contextManager(), {
+    inputs: {
+      resourceType,
+      findMode: options.findMode ?? 'findMany',
+      conditions: options.conditions ?? [],
+      conditionGroups: options.conditionGroups ?? [],
+      orderBy: options.orderBy,
+      limit: undefined,
+    },
+    metadata: {},
+  } as unknown as PreprocessedNodeData)
+}
+
+/** The query the system lane handed to the resource fetcher. */
+const systemQuery = () =>
+  (executeResourceQuery.mock.calls[0] as unknown[] | undefined)?.[2] as
+    | { where?: unknown; orderBy?: unknown[] }
+    | undefined
+
+const systemWhere = () => render(systemQuery()?.where)
+
+beforeEach(() => {
+  executeResourceQuery.mockClear()
+  threadSelect.mockReset()
+  threadSelect.mockImplementation(() => createChainableDatabaseMock())
+  capturedThreadWhere = undefined
+})
+
+// ── system lane ──────────────────────────────────────────────────────────────
+
+describe('system lane — cuid field references', () => {
+  it('resolves a bare cuid to the static key and narrows the query', async () => {
+    const result = await run('message', {
+      conditionGroups: group([condition(MESSAGE_SUBJECT_CUID, 'is', 'Refunds')]),
+    })
+
+    expect(result.status).toBe(NodeRunningStatus.Succeeded)
+    // The claim is *resolution*, not forwarding: an unresolved ref produces no
+    // clause at all, so the column has to appear.
+    expect(systemWhere()).toContain('"subject"')
+  })
+
+  it('resolves a `<resourceType>:<cuid>` reference identically', async () => {
+    const bare = await run('message', {
+      conditionGroups: group([condition(MESSAGE_SUBJECT_CUID, 'is', 'Refunds')]),
+    })
+    const bareSql = systemWhere()
+
+    executeResourceQuery.mockClear()
+    const prefixed = await run('message', {
+      conditionGroups: group([condition(`message:${MESSAGE_SUBJECT_CUID}`, 'is', 'Refunds')]),
+    })
+
+    expect(bare.status).toBe(NodeRunningStatus.Succeeded)
+    expect(prefixed.status).toBe(NodeRunningStatus.Succeeded)
+    expect(systemWhere()).toBe(bareSql)
+  })
+
+  // CONTROL. On a system resource an unresolvable reference is refused by
+  // `validateConditionValues`, which runs on the canonical groups *before* the
+  // builder — so this pins the preflight guard, not the drop guard. It survives
+  // every neutralization by design; the drop guard is pinned on the thread lane,
+  // which is where a ref can pass preflight and still fail to build.
+  it('fails the node on an unresolvable reference, naming it', async () => {
+    const result = await run('message', {
+      conditionGroups: group([condition('notAFieldAtAll')]),
+    })
+
+    expect(result.status).toBe(NodeRunningStatus.Failed)
+    expect(result.error).toContain('Unknown field: notAFieldAtAll')
+    expect(executeResourceQuery).not.toHaveBeenCalled()
+  })
+
+  // CONTROL, same path as above.
+  it('never leaks builder internals into the run log', async () => {
+    const result = await run('thread', {
+      conditionGroups: group([condition('thread:visitCity', 'is', 'Berlin')]),
+    })
+
+    // #1475 pins that the builders' internal `detail` never reaches a
+    // user-visible payload, and a workflow run log is user-visible.
+    expect(result.status).toBe(NodeRunningStatus.Failed)
+    expect(result.error).toContain('visitCity')
+    expect(result.error).not.toContain('SystemConditionBuilder')
+  })
+})
+
+// ── thread lane ──────────────────────────────────────────────────────────────
+
+describe('thread lane — the mail builder vocabulary gap', () => {
+  it('builds `tags`, the key THREAD_FIELDS declares', async () => {
+    stubThreadSelect([{ id: 'thread_1' }])
+
+    const result = await run('thread', {
+      conditionGroups: group([condition('thread:tags', 'is', 'tag_refunds')]),
+    })
+
+    expect(result.status).toBe(NodeRunningStatus.Succeeded)
+    // A dropped condition would leave the bare base scope; the tag subquery is
+    // what tells the two apart.
+    expect(render(capturedThreadWhere)).not.toBe(threadBaseScopeSql())
+    expect(render(capturedThreadWhere)).toContain('"FieldValue"')
+  })
+
+  it('resolves a cuid-addressed `tags` to the same clause', async () => {
+    stubThreadSelect([{ id: 'thread_1' }])
+    await run('thread', { conditionGroups: group([condition('thread:tags', 'is', 'tag_refunds')]) })
+    const byKey = render(capturedThreadWhere)
+
+    stubThreadSelect([{ id: 'thread_1' }])
+    const result = await run('thread', {
+      conditionGroups: group([condition(THREAD_TAGS_CUID, 'is', 'tag_refunds')]),
+    })
+
+    expect(result.status).toBe(NodeRunningStatus.Succeeded)
+    expect(render(capturedThreadWhere)).toBe(byKey)
+  })
+
+  it.each([
+    'visitCity',
+    'visitIp',
+    'visitCountry',
+    'messages',
+  ])('fails the node on `%s` instead of returning the whole mailbox', async (fieldKey) => {
+    stubThreadSelect([{ id: 'thread_1' }, { id: 'thread_2' }])
+
+    const result = await run('thread', {
+      conditionGroups: group([condition(`thread:${fieldKey}`, 'is', 'Berlin')]),
+    })
+
+    expect(result.status).toBe(NodeRunningStatus.Failed)
+    expect(result.error).toContain(fieldKey)
+    expect(result.output).toBeUndefined()
+  })
+
+  it('fails on a partial drop, not only when every condition is dropped', async () => {
+    stubThreadSelect([{ id: 'thread_1' }])
+
+    const result = await run('thread', {
+      conditionGroups: group([
+        condition('thread:status', 'is', 'OPEN'),
+        condition('thread:visitCity', 'is', 'Berlin'),
+      ]),
+    })
+
+    // A partial drop widens an AND group and narrows an OR group — there is no
+    // reading under which the node did what it was configured to do, and this
+    // node has no channel to report a partial drop mid-run.
+    expect(result.status).toBe(NodeRunningStatus.Failed)
+    expect(result.error).toContain('visitCity')
+  })
+})
+
+// ── preflight ≡ build ────────────────────────────────────────────────────────
+
+/**
+ * The invariant is the *agreement*, not either side's verdict: a reference the
+ * node's own `validateConditionValues` accepts must be one the builder can
+ * build, and vice versa. This node had exactly the divergence #1478 had to
+ * close for `inspectFilterConditions`.
+ */
+describe('preflight and build agree', () => {
+  const systemRefs = ['message:subject', MESSAGE_SUBJECT_CUID, 'notAFieldAtAll', 'message:id']
+
+  it.each(systemRefs)('system lane: `%s`', async (fieldRef) => {
+    const groups = group([condition(fieldRef, 'is', 'value')])
+    const nodeSucceeded = (await run('message', { conditionGroups: groups })).status === 'succeeded'
+
+    const built = ConditionQueryBuilder.buildGroupedQueryWithDiagnostics(
+      canonicalizeSystemConditions(groups, 'message', RESOURCES.message!.fields),
+      'message'
+    )
+
+    expect(nodeSucceeded).toBe(built.droppedConditions.length === 0)
+  })
+
+  const threadRefs = ['thread:status', 'thread:tags', THREAD_TAGS_CUID, 'thread:visitCity']
+
+  it.each(threadRefs)('thread lane: `%s`', async (fieldRef) => {
+    stubThreadSelect([])
+    const groups = group([condition(fieldRef, 'is', 'OPEN')])
+    const nodeSucceeded = (await run('thread', { conditionGroups: groups })).status === 'succeeded'
+
+    const canonical = canonicalizeSystemConditions(groups, 'thread', RESOURCES.thread!.fields)
+    const built = buildConditionGroupsQueryWithDiagnostics(
+      canonical.map((g) => ({
+        ...g,
+        conditions: g.conditions.map((c) => ({
+          ...c,
+          fieldId: String(c.fieldId).includes(':')
+            ? String(c.fieldId).split(':').slice(1).join(':')
+            : String(c.fieldId),
+        })),
+      })) as ConditionGroup[],
+      'org_1',
+      AUTOMATION_VIEWER
+    )
+
+    expect(nodeSucceeded).toBe(built.droppedConditions.length === 0)
+  })
+})
+
+// ── the flat-conditions fold ─────────────────────────────────────────────────
+
+describe('flat conditions fold into one group', () => {
+  it('produces the same SQL as the equivalent single AND group', async () => {
+    const conditions = [
+      condition('message:subject', 'is', 'Refunds'),
+      condition('message:id', 'is', 'message_1'),
+    ]
+
+    await run('message', { conditions })
+    const flatSql = systemWhere()
+
+    executeResourceQuery.mockClear()
+    await run('message', { conditionGroups: group(conditions) })
+
+    expect(flatSql).toBeDefined()
+    expect(systemWhere()).toBe(flatSql)
+  })
+
+  it('carries an OR across the fold', async () => {
+    const conditions = [
+      condition('message:subject', 'is', 'Refunds'),
+      { ...condition('message:id', 'is', 'message_1'), logicalOperator: 'OR' as const },
+    ]
+
+    await run('message', { conditions })
+
+    // `BaseConditionBuilder.deriveFlatOperator` reads the operator off
+    // conditions *after the first*; folding to a hard-coded AND would silently
+    // change which rows come back.
+    expect(systemWhere()).toContain(' or ')
+  })
+
+  it('lets groups win over flat conditions, as validateNodeConfig warns', async () => {
+    await run('message', {
+      conditions: [condition('notAFieldAtAll')],
+      conditionGroups: group([condition('message:subject', 'is', 'Refunds')]),
+    })
+
+    expect(systemWhere()).toContain('"subject"')
+  })
+})
+
+// ── orderBy ──────────────────────────────────────────────────────────────────
+
+describe('orderBy resolution', () => {
+  it('sorts by a cuid-addressed field', async () => {
+    await run('message', {
+      orderBy: { field: MESSAGE_SUBJECT_CUID, direction: 'desc' },
+    })
+
+    expect(systemQuery()?.orderBy).toBeDefined()
+    expect(render(systemQuery()?.orderBy?.[0])).toContain('"subject"')
+  })
+
+  it('no-ops on an unresolvable sort without failing the node', async () => {
+    const result = await run('message', {
+      orderBy: { field: 'notAFieldAtAll', direction: 'desc' },
+    })
+
+    // Carried forward from #1478: sort is deliberately not a reporting channel.
+    expect(result.status).toBe(NodeRunningStatus.Succeeded)
+    expect(systemQuery()?.orderBy).toBeUndefined()
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/find.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/find.ts
@@ -11,13 +11,19 @@ import {
   requireCachedEntityDefId,
 } from '../../../cache'
 import type { Condition, ConditionGroup as MailConditionGroup } from '../../../conditions/types'
-import { buildConditionGroupsQuery } from '../../../mail-query/condition-query-builder'
+import { buildConditionGroupsQueryWithDiagnostics } from '../../../mail-query/condition-query-builder'
 import { getAutomationVisibility } from '../../../permissions/visibility/automation-visibility'
 import { FIND_RESOURCE_CONFIGS } from '../../../resources/find-definitions'
 import type {
   ConditionGroup,
   GenericCondition,
 } from '../../../resources/query-builder/base-condition-builder'
+// Narrow import path on purpose: the `query-builder` barrel re-exports builders
+// that pull in `@auxx/database`, and this module only needs the pure rewriter.
+import {
+  canonicalizeSystemConditions,
+  canonicalizeSystemFieldRef,
+} from '../../../resources/query-builder/canonicalize-system-fields'
 import { ConditionQueryBuilder } from '../../../resources/query-builder/condition-query-builder'
 import {
   getFieldOperators,
@@ -113,6 +119,72 @@ function normalizeGroupsForMailBuilder(groups: ConditionGroup[]): MailConditionG
     ...g,
     conditions: normalizeConditionsForMailBuilder(g.conditions),
   }))
+}
+
+/**
+ * Fold the legacy flat `conditions[]` into a single group so the node has
+ * exactly one filter path through every lane.
+ *
+ * The combining operator reproduces `BaseConditionBuilder.deriveFlatOperator`
+ * — `OR` when any condition *after the first* asks for it, `AND` otherwise —
+ * so the folded group builds the same SQL as the `buildWhereSql` call it
+ * replaces. Groups, when present, always win: that is the pre-existing
+ * precedence `validateNodeConfig` already warns about.
+ */
+function foldFlatConditions(
+  conditions: GenericCondition[],
+  conditionGroups: ConditionGroup[]
+): ConditionGroup[] {
+  if (conditionGroups.length > 0) return conditionGroups
+  if (conditions.length === 0) return []
+
+  return [
+    {
+      id: 'flat',
+      conditions,
+      logicalOperator: conditions.some(
+        (condition, index) => index > 0 && condition.logicalOperator === 'OR'
+      )
+        ? 'OR'
+        : 'AND',
+    },
+  ]
+}
+
+/** One dropped condition, flattened out of either builder's diagnostics shape. */
+interface DroppedRef {
+  ref: string
+  reason: string
+}
+
+/**
+ * Message for a build that silently discarded a filter.
+ *
+ * A workflow acts on the result, so a dropped condition is a failure rather
+ * than a notice: dropping widens an AND group and narrows an OR group, and
+ * there is no human reading a warning mid-run. Mirrors the `UnprocessableEntity`
+ * the AI count tools raise, except that this node fails on *any* drop — it has
+ * no channel to report a partial one.
+ *
+ * Deliberately omits each drop's internal `detail` (the builder class name, or
+ * a field builder's thrown message): a workflow run log is user-visible.
+ */
+function describeDroppedConditions(resourceType: string, drops: DroppedRef[]): string {
+  const described = drops.map((drop) => `${drop.ref} (${drop.reason})`).join(', ')
+  return `Cannot filter ${resourceType} by: ${described}`
+}
+
+/**
+ * CUID2 shape, as `CustomField.id` is minted.
+ *
+ * Narrower than `isCustomResourceId` on purpose: this asks "is this reference a
+ * field cuid?", and no static registry key can match it — every one of them is
+ * either short or camelCase.
+ */
+const CUID_FIELD_REF = /^[a-z][a-z0-9]{19,}$/
+
+function isCuidFieldRef(fieldRef: string): boolean {
+  return CUID_FIELD_REF.test(fieldRef)
 }
 
 /**
@@ -516,34 +588,40 @@ export class FindProcessor extends BaseNodeProcessor {
         resourceType = await requireCachedEntityDefId(organizationId, resourceType)
       }
 
+      // Fold the legacy flat array into a group, then rewrite every field
+      // reference into the form the builders resolve — both BEFORE validation,
+      // so preflight and the build agree by construction rather than by
+      // coincidence. That equivalence is the invariant #1478 had to restore for
+      // `inspectFilterConditions`; this node had the same divergence.
+      //
+      // The entity lane is skipped: `entityConditionBuilder` resolves a cuid
+      // natively, and `RESOURCE_FIELD_REGISTRY` has no slice for an
+      // entityDefinitionId, so canonicalizing there would rewrite every field
+      // to `custom_<cuid>`.
+      const foldedGroups = foldFlatConditions(conditions, conditionGroups)
+      const conditionGroupsToBuild = isCustomResourceId(resourceType)
+        ? foldedGroups
+        : canonicalizeSystemConditions(foldedGroups, resourceType as TableId, resource.fields)
+
       // Validate conditions using dynamic fields (pass cached resource for UUID matching)
-      const flatConditionErrors = this.validateConditionValues(
-        resourceType,
-        conditions,
-        resource.fields
-      )
-      const groupConditionErrors: string[] = []
-      for (const group of conditionGroups) {
-        const groupErrors = this.validateConditionValues(
-          resourceType,
-          group.conditions,
-          resource.fields
+      const allValidationErrors: string[] = []
+      for (const group of conditionGroupsToBuild) {
+        allValidationErrors.push(
+          ...this.validateConditionValues(resourceType, group.conditions, resource.fields)
         )
-        groupConditionErrors.push(...groupErrors)
       }
 
-      const allValidationErrors = [...flatConditionErrors, ...groupConditionErrors]
       if (allValidationErrors.length > 0) {
         throw new Error(`Invalid conditions: ${allValidationErrors.join(', ')}`)
       }
 
-      const totalConditions =
-        conditions.length +
-        conditionGroups.reduce((total, group) => total + group.conditions.length, 0)
+      const totalConditions = conditionGroupsToBuild.reduce(
+        (total, group) => total + group.conditions.length,
+        0
+      )
 
       contextManager.log('DEBUG', node.nodeId, `Executing ${findMode} query for ${resourceType}`, {
-        flatConditions: conditions.length,
-        groups: conditionGroups.length,
+        groups: conditionGroupsToBuild.length,
         totalConditions,
         orderBy,
         limit,
@@ -553,21 +631,13 @@ export class FindProcessor extends BaseNodeProcessor {
       let result
       let resultCount: number
 
-      console.log('🔍 [FindProcessor] Executing query', {
-        findMode,
-        resourceType,
-        organizationId,
-        isCustomResource: isCustomResourceId(resourceType),
-      })
-
       if (isCustomResourceId(resourceType)) {
         // Handle custom entity query
         const queryResult = await this.executeCustomEntityQuery(
           resourceType,
           organizationId,
           db,
-          conditions,
-          conditionGroups,
+          conditionGroupsToBuild,
           orderBy,
           limit,
           findMode
@@ -579,8 +649,8 @@ export class FindProcessor extends BaseNodeProcessor {
         // cross-table joins (sender, recipients, body, tags, attachments, etc.)
         const queryResult = await this.executeThreadQuery(
           organizationId,
-          conditions,
-          conditionGroups,
+          conditionGroupsToBuild,
+          resource.fields,
           orderBy,
           limit,
           findMode
@@ -591,8 +661,8 @@ export class FindProcessor extends BaseNodeProcessor {
         // Handle other system resource queries (message, user, dataset, etc.)
         const query = this.buildQuery(
           resourceType as TableId,
-          conditions,
-          conditionGroups,
+          conditionGroupsToBuild,
+          resource.fields,
           orderBy,
           limit
         )
@@ -615,13 +685,6 @@ export class FindProcessor extends BaseNodeProcessor {
         }
       }
 
-      console.log('🔍 [FindProcessor] Query executed', {
-        findMode,
-        resourceType,
-        resultCount,
-        resultType: Array.isArray(result) ? 'array' : typeof result,
-      })
-
       contextManager.log(
         'INFO',
         node.nodeId,
@@ -636,7 +699,7 @@ export class FindProcessor extends BaseNodeProcessor {
         query_info: {
           resource_type: resourceType,
           find_mode: findMode,
-          flat_conditions_applied: conditions.length,
+          flat_conditions_applied: conditionGroups.length > 0 ? 0 : conditions.length,
           groups_applied: conditionGroups.length,
           total_conditions: totalConditions,
           order_by: orderBy?.field,
@@ -712,91 +775,52 @@ export class FindProcessor extends BaseNodeProcessor {
   }
 
   /**
-   * Build database query from conditions and groups using ConditionQueryBuilder
-   * Note: This is only for system resources - custom entities use executeCustomEntityQuery
+   * Build the database query for a system resource from already-canonicalized
+   * condition groups.
+   *
+   * Custom entities take `executeCustomEntityQuery` and threads take
+   * `executeThreadQuery`; this covers the rest.
+   *
+   * @throws When the builder dropped any condition — see
+   *         {@link describeDroppedConditions}.
    */
   private buildQuery(
     resourceType: TableId,
-    conditions: GenericCondition[],
     conditionGroups: ConditionGroup[],
+    fields: ResourceField[],
     orderBy?: FindNodeData['orderBy'],
     limit?: number
   ): BuiltQuery {
-    let whereClause: SQL<unknown> | undefined
+    const { sql: whereClause, droppedConditions } =
+      ConditionQueryBuilder.buildGroupedQueryWithDiagnostics(conditionGroups, resourceType)
 
-    console.log('🔍 [FindProcessor] Building query', {
-      resourceType,
-      hasGroups: conditionGroups.length > 0,
-      groupCount: conditionGroups.length,
-      flatConditionCount: conditions.length,
-      orderBy,
-      limit,
-    })
-
-    if (conditionGroups.length > 0) {
-      console.log('🔍 [FindProcessor] Building grouped query with groups:', {
-        groups: conditionGroups.map((g, i) => ({
-          index: i,
-          logicalOp: g.logicalOperator,
-          conditionCount: g.conditions.length,
-          conditions: g.conditions.map((c) => {
-            const fId = Array.isArray(c.fieldId) ? c.fieldId[0] : c.fieldId
-            return {
-              fieldId: c.fieldId,
-              operator: c.operator,
-              value: c.value,
-              isCustomField: fId?.startsWith('custom_') ?? false,
-            }
-          }),
-        })),
-      })
-      whereClause = this.buildGroupedQuery(conditionGroups, resourceType)
-    } else if (conditions.length > 0) {
-      console.log('🔍 [FindProcessor] Building flat query with conditions:', {
-        conditions: conditions.map((c) => {
-          const fId = Array.isArray(c.fieldId) ? c.fieldId[0] : c.fieldId
-          return {
-            fieldId: c.fieldId,
-            operator: c.operator,
-            value: c.value,
-            isCustomField: fId?.startsWith('custom_') ?? false,
-          }
-        }),
-      })
-      whereClause = ConditionQueryBuilder.buildWhereSql(conditions, resourceType)
+    if (droppedConditions.length > 0) {
+      throw new Error(
+        describeDroppedConditions(
+          resourceType,
+          droppedConditions.map((dropped) => ({
+            ref: Array.isArray(dropped.fieldRef) ? dropped.fieldRef.join(' → ') : dropped.fieldRef,
+            reason: dropped.reason,
+          }))
+        )
+      )
     }
 
+    // An unresolvable sort still no-ops silently — sort is deliberately not a
+    // reporting channel (carried forward from #1478).
     const orderByClause = orderBy
       ? ConditionQueryBuilder.buildOrderBySql(
-          orderBy.field,
+          canonicalizeSystemFieldRef(orderBy.field, resourceType, fields),
           orderBy.direction || 'asc',
           resourceType
         )
       : undefined
 
-    const builtQuery = {
+    return {
       where: whereClause,
       orderBy: orderByClause,
       limit,
     }
-
-    console.log('🔍 [FindProcessor] Query built', {
-      hasWhereClause: !!whereClause,
-      hasOrderBy: !!orderByClause,
-      limit,
-    })
-
-    return builtQuery
-  }
-
-  /**
-   * Build query from condition groups
-   */
-  private buildGroupedQuery(
-    groups: ConditionGroup[],
-    resourceType: TableId
-  ): SQL<unknown> | undefined {
-    return ConditionQueryBuilder.buildGroupedQuery(groups, resourceType)
   }
 
   /**
@@ -824,42 +848,54 @@ export class FindProcessor extends BaseNodeProcessor {
   /**
    * Execute thread query using the dedicated mail condition builder.
    * Supports cross-table joins for sender, recipients, body, tags, attachments, etc.
+   *
+   * `conditionGroups` arrives canonicalized against `THREAD_FIELDS`, which is
+   * the vocabulary the mail builder already shares (`subject`, `status`,
+   * `inbox`, `assignee`, `ticket`, `from`, `to`, `body`, …), so a cuid-addressed
+   * materialized field lands on the static key the builder dispatches on.
+   *
+   * A genuinely custom field on a thread canonicalizes to `custom_<cuid>`,
+   * which is **meaningless to the mail builder** — it drops, and the drop now
+   * fails the node. Do not "fix" that by teaching the mail builder a `custom_`
+   * prefix: that would be a `FieldValue` read outside the mail lens.
+   *
+   * @throws When the builder dropped any condition.
    */
   private async executeThreadQuery(
     organizationId: string,
-    conditions: GenericCondition[],
     conditionGroups: ConditionGroup[],
+    fields: ResourceField[],
     orderBy: FindNodeData['orderBy'] | undefined,
     limit: number | undefined,
     findMode: 'findOne' | 'findMany'
   ): Promise<{ results: any[] | any; count: number }> {
     // Normalize conditions: strip fieldId prefix, unwrap { referenceId }, extract .id
-    const normalizedGroups =
-      conditionGroups.length > 0
-        ? normalizeGroupsForMailBuilder(conditionGroups)
-        : conditions.length > 0
-          ? [
-              {
-                id: 'flat',
-                conditions: normalizeConditionsForMailBuilder(conditions),
-                logicalOperator: 'AND' as const,
-              },
-            ]
-          : []
+    const normalizedGroups = normalizeGroupsForMailBuilder(conditionGroups)
 
     // Build WHERE clause via mail builder (includes org scoping internally).
     // Configured automation reads as AUTOMATION_SYSTEM (§8.2): full on org
     // inboxes, zero access to personal inboxes.
-    const whereClause = buildConditionGroupsQuery(
+    const { sql: whereClause, droppedConditions } = buildConditionGroupsQueryWithDiagnostics(
       normalizedGroups,
       organizationId,
       await getAutomationVisibility(organizationId)
     )
 
+    // A dropped mail condition leaves `sql` as the bare base scope — the whole
+    // visible mailbox — which for a workflow is the worst available outcome.
+    if (droppedConditions.length > 0) {
+      throw new Error(
+        describeDroppedConditions(
+          'thread',
+          droppedConditions.map((dropped) => ({ ref: dropped.fieldId, reason: dropped.reason }))
+        )
+      )
+    }
+
     // Build ORDER BY (fall back to SystemConditionBuilder for column resolution)
     const orderByClause = orderBy
       ? ConditionQueryBuilder.buildOrderBySql(
-          this.stripFieldPrefix(orderBy.field),
+          canonicalizeSystemFieldRef(orderBy.field, 'thread', fields),
           orderBy.direction || 'asc',
           'thread'
         )
@@ -887,7 +923,6 @@ export class FindProcessor extends BaseNodeProcessor {
     resourceType: string,
     organizationId: string,
     db: Database,
-    conditions: GenericCondition[],
     conditionGroups: ConditionGroup[],
     orderBy: FindNodeData['orderBy'] | undefined,
     limit: number | undefined,
@@ -930,14 +965,17 @@ export class FindProcessor extends BaseNodeProcessor {
       relatedEntityFields,
     }
 
-    // Build WHERE clause using EntityConditionBuilder
-    let whereClause: SQL<unknown> | undefined
-
-    if (conditionGroups.length > 0) {
-      whereClause = entityConditionBuilder.buildGroupedQuery(conditionGroups, entityContext)
-    } else if (conditions.length > 0) {
-      whereClause = entityConditionBuilder.buildWhereSql(conditions, entityContext)
-    }
+    // Build WHERE clause using EntityConditionBuilder.
+    //
+    // Unlike the system and thread lanes, a drop here is NOT failed — this lane
+    // resolves cuids natively, so it never had the field-vocabulary mismatch
+    // those two do, and it was deliberately left alone. Its remaining drops
+    // (an operator the entity builder can't build) still widen silently;
+    // that is a known gap, not an oversight.
+    const whereClause =
+      conditionGroups.length > 0
+        ? entityConditionBuilder.buildGroupedQuery(conditionGroups, entityContext)
+        : undefined
 
     // Build ORDER BY clause
     let orderByClause: SQL<unknown>[] | undefined
@@ -1061,6 +1099,21 @@ export class FindProcessor extends BaseNodeProcessor {
     const warnings: string[] = []
     const config = node.data as unknown as FindNodeData
 
+    /**
+     * Report a field the static `FIND_RESOURCE_CONFIGS` slice doesn't know.
+     *
+     * Design time has no `organizationId`, so a `CustomField` cuid can't be
+     * resolved here at all — erroring on a reference the panel itself offered
+     * would be worse than not checking it. Everything else stays an error.
+     */
+    const pushUnknownField = (fieldId: string, message: string) => {
+      if (isCuidFieldRef(fieldId)) {
+        warnings.push(`${message} (custom field — validated at runtime)`)
+      } else {
+        errors.push(message)
+      }
+    }
+
     // Validate resource type
     if (!config.resourceType) {
       errors.push('Resource type is required')
@@ -1108,7 +1161,13 @@ export class FindProcessor extends BaseNodeProcessor {
             getFieldOutputKey(f) === flatFieldId || f.key === flatFieldId || f.id === flatFieldId
         )
         if (!field) {
-          errors.push(
+          // A cuid-shaped ref is a field the panel legitimately offered — a
+          // materialized or truly-custom `CustomField` — and is unresolvable
+          // here by construction: `validateNodeConfig` has no `organizationId`
+          // and so cannot load the merged fields. Warn, exactly like the
+          // `custom_` branch above. A plainly-named unknown field stays an error.
+          pushUnknownField(
+            flatFieldId,
             `Flat Condition ${index + 1}: Invalid field "${flatFieldId}" for ${config.resourceType}`
           )
         } else {
@@ -1194,7 +1253,8 @@ export class FindProcessor extends BaseNodeProcessor {
               f.id === groupFieldId
           )
           if (!field) {
-            errors.push(
+            pushUnknownField(
+              groupFieldId,
               `Group ${groupIndex + 1}, Condition ${condIndex + 1}: Invalid field "${groupFieldId}" for ${config.resourceType}`
             )
           } else {


### PR DESCRIPTION
## The bug

The Find node validates a condition against **one** field vocabulary and builds SQL against a **different** one, and every disagreement is a silent widen — not an error, not a zero-row result.

`executeNode` routes on the shape of `resourceType` into three lanes with three vocabularies:

| Lane | Builder | Vocabulary | On an unresolvable ref |
|---|---|---|---|
| Entity | `entityConditionBuilder` | four probes incl. cuid | resolves — fine, untouched |
| Thread | `mail-query/condition-query-builder` | its own 24-case `switch` | **drop → `baseScope`** = the whole visible mailbox |
| System | `systemConditionBuilder` | `RESOURCE_FIELD_REGISTRY[tableId]`, by static key | **drop → clause omitted** = the whole table |

**The live case is the thread lane.** `THREAD_FIELDS` declares ten `filterable: true` fields the mail builder has no case for — `tags` (it has `tag`), `messages`, and eight `visit*` — and all ten are in the Find panel's field dropdown. Configure *"Find Many Threads where Tag is Refunds"* and the node returns **every thread in the org's shared inboxes**, up to `limit` — and `limit` is optional, so a `findMany` with none set hands the entire mailbox to whatever runs next.

Worse, the node's own preflight *passes* these: `validateConditionValues` resolves against the **merged** fields, which know `tags` and every cuid, while the builder dispatches on its own switch. Preflight and the query lane disagree — precisely the divergence #1478 had to close for `inspectFilterConditions`.

## What changed

- **Fold the legacy flat `conditions[]` into one group** so every lane takes a single filter path. The combining operator reproduces `BaseConditionBuilder.deriveFlatOperator` rather than hard-coding `AND` — that is what keeps the fold SQL-identical to the `buildWhereSql` call it replaces, and it fixes the thread lane's pre-existing hard-code on the way.
- **Canonicalize field references** through the existing `canonicalizeSystemConditions` *before* validation, so preflight and the build agree by construction. The entity lane is skipped: it resolves cuids natively, and `RESOURCE_FIELD_REGISTRY` has no slice for an entityDefinitionId.
- **Fail the node on any drop**, partial included. A partial drop widens an AND group and narrows an OR group; there is no reading under which the node did what it was configured to do, and unlike the AI count tools this node has no channel to report one mid-run. The message names the refs and reasons; the builders' internal `detail` is deliberately withheld, since #1475 pins that it never reaches a user-visible payload and a run log is user-visible.
- **Map `tags` → `tag`** in the mail dispatcher. `THREAD_FIELDS` declares the field as `tags`; `tag` is this builder's own older name, still emitted by `context-to-conditions`.
- **Delete six `console.log('🔍 [FindProcessor] …')` calls** that wrote full condition values — user data — to stdout on every run, bypassing `@auxx/logger` and OpenObserve's level filtering.
- **Delete ~180 lines of commented-out field validation** in the web twin. It could not be revived: `validateFindNodeConfig` receives only `data`, so its sole vocabulary is the static `filterableFields` — exactly what cannot see a `CustomField`.

`visit*` and `messages` are deliberately **not** made filterable (they need typed-column comparisons and an `EXISTS` join respectively — those are features). Under this change they become loud instead of wrong.

## Three things worth a reviewer's attention

1. **The flat-fold operator.** Copying the thread lane's hard-coded `AND` would have silently changed which rows a flat `OR` filter returns. Pinned by the one test that goes red when it is hard-coded.
2. **The system lane cannot demonstrate the drop guard**, and the tests say so rather than implying otherwise. A garbage ref there is refused by `validateConditionValues` before the builder runs, and all 16 `message` fields have a `dbColumn`, so no ref passes preflight and then drops. Both system-lane failure tests are labelled `CONTROL`.
3. **The entity lane takes the fold but not the throw.** It never had the vocabulary mismatch. Its remaining drops still widen silently — a known gap, commented in place, not an oversight.

## Scope

The cuid half is **preventive**. Re-measured on the dev DB before executing: every `CustomField` row on a system `modelType` carries a `systemAttribute` (`NULL` appears only under `modelType = 'entity'`), and of the 7 stored Find nodes across 199 workflows, 6 target entity resources and 1 targets `thread` with an empty condition group. Zero stored cuid-addressed system conditions.

## Testing

New `find-condition-resolution.test.ts` (24 cases) covering cuid resolution on both lanes, the `visit*`/`messages` failures, a partial drop, preflight≡build as an `it.each` in both directions, the flat≡single-group fold, and `orderBy`. `tag / tags` equivalence added to the mail builder suite.

**Non-vacuity** — each fix neutralized in turn, and the expected tests went red:

| neutralized | red |
|---|---|
| canonicalizer off in `executeNode` | 5 — every cuid case |
| drop-throws removed from both lanes | 6 — every `visit*`/`messages` case |
| `tags` case removed from the mail dispatcher | 2 |
| fold operator hard-coded to `AND` | 1 |

The survivors are named controls. The table is reproduced in the test file's header so it travels with the code.

- `lib`: **6682 passed, 0 failed** (562 files) · `web`: **2643 passed, 0 failed** (173 files)
- Typecheck on TypeScript 7: `packages/lib` at **29**, its exact pre-existing baseline (all in `scripts/` + `vitest.integration.config.ts`; `src/` stays at zero). `apps/web` at **1**, the known `AgentDomainConfig` variance.
- Biome clean on all five files.

**Not covered by tests:** the end-to-end behaviour in a real org. Worth one manual pass — *Tags is \<a tag\>* should return the tagged threads (on `main` today it returns the mailbox), *Visit City is Berlin* should fail the node naming `visitCity` and return no rows, and an entity-resource Find node should run unchanged.

## Follow-ups this does not do

- `executeResourceQuery` supports four tables while `FIND_RESOURCE_CONFIGS` advertises eight; the rest hit `default:`, log "Unsupported resource type", and return `null`/`[]` while the node reports **success**. Separate bug, fails closed — but it is the first thing to check if a Find node returns nothing after this change.
- `case 'user'` is queried with **no `organizationId` predicate**. This PR removes the fail-open half that made it reachable through a dropped filter; the unscoped read itself needs its own look.