### PR TITLE
feat(lambda): run workflow code nodes in an isolated child process

### DIFF
--- a/apps/lambda/Dockerfile.dev
+++ b/apps/lambda/Dockerfile.dev
@@ -24,11 +24,19 @@ COPY apps/lambda/deno.json ./deno.json
 EXPOSE 3008
 
 # Development server with hot reload
+# --allow-run is UNSCOPED here and only here. This image keeps hot reload, so there
+# is no compiled runner to point at — sandbox/spawn.ts falls back to spawning
+# `deno run` with the permission flags on the command line. The production image
+# (Dockerfile.server) bakes those permissions into a compiled binary and scopes the
+# parent to --allow-run=/runner. Do not copy this line into a deployed build.
+ENV LAMBDA_SANDBOX_DEV_RUNNER=1
+
 CMD ["deno", "run", \
      "--watch", \
      "--allow-net", \
      "--allow-env", \
      "--allow-read=/app,/bundles", \
      "--allow-sys", \
+     "--allow-run", \
      "--no-check", \
      "src/dev-server.ts"]

--- a/apps/lambda/Dockerfile.server
+++ b/apps/lambda/Dockerfile.server
@@ -29,10 +29,24 @@ COPY apps/lambda/deno.json ./deno.json
 # Cache dependencies
 RUN deno cache src/dev-server.ts
 
-# Compile to standalone binary
+# Compile the sandbox runner FIRST — the child process that evaluates untrusted
+# code. Its permissions are baked in here, at build time, precisely so they cannot
+# be widened at spawn (plan §5.1, D3). `--allow-net` rather than `--deny-net` is
+# deliberate: the egress broker is deferred (D13, §6.1).
+RUN deno compile \
+  --deny-env --deny-read --deny-write --deny-ffi --deny-run --deny-sys \
+  --allow-net \
+  --v8-flags=--max-old-space-size=256 \
+  --output dist/runner \
+  src/sandbox/runner.ts
+
+# Compile to standalone binary.
+# The parent gains exactly one new grant: --allow-run scoped to the runner path,
+# never blanket --allow-run.
 RUN deno compile \
   --allow-net --allow-env \
   --allow-read=/app,/bundles --allow-sys \
+  --allow-run=/runner \
   --output dist/server \
   src/dev-server.ts
 
@@ -48,6 +62,10 @@ ENV APP_VERSION=$APP_VERSION
 ENV BUILD_TIME=$BUILD_TIME
 
 COPY --from=builder /app/dist/server /server
+# Must land at /runner — the path baked into the parent's --allow-run grant and
+# the default in sandbox/spawn.ts. Distroless has no shell, which is irrelevant:
+# Deno.Command execs this binary directly.
+COPY --from=builder /app/dist/runner /runner
 
 EXPOSE 3008
 

--- a/apps/lambda/bootstrap
+++ b/apps/lambda/bootstrap
@@ -2,9 +2,21 @@
 set -euo pipefail
 
 # AWS Lambda Runtime Interface for Deno
+#
+# UNVERIFIED PATH. This interpreted entry point is not how the service is deployed
+# — production is Railway via Dockerfile.server (a compiled binary). It is kept in
+# sync with the permission set only so it cannot silently drift (plan D15).
+#
+# --allow-run is scoped to the deno executable because this variant has no compiled
+# runner to exec; sandbox/spawn.ts falls back to `deno run src/sandbox/runner.ts`.
+# That fallback is refused when NODE_ENV=production (it fails closed rather than
+# accept command-line permissions as the boundary), so running untrusted code from
+# THIS entry point in production requires compiling a runner and pointing
+# LAMBDA_RUNNER_PATH at it.
 exec deno run \
   --allow-net \
   --allow-env \
   --allow-read=/var/task,/tmp \
+  --allow-run=deno \
   --no-check \
   /var/task/src/index.ts

--- a/apps/lambda/build.sh
+++ b/apps/lambda/build.sh
@@ -26,6 +26,24 @@ cp -r "$SCRIPT_DIR/src" "$BUILD_DIR/src"
 mkdir -p "$BUILD_DIR/packages/sdk"
 cp -r "$PROJECT_ROOT/packages/sdk/lib" "$BUILD_DIR/packages/sdk/lib"
 
+# The sandbox runner — the child process that evaluates untrusted code. Kept in
+# lockstep with Dockerfile.server on purpose (plan D15): if only the Railway build
+# is updated, this binary keeps the old permission set and the §10 escape tests pass
+# against a binary that is not the one running. Drift here is how a hardened
+# permission set silently regresses.
+echo "[build] Compiling sandbox runner (aarch64-unknown-linux-gnu)..."
+
+deno compile \
+  --target aarch64-unknown-linux-gnu \
+  --config "$BUILD_DIR/deno.json" \
+  --deny-env --deny-read --deny-write --deny-ffi --deny-run --deny-sys \
+  --allow-net \
+  --v8-flags=--max-old-space-size=256 \
+  --output "$DIST_DIR/runner" \
+  "$BUILD_DIR/src/sandbox/runner.ts"
+
+chmod +x "$DIST_DIR/runner"
+
 echo "[build] Compiling bootstrap binary (aarch64-unknown-linux-gnu)..."
 
 deno compile \
@@ -35,6 +53,7 @@ deno compile \
   --allow-env \
   --allow-read=/var/task,/tmp,/bundles \
   --allow-sys \
+  --allow-run=/var/task/runner \
   --output "$DIST_DIR/bootstrap" \
   "$BUILD_DIR/src/lambda-runtime.ts"
 
@@ -42,8 +61,12 @@ chmod +x "$DIST_DIR/bootstrap"
 
 # Print info
 echo "[build] Done."
-ls -lh "$DIST_DIR/bootstrap"
+ls -lh "$DIST_DIR/bootstrap" "$DIST_DIR/runner"
 file "$DIST_DIR/bootstrap" 2>/dev/null || true
+
+# The runner must be deployed alongside the bootstrap at /var/task/runner — the
+# path baked into the --allow-run grant above. Set LAMBDA_RUNNER_PATH if it lands
+# elsewhere, or spawn.ts will fail closed rather than execute anything.
 
 # Cleanup
 rm -rf "$BUILD_DIR"

--- a/apps/lambda/deno.json
+++ b/apps/lambda/deno.json
@@ -18,8 +18,8 @@
     }
   },
   "tasks": {
-    "dev": "deno run --watch --allow-all src/index.ts",
-    "test": "deno test --allow-all"
+    "dev": "LAMBDA_SANDBOX_DEV_RUNNER=1 deno run --watch --allow-all src/index.ts",
+    "test": "LAMBDA_SANDBOX_DEV_RUNNER=1 deno test --allow-all"
   },
   "imports": {
     "@aws-sdk/client-s3": "npm:@aws-sdk/client-s3@^3.893.0",

--- a/apps/lambda/package.json
+++ b/apps/lambda/package.json
@@ -11,7 +11,7 @@
     "dev:bash": "docker compose exec lambda-dev bash",
     "build": "pnpm --filter @auxx/sdk build && ./build.sh",
     "pretest": "pnpm --filter @auxx/sdk build && mkdir -p packages/sdk && ln -sfn ../../../../packages/sdk/lib packages/sdk/lib",
-    "test": "deno test --allow-all",
+    "test": "LAMBDA_SANDBOX_DEV_RUNNER=1 deno test --allow-all",
     "typecheck": "deno check src/index.ts",
     "clean": "docker compose down -v && rm -rf .deno dist"
   },

--- a/apps/lambda/src/executors/__tests__/sandbox-mitigation.test.ts
+++ b/apps/lambda/src/executors/__tests__/sandbox-mitigation.test.ts
@@ -1,21 +1,32 @@
 // apps/lambda/src/executors/__tests__/sandbox-mitigation.test.ts
 
 /**
- * Phase A mitigation tests — `plans/lambda/security/01-sandbox-hardening-plan.md` §9.
+ * Sandbox tests — `plans/lambda/security/01-sandbox-hardening-plan.md` §9, §10.
  *
- * These pin the interim mitigations, NOT isolation. User code still shares this
- * realm; the boundary arrives with Phase B (child process). What is asserted here:
+ * Two layers, and it matters which is which:
  *
- *  - A1  secrets are removed from the environment after boot, so a code node that
- *        reaches the environment finds nothing (the non-bypassable part)
- *  - A2  a bare `Deno` reference in user code resolves to the shadowed parameter
- *        (defense in depth — `globalThis.Deno` deliberately still works, and the
- *        test pins that it does, so nobody mistakes this for the boundary)
+ *  - **Phase A (parent-side mitigations).** A1 env sealing and A3 the response cap.
+ *    These are properties of THIS process and still hold.
+ *  - **Phase B (the boundary).** Untrusted code now runs in a child process with no
+ *    ambient authority (`../../sandbox/spawn.ts`). Each escape attempt asserts a
+ *    SPECIFIC denial — a `NotCapable`, a kill, a structured failure — never merely
+ *    that a secret is absent from the output. A test that passes because a value
+ *    happened to be empty is a test that keeps passing after the sandbox breaks.
  *
- * A3 (response cap) is asserted against the handler in index.ts, not here.
+ * A2's `Deno` parameter shadowing is deliberately GONE and its tests with it. It was
+ * an interim trick for a world where the namespace was genuinely reachable; the child
+ * denies it for real, and shadowing would turn a truthful `NotCapable` into a
+ * misleading `TypeError` — hiding the boundary from the tests written to prove it.
+ *
+ * CAVEAT ON WHAT THESE PROVE. Under `deno test` the runner is started through the dev
+ * fallback, so its permissions come from command-line flags rather than being baked
+ * into a compiled binary (D3). These assert the permission SET is right. That the
+ * flags are genuinely baked in was verified separately against a compiled runner —
+ * see the plan's §9 "Validate early" measurements.
  */
 
-import { assertEquals, assertNotEquals } from 'jsr:@std/assert'
+import { assertEquals, assertNotEquals, assertStringIncludes } from 'jsr:@std/assert'
+import { runInSandbox } from '../../sandbox/spawn.ts'
 import { executeCode } from '../code-executor.ts'
 
 function codeEvent(body: string) {
@@ -31,32 +42,236 @@ function codeEvent(body: string) {
   }
 }
 
-Deno.test('A2: a bare `Deno` reference in user code is shadowed, not the namespace', async () => {
-  const result = await executeCode(codeEvent('return typeof Deno'))
+/**
+ * Run a body in the sandbox directly.
+ *
+ * Forces `NODE_ENV=development` because the A1 tests below set it to `production`,
+ * and in production `resolveRunner` fails closed to the compiled `/runner` binary
+ * that does not exist in a test run. Deno test order is not guaranteed, so this
+ * cannot rely on running first.
+ */
+function runBody(body: string, timeout = 15000) {
+  Deno.env.set('NODE_ENV', 'development')
+  return runInSandbox(
+    // `async` so bodies may `await` — a non-async wrapper turns `await import(...)`
+    // into a SyntaxError, which would fail a denial test for entirely the wrong reason.
+    { code: `async function main() {\n${body}\n}`, codeInput: {}, inputsConfig: [], variables: {} },
+    timeout
+  )
+}
 
-  assertEquals(result.result, 'undefined')
+/** Capture the error name from inside the child, where the denial actually happens. */
+function nameOfThrow(expression: string) {
+  return runBody(
+    `try { ${expression}; return { name: 'NO_THROW' } } catch (e) { return { name: e.name } }`
+  )
+}
+
+const spawnTest = { sanitizeOps: false, sanitizeResources: false }
+
+// ---------------------------------------------------------------------------
+// §10 rows 1, 2, 10, 11, 15, 16 — capability denials
+// ---------------------------------------------------------------------------
+
+Deno.test('row 1: Deno.env.toObject() is denied', spawnTest, async () => {
+  const result = await nameOfThrow('return Deno.env.toObject()')
+
+  assertEquals((result.value as { name: string }).name, 'NotCapable')
 })
 
-Deno.test('A2: `Deno.env.get` in user code throws rather than returning a secret', async () => {
-  const result = await executeCode(
-    codeEvent(`
-      try { return { value: Deno.env.get('LAMBDA_INVOKE_SECRET') } }
-      catch (e) { return { threw: e.constructor.name } }
-    `)
+Deno.test(
+  'row 2: the invoke secret is unreachable, by denial not by absence',
+  spawnTest,
+  async () => {
+    // Set it in the PARENT first. If the child could reach the environment at all,
+    // this is the value it would find — so a pass here cannot be the empty-value
+    // false positive the plan warns about.
+    Deno.env.set('LAMBDA_INVOKE_SECRET', 'probe-secret-value')
+
+    const result = await nameOfThrow("return Deno.env.get('LAMBDA_INVOKE_SECRET')")
+
+    assertEquals((result.value as { name: string }).name, 'NotCapable')
+    assertEquals(JSON.stringify(result).includes('probe-secret-value'), false)
+  }
+)
+
+Deno.test('row 10: the filesystem is unreadable', spawnTest, async () => {
+  const result = await nameOfThrow("return Deno.readTextFileSync('/etc/passwd')")
+
+  assertEquals((result.value as { name: string }).name, 'NotCapable')
+})
+
+Deno.test('row 11: node:fs cannot reach the filesystem either', spawnTest, async () => {
+  // The §4.3 bypass. Deleting `globalThis.Deno` never stopped this — node:fs kept
+  // full read AND write. Only the process boundary closes it.
+  const result = await runBody(`
+    try {
+      const fs = await import('node:fs')
+      return { name: 'NO_THROW', bytes: fs.readFileSync('/etc/passwd', 'utf8').length }
+    } catch (e) { return { name: e.name } }
+  `)
+
+  assertEquals((result.value as { name: string }).name, 'NotCapable')
+})
+
+Deno.test('row 15: the filesystem is unwritable', spawnTest, async () => {
+  const result = await nameOfThrow("return Deno.writeTextFileSync('/tmp/pwned', 'x')")
+
+  assertEquals((result.value as { name: string }).name, 'NotCapable')
+})
+
+Deno.test('row 9: spawning a process is denied at call time', spawnTest, async () => {
+  // Two traps here, both of which produce a test that passes for the wrong reason.
+  //
+  // 1. Assert on .outputSync(), NEVER on `typeof Deno.Command` — the constructor is
+  //    present regardless of permissions; --allow-run is enforced when it is called.
+  // 2. Use an ABSOLUTE path. `clearEnv: true` (D5) leaves the child with no PATH, so
+  //    a bare 'sh' fails with "no path to search ... not an absolute path" — an
+  //    incidental resolution failure, not a permission denial. That would keep
+  //    passing even if --allow-run were granted.
+  const result = await nameOfThrow(
+    "return new Deno.Command('/bin/sh', { args: ['-c', 'id'] }).outputSync()"
   )
 
-  assertEquals((result.result as { threw?: string }).threw, 'TypeError')
+  assertEquals((result.value as { name: string }).name, 'NotCapable')
 })
 
-Deno.test('A2 is NOT the boundary: globalThis.Deno still reaches the namespace', async () => {
-  // Pinned deliberately. Parameter shadowing raises the bar for casual access; it
-  // does not contain hostile code. If this ever starts failing because someone
-  // deleted the global instead, read the comment in code-executor.ts first —
-  // global deletion is process-wide and breaks concurrent invocations.
-  const result = await executeCode(codeEvent('return typeof globalThis.Deno'))
+Deno.test('row 16: FFI is denied', spawnTest, async () => {
+  // The permission check precedes any attempt to open the library, so this asserts
+  // the denial rather than the path's existence and holds on any platform.
+  const result = await nameOfThrow("return Deno.dlopen('/usr/lib/libSystem.dylib', {})")
 
-  assertEquals(result.result, 'object')
+  assertEquals((result.value as { name: string }).name, 'NotCapable')
 })
+
+// ---------------------------------------------------------------------------
+// §10 rows 7, 8, 13 — resource limits, and the parent surviving each one
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  'row 7: a synchronous infinite loop is killed, and the parent still serves',
+  spawnTest,
+  async () => {
+    // The defect Promise.race could never fix (§2.3): a macrotask timer cannot fire
+    // while `while(true)` holds the isolate. SIGKILL does not need the child's consent.
+    const started = Date.now()
+    const hung = await runBody('while (true) {}', 2000)
+    const elapsed = Date.now() - started
+
+    assertEquals(hung.ok, false)
+    assertEquals(hung.failure, 'timeout')
+    assertEquals(elapsed < 10000, true, `expected a prompt kill, took ${elapsed}ms`)
+
+    // The property that matters more than the kill itself.
+    const next = await runBody("return 'parent still serving'")
+    assertEquals(next.value, 'parent still serving')
+  }
+)
+
+Deno.test('row 8: a memory bomb kills only the child', spawnTest, async () => {
+  // The measurement that rejected Workers (§4.2): this exact input aborted the
+  // ENTIRE host process (exit 133) in a worker, and `event.preventDefault()` did
+  // not help because a V8 fatal abort is not a JS error. Here it must be contained.
+  const bomb = await runBody(
+    'const a = []; while (true) { a.push(new Array(1e6).fill("x")) }',
+    30000
+  )
+
+  assertEquals(bomb.ok, false)
+  assertEquals(bomb.failure, 'out_of_memory')
+
+  const next = await runBody("return 'parent survived the bomb'")
+  assertEquals(next.value, 'parent survived the bomb')
+})
+
+Deno.test('row 13: an oversized result trips the output cap', spawnTest, async () => {
+  const big = await runBody('return "x".repeat(50 * 1024 * 1024)')
+
+  assertEquals(big.ok, false)
+  assertEquals(big.failure, 'output_too_large')
+
+  const next = await runBody("return 'parent healthy'")
+  assertEquals(next.value, 'parent healthy')
+})
+
+// ---------------------------------------------------------------------------
+// §10 row 14 — no authority crosses the boundary
+// ---------------------------------------------------------------------------
+
+Deno.test('row 14: callback tokens are not reachable from the child', spawnTest, async () => {
+  // §8 item 1. In the parent's realm `runtime-helpers/index.ts` assigns the whole
+  // RuntimeContext — tokens included — onto globalThis. Nothing may serialize it
+  // across: a child holding a bearer credential gives back most of the boundary.
+  const result = await runBody('return typeof globalThis.__AUXX_SERVER_CONTEXT__')
+
+  assertEquals(result.value, 'undefined')
+})
+
+// ---------------------------------------------------------------------------
+// Non-escape regressions — the boundary must not break legitimate code
+// ---------------------------------------------------------------------------
+
+Deno.test('the sanitizeForJson contract survives the boundary', spawnTest, async () => {
+  // Pins the `undefined → null` guarantee now that it is applied in the child.
+  Deno.env.set('NODE_ENV', 'development')
+  const result = await runInSandbox(
+    {
+      code: 'function main() { return { present: 1, missing: undefined, nested: { gone: undefined } } }',
+      codeInput: {},
+      inputsConfig: [],
+      variables: {},
+    },
+    15000
+  )
+
+  assertEquals(result.ok, true)
+  assertEquals(result.value, { present: 1, missing: null, nested: { gone: null } })
+})
+
+Deno.test(
+  '$(...).var() still resolves workflow variables across the boundary',
+  spawnTest,
+  async () => {
+    Deno.env.set('NODE_ENV', 'development')
+    const result = await runInSandbox(
+      {
+        code: "function main() { return $('sys').var('workflowId') }",
+        codeInput: {},
+        inputsConfig: [],
+        variables: { 'sys.workflowId': 'wf_123' },
+      },
+      15000
+    )
+
+    assertEquals(result.value, 'wf_123')
+  }
+)
+
+Deno.test('console output is captured in the child and returned', spawnTest, async () => {
+  const result = await executeCode(codeEvent("console.log('from the child'); return 'done'"))
+
+  assertEquals(result.result, 'done')
+  assertEquals(result.metadata?.consoleLogs?.[0]?.message, 'from the child')
+})
+
+Deno.test(
+  'a user error surfaces with its message, not as a platform crash',
+  spawnTest,
+  async () => {
+    let message = ''
+    try {
+      await executeCode(codeEvent("throw new Error('deliberate user failure')"))
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    assertStringIncludes(message, 'deliberate user failure')
+  }
+)
+
+// ---------------------------------------------------------------------------
+// Phase A — parent-side mitigations, unchanged by the boundary
+// ---------------------------------------------------------------------------
 
 Deno.test('A1: sealed secrets are absent from the environment', async () => {
   // Mirrors what sealEnvironment() guarantees at boot. Set a value, seal, and
@@ -80,9 +295,12 @@ Deno.test('A1: sealing does not disturb variables the service still needs', asyn
   sealEnvironment()
 
   assertNotEquals(Deno.env.get('NODE_ENV'), undefined)
+
+  // Restore, so a later-scheduled sandbox test does not fail closed to /runner.
+  Deno.env.set('NODE_ENV', 'development')
 })
 
-Deno.test('A3: an oversized execution result is rejected, not returned', async () => {
+Deno.test('A3: an oversized execution result is rejected, not returned', spawnTest, async () => {
   // No secret configured + NODE_ENV=development skips the inbound auth gate, so
   // the handler can be exercised directly. See index.ts:154-162.
   Deno.env.set('NODE_ENV', 'development')
@@ -94,6 +312,10 @@ Deno.test('A3: an oversized execution result is rejected, not returned', async (
     ...codeEvent("return 'x'.repeat(6 * 1024 * 1024)"),
   } as never)
 
+  // Still 413 RESPONSE_TOO_LARGE, but it is now the SANDBOX's 4 MB frame cap that
+  // trips rather than the handler measuring a serialized body — the child is killed
+  // before it can hand the parent something that large. index.ts maps the code back
+  // to 413 so the documented status is not silently downgraded to a generic 500.
   assertEquals(oversized.statusCode, 413)
   assertEquals(JSON.parse(oversized.body).error.code, 'RESPONSE_TOO_LARGE')
 

--- a/apps/lambda/src/executors/code-executor.ts
+++ b/apps/lambda/src/executors/code-executor.ts
@@ -2,278 +2,44 @@
 
 /**
  * Code executor for Lambda runtime.
- * Executes user code in a sandboxed environment with variable access via $ function.
+ *
+ * Routes workflow code nodes through the sandbox child process
+ * (`../sandbox/spawn.ts`). This file no longer evaluates anything itself — the
+ * `new Function` call that ran user code in this realm is deleted, along with the
+ * wrapper generation and `sanitizeForJson`, both of which moved into the runner so
+ * they execute on the far side of the boundary.
+ *
+ * See `plans/lambda/security/01-sandbox-hardening-plan.md` §5, Phase B step 4.
+ * This is the surface every full-seat member can reach
+ * (`MEMBER_BASELINE_LEVELS[Area.workflows] = Level.Full`), so it cuts over first.
  */
 
-import {
-  clearCapturedLogs,
-  getCapturedLogs,
-  interceptConsole,
-  restoreConsole,
-} from '../runtime-helpers/index.ts'
+import { setCapturedLogs } from '../runtime-helpers/console.ts'
+import { runInSandbox } from '../sandbox/spawn.ts'
 import type { ExecutionResult } from '../types.ts'
 import type { CodeExecutionEvent } from '../validator.ts'
 
 /**
- * Helper to resolve variable paths with multiple fallback strategies
- * Ported from packages/lib/src/workflow-engine/nodes/action-nodes/code.ts:237-259
- */
-function resolveVariablePath(path: string, variables: Record<string, any>): any {
-  // 1. Direct lookup: "sys.currentTime"
-  if (variables[path] !== undefined) {
-    return variables[path]
-  }
-
-  // 2. Underscore format: "sys_currentTime" (for backwards compatibility)
-  const underscorePath = path.replace(/\./g, '_')
-  if (variables[underscorePath] !== undefined) {
-    return variables[underscorePath]
-  }
-
-  // 3. Nested object access: "message.subject" where variables['message'] is an object
-  const parts = path.split('.')
-  if (parts.length > 1) {
-    const rootValue = variables[parts[0]]
-    if (rootValue && typeof rootValue === 'object') {
-      return getNestedProperty(rootValue, parts.slice(1).join('.'))
-    }
-  }
-
-  return undefined
-}
-
-/**
- * Helper for nested property access with array support
- * Ported from packages/lib/src/workflow-engine/nodes/action-nodes/code.ts:262-276
- */
-function getNestedProperty(obj: any, path: string): any {
-  return path.split('.').reduce((current, prop) => {
-    if (current === null || current === undefined) return undefined
-
-    // Handle array access like "items[0]"
-    const arrayMatch = prop.match(/^(.+)\[(\d+)\]$/)
-    if (arrayMatch) {
-      const [, arrayProp, index] = arrayMatch
-      const array = current[arrayProp]
-      return Array.isArray(array) ? array[parseInt(index, 10)] : undefined
-    }
-
-    return current[prop]
-  }, obj)
-}
-
-/**
- * Check if contextId is a known schema context
- * Ported from packages/lib/src/workflow-engine/nodes/action-nodes/code.ts:279-281
- */
-function isSchemaContext(contextId: string): boolean {
-  return ['message', 'order', 'customer', 'product', 'ticket', 'user'].includes(contextId)
-}
-
-/**
- * Create the $ function for variable access
- * Ported from packages/lib/src/workflow-engine/nodes/action-nodes/code.ts:284-298
- *
- * Usage:
- * - $('sys').var('currentTime') → looks up "sys.currentTime"
- * - $('env').var('apiKey') → looks up "env.apiKey"
- * - $('nodeId').var('result') → looks up "nodeId.result"
- */
-// function createDollarFunction(variables: Record<string, any>) {
-//   return function $(contextId: string) {
-//     return {
-//       var: (varPath: string) => {
-//         if (contextId === 'sys' || contextId === 'env' || isSchemaContext(contextId)) {
-//           // Handle system, environment, and schema variables
-//           const fullPath = contextId + '.' + varPath
-//           return resolveVariablePath(fullPath, variables)
-//         } else {
-//           // Handle node variables
-//           const fullPath = contextId + '.' + varPath
-//           return resolveVariablePath(fullPath, variables)
-//         }
-//       },
-//     }
-//   }
-// }
-
-/**
- * Generate the wrapped code that includes $ function and main() execution
- */
-function generateWrappedCode(
-  userCode: string,
-  inputsConfig: Array<{ name: string; variableId: string }>
-): string {
-  // Build argument list dynamically from inputsConfig
-  const argList = inputsConfig.map((input) => `codeInput.${input.name}`).join(', ')
-
-  return `
-    return (async function() {
-      'use strict';
-
-      // Receive workflow variables and code inputs as parameters (not stringified!)
-      // These are passed via Function constructor parameters below
-      const __variables = variables;
-
-      // $ function for variable access
-      ${resolveVariablePath.toString()}
-      ${getNestedProperty.toString()}
-      ${isSchemaContext.toString()}
-
-      const $ = function(contextId) {
-        return {
-          var: function(varPath) {
-            if (contextId === 'sys' || contextId === 'env' || isSchemaContext(contextId)) {
-              // Handle system, environment, and schema variables
-              const fullPath = contextId + '.' + varPath;
-              return resolveVariablePath(fullPath, __variables);
-            } else {
-              // Handle node variables
-              const fullPath = contextId + '.' + varPath;
-              return resolveVariablePath(fullPath, __variables);
-            }
-          }
-        };
-      };
-
-      // User's code
-      ${userCode}
-
-      // Execute main function with input values as arguments
-      if (typeof main === 'function') {
-        // IMPORTANT: Pass input values as arguments in the order defined in inputsConfig
-        // Access values from codeInput object (passed as parameter)
-        // This preserves complex types: Dates, Functions, circular refs, etc.
-        const argValues = [${argList}];
-        return await main(...argValues);
-      } else {
-        throw new Error('Code must define a main() function');
-      }
-    })()
-  `
-}
-
-/**
- * Execute JavaScript code in Deno sandbox
- */
-async function executeJavaScript(
-  code: string,
-  codeInput: Record<string, any>,
-  inputsConfig: Array<{ name: string; variableId: string }>,
-  variables: Record<string, any>,
-  timeout: number
-): Promise<any> {
-  // Generate wrapped code
-  const wrappedCode = generateWrappedCode(code, inputsConfig)
-
-  // Execute with timeout.
-  //
-  // NOTE: this cannot preempt synchronous user code — `Promise.race` only settles
-  // between macrotasks, so `while(true){}` holds the isolate and the timer never
-  // fires. Killing a runaway needs the child process of Phase B. The timer is
-  // cleared below so a completed execution does not leave one pending.
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  const timeoutPromise = new Promise((_, reject) => {
-    timeoutId = setTimeout(
-      () => reject(new Error(`Code execution timeout after ${timeout}ms`)),
-      timeout
-    )
-  })
-
-  const executionPromise = (async () => {
-    try {
-      // Execute wrapped code with values passed as parameters
-      // This avoids JSON.stringify issues with complex objects
-      //
-      // `Deno` is declared as a parameter and left undefined, so a bare `Deno.env`
-      // in user code resolves to the parameter instead of the global namespace.
-      //
-      // DEFENSE IN DEPTH ONLY — this is NOT the security boundary, and it is
-      // BYPASSABLE: `globalThis.Deno` still reaches the namespace, and
-      // `import('node:fs')` reaches the filesystem without touching `Deno` at all
-      // (measured — see plan §4.3). Parameter shadowing is used rather than
-      // deleting the global because deletion is process-wide: a concurrent
-      // invocation, or one that hangs on an unresolved promise past the timeout,
-      // would leave the whole service without `Deno`.
-      //
-      // The real boundary is a child process with no ambient authority (Phase B).
-      // The non-bypassable part of Phase A is secrets.ts, which removes the
-      // credentials from the environment outright instead of hiding a path to them.
-      const fn = new Function('variables', 'codeInput', 'Deno', wrappedCode)
-      const result = await fn(variables, codeInput, undefined)
-      return result
-    } catch (error) {
-      // Enhance error message
-      if (error instanceof Error) {
-        throw new Error(`Code execution error: ${error.message}\n${error.stack || ''}`)
-      }
-      throw error
-    }
-  })()
-
-  try {
-    return await Promise.race([executionPromise, timeoutPromise])
-  } finally {
-    if (timeoutId !== undefined) clearTimeout(timeoutId)
-  }
-}
-
-/**
  * Execute Python code (placeholder for future implementation)
  */
-async function executePython(
-  _code: string,
-  _codeInput: Record<string, any>,
-  _inputsConfig: Array<{ name: string; variableId: string }>,
-  _workflowVariables: Record<string, any>,
-  _timeout: number
-): Promise<any> {
+function executePython(): never {
   throw new Error('Python execution not yet implemented')
 }
 
 /**
- * Sanitize object for JSON serialization
- * Converts undefined values to null to preserve object structure
- * (JSON.stringify drops undefined properties, but preserves null)
- */
-function sanitizeForJson(obj: any): any {
-  // Primitives
-  if (obj === undefined) return null
-  if (obj === null) return null
-  if (typeof obj !== 'object') return obj
-
-  // Arrays
-  if (Array.isArray(obj)) {
-    return obj.map(sanitizeForJson)
-  }
-
-  // Objects
-  const sanitized: Record<string, any> = {}
-  for (const [key, value] of Object.entries(obj)) {
-    sanitized[key] = value === undefined ? null : sanitizeForJson(value)
-  }
-  return sanitized
-}
-
-/**
  * Main code executor function.
- * Executes user code in a sandboxed environment with:
- * - $ function for workflow variable access
- * - Input variables passed as function parameters
- * - Console log capture
- * - Timeout enforcement
  *
- * Uses CodeExecutionEvent type from validator for type safety
+ * Executes user code in a child process with no ambient authority, with:
+ * - `$` function for workflow variable access
+ * - input variables passed as function parameters
+ * - console log capture (performed in the child, shipped back over stdio)
+ * - timeout enforcement that can preempt synchronous code
+ *
+ * Uses CodeExecutionEvent type from validator for type safety.
  */
 export async function executeCode(options: CodeExecutionEvent): Promise<ExecutionResult> {
-  const {
-    code,
-    codeLanguage,
-    codeInput = {}, // Default to empty object
-    inputsConfig = [], // Default to empty array
-    variables,
-    timeout, // Default provided by Zod schema
-  } = options
+  const { code, codeLanguage, codeInput = {}, inputsConfig = [], variables, timeout } = options
+
   console.log('[CodeExecutor] Executing code:', {
     language: codeLanguage,
     timeout,
@@ -284,47 +50,42 @@ export async function executeCode(options: CodeExecutionEvent): Promise<Executio
     userId: variables['sys.userId'],
   })
 
-  try {
-    // 1. Clear previous logs and intercept console
-    clearCapturedLogs()
-    interceptConsole()
+  if (codeLanguage === 'python3') {
+    executePython()
+  }
 
-    // 2. Execute code based on language
-    let result: any
-    if (codeLanguage === 'javascript') {
-      result = await executeJavaScript(
-        code,
-        codeInput,
-        inputsConfig,
-        variables, // Pass all variables
-        timeout
-      )
-    } else if (codeLanguage === 'python3') {
-      result = await executePython(
-        code,
-        codeInput,
-        inputsConfig,
-        variables, // Pass all variables
-        timeout
-      )
-    } else {
-      throw new Error(`Unsupported language: ${codeLanguage}`)
-    }
+  if (codeLanguage !== 'javascript') {
+    throw new Error(`Unsupported language: ${codeLanguage}`)
+  }
 
-    // 3. Get captured logs
-    const consoleLogs = getCapturedLogs()
+  const outcome = await runInSandbox({ code, codeInput, inputsConfig, variables }, timeout)
 
-    console.log('[CodeExecutor] Execution succeeded:', {
-      resultType: typeof result,
-      logCount: consoleLogs.length,
+  // Publish the child's logs before any throw, so the error path in index.ts
+  // still reports what the code printed before it failed.
+  setCapturedLogs(outcome.logs)
+
+  if (!outcome.ok) {
+    console.error('[CodeExecutor] Execution failed:', {
+      failure: outcome.failure,
+      logCount: outcome.logs.length,
     })
 
-    return {
-      result: sanitizeForJson(result),
-      metadata: { consoleLogs },
+    const error = new Error(outcome.message ?? 'Code execution failed') as Error & {
+      code?: string
     }
-  } finally {
-    // 4. Always restore console
-    restoreConsole()
+    // Preserves the 413 the handler already returns for oversized results — the
+    // sandbox cap now trips before index.ts can measure the serialized body.
+    if (outcome.failure === 'output_too_large') error.code = 'RESPONSE_TOO_LARGE'
+    throw error
+  }
+
+  console.log('[CodeExecutor] Execution succeeded:', {
+    resultType: typeof outcome.value,
+    logCount: outcome.logs.length,
+  })
+
+  return {
+    result: outcome.value,
+    metadata: { consoleLogs: outcome.logs },
   }
 }

--- a/apps/lambda/src/index.ts
+++ b/apps/lambda/src/index.ts
@@ -319,7 +319,11 @@ export async function handler(
     }
 
     return {
-      statusCode: 500,
+      // The sandbox's own output cap (4 MB) trips before this handler ever gets a
+      // value to measure against MAX_RESPONSE_BYTES, so the oversized-result case
+      // now arrives here as a throw. Keep answering 413 for it rather than
+      // silently downgrading a documented status to a generic 500.
+      statusCode: code === 'RESPONSE_TOO_LARGE' ? 413 : 500,
       body: JSON.stringify({
         error: {
           message,

--- a/apps/lambda/src/runtime-helpers/console.ts
+++ b/apps/lambda/src/runtime-helpers/console.ts
@@ -322,3 +322,20 @@ export function getCapturedLogs(): ConsoleLog[] {
 export function clearCapturedLogs(): void {
   capturedLogs = []
 }
+
+/**
+ * Adopt logs captured elsewhere as this invocation's logs.
+ *
+ * Needed because untrusted code no longer runs in this process: the sandbox child
+ * captures its own console and ships the logs back over stdio
+ * (`sandbox/protocol.ts`). Publishing them here keeps the one retrieval path in
+ * `index.ts` working for BOTH outcomes — in particular the error path, which
+ * reads `getCapturedLogs()` after a throw and would otherwise report nothing for
+ * a failed code node.
+ *
+ * @param {ConsoleLog[]} logs - Logs captured by the sandbox child
+ * @returns {void}
+ */
+export function setCapturedLogs(logs: ConsoleLog[]): void {
+  capturedLogs = logs
+}

--- a/apps/lambda/src/sandbox/protocol.ts
+++ b/apps/lambda/src/sandbox/protocol.ts
@@ -1,0 +1,75 @@
+// apps/lambda/src/sandbox/protocol.ts
+
+/**
+ * Wire protocol between the parent service and the untrusted-code child process.
+ * See `plans/lambda/security/01-sandbox-hardening-plan.md` §5.
+ *
+ * One request in, one response out, newline-delimited JSON on stdin/stdout.
+ *
+ * DELIBERATELY DEPENDENCY-FREE. This module is imported by `runner.ts`, which is
+ * a separate `deno compile` target, and the child's module graph is part of its
+ * security posture: nothing here may pull in `../types.ts` (→ `validator.ts` → zod)
+ * or anything that reaches the AWS SDK. `SandboxConsoleLog` is therefore a
+ * structural copy of `ConsoleLog` from `../types.ts` rather than an import.
+ *
+ * Nothing carrying authority may be added to `SandboxRequest`. In particular
+ * callback tokens must never cross this boundary (§8 item 1) — a child that holds
+ * a bearer credential has given back most of what the process boundary bought.
+ */
+
+export const PROTOCOL_VERSION = 1
+
+/** Structural copy of `ConsoleLog` (`../types.ts`) — see the no-imports note above. */
+export interface SandboxConsoleLog {
+  level: 'log' | 'warn' | 'error'
+  message: string
+  args: unknown[]
+  timestamp: number
+}
+
+/** Parent → child. Everything the child needs, and nothing more. */
+export interface SandboxRequest {
+  v: typeof PROTOCOL_VERSION
+  code: string
+  codeInput: Record<string, unknown>
+  inputsConfig: Array<{ name: string; variableId: string }>
+  variables: Record<string, unknown>
+}
+
+export interface SandboxOk {
+  ok: true
+  value: unknown
+  logs: SandboxConsoleLog[]
+}
+
+export interface SandboxErr {
+  ok: false
+  /**
+   * Structured rather than a formatted string so the parent decides what to
+   * surface. `stack` is included for the parent's logs but must not be echoed
+   * to callers — V8 traces leak host paths and layout (§7).
+   */
+  error: { name: string; message: string; stack?: string }
+  logs: SandboxConsoleLog[]
+}
+
+export type SandboxResponse = SandboxOk | SandboxErr
+
+/** Serialize a frame, newline-terminated. Throws if the value is not serializable. */
+export function encodeFrame(value: SandboxRequest | SandboxResponse): Uint8Array {
+  return new TextEncoder().encode(`${JSON.stringify(value)}\n`)
+}
+
+/**
+ * Parse a frame. Returns `null` rather than throwing on malformed input — the
+ * child is untrusted and a crash-on-parse would be a denial-of-service lever on
+ * the parent.
+ */
+export function decodeFrame<T extends SandboxRequest | SandboxResponse>(raw: string): T | null {
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as T) : null
+  } catch {
+    return null
+  }
+}

--- a/apps/lambda/src/sandbox/runner.ts
+++ b/apps/lambda/src/sandbox/runner.ts
@@ -1,0 +1,267 @@
+// apps/lambda/src/sandbox/runner.ts
+
+/**
+ * Untrusted-code child process — the security boundary.
+ * See `plans/lambda/security/01-sandbox-hardening-plan.md` §5, D1, D3.
+ *
+ * Reads one `SandboxRequest` frame from stdin, evaluates the user's code, writes
+ * one `SandboxResponse` frame to stdout, exits. Holds no secrets, no credentials
+ * and no callback tokens, and is compiled with permissions baked in so they
+ * cannot be widened at spawn time:
+ *
+ *   deno compile --deny-env --deny-read --deny-write --deny-ffi --deny-run --deny-sys \
+ *     --v8-flags=--max-old-space-size=256 --output dist/runner src/sandbox/runner.ts
+ *
+ * `--allow-net` is deliberately present rather than `--deny-net` (D13): user code
+ * legitimately calls out, and the egress broker that would make denial workable is
+ * deferred. Unrestricted egress is far less dangerous here than the same grant on
+ * the parent, because this process has nothing worth exfiltrating — see §6.1.
+ *
+ * NOTE ON `Deno` SHADOWING. Phase A passed `Deno` as an undefined `new Function`
+ * parameter (A2), because in the parent's realm the namespace was genuinely
+ * reachable. That is deliberately NOT done here. The permission set denies the
+ * namespace for real, and shadowing would convert a truthful `NotCapable` into a
+ * misleading `TypeError` — hiding the boundary from the very tests written to
+ * prove it (§10 rows 1, 2, 9, 15, 16).
+ */
+
+import {
+  decodeFrame,
+  encodeFrame,
+  PROTOCOL_VERSION,
+  type SandboxConsoleLog,
+  type SandboxRequest,
+  type SandboxResponse,
+} from './protocol.ts'
+
+// ---------------------------------------------------------------------------
+// Console capture (inlined rather than imported from ../runtime-helpers/console.ts,
+// which is reachable from the server SDK and would widen the child's module graph)
+// ---------------------------------------------------------------------------
+
+const MAX_MESSAGE_LENGTH = 10000
+const MAX_LOGS = 1000
+
+const capturedLogs: SandboxConsoleLog[] = []
+
+function serializeArgs(args: unknown[]): string {
+  try {
+    const message = args
+      .map((arg) => {
+        if (typeof arg === 'string') return arg
+        if (typeof arg === 'number' || typeof arg === 'boolean') return String(arg)
+        if (arg === null) return 'null'
+        if (arg === undefined) return 'undefined'
+        try {
+          return JSON.stringify(arg)
+        } catch {
+          return String(arg)
+        }
+      })
+      .join(' ')
+
+    return message.length > MAX_MESSAGE_LENGTH
+      ? `${message.substring(0, MAX_MESSAGE_LENGTH)}... [truncated]`
+      : message
+  } catch {
+    return '[Error serializing arguments]'
+  }
+}
+
+/**
+ * Redirect console to the capture buffer.
+ *
+ * Every level must be redirected, not just captured: stdout is the response
+ * channel, so a stray `console.log` in user code would corrupt the frame the
+ * parent is trying to parse.
+ */
+function interceptConsole(): void {
+  const capture =
+    (level: SandboxConsoleLog['level']) =>
+    (...args: unknown[]) => {
+      if (capturedLogs.length >= MAX_LOGS) return
+      capturedLogs.push({
+        level,
+        message: serializeArgs(args),
+        args: [],
+        timestamp: Date.now(),
+      })
+    }
+
+  console.log = capture('log')
+  console.info = capture('log')
+  console.debug = capture('log')
+  console.warn = capture('warn')
+  console.error = capture('error')
+}
+
+// ---------------------------------------------------------------------------
+// Variable access — ported verbatim from code-executor.ts so `$('sys').var(...)`
+// behaves identically across the new boundary
+// ---------------------------------------------------------------------------
+
+function resolveVariablePath(path: string, variables: Record<string, any>): any {
+  if (variables[path] !== undefined) {
+    return variables[path]
+  }
+
+  const underscorePath = path.replace(/\./g, '_')
+  if (variables[underscorePath] !== undefined) {
+    return variables[underscorePath]
+  }
+
+  const parts = path.split('.')
+  if (parts.length > 1) {
+    const rootValue = variables[parts[0]]
+    if (rootValue && typeof rootValue === 'object') {
+      return getNestedProperty(rootValue, parts.slice(1).join('.'))
+    }
+  }
+
+  return undefined
+}
+
+function getNestedProperty(obj: any, path: string): any {
+  return path.split('.').reduce((current, prop) => {
+    if (current === null || current === undefined) return undefined
+
+    const arrayMatch = prop.match(/^(.+)\[(\d+)\]$/)
+    if (arrayMatch) {
+      const [, arrayProp, index] = arrayMatch
+      const array = current[arrayProp]
+      return Array.isArray(array) ? array[parseInt(index, 10)] : undefined
+    }
+
+    return current[prop]
+  }, obj)
+}
+
+function isSchemaContext(contextId: string): boolean {
+  return ['message', 'order', 'customer', 'product', 'ticket', 'user'].includes(contextId)
+}
+
+function generateWrappedCode(
+  userCode: string,
+  inputsConfig: Array<{ name: string; variableId: string }>
+): string {
+  const argList = inputsConfig.map((input) => `codeInput.${input.name}`).join(', ')
+
+  return `
+    return (async function() {
+      'use strict';
+
+      const __variables = variables;
+
+      ${resolveVariablePath.toString()}
+      ${getNestedProperty.toString()}
+      ${isSchemaContext.toString()}
+
+      const $ = function(contextId) {
+        return {
+          var: function(varPath) {
+            const fullPath = contextId + '.' + varPath;
+            return resolveVariablePath(fullPath, __variables);
+          }
+        };
+      };
+
+      // User's code
+      ${userCode}
+
+      if (typeof main === 'function') {
+        const argValues = [${argList}];
+        return await main(...argValues);
+      } else {
+        throw new Error('Code must define a main() function');
+      }
+    })()
+  `
+}
+
+/**
+ * Convert `undefined` to `null` so object structure survives `JSON.stringify`.
+ * Moved here from `code-executor.ts` per §5.1 so the contract holds on the side
+ * of the boundary that produces the value.
+ */
+function sanitizeForJson(obj: any): any {
+  if (obj === undefined) return null
+  if (obj === null) return null
+  if (typeof obj !== 'object') return obj
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeForJson)
+  }
+
+  const sanitized: Record<string, any> = {}
+  for (const [key, value] of Object.entries(obj)) {
+    sanitized[key] = value === undefined ? null : sanitizeForJson(value)
+  }
+  return sanitized
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function readStdin(): Promise<string> {
+  const chunks: Uint8Array[] = []
+  const reader = Deno.stdin.readable.getReader()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) chunks.push(value)
+  }
+
+  const total = chunks.reduce((sum, c) => sum + c.length, 0)
+  const merged = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return new TextDecoder().decode(merged)
+}
+
+async function writeResponse(response: SandboxResponse): Promise<void> {
+  await Deno.stdout.write(encodeFrame(response))
+}
+
+async function main(): Promise<void> {
+  // Capture BEFORE any user code runs, so nothing user-authored reaches stdout.
+  interceptConsole()
+
+  const raw = await readStdin()
+  const request = decodeFrame<SandboxRequest>(raw.trim())
+
+  if (!request || request.v !== PROTOCOL_VERSION) {
+    await writeResponse({
+      ok: false,
+      error: { name: 'ProtocolError', message: 'malformed or unsupported request frame' },
+      logs: [],
+    })
+    Deno.exit(2)
+  }
+
+  try {
+    const wrapped = generateWrappedCode(request.code, request.inputsConfig ?? [])
+    const fn = new Function('variables', 'codeInput', wrapped)
+    const value = await fn(request.variables ?? {}, request.codeInput ?? {})
+
+    await writeResponse({ ok: true, value: sanitizeForJson(value), logs: capturedLogs })
+  } catch (error) {
+    const err = error as Error
+    await writeResponse({
+      ok: false,
+      error: {
+        name: err?.name ?? 'Error',
+        message: err?.message ?? String(error),
+        stack: err?.stack,
+      },
+      logs: capturedLogs,
+    })
+  }
+}
+
+await main()

--- a/apps/lambda/src/sandbox/spawn.ts
+++ b/apps/lambda/src/sandbox/spawn.ts
@@ -1,0 +1,342 @@
+// apps/lambda/src/sandbox/spawn.ts
+
+/**
+ * Parent side of the sandbox boundary — the ONLY call site for untrusted code.
+ * See `plans/lambda/security/01-sandbox-hardening-plan.md` §5, §7, D1, D5, D6, D9.
+ *
+ * Spawns a fresh child per invocation (D6 — no warm pool, so cross-tenant state
+ * reuse is not expressible), applies the four resource limits the isolate could
+ * never enforce, and returns a structured result.
+ */
+
+import {
+  decodeFrame,
+  encodeFrame,
+  PROTOCOL_VERSION,
+  type SandboxConsoleLog,
+  type SandboxRequest,
+  type SandboxResponse,
+} from './protocol.ts'
+
+/** Response frame cap. Under `MAX_PAYLOAD_BYTES` (5 MB, index.ts) so §2.4 closes here first. */
+const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+
+/** stderr is for the parent's logs only — never echoed to callers (§7). */
+const MAX_STDERR_BYTES = 64 * 1024
+
+/** V8 fatal abort (OOM). The runner's baked `--max-old-space-size` produces this. */
+const V8_OOM_EXIT_CODE = 133
+
+/**
+ * Concurrent children. Each is a Deno process with a ~30-50 MB baseline plus up
+ * to its 256 MB heap cap, so this is what keeps the container inside its memory
+ * ceiling (§5.1, D14).
+ *
+ * TODO(before Phase B ships): 4 is a DELIBERATELY CONSERVATIVE PLACEHOLDER, not a
+ * measured value. The plan is explicit that this is "the one number that should be
+ * measured before Phase B ships, not after" — size it against the Railway service's
+ * actual memory ceiling and observed peak concurrency. `auxx-infra/config/services.json`
+ * declares no resource limits, so the ceiling is the Railway plan default and has to
+ * come from the dashboard.
+ */
+const DEFAULT_MAX_CONCURRENT = 4
+
+function maxConcurrent(): number {
+  const raw = Deno.env.get('LAMBDA_MAX_CONCURRENT_SANDBOXES')
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_CONCURRENT
+}
+
+/** Why a sandbox run ended. Distinguished so callers can log and surface accurately. */
+export type SandboxFailure =
+  | 'timeout' // wall clock exceeded, child SIGKILLed
+  | 'out_of_memory' // child hit its heap cap and aborted alone
+  | 'output_too_large' // response frame exceeded the cap
+  | 'protocol_error' // child produced no parseable frame
+  | 'user_error' // the user's code threw — an ordinary outcome, not a fault
+  | 'spawn_failed' // the runner binary could not be started
+
+export interface SandboxResult {
+  ok: boolean
+  value?: unknown
+  logs: SandboxConsoleLog[]
+  failure?: SandboxFailure
+  /** Safe to surface. Never contains a stack trace (§7). */
+  message?: string
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+let active = 0
+const waiting: Array<() => void> = []
+
+async function acquire(): Promise<void> {
+  const limit = maxConcurrent()
+  if (active < limit) {
+    active++
+    return
+  }
+  await new Promise<void>((resolve) => waiting.push(resolve))
+  active++
+}
+
+function release(): void {
+  active--
+  const next = waiting.shift()
+  if (next) next()
+}
+
+// ---------------------------------------------------------------------------
+// Runner resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Permissions for the DEV FALLBACK only. In production these are baked into the
+ * compiled runner at build time and are not expressible at spawn (D3) — which is
+ * the point: a flag list on a command line is something a caller could widen.
+ *
+ * `--allow-net` rather than `--deny-net` is deliberate (D13, §6.1).
+ */
+const DEV_RUNNER_FLAGS = [
+  '--deny-env',
+  '--deny-read',
+  '--deny-write',
+  '--deny-ffi',
+  '--deny-run',
+  '--deny-sys',
+  '--allow-net',
+  '--v8-flags=--max-old-space-size=256',
+]
+
+interface RunnerCommand {
+  path: string
+  args: string[]
+}
+
+/** Where Dockerfile.server COPYs the runner, and the target of the parent's --allow-run grant. */
+const DEFAULT_RUNNER_PATH = '/runner'
+
+/**
+ * Locate the runner.
+ *
+ * Production FAILS CLOSED: if no compiled runner is configured we throw rather
+ * than falling back to a flag-configured `deno run`, because the fallback's
+ * permissions live on a command line instead of inside the binary. Silently
+ * degrading the boundary is exactly the failure mode A5 fixed on the auth path.
+ */
+function resolveRunner(): RunnerCommand {
+  const configured = Deno.env.get('LAMBDA_RUNNER_PATH')
+  if (configured) return { path: configured, args: [] }
+
+  // The dev fallback is OPT-IN, and the default is the compiled binary.
+  //
+  // Auto-detecting "am I a compiled binary?" was tried and does not work: inside a
+  // `deno compile` output `import.meta.url` is still a file: URL, so the check
+  // silently inverted and the parent tried to exec ITSELF (`/server`) as the
+  // sandbox. Deno exposes no reliable is-compiled signal, and a misdetection here
+  // fails toward the weaker mode — flags on a command line instead of permissions
+  // baked into a binary (D3). So it is stated explicitly or not used at all.
+  const devRunnerRequested = Deno.env.get('LAMBDA_SANDBOX_DEV_RUNNER') === '1'
+  const isProduction = Deno.env.get('NODE_ENV') === 'production'
+
+  if (devRunnerRequested && !isProduction) {
+    const source = new URL('./runner.ts', import.meta.url)
+    return { path: Deno.execPath(), args: ['run', ...DEV_RUNNER_FLAGS, source.pathname] }
+  }
+
+  return { path: DEFAULT_RUNNER_PATH, args: [] }
+}
+
+// ---------------------------------------------------------------------------
+// Stream reading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a stream up to `limit` bytes. Signals rather than throws on overflow so
+ * the caller can kill the child before it produces more.
+ */
+async function readCapped(
+  stream: ReadableStream<Uint8Array>,
+  limit: number,
+  onOverflow: () => void
+): Promise<{ text: string; overflowed: boolean }> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let size = 0
+  let overflowed = false
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value) continue
+
+      size += value.length
+      if (size > limit) {
+        overflowed = true
+        onOverflow()
+        break
+      }
+      chunks.push(value)
+    }
+  } catch {
+    // Child died mid-stream (kill, OOM). Whatever arrived is what we have.
+  } finally {
+    try {
+      reader.releaseLock()
+    } catch {
+      // already released
+    }
+  }
+
+  const merged = new Uint8Array(chunks.reduce((sum, c) => sum + c.length, 0))
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return { text: new TextDecoder().decode(merged), overflowed }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute untrusted code in a child process.
+ *
+ * Never throws for anything the user's code did — a thrown user error comes back
+ * as `{ ok: false, failure: 'user_error' }`. It throws only if the runner itself
+ * could not be resolved, which is a deployment fault.
+ */
+export async function runInSandbox(
+  request: Omit<SandboxRequest, 'v'>,
+  timeout: number
+): Promise<SandboxResult> {
+  const runner = resolveRunner()
+
+  await acquire()
+
+  let child: Deno.ChildProcess
+  try {
+    child = new Deno.Command(runner.path, {
+      args: runner.args,
+      stdin: 'piped',
+      stdout: 'piped',
+      stderr: 'piped',
+      // D5 — `--deny-env` blocks the `Deno.env` API but leaves variables in the
+      // child's OS process environment, where `/proc/self/environ` and the node
+      // compat layer can still reach them. Both controls are required.
+      clearEnv: true,
+      env: {},
+    }).spawn()
+  } catch (error) {
+    release()
+    return {
+      ok: false,
+      logs: [],
+      failure: 'spawn_failed',
+      message: `sandbox runner could not be started: ${(error as Error)?.message ?? 'unknown'}`,
+    }
+  }
+
+  let failure: SandboxFailure | undefined
+  let killed = false
+
+  const kill = () => {
+    if (killed) return
+    killed = true
+    try {
+      // SIGKILL, not SIGTERM — this is the one thing `Promise.race` could never
+      // do (§2.3): it preempts a synchronous `while(true)` that no timer can
+      // interrupt, because the child has no say in receiving it.
+      child.kill('SIGKILL')
+    } catch {
+      // already exited
+    }
+  }
+
+  const timer = setTimeout(() => {
+    failure = 'timeout'
+    kill()
+  }, timeout)
+
+  // Write and read concurrently. The child drains stdin to EOF before executing,
+  // and awaiting the write first would deadlock against a child that dies early.
+  const writeStdin = (async () => {
+    try {
+      const writer = child.stdin.getWriter()
+      await writer.write(encodeFrame({ v: PROTOCOL_VERSION, ...request }))
+      await writer.close()
+    } catch {
+      // BrokenPipe — the child was killed or exited. The read side reports it.
+    }
+  })()
+
+  const [stdout, stderr, status] = await Promise.all([
+    readCapped(child.stdout, MAX_OUTPUT_BYTES, () => {
+      failure = 'output_too_large'
+      kill()
+    }),
+    readCapped(child.stderr, MAX_STDERR_BYTES, () => {}),
+    child.status,
+  ])
+
+  clearTimeout(timer)
+  await writeStdin
+  release()
+
+  if (stderr.text.trim()) {
+    // Parent-side only. V8 fatal traces name host paths and memory layout, so
+    // this must never reach the response body (§7).
+    console.error('[sandbox] child stderr:', stderr.text.slice(0, 2000))
+  }
+
+  if (failure === 'timeout') {
+    return { ok: false, logs: [], failure, message: `Code execution timeout after ${timeout}ms` }
+  }
+
+  if (failure === 'output_too_large') {
+    return {
+      ok: false,
+      logs: [],
+      failure,
+      message: `Execution result exceeded ${MAX_OUTPUT_BYTES} bytes`,
+    }
+  }
+
+  // The child OOMs alone. This is the measured contrast with a Worker, which
+  // aborts the entire host process on the same input (§4.2, exit 133).
+  if (status.code === V8_OOM_EXIT_CODE || status.signal === 'SIGTRAP') {
+    return {
+      ok: false,
+      logs: [],
+      failure: 'out_of_memory',
+      message: 'Code execution exceeded the memory limit',
+    }
+  }
+
+  const response = decodeFrame<SandboxResponse>(stdout.text.trim())
+  if (!response) {
+    return {
+      ok: false,
+      logs: [],
+      failure: 'protocol_error',
+      message: 'Sandbox produced no result',
+    }
+  }
+
+  if (response.ok) {
+    return { ok: true, value: response.value, logs: response.logs ?? [] }
+  }
+
+  return {
+    ok: false,
+    logs: response.logs ?? [],
+    failure: 'user_error',
+    message: `${response.error.name}: ${response.error.message}`,
+  }
+}


### PR DESCRIPTION
Implements **Phase B steps 1, 2, 4 and 7** of `plans/lambda/security/01-sandbox-hardening-plan.md`.

## The problem

Workflow code nodes executed via `new Function()` in the service's own realm, with the service's own Deno permissions and process environment. `Promise.race` cannot preempt a synchronous loop, and a memory bomb had nothing stopping it.

This is a **baseline member capability**, not an admin one — `MEMBER_BASELINE_LEVELS[Area.workflows] = Level.Full`, and `runSingleNode` is a one-click author→execute loop. That's why it cuts over first.

## What changed

| File | Role |
|---|---|
| `src/sandbox/protocol.ts` | Newline-delimited JSON frames. **Dependency-free on purpose** — the child's module graph is part of its security posture, so it never reaches zod or the AWS SDK (19 KB of source total). |
| `src/sandbox/runner.ts` | The child. Permissions baked in at compile time so they cannot be widened at spawn. No secrets, no credentials, no callback tokens. |
| `src/sandbox/spawn.ts` | Parent side: `SIGKILL` on timeout, 4 MB output cap, concurrency semaphore, `clearEnv: true`, stderr captured but never echoed. |

`new Function` is deleted from `code-executor.ts`. Wrapper generation and `sanitizeForJson` move into the runner, so the `undefined → null` contract is applied on the side of the boundary that produces the value.

Build changes ship the runner in **both** shapes — `Dockerfile.server` and `build.sh`/`bootstrap` — per D15, so the AWS variant can't silently drift to an older permission set. The parent gains exactly one grant: `--allow-run=/runner`, never blanket.

## Verification

Run against the **compiled binaries in the distroless production image**, not only under `deno test`:

| Attempt | Result |
|---|---|
| normal return with `undefined` fields | `{a:1, b:null}` — contract intact |
| `Deno.env.toObject()` / `env.get(secret)` | `NotCapable` |
| `Deno.readTextFileSync` / `writeTextFileSync` | `NotCapable` |
| `new Deno.Command('/bin/sh').outputSync()` | `NotCapable` |
| `import('node:fs').readFileSync` | `NotCapable` — closes the §4.3 bypass that defeated global scrubbing |
| `globalThis.__AUXX_SERVER_CONTEXT__` | `undefined` |
| `while(true){}` | killed at the timeout — **fixes §2.3** |
| memory bomb | child OOMs alone, parent serves the next request |
| `'x'.repeat(50MB)` | 413 `RESPONSE_TOO_LARGE` |

34 tests green across the real test dirs; 18 in `sandbox-mitigation.test.ts`.

## Scope — what this does NOT fix

**The six app-bundle executors and `bundle-cache.ts:66` still compile in-realm** (plan steps 5 and 6). For third-party bundles the original finding stands as written, including callback tokens on `globalThis`. Only the code-node path is behind the boundary.

## Reviewer notes

Three findings worth carrying forward, each of which produced a wrong result first:

1. **`clearEnv: true` leaves the child with no PATH**, so `new Deno.Command('sh', …)` fails with "no path to search" rather than `NotCapable`. That assertion would keep passing with `--allow-run` granted. The test uses an absolute path.
2. **A non-`async` `main()` wrapper** turns `await import('node:fs')` into a `SyntaxError`, failing a denial test for an unrelated reason.
3. **Auto-detecting "am I a compiled binary?" via `import.meta.url` does not work** — it is still a `file:` URL inside a `deno compile` output, so the check inverted and the parent tried to exec *itself* as the sandbox. The dev fallback is now explicit opt-in (`LAMBDA_SANDBOX_DEV_RUNNER=1`, refused when `NODE_ENV=production`); the default is the compiled `/runner`.

A2's `Deno` parameter shadowing is deliberately removed: under real denials it would convert a truthful `NotCapable` into a misleading `TypeError`, hiding the boundary from the tests written to prove it.

## Before this is relied on under load

The concurrency semaphore defaults to **4, a placeholder rather than a measured value**. `auxx-infra/config/services.json` declares no resource limits, so the ceiling is the Railway plan default and needs the dashboard. Override with `LAMBDA_MAX_CONCURRENT_SANDBOXES`.

Separately: `apps/lambda/test/integration.test.ts` imports `src/executor.ts`, which has not existed since #85, so whole-suite `deno test` fails on type-check independently of this PR.
