### PR TITLE
fix(admin): keep trial recovery actions reachable after a trial ends

### DIFF
--- a/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
@@ -44,7 +44,7 @@ function isSubscriptionExpired(subscription: DehydratedOrganization['subscriptio
 /** Helper function to check if trial is expired */
 function isTrialExpired(subscription: DehydratedOrganization['subscription']): boolean {
   if (!subscription) return false
-  return subscription.hasTrialEnded && subscription.status === 'trialing'
+  return subscription.hasTrialEnded && subscription.status.toLowerCase() === 'trialing'
 }
 
 /**

--- a/apps/web/src/app/admin/organizations/[id]/_components/subscription-management-section.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/_components/subscription-management-section.tsx
@@ -416,12 +416,10 @@ export function SubscriptionManagementSection({
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value='active'>Active</SelectItem>
-                      <SelectItem value='ACTIVE'>ACTIVE</SelectItem>
-                      <SelectItem value='canceled'>Canceled</SelectItem>
+                      <SelectItem value='trialing'>Trialing</SelectItem>
                       <SelectItem value='past_due'>Past Due</SelectItem>
                       <SelectItem value='incomplete'>Incomplete</SelectItem>
-                      <SelectItem value='trialing'>Trialing</SelectItem>
-                      <SelectItem value='TRIALING'>TRIALING</SelectItem>
+                      <SelectItem value='canceled'>Canceled</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/apps/web/src/app/admin/organizations/[id]/_components/trial-management-section.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/_components/trial-management-section.tsx
@@ -14,7 +14,7 @@ import { Label } from '@auxx/ui/components/label'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { addDays, format } from 'date-fns'
-import { Calendar, CheckCircle, Clock } from 'lucide-react'
+import { AlertTriangle, Calendar, CheckCircle, Clock } from 'lucide-react'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -127,8 +127,17 @@ export function TrialManagementSection({
     }
   }
 
-  const isOnTrial = subscription?.status === 'trialing' && !subscription?.hasTrialEnded
-  const hasTrialEnded = subscription?.hasTrialEnded
+  // Status is stored lowercase; normalize so a legacy uppercase row still resolves.
+  const status = subscription?.status?.toLowerCase() ?? null
+  const hasTrialEnded = subscription?.hasTrialEnded ?? false
+  const isOnTrial = status === 'trialing' && !hasTrialEnded
+  /**
+   * Trial ended but the subscription never left `trialing` — the state that locks members
+   * out of the app (`isTrialExpired` in app-layout-wrapper). Extend/convert must stay
+   * reachable here, or ending a trial early strands the org with no way back.
+   */
+  const isTrialExpired = status === 'trialing' && hasTrialEnded
+  const canManageTrial = isOnTrial || isTrialExpired
 
   return (
     <>
@@ -149,6 +158,13 @@ export function TrialManagementSection({
                     <>
                       <Clock className='size-4 text-blue-500' />
                       <span className='font-medium text-blue-500'>Active</span>
+                    </>
+                  ) : isTrialExpired ? (
+                    <>
+                      <AlertTriangle className='size-4 text-destructive' />
+                      <span className='font-medium text-destructive'>
+                        Ended — members locked out
+                      </span>
                     </>
                   ) : hasTrialEnded ? (
                     <>
@@ -176,41 +192,45 @@ export function TrialManagementSection({
           </div>
 
           {/* Actions */}
-          {isOnTrial ? (
+          {canManageTrial ? (
             <Accordion type='single' collapsible className='rounded-lg border'>
               {/* End Trial Immediately */}
-              <AccordionItem value='end-trial' className='border-b px-4 last:border-b-0'>
-                <AccordionTrigger>End Trial Immediately</AccordionTrigger>
-                <AccordionContent className='space-y-3'>
-                  <p className='text-sm text-muted-foreground'>
-                    Force trial to end now, requiring organization to upgrade
-                  </p>
-                  <div>
-                    <Label htmlFor='end-reason'>Reason (Optional)</Label>
-                    <Textarea
-                      id='end-reason'
-                      placeholder='Why are you ending this trial early?'
-                      value={reason}
-                      onChange={(e) => setReason(e.target.value)}
-                      rows={2}
-                    />
-                  </div>
-                  <Button
-                    variant='destructive'
-                    size='sm'
-                    onClick={handleEndTrial}
-                    loading={endTrial.isPending}>
-                    End Trial Now
-                  </Button>
-                </AccordionContent>
-              </AccordionItem>
+              {isOnTrial && (
+                <AccordionItem value='end-trial' className='border-b px-4 last:border-b-0'>
+                  <AccordionTrigger>End Trial Immediately</AccordionTrigger>
+                  <AccordionContent className='space-y-3'>
+                    <p className='text-sm text-muted-foreground'>
+                      Force trial to end now, requiring organization to upgrade
+                    </p>
+                    <div>
+                      <Label htmlFor='end-reason'>Reason (Optional)</Label>
+                      <Textarea
+                        id='end-reason'
+                        placeholder='Why are you ending this trial early?'
+                        value={reason}
+                        onChange={(e) => setReason(e.target.value)}
+                        rows={2}
+                      />
+                    </div>
+                    <Button
+                      variant='destructive'
+                      size='sm'
+                      onClick={handleEndTrial}
+                      loading={endTrial.isPending}>
+                      End Trial Now
+                    </Button>
+                  </AccordionContent>
+                </AccordionItem>
+              )}
 
               {/* Extend Trial */}
               <AccordionItem value='extend-trial' className='border-b px-4 last:border-b-0'>
                 <AccordionTrigger>Extend Trial Period</AccordionTrigger>
                 <AccordionContent className='space-y-3'>
                   <p className='text-sm text-muted-foreground'>
-                    Give customer more time to evaluate the product
+                    {isTrialExpired
+                      ? 'Reopen the ended trial — restores access with the trial feature limits'
+                      : 'Give customer more time to evaluate the product'}
                   </p>
                   <div>
                     <Label htmlFor='extend-days'>Extend by (days)</Label>
@@ -250,7 +270,9 @@ export function TrialManagementSection({
                 <AccordionTrigger>Convert Trial to Paid</AccordionTrigger>
                 <AccordionContent className='space-y-3'>
                   <p className='text-sm text-muted-foreground'>
-                    Manually convert trial to paid without payment (admin override)
+                    {isTrialExpired
+                      ? 'Restore access on the full plan without payment (admin override)'
+                      : 'Manually convert trial to paid without payment (admin override)'}
                   </p>
                   <Button
                     variant='outline'

--- a/apps/web/src/app/admin/organizations/[id]/page.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/page.tsx
@@ -663,7 +663,9 @@ export default function OrganizationDetailsPage() {
                               <TableCell className='py-2'>
                                 <Badge
                                   variant={
-                                    org.subscription.status === 'ACTIVE' ? 'default' : 'outline'
+                                    org.subscription.status.toLowerCase() === 'active'
+                                      ? 'default'
+                                      : 'outline'
                                   }
                                   className='uppercase text-xs'>
                                   {org.subscription.status}

--- a/packages/lib/src/cache/__tests__/features-provider.test.ts
+++ b/packages/lib/src/cache/__tests__/features-provider.test.ts
@@ -1,0 +1,107 @@
+// packages/lib/src/cache/__tests__/features-provider.test.ts
+// The features map is derived from PlanSubscription.status. A status the provider does
+// not recognize yields an EMPTY map, which every caller reads as "feature disabled" —
+// so status matching must not be case-sensitive (admin overrides have written uppercase
+// rows), and an ended trial must resolve to no features.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isSelfHosted: vi.fn(() => false),
+  appGetOrRecompute: vi.fn(),
+  orgGetOrRecompute: vi.fn(),
+}))
+
+vi.mock('@auxx/deployment', () => ({ isSelfHosted: h.isSelfHosted }))
+vi.mock('../singletons', () => ({
+  getAppCache: () => ({ getOrRecompute: h.appGetOrRecompute }),
+  getOrgCache: () => ({ getOrRecompute: h.orgGetOrRecompute }),
+}))
+
+import { featuresProvider } from '../providers/features-provider'
+
+const PLAN = {
+  id: 'plan_growth',
+  name: 'Growth',
+  isFree: false,
+  featureLimits: [
+    { key: 'mail', limit: '+' },
+    { key: 'workflows', limit: 5 },
+  ],
+  trialFeatureLimits: [{ key: 'mail', limit: 1 }],
+}
+
+function fakeDb(subscription: Record<string, unknown> | undefined) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve(subscription ? [subscription] : []) }),
+      }),
+    }),
+  } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isSelfHosted.mockReturnValue(false)
+  h.appGetOrRecompute.mockResolvedValue({ planMap: { plan_growth: PLAN } })
+  h.orgGetOrRecompute.mockResolvedValue({ orgProfile: { demoExpiresAt: null } })
+})
+
+describe('featuresProvider.compute — status resolution', () => {
+  it('resolves full plan limits for an active subscription', async () => {
+    const features = await featuresProvider.compute(
+      'org_1',
+      fakeDb({
+        status: 'active',
+        hasTrialEnded: true,
+        planId: 'plan_growth',
+        customFeatureLimits: null,
+      })
+    )
+    expect(features).toMatchObject({ mail: '+', workflows: 5 })
+  })
+
+  // Regression: the admin "Force Status Change" select used to offer an uppercase
+  // ACTIVE row. Storing it cleared the expired screen but matched neither branch here,
+  // leaving the org silently featureless.
+  it('resolves the same limits for a legacy uppercase status', async () => {
+    const features = await featuresProvider.compute(
+      'org_1',
+      fakeDb({
+        status: 'ACTIVE',
+        hasTrialEnded: true,
+        planId: 'plan_growth',
+        customFeatureLimits: null,
+      })
+    )
+    expect(features).toMatchObject({ mail: '+', workflows: 5 })
+  })
+
+  it('resolves trial limits while the trial is running', async () => {
+    const features = await featuresProvider.compute(
+      'org_1',
+      fakeDb({
+        status: 'TRIALING',
+        hasTrialEnded: false,
+        planId: 'plan_growth',
+        customFeatureLimits: null,
+      })
+    )
+    expect(features).toMatchObject({ mail: 1 })
+    expect(features.workflows).toBeUndefined()
+  })
+
+  it('resolves no features for an ended trial that never left trialing', async () => {
+    const features = await featuresProvider.compute(
+      'org_1',
+      fakeDb({
+        status: 'trialing',
+        hasTrialEnded: true,
+        planId: 'plan_growth',
+        customFeatureLimits: null,
+      })
+    )
+    expect(features).toEqual({})
+  })
+})

--- a/packages/lib/src/cache/providers/features-provider.ts
+++ b/packages/lib/src/cache/providers/features-provider.ts
@@ -40,13 +40,23 @@ export const featuresProvider: CacheProvider<FeatureMapObject> = {
 
     if (subscription?.planId) {
       const plan = planMap[subscription.planId]
+      // Status is stored lowercase, but admin overrides have written uppercase rows in the
+      // past. Normalize — an unmatched status silently yields zero features, which reads
+      // as "every feature disabled" rather than as an error.
+      const status = subscription.status?.toLowerCase()
 
       if (!plan) {
         logger.warn('Plan not found in planMap', { orgId, planId: subscription.planId })
-      } else if (subscription.status === 'trialing' && !subscription.hasTrialEnded) {
+      } else if (status === 'trialing' && !subscription.hasTrialEnded) {
         featureDefinitions = parseFeatureLimits(plan.trialFeatureLimits ?? plan.featureLimits)
-      } else if (subscription.status === 'active' || subscription.status === 'past_due') {
+      } else if (status === 'active' || status === 'past_due') {
         featureDefinitions = parseFeatureLimits(plan.featureLimits)
+      } else {
+        logger.warn('Subscription status resolves to no features', {
+          orgId,
+          status: subscription.status,
+          hasTrialEnded: subscription.hasTrialEnded,
+        })
       }
     } else {
       // No subscription — resolve from org type (demo vs free)


### PR DESCRIPTION
## Problem

Hit while trying to restore a test organization that showed as expired.

`endTrialImmediately` sets `hasTrialEnded = true` and leaves `status = 'trialing'`. That pair is exactly what `isTrialExpired` in `app-layout-wrapper.tsx` blocks on, so the org's members get the subscription-ended screen.

The trial panel gated its entire action list on `isOnTrial` (`trialing && !hasTrialEnded`), so pressing **End Trial Now** removed **Extend Trial** and **Convert to Paid** in the same render and replaced them with "Organization is not currently on trial". The button that breaks access also hides the two buttons that restore it, and the only way out was Force Status Change in the neighbouring card.

Second issue found on the way: the Force Status Change select offered both `active`/`ACTIVE` and `trialing`/`TRIALING`. `features-provider` compared status case-sensitively, so storing an uppercase value cleared the expired screen but matched neither branch, resolving to an empty feature map. The org came back "working" with every feature silently disabled.

## Changes

- `trial-management-section.tsx` — extend and convert stay available while the subscription is still `trialing`, ended or not; only End Trial hides once the trial has ended. Status readout shows "Ended — members locked out" for the locked state instead of a green "Ended". Status compared case-insensitively.
- `subscription-management-section.tsx` — dropped the uppercase `ACTIVE` / `TRIALING` options.
- `features-provider.ts` — normalizes status case before matching, and warns when a status resolves to no features instead of failing silently.
- `app-layout-wrapper.tsx`, admin org `page.tsx` — same case normalization on the two status comparisons that were exact-match.

## Tests

New `features-provider.test.ts` covers active, legacy uppercase `ACTIVE`, running trial, and the ended-trial-still-trialing case (which correctly resolves to no features). 4 passing.

`tsc --noEmit` on apps/web reports nothing for the touched files.

## Note

Existing rows written by the uppercase options keep working now that the provider normalizes, but they are still non-canonical. Worth a one-off `UPDATE "PlanSubscription" SET status = lower(status)` if any exist in prod.