### PR TITLE
fix: resolve aliased field refs and report concrete LLM client names

### DIFF
--- a/apps/web/src/components/resources/store/resource-store.test.ts
+++ b/apps/web/src/components/resources/store/resource-store.test.ts
@@ -29,10 +29,32 @@ const idField = {
   isAppOwned: true,
 } as unknown as ResourceField
 
+/**
+ * A system-attributed field, as the Kopilot agents-builder addresses it:
+ * canonical ref is `def_orders:cf_2`, static key is `status`, and the
+ * systemAttribute — the form `list_entity_fields` reports — is `order_status`.
+ */
+const statusField = {
+  id: 'cf_2',
+  key: 'status',
+  label: 'Status',
+  type: 'string',
+  capabilities: {
+    filterable: true,
+    sortable: true,
+    creatable: true,
+    updatable: true,
+    configurable: true,
+  },
+  resourceFieldId: toResourceFieldId('def_orders', 'cf_2'),
+  systemAttribute: 'order_status',
+} as unknown as ResourceField
+
 const ordersResource = {
   id: 'def_orders',
   type: 'custom',
   apiSlug: 'shopify_orders',
+  entityType: 'shopify_order',
   entityDefinitionId: 'def_orders',
   organizationId: 'org_1',
   label: 'Order',
@@ -40,7 +62,7 @@ const ordersResource = {
   icon: 'box',
   color: 'blue',
   isVisible: true,
-  fields: [idField],
+  fields: [idField, statusField],
   display: {
     primaryDisplayField: null,
     secondaryDisplayField: null,
@@ -86,6 +108,35 @@ describe('getFieldByRef', () => {
     expect(getResourceStoreState().getFieldByRef(null)).toBeUndefined()
     expect(getResourceStoreState().getFieldByRef(undefined)).toBeUndefined()
   })
+
+  // Alias spellings. The agents-builder writes persona chips the way
+  // `list_entity_fields` reports fields (apiSlug def half + systemAttribute
+  // field half), and the server accepts that form — so the badge renderers
+  // behind useField have to resolve it too, or every AI-authored field chip
+  // renders as an unknown-field badge.
+  it('resolves an apiSlug def half against a canonical field half', () => {
+    const field = getResourceStoreState().getFieldByRef('shopify_orders:cf_1')
+    expect(field?.resourceFieldId).toBe('def_orders:cf_1')
+  })
+
+  it('resolves an entityType def half against a static key field half', () => {
+    const field = getResourceStoreState().getFieldByRef('shopify_order:status')
+    expect(field?.resourceFieldId).toBe('def_orders:cf_2')
+  })
+
+  it('resolves a systemAttribute field half under every def spelling', () => {
+    for (const ref of [
+      'def_orders:order_status',
+      'shopify_orders:order_status',
+      'shopify_order:order_status',
+    ]) {
+      expect(getResourceStoreState().getFieldByRef(ref)?.resourceFieldId).toBe('def_orders:cf_2')
+    }
+  })
+
+  it('does not resolve a systemAttribute against the wrong definition', () => {
+    expect(getResourceStoreState().getFieldByRef('def_missing:order_status')).toBeUndefined()
+  })
 })
 
 describe('useField', () => {
@@ -102,5 +153,11 @@ describe('useField', () => {
   it('returns undefined for an unresolvable ref', () => {
     const { result } = renderHook(() => useField('shopify_orders:@app:shopify:missing'))
     expect(result.current).toBeUndefined()
+  })
+
+  it('resolves an apiSlug + systemAttribute ref the same as the concrete one', () => {
+    const { result } = renderHook(() => useField('shopify_orders:order_status'))
+    expect(result.current?.resourceFieldId).toBe('def_orders:cf_2')
+    expect(result.current?.label).toBe('Status')
   })
 })

--- a/apps/web/src/components/resources/store/resource-store.ts
+++ b/apps/web/src/components/resources/store/resource-store.ts
@@ -1,9 +1,14 @@
 // apps/web/src/components/resources/store/resource-store.ts
 
 import type { CustomResource, Resource, ResourceField } from '@auxx/lib/resources/client'
-import { isCustomResource, resolveFieldRef } from '@auxx/lib/resources/client'
+import { isCustomResource, resolveFieldRef, resolveStaticPrefix } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
-import { parseAppFieldRef, parseResourceFieldId, toResourceFieldId } from '@auxx/types/field'
+import {
+  parseAppFieldRef,
+  parseResourceFieldId,
+  toFieldId,
+  toResourceFieldId,
+} from '@auxx/types/field'
 import { deepEqual, shallowEqual } from '@auxx/utils/objects'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
@@ -344,6 +349,52 @@ function staticKeyAliasId(
   const { entityDefinitionId, fieldId } = parseResourceFieldId(canonicalKey)
   if (field.key === fieldId) return undefined
   return toResourceFieldId(entityDefinitionId, field.key)
+}
+
+/**
+ * Resolve the ALIAS spellings of a `ResourceFieldId` that `fieldMap` cannot key
+ * directly, both halves independently:
+ *
+ * 1. Definition half — `entityType` / `apiSlug` → canonical entityDefinitionId
+ *    (`definitionIdByPrefix`). `fieldMap` is keyed by the canonical id only.
+ * 2. Field half — a `systemAttribute` (`ticket_status`). `fieldMap` registers a
+ *    field under its row id and its static `key` (`status`), never under the
+ *    systemAttribute; that spelling only exists in `systemAttributeByDef`.
+ *
+ * Both are the shapes external authors use — the Kopilot agents-builder, the
+ * SDK, and imports address fields the way `list_entity_fields` reports them
+ * (`getFieldOutputKey` = `systemAttribute ?? key`), and the server accepts them
+ * interchangeably with the canonical form.
+ *
+ * The systemAttribute lookup is deliberately scoped to the resolved definition
+ * and never falls back to the bare `systemAttributeMap`: a by-name lookup for a
+ * shared attribute (`inbox_name` is on both `inbox` and `personal_inbox`)
+ * returns the OTHER definition's field. Returns undefined when the ref is
+ * already canonical, unknown, or a late-bound `@app:` ref (`getFieldByRef`
+ * resolves those against the effective resource instead).
+ */
+function resolveAliasedFieldRef(
+  state: Pick<ResourceStoreState, 'fieldMap' | 'definitionIdByPrefix' | 'systemAttributeByDef'>,
+  ref: ResourceFieldId
+): ResourceField | undefined {
+  // Split on the FIRST colon only — the field half may itself contain colons.
+  const colonIndex = ref.indexOf(':')
+  if (colonIndex === -1) return undefined
+  const defSegment = ref.slice(0, colonIndex)
+  const fieldHalf = ref.slice(colonIndex + 1)
+  if (fieldHalf.startsWith('@app:')) return undefined
+
+  const canonicalDef =
+    resolveStaticPrefix(defSegment) ?? state.definitionIdByPrefix.get(defSegment) ?? defSegment
+
+  // Alias def half with an already-resolvable field half (row id or static key).
+  if (canonicalDef !== defSegment) {
+    const byDef = state.fieldMap[toResourceFieldId(canonicalDef, toFieldId(fieldHalf))]
+    if (byDef) return byDef
+  }
+
+  const attrRef = state.systemAttributeByDef[`${canonicalDef}:${fieldHalf}`]
+  return attrRef ? state.fieldMap[attrRef] : undefined
 }
 
 /**
@@ -716,6 +767,14 @@ export const useResourceStore = create<ResourceStoreState>()(
       // stable reference (keeps the field hooks granular).
       const direct = get().fieldMap[ref as ResourceFieldId]
       if (direct) return direct
+      // Alias forms. External authors (the Kopilot agents-builder, the SDK, imports)
+      // address fields the way `list_entity_fields` reports them — an apiSlug or
+      // entityType def half, and a systemAttribute field half (`tickets:ticket_status`).
+      // The server treats those as interchangeable with the canonical row-id form
+      // (`getFieldOutputKey`), so resolve them here rather than letting every caller
+      // render an unknown field. `@app:` refs keep their encoding for the branch below.
+      const aliased = resolveAliasedFieldRef(get(), ref as ResourceFieldId)
+      if (aliased) return aliased
       // Late-bound `@app:` ref → resolve to the now-created column by appFieldKey. The
       // def segment is an apiSlug (connector refs) OR a real def id (binding refs);
       // getEffectiveResource accepts both (resourceMap is keyed by id + apiSlug) and

--- a/packages/lib/src/ai/providers/deepseek/deepseek-llm-client.ts
+++ b/packages/lib/src/ai/providers/deepseek/deepseek-llm-client.ts
@@ -31,6 +31,8 @@ function findLastAssistantWithReasoningIndex(messages: Message[]): number {
  * - Within a single turn's tool-calling cycle, reasoning_content MUST be preserved on the last assistant
  */
 export class DeepSeekLLMClient extends OpenAILLMClient {
+  protected static override clientName = 'DeepSeek-LLM'
+
   /**
    * DeepSeek's OpenAI-compatible endpoint only supports legacy JSON mode
    * (`response_format: { type: 'json_object' }`), not strict Structured Outputs

--- a/packages/lib/src/ai/providers/google/google-llm-client.ts
+++ b/packages/lib/src/ai/providers/google/google-llm-client.ts
@@ -50,6 +50,8 @@ const SUPPORTED_PARAMS = new Set([
  *   isn't wired up yet — `thinkingBudget` params are dropped for now.
  */
 export class GoogleLLMClient extends OpenAILLMClient {
+  protected static override clientName = 'Google-LLM'
+
   /**
    * Translate camelCase rule names (topP/maxOutputTokens) to their OpenAI
    * field names and drop everything the compat endpoint would 400 on

--- a/packages/lib/src/ai/providers/grok/grok-llm-client.ts
+++ b/packages/lib/src/ai/providers/grok/grok-llm-client.ts
@@ -15,4 +15,6 @@ import { OpenAILLMClient } from '../openai/openai-llm-client'
  * the DeepSeek pattern (strip prior-turn reasoning) vs the Kimi pattern
  * (preserve all) to match what xAI accepts.
  */
-export class GrokLLMClient extends OpenAILLMClient {}
+export class GrokLLMClient extends OpenAILLMClient {
+  protected static override clientName = 'Grok-LLM'
+}

--- a/packages/lib/src/ai/providers/groq/groq-llm-client.ts
+++ b/packages/lib/src/ai/providers/groq/groq-llm-client.ts
@@ -17,6 +17,8 @@ const STRICT_JSON_SCHEMA_MODELS = new Set(['openai/gpt-oss-20b', 'openai/gpt-oss
  * calling all work through the base client.
  */
 export class GroqLLMClient extends OpenAILLMClient {
+  protected static override clientName = 'Groq-LLM'
+
   /**
    * Groq only supports strict Structured Outputs on the `openai/gpt-oss-*`
    * models — every other model (e.g. llama-3.3-70b-versatile) only offers

--- a/packages/lib/src/ai/providers/kimi/kimi-llm-client.ts
+++ b/packages/lib/src/ai/providers/kimi/kimi-llm-client.ts
@@ -15,6 +15,8 @@ import { OpenAILLMClient } from '../openai/openai-llm-client'
  * in multi-turn conversations.
  */
 export class KimiLLMClient extends OpenAILLMClient {
+  protected static override clientName = 'Kimi-LLM'
+
   /** Kimi requires reasoning_content on all assistant messages — preserve everything. */
   protected override prepareReasoningContent(messages: Message[]): Message[] {
     return messages

--- a/packages/lib/src/ai/providers/openai/openai-llm-client.ts
+++ b/packages/lib/src/ai/providers/openai/openai-llm-client.ts
@@ -37,6 +37,16 @@ interface ReasoningDelta {
  * OpenAI specialized LLM client with production features
  */
 export class OpenAILLMClient extends LLMClient {
+  /**
+   * Label this client reports in errors, operation logs, and circuit-breaker state.
+   *
+   * Every OpenAI-compatible provider (DeepSeek, Groq, Qwen, …) subclasses this client
+   * without its own constructor, so each one MUST override this or its failures get
+   * reported as OpenAI failures — e.g. a DeepSeek 402 surfacing as
+   * `OpenAI-LLM invoke failed: Insufficient Balance`, sending you to the wrong dashboard.
+   */
+  protected static clientName = 'OpenAI-LLM'
+
   private tokenizer?: any // tiktoken encoding - lazy loaded
 
   constructor(
@@ -44,7 +54,9 @@ export class OpenAILLMClient extends LLMClient {
     config: ClientConfig,
     logger?: Logger
   ) {
-    super(config, 'OpenAI-LLM', logger)
+    // new.target is the concrete subclass being constructed, so this picks up the
+    // subclass's override without every subclass needing to redeclare a constructor.
+    super(config, (new.target as typeof OpenAILLMClient).clientName, logger)
   }
 
   async invoke(params: LLMInvokeParams): Promise<LLMResponse> {

--- a/packages/lib/src/ai/providers/qwen/qwen-llm-client.ts
+++ b/packages/lib/src/ai/providers/qwen/qwen-llm-client.ts
@@ -33,6 +33,8 @@ function findLastAssistantWithReasoningIndex(messages: Message[]): number {
  * tool-calling cycle.
  */
 export class QwenLLMClient extends OpenAILLMClient {
+  protected static override clientName = 'Qwen-LLM'
+
   /**
    * DashScope's compatible-mode endpoint only documents legacy JSON mode
    * (`response_format: { type: 'json_object' }`), not strict Structured Outputs

--- a/packages/lib/src/ai/providers/zai/zai-llm-client.ts
+++ b/packages/lib/src/ai/providers/zai/zai-llm-client.ts
@@ -30,6 +30,8 @@ function findLastAssistantWithReasoningIndex(messages: Message[]): number {
  * (the Kimi behavior), switch this override to simply `return messages`.
  */
 export class ZaiLLMClient extends OpenAILLMClient {
+  protected static override clientName = 'Zai-LLM'
+
   /**
    * Z.AI's API only documents legacy JSON mode
    * (`response_format: { type: 'json_object' }`), not strict Structured Outputs

--- a/scripts/audit/find-duplicate-queries.mjs
+++ b/scripts/audit/find-duplicate-queries.mjs
@@ -562,8 +562,8 @@ writeFileSync(
       raw: raws.map((c) => ({ ...c, list: c.list })),
     },
     (k, v) => (k === 'key' ? undefined : v),
-    1,
-  ),
+    1
+  )
 )
 
 console.log(`files scanned:        ${files.length}`)


### PR DESCRIPTION
Three independent fixes that were sitting in the working tree.

## `getFieldByRef` didn't resolve alias field-ref spellings

`getFieldByRef` only matched the canonical `<entityDefinitionId>:<fieldId>` form, but external authors — the Kopilot agents-builder, the SDK, imports — address fields the way `list_entity_fields` reports them (`getFieldOutputKey` = `systemAttribute ?? key`): an `apiSlug` or `entityType` definition half, and a `systemAttribute` field half, e.g. `shopify_orders:order_status`. The server accepts those interchangeably with the canonical form, so every AI-authored field chip rendered as an unknown-field badge.

`resolveAliasedFieldRef` now resolves both halves independently before falling through to the existing `@app:` branch. The systemAttribute lookup is deliberately scoped to the resolved definition and never falls back to the bare attribute map — a shared attribute name (`inbox_name` is on both `inbox` and `personal_inbox`) would otherwise resolve to the other definition's field. `@app:` refs keep their encoding and are left to the branch below.

Covered by 5 new cases in `resource-store.test.ts`, including the negative case (`def_missing:order_status` → `undefined`).

## OpenAI-compatible clients all reported as `OpenAI-LLM`

Every OpenAI-compatible provider (DeepSeek, Groq, Qwen, Kimi, Grok, Google, Z.AI) subclasses `OpenAILLMClient` without its own constructor, so all of them passed the hardcoded `'OpenAI-LLM'` label to the base client. That label is what surfaces in errors, operation logs, and circuit-breaker state — a DeepSeek 402 showed up as `OpenAI-LLM invoke failed: Insufficient Balance`, sending you to the wrong provider dashboard.

The label is now a `protected static clientName` resolved through `new.target`, so each subclass declares only its own name and no subclass needs a constructor.

## Biome formatting in `scripts/audit/find-duplicate-queries.mjs`

Trailing commas the linter flags.

## Verification

- `vitest run src/components/resources/store/resource-store.test.ts` — 13 passed
- `biome check` on all changed files — no errors
- `tsc --noEmit` in `packages/lib` — no errors in any changed provider file