### PR TITLE
fix(search): gate participant lookup and drop a phantom column

### DIFF
--- a/apps/web/src/server/api/routers/search-participant-gate.test.ts
+++ b/apps/web/src/server/api/routers/search-participant-gate.test.ts
@@ -1,0 +1,319 @@
+// apps/web/src/server/api/routers/search-participant-gate.test.ts
+
+import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `search.ts`'s two `Participant` reads answer the same question the mail lens
+ * exists to refuse: **"has this address ever corresponded with anyone in this
+ * org?"**
+ *
+ * `Participant` is org-scoped with no inbox column and no lens — one row per
+ * email/phone identity that has ever touched the org, whichever mailbox it
+ * arrived in, including someone else's PERSONAL one. Both reads were an
+ * unqualified `ILIKE` over `identifier` / `name` / `displayName`:
+ *
+ *  - `suggestions`, the `from:` / `to:` / `cc:` / `recipient:` / `with:` /
+ *    `participants` operator branch — a `capabilityProcedure` that asserted
+ *    nothing, fifteen lines above a `TAG` branch that *does* check
+ *    `canViewEntity('tag')`. So it was never a house convention; it was a
+ *    missing check.
+ *  - `participants`, the recipient typeahead — a bare `protectedProcedure` with
+ *    no capability set in `ctx` at all.
+ *
+ * The bar is the coarse mail door, `PermissionKey.inboxesView` — the SAME
+ * primitive every mail router already asserts as
+ * `permissionProcedure(PermissionKey.inboxesView)`, including `participant.ts`,
+ * whose `getByIds` was gated while this sibling read was not. Not a rank check:
+ * `docs/channels-mail-architecture-guide.md` §16.3 forbids gating mail on rank,
+ * and nothing here reads `isAdmin`.
+ *
+ * ⚠ **This gate is COARSE and these tests do not claim otherwise.** A member
+ * holding one narrow inbox still passes and can still probe addresses drawn from
+ * threads their lens hides. Narrowing suggestions to participants on
+ * lens-admitted threads is the tight answer and is deliberately out of scope.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Doubles
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Rows the stub db hands back, in call order. */
+let dbRows: unknown[][] = []
+/** How many times the router actually reached the database. */
+let dbCalls = 0
+
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => {
+          dbCalls += 1
+          return dbRows.shift() ?? []
+        },
+      }),
+    }),
+  }),
+}
+
+// `apps/web` has no shared `drizzle-orm` / `@auxx/database` / `@auxx/logger`
+// mock in `src/test/setup.ts` (it mocks only `next/*`), so these are this file's
+// own doubles rather than a replacement of a shared one. The predicate helpers
+// are inert on purpose — the stub `db` above never compiles SQL, and asserting
+// on built predicates is meaningless when columns are placeholder objects.
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  or: (...args: unknown[]) => ({ or: args }),
+  eq: (...args: unknown[]) => ({ eq: args }),
+  ilike: (...args: unknown[]) => ({ ilike: args }),
+  asc: (x: unknown) => x,
+  inArray: (...args: unknown[]) => ({ inArray: args }),
+  count: () => ({ count: true }),
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: new Proxy({} as Record<string, Record<string, object>>, {
+    get: (target, table: string) => {
+      if (!(table in target)) {
+        target[table] = new Proxy(
+          {},
+          {
+            get: (cols: Record<string, object>, col: string) => {
+              if (!(col in cols)) cols[col] = { table, col }
+              return cols[col]
+            },
+          }
+        )
+      }
+      return target[table]
+    },
+  }),
+}))
+
+// PARTIAL, not a replacement: `enums.ts` is a leaf module (no `db/client`, so no
+// pool), and the real `CapabilitySet` reaches through it for `ResourcePermission`
+// on the `tag` control path. A full replacement type-checks and passes fifteen
+// tests before dying inside `levelToRecordBasePermission`.
+vi.mock('@auxx/database/enums', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ParticipantRole: { FROM: 'FROM', TO: 'TO', CC: 'CC' },
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+// The REAL operator vocabulary, reached at its deep path so the barrel (which
+// hangs under vitest) is never loaded. Hard-coding `'from'` here would let the
+// router's switch drift away from the test without either side noticing.
+vi.mock('@auxx/lib/mail-query', async () => {
+  const parser = await vi.importActual<Record<string, unknown>>(
+    '@auxx/lib/mail-query/search-query-parser'
+  )
+  return { SearchOperator: parser.SearchOperator, IsOperatorValue: parser.IsOperatorValue }
+})
+
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await vi.importActual<Record<string, unknown>>(
+    '@auxx/lib/permissions/capabilities/registry'
+  )
+  return { PermissionKey: registry.PermissionKey }
+})
+
+const listAll = vi.fn(async () => ({ items: [] }))
+vi.mock('@auxx/lib/resources', () => ({ listAll }))
+vi.mock('@auxx/lib/members', () => ({ listMembersWithUser: vi.fn(async () => []) }))
+vi.mock('@auxx/lib/inboxes', () => ({
+  InboxService: class {
+    listInboxes = vi.fn(async () => [])
+  },
+}))
+
+/**
+ * Mirrors the REAL procedures: ctx already carries the capability set, so the
+ * only thing dropped is the `getCapabilities` read. The gate under test is the
+ * one written in `search.ts`, not a re-implementation here.
+ */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: () => t.procedure,
+    isAuxxError: (e: unknown) =>
+      typeof e === 'object' && e !== null && 'statusCode' in (e as Record<string, unknown>),
+  }
+})
+
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { searchRouter } = await import('./search')
+
+type Caps = InstanceType<typeof CapabilitySet>
+
+function capabilitiesFor(opts: { inboxes?: Level; derivedKeys?: PermissionKey[] } = {}): Caps {
+  const toSlug = (id: string) => id
+  return new CapabilitySet(
+    new Set(
+      expandLevelsToKeys({
+        [Area.inboxes]: opts.inboxes ?? Level.Read,
+        [Area.records]: Level.Edit,
+      })
+    ),
+    {},
+    'MEMBER',
+    'full',
+    toSlug,
+    undefined,
+    toSlug,
+    {},
+    new Set(),
+    {},
+    new Set(opts.derivedKeys ?? [])
+  )
+}
+
+function ctxFor(capabilities: Caps) {
+  return {
+    db,
+    capabilities,
+    headers: new Headers(),
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, isAdmin: false },
+    },
+  } as never
+}
+
+const search = (c: Caps) => searchRouter.createCaller(ctxFor(c))
+
+const PARTICIPANT_ROW = {
+  id: 'prt_cuid00000000000000000a',
+  identifier: 'someone@example.com',
+  name: 'Someone',
+  displayName: 'Someone',
+  identifierType: 'EMAIL',
+  entityInstanceId: null,
+}
+
+/** 403, asserted by STATUS — a denial surfacing as a 500 is a worse outcome. */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+beforeEach(() => {
+  dbRows = []
+  dbCalls = 0
+  listAll.mockClear()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('search.suggestions — participant operator branch', () => {
+  const PARTICIPANT_OPERATORS = ['from', 'to', 'cc', 'recipient', 'with', 'participants']
+
+  it.each(
+    PARTICIPANT_OPERATORS
+  )('%s: a member whose profile closes mail gets no participant suggestions', async (operator) => {
+    dbRows = [[PARTICIPANT_ROW]]
+    const result = await search(capabilitiesFor({ inboxes: Level.None })).suggestions({
+      operator,
+      query: 'someone',
+    })
+
+    expect(result).toEqual([])
+    // Denied BEFORE the query — the address never leaves the database.
+    expect(dbCalls).toBe(0)
+  })
+
+  it.each(
+    PARTICIPANT_OPERATORS
+  )('%s: a member with mail read still gets them', async (operator) => {
+    dbRows = [[PARTICIPANT_ROW]]
+    const result = await search(capabilitiesFor({ inboxes: Level.Read })).suggestions({
+      operator,
+      query: 'someone',
+    })
+
+    expect(result).toEqual([
+      {
+        type: 'participant',
+        value: 'someone@example.com',
+        label: 'Someone',
+        secondary: 'someone@example.com',
+      },
+    ])
+    expect(dbCalls).toBe(1)
+  })
+
+  it('denies by `break`, not by throwing — sibling operators still answer', async () => {
+    // The whole point of `break`: `suggestions` is ONE procedure serving many
+    // operator branches, so a mail-closed member typing `tag:` must still get
+    // their tag suggestions. A `throw` here would have taken the router down for
+    // every operator at once.
+    const caller = search(capabilitiesFor({ inboxes: Level.None }))
+    await expect(caller.suggestions({ operator: 'from', query: 'x' })).resolves.toEqual([])
+    await expect(caller.suggestions({ operator: 'tag', query: 'x' })).resolves.toBeDefined()
+    expect(listAll).toHaveBeenCalled()
+  })
+
+  it('an instance grant on ONE inbox is enough — the gate reads the front door', async () => {
+    // `can()` is `keys ∪ instanceDerivedKeys`, NOT the area level: a member whose
+    // profile sets `Area.inboxes = None` but who holds a `view`-or-better grant
+    // on a single inbox has `inboxesView` synthesized at composition time and
+    // genuinely does have mail reach. Gating on `areaLevel()` would deny them.
+    dbRows = [[PARTICIPANT_ROW]]
+    const result = await search(
+      capabilitiesFor({ inboxes: Level.None, derivedKeys: [PermissionKey.inboxesView] })
+    ).suggestions({ operator: 'from', query: 'someone' })
+
+    expect(result).toHaveLength(1)
+    expect(dbCalls).toBe(1)
+  })
+})
+
+describe('search.participants — the recipient typeahead', () => {
+  it('403s a member whose profile closes mail', async () => {
+    dbRows = [[PARTICIPANT_ROW]]
+    await expect(
+      search(capabilitiesFor({ inboxes: Level.None })).participants({ query: 'someone' })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(dbCalls).toBe(0)
+  })
+
+  it('serves a member with mail read', async () => {
+    dbRows = [[PARTICIPANT_ROW]]
+    const result = await search(capabilitiesFor({ inboxes: Level.Read })).participants({
+      query: 'someone',
+    })
+
+    expect(result).toEqual([
+      {
+        id: PARTICIPANT_ROW.id,
+        identifier: 'someone@example.com',
+        displayName: 'Someone',
+        identifierType: 'EMAIL',
+        contactId: null,
+        contact: null,
+      },
+    ])
+  })
+
+  it('an instance grant on ONE inbox is enough here too', async () => {
+    dbRows = [[PARTICIPANT_ROW]]
+    await expect(
+      search(
+        capabilitiesFor({ inboxes: Level.None, derivedKeys: [PermissionKey.inboxesView] })
+      ).participants({ query: 'someone' })
+    ).resolves.toHaveLength(1)
+  })
+})

--- a/apps/web/src/server/api/routers/search.ts
+++ b/apps/web/src/server/api/routers/search.ts
@@ -3,6 +3,7 @@ import { ParticipantRole } from '@auxx/database/enums'
 import { InboxService } from '@auxx/lib/inboxes'
 import { IsOperatorValue, SearchOperator } from '@auxx/lib/mail-query'
 import { listMembersWithUser } from '@auxx/lib/members'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { listAll } from '@auxx/lib/resources'
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, count as drizzleCount, eq, ilike, inArray, or } from 'drizzle-orm'
@@ -220,6 +221,31 @@ export const searchRouter = createTRPCRouter({
         case SearchOperator.RECIPIENT:
         case SearchOperator.WITH:
         case 'participants': {
+          // Read enforcement: `Participant` is an ORG-WIDE table of every email /
+          // phone identity that has ever touched the org, with no inbox column and
+          // no mail lens — so an ungated ILIKE here answered "has this address ever
+          // corresponded with anyone in this org?" for any authenticated member,
+          // including addresses that only ever appeared in someone else's PERSONAL
+          // mailbox. These are mail-search operators, so the coarse mail door is the
+          // right bar, and it is the SAME primitive every mail router asserts
+          // (`const mailProcedure = permissionProcedure(PermissionKey.inboxesView)`
+          // in thread/message/draft/label/inbox/mailView — and in `participant.ts`,
+          // whose `getByIds` was already gated while this sibling read was not).
+          //
+          // `can()` reads `keys ∪ instanceDerivedKeys`, which is the front-door
+          // union rather than the area level — so a member whose profile closes
+          // `Area.inboxes` but who holds an explicit grant on ONE inbox still
+          // passes, which is correct: they do have mail reach.
+          //
+          // ⚠ This is a COARSE gate and does not claim to be more. A member with
+          // one narrow inbox can still probe addresses drawn from threads their
+          // lens hides — narrowing to participants on lens-admitted threads is the
+          // tight answer and is deliberately NOT attempted here.
+          //
+          // `break` rather than throw, matching the `TAG` branch below: this is one
+          // operator of a shared autocomplete, and a mail-closed member using
+          // `tag:` must still get their suggestions.
+          if (!ctx.capabilities.can(PermissionKey.inboxesView)) break
           const participants = await ctx.db
             .select()
             .from(schema.Participant)
@@ -337,8 +363,20 @@ export const searchRouter = createTRPCRouter({
       }
       return suggestions
     }),
-  // Participant search endpoint
-  participants: protectedProcedure
+  /**
+   * Participant search endpoint — the recipient/participant typeahead.
+   *
+   * Gated on the same coarse mail door as the `FROM`/`TO`/`CC`/`RECIPIENT`/`WITH`
+   * branch of {@link suggestions}, and for the same reason: this is the identical
+   * org-wide `Participant` ILIKE, just reached through its own procedure. It was a
+   * bare `protectedProcedure` — no capability set in `ctx` at all — so gating it
+   * required promoting it to `capabilityProcedure` first.
+   *
+   * `assert` rather than `break` here, unlike the suggestions branch: this
+   * procedure serves ONLY participants, so there is no sibling operator whose
+   * results a silent empty list would have to preserve. A 403 is the honest answer.
+   */
+  participants: capabilityProcedure
     .input(
       z.object({
         query: z.string(),
@@ -346,6 +384,7 @@ export const searchRouter = createTRPCRouter({
       })
     )
     .query(async ({ input, ctx }) => {
+      ctx.capabilities.assert(PermissionKey.inboxesView)
       const { query, type } = input
       const organizationId = ctx.session.organizationId
       // Build role filter based on type

--- a/packages/lib/src/resources/registry/display-config.test.ts
+++ b/packages/lib/src/resources/registry/display-config.test.ts
@@ -1,0 +1,257 @@
+// packages/lib/src/resources/registry/display-config.test.ts
+//
+// Registry integrity: every column name a `RESOURCE_DISPLAY_CONFIG` entry
+// mentions must actually exist on the table that entry resolves to.
+//
+// ## Why this file exists
+//
+// `RESOURCE_DISPLAY_CONFIG` is a bag of STRINGS. Nothing in the type system ties
+// `searchFields: ['name', 'email']` to the Drizzle table the entry is served
+// from, so a config could — and did, from the repo's initial commit — name a
+// column that has never existed. `participant` declared `email` as both its
+// secondary display field and a search field while `Participant` has only
+// `identifier` / `identifierType`. The consequences were spread across three
+// lanes and all three were quiet:
+//
+//   - `searchGlobalUnion` catches per-kind failures and logs them, so the
+//     participant leg contributed ZERO rows to every global search for months;
+//   - scoped `record.search({ entityDefinitionId: 'participant' })` threw
+//     uncaught — a 500 reading `Unknown column 'email' on table 'undefined'`
+//     (the `'undefined'` is `getTableName` on Drizzle's relational-query fields
+//     bag, which carries no table-name symbol — it is NOT a table that failed to
+//     resolve, and it misdirected the diagnosis for a long time);
+//   - the by-ids hydration path silently produced `secondaryInfo: undefined`.
+//
+// One assertion per column reference is all it took to catch it, and this guards
+// the other legs of the same union.
+//
+// ## Reading the real schema under Vitest
+//
+// ⚠ `src/test/setup.ts` mocks `@auxx/database` with a Proxy that hands back `{}`
+// for every table, so `schema.Participant.identifier` is `undefined` under the
+// normal import — column-level introspection is impossible through it, and a
+// test written against the mock would report EVERY column as missing (or, if
+// inverted to compensate, would pass vacuously forever).
+//
+// So the real tables are pulled in with `vi.importActual` on the schema barrel
+// **directly**, not on `@auxx/database`: the package index also evaluates
+// `db/client`, whose top-level `createDatabase()` opens a `pg.Pool` at import.
+// The barrel is pure table declarations. The shared setup mock is left entirely
+// alone — nothing here re-mocks `@auxx/database`, `@auxx/logger` or
+// `drizzle-orm`.
+//
+// {@link REAL_COLUMNS_ARE_VISIBLE} is the anti-vacuity guard: if the import ever
+// silently degrades back to the `{}` mock, that test fails first and says so,
+// rather than letting every `for` loop below iterate over nothing.
+
+import { Column, is } from 'drizzle-orm'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { RESOURCE_DISPLAY_CONFIG } from './display-config'
+import { RESOURCE_TABLE_MAP, type TableId } from './field-registry'
+
+let realSchema: Record<string, unknown>
+
+beforeAll(async () => {
+  realSchema = await vi.importActual<Record<string, unknown>>('@auxx/database/db/schema')
+})
+
+/**
+ * The column names on a real Drizzle table, or `undefined` when `dbName` names
+ * no table in the schema.
+ *
+ * `is(value, Column)` rather than a truthy property check: a Drizzle table also
+ * carries non-column members (`enableRLS`, symbols), and a display config naming
+ * one of those would resolve truthily through `requireColumn` and then build
+ * nonsense SQL. This is strictly stricter than the runtime it guards.
+ */
+function columnsOf(dbName: string): Set<string> | undefined {
+  const table = realSchema[dbName]
+  if (!table || typeof table !== 'object') return undefined
+  const columns = new Set<string>()
+  for (const [key, value] of Object.entries(table)) {
+    if (is(value, Column)) columns.add(key)
+  }
+  return columns.size > 0 ? columns : undefined
+}
+
+/**
+ * Display-config entries served from a REAL table, paired with that table's
+ * column set.
+ *
+ * Entries are skipped when the resource has no `RESOURCE_TABLE_MAP` row
+ * (`ticket` / `contact` / `part` / `inbox` / `personal_inbox` are
+ * EntityDefinition-backed, so `RESOURCE_TABLE_REGISTRY` excludes them) or when
+ * its `dbName` names no table (those rows live in `EntityInstance`). Skipping is
+ * only safe because {@link COVERED_TABLES} pins what must survive the filter.
+ */
+function coveredEntries(): Array<{
+  tableId: TableId
+  dbName: string
+  columns: Set<string>
+}> {
+  const covered: Array<{ tableId: TableId; dbName: string; columns: Set<string> }> = []
+  for (const tableId of Object.keys(RESOURCE_DISPLAY_CONFIG) as TableId[]) {
+    const dbName = RESOURCE_TABLE_MAP[tableId]?.dbName
+    if (!dbName) continue
+    const columns = columnsOf(dbName)
+    if (!columns) continue
+    covered.push({ tableId, dbName, columns })
+  }
+  return covered
+}
+
+/**
+ * The resources this file MUST be checking. Every one is a leg of the
+ * `searchGlobalUnion` fan-out or a mail table reached by id, and every one is
+ * served by `fetchResourcesDirect` / `fetchResourcesWithJoin`, which pass these
+ * config strings straight to `requireColumn`.
+ *
+ * Hard-coded on purpose. Without it, a regression that broke the schema import
+ * or renamed a `dbName` would empty `coveredEntries()` and turn every assertion
+ * below into a no-op loop — the exact failure mode this file is meant to prevent.
+ */
+const COVERED_TABLES: TableId[] = [
+  'user',
+  'participant',
+  'dataset',
+  'article',
+  'kb',
+  'visit',
+  'thread',
+  'message',
+]
+
+/**
+ * Column references that are KNOWN to be broken and are deliberately not fixed
+ * here, keyed `tableId` → the `columnRefs` labels to exempt.
+ *
+ * **This list must shrink, never grow.** Each entry is asserted to be genuinely
+ * still missing (see the "known defects are still defects" test), so fixing the
+ * underlying config without deleting its exemption fails the suite rather than
+ * quietly leaving a stale waiver behind.
+ *
+ * `message.searchFields[1] = 'from'` — `Message` has `fromId` (an FK to
+ * `Participant`), not `from`; `from` is a RELATION name, and `searchFields` are
+ * fed to `ilike(requireColumn(...))`, which a relation can never satisfy. It is
+ * inert today only because `message` is an {@link
+ * import('../picker/mail-lens-tables').isMailLensTableId} table, so
+ * `fetchResourcesFromDb` throws the mail-lens refusal BEFORE `requireColumn` is
+ * reached — the day `message` leaves that set, this becomes the participant bug
+ * again. Left alone here because a mail table's display semantics are a mail
+ * decision, not a drive-by edit.
+ */
+const KNOWN_BAD: Partial<Record<TableId, string[]>> = {
+  message: ["searchFields[1]: 'from'"],
+}
+
+/** Every config key whose value is a column name on the entry's own table. */
+function columnRefs(tableId: TableId): Array<{ where: string; column: string }> {
+  const config = RESOURCE_DISPLAY_CONFIG[tableId]
+  if (!config) return []
+  const refs: Array<{ where: string; column: string }> = []
+  const push = (where: string, column: string | undefined) => {
+    if (column) refs.push({ where, column })
+  }
+
+  push('identifierField', config.identifierField)
+  push('primaryDisplayFieldId', config.primaryDisplayFieldId)
+  push('secondaryDisplayFieldId', config.secondaryDisplayFieldId)
+  push('avatarFieldId', config.avatarFieldId)
+  push('iconFieldId', config.iconFieldId)
+  push('colorFieldId', config.colorFieldId)
+  // `fetchResourcesDirect` sorts with `requireColumn(table, sortField)`, so a bad
+  // sort field throws on EVERY read of the table, not just a searched one.
+  push('defaultSortField', config.defaultSortField)
+  config.searchFields.forEach((field, i) => push(`searchFields[${i}]`, field))
+  for (const key of Object.keys(config.neverPickable ?? {})) {
+    push(`neverPickable['${key}']`, key)
+  }
+  return refs
+}
+
+describe('RESOURCE_DISPLAY_CONFIG column integrity', () => {
+  it('REAL_COLUMNS_ARE_VISIBLE: the schema import is not the `{}` setup mock', () => {
+    // If this fails, every other test in this file is vacuous — fix the import
+    // before trusting a green run.
+    const participant = columnsOf('Participant')
+    expect(participant).toBeDefined()
+    expect([...participant!].sort()).toEqual(
+      [
+        'createdAt',
+        'displayName',
+        'entityInstanceId',
+        'firstInteractionDate',
+        'firstInteractionType',
+        'hasReceivedMessage',
+        'id',
+        'identifier',
+        'identifierType',
+        'initials',
+        'isInternal',
+        'isSpammer',
+        'lastSentMessageAt',
+        'name',
+        'organizationId',
+        'updatedAt',
+      ].sort()
+    )
+    // The original bug, pinned from both sides: `email` is absent and
+    // `identifier` is what actually holds the address.
+    expect(participant!.has('email')).toBe(false)
+    expect(participant!.has('identifier')).toBe(true)
+  })
+
+  it('covers every union leg — the skip filter has not swallowed the suite', () => {
+    const coveredIds = coveredEntries().map((entry) => entry.tableId)
+    for (const tableId of COVERED_TABLES) {
+      expect(coveredIds).toContain(tableId)
+    }
+  })
+
+  it.each(COVERED_TABLES)('%s names only real columns', (tableId) => {
+    const dbName = RESOURCE_TABLE_MAP[tableId]?.dbName
+    expect(dbName).toBeTruthy()
+    const columns = columnsOf(dbName!)
+    expect(columns).toBeDefined()
+
+    const exempt = new Set(KNOWN_BAD[tableId] ?? [])
+    const missing = columnRefs(tableId)
+      .filter((ref) => !columns!.has(ref.column))
+      .map((ref) => `${ref.where}: '${ref.column}'`)
+      .filter((label) => !exempt.has(label))
+
+    expect(missing).toEqual([])
+  })
+
+  it('known defects are still defects — no stale waivers in KNOWN_BAD', () => {
+    for (const [tableId, labels] of Object.entries(KNOWN_BAD) as Array<[TableId, string[]]>) {
+      const columns = columnsOf(RESOURCE_TABLE_MAP[tableId]!.dbName)
+      const stillMissing = columnRefs(tableId)
+        .filter((ref) => !columns!.has(ref.column))
+        .map((ref) => `${ref.where}: '${ref.column}'`)
+      for (const label of labels) {
+        expect(
+          stillMissing,
+          `KNOWN_BAD['${tableId}'] lists "${label}", which now resolves — delete the waiver`
+        ).toContain(label)
+      }
+    }
+  })
+
+  it('join-scoped entries reference real columns on both tables', () => {
+    for (const { tableId, columns } of coveredEntries()) {
+      const join = RESOURCE_DISPLAY_CONFIG[tableId]?.joinScoping
+      if (!join) continue
+      const joinColumns = columnsOf(join.joinTable)
+      expect(joinColumns, `${tableId}: join table '${join.joinTable}'`).toBeDefined()
+
+      // `fetchResourcesWithJoin` passes each of these to `requireColumn`.
+      expect(columns.has(join.mainTableKey), `${tableId}.mainTableKey`).toBe(true)
+      expect(joinColumns!.has(join.joinSourceKey), `${tableId}.joinSourceKey`).toBe(true)
+      expect(joinColumns!.has(join.joinOrgKey), `${tableId}.joinOrgKey`).toBe(true)
+      for (const key of Object.keys(join.additionalConditions ?? {})) {
+        expect(columns.has(key), `${tableId}.additionalConditions['${key}']`).toBe(true)
+      }
+    }
+  })
+})

--- a/packages/lib/src/resources/registry/display-config.ts
+++ b/packages/lib/src/resources/registry/display-config.ts
@@ -1,4 +1,4 @@
-// packages/lib/src/workflow-engine/resources/registry/display-config.ts
+// packages/lib/src/resources/registry/display-config.ts
 
 import type { TableId } from './field-registry'
 
@@ -207,11 +207,26 @@ export const RESOURCE_DISPLAY_CONFIG: Partial<Record<TableId, ResourceDisplayCon
     orgScopingStrategy: 'direct',
   },
 
+  // ⚠ `Participant` has NO `email` column — a participant's address lives in
+  // `identifier`, typed by `identifierType` (EMAIL / PHONE). This entry named
+  // `email` as both the secondary display field and a search field from the
+  // initial commit onward, which made `requireColumn` throw on every search:
+  // swallowed and logged in the global union (`searchGlobalUnion`'s per-kind
+  // catch), an uncaught 500 on scoped `record.search({entityDefinitionId:
+  // 'participant'})`. See `resources/registry/display-config.test.ts`, which now
+  // fails on any display config naming a column its table does not have.
+  //
+  // 🔴 NOT repointed at `identifier`, deliberately. `Participant` is org-wide
+  // with no inbox column and no mail lens, so making addresses text-searchable
+  // through the generic record path would hand any member with `Records: Read` a
+  // typeahead over every identity that has ever mailed the org — including ones
+  // that only ever appeared in another member's PERSONAL mailbox. That is a
+  // visibility decision, not a bug fix. `displayName` is not a safe substitute
+  // either: it equals the raw address for roughly a third of rows.
   participant: {
     identifierField: 'id',
     primaryDisplayFieldId: 'name',
-    secondaryDisplayFieldId: 'email',
-    searchFields: ['name', 'email'],
+    searchFields: ['name'],
     defaultSortField: 'createdAt',
     defaultSortDirection: 'desc',
     orgScopingStrategy: 'direct',
@@ -258,10 +273,11 @@ export const RESOURCE_DISPLAY_CONFIG: Partial<Record<TableId, ResourceDisplayCon
     orgScopingStrategy: 'direct',
     // `source` only — NOT `learned`. Source KBs are internal containers with no
     // UI of their own. The `learned` KB (AI Memory) is a real, member-facing
-    // knowledge base with its own card on the KB landing page; it is absent from
-    // `listKnowledgeBases` because that query backs the standard-KB grid, not
-    // because it is secret. Excluding it here would make the AI Memory KB
-    // unresolvable anywhere it is referenced.
+    // knowledge base, and since plan v3/06 P4 it is returned by
+    // `listKnowledgeBases` too — that query was filtering `kind = 'standard'`,
+    // which meant no Share card could ever be rendered for AI Memory and no `kb`
+    // grant row could be authored against it. Excluding it here would make the
+    // AI Memory KB unresolvable anywhere it is referenced.
     neverPickable: { kind: ['source'] },
   },
 

--- a/packages/lib/src/resources/registry/resources/participant-fields.ts
+++ b/packages/lib/src/resources/registry/resources/participant-fields.ts
@@ -1,4 +1,4 @@
-// packages/lib/src/workflow-engine/resources/registry/resources/participant-fields.ts
+// packages/lib/src/resources/registry/resources/participant-fields.ts
 
 import { FieldType } from '@auxx/database/enums'
 import { toFieldId } from '@auxx/types/field'


### PR DESCRIPTION
### Capability gate

Two search paths ran an org-wide `ILIKE` over `Participant` with no capability check, while the dedicated participant router (`participant.ts`) already gated the same table on `PermissionKey.inboxesView` — as does every other mail router in the tree. These two were the outliers, so they now use the same key.

- **`search.suggestions`** — the `from:` / `to:` / `cc:` / `recipient:` / `with:` operators `break` early unless the viewer holds `inboxesView`. Breaking rather than throwing matches the `tag:` branch alongside them: a shared autocomplete must still serve its other operators to a member who has no mail access.
- **`search.participants`** — promoted from `protectedProcedure` (which carries no capability set at all) to `capabilityProcedure`, and asserts the same key. Its only consumers are mail-view filter fields, whose router is already `mailProcedure`-gated.

`can()` is used rather than `areaLevel()` deliberately: it reads `keys ∪ instanceDerivedKeys`, so a member whose profile closes `Area.inboxes` but who holds a `view` grant on a single inbox still passes. There is a test for that arm.

**Scope of this change:** it narrows *who* can run the lookup, not *what* the lookup returns. `Participant` has no inbox column, so the query remains org-wide for anyone holding the key — which, since `MEMBER_BASELINE_LEVELS[Area.inboxes]` is `Read`, is most members on a stock org. Narrowing to identities on threads the viewer's lens admits means intersecting against `ThreadParticipant` and `buildMailVisibilityPredicate` — a three-table join on a typeahead hot path, worth doing as its own change.

### Phantom column

`RESOURCE_DISPLAY_CONFIG.participant` named an `email` column that `Participant` has never had (the address lives in `identifier`, typed by `identifierType`). Consequences: every global search logged a swallowed `per-kind fetch failed`, so the participant leg contributed zero rows; and scoped `record.search({entityDefinitionId:'participant'})` was a hard 500 for the life of the repo.

`searchFields` is now `['name']` and `secondaryDisplayFieldId` is dropped. Nothing is repointed at `identifier` — that would make addresses substring-searchable, which is a separate decision.

The misleading `on table 'undefined'` in the log is cosmetic: Drizzle's relational query builder hands the `where` callback an aliased-columns bag rather than a `PgTable`, so `getTableName()` returns undefined.

### Registry integrity test

Asserts every display-config field id (`searchFields`, `identifierField`, `primaryDisplayFieldId`, `secondaryDisplayFieldId`, `iconFieldId`, `colorFieldId`) resolves to a real column on its `RESOURCE_TABLE_MAP` table. It would have caught this at the first commit, and it guards the other five union legs.

It immediately found a second case: `message.searchFields` names `from`, which is a *relation*, not a column — inert only because the mail-lens refusal throws before `requireColumn` runs. Rather than change a mail table's display semantics here, it is recorded as a `KNOWN_BAD` waiver with a companion test that fails if the waiver goes stale.

The test guards against its own vacuity: it imports the schema barrel (not `@auxx/database`, whose index opens a pool at import), and pins `Participant`'s exact column set so a degraded import fails loudly instead of iterating over nothing.

### Also

Two stale file-path header comments corrected. One of them is a KB-related comment fix that belongs logically with #1500 but lives in the same file as the participant change; it rides along here rather than splitting hunks.

### Deferred

`PARTICIPANT_FIELDS.email` still declares the same phantom column as `filterable`/`sortable`. It fails *open* — `SystemConditionBuilder.resolveColumns` skips unresolvable columns, so a filter or sort on it is silently dropped and the result set widens. Left untouched here because it changes filter behaviour on `listFiltered` / aggregates / the workflow Find node.