### PR TITLE
feat(fields): field groups in the record create/edit dialog

### DIFF
--- a/apps/web/src/components/custom-fields/ui/dialog-field-config-row.tsx
+++ b/apps/web/src/components/custom-fields/ui/dialog-field-config-row.tsx
@@ -4,57 +4,56 @@
 import { Switch } from '@auxx/ui/components/switch'
 import { cn } from '@auxx/ui/lib/utils'
 import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
 import { GripVertical } from 'lucide-react'
-import { memo, useMemo } from 'react'
+import { memo } from 'react'
 
 /** Props for DialogFieldConfigRow */
 interface DialogFieldConfigRowProps {
-  /** Unique ID for the sortable item */
+  /** Unique ID for the sortable item — the VIEW field id, which is every dnd id */
   id: string
   /** Display label for the field */
   label: string
   /** Whether the field is currently visible */
   isVisible: boolean
-  /** Handler for toggling visibility */
-  onToggleVisibility: (visible: boolean) => void
+  /**
+   * Handler for toggling visibility. Withheld for a preview row (the drag
+   * ghost), which is what collapses it to grip + name.
+   */
+  onToggleVisibility?: (visible: boolean) => void
+  /** Last row of the panel — see `FieldPanel`'s `rowBorders='managed'`. */
+  isLastRow?: boolean
 }
 
 /**
  * Sortable row for dialog config mode.
+ *
  * Mirrors FieldPanelRow DOM structure (data-slot="field-row") so there is
  * zero layout shift when toggling between normal and config mode.
  * GripVertical replaces the type icon; Switch replaces the input content.
+ *
+ * There is deliberately NO `SortableContext` around it (see
+ * `fields/ui/field-group-list.tsx`): nothing displaces, so `useSortable` never
+ * resolves a `transform` and applying one would be dead code. The row fades in
+ * place at 0.3 — the same value `FieldEditRow`, `FieldGroupRow` and the KB
+ * sidebar use — and the `DragOverlay` ghost is what follows the pointer.
  */
 export const DialogFieldConfigRow = memo(function DialogFieldConfigRow({
   id,
   label,
   isVisible,
   onToggleVisibility,
+  isLastRow = false,
 }: DialogFieldConfigRowProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id,
-  })
-
-  /** Memoize style to prevent unnecessary re-renders during drag */
-  const style = useMemo(
-    () => ({
-      transform: CSS.Transform.toString(transform),
-      transition,
-      zIndex: isDragging ? 10 : 1,
-      opacity: isDragging ? 0.8 : 1,
-    }),
-    [transform, transition, isDragging]
-  )
+  const { attributes, listeners, setNodeRef, isDragging } = useSortable({ id })
 
   return (
     <div
       ref={setNodeRef}
-      style={style}
       data-slot='field-row'
+      data-last-row={isLastRow ? '' : undefined}
       className={cn(
         'relative flex border-b dark:border-b-[#404754]/20',
-        isDragging && 'bg-accent rounded',
+        isDragging && 'opacity-30',
         !isVisible && 'opacity-50'
       )}>
       {/* Label area — matches FieldPanelRow [data-slot="field-row-label"] */}
@@ -73,7 +72,9 @@ export const DialogFieldConfigRow = memo(function DialogFieldConfigRow({
       <div
         data-slot='field-row-content'
         className='w-full flex-1 flex items-center justify-end pe-2 py-1.5'>
-        <Switch checked={isVisible} size='sm' onCheckedChange={onToggleVisibility} />
+        {onToggleVisibility && (
+          <Switch checked={isVisible} size='sm' onCheckedChange={onToggleVisibility} />
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
@@ -1,11 +1,13 @@
 // apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
 'use client'
 
+import type { FieldGroup, ViewContextType } from '@auxx/lib/conditions/client'
 import { formatToRawValue } from '@auxx/lib/field-values/client'
 import {
   isTrailingMetadataField,
   parseRecordId,
   type RecordId,
+  type ResourceField,
   toRecordId,
 } from '@auxx/lib/resources/client'
 import { Button, buttonVariants } from '@auxx/ui/components/button'
@@ -14,34 +16,73 @@ import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { Switch } from '@auxx/ui/components/switch'
 import { cn } from '@auxx/ui/lib/utils'
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core'
-import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
+import { KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { Pencil, X } from 'lucide-react'
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useFieldGroupDnd } from '~/components/fields/hooks/use-field-group-dnd'
 import { useFieldView } from '~/components/fields/hooks/use-field-view'
 import { useFieldViewDraft } from '~/components/fields/hooks/use-field-view-draft'
 import { mergeFieldOrder } from '~/components/fields/merge-field-order'
+import { AddGroupRow } from '~/components/fields/rows/field-group-row'
+import {
+  FieldGroupList,
+  type FieldGroupListRowContext,
+} from '~/components/fields/ui/field-group-list'
 import { FieldPanel } from '~/components/global/forms/field-panel'
 import { useResource } from '~/components/resources'
 import { useCreateRecord } from '~/components/resources/hooks/use-create-record'
 import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-value-syncer'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { DialogFieldConfigRow } from '../dialog-field-config-row'
 import { FieldInputRow } from '../field-input-row'
+
+/** The view id a field is keyed by in `fieldOrder` / `fieldGroups[].fieldIds`. */
+function viewFieldId(field: { resourceFieldId?: unknown; id?: unknown; key?: unknown }): string {
+  return String(field.resourceFieldId ?? field.id ?? field.key)
+}
+
+/**
+ * A grouped row's inset.
+ *
+ * The label column is a fixed width synced across mounted panels, and the resize
+ * divider is ONE absolutely positioned line at that offset — so indenting the
+ * ROW would push its content column 12px past the divider and break the
+ * alignment contract for grouped rows only. Indent the label TEXT instead,
+ * keeping the label/content boundary global. On mobile there is no fixed column
+ * to misalign, so the whole row can indent there.
+ *
+ * The label-slot override beats `FieldPanelRow`'s own `ps-2` on specificity —
+ * (0,2,0) vs (0,1,0) — the same mechanism `FieldPanel` uses for its orientation
+ * rules. `@md` matches the `breakpoint='md'` both panels below declare.
+ */
+const GROUPED_ROW_CLASS = 'ps-3 @md:ps-0 @md:[&_[data-slot=field-row-label]]:ps-5'
+
+/**
+ * Re-align the group header with the rows around it.
+ *
+ * `FieldGroupRow` is shaped for the property panel, whose rows put their glyph
+ * in a 24px band flush with the row's left edge and band it to the row's TOP.
+ * A `FieldPanelRow` does neither: its icon sits in the panel's `ps-2` gutter and
+ * is vertically centred. The 24px band width is unchanged either way, so the
+ * header's label text stays on the same x as the field names below it — only
+ * the glyph and the vertical banding move.
+ */
+const GROUP_HEADER_CLASS = [
+  '[&_[data-slot=field-group-glyph]]:justify-start [&_[data-slot=field-group-glyph]]:ps-2',
+  '[&_[data-slot=field-group-band]]:self-center',
+  // The rows' content area ends on `pe-2`, so their switches never touch the
+  // panel's edge. The header's delete button gets the same gutter.
+  '[&_[data-slot=field-group-actions]]:pe-2',
+].join(' ')
+
+/** What each mode hands `FieldGroupList` to draw one row. */
+type FieldListRowRenderer = (field: ResourceField, ctx: FieldGroupListRowContext) => ReactNode
+
+/** Stable empty array so a group-less view keeps referential identity across renders. */
+const NO_GROUPS: FieldGroup[] = []
 
 /** Title + description derived from the form's mode, handed to the header slot. */
 export interface EntityInstanceFormHeaderContext {
@@ -131,6 +172,7 @@ export function EntityInstanceForm({
   const {
     draft,
     isDraftMode,
+    isDraftDirty,
     isSaving,
     draftContextType,
     enterDraft,
@@ -139,10 +181,17 @@ export function EntityInstanceForm({
     setDraftVisibility,
     reorderDraft,
     saveDraft,
+    draftGroups,
+    addGroup,
+    renameGroup,
+    deleteGroup,
+    assignFieldToGroup,
+    moveGroup,
   } = useFieldViewDraft({ entityDefinitionId, contextType, fields: allEditableFields })
 
-  // Use field view for visibility/ordering (normal mode only)
-  const { getVisibleFields } = useFieldView({
+  // Use field view for visibility/ordering (normal mode only). `config` carries
+  // the saved groups read mode renders sections from.
+  const { config: viewConfig, getVisibleFields } = useFieldView({
     entityDefinitionId,
     contextType,
     fields: allEditableFields,
@@ -150,10 +199,7 @@ export function EntityInstanceForm({
   })
 
   // Field IDs in baseline order — the merge baseline for config mode
-  const fieldIds = useMemo(
-    () => allEditableFields.map((f) => String(f.resourceFieldId ?? f.id ?? f.key)),
-    [allEditableFields]
-  )
+  const fieldIds = useMemo(() => allEditableFields.map(viewFieldId), [allEditableFields])
 
   // DnD sensors for config mode
   const sensors = useSensors(
@@ -161,16 +207,103 @@ export function EntityInstanceForm({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
+  // Confirm dialog for discarding unsaved view edits (the X and the Create/Edit
+  // tab both route through it) and for deleting a populated group.
+  const [confirmDraft, ConfirmDraftDialog] = useConfirm()
+
   // ─── Config Mode Handlers ──────────────────────────────────────────────────
 
-  /** dnd-kit adapter over the draft hook's index-free reorder */
-  const handleDraftDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event
-      if (!over || active.id === over.id) return
-      reorderDraft(String(active.id), String(over.id))
+  // The field half of drop routing, shared verbatim with the property panel.
+  const { handleFieldDragEnd, placeFieldBesideGroup } = useFieldGroupDnd({
+    draft,
+    draftGroups,
+    assignFieldToGroup,
+    reorderDraft,
+  })
+
+  /** The group whose label input should take focus (just created in this session). */
+  const [newGroupId, setNewGroupId] = useState<string | null>(null)
+
+  const handleAddGroup = () => setNewGroupId(addGroup('New group'))
+
+  const handleDeleteGroup = async (groupId: string, label: string) => {
+    // An EMPTY group has nothing to lose — no field changes hands and the draft
+    // is still discardable with Cancel — so a confirm is pure friction on the
+    // most likely case: created one by mistake, remove it again.
+    const memberCount = draftGroups.find((g) => g.id === groupId)?.fieldIds.length ?? 0
+    if (memberCount === 0) {
+      deleteGroup(groupId)
+      return
+    }
+
+    const confirmed = await confirmDraft({
+      title: 'Delete group?',
+      description: `"${label}" will be removed and its ${memberCount} field${memberCount === 1 ? '' : 's'} become ungrouped. No field is deleted — only the group.`,
+      confirmText: 'Delete group',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+
+    if (confirmed) deleteGroup(groupId)
+  }
+
+  /**
+   * "Save or discard?" — the prompt both silent-discard exits now route through.
+   *
+   * Ordering-only edits made losing a draft an annoyance; a half-built group is
+   * real work. Saving here is exactly Save View: the same `saveDraft`, one
+   * config write.
+   */
+  const askToSaveDraft = useCallback(
+    () =>
+      confirmDraft({
+        title: 'Save changes to this view?',
+        description:
+          'Your changes to the field layout have not been saved. Saving applies them for everyone in the organization.',
+        confirmText: 'Save',
+        cancelText: 'Discard',
+      }),
+    [confirmDraft]
+  )
+
+  /**
+   * The X out of config mode. Unlike the footer's Cancel — which sits beside
+   * Save View, so the choice has already been put to the user — this reads as
+   * "close this", not "throw my work away".
+   *
+   * `saveDraft` never rejects: on failure it toasts and leaves the draft intact,
+   * so a failed save keeps the user in config mode with their changes rather
+   * than closing over them.
+   */
+  const handleExitDraft = useCallback(async () => {
+    if (!isDraftDirty) {
+      cancelDraft()
+      return
+    }
+    if (await askToSaveDraft()) await saveDraft()
+    else cancelDraft()
+  }, [askToSaveDraft, cancelDraft, isDraftDirty, saveDraft])
+
+  /**
+   * The Create/Edit tab re-snapshots from the store, which drops the current
+   * context's unsaved edits — so it asks first, exactly like the X.
+   *
+   * A successful `saveDraft` leaves config mode entirely, so the save branch
+   * re-enters it: this is a tab switch, not an exit. A failed one aborts the
+   * switch outright, leaving the user on the tab whose work is still unsaved.
+   */
+  const handleSwitchDraftContext = useCallback(
+    async (next: ViewContextType) => {
+      if (next === draftContextType) return
+      if (isDraftDirty) {
+        if (await askToSaveDraft()) {
+          if (!(await saveDraft())) return
+          enterDraft()
+        }
+      }
+      switchDraftContext(next)
     },
-    [reorderDraft]
+    [askToSaveDraft, draftContextType, enterDraft, isDraftDirty, saveDraft, switchDraftContext]
   )
 
   // ─── Config Mode Derived State ────────────────────────────────────────────
@@ -178,9 +311,7 @@ export function EntityInstanceForm({
   /** Fields ordered by the draft config (for config mode rendering) */
   const configModeFields = useMemo(() => {
     if (!draft) return []
-    const fieldMap = new Map(
-      allEditableFields.map((f) => [String(f.resourceFieldId ?? f.id ?? f.key), f])
-    )
+    const fieldMap = new Map(allEditableFields.map((f) => [viewFieldId(f), f]))
 
     // The merge yields exactly the baseline ids, each once — a field missing from
     // the stored order is spliced in at its baseline anchor rather than appended
@@ -213,11 +344,12 @@ export function EntityInstanceForm({
     return isDraftMode ? configModeFields : getVisibleFields()
   }, [isDraftMode, configModeFields, getVisibleFields])
 
-  // Sortable IDs for DnD (all fields in config mode)
-  const sortableFieldIds = useMemo(
-    () => editableFields.map((f) => f.resourceFieldId ?? f.id ?? f.key),
-    [editableFields]
-  )
+  /**
+   * The groups the list renders sections from: the unsaved draft's in config
+   * mode, the saved org view's in normal mode. A group carries no position —
+   * its header renders where its first member sits in the field order.
+   */
+  const renderedGroups = isDraftMode ? draftGroups : (viewConfig.fieldGroups ?? NO_GROUPS)
 
   // RecordIds for syncer
   const recordIds = useMemo(() => (recordId ? [recordId] : []), [recordId])
@@ -509,6 +641,28 @@ export function EntityInstanceForm({
     }
   }
 
+  /**
+   * Groups holding a field that currently fails validation, so the list can
+   * force them open.
+   *
+   * TWO ID KEYSPACES MEET HERE. `errors` is keyed by `field.id` (the form
+   * keyspace); groups are keyed by the VIEW id (`resourceFieldId`, which for a
+   * custom field is `<entityDefinitionId>:<fieldId>` — a genuinely different
+   * string). The map therefore goes through the field OBJECT and never
+   * string-matches one against the other.
+   */
+  const errorGroupIds = useMemo(() => {
+    if (Object.keys(errors).length === 0 || renderedGroups.length === 0) return []
+    const ids = new Set<string>()
+    for (const field of editableFields) {
+      if (!errors[field.id]) continue
+      const viewId = viewFieldId(field)
+      const group = renderedGroups.find((g) => g.fieldIds.includes(viewId))
+      if (group) ids.add(group.id)
+    }
+    return [...ids]
+  }, [errors, editableFields, renderedGroups])
+
   const resourceLabel = resource?.label ?? 'Record'
 
   const title = isDraftMode
@@ -522,8 +676,31 @@ export function EntityInstanceForm({
       ? `Update the ${resourceLabel.toLowerCase()} details below.`
       : `Enter the details for the new ${resourceLabel.toLowerCase()}.`
 
+  /** Shared by both modes — one list component, one drag model, one collapse state. */
+  const renderFieldList = (renderRow: FieldListRowRenderer) => (
+    <FieldGroupList<ResourceField>
+      rows={editableFields}
+      rowId={viewFieldId}
+      rowKey={(field) => String(field.id ?? field.key)}
+      groups={renderedGroups}
+      isEditMode={isDraftMode}
+      sensors={sensors}
+      onFieldDragEnd={handleFieldDragEnd}
+      onPlaceFieldBesideGroup={placeFieldBesideGroup}
+      onMoveGroup={moveGroup}
+      onRenameGroup={renameGroup}
+      onDeleteGroup={handleDeleteGroup}
+      newGroupId={newGroupId}
+      groupedRowClassName={GROUPED_ROW_CLASS}
+      groupClassName={GROUP_HEADER_CLASS}
+      forceExpandGroupIds={errorGroupIds}
+      renderRow={renderRow}
+    />
+  )
+
   return (
     <>
+      <ConfirmDraftDialog />
       {header?.({ title, description })}
 
       {/* Field card area — floating edit button anchored to its top-right corner */}
@@ -537,7 +714,7 @@ export function EntityInstanceForm({
           <Button
             variant='ghost'
             size='icon-xs'
-            onClick={() => (isDraftMode ? cancelDraft() : enterDraft())}
+            onClick={() => (isDraftMode ? void handleExitDraft() : enterDraft())}
             className={cn(
               'cursor-pointer',
               isDraftMode
@@ -549,31 +726,36 @@ export function EntityInstanceForm({
         </div>
 
         {isDraftMode ? (
-          /* Config mode: sortable field list with visibility switches.
+          /* Config mode: grouped, draggable field list with visibility switches.
              No resizeId here — the resize strip would steal pointer-downs from
-             the row drag-and-drop. */
-          <FieldPanel className='p-0'>
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDraftDragEnd}
-              modifiers={[restrictToVerticalAxis]}>
-              <SortableContext items={sortableFieldIds} strategy={verticalListSortingStrategy}>
-                {editableFields.map((field) => {
-                  const fieldKey = field.resourceFieldId ?? field.id ?? field.key
-                  return (
-                    <DialogFieldConfigRow
-                      key={fieldKey}
-                      id={fieldKey}
-                      label={field.label ?? field.name ?? field.key}
-                      isVisible={draft?.fieldVisibility[fieldKey] !== false}
-                      onToggleVisibility={(visible) => setDraftVisibility(fieldKey, visible)}
-                    />
-                  )
-                })}
-              </SortableContext>
-            </DndContext>
-          </FieldPanel>
+             the row drag-and-drop, and group-header drags make that worse.
+             `rowBorders='managed'`: group wrappers nest the rows, which defeats
+             the panel's direct-child last-row rule. */
+          <>
+            <FieldPanel className='p-0' breakpoint='md' rowBorders='managed'>
+              {renderFieldList((field, ctx) => {
+                const fieldKey = viewFieldId(field)
+                return (
+                  <DialogFieldConfigRow
+                    id={fieldKey}
+                    label={field.label ?? field.name ?? field.key}
+                    isVisible={draft?.fieldVisibility[fieldKey] !== false}
+                    // A preview row is the drag ghost: withholding the handler
+                    // is what collapses it to grip + name.
+                    onToggleVisibility={
+                      ctx.preview ? undefined : (visible) => setDraftVisibility(fieldKey, visible)
+                    }
+                    isLastRow={ctx.isLast}
+                  />
+                )
+              })}
+            </FieldPanel>
+            {/* Field DEFINITION administration lives in the property panel and
+                settings, so there is no Add Field counterpart here. The panel is
+                a bordered card in this surface, not a bare list, so the row
+                needs its own clearance from the edge. */}
+            <AddGroupRow onClick={handleAddGroup} className='mt-2 ms-0' />
+          </>
         ) : (
           /* Normal mode: form inputs */
           <>
@@ -581,10 +763,10 @@ export function EntityInstanceForm({
               <FieldPanel
                 className='p-0'
                 breakpoint='md'
+                rowBorders='managed'
                 resizeId={`entity-instance:${entityDefinitionId}`}>
-                {editableFields.map((field) => (
+                {renderFieldList((field, ctx) => (
                   <FieldInputRow
-                    key={field.id}
                     field={field}
                     value={values[field.id] ?? ''}
                     onChange={handleFieldChange}
@@ -595,9 +777,11 @@ export function EntityInstanceForm({
                     }
                     validationType='error'
                     disabled={isPending}
+                    isLastRow={ctx.isLast}
                   />
                 ))}
               </FieldPanel>
+              {/* Outside every group, after the sections. */}
               {!isEditing && createExtension?.content}
             </div>
 
@@ -617,7 +801,7 @@ export function EntityInstanceForm({
           {/* Left side: Context type toggle (Create / Edit) */}
           <RadioTab
             value={draftContextType}
-            onValueChange={switchDraftContext}
+            onValueChange={(value) => void handleSwitchDraftContext(value as ViewContextType)}
             size='sm'
             radioGroupClassName='rounded-xl'
             className='h-7'>
@@ -637,7 +821,7 @@ export function EntityInstanceForm({
             <Button
               size='sm'
               variant='outline'
-              onClick={saveDraft}
+              onClick={() => void saveDraft()}
               loading={isSaving}
               loadingText='Saving...'>
               Save View

--- a/apps/web/src/components/custom-fields/ui/field-input-row.tsx
+++ b/apps/web/src/components/custom-fields/ui/field-input-row.tsx
@@ -82,6 +82,11 @@ interface FieldInputRowProps {
   disabled?: boolean
   /** Custom placeholder text (e.g., "<Varies>" for bulk edit) */
   placeholder?: string
+  /**
+   * Last row of the panel. Only used by a panel running `rowBorders='managed'`
+   * (the grouped record dialog), where nesting defeats the direct-child rule.
+   */
+  isLastRow?: boolean
 }
 
 /**
@@ -96,6 +101,7 @@ export function FieldInputRow({
   validationType = 'error',
   disabled = false,
   placeholder,
+  isLastRow = false,
 }: FieldInputRowProps) {
   const isRequired = field.required ?? field.capabilities?.required ?? false
   const fieldType = field.fieldType ?? 'TEXT'
@@ -152,6 +158,7 @@ export function FieldInputRow({
       isRequired={isRequired}
       validationError={validationError}
       validationType={validationType}
+      isLastRow={isLastRow}
       showIcon>
       <FieldInputAdapter
         fieldType={fieldType}

--- a/apps/web/src/components/dynamic-table/components/header-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/header-cell.tsx
@@ -673,7 +673,11 @@ export function HeaderCell<TData>({ header, isDragging = false }: HeaderCellProp
 
           {/* New button (only for primary column with onAddNew) */}
           {showNewButton && (
-            <Tooltip content={`New ${entityLabel || ''}`} side='top'>
+            /* `allowInteraction`: without it `SimpleTooltip` preventDefault-s the
+               pointerdown and pins itself open for 50ms, which suppresses Radix's
+               own close-on-click — so the bubble hung over the dialog this button
+               opens. */
+            <Tooltip content={`New ${entityLabel || ''}`} side='top' allowInteraction>
               <Button
                 variant='ghost'
                 size='icon-xs'

--- a/apps/web/src/components/fields/entity-fields-content.tsx
+++ b/apps/web/src/components/fields/entity-fields-content.tsx
@@ -6,45 +6,19 @@ import { parseRecordId, type RecordId, type ResourceField } from '@auxx/lib/reso
 import type { ResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
-import type {
-  CollisionDetection,
-  DragOverEvent,
-  DragStartEvent,
-  SensorDescriptor,
-  SensorOptions,
-} from '@dnd-kit/core'
-import {
-  closestCorners,
-  DndContext,
-  type DragEndEvent,
-  DragOverlay,
-  pointerWithin,
-} from '@dnd-kit/core'
-import { restrictToVerticalAxis, restrictToWindowEdges } from '@dnd-kit/modifiers'
+import type { DragEndEvent, SensorDescriptor, SensorOptions } from '@dnd-kit/core'
 import { Pencil, X } from 'lucide-react'
 import type React from 'react'
-import { Fragment, useCallback, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useCallback, useRef, useState } from 'react'
 import { CustomFieldDialog } from '~/components/custom-fields/ui/custom-field-dialog'
 import { AddFieldRow } from './add-field-row'
 import { useFieldNavigation } from './field-navigation-context'
-import { type FieldGroupLike, type GroupedFieldSection, groupFieldOrder } from './group-fields'
 import { FieldEditRow } from './rows/field-edit-row'
-import { AddGroupRow, FieldGroupRow, parseGroupDropId } from './rows/field-group-row'
-import {
-  type FieldDropTarget,
-  FieldDropZone,
-  FieldInsertLine,
-  fieldBeforeDropId,
-  groupAfterDropId,
-  groupBeforeDropId,
-  groupDropId,
-  groupEndDropId,
-  resolveDropTarget,
-} from './rows/field-insert-line'
+import { AddGroupRow } from './rows/field-group-row'
 import { FieldValueRow } from './rows/field-value-row'
 import { toPanelField } from './rows/to-panel-field'
 import type { PanelField } from './rows/types'
+import { FieldGroupList } from './ui/field-group-list'
 
 /**
  * Props for EntityFieldsContent component (unified version)
@@ -62,7 +36,7 @@ export interface EntityFieldsContentProps {
    */
   onExitEditMode: () => void | Promise<void>
   /** Persist the draft (order + visibility) as one config write */
-  onSaveView: () => void | Promise<void>
+  onSaveView: () => unknown
   /** Whether the view config is currently being persisted */
   isSaving?: boolean
   dialogOpen: boolean
@@ -229,43 +203,7 @@ export function EntityFieldsContent({
     }
   })
 
-  // ─────────────────────────────────────────────────────────────────
-  // GROUPS
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * Collapse is LOCAL and read-mode only, deliberately.
-   *
-   * `FieldGroup.collapsed` is part of the org's shared default view — one config
-   * row every member of the org reads. Persisting a chevron click would be a
-   * server write per click that collapses the group for *everyone*, which is not
-   * what "I want this section out of my way right now" means. So collapse is a
-   * per-mount override layered on the persisted default.
-   *
-   * Nothing writes that persisted default today: edit mode forces every group
-   * open and shows no chevron, so there is no UI for it. The schema field and
-   * the draft hook's `setGroupCollapsed` remain, since a "starts collapsed"
-   * option is the natural place to wire it back up.
-   */
-  const [collapsedOverrides, setCollapsedOverrides] = useState<Record<string, boolean>>({})
-
-  /**
-   * Edit mode forces every group OPEN. You are rearranging structure there —
-   * dragging fields between groups and groups past each other — and a hidden
-   * block is a block you cannot drop into or see the result of. It also removes
-   * the collapsed-group drop target, which was the main source of drop
-   * ambiguity: with every member row visible, a drop always has a real row to
-   * resolve against instead of a header standing in for hidden content.
-   */
-  const isGroupCollapsed = (group: FieldGroup): boolean => {
-    if (isEditMode) return false
-    return collapsedOverrides[group.id] ?? group.collapsed ?? false
-  }
-
-  const toggleGroupCollapsed = (group: FieldGroup) => {
-    if (isEditMode) return
-    setCollapsedOverrides((prev) => ({ ...prev, [group.id]: !isGroupCollapsed(group) }))
-  }
+  type FieldRow = (typeof rows)[number]
 
   /** The group whose label input should take focus (just created in this session). */
   const [newGroupId, setNewGroupId] = useState<string | null>(null)
@@ -274,589 +212,6 @@ export function EntityFieldsContent({
     const groupId = onAddGroup?.()
     if (groupId) setNewGroupId(groupId)
   }
-
-  // Sections are derived from the ids that actually render, so exclusion filters
-  // and hidden fields can never leave a group claiming a field the list doesn't
-  // show. Empty groups only exist in edit mode, where they are drop targets;
-  // read mode drops them entirely.
-  const rowById = new Map(rows.map((row) => [row.id, row]))
-  const sections = groupFieldOrder({
-    fieldOrder: rows.map((row) => row.id),
-    groups: fieldGroups ?? [],
-    includeEmptyGroups: isEditMode,
-  })
-
-  // The flat visible field sequence: a collapsed group contributes NO rows, so
-  // its members are neither in the sortable set nor registered with the keyboard
-  // navigation context (rows register themselves on mount — not rendering them
-  // is what keeps them unreachable by arrow keys).
-  const visibleRowIds = sections.flatMap((section) =>
-    section.group && isGroupCollapsed(section.group) ? [] : section.fieldIds
-  )
-  const navIndexById = new Map(visibleRowIds.map((id, index) => [id, index]))
-
-  // ─────────────────────────────────────────────────────────────────
-  // DRAG MODEL — insert lines, not displacement
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * There is deliberately NO `SortableContext` here, and no sorting strategy.
-   *
-   * A group is a header plus a contiguous member block, and a displacement
-   * strategy cannot express "this whole block moves": it displaces individual
-   * rows by the dragged node's height, so a group drag either moved the header
-   * alone or (with a `DragOverlay`) shoved every row down by the block's height
-   * while the block was still in flow. The KB sidebar solved the same problem by
-   * dropping the strategy entirely — `useSortable` is kept purely for
-   * `isDragging`/`attributes`/`listeners`, nothing displaces, and the answer to
-   * "where will this land" is stated explicitly by an insert line plus a
-   * whole-group highlight. This is that model (see `rows/field-insert-line.tsx`
-   * for the id keyspace).
-   *
-   * Consequence worth knowing: without a `SortableContext` `useSortable` never
-   * resolves a transform, so the dragged row does not follow the pointer — it
-   * dims to 0.3 and stays put. A `DragOverlay` is now safe to add if a ghost is
-   * wanted (the displacement failure mode that killed the last attempt lived in
-   * the strategy, which is gone), but it is not needed for the affordance.
-   */
-  const [activeDragId, setActiveDragId] = useState<string | null>(null)
-  const [dropTarget, setDropTarget] = useState<FieldDropTarget | null>(null)
-
-  /** The group being dragged, or null when a field row is in hand. */
-  const activeGroupId = activeDragId === null ? null : parseGroupDropId(activeDragId)
-
-  const memberIdsOfGroup = (groupId: string): string[] =>
-    sections.find((section) => section.group?.id === groupId)?.fieldIds ?? []
-
-  /**
-   * What the drag ghost renders: the whole block for a group drag, one row for a
-   * field drag. Null when nothing is in hand, which is what keeps the overlay
-   * unmounted the rest of the time.
-   */
-  const activeGroupSection =
-    activeGroupId === null
-      ? undefined
-      : sections.find((section) => section.group?.id === activeGroupId)
-  const activeFieldRow =
-    activeDragId !== null && activeGroupId === null ? rowById.get(activeDragId) : undefined
-
-  // Positions are compared in the RENDERED order (which is `fieldOrder`,
-  // group-contiguous) so the insert line can be drawn on the edge the drop
-  // actually lands on — see `deriveDropFeedback`.
-  const renderedOrder = sections.flatMap((section) => section.fieldIds)
-  const orderIndexById = new Map(renderedOrder.map((fieldId, index) => [fieldId, index]))
-  const groupIdByFieldId = new Map<string, string>()
-  for (const section of sections) {
-    if (!section.group) continue
-    for (const fieldId of section.fieldIds) groupIdByFieldId.set(fieldId, section.group.id)
-  }
-
-  /** Where the dragged thing sits today: a field's slot, or a block's anchor. */
-  const activeAnchorIndex = (() => {
-    if (activeDragId === null) return -1
-    if (activeGroupId === null) return orderIndexById.get(activeDragId) ?? -1
-    const firstMemberId = memberIdsOfGroup(activeGroupId)[0]
-    return firstMemberId === undefined ? -1 : (orderIndexById.get(firstMemberId) ?? -1)
-  })()
-
-  /**
-   * `reorderDraft` and `moveGroupBlock` are both direction-sensitive: dragging
-   * DOWN onto a target lands after it, dragging UP lands at it. So the line is
-   * drawn on the target's bottom edge for a downward drag and its top edge for
-   * an upward one — otherwise the affordance would promise a slot the drop does
-   * not deliver.
-   */
-  const edgeFor = (targetIndex: number): 'top' | 'bottom' =>
-    activeAnchorIndex >= 0 && targetIndex >= 0 && activeAnchorIndex < targetIndex ? 'bottom' : 'top'
-
-  type DropIndicator =
-    | { kind: 'row'; rowId: string; side: 'top' | 'bottom'; inset: boolean }
-    | { kind: 'group'; groupId: string; side: 'top' | 'bottom'; inset: boolean }
-
-  /**
-   * Turn the hovered droppable into the ONE line to draw and the ONE group to
-   * light up.
-   *
-   * The highlight answers "will this end up INSIDE that group", and its colour
-   * answers it in both directions:
-   *
-   * - `blocked: false` (blue) — a FIELD about to join the group. It really will
-   *   be a member.
-   * - `blocked: true` (grey) — a GROUP hovering another group. Groups do not
-   *   nest, so the drop repositions the block against that group's boundary
-   *   instead. The fill says "not into this"; the insert line still says where
-   *   the block lands, which is why lines stay blue in both cases.
-   *
-   * Deliberately NOT drawn for `group-before`/`group-after`: those land the
-   * field outside every group, so there is no group to be inside of.
-   */
-  const deriveDropFeedback = (): {
-    indicator: DropIndicator | null
-    highlight: { groupId: string; blocked: boolean } | null
-  } => {
-    if (dropTarget === null || activeDragId === null) {
-      return { indicator: null, highlight: null }
-    }
-
-    const anchorIndexOfGroup = (groupId: string): number => {
-      const firstMemberId = memberIdsOfGroup(groupId)[0]
-      return firstMemberId === undefined ? -1 : (orderIndexById.get(firstMemberId) ?? -1)
-    }
-
-    // A GROUP drag always snaps to a whole block boundary (`moveGroupBlock`
-    // never splits another group), so a field target resolves to that field's
-    // group when it has one.
-    if (activeGroupId !== null) {
-      const overFieldId =
-        dropTarget.kind === 'field' || dropTarget.kind === 'field-before'
-          ? dropTarget.fieldId
-          : null
-      const referenceGroupId =
-        overFieldId !== null
-          ? (groupIdByFieldId.get(overFieldId) ?? null)
-          : dropTarget.kind === 'field' || dropTarget.kind === 'field-before'
-            ? null
-            : dropTarget.groupId
-      if (referenceGroupId === null) {
-        const fieldId = overFieldId
-        if (fieldId === null) return { indicator: null, highlight: null }
-        const side = edgeFor(orderIndexById.get(fieldId) ?? -1)
-        return {
-          indicator: { kind: 'row', rowId: fieldId, side, inset: false },
-          highlight: null,
-        }
-      }
-      if (referenceGroupId === activeGroupId) return { indicator: null, highlight: null }
-      const side = edgeFor(anchorIndexOfGroup(referenceGroupId))
-      return {
-        indicator: { kind: 'group', groupId: referenceGroupId, side, inset: false },
-        // A group hovering a group: the block lands beside it, never inside it.
-        highlight: { groupId: referenceGroupId, blocked: true },
-      }
-    }
-
-    switch (dropTarget.kind) {
-      case 'field': {
-        const side = edgeFor(orderIndexById.get(dropTarget.fieldId) ?? -1)
-        const targetGroupId = groupIdByFieldId.get(dropTarget.fieldId) ?? null
-        return {
-          indicator: { kind: 'row', rowId: dropTarget.fieldId, side, inset: false },
-          highlight: targetGroupId === null ? null : { groupId: targetGroupId, blocked: false },
-        }
-      }
-      case 'field-before': {
-        // Named boundary: always the row's top edge, never `edgeFor`.
-        const targetGroupId = groupIdByFieldId.get(dropTarget.fieldId) ?? null
-        return {
-          indicator: { kind: 'row', rowId: dropTarget.fieldId, side: 'top', inset: false },
-          highlight: targetGroupId === null ? null : { groupId: targetGroupId, blocked: false },
-        }
-      }
-      case 'group-into': {
-        // A field dropped on the header lands at the HEAD of the block, so the
-        // line belongs above the first member — not above the header, which is
-        // the `group-before` position and means something else entirely.
-        const firstMemberId = memberIdsOfGroup(dropTarget.groupId).find((id) => id !== activeDragId)
-        return {
-          indicator:
-            firstMemberId === undefined
-              ? null
-              : { kind: 'row', rowId: firstMemberId, side: 'top', inset: false },
-          highlight: { groupId: dropTarget.groupId, blocked: false },
-        }
-      }
-      case 'group-end': {
-        // Full-width line under the last member, and the group lights up: this
-        // lands INSIDE. The `group-after` zone directly below draws the short
-        // inset line instead, so the two are told apart at a glance even though
-        // they sit only a few pixels apart.
-        const memberIds = memberIdsOfGroup(dropTarget.groupId).filter((id) => id !== activeDragId)
-        const lastMemberId = memberIds[memberIds.length - 1]
-        return {
-          indicator:
-            lastMemberId === undefined
-              ? null
-              : { kind: 'row', rowId: lastMemberId, side: 'bottom', inset: false },
-          highlight: { groupId: dropTarget.groupId, blocked: false },
-        }
-      }
-      case 'group-before':
-        return {
-          indicator: { kind: 'group', groupId: dropTarget.groupId, side: 'top', inset: false },
-          highlight: null,
-        }
-      case 'group-after':
-        return {
-          indicator: { kind: 'group', groupId: dropTarget.groupId, side: 'bottom', inset: true },
-          highlight: null,
-        }
-    }
-  }
-
-  const { indicator, highlight } = deriveDropFeedback()
-
-  const lineForRow = (rowId: string, side: 'top' | 'bottom'): boolean =>
-    indicator?.kind === 'row' && indicator.rowId === rowId && indicator.side === side
-
-  const lineForGroup = (groupId: string, side: 'top' | 'bottom'): boolean =>
-    indicator?.kind === 'group' && indicator.groupId === groupId && indicator.side === side
-
-  // `collisionDetection` runs outside the render that produced `sections`, so it
-  // reads them through a ref and stays referentially stable.
-  const sectionsRef = useRef<GroupedFieldSection[]>(sections)
-  sectionsRef.current = sections
-
-  /**
-   * `closestCorners` (the KB sidebar's choice), minus the targets that describe
-   * a drop the mutation layer would refuse anyway:
-   *
-   * - a FIELD may not target its own row (`x-before` and the bare `x` both
-   *   resolve to the same no-op),
-   * - a GROUP may not land inside its own block — its members' rows, its own
-   *   header, its own `-before`/`-after-group` boundaries,
-   * - a GROUP may not target an EMPTY group at all. An empty group has no index
-   *   in `fieldOrder` (its end-of-list slot is a render convention), so
-   *   `moveGroupBlock` has no honest insertion point and refuses every one of
-   *   its three droppables. Letting it become `over` drew a highlight and an
-   *   insert line for a drop that then did nothing. A FIELD drag still targets
-   *   it — that is the only way a new group ever gets its first member.
-   *
-   * Filtering here rather than per-row is what lets every affordance below key
-   * off `over` alone: an invalid target simply never becomes `over`, so no
-   * component needs its own validity gate.
-   */
-  const collisionDetection = useCallback<CollisionDetection>((args) => {
-    // `pointerWithin` FIRST: the drop zones deliberately overlap each other and
-    // the rows (each is `absolute left-0 right-0 h-4` hanging off an edge), and
-    // `closestCorners` resolves from the DRAGGED ELEMENT'S rect rather than the
-    // cursor — with a long list and vertical-only movement its nearest corner
-    // can be a zone nowhere near where the user is pointing. `closestCorners` is
-    // kept as the fallback for the gaps where the pointer is inside no zone.
-    const collisions = pointerWithin(args).length > 0 ? pointerWithin(args) : closestCorners(args)
-    const draggedId = String(args.active.id)
-    const draggedGroupId = parseGroupDropId(draggedId)
-
-    if (draggedGroupId === null) {
-      /** The field in hand is already the last thing in that group's block. */
-      const isLastMemberOf = (groupId: string): boolean => {
-        const memberIds = sectionsRef.current.find((s) => s.group?.id === groupId)?.fieldIds ?? []
-        return memberIds[memberIds.length - 1] === draggedId
-      }
-
-      const usable = collisions.filter((collision) => {
-        const target = resolveDropTarget(String(collision.id))
-        if (target.kind === 'field' || target.kind === 'field-before')
-          return target.fieldId !== draggedId
-        // "Inside, last slot" is where this field already IS — the drop would be
-        // a no-op, and the zone would sit on top of the one target that isn't:
-        // leaving the group downward.
-        if (target.kind === 'group-end') return !isLastMemberOf(target.groupId)
-        return true
-      })
-
-      // `group-end` wins outright wherever it is under the pointer.
-      //
-      // `pointerWithin` ranks by distance from the pointer to each droppable's
-      // CENTRE, and this zone is a band inside the last member's row — so the
-      // two centres are about a pixel apart and the winner flipped with a pixel
-      // of pointer movement, which read as "the zone doesn't accept drops".
-      // Sizing cannot fix that; only precedence can. It is safe because the
-      // zone only overlaps that one row, and for a DOWNWARD drag both targets
-      // resolve to the same slot anyway.
-      const endIndex = usable.findIndex(
-        (collision) => resolveDropTarget(String(collision.id)).kind === 'group-end'
-      )
-      if (endIndex > 0) {
-        const promoted = usable[endIndex]
-        usable.splice(endIndex, 1)
-        if (promoted) usable.unshift(promoted)
-      }
-
-      return usable
-    }
-
-    const ownMemberIds = new Set(
-      sectionsRef.current.find((section) => section.group?.id === draggedGroupId)?.fieldIds ?? []
-    )
-    const emptyGroupIds = new Set(
-      sectionsRef.current
-        .filter((section) => section.group !== null && section.fieldIds.length === 0)
-        .map((section) => section.group?.id)
-    )
-    return collisions.filter((collision) => {
-      const target = resolveDropTarget(String(collision.id))
-      if (target.kind === 'field' || target.kind === 'field-before')
-        return !ownMemberIds.has(target.fieldId)
-      // `group-end` means "inside that group", which a group can never be. Left
-      // in, it would only compete with the `group-after` zone beneath it for the
-      // one thing a group drag CAN do at that boundary.
-      if (target.kind === 'group-end') return false
-      return target.groupId !== draggedGroupId && !emptyGroupIds.has(target.groupId)
-    })
-  }, [])
-
-  const handleDragStart = (event: DragStartEvent) => {
-    setActiveDragId(String(event.active.id))
-    setDropTarget(null)
-  }
-
-  /** Identity of a drop target, so an unchanged hover does not re-render. */
-  const dropTargetKey = (target: FieldDropTarget): string =>
-    target.kind === 'field' || target.kind === 'field-before'
-      ? `${target.kind}:${target.fieldId}`
-      : `${target.kind}:${target.groupId}`
-
-  const handleDragOver = (event: DragOverEvent) => {
-    const next = event.over === null ? null : resolveDropTarget(String(event.over.id))
-    setDropTarget((prev) => {
-      if (prev === null || next === null) return prev === next ? prev : next
-      return dropTargetKey(prev) === dropTargetKey(next) ? prev : next
-    })
-  }
-
-  /** A synthetic drag-end aimed at `overId`, so the existing handlers see a normal drop. */
-  const aimedAt = (event: DragEndEvent, overId: string): DragEndEvent =>
-    event.over === null ? event : { ...event, over: { ...event.over, id: overId } }
-
-  /**
-   * Route a drop by WHAT WAS DRAGGED, not by what it landed on.
-   *
-   * A group header and a field row are the same kind of thing to dnd-kit but
-   * different operations here: dragging a group repositions its whole member
-   * block (order only — `moveGroup`), while dragging a field can also change
-   * which group it belongs to. Running the field path for a group drag would
-   * reassign membership from wherever the header happened to land, which is why
-   * the two never share a code path.
-   *
-   * Every branch translates the suffixed droppable id back to the bare field or
-   * group id the existing handlers already expect; neither handler is modified.
-   */
-  const routeDragEnd = (event: DragEndEvent) => {
-    setActiveDragId(null)
-    setDropTarget(null)
-
-    const { active, over } = event
-    if (!over) return
-
-    const activeId = String(active.id)
-    const target = resolveDropTarget(String(over.id))
-    const draggedGroupId = parseGroupDropId(activeId)
-
-    // GROUP drag — order only. Every group-addressing target collapses to the
-    // same call: `moveGroupBlock` owns the snap-to-boundary and direction rules,
-    // so "above" vs "below" is its decision, not the droppable's.
-    if (draggedGroupId !== null) {
-      if (target.kind === 'field' || target.kind === 'field-before') {
-        onMoveGroup?.(draggedGroupId, target.fieldId, false)
-        return
-      }
-      if (target.groupId === draggedGroupId) return
-      onMoveGroup?.(draggedGroupId, target.groupId, true)
-      return
-    }
-
-    switch (target.kind) {
-      case 'field-before':
-        // The zone names the edge, so the drop does not consult the direction.
-        if (target.fieldId === activeId) return
-        handleDragEnd(aimedAt(event, target.fieldId), 'before')
-        return
-      case 'field': {
-        if (target.fieldId === activeId) return
-        // The SAME expression `deriveDropFeedback` draws the insert line from,
-        // so the drop cannot land on a different edge than the line promised.
-        // It must be read from the pre-drag positions in this render's closure —
-        // `handleDragEnd` may relocate the field (joining a group appends it to
-        // the block's tail) before it reorders, which would flip the direction.
-        const side = edgeFor(orderIndexById.get(target.fieldId) ?? -1)
-        handleDragEnd(aimedAt(event, target.fieldId), side === 'bottom' ? 'after' : 'before')
-        return
-      }
-      case 'group-into':
-        handleDragEnd(aimedAt(event, groupDropId(target.groupId)))
-        return
-      case 'group-end': {
-        // Aim at the last member with an explicit `after`. `handleDragEnd`
-        // reads membership from where the field lands, so targeting a member
-        // both joins the group and settles at its end — and naming the edge is
-        // the whole point: an upward drag would otherwise land before it.
-        const memberIds = memberIdsOfGroup(target.groupId).filter((id) => id !== activeId)
-        const lastMemberId = memberIds[memberIds.length - 1]
-        if (lastMemberId === undefined) {
-          handleDragEnd(aimedAt(event, groupDropId(target.groupId)))
-          return
-        }
-        handleDragEnd(aimedAt(event, lastMemberId), 'after')
-        return
-      }
-      case 'group-before':
-        onPlaceFieldBesideGroup?.(activeId, target.groupId, 'before')
-        return
-      case 'group-after':
-        onPlaceFieldBesideGroup?.(activeId, target.groupId, 'after')
-        return
-    }
-  }
-
-  type FieldRow = (typeof rows)[number]
-
-  /** A section's member rows, in the section's own order, ghosts skipped. */
-  const memberRowsOf = (fieldIds: string[]): FieldRow[] =>
-    fieldIds.flatMap((fieldId) => {
-      const row = rowById.get(fieldId)
-      return row ? [row] : []
-    })
-
-  /**
-   * One group header, rendered inside its section wrapper so the wrapper's
-   * highlight and boundary lines cover the header and its members as one unit.
-   */
-  const renderGroupHeader = (
-    group: FieldGroupLike,
-    memberCount: number,
-    autoFocusLabel: boolean,
-    preview = false
-  ) => (
-    <FieldGroupRow
-      group={group}
-      collapsed={isGroupCollapsed(group)}
-      memberCount={memberCount}
-      onToggleCollapsed={() => toggleGroupCollapsed(group)}
-      isEditMode={isEditMode}
-      // The ghost is a picture of what is in hand, not a live row: no rename
-      // input to focus, no delete button to hit. Withholding the handlers is
-      // what collapses it to icon + title, since the trailing actions only
-      // render when their handler exists.
-      onRename={
-        !preview && isEditMode && onRenameGroup
-          ? (label) => onRenameGroup(group.id, label)
-          : undefined
-      }
-      onDelete={
-        !preview && isEditMode && onDeleteGroup
-          ? () => onDeleteGroup(group.id, group.label)
-          : undefined
-      }
-      autoFocusLabel={!preview && autoFocusLabel}
-    />
-  )
-
-  /** One member row plus the wrapper carrying its group inset. */
-  const renderMemberRow = (
-    row: FieldRow,
-    options: { grouped: boolean; dimmed?: boolean; preview?: boolean }
-  ) => (
-    // Grouped rows sit slightly inset so the group's extent is readable
-    // without a border. Ungrouped rows keep the flush edge, so the indent
-    // alone distinguishes "in this group" from "after it".
-    //
-    // `dimmed` fades a member of the group currently in hand. `FieldGroupRow`
-    // already fades its own header via `isDragging`, but a member row has no
-    // idea its group is being dragged — without this only the header dimmed and
-    // the block did not read as lifted. Safe now that nothing displaces: there
-    // is no `SortableContext`, so dimming cannot desync any layout math.
-    <div
-      key={row.providerId}
-      className={cn('relative', options.grouped && 'ps-3', options.dimmed && 'opacity-30')}>
-      {isEditMode && !options.preview && (
-        <>
-          <FieldDropZone id={fieldBeforeDropId(row.id)} edge='top' />
-          {lineForRow(row.id, 'top') && <FieldInsertLine side='top' />}
-          {lineForRow(row.id, 'bottom') && <FieldInsertLine side='bottom' />}
-        </>
-      )}
-      {isEditMode ? (
-        <FieldEditRow
-          id={row.id}
-          field={row.field}
-          isSortable={row.isSortable}
-          resourceFieldId={row.resourceFieldId}
-          isVisible={row.isVisible}
-          // Preview rows carry no actions — `FieldEditRow` renders the pencil,
-          // trash and visibility switch only when handed their handlers, so
-          // withholding them is what leaves the ghost as icon + name.
-          onEdit={options.preview || row.isSystemField ? undefined : handleEditField}
-          onDelete={options.preview || row.isSystemField ? undefined : handleDeleteField}
-          onToggleVisibility={options.preview ? undefined : onToggleVisibility}
-        />
-      ) : (
-        <FieldValueRow
-          providerId={row.providerId}
-          field={row.field}
-          index={navIndexById.get(row.id) ?? row.index}
-          loading={isLoading}
-          recordId={recordId}
-          readOnly={readOnly}
-          showTitle={showTitle}
-          onOpenChange={handleProviderOpenChange}
-          registerClose={registerProviderClose}
-          unregisterClose={unregisterProviderClose}
-        />
-      )}
-    </div>
-  )
-
-  /**
-   * Walk the sections into elements: an ungrouped run stays a bare fragment, a
-   * group becomes ONE positioned wrapper around its header and members.
-   *
-   * That wrapper is what makes the group a single visual unit: the dashed
-   * highlight is drawn across it, and the two boundaries that address the block
-   * from outside (`-before` above the header, `-after-group` below the last
-   * member) hang off its edges. It also owns the header's top margin — inside
-   * the wrapper the header is always `:first-child`, so `first:mt-0` had to move
-   * out with it.
-   */
-  const renderSections = () =>
-    sections.map((section, sectionIndex) => {
-      const group = section.group
-      const collapsed = group ? isGroupCollapsed(group) : false
-      const memberRows = collapsed ? [] : memberRowsOf(section.fieldIds)
-      // Every member of the group in hand fades with its header, so the block
-      // reads as one thing being lifted rather than a header leaving its rows.
-      const blockDimmed = group !== null && group.id === activeGroupId
-      const rowElements = memberRows.map((row) =>
-        renderMemberRow(row, { grouped: group !== null, dimmed: blockDimmed })
-      )
-
-      if (!group) return <Fragment key={`ungrouped-${sectionIndex}`}>{rowElements}</Fragment>
-
-      return (
-        <div
-          key={`group-${group.id}`}
-          className={cn(
-            'relative mt-1.5 first:mt-0',
-            // The fill is a real BACKGROUND on the section, not part of the
-            // overlay below: `bg-primary-100` is opaque, and an absolutely
-            // positioned overlay paints above statically positioned children —
-            // it would hide the header and rows it is meant to be highlighting.
-            highlight?.groupId === group.id &&
-              (highlight.blocked ? 'rounded-md bg-primary-100' : 'rounded-md bg-primary/10')
-          )}>
-          {isEditMode && (
-            <>
-              <FieldDropZone id={groupBeforeDropId(group.id)} edge='top' />
-              {/* Only when the block HAS a last member to land after. On an
-                  empty group this band would sit over the header, where
-                  `group-into` already means the same thing. */}
-              {memberRows.length > 0 && (
-                <FieldDropZone id={groupEndDropId(group.id)} edge='inner-bottom' />
-              )}
-              <FieldDropZone id={groupAfterDropId(group.id)} edge='bottom' />
-              {highlight?.groupId === group.id && (
-                <div className='pointer-events-none absolute inset-0 z-10 rounded-md border border-primary-200 border-dashed' />
-              )}
-              {lineForGroup(group.id, 'top') && <FieldInsertLine side='top' />}
-              {lineForGroup(group.id, 'bottom') && (
-                <FieldInsertLine side='bottom' inset={indicator?.inset ?? false} />
-              )}
-            </>
-          )}
-          {renderGroupHeader(group, section.fieldIds.length, group.id === newGroupId)}
-          {rowElements}
-        </div>
-      )
-    })
 
   return (
     <>
@@ -907,95 +262,54 @@ export function EntityFieldsContent({
             </div>
           )}
 
-          {/* Reordering is edit-mode only, so the DnD context only exists there */}
-          {isEditMode ? (
-            <DndContext
-              // An empty sensor list is how a drag is made unreachable without
-              // tearing the context out from under the rows (the KB sidebar's
-              // pattern). Edit mode is already gated on `canEdit`; this keeps
-              // the two from drifting.
-              sensors={canEdit ? sensors : []}
-              collisionDetection={collisionDetection}
-              onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
-              onDragEnd={routeDragEnd}
-              onDragCancel={() => {
-                setActiveDragId(null)
-                setDropTarget(null)
-              }}
-              modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}>
-              {/* No `SortableContext`: nothing displaces, and the landing slot
-                  is stated by an insert line plus a whole-group highlight. */}
-              {renderSections()}
-
-              {/* The ghost under the cursor. Without a `SortableContext` the
-                  rows get no transform of their own, so the source only fades —
-                  this is the piece that actually follows the pointer.
-
-                  An earlier attempt at this DID break the list, but that failure
-                  was `verticalListSortingStrategy` displacing every row by the
-                  overlay's height while the source was still in flow. There is
-                  no strategy now, so an overlay cannot move anything. */}
-              {/* PORTALLED TO `document.body` ON PURPOSE. `DragOverlay` is
-                  `position: fixed`, and fixed resolves against the nearest
-                  ancestor with a `transform` / `filter` / `will-change` — not the
-                  viewport. The record drawer animates in with a transform, so
-                  rendering the overlay in place anchored it to the DRAWER and the
-                  ghost sat ~200px below the cursor while the insert line (which
-                  is absolutely positioned inside the list, so unaffected) stayed
-                  correct. The portal takes the overlay out of that containing
-                  block. */}
-              {typeof document !== 'undefined' &&
-                createPortal(
-                  <DragOverlay
-                    dropAnimation={null}
-                    // dnd-kit sizes the overlay from the ACTIVE node's rect — for
-                    // a group that is only the header, so a block preview has to
-                    // be free to grow past it. The anchor stays the header's top
-                    // edge, which is where the grab happened.
-                    // dnd-kit hard-sets width AND height from the ACTIVE node's rect —
-                    // a full-panel-width row. Releasing both lets the ghost shrink to
-                    // its own content (icon + name), which is all it needs to say.
-                    style={{ height: 'auto', width: 'auto' }}
-                    className='pointer-events-none'>
-                    {activeGroupSection ? (
-                      // Semi-transparent so the insert line stays readable through
-                      // the ghost — the line marks the landing slot and the ghost
-                      // is only "what is in hand", so the line has to win.
-                      //
-                      // `pe-2`: the overlay's width is released to `auto`, so an
-                      // EMPTY group shrinks to icon + title + member count with
-                      // the count pressed against the ring. Members give the
-                      // ghost its own width and never need it.
-                      <div className='rounded-md bg-background/90 pe-2 opacity-90 shadow-lg ring-1 ring-border'>
-                        {renderGroupHeader(
-                          activeGroupSection.group as FieldGroupLike,
-                          activeGroupSection.fieldIds.length,
-                          false,
-                          true
-                        )}
-                        {memberRowsOf(activeGroupSection.fieldIds).map((row) =>
-                          renderMemberRow(row, { grouped: true, preview: true })
-                        )}
-                      </div>
-                    ) : activeFieldRow ? (
-                      // Semi-transparent so the insert line stays readable through
-                      // the ghost — the line marks the landing slot and the ghost
-                      // is only "what is in hand", so the line has to win.
-                      <div className='rounded-md bg-background/90 opacity-90 shadow-lg ring-1 ring-border'>
-                        {renderMemberRow(activeFieldRow, {
-                          grouped: groupIdByFieldId.has(activeFieldRow.id),
-                          preview: true,
-                        })}
-                      </div>
-                    ) : null}
-                  </DragOverlay>,
-                  document.body
-                )}
-            </DndContext>
-          ) : (
-            renderSections()
-          )}
+          {/* The grouped list and the whole drag model — shared with the record
+              dialog's config mode, so the two surfaces can never drift apart. */}
+          <FieldGroupList<FieldRow>
+            rows={rows}
+            rowId={(row) => row.id}
+            rowKey={(row) => row.providerId}
+            groups={fieldGroups ?? []}
+            isEditMode={isEditMode}
+            canEdit={canEdit}
+            sensors={sensors}
+            onFieldDragEnd={handleDragEnd}
+            onPlaceFieldBesideGroup={onPlaceFieldBesideGroup}
+            onMoveGroup={onMoveGroup}
+            onRenameGroup={onRenameGroup}
+            onDeleteGroup={onDeleteGroup}
+            newGroupId={newGroupId}
+            renderRow={(row, ctx) =>
+              isEditMode ? (
+                <FieldEditRow
+                  id={row.id}
+                  field={row.field}
+                  isSortable={row.isSortable}
+                  resourceFieldId={row.resourceFieldId}
+                  isVisible={row.isVisible}
+                  // Preview rows carry no actions — `FieldEditRow` renders the
+                  // pencil, trash and visibility switch only when handed their
+                  // handlers, so withholding them is what leaves the ghost as
+                  // icon + name.
+                  onEdit={ctx.preview || row.isSystemField ? undefined : handleEditField}
+                  onDelete={ctx.preview || row.isSystemField ? undefined : handleDeleteField}
+                  onToggleVisibility={ctx.preview ? undefined : onToggleVisibility}
+                />
+              ) : (
+                <FieldValueRow
+                  providerId={row.providerId}
+                  field={row.field}
+                  index={ctx.navIndex}
+                  loading={isLoading}
+                  recordId={recordId}
+                  readOnly={readOnly}
+                  showTitle={showTitle}
+                  onOpenChange={handleProviderOpenChange}
+                  registerClose={registerProviderClose}
+                  unregisterClose={unregisterProviderClose}
+                />
+              )
+            }
+          />
 
           {/* Add Field / Add Group — edit mode only, same permission gate */}
           {isEditMode && canEdit && (

--- a/apps/web/src/components/fields/entity-fields.tsx
+++ b/apps/web/src/components/fields/entity-fields.tsx
@@ -4,13 +4,7 @@
 import type { FieldGroup } from '@auxx/lib/conditions/client'
 import { parseRecordId, type RecordId, type ResourceField } from '@auxx/lib/resources/client'
 import { type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
-import {
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core'
+import { KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { useCallback, useMemo, useState } from 'react'
 import { useCustomFieldMutations } from '~/components/custom-fields/hooks/use-custom-field-mutations'
@@ -20,10 +14,10 @@ import { useAccess } from '~/providers/capabilities-provider'
 import { EntityFieldsContent } from './entity-fields-content'
 import { FieldNavigationProvider } from './field-navigation-context'
 import { useDynamicFieldOptions } from './hooks/use-dynamic-field-options'
+import { useFieldGroupDnd } from './hooks/use-field-group-dnd'
 import { useFieldPopoverCoordination } from './hooks/use-field-popover-coordination'
 import { resolveFieldVisible, useFieldView } from './hooks/use-field-view'
 import { useFieldViewDraft } from './hooks/use-field-view-draft'
-import { parseGroupDropId } from './rows/field-group-row'
 import type { PanelField } from './rows/types'
 
 /** The id a field is keyed by in `FieldViewConfig.fieldOrder` / `fieldVisibility`. */
@@ -282,135 +276,15 @@ function EntityFields({
   // DRAG & DROP
   // ─────────────────────────────────────────────────────────────────
 
-  /** The group a field currently belongs to in the draft, or null if ungrouped. */
-  const draftGroupIdOf = useCallback(
-    (fieldId: string): string | null =>
-      draftGroups.find((group) => group.fieldIds.includes(fieldId))?.id ?? null,
-    [draftGroups]
-  )
-
-  /**
-   * The FIELD half of the drag-end routing (`EntityFieldsContent.routeDragEnd`
-   * splits by what is being dragged, and sends group-header drags to
-   * `moveGroup` instead — a block move changes order only, never membership).
-   *
-   * Reordering moves the field within the DRAFT's `fieldOrder`. The dnd ids are
-   * the same ids `fieldOrder` stores (see `viewFieldId`) — mismatched ids would
-   * make this a silent no-op.
-   *
-   * Group membership is derived from where the field LANDED: because a group's
-   * members are contiguous, the row a field is dropped among identifies exactly
-   * one group (or none, outside every block), and that is the drop's intent. A
-   * drop on a group HEADER addresses the group directly — headers are drop
-   * targets for every block now that they are sortables in their own right, so
-   * this is how a field joins a group whose members it cannot aim at (an empty
-   * or collapsed one) as well as one it can.
-   *
-   * Membership is applied FIRST, then the reorder: `assignFieldToGroup` moves
-   * membership and position together so the target block keeps its anchor, and
-   * the reorder that follows settles the field into the exact slot it was
-   * dropped on. Both are functional `setDraft` updaters, so the second observes
-   * the first within this handler. A same-group drag skips the assignment — it
-   * is a no-op on membership but not on position, so running it would move the
-   * field twice.
-   *
-   * `edge` is why the reorder cannot be a bare `arrayMove`. Joining a group
-   * relocates the field to the block's TAIL, so a field dragged DOWN into a
-   * group arrives above its target having travelled up — and an arrayMove reads
-   * direction from the post-assignment position, landing it one slot early
-   * (dropping on the last member put it second-to-last). The caller passes the
-   * same edge the insert line was drawn from, so the drop lands where the line
-   * promised.
-   */
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent, edge?: 'before' | 'after') => {
-      const { active, over } = event
-      if (!over) return
-
-      const activeId = String(active.id)
-      const overId = String(over.id)
-      if (activeId === overId) return
-
-      const currentGroupId = draftGroupIdOf(activeId)
-
-      // Header drop. An EMPTY group has no members to aim at, so the header is
-      // the only target and assign-only is right — the field keeps its position
-      // and the group forms around it. A group that HAS members is different:
-      // assign-only would silently append the field to the end of the block, so
-      // a drop near the top of a group would fling the row to its bottom. Land
-      // it at the head of the block instead, which is what dropping on a header
-      // reads as.
-      const headerGroupId = parseGroupDropId(overId)
-      if (headerGroupId) {
-        if (headerGroupId !== currentGroupId) assignFieldToGroup(activeId, headerGroupId)
-        const firstMemberId = draftGroups
-          .find((group) => group.id === headerGroupId)
-          ?.fieldIds.find((id) => id !== activeId)
-        // `before` states the intent outright — dropping on a header means the
-        // head of the block, whichever direction the field travelled from. An
-        // EMPTY group has no first member, and none is needed: the assignment
-        // has already sent the field to where an empty group renders.
-        if (firstMemberId) reorderDraft(activeId, firstMemberId, 'before')
-        return
-      }
-
-      const targetGroupId = draftGroupIdOf(overId)
-
-      if (targetGroupId !== currentGroupId) assignFieldToGroup(activeId, targetGroupId)
-      reorderDraft(activeId, overId, edge)
-    },
-    [assignFieldToGroup, draftGroupIdOf, draftGroups, reorderDraft]
-  )
-
-  /**
-   * Land a field BESIDE a group's block, belonging to no group.
-   *
-   * This is the position the drag model had no vocabulary for, and its absence
-   * was a real trap: with only row ids as drop targets, every target near a
-   * group reads as "join that group", so a group rendered first in the panel
-   * swallowed any field dragged toward the top of the list. The `-before` /
-   * `-after-group` droppables name those two positions; this applies them.
-   *
-   * Why the round trip THROUGH the group rather than `assignFieldToGroup(null)`
-   * plus a reorder: aiming at the group's first member is direction-sensitive
-   * unless the edge is named. Joining the block first puts the field at a known
-   * end of it, and leaving the block then keeps that slot —
-   * `assignFieldToGroupInOrder` re-anchors the block at its first remaining
-   * MEMBER, so a departing field at the head floats above the block and one at
-   * the tail floats below it. The result is the same in both drag directions.
-   *
-   * All three writes are functional `setDraft` updaters, so each observes the
-   * previous one within this handler.
-   */
-  const placeFieldBesideGroup = useCallback(
-    (fieldId: string, groupId: string, side: 'before' | 'after') => {
-      const memberSet = new Set(draftGroups.find((g) => g.id === groupId)?.fieldIds ?? [])
-
-      // Members in DISPLAY order, from `fieldOrder` — NOT the group's own
-      // `fieldIds` array. Membership is a set whose array order is only a
-      // tie-break; it drifts from the rendered order the moment anything is
-      // reordered inside the group. Reading `fieldIds[0]` as "the top of the
-      // block" therefore aimed step 2 at an arbitrary member, and a field
-      // dropped ABOVE a group landed in the middle of it — from where step 3's
-      // re-normalisation pushed it out BELOW the whole block.
-      const memberIds = (draft?.fieldOrder ?? []).filter(
-        (id) => id !== fieldId && memberSet.has(id)
-      )
-
-      // 1. Join the block — `assignFieldToGroup` places it at the block's end
-      //    without moving the block itself.
-      assignFieldToGroup(fieldId, groupId)
-
-      // 2. For `before`, pull it to the head; for `after` it is already at the
-      //    tail, since step 1 appends.
-      const firstMemberId = memberIds[0]
-      if (side === 'before' && firstMemberId) reorderDraft(fieldId, firstMemberId, 'before')
-
-      // 3. Leave every group, keeping the slot just established.
-      assignFieldToGroup(fieldId, null)
-    },
-    [assignFieldToGroup, draft, draftGroups, reorderDraft]
-  )
+  // The field half of drop routing, shared verbatim with the record dialog.
+  // `FieldGroupList` splits by WHAT was dragged and sends group-header drags to
+  // `moveGroup` — a block move changes order only, never membership.
+  const { handleFieldDragEnd, placeFieldBesideGroup } = useFieldGroupDnd({
+    draft,
+    draftGroups,
+    assignFieldToGroup,
+    reorderDraft,
+  })
 
   // ─────────────────────────────────────────────────────────────────
   // FIELD MANAGEMENT (create/edit/delete custom fields)
@@ -497,7 +371,7 @@ function EntityFields({
         setDialogOpen={setDialogOpen}
         editingResourceFieldId={editingResourceFieldId}
         sensors={sensors}
-        handleDragEnd={handleDragEnd}
+        handleDragEnd={handleFieldDragEnd}
         fields={filteredFields}
         isLoading={isLoading}
         isSortable={isSortable}

--- a/apps/web/src/components/fields/hooks/use-field-group-dnd.ts
+++ b/apps/web/src/components/fields/hooks/use-field-group-dnd.ts
@@ -1,0 +1,169 @@
+// apps/web/src/components/fields/hooks/use-field-group-dnd.ts
+'use client'
+
+import type { FieldGroup, FieldViewConfig } from '@auxx/lib/conditions/client'
+import type { DragEndEvent } from '@dnd-kit/core'
+import { useCallback } from 'react'
+import { parseGroupDropId } from '~/components/fields/rows/field-group-row'
+
+export interface UseFieldGroupDndOptions {
+  /** The draft being edited. Only `fieldOrder` is read (display order of members). */
+  draft: FieldViewConfig | null
+  /** The draft's groups. */
+  draftGroups: FieldGroup[]
+  /** From `useFieldViewDraft` — moves membership AND position together. */
+  assignFieldToGroup: (fieldId: string, groupId: string | null) => void
+  /** From `useFieldViewDraft` — `edge` names the side of `overId` to land on. */
+  reorderDraft: (activeId: string, overId: string, edge?: 'before' | 'after') => void
+}
+
+export interface UseFieldGroupDndResult {
+  /** The FIELD half of drag-end routing (`FieldGroupList` splits by what was dragged). */
+  handleFieldDragEnd: (event: DragEndEvent, edge?: 'before' | 'after') => void
+  /** Land a field immediately before/after a group's block, belonging to no group. */
+  placeFieldBesideGroup: (fieldId: string, groupId: string, side: 'before' | 'after') => void
+}
+
+/**
+ * The glue between `FieldGroupList`'s drop routing and `useFieldViewDraft`'s
+ * mutators — pure draft manipulation, no rendering, so both the property panel
+ * and the record dialog consume the identical drop semantics.
+ */
+export function useFieldGroupDnd({
+  draft,
+  draftGroups,
+  assignFieldToGroup,
+  reorderDraft,
+}: UseFieldGroupDndOptions): UseFieldGroupDndResult {
+  /** The group a field currently belongs to in the draft, or null if ungrouped. */
+  const draftGroupIdOf = useCallback(
+    (fieldId: string): string | null =>
+      draftGroups.find((group) => group.fieldIds.includes(fieldId))?.id ?? null,
+    [draftGroups]
+  )
+
+  /**
+   * The FIELD half of the drag-end routing (`FieldGroupList.routeDragEnd`
+   * splits by what is being dragged, and sends group-header drags to
+   * `moveGroup` instead — a block move changes order only, never membership).
+   *
+   * Reordering moves the field within the DRAFT's `fieldOrder`. The dnd ids are
+   * the same ids `fieldOrder` stores — mismatched ids would make this a silent
+   * no-op.
+   *
+   * Group membership is derived from where the field LANDED: because a group's
+   * members are contiguous, the row a field is dropped among identifies exactly
+   * one group (or none, outside every block), and that is the drop's intent. A
+   * drop on a group HEADER addresses the group directly — headers are drop
+   * targets for every block now that they are sortables in their own right, so
+   * this is how a field joins a group whose members it cannot aim at (an empty
+   * or collapsed one) as well as one it can.
+   *
+   * Membership is applied FIRST, then the reorder: `assignFieldToGroup` moves
+   * membership and position together so the target block keeps its anchor, and
+   * the reorder that follows settles the field into the exact slot it was
+   * dropped on. Both are functional `setDraft` updaters, so the second observes
+   * the first within this handler. A same-group drag skips the assignment — it
+   * is a no-op on membership but not on position, so running it would move the
+   * field twice.
+   *
+   * `edge` is why the reorder cannot be a bare `arrayMove`. Joining a group
+   * relocates the field to the block's TAIL, so a field dragged DOWN into a
+   * group arrives above its target having travelled up — and an arrayMove reads
+   * direction from the post-assignment position, landing it one slot early
+   * (dropping on the last member put it second-to-last). The caller passes the
+   * same edge the insert line was drawn from, so the drop lands where the line
+   * promised.
+   */
+  const handleFieldDragEnd = useCallback(
+    (event: DragEndEvent, edge?: 'before' | 'after') => {
+      const { active, over } = event
+      if (!over) return
+
+      const activeId = String(active.id)
+      const overId = String(over.id)
+      if (activeId === overId) return
+
+      const currentGroupId = draftGroupIdOf(activeId)
+
+      // Header drop. An EMPTY group has no members to aim at, so the header is
+      // the only target and assign-only is right — the field keeps its position
+      // and the group forms around it. A group that HAS members is different:
+      // assign-only would silently append the field to the end of the block, so
+      // a drop near the top of a group would fling the row to its bottom. Land
+      // it at the head of the block instead, which is what dropping on a header
+      // reads as.
+      const headerGroupId = parseGroupDropId(overId)
+      if (headerGroupId) {
+        if (headerGroupId !== currentGroupId) assignFieldToGroup(activeId, headerGroupId)
+        const firstMemberId = draftGroups
+          .find((group) => group.id === headerGroupId)
+          ?.fieldIds.find((id) => id !== activeId)
+        // `before` states the intent outright — dropping on a header means the
+        // head of the block, whichever direction the field travelled from. An
+        // EMPTY group has no first member, and none is needed: the assignment
+        // has already sent the field to where an empty group renders.
+        if (firstMemberId) reorderDraft(activeId, firstMemberId, 'before')
+        return
+      }
+
+      const targetGroupId = draftGroupIdOf(overId)
+
+      if (targetGroupId !== currentGroupId) assignFieldToGroup(activeId, targetGroupId)
+      reorderDraft(activeId, overId, edge)
+    },
+    [assignFieldToGroup, draftGroupIdOf, draftGroups, reorderDraft]
+  )
+
+  /**
+   * Land a field BESIDE a group's block, belonging to no group.
+   *
+   * This is the position the drag model had no vocabulary for, and its absence
+   * was a real trap: with only row ids as drop targets, every target near a
+   * group reads as "join that group", so a group rendered first in the panel
+   * swallowed any field dragged toward the top of the list. The `-before` /
+   * `-after-group` droppables name those two positions; this applies them.
+   *
+   * Why the round trip THROUGH the group rather than `assignFieldToGroup(null)`
+   * plus a reorder: aiming at the group's first member is direction-sensitive
+   * unless the edge is named. Joining the block first puts the field at a known
+   * end of it, and leaving the block then keeps that slot —
+   * `assignFieldToGroupInOrder` re-anchors the block at its first remaining
+   * MEMBER, so a departing field at the head floats above the block and one at
+   * the tail floats below it. The result is the same in both drag directions.
+   *
+   * All three writes are functional `setDraft` updaters, so each observes the
+   * previous one within this handler.
+   */
+  const placeFieldBesideGroup = useCallback(
+    (fieldId: string, groupId: string, side: 'before' | 'after') => {
+      const memberSet = new Set(draftGroups.find((g) => g.id === groupId)?.fieldIds ?? [])
+
+      // Members in DISPLAY order, from `fieldOrder` — NOT the group's own
+      // `fieldIds` array. Membership is a set whose array order is only a
+      // tie-break; it drifts from the rendered order the moment anything is
+      // reordered inside the group. Reading `fieldIds[0]` as "the top of the
+      // block" therefore aimed step 2 at an arbitrary member, and a field
+      // dropped ABOVE a group landed in the middle of it — from where step 3's
+      // re-normalisation pushed it out BELOW the whole block.
+      const memberIds = (draft?.fieldOrder ?? []).filter(
+        (id) => id !== fieldId && memberSet.has(id)
+      )
+
+      // 1. Join the block — `assignFieldToGroup` places it at the block's end
+      //    without moving the block itself.
+      assignFieldToGroup(fieldId, groupId)
+
+      // 2. For `before`, pull it to the head; for `after` it is already at the
+      //    tail, since step 1 appends.
+      const firstMemberId = memberIds[0]
+      if (side === 'before' && firstMemberId) reorderDraft(fieldId, firstMemberId, 'before')
+
+      // 3. Leave every group, keeping the slot just established.
+      assignFieldToGroup(fieldId, null)
+    },
+    [assignFieldToGroup, draft, draftGroups, reorderDraft]
+  )
+
+  return { handleFieldDragEnd, placeFieldBesideGroup }
+}

--- a/apps/web/src/components/fields/hooks/use-field-view-draft.ts
+++ b/apps/web/src/components/fields/hooks/use-field-view-draft.ts
@@ -60,8 +60,12 @@ export interface UseFieldViewDraftResult {
    * flat `SortableContext` drag wants. See {@link moveFieldToSlot}.
    */
   reorderDraft: (activeId: string, overId: string, edge?: 'before' | 'after') => void
-  /** Persist the draft: update the existing org default view, or create one. Resolves on success. */
-  saveDraft: () => Promise<void>
+  /**
+   * Persist the draft: update the existing org default view, or create one.
+   * Never rejects — resolves `true` when the write landed (and draft mode has
+   * exited), `false` when it failed and the draft was left intact.
+   */
+  saveDraft: () => Promise<boolean>
   /** Groups in the draft. Empty array when the draft has none. */
   draftGroups: FieldGroup[]
   /** Create a group; returns its new id. */
@@ -432,8 +436,8 @@ export function useFieldViewDraft({
    * failures surface through the mutations' `onError` toasts and leave the
    * draft intact so the user can retry.
    */
-  const saveDraft = useCallback(async () => {
-    if (!draft) return
+  const saveDraft = useCallback(async (): Promise<boolean> => {
+    if (!draft) return false
 
     try {
       if (orgFieldView) {
@@ -469,8 +473,10 @@ export function useFieldViewDraft({
       setDraft(null)
       setPristineConfig(null)
       setIsDraftMode(false)
+      return true
     } catch {
       // Errors handled by mutation onError
+      return false
     }
   }, [draft, orgFieldView, draftContextType, entityDefinitionId, updateView, createView])
 

--- a/apps/web/src/components/fields/rows/field-group-row.tsx
+++ b/apps/web/src/components/fields/rows/field-group-row.tsx
@@ -108,6 +108,7 @@ export const FieldGroupRow = memo(function FieldGroupRow({
     <div
       ref={setNodeRef}
       style={style}
+      data-slot='field-group-row'
       // The section wrapper owns this header's top margin now — it wraps the
       // header AND its members, so `first:mt-0` has to be measured against the
       // panel's children, not against the inside of that wrapper.
@@ -116,13 +117,19 @@ export const FieldGroupRow = memo(function FieldGroupRow({
           24px band. `FieldEditRow` bands its grip + field name the same way, so
           the row is 30px tall but its text sits at the top. Leaving the label as
           a sibling centred by the row's `items-center` dropped group titles a few
-          px below the field names beneath them. */}
-      <div className='flex h-[24px] min-w-0 flex-1 items-center gap-[4px] self-start'>
+          px below the field names beneath them.
+          A surface whose rows centre theirs instead (the record dialog's
+          `FieldPanelRow`s) overrides through `data-slot`. */}
+      <div
+        data-slot='field-group-band'
+        className='flex h-[24px] min-w-0 flex-1 items-center gap-[4px] self-start'>
         {isEditMode ? (
           /* Icon by default, grip cross-fading in on row hover or while dragging
              — the same swap `TreeRow` and `FieldEditRow` use, so a group header
              reads like the rows it contains. */
-          <span className='relative flex size-6 shrink-0 items-center justify-center'>
+          <span
+            data-slot='field-group-glyph'
+            className='relative flex size-6 shrink-0 items-center justify-center'>
             <span
               className={cn(
                 'flex items-center justify-center opacity-0 transition-opacity pointer-fine:opacity-100',
@@ -141,6 +148,11 @@ export const FieldGroupRow = memo(function FieldGroupRow({
               {...attributes}
               {...listeners}
               aria-label={`Reorder group ${group.label}`}
+              // Carries the glyph slot too: `inset-0` resolves against the
+              // PADDING box, so an override that insets the icon layer above
+              // would leave the grip centred and the two would cross-fade
+              // between different x positions.
+              data-slot='field-group-glyph'
               className={cn(
                 'absolute inset-0 flex cursor-grab touch-none items-center justify-center opacity-100 transition-opacity pointer-fine:opacity-0 active:cursor-grabbing',
                 isDragging
@@ -159,6 +171,7 @@ export const FieldGroupRow = memo(function FieldGroupRow({
             aria-expanded={!collapsed}
             aria-label={collapsed ? `Expand ${group.label}` : `Collapse ${group.label}`}
             onClick={onToggleCollapsed}
+            data-slot='field-group-glyph'
             className='flex size-6 shrink-0 cursor-pointer items-center justify-center rounded transition-colors hover:bg-primary-200/60'>
             <ChevronRight
               className={cn(
@@ -204,14 +217,19 @@ export const FieldGroupRow = memo(function FieldGroupRow({
       </div>
 
       {onDelete && (
-        <Button
-          variant='ghost'
-          size='icon-sm'
-          aria-label={`Delete group ${group.label}`}
-          className='text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
-          onClick={onDelete}>
-          <Trash2 />
-        </Button>
+        /* Trailing actions, flush right by default — the panel's rows are too.
+           A surface whose rows keep a right gutter (the dialog's `pe-2` content
+           area) adds one through this slot. */
+        <div data-slot='field-group-actions' className='flex shrink-0 items-center'>
+          <Button
+            variant='ghost'
+            size='icon-sm'
+            aria-label={`Delete group ${group.label}`}
+            className='text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
+            onClick={onDelete}>
+            <Trash2 />
+          </Button>
+        </div>
       )}
     </div>
   )
@@ -219,17 +237,22 @@ export const FieldGroupRow = memo(function FieldGroupRow({
 
 interface AddGroupRowProps {
   onClick: () => void
+  /** Spacing/alignment for the surface it sits under (the panel needs none). */
+  className?: string
 }
 
 /**
  * Edit-mode affordance that creates a new (empty) group, mirroring `AddFieldRow`'s
  * shape so the two read as one pair of actions.
  */
-export function AddGroupRow({ onClick }: AddGroupRowProps) {
+export function AddGroupRow({ onClick, className }: AddGroupRowProps) {
   return (
     <div
       onClick={onClick}
-      className='-ms-1 row group flex h-[24px] min-h-[30px] cursor-pointer items-center gap-1 rounded-md transition-colors hover:bg-primary-200/50'>
+      className={cn(
+        '-ms-1 row group flex h-[24px] min-h-[30px] cursor-pointer items-center gap-1 rounded-md transition-colors hover:bg-primary-200/50',
+        className
+      )}>
       <div className='flex h-[24px] shrink-0 items-center gap-[4px] ps-1.5 text-primary-500'>
         <FolderPlus className='size-4 shrink-0' />
         <div className='w-[120px] shrink-0 text-sm'>

--- a/apps/web/src/components/fields/ui/field-group-list.tsx
+++ b/apps/web/src/components/fields/ui/field-group-list.tsx
@@ -1,0 +1,826 @@
+// apps/web/src/components/fields/ui/field-group-list.tsx
+'use client'
+
+import type { FieldGroup } from '@auxx/lib/conditions/client'
+import { cn } from '@auxx/ui/lib/utils'
+import type {
+  CollisionDetection,
+  DragOverEvent,
+  DragStartEvent,
+  SensorDescriptor,
+  SensorOptions,
+} from '@dnd-kit/core'
+import {
+  closestCorners,
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  pointerWithin,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis, restrictToWindowEdges } from '@dnd-kit/modifiers'
+import { Fragment, type ReactNode, useCallback, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { type FieldGroupLike, type GroupedFieldSection, groupFieldOrder } from '../group-fields'
+import { FieldGroupRow, parseGroupDropId } from '../rows/field-group-row'
+import {
+  type FieldDropTarget,
+  FieldDropZone,
+  FieldInsertLine,
+  fieldBeforeDropId,
+  groupAfterDropId,
+  groupBeforeDropId,
+  groupDropId,
+  groupEndDropId,
+  resolveDropTarget,
+} from '../rows/field-insert-line'
+
+/** What `renderRow` is told about the slot it is rendering into. */
+export interface FieldGroupListRowContext {
+  /** The row belongs to a group (the caller decides how to indent it). */
+  grouped: boolean
+  /** A member of the group currently in hand — fades with its header. */
+  dimmed: boolean
+  /** Rendered inside the drag ghost: no actions, no drop zones, no insert lines. */
+  preview: boolean
+  /**
+   * The last row in the whole rendered list. Only the dialog needs it — see the
+   * `rowBorders: 'managed'` variant on `FieldPanel`, whose direct-child last-row
+   * rule cannot see across group wrappers.
+   */
+  isLast: boolean
+  /**
+   * Position in the VISIBLE rendered order (a collapsed group contributes no
+   * rows). The property panel's keyboard navigation is indexed by this.
+   */
+  navIndex: number
+}
+
+export interface FieldGroupListProps<TRow> {
+  /** Rows in `fieldOrder` order, already filtered to what should render. */
+  rows: TRow[]
+  /** The VIEW field id — the id `fieldOrder` / `fieldGroups[].fieldIds` store, and every dnd id. */
+  rowId: (row: TRow) => string
+  /** React key. Deliberately separate from `rowId`: the panel keys by `providerId`. */
+  rowKey: (row: TRow) => string
+  groups: FieldGroup[]
+  isEditMode: boolean
+  /** Gate on the surface's own permission — an empty sensor list disables dragging. */
+  canEdit?: boolean
+  sensors: SensorDescriptor<SensorOptions>[]
+  /**
+   * Drop handler for a FIELD drag. `edge` names which side of the target the
+   * field lands on, read from the pre-drag positions so the drop agrees with
+   * the insert line.
+   */
+  onFieldDragEnd: (event: DragEndEvent, edge?: 'before' | 'after') => void
+  /** Place a field immediately before/after a group's block, belonging to NO group. */
+  onPlaceFieldBesideGroup?: (fieldId: string, groupId: string, side: 'before' | 'after') => void
+  /** Move a whole group block. `overId` is a bare group id when `overIsGroup`, else a field id. */
+  onMoveGroup?: (groupId: string, overId: string, overIsGroup: boolean) => void
+  onRenameGroup?: (groupId: string, label: string) => void
+  onDeleteGroup?: (groupId: string, label: string) => void
+  /** Autofocus the label of a group that was just created. */
+  newGroupId?: string | null
+  /** Class applied to a GROUPED row's wrapper — the two surfaces indent differently. */
+  groupedRowClassName?: string
+  /**
+   * Class applied to a group's section wrapper (and to the drag ghost, so the
+   * two agree). This is where a surface re-aligns the header with its own rows,
+   * through `FieldGroupRow`'s `data-slot`s — see the record dialog.
+   */
+  groupClassName?: string
+  /**
+   * Groups that cannot be collapsed right now (the dialog's validation errors).
+   * A derived override, not an imperative expand: while a group holds an unfixed
+   * error the user cannot collapse it, which is the intended reading of
+   * "auto-expand on error" — clearing the override once would hide the error
+   * again on the next click.
+   */
+  forceExpandGroupIds?: string[]
+  renderRow: (row: TRow, ctx: FieldGroupListRowContext) => ReactNode
+}
+
+/**
+ * The grouped field list and its whole drag model, shared by the property panel
+ * drawer and the record create/edit dialog.
+ *
+ * There is deliberately NO `SortableContext` here, and no sorting strategy.
+ *
+ * A group is a header plus a contiguous member block, and a displacement
+ * strategy cannot express "this whole block moves": it displaces individual
+ * rows by the dragged node's height, so a group drag either moved the header
+ * alone or (with a `DragOverlay`) shoved every row down by the block's height
+ * while the block was still in flow. The KB sidebar solved the same problem by
+ * dropping the strategy entirely — `useSortable` is kept purely for
+ * `isDragging`/`attributes`/`listeners`, nothing displaces, and the answer to
+ * "where will this land" is stated explicitly by an insert line plus a
+ * whole-group highlight. This is that model (see `rows/field-insert-line.tsx`
+ * for the id keyspace).
+ *
+ * Consequence worth knowing: without a `SortableContext` `useSortable` never
+ * resolves a transform, so the dragged row does not follow the pointer — it
+ * dims to 0.3 and stays put. The `DragOverlay` below is what follows the
+ * cursor.
+ */
+export function FieldGroupList<TRow>({
+  rows,
+  rowId,
+  rowKey,
+  groups,
+  isEditMode,
+  canEdit = true,
+  sensors,
+  onFieldDragEnd,
+  onPlaceFieldBesideGroup,
+  onMoveGroup,
+  onRenameGroup,
+  onDeleteGroup,
+  newGroupId,
+  groupedRowClassName = 'ps-3',
+  groupClassName,
+  forceExpandGroupIds,
+  renderRow,
+}: FieldGroupListProps<TRow>) {
+  const rowById = new Map(rows.map((row) => [rowId(row), row]))
+
+  // ─────────────────────────────────────────────────────────────────
+  // GROUPS
+  // ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Collapse is LOCAL and read-mode only, deliberately.
+   *
+   * `FieldGroup.collapsed` is part of the org's shared default view — one config
+   * row every member of the org reads. Persisting a chevron click would be a
+   * server write per click that collapses the group for *everyone*, which is not
+   * what "I want this section out of my way right now" means. So collapse is a
+   * per-mount override layered on the persisted default.
+   *
+   * Nothing writes that persisted default today: edit mode forces every group
+   * open and shows no chevron, so there is no UI for it. The schema field and
+   * the draft hook's `setGroupCollapsed` remain, since a "starts collapsed"
+   * option is the natural place to wire it back up.
+   */
+  const [collapsedOverrides, setCollapsedOverrides] = useState<Record<string, boolean>>({})
+
+  const forceExpanded = new Set(forceExpandGroupIds ?? [])
+
+  /**
+   * Edit mode forces every group OPEN. You are rearranging structure there —
+   * dragging fields between groups and groups past each other — and a hidden
+   * block is a block you cannot drop into or see the result of. It also removes
+   * the collapsed-group drop target, which was the main source of drop
+   * ambiguity: with every member row visible, a drop always has a real row to
+   * resolve against instead of a header standing in for hidden content.
+   */
+  const isGroupCollapsed = (group: FieldGroupLike): boolean => {
+    if (isEditMode) return false
+    if (forceExpanded.has(group.id)) return false
+    return collapsedOverrides[group.id] ?? group.collapsed ?? false
+  }
+
+  const toggleGroupCollapsed = (group: FieldGroupLike) => {
+    if (isEditMode) return
+    setCollapsedOverrides((prev) => ({ ...prev, [group.id]: !isGroupCollapsed(group) }))
+  }
+
+  // Sections are derived from the ids that actually render, so exclusion filters
+  // and hidden fields can never leave a group claiming a field the list doesn't
+  // show. Empty groups only exist in edit mode, where they are drop targets;
+  // read mode drops them entirely.
+  const sections = groupFieldOrder({
+    fieldOrder: rows.map(rowId),
+    groups,
+    includeEmptyGroups: isEditMode,
+  })
+
+  // The flat visible field sequence: a collapsed group contributes NO rows, so
+  // its members are neither in the sortable set nor registered with the keyboard
+  // navigation context (rows register themselves on mount — not rendering them
+  // is what keeps them unreachable by arrow keys).
+  const visibleRowIds = sections.flatMap((section) =>
+    section.group && isGroupCollapsed(section.group) ? [] : section.fieldIds
+  )
+  const navIndexById = new Map(visibleRowIds.map((id, index) => [id, index]))
+  const lastVisibleRowId = visibleRowIds[visibleRowIds.length - 1]
+
+  // ─────────────────────────────────────────────────────────────────
+  // DRAG MODEL — insert lines, not displacement
+  // ─────────────────────────────────────────────────────────────────
+
+  const [activeDragId, setActiveDragId] = useState<string | null>(null)
+  const [dropTarget, setDropTarget] = useState<FieldDropTarget | null>(null)
+
+  /** The group being dragged, or null when a field row is in hand. */
+  const activeGroupId = activeDragId === null ? null : parseGroupDropId(activeDragId)
+
+  const memberIdsOfGroup = (groupId: string): string[] =>
+    sections.find((section) => section.group?.id === groupId)?.fieldIds ?? []
+
+  /**
+   * What the drag ghost renders: the whole block for a group drag, one row for a
+   * field drag. Null when nothing is in hand, which is what keeps the overlay
+   * unmounted the rest of the time.
+   */
+  const activeGroupSection =
+    activeGroupId === null
+      ? undefined
+      : sections.find((section) => section.group?.id === activeGroupId)
+  const activeFieldRow =
+    activeDragId !== null && activeGroupId === null ? rowById.get(activeDragId) : undefined
+
+  // Positions are compared in the RENDERED order (which is `fieldOrder`,
+  // group-contiguous) so the insert line can be drawn on the edge the drop
+  // actually lands on — see `deriveDropFeedback`.
+  const renderedOrder = sections.flatMap((section) => section.fieldIds)
+  const orderIndexById = new Map(renderedOrder.map((fieldId, index) => [fieldId, index]))
+  const groupIdByFieldId = new Map<string, string>()
+  for (const section of sections) {
+    if (!section.group) continue
+    for (const fieldId of section.fieldIds) groupIdByFieldId.set(fieldId, section.group.id)
+  }
+
+  /** Where the dragged thing sits today: a field's slot, or a block's anchor. */
+  const activeAnchorIndex = (() => {
+    if (activeDragId === null) return -1
+    if (activeGroupId === null) return orderIndexById.get(activeDragId) ?? -1
+    const firstMemberId = memberIdsOfGroup(activeGroupId)[0]
+    return firstMemberId === undefined ? -1 : (orderIndexById.get(firstMemberId) ?? -1)
+  })()
+
+  /**
+   * `reorderDraft` and `moveGroupBlock` are both direction-sensitive: dragging
+   * DOWN onto a target lands after it, dragging UP lands at it. So the line is
+   * drawn on the target's bottom edge for a downward drag and its top edge for
+   * an upward one — otherwise the affordance would promise a slot the drop does
+   * not deliver.
+   */
+  const edgeFor = (targetIndex: number): 'top' | 'bottom' =>
+    activeAnchorIndex >= 0 && targetIndex >= 0 && activeAnchorIndex < targetIndex ? 'bottom' : 'top'
+
+  type DropIndicator =
+    | { kind: 'row'; rowId: string; side: 'top' | 'bottom'; inset: boolean }
+    | { kind: 'group'; groupId: string; side: 'top' | 'bottom'; inset: boolean }
+
+  /**
+   * Turn the hovered droppable into the ONE line to draw and the ONE group to
+   * light up.
+   *
+   * The highlight answers "will this end up INSIDE that group", and its colour
+   * answers it in both directions:
+   *
+   * - `blocked: false` (blue) — a FIELD about to join the group. It really will
+   *   be a member.
+   * - `blocked: true` (grey) — a GROUP hovering another group. Groups do not
+   *   nest, so the drop repositions the block against that group's boundary
+   *   instead. The fill says "not into this"; the insert line still says where
+   *   the block lands, which is why lines stay blue in both cases.
+   *
+   * Deliberately NOT drawn for `group-before`/`group-after`: those land the
+   * field outside every group, so there is no group to be inside of.
+   */
+  const deriveDropFeedback = (): {
+    indicator: DropIndicator | null
+    highlight: { groupId: string; blocked: boolean } | null
+  } => {
+    if (dropTarget === null || activeDragId === null) {
+      return { indicator: null, highlight: null }
+    }
+
+    const anchorIndexOfGroup = (groupId: string): number => {
+      const firstMemberId = memberIdsOfGroup(groupId)[0]
+      return firstMemberId === undefined ? -1 : (orderIndexById.get(firstMemberId) ?? -1)
+    }
+
+    // A GROUP drag always snaps to a whole block boundary (`moveGroupBlock`
+    // never splits another group), so a field target resolves to that field's
+    // group when it has one.
+    if (activeGroupId !== null) {
+      const overFieldId =
+        dropTarget.kind === 'field' || dropTarget.kind === 'field-before'
+          ? dropTarget.fieldId
+          : null
+      const referenceGroupId =
+        overFieldId !== null
+          ? (groupIdByFieldId.get(overFieldId) ?? null)
+          : dropTarget.kind === 'field' || dropTarget.kind === 'field-before'
+            ? null
+            : dropTarget.groupId
+      if (referenceGroupId === null) {
+        const fieldId = overFieldId
+        if (fieldId === null) return { indicator: null, highlight: null }
+        const side = edgeFor(orderIndexById.get(fieldId) ?? -1)
+        return {
+          indicator: { kind: 'row', rowId: fieldId, side, inset: false },
+          highlight: null,
+        }
+      }
+      if (referenceGroupId === activeGroupId) return { indicator: null, highlight: null }
+      const side = edgeFor(anchorIndexOfGroup(referenceGroupId))
+      return {
+        indicator: { kind: 'group', groupId: referenceGroupId, side, inset: false },
+        // A group hovering a group: the block lands beside it, never inside it.
+        highlight: { groupId: referenceGroupId, blocked: true },
+      }
+    }
+
+    switch (dropTarget.kind) {
+      case 'field': {
+        const side = edgeFor(orderIndexById.get(dropTarget.fieldId) ?? -1)
+        const targetGroupId = groupIdByFieldId.get(dropTarget.fieldId) ?? null
+        return {
+          indicator: { kind: 'row', rowId: dropTarget.fieldId, side, inset: false },
+          highlight: targetGroupId === null ? null : { groupId: targetGroupId, blocked: false },
+        }
+      }
+      case 'field-before': {
+        // Named boundary: always the row's top edge, never `edgeFor`.
+        const targetGroupId = groupIdByFieldId.get(dropTarget.fieldId) ?? null
+        return {
+          indicator: { kind: 'row', rowId: dropTarget.fieldId, side: 'top', inset: false },
+          highlight: targetGroupId === null ? null : { groupId: targetGroupId, blocked: false },
+        }
+      }
+      case 'group-into': {
+        // A field dropped on the header lands at the HEAD of the block, so the
+        // line belongs above the first member — not above the header, which is
+        // the `group-before` position and means something else entirely.
+        const firstMemberId = memberIdsOfGroup(dropTarget.groupId).find((id) => id !== activeDragId)
+        return {
+          indicator:
+            firstMemberId === undefined
+              ? null
+              : { kind: 'row', rowId: firstMemberId, side: 'top', inset: false },
+          highlight: { groupId: dropTarget.groupId, blocked: false },
+        }
+      }
+      case 'group-end': {
+        // Full-width line under the last member, and the group lights up: this
+        // lands INSIDE. The `group-after` zone directly below draws the short
+        // inset line instead, so the two are told apart at a glance even though
+        // they sit only a few pixels apart.
+        const memberIds = memberIdsOfGroup(dropTarget.groupId).filter((id) => id !== activeDragId)
+        const lastMemberId = memberIds[memberIds.length - 1]
+        return {
+          indicator:
+            lastMemberId === undefined
+              ? null
+              : { kind: 'row', rowId: lastMemberId, side: 'bottom', inset: false },
+          highlight: { groupId: dropTarget.groupId, blocked: false },
+        }
+      }
+      case 'group-before':
+        return {
+          indicator: { kind: 'group', groupId: dropTarget.groupId, side: 'top', inset: false },
+          highlight: null,
+        }
+      case 'group-after':
+        return {
+          indicator: { kind: 'group', groupId: dropTarget.groupId, side: 'bottom', inset: true },
+          highlight: null,
+        }
+    }
+  }
+
+  const { indicator, highlight } = deriveDropFeedback()
+
+  const lineForRow = (id: string, side: 'top' | 'bottom'): boolean =>
+    indicator?.kind === 'row' && indicator.rowId === id && indicator.side === side
+
+  const lineForGroup = (groupId: string, side: 'top' | 'bottom'): boolean =>
+    indicator?.kind === 'group' && indicator.groupId === groupId && indicator.side === side
+
+  // `collisionDetection` runs outside the render that produced `sections`, so it
+  // reads them through a ref and stays referentially stable.
+  const sectionsRef = useRef<GroupedFieldSection[]>(sections)
+  sectionsRef.current = sections
+
+  /**
+   * `closestCorners` (the KB sidebar's choice), minus the targets that describe
+   * a drop the mutation layer would refuse anyway:
+   *
+   * - a FIELD may not target its own row (`x-before` and the bare `x` both
+   *   resolve to the same no-op),
+   * - a GROUP may not land inside its own block — its members' rows, its own
+   *   header, its own `-before`/`-after-group` boundaries,
+   * - a GROUP may not target an EMPTY group at all. An empty group has no index
+   *   in `fieldOrder` (its end-of-list slot is a render convention), so
+   *   `moveGroupBlock` has no honest insertion point and refuses every one of
+   *   its three droppables. Letting it become `over` drew a highlight and an
+   *   insert line for a drop that then did nothing. A FIELD drag still targets
+   *   it — that is the only way a new group ever gets its first member.
+   *
+   * Filtering here rather than per-row is what lets every affordance below key
+   * off `over` alone: an invalid target simply never becomes `over`, so no
+   * component needs its own validity gate.
+   */
+  const collisionDetection = useCallback<CollisionDetection>((args) => {
+    // `pointerWithin` FIRST: the drop zones deliberately overlap each other and
+    // the rows (each is `absolute left-0 right-0 h-4` hanging off an edge), and
+    // `closestCorners` resolves from the DRAGGED ELEMENT'S rect rather than the
+    // cursor — with a long list and vertical-only movement its nearest corner
+    // can be a zone nowhere near where the user is pointing. `closestCorners` is
+    // kept as the fallback for the gaps where the pointer is inside no zone.
+    const collisions = pointerWithin(args).length > 0 ? pointerWithin(args) : closestCorners(args)
+    const draggedId = String(args.active.id)
+    const draggedGroupId = parseGroupDropId(draggedId)
+
+    if (draggedGroupId === null) {
+      /** The field in hand is already the last thing in that group's block. */
+      const isLastMemberOf = (groupId: string): boolean => {
+        const memberIds = sectionsRef.current.find((s) => s.group?.id === groupId)?.fieldIds ?? []
+        return memberIds[memberIds.length - 1] === draggedId
+      }
+
+      const usable = collisions.filter((collision) => {
+        const target = resolveDropTarget(String(collision.id))
+        if (target.kind === 'field' || target.kind === 'field-before')
+          return target.fieldId !== draggedId
+        // "Inside, last slot" is where this field already IS — the drop would be
+        // a no-op, and the zone would sit on top of the one target that isn't:
+        // leaving the group downward.
+        if (target.kind === 'group-end') return !isLastMemberOf(target.groupId)
+        return true
+      })
+
+      // `group-end` wins outright wherever it is under the pointer.
+      //
+      // `pointerWithin` ranks by distance from the pointer to each droppable's
+      // CENTRE, and this zone is a band inside the last member's row — so the
+      // two centres are about a pixel apart and the winner flipped with a pixel
+      // of pointer movement, which read as "the zone doesn't accept drops".
+      // Sizing cannot fix that; only precedence can. It is safe because the
+      // zone only overlaps that one row, and for a DOWNWARD drag both targets
+      // resolve to the same slot anyway.
+      const endIndex = usable.findIndex(
+        (collision) => resolveDropTarget(String(collision.id)).kind === 'group-end'
+      )
+      if (endIndex > 0) {
+        const promoted = usable[endIndex]
+        usable.splice(endIndex, 1)
+        if (promoted) usable.unshift(promoted)
+      }
+
+      return usable
+    }
+
+    const ownMemberIds = new Set(
+      sectionsRef.current.find((section) => section.group?.id === draggedGroupId)?.fieldIds ?? []
+    )
+    const emptyGroupIds = new Set(
+      sectionsRef.current
+        .filter((section) => section.group !== null && section.fieldIds.length === 0)
+        .map((section) => section.group?.id)
+    )
+    return collisions.filter((collision) => {
+      const target = resolveDropTarget(String(collision.id))
+      if (target.kind === 'field' || target.kind === 'field-before')
+        return !ownMemberIds.has(target.fieldId)
+      // `group-end` means "inside that group", which a group can never be. Left
+      // in, it would only compete with the `group-after` zone beneath it for the
+      // one thing a group drag CAN do at that boundary.
+      if (target.kind === 'group-end') return false
+      return target.groupId !== draggedGroupId && !emptyGroupIds.has(target.groupId)
+    })
+  }, [])
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveDragId(String(event.active.id))
+    setDropTarget(null)
+  }
+
+  /** Identity of a drop target, so an unchanged hover does not re-render. */
+  const dropTargetKey = (target: FieldDropTarget): string =>
+    target.kind === 'field' || target.kind === 'field-before'
+      ? `${target.kind}:${target.fieldId}`
+      : `${target.kind}:${target.groupId}`
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const next = event.over === null ? null : resolveDropTarget(String(event.over.id))
+    setDropTarget((prev) => {
+      if (prev === null || next === null) return prev === next ? prev : next
+      return dropTargetKey(prev) === dropTargetKey(next) ? prev : next
+    })
+  }
+
+  /** A synthetic drag-end aimed at `overId`, so the existing handlers see a normal drop. */
+  const aimedAt = (event: DragEndEvent, overId: string): DragEndEvent =>
+    event.over === null ? event : { ...event, over: { ...event.over, id: overId } }
+
+  /**
+   * Route a drop by WHAT WAS DRAGGED, not by what it landed on.
+   *
+   * A group header and a field row are the same kind of thing to dnd-kit but
+   * different operations here: dragging a group repositions its whole member
+   * block (order only — `moveGroup`), while dragging a field can also change
+   * which group it belongs to. Running the field path for a group drag would
+   * reassign membership from wherever the header happened to land, which is why
+   * the two never share a code path.
+   *
+   * Every branch translates the suffixed droppable id back to the bare field or
+   * group id the existing handlers already expect; neither handler is modified.
+   */
+  const routeDragEnd = (event: DragEndEvent) => {
+    setActiveDragId(null)
+    setDropTarget(null)
+
+    const { active, over } = event
+    if (!over) return
+
+    const activeId = String(active.id)
+    const target = resolveDropTarget(String(over.id))
+    const draggedGroupId = parseGroupDropId(activeId)
+
+    // GROUP drag — order only. Every group-addressing target collapses to the
+    // same call: `moveGroupBlock` owns the snap-to-boundary and direction rules,
+    // so "above" vs "below" is its decision, not the droppable's.
+    if (draggedGroupId !== null) {
+      if (target.kind === 'field' || target.kind === 'field-before') {
+        onMoveGroup?.(draggedGroupId, target.fieldId, false)
+        return
+      }
+      if (target.groupId === draggedGroupId) return
+      onMoveGroup?.(draggedGroupId, target.groupId, true)
+      return
+    }
+
+    switch (target.kind) {
+      case 'field-before':
+        // The zone names the edge, so the drop does not consult the direction.
+        if (target.fieldId === activeId) return
+        onFieldDragEnd(aimedAt(event, target.fieldId), 'before')
+        return
+      case 'field': {
+        if (target.fieldId === activeId) return
+        // The SAME expression `deriveDropFeedback` draws the insert line from,
+        // so the drop cannot land on a different edge than the line promised.
+        // It must be read from the pre-drag positions in this render's closure —
+        // `onFieldDragEnd` may relocate the field (joining a group appends it to
+        // the block's tail) before it reorders, which would flip the direction.
+        const side = edgeFor(orderIndexById.get(target.fieldId) ?? -1)
+        onFieldDragEnd(aimedAt(event, target.fieldId), side === 'bottom' ? 'after' : 'before')
+        return
+      }
+      case 'group-into':
+        onFieldDragEnd(aimedAt(event, groupDropId(target.groupId)))
+        return
+      case 'group-end': {
+        // Aim at the last member with an explicit `after`. `onFieldDragEnd`
+        // reads membership from where the field lands, so targeting a member
+        // both joins the group and settles at its end — and naming the edge is
+        // the whole point: an upward drag would otherwise land before it.
+        const memberIds = memberIdsOfGroup(target.groupId).filter((id) => id !== activeId)
+        const lastMemberId = memberIds[memberIds.length - 1]
+        if (lastMemberId === undefined) {
+          onFieldDragEnd(aimedAt(event, groupDropId(target.groupId)))
+          return
+        }
+        onFieldDragEnd(aimedAt(event, lastMemberId), 'after')
+        return
+      }
+      case 'group-before':
+        onPlaceFieldBesideGroup?.(activeId, target.groupId, 'before')
+        return
+      case 'group-after':
+        onPlaceFieldBesideGroup?.(activeId, target.groupId, 'after')
+        return
+    }
+  }
+
+  /** A section's member rows, in the section's own order, ghosts skipped. */
+  const memberRowsOf = (fieldIds: string[]): TRow[] =>
+    fieldIds.flatMap((fieldId) => {
+      const row = rowById.get(fieldId)
+      return row === undefined ? [] : [row]
+    })
+
+  /**
+   * One group header, rendered inside its section wrapper so the wrapper's
+   * highlight and boundary lines cover the header and its members as one unit.
+   */
+  const renderGroupHeader = (
+    group: FieldGroupLike,
+    memberCount: number,
+    autoFocusLabel: boolean,
+    preview = false
+  ) => (
+    <FieldGroupRow
+      group={group}
+      collapsed={isGroupCollapsed(group)}
+      memberCount={memberCount}
+      onToggleCollapsed={() => toggleGroupCollapsed(group)}
+      isEditMode={isEditMode}
+      // The ghost is a picture of what is in hand, not a live row: no rename
+      // input to focus, no delete button to hit. Withholding the handlers is
+      // what collapses it to icon + title, since the trailing actions only
+      // render when their handler exists.
+      onRename={
+        !preview && isEditMode && onRenameGroup
+          ? (label) => onRenameGroup(group.id, label)
+          : undefined
+      }
+      onDelete={
+        !preview && isEditMode && onDeleteGroup
+          ? () => onDeleteGroup(group.id, group.label)
+          : undefined
+      }
+      autoFocusLabel={!preview && autoFocusLabel}
+    />
+  )
+
+  /** One member row plus the wrapper carrying its group inset. */
+  const renderMemberRow = (
+    row: TRow,
+    options: { grouped: boolean; dimmed?: boolean; preview?: boolean }
+  ) => {
+    const id = rowId(row)
+    return (
+      // Grouped rows sit slightly inset so the group's extent is readable
+      // without a border. Ungrouped rows keep the flush edge, so the indent
+      // alone distinguishes "in this group" from "after it".
+      //
+      // `dimmed` fades a member of the group currently in hand. `FieldGroupRow`
+      // already fades its own header via `isDragging`, but a member row has no
+      // idea its group is being dragged — without this only the header dimmed and
+      // the block did not read as lifted. Safe now that nothing displaces: there
+      // is no `SortableContext`, so dimming cannot desync any layout math.
+      <div
+        key={rowKey(row)}
+        className={cn(
+          'relative',
+          options.grouped && groupedRowClassName,
+          options.dimmed && 'opacity-30'
+        )}>
+        {isEditMode && !options.preview && (
+          <>
+            <FieldDropZone id={fieldBeforeDropId(id)} edge='top' />
+            {lineForRow(id, 'top') && <FieldInsertLine side='top' />}
+            {lineForRow(id, 'bottom') && <FieldInsertLine side='bottom' />}
+          </>
+        )}
+        {renderRow(row, {
+          grouped: options.grouped,
+          dimmed: options.dimmed ?? false,
+          preview: options.preview ?? false,
+          // A preview lives in the overlay, outside the panel — it must never
+          // claim the managed last-row border.
+          isLast: !options.preview && id === lastVisibleRowId,
+          navIndex: navIndexById.get(id) ?? 0,
+        })}
+      </div>
+    )
+  }
+
+  /**
+   * Walk the sections into elements: an ungrouped run stays a bare fragment, a
+   * group becomes ONE positioned wrapper around its header and members.
+   *
+   * That wrapper is what makes the group a single visual unit: the dashed
+   * highlight is drawn across it, and the two boundaries that address the block
+   * from outside (`-before` above the header, `-after-group` below the last
+   * member) hang off its edges. It also owns the header's top margin — inside
+   * the wrapper the header is always `:first-child`, so `first:mt-0` had to move
+   * out with it.
+   */
+  const renderSections = () =>
+    sections.map((section, sectionIndex) => {
+      const group = section.group
+      const collapsed = group ? isGroupCollapsed(group) : false
+      const memberRows = collapsed ? [] : memberRowsOf(section.fieldIds)
+      // Every member of the group in hand fades with its header, so the block
+      // reads as one thing being lifted rather than a header leaving its rows.
+      const blockDimmed = group !== null && group.id === activeGroupId
+      const rowElements = memberRows.map((row) =>
+        renderMemberRow(row, { grouped: group !== null, dimmed: blockDimmed })
+      )
+
+      if (!group) return <Fragment key={`ungrouped-${sectionIndex}`}>{rowElements}</Fragment>
+
+      return (
+        <div
+          key={`group-${group.id}`}
+          className={cn(
+            'relative mt-1.5 first:mt-0',
+            groupClassName,
+            // The fill is a real BACKGROUND on the section, not part of the
+            // overlay below: `bg-primary-100` is opaque, and an absolutely
+            // positioned overlay paints above statically positioned children —
+            // it would hide the header and rows it is meant to be highlighting.
+            highlight?.groupId === group.id &&
+              (highlight.blocked ? 'rounded-md bg-primary-100' : 'rounded-md bg-primary/10')
+          )}>
+          {isEditMode && (
+            <>
+              <FieldDropZone id={groupBeforeDropId(group.id)} edge='top' />
+              {/* Only when the block HAS a last member to land after. On an
+                  empty group this band would sit over the header, where
+                  `group-into` already means the same thing. */}
+              {memberRows.length > 0 && (
+                <FieldDropZone id={groupEndDropId(group.id)} edge='inner-bottom' />
+              )}
+              <FieldDropZone id={groupAfterDropId(group.id)} edge='bottom' />
+              {highlight?.groupId === group.id && (
+                <div className='pointer-events-none absolute inset-0 z-10 rounded-md border border-primary-200 border-dashed' />
+              )}
+              {lineForGroup(group.id, 'top') && <FieldInsertLine side='top' />}
+              {lineForGroup(group.id, 'bottom') && (
+                <FieldInsertLine side='bottom' inset={indicator?.inset ?? false} />
+              )}
+            </>
+          )}
+          {renderGroupHeader(group, section.fieldIds.length, group.id === newGroupId)}
+          {rowElements}
+        </div>
+      )
+    })
+
+  // Reordering is edit-mode only, so the DnD context only exists there.
+  if (!isEditMode) return <>{renderSections()}</>
+
+  return (
+    <DndContext
+      // An empty sensor list is how a drag is made unreachable without
+      // tearing the context out from under the rows (the KB sidebar's
+      // pattern). Edit mode is already gated on `canEdit`; this keeps
+      // the two from drifting.
+      sensors={canEdit ? sensors : []}
+      collisionDetection={collisionDetection}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={routeDragEnd}
+      onDragCancel={() => {
+        setActiveDragId(null)
+        setDropTarget(null)
+      }}
+      modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}>
+      {/* No `SortableContext`: nothing displaces, and the landing slot
+          is stated by an insert line plus a whole-group highlight. */}
+      {renderSections()}
+
+      {/* The ghost under the cursor. Without a `SortableContext` the
+          rows get no transform of their own, so the source only fades —
+          this is the piece that actually follows the pointer.
+
+          An earlier attempt at this DID break the list, but that failure
+          was `verticalListSortingStrategy` displacing every row by the
+          overlay's height while the source was still in flow. There is
+          no strategy now, so an overlay cannot move anything. */}
+      {/* PORTALLED TO `document.body` ON PURPOSE. `DragOverlay` is
+          `position: fixed`, and fixed resolves against the nearest
+          ancestor with a `transform` / `filter` / `will-change` — not the
+          viewport. The record drawer animates in with a transform (and Radix
+          `DialogContent` centres with one), so rendering the overlay in place
+          anchored it to the DRAWER and the ghost sat ~200px below the cursor
+          while the insert line (which is absolutely positioned inside the list,
+          so unaffected) stayed correct. The portal takes the overlay out of that
+          containing block. */}
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <DragOverlay
+            dropAnimation={null}
+            // dnd-kit hard-sets width AND height from the ACTIVE node's rect —
+            // for a group that is only the header, so a block preview has to be
+            // free to grow past it, and a row ghost would otherwise be a
+            // full-panel-width bar. Releasing both lets the ghost shrink to its
+            // own content (icon + name), which is all it needs to say. The
+            // anchor stays the active node's top edge, where the grab happened.
+            style={{ height: 'auto', width: 'auto' }}
+            className='pointer-events-none'>
+            {activeGroupSection ? (
+              // Semi-transparent so the insert line stays readable through
+              // the ghost — the line marks the landing slot and the ghost
+              // is only "what is in hand", so the line has to win.
+              //
+              // `pe-2`: the overlay's width is released to `auto`, so an
+              // EMPTY group shrinks to icon + title + member count with
+              // the count pressed against the ring. Members give the
+              // ghost its own width and never need it.
+              <div
+                className={cn(
+                  'rounded-md bg-background/90 pe-2 opacity-90 shadow-lg ring-1 ring-border',
+                  groupClassName
+                )}>
+                {renderGroupHeader(
+                  activeGroupSection.group as FieldGroupLike,
+                  activeGroupSection.fieldIds.length,
+                  false,
+                  true
+                )}
+                {memberRowsOf(activeGroupSection.fieldIds).map((row) =>
+                  renderMemberRow(row, { grouped: true, preview: true })
+                )}
+              </div>
+            ) : activeFieldRow !== undefined ? (
+              <div className='rounded-md bg-background/90 opacity-90 shadow-lg ring-1 ring-border'>
+                {renderMemberRow(activeFieldRow, {
+                  grouped: groupIdByFieldId.has(rowId(activeFieldRow)),
+                  preview: true,
+                })}
+              </div>
+            ) : null}
+          </DragOverlay>,
+          document.body
+        )}
+    </DndContext>
+  )
+}

--- a/apps/web/src/components/global/forms/field-panel.tsx
+++ b/apps/web/src/components/global/forms/field-panel.tsx
@@ -44,10 +44,24 @@ const fieldPanelVariants = cva(
   [
     'relative grow rounded-2xl px-1.5 py-0.5',
     'bg-primary-200/30 dark:bg-[#23272e]/30 border flex flex-col focus-within:border-primary-300',
-    '[&>[data-slot=field-row]:not(:has(~[data-slot=field-row]))]:border-b-0',
   ],
   {
     variants: {
+      /**
+       * Which rule strips the bottom border from the panel's last row.
+       *
+       * `auto` is a DIRECT-CHILD selector, so it breaks the moment rows are
+       * nested (field groups wrap their members in a section div): the last row
+       * inside a group keeps a border it should not have, and a direct-child row
+       * followed by a group wrapper loses one it should keep. CSS cannot express
+       * "no field-row later in document order" across different parents, so
+       * `managed` has the renderer mark the last row with `data-last-row`
+       * instead — the honest encoding, not a shortcut.
+       */
+      rowBorders: {
+        auto: ['[&>[data-slot=field-row]:not(:has(~[data-slot=field-row]))]:border-b-0'],
+        managed: ['[&_[data-slot=field-row][data-last-row]]:border-b-0'],
+      },
       orientation: {
         horizontal: [
           // field-row: horizontal layout (default behavior)
@@ -105,6 +119,7 @@ const fieldPanelVariants = cva(
     defaultVariants: {
       orientation: 'responsive',
       breakpoint: 'sm',
+      rowBorders: 'auto',
     },
   }
 )
@@ -134,6 +149,7 @@ function FieldPanel({
   validationType = 'error',
   orientation = 'responsive',
   breakpoint = 'sm',
+  rowBorders = 'auto',
   className,
   resizeId,
   defaultLabelWidth = DEFAULT_LABEL_WIDTH,
@@ -227,7 +243,7 @@ function FieldPanel({
       data-slot='field'
       data-orientation={orientation}
       style={{ '--field-panel-label-w': `${labelWidth}px` } as React.CSSProperties}
-      className={cn(fieldPanelVariants({ orientation, breakpoint }), className)}>
+      className={cn(fieldPanelVariants({ orientation, breakpoint, rowBorders }), className)}>
       {children}
       {showResizer && (
         <div
@@ -273,6 +289,12 @@ interface FieldPanelRowProps {
   className?: string
   /** When provided, renders a clear button on row hover (positioned on the right edge) */
   onClear?: () => void
+  /**
+   * Marks this row as the panel's last one for `rowBorders: 'managed'`. Only
+   * needed when rows are nested (field groups), where the default direct-child
+   * rule cannot see them.
+   */
+  isLastRow?: boolean
 }
 
 /**
@@ -291,10 +313,12 @@ function FieldPanelRow({
   showIcon = false,
   className,
   onClear,
+  isLastRow = false,
 }: FieldPanelRowProps) {
   return (
     <div
       data-slot='field-row'
+      data-last-row={isLastRow ? '' : undefined}
       className={cn(
         'group/field-row relative flex border-b dark:border-b-[#404754]/20',
         className


### PR DESCRIPTION
Implements `plans/panel/field-groups-in-the-record-dialog.md` — the follow-on to #1539/#1540/#1541 that finishes item 11 of the original panel plan.

The dialog had phase 1 only: it shared `useFieldViewDraft` and the group-aware baseline merge, so it ordered fields correctly around groups but rendered them flat — through the exact `SortableContext` + `verticalListSortingStrategy` + `closestCenter` model the panel work had to throw away twice.

## Phase 1 — extraction, panel behaviour unchanged

- **`fields/ui/field-group-list.tsx`** (new) owns the section walk, drop zones, insert lines, whole-group highlight, collision detection, drag state and the portalled `DragOverlay`. Rows render through a render prop, so the panel keeps `FieldEditRow`/`FieldValueRow` and the dialog gets `DialogFieldConfigRow`/`FieldInputRow`.
- **`fields/hooks/use-field-group-dnd.ts`** (new) is the field half of drop routing, lifted verbatim from `entity-fields.tsx` — `handleFieldDragEnd` + `placeFieldBesideGroup`.
- `EntityFieldsContent` drops 1030 → ~330 lines, keeping card chrome, keyboard nav, the X, the footer and `CustomFieldDialog`.

The corrected drop model carries over whole — the named-boundary `field-before` kind, the explicit `edge` on `reorderDraft`, the empty-group `anchorFieldId` branch, the `fieldgroup:<g>-end` slot and its precedence in `collisionDetection`, the three stacked bottom bands, and deriving group members from `fieldOrder` rather than the membership set.

One addition to the plan's render-prop contract: `navIndex` (position in the *visible* order) is passed to `renderRow`, because the panel's keyboard navigation is indexed off it and only the list knows the collapse state.

## Phases 2–3 — the dialog

Config mode and read mode both render through `FieldGroupList`. Groups can be created, renamed, deleted and dragged; read mode renders collapsible sections and force-expands any group holding a validation error. The error map goes through the field object, never a string match — `errors` is keyed by `field.id`, groups by the view id (`<entityDefinitionId>:<fieldId>` for a custom field).

`DialogFieldConfigRow` drops its dead `transform` (there is no strategy any more) and fades in place at `0.3`. The X and the Create/Edit tab both prompt before discarding an unsaved draft; `saveDraft` now resolves a boolean so the tab switch can abort rather than re-snapshot over work that failed to save.

## `FieldPanel`

Two things nesting rows inside group wrappers breaks:

1. The last-row border rule is a direct-child selector, so it fails both ways. New `rowBorders` variant: `auto` (today, the default — no other consumer changes) and `managed`, which reads a `data-last-row` marker the renderer stamps. CSS cannot express "no field-row later in document order" across different parents, so the marker is the honest encoding.
2. Putting the panel's `ps-3` on a grouped row would push its content column 12px past the single absolutely-positioned resize divider. The indent goes on the label *text* instead, keeping the label/content boundary global.

Group-header alignment is re-done from the parent through `data-slot`s (`field-group-glyph`, `field-group-band`, `field-group-actions`) rather than a variant prop, since `FieldGroupRow` is shaped for the panel's rows and the dialog's `FieldPanelRow`s put their glyph in a `ps-2` gutter.

## Second commit

`fix(table): close the primary-column add tooltip on click` — unrelated one-liner. `SimpleTooltip` preventDefault-s the trigger's pointerdown and pins itself open for 50ms, suppressing Radix's close-on-click, so the bubble hung over the create dialog. `allowInteraction` skips that branch, as every other clickable trigger in the app already does.

## Testing

- `pnpm exec vitest run src/components/fields` — 108 passing, pure layer untouched.
- `tsc --noEmit` in `apps/web` — 16 errors, the same 16 that were there before.
- Biome clean.

**Not verified: the drag gestures.** Static checks do not verify drag behaviour — that is recorded as a fact in the panel plan, not a caution, after three rebuilds each passed typecheck, biome and the unit tests (two of them unusable). The extraction is line-for-line and phase 1 changes no behaviour, but this needs hand-driving before merge:

- **Panel (proves nothing moved):** field within a group, field out of a group, field above a leading group, field below a trailing group, block move onto a field, onto another group, onto an empty group (no-op by design), and the ghost tracking the cursor in the record drawer.
- **Dialog:** the same, in **both** hosts — the modal (`entity-instance-dialog.tsx`) and the kbar palette page — and in both tabs.
- **Read mode:** collapse a group holding a required field, submit, confirm it expands with the error on the right row.
