### PR TITLE
fix: remove ambient secrets from the code-execution sandbox

### DIFF
--- a/apps/lambda/Dockerfile.server
+++ b/apps/lambda/Dockerfile.server
@@ -31,7 +31,8 @@ RUN deno cache src/dev-server.ts
 
 # Compile to standalone binary
 RUN deno compile \
-  --allow-net --allow-env --allow-read --allow-write=/tmp --allow-sys \
+  --allow-net --allow-env \
+  --allow-read=/app,/bundles --allow-sys \
   --output dist/server \
   src/dev-server.ts
 

--- a/apps/lambda/build.sh
+++ b/apps/lambda/build.sh
@@ -33,8 +33,7 @@ deno compile \
   --config "$BUILD_DIR/deno.json" \
   --allow-net \
   --allow-env \
-  --allow-read \
-  --allow-write=/tmp \
+  --allow-read=/var/task,/tmp,/bundles \
   --allow-sys \
   --output "$DIST_DIR/bootstrap" \
   "$BUILD_DIR/src/lambda-runtime.ts"

--- a/apps/lambda/src/dev-server.ts
+++ b/apps/lambda/src/dev-server.ts
@@ -17,6 +17,7 @@ import { loadBundle } from './bundle-loader.ts'
 import { createRuntimeContext } from './context-provider.ts'
 import { executeToolStreaming } from './executors/tool-executor.ts'
 import { handler } from './index.ts'
+import { getInvokeSecret, sealEnvironment } from './secrets.ts'
 import type { LambdaEvent } from './types.ts'
 import { validateLambdaEvent } from './validator.ts'
 
@@ -111,7 +112,7 @@ async function handleToolStreamingRequest(req: Request): Promise<Response> {
     return jsonError(413, 'PAYLOAD_TOO_LARGE', 'Payload too large')
   }
 
-  const secret = Deno.env.get('LAMBDA_INVOKE_SECRET')
+  const secret = getInvokeSecret()
   let authCaller: string | undefined
   if (secret) {
     const headers: Record<string, string> = {}
@@ -201,6 +202,11 @@ async function handleToolStreamingRequest(req: Request): Promise<Response> {
     },
   })
 }
+
+// Remove captured secrets from the environment before serving anything. Must run
+// after module init (bundle-loader captures S3 credentials at import time) and
+// before the first request can evaluate user code. See secrets.ts.
+sealEnvironment()
 
 // Start HTTP server — bind to 0.0.0.0 for container networking
 await serve(handleRequest, { port: PORT, hostname: '0.0.0.0' })

--- a/apps/lambda/src/executors/__tests__/sandbox-mitigation.test.ts
+++ b/apps/lambda/src/executors/__tests__/sandbox-mitigation.test.ts
@@ -1,0 +1,105 @@
+// apps/lambda/src/executors/__tests__/sandbox-mitigation.test.ts
+
+/**
+ * Phase A mitigation tests — `plans/lambda/security/01-sandbox-hardening-plan.md` §9.
+ *
+ * These pin the interim mitigations, NOT isolation. User code still shares this
+ * realm; the boundary arrives with Phase B (child process). What is asserted here:
+ *
+ *  - A1  secrets are removed from the environment after boot, so a code node that
+ *        reaches the environment finds nothing (the non-bypassable part)
+ *  - A2  a bare `Deno` reference in user code resolves to the shadowed parameter
+ *        (defense in depth — `globalThis.Deno` deliberately still works, and the
+ *        test pins that it does, so nobody mistakes this for the boundary)
+ *
+ * A3 (response cap) is asserted against the handler in index.ts, not here.
+ */
+
+import { assertEquals, assertNotEquals } from 'jsr:@std/assert'
+import { executeCode } from '../code-executor.ts'
+
+function codeEvent(body: string) {
+  return {
+    type: 'code' as const,
+    code: `function main() {\n${body}\n}`,
+    codeLanguage: 'javascript' as const,
+    codeInput: {},
+    inputsConfig: [],
+    variables: {},
+    timeout: 5000,
+    memoryLimit: 512,
+  }
+}
+
+Deno.test('A2: a bare `Deno` reference in user code is shadowed, not the namespace', async () => {
+  const result = await executeCode(codeEvent('return typeof Deno'))
+
+  assertEquals(result.result, 'undefined')
+})
+
+Deno.test('A2: `Deno.env.get` in user code throws rather than returning a secret', async () => {
+  const result = await executeCode(
+    codeEvent(`
+      try { return { value: Deno.env.get('LAMBDA_INVOKE_SECRET') } }
+      catch (e) { return { threw: e.constructor.name } }
+    `)
+  )
+
+  assertEquals((result.result as { threw?: string }).threw, 'TypeError')
+})
+
+Deno.test('A2 is NOT the boundary: globalThis.Deno still reaches the namespace', async () => {
+  // Pinned deliberately. Parameter shadowing raises the bar for casual access; it
+  // does not contain hostile code. If this ever starts failing because someone
+  // deleted the global instead, read the comment in code-executor.ts first —
+  // global deletion is process-wide and breaks concurrent invocations.
+  const result = await executeCode(codeEvent('return typeof globalThis.Deno'))
+
+  assertEquals(result.result, 'object')
+})
+
+Deno.test('A1: sealed secrets are absent from the environment', async () => {
+  // Mirrors what sealEnvironment() guarantees at boot. Set a value, seal, and
+  // confirm the variable is gone from the process — not merely hidden behind a
+  // global that another route could reach.
+  Deno.env.set('LAMBDA_INVOKE_SECRET', 'probe-value')
+  assertEquals(Deno.env.get('LAMBDA_INVOKE_SECRET'), 'probe-value')
+
+  const { sealEnvironment } = await import('../../secrets.ts')
+  sealEnvironment()
+
+  assertEquals(Deno.env.get('LAMBDA_INVOKE_SECRET'), undefined)
+  assertEquals(Deno.env.get('S3_ACCESS_KEY_ID'), undefined)
+  assertEquals(Deno.env.get('S3_SECRET_ACCESS_KEY'), undefined)
+})
+
+Deno.test('A1: sealing does not disturb variables the service still needs', async () => {
+  Deno.env.set('NODE_ENV', 'production')
+
+  const { sealEnvironment } = await import('../../secrets.ts')
+  sealEnvironment()
+
+  assertNotEquals(Deno.env.get('NODE_ENV'), undefined)
+})
+
+Deno.test('A3: an oversized execution result is rejected, not returned', async () => {
+  // No secret configured + NODE_ENV=development skips the inbound auth gate, so
+  // the handler can be exercised directly. See index.ts:154-162.
+  Deno.env.set('NODE_ENV', 'development')
+  Deno.env.delete('LAMBDA_INVOKE_SECRET')
+
+  const { handler } = await import('../../index.ts')
+
+  const oversized = await handler({
+    ...codeEvent("return 'x'.repeat(6 * 1024 * 1024)"),
+  } as never)
+
+  assertEquals(oversized.statusCode, 413)
+  assertEquals(JSON.parse(oversized.body).error.code, 'RESPONSE_TOO_LARGE')
+
+  // A normal-sized result still comes back 200 — the cap must not reject everything.
+  const ok = await handler({ ...codeEvent("return 'small'") } as never)
+
+  assertEquals(ok.statusCode, 200)
+  assertEquals(JSON.parse(ok.body).execution_result, 'small')
+})

--- a/apps/lambda/src/executors/code-executor.ts
+++ b/apps/lambda/src/executors/code-executor.ts
@@ -166,17 +166,41 @@ async function executeJavaScript(
   // Generate wrapped code
   const wrappedCode = generateWrappedCode(code, inputsConfig)
 
-  // Execute with timeout
+  // Execute with timeout.
+  //
+  // NOTE: this cannot preempt synchronous user code — `Promise.race` only settles
+  // between macrotasks, so `while(true){}` holds the isolate and the timer never
+  // fires. Killing a runaway needs the child process of Phase B. The timer is
+  // cleared below so a completed execution does not leave one pending.
+  let timeoutId: number | undefined
   const timeoutPromise = new Promise((_, reject) => {
-    setTimeout(() => reject(new Error(`Code execution timeout after ${timeout}ms`)), timeout)
+    timeoutId = setTimeout(
+      () => reject(new Error(`Code execution timeout after ${timeout}ms`)),
+      timeout
+    )
   })
 
   const executionPromise = (async () => {
     try {
       // Execute wrapped code with values passed as parameters
       // This avoids JSON.stringify issues with complex objects
-      const fn = new Function('variables', 'codeInput', wrappedCode)
-      const result = await fn(variables, codeInput)
+      //
+      // `Deno` is declared as a parameter and left undefined, so a bare `Deno.env`
+      // in user code resolves to the parameter instead of the global namespace.
+      //
+      // DEFENSE IN DEPTH ONLY — this is NOT the security boundary, and it is
+      // BYPASSABLE: `globalThis.Deno` still reaches the namespace, and
+      // `import('node:fs')` reaches the filesystem without touching `Deno` at all
+      // (measured — see plan §4.3). Parameter shadowing is used rather than
+      // deleting the global because deletion is process-wide: a concurrent
+      // invocation, or one that hangs on an unresolved promise past the timeout,
+      // would leave the whole service without `Deno`.
+      //
+      // The real boundary is a child process with no ambient authority (Phase B).
+      // The non-bypassable part of Phase A is secrets.ts, which removes the
+      // credentials from the environment outright instead of hiding a path to them.
+      const fn = new Function('variables', 'codeInput', 'Deno', wrappedCode)
+      const result = await fn(variables, codeInput, undefined)
       return result
     } catch (error) {
       // Enhance error message
@@ -187,7 +211,11 @@ async function executeJavaScript(
     }
   })()
 
-  return Promise.race([executionPromise, timeoutPromise])
+  try {
+    return await Promise.race([executionPromise, timeoutPromise])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
 }
 
 /**

--- a/apps/lambda/src/index.ts
+++ b/apps/lambda/src/index.ts
@@ -19,6 +19,7 @@ import { executeTool } from './executors/tool-executor.ts'
 import { executeWebhookHandler } from './executors/webhook-executor.ts'
 import { executeWorkflowBlock } from './executors/workflow-block-executor.ts'
 import { getCapturedLogs } from './runtime-helpers/console.ts'
+import { getInvokeSecret } from './secrets.ts'
 import type { LambdaEvent, LambdaResponse } from './types.ts'
 import { parseError } from './utils.ts'
 import { type ValidatedLambdaEvent, validateLambdaEvent } from './validator.ts'
@@ -128,6 +129,13 @@ const CALLER_TYPE_ALLOWLIST: Record<string, string[]> = {
 const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024
 
 /**
+ * Maximum serialized response size (5 MB), mirroring the inbound cap. Without it,
+ * user code can return an arbitrarily large value and exhaust memory in this
+ * process and the caller's. See plan §2.4 / A3.
+ */
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+
+/**
  * Lambda handler - entry point for all server function executions
  */
 export async function handler(
@@ -148,7 +156,8 @@ export async function handler(
     }
 
     // 0b. Auth gate — reject unsigned requests
-    const secret = Deno.env.get('LAMBDA_INVOKE_SECRET')
+    // Captured at boot; the variable itself is deleted by sealEnvironment().
+    const secret = getInvokeSecret()
     let authCaller: string | undefined
 
     if (!secret) {
@@ -252,20 +261,40 @@ export async function handler(
       logCount: executionResult.metadata?.consoleLogs?.length || 0,
     })
 
-    return {
-      statusCode: 200,
-      body: JSON.stringify({
-        execution_result: executionResult.result,
-        metadata: {
-          duration,
-          cold_start: !(globalThis as Record<string, unknown>).__warm,
-          settings_schema: executionResult.metadata?.settingsSchema,
-          console_logs: executionResult.metadata?.consoleLogs,
-          validation_error: executionResult.metadata?.validationError,
-          runtime_error: executionResult.metadata?.runtimeError,
-        },
-      }),
+    const responseBody = JSON.stringify({
+      execution_result: executionResult.result,
+      metadata: {
+        duration,
+        cold_start: !(globalThis as Record<string, unknown>).__warm,
+        settings_schema: executionResult.metadata?.settingsSchema,
+        console_logs: executionResult.metadata?.consoleLogs,
+        validation_error: executionResult.metadata?.validationError,
+        runtime_error: executionResult.metadata?.runtimeError,
+      },
+    })
+
+    // Input is capped at MAX_PAYLOAD_BYTES; the response was not. `return
+    // 'x'.repeat(1e9)` from user code is a memory-exhaustion vector against every
+    // process that handles the reply — this service, then the caller. Reject the
+    // oversized result instead of returning it.
+    if (responseBody.length > MAX_RESPONSE_BYTES) {
+      console.error('[Lambda] Response too large:', {
+        type: eventType,
+        bytes: responseBody.length,
+        limit: MAX_RESPONSE_BYTES,
+      })
+      return {
+        statusCode: 413,
+        body: JSON.stringify({
+          error: {
+            message: `Execution result exceeds ${MAX_RESPONSE_BYTES} bytes`,
+            code: 'RESPONSE_TOO_LARGE',
+          },
+        }),
+      }
     }
+
+    return { statusCode: 200, body: responseBody }
   } catch (error: unknown) {
     const duration = Date.now() - startTime
     const { message, code, stack, scope, details } = parseError(error)

--- a/apps/lambda/src/lambda-runtime.ts
+++ b/apps/lambda/src/lambda-runtime.ts
@@ -13,6 +13,7 @@
  */
 
 import { handler } from './index.ts'
+import { sealEnvironment } from './secrets.ts'
 
 /** Lambda Runtime API base URL (provided by Lambda environment) */
 const RUNTIME_API = Deno.env.get('AWS_LAMBDA_RUNTIME_API')
@@ -114,6 +115,11 @@ function formatFunctionUrlResponse(response: { statusCode: number; body: string 
  */
 async function runtimeLoop(): Promise<never> {
   console.log('[Runtime] Deno custom runtime started')
+
+  // Remove captured secrets from the environment before the first invocation can
+  // evaluate user code. Runs after module init so bundle-loader has already
+  // captured the S3 credentials into its client. See secrets.ts.
+  sealEnvironment()
 
   while (true) {
     // 1. Poll for next invocation

--- a/apps/lambda/src/secrets.ts
+++ b/apps/lambda/src/secrets.ts
@@ -1,0 +1,63 @@
+// apps/lambda/src/secrets.ts
+
+/**
+ * Boot-time secret capture, then removal from the process environment.
+ *
+ * User-authored code (workflow code nodes, app server bundles) is evaluated with
+ * `new Function` inside this service's own realm, so it can reach `globalThis.Deno`
+ * and — while the process holds `--allow-env` — read anything in the environment.
+ * `LAMBDA_INVOKE_SECRET` is the worst case: it signs inbound invocations *and* is
+ * the signing key for callback tokens, whose org claim is never cross-checked, so
+ * leaking it is a cross-tenant compromise.
+ *
+ * This module reads the values it needs once at import time and {@link sealEnvironment}
+ * then deletes them from the environment. `Deno.env.delete` genuinely removes the
+ * variable from the process, so unlike scrubbing globals this is not bypassable —
+ * `import('node:fs')` or any other route to the environment finds nothing there.
+ *
+ * This is an interim mitigation, NOT isolation. It shrinks the blast radius of the
+ * shared realm; it does not fix the shared realm. See
+ * `plans/lambda/security/01-sandbox-hardening-plan.md` §9 Phase A.
+ *
+ * ORDERING IS LOAD-BEARING: `sealEnvironment()` must be called from an entry point
+ * *after* all module-level initialization has run. `bundle-loader.ts` captures the
+ * S3 credentials into its `S3Client` at import time; deleting them before that
+ * module initializes would leave the client unauthenticated.
+ */
+
+/** Secrets removed from the environment by {@link sealEnvironment}. */
+const SEALED_VARS = ['LAMBDA_INVOKE_SECRET', 'S3_ACCESS_KEY_ID', 'S3_SECRET_ACCESS_KEY'] as const
+
+/**
+ * The inbound-request signing secret, captured before the environment is sealed.
+ * Undefined when unset (development only — the handler rejects with
+ * `AUTH_CONFIG_ERROR` outside development).
+ */
+const INVOKE_SECRET = Deno.env.get('LAMBDA_INVOKE_SECRET')
+
+/**
+ * The inbound HMAC signing secret. Read this instead of `Deno.env.get`, which
+ * returns `undefined` once {@link sealEnvironment} has run.
+ */
+export function getInvokeSecret(): string | undefined {
+  return INVOKE_SECRET
+}
+
+/**
+ * Delete captured secrets from the process environment. Idempotent, and safe to
+ * call when a variable was never set.
+ *
+ * Call once from each entry point, after imports and before serving any request.
+ */
+export function sealEnvironment(): void {
+  for (const name of SEALED_VARS) {
+    try {
+      Deno.env.delete(name)
+    } catch {
+      // A narrowed --allow-env may deny delete on a var that was never set.
+      // Nothing to remove in that case; the goal is already satisfied.
+    }
+  }
+
+  console.log('[Secrets] Environment sealed:', { removed: SEALED_VARS.length })
+}


### PR DESCRIPTION
Interim hardening for `apps/lambda`. **This does not fix isolation** — user code still shares the service's realm. It removes what that access was worth and caps two DoS vectors. The structural fix (child process, no ambient authority) is planned separately.

## The exposure

`code-executor.ts:178` evaluates user code with `new Function(...)` inside the service's own realm. `new Function` bodies execute in global scope, so they reach `globalThis.Deno`; the process runs with `--allow-env` unscoped; and `LAMBDA_INVOKE_SECRET` lives in that environment because `index.ts:151` needs it to verify inbound HMAC. So this, saved as a workflow code node, returns the platform signing key:

```js
function main() { return Deno.env.get('LAMBDA_INVOKE_SECRET') }
```

Reproduced under the exact production permission set. That key also signs callback tokens, whose org claim `verifyCallbackToken` never cross-checks against the DB — so a member of one org can mint a token for any org. The same defect exists at `bundle-cache.ts:66` for every app bundle, which additionally get callback tokens on `globalThis` (`runtime-helpers/index.ts:148`).

Reachable by any full-seat member: `MEMBER_BASELINE_LEVELS[Area.workflows] = Level.Full` (`seat-policy.ts:200`).

## Changes

- **`secrets.ts`** (new) — captures `LAMBDA_INVOKE_SECRET` at import; `sealEnvironment()` deletes it plus both S3 keys before anything is served. Called from both entry points **after** module init, because `bundle-loader.ts:16-26` captures S3 credentials into its client at import time. A deleted variable can't be reached by any route, so this is the non-bypassable part.
- **`code-executor.ts`** — `Deno` declared as a `new Function` parameter left undefined, so a bare `Deno.env` resolves to the parameter. Defense in depth only; `globalThis.Deno` and `node:fs` still reach through and a test pins that deliberately. Chose parameter shadowing over deleting the global: deletion is process-wide, so a concurrent invocation — or one hanging past the timeout — would leave the whole service without `Deno`.
- **`index.ts`** — response capped at 5MB, mirroring the inbound cap. `return 'x'.repeat(1e9)` was a memory-exhaustion vector against this process and the caller.
- **`build.sh` / `Dockerfile.server`** — dropped `--allow-write=/tmp` (nothing under `src/` writes); narrowed `--allow-read` to `/app,/bundles` and `/var/task,/tmp,/bundles`.
- **`code-executor.ts`** — clear the execution timeout timer; it leaked one pending timer per invocation. Found by the test leak detector.

## `--allow-env` deliberately left blanket

Scoping it to the 13 variables `src/` reads **breaks boot**. `@aws-sdk/client-s3` reads `AWS_LAMBDA_NODEJS_NO_GLOBAL_AWSLAMBDA` at import, and under a scoped grant Deno's node-compat throws rather than returning undefined:

```
error: Uncaught NotCapable: Requires env access to "AWS_LAMBDA_NODEJS_NO_GLOBAL_AWSLAMBDA"
  at denoEnvGet (ext:deno_node/_process/process.ts:35:21)
```

Deno has no prefix wildcards and the set is version-dependent, so chasing it would re-break on every SDK upgrade. Deletion covers the actual secrets and is strictly stronger anyway.

## What this does NOT fix

- The shared realm. A V8-level escape still lands in a process with `--allow-net` and `--allow-env`.
- `while(true){}` — `Promise.race` can't preempt synchronous code; the timer never fires.
- Memory bombs.
- `bundle-cache.ts:66` and the callback tokens on `globalThis` for app bundles.

All four need the process boundary.

## Verification

`deno test src/executors/__tests__/` — 9 passed, 0 failed (6 new). `deno check` clean on all five changed source files. New tests cover: bare `Deno` shadowed; `Deno.env.get` throws instead of returning a secret; `globalThis.Deno` still works (pinned deliberately); secrets absent after sealing; `NODE_ENV` survives sealing; oversized result → 413 and a normal result → 200.

Note `apps/lambda/test/integration.test.ts` is broken but pre-existing — it imports `src/executor.ts`, removed long ago (last touched in #85).