### PR TITLE
chore(audit): add code-cleanup sweep scripts

### DIFF
--- a/scripts/audit/build-inventory.mjs
+++ b/scripts/audit/build-inventory.mjs
@@ -1,0 +1,626 @@
+// scripts/audit/build-inventory.mjs
+/**
+ * Builds the code-cleanup surface inventory.
+ *
+ * A "surface" is the unit of cleanup decision — a lib module, a tRPC router, a
+ * route group, a UI component family. Findings are attributed to surfaces so we
+ * review ~250 areas instead of ~50k symbols.
+ *
+ * Emits:
+ *   plans/cleanup/code/inventory.jsonl  — one JSON object per surface (machine)
+ *   plans/cleanup/code/inventory.md     — triage-ordered tables (human)
+ *
+ * Usage: node scripts/audit/build-inventory.mjs
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const OUT_DIR = path.join(REPO, 'plans/cleanup/code')
+
+const CODE_EXT = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs'])
+
+/**
+ * Surface rules, most-specific root first. `depth: 1` means each child of the
+ * root (dir or file) is its own surface.
+ *
+ * `entrypoint: true` marks surfaces that are invoked by a framework/runtime
+ * rather than imported (Next routes, express routes, workers, scripts). Their
+ * importer count is structurally 0 and must NOT count as a dead-code signal.
+ */
+const RULES = [
+  { root: 'packages/lib/src', depth: 1, kind: 'lib-module' },
+  { root: 'packages/services/src', depth: 1, kind: 'services-module' },
+  { root: 'packages/ui/src/components', depth: 1, kind: 'ui-component' },
+  { root: 'packages/ui/src/lib', depth: 1, kind: 'ui-lib' },
+  { root: 'packages/ui/src/hooks', depth: 1, kind: 'ui-lib' },
+  { root: 'packages/database/src/db/schema', depth: 1, kind: 'db-schema' },
+  { root: 'packages/database/src/db/models', depth: 1, kind: 'db-model' },
+  { root: 'packages/chat/src/views', depth: 1, kind: 'chat-view' },
+  { root: 'packages/chat/src', depth: 1, kind: 'chat-module' },
+  { root: 'packages/workflow-nodes/src', depth: 1, kind: 'workflow-node' },
+  { root: 'packages/email/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/billing/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/sdk/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/utils/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/types/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/credentials/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/redis/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/config/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/logger/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/deployment/src', depth: 1, kind: 'pkg-module' },
+  { root: 'packages/seed/src', depth: 1, kind: 'seed-module', entrypoint: true },
+
+  { root: 'apps/web/src/server/api/routers', depth: 1, kind: 'trpc-router' },
+  { root: 'apps/web/src/components', depth: 1, kind: 'web-component' },
+  { root: 'apps/web/src/app/(protected)/app', depth: 1, kind: 'web-route', entrypoint: true },
+  { root: 'apps/web/src/app/(protected)', depth: 1, kind: 'web-route', entrypoint: true },
+  { root: 'apps/web/src/app/(auth)', depth: 1, kind: 'web-route', entrypoint: true },
+  { root: 'apps/web/src/app/(public)', depth: 1, kind: 'web-route', entrypoint: true },
+  { root: 'apps/web/src/app/api', depth: 1, kind: 'web-route-api', entrypoint: true },
+  { root: 'apps/web/src/app/admin', depth: 1, kind: 'web-route', entrypoint: true },
+  { root: 'apps/web/src/app', depth: 1, kind: 'web-route', entrypoint: true },
+  { root: 'apps/web/src/hooks', depth: 1, kind: 'web-lib' },
+  { root: 'apps/web/src/lib', depth: 1, kind: 'web-lib' },
+  { root: 'apps/web/src/stores', depth: 1, kind: 'web-lib' },
+  { root: 'apps/web/src/utils', depth: 1, kind: 'web-lib' },
+  { root: 'apps/web/src/providers', depth: 1, kind: 'web-lib' },
+  { root: 'apps/web/src/realtime', depth: 1, kind: 'web-lib' },
+  { root: 'apps/web/src/server', depth: 1, kind: 'web-server' },
+
+  { root: 'apps/worker/scripts', depth: 1, kind: 'dev-script', entrypoint: true },
+  { root: 'packages/lib/scripts', depth: 1, kind: 'dev-script', entrypoint: true },
+  { root: 'packages/database/scripts', depth: 1, kind: 'dev-script', entrypoint: true },
+  { root: 'scripts', depth: 1, kind: 'repo-script', entrypoint: true },
+
+  { root: 'apps/api/src/routes', depth: 1, kind: 'api-route', entrypoint: true },
+  { root: 'apps/api/src', depth: 1, kind: 'api-module' },
+  { root: 'apps/worker/src/workers', depth: 1, kind: 'worker-job', entrypoint: true },
+  { root: 'apps/worker/src', depth: 1, kind: 'worker-module', entrypoint: true },
+  { root: 'apps/build/src/server/api/routers', depth: 1, kind: 'trpc-router' },
+  { root: 'apps/build/src/components', depth: 1, kind: 'build-component' },
+  { root: 'apps/build/src/app', depth: 1, kind: 'build-route', entrypoint: true },
+  { root: 'apps/kb/src', depth: 1, kind: 'kb-module', entrypoint: true },
+  { root: 'apps/homepage/src', depth: 1, kind: 'homepage-module', entrypoint: true },
+  { root: 'apps/lambda/src', depth: 1, kind: 'lambda-module', entrypoint: true },
+  { root: 'apps/extension/src', depth: 1, kind: 'extension-module', entrypoint: true },
+  { root: 'apps/mail-ingress/src', depth: 1, kind: 'mail-ingress', entrypoint: true },
+  { root: 'apps/echtzeit/src', depth: 1, kind: 'echtzeit-module', entrypoint: true },
+]
+
+const SKIP_PREFIX = [
+  'node_modules/',
+  'dist/',
+  '.next/',
+  '.turbo/',
+  'packages/e2e/',
+  'packages/test-utils/',
+  'packages/typescript-config/',
+  'infra/',
+  'apps/docs/',
+]
+
+// ---------------------------------------------------------------------------
+// 1. File list
+// ---------------------------------------------------------------------------
+
+const git = (args) =>
+  execFileSync('git', args, { cwd: REPO, encoding: 'utf8', maxBuffer: 1024 * 1024 * 512 })
+
+const allFiles = git(['ls-files'])
+  .split('\n')
+  .filter(Boolean)
+  .filter((f) => CODE_EXT.has(path.extname(f)))
+  .filter((f) => !SKIP_PREFIX.some((p) => f.startsWith(p)))
+  .filter((f) => !f.includes('/node_modules/') && !f.includes('/dist/'))
+  // Only real source trees — drops vitest/tsdown/next configs and *-env.d.ts,
+  // which are tool-invoked and would otherwise pile into `*misc*` surfaces.
+  .filter((f) => /^(apps|packages)\/[^/]+\/(src|scripts)\//.test(f) || /^scripts\//.test(f))
+  // Ambient declarations are not code anyone imports.
+  .filter((f) => !f.endsWith('.d.ts'))
+
+// ---------------------------------------------------------------------------
+// 2. Surfaces
+// ---------------------------------------------------------------------------
+
+/** @type {Map<string, {id:string,kind:string,root:string,dir:string,entrypoint:boolean,files:string[],lines:number}>} */
+const surfaces = new Map()
+/** @type {Map<string, string>} surfaceRootDir -> surfaceId, for prefix lookup */
+const surfaceByDir = new Map()
+
+function surfaceIdFor(file) {
+  // Any package's own scripts/ dir — dev/ops scripts, invoked by hand or CI.
+  const scriptMatch = file.match(/^((?:apps|packages)\/[^/]+\/scripts)\/(.+)$/)
+  if (scriptMatch) {
+    const seg = scriptMatch[2].split('/')[0]
+    const isFile = scriptMatch[2] === seg
+    return {
+      id: `${scriptMatch[1]}/${isFile ? seg.replace(/\.[^.]+$/, '') : seg}`,
+      kind: 'dev-script',
+      root: scriptMatch[1],
+      dir: `${scriptMatch[1]}/${seg}`,
+      entrypoint: true,
+      isFile,
+    }
+  }
+  for (const rule of RULES) {
+    if (!file.startsWith(`${rule.root}/`)) continue
+    const rest = file.slice(rule.root.length + 1)
+    const seg = rest.split('/')[0]
+    if (!seg) continue
+    // a bare file directly under the root is its own surface (strip extension)
+    const isFile = rest === seg
+    const name = isFile ? seg.replace(/\.[^.]+$/, '') : seg
+    return {
+      id: `${rule.root}/${name}`,
+      kind: rule.kind,
+      root: rule.root,
+      dir: `${rule.root}/${seg}`,
+      // A bare file directly under a package's src/ is a bootstrap or public
+      // barrel (index.ts, server.ts, main.tsx, the CLI bin) — it is a build
+      // input or an export-map target, not something internal code imports.
+      // Known blind spot: a genuinely dead top-level file hides here.
+      entrypoint:
+        Boolean(rule.entrypoint) || (isFile && /^(apps|packages)\/[^/]+\/src$/.test(rule.root)),
+      isFile,
+    }
+  }
+  // fallback: package-level surface
+  const m = file.match(/^((?:apps|packages)\/[^/]+)\//)
+  if (m) {
+    return {
+      id: `${m[1]}/*misc*`,
+      kind: 'misc',
+      root: m[1],
+      dir: m[1],
+      entrypoint: false,
+      isFile: false,
+    }
+  }
+  return { id: 'root/*misc*', kind: 'misc', root: '.', dir: '.', entrypoint: false, isFile: false }
+}
+
+const fileToSurface = new Map()
+
+const isTestFile = (f) =>
+  /(^|\/)(__tests__|__integration__|__mocks__|test|tests)\//.test(f) ||
+  /\.(test|spec)\.[cm]?[jt]sx?$/.test(f)
+
+/** Strip test scaffolding so a test maps to the surface it exercises. */
+const toProdPath = (f) =>
+  f
+    .replace(/(^|\/)(__tests__|__integration__|__mocks__|tests?)\//g, '$1')
+    .replace(/\.(test|spec)\.([cm]?[jt]sx?)$/, '.$2')
+
+const lineCount = (file) => {
+  try {
+    return readFileSync(path.join(REPO, file), 'utf8').split('\n').length
+  } catch {
+    return 0
+  }
+}
+
+function ensureSurface(s) {
+  let entry = surfaces.get(s.id)
+  if (!entry) {
+    entry = {
+      id: s.id,
+      kind: s.kind,
+      root: s.root,
+      dir: s.dir,
+      entrypoint: s.entrypoint,
+      files: [],
+      lines: 0,
+      testFiles: [],
+      testLines: 0,
+    }
+    surfaces.set(s.id, entry)
+    surfaceByDir.set(s.dir, s.id)
+  }
+  return entry
+}
+
+const prodFiles = allFiles.filter((f) => !isTestFile(f))
+const testFiles = allFiles.filter(isTestFile)
+
+// Pass 1 — production files define the surfaces.
+for (const file of prodFiles) {
+  const entry = ensureSurface(surfaceIdFor(file))
+  fileToSurface.set(file, entry.id)
+  entry.files.push(file)
+  entry.lines += lineCount(file)
+}
+
+// Pass 2 — tests attach to the surface they cover; they never form their own.
+for (const file of testFiles) {
+  const entry = ensureSurface(surfaceIdFor(toProdPath(file)))
+  fileToSurface.set(file, entry.id)
+  entry.testFiles.push(file)
+  entry.testLines += lineCount(file)
+}
+
+// ---------------------------------------------------------------------------
+// 3. Package export maps (@auxx/* subpath -> source file)
+// ---------------------------------------------------------------------------
+
+/** @type {Map<string, {dir:string, exports:Record<string,string>}>} */
+const pkgExports = new Map()
+
+for (const pkgJson of git(['ls-files', '*/package.json']).split('\n').filter(Boolean)) {
+  if (pkgJson.includes('node_modules')) continue
+  let json
+  try {
+    json = JSON.parse(readFileSync(path.join(REPO, pkgJson), 'utf8'))
+  } catch {
+    continue
+  }
+  if (!json.name?.startsWith('@auxx/')) continue
+  const dir = path.dirname(pkgJson)
+  const map = {}
+  const pick = (v) => {
+    if (typeof v === 'string') return v
+    if (v && typeof v === 'object') return v.source ?? v.types ?? v.default ?? v.import
+    return undefined
+  }
+  for (const [sub, val] of Object.entries(json.exports ?? {})) {
+    const target = pick(val)
+    if (typeof target === 'string') map[sub] = target
+  }
+  if (!Object.keys(map).length) {
+    const main = json.source ?? json.main ?? 'src/index.ts'
+    map['.'] = main
+  }
+  pkgExports.set(json.name, { dir, exports: map })
+}
+
+/**
+ * Surfaces that a package's `exports` map points at — the package's public API.
+ * These are reached across the package boundary by consumers, so "no importers"
+ * says nothing about them.
+ *
+ * Note: `@auxx/lib`'s exports map is itself codegen'd by scanning consumer
+ * imports (`packages/lib/scripts/generate-exports.ts`), so a lib subpath being
+ * present is already evidence that something imports it.
+ */
+const publicApiSurfaces = new Set()
+for (const [, pkg] of pkgExports) {
+  for (const [key, target] of Object.entries(pkg.exports)) {
+    if (target.includes('*')) continue
+    const candidates = [path.posix.normalize(path.posix.join(pkg.dir, target))]
+    // Packages that publish only `dist/` paths (no `source` condition) can't be
+    // mapped back through the target — fall back to the subpath itself.
+    if (key !== '.') candidates.push(path.posix.join(pkg.dir, 'src', key.slice(2)))
+    for (const c of candidates) {
+      const sid = tryResolve(c) && fileToSurface.get(tryResolve(c))
+      if (sid) publicApiSurfaces.add(sid)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Import extraction + resolution
+// ---------------------------------------------------------------------------
+
+const IMPORT_RE = /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|\bimport\s+)['"]([^'"\n]+)['"]/g
+
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+}
+
+function tryResolve(abs) {
+  // ESM-style specifiers point at `./foo.js` while the source is `foo.ts`.
+  const jsless = abs.replace(/\.(js|jsx|mjs)$/, '')
+  const cands = [
+    abs,
+    `${jsless}.ts`,
+    `${jsless}.tsx`,
+    `${jsless}.mts`,
+    `${abs}.ts`,
+    `${abs}.tsx`,
+    `${abs}.mts`,
+    `${abs}.js`,
+    `${abs}.jsx`,
+    `${abs}/index.ts`,
+    `${abs}/index.tsx`,
+    `${abs}/index.js`,
+  ]
+  for (const c of cands) {
+    if (existsSync(path.join(REPO, c)) && statSync(path.join(REPO, c)).isFile()) return c
+  }
+  return null
+}
+
+/** package root of a repo-relative file, e.g. apps/web */
+function pkgRootOf(file) {
+  const m = file.match(/^((?:apps|packages)\/[^/]+)\//)
+  return m ? m[1] : null
+}
+
+function resolveSpecifier(spec, fromFile) {
+  if (spec.startsWith('.')) {
+    const abs = path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), spec))
+    return tryResolve(abs)
+  }
+  if (spec.startsWith('~/') || spec.startsWith('@/')) {
+    const root = pkgRootOf(fromFile)
+    if (!root) return null
+    return tryResolve(path.posix.join(root, 'src', spec.slice(2)))
+  }
+  if (spec.startsWith('@auxx/')) {
+    const parts = spec.split('/')
+    const name = `${parts[0]}/${parts[1]}`
+    const pkg = pkgExports.get(name)
+    if (!pkg) return null
+    const sub = parts.length > 2 ? `./${parts.slice(2).join('/')}` : '.'
+    let target = pkg.exports[sub]
+    if (!target) {
+      // wildcard exports, e.g. "./lib/*": "./src/lib/*.ts"
+      for (const [k, v] of Object.entries(pkg.exports)) {
+        if (!k.includes('*')) continue
+        const [pre, post] = k.split('*')
+        if (sub.startsWith(pre) && sub.endsWith(post ?? '')) {
+          const star = sub.slice(pre.length, sub.length - (post ?? '').length)
+          target = v.replace('*', star)
+          break
+        }
+      }
+    }
+    if (!target) return tryResolve(path.posix.join(pkg.dir, 'src', parts.slice(2).join('/')))
+    return tryResolve(path.posix.normalize(path.posix.join(pkg.dir, target)))
+  }
+  return null
+}
+
+/** surfaceId -> Set of importing production files outside the surface */
+const importersBySurface = new Map()
+/** surfaceId -> Set of importing test files outside the surface */
+const testImportersBySurface = new Map()
+/** surfaceId -> Set of importing surfaces (production only) */
+const importerSurfaces = new Map()
+/** surfaceId -> Set of surfaces it imports from */
+const importsBySurface = new Map()
+let unresolvedInternal = 0
+let resolvedEdges = 0
+
+for (const file of allFiles) {
+  let src
+  try {
+    src = stripComments(readFileSync(path.join(REPO, file), 'utf8'))
+  } catch {
+    continue
+  }
+  const own = fileToSurface.get(file)
+  IMPORT_RE.lastIndex = 0
+  let m
+  const seen = new Set()
+  while ((m = IMPORT_RE.exec(src))) {
+    const spec = m[1]
+    if (seen.has(spec)) continue
+    seen.add(spec)
+    const isInternal =
+      spec.startsWith('.') ||
+      spec.startsWith('~/') ||
+      spec.startsWith('@/') ||
+      spec.startsWith('@auxx/')
+    if (!isInternal) continue
+    const target = resolveSpecifier(spec, file)
+    if (!target) {
+      unresolvedInternal++
+      continue
+    }
+    resolvedEdges++
+    const targetSurface = fileToSurface.get(target)
+    if (!targetSurface || targetSurface === own) continue
+    if (isTestFile(file)) {
+      // A test-only consumer proves the code compiles, not that anything uses it.
+      if (!testImportersBySurface.has(targetSurface))
+        testImportersBySurface.set(targetSurface, new Set())
+      testImportersBySurface.get(targetSurface).add(file)
+      continue
+    }
+    if (!importersBySurface.has(targetSurface)) importersBySurface.set(targetSurface, new Set())
+    importersBySurface.get(targetSurface).add(file)
+    if (!importerSurfaces.has(targetSurface)) importerSurfaces.set(targetSurface, new Set())
+    importerSurfaces.get(targetSurface).add(own)
+    if (!importsBySurface.has(own)) importsBySurface.set(own, new Set())
+    importsBySurface.get(own).add(targetSurface)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Git recency (single pass over history)
+// ---------------------------------------------------------------------------
+
+const NOW = Math.floor(Date.now() / 1000)
+const D90 = NOW - 90 * 86400
+const D180 = NOW - 180 * 86400
+
+const lastTouched = new Map()
+const commits90 = new Map()
+const commits180 = new Map()
+
+{
+  const log = git(['log', '--no-renames', '--format=@%at', '--name-only'])
+  let ts = 0
+  for (const line of log.split('\n')) {
+    if (!line) continue
+    if (line.startsWith('@')) {
+      ts = Number(line.slice(1))
+      continue
+    }
+    if (isTestFile(line)) continue // recency of the code itself, not of its tests
+    const sid = fileToSurface.get(line)
+    if (!sid) continue
+    if ((lastTouched.get(sid) ?? 0) < ts) lastTouched.set(sid, ts)
+    if (ts >= D90) commits90.set(sid, (commits90.get(sid) ?? 0) + 1)
+    if (ts >= D180) commits180.set(sid, (commits180.get(sid) ?? 0) + 1)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Score + emit
+// ---------------------------------------------------------------------------
+
+const iso = (ts) => (ts ? new Date(ts * 1000).toISOString().slice(0, 10) : 'unknown')
+
+const rows = [...surfaces.values()]
+  // Test-only shells: a test whose subject path no longer exists. Reported as a
+  // count below rather than as surfaces, since there is no code to triage.
+  .filter((s) => s.files.length > 0)
+  .map((s) => {
+    const importerFiles = importersBySurface.get(s.id)?.size ?? 0
+    const testImporterFiles = testImportersBySurface.get(s.id)?.size ?? 0
+    const importerSurf = importerSurfaces.get(s.id)?.size ?? 0
+    const last = lastTouched.get(s.id) ?? 0
+    const c90 = commits90.get(s.id) ?? 0
+    const c180 = commits180.get(s.id) ?? 0
+
+    const publicApi = publicApiSurfaces.has(s.id)
+
+    // Triage ordering only — never a verdict. Importer signals are suppressed for
+    // entrypoint and public-API surfaces, where 0 importers is structural.
+    let score = 0
+    const reasons = []
+    if (publicApi) reasons.push('public-api')
+    if (!s.entrypoint && !publicApi) {
+      if (importerFiles === 0 && testImporterFiles > 0) {
+        score += 3
+        reasons.push('test-only-consumers')
+      } else if (importerFiles === 0) {
+        score += 3
+        reasons.push('no-importers')
+      } else if (importerSurf <= 1) {
+        // One consumer is normal and healthy for most components — this is an
+        // inline/merge hint, not a dead-code signal. Only reaches the suspect
+        // threshold when the surface is also cold.
+        score += 1
+        reasons.push('single-consumer')
+      }
+    }
+    if (c180 === 0) {
+      score += 2
+      reasons.push('untouched-180d')
+    } else if (c90 === 0) {
+      score += 1
+      reasons.push('untouched-90d')
+    }
+
+    return {
+      id: s.id,
+      kind: s.kind,
+      entrypoint: s.entrypoint,
+      publicApi,
+      files: s.files.length,
+      lines: s.lines,
+      testFiles: s.testFiles.length,
+      testLines: s.testLines,
+      importerFiles,
+      testImporterFiles,
+      importerSurfaces: importerSurf,
+      importsSurfaces: importsBySurface.get(s.id)?.size ?? 0,
+      lastTouched: iso(last),
+      commits90: c90,
+      commits180: c180,
+      score,
+      reasons,
+      status: 'untriaged',
+      verdict: null,
+    }
+  })
+
+rows.sort((a, b) => b.score - a.score || b.lines - a.lines)
+
+mkdirSync(OUT_DIR, { recursive: true })
+writeFileSync(
+  path.join(OUT_DIR, 'inventory.jsonl'),
+  `${rows.map((r) => JSON.stringify(r)).join('\n')}\n`
+)
+
+// --- markdown report ---
+
+const totalLines = rows.reduce((n, r) => n + r.lines, 0)
+const byKind = new Map()
+for (const r of rows) {
+  if (!byKind.has(r.kind)) byKind.set(r.kind, [])
+  byKind.get(r.kind).push(r)
+}
+
+const fmt = (n) => n.toLocaleString('en-US')
+const table = (list) => {
+  const head =
+    '| Surface | Files | Lines | Importers (prod) | Importers (test) | Surfaces | Last touched | Signals |\n' +
+    '|---|---:|---:|---:|---:|---:|---|---|'
+  const body = list
+    .map(
+      (r) =>
+        `| \`${r.id.replace(/^(apps|packages)\//, '')}\` | ${r.files} | ${fmt(r.lines)} | ${
+          r.entrypoint ? '—' : r.importerFiles
+        } | ${r.entrypoint ? '—' : r.testImporterFiles} | ${
+          r.entrypoint ? '—' : r.importerSurfaces
+        } | ${r.lastTouched} | ${r.reasons.join(', ') || '—'} |`
+    )
+    .join('\n')
+  return `${head}\n${body}`
+}
+
+const suspects = rows.filter((r) => r.score >= 3)
+const md = `# Code Cleanup — Surface Inventory
+
+> Generated by \`scripts/audit/build-inventory.mjs\`. Do not hand-edit; re-run instead.
+> Triage decisions live in \`decisions.md\`, not here.
+
+**Generated:** ${new Date().toISOString().slice(0, 10)}
+**Surfaces:** ${rows.length} · **Files:** ${fmt(allFiles.length)} · **Lines:** ${fmt(totalLines)}
+**Resolved import edges:** ${fmt(resolvedEdges)} · **Unresolved internal specifiers:** ${fmt(unresolvedInternal)}
+
+## How to read this
+
+- **Importers (prod / test)** — how many files outside this surface import from it. Test files are
+  counted separately and **never** attributed to the surface they live in: a surface whose only
+  consumers are tests (\`test-only-consumers\`) is code kept alive by its own test suite.
+- \`—\` means the surface is an **entrypoint** (Next route, express route, worker, seed, script): it is
+  invoked by a framework, never imported, so 0 importers is structural and carries no signal.
+- **Signals** are triage ordering, not verdicts. \`no-importers\` is a *starting point for a question*,
+  and is wrong on its own for anything reached by dynamic import, string-keyed registry, or codegen.
+- Git history starts 2025-12-28, so \`untouched-180d\` is close to "never touched since the repo began".
+- Nothing here is deleted without a second independent signal. See \`00-approach.md\`.
+
+## Top suspects (score ≥ 3)
+
+${suspects.length} surfaces, ${fmt(suspects.reduce((n, r) => n + r.lines, 0))} lines.
+
+${table(suspects.slice(0, 60))}
+
+${suspects.length > 60 ? `\n_…${suspects.length - 60} more in \`inventory.jsonl\`._\n` : ''}
+## Cold surfaces by kind
+
+Surfaces carrying at least one signal. Everything else is warm and lives only in
+\`inventory.jsonl\` — that file is the complete ledger, this is the reading copy.
+
+${[...byKind.entries()]
+  .sort((a, b) => b[1].length - a[1].length)
+  .map(([kind, list]) => {
+    const cold = list
+      .filter((r) => r.score >= 1)
+      .sort((a, b) => b.score - a.score || b.lines - a.lines)
+    const head = `### ${kind} — ${list.length} surfaces, ${fmt(
+      list.reduce((n, r) => n + r.lines, 0)
+    )} lines`
+    if (!cold.length) return `${head}\n\nNo signals.`
+    return `${head}\n\n${cold.length} cold of ${list.length}.\n\n${table(cold)}`
+  })
+  .join('\n\n')}
+`
+
+writeFileSync(path.join(OUT_DIR, 'inventory.md'), md)
+
+console.log(`surfaces:            ${rows.length}`)
+console.log(`files:               ${allFiles.length}`)
+console.log(`lines:               ${totalLines}`)
+console.log(`resolved edges:      ${resolvedEdges}`)
+console.log(`unresolved internal: ${unresolvedInternal}`)
+console.log(`suspects (score>=3): ${suspects.length}`)
+console.log(`wrote ${path.relative(REPO, OUT_DIR)}/inventory.{jsonl,md}`)

--- a/scripts/audit/find-duplicate-logic.mjs
+++ b/scripts/audit/find-duplicate-logic.mjs
@@ -1,0 +1,425 @@
+// scripts/audit/find-duplicate-logic.mjs
+/**
+ * Finds the same logic implemented more than once.
+ *
+ * Three lenses, weakest precision last:
+ *   1. Name collisions   — the same exported name defined in several modules.
+ *   2. Copy-paste        — identical bodies after erasing literals; catches
+ *                          renamed copies, which a name histogram misses.
+ *   3. Structural        — identical bodies after erasing every local name too;
+ *                          catches the same algorithm written from scratch.
+ *
+ * Results roll up into module pairs, so the question is "these two modules
+ * overlap" rather than a list of individual functions.
+ *
+ * Emits plans/cleanup/code/sweeps/duplicate-logic.md
+ *
+ * Usage: node scripts/audit/find-duplicate-logic.mjs [--min-tokens 30]
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const OUT = path.join(REPO, 'plans/cleanup/code/sweeps')
+const MIN_TOKENS = Number(process.argv[process.argv.indexOf('--min-tokens') + 1]) || 30
+
+const git = (args) =>
+  execFileSync('git', args, { cwd: REPO, encoding: 'utf8', maxBuffer: 1024 * 1024 * 512 })
+
+const files = git(['ls-files', '*.ts', '*.tsx'])
+  .split('\n')
+  .filter(Boolean)
+  .filter((f) => /^(apps|packages)\/[^/]+\/(src|scripts)\//.test(f))
+  .filter((f) => !f.includes('/node_modules/') && !f.includes('/dist/'))
+  .filter((f) => !f.endsWith('.d.ts'))
+  .filter((f) => !f.startsWith('packages/e2e/'))
+
+const classify = (file) => {
+  if (
+    /(^|\/)(__tests__|__integration__|__mocks__|tests?)\//.test(file) ||
+    /\.(test|spec)\.[cm]?tsx?$/.test(file)
+  )
+    return 'test'
+  if (/\/(data-migrations|entity-migrations)\//.test(file)) return 'migration'
+  if (/\/scripts\//.test(file)) return 'script'
+  return 'prod'
+}
+
+/** The module a file belongs to — the unit findings roll up to. */
+function moduleOf(file) {
+  const m =
+    file.match(/^((?:apps|packages)\/[^/]+\/src\/[^/]+\/[^/]+)\//) ||
+    file.match(/^((?:apps|packages)\/[^/]+\/src\/[^/]+)\//) ||
+    file.match(/^((?:apps|packages)\/[^/]+\/(?:src|scripts))\//)
+  return m ? m[1] : path.dirname(file)
+}
+
+// ---------------------------------------------------------------------------
+// Declaration extraction
+// ---------------------------------------------------------------------------
+
+/** Names that carry no information about what the code does. */
+const IGNORED_NAMES = new Set([
+  'default',
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+  'generateMetadata',
+  'generateStaticParams',
+  'metadata',
+  'viewport',
+  'config',
+  'handler',
+  'Page',
+  'Layout',
+  'Loading',
+  'Error',
+  'NotFound',
+  'middleware',
+  'runtime',
+  'dynamic',
+  'revalidate',
+  'index',
+  'main',
+  'run',
+  'up',
+  'down',
+])
+
+const DECL_RE =
+  /(?:^|\n)[ \t]*(export\s+)?(?:async\s+)?(?:function\s+([A-Za-z_$][\w$]*)|const\s+([A-Za-z_$][\w$]*)\s*(?::[^=\n]+)?=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*(?::[^=>\n]+)?=>)/g
+
+/** Reads a balanced `{...}` or a single-expression arrow body from `start`. */
+function readBody(src, start) {
+  let i = start
+  const n = src.length
+  while (i < n && /\s/.test(src[i])) i++
+  if (i >= n) return null
+  const braced = src[i] === '{'
+  let depth = 0
+  const from = i
+  while (i < n) {
+    const c = src[i]
+    if (c === "'" || c === '"' || c === '`') {
+      const q = c
+      i++
+      while (i < n) {
+        if (src[i] === '\\') {
+          i += 2
+          continue
+        }
+        if (src[i] === q) break
+        if (q === '`' && src[i] === '$' && src[i + 1] === '{') {
+          let d = 1
+          i += 2
+          while (i < n && d > 0) {
+            if (src[i] === '{') d++
+            else if (src[i] === '}') d--
+            i++
+          }
+          continue
+        }
+        i++
+      }
+      i++
+      continue
+    }
+    if (c === '/' && src[i + 1] === '/') {
+      while (i < n && src[i] !== '\n') i++
+      continue
+    }
+    if (c === '/' && src[i + 1] === '*') {
+      const e = src.indexOf('*/', i)
+      if (e < 0) return null
+      i = e + 2
+      continue
+    }
+    if (c === '{' || c === '(' || c === '[') depth++
+    else if (c === '}' || c === ')' || c === ']') {
+      depth--
+      if (braced && depth === 0) return src.slice(from, i + 1)
+      if (depth < 0) return src.slice(from, i)
+    } else if (!braced && depth === 0 && (c === '\n' || c === ';')) {
+      return src.slice(from, i)
+    }
+    i++
+  }
+  return null
+}
+
+/** Language keywords and globals that must survive structural normalisation. */
+const KEYWORDS = new Set([
+  'if',
+  'else',
+  'for',
+  'while',
+  'do',
+  'switch',
+  'case',
+  'break',
+  'continue',
+  'return',
+  'throw',
+  'try',
+  'catch',
+  'finally',
+  'new',
+  'delete',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'await',
+  'async',
+  'function',
+  'const',
+  'let',
+  'var',
+  'class',
+  'extends',
+  'super',
+  'this',
+  'null',
+  'undefined',
+  'true',
+  'false',
+  'void',
+  'yield',
+  'as',
+  'satisfies',
+  'is',
+  'keyof',
+  'readonly',
+])
+
+const TOKEN_RE =
+  /"S"|[A-Za-z_$][\w$]*|=>|===|!==|==|!=|<=|>=|&&|\|\||\?\?|\.\.\.|[.,;:(){}[\]?!<>=+\-*/%&|^~]/g
+
+function tokenize(body) {
+  const lit = body
+    .replace(/`(?:[^`\\]|\\.)*`/g, '"S"')
+    .replace(/'(?:[^'\\]|\\.)*'/g, '"S"')
+    .replace(/"(?:[^"\\]|\\.)*"/g, '"S"')
+    .replace(/\/\/[^\n]*/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\b\d+(\.\d+)?\b/g, '0')
+  return lit.match(TOKEN_RE) ?? []
+}
+
+/** Literals erased, names kept — a renamed copy-paste still matches. */
+const sigCopy = (tokens) => tokens.join(' ')
+/** Local names erased too — the same algorithm rewritten still matches. */
+const sigStruct = (tokens) =>
+  tokens.map((t) => (/^[A-Za-z_$][\w$]*$/.test(t) && !KEYWORDS.has(t) ? '_' : t)).join(' ')
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+
+const decls = []
+
+for (const file of files) {
+  let src
+  try {
+    src = readFileSync(path.join(REPO, file), 'utf8')
+  } catch {
+    continue
+  }
+  const lineAt = (idx) => src.slice(0, idx).split('\n').length
+
+  DECL_RE.lastIndex = 0
+  let m
+  while ((m = DECL_RE.exec(src))) {
+    const name = m[2] ?? m[3]
+    if (!name) continue
+    const bodyStart = m[3]
+      ? src.indexOf('=>', m.index + m[0].length - 2) + 2
+      : src.indexOf('{', m.index + m[0].length)
+    if (bodyStart <= 0) continue
+    const body = readBody(src, bodyStart)
+    if (!body) continue
+    const tokens = tokenize(body)
+    if (tokens.length < MIN_TOKENS) continue
+    decls.push({
+      file,
+      line: lineAt(m.index),
+      name,
+      exported: Boolean(m[1]),
+      module: moduleOf(file),
+      class: classify(file),
+      tokens: tokens.length,
+      body,
+      copy: sigCopy(tokens),
+      struct: sigStruct(tokens),
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster
+// ---------------------------------------------------------------------------
+
+function cluster(items, key, { crossModule = true } = {}) {
+  const map = new Map()
+  for (const it of items) {
+    const k = key(it)
+    if (!k) continue
+    if (!map.has(k)) map.set(k, [])
+    map.get(k).push(it)
+  }
+  return [...map.entries()]
+    .filter(([, l]) => l.length >= 2)
+    .map(([k, l]) => ({
+      key: k,
+      list: l,
+      modules: new Set(l.map((i) => i.module)),
+      prod: l.filter((i) => i.class === 'prod'),
+      tokens: l[0].tokens,
+    }))
+    .filter((c) => (crossModule ? c.modules.size > 1 : true))
+    .filter((c) => new Set(c.prod.map((i) => i.module)).size > 1)
+    .sort((a, b) => b.list.length * b.tokens - a.list.length * a.tokens)
+}
+
+const byName = cluster(
+  decls.filter((d) => d.exported && !IGNORED_NAMES.has(d.name)),
+  (d) => d.name
+)
+const byCopy = cluster(decls, (d) => d.copy)
+const copyKeys = new Set(byCopy.map((c) => c.key))
+const byStruct = cluster(decls, (d) => d.struct).filter(
+  (c) => !c.list.every((i) => copyKeys.has(i.copy))
+)
+
+/** Module pairs that keep showing up together across all three lenses. */
+const pairs = new Map()
+for (const c of [...byCopy, ...byStruct, ...byName]) {
+  const mods = [...new Set(c.prod.map((i) => i.module))].sort()
+  for (let a = 0; a < mods.length; a++) {
+    for (let b = a + 1; b < mods.length; b++) {
+      const k = `${mods[a]} ⇄ ${mods[b]}`
+      if (!pairs.has(k)) pairs.set(k, { key: k, hits: 0, tokens: 0, samples: [] })
+      const p = pairs.get(k)
+      p.hits++
+      p.tokens += c.tokens
+      if (p.samples.length < 4) p.samples.push(c.list[0].name)
+    }
+  }
+}
+const pairRows = [...pairs.values()].filter((p) => p.hits >= 2).sort((a, b) => b.hits - a.hits)
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const fmt = (n) => n.toLocaleString('en-US')
+const short = (m) => m.replace(/^(apps|packages)\//, '')
+const trim = (s, n = 260) => {
+  const one = s.replace(/\s+/g, ' ').trim()
+  return one.length > n ? `${one.slice(0, n)}…` : one
+}
+
+const render = (c, i) => {
+  const sites = c.list
+    .slice(0, 10)
+    .map(
+      (s) =>
+        `  - \`${s.name}\` — \`${s.file}:${s.line}\`${s.class === 'prod' ? '' : ` _(${s.class})_`}`
+    )
+    .join('\n')
+  const more = c.list.length > 10 ? `\n  - _…${c.list.length - 10} more_` : ''
+  return `#### ${i + 1}. ${c.list.length}× · ${c.tokens} tokens · ${c.modules.size} modules
+
+\`\`\`ts
+${trim(c.list[0].body, 320)}
+\`\`\`
+
+${sites}${more}
+`
+}
+
+const md = `# Sweep — Duplicate logic
+
+> Generated by \`scripts/audit/find-duplicate-logic.mjs\`. Re-run, don't hand-edit.
+> Verdicts go in \`../decisions.md\`.
+
+**Generated:** ${new Date().toISOString().slice(0, 10)}
+**Scanned:** ${fmt(files.length)} files · **${fmt(decls.length)}** declarations of ≥${MIN_TOKENS} tokens
+
+## Method
+
+Every top-level function and arrow const is tokenised and hashed twice:
+
+- **Copy-paste** — literals erased, names kept. Matches survive a rename, so this
+  finds copies that a name search never would.
+- **Structural** — every local identifier erased as well. Matches are the same
+  algorithm written independently. Lower precision: read before believing.
+- **Name collisions** — the same exported name defined in several modules. Cheap,
+  and often the fastest route to "we built this twice".
+
+Only clusters spanning **2+ production modules** are reported. Repetition inside
+one module is usually deliberate; migrations, tests and scripts are tagged and
+excluded from the module count for the reasons in \`duplicate-queries.md\`.
+
+## Areas — module pairs (${pairRows.length})
+
+Modules that collide repeatedly. This is the decision unit: one question per pair,
+not per function.
+
+| Module A ⇄ Module B | Shared | Examples |
+|---|---:|---|
+${pairRows
+  .slice(0, 30)
+  .map((p) => `| \`${short(p.key)}\` | ${p.hits} | ${p.samples.join(', ')} |`)
+  .join('\n')}
+
+## Copy-paste duplicates (${byCopy.length} clusters)
+
+Identical after erasing literals — the same code, possibly renamed.
+
+${byCopy.slice(0, 25).map(render).join('\n')}
+
+## Structural duplicates (${byStruct.length} clusters)
+
+Same shape, different names throughout. Candidates, not findings.
+
+${byStruct.slice(0, 20).map(render).join('\n')}
+
+## Exported name collisions (${byName.length})
+
+The same exported name in more than one production module. A collision is not
+automatically a duplicate — check whether the bodies agree.
+
+| Name | Defined in | Locations |
+|---|---:|---|
+${byName
+  .slice(0, 60)
+  .map(
+    (c) =>
+      `| \`${c.list[0].name}\` | ${c.modules.size} | ${[
+        ...new Set(c.list.map((i) => short(i.module))),
+      ]
+        .slice(0, 5)
+        .map((m) => `\`${m}\``)
+        .join(', ')} |`
+  )
+  .join('\n')}
+`
+
+mkdirSync(OUT, { recursive: true })
+writeFileSync(path.join(OUT, 'duplicate-logic.md'), md)
+
+console.log(`files scanned:      ${files.length}`)
+console.log(`declarations:       ${decls.length}`)
+console.log(`copy-paste:         ${byCopy.length}`)
+console.log(`structural:         ${byStruct.length}`)
+console.log(`name collisions:    ${byName.length}`)
+console.log(`module pairs:       ${pairRows.length}`)
+console.log(`wrote plans/cleanup/code/sweeps/duplicate-logic.md`)

--- a/scripts/audit/find-duplicate-queries.mjs
+++ b/scripts/audit/find-duplicate-queries.mjs
@@ -1,0 +1,575 @@
+// scripts/audit/find-duplicate-queries.mjs
+/**
+ * Finds Drizzle query chains and raw `sql` templates that are structurally the
+ * same query written more than once.
+ *
+ * Two call sites collapse to the same signature when they differ only in
+ * variable names, literals, and (at shape level) projection/ordering/paging.
+ * That is the definition of "pretty much identical" that matters here: the same
+ * question asked of the same tables with the same filters.
+ *
+ * Emits plans/cleanup/code/sweeps/duplicate-queries.md
+ *
+ * Usage: node scripts/audit/find-duplicate-queries.mjs [--min 2]
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const OUT = path.join(REPO, 'plans/cleanup/code/sweeps')
+const MIN = Number(process.argv[process.argv.indexOf('--min') + 1]) || 2
+
+const git = (args) =>
+  execFileSync('git', args, { cwd: REPO, encoding: 'utf8', maxBuffer: 1024 * 1024 * 512 })
+
+const files = git(['ls-files', '*.ts', '*.tsx'])
+  .split('\n')
+  .filter(Boolean)
+  .filter((f) => /^(apps|packages)\/[^/]+\/(src|scripts)\//.test(f))
+  .filter((f) => !f.includes('/node_modules/') && !f.includes('/dist/'))
+  .filter((f) => !f.endsWith('.d.ts'))
+  .filter((f) => !f.startsWith('packages/e2e/'))
+
+// ---------------------------------------------------------------------------
+// Chain extraction
+// ---------------------------------------------------------------------------
+
+/** Anchors that begin a query chain, however the chain is line-wrapped. */
+const CHAIN_START =
+  /\b(?:ctx\.db|this\.db|trx|tx|db)\s*\.\s*(?:select|selectDistinct|selectDistinctOn|insert|update|delete|execute|query)\b/g
+
+/**
+ * Walks forward from `start` to the end of the method chain, honouring string,
+ * template, comment and bracket nesting. The chain ends at depth 0 when the
+ * next meaningful character is not a `.` continuing it.
+ */
+function readChain(src, start) {
+  let i = start
+  let depth = 0
+  const n = src.length
+  while (i < n) {
+    const c = src[i]
+    // strings / templates
+    if (c === "'" || c === '"' || c === '`') {
+      const quote = c
+      i++
+      while (i < n) {
+        if (src[i] === '\\') {
+          i += 2
+          continue
+        }
+        if (quote === '`' && src[i] === '$' && src[i + 1] === '{') {
+          let d = 1
+          i += 2
+          while (i < n && d > 0) {
+            if (src[i] === '{') d++
+            else if (src[i] === '}') d--
+            i++
+          }
+          continue
+        }
+        if (src[i] === quote) break
+        i++
+      }
+      i++
+      continue
+    }
+    if (c === '/' && src[i + 1] === '/') {
+      while (i < n && src[i] !== '\n') i++
+      continue
+    }
+    if (c === '/' && src[i + 1] === '*') {
+      i = src.indexOf('*/', i)
+      if (i < 0) return null
+      i += 2
+      continue
+    }
+    if (c === '(' || c === '[' || c === '{') {
+      depth++
+      i++
+      continue
+    }
+    if (c === ')' || c === ']' || c === '}') {
+      if (depth === 0) break // closing bracket that belongs to our caller
+      depth--
+      i++
+      continue
+    }
+    if (depth === 0) {
+      // at chain level: whitespace is only allowed if a `.` follows
+      if (/\s/.test(c)) {
+        let j = i
+        while (j < n && /\s/.test(src[j])) j++
+        if (src[j] === '.') {
+          i = j
+          continue
+        }
+        break
+      }
+      if (/[;,)\]}]/.test(c)) break
+    }
+    i++
+  }
+  return src.slice(start, i)
+}
+
+// ---------------------------------------------------------------------------
+// Normalisation
+// ---------------------------------------------------------------------------
+
+/** Drizzle + SQL vocabulary that carries meaning and must survive normalisation. */
+const KEEP = new Set([
+  'db',
+  'ctx',
+  'this',
+  'tx',
+  'trx',
+  'select',
+  'selectDistinct',
+  'selectDistinctOn',
+  'from',
+  'where',
+  'orderBy',
+  'groupBy',
+  'having',
+  'limit',
+  'offset',
+  'innerJoin',
+  'leftJoin',
+  'rightJoin',
+  'fullJoin',
+  'crossJoin',
+  'insert',
+  'into',
+  'values',
+  'update',
+  'set',
+  'delete',
+  'returning',
+  'onConflictDoUpdate',
+  'onConflictDoNothing',
+  'execute',
+  'query',
+  'findFirst',
+  'findMany',
+  'with',
+  'columns',
+  'extras',
+  'as',
+  'for',
+  'union',
+  'unionAll',
+  'intersect',
+  'except',
+  '$dynamic',
+  'and',
+  'or',
+  'not',
+  'eq',
+  'ne',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'isNull',
+  'isNotNull',
+  'inArray',
+  'notInArray',
+  'like',
+  'ilike',
+  'notLike',
+  'notIlike',
+  'between',
+  'notBetween',
+  'exists',
+  'notExists',
+  'arrayContains',
+  'arrayContained',
+  'arrayOverlaps',
+  'asc',
+  'desc',
+  'sql',
+  'count',
+  'countDistinct',
+  'sum',
+  'avg',
+  'min',
+  'max',
+  'coalesce',
+  'lower',
+  'upper',
+  'getTableColumns',
+  'alias',
+  'aliasedTable',
+  'raw',
+  'join',
+  'on',
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'await',
+  'return',
+])
+
+const TOKEN_RE = /'S'|[A-Za-z_$][A-Za-z0-9_$]*|=>|\?\?|[.,(){}[\]:?!<>=+\-*/%&|`]/g
+
+/**
+ * Structural signature. Literals become `'S'`/`N`; local variable names become
+ * `V`; table and column identifiers (PascalCase, and the `.prop` after them)
+ * survive, because they are what makes two queries the same query.
+ */
+function normalize(chain) {
+  const lit = chain
+    .replace(/`(?:[^`\\]|\\.)*`/g, "'S'")
+    .replace(/'(?:[^'\\]|\\.)*'/g, "'S'")
+    .replace(/"(?:[^"\\]|\\.)*"/g, "'S'")
+    .replace(/\b\d+(\.\d+)?\b/g, 'N')
+
+  const out = []
+  let prevWasTableDot = false
+  let m
+  TOKEN_RE.lastIndex = 0
+  while ((m = TOKEN_RE.exec(lit))) {
+    const t = m[0]
+    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(t)) {
+      if (prevWasTableDot) {
+        out.push(t) // column name on a known table
+        prevWasTableDot = false
+        continue
+      }
+      if (/^[A-Z]/.test(t)) {
+        out.push(t) // table / enum / type
+        prevWasTableDot = lit[TOKEN_RE.lastIndex] === '.'
+        continue
+      }
+      out.push(KEEP.has(t) ? t : 'V')
+      prevWasTableDot = false
+      continue
+    }
+    prevWasTableDot = false
+    if (/\s/.test(t)) continue
+    out.push(t)
+  }
+  return out.join('')
+}
+
+/** Looser signature: same tables + same filters, ignoring projection and paging. */
+function shapeOf(sig) {
+  return sig
+    .replace(/select\([^)]*\)/g, 'select(*)')
+    .replace(/\.orderBy\([^()]*(\([^()]*\))?[^()]*\)/g, '')
+    .replace(/\.limit\([^)]*\)/g, '')
+    .replace(/\.offset\([^)]*\)/g, '')
+    .replace(/\.columns\(\{[^}]*\}\)/g, '')
+}
+
+/** Tables referenced, for grouping the report by domain. */
+function tablesOf(sig) {
+  const set = new Set()
+  for (const m of sig.matchAll(/\b([A-Z][A-Za-z0-9_]*)\b/g)) set.add(m[1])
+  return [...set]
+}
+
+/**
+ * Reads a template literal starting at the opening backtick, replacing each
+ * `${...}` with `?`. Handles nested templates inside interpolations, which is
+ * where a regex-based reader silently truncates.
+ */
+function readTemplate(src, openIdx) {
+  let i = openIdx + 1
+  const n = src.length
+  let out = ''
+  while (i < n) {
+    const c = src[i]
+    if (c === '\\') {
+      out += src.slice(i, i + 2)
+      i += 2
+      continue
+    }
+    if (c === '`') return out
+    if (c === '$' && src[i + 1] === '{') {
+      let depth = 1
+      i += 2
+      while (i < n && depth > 0) {
+        const d = src[i]
+        if (d === '`') {
+          const inner = readTemplate(src, i)
+          if (inner === null) return null
+          i += inner.length + 2 // crude but only used to skip
+          continue
+        }
+        if (d === '{') depth++
+        else if (d === '}') depth--
+        i++
+      }
+      out += '?'
+      continue
+    }
+    out += c
+    i++
+  }
+  return null
+}
+
+/** Where a call site lives — migrations and tests are deliberately repetitive. */
+function classify(file) {
+  if (
+    /(^|\/)(__tests__|__integration__|__mocks__|tests?)\//.test(file) ||
+    /\.(test|spec)\.[cm]?tsx?$/.test(file)
+  )
+    return 'test'
+  if (/\/(data-migrations|entity-migrations)\//.test(file)) return 'migration'
+  if (/\/scripts\//.test(file)) return 'script'
+  return 'prod'
+}
+
+/** The table a query is actually about. */
+function primaryTable(sig) {
+  // `schema.` normalises to `V.`, so both spellings have to be accepted here.
+  const q = '(?:schema\\.|V\\.)?'
+  const m =
+    sig.match(new RegExp(`\\.from\\(${q}([A-Z][A-Za-z0-9_]*)`)) ||
+    sig.match(new RegExp(`\\.(?:update|insert|delete)\\(${q}([A-Z][A-Za-z0-9_]*)`)) ||
+    sig.match(/\.query\.([A-Za-z0-9_]+)/)
+  return m ? m[1] : '—'
+}
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+
+const chains = []
+const rawSql = []
+
+for (const file of files) {
+  let src
+  try {
+    src = readFileSync(path.join(REPO, file), 'utf8')
+  } catch {
+    continue
+  }
+  const lineAt = (idx) => src.slice(0, idx).split('\n').length
+
+  CHAIN_START.lastIndex = 0
+  let m
+  while ((m = CHAIN_START.exec(src))) {
+    const chain = readChain(src, m.index)
+    if (!chain || chain.length < 40) continue
+    const sig = normalize(chain)
+    if (sig.length < 40) continue
+    chains.push({ file, line: lineAt(m.index), text: chain, sig, shape: shapeOf(sig) })
+    CHAIN_START.lastIndex = m.index + chain.length
+  }
+
+  // raw sql`` templates — scanned, not regexed: interpolations nest further
+  // templates (`sql.join(conds, sql\` OR \`)`) and a regex mis-terminates there.
+  for (const t of src.matchAll(/\bsql(?:<[^>]*>)?\s*`/g)) {
+    const body = readTemplate(src, t.index + t[0].length - 1)
+    if (body === null) continue
+    const norm = body.replace(/\s+/g, ' ').trim()
+    if (norm.length < 25) continue
+    rawSql.push({ file, line: lineAt(t.index), text: norm, sig: norm.toLowerCase() })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster
+// ---------------------------------------------------------------------------
+
+function cluster(items, key) {
+  const map = new Map()
+  for (const it of items) {
+    const k = key(it)
+    if (!map.has(k)) map.set(k, [])
+    map.get(k).push(it)
+  }
+  return [...map.entries()]
+    .filter(([, list]) => list.length >= MIN)
+    .map(([k, list]) => {
+      const classes = new Set(list.map((i) => classify(i.file)))
+      const prodSites = list.filter((i) => classify(i.file) === 'prod')
+      return {
+        key: k,
+        list,
+        classes: [...classes],
+        prodSites: prodSites.length,
+        prodFiles: new Set(prodSites.map((i) => i.file)).size,
+        table: primaryTable(k),
+        files: new Set(list.map((i) => i.file)).size,
+        weight: list.length * (list[0].text.length / 100),
+      }
+    })
+    .sort((a, b) => b.weight - a.weight)
+}
+
+const exact = cluster(chains, (c) => c.sig)
+const shape = cluster(chains, (c) => c.shape)
+// Only report a shape cluster when it adds something the exact pass didn't.
+const exactKeys = new Set(exact.map((c) => c.key))
+const shapeOnly = shape.filter((c) => !c.list.every((i) => exactKeys.has(i.sig)))
+const raws = cluster(rawSql, (c) => c.sig)
+const areaRows = areas([exact, shapeOnly])
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const fmt = (n) => n.toLocaleString('en-US')
+const trim = (s, n = 400) => {
+  const one = s.replace(/\s+/g, ' ').trim()
+  return one.length > n ? `${one.slice(0, n)}…` : one
+}
+
+const renderCluster = (c, i) => {
+  const sites = c.list
+    .map((s) => {
+      const cls = classify(s.file)
+      return `  - \`${s.file}:${s.line}\`${cls === 'prod' ? '' : ` _(${cls})_`}`
+    })
+    .slice(0, 12)
+    .join('\n')
+  const more = c.list.length > 12 ? `\n  - _…${c.list.length - 12} more_` : ''
+  const tables = tablesOf(c.key).slice(0, 6).join(', ') || '—'
+  return `#### ${i + 1}. ${c.list.length}× across ${c.files} file${c.files === 1 ? '' : 's'} — ${tables}
+
+\`\`\`ts
+${trim(c.list[0].text, 500)}
+\`\`\`
+
+${sites}${more}
+`
+}
+
+const crossFile = (list) => list.filter((c) => c.files > 1)
+/** Production duplication — what's actually worth a shared helper. */
+const prodWorthy = (list) => list.filter((c) => c.prodFiles > 1)
+
+/**
+ * Roll clusters up to one row per table. This is the decision unit: "Integration
+ * lookups are hand-rolled in 17 files" is a question you can answer once,
+ * where 27 individual clusters is a list nobody reads.
+ */
+function areas(clusterLists) {
+  const map = new Map()
+  for (const c of clusterLists.flat()) {
+    if (c.prodFiles < 2) continue
+    if (!map.has(c.table))
+      map.set(c.table, { table: c.table, clusters: 0, sites: 0, files: new Set(), top: c })
+    const a = map.get(c.table)
+    a.clusters++
+    a.sites += c.prodSites
+    for (const s of c.list) if (classify(s.file) === 'prod') a.files.add(s.file)
+    if (c.prodSites > a.top.prodSites) a.top = c
+  }
+  return [...map.values()].sort((a, b) => b.sites - a.sites || b.files.size - a.files.size)
+}
+
+const md = `# Sweep — Duplicate queries
+
+> Generated by \`scripts/audit/find-duplicate-queries.mjs\`. Re-run, don't hand-edit.
+> Verdicts go in \`../decisions.md\`.
+
+**Generated:** ${new Date().toISOString().slice(0, 10)}
+**Scanned:** ${fmt(files.length)} files · **${fmt(chains.length)}** Drizzle chains · **${fmt(rawSql.length)}** raw \`sql\` templates
+
+## Method
+
+Each query chain is reduced to a structural signature: string/number literals are
+erased, local variable names collapse to \`V\`, and table + column identifiers are
+kept — those are what make two queries *the same query*. Sites that then hash
+alike differ only in naming, not in what they ask the database.
+
+- **Exact** — identical after that normalisation, projection included.
+- **Shape** — identical tables and filters, ignoring projection, ordering and paging.
+  Looser, so read these as candidates rather than as findings.
+- Clusters confined to a single file are usually a legitimate local pattern; the
+  cross-file ones are where a shared helper is missing.
+
+### What is excluded from the ranking, and why
+
+Sites are tagged \`prod\` / \`test\` / \`migration\` / \`script\`, and only clusters
+spanning **2+ production files** are ranked. Repetition in the other three is
+mostly correct:
+
+- **Migrations are frozen snapshots.** \`data-migrations/\` and \`entity-migrations/\`
+  write raw Drizzle deliberately — a shared helper would change what an already-run
+  migration did. Do not dedupe these.
+- **Tests** repeat setup on purpose; a shared fixture is a different, smaller call.
+- **Scripts** are one-off operational tools.
+
+## Areas (${areaRows.length})
+
+One row per table. This is the decision unit — answer it once per table rather
+than reading ${prodWorthy(exact).length + prodWorthy(shapeOnly).length} individual clusters.
+
+| Table | Dup sites | Prod files | Clusters | Largest cluster |
+|---|---:|---:|---:|---|
+${areaRows
+  .map(
+    (a) =>
+      `| \`${a.table}\` | ${a.sites} | ${a.files.size} | ${a.clusters} | ${a.top.prodSites}× — ${trim(
+        a.top.list[0].text,
+        90
+      )} |`
+  )
+  .join('\n')}
+
+## Exact duplicates — 2+ production files (${prodWorthy(exact).length} clusters)
+
+${prodWorthy(exact).slice(0, 30).map(renderCluster).join('\n')}
+
+## Shape duplicates — 2+ production files (${prodWorthy(shapeOnly).length} clusters)
+
+Same tables and filters, different projection/paging.
+
+${prodWorthy(shapeOnly).slice(0, 25).map(renderCluster).join('\n')}
+
+## Raw \`sql\` template duplicates (${raws.length} clusters)
+
+${raws
+  .slice(0, 25)
+  .map(
+    (c, i) =>
+      `#### ${i + 1}. ${c.list.length}× across ${c.files} file${c.files === 1 ? '' : 's'}\n\n\`\`\`sql\n${trim(
+        c.list[0].text,
+        300
+      )}\n\`\`\`\n\n${c.list
+        .map((s) => `  - \`${s.file}:${s.line}\``)
+        .slice(0, 10)
+        .join('\n')}${c.list.length > 10 ? `\n  - _…${c.list.length - 10} more_` : ''}\n`
+  )
+  .join('\n')}
+
+## Single-file repeats
+
+${exact.length - crossFile(exact).length} exact clusters live inside one file — local
+patterns, lower priority, listed in full only on request.
+`
+
+mkdirSync(OUT, { recursive: true })
+writeFileSync(path.join(OUT, 'duplicate-queries.md'), md)
+// Full cluster data — the markdown only shows the top N per section.
+writeFileSync(
+  path.join(OUT, 'duplicate-queries.json'),
+  JSON.stringify(
+    {
+      exact: exact.map((c) => ({ ...c, list: c.list, modules: undefined })),
+      shapeOnly: shapeOnly.map((c) => ({ ...c, list: c.list })),
+      raw: raws.map((c) => ({ ...c, list: c.list })),
+    },
+    (k, v) => (k === 'key' ? undefined : v),
+    1,
+  ),
+)
+
+console.log(`files scanned:        ${files.length}`)
+console.log(`drizzle chains:       ${chains.length}`)
+console.log(`raw sql templates:    ${rawSql.length}`)
+console.log(`exact clusters:       ${exact.length} (${crossFile(exact).length} cross-file)`)
+console.log(`shape-only clusters:  ${shapeOnly.length} (${crossFile(shapeOnly).length} cross-file)`)
+console.log(`raw sql clusters:     ${raws.length}`)
+console.log(`wrote plans/cleanup/code/sweeps/duplicate-queries.md`)


### PR DESCRIPTION
Three read-only audit scripts backing the codebase-cleanup effort. Reports are written to `plans/cleanup/code/`, which is gitignored — only the tooling is tracked here. Each script regenerates its own output; nothing is hand-maintained.

Run them with plain `node`, no deps:

```bash
node scripts/audit/build-inventory.mjs
node scripts/audit/find-duplicate-queries.mjs
node scripts/audit/find-duplicate-logic.mjs
```

## `build-inventory.mjs`

Enumerates **1,201 surfaces** (lib module, tRPC router, route group, UI component family, schema file) across 9,000 files and 1.29M lines, resolves the internal import graph (relative, `~/`, `@/`, and `@auxx/*` via each package's `exports` map — 40,069 edges, 9 unresolved), and scores each surface for dead-code triage.

The unit of decision is deliberately a surface, not a symbol, so review is ~200 area questions instead of ~50k symbol questions.

Signals are suppressed where they'd be structurally meaningless:

- **entrypoint** surfaces (Next routes, express routes, workers, seeds, scripts) are invoked, never imported — 0 importers proves nothing.
- **public-API** surfaces (177 `exports`-map targets) are reached across a package boundary.
- **tests** attach to the surface they cover rather than forming their own, and count as a separate importer class — so "kept alive only by its own tests" becomes visible instead of reading as healthy.

Known blind spots are documented in the generated report rather than left implicit.

## `find-duplicate-queries.mjs`

Reduces Drizzle chains (3,569) and raw `sql` templates (352) to structural signatures — string/number literals erased, local variable names collapsed to `V`, table and column identifiers kept, since those are what make two queries *the same query*. Clusters at two levels: exact, and shape (ignoring projection/ordering/paging).

Sites are tagged `prod` / `test` / `migration` / `script`, and only clusters spanning 2+ **production** files are ranked. That exclusion matters: `data-migrations/` and `entity-migrations/` write raw Drizzle deliberately, and a shared helper would change what an already-run migration did.

Output rolls up to one row per table.

## `find-duplicate-logic.mjs`

Three lenses over 9,574 declarations:

- **copy-paste** — identical after erasing literals; survives a rename, which a name search does not.
- **structural** — identical after erasing every local identifier; the same algorithm written independently.
- **name collisions** — the same exported name in several modules.

Rolls up into module pairs, so the question is "these two modules overlap" rather than a list of functions.

## What they found

Surface-level dead code is thin — 15 suspects, ~2,900 lines, 1,945 of it in one directory. Duplication is not:

| Finding | Scale |
|---|---|
| `Integration` lookups hand-rolled | 98 sites / 38 files / 20 clusters |
| Logo components triplicated | homepage ⇄ web ⇄ `web/src/constants/icons.tsx`, 47 components |
| Next query areas | `EntityInstance` 27, `Organization` 26, `User` 22, `Thread` 20 |
| Copy-paste / structural / name clusters | 78 / 68 / 78 |

Spot-verified by hand: `apps/web/src/components/logos` (44 files, no references incl. no dynamic path), `haversineMeters` (2 modules), `isSameDay` (3 modules), and the `getCreatable/Updatable/Required/ReadOnlyFields` quartet duplicated between `resources/crud-definitions.ts` and `resources/registry/index.ts`.

## Notes for review

- No production code touched — three new files under `scripts/audit/`, all read-only (`git ls-files`, `git log`, file reads).
- Biome-clean.
- Scores are a triage sort order, not verdicts; the approach doc requires two independent signals before anything is deleted.