### PR TITLE
fix(lambda): type the execution timeout handle environment-agnostically

### DIFF
--- a/apps/lambda/src/executors/code-executor.ts
+++ b/apps/lambda/src/executors/code-executor.ts
@@ -172,7 +172,7 @@ async function executeJavaScript(
   // between macrotasks, so `while(true){}` holds the isolate and the timer never
   // fires. Killing a runaway needs the child process of Phase B. The timer is
   // cleared below so a completed execution does not leave one pending.
-  let timeoutId: number | undefined
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise((_, reject) => {
     timeoutId = setTimeout(
       () => reject(new Error(`Code execution timeout after ${timeout}ms`)),


### PR DESCRIPTION
## Problem

`Docker lambda-server` fails on `main`, which skips **Deploy to Railway** ([run 30728549559](https://github.com/Auxx-Ai/auxx-ai/actions/runs/30728549559/job/91444613340)):

```
TS2322 [ERROR]: Type 'Timeout' is not assignable to type 'number'.
    timeoutId = setTimeout(
    at file:///app/src/executors/code-executor.ts:177:5
```

`Dockerfile.server` typechecks `src/dev-server.ts` with `@types/node` in scope, where `setTimeout` returns `Timeout`, not `number`. The timer handle added by A7 in `2e1a99a77` was typed `number`.

## Fix

One line — `ReturnType<typeof setTimeout>`, matching what `workflow-block-executor.ts:57` already does.

## Why only this job failed

The AWS `Dockerfile` unpacks a prebuilt bootstrap rather than running `deno compile` over `src/`, so `Dockerfile.server` is the only build that typechecks this file. That's the D15 build-drift the sandbox-hardening plan warns about, benign in this instance.

## Verification

- `deno check src/dev-server.ts` (the exact failing command) — passes
- `docker build -f apps/lambda/Dockerfile.server .` — builds clean, compile step 5.0s, image exports