### PR TITLE
fix(fields): gate the record dialog's view config on def administration

### DIFF
--- a/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
@@ -36,6 +36,7 @@ import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-valu
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
+import { useAccess } from '~/providers/capabilities-provider'
 import { DialogFieldConfigRow } from '../dialog-field-config-row'
 import { FieldInputRow } from '../field-input-row'
 
@@ -149,6 +150,15 @@ export function EntityInstanceForm({
 
   // Determine context type based on mode (for normal form rendering)
   const contextType = isEditing ? 'dialog_edit' : 'dialog_create'
+
+  // Config mode edits the ORG'S shared default view for this context — def
+  // administration (the `Full`/`admin` rung), not record editing. It is the same
+  // capability the server gates the write on (`tableView.update` →
+  // `assertStructuralAccess` → `assertAdministerDef`) and the same one the
+  // property panel gates its own pencil on, so the affordance and the write
+  // agree instead of ending in a 403 toast over a layout the user just built.
+  const { canAdministerDef } = useAccess()
+  const canConfigureView = canAdministerDef(entityDefinitionId)
 
   // Get all potentially editable fields first. `resource.fields` already arrives
   // in baseline order — `ORDER BY sortOrder ASC` server-side, then partitioned by
@@ -705,25 +715,29 @@ export function EntityInstanceForm({
 
       {/* Field card area — floating edit button anchored to its top-right corner */}
       <div className='relative group/field-card'>
-        {/* Floating edit button — matches entity-fields panel placement */}
-        <div
-          className={cn(
-            'absolute -top-4 -right-3 z-80 rounded-full transition-opacity duration-200 ring ring-border bg-background flex items-center justify-center size-7 shadow-md backdrop-blur-sm',
-            isDraftMode ? 'opacity-100' : 'opacity-0 group-hover/field-card:opacity-100'
-          )}>
-          <Button
-            variant='ghost'
-            size='icon-xs'
-            onClick={() => (isDraftMode ? void handleExitDraft() : enterDraft())}
+        {/* Floating edit button — matches entity-fields panel placement. This is
+            the ONLY caller of `enterDraft`, so gating it here is what makes the
+            whole of config mode unreachable without def administration. */}
+        {canConfigureView && (
+          <div
             className={cn(
-              'cursor-pointer',
-              isDraftMode
-                ? 'bg-bad-200 hover:bg-bad-200 text-bad-700 hover:text-bad-800'
-                : 'text-muted-foreground hover:text-foreground'
+              'absolute -top-4 -right-3 z-80 rounded-full transition-opacity duration-200 ring ring-border bg-background flex items-center justify-center size-7 shadow-md backdrop-blur-sm',
+              isDraftMode ? 'opacity-100' : 'opacity-0 group-hover/field-card:opacity-100'
             )}>
-            {isDraftMode ? <X /> : <Pencil />}
-          </Button>
-        </div>
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              onClick={() => (isDraftMode ? void handleExitDraft() : enterDraft())}
+              className={cn(
+                'cursor-pointer',
+                isDraftMode
+                  ? 'bg-bad-200 hover:bg-bad-200 text-bad-700 hover:text-bad-800'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}>
+              {isDraftMode ? <X /> : <Pencil />}
+            </Button>
+          </div>
+        )}
 
         {isDraftMode ? (
           /* Config mode: grouped, draggable field list with visibility switches.


### PR DESCRIPTION
Follow-up to #1542, from a review question: does a non-admin really see the pencil on the record create/edit dialog? They do — the property panel gates its own, the dialog never did.

## The gap

Config mode edits the **org's shared default view** for a context, which is def administration (the `Full`/`admin` rung), not record editing. The server already treats it that way — `tableView.update` → `assertStructuralAccess` → `capabilities.assertAdministerDef(entityDefinitionId)` (`routers/tableView.ts:131-140`).

The property panel gates its affordance on the same capability (`fields/entity-fields.tsx:77-78`):

```ts
const { canAdministerDef } = useAccess()
const canManageFields = canEdit && canAdministerDef(entityDefinitionId)
```

`EntityInstanceForm` had no such check — it never imported `useAccess`. The floating pencil is `opacity-0` until you hover the field card, but it renders and is clickable for every user who can open create/edit.

So a non-admin could open config mode, build and name a group, drag fields into it, switch tabs, and only learn it was refused when Save View toasted a 403. **Nothing was ever written — this is an affordance bug, not a hole.** But the work was gone, and groups raised the cost of hitting it from a lost reorder to a lost layout.

Pre-existing; #1542 did not introduce it.

## The fix

`useAccess()` + one conditional around the floating button. The pencil is the only caller of `enterDraft`, so gating it makes all of config mode unreachable — no separate gate is needed on `AddGroupRow`, the footer, or the Create/Edit tabs.

Covers both hosts, since they render the same component: the modal (`entity-instance-dialog.tsx`) and the kbar palette page (`kbar/pages/create.tsx`).

## Testing

- `vitest run src/components/records src/components/fields src/components/custom-fields` — 157 passing.
- `tsc --noEmit` in `apps/web` — the same 16 pre-existing errors, none in the touched file.
- Biome clean.
- Every consumer of `EntityInstanceForm` (records, dispatch, dynamic-table, calendar, kbar) sits under `app/(protected)/layout.tsx`, which mounts `CapabilitiesProvider` — `useAccess` throws outside it, so this was worth confirming rather than assuming.

Not verified in a browser: that the pencil is actually absent for a non-admin viewer. The capability call mirrors the panel's exactly, but nobody has driven it with a non-admin session.
