### PR TITLE
fix: fail closed when callback auth is not configured

### DIFF
--- a/apps/api/src/lib/__tests__/callback-auth.test.ts
+++ b/apps/api/src/lib/__tests__/callback-auth.test.ts
@@ -1,0 +1,127 @@
+// apps/api/src/lib/__tests__/callback-auth.test.ts
+
+/**
+ * `verifyCallbackAuth` guards every `/api/v1/sdk/*` route. It previously fell
+ * through to "installation ID only" whenever `LAMBDA_INVOKE_SECRET` was unset —
+ * keyed on the env var rather than on `NODE_ENV`, so one missing variable
+ * silently disabled SDK auth platform-wide, and `installationId` is a
+ * caller-supplied header. These tests pin that it now fails closed outside
+ * development.
+ *
+ * See plans/lambda/security/01-sandbox-hardening-plan.md §8 item 2 (A5).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockVerifyCallbackToken = vi.fn()
+
+vi.mock('@auxx/credentials/lambda-auth', () => ({
+  verifyCallbackToken: (...args: unknown[]) => mockVerifyCallbackToken(...args),
+}))
+
+import { verifyCallbackAuth } from '../callback-auth'
+
+const INSTALLATION_ID = 'inst_1'
+const ORG_ID = 'org_1'
+
+/** Minimal Hono-ish context: header lookup + a `json` that records the status. */
+function fakeContext(headers: Record<string, string>) {
+  return {
+    res: undefined as unknown,
+    req: { header: (name: string) => headers[name] },
+    json: (body: unknown, status: number) => ({ body, status }),
+  } as never
+}
+
+const ORIGINAL_ENV = { ...process.env }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV }
+})
+
+describe('verifyCallbackAuth — missing LAMBDA_INVOKE_SECRET', () => {
+  it('fails closed with 500 in production', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.LAMBDA_INVOKE_SECRET = undefined
+    delete process.env.LAMBDA_INVOKE_SECRET
+
+    const c = fakeContext({ 'X-App-Installation-Id': INSTALLATION_ID })
+    const result = verifyCallbackAuth(c, 'storage')
+
+    expect(result).toBeNull()
+    expect((c as unknown as { res: { status: number } }).res.status).toBe(500)
+  })
+
+  it('fails closed when NODE_ENV is unset — absence is not development', () => {
+    delete process.env.NODE_ENV
+    delete process.env.LAMBDA_INVOKE_SECRET
+
+    const c = fakeContext({ 'X-App-Installation-Id': INSTALLATION_ID })
+
+    expect(verifyCallbackAuth(c, 'storage')).toBeNull()
+    expect((c as unknown as { res: { status: number } }).res.status).toBe(500)
+  })
+
+  it('keeps the unverified fallback in development only', () => {
+    process.env.NODE_ENV = 'development'
+    delete process.env.LAMBDA_INVOKE_SECRET
+
+    const c = fakeContext({ 'X-App-Installation-Id': INSTALLATION_ID })
+
+    expect(verifyCallbackAuth(c, 'storage')).toEqual({
+      installationId: INSTALLATION_ID,
+      organizationId: '',
+    })
+  })
+})
+
+describe('verifyCallbackAuth — secret configured', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production'
+    process.env.LAMBDA_INVOKE_SECRET = 'signing-key'
+  })
+
+  it('rejects a request with no bearer token', () => {
+    const c = fakeContext({ 'X-App-Installation-Id': INSTALLATION_ID })
+
+    expect(verifyCallbackAuth(c, 'storage')).toBeNull()
+    expect((c as unknown as { res: { status: number } }).res.status).toBe(401)
+    expect(mockVerifyCallbackToken).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid token', () => {
+    mockVerifyCallbackToken.mockReturnValue({ valid: false, error: 'bad signature' })
+    const c = fakeContext({
+      'X-App-Installation-Id': INSTALLATION_ID,
+      Authorization: 'Bearer nope',
+    })
+
+    expect(verifyCallbackAuth(c, 'storage')).toBeNull()
+    expect((c as unknown as { res: { status: number } }).res.status).toBe(401)
+  })
+
+  it('returns the org from a verified token', () => {
+    mockVerifyCallbackToken.mockReturnValue({ valid: true, organizationId: ORG_ID })
+    const c = fakeContext({
+      'X-App-Installation-Id': INSTALLATION_ID,
+      Authorization: 'Bearer good',
+    })
+
+    expect(verifyCallbackAuth(c, 'storage')).toEqual({
+      installationId: INSTALLATION_ID,
+      organizationId: ORG_ID,
+      connectionId: undefined,
+    })
+  })
+
+  it('rejects a request with no installation id header', () => {
+    const c = fakeContext({ Authorization: 'Bearer good' })
+
+    expect(verifyCallbackAuth(c, 'storage')).toBeNull()
+    expect((c as unknown as { res: { status: number } }).res.status).toBe(401)
+  })
+})

--- a/apps/api/src/lib/callback-auth.ts
+++ b/apps/api/src/lib/callback-auth.ts
@@ -26,7 +26,24 @@ export function verifyCallbackAuth(
 
   const secret = process.env.LAMBDA_INVOKE_SECRET
   if (!secret) {
-    // No secret configured — fall back to installation ID only (dev mode)
+    // FAIL CLOSED. This previously fell through to "installation ID only", which
+    // meant a deploy missing LAMBDA_INVOKE_SECRET silently disabled auth on every
+    // /api/v1/sdk/* route — and `installationId` is a caller-supplied header, so
+    // anyone could name any installation. Keying the bypass on the env var rather
+    // than on NODE_ENV turned one missing variable into a platform-wide hole.
+    //
+    // The dev convenience is kept, but gated explicitly on NODE_ENV.
+    if (process.env.NODE_ENV !== 'development') {
+      c.res = c.json(
+        errorResponse('AUTH_CONFIG_ERROR', 'Callback auth is not configured'),
+        500
+      ) as any
+      return null
+    }
+
+    console.warn(
+      '[CallbackAuth] LAMBDA_INVOKE_SECRET unset — callback tokens are NOT verified. Development only.'
+    )
     return { installationId, organizationId: '' }
   }
 

--- a/apps/api/src/routes/storage.ts
+++ b/apps/api/src/routes/storage.ts
@@ -66,6 +66,12 @@ async function resolveConnectionId(
 
   // The credential must exist and be bound to this installation (which already
   // ties it to one app + org). When the token carries an org, assert it too.
+  //
+  // `auth.organizationId` is empty ONLY in the unverified development path of
+  // verifyCallbackAuth (LAMBDA_INVOKE_SECRET unset + NODE_ENV=development). Any
+  // verified token carries the org, since createCallbackToken signs it in. Before
+  // that path was gated on NODE_ENV, a deploy missing the secret made this
+  // short-circuit to true in production and dropped the org assertion entirely.
   if (
     !credential ||
     credential.appInstallationId !== auth.installationId ||


### PR DESCRIPTION
Phase A item A5 from the lambda sandbox hardening work. Independent of the sandbox itself — this is an `apps/api` authorization fix.

## The hole

`verifyCallbackAuth` (`apps/api/src/lib/callback-auth.ts`) guards **every** `/api/v1/sdk/*` route — app storage, settings, webhook registrations, entity field values. When `LAMBDA_INVOKE_SECRET` was unset it did this:

```ts
const secret = process.env.LAMBDA_INVOKE_SECRET
if (!secret) {
  // No secret configured — fall back to installation ID only (dev mode)
  return { installationId, organizationId: '' }
}
```

Three problems compounding:

1. **It keyed on the env var, not on `NODE_ENV`.** A production deploy missing that one variable silently disabled SDK auth platform-wide — no error, no log, nothing to notice.
2. **`installationId` is a caller-supplied header** (`X-App-Installation-Id`). With the bypass active, any caller could name any installation and be accepted.
3. **It poisoned the downstream org assertion.** `storage.ts:72` reads `auth.organizationId && credential.organizationId !== auth.organizationId` — the empty string short-circuits that to true, dropping the org check entirely.

## The fix

Return 500 `AUTH_CONFIG_ERROR` when the secret is missing, unless `NODE_ENV === 'development'`. The dev convenience survives behind a `console.warn`. Absence of `NODE_ENV` is treated as **not** development — that's the misconfigured-deploy case, and it's the one that has to fail closed.

`storage.ts` is a comment-only change. I traced whether its guard is still weak: `createCallbackToken` always signs `organizationId` in (`callback-token.ts:40`), so any *verified* token carries it, and after this fix the empty-org case is reachable only on the dev path. The guard is sound; the comment records why so it doesn't read as load-bearing.

## Verification

`apps/api` suite: 24 passed / 4 files. `tsc --noEmit` exit 0.

7 new tests, all asserting on status: 500 in production, 500 when `NODE_ENV` is unset, dev fallback preserved, plus the four already-correct paths (no bearer token, invalid token, verified token returns the org, missing installation header).

Non-vacuity verified by neutering the guard and re-running — the two fail-closed tests went red (`expected 200 to be 500`), the other five stayed green, then restored.

## Not addressed

Three other findings in the same area, from the plan's §8, all larger than this fix:

- **No replay binding** — the token's `nonce` is written and never checked, so within its 60s TTL it's an unlimited-use bearer credential.
- **`settings` routes don't enforce the settings schema on write** (`settings.ts:300-304`), while the same file loads it for reads. App settings hold app credentials.
- **`AppInstallation.uninstalledAt` is unchecked everywhere** — an uninstalled app's token still works for its remaining TTL.