### PR TITLE
fix(tags): stop tag deletes orphaning their records, and add the archive path

### DIFF
--- a/apps/web/src/components/tags/hooks/use-tag-hierarchy.ts
+++ b/apps/web/src/components/tags/hooks/use-tag-hierarchy.ts
@@ -12,6 +12,15 @@ interface UseTagHierarchyOptions {
    * scope are returned. Tags without a scope value default to 'thread'.
    */
   scope?: TagScopeValue
+  /**
+   * Include archived tags in the result, each flagged as {@link TagNode.isArchived}.
+   *
+   * Off everywhere except the settings list's "Show archived" toggle: a picker
+   * must never offer a retired tag, and the classifier never sees one either
+   * (`labels.ts:92`). The settings list is the one surface that has to show them,
+   * because archive would otherwise be a one-way door with no route back.
+   */
+  includeArchived?: boolean
 }
 
 /**
@@ -27,6 +36,7 @@ export function useTagHierarchy(options?: UseTagHierarchyOptions): UseTagHierarc
   const { records, entityDefinitionId, fields, isLoading, error, refresh } =
     useAllRecords<TagRecord>({
       entityDefinitionId: 'tag',
+      includeArchived: options?.includeArchived,
     })
 
   const scope = options?.scope
@@ -61,6 +71,11 @@ export function useTagHierarchy(options?: UseTagHierarchyOptions): UseTagHierarc
         // Empty string reads as "no template" so a blanked-out field cannot make
         // a tag look seeded (and cannot resolve a default that does not exist).
         templateKey: record.fieldValues.tag_template_key || null,
+        // `record.listAll` spreads the whole `EntityInstance` row, so `archivedAt`
+        // rides along untyped through `RecordMeta`'s index signature. Narrowed to
+        // a boolean here so no caller has to re-derive it (or get the null check
+        // backwards).
+        isArchived: Boolean((record as { archivedAt?: unknown }).archivedAt),
         scope: tagScope,
         children: [],
       }

--- a/apps/web/src/components/tags/types.ts
+++ b/apps/web/src/components/tags/types.ts
@@ -58,6 +58,17 @@ export interface TagNode {
    * that the delete hook will refuse.
    */
   templateKey: string | null
+  /**
+   * `EntityInstance.archivedAt !== null` — the tag is retired but every record
+   * that carries it keeps it.
+   *
+   * ⚠️ Archive is the DEFAULT retirement path for a tag in use, not a lesser
+   * delete. `mail-classification/labels.ts:92` already filters archived tags out
+   * of the classifier's label set, so archiving stops a tag being applied to new
+   * mail while leaving the historical claim on the threads that have it — which
+   * is what `rejectDeleteIfTagInUse` points callers at when it refuses a delete.
+   */
+  isArchived: boolean
   scope: TagScopeValue
   children: TagNode[]
 }

--- a/apps/web/src/components/tags/ui/tags-list.tsx
+++ b/apps/web/src/components/tags/ui/tags-list.tsx
@@ -17,7 +17,17 @@ import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { ChevronDown, Edit, Lock, Plus, Sparkles, Tags, Trash2 } from 'lucide-react'
+import {
+  Archive,
+  ArchiveRestore,
+  ChevronDown,
+  Edit,
+  Lock,
+  Plus,
+  Sparkles,
+  Tags,
+  Trash2,
+} from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -50,8 +60,23 @@ export function TagTreeView() {
   const [isSuggestedOpen, setIsSuggestedOpen] = useState(false)
   const [editingRecordId, setEditingRecordId] = useState<RecordId | undefined>(undefined)
 
+  // Archived tags are hidden by default and revealed by the toolbar toggle.
+  // ⚠️ Without this the archive action would be a ONE-WAY DOOR — an archived tag
+  // vanishes from the only surface that manages tags, with no route back. That
+  // would be strictly worse than the delete it replaces.
+  const [showArchived, setShowArchived] = useQueryState('archived', {
+    defaultValue: false,
+    parse: (v) => v === '1',
+    serialize: (v) => (v ? '1' : ''),
+  })
+
   // Fetch tag hierarchy
-  const { hierarchy: tagHierarchy, isLoading, refresh, entityDefinitionId } = useTagHierarchy()
+  const {
+    hierarchy: tagHierarchy,
+    isLoading,
+    refresh,
+    entityDefinitionId,
+  } = useTagHierarchy({ includeArchived: showArchived })
 
   // Tags are RECORDS, not a settings surface: this page creates and deletes them
   // through `record.create`/`record.delete`, which assert `assertEditEntity` on
@@ -66,7 +91,25 @@ export function TagTreeView() {
       refresh()
     },
     onError: (error) => {
+      // ⚠️ The common failure here is a 409 from `rejectDeleteIfTagInUse`, whose
+      // message already names the record count and points at archive. Surfacing
+      // `error.message` verbatim is the whole remedy — do not replace it with a
+      // generic string.
       toastError({ title: 'Failed to delete tag', description: error.message })
+    },
+  })
+
+  const archiveRecord = api.record.archive.useMutation({
+    onSuccess: () => refresh(),
+    onError: (error) => {
+      toastError({ title: 'Failed to archive tag', description: error.message })
+    },
+  })
+
+  const restoreRecord = api.record.restore.useMutation({
+    onSuccess: () => refresh(),
+    onError: (error) => {
+      toastError({ title: 'Failed to restore tag', description: error.message })
     },
   })
 
@@ -156,6 +199,35 @@ export function TagTreeView() {
     }
   }
 
+  /**
+   * Archive a tag — the default way to retire one that is in use.
+   *
+   * Confirmed rather than immediate, despite being reversible: an archived tag
+   * leaves the classifier's label set (`labels.ts:92`), so mail that used to get
+   * this category silently stops getting it. That is a behaviour change worth one
+   * click, and the copy says so.
+   */
+  const handleArchiveTag = async (tag: TagNode) => {
+    const confirmed = await confirm({
+      title: 'Archive tag?',
+      description: tag.aiClassify
+        ? `"${tag.title}" stays on every conversation that already has it, but will no longer be applied to new mail by AI. You can restore it at any time.`
+        : `"${tag.title}" stays on every record that already has it, but will no longer be offered when tagging. You can restore it at any time.`,
+      confirmText: 'Archive',
+      cancelText: 'Cancel',
+      destructive: false,
+    })
+
+    if (confirmed) {
+      archiveRecord.mutate({ recordId: tag.recordId })
+    }
+  }
+
+  /** Restore an archived tag. Reversible and consequence-free — no confirm. */
+  const handleRestoreTag = (tag: TagNode) => {
+    restoreRecord.mutate({ recordId: tag.recordId })
+  }
+
   return (
     <div className='flex flex-1 flex-col'>
       <ListToolbar sticky={false}>
@@ -165,6 +237,17 @@ export function TagTreeView() {
           onChange={(e) => setSearchQuery(e.target.value)}
         />
         <ListToolbarGroup align='end'>
+          {/* The route back out of archive. Kept beside the create control rather
+              than buried in a menu — it is the only way to reach a restore. */}
+          <Button
+            variant={showArchived ? 'secondary' : 'outline'}
+            size='sm'
+            onClick={() => setShowArchived(showArchived ? null : true)}>
+            <Archive />
+            <span className='hidden sm:inline'>
+              {showArchived ? 'Hide archived' : 'Show archived'}
+            </span>
+          </Button>
           {/* Matches the create dropdown on custom-fields: blank first, shipped
               templates second. The suggested categories live here rather than in
               a settings section of their own — they ARE tags, and the list is
@@ -214,6 +297,8 @@ export function TagTreeView() {
                 onToggle={toggleExpanded}
                 onEdit={handleEditTag}
                 onDelete={handleDeleteTag}
+                onArchive={handleArchiveTag}
+                onRestore={handleRestoreTag}
               />
             )}
           />
@@ -264,6 +349,8 @@ interface TagTreeItemProps {
   onToggle: (tagId: string) => void
   onEdit: (tag: TagNode) => void
   onDelete: (tag: TagNode) => void
+  onArchive: (tag: TagNode) => void
+  onRestore: (tag: TagNode) => void
 }
 
 /**
@@ -279,6 +366,8 @@ function TagTreeItem({
   onToggle,
   onEdit,
   onDelete,
+  onArchive,
+  onRestore,
 }: TagTreeItemProps) {
   const hasChildren = tag.children?.length > 0
   const isExpanded = !!expandedTags[tag.id]
@@ -286,7 +375,12 @@ function TagTreeItem({
   return (
     <TreeRow
       depth={depth}
-      rowClassName='bg-primary-50 hover:bg-primary-100'
+      rowClassName={cn(
+        'bg-primary-50 hover:bg-primary-100',
+        // Muted, never hidden: the row is still actionable (restore lives on it),
+        // so it reads as retired rather than disabled.
+        tag.isArchived && 'opacity-60'
+      )}
       icon={
         <span
           className={cn(
@@ -300,11 +394,18 @@ function TagTreeItem({
         // Bare string when there is no badge: TreeRow's own `truncate` ellipsizes
         // inline text, but clips an inline-flex child instead — so only pay that
         // cost on the rows that actually need a badge beside the name.
-        !tag.isSystemTag && !tag.aiClassify ? (
+        !tag.isSystemTag && !tag.aiClassify && !tag.isArchived ? (
           tag.title
         ) : (
           <span className='inline-flex min-w-0 items-center gap-1.5'>
             <span className='truncate'>{tag.title}</span>
+            {tag.isArchived && (
+              <Tooltip content='Archived. Kept on the records that have it, but no longer offered — or applied by AI.'>
+                <span className='shrink-0 rounded border px-1 py-px text-[10px] leading-none text-muted-foreground'>
+                  Archived
+                </span>
+              </Tooltip>
+            )}
             {tag.isSystemTag && (
               <Tooltip content='System tag, managed by Auxx. Read-only.'>
                 <Lock className='size-3 shrink-0 text-muted-foreground' aria-label='System tag' />
@@ -331,10 +432,20 @@ function TagTreeItem({
       isOpen={isExpanded}
       onToggleOpen={hasChildren ? () => onToggle(tag.id) : undefined}
       actions={
-        tag.isSystemTag ? undefined : (
+        tag.isSystemTag ? undefined : tag.isArchived ? (
+          // An archived row offers only the way back. Editing a retired tag or
+          // archiving it twice are both meaningless; delete stays reachable by
+          // restoring first, which is one deliberate step rather than a trap.
+          <TreeRowButton tooltipText='Restore tag' onClick={() => onRestore(tag)}>
+            <ArchiveRestore />
+          </TreeRowButton>
+        ) : (
           <>
             <TreeRowButton tooltipText='Edit tag' onClick={() => onEdit(tag)}>
               <Edit />
+            </TreeRowButton>
+            <TreeRowButton tooltipText='Archive tag' onClick={() => onArchive(tag)}>
+              <Archive />
             </TreeRowButton>
             <TreeRowButton
               variant='destructive'
@@ -355,6 +466,8 @@ function TagTreeItem({
             onToggle={onToggle}
             onEdit={onEdit}
             onDelete={onDelete}
+            onArchive={onArchive}
+            onRestore={onRestore}
           />
         ))}
     </TreeRow>

--- a/packages/lib/src/field-hooks/pre/tag-in-use-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/tag-in-use-guard.test.ts
@@ -1,0 +1,82 @@
+// packages/lib/src/field-hooks/pre/tag-in-use-guard.test.ts
+// The guard that stops a tag delete from orphaning the rows that reference it.
+//
+// ⚠️ PARTIAL mock of `@auxx/database`, via `createSchemaMock` — a full
+// replacement dies at COLLECTION the moment this file's import graph reaches a
+// module that reads some other table at import time, and the failure looks
+// nothing like its cause.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConflictError } from '../../errors'
+import type { EntityPreDeleteEvent } from '../types'
+
+const h = vi.hoisted(() => ({ where: vi.fn() }))
+
+vi.mock('@auxx/database', async () => ({
+  database: {
+    select: () => ({ from: () => ({ where: h.where }) }),
+  },
+  schema: (await import('../../test/database-mock')).createSchemaMock({
+    FieldValue: {
+      relatedEntityId: 'FieldValue.relatedEntityId',
+      organizationId: 'FieldValue.organizationId',
+    },
+  }),
+}))
+
+import { rejectDeleteIfTagInUse } from './tag-in-use-guard'
+
+function event(): EntityPreDeleteEvent {
+  return {
+    recordId: 'tagdef123:sx81fbbgbi80ba8f80vyj3kq' as EntityPreDeleteEvent['recordId'],
+    entityDefinitionId: 'tagdef123',
+    entityType: null,
+    entitySlug: 'tags',
+    values: {},
+    organizationId: 'org_1',
+    userId: 'usr_1',
+    bypass: new Set(),
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('rejectDeleteIfTagInUse', () => {
+  it('allows the delete when nothing references the tag', async () => {
+    h.where.mockResolvedValue([{ references: 0 }])
+    await expect(rejectDeleteIfTagInUse(event())).resolves.toBeUndefined()
+  })
+
+  it('⚠️ refuses while references exist — this is the orphan bug', async () => {
+    // The observed incident: one delete left 532 rows whose `relatedEntityId`
+    // pointed at a tag row that no longer existed, and the mail list kept
+    // rendering a tag that was gone. `relatedEntityId` has no FK, so nothing
+    // else stops it.
+    h.where.mockResolvedValue([{ references: 532 }])
+    await expect(rejectDeleteIfTagInUse(event())).rejects.toThrow(ConflictError)
+  })
+
+  it('names the count and points at archive, because the caller has to choose', async () => {
+    h.where.mockResolvedValue([{ references: 532 }])
+    await expect(rejectDeleteIfTagInUse(event())).rejects.toThrow(/532 records/)
+    await expect(rejectDeleteIfTagInUse(event())).rejects.toThrow(/Archive it instead/)
+  })
+
+  it('singularises one reference', async () => {
+    h.where.mockResolvedValue([{ references: 1 }])
+    await expect(rejectDeleteIfTagInUse(event())).rejects.toThrow(/still on 1 record\./)
+  })
+
+  it('⚠️ is a 409, not a 403 — the caller IS allowed, the state is what blocks', async () => {
+    // Its siblings (`rejectDeleteIfSystemTag`, `rejectDeleteIfTemplateTag`) throw
+    // 403 because those tags may NEVER be deleted. This one is clearable: untag
+    // the records, or archive, and the same caller succeeds.
+    h.where.mockResolvedValue([{ references: 3 }])
+    await expect(rejectDeleteIfTagInUse(event())).rejects.toMatchObject({ statusCode: 409 })
+  })
+
+  it('treats a missing count row as "no references" rather than throwing', async () => {
+    h.where.mockResolvedValue([])
+    await expect(rejectDeleteIfTagInUse(event())).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/field-hooks/pre/tag-in-use-guard.ts
+++ b/packages/lib/src/field-hooks/pre/tag-in-use-guard.ts
@@ -1,0 +1,62 @@
+// packages/lib/src/field-hooks/pre/tag-in-use-guard.ts
+
+import { database, schema } from '@auxx/database'
+import { and, count, eq } from 'drizzle-orm'
+import { ConflictError } from '../../errors'
+import { parseRecordId } from '../../resources/resource-id'
+import type { EntityPreDeleteHandler } from '../types'
+
+/**
+ * Reject a tag delete while anything still references the tag.
+ *
+ * ⚠️ **This exists because a tag delete used to silently corrupt every record
+ * that carried it.** A tag↔thread link is TWO `FieldValue` rows — the tag side
+ * (`tag_threads`, `entityId = tagId`) and the record side (`relatedEntityId =
+ * tagId`) — and `relatedEntityId` has NO foreign key (`field-value.ts:93`).
+ * Deleting the tag row takes its own field values with it and leaves every
+ * record-side row pointing at an id that no longer resolves. Observed in the
+ * wild: one deleted tag left 532 orphaned rows, and the mail list went on
+ * rendering a tag that did not exist.
+ *
+ * The count is exactly "rows that would be orphaned by this delete", which is
+ * why it deliberately does NOT filter by field: a thread link, an article link
+ * and a child tag's `tag_parent` are all references that must not dangle.
+ * Indexed by `FieldValue_relatedEntityId_idx`.
+ *
+ * ## Why `ConflictError` and not `ForbiddenError`
+ *
+ * Its two siblings — `rejectDeleteIfSystemTag` and `rejectDeleteIfTemplateTag` —
+ * throw 403, and correctly: a system tag and a seeded category may NEVER be
+ * deleted, by anyone, ever. This is a different answer. The caller is fully
+ * authorized and the tag is deletable; it just is not deletable *right now*,
+ * and the state that blocks it is one the caller can clear. That is a 409.
+ *
+ * ## The remedy the message points at
+ *
+ * Archiving sets `EntityInstance.archivedAt`, which `labels.ts:92` already
+ * honours — an archived tag stops being offered to the classifier and stops
+ * appearing in pickers, while every record that carries it keeps it. For a
+ * label that 529 classification markers already reference, preserving the
+ * historical claim is the right default and destroying it is not.
+ */
+export const rejectDeleteIfTagInUse: EntityPreDeleteHandler = async (event) => {
+  const { entityInstanceId } = parseRecordId(event.recordId)
+
+  const [row] = await database
+    .select({ references: count() })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.relatedEntityId, entityInstanceId),
+        eq(schema.FieldValue.organizationId, event.organizationId)
+      )
+    )
+
+  const references = row?.references ?? 0
+  if (references === 0) return
+
+  const label = references === 1 ? '1 record' : `${references} records`
+  throw new ConflictError(
+    `This tag is still on ${label}. Archive it instead to keep it on them, or remove it from them first.`
+  )
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -48,6 +48,7 @@ import { guardInboxOwnerField } from './pre/inbox-owner-guard'
 import { guardInvoiceDelete } from './pre/invoice-delete-guard'
 import { guardQuoteConvertedDelete } from './pre/quote-delete-guard'
 import { guardQuoteDraftReturnWithPaidDeposit } from './pre/quote-deposit-guard'
+import { rejectDeleteIfTagInUse } from './pre/tag-in-use-guard'
 import {
   dropUnauthorizedSystemFlag,
   rejectDeleteIfSystemTag,
@@ -262,7 +263,15 @@ export function registerAllHooks(): void {
   // The drop hook is what actually enforces invariant 2 (the field's
   // `capabilities.updatable: false` is not read by the write path).
   registerFieldPreHooks('tags', 'tag_template_key', [dropUnauthorizedTemplateKey])
-  registerEntityPreDeleteHooks('tags', [rejectDeleteIfSystemTag, rejectDeleteIfTemplateTag])
+  // ⚠️ ORDER IS THE MESSAGE. The two "never, by anyone" guards run first and throw
+  // 403; only then does the in-use check throw 409. A system tag that also carries
+  // 500 threads must be refused as a system tag, not told to untag itself first —
+  // clearing the references would not make it deletable.
+  registerEntityPreDeleteHooks('tags', [
+    rejectDeleteIfSystemTag,
+    rejectDeleteIfTemplateTag,
+    rejectDeleteIfTagInUse,
+  ])
 
   // Money delete-safety (plans/dispatch/money/12-delete-safety.md §A/§C/§F) — moves the
   // invoice/work-order guard+cleanup logic out of the client-only drawer branch and into the


### PR DESCRIPTION
Deleting a tag silently corrupted every record that carried it. This stops that, and builds the archive path the fix points at.

## The bug

A tag↔record link is **two** `FieldValue` rows:

| side | `entityId` | `relatedEntityId` |
| --- | --- | --- |
| tag | tagId | recordId |
| record | recordId | tagId |

Deleting the tag row cascades its own field values — the tag side goes. The **record side does not**, because `relatedEntityId` has no foreign key (`field-value.ts:93`). Nothing stopped it.

Found on a real org: one deleted tag left **532 orphaned rows**, and the mail list kept rendering a tag that no longer existed. 529 classification markers pointed at the dead id too.

To be clear about what was *not* wrong: the delete itself was legitimate. The tag was user-created, so `rejectDeleteIfTemplateTag` (06 D4) correctly did not fire — seeded categories carry a `tag_template_key` and this one didn't. The authorization was right; only the cleanup was missing.

## 1. The guard

`rejectDeleteIfTagInUse` counts precisely the rows the delete would orphan and refuses while any exist. Deliberately **unfiltered by field** — a thread link, an article link and a child's `tag_parent` are all references that must not dangle. Backed by `FieldValue_relatedEntityId_idx`.

**409, not 403.** Its two siblings guard tags that may *never* be deleted, by anyone. This is a state the caller can clear — untag or archive and the same caller succeeds.

**Registered third**, so the never-guards answer first. A system tag holding 500 threads must be refused *as a system tag*, not told to untag itself — clearing the references wouldn't make it deletable. Verified the fire point is a sequential `await` loop (`unified-handler-mutations.ts:705`), so a throw aborts and order holds.

## 2. The archive path

The guard says "archive instead", and until now you couldn't: the tag manage cluster offered Edit and Delete only.

`record.archive`/`record.restore` already existed and `useAllRecords` already took `includeArchived` — this wires them up. `TagNode` gains `isArchived`, read off the `archivedAt` that `record.listAll` already spreads from the `EntityInstance` row.

⚠️ **The toggle is load-bearing, not a nicety.** Archived tags are hidden by default, so with no way to reveal them archive would be a **one-way door** — the tag vanishes from the only surface that manages tags, with no route back. That is strictly worse than the delete it replaces.

An archived row is muted, badged `Archived`, and offers **restore and nothing else**: editing a retired tag or archiving it twice are both meaningless, and delete stays reachable by restoring first — one deliberate step rather than a trap.

Archive is confirmed despite being reversible, because an archived tag leaves the classifier's label set (`labels.ts:92`) and mail that used to get the category silently stops getting it. Restore isn't confirmed.

## Why archive rather than cascade-on-delete

Cascading looked right and isn't. `tagThreadsBulk` is the single write path for thread tags (`realtime/events.ts:274`) because tag changes keep mail counts, realtime publishes and **provider label push-back** in sync — Gmail and IMAP both implement `removeLabel`. Untagging 532 threads is 532 provider round-trips, i.e. a background job with partial-failure handling, not a `DELETE`. And for a label 529 markers already reference, preserving the historical claim is the better default.

## Testing

- 6 new tests on the guard; 44 field-hooks tests green.
- 25 tag component tests green.
- `tsc --noEmit` clean for `packages/lib` and `apps/web` on every touched file; lint clean.
- Verified in the running app: the tag list renders, editable tags now show three actions (Edit/Archive/Delete) where they showed two, system tags still show none, and the toggle drives `?archived=1` with no console errors.
- Verified the guard's ordering claim against the real fire point rather than assuming it.

## Not included

Cleanup of already-orphaned rows from past deletes. This org's were repaired by hand; a sweep for any others is a separate change.
