### PR TITLE
fix(mail): date threads whose sends never landed, and surface the failure

### DIFF
--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/compact-thread-item.tsx
 'use client'
 
+import { SendStatus } from '@auxx/database/enums'
 import { evaluateConditions, normalizeStatusConditions } from '@auxx/lib/conditions/client'
 import type { ActorId } from '@auxx/types/actor'
 import { toRecordId } from '@auxx/types/resource'
@@ -10,7 +11,16 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNowStrict } from 'date-fns'
 import DOMPurify from 'dompurify'
-import { Archive, Clock, Share2, ShieldAlert, Tag, Trash2, UserRound } from 'lucide-react'
+import {
+  Archive,
+  ChevronRight,
+  Clock,
+  Share2,
+  ShieldAlert,
+  Tag,
+  Trash2,
+  UserRound,
+} from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
@@ -35,9 +45,11 @@ import {
 import { threadFieldResolver } from '~/components/threads/utils/thread-field-resolver'
 import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { AssigneeChip } from './assignee-chip'
+import { useRetrySend } from './hooks'
 import { useMailFilter } from './mail-filter-context'
 import { getIntegrationIcon } from './mail-status-config'
 import { ProcessingMenu } from './mail-thread-item'
+import { SendStatusIndicator } from './send-status-indicator'
 
 export interface CompactThreadItemProps {
   threadId: string
@@ -104,6 +116,18 @@ export const CompactThreadItem = memo(function CompactThreadItem({
 
   const hasDraft = (thread?.draftIds?.length ?? 0) > 0
   const hasScheduledMessage = (thread?.scheduledMessageCount ?? 0) > 0
+
+  // A failed outbound send outranks every other dot in the status slot — it's
+  // the only one that needs the agent to do something. `latestMessage` is
+  // already in the store for the snippet, so this costs no extra fetch.
+  const sendFailed =
+    latestMessage?.isInbound === false &&
+    (latestMessage.sendStatus === SendStatus.FAILED ||
+      latestMessage.sendStatus === SendStatus.BOUNCED)
+  const { retry, isRetrying } = useRetrySend(
+    sendFailed ? latestMessage?.id : undefined,
+    thread?.integrationId
+  )
 
   const isMultiSelected = useIsThreadSelected(threadId)
 
@@ -232,7 +256,18 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                 )}
               </div>
               <div className='flex w-3 shrink-0 items-center justify-center'>
-                {hasScheduledMessage && !hasDraft ? (
+                {sendFailed ? (
+                  <SendStatusIndicator
+                    variant='icon'
+                    status={latestMessage?.sendStatus}
+                    error={latestMessage?.providerError}
+                    attempts={latestMessage?.attempts}
+                    integrationId={thread.integrationId}
+                    onRetry={retry}
+                    isRetrying={isRetrying}
+                    className='size-3'
+                  />
+                ) : hasScheduledMessage && !hasDraft ? (
                   <Clock className='size-2.5 text-amber-500' />
                 ) : hasDraft ? (
                   <div className='size-2 rounded-full bg-red-500' />
@@ -315,7 +350,9 @@ export const CompactThreadItem = memo(function CompactThreadItem({
               )}
               {snippet && (
                 <>
-                  <span className='shrink-0 text-muted-foreground/50'>—</span>
+                  <span className='shrink-0 text-muted-foreground/40'>
+                    <ChevronRight className='size-3' />
+                  </span>
                   <span className='min-w-0 truncate text-xs text-muted-foreground'>{snippet}</span>
                 </>
               )}

--- a/apps/web/src/components/mail/email-display.tsx
+++ b/apps/web/src/components/mail/email-display.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/email-display.tsx
 'use client'
 
+import { SendStatus } from '@auxx/database/enums'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -13,7 +14,6 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { Kbd } from '@auxx/ui/components/kbd'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -45,6 +45,7 @@ import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
 import type { MessageType } from './email-editor/types'
 import { useHtmlBody } from './hooks/use-html-body'
+import { useRetrySend } from './hooks/use-retry-send'
 import { ParticipantList, type ParticipantListEntry } from './participant-display'
 import { SendStatusIndicator } from './send-status-indicator'
 import { initialsFor } from './utils/participant-initials'
@@ -126,21 +127,7 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
     return result
   }, [message, from, to, cc])
 
-  // Retry send mutation
-  const retrySendMessage = api.thread.retrySendMessage.useMutation({
-    onError: (error) => {
-      toastError({
-        title: 'Failed to retry sending',
-        description: error.message,
-      })
-    },
-  })
-
-  const handleRetry = useCallback(() => {
-    if (message) {
-      retrySendMessage.mutate({ messageId: message.id })
-    }
-  }, [message, retrySendMessage])
+  const { retry, isRetrying } = useRetrySend(message?.id, thread?.integrationId)
 
   const editorMessage: MessageType | null = useMemo(
     () => (message ? toEditorMessage(message, { from, to, cc }) : null),
@@ -225,6 +212,11 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
   const isMe = !message.isInbound
   const senderInitials = initialsFor(from)
 
+  // Outbound messages carry a blue frame; a send that never landed swaps it for
+  // a red one so the failure reads from the card, not just the status icon.
+  const sendFailed =
+    isMe && (message.sendStatus === SendStatus.FAILED || message.sendStatus === SendStatus.BOUNCED)
+
   // Read-only seam: a populated `messageActions` always carries `onReply`. When
   // it's empty (e.g. the palette's ReadOnlyThreadProvider) hide every action
   // affordance — the dropdown and the inline reply/forward buttons.
@@ -234,7 +226,10 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
     <div
       className={cn(
         'flex flex-col rounded-2xl border bg-background shadow-xs transition-all duration-200 ease-in-out hover:bg-muted',
-        { 'ring-5 ring-info/5 hover:ring-info/20 border-info': isMe },
+        { 'ring-5 ring-info/5 hover:ring-info/20 border-info': isMe && !sendFailed },
+        {
+          'ring-5 ring-destructive/10 hover:ring-destructive/30 border-destructive': sendFailed,
+        },
         { 'hover:bg-background transition-none': selected }
       )}
       ref={letterRef}>
@@ -281,29 +276,33 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
                 )}
               </AnimatePresence>
             </div>
-            <SendStatusIndicator
-              status={message.sendStatus}
-              error={message.providerError}
-              attempts={message.attempts}
-              onRetry={handleRetry}
-              className='mt-1'
-            />
           </div>
           <div className='flex shrink-0 grow-0 items-start gap-2'>
             <div className='flex flex-col items-end'>
-              {hasActions && (
-                <div className='flex items-center flex-row justify-end'>
-                  <DropdownMenuDemo
-                    message={message}
-                    editorMessage={editorMessage}
-                    emailActions={messageActions}
-                    onMarkUnread={markAsUnread}
-                  />
-                  <Button variant='ghost' size='icon-sm' onClick={handleReply}>
-                    <Reply />
-                  </Button>
-                </div>
-              )}
+              <div className='flex items-center flex-row justify-end gap-1'>
+                <SendStatusIndicator
+                  variant='icon'
+                  status={message.sendStatus}
+                  error={message.providerError}
+                  attempts={message.attempts}
+                  integrationId={thread?.integrationId}
+                  onRetry={retry}
+                  isRetrying={isRetrying}
+                />
+                {hasActions && (
+                  <>
+                    <DropdownMenuDemo
+                      message={message}
+                      editorMessage={editorMessage}
+                      emailActions={messageActions}
+                      onMarkUnread={markAsUnread}
+                    />
+                    <Button variant='ghost' size='icon-sm' onClick={handleReply}>
+                      <Reply />
+                    </Button>
+                  </>
+                )}
+              </div>
               <div className='text-xs text-muted-foreground'>
                 <Tooltip
                   content={message.sentAt ? new Date(message.sentAt).toString() : ''}

--- a/apps/web/src/components/mail/hooks/index.ts
+++ b/apps/web/src/components/mail/hooks/index.ts
@@ -2,4 +2,5 @@
 
 export { useCountUpdates, type ViewDefinition } from './use-count-updates'
 export { useHtmlBody } from './use-html-body'
+export { useRetrySend } from './use-retry-send'
 export { type ThreadCounterparty, useThreadCounterparty } from './use-thread-counterparty'

--- a/apps/web/src/components/mail/hooks/use-retry-send.ts
+++ b/apps/web/src/components/mail/hooks/use-retry-send.ts
@@ -1,0 +1,61 @@
+// apps/web/src/components/mail/hooks/use-retry-send.ts
+'use client'
+
+import type { SendStatus } from '@auxx/database/types'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback } from 'react'
+import { useChannelById } from '~/components/channels/store/channel-store'
+import { getChannelProviderName } from '~/components/channels/ui/channel-icon'
+import { getMessageStoreState } from '~/components/threads/store'
+import { api } from '~/trpc/react'
+import { humanizeSendError } from '../send-status-error'
+
+/**
+ * Wires the retry-send mutation for a single message.
+ *
+ * The server publishes `message:updated` for other tabs, but the tab that
+ * fired the mutation is excluded from its own publish — so the result is
+ * written into the message store here from the mutation's return value.
+ * A retry that the provider rejects again resolves successfully with
+ * `success: false`, which is why the failure branch lives in `onSuccess`.
+ */
+export function useRetrySend(messageId: string | null | undefined, integrationId?: string | null) {
+  const channel = useChannelById(integrationId ?? undefined)
+  const channelName = channel
+    ? channel.name || channel.identifier || getChannelProviderName(channel.provider)
+    : undefined
+
+  const retrySendMessage = api.thread.retrySendMessage.useMutation({
+    onSuccess: (result) => {
+      const id = result.message?.id ?? messageId
+      if (id) {
+        getMessageStoreState().updateMessage(id, {
+          sendStatus: (result.message?.sendStatus ?? null) as SendStatus | null,
+          providerError: result.message?.providerError ?? null,
+          sentAt: result.message?.sentAt ? new Date(result.message.sentAt).toISOString() : null,
+          attempts: result.attemptNumber,
+        })
+      }
+      if (!result.success) {
+        toastError({
+          title: 'Still could not send',
+          description:
+            humanizeSendError(result.message?.providerError ?? result.error, channelName) ??
+            'The provider rejected the message again.',
+        })
+      }
+    },
+    onError: (error) => {
+      toastError({
+        title: 'Could not retry sending',
+        description: error.message || 'This message can no longer be retried.',
+      })
+    },
+  })
+
+  const retry = useCallback(() => {
+    if (messageId) retrySendMessage.mutate({ messageId })
+  }, [messageId, retrySendMessage])
+
+  return { retry, isRetrying: retrySendMessage.isPending }
+}

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/mail-thread-item.tsx
 'use client'
 
+import { SendStatus } from '@auxx/database/enums'
 import { evaluateConditions, normalizeStatusConditions } from '@auxx/lib/conditions/client'
 import type { ActorId } from '@auxx/types/actor'
 import { getInstanceId, type RecordId, toRecordId } from '@auxx/types/resource'
@@ -60,8 +61,10 @@ import { useIsRecordProcessing } from '~/components/workflow/use-is-record-proce
 import { WorkflowSubMenu } from '~/components/workflow/workflow-submenu'
 import { api } from '~/trpc/react'
 import { AssigneeChip } from './assignee-chip'
+import { useRetrySend } from './hooks'
 import { useMailFilter } from './mail-filter-context'
 import { getIntegrationIcon } from './mail-status-config'
+import { SendStatusIndicator } from './send-status-indicator'
 
 /**
  * Processing menu component for triggering manual message processing
@@ -264,6 +267,18 @@ export const MailThreadItem = memo(function MailThreadItem({
   const hasDraft = (thread?.draftIds?.length ?? 0) > 0
   const hasScheduledMessage = (thread?.scheduledMessageCount ?? 0) > 0
 
+  // A failed outbound send outranks every other dot in the status slot — it's
+  // the only one that needs the agent to do something. `latestMessage` is
+  // already in the store for the snippet, so this costs no extra fetch.
+  const sendFailed =
+    latestMessage?.isInbound === false &&
+    (latestMessage.sendStatus === SendStatus.FAILED ||
+      latestMessage.sendStatus === SendStatus.BOUNCED)
+  const { retry, isRetrying } = useRetrySend(
+    sendFailed ? latestMessage?.id : undefined,
+    thread?.integrationId
+  )
+
   // --- Selection state ---
   // isMultiSelected = user-driven checkbox selection (drives checkbox + drag payload).
   // isActive = the thread currently open in the detail pane.
@@ -416,8 +431,22 @@ export const MailThreadItem = memo(function MailThreadItem({
             aria-selected={isHighlighted}
             onClick={handleClick}
             onDragStart={(e) => e.preventDefault()}>
-            {/* Status indicator dot: red for draft, amber clock for scheduled, blue for unread */}
-            {(hasDraft || hasScheduledMessage || isUnread) &&
+            {/* Status indicator dot: warning for a failed send, red for draft, amber clock for scheduled, blue for unread */}
+            {sendFailed ? (
+              <div className='absolute left-1 top-8'>
+                <SendStatusIndicator
+                  variant='icon'
+                  status={latestMessage?.sendStatus}
+                  error={latestMessage?.providerError}
+                  attempts={latestMessage?.attempts}
+                  integrationId={thread.integrationId}
+                  onRetry={retry}
+                  isRetrying={isRetrying}
+                  className='size-3.5'
+                />
+              </div>
+            ) : (
+              (hasDraft || hasScheduledMessage || isUnread) &&
               (hasScheduledMessage && !hasDraft ? (
                 <div
                   className={cn(
@@ -436,7 +465,8 @@ export const MailThreadItem = memo(function MailThreadItem({
                   )}
                   aria-label={hasDraft ? 'Has draft' : 'Unread message'}
                 />
-              ))}
+              ))
+            )}
 
             <div className={cn('absolute left-1', isProcessing ? 'top-1' : 'top-3')}>
               {viewMode === 'edit' ? (

--- a/apps/web/src/components/mail/message-display.tsx
+++ b/apps/web/src/components/mail/message-display.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -37,6 +36,7 @@ import { ContactHoverCard } from '../contacts/contact-hover-card'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
 import { useHtmlBody } from './hooks/use-html-body'
+import { useRetrySend } from './hooks/use-retry-send'
 import { SendStatusIndicator } from './send-status-indicator'
 import { initialsFor } from './utils/participant-initials'
 import { resolveInlineEmailHtml } from './utils/resolve-inline-email-html'
@@ -68,21 +68,7 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
   // Fetch sender participant using the new hook
   const { from: sender } = useMessageParticipants(message?.participants ?? [])
 
-  // Retry send mutation
-  const retrySendMessage = api.thread.retrySendMessage.useMutation({
-    onError: (error) => {
-      toastError({
-        title: 'Failed to retry sending',
-        description: error.message,
-      })
-    },
-  })
-
-  const handleRetry = useCallback(() => {
-    if (message) {
-      retrySendMessage.mutate({ messageId: message.id })
-    }
-  }, [message, retrySendMessage])
+  const { retry, isRetrying } = useRetrySend(message?.id)
 
   // Determine whether HTML is available inline or needs lazy fetch
   const hasInlineHtml = !!message?.textHtml
@@ -171,7 +157,8 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
                     status={message.sendStatus}
                     error={message.providerError}
                     attempts={message.attempts}
-                    onRetry={handleRetry}
+                    onRetry={retry}
+                    isRetrying={isRetrying}
                   />
                 </div>
               </div>

--- a/apps/web/src/components/mail/send-status-error.ts
+++ b/apps/web/src/components/mail/send-status-error.ts
@@ -1,0 +1,44 @@
+// apps/web/src/components/mail/send-status-error.ts
+
+/**
+ * Provider errors are persisted verbatim on `Message.providerError`, and the
+ * provider registry embeds the raw integration id in its copy (see
+ * `packages/lib/src/providers/provider-registry-service.ts`). That id is
+ * meaningless to an agent reading the thread list, so the id is swapped for the
+ * channel's display name at render time — the channel store already holds every
+ * channel, so no extra fetch is needed to resolve it.
+ */
+
+/** Cuid-ish token following the literal word `Integration` in a provider error. */
+const INTEGRATION_ID_PATTERN = 'Integration ([A-Za-z0-9_-]{16,})'
+
+/**
+ * Pulls the integration id out of a provider error so the caller can look the
+ * channel up. Returns undefined when the error doesn't name one.
+ */
+export function extractIntegrationId(error?: string | null): string | undefined {
+  if (!error) return undefined
+  return new RegExp(INTEGRATION_ID_PATTERN).exec(error)?.[1]
+}
+
+/**
+ * Rewrites a raw provider error into copy an agent can act on, naming the
+ * channel instead of its id. Falls back to a generic noun when the channel
+ * isn't in the store (deleted, or another member's personal channel).
+ */
+export function humanizeSendError(
+  error: string | null | undefined,
+  channelName?: string | null
+): string | null {
+  if (!error) return null
+
+  const name = channelName?.trim() || 'This channel'
+
+  // The re-auth error is the common one and reads like a stack trace
+  // ("User must re-connect the integration") — replace it wholesale.
+  if (/requires re-authentication/i.test(error)) {
+    return `${name} needs to be reconnected. Its authorization has expired.`
+  }
+
+  return error.replace(new RegExp(INTEGRATION_ID_PATTERN, 'g'), name)
+}

--- a/apps/web/src/components/mail/send-status-indicator.tsx
+++ b/apps/web/src/components/mail/send-status-indicator.tsx
@@ -2,25 +2,52 @@
 'use client'
 import { SendStatus } from '@auxx/database/enums'
 import type { SendStatus as SendStatusType } from '@auxx/database/types'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { cn } from '@auxx/ui/lib/utils'
 import type { VariantProps } from 'class-variance-authority'
 import { RotateCw } from 'lucide-react'
+import type React from 'react'
+import { useMemo } from 'react'
+import { useChannelById } from '~/components/channels/store/channel-store'
+import { getChannelProviderName } from '~/components/channels/ui/channel-icon'
 import { Tooltip } from '~/components/global/tooltip'
 import { recordBadgeVariants } from '~/components/resources/ui/record-badge'
 import { sendStatusConfig } from './mail-status-config'
+import { extractIntegrationId, humanizeSendError } from './send-status-error'
 
-interface SendStatusIndicatorProps extends VariantProps<typeof recordBadgeVariants> {
+// Only `size` is borrowed from the badge cva — `variant` below is this
+// component's own (badge vs. icon), not `recordBadgeVariants`' default/link.
+interface SendStatusIndicatorProps extends Pick<VariantProps<typeof recordBadgeVariants>, 'size'> {
   status?: SendStatusType | null
   error?: string | null
   attempts?: number
   className?: string
   onRetry?: () => void
+  isRetrying?: boolean
+  /**
+   * `badge` renders the labelled chip used in message headers. `icon` renders a
+   * bare glyph sized for the thread-list status-dot slot and the detail view's
+   * icon-button row.
+   */
+  variant?: 'badge' | 'icon'
+  /**
+   * Channel the message was sent through. Used to name the channel in the error
+   * copy when the provider error doesn't embed an id itself.
+   */
+  integrationId?: string | null
 }
+
 /**
- * Displays the send status of a message as a RecordBadge-style chip with an
- * optional retry button. Reuses `recordBadgeVariants` and the `record-display`
- * / `record-remove` data-slots so it matches `RecordBadge`/`TicketBadge` and
- * renders correctly in dark mode.
+ * Surfaces a non-`SENT` send status. Hovering explains what went wrong; clicking
+ * opens a menu with the full error and a Retry action.
+ *
+ * Renders nothing for `SENT` (and for a missing status), so call sites can drop
+ * it in unconditionally.
  */
 export function SendStatusIndicator({
   status,
@@ -29,7 +56,18 @@ export function SendStatusIndicator({
   className,
   size,
   onRetry,
+  isRetrying,
+  variant = 'badge',
+  integrationId,
 }: SendStatusIndicatorProps) {
+  // Prefer the id the provider named in its own error — a message can be sent
+  // through a channel other than the thread's current one.
+  const channel = useChannelById(extractIntegrationId(error) ?? integrationId ?? undefined)
+  const channelName = channel
+    ? channel.name || channel.identifier || getChannelProviderName(channel.provider)
+    : undefined
+  const friendlyError = useMemo(() => humanizeSendError(error, channelName), [error, channelName])
+
   // Don't show indicator for successfully sent messages
   if (!status || status === SendStatus.SENT) {
     return null
@@ -39,48 +77,102 @@ export function SendStatusIndicator({
   if (!config) return null
   const Icon = config.icon
   const canRetry = status === SendStatus.FAILED && !!onRetry
-  // Build tooltip content for additional details
-  const tooltipContent =
-    error || (attempts && attempts > 1) ? (
-      <div className='max-w-xs'>
-        <p className='font-medium'>{config.description}</p>
-        {error && <p className='mt-1 text-xs text-muted-foreground'>{error}</p>}
-        {attempts && attempts > 1 && (
-          <p className='mt-1 text-xs text-muted-foreground'>Attempted {attempts} times</p>
-        )}
-      </div>
-    ) : undefined
-  return (
-    <Tooltip
-      contentComponent={tooltipContent}
-      content={!tooltipContent ? config.description : undefined}>
-      <div
-        data-slot='record-badge'
-        className={cn(recordBadgeVariants({ size }), config.badgeClass, className)}>
-        <Icon
-          className={cn(
-            'shrink-0',
-            size === 'sm' ? 'size-3' : 'size-3.5',
-            config.animate && 'animate-spin'
-          )}
-        />
+
+  const iconSizeClass = size === 'sm' ? 'size-3' : 'size-3.5'
+
+  const visual =
+    variant === 'icon' ? (
+      // Fills the trigger so the call site sets one size (via `className`)
+      // instead of keeping the button and the glyph in sync by hand.
+      <Icon className={cn('size-full shrink-0', config.color, config.animate && 'animate-spin')} />
+    ) : (
+      <>
+        <Icon className={cn('shrink-0', iconSizeClass, config.animate && 'animate-spin')} />
         <span data-slot='record-display' className='truncate'>
           {config.label}
         </span>
-        {canRetry && (
+      </>
+    )
+
+  const triggerClassName =
+    variant === 'icon'
+      ? cn(
+          'inline-flex size-3.5 shrink-0 items-center justify-center rounded-[3px] focus-visible:outline-none',
+          onRetry && 'cursor-pointer',
+          className
+        )
+      : cn(recordBadgeVariants({ size }), config.badgeClass, onRetry && 'cursor-pointer', className)
+
+  const tooltipContent = (
+    <div className='max-w-xs'>
+      <p className='font-medium'>{config.label}</p>
+      <p className='mt-1 text-xs text-muted-foreground'>{friendlyError ?? config.description}</p>
+      {canRetry && <p className='mt-1 text-xs text-muted-foreground'>Click to retry</p>}
+    </div>
+  )
+
+  // Without a retry handler there's nothing to put in a menu — the tooltip
+  // carries the whole story, so render a plain (non-interactive) indicator.
+  if (!canRetry) {
+    return (
+      <Tooltip contentComponent={tooltipContent}>
+        <div
+          data-slot={variant === 'badge' ? 'record-badge' : undefined}
+          className={triggerClassName}>
+          {visual}
+        </div>
+      </Tooltip>
+    )
+  }
+
+  // The indicator lives inside clickable thread rows and message headers, so
+  // every pointer event it handles has to stop short of opening the thread.
+  const swallow = (e: React.SyntheticEvent) => e.stopPropagation()
+
+  return (
+    <DropdownMenu>
+      {/* `allowInteraction` stops SimpleTooltip preventDefault-ing pointerdown,
+          which would otherwise swallow the trigger's own open gesture. */}
+      <Tooltip contentComponent={tooltipContent} allowInteraction>
+        <DropdownMenuTrigger asChild>
           <button
             type='button'
-            data-slot='record-remove'
-            aria-label='Retry sending'
-            onClick={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              onRetry?.()
-            }}>
-            <RotateCw />
+            aria-label={config.label}
+            data-slot={variant === 'badge' ? 'record-badge' : undefined}
+            className={triggerClassName}
+            onClick={swallow}
+            onPointerDown={swallow}>
+            {visual}
           </button>
+        </DropdownMenuTrigger>
+      </Tooltip>
+      <DropdownMenuContent
+        // Anchored to the trigger's start so the list-row icon (far left) opens
+        // rightward instead of over the sidebar; Radix flips it for the
+        // detail-view icon row, which sits against the right edge.
+        align='start'
+        className='w-72 p-3'
+        onClick={swallow}
+        onPointerDown={swallow}>
+        <p className='text-sm font-medium'>{config.label}</p>
+        <p className='mt-1 text-xs text-muted-foreground'>{friendlyError ?? config.description}</p>
+        {attempts !== undefined && attempts > 1 && (
+          <p className='mt-1 text-xs text-muted-foreground'>Attempted {attempts} times</p>
         )}
-      </div>
-    </Tooltip>
+        <Button
+          variant='outline'
+          size='sm'
+          className='mt-3 w-full'
+          loading={isRetrying}
+          loadingText='Retrying...'
+          onClick={(e) => {
+            e.stopPropagation()
+            onRetry?.()
+          }}>
+          <RotateCw />
+          Retry sending
+        </Button>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/packages/lib/src/data-migrations/migrations/077-backfill-unsent-thread-dates.ts
+++ b/packages/lib/src/data-migrations/migrations/077-backfill-unsent-thread-dates.ts
@@ -1,0 +1,117 @@
+// packages/lib/src/data-migrations/migrations/077-backfill-unsent-thread-dates.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-077')
+
+/** Threads scanned per statement. */
+const BATCH_SIZE = 500
+
+/** Log a progress line every N batches so a long run is observable. */
+const LOG_EVERY = 20
+
+/**
+ * Repair `Thread.firstMessageAt` / `Thread.lastMessageAt` on threads whose only
+ * messages were never delivered.
+ *
+ * **Why.** Both thread-metadata recomputes used to aggregate
+ * `MIN/MAX("sentAt")` filtered on `sentAt IS NOT NULL`, and the reconciler nulls
+ * `sentAt` when a provider rejects a send. An outbound-only thread whose send
+ * failed therefore ended up with `lastMessageAt = NULL` while still carrying a
+ * real `latestMessageId`. Two things went wrong downstream, and neither raised
+ * an error:
+ *
+ * 1. The list projection substituted the current time for the NULL, so the row
+ *    rendered its age as "0 seconds" on every fetch, forever.
+ * 2. List ordering is `ORDER BY "lastMessageAt" DESC`, and Postgres sorts NULLs
+ *    first under `DESC` — so every one of these threads pinned itself to the top
+ *    of every newest-first list.
+ *
+ * The recomputes now coalesce to `createdAt`, but that only fixes threads that
+ * get written again. This pass repairs the rows already sitting at NULL.
+ *
+ * **Scoped to the broken rows.** The `WHERE` matches only threads that have at
+ * least one message and a NULL `lastMessageAt`, so a healthy thread is never
+ * rewritten. `messageCount` is deliberately left alone: it still counts
+ * delivered messages only, which is the existing semantic everywhere else.
+ *
+ * **Batched and resumable.** Keyset-paginated on `id`, and because the predicate
+ * only ever matches rows that are still NULL, a re-run after a partial failure
+ * is a no-op over the part that already succeeded.
+ *
+ * Self-sufficient: touches only columns that already exist, and depends on no
+ * runtime step landing first.
+ */
+export const migration077BackfillUnsentThreadDates: DataMigrationDef = {
+  id: '077-backfill-unsent-thread-dates',
+  description: 'Backfill Thread first/lastMessageAt for threads whose sends never landed',
+  async run(db: Database): Promise<void> {
+    let cursor = ''
+    let scanned = 0
+    let updated = 0
+    let batches = 0
+
+    for (;;) {
+      // `batch` is MATERIALIZED so the keyset page is computed once and shared
+      // by the UPDATE and the accounting SELECT.
+      const result = await db.execute<{
+        lastId: string | null
+        scanned: number
+        updated: number
+      }>(sql`
+        WITH batch AS MATERIALIZED (
+          SELECT id
+          FROM "Thread"
+          WHERE id > ${cursor}
+          ORDER BY id
+          LIMIT ${BATCH_SIZE}
+        ),
+        touched AS (
+          UPDATE "Thread" t
+          SET
+            "firstMessageAt" = m.first_at,
+            "lastMessageAt" = m.last_at
+          FROM batch
+          JOIN LATERAL (
+            SELECT
+              MIN(COALESCE("sentAt", "createdAt")) AS first_at,
+              MAX(COALESCE("sentAt", "createdAt")) AS last_at
+            FROM "Message"
+            WHERE "threadId" = batch.id
+          ) m ON TRUE
+          WHERE t.id = batch.id
+            AND t."lastMessageAt" IS NULL
+            AND m.last_at IS NOT NULL
+          RETURNING t.id
+        )
+        SELECT
+          (SELECT max(id) FROM batch) AS "lastId",
+          (SELECT count(*) FROM batch)::int AS "scanned",
+          (SELECT count(*) FROM touched)::int AS "updated"
+      `)
+
+      const row = result.rows[0]
+      if (!row?.lastId || Number(row.scanned) === 0) break
+
+      cursor = row.lastId
+      scanned += Number(row.scanned)
+      updated += Number(row.updated)
+      batches += 1
+
+      if (batches % LOG_EVERY === 0) {
+        logger.info('Backfilling unsent thread dates', { scanned, updated, cursor })
+      }
+
+      if (Number(row.scanned) < BATCH_SIZE) break
+    }
+
+    logger.info('Backfilled thread dates for sends that never landed', {
+      scanned,
+      updated,
+      batches,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -41,6 +41,7 @@ import { migration071BackfillOutlookPlainText } from './migrations/071-backfill-
 import { migration072MailFiltersLimit } from './migrations/072-mail-filters-limit'
 import { migration073BackfillBulkMailFields } from './migrations/073-backfill-bulk-mail-fields'
 import { migration076MailCategoryRework } from './migrations/076-mail-category-rework'
+import { migration077BackfillUnsentThreadDates } from './migrations/077-backfill-unsent-thread-dates'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -108,6 +109,7 @@ function buildRegistry(): DataMigrationDef[] {
     // shared sequence and both sort before 076, which depends on the fields they
     // materialize.
     migration076MailCategoryRework,
+    migration077BackfillUnsentThreadDates,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/ingest/threads/update-metadata.ts
+++ b/packages/lib/src/ingest/threads/update-metadata.ts
@@ -36,17 +36,19 @@ export async function updateThreadMetadataEfficient(
           WHERE "threadId" = ${threadId}
             AND "sentAt" IS NOT NULL
         ), 0),
+        -- Kept in step with \`ThreadManagerService.updateThreadMetadata\`: dates
+        -- fall back to "createdAt" so a message the provider rejected still
+        -- dates the thread, instead of leaving "lastMessageAt" NULL for the
+        -- list projection to paper over with the current time.
         "firstMessageAt" = (
-          SELECT MIN("sentAt")
+          SELECT MIN(COALESCE("sentAt", "createdAt"))
           FROM "Message"
           WHERE "threadId" = ${threadId}
-            AND "sentAt" IS NOT NULL
         ),
         "lastMessageAt" = (
-          SELECT MAX("sentAt")
+          SELECT MAX(COALESCE("sentAt", "createdAt"))
           FROM "Message"
           WHERE "threadId" = ${threadId}
-            AND "sentAt" IS NOT NULL
         ),
         "latestMessageId" = (
           SELECT id

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -20,7 +20,7 @@ import { getThreadLens } from '../permissions/visibility/thread-lens'
 import type { NormalizedEmailError as NormalizedEmailErrorInstance } from '../providers/error-normalization'
 import type { AttachmentFile } from '../providers/message-provider-interface'
 import type { ProviderRegistryService } from '../providers/provider-registry-service'
-import { getRealtimeService, publishMessageCreated } from '../realtime'
+import { getRealtimeService, publishMessageCreated, publishMessageUpdated } from '../realtime'
 import { Result } from '../result'
 import { isSuppressed } from '../sequences/suppression'
 import { getOrganizationSetting } from '../settings/settings-service'
@@ -1125,8 +1125,8 @@ export class MessageSenderService {
       const sendParams = await this.extractRetryParameters(failedMessage)
       // 5. Send directly via provider (skip composition)
       const result = await this.retrySendViaProvider(sendParams)
-      // 6. Handle result and update message status
-      return await this.processRetryResult(failedMessage.id, result, attemptNumber)
+      // 6. Run the same post-send tail a first-time send runs
+      return await this.finalizeRetry(failedMessage, result, attemptNumber)
     } catch (error) {
       logger.error('Failed to retry message', {
         messageId: input.messageId,
@@ -1410,67 +1410,118 @@ export class MessageSenderService {
         provider: providerType,
         messageId: params.messageId,
       })
-      // Update message with error - don't throw, let processRetryResult handle it.
-      // The provider's own text is merged into metadata rather than assigned, so
-      // the earlier reconciliation bookkeeping survives the retry.
-      const raw = extractProviderErrorText(error)
-      await db
-        .update(schema.Message)
-        .set({
-          sendStatus: 'FAILED' as any,
-          providerError: normalizedError.message,
-          ...(raw ? { metadata: providerErrorRawMerge(raw) } : {}),
-        })
-        .where(eq(schema.Message.id, params.messageId))
-      // Return failure response instead of throwing
+      // Don't throw and don't write the row here — returning a failure response
+      // lets `finalizeRetry` put it through the reconciler, which is the single
+      // writer of `sendStatus`/`providerError` on every other send path.
       return {
         success: false,
         error: normalizedError.message,
         timestamp: new Date(),
-        metadata: { error: normalizedError, providerErrorRaw: raw },
+        metadata: { error: normalizedError, providerErrorRaw: extractProviderErrorText(error) },
       }
     }
   }
   /**
-   * Processes the result of a retry attempt
+   * Runs the post-send tail for a retry attempt.
+   *
+   * A retry is a second run of the *same* send, so it goes through the same
+   * infrastructure `sendMessage` uses rather than hand-writing message rows:
+   * the reconciler owns `sendStatus`/`sentAt`/`externalId`/`lastAttemptAt`,
+   * thread counters get recomputed, and a `message:updated` goes out so open
+   * tabs reflect the result without a reload.
    */
-  private async processRetryResult(
-    messageId: string,
+  private async finalizeRetry(
+    failedMessage: any,
     result: ProviderSendResponse,
     attemptNumber: number
   ): Promise<RetryMessageResult> {
-    if (result.success) {
-      // Update message as sent
-      await db
-        .update(schema.Message)
-        .set({
-          sendStatus: 'SENT' as any,
-          externalId: result.messageId ?? null,
-          metadata: (result.metadata as any) ?? {},
-          sentAt: result.timestamp ?? new Date(),
-        })
-        .where(eq(schema.Message.id, messageId))
-      // Get updated message
-      const message = await this.getUpdatedMessage(messageId)
-      logger.info('Message retry successful', {
-        messageId,
-        attemptNumber,
-        externalId: result.messageId,
+    const messageId = failedMessage.id as string
+    const threadId = failedMessage.threadId as string
+    const integrationId = failedMessage.integrationId as string
+    const capabilities = await this.getCapabilitiesForIntegration(integrationId)
+
+    // Step 7 equivalent: per-message bookkeeping, thread reconciliation gated on
+    // the provider having external thread state to reconcile against.
+    await this.reconciler.reconcileSentMessage({
+      messageId,
+      sendToken: failedMessage.sendToken ?? '',
+      providerResponse: result,
+      threadContext: {
+        id: threadId,
+        organizationId: this.organizationId,
+        integrationId,
+        externalId: failedMessage.thread?.externalId ?? null,
+        isPending: false,
+      },
+      reconcileThread: capabilities.requiresSendReconciliation,
+    })
+
+    // The reconciler replaces `metadata` wholesale, so the provider's own text
+    // has to be merged back in afterwards or it is lost (same as Step 7).
+    if (!result.success) {
+      await this.persistProviderErrorRaw(messageId, result.metadata?.providerErrorRaw)
+    }
+
+    // Step 8 equivalent. Thread counters are derived from `MAX(sentAt)`, so a
+    // retry that finally lands has to recompute them — otherwise the thread
+    // keeps `lastMessageAt = NULL` and renders as "0 seconds" forever.
+    await this.threadManager.updateThreadMetadata(threadId)
+    await this.threadManager.updateThreadParticipants(threadId)
+    await touchActivityForThreadLinks(threadId, this.organizationId)
+
+    const message = await this.getUpdatedMessage(messageId)
+
+    // Realtime: the row already exists client-side, so this is an update rather
+    // than the `message:created` a first-time send publishes.
+    try {
+      const [threadRow] = await (this.db ?? db)
+        .select({ inboxId: schema.Thread.inboxId, assigneeId: schema.Thread.assigneeId })
+        .from(schema.Thread)
+        .where(eq(schema.Thread.id, threadId))
+        .limit(1)
+      await publishMessageUpdated(
+        getRealtimeService(),
+        this.organizationId,
+        {
+          messageId,
+          threadId,
+          inboxId: threadRow?.inboxId ?? null,
+          assigneeId: threadRow?.assigneeId ?? null,
+          patch: {
+            sendStatus: message.sendStatus,
+            providerError: message.providerError ?? null,
+            sentAt: message.sentAt ? new Date(message.sentAt).toISOString() : null,
+            attempts: attemptNumber,
+          },
+        },
+        { excludeSocketId: this.socketId }
+      )
+    } catch (err) {
+      logger.debug('Failed to publish message:updated for retry (non-critical)', {
+        err: err instanceof Error ? err.message : err,
       })
-      return {
-        success: true,
-        message,
-        attemptNumber,
-      }
-    } else {
-      // Already updated as failed in retrySendViaProvider catch block
-      const message = await this.getUpdatedMessage(messageId)
-      return {
-        success: false,
-        message,
-        attemptNumber,
-        error: 'Failed to send message via provider',
-      }
+    }
+
+    // Step 9 equivalent — only meaningful once the provider actually accepted it.
+    if (result.success && capabilities.triggersPostSendSync) {
+      await this.triggerPostSendSync(integrationId, {
+        messageId,
+        threadId,
+        sendToken: failedMessage.sendToken ?? '',
+      })
+    }
+
+    logger.info('Message retry finalized', {
+      messageId,
+      attemptNumber,
+      success: result.success,
+    })
+
+    return {
+      success: result.success,
+      message,
+      attemptNumber,
+      error: result.success ? undefined : (result.error ?? 'Failed to send message via provider'),
     }
   }
 }

--- a/packages/lib/src/messages/thread-manager.service.ts
+++ b/packages/lib/src/messages/thread-manager.service.ts
@@ -331,17 +331,22 @@ export class ThreadManagerService {
             WHERE "threadId" = ${threadId}
               AND "sentAt" IS NOT NULL
           ), 0),
+          -- Dates fall back to "createdAt" for messages that never got a
+          -- "sentAt" (a send the provider rejected). Aggregating on "sentAt"
+          -- alone left an outbound-only thread with "lastMessageAt" NULL, which
+          -- the list projection then papered over with the current time —
+          -- rendering as "0 seconds" forever and pinning the row to the top of
+          -- every newest-first list (DESC sorts NULLs first). "messageCount"
+          -- deliberately still counts delivered messages only.
           "firstMessageAt" = (
-            SELECT MIN("sentAt")
+            SELECT MIN(COALESCE("sentAt", "createdAt"))
             FROM "Message"
             WHERE "threadId" = ${threadId}
-              AND "sentAt" IS NOT NULL
           ),
           "lastMessageAt" = (
-            SELECT MAX("sentAt")
+            SELECT MAX(COALESCE("sentAt", "createdAt"))
             FROM "Message"
             WHERE "threadId" = ${threadId}
-              AND "sentAt" IS NOT NULL
           ),
           "latestMessageId" = (
             SELECT id

--- a/packages/lib/src/messages/types/message-sending.types.ts
+++ b/packages/lib/src/messages/types/message-sending.types.ts
@@ -130,6 +130,8 @@ export interface SentMessage {
   subject: string
   sendStatus: SendStatus
   sentAt: Date | null
+  /** Sanitized provider failure text, selected alongside the status. */
+  providerError?: string | null
   error?: string | null
   /**
    * Resolved participants (id + role) for the sent message, so the client can


### PR DESCRIPTION
## The bug

Six `Reminder: your visit is coming up` threads showed **"0 seconds"** in the thread list and sat pinned above everything else. Their sends had genuinely failed at the time (expired Gmail auth), but the display was lying about it.

Root cause: both thread-metadata recomputes derived the date columns from `MIN/MAX("sentAt")` filtered on `sentAt IS NOT NULL`, and the reconciler nulls `sentAt` when a provider rejects a send. So an outbound-only thread whose send failed kept `lastMessageAt = NULL` while still carrying a real `latestMessageId`. Two silent consequences:

1. The list projection substituted `new Date()` for the NULL, so the row re-read its own age as "0 seconds" on every fetch, forever.
2. Ordering is `ORDER BY "lastMessageAt" DESC`, and Postgres sorts NULLs **first** under `DESC`, so these threads pinned themselves to the top of every newest-first list.

## Fixes

**Dating.** Both recompute sites now use `MAX(COALESCE("sentAt", "createdAt"))`, so a rejected message still dates its thread. Fixing this at the source keeps `ThreadMeta.lastMessageAt` non-nullable (it has ~30 consumers) and needs no cursor changes. `messageCount` deliberately still counts delivered messages only. **Migration 077** repairs rows already sitting at NULL.

**Retry reuses the send infrastructure.** It had built its own path: hand-written message rows, skipping the reconciler, the thread-metadata recompute, activity touch, post-send sync, and any realtime publish. The missing publish is exactly why a retry never appeared without a reload, and the missing recompute meant even a *successful* retry left the thread undated. It now runs the same tail as a first-time send via `finalizeRetry`, with the reconciler as the single writer of `sendStatus`/`providerError`, and publishes `message:updated`. The duplicate failure write inside `retrySendViaProvider` is gone.

**Surfacing, at no extra fetch cost.** Both list rows already load the latest message for the snippet, and `sendStatus`/`providerError`/`attempts` were already in that batch and on the client type, so this is purely a render change.

- `SendStatusIndicator` gains an icon variant: tooltip on hover, dropdown with the error and a Retry action on click. It takes the status-dot slot in both row variants, above scheduled/draft/unread.
- Detail view moves the indicator left of the overflow button, and the message card's frame plus hover ring turn red on a failed send.
- Provider errors embedded a raw integration id (`Integration bytr9n3jh... requires re-authentication`). `humanizeSendError` now names the channel from the already-hydrated channel store: *"markus@auxx.ai needs to be reconnected. Its authorization has expired."*

## Verification

Driven in the browser end to end. A retry flipped the card red to blue in place with no reload; the DB then showed `sendStatus SENT`, `lastMessageAt` recomputed, `providerError` cleared, and `lastAttemptAt` set (the old path never wrote that field). The list dropdown opens without the row click opening the thread, and "0 seconds" is gone.

- `packages/lib` 29 typecheck errors, `apps/web` 16 — both unchanged baselines, none in touched files
- 256 tests pass across `src/data-migrations`, `src/messages`, `src/ingest/threads`
- Biome clean on every touched file
- Migration SQL exercised against a deliberately re-broken row: repairs it, skips healthy rows

## Notes for review

- `SimpleTooltip` calls `preventDefault()` on pointerdown, which silently swallows a nested trigger's open gesture. That is what `allowInteraction` is for; worth knowing before wrapping any other interactive element in a tooltip.
- Open question left for you: should `messageCount` count unsent messages? A thread with one failed message currently reports 0. I left the existing semantic alone rather than guess.
