### PR TITLE
fix(fields): correct update capabilities on ticket type and dialogs

### DIFF
--- a/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
@@ -51,13 +51,28 @@ export function BulkUpdateEntityInstanceDialog({
   // Get resource definition with fields
   const { resource } = useResource(entityDefinitionId)
 
-  // Get editable fields (exclude system fields like id, createdAt, updatedAt)
+  // Get editable fields (exclude system fields like id, createdAt, updatedAt).
+  //
+  // BOTH capabilities, and each for its own reason. `updatable` because every
+  // write this dialog makes is an update, so a create-only field
+  // (`ticket_number`, stock-movement columns, connector-owned columns) must not
+  // be offered — the table cell and property panel already refuse those, and the
+  // write path does not check the capability itself, so this filter is what
+  // actually holds. `creatable` because it is the closest proxy for "writable
+  // through the generic `fieldValue.set` path this dialog uses": an edit-only
+  // system field (`thread_status`, `subject`) lives in a `dbColumn` on its host
+  // table, and that path writes a `FieldValue` row while reads project the
+  // column — the edit would appear to save and silently vanish, besides skipping
+  // the events, counters and provider push its own service owns.
   const editableFields = useMemo(() => {
     if (!resource) return []
     return resource.fields
       .filter(
         (f): f is typeof f & { id: string } =>
-          f.capabilities?.creatable !== false && !f.capabilities?.hidden && !!f.id
+          f.capabilities?.creatable !== false &&
+          f.capabilities?.updatable !== false &&
+          !f.capabilities?.hidden &&
+          !!f.id
       )
       .sort((a, b) => (a.sortOrder ?? '').localeCompare(b.sortOrder ?? ''))
   }, [resource])

--- a/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
@@ -165,6 +165,17 @@ export function EntityInstanceForm({
   // `sortFieldsWithMetadataLast` — so no re-sort here; re-sorting by raw
   // `sortOrder` would discard that partition and make this surface define
   // "baseline" differently from the property panel.
+  //
+  // `creatable` is the pool floor, NOT because this list is create-only — it also
+  // feeds edit mode — but because it is the closest proxy for "writable through
+  // the generic `fieldValue.set` path this dialog uses". An edit-only system
+  // field (`thread_status`, `subject`) has a `dbColumn` on its host table, and
+  // that path writes a `FieldValue` row while reads project the column — so the
+  // edit would appear to save and silently vanish, on top of skipping the
+  // lifecycle events, counters and provider push that `ThreadMutationService`
+  // owns. Those fields are updatable via their own routers; they are simply not
+  // this dialog's to write. Narrowing FURTHER per mode happens in
+  // `editableFields` below.
   const allEditableFields = useMemo(() => {
     if (!resource) return []
     return resource.fields.filter(
@@ -350,9 +361,21 @@ export function EntityInstanceForm({
   }, [draft, allEditableFields, fieldIds])
 
   // Get editable fields: config mode shows all from draft, normal mode shows visible
+  // fields the CURRENT mode can actually write.
+  //
+  // The mode split matters: this dialog used to gate on `creatable` alone, so a
+  // create-only field stayed editable while EDITING, and the write went through —
+  // the write path does not check `capabilities.updatable` (see
+  // `field-hooks/register-hooks.ts`), so the flag is only ever as strong as the
+  // surface honouring it. That put the dialog at odds with the table cell,
+  // property panel and kanban card, which all refuse a field with
+  // `updatable === false`.
   const editableFields = useMemo(() => {
-    return isDraftMode ? configModeFields : getVisibleFields()
-  }, [isDraftMode, configModeFields, getVisibleFields])
+    if (isDraftMode) return configModeFields
+    return getVisibleFields().filter((f) =>
+      isEditing ? f.capabilities?.updatable !== false : f.capabilities?.creatable !== false
+    )
+  }, [isDraftMode, configModeFields, getVisibleFields, isEditing])
 
   /**
    * The groups the list renders sections from: the unsaved draft's in config

--- a/packages/lib/src/data-migrations/migrations/078-ticket-type-updatable.ts
+++ b/packages/lib/src/data-migrations/migrations/078-ticket-type-updatable.ts
@@ -1,0 +1,96 @@
+// packages/lib/src/data-migrations/migrations/078-ticket-type-updatable.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-078')
+
+/**
+ * The seeded help text, cleared only where it still matches verbatim so an
+ * org that somehow re-worded it keeps its own copy.
+ */
+const STALE_DESCRIPTION = 'Ticket type cannot be changed after creation'
+
+/**
+ * Make a ticket's `type` editable after creation.
+ *
+ * **Why the registry flag alone is not enough.** `TICKET_FIELDS.type` shipped
+ * with `updatable: false` in the initial commit, and the entity seeder maps that
+ * capability onto the `CustomField.isUpdatable` column
+ * (`entity-seeder/utils.ts` → `mapCapabilities`). At read time
+ * `mergeSystemAndCustomFields` spreads the **DB** row's capabilities and
+ * overrides only `hidden` from the static registry — `updatable` is projected
+ * straight from `isUpdatable`. So flipping the registry only reaches orgs seeded
+ * *after* the change; `create-fields.ts` inserts and never updates, so a re-seed
+ * does not catch existing orgs up either. This pass flips the column.
+ *
+ * **Why it was wrong.** The flag was only ever advisory: the write path does not
+ * read `capabilities.updatable` (see `field-hooks/register-hooks.ts`), `ticket`
+ * is commented out of `CRUD_RESOURCE_CONFIGS`, and the record dialog filters its
+ * field list on `creatable` — so the dialog has always written `type` on edit
+ * while the table cell, property panel and kanban card refused to. The intent is
+ * that applying a different type to an existing ticket is allowed, so the flag
+ * goes rather than the four surfaces that honour it.
+ *
+ * **Scoped to the system field.** Matched on `systemAttribute = 'ticket_type'`,
+ * which is the seeded identity of this field on every org's `ticket` def. A
+ * business's own SINGLE_SELECT named "Type" carries a NULL `systemAttribute` and
+ * is untouched, as is `stock_movement_type`, whose immutability is a separate
+ * question — a movement's type is arguably the record.
+ *
+ * **Cache clear is required and is ours.** Unlike the entity-migration runner,
+ * the data-migration runner does not invalidate org caches, and `customFields` /
+ * `resources` are cached per org. Without the flush, every org already holding a
+ * warm blob keeps serving `updatable: false` until the key expires.
+ *
+ * **The help text goes too.** `mergeSystemAndCustomFields` does not re-take
+ * `description` from the static registry either, so the seeded
+ * "Ticket type cannot be changed after creation" string lives in the DB and
+ * renders next to the field. Dropping it from `TICKET_FIELDS` alone would leave
+ * every existing org reading a caption that contradicts the control beside it.
+ *
+ * Idempotent: the `WHERE` only matches rows still sitting at `false` or still
+ * carrying the stale caption, so a re-run after a partial failure updates
+ * nothing. Small and unbatched on purpose — this is one row per organization,
+ * not a table scan.
+ */
+export const migration078TicketTypeUpdatable: DataMigrationDef = {
+  id: '078-ticket-type-updatable',
+  description: 'Allow a ticket’s type to be changed after creation (CustomField.isUpdatable)',
+  async run(db: Database): Promise<void> {
+    const result = await db.execute<{ organizationId: string }>(sql`
+      UPDATE "CustomField"
+      SET
+        "isUpdatable" = true,
+        "description" = CASE
+          WHEN "description" = ${STALE_DESCRIPTION} THEN NULL
+          ELSE "description"
+        END,
+        "updatedAt" = now()
+      WHERE "systemAttribute" = 'ticket_type'
+        AND ("isUpdatable" = false OR "description" = ${STALE_DESCRIPTION})
+      RETURNING "organizationId"
+    `)
+
+    const organizationIds = [...new Set(result.rows.map((r) => r.organizationId))]
+
+    if (organizationIds.length > 0) {
+      // Lazy so the data-migration graph does not pull the cache barrel (and its
+      // Redis client) into every migration run.
+      const { getOrgCache } = await import('../../cache')
+      const cache = getOrgCache()
+      await Promise.all(
+        organizationIds.map((organizationId) =>
+          cache.invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+        )
+      )
+    }
+
+    logger.info('Ticket type is now updatable', {
+      fieldsUpdated: result.rows.length,
+      organizationsAffected: organizationIds.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/migrations/079-enrichment-fields-backend-owned.ts
+++ b/packages/lib/src/data-migrations/migrations/079-enrichment-fields-backend-owned.ts
@@ -1,0 +1,74 @@
+// packages/lib/src/data-migrations/migrations/079-enrichment-fields-backend-owned.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-079')
+
+/** The company enrichment markers, written by the enrichment job and nothing else. */
+const BACKEND_OWNED_ATTRIBUTES = ['company_enriched_at', 'company_enrichment_status']
+
+/**
+ * Mark the company enrichment fields as not user-updatable.
+ *
+ * **This changes nothing visible today, on purpose.** Both fields carry
+ * `hidden: true` in `COMPANY_FIELDS`, and `hidden` is the one capability
+ * `mergeSystemAndCustomFields` re-takes from the static registry — so they are
+ * already filtered off every surface (the dialogs gate on
+ * `!capabilities?.hidden`) no matter what the DB row says. This closes the gap
+ * underneath that: `isUpdatable` is `true` on every existing row, and `updatable`
+ * IS read from the DB, so the day someone unhides these to show enrichment state
+ * on a company record they would come back user-editable in every org that
+ * already exists.
+ *
+ * That is exactly how ticket `type` went wrong (`078`): a capability that only
+ * ever lived in one place, disagreed with the other, and was never enforced by
+ * the write path. The enrichment job is unaffected — the write path does not read
+ * `capabilities.updatable` at all (`field-hooks/register-hooks.ts`), so this
+ * constrains the UI and nothing else.
+ *
+ * **Not folded into `078`.** That migration is already recorded as applied in
+ * environments that have booted since it landed, and the runner skips an applied
+ * id — extending it in place would silently never run there.
+ *
+ * Scoped by `systemAttribute`, so a business's own field named "Enriched At"
+ * (NULL `systemAttribute`) is untouched. Idempotent: the `WHERE` only matches
+ * rows still sitting at `true`.
+ */
+export const migration079EnrichmentFieldsBackendOwned: DataMigrationDef = {
+  id: '079-enrichment-fields-backend-owned',
+  description: 'Mark company enrichment markers as backend-owned (CustomField.isUpdatable = false)',
+  async run(db: Database): Promise<void> {
+    const result = await db.execute<{ organizationId: string }>(sql`
+      UPDATE "CustomField"
+      SET "isUpdatable" = false, "updatedAt" = now()
+      WHERE "systemAttribute" IN (${sql.join(
+        BACKEND_OWNED_ATTRIBUTES.map((attribute) => sql`${attribute}`),
+        sql`, `
+      )})
+        AND "isUpdatable" = true
+      RETURNING "organizationId"
+    `)
+
+    const organizationIds = [...new Set(result.rows.map((r) => r.organizationId))]
+
+    if (organizationIds.length > 0) {
+      // Lazy so the data-migration graph does not pull the cache barrel (and its
+      // Redis client) into every migration run.
+      const { getOrgCache } = await import('../../cache')
+      const cache = getOrgCache()
+      await Promise.all(
+        organizationIds.map((organizationId) =>
+          cache.invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+        )
+      )
+    }
+
+    logger.info('Company enrichment markers are now backend-owned', {
+      fieldsUpdated: result.rows.length,
+      organizationsAffected: organizationIds.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -42,6 +42,8 @@ import { migration072MailFiltersLimit } from './migrations/072-mail-filters-limi
 import { migration073BackfillBulkMailFields } from './migrations/073-backfill-bulk-mail-fields'
 import { migration076MailCategoryRework } from './migrations/076-mail-category-rework'
 import { migration077BackfillUnsentThreadDates } from './migrations/077-backfill-unsent-thread-dates'
+import { migration078TicketTypeUpdatable } from './migrations/078-ticket-type-updatable'
+import { migration079EnrichmentFieldsBackendOwned } from './migrations/079-enrichment-fields-backend-owned'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -110,6 +112,8 @@ function buildRegistry(): DataMigrationDef[] {
     // materialize.
     migration076MailCategoryRework,
     migration077BackfillUnsentThreadDates,
+    migration078TicketTypeUpdatable,
+    migration079EnrichmentFieldsBackendOwned,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/resources/hooks/ticket-hooks.ts
+++ b/packages/lib/src/resources/hooks/ticket-hooks.ts
@@ -270,7 +270,14 @@ const publishAssigneeChangeEvent: SystemHook = async ({
  * Ticket hooks registry.
  *
  * Note: No validation hooks - handled by field options in entity-seeder.
- * Note: No prevent-update hooks - handled by field capabilities (isUpdatable: false).
+ *
+ * Note: no field here is update-locked. `ticket_type` used to carry
+ * `updatable: false`, but that flag was never read by the write path
+ * (see `field-hooks/register-hooks.ts`) — it only ever disabled UI affordances,
+ * and inconsistently at that. Changing a ticket's type is now allowed outright
+ * (data migration `078-ticket-type-updatable`). If a field ever does need to be
+ * genuinely immutable, it needs a hook here — the capability flag alone will not
+ * stop an API, workflow-node, or Kopilot write.
  */
 export const TICKET_HOOKS: SystemHookRegistry = {
   // Auto-generate ticket number on create

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -430,7 +430,11 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
       filterable: false,
       sortable: false,
       creatable: false,
-      updatable: true,
+      // Written by the enrichment job only. The write path does not read this
+      // flag, so the backend keeps writing — it is the UI surfaces that honour
+      // it. `hidden` already keeps the field off every surface; this makes the
+      // declaration true so unhiding it later cannot silently make it editable.
+      updatable: false,
       configurable: false,
       hidden: true,
     },
@@ -459,7 +463,8 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
       filterable: false,
       sortable: false,
       creatable: false,
-      updatable: true,
+      // Backend-owned lifecycle marker — see `enrichedAt` above.
+      updatable: false,
       configurable: false,
       hidden: true,
     },

--- a/packages/lib/src/resources/registry/resources/ticket-fields.ts
+++ b/packages/lib/src/resources/registry/resources/ticket-fields.ts
@@ -100,12 +100,11 @@ export const TICKET_FIELDS: Record<string, ResourceField> = {
       filterable: true,
       sortable: true,
       creatable: true,
-      updatable: false, // Type cannot be changed after creation
+      updatable: true,
       required: true,
       configurable: false,
     },
     placeholder: 'Select ticket type',
-    description: 'Ticket type cannot be changed after creation',
     defaultValue: 'GENERAL',
   },
 


### PR DESCRIPTION
## Problem

Ticket `type` could not be changed after creation — but only on *some* surfaces. Reported as "type is marked readonly in the table and field panel, but I can still edit it in the record dialog."

`TICKET_FIELDS.type` shipped with `updatable: false` in the initial commit (2025-12-28). The flag turned out to be advisory only:

- the write path does not read `capabilities.updatable` (`field-hooks/register-hooks.ts`)
- `ticket` is commented out of `CRUD_RESOURCE_CONFIGS`
- the record dialog filtered its field list on `creatable` alone

So four surfaces (table cell, property panel, kanban card, paste/fill) enforced an invariant that the record dialog ignored and the server never knew about — and the dialog's write **landed**. The divergence opened on 2026-01-09 when the property panel became the first surface to honour the flag; the dialog was simply never included.

Reclassifying a ticket is normal helpdesk work, so the flag goes rather than the four surfaces.

## Why a data migration is required

`updatable` is read from `CustomField.isUpdatable`, not the registry — `mergeSystemAndCustomFields` re-takes only `hidden` from the static file — and `create-fields.ts` is insert-only. The registry edit alone reaches no existing org.

`078` flips the column and clears the seeded `"Ticket type cannot be changed after creation"` caption, which also lives in the DB and would otherwise contradict the control next to it.

## Also in this PR

**Company enrichment markers (`079`).** `enrichedAt` / `enrichmentStatus` are written by the enrichment job but declared `updatable: true`. Both are `hidden`, so nothing renders them today — which is precisely the trap ticket type fell into, one unhide away from being user-editable in every existing org. The write path ignores the flag, so the job is unaffected.

**Both entity-instance dialogs now filter on `creatable && updatable`.**

- `updatable` is the fix — create-only fields (`ticket_number`, stock-movement columns, `work_order.jobType`, connector-owned columns) were editable in the edit and bulk dialogs while every other surface refused them.
- `creatable` is kept deliberately, now with a stated reason: it is the closest proxy for "writable through the generic `fieldValue.set` path these dialogs use". An edit-only system field (`thread_status`, `subject`) carries a `dbColumn` on a host table that path never writes, so the edit would appear to save and silently vanish, besides skipping the lifecycle events, counters and provider push `ThreadMutationService` owns.

Net effect for users: ticket type becomes editable. Nothing new is exposed.

## Verification

- Both migrations applied on dev and confirmed against real rows (29 orgs each).
- `078` initially ran before the caption clause existed, so dev is half-applied and still shows the stale caption — cosmetic, and a rerun clears it. Fresh environments get the complete version.
- `079` failed on first run (`= ANY(${array})` binds as a tuple, not a Postgres array — `42809`) and was fixed to `IN (…)` via `sql.join` before re-running clean. Worth noting a `failed` ledger row halts the whole run and never auto-retries.
- `apps/web` typecheck ratchet: no new errors. `packages/lib` typecheck clean on changed files. Biome clean. `data-migrations.test.ts` 10/10.

## Not addressed

- No server-side enforcement of `capabilities.updatable` exists at all. Moot for ticket type now, but any field still carrying the flag is UI-gated only.
- Ticket type *options* remain non-org-editable (`configurable: false`, values from the static `TicketType` list).
- `BUILT_IN_FIELDS` is an empty registry, making the built-in handler branch in `field-value-mutations.ts` dead code.
- Threads deliberately untouched — `thread` defs are `isVisible: false` in every org, so no generic surface reaches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)