### PR TITLE
fix(kb): gate preview routes and learned-memory readers on kb access

### DIFF
--- a/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/preview-redirect-instance-access.test.ts
+++ b/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/preview-redirect-instance-access.test.ts
@@ -1,0 +1,203 @@
+// apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/preview-redirect-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The stable-id redirect behind `auxx://kb/article/{id}` links (plan v3/06 §3.3
+ * X7). Three separate holes, all in one handler:
+ *
+ * 1. The `ArticlePlacement` query carried **no `organizationId` filter**, so it
+ *    resolved placements from any org.
+ * 2. The org guard was `if (userOrgId && userOrgId !== row.organizationId)` —
+ *    the `userOrgId &&` short-circuit meant a session with no
+ *    `defaultOrganizationId` passed it entirely. That made the route
+ *    cross-**org**, not merely cross-KB.
+ * 3. There was no KB instance gate at all. It only 308s, so it discloses the
+ *    target's slug path rather than the body — still a read of a KB the member
+ *    may be explicitly denied.
+ *
+ * The gate keys on the **resolved target** KB (`row.knowledgeBaseId`), not the
+ * URL's: a cross-KB internal link redirects to a different KB than it names.
+ *
+ * ⚠ Route handlers get no `auxxErrorMiddleware`, so these pin the **status
+ * code**.
+ */
+
+const { getCapabilities, getSession, select, where, eq, and } = vi.hoisted(() => ({
+  getCapabilities: vi.fn(),
+  getSession: vi.fn(),
+  select: vi.fn(),
+  where: vi.fn(),
+  eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+  and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: { select },
+  ArticlePlacement: {
+    id: 'ArticlePlacement.id',
+    slug: 'ArticlePlacement.slug',
+    parentId: 'ArticlePlacement.parentId',
+    articleId: 'ArticlePlacement.articleId',
+    knowledgeBaseId: 'ArticlePlacement.knowledgeBaseId',
+    organizationId: 'ArticlePlacement.organizationId',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({ and, eq }))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest — stub it, keep the
+// enums real via `/client` (see `kb-article-instance-access.test.ts`).
+vi.mock('@auxx/lib/permissions', () => ({ getCapabilities }))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const OTHER_ORG_ID = 'org_otheruid0000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const KB_ID = 'kb_cuid0000000000000000000000'
+const ARTICLE_ID = 'art_cuid000000000000000000000'
+const PLACEMENT_ID = 'plc_cuid000000000000000000000'
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/** A real `CapabilitySet` holding `permission` on {@link KB_ID} via an explicit row. */
+function capabilitiesFor(permission: ResourcePermission, areaLevel = AREA_LEVEL_OF[permission]) {
+  const instances = { [KB_ID]: permissionToRung(permission) }
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/** A real `CapabilitySet` with no instance rows at all — pure area level. */
+function areaOnly(level: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+function signedIn(capabilities: InstanceType<typeof CapabilitySet>, orgId: string | null = ORG_ID) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: orgId, isSuperAdmin: false },
+  })
+  getCapabilities.mockResolvedValue(capabilities)
+}
+
+const request = () =>
+  ({
+    url: `https://app.auxx.ai/preview/kb/${KB_ID}/r/${ARTICLE_ID}`,
+    nextUrl: { pathname: `/preview/kb/${KB_ID}/r/${ARTICLE_ID}` },
+  }) as never
+
+const ctx = { params: Promise.resolve({ knowledgeBaseId: KB_ID, articleId: ARTICLE_ID }) }
+
+/** Placement rows returned by the first `select`; the slug walk gets the second. */
+function placements(rows: Array<Record<string, unknown>>) {
+  where
+    .mockResolvedValueOnce(rows)
+    .mockResolvedValue([{ id: PLACEMENT_ID, slug: 'getting-started', parentId: null }])
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  eq.mockClear()
+  and.mockClear()
+  where.mockReset()
+  select.mockReset().mockReturnValue({ from: () => ({ where }) })
+})
+
+describe('GET /preview/kb/[kbId]/r/[articleId] — org scope + KB gate', () => {
+  it('redirects to login without a session, before any read', async () => {
+    getSession.mockResolvedValue(null)
+    placements([{ id: PLACEMENT_ID, knowledgeBaseId: KB_ID, organizationId: ORG_ID }])
+    const res = await GET(request(), ctx)
+    expect(res.status).toBe(307)
+    expect(select).not.toHaveBeenCalled()
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('403s a session with no organization instead of resolving the article', async () => {
+    // The old guard was `userOrgId && userOrgId !== row.organizationId`, so an
+    // org-less session skipped it and got another org's slug path.
+    signedIn(capabilitiesFor(ResourcePermission.admin), null)
+    placements([{ id: PLACEMENT_ID, knowledgeBaseId: KB_ID, organizationId: OTHER_ORG_ID }])
+    const res = await GET(request(), ctx)
+    expect(res.status).toBe(403)
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('scopes the placement read by organization', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    placements([{ id: PLACEMENT_ID, knowledgeBaseId: KB_ID, organizationId: ORG_ID }])
+    await GET(request(), ctx)
+    expect(eq).toHaveBeenCalledWith('ArticlePlacement.organizationId', ORG_ID)
+  })
+
+  it('403s — not 500 — a member composing `knowledgeBase: None`', async () => {
+    signedIn(areaOnly(Level.None))
+    placements([{ id: PLACEMENT_ID, knowledgeBaseId: KB_ID, organizationId: ORG_ID }])
+    const res = await GET(request(), ctx)
+    expect(res.status).toBe(403)
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('403s a member holding an explicit `none` restriction on the KB', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.none, Level.Full))
+    placements([{ id: PLACEMENT_ID, knowledgeBaseId: KB_ID, organizationId: ORG_ID }])
+    const res = await GET(request(), ctx)
+    expect(res.status).toBe(403)
+  })
+
+  it('308s to the slug path for a member holding instance `view`', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    placements([{ id: PLACEMENT_ID, knowledgeBaseId: KB_ID, organizationId: ORG_ID }])
+    const res = await GET(request(), ctx)
+    expect(res.status).toBe(308)
+    expect(res.headers.get('location')).toBe(
+      `https://app.auxx.ai/preview/kb/${KB_ID}/getting-started`
+    )
+  })
+
+  it('gates the RESOLVED target KB, not the URL segment', async () => {
+    // The link names KB_ID but the only placement lives in a KB the member is
+    // denied — asserting on the URL segment would wave this through.
+    const TARGET_KB = 'kb_targetuid00000000000000000'
+    signedIn(capabilitiesFor(ResourcePermission.admin, Level.None))
+    placements([{ id: PLACEMENT_ID, knowledgeBaseId: TARGET_KB, organizationId: ORG_ID }])
+    const res = await GET(request(), ctx)
+    expect(res.status).toBe(403)
+  })
+
+  it('404s when the article has no placement in the caller org', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.admin))
+    placements([])
+    const res = await GET(request(), ctx)
+    expect(res.status).toBe(404)
+    expect(getCapabilities).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/route.ts
+++ b/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/route.ts
@@ -6,7 +6,8 @@
 // target's *actual* KB id, so cross-KB internal links navigate correctly.
 
 import { ArticlePlacement, database } from '@auxx/database'
-import { eq } from 'drizzle-orm'
+import { getCapabilities } from '@auxx/lib/permissions'
+import { and, eq } from 'drizzle-orm'
 import { headers } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 import { auth } from '~/auth/server'
@@ -15,6 +16,22 @@ interface RouteContext {
   params: Promise<{ knowledgeBaseId: string; articleId: string }>
 }
 
+/**
+ * Authorization, in order — all three of these were holes:
+ *
+ * 1. **Org.** The placement query carried no `organizationId` filter and the
+ *    guard below was `userOrgId && userOrgId !== row.organizationId`, so a
+ *    session with no `defaultOrganizationId` skipped it entirely and resolved
+ *    ANOTHER org's article id. The read is now org-scoped and the guard is
+ *    unconditional: an absent org is a 403, not a pass.
+ * 2. **KB instance access.** There was none. The gate keys on the *resolved
+ *    target* KB (`row.knowledgeBaseId`), not the URL's — the redirect lands on
+ *    the target, which for a cross-KB internal link is a different KB.
+ * 3. Everything below stays a 308 to a surface that gates independently.
+ *
+ * ⚠ Route handlers get no `auxxErrorMiddleware`, so denials are hand-mapped
+ * status codes — an `AuxxError` thrown here would surface as a 500.
+ */
 export async function GET(req: NextRequest, ctx: RouteContext): Promise<Response> {
   const { knowledgeBaseId, articleId } = await ctx.params
   if (!articleId) {
@@ -28,7 +45,15 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<Response
     )
   }
 
+  const userOrgId = (session.user as { defaultOrganizationId?: string | null })
+    .defaultOrganizationId
+  if (!userOrgId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   // Resolve the article's placement — prefer the link's source KB, else any.
+  // Org-scoped, so another org's article id is indistinguishable from one that
+  // never existed (both → 404).
   const placements = await database
     .select({
       id: ArticlePlacement.id,
@@ -36,17 +61,22 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<Response
       organizationId: ArticlePlacement.organizationId,
     })
     .from(ArticlePlacement)
-    .where(eq(ArticlePlacement.articleId, articleId))
+    .where(
+      and(eq(ArticlePlacement.articleId, articleId), eq(ArticlePlacement.organizationId, userOrgId))
+    )
 
   const row = placements.find((p) => p.knowledgeBaseId === knowledgeBaseId) ?? placements[0]
   if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-  // Authorize against the *target* article's org. Cross-org leakage would
-  // be a problem, but we expect the picker to scope to the active org so
-  // this is mostly a sanity check.
-  const userOrgId = (session.user as { defaultOrganizationId?: string | null })
-    .defaultOrganizationId
-  if (userOrgId && userOrgId !== row.organizationId) {
+  // Belt-and-braces after the scoped read above.
+  if (userOrgId !== row.organizationId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // The redirect discloses the target's slug path, so it needs the same instance
+  // gate as the preview it points at (`kb.getArticles` / the `.md` route).
+  const capabilities = await getCapabilities(session.user.id, userOrgId)
+  if (!capabilities.canViewInstance('kb', row.knowledgeBaseId)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 

--- a/apps/web/src/app/(protected)/preview/kb/md/[knowledgeBaseId]/[[...articleSlug]]/preview-md-instance-access.test.ts
+++ b/apps/web/src/app/(protected)/preview/kb/md/[knowledgeBaseId]/[[...articleSlug]]/preview-md-instance-access.test.ts
@@ -1,0 +1,203 @@
+// apps/web/src/app/(protected)/preview/kb/md/[knowledgeBaseId]/[[...articleSlug]]/preview-md-instance-access.test.ts
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The `.md` preview route — the widest article read in the product (plan v3/06
+ * §3.3 X6).
+ *
+ * Its ONLY authorization was "there is a session and it carries a
+ * `defaultOrganizationId`". It then ran `getArticles(kbId, { includeUnpublished:
+ * true })` and returned the article's full DRAFT Markdown body, for ANY KB id in
+ * the org — hidden `source` KBs, AI Memory, unpublished drafts. The tRPC sibling
+ * `kb.getArticles` runs `assertViewInstance('kb', kbId)`.
+ *
+ * ⚠ Route handlers get no `auxxErrorMiddleware`, so these pin the **status
+ * code**: an `AuxxError` escaping here would be a 500, not a 403.
+ *
+ * Behavioral: the handler runs with a REAL `CapabilitySet`, and `KBService`
+ * reads are the observed side effect — the gate must land ahead of them.
+ */
+
+const {
+  getCapabilities,
+  getSession,
+  getArticles,
+  getArticleById,
+  findArticleBySlugPath,
+  findFirstNavigableUnder,
+} = vi.hoisted(() => ({
+  getCapabilities: vi.fn(),
+  getSession: vi.fn(),
+  getArticles: vi.fn(),
+  getArticleById: vi.fn(),
+  findArticleBySlugPath: vi.fn(),
+  findFirstNavigableUnder: vi.fn(),
+}))
+
+vi.mock('@auxx/database', () => ({ database: {} }))
+
+vi.mock('@auxx/lib/kb', () => ({
+  KBService: class {
+    getArticles = getArticles
+    getArticleById = getArticleById
+  },
+  articleToMarkdown: () => 'body text',
+}))
+
+// The `@auxx/lib/permissions` barrel HANGS under vitest — stub it, keep the
+// enums real via `/client` (see `kb-article-instance-access.test.ts`).
+vi.mock('@auxx/lib/permissions', () => ({ getCapabilities }))
+
+vi.mock('@auxx/ui/components/kb', () => ({
+  findArticleBySlugPath,
+  findFirstNavigableUnder,
+  getFullSlugPath: () => 'some/path',
+}))
+
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Deep path on purpose — the barrel hangs (see above).
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { permissionToRung } = await import('@auxx/lib/permissions/capabilities/rung')
+const { GET } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const KB_ID = 'kb_cuid0000000000000000000000'
+const ARTICLE_ID = 'art_cuid000000000000000000000'
+
+const AREA_LEVEL_OF: Record<ResourcePermission, Level> = {
+  [ResourcePermission.none]: Level.None,
+  [ResourcePermission.view]: Level.Read,
+  [ResourcePermission.edit]: Level.Edit,
+  [ResourcePermission.admin]: Level.Full,
+}
+
+/** A real `CapabilitySet` holding `permission` on {@link KB_ID} via an explicit row. */
+function capabilitiesFor(permission: ResourcePermission, areaLevel = AREA_LEVEL_OF[permission]) {
+  const instances = { [KB_ID]: permissionToRung(permission) }
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/** A real `CapabilitySet` with no instance rows at all — pure area level. */
+function areaOnly(level: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+function signedIn(capabilities: InstanceType<typeof CapabilitySet>) {
+  getSession.mockResolvedValue({
+    user: { id: USER_ID, defaultOrganizationId: ORG_ID, isSuperAdmin: false },
+  })
+  getCapabilities.mockResolvedValue(capabilities)
+}
+
+const request = () => new Request('https://app.auxx.ai/preview/kb/md/kb_x/getting-started')
+const params = {
+  params: Promise.resolve({ knowledgeBaseId: KB_ID, articleSlug: ['getting-started'] }),
+}
+
+beforeEach(() => {
+  getSession.mockReset()
+  getCapabilities.mockReset()
+  getArticles.mockReset().mockResolvedValue([{ id: ARTICLE_ID, articleKind: 'page' }])
+  getArticleById
+    .mockReset()
+    .mockResolvedValue({ title: 'Secret runbook', contentJson: [{ type: 'paragraph' }] })
+  findArticleBySlugPath.mockReset().mockReturnValue({ id: ARTICLE_ID, articleKind: 'page' })
+  findFirstNavigableUnder.mockReset().mockReturnValue({ id: ARTICLE_ID, articleKind: 'page' })
+})
+
+describe('GET /preview/kb/md/[knowledgeBaseId] — the draft-body hole', () => {
+  it('401s without a session, before any capability or KB read', async () => {
+    getSession.mockResolvedValue(null)
+    const res = await GET(request(), params)
+    expect(res.status).toBe(401)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(getArticles).not.toHaveBeenCalled()
+  })
+
+  it('403s a session with no organization, before any capability or KB read', async () => {
+    getSession.mockResolvedValue({ user: { id: USER_ID, isSuperAdmin: false } })
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(getCapabilities).not.toHaveBeenCalled()
+    expect(getArticles).not.toHaveBeenCalled()
+  })
+
+  it('403s — not 500 — a member composing `knowledgeBase: None`', async () => {
+    signedIn(areaOnly(Level.None))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    // The gate must precede the read: `getArticles` is what fetches the draft.
+    expect(getArticles).not.toHaveBeenCalled()
+    expect(getArticleById).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding an explicit `none` restriction on the KB', async () => {
+    // THE case this fix exists for: the area is wide open (Full) and only the
+    // per-instance `none` row stands between the caller and the draft body.
+    signedIn(capabilitiesFor(ResourcePermission.none, Level.Full))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(403)
+    expect(getArticles).not.toHaveBeenCalled()
+  })
+
+  it('never emits the draft markdown on the denied path', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.none, Level.Full))
+    const res = await GET(request(), params)
+    const text = await res.text()
+    expect(text).not.toContain('Secret runbook')
+    expect(text).not.toContain('body text')
+    expect(res.headers.get('content-type')).not.toContain('text/markdown')
+  })
+
+  it('200s with the markdown for a member holding instance `view` on the KB', async () => {
+    signedIn(capabilitiesFor(ResourcePermission.view))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    expect(await res.text()).toBe('# Secret runbook\n\nbody text')
+  })
+
+  it('200s for a row-less KB at the area Read rung (baselineAtCreate: false)', async () => {
+    signedIn(areaOnly(Level.Read))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+  })
+
+  it('gates on the requested KB, not the area, when only an instance row grants it', async () => {
+    // Area None, and the ONLY grant is an explicit `view` row on the KB.
+    signedIn(capabilitiesFor(ResourcePermission.view, Level.None))
+    const res = await GET(request(), params)
+    expect(res.status).toBe(200)
+  })
+
+  it('403s a KB the member holds no row on while holding another at admin', async () => {
+    // The URL's KB id is caller-supplied — holding one KB must not open a second.
+    signedIn(capabilitiesFor(ResourcePermission.admin, Level.None))
+    const res = await GET(request(), {
+      params: Promise.resolve({ knowledgeBaseId: 'kb_otheruid00000000000000000' }),
+    })
+    expect(res.status).toBe(403)
+    expect(getArticles).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/(protected)/preview/kb/md/[knowledgeBaseId]/[[...articleSlug]]/route.ts
+++ b/apps/web/src/app/(protected)/preview/kb/md/[knowledgeBaseId]/[[...articleSlug]]/route.ts
@@ -1,7 +1,8 @@
-// apps/web/src/app/(protected)/preview/kb/_md/[knowledgeBaseId]/[[...articleSlug]]/route.ts
+// apps/web/src/app/(protected)/preview/kb/md/[knowledgeBaseId]/[[...articleSlug]]/route.ts
 
 import { database } from '@auxx/database'
 import { articleToMarkdown, KBService } from '@auxx/lib/kb'
+import { getCapabilities } from '@auxx/lib/permissions'
 import {
   findArticleBySlugPath,
   findFirstNavigableUnder,
@@ -17,8 +18,25 @@ interface RouteParams {
 /**
  * Plain-Markdown preview of a KB article's draft revision. Reached via
  * `/preview/kb/<id>/<slug>.md` after `proxy.ts` rewrites the suffix onto
- * this internal `_md` segment. Admin-only — auth happens here because route
- * handlers don't inherit the (protected) layout's auth check.
+ * this internal `md` segment. Auth happens here because route handlers don't
+ * inherit the (protected) layout's auth check — and that layout is a bare
+ * `<div>` anyway, so there is no second line of defence.
+ *
+ * Gated on instance **`view`** of the requested KnowledgeBase, matching the
+ * tRPC sibling `kb.getArticles` (`capabilityProcedure` +
+ * `assertViewInstance('kb', kbId)`) and the SSE route
+ * (`api/kb/articles/[articleId]/events`). Before this, session + org membership
+ * was the whole check, so any authenticated org member could read the full
+ * DRAFT Markdown body of any article in any KB in the org — including hidden
+ * `source` KBs, AI Memory, and unpublished drafts.
+ *
+ * The gate keys on the URL's KB because that is the KB whose placement tree is
+ * walked below (`getArticles` is KB-scoped): reads are placement-permissive, so
+ * an article homed elsewhere but linked into a KB the viewer holds stays
+ * readable through that KB, exactly as `kb.getArticles` already allows.
+ *
+ * ⚠ Route handlers get no `auxxErrorMiddleware`, so the denial is a hand-mapped
+ * status code — an `AuxxError` thrown here would surface as a 500.
  */
 export async function GET(req: Request, { params }: RouteParams): Promise<Response> {
   const { knowledgeBaseId, articleSlug = [] } = await params
@@ -28,6 +46,11 @@ export async function GET(req: Request, { params }: RouteParams): Promise<Respon
 
   const orgId = (session.user as { defaultOrganizationId?: string | null }).defaultOrganizationId
   if (!orgId) return new Response('Forbidden', { status: 403 })
+
+  const capabilities = await getCapabilities(session.user.id, orgId)
+  if (!capabilities.canViewInstance('kb', knowledgeBaseId)) {
+    return new Response('Forbidden', { status: 403 })
+  }
 
   const service = new KBService(database, orgId)
   const articles = await service.getArticles(knowledgeBaseId, { includeUnpublished: true })

--- a/apps/web/src/server/api/routers/kb-learned-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/kb-learned-instance-access.test.ts
@@ -1,0 +1,320 @@
+// apps/web/src/server/api/routers/kb-learned-instance-access.test.ts
+
+import type { ResourcePermission } from '@auxx/database/enums'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `kb.learnedArticleDiff` / `kb.learnedProvenance` (plan v3/06 §3.2 K5).
+ *
+ * Both gated on `assert(PermissionKey.knowledgeBaseView)` alone — an AREA check
+ * with no instance check — and neither was restricted to the learned KB. Since
+ * `articleId` is caller-supplied, `learnedArticleDiff({ articleId, markdown:
+ * '' })` renders the target article's ENTIRE published body as removed diff
+ * lines: a full-content read of any article in the org for anyone at
+ * `knowledgeBase: Read`. `learnedProvenance` additionally returned `Thread`
+ * subject lines with no mail lens.
+ *
+ * The fix keeps the area assert and ADDS `assertViewInstance('kb', homeKbId)`,
+ * matching every other article read in this router. The mail clamp is separate:
+ * a subject is `identity`-tier (`permissions/visibility/lens.ts`), so KB access
+ * alone must not surface it.
+ */
+
+const {
+  getLearnedArticleDiff,
+  getLearnedProvenance,
+  getThreadLensBatch,
+  getCachedUserInstanceGrants,
+  getUserOrganizationId,
+  articleLimit,
+  select,
+  eq,
+  and,
+} = vi.hoisted(() => ({
+  getLearnedArticleDiff: vi.fn(async () => ({
+    found: true,
+    currentTitle: 'Refund policy',
+    lines: [{ kind: 'removed', text: 'We refund within 30 days.' }],
+    addedCount: 0,
+    removedCount: 1,
+  })),
+  getLearnedProvenance: vi.fn(),
+  getThreadLensBatch: vi.fn(),
+  getCachedUserInstanceGrants: vi.fn(async () => ({ grants: {}, defEntityTypes: {} })),
+  getUserOrganizationId: vi.fn(() => 'org_cuid000000000000000000000'),
+  articleLimit: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+  and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: {
+    Article: {
+      id: 'Article.id',
+      organizationId: 'Article.organizationId',
+      homeKnowledgeBaseId: 'Article.homeKnowledgeBaseId',
+    },
+    ArticleRevision: { id: 'ArticleRevision.id', articleId: 'ArticleRevision.articleId' },
+    KnowledgeBase: { id: 'KnowledgeBase.id', organizationId: 'KnowledgeBase.organizationId' },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({ and, eq, count: vi.fn(() => 'count') }))
+
+vi.mock('@auxx/lib/kb', () => ({
+  KBService: class {
+    getArticleSlugPath = vi.fn(async () => 'some/path')
+  },
+  getLearnedArticleDiff,
+  getLearnedProvenance,
+  ensureLearnedKb: vi.fn(async () => ({ kb: { id: 'kb_learned' } })),
+  articleToMarkdown: vi.fn(() => ''),
+  linkArticlesIntoKb: vi.fn(async () => undefined),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  onCacheEvent: vi.fn(async () => undefined),
+  getCachedUserInstanceGrants,
+}))
+vi.mock('@auxx/lib/email', () => ({ getUserOrganizationId }))
+vi.mock('@auxx/lib/permissions/visibility', () => ({ getThreadLensBatch }))
+vi.mock('~/server/lib/kb-revalidate', () => ({ fireKBRevalidate: vi.fn(() => Promise.resolve()) }))
+
+// The permissions barrel hangs under vitest — hand back the real enums and the
+// real rung comparator, plus a stub feature service.
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  const rung = await import('@auxx/lib/permissions/capabilities/rung')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    satisfiesRung: rung.satisfiesRung,
+    FeaturePermissionService: class {
+      requireAccess = vi.fn(async () => undefined)
+      requireAccessAndLimit = vi.fn(async () => undefined)
+    },
+  }
+})
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  }
+})
+
+// Deep path on purpose — see the note above.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { knowledgeBaseRouter } = await import('./kb')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+/** The article's home KB — the gate's subject. */
+const KB_ID = 'kb_cuid0000000000000000000000'
+const ARTICLE_ID = 'art_cuid000000000000000000000'
+const THREAD_ID = 'thr_cuid000000000000000000000'
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to 403). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+/** A real `CapabilitySet` holding `permission` on {@link KB_ID} via an explicit row. */
+function capabilitiesFor(
+  permission: ResourcePermission,
+  areaLevel: Level = {
+    none: Level.None,
+    read: Level.Read,
+    edit: Level.Edit,
+    admin: Level.Full,
+  }[permission]
+) {
+  const instances = { [KB_ID]: permission }
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: areaLevel })),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances))
+  )
+}
+
+/** A real `CapabilitySet` with no instance rows at all — pure area level. */
+function areaOnly(level: Level) {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.knowledgeBase]: level })),
+    {},
+    'MEMBER',
+    'full'
+  )
+}
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return knowledgeBaseRouter.createCaller({
+    db: { select },
+    capabilities,
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID },
+    },
+  } as never)
+}
+
+beforeEach(() => {
+  getLearnedArticleDiff.mockClear()
+  getLearnedProvenance.mockReset().mockResolvedValue([
+    {
+      threadId: THREAD_ID,
+      subject: 'Refund for order #1042',
+      extractedAt: '2026-07-01T00:00:00Z',
+    },
+  ])
+  getThreadLensBatch.mockReset().mockResolvedValue(new Map([[THREAD_ID, 'read']]))
+  getCachedUserInstanceGrants.mockClear()
+  eq.mockClear()
+  and.mockClear()
+  articleLimit.mockReset().mockResolvedValue([{ knowledgeBaseId: KB_ID }])
+  select.mockReset().mockReturnValue({ from: () => ({ where: () => ({ limit: articleLimit }) }) })
+})
+
+describe('kb.learnedArticleDiff — the full-body disclosure', () => {
+  it('403s a member composing `knowledgeBase: None` on the area assert alone', async () => {
+    await expect(
+      caller(areaOnly(Level.None)).learnedArticleDiff({ articleId: ARTICLE_ID, markdown: 'x' })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(getLearnedArticleDiff).not.toHaveBeenCalled()
+  })
+
+  it('403s `markdown: ""` for a KB the member holds an explicit `none` on', async () => {
+    // THE case. The area is wide open (Full) — only the per-instance `none` row
+    // stands between the caller and every published line of the article, which
+    // an empty proposal renders as removed diff lines.
+    await expect(
+      caller(capabilitiesFor('none', Level.Full)).learnedArticleDiff({
+        articleId: ARTICLE_ID,
+        markdown: '',
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(getLearnedArticleDiff).not.toHaveBeenCalled()
+  })
+
+  it('403s an area-Read member with no row on the article home KB', async () => {
+    // The pre-fix bar: `knowledgeBase: Read` and nothing else. `kb` is
+    // `baselineAtCreate: false`, so an area-None member with no row composes
+    // `undefined` — this member holds Read on the area but the KB carries a
+    // restricting row for someone else, i.e. the restricted set is non-empty.
+    await expect(
+      caller(capabilitiesFor('none', Level.Read)).learnedArticleDiff({
+        articleId: ARTICLE_ID,
+        markdown: '',
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(getLearnedArticleDiff).not.toHaveBeenCalled()
+  })
+
+  it('resolves the gate subject from the article home KB, org-scoped', async () => {
+    await caller(capabilitiesFor('read')).learnedArticleDiff({
+      articleId: ARTICLE_ID,
+      markdown: 'x',
+    })
+    expect(eq).toHaveBeenCalledWith('Article.id', ARTICLE_ID)
+    expect(eq).toHaveBeenCalledWith('Article.organizationId', ORG_ID)
+  })
+
+  it('200s for a member holding instance `read` on the home KB', async () => {
+    await expect(
+      caller(capabilitiesFor('read')).learnedArticleDiff({ articleId: ARTICLE_ID, markdown: '' })
+    ).resolves.toMatchObject({ found: true })
+    expect(getLearnedArticleDiff).toHaveBeenCalledTimes(1)
+  })
+
+  it('200s for a row-less KB at the area Read rung (baselineAtCreate: false)', async () => {
+    await expect(
+      caller(areaOnly(Level.Read)).learnedArticleDiff({ articleId: ARTICLE_ID, markdown: 'x' })
+    ).resolves.toBeDefined()
+  })
+
+  it('404s an article outside the caller org before the instance gate', async () => {
+    articleLimit.mockResolvedValue([])
+    await expect(
+      caller(capabilitiesFor('admin')).learnedArticleDiff({ articleId: ARTICLE_ID, markdown: '' })
+    ).rejects.toMatchObject({ cause: { name: 'NotFoundError', statusCode: 404 } })
+    expect(getLearnedArticleDiff).not.toHaveBeenCalled()
+  })
+})
+
+describe('kb.learnedProvenance — KB gate plus the mail clamp', () => {
+  it('403s a member composing `knowledgeBase: None`', async () => {
+    await expect(
+      caller(areaOnly(Level.None)).learnedProvenance({ articleId: ARTICLE_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(getLearnedProvenance).not.toHaveBeenCalled()
+  })
+
+  it('403s a member holding an explicit `none` restriction on the home KB', async () => {
+    await expect(
+      caller(capabilitiesFor('none', Level.Full)).learnedProvenance({ articleId: ARTICLE_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(getLearnedProvenance).not.toHaveBeenCalled()
+  })
+
+  it('200s and keeps the subject at mail lens `read`', async () => {
+    await expect(
+      caller(capabilitiesFor('read')).learnedProvenance({ articleId: ARTICLE_ID })
+    ).resolves.toEqual([
+      {
+        threadId: THREAD_ID,
+        subject: 'Refund for order #1042',
+        extractedAt: '2026-07-01T00:00:00Z',
+      },
+    ])
+  })
+
+  it('keeps the subject at lens `identity` — the tier that grants subject', async () => {
+    getThreadLensBatch.mockResolvedValue(new Map([[THREAD_ID, 'identity']]))
+    const [source] = await caller(capabilitiesFor('read')).learnedProvenance({
+      articleId: ARTICLE_ID,
+    })
+    expect(source?.subject).toBe('Refund for order #1042')
+  })
+
+  it('nulls the subject at lens `metadata` — below the subject tier', async () => {
+    getThreadLensBatch.mockResolvedValue(new Map([[THREAD_ID, 'metadata']]))
+    const [source] = await caller(capabilitiesFor('read')).learnedProvenance({
+      articleId: ARTICLE_ID,
+    })
+    expect(source).toEqual({
+      threadId: THREAD_ID,
+      subject: null,
+      extractedAt: '2026-07-01T00:00:00Z',
+    })
+  })
+
+  it('nulls the subject for a thread absent from the lens map (deleted / invisible)', async () => {
+    getThreadLensBatch.mockResolvedValue(new Map())
+    const [source] = await caller(capabilitiesFor('read')).learnedProvenance({
+      articleId: ARTICLE_ID,
+    })
+    expect(source?.subject).toBeNull()
+  })
+
+  it('skips the lens read entirely when the article has no provenance', async () => {
+    getLearnedProvenance.mockResolvedValue([])
+    await expect(
+      caller(capabilitiesFor('read')).learnedProvenance({ articleId: ARTICLE_ID })
+    ).resolves.toEqual([])
+    expect(getThreadLensBatch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -3,7 +3,7 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { ArticleStatus } from '@auxx/database/enums'
-import { onCacheEvent } from '@auxx/lib/cache'
+import { getCachedUserInstanceGrants, onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { NotFoundError } from '@auxx/lib/errors'
 import {
@@ -14,7 +14,13 @@ import {
   KBService,
   linkArticlesIntoKb,
 } from '@auxx/lib/kb'
-import { FeatureKey, FeaturePermissionService, PermissionKey } from '@auxx/lib/permissions'
+import {
+  FeatureKey,
+  FeaturePermissionService,
+  PermissionKey,
+  satisfiesRung,
+} from '@auxx/lib/permissions'
+import { getThreadLensBatch } from '@auxx/lib/permissions/visibility'
 import { TRPCError } from '@trpc/server'
 import { and, count, eq } from 'drizzle-orm'
 import { z } from 'zod'
@@ -236,6 +242,17 @@ export const knowledgeBaseRouter = createTRPCRouter({
       // Read-only over an article the viewer can already see in the memory
       // editor; the Read rung is the right bar.
       ctx.capabilities.assert(PermissionKey.knowledgeBaseView)
+      // …but the area rung alone is NOT the bar: `articleId` is caller-supplied
+      // and unconstrained to the learned KB, and `markdown: ''` renders the
+      // target's entire published body as removed diff lines. That makes this a
+      // full-content read of ANY article in the org. Gate the article's home KB
+      // exactly as `kb.getArticleById` does.
+      const knowledgeBaseId = await knowledgeBaseIdForArticle(
+        ctx.db,
+        input.articleId,
+        organizationId
+      )
+      ctx.capabilities.assertViewInstance('kb', knowledgeBaseId)
       return getLearnedArticleDiff(ctx.db, {
         organizationId,
         articleId: input.articleId,
@@ -247,6 +264,15 @@ export const knowledgeBaseRouter = createTRPCRouter({
    * The conversations a memory article was learned from — the reader for
    * `Article.learnedProvenance`. Answers "why does the AI believe this?", which
    * is the question anyone asks before deleting a memory.
+   *
+   * Two gates, because this crosses two authorities. The article's home KB
+   * decides whether the viewer may ask the question at all (`articleId` is
+   * caller-supplied and not constrained to the learned KB). The **mail lens**
+   * then decides how much of each cited conversation comes back: a thread's
+   * subject line is `identity`-tier (`permissions/visibility/lens.ts`), so a
+   * viewer below that rung gets the entry with a `null` subject — the same
+   * shape the UI already renders for a conversation that no longer exists.
+   * KB access is never a licence to read mail.
    */
   learnedProvenance: capabilityProcedure
     .input(z.object({ articleId: z.string() }))
@@ -259,7 +285,32 @@ export const knowledgeBaseRouter = createTRPCRouter({
         })
       }
       ctx.capabilities.assert(PermissionKey.knowledgeBaseView)
-      return getLearnedProvenance(ctx.db, { organizationId, articleId: input.articleId })
+      const knowledgeBaseId = await knowledgeBaseIdForArticle(
+        ctx.db,
+        input.articleId,
+        organizationId
+      )
+      ctx.capabilities.assertViewInstance('kb', knowledgeBaseId)
+
+      const sources = await getLearnedProvenance(ctx.db, {
+        organizationId,
+        articleId: input.articleId,
+      })
+      if (sources.length === 0) return sources
+
+      const viewer = await getCachedUserInstanceGrants(ctx.session.user.id, organizationId)
+      const lenses = await getThreadLensBatch(
+        ctx.db,
+        organizationId,
+        viewer,
+        sources.map((s) => s.threadId)
+      )
+      return sources.map((source) => ({
+        ...source,
+        subject: satisfiesRung(lenses.get(source.threadId) ?? 'none', 'identity')
+          ? source.subject
+          : null,
+      }))
     }),
 
   create: capabilityProcedure.input(kbCreateSchema).mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
Four KB read paths resolved articles without checking instance access on the owning knowledge base. They now assert it, matching what the article SSE route and `kb.getArticles` already do.

### Changes

- **`preview/kb/md/…`** — assert `canViewInstance('kb', …)` before loading articles. Also fixes the file header comment, which said the route segment was `_md`; it is `md`.
- **`preview/kb/[id]/r/[articleId]`** — scope the `ArticlePlacement` query to the organization, require an org on the session unconditionally (the previous check short-circuited when `defaultOrganizationId` was absent), and assert on the **resolved target** KB rather than the URL segment, since the handler redirects to the target's own KB id.
- **`kb.learnedArticleDiff` / `kb.learnedProvenance`** — assert on the article's home KB in addition to the existing `knowledgeBaseView` area check, resolved via the existing `knowledgeBaseIdForArticle` helper.
- **`kb.learnedProvenance`** — clamp `Thread.subject` to the viewer's mail lens (`identity` is the documented tier for subject lines), reusing the `getCachedUserInstanceGrants` → `getThreadLens` shape from the message body route.

Entries whose lens is below `identity` return `subject: null` rather than being dropped: `getThreadLensBatch` cannot distinguish a denied thread from a deleted one, and `getLearnedProvenance` deliberately keeps deleted threads ("learned from a conversation that no longer exists"). The UI already renders that as "Untitled conversation".

### Notes

App Router route handlers do not inherit `auxxErrorMiddleware`, so an `AuxxError` there would surface as a 500. Denials are mapped to status codes by hand and the tests assert on **status**, not on thrownness.

### Tests

31 new tests across three files, modelled on the existing `kb-article-instance-access.test.ts`. Each gate was mutation-checked — removed, confirmed the tests discriminate, restored.