### PR TITLE
fix: green the test suite and close the typecheck gaps outside CI

### DIFF
--- a/apps/web/src/server/api/routers/file-attachment-permission.test.ts
+++ b/apps/web/src/server/api/routers/file-attachment-permission.test.ts
@@ -105,7 +105,17 @@ vi.mock('drizzle-orm', () => ({
   isNull: vi.fn((a: unknown) => ({ op: 'isNull', a })),
 }))
 
-vi.mock('@auxx/lib/cache', () => ({ getOrgCache: vi.fn() }))
+// `getOrgCache()` must return a usable cache, not a bare `vi.fn()`:
+// `protectedProcedure` runs `organizationDisabledMiddleware`, which reads
+// `getOrRecompute(orgId, ['orgProfile'])` before any router code. A stub that
+// resolves to `undefined` turns every expected 4xx into an INTERNAL_SERVER_ERROR
+// and the suite stops asserting anything about permissions.
+vi.mock('@auxx/lib/cache', () => ({
+  getOrgCache: () => ({
+    get: vi.fn(async () => ({})),
+    getOrRecompute: vi.fn(async () => ({ orgProfile: {}, features: {} })),
+  }),
+}))
 vi.mock('@auxx/lib/members', () => ({ isOwner: vi.fn() }))
 vi.mock('@auxx/lib/utils/rate-limiter/redis-rate-limiter', () => ({
   RedisRateLimiter: class {

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -16,5 +16,9 @@
     //   "@auxx/workflow-nodes": ["../../packages/workflow-nodes"]
     // }
   },
-  "include": ["src/**/*.ts", "*.ts"]
+  "include": ["src/**/*.ts", "*.ts"],
+  // `vitest.config.ts` imports the repo-root `vitest.alias.ts`, which sits above
+  // this package's rootDir (TS6059/TS6307). apps/api and apps/kb keep their
+  // vitest configs out of the program for the same reason.
+  "exclude": ["node_modules", "dist", "vitest.config.ts"]
 }

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,6 +1,7 @@
 // apps/worker/vitest.config.ts
 
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   test: {
@@ -12,5 +13,12 @@ export default defineConfig({
       'src/**/__tests__/**/*.{js,mjs,cjs,ts,mts,cts}',
     ],
     exclude: ['node_modules/**', 'dist/**', '**/*.config.*'],
+  },
+
+  // Without this, Vite resolves `@auxx/*` through the `import` condition to
+  // `dist/`, which does not exist on a cold CI checkout — `maintenance-worker`
+  // died on `Failed to resolve entry for package "@auxx/deployment"`.
+  resolve: {
+    alias: auxxSourceAlias,
   },
 })

--- a/packages/chat/src/views/conversation/composer/autosize-textarea.tsx
+++ b/packages/chat/src/views/conversation/composer/autosize-textarea.tsx
@@ -124,11 +124,17 @@ function calculateHeight(
 
 // `JSX.HTMLAttributes` is the element-agnostic base and has no `value` — the
 // textarea-specific attribute set is what carries `value` / `rows` / `wrap`.
-interface AutosizeTextareaProps extends Omit<JSX.IntrinsicElements['textarea'], 'style'> {
+//
+// `value` is then re-declared rather than inherited: how the intrinsic type
+// resolves through `forwardRef`'s `PropsWithoutRef` is not stable here (a
+// byte-identical copy of `composer.tsx` typechecks while the original does not),
+// and the measurement code reads `value` as a plain string anyway.
+interface AutosizeTextareaProps extends Omit<JSX.IntrinsicElements['textarea'], 'style' | 'value'> {
   minRows?: number
   maxRows?: number
   cacheMeasurements?: boolean
   style?: CSSProperties
+  value?: string
 }
 
 export const AutosizeTextarea = forwardRef<HTMLTextAreaElement, AutosizeTextareaProps>(

--- a/packages/lib/src/data-migrations/migrations/076-mail-category-rework.test.ts
+++ b/packages/lib/src/data-migrations/migrations/076-mail-category-rework.test.ts
@@ -878,6 +878,9 @@ describe('migration076MailCategoryRework', () => {
     expect(migration076MailCategoryRework.id).toBe('076-mail-category-rework')
   })
 
+  // The registry import pulls in every migration module and its dependencies —
+  // ~6s warm, past the 10s project default on a cold runner. The budget is for
+  // that one import, not for the assertions.
   it('is registered exactly once', async () => {
     const { ALL_DATA_MIGRATIONS } = await import('../registry')
     const matches = ALL_DATA_MIGRATIONS.filter((m) => m.id === migration076MailCategoryRework.id)
@@ -885,5 +888,5 @@ describe('migration076MailCategoryRework', () => {
     // It must sort after the entity migration that materializes the field.
     expect(ALL_DATA_MIGRATIONS.some((m) => m.id === '075-tag-template-key')).toBe(true)
     expect('076-mail-category-rework' > '075-tag-template-key').toBe(true)
-  })
+  }, 30_000)
 })

--- a/packages/lib/src/events/handlers/create-event-job.ts
+++ b/packages/lib/src/events/handlers/create-event-job.ts
@@ -2,14 +2,12 @@
 
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import type { Job } from 'bullmq'
 import type { AuxxEvent } from '../types'
 import { THREAD_REALTIME_EVENT_TYPES } from './publish-thread-event-to-realtime'
 
 const logger = createScopedLogger('create-event-job')
 
-export const createEventJob = async (job: Job<AuxxEvent>) => {
-  const event = job.data
+export const createEventJob = async ({ data: event }: { data: AuxxEvent }) => {
   // Thread lifecycle events are persisted by `publishThreadEventToRealtime`
   // so the realtime payload can carry the row id + createdAt for client-side
   // dedupe. Skip here to avoid double-insert.

--- a/packages/lib/src/events/handlers/publish-event-job.ts
+++ b/packages/lib/src/events/handlers/publish-event-job.ts
@@ -1,7 +1,6 @@
 // packages/lib/src/events/handlers/publish-event-job.ts
 
 import { createScopedLogger } from '@auxx/logger'
-import type { Job } from 'bullmq'
 import { handleFieldTriggerJob } from '../../field-hooks/field-hook-job'
 import { getQueue } from '../../jobs/queues'
 import { Queues } from '../../jobs/queues/types'
@@ -264,8 +263,7 @@ async function runGate(gate: GateHandler<AuxxEvent>[], event: AuxxEvent): Promis
   return suppressed
 }
 
-export const publishEventJob = async (job: Job<AuxxEvent>) => {
-  const event = job.data
+export const publishEventJob = async ({ data: event }: { data: AuxxEvent }) => {
   // The map is keyed per event type, so indexing it with a union `event.type`
   // yields a union of unrelated handler-array types. Widen once, here.
   const entry = EventHandlers[event.type] as

--- a/packages/lib/src/events/handlers/publish-to-analytics-job.ts
+++ b/packages/lib/src/events/handlers/publish-to-analytics-job.ts
@@ -1,7 +1,5 @@
 // packages/lib/src/events/handlers/publish-to-analytics-job.ts
-// packages/lib/src/events/handlers/publish-to-analytics-job.ts
 import { configService } from '@auxx/credentials'
-import type { Job } from 'bullmq'
 import { createScopedLogger } from '../../logger'
 import { getPostHogClient } from '../../posthog/posthog-client'
 import type { AuxxEvent } from '../types'
@@ -24,8 +22,7 @@ function resolveDistinctId(data: Record<string, unknown>): string | null {
 }
 
 /** Publishes AuxxEvents to PostHog for analytics tracking. */
-export const publishToAnalyticsJob = async (job: Job<AuxxEvent>) => {
-  const event = job.data
+export const publishToAnalyticsJob = async ({ data: event }: { data: AuxxEvent }) => {
   const d = event.data as Record<string, unknown>
 
   const distinctId = resolveDistinctId(d)

--- a/packages/lib/src/mail-filters/evaluate.test.ts
+++ b/packages/lib/src/mail-filters/evaluate.test.ts
@@ -264,6 +264,9 @@ describe('invariant 9 — what body conditions actually depend on', () => {
    * `Thread.searchText`, so no ingest ORDERING affects it — which is what makes
    * `body` safe on a brand-new thread.
    */
+  // `importActual` loads the REAL builder and the schema behind it — ~4.5s warm,
+  // past the 10s project default once the rest of the suite is competing for the
+  // machine. The budget is for that import, not for the three assertions.
   it('compiles `body contains` to a correlated EXISTS, with nothing dropped', async () => {
     const { buildConditionGroupsQueryWithDiagnostics } = await vi.importActual<
       typeof import('../mail-query/condition-query-builder')
@@ -274,7 +277,7 @@ describe('invariant 9 — what body conditions actually depend on', () => {
     expect(built.droppedConditions).toEqual([])
     expect(built.allConditionsDropped).toBe(false)
     expect(render(built.sql)).toMatch(/exists/i)
-  })
+  }, 30_000)
 
   /**
    * The subquery's target is not observable from a rendered clause here — the

--- a/packages/lib/src/members/member-queries.ts
+++ b/packages/lib/src/members/member-queries.ts
@@ -2,7 +2,7 @@
 
 import { type Database, database as defaultDb, schema } from '@auxx/database'
 import type { OrganizationMemberInfo, OrganizationRole } from '@auxx/database/types'
-import { and, asc, count, eq } from 'drizzle-orm'
+import { and, asc, count, eq, getTableColumns } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 
 /** Find membership for a user within an organization (uses org cache) */
@@ -168,22 +168,27 @@ export async function getActiveMemberCount(
  * name then email.
  */
 export async function getOrganizationMembers(organizationId: string, db: Database = defaultDb) {
-  const members = await db.query.OrganizationMember.findMany({
-    where: eq(schema.OrganizationMember.organizationId, organizationId),
-    with: {
+  // An INNER JOIN, not `findMany({ with: { user: { where } } })`: Drizzle's
+  // relational config for a TO-ONE relation has no `where` key, so the filter
+  // that used to sit there was dropped silently and SYSTEM/AGENT users were
+  // listed as ordinary members.
+  const members = await db
+    .select({
+      ...getTableColumns(schema.OrganizationMember),
       user: {
-        columns: {
-          id: true,
-          name: true,
-          email: true,
-          image: true,
-        },
-        // Exclude system users from member lists
-        where: eq(schema.User.userType, 'USER'),
+        id: schema.User.id,
+        name: schema.User.name,
+        email: schema.User.email,
+        image: schema.User.image,
       },
-    },
-    orderBy: [asc(schema.OrganizationMember.role)],
-  })
+    })
+    .from(schema.OrganizationMember)
+    .innerJoin(
+      schema.User,
+      and(eq(schema.User.id, schema.OrganizationMember.userId), eq(schema.User.userType, 'USER'))
+    )
+    .where(eq(schema.OrganizationMember.organizationId, organizationId))
+    .orderBy(asc(schema.OrganizationMember.role))
 
   const roleOrder: Record<OrganizationRole, number> = { OWNER: 0, ADMIN: 1, USER: 2 }
   return members.sort((a, b) => {

--- a/packages/lib/src/signals/email/__tests__/tracking-tokens.test.ts
+++ b/packages/lib/src/signals/email/__tests__/tracking-tokens.test.ts
@@ -60,7 +60,13 @@ describe('tracking-tokens', () => {
 
   it('fails verification for a tampered token', async () => {
     const token = await issueOpenToken({ organizationId: 'org_1', messageId: 'msg_1' })
-    const tampered = `${token.slice(0, -2)}zz`
+    // Flip the FIRST character of the signature segment. The last character
+    // carries only 2 significant bits of a 32-byte HS256 signature (43 base64url
+    // chars encode 258 bits), so several values there decode to identical bytes
+    // and "tampering" with it hands the verifier a still-valid token.
+    const [header, payload, signature] = token.split('.')
+    const flipped = `${signature.startsWith('A') ? 'B' : 'A'}${signature.slice(1)}`
+    const tampered = `${header}.${payload}.${flipped}`
 
     const result = await verifyTrackingToken(tampered)
     expect(Result.isOk(result)).toBe(false)

--- a/packages/test-utils/vitest.config.ts
+++ b/packages/test-utils/vitest.config.ts
@@ -1,20 +1,28 @@
 // packages/test-utils/vitest.config.ts
-import path from 'path'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   test: {
     name: 'integration',
     environment: 'node',
 
-    // Find .test.ts files across packages that need real DB
-    include: [
-      './src/**/*.test.ts',
-      '../../packages/database/src/**/*.test.ts',
-      '../../packages/services/src/**/*.test.ts',
-      '../../apps/web/src/server/api/**/*.test.ts',
-      '../../apps/api/src/**/*.test.ts',
-    ],
+    // This project's own suites only.
+    //
+    // It used to glob `packages/database`, `packages/services`,
+    // `apps/web/src/server/api` and `apps/api` wholesale, on the theory that
+    // those are "tests that need a real DB". They are not — every one of those
+    // paths is already owned by its own project (`database`, `services`, `web`,
+    // `api`), and re-collecting them here ran ordinary mock-based unit tests a
+    // second time without their `~` alias, their setup files or their mocks.
+    // That produced 148 failures in a full local run: `Cannot find module
+    // '~/server/...'`, `Missing "./..." specifier in "@auxx/lib"`, files
+    // reporting `(0 test)`, plus real-DB timeouts on suites never written for
+    // one. CI does not run this project, so none of it was visible.
+    //
+    // Real DB-backed tests use the `.int.test.ts` suffix and belong to
+    // `packages/lib/vitest.integration.config.ts` (`lib-integration`).
+    include: ['./src/**/*.test.ts'],
     exclude: ['node_modules/**', 'dist/**'],
 
     // Global setup/teardown for DB initialization
@@ -32,9 +40,8 @@ export default defineConfig({
     setupFiles: ['./src/setup/per-test-setup.ts'],
   },
 
+  // The shared source map, not a one-package subset — see `vitest.alias.ts`.
   resolve: {
-    alias: {
-      '@auxx/logger': path.resolve(__dirname, '../logger/src'),
-    },
+    alias: auxxSourceAlias,
   },
 })


### PR DESCRIPTION
CI's Test job has been red on `main`. This gets it green, and fixes three type errors that live outside CI's typecheck matrix.

```
before   163 failed | 11114 passed   (49 files)
after      0 failed | 11088 passed   (855 files, 4 skipped)
```

## The one behavior change

`getOrganizationMembers` had its "exclude system users" filter inside a to-one `with` on a relational query. Drizzle's config for a to-one relation has no `where` key, so it was **dropped silently** — SYSTEM and AGENT users have been showing up in the org members list and the admin panel. It is now an INNER JOIN that applies the filter in SQL.

This is a live behavior change and the function has **no test coverage**, so it is worth a look before merging. The same dead `where` also broke the inferred type, which is why `apps/kb` and `apps/build` reported 5 errors on this file while `web` and `lib` did not.

## What CI was red on (17 failures, 4 files)

| File | Cause |
|---|---|
| `file-attachment-permission.test.ts` | Cache stub was a bare `vi.fn()`, so `getOrgCache().getOrRecompute()` threw in `organizationDisabledMiddleware`. All 15 expected `FORBIDDEN`/`NOT_FOUND`/`BAD_REQUEST` came back `INTERNAL_SERVER_ERROR` — the permission assertions were passing through without testing anything. |
| `maintenance-worker.test.ts` | `apps/worker` was the only project config without `auxxSourceAlias`, so Vite resolved `@auxx/deployment` through the `import` condition to a `dist/` that does not exist on a cold checkout — exactly what `vitest.alias.ts` documents. |
| `076-mail-category-rework.test.ts` | Whole budget spent on `await import('../registry')` — 6.0s warm against a 10s default. |
| `tracking-tokens.test.ts` | `token.slice(0, -2) + 'zz'` is a no-op whenever the signature already ends that way (~1 run in 4096). |

`mail-filters/evaluate.test.ts` was in the same flaky tail (4.5s on one `importActual`) and got the same explicit timeout.

On the token test: flipping the **last** character is not a fix either — a 32-byte HS256 signature is 43 base64url chars encoding 258 bits, so the final character has 2 slack bits and several values decode to identical bytes. It now flips the first character of the signature segment.

## The 148 local-only failures

`packages/test-utils/vitest.config.ts` globbed `apps/web/src/server/api`, `apps/api`, `packages/services` and `packages/database` wholesale, on the theory that those are "tests that need a real DB". They are not — every one of those paths is already owned by its own project, and re-collecting them here ran ordinary mock-based unit tests a second time without their `~` alias, setup files or mocks: `Cannot find module '~/server/...'`, `Missing "./..." specifier in "@auxx/lib"`, files reporting `(0 test)`, plus real-DB timeouts on suites never written for one.

Real DB-backed tests use the `.int.test.ts` suffix and belong to `lib-integration`. Narrowed to its own `src/` and given the shared alias map. Its own smoke test went 1/4 → 4/4 — the other three were pure DB contention from the 40+ files that should not have been there.

CI does not run this project, so none of it was ever visible.

## Verification

- `pnpm exec vitest run` — 855 files / 11088 tests, 0 failures
- `node scripts/ci/typecheck-ratchet.js --package lib` — at baseline (29)
- `node scripts/ci/typecheck-ratchet.js --package web` — at baseline (1)
- `tsc --noEmit` clean in `kb`, `build`, `chat`, `worker`
- `biome check --diagnostic-level=error` clean on every changed file

## Not fixed here

`chat`, `worker`, `kb`, `build` and `api` have no typecheck gate in CI (the matrix is `lib` and `web` only), which is how the three type errors accumulated. Worth adding, but not in this PR.
