### PR TITLE
fix(workflow): route failed nodes to their wired fail branch

### DIFF
--- a/packages/lib/src/workflow-engine/core/__tests__/failed-node-routing.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/failed-node-routing.test.ts
@@ -1,0 +1,194 @@
+// packages/lib/src/workflow-engine/core/__tests__/failed-node-routing.test.ts
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { BaseNodeProcessor } from '../../nodes/base-node'
+import type { ExecutionContextManager } from '../execution-context'
+import type { NodeProcessorRegistry } from '../node-processor-registry'
+import type { NodeExecutionResult, Workflow, WorkflowNode, WorkflowTriggerType } from '../types'
+import { NodeRunningStatus, WorkflowNodeType } from '../types'
+import { WorkflowEngine } from '../workflow-engine'
+
+/** Records which nodes ran so tests can assert the path taken. */
+const executedNodes: string[] = []
+
+class MockTriggerProcessor extends BaseNodeProcessor {
+  readonly type = WorkflowNodeType.MANUAL
+
+  protected async executeNode(): Promise<Partial<NodeExecutionResult>> {
+    return {
+      status: NodeRunningStatus.Succeeded,
+      output: { triggered: true },
+      outputHandle: 'source',
+    }
+  }
+}
+
+/**
+ * Fails with whatever outputHandle the node's data dictates — mirrors real
+ * processors like crud (`'fail'`) and http (`'fail'` for error_strategy 'fail').
+ * When `data.succeedWithHandle` is set it succeeds with that handle instead,
+ * mirroring http's error_strategy 'none' continue-on-error result.
+ */
+class MockFailingProcessor extends BaseNodeProcessor {
+  readonly type = 'mock-failing' as WorkflowNodeType
+
+  protected async executeNode(
+    node: WorkflowNode,
+    _contextManager: ExecutionContextManager
+  ): Promise<Partial<NodeExecutionResult>> {
+    executedNodes.push(node.nodeId)
+    if (node.data.succeedWithHandle) {
+      return {
+        status: NodeRunningStatus.Succeeded,
+        output: { error: 'request failed', status: 0 },
+        outputHandle: node.data.succeedWithHandle,
+      }
+    }
+    return {
+      status: NodeRunningStatus.Failed,
+      error: 'boom',
+      output: { error: 'boom' },
+      outputHandle: node.data.failHandle,
+    }
+  }
+}
+
+class MockRecorderProcessor extends BaseNodeProcessor {
+  readonly type = 'mock-recorder' as WorkflowNodeType
+
+  protected async executeNode(node: WorkflowNode): Promise<Partial<NodeExecutionResult>> {
+    executedNodes.push(node.nodeId)
+    return {
+      status: NodeRunningStatus.Succeeded,
+      output: { recorded: true },
+      outputHandle: 'source',
+    }
+  }
+}
+
+const edge = (id: string, source: string, target: string, sourceHandle = 'source') => ({
+  id,
+  source,
+  target,
+  sourceHandle,
+  targetHandle: 'target',
+})
+
+const buildWorkflow = (
+  failNodeData: Record<string, unknown>,
+  failEdgeHandle?: string
+): Workflow => ({
+  id: 'fail-routing-test',
+  workflowId: 'fail-routing-test',
+  workflowAppId: 'test-app',
+  organizationId: 'test-org',
+  name: 'Fail Branch Routing Test',
+  enabled: true,
+  version: 1,
+  triggerType: 'manual' as WorkflowTriggerType,
+  nodes: [],
+  graph: {
+    nodes: [
+      { id: 'trigger', type: 'manual', data: { type: 'manual' } },
+      { id: 'flaky', type: 'mock-failing', data: { type: 'mock-failing', ...failNodeData } },
+      { id: 'success-path', type: 'mock-recorder', data: { type: 'mock-recorder' } },
+      { id: 'fail-handler', type: 'mock-recorder', data: { type: 'mock-recorder' } },
+    ],
+    edges: [
+      edge('e1', 'trigger', 'flaky'),
+      edge('e2', 'flaky', 'success-path'),
+      ...(failEdgeHandle ? [edge('e3', 'flaky', 'fail-handler', failEdgeHandle)] : []),
+    ],
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+})
+
+const runWorkflow = (engine: WorkflowEngine, workflow: Workflow) =>
+  engine.executeWorkflow(workflow, {
+    type: 'manual' as WorkflowTriggerType,
+    data: {},
+    timestamp: new Date(),
+    organizationId: 'test-org',
+  })
+
+describe('Failed node routing', () => {
+  let engine: WorkflowEngine
+  let registry: NodeProcessorRegistry
+
+  beforeEach(() => {
+    executedNodes.length = 0
+    engine = new WorkflowEngine()
+    registry = engine.getNodeRegistry()
+    registry.registerProcessor(new MockTriggerProcessor())
+    registry.registerProcessor(new MockFailingProcessor())
+    registry.registerProcessor(new MockRecorderProcessor())
+  })
+
+  it('routes a failed node to its wired fail branch via the emitted outputHandle', async () => {
+    // The builder renders a 'fail' source handle (http/crud) and persists edges
+    // with sourceHandle 'fail'; the processor emits outputHandle 'fail' on failure.
+    const workflow = buildWorkflow({ failHandle: 'fail' }, 'fail')
+
+    const result = await runWorkflow(engine, workflow)
+
+    expect(result.status).toBe('COMPLETED')
+    expect(executedNodes).toContain('fail-handler')
+    expect(executedNodes).not.toContain('success-path')
+  })
+
+  it('still honors legacy onError edges as a fallback', async () => {
+    const workflow = buildWorkflow({ failHandle: 'fail' }, 'onError')
+
+    const result = await runWorkflow(engine, workflow)
+
+    expect(result.status).toBe('COMPLETED')
+    expect(executedNodes).toContain('fail-handler')
+    expect(executedNodes).not.toContain('success-path')
+  })
+
+  it('fails the workflow when a failed node has no wired fail branch', async () => {
+    const workflow = buildWorkflow({ failHandle: 'fail' })
+
+    const result = await runWorkflow(engine, workflow)
+
+    expect(result.status).toBe('FAILED')
+    expect(executedNodes).not.toContain('success-path')
+    expect(executedNodes).not.toContain('fail-handler')
+  })
+
+  it('never routes a failed node down the success path, even without an explicit handle', async () => {
+    // A Failed result with no outputHandle must not match the 'source' edge.
+    const workflow = buildWorkflow({ failHandle: undefined })
+
+    const result = await runWorkflow(engine, workflow)
+
+    expect(result.status).toBe('FAILED')
+    expect(executedNodes).not.toContain('success-path')
+  })
+
+  it('continues down the success path when a node swallows its error (http error_strategy none)', async () => {
+    // http with error_strategy 'none' returns Succeeded after an error and the
+    // builder renders only a 'source' handle for it — continuing down the
+    // success path with the error payload as output is the intended behavior.
+    const workflow = buildWorkflow({ succeedWithHandle: 'source' })
+
+    const result = await runWorkflow(engine, workflow)
+
+    expect(result.status).toBe('COMPLETED')
+    expect(executedNodes).toContain('success-path')
+    expect(executedNodes).not.toContain('fail-handler')
+  })
+
+  it('falls back to the source route for a succeeded result with an unmatched handle', async () => {
+    // Documents the deliberate getNextNodes fallback: a Succeeded result whose
+    // handle matches no persisted edge continues via 'source' (logged loudly).
+    const workflow = buildWorkflow({ succeedWithHandle: 'error' })
+
+    const result = await runWorkflow(engine, workflow)
+
+    expect(result.status).toBe('COMPLETED')
+    expect(executedNodes).toContain('success-path')
+    expect(executedNodes).not.toContain('fail-handler')
+  })
+})

--- a/packages/lib/src/workflow-engine/core/__tests__/loop-execution-manager.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/loop-execution-manager.test.ts
@@ -626,6 +626,81 @@ describe('LoopExecutionManager', () => {
         )
       ).rejects.toThrow('Node body-1 failed within loop')
     })
+
+    it('should route a failed body node to its wired fail branch', async () => {
+      const loopNode = createNode('loop-1', WorkflowNodeType.LOOP, 'Test Loop')
+      const bodyNode = createNode('body-1', WorkflowNodeType.CODE, 'Body Node')
+      const handlerNode = createNode('handler-1', WorkflowNodeType.CODE, 'Fail Handler')
+
+      const workflowWithFailBranch = {
+        ...mockWorkflow,
+        nodes: [loopNode, bodyNode, handlerNode],
+        graph: {
+          nodes: [loopNode, bodyNode, handlerNode],
+          edges: [
+            {
+              id: 'e1',
+              source: 'loop-1',
+              target: 'body-1',
+              sourceHandle: 'loop-start',
+              targetHandle: 'target',
+            },
+            {
+              id: 'e2',
+              source: 'body-1',
+              target: 'handler-1',
+              sourceHandle: 'fail',
+              targetHandle: 'target',
+            },
+            {
+              id: 'e3',
+              source: 'handler-1',
+              target: 'loop-1',
+              sourceHandle: 'source',
+              targetHandle: 'loop-back',
+            },
+          ],
+        },
+      }
+
+      executeNodeCallback.mockImplementation(async (node: WorkflowNode) => {
+        if (node.nodeId === 'body-1') {
+          return {
+            nodeId: node.nodeId,
+            status: NodeRunningStatus.Failed,
+            error: 'boom',
+            outputHandle: 'fail',
+            executionTime: 50,
+          }
+        }
+        return {
+          nodeId: node.nodeId,
+          status: NodeRunningStatus.Succeeded,
+          output: { handled: true },
+          executionTime: 50,
+        }
+      })
+
+      const mockProcessor: LoopProcessorMock = {
+        preprocessNode: vi.fn().mockResolvedValue({}),
+        execute: vi.fn().mockImplementation(async () => {
+          return await runLoopBody(mockProcessor, loopNode, contextManager)
+        }),
+      }
+
+      const options: WorkflowExecutionOptions = {}
+
+      await manager.setupLoopExecution(
+        loopNode,
+        mockProcessor,
+        contextManager,
+        options,
+        workflowWithFailBranch
+      )
+
+      expect(executeNodeCallback).toHaveBeenCalledWith(bodyNode, contextManager, options)
+      expect(executeNodeCallback).toHaveBeenCalledWith(handlerNode, contextManager, options)
+    })
   })
 
   describe('isLoopBackConnection', () => {

--- a/packages/lib/src/workflow-engine/core/graph-navigation.ts
+++ b/packages/lib/src/workflow-engine/core/graph-navigation.ts
@@ -49,6 +49,36 @@ export function getTargetsFromHandle(
 }
 
 /**
+ * Find the edge a failed node should route to, if any.
+ *
+ * Preference order:
+ * 1. The handle the processor emitted on failure (e.g. 'fail'), which matches
+ *    what the builder renders and persists for wired fail branches.
+ * 2. The legacy 'onError' handle, kept for back-compat with older graphs.
+ *
+ * The default 'source' handle is deliberately excluded — a failed node must
+ * never route down its success path. Returns undefined when no failure edge
+ * is wired (caller should treat the failure as fatal, as before).
+ */
+export function findFailureEdge(
+  workflow: Workflow,
+  nodeId: string,
+  outputHandle?: string
+): WorkflowEdge | undefined {
+  const edges = workflow.graph?.edges
+  if (!edges) return undefined
+
+  if (outputHandle && outputHandle !== 'source') {
+    const emittedEdge = edges.find(
+      (edge) => edge.source === nodeId && edge.sourceHandle === outputHandle
+    )
+    if (emittedEdge) return emittedEdge
+  }
+
+  return edges.find((edge) => edge.source === nodeId && edge.sourceHandle === 'onError')
+}
+
+/**
  * Get next node IDs based on node execution result and output handle
  *
  * All nodes return a single outputHandle (not the plural outputHandles array).

--- a/packages/lib/src/workflow-engine/core/loop-execution-manager.ts
+++ b/packages/lib/src/workflow-engine/core/loop-execution-manager.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/workflow-engine/core/loop-execution-manager.ts
 
 import type { ExecutionContextManager } from './execution-context'
-import { findNodeById, getTargetsFromHandle } from './graph-navigation'
+import { findFailureEdge, findNodeById, getTargetsFromHandle } from './graph-navigation'
 import type { LoopProgressUpdate } from './loop-progress-tracker'
 import type {
   NodeExecutionResult,
@@ -305,10 +305,8 @@ export class LoopExecutionManager {
 
       // Handle node failure
       if (result.status === NodeRunningStatus.Failed) {
-        // Check for error handling using edges
-        const errorEdge = workflow.graph?.edges?.find(
-          (edge) => edge.source === currentNode!.nodeId && edge.sourceHandle === 'onError'
-        )
+        // Route to a wired fail branch (emitted handle first, legacy 'onError' fallback)
+        const errorEdge = findFailureEdge(workflow, currentNode.nodeId, result.outputHandle)
 
         if (errorEdge) {
           const errorNode = findNodeById(workflow, errorEdge.target)

--- a/packages/lib/src/workflow-engine/core/workflow-engine.ts
+++ b/packages/lib/src/workflow-engine/core/workflow-engine.ts
@@ -23,7 +23,7 @@ import {
 import { ExecutionContextManager } from './execution-context'
 import { ExecutionTrackingManager } from './execution-tracking'
 import { calculateTotalTokens } from './execution-utils'
-import { findEntryNode, findNodeById, getNextNodeIds } from './graph-navigation'
+import { findEntryNode, findFailureEdge, findNodeById, getNextNodeIds } from './graph-navigation'
 import {
   type BranchArrivalStatus,
   JoinExecutionManager,
@@ -512,15 +512,15 @@ export class WorkflowEngine {
         break
       }
       if (result.status === NodeRunningStatus.Failed) {
-        // Check for error handling using edges
-        const errorEdge = workflow.graph?.edges?.find(
-          (edge) => edge.source === currentNode!.nodeId && edge.sourceHandle === 'onError'
-        )
+        // Route to a wired fail branch (emitted handle first, legacy 'onError' fallback)
+        const errorEdge = findFailureEdge(workflow, currentNode.nodeId, result.outputHandle)
         if (errorEdge) {
           const errorNode = findNodeById(workflow, errorEdge.target)
           if (errorNode) {
             currentNode = errorNode
-            contextManager.log('INFO', currentNode.name, 'Moving to error handler node')
+            contextManager.log('INFO', currentNode.name, 'Moving to error handler node', {
+              failureHandle: errorEdge.sourceHandle,
+            })
             continue
           }
         }

--- a/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
+++ b/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
@@ -851,6 +851,12 @@ export class WorkflowGraphBuilder {
 }
 
 /**
+ * Output handles that signal a failure/error outcome. Used to log loudly when
+ * such a handle has no wired edge and routing falls back to the success path.
+ */
+const ERROR_LIKE_HANDLES = new Set(['fail', 'error', 'onError'])
+
+/**
  * Helper functions for working with the workflow graph
  */
 export class WorkflowGraphHelper {
@@ -880,11 +886,25 @@ export class WorkflowGraphHelper {
     // Fallback to 'source' if specific handle not found
     if (!route && outputHandle !== 'source') {
       route = routeInfo.routes.get('source')
-      logger.debug('Fallback to source handle', {
-        nodeId,
-        originalHandle: outputHandle,
-        foundSourceRoute: !!route,
-      })
+      if (ERROR_LIKE_HANDLES.has(outputHandle)) {
+        // A succeeded result carrying an error-ish handle with no wired edge
+        // continues down the success path (e.g. http error_strategy 'none').
+        // Log loudly so this never silently masks a mis-wired fail branch.
+        // Failed results never reach this fallback — the engine routes them
+        // via findFailureEdge before consulting getNextNodes.
+        logger.warn('Unmatched error-ish output handle falling back to success path', {
+          nodeId,
+          originalHandle: outputHandle,
+          availableRoutes: Array.from(routeInfo.routes.keys()),
+          foundSourceRoute: !!route,
+        })
+      } else {
+        logger.debug('Fallback to source handle', {
+          nodeId,
+          originalHandle: outputHandle,
+          foundSourceRoute: !!route,
+        })
+      }
     }
 
     const result = route?.targetNodes || []

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/http.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/http.ts
@@ -427,8 +427,10 @@ export class HttpProcessor extends BaseNodeProcessor {
       if (config.error_strategy === 'none') {
         return {
           status: NodeRunningStatus.Succeeded,
+          // Continue on error: 'none' renders no fail handle in the builder, so
+          // execution proceeds down the success path with the error as output.
           output: { error: errorMessage, status: 0 },
-          outputHandle: 'error', // Error output handle
+          outputHandle: 'source',
         }
       } else if (config.error_strategy === 'default' && config.default_value.length > 0) {
         const defaultValues = await this.processDefaultValues(config.default_value, contextManager)
@@ -441,11 +443,12 @@ export class HttpProcessor extends BaseNodeProcessor {
         }
       }
 
-      // Default: fail
+      // Default: fail — 'fail' is the handle the builder renders and persists
+      // for the Fail Branch, so the engine can route to a wired handler.
       return {
         status: NodeRunningStatus.Failed,
         error: errorMessage,
-        outputHandle: 'error', // Error output handle
+        outputHandle: 'fail',
       }
     }
   }


### PR DESCRIPTION
## The bug

No wired Fail Branch ever executed in the workflow engine:

1. **Dead fail-branch routing.** When a node result came back `Failed`, `workflow-engine.ts` looked exclusively for an edge with `sourceHandle === 'onError'` and otherwise threw. No builder UI renders an `onError` handle and no processor emits one — the builder renders and persists `fail` handles (http, crud). So every user-drawn Fail Branch was dead: the workflow just failed with `Node <name> failed: ...` instead of routing to the handler the user wired.
2. **Duplicated in loops.** `loop-execution-manager.ts` had a copy of the same `onError`-only lookup for nodes failing inside a loop body.
3. **Handle-name drift.** The http processor emitted `outputHandle: 'error'` on failure while its builder node renders (and persists edges for) a `fail` handle, so even handle-aware routing would never have matched.

## The fix

- **`findFailureEdge` (new, `graph-navigation.ts`)** — shared by the engine's main loop and the loop-body executor so they can't diverge again. On `Failed`, it first looks for an edge whose `sourceHandle` matches the handle the processor emitted (e.g. `fail`), then falls back to the legacy `onError` lookup for back-compat. The default `source` handle is explicitly excluded so a failed node can never route down its success path. If neither edge exists, the failure stays fatal exactly as before.
- **http processor** now emits `outputHandle: 'fail'` on failure, matching the handle the builder renders and persists (`error_strategy: 'fail'`). The old `'error'` name never matched anything persisted, so renaming the processor side is safe.
- **`getNextNodes` fallback** — kept, but no longer silent for error-ish handles. When a *succeeded* result carries an unmatched `fail`/`error`/`onError` handle, the fallback to `source` now logs a **warn** with the available routes instead of a debug line. Failed results never reach this fallback anymore (they go through `findFailureEdge` first).

## Design decisions (and one deliberate non-fix)

- **http `error_strategy: 'none'` routing to the success path is intended, not a bug.** The processor deliberately returns `Succeeded` with the error payload as output, and the builder renders *only* a `source` handle for that strategy — "none" means continue on error. The processor now emits `outputHandle: 'source'` explicitly instead of relying on the fail-open fallback, so behavior is unchanged but no longer accidental.
- **Six dataset/transform processors left alone** (`dataset`, `knowledge-retrieval`, `chunker`, `document-extractor`, `list-processor`, `format-processor`) plus `execute`: they emit `Failed` + `outputHandle: 'error'`, but none of their builder nodes render any error/fail handle (`execute` has no builder node at all), so no persisted graph can contain a matching edge. Renaming would be meaningless; their failures stay fatal unless a legacy `onError` edge exists — same as today. If any of them grows a Fail Branch UI later, wiring works as long as the rendered handle id matches the emitted one.
- **Single-target routing on failure** — `findFailureEdge` returns the first matching edge, same as the legacy `onError` code path. Fanning a failure out to multiple handlers stays out of scope.

## Behavior changes

- Workflows with a wired Fail Branch on http (`error_strategy: 'fail'`) or crud nodes **now route to the handler instead of failing the run** — this is the intended fix. Runs that previously ended `FAILED` with `Node <name> failed` will now continue down the wired fail path, including inside loop bodies.
- Everything else is behavior-preserving: no fail branch wired → still fatal; legacy `onError` edges → still honored; http `'none'`/`'default'` strategies → unchanged.

## Tests

- New `failed-node-routing.test.ts` (engine level): routes via emitted handle, honors legacy `onError`, stays fatal without a wired branch, never routes `Failed` down `source`, and documents the `'none'` continue-on-error path plus the succeeded-unmatched-handle fallback. The wired-fail-branch case was written first and reproduced the bug (run ended `FAILED`) before the fix.
- New loop-body case in `loop-execution-manager.test.ts`: a failed body node routes to its wired `fail` handler (also reproduced the throw before the fix).
- Full engine suite: 53 files / 1013 tests green. `apps/web` workflow suite incl. builder↔engine parity: green. `packages/lib` tsc: no new errors (remaining ones pre-exist in `scripts/` and an unrelated signals test). Biome clean.
