### PR TITLE
fix(mail): keep an interrupted classification run visible and undoable

### DIFF
--- a/apps/web/src/components/inbox/ui/inbox-reclassify-row.test.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-row.test.tsx
@@ -148,3 +148,55 @@ describe('InboxReclassifyRow — after a sample', () => {
     expect(screen.getByRole('button', { name: /View results/i })).toBeInTheDocument()
   })
 })
+
+/**
+ * ⚠️ The regression this section exists for: a run the worker DIED under used to
+ * render as one that never happened.
+ *
+ * `runReport` is only populated for `completed`, so a `failed` job fell through
+ * to the backlog branch and the row said "N older conversations have never been
+ * classified" — the run visibly vanished. That is not an exotic state: every
+ * deploy kills an active run, and every dev `--watch` restart does too. And it
+ * is not only cosmetic, because a run killed partway has already applied tags
+ * that somebody may want back.
+ */
+describe('an interrupted run', () => {
+  beforeEach(() => {
+    h.runStatus = {
+      jobId: 'j1',
+      state: 'failed',
+      processed: 340,
+      total: 1204,
+      startedAtIso: '2026-08-11T01:44:00.000Z',
+    }
+  })
+
+  it('says it stopped rather than falling back to the backlog copy', () => {
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.getByText(/Run interrupted after 340 of 1,204/i)).toBeInTheDocument()
+    expect(screen.queryByText(/have never been classified/i)).not.toBeInTheDocument()
+  })
+
+  /**
+   * The undo key comes off the job's PROGRESS, not its report — progress
+   * survives a failure, a return value does not. Without it the tags an
+   * interrupted run applied would be unreachable.
+   */
+  it('still offers undo, keyed off the progress-carried start time', async () => {
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    await userEvent.click(screen.getByRole('button', { name: /^Undo$/i }))
+    expect(h.undoRun).toHaveBeenCalledWith({
+      inboxId: 'ibx_1',
+      sinceIso: '2026-08-11T01:44:00.000Z',
+    })
+  })
+
+  it('offers to resume, and says resuming does not pay twice', () => {
+    render(<InboxReclassifyRow inboxId='ibx_1' />)
+
+    expect(screen.getByRole('button', { name: /Resume/i })).toBeInTheDocument()
+    expect(screen.getByText(/picks up where it left off/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/inbox/ui/inbox-reclassify-row.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-row.tsx
@@ -124,6 +124,21 @@ export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
   const runState = runStatus.data?.state
   const runActive = runState === 'waiting' || runState === 'active' || runState === 'delayed'
   const runReport = runState === 'completed' ? runStatus.data?.report : undefined
+  /**
+   * ⚠️ A run that DIED must not render as one that never happened.
+   *
+   * `runReport` is only set for `completed`, so before this a failed run fell
+   * straight through to the backlog branch — "N older conversations have never
+   * been classified" — and the run visibly vanished. The worker dying under an
+   * active run is not exotic: every deploy does it, and every `--watch` restart
+   * does it in dev.
+   *
+   * It matters beyond the copy, because a run killed partway has already applied
+   * tags. `startedAtIso` comes off the job's PROGRESS rather than its report
+   * (progress survives a failure), so those tags stay undoable.
+   */
+  const runFailed = runState === 'failed'
+  const runStartedAtIso = runStatus.data?.startedAtIso
 
   const state = status.data?.state
   const running = state === 'waiting' || state === 'active' || state === 'delayed'
@@ -133,26 +148,38 @@ export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
 
   // Nothing to catch up on and nothing in flight — the row is a standing
   // affordance, not a permanent fixture.
-  if (!runActive && !runReport && !running && !report && count === 0) return null
+  if (!runActive && !runReport && !runFailed && !running && !report && count === 0) return null
 
   // A run outranks a sample everywhere below: it is the one that spent real money
   // and changed real data, so it is the one a user needs to see.
-  const processed = (runActive ? runStatus.data?.processed : status.data?.processed) ?? 0
-  const total = (runActive ? runStatus.data?.total : status.data?.total) ?? 0
+  //
+  // ⚠️ `runFailed` counts as "showing the run". Keying this on `runActive` alone
+  // made an interrupted run read the SAMPLE's counters — which are null when no
+  // sample ran — so it rendered "interrupted after 0 of 0" and told the user
+  // nothing about how far it got.
+  const showingRun = runActive || runFailed
+  const processed = (showingRun ? runStatus.data?.processed : status.data?.processed) ?? 0
+  const total = (showingRun ? runStatus.data?.total : status.data?.total) ?? 0
   const pct = total > 0 ? Math.min(100, Math.round((processed / total) * 100)) : 0
   const busy = runActive || running
 
   const handleUndo = async () => {
-    if (!runReport) return
+    // A finished run knows its own count; an interrupted one does not, because
+    // the report it would have carried was never written.
+    if (!runStartedAtIso) return
+    const applied = runReport?.applied
     const confirmed = await confirm({
-      title: `Remove ${runReport.applied.toLocaleString()} applied ${runReport.applied === 1 ? 'category' : 'categories'}?`,
+      title:
+        applied === undefined
+          ? 'Remove the categories this run applied?'
+          : `Remove ${applied.toLocaleString()} applied ${applied === 1 ? 'category' : 'categories'}?`,
       description:
         'Conversations that also carry another category are left alone, because the AI is not necessarily the only thing that applied it. This does not refund the classification.',
       confirmText: 'Undo',
       cancelText: 'Keep them',
       destructive: true,
     })
-    if (confirmed) undoRun.mutate({ inboxId, sinceIso: runReport.startedAtIso })
+    if (confirmed) undoRun.mutate({ inboxId, sinceIso: runStartedAtIso })
   }
 
   return (
@@ -174,6 +201,11 @@ export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
                 {runReport.capped > 0
                   ? `, ${runReport.capped.toLocaleString()} left over the per-run limit`
                   : ''}
+              </p>
+            ) : runFailed ? (
+              <p className='text-sm font-medium'>
+                Run interrupted after {processed.toLocaleString()} of{' '}
+                {(total || 0).toLocaleString()}
               </p>
             ) : running ? (
               <p className='text-sm font-medium'>
@@ -198,7 +230,12 @@ export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
                 mail" reads as "apply my automations to old mail" to most people,
                 and the honest correction belongs at the point of action. */}
             <p className='text-xs text-muted-foreground'>
-              Labels older mail for search and reporting. Your filters will not run on it.
+              {runFailed
+                ? // Resuming is safe and free for what already landed: a
+                  // classified conversation carries a marker, so fill-gaps skips
+                  // it rather than paying twice.
+                  'It stopped before finishing — usually a restart. Everything it already classified is saved, and running it again picks up where it left off.'
+                : 'Labels older mail for search and reporting. Your filters will not run on it.'}
             </p>
           </div>
 
@@ -213,12 +250,15 @@ export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
               }>
               Cancel
             </Button>
-          ) : runReport ? (
+          ) : runReport || runFailed ? (
             <div className='flex shrink-0 items-center gap-2'>
               {/* Undo is offered only while the report exists — the job is reaped
                   a day after it completes, and `startedAtIso` is the only scope
                   key undo has. An undo button with no key is worse than none. */}
-              {runReport.applied > 0 ? (
+              {/* Offered whenever a scope key exists — including for an
+                  interrupted run, which is precisely the one whose partial work
+                  somebody needs to reverse. */}
+              {runStartedAtIso && (runReport ? runReport.applied > 0 : true) ? (
                 <Button
                   variant='ghost'
                   size='sm'
@@ -229,7 +269,7 @@ export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
                 </Button>
               ) : null}
               <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
-                Classify more…
+                {runFailed ? 'Resume…' : 'Classify more…'}
               </Button>
             </div>
           ) : (

--- a/packages/lib/src/mail-classification/client.ts
+++ b/packages/lib/src/mail-classification/client.ts
@@ -420,6 +420,18 @@ export interface MailReclassifyRunStatus {
   processed: number
   total: number
   report?: MailReclassifyRunReport
+  /**
+   * The run's start, available even when it never finished.
+   *
+   * ⚠️ **This is what makes a crashed run undoable.** BullMQ keeps `progress` on
+   * a failed job but only keeps a return value for one that completed, so a run
+   * the worker died under — a deploy, a dev `--watch` restart — has applied tags
+   * and produced no report. Reading the key off progress instead means undo does
+   * not depend on the run having ended cleanly.
+   */
+  startedAtIso?: string
+  /** Why a `failed` run failed, when BullMQ recorded a reason. */
+  failedReason?: string
 }
 
 /**

--- a/packages/lib/src/mail-classification/retroactive.ts
+++ b/packages/lib/src/mail-classification/retroactive.ts
@@ -600,6 +600,7 @@ export interface RunMailReclassifySampleInput {
   threadDelayMs?: number
   now?: Date
   /** Called after each thread, for the job's progress surface. */
+  /** Called after each thread, for the job's progress surface. */
   onProgress?: (processed: number, total: number) => void
   /** Stop between threads. Safe at any point — a sample commits nothing. */
   isCancelled?: () => boolean
@@ -769,7 +770,15 @@ export interface RunMailReclassifyApplyInput {
   /** Test override for {@link MAIL_RECLASSIFY_PAGE_SIZE}. */
   pageSize?: number
   now?: Date
-  onProgress?: (processed: number, total: number) => void
+  /**
+   * ⚠️ Carries `startedAtIso` as well as the counts, and that is not cosmetic.
+   * BullMQ keeps `progress` on a job even when the job FAILS, whereas a return
+   * value only exists for a run that reached its end. A run the worker dies
+   * under — a deploy, a dev `--watch` restart — has therefore already applied
+   * tags and produced no report, so without this there is no scope key and its
+   * work cannot be undone. See {@link getMailReclassifyRunStatus}.
+   */
+  onProgress?: (processed: number, total: number, startedAtIso: string) => void
   /**
    * Stop between threads. Safe at ANY point (§2.5): each thread is committed on
    * its own, so a cancelled run is a partial run, never a broken one.
@@ -840,6 +849,11 @@ export async function runMailReclassifyApply(
     skipped[reason] = (skipped[reason] ?? 0) + 1
   }
 
+  // ⚠️ Published BEFORE the first thread, so the undo key exists from the moment
+  // the run can have changed anything. A run that dies on thread 1 has still
+  // applied a tag on thread 1.
+  input.onProgress?.(0, total, startedAt.toISOString())
+
   let cursor: ReclassifyCursor | undefined
   pager: while (selected < total) {
     const rows = await selectReclassifyThreadPage(db, {
@@ -878,7 +892,7 @@ export async function runMailReclassifyApply(
 
       if (!resolved.proceed) {
         note(resolved.reason)
-        input.onProgress?.(selected, total)
+        input.onProgress?.(selected, total, startedAt.toISOString())
         continue
       }
 
@@ -890,7 +904,7 @@ export async function runMailReclassifyApply(
       // run over one transient 429.
       if (!result.inferred) {
         note(result.reason ?? 'error')
-        input.onProgress?.(selected, total)
+        input.onProgress?.(selected, total, startedAt.toISOString())
         continue
       }
 
@@ -931,7 +945,7 @@ export async function runMailReclassifyApply(
         },
       })
 
-      input.onProgress?.(selected, total)
+      input.onProgress?.(selected, total, startedAt.toISOString())
       await sleep(threadDelayMs)
     }
 
@@ -1216,8 +1230,8 @@ export async function mailReclassifyApplyJob(
     mode,
     threadDelayMs,
     isCancelled: () => ctx.isCancelled?.() ?? false,
-    onProgress: (processed, total) => {
-      void ctx.job?.updateProgress({ processed, total })?.catch(() => {})
+    onProgress: (processed, total, startedAtIso) => {
+      void ctx.job?.updateProgress({ processed, total, startedAtIso })?.catch(() => {})
     },
   }).catch((error) => {
     logger.error('Mail re-classification run failed', {
@@ -1297,7 +1311,11 @@ export async function getMailReclassifyRunStatus(
   if (!job) return null
 
   const rawState = await job.getState().catch(() => 'unknown')
-  const progress = (job.progress ?? {}) as { processed?: number; total?: number }
+  const progress = (job.progress ?? {}) as {
+    processed?: number
+    total?: number
+    startedAtIso?: string
+  }
   const value = job.returnvalue as MailReclassifyRunReport | { skipped: string } | undefined
 
   const KNOWN: MailReclassifyRunStatus['state'][] = [
@@ -1308,14 +1326,21 @@ export async function getMailReclassifyRunStatus(
     'delayed',
   ]
 
+  // `startedAtIso` is the discriminator — a `{ skipped }` value has no such key,
+  // so a precondition failure never renders as an all-zero run.
+  const report = value && 'startedAtIso' in value ? value : undefined
+
   return {
     jobId: job.id ?? mailReclassifyApplyJobId(organizationId, inboxId),
     state: KNOWN.find((known) => known === rawState) ?? 'unknown',
     processed: typeof progress.processed === 'number' ? progress.processed : 0,
     total: typeof progress.total === 'number' ? progress.total : 0,
-    // `startedAtIso` is the discriminator — a `{ skipped }` value has no such
-    // key, so a precondition failure never renders as an all-zero run.
-    report: value && 'startedAtIso' in value ? value : undefined,
+    report,
+    // ⚠️ Progress FIRST, report second. The report only exists for a run that
+    // ended; progress survives a run the worker died under, and that is exactly
+    // the run whose applied tags somebody needs to reverse.
+    startedAtIso: progress.startedAtIso ?? report?.startedAtIso,
+    ...(job.failedReason ? { failedReason: job.failedReason } : {}),
   }
 }
 


### PR DESCRIPTION
## What prompted this

A run appeared to vanish. **It turned out no run had happened** — Redis held a completed *sample* (100/100) and no apply job at all, and the 104 model calls in that window were 100 sample inferences (which persist nothing, invariant 9) plus 4 live classifications of mail that arrived while it ran. Nothing was lost and nothing was billed for a run.

But the report was right about the *shape*, and chasing it found two real defects in a state `07` never wrote down: **a run that never finishes.**

⚠️ That state is not exotic. Every deploy kills an active run, and every dev `--watch` restart does too — the maintenance worker restarted **four times** during the window in question. A run over thousands of threads meets a restart eventually, so "interrupted" is a normal outcome, not an error path.

## 1. An interrupted run rendered as one that never happened

`inbox-reclassify-row.tsx` reads `report` only when the job state is `completed`, and `runActive` excludes `failed`. So a killed run fell through to the backlog branch and said *"N older conversations have never been classified."* The run visibly disappeared.

## 2. Its applied tags were unreachable

Undo's scope key is `startedAtIso`, which §2.7 took from the run's **report** — and a run that dies produces no report. A run killed after applying 500 tags had no way to reverse them.

**The fix, and the general rule in it:** BullMQ keeps a job's `progress` when the job **fails**, but keeps a return value only for one that **completed**. So the run now publishes `startedAtIso` into progress **before its first thread** — the key exists from the moment the run can have changed anything — and `getMailReclassifyRunStatus` prefers progress over the report. Undo no longer depends on a run having ended cleanly.

## 3. A third defect the test found

Writing the test for the above surfaced one more: the row's `processed`/`total` were selected on `runActive`, so an interrupted run read the **sample's** counters — null when no sample ran — and rendered *"interrupted after 0 of 0"*. The same mistake in miniature: a condition meaning *"is a run happening"* reused for *"are we showing a run"*.

## What the row does now

- **"Run interrupted after 340 of 1,204"**, instead of silently reverting to backlog copy.
- **Undo**, keyed off the progress-carried start time.
- **"Resume…"**, with a sentence saying resuming does not pay twice — a classified conversation carries a marker, so a `fill-gaps` re-run skips it.

## Verification

- 38 tests in `apps/web` inbox components (3 new, covering all three defects), 137 in `packages/lib`.
- `tsc --noEmit` clean for every touched file.

## Plan

`07`§7.9 records the investigation and the progress-vs-return-value rule. §7.8 item 1 updated: **six** of the defects found since this feature shipped were things a single real run in a browser would have caught, and every one of them shipped with green tests and a clean typecheck.