### PR TITLE
fix(ai): stop `userId: ''` rejecting every usage write

### DIFF
--- a/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.tsx
@@ -3,10 +3,13 @@
 'use client'
 
 import {
+  countClassificationFailures,
+  MAIL_CLASSIFY_FAILURE_REASONS,
   MAIL_RECLASSIFY_DAY_PRESETS,
   MAIL_RECLASSIFY_DEFAULT_MODE,
   MAIL_RECLASSIFY_SAMPLE_SIZE,
   MAIL_RECLASSIFY_THREAD_PRESETS,
+  type MailClassificationFailureReason,
   type MailReclassifyMode,
   type MailReclassifyRange,
   type MailReclassifySampleReport,
@@ -386,6 +389,14 @@ function SampleProgress({ processed, total }: { processed: number; total: number
  * Nothing was applied, so there is no undo affordance here and no "sampled" state
  * on any conversation (07 invariant 9).
  */
+/** Plain-language cause for each failure arm, for the results line. */
+const FAILURE_LABELS: Record<MailClassificationFailureReason, string> = {
+  'no-default-model': 'no default model configured',
+  'quota-exceeded': 'out of AI credits',
+  unavailable: 'the provider was unavailable',
+  error: 'an unexpected error',
+}
+
 function SampleResults({ report }: { report: MailReclassifySampleReport }) {
   const rows = [
     ...report.labels.map((label) => ({
@@ -405,6 +416,12 @@ function SampleResults({ report }: { report: MailReclassifySampleReport }) {
   ]
   const max = Math.max(1, ...rows.map((row) => row.count))
   const skipped = Math.max(0, report.selected - report.inferred)
+  const failures = countClassificationFailures(report.skipped)
+  // Whatever `skipped` is not accounted for by a failure is a guard exit.
+  const exits = Math.max(0, skipped - failures)
+  const failureReasons = MAIL_CLASSIFY_FAILURE_REASONS.filter((r) => (report.skipped[r] ?? 0) > 0)
+    .map((r) => FAILURE_LABELS[r])
+    .join(', ')
 
   return (
     <div className='space-y-3'>
@@ -433,11 +450,23 @@ function SampleResults({ report }: { report: MailReclassifySampleReport }) {
         ))}
       </div>
 
+      {/* ⚠️ Failures are called out separately from guard exits, and first.
+          Folding them into one "never reached the model" sentence is how a run
+          where EVERY call failed rendered as `0 classified · 0 no category` —
+          indistinguishable from a taxonomy that matched nothing, and read as a
+          result rather than as an incident. */}
+      {failures > 0 ? (
+        <p className='text-xs font-medium text-destructive'>
+          {n(failures)} {failures === 1 ? 'call' : 'calls'} failed and never reached a verdict
+          {failureReasons ? ` (${failureReasons})` : ''}. These conversations were not sampled.
+        </p>
+      ) : null}
+
       <p className='text-xs text-muted-foreground'>
         {/* Guard exits reduce the sample; 07 §2.11 requires saying so rather than
             implying the full sample size. */}
-        {skipped > 0
-          ? `${n(skipped)} of them never reached the model: already classified, machine mail, or a failed call. `
+        {exits > 0
+          ? `${n(exits)} of them were skipped by the guard: already classified, or machine mail. `
           : ''}
         Nothing was applied and nothing was marked as classified, so a real run still covers all of
         these.

--- a/packages/lib/src/ai/orchestrator/llm-orchestrator.ts
+++ b/packages/lib/src/ai/orchestrator/llm-orchestrator.ts
@@ -83,11 +83,17 @@ export class LLMOrchestrator {
       // Single-pass gate: resolves the client + credential metadata AND enforces
       // the SYSTEM credit quota + abuse rate-limit. One DB lookup for client
       // credentials covers both.
+      //
+      // ⚠️ `userId ?? ''` ONLY here. Credential resolution and the rate-limit key
+      // have always read an empty user as "no user-specific key", which is a
+      // truthful reading of `null`. The metering insert below is the one place
+      // `''` is fatal, and it gets the real value — see
+      // `LLMInvocationRequest.userId`.
       const {
         client: llmClient,
         providerType,
         credentialSource,
-      } = await this.enforceQuotaGate(provider, model, organizationId, userId, {
+      } = await this.enforceQuotaGate(provider, model, organizationId, userId ?? '', {
         forceSystem: request.forceSystem ?? false,
       })
 
@@ -250,11 +256,14 @@ export class LLMOrchestrator {
 
     // Single-pass gate: resolves the client + credential metadata AND enforces
     // the SYSTEM credit quota + abuse rate-limit.
+    //
+    // ⚠️ `userId ?? ''` only for the credential/rate-limit path — see the same
+    // note in `invoke` above.
     const {
       client: llmClient,
       providerType,
       credentialSource,
-    } = await this.enforceQuotaGate(provider, model, organizationId, userId, {
+    } = await this.enforceQuotaGate(provider, model, organizationId, userId ?? '', {
       forceSystem: request.forceSystem ?? false,
     })
 

--- a/packages/lib/src/ai/orchestrator/types.ts
+++ b/packages/lib/src/ai/orchestrator/types.ts
@@ -22,7 +22,16 @@ export interface LLMInvocationRequest {
 
   // Context
   organizationId: string
-  userId: string
+  /**
+   * Who this call is on behalf of, or **null** for a background run that no user
+   * initiated (mail classification, a sweeper).
+   *
+   * ⚠️ Nullable so callers stop reaching for `''`. It reaches two places and they
+   * want different things: credential resolution treats a missing user as "no
+   * user-specific key", which `''` already meant; the usage insert writes it to a
+   * FK column where `''` is fatal. See {@link UsageTrackingRequest.userId}.
+   */
+  userId: string | null
   context?: {
     source: string
     workflowId?: string
@@ -168,7 +177,20 @@ export type UsageSource =
 
 export interface UsageTrackingRequest {
   organizationId: string
-  userId: string
+  /**
+   * Who incurred this spend, or **null** when nobody did.
+   *
+   * ⚠️ Nullable because the column is: `AiUsage.userId` and `UsageEvent.userId`
+   * are both `text().references(User.id, { onDelete: 'set null' })`, i.e. a usage
+   * row is DESIGNED to exist without a user. Typing this as a required `string`
+   * is what produced the `userId: ''` that background callers reached for to
+   * satisfy the compiler — and `''` is not "no user", it is a `User.id` that does
+   * not exist, so the FK rejected the insert.
+   *
+   * A background run (mail classification, a sweeper) genuinely has no user, and
+   * attribution for it lives in `source`, not here. Pass null.
+   */
+  userId: string | null
   provider: string
   model: string
   usage: UsageMetrics

--- a/packages/lib/src/ai/usage/usage-tracking-service.ts
+++ b/packages/lib/src/ai/usage/usage-tracking-service.ts
@@ -103,7 +103,13 @@ export class UsageTrackingService {
 
     await this.database.insert(schema.AiUsage).values({
       organizationId: request.organizationId,
-      userId: request.userId,
+      // ⚠️ `||`, not `??`. `AiUsage.userId` is a FK to `User.id`, so an EMPTY
+      // STRING is not "no user" — it is a user id that does not exist, and the
+      // insert fails. Normalizing at the write rather than trusting the caller is
+      // deliberate: this insert runs AFTER the provider has already been paid, so
+      // a throw here loses the record of spend that really happened. Whatever a
+      // caller passes, the column gets something the FK accepts.
+      userId: request.userId || null,
       provider: request.provider,
       model: request.model,
       modelType: 'llm',
@@ -202,7 +208,9 @@ export class UsageTrackingService {
 
     const rows = [...grouped.values()].map((g) => ({
       organizationId: g.ref.organizationId,
-      userId: g.ref.userId,
+      // `||` for the same reason as the single-row insert above — and it matters
+      // more here, because one bad id would fail the whole grouped batch.
+      userId: g.ref.userId || null,
       provider: g.ref.provider,
       model: g.ref.model,
       modelType: 'llm' as const,

--- a/packages/lib/src/field-values/ai-autofill/generation-service.ts
+++ b/packages/lib/src/field-values/ai-autofill/generation-service.ts
@@ -114,7 +114,9 @@ export async function generateFieldValue(params: {
     model: def.model,
     provider: def.provider,
     organizationId: orgId,
-    userId: userId ?? '',
+    // `?? null`, not `?? ''` — the FK on `AiUsage.userId` rejects an empty
+    // string, and the throw lands after the provider has been paid.
+    userId: userId ?? null,
     messages: [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: resolvedPrompt },

--- a/packages/lib/src/field-values/ai-autofill/preview-service.ts
+++ b/packages/lib/src/field-values/ai-autofill/preview-service.ts
@@ -104,7 +104,8 @@ export async function previewFieldValue(params: {
     model: def.model,
     provider: def.provider,
     organizationId: orgId,
-    userId: userId ?? '',
+    // `?? null`, not `?? ''` — see `generation-service.ts`.
+    userId: userId ?? null,
     messages: [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: resolvedPrompt },

--- a/packages/lib/src/mail-classification/classify.ts
+++ b/packages/lib/src/mail-classification/classify.ts
@@ -217,7 +217,13 @@ export async function classifyMessage(
       model: def.model,
       provider: def.provider,
       organizationId,
-      userId: '',
+      // ⚠️ NULL, never `''`. Nobody asked for this classification — it runs off
+      // an inbound message — and `AiUsage.userId` is a FK to `User.id`, so an
+      // empty string is a user that does not exist. It made every insert throw
+      // AFTER the provider had already been paid, so the call was billed, no
+      // usage row was written, and the thread came back untagged. Attribution for
+      // this spend is `source: 'mail_classification'` below, not a user.
+      userId: null,
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },
         { role: 'user', content: buildClassificationPrompt(context) },

--- a/packages/lib/src/mail-classification/client.ts
+++ b/packages/lib/src/mail-classification/client.ts
@@ -90,10 +90,18 @@ export interface MailClassificationLabel {
  *   was "apply nothing", which is a decision, and it was paid for. The marker
  *   goes down (C9) and the message is done.
  * - `'no-default-model'` / `'quota-exceeded'` / `'unavailable'` / `'error'` —
- *   nothing ran. `LLMOrchestrator` only meters usage against a response that
- *   came back (`llm-orchestrator.ts`), so a throw means no spend and no
- *   decision. These must NOT stamp the marker, or one transient 429 disqualifies
- *   the message from classification forever.
+ *   no decision was reached. These must NOT stamp the marker, or one transient
+ *   429 disqualifies the message from classification forever.
+ *
+ * ⚠️ **"A throw means no spend" is not guaranteed, and assuming it caused a real
+ * incident.** The original reasoning was that `LLMOrchestrator` only meters
+ * against a response that came back, so a throw implies nothing was billed. But
+ * `invoke` also throws when the *metering write itself* fails — which is what
+ * happened when a caller passed `userId: ''` into a column with a FK to
+ * `User.id`: 100 calls were completed and paid for at the provider, every
+ * `AiUsage` insert was rejected, and all 100 came back as `'unavailable'`. Not
+ * stamping the marker is still right (the message deserves another attempt), but
+ * treat these arms as "no decision", never as "no cost".
  *
  * That distinction is carried explicitly by `MailClassificationResult.inferred`
  * rather than re-derived from this union — see the note there.
@@ -108,12 +116,48 @@ export type MailClassificationSkipReason =
   | 'no-default-model'
   | 'below-threshold'
   | 'no-category'
-  /** Out of AI credits, or over the completions rate limit. Nothing was spent. */
+  /** Out of AI credits, or over the completions rate limit. Gated before any call. */
   | 'quota-exceeded'
-  /** Provider 429/5xx, network failure or timeout — transient, nothing spent. */
+  /**
+   * Provider 429/5xx, network failure, timeout — or a metering write that failed
+   * after a successful call. Transient, but see the warning above: not free.
+   */
   | 'unavailable'
-  /** Anything unexpected. Also unspent, but worth an `error` log rather than a warn. */
+  /** Anything unexpected. Worth an `error` log rather than a warn. */
   | 'error'
+
+/**
+ * The skip reasons that mean **something went wrong**, as opposed to the guard
+ * doing its job.
+ *
+ * ⚠️ Exists because a sample report cannot be read without it. `selected -
+ * inferred` counts every thread that never reached a decision, and "all 100 were
+ * already classified" and "all 100 calls failed" produce the identical number.
+ * The first is a no-op; the second is an incident that silently reads as "the
+ * taxonomy matched nothing".
+ */
+export const MAIL_CLASSIFY_FAILURE_REASONS = [
+  'no-default-model',
+  'quota-exceeded',
+  'unavailable',
+  'error',
+  // `satisfies`, not a type annotation: the annotation would widen this to
+  // `MailClassificationSkipReason[]` and a caller keying a Record off it would be
+  // forced to handle all twelve arms. This keeps the literal tuple AND still
+  // fails to compile if one of these stops being a real skip reason.
+] as const satisfies readonly MailClassificationSkipReason[]
+
+/** One of the four arms in {@link MAIL_CLASSIFY_FAILURE_REASONS}. */
+export type MailClassificationFailureReason = (typeof MAIL_CLASSIFY_FAILURE_REASONS)[number]
+
+/** How many of a report's `skipped` counts are failures rather than guard exits. */
+export function countClassificationFailures(
+  skipped: Partial<Record<MailClassificationSkipReason, number>>
+): number {
+  let total = 0
+  for (const reason of MAIL_CLASSIFY_FAILURE_REASONS) total += skipped[reason] ?? 0
+  return total
+}
 
 /** The marker written to `Message.metadata.mailClassification` after a call. */
 export interface MailClassificationMarker {

--- a/packages/lib/src/mail-classification/index.ts
+++ b/packages/lib/src/mail-classification/index.ts
@@ -13,12 +13,14 @@ export {
 } from './classify'
 // Client-safe constants + types (also importable as `@auxx/lib/mail-classification/client`)
 export {
+  countClassificationFailures,
   isSameReclassifyScope,
   MAIL_CLASSIFICATION_INBOX_IDS_SETTING,
   MAIL_CLASSIFICATION_JOB_NAME,
   MAIL_CLASSIFICATION_METADATA_KEY,
   MAIL_CLASSIFY_BODY_CHARS,
   MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
+  MAIL_CLASSIFY_FAILURE_REASONS,
   MAIL_CLASSIFY_NO_CATEGORY,
   MAIL_RECLASSIFY_BACKLOG_COUNT_CAP,
   MAIL_RECLASSIFY_DAY_PRESETS,

--- a/packages/lib/src/usage/flush-usage-events-job.ts
+++ b/packages/lib/src/usage/flush-usage-events-job.ts
@@ -13,19 +13,50 @@ const logger = createScopedLogger('flush-usage-events-job')
 const BATCH_SIZE = 500
 
 /**
+ * One buffered event as a `UsageEvent` row.
+ *
+ * ⚠️ `userId: e.userId || null`, not `?? null`. `UsageEvent.userId` is a FK to
+ * `User.id`, so an empty string is a user id that does not exist and the row is
+ * rejected — `??` passes `''` straight through, which is how the whole buffer
+ * came to be poisoned.
+ */
+function toRow(e: RecordUsageEventJobData) {
+  return {
+    eventId: e.eventId ?? null,
+    organizationId: e.orgId,
+    userId: e.userId || null,
+    metric: e.metric,
+    quantity: e.quantity,
+    metadata: e.metadata ?? null,
+    periodKey: e.periodKey,
+    // Preserve the original event time (createdAt would default to flush time)
+    ...(Number.isFinite(e.timestamp) ? { createdAt: new Date(e.timestamp) } : {}),
+  }
+}
+
+/**
  * Scheduled BullMQ job: drains the Redis usage-event buffer into Postgres as
  * batch inserts (was one job + one INSERT per metered event).
  *
- * Failure handling: a failed batch is pushed back onto the buffer and the job
- * throws (BullMQ retries). If the INSERT actually committed before the error,
- * the `eventId` unique index + ON CONFLICT DO NOTHING makes the replay a no-op.
- * Order across events is irrelevant — every reader is a SUM over quantities.
+ * Failure handling: a failed batch is retried ROW BY ROW, and only the rows that
+ * still fail are dropped (loudly). If the INSERT actually committed before the
+ * error, the `eventId` unique index + ON CONFLICT DO NOTHING makes the replay a
+ * no-op. Order across events is irrelevant — every reader is a SUM over
+ * quantities.
+ *
+ * ⚠️ **Why the batch is not pushed back any more.** It used to be: a failed
+ * batch went back on the buffer and the job threw. One permanently-bad row
+ * therefore recycled forever and every other org's events queued behind it never
+ * reached Postgres — metering stopped instance-wide and could not self-heal. That
+ * is exactly what happened when mail classification emitted `userId: ''` against
+ * a FK to `User.id`. A poison row must cost its own row, never the pipeline.
  */
 export async function flushUsageEventsJob(_ctx: JobContext): Promise<void> {
   const redis = await getRedisClient(false)
   if (!redis) return
 
   let flushed = 0
+  let dropped = 0
   while (true) {
     const popped = await redis.lpop(USAGE_EVENT_BUFFER_KEY, BATCH_SIZE)
     if (!popped || popped.length === 0) break
@@ -41,32 +72,49 @@ export async function flushUsageEventsJob(_ctx: JobContext): Promise<void> {
     }
     if (events.length === 0) continue
 
+    const rows = events.map(toRow)
+
     try {
-      await db
-        .insert(schema.UsageEvent)
-        .values(
-          events.map((e) => ({
-            eventId: e.eventId ?? null,
-            organizationId: e.orgId,
-            userId: e.userId ?? null,
-            metric: e.metric,
-            quantity: e.quantity,
-            metadata: e.metadata ?? null,
-            periodKey: e.periodKey,
-            // Preserve the original event time (createdAt would default to flush time)
-            ...(Number.isFinite(e.timestamp) ? { createdAt: new Date(e.timestamp) } : {}),
-          }))
-        )
-        .onConflictDoNothing({ target: schema.UsageEvent.eventId })
+      await db.insert(schema.UsageEvent).values(rows).onConflictDoNothing({
+        target: schema.UsageEvent.eventId,
+      })
       flushed += events.length
     } catch (error) {
-      // Return the batch to the buffer for the next attempt before failing the job
-      await redis.rpush(USAGE_EVENT_BUFFER_KEY, ...raw)
-      throw error
+      // One bad row fails the whole multi-row INSERT, and there is no way to tell
+      // which from the error. Retry individually so the good ones land.
+      logger.warn('Usage-event batch insert failed, falling back to per-row', {
+        size: rows.length,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      for (const row of rows) {
+        try {
+          await db.insert(schema.UsageEvent).values(row).onConflictDoNothing({
+            target: schema.UsageEvent.eventId,
+          })
+          flushed++
+        } catch (rowError) {
+          // DROPPED, not re-buffered. A row that cannot be inserted now will not
+          // become insertable later, and re-buffering it blocks every event
+          // behind it forever. Losing one metering row is strictly better than
+          // losing all of them, but it is still data loss — hence `error`.
+          dropped++
+          logger.error('Dropping an unwritable usage event', {
+            organizationId: row.organizationId,
+            metric: row.metric,
+            userId: row.userId,
+            error: rowError instanceof Error ? rowError.message : String(rowError),
+          })
+        }
+      }
     }
   }
 
   if (flushed > 0) {
     logger.debug('Flushed usage events to Postgres', { flushed })
+  }
+  // Its own line, at `warn`: a drop is billable usage that will never be counted,
+  // and it must be visible without reading per-row errors.
+  if (dropped > 0) {
+    logger.warn('Usage events dropped as unwritable', { dropped, flushed })
   }
 }


### PR DESCRIPTION
Follow-up to #1523. With the enqueue fixed, the reclassify sample ran — and reported `Sampled 100 conversations · 0 classified · 0 no category`. That was not a taxonomy result. All 100 calls reached OpenAI, succeeded, were billed, and then died writing usage.

## Root cause: a required type over an optional column

`AiUsage.userId` and `UsageEvent.userId` are nullable FKs to `User.id`, declared `onDelete: 'set null'` — a usage row with no user is a **designed** state. But `LLMInvocationRequest.userId` and `UsageTrackingRequest.userId` were typed as a required `string`, so background callers with no user reached for `''` to satisfy the compiler.

`''` is not "no user". It is a `User.id` that does not exist, and the FK rejects the row:

```
insert or update on table "AiUsage" violates foreign key constraint "AiUsage_userId_User_id_fk"
params: …,<orgId>,<empty>,733,llm,22,6,SYSTEM,SYSTEM,mail_classification,
```

`classify.ts` passed `userId: ''` on every inbound message. The insert runs *after* the provider has been paid, so each call was billed, `invoke` threw, `classify.ts` recorded `unavailable`, and the thread came back untagged. The `AiUsage` rows for that spend do not exist — confirmed, zero rows for the run window.

## The same `''` poisoned the usage-event pipeline

It also reached the Redis buffer through the quota guard's `aiCompletions` counter, where `flush-usage-events-job.ts` compounded it twice:

- `userId: e.userId ?? null` — `??` does not catch `''`, so the row entered the batch insert;
- on failure the **entire batch was pushed back** onto the buffer and the job threw.

So one permanently-bad row recycled forever with every other org's events queued behind it. Observed live: the flush job failed every 15s for several minutes. It recovered only because the normalization fix below hot-reloaded into the dev worker, which then drained all 100 events successfully with `userId: NULL`.

## Fixes — at the boundary, so the class cannot return

1. `userId` widened to `string | null` on both interfaces; `null` from `classify.ts`, `?? null` in `generation-service.ts` and `preview-service.ts` which carried the same `?? ''`.
2. **Both `AiUsage` inserts normalize with `|| null`.** This is the load-bearing one: whatever a caller passes, the column gets something the FK accepts. This write happens after the money is spent, so it must not be able to throw on a caller's bad input.
3. The flush job normalizes the same way, and a failed batch now retries **row by row**, dropping (loudly, at `error`) only what still fails. A poison row costs its own row, never the pipeline.
4. `userId ?? ''` is kept for credential resolution and the rate-limit key only, where an empty user has always meant "no user-specific key" — a truthful reading of `null`.

Deliberately not widened: `getClientWithMetadata`, `ProviderRegistry.createClient` and the credentials context still take `string`. Threading null through those touches every provider path for no benefit, since none of them write to a FK.

## Two corrections to comments that hid this

- `MailClassificationSkipReason` documented that `'unavailable'` / `'error'` mean "nothing was spent", on the reasoning that `LLMOrchestrator` only meters against a response that came back. `invoke` also throws when the **metering write itself** fails, which is exactly this bug. `inferred: false` is still right — the message deserves another attempt — but these arms are "no decision", never "no cost".
- The sample dialog folded failures and guard exits into one "never reached the model" sentence, so 100 failed calls rendered identically to 100 already-classified threads. Failures are now called out separately, first, with the cause named.

## Verification

- 136 tests pass in `packages/lib/src/mail-classification` and `src/usage`.
- `tsc --noEmit` clean for every touched file in `packages/lib` and `apps/web`.
- Confirmed in the dev DB: the 100 buffered usage events landed with `userId: NULL` once the normalization was live, and the flush job has not failed since.

## Known residue

The 100 `AiUsage` rows for that run are gone for good — the calls were paid for and there is no record of the cost. The `UsageEvent` counters for them survived.