### PR TITLE
fix(mail): guard the subject-key keyspace and keep the tag-candidate corpus clean

### DIFF
--- a/packages/lib/src/mail-classification/classify.test.ts
+++ b/packages/lib/src/mail-classification/classify.test.ts
@@ -284,6 +284,29 @@ describe('classifyMessage — the summary and the candidate label (08 phase 1)',
     expect(result).not.toHaveProperty('altTagName')
   })
 
+  it('⚠️ DROPS it on an INELIGIBLE pick — that is not an abstention', async () => {
+    // `reason: 'no-category'` covers two different events: the model returned
+    // `__none__` (your taxonomy has no tag for this — real evidence for a new
+    // tag), and the model returned an id outside the eligible set (it believed
+    // it HAD classified the mail; the id just does not exist). Only the first is
+    // mineable, and the candidate corpus is stored verbatim and clustered months
+    // later (08 T5), so noise written here is noise the miner reads then.
+    h.invoke.mockResolvedValue({
+      structured_output: {
+        category: 'tag_does_not_exist',
+        confidence: 0.95,
+        messageSummary: 'A question about a wholesale account.',
+        altTagName: 'wholesale enquiry',
+      },
+    })
+
+    const result = await classifyMessage(db, context)
+    expect(result).toMatchObject({ tagId: null, reason: 'no-category' })
+    expect(result).not.toHaveProperty('altTagName')
+    // The summary is unaffected — it describes the message, not the decision.
+    expect(result.messageSummary).toBe('A question about a wholesale account.')
+  })
+
   it('treats the empty-string sentinel as "nothing to record", not as a value', async () => {
     h.invoke.mockResolvedValue({
       structured_output: {

--- a/packages/lib/src/mail-classification/classify.ts
+++ b/packages/lib/src/mail-classification/classify.ts
@@ -331,14 +331,31 @@ export async function classifyMessage(
 
   const applied = category !== null && confidence >= MAIL_CLASSIFY_CONFIDENCE_THRESHOLD
 
+  // A pick that was not one of ours: the model named a category id outside the
+  // eligible set, so `category` fell to null above. This is NOT an abstention —
+  // the model believed it had classified the mail — and the two must not be
+  // conflated, because they end in the same `'no-category'` reason.
+  const ineligiblePick =
+    rawCategory !== null && rawCategory !== MAIL_CLASSIFY_NO_CATEGORY && !category
+
   const messageSummary = clampText(structured?.messageSummary, MAIL_CLASSIFY_SUMMARY_CHARS)
   // ⚠️ Dropped outright when a tag was applied (08 T3), rather than trusted from
   // the prompt. The instruction says "leave it empty whenever a category fitted",
   // and a model that fills it in anyway would seed the miner with candidates
   // arguing for tags the org demonstrably already has.
-  const altTagName = applied
-    ? undefined
-    : clampText(structured?.altTagName, MAIL_CLASSIFY_ALT_TAG_CHARS)
+  //
+  // ⚠️ Dropped on an INELIGIBLE PICK too, for the opposite reason. That path
+  // reports `reason: 'no-category'` — the same arm a real `__none__` abstention
+  // takes — but the two say different things: one is "your taxonomy has no tag
+  // for this", the other is "the model returned an id that does not exist". Only
+  // the first is evidence for a new tag. Keeping the second would let a
+  // misbehaving model argue, through the 08 phase-2 miner, for tags nobody's mail
+  // ever asked for, and the candidate corpus is stored verbatim and mined later
+  // (T5) — so noise written today is noise the miner reads months from now.
+  const altTagName =
+    applied || ineligiblePick
+      ? undefined
+      : clampText(structured?.altTagName, MAIL_CLASSIFY_ALT_TAG_CHARS)
 
   // ⚠️ Q4 — LOG ON EVERY CALL, including the below-threshold ones that apply
   // nothing. There is no column and no audit row: this line IS the tuning data.

--- a/packages/lib/src/mail-unsubscribe/client.test.ts
+++ b/packages/lib/src/mail-unsubscribe/client.test.ts
@@ -243,4 +243,19 @@ describe('subject keys stay two prefixes (S7, invariant 8)', () => {
     expect(parseMailSubjectKey('sender:example.com')).toBeNull()
     expect(parseMailSubjectKey('list:')).toBeNull()
   })
+
+  // ⚠️ The regression this guards: `parseMailSubjectKey` used to end in a
+  // ternary whose else-branch meant "not a list, therefore a domain". The
+  // keyspace lives in `mail-suggestions/client.ts` and will grow prefixes this
+  // module has no meaning for (`topic:`, 08 §4.2) — under that else a `topic:`
+  // key parsed as `{ kind: 'domain', senderDomain: '<topic text>' }` and
+  // `buildSubjectKeyPredicate` compiled it into a real predicate that matches
+  // nothing instead of throwing. A sweep that counts no later mail reports every
+  // sender as honoring an unsubscribe they ignored. The throwing half is
+  // asserted in `subject-key.test.ts`.
+  it('never coerces a non-bulk-mail key into a domain group', () => {
+    for (const key of ['topic:refund request', 'thread:abc', 'contact:someone@example.com']) {
+      expect(parseMailSubjectKey(key)).toBeNull()
+    }
+  })
 })

--- a/packages/lib/src/mail-unsubscribe/client.ts
+++ b/packages/lib/src/mail-unsubscribe/client.ts
@@ -230,15 +230,36 @@ export function toMailSubjectKey(group: {
 /**
  * The inverse of {@link toMailSubjectKey}, in this module's discriminated shape.
  * Returns null for an unknown prefix **or a bare prefix with no value**.
+ *
+ * ⚠️ **Every arm is matched EXPLICITLY, and an unrecognized kind returns null** —
+ * never an `else` that assumes "not a list, therefore a domain".
+ *
+ * `parseSubjectKey` owns the keyspace and will grow prefixes this module has no
+ * meaning for (`topic:` for mined tag suggestions, 08 §4.2). Under an else-branch
+ * a `topic:refund request` key would arrive here as
+ * `{ kind: 'domain', senderDomain: 'refund request' }`, and
+ * `buildSubjectKeyPredicate` would compile it into a real `Message` predicate that
+ * matches nothing instead of throwing — which is precisely the "silently degrade
+ * into match-nothing" failure that function refuses, because a sweep counting zero
+ * later mail reports every sender as honoring an unsubscribe they ignored.
+ *
+ * Returning null routes an unknown kind into that same `BadRequestError`, and the
+ * `satisfies never` below makes a newly added prefix a COMPILE error here rather
+ * than a silent misparse at runtime.
  */
 export function parseMailSubjectKey(
   subjectKey: string
 ): { kind: 'list'; listId: string } | { kind: 'domain'; senderDomain: string } | null {
   const parsed = parseSubjectKey(subjectKey)
   if (!parsed) return null
-  return parsed.kind === 'list'
-    ? { kind: 'list', listId: parsed.value }
-    : { kind: 'domain', senderDomain: parsed.value }
+  if (parsed.kind === 'list') return { kind: 'list', listId: parsed.value }
+  if (parsed.kind === 'domain') return { kind: 'domain', senderDomain: parsed.value }
+
+  // Unreachable today. When the keyspace grows a prefix that is not a bulk-mail
+  // group, this stops compiling and whoever added it has to decide what
+  // unsubscribe should do with it — which is "refuse", not "guess a domain".
+  const unhandledKind: never = parsed.kind
+  return unhandledKind
 }
 
 /**

--- a/packages/lib/src/mail-unsubscribe/subject-key.test.ts
+++ b/packages/lib/src/mail-unsubscribe/subject-key.test.ts
@@ -1,0 +1,36 @@
+// packages/lib/src/mail-unsubscribe/subject-key.test.ts
+// The refusal half of `buildSubjectKeyPredicate`: an unparseable subject key
+// must THROW, never compile into a predicate.
+//
+// ⚠️ Why this file exists. `parseMailSubjectKey` used to narrow with a ternary
+// whose else-branch meant "not a list, therefore a domain". The keyspace is
+// owned by `mail-suggestions/client.ts` and will grow prefixes this module has
+// no meaning for — `topic:` for mined tag suggestions (08 §4.2) — and under that
+// else a `topic:refund request` key became
+// `{ kind: 'domain', senderDomain: 'refund request' }`, which compiles into a
+// perfectly valid `Message` predicate that matches nothing. Matching nothing is
+// the one answer this module must never give: the sweep reads "no mail arrived
+// since" as "the sender honored the unsubscribe".
+//
+// Only the rejection paths are asserted. The accepting paths build drizzle
+// fragments off `schema.Message`, and the shared `src/test/setup.ts` proxy does
+// not make columns assertable — they are covered by `unsubscribe-queries.test.ts`
+// and `sweep.test.ts` against the real query builder.
+
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../errors'
+import { buildSubjectKeyPredicate } from './subject-key'
+
+describe('buildSubjectKeyPredicate — refusals', () => {
+  it('throws on a keyspace prefix that is not a bulk-mail group', () => {
+    for (const key of ['topic:refund request', 'thread:abc', 'contact:a@example.com']) {
+      expect(() => buildSubjectKeyPredicate(key)).toThrow(BadRequestError)
+    }
+  })
+
+  it('throws on an unknown prefix, a bare prefix and a key with no prefix at all', () => {
+    for (const key of ['sender:example.com', 'list:', 'domain:', '', 'example.com']) {
+      expect(() => buildSubjectKeyPredicate(key)).toThrow(BadRequestError)
+    }
+  })
+})


### PR DESCRIPTION
Two small fixes from a review pass over `plans/mail-filter/08-mail-topic-suggestions-plan.md`. Neither is a bug #1531 introduced — both close gaps the plan had.

## 1. The subject-key narrowing is now exhaustive

`parseMailSubjectKey` narrowed with a ternary whose else-branch meant *not a list, therefore a domain*. The keyspace is owned by `mail-suggestions/client.ts` and phase 2 of the plan adds a `topic:` arm to it for mined tag suggestions. Under that else, `topic:refund request` would have parsed as:

```ts
{ kind: 'domain', senderDomain: 'refund request' }
```

…which compiles into a perfectly valid `Message` predicate that matches nothing — sailing straight past the `BadRequestError` in `buildSubjectKeyPredicate` that exists for exactly this case. Its own docstring says why an unknown prefix must not "silently degrade into match nothing": the sweep then reads *no mail arrived since* as *the sender honored the unsubscribe*, and we tell the user a sender respected an unsubscribe they ignored.

Both kinds are now matched explicitly, ending in `const unhandledKind: never = parsed.kind`. Adding a third arm to the keyspace is now a **compile error in `mail-unsubscribe`** rather than a silent misparse at runtime, so whoever adds `topic:` is forced to decide what unsubscribe does with it. The answer is "refuse", and the `never` should stay in place when that happens.

**Verified it actually bites** — temporarily widening `parseSubjectKey`'s union to include `'topic'` produced exactly one error, then reverted:

```
src/mail-unsubscribe/client.ts(261,9): error TS2322: Type '"topic"' is not assignable to type 'never'.
```

## 2. Tag candidates are dropped on an ineligible pick

`reason: 'no-category'` covers two different events:

| The model returned | Means | Mineable? |
| --- | --- | --- |
| `__none__` | your taxonomy has no tag for this | yes — this is the signal |
| an id outside the eligible set | a malfunction; it believed it *had* classified the mail | no |

`classify.ts` re-checks enum membership rather than trusting `strict`, so the second case falls to `category = null` and lands on the same arm as a real abstention — and was seeding the candidate corpus with evidence of its own malfunction. That corpus is stored verbatim and clustered months later (plan T5), so noise written today is noise the miner reads then.

`messageSummary` is unaffected: it describes the message, not the decision.

## Testing

- 366 tests pass across `mail-classification`, `mail-unsubscribe` and `mail-suggestions` (22 files), including 3 new cases.
- `pnpm --filter @auxx/lib typecheck`: no errors in any touched module; lib's pre-existing baseline unchanged.
- `pnpm lint:changed`: clean.

## Not in this PR

The plan edits from the same review live in `plans/`, which is gitignored. The measurement that #1531 was supposed to be gated on (§3.4) is still outstanding and is unaffected by these changes.
