### PR TITLE
fix(ci): unbreak main typecheck, lint and api tests

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,7 +1,7 @@
 // apps/api/vitest.config.ts
 
-import path from 'path'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   test: {
@@ -16,10 +16,11 @@ export default defineConfig({
   },
 
   resolve: {
-    alias: {
-      '@auxx/config': path.resolve(__dirname, '../../packages/config/src'),
-      '@auxx/credentials': path.resolve(__dirname, '../../packages/credentials/src'),
-      '@auxx/logger': path.resolve(__dirname, '../../packages/logger/src'),
-    },
+    // The shared map, not a bespoke subset. The three-entry version that used to
+    // live here omitted `@auxx/database`, so it resolved through the package.json
+    // `import` condition to `dist/` — present on a laptop, absent on a fresh
+    // checkout, where `deployments.test.ts` died with "Failed to resolve entry for
+    // package @auxx/database" before any assertion ran.
+    alias: auxxSourceAlias,
   },
 })

--- a/packages/lib/src/cache/__tests__/features-provider.test.ts
+++ b/packages/lib/src/cache/__tests__/features-provider.test.ts
@@ -88,8 +88,10 @@ describe('featuresProvider.compute — status resolution', () => {
         customFeatureLimits: null,
       })
     )
-    expect(features).toMatchObject({ mail: 1 })
-    expect(features.workflows).toBeUndefined()
+    // Exact, not toMatchObject: the point of the trial branch is that `workflows` is
+    // ABSENT, and a partial match cannot assert absence. `FeatureMapObject` is nullable,
+    // so dereferencing `features.workflows` to check that does not typecheck either.
+    expect(features).toEqual({ mail: 1 })
   })
 
   it('resolves no features for an ended trial that never left trialing', async () => {

--- a/packages/lib/src/workflow-engine/testing/workflow-test-runner.ts
+++ b/packages/lib/src/workflow-engine/testing/workflow-test-runner.ts
@@ -338,6 +338,13 @@ export class WorkflowTestRunner {
       integrationId: 'test-integration',
       isInbound: true,
       machineMailTier: null,
+      // Bulk-mail identity, derived at ingest. All null here: a workflow test message is
+      // ordinary human mail, and `senderAuthenticated: null` is the correct default —
+      // unknown reads as NOT authenticated.
+      listId: null,
+      senderDomain: null,
+      unsubscribeMeta: null,
+      senderAuthenticated: null,
       isFirstInThread: true,
       subject: 'Test Subject',
       textHtml: '<p>Test message body</p>',

--- a/scripts/ci/check-package-exports.js
+++ b/scripts/ci/check-package-exports.js
@@ -16,6 +16,16 @@ const SKIP_PACKAGES = new Set(['lib', 'sdk', 'typescript-config', 'ui', 'seed', 
 // Disallowed deep import patterns (checked across all consumer files)
 const DISALLOWED_IMPORTS = [/@auxx\/database\/schema\//, /@auxx\/database\/db\//]
 
+// The one legitimate reason to reach past the exports map: a test that needs the REAL
+// Drizzle tables. `src/test/setup.ts` mocks `@auxx/database` with a Proxy handing back
+// `{}` per table, so column-level introspection is impossible through it — and
+// `vi.importActual('@auxx/database')` is not an option either, because the package index
+// evaluates `db/client`, whose top-level `createDatabase()` opens a `pg.Pool` at import.
+// The schema barrel is pure table declarations. Narrow on purpose: test files only, and
+// only through `importActual` — production code bypassing the exports map still errors.
+const DEEP_IMPORT_EXEMPT_FILE = /\.(test|spec)\.tsx?$/
+const DEEP_IMPORT_EXEMPT_LINE = /\bvi\.importActual\b/
+
 // @auxx/* packages that are NOT published to npm. If any of these appear inside
 // a published package's dist/, the customer install will 404. Add a new entry
 // here when a new private @auxx/* package gets created.
@@ -135,7 +145,9 @@ async function checkDisallowedImports() {
         for (const file of files) {
           const content = await readFile(file, 'utf-8')
           const lines = content.split('\n')
+          const isTestFile = DEEP_IMPORT_EXEMPT_FILE.test(file)
           for (const line of lines) {
+            if (isTestFile && DEEP_IMPORT_EXEMPT_LINE.test(line)) continue
             if (line.match(pattern) && !line.trimStart().startsWith('//')) {
               const relFile = file.replace(ROOT + '/', '')
               console.error(`ERROR: Disallowed deep import in ${relFile}: ${line.trim()}`)


### PR DESCRIPTION
`main` is red on **Lint** and **Typecheck (lib)**, and the **Test** job has a latent cold-checkout failure. Four independent breakages, none of them introduced by the same PR.

## Typecheck (lib) — 2 new error locations over baseline

**`workflow-engine/testing/workflow-test-runner.ts`** — the `ProcessedMessage` fixture predates the bulk-mail columns added by #1510, so it no longer satisfies the type:

```
TS2739: missing listId, senderAuthenticated, senderDomain, unsubscribeMeta
```

All four are added as `null`. A workflow test message is ordinary human mail, and `null` is the *correct* default for `senderAuthenticated` — per the schema's own invariant, unknown reads as **not** authenticated.

**`cache/__tests__/features-provider.test.ts`** — dereferenced `features.workflows`, which doesn't typecheck against `FeatureMapObject = Record<string, FeatureLimit> | null` (TS18047). Replaced the `toMatchObject` + deref pair with a single exact assertion:

```ts
expect(features).toEqual({ mail: 1 })
```

This is strictly stronger, not a workaround. The trial branch's whole point is that `workflows` is **absent**, and `toMatchObject` cannot assert absence — the old two-line version only checked it after a partial match that would have tolerated extra keys.

Ratchet after: `lib: no new type errors (29 total, baseline 29)`. No baseline was re-recorded.

## Lint — export validator

Flagged `resources/registry/display-config.test.ts` for `vi.importActual('@auxx/database/db/schema')`.

That import is deliberate and the file documents why: the shared `src/test/setup.ts` mocks `@auxx/database` with a Proxy handing back `{}` for every table, so column-level introspection is impossible through it — and `importActual` on the *package index* would evaluate `db/client`, whose top-level `createDatabase()` opens a `pg.Pool` at import. The schema barrel is pure table declarations.

The rule exists to stop **runtime** code bypassing the exports map, so the exemption is narrowed to exactly that case — test files only, and only via `importActual`. Production code deep-importing `@auxx/database/db/` still errors.

## Test — `apps/api` cold-checkout resolution

`apps/api/vitest.config.ts` carried a hand-rolled three-entry alias map (`config`, `credentials`, `logger`) that omitted `@auxx/database`. It therefore resolved through the package.json `import` condition to `dist/index.mjs` — present on a laptop, absent on a fresh CI checkout:

```
Failed to resolve entry for package "@auxx/database".
 ❯ src/routes/__tests__/deployments.test.ts:3:1
```

Replaced with the shared `auxxSourceAlias`, which exists for precisely this failure and whose header already warns that partial hand-rolled copies are what cost a red `main` on 2026-07-30. This is the same class of bug, in the one config that hadn't been converted.

## Verification

Everything run locally on the branch:

- `node scripts/ci/typecheck-ratchet.js --package lib` → `no new type errors (29 total, baseline 29)`
- `node scripts/ci/check-package-exports.js` → `All package exports validated successfully.`
- `pnpm lint` (repo-wide, errors only) → `Checked 9807 files. No fixes applied.`
- `vitest run --project api` → 4 files / 24 tests passed
- `vitest run --project lib packages/lib/src/workflow-engine` → 27 files / 446 tests passed
- `vitest run` on both touched lib test files → 16 tests passed

## Not addressed here

- `packages/workflow-nodes/vitest.config.ts` aliases `@auxx/database` to the package **root** rather than `src`, which is the same latent cold-checkout landmine. It passes in CI today, so it's left out to keep this diff scoped to the actual breakage.
- The `web` Docker job's `ResourceExhausted: cannot allocate memory` is a runner sizing issue, not a code fix.