### PR TITLE
fix(fields): land group drops where the insert line promised, and let empty groups hold a position

### DIFF
--- a/apps/web/src/components/fields/entity-fields-content.tsx
+++ b/apps/web/src/components/fields/entity-fields-content.tsx
@@ -53,8 +53,13 @@ export interface EntityFieldsContentProps {
   isEditMode: boolean
   /** Enter edit mode (snapshots the current view into a draft buffer) */
   onEnterEditMode: () => void
-  /** Leave edit mode, discarding the draft */
+  /** Leave edit mode, discarding the draft — the footer's explicit Cancel */
   onCancelEditMode: () => void
+  /**
+   * Leave edit mode via the header's X. Unlike Cancel this is not a decision to
+   * discard, so the owner prompts to save or discard when the draft is dirty.
+   */
+  onExitEditMode: () => void | Promise<void>
   /** Persist the draft (order + visibility) as one config write */
   onSaveView: () => void | Promise<void>
   /** Whether the view config is currently being persisted */
@@ -63,7 +68,12 @@ export interface EntityFieldsContentProps {
   setDialogOpen: (value: boolean) => void
   editingResourceFieldId: ResourceFieldId | null
   sensors: SensorDescriptor<SensorOptions>[]
-  handleDragEnd: (event: DragEndEvent) => void
+  /**
+   * Drop handler for a FIELD drag. `edge` names which side of the target the
+   * field lands on, read from the pre-drag positions so the drop agrees with
+   * the insert line.
+   */
+  handleDragEnd: (event: DragEndEvent, edge?: 'before' | 'after') => void
   /** Unified sorted fields (system + custom) */
   fields: ResourceField[]
   /** Loading state */
@@ -127,6 +137,7 @@ export function EntityFieldsContent({
   isEditMode,
   onEnterEditMode,
   onCancelEditMode,
+  onExitEditMode,
   onSaveView,
   isSaving = false,
   dialogOpen,
@@ -365,17 +376,25 @@ export function EntityFieldsContent({
    * Turn the hovered droppable into the ONE line to draw and the ONE group to
    * light up.
    *
-   * The highlight means "you will be inside this group" — it is drawn for a
-   * field about to join a group and for a group about to snap against another
-   * group's block, and deliberately NOT for `group-before`/`group-after`, which
-   * land the field outside every group.
+   * The highlight answers "will this end up INSIDE that group", and its colour
+   * answers it in both directions:
+   *
+   * - `blocked: false` (blue) — a FIELD about to join the group. It really will
+   *   be a member.
+   * - `blocked: true` (grey) — a GROUP hovering another group. Groups do not
+   *   nest, so the drop repositions the block against that group's boundary
+   *   instead. The fill says "not into this"; the insert line still says where
+   *   the block lands, which is why lines stay blue in both cases.
+   *
+   * Deliberately NOT drawn for `group-before`/`group-after`: those land the
+   * field outside every group, so there is no group to be inside of.
    */
   const deriveDropFeedback = (): {
     indicator: DropIndicator | null
-    highlightGroupId: string | null
+    highlight: { groupId: string; blocked: boolean } | null
   } => {
     if (dropTarget === null || activeDragId === null) {
-      return { indicator: null, highlightGroupId: null }
+      return { indicator: null, highlight: null }
     }
 
     const anchorIndexOfGroup = (groupId: string): number => {
@@ -393,27 +412,29 @@ export function EntityFieldsContent({
           : dropTarget.groupId
       if (referenceGroupId === null) {
         const fieldId = dropTarget.kind === 'field' ? dropTarget.fieldId : null
-        if (fieldId === null) return { indicator: null, highlightGroupId: null }
+        if (fieldId === null) return { indicator: null, highlight: null }
         const side = edgeFor(orderIndexById.get(fieldId) ?? -1)
         return {
           indicator: { kind: 'row', rowId: fieldId, side, inset: false },
-          highlightGroupId: null,
+          highlight: null,
         }
       }
-      if (referenceGroupId === activeGroupId) return { indicator: null, highlightGroupId: null }
+      if (referenceGroupId === activeGroupId) return { indicator: null, highlight: null }
       const side = edgeFor(anchorIndexOfGroup(referenceGroupId))
       return {
         indicator: { kind: 'group', groupId: referenceGroupId, side, inset: false },
-        highlightGroupId: referenceGroupId,
+        // A group hovering a group: the block lands beside it, never inside it.
+        highlight: { groupId: referenceGroupId, blocked: true },
       }
     }
 
     switch (dropTarget.kind) {
       case 'field': {
         const side = edgeFor(orderIndexById.get(dropTarget.fieldId) ?? -1)
+        const targetGroupId = groupIdByFieldId.get(dropTarget.fieldId) ?? null
         return {
           indicator: { kind: 'row', rowId: dropTarget.fieldId, side, inset: false },
-          highlightGroupId: groupIdByFieldId.get(dropTarget.fieldId) ?? null,
+          highlight: targetGroupId === null ? null : { groupId: targetGroupId, blocked: false },
         }
       }
       case 'group-into': {
@@ -426,23 +447,23 @@ export function EntityFieldsContent({
             firstMemberId === undefined
               ? null
               : { kind: 'row', rowId: firstMemberId, side: 'top', inset: false },
-          highlightGroupId: dropTarget.groupId,
+          highlight: { groupId: dropTarget.groupId, blocked: false },
         }
       }
       case 'group-before':
         return {
           indicator: { kind: 'group', groupId: dropTarget.groupId, side: 'top', inset: false },
-          highlightGroupId: null,
+          highlight: null,
         }
       case 'group-after':
         return {
           indicator: { kind: 'group', groupId: dropTarget.groupId, side: 'bottom', inset: true },
-          highlightGroupId: null,
+          highlight: null,
         }
     }
   }
 
-  const { indicator, highlightGroupId } = deriveDropFeedback()
+  const { indicator, highlight } = deriveDropFeedback()
 
   const lineForRow = (rowId: string, side: 'top' | 'bottom'): boolean =>
     indicator?.kind === 'row' && indicator.rowId === rowId && indicator.side === side
@@ -462,7 +483,13 @@ export function EntityFieldsContent({
    * - a FIELD may not target its own row (`x-before` and the bare `x` both
    *   resolve to the same no-op),
    * - a GROUP may not land inside its own block — its members' rows, its own
-   *   header, its own `-before`/`-after-group` boundaries.
+   *   header, its own `-before`/`-after-group` boundaries,
+   * - a GROUP may not target an EMPTY group at all. An empty group has no index
+   *   in `fieldOrder` (its end-of-list slot is a render convention), so
+   *   `moveGroupBlock` has no honest insertion point and refuses every one of
+   *   its three droppables. Letting it become `over` drew a highlight and an
+   *   insert line for a drop that then did nothing. A FIELD drag still targets
+   *   it — that is the only way a new group ever gets its first member.
    *
    * Filtering here rather than per-row is what lets every affordance below key
    * off `over` alone: an invalid target simply never becomes `over`, so no
@@ -489,10 +516,15 @@ export function EntityFieldsContent({
     const ownMemberIds = new Set(
       sectionsRef.current.find((section) => section.group?.id === draggedGroupId)?.fieldIds ?? []
     )
+    const emptyGroupIds = new Set(
+      sectionsRef.current
+        .filter((section) => section.group !== null && section.fieldIds.length === 0)
+        .map((section) => section.group?.id)
+    )
     return collisions.filter((collision) => {
       const target = resolveDropTarget(String(collision.id))
       if (target.kind === 'field') return !ownMemberIds.has(target.fieldId)
-      return target.groupId !== draggedGroupId
+      return target.groupId !== draggedGroupId && !emptyGroupIds.has(target.groupId)
     })
   }, [])
 
@@ -555,10 +587,17 @@ export function EntityFieldsContent({
     }
 
     switch (target.kind) {
-      case 'field':
+      case 'field': {
         if (target.fieldId === activeId) return
-        handleDragEnd(aimedAt(event, target.fieldId))
+        // The SAME expression `deriveDropFeedback` draws the insert line from,
+        // so the drop cannot land on a different edge than the line promised.
+        // It must be read from the pre-drag positions in this render's closure —
+        // `handleDragEnd` may relocate the field (joining a group appends it to
+        // the block's tail) before it reorders, which would flip the direction.
+        const side = edgeFor(orderIndexById.get(target.fieldId) ?? -1)
+        handleDragEnd(aimedAt(event, target.fieldId), side === 'bottom' ? 'after' : 'before')
         return
+      }
       case 'group-into':
         handleDragEnd(aimedAt(event, groupDropId(target.groupId)))
         return
@@ -695,13 +734,23 @@ export function EntityFieldsContent({
       if (!group) return <Fragment key={`ungrouped-${sectionIndex}`}>{rowElements}</Fragment>
 
       return (
-        <div key={`group-${group.id}`} className='relative mt-1.5 first:mt-0'>
+        <div
+          key={`group-${group.id}`}
+          className={cn(
+            'relative mt-1.5 first:mt-0',
+            // The fill is a real BACKGROUND on the section, not part of the
+            // overlay below: `bg-primary-100` is opaque, and an absolutely
+            // positioned overlay paints above statically positioned children —
+            // it would hide the header and rows it is meant to be highlighting.
+            highlight?.groupId === group.id &&
+              (highlight.blocked ? 'rounded-md bg-primary-100' : 'rounded-md bg-primary/10')
+          )}>
           {isEditMode && (
             <>
               <FieldDropZone id={groupBeforeDropId(group.id)} edge='top' />
               <FieldDropZone id={groupAfterDropId(group.id)} edge='bottom' />
-              {highlightGroupId === group.id && (
-                <div className='pointer-events-none absolute inset-0 z-10 rounded-md border border-primary/40 border-dashed bg-primary/10' />
+              {highlight?.groupId === group.id && (
+                <div className='pointer-events-none absolute inset-0 z-10 rounded-md border border-primary-200 border-dashed' />
               )}
               {lineForGroup(group.id, 'top') && <FieldInsertLine side='top' />}
               {lineForGroup(group.id, 'bottom') && (
@@ -752,7 +801,7 @@ export function EntityFieldsContent({
               <Button
                 variant='ghost'
                 size='icon-xs'
-                onClick={() => (isEditMode ? onCancelEditMode() : onEnterEditMode())}
+                onClick={() => (isEditMode ? void onExitEditMode() : onEnterEditMode())}
                 className={cn(
                   'cursor-pointer',
                   isEditMode
@@ -819,7 +868,12 @@ export function EntityFieldsContent({
                       // Semi-transparent so the insert line stays readable through
                       // the ghost — the line marks the landing slot and the ghost
                       // is only "what is in hand", so the line has to win.
-                      <div className='rounded-md bg-background/90 opacity-90 shadow-lg ring-1 ring-border'>
+                      //
+                      // `pe-2`: the overlay's width is released to `auto`, so an
+                      // EMPTY group shrinks to icon + title + member count with
+                      // the count pressed against the ring. Members give the
+                      // ghost its own width and never need it.
+                      <div className='rounded-md bg-background/90 pe-2 opacity-90 shadow-lg ring-1 ring-border'>
                         {renderGroupHeader(
                           activeGroupSection.group as FieldGroupLike,
                           activeGroupSection.fieldIds.length,

--- a/apps/web/src/components/fields/entity-fields.tsx
+++ b/apps/web/src/components/fields/entity-fields.tsx
@@ -103,6 +103,11 @@ function EntityFields({
   // Confirm dialog for delete
   const [confirmDelete, ConfirmDeleteDialog] = useConfirm()
 
+  // Confirm dialog for leaving edit mode with unsaved view changes. Separate
+  // instance from the delete one so neither has to borrow the other's naming;
+  // they can never be open at the same time.
+  const [confirmExit, ConfirmExitDialog] = useConfirm()
+
   // DnD sensors
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
@@ -143,6 +148,7 @@ function EntityFields({
   const {
     draft,
     isDraftMode: isEditMode,
+    isDraftDirty,
     isSaving,
     enterDraft,
     cancelDraft,
@@ -165,6 +171,39 @@ function EntityFields({
   // view's otherwise. A group has no stored position — its header renders where
   // its first member sits in the field order (see `group-fields.ts`).
   const fieldGroups: FieldGroup[] = isEditMode ? draftGroups : (viewConfig.fieldGroups ?? [])
+
+  /**
+   * Leaving edit mode via the header's X.
+   *
+   * The X reads as "close this", not "throw my work away", so an untouched draft
+   * just closes and a modified one asks first. Saving here is exactly Save View —
+   * the same `saveDraft`, one config write — so the prompt is a route to it, not
+   * a second write path.
+   *
+   * `saveDraft` never rejects: on failure it toasts and leaves the draft intact,
+   * so a failed save keeps the user in edit mode with their changes rather than
+   * closing over them.
+   *
+   * The footer's explicit Cancel is deliberately NOT routed through here — it
+   * sits beside Save View, so the choice has already been put to the user.
+   */
+  const handleExitEditMode = useCallback(async () => {
+    if (!isDraftDirty) {
+      cancelDraft()
+      return
+    }
+
+    const shouldSave = await confirmExit({
+      title: 'Save changes to this view?',
+      description:
+        'Your changes to the field layout have not been saved. Saving applies them for everyone in the organization.',
+      confirmText: 'Save',
+      cancelText: 'Discard',
+    })
+
+    if (shouldSave) await saveDraft()
+    else cancelDraft()
+  }, [isDraftDirty, cancelDraft, confirmExit, saveDraft])
 
   // ─────────────────────────────────────────────────────────────────
   // FIELD PROCESSING (unified system + custom)
@@ -274,9 +313,17 @@ function EntityFields({
    * the first within this handler. A same-group drag skips the assignment — it
    * is a no-op on membership but not on position, so running it would move the
    * field twice.
+   *
+   * `edge` is why the reorder cannot be a bare `arrayMove`. Joining a group
+   * relocates the field to the block's TAIL, so a field dragged DOWN into a
+   * group arrives above its target having travelled up — and an arrayMove reads
+   * direction from the post-assignment position, landing it one slot early
+   * (dropping on the last member put it second-to-last). The caller passes the
+   * same edge the insert line was drawn from, so the drop lands where the line
+   * promised.
    */
   const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
+    (event: DragEndEvent, edge?: 'before' | 'after') => {
       const { active, over } = event
       if (!over) return
 
@@ -299,14 +346,18 @@ function EntityFields({
         const firstMemberId = draftGroups
           .find((group) => group.id === headerGroupId)
           ?.fieldIds.find((id) => id !== activeId)
-        if (firstMemberId) reorderDraft(activeId, firstMemberId)
+        // `before` states the intent outright — dropping on a header means the
+        // head of the block, whichever direction the field travelled from. An
+        // EMPTY group has no first member, and none is needed: the assignment
+        // has already sent the field to where an empty group renders.
+        if (firstMemberId) reorderDraft(activeId, firstMemberId, 'before')
         return
       }
 
       const targetGroupId = draftGroupIdOf(overId)
 
       if (targetGroupId !== currentGroupId) assignFieldToGroup(activeId, targetGroupId)
-      reorderDraft(activeId, overId)
+      reorderDraft(activeId, overId, edge)
     },
     [assignFieldToGroup, draftGroupIdOf, draftGroups, reorderDraft]
   )
@@ -425,11 +476,13 @@ function EntityFields({
 
   return (
     <FieldNavigationProvider>
+      <ConfirmExitDialog />
       <EntityFieldsContent
         className={className}
         isEditMode={isEditMode}
         onEnterEditMode={enterDraft}
         onCancelEditMode={cancelDraft}
+        onExitEditMode={handleExitEditMode}
         onSaveView={saveDraft}
         isSaving={isSaving}
         dialogOpen={dialogOpen}

--- a/apps/web/src/components/fields/group-fields.test.ts
+++ b/apps/web/src/components/fields/group-fields.test.ts
@@ -11,9 +11,11 @@ import {
   assignFieldToGroupInOrder,
   type FieldGroupLike,
   groupFieldOrder,
+  moveFieldToSlot,
   moveGroupBlock,
   normalizeGroupContiguity,
   reassignFieldToGroup,
+  resolveEmptyGroupAnchor,
 } from './group-fields'
 
 const group = (id: string, fieldIds: string[]): FieldGroupLike => ({
@@ -164,6 +166,61 @@ describe('groupFieldOrder', () => {
       ['empty', []],
       ['ghosts', []],
     ])
+  })
+
+  it('renders an anchored empty group immediately BEFORE its anchor field', () => {
+    const groups = [group('g1', ['A']), { ...group('empty', []), anchorFieldId: 'B' }]
+    const sections = groupFieldOrder({
+      fieldOrder: ['A', 'B', 'C'],
+      groups,
+      includeEmptyGroups: true,
+    })
+    // The ungrouped run splits around it — B and C must not read as one run
+    // straddling a group header.
+    expect(shape(sections)).toEqual([
+      ['g1', ['A']],
+      ['empty', []],
+      [null, ['B', 'C']],
+    ])
+  })
+
+  it('falls back to the end when the anchor field no longer exists', () => {
+    const groups = [{ ...group('empty', []), anchorFieldId: 'deleted' }, group('g1', ['A'])]
+    expect(
+      shape(groupFieldOrder({ fieldOrder: ['A', 'B'], groups, includeEmptyGroups: true }))
+    ).toEqual([
+      ['g1', ['A']],
+      [null, ['B']],
+      ['empty', []],
+    ])
+  })
+
+  it('ignores the anchor once the group has a surviving member', () => {
+    // A populated group derives its position from its first member, so a stale
+    // anchor from when it was empty must not move it — and must not emit it twice.
+    const groups = [{ ...group('g1', ['C']), anchorFieldId: 'A' }]
+    expect(
+      shape(groupFieldOrder({ fieldOrder: ['A', 'B', 'C'], groups, includeEmptyGroups: true }))
+    ).toEqual([
+      [null, ['A', 'B']],
+      ['g1', ['C']],
+    ])
+  })
+
+  it('honours an anchor that names a group’s first member', () => {
+    const groups = [group('g1', ['B', 'C']), { ...group('empty', []), anchorFieldId: 'B' }]
+    expect(
+      shape(groupFieldOrder({ fieldOrder: ['A', 'B', 'C'], groups, includeEmptyGroups: true }))
+    ).toEqual([
+      [null, ['A']],
+      ['empty', []],
+      ['g1', ['B', 'C']],
+    ])
+  })
+
+  it('drops anchored empty groups in read mode like any other empty group', () => {
+    const groups = [{ ...group('empty', []), anchorFieldId: 'B' }]
+    expect(shape(groupFieldOrder({ fieldOrder: ['A', 'B'], groups }))).toEqual([[null, ['A', 'B']]])
   })
 
   it('returns [] for an empty fieldOrder, and only empty groups when asked', () => {
@@ -414,15 +471,13 @@ describe('assignFieldToGroupInOrder', () => {
     fieldOrder: string[],
     groups: FieldGroupLike[],
     activeId: string,
-    overId: string
+    overId: string,
+    edge?: 'before' | 'after'
   ) {
-    const from = fieldOrder.indexOf(activeId)
-    const to = fieldOrder.indexOf(overId)
-    if (from === -1 || to === -1) return fieldOrder
-    const next = [...fieldOrder]
-    const [moved] = next.splice(from, 1)
-    next.splice(to, 0, moved as string)
-    return normalizeGroupContiguity(next, groups)
+    return normalizeGroupContiguity(
+      moveFieldToSlot({ fieldOrder, fieldId: activeId, overId, edge }),
+      groups
+    )
   }
 
   it('does not relocate the block when a field joins from ABOVE it', () => {
@@ -457,26 +512,105 @@ describe('assignFieldToGroupInOrder', () => {
     expect(r.groups[0]?.fieldIds).toEqual(['b', 'd'])
   })
 
-  it('no-ops the order when the target group has no other surviving members', () => {
+  it('sends the field to the END when the target group has no surviving members', () => {
+    // An empty group is drawn after every other section, so the field has to
+    // travel down to it. Leaving the field at its old slot would give the group
+    // that position instead — the group would jump UP to meet the field, which
+    // is what a freshly created group did.
     const r = assignFieldToGroupInOrder({
       fieldOrder: ['a', 'x', 'b'],
       groups: [{ id: 'G', label: 'G', fieldIds: [] }],
       fieldId: 'x',
       groupId: 'G',
     })
-    expect(r.fieldOrder).toEqual(['a', 'x', 'b'])
+    expect(r.fieldOrder).toEqual(['a', 'b', 'x'])
     expect(r.groups[0]?.fieldIds).toEqual(['x'])
   })
 
-  it('composes with a follow-up reorder to hit the exact intra-group slot', () => {
+  it('lands the first field at an empty group’s ANCHOR, not at the end', () => {
+    // The group was dragged up the panel while empty, so it renders before `b`.
+    // Sending its first field to the end would drag the group back down with it.
+    const r = assignFieldToGroupInOrder({
+      fieldOrder: ['a', 'b', 'c', 'x'],
+      groups: [{ id: 'G', label: 'G', fieldIds: [], anchorFieldId: 'b' }],
+      fieldId: 'x',
+      groupId: 'G',
+    })
+    expect(r.fieldOrder).toEqual(['a', 'x', 'b', 'c'])
+  })
+
+  it('keeps the group in place when its anchor IS the field being dropped in', () => {
+    const r = assignFieldToGroupInOrder({
+      fieldOrder: ['a', 'x', 'b'],
+      groups: [{ id: 'G', label: 'G', fieldIds: [], anchorFieldId: 'x' }],
+      fieldId: 'x',
+      groupId: 'G',
+    })
+    expect(r.fieldOrder).toEqual(['a', 'x', 'b'])
+  })
+
+  it('pins a group that is losing its LAST member to where it currently renders', () => {
+    // Otherwise the emptied group falls back to the end of the list — or to a
+    // stale anchor from before it was ever filled.
+    const r = assignFieldToGroupInOrder({
+      fieldOrder: ['a', 'x', 'b', 'c'],
+      groups: [{ id: 'G', label: 'G', fieldIds: ['x'], anchorFieldId: 'c' }],
+      fieldId: 'x',
+      groupId: null,
+    })
+    expect(r.groups[0]?.fieldIds).toEqual([])
+    // `b` followed the block, so the emptied group renders just above `b` —
+    // exactly where it sat. NOT `x`, which the caller is about to reorder.
+    expect(r.groups[0]?.anchorFieldId).toBe('b')
+  })
+
+  it('clears the anchor when the emptied group sat last', () => {
+    const r = assignFieldToGroupInOrder({
+      fieldOrder: ['a', 'b', 'x'],
+      groups: [{ id: 'G', label: 'G', fieldIds: ['x'], anchorFieldId: 'a' }],
+      fieldId: 'x',
+      groupId: null,
+    })
+    expect(r.groups[0]?.anchorFieldId).toBeUndefined()
+  })
+
+  it('leaves the anchor alone while the source group keeps a member', () => {
+    const r = assignFieldToGroupInOrder({
+      fieldOrder: ['a', 'x', 'y', 'b'],
+      groups: [{ id: 'G', label: 'G', fieldIds: ['x', 'y'], anchorFieldId: 'stale' }],
+      fieldId: 'x',
+      groupId: null,
+    })
+    expect(r.groups[0]?.fieldIds).toEqual(['y'])
+    expect(r.groups[0]?.anchorFieldId).toBe('stale')
+  })
+
+  it('composes with an edge-named reorder to hit the exact intra-group slot', () => {
     const r = assignFieldToGroupInOrder({
       fieldOrder: ['x', 'a', 'b', 'c', 'd'],
       groups: G(),
       fieldId: 'x',
       groupId: 'G',
     })
-    expect(reorder(r.fieldOrder, r.groups, 'x', 'c')).toEqual(['a', 'b', 'x', 'c', 'd'])
-    expect(reorder(r.fieldOrder, r.groups, 'x', 'b')).toEqual(['a', 'x', 'b', 'c', 'd'])
+    expect(r.fieldOrder).toEqual(['a', 'b', 'c', 'd', 'x'])
+    expect(reorder(r.fieldOrder, r.groups, 'x', 'c', 'after')).toEqual(['a', 'b', 'c', 'x', 'd'])
+    expect(reorder(r.fieldOrder, r.groups, 'x', 'c', 'before')).toEqual(['a', 'b', 'x', 'c', 'd'])
+  })
+
+  it('lands on the LAST member when a field joins from above and aims at it', () => {
+    // The reported bug. `x` starts above the block and is dragged onto `d`, the
+    // last member — the insert line is drawn on `d`'s bottom edge. Assignment
+    // has already moved `x` to the block's tail, so a bare arrayMove reads the
+    // gesture as travelling UP and lands `x` before `d` instead.
+    const r = assignFieldToGroupInOrder({
+      fieldOrder: ['x', 'a', 'b', 'c', 'd'],
+      groups: G(),
+      fieldId: 'x',
+      groupId: 'G',
+    })
+    expect(reorder(r.fieldOrder, r.groups, 'x', 'd', 'after')).toEqual(['a', 'b', 'c', 'd', 'x'])
+    // Without the edge — what the handler used to do — it lands one slot early.
+    expect(reorder(r.fieldOrder, r.groups, 'x', 'd')).toEqual(['a', 'b', 'c', 'x', 'd'])
   })
 
   it('leaves the result a fixpoint under re-normalization', () => {
@@ -863,5 +997,106 @@ describe('moveGroupBlock', () => {
     moveGroupBlock({ fieldOrder, groups, groupId: 'gA', overId: 'gB', overIsGroup: true })
     expect(fieldOrder).toEqual(orderCopy)
     expect(groups).toEqual(groupsCopy)
+  })
+})
+
+describe('resolveEmptyGroupAnchor', () => {
+  const groups = (): FieldGroupLike[] => [group('E', []), group('G', ['b', 'c'])]
+  const fieldOrder = ['a', 'b', 'c', 'd']
+
+  it('anchors on an ungrouped field the drop landed on', () => {
+    expect(
+      resolveEmptyGroupAnchor({
+        fieldOrder,
+        groups: groups(),
+        groupId: 'E',
+        overId: 'a',
+        overIsGroup: false,
+      })
+    ).toEqual({ anchorFieldId: 'a' })
+  })
+
+  it('snaps to the group boundary when the drop lands on a grouped field', () => {
+    // `c` is mid-block. Anchoring there would point at a field that never opens
+    // a section, so `groupFieldOrder` would ignore it and the group would jump
+    // back to the end. Resolve to the block's first member instead.
+    expect(
+      resolveEmptyGroupAnchor({
+        fieldOrder,
+        groups: groups(),
+        groupId: 'E',
+        overId: 'c',
+        overIsGroup: false,
+      })
+    ).toEqual({ anchorFieldId: 'b' })
+  })
+
+  it('anchors on a target group’s first surviving member', () => {
+    expect(
+      resolveEmptyGroupAnchor({
+        fieldOrder,
+        groups: groups(),
+        groupId: 'E',
+        overId: 'G',
+        overIsGroup: true,
+      })
+    ).toEqual({ anchorFieldId: 'b' })
+  })
+
+  it('returns null for every unresolvable drop', () => {
+    const g = groups()
+    // Unknown moving group
+    expect(
+      resolveEmptyGroupAnchor({
+        fieldOrder,
+        groups: g,
+        groupId: 'nope',
+        overId: 'a',
+        overIsGroup: false,
+      })
+    ).toBeNull()
+    // Dropped on itself
+    expect(
+      resolveEmptyGroupAnchor({
+        fieldOrder,
+        groups: g,
+        groupId: 'E',
+        overId: 'E',
+        overIsGroup: true,
+      })
+    ).toBeNull()
+    // Target group has no surviving members
+    expect(
+      resolveEmptyGroupAnchor({
+        fieldOrder: ['a'],
+        groups: g,
+        groupId: 'E',
+        overId: 'G',
+        overIsGroup: true,
+      })
+    ).toBeNull()
+    // Field absent from the order
+    expect(
+      resolveEmptyGroupAnchor({
+        fieldOrder,
+        groups: g,
+        groupId: 'E',
+        overId: 'gone',
+        overIsGroup: false,
+      })
+    ).toBeNull()
+  })
+
+  it('never mutates its inputs', () => {
+    const g = groups()
+    const copy = g.map((x) => ({ ...x, fieldIds: [...x.fieldIds] }))
+    resolveEmptyGroupAnchor({
+      fieldOrder,
+      groups: g,
+      groupId: 'E',
+      overId: 'a',
+      overIsGroup: false,
+    })
+    expect(g).toEqual(copy)
   })
 })

--- a/apps/web/src/components/fields/group-fields.ts
+++ b/apps/web/src/components/fields/group-fields.ts
@@ -14,6 +14,12 @@ export interface FieldGroupLike {
   collapsed?: boolean
   icon?: string
   fieldIds: string[]
+  /**
+   * Where an EMPTY group renders: immediately before this field. Read only
+   * while the group has no surviving member, ignored once it has one. See
+   * {@link resolveEmptyGroupAnchor}.
+   */
+  anchorFieldId?: string
 }
 
 export interface GroupedFieldSection {
@@ -54,10 +60,17 @@ export interface GroupFieldOrderParams {
  *   skip-the-miss pattern `fieldOrder` itself already relies on.
  * - **Duplicates in `fieldOrder` collapse** to their first occurrence, matching
  *   `mergeFieldOrder`.
- * - With `includeEmptyGroups`, groups with zero surviving members are appended
- *   at the END, after everything else, in `groups` array order — they have no
- *   derived position to render at, by construction. Read mode passes false and
- *   they vanish; edit mode passes true and they become drop targets.
+ * - With `includeEmptyGroups`, groups with zero surviving members render
+ *   immediately before their `anchorFieldId`, or at the END when they have no
+ *   anchor or their anchor no longer exists. An empty group has no member to
+ *   derive a position from, so the anchor is the only thing it can be placed by;
+ *   it is written by dragging the group (see {@link resolveEmptyGroupAnchor}).
+ *   Read mode passes false and empty groups vanish entirely, anchor or not.
+ * - **An anchor only fires where a section STARTS.** Later members of a group
+ *   are consumed while emitting that group's block, so an anchor naming one is
+ *   never reached and the empty group falls through to the end. The resolver
+ *   only ever writes an ungrouped field or a group's first member, so this
+ *   costs nothing in practice and keeps a group's block unsplittable.
  *
  * Invariant: flattening the result's `fieldIds` yields a permutation of
  * `fieldOrder` (deduplicated) with no losses and no duplicates.
@@ -87,8 +100,32 @@ export function groupFieldOrder(params: GroupFieldOrderParams): GroupedFieldSect
   // producing an empty `group: null` section.
   let openUngrouped: GroupedFieldSection | null = null
 
+  // Empty groups indexed by the field they render before, in `groups` order so
+  // several anchored on the same field keep a stable sequence.
+  const anchoredEmptyGroups = new Map<string, number[]>()
+  if (includeEmptyGroups) {
+    for (let index = 0; index < groups.length; index++) {
+      const group = groups[index] as FieldGroupLike
+      if (group.anchorFieldId === undefined) continue
+      if (group.fieldIds.some((fieldId) => fieldOrder.includes(fieldId))) continue
+      const pending = anchoredEmptyGroups.get(group.anchorFieldId)
+      if (pending) pending.push(index)
+      else anchoredEmptyGroups.set(group.anchorFieldId, [index])
+    }
+  }
+
   for (const fieldId of fieldOrder) {
     if (consumed.has(fieldId)) continue
+
+    // Anchored empty groups go in BEFORE the section this field opens. Emitting
+    // one closes the ungrouped run in progress, so the fields after it start a
+    // new section rather than reading as part of the run above the group.
+    for (const index of anchoredEmptyGroups.get(fieldId) ?? []) {
+      sections.push({ group: groups[index] as FieldGroupLike, fieldIds: [] })
+      emitted.add(index)
+      openUngrouped = null
+    }
+
     consumed.add(fieldId)
 
     const ownerIndex = ownerByField.get(fieldId)
@@ -228,11 +265,17 @@ export interface AssignFieldInOrderResult {
  *
  * The field lands at the END of the target group's block; callers that want a
  * precise intra-group slot should follow this with a reorder against the
- * returned order (the two compose — see the tests).
+ * returned order. **That follow-up reorder must name its edge** — this function
+ * has just moved the field to the block's tail, so an `arrayMove` against a
+ * member would read the gesture as travelling upward and land the field one slot
+ * early (see {@link moveFieldToSlot}).
  *
- * No-ops on the order when the target group has no other surviving members
- * (nothing to anchor against) or when the field is absent from `fieldOrder`.
- * Never mutates the inputs.
+ * A target group with no surviving members sends the field to wherever
+ * {@link groupFieldOrder} draws that empty group — just before its
+ * `anchorFieldId`, or the END of `fieldOrder` when it has no live anchor.
+ * Leaving the field in place would instead give the group the field's position
+ * and move the group. No-ops on the order when the field is absent from
+ * `fieldOrder`. Never mutates the inputs.
  */
 export function assignFieldToGroupInOrder(params: {
   fieldOrder: string[]
@@ -241,14 +284,43 @@ export function assignFieldToGroupInOrder(params: {
   groupId: string | null
 }): AssignFieldInOrderResult {
   const { fieldOrder, groups, fieldId, groupId } = params
-  const nextGroups = reassignFieldToGroup({ groups, fieldId, groupId })
+  const reassigned = reassignFieldToGroup({ groups, fieldId, groupId })
 
   // Membership unchanged (the field is already in the target group, or already
   // ungrouped) → the order must be left ALONE. Relocating here would move a
   // field on a same-group drag, so a caller doing the usual
   // assign-then-reorder would move it twice and land it a slot off.
   const wasMember = groups.some((g) => g.id === groupId && g.fieldIds.includes(fieldId))
-  if (wasMember) return { fieldOrder, groups: nextGroups }
+  if (wasMember) return { fieldOrder, groups: reassigned }
+
+  const from = fieldOrder.indexOf(fieldId)
+
+  /**
+   * The group the field is LEAVING, when this is its last surviving member.
+   *
+   * It is about to lose the only thing giving it a position, so pin it to where
+   * it renders right now — otherwise it falls back to the end of the list (or,
+   * worse, to a stale `anchorFieldId` from before it was ever filled, which is
+   * where it was last seen jumping to).
+   *
+   * The anchor is the field that FOLLOWS the departing one, read from the
+   * order as it stands before the move. Anchoring to the departing field itself
+   * would be wrong: the caller usually reorders it straight afterwards, and the
+   * emptied group would then travel with it. Blocks are contiguous, so the
+   * successor is always either ungrouped or the first member of the next group
+   * — never mid-block, which the walk would ignore. No successor means the
+   * block sat last, and no anchor already means "at the end".
+   */
+  const sourceGroup = groups.find((g) => g.id !== groupId && g.fieldIds.includes(fieldId))
+  const sourceEmptied =
+    sourceGroup !== undefined &&
+    !sourceGroup.fieldIds.some((id) => id !== fieldId && fieldOrder.includes(id))
+  const successorId = from === -1 ? undefined : fieldOrder[from + 1]
+
+  const nextGroups =
+    sourceEmptied && sourceGroup
+      ? reassigned.map((g) => (g.id === sourceGroup.id ? { ...g, anchorFieldId: successorId } : g))
+      : reassigned
 
   const target = groupId ? nextGroups.find((g) => g.id === groupId) : undefined
   if (!target)
@@ -259,17 +331,168 @@ export function assignFieldToGroupInOrder(params: {
   for (let i = 0; i < fieldOrder.length; i++) {
     if (siblings.has(fieldOrder[i] as string)) lastSibling = i
   }
-  const from = fieldOrder.indexOf(fieldId)
-  if (lastSibling === -1 || from === -1) {
+  if (from === -1) {
     return { fieldOrder: normalizeGroupContiguity(fieldOrder, nextGroups), groups: nextGroups }
   }
 
   const next = [...fieldOrder]
   next.splice(from, 1)
-  // Removing the field shifts indices left when it sat before the block.
-  next.splice(from < lastSibling ? lastSibling : lastSibling + 1, 0, fieldId)
+
+  /**
+   * An EMPTY group has no member to land beside, so the field goes to wherever
+   * that group is currently DRAWN — otherwise the group inherits the field's
+   * position instead and visibly jumps to meet it.
+   *
+   * `groupFieldOrder` draws an empty group immediately before its
+   * `anchorFieldId`, or at the very end when it has none (or the anchor is a
+   * deleted field). Both cases have to be mirrored here, and the anchor case is
+   * the one that matters most: a group the user has just dragged up the panel
+   * must not snap back to the bottom the moment it gets its first field.
+   */
+  const emptyGroupInsertAt = (): number => {
+    const anchorFieldId = target.anchorFieldId
+    if (anchorFieldId === undefined) return next.length
+    // The anchor IS the field being dropped in: the group already renders just
+    // above it, so keeping the field's own slot leaves the group where it is.
+    if (anchorFieldId === fieldId) return Math.min(from, next.length)
+    const anchorIndex = next.indexOf(anchorFieldId)
+    return anchorIndex === -1 ? next.length : anchorIndex
+  }
+
+  // With members, the field lands after the block's last one. Removing it first
+  // shifts indices left when it sat before the block, hence the two cases.
+  const insertAt =
+    lastSibling === -1 ? emptyGroupInsertAt() : from < lastSibling ? lastSibling : lastSibling + 1
+  next.splice(insertAt, 0, fieldId)
 
   return { fieldOrder: normalizeGroupContiguity(next, nextGroups), groups: nextGroups }
+}
+
+export interface MoveFieldToSlotParams {
+  fieldOrder: string[]
+  /** The field being moved. */
+  fieldId: string
+  /** The field whose slot it is aimed at. */
+  overId: string
+  /**
+   * Which side of `overId` the field lands on.
+   *
+   * **Omit for dnd-kit's `arrayMove` semantics**, which are direction-dependent:
+   * the destination index is read BEFORE the source is spliced out, so removing
+   * an element that sat earlier shifts everything left and the field lands
+   * AFTER the target — while a field that sat later lands ON it, i.e. before.
+   * A flat `SortableContext` drag wants exactly that, because the row has
+   * already been displaced on screen.
+   *
+   * **Pass it when a drop and its affordance must agree.** The property panel's
+   * insert line is drawn from the ORIGINAL positions, so any step that relocates
+   * the field before the reorder — joining a group appends it to the block's
+   * tail — inverts the arrayMove direction and lands it one slot early. Naming
+   * the side removes the dependency: the target index is recomputed after the
+   * removal, so the result is the same whichever way the field travelled.
+   */
+  edge?: 'before' | 'after'
+}
+
+/**
+ * Move a field to another field's slot in `fieldOrder`.
+ *
+ * Returns the input array by reference when either id is missing or the move is
+ * a no-op, so callers can skip a state write. Never mutates the input, and never
+ * touches group membership — run {@link normalizeGroupContiguity} afterwards if
+ * the move may have split a block.
+ */
+export function moveFieldToSlot(params: MoveFieldToSlotParams): string[] {
+  const { fieldOrder, fieldId, overId, edge } = params
+
+  const from = fieldOrder.indexOf(fieldId)
+  const to = fieldOrder.indexOf(overId)
+  if (from === -1 || to === -1 || from === to) return fieldOrder
+
+  const next = [...fieldOrder]
+  next.splice(from, 1)
+
+  if (edge === undefined) {
+    next.splice(to, 0, fieldId)
+    return next
+  }
+
+  const target = next.indexOf(overId)
+  next.splice(edge === 'after' ? target + 1 : target, 0, fieldId)
+  return next
+}
+
+export interface ResolveEmptyGroupAnchorParams {
+  fieldOrder: string[]
+  groups: FieldGroupLike[]
+  /** The EMPTY group being dragged. */
+  groupId: string
+  /** Drop target: a field id, or another group's id. */
+  overId: string
+  /** True when `overId` names a group rather than a field. */
+  overIsGroup: boolean
+}
+
+/**
+ * Where a dragged EMPTY group should come to rest, as an `anchorFieldId`.
+ *
+ * {@link moveGroupBlock} cannot answer this: it works by lifting a group's
+ * member rows out of `fieldOrder` and splicing them back at a new index, and an
+ * empty group has no rows to lift. So an empty group is repositioned by naming
+ * the field it renders BEFORE, which {@link groupFieldOrder} then honours.
+ *
+ * **Before, not after.** The insert line for an empty group is always drawn on
+ * its target's TOP edge — `edgeFor` needs the block's own first member to know
+ * which way it travelled, and there isn't one — so "before the target" is the
+ * position the affordance actually promises. It also leaves the end of the list
+ * reachable as the no-anchor default, which an "after" encoding would not.
+ *
+ * Decisions this function pins down:
+ * - **A drop snaps to a group boundary**, exactly as `moveGroupBlock` does: a
+ *   field belonging to another group resolves to that group's FIRST surviving
+ *   member, so the empty group lands above that whole block instead of inside
+ *   it. `groupFieldOrder` only fires anchors where a section starts, so an
+ *   anchor pointing mid-block would silently do nothing.
+ * - **Returns null for anything unresolvable** — an unknown group, a target
+ *   that is the moving group itself, a target group with no surviving members,
+ *   a field absent from `fieldOrder` — so the caller writes nothing.
+ * - **The caller is responsible for only calling this on an empty group.** A
+ *   populated group has a real derived position and must go through
+ *   `moveGroupBlock`.
+ *
+ * Never mutates its inputs.
+ */
+export function resolveEmptyGroupAnchor(
+  params: ResolveEmptyGroupAnchorParams
+): { anchorFieldId: string } | null {
+  const { fieldOrder, groups, groupId, overId, overIsGroup } = params
+
+  if (!groups.some((group) => group.id === groupId)) return null
+
+  const ownerById = new Map<string, string>()
+  for (const group of groups) {
+    for (const fieldId of group.fieldIds) {
+      if (!ownerById.has(fieldId)) ownerById.set(fieldId, group.id)
+    }
+  }
+
+  const firstMemberOf = (targetGroupId: string): string | undefined =>
+    fieldOrder.find((fieldId) => ownerById.get(fieldId) === targetGroupId)
+
+  if (overIsGroup) {
+    if (overId === groupId) return null
+    const anchorFieldId = firstMemberOf(overId)
+    return anchorFieldId === undefined ? null : { anchorFieldId }
+  }
+
+  if (!fieldOrder.includes(overId)) return null
+
+  const ownerGroupId = ownerById.get(overId)
+  if (ownerGroupId === undefined) return { anchorFieldId: overId }
+  if (ownerGroupId === groupId) return null
+
+  const anchorFieldId = firstMemberOf(ownerGroupId)
+  return anchorFieldId === undefined ? null : { anchorFieldId }
 }
 
 export interface MoveGroupBlockParams {

--- a/apps/web/src/components/fields/hooks/use-field-view-draft.ts
+++ b/apps/web/src/components/fields/hooks/use-field-view-draft.ts
@@ -15,8 +15,10 @@ import { useDynamicTableStore } from '~/components/dynamic-table/stores/dynamic-
 import { useOrgFieldView } from '~/components/dynamic-table/stores/store-selectors'
 import {
   assignFieldToGroupInOrder,
+  moveFieldToSlot,
   moveGroupBlock,
   normalizeGroupContiguity,
+  resolveEmptyGroupAnchor,
 } from '~/components/fields/group-fields'
 import { resolveFieldVisible } from '~/components/fields/hooks/use-field-view'
 import { mergeFieldOrder } from '~/components/fields/merge-field-order'
@@ -37,6 +39,12 @@ export interface UseFieldViewDraftResult {
   /** Null when not in draft mode. */
   draft: FieldViewConfig | null
   isDraftMode: boolean
+  /**
+   * Whether the draft differs from the snapshot draft mode opened with. False
+   * outside draft mode. Lets a surface skip the "save or discard?" prompt when
+   * the user only looked around.
+   */
+  isDraftDirty: boolean
   isSaving: boolean
   /** Which context the draft is currently editing (may differ from `contextType`). */
   draftContextType: ViewContextType
@@ -45,8 +53,13 @@ export interface UseFieldViewDraftResult {
   /** Re-snapshot for a different context (the dialog's Create/Edit toggle). */
   switchDraftContext: (contextType: ViewContextType) => void
   setDraftVisibility: (resourceFieldId: string, visible: boolean) => void
-  /** Move `activeId` to `overId`'s slot within draft.fieldOrder. No-op if either is absent. */
-  reorderDraft: (activeId: string, overId: string) => void
+  /**
+   * Move `activeId` to `overId`'s slot within draft.fieldOrder. No-op if either
+   * is absent. `edge` names which side of `overId` the field lands on; omit it
+   * for dnd-kit's direction-dependent `arrayMove` semantics, which is what a
+   * flat `SortableContext` drag wants. See {@link moveFieldToSlot}.
+   */
+  reorderDraft: (activeId: string, overId: string, edge?: 'before' | 'after') => void
   /** Persist the draft: update the existing org default view, or create one. Resolves on success. */
   saveDraft: () => Promise<void>
   /** Groups in the draft. Empty array when the draft has none. */
@@ -92,6 +105,12 @@ export function useFieldViewDraft({
 
   /** Draft config: local buffer for batch save (null when not in draft mode) */
   const [draft, setDraft] = useState<FieldViewConfig | null>(null)
+
+  /**
+   * The snapshot draft mode opened with, serialized — the baseline `isDraftDirty`
+   * compares against. Null outside draft mode.
+   */
+  const [pristineConfig, setPristineConfig] = useState<string | null>(null)
 
   // Field IDs for creating default configs
   const fieldIds = useMemo(
@@ -198,24 +217,49 @@ export function useFieldViewDraft({
 
   /** Enter draft mode: snapshot the current config into the buffer */
   const enterDraft = useCallback(() => {
+    const snapshot = snapshotConfigForContext(contextType)
     setDraftContextType(contextType)
-    setDraft(snapshotConfigForContext(contextType))
+    setDraft(snapshot)
+    setPristineConfig(JSON.stringify(snapshot))
     setIsDraftMode(true)
   }, [contextType, snapshotConfigForContext])
 
   /** Cancel draft mode: discard the buffer, exit */
   const cancelDraft = useCallback(() => {
     setDraft(null)
+    setPristineConfig(null)
     setIsDraftMode(false)
   }, [])
 
-  /** Switch which context is being edited, re-snapshotting from the store */
+  /**
+   * Switch which context is being edited, re-snapshotting from the store.
+   *
+   * The new snapshot becomes the dirty baseline — unsaved edits to the previous
+   * context are dropped by the re-snapshot itself, so carrying its baseline over
+   * would only report a phantom diff against a draft that no longer exists.
+   */
   const switchDraftContext = useCallback(
     (newContextType: ViewContextType) => {
+      const snapshot = snapshotConfigForContext(newContextType)
       setDraftContextType(newContextType)
-      setDraft(snapshotConfigForContext(newContextType))
+      setDraft(snapshot)
+      setPristineConfig(JSON.stringify(snapshot))
     },
     [snapshotConfigForContext]
+  )
+
+  /**
+   * Structural comparison against the opening snapshot.
+   *
+   * `JSON.stringify` is sound here because every mutator above rebuilds the
+   * config by spreading the previous one and overwriting keys that the snapshot
+   * already established, so key order never drifts. The only way it can be wrong
+   * is a spurious `true` (a prompt with nothing to save) — never a false `false`,
+   * which is the direction that would silently discard the user's work.
+   */
+  const isDraftDirty = useMemo(
+    () => draft !== null && pristineConfig !== null && JSON.stringify(draft) !== pristineConfig,
+    [draft, pristineConfig]
   )
 
   /** Toggle field visibility in the draft (no server call) */
@@ -230,26 +274,29 @@ export function useFieldViewDraft({
   }, [])
 
   /** Reorder a field within the draft's `fieldOrder` (no server call) */
-  const reorderDraft = useCallback((activeId: string, overId: string) => {
-    if (activeId === overId) return
+  const reorderDraft = useCallback(
+    (activeId: string, overId: string, edge?: 'before' | 'after') => {
+      if (activeId === overId) return
 
-    setDraft((prev) => {
-      if (!prev) return prev
-      const fromIndex = prev.fieldOrder.indexOf(activeId)
-      const toIndex = prev.fieldOrder.indexOf(overId)
-      if (fromIndex === -1 || toIndex === -1) return prev
+      setDraft((prev) => {
+        if (!prev) return prev
+        const newOrder = moveFieldToSlot({
+          fieldOrder: prev.fieldOrder,
+          fieldId: activeId,
+          overId,
+          edge,
+        })
+        // Returned by reference when either id is missing or the move is a no-op.
+        if (newOrder === prev.fieldOrder) return prev
 
-      const newOrder = [...prev.fieldOrder]
-      const [moved] = newOrder.splice(fromIndex, 1)
-      if (!moved) return prev
-      newOrder.splice(toIndex, 0, moved)
-
-      // A drag can drop a non-member in the middle of a group's block, which
-      // would split it. Membership changes travel through `assignFieldToGroup`;
-      // position alone never rewrites it, so the split is repaired here instead.
-      return { ...prev, fieldOrder: normalizeGroupContiguity(newOrder, prev.fieldGroups ?? []) }
-    })
-  }, [])
+        // A drag can drop a non-member in the middle of a group's block, which
+        // would split it. Membership changes travel through `assignFieldToGroup`;
+        // position alone never rewrites it, so the split is repaired here instead.
+        return { ...prev, fieldOrder: normalizeGroupContiguity(newOrder, prev.fieldGroups ?? []) }
+      })
+    },
+    []
+  )
 
   /** Add a group to the draft. Returns the new group's id so the caller can focus/rename it. */
   const addGroup = useCallback((label: string): string => {
@@ -326,22 +373,51 @@ export function useFieldViewDraft({
   /**
    * Move a whole group to `overId`'s position, carrying its members with it.
    *
-   * Membership is untouched — a block move is purely positional, so `fieldGroups`
-   * is passed straight through and only `fieldOrder` changes. `moveGroupBlock`
-   * owns all of the arithmetic (block extraction, drop-index resolution, the
-   * snap-to-group-boundary rule) and returns an already-normalized order, so
-   * there is no second contiguity pass here.
+   * Two different writes, because a group's position has two different sources:
+   *
+   * - **Populated** → `fieldOrder`. Membership is untouched (a block move is
+   *   purely positional), and `moveGroupBlock` owns all of the arithmetic —
+   *   block extraction, drop-index resolution, the snap-to-group-boundary rule —
+   *   returning an already-normalized order, so there is no second contiguity
+   *   pass here.
+   * - **Empty** → the group's own `anchorFieldId`. There are no member rows to
+   *   lift, so `moveGroupBlock` can only no-op; the group instead records the
+   *   field it renders before. The anchor stays on the row once members arrive
+   *   and is simply ignored — a populated group derives its position from its
+   *   first member — so emptying the group later returns it to where it was.
    */
   const moveGroup = useCallback((groupId: string, overId: string, overIsGroup: boolean) => {
     if (groupId === overId) return
 
     setDraft((prev) => {
       if (!prev) return prev
+      const groups = prev.fieldGroups ?? []
+      const moving = groups.find((group) => group.id === groupId)
+      if (!moving) return prev
+
+      const hasMembers = moving.fieldIds.some((fieldId) => prev.fieldOrder.includes(fieldId))
+      if (!hasMembers) {
+        const resolved = resolveEmptyGroupAnchor({
+          fieldOrder: prev.fieldOrder,
+          groups,
+          groupId,
+          overId,
+          overIsGroup,
+        })
+        if (!resolved) return prev
+        return {
+          ...prev,
+          fieldGroups: groups.map((group) =>
+            group.id === groupId ? { ...group, anchorFieldId: resolved.anchorFieldId } : group
+          ),
+        }
+      }
+
       return {
         ...prev,
         fieldOrder: moveGroupBlock({
           fieldOrder: prev.fieldOrder,
-          groups: prev.fieldGroups ?? [],
+          groups,
           groupId,
           overId,
           overIsGroup,
@@ -391,6 +467,7 @@ export function useFieldViewDraft({
 
       // Exit draft mode
       setDraft(null)
+      setPristineConfig(null)
       setIsDraftMode(false)
     } catch {
       // Errors handled by mutation onError
@@ -400,6 +477,7 @@ export function useFieldViewDraft({
   return {
     draft,
     isDraftMode,
+    isDraftDirty,
     isSaving: updateView.isPending || createView.isPending,
     draftContextType,
     enterDraft,

--- a/packages/lib/src/conditions/field-view-config.ts
+++ b/packages/lib/src/conditions/field-view-config.ts
@@ -40,6 +40,20 @@ export const fieldGroupSchema = z.object({
    * harmless and skipped at read time.
    */
   fieldIds: z.array(z.string()),
+  /**
+   * Where an EMPTY group renders: immediately before this field.
+   *
+   * Read only while `fieldIds` has no surviving member, and ignored entirely
+   * once the group has one — a populated group's position is still derived from
+   * where its first member sits in `fieldOrder`, so this can never disagree with
+   * that. It exists because an empty group has no member to derive a position
+   * from at all, which left a freshly created group pinned at the end of the
+   * list and impossible to move until something was dragged into it.
+   *
+   * Unset, or naming a field that no longer exists, means "render at the end" —
+   * the same convention as before.
+   */
+  anchorFieldId: z.string().optional(),
 })
 
 /** A labelled, collapsible group of fields in the property panel */


### PR DESCRIPTION
Follow-up to #1539. Five defects in the property panel's group drag, plus one edit-mode papercut. Every one of them passed typecheck, biome and the 92 existing unit tests — the drag model's failures live in the composition of correct-looking pieces.

## Drops landed a slot early when a field joined a group from above

Joining a group appends the field to the block's **tail**, so a field dragged *down* into a group arrives *above* its target having travelled *up*. `reorderDraft` was a bare `arrayMove`, which reads direction from the post-assignment position — so dropping on the last member put the field second-to-last, while the insert line (drawn from the pre-drag positions) promised otherwise.

`moveFieldToSlot` now takes an explicit `edge`, and the drag router passes **the same expression `deriveDropFeedback` draws the line from**, so line and drop cannot disagree. Omitting the edge keeps `arrayMove` semantics, which is what the record dialog's flat `SortableContext` drag still wants — that surface is untouched.

Worth flagging: the old behaviour was *pinned by a test* that asserted what the code did rather than what the drag promised. It has been rewritten.

## Empty groups had no position at all

A freshly created group was pinned at the end of the list and could not be moved until something was dragged into it — and the first field dropped in took the group back down to wherever that field already sat.

`fieldGroupSchema` gains `anchorFieldId`: the field an empty group renders **before**. Read only while the group has no surviving member and ignored once it has one, so it can never disagree with the derived position. Unset, or naming a deleted field, means "at the end" — the previous convention.

`moveGroupBlock` cannot express this move (it works by lifting member rows out of `fieldOrder`, and there are none), so `moveGroup` branches to a new `resolveEmptyGroupAnchor`. The anchor is written at **three** moments, and missing any one makes the group visibly teleport:

1. dragging the group while empty,
2. the **first field joining** it — that field lands at the anchor, not at the end,
3. the **last field leaving** it — pinned to the field that *followed* the block, not to the departing field, which the caller usually reorders immediately afterwards.

No DB migration: it rides in the existing `TableView.config` jsonb.

## Highlight said "you will be inside this group" when you won't

A group hovering another group drew the same blue highlight a joining field does, though groups do not nest. That case is now grey; insert lines stay blue in both, since the drop does still reposition the block against that group's boundary.

An empty group is also no longer a target for a group drag at all — `moveGroupBlock` refuses those drops, so the highlight and line were promising a no-op.

## Leaving edit mode no longer discards silently

The header's X now prompts to save or discard when the draft is dirty (`isDraftDirty`, new on the shared hook); an untouched draft just closes. Saving routes through the same `saveDraft` as Save View — one config write, not a second path. The footer's explicit Cancel still discards, since it sits directly beside Save View.

## Testing

108 unit tests green (was 92), including regressions for each defect above. `apps/web` and `packages/lib` typecheck clean in every touched file; biome clean.

Static checks only on my side — these were **not** driven by hand in the browser by the author. Each defect here was found by the reviewer driving the panel, and the fixes were confirmed the same way. Known gap at time of merge: dropping a field at the *bottom* position inside a group still resolves to "below the group, ungrouped", because the group's trailing drop zone sits inside its last member row. Fixed separately.
