### PR TITLE
fix(workflow): message trigger scope picker fixes and selection chips

### DIFF
--- a/apps/web/src/components/channels/ui/channel-badge.tsx
+++ b/apps/web/src/components/channels/ui/channel-badge.tsx
@@ -1,0 +1,45 @@
+// apps/web/src/components/channels/ui/channel-badge.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import type { VariantProps } from 'class-variance-authority'
+import { getIntegrationColor, getIntegrationIconClass } from '~/components/mail/mail-status-config'
+import { recordBadgeVariants } from '~/components/resources/ui/record-badge'
+import { type Channel, useChannelStore } from '../store/channel-store'
+
+interface ChannelBadgeProps extends VariantProps<typeof recordBadgeVariants> {
+  /** Integration id, resolved via the channel store when `channel` is not given. */
+  channelId?: string
+  /** Pre-resolved channel row; skips the store lookup. */
+  channel?: Channel
+  className?: string
+}
+
+/**
+ * Inline pill for a channel (an Integration row). Channels are not records,
+ * so this composes `recordBadgeVariants` with the provider icon, the same
+ * shape as `ToolsetBadge` uses for `toolset:` chips. Falls back to a neutral
+ * label when the id no longer resolves (e.g. a disconnected channel still
+ * referenced by stored config).
+ */
+export function ChannelBadge({ channelId, channel, className, variant, size }: ChannelBadgeProps) {
+  const fromStore = useChannelStore((s) => (channelId ? s.channelMap.get(channelId) : undefined))
+  const resolved = channel ?? fromStore
+  const Icon = getIntegrationIconClass(resolved?.provider)
+  const color = getIntegrationColor(resolved?.provider)
+
+  return (
+    <span
+      data-slot='channel-badge'
+      className={cn(recordBadgeVariants({ variant, size }), className)}>
+      <span
+        className='flex size-4 shrink-0 items-center justify-center rounded'
+        style={{ backgroundColor: `${color}20` }}>
+        <Icon className='size-3' style={{ color }} />
+      </span>
+      <span data-slot='record-display' className='truncate max-w-[160px]'>
+        {resolved?.name || resolved?.email || 'Unknown channel'}
+      </span>
+    </span>
+  )
+}

--- a/apps/web/src/components/pickers/inbox-picker.tsx
+++ b/apps/web/src/components/pickers/inbox-picker.tsx
@@ -34,7 +34,7 @@ interface InboxPickerProps {
    * Passed through to the default trigger `<Button>` (variant/className/size/…)
    * when no custom `children` trigger is given. Lets callers match the shared
    * `w-full ps-0 pe-1` flush-in-a-`FieldPanelRow` sizing convention without
-   * hand-rolling a trigger — see `docs/ui-design-guide.md` §5.
+   * hand-rolling a trigger, see `docs/ui-design-guide.md` §5.
    */
   triggerProps?: React.ComponentProps<typeof Button>
 }
@@ -73,7 +73,7 @@ export function InboxPicker({
   const setIsOpen = controlledOnOpenChange || setInternalOpen
 
   // Fetch inboxes if not provided. Personal inboxes are never valid
-  // routing/move targets (mail-permissions §11) — exclude them everywhere.
+  // routing/move targets (mail-permissions §11), exclude them everywhere.
   const { inboxes: fetchedInboxes } = useInboxes()
   const inboxes = (externalInboxes || fetchedInboxes || []).filter((inbox) => !inbox.isPersonal)
 

--- a/apps/web/src/components/pickers/integration-picker.tsx
+++ b/apps/web/src/components/pickers/integration-picker.tsx
@@ -47,7 +47,7 @@ interface IntegrationPickerProps {
    * Passed through to the default trigger `<Button>` (variant/className/size/…)
    * when no custom `children` trigger is given. Lets callers match the shared
    * `w-full ps-0 pe-1` flush-in-a-`FieldPanelRow` sizing convention without
-   * hand-rolling a trigger — see `docs/ui-design-guide.md` §5.
+   * hand-rolling a trigger, see `docs/ui-design-guide.md` §5.
    */
   triggerProps?: React.ComponentProps<typeof Button>
 }
@@ -73,12 +73,13 @@ export function IntegrationPicker({
   const storeChannels = useChannelStore((s) => s.channels)
   const integrations = externalIntegrations || storeChannels
 
-  // Local state for managing selected integrations
-  const [localSelected, setLocalSelected] = useState<string[]>(selected)
+  // Fully controlled: `selected` is the single source of truth, like InboxPicker.
+  // A local useState copy went stale whenever the caller changed the selection
+  // from outside the picker (e.g. the inbox shortcut on the message trigger).
   const [searchValue, setSearchValue] = useState('')
 
   // Check if "Select all" is currently selected
-  const isSelectAllChecked = localSelected.includes(INTEGRATION_SELECT_ALL_VALUE)
+  const isSelectAllChecked = selected.includes(INTEGRATION_SELECT_ALL_VALUE)
 
   // Handle integration selection
   const handleIntegrationSelect = (integrationId: string) => {
@@ -105,9 +106,9 @@ export function IntegrationPicker({
           newSelected = [integrationId]
         } else {
           // Normal multi-select behavior
-          newSelected = localSelected.includes(integrationId)
-            ? localSelected.filter((id) => id !== integrationId)
-            : [...localSelected, integrationId]
+          newSelected = selected.includes(integrationId)
+            ? selected.filter((id) => id !== integrationId)
+            : [...selected, integrationId]
         }
       }
     }
@@ -118,7 +119,6 @@ export function IntegrationPicker({
         onOpenChange(false)
       }
     }
-    setLocalSelected(newSelected)
     onChange?.(newSelected)
   }
 
@@ -189,13 +189,11 @@ export function IntegrationPicker({
                     </div>
                     {allowMultiple ? (
                       <Checkbox
-                        checked={!isSelectAllChecked && localSelected.includes(integration.id)}
+                        checked={!isSelectAllChecked && selected.includes(integration.id)}
                         onCheckedChange={() => handleIntegrationSelect(integration.id)}
                       />
                     ) : (
-                      localSelected.includes(integration.id) && (
-                        <Check className='ml-auto h-4 w-4' />
-                      )
+                      selected.includes(integration.id) && <Check className='ml-auto h-4 w-4' />
                     )}
                   </CommandItem>
                 )
@@ -203,35 +201,37 @@ export function IntegrationPicker({
             </CommandGroup>
           </CommandList>
         </Command>
-        {allowMultiple && localSelected.length > 0 && (
+        {allowMultiple && selected.length > 0 && (
           <div className='flex flex-wrap gap-1 border-t p-2'>
             {isSelectAllChecked ? (
               <Badge variant='secondary' className='flex items-center'>
                 All Channels Selected
               </Badge>
             ) : (
-              localSelected.map((selectedId) => {
-                const selectedIntegration = integrations.find(
-                  (integration) => integration.id === selectedId
-                )
-                if (!selectedIntegration) return null
+              selected
+                .filter((id) => id !== INTEGRATION_SELECT_ALL_VALUE)
+                .map((selectedId) => {
+                  const selectedIntegration = integrations.find(
+                    (integration) => integration.id === selectedId
+                  )
+                  if (!selectedIntegration) return null
 
-                const Icon = getIntegrationIconClass(selectedIntegration.provider)
-                const color = getIntegrationColor(selectedIntegration.provider)
-                const displayName =
-                  selectedIntegration.name || `${selectedIntegration.provider} Integration`
+                  const Icon = getIntegrationIconClass(selectedIntegration.provider)
+                  const color = getIntegrationColor(selectedIntegration.provider)
+                  const displayName =
+                    selectedIntegration.name || `${selectedIntegration.provider} Integration`
 
-                return (
-                  <Badge key={selectedId} variant='secondary' className='flex items-center'>
-                    <div
-                      className='mr-2 flex h-3 w-3 items-center justify-center rounded'
-                      style={{ backgroundColor: `${color}20` }}>
-                      <Icon className='h-2 w-2' style={{ color }} />
-                    </div>
-                    {displayName}
-                  </Badge>
-                )
-              })
+                  return (
+                    <Badge key={selectedId} variant='secondary' className='flex items-center'>
+                      <div
+                        className='mr-2 flex h-3 w-3 items-center justify-center rounded'
+                        style={{ backgroundColor: `${color}20` }}>
+                        <Icon className='h-2 w-2' style={{ color }} />
+                      </div>
+                      {displayName}
+                    </Badge>
+                  )
+                })
             )}
           </div>
         )}

--- a/apps/web/src/components/workflow/nodes/core/message-received/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/message-received/panel.tsx
@@ -4,6 +4,7 @@
 
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { getMessageConditionFields } from '@auxx/lib/message-trigger-conditions/client'
+import type { RecordId } from '@auxx/lib/resources/client'
 import { getInstanceId, isRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -18,6 +19,7 @@ import { Plus } from 'lucide-react'
 import type React from 'react'
 import { memo, useCallback, useMemo } from 'react'
 import { useChannelStore } from '~/components/channels/store/channel-store'
+import { ChannelBadge } from '~/components/channels/ui/channel-badge'
 import {
   type Condition,
   ConditionContainer,
@@ -31,7 +33,9 @@ import {
   INTEGRATION_SELECT_ALL_VALUE,
   IntegrationPicker,
 } from '~/components/pickers/integration-picker'
+import { RecordBadge } from '~/components/resources/ui'
 import { useInboxes } from '~/components/threads/hooks'
+import { PickerTrigger } from '~/components/ui/picker-trigger'
 import { useNodeCrud, useReadOnly } from '~/components/workflow/hooks'
 import { OutputVariablesDisplay } from '~/components/workflow/ui/output-variables'
 import Section from '../../../ui/section'
@@ -40,8 +44,12 @@ import { staticOutputVariableContext } from '../output-variable-context'
 import { messageReceivedDefinition, UNSCOPED_MESSAGE_TRIGGER_WARNING } from './schema'
 import type { MessageReceivedNodeData } from './types'
 
-/** The flush-in-a-FieldPanelRow trigger sizing shared by every panel using this pattern. */
-const TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' } as const
+/**
+ * The flush-in-a-FieldPanelRow trigger sizing shared by every panel using this
+ * pattern, plus h-auto so the button grows when selection chips wrap to
+ * multiple lines instead of clipping them.
+ */
+const TRIGGER_CLASS = 'w-full ps-0 pe-1 h-auto min-h-8'
 
 /** The provider drives groups here; the flat condition list stays empty (mirrors mail-filter-configure-page). */
 const EMPTY_CONDITIONS: Condition[] = []
@@ -73,7 +81,7 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
   )
 
   // ── Run on: channel/inbox scope (§4) ────────────────────────────────────
-  // `channelIds` is the ONLY thing persisted — the inbox picker below is a
+  // `channelIds` is the ONLY thing persisted, the inbox picker below is a
   // write-only shortcut that expands to that inbox's channel ids.
   const channels = useChannelStore((s) => s.channels)
   const { inboxes } = useInboxes()
@@ -93,7 +101,7 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
   const channelIdSet = useMemo(() => new Set(channelIds), [channelIds])
 
   // An inbox reads as "selected" when every one of its channels is currently
-  // in scope — purely derived, nothing about inbox selection is stored.
+  // in scope. Purely derived; nothing about inbox selection is stored.
   const selectedInboxRecordIds = useMemo(() => {
     if (channelIds.length === 0) return []
     return nonPersonalInboxes
@@ -103,6 +111,19 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
       })
       .map((inbox) => inbox.recordId as string)
   }, [nonPersonalInboxes, channelIdsByInboxId, channelIds.length, channelIdSet])
+
+  // Unscoped (= all channels) must read back as "All shared inboxes" checked,
+  // exactly like the Channels row below, without this the select-all row can
+  // never appear checked, since clicking it sets the already-current state.
+  const displayedInboxSelection = useMemo(
+    () => (channelIds.length === 0 ? [INBOX_SELECT_ALL_VALUE] : selectedInboxRecordIds),
+    [channelIds.length, selectedInboxRecordIds]
+  )
+
+  const selectedChannels = useMemo(
+    () => channelIds.map((id) => channels.find((c) => c.id === id)).filter((c) => c != null),
+    [channelIds, channels]
+  )
 
   const handleInboxesChange = useCallback(
     (nextSelected: string[]) => {
@@ -136,7 +157,7 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
     [setChannelIds]
   )
 
-  // ── Content conditions (§3) — shared condition builder, replaces Message Filters ──
+  // ── Content conditions (§3): shared condition builder, replaces Message Filters ──
   const conditionFields = useMemo(() => getMessageConditionFields(), [])
 
   const conditionConfig: ConditionSystemConfig = useMemo(
@@ -153,7 +174,7 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
       showGroupSubtext: false,
       showGroupName: false,
       defaultGroupName: '',
-      // Constants only — a trigger fires before any node has run, so there is
+      // Constants only, a trigger fires before any node has run, so there is
       // no workflow variable to reference.
       allowVarEditor: false,
       allowConstantToggle: false,
@@ -205,15 +226,29 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
           className='p-0'>
           <FieldPanelRow
             title='Inboxes'
-            description='Shortcut — selects every channel linked to the chosen inbox(es).'>
+            description='Shortcut: selects every channel linked to the chosen inbox(es).'>
             <InboxPicker
               allowMultiple
               selectAll
               selectAllLabel='All shared inboxes'
-              selected={selectedInboxRecordIds}
-              onChange={handleInboxesChange}
-              triggerProps={TRIGGER_PROPS}
-            />
+              selected={displayedInboxSelection}
+              onChange={handleInboxesChange}>
+              <PickerTrigger hasValue className={TRIGGER_CLASS}>
+                {channelIds.length === 0 ? (
+                  <span className='truncate text-sm'>All shared inboxes</span>
+                ) : selectedInboxRecordIds.length > 0 ? (
+                  <div className='flex flex-wrap items-center gap-1 py-1'>
+                    {selectedInboxRecordIds.map((recordId) => (
+                      <RecordBadge key={recordId} recordId={recordId as RecordId} />
+                    ))}
+                  </div>
+                ) : (
+                  <span className='truncate text-sm text-muted-foreground'>
+                    Custom channel selection
+                  </span>
+                )}
+              </PickerTrigger>
+            </InboxPicker>
           </FieldPanelRow>
 
           <FieldPanelRow
@@ -225,9 +260,19 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
               selectAll
               selectAllLabel='All channels'
               selected={channelIds.length === 0 ? [INTEGRATION_SELECT_ALL_VALUE] : channelIds}
-              onChange={handleChannelsChange}
-              triggerProps={TRIGGER_PROPS}
-            />
+              onChange={handleChannelsChange}>
+              <PickerTrigger hasValue className={TRIGGER_CLASS}>
+                {selectedChannels.length === 0 ? (
+                  <span className='truncate text-sm'>All channels</span>
+                ) : (
+                  <div className='flex flex-wrap items-center gap-1 py-1'>
+                    {selectedChannels.map((channel) => (
+                      <ChannelBadge key={channel.id} channel={channel} />
+                    ))}
+                  </div>
+                )}
+              </PickerTrigger>
+            </IntegrationPicker>
           </FieldPanelRow>
         </FieldPanel>
       </Section>
@@ -244,7 +289,7 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
         getFieldDefinition={getConditionFieldDefinition}>
         <Section
           title='Conditions'
-          description='Match on message content — sender, subject, body, attachments. Channel scope is set above, not here.'
+          description='Match on message content: sender, subject, body, attachments. Channel scope is set above, not here.'
           initialOpen={false}
           actions={<AddConditionGroupButton />}>
           <ConditionContainer
@@ -294,7 +339,7 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
   )
 }
 
-/** "Add group" trigger for the conditions header — lives inside the ConditionProvider. */
+/** "Add group" trigger for the conditions header, lives inside the ConditionProvider. */
 function AddConditionGroupButton() {
   const { addGroup } = useConditionActions()
   if (!addGroup) return null

--- a/apps/web/src/components/workflow/nodes/core/message-received/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/message-received/schema.ts
@@ -61,12 +61,12 @@ export const messageReceivedDefaultData: Partial<MessageReceivedNodeData> = {
 
 /**
  * Warning shown (on the node badge and inline in the panel) when a trigger has
- * no channel scope. Unscoped is a valid, supported state — publish never
- * forces a choice — but it must stay visible: the dispatcher fans this
+ * no channel scope. Unscoped is a valid, supported state, publish never
+ * forces a choice, but it must stay visible: the dispatcher fans this
  * workflow out to every channel in the org.
  */
 export const UNSCOPED_MESSAGE_TRIGGER_WARNING =
-  'Unscoped — runs on every channel in the org. Select channels or an inbox under "Run on" to limit it.'
+  'Unscoped: runs on every channel in the org. Select channels or an inbox under "Run on" to limit it.'
 
 /**
  * Validation function for message-received configuration
@@ -82,7 +82,7 @@ export const validateMessageReceivedConfig = (data: MessageReceivedNodeData): Va
     errors.push({ field: 'title', message: 'Title is required', type: 'error' })
   }
 
-  // Unscoped trigger — allowed, but must be an unmissable warning (§4).
+  // Unscoped trigger, allowed, but must be an unmissable warning (§4).
   if (!dataToValidate.channelIds || dataToValidate.channelIds.length === 0) {
     errors.push({
       field: 'channelIds',
@@ -218,7 +218,7 @@ function getMessageReceivedOutputVariables(
     },
   })
 
-  // Thread relation — points to the thread this message belongs to
+  // Thread relation, points to the thread this message belongs to
   const threadRelation = createUnifiedOutputVariable({
     nodeId,
     path: 'thread',
@@ -227,7 +227,7 @@ function getMessageReceivedOutputVariables(
     resourceId: 'thread',
   })
 
-  // Message relation — points to the received message itself
+  // Message relation, points to the received message itself
   const messageRelation = createUnifiedOutputVariable({
     nodeId,
     path: 'message_ref',
@@ -236,7 +236,7 @@ function getMessageReceivedOutputVariables(
     resourceId: 'message',
   })
 
-  // Ticket relation — the thread's linked ticket. Empty unless the thread was
+  // Ticket relation, the thread's linked ticket. Empty unless the thread was
   // already linked to one: receiving mail never creates or links a ticket.
   const ticketRelation = createUnifiedOutputVariable({
     nodeId,

--- a/apps/web/src/components/workflow/nodes/core/message-received/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/message-received/trace-renderer.tsx
@@ -14,7 +14,7 @@ interface MessageReceivedOutputs {
 }
 
 /**
- * Preview for Message Received trigger executions — the triggering thread,
+ * Preview for Message Received trigger executions, the triggering thread,
  * so a reviewer can see "what fired this run" at a glance. Legacy runs
  * persisted before `threadId` was added to this node's output fall back to
  * raw JSON.

--- a/apps/web/src/components/workflow/nodes/core/message-received/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/message-received/types.ts
@@ -10,8 +10,8 @@ import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/nod
 export interface MessageReceivedNodeData extends BaseNodeData {
   desc?: string // Legacy field, prefer description
   /**
-   * Channel scope — which channels' inbound mail can start this workflow.
-   * `undefined`/empty means **all channels** (the default — publish never
+   * Channel scope, which channels' inbound mail can start this workflow.
+   * `undefined`/empty means **all channels** (the default, publish never
    * forces a choice). Read by the `triggerMessageWorkflows` dispatcher off the
    * published graph (`triggerNode.data.channelIds`), not by the runtime node
    * itself. The "Inboxes" picker in the panel is UI sugar only: picking an
@@ -28,10 +28,10 @@ export interface MessageReceivedNodeData extends BaseNodeData {
    */
   machineMail?: 'exclude' | 'include'
   /**
-   * Content conditions — replaces the deleted "Message Filters" UI. Evaluated
+   * Content conditions, replaces the deleted "Message Filters" UI. Evaluated
    * by the engine with the shared `evaluateConditionsWithDiagnostics` against
    * message-resolvable fields (from/to/subject/body/hasAttachments).
-   * Deliberately excludes `channel`/`isInbound` — channel scoping lives only
+   * Deliberately excludes `channel`/`isInbound`, channel scoping lives only
    * in `channelIds` above. Undefined/empty means "runs on every message".
    */
   conditions?: ConditionGroup[]


### PR DESCRIPTION
## Summary

Follow-ups to #1555 from live testing of the message trigger's "Run on" scope controls.

### Fixes
- **"All shared inboxes" could never be checked.** The panel fed the inbox picker an empty selection when unscoped, so the select-all row rendered unchecked and clicking it re-set the already-current state. The unscoped all-state is now reflected back into the picker, same as the Channels row.
- **Channels dropdown showed a stale selection** (an old channel checked instead of "All channels") after using the inbox shortcut. `IntegrationPicker` copied `selected` into `useState` at mount and never re-synced, so external changes to `channelIds` never reached it. The picker is now fully controlled (like `InboxPicker`); all three consumers already pass controlled values.

### UI
- Scope triggers now show selections as chips instead of static button text: `RecordBadge` for inboxes (they are records), and a new reusable `ChannelBadge` for channels.
- `ChannelBadge` lives in `apps/web/src/components/channels/ui/channel-badge.tsx`: composes `recordBadgeVariants` with the provider icon (the `ToolsetBadge` pattern), takes a `channelId` (store lookup) or a pre-resolved `channel`, with an "Unknown channel" fallback.
- Chip triggers use `h-auto min-h-8` so wrapped chip rows are not clipped.
- Em dashes removed from UI copy and comments in these files.

## Verification
- apps/web typecheck clean on all touched files (picker, both consumers, panel, channel-badge).
- Biome clean.
- Manually tested: select-all in both pickers, inbox shortcut expanding to channels, chips wrapping across lines.