### PR TITLE
feat(workflow): node catalog skeleton and the variable-inference split

### DIFF
--- a/apps/web/src/components/workflow/nodes/define-from-manifest.ts
+++ b/apps/web/src/components/workflow/nodes/define-from-manifest.ts
@@ -1,0 +1,63 @@
+// apps/web/src/components/workflow/nodes/define-from-manifest.ts
+
+import type { NodeManifest } from '@auxx/lib/workflow-engine/client'
+import type { ComponentType } from 'react'
+import type { NodeDefinition, NodePanelProps, TraceRendererProps } from '../types'
+import type { UnifiedOutputVariablesFunction } from '../types/output-variables'
+
+/**
+ * React parts a manifest is merged with. The manifest (lib) carries the data
+ * half of a node definition; these stay in apps/web forever — the node-catalog
+ * migration's hard invariant is that node.tsx / panel.tsx / trace-renderer.tsx
+ * never change.
+ */
+export interface ManifestComponents<TData> {
+  component?: ComponentType<any>
+  panel?: ComponentType<NodePanelProps<TData>>
+  traceRenderer?: ComponentType<TraceRendererProps>
+  /**
+   * Output resolver. Still declared web-side because manifests deliberately
+   * defer `resolveOutputs` until output resolution gets a server-callable
+   * context (Phase 2) — at which point this becomes optional and defaults to
+   * the manifest's resolver.
+   */
+  outputVariables: UnifiedOutputVariablesFunction<TData>
+}
+
+/**
+ * Build today's `NodeDefinition` from a lib catalog manifest plus the React
+ * parts, so every existing registry consumer (`getPanel`, `getNodeIcon`,
+ * `availableNextNodesForType`, `validateNode`, `computeNodeOutputs`) keeps
+ * working unchanged as node types migrate. A migrated `core/<type>/schema.ts`
+ * shrinks to one `defineFromManifest` call plus back-compat re-exports.
+ */
+export function defineFromManifest<TData>(
+  manifest: NodeManifest<TData>,
+  parts: ManifestComponents<TData>
+): NodeDefinition<TData> {
+  return {
+    id: manifest.id,
+    category: manifest.category,
+    displayName: manifest.displayName,
+    description: manifest.description,
+    icon: manifest.icon,
+    getIcon: manifest.getIcon,
+    color: manifest.color,
+    defaultData: manifest.defaultData(),
+    schema: manifest.configSchema,
+    component: parts.component,
+    panel: parts.panel,
+    traceRenderer: parts.traceRenderer,
+    validator: manifest.validate,
+    triggerType: manifest.triggerType,
+    extractVariables: manifest.extractVariables,
+    outputVariables: parts.outputVariables,
+    canConnect: manifest.connection.canConnect,
+    canRunSingle: manifest.connection.canRunSingle,
+    acceptsInputNodes: manifest.connection.acceptsInputNodes,
+    availableNextNodes: manifest.connection.availableNextNodes,
+    availablePrevNodes: manifest.connection.availablePrevNodes,
+    maxIncomingConnections: manifest.connection.maxIncomingConnections,
+    maxOutgoingConnections: manifest.connection.maxOutgoingConnections,
+  }
+}

--- a/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
+++ b/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
@@ -1,0 +1,102 @@
+// apps/web/src/components/workflow/parity/catalog-coverage.test.ts
+
+import {
+  getManifest,
+  listManifests,
+  NOT_YET_MIGRATED,
+  NodeCategory,
+  type NodeManifest,
+} from '@auxx/lib/workflow-engine/client'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { defineFromManifest } from '../nodes/define-from-manifest'
+import { NodeType } from '../types/node-types'
+
+/**
+ * Catalog migration coverage (node-catalog Phase 1).
+ *
+ * Every builder `NodeType` lives in EXACTLY one of two places: the lib
+ * catalog's registered manifests, or its explicit `NOT_YET_MIGRATED` list.
+ * Asserted as exact set equality in both directions, so:
+ *   - migrating a type without deleting its list entry fails;
+ *   - adding a new NodeType without deciding its catalog status fails;
+ *   - registering a manifest for a type the builder doesn't know fails.
+ *
+ * The NOT_YET_MIGRATED list is the migration tracker and may only shrink.
+ * App blocks (`appId:blockId` dynamic types) are outside NodeType and outside
+ * this contract — they get a declarative adapter in a later wave.
+ */
+describe('node catalog coverage', () => {
+  const nodeTypes = new Set<string>(Object.values(NodeType))
+  const migrated = new Set(listManifests().map((manifest) => manifest.id))
+  const notYetMigrated = new Set(NOT_YET_MIGRATED)
+
+  it('covers every NodeType exactly once across {manifests, NOT_YET_MIGRATED}', () => {
+    const uncovered = [...nodeTypes].filter((t) => !migrated.has(t) && !notYetMigrated.has(t))
+    const doubleCovered = [...nodeTypes].filter((t) => migrated.has(t) && notYetMigrated.has(t))
+    expect({ uncovered, doubleCovered }).toEqual({ uncovered: [], doubleCovered: [] })
+  })
+
+  it('lists no unknown types in NOT_YET_MIGRATED and registers no unknown manifests', () => {
+    const unknownListed = [...notYetMigrated].filter((t) => !nodeTypes.has(t))
+    const unknownRegistered = [...migrated].filter((t) => !nodeTypes.has(t))
+    expect({ unknownListed, unknownRegistered }).toEqual({
+      unknownListed: [],
+      unknownRegistered: [],
+    })
+  })
+
+  it('every manifest default parses against its own configSchema', () => {
+    // The legacy NodeDefinition.schema was `any` and never parsed — the code
+    // node's dead `output.type?.type` read and resource-trigger's
+    // schema-failing defaults both hid behind that. Manifests don't get to.
+    const failures = listManifests()
+      .map((manifest) => ({
+        id: manifest.id,
+        result: manifest.configSchema.safeParse(manifest.defaultData()),
+      }))
+      .filter(({ result }) => !result.success)
+      .map(({ id, result }) => ({ id, error: (result as { error?: unknown }).error }))
+    expect(failures).toEqual([])
+  })
+})
+
+describe('defineFromManifest', () => {
+  const fakeManifest: NodeManifest<{ title: string }> = {
+    id: 'fake-node',
+    category: NodeCategory.UTILITY,
+    displayName: 'Fake Node',
+    description: 'Merge-helper unit fixture',
+    icon: 'box',
+    color: 'gray',
+    defaultData: () => ({ title: 'Untitled' }),
+    configSchema: z.object({ title: z.string() }),
+    validate: (config) => ({
+      isValid: config.title.length > 0,
+      errors: config.title.length > 0 ? [] : [{ field: 'title', message: 'Required' }],
+    }),
+    connection: { canConnect: true, maxOutgoingConnections: 1 },
+    agent: { authorable: true, usage: 'test only', examples: [] },
+  }
+
+  it('builds a NodeDefinition every registry consumer can read', () => {
+    const definition = defineFromManifest(fakeManifest, {
+      outputVariables: () => [],
+    })
+
+    expect(definition.id).toBe('fake-node')
+    expect(definition.category).toBe(NodeCategory.UTILITY)
+    expect(definition.displayName).toBe('Fake Node')
+    expect(definition.icon).toBe('box')
+    expect(definition.defaultData).toEqual({ title: 'Untitled' })
+    expect(definition.schema).toBe(fakeManifest.configSchema)
+    expect(definition.canConnect).toBe(true)
+    expect(definition.maxOutgoingConnections).toBe(1)
+    expect(definition.validator?.({ title: '' }).isValid).toBe(false)
+    expect(definition.validator?.({ title: 'ok' }).isValid).toBe(true)
+  })
+
+  it('keeps getManifest empty-safe for unmigrated types', () => {
+    expect(getManifest('wait')).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/workflow/types/registry.ts
+++ b/apps/web/src/components/workflow/types/registry.ts
@@ -1,38 +1,25 @@
 // apps/web/src/components/workflow/types/registry.ts
 
 import type { WorkflowNodeExecutionEntity } from '@auxx/database/types'
-import type { WorkflowTriggerType } from '@auxx/lib/workflow-engine/client'
+import type {
+  NodeCategory,
+  NodeValidationResult as ValidationResult,
+  WorkflowTriggerType,
+} from '@auxx/lib/workflow-engine/client'
 import type { ComponentType } from 'react'
 import type { BaseNodeData } from './node-base'
 import type { UnifiedOutputVariablesFunction } from './output-variables'
 
 // Simplified typing approach to avoid Zod complexity
 
-/**
- * UI node categories for organization
- */
-export enum NodeCategory {
-  TRIGGER = 'trigger',
-  INPUT = 'input',
-  CONDITION = 'condition',
-  ACTION = 'action',
-  TRANSFORM = 'transform',
-  FLOW_CONTROL = 'flow_control',
-  DATA = 'data',
-  DATASET = 'dataset',
-  INTEGRATION = 'integration',
-  AI = 'ai',
-  DEBUG = 'debug',
-  UTILITY = 'utility',
-}
-
-/**
- * Validation result interface
- */
-export interface ValidationResult {
-  isValid: boolean
-  errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }>
-}
+export type { NodeValidationResult as ValidationResult } from '@auxx/lib/workflow-engine/client'
+// NodeCategory and ValidationResult relocated to the lib node catalog
+// (node-catalog Phase 1 — `@auxx/lib/workflow-engine/catalog/types`), where
+// they are the manifest's category and validator-result types. Re-exported
+// here so no web import churns; lib names the validator result
+// `NodeValidationResult` to avoid colliding with the engine's own
+// whole-workflow `ValidationResult`.
+export { NodeCategory } from '@auxx/lib/workflow-engine/client'
 
 /**
  * Props every node configuration panel receives.

--- a/apps/web/src/components/workflow/types/unified-types.ts
+++ b/apps/web/src/components/workflow/types/unified-types.ts
@@ -8,17 +8,8 @@
  * type systems with one unified approach.
  */
 
+// ValidationRules moved to lib with UnifiedVariable (node-catalog Phase 1);
+// re-exported here so existing imports keep working.
+export type { ValidationRules } from '@auxx/lib/workflow-engine/client'
 // Import BaseType from backend (single source of truth)
 export { BaseType } from '@auxx/lib/workflow-engine/client'
-
-/**
- * Validation rules for type values
- */
-export interface ValidationRules {
-  min?: number
-  max?: number
-  minLength?: number
-  maxLength?: number
-  pattern?: string | RegExp
-  custom?: (value: any) => boolean | string
-}

--- a/apps/web/src/components/workflow/types/variable-types.ts
+++ b/apps/web/src/components/workflow/types/variable-types.ts
@@ -1,101 +1,14 @@
 // apps/web/src/components/workflow/types/variable-types.ts
 
-import type { FieldOptions } from '@auxx/lib/field-values/converters'
-import type { TableId } from '@auxx/lib/workflow-engine/client'
-import type { ResourceFieldId } from '@auxx/types/field'
-import type { BaseType, ValidationRules } from './unified-types'
+import type { TableId, UnifiedVariable } from '@auxx/lib/workflow-engine/client'
 
+// UnifiedVariable and AllowedVarType moved to lib (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/types/unified-variable`) so node manifests and
+// server-side output resolution can share them. Re-exported here so the ~100
+// existing web imports keep working; the React-carrying picker/UI types below
+// stay in this file.
+export type { AllowedVarType, UnifiedVariable } from '@auxx/lib/workflow-engine/client'
 export { BaseType } from './unified-types'
-
-/**
- * One entry of a variable picker's `allowedTypes` / `expectedTypes` filter.
- *
- * Either a {@link BaseType}, or a **resource identifier** used to filter
- * relation/reference variables. That identifier is not restricted to the system
- * `TableId` union — it may equally be an `EntityDefinition` id or a resource
- * slug, which `isVariableTypeCompatible` cross-resolves through the resource
- * store. Hence `string` rather than `TableId`.
- */
-export type AllowedVarType = BaseType | string
-
-/**
- * Unified variable type that merges all legacy variable formats
- * This is the single source of truth for variables across the workflow system
- */
-export interface UnifiedVariable {
-  // Core identification
-  id: string // Unique identifier (full path: "node-123.content", "env.API_KEY")
-  nodeId?: string
-
-  // Display information
-  label: string // Human-readable label
-  description?: string // Optional description
-
-  type: BaseType // Base type from unified type system
-
-  // ─────────────────────────────────────────────────────────────
-  // FIELD REFERENCE (typed, replaces untyped `reference`)
-  // ─────────────────────────────────────────────────────────────
-
-  /**
-   * Typed field reference using ResourceFieldId system.
-   * Format: `${entityDefinitionId}:${fieldId}`
-   *
-   * Examples:
-   * - "contact:email" (system field on contact)
-   * - "ticket:cm1abc123xyz" (custom field on ticket)
-   *
-   * Use parseResourceFieldId() to extract components - NO manual .split(':')
-   */
-  fieldReference?: ResourceFieldId
-
-  /**
-   * For direct resource references (e.g., "contact", "ticket")
-   * When the variable IS a resource, not a field ON a resource.
-   */
-  resourceId?: string
-
-  /**
-   * Field options using unified FieldOptions structure.
-   * Same format as custom fields for consistency.
-   */
-  options?: FieldOptions
-
-  /**
-   * Allowed values for `BaseType.ENUM` variables.
-   *
-   * Sourced from a JSON Schema `enum`, which permits both strings and numbers —
-   * see `schemaToUnifiedVariable` in utils/schema-to-variable.ts.
-   */
-  enum?: (string | number)[]
-
-  // ─────────────────────────────────────────────────────────────
-  // STRUCTURAL TYPES
-  // ─────────────────────────────────────────────────────────────
-
-  // For arrays: type of items
-  items?: UnifiedVariable // Replaces itemType, now recursive
-
-  // For objects: property definitions with key preservation
-  properties?: Record<string, UnifiedVariable> // Object properties by key
-
-  // ─────────────────────────────────────────────────────────────
-  // METADATA
-  // ─────────────────────────────────────────────────────────────
-
-  // Categorization
-  category: 'node' | 'environment' | 'system'
-
-  // Value constraints
-  required?: boolean // Is this variable required?
-  default?: any // Default value
-  example?: any // Example value
-  validation?: ValidationRules
-
-  // UI hints (optional)
-  icon?: string // Icon for UI display
-  color?: string // Color for UI display
-}
 
 export const VAR_MODE = { PICKER: 'picker', RICH: 'rich' } as const
 export type VarMode = (typeof VAR_MODE)[keyof typeof VAR_MODE]

--- a/apps/web/src/components/workflow/utils/variable-conversion.ts
+++ b/apps/web/src/components/workflow/utils/variable-conversion.ts
@@ -1,8 +1,14 @@
 // apps/web/src/components/workflow/utils/variable-conversion.ts
 
-import type { BaseType } from '~/components/workflow/types/unified-types'
-import type { UnifiedVariable } from '~/components/workflow/types/variable-types'
-import { buildVariableId, getLabelFromVariableId } from './variable-utils'
+// Deliberately zero `~/` imports: this module sits on the import path of ~24
+// node schema files, and the node-catalog migration needs that path free of
+// stores and React barrels (node-catalog Phase 1 step 0).
+import {
+  type BaseType,
+  buildVariableId,
+  getLabelFromVariableId,
+  type UnifiedVariable,
+} from '@auxx/lib/workflow-engine/client'
 
 /**
  * Deduplicate variables by their fullPath (id in new system)

--- a/apps/web/src/components/workflow/utils/variable-utils.ts
+++ b/apps/web/src/components/workflow/utils/variable-utils.ts
@@ -8,16 +8,43 @@ import {
 import {
   BaseType,
   isTypeCompatible as isBaseTypeCompatible,
-  RESOURCE_FIELD_REGISTRY,
   RESOURCE_TABLE_MAP,
   type ResourceField,
   type TableId,
+  type UnifiedVariable,
 } from '@auxx/lib/workflow-engine/client'
 import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
 import { isResourceFieldId, parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
 import type { FieldDefinition } from '~/components/conditions'
 import { useResourceStore } from '~/components/resources/store/resource-store'
-import type { UnifiedVariable } from '~/components/workflow/types/variable-types'
+
+// The pure inference layer moved to lib (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/variable-inference`). Re-exported here so
+// this module's many importers keep working; only the store-reading display
+// helpers below actually live in this file now.
+export {
+  type ArraySegmentInfo,
+  buildVariableId,
+  buildVariableLabelPath,
+  containsVariableReference,
+  getArrayAccessorCompactLabel,
+  getArrayAccessorMenuLabel,
+  getArrayItemVariable,
+  getLabelFromVariableId,
+  getNodeIdFromVariableId,
+  getPathFromVariableId,
+  inferPluckOutputType,
+  isEnvironmentVariable,
+  isNodeVariable,
+  isSystemVariable,
+  isVariableMode,
+  parseArraySegmentsFromId,
+  parseResourceFieldFromVariableId,
+  preserveArrayStructure,
+  replaceArrayAccessor,
+  resolveFieldPath,
+  VARIABLE_PATTERN,
+} from '@auxx/lib/workflow-engine/client'
 
 /**
  * `OperatorDefinition.key` is declared as a plain `string`, so narrow it back to
@@ -25,256 +52,6 @@ import type { UnifiedVariable } from '~/components/workflow/types/variable-types
  */
 const isOperatorKey = (key: string): key is Operator =>
   ALL_OPERATOR_KEYS.some((known) => known === key)
-
-/** Info about a single array segment within a variable ID */
-export interface ArraySegmentInfo {
-  /** The property name before the bracket (e.g., "to" from "to[*]") */
-  path: string
-  /** The current accessor value (e.g., "*", "0", "-1") */
-  accessor: string
-  /** The full segment string (e.g., "to[*]") */
-  fullSegment: string
-  /** Human-readable label for the property */
-  label: string
-}
-
-/** Pattern matching array bracket notation in variable IDs */
-const ARRAY_SEGMENT_PATTERN = /([^.[]+)\[(-?\d+|\*)\]/g
-
-/**
- * Parse all array segments from a variable ID
- * @example
- * parseArraySegmentsFromId("nodeId.message.to[*].items[0].name")
- * // → [{ path: "to", accessor: "*", fullSegment: "to[*]", label: "to" },
- * //    { path: "items", accessor: "0", fullSegment: "items[0]", label: "items" }]
- */
-export function parseArraySegmentsFromId(variableId: string): ArraySegmentInfo[] {
-  const segments: ArraySegmentInfo[] = []
-  let match: RegExpExecArray | null
-
-  // Reset lastIndex for global regex
-  ARRAY_SEGMENT_PATTERN.lastIndex = 0
-  while ((match = ARRAY_SEGMENT_PATTERN.exec(variableId)) !== null) {
-    segments.push({
-      path: match[1]!,
-      accessor: match[2]!,
-      fullSegment: match[0],
-      label: match[1]!,
-    })
-  }
-  return segments
-}
-
-/**
- * Replace the accessor for a specific array segment in a variable ID
- * @example
- * replaceArrayAccessor("nodeId.msg.to[*].name", "to", "0")
- * // → "nodeId.msg.to[0].name"
- */
-export function replaceArrayAccessor(
-  variableId: string,
-  segmentPath: string,
-  newAccessor: string
-): string {
-  // Match the specific segment[accessor] and replace the accessor
-  const pattern = new RegExp(`(${escapeRegExp(segmentPath)})\\[(-?\\d+|\\*)\\]`)
-  return variableId.replace(pattern, `$1[${newAccessor}]`)
-}
-
-/**
- * Get display label for an accessor — verbose format for context menu items
- */
-export function getArrayAccessorMenuLabel(accessor: string): string {
-  if (accessor === '*') return 'All items'
-  const idx = Number.parseInt(accessor, 10)
-  if (idx === 0) return 'First item'
-  if (idx === -1) return 'Last item'
-  if (idx < -1) return `${ordinal(Math.abs(idx))} to last`
-  return `${ordinal(idx + 1)} item`
-}
-
-/**
- * Get compact label for an accessor — for inline display in variable tags
- */
-export function getArrayAccessorCompactLabel(accessor: string): string {
-  return `[${accessor}]`
-}
-
-/** Get ordinal suffix for a number (1st, 2nd, 3rd, etc.) */
-function ordinal(n: number): string {
-  const s = ['th', 'st', 'nd', 'rd']
-  const v = n % 100
-  return `${n}${s[(v - 20) % 10] || s[v] || s[0]}`
-}
-
-/** Escape special regex characters in a string */
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-/**
- * Regular expression pattern for matching workflow variables in the format {{variable-name}}
- * Note: This has the 'g' flag for global matching (finding all occurrences)
- */
-export const VARIABLE_PATTERN = /\{\{([^}]+)\}\}/g
-
-/**
- * Regular expression pattern for testing if text contains a variable reference
- * Note: This does NOT have the 'g' flag, making it suitable for .test()
- */
-const VARIABLE_TEST_PATTERN = /\{\{([^}]+)\}\}/
-
-/**
- * Check if a string contains variable references in the format {{variable-name}}
- * @param text - The text to check for variable references
- * @returns true if the text contains at least one variable reference, false otherwise
- */
-export function containsVariableReference(text: string | null | undefined): boolean {
-  if (!text) return false
-  return VARIABLE_TEST_PATTERN.test(text)
-}
-
-/**
- * Get the nodeId from a variable ID
- * Examples:
- *   "webhook-123.body.email" → "webhook-123"
- *   "env.API_KEY" → "env"
- *   "sys.userId" → "sys"
- */
-export function getNodeIdFromVariableId(variableId: string): string {
-  const firstDot = variableId.indexOf('.')
-  return firstDot > 0 ? variableId.substring(0, firstDot) : variableId
-}
-
-/**
- * Get the path (relative to node) from a variable ID
- * Examples:
- *   "webhook-123.body.email" → "body.email"
- *   "env.API_KEY" → "API_KEY"
- *   "sys.userId" → "userId"
- */
-export function getPathFromVariableId(variableId: string): string {
-  const firstDot = variableId.indexOf('.')
-  return firstDot > 0 ? variableId.substring(firstDot + 1) : ''
-}
-
-/**
- * Get the label (last segment) from a variable ID
- * Examples:
- *   "webhook-123.body.contact.email" → "email"
- *   "env.API_KEY" → "API_KEY"
- */
-export function getLabelFromVariableId(variableId: string): string {
-  const segments = variableId.split('.')
-  return segments[segments.length - 1] || variableId
-}
-
-/**
- * Build a human-readable label path for a variable ID.
- * Resolves each path segment to its variable label via the variable store.
- *
- * Examples:
- *   "trigger-1.contact.first_name" → "Contact.first_name" (or "Contact.First Name" if labels resolve)
- *   "find-1.tickets" → "Tickets"
- *
- * @param variableId - Full variable ID (e.g., "trigger-1.contact.email")
- * @param resolveVariable - Function to look up a variable by ID
- * @returns Label path string with dot-separated labels
- */
-export function buildVariableLabelPath(
-  variableId: string,
-  resolveVariable: (id: string) => UnifiedVariable | undefined
-): string {
-  const parts = variableId.split('.')
-  if (parts.length <= 1) return ''
-
-  const labels: string[] = []
-  // Skip first segment (node ID), resolve labels for remaining segments
-  for (let i = 1; i < parts.length; i++) {
-    const segment = parts[i]
-    if (segment === undefined) continue
-
-    // Check for bracket notation: [*], [0], [-1], [n]
-    const bracketMatch = segment.match(/^(.+?)\[(.+)\]$/)
-    if (bracketMatch) {
-      const baseSegment = bracketMatch[1]!
-      const accessor = bracketMatch[2]!
-
-      // Resolve the array parent (without bracket)
-      const baseId = [...parts.slice(0, i), baseSegment].join('.')
-      const baseVariable = resolveVariable(baseId)
-      labels.push(baseVariable?.label || baseSegment)
-
-      if (accessor === '*') {
-        // For [*], also resolve the items variable label
-        const currentId = parts.slice(0, i + 1).join('.')
-        const itemsVariable = resolveVariable(currentId)
-        if (itemsVariable?.label) {
-          labels.push(itemsVariable.label)
-        }
-      } else {
-        // For [0], [-1], [n], show compact accessor in the label
-        labels.push(`[${accessor}]`)
-      }
-    } else {
-      const currentId = parts.slice(0, i + 1).join('.')
-      const variable = resolveVariable(currentId)
-      labels.push(variable?.label || segment)
-    }
-  }
-
-  return labels.join('.')
-}
-
-/**
- * Build a variable ID from nodeId and path
- * Examples:
- *   ("webhook-123", "body.email") → "webhook-123.body.email"
- *   ("env", "API_KEY") → "env.API_KEY"
- */
-export function buildVariableId(nodeId: string, path: string): string {
-  return `${nodeId}.${path}`
-}
-
-/**
- * Check if a variable ID is a system variable
- */
-export function isSystemVariable(variableId: string | undefined): boolean {
-  return typeof variableId === 'string' && variableId.startsWith('sys.')
-}
-
-/**
- * Check if a variable ID is an environment variable
- */
-export function isEnvironmentVariable(variableId: string | undefined): boolean {
-  return typeof variableId === 'string' && variableId.startsWith('env.')
-}
-
-/**
- * Check if a variable ID is a node variable
- * Node variables must have format "nodeId.path" (contain at least one dot)
- * and not be system or environment variables
- */
-export function isNodeVariable(variableId: string | undefined): boolean {
-  return (
-    typeof variableId === 'string' &&
-    !isSystemVariable(variableId) &&
-    !isEnvironmentVariable(variableId) &&
-    variableId.includes('.')
-  )
-}
-
-/**
- * Check if a field is in variable mode (not constant mode)
- * fieldModes[field] === true means constant mode
- * fieldModes[field] === false or undefined means variable mode
- */
-export function isVariableMode(
-  fieldModes: Record<string, boolean> | undefined,
-  field: string
-): boolean {
-  return fieldModes?.[field] !== true
-}
 
 /**
  * Get display type for a variable (for UI display only)
@@ -566,210 +343,6 @@ export function hasCompatibleChildPath(
   }
 
   return false
-}
-
-/**
- * Parse variable ID to extract resource type and field key
- * Used to look up metadata from RESOURCE_FIELD_REGISTRY
- *
- * @param variableId - Variable ID in format "nodeId.resourceType.fieldKey"
- * @returns Parsed resource type and field key, or null if not a registry-based variable
- *
- * @example
- * ```typescript
- * parseResourceFieldFromVariableId('find-123.ticket.status')
- * // Returns: { resourceType: 'ticket', fieldKey: 'status' }
- *
- * parseResourceFieldFromVariableId('find-123.ticket.contact.name')
- * // Returns: { resourceType: 'ticket', fieldKey: 'contact.name' }
- * ```
- */
-export function parseResourceFieldFromVariableId(
-  variableId: string
-): { resourceType: TableId; fieldKey: string } | null {
-  // Pattern: nodeId.resourceType.fieldKey (e.g., "find-123.ticket.status")
-  const parts = variableId.split('.')
-  if (parts.length < 3) return null
-
-  const resourceType = parts[1] as TableId
-  const fieldKey = parts.slice(2).join('.') // Handle nested paths like "contact.name"
-
-  // Validate that this is a known resource type
-  if (!RESOURCE_FIELD_REGISTRY[resourceType]) return null
-
-  return { resourceType, fieldKey }
-}
-
-/**
- * Get the item variable from an array variable
- *
- * @param arrayVar - Array variable to extract items from
- * @returns The items variable, or null if not an array
- *
- * @example
- * ```typescript
- * const contacts = { type: BaseType.ARRAY, items: { type: BaseType.OBJECT, ... } }
- * const itemVar = getArrayItemVariable(contacts) // Returns the Contact object structure
- * ```
- */
-export function getArrayItemVariable(arrayVar: UnifiedVariable): UnifiedVariable | null {
-  if (arrayVar.type !== BaseType.ARRAY) return null
-  return arrayVar.items || null
-}
-
-/**
- * Resolve a field path in a variable structure (supports nested paths like "contact.firstName")
- *
- * @param itemVar - The item variable to traverse
- * @param fieldPath - The field path (e.g., "contact.firstName", "tags")
- * @returns The resolved field variable, or null if not found
- *
- * @example
- * ```typescript
- * // Navigate to nested field
- * const ticket = { type: BaseType.OBJECT, properties: { contact: { properties: { firstName: {...} } } } }
- * const field = resolveFieldPath(ticket, 'contact.firstName') // Returns firstName variable
- * ```
- */
-export function resolveFieldPath(
-  itemVar: UnifiedVariable | null,
-  fieldPath: string
-): UnifiedVariable | null {
-  if (!itemVar || !fieldPath) return null
-
-  const parts = fieldPath.split('.')
-  let current = itemVar
-
-  for (const part of parts) {
-    // Navigate through properties
-    if (current.properties?.[part]) {
-      current = current.properties[part]
-    } else {
-      // Field not found in path
-      return null
-    }
-  }
-
-  return current
-}
-
-/**
- * Infer output type for pluck operation
- *
- * @param inputArrayVar - The input array variable
- * @param pluckField - The field path to pluck (e.g., "contact.firstName")
- * @param flatten - Whether to flatten array results
- * @returns The inferred output type metadata
- *
- * @example
- * ```typescript
- * // Pluck simple field: Contact[].email -> string[]
- * inferPluckOutputType(contactsArray, 'email', false)
- * // Returns: { type: BaseType.EMAIL, items: undefined, ... }
- *
- * // Pluck nested field: Ticket[].contact.firstName -> string[]
- * inferPluckOutputType(ticketsArray, 'contact.firstName', false)
- * // Returns: { type: BaseType.STRING, items: undefined, ... }
- *
- * // Pluck array field with flatten: Contact[].tags (flatten) -> string[]
- * inferPluckOutputType(contactsArray, 'tags', true)
- * // Returns: { type: BaseType.STRING, items: undefined, ... }
- * ```
- */
-export function inferPluckOutputType(
-  inputArrayVar: UnifiedVariable | null,
-  pluckField: string,
-  flatten: boolean = false
-): {
-  type: BaseType
-  items?: UnifiedVariable
-  resourceId?: string
-  properties?: Record<string, UnifiedVariable>
-} | null {
-  if (!inputArrayVar) return null
-
-  // Get the item structure from the input array
-  const itemVar = getArrayItemVariable(inputArrayVar)
-  if (!itemVar) return null
-
-  // Resolve the field being plucked
-  const fieldVar = resolveFieldPath(itemVar, pluckField)
-  if (!fieldVar) return null
-
-  // Detect and unwrap collection wrappers (one-to-many, many-to-many relations)
-  // Collection wrappers are objects with:
-  // - type: 'object'
-  // - fieldReference: 'resourceType:fieldKey' (e.g., 'contact:ticket')
-  // - properties.values: array of actual items
-  const isCollectionWrapper =
-    fieldVar.type === BaseType.OBJECT &&
-    fieldVar.fieldReference &&
-    isResourceFieldId(fieldVar.fieldReference) &&
-    fieldVar.properties?.values?.type === BaseType.ARRAY
-
-  if (isCollectionWrapper && fieldVar.properties?.values?.items) {
-    // Extract items from collection.values
-    // Note: collection.values.items IS the properties object directly, not a wrapped structure
-    const valuesArray = fieldVar.properties.values
-    const itemProperties = valuesArray.items! // This is the properties object itself
-
-    // Parse reference to get target resource type using typed parsing
-    // "contact:ticket" → { entityDefinitionId: 'contact', fieldId: 'ticket' }
-    const { fieldId: targetTable } = parseResourceFieldId(
-      fieldVar.fieldReference as ResourceFieldId
-    )
-
-    return {
-      type: BaseType.OBJECT, // Collection items are always objects (resource types)
-      items: undefined, // Objects don't have items (only arrays do)
-      resourceId: targetTable,
-      properties: itemProperties as any, // Properties will get IDs assigned by calling code
-    }
-  }
-
-  // If the field itself is an array and flatten is true, unwrap one level
-  if (fieldVar.type === BaseType.ARRAY && flatten && fieldVar.items) {
-    return {
-      type: fieldVar.items.type,
-      items: fieldVar.items.items, // Nested items (if any)
-      resourceId: fieldVar.items.resourceId,
-      properties: fieldVar.items.properties,
-    }
-  }
-
-  // Return the field's type as-is
-  return {
-    type: fieldVar.type,
-    items: fieldVar.items,
-    resourceId: fieldVar.resourceId,
-    properties: fieldVar.properties,
-  }
-}
-
-/**
- * Preserve array structure for operations that don't transform item types
- * (filter, sort, unique, reverse, slice)
- *
- * @param inputArrayVar - The input array variable
- * @returns The same structure (shallow clone)
- *
- * @example
- * ```typescript
- * // Filter operation: Contact[] -> Contact[] (same structure)
- * const filtered = preserveArrayStructure(contactsArray)
- * // Returns a shallow copy of the array structure
- * ```
- */
-export function preserveArrayStructure(
-  inputArrayVar: UnifiedVariable | null
-): UnifiedVariable | null {
-  if (!inputArrayVar || inputArrayVar.type !== BaseType.ARRAY) return null
-
-  // Return a shallow copy of the array structure
-  return {
-    ...inputArrayVar,
-    items: inputArrayVar.items ? { ...inputArrayVar.items } : undefined,
-  }
 }
 
 /**

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -1,0 +1,64 @@
+// packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+
+/**
+ * Node types whose definitions still live ONLY in
+ * `apps/web/src/components/workflow/nodes/core/<type>/schema.ts` and have no
+ * catalog manifest yet.
+ *
+ * This list is the migration tracker and it may ONLY SHRINK: migrating a type
+ * means registering its manifest in `registry.ts` and deleting its entry
+ * here. The catalog coverage test (apps/web parity suite) asserts that every
+ * builder `NodeType` value is in exactly one of {registered manifests, this
+ * list} — so adding a node type, migrating one, or retiring one is always an
+ * explicit edit here, never silent.
+ *
+ * Values are the persisted `data.type` strings (the builder's `NodeType` enum
+ * values), listed in the enum's order.
+ */
+export const NOT_YET_MIGRATED: readonly string[] = [
+  // Triggers
+  'message-received',
+  'webhook',
+  'webhook-endpoint',
+  'scheduled',
+  'manual',
+  'resource-trigger',
+  // Legacy per-resource triggers (kept for backwards compatibility)
+  'contact-created-trigger',
+  'contact-updated-trigger',
+  'contact-deleted-trigger',
+  'ticket-created-trigger',
+  'ticket-updated-trigger',
+  'ticket-deleted-trigger',
+  // Input nodes
+  'form-input',
+  'number-input',
+  'file-upload',
+  // Condition nodes
+  'if-else',
+  // Action nodes
+  'answer',
+  'ai',
+  'find',
+  'http',
+  'crud',
+  'document-extractor',
+  'chunker',
+  'dataset',
+  'knowledge-retrieval',
+  // Transform nodes
+  'code',
+  'text-classifier',
+  'information-extractor',
+  'var-assign',
+  'date-time',
+  'list',
+  'format',
+  // Data nodes
+  'note',
+  // Control nodes
+  'end',
+  'wait',
+  'loop',
+  'human-confirmation',
+] as const

--- a/packages/lib/src/workflow-engine/catalog/registry.ts
+++ b/packages/lib/src/workflow-engine/catalog/registry.ts
@@ -1,0 +1,39 @@
+// packages/lib/src/workflow-engine/catalog/registry.ts
+
+import type { NodeManifest } from './types'
+
+/**
+ * The catalog registry — a plain module-level map, no class (lib-module
+ * convention). Node manifests register themselves at module load via
+ * `registerManifest`; consumers read through `getManifest` / `listManifests`.
+ *
+ * Migration discipline: a node type lives EITHER here or on the
+ * `NOT_YET_MIGRATED` list (`not-yet-migrated.ts`) — never both, never
+ * neither. The catalog coverage test asserts exact set equality against the
+ * builder's `NodeType` enum, so migrating a type is always an explicit
+ * two-file change: register the manifest, delete the list entry.
+ */
+const manifests = new Map<string, NodeManifest<any>>()
+
+/** Register a node manifest. Throws on duplicate ids — two declarations of one type is the drift this catalog exists to end. */
+export function registerManifest(manifest: NodeManifest<any>): void {
+  if (manifests.has(manifest.id)) {
+    throw new Error(`Node manifest already registered for type "${manifest.id}"`)
+  }
+  manifests.set(manifest.id, manifest)
+}
+
+/** Look up one node type's manifest. Undefined ⇒ not yet migrated (check `NOT_YET_MIGRATED`). */
+export function getManifest(type: string): NodeManifest<any> | undefined {
+  return manifests.get(type)
+}
+
+/** Every registered manifest. */
+export function listManifests(): NodeManifest<any>[] {
+  return Array.from(manifests.values())
+}
+
+/** Manifests Kopilot may author (`agent.authorable === true`). */
+export function getAuthorableManifests(): NodeManifest<any>[] {
+  return listManifests().filter((manifest) => manifest.agent?.authorable === true)
+}

--- a/packages/lib/src/workflow-engine/catalog/types.ts
+++ b/packages/lib/src/workflow-engine/catalog/types.ts
@@ -1,0 +1,135 @@
+// packages/lib/src/workflow-engine/catalog/types.ts
+
+import type { z } from 'zod'
+import type { WorkflowTriggerType } from '../core/types'
+
+/**
+ * The node catalog: one server-safe declaration of what a workflow node *is*,
+ * shared by the builder (apps/web merges in the React parts via
+ * `registerFromManifest`), the engine processors, and — later — Kopilot's
+ * authoring tools. Replaces the three drifting copies (builder
+ * `NodeDefinition`, engine shadow interfaces, and the parity suite's static
+ * extraction) one migrated node type at a time; `not-yet-migrated.ts` is the
+ * tracker.
+ */
+
+/**
+ * UI node categories for organization.
+ * Relocated from apps/web types/registry.ts (which re-exports it) so the
+ * catalog can categorize without importing web code.
+ */
+export enum NodeCategory {
+  TRIGGER = 'trigger',
+  INPUT = 'input',
+  CONDITION = 'condition',
+  ACTION = 'action',
+  TRANSFORM = 'transform',
+  FLOW_CONTROL = 'flow_control',
+  DATA = 'data',
+  DATASET = 'dataset',
+  INTEGRATION = 'integration',
+  AI = 'ai',
+  DEBUG = 'debug',
+  UTILITY = 'utility',
+}
+
+/**
+ * Per-field validation result a node validator returns.
+ *
+ * NOT the engine's `ValidationResult` (core/types.ts — `{ valid, errors:
+ * string[] }`, a whole-workflow publish check). This is the builder-checklist
+ * shape; apps/web types/registry.ts re-exports it under its historical name
+ * `ValidationResult`.
+ */
+export interface NodeValidationResult {
+  isValid: boolean
+  errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }>
+}
+
+/** A branch handle a node exposes for a given config (if-else cases, fail branches, …). */
+export interface NodeBranch {
+  id: string
+  name: string
+  kind: 'default' | 'fail'
+}
+
+/**
+ * Connection rules for a node type — how the canvas may wire it.
+ * Mirrors the connection-related fields of the builder's `NodeDefinition`.
+ */
+export interface NodeConnectionRules<TConfig = unknown> {
+  canConnect?: boolean
+  canRunSingle?: boolean
+  acceptsInputNodes?: boolean
+  availableNextNodes?: string[]
+  availablePrevNodes?: string[]
+  maxIncomingConnections?: number
+  maxOutgoingConnections?: number
+  /**
+   * Branch handles this node exposes for a given config. The single source
+   * for the handle id the canvas renders AND the handle the processor emits —
+   * asserted by the parity suite's handle checks.
+   */
+  branches?: (config: TConfig) => NodeBranch[]
+}
+
+/** Prompt-facing documentation consumed by agent-authoring tools (`describe_node_type`). */
+export interface NodeAgentDocs {
+  /** May Kopilot author this node type? Non-authorable types are read-only to the agent. */
+  authorable: boolean
+  /** Short usage guidance the tool returns verbatim. */
+  usage: string
+  examples: Array<{ description: string; config: unknown }>
+}
+
+/**
+ * The data half of a workflow node definition — everything about a node type
+ * that is not React. The web registry merges a manifest with its components
+ * (`node.tsx` / `panel.tsx` / `trace-renderer.tsx`, which never move) via
+ * `registerFromManifest`; server callers read manifests directly.
+ */
+export interface NodeManifest<TConfig = unknown> {
+  /** NodeType value, e.g. 'wait' — the `data.type` persisted on graph nodes. */
+  id: string
+  category: NodeCategory
+  displayName: string
+  description: string
+  /** Icon NAME only — apps/web resolves the actual component. */
+  icon: string
+  color?: string
+  /** Dynamic icon name based on config (optional). */
+  getIcon?: (config: TConfig) => string
+
+  /** Only set for trigger nodes. */
+  triggerType?: WorkflowTriggerType
+  defaultData: () => Partial<TConfig>
+
+  /**
+   * Authoritative config schema. Unlike the legacy `NodeDefinition.schema`
+   * (typed `any`, never parsed), manifests are held to `configSchema
+   * .safeParse(defaultData())` by the catalog test, and later phases parse on
+   * save.
+   */
+  configSchema: z.ZodType<TConfig>
+
+  /**
+   * Agent-facing projection of the SAME configuration, present only where the
+   * persisted shape is hostile to a model (Tiptap docs, positional payload
+   * items, `z.any()`). Absent ⇒ `configSchema` is used directly. Must never
+   * admit something `configSchema` would reject after `fromAgentConfig`.
+   */
+  agentSchema?: z.ZodType
+  fromAgentConfig?: (friendly: unknown, ctx: unknown) => TConfig
+
+  validate: (config: TConfig) => NodeValidationResult
+  extractVariables?: (config: TConfig) => string[]
+
+  // resolveOutputs: OutputResolver<TConfig>
+  // ^ deliberately deferred — output resolution gets a server-callable context
+  //   in the next phase; adding the member now would force a design under
+  //   time pressure. The web merge falls back to the legacy `outputVariables`
+  //   until then.
+
+  connection: NodeConnectionRules<TConfig>
+  agent?: NodeAgentDocs
+}

--- a/packages/lib/src/workflow-engine/catalog/variable-inference.ts
+++ b/packages/lib/src/workflow-engine/catalog/variable-inference.ts
@@ -1,0 +1,447 @@
+// packages/lib/src/workflow-engine/catalog/variable-inference.ts
+
+import { isResourceFieldId, parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import { RESOURCE_FIELD_REGISTRY, type TableId } from '../../resources/registry/field-registry'
+import { BaseType } from '../core/types'
+import type { UnifiedVariable } from '../types/unified-variable'
+
+/**
+ * Pure variable-id and variable-shape inference helpers, shared by the builder
+ * (apps/web) and the server side of the node catalog.
+ *
+ * Split out of apps/web utils/variable-utils.ts (Phase 1 step 0 of the node
+ * catalog migration): everything here is pure — no store, no React, no DOM.
+ * The display-oriented helpers that read `useResourceStore` stayed behind in
+ * apps/web. Keeping that boundary is what lets node definitions (and their
+ * output resolvers) move into lib without dragging the browser in.
+ */
+
+/** Info about a single array segment within a variable ID */
+export interface ArraySegmentInfo {
+  /** The property name before the bracket (e.g., "to" from "to[*]") */
+  path: string
+  /** The current accessor value (e.g., "*", "0", "-1") */
+  accessor: string
+  /** The full segment string (e.g., "to[*]") */
+  fullSegment: string
+  /** Human-readable label for the property */
+  label: string
+}
+
+/** Pattern matching array bracket notation in variable IDs */
+const ARRAY_SEGMENT_PATTERN = /([^.[]+)\[(-?\d+|\*)\]/g
+
+/**
+ * Parse all array segments from a variable ID
+ * @example
+ * parseArraySegmentsFromId("nodeId.message.to[*].items[0].name")
+ * // → [{ path: "to", accessor: "*", fullSegment: "to[*]", label: "to" },
+ * //    { path: "items", accessor: "0", fullSegment: "items[0]", label: "items" }]
+ */
+export function parseArraySegmentsFromId(variableId: string): ArraySegmentInfo[] {
+  const segments: ArraySegmentInfo[] = []
+  let match: RegExpExecArray | null
+
+  // Reset lastIndex for global regex
+  ARRAY_SEGMENT_PATTERN.lastIndex = 0
+  while ((match = ARRAY_SEGMENT_PATTERN.exec(variableId)) !== null) {
+    segments.push({
+      path: match[1]!,
+      accessor: match[2]!,
+      fullSegment: match[0],
+      label: match[1]!,
+    })
+  }
+  return segments
+}
+
+/**
+ * Replace the accessor for a specific array segment in a variable ID
+ * @example
+ * replaceArrayAccessor("nodeId.msg.to[*].name", "to", "0")
+ * // → "nodeId.msg.to[0].name"
+ */
+export function replaceArrayAccessor(
+  variableId: string,
+  segmentPath: string,
+  newAccessor: string
+): string {
+  // Match the specific segment[accessor] and replace the accessor
+  const pattern = new RegExp(`(${escapeRegExp(segmentPath)})\\[(-?\\d+|\\*)\\]`)
+  return variableId.replace(pattern, `$1[${newAccessor}]`)
+}
+
+/**
+ * Get display label for an accessor — verbose format for context menu items
+ */
+export function getArrayAccessorMenuLabel(accessor: string): string {
+  if (accessor === '*') return 'All items'
+  const idx = Number.parseInt(accessor, 10)
+  if (idx === 0) return 'First item'
+  if (idx === -1) return 'Last item'
+  if (idx < -1) return `${ordinal(Math.abs(idx))} to last`
+  return `${ordinal(idx + 1)} item`
+}
+
+/**
+ * Get compact label for an accessor — for inline display in variable tags
+ */
+export function getArrayAccessorCompactLabel(accessor: string): string {
+  return `[${accessor}]`
+}
+
+/** Get ordinal suffix for a number (1st, 2nd, 3rd, etc.) */
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return `${n}${s[(v - 20) % 10] || s[v] || s[0]}`
+}
+
+/** Escape special regex characters in a string */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Regular expression pattern for matching workflow variables in the format {{variable-name}}
+ * Note: This has the 'g' flag for global matching (finding all occurrences)
+ */
+export const VARIABLE_PATTERN = /\{\{([^}]+)\}\}/g
+
+/**
+ * Regular expression pattern for testing if text contains a variable reference
+ * Note: This does NOT have the 'g' flag, making it suitable for .test()
+ */
+const VARIABLE_TEST_PATTERN = /\{\{([^}]+)\}\}/
+
+/**
+ * Check if a string contains variable references in the format {{variable-name}}
+ * @param text - The text to check for variable references
+ * @returns true if the text contains at least one variable reference, false otherwise
+ */
+export function containsVariableReference(text: string | null | undefined): boolean {
+  if (!text) return false
+  return VARIABLE_TEST_PATTERN.test(text)
+}
+
+/**
+ * Get the nodeId from a variable ID
+ * Examples:
+ *   "webhook-123.body.email" → "webhook-123"
+ *   "env.API_KEY" → "env"
+ *   "sys.userId" → "sys"
+ */
+export function getNodeIdFromVariableId(variableId: string): string {
+  const firstDot = variableId.indexOf('.')
+  return firstDot > 0 ? variableId.substring(0, firstDot) : variableId
+}
+
+/**
+ * Get the path (relative to node) from a variable ID
+ * Examples:
+ *   "webhook-123.body.email" → "body.email"
+ *   "env.API_KEY" → "API_KEY"
+ *   "sys.userId" → "userId"
+ */
+export function getPathFromVariableId(variableId: string): string {
+  const firstDot = variableId.indexOf('.')
+  return firstDot > 0 ? variableId.substring(firstDot + 1) : ''
+}
+
+/**
+ * Get the label (last segment) from a variable ID
+ * Examples:
+ *   "webhook-123.body.contact.email" → "email"
+ *   "env.API_KEY" → "API_KEY"
+ */
+export function getLabelFromVariableId(variableId: string): string {
+  const segments = variableId.split('.')
+  return segments[segments.length - 1] || variableId
+}
+
+/**
+ * Build a human-readable label path for a variable ID.
+ * Resolves each path segment to its variable label via the supplied resolver.
+ *
+ * Examples:
+ *   "trigger-1.contact.first_name" → "Contact.first_name" (or "Contact.First Name" if labels resolve)
+ *   "find-1.tickets" → "Tickets"
+ *
+ * @param variableId - Full variable ID (e.g., "trigger-1.contact.email")
+ * @param resolveVariable - Function to look up a variable by ID
+ * @returns Label path string with dot-separated labels
+ */
+export function buildVariableLabelPath(
+  variableId: string,
+  resolveVariable: (id: string) => UnifiedVariable | undefined
+): string {
+  const parts = variableId.split('.')
+  if (parts.length <= 1) return ''
+
+  const labels: string[] = []
+  // Skip first segment (node ID), resolve labels for remaining segments
+  for (let i = 1; i < parts.length; i++) {
+    const segment = parts[i]
+    if (segment === undefined) continue
+
+    // Check for bracket notation: [*], [0], [-1], [n]
+    const bracketMatch = segment.match(/^(.+?)\[(.+)\]$/)
+    if (bracketMatch) {
+      const baseSegment = bracketMatch[1]!
+      const accessor = bracketMatch[2]!
+
+      // Resolve the array parent (without bracket)
+      const baseId = [...parts.slice(0, i), baseSegment].join('.')
+      const baseVariable = resolveVariable(baseId)
+      labels.push(baseVariable?.label || baseSegment)
+
+      if (accessor === '*') {
+        // For [*], also resolve the items variable label
+        const currentId = parts.slice(0, i + 1).join('.')
+        const itemsVariable = resolveVariable(currentId)
+        if (itemsVariable?.label) {
+          labels.push(itemsVariable.label)
+        }
+      } else {
+        // For [0], [-1], [n], show compact accessor in the label
+        labels.push(`[${accessor}]`)
+      }
+    } else {
+      const currentId = parts.slice(0, i + 1).join('.')
+      const variable = resolveVariable(currentId)
+      labels.push(variable?.label || segment)
+    }
+  }
+
+  return labels.join('.')
+}
+
+/**
+ * Build a variable ID from nodeId and path
+ * Examples:
+ *   ("webhook-123", "body.email") → "webhook-123.body.email"
+ *   ("env", "API_KEY") → "env.API_KEY"
+ */
+export function buildVariableId(nodeId: string, path: string): string {
+  return `${nodeId}.${path}`
+}
+
+/**
+ * Check if a variable ID is a system variable
+ */
+export function isSystemVariable(variableId: string | undefined): boolean {
+  return typeof variableId === 'string' && variableId.startsWith('sys.')
+}
+
+/**
+ * Check if a variable ID is an environment variable
+ */
+export function isEnvironmentVariable(variableId: string | undefined): boolean {
+  return typeof variableId === 'string' && variableId.startsWith('env.')
+}
+
+/**
+ * Check if a variable ID is a node variable
+ * Node variables must have format "nodeId.path" (contain at least one dot)
+ * and not be system or environment variables
+ */
+export function isNodeVariable(variableId: string | undefined): boolean {
+  return (
+    typeof variableId === 'string' &&
+    !isSystemVariable(variableId) &&
+    !isEnvironmentVariable(variableId) &&
+    variableId.includes('.')
+  )
+}
+
+/**
+ * Check if a field is in variable mode (not constant mode)
+ * fieldModes[field] === true means constant mode
+ * fieldModes[field] === false or undefined means variable mode
+ */
+export function isVariableMode(
+  fieldModes: Record<string, boolean> | undefined,
+  field: string
+): boolean {
+  return fieldModes?.[field] !== true
+}
+
+/**
+ * Parse variable ID to extract resource type and field key
+ * Used to look up metadata from RESOURCE_FIELD_REGISTRY
+ *
+ * @param variableId - Variable ID in format "nodeId.resourceType.fieldKey"
+ * @returns Parsed resource type and field key, or null if not a registry-based variable
+ *
+ * @example
+ * ```typescript
+ * parseResourceFieldFromVariableId('find-123.ticket.status')
+ * // Returns: { resourceType: 'ticket', fieldKey: 'status' }
+ *
+ * parseResourceFieldFromVariableId('find-123.ticket.contact.name')
+ * // Returns: { resourceType: 'ticket', fieldKey: 'contact.name' }
+ * ```
+ */
+export function parseResourceFieldFromVariableId(
+  variableId: string
+): { resourceType: TableId; fieldKey: string } | null {
+  // Pattern: nodeId.resourceType.fieldKey (e.g., "find-123.ticket.status")
+  const parts = variableId.split('.')
+  if (parts.length < 3) return null
+
+  const resourceType = parts[1] as TableId
+  const fieldKey = parts.slice(2).join('.') // Handle nested paths like "contact.name"
+
+  // Validate that this is a known resource type
+  if (!RESOURCE_FIELD_REGISTRY[resourceType]) return null
+
+  return { resourceType, fieldKey }
+}
+
+/**
+ * Get the item variable from an array variable
+ *
+ * @param arrayVar - Array variable to extract items from
+ * @returns The items variable, or null if not an array
+ */
+export function getArrayItemVariable(arrayVar: UnifiedVariable): UnifiedVariable | null {
+  if (arrayVar.type !== BaseType.ARRAY) return null
+  return arrayVar.items || null
+}
+
+/**
+ * Resolve a field path in a variable structure (supports nested paths like "contact.firstName")
+ *
+ * @param itemVar - The item variable to traverse
+ * @param fieldPath - The field path (e.g., "contact.firstName", "tags")
+ * @returns The resolved field variable, or null if not found
+ */
+export function resolveFieldPath(
+  itemVar: UnifiedVariable | null,
+  fieldPath: string
+): UnifiedVariable | null {
+  if (!itemVar || !fieldPath) return null
+
+  const parts = fieldPath.split('.')
+  let current = itemVar
+
+  for (const part of parts) {
+    // Navigate through properties
+    if (current.properties?.[part]) {
+      current = current.properties[part]
+    } else {
+      // Field not found in path
+      return null
+    }
+  }
+
+  return current
+}
+
+/**
+ * Infer output type for pluck operation
+ *
+ * @param inputArrayVar - The input array variable
+ * @param pluckField - The field path to pluck (e.g., "contact.firstName")
+ * @param flatten - Whether to flatten array results
+ * @returns The inferred output type metadata
+ *
+ * @example
+ * ```typescript
+ * // Pluck simple field: Contact[].email -> string[]
+ * inferPluckOutputType(contactsArray, 'email', false)
+ * // Returns: { type: BaseType.EMAIL, items: undefined, ... }
+ *
+ * // Pluck array field with flatten: Contact[].tags (flatten) -> string[]
+ * inferPluckOutputType(contactsArray, 'tags', true)
+ * // Returns: { type: BaseType.STRING, items: undefined, ... }
+ * ```
+ */
+export function inferPluckOutputType(
+  inputArrayVar: UnifiedVariable | null,
+  pluckField: string,
+  flatten: boolean = false
+): {
+  type: BaseType
+  items?: UnifiedVariable
+  resourceId?: string
+  properties?: Record<string, UnifiedVariable>
+} | null {
+  if (!inputArrayVar) return null
+
+  // Get the item structure from the input array
+  const itemVar = getArrayItemVariable(inputArrayVar)
+  if (!itemVar) return null
+
+  // Resolve the field being plucked
+  const fieldVar = resolveFieldPath(itemVar, pluckField)
+  if (!fieldVar) return null
+
+  // Detect and unwrap collection wrappers (one-to-many, many-to-many relations)
+  // Collection wrappers are objects with:
+  // - type: 'object'
+  // - fieldReference: 'resourceType:fieldKey' (e.g., 'contact:ticket')
+  // - properties.values: array of actual items
+  const isCollectionWrapper =
+    fieldVar.type === BaseType.OBJECT &&
+    fieldVar.fieldReference &&
+    isResourceFieldId(fieldVar.fieldReference) &&
+    fieldVar.properties?.values?.type === BaseType.ARRAY
+
+  if (isCollectionWrapper && fieldVar.properties?.values?.items) {
+    // Extract items from collection.values
+    // Note: collection.values.items IS the properties object directly, not a wrapped structure
+    const valuesArray = fieldVar.properties.values
+    const itemProperties = valuesArray.items! // This is the properties object itself
+
+    // Parse reference to get target resource type using typed parsing
+    // "contact:ticket" → { entityDefinitionId: 'contact', fieldId: 'ticket' }
+    const { fieldId: targetTable } = parseResourceFieldId(
+      fieldVar.fieldReference as ResourceFieldId
+    )
+
+    return {
+      type: BaseType.OBJECT, // Collection items are always objects (resource types)
+      items: undefined, // Objects don't have items (only arrays do)
+      resourceId: targetTable,
+      properties: itemProperties as any, // Properties will get IDs assigned by calling code
+    }
+  }
+
+  // If the field itself is an array and flatten is true, unwrap one level
+  if (fieldVar.type === BaseType.ARRAY && flatten && fieldVar.items) {
+    return {
+      type: fieldVar.items.type,
+      items: fieldVar.items.items, // Nested items (if any)
+      resourceId: fieldVar.items.resourceId,
+      properties: fieldVar.items.properties,
+    }
+  }
+
+  // Return the field's type as-is
+  return {
+    type: fieldVar.type,
+    items: fieldVar.items,
+    resourceId: fieldVar.resourceId,
+    properties: fieldVar.properties,
+  }
+}
+
+/**
+ * Preserve array structure for operations that don't transform item types
+ * (filter, sort, unique, reverse, slice)
+ *
+ * @param inputArrayVar - The input array variable
+ * @returns The same structure (shallow clone)
+ */
+export function preserveArrayStructure(
+  inputArrayVar: UnifiedVariable | null
+): UnifiedVariable | null {
+  if (!inputArrayVar || inputArrayVar.type !== BaseType.ARRAY) return null
+
+  // Return a shallow copy of the array structure
+  return {
+    ...inputArrayVar,
+    items: inputArrayVar.items ? { ...inputArrayVar.items } : undefined,
+  }
+}

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -70,6 +70,53 @@ export * from './utils/terminal-nodes'
 // NOTE: Operator definitions moved to @auxx/lib/conditions
 // Import OPERATOR_DEFINITIONS, Operator, etc. from '@auxx/lib/conditions' or '@auxx/lib/conditions/client'
 
+// ── Node catalog (Phase 1 of the node-catalog migration) ─────────────────────
+// The server-safe node contract: manifest types, the registry, the migration
+// tracker, and the pure variable-inference helpers split out of apps/web
+// utils/variable-utils.ts (the store-reading display helpers stayed there).
+export { NOT_YET_MIGRATED } from './catalog/not-yet-migrated'
+export {
+  getAuthorableManifests,
+  getManifest,
+  listManifests,
+  registerManifest,
+} from './catalog/registry'
+export {
+  type NodeAgentDocs,
+  type NodeBranch,
+  NodeCategory,
+  type NodeConnectionRules,
+  type NodeManifest,
+  type NodeValidationResult,
+} from './catalog/types'
+export {
+  type ArraySegmentInfo,
+  buildVariableId,
+  buildVariableLabelPath,
+  containsVariableReference,
+  getArrayAccessorCompactLabel,
+  getArrayAccessorMenuLabel,
+  getArrayItemVariable,
+  getLabelFromVariableId,
+  getNodeIdFromVariableId,
+  getPathFromVariableId,
+  inferPluckOutputType,
+  isEnvironmentVariable,
+  isNodeVariable,
+  isSystemVariable,
+  isVariableMode,
+  parseArraySegmentsFromId,
+  parseResourceFieldFromVariableId,
+  preserveArrayStructure,
+  replaceArrayAccessor,
+  resolveFieldPath,
+  VARIABLE_PATTERN,
+} from './catalog/variable-inference'
+export type {
+  AllowedVarType,
+  UnifiedVariable,
+  ValidationRules,
+} from './types/unified-variable'
 // Field type mapping utilities
 export {
   extractEnumOptions,

--- a/packages/lib/src/workflow-engine/types/unified-variable.ts
+++ b/packages/lib/src/workflow-engine/types/unified-variable.ts
@@ -1,0 +1,109 @@
+// packages/lib/src/workflow-engine/types/unified-variable.ts
+
+import type { ResourceFieldId } from '@auxx/types/field'
+import type { FieldOptions } from '../../field-values/converters'
+import type { BaseType } from '../core/types'
+
+/**
+ * Validation rules for type values
+ */
+export interface ValidationRules {
+  min?: number
+  max?: number
+  minLength?: number
+  maxLength?: number
+  pattern?: string | RegExp
+  custom?: (value: any) => boolean | string
+}
+
+/**
+ * One entry of a variable picker's `allowedTypes` / `expectedTypes` filter.
+ *
+ * Either a {@link BaseType}, or a **resource identifier** used to filter
+ * relation/reference variables. That identifier is not restricted to the system
+ * `TableId` union — it may equally be an `EntityDefinition` id or a resource
+ * slug, which `isVariableTypeCompatible` cross-resolves through the resource
+ * store. Hence `string` rather than `TableId`.
+ */
+export type AllowedVarType = BaseType | string
+
+/**
+ * Unified variable type that merges all legacy variable formats.
+ * The single source of truth for variables across the workflow system —
+ * declared by node output resolvers, consumed by the variable picker and the
+ * execution context.
+ */
+export interface UnifiedVariable {
+  // Core identification
+  id: string // Unique identifier (full path: "node-123.content", "env.API_KEY")
+  nodeId?: string
+
+  // Display information
+  label: string // Human-readable label
+  description?: string // Optional description
+
+  type: BaseType // Base type from unified type system
+
+  // ─────────────────────────────────────────────────────────────
+  // FIELD REFERENCE (typed, replaces untyped `reference`)
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Typed field reference using ResourceFieldId system.
+   * Format: `${entityDefinitionId}:${fieldId}`
+   *
+   * Examples:
+   * - "contact:email" (system field on contact)
+   * - "ticket:cm1abc123xyz" (custom field on ticket)
+   *
+   * Use parseResourceFieldId() to extract components - NO manual .split(':')
+   */
+  fieldReference?: ResourceFieldId
+
+  /**
+   * For direct resource references (e.g., "contact", "ticket")
+   * When the variable IS a resource, not a field ON a resource.
+   */
+  resourceId?: string
+
+  /**
+   * Field options using unified FieldOptions structure.
+   * Same format as custom fields for consistency.
+   */
+  options?: FieldOptions
+
+  /**
+   * Allowed values for `BaseType.ENUM` variables.
+   *
+   * Sourced from a JSON Schema `enum`, which permits both strings and numbers —
+   * see `schemaToUnifiedVariable` in apps/web utils/schema-to-variable.ts.
+   */
+  enum?: (string | number)[]
+
+  // ─────────────────────────────────────────────────────────────
+  // STRUCTURAL TYPES
+  // ─────────────────────────────────────────────────────────────
+
+  // For arrays: type of items
+  items?: UnifiedVariable // Replaces itemType, now recursive
+
+  // For objects: property definitions with key preservation
+  properties?: Record<string, UnifiedVariable> // Object properties by key
+
+  // ─────────────────────────────────────────────────────────────
+  // METADATA
+  // ─────────────────────────────────────────────────────────────
+
+  // Categorization
+  category: 'node' | 'environment' | 'system'
+
+  // Value constraints
+  required?: boolean // Is this variable required?
+  default?: any // Default value
+  example?: any // Example value
+  validation?: ValidationRules
+
+  // UI hints (optional)
+  icon?: string // Icon for UI display
+  color?: string // Color for UI display
+}


### PR DESCRIPTION
## Summary

Phase 1 steps 0+1 of the node-catalog migration (the plan that ends the builder↔engine node-definition duplication the parity suite currently guards by static extraction). **No node type migrates in this PR**, and the hard invariant holds: zero diff under any node's `node.tsx` / `panel.tsx` / `trace-renderer.tsx`.

### Step 0 — the `variable-utils` split

`utils/variable-utils.ts` mixed pure variable-id/shape inference with store-reading display helpers; via `variable-conversion.ts`, ~24 node schema files transitively pulled zustand + a React barrel — the blocker for moving any node definition to lib.

- Pure layer → `packages/lib/src/workflow-engine/catalog/variable-inference.ts` (grep-proven: no `~/`, no store, no React).
- `UnifiedVariable` / `AllowedVarType` / `ValidationRules` → `workflow-engine/types/unified-variable.ts` (their imports were already all lib types); web files re-export so no import churns. The React-carrying picker types (`VariableGroup`, `VariableCategory`) stay in web.
- `variable-conversion.ts` now has deliberately **zero `~/` imports**; `schema-to-variable.ts` is severed transitively.
- Web `variable-utils.ts` keeps only the six `useResourceStore` display helpers + back-compat re-exports.

### Step 1 — the catalog skeleton

- `catalog/types.ts`: `NodeManifest` — the data half of a node definition: enforced `configSchema`, `agentSchema` projection slot, connection rules incl. `branches()` (the future single source for the handle ids the parity suite now asserts), and agent-facing docs. `NodeCategory` relocates here; the builder's validator result relocates as `NodeValidationResult` (the engine's whole-workflow `ValidationResult` keeps its name — different shape, deliberate rename).
- `catalog/registry.ts`: module-level map (no class), duplicate registration throws.
- `catalog/not-yet-migrated.ts`: all 38 `NodeType` values — the migration tracker, may only shrink.
- apps/web `defineFromManifest`: builds today's `NodeDefinition` from manifest + React parts so every registry consumer keeps working as types migrate. Output resolution is deliberately deferred (commented slot) until it gets a server-callable context.
- `parity/catalog-coverage.test.ts`: exact set-equality coverage (every `NodeType` in exactly one of {manifests, `NOT_YET_MIGRATED`}), `configSchema.safeParse(defaultData())` for every manifest — the discipline the legacy `schema: any` never had — and a `defineFromManifest` merge unit test.

## Verification

- `apps/web` workflow suite: **90 passed** (85 existing incl. full parity suite + 5 new catalog tests).
- `packages/lib` tsc: zero errors in new files (remaining errors are the known pre-existing baseline).
- Node component zero-diff verified by `git diff --stat` over `nodes/core/*/{node,panel,trace-renderer}.tsx` + `components/`.

Next: `wait` migrates end-to-end as the template PR.