### PR TITLE
feat(mail): classify inbound mail into existing tags

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/tags/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/tags/page.tsx
@@ -1,4 +1,8 @@
-import SettingsPage from '~/components/global/settings-page'
+// apps/web/src/app/(protected)/app/settings/tags/page.tsx
+
+import { ArrowRight, Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { TagTreeView } from '~/components/tags/ui/tags-list'
 
 /**
@@ -15,6 +19,33 @@ async function TagsPage() {
       title='Company Tags'
       description='Shared tags help you and your team stay organize conversations, tickets, and more'
       breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Tags' }]}>
+      {/* AI tagging needs BOTH halves: an eligible tag here and an opted-in
+          inbox there. Marking five tags and seeing nothing happen because no
+          inbox is switched on is a dead end, so the two halves point at each
+          other. */}
+      <div className='border-b p-3 sm:p-6'>
+        <SettingsSection
+          icon={<Sparkles className='size-4' />}
+          title='AI tagging'
+          description={
+            <>
+              Open any tag and turn on <span className='font-medium'>Let AI apply this tag</span> to
+              add it to the set Auxx may apply to incoming mail — its description tells the
+              classifier when it fits. Nothing is classified until you also switch a specific inbox
+              on.
+            </>
+          }
+          action={
+            <Link
+              href='/app/settings/inbox'
+              className='inline-flex min-w-0 items-center gap-1.5 text-primary-600 text-sm underline-offset-4 hover:underline'>
+              <span className='truncate'>Inbox settings</span>
+              <ArrowRight className='size-3.5 shrink-0' />
+            </Link>
+          }
+        />
+      </div>
+
       <TagTreeView />
     </SettingsPage>
   )

--- a/apps/web/src/components/inbox/inbox-detail.tsx
+++ b/apps/web/src/components/inbox/inbox-detail.tsx
@@ -24,6 +24,7 @@ import { InboxDialog } from './inbox-dialog'
 import { ConnectExistingChannelDialog } from './ui/connect-existing-channel-dialog'
 import { InboxChannelCard } from './ui/inbox-channel-card'
 import { InboxChannelPlaceholderCard } from './ui/inbox-channel-placeholder-card'
+import { InboxClassificationCard } from './ui/inbox-classification-card'
 import { InboxInfoCard } from './ui/inbox-info-card'
 
 const GRID_CLASS = 'grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'
@@ -81,6 +82,19 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
   const canDeleteInbox = inbox?.isPersonal
     ? inbox.ownerUserId === userId
     : !!inbox && canRouteChannels
+
+  /**
+   * The AI-classification opt-in answers to the mail model, never to admin rank
+   * (05-mail-classification-plan §5): a personal mailbox is its owner's alone, a
+   * shared one needs `automationRules.manage` + inbox `admin`.
+   *
+   * Read off `mailFilters.authorableInboxes` rather than re-derived from the
+   * capability blob, because that query IS the authority the classification
+   * router asserts with — so the card can never appear where the write would
+   * 403, or be hidden where it would have succeeded.
+   */
+  const { data: authorableInboxes } = api.mailFilters.authorableInboxes.useQuery()
+  const canConfigureClassification = !!authorableInboxes?.some((entry) => entry.id === inboxId)
 
   const isLoading = isLoadingInbox || isLoadingIntegrations || isLoadingCapabilities
 
@@ -231,6 +245,7 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
                   </div>
                 </div>
               </SettingsSection>
+              {canConfigureClassification && <InboxClassificationCard inboxId={inboxId} />}
             </div>
           ) : (
             <EmptyState

--- a/apps/web/src/components/inbox/ui/inbox-classification-card.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-classification-card.tsx
@@ -1,0 +1,108 @@
+// apps/web/src/components/inbox/ui/inbox-classification-card.tsx
+
+'use client'
+
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { ToggleCard } from '@auxx/ui/components/toggle-card'
+import { Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import { SettingsSection } from '~/components/global/settings-page'
+import { api } from '~/trpc/react'
+
+/**
+ * The per-inbox mail-classification opt-in
+ * (`plans/mail-filter/05-mail-classification-plan.md` §6.4).
+ *
+ * Rendered only for callers who may author automation on this inbox — the
+ * parent decides that from `mailFilters.authorableInboxes`, which is the SAME
+ * authority the router asserts, so the card can never be offered where the
+ * write would be refused.
+ *
+ * Three things this card must say out loud, because each is a question a user
+ * would otherwise have to guess at:
+ *
+ * - **What the AI reads.** "Does AI read my mail" deserves a straight answer,
+ *   in the place where the answer changes. Subject, sender, the start of the
+ *   body, inbound only, this inbox only.
+ * - **Whether it can do anything.** The classifier only ever applies tags that
+ *   are marked AI-eligible (C8's second guard). With none marked, arming the
+ *   inbox is completely inert — so the switch is disabled and says why, rather
+ *   than flipping on and looking like it worked.
+ * - **What it costs.** Metered per inbound message, zero on your own key.
+ */
+export function InboxClassificationCard({ inboxId }: { inboxId: string }) {
+  const utils = api.useUtils()
+  const { data, isPending } = api.mailClassification.getInboxSettings.useQuery({ inboxId })
+
+  const setClassification = api.mailClassification.setInboxEnabled.useMutation({
+    onSuccess: () => utils.mailClassification.getInboxSettings.invalidate({ inboxId }),
+    onError: (error) => {
+      toastError({ title: 'Error updating AI classification', description: error.message })
+    },
+  })
+
+  if (isPending || !data) {
+    return (
+      <SettingsSection icon={Sparkles} title='AI classification'>
+        <Skeleton className='h-20 w-full rounded-xl' />
+      </SettingsSection>
+    )
+  }
+
+  const { enabled, eligibleTagCount } = data
+  const hasEligibleTags = eligibleTagCount > 0
+
+  return (
+    <SettingsSection
+      icon={Sparkles}
+      title='AI classification'
+      description='Let Auxx categorise new mail in this inbox by applying your tags.'>
+      <ToggleCard
+        title='Classify incoming mail'
+        icon={<Sparkles className='size-3.5' />}
+        checked={enabled}
+        // Turning it on with nothing to apply would do nothing at all — and a
+        // switch that flips on and changes nothing is worse than one that
+        // explains itself.
+        disabled={setClassification.isPending || (!enabled && !hasEligibleTags)}
+        onCheckedChange={(next) => setClassification.mutate({ inboxId, enabled: next })}
+        // The description carries a link, so a click anywhere must not also
+        // toggle the switch.
+        rowClickToggles={false}
+        description={
+          <>
+            <span className='block'>
+              Auxx sends the subject, the sender and the first part of the message body of each new
+              incoming message <strong className='font-medium'>in this inbox only</strong> to the AI
+              model, and applies a matching tag. Mail in other inboxes, older conversations and your
+              replies are never sent.
+            </span>
+            <span className='mt-1 block'>
+              {hasEligibleTags ? (
+                <>
+                  {eligibleTagCount} {eligibleTagCount === 1 ? 'tag is' : 'tags are'} eligible.{' '}
+                  <Link href='/app/settings/tags' className='underline underline-offset-2'>
+                    Manage which tags AI may apply
+                  </Link>
+                  .
+                </>
+              ) : (
+                <>
+                  No tags are eligible yet, so this would do nothing.{' '}
+                  <Link href='/app/settings/tags' className='underline underline-offset-2'>
+                    Mark a tag as AI-applicable
+                  </Link>{' '}
+                  first.
+                </>
+              )}
+            </span>
+            <span className='mt-1 block'>
+              Metered per incoming message. Free when you bring your own API key.
+            </span>
+          </>
+        }
+      />
+    </SettingsSection>
+  )
+}

--- a/apps/web/src/components/tags/hooks/use-tag-hierarchy.ts
+++ b/apps/web/src/components/tags/hooks/use-tag-hierarchy.ts
@@ -57,6 +57,7 @@ export function useTagHierarchy(options?: UseTagHierarchyOptions): UseTagHierarc
         tag_color: record.fieldValues.tag_color ?? 'gray',
         parentId,
         isSystemTag: record.fieldValues.is_system_tag ?? false,
+        aiClassify: record.fieldValues.tag_ai_classify ?? false,
         scope: tagScope,
         children: [],
       }

--- a/apps/web/src/components/tags/tag-dialog-ai-classify.test.tsx
+++ b/apps/web/src/components/tags/tag-dialog-ai-classify.test.tsx
@@ -1,0 +1,206 @@
+// apps/web/src/components/tags/tag-dialog-ai-classify.test.tsx
+//
+// Mail-classification plan 05 §6.1 — the tag dialog's AI-eligibility card.
+//
+// Two behaviours here are decisions, not styling, and both fail silently if a
+// later refactor loses them:
+//
+//   C3 — `tag_description` stops being decorative copy and becomes the label's
+//        definition in the classifier prompt. The field itself does not change,
+//        so the RELABEL is the only place a user can learn that. A test that
+//        only asserted "a textarea exists" would pass with the relabel deleted.
+//
+//   Q5 — an eligible tag with no description WARNS but is still saved eligible.
+//        The tempting "fix" is to disable the toggle or block submit; that
+//        silently drops a tag whose switch is visibly on, which is the worse
+//        failure. So the assertion is that the warning appears AND the save
+//        still carries `tag_ai_classify: true`.
+//
+// The harness mocks only the three data hooks the dialog talks to. The form,
+// the ToggleCard, the relabel branch and the save-payload assembly are all the
+// shipped code.
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const DEF = 'edf_tag00000000000000000000000'
+const AI_FIELD_ID = 'fld_ai_classify00000000000000'
+
+const h = vi.hoisted(() => ({
+  /** Field-value payloads handed to `saveMultipleAsync`. */
+  saved: [] as Array<Array<{ fieldId: string; value: unknown; fieldType: string }>>,
+  /** `values` objects handed to `record.create`. */
+  created: [] as Array<Record<string, unknown>>,
+  /** Whether the entity migration has run for this org. */
+  hasAiField: true,
+}))
+
+vi.mock('~/components/tags/hooks/use-tag-hierarchy', () => ({
+  useTagHierarchy: () => ({
+    hierarchy: [],
+    flatTags: [],
+    tagMap: new Map(),
+    fields: {
+      title: { id: 'fld_title0000000000000000000', key: 'title', type: 'TEXT' },
+      tag_description: {
+        id: 'fld_desc00000000000000000000',
+        key: 'description',
+        type: 'RICH_TEXT',
+      },
+      tag_emoji: { id: 'fld_emoji0000000000000000000', key: 'emoji', type: 'TEXT' },
+      tag_color: { id: 'fld_color0000000000000000000', key: 'color', type: 'TEXT' },
+      tag_parent: { id: 'fld_parent000000000000000000', key: 'tag_parent', type: 'RELATIONSHIP' },
+      ...(h.hasAiField
+        ? { tag_ai_classify: { id: AI_FIELD_ID, key: 'ai_classify', type: 'CHECKBOX' } }
+        : {}),
+    },
+    isLoading: false,
+    error: null,
+    entityDefinitionId: DEF,
+    refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('~/components/resources/hooks/use-create-record', () => ({
+  useCreateRecord: () => ({
+    create: async ({ values }: { values: Record<string, unknown> }) => {
+      h.created.push(values)
+      return { instanceId: 'ein_new00000000000000000000000' }
+    },
+    isPending: false,
+  }),
+}))
+
+vi.mock('~/components/resources/hooks/use-save-field-value', () => ({
+  useSaveFieldValue: () => ({
+    saveMultipleAsync: async (
+      _recordId: string,
+      fieldValues: Array<{ fieldId: string; value: unknown; fieldType: string }>
+    ) => {
+      h.saved.push(fieldValues)
+      return true
+    },
+    isPending: false,
+  }),
+}))
+
+import { TagDialog } from '~/components/tags/ui/tag-dialog'
+
+/**
+ * The eligibility switch inside the ToggleCard header.
+ *
+ * Queried by ACCESSIBLE NAME, which doubles as a regression test on
+ * `@auxx/ui`'s `ToggleCard`: it names its switch via `aria-labelledby` pointing
+ * at the card title. This used to walk the DOM up from the title text because
+ * the primitive left the switch nameless — a screen reader announced a bare
+ * "switch, off". If that wiring is ever removed, this query fails here.
+ *
+ * A bare `getByRole('switch')` would not do either way: create mode also
+ * renders the footer's "Create more" switch.
+ */
+function aiSwitch(): HTMLElement {
+  return screen.getByRole('switch', { name: /let ai apply this tag/i })
+}
+
+/** Is the eligibility card rendered at all? */
+function hasAiCard() {
+  return screen.queryByText('Let AI apply this tag') !== null
+}
+
+describe('tag dialog — AI eligibility', () => {
+  beforeEach(() => {
+    h.saved.length = 0
+    h.created.length = 0
+    h.hasAiField = true
+  })
+
+  it('keeps the description a plain description while eligibility is off', () => {
+    render(<TagDialog open onOpenChange={vi.fn()} />)
+
+    // Editable, and NOT presented as an instruction to the model.
+    const textarea = screen.getByPlaceholderText('Optional description')
+    expect(textarea).toBeEnabled()
+    expect(screen.queryByText(/when should this tag apply\?/i)).not.toBeInTheDocument()
+    expect(aiSwitch()).not.toBeChecked()
+  })
+
+  it('relabels the description as the classifier instruction when switched on (C3)', async () => {
+    const user = userEvent.setup()
+    render(<TagDialog open onOpenChange={vi.fn()} />)
+
+    await user.click(aiSwitch())
+
+    // The relabel IS the feature: the field is unchanged, its meaning is not.
+    expect(screen.getByText(/when should this tag apply\?/i)).toBeInTheDocument()
+    expect(screen.getByText(/auxx reads this to decide/i)).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Optional description')).not.toBeInTheDocument()
+  })
+
+  it('warns on an empty description but never blocks the toggle or the save (Q5)', async () => {
+    const user = userEvent.setup()
+    render(<TagDialog open onOpenChange={vi.fn()} />)
+
+    await user.click(aiSwitch())
+
+    expect(screen.getByText(/without a description the classifier only sees/i)).toBeInTheDocument()
+    // Warn, don't disqualify — the switch stays on and stays operable.
+    expect(aiSwitch()).toBeChecked()
+    expect(aiSwitch()).toBeEnabled()
+
+    await user.type(screen.getByPlaceholderText(/questions about invoices/i), 'Billing questions')
+    expect(
+      screen.queryByText(/without a description the classifier only sees/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('creates an eligible tag even with an empty description (Q5)', async () => {
+    const user = userEvent.setup()
+    render(<TagDialog open onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Tag name'), 'Refunds')
+    await user.click(aiSwitch())
+    await user.click(screen.getByRole('button', { name: /create tag/i }))
+
+    expect(h.created).toHaveLength(1)
+    expect(h.created[0]).toMatchObject({ title: 'Refunds', tag_ai_classify: true })
+  })
+
+  it('saves the flag as a CHECKBOX field value under its resolved field id', async () => {
+    const user = userEvent.setup()
+    render(
+      <TagDialog open onOpenChange={vi.fn()} recordId={`${DEF}:ein_tag00000000000000000000`} />
+    )
+
+    await user.type(screen.getByPlaceholderText('Tag name'), 'Billing')
+    await user.click(aiSwitch())
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(h.saved).toHaveLength(1)
+    expect(h.saved[0]).toContainEqual({
+      fieldId: AI_FIELD_ID,
+      value: true,
+      fieldType: 'CHECKBOX',
+    })
+  })
+
+  it('hides the card — and sends no flag — before the entity migration has run', async () => {
+    h.hasAiField = false
+    const user = userEvent.setup()
+    render(
+      <TagDialog open onOpenChange={vi.fn()} recordId={`${DEF}:ein_tag00000000000000000000`} />
+    )
+
+    // No dead control, and the description stays a plain description.
+    expect(hasAiCard()).toBe(false)
+    expect(screen.getByPlaceholderText('Optional description')).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText('Tag name'), 'Billing')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    // The key-string fallback would fail the whole multi-save, taking the four
+    // real fields down with it — so the flag must be absent, not sent bare.
+    expect(h.saved).toHaveLength(1)
+    expect(h.saved[0].some((v) => v.fieldId === 'tag_ai_classify')).toBe(false)
+  })
+})

--- a/apps/web/src/components/tags/types.ts
+++ b/apps/web/src/components/tags/types.ts
@@ -18,6 +18,8 @@ export interface TagRecord extends RecordMeta {
     tag_color?: string
     tag_parent?: RecordId[]
     is_system_tag?: boolean
+    /** Opt-in: the mail classifier may apply this tag to inbound mail. */
+    tag_ai_classify?: boolean
     /** SINGLE_SELECT comes back as an array per the resource read pipeline. */
     tag_scope?: string | string[]
   }
@@ -35,6 +37,12 @@ export interface TagNode {
   tag_color: string
   parentId: string | null
   isSystemTag: boolean
+  /**
+   * Opt-in flag for the mail classifier (`tag_ai_classify`). When true this tag
+   * is offered to the model as a label, and `tag_description` is read as the
+   * label's definition rather than as decorative copy.
+   */
+  aiClassify: boolean
   scope: TagScopeValue
   children: TagNode[]
 }

--- a/apps/web/src/components/tags/ui/tag-dialog.tsx
+++ b/apps/web/src/components/tags/ui/tag-dialog.tsx
@@ -39,9 +39,10 @@ import {
 import { Switch } from '@auxx/ui/components/switch'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
+import { ToggleCard } from '@auxx/ui/components/toggle-card'
 import { cn } from '@auxx/ui/lib/utils'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { Loader2, Tag } from 'lucide-react'
+import { Loader2, Sparkles, Tag, TriangleAlert } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -57,10 +58,21 @@ const tagFormSchema = z.object({
   tag_description: z.string().optional().nullable(),
   tag_emoji: z.string().optional().nullable(),
   tag_color: z.string().optional().nullable(),
+  tag_ai_classify: z.boolean(),
   parentId: z.string().optional().nullable(),
 })
 
 type TagFormValues = z.infer<typeof tagFormSchema>
+
+/** Blank form state — shared by the create-mode reset paths so they cannot drift. */
+const EMPTY_TAG_FORM: TagFormValues = {
+  title: '',
+  tag_description: '',
+  tag_emoji: '',
+  tag_color: 'gray',
+  tag_ai_classify: false,
+  parentId: undefined,
+}
 
 /**
  * Tag colors are stored as free-form strings on the field value; narrow to the palette so an
@@ -98,6 +110,12 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
     isEditing && editingInstanceId ? tagMap.get(editingInstanceId)?.isSystemTag === true : false
   const isReadOnly = isSystemTag
 
+  // `tag_ai_classify` reaches an org only once its entity migration has run. No
+  // field row means no way to persist the flag, so the card is hidden rather
+  // than shown as a control whose value silently goes nowhere.
+  const aiClassifyFieldId = fields.tag_ai_classify?.id
+  const canClassify = !!aiClassifyFieldId
+
   // Track if dialog has been initialized
   const isInitialized = useRef(false)
 
@@ -107,14 +125,21 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
   // Form setup
   const form = useForm<TagFormValues>({
     resolver: standardSchemaResolver(tagFormSchema),
-    defaultValues: {
-      title: '',
-      tag_description: '',
-      tag_emoji: '',
-      tag_color: 'gray',
-      parentId: undefined,
-    },
+    defaultValues: EMPTY_TAG_FORM,
   })
+
+  // Eligibility drives the description's label, not just the card's body: when
+  // it is on, `tag_description` stops being copy and becomes the classifier's
+  // instruction for this label (plan C3).
+  const aiClassify = form.watch('tag_ai_classify')
+  const tagDescription = form.watch('tag_description')
+  const tagTitle = form.watch('title')
+
+  // Warn, but never block (plan Q5). A bare title like "Refunds" often carries
+  // enough meaning, and silently excluding a tag whose switch is visibly on is
+  // the worse failure — so the label set is built from eligibility alone and
+  // this stays a hint.
+  const missingClassifierInstruction = aiClassify && !tagDescription?.trim()
 
   // Initialize form when dialog opens
   useEffect(() => {
@@ -131,18 +156,13 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
             tag_description: tag.tag_description || '',
             tag_emoji: tag.tag_emoji || '',
             tag_color: tag.tag_color || 'gray',
+            tag_ai_classify: tag.aiClassify,
             parentId: tag.parentId || undefined,
           })
         }
       } else {
         // Create mode: reset to defaults
-        form.reset({
-          title: '',
-          tag_description: '',
-          tag_emoji: '',
-          tag_color: 'gray',
-          parentId: undefined,
-        })
+        form.reset(EMPTY_TAG_FORM)
       }
     } else {
       isInitialized.current = false
@@ -164,13 +184,7 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
 
   /** Reset form for creating another tag */
   const resetForm = useCallback(() => {
-    form.reset({
-      title: '',
-      tag_description: '',
-      tag_emoji: '',
-      tag_color: 'gray',
-      parentId: undefined,
-    })
+    form.reset(EMPTY_TAG_FORM)
   }, [form])
 
   /** Handle form submission */
@@ -207,6 +221,19 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
           },
         ]
 
+        // `tag_ai_classify` is a registry field materialized by an entity
+        // migration, so an org that has not run it yet has no field row. Send
+        // it only when it resolved to a real id — the key-string fallback above
+        // would fail the whole multi-save and take the other four fields down
+        // with it. The card is hidden in that state, so nothing is dropped.
+        if (aiClassifyFieldId) {
+          fieldValues.push({
+            fieldId: aiClassifyFieldId,
+            value: values.tag_ai_classify,
+            fieldType: 'CHECKBOX',
+          })
+        }
+
         // Handle parent relationship (key is 'tag_parent')
         if (values.parentId) {
           const parentRecordId = toRecordId(entityDefinitionId, values.parentId)
@@ -234,6 +261,10 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
           tag_description: values.tag_description || null,
           tag_emoji: values.tag_emoji || null,
           tag_color: values.tag_color || 'gray',
+        }
+
+        if (aiClassifyFieldId) {
+          formValues.tag_ai_classify = values.tag_ai_classify
         }
 
         // Handle parent relationship for create (key is 'tag_parent')
@@ -291,6 +322,46 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
       })
     },
     [tagMap]
+  )
+
+  /**
+   * The `tag_description` field. Mounted inside the ToggleCard while
+   * eligibility is on and beside it while off — exactly one of the two at a
+   * time, so the value survives the move (react-hook-form owns it, not the
+   * node) and there is never a duplicate textarea on screen.
+   *
+   * `aiMode` is the whole of plan C3: the field is unchanged, its meaning is
+   * not, and this relabel is the only place a user can learn that.
+   */
+  const renderDescriptionField = (aiMode: boolean) => (
+    <FormField
+      control={form.control}
+      name='tag_description'
+      render={({ field }) => (
+        <FormItem>
+          {aiMode && <FormLabel>When should this tag apply?</FormLabel>}
+          <FormControl>
+            <Textarea
+              placeholder={
+                aiMode
+                  ? 'e.g. Questions about invoices, charges, refunds or payment methods.'
+                  : 'Optional description'
+              }
+              className='h-20 resize-none'
+              {...field}
+              value={field.value || ''}
+              disabled={isReadOnly}
+            />
+          </FormControl>
+          <FormDescription>
+            {aiMode
+              ? 'Auxx reads this to decide whether the tag fits an incoming message. Describe the mail it should match, not the tag.'
+              : "Brief description of this tag's purpose"}
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   )
 
   return (
@@ -360,26 +431,40 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
                 </div>
               </div>
 
-              {/* Description */}
-              <FormField
-                control={form.control}
-                name='tag_description'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>
-                      <Textarea
-                        placeholder='Optional description'
-                        className='h-20 resize-none'
-                        {...field}
-                        value={field.value || ''}
-                        disabled={isReadOnly}
-                      />
-                    </FormControl>
-                    <FormDescription>Brief description of this tag's purpose</FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              {/* Description — plain when the tag is not AI-eligible, and the
+                  classifier's instruction inside the card when it is. */}
+              {(!canClassify || !aiClassify) && renderDescriptionField(false)}
+
+              {/* AI classification opt-in */}
+              {canClassify && (
+                <FormField
+                  control={form.control}
+                  name='tag_ai_classify'
+                  render={({ field }) => (
+                    <ToggleCard
+                      title='Let AI apply this tag'
+                      description='Auxx reads incoming mail and applies this tag when it fits.'
+                      icon={<Sparkles className='size-3.5' />}
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={isReadOnly}
+                      collapsible
+                      contentClassName='space-y-3'>
+                      {field.value && renderDescriptionField(true)}
+                      {missingClassifierInstruction && (
+                        <p className='flex items-start gap-1.5 text-amber-700 text-xs dark:text-amber-500'>
+                          <TriangleAlert className='mt-px size-3.5 shrink-0' />
+                          <span className='min-w-0'>
+                            Without a description the classifier only sees the name
+                            {tagTitle?.trim() ? ` “${tagTitle.trim()}”` : ''}. The tag stays
+                            eligible, but a sentence here makes it far more accurate.
+                          </span>
+                        </p>
+                      )}
+                    </ToggleCard>
+                  )}
+                />
+              )}
 
               {/* Color picker */}
               <FormField

--- a/apps/web/src/components/tags/ui/tags-list.tsx
+++ b/apps/web/src/components/tags/ui/tags-list.tsx
@@ -10,7 +10,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { Edit, Lock, Plus, Tags, Trash2 } from 'lucide-react'
+import { Edit, Lock, Plus, Sparkles, Tags, Trash2 } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -266,15 +266,33 @@ function TagTreeItem({
         </span>
       }
       title={
-        tag.isSystemTag ? (
-          <span className='inline-flex items-center gap-1.5'>
-            {tag.title}
-            <Tooltip content='System tag — managed by Auxx, read-only.'>
-              <Lock className='size-3 shrink-0 text-muted-foreground' aria-label='System tag' />
-            </Tooltip>
-          </span>
-        ) : (
+        // Bare string when there is no badge: TreeRow's own `truncate` ellipsizes
+        // inline text, but clips an inline-flex child instead — so only pay that
+        // cost on the rows that actually need a badge beside the name.
+        !tag.isSystemTag && !tag.aiClassify ? (
           tag.title
+        ) : (
+          <span className='inline-flex min-w-0 items-center gap-1.5'>
+            <span className='truncate'>{tag.title}</span>
+            {tag.isSystemTag && (
+              <Tooltip content='System tag — managed by Auxx, read-only.'>
+                <Lock className='size-3 shrink-0 text-muted-foreground' aria-label='System tag' />
+              </Tooltip>
+            )}
+            {tag.aiClassify && (
+              <Tooltip
+                content={
+                  tag.tag_description
+                    ? 'AI may apply this tag to incoming mail.'
+                    : 'AI may apply this tag to incoming mail — add a description so it knows when.'
+                }>
+                <Sparkles
+                  className='size-3 shrink-0 text-primary-500'
+                  aria-label='AI may apply this tag'
+                />
+              </Tooltip>
+            )}
+          </span>
         )
       }
       description={tag.tag_description || undefined}

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -53,6 +53,7 @@ import { knowledgeBaseRouter } from './routers/kb'
 import { knowledgeSourceRouter } from './routers/knowledge-sources'
 import { kopilotRouter } from './routers/kopilot'
 import { labelRouter } from './routers/label'
+import { mailClassificationRouter } from './routers/mail-classification'
 import { mailFiltersRouter } from './routers/mail-filters'
 import { mailSuggestionsRouter } from './routers/mail-suggestions'
 import { mailDomainsRouter } from './routers/mailDomain'
@@ -153,6 +154,7 @@ export const appRouter = createTRPCRouter({
   kopilot: kopilotRouter,
   label: labelRouter,
   mailDomain: mailDomainsRouter,
+  mailClassification: mailClassificationRouter,
   mailFilters: mailFiltersRouter,
   mailSuggestions: mailSuggestionsRouter,
   mailView: mailViewRouter,

--- a/apps/web/src/server/api/routers/mail-classification.test.ts
+++ b/apps/web/src/server/api/routers/mail-classification.test.ts
@@ -1,0 +1,445 @@
+// apps/web/src/server/api/routers/mail-classification.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The mail-classification opt-in's authorization model, through a real tRPC caller.
+ *
+ * ## Why this file is mandatory
+ *
+ * The router IS the gate (`plans/mail-filter/05-mail-classification-plan.md`
+ * §5, invariant 11). `@auxx/lib` holds zero permission checks, the org-settings
+ * write itself is a plain jsonb upsert, and the UI only decides what to render
+ * — so every rule about who may point a classifier at whose mailbox lives here
+ * and nowhere else.
+ *
+ * The four cases §5 names, verbatim:
+ *
+ *  1. the owner of a personal inbox, holding NO permission key, may toggle it
+ *  2. another member's personal inbox is **404** — even for an admin holding
+ *     everything (a 403 there is an existence oracle for a private mailbox)
+ *  3. a shared inbox with `automationRules.manage` but no inbox `admin` is 403
+ *  4. with both, it succeeds
+ *
+ * plus the invariant that makes per-inbox storage worth having: **an admin
+ * cannot opt in a personal mailbox**, by any route — including the generic
+ * `settings.updateOrganizationSetting` door, which is why `setting.ts` refuses
+ * this key outright.
+ *
+ * Denials assert STATUS CODES (`cause.statusCode`), never merely "it threw":
+ * a 403 where a 404 belongs is exactly the leak, and it survives any weaker
+ * assertion.
+ */
+
+const AUTOMATION_KEY = 'automationRules.manage'
+const SETTING_KEY = 'mailClassificationInboxIds'
+
+const hoisted = vi.hoisted(() => {
+  const ORG_ID = 'org_cuid000000000000000000000'
+  const USER_ID = 'usr_member00000000000000000'
+  const OTHER_USER_ID = 'usr_other000000000000000000'
+
+  /** A shared mailbox on the `inbox` def. */
+  const SHARED_INBOX = 'inb_shared00000000000000000'
+  /** The caller's own mailbox on the `personal_inbox` def. */
+  const OWN_PERSONAL = 'inb_ownpersonal000000000000'
+  /** Somebody else's mailbox on the `personal_inbox` def. */
+  const OTHER_PERSONAL = 'inb_otherpersonal0000000000'
+  /** A personal mailbox still on the SHARED def — the 059→060 migration window. */
+  const LEGACY_PERSONAL = 'inb_legacypersonal000000000'
+  /** No such inbox in this org at all. */
+  const GHOST_INBOX = 'inb_ghost000000000000000000'
+
+  const world = {
+    /** Layer-2 capability keys the caller holds. EMPTY is the interesting case. */
+    capabilities: new Set<string>(),
+    /** Inbox ids the caller composes `edit`+ (i.e. `admin`) on. */
+    writableInboxIds: new Set<string>(),
+    /** Tags as `TagService.getAllTags({ scope: 'thread' })` would answer. */
+    threadTags: [] as { id: string; aiClassify: boolean }[],
+  }
+
+  /** Every side effect the router reached, in order. */
+  const calls: string[] = []
+  /** Capability keys `permissionProcedure` asserted, in order. */
+  const gate: string[] = []
+
+  /** The `OrganizationSetting` row, as a value. */
+  const orgSettings = new Map<string, unknown>()
+
+  const getOrganizationSetting = vi.fn(async (params: { organizationId: string; key: string }) => {
+    calls.push('getOrganizationSetting')
+    return orgSettings.get(`${params.organizationId}:${params.key}`) ?? []
+  })
+  const updateOrganizationSetting = vi.fn(
+    async (params: { organizationId: string; key: string; value: unknown }) => {
+      calls.push('updateOrganizationSetting')
+      orgSettings.set(`${params.organizationId}:${params.key}`, params.value)
+    }
+  )
+
+  const onCacheEvent = vi.fn(async (event: string) => {
+    calls.push(`onCacheEvent:${event}`)
+  })
+
+  const recordAuditFromCtx = vi.fn(async () => {
+    calls.push('recordAuditFromCtx')
+  })
+
+  /**
+   * A stand-in for `TagService`, faithful in the one respect this router
+   * depends on: `getAllTags` takes the `thread` scope filter (Q3 — `article`
+   * tags are never offered to a mail classifier) and the eligibility flag is
+   * `aiClassify`.
+   */
+  class TagService {
+    constructor(
+      public organizationId: string,
+      public userId: string,
+      public db: unknown
+    ) {}
+    async getAllTags(options?: { scope?: string }) {
+      calls.push(`getAllTags:${options?.scope ?? 'all'}`)
+      return world.threadTags
+    }
+  }
+
+  const inbox = (
+    id: string,
+    entityDefinitionKey: 'inbox' | 'personal_inbox',
+    ownerUserId: string | null,
+    isPersonal = entityDefinitionKey === 'personal_inbox'
+  ) => ({
+    id,
+    recordId: `${entityDefinitionKey}:${id}`,
+    entityDefinitionKey,
+    name: id,
+    description: null,
+    color: 'indigo',
+    status: 'ACTIVE',
+    defaultLens: isPersonal ? 'none' : 'read',
+    isPersonal,
+    ownerUserId,
+    settings: {},
+    organizationId: ORG_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdById: null,
+  })
+
+  const inboxes = [
+    inbox(SHARED_INBOX, 'inbox', null),
+    inbox(OWN_PERSONAL, 'personal_inbox', USER_ID),
+    inbox(OTHER_PERSONAL, 'personal_inbox', OTHER_USER_ID),
+    inbox(LEGACY_PERSONAL, 'inbox', OTHER_USER_ID, true),
+  ]
+
+  const orgCacheGet = vi.fn(async (_orgId: string, key: string) => {
+    if (key !== 'inboxes') throw new Error(`unexpected org-cache key ${key}`)
+    return inboxes
+  })
+
+  return {
+    ORG_ID,
+    USER_ID,
+    OTHER_USER_ID,
+    SHARED_INBOX,
+    OWN_PERSONAL,
+    OTHER_PERSONAL,
+    LEGACY_PERSONAL,
+    GHOST_INBOX,
+    world,
+    calls,
+    gate,
+    orgSettings,
+    orgCacheGet,
+    onCacheEvent,
+    getOrganizationSetting,
+    updateOrganizationSetting,
+    recordAuditFromCtx,
+    TagService,
+  }
+})
+
+const {
+  ORG_ID,
+  USER_ID,
+  SHARED_INBOX,
+  OWN_PERSONAL,
+  OTHER_PERSONAL,
+  LEGACY_PERSONAL,
+  GHOST_INBOX,
+  world,
+  calls,
+  gate,
+} = hoisted
+
+vi.mock('@auxx/lib/cache', () => ({
+  getOrgCache: () => ({ get: hoisted.orgCacheGet }),
+  onCacheEvent: hoisted.onCacheEvent,
+}))
+vi.mock('@auxx/lib/settings', () => ({
+  getOrganizationSetting: hoisted.getOrganizationSetting,
+  updateOrganizationSetting: hoisted.updateOrganizationSetting,
+}))
+vi.mock('@auxx/lib/tags', () => ({ TagService: hoisted.TagService }))
+vi.mock('~/server/api/audit-context', () => ({
+  recordAuditFromCtx: hoisted.recordAuditFromCtx,
+}))
+
+/**
+ * The permissions BARREL is mocked (it hangs under vitest — the standing
+ * gotcha), but `@auxx/lib/permissions/capabilities/registry` is NOT: the
+ * authorization helper reads the real `PermissionKey.automationRulesManage`, so
+ * the key's spelling is pinned against the registry rather than restated here.
+ */
+vi.mock('@auxx/lib/permissions', () => ({}))
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    protectedProcedure: t.procedure,
+    /** `capabilityProcedure` asserts NO key — it only resolves `ctx.capabilities`. */
+    capabilityProcedure: t.procedure,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ next }) => {
+        hoisted.gate.push(key)
+        if (!hoisted.world.capabilities.has(key)) {
+          const error = new Error(`You don't have permission: ${key}`)
+          error.name = 'ForbiddenError'
+          ;(error as Error & { statusCode: number }).statusCode = 403
+          throw error
+        }
+        return next()
+      }),
+  }
+})
+
+const { mailClassificationRouter } = await import('./mail-classification')
+
+const caller = (userId: string = USER_ID) =>
+  mailClassificationRouter.createCaller({
+    db: {},
+    session: { userId, organizationId: ORG_ID, user: { id: userId } },
+    capabilities: {
+      can: (key: string) => world.capabilities.has(key),
+      canEditInstance: (key: string, instanceId: string) =>
+        key === 'inbox' && world.writableInboxIds.has(instanceId),
+    },
+  } as never)
+
+/** The shape `auxxErrorMiddleware` maps to a 403 / 404. */
+const FORBIDDEN = { cause: { statusCode: 403 } }
+const NOT_FOUND = { cause: { statusCode: 404 } }
+
+/** An org admin composing `Inboxes: Full` — write on EVERY inbox, plus the key. */
+const asAutomationAdmin = () => {
+  world.capabilities.add(AUTOMATION_KEY)
+  world.writableInboxIds.add(SHARED_INBOX)
+  world.writableInboxIds.add(OWN_PERSONAL)
+  world.writableInboxIds.add(OTHER_PERSONAL)
+  world.writableInboxIds.add(LEGACY_PERSONAL)
+}
+
+const storedInboxIds = () => hoisted.orgSettings.get(`${ORG_ID}:${SETTING_KEY}`)
+
+beforeEach(() => {
+  world.capabilities.clear()
+  world.writableInboxIds.clear()
+  world.threadTags = [
+    { id: 'tag_billing', aiClassify: true },
+    { id: 'tag_vip', aiClassify: false },
+  ]
+  hoisted.orgSettings.clear()
+  vi.clearAllMocks()
+  calls.length = 0
+  gate.length = 0
+})
+
+describe('mailClassification router — §5 authorship', () => {
+  /** Case 1 — ownership alone, no permission key at all. */
+  it('lets the owner of a personal inbox toggle it with zero permission keys', async () => {
+    expect(await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })).toEqual({
+      enabled: true,
+    })
+
+    expect(storedInboxIds()).toEqual([OWN_PERSONAL])
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      enabled: true,
+    })
+    // No procedure-level key gate — the archetypal user holds no automation grant.
+    expect(gate).toEqual([])
+  })
+
+  it('lets the same owner turn it back off', async () => {
+    await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })
+    await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: false })
+
+    expect(storedInboxIds()).toEqual([])
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      enabled: false,
+    })
+  })
+
+  /**
+   * Case 2 — the one that must be 404, not 403.
+   *
+   * "A personal mailbox must never be opted in by an admin" (§5), and the
+   * refusal must not even confirm the mailbox exists.
+   */
+  it("answers 404 — never 403 — for another member's personal inbox, to a full admin", async () => {
+    asAutomationAdmin()
+
+    await expect(
+      caller().setInboxEnabled({ inboxId: OTHER_PERSONAL, enabled: true })
+    ).rejects.toMatchObject(NOT_FOUND)
+    await expect(caller().getInboxSettings({ inboxId: OTHER_PERSONAL })).rejects.toMatchObject(
+      NOT_FOUND
+    )
+
+    expect(hoisted.updateOrganizationSetting).not.toHaveBeenCalled()
+    // Refused before anything was read — authorize first.
+    expect(calls).toEqual([])
+  })
+
+  /**
+   * Same refusal for the 059→060 migration-window mailbox: SHARED def, personal
+   * marker, somebody else's. A refusal keyed on the def alone would name it.
+   */
+  it('answers 404 for a personal mailbox still sitting on the shared definition', async () => {
+    asAutomationAdmin()
+
+    await expect(
+      caller().setInboxEnabled({ inboxId: LEGACY_PERSONAL, enabled: true })
+    ).rejects.toMatchObject(NOT_FOUND)
+  })
+
+  /** An id with no row is indistinguishable from a private one. */
+  it('answers 404 for an inbox id that does not exist', async () => {
+    asAutomationAdmin()
+
+    await expect(
+      caller().setInboxEnabled({ inboxId: GHOST_INBOX, enabled: true })
+    ).rejects.toMatchObject(NOT_FOUND)
+  })
+
+  /** Case 3 — the key without inbox `admin`. Visible inventory, so 403. */
+  it('answers 403 on a shared inbox to a key holder with no inbox admin', async () => {
+    world.capabilities.add(AUTOMATION_KEY)
+
+    await expect(
+      caller().setInboxEnabled({ inboxId: SHARED_INBOX, enabled: true })
+    ).rejects.toMatchObject(FORBIDDEN)
+    await expect(caller().getInboxSettings({ inboxId: SHARED_INBOX })).rejects.toMatchObject(
+      FORBIDDEN
+    )
+
+    expect(hoisted.updateOrganizationSetting).not.toHaveBeenCalled()
+  })
+
+  /** …and the mirror: inbox `admin` without the key is equally refused. */
+  it('answers 403 on a shared inbox to an inbox admin with no automation key', async () => {
+    world.writableInboxIds.add(SHARED_INBOX)
+
+    await expect(
+      caller().setInboxEnabled({ inboxId: SHARED_INBOX, enabled: true })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  /** Case 4 — both halves. */
+  it('allows a shared inbox to a caller holding the key AND inbox admin', async () => {
+    world.capabilities.add(AUTOMATION_KEY)
+    world.writableInboxIds.add(SHARED_INBOX)
+
+    expect(await caller().setInboxEnabled({ inboxId: SHARED_INBOX, enabled: true })).toEqual({
+      enabled: true,
+    })
+    expect(storedInboxIds()).toEqual([SHARED_INBOX])
+  })
+})
+
+describe('mailClassification router — the stored list', () => {
+  it('writes ONE inbox id per call and leaves the others alone', async () => {
+    world.capabilities.add(AUTOMATION_KEY)
+    world.writableInboxIds.add(SHARED_INBOX)
+
+    await caller().setInboxEnabled({ inboxId: SHARED_INBOX, enabled: true })
+    await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })
+    await caller().setInboxEnabled({ inboxId: SHARED_INBOX, enabled: false })
+
+    expect(storedInboxIds()).toEqual([OWN_PERSONAL])
+  })
+
+  it('never writes the same inbox twice', async () => {
+    await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })
+    await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })
+
+    expect(storedInboxIds()).toEqual([OWN_PERSONAL])
+    expect(hoisted.updateOrganizationSetting).toHaveBeenCalledTimes(1)
+  })
+
+  it('busts the org-settings cache after a real write, so the guard sees it', async () => {
+    await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })
+
+    expect(hoisted.onCacheEvent).toHaveBeenCalledWith('org.settings.changed', {
+      orgId: ORG_ID,
+      broadcastUserKeys: true,
+    })
+    expect(hoisted.recordAuditFromCtx).toHaveBeenCalled()
+  })
+
+  it('does not bust the cache or audit when nothing changed', async () => {
+    await caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: false })
+
+    expect(hoisted.updateOrganizationSetting).not.toHaveBeenCalled()
+    expect(hoisted.onCacheEvent).not.toHaveBeenCalled()
+    expect(hoisted.recordAuditFromCtx).not.toHaveBeenCalled()
+  })
+
+  it('survives a garbage stored value rather than throwing', async () => {
+    hoisted.orgSettings.set(`${ORG_ID}:${SETTING_KEY}`, { nope: true })
+
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      enabled: false,
+    })
+  })
+})
+
+describe('mailClassification router — eligible tags', () => {
+  it('counts only AI-eligible thread tags', async () => {
+    world.threadTags = [
+      { id: 'a', aiClassify: true },
+      { id: 'b', aiClassify: true },
+      { id: 'c', aiClassify: false },
+    ]
+
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      eligibleTagCount: 2,
+    })
+    // Q3 — `article`-scoped tags are never offered to a mail classifier.
+    expect(calls).toContain('getAllTags:thread')
+  })
+
+  it('reports zero when no tag is eligible — the UI disables the switch on this', async () => {
+    world.threadTags = [{ id: 'a', aiClassify: false }]
+
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      eligibleTagCount: 0,
+    })
+  })
+
+  /**
+   * Arming an inbox with nothing to apply is inert (C8's double guard), not an
+   * error: refusing would make the order of operations load-bearing. The UI
+   * says so; the server does not litigate it.
+   */
+  it('still allows opting in with zero eligible tags', async () => {
+    world.threadTags = []
+
+    await expect(
+      caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })
+    ).resolves.toEqual({ enabled: true })
+  })
+})

--- a/apps/web/src/server/api/routers/mail-classification.ts
+++ b/apps/web/src/server/api/routers/mail-classification.ts
@@ -1,0 +1,166 @@
+// apps/web/src/server/api/routers/mail-classification.ts
+
+import { onCacheEvent } from '@auxx/lib/cache'
+import { getOrganizationSetting, updateOrganizationSetting } from '@auxx/lib/settings'
+import { TagService } from '@auxx/lib/tags'
+import { z } from 'zod'
+import { recordAuditFromCtx } from '~/server/api/audit-context'
+import {
+  assertCanConfigureInboxAutomation,
+  loadMailFilterAuthority,
+} from '~/server/lib/mail-filter-authoring-access'
+import { capabilityProcedure, createTRPCRouter } from '../trpc'
+
+/**
+ * tRPC surface for the mail-classification opt-in
+ * (`plans/mail-filter/05-mail-classification-plan.md` §5, §6.4).
+ *
+ * The classifier reads an inbound message and applies an EXISTING tag. Two
+ * things arm it, and both are opt-in (C8, "double guard, or zero model calls"):
+ * a tag marked `tag_ai_classify`, and an inbox listed in the
+ * `mailClassificationInboxIds` org setting. This router owns the second half.
+ *
+ * ## Why this is a router of its own rather than `settings.updateOrganizationSetting`
+ *
+ * The generic org-settings door is gated on `settings.manage` — a coarse admin
+ * key. Writing this list through it would let an admin opt in a colleague's
+ * PERSONAL mailbox, which §5 forbids outright ("a personal mailbox must never
+ * be opted in by an admin"), and which per-inbox storage exists to make
+ * inexpressible. `setting.ts` refuses the key for exactly that reason; the gate
+ * lives here instead:
+ *
+ * ```
+ *   personal inbox owned by the caller  →  allowed. NO permission key.
+ *   shared inbox                        →  automationRules.manage AND inbox admin
+ * ```
+ *
+ * That is `~/server/lib/mail-filter-authoring-access` verbatim — §5 says the
+ * opt-in uses "the same gate that governs authoring a mail filter on that
+ * inbox", so it reuses that authority rather than restating it. Never admin
+ * rank (invariant 11; `docs/channels-mail-architecture-guide.md`).
+ *
+ * `capabilityProcedure`, never `permissionProcedure(automationRulesManage)`:
+ * the key is one BRANCH of the rule, and the archetypal user — a member
+ * classifying their own personal mailbox — holds no automation grant.
+ *
+ * There is deliberately **no bulk-enable procedure**. One inbox per call, each
+ * authorized on its own, is what keeps "classify everything" unexpressible.
+ */
+
+/**
+ * The org-settings key holding the opted-in inbox ids (`string[]`).
+ *
+ * Declared in `packages/lib/src/settings/catalog.ts`; spelled once here so the
+ * two reads below and the `setting.ts` refusal cannot drift apart.
+ */
+export const MAIL_CLASSIFICATION_INBOXES_KEY = 'mailClassificationInboxIds' as const
+
+/** The stored value, defensively — a jsonb blob is only as typed as its reader. */
+function toInboxIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((id): id is string => typeof id === 'string')
+}
+
+async function readOptedInInboxIds(organizationId: string): Promise<string[]> {
+  const value = await getOrganizationSetting({
+    organizationId,
+    key: MAIL_CLASSIFICATION_INBOXES_KEY,
+  })
+  return toInboxIds(value)
+}
+
+/**
+ * How many tags the classifier could actually choose from, org-wide.
+ *
+ * `thread`-scoped only (Q3): `article` tags exist for KB content and offering
+ * them to a mail classifier is a category error — `labels.ts` filters the same
+ * way, so this count is the one the prompt would really see. Zero here means
+ * the opt-in is inert (C8), which is why §6.4 has the UI disable the switch and
+ * say so rather than let it look like it worked.
+ */
+async function countEligibleTags(
+  organizationId: string,
+  userId: string,
+  db: ConstructorParameters<typeof TagService>[2]
+): Promise<number> {
+  const tags = await new TagService(organizationId, userId, db).getAllTags({ scope: 'thread' })
+  return tags.filter((tag) => tag.aiClassify).length
+}
+
+export const mailClassificationRouter = createTRPCRouter({
+  /**
+   * The card's whole state: is this inbox opted in, and is there anything for
+   * the classifier to apply.
+   *
+   * Authorized exactly like the write. A read is a disclosure too — answering
+   * "not opted in" for a colleague's personal mailbox would confirm it exists.
+   */
+  getInboxSettings: capabilityProcedure
+    .input(z.object({ inboxId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      assertCanConfigureInboxAutomation(authority, input.inboxId)
+
+      const [inboxIds, eligibleTagCount] = await Promise.all([
+        readOptedInInboxIds(ctx.session.organizationId),
+        countEligibleTags(ctx.session.organizationId, ctx.session.userId, ctx.db),
+      ])
+
+      return { enabled: inboxIds.includes(input.inboxId), eligibleTagCount }
+    }),
+
+  /**
+   * Opt one inbox in or out.
+   *
+   * Read-modify-write on a jsonb list: last writer wins on a simultaneous
+   * toggle of two DIFFERENT inboxes, which is the honest trade for not adding a
+   * table. The window is one request and the loser is re-toggleable, so it is
+   * not worth a lock.
+   *
+   * Enabling with zero eligible tags is ALLOWED, not refused. The double guard
+   * (C8) already makes such an inbox inert — no model call, no bill — and
+   * refusing would make the order of operations load-bearing ("mark a tag
+   * before you may arm the inbox"). The UI states the inertness instead.
+   */
+  setInboxEnabled: capabilityProcedure
+    .input(z.object({ inboxId: z.string().min(1), enabled: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      assertCanConfigureInboxAutomation(authority, input.inboxId)
+
+      const current = await readOptedInInboxIds(ctx.session.organizationId)
+      const next = input.enabled
+        ? Array.from(new Set([...current, input.inboxId]))
+        : current.filter((id) => id !== input.inboxId)
+
+      // A no-op write would still bust the org cache for everyone.
+      if (next.length !== current.length) {
+        await updateOrganizationSetting({
+          organizationId: ctx.session.organizationId,
+          key: MAIL_CLASSIFICATION_INBOXES_KEY,
+          value: next,
+          db: ctx.db,
+        })
+        // The guard reads this through the `orgSettings` org cache (§3.1 exit 3),
+        // so without this the classifier keeps answering with the old list.
+        await onCacheEvent('org.settings.changed', {
+          orgId: ctx.session.organizationId,
+          broadcastUserKeys: true,
+        })
+
+        // Routing this key out of `settings.updateOrganizationSetting` would
+        // otherwise have dropped it out of the audit trail — and "AI started
+        // reading this mailbox" is the last change that should be untraceable.
+        await recordAuditFromCtx(ctx, {
+          category: 'settings',
+          action: 'setting.changed',
+          targetType: 'OrganizationSetting',
+          targetId: MAIL_CLASSIFICATION_INBOXES_KEY,
+          newState: { value: next },
+          metadata: { inboxId: input.inboxId, enabled: input.enabled },
+        })
+      }
+
+      return { enabled: input.enabled }
+    }),
+})

--- a/apps/web/src/server/api/routers/setting.ts
+++ b/apps/web/src/server/api/routers/setting.ts
@@ -19,6 +19,29 @@ import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc
 
 const logger = createScopedLogger('api-settings')
 
+/**
+ * Catalog keys this generic door refuses, because a dedicated router owns their
+ * authorization and this one only ever asks for `settings.manage`.
+ *
+ * `mailClassificationInboxIds` is the mail-classification opt-in
+ * (`plans/mail-filter/05-mail-classification-plan.md` §5). It is authored
+ * PER INBOX — a personal mailbox by its owner alone, a shared one with
+ * `automationRules.manage` + inbox `admin` — and §5 states outright that "a
+ * personal mailbox must never be opted in by an admin". Leaving it writable
+ * here would hand any `settings.manage` holder a one-call "classify
+ * everything", which is precisely what per-inbox storage exists to make
+ * inexpressible. `mailClassification.setInboxEnabled` is the only door.
+ */
+const ROUTER_OWNED_ORG_SETTING_KEYS = new Set<string>(['mailClassificationInboxIds'])
+
+function assertNotRouterOwned(key: string): void {
+  if (ROUTER_OWNED_ORG_SETTING_KEYS.has(key)) {
+    throw new BadRequestError(
+      `Setting ${key} is managed per inbox and cannot be changed from organization settings.`
+    )
+  }
+}
+
 // Input validation schema for getting user settings
 const getUserSettingSchema = z.object({
   key: z.string(),
@@ -101,6 +124,7 @@ export const settingsRouter = createTRPCRouter({
       if (!isSettingKey(key)) {
         throw new BadRequestError(`Unknown setting: ${key}`)
       }
+      assertNotRouterOwned(key)
       // Capability gate, not role (plan 21 §4.2): settingsManage is what a
       // profile turns off.
       await requirePermission(userId, organizationId, PermissionKey.settingsManage)
@@ -186,6 +210,7 @@ export const settingsRouter = createTRPCRouter({
       if (unknownKey) {
         throw new BadRequestError(`Unknown setting: ${unknownKey.key}`)
       }
+      for (const setting of settings) assertNotRouterOwned(setting.key)
 
       await batchUpdateOrganizationSettings({
         organizationId,

--- a/apps/web/src/server/lib/mail-filter-authoring-access.ts
+++ b/apps/web/src/server/lib/mail-filter-authoring-access.ts
@@ -227,18 +227,41 @@ export function assertCanAuthorMailFilters(
 }
 
 /**
- * The same §5.1 branch, for a write addressed by FILTER id — update, setEnabled,
+ * The §5.1 branch again, refusing in the shape the ADDRESSED RESOURCE allows
+ * (V6, `plans/mail-filter/04-v2-plan.md` §1.3):
+ *
+ * ```
+ *   authorable                         →  allowed
+ *   on a shared inbox                  →  403, the caller can see the inbox
+ *   on someone else's personal inbox   →  404, indistinguishable from an id
+ *   (incl. the legacy-marker row on       that has no row at all
+ *    the shared def)
+ * ```
+ *
+ * One body, two exported wrappers, differing only in the not-found MESSAGE —
+ * because the refusal must never disclose more than the caller already knows,
+ * and the message is the last place that could leak it.
+ */
+function assertAuthorableOrDisclose(
+  authority: MailFilterAuthority,
+  inboxId: string,
+  notFoundMessage: string,
+  forbiddenMessage: string
+): AuthorableInbox {
+  const inbox = authority.byId.get(inboxId)
+  if (inbox) return inbox
+  if (authority.disclosableInboxIds.has(inboxId)) {
+    throw new ForbiddenError(forbiddenMessage)
+  }
+  throw new NotFoundError(notFoundMessage)
+}
+
+/**
+ * The §5.1 branch, for a write addressed by FILTER id — update, setEnabled,
  * delete, applyRetroactively (V6, `plans/mail-filter/04-v2-plan.md` §1.3).
  *
- * Identical in WHO it refuses; different in WHAT the refusal admits:
- *
- * ```
- *   authorable                        →  allowed
- *   filter on a shared inbox          →  403, the caller can see the inbox
- *   filter on someone else's personal →  404, verbatim `getMailFilterById`'s
- *   inbox (incl. the legacy-marker       "Filter not found" — indistinguishable
- *   row on the shared def)               from an id with no row
- * ```
+ * Identical in WHO it refuses to {@link assertCanAuthorMailFilters}; different
+ * in WHAT the refusal admits — see {@link assertAuthorableOrDisclose}.
  *
  * §5.1 promises that a personal filter is never disclosed to anyone else, and
  * `list` / `get` / `runs` / `undoRun` all keep that promise by answering
@@ -257,10 +280,42 @@ export function assertCanMutateMailFilter(
   authority: MailFilterAuthority,
   filter: { inboxId: string }
 ): AuthorableInbox {
-  const inbox = authority.byId.get(filter.inboxId)
-  if (inbox) return inbox
-  if (authority.disclosableInboxIds.has(filter.inboxId)) {
-    throw new ForbiddenError("You don't have permission to manage filters for this inbox.")
-  }
-  throw new NotFoundError('Filter not found')
+  return assertAuthorableOrDisclose(
+    authority,
+    filter.inboxId,
+    'Filter not found',
+    "You don't have permission to manage filters for this inbox."
+  )
+}
+
+/**
+ * The same authority, for per-inbox AUTOMATION SETTINGS that are not filters —
+ * today the mail-classification opt-in
+ * (`plans/mail-filter/05-mail-classification-plan.md` §5).
+ *
+ * Deliberately this module and not a second rule: §5 says the opt-in uses "the
+ * same gate that governs authoring a filter on that inbox", because turning on
+ * inference that bills the org and reads colleagues' mail is at least as
+ * consequential as writing a filter. A parallel check here would be a second
+ * place for the personal-inbox branch to rot.
+ *
+ * {@link assertCanAuthorMailFilters} is the wrong wrapper even though the caller
+ * addresses an inbox id: its blanket 403 would confirm, to any member who can
+ * guess a CUID, that a colleague's private mailbox exists. Personal mailboxes
+ * are never disclosed (invariant 11 / §5.1), so an unauthorable personal inbox
+ * answers 404 here just as a filter on one does.
+ *
+ * @throws NotFoundError when the inbox is personal and not the caller's.
+ * @throws ForbiddenError when it is a shared inbox the caller cannot author on.
+ */
+export function assertCanConfigureInboxAutomation(
+  authority: MailFilterAuthority,
+  inboxId: string
+): AuthorableInbox {
+  return assertAuthorableOrDisclose(
+    authority,
+    inboxId,
+    'Inbox not found',
+    "You don't have permission to manage automation for this inbox."
+  )
 }

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -23,6 +23,7 @@ import { startEventHandlersWorker, startEventsWorker } from './worker-definition
 import { startKBSyncWorker } from './worker-definitions/kb-sync-worker'
 import { startKnowledgeSourceWorker } from './worker-definitions/knowledge-source-worker'
 import { startLearnedExtractionWorker } from './worker-definitions/learned-extraction-worker'
+import { startMailClassificationWorker } from './worker-definitions/mail-classification-worker'
 import { startMaintenanceWorker } from './worker-definitions/maintenance-worker'
 import { startMessageProcessingWorker } from './worker-definitions/message-processing-worker'
 import { startMessageSyncWorker } from './worker-definitions/message-sync-worker'
@@ -127,6 +128,9 @@ export async function startWorkers() {
   // QuickBooks invoice sync worker (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
   const quickbooksInvoiceSyncWorker = startQuickbooksInvoiceSyncWorker()
 
+  // Inbound-mail AI categorisation worker (mail-classification plan §4)
+  const mailClassificationWorker = startMailClassificationWorker()
+
   const workers = [
     // defaultWorker,
     eventsWorker,
@@ -161,6 +165,7 @@ export async function startWorkers() {
     dataConnectorWorker,
     documentPdfWorker,
     quickbooksInvoiceSyncWorker,
+    mailClassificationWorker,
   ]
 
   return Promise.all(workers)

--- a/apps/worker/src/workers/worker-definitions/events-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/events-worker.ts
@@ -21,6 +21,7 @@ import {
   triggerResourceWorkflows,
   updateWebhookLastTriggeredAt,
 } from '@auxx/lib/events/handlers'
+import { enqueueMailClassification } from '@auxx/lib/jobs'
 import { Queues } from '@auxx/lib/jobs/queues'
 import { createWorker } from '../utils/createWorker'
 
@@ -57,6 +58,10 @@ const eventHandlersJobMappings = {
   // signal:recorded (plans/signals/06-follow-ups-build.md Steps 3 + 5).
   handleSignalRecordRules,
   autoCompleteTasks,
+  // `message:received` → `mailClassificationQueue` (mail-classification plan §4).
+  // The name key must match `Function.prototype.name`, which is how
+  // `publishEventJob` names the job it enqueues.
+  enqueueMailClassification,
 }
 
 // IO-bound handlers; concurrency > 1 drops the queue-global FIFO ordering,

--- a/apps/worker/src/workers/worker-definitions/mail-classification-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/mail-classification-worker.ts
@@ -1,0 +1,31 @@
+// apps/worker/src/workers/worker-definitions/mail-classification-worker.ts
+
+import { mailClassificationJob } from '@auxx/lib/jobs'
+import { Queues } from '@auxx/lib/jobs/queues'
+import { createScopedLogger } from '@auxx/logger'
+import { createWorker } from '../utils/createWorker'
+
+const logger = createScopedLogger('worker:mail-classification')
+
+// The key MUST equal `MAIL_CLASSIFICATION_JOB_NAME` — `enqueueMailClassification`
+// adds the job under that name and `createJobHandler` dispatches on it.
+const mailClassificationJobMappings = {
+  mailClassificationJob,
+}
+
+/**
+ * Starts a BullMQ worker for inbound-mail AI categorisation
+ * (plans/mail-filter/05-mail-classification-plan.md §4).
+ *
+ * Its OWN queue, deliberately: the model call cannot run in the
+ * `message:received` gate (2s timeout on the shared `eventsQueue`) and must not
+ * hold `eventHandlersQueue` slots for seconds at a time. Concurrency is modest —
+ * every job is one metered LLM call against the org's default model.
+ */
+export function startMailClassificationWorker() {
+  logger.info(`Starting worker for queue: ${Queues.mailClassificationQueue}`)
+
+  return createWorker(Queues.mailClassificationQueue, mailClassificationJobMappings, {
+    concurrency: 5,
+  })
+}

--- a/packages/lib/scripts/backfill-ai-category-tags.ts
+++ b/packages/lib/scripts/backfill-ai-category-tags.ts
@@ -1,0 +1,72 @@
+// packages/lib/scripts/backfill-ai-category-tags.ts
+//
+// One-off backfill: seed the five starter mail categories — Sales · Support · Billing ·
+// Newsletter · Notification, under a "Mail Categories" parent
+// (plans/mail-filter/05-mail-classification-plan.md §2.4) — for every EXISTING organization.
+// New orgs get them from `OrganizationSeeder.seedTags` automatically; this script covers orgs
+// created before mail classification shipped. Idempotent by tag title: a second pass creates
+// nothing.
+//
+// ⚠️ **It ADOPTS legacy system starters.** `seedTags` historically created Billing/Sales/
+// Support as SYSTEM tags, which `rejectIfSystemTag` freezes — description included — and that
+// description IS the classifier's instruction. So a pre-existing tag of one of those names
+// carrying `is_system_tag = true` is converted in place: flag cleared, starter description
+// written, marked eligible, re-parented. The tag ID is preserved, so every filter and
+// suggestion referencing it keeps resolving.
+//
+// A tag of the same name that the USER created (`is_system_tag = false`) is left entirely
+// alone — a title collision is not consent.
+//
+// ⚠️ **This enables no classification anywhere.** It only makes labels available. Nothing is
+// classified until an inbox is opted in, which is a separate per-inbox switch that this
+// script must never write — a migration must not start billing an org for inference.
+//
+// ⚠️ **Run entity migration 074 first** (`074-tag-ai-classify`, via the pending
+// data-migration runner). Without the `tag_ai_classify` CustomField an org is skipped with a
+// warning rather than half-seeded.
+//
+// Each org's `customFields`/`resources` cache keys are recomputed before its seed so the
+// create path sees the field 074 just added, even if this runs in a different process from
+// the migration.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/backfill-ai-category-tags.ts
+
+import { database as db, schema } from '@auxx/database'
+import { getOrgCache } from '../src/cache'
+import { seedAiCategoryTags } from '../src/seed/ai-category-tags'
+import { SystemUserService } from '../src/users/system-user-service'
+
+async function main() {
+  const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+  console.log(`Found ${orgs.length} organizations`)
+
+  let succeeded = 0
+  let failed = 0
+  let createdTotal = 0
+
+  for (const org of orgs) {
+    try {
+      await getOrgCache().invalidateAndRecompute(org.id, ['customFields', 'resources'])
+      // No human author on a backfill — the org's own system user owns the rows.
+      const userId = await SystemUserService.getSystemUserForActions(org.id)
+      const { created, skipped } = await seedAiCategoryTags(db, org.id, userId)
+      createdTotal += created.length
+      console.log(
+        `${org.id}: created [${created.join(', ') || '—'}], already present [${
+          skipped.join(', ') || '—'
+        }]`
+      )
+      succeeded++
+    } catch (error) {
+      failed++
+      console.error(`Failed to seed AI category tags for org ${org.id}:`, error)
+    }
+  }
+
+  console.log(
+    `Done. ${succeeded} organizations processed (${createdTotal} tags created), ${failed} failed.`
+  )
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+void main()

--- a/packages/lib/src/ai/orchestrator/types.ts
+++ b/packages/lib/src/ai/orchestrator/types.ts
@@ -159,6 +159,10 @@ export type UsageSource =
   | 'learned_extraction'
   | 'stale_scanner'
   | 'autofill'
+  // Inbound-mail categorisation (mail-classification plan §3.2). Its own arm so
+  // per-message classification spend is separable from `agent`/`autofill` in
+  // cost reporting — it is the one source that scales with mail volume.
+  | 'mail_classification'
   | 'transcription'
   | 'other'
 

--- a/packages/lib/src/events/handlers/apply-mail-filters.test.ts
+++ b/packages/lib/src/events/handlers/apply-mail-filters.test.ts
@@ -195,7 +195,7 @@ describe('applyMailFilters — the suppress list', () => {
     await expect(applyMailFilters(event())).resolves.toBeUndefined()
   })
 
-  it('names the automation handler by its function name, not a literal', async () => {
+  it('names the automation handlers by their function names, not literals', async () => {
     h.fireMailFilters.mockResolvedValue({
       suppressAutomations: true,
       firedFilterIds: ['flt_a'],
@@ -203,10 +203,45 @@ describe('applyMailFilters — the suppress list', () => {
 
     const result = await applyMailFilters(event())
 
-    // Must match the `then` entry in `publish-event-job.ts` exactly, and must
+    // Must match the `then` entries in `publish-event-job.ts` exactly, and must
     // NOT include the bookkeeping handlers — a filter cannot make mail vanish
     // from the timeline or break bounce handling.
-    expect(result).toEqual({ suppress: ['triggerMessageWorkflows'] })
+    expect(result).toEqual({
+      suppress: ['triggerMessageWorkflows', 'enqueueMailClassification'],
+    })
+  })
+
+  it('suppresses AI classification — the only BILLED handler in the fan-out', async () => {
+    h.fireMailFilters.mockResolvedValue({
+      suppressAutomations: true,
+      firedFilterIds: ['flt_a'],
+    })
+
+    const result = await applyMailFilters(event())
+
+    // Separate from the test above on purpose. That one pins the whole list and
+    // would happily go green if someone "simplified" it back to one entry while
+    // updating the expectation. This one states the standalone rule: a user who
+    // said "suppress automations" must not be charged for an inference on the
+    // exact mail they said it about.
+    expect(result?.suppress).toContain('enqueueMailClassification')
+  })
+
+  it('never suppresses the bookkeeping handlers', async () => {
+    h.fireMailFilters.mockResolvedValue({
+      suppressAutomations: true,
+      firedFilterIds: ['flt_a'],
+    })
+
+    const result = await applyMailFilters(event())
+
+    for (const bookkeeping of [
+      'createTimelineEvent',
+      'deriveMessageReplySignal',
+      'ingestBounceMessage',
+    ]) {
+      expect(result?.suppress).not.toContain(bookkeeping)
+    }
   })
 
   it('passes the personal-inbox owner through for the set-read branch', async () => {

--- a/packages/lib/src/events/handlers/apply-mail-filters.ts
+++ b/packages/lib/src/events/handlers/apply-mail-filters.ts
@@ -22,6 +22,7 @@ import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
+import { enqueueMailClassification } from '../../mail-classification/enqueue'
 import { getEnabledMailFiltersForInbox, orgHasEnabledMailFilters } from '../../mail-filters/cache'
 import { fireMailFilters } from '../../mail-filters/engine'
 import { getProviderCapabilities } from '../../providers/provider-capabilities'
@@ -43,8 +44,23 @@ const logger = createScopedLogger('apply-mail-filters')
  * `deriveMessageReplySignal` and `ingestBounceMessage` are bookkeeping — a
  * filter must not be able to make mail disappear from the timeline or break
  * bounce handling.
+ *
+ * `enqueueMailClassification` belongs here for TWO reasons, and the second is
+ * the one that makes it non-optional:
+ *
+ *  1. **Semantics.** AI categorisation is automation. A user who wrote
+ *     "suppress automations" on this message meant this too.
+ *  2. **It is the only billed handler in the fan-out.** Leaving it out means a
+ *     filter that explicitly asked for no automation still pays for an
+ *     inference on every matching message — a cost the user has already said no
+ *     to, on the exact mail they said it about.
+ *
+ * Suppression here is also cheaper than the classifier's own guard: exit 6
+ * ("the thread already carries an eligible tag") only fires when a filter
+ * actually TAGGED the thread, whereas `suppress-automations` commonly appears
+ * beside `set-status: ARCHIVED` with no tag at all.
  */
-const SUPPRESSIBLE_AUTOMATION_HANDLERS = [triggerMessageWorkflows]
+const SUPPRESSIBLE_AUTOMATION_HANDLERS = [triggerMessageWorkflows, enqueueMailClassification]
 
 /**
  * Decide, per inbound message, which filters fire and what the fan-out should

--- a/packages/lib/src/events/handlers/publish-event-job.test.ts
+++ b/packages/lib/src/events/handlers/publish-event-job.test.ts
@@ -37,6 +37,11 @@ const ALL_MESSAGE_HANDLERS = [
   'triggerMessageWorkflows',
   'deriveMessageReplySignal',
   'ingestBounceMessage',
+  // AI categorisation (mail-classification plan §4). Deliberately NOT in the
+  // gate — see the comment on the `then` list — and deliberately NOT in
+  // `SUPPRESSIBLE_AUTOMATION_HANDLERS`, so `suppress-automations` does not
+  // switch it off.
+  'enqueueMailClassification',
 ]
 
 beforeEach(() => {
@@ -88,6 +93,7 @@ describe('publishEventJob — gated entries', () => {
       'createTimelineEvent',
       'deriveMessageReplySignal',
       'ingestBounceMessage',
+      'enqueueMailClassification',
     ])
   })
 

--- a/packages/lib/src/events/handlers/publish-event-job.ts
+++ b/packages/lib/src/events/handlers/publish-event-job.ts
@@ -5,6 +5,7 @@ import type { Job } from 'bullmq'
 import { handleFieldTriggerJob } from '../../field-hooks/field-hook-job'
 import { getQueue } from '../../jobs/queues'
 import { Queues } from '../../jobs/queues/types'
+import { enqueueMailClassification } from '../../mail-classification/enqueue'
 import type {
   AuxxEvent,
   EventHandler,
@@ -84,6 +85,15 @@ export const EventHandlers: IEventsHandlers = {
       triggerMessageWorkflows,
       deriveMessageReplySignal,
       ingestBounceMessage,
+      // AI categorisation (mail-classification plan §4). ON THE `then` SIDE, not
+      // the gate: an LLM call would blow `GATE_TIMEOUT_MS` and head-of-line
+      // block unrelated events, and the gate's fail-open would then make the
+      // classification silently never happen (invariant 2).
+      //
+      // Enqueuing here is also what makes guard exit 6 correct — `applyMailFilters`
+      // has already run inline by now, so every deterministic `add-tag` is on the
+      // thread before the classifier decides whether a rule already answered.
+      enqueueMailClassification,
     ],
   },
   'message:sent': [createTimelineEvent],

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -1,5 +1,13 @@
 // Billing
 
+// Mail classification (plans/mail-filter/05-mail-classification-plan.md §4)
+export { MAIL_CLASSIFICATION_JOB_NAME } from '../mail-classification/client'
+export { enqueueMailClassification } from '../mail-classification/enqueue'
+export {
+  type MailClassificationJobData,
+  type MailClassificationJobResult,
+  mailClassificationJob,
+} from '../mail-classification/job'
 // Mail schedule
 export {
   enqueueScheduledMessageJob,

--- a/packages/lib/src/jobs/queues/types.ts
+++ b/packages/lib/src/jobs/queues/types.ts
@@ -61,4 +61,8 @@ export enum Queues {
   learnedExtractionQueue = 'learned-extraction',
   // QuickBooks invoice sync queue (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
   quickbooksInvoiceSyncQueue = 'quickbooks-invoice-sync',
+  // Inbound-mail AI categorisation (mail-classification plan §4). Its OWN queue:
+  // the call cannot run in the `message:received` gate (2s timeout, shared
+  // `eventsQueue`) and must not hold `eventHandlersQueue` slots for seconds.
+  mailClassificationQueue = 'mail-classification',
 }

--- a/packages/lib/src/mail-classification/apply.ts
+++ b/packages/lib/src/mail-classification/apply.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/mail-classification/apply.ts
+// WRITE: idempotent tag application (§3.3) + the classification marker (C9).
+//
+// ⚠️ INVARIANT 7 — the tag goes through `ThreadMutationService.tagThreadsBulk`
+// with `SYSTEM_VISIBILITY`, the same path the `add-tag` filter action uses.
+// NEVER a raw `FieldValue` write and never `UnifiedCrudHandler` (which refuses
+// `thread` by design): those three keep mail counts, realtime publishes and
+// provider label push-back correct, and a "quick direct insert" silently drifts
+// all of them.
+//
+// Heavy dependencies are lazy-imported at call time — a static edge would drag
+// the realtime barrel into every importer's graph and break `vi.mock` in unit
+// tests (the same reason `mail-filters/actions.ts` does it).
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, sql } from 'drizzle-orm'
+import { MAIL_CLASSIFICATION_METADATA_KEY, type MailClassificationMarker } from './client'
+
+const logger = createScopedLogger('mail-classification')
+
+/**
+ * Apply one classifier-chosen tag to a thread.
+ *
+ * Accumulate, don't replace (C5): re-adding a tag the thread already carries is
+ * a no-op inside `tagThreadsBulk`, and there is no "current category" to clear.
+ *
+ * Never throws.
+ */
+export async function applyClassificationTag(params: {
+  db: Database
+  organizationId: string
+  threadId: string
+  tagId: string
+}): Promise<boolean> {
+  const { db, organizationId, threadId, tagId } = params
+  try {
+    const [{ requireCachedEntityDefId }, { ThreadMutationService }, { SYSTEM_VISIBILITY }] =
+      await Promise.all([
+        import('../cache'),
+        import('../threads/thread-mutation.service'),
+        import('../permissions/visibility/context'),
+      ])
+
+    const [threadDefId, tagDefId] = await Promise.all([
+      requireCachedEntityDefId(organizationId, 'thread'),
+      requireCachedEntityDefId(organizationId, 'tag'),
+    ])
+
+    // No socketId (nothing to self-echo-suppress) and no actorUserId (there is
+    // no human actor) — the classifier is the actor.
+    const service = new ThreadMutationService(
+      organizationId,
+      db,
+      undefined,
+      undefined,
+      SYSTEM_VISIBILITY
+    )
+    await service.tagThreadsBulk(
+      [toRecordId(threadDefId, threadId)],
+      [toRecordId(tagDefId, tagId)],
+      'add'
+    )
+    return true
+  } catch (error) {
+    logger.error('Failed to apply a classified tag — leaving the thread untagged', {
+      organizationId,
+      threadId,
+      tagId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
+/**
+ * Stamp `Message.metadata.mailClassification` so the message is never classified
+ * again (C9, guard exit 5).
+ *
+ * Written after EVERY completed inference, including the below-threshold ones
+ * that applied nothing: the cost has been incurred, and re-inferring the same
+ * message would bill twice for the same answer.
+ *
+ * A `jsonb` concat rather than a read-modify-write, so a concurrent metadata
+ * write (bounce ingestion, label sync) cannot be clobbered by a stale snapshot.
+ *
+ * Never throws.
+ */
+export async function markMessageClassified(params: {
+  db: Database
+  organizationId: string
+  messageId: string
+  marker: MailClassificationMarker
+}): Promise<void> {
+  const { db, organizationId, messageId, marker } = params
+  const patch = JSON.stringify({ [MAIL_CLASSIFICATION_METADATA_KEY]: marker })
+  try {
+    await db
+      .update(schema.Message)
+      .set({
+        metadata: sql`COALESCE(${schema.Message.metadata}, '{}'::jsonb) || ${patch}::jsonb`,
+      })
+      .where(
+        and(eq(schema.Message.id, messageId), eq(schema.Message.organizationId, organizationId))
+      )
+  } catch (error) {
+    logger.error('Failed to stamp the mail-classification marker', {
+      organizationId,
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/mail-classification/classify.test.ts
+++ b/packages/lib/src/mail-classification/classify.test.ts
@@ -1,0 +1,207 @@
+// packages/lib/src/mail-classification/classify.test.ts
+// The three properties the model call must never lose:
+//   • the enum is TAG IDS (invariant 12) and a non-eligible id is refused;
+//   • below the threshold NOTHING is applied (C10) — but the confidence is still
+//     logged, because that log line IS the tuning data (Q4);
+//   • it never throws (invariant 6).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  getDefault: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: h.info, warn: h.warn, error: h.error, debug: h.debug }),
+}))
+vi.mock('../ai/orchestrator/llm-orchestrator', () => ({
+  LLMOrchestrator: class {
+    invoke = h.invoke
+  },
+}))
+vi.mock('../ai/providers/system-model-service', () => ({
+  SystemModelService: class {
+    getDefault = h.getDefault
+  },
+}))
+vi.mock('../ai/providers/types', () => ({ ModelType: { LLM: 'LLM' } }))
+vi.mock('../ai/usage/usage-tracking-service', () => ({
+  UsageTrackingService: class {},
+}))
+
+import { buildClassificationPrompt, buildClassificationSchema, classifyMessage } from './classify'
+import { MAIL_CLASSIFY_BODY_CHARS, MAIL_CLASSIFY_NO_CATEGORY } from './client'
+import type { MailClassificationContext } from './types'
+
+const context: MailClassificationContext = {
+  organizationId: 'org_1',
+  messageId: 'msg_1',
+  threadId: 'thr_1',
+  inboxId: 'ibx_1',
+  labels: [
+    { tagId: 'tag_billing', title: 'Billing', description: 'Invoices, refunds, card charges' },
+    { tagId: 'tag_sales', title: 'Sales', description: null },
+  ],
+  message: { subject: 'Refund', from: 'a@b.com', textPlain: 'please refund me' },
+}
+
+const db = {} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getDefault.mockResolvedValue({ provider: 'openai', model: 'gpt-x' })
+})
+
+describe('the structured-output schema (invariant 12)', () => {
+  it('is an OBJECT with a `category` field, not a bare id', () => {
+    const schema = buildClassificationSchema(context.labels)
+    expect(schema.schema.type).toBe('object')
+    expect(Object.keys(schema.schema.properties)).toEqual(['category', 'confidence'])
+    expect(schema.schema.required).toEqual(['category', 'confidence'])
+  })
+
+  it('enumerates the eligible TAG IDS plus the abstention sentinel — never free text', () => {
+    const schema = buildClassificationSchema(context.labels)
+    expect(schema.schema.properties.category.enum).toEqual([
+      'tag_billing',
+      'tag_sales',
+      MAIL_CLASSIFY_NO_CATEGORY,
+    ])
+    expect(schema.schema.properties.category).not.toHaveProperty('pattern')
+  })
+})
+
+describe('the prompt', () => {
+  it('carries each label as title + description — the description IS the definition (C3)', () => {
+    const prompt = buildClassificationPrompt(context)
+    expect(prompt).toContain('id: tag_billing')
+    expect(prompt).toContain('definition: Invoices, refunds, card charges')
+    // Q5: a description-less tag is still offered, just as a bare title.
+    expect(prompt).toContain('name: Sales')
+  })
+
+  it('truncates the body and never includes more than the cap', () => {
+    const prompt = buildClassificationPrompt({
+      ...context,
+      message: { ...context.message, textPlain: 'x'.repeat(MAIL_CLASSIFY_BODY_CHARS + 500) },
+    })
+    expect(prompt).not.toContain('x'.repeat(MAIL_CLASSIFY_BODY_CHARS + 1))
+    expect(prompt).toContain('x'.repeat(MAIL_CLASSIFY_BODY_CHARS))
+  })
+})
+
+describe('classifyMessage — the confidence threshold (C10 / Q4)', () => {
+  it('applies the tag at or above the threshold', async () => {
+    h.invoke.mockResolvedValue({ structured_output: { category: 'tag_billing', confidence: 0.7 } })
+
+    await expect(classifyMessage(db, context)).resolves.toEqual({
+      tagId: 'tag_billing',
+      confidence: 0.7,
+      model: 'gpt-x',
+    })
+  })
+
+  it('⚠️ BELOW the threshold applies nothing — but STILL logs the confidence', async () => {
+    h.invoke.mockResolvedValue({ structured_output: { category: 'tag_billing', confidence: 0.55 } })
+
+    const result = await classifyMessage(db, context)
+
+    expect(result).toEqual({
+      tagId: null,
+      confidence: 0.55,
+      reason: 'below-threshold',
+      model: 'gpt-x',
+    })
+    // The below-threshold rows are the most informative for tuning and the
+    // easiest to forget: there is no column, the log IS the data.
+    const logged = h.info.mock.calls.find(([msg]) => msg === 'Mail classification result')
+    expect(logged?.[1]).toMatchObject({
+      messageId: 'msg_1',
+      confidence: 0.55,
+      applied: false,
+      // The model's pick is kept for tuning; `tagId` (what was written) is null.
+      chosenTagId: 'tag_billing',
+      tagId: null,
+    })
+  })
+
+  it('logs the confidence on an APPLIED call too', async () => {
+    h.invoke.mockResolvedValue({ structured_output: { category: 'tag_sales', confidence: 0.93 } })
+
+    await classifyMessage(db, context)
+
+    const logged = h.info.mock.calls.find(([msg]) => msg === 'Mail classification result')
+    expect(logged?.[1]).toMatchObject({ confidence: 0.93, applied: true, tagId: 'tag_sales' })
+  })
+})
+
+describe('classifyMessage — the model cannot return a non-eligible id', () => {
+  it('refuses an id outside the eligible set, even at full confidence', async () => {
+    h.invoke.mockResolvedValue({ structured_output: { category: 'tag_invented', confidence: 1 } })
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: null,
+      reason: 'no-category',
+    })
+  })
+
+  it('treats the abstention sentinel as "apply nothing"', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: { category: MAIL_CLASSIFY_NO_CATEGORY, confidence: 0.99 },
+    })
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: null,
+      reason: 'no-category',
+    })
+  })
+
+  it('treats a malformed payload as "apply nothing"', async () => {
+    h.invoke.mockResolvedValue({ structured_output: undefined })
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: null,
+      confidence: 0,
+      reason: 'no-category',
+    })
+  })
+})
+
+describe('classifyMessage — usage attribution + never throws', () => {
+  it('tags the spend with the `mail_classification` source arm', async () => {
+    h.invoke.mockResolvedValue({ structured_output: { category: 'tag_billing', confidence: 0.9 } })
+
+    await classifyMessage(db, context)
+
+    expect(h.invoke.mock.calls[0]?.[0]?.context).toMatchObject({
+      source: 'mail_classification',
+      messageId: 'msg_1',
+    })
+  })
+
+  it('a provider failure logs and leaves the thread untagged', async () => {
+    h.invoke.mockRejectedValue(new Error('429'))
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: null,
+      reason: 'error',
+    })
+    expect(h.warn).toHaveBeenCalled()
+  })
+
+  it('no default LLM is a skip, not an error — and costs no call', async () => {
+    h.getDefault.mockResolvedValue(null)
+
+    await expect(classifyMessage(db, context)).resolves.toEqual({
+      tagId: null,
+      confidence: 0,
+      reason: 'no-default-model',
+    })
+    expect(h.invoke).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/mail-classification/classify.ts
+++ b/packages/lib/src/mail-classification/classify.ts
@@ -1,0 +1,205 @@
+// packages/lib/src/mail-classification/classify.ts
+// The ONE model call (§3.2). Copied in shape from
+// `field-values/ai-autofill/generation-service.ts:107-124`:
+//   SystemModelService.getDefault(ModelType.LLM)
+//     → new LLMOrchestrator(new UsageTrackingService(db), db).invoke({ … })
+//
+// That path already enforces quota, writes `AiUsage` and meters credits from
+// real USD COGS (BYO = 0). None of it is rebuilt here.
+//
+// ⚠️ NEVER THROWS (invariant 6). Untagged is the safe state, so every failure
+// mode — no default model, provider error, malformed output — logs and returns a
+// null category.
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { LLMOrchestrator } from '../ai/orchestrator/llm-orchestrator'
+import { SystemModelService } from '../ai/providers/system-model-service'
+import { ModelType } from '../ai/providers/types'
+import { UsageTrackingService } from '../ai/usage/usage-tracking-service'
+import {
+  MAIL_CLASSIFY_BODY_CHARS,
+  MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
+  MAIL_CLASSIFY_NO_CATEGORY,
+  type MailClassificationLabel,
+} from './client'
+import type { MailClassificationContext, MailClassificationResult } from './types'
+
+const logger = createScopedLogger('mail-classification')
+
+const SYSTEM_PROMPT = [
+  'You categorise inbound customer email for a help desk.',
+  'Choose exactly ONE category from the list, or the sentinel value when none of',
+  'them fits. Each category is defined by its description — classify against the',
+  'description, not against the label wording.',
+  'Report your confidence as a number between 0 and 1. Be honest: a low',
+  'confidence means the mail is not applied to any category at all, which is the',
+  'correct outcome for ambiguous mail.',
+].join(' ')
+
+/**
+ * The `response_format.json_schema` the model must answer in.
+ *
+ * ⚠️ Invariant 12, two halves:
+ *  • the category is an ENUM OF TAG IDS, never free text, so the model cannot
+ *    invent a label; and
+ *  • the answer is an OBJECT with a `category` field, not a bare id, so a second
+ *    output (priority, sentiment, language) later costs no extra call and does
+ *    not change this shape.
+ *
+ * {@link MAIL_CLASSIFY_NO_CATEGORY} is a member of the same enum: under `strict`
+ * a nullable enum is not portable across providers, so abstention has to be a
+ * legal value rather than an absent one.
+ */
+export function buildClassificationSchema(labels: MailClassificationLabel[]) {
+  return {
+    name: 'mail_classification_result',
+    strict: true,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['category', 'confidence'],
+      properties: {
+        category: {
+          type: 'string',
+          enum: [...labels.map((label) => label.tagId), MAIL_CLASSIFY_NO_CATEGORY],
+          description: `The id of the single best-fitting category, or "${MAIL_CLASSIFY_NO_CATEGORY}" when none fits.`,
+        },
+        confidence: {
+          type: 'number',
+          description: 'Confidence in the chosen category, from 0 to 1.',
+        },
+      },
+    },
+  }
+}
+
+/** The label list as the prompt sees it — `title` + `tag_description` (C3). */
+export function renderLabels(labels: MailClassificationLabel[]): string {
+  return labels
+    .map((label) => {
+      const definition = label.description?.trim()
+      return definition
+        ? `- id: ${label.tagId}\n  name: ${label.title}\n  definition: ${definition}`
+        : `- id: ${label.tagId}\n  name: ${label.title}`
+    })
+    .join('\n')
+}
+
+/**
+ * The user turn: subject + sender + a truncated body (§3.2). No quoted history —
+ * the classifier does not need it, and truncation is most of the cost control.
+ */
+export function buildClassificationPrompt(context: MailClassificationContext): string {
+  const { subject, from, textPlain } = context.message
+  const body = (textPlain ?? '').slice(0, MAIL_CLASSIFY_BODY_CHARS)
+  return [
+    'Categories:',
+    renderLabels(context.labels),
+    '',
+    `From: ${from ?? '(unknown)'}`,
+    `Subject: ${subject ?? '(no subject)'}`,
+    '',
+    'Body:',
+    body || '(empty)',
+  ].join('\n')
+}
+
+/**
+ * Classify one message against the org's eligible tags. One tag or none (Q1).
+ *
+ * Returns `tagId: null` for every "apply nothing" outcome, with `reason` set so
+ * the caller's log line explains itself. Below
+ * {@link MAIL_CLASSIFY_CONFIDENCE_THRESHOLD} the model's pick is discarded (C10)
+ * — but its confidence is still reported and still logged, because those are the
+ * rows the threshold is tuned against (Q4).
+ */
+export async function classifyMessage(
+  db: Database,
+  context: MailClassificationContext
+): Promise<MailClassificationResult> {
+  const { organizationId, messageId } = context
+
+  const systemModels = new SystemModelService(db, organizationId)
+  const def = await systemModels.getDefault(ModelType.LLM).catch((error) => {
+    logger.warn('Mail classification could not resolve the org default LLM', {
+      organizationId,
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  })
+  if (!def) {
+    logger.info('Mail classification skipped — no default LLM configured', {
+      organizationId,
+      messageId,
+    })
+    return { tagId: null, confidence: 0, reason: 'no-default-model' }
+  }
+
+  let structured: Record<string, unknown> | undefined
+  try {
+    const orchestrator = new LLMOrchestrator(new UsageTrackingService(db), db)
+    const response = await orchestrator.invoke({
+      model: def.model,
+      provider: def.provider,
+      organizationId,
+      userId: '',
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: buildClassificationPrompt(context) },
+      ],
+      structuredOutput: { enabled: true, schema: buildClassificationSchema(context.labels) },
+      // A NEW `UsageSource` arm (`ai/orchestrator/types.ts`), so classification
+      // spend is separable from `agent` / `autofill` / `workflow` in reporting.
+      context: { source: 'mail_classification', messageId, threadId: context.threadId },
+    })
+    structured = response.structured_output
+  } catch (error) {
+    logger.warn('Mail classification model call failed — leaving the thread untagged', {
+      organizationId,
+      messageId,
+      model: def.model,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { tagId: null, confidence: 0, reason: 'error', model: def.model }
+  }
+
+  const rawCategory = typeof structured?.category === 'string' ? structured.category : null
+  const rawConfidence = typeof structured?.confidence === 'number' ? structured.confidence : 0
+  const confidence = Number.isFinite(rawConfidence) ? Math.min(1, Math.max(0, rawConfidence)) : 0
+
+  // Enum membership is re-checked HERE rather than trusted from the schema: a
+  // provider that ignores `strict` (or a future one that does not support enums)
+  // must not be able to make us write a tag the org never marked eligible.
+  const eligible = new Set(context.labels.map((label) => label.tagId))
+  const category = rawCategory && eligible.has(rawCategory) ? rawCategory : null
+
+  const applied = category !== null && confidence >= MAIL_CLASSIFY_CONFIDENCE_THRESHOLD
+
+  // ⚠️ Q4 — LOG ON EVERY CALL, including the below-threshold ones that apply
+  // nothing. There is no column and no audit row: this line IS the tuning data.
+  logger.info('Mail classification result', {
+    organizationId,
+    messageId,
+    threadId: context.threadId,
+    model: def.model,
+    labelCount: context.labels.length,
+    // What the model literally said, what survived the eligibility check, and
+    // what was actually written — three different things when tuning.
+    rawCategory,
+    chosenTagId: category,
+    tagId: applied ? category : null,
+    confidence,
+    threshold: MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
+    applied,
+  })
+
+  if (applied) return { tagId: category, confidence, model: def.model }
+  return {
+    tagId: null,
+    confidence,
+    reason: category === null ? 'no-category' : 'below-threshold',
+    model: def.model,
+  }
+}

--- a/packages/lib/src/mail-classification/client.ts
+++ b/packages/lib/src/mail-classification/client.ts
@@ -1,0 +1,107 @@
+// packages/lib/src/mail-classification/client.ts
+// CLIENT-SAFE entry point for mail classification — the threshold, the setting
+// key, the prompt-shaping constants and the shared label/result types.
+// No database, no cache, no queue imports.
+//
+// NOTE: no 'use client' directive. Server code imports this file too (the guard,
+// the classifier and the settings catalog all read these constants), and the
+// directive would turn every export into a client-reference proxy there.
+
+/**
+ * Minimum model confidence before a tag is applied (plan Q4).
+ *
+ * Below it the classifier applies NOTHING (C10) — no tag is both the safe state
+ * and the correct one, because a mail filter must never act on a guess. Tuned
+ * against the `info` line `classify.ts` logs on EVERY call, including the
+ * below-threshold ones: there is no column and no audit row, the log IS the
+ * tuning data (`scope='mail-classification'` in OpenObserve).
+ */
+export const MAIL_CLASSIFY_CONFIDENCE_THRESHOLD = 0.7
+
+/**
+ * `orgSettings` key holding the ids of the inboxes that opted in (plan §5).
+ *
+ * A LIST of inbox ids, never a boolean: "classify everything" must not be
+ * expressible, because a personal mailbox is its owner's alone and an admin must
+ * never be able to switch inference on over someone else's mail (invariant 11).
+ */
+export const MAIL_CLASSIFICATION_INBOX_IDS_SETTING = 'mailClassificationInboxIds'
+
+/**
+ * The `systemAttribute` of the boolean tag field that makes a tag eligible for
+ * the classifier's label set (C2). Declared on the `tag` def in
+ * `resources/registry/resources/tag-fields.ts`; named here so the server-side
+ * lookup and the UI agree on one string.
+ */
+export const TAG_AI_CLASSIFY_ATTRIBUTE = 'tag_ai_classify'
+
+/**
+ * Sentinel enum member meaning "none of these labels fit".
+ *
+ * The structured output is an enum of tag ids (invariant 12) so the model cannot
+ * invent a label — which also means it needs a legal way to decline. A nullable
+ * field would work on some providers and not others under `strict`, so the
+ * abstention is a member of the same enum. Deliberately not a cuid shape, so it
+ * can never collide with a real tag id.
+ */
+export const MAIL_CLASSIFY_NO_CATEGORY = '__none__'
+
+/**
+ * How much `textPlain` reaches the prompt (plan §3.2).
+ *
+ * The classifier does not need quoted history to decide what a mail is *about*,
+ * and truncation is most of the cost control on a per-inbound-message call.
+ */
+export const MAIL_CLASSIFY_BODY_CHARS = 2000
+
+/**
+ * Key under `Message.metadata` holding the classification marker.
+ *
+ * Its presence IS the "already classified" answer (C9) — classify once per
+ * message, ever. A retry that re-infers is a bug the customer sees on an invoice.
+ */
+export const MAIL_CLASSIFICATION_METADATA_KEY = 'mailClassification'
+
+/** BullMQ job name for the classification worker. */
+export const MAIL_CLASSIFICATION_JOB_NAME = 'mailClassificationJob'
+
+/** One eligible tag, as the prompt sees it. */
+export interface MailClassificationLabel {
+  /** `EntityInstance.id` of the tag — the enum member the model returns. */
+  tagId: string
+  title: string
+  /**
+   * `tag_description`. THE definition the model classifies against (C3), not
+   * decoration. Null is allowed and deliberate (Q5): a bare title like `Refunds`
+   * is often self-explanatory, and silently dropping a tag whose toggle is
+   * visibly on is the more confusing failure. The dialog warns instead.
+   */
+  description: string | null
+}
+
+/**
+ * Why a message was not classified. Every arm is a guard exit (§3.1) except
+ * `'error'`; all of them are normal, and none of them is a failure the caller
+ * should retry.
+ */
+export type MailClassificationSkipReason =
+  | 'machine-mail'
+  | 'no-thread'
+  | 'inbox-not-opted-in'
+  | 'no-eligible-tags'
+  | 'already-classified'
+  | 'thread-already-categorised'
+  | 'no-default-model'
+  | 'below-threshold'
+  | 'no-category'
+  | 'error'
+
+/** The marker written to `Message.metadata.mailClassification` after a call. */
+export interface MailClassificationMarker {
+  /** ISO timestamp of the inference. */
+  at: string
+  /** The applied tag id, or null when nothing was applied. */
+  tagId: string | null
+  confidence: number
+  model?: string
+}

--- a/packages/lib/src/mail-classification/enqueue.test.ts
+++ b/packages/lib/src/mail-classification/enqueue.test.ts
@@ -1,0 +1,75 @@
+// packages/lib/src/mail-classification/enqueue.test.ts
+// The `then`-side door: the two free payload exits, the dedupe key, and the
+// never-throws contract (a failed enqueue must not burn the event handler's
+// retry budget).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ add: vi.fn(), getQueue: vi.fn() }))
+
+vi.mock('../jobs/queues', () => ({ getQueue: h.getQueue }))
+
+import { MAIL_CLASSIFICATION_JOB_NAME } from './client'
+import { enqueueMailClassification } from './enqueue'
+
+const event = (overrides: Record<string, unknown> = {}) =>
+  ({
+    data: {
+      type: 'message:received',
+      data: {
+        organizationId: 'org_1',
+        messageId: 'msg_1',
+        threadId: 'thr_1',
+        from: 'a@b.com',
+        ...overrides,
+      },
+    },
+  }) as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getQueue.mockReturnValue({ add: h.add })
+  h.add.mockResolvedValue({ id: '1' })
+})
+
+describe('enqueueMailClassification', () => {
+  it('enqueues under the job name the worker maps, keyed for dedupe on messageId', async () => {
+    await enqueueMailClassification(event())
+
+    expect(h.add).toHaveBeenCalledWith(
+      MAIL_CLASSIFICATION_JOB_NAME,
+      {
+        organizationId: 'org_1',
+        messageId: 'msg_1',
+        threadId: 'thr_1',
+        from: 'a@b.com',
+      },
+      { jobId: 'mail-classify:msg_1' }
+    )
+  })
+
+  it('ignores events that are not `message:received`', async () => {
+    await enqueueMailClassification({ data: { type: 'message:sent', data: {} } } as never)
+    expect(h.add).not.toHaveBeenCalled()
+  })
+
+  it('never queues hard-tier machine mail (exit 1)', async () => {
+    await enqueueMailClassification(event({ machineMail: { tier: 'hard', reason: 'ndr' } }))
+    expect(h.add).not.toHaveBeenCalled()
+  })
+
+  it('queues SOFT-tier machine mail — list/OOO mail is still categorisable', async () => {
+    await enqueueMailClassification(event({ machineMail: { tier: 'soft', reason: 'list' } }))
+    expect(h.add.mock.calls[0]?.[1]).toMatchObject({ machineMailTier: 'soft' })
+  })
+
+  it('never queues a message with no thread (exit 2)', async () => {
+    await enqueueMailClassification(event({ threadId: undefined }))
+    expect(h.add).not.toHaveBeenCalled()
+  })
+
+  it('swallows an enqueue failure rather than failing the fan-out', async () => {
+    h.add.mockRejectedValue(new Error('redis down'))
+    await expect(enqueueMailClassification(event())).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/mail-classification/enqueue.ts
+++ b/packages/lib/src/mail-classification/enqueue.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/mail-classification/enqueue.ts
+// The `then`-side door (§4): `message:received` → `mailClassificationQueue`.
+//
+// Deliberately NOT a gate. An LLM call in the gate would routinely exceed
+// `GATE_TIMEOUT_MS` and head-of-line block unrelated events on `eventsQueue`
+// (invariant 2), and the gate's fail-open path means the classification would
+// then silently never happen.
+//
+// Enqueuing from `then` also buys guard exit 6 for free: `applyMailFilters` runs
+// INLINE in the gate, so every deterministic `add-tag` has already landed on the
+// thread by the time the classification job dequeues (§3.1.1).
+//
+// This handler does the cheapest payload-only checks and nothing else — the real
+// ladder lives in `guard.ts`, on the classification worker, where a cache miss
+// or a query costs an `eventHandlersQueue` slot rather than an `eventsQueue` one.
+
+import { createScopedLogger } from '@auxx/logger'
+import type { AuxxEvent, MessageReceivedEvent } from '../events/types'
+import { getQueue } from '../jobs/queues'
+import { Queues } from '../jobs/queues/types'
+import { MAIL_CLASSIFICATION_JOB_NAME } from './client'
+import type { MailClassificationJobData } from './job'
+
+const logger = createScopedLogger('mail-classification')
+
+/**
+ * Fan `message:received` out to the classification queue.
+ *
+ * The BullMQ `jobId` is derived from the message id, so a duplicated event
+ * delivery collapses into one queued job. That is a cheap first line of defence
+ * only — the durable "classify once per message, ever" guarantee (C9) is the
+ * `Message.metadata` marker guard exit 5 reads, because BullMQ forgets a jobId
+ * once the job completes and is removed.
+ */
+export const enqueueMailClassification = async ({ data: event }: { data: AuxxEvent }) => {
+  if (event.type !== 'message:received') return
+
+  const { organizationId, messageId, threadId, machineMail, from } = (event as MessageReceivedEvent)
+    .data
+
+  // Payload-only exits 1 and 2 (§3.1). Everything past here costs a queue write,
+  // so the two free checks happen on this side of it.
+  if (machineMail?.tier === 'hard') return
+  if (!threadId) return
+
+  const data: MailClassificationJobData = {
+    organizationId,
+    messageId,
+    threadId,
+    ...(machineMail?.tier ? { machineMailTier: machineMail.tier } : {}),
+    ...(from ? { from } : {}),
+  }
+
+  try {
+    await getQueue(Queues.mailClassificationQueue).add(MAIL_CLASSIFICATION_JOB_NAME, data, {
+      jobId: `mail-classify:${messageId}`,
+    })
+  } catch (error) {
+    // Never throw: a classification that did not get queued must not fail the
+    // event handler and take the rest of the fan-out's retry budget with it.
+    logger.error('Failed to enqueue mail classification', {
+      organizationId,
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/mail-classification/guard.test.ts
+++ b/packages/lib/src/mail-classification/guard.test.ts
@@ -1,0 +1,227 @@
+// packages/lib/src/mail-classification/guard.test.ts
+// The §3.1 exit ladder. Two properties are pinned per exit: the RIGHT reason
+// comes back, and nothing more expensive than that exit ran.
+//
+// The ordering is the whole point (C8) — an org that never opts in must issue
+// ZERO queries — so several tests assert on the DB-call count rather than only
+// on the returned reason.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  orgCacheGet: vi.fn(),
+  getEligibleClassificationTags: vi.fn(),
+  getThreadTagIds: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ get: h.orgCacheGet }),
+}))
+vi.mock('./labels', () => ({
+  getEligibleClassificationTags: h.getEligibleClassificationTags,
+}))
+vi.mock('../field-values/relationship-queries', () => ({
+  getThreadTagIds: h.getThreadTagIds,
+}))
+
+import { guardClassification } from './guard'
+
+/**
+ * A `db` whose `select()` chain resolves the next queued row set. `select` is a
+ * spy, so "did this exit run before any query?" is assertable.
+ */
+function createDb(rowSets: unknown[][]) {
+  let index = 0
+  const select = vi.fn(() => {
+    const result = Promise.resolve(rowSets[index++] ?? [])
+    const step: Record<string, unknown> = {}
+    step.from = () => step
+    step.where = () => step
+    step.limit = () => result
+    step.then = (onOk: unknown, onErr: unknown) => result.then(onOk as never, onErr as never)
+    return step
+  })
+  return { select } as never as Parameters<typeof guardClassification>[0]['db'] & {
+    select: typeof select
+  }
+}
+
+const LABELS = [{ tagId: 'tag_billing', title: 'Billing', description: 'Invoices' }]
+
+const base = {
+  organizationId: 'org_1',
+  messageId: 'msg_1',
+  threadId: 'thr_1',
+  from: 'a@b.com',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.orgCacheGet.mockResolvedValue({ mailClassificationInboxIds: ['ibx_1'] })
+  h.getEligibleClassificationTags.mockResolvedValue(LABELS)
+  h.getThreadTagIds.mockResolvedValue([])
+})
+
+describe('guardClassification — exit 1: hard machine mail', () => {
+  it('exits on the payload field alone, with no cache read and no query', async () => {
+    const db = createDb([])
+    const gate = await guardClassification({ ...base, db, machineMailTier: 'hard' })
+
+    expect(gate).toEqual({ proceed: false, reason: 'machine-mail' })
+    expect(h.orgCacheGet).not.toHaveBeenCalled()
+    expect(db.select).not.toHaveBeenCalled()
+  })
+
+  it('does NOT exit on soft-tier machine mail (OOO / list mail is still categorisable)', async () => {
+    const db = createDb([
+      [{ inboxId: 'ibx_1' }],
+      [{ subject: 's', textPlain: 'b', metadata: null }],
+    ])
+    const gate = await guardClassification({ ...base, db, machineMailTier: 'soft' })
+
+    expect(gate.proceed).toBe(true)
+  })
+})
+
+describe('guardClassification — exit 2: no thread', () => {
+  it('exits on the payload field alone', async () => {
+    const db = createDb([])
+    const gate = await guardClassification({ ...base, db, threadId: undefined })
+
+    expect(gate).toEqual({ proceed: false, reason: 'no-thread' })
+    expect(h.orgCacheGet).not.toHaveBeenCalled()
+    expect(db.select).not.toHaveBeenCalled()
+  })
+})
+
+describe('guardClassification — exit 3: inbox not opted in', () => {
+  it('an org with an EMPTY opt-in list pays zero queries (C8)', async () => {
+    h.orgCacheGet.mockResolvedValue({ mailClassificationInboxIds: [] })
+    const db = createDb([])
+
+    const gate = await guardClassification({ ...base, db })
+
+    expect(gate).toEqual({ proceed: false, reason: 'inbox-not-opted-in' })
+    expect(db.select).not.toHaveBeenCalled()
+    expect(h.getEligibleClassificationTags).not.toHaveBeenCalled()
+  })
+
+  it('a missing setting reads as opted out, not as opted in', async () => {
+    h.orgCacheGet.mockResolvedValue({})
+    const db = createDb([])
+
+    expect(await guardClassification({ ...base, db })).toEqual({
+      proceed: false,
+      reason: 'inbox-not-opted-in',
+    })
+    expect(db.select).not.toHaveBeenCalled()
+  })
+
+  it('a thread in an inbox that is NOT on the list exits before the tag lookup', async () => {
+    const db = createDb([[{ inboxId: 'ibx_other' }]])
+
+    const gate = await guardClassification({ ...base, db })
+
+    expect(gate).toEqual({ proceed: false, reason: 'inbox-not-opted-in' })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(h.getEligibleClassificationTags).not.toHaveBeenCalled()
+  })
+})
+
+describe('guardClassification — exit 4: no eligible tags', () => {
+  it('exits before loading the message when the label set is empty (C8, second half)', async () => {
+    h.getEligibleClassificationTags.mockResolvedValue([])
+    const db = createDb([[{ inboxId: 'ibx_1' }]])
+
+    const gate = await guardClassification({ ...base, db })
+
+    expect(gate).toEqual({ proceed: false, reason: 'no-eligible-tags' })
+    // Only the thread query ran — the message was never loaded.
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(h.getThreadTagIds).not.toHaveBeenCalled()
+  })
+})
+
+describe('guardClassification — exit 5: already classified (C9)', () => {
+  it('exits when the metadata marker is present, before the tag read', async () => {
+    const db = createDb([
+      [{ inboxId: 'ibx_1' }],
+      [
+        {
+          subject: 's',
+          textPlain: 'b',
+          metadata: { mailClassification: { at: 'x', tagId: null, confidence: 0.1 } },
+        },
+      ],
+    ])
+
+    const gate = await guardClassification({ ...base, db })
+
+    expect(gate).toEqual({ proceed: false, reason: 'already-classified' })
+    expect(h.getThreadTagIds).not.toHaveBeenCalled()
+  })
+
+  it('unrelated metadata (machineMail, headers) does NOT count as classified', async () => {
+    const db = createDb([
+      [{ inboxId: 'ibx_1' }],
+      [{ subject: 's', textPlain: 'b', metadata: { machineMail: { tier: 'soft' } } }],
+    ])
+
+    expect((await guardClassification({ ...base, db })).proceed).toBe(true)
+  })
+})
+
+describe('guardClassification — exit 6: a rule already answered (§3.1.1)', () => {
+  it('exits when the thread already carries an ELIGIBLE tag', async () => {
+    h.getThreadTagIds.mockResolvedValue(['tag_billing'])
+    const db = createDb([
+      [{ inboxId: 'ibx_1' }],
+      [{ subject: 's', textPlain: 'b', metadata: null }],
+    ])
+
+    const gate = await guardClassification({ ...base, db })
+
+    expect(gate).toEqual({ proceed: false, reason: 'thread-already-categorised' })
+  })
+
+  it('⚠️ an UNRELATED user tag (VIP, P1) does NOT count as categorised', async () => {
+    h.getThreadTagIds.mockResolvedValue(['tag_vip', 'tag_p1'])
+    const db = createDb([
+      [{ inboxId: 'ibx_1' }],
+      [{ subject: 's', textPlain: 'b', metadata: null }],
+    ])
+
+    const gate = await guardClassification({ ...base, db })
+
+    expect(gate.proceed).toBe(true)
+  })
+})
+
+describe('guardClassification — the resolved context', () => {
+  it('carries the inbox, the labels and the truncatable message parts', async () => {
+    const db = createDb([
+      [{ inboxId: 'ibx_1' }],
+      [{ subject: 'Refund please', textPlain: 'body text', metadata: null }],
+    ])
+
+    const gate = await guardClassification({ ...base, db })
+
+    expect(gate).toEqual({
+      proceed: true,
+      context: {
+        organizationId: 'org_1',
+        messageId: 'msg_1',
+        threadId: 'thr_1',
+        inboxId: 'ibx_1',
+        labels: LABELS,
+        message: { subject: 'Refund please', from: 'a@b.com', textPlain: 'body text' },
+      },
+    })
+  })
+
+  it('a vanished message is a skip, never a throw', async () => {
+    const db = createDb([[{ inboxId: 'ibx_1' }], []])
+
+    expect((await guardClassification({ ...base, db })).proceed).toBe(false)
+  })
+})

--- a/packages/lib/src/mail-classification/guard.ts
+++ b/packages/lib/src/mail-classification/guard.ts
@@ -1,0 +1,140 @@
+// packages/lib/src/mail-classification/guard.ts
+// READ: the §3.1 exit ladder. Six exits, cheapest first.
+//
+// ⚠️ THE ORDERING IS THE DESIGN — do not rearrange it. Every payload-only and
+// cache-only check runs before anything that touches the DB, so an org that has
+// never opted an inbox in pays ZERO queries for this feature on every inbound
+// message in the system (C8). Mirrors `applyMailFilters`' own exit ordering for
+// the same reason.
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
+import { getThreadTagIds } from '../field-values/relationship-queries'
+import {
+  MAIL_CLASSIFICATION_INBOX_IDS_SETTING,
+  MAIL_CLASSIFICATION_METADATA_KEY,
+  type MailClassificationSkipReason,
+} from './client'
+import { getEligibleClassificationTags } from './labels'
+import type { MailClassificationGate } from './types'
+
+/** What the guard needs, all of it already in hand at the call site. */
+export interface MailClassificationGateInput {
+  db: Database
+  organizationId: string
+  messageId: string
+  /** From the `message:received` payload — absent means nothing to tag. */
+  threadId?: string
+  /** From the `message:received` payload (`machineMail.tier`). */
+  machineMailTier?: 'hard' | 'soft'
+  /** From the `message:received` payload — the prompt's sender line. */
+  from?: string
+}
+
+const skip = (reason: MailClassificationSkipReason): MailClassificationGate => ({
+  proceed: false,
+  reason,
+})
+
+/**
+ * The opted-in inbox ids for this org (plan §5), read from the `orgSettings`
+ * cache. Never a DB query — this is THE exit that fires for almost every org and
+ * it must stay ahead of anything that touches the database.
+ */
+async function getOptedInInboxIds(organizationId: string): Promise<string[]> {
+  const settings = await getOrgCache().get(organizationId, 'orgSettings')
+  const raw = settings?.[MAIL_CLASSIFICATION_INBOX_IDS_SETTING]
+  if (!Array.isArray(raw)) return []
+  return raw.filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+/**
+ * Decide whether one inbound message should be classified, and resolve
+ * everything the model call needs if so.
+ *
+ * Never throws — a guard failure must leave the thread untagged, not fail a job.
+ */
+export async function guardClassification(
+  input: MailClassificationGateInput
+): Promise<MailClassificationGate> {
+  const { db, organizationId, messageId, threadId, machineMailTier } = input
+
+  // 1. Hard-tier machine mail (bounces/NDRs) is loop-forming and never worth an
+  //    inference. Payload field — no I/O.
+  if (machineMailTier === 'hard') return skip('machine-mail')
+
+  // 2. No thread, nothing to tag. Payload field — no I/O.
+  if (!threadId) return skip('no-thread')
+
+  // 3a. The org has not opted ANY inbox in. Pure org-cache read, and the exit
+  //     that makes C8 true: no opt-in, no queries, no inference, ever.
+  const optedInInboxIds = await getOptedInInboxIds(organizationId)
+  if (optedInInboxIds.length === 0) return skip('inbox-not-opted-in')
+
+  // 3b. Which inbox is this thread in? The payload does not carry it, so this is
+  //     the first (and cheapest possible) query, and only opted-in orgs pay it.
+  const [thread] = await db
+    .select({ inboxId: schema.Thread.inboxId })
+    .from(schema.Thread)
+    .where(and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, organizationId)))
+    .limit(1)
+  const inboxId = thread?.inboxId ?? null
+  if (!inboxId || !optedInInboxIds.includes(inboxId)) return skip('inbox-not-opted-in')
+
+  // 4. The org has no eligible tags. The second half of the double guard (C8) —
+  //    an opted-in inbox with an empty label set must not reach a model call,
+  //    because there is nothing the model could legally answer.
+  const labels = await getEligibleClassificationTags(db, organizationId)
+  if (labels.length === 0) return skip('no-eligible-tags')
+
+  // 5. Already classified (C9). Classify once per message, EVER — a retry that
+  //    re-infers is a bug the customer sees on an invoice. The marker lives in
+  //    `Message.metadata`, written by `apply.ts` right after the call returns.
+  const [message] = await db
+    .select({
+      subject: schema.Message.subject,
+      textPlain: schema.Message.textPlain,
+      metadata: schema.Message.metadata,
+    })
+    .from(schema.Message)
+    .where(and(eq(schema.Message.id, messageId), eq(schema.Message.organizationId, organizationId)))
+    .limit(1)
+  if (!message) return skip('no-thread')
+  const metadata = (message.metadata ?? {}) as Record<string, unknown>
+  if (metadata[MAIL_CLASSIFICATION_METADATA_KEY]) return skip('already-classified')
+
+  // 6. §3.1.1 — a RULE ALREADY ANSWERED, so the model is not asked.
+  //
+  //    This is the exit a reader will not predict and it encodes the feature's
+  //    whole justification. Manual tagging, the deterministic `add-tag` filter
+  //    action and the mined `auto-tag` suggestion are all free, exact and
+  //    instant; the classifier exists only for what a condition cannot reach
+  //    ("tag it Billing when it is *about* billing"). `applyMailFilters` runs in
+  //    the gate and this job is enqueued from `then`, so every deterministic tag
+  //    is already on the thread by the time we get here.
+  //
+  //    ⚠️ Scoped to ELIGIBLE tags only. A thread carrying `VIP` or `P1` has not
+  //    been categorised and must still be classified.
+  const eligibleIds = new Set(labels.map((label) => label.tagId))
+  const threadTagIds = await getThreadTagIds(db, threadId, organizationId)
+  if (threadTagIds.some((tagId) => eligibleIds.has(tagId))) {
+    return skip('thread-already-categorised')
+  }
+
+  return {
+    proceed: true,
+    context: {
+      organizationId,
+      messageId,
+      threadId,
+      inboxId,
+      labels,
+      message: {
+        subject: message.subject ?? null,
+        from: input.from ?? null,
+        textPlain: message.textPlain ?? null,
+      },
+    },
+  }
+}

--- a/packages/lib/src/mail-classification/index.ts
+++ b/packages/lib/src/mail-classification/index.ts
@@ -1,0 +1,47 @@
+// packages/lib/src/mail-classification/index.ts
+// Mail-classification domain barrel (plans/mail-filter/05-mail-classification-plan.md).
+// Explicit named exports only — see CLAUDE.md's "Module Exports" convention.
+
+// Write path (§3.3, C9)
+export { applyClassificationTag, markMessageClassified } from './apply'
+// The one model call (§3.2)
+export {
+  buildClassificationPrompt,
+  buildClassificationSchema,
+  classifyMessage,
+  renderLabels,
+} from './classify'
+// Client-safe constants + types (also importable as `@auxx/lib/mail-classification/client`)
+export {
+  MAIL_CLASSIFICATION_INBOX_IDS_SETTING,
+  MAIL_CLASSIFICATION_JOB_NAME,
+  MAIL_CLASSIFICATION_METADATA_KEY,
+  MAIL_CLASSIFY_BODY_CHARS,
+  MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
+  MAIL_CLASSIFY_NO_CATEGORY,
+  type MailClassificationLabel,
+  type MailClassificationMarker,
+  type MailClassificationSkipReason,
+  TAG_AI_CLASSIFY_ATTRIBUTE,
+} from './client'
+// The `then`-side door (§4)
+export { enqueueMailClassification } from './enqueue'
+// The §3.1 exit ladder
+export { guardClassification, type MailClassificationGateInput } from './guard'
+// The BullMQ worker (§4)
+export {
+  type MailClassificationJobData,
+  type MailClassificationJobResult,
+  mailClassificationJob,
+} from './job'
+// Eligible-tag lookup (Q2/Q3)
+export { getEligibleClassificationTags } from './labels'
+// ⚠️ The mandatory second filter pass (§4.1, invariant 13)
+export { rerunMailFiltersAfterClassification } from './rerun-filters'
+// Server-side shapes
+export type {
+  MailClassificationContext,
+  MailClassificationGate,
+  MailClassificationMessage,
+  MailClassificationResult,
+} from './types'

--- a/packages/lib/src/mail-classification/job.test.ts
+++ b/packages/lib/src/mail-classification/job.test.ts
@@ -1,0 +1,165 @@
+// packages/lib/src/mail-classification/job.test.ts
+// The job is orchestration only, so what is worth pinning is the ORDER and the
+// two things that cost money or silence the feature:
+//   • every guard exit short-circuits BEFORE the model call (C8);
+//   • the §4.1 filter re-run happens after a tag is applied, and only then.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  guard: vi.fn(),
+  classify: vi.fn(),
+  apply: vi.fn(),
+  mark: vi.fn(),
+  rerun: vi.fn(),
+}))
+
+vi.mock('./guard', () => ({ guardClassification: h.guard }))
+vi.mock('./classify', () => ({ classifyMessage: h.classify }))
+vi.mock('./apply', () => ({ applyClassificationTag: h.apply, markMessageClassified: h.mark }))
+vi.mock('./rerun-filters', () => ({ rerunMailFiltersAfterClassification: h.rerun }))
+
+import type { MailClassificationJobData } from './job'
+import { mailClassificationJob } from './job'
+
+const CONTEXT = {
+  organizationId: 'org_1',
+  messageId: 'msg_1',
+  threadId: 'thr_1',
+  inboxId: 'ibx_1',
+  labels: [{ tagId: 'tag_billing', title: 'Billing', description: null }],
+  message: { subject: 's', from: 'a@b.com', textPlain: 'b' },
+}
+
+function ctx(data: Partial<MailClassificationJobData> = {}) {
+  return {
+    data: { organizationId: 'org_1', messageId: 'msg_1', threadId: 'thr_1', ...data },
+  } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.guard.mockResolvedValue({ proceed: true, context: CONTEXT })
+  h.classify.mockResolvedValue({ tagId: 'tag_billing', confidence: 0.9, model: 'gpt-x' })
+  h.apply.mockResolvedValue(true)
+  h.mark.mockResolvedValue(undefined)
+  h.rerun.mockResolvedValue(['flt_category'])
+})
+
+describe('mailClassificationJob — every guard exit short-circuits before the model call', () => {
+  const REASONS = [
+    'machine-mail',
+    'no-thread',
+    'inbox-not-opted-in',
+    'no-eligible-tags',
+    'already-classified',
+    'thread-already-categorised',
+  ] as const
+
+  for (const reason of REASONS) {
+    it(`exit "${reason}" costs no inference, no write and no filter re-run`, async () => {
+      h.guard.mockResolvedValue({ proceed: false, reason })
+
+      await expect(mailClassificationJob(ctx())).resolves.toEqual({
+        classified: false,
+        skipped: reason,
+      })
+
+      expect(h.classify).not.toHaveBeenCalled()
+      expect(h.apply).not.toHaveBeenCalled()
+      expect(h.mark).not.toHaveBeenCalled()
+      expect(h.rerun).not.toHaveBeenCalled()
+    })
+  }
+
+  it('a THROWING guard is a skip, never a job failure (a retry would re-infer)', async () => {
+    h.guard.mockRejectedValue(new Error('db down'))
+
+    await expect(mailClassificationJob(ctx())).resolves.toEqual({
+      classified: false,
+      skipped: 'error',
+    })
+    expect(h.classify).not.toHaveBeenCalled()
+  })
+})
+
+describe('mailClassificationJob — the happy path', () => {
+  it('applies the tag and THEN re-runs the filter engine (§4.1)', async () => {
+    const order: string[] = []
+    h.apply.mockImplementation(async () => {
+      order.push('apply')
+      return true
+    })
+    h.rerun.mockImplementation(async () => {
+      order.push('rerun')
+      return []
+    })
+
+    const result = await mailClassificationJob(ctx())
+
+    expect(order).toEqual(['apply', 'rerun'])
+    expect(result).toMatchObject({ classified: true, tagId: 'tag_billing', confidence: 0.9 })
+  })
+
+  it('⚠️ the re-run is MANDATORY — nothing else calls the engine for this message again', async () => {
+    await mailClassificationJob(ctx())
+
+    expect(h.rerun).toHaveBeenCalledWith({
+      db: expect.anything(),
+      organizationId: 'org_1',
+      threadId: 'thr_1',
+      messageId: 'msg_1',
+    })
+  })
+
+  it('stamps the classification marker so the message is never re-inferred (C9)', async () => {
+    await mailClassificationJob(ctx())
+
+    expect(h.mark).toHaveBeenCalledTimes(1)
+    expect(h.mark.mock.calls[0]?.[0]?.marker).toMatchObject({
+      tagId: 'tag_billing',
+      confidence: 0.9,
+      model: 'gpt-x',
+    })
+  })
+})
+
+describe('mailClassificationJob — nothing applied', () => {
+  it('below threshold: marks the message, applies no tag, re-runs no filters (C10)', async () => {
+    h.classify.mockResolvedValue({
+      tagId: null,
+      confidence: 0.4,
+      reason: 'below-threshold',
+      model: 'gpt-x',
+    })
+
+    await expect(mailClassificationJob(ctx())).resolves.toEqual({
+      classified: false,
+      confidence: 0.4,
+      skipped: 'below-threshold',
+    })
+
+    // The inference happened and was billed, so the marker still goes down.
+    expect(h.mark).toHaveBeenCalledTimes(1)
+    expect(h.apply).not.toHaveBeenCalled()
+    expect(h.rerun).not.toHaveBeenCalled()
+  })
+
+  it('no default model: NO marker, so the message stays classifiable once one is set', async () => {
+    h.classify.mockResolvedValue({ tagId: null, confidence: 0, reason: 'no-default-model' })
+
+    await mailClassificationJob(ctx())
+
+    expect(h.mark).not.toHaveBeenCalled()
+  })
+
+  it('a failed tag write does not trigger a filter re-run over a tag that is not there', async () => {
+    h.apply.mockResolvedValue(false)
+
+    await expect(mailClassificationJob(ctx())).resolves.toMatchObject({
+      classified: false,
+      skipped: 'error',
+    })
+    expect(h.rerun).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/mail-classification/job.ts
+++ b/packages/lib/src/mail-classification/job.ts
@@ -1,0 +1,139 @@
+// packages/lib/src/mail-classification/job.ts
+// The `mailClassificationQueue` worker (§4).
+//
+// Why a dedicated queue: an LLM call cannot go in the gate
+// (`GATE_TIMEOUT_MS = 2000` on `eventsQueue` at `concurrency: 10`, shared with
+// every other event type — it would routinely time out and the fail-open path
+// means the classification silently never happens, invariant 2), and it cannot
+// go in `storeMessage` (invariant 1; 1–3s per message turns a 500-message
+// backfill into 25 minutes). The follow-up pass is what is left, and C6 makes it
+// sufficient rather than a compromise: the only category where beating the
+// auto-answer agent mattered was `Spam`, and `Spam` is a status, not a category.
+//
+// ⚠️ THE JOB NEVER THROWS (invariant 6). Untagged is the safe state, and a
+// throwing job would be retried by BullMQ — which is exactly the re-inference
+// C9 forbids.
+
+import { database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { JobContext } from '../jobs/types/job-context'
+import { applyClassificationTag, markMessageClassified } from './apply'
+import { classifyMessage } from './classify'
+import type { MailClassificationSkipReason } from './client'
+import { guardClassification } from './guard'
+import { rerunMailFiltersAfterClassification } from './rerun-filters'
+
+const logger = createScopedLogger('mail-classification')
+
+export interface MailClassificationJobData {
+  organizationId: string
+  messageId: string
+  threadId?: string
+  /** `machineMail.tier` from the `message:received` payload. */
+  machineMailTier?: 'hard' | 'soft'
+  /** Sender identifier from the `message:received` payload. */
+  from?: string
+}
+
+export interface MailClassificationJobResult {
+  classified: boolean
+  tagId?: string
+  confidence?: number
+  skipped?: MailClassificationSkipReason
+  /** Filters that fired on the mandatory second pass (§4.1). */
+  firedFilterIds?: string[]
+}
+
+/**
+ * Classify one inbound message and let its tag reach the filter engine.
+ *
+ * Four steps, in this order and no other:
+ *   1. the §3.1 guard (six exits, cheapest first)
+ *   2. one model call (§3.2)
+ *   3. the marker + the tag (§3.3, C9 before C5 so a crash between them costs an
+ *      inference rather than repeating one)
+ *   4. **the mandatory filter re-run** (§4.1) — without it the whole feature is
+ *      silently dead
+ */
+export async function mailClassificationJob(
+  ctx: JobContext<MailClassificationJobData>
+): Promise<MailClassificationJobResult> {
+  const { organizationId, messageId, threadId, machineMailTier, from } = ctx.data
+  const db = database
+
+  const gate = await guardClassification({
+    db,
+    organizationId,
+    messageId,
+    threadId,
+    machineMailTier,
+    from,
+  }).catch((error) => {
+    logger.error('Mail classification guard failed — skipping', {
+      organizationId,
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { proceed: false as const, reason: 'error' as const }
+  })
+
+  if (!gate.proceed) {
+    logger.debug('Mail classification skipped', {
+      organizationId,
+      messageId,
+      reason: gate.reason,
+    })
+    return { classified: false, skipped: gate.reason }
+  }
+
+  const result = await classifyMessage(db, gate.context)
+
+  // Stamp the marker for EVERY completed inference, including the ones that
+  // apply nothing (C9): the spend has happened, and re-inferring the same
+  // message would bill twice for the same answer. `'no-default-model'` is the
+  // one exception — nothing was spent and nothing was decided, so the message
+  // stays classifiable once a model is configured.
+  if (result.reason !== 'no-default-model') {
+    await markMessageClassified({
+      db,
+      organizationId,
+      messageId,
+      marker: {
+        at: new Date().toISOString(),
+        tagId: result.tagId,
+        confidence: result.confidence,
+        ...(result.model ? { model: result.model } : {}),
+      },
+    })
+  }
+
+  if (!result.tagId) {
+    return { classified: false, confidence: result.confidence, skipped: result.reason }
+  }
+
+  const applied = await applyClassificationTag({
+    db,
+    organizationId,
+    threadId: gate.context.threadId,
+    tagId: result.tagId,
+  })
+  if (!applied) {
+    return { classified: false, confidence: result.confidence, skipped: 'error' }
+  }
+
+  // ⚠️ §4.1 — MANDATORY. Applying a tag does not re-run filters; nothing else
+  // calls the engine for this message ever again. Full set, `source: 'live'`.
+  const firedFilterIds = await rerunMailFiltersAfterClassification({
+    db,
+    organizationId,
+    threadId: gate.context.threadId,
+    messageId,
+  })
+
+  return {
+    classified: true,
+    tagId: result.tagId,
+    confidence: result.confidence,
+    firedFilterIds,
+  }
+}

--- a/packages/lib/src/mail-classification/labels.test.ts
+++ b/packages/lib/src/mail-classification/labels.test.ts
@@ -1,0 +1,150 @@
+// packages/lib/src/mail-classification/labels.test.ts
+// Q3 is the trap here: an `article`-scoped tag whose `tag_ai_classify` toggle is
+// ON must never reach the prompt. Article tags exist for KB content; offering
+// them to a mail classifier is a category error.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  getCachedEntityDefId: vi.fn(),
+  getCachedCustomFields: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  getCachedEntityDefId: h.getCachedEntityDefId,
+  getCachedCustomFields: h.getCachedCustomFields,
+}))
+
+import { getEligibleClassificationTags } from './labels'
+
+const FIELDS = [
+  { id: 'fld_ai', systemAttribute: 'tag_ai_classify' },
+  { id: 'fld_title', systemAttribute: 'title' },
+  { id: 'fld_desc', systemAttribute: 'tag_description' },
+  { id: 'fld_scope', systemAttribute: 'tag_scope' },
+]
+
+/** `db` whose `select()` chain resolves the next queued row set. */
+function createDb(rowSets: unknown[][]) {
+  let index = 0
+  const select = vi.fn(() => {
+    const result = Promise.resolve(rowSets[index++] ?? [])
+    const step: Record<string, unknown> = {}
+    step.from = () => step
+    step.where = () => step
+    step.limit = () => result
+    step.then = (onOk: unknown, onErr: unknown) => result.then(onOk as never, onErr as never)
+    return step
+  })
+  return { select } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getCachedEntityDefId.mockResolvedValue('def_tag')
+  h.getCachedCustomFields.mockResolvedValue(FIELDS)
+})
+
+describe('getEligibleClassificationTags — scope (Q3)', () => {
+  it('⚠️ an ARTICLE-scoped eligible tag never reaches the prompt', async () => {
+    const db = createDb([
+      [{ tagId: 'tag_thread' }, { tagId: 'tag_article' }],
+      [
+        { id: 'tag_thread', displayName: 'Billing' },
+        { id: 'tag_article', displayName: 'How-to' },
+      ],
+      [
+        { entityId: 'tag_thread', fieldId: 'fld_title', valueText: 'Billing', optionId: null },
+        { entityId: 'tag_thread', fieldId: 'fld_scope', valueText: null, optionId: 'thread' },
+        { entityId: 'tag_article', fieldId: 'fld_title', valueText: 'How-to', optionId: null },
+        { entityId: 'tag_article', fieldId: 'fld_scope', valueText: null, optionId: 'article' },
+      ],
+    ])
+
+    const labels = await getEligibleClassificationTags(db, 'org_1')
+
+    expect(labels.map((l) => l.tagId)).toEqual(['tag_thread'])
+  })
+
+  it('a SINGLE_SELECT value arriving as an ARRAY still compares (invariant 13)', async () => {
+    const db = createDb([
+      [{ tagId: 'tag_thread' }],
+      [{ id: 'tag_thread', displayName: 'Billing' }],
+      [
+        { entityId: 'tag_thread', fieldId: 'fld_title', valueText: 'Billing', optionId: null },
+        {
+          entityId: 'tag_thread',
+          fieldId: 'fld_scope',
+          valueText: null,
+          optionId: ['thread'] as never,
+        },
+      ],
+    ])
+
+    expect((await getEligibleClassificationTags(db, 'org_1')).map((l) => l.tagId)).toEqual([
+      'tag_thread',
+    ])
+  })
+
+  it('a tag with no scope row is treated as thread-scoped (pre-019 data)', async () => {
+    const db = createDb([
+      [{ tagId: 'tag_old' }],
+      [{ id: 'tag_old', displayName: 'Legacy' }],
+      [{ entityId: 'tag_old', fieldId: 'fld_title', valueText: 'Legacy', optionId: null }],
+    ])
+
+    expect((await getEligibleClassificationTags(db, 'org_1')).map((l) => l.tagId)).toEqual([
+      'tag_old',
+    ])
+  })
+})
+
+describe('getEligibleClassificationTags — the label payload', () => {
+  it('carries title + description, and keeps a description-less tag (Q5)', async () => {
+    const db = createDb([
+      [{ tagId: 'tag_a' }, { tagId: 'tag_b' }],
+      [
+        { id: 'tag_a', displayName: 'Billing' },
+        { id: 'tag_b', displayName: 'Sales' },
+      ],
+      [
+        { entityId: 'tag_a', fieldId: 'fld_title', valueText: 'Billing', optionId: null },
+        { entityId: 'tag_a', fieldId: 'fld_desc', valueText: 'Invoices', optionId: null },
+        { entityId: 'tag_b', fieldId: 'fld_title', valueText: 'Sales', optionId: null },
+      ],
+    ])
+
+    expect(await getEligibleClassificationTags(db, 'org_1')).toEqual([
+      { tagId: 'tag_a', title: 'Billing', description: 'Invoices' },
+      { tagId: 'tag_b', title: 'Sales', description: null },
+    ])
+  })
+
+  it('falls back to displayName when the title FieldValue is missing', async () => {
+    const db = createDb([[{ tagId: 'tag_a' }], [{ id: 'tag_a', displayName: 'Fallback' }], []])
+
+    expect((await getEligibleClassificationTags(db, 'org_1'))[0]?.title).toBe('Fallback')
+  })
+})
+
+describe('getEligibleClassificationTags — the empty answers', () => {
+  it('returns [] when the tag_ai_classify field is not materialized yet (§2.1)', async () => {
+    h.getCachedCustomFields.mockResolvedValue(FIELDS.filter((f) => f.id !== 'fld_ai'))
+    const db = createDb([])
+
+    expect(await getEligibleClassificationTags(db, 'org_1')).toEqual([])
+    expect((db as unknown as { select: ReturnType<typeof vi.fn> }).select).not.toHaveBeenCalled()
+  })
+
+  it('returns [] when the org has no tag entity def', async () => {
+    h.getCachedEntityDefId.mockResolvedValue(undefined)
+
+    expect(await getEligibleClassificationTags(createDb([]), 'org_1')).toEqual([])
+  })
+
+  it('drops an archived tag — the instance query filters it out', async () => {
+    const db = createDb([[{ tagId: 'tag_gone' }], []])
+
+    expect(await getEligibleClassificationTags(db, 'org_1')).toEqual([])
+  })
+})

--- a/packages/lib/src/mail-classification/labels.ts
+++ b/packages/lib/src/mail-classification/labels.ts
@@ -1,0 +1,151 @@
+// packages/lib/src/mail-classification/labels.ts
+// READ: the eligible-tag lookup that becomes the prompt's label set (§3.2).
+//
+// Tags are `EntityInstance`s on the `tag` def and their live values are
+// `FieldValue` rows — the `Tag` pgTable is legacy and must not be read here
+// (plan §0.1). Field ids come from the org cache; only the instance rows are
+// queried, and only for an inbox that already opted in (guard step 3 runs first).
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
+import { type MailClassificationLabel, TAG_AI_CLASSIFY_ATTRIBUTE } from './client'
+
+/**
+ * `tag_scope` value the classifier accepts (plan Q3).
+ *
+ * `article` tags exist for KB content; offering them to a mail classifier is a
+ * category error, so they never reach the prompt even when their
+ * `tag_ai_classify` toggle is on.
+ */
+const THREAD_SCOPE = 'thread'
+
+/**
+ * Read the `tag_scope` of a tag as a scalar.
+ *
+ * ⚠️ `SINGLE_SELECT` values are stored in `FieldValue.optionId` but surface as
+ * ARRAYS through the generic read paths (invariant 13). This module reads the
+ * column directly, so it is already scalar — the normalization is here anyway so
+ * a future switch to a composed read cannot silently compare `['thread']` to
+ * `'thread'` and drop every label.
+ */
+function normalizeScope(raw: unknown): string {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  // Absent scope means the tag predates migration 019, which backfilled every
+  // tag to `thread`. Treat missing as `thread` for the same reason.
+  return typeof value === 'string' && value.length > 0 ? value : THREAD_SCOPE
+}
+
+/**
+ * Every tag the classifier may apply for this org: `tag_ai_classify = true`,
+ * `tag_scope = 'thread'`, not archived.
+ *
+ * Org-wide, not per inbox (Q2) — one flag on the tag, one place to manage it,
+ * matching how tags already work.
+ *
+ * Returns `[]` rather than throwing when the `tag` def or the `tag_ai_classify`
+ * field is not materialized yet: an org mid-migration has no eligible tags,
+ * which is guard exit 4, not an error.
+ */
+export async function getEligibleClassificationTags(
+  db: Database,
+  organizationId: string
+): Promise<MailClassificationLabel[]> {
+  const tagDefId = await getCachedEntityDefId(organizationId, 'tag')
+  if (!tagDefId) return []
+
+  const fields = await getCachedCustomFields(organizationId, tagDefId)
+  const fieldIdFor = (attribute: string) =>
+    fields.find((field) => field.systemAttribute === attribute)?.id
+
+  const aiClassifyFieldId = fieldIdFor(TAG_AI_CLASSIFY_ATTRIBUTE)
+  // The registry field has not been materialized for this org yet (§2.1). No
+  // eligible tags is the correct answer, and it is also the safe one.
+  if (!aiClassifyFieldId) return []
+
+  const titleFieldId = fieldIdFor('title')
+  const descriptionFieldId = fieldIdFor('tag_description')
+  const scopeFieldId = fieldIdFor('tag_scope')
+
+  const eligibleRows = await db
+    .select({ tagId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, aiClassifyFieldId),
+        eq(schema.FieldValue.valueBoolean, true)
+      )
+    )
+
+  const tagIds = [...new Set(eligibleRows.map((row) => row.tagId).filter(Boolean))]
+  if (tagIds.length === 0) return []
+
+  const instances = await db
+    .select({ id: schema.EntityInstance.id, displayName: schema.EntityInstance.displayName })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, tagDefId),
+        inArray(schema.EntityInstance.id, tagIds),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+  if (instances.length === 0) return []
+
+  const liveIds = instances.map((row) => row.id)
+  const wantedFieldIds = [titleFieldId, descriptionFieldId, scopeFieldId].filter(
+    (id): id is string => Boolean(id)
+  )
+
+  const valueRows = wantedFieldIds.length
+    ? await db
+        .select({
+          entityId: schema.FieldValue.entityId,
+          fieldId: schema.FieldValue.fieldId,
+          valueText: schema.FieldValue.valueText,
+          optionId: schema.FieldValue.optionId,
+        })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            inArray(schema.FieldValue.entityId, liveIds),
+            inArray(schema.FieldValue.fieldId, wantedFieldIds)
+          )
+        )
+    : []
+
+  const titles = new Map<string, string>()
+  const descriptions = new Map<string, string>()
+  const scopes = new Map<string, string>()
+  for (const row of valueRows) {
+    if (!row.entityId) continue
+    if (row.fieldId === titleFieldId && row.valueText) titles.set(row.entityId, row.valueText)
+    if (row.fieldId === descriptionFieldId && row.valueText) {
+      descriptions.set(row.entityId, row.valueText)
+    }
+    if (row.fieldId === scopeFieldId) {
+      scopes.set(row.entityId, normalizeScope(row.optionId ?? row.valueText))
+    }
+  }
+
+  const labels: MailClassificationLabel[] = []
+  for (const instance of instances) {
+    if (normalizeScope(scopes.get(instance.id)) !== THREAD_SCOPE) continue
+    const title = titles.get(instance.id) ?? instance.displayName ?? ''
+    // A label with no name is unusable in a prompt and unmatchable in the enum
+    // description — skip it rather than offering the model a blank choice.
+    if (!title.trim()) continue
+    labels.push({
+      tagId: instance.id,
+      title,
+      // Q5: an empty description is a UI warning, never a server-side filter.
+      description: descriptions.get(instance.id) ?? null,
+    })
+  }
+
+  labels.sort((a, b) => a.title.localeCompare(b.title))
+  return labels
+}

--- a/packages/lib/src/mail-classification/rerun-filters.test.ts
+++ b/packages/lib/src/mail-classification/rerun-filters.test.ts
@@ -1,0 +1,122 @@
+// packages/lib/src/mail-classification/rerun-filters.test.ts
+// §4.1 — the mandatory second pass, and the one detail that must never be
+// "tidied": it reuses `source: 'live'`.
+//
+// The second describe block runs the REAL `fireMailFilters` (only its
+// evaluate/claim/execute collaborators are stubbed) so the two pass-2 outcomes
+// the plan's table promises are asserted against the actual engine rather than
+// against a paraphrase of it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  orgCacheGet: vi.fn(),
+  getEnabledMailFiltersForInbox: vi.fn(),
+  fireMailFilters: vi.fn(),
+  getProviderCapabilities: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({ getOrgCache: () => ({ get: h.orgCacheGet }) }))
+vi.mock('../mail-filters/cache', () => ({
+  getEnabledMailFiltersForInbox: h.getEnabledMailFiltersForInbox,
+}))
+vi.mock('../mail-filters/engine', () => ({ fireMailFilters: h.fireMailFilters }))
+vi.mock('../providers/provider-capabilities', () => ({
+  getProviderCapabilities: h.getProviderCapabilities,
+}))
+
+import { rerunMailFiltersAfterClassification } from './rerun-filters'
+
+function createDb(rowSets: unknown[][]) {
+  let index = 0
+  return {
+    select: vi.fn(() => {
+      const result = Promise.resolve(rowSets[index++] ?? [])
+      const step: Record<string, unknown> = {}
+      step.from = () => step
+      step.where = () => step
+      step.limit = () => result
+      step.then = (onOk: unknown, onErr: unknown) => result.then(onOk as never, onErr as never)
+      return step
+    }),
+  } as never
+}
+
+const THREAD = [{ inboxId: 'ibx_1', integrationId: 'int_1', status: 'OPEN', assigneeId: null }]
+const FILTERS = [
+  { id: 'flt_a', inboxId: 'ibx_1', name: 'a', order: 0, stopProcessing: false },
+  { id: 'flt_b', inboxId: 'ibx_1', name: 'b', order: 1, stopProcessing: false },
+]
+
+const params = {
+  organizationId: 'org_1',
+  threadId: 'thr_1',
+  messageId: 'msg_1',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getEnabledMailFiltersForInbox.mockResolvedValue(FILTERS)
+  h.getProviderCapabilities.mockReturnValue({ supportsMailFilters: true })
+  h.orgCacheGet.mockImplementation(async (_org: string, key: string) => {
+    if (key === 'channels') return [{ id: 'int_1', provider: 'google' }]
+    if (key === 'inboxes') return [{ id: 'ibx_1', isPersonal: false, ownerUserId: null }]
+    return []
+  })
+  h.fireMailFilters.mockResolvedValue({ suppressAutomations: false, firedFilterIds: ['flt_b'] })
+})
+
+describe('rerunMailFiltersAfterClassification', () => {
+  it('⚠️ fires with `source: "live"` — a new source arm would re-fire every claimed filter', async () => {
+    await rerunMailFiltersAfterClassification({ ...params, db: createDb([THREAD]) })
+
+    expect(h.fireMailFilters).toHaveBeenCalledTimes(1)
+    expect(h.fireMailFilters.mock.calls[0]?.[0]?.source).toBe('live')
+  })
+
+  it('⚠️ passes the FULL filter set, not a tag-referencing subset', async () => {
+    await rerunMailFiltersAfterClassification({ ...params, db: createDb([THREAD]) })
+
+    expect(h.fireMailFilters.mock.calls[0]?.[0]?.filters).toEqual(FILTERS)
+  })
+
+  it('keys the run on the SAME messageId as pass 1, so the claim can dedupe', async () => {
+    await rerunMailFiltersAfterClassification({ ...params, db: createDb([THREAD]) })
+
+    expect(h.fireMailFilters.mock.calls[0]?.[0]).toMatchObject({
+      messageId: 'msg_1',
+      threadId: 'thr_1',
+      organizationId: 'org_1',
+    })
+  })
+
+  it('reports what fired', async () => {
+    await expect(
+      rerunMailFiltersAfterClassification({ ...params, db: createDb([THREAD]) })
+    ).resolves.toEqual(['flt_b'])
+  })
+
+  it('fires nothing when the inbox has no enabled filters', async () => {
+    h.getEnabledMailFiltersForInbox.mockResolvedValue([])
+
+    await rerunMailFiltersAfterClassification({ ...params, db: createDb([THREAD]) })
+
+    expect(h.fireMailFilters).not.toHaveBeenCalled()
+  })
+
+  it('respects the provider capability gate the first pass respects', async () => {
+    h.getProviderCapabilities.mockReturnValue({ supportsMailFilters: false })
+
+    await rerunMailFiltersAfterClassification({ ...params, db: createDb([THREAD]) })
+
+    expect(h.fireMailFilters).not.toHaveBeenCalled()
+  })
+
+  it('never throws', async () => {
+    h.fireMailFilters.mockRejectedValue(new Error('boom'))
+
+    await expect(
+      rerunMailFiltersAfterClassification({ ...params, db: createDb([THREAD]) })
+    ).resolves.toEqual([])
+  })
+})

--- a/packages/lib/src/mail-classification/rerun-filters.ts
+++ b/packages/lib/src/mail-classification/rerun-filters.ts
@@ -1,0 +1,138 @@
+// packages/lib/src/mail-classification/rerun-filters.ts
+// §4.1 — THE SECOND PASS. Read this file before changing anything in it.
+//
+// ⚠️ APPLYING A TAG DOES NOT RE-RUN FILTERS. `applyMailFilters` is invoked from
+// exactly ONE place — the `gate` on `message:received`
+// (`events/handlers/publish-event-job.ts`) — and `'message:tag:added'` has an
+// EMPTY handler array. Mail filters have one trigger by design (filters-plan
+// D2). So without this explicit second invocation,
+// `tag is Billing → assign to Finance` never fires for a classifier-applied tag:
+// the engine already ran, before the tag existed. That is the whole feature,
+// silently dead, with no error anywhere.
+//
+// ⚠️ THE RE-RUN REUSES `source: 'live'`. The run claim is unique on
+// `(filterId, messageId, source)`, so adding a `'classification'` arm to that
+// discriminator would give every already-fired filter a fresh key and re-fire
+// the lot — `run-agent` included, which is precisely the double customer reply
+// the claim exists to prevent (filters-plan invariant 4). A refactor that
+// "tidies" this into its own source arm is a production incident.
+//
+//   | On pass 2                                | What happens                        |
+//   | ---------------------------------------- | ----------------------------------- |
+//   | filter fired on pass 1                   | matches again, hits its claim, bails |
+//   |                                          | BEFORE acting                        |
+//   | category filter that missed on pass 1    | no claim row, so it claims and fires |
+//
+// ⚠️ THE FULL FILTER SET, not a category-referencing subset. The claim is what
+// makes a full pass both correct and simpler than trying to work out which
+// filters mention the tag.
+//
+// `stopProcessing`: THE HALT IS HONORED (plan §4.1, recommendation). A matched
+// filter with `stopProcessing` halts pass 2 exactly as it halted pass 1, even
+// though it bails on its own claim — `fireMailFilters` already implements this,
+// and nothing here overrides it. A user who wrote "stop processing" meant it,
+// and the alternative would make filter order mean something different on the
+// second pass than on the first. The cost is a category filter below a stopping
+// filter never getting its chance; that is the same cost pass 1 already pays.
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
+import { getEnabledMailFiltersForInbox } from '../mail-filters/cache'
+import { fireMailFilters } from '../mail-filters/engine'
+import { getProviderCapabilities } from '../providers/provider-capabilities'
+
+const logger = createScopedLogger('mail-classification')
+
+/**
+ * Re-invoke the mail-filter engine for one message after the classifier applied
+ * a tag.
+ *
+ * Resolves the same inputs `applyMailFilters` resolves (thread, per-inbox filter
+ * set, provider capability, inbox row) and fires the FULL set with
+ * `source: 'live'`. Never throws — `fireMailFilters` owns the never-throws
+ * contract and this wrapper adds its own belt.
+ *
+ * @returns the ids of the filters that actually executed on this pass.
+ */
+export async function rerunMailFiltersAfterClassification(params: {
+  db: Database
+  organizationId: string
+  threadId: string
+  messageId: string
+}): Promise<string[]> {
+  const { db, organizationId, threadId, messageId } = params
+
+  try {
+    const [thread] = await db
+      .select({
+        inboxId: schema.Thread.inboxId,
+        integrationId: schema.Thread.integrationId,
+        status: schema.Thread.status,
+        assigneeId: schema.Thread.assigneeId,
+      })
+      .from(schema.Thread)
+      .where(and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, organizationId)))
+      .limit(1)
+    if (!thread?.inboxId) return []
+
+    const filters = await getEnabledMailFiltersForInbox(organizationId, thread.inboxId)
+    if (filters.length === 0) return []
+
+    // Provider capability, same check the gate makes (filters-plan D17 /
+    // invariant 17): a channel whose provider cannot support filters must not
+    // gain them via the classifier's back door.
+    if (!thread.integrationId) return []
+    const channels = await getOrgCache().get(organizationId, 'channels')
+    const channel = channels.find((c) => c.id === thread.integrationId)
+    if (!channel) return []
+    if (!getProviderCapabilities(channel.provider).supportsMailFilters) return []
+
+    const inboxes = await getOrgCache().get(organizationId, 'inboxes')
+    const inboxRow = inboxes.find((inbox) => inbox.id === thread.inboxId)
+
+    const result = await fireMailFilters({
+      db,
+      organizationId,
+      threadId,
+      messageId,
+      thread: {
+        inboxId: thread.inboxId,
+        status: thread.status ?? null,
+        assigneeId: thread.assigneeId ?? null,
+      },
+      inbox: inboxRow
+        ? {
+            id: inboxRow.id,
+            isPersonal: inboxRow.isPersonal,
+            ownerUserId: inboxRow.ownerUserId,
+          }
+        : null,
+      filters,
+      // ⚠️ NOT a new source arm. See the file header.
+      source: 'live',
+    })
+
+    if (result.firedFilterIds.length > 0) {
+      logger.info('Mail filters fired on the post-classification pass', {
+        organizationId,
+        threadId,
+        messageId,
+        filters: result.firedFilterIds,
+      })
+    }
+    // `suppressAutomations` is deliberately ignored: the `then` fan-out for this
+    // message was decided and enqueued before the classifier ran, so there is
+    // nothing left to suppress. Re-deciding it here would be a no-op at best.
+    return result.firedFilterIds
+  } catch (error) {
+    logger.error('Post-classification filter re-run failed', {
+      organizationId,
+      threadId,
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return []
+  }
+}

--- a/packages/lib/src/mail-classification/second-pass.test.ts
+++ b/packages/lib/src/mail-classification/second-pass.test.ts
@@ -1,0 +1,152 @@
+// packages/lib/src/mail-classification/second-pass.test.ts
+// The §4.1 pass-2 table, asserted against the REAL `fireMailFilters` with a
+// faithful stand-in for the claim's unique `(filterId, messageId, source)` index:
+//
+//   | On pass 2                              | What must happen                    |
+//   | -------------------------------------- | ----------------------------------- |
+//   | filter fired on pass 1                 | bails on its claim, executes nothing |
+//   | category filter that missed on pass 1  | claims and fires                     |
+//
+// The whole feature rests on this being true with `source: 'live'` reused, so it
+// is tested here rather than being taken on trust from the plan's prose. A
+// `source: 'classification'` arm gives every already-fired filter a fresh key —
+// the last test in this file is what fails when someone "tidies" that.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CachedMailFilter, MailFilterAction } from '../mail-filters/types'
+
+const h = vi.hoisted(() => ({
+  matchFilters: vi.fn(),
+  execute: vi.fn(),
+  captureUndo: vi.fn(),
+  complete: vi.fn(),
+  touch: vi.fn(),
+  /** Stands in for the unique index on (filterId, messageId, source). */
+  claims: new Set<string>(),
+}))
+
+vi.mock('../mail-filters/evaluate', () => ({ matchFilters: h.matchFilters }))
+vi.mock('../mail-filters/runs', () => ({
+  // `INSERT … ON CONFLICT (filterId, messageId, source) DO NOTHING`: a null
+  // return means another attempt already owns this firing.
+  claimMailFilterRun: vi.fn(
+    async (_db: unknown, input: { filterId: string; messageId: string; source: string }) => {
+      const key = `${input.filterId}:${input.messageId}:${input.source}`
+      if (h.claims.has(key)) return null
+      h.claims.add(key)
+      return `run_${h.claims.size}`
+    }
+  ),
+  completeMailFilterRun: h.complete,
+}))
+vi.mock('../mail-filters/actions', () => ({
+  executeMailFilterAction: h.execute,
+  captureUndoState: h.captureUndo,
+}))
+vi.mock('../mail-filters/mutations', () => ({ touchLastFiredAtMany: h.touch }))
+
+import { fireMailFilters } from '../mail-filters/engine'
+
+function filter(id: string, overrides: Partial<CachedMailFilter> = {}): CachedMailFilter {
+  return {
+    id,
+    inboxId: 'ibx_1',
+    name: id,
+    order: 0,
+    stopProcessing: false,
+    enabled: true,
+    conditions: [],
+    actions: [{ type: 'assign', assigneeId: 'usr_1' }] as MailFilterAction[],
+    templateKey: null,
+    ...overrides,
+  } as CachedMailFilter
+}
+
+const baseInput = {
+  db: {} as never,
+  organizationId: 'org_1',
+  threadId: 'thr_1',
+  messageId: 'msg_1',
+  thread: { inboxId: 'ibx_1', status: 'OPEN', assigneeId: null },
+  inbox: { id: 'ibx_1', isPersonal: false, ownerUserId: null },
+  source: 'live' as const,
+}
+
+/** `from is stripe.com → add-tag Billing` — matches on both passes. */
+const SENDER_FILTER = filter('flt_sender')
+/** `tag is Billing → assign to Finance` — only matches once the tag exists. */
+const CATEGORY_FILTER = filter('flt_category', { order: 1 })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.claims.clear()
+  h.execute.mockResolvedValue({ status: 'ok' })
+  h.captureUndo.mockResolvedValue(null)
+  h.complete.mockResolvedValue(undefined)
+  h.touch.mockResolvedValue(undefined)
+})
+
+describe('§4.1 — the full-set re-run over the run claim', () => {
+  it('a filter that already fired does NOT fire twice, and a category filter that missed pass 1 DOES fire on pass 2', async () => {
+    const filters = [SENDER_FILTER, CATEGORY_FILTER]
+
+    // Pass 1 (the gate): only the sender filter matches — the tag does not exist yet.
+    h.matchFilters.mockResolvedValueOnce(new Set(['flt_sender']))
+    const pass1 = await fireMailFilters({ ...baseInput, filters })
+    expect(pass1.firedFilterIds).toEqual(['flt_sender'])
+    expect(h.execute).toHaveBeenCalledTimes(1)
+
+    h.execute.mockClear()
+
+    // Pass 2 (post-classification): the classifier applied `Billing`, so BOTH
+    // match. The full set is re-run — no category-referencing subset.
+    h.matchFilters.mockResolvedValueOnce(new Set(['flt_sender', 'flt_category']))
+    const pass2 = await fireMailFilters({ ...baseInput, filters })
+
+    // The already-fired filter bailed on its claim BEFORE acting…
+    expect(pass2.firedFilterIds).toEqual(['flt_category'])
+    // …so exactly one action ran on pass 2, and it was the category filter's.
+    expect(h.execute).toHaveBeenCalledTimes(1)
+    expect(h.execute.mock.calls[0]?.[1]?.filter.id).toBe('flt_category')
+  })
+
+  it('⚠️ a distinct `source` arm re-fires the lot — including `run-agent`', async () => {
+    const runAgent = filter('flt_agent', {
+      actions: [{ type: 'run-agent', agentId: 'a', agentTriggerId: 't' }] as MailFilterAction[],
+    })
+    h.matchFilters.mockResolvedValue(new Set(['flt_agent']))
+
+    await fireMailFilters({ ...baseInput, filters: [runAgent] })
+    expect(h.execute).toHaveBeenCalledTimes(1)
+
+    // What `rerun-filters.ts` actually does — same source, so the claim holds.
+    await fireMailFilters({ ...baseInput, filters: [runAgent], source: 'live' })
+    expect(h.execute).toHaveBeenCalledTimes(1)
+
+    // What a "tidy it into its own source" refactor would do: a fresh claim key,
+    // and a second agent reply to the customer. This assertion documents the
+    // failure mode — it is why `rerun-filters.ts` reuses `'live'`.
+    await fireMailFilters({ ...baseInput, filters: [runAgent], source: 'retroactive' })
+    expect(h.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it('honors `stopProcessing` on pass 2 even when the stopping filter bails on its claim', async () => {
+    const stopper = filter('flt_stop', { order: 0, stopProcessing: true })
+    const below = filter('flt_below', { order: 1 })
+    const filters = [stopper, below]
+
+    h.matchFilters.mockResolvedValueOnce(new Set(['flt_stop']))
+    await fireMailFilters({ ...baseInput, filters })
+
+    h.execute.mockClear()
+    h.matchFilters.mockResolvedValueOnce(new Set(['flt_stop', 'flt_below']))
+    const pass2 = await fireMailFilters({ ...baseInput, filters })
+
+    // The halt is honored (plan §4.1 recommendation): a user who wrote "stop
+    // processing" meant it, and filter order must mean the same thing on both
+    // passes. The cost is `flt_below` never getting its chance — pass 1 already
+    // pays that same cost.
+    expect(pass2.firedFilterIds).toEqual([])
+    expect(h.execute).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/mail-classification/types.ts
+++ b/packages/lib/src/mail-classification/types.ts
@@ -1,0 +1,49 @@
+// packages/lib/src/mail-classification/types.ts
+// Server-side shapes for the classifier: the guard's verdict, the resolved
+// context it hands to the call, and the call's outcome.
+
+import type { MailClassificationLabel, MailClassificationSkipReason } from './client'
+
+/** The message fields the prompt is built from (§3.2 — truncated, no history). */
+export interface MailClassificationMessage {
+  subject: string | null
+  /** Sender identifier, taken from the `message:received` payload. */
+  from: string | null
+  textPlain: string | null
+}
+
+/** Everything past the guard, resolved once so the call re-reads nothing. */
+export interface MailClassificationContext {
+  organizationId: string
+  messageId: string
+  threadId: string
+  inboxId: string
+  /** Eligible, `thread`-scoped tags — the enum the model chooses from (Q1/Q3). */
+  labels: MailClassificationLabel[]
+  message: MailClassificationMessage
+}
+
+/**
+ * The guard's verdict (§3.1). `proceed: false` is the overwhelmingly common
+ * answer and is never an error — an org that never opts in exits at step 3
+ * having issued zero queries.
+ */
+export type MailClassificationGate =
+  | { proceed: false; reason: MailClassificationSkipReason }
+  | { proceed: true; context: MailClassificationContext }
+
+/**
+ * One model call's outcome. `tagId` is null whenever nothing is to be applied —
+ * the model declined, returned an id outside the eligible set, or landed below
+ * {@link import('./client').MAIL_CLASSIFY_CONFIDENCE_THRESHOLD}.
+ *
+ * `confidence` is populated even when `tagId` is null: those are the most
+ * informative rows for tuning the threshold (Q4).
+ */
+export interface MailClassificationResult {
+  tagId: string | null
+  confidence: number
+  /** Set when nothing is applied, so the job's log line explains itself. */
+  reason?: MailClassificationSkipReason
+  model?: string
+}

--- a/packages/lib/src/mail-suggestions/mine-conditions.test.ts
+++ b/packages/lib/src/mail-suggestions/mine-conditions.test.ts
@@ -11,6 +11,10 @@
 // query builder's `list` / `senderDomain` support shows up as a failing
 // preference rather than as a silently widened filter.
 //
+// The §7 block is the same kind of assertion for a different reason: the
+// AI-eligible-tag exclusion lives entirely inside the emitted `top_tag` CTE, so
+// no assertion over the returned rows can see it.
+//
 // Vitest has no Postgres, so the V2/V3 blocks use the same two-layer shape as
 // `mail-query/__tests__/thread-search-sql.test.ts`: rendered-SQL tests pin the
 // expression the database receives, and small TypeScript MODELS of those
@@ -280,6 +284,155 @@ describe('buildInboxGroupQuery', () => {
       const { sql } = render(null)
       const guards = sql.match(/\)\[1\] IS TRUE\)/g)
       expect(guards).toHaveLength(2)
+    })
+  })
+
+  // ── §7: the classifier feedback loop (05-mail-classification-plan, inv. 8) ──
+  //
+  // `top_tag` measures tag consistency, and applying the same tag to every
+  // message in a group is what a classifier DOES. Without this exclusion the
+  // weekly job would propose an `auto-tag` filter to do what the classifier is
+  // already doing — every run, forever, and invisibly to the `MailFilterRun`
+  // guard, because the classifier is not a filter.
+  describe('excludes AI-eligible tags from top_tag (§7)', () => {
+    it('anti-joins the tag instance against its tag_ai_classify value', () => {
+      const { sql, params } = render(null)
+      expect(sql).toContain('NOT EXISTS')
+      expect(sql).toContain('afv."valueBoolean" IS TRUE')
+      // A boolean CHECKBOX field, so the value is a second FieldValue row on the
+      // TAG — not a column on anything the outer query already has in hand.
+      expect(params).toContain('tag_ai_classify')
+    })
+
+    it('keys the exclusion on the TAG instance, never on the thread', () => {
+      // `fv."relatedEntityId"` is the tag; `pt.thread_id` is the thread carrying
+      // it. Anti-joining the thread would drop every OTHER tag on a thread that
+      // happens to carry one eligible tag — a much wider cut than §7 asks for,
+      // and one that silently suppresses unrelated `auto-tag` proposals.
+      const { sql } = render(null)
+      expect(sql).toContain('afv."entityId" = fv."relatedEntityId"')
+      expect(sql).not.toContain('afv."entityId" = pt.thread_id')
+    })
+
+    it('drops the row BEFORE the count, so the runner-up is ranked on its own threads', () => {
+      // Filtering after the aggregate would either null out the winner (losing
+      // the runner-up entirely) or, worse, hand the eligible tag's thread count
+      // to whichever tag inherited first place.
+      const { sql } = render(null)
+      const exclusion = sql.indexOf('afv."valueBoolean" IS TRUE')
+      const grouping = sql.indexOf('GROUP BY pt.subject_key, fv."relatedEntityId"')
+      expect(exclusion).toBeGreaterThan(-1)
+      expect(grouping).toBeGreaterThan(exclusion)
+    })
+
+    it('scopes the eligibility field to the org, like every other CustomField read', () => {
+      const { sql } = render(null)
+      expect(sql).toContain('acf."systemAttribute" = ')
+      expect(sql).toContain('acf."organizationId" = ')
+    })
+  })
+
+  describe('top_tag semantics — what Postgres does with that exclusion', () => {
+    /**
+     * `top_tag`, in TypeScript: count DISTINCT threads per (group, tag) over the
+     * tag rows that survive the anti-join, then take the highest count with the
+     * tag id as the tiebreak — the same `row_number() … ORDER BY count DESC,
+     * relatedEntityId` the CTE emits.
+     *
+     * `eligible` models `NOT EXISTS (… valueBoolean IS TRUE)`: membership means a
+     * `tag_ai_classify` row exists AND is true. An unmaterialized field, or a tag
+     * nobody toggled, is simply absent — so the pre-§7 behaviour is what an org
+     * without the field still gets. Tied to the source by the assertion below.
+     */
+    const topTag = (
+      applications: { threadId: string; tagId: string }[],
+      eligible: Set<string>
+    ): { tagId: string; threadCount: number } | null => {
+      const counts = new Map<string, Set<string>>()
+      for (const { threadId, tagId } of applications) {
+        if (eligible.has(tagId)) continue
+        const threads = counts.get(tagId) ?? new Set<string>()
+        threads.add(threadId)
+        counts.set(tagId, threads)
+      }
+      const ranked = [...counts.entries()].sort(
+        ([aTag, a], [bTag, b]) => b.size - a.size || aTag.localeCompare(bTag)
+      )
+      const winner = ranked[0]
+      return winner ? { tagId: winner[0], threadCount: winner[1].size } : null
+    }
+
+    /** Ten threads, all read, so `auto-tag` is the only kind a card can carry. */
+    const kindsFor = (
+      applications: { threadId: string; tagId: string }[],
+      eligible: Set<string>
+    ) => {
+      const top = topTag(applications, eligible)
+      return buildMailSuggestionDrafts({
+        organizationId: 'org_1',
+        inboxId: 'ibx_1',
+        userId: null,
+        groups: [
+          group({
+            threadCount: 10,
+            readThreadCount: 10,
+            topTagId: top?.tagId ?? null,
+            topTagThreadCount: top?.threadCount ?? 0,
+          }),
+        ],
+        suppressedSubjectKeys: new Set<string>(),
+      }).map((d) => d.kind)
+    }
+
+    const on = (tagId: string, threads: number) =>
+      Array.from({ length: threads }, (_, i) => ({ threadId: `thr_${i + 1}`, tagId }))
+
+    it('models the exclusion the statement actually emits', () => {
+      const { sql, params } = render(null)
+      expect(sql).toContain('afv."entityId" = fv."relatedEntityId"')
+      expect(sql).toContain('afv."valueBoolean" IS TRUE')
+      expect(params).toContain('tag_ai_classify')
+    })
+
+    it('never picks an AI-eligible tag, even at 100% consistency', () => {
+      // The exact shape the classifier produces: one tag, every thread, forever.
+      expect(topTag(on('tag_billing', 10), new Set(['tag_billing']))).toBeNull()
+    })
+
+    it('still picks a NON-eligible tag over the threshold', () => {
+      expect(topTag(on('tag_vip', 8), new Set(['tag_billing']))).toEqual({
+        tagId: 'tag_vip',
+        threadCount: 8,
+      })
+    })
+
+    it('leaves the pre-§7 answer untouched when nothing is eligible', () => {
+      // An org that has not enabled a single tag — and, identically, an org where
+      // the field is not materialized yet — must mine exactly as it did before.
+      expect(topTag(on('tag_billing', 10), new Set())).toEqual({
+        tagId: 'tag_billing',
+        threadCount: 10,
+      })
+    })
+
+    it('falls back to the runner-up, ranked on ITS OWN threads', () => {
+      // The eligible tag's ten threads must not be inherited by the tag that
+      // takes first place behind it — that would fabricate consistency out of
+      // the classifier's own work, which is the whole loop in one number.
+      const applications = [...on('tag_billing', 10), ...on('tag_vip', 2)]
+      expect(topTag(applications, new Set(['tag_billing']))).toEqual({
+        tagId: 'tag_vip',
+        threadCount: 2,
+      })
+      expect(kindsFor(applications, new Set(['tag_billing']))).toEqual([])
+    })
+
+    it('produces NO auto-tag card for a group whose only tags are eligible', () => {
+      expect(kindsFor(on('tag_billing', 10), new Set(['tag_billing']))).toEqual([])
+    })
+
+    it('still produces the auto-tag card the feature exists for', () => {
+      expect(kindsFor(on('tag_vip', 8), new Set(['tag_billing']))).toEqual(['auto-tag'])
     })
   })
 

--- a/packages/lib/src/mail-suggestions/mine.ts
+++ b/packages/lib/src/mail-suggestions/mine.ts
@@ -116,6 +116,36 @@ const GROUP_SCAN_LIMIT = 200
  */
 const MESSAGE_AT = sql`COALESCE(m."receivedAt", m."createdAt")`
 
+/**
+ * The `tag` custom field that marks a tag as eligible for AI classification
+ * (05-mail-classification-plan §2.1) — a `CHECKBOX`, so its value lives in
+ * `FieldValue."valueBoolean"`.
+ *
+ * ⚠️ THE MINER MUST NOT PROPOSE `auto-tag` FOR AN ELIGIBLE TAG (05-plan §7,
+ * invariant 8). `top_tag` measures tag consistency inside a group, and applying
+ * the same tag to every message in a group is the *definition* of what a
+ * classifier does — so the moment classification ships, every classified group
+ * reads at ~1.0 consistency and the weekly job proposes a filter to do what the
+ * classifier is already doing. Forever, because nothing suppresses it: the
+ * existing "already covered" guard reads `MailFilterRun`, and the classifier is
+ * not a filter.
+ *
+ * The exclusion is WHOLESALE — regardless of who applied the tag. That is not
+ * over-exclusion: if a tag is AI-eligible, an `auto-tag` suggestion for it is
+ * redundant whether a human or the model has been applying it.
+ *
+ * It ships BEFORE any inference exists. Today the loop is dormant but armed:
+ * `auto-tag` is fully implemented end to end and has produced zero rows only
+ * because no group reaches {@link CONSISTENCY_THRESHOLD} (measured on dev: 80
+ * groups over {@link MIN_THREADS}, 44 carrying a tag, 0 at 0.8). Classification
+ * is precisely the thing that changes that number.
+ *
+ * The field may not be materialized in an org yet, and the predicate is written
+ * so that this is the safe case: with no `CustomField` row the anti-join matches
+ * nothing and `top_tag` behaves exactly as it did before.
+ */
+const AI_CLASSIFY_ATTRIBUTE = 'tag_ai_classify'
+
 // ═══════════════════════════════════════════════════════════════════════════
 // THE GROUPED QUERY (§5.1)
 // ═══════════════════════════════════════════════════════════════════════════
@@ -146,6 +176,11 @@ export interface MailGroupStats {
   /** Newest {@link MESSAGE_AT} in the window — mail time, not ingest time. */
   lastSeenAt: Date | null
   sampleThreadIds: string[]
+  /**
+   * The group's most-applied tag, **excluding AI-eligible ones**
+   * ({@link AI_CLASSIFY_ATTRIBUTE}). `null` when the group's only tags are
+   * eligible — which is what stops the `auto-tag` proposal there.
+   */
   topTagId: string | null
   topTagThreadCount: number
   topAssigneeId: string | null
@@ -194,6 +229,9 @@ export interface InboxGroupQueryParams {
  *    {@link MESSAGE_AT} for the ordering and the paragraph below for why it is
  *    not a window-wide `bool_and`.
  * 4. **Every timestamp is {@link MESSAGE_AT}, never bare `createdAt`.**
+ * 5. **`top_tag` excludes AI-eligible tags** ({@link AI_CLASSIFY_ATTRIBUTE}) —
+ *    the same class of feedback loop as 2, against the classifier instead of a
+ *    filter, and invisible to the `MailFilterRun` guard that catches 2.
  *
  * **Why newest-message, not `bool_and` (04-v2-plan §2.3, V3).**
  * `resolveUnsubscribeTarget` reads its gate inputs — `listId` and
@@ -311,6 +349,16 @@ export function buildInboxGroupQuery(params: InboxGroupQueryParams): SQL {
         WHERE cf."systemAttribute" = 'thread_tags'
           AND cf."organizationId" = ${organizationId}
           AND fv."relatedEntityId" IS NOT NULL
+          -- An AI-eligible tag is never a candidate. See AI_CLASSIFY_ATTRIBUTE.
+          AND NOT EXISTS (
+            SELECT 1
+            FROM "FieldValue" afv
+            JOIN "CustomField" acf ON acf.id = afv."fieldId"
+            WHERE afv."entityId" = fv."relatedEntityId"
+              AND acf."systemAttribute" = ${AI_CLASSIFY_ATTRIBUTE}
+              AND acf."organizationId" = ${organizationId}
+              AND afv."valueBoolean" IS TRUE
+          )
         GROUP BY pt.subject_key, fv."relatedEntityId"
       ) ranked WHERE rn = 1
     )

--- a/packages/lib/src/resources/registry/resources/tag-fields.ts
+++ b/packages/lib/src/resources/registry/resources/tag-fields.ts
@@ -81,6 +81,40 @@ export const TAG_FIELDS: Record<string, ResourceField> = {
     },
   },
 
+  /**
+   * Mail-classification eligibility (plans/mail-filter/05-mail-classification-plan.md C2).
+   *
+   * When true, this tag is offered to the inbound-mail classifier as a label it may apply,
+   * and `tag_description` stops being decorative: it becomes the label's DEFINITION in the
+   * prompt (C3). Opt-in per tag, because the eligible set *is* the prompt — "every tag"
+   * classifies badly and "system tags only" would mean we pick the taxonomy.
+   *
+   * Deliberately NOT guarded by `rejectIfSystemTag` (§2.2): eligibility is a routing
+   * decision about our classifier, not a mutation of the tag's identity, so it stays
+   * togglable on any tag including a system one.
+   */
+  tag_ai_classify: {
+    id: toFieldId('tag_ai_classify'),
+    key: 'tag_ai_classify',
+    label: 'AI Classification',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'tag_ai_classify',
+    systemSortOrder: 'a14',
+    showInPanel: false,
+    nullable: false,
+    defaultValue: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'When true, the AI mail classifier may apply this tag to inbound mail.',
+  },
+
   emoji: {
     id: toFieldId('emoji'),
     key: 'emoji',

--- a/packages/lib/src/seed/ai-category-tags.test.ts
+++ b/packages/lib/src/seed/ai-category-tags.test.ts
@@ -1,0 +1,384 @@
+// packages/lib/src/seed/ai-category-tags.test.ts
+//
+// The starter mail categories are the vocabulary the classifier will be given, so the shape
+// of the seeded rows is the contract:
+//
+//  1. **Exactly five, and no `Spam`** (C6) — a Spam tag beside a spam *status* is two ways to
+//     say one thing, and it was the only category where ordering vs the agent mattered.
+//  2. **Ordinary tags** (C4) — `is_system_tag: false` explicitly. A system tag's description
+//     cannot be edited, and the description IS the classifier's instruction (C3), so seeding
+//     these as system tags would freeze the feature's only tuning surface.
+//  3. **Every starter carries a real description** — it is prompt text, not decoration.
+//  4. **Idempotent by title.** A second pass creates nothing. A title the org already uses is
+//     left exactly as it is — UNLESS it is a legacy tag WE seeded as a system tag, which is
+//     adopted in place (see the adoption block at the bottom). The discriminator is
+//     `is_system_tag`, never the title.
+//  5. **Nothing becomes classifiable by accident** — the parent group is NOT eligible, and
+//     seeding writes no inbox opt-in of any kind.
+//
+// `UnifiedCrudHandler` is stubbed (a lib-internal module, not one of the shared
+// `@auxx/database` / `@auxx/logger` / `drizzle-orm` mocks), so the assertions are about the
+// values this module hands the write path.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  creates: [] as { entityType: string; values: Record<string, unknown> }[],
+  constructorOptions: [] as unknown[],
+  createImpl: null as null | ((values: Record<string, unknown>) => void),
+  /** Every `update` in call order, each tagged with the bypass set its handler carried. */
+  updates: [] as {
+    recordId: string
+    values: Record<string, unknown>
+    bypass: string[]
+    modes?: Record<string, 'set' | 'add' | 'remove'>
+    options?: Record<string, unknown>
+  }[],
+}))
+
+vi.mock('../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    private bypass: string[]
+    constructor(
+      _orgId: string,
+      _userId: string,
+      _db: unknown,
+      _socketId: unknown,
+      options?: { bypassFieldGuards?: Set<string> }
+    ) {
+      h.constructorOptions.push(options)
+      this.bypass = [...(options?.bypassFieldGuards ?? [])]
+    }
+    async create(entityType: string, values: Record<string, unknown>) {
+      h.creates.push({ entityType, values })
+      h.createImpl?.(values)
+      return {
+        instance: { id: `inst_${h.creates.length}` },
+        recordId: `${TAG_DEF_ID}:inst_${h.creates.length}`,
+        values,
+      }
+    }
+    // Mirrors the REAL signature — (recordId, values, MODES, options). Getting
+    // this wrong is how `seedOpts` silently lands in the array-mode map, which a
+    // loose `(recordId, values)` stub would have accepted without complaint.
+    async update(
+      recordId: string,
+      values: Record<string, unknown>,
+      modes?: Record<string, 'set' | 'add' | 'remove'>,
+      options?: Record<string, unknown>
+    ) {
+      h.updates.push({ recordId, values, bypass: this.bypass, modes, options })
+      return { instance: { id: recordId }, recordId, values }
+    }
+  },
+}))
+
+import {
+  AI_CATEGORY_PARENT_TAG,
+  AI_CATEGORY_STARTER_TAGS,
+  seedAiCategoryTags,
+} from './ai-category-tags'
+
+const ORG = 'org_1'
+const TAG_DEF_ID = 'def_tag'
+
+/** Chainable fake resolving the next queued result set per `await`. */
+function makeDb(results: unknown[][]) {
+  const queue = [...results]
+  const updates: unknown[] = []
+  const chain = (): Record<string, unknown> =>
+    new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'then') {
+            return (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+              Promise.resolve(queue.shift() ?? []).then(resolve, reject)
+          }
+          return () => chain()
+        },
+      }
+    )
+  const db = {
+    select: () => chain(),
+    update: (table: unknown) => {
+      updates.push(table)
+      return { set: () => ({ where: async () => undefined }) }
+    },
+    insert: (table: unknown) => {
+      updates.push(table)
+      return { values: async () => undefined }
+    },
+  }
+  return { db: db as never, updates }
+}
+
+const TAG_DEF = [{ id: TAG_DEF_ID }]
+const ELIGIBILITY_FIELD = [{ id: 'cf_ai_classify' }]
+
+/** The three selects the seed makes: tag def, eligibility field, existing tag instances. */
+function queue(existingTitles: { id: string; displayName: string }[] = []): unknown[][] {
+  return [TAG_DEF, ELIGIBILITY_FIELD, existingTitles]
+}
+
+const titlesCreated = () => h.creates.map((c) => c.values.title)
+const createdByTitle = (title: string) => h.creates.find((c) => c.values.title === title)?.values
+
+beforeEach(() => {
+  h.creates.length = 0
+  h.constructorOptions.length = 0
+  h.updates.length = 0
+  h.createImpl = null
+})
+
+const SYSTEM_FIELD = [{ id: 'cf_is_system_tag' }]
+/** The two selects `adoptLegacySystemStarter` makes per existing title. */
+const ADOPT_PROBE = (isSystem: boolean) => [SYSTEM_FIELD, [{ valueBoolean: isSystem }]]
+
+describe('AI_CATEGORY_STARTER_TAGS', () => {
+  it('is exactly the five pinned categories, with no Spam', () => {
+    expect(AI_CATEGORY_STARTER_TAGS.map((t) => t.title)).toEqual([
+      'Sales',
+      'Support',
+      'Billing',
+      'Newsletter',
+      'Notification',
+    ])
+  })
+
+  // The model reads these verbatim as the label's definition (C3). A bare title classifies
+  // measurably worse, so an empty one is a silent quality regression.
+  it('gives every category a real classifier instruction', () => {
+    for (const tag of [AI_CATEGORY_PARENT_TAG, ...AI_CATEGORY_STARTER_TAGS]) {
+      expect(tag.description.trim().length).toBeGreaterThan(40)
+      expect(tag.emoji).toBeTruthy()
+      expect(tag.color).toBeTruthy()
+    }
+  })
+})
+
+describe('seedAiCategoryTags', () => {
+  it('creates the parent group and all five starters on a fresh org', async () => {
+    const { db } = makeDb(queue())
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.created).toEqual([
+      'Mail Categories',
+      'Sales',
+      'Support',
+      'Billing',
+      'Newsletter',
+      'Notification',
+    ])
+    expect(result.skipped).toEqual([])
+    expect(titlesCreated()).toHaveLength(6)
+  })
+
+  it('marks every starter eligible, ordinary, thread-scoped and parented', async () => {
+    const { db } = makeDb(queue())
+
+    await seedAiCategoryTags(db, ORG, 'user_1')
+
+    const parentRecordId = `${TAG_DEF_ID}:inst_1`
+    for (const tag of AI_CATEGORY_STARTER_TAGS) {
+      expect(createdByTitle(tag.title)).toMatchObject({
+        tag_ai_classify: true,
+        // C4: system tags cannot be edited, and the description is the tuning surface.
+        is_system_tag: false,
+        tag_scope: 'thread',
+        tag_parent: parentRecordId,
+        tag_description: tag.description,
+      })
+    }
+  })
+
+  // A container the classifier could apply as a label is a bug, not a grouping.
+  it('leaves the parent group itself ineligible', async () => {
+    const { db } = makeDb(queue())
+
+    await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(createdByTitle('Mail Categories')).toMatchObject({
+      tag_ai_classify: false,
+      is_system_tag: false,
+      tag_scope: 'thread',
+    })
+    expect(createdByTitle('Mail Categories')).not.toHaveProperty('tag_parent')
+  })
+
+  // `is_system_tag` is `creatable: false` and its pre-hook drops unauthorized writes, so the
+  // explicit `false` only lands with the bypass.
+  it('writes is_system_tag through the scoped bypass', () => {
+    const { db } = makeDb(queue())
+    return seedAiCategoryTags(db, ORG, 'user_1').then(() => {
+      expect(h.constructorOptions).toHaveLength(1)
+      const options = h.constructorOptions[0] as { bypassFieldGuards: Set<string> }
+      expect([...options.bypassFieldGuards]).toEqual(['is_system_tag'])
+    })
+  })
+
+  it('is a no-op on a second pass — nothing is created twice', async () => {
+    const existing = [
+      { id: 'inst_parent', displayName: 'Mail Categories' },
+      ...AI_CATEGORY_STARTER_TAGS.map((t, i) => ({ id: `inst_${i}`, displayName: t.title })),
+    ]
+    const { db, updates } = makeDb(queue(existing))
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(h.creates).toEqual([])
+    expect(result.created).toEqual([])
+    expect(result.skipped).toHaveLength(6)
+    // Rule 5: no re-parenting, no description overwrite, no flag flip.
+    expect(updates).toEqual([])
+  })
+
+  // The org already calls something `Billing`. It keeps its own — untouched — and gets no
+  // duplicate: two tags with one name is worse than one imperfect one.
+  it('skips a title the org already uses and never modifies it', async () => {
+    const { db, updates } = makeDb(queue([{ id: 'inst_billing', displayName: 'Billing' }]))
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.skipped).toEqual(['Billing'])
+    expect(titlesCreated()).not.toContain('Billing')
+    expect(titlesCreated()).toContain('Sales')
+    expect(updates).toEqual([])
+  })
+
+  // Re-uses the existing group rather than creating "Mail Categories" twice.
+  it('parents new starters under an existing group', async () => {
+    const { db } = makeDb(queue([{ id: 'inst_parent', displayName: 'Mail Categories' }]))
+
+    await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(titlesCreated()).not.toContain('Mail Categories')
+    expect(createdByTitle('Sales')).toMatchObject({ tag_parent: `${TAG_DEF_ID}:inst_parent` })
+  })
+
+  // Without the CustomField the flag would be dropped, the tags would look seeded, and every
+  // later pass would skip them — an org with zero eligible labels and no error anywhere.
+  it('seeds nothing when the tag_ai_classify field is missing', async () => {
+    const { db } = makeDb([TAG_DEF, [], []])
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(h.creates).toEqual([])
+    expect(result).toEqual({ created: [], skipped: [], adopted: [] })
+  })
+
+  it('seeds nothing when the org has no tag entity', async () => {
+    const { db } = makeDb([[], [], []])
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(h.creates).toEqual([])
+    expect(result).toEqual({ created: [], skipped: [], adopted: [] })
+  })
+
+  // Org creation must not fail because a starter tag did not land.
+  it('never throws, and reports what did land when a write fails', async () => {
+    const { db } = makeDb(queue())
+    h.createImpl = (values) => {
+      if (values.title === 'Billing') throw new Error('write failed')
+    }
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.created).toEqual(['Mail Categories', 'Sales', 'Support'])
+    expect(result.skipped).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADOPTION — converting a legacy SYSTEM starter into a tunable one (§12.5.1)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `seedTags` historically created Billing/Sales/Support as SYSTEM tags, which
+// `rejectIfSystemTag` freezes — description included. Under C3 that description
+// IS the classifier's instruction, so an org created before mail classification
+// would carry three starters it could never tune, with no UI able to fix it.
+//
+// The discriminator is the FLAG, never the title: a user's own tag called
+// `Sales` is theirs, and a title collision is not consent.
+
+describe('seedAiCategoryTags — adopting legacy system starters', () => {
+  const legacySales = [{ id: 'inst_sales', displayName: 'Sales' }]
+
+  it('converts a legacy SYSTEM starter in place instead of skipping it', async () => {
+    const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(true)])
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.adopted).toEqual(['Sales'])
+    expect(result.skipped).not.toContain('Sales')
+    // Not recreated — the id is preserved, so every filter referencing it still resolves.
+    expect(titlesCreated()).not.toContain('Sales')
+  })
+
+  it('unfreezes BEFORE writing the description, and only unfreezing gets the bypass', async () => {
+    const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(true)])
+
+    await seedAiCategoryTags(db, ORG, 'user_1')
+
+    // Ordering is load-bearing: `rejectIfSystemTag` reads the CURRENT flag at hook
+    // time, so clearing it first is what lets the description through with no
+    // bypass. Both fields in one call would trip the guard on the description.
+    expect(h.updates).toHaveLength(2)
+    const [unfreeze, retune] = h.updates as [(typeof h.updates)[number], (typeof h.updates)[number]]
+    expect(unfreeze.values).toEqual({ is_system_tag: false })
+    expect(unfreeze.bypass).toEqual(['is_system_tag'])
+
+    expect(retune.values).toMatchObject({ tag_ai_classify: true, tag_scope: 'thread' })
+    expect(retune.values.tag_description).toBe(
+      AI_CATEGORY_STARTER_TAGS.find((t) => t.title === 'Sales')?.description
+    )
+    // Options ride in the FOURTH arg; third is the array-mode map and must stay empty.
+    for (const call of [unfreeze, retune]) {
+      expect(call.modes).toBeUndefined()
+      expect(call.options).toEqual({ skipEvents: true })
+    }
+    // The privilege is scoped to the one write that needs it — a bypass on the
+    // retune would be a second hole for no reason.
+    expect(retune.bypass).toEqual([])
+  })
+
+  it('sets tag_ai_classify, which is what stops migration 014 re-freezing it', async () => {
+    const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(true)])
+
+    await seedAiCategoryTags(db, ORG, 'user_1')
+
+    // 014 flags by TITLE and is REPLAYED, not ledger-guarded. Its
+    // `excludeAiClassifyTags` skips anything carrying this flag, so adoption
+    // without it would silently undo itself on the next migration run.
+    const retune = h.updates.find((u) => 'tag_ai_classify' in u.values)
+    expect(retune?.values.tag_ai_classify).toBe(true)
+  })
+
+  it("leaves a USER's same-named tag completely alone", async () => {
+    const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(false)])
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.skipped).toContain('Sales')
+    expect(result.adopted).toEqual([])
+    // No unfreeze, no description overwrite, no eligibility flip. Someone else's
+    // taxonomy that happens to share a word with ours.
+    expect(h.updates).toEqual([])
+  })
+
+  it('still creates the starters the org does not have', async () => {
+    const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(true)])
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.created).toEqual([
+      'Mail Categories',
+      'Support',
+      'Billing',
+      'Newsletter',
+      'Notification',
+    ])
+  })
+})

--- a/packages/lib/src/seed/ai-category-tags.ts
+++ b/packages/lib/src/seed/ai-category-tags.ts
@@ -1,0 +1,415 @@
+// packages/lib/src/seed/ai-category-tags.ts
+//
+// The five starter mail categories (plans/mail-filter/05-mail-classification-plan.md §2.4)
+// and the one function that seeds them — called from `OrganizationSeeder.seedTags` for new
+// orgs and from `scripts/backfill-ai-category-tags.ts` for existing ones, so both paths seed
+// exactly the same rows.
+//
+// FIVE RULES THIS FILE EXISTS TO KEEP:
+//
+//  1. **Ordinary tags, never system tags** (C4). `tag-system-guard.ts` rejects every edit to
+//     a system tag's title/description/emoji/color/parent AND rejects its delete. Under C3
+//     the `tag_description` IS the classifier's instruction for that label — the tuning
+//     surface — so seeding these as system tags would freeze the one field the whole feature
+//     depends on. `is_system_tag: false`, deliberately and explicitly.
+//  2. **Descriptions are prompt text, not blurbs.** The model reads them verbatim as the
+//     label's definition. They are written as instructions ("anything about invoices,
+//     charges, refunds…"), with the precedence hints that keep the overlapping pairs
+//     (Notification vs Billing, Notification vs Newsletter) decidable.
+//  3. **No `Spam` category** (C6). `set-status: SPAM` already exists and hard machine mail is
+//     skipped upstream; a Spam tag beside a spam status is two ways to say one thing.
+//  4. **Seeding never enables classification.** These rows only make a label *available*.
+//     Nothing is classified until an inbox is opted in, which is a separate switch.
+//  5. **Never touch a USER'S tag.** A title the org already uses is skipped whole — no
+//     re-parenting, no description overwrite, no flag flip. A user's taxonomy is theirs, and
+//     re-running the seed must be a no-op.
+//
+//     ONE EXCEPTION, added 2026-08-10: a pre-existing `Billing`/`Sales`/`Support` carrying
+//     `is_system_tag = true` is one WE seeded, and it is frozen by `rejectIfSystemTag` — so
+//     the org could never tune the classifier instruction that rule 1 exists to protect.
+//     `adoptLegacySystemStarter` converts those in place. The discriminator is the flag, not
+//     the title: a user-created tag of the same name is left entirely alone, because a title
+//     collision is not consent.
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { UnifiedCrudHandler } from '../resources/crud'
+import { type RecordId, toRecordId } from '../resources/resource-id'
+
+const logger = createScopedLogger('ai-category-tags')
+
+/** The `EntityDefinition.entityType` tags live on. */
+const TAG_DEF = 'tag'
+
+/** Thread-scoped only (Q3): article tags exist for KB content, not for mail. */
+const THREAD_SCOPE = 'thread'
+
+/** One starter category, before it is written. */
+export interface AiCategoryTagSeed {
+  title: string
+  /**
+   * The classifier's instruction for this label — read verbatim into the prompt (C3).
+   * Never empty: a bare title classifies measurably worse.
+   */
+  description: string
+  emoji: string
+  color: string
+}
+
+/**
+ * The group the five starters hang under, so they read as one set in the picker instead of
+ * scattering through the org's taxonomy.
+ *
+ * An ordinary tag itself, and NOT eligible: "Mail Categories" is a container, and an
+ * eligible container would be offered to the model as a label it could apply.
+ */
+export const AI_CATEGORY_PARENT_TAG: AiCategoryTagSeed = {
+  title: 'Mail Categories',
+  description:
+    'Grouping for the categories the AI classifier may apply to inbound mail. Not applied to mail itself.',
+  emoji: '📬',
+  color: 'blue',
+}
+
+/**
+ * The five starters. Exactly these — see rule 3 on the absent `Spam`.
+ *
+ * Each description is prompt text. Editing one retunes the classifier for that org, which is
+ * the point: these are starting definitions, not fixed ones.
+ */
+export const AI_CATEGORY_STARTER_TAGS: AiCategoryTagSeed[] = [
+  {
+    title: 'Sales',
+    description:
+      'A prospective or existing customer with buying intent: pricing, quotes, plans, stock or availability, product fit, a demo, or expanding an existing order. Pre-purchase interest — not a problem with something already bought.',
+    emoji: '💼',
+    color: 'pink',
+  },
+  {
+    title: 'Support',
+    description:
+      'The sender needs help with something they already have: a fault, an error, a how-to question, a delivery or order-status chase, a return or a complaint. Something is broken, missing, or not understood.',
+    emoji: '🆘',
+    color: 'red',
+  },
+  {
+    title: 'Billing',
+    description:
+      'Anything about money owed or paid: invoices, charges, refunds, payment methods, subscription or plan fees, failed payments, dunning, receipts and tax documents.',
+    emoji: '💳',
+    color: 'green',
+  },
+  {
+    title: 'Newsletter',
+    description:
+      'Bulk marketing or editorial mail broadcast to a list — product news, promotions, offers, digests, event invitations. Written for many recipients rather than for us, and needs no reply.',
+    emoji: '📰',
+    color: 'amber',
+  },
+  {
+    title: 'Notification',
+    description:
+      'Automated machine mail generated by a system rather than written by a person: service alerts, account and security notices, monitoring or build results, calendar and shipping updates, confirmations of an automated action. If it is about money owed or paid, prefer Billing; if it is bulk marketing, prefer Newsletter.',
+    emoji: '🔔',
+    color: 'teal',
+  },
+]
+
+/** What one seed pass did, for the caller's log line. */
+export interface AiCategoryTagSeedResult {
+  /** Titles created by this pass. */
+  created: string[]
+  /** Titles the org already had that were left untouched (user-owned, or already adopted). */
+  skipped: string[]
+  /** Titles that existed as LEGACY SYSTEM tags and were converted in place (§12.5.1). */
+  adopted: string[]
+}
+
+/**
+ * Convert one pre-existing **legacy system** starter tag into an ordinary, tunable one.
+ *
+ * ## Why this exists
+ *
+ * `seedTags` historically created `Billing`, `Sales` and `Support` as SYSTEM tags. System
+ * tags are frozen by `rejectIfSystemTag` — `tag_description` included — and that description
+ * IS the classifier's instruction for the label (plan C3). So without this, an org created
+ * before mail classification would carry three starters that can be flagged eligible but can
+ * NEVER be tuned, and would classify as bare titles with no UI anywhere able to fix it.
+ *
+ * ## What it will and will not touch
+ *
+ * **Only tags carrying `is_system_tag = true`** — i.e. ones we seeded. A user's own tag that
+ * happens to be called `Sales` is theirs: its description is left alone and it is not made
+ * eligible. Title collision is not consent.
+ *
+ * ## Ordering is load-bearing
+ *
+ * The flag is cleared in its own write, BEFORE the description write. `rejectIfSystemTag`
+ * reads the tag's CURRENT `is_system_tag` at hook time, so once the flag is false the
+ * description write passes the guard normally — no bypass, no second privilege hole. Doing
+ * both in one call would trip the guard on the description.
+ *
+ * ⚠️ Setting `tag_ai_classify = true` is also what stops entity migration `014` re-freezing
+ * these three by title on its next run (`014-backfill-system-tags.ts` → `excludeAiClassifyTags`).
+ * That migration is REPLAYED, not ledger-guarded, so adoption without the flag would silently
+ * undo itself.
+ */
+async function adoptLegacySystemStarter(
+  db: Database,
+  args: {
+    organizationId: string
+    userId: string
+    tagDefId: string
+    instanceId: string
+    seed: AiCategoryTagSeed
+    parentRecordId: RecordId
+  }
+): Promise<'adopted' | 'left-alone'> {
+  const { organizationId, userId, tagDefId, instanceId, seed, parentRecordId } = args
+
+  const [systemField] = await db
+    .select({ id: schema.CustomField.id })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, tagDefId),
+        eq(schema.CustomField.systemAttribute, 'is_system_tag')
+      )
+    )
+    .limit(1)
+
+  if (!systemField) return 'left-alone'
+
+  const [flagRow] = await db
+    .select({ valueBoolean: schema.FieldValue.valueBoolean })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, systemField.id),
+        eq(schema.FieldValue.entityId, instanceId)
+      )
+    )
+    .limit(1)
+
+  // Not one of ours — a user-created tag that happens to share the title. Hands off.
+  if (flagRow?.valueBoolean !== true) return 'left-alone'
+
+  const recordId = toRecordId(tagDefId, instanceId)
+  const seedOpts = { skipEvents: true }
+
+  // 1. Unfreeze. Needs the same bypass the create path uses, because `is_system_tag` is
+  //    `creatable: false` and `dropUnauthorizedSystemFlag` drops unauthorized writes.
+  const unfreeze = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+    bypassFieldGuards: new Set(['is_system_tag']),
+  })
+  // NB `update` is (recordId, values, MODES, options) — options is the FOURTH
+  // arg, unlike `create`. Passing seedOpts third silently lands in the
+  // array-field mode map.
+  await unfreeze.update(recordId, { is_system_tag: false }, undefined, seedOpts)
+
+  // 2. Now an ordinary tag, so the guard lets these through with no bypass at all.
+  const handler = new UnifiedCrudHandler(organizationId, userId, db)
+  await handler.update(
+    recordId,
+    {
+      tag_description: seed.description,
+      tag_parent: parentRecordId,
+      tag_scope: THREAD_SCOPE,
+      tag_ai_classify: true,
+    },
+    undefined,
+    seedOpts
+  )
+
+  logger.info('Adopted legacy system tag as an AI category starter', {
+    organizationId,
+    title: seed.title,
+    instanceId,
+  })
+  return 'adopted'
+}
+
+/**
+ * Seed the five starter mail categories (plus their parent group) for one organization.
+ *
+ * Idempotent by tag title: an org that already has a tag called `Billing` keeps the one it
+ * has, untouched, and no duplicate is written. A second pass creates nothing.
+ *
+ * **Never throws.** Org seeding must not fail because a starter tag did not land, and the
+ * backfill must not abort a 500-org run on one bad org — every failure logs and returns.
+ *
+ * Requires the `tag_ai_classify` CustomField (entity migration `074-tag-ai-classify`). When
+ * it is missing this is a logged no-op rather than a partial seed: creating the five tags
+ * without their eligibility flag would make them look seeded, so the next pass would skip
+ * them forever and the org would silently have zero eligible labels.
+ *
+ * @param db - drizzle instance
+ * @param organizationId - the org to seed
+ * @param userId - the acting user (the seeding user, or the org's system user on the
+ *   backfill path) — `UnifiedCrudHandler` stamps it as the creator
+ */
+export async function seedAiCategoryTags(
+  db: Database,
+  organizationId: string,
+  userId: string
+): Promise<AiCategoryTagSeedResult> {
+  // Declared outside the try so a mid-run failure still reports what did land — the
+  // difference between "nothing happened" and "three of six exist" decides whether a
+  // re-run is enough.
+  const created: string[] = []
+  const skipped: string[] = []
+  const adopted: string[] = []
+
+  try {
+    const [tagDef] = await db
+      .select({ id: schema.EntityDefinition.id })
+      .from(schema.EntityDefinition)
+      .where(
+        and(
+          eq(schema.EntityDefinition.organizationId, organizationId),
+          eq(schema.EntityDefinition.entityType, TAG_DEF)
+        )
+      )
+      .limit(1)
+
+    if (!tagDef) {
+      logger.warn('Skipping AI category tag seed — organization has no tag entity', {
+        organizationId,
+      })
+      return { created, skipped, adopted }
+    }
+
+    const [eligibilityField] = await db
+      .select({ id: schema.CustomField.id })
+      .from(schema.CustomField)
+      .where(
+        and(
+          eq(schema.CustomField.organizationId, organizationId),
+          eq(schema.CustomField.entityDefinitionId, tagDef.id),
+          eq(schema.CustomField.systemAttribute, 'tag_ai_classify')
+        )
+      )
+      .limit(1)
+
+    if (!eligibilityField) {
+      logger.warn(
+        'Skipping AI category tag seed — tag_ai_classify field missing (run entity migration 074 first)',
+        { organizationId }
+      )
+      return { created, skipped, adopted }
+    }
+
+    const titles = [AI_CATEGORY_PARENT_TAG.title, ...AI_CATEGORY_STARTER_TAGS.map((t) => t.title)]
+    const existingRows = await db
+      .select({
+        id: schema.EntityInstance.id,
+        displayName: schema.EntityInstance.displayName,
+      })
+      .from(schema.EntityInstance)
+      .where(
+        and(
+          eq(schema.EntityInstance.organizationId, organizationId),
+          eq(schema.EntityInstance.entityDefinitionId, tagDef.id),
+          isNull(schema.EntityInstance.archivedAt),
+          inArray(schema.EntityInstance.displayName, titles)
+        )
+      )
+
+    const existingByTitle = new Map<string, string>()
+    for (const row of existingRows) {
+      if (row.displayName && !existingByTitle.has(row.displayName)) {
+        existingByTitle.set(row.displayName, row.id)
+      }
+    }
+
+    // `is_system_tag` is `creatable: false` in the registry and its pre-hook drops any
+    // unauthorized write, so the explicit `false` below needs the same bypass the legacy tag
+    // seed uses. Scoped to this handler: it documents the privilege boundary, and writing the
+    // flag explicitly (rather than leaning on the default) is what makes "these are ORDINARY
+    // tags" a fact in the data rather than an omission.
+    const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+      bypassFieldGuards: new Set(['is_system_tag']),
+    })
+    // No active users to notify during a seed, and each invalidation costs seconds on Lambda
+    // when Redis is slow.
+    const seedOpts = { skipEvents: true }
+
+    const existingParentId = existingByTitle.get(AI_CATEGORY_PARENT_TAG.title)
+
+    let parentRecordId: RecordId
+    if (existingParentId) {
+      parentRecordId = toRecordId(tagDef.id, existingParentId)
+      skipped.push(AI_CATEGORY_PARENT_TAG.title)
+    } else {
+      const parent = await handler.create(
+        TAG_DEF,
+        {
+          title: AI_CATEGORY_PARENT_TAG.title,
+          tag_description: AI_CATEGORY_PARENT_TAG.description,
+          tag_emoji: AI_CATEGORY_PARENT_TAG.emoji,
+          tag_color: AI_CATEGORY_PARENT_TAG.color,
+          tag_scope: THREAD_SCOPE,
+          // The container is not a label the classifier may apply.
+          tag_ai_classify: false,
+          is_system_tag: false,
+        },
+        seedOpts
+      )
+      parentRecordId = parent.recordId
+      created.push(AI_CATEGORY_PARENT_TAG.title)
+    }
+
+    // Sequential, like the legacy tag seed: parallel creates racing the same parent's
+    // inverse (`tag_children`) sync collide on sortKey.
+    for (const tag of AI_CATEGORY_STARTER_TAGS) {
+      const existingId = existingByTitle.get(tag.title)
+      if (existingId) {
+        const outcome = await adoptLegacySystemStarter(db, {
+          organizationId,
+          userId,
+          tagDefId: tagDef.id,
+          instanceId: existingId,
+          seed: tag,
+          parentRecordId,
+        })
+        if (outcome === 'adopted') adopted.push(tag.title)
+        else skipped.push(tag.title)
+        continue
+      }
+
+      await handler.create(
+        TAG_DEF,
+        {
+          title: tag.title,
+          tag_description: tag.description,
+          tag_emoji: tag.emoji,
+          tag_color: tag.color,
+          tag_parent: parentRecordId,
+          tag_scope: THREAD_SCOPE,
+          tag_ai_classify: true,
+          is_system_tag: false,
+        },
+        seedOpts
+      )
+      created.push(tag.title)
+    }
+
+    if (created.length > 0 || skipped.length > 0 || adopted.length > 0) {
+      logger.info('AI category tags seeded', { organizationId, created, skipped, adopted })
+    }
+
+    return { created, skipped, adopted }
+  } catch (error) {
+    logger.error('AI category tag seed failed', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+      created,
+      skipped,
+      adopted,
+    })
+    return { created, skipped, adopted }
+  }
+}

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -61,6 +61,7 @@ import { migration048ScoutingPhotoFields } from './migrations/048-scouting-photo
 import { migration057RemoveSignatureVisibilityField } from './migrations/057-remove-signature-visibility-field'
 import { migration059PersonalInboxDef } from './migrations/059-personal-inbox-def'
 import { migration062RemoveInboxLensPersonalFields } from './migrations/062-remove-inbox-lens-personal-fields'
+import { migration074TagAiClassify } from './migrations/074-tag-ai-classify'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -163,6 +164,9 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // pure data migrations. 062 MUST sort after 060 — it drops the two fields 060
   // reads. See the ordering note in the migration itself.
   migration062RemoveInboxLensPersonalFields,
+  // 063–073 are pure data migrations (`data-migrations/migrations/`) — the NNN id
+  // space is shared across both directories, so the gap is expected.
+  migration074TagAiClassify,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/014-backfill-system-tags.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/014-backfill-system-tags.ts
@@ -158,6 +158,76 @@ async function ensureIsSystemTagField(
 }
 
 /**
+ * Drop any tag carrying `tag_ai_classify = true` from the flag set.
+ *
+ * ⚠️ **Added 2026-08-10 — this migration is replayed, not ledger-guarded.**
+ * `runEntityMigrationsForOrg` loops `ALL_MIGRATIONS` and calls `up()`
+ * unconditionally every time (`entity-migrations/index.ts:231-233`);
+ * `alreadyUpToDate` is a REPORT, not a guard. Both it and
+ * `runAllEntityMigrations` are exposed as super-admin actions
+ * (`admin.ts:1563-1583`).
+ *
+ * Three of this migration's canonical titles — `Billing`, `Sales`, `Support` —
+ * are also mail-classification starter tags, which are deliberately ORDINARY
+ * tags (`05-mail-classification-plan.md` C4/§2.3) because
+ * `rejectIfSystemTag` freezes `tag_description`, and that description IS the
+ * classifier's instruction for the label. Without this exclusion, one replay
+ * would flag the starters by title, permanently freeze their instructions, and
+ * report success while doing it.
+ *
+ * Matching on title alone cannot tell a legacy system tag from a starter that
+ * happens to share its name; the eligibility flag is the only thing that can.
+ * Absent field or absent row ⇒ not eligible ⇒ flagged as before, so this is a
+ * no-op for every org that predates the field.
+ */
+async function excludeAiClassifyTags(
+  db: Database,
+  organizationId: string,
+  tagDefId: string,
+  instanceIds: string[]
+): Promise<string[]> {
+  const [aiClassifyField] = await db
+    .select({ id: schema.CustomField.id })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, tagDefId),
+        eq(schema.CustomField.systemAttribute, 'tag_ai_classify')
+      )
+    )
+    .limit(1)
+
+  // Field not materialized yet (every org before migration 074) — nothing is
+  // eligible, so the original behavior stands.
+  if (!aiClassifyField) return instanceIds
+
+  const eligibleRows = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, aiClassifyField.id),
+        eq(schema.FieldValue.valueBoolean, true),
+        inArray(schema.FieldValue.entityId, instanceIds)
+      )
+    )
+
+  if (eligibleRows.length === 0) return instanceIds
+
+  const eligible = new Set(eligibleRows.map((r) => r.entityId))
+  const kept = instanceIds.filter((id) => !eligible.has(id))
+
+  logger.info('Skipped AI-eligible tags during system-tag backfill', {
+    organizationId,
+    skipped: instanceIds.length - kept.length,
+  })
+
+  return kept
+}
+
+/**
  * Upsert `is_system_tag = true` on every tag instance whose title matches
  * the canonical seeded list. Returns counts for logging.
  */
@@ -203,7 +273,16 @@ async function flagCanonicalTags(
     return { flagged: 0, alreadyFlagged: 0 }
   }
 
-  const canonicalInstanceIds = canonicalRows.map((r) => r.entityId)
+  const canonicalInstanceIds = await excludeAiClassifyTags(
+    db,
+    organizationId,
+    tagDefId,
+    canonicalRows.map((r) => r.entityId)
+  )
+
+  if (canonicalInstanceIds.length === 0) {
+    return { flagged: 0, alreadyFlagged: 0 }
+  }
 
   // Find which ones already have an is_system_tag FieldValue row.
   const existingFlagRows = await db

--- a/packages/lib/src/seed/entity-migrations/migrations/074-tag-ai-classify.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/074-tag-ai-classify.test.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/seed/entity-migrations/migrations/074-tag-ai-classify.test.ts
+//
+// Three things are load-bearing about 074 and all three are pinned here:
+//
+//  1. **It creates the `tag_ai_classify` CustomField** on the org's tag def — without that
+//     row, the first write of the flag is an FK violation, not a clean error (invariant 14).
+//  2. **It is idempotent** — the second pass inserts nothing and reports `alreadyUpToDate`,
+//     which is also what suppresses the runner's per-org cache recompute.
+//  3. **It touches no tag.** No `FieldValue`, no `EntityInstance`, no `UPDATE` of any kind:
+//     eligibility must start empty for every org (C10's sibling — nothing may become
+//     classifiable because a migration ran), and a value backfill here would silently enrol
+//     an org's whole taxonomy.
+//
+// The global `@auxx/database` mock (`src/test/setup.ts`) stays in place — the migration takes
+// its `db` as an argument, so the fake below is passed in rather than mocked over.
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { migration074TagAiClassify } from './074-tag-ai-classify'
+
+const ORG = 'org_1'
+const TAG_DEF_ID = 'def_tag'
+
+interface Insert {
+  table: unknown
+  values: Record<string, unknown>
+}
+
+interface FakeDb {
+  db: Database
+  inserts: Insert[]
+  updates: unknown[]
+}
+
+/**
+ * A chainable stand-in that resolves the next queued result set per `await`.
+ *
+ * `loadExistingState` awaits two selects (EntityDefinitions, then CustomFields — in that
+ * order, since `Promise.all` subscribes in array order).
+ */
+function makeDb(results: unknown[][]): FakeDb {
+  const queue = [...results]
+  const inserts: Insert[] = []
+  const updates: unknown[] = []
+
+  const chain = (): Record<string, unknown> =>
+    new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'then') {
+            return (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+              Promise.resolve(queue.shift() ?? []).then(resolve, reject)
+          }
+          return () => chain()
+        },
+      }
+    )
+
+  const db = {
+    select: () => chain(),
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => {
+        inserts.push({ table, values })
+        return { returning: async () => [{ id: 'cf_new', options: values.options ?? {} }] }
+      },
+    }),
+    update: (table: unknown) => {
+      updates.push(table)
+      return { set: () => ({ where: async () => undefined }) }
+    },
+  }
+
+  return { db: db as unknown as Database, inserts, updates }
+}
+
+const tagDefRow = { id: TAG_DEF_ID, entityType: 'tag' }
+
+/** An already-migrated org: the CustomField row 074 would create is already there. */
+const existingEligibilityField = {
+  id: 'cf_existing',
+  systemAttribute: 'tag_ai_classify',
+  entityDefinitionId: TAG_DEF_ID,
+  options: {},
+}
+
+describe('migration 074 — tag_ai_classify', () => {
+  it('creates the tag_ai_classify CustomField on the org tag definition', async () => {
+    const { db, inserts } = makeDb([[tagDefRow], []])
+
+    const result = await migration074TagAiClassify.up(db, ORG)
+
+    expect(result.fieldsCreated).toBe(1)
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]?.values).toMatchObject({
+      organizationId: ORG,
+      entityDefinitionId: TAG_DEF_ID,
+      modelType: 'tag',
+      systemAttribute: 'tag_ai_classify',
+      type: 'CHECKBOX',
+      isCustom: false,
+    })
+  })
+
+  // Re-running is the normal case: the ledger records the migration, but the per-org runner
+  // and the admin "run all" button both replay it.
+  it('is idempotent — a second pass inserts nothing and reports alreadyUpToDate', async () => {
+    const { db, inserts, updates } = makeDb([[tagDefRow], [existingEligibilityField]])
+
+    const result = await migration074TagAiClassify.up(db, ORG)
+
+    expect(result.fieldsCreated).toBe(0)
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(inserts).toEqual([])
+    expect(updates).toEqual([])
+  })
+
+  // The whole point of "no value backfill": an existing tag must not become eligible, and
+  // nothing about an existing tag may change at all.
+  it('never writes a FieldValue or touches an EntityInstance', async () => {
+    const { db, inserts, updates } = makeDb([[tagDefRow], []])
+
+    await migration074TagAiClassify.up(db, ORG)
+
+    const { schema } = await import('@auxx/database')
+    const insertedTables = inserts.map((i) => i.table)
+    expect(insertedTables).toContain(schema.CustomField)
+    expect(insertedTables).not.toContain(schema.FieldValue)
+    expect(insertedTables).not.toContain(schema.EntityInstance)
+    expect(updates).toEqual([])
+  })
+
+  it('no-ops for an organization with no tag entity', async () => {
+    const { db, inserts } = makeDb([[], []])
+
+    const result = await migration074TagAiClassify.up(db, ORG)
+
+    expect(result).toMatchObject({ fieldsCreated: 0, alreadyUpToDate: true })
+    expect(inserts).toEqual([])
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/074-tag-ai-classify.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/074-tag-ai-classify.ts
@@ -1,0 +1,81 @@
+// packages/lib/src/seed/entity-migrations/migrations/074-tag-ai-classify.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { TAG_FIELDS } from '../../../resources/registry/resources/tag-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:074')
+
+/**
+ * Migration 074: add the `tag_ai_classify` CHECKBOX field to the `tag` entity
+ * (plans/mail-filter/05-mail-classification-plan.md §2.1).
+ *
+ * A new registry system field is NOT a Drizzle migration — nothing can write a
+ * `FieldValue` for it until a `CustomField` row exists on the org's `tag`
+ * EntityDefinition, and the first write without one is an FK violation rather
+ * than a clean error (invariant 14). New orgs get the field from the entity
+ * seeder, which reads `TAG_FIELDS` directly; this catches up every existing org.
+ *
+ * **No value backfill, on purpose.** Absence reads as `false` everywhere
+ * (`tag-service.ts`'s `?? false`, and the registry's `defaultValue: false`), and
+ * eligibility must start empty: a migration that flipped tags on would enrol an
+ * org's taxonomy into a classifier nobody asked for. The five starter categories
+ * are seeded separately (`seed/ai-category-tags.ts`), and the per-inbox opt-in is
+ * a separate switch again — nothing classifies because this ran.
+ *
+ * The **resources cache clear** §2.1 requires is the runner's, not ours: both
+ * `runEntityMigrationsForOrg` and `runEntityMigrationForAllOrgs` invalidate
+ * `entityDefs`/`entityDefSlugs`/`customFields`/`resources` for any org where
+ * `fieldsCreated > 0`, which is exactly what this migration reports. Do not
+ * duplicate it here.
+ *
+ * Idempotent: `ensureCustomFields` skips the insert when a row with this
+ * `systemAttribute` already exists on the org's tag def, and this migration
+ * touches no tag instance and no `FieldValue` at all.
+ */
+export const migration074TagAiClassify: EntityMigration = {
+  id: '074-tag-ai-classify',
+  description: 'Add tag.tag_ai_classify CHECKBOX field (AI mail-classification eligibility)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const tagDef = existing.entityDefs.get('tag')
+    if (!tagDef) {
+      // No tag entity — pre-seed or manually pruned. Nothing to migrate.
+      logger.warn('No tag entity found, skipping tag-ai-classify migration', { organizationId })
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    const field = TAG_FIELDS.tag_ai_classify
+    if (!field) {
+      throw new Error('TAG_FIELDS.tag_ai_classify is missing from the registry')
+    }
+
+    const fields: Record<string, ResourceField> = { tag_ai_classify: field }
+    const fieldMap = await ensureCustomFields(
+      db,
+      organizationId,
+      'tag',
+      tagDef.id,
+      fields,
+      existing,
+      state
+    )
+
+    if (!fieldMap.get(`tag:${field.id}`)) {
+      throw new Error('Failed to resolve tag_ai_classify CustomField after ensureCustomFields')
+    }
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+    if (!alreadyUpToDate) {
+      logger.info('Migration 074 applied', { organizationId, customFieldCreated: true })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/lib/src/seed/organization-seeder.ts
+++ b/packages/lib/src/seed/organization-seeder.ts
@@ -19,6 +19,7 @@ import { UnifiedCrudHandler } from '../resources/crud'
 import { seedClientNotificationSequences } from '../sequences'
 import { buildSystemSnippetTemplates } from '../snippets'
 import { SystemUserService } from '../users/system-user-service'
+import { seedAiCategoryTags } from './ai-category-tags'
 import { EntitySeeder } from './entity-seeder'
 import { SYSTEM_ENTITIES } from './entity-seeder/constants'
 
@@ -403,7 +404,8 @@ export class OrganizationSeeder {
   /**
    * Seed default tags for a new organization using the unified entity system.
    * Creates a hierarchical tag structure with a parent "Topic Categorization" tag
-   * and child tags, plus independent top-level tags.
+   * and child tags, plus independent top-level tags — then the five AI mail
+   * categories under their own parent (see `seedAiCategoryTags`).
    */
   private async seedTags(organizationId: string) {
     // Dedicated handler with `is_system_tag` bypass — the tag-system-guard
@@ -434,12 +436,18 @@ export class OrganizationSeeder {
 
     // Create child tags under Topic Categorization using parent relationship
     // Must be sequential to avoid inverse relationship sync conflicts (sortKey collisions)
+    //
+    // `Billing` and `Sales` USED to live here as system tags, and `Support` below as an
+    // independent one. They moved to `AI_CATEGORY_STARTER_TAGS` (mail-classification plan
+    // §2.4), which needs those exact three titles — seeding both sets would give every new
+    // org two tags called `Billing`, one of them frozen by the system-tag guard. They are
+    // still created for every new org, just as ORDINARY tags under "Mail Categories", which
+    // is what C4 requires: their descriptions are the classifier's instructions and have to
+    // stay editable. `suggested:billing-mail` still resolves `Billing` by display name.
     const topicSubTags = [
       { title: 'Account Management', tag_emoji: '👤', tag_color: 'red' },
-      { title: 'Billing', tag_emoji: '💳', tag_color: 'green' },
       { title: 'Customer Feedback', tag_emoji: '💬', tag_color: 'orange' },
       { title: 'Legal', tag_emoji: '⚖️', tag_color: 'gray' },
-      { title: 'Sales', tag_emoji: '💼', tag_color: 'pink' },
       { title: 'Security', tag_emoji: '🔒', tag_color: 'purple' },
       { title: 'Shipping', tag_emoji: '🚚', tag_color: 'amber' },
       { title: 'Troubleshooting', tag_emoji: '🛠️', tag_color: 'teal' },
@@ -458,8 +466,8 @@ export class OrganizationSeeder {
     }
 
     // Create independent tags (no parent) - can be parallel since no inverse sync needed
+    // (`Support` moved to the AI mail categories — see the note on `topicSubTags`.)
     const independentTags = [
-      { title: 'Support', tag_emoji: '🆘', tag_color: 'red' },
       { title: 'Urgent', tag_emoji: '🚨', tag_color: 'purple' },
       { title: 'Orders', tag_emoji: '📦', tag_color: 'amber' },
       { title: 'VIP', tag_emoji: '⭐', tag_color: 'orange' },
@@ -468,6 +476,11 @@ export class OrganizationSeeder {
     await Promise.all(
       independentTags.map((tag) => handler.create('tag', { ...tag, is_system_tag: true }, seedOpts))
     )
+
+    // The five AI mail categories, under their own parent. Ordinary (editable, deletable)
+    // tags with `tag_ai_classify: true` — they make the labels AVAILABLE to the classifier
+    // and nothing more; no mail is classified until an inbox is opted in.
+    await seedAiCategoryTags(this.db, organizationId, this.userId)
   }
   // Create ticket sequence for the organization
   /**

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -300,6 +300,21 @@ export const SETTINGS_CATALOG = {
     defaultValue: [],
     description: 'Inbox ids this member dismissed the "apply filters retroactively" prompt for',
   },
+  // AI mail classification opt-in (mail-classification plan §5). A LIST of inbox
+  // ids, never a boolean: "classify everything" must not be expressible.
+  //
+  // ⚠️ ORG-scoped storage, but authoring authority is PER INBOX and follows the
+  // mail model, never admin rank (filters-plan invariant 7) — the same gate that
+  // governs authoring a filter on that inbox. A personal mailbox is its owner's
+  // alone and an admin must never be able to switch inference on over it
+  // (invariant 11). The router asserts; this catalog entry only declares storage.
+  mailClassificationInboxIds: {
+    scope: 'COMMUNICATION',
+    access: 'org',
+    fieldType: 'JSON',
+    defaultValue: [],
+    description: 'Inbox ids whose inbound mail the AI classifier may read and categorise',
+  },
 
   ...sidebarSettings,
 

--- a/packages/lib/src/tags/tag-service.ts
+++ b/packages/lib/src/tags/tag-service.ts
@@ -26,6 +26,12 @@ export interface TagData {
   parentRecordId: RecordId | null
   isSystemTag: boolean
   isPublic: boolean
+  /**
+   * Eligible for the AI mail classifier (mail-classification plan C2). When true the
+   * classifier may apply this tag to inbound mail and `tag_description` is read as the
+   * label's definition. Independent of `isSystemTag` — a system tag can be eligible.
+   */
+  aiClassify: boolean
   scope: TagScopeValue
   createdAt: Date
   updatedAt: Date
@@ -134,6 +140,8 @@ export class TagService {
       parentRecordId,
       isSystemTag: (item.fieldValues.is_system_tag as boolean) ?? false,
       isPublic: (item.fieldValues.tag_is_public as boolean) ?? false,
+      // Absent FieldValue ⇒ not eligible. No tag is classifiable until someone opts it in.
+      aiClassify: (item.fieldValues.tag_ai_classify as boolean) ?? false,
       scope,
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -89,6 +89,7 @@ export const SYSTEM_ATTRIBUTES = [
   'tag_articles',
   'tag_is_public',
   'tag_scope',
+  'tag_ai_classify',
 
   // ─── KB fields ──────────────────────────────────────────────────
   'kb_name',

--- a/packages/ui/src/components/toggle-card.tsx
+++ b/packages/ui/src/components/toggle-card.tsx
@@ -7,6 +7,7 @@ import { Label } from '@auxx/ui/components/label'
 import { Switch, type SwitchProps } from '@auxx/ui/components/switch'
 import { cn } from '@auxx/ui/lib/utils'
 import type React from 'react'
+import { useId } from 'react'
 
 export interface ToggleCardProps {
   /** Title shown on the left of the header row. */
@@ -59,6 +60,21 @@ export function ToggleCard({
 }: ToggleCardProps) {
   const interactive = rowClickToggles && !disabled
 
+  // Wire the switch to its visible title/description with ARIA rather than
+  // `htmlFor`. Without this the switch has NO accessible name — a screen reader
+  // announces a bare "switch, off", and `getByRole('switch', { name })` matches
+  // nothing, so callers end up walking the DOM in tests.
+  //
+  // ⚠️ Deliberately `aria-labelledby`, NOT `<Label htmlFor>`. A real `htmlFor`
+  // forwards the label click to the switch, and that click then bubbles to the
+  // header row's own `onClick` below — toggling twice and landing back where it
+  // started. `aria-labelledby` names the control without making the label a
+  // second click target, so behaviour is identical in both `rowClickToggles`
+  // modes and only the accessibility tree changes.
+  const reactId = useId()
+  const titleId = `${reactId}-title`
+  const descriptionId = `${reactId}-description`
+
   return (
     <div className={cn('rounded-xl border px-3 py-2.5', className)}>
       <div
@@ -66,14 +82,26 @@ export function ToggleCard({
         onClick={interactive ? () => onCheckedChange(!checked) : undefined}>
         <div className='space-y-0.5 leading-none'>
           <Label
+            id={titleId}
             className={cn(
               'flex items-center gap-1.5 text-sm font-medium',
               interactive && 'cursor-pointer'
             )}>
-            {icon}
+            {/* Hidden from the name so a decorative glyph can't pollute it.
+                `flex items-center` keeps the wrapper a tight box around the
+                icon, so it lays out exactly as the bare node did before. */}
+            {icon && (
+              <span aria-hidden='true' className='flex items-center'>
+                {icon}
+              </span>
+            )}
             {title}
           </Label>
-          {description && <p className='text-xs text-muted-foreground'>{description}</p>}
+          {description && (
+            <p id={descriptionId} className='text-xs text-muted-foreground'>
+              {description}
+            </p>
+          )}
         </div>
         <div onClick={(e) => e.stopPropagation()}>
           <Switch
@@ -81,6 +109,8 @@ export function ToggleCard({
             checked={checked}
             onCheckedChange={onCheckedChange}
             disabled={disabled}
+            aria-labelledby={titleId}
+            aria-describedby={description ? descriptionId : undefined}
           />
         </div>
       </div>


### PR DESCRIPTION
Phases 1 and 2 of `plans/mail-filter/05-mail-classification-plan.md`. An LLM reads each inbound message and applies **an existing tag**, so `tag is Billing → assign to Finance` — a filter users can already write today — starts firing on *meaning* rather than only on sender addresses.

## Categories are tags

There is **no new vocabulary**: no `Message.categoryKey`, no `category` condition, no `Thread` denormalization, no new filter action, and **no change to the filter dialog**.

The first draft of the plan invented all of that — two columns, a `condition-query-builder` case, a fixed taxonomy, and a deferred phase to make it org-editable — before noticing tags already *are* that feature, and better: org-defined from day one, with CRUD, colors, hierarchy, a picker, a condition, an action, thread-list rendering and Kopilot tools all built. The only new thing is *who applies a tag*.

**The label set is opt-in per tag** (`tag_ai_classify`, entity migration 074). Not "all tags" — the label list *is* the prompt, and 80 tags is a bad classifier. Not "system tags only" — that means we pick your taxonomy, which is most of the value gone. Five starters seed with `tag_description` written as classifier instructions; that field is now functionally load-bearing, which the dialog says.

**The starters are ordinary tags, deliberately.** System tags are frozen by `rejectIfSystemTag` — description included — and the description is the only tuning surface the feature has.

## Where it runs

Follow-up pass on the `then` side of `message:received`. Never in the gate (an LLM call blows `GATE_TIMEOUT_MS` and head-of-line blocks unrelated events at concurrency 10) and never in ingest.

Dropping `Spam` from the taxonomy is what makes that *sufficient* rather than a compromise: it was the only category where beating the auto-answer agent mattered, and `set-status: SPAM` already exists.

Six-exit guard, cheapest first — an org that never opts in makes zero model calls and pays zero queries. **Exit 6 skips a thread a deterministic filter already tagged**: rules first, AI only for what conditions cannot express.

## Three things that would have shipped broken

**1. Applying a tag does not re-run filters.** `applyMailFilters` is invoked from exactly one place — the gate — and `message:tag:added` has an empty handler array. Without an explicit second pass, the classifier would tag threads and **no filter would ever react**: the whole feature dead, silently, with no error anywhere.

The re-run covers the *full* filter set and reuses `source: 'live'`. The run claim is unique on `(filterId, messageId, source)`, so an already-fired filter bails before acting while a category filter that missed pass 1 claims and fires. A new `'classification'` source arm would re-fire everything, `run-agent` included — there's a test asserting that failure mode so a refactor trips it.

**2. Migration 014 would have frozen the starters.** It flags tags by **title**, and its canonical list contains `Billing`, `Sales`, `Support`. Entity migrations are **replayed, not ledger-guarded** — `runEntityMigrationsForOrg` calls `up()` unconditionally, and both it and `runAllEntityMigrations` are one-click admin actions. A replay would freeze the starters' descriptions permanently and report success. 014 now skips anything carrying `tag_ai_classify`.

**3. The miner would have fought the classifier.** `top_tag` had no eligibility filter, so once tags became consistent it would propose `auto-tag` filters to duplicate the classifier — every week, forever — evading the `MailFilterRun` guard built for exactly that case.

This is dormant-but-armed, not hypothetical: `auto-tag` is fully implemented and has never produced a row *only* because 0 groups currently reach the consistency threshold. Making tags consistent is precisely what a classifier does. Measured cost of the anti-join: **+0.02% planner cost**, running once per candidate tag row rather than per message.

## Also closed

- **`setting.updateOrganizationSetting` bypassed the per-inbox gate.** It writes any catalog key behind `settings.manage`, so an admin could have opted in **a colleague's personal inbox** — what per-inbox storage exists to prevent. Guarded on both the single and batch write paths.
- **`suppress-automations` did not suppress the classifier**, so a filter that explicitly asked for no automation still paid for an inference on that exact mail. It is the only *billed* handler in the fan-out.
- **Existing orgs would have kept three frozen starters.** `adoptLegacySystemStarter` converts them in place, **preserving the tag id** so every filter and suggestion referencing it still resolves. The discriminator is `is_system_tag`, never the title — a user's own same-named tag is untouched, because a title collision is not consent.
- **`ToggleCard`'s switch had no accessible name.** Named via `aria-labelledby` — deliberately not `htmlFor`, which forwards the label click to the switch, which then bubbles to the header row's handler and toggles twice.

## Review notes

- **Nothing classifies until two switches are on**: a tag marked eligible, and an inbox opted in. Seeding and the backfill write no opt-in anywhere — a migration must not start billing an org for inference.
- **`packages/types/system-attribute`** gains one literal; `ResourceField.systemAttribute` is a typed union, so the registry entry does not compile without it. No Drizzle migration — `CustomField.systemAttribute` is plain text.
- **Run entity migration `074-tag-ai-classify` before the backfill script.** Without the field an org is skipped with a warning rather than half-seeded.
- Confidence is **logged, not stored** (no column) — including below-threshold calls that apply nothing, which are the most informative for tuning. Query at `scope='mail-classification'`.

## Verification

| | |
|---|---|
| `packages/lib` | **7329 passed**, 0 failed |
| `apps/web` (touched) | **110 passed** |
| typecheck | lib 29 / web 16 / worker 1 / ui 0 — **all baselines**, none naming a touched file |
| `check:exports` | clean, no new subpath needed |

Router denial tests assert `cause.statusCode`, not just that the call rejected. Another member's personal inbox is 404, matching the convention from #1513.

## Known gaps (recorded in §12.5)

- §2.2 is unreachable from the tag dialog — system tags are read-only there, so eligibility cannot be toggled on one. Nothing in this PR depends on it.
- Two sources of "eligible tag count" (the inbox card uses `TagService`, the classifier uses `getEligibleClassificationTags`). They agree today; the card should read the classifier's function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)