### PR TITLE
test(workflow): assert handle parity and written-to-advertised coverage

### DIFF
--- a/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
+++ b/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
@@ -2,17 +2,22 @@
 
 import { describe, expect, it } from 'vitest'
 import type { UnifiedVariable } from '~/components/workflow/types/variable-types'
+import { BUILDER_RENDERED_HANDLES } from './builder-rendered-handles'
 import {
   EXTRACTION_BLIND_SPOTS,
   KNOWN_BROKEN_CONFIG_KEYS,
   KNOWN_BROKEN_FAILURE_PATH_WRITES,
+  KNOWN_BROKEN_OUTPUT_HANDLES,
   KNOWN_BROKEN_OUTPUT_VARIABLES,
+  KNOWN_BROKEN_UNADVERTISED_WRITES,
 } from './contract-drift-allowlist'
 import {
   advertisedPath,
   builderDeclaredKeys,
   isPathWritten,
+  isWriteAdvertised,
   readEngineContracts,
+  readEngineRoutedHandleLiterals,
 } from './engine-contract'
 import { BUILDER_NODE_DEFINITIONS, CONFIG_VARIANTS } from './node-definitions'
 
@@ -23,19 +28,32 @@ import { BUILDER_NODE_DEFINITIONS, CONFIG_VARIANTS } from './node-definitions'
 // — at audit time the only assertion in the repo that "everything the UI offers
 // actually dispatches", and the only condition surface that had not drifted.
 //
-// The workflow builder and the workflow engine agree on two contracts, and
-// neither is expressed in a type:
+// The workflow builder and the workflow engine agree on three contracts, and
+// none of them is expressed in a type:
 //
 //   1. OUTPUT VARIABLES. The builder's `outputVariables(config, nodeId, ctx)`
 //      is what the variable picker offers downstream nodes. The engine makes a
 //      value addressable ONLY by calling `setNodeVariable(nodeId, path, value)`.
 //      A path the picker offers that the engine never writes resolves to `''`
 //      (or `undefined`) at run time — no error, no warning, just a branch that
-//      never fires or an email with a hole in it.
+//      never fires or an email with a hole in it. Asserted in BOTH directions:
+//      advertised-but-never-written (a picker entry that resolves to nothing)
+//      and written-but-never-advertised (a real value no picker will ever
+//      offer — crud's create/update outputs shipped this way).
 //
 //   2. CONFIG KEYS. The panel writes `node.data.<key>`; the processor reads it.
 //      A rename on one side is a silent no-op on the other — the audit's
 //      `data.assigneeId` vs `data.assignee` and `config.logic` findings.
+//
+//   3. BRANCH HANDLES. A processor picks its outgoing edge by returning
+//      `outputHandle`; the canvas can only draw edges from handles the node's
+//      UI renders; and the engine core additionally goes LOOKING for literal
+//      handles of its own (`sourceHandle === 'onError'` on the Failed path).
+//      Three vocabularies, no shared declaration — which is how crud came to
+//      emit `fail`, http `error`, the UI to render `fail`, and the Failed path
+//      to search for `onError`, with no two of them meeting. The builder half
+//      is the hand-verified table in `builder-rendered-handles.ts` (interim
+//      until a lib-side handle manifest exists).
 //
 // This half lives in `apps/web` and not beside the engine because the
 // declarations it reads are here: `nodes/core/*/schema.ts`. `packages/lib` is
@@ -246,6 +264,39 @@ describe('engine reader — attributes a .data read to the right node and the ri
   })
 })
 
+describe('engine reader — extracts the outputHandle values a processor can emit', () => {
+  it('collects both arms of a conditional emission', () => {
+    // document-extractor.ts:294 `outputHandle: extractionResult.success ?
+    // 'source' : 'error'` — one expression, two emittable handles. A reader
+    // that only accepted a bare literal would see neither.
+    expect(ENGINE.get('document-extractor')?.outputHandles).toEqual(
+      expect.arrayContaining(['error', 'source'])
+    )
+  })
+
+  it('does not read a ternary CONDITION literal as an emission', () => {
+    // text-classifier.ts:117 `config.outputMode === 'variable' ? 'source' :
+    // getOutputHandleForCategory(…)` — `'variable'` is a comparison operand.
+    // Collecting it would invent a handle the node can never emit and file a
+    // phantom mismatch against a panel that is entirely correct.
+    const classifier = ENGINE.get('text-classifier')
+    expect(classifier?.outputHandles).toContain('source')
+    expect(classifier?.outputHandles).not.toContain('variable')
+  })
+
+  it('records a computed handle as dynamic rather than guessing at its values', () => {
+    // human-confirmation.ts:322 routes via `handleForApprovalOutcome(outcome)`
+    // (resolved in core/pause-resume.ts — approved/denied/timeout/source) and
+    // if-else.ts:178 via `outputHandle = matchedCaseId`. Neither is readable
+    // here, so both must surface as gaps, not as empty emission sets silently
+    // passing.
+    expect(ENGINE.get('human-confirmation')?.dynamicOutputHandles.join(' ')).toContain(
+      'handleForApprovalOutcome'
+    )
+    expect(ENGINE.get('if-else')?.dynamicOutputHandles.join(' ')).toContain('matchedCaseId')
+  })
+})
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 1. OUTPUT VARIABLES
 // ═══════════════════════════════════════════════════════════════════════════
@@ -361,6 +412,58 @@ describe('output variables — every path the picker offers is one the engine wr
       EXTRACTION_BLIND_SPOTS
     )
   })
+
+  it('advertises every path the engine writes — the reverse direction', () => {
+    // The forward assertion proves the picker never promises what the engine
+    // does not deliver. This one proves the engine never delivers what the
+    // picker does not offer: a `setNodeVariable` path `outputVariables` omits
+    // is a real value at run time that no variable picker will ever show, so
+    // downstream nodes can only reach it by typing the path blind. crud's
+    // create/update outputs shipped exactly this way — `.id` and `.record`
+    // written on every create, advertised for none of them.
+    //
+    // Same floor as the forward direction: the advertised set is the union over
+    // `defaultData` plus CONFIG_VARIANTS, so a path advertised only under a
+    // config that cannot be pinned here (crud/find in resource mode need a live
+    // Resource) reads as unadvertised and belongs in the blind-spot map, not in
+    // the burn-down list.
+    const observed = new Map<string, string>()
+
+    for (const { nodeType, definition } of BUILDER_NODE_DEFINITIONS) {
+      const contract = ENGINE.get(nodeType)
+      if (!contract) continue
+
+      const advertised = new Set<string>()
+      let threw = false
+      for (const config of configsFor(nodeType, definition.defaultData ?? {})) {
+        try {
+          for (const id of flatten(
+            definition.outputVariables(config.data, NODE_ID, outputVariableContext) ?? []
+          )) {
+            advertised.add(advertisedPath(id, NODE_ID))
+          }
+        } catch {
+          threw = true // reported by the forward assertion
+        }
+      }
+      if (threw) continue
+
+      for (const write of contract.writes) {
+        if (isWriteAdvertised(write, advertised)) continue
+        observed.set(
+          `written:${nodeType}.${write}`,
+          `engine writes this path (${contract.files.join(', ')}) but outputVariables never advertises it under any pinned config — invisible in the variable picker`
+        )
+      }
+    }
+
+    assertAgainstAllowlist(
+      observed,
+      'written:',
+      KNOWN_BROKEN_UNADVERTISED_WRITES,
+      EXTRACTION_BLIND_SPOTS
+    )
+  })
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -409,5 +512,87 @@ describe('config keys — every node.data key the engine reads has a builder wri
     }
 
     assertAgainstAllowlist(observed, 'config:', KNOWN_BROKEN_CONFIG_KEYS, EXTRACTION_BLIND_SPOTS)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. BRANCH HANDLES
+//
+// A processor returns `outputHandle` and the engine follows the edge whose
+// `sourceHandle` matches it (graph-navigation.ts:67-68) — falling back to
+// 'source' when unset. The canvas can only draw an edge FROM a handle the
+// node's UI renders. So an emitted handle the UI does not render is a branch no
+// user can wire: the result routes to a handle with no possible edge and the
+// run simply stops there. No error, no warning — the exact failure mode of the
+// live `fail`/`error`/`onError` mismatch these assertions pin down.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('branch handles — every handle the engine can emit is one the builder renders', () => {
+  it('declares rendered handles for exactly the palette', () => {
+    // The table is hand-written, so its completeness is itself an assertion —
+    // a palette node without an entry would silently skip the handle check the
+    // same way a missing CONFIG_VARIANTS entry silently skips a branch.
+    const palette = BUILDER_NODE_DEFINITIONS.map(({ nodeType }) => nodeType).sort()
+    expect(Object.keys(BUILDER_RENDERED_HANDLES).sort()).toEqual(palette)
+  })
+
+  it('emits only handles the builder renders, or the default source', () => {
+    // 'source' is always acceptable: it is the engine-wide fallback
+    // (`result.outputHandle || 'source'`) and edge sourceHandles default to it
+    // too (workflow-graph-builder.ts:442), so even a node whose UI names its
+    // handle differently (form-input's `input-output`) routes a plain 'source'
+    // result over its only edge.
+    const observed = new Map<string, string>()
+
+    for (const { nodeType } of BUILDER_NODE_DEFINITIONS) {
+      const contract = ENGINE.get(nodeType)
+      const rendered = BUILDER_RENDERED_HANDLES[nodeType]
+      if (!contract || !rendered) continue
+
+      for (const handle of contract.outputHandles) {
+        if (handle === 'source' || rendered.sources.includes(handle)) continue
+        // Computed handles are named in the detail for the same reason the
+        // variable assertion names unresolvable bulk payloads: whoever
+        // regenerates the allowlist must know the literal set is a floor.
+        const dynamicNote = contract.dynamicOutputHandles.length
+          ? ` — NOTE: this node also emits computed handles (${contract.dynamicOutputHandles.join('; ')}), which are not asserted`
+          : ''
+        observed.set(
+          `handle:${nodeType}.${handle}`,
+          `engine can emit outputHandle '${handle}' (${contract.files.join(', ')}) but the UI renders only [${[
+            ...rendered.sources,
+            ...(rendered.dynamicSources ? ['<dynamic>'] : []),
+          ].join(', ')}] — no edge can ever leave this branch${dynamicNote}`
+        )
+      }
+    }
+
+    assertAgainstAllowlist(observed, 'handle:', KNOWN_BROKEN_OUTPUT_HANDLES, EXTRACTION_BLIND_SPOTS)
+  })
+
+  it('searches for edges only on handles some node renders', () => {
+    // The engine core's own literal lookups — today the Failed-path recovery,
+    // which hunts for an `onError` edge. A literal here that no node's UI ever
+    // renders is a recovery path that cannot fire on any canvas a user can
+    // build.
+    const rendered = new Set(
+      Object.values(BUILDER_RENDERED_HANDLES).flatMap(({ sources }) => sources)
+    )
+    const observed = new Map<string, string>()
+
+    for (const { handle, file } of readEngineRoutedHandleLiterals()) {
+      if (handle === 'source' || rendered.has(handle)) continue
+      observed.set(
+        `routing:engine-core.${handle}`,
+        `the engine core looks for an edge with sourceHandle === '${handle}' (${file}) but no node's UI renders that handle, so the lookup can never match`
+      )
+    }
+
+    assertAgainstAllowlist(
+      observed,
+      'routing:',
+      KNOWN_BROKEN_OUTPUT_HANDLES,
+      EXTRACTION_BLIND_SPOTS
+    )
   })
 })

--- a/apps/web/src/components/workflow/parity/builder-rendered-handles.ts
+++ b/apps/web/src/components/workflow/parity/builder-rendered-handles.ts
@@ -1,0 +1,168 @@
+// apps/web/src/components/workflow/parity/builder-rendered-handles.ts
+
+import { NodeType } from '~/components/workflow/types/node-types'
+
+/**
+ * The handles each builder node's UI actually renders — the builder half of the
+ * HANDLE contract, beside the engine half `engine-contract.ts` extracts
+ * (`outputHandles` per processor, plus `readEngineRoutedHandleLiterals` for the
+ * core's own edge lookups).
+ *
+ * ── WHY A HAND-WRITTEN TABLE ────────────────────────────────────────────────
+ * There is no central declaration of rendered handles anywhere in the builder —
+ * that absence IS the finding this file records. Each node's `node.tsx` places
+ * its own `<NodeSourceHandle handleId=…>` / `<NodeTargetHandle handleId=…>`
+ * elements, the engine's `WorkflowGraphBuilder.getNodeHandles`
+ * (`packages/lib/src/workflow-engine/core/workflow-graph-builder.ts:476`)
+ * hard-codes its OWN per-type list, and nothing ever compares the two. That
+ * blind spot hid a whole bug family: crud emits `outputHandle: 'fail'`, http
+ * and six other processors emit `'error'`, the UI renders `fail` handles, and
+ * the engine's Failed-path recovery looks for `sourceHandle === 'onError'` —
+ * and none of them meet.
+ *
+ * This table is the INTERIM contract. The durable fix is a per-node handle
+ * manifest in `packages/lib` that the graph builder, the processors and the
+ * node components all consume — when that lands, this file is replaced by an
+ * import and the parity test compares the engine against the manifest instead.
+ * Until then: every entry below was verified against the cited render site, and
+ * a node whose UI changes its handles MUST update its entry (the completeness
+ * assertion in the test fails on a palette node with no entry).
+ *
+ * ── WHAT AN ENTRY MEANS ─────────────────────────────────────────────────────
+ * `sources` / `targets` are the LITERAL handle ids the node's component passes
+ * to `<NodeSourceHandle>` / `<NodeTargetHandle>` (or raw `<Handle>`), including
+ * ones rendered conditionally (crud/http render `fail` only when
+ * `error_strategy === 'fail'`; the human node renders `timeout` only when a
+ * timeout is configured) — a conditionally-rendered handle is still one the
+ * builder can produce an edge for, which is what the parity question needs.
+ * `dynamicSources` documents branch handles whose ids are USER DATA (if-else
+ * case ids, text-classifier category ids); they cannot be enumerated here, and
+ * the engine emits them via computed expressions the static reader records as
+ * `dynamicOutputHandles` anyway, so neither side's dynamic half is asserted —
+ * the prose keeps the shape written down.
+ */
+export interface RenderedHandles {
+  /** Literal source-handle ids the node's UI renders. */
+  sources: string[]
+  /** Literal target-handle ids the node's UI renders. */
+  targets: string[]
+  /** Branch handles whose ids are user data — a description, not an id list. */
+  dynamicSources?: string
+}
+
+export const BUILDER_RENDERED_HANDLES: Record<string, RenderedHandles> = {
+  // nodes/core/ai/node.tsx:39 (source), :13 (target)
+  [NodeType.AI]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/answer/node.tsx:13 (source), :12 (target)
+  [NodeType.ANSWER]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/chunker/node.tsx:83 (source), :41 (target)
+  [NodeType.CHUNKER]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/code/node.tsx:20 (source), :14 (target)
+  [NodeType.CODE]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/crud/node.tsx:63 (source), :83 (fail — rendered when
+  // `hasFailBranch`, i.e. error_strategy === 'fail'), :48 (target)
+  [NodeType.CRUD]: { sources: ['source', 'fail'], targets: ['target'] },
+
+  // nodes/core/dataset/node.tsx:95 (source), :38 (target)
+  [NodeType.DATASET]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/date-time/node.tsx:53 (source), :42 (target)
+  [NodeType.DATE_TIME]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/document-extractor/node.tsx:60 (source), :34 (target)
+  [NodeType.DOCUMENT_EXTRACTOR]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/end/node.tsx:30 (source), :17 (target)
+  [NodeType.END]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/find/node.tsx:108 (source), :58 (target)
+  [NodeType.FIND]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/format/node.tsx:35 (source), :23 (target)
+  [NodeType.FORMAT]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/inputs/form-input/node.tsx:23 — a single `input-output` source that
+  // wires into another node's `input` handle; no target, no plain `source`.
+  // (Its processor still emits 'source', which the assertion always accepts —
+  // when wired into a trigger the node is NON_EXECUTABLE anyway, see
+  // form-input-processor.ts:83.)
+  [NodeType.FORM_INPUT]: { sources: ['input-output'], targets: [] },
+
+  // nodes/core/http/node.tsx:32 (source), :50 (fail — rendered when
+  // error_strategy === 'fail'), :21 (target)
+  [NodeType.HTTP]: { sources: ['source', 'fail'], targets: ['target'] },
+
+  // nodes/core/human/node.tsx:89 (approved), :102 (denied), :122 (timeout —
+  // rendered when a timeout is configured), :57 (target)
+  [NodeType.HUMAN_CONFIRMATION]: {
+    sources: ['approved', 'denied', 'timeout'],
+    targets: ['target'],
+  },
+
+  // nodes/core/if-else/node.tsx:96 (one handle per case, id = case_id),
+  // :128 (false — the ELSE arm), :78 (target)
+  [NodeType.IF_ELSE]: {
+    sources: ['false'],
+    targets: ['target'],
+    dynamicSources: 'one source handle per configured case, handleId = case_id (node.tsx:96)',
+  },
+
+  // nodes/core/information-extractor/node.tsx:67 (source), :25 (target)
+  [NodeType.INFORMATION_EXTRACTOR]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/knowledge-retrieval/node.tsx:87 (source), :39 (target)
+  [NodeType.KNOWLEDGE_RETRIEVAL]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/list/node.tsx:107 (source), :76 (target)
+  [NodeType.LIST]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/loop/node.tsx:36 (loop-start, into the loop body), :150 (source,
+  // after the loop), :146 (target), :54 (loop-back — where the last node in the
+  // body connects to close the iteration). Handle ids from LOOP_HANDLES
+  // (nodes/core/loop/constants.ts:19).
+  [NodeType.LOOP]: { sources: ['loop-start', 'source'], targets: ['target', 'loop-back'] },
+
+  // nodes/core/manual/node.tsx:23 (source), :29 (input — the target that
+  // form-input nodes wire their `input-output` into)
+  [NodeType.MANUAL]: { sources: ['source'], targets: ['input'] },
+
+  // nodes/core/message-received/node.tsx:15 (source; trigger, no target)
+  [NodeType.MESSAGE_RECEIVED]: { sources: ['source'], targets: [] },
+
+  // nodes/core/note/node.tsx:105 (target), :110 (source) — both invisible and
+  // `isConnectable={false}`, rendered only to suppress React Flow warnings. A
+  // note has no runtime, so nothing routes over them.
+  [NodeType.NOTE]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/resource-trigger/node.tsx:28 (source; trigger, no target)
+  [NodeType.RESOURCE_TRIGGER]: { sources: ['source'], targets: [] },
+
+  // nodes/core/scheduled/node.tsx:32 (source; trigger, no target)
+  [NodeType.SCHEDULED]: { sources: ['source'], targets: [] },
+
+  // nodes/core/text-classifier/node.tsx:61 (source — variable mode only),
+  // :79 (one handle per category, id = category.id — branches mode),
+  // :93 (unmatched — branches mode), :30 (target)
+  [NodeType.TEXT_CLASSIFIER]: {
+    sources: ['source', 'unmatched'],
+    targets: ['target'],
+    dynamicSources:
+      'branches mode renders one source handle per category, handleId = category.id (node.tsx:79)',
+  },
+
+  // nodes/core/var-assign/node.tsx:59 (source), :24 (target)
+  [NodeType.VAR_ASSIGN]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/wait/node.tsx:125 (source), :76 (target)
+  [NodeType.WAIT]: { sources: ['source'], targets: ['target'] },
+
+  // nodes/core/webhook/node.tsx:17 (source; trigger, no target)
+  [NodeType.WEBHOOK]: { sources: ['source'], targets: [] },
+
+  // nodes/core/webhook-trigger/node.tsx:26 (source; trigger, no target)
+  [NodeType.WEBHOOK_ENDPOINT]: { sources: ['source'], targets: [] },
+}

--- a/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
+++ b/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
@@ -11,11 +11,13 @@
  *
  * ── WHY THIS FILE EXISTS ────────────────────────────────────────────────────
  * The parity suite asserts that everything the builder ADVERTISES the engine
- * actually WRITES, and that everything the engine READS the builder can write.
- * It was landed against a codebase that had already drifted, so it would have
- * been red on commit. Rather than weaken the assertion, the drift is enumerated
- * here — one line of reason per entry — so the suite is green today and every
- * NEW drift is a hard failure.
+ * actually WRITES (and the reverse: everything the engine writes, the picker
+ * offers), that everything the engine READS the builder can write, and that
+ * every branch HANDLE the engine can emit or route on is one the builder
+ * renders. It was landed against a codebase that had already drifted, so it
+ * would have been red on commit. Rather than weaken the assertion, the drift is
+ * enumerated here — one line of reason per entry — so the suite is green today
+ * and every NEW drift is a hard failure.
  *
  * ── THE TWO MAPS ARE NOT THE SAME KIND OF THING ─────────────────────────────
  * `KNOWN_BROKEN_*` is a burn-down list: real bugs, go fix them.
@@ -26,10 +28,20 @@
  * open the processor and read it — every entry below was verified at source.
  *
  * ── WHERE IT STANDS ─────────────────────────────────────────────────────────
- * The burn-down is DONE. All three `KNOWN_BROKEN_*` maps are empty: every path
- * the builder advertises is written, and every `node.data` key the engine reads
- * has a writer. What remains is 42 blind-spot entries — things that work and
- * that this reader structurally cannot confirm.
+ * The FORWARD burn-down is DONE: `KNOWN_BROKEN_OUTPUT_VARIABLES`,
+ * `KNOWN_BROKEN_FAILURE_PATH_WRITES` and `KNOWN_BROKEN_CONFIG_KEYS` are empty —
+ * every path the builder advertises is written, and every `node.data` key the
+ * engine reads has a writer.
+ *
+ * Two assertions landed later, each against code that had already drifted, so
+ * each carries its own burn-down:
+ *   - `KNOWN_BROKEN_OUTPUT_HANDLES` — the `error`-vs-`fail`-vs-`onError` handle
+ *     mismatch family. A PR renaming the emitted handles and fixing the
+ *     Failed-path routing is IN FLIGHT in parallel with this suite; when it
+ *     lands, these entries start passing and the stale-entry failure forces
+ *     their deletion in that PR. Do not burn these down independently.
+ *   - `KNOWN_BROKEN_UNADVERTISED_WRITES` — the Phase 2 fix list: real values
+ *     the engine publishes that no variable picker will ever offer.
  *
  * An empty burn-down list is not an invitation to delete the maps. They are the
  * landing zone for the next regression, and the suite fails into them.
@@ -51,6 +63,8 @@
  *     the graph, so it is probably some OTHER node's config key.
  *   - "INHERITED read" — it lives in the named ancestor file, and every sibling
  *     subclass reports the same read separately. Fix it once, there.
+ *   - "also emits computed handles" — the node's literal handle set is a floor;
+ *     an expression the reader cannot evaluate may emit more.
  *
  *     cd apps/web && \
  *       WORKFLOW_PARITY_PRINT_ALLOWLIST=1 pnpm exec vitest run \
@@ -98,6 +112,100 @@ export const KNOWN_BROKEN_FAILURE_PATH_WRITES: Record<string, string> = {}
  * were mis-filed — see the two `manual.*` and two `wait.*` entries below.
  */
 export const KNOWN_BROKEN_CONFIG_KEYS: Record<string, string> = {}
+
+/**
+ * Entry key: `written:<nodeType>.<path>`.
+ *
+ * The engine writes the path via `setNodeVariable(s)`, but `outputVariables`
+ * never advertises it under any pinned config — a real run-time value no
+ * variable picker will ever offer, reachable only by typing the path blind.
+ *
+ * This is the Phase 2 fix list. Each entry needs one of two fixes: advertise
+ * the path in the node's `outputVariables` (it is useful data), or stop
+ * writing it (it is dead weight in the variable store). Fixing either way
+ * makes the entry stale and forces its deletion.
+ */
+export const KNOWN_BROKEN_UNADVERTISED_WRITES: Record<string, string> = {
+  // ── The generic `output` duplicate ─────────────────────────────────────────
+  // Several AI-family processors publish their main result twice: under the
+  // advertised name AND under a legacy bare `output` nothing advertises.
+  'written:ai.output':
+    "ai-v2.ts:555 writes the final assistant message under 'output' (and base-ai-node.ts:257 does the same for the legacy path); the picker offers `text`. Advertise or drop the duplicate.",
+  'written:information-extractor.output':
+    "information-extractor.ts:248/:388 writes the structured result under 'output'; the picker offers `extracted_data`. Advertise or drop the duplicate.",
+  'written:text-classifier.output':
+    "INHERITED from base-ai-node.ts:257 — the base publishes 'output' for every subclass; the classifier advertises only category/confidence/reasoning. Fix once, in the base (ai has the same entry).",
+  'written:text-classifier.structured_output':
+    'INHERITED from base-ai-node.ts — written for every AI subclass; only ai advertises it. Same base-class fix as `output`.',
+  'written:text-classifier.text':
+    'INHERITED from base-ai-node.ts — written for every AI subclass; only ai advertises it. Same base-class fix as `output`.',
+  'written:text-classifier.tool_results':
+    'INHERITED from base-ai-node.ts — written for every AI subclass; only ai (with toolsEnabled) advertises it. Same base-class fix as `output`.',
+
+  // ── crud: the create/update outputs the picker never offers ───────────────
+  'written:crud.record':
+    "crud.ts:613 writes the created/updated record ref on every resource-mode success — the reverse assertion's founding example. The picker never offers `record` under any config.",
+  'written:crud.thread':
+    'crud.ts:590 writes the thread ref on every thread-mode success; the thread-mode advertisement (schema.ts) never includes it.',
+  'written:crud.error':
+    "crud.ts:575 writes null on success and crud.ts:1255 the failure message on the fail path; `success` is advertised, `error` — the thing you'd branch on — is not.",
+  'written:crud.errorDetails':
+    'crud.ts:1256 writes the structured failure (db error code, constraint) on the fail path; never advertised.',
+  'written:crud.operation':
+    'crud.ts:572/:1257 writes the mode on every run, success and failure; never advertised.',
+  'written:crud.resourceType':
+    'crud.ts:573/:1258 writes the resource type on every run; never advertised.',
+
+  // ── Whole-result summaries nothing advertises ─────────────────────────────
+  'written:code.result':
+    "code.ts:72 writes the sandbox's whole return object under 'result'; the picker offers only the per-declared outputs (code.ts:66). Advertise or drop.",
+  'written:find.count':
+    'find.ts:745 writes the result count on every run; the picker offers the found record(s) but never the count.',
+  'written:find.query_info': 'find.ts:746 writes the executed-query metadata; never advertised.',
+  'written:var-assign.variables':
+    "var-assign-processor.ts:140 writes the full assignment-results array under 'variables'; the picker offers only the per-assignment names. Advertise or drop.",
+  'written:webhook.output':
+    "webhook-processor.ts:70 writes the aggregate payload under 'output'; the picker offers method/headers/query/body individually. Advertise or drop the aggregate.",
+  'written:webhook-endpoint.output':
+    'webhook-endpoint.ts:101 writes the aggregate payload; same shape as webhook, same fix.',
+  'written:form-input.totalSize':
+    'manual.ts:195 writes `totalSize` (keyed by the form-input node, beside `files`/`fileCount`) for a multi-file input; the multi-file advertisement (form-input/output-variables.ts) offers `files.count` but not `totalSize`. Advertise or drop.',
+}
+
+/**
+ * Entry keys:
+ *   `handle:<nodeType>.<handle>`   — emitted outputHandle the UI never renders
+ *   `routing:engine-core.<handle>` — engine-core edge lookup on a handle no
+ *                                    node renders
+ *
+ * Either way the branch is unwirable: the emitted result (or the recovery
+ * lookup) targets a handle no canvas can have an edge on, so the path dies
+ * silently — no error, the run just stops.
+ *
+ * 🔶 COORDINATION: every entry below is one bug family, and a PR fixing it —
+ * renaming the `error` emissions toward the `fail` handle the UI renders, and
+ * making the engine route Failed results — is IN FLIGHT in parallel with the
+ * PR that landed this assertion. That PR must delete these entries as it fixes
+ * them; the stale-entry failure enforces this at its rebase. Do not fix these
+ * independently.
+ */
+export const KNOWN_BROKEN_OUTPUT_HANDLES: Record<string, string> = {
+  'handle:chunker.error':
+    "chunker.ts:384 emits 'error' on failure; the UI renders only [source], so the error branch is unwirable.",
+  'handle:dataset.error': "dataset.ts:619 emits 'error' on failure; the UI renders only [source].",
+  'handle:document-extractor.error':
+    "document-extractor.ts:294/:319 emits 'error' on extraction failure; the UI renders only [source].",
+  'handle:format.error':
+    "format-processor.ts:429 emits 'error' on failure; the UI renders only [source].",
+  'handle:http.error':
+    "http.ts:431/:448 emits 'error' on the error path — but the UI renders the failure branch as `fail` (http/node.tsx:50), so the handle the panel draws and the handle the engine emits never meet. The closest thing to the whole bug family in one node.",
+  'handle:knowledge-retrieval.error':
+    "knowledge-retrieval.ts:394 emits 'error' on failure; the UI renders only [source].",
+  'handle:list.error':
+    "list-processor.ts:181 emits 'error' on failure; the UI renders only [source].",
+  'routing:engine-core.onError':
+    "workflow-engine.ts:517 (and its twin loop-execution-manager.ts:310) recovers a Failed node by hunting for an edge with sourceHandle === 'onError' — a handle NO node's UI has ever rendered, so the Failed path can never route and always falls through to the throw. The engine side of the same family.",
+}
 
 /**
  * Entries that are NOT drift: either the static reader cannot see the write, or
@@ -227,4 +335,128 @@ export const EXTRACTION_BLIND_SPOTS: Record<string, string> = {
     'By design, not drift: written by `buildSequenceGraph` (packages/lib/src/sequences/publish.ts:96-104) onto the wait nodes a published sequence compiles to, and DELIBERATELY never panel-authored — wait-processor.ts:34 says so explicitly. A panel control here would be a second, divergent writer for a server-computed value.',
   'config:wait.deliveryWindow':
     "By design, same origin: `buildSequenceGraph` emits it from the sequence's delivery window (publish.ts:99). A zero-delay wait node exists ONLY to carry it, which is why the pairing has to stay one-directional.",
+
+  // ── Handle the reader can see but production can never emit ───────────────
+  'handle:if-else.true':
+    "Dead arm, not drift: `outputHandle = conditionResult ? 'true' : 'false'` (if-else.ts:181) runs only when matchedCaseId is null, and buildExecutionResult is only ever called with (true, case_id, …) on a match (if-else.ts:138) or (false, null, …) on none (if-else.ts:150) — so the 'true' literal is unreachable. Production emits case ids and 'false', both rendered. The reachability hole in the reader's net (engine-contract.ts header) seen from the other side: it proves a write EXISTS, never that it runs.",
+
+  // ── Internal bookkeeping, deliberately not picker material ────────────────
+  'written:ai._resolvedPromptVars':
+    'By design: ai-v2.ts:165 stashes the resolved variable map for the run log ("for run-log + downstream uses"), underscore-named to mark it internal. Not a picker variable.',
+
+  // ── manual.ts writes keyed by the FORM-INPUT node, mis-attributed here ────
+  // `setFileVariables(nodeId, …)` (manual.ts:184) and the reader disagree about
+  // whose variables these are: `nodeId` is a key of `triggerData` — the id of
+  // the form-input node wired into the trigger — so every one of these writes
+  // publishes under the FORM-INPUT node's id, where the form-input panel's
+  // single/multi-file advertisements pick them up. The reader attributes a
+  // write to the file's own node type because it cannot see what `nodeId`
+  // holds; the forward direction exploits the same fold-in deliberately
+  // (EXTRA_ENGINE_SOURCES documents the over-attribution cost — this is that
+  // cost, itemised).
+  'written:manual.file':
+    'Keyed by the form-input node (manual.ts:198); its panel advertises `file`.',
+  'written:manual.file.id':
+    'Keyed by the form-input node (manual.ts:199); advertised by the single-file shape.',
+  'written:manual.file.filename':
+    'Keyed by the form-input node (manual.ts:200); advertised by the single-file shape.',
+  'written:manual.file.size':
+    'Keyed by the form-input node (manual.ts:201); advertised by the single-file shape.',
+  'written:manual.file.mimeType':
+    'Keyed by the form-input node (manual.ts:202); advertised by the single-file shape.',
+  'written:manual.file.url':
+    'Keyed by the form-input node (manual.ts:203); advertised by the single-file shape.',
+  'written:manual.files':
+    'Keyed by the form-input node (manual.ts:193); advertised by the multi-file shape.',
+  'written:manual.fileCount':
+    'Keyed by the form-input node (manual.ts:194); the multi-file arm of the same fold-in that EXTRA_ENGINE_SOURCES exists to credit.',
+  'written:manual.totalSize':
+    'Keyed by the form-input node (manual.ts:195) — the same unadvertised write filed as `written:form-input.totalSize`, which is the entry that owns the fix.',
+  'written:manual.filename':
+    'Keyed by the form-input node (manual.ts:206) — legacy flat format, see the form-input legacy entries below.',
+  'written:manual.url': 'Keyed by the form-input node (manual.ts:207) — legacy flat format.',
+  'written:manual.size': 'Keyed by the form-input node (manual.ts:208) — legacy flat format.',
+  'written:manual.mimeType': 'Keyed by the form-input node (manual.ts:209) — legacy flat format.',
+  'written:manual.assetId': 'Keyed by the form-input node (manual.ts:210) — legacy flat format.',
+  'written:manual.versionId': 'Keyed by the form-input node (manual.ts:211) — legacy flat format.',
+
+  // ── The other side of the same fold-in ────────────────────────────────────
+  // EXTRA_ENGINE_SOURCES folds ALL of manual.ts into form-input's contract so
+  // the trigger-published file variables get credit. The fold cannot be
+  // selective, so form-input also inherits writes that are genuinely manual's
+  // own (keyed by the MANUAL node's id, manual.ts:54) …
+  'written:form-input.inputs':
+    "manual.ts's own write (manual.ts:54, keyed by the manual node, which advertises it under the connected-inputs variant) — folded into form-input's contract by EXTRA_ENGINE_SOURCES; the documented over-attribution cost.",
+  'written:form-input.timestamp':
+    "manual.ts's own write (manual.ts:54) — same fold-in, same over-attribution.",
+  'written:form-input.userId':
+    "manual.ts's own write (manual.ts:54) — same fold-in, same over-attribution.",
+  // … and the legacy flat file format, which IS keyed by the form-input node
+  // but is deliberately absent from the picker: manual.ts:205 keeps it only so
+  // existing workflows that referenced the pre-`file.*` names keep resolving.
+  'written:form-input.filename':
+    'Legacy flat format (manual.ts:206, "existing workflows may reference these") — deliberately unadvertised back-compat; the picker offers `file.filename`.',
+  'written:form-input.url':
+    'Legacy flat format (manual.ts:207) — back-compat for pre-`file.*` references; the picker offers `file.url`.',
+  'written:form-input.size':
+    'Legacy flat format (manual.ts:208) — back-compat; the picker offers `file.size`.',
+  'written:form-input.mimeType':
+    'Legacy flat format (manual.ts:209) — back-compat; the picker offers `file.mimeType`.',
+  'written:form-input.assetId':
+    'Legacy flat format (manual.ts:210) — back-compat; the picker offers `file.id` (which carries the assetId, manual.ts:199).',
+  'written:form-input.versionId':
+    'Legacy flat format (manual.ts:211) — back-compat; nothing advertises a version id in the file shapes.',
+
+  // ── Advertised through a channel that is not `outputVariables` ────────────
+  // The loop ITERATOR variables are offered to nodes INSIDE the loop body by
+  // the var store's loop scope (use-var-store.ts:129-180 pushes
+  // `<loopNodeId>.item/index/count/total/isFirst/isLast` for every loop
+  // ancestor), not by the loop node's own `outputVariables` — which correctly
+  // advertises only the POST-loop outputs (results/lastResult/…). The pairing
+  // is right; this suite reads only `outputVariables`, so it cannot see it.
+  'written:loop.item':
+    "Advertised by the picker's loop scope (use-var-store.ts:129), not outputVariables; written per iteration by core/loop-context-extensions.ts:180.",
+  'written:loop.index':
+    'Advertised by the loop scope (use-var-store.ts:145); written by loop-context-extensions.ts:172.',
+  'written:loop.count':
+    'Advertised by the loop scope (use-var-store.ts:152); written by loop-context-extensions.ts:173.',
+  'written:loop.total':
+    'Advertised by the loop scope (use-var-store.ts:159); written by loop-context-extensions.ts:174.',
+  'written:loop.isFirst':
+    'Advertised by the loop scope (use-var-store.ts:166); written by loop-context-extensions.ts:175.',
+  'written:loop.isLast':
+    'Advertised by the loop scope (use-var-store.ts:173); written by loop-context-extensions.ts:176.',
+
+  // ── Advertised, but only under a config this harness cannot pin ───────────
+  // resource-trigger's `outputVariables` returns [] without a populated
+  // Resource in context (output-variables.ts:36); with one, the lib generator
+  // emits the whole `trigger.*` metadata tree
+  // (packages/lib/src/resources/variable-generators.ts:272-351, basePath
+  // 'trigger'). Resource mode needs a live org — the same reach limit
+  // CONFIG_VARIANTS documents for crud/find — so the reverse direction reads
+  // these correct pairings as unadvertised.
+  'written:resource-trigger.trigger.timestamp':
+    'Advertised via the resource-mode generator (variable-generators.ts, basePath trigger) that needs a live Resource; written at resource-trigger-base.ts:217.',
+  'written:resource-trigger.trigger.operation':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:218.',
+  'written:resource-trigger.trigger.source':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:224.',
+  'written:resource-trigger.trigger.resourceType':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:225.',
+  'written:resource-trigger.trigger.resourceId':
+    'Same resource-mode advertisement; manual-operation arm of resource-trigger-base.ts.',
+  'written:resource-trigger.trigger.createdBy':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:227.',
+  'written:resource-trigger.trigger.changedFields':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:240.',
+  'written:resource-trigger.trigger.previousValues':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:243.',
+  'written:resource-trigger.trigger.deletedBy':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:249.',
+  'written:resource-trigger.trigger.deletedBy.id':
+    'Same resource-mode advertisement; written at resource-trigger-base.ts:251.',
+  'written:resource-trigger.trigger.deletedBy.name':
+    'Same resource-mode advertisement; delete arm of resource-trigger-base.ts.',
+  'written:resource-trigger.trigger.deletedBy.email':
+    'Same resource-mode advertisement; delete arm of resource-trigger-base.ts.',
 }

--- a/apps/web/src/components/workflow/parity/engine-contract.ts
+++ b/apps/web/src/components/workflow/parity/engine-contract.ts
@@ -33,6 +33,14 @@ import { fileURLToPath } from 'node:url'
  *    `inheritedDataReads` — see `withInherited`.
  *  - Whether every call site for a path sits inside an `else` block — see
  *    `failurePathOnlyWrites`.
+ *  - Literal `outputHandle` values a processor can emit — `outputHandle: '<lit>'`
+ *    properties, `outputHandle = <expr>` assignments, and every string literal in
+ *    the VALUE arms of a conditional (`ok ? 'source' : 'error'` contributes
+ *    both; the literal in a ternary's CONDITION is compared against, never
+ *    emitted, and is not collected). Routing follows
+ *    `result.outputHandle || 'source'` (graph-navigation.ts:67), so an emitted
+ *    handle with no edge whose `sourceHandle` matches it is a dead end for that
+ *    branch — no error, the run just stops there.
  *
  * ── WHAT IT CANNOT SEE ──────────────────────────────────────────────────────
  *  - Dynamically-computed paths: `setNodeVariable(nodeId, key, value)` inside a
@@ -51,6 +59,14 @@ import { fileURLToPath } from 'node:url'
  *    `executeFilter(list, node.data.filterConfig)` then `config.logic`. Only the
  *    TOP-LEVEL key (`filterConfig`) is seen, so the config-key assertion is a
  *    floor, not a ceiling.
+ *  - A COMPUTED `outputHandle`: `outputHandle = matchedCaseId` (if-else.ts),
+ *    `handleForApprovalOutcome(outcome)` (human-confirmation.ts, resolved in
+ *    core/pause-resume.ts), `getOutputHandleForCategory(…)` (text-classifier.ts).
+ *    The values those can take are invisible to a textual reader, so they are
+ *    recorded as `dynamicOutputHandles` — they satisfy nothing and fail nothing,
+ *    exactly like `dynamicWrites`. The handle-parity assertion is therefore a
+ *    floor too: a green run proves the LITERAL emissions are renderable, not
+ *    that every computed one is.
  *  - Anything written outside `packages/lib/src/workflow-engine/`. A node's
  *    variables are not always published by its own processor —
  *    `human-confirmation`'s are written by `core/workflow-engine.ts` on resume,
@@ -213,6 +229,21 @@ export interface EngineNodeContract {
    * blind-spot map, never in the burn-down list.
    */
   unresolvedBulkWrites: string[]
+  /**
+   * Literal `outputHandle` values this node's processor can emit. The engine
+   * routes a result over the edge whose `sourceHandle` equals this value
+   * (falling back to `'source'` when unset — graph-navigation.ts:67), so every
+   * entry here is a branch the node can actually take.
+   */
+  outputHandles: string[]
+  /**
+   * `outputHandle` expressions with no readable literal value — a computed
+   * handle (`matchedCaseId`, `handleForApprovalOutcome(outcome)`). What those
+   * evaluate to is invisible here, so like `dynamicWrites` they satisfy nothing
+   * and fail nothing; they are carried so a finding's detail can say "this node
+   * also emits computed handles" instead of implying the literal set is total.
+   */
+  dynamicOutputHandles: string[]
   /** Top-level `node.data.<key>` reads, including via a local alias. */
   dataReads: string[]
   /**
@@ -240,6 +271,8 @@ interface FileFacts {
   failurePathOnly: string[]
   dynamicWrites: string[]
   unresolvedBulkWrites: string[]
+  outputHandles: string[]
+  dynamicOutputHandles: string[]
   dataReads: string[]
   foreignDataReads: Record<string, string>
 }
@@ -499,6 +532,118 @@ function foreignNodeBindings(source: string): Record<string, string> {
   return bindings
 }
 
+/**
+ * Capture the value expression that starts at `start` — the right-hand side of
+ * an `outputHandle:` property or an `outputHandle =` assignment.
+ *
+ * There is no parser here, so the boundary is structural: a top-level `,` or `;`
+ * ends it, an unbalanced closer (`}` `)` `]`) ends it, and a top-level newline
+ * ends it UNLESS the expression is visibly unfinished — it trails an operator, or
+ * the next line leads with one. That last rule is what keeps a multi-line
+ * ternary together (text-classifier.ts breaks before its `?` and `:`) without
+ * swallowing the statement after a single-line assignment.
+ */
+function captureValueExpression(source: string, start: number): string {
+  let out = ''
+  let depth = 0
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i] as string
+    if (ch === "'" || ch === '"' || ch === '`') {
+      out += ch
+      for (i++; i < source.length; i++) {
+        out += source[i]
+        if (source[i] === '\\') {
+          i++
+          out += source[i] ?? ''
+        } else if (source[i] === ch) break
+      }
+      continue
+    }
+    if (ch === '(' || ch === '{' || ch === '[') depth++
+    else if (ch === ')' || ch === '}' || ch === ']') {
+      if (depth === 0) break
+      depth--
+    } else if ((ch === ',' || ch === ';') && depth === 0) break
+    else if (ch === '\n' && depth === 0) {
+      const trailing = out.trimEnd()
+      const lead = source.slice(i + 1).match(/^\s*([?:.]|\|\||&&)/)
+      if (!/[=?:.|&(+]$/.test(trailing) && !lead) break
+    }
+    out += ch
+  }
+  return out.trim()
+}
+
+/**
+ * The `outputHandle` values a file can emit.
+ *
+ * Two shapes cover every emission site in the engine today:
+ *   `outputHandle: <expr>`   — a result-object property
+ *   `outputHandle = <expr>`  — an assignment later returned via shorthand
+ *
+ * From the captured expression, every string literal in its VALUE position is an
+ * emittable handle — and for a conditional that means the arms only. The literal
+ * in `config.outputMode === 'variable' ? 'source' : …` is a comparison operand,
+ * not a handle, so collection starts after the first top-level `?`. Whatever
+ * non-literal remains (an identifier, a call) makes the expression a
+ * `dynamic` entry as well, because it can evaluate to handles no literal names.
+ */
+function extractOutputHandles(source: string): { literals: string[]; dynamic: string[] } {
+  const literals: string[] = []
+  const dynamic: string[] = []
+
+  const record = (expression: string) => {
+    // `let outputHandle: string` — the property regex also matches a type
+    // annotation, which names no value at all.
+    if (/^(?:string|number|boolean|any|unknown|undefined|null)$/.test(expression)) return
+    // `outputHandle=${outputHandle}` inside a log's TEMPLATE LITERAL (if-else.ts)
+    // also matches the assignment regex; the capture then starts at `${` and
+    // swallows string fragments. Prose in a template is not an emission site.
+    if (expression.startsWith('$') || expression.includes('`')) return
+
+    // First top-level `?` (skipping strings and brackets; `?.`/`??` are not
+    // ternaries). Everything before it is condition, not value.
+    let valueStart = 0
+    let depth = 0
+    for (let i = 0; i < expression.length; i++) {
+      const ch = expression[i] as string
+      if (ch === "'" || ch === '"' || ch === '`') {
+        for (i++; i < expression.length; i++) {
+          if (expression[i] === '\\') i++
+          else if (expression[i] === ch) break
+        }
+        continue
+      }
+      if (ch === '(' || ch === '{' || ch === '[') depth++
+      else if (ch === ')' || ch === '}' || ch === ']') depth--
+      else if (ch === '?' && depth === 0) {
+        const next = expression[i + 1]
+        if (next === '.' || next === '?') {
+          i++
+          continue
+        }
+        valueStart = i + 1
+        break
+      }
+    }
+
+    const value = expression.slice(valueStart)
+    for (const m of value.matchAll(/'([^']*)'/g)) literals.push(m[1] as string)
+    if (/[\w$]/.test(value.replace(/'[^']*'/g, ''))) dynamic.push(expression)
+  }
+
+  for (const m of source.matchAll(/\boutputHandle\s*:\s*/g)) {
+    record(captureValueExpression(source, (m.index ?? 0) + (m[0] as string).length))
+  }
+  // `=` but not `==`/`===` (the left `outputHandle ===` of a comparison) and not
+  // `!==` (no match: `!` sits between the identifier and the `=`).
+  for (const m of source.matchAll(/\boutputHandle\s*=(?!=)\s*/g)) {
+    record(captureValueExpression(source, (m.index ?? 0) + (m[0] as string).length))
+  }
+
+  return { literals, dynamic }
+}
+
 /** Character spans of every `else { ... }` block in a source file. */
 function elseBlockSpans(source: string): Array<[number, number]> {
   const spans: Array<[number, number]> = []
@@ -648,6 +793,8 @@ function scanFile(path: string): FileFacts {
     }
   }
 
+  const handles = extractOutputHandles(source)
+
   const ownKeys = Array.from(dataReads).filter((key) => !FRAMEWORK_DATA_KEYS.has(key))
   return {
     path,
@@ -658,6 +805,8 @@ function scanFile(path: string): FileFacts {
     failurePathOnly: Array.from(onlyElse).filter((path) => !anywhere.has(path)),
     dynamicWrites,
     unresolvedBulkWrites,
+    outputHandles: handles.literals,
+    dynamicOutputHandles: handles.dynamic,
     dataReads: ownKeys,
     foreignDataReads: Object.fromEntries(
       Object.entries(foreignDataReads).filter(
@@ -711,6 +860,8 @@ export function readEngineContracts(): Map<string, EngineNodeContract> {
     const failurePathOnly = [...fact.failurePathOnly]
     const dynamic = [...fact.dynamicWrites]
     const unresolvedBulk = [...fact.unresolvedBulkWrites]
+    const outputHandles = [...fact.outputHandles]
+    const dynamicOutputHandles = [...fact.dynamicOutputHandles]
     const reads = [...fact.dataReads]
     const foreign = { ...fact.foreignDataReads }
     const inheritedFrom: Record<string, string> = {}
@@ -724,6 +875,8 @@ export function readEngineContracts(): Map<string, EngineNodeContract> {
       failurePathOnly.push(...parent.failurePathOnly)
       dynamic.push(...parent.dynamicWrites)
       unresolvedBulk.push(...parent.unresolvedBulkWrites)
+      outputHandles.push(...parent.outputHandles)
+      dynamicOutputHandles.push(...parent.dynamicOutputHandles)
       reads.push(...parent.dataReads)
       for (const key of parent.dataReads) {
         if (!own.has(key) && !(key in inheritedFrom)) inheritedFrom[key] = relative
@@ -733,7 +886,17 @@ export function readEngineContracts(): Map<string, EngineNodeContract> {
       }
       parent = parent.superClass ? byClass.get(parent.superClass) : undefined
     }
-    return { writes, failurePathOnly, dynamic, unresolvedBulk, reads, foreign, inheritedFrom }
+    return {
+      writes,
+      failurePathOnly,
+      dynamic,
+      unresolvedBulk,
+      outputHandles,
+      dynamicOutputHandles,
+      reads,
+      foreign,
+      inheritedFrom,
+    }
   }
 
   // When two files declare the same node type, the REGISTERED one wins outright.
@@ -772,6 +935,11 @@ export function readEngineContracts(): Map<string, EngineNodeContract> {
           ...(existing?.unresolvedBulkWrites ?? []),
           ...inherited.unresolvedBulk,
         ],
+        outputHandles: [...(existing?.outputHandles ?? []), ...inherited.outputHandles],
+        dynamicOutputHandles: [
+          ...(existing?.dynamicOutputHandles ?? []),
+          ...inherited.dynamicOutputHandles,
+        ],
         dataReads: [...(existing?.dataReads ?? []), ...inherited.reads],
         foreignDataReads: { ...(existing?.foreignDataReads ?? {}), ...inherited.foreign },
         inheritedDataReads: {
@@ -793,6 +961,8 @@ export function readEngineContracts(): Map<string, EngineNodeContract> {
       contract.writes.push(...fact.writes)
       contract.dynamicWrites.push(...fact.dynamicWrites)
       contract.unresolvedBulkWrites.push(...fact.unresolvedBulkWrites)
+      contract.outputHandles.push(...fact.outputHandles)
+      contract.dynamicOutputHandles.push(...fact.dynamicOutputHandles)
     }
   }
 
@@ -802,6 +972,8 @@ export function readEngineContracts(): Map<string, EngineNodeContract> {
     contract.failurePathOnlyWrites = Array.from(new Set(contract.failurePathOnlyWrites)).sort()
     contract.dynamicWrites = Array.from(new Set(contract.dynamicWrites)).sort()
     contract.unresolvedBulkWrites = Array.from(new Set(contract.unresolvedBulkWrites)).sort()
+    contract.outputHandles = Array.from(new Set(contract.outputHandles)).sort()
+    contract.dynamicOutputHandles = Array.from(new Set(contract.dynamicOutputHandles)).sort()
     contract.dataReads = Array.from(new Set(contract.dataReads)).sort()
   }
 
@@ -843,6 +1015,33 @@ export function isPathWritten(path: string, writes: string[]): boolean {
 }
 
 /**
+ * Literal `sourceHandle` values the engine CORE compares edges against when it
+ * routes — the third leg of the handle contract, beside what processors emit
+ * and what the builder renders.
+ *
+ * A literal here is a handle the engine goes LOOKING for on the canvas: the
+ * Failed-path recovery in `workflow-engine.ts` (and its loop-manager twin)
+ * searches for an edge with `sourceHandle === 'onError'`, and a literal no node
+ * ever renders is a code path that can never fire — the exact shape of the live
+ * fail-branch bug this suite exists to keep out.
+ *
+ * Comparisons against a VARIABLE (`edge.sourceHandle === outputHandle`) are the
+ * normal result-routing and prove nothing either way, so only string-literal
+ * comparisons are collected.
+ */
+export function readEngineRoutedHandleLiterals(): Array<{ handle: string; file: string }> {
+  const coreDir = join(ENGINE_ROOT, 'core')
+  const lookups: Array<{ handle: string; file: string }> = []
+  for (const path of listSources(coreDir)) {
+    const source = stripComments(readFileSync(path, 'utf8'))
+    for (const m of source.matchAll(/\bsourceHandle\s*===\s*'([^']+)'/g)) {
+      lookups.push({ handle: m[1] as string, file: path.replace(`${ENGINE_ROOT}/`, '') })
+    }
+  }
+  return lookups
+}
+
+/**
  * Property names declared in a builder node's `types.ts`.
  *
  * The zod schema alone is NOT the builder's writable surface. Several nodes
@@ -863,6 +1062,32 @@ export function builderDeclaredKeys(builderDir: string): Set<string> {
   if (!existsSync(path)) return new Set()
   const source = stripComments(readFileSync(path, 'utf8'))
   return new Set(Array.from(source.matchAll(/^\s+(\w+)\??\s*:/gm), (m) => m[1] as string))
+}
+
+/**
+ * Is a path the engine WRITES surfaced anywhere in the picker — the reverse of
+ * `isPathWritten`?
+ *
+ * A write is discoverable when the advertised set contains the path itself, a
+ * DEEPER path under it (the picker's `record.contact.email` proves `record` is
+ * populated and offered, if only partially), or a SHALLOWER prefix of it (an
+ * advertised `record` object lets a user reach `record.name` by typing into it —
+ * `resolveVariablePath` walks into the stored value). Only a write with no
+ * prefix relation to anything advertised is truly invisible: it exists at run
+ * time and nothing in the UI will ever offer it.
+ *
+ * Template-literal writes (`tool_${index}`) match on their literal stem, the
+ * same convention `isPathWritten` uses.
+ */
+export function isWriteAdvertised(write: string, advertised: Set<string>): boolean {
+  if (write.includes('${')) {
+    const stem = write.slice(0, write.indexOf('${'))
+    return stem.length > 0 && Array.from(advertised).some((path) => path.startsWith(stem))
+  }
+  for (const path of advertised) {
+    if (path === write || path.startsWith(`${write}.`) || write.startsWith(`${path}.`)) return true
+  }
+  return false
 }
 
 /**


### PR DESCRIPTION
Adds the two missing assertions to the builder↔engine parity suite (#1551/#1552). Suite is green on this branch; all real violations are allowlisted under the suite's existing self-cleaning discipline (a fixed violation turns its entry stale and fails the run until the line is deleted).

## 1. Handle/branch parity

Nothing previously compared the three handle vocabularies: what a processor can emit as `outputHandle`, what the node's UI renders as `<NodeSourceHandle>`/`<NodeTargetHandle>`, and what the engine core itself goes looking for when routing.

- **Engine side** — `engine-contract.ts` now extracts the literal `outputHandle` values each processor can emit (property and assignment forms, both arms of a conditional, through class inheritance; ternary *condition* literals are excluded). Computed handles (`matchedCaseId`, `handleForApprovalOutcome(outcome)`, `getOutputHandleForCategory(…)`) are recorded as `dynamicOutputHandles` — a documented blind spot, same treatment as `dynamicWrites`. A second reader (`readEngineRoutedHandleLiterals`) collects the core's own literal `sourceHandle === '…'` edge lookups.
- **Builder side** — there is **no central declaration of rendered handles anywhere in the builder**; that absence is itself a finding. `builder-rendered-handles.ts` is the new hand-verified per-node table (every entry cited with the `node.tsx` file:line of the render site; dynamic branch handles like if-else case ids and text-classifier category ids declared as prose predicates). Its header says explicitly it is the **interim contract that a future lib-side handle manifest replaces**.
- **Assertions** — every statically-extracted emitted handle must be declared for that node type, be `'source'` (the engine-wide fallback), or be allowlisted; every core routing literal must be a handle some node renders; and the table must cover exactly the palette.

### What it flushed out (9 findings)

- `handle:{http, dataset, chunker, knowledge-retrieval, document-extractor, list, format}.error` — seven processors emit `outputHandle: 'error'` while the UI renders `fail` (http) or only `source` — the error branch is unwirable on every one of them.
- `routing:engine-core.onError` — the Failed-path recovery (`workflow-engine.ts:517`, twin in `loop-execution-manager.ts:310`) hunts for an edge with `sourceHandle === 'onError'`, a handle no node's UI has ever rendered, so it can never match.
- `handle:if-else.true` — filed as an extraction blind spot, not a bug: the `'true'` arm is statically visible but unreachable (`buildExecutionResult` is only ever called `(true, case_id, …)` or `(false, null, …)`), so production emits case ids and `'false'`, both rendered.

> **🔶 Coordination:** the eight `KNOWN_BROKEN_OUTPUT_HANDLES` entries are one bug family, and the fail-branch PR (renaming emitted handles toward what the UI renders + making the engine route Failed results) is in flight in parallel. **That PR must delete these allowlist entries as it lands** — the suite's stale-entry failure enforces this automatically at its rebase. They are deliberately *not* fixed here.

## 2. Written→advertised (the reverse direction)

The suite asserted advertised→written but never the reverse, so a processor could publish variable paths the builder never declares — real run-time values invisible in the variable picker. New assertion over the same extracted data: every literal `setNodeVariable(s)` path must be advertised by the builder's resolver output (union over `defaultData` + `CONFIG_VARIANTS`, prefix-matched in both directions), or allowlisted.

### What it flushed out (62 findings, triaged one by one at source)

**19 real (`KNOWN_BROKEN_UNADVERTISED_WRITES` — the Phase 2 fix list):**
- `crud.record` (the founding example: written on every resource-mode create/update, advertised never), `crud.thread`, `crud.error`, `crud.errorDetails`, `crud.operation`, `crud.resourceType`
- the generic `output` duplicate across the AI family: `ai.output`, `information-extractor.output`, and four inherited from `base-ai-node.ts` onto `text-classifier` (`output`, `text`, `structured_output`, `tool_results`) — one fix site, in the base
- whole-result summaries nothing advertises: `code.result`, `find.count`, `find.query_info`, `var-assign.variables`, `webhook.output`, `webhook-endpoint.output`, `form-input.totalSize`

**43 blind spots (`EXTRACTION_BLIND_SPOTS` — verified correct, reader structurally can't see them):**
- 15 `manual.*` file keys actually keyed by the wired form-input node (`setFileVariables(nodeId, …)` where `nodeId` comes from `triggerData`) — the itemised cost of the `EXTRA_ENGINE_SOURCES` fold-in the forward direction relies on
- 9 `form-input.*`: three of manual's own keys folded in by the same mechanism, plus the deliberately-unadvertised legacy flat file format (`manual.ts:205` back-compat)
- 6 `loop.*` iterator variables — advertised through the var store's loop scope (`use-var-store.ts:129-180`), a declaration channel `outputVariables` doesn't carry
- 12 `resource-trigger.trigger.*` — advertised only with a populated `Resource` in context, which needs a live org (same reach limit `CONFIG_VARIANTS` documents for crud/find resource mode)
- `ai._resolvedPromptVars` — underscore-marked internal run-log stash

## Mechanics

- Three new reader-pinning tests (section 0 style) lock the handle extraction's behavior: conditional arms are collected, ternary condition literals are not, computed handles surface as dynamic.
- Suite: `cd apps/web && pnpm exec vitest run src/components/workflow/parity` — 16/16 green; full `src/components/workflow` suite 85/85 green. Only `apps/web/src/components/workflow/parity/**` is touched.