### PR TITLE
fix(mail): unsubscribe terminal status, inbox read authority, personal-filter 404s

### DIFF
--- a/apps/web/src/components/mail-suggestions/hooks/use-mail-suggestion-actions.ts
+++ b/apps/web/src/components/mail-suggestions/hooks/use-mail-suggestion-actions.ts
@@ -90,6 +90,13 @@ export function useMailSuggestionActions(
    *
    * The count is a LOWER BOUND (the preview evaluates under the caller's own
    * viewer while the engine fires as SYSTEM), so the copy says "at least".
+   *
+   * ⚠️ **The two numbers on screen measure different things** (v2 plan §4.5).
+   * The card's evidence line is a SAMPLE — the last `evidence.windowDays` days of
+   * mail, which is all the miner looked at — while this count is every
+   * conversation in the mailbox, however old. "68 emails in 90 days" above
+   * "matches 408 conversations" is both-correct and reads as a bug, so the prompt
+   * names the window rather than leaving the user to reconcile it.
    */
   const acceptFilter = async (): Promise<boolean> => {
     const created = await accept.mutateAsync({ suggestionId: suggestion.id })
@@ -98,9 +105,10 @@ export function useMailSuggestionActions(
       const confirmed = await confirm({
         title: 'Apply this to existing mail?',
         description:
-          `This matches at least ${count} conversation${created.matchCount === 1 ? '' : 's'} ` +
-          'already in this mailbox. Applying runs in the background and every change can be ' +
-          'reversed from the conversation it changed.',
+          `This matches at least ${count} conversation${created.matchCount === 1 ? '' : 's'} in ` +
+          `this mailbox, going back further than the ${suggestion.evidence.windowDays}-day ` +
+          'sample the suggestion was based on. Applying runs in the background and every change ' +
+          'can be reversed from the conversation it changed.',
         confirmText: 'Apply now',
         cancelText: 'Only new mail',
       })
@@ -147,6 +155,19 @@ export function useMailSuggestionActions(
         // block-sender alternative and the filter half is still worth doing.
         if (outcome.status === 'refused') {
           setRefusal(outcome.refusal.message)
+        } else if (outcome.status === 'failed') {
+          // The sender's one-click endpoint REFUSED us (500 / 403 / 410 are all
+          // real answers). Say so — reporting it as done is the defect this
+          // replaces. We deliberately do NOT fall back to opening the URL: a
+          // one-click POST endpoint is not necessarily a browsable confirmation
+          // page, which is why tier 2 exists as its own tier. The row is left
+          // `failed`, so the card re-offers and a second click really retries.
+          toastError({
+            title: 'The sender rejected the unsubscribe',
+            description:
+              'Their unsubscribe endpoint refused the request. You can try again, or block the ' +
+              'sender instead.',
+          })
         } else if (outcome.status === 'requested' && outcome.openUrl) {
           // The `http` tier: we never POST that URL, the user opens it. A blocked
           // popup becomes a link on the card rather than nothing at all.

--- a/apps/web/src/components/mail-suggestions/ui/mail-suggestion-content.test.ts
+++ b/apps/web/src/components/mail-suggestions/ui/mail-suggestion-content.test.ts
@@ -1,0 +1,124 @@
+// apps/web/src/components/mail-suggestions/ui/mail-suggestion-content.test.ts
+// The card's refusal explanation is the SERVER's refusal, not a paraphrase of it
+// (v2 plan §4.1 / V13).
+//
+// `unsubscribeRefusalReason` is an adapter from the denormalized `evidence` row
+// onto `unsubscribeRefusal` — the same predicate `selectUnsubscribeMethod` runs
+// before it touches a stranger's endpoint. These tests exist to make the two
+// impossible to drift: every case is asserted against the gate's own answer for
+// the equivalent `Message`, never against a hard-coded string.
+
+import type {
+  MailSuggestionEvidence,
+  MailUnsubscribeMethod,
+} from '@auxx/lib/mail-suggestions/client'
+import type { UnsubscribeCandidate } from '@auxx/lib/mail-unsubscribe/client'
+import { selectUnsubscribeMethod } from '@auxx/lib/mail-unsubscribe/client'
+import { describe, expect, it } from 'vitest'
+import { unsubscribeRefusalReason } from './mail-suggestion-content'
+
+const HTTP_URL = 'https://list.example.com/u/abc'
+const MAILTO = 'unsub-abc@list.example.com'
+
+function evidence(overrides: Partial<MailSuggestionEvidence> = {}): MailSuggestionEvidence {
+  return {
+    windowDays: 90,
+    messageCount: 34,
+    threadCount: 30,
+    unreadRate: 1,
+    manualArchiveRate: 0,
+    everReplied: false,
+    sampleThreadIds: [],
+    unsubscribeMethod: 'one-click',
+    listId: 'stripe.updates.example.com',
+    senderDomain: 'example.com',
+    senderAuthenticated: true,
+    historyDays: 60,
+    filteredThreadCount: 0,
+    ...overrides,
+  }
+}
+
+/**
+ * The `Message` the gate would read for the same group. The miner denormalizes
+ * the resolved tier onto `evidence.unsubscribeMethod`, so this rebuilds the
+ * header shape that tier came from.
+ */
+function candidateFor(row: MailSuggestionEvidence): UnsubscribeCandidate {
+  const meta: Record<MailUnsubscribeMethod, UnsubscribeCandidate['unsubscribeMeta']> = {
+    'one-click': { httpUrl: HTTP_URL, oneClick: true },
+    http: { httpUrl: HTTP_URL, oneClick: false },
+    mailto: { mailto: MAILTO, oneClick: false },
+  }
+  return {
+    listId: row.listId,
+    senderAuthenticated: row.senderAuthenticated,
+    unsubscribeMeta: row.unsubscribeMethod ? meta[row.unsubscribeMethod] : null,
+  }
+}
+
+/** The gate's answer for the same inputs, in the card's `string | null` shape. */
+function gateReason(row: MailSuggestionEvidence): string | null {
+  const offer = selectUnsubscribeMethod(candidateFor(row))
+  return offer.offered ? null : offer.message
+}
+
+describe('unsubscribeRefusalReason — one predicate, two callers (§4.1 / V13)', () => {
+  const cases: [name: string, row: MailSuggestionEvidence][] = [
+    ['authenticated sender with a list-id and one-click', evidence()],
+    [
+      'a real list-id is identity enough on an unauthenticated sender',
+      evidence({
+        senderAuthenticated: false,
+      }),
+    ],
+    ['domain group, authenticated', evidence({ listId: null, senderAuthenticated: true })],
+    ['domain group, NOT authenticated', evidence({ listId: null, senderAuthenticated: false })],
+    ['no published unsubscribe address', evidence({ unsubscribeMethod: null })],
+    [
+      'unverified AND no address — the unverified branch wins',
+      evidence({
+        listId: null,
+        senderAuthenticated: false,
+        unsubscribeMethod: null,
+      }),
+    ],
+    ['http tier', evidence({ unsubscribeMethod: 'http' })],
+    ['mailto tier', evidence({ unsubscribeMethod: 'mailto' })],
+  ]
+
+  for (const [name, row] of cases) {
+    it(`agrees with the server gate: ${name}`, () => {
+      expect(unsubscribeRefusalReason(row)).toBe(gateReason(row))
+    })
+  }
+
+  it('refuses a domain group whose senderAuthenticated is NULL (invariant 3)', () => {
+    // The column is nullable and the evidence type collapses NULL to `false` at
+    // mining time — but a row written before that collapse, or a jsonb blob from
+    // any other producer, can still carry NULL. NULL IS NOT A PASS, and the card
+    // must not reach a different verdict than the executor by leaning on
+    // truthiness.
+    const row = evidence({
+      listId: null,
+      senderAuthenticated: null as unknown as boolean,
+    })
+
+    expect(unsubscribeRefusalReason(row)).toBe(gateReason(row))
+    expect(unsubscribeRefusalReason(row)).toMatch(/not authenticated/)
+  })
+
+  it('offers on a list-id whose senderAuthenticated is NULL — the list IS the identity', () => {
+    const row = evidence({ senderAuthenticated: null as unknown as boolean })
+
+    expect(unsubscribeRefusalReason(row)).toBeNull()
+    expect(gateReason(row)).toBeNull()
+  })
+
+  it('never invents copy the gate does not publish', () => {
+    for (const [, row] of cases) {
+      const reason = unsubscribeRefusalReason(row)
+      if (reason !== null) expect(reason).toBe(gateReason(row))
+    }
+  })
+})

--- a/apps/web/src/components/mail-suggestions/ui/mail-suggestion-content.tsx
+++ b/apps/web/src/components/mail-suggestions/ui/mail-suggestion-content.tsx
@@ -8,6 +8,7 @@ import {
   describeSubjectKey,
   MAIL_SUGGESTION_KIND_LABELS,
 } from '@auxx/lib/mail-suggestions/client'
+import { unsubscribeRefusal } from '@auxx/lib/mail-unsubscribe/client'
 import { Button } from '@auxx/ui/components/button'
 import { ShieldBan, SquareArrowOutUpRight } from 'lucide-react'
 import Link from 'next/link'
@@ -28,21 +29,23 @@ import type { MailSuggestionCard } from '../hooks/use-mail-suggestions'
  * The mining job only ever mints `kind: 'unsubscribe'` for a group that PASSED
  * this gate, so a card that reaches the refusal branch always arrives as
  * `auto-archive` — which is why an unsubscribe button we would refuse is never
- * rendered in the first place. This restates the gate for the *explanation*, not
- * as a second authority: the executor re-runs it against the freshest message on
- * every real attempt.
+ * rendered in the first place.
+ *
+ * This is an adapter onto the denormalized `evidence` shape, NOT a second
+ * implementation: `unsubscribeRefusal` is the same predicate
+ * `selectUnsubscribeMethod` runs server-side, so the card's explanation and the
+ * executor's answer cannot drift (v2 plan §4.1). `evidence.unsubscribeMethod`
+ * is the tier the miner already resolved, so `!== null` is this row's version of
+ * "the mail carried a usable `List-Unsubscribe`".
  */
 export function unsubscribeRefusalReason(evidence: MailSuggestionEvidence): string | null {
-  if (!evidence.listId && !evidence.senderAuthenticated) {
-    return (
-      'This sender has no mailing-list identity and is not authenticated, so unsubscribing would ' +
-      'only confirm your address is live.'
-    )
-  }
-  if (evidence.unsubscribeMethod === null) {
-    return 'This sender publishes no unsubscribe address.'
-  }
-  return null
+  return (
+    unsubscribeRefusal({
+      listId: evidence.listId,
+      senderAuthenticated: evidence.senderAuthenticated,
+      hasUnsubscribeMethod: evidence.unsubscribeMethod !== null,
+    })?.message ?? null
+  )
 }
 
 /** Which buttons this card offers, given what the caller is allowed to do. */

--- a/apps/web/src/server/api/routers/mail-filters.test.ts
+++ b/apps/web/src/server/api/routers/mail-filters.test.ts
@@ -64,6 +64,13 @@ const hoisted = vi.hoisted(() => {
   const OWN_FILTER = 'mfl_own00000000000000000000'
   const OTHER_FILTER = 'mfl_other00000000000000000'
   /**
+   * A filter on the 059→060 migration-window mailbox: SHARED def, personal
+   * marker, somebody else's. It is the row that separates "personal by
+   * definition" from "personal in fact", and a refusal keyed on the def alone
+   * would name it.
+   */
+  const LEGACY_FILTER = 'mfl_legacy00000000000000000'
+  /**
    * A filter id with NO row — `MailFilterRun.filterId` carries no FK on purpose,
    * so a run whose filter was deleted is a real, expected state.
    */
@@ -139,6 +146,7 @@ const hoisted = vi.hoisted(() => {
     [SHARED_FILTER]: SHARED_INBOX,
     [OWN_FILTER]: OWN_PERSONAL,
     [OTHER_FILTER]: OTHER_PERSONAL,
+    [LEGACY_FILTER]: LEGACY_PERSONAL,
   }
 
   const filterRow = (id: string) => ({
@@ -455,6 +463,7 @@ const hoisted = vi.hoisted(() => {
     SHARED_FILTER,
     OWN_FILTER,
     OTHER_FILTER,
+    LEGACY_FILTER,
     GONE_FILTER,
     THREAD_ID,
     FOREIGN_THREAD,
@@ -493,6 +502,8 @@ const {
   SHARED_FILTER,
   OWN_FILTER,
   OTHER_FILTER,
+  LEGACY_FILTER,
+  GONE_FILTER,
   THREAD_ID,
   FOREIGN_THREAD,
   RUN_OWN,
@@ -742,13 +753,14 @@ describe('mailFilters router — §5.1 authorship', () => {
     expect(gate).toEqual([])
   })
 
+  /** V6 — the refusal is 404, not 403. The full matrix is its own describe below. */
   it("refuses to mutate another member's personal filter", async () => {
     world.capabilities.add(AUTOMATION_KEY)
     world.writableInboxIds.add(OTHER_PERSONAL)
 
     await expect(
       caller().setEnabled({ filterId: OTHER_FILTER, enabled: false })
-    ).rejects.toMatchObject(FORBIDDEN)
+    ).rejects.toMatchObject(NOT_FOUND)
     expect(lib.setMailFilterEnabled).not.toHaveBeenCalled()
   })
 
@@ -817,6 +829,96 @@ describe('mailFilters router — §5.1 authorship', () => {
       })
     }
   })
+})
+
+/**
+ * V6 (`plans/mail-filter/04-v2-plan.md` §1.3) — the SHAPE of the refusal on the
+ * four filter-addressed write paths.
+ *
+ * §5.1 promises a personal filter you do not own is indistinguishable from one
+ * that does not exist. The read paths kept that promise; these four answered
+ * 403, which is an existence oracle for a guessed CUID. They now answer 404 —
+ * **with the same message** `getMailFilterById` uses, because a distinct string
+ * is a distinguishing signal even when the status matches.
+ *
+ * A shared-inbox filter deliberately stays 403: the caller can see that inbox,
+ * so "you need permission to manage automation rules" is the actionable answer
+ * rather than a lie. Flattening the two into one code is the failure mode this
+ * block exists to catch, in BOTH directions — hence the positive controls.
+ */
+describe('mailFilters router — 404 vs 403 on the filter write paths', () => {
+  /** Byte-identical to what `getMailFilterById` answers for an id with no row. */
+  const GONE = { cause: { statusCode: 404, message: 'Filter not found' } }
+
+  const writes: Array<{
+    name: 'update' | 'setEnabled' | 'delete' | 'applyRetroactively'
+    input: (filterId: string) => object
+    helper: () => unknown
+  }> = [
+    {
+      name: 'update',
+      input: (filterId) => ({ filterId, name: 'Renamed' }),
+      helper: () => lib.updateMailFilter,
+    },
+    {
+      name: 'setEnabled',
+      input: (filterId) => ({ filterId, enabled: false }),
+      helper: () => lib.setMailFilterEnabled,
+    },
+    { name: 'delete', input: (filterId) => ({ filterId }), helper: () => lib.deleteMailFilter },
+    {
+      name: 'applyRetroactively',
+      input: (filterId) => ({ filterId }),
+      helper: () => lib.applyRetroactively,
+    },
+  ]
+
+  const invoke = (op: string, input: object) =>
+    (caller() as unknown as Record<string, (arg: unknown) => Promise<unknown>>)[op]!(input)
+
+  for (const { name, input, helper } of writes) {
+    it(`${name} 404s another member's personal filter, even for an admin`, async () => {
+      // `Inboxes: Full` composes write on EVERY inbox and the key is held — the
+      // strongest caller in the org still gets not-found (§5.1: no override).
+      asAutomationAdmin()
+
+      await expect(invoke(name, input(OTHER_FILTER))).rejects.toMatchObject(GONE)
+      expect(helper()).not.toHaveBeenCalled()
+      expect(gate).toEqual([])
+    })
+
+    it(`${name} 404s a personal mailbox still on the SHARED def`, async () => {
+      // The 059→060 window. Keyed on the def alone this row reads as shared and
+      // would 403 — naming somebody's private mailbox.
+      asAutomationAdmin()
+
+      await expect(invoke(name, input(LEGACY_FILTER))).rejects.toMatchObject(GONE)
+      expect(helper()).not.toHaveBeenCalled()
+    })
+
+    it(`${name} 404s an id with no row at all`, async () => {
+      asAutomationAdmin()
+
+      await expect(invoke(name, input(GONE_FILTER))).rejects.toMatchObject(GONE)
+      expect(helper()).not.toHaveBeenCalled()
+    })
+
+    it(`${name} 403s a shared-inbox filter the caller may not author on`, async () => {
+      // Holds the key, writes to no inbox. The inbox is org inventory the caller
+      // can see, so hiding it behind a 404 would be a lie, not a protection.
+      world.capabilities.add(AUTOMATION_KEY)
+
+      await expect(invoke(name, input(SHARED_FILTER))).rejects.toMatchObject(FORBIDDEN)
+      expect(helper()).not.toHaveBeenCalled()
+    })
+
+    it(`${name} succeeds for the owner of the personal filter, with no key`, async () => {
+      await invoke(name, input(OWN_FILTER))
+
+      expect(helper()).toHaveBeenCalledTimes(1)
+      expect(gate).toEqual([])
+    })
+  }
 })
 
 /** Invariant 15 — server-side rejection, not a hidden catalog entry. */
@@ -1304,11 +1406,12 @@ describe('mailFilters router — applyRetroactively', () => {
     expect(lib.loadBackfillableFilter).not.toHaveBeenCalled()
   })
 
+  /** V6 — 404, so the largest mutation the feature has is not an existence oracle. */
   it("refuses another member's personal filter", async () => {
     asAutomationAdmin()
 
     await expect(caller().applyRetroactively({ filterId: OTHER_FILTER })).rejects.toMatchObject(
-      FORBIDDEN
+      NOT_FOUND
     )
     expect(lib.applyRetroactively).not.toHaveBeenCalled()
   })

--- a/apps/web/src/server/api/routers/mail-filters.ts
+++ b/apps/web/src/server/api/routers/mail-filters.ts
@@ -31,6 +31,7 @@ import { getUserSetting, updateUserSetting } from '@auxx/lib/settings'
 import { z } from 'zod'
 import {
   assertCanAuthorMailFilters,
+  assertCanMutateMailFilter,
   loadMailFilterAuthority,
   type MailFilterAuthority,
 } from '~/server/lib/mail-filter-authoring-access'
@@ -176,6 +177,11 @@ function assertActionDestinationsAllowed(
  * an authorization decision ever being made, so a 403 can never be used as an
  * existence oracle. `inboxId` is not patchable (the lib omits it from
  * `UpdateMailFilterInput`), so the stored inbox is always the one to judge.
+ *
+ * `assertCanMutateMailFilter`, not `assertCanAuthorMailFilters` (V6): the caller
+ * addressed a FILTER here, so a refusal on somebody else's personal mailbox has
+ * to read as `NotFoundError` — 403 was an existence oracle for the one thing
+ * §5.1 promises is never disclosed. Shared-inbox filters still 403.
  */
 async function loadFilterForWrite(
   db: Parameters<typeof getMailFilterById>[0],
@@ -185,7 +191,7 @@ async function loadFilterForWrite(
 ) {
   const result = await getMailFilterById(db, organizationId, filterId)
   if (result.isErr()) throw result.error
-  assertCanAuthorMailFilters(authority, result.value.inboxId)
+  assertCanMutateMailFilter(authority, result.value)
   return result.value
 }
 

--- a/apps/web/src/server/api/routers/mail-suggestions.test.ts
+++ b/apps/web/src/server/api/routers/mail-suggestions.test.ts
@@ -15,14 +15,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  *
  *  1. owns a personal inbox ⇒ sees exactly their own cards
  *  2. an admin ⇒ never sees another member's personal-inbox cards
- *  3. no inbox write ⇒ denied on unsubscribe (§7.1 is inbox write, and ONLY that)
+ *  3. no inbox read ⇒ denied on unsubscribe (§7.1 is inbox read, and ONLY that)
  *  4. no filter-authoring rights ⇒ denied on accept (invariant 10 — the
  *     suggestion is a PREFILL, never an authorization path)
  *
  * plus invariant 7 (dismissal is a STATUS WRITE, never a delete — dismissed rows
  * ARE the suppression list) and the §7.1 divergence itself: unsubscribing needs
- * inbox write and must NOT need `automationRules.manage`, because gating mail on
+ * inbox `read` and must NOT need `automationRules.manage`, because gating mail on
  * an automation grant is gating mail on admin rank.
+ *
+ * ## The two thresholds are modelled, not stubbed
+ *
+ * The caller composes a RUNG per inbox on the real, sparse mail ladder
+ * (`none < metadata < identity < read < admin` — no `edit`, on purpose), and both
+ * capability reads are derived from it the way the real `CapabilitySet` derives
+ * them: `canViewInstance` is `>= read`, `canEditInstance` is `>= edit`, which on
+ * this ladder only `admin` reaches. That is what makes the v2 §2.1 divergence
+ * assertable here: a member at `read` may unsubscribe and may NOT author.
  *
  * ## Shape notes
  *
@@ -45,6 +54,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const AUTOMATION_KEY = 'automationRules.manage'
 
 const hoisted = vi.hoisted(() => {
+  /**
+   * The mail rung ladder, verbatim from
+   * `permissions/capabilities/instance-access.ts`. `edit` is ABSENT on purpose:
+   * mail's `read` already confers acting (reply, assign), so the only tier above
+   * it is managing the mailbox itself.
+   */
+  const INBOX_RUNGS = ['none', 'metadata', 'identity', 'read', 'admin'] as const
+  type InboxRung = (typeof INBOX_RUNGS)[number]
+
+  /** `canViewInstance` — the `>= read` threshold, i.e. mail's acting tier. */
+  const satisfiesRead = (rung: InboxRung | undefined): boolean =>
+    rung !== undefined && INBOX_RUNGS.indexOf(rung) >= INBOX_RUNGS.indexOf('read')
+
+  /**
+   * `canEditInstance` — the `>= edit` threshold. `edit` is not in this ladder, so
+   * `admin` is the only rung that satisfies it, exactly as in production.
+   */
+  const satisfiesEdit = (rung: InboxRung | undefined): boolean => rung === 'admin'
+
   const ORG_ID = 'org_cuid000000000000000000000'
   const USER_ID = 'usr_member00000000000000000'
   const OTHER_USER_ID = 'usr_other000000000000000000'
@@ -66,8 +94,12 @@ const hoisted = vi.hoisted(() => {
   const world = {
     /** Layer-2 capability keys the caller holds. EMPTY is the interesting case. */
     capabilities: new Set<string>(),
-    /** Inbox ids the caller composes `edit`+ on (the shared branch's second half). */
-    writableInboxIds: new Set<string>(),
+    /**
+     * The rung the caller composes per inbox. Absent ⇒ no access at all.
+     * Both `canViewInstance` (`>= read`) and `canEditInstance` (`>= edit`, i.e.
+     * `admin` on this ladder) are derived from it — see the header note.
+     */
+    inboxRungs: new Map<string, InboxRung>(),
     /** What `executeUnsubscribe` answers. */
     unsubscribeOutcome: {
       status: 'requested',
@@ -203,14 +235,14 @@ const hoisted = vi.hoisted(() => {
     ownerUserId: string | null
   }
   interface AuthorityCaps {
-    canEditInstance(key: 'inbox', instanceId: string): boolean
+    canViewInstance(key: 'inbox', instanceId: string): boolean
   }
 
   /**
    * A FAITHFUL stand-in for `unsubscribe-authority.ts` (§7.1):
    *
    *   personal_inbox owned by the caller  →  allowed, NO permission key
-   *   shared inbox                        →  inbox write, and NOTHING else
+   *   shared inbox                        →  inbox READ, and NOTHING else
    *
    * The legacy `isPersonal` marker narrows and never widens, exactly as the real
    * predicate does — personal-ness can be self-declared into a stricter rule, not
@@ -220,7 +252,7 @@ const hoisted = vi.hoisted(() => {
     (inbox: AuthorityInbox, userId: string, capabilities: AuthorityCaps) => {
       if (inbox.entityDefinitionKey === 'personal_inbox') return inbox.ownerUserId === userId
       if (inbox.isPersonal) return inbox.ownerUserId === userId
-      return capabilities.canEditInstance('inbox', inbox.id)
+      return capabilities.canViewInstance('inbox', inbox.id)
     }
   )
 
@@ -365,6 +397,8 @@ const hoisted = vi.hoisted(() => {
   }
 
   return {
+    satisfiesRead,
+    satisfiesEdit,
     ORG_ID,
     USER_ID,
     OTHER_USER_ID,
@@ -470,27 +504,36 @@ const caller = (userId: string = USER_ID) =>
     },
     capabilities: {
       can: (key: string) => world.capabilities.has(key),
+      /** `>= read` — the unsubscribe/dismiss threshold (§7.1, v2 §2.1). */
+      canViewInstance: (key: string, instanceId: string) =>
+        key === 'inbox' && hoisted.satisfiesRead(world.inboxRungs.get(instanceId)),
+      /** `>= edit`, i.e. `admin` on the mail ladder — the filter-authoring half. */
       canEditInstance: (key: string, instanceId: string) =>
-        key === 'inbox' && world.writableInboxIds.has(instanceId),
+        key === 'inbox' && hoisted.satisfiesEdit(world.inboxRungs.get(instanceId)),
     },
   } as never)
+
+/** Compose one rung on one inbox. Defaults to the unsubscribe threshold. */
+const grantInbox = (inboxId: string, rung: 'none' | 'metadata' | 'identity' | 'read' | 'admin') => {
+  world.inboxRungs.set(inboxId, rung)
+}
 
 /** The shape `auxxErrorMiddleware` maps to a 403 / 404. */
 const FORBIDDEN = { cause: { statusCode: 403 } }
 const NOT_FOUND = { cause: { statusCode: 404 } }
 
-/** An org admin composing `Inboxes: Full` — write on EVERY inbox, plus the key. */
+/** An org admin composing `Inboxes: Full` — `admin` on EVERY inbox, plus the key. */
 const asAutomationAdmin = () => {
   world.capabilities.add(AUTOMATION_KEY)
-  world.writableInboxIds.add(SHARED_INBOX)
-  world.writableInboxIds.add(OWN_PERSONAL)
-  world.writableInboxIds.add(OTHER_PERSONAL)
-  world.writableInboxIds.add(LEGACY_PERSONAL)
+  grantInbox(SHARED_INBOX, 'admin')
+  grantInbox(OWN_PERSONAL, 'admin')
+  grantInbox(OTHER_PERSONAL, 'admin')
+  grantInbox(LEGACY_PERSONAL, 'admin')
 }
 
 beforeEach(() => {
   world.capabilities.clear()
-  world.writableInboxIds.clear()
+  world.inboxRungs.clear()
   world.unsubscribeOutcome = {
     status: 'requested',
     method: 'one-click',
@@ -573,21 +616,46 @@ describe('mailSuggestions router — §7.2 visibility', () => {
   })
 
   it('hides the filter half from a caller without the automation key', async () => {
-    world.writableInboxIds.add(SHARED_INBOX)
+    grantInbox(SHARED_INBOX, 'admin')
 
     const shared = (await caller().list()).find((row) => row.id === SHARED_SUGGESTION)
 
-    // Inbox write is enough to unsubscribe (§7.1) and NOT enough to author a
+    // Inbox authority is enough to unsubscribe (§7.1) and NOT enough to author a
     // filter — the card must say so rather than offering a button we would 403.
     expect(shared?.canUnsubscribe).toBe(true)
     expect(shared?.canAuthorFilter).toBe(false)
   })
+
+  it('shows the cards to a plain READER of a shared mailbox', async () => {
+    // v2 §2.1: the scope is the unsubscribe predicate, so widening that gate to
+    // `read` widens visibility with it — correctly, because a member at `read`
+    // can now answer every prompt the card offers.
+    world.capabilities.add(AUTOMATION_KEY)
+    grantInbox(SHARED_INBOX, 'read')
+
+    const shared = (await caller().list()).find((row) => row.id === SHARED_SUGGESTION)
+
+    expect(shared?.canUnsubscribe).toBe(true)
+    // …and still cannot author the standing filter, which stayed at `admin`.
+    expect(shared?.canAuthorFilter).toBe(false)
+  })
+
+  it.each([
+    'none',
+    'metadata',
+    'identity',
+  ] as const)('shows a member composing %s nothing at all', async (rung) => {
+    grantInbox(SHARED_INBOX, rung)
+
+    expect(await caller(STRANGER_ID).list()).toEqual([])
+    expect(suggestionsLib.listMailSuggestions).not.toHaveBeenCalled()
+  })
 })
 
 describe('mailSuggestions router — §7.1 unsubscribe authority', () => {
-  /** Case 3 — inbox write, and nothing else, is the whole gate. */
-  it('denies unsubscribe on a shared inbox to a caller with no inbox write', async () => {
-    // Deliberately holds the AUTOMATION key and no inbox write: an automation
+  /** Case 3 — inbox authority, and nothing else, is the whole gate. */
+  it('denies unsubscribe on a shared inbox to a caller with no inbox access', async () => {
+    // Deliberately holds the AUTOMATION key and no inbox rung: an automation
     // grant must not buy mail authority in either direction.
     world.capabilities.add(AUTOMATION_KEY)
 
@@ -597,8 +665,8 @@ describe('mailSuggestions router — §7.1 unsubscribe authority', () => {
     expect(unsubscribeLib.executeUnsubscribe).not.toHaveBeenCalled()
   })
 
-  it('allows unsubscribe on a shared inbox with inbox write and NO automation key', async () => {
-    world.writableInboxIds.add(SHARED_INBOX)
+  it('allows unsubscribe on a shared inbox with inbox access and NO automation key', async () => {
+    grantInbox(SHARED_INBOX, 'admin')
 
     const result = await caller().unsubscribe({ suggestionId: SHARED_SUGGESTION })
 
@@ -650,7 +718,7 @@ describe('mailSuggestions router — §7.1 unsubscribe authority', () => {
   })
 
   it('returns a refusal as an OUTCOME rather than an error', async () => {
-    world.writableInboxIds.add(SHARED_INBOX)
+    grantInbox(SHARED_INBOX, 'admin')
     world.unsubscribeOutcome = {
       status: 'refused',
       refusal: { offered: false, reason: 'unverified-sender', alternative: 'block-sender' },
@@ -664,13 +732,83 @@ describe('mailSuggestions router — §7.1 unsubscribe authority', () => {
   })
 })
 
+/**
+ * V4 — the rung, not merely "some authority".
+ *
+ * §7.1 designed unsubscribe as the LOOSER of the two shared-inbox gates, but
+ * asking `canEditInstance` on a ladder with no `edit` rung resolves to `admin`,
+ * which is the strict half of the filter-authoring gate. The divergence had
+ * collapsed invisibly because both landed on the same rung. User decision
+ * 2026-08-10: unsubscribe is `read`; authoring is unchanged.
+ */
+describe('mailSuggestions router — v2 §2.1, unsubscribe is gated on inbox READ', () => {
+  it('allows a member with inbox read who is NOT an inbox admin', async () => {
+    grantInbox(SHARED_INBOX, 'read')
+
+    await expect(caller().unsubscribe({ suggestionId: SHARED_SUGGESTION })).resolves.toMatchObject({
+      status: 'requested',
+    })
+    expect(unsubscribeLib.executeUnsubscribe).toHaveBeenCalled()
+  })
+
+  it.each([
+    'none',
+    'metadata',
+    'identity',
+  ] as const)('denies a member composing %s', async (rung) => {
+    grantInbox(SHARED_INBOX, rung)
+
+    await expect(caller().unsubscribe({ suggestionId: SHARED_SUGGESTION })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(unsubscribeLib.executeUnsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('does not move the AUTHORING gate — read still cannot accept', async () => {
+    // The whole point of restoring the divergence: a one-shot command sits with
+    // reply and assign at `read`, an unattended standing mutation does not.
+    world.capabilities.add(AUTOMATION_KEY)
+    grantInbox(SHARED_INBOX, 'read')
+
+    await expect(caller().accept({ suggestionId: SHARED_SUGGESTION })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(filtersLib.createMailFilter).not.toHaveBeenCalled()
+  })
+
+  it("a reader of every shared mailbox still cannot touch another member's personal one", async () => {
+    // The personal branch never consults a capability at all, so loosening the
+    // shared rung must not reach across it. 404, never 403 — a private mailbox
+    // must not be distinguishable from an id that was never real.
+    grantInbox(SHARED_INBOX, 'read')
+    grantInbox(OTHER_PERSONAL, 'read')
+    grantInbox(LEGACY_PERSONAL, 'read')
+
+    await expect(caller().unsubscribe({ suggestionId: OTHER_SUGGESTION })).rejects.toMatchObject(
+      NOT_FOUND
+    )
+    await expect(caller().unsubscribe({ suggestionId: LEGACY_SUGGESTION })).rejects.toMatchObject(
+      NOT_FOUND
+    )
+    expect(unsubscribeLib.executeUnsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('carries the same rung to dismiss — the decline half of one decision', async () => {
+    grantInbox(SHARED_INBOX, 'read')
+
+    await expect(caller().dismiss({ suggestionId: SHARED_SUGGESTION })).resolves.toMatchObject({
+      status: 'dismissed',
+    })
+  })
+})
+
 describe('mailSuggestions router — §6.2 block sender is a THIRD authority', () => {
   it('blocks the from-ADDRESS, never the group domain', async () => {
     // The refusal branch is dominated by consumer mail — on real data it includes
     // `domain:gmail.com` (477 messages), hotmail, outlook, yahoo. Blocking a
     // domain key there would stop every consumer sender on the channel,
     // customers included. Only the exact address may be blocked from a card.
-    world.writableInboxIds.add(SHARED_INBOX)
+    grantInbox(SHARED_INBOX, 'admin')
 
     const result = await caller().blockSender({ suggestionId: SHARED_SUGGESTION })
 
@@ -687,7 +825,7 @@ describe('mailSuggestions router — §6.2 block sender is a THIRD authority', (
   it('requires PER-CHANNEL manage authority, not just inbox write', async () => {
     // Blocking writes ChannelSettings.excludeSenders, which reaches every inbox
     // that channel feeds — strictly more than the one this card is about.
-    world.writableInboxIds.add(SHARED_INBOX)
+    grantInbox(SHARED_INBOX, 'admin')
     world.canManageChannel = false
 
     await expect(caller().blockSender({ suggestionId: SHARED_SUGGESTION })).rejects.toThrow(
@@ -696,7 +834,7 @@ describe('mailSuggestions router — §6.2 block sender is a THIRD authority', (
     expect(hoisted.channels.addExcludedSender).not.toHaveBeenCalled()
   })
 
-  it('denies a caller without inbox write before it ever reaches the channel', async () => {
+  it('denies a caller without inbox access before it ever reaches the channel', async () => {
     world.capabilities.add(AUTOMATION_KEY)
 
     await expect(caller().blockSender({ suggestionId: SHARED_SUGGESTION })).rejects.toMatchObject(
@@ -706,10 +844,36 @@ describe('mailSuggestions router — §6.2 block sender is a THIRD authority', (
     expect(hoisted.channels.addExcludedSender).not.toHaveBeenCalled()
   })
 
+  it.each([
+    'none',
+    'metadata',
+    'identity',
+  ] as const)('refuses a %s reader before the channel layer, even after v2 §2.1 loosened the inbox gate', async (rung) => {
+    // The ordering is the property: inbox authority is asserted FIRST, so
+    // widening it must never let someone reach the channel gate who could not
+    // reach it before.
+    grantInbox(SHARED_INBOX, rung)
+
+    await expect(caller().blockSender({ suggestionId: SHARED_SUGGESTION })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+    expect(hoisted.channels.requireChannelManageAccess).not.toHaveBeenCalled()
+  })
+
+  it('still requires the channel gate from a plain inbox READER', async () => {
+    grantInbox(SHARED_INBOX, 'read')
+    world.canManageChannel = false
+
+    await expect(caller().blockSender({ suggestionId: SHARED_SUGGESTION })).rejects.toThrow(
+      /manage shared channels/
+    )
+    expect(hoisted.channels.addExcludedSender).not.toHaveBeenCalled()
+  })
+
   it('dismisses the card afterwards — blocking IS the answer', async () => {
     // A status write, never a delete: otherwise the next weekly sweep re-proposes
     // a sender the user has already blocked (invariant 7).
-    world.writableInboxIds.add(SHARED_INBOX)
+    grantInbox(SHARED_INBOX, 'admin')
 
     await caller().blockSender({ suggestionId: SHARED_SUGGESTION })
 
@@ -720,7 +884,7 @@ describe('mailSuggestions router — §6.2 block sender is a THIRD authority', (
 describe('mailSuggestions router — invariant 10, accept is a prefill', () => {
   /** Case 4 — accepting runs the SAME gate as authoring a filter by hand. */
   it('denies accept to a caller with inbox write but no automation key', async () => {
-    world.writableInboxIds.add(SHARED_INBOX)
+    grantInbox(SHARED_INBOX, 'admin')
 
     await expect(caller().accept({ suggestionId: SHARED_SUGGESTION })).rejects.toMatchObject(
       FORBIDDEN

--- a/apps/web/src/server/api/routers/mail-suggestions.ts
+++ b/apps/web/src/server/api/routers/mail-suggestions.ts
@@ -42,8 +42,8 @@ import { mailFiltersRouter } from './mail-filters'
  * | Operation | Gate |
  * | --- | --- |
  * | listing cards | {@link loadMailSuggestionScope}, in SQL — personal ⇒ owner only |
- * | dismissing | inbox write — it silences that sender for everyone, permanently |
- * | unsubscribing | `assertCanUnsubscribe` — inbox write, NO automation key (§7.1) |
+ * | dismissing | inbox read — the same authority unsubscribing needs |
+ * | unsubscribing | `assertCanUnsubscribe` — inbox read, NO automation key (§7.1) |
  * | accepting (⇒ a filter) | `assertCanAuthorMailFilters` — the ordinary filter gate |
  *
  * **The suggestion is a PREFILL, never an authorization path** (invariant 10).
@@ -72,10 +72,11 @@ interface MailSuggestionScope {
  *   confers no override — that predicate branches on the inbox DEFINITION, so
  *   personal-ness cannot be forged, only self-declared into a stricter rule.
  * - The filter-authoring set is a strict SUBSET of this one (authoring wants
- *   `automationRules.manage` *and* inbox write; unsubscribing wants inbox write
- *   alone), so scoping visibility here can never hide a card its viewer could
- *   have accepted — while a mere reader, who could act on nothing, is not shown
- *   an action prompt they cannot answer.
+ *   `automationRules.manage` *and* inbox `admin`; unsubscribing wants inbox
+ *   `read` alone), so scoping visibility here can never hide a card its viewer
+ *   could have accepted — and a member who can read the mailbox can answer every
+ *   prompt the card offers, because mail's `read` is the rung that confers
+ *   acting.
  *
  * One computation, two consumers (`list` and `count`), so the badge and the cards
  * cannot drift. The mutations re-derive authority per operation against the row
@@ -83,7 +84,7 @@ interface MailSuggestionScope {
  */
 async function loadMailSuggestionScope(ctx: {
   session: { organizationId: string; userId: string }
-  capabilities: { canEditInstance(key: 'inbox', instanceId: string): boolean }
+  capabilities: { canViewInstance(key: 'inbox', instanceId: string): boolean }
 }): Promise<MailSuggestionScope> {
   const inboxes = await getOrgCache().get(ctx.session.organizationId, 'inboxes')
   const visible = inboxes.filter((inbox) =>
@@ -238,9 +239,12 @@ export const mailSuggestionsRouter = createTRPCRouter({
       const organizationId = ctx.session.organizationId
       const { inbox } = await loadSuggestionForWrite(ctx.db, ctx, input.suggestionId)
       /**
-       * The same inbox-write authority unsubscribing needs, because dismissal is
-       * an org-level decision on a shared mailbox: it silences that sender's card
-       * permanently, for everyone, and the next weekly sweep honours it.
+       * The same inbox authority unsubscribing needs, deliberately one predicate
+       * rather than two: dismissal is the *decline* half of the same decision,
+       * and a member who may stop the mail outright but not decline the
+       * suggestion about it would be an incoherent pair of gates. It is still an
+       * org-level act on a shared mailbox — the card is silenced permanently,
+       * for everyone, and the next weekly sweep honours it.
        */
       if (!canUnsubscribeOnInbox(inbox, ctx.session.userId, ctx.capabilities)) {
         throw new ForbiddenError("You don't have permission to change this mailbox's suggestions.")
@@ -316,15 +320,22 @@ export const mailSuggestionsRouter = createTRPCRouter({
   /**
    * Unsubscribe this inbox from the card's list (§6).
    *
-   * ⚠️ Gated on **inbox write alone** — `assertCanUnsubscribe`, and deliberately
-   * NOT `automationRules.manage` (§7.1). Unsubscribing is a mail operation, not
-   * an automation one; requiring an automation grant to stop a newsletter would
-   * gate mail on admin rank, which the mail guide forbids.
+   * ⚠️ Gated on **inbox `read` alone** — `assertCanUnsubscribe`, and deliberately
+   * NOT `automationRules.manage` (§7.1, v2 plan §2.1). Unsubscribing is a mail
+   * operation, not an automation one; requiring an automation grant to stop a
+   * newsletter would gate mail on admin rank, which the mail guide forbids. Mail's
+   * `read` is the rung that confers acting (reply, assign), and a one-shot command
+   * against a list belongs with them — authoring a standing filter does not, and
+   * keeps its stricter gate.
    *
    * `refused` comes back as an OUTCOME, not an error: "we won't unsubscribe from
    * this, block the sender instead" is a legitimate answer the card renders.
    * `openUrl` is set for the `http` tier only — we hand that URL to the client to
    * open, and never fetch it ourselves.
+   *
+   * The returned `status` is what the tier ACHIEVED: only the one-click tier is
+   * acknowledged, so only it can come back `confirmed` or `failed`; `http` and
+   * `mailto` stay `requested`.
    */
   unsubscribe: capabilityProcedure
     .input(z.object({ suggestionId: z.string().min(1) }))
@@ -355,7 +366,7 @@ export const mailSuggestionsRouter = createTRPCRouter({
    * prevention, not a polite request.
    *
    * ⚠️ **This is a THIRD authority, stricter than the other two.** Unsubscribe and
-   * dismiss are gated on inbox write; blocking writes `ChannelSettings.excludeSenders`
+   * dismiss are gated on inbox read; blocking writes `ChannelSettings.excludeSenders`
    * on the *channel*, one step EARLIER than a filter — `shouldIgnoreMessage` runs
    * before the write, so blocked mail never becomes a thread at all
    * (mail-filters §3.5). It affects every inbox fed by that channel, not just this
@@ -376,7 +387,11 @@ export const mailSuggestionsRouter = createTRPCRouter({
       const organizationId = ctx.session.organizationId
       const { suggestion, inbox } = await loadSuggestionForWrite(ctx.db, ctx, input.suggestionId)
 
-      // Inbox write first: without it you may not act on this mail at all.
+      // Inbox authority FIRST, and the ordering is load-bearing: without it you
+      // may not act on this mail at all, so a caller who cannot reach the
+      // mailbox never learns anything about the channel behind it. The channel
+      // layer below is a separate, stricter gate — never a substitute for this
+      // one, and never reached before it.
       assertCanUnsubscribe(inbox, ctx.session.userId, ctx.capabilities)
 
       const targetResult = await resolveUnsubscribeTarget(

--- a/apps/web/src/server/lib/mail-filter-authoring-access.ts
+++ b/apps/web/src/server/lib/mail-filter-authoring-access.ts
@@ -1,7 +1,7 @@
 // apps/web/src/server/lib/mail-filter-authoring-access.ts
 
 import { getOrgCache } from '@auxx/lib/cache'
-import { ForbiddenError } from '@auxx/lib/errors'
+import { ForbiddenError, NotFoundError } from '@auxx/lib/errors'
 import type { Inbox } from '@auxx/lib/inboxes'
 import type { InstanceAccessKey } from '@auxx/lib/permissions/capabilities/instance-access'
 import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
@@ -22,9 +22,12 @@ import { PermissionKey } from '@auxx/lib/permissions/capabilities/registry'
  * **One computation, three consumers.** `mailFilters.list` scopes its SQL with
  * {@link MailFilterAuthority.inboxIds}, `mailFilters.authorableInboxes` renders
  * {@link MailFilterAuthority.inboxes}, and every mutation asserts through
- * {@link assertCanAuthorMailFilters} against the same map. They cannot drift,
- * which is what invariant 11 asks for now that the `settings/rules` page guard
- * is gone and the router is the only gate left.
+ * {@link assertCanAuthorMailFilters} / {@link assertCanMutateMailFilter} against
+ * the same map. They cannot drift, which is what invariant 11 asks for now that
+ * the `settings/rules` page guard is gone and the router is the only gate left.
+ *
+ * The two asserts differ ONLY in the shape of the refusal, never in who is
+ * refused — see {@link assertCanMutateMailFilter}.
  *
  * Deep permission imports rather than the `@auxx/lib/permissions` barrel: the
  * barrel hangs under vitest (the `snippet-instance-access.ts` precedent), and
@@ -65,6 +68,24 @@ export interface MailFilterAuthority {
   inboxIds: string[]
   /** Lookup for the per-mutation assert. */
   byId: Map<string, AuthorableInbox>
+  /**
+   * Every inbox in the org whose EXISTENCE is not private — i.e. every inbox on
+   * the shared `inbox` def, authorable or not.
+   *
+   * This set decides the SHAPE of a refusal, never who is refused
+   * (`plans/mail-filter/04-v2-plan.md` §1.3, V6). §5.1 says a personal filter
+   * you do not own must be indistinguishable from a filter that does not exist,
+   * so refusing one has to read as 404 — while a shared inbox is org inventory
+   * the caller can already see, and answering 404 there would hide the one thing
+   * they can act on ("ask for `automationRules.manage`").
+   *
+   * The legacy-marker row is EXCLUDED for the same reason
+   * {@link canAuthorOnInbox} excludes it: between entity migration 059 and data
+   * migration 060 a private mailbox still sits on the shared def, and disclosing
+   * it by def alone would name somebody's personal mailbox. The marker narrows
+   * here too — it can only ever move a row from "disclosable" to "private".
+   */
+  disclosableInboxIds: Set<string>
   /**
    * Whether the caller holds `automationRules.manage`. Carried on the authority
    * because invariant 15 needs it a second time, on the ACTION list: an author
@@ -148,6 +169,11 @@ export function mailFilterAuthority(args: {
     inboxes: authorable,
     inboxIds: authorable.map((inbox) => inbox.id),
     byId: new Map(authorable.map((inbox) => [inbox.id, inbox])),
+    disclosableInboxIds: new Set(
+      inboxes
+        .filter((inbox) => inbox.entityDefinitionKey !== 'personal_inbox' && !inbox.isPersonal)
+        .map((inbox) => inbox.id)
+    ),
     hasAutomationKey,
   }
 }
@@ -176,10 +202,16 @@ export async function loadMailFilterAuthority(
 /**
  * Assert the §5.1 branch for one inbox and return its authorable descriptor.
  *
- * Called by EVERY mutating procedure — create, update, setEnabled, reorder and
- * delete — rather than once at create. Rights change after a filter is written
- * and an inbox can be moved between definitions, so authorization is re-derived
- * on each write from the state it is being written against.
+ * The INBOX-ADDRESSED assert: the caller named the inbox itself (create,
+ * reorder, previewMatchCount, a `move-inbox` destination, a prompt dismissal),
+ * so the refusal is about that inbox and 403 is the honest answer. The
+ * FILTER-addressed paths go through {@link assertCanMutateMailFilter} instead,
+ * which has one more thing to protect.
+ *
+ * Called by EVERY mutating procedure rather than once at create. Rights change
+ * after a filter is written and an inbox can be moved between definitions, so
+ * authorization is re-derived on each write from the state it is being written
+ * against.
  *
  * @throws ForbiddenError when the caller may not author on this inbox.
  */
@@ -192,4 +224,43 @@ export function assertCanAuthorMailFilters(
     throw new ForbiddenError("You don't have permission to manage filters for this inbox.")
   }
   return inbox
+}
+
+/**
+ * The same §5.1 branch, for a write addressed by FILTER id — update, setEnabled,
+ * delete, applyRetroactively (V6, `plans/mail-filter/04-v2-plan.md` §1.3).
+ *
+ * Identical in WHO it refuses; different in WHAT the refusal admits:
+ *
+ * ```
+ *   authorable                        →  allowed
+ *   filter on a shared inbox          →  403, the caller can see the inbox
+ *   filter on someone else's personal →  404, verbatim `getMailFilterById`'s
+ *   inbox (incl. the legacy-marker       "Filter not found" — indistinguishable
+ *   row on the shared def)               from an id with no row
+ * ```
+ *
+ * §5.1 promises that a personal filter is never disclosed to anyone else, and
+ * `list` / `get` / `runs` / `undoRun` all keep that promise by answering
+ * not-found. A 403 here broke it: it is an existence oracle for a guessed CUID,
+ * confirming that a colleague's private mailbox holds that filter. Flattening
+ * the shared case into 404 as well would over-correct — that filter IS visible
+ * inventory to a member who can see the inbox, and "you need permission" is the
+ * actionable answer rather than a lie.
+ *
+ * @throws NotFoundError when the filter sits on a personal inbox that is not the
+ *   caller's — same class and same message as a filter that does not exist.
+ * @throws ForbiddenError when it sits on a shared inbox the caller cannot author
+ *   on.
+ */
+export function assertCanMutateMailFilter(
+  authority: MailFilterAuthority,
+  filter: { inboxId: string }
+): AuthorableInbox {
+  const inbox = authority.byId.get(filter.inboxId)
+  if (inbox) return inbox
+  if (authority.disclosableInboxIds.has(filter.inboxId)) {
+    throw new ForbiddenError("You don't have permission to manage filters for this inbox.")
+  }
+  throw new NotFoundError('Filter not found')
 }

--- a/docs/mail-suggestions-architecture-guide.md
+++ b/docs/mail-suggestions-architecture-guide.md
@@ -295,9 +295,10 @@ the job runs from a worker with no caller at all, and holds zero permission chec
 `buildInboxGroupQuery(params)` — exported specifically so a test can read the emitted SQL, because
 the `MailFilterRun` exclusion is invisible to any assertion made on the returned rows alone. Four
 CTEs: `per_thread` → `per_group` → `top_assignee` / `top_tag`. Scope: one inbox, inbound only,
-`mergedIntoThreadId IS NULL`, `createdAt >= now − 90d`, and at least one of `listId`/`senderDomain`.
+`mergedIntoThreadId IS NULL`, `coalesce(receivedAt, createdAt) >= now − 90d`, and at least one of
+`listId`/`senderDomain`.
 
-Three things in it are load-bearing rather than incidental:
+Four things in it are load-bearing rather than incidental:
 
 1. **`per_thread` collapses to one row per thread before any rate is taken.** A newsletter thread with
    12 messages must count once toward `threadCount`; aggregating rates straight off `Message` would
@@ -305,8 +306,21 @@ Three things in it are load-bearing rather than incidental:
 2. **`manual_archived` counts `archived AND NOT filtered`** — threads with a `MailFilterRun` are
    excluded. Without it the job proposes a filter to do what a filter is already doing, every week,
    forever.
-3. **`bool_and(m."senderAuthenticated" IS TRUE)`, not `bool_or`.** NULL collapses to `false`, and
-   requiring every message in the window to have passed is the conservative branch (§9.2).
+3. **`senderAuthenticated` is the NEWEST message's verdict**, not `bool_and` over the window:
+   `(array_agg(m."senderAuthenticated" ORDER BY <mail time> DESC))[1] IS TRUE`, rolled up to the
+   group by the thread holding its newest message. `resolveUnsubscribeTarget` reads the gate inputs
+   off the newest inbound message because §6.2 is written per-message and the executor is the thing
+   that acts; a window-wide `bool_and` disagreed with it, so the card refused while the button would
+   have offered (`domain:intuit.com`, on real data — 04-v2-plan §2.3). The `IS TRUE` at both levels is
+   what keeps invariant 3: a NULL subscript is `NULL`, and `NULL` is not authenticated.
+4. **Every timestamp is `COALESCE(m."receivedAt", m."createdAt")` — MAIL time, not ingest time**
+   (04-v2-plan §1.2): the window bound, `first_at`/`last_at` (and therefore `historyDays`), and both
+   "newest message" orderings. `createdAt` *names* ingest time, so a backfill on it would report
+   years of history as 90 days of traffic under a card reading "34 emails in 90 days". Latent rather
+   than live today — every ingest path happens to set `createdAt` from the provider's message time
+   (`createdTime: receivedAt`), so the two columns agree on every dev row — but that is five
+   independent call sites agreeing, not a constraint. `receivedAt` is nullable, hence the coalesce
+   rather than a swap.
 
 `readerUserId` decides what "unread" means: a personal inbox passes its owner; a **shared inbox
 passes `null`**, so unread means *no member has read it*.
@@ -785,9 +799,10 @@ engine — into every importer's graph.
    tests are thorough (`mine*.test.ts`, `mutations.test.ts`, `retention.test.ts`, and seven files in
    `mail-unsubscribe/`), but the only authorization path in the feature is currently unpinned. Write
    the router test before changing anything in §10.
-4. **The mining window uses `Message.createdAt` (ingest time) while the sweep counts on
-   `receivedAt`.** For a freshly backfilled mailbox the 90-day evidence window is ingest-relative, not
-   send-relative.
+4. ~~**The mining window uses `Message.createdAt` (ingest time) while the sweep counts on
+   `receivedAt`.**~~ Closed (04-v2-plan V2/V3): the miner now windows, bounds and orders on
+   `coalesce(receivedAt, createdAt)`, and reads `senderAuthenticated` off the newest message like the
+   executor. See §5.1 items 3–4.
 
 ---
 
@@ -801,8 +816,10 @@ engine — into every importer's graph.
 3. **Never record our outbound unsubscribe as `contact:unsubscribed`** — that kind upserts an org-wide
    suppression and would silence our own mail to that address. Use `mail:unsubscribed_from`
    (`rollup: 'none'`).
-4. **`senderAuthenticated IS NULL` means "not authenticated".** In SQL that is
-   `bool_and(x IS TRUE)`; in TS it is `senderAuthenticated !== true`.
+4. **`senderAuthenticated IS NULL` means "not authenticated".** In SQL that is the `IS TRUE` on the
+   newest-message subscript (§5.1 item 3) — an out-of-range or NULL element yields `NULL`, which is
+   not a pass; in TS it is `senderAuthenticated !== true`. Only the unsubscribe *header* may fall
+   back to an older message (`findFreshestUnsubscribeMeta`); the verdict never does.
 5. **No `listId` + not authenticated ⇒ offer block/filter to spam, never unsubscribe.**
 6. **One reply ever ⇒ no suggestion for that `subjectKey`, permanently.** The most important rule in
    the feature.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -778,6 +778,12 @@
       "import": "./dist/mail-unsubscribe/index.mjs",
       "default": "./src/mail-unsubscribe/index.ts"
     },
+    "./mail-unsubscribe/client": {
+      "types": "./src/mail-unsubscribe/client.ts",
+      "source": "./src/mail-unsubscribe/client.ts",
+      "import": "./dist/mail-unsubscribe/client.mjs",
+      "default": "./src/mail-unsubscribe/client.ts"
+    },
     "./mail-views": {
       "types": "./src/mail-views/index.ts",
       "source": "./src/mail-views/index.ts",

--- a/packages/lib/src/mail-suggestions/mine-conditions.test.ts
+++ b/packages/lib/src/mail-suggestions/mine-conditions.test.ts
@@ -1,17 +1,31 @@
 // packages/lib/src/mail-suggestions/mine-conditions.test.ts
-// The two halves of the miner that only mean anything against the REAL filter
-// machinery: which condition a proposal actually prefills, and whether the
-// grouped statement really excludes filter-touched threads.
+// The parts of the miner that only mean anything against the REAL filter
+// machinery and the REAL emitted statement: which condition a proposal actually
+// prefills, whether the grouped query excludes filter-touched threads, which
+// CLOCK it windows on (04-v2-plan §1.2, V2), and how it reads
+// `senderAuthenticated` (04-v2-plan §2.3, V3).
 //
 // No module is replaced here — `mine.test.ts` stubs
 // `assertFilterConditionsCompile` because a throwing gate is what it is testing;
 // this file deliberately runs the genuine compiler, so a regression in the
 // query builder's `list` / `senderDomain` support shows up as a failing
 // preference rather than as a silently widened filter.
+//
+// Vitest has no Postgres, so the V2/V3 blocks use the same two-layer shape as
+// `mail-query/__tests__/thread-search-sql.test.ts`: rendered-SQL tests pin the
+// expression the database receives, and small TypeScript MODELS of those
+// expressions prove the behaviour that follows from them — each model asserted
+// against the rendered SQL so it cannot outlive a change to the source.
 
 import { PgDialect } from 'drizzle-orm/pg-core'
 import { describe, expect, it } from 'vitest'
-import { buildInboxGroupQuery, type MailGroupStats, resolveProposedConditions } from './mine'
+import {
+  buildInboxGroupQuery,
+  buildMailSuggestionDrafts,
+  type MailGroupStats,
+  resolveProposedConditions,
+  toMailGroupStats,
+} from './mine'
 
 function group(overrides: Partial<MailGroupStats> = {}): MailGroupStats {
   return {
@@ -128,12 +142,6 @@ describe('buildInboxGroupQuery', () => {
     expect(params).toContain('usr_owner')
   })
 
-  it('treats an unknown DMARC verdict as unauthenticated (invariant 3)', () => {
-    // `bool_and(... IS TRUE)` — a NULL column can never make the group pass.
-    const { sql } = render(null)
-    expect(sql).toContain('bool_and(m."senderAuthenticated" IS TRUE)')
-  })
-
   it('counts only inbound mail, inside the window, on unmerged threads', () => {
     const { sql, params } = render(null)
     expect(sql).toContain('m."isInbound" = true')
@@ -144,5 +152,224 @@ describe('buildInboxGroupQuery', () => {
   it('groups on the list-then-domain keyspace, never on a fused key (S7)', () => {
     const { sql } = render(null)
     expect(sql).toContain(`COALESCE('list:' || m."listId", 'domain:' || m."senderDomain")`)
+  })
+
+  // ── V2: mail time, not ingest time (04-v2-plan §1.2) ───────────────────────
+  //
+  // Vitest has no Postgres, so what is pinned here is the EXPRESSION the
+  // database receives; `MESSAGE_AT semantics` below models what Postgres then
+  // does with it, and asserts the model against this same rendered SQL so the
+  // two cannot drift apart. Together they cover the two cases that matter: a
+  // NULL `receivedAt` still counts (the fallback survives), and an old message
+  // re-ingested today does NOT (the backfill stops masquerading as recent).
+  //
+  // The second case is LATENT today — every ingest path currently sets
+  // `createdAt` from the provider's message time, so the two columns agree on
+  // every row in dev. That is exactly why it wants a test: the property is held
+  // by five unrelated call sites agreeing, not by anything enforced.
+  describe('windows on mail time, not ingest time (V2)', () => {
+    it('binds the 90-day window to COALESCE(receivedAt, createdAt)', () => {
+      const { sql } = render(null)
+      expect(sql).toContain('AND COALESCE(m."receivedAt", m."createdAt") >= ')
+    })
+
+    it('takes first_at / last_at off the same clock, so historyDays is mail time', () => {
+      const { sql } = render(null)
+      // `historyDays` and the "N emails in 90 days" copy are computed from these
+      // two. On an ingest-time clock a freshly connected mailbox would report
+      // its whole backfill as 90 days of traffic.
+      expect(sql).toContain('min(COALESCE(m."receivedAt", m."createdAt")) AS first_at')
+      expect(sql).toContain('max(COALESCE(m."receivedAt", m."createdAt")) AS last_at')
+    })
+
+    it('orders "newest message" picks on the same clock', () => {
+      const { sql } = render(null)
+      // Both the unsubscribe header and the DMARC verdict are "newest wins"
+      // reads. Ordering them on ingest time would hand back whichever message
+      // we happened to sync last.
+      const orderings = sql.match(/ORDER BY COALESCE\(m\."receivedAt", m\."createdAt"\) DESC/g)
+      expect(orderings).toHaveLength(2)
+    })
+
+    it('leaves no bare m."createdAt" anywhere in the statement', () => {
+      // The real regression guard: one un-coalesced reference re-opens V2 for
+      // whichever number it feeds.
+      const { sql } = render(null)
+      expect(sql.replace(/COALESCE\(m\."receivedAt", m\."createdAt"\)/g, '')).not.toContain(
+        'm."createdAt"'
+      )
+    })
+
+    it('never windows on receivedAt alone — the fallback is what keeps NULLs in', () => {
+      // `receivedAt` is nullable (Outlook/IMAP history). Dropping the coalesce
+      // for a bare `receivedAt >= since` would silently exclude every message
+      // that has no mail-time at all, which is the opposite failure.
+      const { sql } = render(null)
+      expect(sql).not.toMatch(/m\."receivedAt"(?!, m\."createdAt")/)
+    })
+  })
+
+  describe('MESSAGE_AT semantics — what Postgres does with that expression', () => {
+    const SINCE = new Date('2026-05-03T00:00:00.000Z')
+
+    /**
+     * COALESCE, in TypeScript. Tied to the source by the assertion below, which
+     * re-reads the rendered SQL: if the expression stops being a coalesce of
+     * those two columns in that order, this model stops being a model.
+     */
+    const messageAt = (m: { receivedAt: Date | null; createdAt: Date }): Date =>
+      m.receivedAt ?? m.createdAt
+    const inWindow = (m: { receivedAt: Date | null; createdAt: Date }) => messageAt(m) >= SINCE
+
+    it('models the expression the statement actually emits', () => {
+      expect(render(null).sql).toContain('COALESCE(m."receivedAt", m."createdAt")')
+    })
+
+    it('still counts a message with no receivedAt — the fallback holds', () => {
+      expect(inWindow({ receivedAt: null, createdAt: new Date('2026-06-01T00:00:00.000Z') })).toBe(
+        true
+      )
+    })
+
+    it('drops a two-year-old message backfilled into the org today (the V2 bug)', () => {
+      // The exact shape of a freshly connected mailbox: ingested minutes ago,
+      // received in 2024. On an ingest-time clock this clears the window and
+      // inflates `messageCount` / `historyDays` under a card claiming
+      // "in 90 days".
+      expect(
+        inWindow({
+          receivedAt: new Date('2024-03-01T00:00:00.000Z'),
+          createdAt: new Date('2026-08-01T00:00:00.000Z'),
+        })
+      ).toBe(false)
+    })
+
+    it('keeps genuinely recent mail regardless of when it was ingested', () => {
+      expect(
+        inWindow({
+          receivedAt: new Date('2026-07-30T00:00:00.000Z'),
+          createdAt: new Date('2026-08-01T00:00:00.000Z'),
+        })
+      ).toBe(true)
+    })
+  })
+
+  // ── V3: the newest message's verdict, matching the executor ────────────────
+  describe('senderAuthenticated is the newest message (V3, invariant 3)', () => {
+    it('picks the newest message per thread, not bool_and over the window', () => {
+      const { sql } = render(null)
+      // `bool_and` disagreed with `resolveUnsubscribeTarget`, which reads the
+      // gate inputs off the newest inbound message: one stale unauthenticated
+      // message made the card refuse while the button would have offered.
+      expect(sql).not.toContain('bool_and(m."senderAuthenticated" IS TRUE)')
+      expect(sql).toContain(
+        'array_agg(m."senderAuthenticated" ORDER BY COALESCE(m."receivedAt", m."createdAt") DESC)'
+      )
+    })
+
+    it('rolls the group up to the thread holding the newest message', () => {
+      const { sql } = render(null)
+      expect(sql).not.toContain('bool_and(sender_authenticated)')
+      expect(sql).toContain('array_agg(sender_authenticated ORDER BY last_at DESC)')
+    })
+
+    it('collapses a NULL verdict to false at BOTH levels (invariant 3 does not move)', () => {
+      // An array subscript over a NULL element yields NULL, and `IS TRUE` is the
+      // only thing standing between that and an unsubscribe offered to an
+      // unverified sender. Two aggregations, two guards.
+      const { sql } = render(null)
+      const guards = sql.match(/\)\[1\] IS TRUE\)/g)
+      expect(guards).toHaveLength(2)
+    })
+  })
+
+  describe('newest-message semantics, end to end into the card', () => {
+    /**
+     * `(array_agg(verdict ORDER BY at DESC))[1] IS TRUE`, in TypeScript — the
+     * same modelling contract as `MESSAGE_AT semantics` above, and the same
+     * reading `resolveUnsubscribeTarget` gets from `ORDER BY receivedAt DESC
+     * LIMIT 1`.
+     */
+    const newestVerdict = (messages: { at: string; verdict: boolean | null }[]): boolean =>
+      [...messages].sort((a, b) => b.at.localeCompare(a.at))[0]?.verdict === true
+
+    /** A DOMAIN group: no `listId`, so the gate rests on the verdict alone. */
+    const cardKindFor = (messages: { at: string; verdict: boolean | null }[]) =>
+      buildMailSuggestionDrafts({
+        organizationId: 'org_1',
+        inboxId: 'ibx_1',
+        userId: null,
+        groups: [
+          group({
+            subjectKey: 'domain:intuit.com',
+            listId: null,
+            senderDomain: 'intuit.com',
+            unsubscribeMeta: { httpUrl: 'https://intuit.com/u', oneClick: true },
+            senderAuthenticated: newestVerdict(messages),
+          }),
+        ],
+        suppressedSubjectKeys: new Set<string>(),
+      }).map((d) => d.kind)
+
+    it('does not let one stale unauthenticated message poison the group', () => {
+      // `domain:intuit.com` — the case where the old `bool_and` made the card
+      // say "unverified sender, archive instead" while the executor, reading the
+      // newest message, would have offered one-click.
+      expect(
+        cardKindFor([
+          { at: '2026-05-10', verdict: false },
+          { at: '2026-06-02', verdict: null },
+          { at: '2026-07-28', verdict: true },
+        ])
+      ).toEqual(['unsubscribe'])
+    })
+
+    it('refuses when the NEWEST message has no verdict, however clean the history', () => {
+      // Invariant 3 at the boundary the change actually moved: unknown on the
+      // newest message is NOT authenticated, even behind a wall of passes.
+      expect(
+        cardKindFor([
+          { at: '2026-05-10', verdict: true },
+          { at: '2026-06-02', verdict: true },
+          { at: '2026-07-28', verdict: null },
+        ])
+      ).toEqual(['auto-archive'])
+    })
+
+    it('refuses when the newest message failed, after older ones passed', () => {
+      expect(
+        cardKindFor([
+          { at: '2026-05-10', verdict: true },
+          { at: '2026-07-28', verdict: false },
+        ])
+      ).toEqual(['auto-archive'])
+    })
+  })
+})
+
+describe('MailGroupStats.senderAuthenticated — NULL is never a pass', () => {
+  it('reads a raw NULL verdict as false, whatever the aggregation emitted', () => {
+    // `toMailGroupStats` is the last line of defence: the column is
+    // `boolean | null` in the database and `boolean` in the type, and only
+    // `=== true` may produce the pass.
+    expect(toMailGroupStats({ subject_key: 'domain:x.com' }).senderAuthenticated).toBe(false)
+    expect(
+      toMailGroupStats({ subject_key: 'domain:x.com', sender_authenticated: null })
+        .senderAuthenticated
+    ).toBe(false)
+    expect(
+      toMailGroupStats({ subject_key: 'domain:x.com', sender_authenticated: true })
+        .senderAuthenticated
+    ).toBe(true)
+  })
+
+  it('carries first/last seen through as the mail-time bounds of the group', () => {
+    const stats = toMailGroupStats({
+      subject_key: 'list:news.acme.com',
+      first_seen_at: '2026-05-04T00:00:00.000Z',
+      last_seen_at: '2026-07-30T00:00:00.000Z',
+    })
+    expect(stats.firstSeenAt).toEqual(new Date('2026-05-04T00:00:00.000Z'))
+    expect(stats.lastSeenAt).toEqual(new Date('2026-07-30T00:00:00.000Z'))
   })
 })

--- a/packages/lib/src/mail-suggestions/mine.ts
+++ b/packages/lib/src/mail-suggestions/mine.ts
@@ -78,6 +78,44 @@ export const MAX_SUGGESTIONS_PER_INBOX = 5
 /** Groups pulled back from one inbox's statement — bounds memory, not behaviour. */
 const GROUP_SCAN_LIMIT = 200
 
+/**
+ * MAIL time, not ingest time (04-v2-plan §1.2, V2). THE clock for every window
+ * bound, every first/last timestamp and every "newest message" ordering in the
+ * grouped statement below.
+ *
+ * `Message.createdAt` NAMES ingest time, and nothing constrains it to mail
+ * time. If it ever holds one — a freshly connected mailbox whose whole backfill
+ * carries a recent `createdAt` — a 90-day window on it sweeps up years:
+ * `evidence.messageCount` and `historyDays` inflate, weak groups clear the §5.2
+ * floors on the strength of two-year-old mail, and the card then reads
+ * "34 emails in 90 days", which is false.
+ *
+ * ⚠️ Today that is LATENT, not live, and the distinction matters to anyone
+ * re-verifying this: every inbound path happens to set `createdAt` from the
+ * provider's message time rather than `now()` — `createdTime: receivedAt` in
+ * `providers/google/messages/parse-message.ts` and `email/inbound/
+ * inbound-email-processor.ts`, `const createdTime = receivedAt` in
+ * `providers/outlook`, `createdTime: sentAt` in `providers/imap` — so on dev
+ * (6392/6392 inbound rows) `createdAt` and `receivedAt` are byte-identical and
+ * this change moves nothing. It is a load-bearing coincidence across five
+ * independent call sites, held by no test and no constraint; one new ingest
+ * path defaulting `createdAt` is all it takes. The window should not depend on
+ * it.
+ *
+ * `receivedAt` is nullable (Outlook/IMAP history, and anything ingested before
+ * the column was populated), which is why `createdAt` was reached for in the
+ * first place; the coalesce keeps that fallback rather than silently dropping
+ * every message that has no mail time at all. `mail-unsubscribe/sweep.ts`
+ * already windows on `receivedAt`, so the miner and the sweep now agree about
+ * "when".
+ *
+ * Not a sargability regression: `Message` carries no index on `createdAt`
+ * either — the statement is driven by `Message_organizationId_listId_idx` /
+ * `Message_organizationId_senderDomain_idx` and the timestamp is a filter on
+ * top of that both before and after.
+ */
+const MESSAGE_AT = sql`COALESCE(m."receivedAt", m."createdAt")`
+
 // ═══════════════════════════════════════════════════════════════════════════
 // THE GROUPED QUERY (§5.1)
 // ═══════════════════════════════════════════════════════════════════════════
@@ -96,9 +134,16 @@ export interface MailGroupStats {
   /** Threads an existing filter fired on. */
   filteredThreadCount: number
   everReplied: boolean
+  /**
+   * The NEWEST message's DMARC verdict, already collapsed — the same reading
+   * `resolveUnsubscribeTarget` gates on, so the card and the button agree.
+   * `false` covers "failed" and "unknown" alike (invariant 3).
+   */
   senderAuthenticated: boolean
   unsubscribeMeta: MailUnsubscribeMeta | null
+  /** Oldest {@link MESSAGE_AT} in the window — mail time, not ingest time. */
   firstSeenAt: Date | null
+  /** Newest {@link MESSAGE_AT} in the window — mail time, not ingest time. */
   lastSeenAt: Date | null
   sampleThreadIds: string[]
   topTagId: string | null
@@ -119,7 +164,10 @@ export interface InboxGroupQueryParams {
    * anyone read this" and the only safe org-level reading is the union.
    */
   readerUserId: string | null
-  /** Oldest message that counts. Bound as a timestamp, never as day arithmetic. */
+  /**
+   * Oldest message that counts, compared against {@link MESSAGE_AT}. Bound as a
+   * timestamp, never as day arithmetic.
+   */
   since: Date
 }
 
@@ -133,7 +181,7 @@ export interface InboxGroupQueryParams {
  *   latest unsubscribeMeta, senderAuthenticated
  * ```
  *
- * Three things in here are load-bearing rather than incidental:
+ * Four things in here are load-bearing rather than incidental:
  *
  * 1. **`per_thread` collapses to ONE ROW PER THREAD before any rate is taken.**
  *    A newsletter thread with 12 messages must count once toward `threadCount`,
@@ -142,12 +190,30 @@ export interface InboxGroupQueryParams {
  * 2. **`manual_archived` excludes threads with a `MailFilterRun`** (§1.2,
  *    invariant 6). Without it the job proposes a filter to do what a filter is
  *    already doing, every week, forever.
- * 3. **`bool_and` on `senderAuthenticated`, not `bool_or`.** NULL means unknown
- *    and must read as "not authenticated" (invariant 3); requiring every message
- *    in the window to have passed is the conservative branch Outlook/IMAP
- *    history lands in until the header backfill catches up (§2.3), and the
- *    consequence — an archive suggestion instead of an unsubscribe one — is the
- *    right one.
+ * 3. **`senderAuthenticated` is the NEWEST message's verdict** — see
+ *    {@link MESSAGE_AT} for the ordering and the paragraph below for why it is
+ *    not a window-wide `bool_and`.
+ * 4. **Every timestamp is {@link MESSAGE_AT}, never bare `createdAt`.**
+ *
+ * **Why newest-message, not `bool_and` (04-v2-plan §2.3, V3).**
+ * `resolveUnsubscribeTarget` reads its gate inputs — `listId` and
+ * `senderAuthenticated` — off the NEWEST inbound message
+ * (`mail-unsubscribe/unsubscribe-queries.ts`), because §6.2 is written
+ * per-message and the executor is the thing that actually acts. The miner used
+ * to take `bool_and(senderAuthenticated IS TRUE)` across the whole window, and
+ * the two disagreed: one unauthenticated message from months ago made the CARD
+ * say "unverified sender / archive instead" while the BUTTON would have offered
+ * one-click (`domain:intuit.com`, on real data). A card that says one thing
+ * while the button does another is the same class of defect as
+ * `03-suggestions-plan.md §12.3`, so the miner adopts the executor's reading —
+ * the same shape as the newest-non-null `unsubscribeMeta` pick beside it.
+ *
+ * ⚠️ **Invariant 3 does not move.** The array subscript yields SQL `NULL` when
+ * the newest message carries no verdict, and the `IS TRUE` collapses that to
+ * `false`. Unknown is still NOT authenticated, at both levels of aggregation.
+ * Note also that only the *header* falls back to an older message
+ * (`findFreshestUnsubscribeMeta`, `03-…§12.3`) — `senderAuthenticated` never
+ * does, here or there.
  *
  * Exported so a test can read the emitted SQL: the `MailFilterRun` exclusion is
  * invisible to any assertion made on the returned rows alone.
@@ -166,10 +232,11 @@ export function buildInboxGroupQuery(params: InboxGroupQueryParams): SQL {
         m."senderDomain" AS sender_domain,
         t.id AS thread_id,
         count(*)::int AS message_count,
-        min(m."createdAt") AS first_at,
-        max(m."createdAt") AS last_at,
-        bool_and(m."senderAuthenticated" IS TRUE) AS sender_authenticated,
-        (array_agg(m."unsubscribeMeta" ORDER BY m."createdAt" DESC)
+        min(${MESSAGE_AT}) AS first_at,
+        max(${MESSAGE_AT}) AS last_at,
+        ((array_agg(m."senderAuthenticated" ORDER BY ${MESSAGE_AT} DESC))[1] IS TRUE)
+          AS sender_authenticated,
+        (array_agg(m."unsubscribeMeta" ORDER BY ${MESSAGE_AT} DESC)
            FILTER (WHERE m."unsubscribeMeta" IS NOT NULL))[1] AS unsubscribe_meta,
         (t."repliedAt" IS NOT NULL) AS ever_replied,
         (t."status" = 'ARCHIVED') AS archived,
@@ -188,7 +255,7 @@ export function buildInboxGroupQuery(params: InboxGroupQueryParams): SQL {
         AND t."inboxId" = ${inboxId}
         AND t."mergedIntoThreadId" IS NULL
         AND m."isInbound" = true
-        AND m."createdAt" >= ${since}
+        AND ${MESSAGE_AT} >= ${since}
         AND (m."listId" IS NOT NULL OR m."senderDomain" IS NOT NULL)
       GROUP BY 1, 2, 3, 4, t."repliedAt", t."status", t."assigneeId"
     ),
@@ -203,7 +270,11 @@ export function buildInboxGroupQuery(params: InboxGroupQueryParams): SQL {
         count(*) FILTER (WHERE archived AND NOT filtered)::int AS manual_archived_thread_count,
         count(*) FILTER (WHERE filtered)::int AS filtered_thread_count,
         bool_or(ever_replied) AS ever_replied,
-        bool_and(sender_authenticated) AS sender_authenticated,
+        -- The thread holding the group's newest message also holds the group's
+        -- max(last_at), so that thread's already-collapsed per-thread verdict IS
+        -- the newest message's. IS TRUE again: unknown stays unauthenticated.
+        ((array_agg(sender_authenticated ORDER BY last_at DESC))[1] IS TRUE)
+          AS sender_authenticated,
         min(first_at) AS first_seen_at,
         max(last_at) AS last_seen_at,
         (array_agg(unsubscribe_meta ORDER BY last_at DESC)
@@ -532,6 +603,10 @@ export function buildMailSuggestionDrafts(params: BuildDraftsParams): MailSugges
     // as NOT authenticated, which is why `senderAuthenticated` is a plain
     // boolean here and the SQL collapses unknown to false. A sender that
     // published no usable header is the same case — there is nothing to click.
+    //
+    // Both inputs are the NEWEST message's, matching `resolveUnsubscribeTarget`
+    // exactly (see {@link buildInboxGroupQuery}): this predicate is the card's
+    // copy of the gate the executor re-runs, and the two must not diverge.
     const unsubscribeOfferable =
       unreadRate >= UNREAD_RATE_THRESHOLD &&
       unsubscribeMethod !== null &&

--- a/packages/lib/src/mail-unsubscribe/client.test.ts
+++ b/packages/lib/src/mail-unsubscribe/client.test.ts
@@ -12,6 +12,7 @@ import {
   parseUnsubscribeMeta,
   selectUnsubscribeMethod,
   toMailSubjectKey,
+  unsubscribeRefusal,
 } from './client'
 
 const oneClickMeta = { httpUrl: 'https://list.example.com/u/abc', oneClick: true }
@@ -76,6 +77,75 @@ describe('selectUnsubscribeMethod — the safety gate (§6.2, invariants 3 & 4)'
     if (offer.offered) throw new Error('unreachable')
     expect(offer.reason).toBe('no-unsubscribe-method')
     expect(offer.alternative).toBe('block-sender')
+  })
+})
+
+describe('unsubscribeRefusal — the ONE predicate the card also renders (v2 §4.1)', () => {
+  const meta = { listId: null, senderAuthenticated: null, hasUnsubscribeMethod: true }
+
+  it('treats senderAuthenticated NULL exactly like FALSE on a domain group (invariant 3)', () => {
+    for (const senderAuthenticated of [null, false] as const) {
+      expect(unsubscribeRefusal({ ...meta, senderAuthenticated })).toMatchObject({
+        offered: false,
+        reason: 'unverified-sender',
+        alternative: 'block-sender',
+      })
+    }
+  })
+
+  it('passes on a domain group only when the sender is explicitly authenticated', () => {
+    expect(unsubscribeRefusal({ ...meta, senderAuthenticated: true })).toBeNull()
+  })
+
+  it('passes on a list-id regardless of the verdict — the list IS the identity', () => {
+    for (const senderAuthenticated of [null, false, true] as const) {
+      expect(
+        unsubscribeRefusal({ ...meta, listId: 'l.example.com', senderAuthenticated })
+      ).toBeNull()
+    }
+  })
+
+  it('refuses a verified sender that publishes no address', () => {
+    expect(
+      unsubscribeRefusal({
+        listId: 'l.example.com',
+        senderAuthenticated: true,
+        hasUnsubscribeMethod: false,
+      })
+    ).toMatchObject({ offered: false, reason: 'no-unsubscribe-method' })
+  })
+
+  it('ranks the unverified branch first — the identity question precedes the header one', () => {
+    expect(
+      unsubscribeRefusal({
+        listId: null,
+        senderAuthenticated: null,
+        hasUnsubscribeMethod: false,
+      })
+    ).toMatchObject({ reason: 'unverified-sender' })
+  })
+
+  it('is the same authority selectUnsubscribeMethod uses — identical message, every case', () => {
+    const rows = [
+      { listId: null, senderAuthenticated: null },
+      { listId: null, senderAuthenticated: false },
+      { listId: null, senderAuthenticated: true },
+      { listId: 'l.example.com', senderAuthenticated: null },
+      { listId: 'l.example.com', senderAuthenticated: true },
+    ] as const
+
+    for (const row of rows) {
+      for (const unsubscribeMeta of [oneClickMeta, httpOnlyMeta, mailtoOnlyMeta, null]) {
+        const offer = selectUnsubscribeMethod({ ...row, unsubscribeMeta })
+        const refusal = unsubscribeRefusal({
+          ...row,
+          hasUnsubscribeMethod: unsubscribeMeta !== null,
+        })
+
+        expect(offer.offered).toBe(refusal === null)
+        if (!offer.offered) expect(offer.message).toBe(refusal?.message)
+      }
+    }
   })
 })
 

--- a/packages/lib/src/mail-unsubscribe/client.ts
+++ b/packages/lib/src/mail-unsubscribe/client.ts
@@ -77,6 +77,69 @@ export type UnsubscribeOffer =
   | { offered: true; method: 'mailto'; mailto: string }
   | UnsubscribeRefusal
 
+/**
+ * What {@link unsubscribeRefusal} needs — the safety gate's inputs, with the
+ * header question reduced to "is there anything to act on at all?".
+ *
+ * The UI holds a denormalized `evidence` row rather than a `Message`, so it
+ * knows only whether a tier was found (`unsubscribeMethod !== null`), never the
+ * raw `unsubscribeMeta`. Taking the boolean is what lets both callers share one
+ * predicate instead of restating the rule.
+ */
+export interface UnsubscribeGateInput {
+  /** Normalized `list-id`, or null when the group is a domain heuristic. */
+  listId: string | null
+  /** DMARC/DKIM verdict. **NULL IS NOT A PASS** — see {@link unsubscribeRefusal}. */
+  senderAuthenticated: boolean | null
+  /** Did the mail carry a usable `List-Unsubscribe` endpoint of any tier? */
+  hasUnsubscribeMethod: boolean
+}
+
+const UNVERIFIED_SENDER_REFUSAL: UnsubscribeRefusal = {
+  offered: false,
+  reason: 'unverified-sender',
+  alternative: 'block-sender',
+  message:
+    'This sender has no mailing-list identity and is not authenticated. Unsubscribing would ' +
+    'confirm your address is live — block the sender or filter it to spam instead.',
+}
+
+const NO_UNSUBSCRIBE_METHOD_REFUSAL: UnsubscribeRefusal = {
+  offered: false,
+  reason: 'no-unsubscribe-method',
+  alternative: 'block-sender',
+  message:
+    'This sender publishes no unsubscribe address. Block the sender or filter it to spam ' +
+    'instead.',
+}
+
+/**
+ * THE refusal predicate (§6.2, invariants 3 & 4) — one implementation, shared by
+ * the server gate below and by the card that has to *explain* the refusal.
+ *
+ * **No `listId` AND not `senderAuthenticated` ⇒ never offer unsubscribe.**
+ * `senderAuthenticated === null` counts as NOT authenticated — the absence of an
+ * `authentication-results` header is not a pass, and coercing the unknown to one
+ * is how you end up POSTing to a spammer's confirmation endpoint. Note the
+ * explicit `!== true`: a truthiness test would agree with this on `boolean |
+ * null` today and diverge the moment the column carried anything else.
+ * Outlook/IMAP history legitimately lands here until the header starts arriving;
+ * the conservative branch is the correct answer for it.
+ *
+ * ⚠️ This is deliberately ONE function rather than a server rule plus a UI
+ * paraphrase. The UI's copy is explanation-only — {@link selectUnsubscribeMethod}
+ * re-runs against the freshest message on every real attempt — but a paraphrase
+ * that agrees on day one is exactly the pair that drifts silently, and the
+ * failure mode is a card promising an unsubscribe the executor will refuse.
+ *
+ * @returns the refusal to render, or `null` when the gate passes.
+ */
+export function unsubscribeRefusal(input: UnsubscribeGateInput): UnsubscribeRefusal | null {
+  if (!input.listId && input.senderAuthenticated !== true) return UNVERIFIED_SENDER_REFUSAL
+  if (!input.hasUnsubscribeMethod) return NO_UNSUBSCRIBE_METHOD_REFUSAL
+  return null
+}
+
 /** Inputs the gate + tier selection read. All four come off one `Message` row. */
 export interface UnsubscribeCandidate {
   /** Normalized `list-id`, or null when the group is a domain heuristic. */
@@ -109,12 +172,8 @@ export function parseUnsubscribeMeta(raw: unknown): UnsubscribeMeta | null {
 /**
  * THE safety gate + tier selection (§6.1, §6.2, invariants 3 & 4).
  *
- * The gate first: **no `listId` AND not `senderAuthenticated` ⇒ never offer
- * unsubscribe.** `senderAuthenticated === null` counts as NOT authenticated —
- * the absence of an `authentication-results` header is not a pass, and coercing
- * the unknown to one is how you end up POSTing to a spammer's confirmation
- * endpoint. Outlook/IMAP history legitimately lands here until the header starts
- * arriving; the conservative branch is the correct answer for it.
+ * The gate first, via {@link unsubscribeRefusal} — the same predicate the card
+ * renders its explanation from.
  *
  * Then the tier, chosen by header and never by provider:
  *
@@ -129,42 +188,21 @@ export function parseUnsubscribeMeta(raw: unknown): UnsubscribeMeta | null {
  */
 export function selectUnsubscribeMethod(candidate: UnsubscribeCandidate): UnsubscribeOffer {
   const { listId, senderAuthenticated, unsubscribeMeta } = candidate
+  const { httpUrl, mailto, oneClick } = unsubscribeMeta ?? { oneClick: false }
 
-  if (!listId && senderAuthenticated !== true) {
-    return {
-      offered: false,
-      reason: 'unverified-sender',
-      alternative: 'block-sender',
-      message:
-        'This sender has no mailing-list identity and is not authenticated. Unsubscribing would ' +
-        'confirm your address is live — block the sender or filter it to spam instead.',
-    }
-  }
+  const refusal = unsubscribeRefusal({
+    listId,
+    senderAuthenticated,
+    hasUnsubscribeMethod: Boolean(httpUrl || mailto),
+  })
+  if (refusal) return refusal
 
-  if (!unsubscribeMeta) {
-    return {
-      offered: false,
-      reason: 'no-unsubscribe-method',
-      alternative: 'block-sender',
-      message:
-        'This sender publishes no unsubscribe address. Block the sender or filter it to spam ' +
-        'instead.',
-    }
-  }
-
-  const { httpUrl, mailto, oneClick } = unsubscribeMeta
   if (oneClick && httpUrl) return { offered: true, method: 'one-click', httpUrl }
   if (httpUrl) return { offered: true, method: 'http', httpUrl }
   if (mailto) return { offered: true, method: 'mailto', mailto }
 
-  return {
-    offered: false,
-    reason: 'no-unsubscribe-method',
-    alternative: 'block-sender',
-    message:
-      'This sender publishes no unsubscribe address. Block the sender or filter it to spam ' +
-      'instead.',
-  }
+  // Unreachable: the gate above already refused a meta with neither operand.
+  return NO_UNSUBSCRIBE_METHOD_REFUSAL
 }
 
 /**

--- a/packages/lib/src/mail-unsubscribe/execute-unsubscribe.test.ts
+++ b/packages/lib/src/mail-unsubscribe/execute-unsubscribe.test.ts
@@ -17,7 +17,10 @@ vi.mock('./unsubscribe-queries', () => ({
   getMailUnsubscribe: vi.fn(),
   resolveUnsubscribeTarget: vi.fn(),
 }))
-vi.mock('./unsubscribe-mutations', () => ({ upsertMailUnsubscribe: vi.fn() }))
+vi.mock('./unsubscribe-mutations', () => ({
+  upsertMailUnsubscribe: vi.fn(),
+  setMailUnsubscribeStatus: vi.fn(),
+}))
 vi.mock('./one-click-post', () => ({ postOneClickUnsubscribe: vi.fn() }))
 vi.mock('./mailto-send', () => ({ sendMailtoUnsubscribe: vi.fn() }))
 vi.mock('../signals/record-signal', () => ({ recordSignal: vi.fn() }))
@@ -30,7 +33,7 @@ import { executeUnsubscribe } from './execute-unsubscribe'
 import { sendMailtoUnsubscribe } from './mailto-send'
 import { postOneClickUnsubscribe } from './one-click-post'
 import type { UnsubscribeTarget } from './types'
-import { upsertMailUnsubscribe } from './unsubscribe-mutations'
+import { setMailUnsubscribeStatus, upsertMailUnsubscribe } from './unsubscribe-mutations'
 import { getMailUnsubscribe, resolveUnsubscribeTarget } from './unsubscribe-queries'
 
 const db = {} as never
@@ -75,6 +78,9 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(getMailUnsubscribe).mockResolvedValue(ok(null))
   vi.mocked(upsertMailUnsubscribe).mockResolvedValue(ok(RECORD))
+  vi.mocked(setMailUnsubscribeStatus).mockImplementation(async (_db, _orgId, id, status) =>
+    ok({ ...RECORD, id, status })
+  )
   vi.mocked(postOneClickUnsubscribe).mockResolvedValue({
     accepted: true,
     status: 200,
@@ -96,7 +102,7 @@ describe('executeUnsubscribe — tiers', () => {
     const result = await executeUnsubscribe(db, INPUT)
 
     expect(result.isOk()).toBe(true)
-    expect(result._unsafeUnwrap()).toMatchObject({ status: 'requested', method: 'one-click' })
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'confirmed', method: 'one-click' })
     expect(postOneClickUnsubscribe).toHaveBeenCalledWith('https://list.example.com/u/abc')
     expect(sendMailtoUnsubscribe).not.toHaveBeenCalled()
   })
@@ -241,7 +247,109 @@ describe('executeUnsubscribe — the signal (§3, INVARIANT 2)', () => {
     const result = await executeUnsubscribe(db, INPUT)
 
     expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'confirmed' })
+  })
+})
+
+/**
+ * V1 — a rejected unsubscribe used to be recorded as a successful one.
+ *
+ * The endpoint's answer was logged at `warn` and thrown away: the row said
+ * `requested`, the card said done, and a sender answering 410 was
+ * indistinguishable from one that honored us. `setMailUnsubscribeStatus` existed
+ * for exactly this and had zero callers, so `confirmed` and `failed` were
+ * unreachable states.
+ */
+describe('executeUnsubscribe — the tier-1 verdict is recorded (V1)', () => {
+  beforeEach(() => {
+    vi.mocked(resolveUnsubscribeTarget).mockResolvedValue(ok(target()))
+  })
+
+  it('records confirmed when the endpoint accepts', async () => {
+    const result = await executeUnsubscribe(db, INPUT)
+
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'confirmed', method: 'one-click' })
+    expect(setMailUnsubscribeStatus).toHaveBeenCalledWith(db, 'org_1', 'unsub_1', 'confirmed')
+    expect(result._unsafeUnwrap()).toMatchObject({ record: { status: 'confirmed' } })
+  })
+
+  it.each([500, 403, 410])('records failed — NOT requested — on a %i', async (status) => {
+    vi.mocked(postOneClickUnsubscribe).mockResolvedValue({
+      accepted: false,
+      status,
+      finalUrl: 'https://list.example.com/u/abc',
+    })
+
+    const result = await executeUnsubscribe(db, INPUT)
+
+    const outcome = result._unsafeUnwrap()
+    expect(outcome).toMatchObject({ status: 'failed', method: 'one-click' })
+    expect(outcome.status).not.toBe('requested')
+    expect(setMailUnsubscribeStatus).toHaveBeenCalledWith(db, 'org_1', 'unsub_1', 'failed')
+  })
+
+  it('never falls back to opening the URL when the POST is rejected', async () => {
+    // A one-click POST endpoint is not necessarily a browsable confirmation
+    // page — that is exactly why tier 2 exists as a separate tier. Surface the
+    // failure; the fallback is a product question, not a silent retry.
+    vi.mocked(postOneClickUnsubscribe).mockResolvedValue({
+      accepted: false,
+      status: 500,
+      finalUrl: 'https://list.example.com/u/abc',
+    })
+
+    const result = await executeUnsubscribe(db, INPUT)
+
+    expect(result._unsafeUnwrap()).not.toHaveProperty('openUrl')
+  })
+
+  it.each([
+    ['http', { offered: true as const, method: 'http' as const, httpUrl: 'https://x.test/u' }],
+    ['mailto', { offered: true as const, method: 'mailto' as const, mailto: 'u@x.test' }],
+  ])('leaves the %s tier at requested — nothing acknowledges it', async (_name, offer) => {
+    vi.mocked(resolveUnsubscribeTarget).mockResolvedValue(ok(target({ offer })))
+
+    const result = await executeUnsubscribe(db, INPUT)
+
     expect(result._unsafeUnwrap()).toMatchObject({ status: 'requested' })
+    // No acknowledgement exists, so there is no terminal state to write.
+    expect(setMailUnsubscribeStatus).not.toHaveBeenCalled()
+  })
+
+  it('a failed status write never fails the unsubscribe — the POST already went out', async () => {
+    // Same posture as the audit write: bookkeeping must not turn a completed
+    // operation into an error the user retries. The endpoint's answer is still
+    // the truth about the attempt, so the reported status does not degrade.
+    vi.mocked(setMailUnsubscribeStatus).mockRejectedValue(new Error('db down'))
+
+    const result = await executeUnsubscribe(db, INPUT)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'confirmed', record: RECORD })
+  })
+
+  it('re-offers a previously FAILED row instead of short-circuiting it', async () => {
+    // Without this, recording `failed` would be worse than the bug it fixes: the
+    // short-circuit would dead-end the card on `already-requested` forever.
+    vi.mocked(getMailUnsubscribe).mockResolvedValue(ok({ ...RECORD, status: 'failed' }))
+
+    const result = await executeUnsubscribe(db, INPUT)
+
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'confirmed' })
+    expect(postOneClickUnsubscribe).toHaveBeenCalled()
+  })
+
+  it.each([
+    'requested',
+    'confirmed',
+    'ignored',
+  ] as const)('still short-circuits a %s row — we never ask a third party twice', async (status) => {
+    vi.mocked(getMailUnsubscribe).mockResolvedValue(ok({ ...RECORD, status }))
+
+    const result = await executeUnsubscribe(db, INPUT)
+
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'already-requested' })
+    expect(postOneClickUnsubscribe).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/lib/src/mail-unsubscribe/execute-unsubscribe.ts
+++ b/packages/lib/src/mail-unsubscribe/execute-unsubscribe.ts
@@ -3,7 +3,7 @@
 //
 // ZERO permission checks (lib-module-guide §6). The router asserts §7.1 —
 // personal inbox owned by the caller ⇒ ownership alone; shared inbox ⇒ inbox
-// write authority and DELIBERATELY NOT `automationRules.manage` — and passes
+// READ authority and DELIBERATELY NOT `automationRules.manage` — and passes
 // `isSharedInbox` in, which only drives the audit row. See
 // `./unsubscribe-authority.ts` for the predicate the router calls.
 //
@@ -16,8 +16,13 @@ import type { AuxxError } from '../errors'
 import { guard } from './guard'
 import { sendMailtoUnsubscribe } from './mailto-send'
 import { postOneClickUnsubscribe } from './one-click-post'
-import type { ExecuteUnsubscribeInput, ExecuteUnsubscribeOutcome } from './types'
-import { upsertMailUnsubscribe } from './unsubscribe-mutations'
+import type {
+  ExecuteUnsubscribeInput,
+  ExecuteUnsubscribeOutcome,
+  MailUnsubscribeRow,
+  SynchronousUnsubscribeStatus,
+} from './types'
+import { setMailUnsubscribeStatus, upsertMailUnsubscribe } from './unsubscribe-mutations'
 import { getMailUnsubscribe, resolveUnsubscribeTarget } from './unsubscribe-queries'
 import { recordUnsubscribeSignal } from './unsubscribe-signal'
 
@@ -30,7 +35,8 @@ const logger = createScopedLogger('mail-unsubscribe')
  *
  * 1. **Already unsubscribed?** Short-circuit. The unique
  *    `(organizationId, inboxId, subjectKey)` index is the race-safe floor, but
- *    checking first is what stops us POSTing a third party twice.
+ *    checking first is what stops us POSTing a third party twice. A `failed`
+ *    row is the one that does NOT short-circuit — see below.
  * 2. **Resolve the target and run the safety gate.** No `listId` and no
  *    `senderAuthenticated` ⇒ a typed REFUSAL (invariants 3 & 4), returned as an
  *    outcome rather than an error so the UI can render "block sender / filter to
@@ -41,13 +47,19 @@ const logger = createScopedLogger('mail-unsubscribe')
  *      to open in a new tab. A bare GET is usually a confirmation page, and
  *      POSTing an arbitrary URL on a user's behalf is not ours to do.
  *    - `mailto` — a real outbound send from that mailbox's own channel.
- * 4. **Record the row**, then the signal + audit.
+ * 4. **Record the row**, stamp the tier's verdict on it, then the signal + audit.
  *
- * The `MailUnsubscribe` row is written AFTER the tier runs, so a failed POST
- * leaves no record claiming we unsubscribed. The `http` tier is the exception
- * worth naming: we record it as `requested` at the moment we hand the URL over,
- * because we will never learn whether the user completed it, and a row that only
- * appears on success would never appear at all.
+ * **The returned status is what the tier actually achieved**, not a blanket "we
+ * asked". Only tier 1 gets an acknowledgement, so only tier 1 can reach a
+ * terminal state synchronously: 2xx ⇒ `confirmed`, anything else ⇒ `failed`.
+ * `http` and `mailto` have nothing that answers them and stay `requested`. A
+ * rejected POST recorded as `requested` is what made a sender answering 410
+ * indistinguishable from one that honored us.
+ *
+ * A `failed` row is deliberately RETRYABLE: the short-circuit in step 1 skips
+ * it, because we never got through, so a second attempt is a first request
+ * rather than a duplicate — the upsert's conflict branch already documents the
+ * `failed → requested` upgrade as the case worth reflecting.
  */
 export async function executeUnsubscribe(
   db: Database,
@@ -62,7 +74,11 @@ export async function executeUnsubscribe(
         input.subjectKey
       )
       if (existing.isErr()) throw existing.error
-      if (existing.value) {
+      // A `failed` row means the endpoint REFUSED us, so nothing was ever
+      // requested and re-offering is correct. Every other status did reach the
+      // sender (or is the sweep's verdict on one that did), and asking twice is
+      // what the short-circuit exists to prevent.
+      if (existing.value && existing.value.status !== 'failed') {
         return { status: 'already-requested' as const, record: existing.value }
       }
 
@@ -80,10 +96,17 @@ export async function executeUnsubscribe(
       }
 
       let openUrl: string | undefined
+      /**
+       * What the tier achieved. `requested` is the floor and the only answer
+       * tiers 2 and 3 can give: neither is acknowledged, so claiming anything
+       * stronger would be a guess.
+       */
+      let status: SynchronousUnsubscribeStatus = 'requested'
 
       switch (target.offer.method) {
         case 'one-click': {
           const posted = await postOneClickUnsubscribe(target.offer.httpUrl)
+          status = posted.accepted ? 'confirmed' : 'failed'
           if (!posted.accepted) {
             logger.warn('One-click unsubscribe endpoint rejected the request', {
               organizationId: input.organizationId,
@@ -116,6 +139,10 @@ export async function executeUnsubscribe(
         requestedByUserId: input.userId,
       })
       if (upserted.isErr()) throw upserted.error
+      const record =
+        status === 'requested'
+          ? upserted.value
+          : await stampTerminalStatus(db, input, upserted.value, status)
 
       if (target.contactEntityInstanceId) {
         await recordUnsubscribeSignal({
@@ -135,15 +162,59 @@ export async function executeUnsubscribe(
       }
 
       return {
-        status: 'requested' as const,
+        status,
         method: target.offer.method,
         ...(openUrl ? { openUrl } : {}),
-        record: upserted.value,
+        record,
       }
     },
     'executeUnsubscribe failed',
     { organizationId: input.organizationId, inboxId: input.inboxId, subjectKey: input.subjectKey }
   )
+}
+
+/**
+ * Stamp tier 1's verdict onto the row the upsert just created.
+ *
+ * **A separate write, on purpose.** The upsert is the RACE-SAFE FLOOR — the
+ * `(organizationId, inboxId, subjectKey)` uniqueness is what stops two tabs
+ * POSTing a third party twice — and it must still fail loudly when it cannot
+ * write, because a missing row is a real failure. This is BOOKKEEPING layered on
+ * an operation that already happened: the POST went out and the sender already
+ * answered. So it is best-effort, the same posture as
+ * {@link writeSharedInboxAudit} — a failed status write must not turn a
+ * completed attempt into an error the user retries.
+ *
+ * The caller still reports the real status either way. The endpoint's answer is
+ * the truth about the attempt whether or not we managed to persist it; only the
+ * returned `record` falls back to the un-stamped row.
+ */
+async function stampTerminalStatus(
+  db: Database,
+  input: ExecuteUnsubscribeInput,
+  record: MailUnsubscribeRow,
+  status: SynchronousUnsubscribeStatus
+): Promise<MailUnsubscribeRow> {
+  try {
+    const updated = await setMailUnsubscribeStatus(db, input.organizationId, record.id, status)
+    if (updated.isOk()) return updated.value
+    logger.warn('Failed to record the unsubscribe outcome', {
+      organizationId: input.organizationId,
+      inboxId: input.inboxId,
+      subjectKey: input.subjectKey,
+      status,
+      error: updated.error.message,
+    })
+  } catch (error) {
+    logger.warn('Failed to record the unsubscribe outcome', {
+      organizationId: input.organizationId,
+      inboxId: input.inboxId,
+      subjectKey: input.subjectKey,
+      status,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+  return record
 }
 
 /** `AuditLog.action` for an unsubscribe on a SHARED inbox. Ad-hoc by design —

--- a/packages/lib/src/mail-unsubscribe/index.ts
+++ b/packages/lib/src/mail-unsubscribe/index.ts
@@ -17,12 +17,14 @@ export {
   UNSUBSCRIBE_IGNORED_AFTER_DAYS,
   type UnsubscribeAlternative,
   type UnsubscribeCandidate,
+  type UnsubscribeGateInput,
   type UnsubscribeMeta,
   type UnsubscribeMethod,
   type UnsubscribeOffer,
   type UnsubscribeRefusal,
   type UnsubscribeRefusalReason,
   type UnsubscribeStatus,
+  unsubscribeRefusal,
 } from './client'
 // The three-tier executor (§6.1) + the shared-inbox audit action
 export { executeUnsubscribe, MAIL_UNSUBSCRIBE_AUDIT_ACTION } from './execute-unsubscribe'
@@ -60,6 +62,7 @@ export type {
   ExecuteUnsubscribeInput,
   ExecuteUnsubscribeOutcome,
   MailUnsubscribeRow,
+  SynchronousUnsubscribeStatus,
   UnsubscribeTarget,
 } from './types'
 export { toMailUnsubscribeRow } from './types'

--- a/packages/lib/src/mail-unsubscribe/sweep.test.ts
+++ b/packages/lib/src/mail-unsubscribe/sweep.test.ts
@@ -96,11 +96,9 @@ describe(`resolveSweepUpdate — the ${UNSUBSCRIBE_IGNORED_AFTER_DAYS}-day 'igno
     expect(update?.status).toBe('ignored')
   })
 
-  it.each([
-    'confirmed',
-    'failed',
-    'ignored',
-  ] as const)("never flips a '%s' row — only 'requested' can become ignored", (status) => {
+  it.each(['failed', 'ignored'] as const)("never flips a '%s' row", (status) => {
+    // `failed` means we never got through, so counting the sender's mail against
+    // our own failure is the wrong attribution; `ignored` is already terminal.
     const update = resolveSweepUpdate(
       row({
         status,
@@ -111,6 +109,33 @@ describe(`resolveSweepUpdate — the ${UNSUBSCRIBE_IGNORED_AFTER_DAYS}-day 'igno
     )
     expect(update?.status).toBeUndefined()
     expect(update?.messagesSeenAfter).toBe(9)
+  })
+
+  it("DOES flip a 'confirmed' row — a 2xx is a promise, not the mail stopping", () => {
+    // V1's companion rule. The one-click endpoint answering 200 is the only
+    // acknowledgement any tier gets, and RFC 8058 says nothing about when (or
+    // whether) the list actually drops the address. Letting `confirmed`
+    // short-circuit the flip would make the one tier that tells us anything the
+    // only tier we never audit.
+    const update = resolveSweepUpdate(
+      row({ status: 'confirmed', requestedAt: new Date(NOW.getTime() - 90 * DAY_MS) }),
+      { messagesSeenAfter: 9, lastSeenAfterAt: NOW },
+      NOW
+    )
+    expect(update?.status).toBe('ignored')
+    expect(update?.messagesSeenAfter).toBe(9)
+  })
+
+  it("a quiet 'confirmed' sender is never called ignored", () => {
+    // Silence past the deadline is the sender HONORING us — the flip needs BOTH
+    // the deadline and mail that actually kept arriving.
+    expect(
+      resolveSweepUpdate(
+        row({ status: 'confirmed', requestedAt: new Date(NOW.getTime() - 90 * DAY_MS) }),
+        { messagesSeenAfter: 0, lastSeenAfterAt: null },
+        NOW
+      )
+    ).toBeNull()
   })
 })
 
@@ -192,6 +217,24 @@ describe('sweepMailUnsubscribes', () => {
 
     expect(stats).toEqual({ scanned: 1, updated: 1, markedIgnored: 1 })
     expect(updates[0]).toMatchObject({ status: 'ignored', messagesSeenAfter: 6 })
+  })
+
+  it('flips a CONFIRMED sender that kept mailing — a 200 buys no exemption', async () => {
+    const { db, updates } = fakeDb(
+      [
+        row({
+          id: 'unsub_confirmed',
+          status: 'confirmed',
+          requestedAt: new Date(NOW.getTime() - 20 * DAY_MS),
+        }),
+      ],
+      [{ messagesSeenAfter: 4, lastSeenAfterAt: NOW }]
+    )
+
+    const stats = await sweepMailUnsubscribes(db, { now: NOW })
+
+    expect(stats).toEqual({ scanned: 1, updated: 1, markedIgnored: 1 })
+    expect(updates[0]).toMatchObject({ status: 'ignored', messagesSeenAfter: 4 })
   })
 
   it('skips an unparseable subject key instead of aborting the whole sweep', async () => {

--- a/packages/lib/src/mail-unsubscribe/sweep.ts
+++ b/packages/lib/src/mail-unsubscribe/sweep.ts
@@ -36,6 +36,26 @@ export interface SweepableUnsubscribe {
 const DAY_MS = 24 * 60 * 60 * 1000
 
 /**
+ * The statuses this sweep still has something to say about — both which rows it
+ * LOADS and which rows the `ignored` flip may move. One list, because those are
+ * the same question: measuring a row we would never flip is work with no answer
+ * attached.
+ *
+ * **`confirmed` is in here deliberately.** A 2xx from an RFC 8058 endpoint is
+ * the sender's *promise*, not the mail stopping — the spec says nothing about
+ * when (or whether) the list actually drops the address, and a sender that keeps
+ * mailing after answering 200 is precisely what the "Stripe ignored your
+ * unsubscribe" surface exists to catch. Letting `confirmed` short-circuit the
+ * flip would make the one tier that tells us anything the only tier we never
+ * audit.
+ *
+ * `failed` and `ignored` stay out. We never got through on a `failed` row, so
+ * counting the sender's mail against our own failure is the wrong attribution
+ * (and the executor re-offers it instead); `ignored` is already terminal.
+ */
+const SWEEPABLE_STATUSES: UnsubscribeStatus[] = ['requested', 'confirmed']
+
+/**
  * Decide what to write for one row, or `null` for "nothing changed".
  *
  * The `ignored` flip needs BOTH conditions and neither alone:
@@ -47,9 +67,8 @@ const DAY_MS = 24 * 60 * 60 * 1000
  *   is the sender HONORING us, and marking that `ignored` would be exactly
  *   backwards.
  *
- * Only `requested` flips. `confirmed` means the endpoint told us it worked and
- * `failed` means we never got through — neither is a claim the sender ignored
- * us — and `ignored` is already terminal.
+ * Which rows may flip at all is {@link SWEEPABLE_STATUSES} — `requested` AND
+ * `confirmed`, for the reason recorded there.
  *
  * Returns `null` when nothing moved, so the job writes only rows that changed
  * rather than touching every row every night.
@@ -61,7 +80,8 @@ export function resolveSweepUpdate(
 ): { messagesSeenAfter: number; lastSeenAfterAt: Date | null; status?: UnsubscribeStatus } | null {
   const pastDeadline =
     now.getTime() - row.requestedAt.getTime() >= UNSUBSCRIBE_IGNORED_AFTER_DAYS * DAY_MS
-  const shouldFlip = row.status === 'requested' && pastDeadline && observation.messagesSeenAfter > 0
+  const shouldFlip =
+    SWEEPABLE_STATUSES.includes(row.status) && pastDeadline && observation.messagesSeenAfter > 0
 
   const countChanged = observation.messagesSeenAfter !== row.messagesSeenAfter
   const seenChanged =
@@ -117,15 +137,6 @@ export async function countMessagesSinceUnsubscribe(
 /** Rows loaded per pass — bounds memory and keeps each write short. */
 export const UNSUBSCRIBE_SWEEP_BATCH = 500
 
-/**
- * Statuses still worth measuring.
- *
- * `ignored` is terminal (we already concluded they don't honor it) and `failed`
- * means the request never got through — counting THEIR mail against OUR failure
- * would be the wrong attribution.
- */
-const OPEN_STATUSES: UnsubscribeStatus[] = ['requested', 'confirmed']
-
 export interface SweepMailUnsubscribesStats {
   scanned: number
   updated: number
@@ -177,7 +188,7 @@ export async function sweepMailUnsubscribes(
       .from(schema.MailUnsubscribe)
       .where(
         and(
-          inArray(schema.MailUnsubscribe.status, OPEN_STATUSES),
+          inArray(schema.MailUnsubscribe.status, SWEEPABLE_STATUSES),
           ...(cursor ? [gt(schema.MailUnsubscribe.id, cursor)] : [])
         )
       )

--- a/packages/lib/src/mail-unsubscribe/types.ts
+++ b/packages/lib/src/mail-unsubscribe/types.ts
@@ -97,6 +97,18 @@ export interface ExecuteUnsubscribeInput {
 }
 
 /**
+ * The statuses one attempt can reach SYNCHRONOUSLY.
+ *
+ * `ignored` is deliberately absent: only the sweep job can conclude a sender
+ * ignored us, and it needs {@link import('./client').UNSUBSCRIBE_IGNORED_AFTER_DAYS}
+ * days of subsequent mail to say so (§6.4).
+ */
+export type SynchronousUnsubscribeStatus = Extract<
+  UnsubscribeStatus,
+  'requested' | 'confirmed' | 'failed'
+>
+
+/**
  * The outcome of an unsubscribe attempt.
  *
  * `refused` is an OUTCOME, not an error: the UI renders the alternative
@@ -107,11 +119,29 @@ export type ExecuteUnsubscribeOutcome =
   /** Already unsubscribed from this list in this inbox — never twice (§6.4). */
   | { status: 'already-requested'; record: MailUnsubscribeRow }
   | {
-      status: 'requested'
+      /**
+       * What the tier ACTUALLY achieved — never a blanket "we asked":
+       *
+       * - `confirmed` — the RFC 8058 endpoint answered 2xx. **Tier 1 only.**
+       * - `failed` — it answered something else. 500 / 403 / 410 are all real
+       *   answers from real senders, and reporting them as `requested` is what
+       *   made a refusal indistinguishable from a success. **Tier 1 only.**
+       * - `requested` — `http` and `mailto`, which carry NO acknowledgement:
+       *   nobody tells us whether the user finished the sender's page or whether
+       *   the list processed our mail, so this is the only honest answer and the
+       *   14-day sweep is what eventually resolves it.
+       *
+       * ⚠️ `confirmed` is not proof the mail stops — it is the sender's promise.
+       * The sweep still measures it; see `sweep.ts`'s `SWEEPABLE_STATUSES`.
+       */
+      status: SynchronousUnsubscribeStatus
       method: UnsubscribeMethod
       /**
        * ONLY set for the `http` tier: the URL the CLIENT must open in a new
-       * tab. We never POST a URL without the RFC 8058 one-click header.
+       * tab. We never POST a URL without the RFC 8058 one-click header, and we
+       * deliberately do NOT fall back to it when a one-click POST is rejected —
+       * a one-click endpoint is not necessarily a browsable confirmation page,
+       * which is exactly why tier 2 exists as its own tier.
        */
       openUrl?: string
       record: MailUnsubscribeRow

--- a/packages/lib/src/mail-unsubscribe/unsubscribe-authority.test.ts
+++ b/packages/lib/src/mail-unsubscribe/unsubscribe-authority.test.ts
@@ -1,19 +1,40 @@
 // packages/lib/src/mail-unsubscribe/unsubscribe-authority.test.ts
-// The §7.1 divergence, pinned: unsubscribe needs INBOX WRITE and nothing else.
+// The §7.1 divergence, pinned: unsubscribe needs INBOX READ and nothing else.
 // If someone ever reintroduces an `automationRules.manage` requirement here,
 // these tests are what fail — the whole point of §7.1 is that stopping a
 // newsletter must not be gated on admin rank (mail guide / filters invariant 7).
+//
+// The rung itself is pinned by `readsAtRung` below, which walks the real mail
+// ladder (`none < metadata < identity < read < admin`, no `edit` — that omission
+// is deliberate, see `instance-access.ts`). v2 plan §2.1 / user decision
+// 2026-08-10 moved this gate from the `edit` threshold — which on that sparse
+// ladder resolves to `admin` and made unsubscribe exactly as strict as authoring
+// a standing filter — down to `read`, where mail already puts reply and assign.
 
 import { describe, expect, it } from 'vitest'
 import {
   assertCanUnsubscribe,
   canUnsubscribeOnInbox,
   isSharedInbox,
+  type UnsubscribeAuthorityCapabilities,
   type UnsubscribeInbox,
 } from './unsubscribe-authority'
 
-const writesToNothing = { canEditInstance: () => false }
-const writesToEverything = { canEditInstance: () => true }
+const writesToNothing = { canViewInstance: () => false }
+const writesToEverything = { canViewInstance: () => true }
+
+/** The mail ladder, ascending. `edit` is absent ON PURPOSE — `instance-access.ts`. */
+const INBOX_RUNGS = ['none', 'metadata', 'identity', 'read', 'admin'] as const
+type InboxRung = (typeof INBOX_RUNGS)[number]
+
+/**
+ * A member composing exactly `rung` on every inbox, as the real `CapabilitySet`
+ * would answer: `canViewInstance` is the `>= read` threshold.
+ */
+function readsAtRung(rung: InboxRung): UnsubscribeAuthorityCapabilities {
+  const satisfiesRead = INBOX_RUNGS.indexOf(rung) >= INBOX_RUNGS.indexOf('read')
+  return { canViewInstance: () => satisfiesRead }
+}
 
 const personal: UnsubscribeInbox = {
   id: 'ibx_personal',
@@ -50,17 +71,17 @@ describe('personal inbox — ownership alone, no key', () => {
   })
 })
 
-describe('shared inbox — inbox write authority, and NOTHING else', () => {
-  it('allows a member with inbox write, holding no automation grant', () => {
+describe('shared inbox — inbox READ authority, and NOTHING else', () => {
+  it('allows a member with inbox read, holding no automation grant', () => {
     expect(canUnsubscribeOnInbox(shared, 'usr_1', writesToEverything)).toBe(true)
   })
 
-  it('denies a member without inbox write', () => {
+  it('denies a member without inbox read', () => {
     expect(canUnsubscribeOnInbox(shared, 'usr_1', writesToNothing)).toBe(false)
   })
 
-  it('asks about THIS inbox, not inbox write in general', () => {
-    const capabilities = { canEditInstance: (_key: 'inbox', id: string) => id === 'ibx_other' }
+  it('asks about THIS inbox, not inbox read in general', () => {
+    const capabilities = { canViewInstance: (_key: 'inbox', id: string) => id === 'ibx_other' }
     expect(canUnsubscribeOnInbox(shared, 'usr_1', capabilities)).toBe(false)
   })
 
@@ -69,6 +90,33 @@ describe('shared inbox — inbox write authority, and NOTHING else', () => {
       /permission to unsubscribe/
     )
     expect(() => assertCanUnsubscribe(shared, 'usr_1', writesToEverything)).not.toThrow()
+  })
+})
+
+describe('shared inbox — the rung is READ, not admin (v2 §2.1)', () => {
+  it.each(['read', 'admin'] as const)('allows a member composing %s', (rung) => {
+    expect(canUnsubscribeOnInbox(shared, 'usr_1', readsAtRung(rung))).toBe(true)
+  })
+
+  it.each(['none', 'metadata', 'identity'] as const)('denies a member composing %s', (rung) => {
+    expect(canUnsubscribeOnInbox(shared, 'usr_1', readsAtRung(rung))).toBe(false)
+  })
+
+  it('does NOT require admin — a plain reader may stop a newsletter', () => {
+    // The regression this guards: asking the `edit` threshold on a ladder with no
+    // `edit` rung silently resolves to `admin`, collapsing §7.1's deliberately
+    // LOOSER gate into the strict half of the filter-authoring one.
+    expect(canUnsubscribeOnInbox(shared, 'usr_1', readsAtRung('read'))).toBe(true)
+    expect(() => assertCanUnsubscribe(shared, 'usr_1', readsAtRung('read'))).not.toThrow()
+  })
+
+  it("a reader still cannot touch another member's personal mailbox", () => {
+    // Loosening the SHARED branch must not reach across the personal one: that
+    // branch keys on the inbox DEFINITION and never consults a capability at all.
+    expect(canUnsubscribeOnInbox(personal, 'usr_other', readsAtRung('admin'))).toBe(false)
+    expect(() => assertCanUnsubscribe(personal, 'usr_other', readsAtRung('read'))).toThrow(
+      /permission to unsubscribe/
+    )
   })
 })
 

--- a/packages/lib/src/mail-unsubscribe/unsubscribe-authority.ts
+++ b/packages/lib/src/mail-unsubscribe/unsubscribe-authority.ts
@@ -23,9 +23,14 @@ import { ForbiddenError } from '../errors'
  *
  * Declared as a METHOD, so a real `CapabilitySet` whose signature takes the wide
  * `InstanceAccessKey` union stays assignable.
+ *
+ * `canViewInstance` is the **`read` threshold**, which is the rung this gate
+ * wants — see {@link canUnsubscribeOnInbox}. Naming the threshold rather than
+ * the rung is deliberate: if the mail ladder ever gains a tier between
+ * `identity` and `read`, the gate moves with it instead of quietly staying put.
  */
 export interface UnsubscribeAuthorityCapabilities {
-  canEditInstance(key: 'inbox', instanceId: string): boolean
+  canViewInstance(key: 'inbox', instanceId: string): boolean
 }
 
 /**
@@ -46,14 +51,14 @@ export interface UnsubscribeInbox {
  *
  * ```
  *   personal_inbox owned by the caller  →  allowed. NO permission key.
- *   shared inbox (`inbox` def)          →  inbox write authority, and NOTHING else.
+ *   shared inbox (`inbox` def)          →  inbox READ, and NOTHING else.
  * ```
  *
- * **This deliberately diverges from the filter-authoring gate**, which also
- * requires `automationRules.manage`. Unsubscribing is a mail operation, not an
- * automation one; requiring an automation grant to stop a newsletter would gate
- * mail on admin rank, which the mail guide forbids (filters-plan invariant 7).
- * Per-inbox authority is the whole model here.
+ * **This deliberately diverges from the filter-authoring gate**, which requires
+ * `automationRules.manage` AND inbox `admin`. Unsubscribing is a mail operation,
+ * not an automation one; requiring an automation grant to stop a newsletter
+ * would gate mail on admin rank, which the mail guide forbids (filters-plan
+ * invariant 7). Per-inbox authority is the whole model here.
  *
  * The personal branch keys on the inbox's DEFINITION — def membership is the
  * unforgeable half of the mail model. The legacy `isPersonal` marker is honored
@@ -61,14 +66,21 @@ export interface UnsubscribeInbox {
  * `canAuthorOnInbox` in `mail-filter-authoring-access.ts`: personal-ness can be
  * self-declared into a stricter rule, never forged into a laxer one.
  *
- * ⚠️ **Known wrinkle, stated as the threshold rather than the rung.** The mail
- * vocabulary is sparse: `INSTANCE_ACCESS_RESOURCES.inbox` declares
- * `none < metadata < identity < read < admin` with NO `edit` rung, and
- * `canEditInstance` asks for `>= edit` on the ordinal ladder — so on an inbox
- * today the only rung that satisfies it is `admin`. That is stricter than §7.1
- * intends. Writing `canAdminInstance` here would hard-code the coincidence; this
- * way, inserting an `edit` rung into the mail ladder MOVES this gate instead of
- * silently leaving it at admin.
+ * ⚠️ **Why `read`, and why it is written as a threshold** (v2 plan §2.1, user
+ * decision 2026-08-10). `INSTANCE_ACCESS_RESOURCES.inbox` declares
+ * `none < metadata < identity < read < admin` with **no `edit` rung, on purpose**
+ * — mail's `read` already confers acting (reply, assign), so the only tier above
+ * it is managing the mailbox itself. This gate previously asked
+ * `canEditInstance`, which on that sparse ladder resolves to `admin` and made
+ * unsubscribe exactly as strict as authoring a standing filter; §7.1 designed it
+ * as the LOOSER of the two, and the divergence had silently collapsed. A
+ * one-shot command against a list is acting on mail, so it sits with reply and
+ * assign at `read`. Authoring is unchanged: an unattended standing mutation is a
+ * different kind of act.
+ *
+ * It stays a THRESHOLD (`canViewInstance`, i.e. `>= read`) rather than a literal
+ * rung comparison, so a later insertion into the mail ladder moves this gate
+ * with it instead of leaving it pinned to a name.
  */
 export function canUnsubscribeOnInbox(
   inbox: UnsubscribeInbox,
@@ -78,7 +90,7 @@ export function canUnsubscribeOnInbox(
   if (inbox.entityDefinitionKey === 'personal_inbox') return inbox.ownerUserId === userId
   if (inbox.isPersonal) return inbox.ownerUserId === userId
 
-  return capabilities.canEditInstance('inbox', inbox.id)
+  return capabilities.canViewInstance('inbox', inbox.id)
 }
 
 /**

--- a/packages/lib/src/mail-unsubscribe/unsubscribe-queries.ts
+++ b/packages/lib/src/mail-unsubscribe/unsubscribe-queries.ts
@@ -3,7 +3,7 @@
 // Functional Drizzle + neverthrow — no service class (docs/lib-module-guide.md).
 //
 // ZERO permission checks by design (lib-module-guide §6): the router asserts the
-// §7.1 branch (own personal inbox ⇒ ownership alone; shared inbox ⇒ inbox write
+// §7.1 branch (own personal inbox ⇒ ownership alone; shared inbox ⇒ inbox READ
 // authority, and NOT `automationRules.manage`) and hands the allowed inbox ids
 // down as `opts.inboxIds`, which this module turns into a WHERE fragment. A
 // post-read `.filter()` would leak counts even where it hides content.


### PR DESCRIPTION
Seven items from the mail filters / suggestions v2 triage (`plans/mail-filter/04-v2-plan.md`, items V1 V2 V3 V4 V6 V13 V17). Each was either a verified defect in the code shipped by #1509 / #1510, or a decision those plans left open.

## The three that were wrong for users today

**V1 — a rejected unsubscribe was recorded as a successful one.** The one-click branch logged a warning on a 500/403/410 and fell through to `requested`, so a sender that refused looked identical to one that honored the request. `setMailUnsubscribeStatus` already existed with zero callers. Now stamps `confirmed`/`failed`, best-effort so bookkeeping can never fail an operation that already happened. `http`/`mailto` stay `requested` — those tiers have no acknowledgement.

Two knock-ons the triage did not anticipate:
- The step-1 short-circuit now skips a `failed` row. Without it, recording `failed` dead-ends the card on `already-requested` **forever** — strictly worse than the bug being fixed.
- The sweep's `ignored` flip now covers `confirmed` as well as `requested`. The old flip was justified by a comment about an unreachable state; once `confirmed` exists that reasoning inverts, because a sender that ACKed the POST and kept mailing for 14+ days is the *strongest* "they ignored you" signal there is. As written, the acknowledging sender would escape detection while the silent one got flagged.

Deliberately **not** done: no tier-2 URL fallback on failure. A one-click POST endpoint is not necessarily a browsable confirmation page — that is why tier 2 is a separate tier. The reason is in the code so it is not re-proposed.

**V4 — shared-inbox unsubscribe resolved to inbox `admin`.** It gated on `canEditInstance`, which lands on `admin` because `INBOX_RUNGS` deliberately has no `edit` rung ("mail's `read` already confers acting"). That collapsed the divergence `03-…§7.1` wanted, where unsubscribe is the *looser* gate. Now `canViewInstance` (`>= read`), still written as a threshold so a future ladder change moves the gate rather than leaving it stranded. **Filter authoring is unchanged** (`automationRules.manage` + `admin`).

**V6 — an existence oracle on the filter write paths.** They 403'd on another member's personal filter while the read paths 404'd. Now three-way:

| Case | Status |
|---|---|
| Another member's **personal** filter | 404, message byte-identical to a genuine miss |
| **Shared** filter the caller may not author | 403 — the inbox is visible org inventory |
| Nonexistent id | 404 |

Personal-ness is excluded by **both** the def and the legacy `isPersonal` marker, so a mailbox still sitting on the shared def during the 059→060 migration window is not disclosed by a def-only check.

## The rest

**V2** — miner windowed on `Message.createdAt`, sweep on `receivedAt`; both now `coalesce(receivedAt, createdAt)`. This is **latent, not live**: every inbound path already sets `createdTime` from provider mail time (dev: 6392 inbound rows, 0 NULL `receivedAt`, 0 diverging, max delta 0.000s). Worth keeping because that property is held by five independent call sites happening to agree, with no test or constraint behind it, and the column default is `now()`.

**V3** — the miner used `bool_and(senderAuthenticated)` over the window while the executor read the newest message, so a card could refuse an unsubscribe the button would have performed. Miner adopts newest-message. Five groups flip org-wide; three only get more accurate refusal wording (no `List-Unsubscribe` at all), but **`shopify.com` (45 msgs) and `intuit.com` (12 msgs) move from refused to offered**. Invariant 3 is untouched — NULL on the newest message still refuses.

**V13** — the unsubscribe refusal rule had two implementations: the server gate and a hand-restated copy in the card. The gate is split so its refusal half takes what the denormalized `evidence` row actually carries, exposed through a generated `./mail-unsubscribe/client` subpath. The `package.json` change is generator output (`check:exports` clean), not hand-written.

**V17** — the retroactive prompt now explains why "N emails in 90 days" sits above "matches M conversations". Half-done: the card's own evidence line still does not signal it is a sample. Follow-up.

## Two things worth a reviewer's opinion

1. **V4 widened visibility, not just the button.** `dismiss` shares the same predicate, and `loadMailSuggestionScope` scopes on it — so shared-inbox suggestion cards are now visible to any inbox **reader**, where before they needed admin. Coherent (a reader can answer every prompt the card offers) but broader than the decision that was taken. Easy to pin back.
2. **A failed unsubscribe still writes the success-shaped trace.** The `mail:unsubscribed_from` signal and the shared-inbox audit fire even when the POST was refused. The attempt did happen and the audit is about the actor, but on a contact timeline it reads as success.

## Follow-ups recorded, not fixed

- **V3b** — `resolveUnsubscribeTarget` orders `desc(receivedAt), desc(createdAt)`; Postgres `DESC` is NULLS FIRST, so a NULL `receivedAt` sorts as "newest" for the executor while the miner's `COALESCE` reads it as `createdAt`. Unreachable today, but it is the same miner/executor disagreement V3 just closed, one level down.
- **V6b** — `create`, `previewMatchCount`, `reorder`, `dismissRetroactivePrompt` and the `move-inbox` destination still 403 on another member's personal-inbox CUID, disclosing the *inbox* rather than the filter.
- **V2 does not explain the `03-…§12.6` preview-count convergence** after all — the miner's window was already mail-time-correct on that data, so that remains open.

## Verification

| | |
|---|---|
| `packages/lib` | **311 tests passed** / 22 files |
| `apps/web` | **136 tests passed** / 4 files |
| `packages/lib` typecheck | 29 errors — baseline unchanged, all in `scripts/`, none naming a touched file |
| `apps/web` typecheck | 16 errors — baseline unchanged, none naming `mail-*` |
| `pnpm -F @auxx/lib check:exports` | clean, 226 entries |

Denial tests assert `cause.statusCode` and message, not just that the call rejected — a 403-that-should-be-404 survives anything weaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)