### PR TITLE
fix(homepage): repair mobile layout in the agents sections

### DIFF
--- a/apps/homepage/src/app/_components/main/header.tsx
+++ b/apps/homepage/src/app/_components/main/header.tsx
@@ -289,14 +289,26 @@ export default function Header() {
         <div className='mask-b-from-35% absolute inset-x-0 -bottom-12 top-0 backdrop-blur max-lg:hidden'></div>
         <div className='bg-background/75 mask-b-from-35% absolute inset-x-0 -bottom-12 top-0 backdrop-blur max-lg:hidden'></div>
       </div>
+      {/*
+       * This box clips (`overflow-hidden`, so the menu opens out of a closed
+       * height instead of overlaying the page), so its height has to clear the
+       * bar inside it plus room for the bar's shadow. `pt-2` + a 14 tall row
+       * puts the bar's bottom edge at 66px; `h-18` left 6px, which cut into the
+       * shadow, and the old `pb-4` pushed the bar itself to 82px so the clip
+       * landed inside its own `rounded-2xl` and squared off the bottom corners.
+       */}
       <div
         className={cn(
-          'max-lg:in-data-[state=active]:bg-background/75 max-lg:in-data-[state=active]:h-screen max-lg:in-data-[state=active]:backdrop-blur max-lg:h-18 fixed inset-x-0 top-0 z-50 pt-2 max-lg:overflow-hidden max-lg:px-2 lg:pt-3'
+          'max-lg:in-data-[state=active]:bg-background/75 max-lg:in-data-[state=active]:h-screen max-lg:in-data-[state=active]:backdrop-blur max-lg:h-20 fixed inset-x-0 top-0 z-50 pt-2 max-lg:overflow-hidden max-lg:px-2 lg:pt-3'
         )}>
         <div
           className={cn(
-            'in-data-scrolled:ring-foreground/5 in-data-scrolled:bg-background/75 in-data-scrolled:shadow-black/10 in-data-scrolled:max-w-4xl max-lg:in-data-scrolled:px-5 in-data-scrolled:backdrop-blur mx-auto w-full max-w-6xl rounded-2xl border border-transparent px-3 shadow-md shadow-transparent ring-1 ring-transparent transition-[max-width,padding,background-color,box-shadow,backdrop-filter] duration-500 ease-in-out max-lg:pb-4',
-            'max-lg:in-data-[state=active]:backdrop-blur max-lg:in-data-[state=active]:ring-foreground/5 max-lg:in-data-[state=active]:bg-background/75 max-lg:in-data-[state=active]:px-5 max-lg:in-data-[state=active]:shadow-black/10'
+            'in-data-scrolled:ring-foreground/5 in-data-scrolled:bg-background/75 in-data-scrolled:shadow-black/10 in-data-scrolled:max-w-4xl max-lg:in-data-scrolled:px-5 in-data-scrolled:backdrop-blur mx-auto w-full max-w-6xl rounded-2xl border border-transparent px-3 shadow-md shadow-transparent ring-1 ring-transparent transition-[max-width,padding,background-color,box-shadow,backdrop-filter] duration-500 ease-in-out',
+            // The bottom padding belongs to the open menu, which ends on a
+            // button that would otherwise sit on the bar's edge. Closed, it was
+            // 16px of dead space under a row that already sets its own height —
+            // it made the bar bottom-heavy and hung it past the clip above.
+            'max-lg:in-data-[state=active]:pb-4 max-lg:in-data-[state=active]:backdrop-blur max-lg:in-data-[state=active]:ring-foreground/5 max-lg:in-data-[state=active]:bg-background/75 max-lg:in-data-[state=active]:px-5 max-lg:in-data-[state=active]:shadow-black/10'
           )}>
           <div className='relative flex flex-wrap items-center justify-between lg:py-3'>
             <div className='max-lg:in-data-[state=active]:border-b flex items-center justify-between gap-8 max-lg:h-14 max-lg:w-full'>

--- a/apps/homepage/src/app/platform/ai/agents/_components/agent-run-illustration.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/agent-run-illustration.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import Link from 'next/link'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   MockAssistantSlot,
   MockToolStatusPill,
@@ -29,12 +29,20 @@ import { AgentPortrait } from './agent-portrait'
 import { AGENT_SCRIPTS, type AgentScript, type RunEntry } from './agent-scripts'
 
 /**
- * Fixed height for both columns, so opening a procedure never moves the page
- * below. Measured max content across the four agents is ~600px; the extra
- * headroom keeps the tallest state off the boundary, and the panel's own list
- * scrolls rather than clipping if copy ever grows past it.
+ * Fixed heights, so revealing an entry or opening a procedure never moves the
+ * page below. Side by side the two columns share one box; stacked they need one
+ * each, and a phone-width column wraps far more, so its box is taller.
+ *
+ * The stacked pins are deliberately under the tallest agent rather than over
+ * it: measured at 314px — what a 390px viewport leaves inside the section's
+ * rails — the four scripts span 79–570px of run and 445–710px of panel, so
+ * pinning to the maximum left the short agents as a half-empty box. Both lists
+ * scroll instead, and both keep the part that matters in view: the run sticks
+ * to its newest entry, the panel to its active line.
  */
-const COLUMN_H = 'min-h-[640px] lg:h-[640px]'
+const GRID_H = 'lg:h-[640px]'
+const RUN_H = 'h-[420px] lg:h-full'
+const PANEL_H = 'h-[560px] lg:h-full'
 
 /** Default per-entry dwell. Individual entries can override it. */
 const STEP_MS = 950
@@ -253,6 +261,44 @@ function RunColumn({
   revealed: number
   reduceMotion: boolean | null
 }) {
+  const listRef = useRef<HTMLDivElement>(null)
+
+  /**
+   * Keep the newest entry in view, the way a chat does. A no-op while the run
+   * fits its box — it earns its keep on a phone, where the pinned height is
+   * under the longest script and the terminal entry (the payoff) would
+   * otherwise sit below the fold.
+   *
+   * Observing the content rather than reacting to `revealed`: an entry's
+   * `layout` animation keeps growing the list for ~280ms after the render that
+   * added it, so a scroll issued on the state change lands short. Scrolling
+   * this box never moves the page, unlike `scrollIntoView`. Scrolling up
+   * releases the pin, so reading back through a run isn't fought.
+   */
+  useEffect(() => {
+    const el = listRef.current
+    const content = el?.firstElementChild
+    if (!el || !content) return
+
+    let pinned = true
+    const stick = () => {
+      if (pinned) el.scrollTop = el.scrollHeight
+    }
+    const release = () => {
+      pinned = el.scrollHeight - el.clientHeight - el.scrollTop < 24
+    }
+
+    const observer = new ResizeObserver(stick)
+    observer.observe(content)
+    el.addEventListener('scroll', release, { passive: true })
+    stick()
+
+    return () => {
+      observer.disconnect()
+      el.removeEventListener('scroll', release)
+    }
+  }, [])
+
   return (
     <div className='flex h-full min-h-0 flex-col overflow-hidden rounded-lg border bg-zinc-200/30 dark:bg-white/[0.03]'>
       <div className='flex items-center justify-between px-3 pt-1 pb-2'>
@@ -263,20 +309,31 @@ function RunColumn({
         </span>
       </div>
 
-      <div className='flex flex-1 flex-col items-start gap-1.5 p-3'>
-        <AnimatePresence initial={false}>
-          {script.run.slice(0, revealed).map((entry, i) => (
-            <motion.div
-              key={`${script.agentId}-${i}`}
-              layout={!reduceMotion}
-              initial={reduceMotion ? false : { opacity: 0, y: 6, filter: 'blur(4px)' }}
-              animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
-              transition={{ duration: 0.28 }}
-              className='w-full'>
-              <RunRow entry={entry} agent={agent} />
-            </motion.div>
-          ))}
-        </AnimatePresence>
+      <div ref={listRef} className='flex min-h-0 flex-1 flex-col overflow-y-auto p-3'>
+        {/* Stacked, the box is shorter than the longest script, so a short run
+            settles at the bottom the way a chat does and the headroom above it
+            reads as an empty transcript rather than a half-filled card. Side by
+            side the box is tuned to hold every script, so entries stay top-
+            aligned with the persona card opposite them.
+
+            `mt-auto` rather than `justify-end`: once the run outgrows the box
+            the margin collapses to zero and the top entries stay reachable,
+            where `justify-end` would push them out of the scrollable area. */}
+        <div className='mt-auto flex w-full flex-col items-start gap-1.5 lg:mt-0'>
+          <AnimatePresence initial={false}>
+            {script.run.slice(0, revealed).map((entry, i) => (
+              <motion.div
+                key={`${script.agentId}-${i}`}
+                layout={!reduceMotion}
+                initial={reduceMotion ? false : { opacity: 0, y: 6, filter: 'blur(4px)' }}
+                animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+                transition={{ duration: 0.28 }}
+                className='w-full'>
+                <RunRow entry={entry} agent={agent} />
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
       </div>
     </div>
   )
@@ -359,13 +416,20 @@ export default function AgentRunIllustration() {
       <AgentChips activeIndex={agentIndex} onSelect={selectAgent} />
 
       {/*
-       * Both columns are pinned to `COLUMN_H`. Without it the grid's height is
-       * driven by whichever column is taller, and that swings ~180px every time
-       * a procedure opens or collapses — which is what made the page below jump
+       * Both columns are pinned. Without it the grid's height is driven by
+       * whichever column is taller, and that swings ~180px every time a
+       * procedure opens or collapses — which is what made the page below jump
        * when you clicked a chip (a click resets to step 0, closing the
        * procedure, and it then reopens a beat later).
+       *
+       * `min-w-0` on both: a grid item's automatic minimum is its min-content
+       * width, and the procedure rows' `truncate` summaries are a single
+       * unbreakable line ~480px wide. Stacked, that is the *only* column, so it
+       * sized the track to 480px inside a 314px viewport and the run bubbles,
+       * persona and procedure prose all ran off the right edge with no
+       * horizontal scroll to recover them.
        */}
-      <div className={cn('mt-6 grid gap-4 lg:grid-cols-2', COLUMN_H)}>
+      <div className={cn('mt-6 grid gap-4 lg:grid-cols-2', GRID_H)}>
         <MockAgentPanel
           agent={agent}
           persona={script.persona}
@@ -376,11 +440,11 @@ export default function AgentRunIllustration() {
           activeLine={activeLine}
           onSelectLine={scrubToLine}
           reduceMotion={reduceMotion}
-          className='order-2 lg:order-1'
+          className={cn('order-2 min-w-0 lg:order-1', PANEL_H)}
         />
 
         {/* Run first on a phone: it is the payoff, the document is context. */}
-        <div className='order-1 min-h-0 lg:order-2'>
+        <div className={cn('order-1 min-h-0 min-w-0 lg:order-2', RUN_H)}>
           <RunColumn
             script={script}
             agent={agent}

--- a/apps/homepage/src/app/platform/ai/agents/_components/eval-loop-illustration.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_components/eval-loop-illustration.tsx
@@ -135,7 +135,10 @@ function CaseRow({
         ))}
       </span>
 
-      <span className='flex w-[150px] shrink-0 items-center'>
+      {/* `h-5` is the resolved chip's height. Stacked on a phone the row is a
+          column, so without it the row grew as each case resolved and swapped a
+          6px pending bar for the chip — five separate nudges per loop. */}
+      <span className='flex h-5 w-[150px] shrink-0 items-center'>
         <AnimatePresence mode='wait' initial={false}>
           {resolved ? (
             <motion.span
@@ -189,14 +192,29 @@ function DiffHeader({ visible }: { visible: boolean }) {
   )
 }
 
-function KopilotCard({ reduceMotion }: { reduceMotion: boolean | null }) {
+/**
+ * Stays mounted and fades, rather than entering and leaving. Mounting it added
+ * its whole height to the board mid-loop; animating a permanent element gets
+ * the same motion out of a slot whose size never changes. The stagger still
+ * replays on every pass, because the chips animate toward a target that flips
+ * with `active`.
+ */
+function KopilotCard({ active, reduceMotion }: { active: boolean; reduceMotion: boolean | null }) {
   return (
     <motion.div
-      initial={reduceMotion ? false : { opacity: 0, y: 12, filter: 'blur(6px)' }}
-      animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
-      exit={reduceMotion ? undefined : { opacity: 0, y: -8, filter: 'blur(6px)' }}
+      aria-hidden={!active}
+      initial={false}
+      animate={
+        reduceMotion
+          ? { opacity: active ? 1 : 0 }
+          : {
+              opacity: active ? 1 : 0,
+              y: active ? 0 : 12,
+              filter: active ? 'blur(0px)' : 'blur(6px)',
+            }
+      }
       transition={{ duration: 0.35 }}
-      className='m-3 rounded-xl border bg-muted/40 p-3'>
+      className='col-start-1 row-start-1 m-3 self-start rounded-xl border bg-muted/40 p-3'>
       <div className='flex items-center gap-1.5 text-xs font-medium text-foreground'>
         <Sparkles className='size-3.5 text-amber-500' />
         Kopilot
@@ -206,9 +224,9 @@ function KopilotCard({ reduceMotion }: { reduceMotion: boolean | null }) {
         {KOPILOT_FIX.tools.map((toolName, i) => (
           <motion.span
             key={toolName}
-            initial={reduceMotion ? false : { opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ delay: reduceMotion ? 0 : 0.5 + i * 0.4, duration: 0.25 }}
+            initial={false}
+            animate={{ opacity: active ? 1 : 0, scale: active ? 1 : 0.9 }}
+            transition={{ delay: reduceMotion || !active ? 0 : 0.5 + i * 0.4, duration: 0.25 }}
             className='inline-flex items-center gap-1 rounded-md border bg-card px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground'>
             <Check className='size-2.5 text-emerald-500' />
             {toolName}
@@ -226,12 +244,18 @@ function KopilotCard({ reduceMotion }: { reduceMotion: boolean | null }) {
  *
  * The `Run 12 / Run 13` tabs are the point of making this interactive rather
  * than a looping video: they let you hold the before and after side by side.
- * The board height is fixed across all three states so the page does not jump.
+ *
+ * Nothing in the board mounts or unmounts across the three phases — the two
+ * footers share a grid cell and the status cell is a fixed height — so its
+ * height is the same in every phase and the page below never moves. The
+ * `min-h` is only a floor for the short desktop state, not what holds the
+ * layout still.
  */
 export default function EvalLoopIllustration() {
   const { phase, resolved, reduceMotion, scrubTo, pause, resume } = useSuitePlayback()
   const agent = agentById('refund')
   const showingAfter = phase === 'after'
+  const showNote = phase === 'before' && resolved === EVAL_CASES.length
 
   return (
     <div onMouseEnter={pause} onMouseLeave={resume} className='mx-auto w-full max-w-3xl text-left'>
@@ -283,16 +307,27 @@ export default function EvalLoopIllustration() {
           ))}
         </div>
 
-        <AnimatePresence mode='wait'>
-          {phase === 'fix' && <KopilotCard key='fix' reduceMotion={reduceMotion} />}
-        </AnimatePresence>
+        {/*
+         * One slot for both phase footers, stacked in the same grid cell and
+         * crossfaded — the same trick `DiffHeader` uses. The cell is as tall as
+         * the taller of the two at whatever width it lands on, so the board
+         * measures the same in all three phases without pinning a height that
+         * would have to be re-measured per breakpoint. `self-start` keeps each
+         * at its natural height instead of stretching to the cell.
+         */}
+        <div className='grid grid-cols-1 grid-rows-1'>
+          <KopilotCard active={phase === 'fix'} reduceMotion={reduceMotion} />
 
-        {phase === 'before' && resolved === EVAL_CASES.length && (
-          <p className='m-3 rounded-lg bg-amber-500/[0.07] px-3 py-2 text-[11px] italic text-muted-foreground'>
+          <p
+            aria-hidden={!showNote}
+            className={cn(
+              'col-start-1 row-start-1 m-3 self-start rounded-lg bg-amber-500/[0.07] px-3 py-2 text-[11px] italic text-muted-foreground transition-opacity duration-300',
+              showNote ? 'opacity-100' : 'opacity-0'
+            )}>
             The last one didn&apos;t fail, it errored: a tool call had no stub, so the run
             couldn&apos;t finish. Nothing passes on a technicality here.
           </p>
-        )}
+        </div>
       </div>
     </div>
   )

--- a/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-panel.tsx
+++ b/apps/homepage/src/app/platform/ai/agents/_mocks/mock-agent-panel.tsx
@@ -14,6 +14,7 @@ import {
   Workflow,
 } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
+import { useEffect, useRef } from 'react'
 import { cn } from '~/lib/utils'
 import type { AgentCastMember } from '../_components/agent-cast'
 import type { ProcedureLine, ProcedureLink, Segment } from '../_components/agent-scripts'
@@ -159,6 +160,7 @@ function Line({
   return (
     <button
       type='button'
+      data-active-line={active || undefined}
       onClick={() => onSelect(line.id)}
       className={cn(
         'relative flex w-full gap-2 rounded-md py-0.5 pr-2 text-left transition-colors',
@@ -271,6 +273,27 @@ export function MockAgentPanel({
   className?: string
 }) {
   const opened = procedures.find((p) => p.id === openedId)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  /**
+   * Follow the run: keep the highlighted line inside the procedures list. On a
+   * phone the panel is short enough that an opened procedure can run past the
+   * box, and a document that doesn't move while its own run steps through it is
+   * the one thing this illustration can't afford. Nudging `scrollTop` by the
+   * rect delta keeps the scrolling inside this box — `scrollIntoView` would
+   * walk up to the page scroller and yank the section around.
+   */
+  useEffect(() => {
+    if (!activeLine) return
+    const box = listRef.current
+    const line = box?.querySelector<HTMLElement>('[data-active-line]')
+    if (!box || !line) return
+
+    const boxRect = box.getBoundingClientRect()
+    const lineRect = line.getBoundingClientRect()
+    if (lineRect.top < boxRect.top) box.scrollTop -= boxRect.top - lineRect.top + 8
+    else if (lineRect.bottom > boxRect.bottom) box.scrollTop += lineRect.bottom - boxRect.bottom + 8
+  }, [activeLine])
 
   return (
     // `min-h-0` + a scrollable list below: the panel absorbs the procedure
@@ -295,7 +318,7 @@ export function MockAgentPanel({
             box clips on all four sides at its padding edge. The rows' `ring-1`
             paints outside their border box, so without the pad the ring loses
             its left/right edges and the first and last row lose theirs. */}
-        <div className='flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-px'>
+        <div ref={listRef} className='flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-px'>
           {procedures.map((link) => {
             const isOpen = link.id === openedId
             const isCandidate = openedId == null


### PR DESCRIPTION
Three unrelated mobile defects on `platform/ai/agents`. Two of these sections also run on the main homepage.

## 1. `AgentRunIllustration` was clipped on mobile

`ProcedureRow`'s `whenToUse` summary uses `truncate` — `white-space: nowrap` — and nowrap text still contributes its **full** width as min-content. That propagates up to the grid items, whose automatic minimum is their min-content width. Side by side it's harmless; stacked, that item is the only column, so the track sized to **481px inside a 314px viewport**. Everything past 314px — the chat bubbles, persona, procedure prose — was cut off, with no horizontal scroll to recover it since the page's scroll container clips overflow-x.

`min-w-0` on both grid items is the fix. Note `ProcedureRow`'s existing inner `min-w-0` does *not* help: it removes the automatic minimum for flexing, not the min-content contribution that propagates.

## 2. The same illustration moved the page while it played

`min-h-[640px]` was a floor on the **pair**, so on a phone it never bound and the columns still grew ~400px per pass. Both columns are now pinned per breakpoint, deliberately *under* the tallest agent rather than over it — measured at 314px the four scripts span 79–570px of run and 445–710px of panel, so pinning to the maximum left the short agents as a half-empty box.

The lists scroll instead, and each keeps the part that matters in view:

- the run sticks to its newest entry (ResizeObserver, not a `revealed` effect — an entry's `layout` animation keeps growing the list ~280ms after the render that added it, so a scroll issued on the state change lands ~30px short; scrolling up releases the pin)
- the panel scrolls its active line into view, so the document still follows its own run

Both nudge `scrollTop` on their own box, so neither can yank the page the way `scrollIntoView` would. Stacked, the run is bottom-anchored (`mt-auto`, not `justify-end`, so the top entries stay reachable once it overflows) and reads as a chat; `lg:mt-0` keeps desktop top-aligned as before.

## 3. `EvalLoopIllustration` shifted the page every few seconds

Three things changed size mid-loop: the Kopilot card (~200px) and the "it errored" note (~66px) mounted and unmounted per phase, and the status cell swapped a 6px pending bar for a ~20px chip — absorbed on desktop's `sm:flex-row`, but the stacked mobile row is a column, so each of the five cases nudged the board as it resolved. `min-h-[440px]` is only a floor and mobile content runs to ~820px, so nothing held it still.

The two footers now share one grid cell (`col-start-1 row-start-1` + `self-start`) and crossfade — the same trick `DiffHeader` already used. The slot is as tall as the taller of them at whatever width it lands on, which keeps the height constant **without** a hardcoded number that would need re-measuring per breakpoint. The status cell gets a fixed `h-5`.

## 4. Header bar lost its bottom corners on mobile

`max-lg:pb-4` belongs to the open menu, which ends on a button that would otherwise sit on the bar's edge. Closed, it was 16px of dead space under a row that already sets its own `h-14`, pushing the bar to 82px inside a 72px `overflow-hidden` box — so the clip landed *inside* its own `rounded-2xl`. The padding is now scoped to `in-data-[state=active]` and the box is `h-20`, which clears the corners and the shadow (`h-18` left 6px and sheared the shadow).

| | before | after |
|---|---|---|
| bar height | 74px (row 56 + pb 16) | 58px (row 56 + borders) |
| space above / below row | 1px / 17px | 1px / 1px |
| clearance for radius + shadow | −10px | 14px |

## Verification

Driven in a real browser at 390 / 768 / 1440.

- Agent run: grid width 314 = container width at 390, no overflow; all four agents fit their pinned heights with the active procedure line visible in every case where one exists; desktop unchanged at 640 with zero internal overflow.
- Eval loop: board height sampled 120× across a full loop spanning all three phases — one distinct value at each width (819px at 390, 440px at 1440).
- Header: corners and shadow render on the collapsed bar and the open menu; desktop untouched (both classes are `max-lg:`).
- Biome clean on all four files; `tsc --noEmit` clean for `apps/homepage`.

## Trade-off worth a look

Reserving the eval footer slot means the `after` phase, which has no footer, shows ~220px of empty board on mobile. That's inherent to removing the shift — the space has to be held by something — and it matches what `min-h-[440px]` already does on desktop. A one-line summary in the `after` phase would use it, but that's new copy so I left it alone.

## Pre-existing, not touched

Opening the mobile menu and then widening past `lg` leaves the mobile menu rendered over the desktop layout — `MobileMenu` renders on `isMobileMenuOpen` alone, with no breakpoint guard.