### PR TITLE
fix: require org membership for dev app installs

### DIFF
--- a/apps/api/src/routes/__tests__/deployments.test.ts
+++ b/apps/api/src/routes/__tests__/deployments.test.ts
@@ -1,0 +1,182 @@
+// apps/api/src/routes/__tests__/deployments.test.ts
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const AUTHENTICATED_USER_ID = 'user_dev'
+const TARGET_ORG_ID = 'org_target'
+
+const mockVerifyOrgMembership = vi.fn()
+const mockOnCacheEvent = vi.fn()
+const mockInstallationInsert = vi.fn()
+
+// Auth/scope middleware are replaced with pass-throughs: this test covers the
+// route's own organization check, not token validation.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('userId', AUTHENTICATED_USER_ID)
+    c.set('user', { id: AUTHENTICATED_USER_ID, email: 'dev@example.com' })
+    c.set('scopes', ['developer', 'apps:write'])
+    await next()
+  },
+}))
+
+vi.mock('../../middleware/scope', () => ({
+  requireScope: () => async (_c: any, next: any) => {
+    await next()
+  },
+}))
+
+// drizzle-orm predicate builders are stubbed because the database mock below
+// ignores where-clauses entirely; the real builders would reject the fake
+// column objects.
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ _and: args }),
+  eq: (a: unknown, b: unknown) => ({ _eq: [a, b] }),
+}))
+
+vi.mock('@auxx/database', () => {
+  const column = new Proxy({}, { get: (_t, prop) => String(prop) })
+  const schema = new Proxy({}, { get: () => column })
+
+  const bundle = { id: 'bundle_1', uploadedAt: new Date() }
+  const deployment = { id: 'deployment_1', version: null, status: 'active' }
+
+  const tx = {
+    delete: () => ({ where: async () => undefined }),
+    insert: () =>
+      ({
+        values: (values: unknown) => {
+          mockInstallationInsert(values)
+          return Object.assign(Promise.resolve(undefined), {
+            returning: async () => [deployment],
+          })
+        },
+      }) as any,
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+    query: {
+      AppInstallation: { findFirst: async () => undefined },
+    },
+  }
+
+  const database = {
+    query: {
+      AppBundle: { findFirst: async () => bundle },
+      AppDeployment: { findFirst: async () => undefined },
+      App: { findFirst: async () => undefined },
+    },
+    transaction: async (cb: (tx: unknown) => Promise<unknown>) => cb(tx),
+    insert: tx.insert,
+  }
+
+  return { database, schema }
+})
+
+vi.mock('@auxx/services/developer-accounts', () => ({
+  verifyAppAccess: async () => ok({ appId: 'app_1' }),
+}))
+
+vi.mock('@auxx/services/organization-members', () => ({
+  verifyOrgMembership: (...args: unknown[]) => mockVerifyOrgMembership(...args),
+}))
+
+vi.mock('@auxx/services/app-versions', () => ({
+  calculateNextVersion: async () => '1.0.0',
+}))
+
+vi.mock('@auxx/lib/apps', () => ({
+  updateDeploymentStatus: vi.fn(),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  invalidateAppCatalog: vi.fn(),
+  invalidateOrgsByDeploymentId: vi.fn(),
+  onCacheEvent: (...args: unknown[]) => mockOnCacheEvent(...args),
+}))
+
+vi.mock('@auxx/lib/data-connectors', () => ({
+  restampWebhookBindingsForDeployment: vi.fn(),
+}))
+
+vi.mock('@auxx/utils/json', () => ({
+  stableStringify: (value: unknown) => JSON.stringify(value ?? null),
+}))
+
+async function postDevDeployment(body: Record<string, unknown>) {
+  const deployments = (await import('../deployments')).default
+  return deployments.request('/app_1/deployments', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test' },
+    body: JSON.stringify(body),
+  })
+}
+
+const DEV_BODY = {
+  clientBundleSha: 'client-sha',
+  serverBundleSha: 'server-sha',
+  deploymentType: 'development',
+  targetOrganizationId: TARGET_ORG_ID,
+}
+
+describe('POST /:appId/deployments — development target organization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects a caller who is not a member of the target organization with 403', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(
+      err({
+        code: 'NOT_MEMBER' as const,
+        message: 'not a member',
+        userId: AUTHENTICATED_USER_ID,
+        organizationId: TARGET_ORG_ID,
+      })
+    )
+
+    const res = await postDevDeployment(DEV_BODY)
+
+    expect(res.status).toBe(403)
+    const json = (await res.json()) as any
+    expect(json.error.code).toBe('ORG_ACCESS_DENIED')
+    // Fail closed: nothing may be installed into the foreign org.
+    expect(mockInstallationInsert).not.toHaveBeenCalled()
+    expect(mockOnCacheEvent).not.toHaveBeenCalled()
+  })
+
+  it('allows a caller who is a member of the target organization', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(
+      ok({ id: 'member_1', userId: AUTHENTICATED_USER_ID, organizationId: TARGET_ORG_ID })
+    )
+
+    const res = await postDevDeployment(DEV_BODY)
+
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as any
+    expect(json.deploymentId).toBe('deployment_1')
+    expect(mockVerifyOrgMembership).toHaveBeenCalledWith({
+      userId: AUTHENTICATED_USER_ID,
+      organizationId: TARGET_ORG_ID,
+    })
+    expect(mockOnCacheEvent).toHaveBeenCalledWith('app.installed', { orgId: TARGET_ORG_ID })
+  })
+
+  it('rejects a development deployment with no targetOrganizationId with 400', async () => {
+    const res = await postDevDeployment({ ...DEV_BODY, targetOrganizationId: undefined })
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as any
+    expect(json.error.code).toBe('BAD_REQUEST')
+    expect(mockVerifyOrgMembership).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a database failure as 500 rather than proceeding', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(
+      err({ code: 'DATABASE_ERROR' as const, message: 'boom', cause: new Error('boom') })
+    )
+
+    const res = await postDevDeployment(DEV_BODY)
+
+    expect(res.status).toBe(500)
+    expect(mockInstallationInsert).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/routes/__tests__/installations.test.ts
+++ b/apps/api/src/routes/__tests__/installations.test.ts
@@ -1,0 +1,98 @@
+// apps/api/src/routes/__tests__/installations.test.ts
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const AUTHENTICATED_USER_ID = 'user_dev'
+const TARGET_ORG_ID = 'org_target'
+
+const mockVerifyOrgMembership = vi.fn()
+const mockGetDevInstallation = vi.fn()
+
+// Auth/scope middleware are replaced with pass-throughs: this test covers the
+// route's own organization check, not token validation.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('userId', AUTHENTICATED_USER_ID)
+    c.set('user', { id: AUTHENTICATED_USER_ID, email: 'dev@example.com' })
+    c.set('scopes', ['developer', 'apps:read'])
+    await next()
+  },
+}))
+
+vi.mock('../../middleware/scope', () => ({
+  requireScope: () => async (_c: any, next: any) => {
+    await next()
+  },
+}))
+
+vi.mock('@auxx/services/developer-accounts', () => ({
+  verifyAppAccess: async () => ok({ appId: 'app_1' }),
+}))
+
+vi.mock('@auxx/services/organization-members', () => ({
+  verifyOrgMembership: (...args: unknown[]) => mockVerifyOrgMembership(...args),
+}))
+
+vi.mock('@auxx/services/app-installations', () => ({
+  getDevInstallation: (...args: unknown[]) => mockGetDevInstallation(...args),
+}))
+
+async function getDevInstallationRequest(organizationId = TARGET_ORG_ID) {
+  const installations = (await import('../installations')).default
+  return installations.request(`/app_1/organization/${organizationId}/dev-installation`, {
+    method: 'GET',
+    headers: { Authorization: 'Bearer test' },
+  })
+}
+
+describe('GET /:appId/organization/:organizationId/dev-installation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetDevInstallation.mockResolvedValue(ok({ appId: 'app_1', organizationId: TARGET_ORG_ID }))
+  })
+
+  it('rejects a caller who is not a member of the organization with 403', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(
+      err({
+        code: 'NOT_MEMBER',
+        message: 'not a member',
+        userId: AUTHENTICATED_USER_ID,
+        organizationId: TARGET_ORG_ID,
+      })
+    )
+
+    const res = await getDevInstallationRequest()
+
+    expect(res.status).toBe(403)
+    expect(await res.json()).toMatchObject({ error: { code: 'ORG_ACCESS_DENIED' } })
+    // The existence oracle must not run at all for a non-member.
+    expect(mockGetDevInstallation).not.toHaveBeenCalled()
+  })
+
+  it('allows a caller who is a member of the organization', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(
+      ok({ id: 'member_1', userId: AUTHENTICATED_USER_ID, organizationId: TARGET_ORG_ID })
+    )
+
+    const res = await getDevInstallationRequest()
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ appId: 'app_1', organizationId: TARGET_ORG_ID })
+    expect(mockGetDevInstallation).toHaveBeenCalledWith({
+      appId: 'app_1',
+      organizationId: TARGET_ORG_ID,
+    })
+  })
+
+  it('surfaces a database failure as 500 rather than proceeding', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(
+      err({ code: 'DATABASE_ERROR', message: 'connection lost' })
+    )
+
+    const res = await getDevInstallationRequest()
+
+    expect(res.status).toBe(500)
+    expect(mockGetDevInstallation).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/routes/deployments.ts
+++ b/apps/api/src/routes/deployments.ts
@@ -7,6 +7,7 @@ import { invalidateAppCatalog, invalidateOrgsByDeploymentId, onCacheEvent } from
 import { restampWebhookBindingsForDeployment } from '@auxx/lib/data-connectors'
 import { calculateNextVersion } from '@auxx/services/app-versions'
 import { verifyAppAccess } from '@auxx/services/developer-accounts'
+import { verifyOrgMembership } from '@auxx/services/organization-members'
 import { stableStringify } from '@auxx/utils/json'
 import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
@@ -152,7 +153,52 @@ deployments.post('/:appId/deployments', requireScope(['developer', 'apps:write']
       : version || null
 
   // Dev deployments: delete old deployments + insert + update installation atomically
-  if (deploymentType === 'development' && targetOrganizationId) {
+  if (deploymentType === 'development') {
+    // `targetOrganizationId` is caller-supplied body input, and a dev deployment
+    // installs this developer's server bundle into that tenant, where it later
+    // executes as app code. Nothing upstream binds the request to an
+    // organization: authMiddleware sets only userId/scopes, requireScope is a
+    // pure token-scope check, verifyAppAccess covers only the developer account
+    // that owns the App, and organizationMiddleware is not mounted on this
+    // router (it keys off a :handle URL param). So membership must be asserted
+    // here. The CLI already picks the org from the membership-scoped
+    // GET /developers/dev-organizations, so this only rejects forged bodies.
+    if (!targetOrganizationId) {
+      return c.json(
+        errorResponse(
+          'BAD_REQUEST',
+          'targetOrganizationId is required for development deployments'
+        ),
+        400
+      )
+    }
+
+    // Deliberately a direct indexed OrganizationMember lookup (via the shared
+    // verifyOrgMembership service) rather than the cached isOrgMember helper
+    // from @auxx/lib/cache: this runs once per bundle upload, not on a hot read
+    // path, it is a security boundary where the org-cache staleness window is
+    // undesirable, and it is cheaper than materializing the whole members blob
+    // to answer a single boolean. No apps/api route uses isOrgMember today —
+    // the established convention here is the services-layer verify* functions.
+    const membershipResult = await verifyOrgMembership({
+      userId,
+      organizationId: targetOrganizationId,
+    })
+
+    if (membershipResult.isErr()) {
+      if (membershipResult.error.code === 'DATABASE_ERROR') {
+        return c.json(errorResponse('INTERNAL_ERROR', 'Database error occurred'), 500)
+      }
+      // Fail closed: a missing organization and a non-member are indistinguishable.
+      return c.json(
+        errorResponse(
+          'ORG_ACCESS_DENIED',
+          'You do not have access to the target organization for this deployment'
+        ),
+        403
+      )
+    }
+
     const result = await database.transaction(async (tx) => {
       // 1. Clean up old dev deployments from the same developer
       await tx

--- a/apps/api/src/routes/installations.ts
+++ b/apps/api/src/routes/installations.ts
@@ -4,6 +4,7 @@ import { getDevInstallation } from '@auxx/services/app-installations'
 // Service imports
 // import { verifyAppAccess } from '../services/developer-accounts'
 import { verifyAppAccess } from '@auxx/services/developer-accounts'
+import { verifyOrgMembership } from '@auxx/services/organization-members'
 import { Hono } from 'hono'
 import { type ErrorStatusCode, errorResponse } from '../lib/response'
 import { authMiddleware } from '../middleware/auth'
@@ -21,6 +22,7 @@ const ERROR_STATUS_MAP: Record<string, ErrorStatusCode> = {
   APP_NOT_FOUND: 404,
   ACCESS_DENIED: 403,
   INSTALLATION_NOT_FOUND: 404,
+  ORG_ACCESS_DENIED: 403,
   DATABASE_ERROR: 500,
 }
 
@@ -44,7 +46,26 @@ installations.get(
       return c.json(errorResponse(error.code, error.message), statusCode)
     }
 
-    // Step 2: Get installation
+    // Step 2: Verify the caller belongs to the organization they are asking about.
+    // `organizationId` is a caller-supplied URL param and verifyAppAccess above
+    // only covers the developer account that owns the App — without this, any
+    // developer could probe whether their app is dev-installed in an arbitrary
+    // tenant. Same guard as the dev-deployment path in `deployments.ts`; the CLI
+    // already picks the org from the membership-scoped
+    // GET /developers/dev-organizations, so this only rejects forged requests.
+    const membershipResult = await verifyOrgMembership({ userId, organizationId })
+    if (membershipResult.isErr()) {
+      if (membershipResult.error.code === 'DATABASE_ERROR') {
+        return c.json(errorResponse('INTERNAL_ERROR', 'Database error occurred'), 500)
+      }
+      // Fail closed: a missing organization and a non-member look identical.
+      return c.json(
+        errorResponse('ORG_ACCESS_DENIED', 'You do not have access to this organization'),
+        403
+      )
+    }
+
+    // Step 3: Get installation
     const installationResult = await getDevInstallation({ appId, organizationId })
     if (installationResult.isErr()) {
       const error = installationResult.error

--- a/packages/services/src/organization-members/__tests__/verify-org-membership.test.ts
+++ b/packages/services/src/organization-members/__tests__/verify-org-membership.test.ts
@@ -1,0 +1,69 @@
+// packages/services/src/organization-members/__tests__/verify-org-membership.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const findFirst = vi.fn()
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    query: {
+      Organization: { findFirst: (...args: unknown[]) => findFirst(...args) },
+    },
+  },
+}))
+
+import { verifyOrgMembership } from '../verify-org-membership'
+
+const USER_ID = 'user_1'
+const ORG_ID = 'org_1'
+const MEMBER = { id: 'member_1', userId: USER_ID, organizationId: ORG_ID, role: 'member' }
+
+describe('verifyOrgMembership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the member for an active organization', async () => {
+    findFirst.mockResolvedValue({ id: ORG_ID, disabledAt: null, members: [MEMBER] })
+
+    const result = await verifyOrgMembership({ userId: USER_ID, organizationId: ORG_ID })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toMatchObject({ id: 'member_1' })
+  })
+
+  it('rejects a member of a disabled organization', async () => {
+    findFirst.mockResolvedValue({
+      id: ORG_ID,
+      disabledAt: new Date(),
+      disabledReason: 'non-payment',
+      members: [MEMBER],
+    })
+
+    const result = await verifyOrgMembership({ userId: USER_ID, organizationId: ORG_ID })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toMatchObject({
+      code: 'ORG_DISABLED',
+      disabledReason: 'non-payment',
+    })
+  })
+
+  it('rejects a non-member of an active organization', async () => {
+    findFirst.mockResolvedValue({ id: ORG_ID, disabledAt: null, members: [] })
+
+    const result = await verifyOrgMembership({ userId: USER_ID, organizationId: ORG_ID })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toMatchObject({ code: 'NOT_MEMBER' })
+  })
+
+  it('rejects a missing organization', async () => {
+    findFirst.mockResolvedValue(undefined)
+
+    const result = await verifyOrgMembership({ userId: USER_ID, organizationId: ORG_ID })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toMatchObject({ code: 'ORGANIZATION_NOT_FOUND' })
+  })
+})

--- a/packages/services/src/organization-members/errors.ts
+++ b/packages/services/src/organization-members/errors.ts
@@ -24,4 +24,10 @@ export type OrganizationMemberError =
       message: string
       organizationId: string
     }
+  | {
+      code: 'ORG_DISABLED'
+      message: string
+      organizationId: string
+      disabledReason: string | null
+    }
   | DatabaseError

--- a/packages/services/src/organization-members/verify-org-membership.ts
+++ b/packages/services/src/organization-members/verify-org-membership.ts
@@ -1,4 +1,4 @@
-// apps/api/src/services/organization-members/verify-org-membership.ts
+// packages/services/src/organization-members/verify-org-membership.ts
 
 import { database } from '@auxx/database'
 import { err, ok, type Result } from 'neverthrow'
@@ -6,7 +6,11 @@ import { fromDatabase } from '../shared/utils'
 import type { OrganizationMemberError } from './errors'
 
 /**
- * Verify that a user is a member of an organization
+ * Verify that a user is an active member of an organization, by organization id.
+ *
+ * The id-keyed counterpart to `verifyOrganizationAccess` (which keys off a
+ * handle). Both reject disabled organizations, so a caller cannot gain access to
+ * a disabled tenant by addressing it by id instead of by handle.
  *
  * @param params - Object containing userId and organizationId
  * @returns Result with organization member data or an error
@@ -22,11 +26,15 @@ export async function verifyOrgMembership(params: {
 > {
   const { userId, organizationId } = params
 
-  // Query database with error handling
+  // One query, joined so `disabledAt` is checked without a second round trip.
   const dbResult = await fromDatabase(
-    database.query.OrganizationMember.findFirst({
-      where: (members, { and, eq }) =>
-        and(eq(members.organizationId, organizationId), eq(members.userId, userId)),
+    database.query.Organization.findFirst({
+      where: (orgs, { eq }) => eq(orgs.id, organizationId),
+      with: {
+        members: {
+          where: (members, { eq }) => eq(members.userId, userId),
+        },
+      },
     }),
     'verify-org-membership'
   )
@@ -36,7 +44,28 @@ export async function verifyOrgMembership(params: {
     return err(dbResult.error)
   }
 
-  const member = dbResult.value
+  const organization = dbResult.value
+
+  // Organization not found
+  if (!organization) {
+    return err({
+      code: 'ORGANIZATION_NOT_FOUND' as const,
+      message: `Organization ${organizationId} not found`,
+      organizationId,
+    })
+  }
+
+  // Organization is disabled — no member of a disabled org has access.
+  if (organization.disabledAt) {
+    return err({
+      code: 'ORG_DISABLED' as const,
+      message: organization.disabledReason || 'This organization has been disabled',
+      organizationId,
+      disabledReason: organization.disabledReason,
+    })
+  }
+
+  const member = organization.members?.[0]
 
   // Member not found
   if (!member) {


### PR DESCRIPTION
## The problem

`POST /api/v1/apps/:appId/deployments` read `targetOrganizationId` from the **request body** and, in the `deploymentType === 'development'` branch, inserted an `AppInstallation` for that organization — installing the caller's server bundle into that tenant, where it later executes as app code.

Nothing verified the caller belonged to that org:

- `authMiddleware` sets only `userId` / `user` / `scopes` — no org binding
- `requireScope(['developer','apps:write'])` is a pure token-scope check
- `verifyAppAccess({ appId, userId })` covers only the developer account that owns the App; it never receives `targetOrganizationId`
- `organizationMiddleware` does the right check but keys off a `:handle` URL param and is not mounted on this router

Developer accounts are self-serve (`apps/build` → `create: protectedProcedure`), so the path was: sign up → create developer account → create app → upload bundle → deploy with someone else's org id.

## Why the fix is safe

The invariant already exists — it was just enforced client-side. The CLI picks the org from `GET /api/v1/developers/dev-organizations` → `listUserOrganizations({ userId })`, a membership-scoped query, and even the `-o <handle>` flag resolves *within* that scoped list. There is no legitimate flow where a developer dev-installs into an org they aren't a member of.

## Changes

- **`deployments.ts`** — dev branch requires `targetOrganizationId` (400 if absent) and asserts membership before the transaction. Non-member and nonexistent org are indistinguishable (403 `ORG_ACCESS_DENIED`); DB errors surface as 500.
- **`installations.ts`** — same guard on `GET /:appId/organization/:organizationId/dev-installation`, which took the org from a URL param and acted as an existence oracle for whether the caller's app was dev-installed in an arbitrary tenant.
- **`verify-org-membership.ts`** — now joins `Organization` and rejects disabled orgs, matching the handle-keyed `verifyOrganizationAccess`. Previously a disabled tenant was reachable by addressing it by id instead of by handle. The third caller (`validate-workflow-access.ts`) branches on `NOT_MEMBER` vs. everything-else → denied, so it picks up the new `ORG_DISABLED` code correctly with no edit.

## Notes for review

- **Caching:** deliberately a direct indexed `OrganizationMember` lookup rather than the cached `isOrgMember` from `@auxx/lib/cache`. Runs once per bundle upload, not on a hot read path; security boundary where the org-cache staleness window is undesirable; cheaper than materializing the whole `members` blob for one boolean. `@auxx/lib` *is* a declared dep of `apps/api`, so this was a choice, not a constraint.
- **Reuses `verifyOrgMembership`** rather than adding a `verifyOrganizationAccessById` — the id-keyed service already existed and was already in use.
- `installations.ts` returns 403 for a disabled org rather than the 410 `organizationMiddleware` uses, to avoid confirming org state to a non-member.

## Verification

- `apps/api`: 17 tests / 3 files pass; `tsc --noEmit` exit 0
- `packages/services`: 6 tests / 2 files pass; `tsc --noEmit` exit 0
- All new tests assert **status codes**, and each guard was temporarily neutered to confirm the tests fail without it (`expected 200 to be 403`, `expected false to be true`) rather than passing vacuously