### PR TITLE
fix(mail): ask about the inbox being viewed in the classify prompt

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -230,6 +230,20 @@ function MailboxInner({
     return ids.length > 0 ? ids : undefined
   }, [contextType, inboxes, userId])
 
+  /**
+   * The inbox this view IS, when the context is a single inbox — the only two
+   * context types whose `contextId` is an inbox id. Everything else (tag, view,
+   * all-inboxes, drafts, sent, search) spans inboxes and resolves to undefined.
+   *
+   * Consumed by the classification prompt below to ask about the mailbox on
+   * screen first.
+   */
+  const activeInboxId =
+    contextType === InternalFilterContextType.SPECIFIC_INBOX ||
+    contextType === InternalFilterContextType.PERSONAL_CHANNEL
+      ? contextId
+      : undefined
+
   // For view contexts, fetch the view's saved filter conditions
   const { data: mailViewData } = api.mailView.getById.useQuery(
     { id: contextId! },
@@ -636,7 +650,7 @@ function MailboxInner({
               one wins. The component enforces it by returning null while a
               filter prompt is pending, but keeping them adjacent here is what
               makes that rule visible to whoever edits this file next. */}
-            <MailClassificationRetroactivePrompt />
+            <MailClassificationRetroactivePrompt activeInboxId={activeInboxId} />
             {/* Unified responsive tree: viewport differences driven by Tailwind
               media queries (sm = 640px). Only layoutMode drives JS branching. */}
             <div

--- a/apps/web/src/components/inbox/ui/mail-classification-retroactive-prompt.tsx
+++ b/apps/web/src/components/inbox/ui/mail-classification-retroactive-prompt.tsx
@@ -33,13 +33,26 @@ import { InboxReclassifyDialog } from './inbox-reclassify-dialog'
  * mail" reads as "apply my automations to old mail" to most people, and the
  * honest correction belongs at the point of action, not in a tooltip.
  */
-export function MailClassificationRetroactivePrompt() {
+export function MailClassificationRetroactivePrompt({
+  activeInboxId,
+}: {
+  /**
+   * The inbox being VIEWED, when the current mail context is one inbox. Only a
+   * preference — the server reorders its candidates and still asks about
+   * another inbox when this one has no backlog, so search / drafts / all-inboxes
+   * (which pass nothing) keep the prompt. Without it the banner sits in the same
+   * slot for every view and names whichever inbox sorted first, which reads as a
+   * claim about the mail on screen.
+   */
+  activeInboxId?: string
+}) {
   const utils = api.useUtils()
   const [dialogOpen, setDialogOpen] = useState(false)
 
-  const { data: prompt } = api.mailClassification.pendingRetroactivePrompt.useQuery(undefined, {
-    staleTime: 60_000,
-  })
+  const { data: prompt } = api.mailClassification.pendingRetroactivePrompt.useQuery(
+    { inboxId: activeInboxId },
+    { staleTime: 60_000 }
+  )
 
   /**
    * ⚠️ **07 §3.4 — TWO PROMPTS MUST NEVER STACK.**

--- a/apps/web/src/server/api/routers/mail-classification.ts
+++ b/apps/web/src/server/api/routers/mail-classification.ts
@@ -769,24 +769,35 @@ export const mailClassificationRouter = createTRPCRouter({
    * Scoped to the caller's configurable inboxes minus their own dismissals, so
    * the lib call holds no permission logic — the house rule, and the same shape
    * `mailFilters.pendingRetroactivePrompt` uses.
+   *
+   * `inboxId` is the inbox the caller is currently VIEWING, and it only ever
+   * reorders the candidates — the banner names the inbox it is about, and asking
+   * about a different one while someone reads this mailbox looks like a
+   * statement about the mail in front of them. It is not a scope: a view with no
+   * inbox of its own (search, drafts, all-inboxes) passes nothing and still gets
+   * asked. ⚠️ It grants nothing either — the preference applies AFTER the
+   * authority filter, so an id the caller cannot configure changes no answer.
    */
-  pendingRetroactivePrompt: capabilityProcedure.query(async ({ ctx }) => {
-    const authority = await loadMailFilterAuthority(ctx)
-    if (authority.inboxIds.length === 0) return null
+  pendingRetroactivePrompt: capabilityProcedure
+    .input(z.object({ inboxId: z.string().min(1).optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      const authority = await loadMailFilterAuthority(ctx)
+      if (authority.inboxIds.length === 0) return null
 
-    const dismissed = await readDismissedClassifyPromptInboxIds(ctx)
-    const candidates = authority.inboxIds.filter((id) => !dismissed.includes(id))
-    if (candidates.length === 0) return null
+      const dismissed = await readDismissedClassifyPromptInboxIds(ctx)
+      const candidates = authority.inboxIds.filter((id) => !dismissed.includes(id))
+      if (candidates.length === 0) return null
 
-    const prompt = await findPendingClassificationPrompt(
-      ctx.db,
-      ctx.session.organizationId,
-      candidates
-    )
-    if (!prompt) return null
+      const prompt = await findPendingClassificationPrompt(
+        ctx.db,
+        ctx.session.organizationId,
+        candidates,
+        { preferredInboxId: input?.inboxId }
+      )
+      if (!prompt) return null
 
-    return { ...prompt, inboxName: authority.byId.get(prompt.inboxId)?.name ?? '' }
-  }),
+      return { ...prompt, inboxName: authority.byId.get(prompt.inboxId)?.name ?? '' }
+    }),
 
   /** Stop asking this member about this inbox. */
   dismissRetroactivePrompt: capabilityProcedure

--- a/packages/lib/src/mail-classification/retroactive.test.ts
+++ b/packages/lib/src/mail-classification/retroactive.test.ts
@@ -46,6 +46,7 @@ import {
   buildReclassifyWhere,
   countReclassifiableThreads,
   enqueueMailReclassifySample,
+  findPendingClassificationPrompt,
   mailReclassifySampleJobId,
   resolveReclassifyWindow,
   runMailReclassifySample,
@@ -760,5 +761,93 @@ describe('enqueueMailReclassifySample — the queue contract (§2.2)', () => {
     expect(h.jobRemove).toHaveBeenCalledTimes(1)
     expect(h.queueAdd).toHaveBeenCalledTimes(1)
     expect(result.deduplicated).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The banner mounts in a fixed slot for EVERY mail view and names the inbox it
+ * is about, so which candidate wins is user-visible: without a preference it
+ * asked about whichever inbox sorted first, which reads — to someone sitting in
+ * a different mailbox — as a claim about the mail on screen.
+ *
+ * A REORDER, never a filter, and never a grant: it lands after the caller's
+ * authorized candidate list has already been narrowed.
+ */
+describe('findPendingClassificationPrompt — the viewed inbox goes first (§3.4)', () => {
+  const INBOX_B = 'ibx_2'
+
+  /** `db.select()` for the synced-channel probe + `db.execute()` for the counts. */
+  function promptDb(syncedInboxIds: string[], countsByInbox: Record<string, number>) {
+    const rows = syncedInboxIds.map((inboxId) => ({ inboxId }))
+    const chain: Record<string, unknown> = {}
+    Object.assign(chain, {
+      from: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable query-builder mock
+      then: (ok: (v: unknown) => unknown, err?: (e: unknown) => unknown) =>
+        Promise.resolve(rows).then(ok, err),
+    })
+    // The count query renders the inbox id inline, so the fake reads it back out
+    // of the SQL rather than relying on call order.
+    const execute = vi.fn(async (fragment: SQL) => {
+      const sql = render(fragment)
+      const params = JSON.stringify(sql.params)
+      const inboxId = Object.keys(countsByInbox).find((id) => params.includes(id))
+      return { rows: [{ count: inboxId ? (countsByInbox[inboxId] ?? 0) : 0 }] }
+    })
+    return { select: () => chain, execute } as unknown as Database
+  }
+
+  beforeEach(() => {
+    h.getOrgCache.mockReturnValue({
+      get: vi.fn(async () => ({ mailClassificationInboxIds: [INBOX, INBOX_B] })),
+    })
+  })
+
+  it('asks about the viewed inbox when it has a backlog', async () => {
+    const db = promptDb([INBOX, INBOX_B], { [INBOX]: 40, [INBOX_B]: 900 })
+
+    const prompt = await findPendingClassificationPrompt(db, ORG, [INBOX, INBOX_B], {
+      preferredInboxId: INBOX_B,
+    })
+
+    expect(prompt).toMatchObject({ inboxId: INBOX_B, threadCount: 900 })
+  })
+
+  // The preference is not a scope — a view whose own inbox is already clean
+  // should still surface the inbox that is not.
+  it('falls back to another candidate when the viewed inbox has none', async () => {
+    const db = promptDb([INBOX, INBOX_B], { [INBOX]: 40, [INBOX_B]: 0 })
+
+    const prompt = await findPendingClassificationPrompt(db, ORG, [INBOX, INBOX_B], {
+      preferredInboxId: INBOX_B,
+    })
+
+    expect(prompt).toMatchObject({ inboxId: INBOX, threadCount: 40 })
+  })
+
+  // ⚠️ The preference must never widen the answer. `candidateInboxIds` is the
+  // caller's authorized set; an id outside it is inert, not an existence oracle.
+  it('ignores an inbox the caller was not already a candidate for', async () => {
+    const db = promptDb([INBOX], { [INBOX]: 40, ibx_other: 900 })
+
+    const prompt = await findPendingClassificationPrompt(db, ORG, [INBOX], {
+      preferredInboxId: 'ibx_other',
+    })
+
+    expect(prompt).toMatchObject({ inboxId: INBOX })
+  })
+
+  // Search, drafts and all-inboxes span inboxes and pass nothing — discovery
+  // must not depend on standing in the right mailbox.
+  it('still asks when no inbox is being viewed', async () => {
+    const db = promptDb([INBOX, INBOX_B], { [INBOX]: 40, [INBOX_B]: 900 })
+
+    const prompt = await findPendingClassificationPrompt(db, ORG, [INBOX, INBOX_B])
+
+    expect(prompt).toMatchObject({ inboxId: INBOX })
   })
 })

--- a/packages/lib/src/mail-classification/retroactive.ts
+++ b/packages/lib/src/mail-classification/retroactive.ts
@@ -1592,7 +1592,7 @@ export async function findPendingClassificationPrompt(
   db: Database,
   organizationId: string,
   candidateInboxIds: string[],
-  opts: { threadCountCap?: number } = {}
+  opts: { threadCountCap?: number; preferredInboxId?: string } = {}
 ): Promise<PendingClassificationPrompt | null> {
   if (candidateInboxIds.length === 0) return null
   const cap = Math.max(1, Math.trunc(opts.threadCountCap ?? MAIL_RECLASSIFY_BACKLOG_COUNT_CAP))
@@ -1601,8 +1601,25 @@ export async function findPendingClassificationPrompt(
   if (labels.length === 0) return null
 
   const optedIn = new Set(await getOptedInInboxIds(organizationId))
-  const candidates = candidateInboxIds.filter((id) => optedIn.has(id))
+  let candidates = candidateInboxIds.filter((id) => optedIn.has(id))
   if (candidates.length === 0) return null
+
+  /**
+   * The inbox the caller is currently LOOKING at goes first, when it is one of
+   * the candidates. The banner mounts in a fixed slot for every mail view and
+   * names the inbox it is about, so without this it asks about whichever inbox
+   * happened to sort first — reading, to anyone in a different mailbox, as a
+   * statement about the mail in front of them.
+   *
+   * ⚠️ A REORDER, never a filter, and it runs AFTER the authority-derived
+   * `candidateInboxIds` have been narrowed — so an id the caller may not
+   * configure is inert here rather than an existence oracle, and a view with no
+   * inbox of its own (search, drafts, all-inboxes) still gets the prompt.
+   */
+  const preferred = opts.preferredInboxId
+  if (preferred && candidates.includes(preferred)) {
+    candidates = [preferred, ...candidates.filter((id) => id !== preferred)]
+  }
 
   // R-Q8 again: an inbox still filling up must not be prompted, because the run
   // it invites would miss everything still arriving.


### PR DESCRIPTION
## The bug

The *"Classify 1,000+ existing conversations in `<inbox>`?"* banner showed the same inbox no matter which mailbox you were reading.

It isn't scoped to the view at all:

- `mail-box.tsx` mounts `<MailClassificationRetroactivePrompt />` unconditionally, in a fixed slot above the thread list — every inbox, every saved view, search, drafts.
- The component called `pendingRetroactivePrompt.useQuery(undefined, …)` — **no inbox argument**. It has no idea what you're looking at.
- The router starts from every inbox you may configure automation on, drops your dismissals, and `findPendingClassificationPrompt` **returns on the first candidate that qualifies**, in the inboxes-cache order.

So the named inbox was just whichever one sorted first. Enable classification on another channel and the banner switches to that one — which is how this got noticed.

## The fix

`findPendingClassificationPrompt` takes an optional `preferredInboxId` and moves it to the front of the candidate list. The router accepts an optional `{ inboxId }` and forwards it; the component takes an `activeInboxId` prop; `mail-box` derives it from the mail context — `SPECIFIC_INBOX` and `PERSONAL_CHANNEL` are the only two context types whose `contextId` is an inbox id. Tag, view, all-inboxes, drafts, sent and search span inboxes and pass nothing.

Two properties worth stating, because both are easy to break later:

- **A reorder, not a filter.** A view whose own inbox is already clean still surfaces the inbox that isn't, so discovery doesn't depend on standing in the right mailbox.
- **Never a grant.** The preference applies *after* the authority-derived candidates are narrowed, so an id the caller cannot configure changes no answer and can't act as an existence oracle for someone else's personal mailbox.

## Known follow-up

`MailFilterRetroactivePrompt` has the identical problem — `useQuery(undefined)`, same slot, same "in {inboxName}?" sentence. And since the filter prompt **wins** the stacking rule, a mismatched filter banner will still suppress a correctly-targeted classification one. Same three-line fix, left out to keep this scoped.

## Testing

Four new cases in `retroactive.test.ts`: asks about the viewed inbox when it has a backlog, falls back to another candidate when the viewed one is clean, ignores a non-candidate id, still asks when no inbox is being viewed.

`tsc --noEmit` clean on `packages/lib` and `apps/web` (lib rebuilt first so web sees the new signature); 137 lib mail-classification tests and 83 web inbox/router tests pass; biome clean.

⚠️ Not driven in a browser.

Note: the query key now varies per inbox, so switching inboxes is a fresh fetch rather than a cache hit — one small query per inbox per minute at the existing `staleTime: 60_000`.