### PR TITLE
fix: enforce org suspension in web app, honor planName on trial conversion

### DIFF
--- a/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
@@ -16,6 +16,7 @@ import { FloatingComposeRoot } from '~/components/mail/email-editor/floating-com
 import { GlobalRecordEditorRoot } from '~/components/records/global-record-editor-root'
 import { SignatureDialogRoot } from '~/components/signatures/ui/signature-dialog-root'
 import { SnippetDialogRoot } from '~/components/snippets/ui/snippet-dialog-root'
+import { OrganizationDisabled } from '~/components/subscriptions/organization-disabled'
 import { SubscriptionEnded } from '~/components/subscriptions/subscription-ended'
 import { FloatingTaskEditorRoot } from '~/components/tasks/ui/floating-task-editor-root'
 import { FloatingTaskRoot } from '~/components/tasks/ui/floating-task-root'
@@ -69,6 +70,23 @@ export function AppLayoutWrapper({
   useOAuthReturn()
 
   const currentOrg = organizations.find((org) => org.id === currentOrgId)
+
+  // Admin suspension outranks every billing state — it applies on self-hosted too,
+  // since it is an operator action rather than a plan gate. Super admins are exempt
+  // here for the same reason `protectedProcedure` exempts them: their own default org
+  // may be the suspended one, and the admin panel is how it gets re-enabled.
+  // The server-side gate in `~/server/api/trpc` is what actually enforces this.
+  if (currentOrg?.disabledAt && user?.isSuperAdmin !== true) {
+    return (
+      <SimpleLayout>
+        <OrganizationDisabled
+          organizationName={currentOrg.name}
+          disabledReason={currentOrg.disabledReason}
+          otherOrganizationsCount={organizations.length - 1}
+        />
+      </SimpleLayout>
+    )
+  }
 
   // Self-hosted deployments skip subscription checks entirely
   const subscriptionExpired = !selfHosted && isSubscriptionExpired(currentOrg?.subscription ?? null)

--- a/apps/web/src/app/admin/organizations/[id]/_components/trial-management-section.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/_components/trial-management-section.tsx
@@ -11,6 +11,13 @@ import { Button } from '@auxx/ui/components/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
 import { Input } from '@auxx/ui/components/input'
 import { Label } from '@auxx/ui/components/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { addDays, format } from 'date-fns'
@@ -18,6 +25,9 @@ import { AlertTriangle, Calendar, CheckCircle, Clock } from 'lucide-react'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
+
+/** Sentinel for "don't change the plan" — Radix `SelectItem` rejects an empty value. */
+const KEEP_CURRENT_PLAN = '__keep_current__'
 
 interface TrialManagementSectionProps {
   organizationId: string
@@ -41,7 +51,11 @@ export function TrialManagementSection({
   const [confirm, ConfirmDialog] = useConfirm()
   const [extendDays, setExtendDays] = useState('7')
   const [reason, setReason] = useState('')
+  /** `KEEP_CURRENT_PLAN` = convert in place; anything else also moves them to that plan. */
+  const [convertPlan, setConvertPlan] = useState(KEEP_CURRENT_PLAN)
   const utils = api.useUtils()
+
+  const plansQuery = api.admin.getPlans.useQuery()
 
   const endTrial = api.admin.billing.endTrial.useMutation({
     onSuccess: () => {
@@ -112,9 +126,13 @@ export function TrialManagementSection({
    * Handle convert trial to paid
    */
   const handleConvertToPaid = async () => {
+    const planName = convertPlan === KEEP_CURRENT_PLAN ? undefined : convertPlan
+
     const confirmed = await confirm({
       title: 'Convert Trial to Paid?',
-      description: `This will convert "${organizationName}" from trial to paid status without requiring payment. Use this for special cases or manual conversions.`,
+      description: planName
+        ? `This will convert "${organizationName}" from trial to paid status on the "${planName}" plan, without requiring payment.`
+        : `This will convert "${organizationName}" from trial to paid status without requiring payment, keeping their current plan. Use this for special cases or manual conversions.`,
       confirmText: 'Convert to Paid',
       cancelText: 'Cancel',
     })
@@ -122,6 +140,7 @@ export function TrialManagementSection({
     if (confirmed) {
       convertTrial.mutate({
         organizationId,
+        planName,
         skipPayment: true,
       })
     }
@@ -274,6 +293,25 @@ export function TrialManagementSection({
                       ? 'Restore access on the full plan without payment (admin override)'
                       : 'Manually convert trial to paid without payment (admin override)'}
                   </p>
+                  <div>
+                    <Label htmlFor='convert-plan'>Plan</Label>
+                    <Select value={convertPlan} onValueChange={setConvertPlan}>
+                      <SelectTrigger id='convert-plan'>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={KEEP_CURRENT_PLAN}>Keep current plan</SelectItem>
+                        {plansQuery.data?.map((plan) => (
+                          <SelectItem key={plan.id} value={plan.name}>
+                            {plan.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className='text-xs text-muted-foreground mt-1'>
+                      Picking a plan moves them to it as part of the conversion.
+                    </p>
+                  </div>
                   <Button
                     variant='outline'
                     size='sm'

--- a/apps/web/src/components/subscriptions/organization-disabled.tsx
+++ b/apps/web/src/components/subscriptions/organization-disabled.tsx
@@ -1,0 +1,70 @@
+// apps/web/src/components/subscriptions/organization-disabled.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
+import { Ban } from 'lucide-react'
+import Link from 'next/link'
+
+/** Props for OrganizationDisabled component */
+interface OrganizationDisabledProps {
+  /** Optional organization name for personalization */
+  organizationName?: string | null
+  /** Admin-supplied reason for the suspension */
+  disabledReason?: string | null
+  /** Number of other organizations the user has access to */
+  otherOrganizationsCount?: number
+}
+
+/**
+ * Shown when an organization has been suspended by a super admin
+ * (`Organization.disabledAt`). Distinct from `SubscriptionEnded` — there is no
+ * self-service path out of a suspension, so this offers support, not checkout.
+ */
+export function OrganizationDisabled({
+  organizationName,
+  disabledReason,
+  otherOrganizationsCount = 0,
+}: OrganizationDisabledProps) {
+  return (
+    <div className='flex items-center justify-center flex-1 min-h-0 h-full'>
+      <div className='flex w-full max-w-sm flex-col items-center space-y-5 px-6 mx-auto'>
+        <Card
+          variant='translucent'
+          className='w-full max-w-md shadow-md shadow-black/20 border-transparent'>
+          <CardHeader className='text-center'>
+            <div className='mx-auto mb-5 size-14 border flex items-center justify-center rounded-2xl bg-muted text-bad-500'>
+              <Ban className='size-8' />
+            </div>
+            <CardTitle>
+              {organizationName
+                ? `${organizationName} is suspended`
+                : 'This workspace is suspended'}
+            </CardTitle>
+            <CardDescription>
+              Access has been suspended by Auxx. Contact support to resolve this.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-3'>
+            {disabledReason && (
+              <div className='rounded-lg border bg-muted/50 p-3 text-sm'>
+                <div className='font-medium mb-1'>Reason</div>
+                <div className='text-muted-foreground'>{disabledReason}</div>
+              </div>
+            )}
+            <Button asChild className='w-full'>
+              <a href='mailto:support@auxx.ai' target='_blank' rel='noopener noreferrer'>
+                Contact support
+              </a>
+            </Button>
+            {otherOrganizationsCount > 0 && (
+              <Button asChild variant='translucent' className='w-full'>
+                <Link href='/organizations'>Switch workspace</Link>
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -329,6 +329,34 @@ const mutationRateLimitMiddleware = t.middleware(async ({ ctx, next, type }) => 
 })
 
 /**
+ * Blocks every member of an admin-suspended organization (`Organization.disabledAt`).
+ *
+ * `apps/api` has enforced this since the column shipped (`verifyOrganizationAccess`,
+ * `verifyOrgMembership`), but nothing in `apps/web` ever read it — so "Disable
+ * Organization" in the admin panel suspended the REST API while leaving the whole
+ * Next.js app usable. This is the authoritative half of the fix; the
+ * `AppLayoutWrapper` screen is only the presentation of it.
+ *
+ * Super admins are exempt: their own `defaultOrganizationId` may well be a
+ * suspended org, and locking them out of tRPC would lock them out of the very
+ * admin panel that re-enables it.
+ */
+const organizationDisabledMiddleware = t.middleware(async ({ ctx, next }) => {
+  const session = ctx.session as { organizationId: string; isSuperAdmin: boolean } | null
+  if (!session || session.isSuperAdmin) return next()
+
+  const { orgProfile } = await getOrgCache().getOrRecompute(session.organizationId, ['orgProfile'])
+  if (orgProfile?.disabledAt) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: orgProfile.disabledReason || 'This organization has been disabled',
+    })
+  }
+
+  return next()
+})
+
+/**
  * Public (unauthenticated) procedure
  *
  * This is the base piece you use to build new queries and mutations on your tRPC API. It does not
@@ -373,6 +401,9 @@ export const protectedProcedure = t.procedure
       },
     })
   })
+  // Chained AFTER the session enrichment above — it reads `organizationId` and
+  // `isSuperAdmin`, which only exist once that middleware has run.
+  .use(organizationDisabledMiddleware)
 /**
  * Owner procedure — genuinely rank-shaped actions ONLY (plan 21 §2.b.4):
  * delete the organization, transfer ownership, manage Owner roles. Everything

--- a/packages/billing/src/services/__tests__/admin-billing-service.test.ts
+++ b/packages/billing/src/services/__tests__/admin-billing-service.test.ts
@@ -1,0 +1,117 @@
+// packages/billing/src/services/__tests__/admin-billing-service.test.ts
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import type { PlanChangeHandler } from '../../types'
+import { AdminBillingService } from '../admin-billing-service'
+
+vi.mock('@auxx/database', () => ({
+  schema: { PlanSubscription: { id: 'id' } },
+  AuditLog: 'AuditLog',
+  toAuditRow: (row: unknown) => row,
+}))
+
+vi.mock('drizzle-orm', () => ({ eq: (a: unknown, b: unknown) => ({ a, b }) }))
+
+const TRIAL_SUBSCRIPTION = {
+  id: 'sub_1',
+  status: 'trialing',
+  plan: 'Free',
+  planId: 'plan_free',
+  trialConversionStatus: null,
+}
+
+const PLANS = [
+  { id: 'plan_free', name: 'Free', isLegacy: false },
+  { id: 'plan_growth', name: 'Growth', isLegacy: false },
+]
+
+/** Captures the `.set()` payload of the single subscription UPDATE the service issues. */
+function createMockDb() {
+  const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+  return {
+    db: {
+      query: {
+        PlanSubscription: { findFirst: vi.fn().mockResolvedValue(TRIAL_SUBSCRIPTION) },
+        Plan: { findMany: vi.fn().mockResolvedValue(PLANS) },
+      },
+      update: vi.fn().mockReturnValue({ set: setSpy }),
+      insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+    } as unknown as Database,
+    setSpy,
+  }
+}
+
+describe('AdminBillingService.convertTrialToPaid', () => {
+  let onPlanChange: Mock<PlanChangeHandler>
+
+  beforeEach(() => {
+    onPlanChange = vi.fn<PlanChangeHandler>().mockResolvedValue(undefined)
+  })
+
+  it('keeps the current plan when no planName is given', async () => {
+    const { db, setSpy } = createMockDb()
+    const service = new AdminBillingService(db, 'https://app.test', onPlanChange)
+
+    await service.convertTrialToPaid({
+      organizationId: 'org_1',
+      skipPayment: true,
+      adminUserId: 'admin_1',
+    })
+
+    const update = setSpy.mock.calls[0]![0]
+    expect(update.status).toBe('active')
+    expect(update.trialConversionStatus).toBe('CONVERTED_TO_PAID')
+    expect(update).not.toHaveProperty('planId')
+    expect(update).not.toHaveProperty('plan')
+    expect(onPlanChange).not.toHaveBeenCalled()
+  })
+
+  it('moves the org onto the requested plan in the same write', async () => {
+    const { db, setSpy } = createMockDb()
+    const service = new AdminBillingService(db, 'https://app.test', onPlanChange)
+
+    await service.convertTrialToPaid({
+      organizationId: 'org_1',
+      planName: 'Growth',
+      skipPayment: true,
+      adminUserId: 'admin_1',
+    })
+
+    const update = setSpy.mock.calls[0]![0]
+    expect(update.status).toBe('active')
+    expect(update.planId).toBe('plan_growth')
+    expect(update.plan).toBe('Growth')
+    expect(onPlanChange).toHaveBeenCalledWith(expect.anything(), 'org_1', 'plan_growth')
+  })
+
+  it('matches plan names case-insensitively — `getPlans()` lowercases them', async () => {
+    const { db, setSpy } = createMockDb()
+    const service = new AdminBillingService(db, 'https://app.test', onPlanChange)
+
+    await service.convertTrialToPaid({
+      organizationId: 'org_1',
+      planName: 'growth',
+      skipPayment: true,
+      adminUserId: 'admin_1',
+    })
+
+    expect(setSpy.mock.calls[0]![0].planId).toBe('plan_growth')
+  })
+
+  it('throws before writing anything when the plan name is unknown', async () => {
+    const { db, setSpy } = createMockDb()
+    const service = new AdminBillingService(db, 'https://app.test', onPlanChange)
+
+    await expect(
+      service.convertTrialToPaid({
+        organizationId: 'org_1',
+        planName: 'Platinum',
+        skipPayment: true,
+        adminUserId: 'admin_1',
+      })
+    ).rejects.toThrow('Plan Platinum not found')
+
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/billing/src/services/admin-billing-service.ts
+++ b/packages/billing/src/services/admin-billing-service.ts
@@ -140,7 +140,11 @@ export class AdminBillingService {
   }
 
   /**
-   * Convert trial to paid without payment (admin override)
+   * Convert trial to paid without payment (admin override).
+   *
+   * When `planName` is omitted the org stays on the plan it trialed on; when it is
+   * given, the conversion lands them on that plan in the same write (which is what
+   * an admin converting a Free trial into a paid Growth workspace needs).
    */
   async convertTrialToPaid(input: {
     organizationId: string
@@ -150,9 +154,17 @@ export class AdminBillingService {
   }): Promise<void> {
     const subscription = await this.getSubscription(input.organizationId)
 
+    // Resolve the target plan up front so an unknown name fails before any write.
+    const targetPlan = input.planName ? await this.findPlanByName(input.planName) : null
+    if (input.planName && !targetPlan) {
+      throw new Error(`Plan ${input.planName} not found`)
+    }
+
     const previousState = {
       status: subscription.status,
       trialConversionStatus: subscription.trialConversionStatus,
+      planId: subscription.planId,
+      plan: subscription.plan,
     }
 
     // Update subscription to active
@@ -162,6 +174,7 @@ export class AdminBillingService {
         status: 'active',
         trialConversionStatus: 'CONVERTED_TO_PAID',
         hasTrialEnded: true,
+        ...(targetPlan ? { planId: targetPlan.id, plan: targetPlan.name } : {}),
         updatedAt: new Date(),
       })
       .where(eq(schema.PlanSubscription.id, subscription.id))
@@ -174,10 +187,38 @@ export class AdminBillingService {
       organizationId: input.organizationId,
       details: { skipPayment: input.skipPayment },
       previousState,
-      newState: { status: 'active', trialConversionStatus: 'CONVERTED_TO_PAID' },
+      newState: {
+        status: 'active',
+        trialConversionStatus: 'CONVERTED_TO_PAID',
+        planId: targetPlan?.id ?? subscription.planId,
+        plan: targetPlan?.name ?? subscription.plan,
+      },
     })
 
-    logger.info('Trial converted to paid', { organizationId: input.organizationId })
+    logger.info('Trial converted to paid', {
+      organizationId: input.organizationId,
+      plan: targetPlan?.name ?? subscription.plan,
+    })
+
+    // A plan change has to run the same overage check every other plan write does.
+    if (targetPlan && targetPlan.id !== subscription.planId) {
+      await this.onPlanChange?.(this.db, input.organizationId, targetPlan.id)
+    }
+  }
+
+  /**
+   * Resolve a non-legacy plan by name, case-insensitively.
+   *
+   * Callers hand us names from two different vocabularies — `Plan.name` is stored
+   * TitleCase ('Growth'), while `PlanService.getPlans()` lowercases it for its
+   * consumers — so matching exactly on either one silently misses the other.
+   */
+  private async findPlanByName(name: string) {
+    const plans = await this.db.query.Plan.findMany({
+      where: (plan, { eq }) => eq(plan.isLegacy, false),
+    })
+    const wanted = name.trim().toLowerCase()
+    return plans.find((plan) => plan.name.toLowerCase() === wanted) ?? null
   }
 
   // ============ Organization Access Management ============

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -160,6 +160,9 @@ export interface DehydratedOrgProfile {
   createdAt: string
   completedOnboarding: boolean
   demoExpiresAt: string | null
+  /** Admin suspension marker — non-null means every member is locked out. */
+  disabledAt: string | null
+  disabledReason: string | null
 }
 
 /** Cached AgentTrigger row (JSON-serializable). Mirrors the dispatch-relevant
@@ -713,7 +716,15 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   // Business data (24h TTL, all invalidated via cache events)
   features: { prefix: 'org:features', ttlSeconds: THIRTY_DAYS },
   subscription: { prefix: 'org:subscription', ttlSeconds: ONE_DAY },
-  orgProfile: { prefix: 'org:profile', ttlSeconds: ONE_DAY },
+  // v2: + disabledAt/disabledReason, which `protectedProcedure` now reads to lock
+  // members out of an admin-suspended org. The shape is still parseable by both
+  // sides, which is exactly why the bump is load-bearing: a v1 blob has no
+  // `disabledAt` key, so the gate reads `undefined` → falsy → **fail-OPEN**, and a
+  // just-suspended org would stay fully usable for up to the ONE_DAY TTL for any
+  // org whose blob was written before the deploy. Moving the keyspace makes that
+  // impossible. (`org.updated` invalidation only covers orgs suspended *after*
+  // the new code is live.)
+  orgProfile: { prefix: 'org:profile:v2', ttlSeconds: ONE_DAY },
   resources: { prefix: 'org:resources', ttlSeconds: ONE_DAY },
   customFields: { prefix: 'org:custom-fields', ttlSeconds: ONE_DAY },
   groups: { prefix: 'org:groups', ttlSeconds: ONE_DAY },

--- a/packages/lib/src/cache/providers/org-profile-provider.ts
+++ b/packages/lib/src/cache/providers/org-profile-provider.ts
@@ -28,6 +28,8 @@ export const orgProfileProvider: CacheProvider<DehydratedOrgProfile> = {
       createdAt: org.createdAt.toISOString(),
       completedOnboarding: org.completedOnboarding ?? false,
       demoExpiresAt: org.demoExpiresAt?.toISOString() ?? null,
+      disabledAt: org.disabledAt?.toISOString() ?? null,
+      disabledReason: org.disabledReason,
     }
   },
 }

--- a/packages/lib/src/dehydration/service.ts
+++ b/packages/lib/src/dehydration/service.ts
@@ -214,6 +214,8 @@ export class DehydrationService {
       createdAt: orgProfile.createdAt,
       completedOnboarding: orgProfile.completedOnboarding,
       demoExpiresAt: orgProfile.demoExpiresAt,
+      disabledAt: orgProfile.disabledAt,
+      disabledReason: orgProfile.disabledReason,
       subscription: toClientSubscription(subscription),
       features: features ?? {},
       capabilities: capabilities.toClientCapabilities(),

--- a/packages/lib/src/dehydration/types.ts
+++ b/packages/lib/src/dehydration/types.ts
@@ -141,6 +141,14 @@ export interface DehydratedOrganization {
   completedOnboarding: boolean
   demoExpiresAt: string | null
 
+  /**
+   * Admin suspension marker. Non-null means every member is locked out —
+   * enforced server-side by `protectedProcedure`; this copy only drives the
+   * client screen.
+   */
+  disabledAt: string | null
+  disabledReason: string | null
+
   // Subscription (nullable)
   subscription: {
     id: string


### PR DESCRIPTION
Two bugs found while auditing the admin panel's "grant access without a subscription" paths.

## 1. Organization suspension was never enforced in `apps/web`

`Organization.disabledAt` has been read by `apps/api` since the column shipped (`verifyOrganizationAccess`, `verifyOrgMembership`), but **nothing in `apps/web` ever looked at it**. The admin panel's "Disable Organization" action — whose confirm dialog promises to *"immediately suspend access"* — only blocked the REST API. Members of a suspended org kept full use of the product and every tRPC procedure.

- **Server-side (authoritative):** new `organizationDisabledMiddleware` chained onto `protectedProcedure` after session enrichment, so it covers every derived procedure (`ownerProcedure`, `capabilityProcedure`, `permissionProcedure`, `superAdminProcedure`, dispatch). Throws `FORBIDDEN` carrying the admin's reason.
- **Client:** new `OrganizationDisabled` screen rendered from `AppLayoutWrapper` ahead of the billing gates — separate from `SubscriptionEnded` because there is no self-service exit from a suspension. Unlike the billing gates it is *not* skipped on self-hosted: a suspension is an operator action, not a plan gate.
- **Super admins are exempt in both places.** Their own `defaultOrganizationId` may be the suspended org, and the admin panel is how it gets re-enabled — gating them would be self-locking.

The marker rides on the existing `orgProfile` cache entry (already a 100 ms in-process memo, and `mutationRateLimitMiddleware` already reads `features` the same way), so the gate adds no DB roundtrip.

**The `org:profile` → `org:profile:v2` keyspace move is load-bearing.** The shape stays parseable by both sides, which is exactly the trap: a v1 blob has no `disabledAt` key, so the gate reads `undefined` → falsy → **fails open**, and any org whose blob predates the deploy would stay fully usable for up to the ONE_DAY TTL. `org.updated` invalidation only covers orgs suspended *after* the new code is live.

## 2. `convertTrialToPaid` silently ignored `planName`

The router accepted `planName` and passed it through; the service's `set()` only touched status and conversion flags. An admin converting a Free trial into a paid Growth workspace left the org on Free with Free's limits.

Now resolves the plan up front (unknown name throws *before* any write), writes `planId`/`plan` in the same UPDATE, records both sides in the audit log, and fires `onPlanChange` for the overage check like every other plan write.

Name matching is case-insensitive because the two vocabularies disagree: `Plan.name` is stored TitleCase (`'Growth'`) while `PlanService.getPlans()` lowercases it for its consumers — an exact match on either one silently misses the other.

Also adds a plan picker to the Convert-to-Paid accordion, defaulting to "Keep current plan". A parameter no UI can send is still dead code.

## Verification

- `@auxx/billing`: typecheck clean, 75 tests pass — including 4 new ones covering keep-plan, move-plan, case-insensitive match, and throw-before-write.
- `packages/lib`: 29 typecheck errors, all pre-existing in `scripts/` + `vitest.integration.config.ts`, none in `cache/` or `dehydration/`. Cache + dehydration suites pass (70 tests).
- `apps/web`: 16 typecheck errors, all pre-existing in `member-queries.ts`, `kopilot/stream/route.ts`, `command-palette.tsx`, `human/panel.tsx` — none in any touched file.
- Biome clean.

## Not included

- The `/organizations` workspace switcher doesn't badge suspended orgs.
- `createSubscription`/`changePlan` store the lowercase plan name while `setEnterprisePlan` stores TitleCase, so `EnterpriseManagementSection`'s `subscription?.plan === 'Enterprise'` badge won't light up for an admin-created Enterprise subscription.
