### PR TITLE
fix(web): wire up the organizations card menu actions

### DIFF
--- a/apps/web/src/app/(protected)/organizations/page.tsx
+++ b/apps/web/src/app/(protected)/organizations/page.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import type { DehydratedOrganization } from '@auxx/lib/dehydration'
+import { capabilityKeySet, PermissionKey } from '@auxx/lib/permissions/client'
 import { BLOCKED_SUBSCRIPTION_STATUSES } from '@auxx/types/billing'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -17,6 +18,7 @@ import { Building, MoreVertical, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { CreateOrganizationDialog } from '~/components/global/create-org-dialog'
+import { useConfirm } from '~/hooks/use-confirm'
 import {
   useDehydratedOrganizations,
   useDehydratedUser,
@@ -51,21 +53,39 @@ function getSubscriptionStatus(org: DehydratedOrganization) {
   return { label: org.subscription.status, isActive: false }
 }
 
+/**
+ * `can('billing.view')` for an organization that may not be the active one.
+ *
+ * `useAccess()` can't answer this: it seeds from the ACTIVE org's snapshot only,
+ * and this page lists every membership. The dehydration seed already carries a
+ * per-org snapshot for each one (`assembleOrganization` resolves capabilities
+ * per membership), so the gate reads off that, through the same front-door union
+ * the provider's `can()` uses.
+ *
+ * No plan layer to mirror here — `billing.view` carries no `featureKey` in the
+ * permission registry, so the provider's `hasAccess()` leg is always true for it.
+ */
+function canViewBilling(org: DehydratedOrganization): boolean {
+  return capabilityKeySet(org.capabilities).has(PermissionKey.billingView)
+}
+
 /** Organization card component */
 function OrganizationCard({
   org,
   isDefault,
   isCurrent,
-  onSwitch,
-  onNavigate,
-  switching,
+  onOpen,
+  onManageSubscription,
+  onLeave,
+  busy,
 }: {
   org: DehydratedOrganization
   isDefault: boolean
   isCurrent: boolean
-  onSwitch: () => void
-  onNavigate: () => void
-  switching: boolean
+  onOpen: () => void
+  onManageSubscription: () => void
+  onLeave: () => void
+  busy: boolean
 }) {
   const status = getSubscriptionStatus(org)
 
@@ -74,12 +94,8 @@ function OrganizationCard({
     if ((e.target as HTMLElement).closest('[data-dropdown-trigger]')) {
       return
     }
-    if (!switching) {
-      if (isCurrent) {
-        onNavigate()
-      } else {
-        onSwitch()
-      }
+    if (!busy) {
+      onOpen()
     }
   }
 
@@ -135,23 +151,25 @@ function OrganizationCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align='end'>
-            <DropdownMenuItem
-              variant='destructive'
-              onClick={(e) => {
-                e.stopPropagation()
-                // Handle delete
-              }}>
-              Leave Organization
-            </DropdownMenuItem>
-            {!status.isActive && (
+            {canViewBilling(org) && (
               <DropdownMenuItem
+                disabled={busy}
                 onClick={(e) => {
                   e.stopPropagation()
-                  window.location.href = `/subscription?org=${org.id}`
+                  onManageSubscription()
                 }}>
                 Manage Subscription
               </DropdownMenuItem>
             )}
+            <DropdownMenuItem
+              variant='destructive'
+              disabled={busy}
+              onClick={(e) => {
+                e.stopPropagation()
+                onLeave()
+              }}>
+              Leave Organization
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -166,26 +184,65 @@ export default function OrganizationsPage() {
   const router = useRouter()
   const [switching, setSwitching] = useState(false)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [confirm, ConfirmDialog] = useConfirm()
 
   const switchOrg = api.organization.setDefault.useMutation({
-    onSuccess: (data) => {
-      setOrganizationId(data.organizationId)
-      router.push('/app')
-      router.refresh()
-    },
     onError: (error) => {
       toastError({ title: 'Failed to switch organization', description: error.message })
       setSwitching(false)
     },
   })
 
-  const handleSwitch = async (orgId: string) => {
+  const leaveOrg = api.organization.leave.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Failed to leave organization', description: error.message })
+    },
+  })
+
+  const busy = switching || leaveOrg.isPending
+
+  /**
+   * Make `orgId` the active organization if it isn't already, then navigate to
+   * `destination`. Switching is what makes the destination resolve against the
+   * right org — every in-app route reads the active org from context.
+   */
+  const openOrg = async (orgId: string, destination: string) => {
+    if (orgId === currentOrgId) {
+      router.push(destination)
+      return
+    }
+
     setSwitching(true)
-    await switchOrg.mutateAsync({ organizationId: orgId })
+    try {
+      const data = await switchOrg.mutateAsync({ organizationId: orgId })
+      setOrganizationId(data.organizationId)
+      router.push(destination)
+      router.refresh()
+    } catch {
+      // onError already toasted and cleared `switching`
+    }
   }
 
-  const handleNavigate = () => {
-    router.push('/app')
+  const handleLeave = async (org: DehydratedOrganization) => {
+    const label = org.name || org.handle || 'this organization'
+    const confirmed = await confirm({
+      title: `Leave ${label}?`,
+      description:
+        'You will immediately lose access to this organization, and any personal email channels you connected here stop syncing. You need a new invite to rejoin.',
+      confirmText: 'Leave',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+
+    try {
+      await leaveOrg.mutateAsync({ organizationId: org.id })
+      // The server picks the replacement default org when the one being left was
+      // the default, so re-read it from the server rather than guessing here.
+      router.refresh()
+    } catch {
+      // onError already toasted
+    }
   }
 
   return (
@@ -211,9 +268,10 @@ export default function OrganizationsPage() {
                     org={org}
                     isDefault={org.id === user.defaultOrganizationId}
                     isCurrent={org.id === currentOrgId}
-                    onSwitch={() => handleSwitch(org.id)}
-                    onNavigate={handleNavigate}
-                    switching={switching}
+                    onOpen={() => openOrg(org.id, '/app')}
+                    onManageSubscription={() => openOrg(org.id, '/app/settings/plans')}
+                    onLeave={() => handleLeave(org)}
+                    busy={busy}
                   />
                 ))
               ) : (
@@ -232,6 +290,7 @@ export default function OrganizationsPage() {
           </CardContent>
         </Card>
         <CreateOrganizationDialog open={createDialogOpen} onOpenChange={setCreateDialogOpen} />
+        <ConfirmDialog />
       </div>
     </div>
   )

--- a/apps/web/src/providers/capabilities-provider.tsx
+++ b/apps/web/src/providers/capabilities-provider.tsx
@@ -14,6 +14,7 @@ import {
   canImportRecord,
   canViewInstance,
   canViewRecord,
+  capabilityKeySet,
   hasDefPresence,
   PERMISSION_REGISTRY_MAP,
   type PermissionKey,
@@ -269,7 +270,7 @@ export function CapabilitiesProvider({ children }: { children: React.ReactNode }
     // pure `keys` — that view is the AREA-level source of truth for
     // `canViewInstance`, and merging the derived key there would hand them every
     // row-less instance in the org.
-    const capKeys = new Set<string>([...snapshot.keys, ...(snapshot.instanceDerivedKeys ?? [])])
+    const capKeys = capabilityKeySet(snapshot)
     const resolved = toResolvedRecordAccess(snapshot)
     const governedInstances = new Set<string>(snapshot.governingInstanceIds ?? [])
 

--- a/packages/lib/src/permissions/capabilities/entity-access.ts
+++ b/packages/lib/src/permissions/capabilities/entity-access.ts
@@ -614,6 +614,26 @@ export interface ClientCapabilities {
 }
 
 /**
+ * The flat key set the coarse `can()` gate answers from: resolved-area `keys`
+ * UNION the Read rungs derived from instance grants, so a member whose only
+ * access to a feature is one shared instance still passes nav / cmd+K / landing
+ * gates.
+ *
+ * This is the FRONT-DOOR union and deliberately not the same view as
+ * {@link toResolvedRecordAccess}, whose `keys` stay pure (see its note). Shared
+ * here because it has two callers that must agree: the `can()` gate in
+ * `capabilities-provider`, which reads the ACTIVE org's snapshot, and surfaces
+ * that gate on a NON-active org's snapshot from the dehydration seed (the
+ * organizations list) — where the provider's hook is structurally unavailable.
+ *
+ * Callers holding a snapshot across many checks should build the Set once.
+ */
+export function capabilityKeySet(caps: ClientCapabilities | null | undefined): Set<string> {
+  if (!caps) return new Set()
+  return new Set<string>([...(caps.keys ?? []), ...(caps.instanceDerivedKeys ?? [])])
+}
+
+/**
  * Rebuild the Set-backed {@link ResolvedRecordAccess} from a wire snapshot.
  *
  * `instanceDerivedKeys` is deliberately NOT merged into `keys` here: this view's

--- a/packages/lib/src/permissions/client.ts
+++ b/packages/lib/src/permissions/client.ts
@@ -27,6 +27,7 @@ export {
   canRecordVerbAtRung,
   canViewInstance,
   canViewRecord,
+  capabilityKeySet,
   effectiveRecordLevel,
   type GrantedDefIds,
   hasDefPresence,


### PR DESCRIPTION
The 3-dot menu on each card in `/organizations` had two broken items. Both are now wired, plus a permission gate on the one that needed it.

## Leave Organization

Was an empty stub:

```tsx
onClick={(e) => {
  e.stopPropagation()
  // Handle delete
}}
```

…even though `organization.leave` has been fully implemented server-side all along (`organization.ts:364`) — membership check, only-owner guard, personal-channel offboarding, audit record.

It now calls the mutation behind a `useConfirm` gate (`destructive: true`), and surfaces the server's two legitimate rejections via `toastError`: the only-owner guard (*"You are the only owner. Transfer ownership before leaving."*) and the `notDemo` guard. On success it calls `router.refresh()` rather than patching client state — the server picks the replacement default org when the one being left was the default (`organization.ts:418-432`), so re-reading is correct and guessing would desync.

## Manage Subscription

Pointed at `/subscription?org=<id>`, which **does not exist** — `(protected)/subscription/` has only `cancel`, `convert`, `ended`, `reactivate`, and `success` subroutes, no `page.tsx`. The real page is `/app/settings/plans`.

It also no longer hides behind `!status.isActive`, which was backwards: you could only reach billing from an org that was *already* expired or trial-ended.

## Org switching

`/app/settings/plans` resolves against the **active** org, so deep-linking another org's billing has to switch first. The hardcoded `router.push('/app')` moved out of the `setDefault` `onSuccess` into an `openOrg(orgId, destination)` helper that switches only when needed. That collapsed the `onSwitch`/`onNavigate` prop pair into a single `onOpen`, and `switching` became `busy` (`switching || leaveOrg.isPending`) so both mutations disable the card and its menu items.

## Permission gate

The menu entry is hidden without `billing.view`, matching `CapabilityPageGuard permissionKey='billing.view'` on the destination — otherwise it is a dead link into `/access-denied`, the same reasoning as `nav-user.tsx:79-81`.

`useAccess()` cannot answer this: `CapabilitiesProvider` seeds from `useDehydratedOrganization(organizationId)`, the **active** org only, while this page lists every membership. The dehydration seed already carries a per-org snapshot for each one (`assembleOrganization` resolves capabilities per membership, not just the current one), so the gate reads off that.

To avoid copying the rule, the front-door union behind `can()` (`keys ∪ instanceDerivedKeys`) is extracted to a shared `capabilityKeySet` helper in `entity-access.ts`, exported from `@auxx/lib/permissions/client`. The provider now calls it too, so the two cannot drift. No plan leg to mirror — `billing.view` carries no `featureKey`.

## Server enforcement — unchanged, already correct

Worth stating explicitly since the client gate is only an affordance. `permissionProcedure` (`trpc.ts:469-481`) resolves capabilities server-side and calls `capabilities.assert(key)`. In the billing router every read exposing billing data is on `billing.view` and every write on `billing.manage`; only `getPlans`, `getCurrentSubscription`, `checkTrialStatus`, and `checkTrialEligibility` are member-open, which is a deliberate documented choice for the shell's plan gates and trial banners.

## Verification

- `apps/web` and `packages/lib` typecheck — no errors in any changed file (the 16 web / 4 lib remaining errors are the pre-existing baseline, all in untouched files)
- `capabilities-provider.test.tsx` — 11/11 pass
- Biome clean on all four files
- Rebuilt `@auxx/lib` and confirmed `capabilityKeySet` lands in `dist`

## Note

`DehydratedOrganization.subscription` ships plan, seats, status, and period dates to every member regardless of `billing.view`. That is pre-existing and coherent with `getCurrentSubscription` being member-open, so it is left alone here — flagging it only because that seed, not the router, is where plan data would leak if you consider it sensitive.