### PR TITLE
fix(workflow): resolve builder↔engine variable path drift

### DIFF
--- a/apps/web/src/components/workflow/hooks/use-var-store-sync.ts
+++ b/apps/web/src/components/workflow/hooks/use-var-store-sync.ts
@@ -19,6 +19,29 @@ export function useVarStoreSync() {
   useEffect(() => {
     let rafId: number | null = null
 
+    const syncFromState = (state: ReturnType<typeof store.getState>) => {
+      const nodes: NodeMeta[] = state.nodes.map((n) => ({
+        id: n.id,
+        type: n.data?.type || n.type || '',
+        data: n.data,
+        parentId: n.parentId,
+      }))
+      const edges: EdgeMeta[] = state.edges.map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        sourceHandle: e.sourceHandle,
+        data: e.data,
+      }))
+      updateGraph(nodes, edges)
+    }
+
+    // Initial sync — the subscription below only fires on *changes*, and the
+    // graph is already in the ReactFlow store by the time this mounts. Without
+    // this the variable store stays empty on a fresh load and every variable
+    // tag renders "Unknown Var" until something happens to mutate nodes/edges.
+    syncFromState(store.getState())
+
     const unsub = store.subscribe((state, prevState) => {
       // Early bail-out: skip pan/zoom/selection (reference equality check)
       if (state.nodes === prevState.nodes && state.edges === prevState.edges) return
@@ -27,20 +50,7 @@ export function useVarStoreSync() {
       if (rafId) cancelAnimationFrame(rafId)
       rafId = requestAnimationFrame(() => {
         rafId = null
-        const nodes: NodeMeta[] = state.nodes.map((n) => ({
-          id: n.id,
-          type: n.data?.type || n.type || '',
-          data: n.data,
-          parentId: n.parentId,
-        }))
-        const edges: EdgeMeta[] = state.edges.map((e) => ({
-          id: e.id,
-          source: e.source,
-          target: e.target,
-          sourceHandle: e.sourceHandle,
-          data: e.data,
-        }))
-        updateGraph(nodes, edges)
+        syncFromState(state)
       })
     })
 

--- a/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
+++ b/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
@@ -38,6 +38,8 @@ import {
 const CONSTANTS = {
   DEBOUNCE_MS: 300,
   DEFAULT_MAX_HEIGHT: 400,
+  /** Floor for the scrollable list so it never collapses behind the surrounding bars. */
+  MIN_LIST_HEIGHT: 120,
   FOCUS_DELAY_MS: 0,
   CMDK_ROOT_SELECTOR: '[cmdk-root]' as const,
 } as const
@@ -135,6 +137,12 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null)
   const [hasManuallyNavigated, setHasManuallyNavigated] = useState(false)
   const commandRef = useRef<HTMLDivElement>(null)
+
+  // Height of everything around the list (search input, breadcrumb bar, hint bar).
+  // The scroll viewport has to be capped at `maxHeight` MINUS this — cap it at the
+  // full `maxHeight` and the column overflows its own container, whose
+  // `overflow-hidden` then clips the last rows somewhere no scroll can reach.
+  const [chromeHeight, setChromeHeight] = useState(0)
 
   const { variables, groups, allVariables } = useAvailableVariables({ nodeId })
 
@@ -412,6 +420,30 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
     }
   }, [selected, hasManuallyNavigated, allVariables, buildNavigationStack])
 
+  // Measure the fixed bars around the list so the list can be capped at the space
+  // actually left for it. Re-runs when the breadcrumb bar swaps for the search bar.
+  useEffect(() => {
+    const root = commandRef.current
+    if (!root) return
+
+    const measure = () => {
+      let height = 0
+      for (const child of Array.from(root.children)) {
+        if (!(child instanceof HTMLElement)) continue
+        if (child.dataset.slot === 'command-list') continue
+        height += child.getBoundingClientRect().height
+      }
+      setChromeHeight(Math.ceil(height))
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(root)
+    return () => observer.disconnect()
+  }, [])
+
+  const listMaxHeight = Math.max(CONSTANTS.MIN_LIST_HEIGHT, maxHeight - chromeHeight)
+
   return (
     <div className={cn('flex flex-1 flex-col overflow-hidden', className)}>
       <Command
@@ -545,8 +577,13 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
 
         {/* Variable List */}
         <CommandList
-          className='flex-1 overflow-y-auto min-h-[200px] outline-none'
-          scrollAreaStyle={{ maxHeight }}>
+          className='outline-none'
+          // `className` lands on the inner cmdk list, where height utilities are a dead
+          // letter — the scroll viewport is the ScrollArea Root, which only `scrollArea*`
+          // reaches. Cap it at the space left after the surrounding bars, not the whole
+          // popover height, or the column overflows and the last rows get clipped.
+          scrollAreaClassName='max-h-none'
+          scrollAreaStyle={{ maxHeight: listMaxHeight }}>
           {getCurrentLevelItems.length === 0 ? (
             <CommandEmpty className='py-8 flex flex-col items-center'>
               <Search className='size-8 mx-auto mb-2 opacity-50' />

--- a/apps/web/src/components/workflow/utils/type-mapping.ts
+++ b/apps/web/src/components/workflow/utils/type-mapping.ts
@@ -77,26 +77,46 @@ export function mapFieldTypeToBaseType(fieldType: string | undefined): BaseType 
  *
  * @param field - The field to convert
  * @param nodeId - The node ID this output belongs to
+ * @param parentPath - Path of the enclosing struct/array, relative to the node. Nested
+ *   fields only carry their own key (`name`), so without this the variable ID collapses
+ *   to `<nodeId>.<key>` and the picker hands out a path the engine can't resolve — the
+ *   runtime stores the top-level output only (`<nodeId>.order`), and reads walk into it.
  * @returns A UnifiedVariable for the variable system
  */
 export function convertFieldToOutputVariable(
   field: WorkflowBlockField,
-  nodeId: string
+  nodeId: string,
+  parentPath?: string
 ): UnifiedVariable {
   // Captured before the guard: `field` narrows to `never` in the invalid branch,
   // but this function is deliberately defensive about malformed runtime input.
   const fieldName: string | undefined = field?.name
+  const path = parentPath ? `${parentPath}.${fieldName ?? 'unknown'}` : (fieldName ?? 'unknown')
 
+  return buildOutputVariable(field, nodeId, path)
+}
+
+/**
+ * Convert a field whose path within the node is already known.
+ * Split out so array items can claim the `<array>[*]` path instead of appending their
+ * own (synthetic) name to it.
+ */
+function buildOutputVariable(
+  field: WorkflowBlockField,
+  nodeId: string,
+  path: string
+): UnifiedVariable {
   // Validate field structure
   if (!isValidWorkflowBlockField(field)) {
     console.error('[Type Mapping] Invalid field passed to convertFieldToOutputVariable:', {
       field,
       nodeId,
+      path,
     })
     // Return a fallback variable to prevent crashes
     return createUnifiedOutputVariable({
       nodeId,
-      path: fieldName || 'unknown', // Changed from 'name' to 'path'
+      path,
       type: BaseType.ANY,
       description: 'Invalid field definition - missing required properties',
     })
@@ -136,19 +156,20 @@ export function convertFieldToOutputVariable(
   if (field.properties) {
     properties = {}
     for (const [key, prop] of Object.entries(field.properties)) {
-      properties[key] = convertFieldToOutputVariable(prop, nodeId)
+      properties[key] = buildOutputVariable(prop, nodeId, `${path}.${prop?.name || key}`)
     }
   }
 
-  // Build items recursively for array types
+  // Build items recursively for array types. The item IS the array at `[*]`, so it takes
+  // that path outright rather than appending its own (synthetic) name to the parent.
   let items: UnifiedVariable | undefined
   if (field.items) {
-    items = convertFieldToOutputVariable(field.items, nodeId)
+    items = buildOutputVariable(field.items, nodeId, `${path}[*]`)
   }
 
   return createUnifiedOutputVariable({
     nodeId,
-    path: field.name, // Changed from 'name' to 'path'
+    path,
     type: baseType, // Now format-aware
     description: field.description,
     properties,

--- a/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else-types.ts
+++ b/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else-types.ts
@@ -19,6 +19,13 @@ export interface NodeCondition {
   comparison_operator: Operator
   // Value to compare against
   value?: string | number | boolean | any[] | Record<string, any>
+  /**
+   * `false` when `value` holds a variable reference rather than a literal — the
+   * builder sets it when the right-hand side is switched out of constant mode.
+   * A `{{…}}` template is resolved regardless of this flag; it only matters for
+   * a bare path (`node_1.total`), which is otherwise a plausible literal string.
+   */
+  isConstant?: boolean
 }
 
 /**

--- a/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.test.ts
@@ -1,0 +1,322 @@
+// packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExecutionContextManager } from '../../core/execution-context'
+import type { WorkflowNode } from '../../core/types'
+import { WorkflowNodeType } from '../../core/types'
+import { IfElseProcessor } from './if-else'
+import type { NodeCase } from './if-else-types'
+
+// Silence the logger. Partial mock: `@auxx/logger/run-log` imports sink-registration
+// helpers from this barrel at module load, so a full replacement breaks collection.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+describe('IfElseProcessor', () => {
+  let processor: IfElseProcessor
+  let contextManager: ExecutionContextManager
+
+  const nodeWithCases = (cases: NodeCase[]): WorkflowNode =>
+    ({
+      id: 'node-1',
+      workflowId: 'workflow-1',
+      nodeId: 'gate-1',
+      type: WorkflowNodeType.IF_ELSE,
+      name: 'Gate',
+      data: { id: 'gate-1', type: WorkflowNodeType.IF_ELSE, title: 'Gate', cases },
+    }) as unknown as WorkflowNode
+
+  /** Run the node the way the engine does: preprocess, then execute. */
+  const run = async (node: WorkflowNode) => {
+    const preprocessed = await processor.preprocessNode(node, contextManager)
+    return processor.execute(node, contextManager, preprocessed)
+  }
+
+  beforeEach(() => {
+    processor = new IfElseProcessor()
+    contextManager = new ExecutionContextManager('workflow-1', 'exec-1', 'org-1', 'user-1')
+  })
+
+  describe('comparison value resolution', () => {
+    it('resolves a {{template}} target instead of comparing against the literal', async () => {
+      contextManager.setVariable('shopify.order.email', 'priya@example.com')
+      contextManager.setVariable('trigger.message.from.email', 'priya@example.com')
+
+      const result = await run(
+        nodeWithCases([
+          {
+            id: 'c1',
+            case_id: 'true',
+            logical_operator: 'and',
+            conditions: [
+              {
+                id: 'cond',
+                variableId: 'shopify.order.email',
+                comparison_operator: 'is',
+                value: '{{trigger.message.from.email}}',
+                isConstant: false,
+              },
+            ],
+          },
+        ])
+      )
+
+      expect(result.outputHandle).toBe('true')
+      expect(result.output?.matched).toBe(true)
+    })
+
+    it('takes the else branch when the two variables differ', async () => {
+      contextManager.setVariable('shopify.order.email', 'someone.else@example.com')
+      contextManager.setVariable('trigger.message.from.email', 'priya@example.com')
+
+      const result = await run(
+        nodeWithCases([
+          {
+            id: 'c1',
+            case_id: 'true',
+            logical_operator: 'and',
+            conditions: [
+              {
+                id: 'cond',
+                variableId: 'shopify.order.email',
+                comparison_operator: 'is',
+                value: '{{trigger.message.from.email}}',
+                isConstant: false,
+              },
+            ],
+          },
+        ])
+      )
+
+      expect(result.outputHandle).toBe('false')
+      expect(result.output?.matched).toBe(false)
+    })
+
+    it('resolves a numeric env target so `>` compares numbers, not NaN', async () => {
+      contextManager.setVariable('order.totalPrice', 50000)
+      contextManager.setVariable('env.HIGH_VALUE_THRESHOLD', 25000)
+
+      const result = await run(
+        nodeWithCases([
+          {
+            id: 'c1',
+            case_id: 'case-high-value',
+            logical_operator: 'and',
+            conditions: [
+              {
+                id: 'cond',
+                variableId: 'order.totalPrice',
+                comparison_operator: '>',
+                value: '{{env.HIGH_VALUE_THRESHOLD}}',
+                isConstant: false,
+              },
+            ],
+          },
+        ])
+      )
+
+      expect(result.outputHandle).toBe('case-high-value')
+    })
+
+    it('resolves a bare variable path when isConstant is false', async () => {
+      contextManager.setVariable('a.value', 'match')
+      contextManager.setVariable('b.value', 'match')
+
+      const result = await run(
+        nodeWithCases([
+          {
+            id: 'c1',
+            case_id: 'true',
+            logical_operator: 'and',
+            conditions: [
+              {
+                id: 'cond',
+                variableId: 'a.value',
+                comparison_operator: 'is',
+                value: 'b.value',
+                isConstant: false,
+              },
+            ],
+          },
+        ])
+      )
+
+      expect(result.output?.matched).toBe(true)
+    })
+
+    it('leaves a dotted literal alone when isConstant is not false', async () => {
+      contextManager.setVariable('status', 'shipped.today')
+      // A variable of the same name exists — a constant target must still win.
+      contextManager.setVariable('shipped.today', 'something else')
+
+      const result = await run(
+        nodeWithCases([
+          {
+            id: 'c1',
+            case_id: 'true',
+            logical_operator: 'and',
+            conditions: [
+              {
+                id: 'cond',
+                variableId: 'status',
+                comparison_operator: 'is',
+                value: 'shipped.today',
+              },
+            ],
+          },
+        ])
+      )
+
+      expect(result.output?.matched).toBe(true)
+    })
+
+    it('passes array targets through untouched for `in`', async () => {
+      contextManager.setVariable('status', 'open')
+
+      const result = await run(
+        nodeWithCases([
+          {
+            id: 'c1',
+            case_id: 'true',
+            logical_operator: 'and',
+            conditions: [
+              {
+                id: 'cond',
+                variableId: 'status',
+                comparison_operator: 'in',
+                value: ['open', 'pending'],
+              },
+            ],
+          },
+        ])
+      )
+
+      expect(result.output?.matched).toBe(true)
+    })
+
+    it('records the resolved target in the trace, not the raw template', async () => {
+      contextManager.setVariable('order.email', 'priya@example.com')
+      contextManager.setVariable('sender.email', 'priya@example.com')
+
+      const result = await run(
+        nodeWithCases([
+          {
+            id: 'c1',
+            case_id: 'true',
+            logical_operator: 'and',
+            conditions: [
+              {
+                id: 'cond',
+                variableId: 'order.email',
+                comparison_operator: 'is',
+                value: '{{sender.email}}',
+                isConstant: false,
+              },
+            ],
+          },
+        ])
+      )
+
+      expect(result.output?.evaluatedCases[0].conditions[0].target).toBe('priya@example.com')
+    })
+  })
+
+  describe('multi-case ordering', () => {
+    /**
+     * The shape the Shopify template relies on: case 1 is "found AND verified",
+     * case 2 is reached only when case 1 failed, so it means "found but not
+     * verified" without having to express the negation.
+     */
+    const orderGate = () =>
+      nodeWithCases([
+        {
+          id: 'c1',
+          case_id: 'true',
+          logical_operator: 'and',
+          conditions: [
+            { id: 'a', variableId: 'order.name', comparison_operator: 'not empty' },
+            {
+              id: 'b',
+              variableId: 'order.email',
+              comparison_operator: 'is',
+              value: '{{sender.email}}',
+              isConstant: false,
+            },
+          ],
+        },
+        {
+          id: 'c2',
+          case_id: 'case_email_mismatch',
+          logical_operator: 'and',
+          conditions: [{ id: 'c', variableId: 'order.name', comparison_operator: 'not empty' }],
+        },
+      ])
+
+    it('routes a verified order to the first case', async () => {
+      contextManager.setVariable('order.name', '#1012')
+      contextManager.setVariable('order.email', 'priya@example.com')
+      contextManager.setVariable('sender.email', 'priya@example.com')
+
+      expect((await run(orderGate())).outputHandle).toBe('true')
+    })
+
+    it('routes a found-but-unverified order to the second case', async () => {
+      contextManager.setVariable('order.name', '#1012')
+      contextManager.setVariable('order.email', 'owner@example.com')
+      contextManager.setVariable('sender.email', 'stranger@example.com')
+
+      expect((await run(orderGate())).outputHandle).toBe('case_email_mismatch')
+    })
+
+    it('routes a missing order to the else branch', async () => {
+      contextManager.setVariable('sender.email', 'priya@example.com')
+
+      expect((await run(orderGate())).outputHandle).toBe('false')
+    })
+
+    it('fails closed to mismatch when the sender address is missing', async () => {
+      contextManager.setVariable('order.name', '#1012')
+      contextManager.setVariable('order.email', 'owner@example.com')
+      // no sender.email — interpolation yields '' rather than throwing
+
+      expect((await run(orderGate())).outputHandle).toBe('case_email_mismatch')
+    })
+  })
+
+  describe('extractRequiredVariables', () => {
+    it('declares variables referenced by the comparison value', async () => {
+      const node = nodeWithCases([
+        {
+          id: 'c1',
+          case_id: 'true',
+          logical_operator: 'and',
+          conditions: [
+            {
+              id: 'cond',
+              variableId: 'order.email',
+              comparison_operator: 'is',
+              value: '{{sender.email}}',
+              isConstant: false,
+            },
+          ],
+        },
+      ])
+
+      const required = (
+        processor as unknown as {
+          extractRequiredVariables: (n: WorkflowNode) => string[]
+        }
+      ).extractRequiredVariables(node)
+
+      expect(required).toContain('order.email')
+      expect(required).toContain('sender.email')
+    })
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.ts
+++ b/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.ts
@@ -60,11 +60,15 @@ export class IfElseProcessor extends BaseNodeProcessor {
         // Resolve values for all conditions in this case in parallel
         const resolvedConditions = await Promise.all(
           caseItem.conditions.map(async (condition) => {
-            const variableValue = await contextManager.getVariable(condition.variableId)
+            const [variableValue, targetValue] = await Promise.all([
+              contextManager.getVariable(condition.variableId),
+              this.resolveConditionTarget(condition, contextManager),
+            ])
 
             return {
               condition, // Original NodeCondition
               resolvedValue: variableValue,
+              targetValue,
             }
           })
         )
@@ -119,11 +123,13 @@ export class IfElseProcessor extends BaseNodeProcessor {
 
       // Evaluate all conditions in this case
       const conditions: EvaluatedCondition[] = resolvedConditions.map(
-        ({ condition, resolvedValue }: any) => ({
+        ({ condition, resolvedValue, targetValue }: any) => ({
           operator: condition.comparison_operator,
-          target: condition.value ?? null,
+          // The *resolved* target, so the trace shows what was actually compared
+          // rather than the `{{…}}` template the author typed.
+          target: targetValue ?? null,
           resolvedValue: resolvedValue ?? null,
-          result: this.evaluateCondition(condition, resolvedValue, contextManager),
+          result: this.evaluateCondition(condition, resolvedValue, targetValue, contextManager),
         })
       )
 
@@ -209,6 +215,33 @@ export class IfElseProcessor extends BaseNodeProcessor {
   }
 
   /**
+   * Resolve the right-hand side of a condition.
+   *
+   * The comparison value is not always a literal — the builder lets you compare a
+   * variable against another variable (`isConstant: false`), and templates ship
+   * `{{env.HIGH_VALUE_THRESHOLD}}`-style targets. Left unresolved these compare as
+   * the literal string `"{{…}}"`, which silently fails every match rather than
+   * erroring, so the branch just never fires.
+   *
+   * Only strings are resolved; numbers, booleans and the array targets used by the
+   * `in` / `not in` operators are already literal values and pass straight through.
+   */
+  private async resolveConditionTarget(
+    condition: NodeCondition,
+    contextManager: ExecutionContextManager
+  ): Promise<NodeCondition['value']> {
+    const { value } = condition
+    if (typeof value !== 'string' || value.length === 0) return value
+
+    const isTemplate = value.includes('{{') && value.includes('}}')
+    // A bare path is only a reference when the author said so — otherwise
+    // "shipped.today" is a perfectly good string to compare against.
+    if (!isTemplate && condition.isConstant !== false) return value
+
+    return this.resolveVariableValue(value, contextManager)
+  }
+
+  /**
    * Extract variables from condition expressions
    */
   protected extractRequiredVariables(node: WorkflowNode): string[] {
@@ -221,6 +254,14 @@ export class IfElseProcessor extends BaseNodeProcessor {
         caseItem.conditions?.forEach((condition) => {
           if (condition.variableId) {
             variables.add(condition.variableId)
+          }
+          // The comparison value can reference a variable too — declare it, or the
+          // node looks independent of an upstream it actually reads.
+          if (typeof condition.value === 'string') {
+            this.extractVariableIds(condition.value).forEach((v) => variables.add(v))
+            if (condition.isConstant === false && !condition.value.includes('{{')) {
+              variables.add(condition.value)
+            }
           }
         })
       })
@@ -286,9 +327,10 @@ export class IfElseProcessor extends BaseNodeProcessor {
   private evaluateCondition(
     condition: NodeCondition,
     resolvedValue: any,
+    value: NodeCondition['value'],
     contextManager: ExecutionContextManager
   ): boolean {
-    const { comparison_operator, value } = condition
+    const { comparison_operator } = condition
     const def = getOperatorDefinition(comparison_operator)
 
     if (!def) {

--- a/packages/lib/src/workflows/templates/fulfillment-follow-up.template.json
+++ b/packages/lib/src/workflows/templates/fulfillment-follow-up.template.json
@@ -143,7 +143,7 @@
               "conditions": [
                 {
                   "id": "cond_status",
-                  "variableId": "shopify_get_order.fulfillmentStatus",
+                  "variableId": "shopify_get_order.order.fulfillmentStatus",
                   "comparison_operator": "is",
                   "value": "fulfilled",
                   "isConstant": true,
@@ -221,7 +221,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.name"
+                          "variableId": "shopify_get_order.order.name"
                         }
                       },
                       {
@@ -234,7 +234,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.fulfillmentStatus"
+                          "variableId": "shopify_get_order.order.fulfillmentStatus"
                         }
                       },
                       {
@@ -247,7 +247,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.totalPrice"
+                          "variableId": "shopify_get_order.order.totalPrice"
                         }
                       },
                       {
@@ -257,7 +257,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.currency"
+                          "variableId": "shopify_get_order.order.currency"
                         }
                       },
                       {
@@ -270,7 +270,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.lineItems"
+                          "variableId": "shopify_get_order.order.lineItems"
                         }
                       },
                       {
@@ -283,7 +283,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.orderStatusUrl"
+                          "variableId": "shopify_get_order.order.orderStatusUrl"
                         }
                       },
                       {
@@ -296,7 +296,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.createdAt"
+                          "variableId": "shopify_get_order.order.createdAt"
                         }
                       }
                     ]
@@ -522,7 +522,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.name"
+                          "variableId": "shopify_get_order.order.name"
                         }
                       },
                       {
@@ -535,7 +535,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.lineItems"
+                          "variableId": "shopify_get_order.order.lineItems"
                         }
                       }
                     ]
@@ -602,7 +602,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.name"
+                          "variableId": "shopify_get_order.order.name"
                         }
                       },
                       {
@@ -711,7 +711,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.name"
+                          "variableId": "shopify_get_order.order.name"
                         }
                       },
                       {
@@ -724,7 +724,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.financialStatus"
+                          "variableId": "shopify_get_order.order.financialStatus"
                         }
                       },
                       {
@@ -737,7 +737,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.fulfillmentStatus"
+                          "variableId": "shopify_get_order.order.fulfillmentStatus"
                         }
                       },
                       {
@@ -750,7 +750,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.totalPrice"
+                          "variableId": "shopify_get_order.order.totalPrice"
                         }
                       },
                       {
@@ -760,7 +760,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.currency"
+                          "variableId": "shopify_get_order.order.currency"
                         }
                       },
                       {
@@ -773,7 +773,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.lineItems"
+                          "variableId": "shopify_get_order.order.lineItems"
                         }
                       },
                       {
@@ -786,7 +786,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.createdAt"
+                          "variableId": "shopify_get_order.order.createdAt"
                         }
                       }
                     ]

--- a/packages/lib/src/workflows/templates/order-issue-triage.template.json
+++ b/packages/lib/src/workflows/templates/order-issue-triage.template.json
@@ -569,13 +569,13 @@
           "resourceType": "@entity:orders",
           "mode": "create",
           "data": {
-            "@field:orderNumber": "{{shopify-order-003.name}}",
-            "@field:orderTotal": "{{shopify-order-003.totalPrice}}",
+            "@field:orderNumber": "{{shopify-order-003.order.name}}",
+            "@field:orderTotal": "{{shopify-order-003.order.totalPrice}}",
             "@field:status": "Processing",
             "@field:priority": "Normal",
-            "@field:orderDate": "{{shopify-order-003.createdAt}}",
+            "@field:orderDate": "{{shopify-order-003.order.createdAt}}",
             "@field:shippingAddress": "",
-            "@field:trackingUrl": "{{shopify-order-003.orderStatusUrl}}",
+            "@field:trackingUrl": "{{shopify-order-003.order.orderStatusUrl}}",
             "@field:itemsOrdered": "",
             "@field:requiresFollowUp": true,
             "@field:internalNotes": "Auto-created from customer support message"
@@ -808,7 +808,7 @@
           "mode": "create",
           "data": {
             "@field:dealName": "Upsell: {{extractor-002.extracted_data.firstName}} {{extractor-002.extracted_data.lastName}} — {{extractor-002.extracted_data.orderNumber}}",
-            "@field:value": "{{shopify-order-003.totalPrice}}",
+            "@field:value": "{{shopify-order-003.order.totalPrice}}",
             "@field:stage": "Discovery",
             "@field:probability": 25,
             "@field:expectedCloseDate": ""
@@ -854,7 +854,7 @@
               "id": "set-vars-017-2",
               "name": "orderValue",
               "type": "NUMBER",
-              "value": "{{shopify-order-003.totalPrice}}",
+              "value": "{{shopify-order-003.order.totalPrice}}",
               "isConstantMode": false
             }
           ],
@@ -887,7 +887,7 @@
               "conditions": [
                 {
                   "id": "cond-high-value",
-                  "variableId": "shopify-order-003.totalPrice",
+                  "variableId": "shopify-order-003.order.totalPrice",
                   "comparison_operator": ">",
                   "value": "{{env.HIGH_VALUE_THRESHOLD}}",
                   "isConstant": false,
@@ -928,7 +928,7 @@
           "title": "Escalate to Slack",
           "desc": "Send high-value order alert to the escalation Slack channel",
           "channel": "{{env.ESCALATION_SLACK_CHANNEL}}",
-          "message": "High-value order issue from {{extractor-002.extracted_data.firstName}} {{extractor-002.extracted_data.lastName}} (Order: {{extractor-002.extracted_data.orderNumber}}, Value: ${{shopify-order-003.totalPrice}})\n\nIssue: {{extractor-002.extracted_data.issueDescription}}\nCategory: {{classifier-013.output.category}}",
+          "message": "High-value order issue from {{extractor-002.extracted_data.firstName}} {{extractor-002.extracted_data.lastName}} (Order: {{extractor-002.extracted_data.orderNumber}}, Value: ${{shopify-order-003.order.totalPrice}})\n\nIssue: {{extractor-002.extracted_data.issueDescription}}\nCategory: {{classifier-013.output.category}}",
           "fieldModes": {
             "channel": false,
             "message": false
@@ -1057,7 +1057,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify-order-003.fulfillmentStatus"
+                          "variableId": "shopify-order-003.order.fulfillmentStatus"
                         }
                       },
                       {
@@ -1070,7 +1070,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify-order-003.orderStatusUrl"
+                          "variableId": "shopify-order-003.order.orderStatusUrl"
                         }
                       }
                     ]

--- a/packages/lib/src/workflows/templates/return-request-processor.template.json
+++ b/packages/lib/src/workflows/templates/return-request-processor.template.json
@@ -191,11 +191,11 @@
           "inputs": [
             {
               "name": "fulfillmentStatus",
-              "variableId": "shopify_get_order.fulfillmentStatus"
+              "variableId": "shopify_get_order.order.fulfillmentStatus"
             },
             {
               "name": "createdAt",
-              "variableId": "shopify_get_order.createdAt"
+              "variableId": "shopify_get_order.order.createdAt"
             }
           ],
           "outputs": [
@@ -276,7 +276,7 @@
           "type": "human-confirmation",
           "title": "Approve Return",
           "description": "Return request meets policy — approve to proceed",
-          "message": "A customer has requested a return that meets policy requirements.\n\nOrder: #{{shopify_get_order.name}}\nItem: {{extractor_1.extracted_data.item_name}}\nReason: {{extractor_1.extracted_data.return_reason}}\nFulfillment: {{shopify_get_order.fulfillmentStatus}}\nDays since order: {{code_check_policy.daysSinceOrder}}\n\nApprove to send the return confirmation to the customer.",
+          "message": "A customer has requested a return that meets policy requirements.\n\nOrder: #{{shopify_get_order.order.name}}\nItem: {{extractor_1.extracted_data.item_name}}\nReason: {{extractor_1.extracted_data.return_reason}}\nFulfillment: {{shopify_get_order.order.fulfillmentStatus}}\nDays since order: {{code_check_policy.daysSinceOrder}}\n\nApprove to send the return confirmation to the customer.",
           "assignees": {
             "actorIds": []
           },
@@ -354,7 +354,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.name"
+                          "variableId": "shopify_get_order.order.name"
                         }
                       },
                       {
@@ -393,7 +393,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.totalPrice"
+                          "variableId": "shopify_get_order.order.totalPrice"
                         }
                       },
                       {
@@ -403,7 +403,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.currency"
+                          "variableId": "shopify_get_order.order.currency"
                         }
                       }
                     ]
@@ -602,7 +602,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.name"
+                          "variableId": "shopify_get_order.order.name"
                         }
                       },
                       {

--- a/packages/lib/src/workflows/templates/shopify-order-lookup.template.json
+++ b/packages/lib/src/workflows/templates/shopify-order-lookup.template.json
@@ -1,7 +1,7 @@
 {
   "slug": "shopify-order-lookup",
   "name": "Shopify Order Lookup & Reply",
-  "description": "When a customer emails about an order, this workflow extracts the order number, looks it up in Shopify, and generates a contextual AI reply with real order details (status, tracking, items). If the number can't be found it asks the customer to confirm it, if no number was given it asks for one, and if the email isn't order-related it stays silent. No AI-generated signatures.",
+  "description": "When a customer emails about an order, this workflow extracts the order number, looks it up in Shopify, and checks the order was placed from the address that emailed us before sharing anything. Verified customers get a contextual AI reply with real order details (status, tracking, items). If the order belongs to a different email it asks them to write from that address instead, if the number can't be found it asks the customer to confirm it, if no number was given it asks for one, and if the email isn't order-related it stays silent. No AI-generated signatures.",
   "categories": ["customer-service", "shopify", "ai"],
   "status": "public",
   "popularity": 95,
@@ -168,17 +168,35 @@
         "height": 100
       },
       {
-        "id": "ifelse_order_found",
+        "id": "format_order_email",
         "type": "standard",
         "position": {
           "x": 1500,
           "y": 150
         },
         "data": {
+          "id": "format_order_email",
+          "type": "format",
+          "title": "Normalize Order Email",
+          "desc": "Lowercase the email on the order so it can be compared to the sender's address",
+          "operation": "lowercase",
+          "input": "{{shopify_get_order.order.email}}"
+        },
+        "width": 244,
+        "height": 100
+      },
+      {
+        "id": "ifelse_order_found",
+        "type": "standard",
+        "position": {
+          "x": 1850,
+          "y": 150
+        },
+        "data": {
           "id": "ifelse_order_found",
           "type": "if-else",
           "title": "Order Found?",
-          "desc": "The extracted number may not match a real order — check Shopify actually returned one",
+          "desc": "The extracted number may not match a real order — and an order that does exist may belong to someone else. Only take the reply path when the order exists AND was placed from the address that emailed us. The order email is normalized upstream because this comparison is case-sensitive; the sender address is already lowercased at ingest.",
           "cases": [
             {
               "id": "case_order_found",
@@ -187,7 +205,28 @@
               "conditions": [
                 {
                   "id": "cond_order_found",
-                  "variableId": "shopify_get_order.name",
+                  "variableId": "shopify_get_order.order.name",
+                  "comparison_operator": "not empty",
+                  "logical_operator": "and"
+                },
+                {
+                  "id": "cond_order_email_matches",
+                  "variableId": "format_order_email.result",
+                  "comparison_operator": "is",
+                  "value": "{{trigger_1.message.from.email}}",
+                  "isConstant": false,
+                  "logical_operator": "and"
+                }
+              ]
+            },
+            {
+              "id": "case_email_mismatch",
+              "case_id": "case_email_mismatch",
+              "logical_operator": "and",
+              "conditions": [
+                {
+                  "id": "cond_order_found_unverified",
+                  "variableId": "shopify_get_order.order.name",
                   "comparison_operator": "not empty",
                   "logical_operator": "and"
                 }
@@ -197,7 +236,12 @@
           "_targetBranches": [
             {
               "id": "true",
-              "name": "Found",
+              "name": "Found & Verified",
+              "type": "default"
+            },
+            {
+              "id": "case_email_mismatch",
+              "name": "Email Mismatch",
               "type": "default"
             },
             {
@@ -214,7 +258,7 @@
         "id": "ai_order_reply",
         "type": "standard",
         "position": {
-          "x": 1850,
+          "x": 2200,
           "y": 40
         },
         "data": {
@@ -291,7 +335,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.name"
+                          "variableId": "shopify_get_order.order.name"
                         }
                       },
                       {
@@ -304,7 +348,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.financialStatus"
+                          "variableId": "shopify_get_order.order.financialStatus"
                         }
                       },
                       {
@@ -317,7 +361,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.fulfillmentStatus"
+                          "variableId": "shopify_get_order.order.fulfillmentStatus"
                         }
                       },
                       {
@@ -330,7 +374,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.totalPrice"
+                          "variableId": "shopify_get_order.order.totalPrice"
                         }
                       },
                       {
@@ -340,7 +384,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.currency"
+                          "variableId": "shopify_get_order.order.currency"
                         }
                       },
                       {
@@ -353,7 +397,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.lineItems"
+                          "variableId": "shopify_get_order.order.lineItems"
                         }
                       },
                       {
@@ -366,7 +410,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.orderStatusUrl"
+                          "variableId": "shopify_get_order.order.orderStatusUrl"
                         }
                       },
                       {
@@ -379,7 +423,7 @@
                       {
                         "type": "variable-node",
                         "attrs": {
-                          "variableId": "shopify_get_order.createdAt"
+                          "variableId": "shopify_get_order.order.createdAt"
                         }
                       }
                     ]
@@ -528,7 +572,7 @@
         "id": "ifelse_reply_order",
         "type": "standard",
         "position": {
-          "x": 2200,
+          "x": 2550,
           "y": 40
         },
         "data": {
@@ -573,7 +617,7 @@
         "id": "answer_order",
         "type": "standard",
         "position": {
-          "x": 2550,
+          "x": 2900,
           "y": 40
         },
         "data": {
@@ -599,11 +643,306 @@
         "height": 100
       },
       {
+        "id": "ai_order_mismatch",
+        "type": "standard",
+        "position": {
+          "x": 2200,
+          "y": 300
+        },
+        "data": {
+          "id": "ai_order_mismatch",
+          "type": "ai",
+          "title": "AI: Verify Order Owner",
+          "desc": "The order exists but was placed from a different email — ask them to write from that address",
+          "model": {
+            "useDefault": true,
+            "provider": "",
+            "name": "",
+            "mode": "chat",
+            "completion_params": {
+              "temperature": 0.7
+            }
+          },
+          "prompt_template": [
+            {
+              "role": "system",
+              "json": {
+                "type": "doc",
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "You are a friendly, professional customer support agent for a Shopify store. The customer referenced order number "
+                      },
+                      {
+                        "type": "variable-node",
+                        "attrs": {
+                          "variableId": "extractor_1.extracted_data.order_number"
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": ", and an order with that number does exist — but it was placed from a different email address than the one this message came from. You cannot share any details of that order with them."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "Customer intent: "
+                      },
+                      {
+                        "type": "variable-node",
+                        "attrs": {
+                          "variableId": "extractor_1.extracted_data.intent"
+                        }
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "Urgency: "
+                      },
+                      {
+                        "type": "variable-node",
+                        "attrs": {
+                          "variableId": "extractor_1.extracted_data.urgency"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "Guidelines:"
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- Acknowledge their message warmly and without suspicion"
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- Explain that for the account holder’s privacy you can only discuss an order with the email address it was placed from"
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- Ask them to reply from the email used at checkout, or to forward the order confirmation email"
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- Offer the alternative that they may have used a second address, or that the order was a gift placed by someone else"
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- NEVER reveal anything about the order: not the email on file (not even partially masked), the customer name, items, totals, status, tracking, or dates. Do not confirm who placed it."
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- Do not accuse them of anything. Most of these are honest mismatches."
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- Keep it concise — don’t over-explain"
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "- Never add a signature or sign-off (no \"Best regards\", no name). The email system adds signatures separately."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "Output: set respond to true and put the reply in email_message. If the email clearly isn’t a genuine customer request (spam, an automated bounce/out-of-office, or nothing to answer), set respond to false and leave email_message empty."
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "role": "user",
+              "json": {
+                "type": "doc",
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "Customer email:"
+                      },
+                      {
+                        "type": "hardBreak"
+                      },
+                      {
+                        "type": "text",
+                        "text": "Subject: "
+                      },
+                      {
+                        "type": "variable-node",
+                        "attrs": {
+                          "variableId": "trigger_1.message.subject"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "variable-node",
+                        "attrs": {
+                          "variableId": "trigger_1.message.body"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "context": {
+            "enabled": false,
+            "variable_selector": []
+          },
+          "vision": {
+            "enabled": false
+          },
+          "structured_output": {
+            "enabled": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "respond": {
+                  "type": "boolean",
+                  "description": "Whether to send a reply at all. Set false only if the email is not a genuine customer request that warrants a response (spam, automated bounce, out-of-office)."
+                },
+                "email_message": {
+                  "type": ["string", "null"],
+                  "description": "The reply body to send. Null when respond is false. Never include a signature or sign-off, and never include any detail of the order."
+                }
+              },
+              "required": ["respond", "email_message"]
+            }
+          }
+        },
+        "width": 244,
+        "height": 100
+      },
+      {
+        "id": "ifelse_reply_mismatch",
+        "type": "standard",
+        "position": {
+          "x": 2550,
+          "y": 300
+        },
+        "data": {
+          "id": "ifelse_reply_mismatch",
+          "type": "if-else",
+          "title": "Should Reply?",
+          "desc": "Only send if the AI decided a reply is warranted",
+          "cases": [
+            {
+              "id": "case_reply_mismatch",
+              "case_id": "true",
+              "logical_operator": "and",
+              "conditions": [
+                {
+                  "id": "cond_reply_mismatch",
+                  "variableId": "ai_order_mismatch.respond",
+                  "comparison_operator": "is",
+                  "value": true,
+                  "isConstant": true,
+                  "logical_operator": "and"
+                }
+              ]
+            }
+          ],
+          "_targetBranches": [
+            {
+              "id": "true",
+              "name": "Yes",
+              "type": "default"
+            },
+            {
+              "id": "false",
+              "name": "No",
+              "type": "default"
+            }
+          ]
+        },
+        "width": 244,
+        "height": 100
+      },
+      {
+        "id": "answer_mismatch",
+        "type": "standard",
+        "position": {
+          "x": 2900,
+          "y": 300
+        },
+        "data": {
+          "id": "answer_mismatch",
+          "type": "answer",
+          "title": "Send Verification Reply",
+          "desc": "Ask the customer to write from the address the order was placed from",
+          "messageType": "reply",
+          "recordId": "trigger_1.thread",
+          "text": "{{ai_order_mismatch.email_message}}",
+          "to": [],
+          "toModes": [],
+          "cc": [],
+          "ccModes": [],
+          "bcc": [],
+          "bccModes": [],
+          "subject": "",
+          "attachments": [],
+          "attachmentFiles": [],
+          "attachmentFilesModes": []
+        },
+        "width": 244,
+        "height": 100
+      },
+      {
         "id": "ai_order_not_found",
         "type": "standard",
         "position": {
-          "x": 1850,
-          "y": 300
+          "x": 2200,
+          "y": 560
         },
         "data": {
           "id": "ai_order_not_found",
@@ -809,8 +1148,8 @@
         "id": "ifelse_reply_not_found",
         "type": "standard",
         "position": {
-          "x": 2200,
-          "y": 300
+          "x": 2550,
+          "y": 560
         },
         "data": {
           "id": "ifelse_reply_not_found",
@@ -854,8 +1193,8 @@
         "id": "answer_not_found",
         "type": "standard",
         "position": {
-          "x": 2550,
-          "y": 300
+          "x": 2900,
+          "y": 560
         },
         "data": {
           "id": "answer_not_found",
@@ -884,7 +1223,7 @@
         "type": "standard",
         "position": {
           "x": 1150,
-          "y": 560
+          "y": 820
         },
         "data": {
           "id": "ai_no_order_reply",
@@ -1081,7 +1420,7 @@
         "type": "standard",
         "position": {
           "x": 1500,
-          "y": 560
+          "y": 820
         },
         "data": {
           "id": "ifelse_reply_no_order",
@@ -1126,7 +1465,7 @@
         "type": "standard",
         "position": {
           "x": 1850,
-          "y": 560
+          "y": 820
         },
         "data": {
           "id": "answer_no_order",
@@ -1174,8 +1513,15 @@
         "targetHandle": "target"
       },
       {
-        "id": "e_shopify_order_found",
+        "id": "e_shopify_format_email",
         "source": "shopify_get_order",
+        "target": "format_order_email",
+        "sourceHandle": "source",
+        "targetHandle": "target"
+      },
+      {
+        "id": "e_format_email_order_found",
+        "source": "format_order_email",
         "target": "ifelse_order_found",
         "sourceHandle": "source",
         "targetHandle": "target"
@@ -1198,6 +1544,27 @@
         "id": "e_gate_answer_order",
         "source": "ifelse_reply_order",
         "target": "answer_order",
+        "sourceHandle": "true",
+        "targetHandle": "target"
+      },
+      {
+        "id": "e_order_mismatch_ai",
+        "source": "ifelse_order_found",
+        "target": "ai_order_mismatch",
+        "sourceHandle": "case_email_mismatch",
+        "targetHandle": "target"
+      },
+      {
+        "id": "e_ai_gate_mismatch",
+        "source": "ai_order_mismatch",
+        "target": "ifelse_reply_mismatch",
+        "sourceHandle": "source",
+        "targetHandle": "target"
+      },
+      {
+        "id": "e_gate_answer_mismatch",
+        "source": "ifelse_reply_mismatch",
+        "target": "answer_mismatch",
         "sourceHandle": "true",
         "targetHandle": "target"
       },


### PR DESCRIPTION
Four related contract fixes between the workflow builder and the engine, all of which surfaced the same way: a variable that silently resolved to nothing rather than erroring.

## Engine

- **`if-else.ts`** — new `resolveConditionTarget`. The comparison *value* was never resolved, so `{{env.HIGH_VALUE_THRESHOLD}}` and variable-mode targets compared as literal strings and the branch simply never fired. The trace now records the resolved target instead of the template the author typed, and value-side variables are declared in `extractRequiredVariables` so a node no longer looks independent of an upstream it actually reads.
- **`if-else-types.ts`** — `NodeCondition.isConstant`. The builder already wrote it; the engine ignored it.

## Builder

- **`utils/type-mapping.ts`** — `convertFieldToOutputVariable` threads a `parentPath`. Nested app-block outputs were losing their parent, so the picker offered `<node>.name` for a value the runtime stores at `<node>.order.name`.
- **`hooks/use-var-store-sync.ts`** — sync once on mount. The subscription only fired on *changes*, so a cold load left every variable tag reading "Unknown Var".
- **`ui/variables/variable-explorer-enhanced.tsx`** — cap the scroll viewport at `maxHeight` minus the measured chrome. Pinned to the full popover height it overflowed its `overflow-hidden` parent, putting the last rows somewhere no scroll could reach.

## Templates

45 flat Shopify `order:get` paths corrected to `<node>.order.<field>` across four templates.

`shopify-order-lookup` also gains an email-verification branch (new feature, not a fix): "Order Found?" gets a third case checking that the order email matches the sender, with an AI branch for the mismatch. Because the engine's `is` is case-sensitive while our participant emails are lowercased at ingest, a `format` node normalizes the Shopify side first rather than changing `is` semantics globally — see the handoff for why that's the pattern to copy.

**Not covered here:** existing workflows carrying the old flat paths are not migrated (decision: reinstall the template), and four admin-created `WorkflowTemplate` DB rows still hold flat paths.

## Verification

- `pnpm exec vitest run src/workflow-engine` in `packages/lib` — **458 passing**, including 12 new tests in `if-else.test.ts`.
- 79 file-template tests pass with the new `shopify-order-lookup` graph.
- Biome clean on the touched files (remaining warnings on those lines are pre-existing).