### PR TITLE
fix(mail): move the assign popover onto the assignee avatar

### DIFF
--- a/apps/web/src/components/mail/assignee-chip.tsx
+++ b/apps/web/src/components/mail/assignee-chip.tsx
@@ -5,20 +5,28 @@ import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
+import { UserRound } from 'lucide-react'
+import type React from 'react'
 import { useActor } from '~/components/resources/hooks'
 
 interface AssigneeChipProps {
-  assigneeId: ActorId
+  assigneeId: ActorId | null | undefined
   className?: string
+  /**
+   * When set, the chip becomes the assign trigger. The assign picker anchors to
+   * the chip's own DOM node, so the popover opens where the avatar sits.
+   */
+  onClick?: () => void
 }
 
 /**
  * Compact assignee avatar shown inline next to a thread subject in the inbox
  * list. Provider-agnostic — works for chat, email, or any thread with an
- * assignee.
+ * assignee. Falls back to a placeholder person icon when nothing is assigned.
  */
-export function AssigneeChip({ assigneeId, className }: AssigneeChipProps) {
+export function AssigneeChip({ assigneeId, className, onClick }: AssigneeChipProps) {
   const assigneeUserId = (() => {
+    if (!assigneeId) return null
     try {
       return parseActorId(assigneeId).id
     } catch {
@@ -31,8 +39,6 @@ export function AssigneeChip({ assigneeId, className }: AssigneeChipProps) {
     enabled: !!assigneeUserId,
   })
 
-  if (!assigneeUserId) return null
-
   const name = assignee?.name || 'A teammate'
   const initials =
     name
@@ -42,12 +48,44 @@ export function AssigneeChip({ assigneeId, className }: AssigneeChipProps) {
       .toUpperCase()
       .substring(0, 2) || '?'
 
+  const chip = assigneeUserId ? (
+    <Avatar className={cn('size-4 shrink-0', className)}>
+      <AvatarImage src={assignee?.avatarUrl || undefined} alt={name} />
+      <AvatarFallback className='text-[8px] text-muted-foreground'>{initials}</AvatarFallback>
+    </Avatar>
+  ) : (
+    <UserRound
+      className={cn(
+        'size-3.5 shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground',
+        className
+      )}
+    />
+  )
+
+  if (!onClick) {
+    return (
+      <SimpleTooltip content={name} side='right' delayDuration={300}>
+        {chip}
+      </SimpleTooltip>
+    )
+  }
+
   return (
-    <SimpleTooltip content={name} side='right' delayDuration={300}>
-      <Avatar className={cn('size-4 shrink-0', className)}>
-        <AvatarImage src={assignee?.avatarUrl || undefined} alt={name} />
-        <AvatarFallback className='text-[8px] text-muted-foreground'>{initials}</AvatarFallback>
-      </Avatar>
+    <SimpleTooltip
+      content={assigneeUserId ? name : 'Assign'}
+      shortcut='A'
+      side='right'
+      delayDuration={300}>
+      <button
+        type='button'
+        aria-label={assigneeUserId ? `Assigned to ${name}` : 'Assign'}
+        className='flex size-5 items-center justify-center rounded-full hover:bg-accent'
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation()
+          onClick()
+        }}>
+        {chip}
+      </button>
     </SimpleTooltip>
   )
 }

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -11,16 +11,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNowStrict } from 'date-fns'
 import DOMPurify from 'dompurify'
-import {
-  Archive,
-  ChevronRight,
-  Clock,
-  Share2,
-  ShieldAlert,
-  Tag,
-  Trash2,
-  UserRound,
-} from 'lucide-react'
+import { Archive, ChevronRight, Clock, Share2, ShieldAlert, Tag, Trash2 } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
@@ -314,9 +305,15 @@ export const CompactThreadItem = memo(function CompactThreadItem({
               )}
             </div>
 
-            {/* Assignee avatar - fixed slot to avoid layout shift */}
-            <div className='flex w-5 shrink-0 items-center justify-center ms-1.5'>
-              {thread.assigneeId && <AssigneeChip assigneeId={thread.assigneeId as ActorId} />}
+            {/* Assignee avatar — fixed slot to avoid layout shift, and the assign
+                picker's anchor (see `assign-anchor-` lookup in mail-thread-list) */}
+            <div
+              id={`assign-anchor-${threadId}`}
+              className='flex w-5 shrink-0 items-center justify-center ms-1.5'>
+              <AssigneeChip
+                assigneeId={thread.assigneeId as ActorId | null}
+                onClick={() => onAssignClick?.(threadId)}
+              />
             </div>
 
             {/* Tags */}
@@ -391,15 +388,6 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                     className='size-6'
                     onClick={() => update(threadId, { status: 'SPAM' })}>
                     <ShieldAlert className='size-3.5' />
-                  </Button>
-                </Tooltip>
-                <Tooltip content='Assign' shortcut='A' delayDuration={300}>
-                  <Button
-                    variant='ghost'
-                    size='icon'
-                    className='size-6'
-                    onClick={() => onAssignClick?.(threadId)}>
-                    <UserRound className='size-3.5' />
                   </Button>
                 </Tooltip>
                 <Tooltip content='Tag' shortcut='T' delayDuration={300}>

--- a/apps/web/src/components/mail/mail-thread-list.tsx
+++ b/apps/web/src/components/mail/mail-thread-list.tsx
@@ -147,13 +147,18 @@ export const ThreadList = memo(function ThreadList({
   const { selectedTags: tagPickerCurrentTags, handleTagChange: handleFocusedTagChange } =
     useThreadTags(tagPickerThreadId ?? '')
 
-  // Anchor ref for assign picker popover — points to the focused thread's DOM element
+  // Anchor ref for the assign picker — points at the thread's assignee avatar
+  // slot so the popover opens where the chip is (falling back to the whole row
+  // for variants that have no chip). Resolved during render rather than in an
+  // effect: `ActorPicker` mounts in this same commit and Radix reads
+  // `virtualRef.current` from a child effect, which runs *before* a parent
+  // effect would have filled it — leaving the first open mispositioned.
   const assignAnchorRef = useRef<HTMLElement | null>(null)
-  useEffect(() => {
-    if (assignPickerThreadId && assignPickerOpen) {
-      assignAnchorRef.current = document.getElementById(`thread-${assignPickerThreadId}`) ?? null
-    }
-  }, [assignPickerThreadId, assignPickerOpen])
+  if (assignPickerThreadId && assignPickerOpen) {
+    assignAnchorRef.current =
+      document.getElementById(`assign-anchor-${assignPickerThreadId}`) ??
+      document.getElementById(`thread-${assignPickerThreadId}`)
+  }
 
   // Assign handler for focused thread
   const { update: updateThread } = useThreadMutation()
@@ -317,7 +322,7 @@ export const ThreadList = memo(function ThreadList({
           multi={false}
           target='user'
           emptyLabel='Assign'
-          align='end'
+          align='start'
           side='bottom'
         />
       )}


### PR DESCRIPTION
## What

The assign action lived in the far-right hover cluster while the assignee avatar sat in its own slot on the left — and the popover anchored to neither. It anchored to the whole row (`align='end' side='bottom'`), so it opened at the row's bottom-right corner no matter which control triggered it.

The chip is now the trigger:

- `AssigneeChip` accepts a null `assigneeId` and renders a placeholder `UserRound` icon when nothing is assigned (dimmed, brightening on row hover) instead of rendering nothing.
- With the new optional `onClick` it wraps in a button that stops propagation (so the row doesn't open), tooltipped "Assign" + the `A` shortcut.
- The avatar slot carries `id={`assign-anchor-${threadId}`}`; `mail-thread-list` resolves that first and falls back to the row `thread-<id>` for the non-compact variant. Picker flipped to `align='start'`.
- The separate assign `Button` in the hover-actions cluster is removed. The `A` hotkey path anchors to the same slot.

## Note on the anchor resolution

`assignAnchorRef` was filled in a `useEffect`, but `ActorPicker` mounts in the same commit and Radix reads `virtualRef.current` from a *child* effect — which runs before the parent's. Against the whole row that was survivable; against a 20px avatar the first open would land wrong. It now resolves during render, before the picker mounts.

## Testing

`tsc --noEmit` on apps/web is clean for all touched files. Not verified in the browser.

Known nit, pre-existing: clicking the chip while the popover is already open closes it on outside-pointerdown and the click immediately reopens it, so it doesn't toggle shut.