### PR TITLE
fix(workflow): guard draft saves with a content-hash cas

### DIFF
--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -73,7 +73,16 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     if (error instanceof TRPCError) {
       return NextResponse.json(
         { error: error.message },
-        { status: error.code === 'NOT_FOUND' ? 404 : error.code === 'UNAUTHORIZED' ? 401 : 400 }
+        {
+          status:
+            error.code === 'NOT_FOUND'
+              ? 404
+              : error.code === 'UNAUTHORIZED'
+                ? 401
+                : error.code === 'CONFLICT'
+                  ? 409
+                  : 400,
+        }
       )
     }
 
@@ -109,7 +118,16 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     if (error instanceof TRPCError) {
       return NextResponse.json(
         { error: error.message },
-        { status: error.code === 'NOT_FOUND' ? 404 : error.code === 'UNAUTHORIZED' ? 401 : 400 }
+        {
+          status:
+            error.code === 'NOT_FOUND'
+              ? 404
+              : error.code === 'UNAUTHORIZED'
+                ? 401
+                : error.code === 'CONFLICT'
+                  ? 409
+                  : 400,
+        }
       )
     }
 

--- a/apps/web/src/components/workflow/hooks/use-workflow-save.ts
+++ b/apps/web/src/components/workflow/hooks/use-workflow-save.ts
@@ -45,6 +45,15 @@ export const useWorkflowSave = () => {
   const posthog = useAnalytics()
   const pendingRef = useRef<PendingChanges>({})
 
+  /**
+   * Set when a save was rejected with 409 CONFLICT — another tab/user saved the
+   * draft after this editor loaded it. Once conflicted, this editor stops
+   * saving entirely (autosave, beacon, manual): its in-memory graph is stale
+   * and every retry would just re-conflict (or clobber). The user reloads to
+   * continue; a reload remounts the hook and clears the flag.
+   */
+  const conflictRef = useRef(false)
+
   const workflowAppId = useWorkflowStore((s) => s.workflowAppId)
   const isDirty = useWorkflowStore((s) => s.isDirty)
   const markClean = useWorkflowStore((s) => s.markClean)
@@ -56,6 +65,14 @@ export const useWorkflowSave = () => {
   // Single tRPC mutation for all updates
   const updateMutation = api.workflow.update.useMutation({
     onError: (error) => {
+      if (error.data?.code === 'CONFLICT') {
+        conflictRef.current = true
+        toastError({
+          title: 'Workflow changed elsewhere',
+          description: `${error.message} Your unsaved changes here will not be saved automatically.`,
+        })
+        return
+      }
       toastError({
         title: 'Failed to save',
         description: error.message,
@@ -164,6 +181,13 @@ export const useWorkflowSave = () => {
       payload.graph = { nodes: cleanNodes, edges: cleanEdges, viewport: { x, y, zoom } }
       payload.triggerType = triggerType
       payload.entityDefinitionId = entityDefinitionId
+
+      // Optimistic-concurrency token: hash of the graph this editor loaded or
+      // last saved (seeded by `getById`, refreshed from each save's response
+      // via `setWorkflow`). The server compare-and-swaps against it and
+      // rejects with 409 if another editor saved in between.
+      const graphHash = (workflow as { graphHash?: string | null }).graphHash
+      if (graphHash) payload.expectedGraphHash = graphHash
     }
 
     // Metadata fields
@@ -192,6 +216,9 @@ export const useWorkflowSave = () => {
    */
   const executeSave = useCallback(async () => {
     if (isReadOnly) return false
+
+    // A conflicted editor never retries — see conflictRef.
+    if (conflictRef.current) return false
 
     // Check for error state in workflow store
     const workflowError = useWorkflowStore.getState().error
@@ -344,6 +371,10 @@ export const useWorkflowSave = () => {
    * This ensures workflow changes are saved even when the page is closed abruptly
    */
   const syncWorkflowWhenPageClose = useCallback(() => {
+    // A conflicted editor's graph is stale — a beacon save would clobber the
+    // other editor's changes (and marks the store clean on mere enqueue).
+    if (conflictRef.current) return
+
     // Check read-only state
     const canvasReadOnly = useCanvasStore.getState().readOnly
     const isViewerMode = useWorkflowStore.getState().isViewerMode

--- a/apps/web/src/components/workflow/types/core.ts
+++ b/apps/web/src/components/workflow/types/core.ts
@@ -55,6 +55,8 @@ export type FetchWorkflowResponse = {
   version: number
   triggerType: WorkflowTriggerType
   graph: { nodes: Node[]; edges: Edge[]; viewport: Viewport }
+  /** Content hash of `graph` — the save path's optimistic-concurrency token. */
+  graphHash?: string | null
   envVars: EnvVar[]
   variables: InputVariable[]
   organizationId: string

--- a/apps/web/src/server/api/routers/workflow.ts
+++ b/apps/web/src/server/api/routers/workflow.ts
@@ -33,6 +33,7 @@ import { recordAuditFromCtx } from '~/server/api/audit-context'
 import {
   capabilityProcedure,
   createTRPCRouter,
+  isAuxxError,
   notDemo,
   permissionProcedure,
 } from '~/server/api/trpc'
@@ -114,6 +115,13 @@ const updateWorkflowSchema = z.object({
     )
     .optional(),
   variables: z.array(z.any()).optional(),
+  /**
+   * Optimistic-concurrency token for draft graph saves: the `graphHash` the
+   * editor loaded (or got back from its last save). When present, the service
+   * compare-and-swaps against the stored draft graph and rejects with 409
+   * CONFLICT if another editor saved in between. Absent → unconditional write.
+   */
+  expectedGraphHash: z.string().optional(),
 
   // Access settings fields
   webEnabled: z.boolean().optional(),
@@ -451,6 +459,9 @@ export const workflowRouter = createTRPCRouter({
       try {
         return await workflowService.update(ctx.session.organizationId, input)
       } catch (error) {
+        // Let AuxxErrors (e.g. the draft-save ConflictError → 409) reach
+        // `auxxErrorMiddleware` instead of flattening them into a generic 500.
+        if (isAuxxError(error)) throw error
         if (error instanceof Error && error.message === 'Workflow not found') {
           throw new TRPCError({ code: 'NOT_FOUND', message: 'Workflow not found' })
         }

--- a/packages/lib/src/workflows/__tests__/workflow-draft-cas.test.ts
+++ b/packages/lib/src/workflows/__tests__/workflow-draft-cas.test.ts
@@ -1,0 +1,224 @@
+// packages/lib/src/workflows/__tests__/workflow-draft-cas.test.ts
+
+import { describe, expect, it, vi } from 'vitest'
+import { ConflictError } from '../../errors'
+import { hashWorkflowGraph } from '../graph-hash'
+
+/**
+ * Compare-and-swap on the workflow draft save path (`WorkflowService.update`).
+ *
+ * Three behaviors under test:
+ *  1. stale `expectedGraphHash` → `ConflictError` (409) and NO write;
+ *  2. matching `expectedGraphHash` → locked (`FOR UPDATE`) write + the new
+ *     graph's hash returned so the client can chain its next save;
+ *  3. absent `expectedGraphHash` → legacy unconditional write, no lock taken
+ *     (template install / system callers must not change behavior).
+ *
+ * Heavy sibling imports of `workflow-service.ts` (BullMQ queues, the engine,
+ * trigger schedulers, org cache) are stubbed per-module; `@auxx/database` and
+ * the drizzle builders stay on the shared setup mocks (never fully replaced —
+ * see src/test/database-mock.ts). The db handed to the service is a local fake:
+ * the service takes `db` via constructor, so no global database plumbing is
+ * needed.
+ */
+
+vi.mock('../../jobs/queues', () => ({
+  getQueue: vi.fn(),
+  Queues: {},
+}))
+vi.mock('../../workflow-engine/core/workflow-engine', () => ({
+  WorkflowEngine: class {},
+}))
+vi.mock('../../cache/invalidate', () => ({
+  onCacheEvent: vi.fn(async () => {}),
+}))
+vi.mock('../../cache/org-cache-helpers', () => ({
+  getCachedResources: vi.fn(async () => []),
+}))
+vi.mock('../../cache/workflow-app-queries', () => ({
+  getCachedWorkflowAppsList: vi.fn(async () => ({ workflows: [], total: 0 })),
+}))
+vi.mock('../mail-trigger-guard', () => ({
+  assertMailTriggerNotPersonal: vi.fn(async () => {}),
+}))
+vi.mock('../polling-trigger-service', () => ({
+  PollingTriggerService: class {
+    schedulePollingTrigger = vi.fn()
+    unschedulePollingTrigger = vi.fn()
+  },
+}))
+vi.mock('../scheduled-trigger-service', () => ({
+  ScheduledTriggerService: class {
+    scheduleWorkflowTriggers = vi.fn()
+    unscheduleWorkflowTriggers = vi.fn()
+  },
+}))
+
+import { schema } from '@auxx/database'
+import { WorkflowService } from '../workflow-service'
+
+const ORG = 'org_1'
+const APP_ID = 'app_1'
+const DRAFT_ID = 'wf_draft_1'
+
+/** The draft graph as this editor loaded it (insertion order A). */
+const storedGraph = {
+  nodes: [{ id: 'n1', type: 'standard', data: { type: 'manual', title: 'Start' } }],
+  edges: [],
+  viewport: { x: 0, y: 0, zoom: 1 },
+}
+
+/**
+ * The same graph as Postgres `jsonb` hands it back — key order NOT preserved.
+ * The CAS must treat this as identical to {@link storedGraph}.
+ */
+const storedGraphJsonb = {
+  viewport: { zoom: 1, y: 0, x: 0 },
+  edges: [],
+  nodes: [{ data: { title: 'Start', type: 'manual' }, type: 'standard', id: 'n1' }],
+}
+
+const newGraph = {
+  nodes: [{ id: 'n1', type: 'standard', data: { type: 'manual', title: 'Renamed' } }],
+  edges: [],
+  viewport: { x: 10, y: 5, zoom: 1 },
+}
+
+interface UpdateCall {
+  table: unknown
+  set: Record<string, unknown> | undefined
+}
+
+/** Fake transaction: records `.update()` writes and serves the FOR UPDATE read. */
+function makeTx(lockedRows: Array<{ graph: unknown; version: number }>) {
+  const updateCalls: UpdateCall[] = []
+  const forUpdate = { count: 0, mode: undefined as unknown }
+
+  const finalApp = {
+    id: APP_ID,
+    name: 'Order Sync',
+    organizationId: ORG,
+    draftWorkflowId: DRAFT_ID,
+    workflowId: null,
+    draftWorkflow: { id: DRAFT_ID, version: 4, graph: newGraph, triggerType: 'manual' },
+    publishedWorkflow: null,
+    createdBy: { id: 'user_1', name: 'A', email: 'a@example.com' },
+  }
+
+  const tx = {
+    select: vi.fn(() => {
+      const chain: Record<string, unknown> = {}
+      chain.from = vi.fn(() => chain)
+      chain.where = vi.fn(() => chain)
+      chain.for = vi.fn((mode: unknown) => {
+        forUpdate.count++
+        forUpdate.mode = mode
+        return chain
+      })
+      chain.limit = vi.fn(async () => lockedRows)
+      return chain
+    }),
+    update: vi.fn((table: unknown) => {
+      const call: UpdateCall = { table, set: undefined }
+      updateCalls.push(call)
+      const chain: Record<string, unknown> = {}
+      chain.set = vi.fn((values: Record<string, unknown>) => {
+        call.set = values
+        return chain
+      })
+      chain.where = vi.fn(async () => undefined)
+      return chain
+    }),
+    insert: vi.fn(),
+    query: { WorkflowApp: { findFirst: vi.fn(async () => finalApp) } },
+  }
+
+  return { tx, updateCalls, forUpdate }
+}
+
+function makeService(tx: ReturnType<typeof makeTx>['tx']) {
+  const existingApp = {
+    id: APP_ID,
+    name: 'Order Sync',
+    organizationId: ORG,
+    draftWorkflow: { id: DRAFT_ID, version: 3, graph: storedGraphJsonb, triggerType: 'manual' },
+    publishedWorkflow: null,
+  }
+  const db = {
+    query: { WorkflowApp: { findFirst: vi.fn(async () => existingApp) } },
+    transaction: vi.fn(async (fn: (t: unknown) => Promise<unknown>) => fn(tx)),
+  }
+  return new WorkflowService(db as never)
+}
+
+describe('hashWorkflowGraph', () => {
+  it('is independent of object key order (jsonb round-trip)', () => {
+    expect(hashWorkflowGraph(storedGraph)).toBe(hashWorkflowGraph(storedGraphJsonb))
+  })
+
+  it('differs for different content', () => {
+    expect(hashWorkflowGraph(storedGraph)).not.toBe(hashWorkflowGraph(newGraph))
+  })
+})
+
+describe('WorkflowService.update draft CAS', () => {
+  it('rejects a stale expectedGraphHash with ConflictError and writes nothing', async () => {
+    const { tx, updateCalls } = makeTx([{ graph: storedGraphJsonb, version: 3 }])
+    const service = makeService(tx)
+
+    const staleHash = hashWorkflowGraph(newGraph) // NOT what is stored
+    const promise = service.update(ORG, {
+      id: APP_ID,
+      graph: newGraph,
+      expectedGraphHash: staleHash,
+    })
+
+    await expect(promise).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(ConflictError)
+      expect((error as ConflictError).statusCode).toBe(409)
+      expect((error as ConflictError).message).toContain('Order Sync')
+      return true
+    })
+    expect(updateCalls).toHaveLength(0)
+  })
+
+  it('writes under FOR UPDATE and returns the new graph hash when the hash matches', async () => {
+    const { tx, updateCalls, forUpdate } = makeTx([{ graph: storedGraphJsonb, version: 3 }])
+    const service = makeService(tx)
+
+    // The hash the editor computed from its (differently key-ordered) load.
+    const expectedGraphHash = hashWorkflowGraph(storedGraph)
+    const result = await service.update(ORG, {
+      id: APP_ID,
+      graph: newGraph,
+      expectedGraphHash,
+    })
+
+    expect(forUpdate.count).toBe(1)
+    expect(forUpdate.mode).toBe('update')
+
+    const draftWrite = updateCalls.find((c) => c.table === schema.Workflow)
+    expect(draftWrite).toBeDefined()
+    expect(draftWrite?.set?.graph).toBe(newGraph)
+    // Version bump comes from the LOCKED row, not the unlocked pre-read.
+    expect(draftWrite?.set?.version).toBe(4)
+
+    expect(result.graphHash).toBe(hashWorkflowGraph(newGraph))
+  })
+
+  it('keeps the legacy unconditional write when expectedGraphHash is absent', async () => {
+    const { tx, updateCalls, forUpdate } = makeTx([])
+    const service = makeService(tx)
+
+    const result = await service.update(ORG, { id: APP_ID, graph: newGraph })
+
+    // No lock, no compare — and the write still lands.
+    expect(forUpdate.count).toBe(0)
+    expect(tx.select).not.toHaveBeenCalled()
+    const draftWrite = updateCalls.find((c) => c.table === schema.Workflow)
+    expect(draftWrite).toBeDefined()
+    expect(draftWrite?.set?.graph).toBe(newGraph)
+    expect(draftWrite?.set?.version).toBe(4)
+    expect(result.graphHash).toBe(hashWorkflowGraph(newGraph))
+  })
+})

--- a/packages/lib/src/workflows/graph-hash.ts
+++ b/packages/lib/src/workflows/graph-hash.ts
@@ -1,0 +1,18 @@
+// packages/lib/src/workflows/graph-hash.ts
+
+import { createHash } from 'node:crypto'
+import { stableStringify } from '@auxx/utils/json'
+
+/**
+ * SHA-256 content hash of a workflow draft graph — the token for the draft
+ * save path's compare-and-swap (mirrors `hashDoc` in
+ * `agents/procedures/authoring/queries.ts`).
+ *
+ * Serializes with {@link stableStringify} (sorted keys) so the hash is stable
+ * across the Postgres `jsonb` round-trip: `jsonb` does NOT preserve object key
+ * order, so a plain `JSON.stringify` of the in-memory graph would not match
+ * the same graph read back from the column — every save would look stale.
+ */
+export function hashWorkflowGraph(graph: unknown): string {
+  return createHash('sha256').update(stableStringify(graph), 'utf8').digest('hex')
+}

--- a/packages/lib/src/workflows/types.ts
+++ b/packages/lib/src/workflows/types.ts
@@ -69,6 +69,14 @@ export interface WorkflowUpdateInput {
   graph?: WorkflowGraph
   envVars?: EnvironmentVariable[]
   variables?: any[]
+  /**
+   * Optimistic-concurrency token for draft saves: the {@link hashWorkflowGraph}
+   * of the graph the caller loaded (or last saved). When present, the update
+   * locks the draft row, recomputes the stored graph's hash and rejects with a
+   * `ConflictError` (409) on mismatch — a concurrent editor saved in between.
+   * When absent, the write is unconditional (template install / system paths).
+   */
+  expectedGraphHash?: string
 
   // Access settings
   webEnabled?: boolean

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -7,9 +7,10 @@ import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import { onCacheEvent } from '../cache/invalidate'
 import { getCachedResources } from '../cache/org-cache-helpers'
 import { getCachedWorkflowAppsList } from '../cache/workflow-app-queries'
-import { NotFoundError } from '../errors'
+import { ConflictError, NotFoundError } from '../errors'
 import { getQueue, Queues } from '../jobs/queues'
 import { WorkflowEngine } from '../workflow-engine/core/workflow-engine'
+import { hashWorkflowGraph } from './graph-hash'
 import { assertMailTriggerNotPersonal } from './mail-trigger-guard'
 import { PollingTriggerService } from './polling-trigger-service'
 import { ScheduledTriggerService } from './scheduled-trigger-service'
@@ -42,6 +43,8 @@ export function toWorkflowAppResponse(workflowApp: WorkflowWithDetails) {
     entityDefinitionId: workflowData?.entityDefinitionId,
     version: workflowData?.version || 1,
     graph: workflowData?.graph,
+    // Seed for the editor's optimistic-concurrency token (see WorkflowUpdateInput.expectedGraphHash)
+    graphHash: workflowData?.graph ? hashWorkflowGraph(workflowData.graph) : null,
     variables: workflowData?.variables || [],
     envVars: workflowData?.envVars,
     organizationId: workflowApp.organizationId,
@@ -393,6 +396,7 @@ export class WorkflowService {
         graph,
         envVars,
         variables,
+        expectedGraphHash,
         webEnabled,
         apiEnabled,
         accessMode,
@@ -448,8 +452,36 @@ export class WorkflowService {
 
         // Update draft workflow (always update draft, not published)
         if (existingWorkflowApp.draftWorkflow) {
+          let draftVersion = existingWorkflowApp.draftWorkflow.version
+
+          // Compare-and-swap draft write: lock the draft row so a concurrent
+          // save can't slip between read and write, then verify the stored
+          // graph still hashes to what this caller loaded. Without this, two
+          // editor tabs silently clobber each other — the stale tab's autosave
+          // overwrites the other tab's changes. Callers that don't send
+          // `expectedGraphHash` (template install, system paths) keep the
+          // unconditional write.
+          if (expectedGraphHash !== undefined) {
+            const [lockedDraft] = await tx
+              .select({ graph: schema.Workflow.graph, version: schema.Workflow.version })
+              .from(schema.Workflow)
+              .where(eq(schema.Workflow.id, existingWorkflowApp.draftWorkflow.id))
+              .for('update')
+              .limit(1)
+            if (!lockedDraft) {
+              throw new NotFoundError(`Draft for workflow "${existingWorkflowApp.name}" not found`)
+            }
+            const currentHash = hashWorkflowGraph(lockedDraft.graph)
+            if (currentHash !== expectedGraphHash) {
+              throw new ConflictError(
+                `The draft of workflow "${existingWorkflowApp.name}" changed while you were editing. Reload the workflow to get the latest version — saving now would overwrite those changes.`
+              )
+            }
+            draftVersion = lockedDraft.version
+          }
+
           const workflowUpdates: any = {
-            version: existingWorkflowApp.draftWorkflow.version + 1,
+            version: draftVersion + 1,
             updatedAt: new Date(),
           }
 
@@ -623,6 +655,9 @@ export class WorkflowService {
           triggerType: workflowData?.triggerType,
           entityDefinitionId: workflowData?.entityDefinitionId,
           graph: workflowData?.graph,
+          // New optimistic-concurrency token — the client chains its next
+          // save's `expectedGraphHash` from this.
+          graphHash: workflowData?.graph ? hashWorkflowGraph(workflowData.graph) : null,
           envVars: workflowData?.envVars,
           variables: workflowData?.variables || [],
           organizationId: result.organizationId,


### PR DESCRIPTION
## The bug

`WorkflowService.update` bumped the draft `Workflow` row's `version` on every save but wrote with a bare `.where(eq(Workflow.id, …))` — no compare-and-swap, no row lock. Two writers silently clobbered each other: with two editor tabs open on one workflow, the stale tab's autosave overwrote the other tab's changes (field-observed in `plans/workflow/HANDOFF-contract-drift.md`).

## The fix — copied precedent

Mirrors `updateAttachedProcedureDraftIfHash` in `packages/lib/src/agents/procedures/authoring/queries.ts`: inside the save transaction, `SELECT … FOR UPDATE` the draft row, recompute the stored graph's content hash, and reject with a `ConflictError` (409, `@auxx/lib/errors`) if it no longer matches the hash the editor loaded. The lock closes the read→compare→write race; the hash makes the guard content-based rather than counter-based.

- **`packages/lib/src/workflows/graph-hash.ts`** (new): `hashWorkflowGraph` — SHA-256 over `stableStringify` from `@auxx/utils/json` (same helper the procedure hash uses). **This is load-bearing**: the graph lives in a `jsonb` column and Postgres `jsonb` does not preserve object key order, so a plain `JSON.stringify` of the in-memory graph would never match the round-tripped column value and every save would look stale. Sorted-key serialization makes the hash stable across the round-trip.
- **`workflow-service.ts`**: `update` accepts optional `expectedGraphHash`. When present → lock + compare + conflict on mismatch; the version bump also comes from the locked row instead of the unlocked pre-read. When absent → behavior unchanged. Both `toWorkflowAppResponse` (seeds the editor on load) and the update response now carry `graphHash` so the client can chain saves.
- **Router** (`workflow.update`): threads `expectedGraphHash` through zod. Also fixes the router's catch-all, which would have flattened the 409 into a generic 500 — AuxxErrors now rethrow via `isAuxxError` so `auxxErrorMiddleware` maps them (per CLAUDE.md). The REST `PUT`/`POST /api/workflows/[id]` handlers map `CONFLICT` → 409 as well.
- **Client** (`use-workflow-save.ts`): graph saves send the hash of the graph the editor loaded / last saved (seeded by `getById`, refreshed from each save's response via the existing `setWorkflow` call). On 409: `toastError` telling the user the workflow changed elsewhere and to reload — no auto-retry, no auto-reload — and the editor stops saving (autosave, manual, and the page-close beacon) until reloaded, since every retry from a stale graph would re-conflict or clobber.

## What happens to each caller class

| Caller | Sends hash? | Behavior |
| --- | --- | --- |
| Editor graph autosave / manual save / beacon | yes | CAS-guarded; 409 on concurrent edit |
| Editor metadata/settings/env-var-only saves | no (no graph in payload) | unchanged; they don't touch the graph, and a version-counter skew is harmless |
| Template install, `createForResource`, system/seed paths | no | unchanged, unconditional write |
| First save when no draft row exists yet | n/a | draft-create branch, nothing to CAS against; if another tab created the draft first, the next guarded save conflicts correctly. (The pre-existing double-create race on this branch is untouched.) |

## Tests

- `packages/lib/src/workflows/__tests__/workflow-draft-cas.test.ts`: hash key-order independence (simulated jsonb reorder); stale hash → `ConflictError` + zero writes; matching hash → `FOR UPDATE` taken, write lands, locked row's version used, new hash returned; absent hash → no lock, legacy write.
- `cd packages/lib && vitest run src/workflows` — 155 passed; `cd apps/web && vitest run src/components/workflow` — 78 passed; router suite `workflow-instance-access.test.ts` — 95 passed.
- Scoped typechecks (`tsc --noEmit` in `packages/lib` and `apps/web`): zero errors in touched files (remaining lib errors are the known pre-existing baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)