### PR TITLE
feat(workflow): flag app nodes with no usable connection

### DIFF
--- a/apps/web/src/components/apps/hooks/use-app-connection-state.ts
+++ b/apps/web/src/components/apps/hooks/use-app-connection-state.ts
@@ -1,0 +1,129 @@
+// apps/web/src/components/apps/hooks/use-app-connection-state.ts
+'use client'
+
+import { useCallback } from 'react'
+import {
+  type AppConnection,
+  type AppInstallation,
+  useOptionalAppsContext,
+} from '~/components/apps/providers/apps-context'
+
+/**
+ * Whether an app node can actually run against a connection.
+ *
+ * - `not_required` — the app declares no ConnectionDefinition; nothing to bind
+ * - `loading`      — installations or connections are still in flight
+ * - `ok`           — a usable (connected) credential resolves for this node
+ * - `missing`      — the app needs a connection and none resolves
+ * - `expired`      — a credential resolves but its refresh circuit is open / token expired
+ */
+export type AppConnectionState = 'not_required' | 'loading' | 'ok' | 'missing' | 'expired'
+
+export interface AppConnectionInfo {
+  state: AppConnectionState
+  /** True when the app declares a user- or org-scoped ConnectionDefinition. */
+  requiresConnection: boolean
+  /** Label of the resolved credential, when one resolved. */
+  label: string | null
+}
+
+const LOADING: AppConnectionInfo = { state: 'loading', requiresConnection: false, label: null }
+
+/**
+ * Resolve a node's connection state the same way the engine does at run time:
+ * an explicit `connectionId` wins, otherwise any credential for the app (user-
+ * or org-scoped) is a candidate — mirrors `resolveAppConnectionForRuntime`,
+ * which falls back to whatever exists for the app when nothing is bound.
+ *
+ * Deliberately fails *open*: `listConnections` returns every user's credentials,
+ * so a user-scoped app that somebody has connected reads as `ok` even though the
+ * run's own user may not have connected. Only "nothing exists at all" is
+ * reported as `missing`.
+ */
+export function deriveAppConnectionState({
+  appId,
+  connectionId,
+  appInstallations,
+  appConnections,
+}: {
+  appId: string | undefined
+  connectionId: string | undefined
+  appInstallations: AppInstallation[]
+  appConnections: AppConnection[]
+}): AppConnectionInfo {
+  if (!appId) return LOADING
+
+  const installation = appInstallations.find((i) => i.app.id === appId)
+  const requiresConnection = !!(
+    installation?.connectionDefinitions?.user || installation?.connectionDefinitions?.organization
+  )
+
+  if (!requiresConnection) {
+    return { state: 'not_required', requiresConnection: false, label: null }
+  }
+
+  // Explicit binding: that row is the only candidate. A bound id with no row is
+  // a deleted credential, which the engine cannot resolve either.
+  if (connectionId) {
+    const bound = appConnections.find((c) => c.id === connectionId)
+    if (!bound) return { state: 'missing', requiresConnection: true, label: null }
+    const label = bound.label ?? bound.appName ?? null
+    if (bound.connectionStatus === 'connected') {
+      return { state: 'ok', requiresConnection: true, label }
+    }
+    return {
+      state: bound.connectionStatus === 'expired' ? 'expired' : 'missing',
+      requiresConnection: true,
+      label,
+    }
+  }
+
+  // Unbound: any credential for the app can serve the run.
+  const candidates = appConnections.filter((c) => c.appId === appId)
+  if (candidates.length === 0) {
+    return { state: 'missing', requiresConnection: true, label: null }
+  }
+  const usable = candidates.find((c) => c.connectionStatus === 'connected')
+  if (usable) {
+    return {
+      state: 'ok',
+      requiresConnection: true,
+      label: usable.label ?? usable.appName ?? null,
+    }
+  }
+  return {
+    state: 'expired',
+    requiresConnection: true,
+    label: candidates[0]?.label ?? candidates[0]?.appName ?? null,
+  }
+}
+
+/**
+ * Returns a resolver over the current apps context. A function rather than a
+ * value so callers that walk many nodes (the workflow checklist) resolve them
+ * all from one context read.
+ *
+ * Returns `loading` for everything outside an `AppsContextProvider`, so shared
+ * components can call it on pages with no apps infrastructure.
+ */
+export function useAppConnectionResolver(): (
+  appId: string | undefined,
+  connectionId: string | undefined
+) => AppConnectionInfo {
+  const context = useOptionalAppsContext()
+  const { appInstallations, appConnections, isLoading, isLoadingConnections } = context ?? {}
+  const unavailable = !context || isLoading || isLoadingConnections
+
+  return useCallback(
+    (appId, connectionId) => {
+      if (unavailable) return LOADING
+      return deriveAppConnectionState({
+        appId,
+        connectionId,
+        appInstallations: appInstallations ?? [],
+        appConnections: appConnections ?? [],
+      })
+    },
+    [unavailable, appInstallations, appConnections]
+  )
+}

--- a/apps/web/src/components/apps/providers/apps-context.tsx
+++ b/apps/web/src/components/apps/providers/apps-context.tsx
@@ -53,6 +53,13 @@ interface AppsContextValue {
    */
   mcpServers: ClientMcpServer[]
   isLoading: boolean
+  /**
+   * `appConnections` resolves on its own query, so it is still empty while
+   * `isLoading` (installations) is already false. Consumers that read
+   * "no connection exists" as an error state must gate on this flag or they
+   * flash that error on every cold load.
+   */
+  isLoadingConnections: boolean
   isError: boolean
   /** Refetch installed apps. Call after installing/uninstalling an app. */
   refreshInstallations: () => Promise<void>
@@ -74,6 +81,7 @@ export function AppsContextProvider({
   appConnections,
   mcpServers,
   isLoading,
+  isLoadingConnections,
   isError,
   refreshInstallations,
   refreshMcpServers,
@@ -83,6 +91,7 @@ export function AppsContextProvider({
   appConnections: AppConnection[]
   mcpServers: ClientMcpServer[]
   isLoading: boolean
+  isLoadingConnections: boolean
   isError: boolean
   refreshInstallations: () => Promise<void>
   refreshMcpServers: () => Promise<void>
@@ -95,6 +104,7 @@ export function AppsContextProvider({
         appConnections,
         mcpServers,
         isLoading,
+        isLoadingConnections,
         isError,
         refreshInstallations,
         refreshMcpServers,
@@ -116,4 +126,13 @@ export function useAppsContext() {
   }
 
   return context
+}
+
+/**
+ * Same as {@link useAppsContext} but returns `null` outside the provider instead
+ * of throwing. For shared components that also render outside `(protected)/app`
+ * — the workflow viewer mounts the same nodes on pages with no AppsProvider.
+ */
+export function useOptionalAppsContext() {
+  return useContext(AppsContext)
 }

--- a/apps/web/src/components/apps/providers/apps-provider.tsx
+++ b/apps/web/src/components/apps/providers/apps-provider.tsx
@@ -106,9 +106,10 @@ export function AppsProvider({ children }: AppsProviderProps) {
     await utils.apps.listInstalled.invalidate()
   }, [utils])
 
-  const { data: connectionsResult } = api.apps.listConnections.useQuery(undefined, {
-    staleTime: ORG_STATIC_STALE_TIME,
-  })
+  const { data: connectionsResult, isPending: isLoadingConnections } =
+    api.apps.listConnections.useQuery(undefined, {
+      staleTime: ORG_STATIC_STALE_TIME,
+    })
   const connections = connectionsResult ?? []
 
   // MCP servers — pure data, mapped to the client-safe `ClientMcpServer` shape the builder
@@ -168,6 +169,7 @@ export function AppsProvider({ children }: AppsProviderProps) {
         appConnections={connections}
         mcpServers={mcpServers}
         isLoading={isLoading}
+        isLoadingConnections={isLoadingConnections}
         isError={!!error}
         refreshInstallations={refreshInstallations}
         refreshMcpServers={refreshMcpServers}>

--- a/apps/web/src/components/workflow/hooks/use-app-connection-issue.ts
+++ b/apps/web/src/components/workflow/hooks/use-app-connection-issue.ts
@@ -1,0 +1,67 @@
+// apps/web/src/components/workflow/hooks/use-app-connection-issue.ts
+
+import { useCallback } from 'react'
+import { useAppConnectionResolver } from '~/components/apps/hooks/use-app-connection-state'
+
+/** Shape shared by `useNodeValidationErrors` and `useChecklist`. */
+export interface NodeIssue {
+  field: string
+  message: string
+  type: 'warning' | 'error'
+}
+
+/**
+ * App nodes carry `type: "<appId>:<blockId>"`. `data.appId` is only written back
+ * once `AppWorkflowNode` has mounted and persisted it, so parse the type — the
+ * checklist validates nodes that were never rendered.
+ */
+function resolveAppId(data: { type?: unknown; appId?: unknown }): string | undefined {
+  if (typeof data.appId === 'string' && data.appId) return data.appId
+  const type = data.type
+  if (typeof type !== 'string' || !type.includes(':')) return undefined
+  const parts = type.split(':')
+  return parts.length === 2 ? parts[0] : undefined
+}
+
+/**
+ * Returns a resolver that reports an app node's connection problem as a standard
+ * validation issue, so it flows through the same path as every other node
+ * problem: the `NodeValidationWarning` badge on the node, the workflow
+ * checklist, and the publish gate in `WorkflowToolbar`.
+ *
+ * Severity is deliberately split:
+ * - **error** for `missing` — no credential exists at all, so the run *will*
+ *   fail in the executor. Blocks publish.
+ * - **warning** for `expired` — a credential exists and the runtime resolver
+ *   refreshes OAuth tokens lazily, so this often heals itself on the next run.
+ *   Blocking publish on it would be wrong.
+ */
+export function useAppConnectionIssueResolver(): (data: any) => NodeIssue | null {
+  const resolveConnection = useAppConnectionResolver()
+
+  return useCallback(
+    (data: any) => {
+      if (!data) return null
+      const appId = resolveAppId(data)
+      if (!appId) return null
+
+      const { state } = resolveConnection(appId, data.connectionId)
+      if (state === 'missing') {
+        return {
+          field: '_connection',
+          message: 'No connection — connect an account in App Settings',
+          type: 'error',
+        }
+      }
+      if (state === 'expired') {
+        return {
+          field: '_connection',
+          message: 'Connection expired — reconnect the account in App Settings',
+          type: 'warning',
+        }
+      }
+      return null
+    },
+    [resolveConnection]
+  )
+}

--- a/apps/web/src/components/workflow/hooks/use-checklist.ts
+++ b/apps/web/src/components/workflow/hooks/use-checklist.ts
@@ -5,6 +5,7 @@ import { useStoreApi } from '@xyflow/react'
 import { useMemo } from 'react'
 import { unifiedNodeRegistry } from '../nodes/unified-registry'
 import { NodeType } from '../types/node-types'
+import { useAppConnectionIssueResolver } from './use-app-connection-issue'
 
 export interface NodeIssue {
   severity: 'error' | 'warning'
@@ -35,6 +36,7 @@ export const useChecklist = (): UseChecklistReturn => {
   // Get nodes and edges from stores
   const state = useStoreApi()
   const { nodes, edges } = state.getState()
+  const resolveAppConnectionIssue = useAppConnectionIssueResolver()
 
   const { nodesWithIssues, warningCount, errorCount } = useMemo(() => {
     const nodeIssuesMap = new Map<string, NodeWithIssues>()
@@ -123,6 +125,16 @@ export const useChecklist = (): UseChecklistReturn => {
         return
       }
 
+      // App nodes: no usable connection means the executor cannot run this node
+      const connectionIssue = resolveAppConnectionIssue(node.data)
+      if (connectionIssue) {
+        addIssueToNode(node.id, nodeType, node.data, {
+          severity: connectionIssue.type,
+          message: connectionIssue.message,
+          unConnected: false,
+        })
+      }
+
       // Validate node data
       const validationResult = unifiedNodeRegistry.validateNode(nodeType, node.data)
 
@@ -180,7 +192,7 @@ export const useChecklist = (): UseChecklistReturn => {
       warningCount: warnings,
       errorCount: errors,
     }
-  }, [nodes, edges])
+  }, [nodes, edges, resolveAppConnectionIssue])
 
   return {
     nodesWithIssues,

--- a/apps/web/src/components/workflow/hooks/use-node-validation-errors.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-validation-errors.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { useDebounce } from '~/hooks/use-debounced-value'
 import { unifiedNodeRegistry } from '../nodes/unified-registry'
 import type { BaseNodeData } from '../types'
+import { useAppConnectionIssueResolver } from './use-app-connection-issue'
 import { useNodeConnections } from './use-node-connections'
 
 interface UseNodeValidationProps {
@@ -38,6 +39,7 @@ export function useNodeValidationErrors({
   enabled = true,
 }: UseNodeValidationProps): ValidationState {
   const { needsOutgoingConnection } = useNodeConnections(nodeId, data.type)
+  const resolveAppConnectionIssue = useAppConnectionIssueResolver()
 
   // Debounce the data to avoid excessive validation
   const debouncedData = useDebounce(data, 300)
@@ -66,6 +68,12 @@ export function useNodeValidationErrors({
       })
     }
 
+    // App nodes: a missing/expired connection is a node problem like any other
+    const connectionIssue = resolveAppConnectionIssue(debouncedData)
+    if (connectionIssue) {
+      issues.push(connectionIssue)
+    }
+
     // Run schema validator
     const nodeDefinition = unifiedNodeRegistry.getDefinition(data.type)
     if (nodeDefinition?.validator) {
@@ -91,7 +99,7 @@ export function useNodeValidationErrors({
       hasErrors: errors.length > 0,
       hasWarnings: warnings.length > 0,
     }
-  }, [debouncedData, needsOutgoingConnection, enabled, data.type])
+  }, [debouncedData, needsOutgoingConnection, enabled, data.type, resolveAppConnectionIssue])
 
   return validation
 }


### PR DESCRIPTION
## Problem

An app node whose app declares a `ConnectionDefinition` but resolves no credential fails inside the executor at run time, and nothing in the builder says so beforehand. Connection state was only discovered lazily during server-function execution, via `connectionExpiredEmitter`.

## Approach

Surface it through the **existing** node-validation path rather than a bespoke affordance, so one issue reaches all three consumers at once:

- the `NodeValidationWarning` badge on the node
- the workflow checklist
- the publish gate in `WorkflowToolbar` (errors block publish; warnings prompt)

`useAppConnectionIssueResolver` produces a standard `{ field, message, type }` issue, consumed by both `useNodeValidationErrors` and `useChecklist`.

## Severity split

| State | Severity | Why |
|---|---|---|
| `missing` — no credential exists at all | **error**, blocks publish | the executor cannot resolve anything, so the run will fail |
| `expired` | **warning** | `connectionStatus` also flips on `expiresAt < now`, and `resolveConnectionForRuntime` refreshes OAuth lazily — this often heals on the next run, so blocking publish would be wrong |

## Notes

- The check mirrors `resolveAppConnectionForRuntime`: an explicit `connectionId` on the node wins, otherwise any credential for the app is a candidate.
- **Fails open by design.** `listConnections` returns every user's credentials, so a user-scoped app that somebody has connected reads as `ok` even if the run's own user hasn't. Only "nothing exists at all" is reported — better to miss that case than block publish on a workflow that runs fine.
- The checklist validates nodes that were never rendered, and `data.appId` is only written back after `AppWorkflowNode` mounts, so the resolver parses the appId out of `data.type` (`"<appId>:<blockId>"`) the same way the node does.
- Adds `isLoadingConnections` to the apps context — `listConnections` is a separate query from `listInstalled`, so without gating on it every app node would report a missing connection on cold load.
- Adds `useOptionalAppsContext()` — the workflow viewer mounts the same `FLOW_NODE_TYPES` outside `(protected)/app`, where `useAppsContext()` throws. Outside the provider everything resolves to `loading` and no issues are reported.

## Verification

- `apps/web` typecheck: only the pre-existing `app/api/kopilot/stream/route.ts` error
- `src/components/workflow`: 78/78 passing
- Biome clean on changed files