### PR TITLE
feat(workflow): migrate end, note and var-assign to the catalog

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/end/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/end/schema.ts
@@ -1,69 +1,19 @@
 // apps/web/src/components/workflow/nodes/core/end/schema.ts
 
-import { z } from 'zod'
-import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
+import { endManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { BaseType, NodeCategory, type NodeDefinition, type ValidationResult } from '../../../types'
-import { NodeType } from '../../../types/node-types'
+import { BaseType, type NodeDefinition } from '../../../types'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { EndNodeData } from './types'
 
-/**
- * Main schema for end node data (simplified structure)
- */
-export const endNodeDataSchema = baseNodeDataSchema.extend({
-  title: z.string().default('End'),
-  description: z.string().optional(),
-  message: z.string().optional(),
-  status: z.enum(['success', 'error']).optional(),
-})
-
-/**
- * Default configuration for the End node
- */
-export const endDefaultData: Partial<EndNodeData> = {
-  title: 'Output',
-  description: '',
-  message: '',
-  status: 'success',
-}
-
-/**
- * Extract variables from end node message field
- */
-export function extractEndVariables(data: Partial<EndNodeData>): string[] {
-  const variableIds = new Set<string>()
-
-  if (data.message && typeof data.message === 'string') {
-    extractVarIdsFromString(data.message).forEach((id) => variableIds.add(id))
-  }
-
-  return Array.from(variableIds)
-}
-
-/**
- * Validates the End node configuration
- */
-export const validateEndConfig = (data: EndNodeData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Validate title
-  if (!data.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Validate status if provided
-  if (data.status && !['success', 'error'].includes(data.status)) {
-    errors.push({ field: 'status', message: 'Invalid status value', type: 'error' })
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
+// The data half (schema, defaults, validator, variable extraction) lives in
+// the node catalog (`@auxx/lib/workflow-engine/catalog/nodes/end`). This file
+// is the merge site: manifest + the web-only output resolver.
 
 /**
  * Define output variables for the end/output node
  */
-const getEndOutputVariables = (data: Partial<EndNodeData>, nodeId: string) => {
+const getEndOutputVariables = (_data: Partial<EndNodeData>, nodeId: string) => {
   return [
     createUnifiedOutputVariable({
       nodeId,
@@ -83,17 +33,19 @@ const getEndOutputVariables = (data: Partial<EndNodeData>, nodeId: string) => {
 /**
  * Node definition for the End node
  */
-export const endDefinition: NodeDefinition<EndNodeData> = {
-  id: NodeType.END,
-  category: NodeCategory.ACTION,
-  displayName: 'Output',
-  description: 'Outputs a message for the manual trigger',
-  icon: 'message-circle',
-  color: '#10b981', // ACTION category color
-  defaultData: endDefaultData,
-  schema: endNodeDataSchema,
-  validator: validateEndConfig,
-  canRunSingle: true,
-  extractVariables: extractEndVariables,
-  outputVariables: getEndOutputVariables as any,
-}
+export const endDefinition: NodeDefinition<EndNodeData> = defineFromManifest(
+  endManifest as unknown as NodeManifest<EndNodeData>,
+  { outputVariables: getEndOutputVariables as any }
+)
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  endNodeDataSchema,
+  extractEndVariables,
+  validateEndConfig,
+} from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Default configuration for the End node
+ */
+export const endDefaultData = endManifest.defaultData() as Partial<EndNodeData>

--- a/apps/web/src/components/workflow/nodes/core/end/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/end/types.ts
@@ -1,15 +1,19 @@
 // apps/web/src/components/workflow/nodes/core/end/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types'
+import type { CatalogEndNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types'
+import type { NodeType } from '~/components/workflow/types/node-types'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/end`). EndNodeData narrows `type`
+// to the web NodeType enum, same as BaseNodeData does over its lib
+// counterpart.
 
 /**
  * Node data structure for the End node with minimal configuration
  */
-export interface EndNodeData extends BaseNodeData {
-  /** Optional message to display when workflow ends */
-  message?: string
-  /** Optional status to set when workflow ends */
-  status?: 'success' | 'error'
+export interface EndNodeData extends CatalogEndNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/note/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/note/schema.ts
@@ -1,61 +1,26 @@
 // apps/web/src/components/workflow/nodes/core/note/schema.ts
 
-import { z } from 'zod'
-import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
-import { NodeCategory, type NodeDefinition, type ValidationResult } from '../../../types'
-import { NodeType } from '../../../types/node-types'
-import type { NoteNodeData, NoteTheme } from './types'
+import { type NodeManifest, noteManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '../../../types'
+import { defineFromManifest } from '../../define-from-manifest'
+import type { NoteNodeData } from './types'
 
-/**
- * Zod schema for note node data (flattened structure)
- */
-export const noteNodeDataSchema = baseNodeDataSchema.extend({
-  text: z.string().default(''),
-  theme: z.enum(['yellow', 'blue', 'purple', 'pink', 'green'] as const).default('yellow'),
-  showAuthor: z.boolean().default(false),
-  author: z.string().default(''),
-  fontSize: z.number().min(10).max(20).default(14),
-})
-
-/**
- * Default configuration for new note nodes
- */
-export const noteDefaultData: Partial<NoteNodeData> = {
-  title: 'Note',
-  desc: '',
-  text: '',
-  theme: 'yellow' as NoteTheme,
-  showAuthor: false,
-  author: '',
-  fontSize: 14,
-}
-
-/**
- * Validation function for note configuration
- */
-export const validateNoteConfig = (data: NoteNodeData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Note nodes don't require validation as they're just for documentation
-  // All fields are optional and have defaults
-
-  return { isValid: true, errors }
-}
+// The data half (schema, defaults, validator) lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/note`). This file is the merge
+// site.
 
 /**
  * Node definition for Note
  */
-export const noteDefinition: NodeDefinition<NoteNodeData> = {
-  id: NodeType.NOTE,
-  category: NodeCategory.DATA,
-  displayName: 'Note',
-  description: 'Add notes and documentation to your workflow',
-  icon: 'sticky-note',
-  color: '#FBBF24',
-  defaultData: noteDefaultData,
-  schema: noteNodeDataSchema,
-  validator: validateNoteConfig,
-  canConnect: false, // Note nodes can be added to canvas but cannot connect to other blocks
-  outputVariables: () => [], // Notes are annotations — they expose nothing downstream
-  extractVariables: () => [], // Note nodes don't extract variables
-}
+export const noteDefinition: NodeDefinition<NoteNodeData> = defineFromManifest(
+  noteManifest as unknown as NodeManifest<NoteNodeData>,
+  { outputVariables: () => [] } // Notes are annotations — they expose nothing downstream
+)
+
+// Back-compat re-exports so no consumer import churns:
+export { noteNodeDataSchema, validateNoteConfig } from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Default configuration for new note nodes
+ */
+export const noteDefaultData = noteManifest.defaultData() as Partial<NoteNodeData>

--- a/apps/web/src/components/workflow/nodes/core/note/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/note/types.ts
@@ -1,18 +1,18 @@
 // apps/web/src/components/workflow/nodes/core/note/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { CatalogNoteNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
 
-export type NoteTheme = 'yellow' | 'blue' | 'purple' | 'pink' | 'green'
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/note`).
+export type { NoteTheme } from '@auxx/lib/workflow-engine/client'
 
 /**
  * Note node data interface with flattened structure
  */
-export interface NoteNodeData extends BaseNodeData {
-  text: string
-  theme: NoteTheme
-  showAuthor: boolean
-  author: string
-  fontSize: number
+export interface NoteNodeData extends CatalogNoteNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/var-assign/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/var-assign/schema.ts
@@ -1,163 +1,17 @@
 // apps/web/src/components/workflow/nodes/core/var-assign/schema.ts
 
-import { v4 as uuidv4 } from 'uuid'
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { NodeType } from '~/components/workflow/types/node-types'
+import { type NodeManifest, varAssignManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
 import { BaseType } from '~/components/workflow/types/unified-types'
 import type { UnifiedVariable } from '~/components/workflow/types/variable-types'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { VarAssignNodeData, VariableAssignment } from './types'
 
-/**
- * Zod schema for variable assignment
- */
-const variableAssignmentSchema = z.object({
-  id: z.string(),
-  name: z
-    .string()
-    .min(1, 'Variable name is required')
-    .regex(
-      /^[a-zA-Z_][a-zA-Z0-9_]*$/,
-      'Variable name must start with a letter or underscore and contain only alphanumeric characters and underscores'
-    ),
-  type: z.enum(BaseType),
-  isArray: z.boolean().optional(),
-  value: z.union([z.string(), z.array(z.string())]),
-  isConstantMode: z.boolean().optional(),
-  itemConstantModes: z.array(z.boolean()).optional(),
-})
-
-/**
- * Zod schema for var-assign configuration
- * @deprecated Use varAssignNodeDataSchema instead
- */
-export const varAssignConfigSchema = z.object({
-  title: z.string().default('Assign Variable'),
-  desc: z.string().optional(),
-  variables: z.array(variableAssignmentSchema),
-  ignoreTypeError: z.boolean().default(false),
-})
-
-/**
- * Zod schema for var-assign node data (flattened structure)
- */
-export const varAssignNodeDataSchema = z.object({
-  // Base node properties
-  id: z.string(),
-  type: z.literal(NodeType.VAR_ASSIGN),
-  selected: z.boolean(),
-
-  // Flattened config properties
-  title: z.string().default('Assign Variable'),
-  desc: z.string().optional(),
-  variables: z.array(variableAssignmentSchema),
-  ignoreTypeError: z.boolean().default(false),
-
-  // Other node data properties
-  isValid: z.boolean().optional(),
-  errors: z.array(z.string()).optional(),
-  disabled: z.boolean().optional(),
-  outputVariables: z.array(z.string()).optional(),
-})
-
-/**
- * Factory function to create default node data (flattened)
- */
-export const createVarAssignDefaultData = (): Partial<VarAssignNodeData> => ({
-  title: 'Assign Variable',
-  desc: 'Create custom variables for use in subsequent nodes',
-  variables: [{ id: uuidv4(), name: '', type: BaseType.STRING, value: '' }],
-  ignoreTypeError: false,
-})
-
-/**
- * Default data for new var-assign nodes (flattened)
- */
-export const varAssignDefaultData = createVarAssignDefaultData()
-
-/**
- * Validation function for var-assign configuration
- */
-export function validateVarAssign(data: VarAssignNodeData): ValidationResult {
-  try {
-    // Support both old config format and new flattened format
-    const dataToValidate = 'config' in data ? data : (data as VarAssignNodeData)
-
-    // Additional custom validation
-    const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-    // Check for duplicate variable names
-    const names = dataToValidate.variables.map((v) => v.name).filter((name) => name.trim())
-    const duplicates = names.filter((name, index) => names.indexOf(name) !== index)
-    if (duplicates.length > 0) {
-      errors.push({
-        field: 'variables',
-        message: `Duplicate variable names: ${duplicates.join(', ')}`,
-        type: 'error',
-      })
-    }
-
-    // Check for empty variable names
-    dataToValidate.variables.forEach((variable, index) => {
-      if (!variable.name.trim()) {
-        errors.push({
-          field: `variables.${index}.name`,
-          message: 'Variable name cannot be empty',
-          type: 'error',
-        })
-      }
-    })
-
-    if (errors.length > 0) {
-      return { isValid: false, errors }
-    }
-
-    return { isValid: true, errors: [] }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return {
-        isValid: false,
-        errors: error.issues.map((e) => ({
-          field: e.path.join('.'),
-          message: e.message,
-          type: 'error' as const,
-        })),
-      }
-    }
-    return {
-      isValid: false,
-      errors: [{ field: 'general', message: 'Invalid configuration', type: 'error' }],
-    }
-  }
-}
-
-/**
- * Extract variables from configuration
- */
-export function extractVarAssignVariables(data: VarAssignNodeData): string[] {
-  const uniqueVariables = new Set<string>()
-
-  // Support both old config format and new flattened format
-  const variables = 'config' in data ? (data as any).config.variables : data.variables
-
-  // Extract variables from each assignment value
-  variables.forEach((assignment: VariableAssignment) => {
-    const values = Array.isArray(assignment.value) ? assignment.value : [assignment.value]
-    values.forEach((val) => {
-      extractVarIdsFromString(val).forEach((varId) => {
-        uniqueVariables.add(varId)
-      })
-    })
-  })
-
-  return Array.from(uniqueVariables)
-}
+// The data half (schemas, defaults, validator, variable extraction) lives in
+// the node catalog (`@auxx/lib/workflow-engine/catalog/nodes/var-assign`).
+// This file is the merge site: manifest + the web-only output resolver. The
+// deprecated, consumer-less `varAssignConfigSchema` died in the move.
 
 /**
  * Get output variables for this node
@@ -204,17 +58,25 @@ export function getVarAssignOutputVariables(
 /**
  * Node definition for var-assign
  */
-export const varAssignDefinition: NodeDefinition<VarAssignNodeData> = {
-  id: NodeType.VAR_ASSIGN,
-  category: NodeCategory.TRANSFORM,
-  displayName: 'Assign Variable',
-  description: 'Create custom variables for use in subsequent nodes',
-  icon: 'variable',
-  color: '#8B5CF6', // TRANSFORM category color
-  schema: varAssignNodeDataSchema,
-  defaultData: varAssignDefaultData,
-  canRunSingle: true,
-  validator: validateVarAssign as any,
-  extractVariables: extractVarAssignVariables as any,
-  outputVariables: getVarAssignOutputVariables as any,
-}
+export const varAssignDefinition: NodeDefinition<VarAssignNodeData> = defineFromManifest(
+  varAssignManifest as unknown as NodeManifest<VarAssignNodeData>,
+  { outputVariables: getVarAssignOutputVariables as any }
+)
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  extractVarAssignVariables,
+  validateVarAssign,
+  varAssignNodeDataSchema,
+} from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Default data for new var-assign nodes (flattened)
+ */
+export const varAssignDefaultData = varAssignManifest.defaultData() as Partial<VarAssignNodeData>
+
+/**
+ * Factory function to create default node data (flattened)
+ */
+export const createVarAssignDefaultData = (): Partial<VarAssignNodeData> =>
+  varAssignManifest.defaultData() as Partial<VarAssignNodeData>

--- a/apps/web/src/components/workflow/nodes/core/var-assign/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/var-assign/types.ts
@@ -1,36 +1,18 @@
 // apps/web/src/components/workflow/nodes/core/var-assign/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
-import type { BaseType } from '~/components/workflow/types/unified-types'
+import type { CatalogVarAssignNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
 
-/**
- * Single variable assignment configuration
- */
-export interface VariableAssignment {
-  /** Unique identifier for the assignment */
-  id: string
-  /** Variable name */
-  name: string
-  /** Variable type (e.g., STRING, NUMBER, BOOLEAN) */
-  type: BaseType
-  /** Whether this is an array of the specified type */
-  isArray?: boolean
-  /** Variable value(s) - can be string or array of strings for array type */
-  value: string | string[]
-  /** Whether this variable is in constant mode (for single values only) */
-  isConstantMode?: boolean
-  /** Constant mode tracking for each array item (for array values only) */
-  itemConstantModes?: boolean[]
-}
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/var-assign`).
+export type { VariableAssignment } from '@auxx/lib/workflow-engine/client'
 
 /**
  * Variable assignment node data (flattened structure)
  */
-export interface VarAssignNodeData extends BaseNodeData {
-  /** Array of variable assignments */
-  variables: VariableAssignment[]
-  /** Whether to ignore type errors during execution */
-  ignoreTypeError?: boolean
+export interface VarAssignNodeData extends CatalogVarAssignNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/ui/input-editor/tiptap-converters.ts
+++ b/apps/web/src/components/workflow/ui/input-editor/tiptap-converters.ts
@@ -40,22 +40,9 @@ export function isJsonObject(value: unknown): value is Record<string, unknown> {
 
 // Extract all tag varIds from string content ({{varId}} format) — used by
 // the 9 non-AI workflow nodes that still persist as `text: string`.
-export function extractVarIdsFromString(text: string): string[] {
-  if (!text) return []
-
-  const varIds: string[] = []
-  const varPattern = /\{\{([^}]+)\}\}/g
-  let match
-
-  while ((match = varPattern.exec(text)) !== null) {
-    const varId = match[1]?.trim()
-    if (varId) {
-      varIds.push(varId)
-    }
-  }
-
-  return [...new Set(varIds)] // Remove duplicates
-}
+// Relocated to lib with the node catalog so manifests can extract variables;
+// re-exported here so no web import churns.
+export { extractVarIdsFromString } from '@auxx/lib/workflow-engine/client'
 
 // Insert a variable tag at current cursor position
 export function insertTag(editor: any, variableId: string, _label?: string) {

--- a/packages/lib/src/workflow-engine/catalog/nodes/end.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/end.ts
@@ -1,0 +1,94 @@
+// packages/lib/src/workflow-engine/catalog/nodes/end.ts
+
+import { z } from 'zod'
+import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import { extractVarIdsFromString } from '../variable-inference'
+
+/**
+ * Node data structure for the End node with minimal configuration
+ */
+export interface EndNodeData extends BaseNodeData {
+  /** Optional message to display when workflow ends */
+  message?: string
+  /** Optional status to set when workflow ends */
+  status?: 'success' | 'error'
+}
+
+/**
+ * Main schema for end node data (simplified structure)
+ */
+export const endNodeDataSchema = baseNodeDataSchema.extend({
+  title: z.string().default('End'),
+  description: z.string().optional(),
+  message: z.string().optional(),
+  status: z.enum(['success', 'error']).optional(),
+})
+
+/**
+ * Extract variables from end node message field
+ */
+export function extractEndVariables(data: Partial<EndNodeData>): string[] {
+  const variableIds = new Set<string>()
+
+  if (data.message && typeof data.message === 'string') {
+    extractVarIdsFromString(data.message).forEach((id) => variableIds.add(id))
+  }
+
+  return Array.from(variableIds)
+}
+
+/**
+ * Validates the End node configuration
+ */
+export const validateEndConfig = (data: EndNodeData): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Validate title
+  if (!data.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Validate status if provided
+  if (data.status && !['success', 'error'].includes(data.status)) {
+    errors.push({ field: 'status', message: 'Invalid status value', type: 'error' })
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/**
+ * End node manifest
+ */
+export const endManifest: NodeManifest<EndNodeData> = {
+  id: 'end',
+  category: NodeCategory.ACTION,
+  displayName: 'Output',
+  description: 'Outputs a message for the manual trigger',
+  icon: 'message-circle',
+  color: '#10b981', // ACTION category color
+  defaultData: () => ({
+    title: 'Output',
+    description: '',
+    message: '',
+    status: 'success',
+  }),
+  configSchema: endNodeDataSchema as unknown as z.ZodType<EndNodeData>,
+  validate: validateEndConfig,
+  extractVariables: extractEndVariables,
+  connection: {
+    canRunSingle: true,
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Terminal output node. `message` supports {{…}} variable references; ' +
+      '`status` is "success" or "error".',
+    examples: [
+      {
+        description: 'Finish with a templated message',
+        config: { message: 'Handled ticket {{find-1.ticket.subject}}', status: 'success' },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/note.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/note.ts
@@ -1,0 +1,75 @@
+// packages/lib/src/workflow-engine/catalog/nodes/note.ts
+
+import { z } from 'zod'
+import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+
+export type NoteTheme = 'yellow' | 'blue' | 'purple' | 'pink' | 'green'
+
+/**
+ * Note node data interface with flattened structure
+ */
+export interface NoteNodeData extends BaseNodeData {
+  text: string
+  theme: NoteTheme
+  showAuthor: boolean
+  author: string
+  fontSize: number
+}
+
+/**
+ * Zod schema for note node data (flattened structure)
+ */
+export const noteNodeDataSchema = baseNodeDataSchema.extend({
+  text: z.string().default(''),
+  theme: z.enum(['yellow', 'blue', 'purple', 'pink', 'green'] as const).default('yellow'),
+  showAuthor: z.boolean().default(false),
+  author: z.string().default(''),
+  fontSize: z.number().min(10).max(20).default(14),
+})
+
+/**
+ * Validation function for note configuration
+ */
+export const validateNoteConfig = (_data: NoteNodeData): NodeValidationResult => {
+  // Note nodes don't require validation as they're just for documentation
+  // All fields are optional and have defaults
+  return { isValid: true, errors: [] }
+}
+
+/**
+ * Note node manifest
+ */
+export const noteManifest: NodeManifest<NoteNodeData> = {
+  id: 'note',
+  category: NodeCategory.DATA,
+  displayName: 'Note',
+  description: 'Add notes and documentation to your workflow',
+  icon: 'sticky-note',
+  color: '#FBBF24',
+  defaultData: () => ({
+    title: 'Note',
+    desc: '',
+    text: '',
+    theme: 'yellow' as NoteTheme,
+    showAuthor: false,
+    author: '',
+    fontSize: 14,
+  }),
+  configSchema: noteNodeDataSchema as unknown as z.ZodType<NoteNodeData>,
+  validate: validateNoteConfig,
+  extractVariables: () => [], // Note nodes don't extract variables
+  connection: {
+    canConnect: false, // Notes can be added to canvas but cannot connect to other blocks
+  },
+  agent: {
+    authorable: true,
+    usage: 'Canvas annotation only — no connections, no outputs. `text` is the note body.',
+    examples: [
+      {
+        description: 'Document a section of the graph',
+        config: { text: 'Escalation path: only fires for VIP customers.' },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/var-assign.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/var-assign.ts
@@ -1,0 +1,212 @@
+// packages/lib/src/workflow-engine/catalog/nodes/var-assign.ts
+
+import { generateId } from '@auxx/utils/generateId'
+import { z } from 'zod'
+import { BaseType } from '../../core/types'
+import type { BaseNodeData } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import { extractVarIdsFromString } from '../variable-inference'
+
+/**
+ * Single variable assignment configuration
+ */
+export interface VariableAssignment {
+  /** Unique identifier for the assignment */
+  id: string
+  /** Variable name */
+  name: string
+  /** Variable type (e.g., STRING, NUMBER, BOOLEAN) */
+  type: BaseType
+  /** Whether this is an array of the specified type */
+  isArray?: boolean
+  /** Variable value(s) - can be string or array of strings for array type */
+  value: string | string[]
+  /** Whether this variable is in constant mode (for single values only) */
+  isConstantMode?: boolean
+  /** Constant mode tracking for each array item (for array values only) */
+  itemConstantModes?: boolean[]
+}
+
+/**
+ * Variable assignment node data (flattened structure)
+ */
+export interface VarAssignNodeData extends BaseNodeData {
+  /** Array of variable assignments */
+  variables: VariableAssignment[]
+  /** Whether to ignore type errors during execution */
+  ignoreTypeError?: boolean
+}
+
+/**
+ * Zod schema for variable assignment
+ */
+const variableAssignmentSchema = z.object({
+  id: z.string(),
+  // Empty is a legitimate PERSISTED state — the canvas default is a blank
+  // starter row the user fills in, and half-configured nodes save. Shape
+  // constraint here (empty OR a valid identifier); COMPLETENESS lives in
+  // `validateVarAssign`, which flags empty names as checklist errors. The
+  // legacy min(1) made the default data fail its own schema — caught by the
+  // catalog defaults-parse test.
+  name: z
+    .string()
+    .regex(
+      /^$|^[a-zA-Z_][a-zA-Z0-9_]*$/,
+      'Variable name must start with a letter or underscore and contain only alphanumeric characters and underscores'
+    ),
+  type: z.enum(BaseType),
+  isArray: z.boolean().optional(),
+  value: z.union([z.string(), z.array(z.string())]),
+  isConstantMode: z.boolean().optional(),
+  itemConstantModes: z.array(z.boolean()).optional(),
+})
+
+/**
+ * Zod schema for var-assign node data (flattened structure).
+ * Kept as the historical hand-rolled subset (not a baseNodeDataSchema extend)
+ * to preserve the exact persisted contract; the `type` literal is the one
+ * schema in the set that pins its own node type.
+ */
+export const varAssignNodeDataSchema = z.object({
+  // Base node properties
+  id: z.string(),
+  type: z.literal('var-assign'),
+  // .default(false) aligns with baseNodeDataSchema — the node factory sets it
+  selected: z.boolean().default(false),
+
+  // Flattened config properties
+  title: z.string().default('Assign Variable'),
+  desc: z.string().optional(),
+  variables: z.array(variableAssignmentSchema),
+  ignoreTypeError: z.boolean().default(false),
+
+  // Other node data properties
+  isValid: z.boolean().optional(),
+  errors: z.array(z.string()).optional(),
+  disabled: z.boolean().optional(),
+  outputVariables: z.array(z.string()).optional(),
+})
+
+/**
+ * Validation function for var-assign configuration
+ */
+export function validateVarAssign(data: VarAssignNodeData): NodeValidationResult {
+  try {
+    // Support both old config format and new flattened format
+    const dataToValidate = 'config' in data ? data : (data as VarAssignNodeData)
+
+    // Additional custom validation
+    const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+    // Check for duplicate variable names
+    const names = dataToValidate.variables.map((v) => v.name).filter((name) => name.trim())
+    const duplicates = names.filter((name, index) => names.indexOf(name) !== index)
+    if (duplicates.length > 0) {
+      errors.push({
+        field: 'variables',
+        message: `Duplicate variable names: ${duplicates.join(', ')}`,
+        type: 'error',
+      })
+    }
+
+    // Check for empty variable names
+    dataToValidate.variables.forEach((variable, index) => {
+      if (!variable.name.trim()) {
+        errors.push({
+          field: `variables.${index}.name`,
+          message: 'Variable name cannot be empty',
+          type: 'error',
+        })
+      }
+    })
+
+    if (errors.length > 0) {
+      return { isValid: false, errors }
+    }
+
+    return { isValid: true, errors: [] }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        isValid: false,
+        errors: error.issues.map((e) => ({
+          field: e.path.join('.'),
+          message: e.message,
+          type: 'error' as const,
+        })),
+      }
+    }
+    return {
+      isValid: false,
+      errors: [{ field: 'general', message: 'Invalid configuration', type: 'error' }],
+    }
+  }
+}
+
+/**
+ * Extract variables from configuration
+ */
+export function extractVarAssignVariables(data: VarAssignNodeData): string[] {
+  const uniqueVariables = new Set<string>()
+
+  // Support both old config format and new flattened format
+  const variables = 'config' in data ? (data as any).config.variables : data.variables
+
+  // Extract variables from each assignment value
+  variables.forEach((assignment: VariableAssignment) => {
+    const values = Array.isArray(assignment.value) ? assignment.value : [assignment.value]
+    values.forEach((val) => {
+      extractVarIdsFromString(val).forEach((varId) => {
+        uniqueVariables.add(varId)
+      })
+    })
+  })
+
+  return Array.from(uniqueVariables)
+}
+
+/**
+ * Var-assign node manifest
+ */
+export const varAssignManifest: NodeManifest<VarAssignNodeData> = {
+  id: 'var-assign',
+  category: NodeCategory.TRANSFORM,
+  displayName: 'Assign Variable',
+  description: 'Create custom variables for use in subsequent nodes',
+  icon: 'variable',
+  color: '#8B5CF6', // TRANSFORM category color
+  defaultData: () => ({
+    title: 'Assign Variable',
+    desc: 'Create custom variables for use in subsequent nodes',
+    variables: [{ id: generateId(), name: '', type: BaseType.STRING, value: '' }],
+    ignoreTypeError: false,
+  }),
+  configSchema: varAssignNodeDataSchema as unknown as z.ZodType<VarAssignNodeData>,
+  validate: validateVarAssign,
+  extractVariables: extractVarAssignVariables,
+  connection: {
+    canRunSingle: true,
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Each entry in `variables` needs a valid identifier `name`, a `type` (BaseType), and a ' +
+      '`value` (string, may contain {{…}} refs; string[] with isArray). Names become ' +
+      'node-scoped outputs: {{Node Title.<name>}}.',
+    examples: [
+      {
+        description: 'Assign a greeting from an upstream value',
+        config: {
+          variables: [
+            {
+              id: 'a1',
+              name: 'greeting',
+              type: 'string',
+              value: 'Hello {{find-1.contact.firstName}}',
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -50,14 +50,14 @@ export const NOT_YET_MIGRATED: readonly string[] = [
   'code',
   'text-classifier',
   'information-extractor',
-  'var-assign',
+  // 'var-assign' — migrated (catalog/nodes/var-assign.ts)
   'date-time',
   'list',
   'format',
   // Data nodes
-  'note',
+  // 'note' — migrated (catalog/nodes/note.ts)
   // Control nodes
-  'end',
+  // 'end' — migrated (catalog/nodes/end.ts)
   // 'wait' — migrated (catalog/nodes/wait.ts)
   'loop',
   'human-confirmation',

--- a/packages/lib/src/workflow-engine/catalog/registry.ts
+++ b/packages/lib/src/workflow-engine/catalog/registry.ts
@@ -1,5 +1,8 @@
 // packages/lib/src/workflow-engine/catalog/registry.ts
 
+import { endManifest } from './nodes/end'
+import { noteManifest } from './nodes/note'
+import { varAssignManifest } from './nodes/var-assign'
 import { waitManifest } from './nodes/wait'
 import type { NodeManifest } from './types'
 
@@ -14,7 +17,12 @@ import type { NodeManifest } from './types'
  * builder's `NodeType` enum, so migrating a type is always an explicit
  * two-file change: add the manifest here, delete the list entry.
  */
-const ALL_MANIFESTS: NodeManifest<any>[] = [waitManifest]
+const ALL_MANIFESTS: NodeManifest<any>[] = [
+  endManifest,
+  noteManifest,
+  varAssignManifest,
+  waitManifest,
+]
 
 const manifests = new Map<string, NodeManifest<any>>(ALL_MANIFESTS.map((m) => [m.id, m]))
 if (manifests.size !== ALL_MANIFESTS.length) {

--- a/packages/lib/src/workflow-engine/catalog/variable-inference.ts
+++ b/packages/lib/src/workflow-engine/catalog/variable-inference.ts
@@ -125,6 +125,29 @@ export function containsVariableReference(text: string | null | undefined): bool
 }
 
 /**
+ * Extract all tag varIds from string content ({{varId}} format) — used by
+ * the non-AI workflow nodes that persist prompt-ish fields as `text: string`.
+ * (Relocated from apps/web ui/input-editor/tiptap-converters.ts, which
+ * re-exports it.)
+ */
+export function extractVarIdsFromString(text: string): string[] {
+  if (!text) return []
+
+  const varIds: string[] = []
+  const varPattern = /\{\{([^}]+)\}\}/g
+  let match: RegExpExecArray | null
+
+  while ((match = varPattern.exec(text)) !== null) {
+    const varId = match[1]?.trim()
+    if (varId) {
+      varIds.push(varId)
+    }
+  }
+
+  return [...new Set(varIds)] // Remove duplicates
+}
+
+/**
  * Get the nodeId from a variable ID
  * Examples:
  *   "webhook-123.body.email" → "webhook-123"

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -80,6 +80,28 @@ export {
   type WorkflowRetryConfig,
 } from './catalog/node-base'
 export {
+  type EndNodeData as CatalogEndNodeData,
+  endManifest,
+  endNodeDataSchema,
+  extractEndVariables,
+  validateEndConfig,
+} from './catalog/nodes/end'
+export {
+  type NoteNodeData as CatalogNoteNodeData,
+  type NoteTheme,
+  noteManifest,
+  noteNodeDataSchema,
+  validateNoteConfig,
+} from './catalog/nodes/note'
+export {
+  extractVarAssignVariables,
+  type VarAssignNodeData as CatalogVarAssignNodeData,
+  type VariableAssignment,
+  validateVarAssign,
+  varAssignManifest,
+  varAssignNodeDataSchema,
+} from './catalog/nodes/var-assign'
+export {
   DurationUnit,
   validateWaitConfig,
   type WaitNodeData as CatalogWaitNodeData,
@@ -110,6 +132,7 @@ export {
   buildVariableId,
   buildVariableLabelPath,
   containsVariableReference,
+  extractVarIdsFromString,
   getArrayAccessorCompactLabel,
   getArrayAccessorMenuLabel,
   getArrayItemVariable,

--- a/packages/lib/src/workflow-engine/nodes/flow-nodes/end.ts
+++ b/packages/lib/src/workflow-engine/nodes/flow-nodes/end.ts
@@ -1,5 +1,10 @@
 // packages/lib/src/workflow-engine/nodes/flow-nodes/end.ts
 
+/**
+ * End node configuration — the message/status subset of the catalog's
+ * `EndNodeData` (node-catalog Phase 1; this file previously shadowed it).
+ */
+import type { EndNodeData } from '../../catalog/nodes/end'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type {
   NodeExecutionResult,
@@ -16,17 +21,7 @@ import {
 } from '../../types/content-segment'
 import { BaseNodeProcessor } from '../base-node'
 
-/**
- * End node configuration interface
- * Minimal configuration for workflow termination
- */
-interface EndNodeConfig {
-  /** Message to display when workflow ends */
-  message?: string
-
-  /** Status of workflow completion */
-  status?: 'success' | 'error'
-}
+type EndNodeConfig = Pick<EndNodeData, 'message' | 'status'>
 
 /**
  * Flow control node that explicitly ends workflow execution

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/var-assign-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/var-assign-processor.ts
@@ -1,19 +1,12 @@
 // packages/lib/src/workflow-engine/nodes/transform-nodes/var-assign-processor.ts
 
+// Assignment shape single-sourced from the node catalog (node-catalog
+// Phase 1) — this file previously shadowed it with a narrower local copy.
+import type { VariableAssignment } from '../../catalog/nodes/var-assign'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
 import { BaseNodeProcessor } from '../base-node'
-
-interface VariableAssignment {
-  id: string
-  name: string
-  type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'date' | 'datetime'
-  isArray?: boolean
-  value: string | string[]
-  isConstantMode?: boolean // UI-only: for single values
-  itemConstantModes?: boolean[] // UI-only: for array items
-}
 
 interface VarAssignConfig {
   variables: VariableAssignment[]


### PR DESCRIPTION
## Summary

Second catalog batch (after #1565's `wait` template): `end`, `note`, and `var-assign` move their data halves to `catalog/nodes/`, each web `schema.ts` shrinks to its `defineFromManifest` merge site + back-compat re-exports, and the zero-diff invariant holds for every `node.tsx` / `panel.tsx` / `trace-renderer.tsx`. Catalog now 4 migrated / 34 to go.

## Notable

- **The defaults-parse discipline caught its first real drift**: `var-assign`'s default starter row (empty `name`) failed its own schema's `min(1)` + identifier regex — exactly the resource-trigger bug class the test was built for. Fixed in the **schema**, not the defaults: an empty name is a legitimate persisted state (half-configured nodes save, and today's save path never parses), so the schema now allows empty-or-valid-identifier while `validateVarAssign` keeps flagging empties as checklist errors. This shape/completeness split is now the precedent for the remaining types.
- **Two engine shadow declarations deleted**: `var-assign-processor`'s local `VariableAssignment` (narrower than the builder's — string-literal type union vs `BaseType`) now imports the catalog type; `end.ts`'s `EndNodeConfig` is a `Pick` of the catalog data.
- `extractVarIdsFromString` (the `{{…}}` extractor used by 9 nodes' `extractVariables`) joins `catalog/variable-inference.ts`; `tiptap-converters` re-exports it — which lets `extractVariables` live in the manifests.
- `var-assign`'s deprecated `varAssignConfigSchema` had zero consumers and died in the move; its default-row id is minted with `generateId` per house rules instead of `uuid`.

## Verification

- `apps/web` workflow suite: 90 passed (parity + catalog coverage included).
- `packages/lib` transform/flow-node engine suites: 292 passed; tsc clean on touched files.
- Zero-diff on all three nodes' React components verified via `git diff --stat`.