### PR TITLE
fix(mail): publish thread tags to the mail UI so they appear live

### DIFF
--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -265,6 +265,17 @@ export interface ThreadMeta {
    * `ChatThreadMetadata`; other channels may carry `{ importance }`.
    */
   metadata?: Record<string, unknown> | null
+  /**
+   * Tag RecordIds — FULL REPLACEMENT of the thread's tag set, not a delta.
+   * Metadata-tier (`THREAD_METADATA_FIELDS`), so it rides every lens variant:
+   * the payload carries tag ids, never tag names, and the org tag vocabulary is
+   * readable to any member anyway.
+   *
+   * Producer is `ThreadMutationService.tagThreadsBulk` — the single write path
+   * for thread tags — so classifier, filter action, workflow node and the
+   * bulk toolbar all publish this identically.
+   */
+  tagIds?: RecordId[]
   /** Soft-merge pointer — target Thread RecordId or null when unmerged/target. */
   mergedIntoThreadId?: RecordId | null
   /**

--- a/packages/lib/src/threads/__tests__/thread-tag-realtime.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-tag-realtime.test.ts
@@ -1,0 +1,240 @@
+// packages/lib/src/threads/__tests__/thread-tag-realtime.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SYSTEM_VISIBILITY } from '../../permissions/visibility/context'
+
+/**
+ * Thread tags must publish the MAIL `thread:updated` event, not only the
+ * field-value layer's `fieldValues:updated`.
+ *
+ * `tagThreadsBulk` delegates to `FieldValueService`, whose publish targets
+ * `rooms.orgRecords(org, threadDefId)` — the per-def RECORDS channel that only
+ * the Records grid joins. The mail UI subscribes to per-inbox lens channels and
+ * has no `fieldValues:updated` handler, so every tag write was invisible there
+ * until a reload: the classifier, the `add-tag` filter action, the workflow
+ * CRUD node, Kopilot's `update-thread`, and the bulk toolbar — whose local
+ * optimistic write hid it from the clicker but not from anyone else.
+ *
+ * Pinned here because the fix lives at the single shared write path, so one
+ * regression would silently take all five callers down again.
+ */
+
+/**
+ * Queued `batchGetThreadTagIds` results — the write path reads the tag set
+ * twice (before, then after). An `Error` entry makes that read throw.
+ */
+const { tagFixture, batchGetThreadTagIds } = vi.hoisted(() => {
+  const tagFixture: { reads: (Map<string, string[]> | Error)[] } = { reads: [] }
+  return {
+    tagFixture,
+    batchGetThreadTagIds: vi.fn(async () => {
+      const next = tagFixture.reads.shift()
+      if (next instanceof Error) throw next
+      return next ?? new Map()
+    }),
+  }
+})
+
+vi.mock('../../field-values/relationship-queries', () => ({ batchGetThreadTagIds }))
+
+const { realtime, orgCache, addRelationValuesBulk } = vi.hoisted(() => ({
+  realtime: {
+    publishThreadUpdated: vi.fn(async () => undefined),
+    publishThreadDeleted: vi.fn(async () => undefined),
+    getRealtimeService: vi.fn(() => ({})),
+  },
+  orgCache: {
+    get: vi.fn(async () => []),
+    from: vi.fn(() => ({ bySystemAttribute: async () => ({ id: 'fld_threadtags' }) })),
+  },
+  addRelationValuesBulk: vi.fn(async () => ({ inserted: 1, skipped: 0 })),
+}))
+
+vi.mock('../../realtime', () => realtime)
+vi.mock('../../events/publisher', () => ({
+  publisher: { publish: vi.fn(async () => undefined), publishLater: vi.fn(async () => undefined) },
+}))
+vi.mock('../../field-values', () => ({
+  FieldValueService: class {
+    addRelationValuesBulk = addRelationValuesBulk
+    removeRelationValuesBulk = vi.fn(async () => ({ removed: 0 }))
+    setValueWithBuiltIn = vi.fn(async () => undefined)
+  },
+}))
+vi.mock('../../cache', () => ({
+  getOrgCache: () => orgCache,
+  getCachedResources: vi.fn(async () => []),
+  getCachedMembers: vi.fn(async () => []),
+}))
+vi.mock('../mail-counts', () => ({
+  applyMailCountDeltas: vi.fn(async () => undefined),
+  markMailCountsStale: vi.fn(async () => undefined),
+  markMailCountsStaleForOrgMembers: vi.fn(async () => undefined),
+}))
+
+const { ThreadMutationService } = await import('../thread-mutation.service')
+const { markMailCountsStaleForOrgMembers } = await import('../mail-counts')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const THREAD_DEF = 'def_thread0000000000000000a'
+const TAG_DEF = 'def_tag00000000000000000000a'
+const THREAD_A = 'thr_cuid0000000000000000000a'
+const THREAD_B = 'thr_cuid0000000000000000000b'
+const INBOX_A = 'inb_cuid0000000000000000000a'
+const SUPPORT = `${TAG_DEF}:tag_support00000000000000a`
+const BILLING = `${TAG_DEF}:tag_billing00000000000000a`
+
+/** `db.select()` in `publishTagChanges` — the inbox/assignee lookup. */
+function makeDb(threadRows: unknown[]) {
+  const chain: Record<string, unknown> = {}
+  Object.assign(chain, {
+    from: () => chain,
+    where: () => chain,
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable query-builder mock
+    then: (ok: (v: unknown) => unknown, err?: (e: unknown) => unknown) =>
+      Promise.resolve(threadRows).then(ok, err),
+  })
+  return { select: () => chain } as never
+}
+
+function service(threadRows: unknown[]) {
+  return new ThreadMutationService(
+    ORG_ID,
+    makeDb(threadRows),
+    undefined,
+    undefined,
+    SYSTEM_VISIBILITY
+  )
+}
+
+/** Args of the last `publishThreadUpdated` call. */
+function lastPublish() {
+  const args = realtime.publishThreadUpdated.mock.calls.at(-1) as unknown as unknown[]
+  return args[2] as { threadId: string; inboxId: string | null; patch: Record<string, unknown> }
+}
+
+beforeEach(() => {
+  tagFixture.reads = []
+  realtime.publishThreadUpdated.mockClear()
+  vi.mocked(markMailCountsStaleForOrgMembers).mockClear()
+})
+
+describe('tagThreadsBulk — mail realtime', () => {
+  it('publishes thread:updated carrying the FULL resulting tag set', async () => {
+    tagFixture.reads = [new Map([[THREAD_A, [SUPPORT]]]), new Map([[THREAD_A, [SUPPORT, BILLING]]])]
+
+    await service([{ id: THREAD_A, inboxId: INBOX_A, assigneeId: null }]).tagThreadsBulk(
+      [`${THREAD_DEF}:${THREAD_A}` as never],
+      [BILLING as never],
+      'add'
+    )
+
+    expect(realtime.publishThreadUpdated).toHaveBeenCalledTimes(1)
+    // Full replacement, not a delta — the store overwrites `tagIds` wholesale.
+    expect(lastPublish().patch).toEqual({ tagIds: [SUPPORT, BILLING] })
+    expect(lastPublish()).toMatchObject({ threadId: THREAD_A, inboxId: INBOX_A })
+  })
+
+  /**
+   * Re-adding a tag a thread already carries is a deliberate no-op
+   * (mail-classification C5, "accumulate don't replace"), and a retroactive
+   * run over a backlog is mostly those. Publishing per requested thread rather
+   * than per CHANGED thread would fan thousands of empty frames per run.
+   */
+  it('publishes only for threads whose tags actually changed', async () => {
+    tagFixture.reads = [
+      new Map([
+        [THREAD_A, [SUPPORT]],
+        [THREAD_B, [SUPPORT]],
+      ]),
+      new Map([
+        [THREAD_A, [SUPPORT, BILLING]],
+        [THREAD_B, [SUPPORT]],
+      ]),
+    ]
+
+    await service([{ id: THREAD_A, inboxId: INBOX_A, assigneeId: null }]).tagThreadsBulk(
+      [`${THREAD_DEF}:${THREAD_A}` as never, `${THREAD_DEF}:${THREAD_B}` as never],
+      [BILLING as never],
+      'add'
+    )
+
+    expect(realtime.publishThreadUpdated).toHaveBeenCalledTimes(1)
+    expect(lastPublish().threadId).toBe(THREAD_A)
+  })
+
+  /** `batchGetThreadTagIds` has no ORDER BY — a reorder is not a change. */
+  it('treats a reordered tag set as unchanged', async () => {
+    tagFixture.reads = [
+      new Map([[THREAD_A, [SUPPORT, BILLING]]]),
+      new Map([[THREAD_A, [BILLING, SUPPORT]]]),
+    ]
+
+    await service([{ id: THREAD_A, inboxId: INBOX_A, assigneeId: null }]).tagThreadsBulk(
+      [`${THREAD_DEF}:${THREAD_A}` as never],
+      [BILLING as never],
+      'add'
+    )
+
+    expect(realtime.publishThreadUpdated).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Mail views filter on arbitrary conditions, tag conditions included, and
+   * `getViewCounts` counts unread threads matching them — so a tag write can
+   * move a view badge.
+   */
+  it('marks mail counts stale when tags changed, and not otherwise', async () => {
+    tagFixture.reads = [new Map(), new Map([[THREAD_A, [BILLING]]])]
+    await service([{ id: THREAD_A, inboxId: INBOX_A, assigneeId: null }]).tagThreadsBulk(
+      [`${THREAD_DEF}:${THREAD_A}` as never],
+      [BILLING as never],
+      'add'
+    )
+    expect(markMailCountsStaleForOrgMembers).toHaveBeenCalledTimes(1)
+
+    vi.mocked(markMailCountsStaleForOrgMembers).mockClear()
+    tagFixture.reads = [new Map([[THREAD_A, [BILLING]]]), new Map([[THREAD_A, [BILLING]]])]
+    await service([{ id: THREAD_A, inboxId: INBOX_A, assigneeId: null }]).tagThreadsBulk(
+      [`${THREAD_DEF}:${THREAD_A}` as never],
+      [BILLING as never],
+      'add'
+    )
+    expect(markMailCountsStaleForOrgMembers).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The tags are already committed by the time we publish, so a realtime
+   * failure degrades to "stale until reload" — it must never surface as a
+   * failed tag write to the classifier or the toolbar.
+   */
+  it('never fails the write when the publish throws', async () => {
+    tagFixture.reads = [new Map(), new Map([[THREAD_A, [BILLING]]])]
+    realtime.publishThreadUpdated.mockRejectedValueOnce(new Error('pusher down') as never)
+
+    const result = await service([
+      { id: THREAD_A, inboxId: INBOX_A, assigneeId: null },
+    ]).tagThreadsBulk([`${THREAD_DEF}:${THREAD_A}` as never], [BILLING as never], 'add')
+
+    expect(result.errors).toEqual([])
+    expect(result.created).toBe(1)
+  })
+
+  /**
+   * Separate from the case above: a rejected `publishThreadUpdated` is absorbed
+   * by `Promise.allSettled`, so only a throw BEFORE the fan-out reaches the
+   * outer catch. Without it a Redis blip on the read-back would turn every
+   * classifier tag write into a failure.
+   */
+  it('never fails the write when the tag read-back throws', async () => {
+    tagFixture.reads = [new Map(), new Error('db gone')]
+
+    const result = await service([
+      { id: THREAD_A, inboxId: INBOX_A, assigneeId: null },
+    ]).tagThreadsBulk([`${THREAD_DEF}:${THREAD_A}` as never], [BILLING as never], 'add')
+
+    expect(result.errors).toEqual([])
+    expect(result.created).toBe(1)
+    expect(realtime.publishThreadUpdated).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -9,6 +9,7 @@ import { getCachedResources, getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import { publisher } from '../events/publisher'
 import { FieldValueService } from '../field-values'
+import { batchGetThreadTagIds } from '../field-values/relationship-queries'
 import { toInboxRecordId } from '../inbox-record-ids'
 import { buildDefIdToSlug } from '../permissions/capabilities/resolve-capability-inputs'
 import type { MailViewer } from '../permissions/visibility/context'
@@ -22,6 +23,19 @@ const logger = createScopedLogger('thread-mutation-service')
 
 /** Active statuses eligible for retroactive filtering */
 const FILTERABLE_STATUSES = ['OPEN', 'ACTIVE', 'PENDING'] as const
+
+/**
+ * Order-insensitive tag-set compare. `batchGetThreadTagIds` has no `ORDER BY`,
+ * so two reads of an unchanged thread can differ in order — comparing as lists
+ * would report every thread as changed.
+ */
+function sameTagSet(a: string[] | undefined, b: string[] | undefined): boolean {
+  const before = a ?? []
+  const after = b ?? []
+  if (before.length !== after.length) return false
+  const seen = new Set(before)
+  return after.every((id) => seen.has(id))
+}
 
 /**
  * Unified thread updates interface.
@@ -1020,8 +1034,10 @@ export class ThreadMutationService {
    * Tags are stored as RELATIONSHIP field values with systemAttribute='thread_tags'.
    *
    * Delegates to FieldValueService bulk primitives so tag writes share the same
-   * inverse-sync, field-trigger, and realtime-publish path as every other
-   * relationship write (no direct FieldValue writes here).
+   * inverse-sync, field-trigger, and relationship-publish path as every other
+   * relationship write (no direct FieldValue writes here), then publishes the
+   * MAIL-side `thread:updated` itself — see {@link publishTagChanges} for why
+   * the field-value layer's own publish is not enough.
    */
   async tagThreadsBulk(
     recordIds: RecordId[],
@@ -1032,7 +1048,8 @@ export class ThreadMutationService {
       return { created: 0, skipped: 0, errors: [] }
     }
 
-    await this.assertCanActOnThreads(recordIds.map((id) => parseRecordId(id).entityInstanceId))
+    const threadIds = recordIds.map((id) => parseRecordId(id).entityInstanceId)
+    await this.assertCanActOnThreads(threadIds)
 
     logger.info(`Bulk tagging threads`, {
       operation,
@@ -1055,6 +1072,14 @@ export class ThreadMutationService {
 
       const fieldId = tagsField.id
       const fieldValueService = new FieldValueService(this.organizationId, undefined, this.db)
+
+      // Tag sets BEFORE the write. Needed because the bulk primitives report
+      // aggregate `inserted`/`skipped`/`removed` counts and never say WHICH
+      // threads moved — and re-adding a tag a thread already carries is a
+      // deliberate no-op (mail-classification C5, "accumulate don't replace"),
+      // so a run over a backlog is mostly no-ops. Diffing keeps the fan-out
+      // below proportional to what actually changed.
+      const tagsBefore = await batchGetThreadTagIds(this.db, threadIds, this.organizationId)
 
       let created = 0
       let skipped = 0
@@ -1090,6 +1115,8 @@ export class ThreadMutationService {
         created = recordIds.length * relatedRecordIds.length
       }
 
+      await this.publishTagChanges(threadIds, tagsBefore)
+
       logger.info(`Bulk thread tagging completed`, { operation, created, skipped })
       return { created, skipped, errors }
     } catch (error: unknown) {
@@ -1099,6 +1126,87 @@ export class ThreadMutationService {
       throw new Error(
         `Database error updating tags for threads: ${error instanceof Error ? error.message : error}`
       )
+    }
+  }
+
+  /**
+   * Publish the MAIL-side `thread:updated` for a tag write, carrying each
+   * changed thread's FULL resulting tag set.
+   *
+   * ⚠️ This exists because the field-value layer's own publish does not reach
+   * the mail UI. `addRelationValuesBulk` emits `fieldValues:updated` on
+   * `rooms.orgRecords(org, threadDefId)` — the per-def RECORDS channel, which
+   * only the Records grid joins (`use-resource-sync`). The mail UI subscribes to
+   * per-inbox lens channels and its dispatcher has no `fieldValues:updated`
+   * case, so before this every tag write was invisible until a reload: the
+   * classifier, the `add-tag` filter action, the workflow CRUD node, Kopilot's
+   * `update-thread`, and the bulk toolbar — whose local optimistic write hid it
+   * from the person clicking, but not from anyone else.
+   *
+   * Reads the tag set back rather than reconstructing it, so the patch is
+   * byte-for-byte what a `thread.getByIds` refetch would return (same
+   * `batchGetThreadTagIds`).
+   *
+   * Best-effort: the tags are already committed, so a realtime failure degrades
+   * to "stale until reload" and must never fail the write.
+   */
+  private async publishTagChanges(
+    threadIds: string[],
+    tagsBefore: Map<string, string[]>
+  ): Promise<void> {
+    try {
+      const tagsAfter = await batchGetThreadTagIds(this.db, threadIds, this.organizationId)
+      const changed = threadIds.filter((id) => !sameTagSet(tagsBefore.get(id), tagsAfter.get(id)))
+      if (changed.length === 0) return
+
+      // `publishThreadUpdated` fans out per inbox lens and to grantees, so it
+      // needs the thread's inbox and assignee — neither is known here, unlike
+      // in `updateBulk` where the write itself RETURNINGs them.
+      const rows = await this.db
+        .select({
+          id: schema.Thread.id,
+          inboxId: schema.Thread.inboxId,
+          assigneeId: schema.Thread.assigneeId,
+        })
+        .from(schema.Thread)
+        .where(
+          and(
+            inArray(schema.Thread.id, changed),
+            eq(schema.Thread.organizationId, this.organizationId)
+          )
+        )
+
+      const realtime = getRealtimeService()
+      // Chunked for the same reason `updateBulk` chunks: a retroactive
+      // classification run tags thousands of threads through a single call.
+      for (let i = 0; i < rows.length; i += 50) {
+        await Promise.allSettled(
+          rows.slice(i, i + 50).map((row) =>
+            publishThreadUpdated(
+              realtime,
+              this.organizationId,
+              {
+                threadId: row.id,
+                inboxId: row.inboxId ?? null,
+                assigneeId: row.assigneeId ?? null,
+                patch: { tagIds: (tagsAfter.get(row.id) ?? []) as RecordId[] },
+              },
+              { excludeSocketId: this.socketId }
+            )
+          )
+        )
+      }
+
+      // A mail view filters on arbitrary conditions, tag conditions included,
+      // and `getViewCounts` counts unread threads matching them — so a tag
+      // write can move a view's badge.
+      await this.markCountsStale()
+    } catch (error) {
+      logger.warn('Failed to publish thread tag updates', {
+        organizationId: this.organizationId,
+        threadCount: threadIds.length,
+        error: error instanceof Error ? error.message : error,
+      })
     }
   }
 


### PR DESCRIPTION
## The bug

Tags applied to a mail thread never showed up until a reload.

`tagThreadsBulk` delegates to the field-value layer, which publishes `fieldValues:updated` on `rooms.orgRecords(org, threadDefId)` — the per-def **records** channel, which only the Records grid joins (`use-resource-sync`). The mail UI subscribes to per-inbox lens channels and its dispatcher has no `fieldValues:updated` case, so the frame was published correctly into a room the mail page isn't in.

`apply.ts`'s invariant-7 comment claims the delegation "keep[s] mail counts, realtime publishes and provider label push-back correct". True for the records realtime — but there was no mail realtime for tags at all, from any caller.

## Blast radius

Not a classification bug. Every writer of thread tags had it:

- the classifier (`applyClassificationTag`) and the retroactive apply
- the `add-tag` mail-filter action
- the workflow CRUD node
- Kopilot's `update-thread` tool
- the bulk toolbar — whose local `updateThreadOptimistic` hid it from the person clicking, but not from anyone else

Classification is just the first caller where nobody was already clicking the button that papered over it.

## The fix

At `tagThreadsBulk`, the single shared write path:

- reads the tag set before the write and back after, and publishes `thread:updated` for **changed threads only** — a re-add is a deliberate no-op (classification C5), so a retroactive run over a backlog is mostly no-ops and publishing per requested thread would fan thousands of empty frames
- the patch carries the **full resulting set**, read with the same `batchGetThreadTagIds` the query path uses, so it matches what a `thread.getByIds` refetch would return
- chunked 50 at a time, for the reason `updateBulk` chunks
- `markCountsStale()`, which `tagThreadsBulk` never called — a mail view filters on arbitrary conditions including tags, and `getViewCounts` counts unread threads matching them, so a tag write can move a badge
- best-effort: tags are already committed, so a realtime failure degrades to stale-until-reload and never fails the write

`tagIds` was **already** classified metadata-tier in `THREAD_METADATA_FIELDS`, so the redaction allowlist needed nothing; only the realtime `ThreadMeta` lacked the key.

No client change needed — `setThreadPatch` shallow-spreads (so the array replaces wholesale) and already skips keys with a pending optimistic mutation, so the toolbar's own write can't be clobbered by its echo.

## Deliberately not in scope

- `tagThreadsBulk` still passes `userId: undefined` to `FieldValueService`, so thread tag writes fire **no field triggers**, for any actor. Passing the actor would newly fire record rules on every classifier tag — its own decision, not a side effect of a realtime fix.
- It also still doesn't forward `socketId` there, so the Records grid keeps echoing a writer's own tag change back at them.

## Testing

New `thread-tag-realtime.test.ts` (6 cases): full set on the wire, publishes only for changed threads, a reorder is not a change (`batchGetThreadTagIds` has no `ORDER BY`), counts stale only when changed, and both failure paths — a rejected publish (absorbed by `allSettled`) and a throwing read-back (the outer catch).

`tsc --noEmit` clean on `packages/lib`; 469 tests pass across `threads`, `realtime`, `mail-classification`, `mail-filters`, `field-values`; biome clean.

⚠️ **Not driven in a browser.** Worth two tabs on one inbox — run a classification, and tag manually from the other.