### PR TITLE
feat(mail): return a summary and a candidate tag from the classify call

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -642,7 +642,7 @@ function MailboxInner({
               mail the question is about, rather than in settings: the person who
               should answer is the one staring at the unfiltered inbox. Renders
               nothing when there is nothing to ask. */}
-            <MailFilterRetroactivePrompt />
+            <MailFilterRetroactivePrompt activeInboxId={activeInboxId} />
             {/* Post-sync classification prompt (07-mail-reclassification-plan.md
               §3.4) — "classify N existing conversations?". Same slot and same
               reasoning as the filter prompt above.

--- a/apps/web/src/components/mail-filters/ui/mail-filter-retroactive-prompt.tsx
+++ b/apps/web/src/components/mail-filters/ui/mail-filter-retroactive-prompt.tsx
@@ -6,6 +6,7 @@ import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
 import { Filter, X } from 'lucide-react'
+import Link from 'next/link'
 import { useState } from 'react'
 import { api } from '~/trpc/react'
 
@@ -26,14 +27,31 @@ import { api } from '~/trpc/react'
  *
  * Mounted in the mail UI rather than in settings: the person who should answer
  * is the one looking at the unfiltered mail.
+ *
+ * ⚠️ **"The one looking at the mail" was aspirational until the `activeInboxId`
+ * preference landed.** The query took no inbox, so the banner named whichever
+ * authorable inbox sorted first and rendered in a fixed slot above EVERY mail
+ * view — putting a one-click bulk mutation on a mailbox the reader was not in.
+ * See `07-…`§7.10.
  */
-export function MailFilterRetroactivePrompt() {
+export function MailFilterRetroactivePrompt({
+  activeInboxId,
+}: {
+  /**
+   * The inbox being VIEWED, when the current mail context is one inbox. Only a
+   * preference — the server reorders its candidates and still asks about
+   * another inbox when this one has nothing pending, so search / drafts /
+   * all-inboxes (which pass nothing) keep the prompt.
+   */
+  activeInboxId?: string
+}) {
   const utils = api.useUtils()
   const [applying, setApplying] = useState(false)
 
-  const { data: prompt } = api.mailFilters.pendingRetroactivePrompt.useQuery(undefined, {
-    staleTime: 60_000,
-  })
+  const { data: prompt } = api.mailFilters.pendingRetroactivePrompt.useQuery(
+    { inboxId: activeInboxId },
+    { staleTime: 60_000 }
+  )
   // Scoped to the caller's authorable inboxes by the router, so this is the same
   // set the prompt is drawn from.
   const { data: filters } = api.mailFilters.list.useQuery(undefined, { enabled: !!prompt })
@@ -83,6 +101,25 @@ export function MailFilterRetroactivePrompt() {
   const filterLabel = prompt.filterCount === 1 ? 'filter' : 'filters'
   const inboxName = prompt.inboxName || 'this inbox'
 
+  /**
+   * ⚠️ **One click only applies to the mailbox you are looking at.**
+   *
+   * The preference above makes a mismatch rare, not impossible — a view that
+   * spans inboxes passes no id at all, and the inbox you are in may have nothing
+   * pending while another does. In those cases the banner is still worth showing
+   * (that is the whole discovery argument), but "Apply now" is not: this button
+   * assigns, archives and moves across a whole mailbox's history, and offering
+   * that in one click for a mailbox that is not on screen is the mistake this
+   * component's own doc comment warns about.
+   *
+   * So off-target, the action degrades to navigation. Same question, same
+   * banner — you just have to be looking at the mail before you can mutate it.
+   */
+  const isActiveInbox = prompt.inboxId === activeInboxId
+  const inboxHref = prompt.isPersonal
+    ? `/app/mail/personal/${prompt.inboxId}/open`
+    : `/app/mail/inboxes/${prompt.inboxId}/unassigned`
+
   return (
     <div className='shrink-0 bg-secondary px-2 pt-2 max-sm:dark:bg-primary-100 sm:dark:bg-muted-50'>
       <Alert variant='blue' className='flex flex-col gap-2 sm:flex-row sm:items-center'>
@@ -101,15 +138,21 @@ export function MailFilterRetroactivePrompt() {
           </div>
         </div>
         <div className='flex shrink-0 items-center gap-1 self-end sm:self-auto'>
-          <Button
-            variant='outline'
-            size='sm'
-            loading={applying}
-            loadingText='Starting...'
-            disabled={applicable.length === 0}
-            onClick={() => void handleApply()}>
-            Apply now
-          </Button>
+          {isActiveInbox ? (
+            <Button
+              variant='outline'
+              size='sm'
+              loading={applying}
+              loadingText='Starting...'
+              disabled={applicable.length === 0}
+              onClick={() => void handleApply()}>
+              Apply now
+            </Button>
+          ) : (
+            <Button variant='outline' size='sm' asChild>
+              <Link href={inboxHref}>Review in {inboxName}</Link>
+            </Button>
+          )}
           <Button
             variant='ghost'
             size='sm'

--- a/apps/web/src/server/api/routers/mail-filters.test.ts
+++ b/apps/web/src/server/api/routers/mail-filters.test.ts
@@ -1508,8 +1508,38 @@ describe('mailFilters router — the retroactive prompt is per-user', () => {
     expect(lib.findPendingRetroactivePrompt).toHaveBeenCalledWith(
       expect.anything(),
       ORG_ID,
-      expect.not.arrayContaining([OTHER_PERSONAL, LEGACY_PERSONAL])
+      expect.not.arrayContaining([OTHER_PERSONAL, LEGACY_PERSONAL]),
+      expect.anything()
     )
+  })
+
+  /**
+   * ⚠️ The viewed-inbox preference must not be able to WIDEN the answer. It is
+   * forwarded verbatim, and the narrowing that protects a colleague's personal
+   * mailbox stays in the candidate list — so a caller naming an inbox they may
+   * not author on gets the same candidates and the same answer.
+   */
+  it('forwards the viewed inbox as a preference without widening the candidates', async () => {
+    await caller(USER_ID).pendingRetroactivePrompt({ inboxId: OTHER_PERSONAL })
+
+    expect(lib.findPendingRetroactivePrompt).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG_ID,
+      expect.not.arrayContaining([OTHER_PERSONAL, LEGACY_PERSONAL]),
+      { preferredInboxId: OTHER_PERSONAL }
+    )
+  })
+
+  /** The client needs it to build the route, and the two live under different paths. */
+  it('reports whether the prompted inbox is personal', async () => {
+    world.writableInboxIds.add(OWN_PERSONAL)
+    world.promptInboxIds.clear()
+    world.promptInboxIds.add(OWN_PERSONAL)
+
+    expect(await caller(USER_ID).pendingRetroactivePrompt()).toMatchObject({
+      inboxId: OWN_PERSONAL,
+      isPersonal: true,
+    })
   })
 
   it('answers null without touching settings for a caller who owns no inbox', async () => {

--- a/apps/web/src/server/api/routers/mail-filters.ts
+++ b/apps/web/src/server/api/routers/mail-filters.ts
@@ -576,21 +576,38 @@ export const mailFiltersRouter = createTRPCRouter({
    *
    * Scoped to the caller's authorable inboxes, so it can never surface someone
    * else's personal mailbox.
+   *
+   * `inboxId` is the inbox the caller is currently VIEWING, and it only ever
+   * reorders the candidates — the banner names the inbox it is about, and its
+   * button MUTATES, so asking about a different mailbox than the one on screen
+   * puts a bulk apply one click from the wrong target. It is not a scope: a view
+   * with no inbox of its own (search, drafts, all-inboxes) passes nothing and
+   * still gets asked. ⚠️ It grants nothing either — the preference applies AFTER
+   * the authority filter, so an id the caller cannot author on changes no answer.
+   *
+   * `isPersonal` rides along so the client can build the right route to the
+   * inbox: personal mailboxes live under `/app/mail/personal/{id}`, shared ones
+   * under `/app/mail/inboxes/{id}`.
    */
-  pendingRetroactivePrompt: capabilityProcedure.query(async ({ ctx }) => {
-    const organizationId = ctx.session.organizationId
-    const authority = await loadMailFilterAuthority(ctx)
-    if (authority.inboxIds.length === 0) return null
+  pendingRetroactivePrompt: capabilityProcedure
+    .input(z.object({ inboxId: z.string().min(1).optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      const organizationId = ctx.session.organizationId
+      const authority = await loadMailFilterAuthority(ctx)
+      if (authority.inboxIds.length === 0) return null
 
-    const dismissed = await readDismissedPromptInboxIds(ctx)
-    const candidates = authority.inboxIds.filter((id) => !dismissed.includes(id))
-    if (candidates.length === 0) return null
+      const dismissed = await readDismissedPromptInboxIds(ctx)
+      const candidates = authority.inboxIds.filter((id) => !dismissed.includes(id))
+      if (candidates.length === 0) return null
 
-    const prompt = await findPendingRetroactivePrompt(ctx.db, organizationId, candidates)
-    if (!prompt) return null
+      const prompt = await findPendingRetroactivePrompt(ctx.db, organizationId, candidates, {
+        preferredInboxId: input?.inboxId,
+      })
+      if (!prompt) return null
 
-    return { ...prompt, inboxName: authority.byId.get(prompt.inboxId)?.name ?? '' }
-  }),
+      const inbox = authority.byId.get(prompt.inboxId)
+      return { ...prompt, inboxName: inbox?.name ?? '', isPersonal: inbox?.isPersonal ?? false }
+    }),
 
   /** Wave the post-connect prompt away for one inbox, for this member only. */
   dismissRetroactivePrompt: capabilityProcedure

--- a/packages/lib/src/mail-classification/apply.ts
+++ b/packages/lib/src/mail-classification/apply.ts
@@ -17,8 +17,34 @@ import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
 import { and, eq, sql } from 'drizzle-orm'
 import { MAIL_CLASSIFICATION_METADATA_KEY, type MailClassificationMarker } from './client'
+import type { MailClassificationResult } from './types'
 
 const logger = createScopedLogger('mail-classification')
+
+/**
+ * The marker for a completed inference.
+ *
+ * ⚠️ Exists so the live job and the retroactive run cannot drift. They stamp the
+ * same marker for the same reason, and the two call sites were byte-identical
+ * blocks — which meant every field added to the marker had to be added twice, and
+ * a miss would show up only as "the backfill produced no summaries" long after
+ * the fact.
+ *
+ * Callers must still gate on `result.inferred` themselves (`05-…§12.6`): a
+ * marker for a call that never completed disqualifies the message from
+ * classification forever, and that decision belongs at the call site where the
+ * skip is also counted.
+ */
+export function toClassificationMarker(result: MailClassificationResult): MailClassificationMarker {
+  return {
+    at: new Date().toISOString(),
+    tagId: result.tagId,
+    confidence: result.confidence,
+    ...(result.model ? { model: result.model } : {}),
+    ...(result.messageSummary ? { messageSummary: result.messageSummary } : {}),
+    ...(result.altTagName ? { altTagName: result.altTagName } : {}),
+  }
+}
 
 /**
  * Apply one classifier-chosen tag to a thread.

--- a/packages/lib/src/mail-classification/classify.test.ts
+++ b/packages/lib/src/mail-classification/classify.test.ts
@@ -41,7 +41,12 @@ vi.mock('../ai/usage/usage-tracking-service', () => ({
 
 import { QuotaExceededError } from '../ai/errors/quota-errors'
 import { buildClassificationPrompt, buildClassificationSchema, classifyMessage } from './classify'
-import { MAIL_CLASSIFY_BODY_CHARS, MAIL_CLASSIFY_NO_CATEGORY } from './client'
+import {
+  MAIL_CLASSIFY_ALT_TAG_CHARS,
+  MAIL_CLASSIFY_BODY_CHARS,
+  MAIL_CLASSIFY_NO_CATEGORY,
+  MAIL_CLASSIFY_SUMMARY_CHARS,
+} from './client'
 import type { MailClassificationContext } from './types'
 
 const context: MailClassificationContext = {
@@ -67,8 +72,36 @@ describe('the structured-output schema (invariant 12)', () => {
   it('is an OBJECT with a `category` field, not a bare id', () => {
     const schema = buildClassificationSchema(context.labels)
     expect(schema.schema.type).toBe('object')
-    expect(Object.keys(schema.schema.properties)).toEqual(['category', 'confidence'])
-    expect(schema.schema.required).toEqual(['category', 'confidence'])
+    expect(Object.keys(schema.schema.properties)).toEqual([
+      'category',
+      'confidence',
+      'messageSummary',
+      'altTagName',
+    ])
+  })
+
+  it('⚠️ requires EVERY property — "optional" does not survive the provider layer (08 T2)', () => {
+    const schema = buildClassificationSchema(context.labels)
+    // `openai-llm-client.ts` overwrites `required` with `Object.keys(properties)`
+    // while `anthropic-llm-client.ts` passes ours through to the forced tool's
+    // `input_schema` untouched. Declaring a property optional therefore means a
+    // different contract per provider, decided by the org's default model. The
+    // absent case is carried as a VALUE (`''`, and `__none__` for `category`).
+    expect(schema.schema.required).toEqual(Object.keys(schema.schema.properties))
+  })
+
+  it('states lengths in prose, never as a `maxLength` keyword (not portable under strict)', () => {
+    const schema = buildClassificationSchema(context.labels)
+    expect(schema.schema.properties.messageSummary).not.toHaveProperty('maxLength')
+    expect(schema.schema.properties.altTagName).not.toHaveProperty('maxLength')
+    expect(schema.schema.properties.messageSummary.description).toContain(
+      String(MAIL_CLASSIFY_SUMMARY_CHARS)
+    )
+  })
+
+  it('keeps `category` first, so the decision is generated before the extras', () => {
+    const schema = buildClassificationSchema(context.labels)
+    expect(Object.keys(schema.schema.properties)[0]).toBe('category')
   })
 
   it('enumerates the eligible TAG IDS plus the abstention sentinel — never free text', () => {
@@ -179,6 +212,148 @@ describe('classifyMessage — the model cannot return a non-eligible id', () => 
       confidence: 0,
       reason: 'no-category',
     })
+  })
+})
+
+describe('classifyMessage — the summary and the candidate label (08 phase 1)', () => {
+  it('captures the summary on an applied classification', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: 'tag_billing',
+        confidence: 0.9,
+        messageSummary: 'The customer wants a refund for a duplicate charge.',
+        altTagName: '',
+      },
+    })
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: 'tag_billing',
+      messageSummary: 'The customer wants a refund for a duplicate charge.',
+    })
+  })
+
+  it('captures the candidate label when the model abstained', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: MAIL_CLASSIFY_NO_CATEGORY,
+        confidence: 0.95,
+        messageSummary: 'The sender is asking about a wholesale account.',
+        altTagName: 'wholesale enquiry',
+      },
+    })
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: null,
+      reason: 'no-category',
+      altTagName: 'wholesale enquiry',
+    })
+  })
+
+  it('captures it on a BELOW-THRESHOLD pick too — the boundary is the signal (08 T3)', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: 'tag_billing',
+        confidence: 0.55,
+        messageSummary: 'A chargeback notice from the payment processor.',
+        altTagName: 'chargeback',
+      },
+    })
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: null,
+      reason: 'below-threshold',
+      altTagName: 'chargeback',
+    })
+  })
+
+  it('⚠️ DROPS the candidate label when a tag was actually applied', async () => {
+    // The prompt says to leave it empty when a category fitted; a model that
+    // fills it in anyway must not seed the miner with candidates arguing for
+    // tags the org demonstrably already has.
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: 'tag_billing',
+        confidence: 0.95,
+        messageSummary: 'A refund request.',
+        altTagName: 'refunds',
+      },
+    })
+
+    const result = await classifyMessage(db, context)
+    expect(result.tagId).toBe('tag_billing')
+    expect(result).not.toHaveProperty('altTagName')
+  })
+
+  it('treats the empty-string sentinel as "nothing to record", not as a value', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: MAIL_CLASSIFY_NO_CATEGORY,
+        confidence: 0.9,
+        messageSummary: '   ',
+        altTagName: '',
+      },
+    })
+
+    const result = await classifyMessage(db, context)
+    expect(result).not.toHaveProperty('altTagName')
+    expect(result).not.toHaveProperty('messageSummary')
+  })
+
+  it('clamps both in TypeScript — the schema states the limit, the clamp holds it', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: MAIL_CLASSIFY_NO_CATEGORY,
+        confidence: 0.9,
+        messageSummary: 'y'.repeat(MAIL_CLASSIFY_SUMMARY_CHARS + 400),
+        altTagName: 'z'.repeat(MAIL_CLASSIFY_ALT_TAG_CHARS + 40),
+      },
+    })
+
+    const result = await classifyMessage(db, context)
+    expect(result.messageSummary).toHaveLength(MAIL_CLASSIFY_SUMMARY_CHARS)
+    expect(result.altTagName).toHaveLength(MAIL_CLASSIFY_ALT_TAG_CHARS)
+  })
+
+  it('survives wrong types without becoming a failure arm (invariant 6)', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: 'tag_billing',
+        confidence: 0.9,
+        messageSummary: { not: 'a string' },
+        altTagName: 42,
+      },
+    })
+
+    await expect(classifyMessage(db, context)).resolves.toMatchObject({
+      tagId: 'tag_billing',
+      inferred: true,
+    })
+  })
+
+  it('captures NOTHING when the call failed — same gate as the tag', async () => {
+    h.invoke.mockRejectedValue(new Error('429'))
+
+    const result = await classifyMessage(db, context)
+    expect(result.inferred).toBe(false)
+    expect(result).not.toHaveProperty('messageSummary')
+    expect(result).not.toHaveProperty('altTagName')
+  })
+
+  it('logs the candidate label but NOT the summary (customer prose stays out of logs)', async () => {
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: MAIL_CLASSIFY_NO_CATEGORY,
+        confidence: 0.9,
+        messageSummary: 'A wholesale enquiry from a boutique.',
+        altTagName: 'wholesale enquiry',
+      },
+    })
+
+    await classifyMessage(db, context)
+
+    const logged = h.info.mock.calls.find(([msg]) => msg === 'Mail classification result')?.[1]
+    expect(logged).toMatchObject({ altTagName: 'wholesale enquiry', hasSummary: true })
+    expect(JSON.stringify(logged)).not.toContain('boutique')
   })
 })
 

--- a/packages/lib/src/mail-classification/classify.ts
+++ b/packages/lib/src/mail-classification/classify.ts
@@ -20,20 +20,31 @@ import { UsageTrackingService } from '../ai/usage/usage-tracking-service'
 import { getCachedDefaultModel } from '../cache'
 import { UsageLimitError } from '../errors'
 import {
+  MAIL_CLASSIFY_ALT_TAG_CHARS,
   MAIL_CLASSIFY_BODY_CHARS,
   MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
   MAIL_CLASSIFY_NO_CATEGORY,
+  MAIL_CLASSIFY_SUMMARY_CHARS,
   type MailClassificationLabel,
 } from './client'
 import type { MailClassificationContext, MailClassificationResult } from './types'
 
 const logger = createScopedLogger('mail-classification')
 
+// ⚠️ The confidence sentence stays LAST (08 §3.2). The two additions below it
+// describe outputs that are recorded and never acted on; the confidence rule
+// governs the only decision this call actually makes, and burying it under
+// secondary instructions is how a prompt quietly stops abstaining.
 const SYSTEM_PROMPT = [
   'You categorise inbound customer email for a help desk.',
   'Choose exactly ONE category from the list, or the sentinel value when none of',
   'them fits. Each category is defined by its description, so classify against the',
   'description, not against the label wording.',
+  'Also summarise the mail in one short sentence describing what the sender wants.',
+  'If — and only if — no category fitted, or you were unsure of the one you chose,',
+  'name the topic you would have used, as a short lowercase noun phrase of at most',
+  'three words. It is recorded for a human to review and is applied to nothing.',
+  'Leave it empty whenever a category fitted.',
   'Report your confidence as a number between 0 and 1. Be honest: a low',
   'confidence means the mail is not applied to any category at all, which is the',
   'correct outcome for ambiguous mail.',
@@ -52,6 +63,28 @@ const SYSTEM_PROMPT = [
  * {@link MAIL_CLASSIFY_NO_CATEGORY} is a member of the same enum: under `strict`
  * a nullable enum is not portable across providers, so abstention has to be a
  * legal value rather than an absent one.
+ *
+ * ⚠️ **EVERY property is `required`, and "absent" is carried as a value** — the
+ * empty string for `altTagName`, exactly as `__none__` carries it for `category`
+ * (08 T2). Declaring a property optional does NOT survive the provider layer and
+ * fails differently per provider, silently:
+ *  • `openai-llm-client.ts` OVERWRITES the array —
+ *    `required = Object.keys(properties)` — so an optional property is mandatory
+ *    by the time the request leaves; while
+ *  • `anthropic-llm-client.ts` unwraps this same schema into a forced synthetic
+ *    tool's `input_schema` and passes `required` through untouched, where it
+ *    really is optional.
+ * An "optional" field therefore means a different contract depending on which
+ * default model the org happens to have picked. Requiring everything makes the
+ * two providers agree by construction rather than by luck.
+ *
+ * Lengths are stated for the model's benefit only — a `maxLength` keyword is not
+ * portable under `strict`, so the clamp in {@link clampText} is what holds.
+ *
+ * Property ORDER is the generation order under strict structured outputs, and
+ * `category` deliberately stays first: summarising before deciding would likely
+ * classify better (a free reasoning step), but it changes the decision on a
+ * shipped feature, so it belongs in a measured follow-up rather than here.
  */
 export function buildClassificationSchema(labels: MailClassificationLabel[]) {
   return {
@@ -60,7 +93,7 @@ export function buildClassificationSchema(labels: MailClassificationLabel[]) {
     schema: {
       type: 'object',
       additionalProperties: false,
-      required: ['category', 'confidence'],
+      required: ['category', 'confidence', 'messageSummary', 'altTagName'],
       properties: {
         category: {
           type: 'string',
@@ -71,9 +104,38 @@ export function buildClassificationSchema(labels: MailClassificationLabel[]) {
           type: 'number',
           description: 'Confidence in the chosen category, from 0 to 1.',
         },
+        messageSummary: {
+          type: 'string',
+          description: `One short sentence describing what the sender wants, at most ${MAIL_CLASSIFY_SUMMARY_CHARS} characters. Summarise only this message.`,
+        },
+        altTagName: {
+          type: 'string',
+          description:
+            `A short lowercase noun phrase of at most three words naming the topic you would have used, ONLY when no category fitted or you were unsure of the one you chose. ` +
+            `The empty string whenever a category fitted. It is recorded for review and applied to nothing.`,
+        },
       },
     },
   }
+}
+
+/**
+ * Trim a model-supplied string to a hard ceiling, or `undefined` when there is
+ * nothing usable.
+ *
+ * ⚠️ The empty string is `undefined` here, and that is the whole abstention
+ * protocol for `altTagName` (08 T2): the field is mandatory on the wire, so
+ * "nothing to say" arrives as `''` rather than as an absent key.
+ *
+ * Verbatim otherwise — no lowercasing, no punctuation stripping. Normalization
+ * belongs to the miner (08 T5), and doing it here would bake today's clustering
+ * strategy into rows that outlive it.
+ */
+function clampText(raw: unknown, max: number): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  return trimmed.length > max ? trimmed.slice(0, max).trimEnd() : trimmed
 }
 
 /**
@@ -269,8 +331,22 @@ export async function classifyMessage(
 
   const applied = category !== null && confidence >= MAIL_CLASSIFY_CONFIDENCE_THRESHOLD
 
+  const messageSummary = clampText(structured?.messageSummary, MAIL_CLASSIFY_SUMMARY_CHARS)
+  // ⚠️ Dropped outright when a tag was applied (08 T3), rather than trusted from
+  // the prompt. The instruction says "leave it empty whenever a category fitted",
+  // and a model that fills it in anyway would seed the miner with candidates
+  // arguing for tags the org demonstrably already has.
+  const altTagName = applied
+    ? undefined
+    : clampText(structured?.altTagName, MAIL_CLASSIFY_ALT_TAG_CHARS)
+
   // ⚠️ Q4 — LOG ON EVERY CALL, including the below-threshold ones that apply
   // nothing. There is no column and no audit row: this line IS the tuning data.
+  //
+  // `altTagName` is logged (until the 08 phase-2 miner exists, this line is the
+  // only way to eyeball candidates); `messageSummary` deliberately is NOT — it is
+  // customer prose already persisted on the message, and a second copy in the log
+  // stream buys nothing.
   logger.info('Mail classification result', {
     organizationId,
     messageId,
@@ -285,17 +361,27 @@ export async function classifyMessage(
     confidence,
     threshold: MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
     applied,
+    hasSummary: messageSummary !== undefined,
+    altTagName: altTagName ?? null,
   })
 
   // Past this point a call COMPLETED, so `inferred: true` even when nothing is
   // applied: "no category" and "not confident enough" are answers, they were
   // paid for, and re-asking would buy the same answer twice (C9).
-  if (applied) return { tagId: category, confidence, model: def.model, inferred: true }
+  const captured = {
+    ...(messageSummary ? { messageSummary } : {}),
+    ...(altTagName ? { altTagName } : {}),
+  }
+
+  if (applied) {
+    return { tagId: category, confidence, model: def.model, inferred: true, ...captured }
+  }
   return {
     tagId: null,
     confidence,
     reason: category === null ? 'no-category' : 'below-threshold',
     model: def.model,
     inferred: true,
+    ...captured,
   }
 }

--- a/packages/lib/src/mail-classification/client.ts
+++ b/packages/lib/src/mail-classification/client.ts
@@ -55,6 +55,19 @@ export const MAIL_CLASSIFY_NO_CATEGORY = '__none__'
 export const MAIL_CLASSIFY_BODY_CHARS = 2000
 
 /**
+ * Ceiling on the one-line message summary (08 §3.1).
+ *
+ * ⚠️ Enforced in TypeScript, NOT by a `maxLength` in the schema (08 §2). Strict-
+ * mode keyword support differs per provider — `sanitizeFormatsForOpenAiStrict`
+ * already strips things the OpenAI API rejects outright — so the schema states
+ * the limit for the model's benefit and the clamp is what actually holds.
+ */
+export const MAIL_CLASSIFY_SUMMARY_CHARS = 200
+
+/** Ceiling on a candidate tag label (08 §3.1). Clamped in TypeScript, as above. */
+export const MAIL_CLASSIFY_ALT_TAG_CHARS = 60
+
+/**
  * Key under `Message.metadata` holding the classification marker.
  *
  * Its presence IS the "already classified" answer (C9) — classify once per
@@ -167,6 +180,27 @@ export interface MailClassificationMarker {
   tagId: string | null
   confidence: number
   model?: string
+  /**
+   * One-line summary of THIS MESSAGE (08 T10).
+   *
+   * ⚠️ Not a thread summary and must never be surfaced as one: it is written
+   * once, from the first inbound message only, against a body truncated to
+   * {@link MAIL_CLASSIFY_BODY_CHARS} with no quoted history, and is never
+   * updated as the conversation grows.
+   */
+  messageSummary?: string
+  /**
+   * The topic label the model WOULD have used, when the taxonomy did not fit
+   * (08 §3.1). Present only on abstentions — `'no-category'` or
+   * `'below-threshold'`.
+   *
+   * ⚠️ Recorded, never applied (08 invariant 5). The classifier's output set
+   * stays closed over the eligible tags (`05-…` invariant 12); nothing may turn
+   * this string into a tag without a human accepting a suggestion. Stored
+   * verbatim — normalization and clustering happen at mine time (08 T5), so rows
+   * written under one strategy never need a backfill under the next.
+   */
+  altTagName?: string
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/lib/src/mail-classification/index.ts
+++ b/packages/lib/src/mail-classification/index.ts
@@ -3,7 +3,7 @@
 // Explicit named exports only — see CLAUDE.md's "Module Exports" convention.
 
 // Write path (§3.3, C9)
-export { applyClassificationTag, markMessageClassified } from './apply'
+export { applyClassificationTag, markMessageClassified, toClassificationMarker } from './apply'
 // The one model call (§3.2)
 export {
   buildClassificationPrompt,
@@ -18,10 +18,12 @@ export {
   MAIL_CLASSIFICATION_INBOX_IDS_SETTING,
   MAIL_CLASSIFICATION_JOB_NAME,
   MAIL_CLASSIFICATION_METADATA_KEY,
+  MAIL_CLASSIFY_ALT_TAG_CHARS,
   MAIL_CLASSIFY_BODY_CHARS,
   MAIL_CLASSIFY_CONFIDENCE_THRESHOLD,
   MAIL_CLASSIFY_FAILURE_REASONS,
   MAIL_CLASSIFY_NO_CATEGORY,
+  MAIL_CLASSIFY_SUMMARY_CHARS,
   MAIL_RECLASSIFY_APPLY_JOB_NAME,
   MAIL_RECLASSIFY_BACKLOG_COUNT_CAP,
   MAIL_RECLASSIFY_DAY_PRESETS,

--- a/packages/lib/src/mail-classification/job.test.ts
+++ b/packages/lib/src/mail-classification/job.test.ts
@@ -16,7 +16,15 @@ const h = vi.hoisted(() => ({
 
 vi.mock('./guard', () => ({ guardClassification: h.guard }))
 vi.mock('./classify', () => ({ classifyMessage: h.classify }))
-vi.mock('./apply', () => ({ applyClassificationTag: h.apply, markMessageClassified: h.mark }))
+// ⚠️ PARTIAL. `toClassificationMarker` is kept REAL so the marker's contents are
+// asserted against the actual builder rather than a paraphrase of it — and so a
+// full replacement cannot silently hand `undefined` to `markMessageClassified`
+// the next time this module grows an export.
+vi.mock('./apply', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./apply')>()),
+  applyClassificationTag: h.apply,
+  markMessageClassified: h.mark,
+}))
 vi.mock('./rerun-filters', () => ({ rerunMailFiltersAfterClassification: h.rerun }))
 
 import type { MailClassificationJobData } from './job'
@@ -126,6 +134,33 @@ describe('mailClassificationJob — the happy path', () => {
       confidence: 0.9,
       model: 'gpt-x',
     })
+  })
+
+  it('carries the summary and the candidate label onto the marker (08 phase 1)', async () => {
+    h.classify.mockResolvedValue({
+      tagId: null,
+      confidence: 0.5,
+      reason: 'below-threshold',
+      model: 'gpt-x',
+      inferred: true,
+      messageSummary: 'The sender wants to open a wholesale account.',
+      altTagName: 'wholesale enquiry',
+    })
+
+    await mailClassificationJob(ctx())
+
+    expect(h.mark.mock.calls[0]?.[0]?.marker).toMatchObject({
+      messageSummary: 'The sender wants to open a wholesale account.',
+      altTagName: 'wholesale enquiry',
+    })
+  })
+
+  it('omits the two keys entirely when the model returned nothing usable', async () => {
+    await mailClassificationJob(ctx())
+
+    const marker = h.mark.mock.calls[0]?.[0]?.marker
+    expect(marker).not.toHaveProperty('messageSummary')
+    expect(marker).not.toHaveProperty('altTagName')
   })
 })
 

--- a/packages/lib/src/mail-classification/job.ts
+++ b/packages/lib/src/mail-classification/job.ts
@@ -17,7 +17,7 @@
 import { database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { JobContext } from '../jobs/types/job-context'
-import { applyClassificationTag, markMessageClassified } from './apply'
+import { applyClassificationTag, markMessageClassified, toClassificationMarker } from './apply'
 import { classifyMessage } from './classify'
 import type { MailClassificationSkipReason } from './client'
 import { guardClassification } from './guard'
@@ -102,12 +102,7 @@ export async function mailClassificationJob(
       db,
       organizationId,
       messageId,
-      marker: {
-        at: new Date().toISOString(),
-        tagId: result.tagId,
-        confidence: result.confidence,
-        ...(result.model ? { model: result.model } : {}),
-      },
+      marker: toClassificationMarker(result),
     })
   }
 

--- a/packages/lib/src/mail-classification/retroactive.ts
+++ b/packages/lib/src/mail-classification/retroactive.ts
@@ -47,7 +47,7 @@ import { err, ok, type Result } from 'neverthrow'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import type { JobContext } from '../jobs/types/job-context'
-import { applyClassificationTag, markMessageClassified } from './apply'
+import { applyClassificationTag, markMessageClassified, toClassificationMarker } from './apply'
 import { classifyMessage } from './classify'
 import {
   MAIL_CLASSIFICATION_INBOX_IDS_SETTING,
@@ -937,12 +937,7 @@ export async function runMailReclassifyApply(
         db,
         organizationId: input.organizationId,
         messageId: row.messageId,
-        marker: {
-          at: new Date().toISOString(),
-          tagId: result.tagId,
-          confidence: result.confidence,
-          ...(result.model ? { model: result.model } : {}),
-        },
+        marker: toClassificationMarker(result),
       })
 
       input.onProgress?.(selected, total, startedAt.toISOString())

--- a/packages/lib/src/mail-classification/types.ts
+++ b/packages/lib/src/mail-classification/types.ts
@@ -63,4 +63,23 @@ export interface MailClassificationResult {
    * usage is only metered against a response that actually came back.
    */
   inferred: boolean
+  /**
+   * One-line summary of the message (08 §3.1). Absent when the model returned
+   * nothing usable, and on every `inferred: false` path — like the tag, it is
+   * only captured where a call completed.
+   *
+   * ⚠️ Of ONE message, not the thread (08 T10). See
+   * {@link import('./client').MailClassificationMarker.messageSummary}.
+   */
+  messageSummary?: string
+  /**
+   * The topic label the model would have used instead of a real category.
+   *
+   * ⚠️ Populated ONLY on abstentions (08 T3) — `'no-category'` and
+   * `'below-threshold'`. A model that fills this in while classifying happily has
+   * its answer dropped: an applied tag means the taxonomy fit, and a candidate
+   * mined from a message that classified fine is noise that would later argue for
+   * a tag the org already has.
+   */
+  altTagName?: string
 }

--- a/packages/lib/src/mail-filters/retroactive.test.ts
+++ b/packages/lib/src/mail-filters/retroactive.test.ts
@@ -83,6 +83,7 @@ vi.mock('@auxx/database', async () => {
 import { matchFilters } from './evaluate'
 import {
   assertBackfillable,
+  findPendingRetroactivePrompt,
   mailFilterRetroactiveApplyJob,
   PREVIEW_MATCH_COUNT_CAP,
   previewMatchCount,
@@ -465,5 +466,105 @@ describe('assertBackfillable', () => {
 
   it('accepts an enabled filter with a real action', () => {
     expect(assertBackfillable(filterRow()).isOk()).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * §7.10 (`07-mail-reclassification-plan.md`) — the banner mounts in a fixed slot
+ * for EVERY mail view and names the inbox it is about, so which candidate wins
+ * is user-visible. Without a preference it asked about whichever inbox sorted
+ * first, and this banner's button MUTATES: a mistargeted one puts a bulk
+ * assign/archive over a whole mailbox's history one click away from someone who
+ * was reading a different mailbox.
+ *
+ * A REORDER, never a filter, and never a grant — it is applied to the caller's
+ * already-authorized candidate list.
+ */
+describe('findPendingRetroactivePrompt — the viewed inbox goes first (§7.10)', () => {
+  const INBOX_A = 'ibx_a'
+  const INBOX_B = 'ibx_b'
+
+  /**
+   * The three reads the prompt makes, in order: enabled filters (`select`),
+   * prior retroactive runs (`selectDistinct`), live channels (`select`). Then one
+   * `execute` per surviving candidate, IN ITERATION ORDER — so queueing counts
+   * rather than keying them by inbox is what makes the order observable.
+   */
+  function promptDb(inboxIds: string[], counts: number[]) {
+    const selectResults = [
+      inboxIds.map((inboxId, i) => ({ id: `flt_${i}`, inboxId })),
+      // `PROVIDER_CAPABILITIES` is keyed by `IntegrationProviderType`, whose
+      // values are lowercase (`google`), not the `ChannelProvider` spellings.
+      inboxIds.map((inboxId) => ({ inboxId, provider: 'google' })),
+    ]
+    let selectCall = 0
+    const chain = (rows: unknown[]) => {
+      const c: Record<string, unknown> = {}
+      Object.assign(c, {
+        from: () => c,
+        innerJoin: () => c,
+        where: () => c,
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable query-builder mock
+        then: (ok: (v: unknown) => unknown, err?: (e: unknown) => unknown) =>
+          Promise.resolve(rows).then(ok, err),
+      })
+      return c
+    }
+    let countCall = 0
+    return {
+      select: () => chain(selectResults[selectCall++] ?? []),
+      selectDistinct: () => chain([]),
+      execute: async () => ({ rows: [{ count: counts[countCall++] ?? 0 }] }),
+    } as never
+  }
+
+  it('asks about the viewed inbox when it has threads', async () => {
+    const prompt = await findPendingRetroactivePrompt(
+      promptDb([INBOX_A, INBOX_B], [7, 7]),
+      'org_1',
+      [INBOX_A, INBOX_B],
+      { preferredInboxId: INBOX_B }
+    )
+
+    expect(prompt).toMatchObject({ inboxId: INBOX_B })
+  })
+
+  // The preference is not a scope — a view whose own inbox has nothing pending
+  // must still surface the inbox that does, or §2.9's discovery argument fails.
+  it('falls back to another candidate when the viewed inbox has nothing', async () => {
+    const prompt = await findPendingRetroactivePrompt(
+      promptDb([INBOX_A, INBOX_B], [0, 7]),
+      'org_1',
+      [INBOX_A, INBOX_B],
+      { preferredInboxId: INBOX_B }
+    )
+
+    expect(prompt).toMatchObject({ inboxId: INBOX_A })
+  })
+
+  // ⚠️ The preference must never widen the answer — `candidateInboxIds` is the
+  // caller's authorized set, and an id outside it is inert, not an oracle.
+  it('ignores an inbox that was not already a candidate', async () => {
+    const prompt = await findPendingRetroactivePrompt(
+      promptDb([INBOX_A, INBOX_B], [7, 7]),
+      'org_1',
+      [INBOX_A, INBOX_B],
+      { preferredInboxId: 'ibx_not_mine' }
+    )
+
+    expect(prompt).toMatchObject({ inboxId: INBOX_A })
+  })
+
+  // Search, drafts and all-inboxes span inboxes and pass nothing.
+  it('still asks when no inbox is being viewed', async () => {
+    const prompt = await findPendingRetroactivePrompt(
+      promptDb([INBOX_A, INBOX_B], [7, 7]),
+      'org_1',
+      [INBOX_A, INBOX_B]
+    )
+
+    expect(prompt).toMatchObject({ inboxId: INBOX_A })
   })
 })

--- a/packages/lib/src/mail-filters/retroactive.ts
+++ b/packages/lib/src/mail-filters/retroactive.ts
@@ -435,11 +435,30 @@ export async function findPendingRetroactivePrompt(
   db: Database,
   organizationId: string,
   candidateInboxIds: string[],
-  opts: { threadCountCap?: number } = {}
+  opts: { threadCountCap?: number; preferredInboxId?: string } = {}
 ): Promise<PendingRetroactivePrompt | null> {
   if (candidateInboxIds.length === 0) return null
   const candidates = new Set(candidateInboxIds)
   const cap = Math.max(1, Math.trunc(opts.threadCountCap ?? PROMPT_THREAD_COUNT_CAP))
+
+  /**
+   * The inbox the caller is currently LOOKING at goes first, when it is one of
+   * the candidates. The banner mounts in a fixed slot for every mail view and
+   * names the inbox it is about, so without this it asks about whichever inbox
+   * sorted first — reading, to anyone in a different mailbox, as a statement
+   * about the mail in front of them. It matters more here than on the
+   * classification twin: this banner's button MUTATES, so a mistargeted one is a
+   * click away from a bulk assign/archive over a mailbox nobody was looking at.
+   *
+   * ⚠️ A REORDER, never a filter, and it runs against the already-authorized
+   * `candidateInboxIds` — so an id the caller may not author on is inert rather
+   * than an existence oracle, and a view with no inbox of its own (search,
+   * drafts, all-inboxes) still gets the prompt.
+   */
+  const order =
+    opts.preferredInboxId && candidates.has(opts.preferredInboxId)
+      ? [opts.preferredInboxId, ...candidateInboxIds.filter((id) => id !== opts.preferredInboxId)]
+      : candidateInboxIds
 
   const filters = await db
     .select({ id: schema.MailFilter.id, inboxId: schema.MailFilter.inboxId })
@@ -499,10 +518,10 @@ export async function findPendingRetroactivePrompt(
       .map((c) => c.inboxId)
   )
 
-  // `candidateInboxIds` order is the caller's order (the authority's inbox
-  // order), so the prompt is stable across refetches rather than whatever the
-  // filter query happened to return first.
-  for (const inboxId of candidateInboxIds) {
+  // `order` is the caller's order (the authority's inbox order, with the viewed
+  // inbox hoisted), so the prompt is stable across refetches rather than
+  // whatever the filter query happened to return first.
+  for (const inboxId of order) {
     const filterIds = byInbox.get(inboxId)
     if (!filterIds || !synced.has(inboxId)) continue
 


### PR DESCRIPTION
Phase 1 of `plans/mail-filter/08-mail-topic-suggestions-plan.md` (the plan file is gitignored, so it lives only in the worktree).

The classifier already reads every first inbound message and already pays for a model call, and `05-…§3.2` made its response an object rather than a bare tag id precisely so "a second output later costs no extra call". This spends that option twice.

## What it adds

**`messageSummary`** — one line describing what the sender wants.

⚠️ Of **one message**, not the thread: written once, from the first inbound message only, off a body truncated to 2000 chars with no quoted history, and never updated as the conversation grows. Named `messageSummary` rather than `summary` so no surface can later sell it as a thread summary it isn't.

**`altTagName`** — the topic label the model *would* have used when the taxonomy didn't fit.

Recorded, never applied — the classifier's output set stays closed over the eligible tags (`05-…` invariant 12). Captured on `no-category` **and** `below-threshold`: a confident abstention says nothing fits, a 0.55 pick says the boundary is wrong, and the second is the stronger signal for tag design. Dropped in code when a tag was applied, rather than trusting the prompt's "leave it empty" — a model that fills it in anyway would seed the future miner with candidates arguing for tags the org demonstrably already has.

Nothing reads it yet. It accumulates a corpus so phase 2 (a weekly miner writing `MailSuggestion` rows) has something to cluster.

## Why every property is `required`

"Make it optional" does not survive the provider layer, and fails differently per provider **silently**:

- `openai-llm-client.ts:597-600` **overwrites the array** — `required = Object.keys(properties)` — so an optional property is mandatory by the time the request leaves;
- `anthropic-llm-client.ts:384` unwraps the same schema into a forced synthetic tool's `input_schema` and passes `required` through untouched, where it really is optional.

So an "optional" field means a different contract depending on which default model the org happens to have picked. Absence is therefore carried as a **value** — `''` for `altTagName`, exactly as `__none__` already carries it for `category` — which makes the two providers agree by construction.

Lengths are stated in the schema for the model's benefit and **clamped in TypeScript**, since `maxLength` isn't portable under strict mode.

## Notes

- Both fields ride the existing `inferred` gate, so a failed call captures nothing exactly as it applies nothing. Sample mode still persists nothing (07 invariant 9).
- New shared `toClassificationMarker`: the live job and the retroactive run had byte-identical marker blocks, so every new field had to be added twice and a miss would surface only as "the backfill produced no summaries" weeks later.
- `job.test.ts`'s `vi.mock('./apply')` went from full replacement to partial — it would otherwise have handed `undefined` to `markMessageClassified` the moment the module grew a third export.
- `category` stays the first property, and so the first thing generated. Summarising *before* deciding would plausibly classify better (a free reasoning step), but it changes the decision on a shipped feature and belongs in a measured follow-up.
- `altTagName` is logged; `messageSummary` deliberately is not — customer prose is already persisted on the message and a second copy in the log stream buys nothing.

## Also included

The mail-filters twin of #1530, from a parallel session (I didn't author it, but its tests are green): the retroactive-prompt banner names the inbox it's about and its button **mutates**, so `findPendingRetroactivePrompt` now hoists the inbox being viewed. A reorder over already-authorized candidates, never a filter — an id the caller can't author on is inert rather than an existence oracle.

## ⚠️ Before merging

**The plan's §3.4 measurement has not been run, and it gates this.** No real provider call has been made with the new schema — the tests mock `invoke`. Adding "or invent one" makes inventing cognitively cheaper than fitting, and could raise abstention on a classifier that already ships. Sample 100 threads on `main`, sample 100 on this branch, compare `abstentionRate` — sample mode applies nothing and reports exactly that number.

## Testing

- `mail-classification`: 155 tests green (13 new)
- `mail-filters/retroactive`: 25 green · `web` router: 85 green
- `packages/lib` typecheck: no new errors (29 pre-existing baseline, none in touched files)
- Biome clean on both modules