### PR TITLE
feat(mail): rework mail categories, editable definitions, and retroactive classification

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/tags/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/tags/page.tsx
@@ -30,9 +30,10 @@ async function TagsPage() {
           description={
             <>
               Open any tag and turn on <span className='font-medium'>Let AI apply this tag</span> to
-              add it to the set Auxx may apply to incoming mail — its description tells the
-              classifier when it fits. Nothing is classified until you also switch a specific inbox
-              on.
+              add it to the set Auxx may apply to incoming mail. Its description tells the
+              classifier when it fits. For ready made categories, use{' '}
+              <span className='font-medium'>Add Tag &rsaquo; Suggested AI categories</span> below.
+              Nothing is classified until you also switch a specific inbox on.
             </>
           }
           action={

--- a/apps/web/src/components/inbox/ui/inbox-classification-card.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-classification-card.tsx
@@ -2,13 +2,15 @@
 
 'use client'
 
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { ToggleCard } from '@auxx/ui/components/toggle-card'
-import { Sparkles } from 'lucide-react'
+import { Sparkles, TriangleAlert } from 'lucide-react'
 import Link from 'next/link'
 import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
+import { InboxReclassifyRow } from './inbox-reclassify-row'
 
 /**
  * The per-inbox mail-classification opt-in
@@ -30,6 +32,11 @@ import { api } from '~/trpc/react'
  *   inbox is completely inert — so the switch is disabled and says why, rather
  *   than flipping on and looking like it worked.
  * - **What it costs.** Metered per inbound message, zero on your own key.
+ * - **Whether it is currently working.** With the balance empty every inbound
+ *   message fails its model call and is left untagged — and because the
+ *   classifier runs in the background, nobody finds out. Every other AI surface
+ *   reports this by interrupting a human mid-action; this one has no human to
+ *   interrupt, so the card has to say it.
  */
 export function InboxClassificationCard({ inboxId }: { inboxId: string }) {
   const utils = api.useUtils()
@@ -50,7 +57,7 @@ export function InboxClassificationCard({ inboxId }: { inboxId: string }) {
     )
   }
 
-  const { enabled, eligibleTagCount } = data
+  const { enabled, eligibleTagCount, creditsExhausted } = data
   const hasEligibleTags = eligibleTagCount > 0
 
   return (
@@ -58,6 +65,19 @@ export function InboxClassificationCard({ inboxId }: { inboxId: string }) {
       icon={Sparkles}
       title='AI classification'
       description='Let Auxx categorise new mail in this inbox by applying your tags.'>
+      {/* Only when it is actually costing something: an inbox that is switched
+          off is not being stopped by anything, and saying so there would just be
+          noise on a page nobody came to for billing. */}
+      {enabled && creditsExhausted ? (
+        <Alert variant='warning' className='mb-3'>
+          <TriangleAlert />
+          <AlertDescription>
+            Classification is paused. Your organization is out of AI credits. Incoming mail is being
+            delivered as normal but is not being tagged. Credits refill at the start of your next
+            billing cycle, and mail that arrives before then is not classified later.
+          </AlertDescription>
+        </Alert>
+      ) : null}
       <ToggleCard
         title='Classify incoming mail'
         icon={<Sparkles className='size-3.5' />}
@@ -103,6 +123,12 @@ export function InboxClassificationCard({ inboxId }: { inboxId: string }) {
           </>
         }
       />
+      {/* The backlog row (07 §3.1) — only once the toggle is on, because the
+          classifier's own double guard (C8) means a switched-off inbox has
+          nothing it may legally run. It hides itself when there is no backlog.
+          ⚠️ Enabling the toggle makes it appear immediately; that IS the prompt,
+          and the cost dialog is never auto-opened (07 invariant 12). */}
+      {enabled ? <InboxReclassifyRow inboxId={inboxId} /> : null}
     </SettingsSection>
   )
 }

--- a/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.test.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.test.tsx
@@ -1,0 +1,271 @@
+// apps/web/src/components/inbox/ui/inbox-reclassify-dialog.test.tsx
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The scope dialog (07 §3.2) and the sample results that replace its body
+ * (07 §3.3).
+ *
+ * Four rules here are the kind that quietly stop being true and never show up in
+ * a screenshot of the happy path:
+ *
+ *  - **The "this does not run your filters" line** (07 invariant 11). Without it
+ *    "classify existing mail" reads as "apply my automations to old mail", and
+ *    the user goes looking for assignments that will never happen.
+ *  - **A capped count is never rendered as a bare number** (07 invariant 8 /
+ *    R-Q5). `5,000` implies completeness; `5,000 of 5,000+` does not.
+ *  - **A label the model never chose still renders, at zero** (07 §3.3 / `06-…`
+ *    Q1). The zero row IS the finding — a label never chosen in a sample is a
+ *    label to merge — so filtering it out deletes the evidence.
+ *  - **Abstention is a row, not a footnote** (07 §2.11). It is the single most
+ *    informative number in the report.
+ */
+
+const h = vi.hoisted(() => ({
+  preview: {
+    count: 412,
+    capped: false,
+    cap: 5000,
+    eligibleTagCount: 4,
+    estimatedCredits: 3790,
+    sampleSize: 100,
+    sampleCredits: 920,
+    syncInProgress: false,
+  } as Record<string, unknown> | null,
+  previewPending: false,
+  previewError: null as { message: string } | null,
+  status: null as Record<string, unknown> | null,
+  startSample: vi.fn(),
+  invalidate: vi.fn(),
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      mailClassification: { getReclassifySampleStatus: { invalidate: h.invalidate } },
+    }),
+    mailClassification: {
+      getReclassifyPreview: {
+        useQuery: () => ({
+          data: h.preview,
+          isPending: h.previewPending,
+          error: h.previewError,
+        }),
+      },
+      getReclassifySampleStatus: { useQuery: () => ({ data: h.status }) },
+      startReclassifySample: {
+        useMutation: () => ({ mutate: h.startSample, isPending: false }),
+      },
+    },
+  },
+}))
+
+/**
+ * `next/link` prefetch does `new IntersectionObserver(...)`, and the global stub
+ * in `src/test/setup.ts` is a `vi.fn().mockImplementation(() => ({…}))` — not a
+ * valid constructor, exactly the failure that file already documents for
+ * `ResizeObserver`. The results view is the only surface here with a link, so it
+ * is swapped for the anchor it renders anyway.
+ */
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const { InboxReclassifyDialog } = await import('./inbox-reclassify-dialog')
+
+const open = () => render(<InboxReclassifyDialog inboxId='ibx_1' open onOpenChange={vi.fn()} />)
+
+/** A completed sample whose `Account` label was never chosen. */
+const report = {
+  inboxId: 'ibx_1',
+  mode: 'fill-gaps',
+  requested: 100,
+  selected: 100,
+  inferred: 100,
+  classified: 74,
+  abstained: 26,
+  abstentionRate: 0.26,
+  meanConfidence: 0.81,
+  labels: [
+    { tagId: 't_support', title: 'Support', count: 34, meanConfidence: 0.88 },
+    { tagId: 't_sales', title: 'Sales', count: 22, meanConfidence: 0.79 },
+    { tagId: 't_billing', title: 'Billing', count: 12, meanConfidence: 0.74 },
+    { tagId: 't_orders', title: 'Order Status', count: 6, meanConfidence: 0.71 },
+    { tagId: 't_account', title: 'Account', count: 0, meanConfidence: 0 },
+  ],
+  skipped: {},
+  abstainedByReason: { 'no-category': 26 },
+  applied: false,
+}
+
+beforeEach(() => {
+  h.preview = {
+    count: 412,
+    capped: false,
+    cap: 5000,
+    eligibleTagCount: 4,
+    estimatedCredits: 3790,
+    sampleSize: 100,
+    sampleCredits: 920,
+    syncInProgress: false,
+  }
+  h.previewPending = false
+  h.previewError = null
+  h.status = null
+})
+
+describe('InboxReclassifyDialog — the scope form', () => {
+  it('says out loud that mail filters do not run on the backlog', () => {
+    open()
+
+    expect(screen.getByText(/Your mail filters do not run on them/i)).toBeInTheDocument()
+    expect(screen.getByText(/nothing is assigned, archived or answered/i)).toBeInTheDocument()
+  })
+
+  it('previews the thread count, the estimated credits and the sample cost', () => {
+    open()
+
+    expect(screen.getByText('412 conversations')).toBeInTheDocument()
+    expect(screen.getByText(/~3,790 credits/)).toBeInTheDocument()
+    expect(screen.getByText(/a sample of 100 costs ~920/)).toBeInTheDocument()
+  })
+
+  /** ⚠️ Never a bare number past the cap — that reads as "covered everything". */
+  it('renders a capped count as "5,000 of 5,000+", never as 5,000', () => {
+    h.preview = { ...(h.preview as object), count: 5000, capped: true, cap: 5000 }
+    open()
+
+    expect(screen.getByText('5,000 of 5,000+ conversations')).toBeInTheDocument()
+    expect(screen.getByText(/Run it again to reach further back/i)).toBeInTheDocument()
+  })
+
+  /** The `null` branch: no default model, or no registry price for it. */
+  it('says "metered per conversation" rather than inventing a credit figure', () => {
+    h.preview = { ...(h.preview as object), estimatedCredits: null, sampleCredits: null }
+    open()
+
+    expect(screen.getAllByText(/metered per conversation/i).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/credits/)).not.toBeInTheDocument()
+  })
+
+  /** 07 R4 — the only place a user can accidentally pay twice. */
+  it('carries the double-billing distinction in the mode copy', () => {
+    open()
+
+    expect(screen.getByText(/Never charges twice/i)).toBeInTheDocument()
+    expect(screen.getByText(/Charges again for those conversations/i)).toBeInTheDocument()
+  })
+
+  it('starts a sample with the current scope', async () => {
+    open()
+
+    await userEvent.click(screen.getByRole('button', { name: /Try a sample of 100/i }))
+
+    expect(h.startSample).toHaveBeenCalledWith({
+      inboxId: 'ibx_1',
+      range: { kind: 'days', days: 30 },
+      mode: 'fill-gaps',
+    })
+  })
+
+  /** 07 R-Q8 — a run started mid-backfill misses everything still arriving. */
+  it('refuses to offer the sample while the inbox is still syncing', () => {
+    h.preview = { ...(h.preview as object), syncInProgress: true }
+    open()
+
+    expect(screen.getByRole('button', { name: /Try a sample of 100/i })).toBeDisabled()
+    expect(screen.getByText(/This inbox is still syncing/i)).toBeInTheDocument()
+  })
+
+  it('refuses to offer the sample when the scope is empty', () => {
+    h.preview = { ...(h.preview as object), count: 0, sampleSize: 0 }
+    open()
+
+    expect(screen.getByRole('button', { name: /Try a sample of/i })).toBeDisabled()
+    expect(screen.getByText(/Nothing to classify in this range/i)).toBeInTheDocument()
+  })
+})
+
+describe('InboxReclassifyDialog — sample results (07 §3.3)', () => {
+  beforeEach(() => {
+    h.status = { jobId: 'j1', state: 'completed', processed: 100, total: 100, report }
+  })
+
+  it('leads with the classified / no-category split', () => {
+    open()
+
+    expect(
+      screen.getByText(/Sampled 100 conversations · 74 classified · 26 no category/i)
+    ).toBeInTheDocument()
+  })
+
+  /** ⚠️ The zero row IS the finding (`06-…` Q1) — a never-chosen label is one to merge. */
+  it('renders a label the model never chose, at zero', () => {
+    open()
+
+    expect(screen.getByText('Account')).toBeInTheDocument()
+    const row = screen.getByText('Account').parentElement
+    expect(row?.textContent).toContain('0')
+  })
+
+  /** ⚠️ Abstention is the single most informative number, so it is a ROW. */
+  it('renders "No category" as its own row', () => {
+    open()
+
+    expect(screen.getByText('No category')).toBeInTheDocument()
+  })
+
+  /** Without this the user has the evidence and nowhere to act on it. */
+  it('links to the categories so the sample loop can close', () => {
+    open()
+
+    expect(screen.getByRole('link', { name: /Adjust my categories/i })).toHaveAttribute(
+      'href',
+      '/app/settings/tags'
+    )
+  })
+
+  it('offers a re-sample rather than a size control', async () => {
+    open()
+
+    await userEvent.click(screen.getByRole('button', { name: /Sample again/i }))
+    expect(h.startSample).toHaveBeenCalled()
+  })
+
+  /** 07 invariant 9 — nothing was applied, so there is nothing to undo. */
+  it('states that nothing was applied and nothing was marked', () => {
+    open()
+
+    expect(screen.getByText(/Nothing was applied and nothing was marked/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument()
+  })
+
+  it('says how many never reached the model rather than implying a full sample', () => {
+    h.status = {
+      jobId: 'j1',
+      state: 'completed',
+      processed: 100,
+      total: 100,
+      report: { ...report, selected: 100, inferred: 88 },
+    }
+    open()
+
+    expect(screen.getByText(/12 of them never reached the model/i)).toBeInTheDocument()
+  })
+})
+
+describe('InboxReclassifyDialog — while a sample runs', () => {
+  it('replaces the form with progress and offers no second start', () => {
+    h.status = { jobId: 'j1', state: 'active', processed: 34, total: 100 }
+    open()
+
+    expect(screen.getByText(/Classifying 34 of 100/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Try a sample/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.tsx
@@ -1,0 +1,447 @@
+// apps/web/src/components/inbox/ui/inbox-reclassify-dialog.tsx
+
+'use client'
+
+import {
+  MAIL_RECLASSIFY_DAY_PRESETS,
+  MAIL_RECLASSIFY_DEFAULT_MODE,
+  MAIL_RECLASSIFY_SAMPLE_SIZE,
+  MAIL_RECLASSIFY_THREAD_PRESETS,
+  type MailReclassifyMode,
+  type MailReclassifyRange,
+  type MailReclassifySampleReport,
+} from '@auxx/lib/mail-classification/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Label } from '@auxx/ui/components/label'
+import { Progress } from '@auxx/ui/components/progress'
+import { RadioGroup } from '@auxx/ui/components/radio-group'
+import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { ArrowRight, Layers, RefreshCw } from 'lucide-react'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { api, type RouterOutputs } from '~/trpc/react'
+
+/**
+ * "Classify existing mail" — the scope dialog (07 §3.2) and the sample results
+ * that replace its body in place (07 §3.3).
+ *
+ * ## The three things this dialog exists to be honest about
+ *
+ * - **It does not run your filters.** `plans/mail-filter/07-…` R2/§2.8: a
+ *   retroactive run tags and stops, because firing `assign`/`archive`/`run-agent`
+ *   over a historical backlog is the late-filter-action problem. What it buys is
+ *   analytics and search — labels on history, never routing. Most people read
+ *   "classify existing mail" as "apply my automations to old mail", so the
+ *   correction is stated at the point of action (07 invariant 11).
+ * - **What it will cost, before it costs it.** The count comes from the same
+ *   predicate the run pages over (07 invariant 10), so the number in the confirm
+ *   is the number being consented to.
+ * - **Which mode charges twice.** `Fill gaps` never re-bills; `Re-classify
+ *   everything` deliberately does. This is the only place a user can accidentally
+ *   pay for the same conversation twice, so the two options carry that in their
+ *   own copy (07 R4).
+ *
+ * ## Why the SAMPLE is the primary action
+ *
+ * 07 R6: sample mode ships first and is the primary CTA until a taxonomy is
+ * proven. ~100 conversations, distribution + abstention rate, applies nothing —
+ * that is what tells you whether the vocabulary is worth running over thousands
+ * of conversations at all. The full run is 07 phase 2 and is deliberately not
+ * offered here yet.
+ *
+ * ⚠️ This dialog is only ever opened by a click on the backlog row. It must never
+ * be auto-opened on opt-in (07 invariant 12) — a dialog asking for money one
+ * click after a toggle reads as a dark pattern, and the row is prompt enough.
+ */
+
+/** The `Select`'s value space — a range flattened to one string. */
+type RangeKey = `days:${number}` | `threads:${number}` | 'all-time'
+
+function toRange(key: RangeKey): MailReclassifyRange {
+  if (key === 'all-time') return { kind: 'all-time' }
+  const [kind, value] = key.split(':')
+  return kind === 'days'
+    ? { kind: 'days', days: Number(value) }
+    : { kind: 'threads', threads: Number(value) }
+}
+
+const DEFAULT_RANGE_KEY: RangeKey = 'days:30'
+
+const MODE_COPY: Record<MailReclassifyMode, { label: string; description: string }> = {
+  // ⚠️ 07 R4 — the cost distinction is the whole point of the copy.
+  'fill-gaps': {
+    label: 'Fill gaps',
+    description: 'Only conversations that have never been classified. Never charges twice.',
+  },
+  're-classify': {
+    label: 'Re-classify everything',
+    description:
+      'Also re-does conversations that were already classified. Use this after changing your categories. Charges again for those conversations.',
+  },
+}
+
+const n = (value: number) => value.toLocaleString()
+
+/** `5,000 of 5,000+` when capped — never a bare number that implies completeness. */
+function describeCount(count: number, capped: boolean): string {
+  const noun = count === 1 ? 'conversation' : 'conversations'
+  // ⚠️ 07 R-Q5 declines an exact total past the cap: the count query is bounded by
+  // `LIMIT cap + 1`, which is the only way it stays cheap, so anything beyond it
+  // is genuinely unknown. `5,000+` is the honest wording (07 invariant 8).
+  return capped ? `${n(count)} of ${n(count)}+ ${noun}` : `${n(count)} ${noun}`
+}
+
+export interface InboxReclassifyDialogProps {
+  inboxId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function InboxReclassifyDialog({ inboxId, open, onOpenChange }: InboxReclassifyDialogProps) {
+  const utils = api.useUtils()
+  const [rangeKey, setRangeKey] = useState<RangeKey>(DEFAULT_RANGE_KEY)
+  const [mode, setMode] = useState<MailReclassifyMode>(MAIL_RECLASSIFY_DEFAULT_MODE)
+
+  // Dialogs do not carry stale state into a fresh open — and re-opening after a
+  // sample must show the scope form again, not last week's numbers.
+  useEffect(() => {
+    if (!open) return
+    setRangeKey(DEFAULT_RANGE_KEY)
+    setMode(MAIL_RECLASSIFY_DEFAULT_MODE)
+  }, [open])
+
+  const range = toRange(rangeKey)
+
+  const preview = api.mailClassification.getReclassifyPreview.useQuery(
+    { inboxId, range, mode },
+    { enabled: open }
+  )
+
+  // The SAME query key the backlog row polls, so the two surfaces share one poll
+  // and can never disagree about whether a sample is running.
+  const status = api.mailClassification.getReclassifySampleStatus.useQuery(
+    { inboxId },
+    {
+      enabled: open,
+      refetchInterval: (query) => {
+        const state = query.state.data?.state
+        return state === 'waiting' || state === 'active' || state === 'delayed' ? 2000 : false
+      },
+    }
+  )
+
+  const startSample = api.mailClassification.startReclassifySample.useMutation({
+    onSuccess: () => utils.mailClassification.getReclassifySampleStatus.invalidate({ inboxId }),
+    onError: (error) =>
+      toastError({ title: 'Error starting the sample', description: error.message }),
+  })
+
+  const running =
+    status.data?.state === 'waiting' ||
+    status.data?.state === 'active' ||
+    status.data?.state === 'delayed'
+  const report = status.data?.state === 'completed' ? status.data.report : undefined
+
+  const handleSample = () => startSample.mutate({ inboxId, range, mode })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc' size='md'>
+        <DialogHeader>
+          <DialogTitle>Classify existing mail</DialogTitle>
+          <DialogDescription>
+            Labels conversations already in this inbox so you can search and report on them.{' '}
+            {/* ⚠️ 07 invariant 11 — not optional. Without it "classify existing
+                mail" reads as "apply my automations to old mail". */}
+            <strong className='font-medium'>Your mail filters do not run on them</strong>. Nothing
+            is assigned, archived or answered.
+          </DialogDescription>
+        </DialogHeader>
+
+        {running ? (
+          <SampleProgress
+            processed={status.data?.processed ?? 0}
+            total={status.data?.total ?? MAIL_RECLASSIFY_SAMPLE_SIZE}
+          />
+        ) : report ? (
+          <SampleResults report={report} />
+        ) : (
+          <div className='space-y-4'>
+            <div className='space-y-1.5'>
+              <Label htmlFor='reclassify-range'>How far back</Label>
+              <Select value={rangeKey} onValueChange={(value) => setRangeKey(value as RangeKey)}>
+                <SelectTrigger id='reclassify-range' size='sm' className='w-full'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MAIL_RECLASSIFY_DAY_PRESETS.map((days) => (
+                    <SelectItem key={days} value={`days:${days}`}>
+                      Last {days} days
+                    </SelectItem>
+                  ))}
+                  {MAIL_RECLASSIFY_THREAD_PRESETS.map((threads) => (
+                    <SelectItem key={threads} value={`threads:${threads}`}>
+                      The {n(threads)} most recent conversations
+                    </SelectItem>
+                  ))}
+                  <SelectItem value='all-time'>All time</SelectItem>
+                </SelectContent>
+              </Select>
+              {/* Newest first, always (07 invariant 8) — so a cancelled or capped
+                  run got the part that mattered, and "the 500 most recent" is a
+                  thing a user can picture. */}
+              <p className='text-xs text-muted-foreground'>
+                {rangeKey === 'all-time'
+                  ? 'Every conversation in this inbox, newest first. This can reach back years, so check the count below before you start.'
+                  : 'Newest conversations first.'}
+              </p>
+            </div>
+
+            <RadioGroup
+              value={mode}
+              onValueChange={(value) => setMode(value as MailReclassifyMode)}
+              className='gap-2'>
+              {(['fill-gaps', 're-classify'] as const).map((option) => (
+                <RadioGroupItemCard
+                  key={option}
+                  value={option}
+                  icon={option === 'fill-gaps' ? <Layers /> : <RefreshCw />}
+                  label={MODE_COPY[option].label}
+                  description={MODE_COPY[option].description}
+                />
+              ))}
+            </RadioGroup>
+
+            <PreviewLine
+              isPending={preview.isPending}
+              error={preview.error?.message ?? null}
+              data={preview.data ?? null}
+            />
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={startSample.isPending}>
+            {running || report ? 'Close' : 'Cancel'}{' '}
+            <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+
+          {report ? (
+            <>
+              {/* Closes the loop 07 §3.3 needs: sample → see it is wrong → fix the
+                  vocabulary → sample again. Without it the user has the evidence
+                  and nowhere to act on it. */}
+              <Button variant='ghost' size='sm' asChild>
+                <Link href='/app/settings/tags'>
+                  Adjust my categories <ArrowRight />
+                </Link>
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={handleSample}
+                loading={startSample.isPending}
+                loadingText='Starting...'
+                data-dialog-submit>
+                Sample again <KbdSubmit variant='outline' size='sm' />
+              </Button>
+            </>
+          ) : running ? null : (
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={handleSample}
+              loading={startSample.isPending}
+              loadingText='Starting...'
+              disabled={
+                preview.isPending || !preview.data?.count || preview.data.syncInProgress === true
+              }
+              data-dialog-submit>
+              Try a sample of {n(preview.data?.sampleSize ?? MAIL_RECLASSIFY_SAMPLE_SIZE)}{' '}
+              <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type Preview = RouterOutputs['mailClassification']['getReclassifyPreview']
+
+/**
+ * `412 conversations · ~830 credits`, recomputed on every scope change.
+ *
+ * ⚠️ The credit figure is an ESTIMATE against the org's own default model, not a
+ * quote — the real charge is metered from actual usage. When the model has no
+ * registry price the router answers `null` and this says "metered per
+ * conversation" rather than inventing a number.
+ */
+function PreviewLine({
+  isPending,
+  error,
+  data,
+}: {
+  isPending: boolean
+  error: string | null
+  data: Preview | null
+}) {
+  if (isPending) return <Skeleton className='h-9 w-full rounded-lg' />
+  if (error) return <p className='text-xs text-destructive'>{error}</p>
+  if (!data) return null
+
+  return (
+    <div className='rounded-2xl border px-3 py-2 text-sm'>
+      {data.count === 0 ? (
+        <p className='text-muted-foreground'>
+          Nothing to classify in this range. Try a longer range, or switch to Re-classify
+          everything.
+        </p>
+      ) : (
+        <p>
+          <span className='font-medium'>{describeCount(data.count, data.capped)}</span>
+          {' · '}
+          <span className='text-muted-foreground'>
+            {data.estimatedCredits === null
+              ? 'metered per conversation'
+              : `~${n(data.estimatedCredits)} credits`}
+            {data.sampleCredits === null
+              ? ''
+              : ` · a sample of ${n(data.sampleSize)} costs ~${n(data.sampleCredits)}`}
+          </span>
+        </p>
+      )}
+      {data.capped ? (
+        <p className='mt-1 text-xs text-muted-foreground'>
+          One run covers at most {n(data.cap)} conversations, newest first. Run it again to reach
+          further back.
+        </p>
+      ) : null}
+      {/* 07 R-Q8 — a run started mid-backfill races the sync and misses
+          everything still arriving. */}
+      {data.syncInProgress ? (
+        <p className='mt-1 text-xs text-warning-600'>
+          This inbox is still syncing. Wait for it to finish, or the sample misses everything still
+          arriving.
+        </p>
+      ) : null}
+      <p className='mt-1 text-xs text-muted-foreground'>
+        Metered per conversation. Free when you bring your own API key.
+      </p>
+    </div>
+  )
+}
+
+function SampleProgress({ processed, total }: { processed: number; total: number }) {
+  const pct = total > 0 ? Math.min(100, Math.round((processed / total) * 100)) : 0
+  return (
+    <div className='space-y-2'>
+      <p className='text-sm'>
+        Classifying {n(processed)} of {n(total || MAIL_RECLASSIFY_SAMPLE_SIZE)}…
+      </p>
+      <Progress value={pct} />
+      <p className='text-xs text-muted-foreground'>
+        Nothing is applied while sampling. No tags are added and no conversation is marked as
+        classified.
+      </p>
+    </div>
+  )
+}
+
+/**
+ * The sample's distribution (07 §3.3).
+ *
+ * ⚠️ Two rows that MUST render even at zero, because each of them IS the finding:
+ *
+ * - **A label the model never chose.** `06-…` Q1 asks exactly this question, and a
+ *   zero row is the answer — a label never chosen in a representative sample is a
+ *   label to merge. Filtering it out deletes the evidence.
+ * - **"No category".** The abstention rate is the single most informative number
+ *   in the report (07 §2.11): high abstention means the vocabulary does not fit
+ *   this mail, or the threshold is wrong. It is a row, never a footnote.
+ *
+ * Nothing was applied, so there is no undo affordance here and no "sampled" state
+ * on any conversation (07 invariant 9).
+ */
+function SampleResults({ report }: { report: MailReclassifySampleReport }) {
+  const rows = [
+    ...report.labels.map((label) => ({
+      key: label.tagId,
+      title: label.title,
+      count: label.count,
+      meanConfidence: label.meanConfidence,
+      muted: false,
+    })),
+    {
+      key: '__abstained__',
+      title: 'No category',
+      count: report.abstained,
+      meanConfidence: 0,
+      muted: true,
+    },
+  ]
+  const max = Math.max(1, ...rows.map((row) => row.count))
+  const skipped = Math.max(0, report.selected - report.inferred)
+
+  return (
+    <div className='space-y-3'>
+      <p className='text-sm'>
+        Sampled {n(report.selected)} {report.selected === 1 ? 'conversation' : 'conversations'} ·{' '}
+        {n(report.classified)} classified · {n(report.abstained)} no category
+      </p>
+
+      <div className='space-y-1.5'>
+        {rows.map((row) => (
+          <div key={row.key} className='flex items-center gap-2 text-sm'>
+            <span className={`w-36 shrink-0 truncate ${row.muted ? 'text-muted-foreground' : ''}`}>
+              {row.title}
+            </span>
+            <span className='w-8 shrink-0 text-right tabular-nums'>{n(row.count)}</span>
+            <span className='h-2 min-w-0 flex-1'>
+              <span
+                className={`block h-2 rounded-full ${row.muted ? 'bg-muted-foreground/40' : 'bg-foreground/70'}`}
+                style={{ width: `${(row.count / max) * 100}%` }}
+              />
+            </span>
+            <span className='w-12 shrink-0 text-right text-xs text-muted-foreground tabular-nums'>
+              {row.count > 0 && !row.muted ? `${Math.round(row.meanConfidence * 100)}%` : ''}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className='text-xs text-muted-foreground'>
+        {/* Guard exits reduce the sample; 07 §2.11 requires saying so rather than
+            implying the full sample size. */}
+        {skipped > 0
+          ? `${n(skipped)} of them never reached the model: already classified, machine mail, or a failed call. `
+          : ''}
+        Nothing was applied and nothing was marked as classified, so a real run still covers all of
+        these.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/inbox/ui/inbox-reclassify-row.test.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-row.test.tsx
@@ -1,0 +1,134 @@
+// apps/web/src/components/inbox/ui/inbox-reclassify-row.test.tsx
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The backlog row (07 §3.1) — the WHOLE discovery mechanism for retroactive
+ * classification.
+ *
+ * There is no completion event left to hang a prompt on for an inbox that
+ * finished syncing last week (07 §2.9), so if this row is wrong the feature is
+ * invisible. Three rules, each of which fails silently:
+ *
+ *  - **The second line is required** (07 invariant 11). "Classify existing mail"
+ *    reads as "apply my automations to old mail" to most people.
+ *  - **The dialog is never auto-opened** (07 invariant 12). A dialog asking for
+ *    money one click after a toggle is a dark pattern; the row is the prompt.
+ *  - **A capped backlog reads `1,000+`** (07 R-Q5) — an order of magnitude for a
+ *    decision, not a billing figure.
+ */
+
+const h = vi.hoisted(() => ({
+  backlog: { count: 1204, capped: false, cap: 1000 } as Record<string, unknown> | undefined,
+  status: null as Record<string, unknown> | null,
+  cancel: vi.fn(),
+  invalidate: vi.fn(),
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      mailClassification: { getReclassifySampleStatus: { invalidate: h.invalidate } },
+    }),
+    mailClassification: {
+      getBacklog: { useQuery: () => ({ data: h.backlog }) },
+      getReclassifySampleStatus: { useQuery: () => ({ data: h.status }) },
+      cancelReclassifySample: { useMutation: () => ({ mutate: h.cancel, isPending: false }) },
+    },
+  },
+}))
+
+/**
+ * The dialog is exercised by its own file; here it is a marker, so this file
+ * asserts only WHEN it opens — which is the invariant-12 question.
+ */
+vi.mock('./inbox-reclassify-dialog', () => ({
+  InboxReclassifyDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid='reclassify-dialog' /> : null,
+}))
+
+const { InboxReclassifyRow } = await import('./inbox-reclassify-row')
+
+beforeEach(() => {
+  h.backlog = { count: 1204, capped: false, cap: 1000 }
+  h.status = null
+})
+
+describe('InboxReclassifyRow — the standing affordance', () => {
+  it('states the backlog and, REQUIRED, that filters will not run on it', () => {
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.getByText(/1,204 older conversations have never been classified/)).toBeVisible()
+    expect(
+      screen.getByText(
+        /Labels older mail for search and reporting\. Your filters will not run on it\./
+      )
+    ).toBeVisible()
+  })
+
+  /** ⚠️ 07 R-Q5 — past the cap the count is genuinely unknown, so it says so. */
+  it('renders a capped backlog as 1,000+', () => {
+    h.backlog = { count: 1000, capped: true, cap: 1000 }
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.getByText(/1,000\+ older conversations/)).toBeVisible()
+  })
+
+  it('disappears entirely when there is no backlog and nothing running', () => {
+    h.backlog = { count: 0, capped: false, cap: 1000 }
+    const { container } = render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  /** ⚠️ 07 invariant 12 — the row is the prompt, the dialog is a click away. */
+  it('never opens the cost dialog on its own', async () => {
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.queryByTestId('reclassify-dialog')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /Classify/i }))
+    expect(screen.getByTestId('reclassify-dialog')).toBeInTheDocument()
+  })
+})
+
+describe('InboxReclassifyRow — while a sample runs', () => {
+  beforeEach(() => {
+    h.status = { jobId: 'j1', state: 'active', processed: 340, total: 1204 }
+  })
+
+  it('becomes the progress surface with a cancel', async () => {
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.getByText(/Classifying a sample: 340 of 1,204/)).toBeVisible()
+
+    await userEvent.click(screen.getByRole('button', { name: /Cancel/i }))
+    expect(h.cancel).toHaveBeenCalledWith({ inboxId: 'ibx_1' })
+  })
+
+  /** A run in flight keeps the row alive even with the backlog counted at zero. */
+  it('stays visible while running even with an empty backlog', () => {
+    h.backlog = { count: 0, capped: false, cap: 1000 }
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.getByText(/Classifying a sample/)).toBeVisible()
+  })
+})
+
+describe('InboxReclassifyRow — after a sample', () => {
+  it('reports the outcome and offers the results, not another start', () => {
+    h.status = {
+      jobId: 'j1',
+      state: 'completed',
+      processed: 100,
+      total: 100,
+      report: { applied: false, selected: 100, classified: 74, abstained: 26, labels: [] },
+    }
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.getByText(/Sample finished: 74 of 100 got a category/)).toBeVisible()
+    expect(screen.getByRole('button', { name: /View results/i })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/inbox/ui/inbox-reclassify-row.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-row.tsx
@@ -1,0 +1,150 @@
+// apps/web/src/components/inbox/ui/inbox-reclassify-row.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Progress } from '@auxx/ui/components/progress'
+import { toastError } from '@auxx/ui/components/toast'
+import { useState } from 'react'
+import { api } from '~/trpc/react'
+import { InboxReclassifyDialog } from './inbox-reclassify-dialog'
+
+/**
+ * The backlog row on the AI classification card (07 §3.1).
+ *
+ * ## This row IS the discovery mechanism
+ *
+ * The classifier only ever sees mail as it arrives. A first-connect backfill
+ * publishes no `message:received` at all, and mail that arrived before the inbox
+ * was opted in exited at guard 3a — both leave a permanent hole with no
+ * completion event left to hang a prompt on (07 §2.9). Two triggers were
+ * considered; this is the first and the durable one:
+ *
+ * - it appears the instant the toggle is enabled, which is the moment of highest
+ *   intent — the user just decided they want this inbox classified;
+ * - it **persists**, unlike a dismissible prompt, so it cannot be dismissed into
+ *   oblivion.
+ *
+ * ⚠️ And it is the WHOLE prompt: the cost dialog is never auto-opened on opt-in
+ * (07 invariant 12). A dialog asking for money one click after a toggle reads as
+ * a dark pattern.
+ *
+ * ## Composition
+ *
+ * No existing primitive is a "stat + action" row — `FieldPanelRow` is for forms,
+ * `StatCard` is for dashboard metrics, `ListCard` is a grid tile. So this is a
+ * plain bordered row matching `ToggleCard`'s `rounded-xl border px-3 py-2.5`
+ * (`docs/ui-design-guide.md`, "When none of these fit").
+ *
+ * ⚠️ Deliberately NOT an `Alert`: this is a normal affordance, not a warning, and
+ * the card already uses `Alert` directly above for the genuine
+ * credits-exhausted warning (07 §3.1).
+ *
+ * While a sample is running the same row becomes the progress surface, with the
+ * cancel that 07 §2.5 requires.
+ */
+export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
+  const utils = api.useUtils()
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const backlog = api.mailClassification.getBacklog.useQuery({ inboxId })
+
+  // Same query key the dialog polls — one poll, and the two surfaces can never
+  // disagree about whether a sample is running.
+  const status = api.mailClassification.getReclassifySampleStatus.useQuery(
+    { inboxId },
+    {
+      refetchInterval: (query) => {
+        const state = query.state.data?.state
+        return state === 'waiting' || state === 'active' || state === 'delayed' ? 2000 : false
+      },
+    }
+  )
+
+  const cancelSample = api.mailClassification.cancelReclassifySample.useMutation({
+    onSuccess: (result) => {
+      void utils.mailClassification.getReclassifySampleStatus.invalidate({ inboxId })
+      // A queued sample is removed outright; one already mid-flight is not.
+      // Saying nothing would leave a click that visibly did nothing, which reads
+      // as broken — this is a refusal, not a success, so it is a toast.
+      if (!result.removed) {
+        toastError({
+          title: 'The sample is already running',
+          description:
+            'It cannot be stopped mid-run, but it only classifies about 100 conversations and applies nothing.',
+        })
+      }
+    },
+    onError: (error) =>
+      toastError({ title: 'Error stopping the sample', description: error.message }),
+  })
+
+  const state = status.data?.state
+  const running = state === 'waiting' || state === 'active' || state === 'delayed'
+  const report = state === 'completed' ? status.data?.report : undefined
+  const count = backlog.data?.count ?? 0
+  const capped = backlog.data?.capped ?? false
+
+  // Nothing to catch up on and nothing in flight — the row is a standing
+  // affordance, not a permanent fixture.
+  if (!running && !report && count === 0) return null
+
+  const processed = status.data?.processed ?? 0
+  const total = status.data?.total ?? 0
+  const pct = total > 0 ? Math.min(100, Math.round((processed / total) * 100)) : 0
+
+  return (
+    <>
+      <div className='mt-3 rounded-xl border px-3 py-2.5'>
+        <div className='flex items-center justify-between gap-3'>
+          <div className='min-w-0 space-y-0.5'>
+            {running ? (
+              <p className='text-sm font-medium'>
+                Classifying a sample: {processed.toLocaleString()} of{' '}
+                {(total || 0).toLocaleString()}…
+              </p>
+            ) : report ? (
+              <p className='text-sm font-medium'>
+                Sample finished: {report.classified.toLocaleString()} of{' '}
+                {report.selected.toLocaleString()} got a category
+              </p>
+            ) : (
+              <p className='text-sm font-medium'>
+                {/* 07 R-Q5 — `1,000+` past the cap. An order of magnitude for a
+                    decision, not a billing figure. */}
+                {count === 1 && !capped
+                  ? '1 older conversation has never been classified'
+                  : `${count.toLocaleString()}${capped ? '+' : ''} older conversations have never been classified`}
+              </p>
+            )}
+            {/* ⚠️ 07 invariant 11 — REQUIRED, not decoration. "Classify existing
+                mail" reads as "apply my automations to old mail" to most people,
+                and the honest correction belongs at the point of action. */}
+            <p className='text-xs text-muted-foreground'>
+              Labels older mail for search and reporting. Your filters will not run on it.
+            </p>
+          </div>
+
+          {running ? (
+            <Button
+              variant='outline'
+              size='sm'
+              loading={cancelSample.isPending}
+              loadingText='Stopping...'
+              onClick={() => cancelSample.mutate({ inboxId })}>
+              Cancel
+            </Button>
+          ) : (
+            <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
+              {report ? 'View results' : 'Classify…'}
+            </Button>
+          )}
+        </div>
+
+        {running ? <Progress value={pct} className='mt-2' /> : null}
+      </div>
+
+      <InboxReclassifyDialog inboxId={inboxId} open={dialogOpen} onOpenChange={setDialogOpen} />
+    </>
+  )
+}

--- a/apps/web/src/components/tags/category-defaults.ts
+++ b/apps/web/src/components/tags/category-defaults.ts
@@ -1,0 +1,120 @@
+// apps/web/src/components/tags/category-defaults.ts
+//
+// CLIENT-SAFE mirror of the shipped mail-category definitions
+// (plans/mail-filter/06-mail-categories-rework-plan.md §2, seeded by
+// `packages/lib/src/seed/ai-category-tags.ts`).
+//
+// ## Why this is a copy and not an import
+//
+// The seed module is the single writer of these rows, but it imports
+// `@auxx/database` and `UnifiedCrudHandler`, so importing it from the tag dialog
+// would pull server-only dependencies into the client bundle (CLAUDE.md,
+// "Client vs Server Imports"). `@auxx/lib/seed` has no `/client` subpath today,
+// and lib's exports map is generated rather than hand-written — so the honest
+// option is a client-safe copy with a DRIFT TEST that reads the seed source and
+// asserts every string here still appears in it verbatim
+// (`tag-dialog-template-category.test.tsx`). If a `@auxx/lib/seed/client`
+// subpath ever lands, delete this map and re-export from there.
+//
+// ⚠️ These descriptions are PROMPT TEXT, read verbatim by the classifier as the
+// label's definition (plan 05 C3). Do not reword, retypeset or "tidy" them here
+// — the em dashes and the precedence hints are load-bearing, and a copy that
+// drifts makes "Reset to default" write something a fresh seed would not.
+
+/** The shipped definition of one seeded category, keyed by `tag_template_key`. */
+export interface TagTemplateDefault {
+  /** `tag_template_key` — the shipped identity, stable across renames. */
+  templateKey: string
+  /** The title the category shipped with. Editable, so it may not be the current one. */
+  title: string
+  /** The description the category shipped with — the classifier's instruction. */
+  description: string
+}
+
+/**
+ * Every shipped category by `tag_template_key`, including the `Mail Categories`
+ * container (which carries a key of its own so it cannot be deleted out from
+ * under its children).
+ */
+export const TAG_TEMPLATE_DEFAULTS: Readonly<Record<string, TagTemplateDefault>> = Object.freeze({
+  'category:mail-categories': {
+    templateKey: 'category:mail-categories',
+    title: 'Mail Categories',
+    description:
+      'Grouping for the categories the AI classifier may apply to inbound mail. Not applied to mail itself.',
+  },
+  'category:sales': {
+    templateKey: 'category:sales',
+    title: 'Sales',
+    description:
+      'A prospective or existing customer with buying intent: pricing, quotes, availability, product fit, a demo, or expanding an order. Pre-purchase interest, not a problem with something already bought.',
+  },
+  'category:support': {
+    templateKey: 'category:support',
+    title: 'Support',
+    description:
+      'The sender needs help with something they already have: a fault, an error, a how-to question, a return, or a complaint. Something is broken, missing, or not understood.',
+  },
+  'category:billing': {
+    templateKey: 'category:billing',
+    title: 'Billing',
+    description:
+      'Anything about money owed or paid: invoices, charges, refunds, payment methods, subscription fees, failed payments, dunning, receipts and tax documents.',
+  },
+  'category:account': {
+    templateKey: 'category:account',
+    title: 'Account',
+    description:
+      'Access and administration rather than money: sign-in and password problems, user or seat changes, permissions, plan or subscription changes, data export, closing an account.',
+  },
+  'category:order-status': {
+    templateKey: 'category:order-status',
+    title: 'Order Status',
+    description:
+      'Asking where an existing order is, when it ships or arrives, or for tracking. The order exists and the sender wants its state, not a fault and not a change request.',
+  },
+  'category:returns-refunds': {
+    templateKey: 'category:returns-refunds',
+    title: 'Returns & Refunds',
+    description:
+      'Wanting to send something back, cancel an order, or get money back for a completed purchase: returns, exchanges, cancellations, damaged or wrong items.',
+  },
+  'category:partners-dealers': {
+    templateKey: 'category:partners-dealers',
+    title: 'Partners & Dealers',
+    description:
+      'A business wanting to sell, install, distribute or integrate with us: dealer and reseller applications, installer enquiries, affiliate and partnership proposals. A business relationship, not an end-customer purchase.',
+  },
+})
+
+/**
+ * The shipped default for a tag's `tag_template_key`, or undefined for a
+ * user-created tag (and for a key this build does not know about — an org seeded
+ * by a newer deploy, which must degrade to "ordinary tag", never to a crash).
+ */
+export function getTagTemplateDefault(
+  templateKey: string | null | undefined
+): TagTemplateDefault | undefined {
+  if (!templateKey) return undefined
+  return TAG_TEMPLATE_DEFAULTS[templateKey]
+}
+
+/**
+ * Why a seeded category has no delete action.
+ *
+ * `rejectDeleteIfTemplateTag` (`packages/lib/src/field-hooks/pre/tag-template-guard.ts`)
+ * throws `ForbiddenError` on any delete of a tag carrying a `tag_template_key`,
+ * so any UI that offers one is offering a request that will 403. Stated here
+ * once so every surface says the same thing.
+ *
+ * ⚠️ This is NOT the system-tag treatment. A seeded category stays fully
+ * editable — title, emoji, colour, parent and above all the description, which
+ * is the classifier's instruction (plan 06 D4 vs D5). Undeletable is the only
+ * thing the marker buys.
+ */
+export const TEMPLATE_TAG_UNDELETABLE_REASON = 'A built-in mail category cannot be deleted.'
+
+/** Does this tag carry a shipped `tag_template_key`, i.e. is it undeletable? */
+export function isTemplateTag(tag: { templateKey?: string | null } | null | undefined): boolean {
+  return !!tag?.templateKey
+}

--- a/apps/web/src/components/tags/hooks/use-tag-hierarchy.ts
+++ b/apps/web/src/components/tags/hooks/use-tag-hierarchy.ts
@@ -58,6 +58,9 @@ export function useTagHierarchy(options?: UseTagHierarchyOptions): UseTagHierarc
         parentId,
         isSystemTag: record.fieldValues.is_system_tag ?? false,
         aiClassify: record.fieldValues.tag_ai_classify ?? false,
+        // Empty string reads as "no template" so a blanked-out field cannot make
+        // a tag look seeded (and cannot resolve a default that does not exist).
+        templateKey: record.fieldValues.tag_template_key || null,
         scope: tagScope,
         children: [],
       }

--- a/apps/web/src/components/tags/tag-dialog-template-category.test.tsx
+++ b/apps/web/src/components/tags/tag-dialog-template-category.test.tsx
@@ -1,0 +1,283 @@
+// apps/web/src/components/tags/tag-dialog-template-category.test.tsx
+//
+// Mail-categories plan 06 §4 + §7.1 — the tag dialog's treatment of a SEEDED
+// category (an ordinary tag carrying `tag_template_key`).
+//
+// Three things here are decisions rather than styling, and each one fails
+// silently if a later refactor loses it:
+//
+//   D4 vs D5 — a seeded category is FULLY EDITABLE. The obvious "cleanup" is to
+//        fold `templateKey` into `isReadOnly` beside `isSystemTag`; that freezes
+//        `tag_description`, which is the classifier's instruction and the one
+//        field this whole feature exists to make the customer's. So the
+//        assertion is that every input stays enabled and the save button is
+//        still there.
+//
+//   §4.1 — the shipped default is the PLACEHOLDER, never the value. A cleared
+//        description must stay cleared through a save; showing the default as
+//        the value would silently re-write text the user deleted on purpose.
+//
+//   §3.2 — `rejectDeleteIfTemplateTag` 403s any delete of a marked tag, so the
+//        UI must state that rather than offer an action that will fail. That
+//        statement keys off the MARKER, not off this build's defaults map — a
+//        category seeded by a newer deploy resolves to no known default and is
+//        still undeletable.
+//
+// Plus a DRIFT TEST: `category-defaults.ts` is a hand-copy of the seed
+// definitions (the seed module imports `@auxx/database`, so the client cannot
+// import it — CLAUDE.md "Client vs Server Imports"). A copy that drifts makes
+// "Reset to default" write something a fresh seed would not, so the test reads
+// the seed source and asserts every string still appears in it verbatim.
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getTagTemplateDefault,
+  TAG_TEMPLATE_DEFAULTS,
+  TEMPLATE_TAG_UNDELETABLE_REASON,
+} from '~/components/tags/category-defaults'
+import type { TagNode } from '~/components/tags/types'
+
+const DEF = 'edf_tag00000000000000000000000'
+const INSTANCE = 'ein_tag00000000000000000000000'
+const RECORD_ID = `${DEF}:${INSTANCE}` as const
+const AI_FIELD_ID = 'fld_ai_classify00000000000000'
+const DESCRIPTION_FIELD_ID = 'fld_desc00000000000000000000'
+
+const BILLING = TAG_TEMPLATE_DEFAULTS['category:billing']!
+
+/** A tag row as `useTagHierarchy` would shape it. */
+function tagNode(overrides: Partial<TagNode> = {}): TagNode {
+  return {
+    id: INSTANCE,
+    recordId: RECORD_ID,
+    title: 'Billing',
+    tag_description: BILLING.description,
+    tag_emoji: '💳',
+    tag_color: 'green',
+    parentId: null,
+    isSystemTag: false,
+    aiClassify: true,
+    templateKey: BILLING.templateKey,
+    scope: 'thread',
+    children: [],
+    ...overrides,
+  }
+}
+
+const h = vi.hoisted(() => ({
+  /** The tag under edit, or null for "not found". */
+  tag: null as TagNode | null,
+  /** Field-value payloads handed to `saveMultipleAsync`. */
+  saved: [] as Array<Array<{ fieldId: string; value: unknown; fieldType: string }>>,
+}))
+
+vi.mock('~/components/tags/hooks/use-tag-hierarchy', () => ({
+  useTagHierarchy: () => ({
+    hierarchy: [],
+    flatTags: [],
+    tagMap: new Map<string, TagNode>(h.tag ? [[h.tag.id, h.tag]] : []),
+    fields: {
+      title: { id: 'fld_title0000000000000000000', key: 'title', type: 'TEXT' },
+      tag_description: { id: DESCRIPTION_FIELD_ID, key: 'description', type: 'RICH_TEXT' },
+      tag_emoji: { id: 'fld_emoji0000000000000000000', key: 'emoji', type: 'TEXT' },
+      tag_color: { id: 'fld_color0000000000000000000', key: 'color', type: 'TEXT' },
+      tag_parent: { id: 'fld_parent000000000000000000', key: 'tag_parent', type: 'RELATIONSHIP' },
+      tag_ai_classify: { id: AI_FIELD_ID, key: 'ai_classify', type: 'CHECKBOX' },
+    },
+    isLoading: false,
+    error: null,
+    entityDefinitionId: DEF,
+    refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('~/components/resources/hooks/use-create-record', () => ({
+  useCreateRecord: () => ({ create: vi.fn(), isPending: false }),
+}))
+
+vi.mock('~/components/resources/hooks/use-save-field-value', () => ({
+  useSaveFieldValue: () => ({
+    saveMultipleAsync: async (
+      _recordId: string,
+      fieldValues: Array<{ fieldId: string; value: unknown; fieldType: string }>
+    ) => {
+      h.saved.push(fieldValues)
+      return true
+    },
+    isPending: false,
+  }),
+}))
+
+import { TagDialog } from '~/components/tags/ui/tag-dialog'
+
+/** The description textarea, wherever the eligibility card has mounted it. */
+function descriptionField(): HTMLTextAreaElement {
+  return screen.getByRole('textbox', { name: /when should this tag apply\?/i })
+}
+
+function resetButton() {
+  return screen.queryByRole('button', { name: /reset to default/i })
+}
+
+/** The `tag_description` entry of the most recent save. */
+function savedDescription() {
+  return h.saved.at(-1)?.find((v) => v.fieldId === DESCRIPTION_FIELD_ID)
+}
+
+function openDialog() {
+  render(<TagDialog open onOpenChange={vi.fn()} recordId={RECORD_ID} />)
+}
+
+describe('tag dialog — seeded mail category', () => {
+  beforeEach(() => {
+    h.tag = tagNode()
+    h.saved.length = 0
+  })
+
+  it('stays fully editable — this is not the system-tag treatment (D4 vs D5)', () => {
+    openDialog()
+
+    // The whole point of `tag_template_key` being a provenance marker rather
+    // than a lock. If `isReadOnly` ever grows a `|| templateKey` this fails.
+    expect(screen.getByPlaceholderText('Tag name')).toBeEnabled()
+    expect(descriptionField()).toBeEnabled()
+    expect(screen.getByRole('switch', { name: /let ai apply this tag/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument()
+
+    // …and none of the system-tag copy, which says the opposite.
+    expect(screen.queryByText(/it cannot be modified or deleted/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('System Tag')).not.toBeInTheDocument()
+  })
+
+  it('states that the category cannot be deleted (§3.2)', () => {
+    openDialog()
+
+    // `rejectDeleteIfTemplateTag` 403s the delete, so no surface may imply one
+    // is available.
+    expect(screen.getByText(new RegExp(TEMPLATE_TAG_UNDELETABLE_REASON, 'i'))).toBeInTheDocument()
+  })
+
+  it('says nothing about built-in categories for an ordinary tag', () => {
+    h.tag = tagNode({ templateKey: null, tag_description: 'Ours.' })
+    openDialog()
+
+    expect(screen.queryByText(/built-in mail category/i)).not.toBeInTheDocument()
+    expect(resetButton()).toBeNull()
+  })
+
+  it('shows the shipped default as the PLACEHOLDER once the description is cleared (§4.1)', () => {
+    h.tag = tagNode({ tag_description: '' })
+    openDialog()
+
+    const field = descriptionField()
+    // Placeholder, never value: a cleared description stays cleared. Showing it
+    // as the value would silently rewrite text the user deleted on purpose.
+    expect(field).toHaveValue('')
+    expect(field).toHaveAttribute('placeholder', BILLING.description)
+  })
+
+  it('keeps a cleared description cleared through a save', async () => {
+    const user = userEvent.setup()
+    h.tag = tagNode({ tag_description: '' })
+    openDialog()
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(savedDescription()).toMatchObject({ value: null })
+  })
+
+  it('offers no reset while the description is still the shipped default', () => {
+    openDialog()
+
+    expect(resetButton()).toBeNull()
+  })
+
+  it('offers "Reset to default" once the description has drifted (§4.2)', async () => {
+    const user = userEvent.setup()
+    h.tag = tagNode({ tag_description: 'Only invoices, nothing else.' })
+    openDialog()
+
+    const button = resetButton()
+    expect(button).not.toBeNull()
+
+    await user.click(button!)
+
+    // Resolved through `tag_template_key`, which is the only reason we know
+    // WHICH default applies to a tag the user may have renamed.
+    expect(descriptionField()).toHaveValue(BILLING.description)
+    // …and the affordance retires itself the moment the text matches again,
+    // without waiting for a save.
+    expect(resetButton()).toBeNull()
+  })
+
+  it('writes the restored default only when the user saves', async () => {
+    const user = userEvent.setup()
+    h.tag = tagNode({ tag_description: 'Only invoices, nothing else.' })
+    openDialog()
+
+    await user.click(resetButton()!)
+    expect(h.saved).toHaveLength(0)
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+    expect(savedDescription()).toMatchObject({ value: BILLING.description })
+  })
+
+  it('offers a reset on a cleared description too — the empty case is drift (§4.1)', () => {
+    h.tag = tagNode({ tag_description: '' })
+    openDialog()
+
+    expect(resetButton()).not.toBeNull()
+  })
+
+  it('resets the description even after the category has been renamed', async () => {
+    const user = userEvent.setup()
+    // The marker survives a rename; the title does not identify the default.
+    h.tag = tagNode({ title: 'Invoices & payments', tag_description: 'drifted' })
+    openDialog()
+
+    await user.click(resetButton()!)
+
+    expect(descriptionField()).toHaveValue(BILLING.description)
+    // The rename is the user's and is never reverted by a description reset.
+    expect(screen.getByPlaceholderText('Tag name')).toHaveValue('Invoices & payments')
+  })
+
+  it('degrades to "undeletable, no default" for a key this build does not know', () => {
+    // An org seeded by a newer deploy. The delete guard reads the MARKER, so the
+    // statement must survive even though no shipped text resolves.
+    h.tag = tagNode({ templateKey: 'category:from-the-future', tag_description: 'whatever' })
+    openDialog()
+
+    expect(screen.getByText(new RegExp(TEMPLATE_TAG_UNDELETABLE_REASON, 'i'))).toBeInTheDocument()
+    expect(resetButton()).toBeNull()
+    expect(descriptionField()).toBeEnabled()
+    expect(getTagTemplateDefault('category:from-the-future')).toBeUndefined()
+  })
+})
+
+describe('category-defaults drift', () => {
+  // Resolved from this file rather than from cwd so the test does not depend on
+  // which package vitest was invoked in.
+  const seedSource = readFileSync(
+    resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../../../../packages/lib/src/seed/ai-category-tags.ts'
+    ),
+    'utf8'
+  )
+
+  it.each(
+    Object.values(TAG_TEMPLATE_DEFAULTS)
+  )('keeps $templateKey byte-identical to the seed definition', (entry) => {
+    // Verbatim, because the descriptions are PROMPT TEXT (05 C3) and "Reset to
+    // default" must write exactly what a fresh seed would have written.
+    expect(seedSource).toContain(`'${entry.templateKey}'`)
+    expect(seedSource).toContain(`'${entry.title}'`)
+    expect(seedSource).toContain(entry.description)
+  })
+})

--- a/apps/web/src/components/tags/types.ts
+++ b/apps/web/src/components/tags/types.ts
@@ -20,6 +20,11 @@ export interface TagRecord extends RecordMeta {
     is_system_tag?: boolean
     /** Opt-in: the mail classifier may apply this tag to inbound mail. */
     tag_ai_classify?: boolean
+    /**
+     * Shipped identity of a seeded mail category (`category:sales`, …). Absent
+     * for every user-created tag. Provenance marker, not a lock.
+     */
+    tag_template_key?: string
     /** SINGLE_SELECT comes back as an array per the resource read pipeline. */
     tag_scope?: string | string[]
   }
@@ -43,6 +48,16 @@ export interface TagNode {
    * label's definition rather than as decorative copy.
    */
   aiClassify: boolean
+  /**
+   * `tag_template_key` — the shipped identity of a seeded mail category, null
+   * for a user-created tag (plan 06 §3.1).
+   *
+   * ⚠️ A PROVENANCE MARKER, not a lock, and deliberately not folded into
+   * {@link TagNode.isSystemTag}: a seeded category stays fully editable
+   * (D4 vs D5). All it buys the UI is a default to reset back to and the fact
+   * that the delete hook will refuse.
+   */
+  templateKey: string | null
   scope: TagScopeValue
   children: TagNode[]
 }

--- a/apps/web/src/components/tags/ui/suggested-categories-dialog.tsx
+++ b/apps/web/src/components/tags/ui/suggested-categories-dialog.tsx
@@ -1,0 +1,190 @@
+// apps/web/src/components/tags/ui/suggested-categories-dialog.tsx
+//
+// The shipped mail categories an org can add, as a one-off picker
+// (plans/mail-filter/06-mail-categories-rework-plan.md §7.2, revised 2026-08-10).
+//
+// ⚠️ THIS REPLACED A PER-PACK TOGGLE, and the reason matters more than the code:
+// a group-level switch was a SECOND control over `tag_ai_classify`, which the tag
+// list already owns one per tag. Its "off" could never mean anything either —
+// turning a pack off never deleted its categories, so they carried on sitting in
+// the list below while the switch above claimed the pack was off. Adding is
+// one-way; from then on these are ordinary tags, managed where every other tag is.
+//
+// So this surface only ever answers "what could I add that I do not have", and
+// closes. Already-present categories are shown as such and cannot be re-added.
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd } from '@auxx/ui/components/kbd'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { Check } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { api } from '~/trpc/react'
+
+/**
+ * How many eligible labels the classifier reads well.
+ *
+ * Plan 06 invariant 10 puts the warning at "past ~8"; Q5 puts the revisit-the-shape
+ * trigger at ~10. Core 4 + Commerce 2 + Partner 1 = 7, so adding every suggestion
+ * stays under budget and only a hand-marked tag can cross it, which is exactly the
+ * case that would otherwise degrade classification with nothing on screen to
+ * explain why.
+ */
+export const ELIGIBLE_LABEL_BUDGET = 8
+
+export function SuggestedCategoriesDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const utils = api.useUtils()
+  const { data, isPending } = api.tag.suggestedCategories.useQuery(undefined, { enabled: open })
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  // A fresh selection each time it opens, so a cancelled pick is not remembered.
+  useEffect(() => {
+    if (open) setSelected(new Set())
+  }, [open])
+
+  const addCategories = api.tag.addSuggestedCategories.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.tag.suggestedCategories.invalidate(),
+        utils.tag.getAll.invalidate(),
+        utils.tag.getHierarchy.invalidate(),
+        utils.record.listAll.invalidate(),
+      ])
+      onOpenChange(false)
+    },
+    onError: (error) =>
+      toastError({ title: 'Error adding categories', description: error.message }),
+  })
+
+  const groups = data?.packs ?? []
+  const available = groups.flatMap((group) => group.labels).filter((label) => !label.present)
+  const nothingLeft = !isPending && available.length === 0
+
+  const toggle = (templateKey: string) =>
+    setSelected((current) => {
+      const next = new Set(current)
+      if (next.has(templateKey)) next.delete(templateKey)
+      else next.add(templateKey)
+      return next
+    })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='sm:max-w-xl'>
+        <DialogHeader>
+          <DialogTitle>Add suggested categories</DialogTitle>
+          <DialogDescription>
+            Ready made categories for the AI classifier, with a definition it reads to decide when
+            each one fits. You can rename them, rewrite the definition, or switch them off later
+            like any other tag.
+          </DialogDescription>
+        </DialogHeader>
+
+        {data && !data.ready ? (
+          <p className='text-muted-foreground text-sm'>
+            Mail categories are not set up for this organization yet.
+          </p>
+        ) : null}
+
+        <div className='max-h-[50vh] space-y-4 overflow-y-auto'>
+          {isPending ? (
+            <>
+              <Skeleton className='h-16 w-full rounded-xl' />
+              <Skeleton className='h-16 w-full rounded-xl' />
+            </>
+          ) : nothingLeft ? (
+            <p className='text-muted-foreground text-sm'>
+              You already have every suggested category. Manage them in the tag list below.
+            </p>
+          ) : (
+            groups.map((group) => (
+              <div key={group.pack} className='space-y-2'>
+                <div>
+                  <p className='font-medium text-sm'>{group.title}</p>
+                  <p className='text-muted-foreground text-xs'>{group.summary}</p>
+                </div>
+                {group.labels.map((label) => (
+                  <label
+                    key={label.templateKey}
+                    className={`flex gap-3 rounded-xl border p-3 ${
+                      label.present ? 'opacity-60' : 'cursor-pointer hover:bg-muted/50'
+                    }`}>
+                    {label.present ? (
+                      <Check className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+                    ) : (
+                      <Checkbox
+                        className='mt-0.5'
+                        checked={selected.has(label.templateKey)}
+                        onCheckedChange={() => toggle(label.templateKey)}
+                      />
+                    )}
+                    <span className='min-w-0'>
+                      <span className='flex items-center gap-1.5 font-medium text-sm'>
+                        <span aria-hidden>{label.emoji}</span>
+                        {label.title}
+                        {label.present ? (
+                          <Badge variant='secondary' className='text-xs'>
+                            Added
+                          </Badge>
+                        ) : null}
+                      </span>
+                      {/* The definition IS the classifier's instruction (plan 05 C3), so it is
+                          shown before the choice rather than hidden behind it. */}
+                      <span className='mt-0.5 block text-muted-foreground text-xs'>
+                        {label.description}
+                      </span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* The only place the size of the classifier's label set is visible. Plan 06
+            invariant 10: growth must be a warning, never a silent accuracy tax. */}
+        {data ? (
+          <p className='text-muted-foreground text-xs'>
+            {data.eligibleLabelCount + selected.size} of about {ELIGIBLE_LABEL_BUDGET} categories
+            the AI reads well.
+            {data.eligibleLabelCount + selected.size > ELIGIBLE_LABEL_BUDGET
+              ? ' Above this, overlapping categories start to compete and the AI applies fewer tags, not more.'
+              : ''}
+          </p>
+        ) : null}
+
+        <DialogFooter>
+          <Button variant='ghost' size='sm' onClick={() => onOpenChange(false)}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            size='sm'
+            disabled={selected.size === 0 || !data?.ready}
+            loading={addCategories.isPending}
+            loadingText='Adding...'
+            onClick={() => addCategories.mutate({ templateKeys: [...selected] })}>
+            {selected.size > 0 ? `Add ${selected.size}` : 'Add'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/tags/ui/tag-dialog.tsx
+++ b/apps/web/src/components/tags/ui/tag-dialog.tsx
@@ -42,12 +42,17 @@ import { toastError } from '@auxx/ui/components/toast'
 import { ToggleCard } from '@auxx/ui/components/toggle-card'
 import { cn } from '@auxx/ui/lib/utils'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { Loader2, Sparkles, Tag, TriangleAlert } from 'lucide-react'
+import { Loader2, RotateCcw, Sparkles, Tag, TriangleAlert } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { useCreateRecord } from '~/components/resources/hooks/use-create-record'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import {
+  getTagTemplateDefault,
+  isTemplateTag,
+  TEMPLATE_TAG_UNDELETABLE_REASON,
+} from '../category-defaults'
 import { useTagHierarchy } from '../hooks/use-tag-hierarchy'
 import type { TagNode } from '../types'
 import { FormColorTagPicker } from './color-tag-picker'
@@ -102,13 +107,32 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
   const isEditing = !!editingInstanceId
 
   // Fetch tag hierarchy for parent selection (includes fields map for saving)
-  const { hierarchy, flatTags, tagMap, fields, entityDefinitionId, refresh } = useTagHierarchy()
+  const { hierarchy, tagMap, fields, entityDefinitionId, refresh } = useTagHierarchy()
+
+  const editingTag = isEditing && editingInstanceId ? tagMap.get(editingInstanceId) : undefined
 
   // System tags are read-only: server rejects edits via field-hooks guard, and
   // the dialog disables inputs + hides the save button as a UX safety net.
-  const isSystemTag =
-    isEditing && editingInstanceId ? tagMap.get(editingInstanceId)?.isSystemTag === true : false
+  const isSystemTag = editingTag?.isSystemTag === true
   const isReadOnly = isSystemTag
+
+  // A SEEDED MAIL CATEGORY (plan 06 D4) — an ordinary tag carrying a
+  // `tag_template_key`. ⚠️ Deliberately NOT folded into `isReadOnly`: that flag
+  // belongs to `is_system_tag` and freezes `tag_description`, which is the one
+  // field this whole feature exists to make editable (D4 vs D5). All the marker
+  // changes here is that there is a shipped default to go back to, and that the
+  // pre-delete hook will refuse a delete.
+  //
+  // ⚠️ Two separate questions, deliberately not one boolean:
+  //   • `isTemplateCategory` — does the row carry the MARKER? That is what
+  //     `rejectDeleteIfTemplateTag` reads, so it alone decides whether we may
+  //     state "cannot be deleted".
+  //   • `templateDefault` — does THIS BUILD know the shipped text for that key?
+  //     A key seeded by a newer deploy resolves to undefined, and only the
+  //     placeholder and "Reset to default" depend on it. Collapsing the two
+  //     would make a category from a newer deploy silently look deletable.
+  const isTemplateCategory = isTemplateTag(editingTag)
+  const templateDefault = getTagTemplateDefault(editingTag?.templateKey)
 
   // `tag_ai_classify` reaches an org only once its entity migration has run. No
   // field row means no way to persist the flag, so the card is hidden rather
@@ -140,6 +164,25 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
   // the worse failure — so the label set is built from eligibility alone and
   // this stays a hint.
   const missingClassifierInstruction = aiClassify && !tagDescription?.trim()
+
+  // "Drifted" is anything that is not byte-identical to the shipped text —
+  // including cleared, which is the case §4.1's placeholder covers. Compared
+  // against the CURRENT form value rather than the saved one, so the affordance
+  // disappears the moment a reset lands instead of waiting for a save.
+  const descriptionHasDrifted =
+    !!templateDefault && (tagDescription ?? '').trim() !== templateDefault.description
+
+  /**
+   * Put the shipped definition back in the field. Writes the form only — the
+   * user still saves — so a mis-click is undone by cancelling the dialog.
+   */
+  const resetDescriptionToDefault = useCallback(() => {
+    if (!templateDefault) return
+    form.setValue('tag_description', templateDefault.description, {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }, [form, templateDefault])
 
   // Initialize form when dialog opens
   useEffect(() => {
@@ -332,6 +375,11 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
    *
    * `aiMode` is the whole of plan C3: the field is unchanged, its meaning is
    * not, and this relabel is the only place a user can learn that.
+   *
+   * On a seeded category it also carries plan 06 §4's two affordances: the
+   * shipped definition as the PLACEHOLDER (never the value — a cleared
+   * description stays cleared, it just still shows what we would have said), and
+   * "Reset to default" once the text has drifted.
    */
   const renderDescriptionField = (aiMode: boolean) => (
     <FormField
@@ -339,13 +387,34 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
       name='tag_description'
       render={({ field }) => (
         <FormItem>
-          {aiMode && <FormLabel>When should this tag apply?</FormLabel>}
+          {(aiMode || (descriptionHasDrifted && !isReadOnly)) && (
+            <div
+              className={cn(
+                'flex min-h-7 items-center gap-2',
+                aiMode ? 'justify-between' : 'justify-end'
+              )}>
+              {aiMode && <FormLabel>When should this tag apply?</FormLabel>}
+              {descriptionHasDrifted && !isReadOnly && (
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='sm'
+                  className='h-6 px-1.5 text-xs'
+                  onClick={resetDescriptionToDefault}>
+                  <RotateCcw />
+                  Reset to default
+                </Button>
+              )}
+            </div>
+          )}
           <FormControl>
             <Textarea
               placeholder={
-                aiMode
-                  ? 'e.g. Questions about invoices, charges, refunds or payment methods.'
-                  : 'Optional description'
+                templateDefault
+                  ? templateDefault.description
+                  : aiMode
+                    ? 'e.g. Questions about invoices, charges, refunds or payment methods.'
+                    : 'Optional description'
               }
               className='h-20 resize-none'
               {...field}
@@ -373,7 +442,7 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
           </DialogTitle>
           <DialogDescription>
             {isReadOnly
-              ? 'Managed by Auxx — read-only.'
+              ? 'Managed by Auxx. Read-only.'
               : isEditing
                 ? "Update this tag's details below."
                 : 'Fill out the form below to create a new tag.'}
@@ -383,6 +452,22 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
         {isReadOnly && (
           <div className='rounded-md bg-amber-100 border border-amber-300 px-3 py-2 text-sm text-amber-900'>
             This is a system tag. It cannot be modified or deleted.
+          </div>
+        )}
+
+        {/* Seeded category. Muted, not amber: this is a statement of provenance,
+            not a warning that something is frozen — everything below stays
+            editable, and saying so is the point (plan 06 D4). The delete line is
+            the UI half of `rejectDeleteIfTemplateTag`: no surface may offer a
+            delete that the pre-delete hook will 403. */}
+        {isTemplateCategory && !isReadOnly && (
+          <div className='rounded-md border bg-muted/40 px-3 py-2 text-muted-foreground text-sm mb-2'>
+            <span className='font-medium text-foreground'>Built-in mail category.</span> Rename it,
+            recolour it and re-word its description to fit your business. The description is what
+            the classifier reads. {TEMPLATE_TAG_UNDELETABLE_REASON}
+            {canClassify &&
+              aiClassify &&
+              ' To stop it being used, switch off “Let AI apply this tag”.'}
           </div>
         )}
 

--- a/apps/web/src/components/tags/ui/tags-list.tsx
+++ b/apps/web/src/components/tags/ui/tags-list.tsx
@@ -3,14 +3,21 @@
 
 import { getOptionColor, type SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { AnimatedGradientText } from '@auxx/ui/components/animated-gradient-text'
 import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { Edit, Lock, Plus, Sparkles, Tags, Trash2 } from 'lucide-react'
+import { ChevronDown, Edit, Lock, Plus, Sparkles, Tags, Trash2 } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -22,6 +29,7 @@ import { api } from '~/trpc/react'
 import { useTagHierarchy } from '../hooks/use-tag-hierarchy'
 import type { TagNode } from '../types'
 import { filterHierarchy } from '../utils/hierarchy'
+import { SuggestedCategoriesDialog } from './suggested-categories-dialog'
 import { TagDialog } from './tag-dialog'
 
 /**
@@ -39,6 +47,7 @@ export function TagTreeView() {
   // State for tag operations
   const [expandedTags, setExpandedTags] = useState<Record<string, boolean>>({})
   const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [isSuggestedOpen, setIsSuggestedOpen] = useState(false)
   const [editingRecordId, setEditingRecordId] = useState<RecordId | undefined>(undefined)
 
   // Fetch tag hierarchy
@@ -156,10 +165,30 @@ export function TagTreeView() {
           onChange={(e) => setSearchQuery(e.target.value)}
         />
         <ListToolbarGroup align='end'>
-          <Button variant='outline' size='sm' onClick={handleCreateTag}>
-            <Plus />
-            <span className='hidden sm:inline'>Add Tag</span>
-          </Button>
+          {/* Matches the create dropdown on custom-fields: blank first, shipped
+              templates second. The suggested categories live here rather than in
+              a settings section of their own — they ARE tags, and the list is
+              where tags are managed (plan 06 §7.2). */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant='outline' size='sm'>
+                <Plus />
+                <span className='hidden sm:inline'>Add Tag</span>
+                <ChevronDown />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuItem onClick={handleCreateTag}>
+                <Plus /> Blank tag
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setIsSuggestedOpen(true)}
+                className='data-highlighted:bg-[#ffaa40]/10'>
+                <Sparkles className='text-[#ffaa40]' />{' '}
+                <AnimatedGradientText>Suggested AI categories</AnimatedGradientText>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </ListToolbarGroup>
       </ListToolbar>
 
@@ -208,6 +237,8 @@ export function TagTreeView() {
           />
         )}
       </div>
+
+      <SuggestedCategoriesDialog open={isSuggestedOpen} onOpenChange={setIsSuggestedOpen} />
 
       {/* Tag dialog for creating/editing */}
       <TagDialog
@@ -275,7 +306,7 @@ function TagTreeItem({
           <span className='inline-flex min-w-0 items-center gap-1.5'>
             <span className='truncate'>{tag.title}</span>
             {tag.isSystemTag && (
-              <Tooltip content='System tag — managed by Auxx, read-only.'>
+              <Tooltip content='System tag, managed by Auxx. Read-only.'>
                 <Lock className='size-3 shrink-0 text-muted-foreground' aria-label='System tag' />
               </Tooltip>
             )}
@@ -284,7 +315,7 @@ function TagTreeItem({
                 content={
                   tag.tag_description
                     ? 'AI may apply this tag to incoming mail.'
-                    : 'AI may apply this tag to incoming mail — add a description so it knows when.'
+                    : 'AI may apply this tag to incoming mail. Add a description so it knows when.'
                 }>
                 <Sparkles
                   className='size-3 shrink-0 text-primary-500'

--- a/apps/web/src/server/api/routers/mail-classification.test.ts
+++ b/apps/web/src/server/api/routers/mail-classification.test.ts
@@ -57,6 +57,35 @@ const hoisted = vi.hoisted(() => {
     writableInboxIds: new Set<string>(),
     /** Tags as `TagService.getAllTags({ scope: 'thread' })` would answer. */
     threadTags: [] as { id: string; aiClassify: boolean }[],
+    /** `QuotaService.getQuotaStatus()` — null models an org with no quota row. */
+    quotaStatus: null as { isExceeded: boolean } | null,
+    /** What `countReclassifiableThreads` answers (07 §2.5). */
+    reclassifyCount: { count: 412, capped: false, cap: 5000, eligibleTagCount: 4 } as {
+      count: number
+      capped: boolean
+      cap: number
+      eligibleTagCount: number
+    },
+    /** Set to make the shared count query refuse (not opted in / no tags). */
+    reclassifyCountError: null as string | null,
+    /** The org's default LLM, or null for "none configured". */
+    defaultModel: { provider: 'openai', model: 'gpt-test' } as {
+      provider: string
+      model: string
+    } | null,
+    /** `ProviderRegistry.getModelCapabilities(...)`.costPer1kTokens, or null. */
+    modelPrice: { input: 0.001, output: 0.004 } as { input: number; output: number } | null,
+    /** SYSTEM draws credits; CUSTOM is the org's own key and is never metered. */
+    providerType: 'SYSTEM' as 'SYSTEM' | 'CUSTOM',
+    /** The eligible labels, whose title+description length the estimate counts. */
+    eligibleLabels: [
+      { tagId: 't1', title: 'Sales', description: 'x'.repeat(120) },
+      { tagId: 't2', title: 'Support', description: 'x'.repeat(120) },
+    ] as { tagId: string; title: string; description: string | null }[],
+    /** Rows the `SYNCING` existence check finds (07 R-Q8). */
+    syncingRows: [] as unknown[],
+    /** What `getMailReclassifySampleStatus` answers. */
+    sampleStatus: null as unknown,
   }
 
   /** Every side effect the router reached, in order. */
@@ -82,6 +111,16 @@ const hoisted = vi.hoisted(() => {
     calls.push(`onCacheEvent:${event}`)
   })
 
+  const getCredentials = vi.fn(async () => {
+    calls.push('getCredentials')
+    return { providerType: world.providerType, credentialSource: world.providerType }
+  })
+
+  const getEligibleClassificationTags = vi.fn(async () => {
+    calls.push('getEligibleClassificationTags')
+    return world.eligibleLabels
+  })
+
   const recordAuditFromCtx = vi.fn(async () => {
     calls.push('recordAuditFromCtx')
   })
@@ -92,6 +131,22 @@ const hoisted = vi.hoisted(() => {
    * tags are never offered to a mail classifier) and the eligibility flag is
    * `aiClassify`.
    */
+  /**
+   * A stand-in for `QuotaService`. The card reads LIVE credit state rather than
+   * a stored failure record, so the only thing this needs to model is
+   * `isExceeded` — including the `null` an org with no quota row returns.
+   */
+  class QuotaService {
+    constructor(
+      public db: unknown,
+      public organizationId: string
+    ) {}
+    async getQuotaStatus() {
+      calls.push('getQuotaStatus')
+      return world.quotaStatus
+    }
+  }
+
   class TagService {
     constructor(
       public organizationId: string,
@@ -134,6 +189,64 @@ const hoisted = vi.hoisted(() => {
     inbox(LEGACY_PERSONAL, 'inbox', OTHER_USER_ID, true),
   ]
 
+  /**
+   * `@auxx/lib/mail-classification`, faithful in the one respect this router
+   * depends on: everything returns a `neverthrow` Result, and the count is the
+   * SAME function the sample run pages over (07 invariant 10) — so the arguments
+   * the router passes it are the assertion worth making.
+   */
+  /**
+   * A `neverthrow` Result, duck-typed. The router only ever asks `isErr()` and
+   * reads `.value` / `.error`, and building the real thing here would drag the
+   * library into a file whose whole point is the router's own behaviour.
+   */
+  const okResult = <T>(value: T) => ({ isErr: () => false as const, value })
+  const errResult = (message: string) => {
+    const error = new Error(message)
+    ;(error as Error & { statusCode: number }).statusCode = 400
+    return { isErr: () => true as const, error }
+  }
+
+  const countReclassifiableThreads = vi.fn(async (_db: unknown, input: Record<string, unknown>) => {
+    calls.push(`countReclassifiableThreads:${JSON.stringify(input)}`)
+    if (world.reclassifyCountError) return errResult(world.reclassifyCountError)
+    return okResult({ ...world.reclassifyCount, mode: input.mode })
+  })
+
+  const enqueueMailReclassifySample = vi.fn(async (input: Record<string, unknown>) => {
+    calls.push(`enqueueMailReclassifySample:${JSON.stringify(input)}`)
+    return okResult({ jobId: 'job_sample', deduplicated: false })
+  })
+
+  const getMailReclassifySampleStatus = vi.fn(async () => {
+    calls.push('getMailReclassifySampleStatus')
+    return world.sampleStatus
+  })
+
+  const cancelMailReclassifySample = vi.fn(async () => {
+    calls.push('cancelMailReclassifySample')
+    return true
+  })
+
+  /** The org's default LLM — resolved live, exactly like the classifier does. */
+  class SystemModelService {
+    constructor(
+      public db: unknown,
+      public organizationId: string
+    ) {}
+    async getDefault() {
+      calls.push('getDefaultModel')
+      return world.defaultModel
+    }
+  }
+
+  const ProviderRegistry = {
+    getModelCapabilities: (model: string) => {
+      calls.push(`getModelCapabilities:${model}`)
+      return world.modelPrice ? { costPer1kTokens: world.modelPrice } : null
+    },
+  }
+
   const orgCacheGet = vi.fn(async (_orgId: string, key: string) => {
     if (key !== 'inboxes') throw new Error(`unexpected org-cache key ${key}`)
     return inboxes
@@ -157,7 +270,16 @@ const hoisted = vi.hoisted(() => {
     getOrganizationSetting,
     updateOrganizationSetting,
     recordAuditFromCtx,
+    getCredentials,
+    getEligibleClassificationTags,
     TagService,
+    QuotaService,
+    countReclassifiableThreads,
+    enqueueMailReclassifySample,
+    getMailReclassifySampleStatus,
+    cancelMailReclassifySample,
+    SystemModelService,
+    ProviderRegistry,
   }
 })
 
@@ -183,6 +305,26 @@ vi.mock('@auxx/lib/settings', () => ({
   updateOrganizationSetting: hoisted.updateOrganizationSetting,
 }))
 vi.mock('@auxx/lib/tags', () => ({ TagService: hoisted.TagService }))
+vi.mock('@auxx/lib/ai', () => ({
+  QuotaService: hoisted.QuotaService,
+  SystemModelService: hoisted.SystemModelService,
+  ProviderRegistry: hoisted.ProviderRegistry,
+  getCredentials: hoisted.getCredentials,
+}))
+// The estimate counts the REAL label list rather than assuming a size, so this
+// has to answer or the per-thread cost is understated as the vocabulary grows.
+vi.mock('@auxx/lib/mail-classification/labels', () => ({
+  getEligibleClassificationTags: hoisted.getEligibleClassificationTags,
+}))
+// ⚠️ `ModelType` is NOT mocked: the `@auxx/lib/ai` barrel re-exports it as a
+// TYPE, so the router deep-imports the real enum and this pins that the value it
+// asks for is a real member rather than a string this file made up.
+vi.mock('@auxx/lib/mail-classification', () => ({
+  countReclassifiableThreads: hoisted.countReclassifiableThreads,
+  enqueueMailReclassifySample: hoisted.enqueueMailReclassifySample,
+  getMailReclassifySampleStatus: hoisted.getMailReclassifySampleStatus,
+  cancelMailReclassifySample: hoisted.cancelMailReclassifySample,
+}))
 vi.mock('~/server/api/audit-context', () => ({
   recordAuditFromCtx: hoisted.recordAuditFromCtx,
 }))
@@ -219,9 +361,15 @@ vi.mock('~/server/api/trpc', async () => {
 
 const { mailClassificationRouter } = await import('./mail-classification')
 
+/**
+ * `db.execute` backs ONE query in this router: the 07 R-Q8 "is a channel routed
+ * to this inbox mid-backfill" existence check. Rows present ⇒ syncing.
+ */
+const execute = vi.fn(async () => ({ rows: world.syncingRows }))
+
 const caller = (userId: string = USER_ID) =>
   mailClassificationRouter.createCaller({
-    db: {},
+    db: { execute },
     session: { userId, organizationId: ORG_ID, user: { id: userId } },
     capabilities: {
       can: (key: string) => world.capabilities.has(key),
@@ -252,6 +400,18 @@ beforeEach(() => {
     { id: 'tag_billing', aiClassify: true },
     { id: 'tag_vip', aiClassify: false },
   ]
+  world.quotaStatus = { isExceeded: false }
+  world.reclassifyCount = { count: 412, capped: false, cap: 5000, eligibleTagCount: 4 }
+  world.reclassifyCountError = null
+  world.defaultModel = { provider: 'openai', model: 'gpt-test' }
+  world.modelPrice = { input: 0.001, output: 0.004 }
+  world.providerType = 'SYSTEM'
+  world.eligibleLabels = [
+    { tagId: 't1', title: 'Sales', description: 'x'.repeat(120) },
+    { tagId: 't2', title: 'Support', description: 'x'.repeat(120) },
+  ]
+  world.syncingRows = []
+  world.sampleStatus = null
   hoisted.orgSettings.clear()
   vi.clearAllMocks()
   calls.length = 0
@@ -429,6 +589,40 @@ describe('mailClassification router — eligible tags', () => {
       eligibleTagCount: 0,
     })
   })
+})
+
+/**
+ * The classifier runs in the background, so an exhausted balance stops it
+ * silently — no dialog, no toast, nothing failing in front of anyone. This card
+ * is the only place that silence gets broken.
+ */
+describe('mailClassification router — credit exhaustion', () => {
+  it('reports an exhausted balance so the card can say classification is paused', async () => {
+    world.quotaStatus = { isExceeded: true }
+
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      creditsExhausted: true,
+    })
+  })
+
+  it('reports false while credits remain', async () => {
+    world.quotaStatus = { isExceeded: false }
+
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      creditsExhausted: false,
+    })
+  })
+
+  it('an org with no quota row is not "exhausted" — that gate fails open', async () => {
+    // `QuotaService.getQuotaStatus` returns null when the org has no row, and
+    // `enforceQuotaGate` lets those calls THROUGH. Reporting exhaustion here
+    // would accuse the org of a block that is not happening.
+    world.quotaStatus = null
+
+    expect(await caller().getInboxSettings({ inboxId: OWN_PERSONAL })).toMatchObject({
+      creditsExhausted: false,
+    })
+  })
 
   /**
    * Arming an inbox with nothing to apply is inert (C8's double guard), not an
@@ -441,5 +635,329 @@ describe('mailClassification router — eligible tags', () => {
     await expect(
       caller().setInboxEnabled({ inboxId: OWN_PERSONAL, enabled: true })
     ).resolves.toEqual({ enabled: true })
+  })
+})
+
+/**
+ * Retroactive re-classification (`plans/mail-filter/07-mail-reclassification-plan.md`).
+ *
+ * A bulk run bills the org and reads colleagues' mail, so 07 §2.4 (axis 3) gives
+ * it **the same gate as the opt-in** and no looser one — never admin rank. That
+ * is the first thing asserted here, across every procedure, because a read that
+ * counted a private mailbox's backlog would be the same disclosure as answering
+ * "not opted in" for it.
+ */
+const SCOPE = { range: { kind: 'days', days: 30 }, mode: 'fill-gaps' } as const
+
+describe('mailClassification router — the retroactive gate (07 §2.4)', () => {
+  it("answers 404 for another member's personal inbox on every retroactive procedure", async () => {
+    asAutomationAdmin()
+
+    await expect(caller().getBacklog({ inboxId: OTHER_PERSONAL })).rejects.toMatchObject(NOT_FOUND)
+    await expect(
+      caller().getReclassifyPreview({ inboxId: OTHER_PERSONAL, ...SCOPE })
+    ).rejects.toMatchObject(NOT_FOUND)
+    await expect(
+      caller().startReclassifySample({ inboxId: OTHER_PERSONAL, ...SCOPE })
+    ).rejects.toMatchObject(NOT_FOUND)
+    await expect(
+      caller().getReclassifySampleStatus({ inboxId: OTHER_PERSONAL })
+    ).rejects.toMatchObject(NOT_FOUND)
+    await expect(
+      caller().cancelReclassifySample({ inboxId: OTHER_PERSONAL })
+    ).rejects.toMatchObject(NOT_FOUND)
+
+    // Refused before anything was counted, queued or priced.
+    expect(calls).toEqual([])
+  })
+
+  it('answers 403 on a shared inbox to a key holder with no inbox admin', async () => {
+    world.capabilities.add(AUTOMATION_KEY)
+
+    await expect(
+      caller().startReclassifySample({ inboxId: SHARED_INBOX, ...SCOPE })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(hoisted.enqueueMailReclassifySample).not.toHaveBeenCalled()
+  })
+
+  /** The archetypal user again: their own mailbox, holding nothing at all. */
+  it('lets a personal-inbox owner with zero permission keys start a sample', async () => {
+    await expect(
+      caller().startReclassifySample({ inboxId: OWN_PERSONAL, ...SCOPE })
+    ).resolves.toEqual({ jobId: 'job_sample', deduplicated: false })
+    expect(gate).toEqual([])
+  })
+})
+
+describe('mailClassification router — the backlog row (07 §3.1)', () => {
+  /**
+   * ⚠️ ALL TIME + fill-gaps, whatever the dialog is set to. The row answers "is
+   * there history worth classifying at all" — a row keyed on the dialog's 30-day
+   * default would vanish the moment someone narrowed the range.
+   */
+  it('counts all time in fill-gaps mode, bounded by the backlog cap', async () => {
+    world.reclassifyCount = { count: 1000, capped: true, cap: 1000, eligibleTagCount: 4 }
+
+    expect(await caller().getBacklog({ inboxId: OWN_PERSONAL })).toEqual({
+      count: 1000,
+      capped: true,
+      cap: 1000,
+    })
+    expect(hoisted.countReclassifiableThreads).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        range: { kind: 'all-time' },
+        mode: 'fill-gaps',
+        cap: 1000,
+      })
+    )
+  })
+
+  /**
+   * A precondition failure is "nothing to offer", not an error to throw at
+   * someone who only opened a settings page. The dialog, where a human is
+   * mid-action, throws instead — asserted below.
+   */
+  it('answers zero rather than throwing when the inbox cannot run', async () => {
+    world.reclassifyCountError = 'Turn on AI classification for this inbox first.'
+
+    expect(await caller().getBacklog({ inboxId: OWN_PERSONAL })).toMatchObject({ count: 0 })
+  })
+})
+
+describe('mailClassification router — the scope preview (07 §3.2)', () => {
+  /**
+   * ⚠️ 07 invariant 10 — the preview count and the run share ONE predicate. The
+   * number in the confirm is the number the user agreed to spend on, so the two
+   * call sites must hand the count function identical scope arguments.
+   */
+  it('asks the count function for exactly what the run will ask it', async () => {
+    await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })
+    const previewArgs = calls.filter((call) => call.startsWith('countReclassifiableThreads:'))
+    calls.length = 0
+    await caller().startReclassifySample({ inboxId: OWN_PERSONAL, ...SCOPE })
+    const runArgs = calls.filter((call) => call.startsWith('countReclassifiableThreads:'))
+
+    expect(previewArgs).toEqual(runArgs)
+  })
+
+  it('surfaces a precondition failure instead of swallowing it', async () => {
+    world.reclassifyCountError = 'No categories are marked for AI classification yet.'
+
+    await expect(
+      caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })
+    ).rejects.toMatchObject({ message: 'No categories are marked for AI classification yet.' })
+  })
+
+  /**
+   * Credits are estimated against the org's OWN default model, not a constant:
+   * 800 input + 30 output tokens at $0.001/$0.004 per 1k is $0.00092 a
+   * conversation, and a credit is $0.0001 of list-price COGS.
+   */
+  it('estimates credits from the org default model, for the run and for the sample', async () => {
+    const preview = await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })
+
+    expect(preview).toMatchObject({
+      count: 412,
+      capped: false,
+      eligibleTagCount: 4,
+      sampleSize: 100,
+      estimatedCredits: 5060,
+      sampleCredits: 1228,
+      billed: true,
+    })
+  })
+
+  /**
+   * ⚠️ THE ONE THAT WAS WRONG. Credits are only drawn when the credentials are
+   * SYSTEM: `LLMOrchestrator`'s quota gate skips the deduction entirely for a
+   * CUSTOM key. Quoting an org several thousand credits for a run that will
+   * charge it nothing discourages a free action, which is the worst direction for
+   * a cost confirm to be wrong in.
+   */
+  it('quotes ZERO for an org on its own API key, because nothing is metered', async () => {
+    world.providerType = 'CUSTOM'
+
+    const preview = await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })
+
+    expect(preview).toMatchObject({
+      count: 412,
+      estimatedCredits: 0,
+      sampleCredits: 0,
+      billed: false,
+    })
+  })
+
+  /**
+   * The prompt embeds every eligible tag's title AND description (05 C3), so the
+   * per-call cost grows with the vocabulary. A fixed token guess drifts low
+   * exactly as an org adds categories, which is the direction that matters.
+   */
+  it('costs more per conversation as the label set grows', async () => {
+    const small = await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })
+
+    world.eligibleLabels = [
+      ...world.eligibleLabels,
+      { tagId: 't3', title: 'Billing', description: 'y'.repeat(400) },
+      { tagId: 't4', title: 'Order Status', description: 'y'.repeat(400) },
+    ]
+    const large = await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })
+
+    expect(large.estimatedCredits).toBeGreaterThan(small.estimatedCredits ?? 0)
+  })
+
+  /** Rounded UP: a small run must never quote 0 while still costing something. */
+  it('never rounds a real cost down to zero', async () => {
+    world.reclassifyCount = { ...world.reclassifyCount, count: 1 }
+
+    const preview = await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })
+
+    expect(preview.estimatedCredits).toBeGreaterThan(0)
+  })
+
+  /**
+   * ⚠️ Null, never a fabricated number. `UNPRICED_FALLBACK_CREDITS` exists to
+   * BILL a call that slipped through unpriced; quoting it in a preview would
+   * over-state the cost by orders of magnitude.
+   */
+  it('reports null credits when there is no default model, and still counts', async () => {
+    world.defaultModel = null
+
+    expect(await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })).toMatchObject({
+      count: 412,
+      estimatedCredits: null,
+      sampleCredits: null,
+    })
+  })
+
+  it('reports null credits when the registry has no price for that model', async () => {
+    world.modelPrice = null
+
+    expect(await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })).toMatchObject({
+      estimatedCredits: null,
+    })
+  })
+
+  it('caps the sample at what the scope actually holds', async () => {
+    world.reclassifyCount = { count: 12, capped: false, cap: 5000, eligibleTagCount: 4 }
+
+    expect(await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })).toMatchObject({
+      sampleSize: 12,
+    })
+  })
+})
+
+/**
+ * 07 R-Q8 — a run started mid-backfill races the sync and misses everything
+ * still arriving. The user pays for a partial answer with no way to tell.
+ */
+describe('mailClassification router — sync in progress (07 R-Q8)', () => {
+  it('reports a syncing channel in the preview so the dialog can say so', async () => {
+    world.syncingRows = [{ '?column?': 1 }]
+
+    expect(await caller().getReclassifyPreview({ inboxId: OWN_PERSONAL, ...SCOPE })).toMatchObject({
+      syncInProgress: true,
+    })
+  })
+
+  it('refuses to start while a channel is syncing, and queues nothing', async () => {
+    world.syncingRows = [{ '?column?': 1 }]
+
+    await expect(
+      caller().startReclassifySample({ inboxId: OWN_PERSONAL, ...SCOPE })
+    ).rejects.toMatchObject({ cause: { statusCode: 409 } })
+    expect(hoisted.enqueueMailReclassifySample).not.toHaveBeenCalled()
+  })
+})
+
+describe('mailClassification router — starting a sample (07 §2.11)', () => {
+  it('passes the chosen scope through to the queue, with the requester recorded', async () => {
+    await caller().startReclassifySample({
+      inboxId: OWN_PERSONAL,
+      range: { kind: 'threads', threads: 500 },
+      mode: 're-classify',
+    })
+
+    expect(hoisted.enqueueMailReclassifySample).toHaveBeenCalledWith({
+      organizationId: ORG_ID,
+      inboxId: OWN_PERSONAL,
+      range: { kind: 'threads', threads: 500 },
+      mode: 're-classify',
+      requestedByUserId: USER_ID,
+    })
+  })
+
+  it('refuses an empty scope rather than paying a worker to find nothing', async () => {
+    world.reclassifyCount = { count: 0, capped: false, cap: 5000, eligibleTagCount: 4 }
+
+    await expect(
+      caller().startReclassifySample({ inboxId: OWN_PERSONAL, ...SCOPE })
+    ).rejects.toMatchObject({ cause: { statusCode: 400 } })
+    expect(hoisted.enqueueMailReclassifySample).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the inbox is not opted in — a re-run is not a way in', async () => {
+    // 07 invariant 6. The worker re-asserts this too, but a refusal there is a
+    // log line nobody is watching.
+    world.reclassifyCountError = 'Turn on AI classification for this inbox first.'
+
+    await expect(
+      caller().startReclassifySample({ inboxId: OWN_PERSONAL, ...SCOPE })
+    ).rejects.toThrow('Turn on AI classification for this inbox first.')
+    expect(hoisted.enqueueMailReclassifySample).not.toHaveBeenCalled()
+  })
+
+  /** "Somebody pointed a model at this mailbox's history" must not be untraceable. */
+  it('audits the run with the scope it was given', async () => {
+    await caller().startReclassifySample({ inboxId: OWN_PERSONAL, ...SCOPE })
+
+    expect(hoisted.recordAuditFromCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'mail.classification.sample_started',
+        targetId: OWN_PERSONAL,
+        metadata: expect.objectContaining({
+          mode: 'fill-gaps',
+          threadsInScope: 412,
+          sampleSize: 100,
+        }),
+      })
+    )
+  })
+
+  it('never audits a refused run', async () => {
+    world.reclassifyCount = { count: 0, capped: false, cap: 5000, eligibleTagCount: 4 }
+
+    await expect(
+      caller().startReclassifySample({ inboxId: OWN_PERSONAL, ...SCOPE })
+    ).rejects.toBeTruthy()
+    expect(hoisted.recordAuditFromCtx).not.toHaveBeenCalled()
+  })
+})
+
+describe('mailClassification router — polling and cancelling', () => {
+  it('passes a finished sample report straight through to the dialog', async () => {
+    world.sampleStatus = {
+      jobId: 'job_sample',
+      state: 'completed',
+      processed: 100,
+      total: 100,
+      report: { applied: false, classified: 74, abstained: 26 },
+    }
+
+    expect(await caller().getReclassifySampleStatus({ inboxId: OWN_PERSONAL })).toMatchObject({
+      state: 'completed',
+      report: { classified: 74 },
+    })
+  })
+
+  it('answers null when no sample has been run recently', async () => {
+    expect(await caller().getReclassifySampleStatus({ inboxId: OWN_PERSONAL })).toBeNull()
+  })
+
+  it('reports whether the job was actually removed', async () => {
+    expect(await caller().cancelReclassifySample({ inboxId: OWN_PERSONAL })).toEqual({
+      removed: true,
+    })
   })
 })

--- a/apps/web/src/server/api/routers/mail-classification.ts
+++ b/apps/web/src/server/api/routers/mail-classification.ts
@@ -1,8 +1,28 @@
 // apps/web/src/server/api/routers/mail-classification.ts
 
+import { getCredentials, ProviderRegistry, QuotaService, SystemModelService } from '@auxx/lib/ai'
+// The `@auxx/lib/ai` barrel re-exports `ModelType` as a TYPE, so the enum VALUE
+// has to come from its own module — the same deep import `aiIntegration.ts` makes.
+import { ModelType } from '@auxx/lib/ai/providers/types'
+import { CREDIT_USD_VALUE } from '@auxx/lib/ai/quota/client'
 import { onCacheEvent } from '@auxx/lib/cache'
+import { BadRequestError, ConflictError } from '@auxx/lib/errors'
+import {
+  cancelMailReclassifySample,
+  countReclassifiableThreads,
+  enqueueMailReclassifySample,
+  getMailReclassifySampleStatus,
+} from '@auxx/lib/mail-classification'
+import {
+  MAIL_CLASSIFY_BODY_CHARS,
+  MAIL_RECLASSIFY_BACKLOG_COUNT_CAP,
+  MAIL_RECLASSIFY_MAX_THREADS,
+  MAIL_RECLASSIFY_SAMPLE_SIZE,
+} from '@auxx/lib/mail-classification/client'
+import { getEligibleClassificationTags } from '@auxx/lib/mail-classification/labels'
 import { getOrganizationSetting, updateOrganizationSetting } from '@auxx/lib/settings'
 import { TagService } from '@auxx/lib/tags'
+import { sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import {
@@ -87,10 +107,173 @@ async function countEligibleTags(
   return tags.filter((tag) => tag.aiClassify).length
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Retroactive re-classification (plans/mail-filter/07-mail-reclassification-plan.md)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The scope a run is pointed at, as JSON (07 §2.4, axis 1).
+ *
+ * Mirrors `MailReclassifyRange` — presets rather than free-form, so the count
+ * preview stays cheap. `days`/`threads` are bounded here as well as in
+ * `resolveReclassifyWindow` because this is the untrusted edge; the lib call
+ * clamps again, which is the point of it being the one place presets become
+ * bounds.
+ */
+const reclassifyRangeSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('days'), days: z.number().int().positive().max(3650) }),
+  z.object({
+    kind: z.literal('threads'),
+    threads: z.number().int().positive().max(MAIL_RECLASSIFY_MAX_THREADS),
+  }),
+  z.object({
+    kind: z.literal('custom'),
+    sinceIso: z.string().min(1),
+    untilIso: z.string().min(1).optional(),
+  }),
+  z.object({ kind: z.literal('all-time') }),
+])
+
+const reclassifyModeSchema = z.enum(['fill-gaps', 're-classify'])
+
+const reclassifyScopeInput = z.object({
+  inboxId: z.string().min(1),
+  range: reclassifyRangeSchema,
+  mode: reclassifyModeSchema,
+})
+
+/**
+ * USD to credits, ROUNDED UP.
+ *
+ * ⚠️ Deliberately not `usdToCredits`, which rounds to nearest: that lets a small
+ * run quote 0 credits while still costing something, and "0" reads as free. Every
+ * rounding decision in this estimate leans high, because the failure that matters
+ * is a confirm the bill then exceeds.
+ */
+function ceilCredits(usd: number): number {
+  return Math.ceil(usd / CREDIT_USD_VALUE)
+}
+
+/**
+ * Chars per token, used DELIBERATELY LOW so the token count comes out high.
+ *
+ * English averages ~4 chars/token; mail carries markup, URLs and quoted headers
+ * that tokenize worse, so 3 is the conservative floor. Every rounding decision in
+ * this estimate leans the same way: a confirm that under-states the bill is the
+ * one that damages trust.
+ */
+const CHARS_PER_TOKEN = 3
+
+/**
+ * Fixed prompt overhead per call, in tokens: the system prompt, the response
+ * schema, the `From:`/`Subject:` lines and the JSON scaffolding around the label
+ * list. Rounded up generously.
+ */
+const CLASSIFY_FIXED_OVERHEAD_TOKENS = 250
+
+/** Output is a tag id plus a confidence number. Small and bounded; rounded up. */
+const CLASSIFY_ESTIMATED_OUTPUT_TOKENS = 50
+
+/**
+ * What one classification of one thread costs, and whether the org actually pays
+ * for it.
+ *
+ * ⚠️ **`credits: 0` for BYO, and this is the bug it was written to fix.** Credits
+ * are only drawn when the credentials are `SYSTEM` — `LLMOrchestrator`'s quota
+ * gate skips the deduction entirely for `CUSTOM` ones. Pricing the run against
+ * the model's list price regardless meant an org on its own API key was quoted
+ * several hundred credits for something that would charge it nothing, which
+ * discourages a free action.
+ *
+ * ⚠️ **The label list is counted, not assumed.** The prompt embeds every eligible
+ * tag's title AND description (plan 05 C3), so the per-call cost grows as an org
+ * adds categories. A fixed token guess drifts low exactly as the label set grows,
+ * which is the direction that matters.
+ *
+ * Null means "we cannot say" (no default model, or no registry price) and the UI
+ * renders "metered per thread" rather than inventing a number.
+ * `UNPRICED_FALLBACK_CREDITS` is deliberately NOT used: it exists for BILLING a
+ * call that slipped through unpriced, and charging that rate in a preview would
+ * over-state by orders of magnitude.
+ */
+async function estimatePerThread(
+  db: ConstructorParameters<typeof SystemModelService>[0],
+  organizationId: string,
+  userId: string
+): Promise<{ usd: number; billed: boolean } | null> {
+  const def = await new SystemModelService(db, organizationId).getDefault(ModelType.LLM)
+  if (!def) return null
+
+  // Same lookup the orchestrator's quota gate makes, off the `aiCredentials` org
+  // cache, so "will this be billed" is answered by the same source that decides it.
+  const credentials = await getCredentials(
+    { db, organizationId, userId },
+    def.provider,
+    def.model,
+    ModelType.LLM
+  ).catch(() => null)
+  const billed = (credentials?.providerType ?? 'CUSTOM') === 'SYSTEM'
+  if (!billed) return { usd: 0, billed: false }
+
+  const price = ProviderRegistry.getModelCapabilities(def.model)?.costPer1kTokens
+  if (!price) return null
+
+  // The real label list, not a guess at its size.
+  const labels = await getEligibleClassificationTags(db, organizationId).catch(() => [])
+  const labelChars = labels.reduce(
+    (total, label) => total + label.title.length + (label.description?.length ?? 0) + 40,
+    0
+  )
+
+  const inputTokens =
+    CLASSIFY_FIXED_OVERHEAD_TOKENS +
+    Math.ceil(MAIL_CLASSIFY_BODY_CHARS / CHARS_PER_TOKEN) +
+    Math.ceil(labelChars / CHARS_PER_TOKEN)
+
+  return {
+    usd: (inputTokens * price.input + CLASSIFY_ESTIMATED_OUTPUT_TOKENS * price.output) / 1000,
+    billed: true,
+  }
+}
+
+/**
+ * Is a channel routed to this inbox mid-backfill (07 R-Q8)?
+ *
+ * A run started during a sync races the backfill and misses everything still
+ * arriving — the user pays for a partial answer and has no way to tell. The
+ * post-sync prompt (07 §3.4) exists so they are asked at the right moment
+ * instead.
+ *
+ * ⚠️ Deliberately a live read, not the `channels` org cache: that cache
+ * explicitly omits `syncStatus` because it flips too often to be cached, so
+ * reading it there would answer "not syncing" for the whole cache TTL.
+ *
+ * `deletedAt IS NULL` because disconnect is a soft delete
+ * (`docs/channels-mail-architecture-guide.md`) — a disconnected channel frozen
+ * in `SYNCING` would otherwise block the inbox forever.
+ */
+async function isChannelSyncInProgress(
+  db: { execute: (query: ReturnType<typeof sql>) => Promise<{ rows?: unknown[] }> },
+  organizationId: string,
+  inboxId: string
+): Promise<boolean> {
+  const result = await db.execute(sql`
+    SELECT 1
+    FROM "InboxIntegration" ii
+    JOIN "Integration" i ON i."id" = ii."integrationId"
+    WHERE ii."inboxId" = ${inboxId}
+      AND i."organizationId" = ${organizationId}
+      AND i."deletedAt" IS NULL
+      AND i."syncStatus" = 'SYNCING'
+    LIMIT 1
+  `)
+  return (result.rows?.length ?? 0) > 0
+}
+
 export const mailClassificationRouter = createTRPCRouter({
   /**
-   * The card's whole state: is this inbox opted in, and is there anything for
-   * the classifier to apply.
+   * The card's whole state: is this inbox opted in, is there anything for the
+   * classifier to apply, and can it currently pay for a call.
    *
    * Authorized exactly like the write. A read is a disclosure too — answering
    * "not opted in" for a colleague's personal mailbox would confirm it exists.
@@ -101,12 +284,28 @@ export const mailClassificationRouter = createTRPCRouter({
       const authority = await loadMailFilterAuthority(ctx)
       assertCanConfigureInboxAutomation(authority, input.inboxId)
 
-      const [inboxIds, eligibleTagCount] = await Promise.all([
+      const [inboxIds, eligibleTagCount, quota] = await Promise.all([
         readOptedInInboxIds(ctx.session.organizationId),
         countEligibleTags(ctx.session.organizationId, ctx.session.userId, ctx.db),
+        // LIVE state, deliberately not a record of the last failure. The
+        // classifier runs in the background with no user watching, so an
+        // exhausted balance stops it in silence — every other AI surface finds
+        // out because a human was mid-action and got a dialog. This card is the
+        // only place that silence can be broken, and reading the current status
+        // means it cannot go stale or need clearing.
+        new QuotaService(ctx.db, ctx.session.organizationId).getQuotaStatus(),
       ])
 
-      return { enabled: inboxIds.includes(input.inboxId), eligibleTagCount }
+      return {
+        enabled: inboxIds.includes(input.inboxId),
+        eligibleTagCount,
+        // Only meaningful for orgs on system credentials — BYO calls never draw
+        // credits, so their balance stays untouched and `isExceeded` stays
+        // false. An org that burned its credits and THEN moved to its own key
+        // is the one case this over-reports, and the sentence it produces is
+        // still true, just no longer the reason anything stopped.
+        creditsExhausted: quota?.isExceeded ?? false,
+      }
     }),
 
   /**
@@ -162,5 +361,209 @@ export const mailClassificationRouter = createTRPCRouter({
       }
 
       return { enabled: input.enabled }
+    }),
+
+  /**
+   * The backlog row's number (07 §3.1) — how much of this inbox's history the
+   * classifier has never seen.
+   *
+   * ⚠️ Always ALL TIME + `fill-gaps`, regardless of what the dialog is currently
+   * set to. The row answers "is there history worth classifying at all", which is
+   * a different question from the dialog's 30-day default, and a row keyed on the
+   * dialog's scope would vanish the moment someone narrowed the range.
+   *
+   * Capped at {@link MAIL_RECLASSIFY_BACKLOG_COUNT_CAP} and reported as such (07
+   * R-Q5): an order of magnitude for a decision, not a billing figure, and an
+   * exact count over a large mailbox is a slow query.
+   *
+   * A precondition failure (not opted in, no eligible tags) answers **zero**
+   * rather than throwing. Both mean "there is nothing to offer here", and the
+   * card already says why — turning a settings page into an error because a
+   * background query disagreed with the toggle it is rendered next to would be
+   * noise. The dialog, where a human is mid-action, throws instead.
+   */
+  getBacklog: capabilityProcedure
+    .input(z.object({ inboxId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      assertCanConfigureInboxAutomation(authority, input.inboxId)
+
+      const counted = await countReclassifiableThreads(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        inboxId: input.inboxId,
+        range: { kind: 'all-time' },
+        mode: 'fill-gaps',
+        cap: MAIL_RECLASSIFY_BACKLOG_COUNT_CAP,
+      })
+      if (counted.isErr()) {
+        return { count: 0, capped: false, cap: MAIL_RECLASSIFY_BACKLOG_COUNT_CAP }
+      }
+      return {
+        count: counted.value.count,
+        capped: counted.value.capped,
+        cap: counted.value.cap,
+      }
+    }),
+
+  /**
+   * What one run over this scope would touch, and roughly what it would cost
+   * (07 §3.2).
+   *
+   * ⚠️ The count comes from `countReclassifiableThreads`, which compiles the SAME
+   * `buildReclassifyWhere` predicate the run pages over (07 invariant 10). The
+   * number in the confirm is the number the user agreed to spend on, so a second
+   * implementation here would be a way to quietly charge for something else.
+   *
+   * Authorized exactly like the opt-in: `assertCanConfigureInboxAutomation`, never
+   * admin rank. A bulk run bills the org and reads colleagues' mail, so it gets no
+   * looser a gate than arming the inbox in the first place (07 §2.4, axis 3).
+   */
+  getReclassifyPreview: capabilityProcedure
+    .input(reclassifyScopeInput)
+    .query(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      assertCanConfigureInboxAutomation(authority, input.inboxId)
+
+      const [counted, perThread, syncInProgress] = await Promise.all([
+        countReclassifiableThreads(ctx.db, {
+          organizationId: ctx.session.organizationId,
+          inboxId: input.inboxId,
+          range: input.range,
+          mode: input.mode,
+        }),
+        // A missing default model must not blank the whole preview — the thread
+        // count is still the useful half, and the UI degrades to "metered per
+        // thread" rather than inventing a number.
+        estimatePerThread(ctx.db, ctx.session.organizationId, ctx.session.userId).catch(() => null),
+        isChannelSyncInProgress(ctx.db, ctx.session.organizationId, input.inboxId),
+      ])
+      // A human is looking at this one, so a precondition failure is surfaced.
+      if (counted.isErr()) throw counted.error
+
+      const { count, capped, cap, eligibleTagCount } = counted.value
+      const sampleSize = Math.min(MAIL_RECLASSIFY_SAMPLE_SIZE, count)
+
+      return {
+        count,
+        /** ⚠️ True means "more than `cap` matched" — render `cap+`, never a bare number. */
+        capped,
+        cap,
+        eligibleTagCount,
+        /**
+         * Null when the org has no default model or the registry has no price;
+         * 0 when the org is on its own API key and will not be charged at all.
+         *
+         * ⚠️ `Math.ceil`, not `usdToCredits`'s `Math.round`. Rounding to nearest
+         * lets a small run quote 0 credits while still costing something, which
+         * reads as "free" — every other rounding decision in this estimate leans
+         * high and so must this one.
+         */
+        estimatedCredits: perThread === null ? null : ceilCredits(perThread.usd * count),
+        /** False when the org uses its own API key: nothing is metered. */
+        billed: perThread?.billed ?? true,
+        sampleSize,
+        sampleCredits: perThread === null ? null : ceilCredits(perThread.usd * sampleSize),
+        /** 07 R-Q8 — a run started mid-backfill misses everything still arriving. */
+        syncInProgress,
+      }
+    }),
+
+  /**
+   * Enqueue a sample of ~100 threads (07 §2.11, R6).
+   *
+   * ⚠️ It applies nothing and writes no marker, so there is nothing to undo — but
+   * it still costs one inference per thread and still meters credits. That is why
+   * it is gated exactly like the opt-in and audited like it.
+   *
+   * The preconditions are re-asserted here rather than left to the worker:
+   * `runMailReclassifySample` refuses a non-opted-in inbox itself (07 invariant
+   * 6), but a refusal on the queue is a log line nobody is watching, whereas this
+   * one lands in the dialog the user is looking at.
+   */
+  startReclassifySample: capabilityProcedure
+    .input(reclassifyScopeInput)
+    .mutation(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      assertCanConfigureInboxAutomation(authority, input.inboxId)
+
+      // 07 R-Q8 — block, do not queue-and-hope. Starting mid-backfill races the
+      // sync and samples a mailbox that is still filling up.
+      if (await isChannelSyncInProgress(ctx.db, ctx.session.organizationId, input.inboxId)) {
+        throw new ConflictError(
+          'This inbox is still syncing. Wait for the sync to finish, then classify its history.'
+        )
+      }
+
+      const counted = await countReclassifiableThreads(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        inboxId: input.inboxId,
+        range: input.range,
+        mode: input.mode,
+      })
+      if (counted.isErr()) throw counted.error
+      if (counted.value.count === 0) {
+        throw new BadRequestError('There are no conversations in that range to classify.')
+      }
+
+      const queued = await enqueueMailReclassifySample({
+        organizationId: ctx.session.organizationId,
+        inboxId: input.inboxId,
+        range: input.range,
+        mode: input.mode,
+        requestedByUserId: ctx.session.userId,
+      })
+      if (queued.isErr()) throw queued.error
+
+      // "Somebody pointed a model at this mailbox's history" is exactly the kind
+      // of spend that should never be untraceable — same reasoning as the opt-in.
+      await recordAuditFromCtx(ctx, {
+        category: 'settings',
+        action: 'mail.classification.sample_started',
+        targetType: 'Inbox',
+        targetId: input.inboxId,
+        metadata: {
+          range: input.range,
+          mode: input.mode,
+          threadsInScope: counted.value.count,
+          sampleSize: Math.min(MAIL_RECLASSIFY_SAMPLE_SIZE, counted.value.count),
+        },
+      })
+
+      return queued.value
+    }),
+
+  /**
+   * Poll one inbox's sample — the dialog's results (07 §3.3) and the card row's
+   * progress surface (07 §3.1) read the same status.
+   *
+   * `null` means no sample has been run recently: the job carries its report as
+   * its return value and is reaped an hour after it completes, so "no job" and
+   * "no result any more" are deliberately the same answer.
+   */
+  getReclassifySampleStatus: capabilityProcedure
+    .input(z.object({ inboxId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      assertCanConfigureInboxAutomation(authority, input.inboxId)
+
+      return await getMailReclassifySampleStatus(ctx.session.organizationId, input.inboxId)
+    }),
+
+  /**
+   * Stop a sample (07 §2.5 — "a long run must be stoppable from the UI").
+   *
+   * Safe at any point because a sample commits nothing. Returns `false` when the
+   * job is already running: BullMQ cancellation is the worker's abort signal,
+   * which the run honours between threads, so the UI reports "stopping" rather
+   * than claiming it stopped.
+   */
+  cancelReclassifySample: capabilityProcedure
+    .input(z.object({ inboxId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      assertCanConfigureInboxAutomation(authority, input.inboxId)
+
+      const removed = await cancelMailReclassifySample(ctx.session.organizationId, input.inboxId)
+      return { removed }
     }),
 })

--- a/apps/web/src/server/api/routers/tag.ts
+++ b/apps/web/src/server/api/routers/tag.ts
@@ -1,10 +1,228 @@
 // server/api/routers/tag.ts
 
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { getCachedCustomFields, getCachedEntityDefId } from '@auxx/lib/cache'
+import { NotFoundError, UnprocessableEntityError } from '@auxx/lib/errors'
+import { getEligibleClassificationTags } from '@auxx/lib/mail-classification/labels'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+import {
+  AI_CATEGORY_COMMERCE_TAGS,
+  AI_CATEGORY_PARTNER_TAGS,
+  type AiCategoryTagSeed,
+  seedAiCategoryTags,
+} from '@auxx/lib/seed/ai-category-tags'
 import { TagService } from '@auxx/lib/tags'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '../trpc'
+import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
 const scopeSchema = z.enum(['thread', 'article']).optional()
+
+/** `EntityDefinition.entityType` tags live on. */
+const TAG_DEF = 'tag'
+
+/** `systemAttribute` of the provenance marker on a seeded category (plan 06 §3.1). */
+const TAG_TEMPLATE_KEY_ATTRIBUTE = 'tag_template_key'
+
+/**
+ * The opt-in vertical packs (plan 06 D3). `core` is deliberately absent: the four core
+ * categories are every org's baseline and there is no supported way to switch them off as a
+ * group.
+ */
+export const OPTIONAL_CATEGORY_PACKS = ['commerce', 'partner'] as const
+export type OptionalCategoryPack = (typeof OPTIONAL_CATEGORY_PACKS)[number]
+
+/** The shipped definitions each pack contributes, keyed by pack (plan 06 §2.2–2.3). */
+const PACK_SEEDS: Record<OptionalCategoryPack, AiCategoryTagSeed[]> = {
+  commerce: AI_CATEGORY_COMMERCE_TAGS,
+  partner: AI_CATEGORY_PARTNER_TAGS,
+}
+
+/** Human framing for the picker. The label text itself always comes from the seeds. */
+const PACK_COPY: Record<OptionalCategoryPack, { title: string; summary: string }> = {
+  commerce: {
+    title: 'Commerce',
+    summary:
+      'For businesses that sell and ship physical goods. Separates "where is my order" and returns from general support.',
+  },
+  partner: {
+    title: 'Partners & dealers',
+    summary:
+      'For businesses approached by resellers, installers, distributors or affiliates. These are enquiries that are neither an end-customer sale nor a support request.',
+  },
+}
+
+/** One shipped category as the picker sees it. */
+export interface CategoryPackLabel {
+  /** Stable shipped identity — the thing a pack is resolved by, never the title. */
+  templateKey: string
+  /**
+   * The live title when the tag exists, otherwise the shipped one. Titles are editable on a
+   * seeded category (plan 06 D4), so the org's own wording is what gets shown.
+   */
+  title: string
+  /** The shipped definition. This text is what the classifier reads (plan 05 C3). */
+  description: string
+  emoji: string
+  /** The tag exists in this org and is not archived. */
+  present: boolean
+  /** The classifier may currently apply it — i.e. the pack is on for this label. */
+  eligible: boolean
+}
+
+/**
+ * One suggestion group, for display only.
+ *
+ * ⚠️ A group is NOT a stateful object. There is deliberately no `enabled` here
+ * (plan 06 §7.2, reversed 2026-08-10): a group-level switch would be a second
+ * control over `tag_ai_classify`, which the tag list already owns per tag, and
+ * its "off" could never mean anything — turning a pack off never deleted its
+ * categories, so they stayed in the list while the switch claimed otherwise.
+ * Adding is one-way; from then on these are ordinary tags.
+ */
+export interface CategoryPackView {
+  pack: OptionalCategoryPack
+  title: string
+  summary: string
+  labels: CategoryPackLabel[]
+}
+
+/** What `categoryPacks` answers. */
+export interface CategoryPacksView {
+  packs: CategoryPackView[]
+  /**
+   * How many labels the classifier prompt would actually contain right now.
+   *
+   * Read from `getEligibleClassificationTags` — the exact function the classifier calls — so
+   * this number cannot drift from the prompt. Plan 05 §12.5 gap 4 flagged that a second,
+   * independently derived count already exists (`mailClassification.getInboxSettings` counts
+   * via `TagService`); this surface deliberately does not add a third.
+   */
+  eligibleLabelCount: number
+  /**
+   * False until entity migration `075-tag-template-key` has materialized the field. Without it
+   * a pack cannot be identified, seeded or turned off, so the UI renders read-only.
+   */
+  ready: boolean
+}
+
+/**
+ * Resolve `tag` def id + the `tag_template_key` field id from the org cache.
+ *
+ * Both come from `@auxx/lib/cache` rather than fresh queries — `entityDefs` and the per-def
+ * custom fields are cached keys, and re-querying them defeats the invalidation.
+ */
+async function loadTagDefContext(organizationId: string) {
+  const tagDefId = await getCachedEntityDefId(organizationId, TAG_DEF)
+  if (!tagDefId) return { tagDefId: undefined, templateKeyFieldId: undefined }
+
+  const fields = await getCachedCustomFields(organizationId, tagDefId)
+  const templateKeyFieldId = fields.find(
+    (field) => field.systemAttribute === TAG_TEMPLATE_KEY_ATTRIBUTE
+  )?.id
+
+  return { tagDefId, templateKeyFieldId }
+}
+
+/**
+ * Every pack's state in one read.
+ *
+ * ⚠️ Packs are resolved by `tag_template_key`, never by title (plan 06 invariant 5). A seeded
+ * category can be renamed by the org and a user-created tag can share a shipped title; only the
+ * template key says "this row is ours".
+ *
+ * NOTE: this query code would normally live in `packages/lib` per CLAUDE.md. It is here because
+ * there is no pack module in lib yet; it should move to one beside `mail-classification/labels`
+ * the moment there is a second caller.
+ */
+async function readCategoryPacks(db: Database, organizationId: string): Promise<CategoryPacksView> {
+  const { tagDefId, templateKeyFieldId } = await loadTagDefContext(organizationId)
+
+  // The classifier's own view of the label set — the count AND the membership test below.
+  const eligibleLabels = await getEligibleClassificationTags(db, organizationId)
+  const eligibleIds = new Set(eligibleLabels.map((label) => label.tagId))
+  const titleById = new Map(eligibleLabels.map((label) => [label.tagId, label.title]))
+
+  const seedByKey = new Map<string, AiCategoryTagSeed>()
+  for (const pack of OPTIONAL_CATEGORY_PACKS) {
+    for (const seed of PACK_SEEDS[pack]) seedByKey.set(seed.templateKey, seed)
+  }
+
+  const tagIdByKey = new Map<string, string>()
+  if (tagDefId && templateKeyFieldId) {
+    const rows = await db
+      .select({
+        entityId: schema.FieldValue.entityId,
+        valueText: schema.FieldValue.valueText,
+      })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          eq(schema.FieldValue.fieldId, templateKeyFieldId),
+          inArray(schema.FieldValue.valueText, [...seedByKey.keys()])
+        )
+      )
+
+    for (const row of rows) {
+      if (row.entityId && row.valueText && !tagIdByKey.has(row.valueText)) {
+        tagIdByKey.set(row.valueText, row.entityId)
+      }
+    }
+  }
+
+  // An archived category is not present for our purposes: it is not in the prompt, and the
+  // seeder would create a fresh row rather than resurrect it.
+  const liveTitleById = new Map<string, string>()
+  const candidateIds = [...new Set(tagIdByKey.values())]
+  if (tagDefId && candidateIds.length > 0) {
+    const instances = await db
+      .select({
+        id: schema.EntityInstance.id,
+        displayName: schema.EntityInstance.displayName,
+      })
+      .from(schema.EntityInstance)
+      .where(
+        and(
+          eq(schema.EntityInstance.organizationId, organizationId),
+          eq(schema.EntityInstance.entityDefinitionId, tagDefId),
+          inArray(schema.EntityInstance.id, candidateIds),
+          isNull(schema.EntityInstance.archivedAt)
+        )
+      )
+    for (const instance of instances) {
+      liveTitleById.set(instance.id, instance.displayName ?? '')
+    }
+  }
+
+  const packs = OPTIONAL_CATEGORY_PACKS.map((pack) => {
+    const labels: CategoryPackLabel[] = PACK_SEEDS[pack].map((seed) => {
+      const tagId = tagIdByKey.get(seed.templateKey)
+      const present = Boolean(tagId && liveTitleById.has(tagId))
+      const eligible = Boolean(tagId && eligibleIds.has(tagId))
+      const liveTitle = tagId ? (titleById.get(tagId) ?? liveTitleById.get(tagId)) : undefined
+
+      return {
+        templateKey: seed.templateKey,
+        title: liveTitle?.trim() ? liveTitle : seed.title,
+        description: seed.description,
+        emoji: seed.emoji,
+        present,
+        eligible,
+      }
+    })
+
+    return { pack, ...PACK_COPY[pack], labels }
+  })
+
+  return {
+    packs,
+    eligibleLabelCount: eligibleLabels.length,
+    ready: Boolean(tagDefId && templateKeyFieldId),
+  }
+}
 
 export const tagRouter = createTRPCRouter({
   /**
@@ -45,8 +263,132 @@ export const tagRouter = createTRPCRouter({
       return tagService.getTagHierarchy({ scope: input?.scope })
     }),
 
+  /**
+   * The shipped mail categories an org could add, plus the current size of the classifier's
+   * label set (plan 06 §7.2).
+   *
+   * A read, and a cheap one — no permission key. Which categories exist is already visible to
+   * anyone who can see the tag list.
+   */
+  suggestedCategories: protectedProcedure.query(async ({ ctx }) => {
+    return readCategoryPacks(ctx.db, ctx.session.organizationId)
+  }),
+
+  /**
+   * Add one or more suggested categories to the org (plan 06 §7.2, revised 2026-08-10).
+   *
+   * ⚠️ **ONE-WAY, and that is the whole point of the revision.** This used to be
+   * `setCategoryPack(pack, enabled)`, a persistent per-pack switch. It was removed because its
+   * "off" could not describe anything true: turning a pack off never deleted its categories, so
+   * they carried on sitting in the tag list — and a user could independently flip
+   * `tag_ai_classify` from the tag dialog, leaving the pack switch and the tag disagreeing with
+   * no defensible answer for which was right.
+   *
+   * So: adding creates the categories (idempotently) and marks them eligible. Everything after
+   * that is ordinary tag management in the list, where `tag_ai_classify` has exactly one control.
+   * To stop the classifier applying one, switch it off on the tag itself.
+   *
+   * Gated on `canEditEntity(tag)` — the same authority every other tag write on this page runs
+   * through (`api.record.create` / `fieldValue.setBulk`). Deliberately not a coarse settings
+   * key: a second authority disagreeing with the one the record path enforces is the defect the
+   * tags page's own comment exists to avoid.
+   */
+  addSuggestedCategories: capabilityProcedure
+    .input(
+      z.object({
+        /** Shipped identities to add. Resolved by `tag_template_key`, never by title. */
+        templateKeys: z.array(z.string().min(1)).min(1).max(20),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const { tagDefId, templateKeyFieldId } = await loadTagDefContext(organizationId)
+
+      if (!tagDefId) throw new NotFoundError('This organization has no tag records yet.')
+      ctx.capabilities.assertEditEntity(tagDefId)
+
+      if (!templateKeyFieldId) {
+        throw new UnprocessableEntityError(
+          'Mail categories are not set up for this organization yet. Run entity migration 075-tag-template-key first.'
+        )
+      }
+
+      const requested = new Set(input.templateKeys)
+      let view = await readCategoryPacks(ctx.db, organizationId)
+      const known = view.packs.flatMap((group) => group.labels)
+      if (!known.some((label) => requested.has(label.templateKey))) {
+        throw new NotFoundError('None of those categories is a known suggestion.')
+      }
+
+      // Seed only the groups that actually own something missing. The seeder is idempotent BY
+      // TITLE, so running it against a group whose categories the org has renamed would create a
+      // second copy — checking presence by template key first keeps that to the narrow case
+      // where a renamed category has also been archived.
+      const groupsToSeed = view.packs
+        .filter((group) =>
+          group.labels.some((label) => requested.has(label.templateKey) && !label.present)
+        )
+        .map((group) => group.pack)
+
+      if (groupsToSeed.length > 0) {
+        await seedAiCategoryTags(ctx.db, organizationId, userId, { packs: groupsToSeed })
+        view = await readCategoryPacks(ctx.db, organizationId)
+      }
+
+      const handler = new UnifiedCrudHandler(organizationId, userId, ctx.db, undefined, {
+        capabilities: ctx.capabilities,
+      })
+
+      // Re-resolve ids from the template keys rather than trusting the pre-seed view.
+      const idByKey = await resolveTagIdsByTemplateKey(ctx.db, organizationId, templateKeyFieldId, [
+        ...requested,
+      ])
+
+      for (const label of view.packs.flatMap((group) => group.labels)) {
+        if (!requested.has(label.templateKey)) continue
+        // Already eligible is a no-op, not an error: adding twice must be safe.
+        if (label.eligible) continue
+        const tagId = idByKey.get(label.templateKey)
+        if (!tagId) continue
+        // `update` is (recordId, values, MODES, options) — options is the FOURTH arg.
+        await handler.update(toRecordId(tagDefId, tagId), { tag_ai_classify: true })
+      }
+
+      return readCategoryPacks(ctx.db, organizationId)
+    }),
+
   // NOTE: Tag create / update / delete endpoints have been removed.
   // The tag UI uses api.record.create, useSaveFieldValue (api.fieldValue.setBulk),
   // and api.record.delete instead. Tag-to-entity assignments use the RELATIONSHIP
   // field type via useSaveFieldValue with fieldType='RELATIONSHIP'.
 })
+
+/** `tag_template_key` → `EntityInstance.id` for the given keys. */
+async function resolveTagIdsByTemplateKey(
+  db: Database,
+  organizationId: string,
+  templateKeyFieldId: string,
+  templateKeys: string[]
+): Promise<Map<string, string>> {
+  const rows = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      valueText: schema.FieldValue.valueText,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, templateKeyFieldId),
+        inArray(schema.FieldValue.valueText, templateKeys)
+      )
+    )
+
+  const byKey = new Map<string, string>()
+  for (const row of rows) {
+    if (row.entityId && row.valueText && !byKey.has(row.valueText)) {
+      byKey.set(row.valueText, row.entityId)
+    }
+  }
+  return byKey
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -718,6 +718,24 @@
       "import": "./dist/knowledge-sources/run-source-sync.mjs",
       "default": "./src/knowledge-sources/run-source-sync.ts"
     },
+    "./mail-classification": {
+      "types": "./src/mail-classification/index.ts",
+      "source": "./src/mail-classification/index.ts",
+      "import": "./dist/mail-classification/index.mjs",
+      "default": "./src/mail-classification/index.ts"
+    },
+    "./mail-classification/client": {
+      "types": "./src/mail-classification/client.ts",
+      "source": "./src/mail-classification/client.ts",
+      "import": "./dist/mail-classification/client.mjs",
+      "default": "./src/mail-classification/client.ts"
+    },
+    "./mail-classification/labels": {
+      "types": "./src/mail-classification/labels.ts",
+      "source": "./src/mail-classification/labels.ts",
+      "import": "./dist/mail-classification/labels.mjs",
+      "default": "./src/mail-classification/labels.ts"
+    },
     "./mail-domains": {
       "types": "./src/mail-domains/index.ts",
       "source": "./src/mail-domains/index.ts",
@@ -1107,6 +1125,12 @@
       "source": "./src/seed/index.ts",
       "import": "./dist/seed/index.mjs",
       "default": "./src/seed/index.ts"
+    },
+    "./seed/ai-category-tags": {
+      "types": "./src/seed/ai-category-tags.ts",
+      "source": "./src/seed/ai-category-tags.ts",
+      "import": "./dist/seed/ai-category-tags.mjs",
+      "default": "./src/seed/ai-category-tags.ts"
     },
     "./seed/entity-migrations": {
       "types": "./src/seed/entity-migrations/index.ts",

--- a/packages/lib/src/data-migrations/migrations/076-mail-category-rework.test.ts
+++ b/packages/lib/src/data-migrations/migrations/076-mail-category-rework.test.ts
@@ -1,0 +1,889 @@
+// packages/lib/src/data-migrations/migrations/076-mail-category-rework.test.ts
+//
+// Migration 076 is the only DESTRUCTIVE step of the mail-category rework
+// (plan 06 §8), so its tests are about the five things the plan marks ⚠️:
+//
+//  1. a tuned description is never overwritten (§5.3, invariant 6);
+//  2. the unfreeze is its own write and lands FIRST (invariant 4);
+//  3. the discriminator is `is_system_tag`, never the title (invariant 5);
+//  4. ids are preserved — adopt and rename, never delete-and-recreate
+//     (invariant 3);
+//  5. every step is idempotent on its own terms, because the migration is
+//     REPLAYED if it is invoked through the entity-migration runner
+//     (05 §12.2).
+//
+// `UnifiedCrudHandler`, the seeder, the org cache and the system-user lookup are
+// stubbed (all lib-internal modules, not the shared `@auxx/database` /
+// `@auxx/logger` / `drizzle-orm` mocks), so the assertions are about the values
+// and the ORDER this migration hands the write path.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Every `update`/`delete`, in call order, tagged with its handler's bypass. */
+  calls: [] as {
+    op: 'update' | 'delete'
+    recordId: string
+    values?: Record<string, unknown>
+    bypass: string[]
+    modes?: Record<string, 'set' | 'add' | 'remove'>
+    options?: Record<string, unknown>
+  }[],
+  seedCalls: [] as { organizationId: string; options?: { packs?: readonly string[] } }[],
+  seedResult: { created: [] as string[], skipped: [] as string[], adopted: [] as string[] },
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    private bypass: string[]
+    constructor(
+      _orgId: string,
+      _userId: string,
+      _db: unknown,
+      _socketId?: unknown,
+      options?: { bypassFieldGuards?: Set<string> }
+    ) {
+      this.bypass = [...(options?.bypassFieldGuards ?? [])]
+    }
+    // Mirrors the REAL signature — (recordId, values, MODES, options). A loose
+    // (recordId, values) stub would accept `SEED_OPTS` silently landing in the
+    // array-mode map.
+    async update(
+      recordId: string,
+      values: Record<string, unknown>,
+      modes?: Record<string, 'set' | 'add' | 'remove'>,
+      options?: Record<string, unknown>
+    ) {
+      h.calls.push({ op: 'update', recordId, values, bypass: this.bypass, modes, options })
+      return { instance: { id: recordId }, recordId, values }
+    }
+    async delete(recordId: string, options?: Record<string, unknown>) {
+      h.calls.push({ op: 'delete', recordId, bypass: this.bypass, options })
+    }
+  },
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ invalidateAndRecompute: async () => undefined }),
+}))
+
+vi.mock('../../users/system-user-service', () => ({
+  SystemUserService: { getSystemUserForActions: async () => 'user_system' },
+}))
+
+vi.mock('../../seed/ai-category-tags', async (importOriginal) => {
+  // Partial mock: the taxonomy constants ARE the contract under test (the
+  // never-clobber rule compares against `LEGACY_STARTER_DESCRIPTIONS`), so only
+  // the write function is replaced.
+  const actual = await importOriginal<typeof import('../../seed/ai-category-tags')>()
+  return {
+    ...actual,
+    seedAiCategoryTags: async (
+      _db: unknown,
+      organizationId: string,
+      _userId: string,
+      options?: { packs?: readonly string[] }
+    ) => {
+      h.seedCalls.push({ organizationId, options })
+      return { ...h.seedResult }
+    },
+  }
+})
+
+import {
+  AI_CATEGORY_CORE_TAGS,
+  AI_CATEGORY_PARENT_TAG,
+  AI_CATEGORY_PARENT_TEMPLATE_KEY,
+  AI_CATEGORY_STARTER_TAGS,
+  LEGACY_STARTER_DESCRIPTIONS,
+} from '../../seed/ai-category-tags'
+import {
+  findCategoryContainer,
+  inferAiCategoryPacks,
+  isSeededCategory,
+  LEGACY_PARENT_TITLE,
+  LEGACY_SYSTEM_ADOPTIONS,
+  LEGACY_SYSTEM_TAG_TITLES,
+  migrateOrganizationTaxonomy,
+  migration076MailCategoryRework,
+  PRESERVED_SYSTEM_TAG_TITLES,
+  planDescriptionWrite,
+  planStarterPatch,
+  RETIRED_LABEL_TITLES,
+  RETIRED_SYSTEM_TAG_TITLES,
+  type TagCensusRow,
+} from './076-mail-category-rework'
+
+const ORG = 'org_1'
+const TAG_DEF_ID = 'def_tag'
+
+const seedFor = (title: string) => {
+  const seed = AI_CATEGORY_STARTER_TAGS.find((t) => t.title === title)
+  if (!seed) throw new Error(`no seed for ${title}`)
+  return seed
+}
+
+function row(overrides: Partial<TagCensusRow> & { id: string; title: string }): TagCensusRow {
+  return {
+    isSystemTag: false,
+    templateKey: null,
+    description: null,
+    parentId: null,
+    aiClassify: false,
+    ...overrides,
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PURE CORE
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ⚠️ Invariant 6, "the unrecoverable one". The description is the classifier's
+// instruction and the one field this whole plan exists to make the business's.
+describe('planDescriptionWrite — the never-clobber rule (§5.3)', () => {
+  const target = seedFor('Sales').description
+  /** The exact string the pre-rework `Sales` starter shipped with. */
+  const legacySales = LEGACY_STARTER_DESCRIPTIONS.Sales as string
+
+  it('writes over the PREVIOUSLY shipped default', () => {
+    expect(planDescriptionWrite(legacySales, target)).toBe('write')
+  })
+
+  it('writes into an empty or whitespace-only description', () => {
+    expect(planDescriptionWrite(null, target)).toBe('write')
+    expect(planDescriptionWrite(undefined, target)).toBe('write')
+    expect(planDescriptionWrite('', target)).toBe('write')
+    expect(planDescriptionWrite('   \n ', target)).toBe('write')
+  })
+
+  it('leaves a tuned description alone', () => {
+    expect(planDescriptionWrite('Only enquiries from our EU resellers.', target)).toBe(
+      'user-edited'
+    )
+  })
+
+  // The comparison is byte-identical on purpose. A trailing space is a keystroke
+  // someone made; treating it as "still our default" is how real tuning is lost.
+  it('treats a near-miss as an edit, never as our default', () => {
+    expect(planDescriptionWrite(`${legacySales} `, target)).toBe('user-edited')
+    expect(planDescriptionWrite(legacySales.toLowerCase(), target)).toBe('user-edited')
+  })
+
+  // The replay case: already migrated, so there is nothing to write at all.
+  it('reports unchanged when the value is already the target', () => {
+    expect(planDescriptionWrite(target, target)).toBe('unchanged')
+  })
+
+  // A description seeded for a DIFFERENT label is still ours — an org that
+  // renamed a category (or 076 mid-run) must not have it read as a user edit.
+  it('recognises every shipped default, not just this label’s', () => {
+    expect(planDescriptionWrite(LEGACY_STARTER_DESCRIPTIONS.Notification, target)).toBe('write')
+    expect(planDescriptionWrite(seedFor('Billing').description, target)).toBe('write')
+    expect(planDescriptionWrite(AI_CATEGORY_PARENT_TAG.description, target)).toBe('write')
+  })
+})
+
+describe('inferAiCategoryPacks — Q3’s recommendation (§5.4)', () => {
+  it('turns commerce on for a Shopify org', () => {
+    expect(inferAiCategoryPacks({ hasShopify: true })).toEqual(['commerce'])
+  })
+
+  it('defaults everything off otherwise', () => {
+    expect(inferAiCategoryPacks({ hasShopify: false })).toEqual([])
+  })
+
+  // Nothing in the data distinguishes a dealer network, and every extra label is
+  // a silent accuracy tax on every classification (invariant 10).
+  it('never infers the partner pack', () => {
+    expect(inferAiCategoryPacks({ hasShopify: true })).not.toContain('partner')
+  })
+})
+
+describe('findCategoryContainer', () => {
+  it('finds it by template key first', () => {
+    const container = row({
+      id: 'c1',
+      title: 'Anything At All',
+      templateKey: AI_CATEGORY_PARENT_TEMPLATE_KEY,
+    })
+    expect(findCategoryContainer([container])?.id).toBe('c1')
+  })
+
+  it('finds a pre-rework container by its shipped description', () => {
+    const container = row({
+      id: 'c1',
+      title: AI_CATEGORY_PARENT_TAG.title,
+      description: AI_CATEGORY_PARENT_TAG.description,
+    })
+    expect(findCategoryContainer([container])?.id).toBe('c1')
+  })
+
+  it('finds one by the categories hanging under it', () => {
+    const container = row({ id: 'c1', title: AI_CATEGORY_PARENT_TAG.title })
+    const child = row({ id: 't1', title: 'Billing', parentId: 'c1' })
+    expect(findCategoryContainer([container, child])?.id).toBe('c1')
+  })
+
+  // ⚠️ Invariant 5. Stamping a user's own group with the container's template key
+  // would make it permanently undeletable.
+  it('refuses a same-named group with nothing proving it is ours', () => {
+    const impostor = row({
+      id: 'c1',
+      title: AI_CATEGORY_PARENT_TAG.title,
+      description: 'my own grouping',
+    })
+    const unrelated = row({ id: 't1', title: 'Warranty Claims', parentId: 'c1' })
+    expect(findCategoryContainer([impostor, unrelated])).toBeNull()
+  })
+
+  it('never adopts a SYSTEM tag as the container', () => {
+    const systemGroup = row({
+      id: 'c1',
+      title: AI_CATEGORY_PARENT_TAG.title,
+      description: AI_CATEGORY_PARENT_TAG.description,
+      isSystemTag: true,
+    })
+    expect(findCategoryContainer([systemGroup])).toBeNull()
+  })
+})
+
+describe('isSeededCategory', () => {
+  it('accepts a tag already carrying a template key', () => {
+    expect(
+      isSeededCategory(row({ id: 't1', title: 'Sales', templateKey: 'category:sales' }), null)
+    ).toBe(true)
+  })
+
+  it('accepts a tag parented under our container', () => {
+    expect(isSeededCategory(row({ id: 't1', title: 'Sales', parentId: 'c1' }), 'c1')).toBe(true)
+  })
+
+  it('accepts a tag still carrying a description we shipped', () => {
+    expect(
+      isSeededCategory(
+        row({ id: 't1', title: 'Sales', description: LEGACY_STARTER_DESCRIPTIONS.Sales }),
+        null
+      )
+    ).toBe(true)
+  })
+
+  // ⚠️ Invariant 5 — a title collision is not consent.
+  it('rejects a user’s own same-named tag', () => {
+    expect(
+      isSeededCategory(row({ id: 't1', title: 'Sales', description: 'leads from the show' }), 'c1')
+    ).toBe(false)
+  })
+
+  // A system tag goes down the adopt path, which unfreezes FIRST. Treating it as
+  // ours here would send a description write at a frozen tag and be rejected.
+  it('never claims a system tag', () => {
+    expect(
+      isSeededCategory(row({ id: 't1', title: 'Sales', isSystemTag: true, parentId: 'c1' }), 'c1')
+    ).toBe(false)
+  })
+})
+
+describe('planStarterPatch', () => {
+  const seed = seedFor('Sales')
+
+  it('stamps the key and rewrites an untouched legacy description', () => {
+    const patch = planStarterPatch(
+      row({ id: 't1', title: 'Sales', description: LEGACY_STARTER_DESCRIPTIONS.Sales }),
+      seed
+    )
+    expect(patch).toEqual({
+      tag_template_key: 'category:sales',
+      tag_description: seed.description,
+    })
+  })
+
+  it('stamps the key but keeps a tuned description', () => {
+    const patch = planStarterPatch(
+      row({ id: 't1', title: 'Sales', description: 'our own wording' }),
+      seed
+    )
+    expect(patch).toEqual({ tag_template_key: 'category:sales' })
+  })
+
+  // ⚠️ Step 2 stamps the key and the description, nothing else. An org that
+  // switched a category off made a routing decision; flipping it back on would
+  // be the migration re-enabling inference nobody asked for.
+  it('never touches tag_ai_classify', () => {
+    const patch = planStarterPatch(
+      row({ id: 't1', title: 'Sales', aiClassify: false, description: '' }),
+      seed
+    )
+    expect(patch).not.toHaveProperty('tag_ai_classify')
+  })
+
+  // Replay: nothing left to do, so no write is issued at all.
+  it('returns null once the row is already settled', () => {
+    expect(
+      planStarterPatch(
+        row({
+          id: 't1',
+          title: 'Sales',
+          templateKey: 'category:sales',
+          description: seed.description,
+        }),
+        seed
+      )
+    ).toBeNull()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE TARGET STATE — the 13 legacy system tags are accounted for, exhaustively
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('the legacy taxonomy is fully partitioned (D6)', () => {
+  it('assigns every one of the 13 legacy system tags a fate', () => {
+    const adopted = LEGACY_SYSTEM_ADOPTIONS.map((a) => a.from)
+    const starters = AI_CATEGORY_CORE_TAGS.map((t) => t.title)
+    const accounted = new Set([
+      ...adopted,
+      ...RETIRED_SYSTEM_TAG_TITLES,
+      ...PRESERVED_SYSTEM_TAG_TITLES,
+      ...starters,
+      LEGACY_PARENT_TITLE,
+    ])
+    const orphans = LEGACY_SYSTEM_TAG_TITLES.filter((title) => !accounted.has(title))
+    expect(orphans).toEqual([])
+  })
+
+  // ⚠️ Invariant 8. Priority and segment are not intents, and an eligible `VIP`
+  // would let classification guard exit 6 suppress categorisation on any thread
+  // a filter marked VIP.
+  it('leaves Urgent and VIP out of every mutating list', () => {
+    for (const title of PRESERVED_SYSTEM_TAG_TITLES) {
+      expect(RETIRED_SYSTEM_TAG_TITLES).not.toContain(title)
+      expect(RETIRED_LABEL_TITLES).not.toContain(title)
+      expect(LEGACY_SYSTEM_ADOPTIONS.map((a) => a.from)).not.toContain(title)
+      expect(AI_CATEGORY_STARTER_TAGS.map((t) => t.title)).not.toContain(title)
+    }
+  })
+
+  // The adoption target is named by template key, so a rename in the taxonomy
+  // propagates instead of silently un-adopting the legacy tag.
+  it('resolves both adoptions against the live taxonomy', () => {
+    const keys = AI_CATEGORY_STARTER_TAGS.map((t) => t.templateKey)
+    for (const adoption of LEGACY_SYSTEM_ADOPTIONS) {
+      expect(keys).toContain(adoption.templateKey)
+    }
+    expect(LEGACY_SYSTEM_ADOPTIONS.map((a) => a.from)).toEqual(['Orders', 'Account Management'])
+  })
+
+  // D2: both are answerable from headers for free, and they ship as seeded
+  // filters now — so they must be gone from the label taxonomy AND cleared on
+  // existing orgs.
+  it('retires Newsletter and Notification as labels only', () => {
+    expect([...RETIRED_LABEL_TITLES]).toEqual(['Newsletter', 'Notification'])
+    for (const title of RETIRED_LABEL_TITLES) {
+      expect(AI_CATEGORY_STARTER_TAGS.map((t) => t.title)).not.toContain(title)
+      // Not deleted, not unflagged as a system tag — they were never system tags.
+      expect(RETIRED_SYSTEM_TAG_TITLES).not.toContain(title)
+    }
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE MIGRATION — order of writes, bypass scoping, idempotency
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Chainable fake resolving the next queued result set per `await`. */
+function makeDb(results: unknown[][]) {
+  const queue = [...results]
+  const chain = (): Record<string, unknown> =>
+    new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'then') {
+            return (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+              Promise.resolve(queue.shift() ?? []).then(resolve, reject)
+          }
+          return () => chain()
+        },
+      }
+    )
+  return { select: () => chain() } as never
+}
+
+const TAG_DEF = [{ id: TAG_DEF_ID }]
+const FIELDS = [
+  { id: 'cf_title', systemAttribute: 'title' },
+  { id: 'cf_description', systemAttribute: 'tag_description' },
+  { id: 'cf_is_system_tag', systemAttribute: 'is_system_tag' },
+  { id: 'cf_template_key', systemAttribute: 'tag_template_key' },
+  { id: 'cf_ai_classify', systemAttribute: 'tag_ai_classify' },
+  { id: 'cf_parent', systemAttribute: 'tag_parent' },
+]
+
+/** One tag as the census reads it: an instance row plus its FieldValue rows. */
+interface FakeTag {
+  id: string
+  title: string
+  isSystemTag?: boolean
+  templateKey?: string | null
+  description?: string | null
+  parentId?: string | null
+  aiClassify?: boolean
+}
+
+function instancesOf(tags: FakeTag[]) {
+  return tags.map((t) => ({ id: t.id, displayName: t.title }))
+}
+
+function valuesOf(tags: FakeTag[]) {
+  const out: Record<string, unknown>[] = []
+  for (const t of tags) {
+    out.push({ entityId: t.id, fieldId: 'cf_title', valueText: t.title })
+    if (t.description !== undefined) {
+      out.push({ entityId: t.id, fieldId: 'cf_description', valueText: t.description })
+    }
+    if (t.isSystemTag !== undefined) {
+      out.push({ entityId: t.id, fieldId: 'cf_is_system_tag', valueBoolean: t.isSystemTag })
+    }
+    if (t.templateKey !== undefined) {
+      out.push({ entityId: t.id, fieldId: 'cf_template_key', valueText: t.templateKey })
+    }
+    if (t.aiClassify !== undefined) {
+      out.push({ entityId: t.id, fieldId: 'cf_ai_classify', valueBoolean: t.aiClassify })
+    }
+    if (t.parentId !== undefined) {
+      out.push({ entityId: t.id, fieldId: 'cf_parent', relatedEntityId: t.parentId })
+    }
+  }
+  return out
+}
+
+/**
+ * The queue for one `migrateOrganizationTaxonomy` pass:
+ * tag def · fields · instances · values · the Shopify probe · then the step-6
+ * re-read (instances · values).
+ *
+ * The probe short-circuits: an `Integration` hit skips the app-installation
+ * query entirely, so a Shopify org consumes ONE slot here and a non-Shopify org
+ * consumes two. Getting that wrong silently shifts every later result set.
+ */
+function queue(before: FakeTag[], after: FakeTag[] = before, shopify = false): unknown[][] {
+  return [
+    TAG_DEF,
+    FIELDS,
+    instancesOf(before),
+    valuesOf(before),
+    ...(shopify ? [[{ id: 'int_1' }]] : [[], []]),
+    instancesOf(after),
+    valuesOf(after),
+  ]
+}
+
+const updatesOf = (values: string) => h.calls.filter((c) => c.values && values in c.values)
+
+beforeEach(() => {
+  h.calls.length = 0
+  h.seedCalls.length = 0
+  h.seedResult = { created: [], skipped: [], adopted: [] }
+})
+
+describe('migrateOrganizationTaxonomy — prerequisites (§5.1 step 1)', () => {
+  // ⚠️ `FieldValue.fieldId` is a real FK and the write path silently ignores an
+  // attribute with no CustomField row, so half-migrating would leave categories
+  // that LOOK seeded: deletable, unresettable, invisible to a re-run.
+  it('aborts with a logged warning when tag_template_key is not materialized', async () => {
+    const db = makeDb([TAG_DEF, FIELDS.filter((f) => f.systemAttribute !== 'tag_template_key')])
+
+    const report = await migrateOrganizationTaxonomy(db, ORG)
+
+    expect(report.skipped).toBe('tag_template_key-missing')
+    expect(h.calls).toEqual([])
+    expect(h.seedCalls).toEqual([])
+  })
+
+  it('aborts when tag_ai_classify is not materialized', async () => {
+    const db = makeDb([TAG_DEF, FIELDS.filter((f) => f.systemAttribute !== 'tag_ai_classify')])
+
+    const report = await migrateOrganizationTaxonomy(db, ORG)
+
+    expect(report.skipped).toBe('tag_ai_classify-missing')
+    expect(h.calls).toEqual([])
+  })
+
+  it('skips an org with no tag entity', async () => {
+    const report = await migrateOrganizationTaxonomy(makeDb([[]]), ORG)
+
+    expect(report.skipped).toBe('no-tag-entity')
+    expect(h.calls).toEqual([])
+  })
+})
+
+describe('migrateOrganizationTaxonomy — step 2, the existing starters', () => {
+  const seededOrg: FakeTag[] = [
+    {
+      id: 'c1',
+      title: 'Mail Categories',
+      description: AI_CATEGORY_PARENT_TAG.description,
+      isSystemTag: false,
+    },
+    {
+      id: 't_sales',
+      title: 'Sales',
+      parentId: 'c1',
+      description: LEGACY_STARTER_DESCRIPTIONS.Sales,
+      aiClassify: true,
+      isSystemTag: false,
+    },
+  ]
+
+  it('stamps the template key and adopts the new description', async () => {
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(seededOrg)), ORG)
+
+    const sales = h.calls.find((c) => c.recordId === `${TAG_DEF_ID}:t_sales`)
+    expect(sales?.values).toEqual({
+      tag_template_key: 'category:sales',
+      tag_description: seedFor('Sales').description,
+    })
+    expect(report.stamped).toContain('Sales')
+  })
+
+  // ⚠️ Invariant 2 — anyone who can write this field can make their own tag
+  // permanently undeletable, so the bypass is the whole enforcement and it is
+  // scoped to that one attribute.
+  it('writes tag_template_key through a bypass scoped to that field alone', async () => {
+    await migrateOrganizationTaxonomy(makeDb(queue(seededOrg)), ORG)
+
+    const sales = h.calls.find((c) => c.recordId === `${TAG_DEF_ID}:t_sales`)
+    expect(sales?.bypass).toEqual(['tag_template_key'])
+    // Options ride in the FOURTH arg; the third is the array-mode map.
+    expect(sales?.modes).toBeUndefined()
+    expect(sales?.options).toEqual({ skipEvents: true })
+  })
+
+  // ⚠️ Invariant 6, the unrecoverable one.
+  it('never overwrites a tuned description', async () => {
+    const tuned = seededOrg.map((t) =>
+      t.id === 't_sales' ? { ...t, description: 'Only EU reseller enquiries.' } : t
+    )
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(tuned)), ORG)
+
+    const sales = h.calls.find((c) => c.recordId === `${TAG_DEF_ID}:t_sales`)
+    expect(sales?.values).toEqual({ tag_template_key: 'category:sales' })
+    expect(report.userEdits).toContain('Sales')
+  })
+
+  // ⚠️ Invariant 5 — the same title, none of the evidence.
+  it('leaves a user’s own same-named tag entirely alone', async () => {
+    const usersOwn: FakeTag[] = [
+      { id: 't_sales', title: 'Sales', description: 'leads from the trade show' },
+    ]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(usersOwn)), ORG)
+
+    expect(h.calls).toEqual([])
+    expect(report.stamped).toEqual([])
+  })
+
+  // The container gets a key too, so it cannot be deleted out from under its
+  // children — but only when something PROVES it is ours.
+  it('stamps the container’s own template key', async () => {
+    await migrateOrganizationTaxonomy(makeDb(queue(seededOrg)), ORG)
+
+    const container = h.calls.find((c) => c.recordId === `${TAG_DEF_ID}:c1`)
+    expect(container?.values).toMatchObject({
+      tag_template_key: AI_CATEGORY_PARENT_TEMPLATE_KEY,
+    })
+  })
+
+  it('writes nothing at all on a replay', async () => {
+    const migrated: FakeTag[] = [
+      {
+        id: 'c1',
+        title: 'Mail Categories',
+        templateKey: AI_CATEGORY_PARENT_TEMPLATE_KEY,
+        description: AI_CATEGORY_PARENT_TAG.description,
+        isSystemTag: false,
+      },
+      {
+        id: 't_sales',
+        title: 'Sales',
+        parentId: 'c1',
+        templateKey: 'category:sales',
+        description: seedFor('Sales').description,
+        aiClassify: true,
+        isSystemTag: false,
+      },
+    ]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(migrated)), ORG)
+
+    expect(h.calls).toEqual([])
+    expect(report.stamped).toEqual([])
+    expect(report.userEdits).toEqual([])
+  })
+})
+
+describe('migrateOrganizationTaxonomy — step 3, adopt and rename', () => {
+  const legacyOrg: FakeTag[] = [
+    { id: 'c1', title: 'Mail Categories', description: AI_CATEGORY_PARENT_TAG.description },
+    { id: 'p_topic', title: LEGACY_PARENT_TITLE, isSystemTag: true },
+    { id: 't_acct', title: 'Account Management', isSystemTag: true, parentId: 'p_topic' },
+  ]
+
+  // ⚠️ Invariant 4 — `rejectIfSystemTag` reads the CURRENT flag at hook time, so
+  // a combined write is rejected on title, description AND parent.
+  it('clears is_system_tag in its own write, before the rename', async () => {
+    await migrateOrganizationTaxonomy(makeDb(queue(legacyOrg)), ORG)
+
+    const acct = h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:t_acct`)
+    expect(acct).toHaveLength(2)
+    expect(acct[0]?.values).toEqual({ is_system_tag: false })
+    expect(acct[0]?.bypass).toEqual(['is_system_tag'])
+    expect(acct[1]?.values).toMatchObject({ title: 'Account' })
+    // Re-granting `is_system_tag` on the second write would reopen the exact hole
+    // the two-write split closes.
+    expect(acct[1]?.bypass).toEqual(['tag_template_key'])
+  })
+
+  it('renames in place, keeping the id — no delete, no recreate', async () => {
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(legacyOrg)), ORG)
+
+    // ⚠️ Invariant 3: filters, mined suggestions and threads all reference this id.
+    const retune = h.calls.find(
+      (c) => c.recordId === `${TAG_DEF_ID}:t_acct` && c.values?.title !== undefined
+    )
+    expect(retune?.recordId).toBe(`${TAG_DEF_ID}:t_acct`)
+    expect(retune?.values).toMatchObject({
+      title: 'Account',
+      tag_template_key: 'category:account',
+      tag_ai_classify: true,
+      tag_scope: 'thread',
+      tag_parent: `${TAG_DEF_ID}:c1`,
+      tag_description: seedFor('Account').description,
+    })
+    expect(h.calls.some((c) => c.op === 'delete' && c.recordId === `${TAG_DEF_ID}:t_acct`)).toBe(
+      false
+    )
+    expect(report.adopted).toContain('Account Management → Account')
+  })
+
+  // ⚠️ Invariant 5 — a user's own `Account Management` is theirs.
+  it('ignores a same-named tag that is not flagged is_system_tag', async () => {
+    const usersOwn = legacyOrg.map((t) => (t.id === 't_acct' ? { ...t, isSystemTag: false } : t))
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(usersOwn)), ORG)
+
+    expect(h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:t_acct`)).toEqual([])
+    expect(report.adopted).toEqual([])
+  })
+
+  it('refuses a rename that would duplicate an existing title', async () => {
+    const collision = [...legacyOrg, { id: 't_account', title: 'Account' }]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(collision)), ORG)
+
+    expect(h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:t_acct`)).toEqual([])
+    expect(report.adopted).toEqual([])
+  })
+
+  // `Orders` is a COMMERCE label. The legacy tag is adopted wherever it exists —
+  // step 3 carries no pack qualifier — but the commerce pack itself is only
+  // seeded where a Shopify integration says so.
+  it('adopts Orders → Order Status and infers commerce from Shopify', async () => {
+    const orders: FakeTag[] = [
+      { id: 'c1', title: 'Mail Categories', description: AI_CATEGORY_PARENT_TAG.description },
+      { id: 't_orders', title: 'Orders', isSystemTag: true },
+    ]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(orders, orders, true)), ORG)
+
+    expect(report.adopted).toContain('Orders → Order Status')
+    expect(report.packs).toEqual(['commerce'])
+    expect(h.seedCalls[0]?.options).toEqual({ packs: ['commerce'] })
+  })
+})
+
+describe('migrateOrganizationTaxonomy — steps 5 and D2, retirement', () => {
+  const retiring: FakeTag[] = [
+    { id: 'c1', title: 'Mail Categories', description: AI_CATEGORY_PARENT_TAG.description },
+    { id: 'p_topic', title: LEGACY_PARENT_TITLE, isSystemTag: true },
+    { id: 't_legal', title: 'Legal', isSystemTag: true, parentId: 'p_topic' },
+    { id: 't_urgent', title: 'Urgent', isSystemTag: true },
+    {
+      id: 't_news',
+      title: 'Newsletter',
+      parentId: 'c1',
+      description: LEGACY_STARTER_DESCRIPTIONS.Newsletter,
+      aiClassify: true,
+    },
+  ]
+
+  it('unflags a retired topic and never deletes it', async () => {
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(retiring)), ORG)
+
+    const legal = h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:t_legal`)
+    expect(legal).toHaveLength(1)
+    expect(legal[0]?.values).toEqual({ is_system_tag: false })
+    expect(legal[0]?.op).toBe('update')
+    expect(report.unflagged).toEqual(['Legal'])
+    // An org may have applied it by hand, and an unflagged tag costs nothing.
+    expect(h.calls.some((c) => c.op === 'delete')).toBe(false)
+  })
+
+  // ⚠️ Invariant 8 / §5.1 step 7.
+  it('leaves Urgent completely untouched', async () => {
+    await migrateOrganizationTaxonomy(makeDb(queue(retiring)), ORG)
+
+    expect(h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:t_urgent`)).toEqual([])
+  })
+
+  // D2 — the label goes, the tag stays: mail already carries it.
+  it('clears tag_ai_classify on Newsletter without deleting the tag', async () => {
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(retiring)), ORG)
+
+    const news = h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:t_news`)
+    expect(news).toHaveLength(1)
+    expect(news[0]?.values).toEqual({ tag_ai_classify: false })
+    // No bypass: `tag_ai_classify` is an ordinary updatable field.
+    expect(news[0]?.bypass).toEqual([])
+    expect(report.labelsRetired).toEqual(['Newsletter'])
+  })
+
+  it('leaves a user’s own Newsletter tag eligible', async () => {
+    const usersOwn = retiring.map((t) =>
+      t.id === 't_news' ? { ...t, parentId: null, description: 'our monthly digest' } : t
+    )
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(usersOwn)), ORG)
+
+    expect(h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:t_news`)).toEqual([])
+    expect(report.labelsRetired).toEqual([])
+  })
+
+  it('does not re-clear an already-retired label on a replay', async () => {
+    const replayed = retiring.map((t) =>
+      t.id === 't_news'
+        ? { ...t, aiClassify: false }
+        : t.id === 't_legal'
+          ? { ...t, isSystemTag: false }
+          : t
+    )
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(replayed)), ORG)
+
+    expect(report.labelsRetired).toEqual([])
+    expect(report.unflagged).toEqual([])
+  })
+})
+
+describe('migrateOrganizationTaxonomy — step 6, collapsing the parents', () => {
+  it('keeps Topic Categorization while it still has children', async () => {
+    const withChildren: FakeTag[] = [
+      { id: 'p_topic', title: LEGACY_PARENT_TITLE, isSystemTag: true },
+      { id: 't_legal', title: 'Legal', isSystemTag: false, parentId: 'p_topic' },
+    ]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(withChildren)), ORG)
+
+    expect(report.legacyParentDeleted).toBe(false)
+    expect(h.calls.some((c) => c.op === 'delete')).toBe(false)
+  })
+
+  it('unflags then deletes an empty Topic Categorization', async () => {
+    const empty: FakeTag[] = [{ id: 'p_topic', title: LEGACY_PARENT_TITLE, isSystemTag: true }]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(empty)), ORG)
+
+    // `rejectDeleteIfSystemTag` refuses a system tag's delete, so the flag has to
+    // be cleared first — its own write, for the same reason as invariant 4.
+    const topic = h.calls.filter((c) => c.recordId === `${TAG_DEF_ID}:p_topic`)
+    expect(topic.map((c) => c.op)).toEqual(['update', 'delete'])
+    expect(topic[0]?.values).toEqual({ is_system_tag: false })
+    expect(topic[0]?.bypass).toEqual(['is_system_tag'])
+    expect(report.legacyParentDeleted).toBe(true)
+  })
+
+  it('re-parents a category adopted before the container existed', async () => {
+    // The org had no `Mail Categories` at census time; step 4's seeder made one.
+    const before: FakeTag[] = [{ id: 't_orders', title: 'Orders', isSystemTag: true }]
+    const after: FakeTag[] = [
+      { id: 'c1', title: 'Mail Categories', templateKey: AI_CATEGORY_PARENT_TEMPLATE_KEY },
+      { id: 't_orders', title: 'Order Status', templateKey: 'category:order-status' },
+    ]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(before, after, true)), ORG)
+
+    const reparent = h.calls.find(
+      (c) => c.recordId === `${TAG_DEF_ID}:t_orders` && c.values?.tag_parent
+    )
+    expect(reparent?.values).toEqual({ tag_parent: `${TAG_DEF_ID}:c1` })
+    expect(report.reparented).toEqual(['Order Status'])
+  })
+
+  it('does not re-parent a category already under the container', async () => {
+    const settled: FakeTag[] = [
+      { id: 'c1', title: 'Mail Categories', templateKey: AI_CATEGORY_PARENT_TEMPLATE_KEY },
+      {
+        id: 't_sales',
+        title: 'Sales',
+        parentId: 'c1',
+        templateKey: 'category:sales',
+        description: seedFor('Sales').description,
+      },
+    ]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(settled)), ORG)
+
+    expect(report.reparented).toEqual([])
+    expect(updatesOf('tag_parent')).toEqual([])
+  })
+
+  // The container must never become its own parent.
+  it('never re-parents the container itself', async () => {
+    const settled: FakeTag[] = [
+      { id: 'c1', title: 'Mail Categories', templateKey: AI_CATEGORY_PARENT_TEMPLATE_KEY },
+    ]
+
+    await migrateOrganizationTaxonomy(makeDb(queue(settled)), ORG)
+
+    expect(h.calls.filter((c) => c.values?.tag_parent)).toEqual([])
+  })
+})
+
+describe('migrateOrganizationTaxonomy — step 4 delegates to the seeder', () => {
+  it('asks the seeder for exactly the inferred packs', async () => {
+    const org: FakeTag[] = [{ id: 'c1', title: 'Mail Categories' }]
+
+    await migrateOrganizationTaxonomy(makeDb(queue(org)), ORG)
+
+    expect(h.seedCalls).toHaveLength(1)
+    expect(h.seedCalls[0]).toEqual({ organizationId: ORG, options: { packs: [] } })
+  })
+
+  it('reports what the seeder created', async () => {
+    h.seedResult = { created: ['Returns & Refunds'], skipped: [], adopted: ['Support'] }
+    const org: FakeTag[] = [{ id: 'c1', title: 'Mail Categories' }]
+
+    const report = await migrateOrganizationTaxonomy(makeDb(queue(org, org, true)), ORG)
+
+    expect(report.created).toEqual(['Returns & Refunds'])
+    expect(report.adopted).toContain('Support')
+  })
+})
+
+describe('migration076MailCategoryRework', () => {
+  it('claims the id 076 in the shared ledger', () => {
+    // ⚠️ The `NNN-` space spans data-migrations/ AND seed/entity-migrations/;
+    // `075-tag-template-key` is the entity migration this one depends on.
+    expect(migration076MailCategoryRework.id).toBe('076-mail-category-rework')
+  })
+
+  it('is registered exactly once', async () => {
+    const { ALL_DATA_MIGRATIONS } = await import('../registry')
+    const matches = ALL_DATA_MIGRATIONS.filter((m) => m.id === migration076MailCategoryRework.id)
+    expect(matches).toHaveLength(1)
+    // It must sort after the entity migration that materializes the field.
+    expect(ALL_DATA_MIGRATIONS.some((m) => m.id === '075-tag-template-key')).toBe(true)
+    expect('076-mail-category-rework' > '075-tag-template-key').toBe(true)
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/076-mail-category-rework.ts
+++ b/packages/lib/src/data-migrations/migrations/076-mail-category-rework.ts
@@ -1,0 +1,938 @@
+// packages/lib/src/data-migrations/migrations/076-mail-category-rework.ts
+//
+// Retire the legacy system tags and adopt the new mail-category taxonomy
+// (plans/mail-filter/06-mail-categories-rework-plan.md §5).
+//
+// THE FIVE TRAPS THIS FILE EXISTS TO AVOID — each one is a plan ⚠️:
+//
+//  1. **Never clobber an edited description** (§5.3, invariant 6 — "the
+//     unrecoverable one"). A seeded category's description IS the classifier's
+//     instruction, and re-wording it per business is the entire point of the
+//     rework. So a description is overwritten ONLY when it is empty or
+//     byte-identical to something we previously shipped. That is why
+//     `LEGACY_STARTER_DESCRIPTIONS` exists in `seed/ai-category-tags.ts` — this
+//     migration is its only consumer.
+//  2. **Unfreeze in its own write, BEFORE the description write** (invariant 4).
+//     `rejectIfSystemTag` reads the tag's CURRENT `is_system_tag` at hook time,
+//     so a combined `{ is_system_tag: false, tag_description: … }` still trips
+//     the guard on the description. `adoptLegacySystemStarter` already does this
+//     correctly and is reused verbatim for the two renames.
+//  3. **The discriminator is `is_system_tag = true`, never the title**
+//     (invariant 5). A user-created tag called `Orders` is theirs; a title
+//     collision is not consent.
+//  4. **Ids are preserved** (invariant 3). Every legacy tag is adopted and
+//     renamed in place, never deleted and recreated — filters, mined
+//     suggestions and threads all reference these ids.
+//  5. **This migration is REPLAYED, not ledger-guarded** if it is ever invoked
+//     through `runEntityMigrationsForOrg` (05 §12.2 — `alreadyUpToDate` is a
+//     report, not a guard). Every step is idempotent on its own terms: it reads
+//     the current state and writes only the difference, never "has this run
+//     before".
+//
+// WHAT THIS MIGRATION MUST NOT DO: re-classify anything (invariant 12). It
+// changes the vocabulary underneath already-classified mail and leaves it
+// labelled with the old categories; re-classification is a product feature
+// (`07-mail-reclassification-plan.md`) and a migration may not spend money.
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import { type RecordId, toRecordId } from '../../resources/resource-id'
+import {
+  AI_CATEGORY_PARENT_TAG,
+  AI_CATEGORY_PARENT_TEMPLATE_KEY,
+  AI_CATEGORY_STARTER_TAGS,
+  type AiCategoryPack,
+  type AiCategoryTagSeed,
+  aiCategoryTagsForPacks,
+  LEGACY_STARTER_DESCRIPTIONS,
+  seedAiCategoryTags,
+} from '../../seed/ai-category-tags'
+import { SystemUserService } from '../../users/system-user-service'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-076')
+
+/** The `EntityDefinition.entityType` tags live on. */
+const TAG_DEF = 'tag'
+
+/** Thread-scoped only — article tags are KB content, never mail labels. */
+const THREAD_SCOPE = 'thread'
+
+/** Every tag write here is a reshape: no realtime fan-out, no notifications. */
+const SEED_OPTS = { skipEvents: true } as const
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE TARGET STATE — what happens to each of the 13 legacy system tags (D6)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Frozen snapshot of `014-backfill-system-tags.ts`'s canonical title list — the
+ * 13 tags `OrganizationSeeder.seedTags` created as SYSTEM tags.
+ *
+ * Kept here so the partition below can be proven exhaustive in a test: every
+ * one of these 13 is adopted, retired, preserved, collapsed, or already an
+ * ordinary starter. A title that belongs to none of those buckets would be left
+ * frozen forever with nothing pointing at it.
+ */
+export const LEGACY_SYSTEM_TAG_TITLES: readonly string[] = Object.freeze([
+  'Topic Categorization',
+  'Account Management',
+  'Billing',
+  'Customer Feedback',
+  'Legal',
+  'Sales',
+  'Security',
+  'Shipping',
+  'Troubleshooting',
+  'Support',
+  'Urgent',
+  'Orders',
+  'VIP',
+])
+
+/** The legacy grouping node the taxonomy collapses into `Mail Categories` (D6). */
+export const LEGACY_PARENT_TITLE = 'Topic Categorization'
+
+/**
+ * The legacy SYSTEM tags worth keeping, adopted in place and renamed (§5.1
+ * step 3).
+ *
+ * The target is named by `templateKey`, not by title, so a later rename in the
+ * taxonomy propagates here automatically instead of silently un-adopting.
+ *
+ * ⚠️ Matched on `is_system_tag = true` only. A user's own `Orders` tag is
+ * theirs (invariant 5), and its id is preserved either way (invariant 3).
+ */
+export const LEGACY_SYSTEM_ADOPTIONS: readonly { from: string; templateKey: string }[] =
+  Object.freeze([
+    { from: 'Orders', templateKey: 'category:order-status' },
+    { from: 'Account Management', templateKey: 'category:account' },
+  ])
+
+/**
+ * Legacy system tags with no place in the taxonomy (§2.4): duplicates of a core
+ * label, or too rare to earn a prompt slot.
+ *
+ * ⚠️ **Unflagged, never deleted** (§5.1 step 5). An org may have applied one by
+ * hand and an ordinary, non-eligible tag costs nothing; deleting it would drop
+ * real curation for a cosmetic tidy.
+ */
+export const RETIRED_SYSTEM_TAG_TITLES: readonly string[] = Object.freeze([
+  'Customer Feedback',
+  'Legal',
+  'Security',
+  'Shipping',
+  'Troubleshooting',
+])
+
+/**
+ * Left **completely** alone (§5.1 step 7): still system tags, still not
+ * eligible.
+ *
+ * ⚠️ Priority and segment are not intents (invariant 8). Making either eligible
+ * would let classification guard exit 6 suppress categorisation entirely for
+ * any thread a filter marked VIP.
+ */
+export const PRESERVED_SYSTEM_TAG_TITLES: readonly string[] = Object.freeze(['Urgent', 'VIP'])
+
+/**
+ * The two starters retired as AI LABELS by D2 — both are answerable from
+ * headers and `machineMailTier` for free, and they ship as seeded filters now
+ * (`seed-suggested-filters.ts`).
+ *
+ * Their `tag_ai_classify` is cleared so they stop costing a prompt slot; the
+ * tags themselves survive as ordinary tags for the same reason the retired
+ * system tags do — mail already carries them.
+ */
+export const RETIRED_LABEL_TITLES: readonly string[] = Object.freeze(['Newsletter', 'Notification'])
+
+/**
+ * Every description this product has ever shipped for a mail category — the
+ * five pre-rework starters, the current taxonomy, and the container's.
+ *
+ * ⚠️ This set is the whole never-clobber rule (§5.3). A stored description that
+ * is a member is still OURS and may be overwritten; anything else is the
+ * business's own tuning of the classifier and is unrecoverable if lost.
+ * `LEGACY_STARTER_DESCRIPTIONS` is deliberately frozen at its source for
+ * exactly this comparison.
+ */
+const SHIPPED_DESCRIPTIONS: ReadonlySet<string> = new Set<string>([
+  ...Object.values(LEGACY_STARTER_DESCRIPTIONS),
+  ...AI_CATEGORY_STARTER_TAGS.map((tag) => tag.description),
+  AI_CATEGORY_PARENT_TAG.description,
+])
+
+/** Titles this product has ever seeded as a mail category, current or retired. */
+const SEEDED_CATEGORY_TITLES: ReadonlySet<string> = new Set<string>([
+  ...AI_CATEGORY_STARTER_TAGS.map((tag) => tag.title),
+  ...Object.keys(LEGACY_STARTER_DESCRIPTIONS),
+])
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PURE CORE — the decisions, separated from the IO that feeds them
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** One live tag instance, folded from its `FieldValue` rows. */
+export interface TagCensusRow {
+  id: string
+  title: string
+  isSystemTag: boolean
+  templateKey: string | null
+  description: string | null
+  parentId: string | null
+  aiClassify: boolean
+}
+
+/** What {@link planDescriptionWrite} decided, and why. */
+export type DescriptionVerdict = 'write' | 'unchanged' | 'user-edited'
+
+/**
+ * The never-clobber rule (§5.3, invariant 6).
+ *
+ * ⚠️ Overwrite ONLY when the stored value is empty or **byte-identical** to
+ * something we shipped. No trimming, no normalising, no case folding on the
+ * comparison itself: a loosened match is how real customer tuning gets
+ * destroyed, and the description is the one field this whole plan exists to
+ * make theirs.
+ *
+ * `unchanged` (already the target) is reported separately from `write` so a
+ * replay writes nothing at all rather than re-writing the same string.
+ */
+export function planDescriptionWrite(
+  current: string | null | undefined,
+  target: string
+): DescriptionVerdict {
+  const value = current ?? ''
+  if (value === target) return 'unchanged'
+  // An empty description is not an edit — it is a category with no instruction,
+  // which classifies measurably worse than one with a definition.
+  if (value.trim().length === 0) return 'write'
+  return SHIPPED_DESCRIPTIONS.has(value) ? 'write' : 'user-edited'
+}
+
+/**
+ * Pack inference for an org that never chose (§5.4, Q3's recommendation):
+ * **commerce where the org has a Shopify integration, default off otherwise.**
+ *
+ * The partner pack is never inferred — nothing in the data distinguishes a
+ * dealer network from a direct-to-consumer store, and every extra label is a
+ * silent accuracy tax on every classification (invariant 10).
+ */
+export function inferAiCategoryPacks(input: { hasShopify: boolean }): AiCategoryPack[] {
+  return input.hasShopify ? ['commerce'] : []
+}
+
+/**
+ * Find the org's `Mail Categories` container, if it has one WE seeded.
+ *
+ * Three arms, strongest first — the title alone is never enough (invariant 5),
+ * because stamping a user's own group with a template key would make it
+ * permanently undeletable:
+ *
+ *  1. it already carries the container's template key (a replay, or a new org);
+ *  2. its description is byte-identical to the shipped container description;
+ *  3. it parents at least one tag whose title is a category we have shipped.
+ *
+ * Returns `null` when nothing proves ownership. The seeder then skips the title
+ * (it matches by title) and the container simply stays unstamped — the safe
+ * failure, and one a human can resolve.
+ */
+export function findCategoryContainer(census: readonly TagCensusRow[]): TagCensusRow | null {
+  const byKey = census.find((row) => row.templateKey === AI_CATEGORY_PARENT_TEMPLATE_KEY)
+  if (byKey) return byKey
+
+  for (const row of census) {
+    if (row.title !== AI_CATEGORY_PARENT_TAG.title || row.isSystemTag) continue
+    if (row.description === AI_CATEGORY_PARENT_TAG.description) return row
+    if (census.some((c) => c.parentId === row.id && SEEDED_CATEGORY_TITLES.has(c.title))) return row
+  }
+  return null
+}
+
+/**
+ * Is this ordinary tag one of OUR seeded categories, rather than a user's tag
+ * that happens to share a title (invariant 5)?
+ *
+ * A SYSTEM tag is never "ours" in this sense — those go down the adopt path
+ * (§5.1 step 3), which unfreezes first and is the only path allowed to write a
+ * frozen tag.
+ */
+export function isSeededCategory(row: TagCensusRow, containerId: string | null): boolean {
+  if (row.isSystemTag) return false
+  if (row.templateKey !== null && row.templateKey.length > 0) return true
+  if (containerId !== null && row.parentId === containerId) return true
+  return row.description !== null && SHIPPED_DESCRIPTIONS.has(row.description)
+}
+
+/**
+ * The values one existing seeded category still needs, or `null` when settled.
+ *
+ * A type ALIAS rather than an interface on purpose: only aliases get TypeScript's
+ * implicit index signature, which is what lets the patch be handed straight to
+ * `update(recordId, values: Record<string, unknown>)` without a cast.
+ */
+export type StarterPatch = {
+  tag_template_key?: string
+  tag_description?: string
+}
+
+/**
+ * Step 2 (§5.1): stamp `tag_template_key` and adopt the new §2.1 description on
+ * a starter the org already has as an ORDINARY tag.
+ *
+ * ⚠️ `tag_ai_classify` is deliberately absent. Step 2 says "stamp
+ * `tag_template_key` and overwrite the description" and nothing else — an org
+ * that switched a category OFF made a routing decision, and silently switching
+ * it back on would be this migration re-enabling inference nobody asked for.
+ *
+ * Returns `null` when there is nothing to write, so a replay makes no call at
+ * all.
+ */
+export function planStarterPatch(row: TagCensusRow, seed: AiCategoryTagSeed): StarterPatch | null {
+  const patch: StarterPatch = {}
+  if (row.templateKey !== seed.templateKey) patch.tag_template_key = seed.templateKey
+  if (planDescriptionWrite(row.description, seed.description) === 'write') {
+    patch.tag_description = seed.description
+  }
+  return Object.keys(patch).length > 0 ? patch : null
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// IO
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Field ids for every `systemAttribute` this migration reads or writes. */
+type TagFieldIds = Map<string, string>
+
+/** Per-org outcome, for the run log. */
+export interface OrgReport {
+  organizationId: string
+  skipped?: string
+  packs: AiCategoryPack[]
+  stamped: string[]
+  adopted: string[]
+  created: string[]
+  unflagged: string[]
+  labelsRetired: string[]
+  reparented: string[]
+  legacyParentDeleted: boolean
+  userEdits: string[]
+}
+
+function emptyReport(organizationId: string): OrgReport {
+  return {
+    organizationId,
+    packs: [],
+    stamped: [],
+    adopted: [],
+    created: [],
+    unflagged: [],
+    labelsRetired: [],
+    reparented: [],
+    legacyParentDeleted: false,
+    userEdits: [],
+  }
+}
+
+/** The `tag` EntityDefinition id for this org, or `null` when it has none. */
+async function loadTagDefId(db: Database, organizationId: string): Promise<string | null> {
+  const [def] = await db
+    .select({ id: schema.EntityDefinition.id })
+    .from(schema.EntityDefinition)
+    .where(
+      and(
+        eq(schema.EntityDefinition.organizationId, organizationId),
+        eq(schema.EntityDefinition.entityType, TAG_DEF)
+      )
+    )
+    .limit(1)
+  return def?.id ?? null
+}
+
+/** `systemAttribute` → `CustomField.id` for the tag def, in one query. */
+async function loadTagFieldIds(
+  db: Database,
+  organizationId: string,
+  tagDefId: string
+): Promise<TagFieldIds> {
+  const rows = await db
+    .select({ id: schema.CustomField.id, systemAttribute: schema.CustomField.systemAttribute })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, tagDefId)
+      )
+    )
+
+  const map: TagFieldIds = new Map()
+  for (const row of rows) {
+    if (row.systemAttribute && !map.has(row.systemAttribute)) map.set(row.systemAttribute, row.id)
+  }
+  return map
+}
+
+/**
+ * Fold every live tag instance and its `FieldValue` rows into one census.
+ *
+ * Reads raw, deliberately (project convention for data migrations): the
+ * composed record read applies lens gates and `_access` folding that a reshape
+ * has no use for, and the `Tag` pgTable is legacy and must not be read at all.
+ */
+async function loadTagCensus(
+  db: Database,
+  organizationId: string,
+  tagDefId: string,
+  fieldIds: TagFieldIds
+): Promise<TagCensusRow[]> {
+  const instances = await db
+    .select({ id: schema.EntityInstance.id, displayName: schema.EntityInstance.displayName })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, tagDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+  if (instances.length === 0) return []
+
+  // `fieldId` already restricts this to the tag def's rows, so no instance-id
+  // list is needed — and the list would be unbounded on a large org anyway.
+  const values = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      valueBoolean: schema.FieldValue.valueBoolean,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityDefinitionId, tagDefId)
+      )
+    )
+
+  const titleId = fieldIds.get('title')
+  const descriptionId = fieldIds.get('tag_description')
+  const systemId = fieldIds.get('is_system_tag')
+  const templateId = fieldIds.get('tag_template_key')
+  const classifyId = fieldIds.get('tag_ai_classify')
+  const parentId = fieldIds.get('tag_parent')
+
+  const rows = new Map<string, TagCensusRow>(
+    instances.map((instance) => [
+      instance.id,
+      {
+        id: instance.id,
+        title: instance.displayName ?? '',
+        isSystemTag: false,
+        templateKey: null,
+        description: null,
+        parentId: null,
+        aiClassify: false,
+      },
+    ])
+  )
+
+  for (const value of values) {
+    const row = value.entityId ? rows.get(value.entityId) : undefined
+    if (!row) continue
+    if (value.fieldId === titleId && value.valueText) row.title = value.valueText
+    else if (value.fieldId === descriptionId) row.description = value.valueText ?? null
+    else if (value.fieldId === systemId) row.isSystemTag = value.valueBoolean === true
+    else if (value.fieldId === templateId) row.templateKey = value.valueText ?? null
+    else if (value.fieldId === classifyId) row.aiClassify = value.valueBoolean === true
+    else if (value.fieldId === parentId) row.parentId = value.relatedEntityId ?? null
+  }
+
+  return [...rows.values()]
+}
+
+/**
+ * Does this org sell? (§5.4 / Q3.)
+ *
+ * Two shapes count, because Shopify arrived twice: the `Integration` row (the
+ * original channel/provider model — soft-deleted on disconnect, so
+ * `deletedAt IS NULL` is mandatory) and an installed marketplace app. Either is
+ * enough; neither is required.
+ */
+async function hasShopifyIntegration(db: Database, organizationId: string): Promise<boolean> {
+  const [integration] = await db
+    .select({ id: schema.Integration.id })
+    .from(schema.Integration)
+    .where(
+      and(
+        eq(schema.Integration.organizationId, organizationId),
+        eq(schema.Integration.provider, 'shopify'),
+        isNull(schema.Integration.deletedAt)
+      )
+    )
+    .limit(1)
+  if (integration) return true
+
+  const [installation] = await db
+    .select({ id: schema.AppInstallation.id })
+    .from(schema.AppInstallation)
+    .innerJoin(schema.App, eq(schema.App.id, schema.AppInstallation.appId))
+    .where(
+      and(
+        eq(schema.AppInstallation.organizationId, organizationId),
+        eq(schema.App.slug, 'shopify'),
+        isNull(schema.AppInstallation.uninstalledAt)
+      )
+    )
+    .limit(1)
+  return Boolean(installation)
+}
+
+/**
+ * The handler that may stamp `tag_template_key`.
+ *
+ * ⚠️ Scoped to that ONE attribute. `is_system_tag` is never in this set: the
+ * unfreeze below is a separate handler with a separate bypass precisely so a
+ * description write can never ride along with the flag clear (invariant 4).
+ */
+function templateKeyHandler(db: Database, organizationId: string, userId: string) {
+  return new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+    bypassFieldGuards: new Set(['tag_template_key']),
+  })
+}
+
+/** The handler that may clear `is_system_tag` — and nothing else. */
+function unfreezeHandler(db: Database, organizationId: string, userId: string) {
+  return new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+    bypassFieldGuards: new Set(['is_system_tag']),
+  })
+}
+
+/**
+ * STEP 2 (§5.1) — the starters the org already has as ordinary tags.
+ *
+ * Adds the provenance marker and brings the description up to the §2 text when
+ * (and only when) the business has not written its own. The container is
+ * stamped the same way, so it cannot be deleted out from under its children.
+ */
+async function stampSeededCategories(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  tagDefId: string,
+  census: readonly TagCensusRow[],
+  container: TagCensusRow | null,
+  seeds: readonly AiCategoryTagSeed[],
+  report: OrgReport
+): Promise<void> {
+  const handler = templateKeyHandler(db, organizationId, userId)
+  const byTitle = new Map<string, TagCensusRow>()
+  for (const row of census) if (!byTitle.has(row.title)) byTitle.set(row.title, row)
+
+  const targets: { row: TagCensusRow; seed: AiCategoryTagSeed }[] = []
+  if (container) targets.push({ row: container, seed: AI_CATEGORY_PARENT_TAG })
+  for (const seed of seeds) {
+    const row = byTitle.get(seed.title)
+    if (!row) continue
+    if (!isSeededCategory(row, container?.id ?? null)) {
+      // A user's own tag of the same name, or a system tag heading for the
+      // adopt path. Either way: not ours to stamp.
+      logger.info('Left a same-named tag alone — ownership unproven', {
+        organizationId,
+        title: seed.title,
+        isSystemTag: row.isSystemTag,
+      })
+      continue
+    }
+    targets.push({ row, seed })
+  }
+
+  for (const { row, seed } of targets) {
+    if (planDescriptionWrite(row.description, seed.description) === 'user-edited') {
+      report.userEdits.push(seed.title)
+      logger.info('Kept a tuned category description — divergence is the business’s own', {
+        organizationId,
+        title: seed.title,
+      })
+    }
+    const patch = planStarterPatch(row, seed)
+    if (!patch) continue
+    await handler.update(toRecordId(tagDefId, row.id), patch, undefined, SEED_OPTS)
+    report.stamped.push(seed.title)
+  }
+}
+
+/**
+ * STEP 3 (§5.1) — adopt a legacy SYSTEM tag in place and rename it.
+ *
+ * ⚠️ Two writes, in this order (invariant 4). `rejectIfSystemTag` reads the
+ * tag's CURRENT flag at hook time, so the flag clear must land first and alone;
+ * a combined write is rejected on `title`, `tag_description` and `tag_parent`
+ * all three. This is `adoptLegacySystemStarter`'s proven sequence with the
+ * rename added.
+ *
+ * ⚠️ The id is preserved — no delete, no recreate (invariant 3).
+ */
+async function adoptAndRename(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  tagDefId: string,
+  row: TagCensusRow,
+  seed: AiCategoryTagSeed,
+  parentRecordId: RecordId | null
+): Promise<void> {
+  const recordId = toRecordId(tagDefId, row.id)
+
+  // 1. Unfreeze, alone.
+  await unfreezeHandler(db, organizationId, userId).update(
+    recordId,
+    { is_system_tag: false },
+    undefined,
+    SEED_OPTS
+  )
+
+  // 2. Now an ordinary tag, so the guard lets the rest through. `tag_ai_classify`
+  //    is also what stops entity migration `014` re-freezing this tag by title on
+  //    its next replay (`excludeAiClassifyTags`).
+  const values: Record<string, unknown> = {
+    title: seed.title,
+    tag_scope: THREAD_SCOPE,
+    tag_ai_classify: true,
+    tag_template_key: seed.templateKey,
+  }
+  if (planDescriptionWrite(row.description, seed.description) !== 'user-edited') {
+    values.tag_description = seed.description
+  }
+  // Absent container: step 6 re-parents once the seeder has created it.
+  if (parentRecordId) values.tag_parent = parentRecordId
+
+  await templateKeyHandler(db, organizationId, userId).update(
+    recordId,
+    values,
+    undefined,
+    SEED_OPTS
+  )
+}
+
+/** STEP 5 (§5.1) — clear `is_system_tag`, and nothing else. Never delete. */
+async function unflagRetiredSystemTags(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  tagDefId: string,
+  census: readonly TagCensusRow[],
+  report: OrgReport
+): Promise<void> {
+  const handler = unfreezeHandler(db, organizationId, userId)
+  for (const row of census) {
+    if (!row.isSystemTag) continue
+    if (!RETIRED_SYSTEM_TAG_TITLES.includes(row.title)) continue
+    await handler.update(
+      toRecordId(tagDefId, row.id),
+      { is_system_tag: false },
+      undefined,
+      SEED_OPTS
+    )
+    report.unflagged.push(row.title)
+  }
+}
+
+/**
+ * D2 — `Newsletter` and `Notification` stop being labels.
+ *
+ * Both are answerable from `List-Id` / `machineMailTier` for free, and paying a
+ * model to read a header is the anti-pattern 05 §3.1.1 was written against.
+ * They ship as seeded filters now. Only the eligibility flag is cleared: the
+ * tag itself survives, because mail already carries it.
+ */
+async function retireLabels(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  tagDefId: string,
+  census: readonly TagCensusRow[],
+  containerId: string | null,
+  report: OrgReport
+): Promise<void> {
+  // No bypass: `tag_ai_classify` is an ordinary updatable field, and it is
+  // deliberately NOT guarded by `rejectIfSystemTag` either.
+  const handler = new UnifiedCrudHandler(organizationId, userId, db)
+  for (const row of census) {
+    if (!RETIRED_LABEL_TITLES.includes(row.title)) continue
+    if (!row.aiClassify) continue
+    if (!isSeededCategory(row, containerId)) continue
+    await handler.update(
+      toRecordId(tagDefId, row.id),
+      { tag_ai_classify: false },
+      undefined,
+      SEED_OPTS
+    )
+    report.labelsRetired.push(row.title)
+  }
+}
+
+/**
+ * STEP 6 (§5.1) — collapse the parents.
+ *
+ * Re-parents every template-keyed category under `Mail Categories` (the ones
+ * adopted before the container existed), then deletes `Topic Categorization`
+ * **only if it has no remaining children**.
+ *
+ * ⚠️ The retired tags of step 5 are NOT moved under `Mail Categories`. They are
+ * not categories — putting them in the container would advertise them as labels
+ * in the picker. The consequence is that an org still carrying any of them
+ * keeps `Topic Categorization` as their group, which the conditional delete
+ * already allows for.
+ */
+async function collapseParents(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  tagDefId: string,
+  census: readonly TagCensusRow[],
+  report: OrgReport
+): Promise<void> {
+  const container = findCategoryContainer(census)
+  /** Ids moved in THIS pass — the census still shows their old parent. */
+  const movedIds = new Set<string>()
+
+  if (container) {
+    const handler = templateKeyHandler(db, organizationId, userId)
+    const parentRecordId = toRecordId(tagDefId, container.id)
+    for (const row of census) {
+      if (row.id === container.id) continue
+      if (!row.templateKey || row.templateKey === AI_CATEGORY_PARENT_TEMPLATE_KEY) continue
+      if (row.parentId === container.id) continue
+      await handler.update(
+        toRecordId(tagDefId, row.id),
+        { tag_parent: parentRecordId },
+        undefined,
+        SEED_OPTS
+      )
+      movedIds.add(row.id)
+      report.reparented.push(row.title)
+    }
+  }
+
+  const legacyParent = census.find((row) => row.title === LEGACY_PARENT_TITLE && row.isSystemTag)
+  if (!legacyParent) return
+
+  // The census predates the re-parents above, so `movedIds` — ids, not titles,
+  // because two tags may share a name — is what keeps the count honest.
+  const children = census.filter((row) => row.parentId === legacyParent.id && !movedIds.has(row.id))
+  if (children.length > 0) {
+    logger.info('Kept Topic Categorization — it still has children', {
+      organizationId,
+      children: children.map((c) => c.title),
+    })
+    return
+  }
+
+  // `rejectDeleteIfSystemTag` refuses a system tag's delete, so the flag has to
+  // be cleared first — its own write again, for the same reason as invariant 4.
+  const recordId = toRecordId(tagDefId, legacyParent.id)
+  await unfreezeHandler(db, organizationId, userId).update(
+    recordId,
+    { is_system_tag: false },
+    undefined,
+    SEED_OPTS
+  )
+  await new UnifiedCrudHandler(organizationId, userId, db).delete(recordId, SEED_OPTS)
+  report.legacyParentDeleted = true
+}
+
+/**
+ * Reshape one organization's tag taxonomy. The seven steps of §5.1, in order.
+ *
+ * Throws on failure — the caller records which orgs failed and re-raises, so
+ * the ledger never marks a partial run as applied.
+ */
+export async function migrateOrganizationTaxonomy(
+  db: Database,
+  organizationId: string
+): Promise<OrgReport> {
+  const report = emptyReport(organizationId)
+
+  const tagDefId = await loadTagDefId(db, organizationId)
+  if (!tagDefId) {
+    report.skipped = 'no-tag-entity'
+    logger.warn('Skipping mail-category rework — organization has no tag entity', {
+      organizationId,
+    })
+    return report
+  }
+
+  // ── Step 1: the prerequisites ──────────────────────────────────────────
+  // The registry field must be MATERIALIZED, not merely declared: `FieldValue.
+  // fieldId` is a real FK, and the write path silently ignores an attribute with
+  // no CustomField row. Half-migrating would leave categories that LOOK seeded —
+  // deletable, unresettable, and invisible to a re-run.
+  const fieldIds = await loadTagFieldIds(db, organizationId, tagDefId)
+  if (!fieldIds.has('tag_template_key')) {
+    report.skipped = 'tag_template_key-missing'
+    logger.warn(
+      'Skipping mail-category rework: tag_template_key field missing (run entity migration 075 first)',
+      { organizationId }
+    )
+    return report
+  }
+  if (!fieldIds.has('tag_ai_classify')) {
+    report.skipped = 'tag_ai_classify-missing'
+    logger.warn(
+      'Skipping mail-category rework: tag_ai_classify field missing (run entity migration 074 first)',
+      { organizationId }
+    )
+    return report
+  }
+  if (!fieldIds.has('is_system_tag')) {
+    // Without the flag nothing can be PROVEN ours, and "unprovable" must read as
+    // the user's — never as consent (invariant 5). Adoption and retirement both
+    // become no-ops; creating the missing categories is still safe.
+    logger.warn('is_system_tag field missing — no legacy tag will be adopted or retired', {
+      organizationId,
+    })
+  }
+
+  // The create/update path resolves fields from the org cache, so a `075` that
+  // ran in this same pass (or another process) has to be visible here or every
+  // `tag_template_key` write is silently dropped.
+  await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+
+  const userId = await SystemUserService.getSystemUserForActions(organizationId)
+  const census = await loadTagCensus(db, organizationId, tagDefId, fieldIds)
+  const container = findCategoryContainer(census)
+
+  const packs = inferAiCategoryPacks({
+    hasShopify: await hasShopifyIntegration(db, organizationId),
+  })
+  report.packs = packs
+  const seeds = aiCategoryTagsForPacks(packs)
+
+  // ── Step 2: adopt the ordinary starters the org already has ────────────
+  await stampSeededCategories(
+    db,
+    organizationId,
+    userId,
+    tagDefId,
+    census,
+    container,
+    seeds,
+    report
+  )
+
+  // ── Step 3: adopt + rename the legacy system tags worth keeping ────────
+  const parentRecordId = container ? toRecordId(tagDefId, container.id) : null
+  for (const adoption of LEGACY_SYSTEM_ADOPTIONS) {
+    const seed = AI_CATEGORY_STARTER_TAGS.find((tag) => tag.templateKey === adoption.templateKey)
+    if (!seed) continue
+    // ⚠️ The flag, never the title (invariant 5).
+    const row = census.find((r) => r.title === adoption.from && r.isSystemTag)
+    if (!row) continue
+    // Renaming onto a title the org already uses would give it two tags with one
+    // name — worse than one badly-named tag, and unrecoverable in the picker.
+    if (census.some((r) => r.title === seed.title && r.id !== row.id)) {
+      logger.warn('Skipped a legacy adoption — the target title is already taken', {
+        organizationId,
+        from: adoption.from,
+        to: seed.title,
+      })
+      continue
+    }
+    await adoptAndRename(db, organizationId, userId, tagDefId, row, seed, parentRecordId)
+    report.adopted.push(`${adoption.from} → ${seed.title}`)
+    // Keep the in-memory census honest for the steps that follow.
+    row.title = seed.title
+    row.isSystemTag = false
+    row.templateKey = seed.templateKey
+    row.aiClassify = true
+    if (container) row.parentId = container.id
+  }
+
+  // ── Step 4: create whatever is still missing ───────────────────────────
+  // Delegated to the seeder so a migrated org and a freshly-seeded one are
+  // byte-identical, including the container and its template key.
+  const seeded = await seedAiCategoryTags(db, organizationId, userId, { packs })
+  report.created = seeded.created
+  report.adopted.push(...seeded.adopted)
+
+  // ── Steps 5 + D2: retire the rest ──────────────────────────────────────
+  if (fieldIds.has('is_system_tag')) {
+    await unflagRetiredSystemTags(db, organizationId, userId, tagDefId, census, report)
+  }
+  await retireLabels(db, organizationId, userId, tagDefId, census, container?.id ?? null, report)
+
+  // ── Step 6: collapse the parents ───────────────────────────────────────
+  // Re-read: step 4 may have created the container, and step 3's renames are
+  // only reflected in the local census.
+  const after = await loadTagCensus(db, organizationId, tagDefId, fieldIds)
+  await collapseParents(db, organizationId, userId, tagDefId, after, report)
+
+  // ── Step 7: `Urgent` and `VIP` are untouched, by never being named. ─────
+
+  logger.info('Mail-category rework applied', { ...report })
+  return report
+}
+
+/**
+ * Retire the 13 legacy system tags and adopt the new mail-category taxonomy for
+ * every organization (plan 06 §5).
+ *
+ * **What it does, per org:** stamps the provenance marker on the starters the
+ * org already has, adopts `Orders` → `Order Status` and `Account Management` →
+ * `Account` in place (ids preserved), creates whatever the org still lacks,
+ * clears `is_system_tag` on the five retired topics, drops `Newsletter` and
+ * `Notification` as AI labels, collapses `Topic Categorization` into
+ * `Mail Categories` when it is empty, and leaves `Urgent`/`VIP` exactly as they
+ * were.
+ *
+ * **What it never does:** re-classify (invariant 12), delete a tag a user might
+ * have applied (§5.1 step 5), or overwrite a description the business has tuned
+ * (§5.3 — the unrecoverable one).
+ *
+ * **Idempotent by state, not by ledger** (05 §12.2): every step reads the
+ * current data and writes only the difference, so a replay through
+ * `runEntityMigrationsForOrg` — where `alreadyUpToDate` is a report rather than
+ * a guard — is a no-op rather than a second reshape.
+ *
+ * One org's failure does not stop the others: each is caught and logged, and
+ * the run re-raises at the end so the ledger records the failure honestly and
+ * the next pass repairs.
+ */
+export const migration076MailCategoryRework: DataMigrationDef = {
+  id: '076-mail-category-rework',
+  description:
+    'Retire the legacy system tags and adopt the mail-category taxonomy (adopt in place, never clobber a tuned description)',
+  async run(db: Database): Promise<void> {
+    const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+    const failures: { organizationId: string; error: string }[] = []
+
+    for (const org of orgs) {
+      try {
+        await migrateOrganizationTaxonomy(db, org.id)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        failures.push({ organizationId: org.id, error: message })
+        logger.error('Mail-category rework failed for one organization', {
+          organizationId: org.id,
+          error: message,
+        })
+      }
+    }
+
+    logger.info('Mail-category rework complete', {
+      organizations: orgs.length,
+      failed: failures.length,
+    })
+
+    if (failures.length > 0) {
+      throw new Error(
+        `Mail-category rework failed for ${failures.length} organization(s): ` +
+          failures.map((f) => `${f.organizationId} (${f.error})`).join('; ')
+      )
+    }
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -40,6 +40,7 @@ import { migration070BackfillArticleSearchText } from './migrations/070-backfill
 import { migration071BackfillOutlookPlainText } from './migrations/071-backfill-outlook-plain-text'
 import { migration072MailFiltersLimit } from './migrations/072-mail-filters-limit'
 import { migration073BackfillBulkMailFields } from './migrations/073-backfill-bulk-mail-fields'
+import { migration076MailCategoryRework } from './migrations/076-mail-category-rework'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -102,6 +103,11 @@ function buildRegistry(): DataMigrationDef[] {
     migration071BackfillOutlookPlainText,
     migration072MailFiltersLimit,
     migration073BackfillBulkMailFields,
+    // 074 (`tag_ai_classify`) and 075 (`tag_template_key`) are ENTITY migrations
+    // and arrive via ALL_ENTITY_MIGRATIONS above; they own those ids in the
+    // shared sequence and both sort before 076, which depends on the fields they
+    // materialize.
+    migration076MailCategoryRework,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/field-hooks/pre/tag-template-guard.ts
+++ b/packages/lib/src/field-hooks/pre/tag-template-guard.ts
@@ -1,0 +1,43 @@
+// packages/lib/src/field-hooks/pre/tag-template-guard.ts
+
+import { ForbiddenError } from '../../errors'
+import type { EntityPreDeleteHandler, FieldPreHookHandler } from '../types'
+
+/**
+ * Silently drop any user-supplied write to `tag_template_key`. Only the seeder
+ * (which puts `tag_template_key` in `ctx.bypassFieldGuards`) may stamp it — every
+ * other caller's value is discarded.
+ *
+ * ⚠️ This hook is what actually enforces invariant 2
+ * (plans/mail-filter/06-mail-categories-rework-plan.md §3.2): the registry's
+ * `capabilities.creatable/updatable: false` is documentation only, since the
+ * field-value write path never reads capabilities. Without this hook any caller
+ * could stamp a template key on their own tag and make it permanently
+ * undeletable via {@link rejectDeleteIfTemplateTag}. Same construction as
+ * `dropUnauthorizedSystemFlag` for `is_system_tag`.
+ *
+ * The framework short-circuits this hook when the bypass set contains
+ * `tag_template_key`, so this body only runs for unauthorized writes.
+ */
+export const dropUnauthorizedTemplateKey: FieldPreHookHandler = async () => undefined
+
+/**
+ * Reject a delete when the target carries a `tag_template_key` — a seeded mail
+ * category is undeletable (D4). Mirrors `rejectDeleteIfSystemTag`, different
+ * predicate: this one is a TEXT marker rather than a boolean flag.
+ *
+ * ⚠️ Deliberately the ONLY guard this marker carries. There is no
+ * `rejectIfSystemTag`-style freeze on title, emoji, colour, parent or
+ * `tag_description` — a seeded category must stay fully editable, because the
+ * description is the classifier's instruction and what "Support" means differs
+ * per business (§3.2, D5).
+ *
+ * `event.values` is pre-captured by the pre-delete fire point (systemAttribute
+ * keyed), so no extra read is needed.
+ */
+export const rejectDeleteIfTemplateTag: EntityPreDeleteHandler = async (event) => {
+  const templateKey = event.values.tag_template_key
+  if (typeof templateKey === 'string' && templateKey.length > 0) {
+    throw new ForbiddenError('Seeded categories cannot be deleted')
+  }
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -53,6 +53,7 @@ import {
   rejectDeleteIfSystemTag,
   rejectIfSystemTag,
 } from './pre/tag-system-guard'
+import { dropUnauthorizedTemplateKey, rejectDeleteIfTemplateTag } from './pre/tag-template-guard'
 import { guardWorkOrderDelete } from './pre/work-order-delete-guard'
 import {
   registerEntityFieldChangeHooks,
@@ -254,7 +255,14 @@ export function registerAllHooks(): void {
   registerFieldPreHooks('tags', 'tag_emoji', [rejectIfSystemTag])
   registerFieldPreHooks('tags', 'tag_color', [rejectIfSystemTag])
   registerFieldPreHooks('tags', 'tag_parent', [rejectIfSystemTag])
-  registerEntityPreDeleteHooks('tags', [rejectDeleteIfSystemTag])
+  // Seeded mail-category guard (plans/mail-filter/06-mail-categories-rework-plan.md §3.2).
+  // A `tag_template_key` marks a shipped category: undeletable, but fully editable —
+  // deliberately NO `rejectIfSystemTag`-style freeze on title/description/emoji/color/parent,
+  // because the description is the classifier's instruction (D4/D5).
+  // The drop hook is what actually enforces invariant 2 (the field's
+  // `capabilities.updatable: false` is not read by the write path).
+  registerFieldPreHooks('tags', 'tag_template_key', [dropUnauthorizedTemplateKey])
+  registerEntityPreDeleteHooks('tags', [rejectDeleteIfSystemTag, rejectDeleteIfTemplateTag])
 
   // Money delete-safety (plans/dispatch/money/12-delete-safety.md §A/§C/§F) — moves the
   // invoice/work-order guard+cleanup logic out of the client-only drawer branch and into the

--- a/packages/lib/src/mail-classification/classify.test.ts
+++ b/packages/lib/src/mail-classification/classify.test.ts
@@ -34,6 +34,7 @@ vi.mock('../ai/usage/usage-tracking-service', () => ({
   UsageTrackingService: class {},
 }))
 
+import { QuotaExceededError } from '../ai/errors/quota-errors'
 import { buildClassificationPrompt, buildClassificationSchema, classifyMessage } from './classify'
 import { MAIL_CLASSIFY_BODY_CHARS, MAIL_CLASSIFY_NO_CATEGORY } from './client'
 import type { MailClassificationContext } from './types'
@@ -103,6 +104,7 @@ describe('classifyMessage — the confidence threshold (C10 / Q4)', () => {
       tagId: 'tag_billing',
       confidence: 0.7,
       model: 'gpt-x',
+      inferred: true,
     })
   })
 
@@ -116,6 +118,9 @@ describe('classifyMessage — the confidence threshold (C10 / Q4)', () => {
       confidence: 0.55,
       reason: 'below-threshold',
       model: 'gpt-x',
+      // The call completed and was paid for — "not confident enough" is an
+      // answer, so the message is done and the marker may go down.
+      inferred: true,
     })
     // The below-threshold rows are the most informative for tuning and the
     // easiest to forget: there is no column, the log IS the data.
@@ -189,7 +194,7 @@ describe('classifyMessage — usage attribution + never throws', () => {
 
     await expect(classifyMessage(db, context)).resolves.toMatchObject({
       tagId: null,
-      reason: 'error',
+      reason: 'unavailable',
     })
     expect(h.warn).toHaveBeenCalled()
   })
@@ -201,7 +206,94 @@ describe('classifyMessage — usage attribution + never throws', () => {
       tagId: null,
       confidence: 0,
       reason: 'no-default-model',
+      inferred: false,
     })
     expect(h.invoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('classifyMessage — a failed call NEVER counts as an inference', () => {
+  // ⚠️ The whole point of this block. `inferred` is what `job.ts` gates the C9
+  // marker on, so a `true` here would disqualify the message from ever being
+  // classified — for a call that cost nothing and decided nothing. One 429 used
+  // to be permanent.
+  const FAILURES: Array<[string, unknown, string]> = [
+    ['a bare 429', new Error('Request failed with status 429'), 'unavailable'],
+    [
+      'the Anthropic client’s status-less rate-limit Error',
+      new Error('Anthropic API rate limit exceeded'),
+      'unavailable',
+    ],
+    [
+      'a 503 carried as a numeric status',
+      Object.assign(new Error('nope'), { status: 503 }),
+      'unavailable',
+    ],
+    [
+      'a dropped socket',
+      Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+      'unavailable',
+    ],
+    ['an unexpected bug', new Error('cannot read properties of undefined'), 'error'],
+  ]
+
+  for (const [label, thrown, reason] of FAILURES) {
+    it(`${label} → reason "${reason}", inferred false`, async () => {
+      h.invoke.mockRejectedValue(thrown)
+
+      await expect(classifyMessage(db, context)).resolves.toMatchObject({
+        tagId: null,
+        reason,
+        inferred: false,
+      })
+    })
+  }
+
+  it('⚠️ unwraps the orchestrator’s re-wrap to find a quota error', async () => {
+    // `LLMOrchestrator.invoke` runs its quota gate INSIDE the try that re-wraps
+    // everything into an OrchestratorError, so `instanceof QuotaExceededError`
+    // is false at this call site and only the chain walk recovers it.
+    const quota = new QuotaExceededError("You're out of AI credits.", { provider: 'openai' })
+    h.invoke.mockRejectedValue(
+      Object.assign(new Error('LLM invocation failed: out of credits'), { originalError: quota })
+    )
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: null,
+      reason: 'quota-exceeded',
+      inferred: false,
+    })
+  })
+
+  it('finds a quota error nested two wrappers deep', async () => {
+    const quota = new QuotaExceededError('out of credits')
+    const inner = Object.assign(new Error('OpenAI-LLM invoke failed'), { originalError: quota })
+    h.invoke.mockRejectedValue(
+      Object.assign(new Error('LLM invocation failed'), { originalError: inner })
+    )
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({ reason: 'quota-exceeded' })
+  })
+
+  it('survives a self-referential error chain instead of spinning', async () => {
+    const loop = new Error('boom') as Error & { originalError?: Error }
+    loop.originalError = loop
+    h.invoke.mockRejectedValue(loop)
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({ reason: 'error' })
+  })
+
+  it('logs an unexpected failure at error level, a transient one at warn', async () => {
+    h.invoke.mockRejectedValue(new Error('totally unexpected'))
+    await classifyMessage(db, context)
+    expect(h.error).toHaveBeenCalled()
+    expect(h.warn).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    h.getDefault.mockResolvedValue({ provider: 'openai', model: 'gpt-x' })
+    h.invoke.mockRejectedValue(new Error('429 too many requests'))
+    await classifyMessage(db, context)
+    expect(h.warn).toHaveBeenCalled()
+    expect(h.error).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/mail-classification/classify.ts
+++ b/packages/lib/src/mail-classification/classify.ts
@@ -13,10 +13,12 @@
 
 import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { QuotaExceededError } from '../ai/errors/quota-errors'
 import { LLMOrchestrator } from '../ai/orchestrator/llm-orchestrator'
 import { SystemModelService } from '../ai/providers/system-model-service'
 import { ModelType } from '../ai/providers/types'
 import { UsageTrackingService } from '../ai/usage/usage-tracking-service'
+import { UsageLimitError } from '../errors'
 import {
   MAIL_CLASSIFY_BODY_CHARS,
   MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
@@ -30,7 +32,7 @@ const logger = createScopedLogger('mail-classification')
 const SYSTEM_PROMPT = [
   'You categorise inbound customer email for a help desk.',
   'Choose exactly ONE category from the list, or the sentinel value when none of',
-  'them fits. Each category is defined by its description — classify against the',
+  'them fits. Each category is defined by its description, so classify against the',
   'description, not against the label wording.',
   'Report your confidence as a number between 0 and 1. Be honest: a low',
   'confidence means the mail is not applied to any category at all, which is the',
@@ -72,6 +74,71 @@ export function buildClassificationSchema(labels: MailClassificationLabel[]) {
       },
     },
   }
+}
+
+/**
+ * Every `Error` in a wrapping chain, outermost first.
+ *
+ * ⚠️ The error that says WHY is never the one thrown. `LLMOrchestrator.invoke`
+ * re-wraps everything its `try` catches into an `OrchestratorError`
+ * (`ai/orchestrator/types.ts`) — INCLUDING the quota gate, which runs inside
+ * that try — and each specialized client wraps the SDK error again below it. So
+ * `err instanceof QuotaExceededError` is false at this call site no matter what
+ * happened, and only walking the chain recovers the cause.
+ *
+ * Both `.originalError` (what the orchestrator and the clients set) and `.cause`
+ * (what a plain `new Error(msg, { cause })` sets) are followed, with a depth cap
+ * so a self-referential chain cannot spin.
+ */
+function errorChain(error: unknown): Error[] {
+  const chain: Error[] = []
+  let current: unknown = error
+  while (current instanceof Error && chain.length < 8 && !chain.includes(current)) {
+    chain.push(current)
+    const next = (current as { originalError?: unknown }).originalError
+    current = next instanceof Error ? next : current.cause
+  }
+  return chain
+}
+
+/** Transient-failure signatures, checked against every link of the chain. */
+const TRANSIENT_PATTERNS =
+  /\b429\b|rate.?limit|too many requests|overloaded|timed? ?out|timeout|socket hang up|fetch failed|network|ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|502|503|504|bad gateway|service unavailable/i
+
+/**
+ * Why the call failed, to the resolution a caller can act on.
+ *
+ * All three answers mean the same thing for the marker — nothing was spent, so
+ * the message stays classifiable (see `MailClassificationResult.inferred`). They
+ * differ in what a human should do:
+ *
+ * - `'quota-exceeded'` is not transient in any useful sense. It clears when the
+ *   billing cycle rolls or somebody tops up, so it is surfaced in the UI rather
+ *   than retried.
+ * - `'unavailable'` is time-resolved and would be recoverable by a retry, if one
+ *   is ever added.
+ * - `'error'` is unexpected and deserves a real error log.
+ */
+function classifyFailure(error: unknown): 'quota-exceeded' | 'unavailable' | 'error' {
+  const chain = errorChain(error)
+
+  if (chain.some((e) => e instanceof QuotaExceededError || e instanceof UsageLimitError)) {
+    return 'quota-exceeded'
+  }
+
+  for (const link of chain) {
+    const status = (link as { status?: unknown }).status
+    if (typeof status === 'number' && (status === 429 || status >= 500)) return 'unavailable'
+    // ⚠️ Message matching is load-bearing, not a fallback: the Anthropic client
+    // turns a `rate_limit_error` into a bare `new Error('Anthropic API rate
+    // limit exceeded')` with no status and no code, so the string is the only
+    // surviving evidence that it was a 429.
+    const code = (link as { code?: unknown }).code
+    if (typeof code === 'string' && TRANSIENT_PATTERNS.test(code)) return 'unavailable'
+    if (TRANSIENT_PATTERNS.test(link.message)) return 'unavailable'
+  }
+
+  return 'error'
 }
 
 /** The label list as the prompt sees it — `title` + `tag_description` (C3). */
@@ -134,7 +201,7 @@ export async function classifyMessage(
       organizationId,
       messageId,
     })
-    return { tagId: null, confidence: 0, reason: 'no-default-model' }
+    return { tagId: null, confidence: 0, reason: 'no-default-model', inferred: false }
   }
 
   let structured: Record<string, unknown> | undefined
@@ -156,13 +223,26 @@ export async function classifyMessage(
     })
     structured = response.structured_output
   } catch (error) {
-    logger.warn('Mail classification model call failed — leaving the thread untagged', {
+    // ⚠️ `inferred: false` on EVERY arm here, which is what keeps the message
+    // classifiable. `invoke` only meters usage against a response that came back
+    // (`llm-orchestrator.ts`) and the quota gate throws before any provider
+    // traffic at all — so a throw means nothing was billed and nothing was
+    // decided, exactly like `'no-default-model'`. Stamping the marker here is
+    // what used to turn one 429 into a permanent write-off.
+    const reason = classifyFailure(error)
+    const fields = {
       organizationId,
       messageId,
+      threadId: context.threadId,
       model: def.model,
+      reason,
       error: error instanceof Error ? error.message : String(error),
-    })
-    return { tagId: null, confidence: 0, reason: 'error', model: def.model }
+    }
+    const message = 'Mail classification call failed, leaving the thread untagged and classifiable'
+    if (reason === 'error') logger.error(message, fields)
+    else logger.warn(message, fields)
+
+    return { tagId: null, confidence: 0, reason, model: def.model, inferred: false }
   }
 
   const rawCategory = typeof structured?.category === 'string' ? structured.category : null
@@ -195,11 +275,15 @@ export async function classifyMessage(
     applied,
   })
 
-  if (applied) return { tagId: category, confidence, model: def.model }
+  // Past this point a call COMPLETED, so `inferred: true` even when nothing is
+  // applied: "no category" and "not confident enough" are answers, they were
+  // paid for, and re-asking would buy the same answer twice (C9).
+  if (applied) return { tagId: category, confidence, model: def.model, inferred: true }
   return {
     tagId: null,
     confidence,
     reason: category === null ? 'no-category' : 'below-threshold',
     model: def.model,
+    inferred: true,
   }
 }

--- a/packages/lib/src/mail-classification/client.ts
+++ b/packages/lib/src/mail-classification/client.ts
@@ -80,9 +80,23 @@ export interface MailClassificationLabel {
 }
 
 /**
- * Why a message was not classified. Every arm is a guard exit (§3.1) except
- * `'error'`; all of them are normal, and none of them is a failure the caller
- * should retry.
+ * Why a message was not classified.
+ *
+ * The first six arms are guard exits (§3.1) and are entirely normal. The last
+ * four are outcomes of the call itself, and they split on ONE question that
+ * decides whether the message may ever be classified again:
+ *
+ * - `'below-threshold'` / `'no-category'` — an inference COMPLETED. The answer
+ *   was "apply nothing", which is a decision, and it was paid for. The marker
+ *   goes down (C9) and the message is done.
+ * - `'no-default-model'` / `'quota-exceeded'` / `'unavailable'` / `'error'` —
+ *   nothing ran. `LLMOrchestrator` only meters usage against a response that
+ *   came back (`llm-orchestrator.ts`), so a throw means no spend and no
+ *   decision. These must NOT stamp the marker, or one transient 429 disqualifies
+ *   the message from classification forever.
+ *
+ * That distinction is carried explicitly by `MailClassificationResult.inferred`
+ * rather than re-derived from this union — see the note there.
  */
 export type MailClassificationSkipReason =
   | 'machine-mail'
@@ -94,6 +108,11 @@ export type MailClassificationSkipReason =
   | 'no-default-model'
   | 'below-threshold'
   | 'no-category'
+  /** Out of AI credits, or over the completions rate limit. Nothing was spent. */
+  | 'quota-exceeded'
+  /** Provider 429/5xx, network failure or timeout — transient, nothing spent. */
+  | 'unavailable'
+  /** Anything unexpected. Also unspent, but worth an `error` log rather than a warn. */
   | 'error'
 
 /** The marker written to `Message.metadata.mailClassification` after a call. */
@@ -104,4 +123,166 @@ export interface MailClassificationMarker {
   tagId: string | null
   confidence: number
   model?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Retroactive re-classification (07-mail-reclassification-plan.md)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * How far back a retroactive run reaches (07 §2.4, axis 1).
+ *
+ * Presets rather than free-form, because the count preview has to be cheap. The
+ * `'threads'` arm is a COUNT of threads rather than a date bound — "just try it
+ * on a bit" without thinking about dates — and combines with the always-newest-
+ * first ordering (07 invariant 8) to mean "the N most recent threads".
+ *
+ * Dates are ISO strings, not `Date`s: this shape travels through tRPC input and
+ * through BullMQ job data, both of which are JSON, so a `Date` would arrive as a
+ * string anyway and only the type would lie.
+ */
+export type MailReclassifyRange =
+  | { kind: 'days'; days: number }
+  | { kind: 'threads'; threads: number }
+  | { kind: 'custom'; sinceIso: string; untilIso?: string }
+  | { kind: 'all-time' }
+
+/** The offered day windows (07 §2.4). */
+export const MAIL_RECLASSIFY_DAY_PRESETS = [7, 30, 90] as const
+
+/** The offered thread-count windows (07 §2.4). */
+export const MAIL_RECLASSIFY_THREAD_PRESETS = [100, 500, 1000] as const
+
+/**
+ * Default range: the last 30 days (07 R-Q1).
+ *
+ * A cost decision, not a correctness one — under R5 a label on 2021 mail has
+ * full analytical value, so "all time" stays available behind a confirm.
+ */
+export const MAIL_RECLASSIFY_DEFAULT_RANGE: MailReclassifyRange = { kind: 'days', days: 30 }
+
+/**
+ * What state of thread a run is pointed at (07 §2.4, axis 2 / R4).
+ *
+ * ⚠️ Two genuinely different operations with different cost profiles, and the UI
+ * must not blur them:
+ *
+ * - `'fill-gaps'` — threads whose first inbound message carries **no** marker.
+ *   Pays once, for mail that never reached the classifier at all. THE DEFAULT.
+ * - `'re-classify'` — everything in scope, marker or not. Bypasses guard exit 5
+ *   and therefore **pays again** for mail already classified. The taxonomy-change
+ *   case, and the only way a user can accidentally spend twice.
+ */
+export type MailReclassifyMode = 'fill-gaps' | 're-classify'
+
+/** 07 R4 — fill-gaps is the default because it can never double-bill. */
+export const MAIL_RECLASSIFY_DEFAULT_MODE: MailReclassifyMode = 'fill-gaps'
+
+/**
+ * Hard ceiling on threads ONE run may touch (07 §2.5, R-Q4).
+ *
+ * ⚠️ Reaching it is reported, never a silent truncate (07 invariant 8) — a capped
+ * run says what it capped, because silent truncation reads as "covered
+ * everything".
+ */
+export const MAIL_RECLASSIFY_MAX_THREADS = 5000
+
+/**
+ * Ceiling for the backlog count shown on the classification card (07 R-Q5).
+ *
+ * Past it the UI renders `1,000+`: it is an order of magnitude for a decision,
+ * not a billing figure, and an exact count over a large mailbox is a slow query.
+ */
+export const MAIL_RECLASSIFY_BACKLOG_COUNT_CAP = 1000
+
+/** Threads one sample classifies (07 §2.11, R-Q2). Re-sample rather than resize. */
+export const MAIL_RECLASSIFY_SAMPLE_SIZE = 100
+
+/** BullMQ job name for the sample run. Registered on `maintenanceQueue`. */
+export const MAIL_RECLASSIFY_SAMPLE_JOB_NAME = 'mailReclassifySampleJob'
+
+/** One label's share of a sample (07 §2.11, §3.3). */
+export interface MailReclassifySampleLabelStat {
+  tagId: string
+  title: string
+  /** Threads the model assigned this label, at or above the threshold. */
+  count: number
+  /**
+   * Mean confidence across those threads, or 0 when `count` is 0.
+   *
+   * A label with consistently low confidence is overlapping another (07 §2.11).
+   */
+  meanConfidence: number
+}
+
+/**
+ * What a sample run reports (07 §2.11).
+ *
+ * ⚠️ It applies NOTHING and writes NO marker (07 invariant 9) — `applied` is a
+ * literal `false` so a future change that starts persisting has to change the
+ * type rather than quietly change behaviour.
+ */
+export interface MailReclassifySampleReport {
+  inboxId: string
+  mode: MailReclassifyMode
+  /** Threads asked for — {@link MAIL_RECLASSIFY_SAMPLE_SIZE} unless overridden. */
+  requested: number
+  /** Threads the scope actually yielded. May be < `requested`. */
+  selected: number
+  /**
+   * Threads a model call COMPLETED for. Guard exits and provider failures reduce
+   * it below `selected`, and 07 §2.11 requires saying so rather than implying
+   * the full sample size.
+   */
+  inferred: number
+  /** Threads that produced a label at or above the confidence threshold. */
+  classified: number
+  /**
+   * Completed inferences that applied nothing.
+   *
+   * **The single most informative number** (07 §2.11): high abstention means the
+   * vocabulary does not fit this mail, or the threshold is wrong. Rendered as its
+   * own row, never hidden (07 §3.3).
+   */
+  abstained: number
+  /** `abstained / inferred`, or 0 when nothing was inferred. */
+  abstentionRate: number
+  /** Mean confidence over every completed inference, abstentions included. */
+  meanConfidence: number
+  /**
+   * Every eligible label, **including the ones never chosen**. A zero row is the
+   * finding (07 §3.3 / 06 Q1: a label never chosen is a label to merge), so it
+   * must render rather than be filtered out.
+   */
+  labels: MailReclassifySampleLabelStat[]
+  /**
+   * Threads that never reached a model call, keyed by guard/failure reason.
+   *
+   * Guard exits and provider failures both land here, and they mean different
+   * things: an exit is normal, a `'quota-exceeded'` or `'unavailable'` means the
+   * sample is smaller than it looks for a reason worth showing.
+   */
+  skipped: Partial<Record<MailClassificationSkipReason, number>>
+  /**
+   * Why the completed inferences applied nothing — `'no-category'` (the model
+   * declined) versus `'below-threshold'` (it picked one but was not confident).
+   *
+   * Kept apart from `skipped` because these DID cost an inference, and because
+   * the split is what says whether the vocabulary is wrong or the threshold is.
+   */
+  abstainedByReason: Partial<Record<MailClassificationSkipReason, number>>
+  /** ⚠️ Always false. Sample mode persists nothing (07 invariant 9). */
+  applied: false
+}
+
+/** Lifecycle of an enqueued sample, as the dialog polls it. */
+export interface MailReclassifySampleStatus {
+  jobId: string
+  state: 'waiting' | 'active' | 'completed' | 'failed' | 'delayed' | 'unknown'
+  /** Threads processed so far, when the job has reported progress. */
+  processed: number
+  /** Threads the job intends to process. */
+  total: number
+  /** Present once `state === 'completed'`. */
+  report?: MailReclassifySampleReport
 }

--- a/packages/lib/src/mail-classification/index.ts
+++ b/packages/lib/src/mail-classification/index.ts
@@ -19,9 +19,22 @@ export {
   MAIL_CLASSIFY_BODY_CHARS,
   MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
   MAIL_CLASSIFY_NO_CATEGORY,
+  MAIL_RECLASSIFY_BACKLOG_COUNT_CAP,
+  MAIL_RECLASSIFY_DAY_PRESETS,
+  MAIL_RECLASSIFY_DEFAULT_MODE,
+  MAIL_RECLASSIFY_DEFAULT_RANGE,
+  MAIL_RECLASSIFY_MAX_THREADS,
+  MAIL_RECLASSIFY_SAMPLE_JOB_NAME,
+  MAIL_RECLASSIFY_SAMPLE_SIZE,
+  MAIL_RECLASSIFY_THREAD_PRESETS,
   type MailClassificationLabel,
   type MailClassificationMarker,
   type MailClassificationSkipReason,
+  type MailReclassifyMode,
+  type MailReclassifyRange,
+  type MailReclassifySampleLabelStat,
+  type MailReclassifySampleReport,
+  type MailReclassifySampleStatus,
   TAG_AI_CLASSIFY_ATTRIBUTE,
 } from './client'
 // The `then`-side door (§4)
@@ -38,6 +51,28 @@ export {
 export { getEligibleClassificationTags } from './labels'
 // ⚠️ The mandatory second filter pass (§4.1, invariant 13)
 export { rerunMailFiltersAfterClassification } from './rerun-filters'
+// Retroactive re-classification, phase 1 (07-mail-reclassification-plan.md §4).
+// ⚠️ This path deliberately does NOT re-run mail filters (07 R2 / invariant 3).
+export {
+  buildReclassifyWhere,
+  cancelMailReclassifySample,
+  countReclassifiableThreads,
+  enqueueMailReclassifySample,
+  getMailReclassifySampleStatus,
+  MAIL_RECLASSIFY_THREAD_DELAY_MS,
+  type MailReclassifyCount,
+  type MailReclassifySampleJobData,
+  mailReclassifySampleJob,
+  mailReclassifySampleJobId,
+  type ReclassifyCursor,
+  type ReclassifyScopeSqlInput,
+  type ReclassifyThreadRow,
+  type ResolvedReclassifyWindow,
+  type RunMailReclassifySampleInput,
+  resolveReclassifyWindow,
+  runMailReclassifySample,
+  selectReclassifyThreadPage,
+} from './retroactive'
 // Server-side shapes
 export type {
   MailClassificationContext,

--- a/packages/lib/src/mail-classification/job.test.ts
+++ b/packages/lib/src/mail-classification/job.test.ts
@@ -40,7 +40,12 @@ function ctx(data: Partial<MailClassificationJobData> = {}) {
 beforeEach(() => {
   vi.clearAllMocks()
   h.guard.mockResolvedValue({ proceed: true, context: CONTEXT })
-  h.classify.mockResolvedValue({ tagId: 'tag_billing', confidence: 0.9, model: 'gpt-x' })
+  h.classify.mockResolvedValue({
+    tagId: 'tag_billing',
+    confidence: 0.9,
+    model: 'gpt-x',
+    inferred: true,
+  })
   h.apply.mockResolvedValue(true)
   h.mark.mockResolvedValue(undefined)
   h.rerun.mockResolvedValue(['flt_category'])
@@ -131,6 +136,7 @@ describe('mailClassificationJob — nothing applied', () => {
       confidence: 0.4,
       reason: 'below-threshold',
       model: 'gpt-x',
+      inferred: true,
     })
 
     await expect(mailClassificationJob(ctx())).resolves.toEqual({
@@ -146,7 +152,54 @@ describe('mailClassificationJob — nothing applied', () => {
   })
 
   it('no default model: NO marker, so the message stays classifiable once one is set', async () => {
-    h.classify.mockResolvedValue({ tagId: null, confidence: 0, reason: 'no-default-model' })
+    h.classify.mockResolvedValue({
+      tagId: null,
+      confidence: 0,
+      reason: 'no-default-model',
+      inferred: false,
+    })
+
+    await mailClassificationJob(ctx())
+
+    expect(h.mark).not.toHaveBeenCalled()
+  })
+
+  // ⚠️ THE REGRESSION. A failed call spends nothing and decides nothing, so the
+  // C9 marker must not go down — stamping it disqualified the message from ever
+  // being classified, permanently, for a condition that usually clears by
+  // itself. The marker is gated on `inferred`, never on the reason.
+  for (const reason of ['quota-exceeded', 'unavailable', 'error'] as const) {
+    it(`"${reason}": NO marker, so the message stays classifiable`, async () => {
+      h.classify.mockResolvedValue({
+        tagId: null,
+        confidence: 0,
+        reason,
+        model: 'gpt-x',
+        inferred: false,
+      })
+
+      await expect(mailClassificationJob(ctx())).resolves.toEqual({
+        classified: false,
+        confidence: 0,
+        skipped: reason,
+      })
+
+      expect(h.mark).not.toHaveBeenCalled()
+      expect(h.apply).not.toHaveBeenCalled()
+      expect(h.rerun).not.toHaveBeenCalled()
+    })
+  }
+
+  it('stamps on `inferred`, NOT on the reason — a new failure arm cannot inherit "stamp"', async () => {
+    // A reason the marker gate has never heard of. If the gate ever goes back to
+    // enumerating reasons, this is what catches it: an unrecognised failure must
+    // default to "stays classifiable", not to "done forever".
+    h.classify.mockResolvedValue({
+      tagId: null,
+      confidence: 0,
+      reason: 'some-future-failure',
+      inferred: false,
+    })
 
     await mailClassificationJob(ctx())
 

--- a/packages/lib/src/mail-classification/job.ts
+++ b/packages/lib/src/mail-classification/job.ts
@@ -90,10 +90,14 @@ export async function mailClassificationJob(
 
   // Stamp the marker for EVERY completed inference, including the ones that
   // apply nothing (C9): the spend has happened, and re-inferring the same
-  // message would bill twice for the same answer. `'no-default-model'` is the
-  // one exception — nothing was spent and nothing was decided, so the message
-  // stays classifiable once a model is configured.
-  if (result.reason !== 'no-default-model') {
+  // message would bill twice for the same answer.
+  //
+  // ⚠️ Gated on `inferred`, never on the reason. A failed call — no credits, a
+  // provider 429, a network blip — spent nothing and decided nothing, so it must
+  // leave the message classifiable exactly as `'no-default-model'` does. Marking
+  // those disqualified the message forever, silently, for a condition that
+  // typically resolves on its own.
+  if (result.inferred) {
     await markMessageClassified({
       db,
       organizationId,

--- a/packages/lib/src/mail-classification/retroactive.test.ts
+++ b/packages/lib/src/mail-classification/retroactive.test.ts
@@ -1,0 +1,733 @@
+// packages/lib/src/mail-classification/retroactive.test.ts
+// What is worth pinning about a bulk path that spends money:
+//   • the ONE predicate the preview and the run share (07 invariant 10), and the
+//     `IS DISTINCT FROM 'hard'` trap inside it (07 invariant 4);
+//   • ONE inference per THREAD, on the FIRST INBOUND message (07 invariant 2);
+//   • sample mode applies nothing, marks nothing, re-runs no filters
+//     (07 invariants 9 and 3);
+//   • the exit-5 bypass is a run parameter and cannot reach the opt-in exits
+//     (07 invariants 5 and 6).
+
+import type { SQL } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  getOrgCache: vi.fn(),
+  getEligibleClassificationTags: vi.fn(),
+  guardClassification: vi.fn(),
+  classifyMessage: vi.fn(),
+  applyClassificationTag: vi.fn(),
+  markMessageClassified: vi.fn(),
+  rerunFilters: vi.fn(),
+  queueAdd: vi.fn(),
+  queueGetJob: vi.fn(),
+  jobRemove: vi.fn(),
+  jobGetState: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({ getOrgCache: h.getOrgCache }))
+vi.mock('./labels', () => ({ getEligibleClassificationTags: h.getEligibleClassificationTags }))
+vi.mock('./guard', () => ({ guardClassification: h.guardClassification }))
+vi.mock('./classify', () => ({ classifyMessage: h.classifyMessage }))
+vi.mock('./apply', () => ({
+  applyClassificationTag: h.applyClassificationTag,
+  markMessageClassified: h.markMessageClassified,
+}))
+vi.mock('./rerun-filters', () => ({ rerunMailFiltersAfterClassification: h.rerunFilters }))
+vi.mock('../jobs/queues', () => ({
+  getQueue: () => ({ add: h.queueAdd, getJob: h.queueGetJob }),
+}))
+vi.mock('../jobs/queues/types', () => ({ Queues: { maintenanceQueue: 'maintenance' } }))
+
+import type { Database } from '@auxx/database'
+import type { MailReclassifyRange } from './client'
+import {
+  buildReclassifyWhere,
+  countReclassifiableThreads,
+  enqueueMailReclassifySample,
+  mailReclassifySampleJobId,
+  resolveReclassifyWindow,
+  runMailReclassifySample,
+  selectReclassifyThreadPage,
+} from './retroactive'
+
+const ORG = 'org_1'
+const INBOX = 'ibx_1'
+const NOW = new Date('2026-08-10T12:00:00.000Z')
+
+const LABELS = [
+  { tagId: 'tag_billing', title: 'Billing', description: 'Money questions' },
+  { tagId: 'tag_support', title: 'Support', description: 'Help with a product' },
+  { tagId: 'tag_account', title: 'Account', description: 'Logins and profiles' },
+]
+
+/** Render a SQL fragment to text so the predicate itself can be asserted. */
+function render(fragment: SQL) {
+  return new PgDialect().sqlToQuery(fragment)
+}
+
+function makeDb(rowsByCall: unknown[][]) {
+  let call = 0
+  const execute = vi.fn(async (_fragment: SQL) => ({ rows: rowsByCall[call++] ?? [] }))
+  return { execute } as unknown as Database & { execute: typeof execute }
+}
+
+/** The SQL a fake db was actually asked to run, rendered. */
+function queryAt(db: ReturnType<typeof makeDb>, index = 0) {
+  const fragment = db.execute.mock.calls[index]?.[0]
+  if (!fragment) throw new Error('no query was executed')
+  return render(fragment)
+}
+
+function threadRow(n: number): Record<string, unknown> {
+  return {
+    threadId: `thr_${n}`,
+    cursorAt: `2026-08-0${n} 10:00:00`,
+    messageId: `msg_first_${n}`,
+    tier: null,
+    subject: `Subject ${n}`,
+    textPlain: `Body ${n}`,
+    from: `sender${n}@example.com`,
+  }
+}
+
+const window30 = () =>
+  resolveReclassifyWindow({ kind: 'days', days: 30 }, { now: NOW })._unsafeUnwrap()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getOrgCache.mockReturnValue({
+    get: vi.fn(async () => ({ mailClassificationInboxIds: [INBOX] })),
+  })
+  h.getEligibleClassificationTags.mockResolvedValue(LABELS)
+  h.guardClassification.mockImplementation((input: { messageId: string; threadId: string }) =>
+    Promise.resolve({
+      proceed: true,
+      context: {
+        organizationId: ORG,
+        messageId: input.messageId,
+        threadId: input.threadId,
+        inboxId: INBOX,
+        labels: LABELS,
+        message: { subject: 's', from: 'a@b.com', textPlain: 'b' },
+      },
+    })
+  )
+  h.classifyMessage.mockResolvedValue({
+    tagId: 'tag_billing',
+    confidence: 0.9,
+    model: 'gpt-x',
+    inferred: true,
+  })
+  h.queueGetJob.mockResolvedValue(null)
+  h.queueAdd.mockResolvedValue({ id: 'job' })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolveReclassifyWindow — the presets (§2.4 axis 1)', () => {
+  it('defaults land on a 30-day window measured from the injected clock', () => {
+    const w = resolveReclassifyWindow({ kind: 'days', days: 30 }, { now: NOW })._unsafeUnwrap()
+
+    expect(w.since?.toISOString()).toBe('2026-07-11T12:00:00.000Z')
+    expect(w.until).toBeNull()
+    expect(w.maxThreads).toBe(5000)
+  })
+
+  for (const days of [7, 30, 90]) {
+    it(`the ${days}-day preset resolves to exactly ${days} days back`, () => {
+      const w = resolveReclassifyWindow({ kind: 'days', days }, { now: NOW })._unsafeUnwrap()
+      expect(NOW.getTime() - (w.since?.getTime() ?? 0)).toBe(days * 86_400_000)
+    })
+  }
+
+  for (const threads of [100, 500, 1000]) {
+    it(`the ${threads}-thread preset bounds the COUNT, not the dates`, () => {
+      const w = resolveReclassifyWindow({ kind: 'threads', threads }, { now: NOW })._unsafeUnwrap()
+
+      expect(w.since).toBeNull()
+      expect(w.until).toBeNull()
+      expect(w.maxThreads).toBe(threads)
+      expect(w.limitSource).toBe('range')
+    })
+  }
+
+  it('a thread preset beyond the hard cap is clamped, and says the CAP is why', () => {
+    const w = resolveReclassifyWindow({ kind: 'threads', threads: 99_999 })._unsafeUnwrap()
+
+    expect(w.maxThreads).toBe(5000)
+    expect(w.limitSource).toBe('cap')
+  })
+
+  it('all-time is unbounded in dates and bounded by the hard cap', () => {
+    const w = resolveReclassifyWindow({ kind: 'all-time' })._unsafeUnwrap()
+
+    expect(w.since).toBeNull()
+    expect(w.maxThreads).toBe(5000)
+    expect(w.limitSource).toBe('cap')
+  })
+
+  it('a custom range carries both bounds', () => {
+    const w = resolveReclassifyWindow({
+      kind: 'custom',
+      sinceIso: '2026-01-01T00:00:00.000Z',
+      untilIso: '2026-02-01T00:00:00.000Z',
+    })._unsafeUnwrap()
+
+    expect(w.since?.toISOString()).toBe('2026-01-01T00:00:00.000Z')
+    expect(w.until?.toISOString()).toBe('2026-02-01T00:00:00.000Z')
+  })
+
+  it('rejects a backwards custom range rather than counting zero threads', () => {
+    const result = resolveReclassifyWindow({
+      kind: 'custom',
+      sinceIso: '2026-02-01T00:00:00.000Z',
+      untilIso: '2026-01-01T00:00:00.000Z',
+    })
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('rejects nonsense day and thread counts', () => {
+    expect(resolveReclassifyWindow({ kind: 'days', days: 0 }).isErr()).toBe(true)
+    expect(resolveReclassifyWindow({ kind: 'threads', threads: -5 }).isErr()).toBe(true)
+    expect(resolveReclassifyWindow({ kind: 'custom', sinceIso: 'not a date' }).isErr()).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildReclassifyWhere — the scoping predicate (§2.4)', () => {
+  const base = {
+    organizationId: ORG,
+    inboxId: INBOX,
+    window: window30(),
+    eligibleTagIds: LABELS.map((l) => l.tagId),
+  }
+
+  // ⚠️ 07 INVARIANT 4. `machineMailTier` is NULL on ~84% of the corpus because
+  // detection only went live 2026-07-15 — NULL means NOT EVALUATED, not human.
+  // A `tier IS NULL` predicate would silently exclude nearly every thread worth
+  // classifying and would look like "nothing to do".
+  it('excludes hard-tier machine mail with IS DISTINCT FROM, never with IS NULL', () => {
+    const { sql: text } = render(buildReclassifyWhere({ ...base, mode: 'fill-gaps' }))
+
+    expect(text).toContain(`fm."tier" IS DISTINCT FROM 'hard'`)
+    expect(text).not.toContain('fm."tier" IS NULL')
+  })
+
+  it('always scopes to one org, one inbox, and drops merged threads', () => {
+    const { sql: text } = render(buildReclassifyWhere({ ...base, mode: 'fill-gaps' }))
+
+    expect(text).toContain('t."organizationId" = $1')
+    expect(text).toContain('t."inboxId" = $2')
+    expect(text).toContain('t."mergedIntoThreadId" IS NULL')
+  })
+
+  it('fill-gaps excludes marked messages AND already-categorised threads', () => {
+    const { sql: text, params } = render(buildReclassifyWhere({ ...base, mode: 'fill-gaps' }))
+
+    expect(text).toContain('fm."metadata" ->')
+    expect(text).toContain('IS NULL')
+    expect(text).toContain('NOT EXISTS')
+    expect(text).toContain(`cf."systemAttribute" = 'thread_tags'`)
+    expect(params).toContain('mailClassification')
+    for (const label of LABELS) expect(params).toContain(label.tagId)
+  })
+
+  // R4 — the two modes have very different cost profiles and must not be blurred.
+  it('re-classify drops BOTH of those exclusions, which is what makes it pay twice', () => {
+    const { sql: text } = render(buildReclassifyWhere({ ...base, mode: 're-classify' }))
+
+    expect(text).not.toContain('fm."metadata" ->')
+    expect(text).not.toContain('NOT EXISTS')
+    // …but it still honours the machine-mail exclusion, which is not a mode.
+    expect(text).toContain(`fm."tier" IS DISTINCT FROM 'hard'`)
+  })
+
+  it('a date window binds both bounds as UTC text, not as a raw Date', () => {
+    const window = resolveReclassifyWindow({
+      kind: 'custom',
+      sinceIso: '2026-01-01T00:00:00.000Z',
+      untilIso: '2026-02-01T00:00:00.000Z',
+    })._unsafeUnwrap()
+    const { sql: text, params } = render(
+      buildReclassifyWhere({ ...base, window, mode: 'fill-gaps' })
+    )
+
+    expect(text).toContain('t."lastMessageAt" >=')
+    expect(text).toContain('t."lastMessageAt" <')
+    expect(params).toContain('2026-01-01T00:00:00.000Z')
+    expect(params).toContain('2026-02-01T00:00:00.000Z')
+  })
+
+  it('an all-time window adds no date bound at all', () => {
+    const window = resolveReclassifyWindow({ kind: 'all-time' })._unsafeUnwrap()
+    const { sql: text } = render(buildReclassifyWhere({ ...base, window, mode: 'fill-gaps' }))
+
+    expect(text).not.toContain('t."lastMessageAt" >=')
+    expect(text).not.toContain('t."lastMessageAt" <')
+  })
+
+  // Keyset, not OFFSET: the run mutates the very columns the fill-gaps predicate
+  // reads, so an offset window would slide underneath itself.
+  it('a cursor becomes a descending row comparison, not an offset', () => {
+    const { sql: text, params } = render(
+      buildReclassifyWhere({
+        ...base,
+        mode: 'fill-gaps',
+        cursor: { at: '2026-08-01 10:00:00', threadId: 'thr_9' },
+      })
+    )
+
+    expect(text).toContain('(t."lastMessageAt", t."id") <')
+    expect(text).not.toContain('OFFSET')
+    expect(params).toContain('thr_9')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('countReclassifiableThreads — the preview (§2.5)', () => {
+  const input = {
+    organizationId: ORG,
+    inboxId: INBOX,
+    range: { kind: 'days', days: 30 } as MailReclassifyRange,
+    mode: 'fill-gaps' as const,
+    now: NOW,
+  }
+
+  // ⚠️ 07 INVARIANT 6 — a re-run is a way to catch up, not a way in.
+  it('refuses an inbox that never opted in', async () => {
+    h.getOrgCache.mockReturnValue({ get: vi.fn(async () => ({ mailClassificationInboxIds: [] })) })
+    const db = makeDb([[{ count: 5 }]])
+
+    const result = await countReclassifiableThreads(db, input)
+
+    expect(result.isErr()).toBe(true)
+    expect(db.execute).not.toHaveBeenCalled()
+  })
+
+  it('refuses an org with no eligible categories', async () => {
+    h.getEligibleClassificationTags.mockResolvedValue([])
+    const db = makeDb([[{ count: 5 }]])
+
+    const result = await countReclassifiableThreads(db, input)
+
+    expect(result.isErr()).toBe(true)
+    expect(db.execute).not.toHaveBeenCalled()
+  })
+
+  it('reports the count and the eligible label count', async () => {
+    const db = makeDb([[{ count: 412 }]])
+
+    const result = (await countReclassifiableThreads(db, input))._unsafeUnwrap()
+
+    expect(result).toMatchObject({
+      count: 412,
+      capped: false,
+      mode: 'fill-gaps',
+      eligibleTagCount: 3,
+    })
+  })
+
+  // ⚠️ 07 INVARIANT 8 — a capped run says what it capped. Silent truncation
+  // reads as "covered everything".
+  it('flags the cap instead of silently truncating', async () => {
+    const db = makeDb([[{ count: 11 }]])
+
+    const result = (await countReclassifiableThreads(db, { ...input, cap: 10 }))._unsafeUnwrap()
+
+    expect(result).toMatchObject({ count: 10, capped: true, cap: 10 })
+  })
+
+  // ⚠️ 07 INVARIANT 10 — the number in the confirm is what the user agreed to
+  // spend on, so the preview compiles the SAME predicate the run pages over.
+  it('counts through buildReclassifyWhere, bounded by LIMIT cap + 1', async () => {
+    const db = makeDb([[{ count: 3 }]])
+
+    await countReclassifiableThreads(db, { ...input, cap: 100 })
+
+    const { sql: text, params } = queryAt(db)
+    expect(text).toContain(`fm."tier" IS DISTINCT FROM 'hard'`)
+    expect(text).toContain('JOIN LATERAL')
+    expect(params).toContain(101)
+  })
+
+  it('a thread preset caps the count at the preset, not at the hard cap', async () => {
+    const db = makeDb([[{ count: 101 }]])
+
+    const result = (
+      await countReclassifiableThreads(db, {
+        ...input,
+        range: { kind: 'threads', threads: 100 },
+      })
+    )._unsafeUnwrap()
+
+    expect(result).toMatchObject({ count: 100, capped: true, cap: 100 })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('selectReclassifyThreadPage — one row per thread (§2.3)', () => {
+  it('pairs each thread with its FIRST INBOUND message and a keyset cursor', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2)]])
+
+    const rows = await selectReclassifyThreadPage(db, {
+      organizationId: ORG,
+      inboxId: INBOX,
+      window: window30(),
+      mode: 'fill-gaps',
+      eligibleTagIds: [],
+      limit: 50,
+    })
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      threadId: 'thr_1',
+      messageId: 'msg_first_1',
+      from: 'sender1@example.com',
+    })
+    expect(rows[1]?.cursor).toEqual({ at: '2026-08-02 10:00:00', threadId: 'thr_2' })
+  })
+
+  // ⚠️ 07 INVARIANT 8 — newest first, always. A run that dies halfway must have
+  // covered the part that mattered.
+  it('selects newest first, one message per thread', async () => {
+    const db = makeDb([[]])
+
+    await selectReclassifyThreadPage(db, {
+      organizationId: ORG,
+      inboxId: INBOX,
+      window: window30(),
+      mode: 'fill-gaps',
+      eligibleTagIds: [],
+      limit: 50,
+    })
+
+    const { sql: text } = queryAt(db)
+    expect(text).toContain('ORDER BY t."lastMessageAt" DESC, t."id" DESC')
+    // The lateral is what makes "one inference per thread" true in SQL rather
+    // than in a loop that could drift.
+    expect(text).toContain('JOIN LATERAL')
+    expect(text).toContain(`m."isInbound" = true`)
+    expect(text).toContain('LIMIT 1')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runMailReclassifySample — sample mode (§2.11)', () => {
+  const input = {
+    organizationId: ORG,
+    inboxId: INBOX,
+    range: { kind: 'days', days: 30 } as MailReclassifyRange,
+    mode: 'fill-gaps' as const,
+    now: NOW,
+    threadDelayMs: 0,
+  }
+
+  // ⚠️ 07 INVARIANT 2 / R3 — the unit is the THREAD. Per-message would spend an
+  // inference per message to produce one tag per thread.
+  it('spends exactly ONE inference per thread, on that thread’s first inbound message', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2), threadRow(3)]])
+
+    await runMailReclassifySample(db, input)
+
+    expect(h.classifyMessage).toHaveBeenCalledTimes(3)
+    const messageIds = h.classifyMessage.mock.calls.map(
+      (call) => (call[1] as { messageId: string }).messageId
+    )
+    expect(messageIds).toEqual(['msg_first_1', 'msg_first_2', 'msg_first_3'])
+  })
+
+  // ⚠️ 07 INVARIANT 9 — a marker would silently disqualify the sampled threads
+  // from the real run that follows. ⚠️ 07 INVARIANT 3 / R2 — the filter re-run
+  // is mandatory on the LIVE path and this is the deliberate exception.
+  it('applies nothing, marks nothing, and re-runs no filters', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2)]])
+
+    const report = (await runMailReclassifySample(db, input))._unsafeUnwrap()
+
+    expect(h.applyClassificationTag).not.toHaveBeenCalled()
+    expect(h.markMessageClassified).not.toHaveBeenCalled()
+    expect(h.rerunFilters).not.toHaveBeenCalled()
+    expect(report.applied).toBe(false)
+  })
+
+  it('reports the distribution, including labels the model never chose', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2), threadRow(3), threadRow(4)]])
+    h.classifyMessage
+      .mockResolvedValueOnce({ tagId: 'tag_billing', confidence: 0.9, inferred: true })
+      .mockResolvedValueOnce({ tagId: 'tag_billing', confidence: 0.7, inferred: true })
+      .mockResolvedValueOnce({ tagId: 'tag_support', confidence: 0.8, inferred: true })
+      .mockResolvedValueOnce({
+        tagId: null,
+        confidence: 0.2,
+        reason: 'below-threshold',
+        inferred: true,
+      })
+
+    const report = (await runMailReclassifySample(db, input))._unsafeUnwrap()
+
+    expect(report.selected).toBe(4)
+    expect(report.inferred).toBe(4)
+    expect(report.classified).toBe(3)
+    expect(report.abstained).toBe(1)
+    expect(report.abstentionRate).toBeCloseTo(0.25)
+    // ⚠️ The zero row IS the finding (§3.3 / 06 Q1) — a label never chosen in a
+    // sample is a label to merge. It must render, not be filtered out.
+    expect(report.labels).toEqual([
+      { tagId: 'tag_billing', title: 'Billing', count: 2, meanConfidence: 0.8 },
+      { tagId: 'tag_support', title: 'Support', count: 1, meanConfidence: 0.8 },
+      { tagId: 'tag_account', title: 'Account', count: 0, meanConfidence: 0 },
+    ])
+  })
+
+  it('splits abstention by reason and keeps it OUT of the guard-exit tally', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2)]])
+    h.classifyMessage
+      .mockResolvedValueOnce({
+        tagId: null,
+        confidence: 0.1,
+        reason: 'no-category',
+        inferred: true,
+      })
+      .mockResolvedValueOnce({
+        tagId: null,
+        confidence: 0.5,
+        reason: 'below-threshold',
+        inferred: true,
+      })
+
+    const report = (await runMailReclassifySample(db, input))._unsafeUnwrap()
+
+    expect(report.abstainedByReason).toEqual({ 'no-category': 1, 'below-threshold': 1 })
+    expect(report.skipped).toEqual({})
+    expect(report.inferred).toBe(2)
+  })
+
+  it('a failed call is a skip that never reached the model, not an abstention', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2)]])
+    h.classifyMessage
+      .mockResolvedValueOnce({ tagId: null, confidence: 0, reason: 'unavailable', inferred: false })
+      .mockResolvedValueOnce({ tagId: 'tag_billing', confidence: 0.9, inferred: true })
+
+    const report = (await runMailReclassifySample(db, input))._unsafeUnwrap()
+
+    expect(report.skipped).toEqual({ unavailable: 1 })
+    expect(report.abstained).toBe(0)
+    expect(report.inferred).toBe(1)
+    // §2.11: say the sample was smaller than asked, rather than implying 100.
+    expect(report.selected).toBe(2)
+  })
+
+  it('honours the guard, and counts every exit it hits', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2)]])
+    h.guardClassification
+      .mockResolvedValueOnce({ proceed: false, reason: 'machine-mail' })
+      .mockResolvedValueOnce({ proceed: false, reason: 'already-classified' })
+
+    const report = (await runMailReclassifySample(db, input))._unsafeUnwrap()
+
+    expect(h.classifyMessage).not.toHaveBeenCalled()
+    expect(report.skipped).toEqual({ 'machine-mail': 1, 'already-classified': 1 })
+    expect(report.inferred).toBe(0)
+  })
+
+  it('passes the selected message’s tier and sender straight to the guard', async () => {
+    const db = makeDb([[{ ...threadRow(1), tier: 'soft' }]])
+
+    await runMailReclassifySample(db, input)
+
+    expect(h.guardClassification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 'msg_first_1',
+        threadId: 'thr_1',
+        machineMailTier: 'soft',
+        from: 'sender1@example.com',
+      })
+    )
+  })
+
+  it('stops between threads when cancelled — nothing is committed, so it is safe', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2), threadRow(3)]])
+    let seen = 0
+    const isCancelled = () => {
+      seen += 1
+      return seen > 2
+    }
+
+    const report = (await runMailReclassifySample(db, { ...input, isCancelled }))._unsafeUnwrap()
+
+    expect(h.classifyMessage).toHaveBeenCalledTimes(2)
+    expect(report.inferred).toBe(2)
+  })
+
+  it('asks for at most the sample size (§2.11 — ~100 threads, not the backlog)', async () => {
+    const db = makeDb([[]])
+
+    await runMailReclassifySample(db, { ...input, sampleSize: 100 })
+
+    expect(queryAt(db).params).toContain(100)
+  })
+
+  it('refuses to sample an inbox that never opted in (invariant 6)', async () => {
+    h.getOrgCache.mockReturnValue({ get: vi.fn(async () => ({ mailClassificationInboxIds: [] })) })
+    const db = makeDb([[threadRow(1)]])
+
+    const result = await runMailReclassifySample(db, input)
+
+    expect(result.isErr()).toBe(true)
+    expect(h.classifyMessage).not.toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runMailReclassifySample — the exit-5 bypass is a run parameter (§2.6)', () => {
+  const base = {
+    organizationId: ORG,
+    inboxId: INBOX,
+    range: { kind: 'all-time' } as MailReclassifyRange,
+    now: NOW,
+    threadDelayMs: 0,
+  }
+
+  // ⚠️ 07 INVARIANT 5 — the guard's default stays "classify once, ever". The
+  // bypass lives in the run, and only re-classify mode asks for it.
+  for (const reason of ['already-classified', 'thread-already-categorised'] as const) {
+    it(`re-classify bypasses "${reason}" and pays again, on purpose`, async () => {
+      const db = makeDb([[threadRow(1)]])
+      h.guardClassification.mockResolvedValue({ proceed: false, reason })
+
+      const report = (
+        await runMailReclassifySample(db, { ...base, mode: 're-classify' })
+      )._unsafeUnwrap()
+
+      expect(h.classifyMessage).toHaveBeenCalledTimes(1)
+      expect(report.inferred).toBe(1)
+    })
+
+    it(`fill-gaps honours "${reason}" and never double-bills`, async () => {
+      const db = makeDb([[threadRow(1)]])
+      h.guardClassification.mockResolvedValue({ proceed: false, reason })
+
+      const report = (
+        await runMailReclassifySample(db, { ...base, mode: 'fill-gaps' })
+      )._unsafeUnwrap()
+
+      expect(h.classifyMessage).not.toHaveBeenCalled()
+      expect(report.skipped).toEqual({ [reason]: 1 })
+    })
+  }
+
+  // ⚠️ 07 INVARIANT 6 — a re-run cannot be used to bypass the opt-in, and a
+  // hard-tier bounce is never worth an inference in either mode.
+  for (const reason of [
+    'machine-mail',
+    'no-thread',
+    'inbox-not-opted-in',
+    'no-eligible-tags',
+  ] as const) {
+    it(`re-classify does NOT bypass "${reason}"`, async () => {
+      const db = makeDb([[threadRow(1)]])
+      h.guardClassification.mockResolvedValue({ proceed: false, reason })
+
+      const report = (
+        await runMailReclassifySample(db, { ...base, mode: 're-classify' })
+      )._unsafeUnwrap()
+
+      expect(h.classifyMessage).not.toHaveBeenCalled()
+      expect(report.skipped).toEqual({ [reason]: 1 })
+    })
+  }
+
+  it('the bypassed context still carries the run’s labels and the selected message', async () => {
+    const db = makeDb([[threadRow(1)]])
+    h.guardClassification.mockResolvedValue({ proceed: false, reason: 'already-classified' })
+
+    await runMailReclassifySample(db, { ...base, mode: 're-classify' })
+
+    expect(h.classifyMessage.mock.calls[0]?.[1]).toMatchObject({
+      organizationId: ORG,
+      messageId: 'msg_first_1',
+      threadId: 'thr_1',
+      inboxId: INBOX,
+      labels: LABELS,
+      message: { subject: 'Subject 1', from: 'sender1@example.com', textPlain: 'Body 1' },
+    })
+  })
+
+  it('a throwing guard skips one thread instead of failing the whole sample', async () => {
+    const db = makeDb([[threadRow(1), threadRow(2)]])
+    h.guardClassification.mockRejectedValueOnce(new Error('db down'))
+
+    const report = (
+      await runMailReclassifySample(db, { ...base, mode: 'fill-gaps' })
+    )._unsafeUnwrap()
+
+    expect(report.skipped).toEqual({ error: 1 })
+    expect(report.inferred).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('enqueueMailReclassifySample — the queue contract (§2.2)', () => {
+  const data = {
+    organizationId: ORG,
+    inboxId: INBOX,
+    range: { kind: 'days', days: 30 } as MailReclassifyRange,
+    mode: 'fill-gaps' as const,
+  }
+
+  it('uses a deterministic jobId so a double-click collapses into one run', async () => {
+    await enqueueMailReclassifySample(data)
+
+    expect(h.queueAdd).toHaveBeenCalledWith(
+      'mailReclassifySampleJob',
+      data,
+      expect.objectContaining({ jobId: mailReclassifySampleJobId(ORG, INBOX) })
+    )
+  })
+
+  // ⚠️ The queue default is `attempts: 5`. A retry re-spends the whole sample —
+  // the bulk equivalent of the C9 double-billing bug.
+  it('pins attempts to 1 and keeps the finished job so its report can be read', async () => {
+    await enqueueMailReclassifySample(data)
+
+    const opts = h.queueAdd.mock.calls[0]?.[2] as { attempts: number; removeOnComplete: unknown }
+    expect(opts.attempts).toBe(1)
+    expect(opts.removeOnComplete).not.toBe(true)
+  })
+
+  it('returns the in-flight run rather than queueing a second one', async () => {
+    h.queueGetJob.mockResolvedValue({
+      getState: async () => 'active',
+      remove: h.jobRemove,
+    })
+
+    const result = (await enqueueMailReclassifySample(data))._unsafeUnwrap()
+
+    expect(result.deduplicated).toBe(true)
+    expect(h.queueAdd).not.toHaveBeenCalled()
+    expect(h.jobRemove).not.toHaveBeenCalled()
+  })
+
+  // §3.3's loop is sample → fix the vocabulary → sample again. A completed job
+  // left in place would make BullMQ hand back the stale report.
+  it('clears a COMPLETED run so the same scope can be re-sampled', async () => {
+    h.queueGetJob.mockResolvedValue({
+      getState: async () => 'completed',
+      remove: h.jobRemove.mockResolvedValue(undefined),
+    })
+
+    const result = (await enqueueMailReclassifySample(data))._unsafeUnwrap()
+
+    expect(h.jobRemove).toHaveBeenCalledTimes(1)
+    expect(h.queueAdd).toHaveBeenCalledTimes(1)
+    expect(result.deduplicated).toBe(false)
+  })
+})

--- a/packages/lib/src/mail-classification/retroactive.ts
+++ b/packages/lib/src/mail-classification/retroactive.ts
@@ -1,0 +1,924 @@
+// packages/lib/src/mail-classification/retroactive.ts
+// Retroactive re-classification — PHASE 1 (07-mail-reclassification-plan.md §4):
+// scope resolution (§2.4), the shared count (§2.5), one-inference-per-thread
+// selection (§2.3) and SAMPLE MODE (§2.11).
+//
+// Shape copied from `mail-filters/retroactive.ts:174` — the proven precedent for
+// exactly this: a queue job with a deterministic `jobId`, paged and logged.
+//
+// ─── The four things a reader will otherwise get wrong ───────────────────────
+//
+// ⚠️ 1. THE UNIT IS THE THREAD, NEVER THE MESSAGE (R3, §2.3, invariant 2).
+//    Live classification is per-message and that is correct — one message
+//    arrives, one inference, and guard exit 6 stops the next message on that
+//    thread. A retroactive run has no such natural throttle: pointed at a backlog
+//    it would see every message individually, so a 20-message thread would cost
+//    20 inferences to produce one tag. Across the measured corpus that is 9,441
+//    inferences to categorise 7,509 threads. So: select THREADS, classify the
+//    FIRST INBOUND message of each, apply at most one tag.
+//
+// ⚠️ 2. THIS PATH MUST NOT RE-RUN MAIL FILTERS (R2, §2.12, invariant 3).
+//    `rerunMailFiltersAfterClassification` is MANDATORY on the live path
+//    (`05-mail-classification-plan.md` invariant 15) — and this is the deliberate
+//    exception. Firing `assign` / `archive` / `run-agent` over a historical
+//    backlog is the late-filter-action problem; a retroactive run tags and stops.
+//    Do not "fix" the inconsistency. A user who wants filters applied to the
+//    newly-tagged backlog runs `mail-filters/retroactive.ts` themselves — a
+//    separate, already-paged, already-undoable action.
+//    This file therefore never imports that module. That absence is the feature.
+//
+// ⚠️ 3. `machineMailTier IS NULL` MEANS *NOT EVALUATED*, NOT *HUMAN*
+//    (invariant 4). Detection only went live 2026-07-15, so the column is NULL on
+//    ~84% of the corpus. The predicate is `IS DISTINCT FROM 'hard'`. A
+//    `tier IS NULL` predicate silently excludes almost every thread worth
+//    classifying, and looks like "nothing to do" rather than like a bug.
+//
+// ⚠️ 4. THE EXIT-5 BYPASS IS A JOB PARAMETER, NEVER A GUARD CHANGE (§2.6,
+//    invariant 5). `guardClassification`'s default stays "classify once, ever".
+//    Only the two "already done" exits are bypassable, and only in `re-classify`
+//    mode; the opt-in exits are never bypassable (invariant 6 — a re-run is a way
+//    to catch up, not a way in).
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { type SQL, sql } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { getOrgCache } from '../cache'
+import { BadRequestError } from '../errors'
+import type { JobContext } from '../jobs/types/job-context'
+import { classifyMessage } from './classify'
+import {
+  MAIL_CLASSIFICATION_INBOX_IDS_SETTING,
+  MAIL_CLASSIFICATION_METADATA_KEY,
+  MAIL_RECLASSIFY_MAX_THREADS,
+  MAIL_RECLASSIFY_SAMPLE_JOB_NAME,
+  MAIL_RECLASSIFY_SAMPLE_SIZE,
+  type MailClassificationLabel,
+  type MailClassificationSkipReason,
+  type MailReclassifyMode,
+  type MailReclassifyRange,
+  type MailReclassifySampleReport,
+  type MailReclassifySampleStatus,
+} from './client'
+import { guardClassification } from './guard'
+import { getEligibleClassificationTags } from './labels'
+import type { MailClassificationContext } from './types'
+
+const logger = createScopedLogger('mail-reclassification')
+
+/**
+ * Delay between inferences inside one run (§2.5 — "throttled").
+ *
+ * This is the one path that deliberately generates sustained model load, and
+ * with the circuit breaker inert (`05-…§12.6`) there is nothing else shedding
+ * it. Threads are processed strictly sequentially (concurrency 1) and this delay
+ * sits between them, so the ceiling is roughly one inference per
+ * `(call duration + delay)`.
+ */
+export const MAIL_RECLASSIFY_THREAD_DELAY_MS = 250
+
+/**
+ * The two guard exits a `re-classify` run may bypass (§2.6).
+ *
+ * ⚠️ Deliberately an explicit pair, not "any skip reason". `'machine-mail'`,
+ * `'no-thread'`, `'inbox-not-opted-in'` and `'no-eligible-tags'` stay fatal in
+ * BOTH modes — invariant 6: a re-run cannot be used to bypass the opt-in.
+ */
+const BYPASSABLE_EXITS = new Set<MailClassificationSkipReason>([
+  'already-classified',
+  'thread-already-categorised',
+])
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Scope resolution (§2.4)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A range resolved against a clock — the only place presets become bounds. */
+export interface ResolvedReclassifyWindow {
+  /** Inclusive lower bound on `Thread.lastMessageAt`, or null for all time. */
+  since: Date | null
+  /** Exclusive upper bound on `Thread.lastMessageAt`, or null for "up to now". */
+  until: Date | null
+  /** Threads this range permits, already intersected with the hard cap. */
+  maxThreads: number
+  /** Which of the two produced `maxThreads` — the UI words the confirm on it. */
+  limitSource: 'range' | 'cap'
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Turn a {@link MailReclassifyRange} into date bounds and a thread ceiling.
+ *
+ * Pure — the clock is injected — because this is the piece worth pinning in
+ * tests, and because the count preview and the job must resolve the SAME window
+ * from the same input (invariant 10).
+ *
+ * Note the two range families bound different things: `'days'` / `'custom'` /
+ * `'all-time'` bound the *dates* and are capped at
+ * {@link MAIL_RECLASSIFY_MAX_THREADS}, while `'threads'` bounds the *count* and
+ * leans entirely on the newest-first ordering (invariant 8) to mean "the N most
+ * recent".
+ */
+export function resolveReclassifyWindow(
+  range: MailReclassifyRange,
+  opts: { now?: Date; hardCap?: number } = {}
+): Result<ResolvedReclassifyWindow, Error> {
+  const now = opts.now ?? new Date()
+  const hardCap = Math.max(1, Math.trunc(opts.hardCap ?? MAIL_RECLASSIFY_MAX_THREADS))
+
+  switch (range.kind) {
+    case 'days': {
+      const days = Math.trunc(range.days)
+      if (!Number.isFinite(days) || days <= 0) {
+        return err(new BadRequestError('A day range must be a positive number of days.'))
+      }
+      return ok({
+        since: new Date(now.getTime() - days * DAY_MS),
+        until: null,
+        maxThreads: hardCap,
+        limitSource: 'cap',
+      })
+    }
+    case 'threads': {
+      const threads = Math.trunc(range.threads)
+      if (!Number.isFinite(threads) || threads <= 0) {
+        return err(new BadRequestError('A thread range must be a positive number of threads.'))
+      }
+      return ok({
+        since: null,
+        until: null,
+        maxThreads: Math.min(threads, hardCap),
+        limitSource: threads <= hardCap ? 'range' : 'cap',
+      })
+    }
+    case 'custom': {
+      const since = new Date(range.sinceIso)
+      if (Number.isNaN(since.getTime())) {
+        return err(new BadRequestError('The start of a custom range is not a valid date.'))
+      }
+      let until: Date | null = null
+      if (range.untilIso) {
+        until = new Date(range.untilIso)
+        if (Number.isNaN(until.getTime())) {
+          return err(new BadRequestError('The end of a custom range is not a valid date.'))
+        }
+        if (until.getTime() <= since.getTime()) {
+          return err(new BadRequestError('A custom range must end after it starts.'))
+        }
+      }
+      return ok({ since, until, maxThreads: hardCap, limitSource: 'cap' })
+    }
+    case 'all-time':
+      return ok({ since: null, until: null, maxThreads: hardCap, limitSource: 'cap' })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. The ONE predicate (§2.5, invariant 10)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Keyset position, newest-first. `at` is the raw `timestamp` text from PG. */
+export interface ReclassifyCursor {
+  at: string
+  threadId: string
+}
+
+export interface ReclassifyScopeSqlInput {
+  organizationId: string
+  inboxId: string
+  window: ResolvedReclassifyWindow
+  mode: MailReclassifyMode
+  /**
+   * Eligible tag ids, used ONLY by the `fill-gaps` "already categorised"
+   * exclusion (guard exit 6, mirrored into SQL so the preview agrees with the
+   * job). Ignored entirely in `re-classify` mode.
+   */
+  eligibleTagIds: string[]
+  cursor?: ReclassifyCursor | null
+}
+
+/**
+ * The FROM clause both the count and the page share.
+ *
+ * `JOIN LATERAL … LIMIT 1` is what makes R3 true in SQL rather than in a loop:
+ * every row of this relation is ONE thread paired with the ONE message that will
+ * be classified for it — its **first inbound message**. A thread with no inbound
+ * message drops out entirely (an inner lateral), which is correct: there is
+ * nothing to classify and nothing to key a marker on.
+ *
+ * "First" is ordered by `COALESCE(receivedAt, sentAt, createdAt)`, not by
+ * `createdAt` alone: on a backfilled mailbox every row's `createdAt` is the
+ * moment of the backfill, in provider order, which is not conversation order.
+ * `isFirstInThread` is not used — it defaults to `true` and is unreliable on
+ * imported mail.
+ *
+ * ⚠️ Why the first inbound message and not the latest (R-Q7): it establishes what
+ * the conversation is about, whereas the latest message is often a one-line
+ * follow-up ("any update?") carrying no signal. It also mirrors what the live
+ * path effectively achieves, since exit 6 means the first message to arrive is
+ * the one that decides the category.
+ */
+function reclassifySource(): SQL {
+  return sql`
+    "Thread" t
+    JOIN LATERAL (
+      SELECT m."id" AS "messageId",
+             m."machineMailTier" AS "tier",
+             m."subject" AS "subject",
+             m."textPlain" AS "textPlain",
+             m."fromId" AS "fromId",
+             m."metadata" AS "metadata"
+      FROM "Message" m
+      WHERE m."threadId" = t."id" AND m."isInbound" = true
+      ORDER BY COALESCE(m."receivedAt", m."sentAt", m."createdAt") ASC, m."id" ASC
+      LIMIT 1
+    ) fm ON TRUE
+    LEFT JOIN "Participant" p ON p."id" = fm."fromId"
+  `
+}
+
+/**
+ * The WHERE clause both the count and the job page over.
+ *
+ * ⚠️ ONE predicate, two callers (invariant 10). The number in the confirm is the
+ * number the user agreed to spend on, so a second implementation for the preview
+ * would be a way to quietly charge for something else.
+ *
+ * The always-implicit exclusions (§2.4), none of which is ever offered as a
+ * choice:
+ *  - merged threads (they are not their own conversation);
+ *  - ⚠️ `fm."tier" IS DISTINCT FROM 'hard'` — **invariant 4**. NULL means *not
+ *    evaluated*, so `IS NULL` here would be very wrong;
+ *  - in `fill-gaps` only: a first inbound message that already carries the C9
+ *    marker (guard exit 5), and a thread that already carries an eligible tag
+ *    (guard exit 6). Those two exclusions ARE the definition of fill-gaps, and
+ *    dropping them is exactly what `re-classify` does.
+ *
+ * `lastMessageAt IS NOT NULL` is required because it is both the range axis and
+ * the keyset axis; a thread with no recorded activity cannot be ordered
+ * newest-first and has no inbound message to classify anyway.
+ *
+ * Timestamps are bound as ISO text and cast, mirroring what Drizzle's own
+ * `timestamp` (no timezone) mapper does — `value.toISOString()` on write, read
+ * back as UTC. A raw `Date` parameter would be reinterpreted in the session
+ * timezone and shift the window.
+ */
+export function buildReclassifyWhere(input: ReclassifyScopeSqlInput): SQL {
+  const { organizationId, inboxId, window, mode, eligibleTagIds, cursor } = input
+  const clauses: SQL[] = [
+    sql`t."organizationId" = ${organizationId}`,
+    sql`t."inboxId" = ${inboxId}`,
+    sql`t."mergedIntoThreadId" IS NULL`,
+    sql`t."lastMessageAt" IS NOT NULL`,
+    // ⚠️ INVARIANT 4 — NOT `IS NULL`. NULL is "not evaluated", not "human".
+    sql`fm."tier" IS DISTINCT FROM 'hard'`,
+  ]
+
+  if (window.since) clauses.push(sql`t."lastMessageAt" >= ${window.since.toISOString()}::timestamp`)
+  if (window.until) clauses.push(sql`t."lastMessageAt" < ${window.until.toISOString()}::timestamp`)
+
+  if (mode === 'fill-gaps') {
+    // Guard exit 5, in SQL. `-> key IS NULL` covers both "no metadata at all"
+    // and "metadata without the marker".
+    clauses.push(sql`fm."metadata" -> ${MAIL_CLASSIFICATION_METADATA_KEY} IS NULL`)
+    // Guard exit 6, in SQL — scoped to ELIGIBLE tags only, exactly as the guard
+    // scopes it. A thread carrying `VIP` or `P1` has not been categorised.
+    if (eligibleTagIds.length > 0) {
+      clauses.push(sql`NOT EXISTS (
+        SELECT 1 FROM "FieldValue" fv
+        JOIN "CustomField" cf ON cf."id" = fv."fieldId"
+        WHERE fv."entityId" = t."id"
+          AND cf."organizationId" = ${organizationId}
+          AND cf."systemAttribute" = 'thread_tags'
+          AND fv."relatedEntityId" IN (${sql.join(
+            eligibleTagIds.map((id) => sql`${id}`),
+            sql`, `
+          )})
+      )`)
+    }
+  }
+
+  if (cursor) {
+    // Keyset, not OFFSET. The run MUTATES the columns the fill-gaps predicate
+    // reads (it writes the marker and the tag), so an offset window would slide
+    // underneath itself and skip rows. A descending keyset cannot: everything
+    // already processed sits above the cursor.
+    clauses.push(sql`(t."lastMessageAt", t."id") < (${cursor.at}::timestamp, ${cursor.threadId})`)
+  }
+
+  return sql.join(clauses, sql` AND `)
+}
+
+/**
+ * ⚠️ Newest first, ALWAYS (invariant 8). If a run is cancelled or dies halfway
+ * the user got the part that mattered, and it makes the preview honest: "the 500
+ * most recent" is a thing a user can picture.
+ */
+const RECLASSIFY_ORDER = sql`ORDER BY t."lastMessageAt" DESC, t."id" DESC`
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Preconditions + count (§2.5, invariant 6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Opted-in inbox ids for this org, from the `orgSettings` cache.
+ *
+ * Same read as `guard.ts`'s private `getOptedInInboxIds`, kept in step with it
+ * deliberately: this path re-asserts the opt-in itself rather than trusting the
+ * caller, because it is the one path that can be pointed at thousands of threads
+ * at once (invariant 6).
+ */
+async function getOptedInInboxIds(organizationId: string): Promise<string[]> {
+  const settings = await getOrgCache().get(organizationId, 'orgSettings')
+  const raw = settings?.[MAIL_CLASSIFICATION_INBOX_IDS_SETTING]
+  if (!Array.isArray(raw)) return []
+  return raw.filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+/** Everything a run needs resolved before it may touch a model. */
+interface ReclassifyPreconditions {
+  labels: MailClassificationLabel[]
+  window: ResolvedReclassifyWindow
+}
+
+/**
+ * C8's double guard, re-asserted for the bulk path (invariant 6).
+ *
+ * ⚠️ A re-run is a way to catch up, **not a way in**. An inbox that never opted
+ * in must not become classifiable by asking for a retroactive run, and an org
+ * with no eligible tags has nothing the model could legally answer.
+ */
+async function resolvePreconditions(
+  db: Database,
+  input: {
+    organizationId: string
+    inboxId: string
+    range: MailReclassifyRange
+    now?: Date
+    hardCap?: number
+  }
+): Promise<Result<ReclassifyPreconditions, Error>> {
+  const optedIn = await getOptedInInboxIds(input.organizationId)
+  if (!optedIn.includes(input.inboxId)) {
+    return err(
+      new BadRequestError(
+        'Turn on AI classification for this inbox before classifying its history.'
+      )
+    )
+  }
+
+  const labels = await getEligibleClassificationTags(db, input.organizationId)
+  if (labels.length === 0) {
+    return err(new BadRequestError('No categories are marked for AI classification yet.'))
+  }
+
+  const resolved = resolveReclassifyWindow(input.range, {
+    now: input.now,
+    hardCap: input.hardCap,
+  })
+  if (resolved.isErr()) return err(resolved.error)
+
+  return ok({ labels, window: resolved.value })
+}
+
+export interface MailReclassifyCount {
+  /** Threads in scope, clamped to {@link MailReclassifyCount.cap}. */
+  count: number
+  /** True when MORE threads matched than `cap` — render `count+`, never a bare number. */
+  capped: boolean
+  cap: number
+  mode: MailReclassifyMode
+  /** Eligible labels the run would classify into — the "N categories" in the copy. */
+  eligibleTagCount: number
+}
+
+/**
+ * How many threads a run over this scope would classify.
+ *
+ * ⚠️ The same predicate the job pages over ({@link buildReclassifyWhere}), so the
+ * preview cannot drift from what actually runs (§2.5, invariant 10).
+ *
+ * Bounded by `LIMIT cap + 1` inside a subquery, so a large mailbox is bounded
+ * work; the `+ 1` distinguishes "exactly the cap" from "more than the cap"
+ * without a second query. Past the cap the caller renders `5,000+` — R-Q5
+ * explicitly declines an exact total, so a confirm reading "5,000 of 5,000+" is
+ * the honest wording, not "5,000 of 8,912".
+ */
+export async function countReclassifiableThreads(
+  db: Database,
+  input: {
+    organizationId: string
+    inboxId: string
+    range: MailReclassifyRange
+    mode: MailReclassifyMode
+    now?: Date
+    cap?: number
+  }
+): Promise<Result<MailReclassifyCount, Error>> {
+  const pre = await resolvePreconditions(db, input)
+  if (pre.isErr()) return err(pre.error)
+  const { labels, window } = pre.value
+
+  const cap = Math.max(1, Math.min(Math.trunc(input.cap ?? window.maxThreads), window.maxThreads))
+
+  const where = buildReclassifyWhere({
+    organizationId: input.organizationId,
+    inboxId: input.inboxId,
+    window,
+    mode: input.mode,
+    eligibleTagIds: labels.map((label) => label.tagId),
+  })
+
+  const result = await db.execute(sql`
+    SELECT count(*)::int AS count FROM (
+      SELECT 1 FROM ${reclassifySource()} WHERE ${where} LIMIT ${cap + 1}
+    ) AS bounded
+  `)
+  const raw = Number((result.rows?.[0] as { count?: number | string } | undefined)?.count ?? 0)
+  const capped = raw > cap
+
+  return ok({
+    count: capped ? cap : raw,
+    capped,
+    cap,
+    mode: input.mode,
+    eligibleTagCount: labels.length,
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Selection — one row per thread, one message each (§2.3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One thread paired with the single message that will be classified for it. */
+export interface ReclassifyThreadRow {
+  threadId: string
+  /** The thread's FIRST INBOUND message (R3). */
+  messageId: string
+  /** `machineMailTier`, handed to the guard so exit 1 is honoured verbatim. */
+  tier: 'hard' | 'soft' | null
+  subject: string | null
+  textPlain: string | null
+  /** Sender identifier — the live path gets this from the event payload. */
+  from: string | null
+  /** Opaque keyset position for the next page. */
+  cursor: ReclassifyCursor
+}
+
+/**
+ * One page of threads, newest first (invariant 8).
+ *
+ * Exported for the job and for tests; callers page by feeding the last row's
+ * `cursor` back in.
+ */
+export async function selectReclassifyThreadPage(
+  db: Database,
+  input: ReclassifyScopeSqlInput & { limit: number }
+): Promise<ReclassifyThreadRow[]> {
+  const limit = Math.max(1, Math.trunc(input.limit))
+  const where = buildReclassifyWhere(input)
+
+  const result = await db.execute(sql`
+    SELECT t."id" AS "threadId",
+           t."lastMessageAt"::text AS "cursorAt",
+           fm."messageId" AS "messageId",
+           fm."tier" AS "tier",
+           fm."subject" AS "subject",
+           fm."textPlain" AS "textPlain",
+           p."identifier" AS "from"
+    FROM ${reclassifySource()}
+    WHERE ${where}
+    ${RECLASSIFY_ORDER}
+    LIMIT ${limit}
+  `)
+
+  const rows = (result.rows ?? []) as Array<Record<string, unknown>>
+  return rows.map((row) => ({
+    threadId: String(row.threadId),
+    messageId: String(row.messageId),
+    tier: (row.tier as 'hard' | 'soft' | null) ?? null,
+    subject: (row.subject as string | null) ?? null,
+    textPlain: (row.textPlain as string | null) ?? null,
+    from: (row.from as string | null) ?? null,
+    // `::text` on the way out and `::timestamp` on the way back in: a raw
+    // `timestamp` column parsed by node-postgres becomes a Date in the LOCAL
+    // zone, and round-tripping that through the keyset would shift the window.
+    cursor: { at: String(row.cursorAt), threadId: String(row.threadId) },
+  }))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Per-thread context, with the parameterised exit-5 bypass (§2.6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ThreadContextResult =
+  | { proceed: true; context: MailClassificationContext }
+  | { proceed: false; reason: MailClassificationSkipReason }
+
+/**
+ * Run the live guard for one selected thread, then apply the mode's bypass.
+ *
+ * ⚠️ Invariant 5 — the bypass lives HERE, as a parameter of the run, and never in
+ * `guardClassification`. The guard's default stays "classify once, ever"; a
+ * `re-classify` run is the caller saying it wants to pay again, which is exactly
+ * what §2.6 says re-classification means.
+ *
+ * Only {@link BYPASSABLE_EXITS} are bypassed. `'inbox-not-opted-in'` and
+ * `'no-eligible-tags'` stay fatal in both modes (invariant 6).
+ *
+ * ⚠️ Consequence of R3 worth knowing (§2.3): the marker is stamped on the FIRST
+ * INBOUND message, not on the whole thread. Guard exit 5 is per-message, so a
+ * later live message on the same thread is still technically classifiable — exit
+ * 6 catches it via the applied tag. If a run applies NO tag (abstention), exit 6
+ * does not catch it and the next inbound message on that thread is classified
+ * normally. That is correct, not a leak, but it is surprising.
+ */
+async function resolveThreadContext(params: {
+  db: Database
+  organizationId: string
+  row: ReclassifyThreadRow
+  labels: MailClassificationLabel[]
+  inboxId: string
+  bypassAlreadyClassified: boolean
+}): Promise<ThreadContextResult> {
+  const { db, organizationId, row, labels, inboxId, bypassAlreadyClassified } = params
+
+  const gate = await guardClassification({
+    db,
+    organizationId,
+    messageId: row.messageId,
+    threadId: row.threadId,
+    machineMailTier: row.tier ?? undefined,
+    from: row.from ?? undefined,
+  })
+
+  if (gate.proceed) return { proceed: true, context: gate.context }
+  if (!bypassAlreadyClassified || !BYPASSABLE_EXITS.has(gate.reason)) {
+    return { proceed: false, reason: gate.reason }
+  }
+
+  // The bypass. Everything the guard would have resolved is already in hand —
+  // the selection query carried the message fields, and the labels were resolved
+  // once for the whole run — so this rebuilds the context rather than re-reading.
+  return {
+    proceed: true,
+    context: {
+      organizationId,
+      messageId: row.messageId,
+      threadId: row.threadId,
+      inboxId,
+      labels,
+      message: { subject: row.subject, from: row.from, textPlain: row.textPlain },
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Sample mode (§2.11, R6) — PHASE 1's whole deliverable
+// ─────────────────────────────────────────────────────────────────────────────
+
+const sleep = (ms: number) =>
+  ms > 0 ? new Promise<void>((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
+
+export interface RunMailReclassifySampleInput {
+  organizationId: string
+  inboxId: string
+  range: MailReclassifyRange
+  mode: MailReclassifyMode
+  /** Defaults to {@link MAIL_RECLASSIFY_SAMPLE_SIZE}. */
+  sampleSize?: number
+  /** Test/ops override for {@link MAIL_RECLASSIFY_THREAD_DELAY_MS}. */
+  threadDelayMs?: number
+  now?: Date
+  /** Called after each thread, for the job's progress surface. */
+  onProgress?: (processed: number, total: number) => void
+  /** Stop between threads. Safe at any point — a sample commits nothing. */
+  isCancelled?: () => boolean
+}
+
+/**
+ * Classify a sample of the chosen scope, report the distribution, **apply
+ * nothing** (§2.11).
+ *
+ * This exists because the taxonomy is a hypothesis drawn from one org in one
+ * vertical (`06-…` Q6). A sample answers "does this vocabulary fit this mail?"
+ * for a few cents, before anyone spends on thousands of threads.
+ *
+ * ⚠️ Invariant 9 — IT APPLIES NOTHING AND WRITES NO MARKER. Neither
+ * `applyClassificationTag` nor `markMessageClassified` is called here, and that
+ * is not an oversight: a marker would silently disqualify the sampled threads
+ * from the real `fill-gaps` run that follows. This is a deliberate "do not
+ * persist" path, separate from the `inferred` flag (which is about spend).
+ *
+ * ⚠️ It still costs one inference per thread and still meters credits. It is
+ * cheap only because N is small, and the UI states the cost like any other run.
+ *
+ * ⚠️ It does NOT re-run mail filters either (R2) — see the file header.
+ *
+ * The sample is the NEWEST N threads of the scope, not a random draw. Two
+ * reasons: it keeps one ordering across preview, sample and run (invariant 8),
+ * and it makes the §3.3 loop — sample → see it is wrong → fix the vocabulary →
+ * sample again — actually readable, because a changed distribution is then
+ * attributable to the edit rather than to a different draw. The cost is that a
+ * seasonal recent skew is not averaged out; the default 30-day window keeps that
+ * bounded.
+ */
+export async function runMailReclassifySample(
+  db: Database,
+  input: RunMailReclassifySampleInput
+): Promise<Result<MailReclassifySampleReport, Error>> {
+  const requested = Math.max(1, Math.trunc(input.sampleSize ?? MAIL_RECLASSIFY_SAMPLE_SIZE))
+  const threadDelayMs = Math.max(0, input.threadDelayMs ?? MAIL_RECLASSIFY_THREAD_DELAY_MS)
+
+  const pre = await resolvePreconditions(db, input)
+  if (pre.isErr()) return err(pre.error)
+  const { labels, window } = pre.value
+
+  const rows = await selectReclassifyThreadPage(db, {
+    organizationId: input.organizationId,
+    inboxId: input.inboxId,
+    window,
+    mode: input.mode,
+    eligibleTagIds: labels.map((label) => label.tagId),
+    limit: Math.min(requested, window.maxThreads),
+  })
+
+  const counts = new Map<string, { count: number; confidenceSum: number }>()
+  const skipped: Partial<Record<MailClassificationSkipReason, number>> = {}
+  const abstainedByReason: Partial<Record<MailClassificationSkipReason, number>> = {}
+  let inferred = 0
+  let classified = 0
+  let abstained = 0
+  let confidenceSum = 0
+
+  const note = (reason: MailClassificationSkipReason) => {
+    skipped[reason] = (skipped[reason] ?? 0) + 1
+  }
+
+  for (const [index, row] of rows.entries()) {
+    if (input.isCancelled?.()) break
+
+    const resolved = await resolveThreadContext({
+      db,
+      organizationId: input.organizationId,
+      row,
+      labels,
+      inboxId: input.inboxId,
+      bypassAlreadyClassified: input.mode === 're-classify',
+    }).catch((error) => {
+      logger.warn('Sample guard failed for a thread — skipping it', {
+        organizationId: input.organizationId,
+        threadId: row.threadId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return { proceed: false as const, reason: 'error' as const }
+    })
+
+    if (!resolved.proceed) {
+      note(resolved.reason)
+      input.onProgress?.(index + 1, rows.length)
+      continue
+    }
+
+    const result = await classifyMessage(db, resolved.context)
+
+    // ⚠️ NOTHING IS PERSISTED HERE. No `markMessageClassified`, no
+    // `applyClassificationTag`, no filter re-run. Invariant 9 + R2.
+    if (!result.inferred) {
+      note(result.reason ?? 'error')
+      input.onProgress?.(index + 1, rows.length)
+      continue
+    }
+
+    inferred += 1
+    confidenceSum += result.confidence
+    if (result.tagId) {
+      classified += 1
+      const bucket = counts.get(result.tagId) ?? { count: 0, confidenceSum: 0 }
+      bucket.count += 1
+      bucket.confidenceSum += result.confidence
+      counts.set(result.tagId, bucket)
+    } else {
+      abstained += 1
+      // ⚠️ NOT into `skipped`. This inference completed and was billed; lumping
+      // it in with the guard exits would hide the most informative number in the
+      // report behind the least informative one.
+      const reason = result.reason ?? 'no-category'
+      abstainedByReason[reason] = (abstainedByReason[reason] ?? 0) + 1
+    }
+
+    input.onProgress?.(index + 1, rows.length)
+    if (index < rows.length - 1) await sleep(threadDelayMs)
+  }
+
+  const report: MailReclassifySampleReport = {
+    inboxId: input.inboxId,
+    mode: input.mode,
+    requested,
+    selected: rows.length,
+    inferred,
+    classified,
+    abstained,
+    abstentionRate: inferred > 0 ? abstained / inferred : 0,
+    meanConfidence: inferred > 0 ? confidenceSum / inferred : 0,
+    // ⚠️ EVERY eligible label, including the never-chosen ones. A zero row IS the
+    // finding (§3.3 / 06 Q1) — filtering it out deletes the answer.
+    labels: labels.map((label) => {
+      const bucket = counts.get(label.tagId)
+      return {
+        tagId: label.tagId,
+        title: label.title,
+        count: bucket?.count ?? 0,
+        meanConfidence: bucket && bucket.count > 0 ? bucket.confidenceSum / bucket.count : 0,
+      }
+    }),
+    skipped,
+    abstainedByReason,
+    applied: false,
+  }
+
+  logger.info('Mail re-classification sample finished', {
+    organizationId: input.organizationId,
+    ...report,
+    labels: report.labels.map((label) => `${label.title}:${label.count}`),
+  })
+
+  return ok(report)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. The queue job (§2.2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MailReclassifySampleJobData {
+  organizationId: string
+  inboxId: string
+  range: MailReclassifyRange
+  mode: MailReclassifyMode
+  sampleSize?: number
+  threadDelayMs?: number
+  /** For the log trail only — the run still executes as SYSTEM. */
+  requestedByUserId?: string
+}
+
+/** Deterministic per (org, inbox), so a double-click collapses into one run. */
+export function mailReclassifySampleJobId(organizationId: string, inboxId: string): string {
+  return `mail-reclassify-sample:${organizationId}:${inboxId}`
+}
+
+/**
+ * Run one sample on the queue.
+ *
+ * ⚠️ NEVER THROWS, and never retries. A thrown job would be retried by BullMQ
+ * (the queue default is `attempts: 5`) and every retry re-spends the whole
+ * sample, which is the same class of bug as re-inferring a marked message. The
+ * enqueue below pins `attempts: 1` and this handler returns its failures.
+ */
+export async function mailReclassifySampleJob(
+  ctx: JobContext<MailReclassifySampleJobData>
+): Promise<MailReclassifySampleReport | { skipped: string }> {
+  const { database } = await import('@auxx/database')
+  const { organizationId, inboxId, range, mode, sampleSize, threadDelayMs } = ctx.data
+
+  const result = await runMailReclassifySample(database, {
+    organizationId,
+    inboxId,
+    range,
+    mode,
+    sampleSize,
+    threadDelayMs,
+    isCancelled: () => ctx.isCancelled?.() ?? false,
+    onProgress: (processed, total) => {
+      // Object progress so the dialog can render "340 of 1,204" (§3.1) rather
+      // than a bare percentage. Fire-and-forget: a progress write must never
+      // fail a run that has already spent money.
+      void ctx.job?.updateProgress({ processed, total })?.catch(() => {})
+    },
+  }).catch((error) => {
+    // The selection query is the only thing left that can throw, and a throw
+    // here would surface as a failed job with no report at all. Turn it into a
+    // reported skip so the dialog can say what happened.
+    logger.error('Mail re-classification sample failed', {
+      organizationId,
+      inboxId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return err(error instanceof Error ? error : new Error(String(error)))
+  })
+
+  if (result.isErr()) {
+    logger.warn('Mail re-classification sample skipped', {
+      organizationId,
+      inboxId,
+      reason: result.error.message,
+    })
+    return { skipped: result.error.message }
+  }
+  return result.value
+}
+
+/**
+ * Enqueue a sample, collapsing a double-click into one run.
+ *
+ * The `jobId` is deterministic, so an in-flight sample is returned as-is rather
+ * than duplicated. A FINISHED sample is removed first, because §3.3's loop —
+ * sample, fix the vocabulary, sample again — has to be able to re-run the same
+ * scope; otherwise BullMQ would hand back the stale report.
+ */
+export async function enqueueMailReclassifySample(
+  input: MailReclassifySampleJobData
+): Promise<Result<{ jobId: string; deduplicated: boolean }, Error>> {
+  const [{ getQueue }, { Queues }] = await Promise.all([
+    import('../jobs/queues'),
+    import('../jobs/queues/types'),
+  ])
+  const queue = getQueue(Queues.maintenanceQueue)
+  const jobId = mailReclassifySampleJobId(input.organizationId, input.inboxId)
+
+  const existing = await queue.getJob(jobId)
+  if (existing) {
+    const state = await existing.getState().catch(() => 'unknown')
+    // Anything not yet finished counts as in flight — BullMQ has more waiting
+    // states than the obvious three (`prioritized`, `waiting-children`), and
+    // treating an unrecognised one as finished would remove a job that is about
+    // to spend money.
+    if (state !== 'completed' && state !== 'failed') return ok({ jobId, deduplicated: true })
+    await existing.remove().catch(() => {})
+  }
+
+  await queue.add(MAIL_RECLASSIFY_SAMPLE_JOB_NAME, input satisfies MailReclassifySampleJobData, {
+    jobId,
+    // ⚠️ ONE attempt. Every retry would re-spend ~100 inferences for the same
+    // answer — the bulk-path equivalent of the C9 double-billing bug.
+    attempts: 1,
+    // The report IS the deliverable (§3.3), so the completed job has to survive
+    // long enough for the dialog to read it back.
+    removeOnComplete: { age: 3600 },
+    removeOnFail: { age: 3600 },
+  })
+  return ok({ jobId, deduplicated: false })
+}
+
+/** Poll one inbox's sample, for the dialog (§3.3) and the card's progress row. */
+export async function getMailReclassifySampleStatus(
+  organizationId: string,
+  inboxId: string
+): Promise<MailReclassifySampleStatus | null> {
+  const [{ getQueue }, { Queues }] = await Promise.all([
+    import('../jobs/queues'),
+    import('../jobs/queues/types'),
+  ])
+  const queue = getQueue(Queues.maintenanceQueue)
+  const jobId = mailReclassifySampleJobId(organizationId, inboxId)
+  const job = await queue.getJob(jobId)
+  if (!job) return null
+
+  const rawState = await job.getState().catch(() => 'unknown')
+  const progress = (job.progress ?? {}) as { processed?: number; total?: number }
+  const value = job.returnvalue as MailReclassifySampleReport | { skipped: string } | undefined
+
+  const KNOWN: MailReclassifySampleStatus['state'][] = [
+    'waiting',
+    'active',
+    'completed',
+    'failed',
+    'delayed',
+  ]
+  const state = KNOWN.find((known) => known === rawState) ?? 'unknown'
+
+  return {
+    jobId,
+    state,
+    processed: typeof progress.processed === 'number' ? progress.processed : 0,
+    total: typeof progress.total === 'number' ? progress.total : 0,
+    // `applied` is the discriminator: the skipped shape has no such key, so a
+    // precondition failure never renders as an all-zero distribution.
+    report: value && 'applied' in value ? value : undefined,
+  }
+}
+
+/**
+ * Cancel a queued sample.
+ *
+ * Removes it outright when it has not started. An ACTIVE job is left alone and
+ * `false` is returned: BullMQ cancellation is the worker's abort signal, which
+ * {@link runMailReclassifySample} honours between threads via `isCancelled`, and
+ * stopping is safe at any point because a sample commits nothing.
+ */
+export async function cancelMailReclassifySample(
+  organizationId: string,
+  inboxId: string
+): Promise<boolean> {
+  const [{ getQueue }, { Queues }] = await Promise.all([
+    import('../jobs/queues'),
+    import('../jobs/queues/types'),
+  ])
+  const queue = getQueue(Queues.maintenanceQueue)
+  const job = await queue.getJob(mailReclassifySampleJobId(organizationId, inboxId))
+  if (!job) return false
+  const state = await job.getState().catch(() => 'unknown')
+  if (state === 'active') return false
+  await job.remove().catch(() => {})
+  return true
+}

--- a/packages/lib/src/mail-classification/types.ts
+++ b/packages/lib/src/mail-classification/types.ts
@@ -46,4 +46,21 @@ export interface MailClassificationResult {
   /** Set when nothing is applied, so the job's log line explains itself. */
   reason?: MailClassificationSkipReason
   model?: string
+  /**
+   * Did a model call COMPLETE and return an answer?
+   *
+   * ⚠️ This is the sole gate on stamping the C9 marker, and it is a field rather
+   * than a check against {@link reason} on purpose: a new failure arm added to
+   * that union must be forced to state its answer here, instead of inheriting
+   * "stamp" by default. Inheriting the wrong default is precisely the bug this
+   * flag replaced — `'error'` was stamped like a completed inference, so a
+   * single provider 429 marked the message classified forever, having neither
+   * classified it nor cost anything.
+   *
+   * True for an applied tag, and equally for a deliberate "apply nothing"
+   * (`'below-threshold'`, `'no-category'`) — the answer was bought and re-asking
+   * would pay twice for it. False for every path where `invoke` threw, because
+   * usage is only metered against a response that actually came back.
+   */
+  inferred: boolean
 }

--- a/packages/lib/src/mail-filters/seed-suggested-filters.test.ts
+++ b/packages/lib/src/mail-filters/seed-suggested-filters.test.ts
@@ -13,6 +13,9 @@
 //     the operator: a field builder that declines it drops the clause the same way.
 //  5. **Seeded rows never consume the plan allowance** — the row always carries a
 //     `templateKey`, and `countBillableMailFilters` excludes `templateKey IS NOT NULL`.
+//  5b. **The deterministic replacement for the retired `Newsletter`/`Notification` AI
+//     labels stays deterministic** (categories plan 06 D2) — a header-keyed filter, no
+//     tag dependency, and never an ARCHIVE on the broad "any mailing list" signal.
 //  6. **The `mailFilters` org-cache key is busted after a seed that actually inserted** —
 //     and only then. The cached array is what the gate reads; leaving it stale is invisible
 //     while seeds are disabled and becomes a real bug the moment one is enabled.
@@ -60,6 +63,8 @@ vi.mock('drizzle-orm', async (importOriginal) => ({
   count: () => ({ count: true }),
 }))
 
+import type { ConditionGroup } from '../conditions/types'
+import { assertFilterConditionsCompile } from './evaluate'
 import { countBillableMailFilters } from './limits'
 import { assertFilterShape } from './mutations'
 import { SUGGESTED_MAIL_FILTER_TEMPLATES, seedSuggestedMailFilters } from './seed-suggested-filters'
@@ -87,6 +92,9 @@ const FIELD_BUILDERS: Record<string, string> = {
   // `buildFromQuery` is a one-line delegation to `buildSenderQuery`, which owns the cases.
   from: 'buildSenderQuery',
   subject: 'buildSubjectQuery',
+  // `buildListQuery` is likewise a one-line delegation — the operator cases live in the
+  // shared `buildMessageTextColumnQuery` it hands `Message.listId` to.
+  list: 'buildMessageTextColumnQuery',
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -199,6 +207,119 @@ describe('SUGGESTED_MAIL_FILTER_TEMPLATES', () => {
         }
       }
     }
+  })
+
+  // ── categories plan 06 D2 / §2.4 ──
+  // `Newsletter` and `Notification` are retired as AI labels because both are
+  // answerable from a header. What replaces them has to actually be a header rule.
+  describe('the deterministic replacement for the retired Newsletter/Notification labels', () => {
+    const listConditionsOf = (templateKey: string) =>
+      SUGGESTED_MAIL_FILTER_TEMPLATES.find((t) => t.templateKey === templateKey)
+        ?.conditions.flatMap((g) => g.conditions)
+        .filter((c) => String(c.fieldId) === 'list') ?? []
+
+    it('ships a filter keyed on the List-Id signal, not on an AI label', () => {
+      const template = SUGGESTED_MAIL_FILTER_TEMPLATES.find(
+        (t) => t.templateKey === 'suggested:mailing-list-mail'
+      )
+      expect(template).toBeDefined()
+      expect(listConditionsOf('suggested:mailing-list-mail').map((c) => c.operator)).toEqual([
+        'not empty',
+      ])
+      // No tag: the replacement must not depend on a tag name resolving at seed time,
+      // or a taxonomy rename silently skips it (§5.2 — resolution is name-based and
+      // logs-and-skips, so the failure is soft but invisible).
+      expect(template?.requiredTagName).toBeUndefined()
+    })
+
+    it('writes no thread state on the broad signal — `soft` cannot tell a blast from a receipt', () => {
+      // §1.1's warning triangle: List-Id (and the `soft` tier it feeds) covers bulk
+      // marketing AND transactional notices in one bucket. "Skip the AI" is true of
+      // both; "archive it" is not.
+      const actions = SUGGESTED_MAIL_FILTER_TEMPLATES.find(
+        (t) => t.templateKey === 'suggested:mailing-list-mail'
+      )?.buildActions('tag_test')
+      expect(actions).toEqual([{ type: 'suppress-automations' }])
+    })
+
+    it('never archives on a bare `list not empty` — that is every mailing list in the mailbox', () => {
+      for (const template of SUGGESTED_MAIL_FILTER_TEMPLATES) {
+        const archives = template
+          .buildActions('tag_test')
+          .some((a) => a.type === 'set-status' || a.type === 'add-tag')
+        if (!archives) continue
+        for (const condition of listConditionsOf(template.templateKey)) {
+          expect(
+            condition.operator,
+            `${template.templateKey} archives/tags on an unqualified mailing-list match`
+          ).not.toBe('not empty')
+        }
+      }
+    })
+
+    it('matches bulk mail on the list identity too, not only on a from-address fragment', () => {
+      // A campaign sender rotates its from-address (VERP) far more often than it
+      // renames its list, so `from contains 'newsletter@'` alone misses most blasts.
+      expect(listConditionsOf('suggested:bulk-newsletters').length).toBeGreaterThan(0)
+      for (const condition of listConditionsOf('suggested:bulk-newsletters')) {
+        expect(condition.operator).toBe('contains')
+        expect(String(condition.value)).not.toBe('')
+      }
+    })
+
+    it('keeps every condition id unique within its template', () => {
+      // The widened OR group is where a copy-pasted `c4` would collide; duplicate
+      // ids make the condition editor edit the wrong row.
+      for (const template of SUGGESTED_MAIL_FILTER_TEMPLATES) {
+        const ids = template.conditions.flatMap((g) => g.conditions.map((c) => c.id))
+        expect(new Set(ids).size, template.templateKey).toBe(ids.length)
+      }
+    })
+  })
+
+  // The source-derived checks above catch a fieldId/operator the builder has no case
+  // for. This runs the REAL save-time gate over the same catalog, which additionally
+  // catches a value the field builder declines (`in` with an empty array, say) and a
+  // builder that throws. Both fail the same way: the condition is dropped, the filter
+  // reduces to the bare org scope, and it matches every thread in the inbox
+  // (invariant 19).
+  describe('every seeded condition set survives assertFilterConditionsCompile', () => {
+    /** `Body starts with` — the exact combination invariant 19 is named after. */
+    const UNCOMPILABLE: ConditionGroup[] = [
+      {
+        id: 'g1',
+        logicalOperator: 'AND',
+        conditions: [
+          { id: 'c1', fieldId: 'body', operator: 'starts with' as never, value: 'unsubscribe' },
+        ],
+      },
+    ]
+
+    /** The same, on the `list` field the D2 templates use — a numeric op it declines. */
+    const UNCOMPILABLE_LIST: ConditionGroup[] = [
+      {
+        id: 'g1',
+        logicalOperator: 'AND',
+        conditions: [{ id: 'c1', fieldId: 'list', operator: '>' as never, value: 'x' }],
+      },
+    ]
+
+    it('rejects a known-uncompilable set — proving the assertion below is not vacuous', () => {
+      expect(() => assertFilterConditionsCompile(UNCOMPILABLE, 'org_1')).toThrow()
+      // Pinned on `list` too: the D2 templates are the only ones on that field, and a
+      // gate that reported "compiles" for everything reaching `buildListQuery` would
+      // pass them vacuously.
+      expect(() => assertFilterConditionsCompile(UNCOMPILABLE_LIST, 'org_1')).toThrow()
+    })
+
+    it('accepts every template in the catalog', () => {
+      for (const template of SUGGESTED_MAIL_FILTER_TEMPLATES) {
+        expect(
+          () => assertFilterConditionsCompile(template.conditions, 'org_1'),
+          template.templateKey
+        ).not.toThrow()
+      }
+    })
   })
 
   it("every condition's operator is one its field builder accepts", () => {

--- a/packages/lib/src/mail-filters/seed-suggested-filters.ts
+++ b/packages/lib/src/mail-filters/seed-suggested-filters.ts
@@ -28,6 +28,11 @@
 //     display name and is skipped entirely when that tag is absent, rather than writing a
 //     `tagIds` entry pointing at nothing.
 //
+// Some of the catalog exists because a DETERMINISTIC rule beat an inference:
+// `plans/mail-filter/06-mail-categories-rework-plan.md` D2 retires `Newsletter` and
+// `Notification` as AI labels precisely because both are answerable from headers this
+// file can match on for free. `suggested:mailing-list-mail` is that replacement.
+//
 // Seeded rows do NOT consume the customer's `mailFiltersLimit` allowance —
 // `countBillableMailFilters` excludes `templateKey IS NOT NULL` (§5.2). They ARE deletable,
 // unlike seeded sequences; see the note on `deleteMailFilter`.
@@ -92,6 +97,28 @@ function subjectContains(id: string, value: string) {
 }
 
 /**
+ * `list` matches on `Message.listId` — the normalized `List-Id` header derived at
+ * ingest (`ingest/filtering/bulk-mail.ts:parseListId`), lowercased and stripped to
+ * the bare identity (`ACME News <news.acme.com>` → `news.acme.com`).
+ *
+ * This is the STABLE bulk-mail identity: it survives VERP and per-campaign
+ * from-addresses, both of which defeat any `from contains` fragment. `not empty`
+ * means "some message in this thread carries a List-Id", i.e. it came from a real
+ * mailing list.
+ */
+function listNotEmpty(id: string) {
+  // `value` is required by `Condition` and ignored by `buildMessageTextColumnQuery`
+  // for `empty` / `not empty`; `''` is the convention `mail-suggestions/mine.ts`
+  // already uses for the value-less operators.
+  return { id, fieldId: 'list', operator: 'not empty' as const, value: '' }
+}
+
+/** `list` substring match on `Message.listId` via `ILIKE '%value%'`. */
+function listContains(id: string, value: string) {
+  return { id, fieldId: 'list', operator: 'contains' as const, value }
+}
+
+/**
  * The starter suggested filters. All seeded `enabled: false`, `stopProcessing: false`, on
  * the org's default shared inbox.
  *
@@ -101,6 +128,8 @@ function subjectContains(id: string, value: string) {
  * - **automated-notifications** — writes no thread state at all. `suppress-automations`
  *   only tells the gate to skip AI/automation for robot mail, which is the single safest
  *   useful thing a filter can do.
+ * - **mailing-list-mail** — the same, on the deterministic signal rather than an
+ *   address fragment. See its own note below.
  * - **bulk-newsletters** — `ARCHIVED` is mail's "done" (never `TRASH`/`SPAM`, which are
  *   destructive and provider-visible), paired with `suppress-automations` because nobody
  *   wants an agent drafting a reply to a marketing blast. Undo restores the prior status.
@@ -128,6 +157,42 @@ export const SUGGESTED_MAIL_FILTER_TEMPLATES: SuggestedMailFilterTemplate[] = [
     buildActions: () => [{ type: 'suppress-automations' }],
   },
   {
+    // ── The deterministic replacement for the retired `Notification` /
+    //    `Newsletter` AI labels (categories plan 06 D2, §2.4). ──
+    //
+    // Both were answerable from a header, and 63% of recent inbound is already
+    // flagged `machineMailTier = 'soft'` by exactly that deterministic rule
+    // (06-plan §1.1). Spending an inference to conclude "this is a notification"
+    // is the anti-pattern `05-mail-classification-plan.md` §3.1.1 was written
+    // against, so it is a filter instead: free, exact, instant.
+    //
+    // ⚠️ `machineMailTier` itself is NOT a condition `condition-query-builder.ts`
+    // dispatches — there is no `machineMailTier` case in its dispatch table, so
+    // the tier the plan names cannot be matched on today. `list` is the signal
+    // that IS in the vocabulary, and it is one of the two headers
+    // (`ingest/filtering/machine-mail.ts:158`) that produce the `soft` tier in
+    // the first place, so this filter selects a large, well-defined subset of
+    // what the plan describes. Inventing a `machineMailTier` fieldId here would
+    // be DROPPED silently and the filter would then match the whole inbox
+    // (invariant 19).
+    //
+    // Suppress only — no status, no tag. §1.1's other warning applies: `soft` (and
+    // `List-Id` with it) covers bulk marketing AND transactional notices in one
+    // bucket, so this cannot tell a newsletter from a shipping notice. "Skip the
+    // AI" is true of both; "archive it" is not, and that stays with the narrower
+    // `bulk-newsletters` below.
+    templateKey: 'suggested:mailing-list-mail',
+    name: 'Skip AI on mailing-list mail',
+    conditions: [
+      {
+        id: 'g1',
+        logicalOperator: 'AND',
+        conditions: [listNotEmpty('c1')],
+      },
+    ],
+    buildActions: () => [{ type: 'suppress-automations' }],
+  },
+  {
     templateKey: 'suggested:bulk-newsletters',
     name: 'Archive newsletters',
     conditions: [
@@ -139,6 +204,16 @@ export const SUGGESTED_MAIL_FILTER_TEMPLATES: SuggestedMailFilterTemplate[] = [
           fromContains('c2', 'newsletters@'),
           fromContains('c3', 'marketing@'),
           fromContains('c4', 'mailer@'),
+          // The same intent on the stable list identity (06-plan D2). A campaign
+          // sender rotates its from-address (VERP, `bounce-1234@…`) far more often
+          // than it renames its list, so these arms catch blasts the four
+          // address fragments above miss entirely. Substring, not `not empty`:
+          // this arm ARCHIVES, and "every mailing list" would sweep in
+          // transactional list mail the tier cannot distinguish (§1.1).
+          listContains('c5', 'news'),
+          listContains('c6', 'marketing'),
+          listContains('c7', 'campaign'),
+          listContains('c8', 'promo'),
         ],
       },
     ],

--- a/packages/lib/src/resources/registry/resources/tag-fields.ts
+++ b/packages/lib/src/resources/registry/resources/tag-fields.ts
@@ -115,6 +115,47 @@ export const TAG_FIELDS: Record<string, ResourceField> = {
     description: 'When true, the AI mail classifier may apply this tag to inbound mail.',
   },
 
+  /**
+   * Shipped identity of a seeded mail category
+   * (plans/mail-filter/06-mail-categories-rework-plan.md §3.1) — `category:sales`,
+   * `category:order-status`, … Null for every user-created tag.
+   *
+   * A **provenance marker, not a lock**. Unlike `is_system_tag` it freezes nothing:
+   * title, emoji, colour, parent and above all `tag_description` stay editable, which
+   * is the entire point (D4/D5) — the description IS the classifier's instruction, so a
+   * category the business cannot re-word is a category it cannot use. What the marker
+   * buys is (a) an undeletable seeded category, via `rejectDeleteIfTemplateTag`, and
+   * (b) a shipped default to reset back to.
+   *
+   * ⚠️ **Not user-writable** (invariant 2): a user who can stamp this on their own tag
+   * makes it undeletable. `creatable`/`updatable: false` is documentation only — the
+   * write path does not read capabilities — so the enforcement is
+   * `dropUnauthorizedTemplateKey` on the field pre-hook chain, exactly as
+   * `is_system_tag` is enforced today. Only the seeder writes it, through
+   * `bypassFieldGuards`.
+   */
+  tag_template_key: {
+    id: toFieldId('tag_template_key'),
+    key: 'tag_template_key',
+    label: 'Template Key',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'tag_template_key',
+    systemSortOrder: 'a15',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Shipped identity of a seeded mail category. Set by the seeder only; makes the tag undeletable and resettable to its shipped default.',
+  },
+
   emoji: {
     id: toFieldId('emoji'),
     key: 'emoji',

--- a/packages/lib/src/seed/ai-category-tags.test.ts
+++ b/packages/lib/src/seed/ai-category-tags.test.ts
@@ -1,20 +1,24 @@
 // packages/lib/src/seed/ai-category-tags.test.ts
 //
-// The starter mail categories are the vocabulary the classifier will be given, so the shape
-// of the seeded rows is the contract:
+// The starter mail categories are the vocabulary the classifier is given, so the shape of the
+// seeded rows is the contract (plans/mail-filter/06-mail-categories-rework-plan.md §2):
 //
-//  1. **Exactly five, and no `Spam`** (C6) — a Spam tag beside a spam *status* is two ways to
-//     say one thing, and it was the only category where ordering vs the agent mattered.
-//  2. **Ordinary tags** (C4) — `is_system_tag: false` explicitly. A system tag's description
-//     cannot be edited, and the description IS the classifier's instruction (C3), so seeding
+//  1. **Core is four, packs are opt-in** (06 D3) — and `Newsletter`/`Notification` are gone as
+//     labels (D2), because both are answerable from headers and `machineMailTier` and paying a
+//     model to read a header is the anti-pattern 05 §3.1.1 was written against. No `Spam`
+//     (05 C6), no catch-all (06 §2.4).
+//  2. **Ordinary tags** (05 C4) — `is_system_tag: false` explicitly. A system tag's description
+//     cannot be edited, and the description IS the classifier's instruction (05 C3), so seeding
 //     these as system tags would freeze the feature's only tuning surface.
-//  3. **Every starter carries a real description** — it is prompt text, not decoration.
+//  3. **Undeletable via `tag_template_key`, written only through the bypass** (06 invariant 2) —
+//     a user who can set that field can make any tag of their own undeletable.
 //  4. **Idempotent by title.** A second pass creates nothing. A title the org already uses is
 //     left exactly as it is — UNLESS it is a legacy tag WE seeded as a system tag, which is
-//     adopted in place (see the adoption block at the bottom). The discriminator is
-//     `is_system_tag`, never the title.
+//     adopted in place. The discriminator is `is_system_tag`, never the title (06 invariant 5).
 //  5. **Nothing becomes classifiable by accident** — the parent group is NOT eligible, and
 //     seeding writes no inbox opt-in of any kind.
+//  6. **The pre-rework descriptions survive as a constant** (06 §5.3) — data migration `076`
+//     compares against them to tell "still our default" from "the customer tuned it".
 //
 // `UnifiedCrudHandler` is stubbed (a lib-internal module, not one of the shared
 // `@auxx/database` / `@auxx/logger` / `drizzle-orm` mocks), so the assertions are about the
@@ -74,8 +78,14 @@ vi.mock('../resources/crud', () => ({
 }))
 
 import {
+  AI_CATEGORY_COMMERCE_TAGS,
+  AI_CATEGORY_CORE_TAGS,
   AI_CATEGORY_PARENT_TAG,
+  AI_CATEGORY_PARENT_TEMPLATE_KEY,
+  AI_CATEGORY_PARTNER_TAGS,
   AI_CATEGORY_STARTER_TAGS,
+  aiCategoryTagsForPacks,
+  LEGACY_STARTER_DESCRIPTIONS,
   seedAiCategoryTags,
 } from './ai-category-tags'
 
@@ -114,11 +124,16 @@ function makeDb(results: unknown[][]) {
 }
 
 const TAG_DEF = [{ id: TAG_DEF_ID }]
-const ELIGIBILITY_FIELD = [{ id: 'cf_ai_classify' }]
+/** One select covers all three guarded attributes — see the comment on `fieldIdByAttribute`. */
+const FIELDS = [
+  { id: 'cf_ai_classify', systemAttribute: 'tag_ai_classify' },
+  { id: 'cf_template_key', systemAttribute: 'tag_template_key' },
+  { id: 'cf_is_system_tag', systemAttribute: 'is_system_tag' },
+]
 
-/** The three selects the seed makes: tag def, eligibility field, existing tag instances. */
+/** The three selects the seed makes: tag def, guarded fields, existing tag instances. */
 function queue(existingTitles: { id: string; displayName: string }[] = []): unknown[][] {
-  return [TAG_DEF, ELIGIBILITY_FIELD, existingTitles]
+  return [TAG_DEF, FIELDS, existingTitles]
 }
 
 const titlesCreated = () => h.creates.map((c) => c.values.title)
@@ -131,22 +146,50 @@ beforeEach(() => {
   h.createImpl = null
 })
 
-const SYSTEM_FIELD = [{ id: 'cf_is_system_tag' }]
-/** The two selects `adoptLegacySystemStarter` makes per existing title. */
-const ADOPT_PROBE = (isSystem: boolean) => [SYSTEM_FIELD, [{ valueBoolean: isSystem }]]
+/** The single select `adoptLegacySystemStarter` makes per existing title. */
+const ADOPT_PROBE = (isSystem: boolean) => [[{ valueBoolean: isSystem }]]
 
-describe('AI_CATEGORY_STARTER_TAGS', () => {
-  it('is exactly the five pinned categories, with no Spam', () => {
-    expect(AI_CATEGORY_STARTER_TAGS.map((t) => t.title)).toEqual([
+const ALL_PACKS = ['commerce', 'partner'] as const
+
+describe('the taxonomy', () => {
+  it('is core four, commerce two, partner one — and nothing else', () => {
+    expect(AI_CATEGORY_CORE_TAGS.map((t) => t.title)).toEqual([
       'Sales',
       'Support',
       'Billing',
-      'Newsletter',
-      'Notification',
+      'Account',
     ])
+    expect(AI_CATEGORY_COMMERCE_TAGS.map((t) => t.title)).toEqual([
+      'Order Status',
+      'Returns & Refunds',
+    ])
+    expect(AI_CATEGORY_PARTNER_TAGS.map((t) => t.title)).toEqual(['Partners & Dealers'])
   })
 
-  // The model reads these verbatim as the label's definition (C3). A bare title classifies
+  // D2: both are answerable from `machineMailTier` and `List-Unsubscribe` for free. They ship
+  // as seeded FILTERS now; an inference to conclude "this is a notification" is the exact
+  // anti-pattern 05 §3.1.1 rejects.
+  it('has retired Newsletter and Notification as labels', () => {
+    const titles = AI_CATEGORY_STARTER_TAGS.map((t) => t.title)
+    expect(titles).not.toContain('Newsletter')
+    expect(titles).not.toContain('Notification')
+  })
+
+  // 05 C6 + 06 §2.4: `set-status: SPAM` and `MAIL_CLASSIFY_NO_CATEGORY` already exist, and a
+  // catch-all label would be reached for INSTEAD of abstaining.
+  it('has no Spam and no catch-all', () => {
+    const titles = AI_CATEGORY_STARTER_TAGS.map((t) => t.title)
+    for (const banned of ['Spam', 'Other', 'General', 'Uncategorized']) {
+      expect(titles).not.toContain(banned)
+    }
+  })
+
+  // 06 Q10: the revisit trigger is ~10 ELIGIBLE leaves, and one further pack reaches it.
+  it('stays under the ~10-leaf revisit trigger', () => {
+    expect(AI_CATEGORY_STARTER_TAGS).toHaveLength(7)
+  })
+
+  // The model reads these verbatim as the label's definition (05 C3). A bare title classifies
   // measurably worse, so an empty one is a silent quality regression.
   it('gives every category a real classifier instruction', () => {
     for (const tag of [AI_CATEGORY_PARENT_TAG, ...AI_CATEGORY_STARTER_TAGS]) {
@@ -155,37 +198,174 @@ describe('AI_CATEGORY_STARTER_TAGS', () => {
       expect(tag.color).toBeTruthy()
     }
   })
+
+  // ⚠️ Returns & Refunds overlaps Billing by design, so the precedence has to live IN the two
+  // descriptions — one label per message means the model has nowhere else to read it from.
+  it('spells out the Returns-vs-Billing precedence in the descriptions themselves', () => {
+    const returns = AI_CATEGORY_COMMERCE_TAGS.find((t) => t.title === 'Returns & Refunds')
+    const billing = AI_CATEGORY_CORE_TAGS.find((t) => t.title === 'Billing')
+    expect(returns?.description).toMatch(/completed purchase/i)
+    expect(billing?.description).toMatch(/money owed or paid/i)
+  })
+
+  // The template key is the identity "reset to default" and the undeletable guard resolve on.
+  // A duplicate would make two categories indistinguishable to both.
+  it('gives every category a unique, stable template key', () => {
+    const keys = AI_CATEGORY_STARTER_TAGS.map((t) => t.templateKey)
+    expect(new Set(keys).size).toBe(keys.length)
+    for (const key of keys) expect(key).toMatch(/^category:[a-z0-9-]+$/)
+    expect(keys).toEqual([
+      'category:sales',
+      'category:support',
+      'category:billing',
+      'category:account',
+      'category:order-status',
+      'category:returns-refunds',
+      'category:partners-dealers',
+    ])
+  })
+
+  // The container carries a key too (so it cannot be deleted out from under its children), but
+  // it is deliberately not one of the category keys — anything enumerating shipped CATEGORIES
+  // excludes it by identity rather than by title.
+  it('keeps the container’s key out of the category keyspace', () => {
+    expect(AI_CATEGORY_PARENT_TAG.templateKey).toBe(AI_CATEGORY_PARENT_TEMPLATE_KEY)
+    expect(AI_CATEGORY_STARTER_TAGS.map((t) => t.templateKey)).not.toContain(
+      AI_CATEGORY_PARENT_TEMPLATE_KEY
+    )
+  })
 })
 
-describe('seedAiCategoryTags', () => {
-  it('creates the parent group and all five starters on a fresh org', async () => {
-    const { db } = makeDb(queue())
+// ═══════════════════════════════════════════════════════════════════════════
+// LEGACY DESCRIPTIONS — the input to migration 076's never-clobber rule (§5.3)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// ⚠️ These literals are duplicated here ON PURPOSE. The constant is the only
+// record of what the five pre-rework starters shipped with, and migration 076
+// overwrites a description ONLY when it is empty or byte-identical to one of
+// them. Reformat, re-wrap or "tidy" a string in the source and the migration
+// silently starts classifying an untouched default as a customer edit (leaving
+// stale prompt text forever) — or, if someone loosens the comparison to
+// compensate, clobbers real customer tuning that cannot be recovered.
 
-    const result = await seedAiCategoryTags(db, ORG, 'user_1')
-
-    expect(result.created).toEqual([
-      'Mail Categories',
+describe('LEGACY_STARTER_DESCRIPTIONS', () => {
+  it('is frozen and holds exactly the five pre-rework titles', () => {
+    expect(Object.isFrozen(LEGACY_STARTER_DESCRIPTIONS)).toBe(true)
+    expect(Object.keys(LEGACY_STARTER_DESCRIPTIONS)).toEqual([
       'Sales',
       'Support',
       'Billing',
       'Newsletter',
       'Notification',
     ])
-    expect(result.skipped).toEqual([])
-    expect(titlesCreated()).toHaveLength(6)
   })
 
-  it('marks every starter eligible, ordinary, thread-scoped and parented', async () => {
+  it('preserves each shipped default byte for byte', () => {
+    expect(LEGACY_STARTER_DESCRIPTIONS.Sales).toBe(
+      'A prospective or existing customer with buying intent: pricing, quotes, plans, stock or availability, product fit, a demo, or expanding an existing order. Pre-purchase interest, not a problem with something already bought.'
+    )
+    expect(LEGACY_STARTER_DESCRIPTIONS.Support).toBe(
+      'The sender needs help with something they already have: a fault, an error, a how-to question, a delivery or order-status chase, a return or a complaint. Something is broken, missing, or not understood.'
+    )
+    expect(LEGACY_STARTER_DESCRIPTIONS.Billing).toBe(
+      'Anything about money owed or paid: invoices, charges, refunds, payment methods, subscription or plan fees, failed payments, dunning, receipts and tax documents.'
+    )
+    expect(LEGACY_STARTER_DESCRIPTIONS.Newsletter).toBe(
+      'Bulk marketing or editorial mail broadcast to a list — product news, promotions, offers, digests, event invitations. Written for many recipients rather than for us, and needs no reply.'
+    )
+    expect(LEGACY_STARTER_DESCRIPTIONS.Notification).toBe(
+      'Automated machine mail generated by a system rather than written by a person: service alerts, account and security notices, monitoring or build results, calendar and shipping updates, confirmations of an automated action. If it is about money owed or paid, prefer Billing; if it is bulk marketing, prefer Newsletter.'
+    )
+  })
+
+  // If a new description equalled the legacy one there would be nothing to migrate for that
+  // label — and the assertion above would be the only thing left proving the constant is real.
+  it('differs from the shipped text for every surviving title', () => {
+    for (const title of ['Sales', 'Support', 'Billing']) {
+      const current = AI_CATEGORY_CORE_TAGS.find((t) => t.title === title)
+      expect(current).toBeDefined()
+      expect(current?.description).not.toBe(LEGACY_STARTER_DESCRIPTIONS[title])
+    }
+  })
+})
+
+describe('aiCategoryTagsForPacks', () => {
+  // 06 Q3: pack selection is the CALLER's to infer (Shopify → commerce). Assuming it here would
+  // push two extra labels into every org's prompt — 06 invariant 12.
+  it('is core-only by default', () => {
+    expect(aiCategoryTagsForPacks().map((t) => t.title)).toEqual([
+      'Sales',
+      'Support',
+      'Billing',
+      'Account',
+    ])
+  })
+
+  it('adds only the packs asked for', () => {
+    expect(aiCategoryTagsForPacks(['commerce']).map((t) => t.title)).toEqual([
+      'Sales',
+      'Support',
+      'Billing',
+      'Account',
+      'Order Status',
+      'Returns & Refunds',
+    ])
+    expect(aiCategoryTagsForPacks(['partner']).map((t) => t.title)).toContain('Partners & Dealers')
+    expect(aiCategoryTagsForPacks(['partner']).map((t) => t.title)).not.toContain('Order Status')
+  })
+
+  it('is unaffected by duplicates or a redundant core request', () => {
+    expect(aiCategoryTagsForPacks(['commerce', 'commerce', 'core'])).toEqual(
+      aiCategoryTagsForPacks(['commerce'])
+    )
+  })
+
+  it('returns the whole taxonomy when every pack is on', () => {
+    expect(aiCategoryTagsForPacks(ALL_PACKS)).toEqual(AI_CATEGORY_STARTER_TAGS)
+  })
+})
+
+describe('seedAiCategoryTags', () => {
+  it('creates the parent group and the four core categories on a fresh org', async () => {
     const { db } = makeDb(queue())
 
-    await seedAiCategoryTags(db, ORG, 'user_1')
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.created).toEqual(['Mail Categories', 'Sales', 'Support', 'Billing', 'Account'])
+    expect(result.skipped).toEqual([])
+    expect(titlesCreated()).toHaveLength(5)
+  })
+
+  it('seeds the pack categories when the caller opts in', async () => {
+    const { db } = makeDb(queue())
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1', { packs: ALL_PACKS })
+
+    expect(result.created).toEqual([
+      'Mail Categories',
+      'Sales',
+      'Support',
+      'Billing',
+      'Account',
+      'Order Status',
+      'Returns & Refunds',
+      'Partners & Dealers',
+    ])
+  })
+
+  it('marks every category eligible, ordinary, thread-scoped, parented and template-keyed', async () => {
+    const { db } = makeDb(queue())
+
+    await seedAiCategoryTags(db, ORG, 'user_1', { packs: ALL_PACKS })
 
     const parentRecordId = `${TAG_DEF_ID}:inst_1`
     for (const tag of AI_CATEGORY_STARTER_TAGS) {
       expect(createdByTitle(tag.title)).toMatchObject({
         tag_ai_classify: true,
-        // C4: system tags cannot be edited, and the description is the tuning surface.
+        // 05 C4 / 06 D5: system tags cannot be edited, and the description is the tuning surface.
         is_system_tag: false,
+        // 06 D4: undeletable and resettable, without freezing anything.
+        tag_template_key: tag.templateKey,
         tag_scope: 'thread',
         tag_parent: parentRecordId,
         tag_description: tag.description,
@@ -202,19 +382,21 @@ describe('seedAiCategoryTags', () => {
     expect(createdByTitle('Mail Categories')).toMatchObject({
       tag_ai_classify: false,
       is_system_tag: false,
+      tag_template_key: AI_CATEGORY_PARENT_TEMPLATE_KEY,
       tag_scope: 'thread',
     })
     expect(createdByTitle('Mail Categories')).not.toHaveProperty('tag_parent')
   })
 
-  // `is_system_tag` is `creatable: false` and its pre-hook drops unauthorized writes, so the
-  // explicit `false` only lands with the bypass.
-  it('writes is_system_tag through the scoped bypass', () => {
+  // Both fields are `creatable: false` and their pre-hooks drop unauthorized writes, so these
+  // values only land with the bypass. ⚠️ A user who can write `tag_template_key` can make any
+  // tag of their own undeletable (06 invariant 2) — the bypass is the whole enforcement.
+  it('writes the guarded fields through one scoped bypass', () => {
     const { db } = makeDb(queue())
     return seedAiCategoryTags(db, ORG, 'user_1').then(() => {
       expect(h.constructorOptions).toHaveLength(1)
       const options = h.constructorOptions[0] as { bypassFieldGuards: Set<string> }
-      expect([...options.bypassFieldGuards]).toEqual(['is_system_tag'])
+      expect([...options.bypassFieldGuards].sort()).toEqual(['is_system_tag', 'tag_template_key'])
     })
   })
 
@@ -223,21 +405,29 @@ describe('seedAiCategoryTags', () => {
       { id: 'inst_parent', displayName: 'Mail Categories' },
       ...AI_CATEGORY_STARTER_TAGS.map((t, i) => ({ id: `inst_${i}`, displayName: t.title })),
     ]
-    const { db, updates } = makeDb(queue(existing))
+    const { db, updates } = makeDb([
+      ...queue(existing),
+      // Each existing starter is probed once; none of them is a system tag.
+      ...AI_CATEGORY_STARTER_TAGS.flatMap(() => ADOPT_PROBE(false)),
+    ])
 
-    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+    const result = await seedAiCategoryTags(db, ORG, 'user_1', { packs: ALL_PACKS })
 
     expect(h.creates).toEqual([])
     expect(result.created).toEqual([])
-    expect(result.skipped).toHaveLength(6)
-    // Rule 5: no re-parenting, no description overwrite, no flag flip.
+    expect(result.skipped).toHaveLength(8)
+    // Rule 6: no re-parenting, no description overwrite, no flag flip.
     expect(updates).toEqual([])
+    expect(h.updates).toEqual([])
   })
 
   // The org already calls something `Billing`. It keeps its own — untouched — and gets no
   // duplicate: two tags with one name is worse than one imperfect one.
   it('skips a title the org already uses and never modifies it', async () => {
-    const { db, updates } = makeDb(queue([{ id: 'inst_billing', displayName: 'Billing' }]))
+    const { db, updates } = makeDb([
+      ...queue([{ id: 'inst_billing', displayName: 'Billing' }]),
+      ...ADOPT_PROBE(false),
+    ])
 
     const result = await seedAiCategoryTags(db, ORG, 'user_1')
 
@@ -245,10 +435,11 @@ describe('seedAiCategoryTags', () => {
     expect(titlesCreated()).not.toContain('Billing')
     expect(titlesCreated()).toContain('Sales')
     expect(updates).toEqual([])
+    expect(h.updates).toEqual([])
   })
 
   // Re-uses the existing group rather than creating "Mail Categories" twice.
-  it('parents new starters under an existing group', async () => {
+  it('parents new categories under an existing group', async () => {
     const { db } = makeDb(queue([{ id: 'inst_parent', displayName: 'Mail Categories' }]))
 
     await seedAiCategoryTags(db, ORG, 'user_1')
@@ -260,7 +451,27 @@ describe('seedAiCategoryTags', () => {
   // Without the CustomField the flag would be dropped, the tags would look seeded, and every
   // later pass would skip them — an org with zero eligible labels and no error anywhere.
   it('seeds nothing when the tag_ai_classify field is missing', async () => {
-    const { db } = makeDb([TAG_DEF, [], []])
+    const { db } = makeDb([
+      TAG_DEF,
+      FIELDS.filter((f) => f.systemAttribute !== 'tag_ai_classify'),
+      [],
+    ])
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(h.creates).toEqual([])
+    expect(result).toEqual({ created: [], skipped: [], adopted: [] })
+  })
+
+  // Same failure shape for the newer field (entity migration 075): categories written without a
+  // template key would be deletable, unresettable, and invisible to migration 076 — while
+  // looking seeded, so no later pass would ever fix them.
+  it('seeds nothing when the tag_template_key field is missing', async () => {
+    const { db } = makeDb([
+      TAG_DEF,
+      FIELDS.filter((f) => f.systemAttribute !== 'tag_template_key'),
+      [],
+    ])
 
     const result = await seedAiCategoryTags(db, ORG, 'user_1')
 
@@ -292,16 +503,20 @@ describe('seedAiCategoryTags', () => {
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
-// ADOPTION — converting a legacy SYSTEM starter into a tunable one (§12.5.1)
+// ADOPTION — converting a legacy SYSTEM starter into a tunable one
 // ═══════════════════════════════════════════════════════════════════════════
 //
 // `seedTags` historically created Billing/Sales/Support as SYSTEM tags, which
-// `rejectIfSystemTag` freezes — description included. Under C3 that description
-// IS the classifier's instruction, so an org created before mail classification
-// would carry three starters it could never tune, with no UI able to fix it.
+// `rejectIfSystemTag` freezes — description included. Under 05 C3 that
+// description IS the classifier's instruction, so an org created before mail
+// classification would carry starters it could never tune, with no UI able to
+// fix it.
 //
 // The discriminator is the FLAG, never the title: a user's own tag called
-// `Sales` is theirs, and a title collision is not consent.
+// `Sales` is theirs, and a title collision is not consent (06 invariant 5).
+//
+// Adoption never renames. `Orders` → `Order Status` and `Account Management` →
+// `Account` are data migration 076's job (06 §5.1 step 3).
 
 describe('seedAiCategoryTags — adopting legacy system starters', () => {
   const legacySales = [{ id: 'inst_sales', displayName: 'Sales' }]
@@ -313,18 +528,19 @@ describe('seedAiCategoryTags — adopting legacy system starters', () => {
 
     expect(result.adopted).toEqual(['Sales'])
     expect(result.skipped).not.toContain('Sales')
-    // Not recreated — the id is preserved, so every filter referencing it still resolves.
+    // Not recreated — the id is preserved, so every filter referencing it still resolves
+    // (06 invariant 3).
     expect(titlesCreated()).not.toContain('Sales')
   })
 
-  it('unfreezes BEFORE writing the description, and only unfreezing gets the bypass', async () => {
+  it('unfreezes BEFORE writing the description, in its own write', async () => {
     const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(true)])
 
     await seedAiCategoryTags(db, ORG, 'user_1')
 
-    // Ordering is load-bearing: `rejectIfSystemTag` reads the CURRENT flag at hook
-    // time, so clearing it first is what lets the description through with no
-    // bypass. Both fields in one call would trip the guard on the description.
+    // Ordering is load-bearing (06 invariant 4): `rejectIfSystemTag` reads the
+    // CURRENT flag at hook time, so clearing it first is what lets the
+    // description through. Both fields in one call would trip the guard.
     expect(h.updates).toHaveLength(2)
     const [unfreeze, retune] = h.updates as [(typeof h.updates)[number], (typeof h.updates)[number]]
     expect(unfreeze.values).toEqual({ is_system_tag: false })
@@ -332,16 +548,26 @@ describe('seedAiCategoryTags — adopting legacy system starters', () => {
 
     expect(retune.values).toMatchObject({ tag_ai_classify: true, tag_scope: 'thread' })
     expect(retune.values.tag_description).toBe(
-      AI_CATEGORY_STARTER_TAGS.find((t) => t.title === 'Sales')?.description
+      AI_CATEGORY_CORE_TAGS.find((t) => t.title === 'Sales')?.description
     )
     // Options ride in the FOURTH arg; third is the array-mode map and must stay empty.
     for (const call of [unfreeze, retune]) {
       expect(call.modes).toBeUndefined()
       expect(call.options).toEqual({ skipEvents: true })
     }
-    // The privilege is scoped to the one write that needs it — a bypass on the
-    // retune would be a second hole for no reason.
-    expect(retune.bypass).toEqual([])
+  })
+
+  // The retune needs a bypass only because `tag_template_key` is `updatable: false`. Re-granting
+  // `is_system_tag` there would reopen the exact hole the two-write split closes — the
+  // description would then pass the guard without the flag ever having been cleared.
+  it('scopes the retune bypass to tag_template_key alone', async () => {
+    const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(true)])
+
+    await seedAiCategoryTags(db, ORG, 'user_1')
+
+    const retune = h.updates[1]
+    expect(retune?.bypass).toEqual(['tag_template_key'])
+    expect(retune?.values.tag_template_key).toBe('category:sales')
   })
 
   it('sets tag_ai_classify, which is what stops migration 014 re-freezing it', async () => {
@@ -368,17 +594,27 @@ describe('seedAiCategoryTags — adopting legacy system starters', () => {
     expect(h.updates).toEqual([])
   })
 
-  it('still creates the starters the org does not have', async () => {
+  // No `is_system_tag` field at all (an org predating it) means nothing can be proven ours, and
+  // "unprovable" must read as the user's — never as consent.
+  it('leaves everything alone when the is_system_tag field does not exist', async () => {
+    const { db } = makeDb([
+      TAG_DEF,
+      FIELDS.filter((f) => f.systemAttribute !== 'is_system_tag'),
+      legacySales,
+    ])
+
+    const result = await seedAiCategoryTags(db, ORG, 'user_1')
+
+    expect(result.skipped).toContain('Sales')
+    expect(result.adopted).toEqual([])
+    expect(h.updates).toEqual([])
+  })
+
+  it('still creates the categories the org does not have', async () => {
     const { db } = makeDb([...queue(legacySales), ...ADOPT_PROBE(true)])
 
     const result = await seedAiCategoryTags(db, ORG, 'user_1')
 
-    expect(result.created).toEqual([
-      'Mail Categories',
-      'Support',
-      'Billing',
-      'Newsletter',
-      'Notification',
-    ])
+    expect(result.created).toEqual(['Mail Categories', 'Support', 'Billing', 'Account'])
   })
 })

--- a/packages/lib/src/seed/ai-category-tags.ts
+++ b/packages/lib/src/seed/ai-category-tags.ts
@@ -1,35 +1,45 @@
 // packages/lib/src/seed/ai-category-tags.ts
 //
-// The five starter mail categories (plans/mail-filter/05-mail-classification-plan.md §2.4)
-// and the one function that seeds them — called from `OrganizationSeeder.seedTags` for new
-// orgs and from `scripts/backfill-ai-category-tags.ts` for existing ones, so both paths seed
-// exactly the same rows.
+// The starter mail categories (plans/mail-filter/06-mail-categories-rework-plan.md §2) and the
+// one function that seeds them — called from `OrganizationSeeder.seedTags` for new orgs and
+// from `scripts/backfill-ai-category-tags.ts` for existing ones, so both paths seed exactly
+// the same rows.
 //
-// FIVE RULES THIS FILE EXISTS TO KEEP:
+// SIX RULES THIS FILE EXISTS TO KEEP:
 //
-//  1. **Ordinary tags, never system tags** (C4). `tag-system-guard.ts` rejects every edit to
-//     a system tag's title/description/emoji/color/parent AND rejects its delete. Under C3
-//     the `tag_description` IS the classifier's instruction for that label — the tuning
-//     surface — so seeding these as system tags would freeze the one field the whole feature
-//     depends on. `is_system_tag: false`, deliberately and explicitly.
-//  2. **Descriptions are prompt text, not blurbs.** The model reads them verbatim as the
-//     label's definition. They are written as instructions ("anything about invoices,
-//     charges, refunds…"), with the precedence hints that keep the overlapping pairs
-//     (Notification vs Billing, Notification vs Newsletter) decidable.
-//  3. **No `Spam` category** (C6). `set-status: SPAM` already exists and hard machine mail is
-//     skipped upstream; a Spam tag beside a spam status is two ways to say one thing.
-//  4. **Seeding never enables classification.** These rows only make a label *available*.
+//  1. **Ordinary tags, never system tags** (05 C4, 06 D5). `tag-system-guard.ts` rejects every
+//     edit to a system tag's title/description/emoji/color/parent AND rejects its delete.
+//     Under 05 C3 the `tag_description` IS the classifier's instruction for that label — the
+//     tuning surface — so seeding these as system tags would freeze the one field the whole
+//     feature depends on. `is_system_tag: false`, deliberately and explicitly.
+//  2. **Undeletable via `tag_template_key`, not via `is_system_tag`** (06 D4). The template key
+//     is a PROVENANCE MARKER, not a lock: title, emoji, colour, parent and above all the
+//     description stay editable, while the delete hook refuses to remove a shipped category and
+//     the UI can offer "reset to default". ⚠️ It is written ONLY through a `bypassFieldGuards`
+//     set, exactly as `is_system_tag` is — a user who can set it can make any tag undeletable
+//     (06 invariant 2).
+//  3. **Descriptions are prompt text, not blurbs.** The model reads them verbatim as the
+//     label's definition, so they are copied byte-for-byte from plan 06 §2.1–2.3 and carry the
+//     precedence hints that keep the overlapping pairs decidable (Returns & Refunds vs Billing).
+//  4. **No `Spam` category** (05 C6) and **no catch-all `Other`** (06 §2.4). `set-status: SPAM`
+//     already exists, and `MAIL_CLASSIFY_NO_CATEGORY` already represents abstention — a
+//     catch-all label would be reached for *instead of* abstaining.
+//  5. **Seeding never enables classification.** These rows only make a label *available*.
 //     Nothing is classified until an inbox is opted in, which is a separate switch.
-//  5. **Never touch a USER'S tag.** A title the org already uses is skipped whole — no
+//  6. **Never touch a USER'S tag.** A title the org already uses is skipped whole — no
 //     re-parenting, no description overwrite, no flag flip. A user's taxonomy is theirs, and
 //     re-running the seed must be a no-op.
 //
-//     ONE EXCEPTION, added 2026-08-10: a pre-existing `Billing`/`Sales`/`Support` carrying
-//     `is_system_tag = true` is one WE seeded, and it is frozen by `rejectIfSystemTag` — so
-//     the org could never tune the classifier instruction that rule 1 exists to protect.
-//     `adoptLegacySystemStarter` converts those in place. The discriminator is the flag, not
-//     the title: a user-created tag of the same name is left entirely alone, because a title
-//     collision is not consent.
+//     ONE EXCEPTION: a pre-existing starter carrying `is_system_tag = true` is one WE seeded,
+//     and it is frozen by `rejectIfSystemTag` — so the org could never tune the classifier
+//     instruction that rule 1 exists to protect. `adoptLegacySystemStarter` converts those in
+//     place. The discriminator is the FLAG, not the title: a user-created tag of the same name
+//     is left entirely alone, because a title collision is not consent (06 invariant 5).
+//
+// WHAT THIS FILE DOES NOT DO: it never RENAMES anything. Adopting the legacy system tags
+// `Orders` → `Order Status` and `Account Management` → `Account` is data migration `076`
+// (06 §5.1 step 3), which owns the one-time reshape of an existing org's taxonomy. The seeder
+// only matches on the titles it ships.
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
@@ -42,27 +52,79 @@ const logger = createScopedLogger('ai-category-tags')
 /** The `EntityDefinition.entityType` tags live on. */
 const TAG_DEF = 'tag'
 
-/** Thread-scoped only (Q3): article tags exist for KB content, not for mail. */
+/** Thread-scoped only (05 Q3): article tags exist for KB content, not for mail. */
 const THREAD_SCOPE = 'thread'
+
+/**
+ * Which set a seeded category belongs to (06 D3).
+ *
+ * `core` is seeded for every org. The vertical packs are opt-in, because the eligible label
+ * list IS the prompt (05 C2) and every extra label costs accuracy for orgs that never see that
+ * intent — see 06 invariant 12.
+ */
+export type AiCategoryPack = 'core' | 'commerce' | 'partner'
 
 /** One starter category, before it is written. */
 export interface AiCategoryTagSeed {
   title: string
   /**
-   * The classifier's instruction for this label — read verbatim into the prompt (C3).
+   * The classifier's instruction for this label — read verbatim into the prompt (05 C3).
    * Never empty: a bare title classifies measurably worse.
    */
   description: string
   emoji: string
   color: string
+  /**
+   * The shipped identity of this category, written to `tag_template_key` (06 §3.1). It is what
+   * lets "reset to default" find the right default and what makes the row undeletable. Stable
+   * forever — a rename changes the title, never this.
+   */
+  templateKey: string
+  /** `core` for every org; anything else is opt-in (06 D3). */
+  pack: AiCategoryPack
 }
 
 /**
- * The group the five starters hang under, so they read as one set in the picker instead of
+ * The descriptions the FIVE pre-rework starters shipped with, keyed by their title.
+ *
+ * ⚠️ **Do not delete, do not "tidy", do not reformat.** Data migration `076` overwrites a
+ * seeded category's description with the new §2.1 text **only when the current value is empty
+ * or byte-identical to one of these** (06 §5.3, invariant 6). Anything else is the customer's
+ * own tuning of the classifier — the single field this whole plan exists to make theirs — and
+ * losing it is unrecoverable. Without these strings the migration cannot tell "still our
+ * shipped default" from "they edited it", and its only remaining options are clobber-everything
+ * or skip-everything.
+ *
+ * `Newsletter` and `Notification` are here even though they are no longer categories (06 D2):
+ * the migration still has to recognise an unedited one to retire it cleanly.
+ */
+export const LEGACY_STARTER_DESCRIPTIONS: Readonly<Record<string, string>> = Object.freeze({
+  Sales:
+    'A prospective or existing customer with buying intent: pricing, quotes, plans, stock or availability, product fit, a demo, or expanding an existing order. Pre-purchase interest, not a problem with something already bought.',
+  Support:
+    'The sender needs help with something they already have: a fault, an error, a how-to question, a delivery or order-status chase, a return or a complaint. Something is broken, missing, or not understood.',
+  Billing:
+    'Anything about money owed or paid: invoices, charges, refunds, payment methods, subscription or plan fees, failed payments, dunning, receipts and tax documents.',
+  Newsletter:
+    'Bulk marketing or editorial mail broadcast to a list — product news, promotions, offers, digests, event invitations. Written for many recipients rather than for us, and needs no reply.',
+  Notification:
+    'Automated machine mail generated by a system rather than written by a person: service alerts, account and security notices, monitoring or build results, calendar and shipping updates, confirmations of an automated action. If it is about money owed or paid, prefer Billing; if it is bulk marketing, prefer Newsletter.',
+})
+
+/** The template key stamped on the container group (see `AI_CATEGORY_PARENT_TAG`). */
+export const AI_CATEGORY_PARENT_TEMPLATE_KEY = 'category:mail-categories'
+
+/**
+ * The group the starters hang under, so they read as one set in the picker instead of
  * scattering through the org's taxonomy.
  *
- * An ordinary tag itself, and NOT eligible: "Mail Categories" is a container, and an
- * eligible container would be offered to the model as a label it could apply.
+ * An ordinary tag itself, and NOT eligible: "Mail Categories" is a container, and an eligible
+ * container would be offered to the model as a label it could apply (06 invariant 17 — the
+ * eligible set stays FLAT, and a parent is decoration to `buildTagQuery` anyway).
+ *
+ * It carries a template key so the container cannot be deleted out from under its children. Its
+ * key is deliberately distinct from every category key, so anything enumerating shipped
+ * *categories* can exclude it by identity rather than by title.
  */
 export const AI_CATEGORY_PARENT_TAG: AiCategoryTagSeed = {
   title: 'Mail Categories',
@@ -70,51 +132,130 @@ export const AI_CATEGORY_PARENT_TAG: AiCategoryTagSeed = {
     'Grouping for the categories the AI classifier may apply to inbound mail. Not applied to mail itself.',
   emoji: '📬',
   color: 'blue',
+  templateKey: AI_CATEGORY_PARENT_TEMPLATE_KEY,
+  pack: 'core',
 }
 
 /**
- * The five starters. Exactly these — see rule 3 on the absent `Spam`.
+ * The core four — every org, every prompt (06 §2.1).
+ *
+ * Four, because Freshdesk ships four types and Salesforce's Case Reason is about six; nobody
+ * mature ships thirteen. Each routes to a different team, which is the test a label has to pass.
  *
  * Each description is prompt text. Editing one retunes the classifier for that org, which is
  * the point: these are starting definitions, not fixed ones.
  */
-export const AI_CATEGORY_STARTER_TAGS: AiCategoryTagSeed[] = [
+export const AI_CATEGORY_CORE_TAGS: AiCategoryTagSeed[] = [
   {
     title: 'Sales',
     description:
-      'A prospective or existing customer with buying intent: pricing, quotes, plans, stock or availability, product fit, a demo, or expanding an existing order. Pre-purchase interest — not a problem with something already bought.',
+      'A prospective or existing customer with buying intent: pricing, quotes, availability, product fit, a demo, or expanding an order. Pre-purchase interest, not a problem with something already bought.',
     emoji: '💼',
     color: 'pink',
+    templateKey: 'category:sales',
+    pack: 'core',
   },
   {
     title: 'Support',
     description:
-      'The sender needs help with something they already have: a fault, an error, a how-to question, a delivery or order-status chase, a return or a complaint. Something is broken, missing, or not understood.',
+      'The sender needs help with something they already have: a fault, an error, a how-to question, a return, or a complaint. Something is broken, missing, or not understood.',
     emoji: '🆘',
     color: 'red',
+    templateKey: 'category:support',
+    pack: 'core',
   },
   {
     title: 'Billing',
     description:
-      'Anything about money owed or paid: invoices, charges, refunds, payment methods, subscription or plan fees, failed payments, dunning, receipts and tax documents.',
+      'Anything about money owed or paid: invoices, charges, refunds, payment methods, subscription fees, failed payments, dunning, receipts and tax documents.',
     emoji: '💳',
     color: 'green',
+    templateKey: 'category:billing',
+    pack: 'core',
   },
   {
-    title: 'Newsletter',
+    title: 'Account',
     description:
-      'Bulk marketing or editorial mail broadcast to a list — product news, promotions, offers, digests, event invitations. Written for many recipients rather than for us, and needs no reply.',
-    emoji: '📰',
-    color: 'amber',
-  },
-  {
-    title: 'Notification',
-    description:
-      'Automated machine mail generated by a system rather than written by a person: service alerts, account and security notices, monitoring or build results, calendar and shipping updates, confirmations of an automated action. If it is about money owed or paid, prefer Billing; if it is bulk marketing, prefer Newsletter.',
-    emoji: '🔔',
-    color: 'teal',
+      'Access and administration rather than money: sign-in and password problems, user or seat changes, permissions, plan or subscription changes, data export, closing an account.',
+    emoji: '👤',
+    color: 'purple',
+    templateKey: 'category:account',
+    pack: 'core',
   },
 ]
+
+/**
+ * Commerce pack — opt-in (06 §2.2). Justified by the corpus: order-related mail is the single
+ * largest human category and WISMO ("where is my order") is the #1 intent in every commerce
+ * helpdesk.
+ *
+ * ⚠️ `Returns & Refunds` overlaps `Billing` and `Support` BY DESIGN, and with one label per
+ * message the model has to be told the precedence — the two descriptions carry it: money *for a
+ * purchase being reversed* is Returns, money *owed or invoiced* is Billing. If measurement shows
+ * the model splitting these inconsistently, MERGE the labels rather than adding tie-break prose;
+ * tie-breakers in a prompt are the smell that killed the old `Notification` label.
+ */
+export const AI_CATEGORY_COMMERCE_TAGS: AiCategoryTagSeed[] = [
+  {
+    title: 'Order Status',
+    description:
+      'Asking where an existing order is, when it ships or arrives, or for tracking. The order exists and the sender wants its state, not a fault and not a change request.',
+    emoji: '📦',
+    color: 'amber',
+    templateKey: 'category:order-status',
+    pack: 'commerce',
+  },
+  {
+    title: 'Returns & Refunds',
+    description:
+      'Wanting to send something back, cancel an order, or get money back for a completed purchase: returns, exchanges, cancellations, damaged or wrong items.',
+    emoji: '↩️',
+    color: 'orange',
+    templateKey: 'category:returns-refunds',
+    pack: 'commerce',
+  },
+]
+
+/**
+ * Partner pack — opt-in (06 §2.3). A dealer/installer/reseller enquiry is neither Sales (not an
+ * end customer) nor Support (nothing is broken), and nothing in the previous vocabulary covered
+ * it despite it being high-volume in the sample corpus.
+ */
+export const AI_CATEGORY_PARTNER_TAGS: AiCategoryTagSeed[] = [
+  {
+    title: 'Partners & Dealers',
+    description:
+      'A business wanting to sell, install, distribute or integrate with us: dealer and reseller applications, installer enquiries, affiliate and partnership proposals. A business relationship, not an end-customer purchase.',
+    emoji: '🤝',
+    color: 'teal',
+    templateKey: 'category:partners-dealers',
+    pack: 'partner',
+  },
+]
+
+/**
+ * Every shipped category, flat, in prompt order (06 invariant 17: the eligible set is FLAT — no
+ * subcategories in v1). Core first so the four an org always has read as the primary vocabulary.
+ *
+ * ⚠️ **Seven eligible leaves in total.** 06 Q10 sets the revisit trigger at ~10, so one further
+ * pack reaches it — at that point price two-stage classification against apply-ancestors instead
+ * of adding an eighth label by reflex.
+ */
+export const AI_CATEGORY_STARTER_TAGS: AiCategoryTagSeed[] = [
+  ...AI_CATEGORY_CORE_TAGS,
+  ...AI_CATEGORY_COMMERCE_TAGS,
+  ...AI_CATEGORY_PARTNER_TAGS,
+]
+
+/**
+ * The categories to seed for a given pack selection: always core, plus whatever was asked for.
+ *
+ * @param packs - opt-in packs beyond core. Unknown or duplicated entries are harmless.
+ */
+export function aiCategoryTagsForPacks(packs: readonly AiCategoryPack[] = []): AiCategoryTagSeed[] {
+  const wanted = new Set<AiCategoryPack>(['core', ...packs])
+  return AI_CATEGORY_STARTER_TAGS.filter((tag) => wanted.has(tag.pack))
+}
 
 /** What one seed pass did, for the caller's log line. */
 export interface AiCategoryTagSeedResult {
@@ -122,8 +263,18 @@ export interface AiCategoryTagSeedResult {
   created: string[]
   /** Titles the org already had that were left untouched (user-owned, or already adopted). */
   skipped: string[]
-  /** Titles that existed as LEGACY SYSTEM tags and were converted in place (§12.5.1). */
+  /** Titles that existed as LEGACY SYSTEM tags and were converted in place. */
   adopted: string[]
+}
+
+/** Options for one seed pass. */
+export interface SeedAiCategoryTagsOptions {
+  /**
+   * Opt-in packs beyond core (06 D3). Empty by default — 06 Q3's recommendation is that pack
+   * selection is inferred by the CALLER (e.g. commerce where the org has a Shopify
+   * integration), never assumed here.
+   */
+  packs?: readonly AiCategoryPack[]
 }
 
 /**
@@ -131,27 +282,32 @@ export interface AiCategoryTagSeedResult {
  *
  * ## Why this exists
  *
- * `seedTags` historically created `Billing`, `Sales` and `Support` as SYSTEM tags. System
- * tags are frozen by `rejectIfSystemTag` — `tag_description` included — and that description
- * IS the classifier's instruction for the label (plan C3). So without this, an org created
- * before mail classification would carry three starters that can be flagged eligible but can
- * NEVER be tuned, and would classify as bare titles with no UI anywhere able to fix it.
+ * `seedTags` historically created `Billing`, `Sales` and `Support` as SYSTEM tags. System tags
+ * are frozen by `rejectIfSystemTag` — `tag_description` included — and that description IS the
+ * classifier's instruction for the label (05 C3). So without this, an org created before mail
+ * classification would carry starters that can be flagged eligible but can NEVER be tuned, and
+ * would classify as bare titles with no UI anywhere able to fix it.
  *
  * ## What it will and will not touch
  *
  * **Only tags carrying `is_system_tag = true`** — i.e. ones we seeded. A user's own tag that
  * happens to be called `Sales` is theirs: its description is left alone and it is not made
- * eligible. Title collision is not consent.
+ * eligible. Title collision is not consent (06 invariant 5).
  *
  * ## Ordering is load-bearing
  *
- * The flag is cleared in its own write, BEFORE the description write. `rejectIfSystemTag`
- * reads the tag's CURRENT `is_system_tag` at hook time, so once the flag is false the
- * description write passes the guard normally — no bypass, no second privilege hole. Doing
- * both in one call would trip the guard on the description.
+ * The flag is cleared in its own write, BEFORE the description write (06 invariant 4).
+ * `rejectIfSystemTag` reads the tag's CURRENT `is_system_tag` at hook time, so once the flag is
+ * false the description write passes the guard normally. Doing both in one call would trip the
+ * guard on the description.
+ *
+ * ⚠️ The second write carries a bypass for `tag_template_key` ONLY — that field is
+ * `creatable: false` / `updatable: false` by design (06 invariant 2), so it cannot land without
+ * one. `is_system_tag` is deliberately NOT in that set: re-granting it there would reopen the
+ * hole the two-write split exists to close.
  *
  * ⚠️ Setting `tag_ai_classify = true` is also what stops entity migration `014` re-freezing
- * these three by title on its next run (`014-backfill-system-tags.ts` → `excludeAiClassifyTags`).
+ * these by title on its next run (`014-backfill-system-tags.ts` → `excludeAiClassifyTags`).
  * That migration is REPLAYED, not ledger-guarded, so adoption without the flag would silently
  * undo itself.
  */
@@ -164,23 +320,13 @@ async function adoptLegacySystemStarter(
     instanceId: string
     seed: AiCategoryTagSeed
     parentRecordId: RecordId
+    /** `CustomField.id` of `is_system_tag`, or undefined when the org has no such field. */
+    systemFieldId: string | undefined
   }
 ): Promise<'adopted' | 'left-alone'> {
-  const { organizationId, userId, tagDefId, instanceId, seed, parentRecordId } = args
+  const { organizationId, userId, tagDefId, instanceId, seed, parentRecordId, systemFieldId } = args
 
-  const [systemField] = await db
-    .select({ id: schema.CustomField.id })
-    .from(schema.CustomField)
-    .where(
-      and(
-        eq(schema.CustomField.organizationId, organizationId),
-        eq(schema.CustomField.entityDefinitionId, tagDefId),
-        eq(schema.CustomField.systemAttribute, 'is_system_tag')
-      )
-    )
-    .limit(1)
-
-  if (!systemField) return 'left-alone'
+  if (!systemFieldId) return 'left-alone'
 
   const [flagRow] = await db
     .select({ valueBoolean: schema.FieldValue.valueBoolean })
@@ -188,7 +334,7 @@ async function adoptLegacySystemStarter(
     .where(
       and(
         eq(schema.FieldValue.organizationId, organizationId),
-        eq(schema.FieldValue.fieldId, systemField.id),
+        eq(schema.FieldValue.fieldId, systemFieldId),
         eq(schema.FieldValue.entityId, instanceId)
       )
     )
@@ -210,8 +356,11 @@ async function adoptLegacySystemStarter(
   // array-field mode map.
   await unfreeze.update(recordId, { is_system_tag: false }, undefined, seedOpts)
 
-  // 2. Now an ordinary tag, so the guard lets these through with no bypass at all.
-  const handler = new UnifiedCrudHandler(organizationId, userId, db)
+  // 2. Now an ordinary tag, so `rejectIfSystemTag` lets the description through. The only
+  //    bypass here is the one `tag_template_key` structurally requires.
+  const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+    bypassFieldGuards: new Set(['tag_template_key']),
+  })
   await handler.update(
     recordId,
     {
@@ -219,6 +368,7 @@ async function adoptLegacySystemStarter(
       tag_parent: parentRecordId,
       tag_scope: THREAD_SCOPE,
       tag_ai_classify: true,
+      tag_template_key: seed.templateKey,
     },
     undefined,
     seedOpts
@@ -227,34 +377,39 @@ async function adoptLegacySystemStarter(
   logger.info('Adopted legacy system tag as an AI category starter', {
     organizationId,
     title: seed.title,
+    templateKey: seed.templateKey,
     instanceId,
   })
   return 'adopted'
 }
 
 /**
- * Seed the five starter mail categories (plus their parent group) for one organization.
+ * Seed the starter mail categories (plus their parent group) for one organization.
  *
- * Idempotent by tag title: an org that already has a tag called `Billing` keeps the one it
- * has, untouched, and no duplicate is written. A second pass creates nothing.
+ * Idempotent by tag title: an org that already has a tag called `Billing` keeps the one it has,
+ * untouched, and no duplicate is written. A second pass creates nothing.
  *
  * **Never throws.** Org seeding must not fail because a starter tag did not land, and the
  * backfill must not abort a 500-org run on one bad org — every failure logs and returns.
  *
- * Requires the `tag_ai_classify` CustomField (entity migration `074-tag-ai-classify`). When
- * it is missing this is a logged no-op rather than a partial seed: creating the five tags
- * without their eligibility flag would make them look seeded, so the next pass would skip
- * them forever and the org would silently have zero eligible labels.
+ * Requires two CustomFields: `tag_ai_classify` (entity migration `074-tag-ai-classify`) and
+ * `tag_template_key` (entity migration `075-tag-template-key`). When either is missing this is
+ * a logged no-op rather than a partial seed: creating the categories without their eligibility
+ * flag or their template key would make them LOOK seeded, so the next pass would skip them
+ * forever — leaving an org with zero eligible labels, or with deletable categories nothing can
+ * reset.
  *
  * @param db - drizzle instance
  * @param organizationId - the org to seed
- * @param userId - the acting user (the seeding user, or the org's system user on the
- *   backfill path) — `UnifiedCrudHandler` stamps it as the creator
+ * @param userId - the acting user (the seeding user, or the org's system user on the backfill
+ *   path) — `UnifiedCrudHandler` stamps it as the creator
+ * @param options - `packs` opts into the vertical packs; core is always seeded
  */
 export async function seedAiCategoryTags(
   db: Database,
   organizationId: string,
-  userId: string
+  userId: string,
+  options: SeedAiCategoryTagsOptions = {}
 ): Promise<AiCategoryTagSeedResult> {
   // Declared outside the try so a mid-run failure still reports what did land — the
   // difference between "nothing happened" and "three of six exist" decides whether a
@@ -264,6 +419,8 @@ export async function seedAiCategoryTags(
   const adopted: string[] = []
 
   try {
+    const seeds = aiCategoryTagsForPacks(options.packs)
+
     const [tagDef] = await db
       .select({ id: schema.EntityDefinition.id })
       .from(schema.EntityDefinition)
@@ -282,27 +439,50 @@ export async function seedAiCategoryTags(
       return { created, skipped, adopted }
     }
 
-    const [eligibilityField] = await db
-      .select({ id: schema.CustomField.id })
+    // One select for all three attributes this module writes through a guard: the two it
+    // REQUIRES, plus `is_system_tag` so the adoption probe below costs one query instead of two.
+    const fieldRows = await db
+      .select({
+        id: schema.CustomField.id,
+        systemAttribute: schema.CustomField.systemAttribute,
+      })
       .from(schema.CustomField)
       .where(
         and(
           eq(schema.CustomField.organizationId, organizationId),
           eq(schema.CustomField.entityDefinitionId, tagDef.id),
-          eq(schema.CustomField.systemAttribute, 'tag_ai_classify')
+          inArray(schema.CustomField.systemAttribute, [
+            'tag_ai_classify',
+            'tag_template_key',
+            'is_system_tag',
+          ])
         )
       )
-      .limit(1)
 
-    if (!eligibilityField) {
+    const fieldIdByAttribute = new Map<string, string>()
+    for (const row of fieldRows) {
+      if (row.systemAttribute && !fieldIdByAttribute.has(row.systemAttribute)) {
+        fieldIdByAttribute.set(row.systemAttribute, row.id)
+      }
+    }
+
+    if (!fieldIdByAttribute.has('tag_ai_classify')) {
       logger.warn(
-        'Skipping AI category tag seed — tag_ai_classify field missing (run entity migration 074 first)',
+        'Skipping AI category tag seed: tag_ai_classify field missing (run entity migration 074 first)',
         { organizationId }
       )
       return { created, skipped, adopted }
     }
 
-    const titles = [AI_CATEGORY_PARENT_TAG.title, ...AI_CATEGORY_STARTER_TAGS.map((t) => t.title)]
+    if (!fieldIdByAttribute.has('tag_template_key')) {
+      logger.warn(
+        'Skipping AI category tag seed: tag_template_key field missing (run entity migration 075 first)',
+        { organizationId }
+      )
+      return { created, skipped, adopted }
+    }
+
+    const titles = [AI_CATEGORY_PARENT_TAG.title, ...seeds.map((t) => t.title)]
     const existingRows = await db
       .select({
         id: schema.EntityInstance.id,
@@ -325,13 +505,13 @@ export async function seedAiCategoryTags(
       }
     }
 
-    // `is_system_tag` is `creatable: false` in the registry and its pre-hook drops any
-    // unauthorized write, so the explicit `false` below needs the same bypass the legacy tag
-    // seed uses. Scoped to this handler: it documents the privilege boundary, and writing the
-    // flag explicitly (rather than leaning on the default) is what makes "these are ORDINARY
-    // tags" a fact in the data rather than an omission.
+    // `is_system_tag` and `tag_template_key` are both `creatable: false` in the registry and
+    // their writes are dropped for unauthorized callers, so the explicit values below only land
+    // with the bypass. Scoped to this handler: it documents the privilege boundary, and writing
+    // `is_system_tag: false` explicitly (rather than leaning on the default) is what makes
+    // "these are ORDINARY tags" a fact in the data rather than an omission.
     const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
-      bypassFieldGuards: new Set(['is_system_tag']),
+      bypassFieldGuards: new Set(['is_system_tag', 'tag_template_key']),
     })
     // No active users to notify during a seed, and each invalidation costs seconds on Lambda
     // when Redis is slow.
@@ -354,6 +534,7 @@ export async function seedAiCategoryTags(
           tag_scope: THREAD_SCOPE,
           // The container is not a label the classifier may apply.
           tag_ai_classify: false,
+          tag_template_key: AI_CATEGORY_PARENT_TAG.templateKey,
           is_system_tag: false,
         },
         seedOpts
@@ -364,7 +545,7 @@ export async function seedAiCategoryTags(
 
     // Sequential, like the legacy tag seed: parallel creates racing the same parent's
     // inverse (`tag_children`) sync collide on sortKey.
-    for (const tag of AI_CATEGORY_STARTER_TAGS) {
+    for (const tag of seeds) {
       const existingId = existingByTitle.get(tag.title)
       if (existingId) {
         const outcome = await adoptLegacySystemStarter(db, {
@@ -374,6 +555,7 @@ export async function seedAiCategoryTags(
           instanceId: existingId,
           seed: tag,
           parentRecordId,
+          systemFieldId: fieldIdByAttribute.get('is_system_tag'),
         })
         if (outcome === 'adopted') adopted.push(tag.title)
         else skipped.push(tag.title)
@@ -390,6 +572,7 @@ export async function seedAiCategoryTags(
           tag_parent: parentRecordId,
           tag_scope: THREAD_SCOPE,
           tag_ai_classify: true,
+          tag_template_key: tag.templateKey,
           is_system_tag: false,
         },
         seedOpts

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -62,6 +62,7 @@ import { migration057RemoveSignatureVisibilityField } from './migrations/057-rem
 import { migration059PersonalInboxDef } from './migrations/059-personal-inbox-def'
 import { migration062RemoveInboxLensPersonalFields } from './migrations/062-remove-inbox-lens-personal-fields'
 import { migration074TagAiClassify } from './migrations/074-tag-ai-classify'
+import { migration075TagTemplateKey } from './migrations/075-tag-template-key'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -167,6 +168,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // 063–073 are pure data migrations (`data-migrations/migrations/`) — the NNN id
   // space is shared across both directories, so the gap is expected.
   migration074TagAiClassify,
+  migration075TagTemplateKey,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/075-tag-template-key.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/075-tag-template-key.test.ts
@@ -1,0 +1,214 @@
+// packages/lib/src/seed/entity-migrations/migrations/075-tag-template-key.test.ts
+//
+// Covers the whole `tag_template_key` data model
+// (plans/mail-filter/06-mail-categories-rework-plan.md §3.1 + §3.2), because the field and
+// its two guards are one unit: the marker only means anything because the delete guard
+// reads it, and it is only safe because nothing but the seeder can write it.
+//
+//  1. **075 creates the `tag_template_key` CustomField** on the org's tag def — without
+//     that row the seeder's first write is an FK violation, not a clean error.
+//  2. **075 is idempotent** — a second pass inserts nothing and reports `alreadyUpToDate`,
+//     which is also what suppresses the runner's per-org cache recompute.
+//  3. **075 stamps no tag.** Deciding WHICH tags become seeded categories is the taxonomy
+//     data migration's job (§5) and has rules this migration cannot express; a key written
+//     here would make tags undeletable before anything chose them.
+//  4. **The delete guard blocks a template tag** and nothing else (§3.2).
+//  5. **Nothing but the seeder can write the key** — invariant 2. `capabilities.updatable:
+//     false` is not read by the write path, so the drop hook is the actual enforcement.
+//
+// The global `@auxx/database` mock (`src/test/setup.ts`) stays in place — the migration
+// takes its `db` as an argument, so the fake below is passed in rather than mocked over.
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { ForbiddenError } from '../../../errors'
+import {
+  dropUnauthorizedTemplateKey,
+  rejectDeleteIfTemplateTag,
+} from '../../../field-hooks/pre/tag-template-guard'
+import type { EntityPreDeleteEvent, FieldPreHookEvent } from '../../../field-hooks/types'
+import { TAG_FIELDS } from '../../../resources/registry/resources/tag-fields'
+import { migration075TagTemplateKey } from './075-tag-template-key'
+
+const ORG = 'org_1'
+const TAG_DEF_ID = 'def_tag'
+
+interface Insert {
+  table: unknown
+  values: Record<string, unknown>
+}
+
+interface FakeDb {
+  db: Database
+  inserts: Insert[]
+  updates: unknown[]
+}
+
+/**
+ * A chainable stand-in that resolves the next queued result set per `await`.
+ *
+ * `loadExistingState` awaits two selects (EntityDefinitions, then CustomFields — in that
+ * order, since `Promise.all` subscribes in array order).
+ */
+function makeDb(results: unknown[][]): FakeDb {
+  const queue = [...results]
+  const inserts: Insert[] = []
+  const updates: unknown[] = []
+
+  const chain = (): Record<string, unknown> =>
+    new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'then') {
+            return (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+              Promise.resolve(queue.shift() ?? []).then(resolve, reject)
+          }
+          return () => chain()
+        },
+      }
+    )
+
+  const db = {
+    select: () => chain(),
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => {
+        inserts.push({ table, values })
+        return { returning: async () => [{ id: 'cf_new', options: values.options ?? {} }] }
+      },
+    }),
+    update: (table: unknown) => {
+      updates.push(table)
+      return { set: () => ({ where: async () => undefined }) }
+    },
+  }
+
+  return { db: db as unknown as Database, inserts, updates }
+}
+
+const tagDefRow = { id: TAG_DEF_ID, entityType: 'tag' }
+
+/** An already-migrated org: the CustomField row 075 would create is already there. */
+const existingTemplateKeyField = {
+  id: 'cf_existing',
+  systemAttribute: 'tag_template_key',
+  entityDefinitionId: TAG_DEF_ID,
+  options: {},
+}
+
+describe('migration 075 — tag_template_key', () => {
+  it('creates the tag_template_key CustomField on the org tag definition', async () => {
+    const { db, inserts } = makeDb([[tagDefRow], []])
+
+    const result = await migration075TagTemplateKey.up(db, ORG)
+
+    expect(result.fieldsCreated).toBe(1)
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]?.values).toMatchObject({
+      organizationId: ORG,
+      entityDefinitionId: TAG_DEF_ID,
+      modelType: 'tag',
+      systemAttribute: 'tag_template_key',
+      type: 'TEXT',
+      isCustom: false,
+    })
+  })
+
+  // Re-running is the normal case: the ledger records the migration, but the per-org runner
+  // and the admin "run all" button both replay it.
+  it('is idempotent — a second pass inserts nothing and reports alreadyUpToDate', async () => {
+    const { db, inserts, updates } = makeDb([[tagDefRow], [existingTemplateKeyField]])
+
+    const result = await migration075TagTemplateKey.up(db, ORG)
+
+    expect(result.fieldsCreated).toBe(0)
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(inserts).toEqual([])
+    expect(updates).toEqual([])
+  })
+
+  // No value backfill: which tags become seeded categories is decided by the taxonomy data
+  // migration (§5), and a key written here would make them undeletable before that choice.
+  it('never writes a FieldValue or touches an EntityInstance', async () => {
+    const { db, inserts, updates } = makeDb([[tagDefRow], []])
+
+    await migration075TagTemplateKey.up(db, ORG)
+
+    const { schema } = await import('@auxx/database')
+    const insertedTables = inserts.map((i) => i.table)
+    expect(insertedTables).toContain(schema.CustomField)
+    expect(insertedTables).not.toContain(schema.FieldValue)
+    expect(insertedTables).not.toContain(schema.EntityInstance)
+    expect(updates).toEqual([])
+  })
+
+  it('no-ops for an organization with no tag entity', async () => {
+    const { db, inserts } = makeDb([[], []])
+
+    const result = await migration075TagTemplateKey.up(db, ORG)
+
+    expect(result).toMatchObject({ fieldsCreated: 0, alreadyUpToDate: true })
+    expect(inserts).toEqual([])
+  })
+})
+
+describe('tag_template_key registry field', () => {
+  // Invariant 2 in its declarative half. The behavioural half is the drop hook below —
+  // these flags are documentation, since the field-value write path never reads them.
+  it('is not creatable or updatable by a caller', () => {
+    const field = TAG_FIELDS.tag_template_key
+    expect(field?.systemAttribute).toBe('tag_template_key')
+    expect(field?.capabilities?.creatable).toBe(false)
+    expect(field?.capabilities?.updatable).toBe(false)
+  })
+
+  // D4/D5 — the marker must freeze nothing. If any of these ever flips to false the
+  // classifier loses the one thing this plan exists to give it: a per-business definition.
+  it('leaves the editable tag fields editable', () => {
+    for (const key of ['title', 'description', 'emoji', 'color', 'tag_parent'] as const) {
+      expect(TAG_FIELDS[key]?.capabilities?.updatable).toBe(true)
+    }
+  })
+})
+
+function deleteEvent(values: Record<string, unknown>): EntityPreDeleteEvent {
+  return {
+    recordId: 'tag:inst_1' as EntityPreDeleteEvent['recordId'],
+    entityDefinitionId: TAG_DEF_ID,
+    entityType: 'tag',
+    entitySlug: 'tags',
+    values,
+    organizationId: ORG,
+    userId: 'user_1',
+    bypass: new Set(),
+  }
+}
+
+describe('rejectDeleteIfTemplateTag', () => {
+  it('rejects a delete of a seeded category', async () => {
+    await expect(
+      rejectDeleteIfTemplateTag(deleteEvent({ tag_template_key: 'category:sales' }))
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+
+  it('allows a delete of an ordinary tag', async () => {
+    await expect(rejectDeleteIfTemplateTag(deleteEvent({}))).resolves.toBeUndefined()
+    await expect(
+      rejectDeleteIfTemplateTag(deleteEvent({ tag_template_key: null }))
+    ).resolves.toBeUndefined()
+    // An empty string is not a template identity — it must not make a tag permanent.
+    await expect(
+      rejectDeleteIfTemplateTag(deleteEvent({ tag_template_key: '' }))
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('dropUnauthorizedTemplateKey', () => {
+  // Invariant 2: a user who can stamp this key makes their own tag undeletable. The hook
+  // returns `undefined`, which is the framework's "drop this write" signal.
+  it('drops the write instead of persisting a user-supplied key', async () => {
+    const event = { newValue: 'category:sales' } as unknown as FieldPreHookEvent
+    await expect(dropUnauthorizedTemplateKey(event)).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/075-tag-template-key.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/075-tag-template-key.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/seed/entity-migrations/migrations/075-tag-template-key.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { TAG_FIELDS } from '../../../resources/registry/resources/tag-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:075')
+
+/**
+ * Migration 075: add the `tag_template_key` TEXT field to the `tag` entity
+ * (plans/mail-filter/06-mail-categories-rework-plan.md §3.1).
+ *
+ * The field holds the shipped identity of a seeded mail category
+ * (`category:sales`, `category:order-status`, …) and is null on every
+ * user-created tag. It is a **provenance marker, not a lock**: unlike
+ * `is_system_tag` it freezes no field, so a business can re-word a category's
+ * `tag_description` — which is the classifier's instruction (D4/D5).
+ *
+ * A new registry system field is NOT a Drizzle migration — nothing can write a
+ * `FieldValue` for it until a `CustomField` row exists on the org's `tag`
+ * EntityDefinition, and the first write without one is an FK violation rather
+ * than a clean error. New orgs get the field from the entity seeder, which reads
+ * `TAG_FIELDS` directly; this catches up every existing org. Same shape as 074.
+ *
+ * **No value backfill, on purpose.** Stamping `tag_template_key` onto existing
+ * tags is the taxonomy data migration's job (§5), and it has rules this
+ * migration cannot express — adopt by `is_system_tag` flag and never by title
+ * (invariant 5), and never clobber an edited description (invariant 6). Writing
+ * a key here would also make the marked tags undeletable before anything has
+ * decided which tags deserve that.
+ *
+ * ⚠️ **Id `075`, and the taxonomy data migration is `076`.** The `NNN-` id space
+ * is shared across `data-migrations/` and `seed/entity-migrations/`, so the two
+ * must not both claim `075` (§3.1).
+ *
+ * The **resources cache clear** is the runner's, not ours: both
+ * `runEntityMigrationsForOrg` and `runEntityMigrationForAllOrgs` invalidate
+ * `entityDefs`/`entityDefSlugs`/`customFields`/`resources` for any org where
+ * `fieldsCreated > 0`, which is exactly what this migration reports. Do not
+ * duplicate it here.
+ *
+ * Idempotent: `ensureCustomFields` skips the insert when a row with this
+ * `systemAttribute` already exists on the org's tag def, and this migration
+ * touches no tag instance and no `FieldValue` at all.
+ */
+export const migration075TagTemplateKey: EntityMigration = {
+  id: '075-tag-template-key',
+  description: 'Add tag.tag_template_key TEXT field (seeded mail-category provenance marker)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const tagDef = existing.entityDefs.get('tag')
+    if (!tagDef) {
+      // No tag entity — pre-seed or manually pruned. Nothing to migrate.
+      logger.warn('No tag entity found, skipping tag-template-key migration', { organizationId })
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    const field = TAG_FIELDS.tag_template_key
+    if (!field) {
+      throw new Error('TAG_FIELDS.tag_template_key is missing from the registry')
+    }
+
+    const fields: Record<string, ResourceField> = { tag_template_key: field }
+    const fieldMap = await ensureCustomFields(
+      db,
+      organizationId,
+      'tag',
+      tagDef.id,
+      fields,
+      existing,
+      state
+    )
+
+    if (!fieldMap.get(`tag:${field.id}`)) {
+      throw new Error('Failed to resolve tag_template_key CustomField after ensureCustomFields')
+    }
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+    if (!alreadyUpToDate) {
+      logger.info('Migration 075 applied', { organizationId, customFieldCreated: true })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -90,6 +90,7 @@ export const SYSTEM_ATTRIBUTES = [
   'tag_is_public',
   'tag_scope',
   'tag_ai_classify',
+  'tag_template_key',
 
   // ─── KB fields ──────────────────────────────────────────────────
   'kb_name',

--- a/packages/ui/src/components/radio-group-item.tsx
+++ b/packages/ui/src/components/radio-group-item.tsx
@@ -38,7 +38,10 @@ function RadioGroupItemCard({
   return (
     <div
       className={cn(
-        'group flex items-center justify-between relative rounded-2xl border py-2 px-3 hover:bg-muted transition-colors  duration-200 has-data-[state=checked]:border-info has-data-[state=checked]:ring-4 has-data-[state=checked]:ring-info/20',
+        // ⚠️ `gap-3`: there was no gap at all, so a multi-line description ran
+        // straight into the radio on the right. The text block below carries
+        // `grow`, which makes that collision certain rather than occasional.
+        'group flex items-center justify-between gap-3 relative rounded-2xl border py-2 px-3 hover:bg-muted transition-colors  duration-200 has-data-[state=checked]:border-info has-data-[state=checked]:ring-4 has-data-[state=checked]:ring-info/20',
         // 'border-input hover:bg-primary-50 has-data-[state=checked]:border-primary-800/50 relative flex w-full items-start gap-2 rounded-md border p-4 shadow-xs outline-none',
         className
       )}>
@@ -51,27 +54,36 @@ function RadioGroupItemCard({
         className='order-1 after:absolute after:inset-0'
         {...props}
       />
-      <div className='flex grow items-start gap-3'>
-        <div className='flex items-center gap-3'>
-          <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors shrink-0 relative [&_svg]:size-4'>
-            {icon && icon}
+      {/* One row, not two nested ones — the old outer wrapper carried a `gap-3`
+          it could never apply (it had a single child) and an `items-start` the
+          inner `items-center` immediately overrode. */}
+      <div className='flex min-w-0 grow items-start gap-3'>
+        {icon && (
+          // ⚠️ `items-start` + `mt-0.5`, not `items-center`: centred against a
+          // two- or three-line description the icon floats in the middle of the
+          // block and reads as detached from the text it belongs to. Aligning it
+          // to the label keeps the pairing obvious at any description length.
+          <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors shrink-0 relative mt-0.5 [&_svg]:size-4'>
+            {icon}
           </div>
-          <div className='grid grow gap-0.5'>
-            <Label htmlFor={itemId} className='font-normal '>
-              {label}
-              {sublabel && (
-                <span className='text-muted-foreground text-xs leading-[inherit] font-normal'>
-                  {' '}
-                  ({sublabel})
-                </span>
-              )}
-            </Label>
-            {description && (
-              <p id={descriptionId} className='text-muted-foreground text-xs'>
-                {description}
-              </p>
+        )}
+        {/* `min-w-0` so a long description wraps inside the card instead of
+            sizing this column to its min-content and shoving the radio out. */}
+        <div className='grid min-w-0 grow gap-0.5'>
+          <Label htmlFor={itemId} className='font-normal '>
+            {label}
+            {sublabel && (
+              <span className='text-muted-foreground text-xs leading-[inherit] font-normal'>
+                {' '}
+                ({sublabel})
+              </span>
             )}
-          </div>
+          </Label>
+          {description && (
+            <p id={descriptionId} className='text-muted-foreground text-xs'>
+              {description}
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/toggle-card.tsx
+++ b/packages/ui/src/components/toggle-card.tsx
@@ -78,9 +78,13 @@ export function ToggleCard({
   return (
     <div className={cn('rounded-xl border px-3 py-2.5', className)}>
       <div
-        className={cn('flex items-center justify-between', interactive && 'cursor-pointer')}
+        className={cn('flex items-center justify-between gap-3', interactive && 'cursor-pointer')}
         onClick={interactive ? () => onCheckedChange(!checked) : undefined}>
-        <div className='space-y-0.5 leading-none'>
+        {/* ⚠️ `min-w-0` is load-bearing: without it this flex child sizes to its
+            text's min-content, so a long description (or one carrying a link)
+            pushes the switch out of the row and overflows the card on narrow
+            viewports. `flex-1` keeps it claiming the space the switch does not. */}
+        <div className='min-w-0 flex-1 space-y-0.5 leading-none'>
           <Label
             id={titleId}
             className={cn(
@@ -103,7 +107,10 @@ export function ToggleCard({
             </p>
           )}
         </div>
-        <div onClick={(e) => e.stopPropagation()}>
+        {/* ⚠️ `shrink-0`: a flex child defaults to shrinking, so a long
+            description squeezed the switch and pushed it flush against the
+            card's padding edge. The `gap-3` on the row is the other half. */}
+        <div className='shrink-0' onClick={(e) => e.stopPropagation()}>
           <Switch
             size={switchSize}
             checked={checked}


### PR DESCRIPTION
Reworks what the mail classifier classifies *into*, makes every category definition editable per business, and adds a deliberate way to classify mail that already arrived. Also fixes a failure-path bug in the shipped classifier and two shared UI primitives.

Plans: `plans/mail-filter/06-mail-categories-rework-plan.md` and `07-mail-reclassification-plan.md` (local, gitignored).

## The bug worth reading first

A provider 429, an outage or an exhausted credit balance was stamping the "already classified" marker **as if an inference had completed**. Guard exit 5 then skipped that message forever, having neither classified it nor spent anything. The job returns normally in that path, so BullMQ recorded a success and `removeOnComplete` deleted it — the configured `attempts: 5` never engaged. The only trace was one `logger.warn`.

The marker is now gated on `MailClassificationResult.inferred`, deliberately a field rather than a reason check, so any new failure arm must state its own answer instead of inheriting "stamp".

Recovering the cause needed a chain walk: `invoke` re-wraps everything into an `OrchestratorError` — including the quota gate, which runs inside its own `try` — so `instanceof QuotaExceededError` is false at the call site. Anthropic's client also turns a `rate_limit_error` into a bare `Error` with no status or code, so message matching is load-bearing rather than a fallback.

## Taxonomy

Measured across the synced corpus before designing anything. **63% of recent inbound is already flagged `machineMailTier='soft'`**, so `Newsletter` and `Notification` are retired as AI labels and become a seeded filter — paying a model to read a header is the anti-pattern rules-first exists to prevent. Order-related mail is the largest human category and had no label at all.

New vocabulary is intent-only: **Sales · Support · Billing · Account** as core, with **Order Status / Returns & Refunds** and **Partners & Dealers** as opt-in groups.

`tag_template_key` (entity migration **075**) gives a seeded category a state the model lacked: editable *including the description*, resettable to the shipped default, and undeletable. System tags cannot serve here — `rejectIfSystemTag` freezes `tag_description`, which is the classifier's instruction.

Data migration **076** retires the 13 legacy system tags. It adopts in place and **preserves ids** so existing filters keep resolving, discriminates on `is_system_tag` rather than title (a same-named user tag is left alone), and **never overwrites a description the customer has edited**, comparing against `LEGACY_STARTER_DESCRIPTIONS` which is kept frozen for exactly that purpose.

## Re-classification

A first-connect backfill publishes no `message:received` at all, and mail that arrived before an inbox was opted in exited at guard 3a. Both leave a hole the live classifier can never fill.

- **Thread is the unit**, one inference each on the first inbound message. Live classification is naturally one call per thread because exit 6 stops the second; a backlog run has no such throttle and would have spent ~9,400 inferences to tag ~7,500 threads.
- **Sample mode ships first** — ~100 threads, a distribution and an abstention rate, applying nothing and writing no marker. A marker would silently disqualify the sampled threads from the real run.
- **`fill-gaps` is the default** and can never double-bill; `re-classify` bypasses exit 5 and pays again. The bypass is a job parameter, never a guard change.
- **It does not re-run mail filters** — the deliberate exception to the live path's mandatory second pass, so a backlog run can't fire `assign`/`archive`/`run-agent` over resolved threads.

The cost estimate leans high everywhere: counts the real label list rather than assuming a size, 3 chars/token, rounds up. It quotes **zero on a BYO key**, because the quota gate only draws credits for `SYSTEM` credentials.

## UI primitives

`ToggleCard` and `RadioGroupItemCard` both laid out as a `justify-between` flex row with **no gap and no `min-w-0`** — fine with short copy, broken with real copy: the text column sized to min-content and shoved the control flush against the padding edge. Both are used in 10+ places each, so this fixes crowding well beyond this feature.

## Verification

| | |
| --- | --- |
| `packages/lib` | 554 tests pass |
| `apps/web` | 95 tests pass |
| `packages/lib` typecheck | 0 non-baseline errors |
| `apps/web` typecheck | 16, baseline unchanged |

## Before merging, please look at

- **`076` is the only destructive piece** and deserves a read, particularly §5.3's never-clobber rule.
- It **deviates from the plan's "raw Drizzle"**: reads are raw, writes go through `UnifiedCrudHandler` with `skipEvents: true`. Raw `FieldValue` writes can't maintain `EntityInstance.displayName` on a rename or the `tag_children` inverse on a re-parent, and `076` does both. I think the deviation is correct.
- **Nothing here has been run against a database**, and **nobody has seen the re-classification UI in a browser** — it is verified by component tests, which is exactly what missed the two primitive layout bugs.
- `07` phase 2 (the full apply path and undo) is **not** built; only sample mode is.

## Order to apply

1. entity migration `075-tag-template-key`
2. data migration `076-mail-category-rework`
3. opt an inbox in, then try sample mode before any full run
