### PR TITLE
feat(approvals): add a past-approvals view and audit access decisions

### DIFF
--- a/apps/web/src/components/global/notifications/hooks/use-notification-subscription.test.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-notification-subscription.test.ts
@@ -16,7 +16,10 @@ const h = vi.hoisted(() => ({
   preflightInvalidate: vi.fn(),
   approvalInvalidates: {
     getPendingCount: vi.fn(),
-    getPendingRequests: vi.fn(),
+    // `approval.list` and `approvals.list` are different routers — distinct spies,
+    // or one shadows the other in this object literal and both assertions pass off
+    // whichever call happened to land last.
+    approvalList: vi.fn(),
     count: vi.fn(),
     list: vi.fn(),
   },
@@ -54,7 +57,7 @@ vi.mock('~/trpc/react', () => ({
       approval: {
         accessRequestPreflight: { invalidate: h.preflightInvalidate },
         getPendingCount: { invalidate: h.approvalInvalidates.getPendingCount },
-        getPendingRequests: { invalidate: h.approvalInvalidates.getPendingRequests },
+        list: { invalidate: h.approvalInvalidates.approvalList },
       },
       approvals: {
         count: { invalidate: h.approvalInvalidates.count },

--- a/apps/web/src/components/global/notifications/hooks/use-notification-subscription.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-notification-subscription.ts
@@ -90,7 +90,7 @@ export function useNotificationSubscription(userId: string) {
  */
 function invalidateApprovals(utils: ReturnType<typeof api.useUtils>) {
   void utils.approval.getPendingCount.invalidate()
-  void utils.approval.getPendingRequests.invalidate()
+  void utils.approval.list.invalidate()
   void utils.approvals.count.invalidate()
   void utils.approvals.list.invalidate()
 }

--- a/apps/web/src/components/global/notifications/notification-panel-store.ts
+++ b/apps/web/src/components/global/notifications/notification-panel-store.ts
@@ -11,11 +11,20 @@ import { persist } from 'zustand/middleware'
  */
 export type NotificationPanelMode = 'all' | 'unread' | 'approvals'
 
+/**
+ * The Approvals tab's own sub-filter. Lives here rather than in `ApprovalsTab`
+ * because the switch renders in the panel's filter strip — above the scroller, so
+ * it does not scroll away — while the sections that read it render inside.
+ */
+export type ApprovalsView = 'pending' | 'past'
+
 interface NotificationPanelState {
   open: boolean
   width: number
   /** Active tab. Lifted out of the panel so callers can open straight onto a tab. */
   mode: NotificationPanelMode
+  /** Approvals tab sub-filter — what still needs a decision, or what is decided. */
+  approvalsView: ApprovalsView
   /** Approval whose row should be scrolled to and flashed once the tab renders. */
   highlightApprovalId?: string
   /**
@@ -30,6 +39,7 @@ interface NotificationPanelState {
   close: () => void
   setWidth: (width: number) => void
   setMode: (mode: NotificationPanelMode) => void
+  setApprovalsView: (view: ApprovalsView) => void
   /** Opens the panel on the Approvals tab, optionally highlighting one entry. */
   openApprovals: (highlightApprovalId?: string) => void
   clearHighlight: () => void
@@ -43,14 +53,19 @@ export const useNotificationPanelStore = create<NotificationPanelState>()(
       open: false,
       width: 420,
       mode: 'unread',
+      approvalsView: 'pending',
       highlightApprovalId: undefined,
       bellPulse: 0,
       toggle: () => set((state) => ({ open: !state.open })),
       close: () => set({ open: false }),
       setWidth: (width) => set({ width }),
       setMode: (mode) => set({ mode }),
+      setApprovalsView: (approvalsView) => set({ approvalsView }),
+      // Resets the sub-view: a caller pointing at one request is always pointing
+      // at a pending one (that is what the notification is for), and landing on
+      // Past would silently drop the highlight as unlisted.
       openApprovals: (highlightApprovalId) =>
-        set({ open: true, mode: 'approvals', highlightApprovalId }),
+        set({ open: true, mode: 'approvals', approvalsView: 'pending', highlightApprovalId }),
       clearHighlight: () => set({ highlightApprovalId: undefined }),
       pulseBell: () => set((state) => ({ bellPulse: state.bellPulse + 1 })),
     }),

--- a/apps/web/src/components/global/notifications/notification-panel.tsx
+++ b/apps/web/src/components/global/notifications/notification-panel.tsx
@@ -34,7 +34,11 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { useApprovalsCount } from './hooks/use-approvals-count'
 import { useNotifications } from './hooks/use-notifications'
-import { type NotificationPanelMode, useNotificationPanelStore } from './notification-panel-store'
+import {
+  type ApprovalsView,
+  type NotificationPanelMode,
+  useNotificationPanelStore,
+} from './notification-panel-store'
 import { ApprovalsTab } from './ui/approvals-tab'
 import { NotificationItemDispatch } from './ui/notification-item'
 import { NotificationRowSkeleton } from './ui/notification-row'
@@ -83,6 +87,8 @@ export function NotificationPanel() {
   // panel straight onto the Approvals tab.
   const mode = useNotificationPanelStore((state) => state.mode)
   const setMode = useNotificationPanelStore((state) => state.setMode)
+  const approvalsView = useNotificationPanelStore((state) => state.approvalsView)
+  const setApprovalsView = useNotificationPanelStore((state) => state.setApprovalsView)
   const [search, setSearch] = useState('')
   const [types, setTypes] = useState<NotificationType[]>([])
   const viewportRef = useRef<HTMLDivElement>(null)
@@ -248,7 +254,24 @@ export function NotificationPanel() {
             ) : null}
           </RadioTabItem>
         </RadioTab>
-        {isApprovals ? null : (
+        {isApprovals ? (
+          // Sub-filter, in the slot the notification search occupies on the other
+          // tabs: it belongs above the scroller so it never scrolls away, and the
+          // sections that read it live inside `ApprovalsTab`.
+          <RadioTab
+            value={approvalsView}
+            onValueChange={(value) => setApprovalsView(value as ApprovalsView)}
+            size='sm'
+            className='w-full border border-primary-200'
+            radioGroupClassName='w-full'>
+            <RadioTabItem value='pending' size='sm' className='gap-1 px-2'>
+              Pending
+            </RadioTabItem>
+            <RadioTabItem value='past' size='sm' className='gap-1 px-2'>
+              Past
+            </RadioTabItem>
+          </RadioTab>
+        ) : (
           <div className='flex items-center gap-2'>
             <InputSearch
               value={search}

--- a/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
@@ -11,7 +11,7 @@ import {
   EmptyTitle,
 } from '@auxx/ui/components/empty'
 import InfiniteScroll from '@auxx/ui/components/infinite-scroll'
-import { CircleCheck, TriangleAlert } from 'lucide-react'
+import { CircleCheck, History, TriangleAlert } from 'lucide-react'
 import type { RefObject } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useMailSuggestions } from '~/components/mail-suggestions/hooks/use-mail-suggestions'
@@ -20,6 +20,7 @@ import { api } from '~/trpc/react'
 import { useNotificationPanelStore } from '../notification-panel-store'
 import { AccessRequestRow } from './items/access-request-row'
 import { ConfirmationRow } from './items/confirmation-row'
+import { DecidedRow } from './items/decided-row'
 import { MailSuggestionRow } from './items/mail-suggestion-row'
 import { SuggestionRow } from './items/suggestion-row'
 import { NotificationRowSkeleton } from './notification-row'
@@ -43,7 +44,23 @@ const HIGHLIGHT_MS = 2000
 /**
  * Body of the notification panel's Approvals tab.
  *
- * Two labelled sections rather than one merged stream: the sources paginate
+ * Splits on the panel's `approvalsView` sub-filter, which renders in the filter
+ * strip above the scroller. The two views share nothing but the row chrome: one
+ * is a work queue whose rows carry mutations, the other is a read-only record.
+ */
+export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
+  const approvalsView = useNotificationPanelStore((state) => state.approvalsView)
+  return approvalsView === 'past' ? (
+    <PastApprovals viewportRef={viewportRef} />
+  ) : (
+    <PendingApprovals viewportRef={viewportRef} />
+  )
+}
+
+/**
+ * Everything still waiting on the viewer.
+ *
+ * Labelled sections rather than one merged stream: the sources paginate
  * differently and carry different urgency — an unanswered workflow confirmation
  * blocks a live run and expires, an unanswered suggestion costs nothing. See
  * plans/today/02-approvals-tab.md §3.
@@ -51,7 +68,7 @@ const HIGHLIGHT_MS = 2000
  * `FeatureKey.todayInbox` gates the suggestions section only. Workflow
  * confirmations are not feature-flagged and stay visible without it.
  */
-export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
+function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
   const { hasAccess } = useFeatureFlags()
   const suggestionsEnabled = hasAccess(FeatureKey.todayInbox)
   const utils = api.useUtils()
@@ -63,9 +80,10 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
   // room (`useNotificationSubscription`), which invalidates this query. Focus
   // refetch stays as the backstop for a missed frame and for suggestions, which
   // are still refetch-driven pending the `ownerScope` call (plan §6).
-  const confirmations = api.approval.getPendingRequests.useQuery(undefined, {
-    refetchOnWindowFocus: true,
-  })
+  const confirmations = api.approval.list.useQuery(
+    { view: 'pending' },
+    { refetchOnWindowFocus: true }
+  )
   const suggestions = api.approvals.list.useInfiniteQuery(SUGGESTION_FILTERS, {
     enabled: suggestionsEnabled,
     getNextPageParam: (lastPage) => lastPage?.nextCursor ?? undefined,
@@ -79,9 +97,11 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
    */
   const mailSuggestions = useMailSuggestions()
 
-  // Deadline order — soonest expiry first, undated last.
+  // Deadline order — soonest expiry first, undated last. Correct only because the
+  // pending view is fetched as one page (the router asks for 100), so this sorts
+  // the whole set rather than a window into it.
   const confirmationItems = useMemo(() => {
-    const items = confirmations.data ?? []
+    const items = confirmations.data?.items ?? []
     return [...items].sort((a, b) => {
       const left = a.expiresAt ? new Date(a.expiresAt).getTime() : null
       const right = b.expiresAt ? new Date(b.expiresAt).getTime() : null
@@ -105,7 +125,9 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
    * drift from what the sections show.
    */
   const onResolved = () => {
-    void utils.approval.getPendingRequests.invalidate()
+    // Both views: a decision moves the row from one to the other, so leaving the
+    // past list cached would show a stale history the moment the user switches.
+    void utils.approval.list.invalidate()
     void utils.approval.getPendingCount.invalidate()
     void utils.approvals.list.invalidate()
     void utils.approvals.count.invalidate()
@@ -283,11 +305,108 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
   )
 }
 
-function SectionHeader({ label, count }: { label: string; count: number }) {
+/**
+ * Approvals the viewer can no longer act on — decided, withdrawn, or lapsed.
+ *
+ * Scoped to the `ApprovalRequest` lane (workflow confirmations + access requests),
+ * NOT the AI suggestion bundles. Those have terminal statuses too and
+ * `approvals.list` already accepts them, but `SuggestionRow` reads every non-FRESH
+ * status as "out of date — the record changed since this was proposed", so an
+ * approved bundle would render with copy that is simply false. Splitting `STALE`
+ * from the terminal statuses in that row is the prerequisite, and it is its own
+ * change.
+ *
+ * The audience is wider than the pending view's on purpose: this lists what the
+ * viewer was involved in, including requests they filed themselves, which they are
+ * never an assignee of. See `listApprovalsForUser`.
+ */
+function PastApprovals({ viewportRef }: ApprovalsTabProps) {
+  const past = api.approval.list.useInfiniteQuery(
+    { view: 'past' },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      refetchOnWindowFocus: false,
+    }
+  )
+
+  const items = useMemo(() => past.data?.pages.flatMap((page) => page.items) ?? [], [past.data])
+
+  if (past.isLoading) {
+    return (
+      <>
+        <NotificationRowSkeleton />
+        <NotificationRowSkeleton />
+        <NotificationRowSkeleton />
+      </>
+    )
+  }
+
+  // Same rule as the pending view: an empty list and a failed one must not look
+  // alike. A history that quietly claims nothing ever happened is worse than one
+  // that admits it could not load.
+  if (past.error && !items.length) {
+    return (
+      <div className='flex flex-1 items-center justify-center'>
+        <Empty className='border-0'>
+          <EmptyHeader>
+            <EmptyMedia variant='icon'>
+              <TriangleAlert />
+            </EmptyMedia>
+            <EmptyTitle>Couldn't load past approvals</EmptyTitle>
+            <EmptyDescription>{past.error.message}</EmptyDescription>
+            <Button variant='outline' size='sm' onClick={() => void past.refetch()}>
+              Try again
+            </Button>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    )
+  }
+
+  if (!items.length) {
+    return (
+      <div className='flex flex-1 items-center justify-center'>
+        <Empty className='border-0'>
+          <EmptyHeader>
+            <EmptyMedia variant='icon'>
+              <History />
+            </EmptyMedia>
+            <EmptyTitle>No past approvals</EmptyTitle>
+            <EmptyDescription>
+              Requests you decide or file will show up here once they're resolved.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    )
+  }
+
+  return (
+    <section>
+      {/* No count: this list pages, so any number here would be "loaded so far"
+          rather than a total, and would climb as the viewer scrolls. */}
+      <SectionHeader label='Decided' />
+      {items.map((request) => (
+        <DecidedRow key={request.id} request={request} />
+      ))}
+      <InfiniteScroll
+        isLoading={past.isFetchingNextPage}
+        hasMore={!!past.hasNextPage}
+        next={() => past.fetchNextPage()}
+        root={viewportRef.current}
+        rootMargin='200px'>
+        <div className='h-px' />
+      </InfiniteScroll>
+      {past.isFetchingNextPage ? <NotificationRowSkeleton /> : null}
+    </section>
+  )
+}
+
+function SectionHeader({ label, count }: { label: string; count?: number }) {
   return (
     <div className='flex items-center gap-1.5 px-3 pt-1 pb-1.5 font-medium text-muted-foreground text-xs'>
       <span className='uppercase tracking-wide'>{label}</span>
-      <span className='font-normal'>({count})</span>
+      {count === undefined ? null : <span className='font-normal'>({count})</span>}
     </div>
   )
 }

--- a/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/access-request-row.tsx
@@ -18,7 +18,7 @@ import { api } from '~/trpc/react'
 import { Emphasis } from '../notification-chips'
 import { NotificationRow } from '../notification-row'
 
-type PendingApprovalRequest = RouterOutputs['approval']['getPendingRequests'][number]
+type PendingApprovalRequest = RouterOutputs['approval']['list']['items'][number]
 
 const TIMESTAMP_FORMAT = 'MMM d, yyyy h:mm a'
 

--- a/apps/web/src/components/global/notifications/ui/items/confirmation-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/confirmation-row.tsx
@@ -25,7 +25,7 @@ import { useNotificationPanelStore } from '../../notification-panel-store'
 import { Emphasis } from '../notification-chips'
 import { NotificationRow } from '../notification-row'
 
-type PendingApprovalRequest = RouterOutputs['approval']['getPendingRequests'][number]
+type PendingApprovalRequest = RouterOutputs['approval']['list']['items'][number]
 
 const TIMESTAMP_FORMAT = 'MMM d, yyyy h:mm a'
 

--- a/apps/web/src/components/global/notifications/ui/items/decided-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/decided-row.tsx
@@ -1,0 +1,195 @@
+// apps/web/src/components/global/notifications/ui/items/decided-row.tsx
+'use client'
+
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { format, formatDistanceToNowStrict } from 'date-fns'
+import { AlertTriangle, ChevronRight } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { useState } from 'react'
+import type { RouterOutputs } from '~/trpc/react'
+import { api } from '~/trpc/react'
+import { Emphasis } from '../notification-chips'
+import { NotificationRow } from '../notification-row'
+
+type PastApprovalRequest = RouterOutputs['approval']['list']['items'][number]
+
+const TIMESTAMP_FORMAT = 'MMM d, yyyy h:mm a'
+
+function formatTimestamp(value: Date | string | null | undefined): string {
+  return value ? format(new Date(value), TIMESTAMP_FORMAT) : '—'
+}
+
+/**
+ * How each terminal state reads. `pending` is in the list because the `past` view
+ * is the complement of "still actionable", not a status list — an access request
+ * whose expiry lapsed is never rewritten to `timeout`, so it arrives here still
+ * marked pending and must not render as if it were awaiting a decision.
+ */
+const OUTCOMES = {
+  approved: { label: 'Approved', dot: 'bg-emerald-500', tone: 'text-emerald-600' },
+  denied: { label: 'Denied', dot: 'bg-red-500', tone: 'text-destructive' },
+  timeout: { label: 'Expired', dot: 'bg-muted-foreground/50', tone: 'text-muted-foreground' },
+  withdrawn: { label: 'Withdrawn', dot: 'bg-muted-foreground/50', tone: 'text-muted-foreground' },
+  superseded: { label: 'Superseded', dot: 'bg-muted-foreground/50', tone: 'text-muted-foreground' },
+  pending: { label: 'Expired', dot: 'bg-muted-foreground/50', tone: 'text-muted-foreground' },
+} as const
+
+function outcomeOf(status: string) {
+  return OUTCOMES[status as keyof typeof OUTCOMES] ?? OUTCOMES.superseded
+}
+
+/**
+ * One decided approval, read-only, in the Approvals tab's Past view.
+ *
+ * A separate component rather than a `readOnly` mode of `ConfirmationRow` /
+ * `AccessRequestRow`: those two are decision surfaces down to their structure —
+ * comment box, confirm dialog, two mutations, expiry countdown — and none of it
+ * survives the decision. What a past row leads with is the opposite: the outcome,
+ * who reached it, and when. Both kinds share this one row because at that point
+ * the difference between them is a noun in the sentence.
+ */
+export function DecidedRow({ request }: { request: PastApprovalRequest }) {
+  const [expanded, setExpanded] = useState(false)
+  const outcome = outcomeOf(request.status)
+
+  // Lazy, and the same query the pending rows use — `getApprovalDetails` gates on
+  // `canUserViewApproval`, which deliberately keeps admitting a request once it
+  // goes terminal.
+  const {
+    data: details,
+    isLoading: detailsLoading,
+    error: detailsError,
+  } = api.approval.getApprovalDetails.useQuery(
+    { id: request.id },
+    { enabled: expanded, retry: false, refetchOnWindowFocus: false }
+  )
+
+  // Live-join-wins, as on the pending rows: the joined workflow name is the truth
+  // when this reader can hydrate it, and `subjectLabel` is the fallback and the
+  // durability guarantee — which is the whole point on a denied access row, whose
+  // requester never got the access needed to resolve the target.
+  const subjectLabel = request.workflow?.name || request.subjectLabel
+  const decidedBy = request.decision?.by?.name
+  const decidedAt = request.decision?.respondedAt
+
+  const subtitle = (
+    <span className={cn('inline-flex items-center gap-1.5', outcome.tone)}>
+      <span className={cn('size-2 shrink-0 rounded-full', outcome.dot)} />
+      {outcome.label}
+      {decidedBy ? ` by ${decidedBy}` : ''}
+      <span className='text-muted-foreground'>
+        · {formatDistanceToNowStrict(new Date(decidedAt ?? request.createdAt), { addSuffix: true })}
+      </span>
+    </span>
+  )
+
+  const drawer = (
+    <div className='space-y-2 rounded-md bg-secondary/40 p-2'>
+      {detailsLoading ? (
+        <div className='space-y-2'>
+          <Skeleton className='h-3 w-1/3' />
+          <Skeleton className='h-10 w-full' />
+        </div>
+      ) : detailsError ? (
+        <div className='flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-2 text-destructive text-xs'>
+          <AlertTriangle className='mt-px size-3.5 shrink-0' />
+          <span>
+            {detailsError.data?.code === 'FORBIDDEN'
+              ? 'You are not authorized to view this approval request.'
+              : detailsError.message}
+          </span>
+        </div>
+      ) : (
+        <>
+          {details?.nodeName ? (
+            <p className='text-muted-foreground text-xs'>
+              Node <span className='text-foreground'>{details.nodeName}</span>
+            </p>
+          ) : null}
+          {(details?.message ?? request.message) ? (
+            <p className='text-sm leading-6'>{details?.message ?? request.message}</p>
+          ) : null}
+        </>
+      )}
+
+      <dl className='grid grid-cols-2 gap-2 text-xs'>
+        <div>
+          <dt className='text-muted-foreground'>Requested</dt>
+          <dd className='font-medium'>{formatTimestamp(request.createdAt)}</dd>
+        </div>
+        <div>
+          <dt className='text-muted-foreground'>{outcome.label}</dt>
+          {/* Only approve/deny write an `ApprovalResponse`, so a withdrawn,
+              timed-out or lapsed row has no decision timestamp to show. */}
+          <dd className='font-medium'>{decidedAt ? formatTimestamp(decidedAt) : '—'}</dd>
+        </div>
+      </dl>
+
+      {request.decision?.comment ? (
+        <div>
+          <p className='text-muted-foreground text-xs'>Comment</p>
+          <p className='mt-1 text-sm leading-6'>{request.decision.comment}</p>
+        </div>
+      ) : null}
+    </div>
+  )
+
+  return (
+    <NotificationRow
+      id={request.id}
+      createdAt={request.createdAt}
+      label={request.kind === 'access' ? 'Access' : 'Workflow'}
+      icon={<span className={cn('size-2 rounded-full', outcome.dot)} />}
+      subtitle={subtitle}
+      actionLabel={
+        <button
+          type='button'
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+          className='flex h-7 cursor-pointer items-center gap-1 rounded-full pr-2 font-medium text-foreground/65 text-xs hover:bg-foreground/5'>
+          <ChevronRight
+            className={cn('size-3.5 transition-transform', expanded && 'rotate-90')}
+            aria-hidden
+          />
+          {expanded ? 'Hide details' : 'Details'}
+        </button>
+      }
+      expanded={
+        <AnimatePresence initial={false}>
+          {expanded && (
+            <motion.div
+              initial={{ height: 0, opacity: 0, filter: 'blur(3px)' }}
+              animate={{ height: 'auto', opacity: 1, filter: 'blur(0px)' }}
+              exit={{ height: 0, opacity: 0, filter: 'blur(3px)' }}
+              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+              style={{ overflow: 'hidden' }}>
+              <div className='pt-2'>{drawer}</div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      }>
+      {request.kind === 'access' ? (
+        <>
+          <Emphasis>{request.requester?.name ?? 'A member'}</Emphasis> requested access
+          {subjectLabel ? (
+            <>
+              {' '}
+              to <Emphasis>{subjectLabel}</Emphasis>
+            </>
+          ) : null}
+        </>
+      ) : (
+        <>
+          Approval
+          {subjectLabel ? (
+            <>
+              {' '}
+              for <Emphasis>{subjectLabel}</Emphasis>
+            </>
+          ) : null}
+        </>
+      )}
+    </NotificationRow>
+  )
+}

--- a/apps/web/src/server/api/routers/approval.ts
+++ b/apps/web/src/server/api/routers/approval.ts
@@ -8,10 +8,10 @@ import {
   createThreadAccessRequest,
   getApprovalMetrics,
   getApprovalRequestWithContext,
-  getPendingApprovalsForUser,
   getPendingCount,
   getRecordAccessRequestApproverView,
   getThreadAccessRequestApproverView,
+  listApprovalsForUser,
   preflightRecordAccessRequest,
   preflightThreadAccessRequest,
   resolveApprovalByToken,
@@ -22,6 +22,7 @@ import {
 import { RedisRateLimiter } from '@auxx/lib/utils/rate-limiter'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { requestAuditContext } from '~/server/api/audit-context'
 import {
   createTRPCRouter,
   isAuxxError,
@@ -63,10 +64,36 @@ function getIpFromHeaders(headers: Headers): string {
  *   where a direct API caller meets them too.
  */
 export const approvalRouter = createTRPCRouter({
-  /** Every pending approval waiting on the caller — both kinds (plan 28 H1). */
-  getPendingRequests: protectedProcedure.query(async ({ ctx }) => {
-    return await getPendingApprovalsForUser(ctx.db, ctx.session.organizationId, ctx.session.userId)
-  }),
+  /**
+   * The caller's approvals — both kinds (plan 28 H1), in one of two views.
+   *
+   * `view` is an enum rather than a raw status list on purpose: `pending` and
+   * `past` are a partition with different audiences (see
+   * {@link listApprovalsForUser}), and an arbitrary status filter from the client
+   * could ask for a combination that is neither.
+   *
+   * `pending` defaults to a page of 100 and the tab does not scroll it — that
+   * section is re-sorted by deadline client-side, which is only correct over the
+   * whole set. `past` pages normally.
+   */
+  list: protectedProcedure
+    .input(
+      z
+        .object({
+          view: z.enum(['pending', 'past']).default('pending'),
+          cursor: z.string().optional(),
+          limit: z.number().min(1).max(100).optional(),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      const view = input?.view ?? 'pending'
+      return await listApprovalsForUser(ctx.db, ctx.session.organizationId, ctx.session.userId, {
+        view,
+        cursor: input?.cursor,
+        limit: input?.limit ?? (view === 'pending' ? 100 : 25),
+      })
+    }),
 
   /** One request with full context. */
   getApprovalDetails: protectedProcedure
@@ -104,6 +131,11 @@ export const approvalRouter = createTRPCRouter({
         userId: ctx.session.userId,
         action: 'approve',
         comment: input.comment,
+        // Feeds both the `ApprovalResponse.ipAddress` column and the security-log
+        // row an access decision writes. `requestAuditContext` rather than
+        // `recordAuditFromCtx`: the write itself belongs in the resolve path, which
+        // the email-token and bulk lanes also reach — see `resolveApprovalRequest`.
+        auditContext: requestAuditContext(ctx.headers),
       })
       if (result.isErr()) throw result.error
       return result.value
@@ -123,6 +155,7 @@ export const approvalRouter = createTRPCRouter({
         userId: ctx.session.userId,
         action: 'deny',
         comment: input.comment,
+        auditContext: requestAuditContext(ctx.headers),
       })
       if (result.isErr()) throw result.error
       return result.value

--- a/docs/today-architecture-guide.md
+++ b/docs/today-architecture-guide.md
@@ -219,18 +219,69 @@ the notification side panel. See `plans/today/` for the rationale.
 ### The tab (`ui/approvals-tab.tsx`)
 Third item in the panel's `RadioTab` (All / Unread / Approvals). It reads
 its two source tables directly — **no `Notification` rows are minted for
-bundles** — and renders two sections:
+bundles**.
 
-- **Needs a decision** — `approval.getPendingRequests` (workflow human
-  confirmations). Not feature-flagged, unpaginated, sorted `expiresAt` asc
-  nulls last.
+The tab carries its own **Pending / Past** `RadioTab`, rendered in the panel's
+filter strip (the slot the notification search occupies on the other tabs) so
+it never scrolls away. State is `approvalsView` on the panel store;
+`openApprovals()` resets it to `pending`, because a caller pointing at one
+request is always pointing at a pending one.
+
+**Pending** renders the sections:
+
+- **Needs a decision** — `approval.list` `{ view: 'pending' }` (workflow human
+  confirmations + access requests). Not feature-flagged, fetched as one page of
+  100, sorted `expiresAt` asc nulls last client-side.
 - **Suggestions** — `approvals.list` (`mine_and_unassigned`,
   `status: ['FRESH']`, limit 25), cursor-paginated. Gated by
   `useFeatureFlags().hasAccess(FeatureKey.todayInbox)`, which skips the
   query entirely when off.
+- **Mail suggestions** — `useMailSuggestions()`, capped at five per inbox by
+  the mining job, so unpaginated.
 
-An empty section is hidden; both empty shows one `Empty` state. Search, the
+An empty section is hidden; all empty shows one `Empty` state. Search, the
 type filter, and the bulk delete actions are hidden on this tab.
+
+**Past** renders one **Decided** section from `approval.list`
+`{ view: 'past' }`, cursor-paginated, through the read-only `DecidedRow`.
+Deliberately scoped to the `ApprovalRequest` lane: suggestion bundles have
+terminal statuses too and `approvals.list` already accepts them, but
+`SuggestionRow` reads every non-`FRESH` status as "out of date — the record
+changed since this was proposed", so an approved bundle would render with copy
+that is false. Splitting `STALE` from the terminal statuses there is the
+prerequisite.
+
+`past` is the **complement** of `pending`, not a status list — see
+`listApprovalsForUser`. Its audience is also wider: it admits rows the viewer
+filed (`createdById` / `requesterId`), not just ones they were assigned, or a
+requester could never see the outcome of their own access request. The bell
+badge (`approval.getPendingCount`) stays pending-only.
+
+### Access decisions and the security log
+A decided `kind: 'access'` request writes one `AuditLog` row, from
+`recordAccessDecisionAudit` in `resolveApprovalRequest`'s **post-commit** block.
+
+- **In the shared resolve path, not the router and not the kind handlers.** The
+  resolve path is reached from the tRPC procedures, the email-token lane and the
+  bulk resolver; a router-side write covers one of three. The two handlers have
+  three terminal outcomes each, so writing there is six sites.
+- **Reads the row back post-commit** rather than trusting the claimed snapshot —
+  the handler can move the status past the claim (`approved` → `superseded`) and
+  is what writes `grantedLevel` / `grantedLens`.
+- **An approved request records `permission.granted`**, the same action the share
+  popover writes via the `resourceAccess` router, keyed on the same canonical
+  `RecordId`. "How did this person get access to X" has to be one filter on
+  `targetId`. `metadata.origin: 'approval'` plus `approvalRequestId` is what
+  distinguishes the two. Denied and superseded get `accessRequest.denied` /
+  `accessRequest.superseded` — they write no grant, but a decision visible in the
+  panel and absent from the log is indistinguishable from a dropped write.
+- **Workflow confirmations write nothing.** A human-confirmation is a business
+  decision already recorded on its `WorkflowRun`, and the `security` category
+  stays readable.
+- Never throws: `recordAudit` returns a Result and the call is wrapped, so a
+  failed audit write cannot turn a committed grant into an error the approver
+  sees. `auditContext` (IP / UA / session) is optional — the bulk and job lanes
+  have no request to derive it from, and the row is still written without it.
 
 ### `SuggestionRow` (`ui/items/suggestion-row.tsx`)
 Shows the bundle's `summary` (or a generic "`N` actions" fallback),

--- a/packages/lib/src/approval-requests/__tests__/approval-request-queries.test.ts
+++ b/packages/lib/src/approval-requests/__tests__/approval-request-queries.test.ts
@@ -88,29 +88,34 @@ describe('runStillActiveOrNotWorkflow — plan 28 H1', () => {
   })
 })
 
+/**
+ * A `db` stub that records every `where()` argument so the built predicate can be
+ * rendered to SQL and asserted, and resolves the builder to `[]` — `getPendingCount`
+ * awaits it and destructures `[row]`.
+ */
+const capture = () => {
+  const whereArgs: unknown[] = []
+  const chain: Record<string, unknown> = {}
+  for (const key of ['from', 'leftJoin', 'orderBy', 'limit']) {
+    chain[key] = () => chain
+  }
+  chain.where = (arg: unknown) => {
+    whereArgs.push(arg)
+    return chain
+  }
+  ;(chain as { then?: unknown }).then = (resolve: (v: unknown) => unknown) => resolve([])
+  return { db: { select: () => chain }, whereArgs }
+}
+
 describe('both list surfaces use the same two predicates', () => {
-  // The predicate is duplicated in SQL across `getPendingApprovalsForUser` and
+  // The predicate is duplicated in SQL across `listApprovalsForUser` and
   // `getPendingCount`. A fix applied to one leaves the badge disagreeing with the
   // list, which is why this asserts the WHERE clause of each carries both arms.
-  const capture = () => {
-    const whereArgs: unknown[] = []
-    const chain: Record<string, unknown> = {}
-    for (const key of ['from', 'leftJoin', 'orderBy', 'limit']) {
-      chain[key] = () => chain
-    }
-    chain.where = (arg: unknown) => {
-      whereArgs.push(arg)
-      return chain
-    }
-    // `getPendingCount` awaits the builder and destructures `[row]`.
-    ;(chain as { then?: unknown }).then = (resolve: (v: unknown) => unknown) => resolve([])
-    return { db: { select: () => chain }, whereArgs }
-  }
 
-  it('getPendingApprovalsForUser admits a null-expiry access row', async () => {
+  it('listApprovalsForUser admits a null-expiry access row', async () => {
     const mod = await import('../approval-request-queries')
     const { db, whereArgs } = capture()
-    await mod.getPendingApprovalsForUser(db as never, 'org1', 'user1')
+    await mod.listApprovalsForUser(db as never, 'org1', 'user1')
     const { sql, params } = render(whereArgs[0])
     expect(sql.toLowerCase()).toContain('"expiresat" is null')
     expect(sql).toContain('"kind" <>')
@@ -125,6 +130,36 @@ describe('both list surfaces use the same two predicates', () => {
     expect(sql.toLowerCase()).toContain('"expiresat" is null')
     expect(sql).toContain('"kind" <>')
     expect(params).toContain('workflow')
+  })
+})
+
+describe('listApprovalsForUser — the two views partition the member’s rows', () => {
+  // `past` is the COMPLEMENT of `pending`, not a status list. A status list would
+  // strand a `pending` access request whose 14-day expiry lapsed — nothing ever
+  // rewrites it to `timeout` — leaving it in neither view.
+  it('past negates the whole actionable predicate rather than listing statuses', async () => {
+    const mod = await import('../approval-request-queries')
+    const { db, whereArgs } = capture()
+    await mod.listApprovalsForUser(db as never, 'org1', 'user1', { view: 'past' })
+    const { sql } = render(whereArgs[0])
+    expect(sql.toLowerCase()).toContain('not (')
+    // The negated conjunction still carries both null-safety arms — negating a
+    // predicate that could go NULL would silently drop rows.
+    expect(sql.toLowerCase()).toContain('"expiresat" is null')
+  })
+
+  // A requester is never in `assigneeUsers`, so an assignee-only audience would
+  // hide the outcome of their own request — and a DENIED row is exactly the case
+  // where they have no access to hydrate the target from anywhere else.
+  it('past admits rows the member filed, pending does not', async () => {
+    const mod = await import('../approval-request-queries')
+    const past = capture()
+    await mod.listApprovalsForUser(past.db as never, 'org1', 'user1', { view: 'past' })
+    expect(render(past.whereArgs[0]).sql).toContain('"createdById"')
+
+    const pending = capture()
+    await mod.listApprovalsForUser(pending.db as never, 'org1', 'user1')
+    expect(render(pending.whereArgs[0]).sql).not.toContain('"createdById"')
   })
 })
 

--- a/packages/lib/src/approval-requests/__tests__/resolve-approval-request.test.ts
+++ b/packages/lib/src/approval-requests/__tests__/resolve-approval-request.test.ts
@@ -59,6 +59,14 @@ vi.mock('../approval-recipients', () => ({
   getApprovalAssigneeUserIds: vi.fn(async () => []),
 }))
 
+// PARTIAL mock — `AUDIT_ACTIONS` must stay real, or the assertions below pin the
+// test's own copy of the action strings instead of the shipped ones.
+const recordAudit = vi.fn(() => Promise.resolve({ isErr: () => false }))
+vi.mock('../../audit-log', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  recordAudit: (...args: unknown[]) => recordAudit(...(args as [])),
+}))
+
 const WORKFLOW_ROW = {
   id: 'req-1',
   organizationId: 'org1',
@@ -90,15 +98,36 @@ const ACCESS_ROW = {
  * pass through, while the advisory pre-flight read keeps reporting `pending` to
  * both (which is exactly the state that made the old unconditional UPDATE unsafe).
  */
-function makeDb(row: Record<string, unknown>, opts: { claimsAvailable?: number } = {}) {
+function makeDb(
+  row: Record<string, unknown>,
+  opts: {
+    claimsAvailable?: number
+    /**
+     * Opt-in: reads AFTER the transaction returns see the claimed status, which is
+     * what the post-commit audit read needs. Off by default — the race tests
+     * deliberately keep the advisory pre-flight reporting `pending` to both callers.
+     */
+    reflectClaimAfterCommit?: boolean
+  } = {}
+) {
   let claimsLeft = opts.claimsAvailable ?? 1
+  let committed = false
   const calls = {
     responseInserts: [] as unknown[],
     statusSets: [] as unknown[],
     updateWheres: [] as unknown[],
   }
+  const claimedStatus = () =>
+    (calls.statusSets.find((s) => (s as { status?: string }).status) as { status?: string })?.status
   const db: Record<string, unknown> = {
-    query: { ApprovalRequest: { findFirst: async () => ({ ...row }) } },
+    query: {
+      ApprovalRequest: {
+        findFirst: async () =>
+          opts.reflectClaimAfterCommit && committed
+            ? { ...row, status: claimedStatus() ?? row.status }
+            : { ...row },
+      },
+    },
     update: () => {
       const chain: Record<string, unknown> = {}
       chain.set = (v: unknown) => {
@@ -126,7 +155,11 @@ function makeDb(row: Record<string, unknown>, opts: { claimsAvailable?: number }
       return chain
     },
   }
-  db.transaction = async (fn: (tx: unknown) => Promise<unknown>) => fn(db)
+  db.transaction = async (fn: (tx: unknown) => Promise<unknown>) => {
+    const result = await fn(db)
+    committed = true
+    return result
+  }
   return { db, calls }
 }
 
@@ -224,6 +257,87 @@ describe('atomic decision claim (plan 42 §4.1)', () => {
     expect((applyAccessDecision.mock.calls as unknown as Array<[unknown]>)[0]![0]).toMatchObject({
       action: 'deny',
     })
+  })
+
+  it('an APPROVED access decision writes the security-log row', async () => {
+    const { resolveApprovalRequest } = await import('../approval-request-mutations')
+    const { db } = makeDb(ACCESS_ROW, { reflectClaimAfterCommit: true })
+
+    await resolveApprovalRequest(db as never, {
+      approvalRequestId: 'req-1',
+      userId: 'user1',
+      action: 'approve',
+      auditContext: { ipAddress: '1.2.3.4', userAgent: 'agent', sessionId: 'sess-1' },
+    })
+
+    expect(recordAudit).toHaveBeenCalledTimes(1)
+    expect(
+      (recordAudit.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    ).toMatchObject({
+      category: 'security',
+      // The SAME action the share popover writes — an approved request is a
+      // permission grant, and "how did they get access to X" must be one filter.
+      action: 'permission.granted',
+      actorId: 'user1',
+      targetType: 'Resource',
+      targetId: 'thread:thread-1',
+      metadata: { origin: 'approval', approvalRequestId: 'req-1', granteeId: 'requester1' },
+      context: { ipAddress: '1.2.3.4', userAgent: 'agent', sessionId: 'sess-1' },
+    })
+  })
+
+  it('a DENIED access decision is logged too, under its own action', async () => {
+    const { resolveApprovalRequest } = await import('../approval-request-mutations')
+    const { db } = makeDb(ACCESS_ROW, { reflectClaimAfterCommit: true })
+
+    await resolveApprovalRequest(db as never, {
+      approvalRequestId: 'req-1',
+      userId: 'user1',
+      action: 'deny',
+    })
+
+    // Not `permission.granted` — nothing was granted — but recorded all the same:
+    // a decision that appears in the panel and nowhere in the log is
+    // indistinguishable from a dropped write.
+    expect(
+      (recordAudit.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    ).toMatchObject({ action: 'accessRequest.denied' })
+  })
+
+  it('a WORKFLOW confirmation writes NO security-log row', async () => {
+    const { resolveApprovalRequest } = await import('../approval-request-mutations')
+    const { db } = makeDb(WORKFLOW_ROW, { reflectClaimAfterCommit: true })
+
+    await resolveApprovalRequest(db as never, {
+      approvalRequestId: 'req-1',
+      userId: 'user1',
+      action: 'approve',
+    })
+
+    // A human-confirmation is a business decision, already recorded on its
+    // `WorkflowRun`. The lane gate is what keeps the security category readable.
+    expect(recordAudit).not.toHaveBeenCalled()
+  })
+
+  it('the LOSER of a race logs nothing', async () => {
+    const { resolveApprovalRequest } = await import('../approval-request-mutations')
+    const { db } = makeDb(ACCESS_ROW, { claimsAvailable: 1 })
+
+    await resolveApprovalRequest(db as never, {
+      approvalRequestId: 'req-1',
+      userId: 'user1',
+      action: 'approve',
+    })
+    recordAudit.mockClear()
+    await resolveApprovalRequest(db as never, {
+      approvalRequestId: 'req-1',
+      userId: 'user2',
+      action: 'deny',
+    })
+
+    // `decidedKind` is set inside the claim, so only the winner reaches the write.
+    // Otherwise every refused double-decision would file a second grant row.
+    expect(recordAudit).not.toHaveBeenCalled()
   })
 
   it('a handler that throws rolls the decision back — no post-commit side effects', async () => {

--- a/packages/lib/src/approval-requests/approval-request-mutations.ts
+++ b/packages/lib/src/approval-requests/approval-request-mutations.ts
@@ -12,9 +12,11 @@
 import { type Database, schema } from '@auxx/database'
 import { ApprovalStatus } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
 import crypto from 'crypto'
 import { and, eq, inArray, lt } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
+import { AUDIT_ACTIONS, type AuditContext, recordAudit } from '../audit-log'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../errors'
 import { publisher } from '../events/publisher'
 import { getQueue, Queues } from '../jobs/queues'
@@ -25,6 +27,112 @@ import { allowsTokenResolution, getApprovalKindHandler } from './registry'
 import type { ApprovalAudience, ApprovalRequestEntity, ApprovalResponseResult } from './types'
 
 const logger = createScopedLogger('approval-requests')
+
+/**
+ * Final status → audit action, for the `access` lane only.
+ *
+ * `approved` maps onto `permission.granted` — the SAME action the share popover
+ * writes through `resourceAccess` — deliberately. An approved access request *is* a
+ * permission grant, and the question an audit log exists to answer ("how did this
+ * person get access to X?") has to be one filter on `targetId`, not a union of two
+ * actions one of which the reader has to know exists. The two paths also agree on
+ * `targetId`: both key it on the canonical `RecordId`.
+ *
+ * The outcomes that write NO grant get their own actions rather than being
+ * omitted — an admin who sees a request marked Denied or Superseded in the panel
+ * and finds nothing in the log cannot tell a decision that wrote nothing from a log
+ * that dropped a write.
+ */
+const ACCESS_DECISION_ACTIONS: Record<string, string> = {
+  [ApprovalStatus.approved]: AUDIT_ACTIONS.permissionGranted,
+  [ApprovalStatus.denied]: AUDIT_ACTIONS.accessRequestDenied,
+  [ApprovalStatus.superseded]: AUDIT_ACTIONS.accessRequestSuperseded,
+}
+
+/**
+ * Append the security-log row for one decided ACCESS request.
+ *
+ * Lives here, in the shared resolve path, rather than in the router or in the two
+ * kind handlers, for one reason each:
+ *
+ * - **Not the router.** `resolveApprovalRequest` is reached from the tRPC
+ *   procedures, the email-token lane, and the bulk resolver. A router-side write
+ *   covers one of the three and silently omits the rest — and it is a permission
+ *   grant that goes unlogged, which is the failure this closes in the first place.
+ * - **Not the handlers.** The thread and record arms have three terminal outcomes
+ *   each; six call sites is six chances for a new outcome to ship unlogged.
+ *
+ * Reads the row back POST-COMMIT rather than trusting the claimed snapshot: the
+ * handler may have moved the status past the claim (`approved` → `superseded`) and
+ * is what writes `grantedLevel`/`grantedLens`. One primary-key read.
+ *
+ * Never throws. `recordAudit` already returns a Result, and a failed audit write
+ * must not turn a committed grant into an error the approver sees.
+ */
+async function recordAccessDecisionAudit(
+  db: Database,
+  approvalRequestId: string,
+  approverUserId: string,
+  context?: AuditContext
+): Promise<void> {
+  try {
+    const row = await db.query.ApprovalRequest.findFirst({
+      where: eq(schema.ApprovalRequest.id, approvalRequestId),
+      columns: {
+        organizationId: true,
+        status: true,
+        requesterId: true,
+        entityDefinitionId: true,
+        entityInstanceId: true,
+        subjectLabel: true,
+        grantedLevel: true,
+        grantedLens: true,
+      },
+    })
+    const action = row ? ACCESS_DECISION_ACTIONS[row.status] : undefined
+    if (!row || !action) return
+
+    const result = await recordAudit({
+      organizationId: row.organizationId,
+      category: 'security',
+      action,
+      actorType: 'user',
+      actorId: approverUserId,
+      targetType: 'Resource',
+      targetId:
+        row.entityDefinitionId && row.entityInstanceId
+          ? toRecordId(row.entityDefinitionId, row.entityInstanceId)
+          : null,
+      newState: {
+        status: row.status,
+        rung: row.grantedLens,
+        level: row.grantedLevel,
+      },
+      metadata: {
+        scope: 'instance',
+        // What distinguishes this row from the share popover's `permission.granted`:
+        // the grant was asked for and decided, and this is the request it came from.
+        origin: 'approval',
+        approvalRequestId,
+        granteeType: 'user',
+        granteeId: row.requesterId,
+        subjectLabel: row.subjectLabel,
+      },
+      context,
+    })
+    if (result.isErr()) {
+      logger.warn('Failed to write access-decision audit row', {
+        approvalRequestId,
+        error: result.error.message,
+      })
+    }
+  } catch (error) {
+    logger.warn('Failed to write access-decision audit row', {
+      approvalRequestId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
 
 /**
  * Record one approver's decision.
@@ -53,6 +161,12 @@ export async function resolveApprovalRequest(
     comment?: string
     ipAddress?: string
     /**
+     * Request context for the security-log row an `access` decision writes. Optional
+     * because the bulk resolver and any job-driven caller have no request to derive
+     * it from — the row is still written, just without IP/UA/session.
+     */
+    auditContext?: AuditContext
+    /**
      * Set by the unauthenticated email-token lane. When true the kind must have
      * opted in via `allowsTokenResolution` (plan 28 H5) — a hard reject, not a
      * "we won't send those emails" convention.
@@ -60,10 +174,12 @@ export async function resolveApprovalRequest(
     viaToken?: boolean
   }
 ): Promise<Result<ApprovalResponseResult, Error>> {
-  const { approvalRequestId, userId, action, comment, ipAddress, viaToken } = params
+  const { approvalRequestId, userId, action, comment, ipAddress, auditContext, viaToken } = params
   let audience: ApprovalAudience | undefined
   let organizationId: string | undefined
   let afterCommit: ((db: Database) => Promise<void>) | undefined
+  /** Set only by the WINNER of the claim — the loser must log nothing. */
+  let decidedKind: string | undefined
 
   const outcome = await guard(
     async () => {
@@ -115,6 +231,7 @@ export async function resolveApprovalRequest(
           // The loser. No response row, no handler, no side effect.
           return { success: false, message: 'Approval already decided' }
         }
+        decidedKind = claimed.kind
 
         await tx.insert(schema.ApprovalResponse).values({
           approvalRequestId,
@@ -173,6 +290,16 @@ export async function resolveApprovalRequest(
           error: error instanceof Error ? error.message : String(error),
         })
       }
+    }
+    // Post-commit and AFTER the handler, so the row reflects the final status the
+    // handler settled on. Only the access lane: a workflow confirmation is a
+    // business decision already recorded on its `WorkflowRun`, not a security event.
+    if (decidedKind === 'access') {
+      await recordAccessDecisionAudit(db, approvalRequestId, userId, {
+        ipAddress: auditContext?.ipAddress ?? ipAddress ?? null,
+        userAgent: auditContext?.userAgent ?? null,
+        sessionId: auditContext?.sessionId ?? null,
+      })
     }
     await retractApprovalNotifications(db, approvalRequestId, organizationId)
     await publishResolved(db, approvalRequestId, audience)

--- a/packages/lib/src/approval-requests/approval-request-queries.ts
+++ b/packages/lib/src/approval-requests/approval-request-queries.ts
@@ -16,6 +16,7 @@ import {
   and,
   arrayContains,
   arrayOverlaps,
+  asc,
   count,
   desc,
   eq,
@@ -25,6 +26,7 @@ import {
   isNull,
   lte,
   ne,
+  not,
   or,
   type SQL,
   sql,
@@ -91,24 +93,118 @@ function assignedTo(userId: string, userGroupIds: string[]): SQL | undefined {
 }
 
 /**
- * Every pending approval waiting on one member — both kinds, in one list.
+ * "This request can still be decided" — the `pending` view's predicate, and the
+ * NEGATION of the `past` view's.
+ *
+ * Defining the two views as `p` and `NOT p` over one builder is what makes them a
+ * PARTITION: every row the member can see is in exactly one of them. Spelling
+ * `past` out as a status list instead would silently strand the rows that are
+ * dead without being terminal — a `pending` access request whose 14-day
+ * `expiresAt` lapsed is never rewritten to `timeout` (only the workflow lane has a
+ * cleanup, `cleanupApprovalsForWorkflowRun`), so a status-list `past` would drop
+ * it from both surfaces and it would exist nowhere in the UI.
+ *
+ * `not()` is sound here only because none of the three conjuncts can evaluate to
+ * NULL (`NOT NULL` is NULL, which would silently exclude the row — the same shape
+ * of bug H1 and its sibling were): `status` is NOT NULL; {@link notExpired} is an
+ * `IS NULL` disjunction; and {@link runStillActiveOrNotWorkflow}'s first arm is
+ * TRUE for every non-workflow row, while a workflow row always has an FK-backed
+ * run to join (`ApprovalRequest_workflow_columns_check`).
+ */
+function stillActionable(): SQL {
+  // Narrowed here rather than at the `not()` call site: `and()` is typed
+  // `SQL | undefined` because it returns undefined when EVERY argument is, and
+  // `eq()` on a non-null column never is. `not()` is the one caller that cannot
+  // take the wider type.
+  return and(
+    eq(schema.ApprovalRequest.status, ApprovalStatus.pending),
+    notExpired(),
+    runStillActiveOrNotWorkflow()
+  ) as SQL
+}
+
+/** Which slice of the member's approvals to list. */
+export type ApprovalListView = 'pending' | 'past'
+
+export interface ListApprovalsForUserArgs {
+  /** Defaults to `pending`, which is the pre-history behaviour of this query. */
+  view?: ApprovalListView
+  cursor?: string
+  limit?: number
+}
+
+function encodeApprovalCursor(createdAt: Date, id: string): string {
+  return Buffer.from(`${createdAt.toISOString()}|${id}`).toString('base64url')
+}
+
+function decodeApprovalCursor(cursor?: string): { createdAt: Date; id: string } | undefined {
+  if (!cursor) return undefined
+  const [createdAt, id] = Buffer.from(cursor, 'base64url').toString('utf8').split('|')
+  if (!createdAt || !id) return undefined
+  const parsed = new Date(createdAt)
+  return Number.isNaN(parsed.getTime()) ? undefined : { createdAt: parsed, id }
+}
+
+/**
+ * One member's approvals — both kinds, in one list, in either of two views.
+ *
+ * - `pending` (default) is what still needs a decision FROM THIS MEMBER, so its
+ *   audience is the assignee set alone.
+ * - `past` is what this member was INVOLVED IN, so the audience additionally
+ *   admits the rows they filed themselves. Without that, a requester could never
+ *   see the outcome of their own access request: a requester is never in
+ *   `assigneeUsers`, and a `denied` row is the one case where they got no access
+ *   to hydrate the target from either.
+ *
+ * The two audiences are deliberately asymmetric. Folding `createdById` into the
+ * pending audience too would surface a member's own open request under "needs a
+ * decision", which they cannot act on.
  *
  * The access-lane columns are projected alongside the workflow ones because the
  * rows H1 stopped excluding are useless to the Approvals tab without them.
  *
- * `requester` is resolved for the whole list in ONE org-member cache read rather
- * than a `User` join or a per-row query (plan 42 §6.2's rule, applied to the
- * approver side): "who asked" is the lead of an access row's collapsed copy, so it
- * cannot be deferred to the lazily-fetched detail drawer without the row rendering
- * anonymous. `null` for workflow rows, which have no requester.
+ * `requester` and (for decided rows) `decision.by` are resolved for the whole page
+ * in ONE org-member cache read rather than `User` joins or per-row queries (plan
+ * 42 §6.2's rule, applied to the approver side): "who asked" is the lead of an
+ * access row's collapsed copy and "who decided" is the lead of a past row's, so
+ * neither can be deferred to the lazily-fetched detail drawer without the row
+ * rendering anonymous.
+ *
+ * ⚠ **The `past` view has no covering index.** Both audience GINs are partial on
+ * `status = 'pending'` (deliberately — see the schema), so this falls back to
+ * `ApprovalRequest_organizationId_idx` and rechecks the assignee arrays on the
+ * heap. It is bounded by the page limit and by how rarely history is opened; the
+ * fix, if it ever bites, is to drop the partial predicate rather than to widen
+ * this query's filters.
  */
-export async function getPendingApprovalsForUser(
+export async function listApprovalsForUser(
   db: Database,
   organizationId: string,
-  userId: string
+  userId: string,
+  args: ListApprovalsForUserArgs = {}
 ) {
+  const view = args.view ?? 'pending'
+  const limit = Math.min(args.limit ?? 25, 100)
+  const isPast = view === 'past'
   const userGroups = await getCachedUserGroupIds(organizationId, userId)
-  const rows = await db
+  const cursor = decodeApprovalCursor(args.cursor)
+
+  // `past` reads newest-first — a history is scanned backwards from the last
+  // decision. `pending` keeps its original oldest-first order; the Approvals tab
+  // re-sorts that section by deadline anyway, so this only decides ties among
+  // rows with no expiry, where oldest-first is the fairer queue.
+  //
+  // Ordered by `createdAt`, NOT by when the decision landed: there is no
+  // decided-at column, and `ApprovalResponse.respondedAt` exists only for
+  // approve/deny. `withdrawn` and `timeout` are bare status writes with no
+  // response row, so ordering on the join would strand them at one end.
+  const cursorCondition = cursor
+    ? isPast
+      ? sql`(${schema.ApprovalRequest.createdAt}, ${schema.ApprovalRequest.id}) < (${cursor.createdAt}, ${cursor.id})`
+      : sql`(${schema.ApprovalRequest.createdAt}, ${schema.ApprovalRequest.id}) > (${cursor.createdAt}, ${cursor.id})`
+    : undefined
+
+  const selected = await db
     .select({
       id: schema.ApprovalRequest.id,
       organizationId: schema.ApprovalRequest.organizationId,
@@ -129,6 +225,8 @@ export async function getPendingApprovalsForUser(
       area: schema.ApprovalRequest.area,
       requestedLevel: schema.ApprovalRequest.requestedLevel,
       requestedLens: schema.ApprovalRequest.requestedLens,
+      grantedLevel: schema.ApprovalRequest.grantedLevel,
+      grantedLens: schema.ApprovalRequest.grantedLens,
       workflow: {
         name: schema.Workflow.name,
         id: schema.Workflow.id,
@@ -143,42 +241,101 @@ export async function getPendingApprovalsForUser(
     .where(
       and(
         eq(schema.ApprovalRequest.organizationId, organizationId),
-        eq(schema.ApprovalRequest.status, ApprovalStatus.pending),
-        notExpired(),
-        assignedTo(userId, userGroups),
-        runStillActiveOrNotWorkflow()
+        isPast ? not(stillActionable()) : stillActionable(),
+        isPast
+          ? or(
+              assignedTo(userId, userGroups),
+              eq(schema.ApprovalRequest.createdById, userId),
+              // Redundant with `createdById` for today's self-service flow, and
+              // deliberately not folded into it: the schema separates the two for
+              // a future admin-filed-on-behalf-of request, and that request's
+              // subject must still see its own outcome.
+              eq(schema.ApprovalRequest.requesterId, userId)
+            )
+          : assignedTo(userId, userGroups),
+        cursorCondition
       )
     )
-    .orderBy(schema.ApprovalRequest.createdAt)
+    .orderBy(
+      ...(isPast
+        ? [desc(schema.ApprovalRequest.createdAt), desc(schema.ApprovalRequest.id)]
+        : [asc(schema.ApprovalRequest.createdAt), asc(schema.ApprovalRequest.id)])
+    )
+    .limit(limit + 1)
 
-  const requesterIds = [
-    ...new Set(rows.flatMap((row) => (row.requesterId ? [row.requesterId] : []))),
-  ]
-  const members = requesterIds.length
-    ? await getCachedMembersByUserIds(organizationId, requesterIds)
+  const hasMore = selected.length > limit
+  const rows = hasMore ? selected.slice(0, limit) : selected
+  const last = rows[rows.length - 1]
+  const nextCursor = hasMore && last ? encodeApprovalCursor(last.createdAt, last.id) : undefined
+
+  // Only the `past` view can carry decisions, and only approve/deny write a
+  // response row at all — a `withdrawn`, `timeout` or lapsed row has none, and
+  // renders on its status alone.
+  const decidedIds = isPast ? rows.map((row) => row.id) : []
+  const responses = decidedIds.length
+    ? await db
+        .select({
+          approvalRequestId: schema.ApprovalResponse.approvalRequestId,
+          userId: schema.ApprovalResponse.userId,
+          action: schema.ApprovalResponse.action,
+          comment: schema.ApprovalResponse.comment,
+          respondedAt: schema.ApprovalResponse.respondedAt,
+        })
+        .from(schema.ApprovalResponse)
+        .where(inArray(schema.ApprovalResponse.approvalRequestId, decidedIds))
     : []
-  const byUserId = new Map(members.map((member) => [member.userId, member]))
+  // Fetched as a second query rather than a join: the unique index is on
+  // `(approvalRequestId, userId)`, so a join is a fan-out risk that would
+  // duplicate list rows, and the page's decider ids fold into the same member
+  // cache read the requesters already pay for.
+  const byRequestId = new Map(responses.map((response) => [response.approvalRequestId, response]))
 
-  return rows.map((row) => {
-    const member = row.requesterId ? byUserId.get(row.requesterId) : undefined
+  const memberIds = [
+    ...new Set([
+      ...rows.flatMap((row) => (row.requesterId ? [row.requesterId] : [])),
+      ...responses.map((response) => response.userId),
+    ]),
+  ]
+  const members = memberIds.length ? await getCachedMembersByUserIds(organizationId, memberIds) : []
+  const byUserId = new Map(members.map((member) => [member.userId, member]))
+  const toPerson = (id: string | null | undefined) => {
+    const member = id ? byUserId.get(id) : undefined
+    return member
+      ? {
+          userId: member.userId,
+          name: member.user?.name ?? null,
+          image: member.user?.image ?? null,
+        }
+      : null
+  }
+
+  const items = rows.map((row) => {
+    const response = byRequestId.get(row.id)
     return {
       ...row,
-      requester: member
+      requester: toPerson(row.requesterId),
+      decision: response
         ? {
-            userId: member.userId,
-            name: member.user?.name ?? null,
-            image: member.user?.image ?? null,
+            action: response.action,
+            comment: response.comment,
+            respondedAt: response.respondedAt,
+            by: toPerson(response.userId),
           }
         : null,
     }
   })
+
+  return { items, nextCursor }
 }
 
 /**
  * Badge count for the Approvals tab. The predicate is DELIBERATELY identical to
- * {@link getPendingApprovalsForUser}'s — they are duplicated in SQL, so both H1
- * and the null-expiry reading have to be applied twice or the badge disagrees
- * with the list.
+ * {@link listApprovalsForUser}'s `pending` view — they are duplicated in SQL, so
+ * both H1 and the null-expiry reading have to be applied twice or the badge
+ * disagrees with the list. {@link stillActionable} is what they now share.
+ *
+ * Stays pending-only, and takes no `view`: this is the number on the bell, and
+ * history is not a thing anyone needs to be counted at.
  */
 export async function getPendingCount(
   db: Database,
@@ -193,10 +350,8 @@ export async function getPendingCount(
     .where(
       and(
         eq(schema.ApprovalRequest.organizationId, organizationId),
-        eq(schema.ApprovalRequest.status, ApprovalStatus.pending),
-        notExpired(),
-        assignedTo(userId, userGroups),
-        runStillActiveOrNotWorkflow()
+        stillActionable(),
+        assignedTo(userId, userGroups)
       )
     )
   // `count(*)` is int8, which pg hands back as a string. The caller adds this to

--- a/packages/lib/src/approval-requests/index.ts
+++ b/packages/lib/src/approval-requests/index.ts
@@ -60,6 +60,10 @@ export {
   resolveApprovalRequests,
   validateApprovalToken,
 } from './approval-request-mutations'
+export type {
+  ApprovalListView,
+  ListApprovalsForUserArgs,
+} from './approval-request-queries'
 export {
   canUserApprove,
   canUserViewApproval,
@@ -67,11 +71,11 @@ export {
   getApprovalRequestById,
   getApprovalRequestWithContext,
   getApprovalsByStatus,
-  getPendingApprovalsForUser,
   getPendingApprovers,
   getPendingCount,
   getUserApprovalStats,
   getWorkflowApprovalHistory,
+  listApprovalsForUser,
 } from './approval-request-queries'
 export type {
   AccessLens,

--- a/packages/lib/src/audit-log/audit-actions.ts
+++ b/packages/lib/src/audit-log/audit-actions.ts
@@ -23,6 +23,12 @@ export const AUDIT_ACTIONS = {
   permissionGranted: 'permission.granted',
   permissionRevoked: 'permission.revoked',
   permissionSet: 'permission.set',
+  // Access-request decisions. An APPROVED request deliberately records
+  // `permission.granted` — the same action the share popover writes — because "how
+  // did this person get access to X" must be one filter on `targetId`, not two. Only
+  // the outcomes that write no grant get their own actions.
+  accessRequestDenied: 'accessRequest.denied',
+  accessRequestSuperseded: 'accessRequest.superseded',
   permissionProfileCreated: 'permission.profile.created',
   permissionProfileUpdated: 'permission.profile.updated',
   sessionsInvalidated: 'sessions.invalidated',


### PR DESCRIPTION
## Why

Decided approvals were retained in full but unreadable. Every read path filtered to `pending`/`FRESH`, there was no route or page for history, and `getApprovalsByStatus` / `getWorkflowApprovalHistory` / `getUserApprovalStats` had zero callers. Separately, approving an access request wrote a `ResourceAccess` grant with **no audit row at all** — `permission.granted` was only ever written by the `resourceAccess` router's manual sharing path.

## Past-approvals view

`approval.getPendingRequests` → **`approval.list`**, taking `{ view: 'pending' | 'past', cursor, limit }` and returning `{ items, nextCursor }`. `getApprovalDetails` needed no change — it already admits terminal rows by design.

Two things worth reviewing closely:

**`past` is the complement of "still actionable", not a status list.** `stillActionable()` (pending + not expired + live run) was extracted, and `past` is `not(stillActionable())`. A status list would have stranded a real case: an access request's 14-day expiry lapses but nothing ever rewrites it to `timeout` — only the workflow lane has a cleanup — so it stays `pending` forever and a status-list `past` would drop it from *both* views. As a partition, every row lands in exactly one. `not()` is safe here only because none of the three conjuncts can evaluate to NULL; the reasoning is written out at the definition.

**The two views have different audiences, deliberately.** `pending` stays assignee-only. `past` also admits `createdById` / `requesterId` — a requester is never in `assigneeUsers`, so without it they could never see the outcome of their own request, and a *denied* row is exactly the case where they have no access to hydrate the target from anywhere else. Folding `createdById` into `pending` too would surface a member's own open request under "needs a decision", which they cannot act on.

`getPendingCount` stays pending-only and now shares the predicate builder with the list, which is what the existing list/badge parity test pins.

### UI

A **Pending / Past** `RadioTab` in the panel's filter strip (the slot the notification search occupies on the other tabs), so it doesn't scroll away. State is `approvalsView` on the panel store; `openApprovals()` resets it to `pending`, since a caller pointing at one request is always pointing at a pending one.

`DecidedRow` is a new read-only row rather than a `readOnly` flag on the existing three — those are decision surfaces down to their structure (comment box, confirm dialog, two mutations, expiry countdown) and none of it survives the decision.

### Known limitation

The Past view is scoped to the `ApprovalRequest` lane. Suggestion bundles have terminal statuses and `approvals.list` already accepts them, but `SuggestionRow:92` computes `isStale = bundle.status !== 'FRESH'` and renders *"Out of date — the record changed since this was proposed"*, so an APPROVED bundle would show copy that is false. Splitting `STALE` from the terminal statuses there is the prerequisite and is its own change. (Side note: since the pending list filters to `['FRESH']`, that stale banner is currently unreachable code.)

## Audit row for access decisions

A decided `kind: 'access'` request now writes one `AuditLog` row from `resolveApprovalRequest`'s **post-commit** block.

- **In the shared resolve path, not the router and not the kind handlers.** The resolve path is reached from the tRPC procedures, the email-token lane, and the bulk resolver; a router-side write covers one of three, and what goes unlogged is a permission grant. The two handlers have three terminal outcomes each — six sites.
- **Reads the row back post-commit** rather than trusting the claimed snapshot: the handler can move the status past the claim (`approved` → `superseded`) and is what writes `grantedLevel`/`grantedLens`.
- **Approve records `permission.granted`** — the same action the share popover writes, on the same canonical `RecordId` as `targetId` — so "how did this person get access to X" stays one filter rather than a union of two actions. `metadata.origin: 'approval'` + `approvalRequestId` distinguishes them. Denied/superseded get `accessRequest.denied` / `accessRequest.superseded`: they write no grant, but a decision visible in the panel and absent from the log is indistinguishable from a dropped write.
- **Workflow confirmations write nothing** — a human-confirmation is a business decision already on its `WorkflowRun`.
- Never throws. `recordAudit` returns a Result and the call is wrapped, so a failed audit write cannot turn a committed grant into an error the approver sees.

Side effect worth noting: the web `approve`/`deny` procedures weren't passing any request context, so `ApprovalResponse.ipAddress` was null on every web decision — only the email-token lane filled it. They now pass `requestAuditContext(ctx.headers)`, which feeds both that column and the audit row.

## Tests

New coverage pins the invariants that are easy to regress:

- `past` negates the whole actionable predicate rather than listing statuses, and still carries both null-safety arms
- `past` admits rows the member filed; `pending` does not
- approve writes `permission.granted` with the right target / grantee / context
- deny writes its own action
- a workflow row writes nothing
- **the loser of a race writes nothing** — without the `decidedKind`-inside-the-claim gate, every refused double-decision would file a second grant row

## Verification

- 138 lib `approval-requests` tests pass (was 134)
- `resource-access-plan-gate` integration test still passes, including "the APPROVAL decision handler runs the same gate before granting"
- web notification tests pass
- `tsc --noEmit` clean for every touched file in both `packages/lib` and `apps/web`
- Biome clean

No schema changes, no migration.
