### PR TITLE
fix(channels): re-enable the channel when a reconnect succeeds

### DIFF
--- a/apps/web/src/components/channels/hooks/use-channel-reconnect.ts
+++ b/apps/web/src/components/channels/hooks/use-channel-reconnect.ts
@@ -18,10 +18,13 @@ const RETURN_TO = '/app/settings/channels'
  * `connections.refreshTokens` first (`attemptRefreshThenOAuth`), popup only when the refresh grant
  * is actually dead. Replaces the four bespoke `channelReauth.initiateReauth` +
  * `window.location.href` call sites (plans/channels/v3/README.md Phase 2).
+ *
+ * Either way a success ends in `channel.recoverAfterReconnect`, which is what makes the channel
+ * usable again — see the note on `onConnected`.
  */
 export function useChannelReconnect() {
   const utils = api.useUtils()
-  const resetSyncState = api.channel.resetSyncState.useMutation()
+  const recoverChannel = api.channel.recoverAfterReconnect.useMutation()
   // credentialId -> integrationId, set right before a reconnect attempt starts. `onConnected`
   // fires with the credId, which for a reconnect always equals the credentialId we passed in.
   const integrationByCredential = useRef(new Map<string, string>())
@@ -32,18 +35,20 @@ export function useChannelReconnect() {
       void utils.channelReauth.getAuthStatus.invalidate()
       void utils.channelReauth.getMultipleAuthStatus.invalidate()
 
-      // Sync-breaker gap: the provisioning hook's relink branch resets `syncStatus`/`syncStage`
-      // back to a healthy baseline, but that only runs on a full OAuth callback. A *silent*
-      // refresh success (attemptRefreshThenOAuth) skips the callback entirely, so a channel
-      // stuck at FAILED would refresh its token and still show "Sync Error" forever.
+      // Recovery gap: the provisioning hook's relink branch re-enables the channel and resets
+      // its sync breaker, but that only runs on a full OAuth callback. A *silent* refresh success
+      // (attemptRefreshThenOAuth) skips the callback entirely, so a channel that auth failures had
+      // auto-disabled would refresh its token, report success, and still reject every sync with
+      // "Cannot sync messages for disabled channel" — with the Reconnect action now hidden,
+      // because the refresh just cleared the credential's reauth flag.
       // `useConnectFlow` doesn't expose which path settled `onConnected` (both the silent-refresh
-      // branch and the popup's `onDone` call the same callback) — resetting on every success is
-      // harmless: the provisioning hook already reset it on the popup path, so this is a no-op
-      // re-write there, and the only path where it actually matters.
+      // branch and the popup's `onDone` call the same callback) — recovering on every success is
+      // harmless: the provisioning hook already did this work on the popup path, so this is a
+      // no-op re-write there, and the only path where it actually matters.
       const integrationId = integrationByCredential.current.get(credId)
       if (integrationId) {
         integrationByCredential.current.delete(credId)
-        resetSyncState.mutate({ integrationId })
+        recoverChannel.mutate({ integrationId })
       }
     },
   })

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -15,6 +15,7 @@ import {
   getProviderType,
   linkChannelToInbox,
   list as listChannels,
+  recoverChannel,
   requireChannelManageAccess,
   resolveChannelDefinitionId,
   supportsPersonalChannelConnection,
@@ -45,7 +46,7 @@ import { fanOutAuxxChatAudienceToShopify } from '@auxx/lib/shopify'
 import { widgetSchema as chatWidgetInputSchema } from '@auxx/lib/widgets/types'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
-import { and, count, eq, isNull } from 'drizzle-orm'
+import { count, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import { createTRPCRouter, notDemo, permissionProcedure, protectedProcedure } from '../trpc'
@@ -919,70 +920,36 @@ export const channelRouter = createTRPCRouter({
     }),
 
   /**
-   * Reset sync state for a stuck integration.
-   * Clears throttle, resets stage to IDLE, and optionally clears lastHistoryId for full re-sync.
+   * Bring a channel back to a healthy baseline after a successful reconnect:
+   * re-enable it, clear the auth-failure counter, and reset the sync breaker.
+   * See `recoverChannel` for why all three have to move together.
    */
-  resetSyncState: protectedProcedure
+  recoverAfterReconnect: protectedProcedure
     .input(
       z.object({
         integrationId: z.string(),
         fullResync: z.boolean().default(false),
       })
     )
-    .use(notDemo('reset sync state'))
+    .use(notDemo('recover channel'))
     .mutation(async ({ ctx, input }) => {
       const { userId } = ctx.session
       const organizationId = getUserOrganizationId(ctx.session)
       await requireChannelManageAccess({ db: ctx.db, organizationId, userId }, input.integrationId)
 
-      // Verify integration belongs to this org
-      const [integration] = await ctx.db
-        .select({ id: schema.Integration.id, syncStage: schema.Integration.syncStage })
-        .from(schema.Integration)
-        .where(
-          and(
-            eq(schema.Integration.id, input.integrationId),
-            eq(schema.Integration.organizationId, organizationId),
-            isNull(schema.Integration.deletedAt)
-          )
-        )
-        .limit(1)
+      const result = await recoverChannel({ db: ctx.db, organizationId }, input.integrationId, {
+        fullResync: input.fullResync,
+      })
+      if (!result.ok) throw result.error
 
-      if (!integration) {
-        throw new Error('Integration not found')
-      }
-
-      // Clear Redis import cache (both main and processing sets)
-      const { clearImportCache } = await import('@auxx/lib/email/polling-import-cache')
-      await clearImportCache(input.integrationId)
-
-      // Reset sync state
-      const updateData: Record<string, any> = {
-        syncStage: 'IDLE',
-        syncStatus: 'ACTIVE',
-        syncStageStartedAt: null,
-        throttleFailureCount: 0,
-        throttleRetryAfter: null,
-        updatedAt: new Date(),
-      }
-
-      if (input.fullResync) {
-        updateData.lastHistoryId = null
-      }
-
-      await ctx.db
-        .update(schema.Integration)
-        .set(updateData)
-        .where(eq(schema.Integration.id, input.integrationId))
-
-      logger.info('Admin reset sync state', {
+      logger.info('Channel recovered after reconnect', {
         integrationId: input.integrationId,
         fullResync: input.fullResync,
-        previousStage: integration.syncStage,
+        reEnabled: result.value.reEnabled,
         userId,
       })
 
-      return { success: true }
+      return result.value
     }),
 
   /**

--- a/packages/lib/src/channels/__tests__/recover.test.ts
+++ b/packages/lib/src/channels/__tests__/recover.test.ts
@@ -1,0 +1,155 @@
+// packages/lib/src/channels/__tests__/recover.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `recoverChannel` — what a successful reconnect has to undo.
+ *
+ * The bug this pins: `AuthErrorHandler` flips `Integration.enabled` to false
+ * after `DISABLE_THRESHOLD` reauth-class failures, and the counter behind that
+ * flip (`metadata.auth.consecutiveFailures`) is only ever cleared by a
+ * SUCCESSFUL SYNC — which a disabled channel can never run. Reconnecting used
+ * to reset the sync breaker only, so the user was told the reconnect worked and
+ * every sync still returned "Cannot sync messages for disabled channel".
+ *
+ * So the two assertions that matter are (1) a disabled channel comes back on,
+ * through `toggle` rather than a bare column write, because that is what
+ * re-arms the provider webhook a long-dark channel has certainly lost, and
+ * (2) the auth block is gone from the metadata write — leaving it would let the
+ * next single auth blip disable the channel again on its first strike.
+ */
+
+const { fixture, toggle, clearCredentialReauth, clearImportCache, onCacheEvent } = vi.hoisted(
+  () => ({
+    fixture: {
+      channel: {} as Record<string, unknown>,
+      update: null as Record<string, unknown> | null,
+    },
+    toggle: vi.fn(async () => ({ ok: true, value: { success: true, message: 'ok' } })),
+    clearCredentialReauth: vi.fn(async () => {}),
+    clearImportCache: vi.fn(async () => {}),
+    onCacheEvent: vi.fn(async () => {}),
+  })
+)
+
+vi.mock('../../logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('../../cache', () => ({ onCacheEvent }))
+vi.mock('../../email/polling-import-cache', () => ({ clearImportCache }))
+vi.mock('../../providers/credential-auth-state', () => ({ clearCredentialReauth }))
+vi.mock('../toggle', () => ({ toggle }))
+vi.mock('../internal/validate', () => ({
+  validateChannelOwnership: async () => ({ ok: true, value: fixture.channel }),
+}))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+vi.mock('@auxx/database', async () => ({
+  schema: (await import('../../test/database-mock')).createSchemaMock(),
+}))
+
+const { recoverChannel } = await import('../recover')
+
+const ORG = 'org_cuid000000000000000000000'
+const CHANNEL = 'int_cuid00000000000000000000'
+
+const db = {
+  update: () => ({
+    set: (values: Record<string, unknown>) => {
+      fixture.update = values
+      return { where: async () => undefined }
+    },
+  }),
+} as never
+
+const ctx = { db, organizationId: ORG }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fixture.update = null
+  fixture.channel = {
+    id: CHANNEL,
+    provider: 'google',
+    enabled: false,
+    metadata: {
+      email: 'support@example.com',
+      settings: { bidirectionalSyncEnabled: false },
+      auth: { consecutiveFailures: 4, requiresReauth: true, type: 'invalid_grant' },
+    },
+  }
+})
+
+describe('recoverChannel', () => {
+  it('re-enables an auto-disabled channel through toggle', async () => {
+    const result = await recoverChannel(ctx, CHANNEL)
+
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.value.reEnabled).toBe(true)
+    expect(toggle).toHaveBeenCalledWith(ctx, CHANNEL, true)
+  })
+
+  it('leaves an already-enabled channel alone', async () => {
+    fixture.channel.enabled = true
+
+    const result = await recoverChannel(ctx, CHANNEL)
+
+    expect(result.ok && result.value.reEnabled).toBe(false)
+    expect(toggle).not.toHaveBeenCalled()
+  })
+
+  it('drops the auth-failure block while keeping the rest of the metadata', async () => {
+    await recoverChannel(ctx, CHANNEL)
+
+    expect(fixture.update?.metadata).toEqual({
+      email: 'support@example.com',
+      settings: { bidirectionalSyncEnabled: false },
+    })
+  })
+
+  it('resets the sync breaker and clears the credential reauth flag', async () => {
+    await recoverChannel(ctx, CHANNEL)
+
+    expect(fixture.update).toMatchObject({
+      syncStatus: 'ACTIVE',
+      syncStage: 'IDLE',
+      syncStageStartedAt: null,
+      throttleFailureCount: 0,
+      throttleRetryAfter: null,
+    })
+    expect(fixture.update).not.toHaveProperty('lastHistoryId')
+    expect(clearCredentialReauth).toHaveBeenCalledWith(CHANNEL)
+    expect(clearImportCache).toHaveBeenCalledWith(CHANNEL)
+  })
+
+  it('clears the history cursor only on a full resync', async () => {
+    await recoverChannel(ctx, CHANNEL, { fullResync: true })
+
+    expect(fixture.update?.lastHistoryId).toBeNull()
+  })
+
+  it('invalidates the channel cache after the metadata write, not before', async () => {
+    const order: string[] = []
+    onCacheEvent.mockImplementation(async () => {
+      order.push(`cache:${fixture.update ? 'after-write' : 'before-write'}`)
+    })
+
+    await recoverChannel(ctx, CHANNEL)
+
+    expect(order).toEqual(['cache:after-write'])
+  })
+
+  it('propagates a failed ownership check without writing', async () => {
+    const { NotFoundError } = await import('../../errors')
+    vi.doMock('../internal/validate', () => ({
+      validateChannelOwnership: async () => ({ ok: false, error: new NotFoundError('nope') }),
+    }))
+    vi.resetModules()
+    const { recoverChannel: fresh } = await import('../recover')
+
+    const result = await fresh(ctx, CHANNEL)
+
+    expect(result.ok).toBe(false)
+    expect(fixture.update).toBeNull()
+    vi.doUnmock('../internal/validate')
+    vi.resetModules()
+  })
+})

--- a/packages/lib/src/channels/index.ts
+++ b/packages/lib/src/channels/index.ts
@@ -25,6 +25,7 @@ export {
   provisionPersonalInbox,
   supportsPersonalChannelConnection,
 } from './personal-connection'
+export { type RecoverChannelResult, recoverChannel } from './recover'
 export { registerChannelHooks } from './register-hooks'
 export {
   addExcludedSender,

--- a/packages/lib/src/channels/internal/auth-metadata.ts
+++ b/packages/lib/src/channels/internal/auth-metadata.ts
@@ -1,0 +1,21 @@
+// packages/lib/src/channels/internal/auth-metadata.ts
+
+/**
+ * Drop the `auth` block from an `Integration.metadata` blob.
+ *
+ * That block is failure state owned by `AuthErrorHandler`: the last classified
+ * error plus `consecutiveFailures`, the counter that flips `enabled` to false
+ * once it reaches `DISABLE_THRESHOLD`. Nothing clears it except a *successful
+ * sync* — which a disabled channel can never run — so every path that proves the
+ * credential works again has to drop it explicitly. Leaving it behind means the
+ * counter survives the recovery and the next single auth blip re-disables the
+ * channel on its first strike.
+ */
+export function withAuthFailuresCleared(metadata: unknown): Record<string, unknown> {
+  const base =
+    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      ? { ...(metadata as Record<string, unknown>) }
+      : {}
+  delete base.auth
+  return base
+}

--- a/packages/lib/src/channels/provisioning-hook.ts
+++ b/packages/lib/src/channels/provisioning-hook.ts
@@ -19,6 +19,7 @@ import { publisher } from '../events'
 import { InboxService } from '../inboxes/inbox-service'
 import { GoogleOAuthService } from '../providers/google/google-oauth'
 import { assertSharedConnectInbox } from './connect-inbox'
+import { withAuthFailuresCleared } from './internal/auth-metadata'
 import { provisionPersonalInbox } from './personal-connection'
 
 const logger = createScopedLogger('channel-provisioning-hook')
@@ -184,6 +185,11 @@ async function assertConnectScope(args: {
  * is healthy again, so a prior `FAILED` must not stick: it both shows a stale "Sync Error" badge
  * and — for webhook-mode channels, which the polling relaunch job skips — would never recover on
  * its own. Reset to the clean `NOT_SYNCED` / `IDLE` baseline so the next push or poll resumes.
+ *
+ * The auth-failure block goes with it. `enabled: true` alone would re-open a channel still
+ * carrying `metadata.auth.consecutiveFailures` at or above the auto-disable threshold, and the
+ * only thing that clears that counter is a successful sync — so the first transient auth error
+ * after the re-consent would disable the channel again on its first strike.
  */
 async function upsertIntegration(args: {
   organizationId: string
@@ -218,7 +224,7 @@ async function upsertIntegration(args: {
         credentialId,
         email,
         enabled: true,
-        metadata: mergeMetadata(existing.metadata, metadataPatch) as any,
+        metadata: withAuthFailuresCleared(mergeMetadata(existing.metadata, metadataPatch)) as any,
         syncStatus: 'NOT_SYNCED',
         syncStage: 'IDLE',
         syncStageStartedAt: null,

--- a/packages/lib/src/channels/recover.ts
+++ b/packages/lib/src/channels/recover.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/channels/recover.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
+import { clearImportCache } from '../email/polling-import-cache'
+import type { NotFoundError } from '../errors'
+import { createScopedLogger } from '../logger'
+import { clearCredentialReauth } from '../providers/credential-auth-state'
+import { Result, type TypedResult } from '../result'
+import { withAuthFailuresCleared } from './internal/auth-metadata'
+import { validateChannelOwnership } from './internal/validate'
+import { toggle } from './toggle'
+import type { ChannelCtx } from './types'
+
+const logger = createScopedLogger('channels.recover')
+
+export interface RecoverChannelResult {
+  success: true
+  /** The channel was auto-disabled by auth failures and has been switched back on. */
+  reEnabled: boolean
+}
+
+/**
+ * Bring a channel back to a healthy baseline after the user re-authenticates it.
+ *
+ * Called on every successful reconnect, including the *silent* token refresh
+ * that `useConnectFlow.attemptRefreshThenOAuth` tries first. That path matters
+ * most: it never reaches the OAuth callback, so the post-connect provisioning
+ * hook — the only other code that re-enables an existing channel — never runs.
+ * Without this the user reconnects, is told it worked, and every sync still
+ * fails with "Cannot sync messages for disabled channel", with no way back
+ * other than finding the Enable item in the card menu.
+ *
+ * Recovery covers all three pieces of stuck state, because each one alone is
+ * enough to keep mail from flowing:
+ *  - `enabled` — flipped false by `AuthErrorHandler` after `DISABLE_THRESHOLD`
+ *    reauth-class failures. Re-enabled through `toggle` so the provider's
+ *    webhook is re-armed: a channel dark long enough to be auto-disabled has
+ *    outlived its Gmail watch, and nothing else re-arms it on this path.
+ *  - `metadata.auth` — the failure counter behind that flip (see
+ *    {@link withAuthFailuresCleared}).
+ *  - the sync breaker — `syncStatus`/`syncStage`/`throttle*`, which otherwise
+ *    keeps showing "Sync Error" and, in webhook mode, never self-heals because
+ *    the polling relaunch job skips those rows.
+ *
+ * Re-enabling is unconditional rather than gated on "was it auto-disabled":
+ * pressing Reconnect *is* the request for a working channel, and the action is
+ * only offered on a channel that needs re-auth in the first place.
+ */
+export async function recoverChannel(
+  ctx: ChannelCtx,
+  channelId: string,
+  options: { fullResync?: boolean } = {}
+): Promise<TypedResult<RecoverChannelResult, NotFoundError>> {
+  const validated = await validateChannelOwnership(ctx, channelId)
+  if (!validated.ok) return validated
+  const channel = validated.value
+
+  const reEnabled = !channel.enabled
+  if (reEnabled) {
+    const toggled = await toggle(ctx, channelId, true)
+    if (!toggled.ok) return toggled
+  }
+
+  await clearImportCache(channelId)
+
+  await ctx.db
+    .update(schema.Integration)
+    .set({
+      syncStatus: 'ACTIVE',
+      syncStage: 'IDLE',
+      syncStageStartedAt: null,
+      throttleFailureCount: 0,
+      throttleRetryAfter: null,
+      ...(options.fullResync ? { lastHistoryId: null } : {}),
+      metadata: withAuthFailuresCleared(channel.metadata) as never,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.Integration.id, channelId))
+
+  await clearCredentialReauth(channelId)
+
+  // After the metadata write, not before: `toggle`'s own invalidation fires
+  // while the stale `auth` block is still on the row, and the cached channel
+  // list carries both `metadata` and `enabled`.
+  await onCacheEvent('channel.toggled', { orgId: ctx.organizationId })
+
+  logger.info('Channel recovered after reconnect', {
+    channelId,
+    provider: channel.provider,
+    reEnabled,
+    fullResync: !!options.fullResync,
+  })
+
+  return Result.ok({ success: true, reEnabled })
+}

--- a/packages/lib/src/providers/google/google-provider.ts
+++ b/packages/lib/src/providers/google/google-provider.ts
@@ -830,79 +830,108 @@ export class GoogleProvider
     const deletedMessageIds: string[] = []
     let newHistoryId = lastHistoryId || '0'
 
-    if (lastHistoryId && !since) {
+    // A cursor older than Gmail's history retention (roughly a week) makes
+    // `history.list` 404. That is the normal state of any channel that has been
+    // dark for a while — auto-disabled by auth failures, throttled, or just
+    // reconnected — so it must degrade to a re-list rather than fail the sync.
+    // Mirrors the fallback `syncGmailMessages` already performs on the manual path.
+    let useHistory = !!lastHistoryId && !since
+    let listSince = since
+
+    if (useHistory) {
       // Incremental sync via History API
       let nextPageToken: string | undefined | null
-      let highestHistoryId = BigInt(lastHistoryId)
+      let highestHistoryId = BigInt(lastHistoryId!)
 
-      do {
-        const historyResponse = await executeWithThrottle(
-          'gmail.history.list',
-          async () =>
-            this.gmail!.users.history.list({
-              userId: 'me',
-              startHistoryId: highestHistoryId.toString(),
-              pageToken: nextPageToken ?? undefined,
-              historyTypes: ['messageAdded', 'messageDeleted', 'labelRemoved'],
-            }),
-          {
-            userId: this.integrationId!,
-            throttler: this.throttler!,
-            cost: getGmailQuotaCost('history.list'),
-            queue: true,
-            priority: 5,
-          }
-        )
+      try {
+        do {
+          const historyResponse = await executeWithThrottle(
+            'gmail.history.list',
+            async () =>
+              this.gmail!.users.history.list({
+                userId: 'me',
+                startHistoryId: highestHistoryId.toString(),
+                pageToken: nextPageToken ?? undefined,
+                historyTypes: ['messageAdded', 'messageDeleted', 'labelRemoved'],
+              }),
+            {
+              userId: this.integrationId!,
+              throttler: this.throttler!,
+              cost: getGmailQuotaCost('history.list'),
+              queue: true,
+              priority: 5,
+            }
+          )
 
-        const historyRecords = historyResponse.data.history || []
+          const historyRecords = historyResponse.data.history || []
 
-        for (const record of historyRecords) {
-          if (record.messagesAdded) {
-            for (const msgAdded of record.messagesAdded) {
-              if (msgAdded.message?.id) {
-                addedMessageIds.push(msgAdded.message.id)
+          for (const record of historyRecords) {
+            if (record.messagesAdded) {
+              for (const msgAdded of record.messagesAdded) {
+                if (msgAdded.message?.id) {
+                  addedMessageIds.push(msgAdded.message.id)
+                }
               }
             }
-          }
-          if (record.messagesDeleted) {
-            for (const msgDeleted of record.messagesDeleted) {
-              if (msgDeleted.message?.id) {
-                deletedMessageIds.push(msgDeleted.message.id)
+            if (record.messagesDeleted) {
+              for (const msgDeleted of record.messagesDeleted) {
+                if (msgDeleted.message?.id) {
+                  deletedMessageIds.push(msgDeleted.message.id)
+                }
               }
             }
-          }
-          // Treat INBOX label removal as deletion (archived messages)
-          if (record.labelsRemoved) {
-            for (const labelChange of record.labelsRemoved) {
-              if (labelChange.labelIds?.includes('INBOX') && labelChange.message?.id) {
-                deletedMessageIds.push(labelChange.message.id)
+            // Treat INBOX label removal as deletion (archived messages)
+            if (record.labelsRemoved) {
+              for (const labelChange of record.labelsRemoved) {
+                if (labelChange.labelIds?.includes('INBOX') && labelChange.message?.id) {
+                  deletedMessageIds.push(labelChange.message.id)
+                }
               }
             }
+            const recordHistoryId = BigInt(record.id ?? '0')
+            if (recordHistoryId > highestHistoryId) {
+              highestHistoryId = recordHistoryId
+            }
           }
-          const recordHistoryId = BigInt(record.id ?? '0')
-          if (recordHistoryId > highestHistoryId) {
-            highestHistoryId = recordHistoryId
+
+          if (historyRecords.length === 0 && historyResponse.data.historyId) {
+            const currentHistoryId = BigInt(historyResponse.data.historyId)
+            if (currentHistoryId > highestHistoryId) {
+              highestHistoryId = currentHistoryId
+            }
           }
-        }
 
-        if (historyRecords.length === 0 && historyResponse.data.historyId) {
-          const currentHistoryId = BigInt(historyResponse.data.historyId)
-          if (currentHistoryId > highestHistoryId) {
-            highestHistoryId = currentHistoryId
-          }
-        }
+          nextPageToken = historyResponse.data.nextPageToken
+        } while (nextPageToken)
 
-        nextPageToken = historyResponse.data.nextPageToken
-      } while (nextPageToken)
+        newHistoryId = highestHistoryId.toString()
+      } catch (error) {
+        const status =
+          (error as { response?: { status?: number }; status?: number })?.response?.status ??
+          (error as { status?: number })?.status
+        if (status !== 404) throw error
 
-      newHistoryId = highestHistoryId.toString()
-    } else {
+        // Expired cursor: re-list instead. `listSince` stays undefined so the
+        // window isn't silently narrowed — anything already imported is deduped
+        // downstream, but a message dropped here is never seen again.
+        logger.warn('History ID expired (404) — falling back to full message list', {
+          integrationId: this.integrationId,
+          expiredHistoryId: lastHistoryId,
+        })
+        useHistory = false
+        listSince = undefined
+        addedMessageIds.length = 0
+        deletedMessageIds.length = 0
+      }
+    }
+
+    if (!useHistory) {
       // Full sync via Message List API. Empty `q` (combined with the existing
       // `includeSpamTrash: false` below) pulls INBOX + SENT + every other
       // non-trash/non-spam label — `in:inbox` would silently drop the user's
       // own SENT messages, which the polling pipeline relies on to thread
       // outbound replies and create recipient contacts.
-      const query = since ? `after:${Math.floor(since.getTime() / 1000)}` : ''
+      const query = listSince ? `after:${Math.floor(listSince.getTime() / 1000)}` : ''
       let nextPageToken: string | undefined | null
       let highestHistoryId = BigInt(0)
       let pageCount = 0


### PR DESCRIPTION
## The bug

A channel auto-disabled by auth failures could never be recovered from the UI.

`AuthErrorHandler` flips `Integration.enabled` to false after `DISABLE_THRESHOLD` reauth-class failures. The only code that ever set it back to true was the post-connect provisioning hook's relink branch — and that runs on the **full OAuth callback only**. `useChannelReconnect` tries a *silent* `connections.refreshTokens` first, which succeeds whenever the refresh grant is still alive, so the popup never opens and the hook never runs.

The result, hit in dev on a Gmail channel that had tripped on Workspace `invalid_rapt`:

1. Reconnect → silent refresh succeeds → success reported, credential's `requiresReauth` cleared.
2. Sync messages → `400 Cannot sync messages for disabled channel`.
3. Reconnect is now *hidden* (the card only offers it when `requiresReauth`), so there's no way back short of finding **Enable** in the three-dot menu.

`resetSyncState` — added to patch exactly this silent-refresh gap — reset `syncStatus`/`syncStage`/`throttle*` but not `enabled`.

## The fix

Replace `resetSyncState` with `recoverChannel`, which moves all the stuck state together:

- **`enabled`** — restored via `toggle`, not a bare column write, so the provider webhook is re-armed. A channel dark long enough to be auto-disabled has outlived its Gmail watch, and nothing else re-arms it on this path.
- **`metadata.auth`** — dropped. It carries `consecutiveFailures`, the counter behind the auto-disable, and the only thing that clears it is a *successful sync* — which a disabled channel can never run. Leaving it meant the next single auth blip disabled the channel again on its first strike. The provisioning hook's relink branch strips it too, so a full re-consent isn't left carrying the same trap.
- **the sync breaker**, the Redis import cache, and the credential's reauth flag.

Cache invalidation moves *after* the metadata write: `toggle` fires its own `channel.toggled` while the stale auth block is still on the row, and the cached channel list carries both `metadata` and `enabled`.

Re-enabling is unconditional rather than gated on an "auto-disabled" marker — pressing Reconnect *is* the request for a working channel, and the action is only offered on a channel that needs re-auth.

## Also

`GoogleProvider.fetchMessageIds` gets the expired-cursor fallback `syncGmailMessages` already has. A `lastHistoryId` older than Gmail's history retention 404s, which is the normal state of any channel that has been dark — so the polling path re-lists instead of failing the sync. Without it, a recovered channel re-enables and then dies on its stale cursor.

## Verification

- New `recover.test.ts` (7 tests) pins the two properties that matter: a disabled channel comes back on *through `toggle`*, and the auth block is gone from the metadata write.
- `packages/lib` channels suite 42/42, providers 178/178; `tsc --noEmit` clean on all changed files in `packages/lib` and `apps/web`.
- Verified end-to-end against the dev DB on the channel that surfaced this: `enabled false → true`, auth block gone, `throttleFailureCount 0`, credential `requiresReauth false`, and a sync entering `MESSAGE_LIST_FETCH` on the click.