### PR TITLE
fix(kopilot): stop invalid streamed dates from crashing block renderers

### DIFF
--- a/apps/web/src/components/kopilot/ui/blocks/__tests__/block-date.test.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/__tests__/block-date.test.ts
@@ -1,0 +1,33 @@
+// apps/web/src/components/kopilot/ui/blocks/__tests__/block-date.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { parseBlockDate } from '../block-date'
+
+describe('parseBlockDate', () => {
+  it('parses a complete ISO timestamp', () => {
+    expect(parseBlockDate('2026-07-31T09:15:00.000Z')?.toISOString()).toBe(
+      '2026-07-31T09:15:00.000Z'
+    )
+  })
+
+  it('returns null for a mid-stream truncated timestamp', () => {
+    // The partial-JSON parser emits prefixes of the streamed string, so every
+    // cut point of a real ISO value must be survivable.
+    const full = '2026-07-31T09:15:00.000Z'
+    for (let i = 1; i < full.length; i++) {
+      const prefix = full.slice(0, i)
+      const parsed = parseBlockDate(prefix)
+      expect(parsed === null || !Number.isNaN(parsed.getTime())).toBe(true)
+    }
+  })
+
+  it('returns null for empty, null and undefined', () => {
+    expect(parseBlockDate('')).toBeNull()
+    expect(parseBlockDate(null)).toBeNull()
+    expect(parseBlockDate(undefined)).toBeNull()
+  })
+
+  it('returns null for garbage', () => {
+    expect(parseBlockDate('not a date')).toBeNull()
+  })
+})

--- a/apps/web/src/components/kopilot/ui/blocks/block-date.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/block-date.ts
@@ -1,0 +1,18 @@
+// apps/web/src/components/kopilot/ui/blocks/block-date.ts
+
+/**
+ * Parses a timestamp out of block data, returning `null` when it is not a
+ * usable date.
+ *
+ * Block props come from a *partially* streamed JSON fence, so any string field
+ * can arrive as a truncated prefix (`"2026-07-31T09:1"`) for a frame or two
+ * while the snapshot object is still streaming. `new Date()` yields an Invalid
+ * Date for those, and date-fns then throws `RangeError: Invalid time value`,
+ * which unmounts the whole message list mid-stream. Callers must render nothing
+ * (or a placeholder) when this returns `null`.
+ */
+export function parseBlockDate(value: string | null | undefined): Date | null {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}

--- a/apps/web/src/components/kopilot/ui/blocks/bulk-update-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/bulk-update-approval-card.tsx
@@ -2,8 +2,7 @@
 
 'use client'
 
-import type { RecordId } from '@auxx/lib/resources/client'
-import { getDefinitionId } from '@auxx/lib/resources/client'
+import { getDefinitionId, isRecordId } from '@auxx/lib/resources/client'
 import { useState } from 'react'
 import { useResource } from '~/components/resources'
 import type { ApprovalCardProps } from './approval-card-registry'
@@ -12,8 +11,14 @@ import { EntityCardItem } from './entity-card-item'
 import { KopilotFieldRow } from './kopilot-field-row'
 
 export function BulkUpdateApprovalCard({ args, status, onApprove, onReject }: ApprovalCardProps) {
-  const recordIds = (args.recordIds ?? []) as RecordId[]
-  const values = (args.values ?? []) as Array<{ fieldId: string; value: unknown }>
+  // Approval-card args are raw model output — only required-key presence is
+  // checked before the card renders, so a wrong-typed `recordIds` would throw
+  // in `getDefinitionId` and a non-array `values` in `.map`.
+  const recordIds = (Array.isArray(args.recordIds) ? args.recordIds : []).filter(isRecordId)
+  const values = (Array.isArray(args.values) ? args.values : []) as Array<{
+    fieldId: string
+    value: unknown
+  }>
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set(recordIds))
 
   const firstRecordId = recordIds[0]

--- a/apps/web/src/components/kopilot/ui/blocks/draft-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/draft-approval-card.tsx
@@ -9,6 +9,11 @@ import type { ApprovalCardProps } from './approval-card-registry'
 import { BlockCard, type BlockCardAction, StatusIndicator } from './block-card'
 import { RecipientChip } from './recipient-chip'
 
+/** Keep only the string entries of a model-authored list — the rest can't be rendered. */
+function toStringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : []
+}
+
 export function DraftApprovalCard({
   args,
   status,
@@ -37,43 +42,26 @@ export function DraftApprovalCard({
   const threadId =
     (typeof d.threadId === 'string' && d.threadId) ||
     (typeof args.threadId === 'string' ? args.threadId : undefined)
-  const body = typeof d.body === 'string' ? d.body : ((args.body as string) ?? '')
-  const argTo = Array.isArray(args.to) ? (args.to as string[]) : []
-  const argCc = Array.isArray(args.cc) ? (args.cc as string[]) : []
+  // Tool args reaching an approval card are only presence-checked, never type
+  // validated (zod runs after approval), so every field here is raw model
+  // output — a non-string rendered as a React child throws.
+  const body = typeof d.body === 'string' ? d.body : typeof args.body === 'string' ? args.body : ''
+  const argTo = toStringList(args.to)
+  const argCc = toStringList(args.cc)
 
   // Post-execution: prefer resolved labels from the digest (real emails / phones).
-  const resolvedLabels =
-    d.recipients ?? resolvedRecipients?.map((r) => r.displayName ?? r.identifier)
+  const resolvedLabels = Array.isArray(d.recipients)
+    ? toStringList(d.recipients)
+    : resolvedRecipients?.map((r) => r.displayName ?? r.identifier)
 
   const handleEditInThread = () => {
+    if (!threadId) return
     const currentSearch = searchParams.toString()
-    console.log('[DraftApprovalCard] edit-in-thread clicked', {
-      threadId,
-      digestThreadId: d.threadId,
-      argsThreadId: args.threadId,
-      status,
-      pathname,
-      currentSearch,
-    })
-    if (!threadId) {
-      console.warn('[DraftApprovalCard] edit-in-thread aborted: no threadId', {
-        digest: d,
-        args,
-      })
-      return
-    }
     const onMailRoute = pathname?.startsWith('/app/mail/') ?? false
     const basePath = onMailRoute ? pathname : '/app/mail/inboxes/all/unassigned'
     const params = new URLSearchParams(onMailRoute ? currentSearch : '')
     params.set('tid', threadId)
-    const target = `${basePath}?${params.toString()}`
-    console.log('[DraftApprovalCard] edit-in-thread navigating', {
-      from: `${pathname}${currentSearch ? `?${currentSearch}` : ''}`,
-      to: target,
-      threadId,
-      onMailRoute,
-    })
-    router.push(target)
+    router.push(`${basePath}?${params.toString()}`)
   }
 
   const isPending = status === 'pending'

--- a/apps/web/src/components/kopilot/ui/blocks/draft-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/draft-list-block.tsx
@@ -13,6 +13,7 @@ import { useThread } from '~/components/threads/hooks'
 import type { ThreadMeta } from '~/components/threads/store'
 import { useCompose } from '~/hooks/use-compose'
 import { BlockCard } from './block-card'
+import { parseBlockDate } from './block-date'
 import type { BlockRendererProps } from './block-registry'
 import type { DraftListData, DraftSnapshotData } from './block-schemas'
 import { useStreamSafeIds } from './use-stream-safe-ids'
@@ -114,8 +115,8 @@ function DraftListRow({ id, snapshot: serverSnapshot }: DraftListRowProps) {
 
   const subject = snapshot.subject ?? '(no subject)'
   const recipientSummary = snapshot.recipientSummary
-  const updatedAt = snapshot.updatedAt
-  const scheduledAt = snapshot.scheduledAt
+  const updatedAt = parseBlockDate(snapshot.updatedAt)
+  const scheduledAt = parseBlockDate(snapshot.scheduledAt)
   const kindLabel = snapshot.kind === 'reply' ? 'Reply' : 'New'
 
   return (
@@ -141,14 +142,14 @@ function DraftListRow({ id, snapshot: serverSnapshot }: DraftListRowProps) {
             <>
               {recipientSummary && <span>·</span>}
               <span className='shrink-0 text-amber-600 dark:text-amber-400'>
-                Scheduled {formatDistanceToNowStrict(new Date(scheduledAt), { addSuffix: true })}
+                Scheduled {formatDistanceToNowStrict(scheduledAt, { addSuffix: true })}
               </span>
             </>
           ) : updatedAt ? (
             <>
               {recipientSummary && <span>·</span>}
               <span className='shrink-0'>
-                {formatDistanceToNowStrict(new Date(updatedAt), { addSuffix: true })}
+                {formatDistanceToNowStrict(updatedAt, { addSuffix: true })}
               </span>
             </>
           ) : null}

--- a/apps/web/src/components/kopilot/ui/blocks/entity-definition-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/entity-definition-block.tsx
@@ -20,12 +20,13 @@ export function EntityDefinitionBlock({ data }: BlockRendererProps<EntityDefinit
         hasFooter={false}>
         <div className='divide-y'>
           {fields.map((field, i) => {
-            // Wait until at least the label has streamed in. Index keys stay
-            // stable so completed fields don't remount when a later field's
-            // label finally arrives.
+            // Wait until at least the label has streamed in. The key is the
+            // index, not `field.id` — the id streams in (and streams in
+            // truncated) after the label, so keying on it would remount the
+            // row on every delta.
             if (!field.label) return null
             return (
-              <div key={field.id ?? i} className='flex items-start gap-2 px-1.5 py-1.5'>
+              <div key={i} className='flex items-start gap-2 px-1.5 py-1.5'>
                 <div className='min-w-0 flex-1'>
                   <div className='flex items-center gap-2 text-sm'>
                     <span className='truncate font-medium'>{field.label}</span>

--- a/apps/web/src/components/kopilot/ui/blocks/task-item-skeleton.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/task-item-skeleton.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { format } from 'date-fns'
 import { Check, CircleDashed } from 'lucide-react'
+import { parseBlockDate } from './block-date'
 import type { TaskSnapshotData } from './block-schemas'
 
 /**
@@ -31,6 +32,7 @@ interface TaskItemSkeletonProps {
  */
 export function TaskItemSkeleton({ snapshot, isDeleted }: TaskItemSkeletonProps) {
   const isCompleted = !!snapshot.completedAt
+  const deadline = parseBlockDate(snapshot.deadline)
   return (
     <div className={cn(TASK_ROW_WRAPPER, (isCompleted || isDeleted) && 'opacity-60')}>
       {isCompleted ? (
@@ -48,9 +50,9 @@ export function TaskItemSkeleton({ snapshot, isDeleted }: TaskItemSkeletonProps)
             )}>
             {snapshot.title}
           </span>
-          {snapshot.deadline && (
+          {deadline && (
             <span className='flex-shrink-0 text-xs leading-6 text-muted-foreground'>
-              {format(new Date(snapshot.deadline), 'MMM d, yyyy')}
+              {format(deadline, 'MMM d, yyyy')}
             </span>
           )}
         </div>

--- a/apps/web/src/components/kopilot/ui/blocks/thread-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/thread-list-block.tsx
@@ -10,6 +10,7 @@ import { motion } from 'motion/react'
 import { useSearchParams } from 'next/navigation'
 import { useThread } from '~/components/threads/hooks/use-thread'
 import { BlockCard } from './block-card'
+import { parseBlockDate } from './block-date'
 import type { BlockRendererProps } from './block-registry'
 import type { ThreadListData, ThreadSnapshotData } from './block-schemas'
 import { useStreamSafeIds } from './use-stream-safe-ids'
@@ -69,8 +70,9 @@ function ThreadListRow({ threadId, snapshot }: ThreadListRowProps) {
   const subject = thread?.subject ?? snapshot?.subject ?? null
   const status = thread?.status
   const sender = snapshot?.sender
-  // `ThreadMeta.lastMessageAt` is already an ISO string in the store.
-  const lastMessageAt = thread?.lastMessageAt ?? snapshot?.lastMessageAt
+  // `ThreadMeta.lastMessageAt` is an ISO string in the store; the snapshot's is
+  // a raw streamed string that can still be a truncated prefix.
+  const lastMessageAt = parseBlockDate(thread?.lastMessageAt ?? snapshot?.lastMessageAt)
   const isUnread = thread?.isUnread ?? snapshot?.isUnread
   const messageCount = thread?.messageCount
   const showDeleted = !thread && !!snapshot && isNotFound
@@ -110,7 +112,7 @@ function ThreadListRow({ threadId, snapshot }: ThreadListRowProps) {
             <>
               {sender && <span>·</span>}
               <span className='shrink-0'>
-                {formatDistanceToNowStrict(new Date(lastMessageAt), { addSuffix: true })}
+                {formatDistanceToNowStrict(lastMessageAt, { addSuffix: true })}
               </span>
             </>
           )}


### PR DESCRIPTION
## The crash

```
RangeError: Invalid time value
  src/components/kopilot/ui/blocks/thread-list-block.tsx (113:43) @ ThreadListRow
```

Block props come from a **partial-JSON parse** of the streaming fence (`assistant-message.tsx:71`), so any string field can be a truncated prefix (`"2026-07-31T09:1"`) for a frame or two while the snapshot object is still streaming. `useStreamSafeIds` withholds only the trailing *id*; snapshot values keep streaming after their row is already mounted.

`new Date(prefix)` yields an Invalid Date, and date-fns v4 throws — unmounting the **whole message list**, not just the one row.

## Fix

New `parseBlockDate(value): Date | null`, with the three unguarded call sites routed through it:

| Site | Field |
| --- | --- |
| `thread-list-block.tsx` | `lastMessageAt` — the reported crash |
| `draft-list-block.tsx` | `updatedAt`, `scheduledAt` |
| `task-item-skeleton.tsx` | `deadline` |

`table-block.tsx` and `task-create-approval-card.tsx` already had inline `Number.isNaN` guards and are unchanged.

## Related fixes from auditing the rest of `ui/blocks/`

Approval-card args are only **presence**-checked before render (`validateRequiredParams` in `query-loop.ts:628`); the zod `validateInputs` pass runs *after* approval. Every `args.x as T` in a card is therefore raw model output.

- **`draft-approval-card`** — `(args.body as string) ?? ''` was rendered straight as a React child (a non-string throws "Objects are not valid as a React child"). `to` / `cc` had an `Array.isArray` guard but their *elements* were unfiltered, and `RecipientChip`'s fallback renders `{value}` raw.
- **`bulk-update-approval-card`** — `recordIds` reached `getDefinitionId` → `parseRecordId` does `recordId.indexOf(':')`, a TypeError on a non-string; `values` was cast to an array then `.map`ped. Now guarded the way `entity-update-approval-card.tsx:14` already was.
- **`draft-approval-card`** — removed three debug `console.log`/`warn` calls (shipped since #576) that dumped full `args` + `digest` — message body and recipient emails — into the browser console on every edit-in-thread click.
- **`entity-definition-block`** — `key={field.id ?? i}` contradicted its own comment: `id` streams in after `label` and arrives truncated first, so the key flipped `i` → partial id → final id, remounting the row on each delta.

## Not changed, worth knowing

- `summarize-tool-result.ts:220` — the legacy sniffer doesn't filter missing `recordId`s the way the digest path at `:78` does. It reads server tool output rather than model args, so it's an inconsistency rather than a live crash.
- `parseToolArgs` is typed `Record<string, unknown>` but returns whatever `JSON.parse` gives, including scalars. Cards reading properties off a number get `undefined` — no crash, just a type lie.

## Verification

- New unit test walks **every prefix cut** of a real ISO string (4 tests passing)
- `tsc --noEmit` in `apps/web` reports nothing for `ui/blocks/`
- biome clean