### PR TITLE
fix(fields): make every named drop boundary mean one thing, whichever way you drag

### DIFF
--- a/apps/web/src/components/fields/entity-fields-content.tsx
+++ b/apps/web/src/components/fields/entity-fields-content.tsx
@@ -39,6 +39,7 @@ import {
   groupAfterDropId,
   groupBeforeDropId,
   groupDropId,
+  groupEndDropId,
   resolveDropTarget,
 } from './rows/field-insert-line'
 import { FieldValueRow } from './rows/field-value-row'
@@ -406,12 +407,18 @@ export function EntityFieldsContent({
     // never splits another group), so a field target resolves to that field's
     // group when it has one.
     if (activeGroupId !== null) {
+      const overFieldId =
+        dropTarget.kind === 'field' || dropTarget.kind === 'field-before'
+          ? dropTarget.fieldId
+          : null
       const referenceGroupId =
-        dropTarget.kind === 'field'
-          ? (groupIdByFieldId.get(dropTarget.fieldId) ?? null)
-          : dropTarget.groupId
+        overFieldId !== null
+          ? (groupIdByFieldId.get(overFieldId) ?? null)
+          : dropTarget.kind === 'field' || dropTarget.kind === 'field-before'
+            ? null
+            : dropTarget.groupId
       if (referenceGroupId === null) {
-        const fieldId = dropTarget.kind === 'field' ? dropTarget.fieldId : null
+        const fieldId = overFieldId
         if (fieldId === null) return { indicator: null, highlight: null }
         const side = edgeFor(orderIndexById.get(fieldId) ?? -1)
         return {
@@ -437,6 +444,14 @@ export function EntityFieldsContent({
           highlight: targetGroupId === null ? null : { groupId: targetGroupId, blocked: false },
         }
       }
+      case 'field-before': {
+        // Named boundary: always the row's top edge, never `edgeFor`.
+        const targetGroupId = groupIdByFieldId.get(dropTarget.fieldId) ?? null
+        return {
+          indicator: { kind: 'row', rowId: dropTarget.fieldId, side: 'top', inset: false },
+          highlight: targetGroupId === null ? null : { groupId: targetGroupId, blocked: false },
+        }
+      }
       case 'group-into': {
         // A field dropped on the header lands at the HEAD of the block, so the
         // line belongs above the first member — not above the header, which is
@@ -447,6 +462,21 @@ export function EntityFieldsContent({
             firstMemberId === undefined
               ? null
               : { kind: 'row', rowId: firstMemberId, side: 'top', inset: false },
+          highlight: { groupId: dropTarget.groupId, blocked: false },
+        }
+      }
+      case 'group-end': {
+        // Full-width line under the last member, and the group lights up: this
+        // lands INSIDE. The `group-after` zone directly below draws the short
+        // inset line instead, so the two are told apart at a glance even though
+        // they sit only a few pixels apart.
+        const memberIds = memberIdsOfGroup(dropTarget.groupId).filter((id) => id !== activeDragId)
+        const lastMemberId = memberIds[memberIds.length - 1]
+        return {
+          indicator:
+            lastMemberId === undefined
+              ? null
+              : { kind: 'row', rowId: lastMemberId, side: 'bottom', inset: false },
           highlight: { groupId: dropTarget.groupId, blocked: false },
         }
       }
@@ -507,10 +537,42 @@ export function EntityFieldsContent({
     const draggedGroupId = parseGroupDropId(draggedId)
 
     if (draggedGroupId === null) {
-      return collisions.filter((collision) => {
+      /** The field in hand is already the last thing in that group's block. */
+      const isLastMemberOf = (groupId: string): boolean => {
+        const memberIds = sectionsRef.current.find((s) => s.group?.id === groupId)?.fieldIds ?? []
+        return memberIds[memberIds.length - 1] === draggedId
+      }
+
+      const usable = collisions.filter((collision) => {
         const target = resolveDropTarget(String(collision.id))
-        return !(target.kind === 'field' && target.fieldId === draggedId)
+        if (target.kind === 'field' || target.kind === 'field-before')
+          return target.fieldId !== draggedId
+        // "Inside, last slot" is where this field already IS — the drop would be
+        // a no-op, and the zone would sit on top of the one target that isn't:
+        // leaving the group downward.
+        if (target.kind === 'group-end') return !isLastMemberOf(target.groupId)
+        return true
       })
+
+      // `group-end` wins outright wherever it is under the pointer.
+      //
+      // `pointerWithin` ranks by distance from the pointer to each droppable's
+      // CENTRE, and this zone is a band inside the last member's row — so the
+      // two centres are about a pixel apart and the winner flipped with a pixel
+      // of pointer movement, which read as "the zone doesn't accept drops".
+      // Sizing cannot fix that; only precedence can. It is safe because the
+      // zone only overlaps that one row, and for a DOWNWARD drag both targets
+      // resolve to the same slot anyway.
+      const endIndex = usable.findIndex(
+        (collision) => resolveDropTarget(String(collision.id)).kind === 'group-end'
+      )
+      if (endIndex > 0) {
+        const promoted = usable[endIndex]
+        usable.splice(endIndex, 1)
+        if (promoted) usable.unshift(promoted)
+      }
+
+      return usable
     }
 
     const ownMemberIds = new Set(
@@ -523,7 +585,12 @@ export function EntityFieldsContent({
     )
     return collisions.filter((collision) => {
       const target = resolveDropTarget(String(collision.id))
-      if (target.kind === 'field') return !ownMemberIds.has(target.fieldId)
+      if (target.kind === 'field' || target.kind === 'field-before')
+        return !ownMemberIds.has(target.fieldId)
+      // `group-end` means "inside that group", which a group can never be. Left
+      // in, it would only compete with the `group-after` zone beneath it for the
+      // one thing a group drag CAN do at that boundary.
+      if (target.kind === 'group-end') return false
       return target.groupId !== draggedGroupId && !emptyGroupIds.has(target.groupId)
     })
   }, [])
@@ -533,15 +600,17 @@ export function EntityFieldsContent({
     setDropTarget(null)
   }
 
+  /** Identity of a drop target, so an unchanged hover does not re-render. */
+  const dropTargetKey = (target: FieldDropTarget): string =>
+    target.kind === 'field' || target.kind === 'field-before'
+      ? `${target.kind}:${target.fieldId}`
+      : `${target.kind}:${target.groupId}`
+
   const handleDragOver = (event: DragOverEvent) => {
     const next = event.over === null ? null : resolveDropTarget(String(event.over.id))
     setDropTarget((prev) => {
       if (prev === null || next === null) return prev === next ? prev : next
-      const sameId =
-        prev.kind === 'field' && next.kind === 'field'
-          ? prev.fieldId === next.fieldId
-          : prev.kind !== 'field' && next.kind !== 'field' && prev.groupId === next.groupId
-      return prev.kind === next.kind && sameId ? prev : next
+      return dropTargetKey(prev) === dropTargetKey(next) ? prev : next
     })
   }
 
@@ -577,7 +646,7 @@ export function EntityFieldsContent({
     // same call: `moveGroupBlock` owns the snap-to-boundary and direction rules,
     // so "above" vs "below" is its decision, not the droppable's.
     if (draggedGroupId !== null) {
-      if (target.kind === 'field') {
+      if (target.kind === 'field' || target.kind === 'field-before') {
         onMoveGroup?.(draggedGroupId, target.fieldId, false)
         return
       }
@@ -587,6 +656,11 @@ export function EntityFieldsContent({
     }
 
     switch (target.kind) {
+      case 'field-before':
+        // The zone names the edge, so the drop does not consult the direction.
+        if (target.fieldId === activeId) return
+        handleDragEnd(aimedAt(event, target.fieldId), 'before')
+        return
       case 'field': {
         if (target.fieldId === activeId) return
         // The SAME expression `deriveDropFeedback` draws the insert line from,
@@ -601,6 +675,20 @@ export function EntityFieldsContent({
       case 'group-into':
         handleDragEnd(aimedAt(event, groupDropId(target.groupId)))
         return
+      case 'group-end': {
+        // Aim at the last member with an explicit `after`. `handleDragEnd`
+        // reads membership from where the field lands, so targeting a member
+        // both joins the group and settles at its end — and naming the edge is
+        // the whole point: an upward drag would otherwise land before it.
+        const memberIds = memberIdsOfGroup(target.groupId).filter((id) => id !== activeId)
+        const lastMemberId = memberIds[memberIds.length - 1]
+        if (lastMemberId === undefined) {
+          handleDragEnd(aimedAt(event, groupDropId(target.groupId)))
+          return
+        }
+        handleDragEnd(aimedAt(event, lastMemberId), 'after')
+        return
+      }
       case 'group-before':
         onPlaceFieldBesideGroup?.(activeId, target.groupId, 'before')
         return
@@ -748,6 +836,12 @@ export function EntityFieldsContent({
           {isEditMode && (
             <>
               <FieldDropZone id={groupBeforeDropId(group.id)} edge='top' />
+              {/* Only when the block HAS a last member to land after. On an
+                  empty group this band would sit over the header, where
+                  `group-into` already means the same thing. */}
+              {memberRows.length > 0 && (
+                <FieldDropZone id={groupEndDropId(group.id)} edge='inner-bottom' />
+              )}
               <FieldDropZone id={groupAfterDropId(group.id)} edge='bottom' />
               {highlight?.groupId === group.id && (
                 <div className='pointer-events-none absolute inset-0 z-10 rounded-md border border-primary-200 border-dashed' />

--- a/apps/web/src/components/fields/entity-fields.tsx
+++ b/apps/web/src/components/fields/entity-fields.tsx
@@ -372,21 +372,29 @@ function EntityFields({
    * `-after-group` droppables name those two positions; this applies them.
    *
    * Why the round trip THROUGH the group rather than `assignFieldToGroup(null)`
-   * plus a reorder: `reorderDraft` is an arrayMove, so aiming at the group's
-   * first member lands the field below it on a downward drag and above it on an
-   * upward one. Joining the block first puts the field at a known end of it, and
-   * leaving the block then keeps that slot — `assignFieldToGroupInOrder` re-
-   * anchors the block at its first remaining MEMBER, so a departing field at the
-   * head floats above the block and one at the tail floats below it. The result
-   * is the same in both drag directions.
+   * plus a reorder: aiming at the group's first member is direction-sensitive
+   * unless the edge is named. Joining the block first puts the field at a known
+   * end of it, and leaving the block then keeps that slot —
+   * `assignFieldToGroupInOrder` re-anchors the block at its first remaining
+   * MEMBER, so a departing field at the head floats above the block and one at
+   * the tail floats below it. The result is the same in both drag directions.
    *
    * All three writes are functional `setDraft` updaters, so each observes the
    * previous one within this handler.
    */
   const placeFieldBesideGroup = useCallback(
     (fieldId: string, groupId: string, side: 'before' | 'after') => {
-      const memberIds = (draftGroups.find((g) => g.id === groupId)?.fieldIds ?? []).filter(
-        (id) => id !== fieldId
+      const memberSet = new Set(draftGroups.find((g) => g.id === groupId)?.fieldIds ?? [])
+
+      // Members in DISPLAY order, from `fieldOrder` — NOT the group's own
+      // `fieldIds` array. Membership is a set whose array order is only a
+      // tie-break; it drifts from the rendered order the moment anything is
+      // reordered inside the group. Reading `fieldIds[0]` as "the top of the
+      // block" therefore aimed step 2 at an arbitrary member, and a field
+      // dropped ABOVE a group landed in the middle of it — from where step 3's
+      // re-normalisation pushed it out BELOW the whole block.
+      const memberIds = (draft?.fieldOrder ?? []).filter(
+        (id) => id !== fieldId && memberSet.has(id)
       )
 
       // 1. Join the block — `assignFieldToGroup` places it at the block's end
@@ -396,12 +404,12 @@ function EntityFields({
       // 2. For `before`, pull it to the head; for `after` it is already at the
       //    tail, since step 1 appends.
       const firstMemberId = memberIds[0]
-      if (side === 'before' && firstMemberId) reorderDraft(fieldId, firstMemberId)
+      if (side === 'before' && firstMemberId) reorderDraft(fieldId, firstMemberId, 'before')
 
       // 3. Leave every group, keeping the slot just established.
       assignFieldToGroup(fieldId, null)
     },
-    [assignFieldToGroup, draftGroups, reorderDraft]
+    [assignFieldToGroup, draft, draftGroups, reorderDraft]
   )
 
   // ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/fields/rows/field-insert-line.tsx
+++ b/apps/web/src/components/fields/rows/field-insert-line.tsx
@@ -34,6 +34,9 @@ export const BEFORE_SUFFIX = '-before'
 /** Suffix for "the boundary below this group's whole block". */
 export const AFTER_GROUP_SUFFIX = '-after-group'
 
+/** Suffix for "the last slot INSIDE this group", after its final member. */
+export const GROUP_END_SUFFIX = '-end'
+
 /** Droppable id for the boundary above a field row. */
 export function fieldBeforeDropId(fieldId: string): string {
   return `${fieldId}${BEFORE_SUFFIX}`
@@ -54,20 +57,44 @@ export function groupAfterDropId(groupId: string): string {
   return `${GROUP_DROP_PREFIX}${groupId}${AFTER_GROUP_SUFFIX}`
 }
 
+/** Droppable id for the last slot INSIDE a group, after its final member. */
+export function groupEndDropId(groupId: string): string {
+  return `${GROUP_DROP_PREFIX}${groupId}${GROUP_END_SUFFIX}`
+}
+
 /**
  * What a droppable id means, once its suffix is parsed off.
  *
- * - `field` — land at that row's slot. Both the row's own `useSortable`
- *   droppable and its `-before` line resolve here: they are two hit areas for
- *   one outcome, which is what makes targeting robust near a row boundary.
+ * - `field` — land at that row's slot, on the side the drag came FROM: down
+ *   onto a row lands after it, up onto a row lands before it. Direction is the
+ *   right rule for a row's body, where the gesture is "past this row".
+ * - `field-before` — land immediately above that row, whatever the direction.
+ *
+ * The two used to be one: a `-before` id had its suffix stripped and resolved
+ * to the bare row, handing its meaning back to `edgeFor`. That made a NAMED
+ * boundary direction-dependent, and next to a group it produced a genuine
+ * inversion — the band above a row meant "above it" while the group zone just
+ * above THAT meant "below the last member", so moving the pointer up moved the
+ * insert position down. A zone that names a boundary now decides its own edge.
  * - `group-into` — join the group (the bare header id).
  * - `group-before` / `group-after` — land beside the block, in no group.
+ * - `group-end` — join the group at its LAST slot, after the final member.
+ *
+ * `group-end` exists because a row target's edge is derived from the drag's
+ * DIRECTION (`edgeFor`): dragging down onto a row lands after it, dragging up
+ * lands before it. So an upward drag can never express "after this row", and
+ * for a group's final member that made the group's own last slot unreachable —
+ * the field had to be dropped into the group somewhere else and reordered in a
+ * second gesture. This names the slot outright, so it means the same thing from
+ * either direction.
  */
 export type FieldDropTarget =
   | { kind: 'field'; fieldId: string }
+  | { kind: 'field-before'; fieldId: string }
   | { kind: 'group-into'; groupId: string }
   | { kind: 'group-before'; groupId: string }
   | { kind: 'group-after'; groupId: string }
+  | { kind: 'group-end'; groupId: string }
 
 /**
  * Parse a dnd `over` id back into the drop it expresses.
@@ -81,10 +108,16 @@ export function resolveDropTarget(overId: string): FieldDropTarget {
     const groupId = parseGroupDropId(overId.slice(0, -AFTER_GROUP_SUFFIX.length))
     if (groupId !== null) return { kind: 'group-after', groupId }
   }
+  if (overId.endsWith(GROUP_END_SUFFIX)) {
+    const groupId = parseGroupDropId(overId.slice(0, -GROUP_END_SUFFIX.length))
+    if (groupId !== null) return { kind: 'group-end', groupId }
+  }
   if (overId.endsWith(BEFORE_SUFFIX)) {
     const bare = overId.slice(0, -BEFORE_SUFFIX.length)
     const groupId = parseGroupDropId(bare)
-    return groupId !== null ? { kind: 'group-before', groupId } : { kind: 'field', fieldId: bare }
+    return groupId !== null
+      ? { kind: 'group-before', groupId }
+      : { kind: 'field-before', fieldId: bare }
   }
   const groupId = parseGroupDropId(overId)
   return groupId !== null ? { kind: 'group-into', groupId } : { kind: 'field', fieldId: overId }
@@ -93,8 +126,13 @@ export function resolveDropTarget(overId: string): FieldDropTarget {
 interface FieldDropZoneProps {
   /** One of the ids minted above. */
   id: string
-  /** Which edge of the positioned parent this zone straddles. */
-  edge: 'top' | 'bottom'
+  /**
+   * Where in the positioned parent this zone sits:
+   * - `top` — straddling the top boundary
+   * - `inner-bottom` — inside the block, just above its closing edge
+   * - `bottom` — the closing edge itself
+   */
+  edge: 'top' | 'inner-bottom' | 'bottom'
 }
 
 /**
@@ -104,22 +142,44 @@ interface FieldDropZoneProps {
  * rects, never from pointer events, so the zone can overlap a row's own controls
  * without swallowing clicks.
  *
- * The two edges are deliberately NOT symmetric. A `top` zone straddles its
- * boundary (`-top-2 h-4`) while a `bottom` zone sits just inside the block it
- * closes (`bottom-0 h-4`). A group's trailing zone and the next row's leading
- * zone describe the same seam, and two droppables with identical rects make
- * `closestCorners` pick by registration order rather than by where the pointer
- * actually is.
+ * A `top` zone STRADDLES its boundary; the two bottom zones sit INSIDE the block
+ * they close. That asymmetry is load bearing: an ungrouped row following a group
+ * has no top margin, so a bottom zone straddling the block's edge would occupy
+ * the identical 16px band as that row's `-top-2 h-4` leading zone — and the two
+ * mean slots one row apart, so the tie would decide the drop.
  */
+/**
+ * The last member's row is ~30px, and its bottom is where three different
+ * answers compete. They are stacked, not overlapped, so each owns real estate:
+ *
+ *   30px ┬ ── row body / its own `-before` band above ─ "before the last member"
+ *        │
+ *   24px ┼ ── inner-bottom ──────────────────────────── "inside, last slot"
+ *        │
+ *   12px ┼ ── bottom ─────────────────────────────────── "below the block, out"
+ *        │
+ *    0px ┴
+ *
+ * Sizing them equally matters, and both directions were tried the hard way: a
+ * 16px `bottom` swallowed the whole lower half and made the group's own last
+ * slot unreachable, then correcting it to 8px made LEAVING the group the hard
+ * one. Height alone cannot settle it either — `pointerWithin` ranks by distance
+ * to each droppable's CENTRE, and a band inside a 30px row has a centre within a
+ * pixel or two of the row's own, so `inner-bottom` is additionally given
+ * precedence in `collisionDetection` rather than left to win on proximity.
+ */
+const ZONE_POSITION: Record<FieldDropZoneProps['edge'], string> = {
+  top: '-top-2 h-4',
+  'inner-bottom': 'bottom-3 h-3',
+  bottom: 'bottom-0 h-3',
+}
+
 export function FieldDropZone({ id, edge }: FieldDropZoneProps) {
   const { setNodeRef } = useDroppable({ id })
   return (
     <div
       ref={setNodeRef}
-      className={cn(
-        'pointer-events-none absolute right-0 left-0 z-0 h-4',
-        edge === 'top' ? '-top-2' : 'bottom-0'
-      )}
+      className={cn('pointer-events-none absolute right-0 left-0 z-0', ZONE_POSITION[edge])}
     />
   )
 }


### PR DESCRIPTION
Follow-up to #1540. Four defects in the property panel's drop targeting, all found by driving the panel — none of them visible to typecheck, biome or the pure layer's tests.

## Named boundaries were direction-dependent

A row's edge comes from `edgeFor`, which reads the drag's **direction**: down onto a row lands after it, up lands before it. That's the right rule for a row's *body*, where the gesture is "past this row".

It was wrong for the `-before` zones. `resolveDropTarget` stripped the suffix and returned the bare row, handing a **named** boundary's meaning back to the direction rule. Next to a group that produced a genuine inversion — the band above a row meant "above it", while the group zone just above *that* meant "below the last member", so **moving the pointer up moved the insert position down**.

`field-before` is now its own target kind, routed with an explicit `'before'`. Row bodies stay direction-derived, which agrees with the bands rather than fighting them: "after B" and "before C" are the same slot.

## The last slot inside a group was unreachable

Every row target means "above" on an upward drag, so there was no way to say "after the last member" — the field had to be dropped into the group and then reordered in a second gesture.

New `fieldgroup:<g>-end` target. The block's bottom is now three stacked bands:

```
  row body      → before the last member
  -end          → inside the group, last slot
  -after-group  → below the block, ungrouped
```

Both mis-sizings were tried on the way here: 16px for the outside band made the group's last slot unreachable; 8px made *leaving* the group the hard one.

## Height cannot settle a proximity contest

`pointerWithin` ranks by distance to each droppable's **centre**, and a band inside a ~30px row has a centre within a pixel of the row's own — so the winner flipped with a pixel of pointer movement and the zone read as "doesn't accept drops". `-end` is therefore given **precedence** in `collisionDetection` rather than left to win on proximity.

It's also filtered out entirely when the dragged field already **is** that group's last member, where it could only mean "no change" while covering the one target that isn't: pulling the field out downward.

## `placeFieldBesideGroup` read membership order as display order

It used `group.fieldIds[0]` as "the top of the block". `fieldIds` is a membership **set** whose array order is only a tie-break — display order lives in `fieldOrder`, and the two drift apart as soon as anything is reordered inside the group.

So the reorder aimed at an arbitrary member and dropped the field mid-block, from where step 3's re-normalisation gathers the real members back to their anchor and pushes the now-ungrouped field out below the whole block. Dropping a field **above** a group landed it **below**. Now derived from `draft.fieldOrder`, with the edge named.

This one predates #1540 and needs a group whose internal order has been changed, which is why a freshly built group never showed it.

## Testing

108 unit tests green, `apps/web` typecheck clean in every touched file, biome clean — but none of that covers drop geometry. Verified by the reviewer driving the panel: field into a group's last slot from above and below, field out of a group downward, field dropped above a group, and reordering within a group after its order had been changed.

Temporary drop-zone tinting and an on-screen target readout were used to diagnose this and have been removed.