### PR TITLE
fix: unblock record hydration for kb/dataset and fix audit sessionId

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/account/_components/account-settings.tsx
+++ b/apps/web/src/app/(protected)/app/settings/account/_components/account-settings.tsx
@@ -48,9 +48,12 @@ export function AccountSettings(): React.JSX.Element {
 
   const canEditEmail = (user?.providers?.length ?? 0) === 0
 
-  // The device line reads the SESSION row's user agent — `session` here is
-  // better-auth's `{ user, session }` envelope, not the session row itself.
-  const userAgent = new UAParser(session?.session.userAgent ?? '')
+  // The device line reads the SESSION row's user agent. `customSession` in
+  // auth/server.ts returns `{ ...session, user }`, so the session row is
+  // FLATTENED onto the top level — there is no `.session` sub-object at
+  // runtime, even though the client types still describe better-auth's default
+  // `{ user, session }` envelope. Hence the narrow cast.
+  const userAgent = new UAParser((session as { userAgent?: string } | null)?.userAgent ?? '')
 
   /**
    * Handle sign out - uses the same implementation as nav-user.tsx

--- a/apps/web/src/server/api/audit-context.ts
+++ b/apps/web/src/server/api/audit-context.ts
@@ -11,7 +11,13 @@ interface AuditableCtx {
   session: {
     user: { id: string }
     organizationId?: string | null
-    session?: { id?: string; token?: string } | null
+    /**
+     * The Session ROW id, flat on the session object — `customSession` in
+     * auth/server.ts returns `{ ...session, user }`, so there is no nested
+     * `.session` here (reading one silently wrote `sessionId: null` on every
+     * audit row until 2026-08-01).
+     */
+    id?: string | null
   }
 }
 
@@ -60,7 +66,7 @@ export function recordAuditFromCtx(
     context: {
       ipAddress: clientIp(ctx.headers),
       userAgent: ctx.headers?.get('user-agent') ?? null,
-      sessionId: ctx.session.session?.id ?? null,
+      sessionId: ctx.session.id ?? null,
     },
   })
 }

--- a/apps/web/src/server/api/routers/record-instance-access-closure.test.ts
+++ b/apps/web/src/server/api/routers/record-instance-access-closure.test.ts
@@ -60,6 +60,15 @@ const CONTACT_ID = 'cnt_cuid0000000000000000000'
  */
 const INBOX_DEF_UUID = 'edf_inbox0000000000000000000'
 const INBOX_API_SLUG = 'inboxes'
+
+/**
+ * The two instance-access resources that live in their OWN tables and are
+ * therefore admitted on the hydration arm — `RecordPickerService` filters them
+ * per row through `canViewInstance`. Unlike `signature`, they have no
+ * `EntityDefinition` row at all, so only the bare-slug form exists.
+ */
+const KB_ID = 'kb_cuid00000000000000000000'
+const DATASET_ID = 'dst_cuid0000000000000000000'
 const INBOX_ID = 'ibx_cuid0000000000000000000'
 const PERSONAL_INBOX_DEF_UUID = 'edf_pinbox000000000000000000'
 const PERSONAL_INBOX_ID = 'pib_cuid0000000000000000000'
@@ -92,7 +101,10 @@ const { handler, cache, identity, fieldValues } = vi.hoisted(() => ({
 }))
 
 vi.mock('@auxx/lib/resources', () => ({
-  RESOURCE_TABLE_REGISTRY: [],
+  // `kb` and `dataset` are real entries — `entityDefinitionIdSchema` validates
+  // against this registry, so an empty stub would reject them at the ZOD layer
+  // and the guard assertions below would never run.
+  RESOURCE_TABLE_REGISTRY: [{ id: 'kb' }, { id: 'dataset' }],
   UnifiedCrudHandler: class {
     getById = handler.getById
     getByIds = handler.getByIds
@@ -236,7 +248,10 @@ const PROCEDURES: [
   keyof typeof handler | null,
 ][] = [
   ['getById', (c, d) => c.getById({ recordId: `${d}:${SIGNATURE_ID}` }), 'getById'],
-  ['getByIds', (c, d) => c.getByIds({ items: [`${d}:${SIGNATURE_ID}`] }), 'getByIds'],
+  // `getByIds` is deliberately ABSENT: it is the one procedure that FILTERS
+  // rather than refuses, because its batch is assembled from unrelated callers.
+  // Its (equally strict) contract lives in the dedicated describe below —
+  // "the HYDRATION arm filters instead of refusing".
   ['search (scoped)', (c, d) => c.search({ entityDefinitionId: d, query: 'a' }), 'search'],
   [
     'lookupByField',
@@ -423,12 +438,6 @@ describe('record router — the guard sits OUTSIDE the try (403, never 500)', ()
     ).rejects.toMatchObject({ cause: { name: 'ForbiddenError', statusCode: 403 } })
   })
 
-  it('getByIds surfaces 403, not a 500', async () => {
-    await expect(caller().getByIds({ items: [`signature:${SIGNATURE_ID}`] })).rejects.toMatchObject(
-      { cause: { name: 'ForbiddenError', statusCode: 403 } }
-    )
-  })
-
   it('search surfaces 403, not a 500', async () => {
     await expect(
       caller().search({ entityDefinitionId: SIGNATURE_DEF_UUID, query: 'a' })
@@ -604,15 +613,81 @@ describe('record router — the MAIL READ arm lets inbox defs through', () => {
     expect(handler.getByIds).toHaveBeenCalledTimes(1)
   })
 
-  it('a signature in that same mixed batch still poisons it', async () => {
-    // The exemption is TWO NAMED DEFS, not "instance-access defs are fine on
-    // reads now". If this ever passes, the carve-out has been widened.
+  it('a signature in that same mixed batch is DROPPED, not poisoning it', async () => {
+    // Was: "still poisons it". The poisoning was the bug — one unroutable id
+    // taking every unrelated record in the batch with it. The exemption is still
+    // exactly as narrow; what changed is the failure MODE, from "403 the call"
+    // to "omit the id". The assertion that matters is the second one: the
+    // signature must never reach the handler.
+    await expect(
+      caller().getByIds({ items: [`inbox:${INBOX_ID}`, `signature:${SIGNATURE_ID}`] })
+    ).resolves.toBeDefined()
+    expect(handler.getByIds).toHaveBeenCalledWith([`inbox:${INBOX_ID}`])
+  })
+})
+
+/**
+ * `record.getByIds` — the HYDRATION arm, and the only procedure on this router
+ * that filters instead of refusing.
+ *
+ * Its input is not one caller's request: the client's record-store batcher
+ * collects ids from every component that mounted in the same tick
+ * (`use-record-batch-fetcher.ts`). Throwing for one unroutable def therefore
+ * denied every unrelated record beside it — which is what a `kb:` id did to the
+ * articles and contacts on `/app/kb`.
+ *
+ * The closure is NOT weakened by this: a refused def still never reaches
+ * `UnifiedCrudHandler`, so nothing about it is readable. Only the shape of the
+ * denial changed, from a thrown 403 to an omitted key — which is already this
+ * path's answer for any id the member cannot reach.
+ *
+ * `kb` and `dataset` go further and are ADMITTED here, because
+ * `RecordPickerService.admitSystemRows` gates them per row through
+ * `canViewInstance` — the same authority `kb.list` filters on. They stay refused
+ * on every other procedure, where no such filter exists.
+ */
+describe('record router — the HYDRATION arm filters instead of refusing', () => {
+  it('a batch that is ONLY a refused def resolves empty and never calls the handler', async () => {
+    await expect(caller().getByIds({ items: [`signature:${SIGNATURE_ID}`] })).resolves.toEqual({})
+    expect(handler.getByIds).not.toHaveBeenCalled()
+  })
+
+  it('…by the def UUID form too, not just the bare slug', async () => {
+    await expect(
+      caller().getByIds({ items: [`${SIGNATURE_DEF_UUID}:${SIGNATURE_ID}`] })
+    ).resolves.toEqual({})
+    expect(handler.getByIds).not.toHaveBeenCalled()
+  })
+
+  it('an ordinary def in the same batch survives the signature beside it', async () => {
     await expect(
       caller().getByIds({
-        items: [`inbox:${INBOX_ID}`, `signature:${SIGNATURE_ID}`],
+        items: [`${CONTACT_DEF_UUID}:${CONTACT_ID}`, `signature:${SIGNATURE_ID}`],
       })
-    ).rejects.toMatchObject(FORBIDDEN)
-    expect(handler.getByIds).not.toHaveBeenCalled()
+    ).resolves.toBeDefined()
+    expect(handler.getByIds).toHaveBeenCalledWith([`${CONTACT_DEF_UUID}:${CONTACT_ID}`])
+  })
+
+  it('kb and dataset ARE admitted — the picker gates them per row', async () => {
+    await expect(
+      caller().getByIds({ items: [`kb:${KB_ID}`, `dataset:${DATASET_ID}`] })
+    ).resolves.toBeDefined()
+    expect(handler.getByIds).toHaveBeenCalledWith([`kb:${KB_ID}`, `dataset:${DATASET_ID}`])
+  })
+
+  it('…and are still refused everywhere else, where nothing gates them', async () => {
+    // The carve-out is one procedure wide. `getById` and the list/search paths
+    // route through `getResources` / `querySystemResourceIdsPaged`, which have
+    // no instance-access filter — admitting `kb` there would hand every member
+    // the org's whole KB list.
+    await expect(caller().getById({ recordId: `kb:${KB_ID}` })).rejects.toMatchObject(FORBIDDEN)
+    await expect(caller().listAll({ entityDefinitionId: 'kb' })).rejects.toMatchObject(FORBIDDEN)
+    await expect(caller().listFiltered({ entityDefinitionId: 'kb' })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    await expect(caller().search({ entityDefinitionId: 'kb', query: 'a' })).rejects.toMatchObject(
+      FORBIDDEN
+    )
   })
 })
 

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -189,6 +189,79 @@ function instanceAccessDefError(key: string): ForbiddenError {
   )
 }
 
+/**
+ * The keys {@link getByIds} admits — the HYDRATION carve-out, and deliberately
+ * wider than {@link MAIL_READ_EXEMPT_KEYS}.
+ *
+ * `kb` and `dataset` are instance-access resources that live in their own
+ * tables, and `RecordPickerService` both resolves them from those tables and
+ * gates them per row through `canViewInstance` (`admitSystemRows`) — the same
+ * authority `kb.list` filters on. So for a hydration read they have exactly one
+ * access authority, which is what the blanket refusal was protecting.
+ *
+ * They are NOT added to the general read arm: the paginated list/search paths
+ * run through `getResources` / `querySystemResourceIdsPaged`, which have no
+ * instance-access filter. Admitting them there would leak the org's whole KB
+ * list. `signature`, `snippet`, `dashboard`, `workflow` and `agent` stay refused
+ * everywhere — they are not statically pickable, so there is no system-table
+ * path to gate in the first place.
+ */
+const HYDRATION_EXEMPT_KEYS: ReadonlySet<InstanceAccessKey> = new Set<InstanceAccessKey>([
+  ...MAIL_READ_EXEMPT_KEYS,
+  'kb',
+  'dataset',
+])
+
+/**
+ * {@link assertNotInstanceAccessDefForRead} as a FILTER rather than an assert —
+ * `getByIds` drops unroutable ids instead of failing the call.
+ *
+ * A hydration batch is not one caller's request: the client's record-store
+ * batcher collects ids from every component that mounted in the same tick and
+ * sends them as one query. Throwing for a single unroutable def therefore takes
+ * every unrelated record down with it — which is exactly what a `kb:` id in the
+ * batch did to the articles and contacts beside it. `RecordPickerService`
+ * already answers "an id you cannot reach" by omitting it, and the client models
+ * the gap (`missingIds` → `setNotFound`), so omission is the consistent answer
+ * here too.
+ *
+ * The TARGETED procedures keep the throw: a caller that named one record is owed
+ * a real error, not a silent empty.
+ */
+async function filterHydratableRecordIds(
+  organizationId: string,
+  recordIds: RecordId[]
+): Promise<RecordId[]> {
+  const kept: RecordId[] = []
+  // Resolved lazily and once — a batch of plain record defs never touches it.
+  let resources: Awaited<ReturnType<typeof getCachedResources>> | undefined
+
+  for (const recordId of recordIds) {
+    const { entityDefinitionId } = parseRecordId(recordId)
+
+    // The bare slug form ('kb', 'signature') decides without the cache.
+    if (isInstanceAccessKey(entityDefinitionId)) {
+      if (HYDRATION_EXEMPT_KEYS.has(entityDefinitionId)) kept.push(recordId)
+      continue
+    }
+
+    // A def UUID or apiSlug still has to resolve — the client sends both forms.
+    resources ??= await getCachedResources(organizationId)
+    const entityType = resources.find(
+      (r) =>
+        r.id === entityDefinitionId ||
+        r.entityDefinitionId === entityDefinitionId ||
+        r.apiSlug === entityDefinitionId
+    )?.entityType
+    if (entityType && isInstanceAccessKey(entityType) && !HYDRATION_EXEMPT_KEYS.has(entityType)) {
+      continue
+    }
+    kept.push(recordId)
+  }
+
+  return kept
+}
+
 /** The def part of each RecordId, for {@link assertNotInstanceAccessDef}. */
 function recordIdDefParts(recordIds: string[]): string[] {
   return recordIds.map((id) => parseRecordId(id as RecordId).entityDefinitionId)
@@ -514,6 +587,9 @@ export const recordRouter = createTRPCRouter({
   /**
    * Get multiple records by IDs (batch)
    * Used for hydrating relationship field values
+   *
+   * Unroutable defs are FILTERED, not refused — see
+   * {@link filterHydratableRecordIds} for why a shared batch must not fail whole.
    */
   getByIds: capabilityProcedure
     .input(
@@ -523,14 +599,15 @@ export const recordRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       const { organizationId, user } = ctx.session
-      await assertNotInstanceAccessDefForRead(organizationId, recordIdDefParts(input.items))
+      const items = await filterHydratableRecordIds(organizationId, input.items as RecordId[])
+      if (items.length === 0) return {}
 
       try {
         const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx), {
           capabilities: ctx.capabilities,
           requestPath: true,
         })
-        return await handler.getByIds(input.items as RecordId[])
+        return await handler.getByIds(items)
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         throw new TRPCError({

--- a/packages/lib/src/resources/picker/record-picker-service.ts
+++ b/packages/lib/src/resources/picker/record-picker-service.ts
@@ -1,9 +1,23 @@
 // packages/lib/src/resources/picker/record-picker-service.ts
 
 import { type Database, schema } from '@auxx/database'
+import type { Rung } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { isEntityDefinitionType, type RecordId } from '@auxx/types/resource'
-import { and, asc, desc, eq, gt, ilike, inArray, lt, or, type SQL, sql } from 'drizzle-orm'
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  ilike,
+  inArray,
+  lt,
+  notInArray,
+  or,
+  type SQL,
+  sql,
+} from 'drizzle-orm'
 import {
   getCachedEntityDefId,
   getCachedResource,
@@ -13,7 +27,11 @@ import {
 import { BadRequestError, ForbiddenError } from '../../errors'
 import { getRecordIdentitiesForRecords } from '../../identity'
 import type { CapabilityView } from '../../permissions/capabilities/capability-view'
-import { isDeclaredInstanceDomain } from '../../permissions/capabilities/instance-access'
+import {
+  type InstanceAccessKey,
+  isDeclaredInstanceDomain,
+  isInstanceAccessKey,
+} from '../../permissions/capabilities/instance-access'
 import {
   type RecordVisibilityScope,
   recordAccessRankSql,
@@ -61,6 +79,47 @@ import type {
 } from './types'
 
 const logger = createScopedLogger('record-picker-service')
+
+/**
+ * An instance-access resource the picker can serve from its OWN table — i.e. a
+ * key that is simultaneously a blob-lane {@link InstanceAccessKey} and a
+ * statically-pickable system table. Today that is exactly `kb` and `dataset`.
+ *
+ * Derived, never listed: `signature` and `snippet` are instance-access too, but
+ * they carry no `RESOURCE_DISPLAY_CONFIG` entry, so `fetchResourcesFromDb`
+ * cannot query them by hand and this returns `undefined` for them — which is
+ * what keeps them refused at the router while these two are admitted.
+ */
+function systemTableInstanceAccessKey(entityDefinitionId: string): InstanceAccessKey | undefined {
+  if (!isInstanceAccessKey(entityDefinitionId)) return undefined
+  if (!RESOURCE_TABLE_MAP[entityDefinitionId as unknown as TableId]) return undefined
+  if (!RESOURCE_DISPLAY_CONFIG[entityDefinitionId as unknown as TableId]) return undefined
+  return entityDefinitionId
+}
+
+/**
+ * A row's instance-access rung, read off the composed capability blob.
+ *
+ * The three predicates are already on {@link CapabilityView} (and already
+ * intersected across run-as/invoker by its combining wrapper), so this walks
+ * them highest-first rather than adding a fourth method that would have to
+ * re-derive the same intersection. `undefined` ⇒ not viewable ⇒ the row drops.
+ *
+ * The vocabulary lines up on purpose: instance access uses `CONFIG_SCALE_RUNGS`
+ * (`none|read|edit|admin`), the same ladder `_access` is judged on by
+ * `canEditRecordAt` / `canDeleteRecordAt` and by `useRecordAccess` on the
+ * client, so a stamped `kb` row gets correct row affordances for free.
+ */
+function instanceRung(
+  capabilities: CapabilityView,
+  key: InstanceAccessKey,
+  instanceId: string
+): Rung | undefined {
+  if (capabilities.canAdminInstance(key, instanceId)) return 'admin'
+  if (capabilities.canEditInstance(key, instanceId)) return 'edit'
+  if (capabilities.canViewInstance(key, instanceId)) return 'read'
+  return undefined
+}
 
 /**
  * The slice of Drizzle's relational query builder the dynamic picker paths use.
@@ -335,6 +394,13 @@ export class RecordPickerService {
           if (searchConditions.length > 0) {
             conditions.push(or(...searchConditions)!)
           }
+        }
+
+        // Rows this table never exposes through the picker (e.g. `kind: 'source'`
+        // knowledge bases). Applied before caller filters so no caller can opt out.
+        for (const [fieldKey, excluded] of Object.entries(displayConfig.neverPickable ?? {})) {
+          const column = table[fieldKey]
+          if (column && excluded.length > 0) conditions.push(notInArray(column, [...excluded]))
         }
 
         // Apply custom filters
@@ -760,6 +826,10 @@ export class RecordPickerService {
     // for the ones that survive so the per-row predicate + `_access` stamp ride
     // the fetch below. Unauthorized ids DROP SILENTLY from the batch — the
     // caller's map simply has no entry — matching `getById`'s non-enumeration.
+    //
+    // System tables answer `{ arm: 'all' }` here and are gated one layer down
+    // instead — see {@link admitSystemRows} for why the instance-access ones
+    // (`kb`, `dataset`) need that and where their per-row policy actually lives.
     const scopes = new Map<string, RecordVisibilityScope>()
     if (this.capabilities) {
       for (const defId of [...grouped.keys()]) {
@@ -808,7 +878,7 @@ export class RecordPickerService {
                 undefined,
                 { id: ids }
               )
-              for (const item of fetched) {
+              for (const item of this.admitSystemRows(tableId, fetched)) {
                 // Re-key to caller's UUID prefix so the result map lookup matches.
                 const key = toRecordId(originalKey, item.id) as RecordId
                 result[key] = { ...item, recordId: key }
@@ -847,13 +917,49 @@ export class RecordPickerService {
             undefined,
             { id: ids }
           )
-          for (const item of fetched) result[item.recordId] = item
+          for (const item of this.admitSystemRows(resolvedId as TableId, fetched)) {
+            result[item.recordId] = item
+          }
         }
       })
     )
 
     await this.attachRecordSources(result)
     return result
+  }
+
+  /**
+   * **The per-row gate for system-table rows** — the half of §5.1/§5.2 that
+   * `fetchResourcesFromDb` cannot express.
+   *
+   * The EntityInstance path narrows in SQL (`scope.where`) and stamps `_access`
+   * from the grantee-union rank in the same projection. A system table has
+   * neither: its rows carry no `ResourceAccess` grant rows to correlate against,
+   * and `recordScope` says so by answering `{ arm: 'all' }`. For the
+   * instance-access keys among them (`kb`, `dataset`) that would be a leak — the
+   * whole org's knowledge bases to any member — so the fetch is filtered here,
+   * in memory, against the same authority `kb.list` uses (`canViewInstance`).
+   *
+   * Rows the member cannot view DROP SILENTLY, matching this method's answer for
+   * every other unreachable id. Non-instance-access system tables (`user`,
+   * `article`, `participant`) pass through untouched: they genuinely have no
+   * per-row policy in this lane.
+   *
+   * `capabilities: undefined` ⇒ internal caller ⇒ no enforcement, the same
+   * convention `recordScope` and `fetchEntityInstancesByIds` follow.
+   */
+  private admitSystemRows(tableId: TableId, fetched: RecordPickerItem[]): RecordPickerItem[] {
+    const key = systemTableInstanceAccessKey(tableId)
+    const capabilities = this.capabilities
+    if (!key || !capabilities) return fetched
+
+    const admitted: RecordPickerItem[] = []
+    for (const item of fetched) {
+      const access = instanceRung(capabilities, key, item.id)
+      if (!access) continue
+      admitted.push({ ...item, _access: access })
+    }
+    return admitted
   }
 
   /**
@@ -967,6 +1073,17 @@ export class RecordPickerService {
     // wrong answer, and `none` is the right one: the lens lives in `mail-query/`,
     // so from the record lane's point of view no thread row is reachable.
     if (isMailLensTableId(entityDefinitionId)) return { arm: 'none' }
+    // ⚠ `{ arm: 'all' }` for a system table is NOT "everyone sees everything" for
+    // the instance-access ones (`kb`, `dataset`). Their policy is real, it just
+    // is not SQL: it lives in the composed capability blob, so
+    // `getResourcesByIds` filters those rows through {@link instanceRung} AFTER
+    // the fetch. The arm stays `all` because this union expresses a WHERE
+    // predicate and there is none to give.
+    //
+    // That filter is on the by-ids (hydration) path only. `getResources` — the
+    // paginated list path — is still unfiltered for these keys, which is safe
+    // solely because `record.ts` refuses them there. Widen that guard and this
+    // has to grow a list arm first.
     if (RESOURCE_TABLE_MAP[entityDefinitionId as TableId]) return { arm: 'all' }
     // Arms 1 and 4 are decided in memory, before any def normalization or
     // grantee resolution — see `UnifiedCrudHandler.recordScope` for why.

--- a/packages/lib/src/resources/picker/system-table-instance-access.test.ts
+++ b/packages/lib/src/resources/picker/system-table-instance-access.test.ts
@@ -1,0 +1,154 @@
+// packages/lib/src/resources/picker/system-table-instance-access.test.ts
+//
+// The per-row gate for SYSTEM-TABLE instance-access resources (`kb`, `dataset`)
+// on the hydration path — `RecordPickerService.getResourcesByIds`.
+//
+// Why this file exists: `recordScope` answers `{ arm: 'all' }` for anything in
+// `RESOURCE_TABLE_MAP`, because a system table has no `ResourceAccess` rows to
+// correlate against in SQL. For an ordinary system table (`user`, `article`)
+// that is the truth. For `kb` and `dataset` it is NOT — their policy is real, it
+// just lives in the composed capability blob — so `admitSystemRows` filters the
+// fetched rows through `canViewInstance` and stamps `_access` from the rung.
+// Without it, admitting `kb` at `record.getByIds` would hand every member the
+// org's entire knowledge-base list.
+//
+// The table fetch itself is stubbed rather than faked through Drizzle: under
+// this package's Vitest config `schema`'s columns are `undefined`, so
+// `fetchResourcesDirect`'s `orderBy`/`requireColumn` cannot run
+// (`project_drizzle_columns_undefined_in_vitest`). What is under test is the
+// gate and its wiring, not the SELECT.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../identity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../identity')>()
+  return { ...actual, getRecordIdentitiesForRecords: vi.fn(async () => new Map()) }
+})
+
+import type { RecordId } from '@auxx/types/resource'
+import { RecordPickerService } from './record-picker-service'
+import type { RecordPickerItem } from './types'
+
+const ORG = 'org_cuid000000000000000000000'
+const USER = 'usr_cuid000000000000000000000'
+
+/** Three KBs in the org — only one of which this member holds anything on. */
+const VISIBLE_KB = 'kb_visible0000000000000000'
+const HIDDEN_KB = 'kb_hidden00000000000000000'
+const OTHER_HIDDEN_KB = 'kb_hidden20000000000000000'
+
+/** What the KnowledgeBase table returns for the batch, before any gating. */
+function tableRows(ids: string[], tableId = 'kb'): RecordPickerItem[] {
+  return ids.map((id) => ({
+    id,
+    recordId: `${tableId}:${id}` as RecordId,
+    displayName: `KB ${id}`,
+    data: { id },
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+  })) as RecordPickerItem[]
+}
+
+/**
+ * A `CapabilityView` stub exposing only the three instance predicates the gate
+ * reads. `rungs` maps instanceId → the highest rung the member holds; an id
+ * that is absent is not viewable at all.
+ */
+function view(rungs: Record<string, 'read' | 'edit' | 'admin'>) {
+  const at = (id: string) => rungs[id]
+  return {
+    canViewInstance: (_key: string, id: string) => at(id) !== undefined,
+    canEditInstance: (_key: string, id: string) => at(id) === 'edit' || at(id) === 'admin',
+    canAdminInstance: (_key: string, id: string) => at(id) === 'admin',
+    canViewEntity: () => true,
+    hasRecordGrantsOn: () => false,
+  } as never
+}
+
+/**
+ * Run a by-ids batch with the table fetch stubbed to `rows`, and report both the
+ * admitted result and what the stub was asked for.
+ */
+async function hydrate(
+  recordIds: string[],
+  rows: RecordPickerItem[],
+  capabilities: unknown
+): Promise<Record<string, RecordPickerItem>> {
+  const service = new RecordPickerService(ORG, USER, {} as never, capabilities as never)
+  ;(service as unknown as { fetchResourcesFromDb: unknown }).fetchResourcesFromDb = vi.fn(
+    async () => ({ items: rows, nextCursor: null, hasMore: false })
+  )
+  return await service.getResourcesByIds(recordIds as RecordId[])
+}
+
+describe('kb hydration — the per-row gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('drops the KBs the member cannot view and keeps the one they can', async () => {
+    const result = await hydrate(
+      [`kb:${VISIBLE_KB}`, `kb:${HIDDEN_KB}`, `kb:${OTHER_HIDDEN_KB}`],
+      tableRows([VISIBLE_KB, HIDDEN_KB, OTHER_HIDDEN_KB]),
+      view({ [VISIBLE_KB]: 'edit' })
+    )
+
+    expect(Object.keys(result)).toEqual([`kb:${VISIBLE_KB}`])
+  })
+
+  it('is a NON-enumeration: an unviewable KB leaves no key behind at all', async () => {
+    // Not `{ 'kb:hidden': null }` — the caller must not learn the id exists.
+    const result = await hydrate(
+      [`kb:${HIDDEN_KB}`],
+      tableRows([HIDDEN_KB]),
+      view({ [VISIBLE_KB]: 'read' })
+    )
+
+    expect(result).toEqual({})
+  })
+
+  it('stamps `_access` with the rung, so row affordances resolve client-side', async () => {
+    // The vocabulary match is the point: instance access uses CONFIG_SCALE_RUNGS,
+    // which is the same ladder `canEditRecordAt` / `useRecordAccess` judge.
+    const rungs = { [VISIBLE_KB]: 'read', [HIDDEN_KB]: 'edit', [OTHER_HIDDEN_KB]: 'admin' } as const
+    const result = await hydrate(
+      [`kb:${VISIBLE_KB}`, `kb:${HIDDEN_KB}`, `kb:${OTHER_HIDDEN_KB}`],
+      tableRows([VISIBLE_KB, HIDDEN_KB, OTHER_HIDDEN_KB]),
+      view(rungs)
+    )
+
+    expect(result[`kb:${VISIBLE_KB}`]?._access).toBe('read')
+    expect(result[`kb:${HIDDEN_KB}`]?._access).toBe('edit')
+    expect(result[`kb:${OTHER_HIDDEN_KB}`]?._access).toBe('admin')
+  })
+
+  it('an internal caller (no capabilities) is not gated', async () => {
+    // `capabilities: undefined` means "no member to judge" — the same convention
+    // `recordScope` and `fetchEntityInstancesByIds` already follow.
+    const service = new RecordPickerService(ORG, undefined, {} as never)
+    ;(service as unknown as { fetchResourcesFromDb: unknown }).fetchResourcesFromDb = vi.fn(
+      async () => ({ items: tableRows([VISIBLE_KB, HIDDEN_KB]), nextCursor: null, hasMore: false })
+    )
+
+    const result = await service.getResourcesByIds([
+      `kb:${VISIBLE_KB}`,
+      `kb:${HIDDEN_KB}`,
+    ] as RecordId[])
+
+    expect(Object.keys(result).sort()).toEqual([`kb:${HIDDEN_KB}`, `kb:${VISIBLE_KB}`])
+  })
+
+  it('an ordinary system table is untouched — it genuinely has no per-row policy', async () => {
+    // `article` is a system table but NOT instance-access, so the gate must not
+    // start dropping its rows just because it is not an `EntityInstance`.
+    const ARTICLE = 'art_cuid0000000000000000000'
+    const result = await hydrate(
+      [`article:${ARTICLE}`],
+      tableRows([ARTICLE], 'article'),
+      view({}) // nothing viewable in the instance keyspace
+    )
+
+    expect(Object.keys(result)).toEqual([`article:${ARTICLE}`])
+    expect(result[`article:${ARTICLE}`]?._access).toBeUndefined()
+  })
+})

--- a/packages/lib/src/resources/registry/display-config.ts
+++ b/packages/lib/src/resources/registry/display-config.ts
@@ -68,6 +68,20 @@ export interface ResourceDisplayConfig {
 
   /** Relations to include in query (for secondary info that needs related data) */
   withRelations?: Record<string, any>
+
+  /**
+   * Rows this table never exposes through the picker, as `column → excluded
+   * values`. Applied by `fetchResourcesDirect` to EVERY picker path — list,
+   * search and by-ids hydration alike.
+   *
+   * This exists because "which rows of this table are addressable" is a property
+   * of the table, not of one caller: `kb` rows of `kind: 'source'` are hidden
+   * containers owned by `KnowledgeSource` and are already filtered out of
+   * `listKnowledgeBases`, whose comment names pickers as a place they must never
+   * reach. Encoding it only in that one query left the picker free to surface
+   * them the moment a second read path opened.
+   */
+  neverPickable?: Record<string, readonly string[]>
 }
 
 /**
@@ -242,6 +256,13 @@ export const RESOURCE_DISPLAY_CONFIG: Partial<Record<TableId, ResourceDisplayCon
     defaultSortField: 'updatedAt',
     defaultSortDirection: 'desc',
     orgScopingStrategy: 'direct',
+    // `source` only — NOT `learned`. Source KBs are internal containers with no
+    // UI of their own. The `learned` KB (AI Memory) is a real, member-facing
+    // knowledge base with its own card on the KB landing page; it is absent from
+    // `listKnowledgeBases` because that query backs the standard-KB grid, not
+    // because it is secret. Excluding it here would make the AI Memory KB
+    // unresolvable anywhere it is referenced.
+    neverPickable: { kind: ['source'] },
   },
 
   visit: {


### PR DESCRIPTION
Two unrelated fixes that showed up in the same pass.

## 1. `record.getByIds` filters instead of refusing

The hydration arm's batch is not one caller's request — the client's record-store batcher collects ids from every component that mounted in the same tick and sends them as one query. Throwing for a single unroutable def therefore took every unrelated record down with it, which is what a `kb:` id did to the articles and contacts on `/app/kb`.

It now **filters** those ids. The closure is not weakened: a refused def still never reaches `UnifiedCrudHandler`, so nothing about it is readable — only the denial *shape* changed, from a thrown 403 to an omitted key, which is already this path's answer for any id the member cannot reach (the client models the gap via `missingIds` → `setNotFound`). Every targeted procedure keeps the throw: a caller that named one record is owed a real error, not a silent empty.

## 2. `kb` / `dataset` are admitted there, behind a real per-row gate

Those two are instance-access resources that live in their own tables. `recordScope` answers `{ arm: 'all' }` for anything in `RESOURCE_TABLE_MAP` because a system table has no `ResourceAccess` rows to correlate against in SQL — true for `user`/`article`, a leak for these two (the org's entire KB list to any member).

So `RecordPickerService.admitSystemRows` filters the fetched rows in memory through `canViewInstance` — the same authority `kb.list` filters on — and stamps `_access` from the rung, so row affordances resolve client-side. Unviewable rows drop silently, matching the method's non-enumeration for every other unreachable id.

They stay **refused on every other procedure**: `getResources` / `querySystemResourceIdsPaged` (the list/search paths) have no instance-access filter, so admitting them there would leak the whole list. `signature`, `snippet`, `dashboard`, `workflow` and `agent` stay refused everywhere — they have no statically-pickable table, so there is no system-table path to gate.

## 3. `neverPickable` display-config key

`kind: 'source'` KBs are hidden containers owned by `KnowledgeSource`, filtered out of `listKnowledgeBases` only. That made "which rows are addressable" a property of one query rather than of the table, so the picker was free to surface them the moment a second read path opened. Now enforced on every picker path, before caller filters. `learned` (AI Memory) is deliberately **not** excluded — it is a real member-facing KB with its own card.

## 4. Audit `sessionId` was always null

`customSession` in `auth/server.ts` returns `{ ...session, user }`, so the session row is flat on the top level — there is no `.session` sub-object at runtime, though the client types still describe better-auth's default envelope. `recordAuditFromCtx` read the nested form and wrote `sessionId: null` on every audit row; the account-settings device line parsed an empty user agent for the same reason.

## Tests

- `apps/web/.../record-instance-access-closure.test.ts` — 133 pass. New describe block pins the hydration contract: refused-only batch resolves `{}` and never calls the handler (bare slug *and* def-UUID form), an ordinary def survives a signature beside it, `kb`/`dataset` are admitted, and are still `FORBIDDEN` on `getById` / `listAll` / `listFiltered` / `search`.
- `packages/lib/.../system-table-instance-access.test.ts` (new) — 5 pass. Covers the drop, the non-enumeration, the `_access` rung stamp, the internal-caller bypass, and that an ordinary system table is untouched.