### PR TITLE
fix(workflow): revive the personal mail-trigger guard and loop-back edge detection

### DIFF
--- a/apps/web/src/components/workflow/services/edge-validation-service.ts
+++ b/apps/web/src/components/workflow/services/edge-validation-service.ts
@@ -41,8 +41,12 @@ export class EdgeValidationService {
    * Create edge data based on source and target nodes
    */
   static createEdgeData(sourceNode: Node, targetNode: Node, connection: Connection) {
-    // Determine if this is a loop back edge
-    const isLoopBackEdge = targetNode?.type === 'loop' && connection.targetHandle === 'loop-back'
+    // Determine if this is a loop back edge. The workflow node type lives in
+    // data.type — node.type is the React Flow renderer type ('standard' on
+    // every loaded graph), so checking it alone never matches.
+    const isLoopBackEdge =
+      (targetNode?.data?.type ?? targetNode?.type) === 'loop' &&
+      connection.targetHandle === 'loop-back'
 
     return {
       sourceType: sourceNode?.data?.type || '',

--- a/apps/web/src/components/workflow/store/edge-store.ts
+++ b/apps/web/src/components/workflow/store/edge-store.ts
@@ -302,8 +302,12 @@ export const useEdgeStore = create<EdgeStore>()(
         Date.now(),
       ].join('-')
 
-      // Determine if this is a loop back edge
-      const isLoopBackEdge = targetNode?.type === 'loop' && connection.targetHandle === 'loop-back'
+      // Determine if this is a loop back edge. The workflow node type lives in
+      // data.type — node.type is the React Flow renderer type ('standard' on
+      // every loaded graph), so checking it alone never matches.
+      const isLoopBackEdge =
+        (targetNode?.data?.type ?? targetNode?.type) === 'loop' &&
+        connection.targetHandle === 'loop-back'
 
       // Import graph utils for loop detection
       const { isNodeInLoop, getContainingLoopId } = require('../utils/graph-utils')

--- a/apps/web/src/components/workflow/utils/workflow-initializer.ts
+++ b/apps/web/src/components/workflow/utils/workflow-initializer.ts
@@ -317,10 +317,14 @@ export const initialEdges = (edges: FlowEdge[], nodes: FlowNode[]): FlowEdge[] =
       updatedEdge.data.loopId = sourceLoopId
     }
 
-    // Check if this is a loop back edge (from loop exit to loop node)
+    // Check if this is a loop back edge. Match both the live-draw predicate
+    // (targetHandle === 'loop-back', see edge-store.ts) and the containment
+    // shape (source parented inside the target loop) — an edge wired to the
+    // loop-back handle whose source lacks parentId must still be recognized,
+    // or var-graph.ts stops filtering it and upstream traversal sees a cycle.
     if (
       targetNode?.data.type === NodeType.LOOP &&
-      sourceNode?.parentId === targetNode.id &&
+      (sourceNode?.parentId === targetNode.id || edge.targetHandle === 'loop-back') &&
       updatedEdge.data
     ) {
       updatedEdge.data.isLoopBackEdge = true

--- a/packages/lib/src/events/handlers/trigger-message-workflows.test.ts
+++ b/packages/lib/src/events/handlers/trigger-message-workflows.test.ts
@@ -13,10 +13,12 @@ const h = vi.hoisted(() => ({
   getCachedWorkflowAppsByTrigger: vi.fn(),
   getQueueAdd: vi.fn(),
   loadProcessedMessage: vi.fn(),
+  orgCacheGet: vi.fn(),
 }))
 
 vi.mock('../../cache', () => ({
   getCachedWorkflowAppsByTrigger: h.getCachedWorkflowAppsByTrigger,
+  getOrgCache: () => ({ get: h.orgCacheGet }),
 }))
 vi.mock('../../jobs/queues', () => ({
   getQueue: () => ({ add: h.getQueueAdd }),
@@ -77,6 +79,7 @@ function event(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks()
   h.loadProcessedMessage.mockResolvedValue({ id: MESSAGE_ID })
+  h.orgCacheGet.mockResolvedValue([])
 })
 
 describe('triggerMessageWorkflows — channel scope (§4)', () => {
@@ -139,6 +142,25 @@ describe('triggerMessageWorkflows — channel scope (§4)', () => {
     await triggerMessageWorkflows(event({ integrationId: undefined }))
 
     expect(h.getQueueAdd).not.toHaveBeenCalled()
+  })
+
+  it('never dispatches for a message on a personal channel, even to unscoped workflows', async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([app('unscoped')])
+    h.orgCacheGet.mockResolvedValue([{ id: 'ibx_personal', isPersonal: true }])
+
+    await triggerMessageWorkflows(event({ inboxId: 'ibx_personal' }))
+
+    expect(h.getQueueAdd).not.toHaveBeenCalled()
+    expect(h.loadProcessedMessage).not.toHaveBeenCalled()
+  })
+
+  it('dispatches normally for a message on a shared inbox', async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([app('unscoped')])
+    h.orgCacheGet.mockResolvedValue([{ id: 'ibx_shared', isPersonal: false }])
+
+    await triggerMessageWorkflows(event({ inboxId: 'ibx_shared' }))
+
+    expect(h.getQueueAdd).toHaveBeenCalledTimes(1)
   })
 
   it('applies channel scope alongside the existing soft machine-mail gate', async () => {

--- a/packages/lib/src/events/handlers/trigger-message-workflows.ts
+++ b/packages/lib/src/events/handlers/trigger-message-workflows.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/events/handlers/trigger-message-workflows.ts
 
 import { createScopedLogger } from '@auxx/logger'
-import { getCachedWorkflowAppsByTrigger } from '../../cache'
+import { getCachedWorkflowAppsByTrigger, getOrgCache } from '../../cache'
 import type { CachedPublishedWorkflow } from '../../cache/providers/workflow-apps-provider'
 import { getQueue } from '../../jobs/queues'
 import { Queues } from '../../jobs/queues/types'
@@ -65,7 +65,7 @@ function matchesChannelScope(
  */
 export const triggerMessageWorkflows = async ({ data: event }: { data: AuxxEvent }) => {
   if (event.type !== 'message:received') return
-  const { messageId, organizationId, threadId, machineMail, integrationId } = (
+  const { messageId, organizationId, threadId, machineMail, integrationId, inboxId } = (
     event as MessageReceivedEvent
   ).data
 
@@ -78,6 +78,23 @@ export const triggerMessageWorkflows = async ({ data: event }: { data: AuxxEvent
       reason: machineMail.reason,
     })
     return
+  }
+
+  // Personal channels are not automatable (§8.2/§11): a message that landed in
+  // a personal mailbox never dispatches message-received workflows. The
+  // save-time guard (`mail-trigger-guard.ts`) blocks explicitly targeting a
+  // personal channel; this covers unscoped triggers, whose scope defaults to
+  // every channel in the org.
+  if (inboxId) {
+    const inboxes = await getOrgCache().get(organizationId, 'inboxes')
+    if (inboxes.some((inbox) => inbox.id === inboxId && inbox.isPersonal)) {
+      logger.info('Skipping MESSAGE_RECEIVED workflows — message is on a personal channel', {
+        messageId,
+        organizationId,
+        inboxId,
+      })
+      return
+    }
   }
 
   const matchingApps = await getCachedWorkflowAppsByTrigger({

--- a/packages/lib/src/inboxes/personal-inbox-def-consumers.test.ts
+++ b/packages/lib/src/inboxes/personal-inbox-def-consumers.test.ts
@@ -219,13 +219,21 @@ describe('ABSENT — automation scope excludes the personal mailbox (HEADLESS)',
 })
 
 describe('ABSENT — workflow mail triggers reject a personal inbox', () => {
+  // Persisted nodes carry the workflow type in data.type — node.type is the
+  // React Flow renderer type ('standard'). The scope is data.channelIds
+  // (message-trigger-scoping); data.filters.integrationId is the legacy shape.
   const graph = {
-    nodes: [{ type: 'message-received', data: { filters: { integrationId: 'int_1' } } }],
+    nodes: [{ type: 'standard', data: { type: 'message-received', channelIds: ['int_1'] } }],
+  }
+  const legacyGraph = {
+    nodes: [
+      { type: 'standard', data: { type: 'message-received', filters: { integrationId: 'int_1' } } },
+    ],
   }
   const dbWithLink = (inboxId: string) =>
     ({
       select: () => ({
-        from: () => ({ where: () => ({ limit: async () => [{ inboxId }] }) }),
+        from: () => ({ where: async () => [{ inboxId }] }),
       }),
     }) as never
 
@@ -238,10 +246,25 @@ describe('ABSENT — workflow mail triggers reject a personal inbox', () => {
     })
   }
 
+  it('refuses a legacy filters.integrationId trigger on a personal channel', async () => {
+    mockCache([sharedInbox, personalOnNewDef])
+    await expect(
+      assertMailTriggerNotPersonal(dbWithLink(PERSONAL_ID), ORG, legacyGraph)
+    ).rejects.toMatchObject({ name: 'BadRequestError', statusCode: 400 })
+  })
+
   it('allows a trigger on a shared inbox (positive control)', async () => {
     mockCache([sharedInbox, personalOnNewDef])
     await expect(
       assertMailTriggerNotPersonal(dbWithLink(SHARED_ID), ORG, graph)
+    ).resolves.toBeUndefined()
+  })
+
+  it('ignores an unscoped trigger (dispatcher owns that exclusion)', async () => {
+    mockCache([sharedInbox, personalOnNewDef])
+    const unscoped = { nodes: [{ type: 'standard', data: { type: 'message-received' } }] }
+    await expect(
+      assertMailTriggerNotPersonal(dbWithLink(PERSONAL_ID), ORG, unscoped)
     ).resolves.toBeUndefined()
   })
 })

--- a/packages/lib/src/workflows/mail-trigger-guard.ts
+++ b/packages/lib/src/workflows/mail-trigger-guard.ts
@@ -1,17 +1,21 @@
 // packages/lib/src/workflows/mail-trigger-guard.ts
 
 import { type Database, schema } from '@auxx/database'
-import { eq } from 'drizzle-orm'
+import { inArray } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import { WorkflowNodeType } from '../workflow-engine/core/types'
 
 /**
  * §8.2/§11: personal channels are not automatable. Rejects a workflow graph
- * whose message-received trigger targets an integration attached to a personal
- * inbox (the engine honors `filters.integrationId` at execution time, so the
- * graph is validated even though the builder UI has no integration picker).
- * No-op for org inboxes and for graphs without an integration filter.
+ * whose message-received trigger is scoped to a channel attached to a personal
+ * inbox. Persisted nodes carry the workflow node type in `data.type`
+ * (`node.type` is the React Flow renderer type, `'standard'`), and the scope
+ * lives in `data.channelIds` (message-trigger-scoping plan §4); the legacy
+ * `data.filters.integrationId` shape is still honored for graphs saved before
+ * scoping shipped. No-op for org channels and for unscoped triggers — unscoped
+ * dispatch excludes personal channels at the dispatcher
+ * (`trigger-message-workflows.ts`).
  */
 export async function assertMailTriggerNotPersonal(
   db: Database,
@@ -23,12 +27,17 @@ export async function assertMailTriggerNotPersonal(
 
   const integrationIds = nodes
     .filter(
-      (n): n is { type: string; data?: { filters?: Record<string, unknown> } } =>
-        typeof n === 'object' &&
-        n !== null &&
-        (n as { type?: unknown }).type === WorkflowNodeType.MESSAGE_RECEIVED
+      (n): n is { type?: string; data?: Record<string, unknown> } =>
+        typeof n === 'object' && n !== null
     )
-    .map((n) => n.data?.filters?.integrationId)
+    .filter(
+      (n) => ((n.data?.type as string | undefined) ?? n.type) === WorkflowNodeType.MESSAGE_RECEIVED
+    )
+    .flatMap((n) => {
+      const channelIds = Array.isArray(n.data?.channelIds) ? n.data.channelIds : []
+      const legacyId = (n.data?.filters as Record<string, unknown> | undefined)?.integrationId
+      return [...channelIds, legacyId]
+    })
     .filter((id): id is string => typeof id === 'string' && id.length > 0)
 
   if (integrationIds.length === 0) return
@@ -41,16 +50,13 @@ export async function assertMailTriggerNotPersonal(
   const personalIds = new Set(inboxes.filter((i) => i.isPersonal).map((i) => i.id))
   if (personalIds.size === 0) return
 
-  for (const integrationId of integrationIds) {
-    const [row] = await db
-      .select({ inboxId: schema.InboxIntegration.inboxId })
-      .from(schema.InboxIntegration)
-      .where(eq(schema.InboxIntegration.integrationId, integrationId))
-      .limit(1)
-    if (row && personalIds.has(row.inboxId)) {
-      throw new BadRequestError(
-        'Mail triggers cannot be configured on a personal inbox. Personal accounts are not automatable.'
-      )
-    }
+  const rows = await db
+    .select({ inboxId: schema.InboxIntegration.inboxId })
+    .from(schema.InboxIntegration)
+    .where(inArray(schema.InboxIntegration.integrationId, integrationIds))
+  if (rows.some((row) => personalIds.has(row.inboxId))) {
+    throw new BadRequestError(
+      'Mail triggers cannot be configured on a personal inbox. Personal accounts are not automatable.'
+    )
   }
 }


### PR DESCRIPTION
## Summary

A re-verification of the workflow plans against post-#1557 main found three guards that could never fire. All three are dead-predicate bugs of the same shape: code matching `node.type`, which is always `'standard'` on persisted graphs (the real workflow type lives in `node.data.type`).

- **`assertMailTriggerNotPersonal` was dead code.** It matched trigger nodes by `n.type === 'message-received'` and read the legacy `data.filters.integrationId` shape that #1555 replaced with `channelIds`. Its only test used a hand-built fixture with the same stale shape, so it passed while guarding nothing. Now matches `data.type`, honors `channelIds` plus the legacy shape for older graphs, and batches the inbox lookup with `inArray`.
- **Unscoped message triggers automated personal mail.** `message:received` publishes for personal-channel messages (only echo suppression gates it), and nothing downstream filtered personal channels — so a trigger with empty `channelIds` ("all channels") dispatched workflows for personal mailboxes, violating the "personal channels are not automatable" invariant. The dispatcher now skips all message-received dispatch when the event's `inboxId` is a personal inbox (one org-cache read, no DB query). The save-time guard can only block *explicit* targeting; this covers the unscoped default.
- **`isLoopBackEdge` detection was half-dead.** The live-draw predicates in `edge-store.ts` and `edge-validation-service.ts` tested `node.type === 'loop'`, which the initializer stamps to `'standard'` on every loaded graph; they now read `data.type`. The initializer's regeneration also keyed only on `parentId` — it now additionally recognizes `targetHandle === 'loop-back'`, so a loop-back edge whose source lacks `parentId` is still excluded from the builder's upstream traversal instead of reading as a cycle.

## Tests

- Guard fixtures now mirror real persisted graphs (`type: 'standard'`, `data.type`), with a legacy-shape case and an unscoped case documenting where each exclusion lives.
- Dispatcher suite gains personal-inbox skip + shared-inbox positive control.
- `packages/lib`: `trigger-message-workflows.test.ts` + `personal-inbox-def-consumers.test.ts` — 31 passed.
- `apps/web`: full workflow suite incl. builder-engine parity — 78 passed.