### PR TITLE
fix(fields): hide inline relationship create without write on the target def

### DIFF
--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -28,6 +28,7 @@ import {
   PhoneInput,
   StringInput,
 } from '~/components/workflow/nodes/shared/node-inputs'
+import { useAccess } from '~/providers/capabilities-provider'
 import { NameFieldInput, type NameValue } from './name-field-input'
 import { getSelectConfig, SelectFieldInput } from './select-input-field'
 
@@ -159,6 +160,17 @@ export function FieldInputAdapter({
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [createEntityDefinitionId, setCreateEntityDefinitionId] = useState<string | null>(null)
 
+  // Inline create writes a record of the TARGET definition, so it needs write on
+  // THAT def — not on the record being edited. Picking an existing target only
+  // needs read, so a `ticket: Read` member keeps the picker and loses "Create
+  // Ticket" inside it. Same rule and same helper as `RelationshipInputField`,
+  // which the property panel uses; this branch is what the record dialog, bulk
+  // update, workflow node panels and the kbar create page go through.
+  //
+  // Read at the top because the RELATIONSHIP case below is inside a `switch` —
+  // a hook may not be called from there.
+  const { canEditEntity } = useAccess()
+
   /**
    * Adapter for NodeInputProps onChange
    */
@@ -221,6 +233,10 @@ export function FieldInputAdapter({
       // Use allowMultiple if provided (from operator), otherwise derive from relationship type
       const multi = allowMultiple ?? isMultiRelationship(relationship.relationshipType)
 
+      // `getRelatedEntityDefinitionId` returns the canonical def id, which is
+      // what `canEditEntity` requires — a slug always resolves to `false`.
+      const canInlineCreate = canEditEntity(entityDefinitionId)
+
       const recordIds = Array.isArray(value) ? value : value ? [value] : []
 
       /**
@@ -255,7 +271,10 @@ export function FieldInputAdapter({
             multi={multi}
             placeholder={placeholder}
             disabled={disabled}
-            onCreate={handleOpenCreate}
+            // Withholding the handler is what hides the row: the picker renders
+            // "Create …" on the handler's presence alone
+            // (`pickers/multi-select-picker.tsx`).
+            onCreate={canInlineCreate ? handleOpenCreate : undefined}
             excludeIds={fieldOptions?.excludeIds}
             showDefinitionIcon={fieldOptions?.showDefinitionIcon}
             triggerProps={triggerProps}
@@ -263,7 +282,9 @@ export function FieldInputAdapter({
             onOpenChange={onOpenChange}
             shouldPreventDismiss={shouldPreventDismiss}
           />
-          {createDialogOpen && createEntityDefinitionId && (
+          {/* Belt and braces: the dialog is a second way in, so it is gated too
+              rather than relying on the trigger being hidden. */}
+          {canInlineCreate && createDialogOpen && createEntityDefinitionId && (
             <RecordEditorDialog
               open={createDialogOpen}
               onOpenChange={setCreateDialogOpen}


### PR DESCRIPTION
The relationship picker offered "Create <Thing>" to members with no write on the target definition. Clicking it opened the editor; the save then 403'd.

## Where it came from

The create row renders on the **presence of an `onCreate` handler alone** — `pickers/multi-select-picker.tsx:608,628`:

```tsx
{!isLoading && (canManage || onCreate || onBrowse) && (
  …
  {onCreate && (
    <CommandItem onSelect={onCreate} …>
```

`FieldInputAdapter` passed one unconditionally (`fields/inputs/field-input-adapter.tsx:258` before this change) and never imported `useAccess`. The chain is `FieldInputAdapter` → `MultiRelationInput` → `MultiSelectPicker`.

The sibling input already gets it right — `fields/inputs/relationship-input-field.tsx:112`:

```ts
// Inline create writes a record of the TARGET definition, so it needs write on
// that def — not on the record being edited.
const canInlineCreate = canEditEntity(relatedEntityDefinitionId)
```

That one also passes `canCreate` to `RecordPickerContent`, whose gate is `canCreate && onCreate` (`record-picker-content.tsx:394`). So the **property panel was never affected** — only the surfaces that go through `FieldInputAdapter`: the record create/edit dialog, bulk update, workflow node panels, the kbar create page, and condition/filter builders.

## Why here and not in `MultiRelationInput`

Gating inside `MultiRelationInput` would cover seven consumers instead of one, which was the first instinct — but it breaks two of them. `chat-widget/ui/settings/sections/general-section.tsx:230` passes `entityDefinitionId='inbox'` and `ai-section.tsx:163` passes `'kb'`. Those are **slugs**, and `canEditEntity`'s contract is explicit that it takes the canonical `entityDefinitionId`, so both would resolve `false` and silently lose a create button they should keep (inbox and KB creation are governed by their own feature UI, not by a record-def write gate).

`FieldInputAdapter` derives its id with `getRelatedEntityDefinitionId(relationship)` — the same helper backing the working gate in `RelationshipInputField` — so the id is canonical and the check is sound.

The other five `MultiRelationInput` consumers (evals, dispatch board, two workflow inputs) pass their own `onCreate` and are still ungated. Out of scope here; worth a follow-up pass, but each needs its id checked for the same slug problem first.

## Change

- `useAccess()` at the top of the component — the RELATIONSHIP branch is inside a `switch`, so the hook can't be called from there.
- `onCreate={canInlineCreate ? handleOpenCreate : undefined}`.
- `canInlineCreate &&` on the `RecordEditorDialog` too, so the dialog isn't reachable if the trigger is ever re-exposed.

## Testing

- Full `apps/web` vitest: **3059 passing**. 15 failures in `src/server/api/routers/file-attachment-permission.test.ts` — **pre-existing**, verified by running that file on clean `main` with this change absent: same 15 fail. Unrelated to this change (server-side attachment permissions).
- `tsc --noEmit` in `apps/web` — the same 16 pre-existing errors, none in the touched file.
- Biome clean.
- Every `FieldInputAdapter` consumer resolves under `app/(protected)/layout.tsx`, which mounts `CapabilitiesProvider` — `useAccess` throws outside it, so that was worth confirming rather than assuming.

Not verified in a browser: that the row is actually absent for a member with read-but-not-write on the target def.
