### PR TITLE
feat(workflow): migrate the wait node to the catalog

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/wait/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/wait/schema.ts
@@ -1,105 +1,15 @@
 // apps/web/src/components/workflow/nodes/core/wait/schema.ts
 
-import { WAIT_CONSTANTS } from '@auxx/lib/workflow-engine/constants'
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
-import { NodeType } from '~/components/workflow/types/node-types'
+import { type NodeManifest, waitManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
+import { defineFromManifest } from '../../define-from-manifest'
 import { BaseType } from '../if-else'
-import { DurationUnit, type WaitNodeData, WaitType } from './types'
+import type { WaitNodeData } from './types'
 
-/**
- * Zod schema for wait node data
- */
-export const waitNodeDataSchema = baseNodeDataSchema
-  .extend({
-    waitType: z.enum(WaitType),
-    durationAmount: z
-      .union([
-        z.number().min(WAIT_CONSTANTS.DURATION.MIN).max(WAIT_CONSTANTS.DURATION.MAX),
-        z.string(),
-        z.object({ id: z.string(), nodeId: z.string().optional(), path: z.string() }), // UnifiedVariable
-      ])
-      .optional(),
-    isDurationConstant: z.boolean().default(true),
-    durationUnit: z.enum(DurationUnit).optional(),
-    time: z
-      .union([
-        z.string(),
-        z.object({ id: z.string(), nodeId: z.string().optional(), path: z.string() }), // UnifiedVariable
-      ])
-      .optional(),
-    isTimeConstant: z.boolean().default(true),
-    timezone: z.string().optional(),
-  })
-  .refine(
-    (data) => {
-      if (data.waitType === WaitType.DURATION) {
-        return data.durationAmount !== undefined && data.durationUnit !== undefined
-      }
-      return data.time !== undefined
-    },
-    { message: 'Required fields missing for selected wait type' }
-  )
-
-/**
- * Default configuration for new wait nodes
- */
-export const waitDefaultData: Partial<WaitNodeData> = {
-  title: 'Wait',
-  description: '',
-  waitType: WaitType.DURATION,
-  durationAmount: 5,
-  isDurationConstant: true,
-  durationUnit: DurationUnit.SECONDS,
-  time: undefined,
-  isTimeConstant: true,
-}
-
-/**
- * Validation function for wait configuration
- */
-export const validateWaitConfig = (data: WaitNodeData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Validate title
-  if (!data.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Validate wait type
-  if (!data.waitType) {
-    errors.push({ field: 'waitType', message: 'Wait type is required', type: 'error' })
-  } else if (data.waitType === WaitType.DURATION) {
-    // Validate duration-based wait
-    if (!data.durationAmount) {
-      errors.push({
-        field: 'durationAmount',
-        message: 'Duration amount is required',
-        type: 'error',
-      })
-    }
-    if (!data.durationUnit) {
-      errors.push({ field: 'durationUnit', message: 'Duration unit is required', type: 'error' })
-    }
-  } else if (data.waitType === WaitType.SPECIFIC_TIME) {
-    // Validate specific time wait
-    if (!data.time) {
-      errors.push({
-        field: 'time',
-        message: 'Time is required for specific time wait',
-        type: 'error',
-      })
-    }
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
+// The data half (enums, data interface, zod schema, defaults, validator)
+// lives in the node catalog (`@auxx/lib/workflow-engine/catalog/nodes/wait`).
+// This file is the merge site: manifest + the web-only output resolver.
 
 /**
  * Get output variables for wait node.
@@ -138,19 +48,21 @@ const getWaitOutputVariables = (_data: WaitNodeData, nodeId: string): any[] => [
 ]
 
 /**
- * Wait node definition
+ * Wait node definition.
+ *
+ * The cast bridges lib's `type: string` to the web `NodeType` narrowing —
+ * safe because the manifest's defaults never set `type` (the node factory
+ * assigns identity).
  */
-export const waitDefinition: NodeDefinition<WaitNodeData> = {
-  id: NodeType.WAIT,
-  category: NodeCategory.UTILITY,
-  displayName: 'Wait',
-  description: 'Pause workflow execution for a specified duration',
-  icon: 'clock',
-  color: '#3B82F6', // UTILITY category color
-  defaultData: waitDefaultData,
-  schema: waitNodeDataSchema,
-  validator: validateWaitConfig,
-  canRunSingle: true,
-  extractVariables: () => [], // Wait node doesn't use any variables
-  outputVariables: getWaitOutputVariables,
-}
+export const waitDefinition: NodeDefinition<WaitNodeData> = defineFromManifest(
+  waitManifest as unknown as NodeManifest<WaitNodeData>,
+  { outputVariables: getWaitOutputVariables }
+)
+
+// Back-compat re-exports so no panel or consumer import churns:
+export { validateWaitConfig, waitNodeDataSchema } from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Default configuration for new wait nodes
+ */
+export const waitDefaultData = waitManifest.defaultData() as Partial<WaitNodeData>

--- a/apps/web/src/components/workflow/nodes/core/wait/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/wait/types.ts
@@ -1,41 +1,20 @@
 // apps/web/src/components/workflow/nodes/core/wait/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { CatalogWaitNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
 
-/**
- * Wait type options
- */
-export enum WaitType {
-  DURATION = 'duration',
-  SPECIFIC_TIME = 'specific_time',
-}
-
-/**
- * Duration unit options
- */
-export enum DurationUnit {
-  SECONDS = 'seconds',
-  MINUTES = 'minutes',
-  HOURS = 'hours',
-  DAYS = 'days',
-}
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/wait`); re-exported here so no web
+// import churns. WaitNodeData narrows `type` to the web NodeType enum, same
+// as BaseNodeData does over its lib counterpart.
+export { DurationUnit, WaitType } from '@auxx/lib/workflow-engine/client'
 
 /**
  * Wait node data interface with complete structure
  */
-export interface WaitNodeData extends BaseNodeData {
-  /** Type of wait operation */
-  waitType: WaitType
-  /** Duration amount for duration-based wait */
-  durationAmount?: number | string
-  isDurationConstant: boolean
-  /** Duration unit for duration-based wait */
-  durationUnit?: DurationUnit
-  /** Specific time for time-based wait */
-  time?: string
-  isTimeConstant: boolean
-  /** Timezone for specific time wait */
-  timezone?: string
+export interface WaitNodeData extends CatalogWaitNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
+++ b/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
@@ -50,10 +50,17 @@ describe('node catalog coverage', () => {
     // The legacy NodeDefinition.schema was `any` and never parsed — the code
     // node's dead `output.type?.type` read and resource-trigger's
     // schema-failing defaults both hid behind that. Manifests don't get to.
+    // Node identity (`id`, `type`) is factory-assigned at add time, never part
+    // of defaults, so the fixture supplies it — everything else must come from
+    // `defaultData()` itself.
     const failures = listManifests()
       .map((manifest) => ({
         id: manifest.id,
-        result: manifest.configSchema.safeParse(manifest.defaultData()),
+        result: manifest.configSchema.safeParse({
+          id: 'test-node',
+          type: manifest.id,
+          ...manifest.defaultData(),
+        }),
       }))
       .filter(({ result }) => !result.success)
       .map(({ id, result }) => ({ id, error: (result as { error?: unknown }).error }))
@@ -96,7 +103,8 @@ describe('defineFromManifest', () => {
     expect(definition.validator?.({ title: 'ok' }).isValid).toBe(true)
   })
 
-  it('keeps getManifest empty-safe for unmigrated types', () => {
-    expect(getManifest('wait')).toBeUndefined()
+  it('resolves migrated types and stays undefined-safe for unmigrated ones', () => {
+    expect(getManifest('wait')?.displayName).toBe('Wait')
+    expect(getManifest('loop')).toBeUndefined()
   })
 })

--- a/apps/web/src/components/workflow/types/node-base.ts
+++ b/apps/web/src/components/workflow/types/node-base.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/types/node-base.ts
 
+import type { CatalogBaseNodeData } from '@auxx/lib/workflow-engine/client'
 import { NodeRunningStatus } from '@auxx/lib/workflow-engine/client'
 import type {
   CoordinateExtent,
@@ -8,29 +9,24 @@ import type {
   Node as ReactFlowNode,
   XYPosition,
 } from '@xyflow/react'
-import { z } from 'zod'
 import type { NodeType } from './node-types'
 
 // Re-export for convenience
 export { NodeRunningStatus }
 
-/**
- * Error handling strategy
- */
-export enum ErrorHandleType {
-  Continue = 'continue',
-  Stop = 'stop',
-  Retry = 'retry',
-}
-
-/**
- * Workflow retry configuration
- */
-export interface WorkflowRetryConfig {
-  maxRetries: number
-  retryInterval: number
-  backoffMultiplier?: number
-}
+// The pure half of this module (base data shape, its zod schema, the error
+// and runtime-state types) moved to lib with the node catalog
+// (`@auxx/lib/workflow-engine/catalog/node-base`); re-exported here so no web
+// import churns. This file keeps the React Flow node/edge types and a
+// `BaseNodeData` that narrows `type` to the web `NodeType` enum.
+export {
+  baseNodeDataSchema,
+  ErrorHandleType,
+  type NodeConnectionMetadata,
+  type NodeLoopContext,
+  type NodeRuntimeState,
+  type WorkflowRetryConfig,
+} from '@auxx/lib/workflow-engine/client'
 
 /**
  * Base configuration that all node configs must extend
@@ -42,87 +38,12 @@ export interface BaseNodeConfig {
 }
 
 /**
- * Connection tracking metadata
- * Properties from ui/node-handle/types.ts
+ * Base data structure for all workflow nodes.
+ * The field set lives in lib (`CatalogBaseNodeData`); this narrows `type`
+ * from `string` to the web `NodeType` enum.
  */
-export interface NodeConnectionMetadata {
-  _connectedSourceHandleIds?: string[]
-  _connectedTargetHandleIds?: string[]
-}
-
-/**
- * Runtime/UI state properties for nodes
- */
-export interface NodeRuntimeState extends NodeConnectionMetadata {
-  // Selection and UI state
-  _isBundled?: boolean
-  _inParallelHovering?: boolean
-  _isEntering?: boolean
-  _isCandidate?: boolean
-  collapsed?: boolean // Collapsed state for visual compaction
-
-  // Execution state
-  _runningStatus?: NodeRunningStatus
-  _waitingRun?: boolean
-  _singleRun?: boolean
-  _singleRunningStatus?: NodeRunningStatus
-  _runningBranchId?: string
-  _retryIndex?: number
-
-  // Container relationships
-  _children?: { nodeId: string; nodeType: string }[]
-}
-
-/**
- * Loop/iteration context for nodes
- */
-export interface NodeLoopContext {
-  isInLoop?: boolean
-  loopId?: string
-  isInIteration?: boolean
-  iterationId?: string
-  _iterationLength?: number
-  _iterationIndex?: number
-  _loopLength?: number
-  _loopIndex?: number
-}
-
-/**
- * Base data structure for all workflow nodes
- * Consolidates properties from multiple locations
- */
-export interface BaseNodeData extends NodeRuntimeState, NodeLoopContext {
-  // Core properties
-  id: string
+export interface BaseNodeData extends CatalogBaseNodeData {
   type: NodeType
-  title: string
-  desc?: string
-  description?: string // Alias for desc
-
-  // Visual properties
-  icon?: string
-  color?: string
-
-  // Validation state
-  isValid?: boolean
-  errors?: string[]
-  disabled?: boolean
-
-  // Output tracking
-  outputVariables?: string[]
-
-  // Credential connection
-  credentialId?: string | null
-
-  // Error handling
-  errorStrategy?: ErrorHandleType
-  retryConfig?: WorkflowRetryConfig
-
-  // Selection state (from NodeHandleProps)
-  selected: boolean
-
-  // Additional properties for React Flow compatibility
-  [key: string]: any
 }
 
 /**
@@ -267,67 +188,3 @@ export type SpecificNode<TType extends string, TData extends BaseNodeData> = {
       ? TData & { id: string; _inParallelHovering?: boolean }
       : CommonNodeType<TData>[K]
 }
-
-/**
- * Zod schema for base node data
- * This schema includes all common fields that every node should have
- */
-export const baseNodeDataSchema = z.object({
-  // Core properties
-  id: z.string(),
-  type: z.string() as unknown as z.ZodType<NodeType>,
-  title: z.string(),
-  desc: z.string().optional(),
-  description: z.string().optional(), // Alias for desc
-
-  // Visual properties
-  icon: z.string().optional(),
-  color: z.string().optional(),
-
-  // Validation state
-  isValid: z.boolean().optional(),
-  errors: z.array(z.string()).optional(),
-  disabled: z.boolean().optional(),
-
-  // Output tracking
-  outputVariables: z.array(z.string()).optional(),
-
-  // Error handling
-  errorStrategy: z.enum(ErrorHandleType).optional(),
-  retryConfig: z
-    .object({
-      maxRetries: z.number(),
-      retryInterval: z.number(),
-      backoffMultiplier: z.number().optional(),
-    })
-    .optional(),
-
-  // Selection state
-  selected: z.boolean().default(false),
-
-  // Runtime state properties (all optional)
-  _isBundled: z.boolean().optional(),
-  _inParallelHovering: z.boolean().optional(),
-  _isEntering: z.boolean().optional(),
-  _isCandidate: z.boolean().optional(),
-  _runningStatus: z.enum(NodeRunningStatus).optional(),
-  _waitingRun: z.boolean().optional(),
-  _singleRun: z.boolean().optional(),
-  _singleRunningStatus: z.enum(NodeRunningStatus).optional(),
-  _runningBranchId: z.string().optional(),
-  _retryIndex: z.number().optional(),
-  _children: z.array(z.object({ nodeId: z.string(), nodeType: z.string() })).optional(),
-  _connectedSourceHandleIds: z.array(z.string()).optional(),
-  _connectedTargetHandleIds: z.array(z.string()).optional(),
-  collapsed: z.boolean().optional(),
-
-  // Loop context
-  isInLoop: z.boolean().optional(),
-  loopId: z.string().optional(),
-  isInIteration: z.boolean().optional(),
-  iterationId: z.string().optional(),
-  _iterationLength: z.number().optional(),
-  _iterationIndex: z.number().optional(),
-  _loopLength: z.number().optional(),
-  _loopIndex: z.number().optional(),
-})

--- a/packages/lib/src/workflow-engine/catalog/node-base.ts
+++ b/packages/lib/src/workflow-engine/catalog/node-base.ts
@@ -1,0 +1,180 @@
+// packages/lib/src/workflow-engine/catalog/node-base.ts
+
+import { z } from 'zod'
+import { NodeRunningStatus } from '../core/types'
+
+/**
+ * The pure half of the builder's node-base types (node-catalog Phase 1):
+ * the base data shape every node's persisted `data` carries, and its zod
+ * schema. Relocated from apps/web types/node-base.ts, which re-exports these
+ * and keeps the React Flow node/edge types (`CommonNodeType`, `FlowNode`,
+ * `SpecificNode`, …) plus a `BaseNodeData` narrowing `type` to the web
+ * `NodeType` enum. Lib types `type` as `string` — the enum is a web construct;
+ * the persisted value is the same string either way.
+ */
+
+/**
+ * Error handling strategy
+ */
+export enum ErrorHandleType {
+  Continue = 'continue',
+  Stop = 'stop',
+  Retry = 'retry',
+}
+
+/**
+ * Workflow retry configuration
+ */
+export interface WorkflowRetryConfig {
+  maxRetries: number
+  retryInterval: number
+  backoffMultiplier?: number
+}
+
+/**
+ * Connection tracking metadata (derived state — stripped on save,
+ * regenerated on load by the workflow initializer)
+ */
+export interface NodeConnectionMetadata {
+  _connectedSourceHandleIds?: string[]
+  _connectedTargetHandleIds?: string[]
+}
+
+/**
+ * Runtime/UI state properties for nodes
+ */
+export interface NodeRuntimeState extends NodeConnectionMetadata {
+  // Selection and UI state
+  _isBundled?: boolean
+  _inParallelHovering?: boolean
+  _isEntering?: boolean
+  _isCandidate?: boolean
+  collapsed?: boolean // Collapsed state for visual compaction
+
+  // Execution state
+  _runningStatus?: NodeRunningStatus
+  _waitingRun?: boolean
+  _singleRun?: boolean
+  _singleRunningStatus?: NodeRunningStatus
+  _runningBranchId?: string
+  _retryIndex?: number
+
+  // Container relationships
+  _children?: { nodeId: string; nodeType: string }[]
+}
+
+/**
+ * Loop/iteration context for nodes
+ */
+export interface NodeLoopContext {
+  isInLoop?: boolean
+  loopId?: string
+  isInIteration?: boolean
+  iterationId?: string
+  _iterationLength?: number
+  _iterationIndex?: number
+  _loopLength?: number
+  _loopIndex?: number
+}
+
+/**
+ * Base data structure for all workflow nodes.
+ * apps/web extends this with `type: NodeType` (its enum narrowing).
+ */
+export interface BaseNodeData extends NodeRuntimeState, NodeLoopContext {
+  // Core properties
+  id: string
+  type: string
+  title: string
+  desc?: string
+  description?: string // Alias for desc
+
+  // Visual properties
+  icon?: string
+  color?: string
+
+  // Validation state
+  isValid?: boolean
+  errors?: string[]
+  disabled?: boolean
+
+  // Output tracking
+  outputVariables?: string[]
+
+  // Credential connection
+  credentialId?: string | null
+
+  // Error handling
+  errorStrategy?: ErrorHandleType
+  retryConfig?: WorkflowRetryConfig
+
+  // Selection state (from NodeHandleProps)
+  selected: boolean
+
+  // Additional properties for React Flow compatibility
+  [key: string]: any
+}
+
+/**
+ * Zod schema for base node data
+ * This schema includes all common fields that every node should have
+ */
+export const baseNodeDataSchema = z.object({
+  // Core properties
+  id: z.string(),
+  type: z.string(),
+  title: z.string(),
+  desc: z.string().optional(),
+  description: z.string().optional(), // Alias for desc
+
+  // Visual properties
+  icon: z.string().optional(),
+  color: z.string().optional(),
+
+  // Validation state
+  isValid: z.boolean().optional(),
+  errors: z.array(z.string()).optional(),
+  disabled: z.boolean().optional(),
+
+  // Output tracking
+  outputVariables: z.array(z.string()).optional(),
+
+  // Error handling
+  errorStrategy: z.enum(ErrorHandleType).optional(),
+  retryConfig: z
+    .object({
+      maxRetries: z.number(),
+      retryInterval: z.number(),
+      backoffMultiplier: z.number().optional(),
+    })
+    .optional(),
+
+  // Selection state
+  selected: z.boolean().default(false),
+
+  // Runtime state properties (all optional)
+  _isBundled: z.boolean().optional(),
+  _inParallelHovering: z.boolean().optional(),
+  _isEntering: z.boolean().optional(),
+  _isCandidate: z.boolean().optional(),
+  _runningStatus: z.enum(NodeRunningStatus).optional(),
+  _waitingRun: z.boolean().optional(),
+  _singleRun: z.boolean().optional(),
+  _singleRunningStatus: z.enum(NodeRunningStatus).optional(),
+  _runningBranchId: z.string().optional(),
+  _retryIndex: z.number().optional(),
+  _children: z.array(z.object({ nodeId: z.string(), nodeType: z.string() })).optional(),
+  _connectedSourceHandleIds: z.array(z.string()).optional(),
+  _connectedTargetHandleIds: z.array(z.string()).optional(),
+  collapsed: z.boolean().optional(),
+
+  // Loop context
+  isInLoop: z.boolean().optional(),
+  loopId: z.string().optional(),
+  isInIteration: z.boolean().optional(),
+  iterationId: z.string().optional(),
+  _iterationLength: z.number().optional(),
+  _iterationIndex: z.number().optional(),
+  _loopLength: z.number().optional(),
+  _loopIndex: z.number().optional(),
+})

--- a/packages/lib/src/workflow-engine/catalog/nodes/wait.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/wait.ts
@@ -1,0 +1,170 @@
+// packages/lib/src/workflow-engine/catalog/nodes/wait.ts
+
+import { z } from 'zod'
+import { WAIT_CONSTANTS } from '../../constants'
+import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+
+/**
+ * The wait node's catalog manifest — the first migrated node type and the
+ * template for the rest. The data half (enums, data interface, zod schema,
+ * defaults, validator) lives here as the single source; apps/web
+ * `core/wait/schema.ts` merges it with the React parts via
+ * `defineFromManifest`, and the engine's `nodes/wait/types.ts` re-exports the
+ * enums instead of re-declaring them.
+ *
+ * Engine note: compiled sequence graphs extend the persisted config with
+ * `deliveryWindow` / `anchor` (see `workflow-engine/nodes/wait/types.ts`).
+ * Those are compiler-written, never builder-authored, so they are not part of
+ * this schema — and zod's default object behavior tolerates the extra keys.
+ */
+
+/**
+ * Wait type options
+ */
+export enum WaitType {
+  DURATION = 'duration',
+  SPECIFIC_TIME = 'specific_time',
+}
+
+/**
+ * Duration unit options
+ */
+export enum DurationUnit {
+  SECONDS = 'seconds',
+  MINUTES = 'minutes',
+  HOURS = 'hours',
+  DAYS = 'days',
+}
+
+/**
+ * Wait node data interface with complete structure
+ */
+export interface WaitNodeData extends BaseNodeData {
+  /** Type of wait operation */
+  waitType: WaitType
+  /** Duration amount for duration-based wait */
+  durationAmount?: number | string
+  isDurationConstant: boolean
+  /** Duration unit for duration-based wait */
+  durationUnit?: DurationUnit
+  /** Specific time for time-based wait */
+  time?: string
+  isTimeConstant: boolean
+  /** Timezone for specific time wait */
+  timezone?: string
+}
+
+/**
+ * Zod schema for wait node data
+ */
+export const waitNodeDataSchema = baseNodeDataSchema
+  .extend({
+    waitType: z.enum(WaitType),
+    durationAmount: z
+      .union([
+        z.number().min(WAIT_CONSTANTS.DURATION.MIN).max(WAIT_CONSTANTS.DURATION.MAX),
+        z.string(),
+        z.object({ id: z.string(), nodeId: z.string().optional(), path: z.string() }), // UnifiedVariable
+      ])
+      .optional(),
+    isDurationConstant: z.boolean().default(true),
+    durationUnit: z.enum(DurationUnit).optional(),
+    time: z
+      .union([
+        z.string(),
+        z.object({ id: z.string(), nodeId: z.string().optional(), path: z.string() }), // UnifiedVariable
+      ])
+      .optional(),
+    isTimeConstant: z.boolean().default(true),
+    timezone: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.waitType === WaitType.DURATION) {
+        return data.durationAmount !== undefined && data.durationUnit !== undefined
+      }
+      return data.time !== undefined
+    },
+    { message: 'Required fields missing for selected wait type' }
+  )
+
+/**
+ * Validation function for wait configuration
+ */
+export const validateWaitConfig = (data: WaitNodeData): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Validate title
+  if (!data.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Validate wait type
+  if (!data.waitType) {
+    errors.push({ field: 'waitType', message: 'Wait type is required', type: 'error' })
+  } else if (data.waitType === WaitType.DURATION) {
+    // Validate duration-based wait
+    if (!data.durationAmount) {
+      errors.push({
+        field: 'durationAmount',
+        message: 'Duration amount is required',
+        type: 'error',
+      })
+    }
+    if (!data.durationUnit) {
+      errors.push({ field: 'durationUnit', message: 'Duration unit is required', type: 'error' })
+    }
+  } else if (data.waitType === WaitType.SPECIFIC_TIME) {
+    // Validate specific time wait
+    if (!data.time) {
+      errors.push({
+        field: 'time',
+        message: 'Time is required for specific time wait',
+        type: 'error',
+      })
+    }
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/**
+ * Wait node manifest
+ */
+export const waitManifest: NodeManifest<WaitNodeData> = {
+  id: 'wait',
+  category: NodeCategory.UTILITY,
+  displayName: 'Wait',
+  description: 'Pause workflow execution for a specified duration',
+  icon: 'clock',
+  color: '#3B82F6', // UTILITY category color
+  defaultData: () => ({
+    title: 'Wait',
+    description: '',
+    waitType: WaitType.DURATION,
+    durationAmount: 5,
+    isDurationConstant: true,
+    durationUnit: DurationUnit.SECONDS,
+    time: undefined,
+    isTimeConstant: true,
+  }),
+  configSchema: waitNodeDataSchema as unknown as z.ZodType<WaitNodeData>,
+  validate: validateWaitConfig,
+  extractVariables: () => [], // Wait node doesn't use any variables
+  connection: {
+    canRunSingle: true,
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Pause the workflow. waitType "duration" needs durationAmount + durationUnit; ' +
+      'waitType "specific_time" needs time (and optionally timezone).',
+    examples: [
+      {
+        description: 'Wait 10 minutes',
+        config: { waitType: 'duration', durationAmount: 10, durationUnit: 'minutes' },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -58,7 +58,7 @@ export const NOT_YET_MIGRATED: readonly string[] = [
   'note',
   // Control nodes
   'end',
-  'wait',
+  // 'wait' — migrated (catalog/nodes/wait.ts)
   'loop',
   'human-confirmation',
 ] as const

--- a/packages/lib/src/workflow-engine/catalog/registry.ts
+++ b/packages/lib/src/workflow-engine/catalog/registry.ts
@@ -1,26 +1,24 @@
 // packages/lib/src/workflow-engine/catalog/registry.ts
 
+import { waitManifest } from './nodes/wait'
 import type { NodeManifest } from './types'
 
 /**
- * The catalog registry — a plain module-level map, no class (lib-module
- * convention). Node manifests register themselves at module load via
- * `registerManifest`; consumers read through `getManifest` / `listManifests`.
+ * The catalog registry — a plain module-level map built from an explicit
+ * manifest list, no class and no registration side effects (import order can
+ * never change what's registered).
  *
  * Migration discipline: a node type lives EITHER here or on the
  * `NOT_YET_MIGRATED` list (`not-yet-migrated.ts`) — never both, never
  * neither. The catalog coverage test asserts exact set equality against the
  * builder's `NodeType` enum, so migrating a type is always an explicit
- * two-file change: register the manifest, delete the list entry.
+ * two-file change: add the manifest here, delete the list entry.
  */
-const manifests = new Map<string, NodeManifest<any>>()
+const ALL_MANIFESTS: NodeManifest<any>[] = [waitManifest]
 
-/** Register a node manifest. Throws on duplicate ids — two declarations of one type is the drift this catalog exists to end. */
-export function registerManifest(manifest: NodeManifest<any>): void {
-  if (manifests.has(manifest.id)) {
-    throw new Error(`Node manifest already registered for type "${manifest.id}"`)
-  }
-  manifests.set(manifest.id, manifest)
+const manifests = new Map<string, NodeManifest<any>>(ALL_MANIFESTS.map((m) => [m.id, m]))
+if (manifests.size !== ALL_MANIFESTS.length) {
+  throw new Error('Duplicate node manifest id in ALL_MANIFESTS')
 }
 
 /** Look up one node type's manifest. Undefined ⇒ not yet migrated (check `NOT_YET_MIGRATED`). */

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -70,6 +70,23 @@ export * from './utils/terminal-nodes'
 // NOTE: Operator definitions moved to @auxx/lib/conditions
 // Import OPERATOR_DEFINITIONS, Operator, etc. from '@auxx/lib/conditions' or '@auxx/lib/conditions/client'
 
+export {
+  type BaseNodeData as CatalogBaseNodeData,
+  baseNodeDataSchema,
+  ErrorHandleType,
+  type NodeConnectionMetadata,
+  type NodeLoopContext,
+  type NodeRuntimeState,
+  type WorkflowRetryConfig,
+} from './catalog/node-base'
+export {
+  DurationUnit,
+  validateWaitConfig,
+  type WaitNodeData as CatalogWaitNodeData,
+  WaitType,
+  waitManifest,
+  waitNodeDataSchema,
+} from './catalog/nodes/wait'
 // ── Node catalog (Phase 1 of the node-catalog migration) ─────────────────────
 // The server-safe node contract: manifest types, the registry, the migration
 // tracker, and the pure variable-inference helpers split out of apps/web
@@ -79,7 +96,6 @@ export {
   getAuthorableManifests,
   getManifest,
   listManifests,
-  registerManifest,
 } from './catalog/registry'
 export {
   type NodeAgentDocs,

--- a/packages/lib/src/workflow-engine/nodes/wait/types.ts
+++ b/packages/lib/src/workflow-engine/nodes/wait/types.ts
@@ -1,20 +1,10 @@
-/**
- * Wait type options
- */
-export enum WaitType {
-  DURATION = 'duration',
-  SPECIFIC_TIME = 'specific_time',
-}
+// WaitType / DurationUnit now single-sourced from the node catalog
+// (node-catalog Phase 1 — the wait node's manifest). This file keeps only the
+// engine's compiled extensions: the sequence compiler writes deliveryWindow /
+// anchor onto the persisted config; the builder never authors them.
+export { DurationUnit, WaitType } from '../../catalog/nodes/wait'
 
-/**
- * Duration unit options
- */
-export enum DurationUnit {
-  SECONDS = 'seconds',
-  MINUTES = 'minutes',
-  HOURS = 'hours',
-  DAYS = 'days',
-}
+import type { DurationUnit, WaitType } from '../../catalog/nodes/wait'
 /**
  * Sequences plan §3.3 — an optional delivery window applied to the computed
  * `resumeAt`, snapping it forward into business hours/days. See


### PR DESCRIPTION
## Summary

Phase 1 step 2 — the first node type migrates into the catalog, and this PR is the **template** for the other 37. Hard invariant verified: zero diff under `nodes/core/wait/{node,panel,trace-renderer}.tsx`.

### What moved

- **`catalog/nodes/wait.ts`** — the data half as single source: `WaitType`, `DurationUnit`, `WaitNodeData`, the zod schema, defaults, validator, connection rules, and agent docs (`authorable: true`, usage + example for the future `describe_node_type`).
- **`catalog/node-base.ts`** — `BaseNodeData` shape + `baseNodeDataSchema` + `ErrorHandleType`/runtime-state types, since every node schema extends them. Lib types `type` as `string`; web's `node-base.ts` keeps the React Flow types and narrows `type` back to the `NodeType` enum (`interface BaseNodeData extends CatalogBaseNodeData { type: NodeType }`) — same pattern for `WaitNodeData`.
- **`core/wait/schema.ts`** shrinks to the merge site: `defineFromManifest(waitManifest, { outputVariables })` + back-compat re-exports. No panel, `core/index.ts`, or parity `node-definitions.ts` import churns.
- **Engine sweep**: `workflow-engine/nodes/wait/types.ts` re-exports the catalog enums instead of re-declaring them, keeping only the sequence-compiled `deliveryWindow`/`anchor` extensions — documented as deliberately outside the manifest schema (compiler-written, never builder-authored; zod tolerates the extra keys).

### Registry hardening

Static explicit-list map replaces `registerManifest` — no registration side effects, import order can never change what's registered, duplicate ids throw at module load.

### Template decisions the next 37 types inherit

1. Web keeps a thin narrowing interface (`type: NodeType`) over the catalog data interface; one documented cast at the merge site bridges it (safe: defaults never set `type`).
2. The defaults-parse test supplies factory-assigned identity (`id`, `type`) — the one legitimate gap in defaults; everything else must parse.
3. Engine-side compiled extensions stay engine-side, documented in the manifest file.
4. Output resolvers stay web-side until Phase 2's server-callable context.

## Verification

- `apps/web` workflow suite: 90 passed — including the full builder↔engine parity suite, which independently validates the migrated definition's schema keys and output paths against the engine, and the catalog coverage test now requiring `wait` registered.
- `packages/lib` wait engine tests: 38 passed; tsc clean on all touched files.
- Node component zero-diff verified via `git diff --stat`.