### PR TITLE
fix(ai): bound provider retries and hung calls, and stop implying a scope

### DIFF
--- a/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.test.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.test.tsx
@@ -312,3 +312,36 @@ describe('InboxReclassifyDialog — while a sample runs', () => {
     expect(screen.queryByRole('button', { name: /Try a sample/i })).not.toBeInTheDocument()
   })
 })
+
+/**
+ * ⚠️ 07 §7.6 left this open: re-running a COMPLETED sample removes the finished
+ * job and pays again, and the button said only "Sample again". That is the one
+ * place someone can spend twice without a number passing in front of them — and
+ * it is shown next to a finished report, the state in which the label reads most
+ * like refreshing a view rather than buying a second one.
+ */
+describe('re-sampling states its cost', () => {
+  it('puts the credit estimate on the button when a report is already showing', () => {
+    h.status = {
+      jobId: 'j1',
+      state: 'completed',
+      processed: 100,
+      total: 100,
+      report,
+    }
+    open()
+
+    expect(
+      screen.getByRole('button', { name: /Sample again \(~\d+ credits\)/i })
+    ).toBeInTheDocument()
+  })
+
+  /** BYO orgs are quoted 0 and must not be shown a bill they will never pay. */
+  it('omits the estimate when the org is not billed for it', () => {
+    h.preview = { ...h.preview, sampleCredits: null }
+    h.status = { jobId: 'j1', state: 'completed', processed: 100, total: 100, report }
+    open()
+
+    expect(screen.getByRole('button', { name: /^Sample again$/i })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-dialog.tsx
@@ -285,13 +285,21 @@ export function InboxReclassifyDialog({ inboxId, open, onOpenChange }: InboxRecl
                   Adjust my categories <ArrowRight />
                 </Link>
               </Button>
+              {/* ⚠️ The cost is ON the button here, unlike the first sample.
+                  Re-sampling removes the finished job and pays again, and the
+                  user is looking at a completed report — the state in which
+                  "Sample again" reads most like refreshing a view rather than
+                  buying a second one. It is the only place someone can spend
+                  twice without passing a number first. */}
               <Button
                 variant='ghost'
                 size='sm'
                 onClick={handleSample}
                 loading={startSample.isPending}
                 loadingText='Starting...'>
-                Sample again
+                {preview.data?.sampleCredits
+                  ? `Sample again (~${n(preview.data.sampleCredits)} credits)`
+                  : 'Sample again'}
               </Button>
               <Button
                 variant='outline'

--- a/apps/web/src/components/inbox/ui/inbox-reclassify-row.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-reclassify-row.tsx
@@ -274,7 +274,13 @@ export function InboxReclassifyRow({ inboxId }: { inboxId: string }) {
             </div>
           ) : (
             <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
-              {report ? 'View results' : 'Classify…'}
+              {/* ⚠️ "Choose what to classify", not "Classify…". The headline above
+                  is the ALL-TIME backlog while the dialog opens on a 30-day
+                  default (07 R-Q1), so a bare "Classify" reads as a promise to do
+                  the number just quoted. The preview corrects it before any
+                  spend, but the button should not have implied it. Same label as
+                  the post-sync prompt, which advertises the same count. */}
+              {report ? 'View results' : 'Choose what to classify'}
             </Button>
           )}
         </div>

--- a/packages/lib/src/ai/clients/base/base-specialized-client.ts
+++ b/packages/lib/src/ai/clients/base/base-specialized-client.ts
@@ -64,13 +64,58 @@ export abstract class BaseSpecializedClient {
   // ===== PROTECTED HELPER METHODS =====
 
   /**
-   * Execute operation with retry logic and circuit breaker
+   * Execute operation with retry logic, a circuit breaker and a TIMEOUT.
+   *
+   * ⚠️ The timeout is the reason this wrapper exists at all for hung providers.
+   * `ClientConfig.timeouts` has carried sane values since it was written and
+   * NOTHING read them, so every call ran to the SDK's own default — roughly ten
+   * minutes — and a single unresponsive provider could pin a worker slot for
+   * that long. Flagged in `05-mail-classification-plan.md` §12.6 as one of the
+   * reasons transient failures hurt more than they should.
+   *
+   * ⚠️ The race does not ABORT the underlying HTTP request; the socket is left
+   * to close on its own. That is a deliberate trade: threading an `AbortSignal`
+   * through every provider SDK is a much larger change, and the harm being fixed
+   * here is the blocked caller, not the idle socket.
+   *
+   * `timeoutMs` is per-operation because an LLM completion and an embedding have
+   * nothing in common in how long they may honestly take — see
+   * `ClientConfig.timeouts.completion`.
    */
   protected async withRetryAndCircuitBreaker<T>(
     operation: () => Promise<T>,
-    context: OperationContext
+    context: OperationContext,
+    opts: { timeoutMs?: number } = {}
   ): Promise<T> {
-    return await this.retryManager.execute(operation, {
+    const timeoutMs = Math.max(1_000, opts.timeoutMs ?? this.config.timeouts.request)
+
+    // Wrapped INSIDE the retry, so each attempt gets its own budget rather than
+    // the first slow attempt consuming the whole allowance.
+    const withTimeout = async (): Promise<T> => {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      try {
+        return await Promise.race([
+          operation(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `${this.clientName} ${context.operation} timed out after ${timeoutMs}ms`
+                  )
+                ),
+              timeoutMs
+            )
+          }),
+        ])
+      } finally {
+        // Without this the process keeps a live timer per call and a short
+        // operation still waits out the full timeout before exiting.
+        if (timer) clearTimeout(timer)
+      }
+    }
+
+    return await this.retryManager.execute(withTimeout, {
       maxRetries: this.config.retries.maxAttempts,
       backoffStrategy: this.config.retries.backoffStrategy,
       circuitBreaker: this.circuitBreaker,

--- a/packages/lib/src/ai/clients/base/types.ts
+++ b/packages/lib/src/ai/clients/base/types.ts
@@ -81,8 +81,19 @@ export interface ClientConfig {
     monitoringPeriod: number
   }
   timeouts: {
+    /** Cap for a single non-streaming call: embeddings, moderation, TTS, STT. */
     request: number
     connection: number
+    /**
+     * Cap for an LLM completion, streaming or not.
+     *
+     * ⚠️ Separate from `request` because a reasoning model can legitimately run
+     * for minutes, and capping a completion at the embedding timeout would fail
+     * calls that were about to succeed. Both exist to bound a HUNG provider well
+     * below the SDK's own ~10-minute default, not to police slow-but-working
+     * ones.
+     */
+    completion: number
   }
 }
 
@@ -362,5 +373,6 @@ export const DEFAULT_CLIENT_CONFIG: ClientConfig = {
   timeouts: {
     request: 120000, // 2 minutes
     connection: 30000, // 30 seconds
+    completion: 300000, // 5 minutes — reasoning models are legitimately slow
   },
 }

--- a/packages/lib/src/ai/providers/anthropic/anthropic-client.ts
+++ b/packages/lib/src/ai/providers/anthropic/anthropic-client.ts
@@ -117,6 +117,15 @@ export class AnthropicClient extends ProviderClient {
   getApiClient(credentials: ProviderCredentials): Anthropic {
     return new Anthropic({
       apiKey: this.requireApiKey(credentials, 'apiKey'),
+      // Retry policy lives in RetryManager (one place), exactly as every other
+      // provider client does it.
+      //
+      // ⚠️ This client was the ONLY one missing it, and the arithmetic is why it
+      // matters: the SDK defaults to 2 internal retries, so `RetryManager`'s 4
+      // attempts became up to 12 HTTP calls against a provider that is asking us
+      // to slow down. `05-mail-classification-plan.md` §12.6 flagged it as a
+      // reason transient failures fired more often than they should.
+      maxRetries: 0,
       // Tee every HTTP attempt (incl. the SDK's silent 4xx/5xx retries) with its
       // status, latency, and diagnostic headers (rate-limit, retry-after, auth)
       // into the agent-session trace, so a throttle-and-retry or auth failure is

--- a/packages/lib/src/ai/providers/anthropic/anthropic-llm-client.ts
+++ b/packages/lib/src/ai/providers/anthropic/anthropic-llm-client.ts
@@ -101,7 +101,11 @@ export class AnthropicLLMClient extends LLMClient {
         {
           operation: 'llm_invoke',
           model: params.model,
-        }
+        },
+        // A completion, streaming or not, gets the longer budget: reasoning
+        // models are legitimately slow, and the embedding-sized `request`
+        // timeout would fail calls that were about to succeed.
+        { timeoutMs: this.config.timeouts.completion }
       )
 
       this.logOperationSuccess('LLM invoke', this.getTimestamp() - startTime, {

--- a/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-integration.test.ts
+++ b/packages/lib/src/ai/providers/deepseek/__tests__/deepseek-integration.test.ts
@@ -98,7 +98,7 @@ describe.skipIf(!canRunLiveApi(DEEPSEEK_API_KEY))('DeepSeek Integration Tests', 
         resetTimeout: 1,
         monitoringPeriod: 1,
       },
-      timeouts: { request: 120_000, connection: 60_000 },
+      timeouts: { request: 120_000, connection: 60_000, completion: 300_000 },
     })
   })
 

--- a/packages/lib/src/ai/providers/google/__tests__/google-integration.test.ts
+++ b/packages/lib/src/ai/providers/google/__tests__/google-integration.test.ts
@@ -100,7 +100,7 @@ describe.skipIf(!canRunLiveApi(GOOGLE_API_KEY))('Google Integration Tests', () =
         resetTimeout: 1,
         monitoringPeriod: 1,
       },
-      timeouts: { request: 120_000, connection: 60_000 },
+      timeouts: { request: 120_000, connection: 60_000, completion: 300_000 },
     })
   })
 

--- a/packages/lib/src/ai/providers/groq/__tests__/groq-integration.test.ts
+++ b/packages/lib/src/ai/providers/groq/__tests__/groq-integration.test.ts
@@ -98,7 +98,7 @@ describe.skipIf(!canRunLiveApi(GROQ_API_KEY))('Groq Integration Tests', () => {
         resetTimeout: 1,
         monitoringPeriod: 1,
       },
-      timeouts: { request: 120_000, connection: 60_000 },
+      timeouts: { request: 120_000, connection: 60_000, completion: 300_000 },
     })
   })
 

--- a/packages/lib/src/ai/providers/openai/__tests__/openai-integration.test.ts
+++ b/packages/lib/src/ai/providers/openai/__tests__/openai-integration.test.ts
@@ -138,7 +138,7 @@ describe.skipIf(!canRunLiveApi(OPENAI_API_KEY))('OpenAI Integration Tests', () =
         resetTimeout: 1,
         monitoringPeriod: 1,
       },
-      timeouts: { request: 120_000, connection: 60_000 },
+      timeouts: { request: 120_000, connection: 60_000, completion: 300_000 },
     })
   })
 

--- a/packages/lib/src/ai/providers/openai/openai-llm-client.ts
+++ b/packages/lib/src/ai/providers/openai/openai-llm-client.ts
@@ -85,7 +85,11 @@ export class OpenAILLMClient extends LLMClient {
         {
           operation: 'llm_invoke',
           model: params.model,
-        }
+        },
+        // A completion, streaming or not, gets the longer budget: reasoning
+        // models are legitimately slow, and the embedding-sized `request`
+        // timeout would fail calls that were about to succeed.
+        { timeoutMs: this.config.timeouts.completion }
       )
       // Only log success on the success path — a `finally` here would log
       // "completed successfully" even when handleApiError re-throws.


### PR DESCRIPTION
Four items carried in the mail plans, closed together. The first two are cross-cutting and affect **every AI caller**, not just mail — they were flagged in `05`§12.6 as reasons transient failures hurt more than they should, and deferred because they didn't belong in that plan.

## 1. `anthropic-client.ts` had no `maxRetries: 0`

Every other provider client sets it, so retry policy lives in `RetryManager` alone. The Anthropic SDK defaults to 2 internal retries, so `RetryManager`'s 4 attempts became up to **12 HTTP calls** against a provider explicitly asking us to slow down.

⚠️ Cohere is the one client still without it, and that's **correct rather than an oversight**: its SDK takes `maxRetries` per *request*, not at construction. Checked, not assumed.

## 2. `ClientConfig.timeouts` had sane values and zero readers

So every call ran to the SDK's own ~10-minute default, and one unresponsive provider could pin a worker slot for that long. The timeout is now enforced in `withRetryAndCircuitBreaker`, which every specialized client already routes through — one change, every provider.

Two decisions in that fix worth reviewing:

- **A new `timeouts.completion` (5 min) sits beside `timeouts.request` (2 min).** Streaming and non-streaming completions share the same wrapper, so a flat cap would have killed long generations — and a reasoning model can legitimately run for minutes. Capping a completion at the embedding timeout would fail calls that were about to succeed. Only `openai-llm-client` and `anthropic-llm-client` needed changing; the other seven extend the OpenAI one.
- **The race does not `abort()` the request**, it only stops the caller waiting. Threading an `AbortSignal` through every provider SDK is a far larger change, and the harm being fixed is the blocked worker slot, not the idle socket. The timeout sits **inside** the retry, so each attempt gets its own budget rather than the first slow one consuming the whole allowance — and the timer is cleared in a `finally`, or a fast call would keep the process alive for the full timeout.

## 3. The backlog row implied a scope it doesn't run

Its headline is the **all-time** backlog, while the dialog opens on a 30-day default (`07` R-Q1) — so `Classify…` read as a promise to do the number just quoted. Now **"Choose what to classify"**, matching the post-sync prompt, which advertises the same count.

The 30-day default stays. It's a cost decision, not a correctness one (R5), and the preview states the real number before any spend. What was wrong was a button implying otherwise.

## 4. Re-sampling a completed sample stated no cost

`07`§7.6 left this open. It removes the finished job and pays again, and it's shown next to a finished report — the state where "Sample again" reads most like refreshing a view rather than buying a second one. It's the only place someone can spend twice without a number passing in front of them.

The credit estimate is now on the button, and **omitted for a BYO org** that would be quoted zero.

## Verification

- 1,068 tests in `packages/lib/src/ai`, 137 in mail-classification, 40 in `apps/web` inbox components (2 new, covering the cost label and the BYO case).
- `tsc --noEmit` clean across both packages; four provider integration-test fixtures updated for the new required field.

## Plans

`05`§12.7.4 rewritten from "still open" to the fix, including why Cohere is excluded and why the race doesn't abort. `07`§7.8 items 2 and 3 closed.