### PR TITLE
fix(mail): unbreak mail classification enqueue, the reclassify sample, and the org seeder

### DIFF
--- a/apps/web/src/server/api/routers/mail-classification.ts
+++ b/apps/web/src/server/api/routers/mail-classification.ts
@@ -14,6 +14,7 @@ import {
   getMailReclassifySampleStatus,
 } from '@auxx/lib/mail-classification'
 import {
+  isSameReclassifyScope,
   MAIL_CLASSIFY_BODY_CHARS,
   MAIL_RECLASSIFY_BACKLOG_COUNT_CAP,
   MAIL_RECLASSIFY_MAX_THREADS,
@@ -514,8 +515,35 @@ export const mailClassificationRouter = createTRPCRouter({
       })
       if (queued.isErr()) throw queued.error
 
+      // ── The collapse case ───────────────────────────────────────────────
+      // The sample's BullMQ `jobId` is keyed on (org, inbox) and carries no
+      // scope, so an in-flight run swallows this request whatever it asked for.
+      // Two different situations hide behind that:
+      //
+      //  - SAME scope — a double-click, or a second tab. Collapsing is exactly
+      //    right, and there is nothing new to say. Fall through to the early
+      //    return: no second run, and no audit row, because nothing started.
+      //  - DIFFERENT scope — the caller asked for something that is NOT going to
+      //    happen. Returning ok would tell them their run began while the old one
+      //    carries on, so refuse and name what is actually running.
+      if (queued.value.deduplicated) {
+        const running = queued.value.running
+        if (running && !isSameReclassifyScope(running, input)) {
+          throw new ConflictError(
+            'A sample is already running for this inbox with a different range. Wait for it to finish or stop it first.'
+          )
+        }
+        return queued.value
+      }
+
       // "Somebody pointed a model at this mailbox's history" is exactly the kind
       // of spend that should never be untraceable — same reasoning as the opt-in.
+      //
+      // ⚠️ Reached only when a run actually STARTED. This used to be written
+      // unconditionally, which meant a collapsed click recorded a run at a scope
+      // that never executed — the one thing an audit trail must not do, and worse
+      // here than a missing row, because the metadata below is the record of what
+      // was spent.
       await recordAuditFromCtx(ctx, {
         category: 'settings',
         action: 'mail.classification.sample_started',

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -48,6 +48,7 @@ import {
   webhookRenewalScannerJob,
 } from '@auxx/lib/jobs'
 import { Queues } from '@auxx/lib/jobs/queues'
+import { mailReclassifySampleJob } from '@auxx/lib/mail-classification'
 import { mailFilterRetroactiveApplyJob, mailFilterRunRetentionJob } from '@auxx/lib/mail-filters'
 import { recordRuleRunRetentionJob } from '@auxx/lib/record-rules'
 import { signalRetentionJob, signalRollupSweepJob } from '@auxx/lib/signals'
@@ -245,6 +246,16 @@ const jobMappings = {
   // `source: 'retroactive'` — so the backfill is auditable and undoable, and its
   // claim key never collides with the live firing on the same message.
   mailFilterRetroactiveApplyJob,
+
+  // Retroactive mail-classification SAMPLE (plans/mail-filter/07-…§2.11, on-demand,
+  // enqueued from `mailClassification.startSample` and jobId-deduped per inbox).
+  // Classifies ~100 threads, reports the label distribution and abstention rate,
+  // and applies NOTHING — no tag, no marker (07 invariant 9), so the threads stay
+  // eligible for the real run that follows.
+  //
+  // ⚠️ Pinned to `attempts: 1` at the enqueue: every retry would re-spend ~100
+  // inferences for the same answer.
+  mailReclassifySampleJob,
 
   // Weekly mail-suggestion mining (plans/mail-filter/03-suggestions-plan.md §5.1):
   // per org → per inbox → ONE indexed grouped query over a 90-day window, then the

--- a/packages/lib/src/mail-classification/classify.test.ts
+++ b/packages/lib/src/mail-classification/classify.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
   invoke: vi.fn(),
-  getDefault: vi.fn(),
+  getCachedDefaultModel: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
@@ -24,12 +24,17 @@ vi.mock('../ai/orchestrator/llm-orchestrator', () => ({
     invoke = h.invoke
   },
 }))
-vi.mock('../ai/providers/system-model-service', () => ({
-  SystemModelService: class {
-    getDefault = h.getDefault
-  },
+vi.mock('../cache', () => ({ getCachedDefaultModel: h.getCachedDefaultModel }))
+// ⚠️ PARTIAL. A full replacement returning only `ModelType` worked until
+// `classify.ts` imported `../cache`, whose graph reaches `provider-registry` →
+// `anthropic-defaults`, which reads `FetchFrom` from this same module at import
+// time. The whole file then died at COLLECTION with "No FetchFrom export is
+// defined on the mock" — a failure that looks nothing like its cause. Keep the
+// real module and override only what needs overriding.
+vi.mock('../ai/providers/types', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ai/providers/types')>()),
+  ModelType: { LLM: 'LLM' },
 }))
-vi.mock('../ai/providers/types', () => ({ ModelType: { LLM: 'LLM' } }))
 vi.mock('../ai/usage/usage-tracking-service', () => ({
   UsageTrackingService: class {},
 }))
@@ -55,7 +60,7 @@ const db = {} as never
 
 beforeEach(() => {
   vi.clearAllMocks()
-  h.getDefault.mockResolvedValue({ provider: 'openai', model: 'gpt-x' })
+  h.getCachedDefaultModel.mockResolvedValue({ provider: 'openai', model: 'gpt-x' })
 })
 
 describe('the structured-output schema (invariant 12)', () => {
@@ -200,7 +205,7 @@ describe('classifyMessage — usage attribution + never throws', () => {
   })
 
   it('no default LLM is a skip, not an error — and costs no call', async () => {
-    h.getDefault.mockResolvedValue(null)
+    h.getCachedDefaultModel.mockResolvedValue(null)
 
     await expect(classifyMessage(db, context)).resolves.toEqual({
       tagId: null,
@@ -290,7 +295,7 @@ describe('classifyMessage — a failed call NEVER counts as an inference', () =>
     expect(h.warn).not.toHaveBeenCalled()
 
     vi.clearAllMocks()
-    h.getDefault.mockResolvedValue({ provider: 'openai', model: 'gpt-x' })
+    h.getCachedDefaultModel.mockResolvedValue({ provider: 'openai', model: 'gpt-x' })
     h.invoke.mockRejectedValue(new Error('429 too many requests'))
     await classifyMessage(db, context)
     expect(h.warn).toHaveBeenCalled()

--- a/packages/lib/src/mail-classification/classify.ts
+++ b/packages/lib/src/mail-classification/classify.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/mail-classification/classify.ts
 // The ONE model call (§3.2). Copied in shape from
 // `field-values/ai-autofill/generation-service.ts:107-124`:
-//   SystemModelService.getDefault(ModelType.LLM)
+//   getCachedDefaultModel(orgId, ModelType.LLM)
 //     → new LLMOrchestrator(new UsageTrackingService(db), db).invoke({ … })
 //
 // That path already enforces quota, writes `AiUsage` and meters credits from
@@ -15,9 +15,9 @@ import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { QuotaExceededError } from '../ai/errors/quota-errors'
 import { LLMOrchestrator } from '../ai/orchestrator/llm-orchestrator'
-import { SystemModelService } from '../ai/providers/system-model-service'
 import { ModelType } from '../ai/providers/types'
 import { UsageTrackingService } from '../ai/usage/usage-tracking-service'
+import { getCachedDefaultModel } from '../cache'
 import { UsageLimitError } from '../errors'
 import {
   MAIL_CLASSIFY_BODY_CHARS,
@@ -187,8 +187,14 @@ export async function classifyMessage(
 ): Promise<MailClassificationResult> {
   const { organizationId, messageId } = context
 
-  const systemModels = new SystemModelService(db, organizationId)
-  const def = await systemModels.getDefault(ModelType.LLM).catch((error) => {
+  // ⚠️ The CACHE, not `SystemModelService` directly. This runs once per inbound
+  // message and once per thread on a retroactive run, so a per-call DB roundtrip
+  // for a value that changes when somebody edits a settings dialog is the most
+  // repeated query in the whole feature. `aiDefaultModels` is hydrated per org
+  // and invalidated by `ai-default-model.changed`, which the two mutations in
+  // `aiIntegration` already fire — so the cache cannot go stale on an edit.
+  // Every other LLM consumer resolves this way; this module was the outlier.
+  const def = await getCachedDefaultModel(organizationId, ModelType.LLM).catch((error) => {
     logger.warn('Mail classification could not resolve the org default LLM', {
       organizationId,
       messageId,

--- a/packages/lib/src/mail-classification/client.test.ts
+++ b/packages/lib/src/mail-classification/client.test.ts
@@ -1,0 +1,82 @@
+// packages/lib/src/mail-classification/client.test.ts
+// `client.ts` is mostly constants and types. The one piece of logic in it is
+// `isSameReclassifyScope`, and it is load-bearing: the sample's BullMQ jobId is
+// keyed on (org, inbox) and carries no scope, so this comparison is the ONLY
+// thing standing between "your run started" and a run at a completely different
+// range quietly continuing instead.
+
+import { describe, expect, it } from 'vitest'
+import { isSameReclassifyScope, type MailReclassifyMode, type MailReclassifyRange } from './client'
+
+const scope = (range: MailReclassifyRange, mode: MailReclassifyMode = 'fill-gaps') => ({
+  range,
+  mode,
+})
+
+describe('isSameReclassifyScope', () => {
+  it('matches identical presets', () => {
+    expect(
+      isSameReclassifyScope(scope({ kind: 'days', days: 30 }), scope({ kind: 'days', days: 30 }))
+    ).toBe(true)
+    expect(isSameReclassifyScope(scope({ kind: 'all-time' }), scope({ kind: 'all-time' }))).toBe(
+      true
+    )
+  })
+
+  it('separates the two modes — this is the one that can double-bill (R4)', () => {
+    expect(
+      isSameReclassifyScope(
+        scope({ kind: 'days', days: 30 }, 'fill-gaps'),
+        scope({ kind: 'days', days: 30 }, 're-classify')
+      )
+    ).toBe(false)
+  })
+
+  it('separates two windows of the same kind', () => {
+    expect(
+      isSameReclassifyScope(scope({ kind: 'days', days: 30 }), scope({ kind: 'days', days: 90 }))
+    ).toBe(false)
+    expect(
+      isSameReclassifyScope(
+        scope({ kind: 'threads', threads: 100 }),
+        scope({ kind: 'threads', threads: 1000 })
+      )
+    ).toBe(false)
+  })
+
+  // ⚠️ 30 days and 100 threads are both "a bit of recent mail" and neither is a
+  // subset of the other — a kind change is a scope change.
+  it('separates different kinds', () => {
+    expect(
+      isSameReclassifyScope(
+        scope({ kind: 'days', days: 30 }),
+        scope({ kind: 'threads', threads: 30 })
+      )
+    ).toBe(false)
+  })
+
+  it('compares both ends of a custom range, including an absent end', () => {
+    const since = '2026-01-01T00:00:00.000Z'
+    expect(
+      isSameReclassifyScope(
+        scope({ kind: 'custom', sinceIso: since }),
+        scope({ kind: 'custom', sinceIso: since })
+      )
+    ).toBe(true)
+    expect(
+      isSameReclassifyScope(
+        scope({ kind: 'custom', sinceIso: since }),
+        scope({ kind: 'custom', sinceIso: since, untilIso: '2026-02-01T00:00:00.000Z' })
+      )
+    ).toBe(false)
+  })
+
+  // The two objects reach the comparison from different places — one from tRPC
+  // input, one out of BullMQ job data — and neither JSON path promises key order,
+  // which is why this is field-by-field rather than a stringify.
+  it('does not depend on key order', () => {
+    const a = { mode: 'fill-gaps' as const, range: { kind: 'custom', sinceIso: 'x' } as const }
+    const b = { range: { sinceIso: 'x', kind: 'custom' } as const, mode: 'fill-gaps' as const }
+    expect(isSameReclassifyScope(a, b)).toBe(true)
+  })
+})

--- a/packages/lib/src/mail-classification/client.ts
+++ b/packages/lib/src/mail-classification/client.ts
@@ -179,6 +179,42 @@ export type MailReclassifyMode = 'fill-gaps' | 're-classify'
 export const MAIL_RECLASSIFY_DEFAULT_MODE: MailReclassifyMode = 'fill-gaps'
 
 /**
+ * Do two requests describe the same run?
+ *
+ * ⚠️ Exists because the sample's BullMQ `jobId` is keyed on **(org, inbox) only**,
+ * so a second start while one is in flight collapses into the running job no
+ * matter what scope was asked for. That collapse is right for a double-click and
+ * wrong for a changed scope: the caller believes it started the run it described,
+ * and would carry on to record it. The router compares here and refuses the
+ * mismatch rather than silently running something else.
+ *
+ * Field-by-field per arm, not `JSON.stringify` — the two objects travel through
+ * tRPC input and BullMQ job data independently, and jsonb/JSON round-trips do not
+ * promise key order.
+ */
+export function isSameReclassifyScope(
+  a: { range: MailReclassifyRange; mode: MailReclassifyMode },
+  b: { range: MailReclassifyRange; mode: MailReclassifyMode }
+): boolean {
+  if (a.mode !== b.mode) return false
+  const x = a.range
+  const y = b.range
+  if (x.kind !== y.kind) return false
+  switch (x.kind) {
+    case 'days':
+      return x.days === (y as { kind: 'days'; days: number }).days
+    case 'threads':
+      return x.threads === (y as { kind: 'threads'; threads: number }).threads
+    case 'custom': {
+      const other = y as { kind: 'custom'; sinceIso: string; untilIso?: string }
+      return x.sinceIso === other.sinceIso && x.untilIso === other.untilIso
+    }
+    case 'all-time':
+      return true
+  }
+}
+
+/**
  * Hard ceiling on threads ONE run may touch (07 §2.5, R-Q4).
  *
  * ⚠️ Reaching it is reported, never a silent truncate (07 invariant 8) — a capped

--- a/packages/lib/src/mail-classification/enqueue.test.ts
+++ b/packages/lib/src/mail-classification/enqueue.test.ts
@@ -44,8 +44,22 @@ describe('enqueueMailClassification', () => {
         threadId: 'thr_1',
         from: 'a@b.com',
       },
-      { jobId: 'mail-classify:msg_1' }
+      { jobId: 'mail-classify-msg_1' }
     )
+  })
+
+  // The previous id was `mail-classify:msg_1`, and this test asserted it happily
+  // while BullMQ threw `Custom Id cannot contain :` on every single enqueue —
+  // live classification never ran once. An equality assertion cannot catch that,
+  // because it only proves we passed the string we meant to pass. This one
+  // encodes BullMQ's actual rule (`job.js`): a `:` is legal ONLY when the id
+  // splits into exactly three parts, a compat carve-out for old repeatable jobs.
+  it('builds a jobId BullMQ will accept', async () => {
+    await enqueueMailClassification(event())
+
+    const { jobId } = h.add.mock.calls[0]![2] as { jobId: string }
+    expect(jobId.includes(':') && jobId.split(':').length !== 3).toBe(false)
+    expect(`${Number.parseInt(jobId, 10)}`).not.toBe(jobId)
   })
 
   it('ignores events that are not `message:received`', async () => {

--- a/packages/lib/src/mail-classification/enqueue.ts
+++ b/packages/lib/src/mail-classification/enqueue.ts
@@ -53,7 +53,13 @@ export const enqueueMailClassification = async ({ data: event }: { data: AuxxEve
 
   try {
     await getQueue(Queues.mailClassificationQueue).add(MAIL_CLASSIFICATION_JOB_NAME, data, {
-      jobId: `mail-classify:${messageId}`,
+      // ⚠️ Hyphen, not a colon. BullMQ rejects a custom `jobId` containing `:`
+      // unless it splits into exactly THREE parts — a compat carve-out for old
+      // repeatable jobs (`bullmq/dist/cjs/classes/job.js`, "Custom Id cannot
+      // contain :"). `mail-classify:<messageId>` is two parts, so EVERY enqueue
+      // threw and the never-throw catch below swallowed it: live classification
+      // never ran once. Deterministic dedup still works, just on a legal id.
+      jobId: `mail-classify-${messageId}`,
     })
   } catch (error) {
     // Never throw: a classification that did not get queued must not fail the

--- a/packages/lib/src/mail-classification/index.ts
+++ b/packages/lib/src/mail-classification/index.ts
@@ -13,6 +13,7 @@ export {
 } from './classify'
 // Client-safe constants + types (also importable as `@auxx/lib/mail-classification/client`)
 export {
+  isSameReclassifyScope,
   MAIL_CLASSIFICATION_INBOX_IDS_SETTING,
   MAIL_CLASSIFICATION_JOB_NAME,
   MAIL_CLASSIFICATION_METADATA_KEY,
@@ -57,6 +58,7 @@ export {
   buildReclassifyWhere,
   cancelMailReclassifySample,
   countReclassifiableThreads,
+  type EnqueueMailReclassifySampleResult,
   enqueueMailReclassifySample,
   getMailReclassifySampleStatus,
   MAIL_RECLASSIFY_THREAD_DELAY_MS,

--- a/packages/lib/src/mail-classification/retroactive.test.ts
+++ b/packages/lib/src/mail-classification/retroactive.test.ts
@@ -716,6 +716,37 @@ describe('enqueueMailReclassifySample — the queue contract (§2.2)', () => {
     expect(h.jobRemove).not.toHaveBeenCalled()
   })
 
+  // ⚠️ The jobId is keyed on (org, inbox) and carries NO scope, so a collapse
+  // says nothing about whether the running job matches what was asked for. The
+  // caller has to be able to tell — without this the router would write an audit
+  // row for a run at a scope that never executed.
+  it('reports the scope of the run it collapsed into', async () => {
+    const inFlight = { ...data, range: { kind: 'all-time' } as MailReclassifyRange }
+    h.queueGetJob.mockResolvedValue({
+      getState: async () => 'active',
+      data: inFlight,
+      remove: h.jobRemove,
+    })
+
+    const result = (
+      await enqueueMailReclassifySample({ ...data, mode: 're-classify' })
+    )._unsafeUnwrap()
+
+    expect(result.running).toEqual({ range: { kind: 'all-time' }, mode: 'fill-gaps' })
+  })
+
+  // A job old enough to predate this field, or one BullMQ hands back with its
+  // payload reaped, must not fabricate a scope — `undefined` is the honest answer
+  // and the router treats it as "cannot prove a mismatch".
+  it('omits the scope when the in-flight job carries no readable data', async () => {
+    h.queueGetJob.mockResolvedValue({ getState: async () => 'waiting', remove: h.jobRemove })
+
+    const result = (await enqueueMailReclassifySample(data))._unsafeUnwrap()
+
+    expect(result.deduplicated).toBe(true)
+    expect(result.running).toBeUndefined()
+  })
+
   // §3.3's loop is sample → fix the vocabulary → sample again. A completed job
   // left in place would make BullMQ hand back the stale report.
   it('clears a COMPLETED run so the same scope can be re-sampled', async () => {

--- a/packages/lib/src/mail-classification/retroactive.ts
+++ b/packages/lib/src/mail-classification/retroactive.ts
@@ -818,6 +818,22 @@ export async function mailReclassifySampleJob(
   return result.value
 }
 
+/** What {@link enqueueMailReclassifySample} decided. */
+export interface EnqueueMailReclassifySampleResult {
+  jobId: string
+  /** True when an in-flight run was returned instead of a new one being started. */
+  deduplicated: boolean
+  /**
+   * The scope of the run already in flight — set only when `deduplicated`, and
+   * only when the job still carried readable data.
+   *
+   * ⚠️ The caller must compare this against what it asked for
+   * ({@link isSameReclassifyScope}). The `jobId` is keyed on (org, inbox), so a
+   * collapse says nothing about whether the running job matches the request.
+   */
+  running?: { range: MailReclassifyRange; mode: MailReclassifyMode }
+}
+
 /**
  * Enqueue a sample, collapsing a double-click into one run.
  *
@@ -825,10 +841,15 @@ export async function mailReclassifySampleJob(
  * than duplicated. A FINISHED sample is removed first, because §3.3's loop —
  * sample, fix the vocabulary, sample again — has to be able to re-run the same
  * scope; otherwise BullMQ would hand back the stale report.
+ *
+ * ⚠️ **A collapse is not a start.** The id is per (org, inbox) and carries no
+ * scope, so this can only report *that* it collapsed and *into what*; deciding
+ * whether that is acceptable is the caller's, because only the caller knows
+ * whether it was about to write an audit row claiming a run began.
  */
 export async function enqueueMailReclassifySample(
   input: MailReclassifySampleJobData
-): Promise<Result<{ jobId: string; deduplicated: boolean }, Error>> {
+): Promise<Result<EnqueueMailReclassifySampleResult, Error>> {
   const [{ getQueue }, { Queues }] = await Promise.all([
     import('../jobs/queues'),
     import('../jobs/queues/types'),
@@ -843,7 +864,14 @@ export async function enqueueMailReclassifySample(
     // states than the obvious three (`prioritized`, `waiting-children`), and
     // treating an unrecognised one as finished would remove a job that is about
     // to spend money.
-    if (state !== 'completed' && state !== 'failed') return ok({ jobId, deduplicated: true })
+    if (state !== 'completed' && state !== 'failed') {
+      const data = existing.data as MailReclassifySampleJobData | undefined
+      return ok({
+        jobId,
+        deduplicated: true,
+        ...(data?.range && data?.mode ? { running: { range: data.range, mode: data.mode } } : {}),
+      })
+    }
     await existing.remove().catch(() => {})
   }
 

--- a/packages/lib/src/seed/entity-migrations/migrations/014-backfill-system-tags.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/014-backfill-system-tags.ts
@@ -15,6 +15,13 @@ const logger = createScopedLogger('entity-migrations:014')
  * Frozen-in-time snapshot of the titles `OrganizationSeeder.seedTags` creates.
  * If the seeder's defaults change later, do NOT edit this list — write a new
  * migration that flags the new titles. Migrations are historical.
+ *
+ * ⚠️ It has already drifted, deliberately. `seedTags` now creates only `Urgent`
+ * and `VIP` as system tags: data migration `076` retired the rest (plan 06 §5.1
+ * / Q6), so seeding them would make every new org need that migration. Eleven of
+ * the titles below therefore describe orgs created before 2026-08-10 and nothing
+ * else — which is exactly what a historical migration should describe. Syncing
+ * this list to the current seeder would be the bug, not the fix.
  */
 const CANONICAL_SYSTEM_TAG_TITLES = [
   // Parent

--- a/packages/lib/src/seed/organization-seeder.ts
+++ b/packages/lib/src/seed/organization-seeder.ts
@@ -403,9 +403,33 @@ export class OrganizationSeeder {
 
   /**
    * Seed default tags for a new organization using the unified entity system.
-   * Creates a hierarchical tag structure with a parent "Topic Categorization" tag
-   * and child tags, plus independent top-level tags — then the five AI mail
-   * categories under their own parent (see `seedAiCategoryTags`).
+   *
+   * Two system tags — `Urgent` and `VIP` — plus the mail categories under their
+   * own parent (see `seedAiCategoryTags`). That is the whole default taxonomy.
+   *
+   * ## Why there is no "Topic Categorization" tree here any more
+   *
+   * This method used to create 13 SYSTEM tags: a `Topic Categorization` parent
+   * with six children, and three independent ones. Data migration `076`
+   * (`076-mail-category-rework.ts`, plan 06 §5.1) retires all of them for
+   * existing orgs — `Orders` and `Account Management` are adopted in place and
+   * renamed to `Order Status` and `Account`, the five remaining topics are
+   * unflagged, and `Topic Categorization` collapses into `Mail Categories`.
+   * Seeding the old set here and immediately migrating it away would mean every
+   * NEW org is born needing that migration (plan 06 Q6).
+   *
+   * ⚠️ The five retired topics (`Customer Feedback`, `Legal`, `Security`,
+   * `Shipping`, `Troubleshooting`) are not seeded at all, where `076` only
+   * UNFLAGS them. The difference is deliberate: `076` keeps them because an
+   * existing org may have applied them by hand and deleting one would drop real
+   * curation. A brand-new org has applied nothing, so there is nothing to
+   * preserve — and plan 06 §2.1's whole argument is that a default taxonomy of
+   * thirteen is the thing to fix.
+   *
+   * ⚠️ `Urgent` and `VIP` stay, and stay SYSTEM tags — plan 06 §5.1 step 7
+   * leaves them completely alone. They are priority and segment, never intents,
+   * so they must never become classifier-eligible (invariant 8), and
+   * `seed-suggested-filters.ts` resolves `VIP` by display name.
    */
   private async seedTags(organizationId: string) {
     // Dedicated handler with `is_system_tag` bypass — the tag-system-guard
@@ -420,56 +444,17 @@ export class OrganizationSeeder {
     // and each invalidation attempt costs 5s on Lambda when Redis is slow/unavailable
     const seedOpts = { skipEvents: true }
 
-    // Create parent tag first - Topic Categorization
-    // UnifiedCrudHandler.create() throws on error, so if we get a result, it succeeded
-    const topicResult = await handler.create(
-      'tag',
-      {
-        title: 'Topic Categorization',
-        tag_description: 'Top-level categorization for support tickets',
-        tag_emoji: '🏷️',
-        tag_color: 'blue',
-        is_system_tag: true,
-      },
-      seedOpts
-    )
-
-    // Create child tags under Topic Categorization using parent relationship
-    // Must be sequential to avoid inverse relationship sync conflicts (sortKey collisions)
+    // Priority and segment. No parent, so these can go in parallel — there is no
+    // inverse (`tag_children`) sync to race on sortKey.
     //
-    // `Billing` and `Sales` USED to live here as system tags, and `Support` below as an
-    // independent one. They moved to `AI_CATEGORY_STARTER_TAGS` (mail-classification plan
-    // §2.4), which needs those exact three titles — seeding both sets would give every new
-    // org two tags called `Billing`, one of them frozen by the system-tag guard. They are
-    // still created for every new org, just as ORDINARY tags under "Mail Categories", which
-    // is what C4 requires: their descriptions are the classifier's instructions and have to
-    // stay editable. `suggested:billing-mail` still resolves `Billing` by display name.
-    const topicSubTags = [
-      { title: 'Account Management', tag_emoji: '👤', tag_color: 'red' },
-      { title: 'Customer Feedback', tag_emoji: '💬', tag_color: 'orange' },
-      { title: 'Legal', tag_emoji: '⚖️', tag_color: 'gray' },
-      { title: 'Security', tag_emoji: '🔒', tag_color: 'purple' },
-      { title: 'Shipping', tag_emoji: '🚚', tag_color: 'amber' },
-      { title: 'Troubleshooting', tag_emoji: '🛠️', tag_color: 'teal' },
-    ]
-
-    for (const tag of topicSubTags) {
-      await handler.create(
-        'tag',
-        {
-          ...tag,
-          tag_parent: topicResult.recordId, // Link to parent via RecordId
-          is_system_tag: true,
-        },
-        seedOpts
-      )
-    }
-
-    // Create independent tags (no parent) - can be parallel since no inverse sync needed
-    // (`Support` moved to the AI mail categories — see the note on `topicSubTags`.)
+    // `Billing`, `Sales` and `Support` used to be seeded here as system tags. They
+    // moved to `AI_CATEGORY_STARTER_TAGS` and are created below as ORDINARY tags
+    // under "Mail Categories", which is what 05 C4 requires: their descriptions are
+    // the classifier's instructions and have to stay editable.
+    // `suggested:billing-mail` still resolves `Billing` by display name, and
+    // `suggested:key-domain` still resolves `VIP` — both titles survive.
     const independentTags = [
       { title: 'Urgent', tag_emoji: '🚨', tag_color: 'purple' },
-      { title: 'Orders', tag_emoji: '📦', tag_color: 'amber' },
       { title: 'VIP', tag_emoji: '⭐', tag_color: 'orange' },
     ]
 
@@ -477,9 +462,14 @@ export class OrganizationSeeder {
       independentTags.map((tag) => handler.create('tag', { ...tag, is_system_tag: true }, seedOpts))
     )
 
-    // The five AI mail categories, under their own parent. Ordinary (editable, deletable)
-    // tags with `tag_ai_classify: true` — they make the labels AVAILABLE to the classifier
-    // and nothing more; no mail is classified until an inbox is opted in.
+    // The core mail categories, under their own parent. Ordinary (editable,
+    // undeletable-by-template-key) tags with `tag_ai_classify: true` — they make the
+    // labels AVAILABLE to the classifier and nothing more; no mail is classified
+    // until an inbox is opted in.
+    //
+    // ⚠️ Core only, deliberately: pack inference (06 §5.4) keys on a Shopify
+    // integration, and a brand-new org has none yet. The vertical packs are
+    // discovered through the tag list's `Add Tag` → suggested-categories picker.
     await seedAiCategoryTags(this.db, organizationId, this.userId)
   }
   // Create ticket sequence for the organization

--- a/packages/lib/src/sequences/field-change-hooks.ts
+++ b/packages/lib/src/sequences/field-change-hooks.ts
@@ -101,7 +101,12 @@ export const enqueueQuickbooksInvoiceSyncOnSent: EntityFieldChangeHandler = asyn
         invoiceInstanceId: entityInstanceId,
         actorUserId: event.userId,
       },
-      { jobId: `qb-invoice-sync:${entityInstanceId}` }
+      // ⚠️ Hyphens, not colons. BullMQ rejects a custom `jobId` containing `:`
+      // unless it splits into exactly THREE parts (`job.js` — a compat carve-out
+      // for old repeatable jobs), so a two-part `qb-invoice-sync:<id>` threw
+      // `Custom Id cannot contain :` on every enqueue and the catch below
+      // swallowed it.
+      { jobId: `qb-invoice-sync-${entityInstanceId}` }
     )
   } catch (error) {
     logger.error('Failed to enqueue QuickBooks invoice sync on invoice:sent', {


### PR DESCRIPTION
Four fixes found while checking whether the reclassify button from #1522 actually worked. It did not, and neither did live classification.

## 1. The reclassify sample never ran — `Job function not found`

`mailReclassifySampleJob` is enqueued to the `maintenance` queue but was never added to that worker's handler map, so `createJobHandler` threw on arrival. Registered it.

## 2. Live mail classification has never run — not once

Chasing the above turned up `Failed to enqueue mail classification` / `"Custom Id cannot contain :"` in the worker logs. BullMQ 5.70.1 rejects a custom `jobId` containing `:` unless it splits into **exactly three** parts — a compat carve-out for old repeatable jobs:

```js
if (jobId.includes(':') && jobId.split(':').length !== 3) throw new Error('Custom Id cannot contain :')
```

`mail-classify:${messageId}` is two parts, so every enqueue threw and `enqueue.ts`'s deliberate never-throw catch swallowed it. Since #1519 merged, no inbound mail has reached the classifier.

Swept every `jobId` in the repo. One other has the same bug — `qb-invoice-sync:${entityInstanceId}` — fixed the same way. The four other colon-bearing ids (`kb-sync:`, `mail-counts-reconcile:`, `mail-filter-retroactive:`, and the reclassify sample id) happen to have exactly two colons and pass.

`enqueue.test.ts` asserted the broken id and passed the whole time; an equality assertion only proves you passed the string you meant to. Replaced with one that encodes BullMQ's rule.

## 3. A collapsed sample reported a run that never happened

The sample's `jobId` is keyed on (org, inbox) and carries no scope, so a second start while one is in flight collapses into the running job whatever it asked for — right for a double-click, wrong for a changed range.

`enqueueMailReclassifySample` now reports the scope it collapsed into; the router compares with `isSameReclassifyScope` and raises a `ConflictError` on a mismatch instead of claiming the run started. The audit row was written unconditionally with the *requested* range, so a collapsed click recorded a run at a scope that never executed — it now fires only when a run actually started, keeping audit == spend.

## 4. `classify.ts` resolves its model from the org cache

It was the only LLM consumer hitting `SystemModelService` directly, once per inbound message and once per thread on a retroactive run. Now `getCachedDefaultModel`, like everything else.

## 5. The org seeder no longer seeds the retired taxonomy (plan 06 Q6)

`seedTags` created 13 system tags that data migration `076` retires, so a new org was born needing the migration *and* carrying both vocabularies — legacy `Account Management`/`Orders` beside the new `Account`/`Order Status`, with no title collision to make it visible. It now creates `Urgent` and `VIP` only, then the core categories, making a fresh org a no-write fixed point of `076`.

It goes further than `076` deliberately: the migration only *unflags* the five retired topics because an existing org may have applied one by hand, and a new org has applied nothing. `014`'s canonical title list is deliberately **not** synced — it is a historical snapshot, and syncing it would re-freeze tags `076` spends two writes each unfreezing.

## Verification

- 136 tests pass in `packages/lib/src/mail-classification`; 142 across seed / `076` / suggested-filters.
- `tsc --noEmit` clean for every touched file in `packages/lib`, `apps/web` and `apps/worker` (one pre-existing unrelated error remains in `events-worker.ts`).
- Confirmed live: the maintenance worker picked up the handler and the `Job function not found` failures stopped.

## Not covered

Re-running a **completed** sample removes the finished job and re-bills, with no second confirm — the button just says "Sample again". Deliberate per plan 07 §3.3's loop, but the copy does not warn. Left as a separate call.