### PR TITLE
feat(workflow): migrate if-else, loop and human-confirmation to the catalog

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/human/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/human/schema.ts
@@ -1,189 +1,50 @@
 // apps/web/src/components/workflow/nodes/core/human/schema.ts
 
-import { z } from 'zod'
-import {
-  BaseType,
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
-import { NodeType } from '~/components/workflow/types/node-types'
+import { humanConfirmationManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
+import { BaseType, type NodeDefinition } from '~/components/workflow/types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { HumanConfirmationNodeData } from './types'
 
-/**
- * Zod schema for human confirmation node data
- */
-export const humanConfirmationNodeDataSchema = baseNodeDataSchema
-  .extend({
-    message: z.string().optional(),
-    assignees: z.object({
-      actorIds: z.array(z.string()).optional(),
-      variable: z.any().optional(), // UnifiedVariable
-    }),
-    notification_methods: z.object({ in_app: z.boolean(), email: z.boolean() }),
-    timeout: z.object({
-      enabled: z.boolean().optional(), // defaults to true
-      duration: z.union([z.number(), z.any()]), // number or UnifiedVariable
-      unit: z.enum(['minutes', 'hours', 'days']),
-    }),
-    reminders: z
-      .object({
-        enabled: z.boolean(),
-        first_after: z.number(),
-        repeat_every: z.number(),
-        max_reminders: z.number(),
-        unit: z.enum(['minutes', 'hours', 'days']),
-      })
-      .optional(),
-    require_login: z.boolean().default(true),
-    test_behavior: z
-      .enum(['always_approve', 'always_deny', 'random', 'delayed', 'live'])
-      .optional(),
-    test_delay: z.number().optional(),
-    include_workflow_context: z.boolean().optional(),
-  })
-  .refine(
-    (data) => {
-      // At least one assignee method required
-      return (data.assignees?.actorIds?.length ?? 0) > 0 || data.assignees?.variable !== undefined
-    },
-    { message: 'At least one assignee is required' }
-  )
-
-/**
- * Default configuration for new human confirmation nodes
- */
-export const humanConfirmationDefaultData: Partial<HumanConfirmationNodeData> = {
-  title: 'Human Review',
-  description: 'Wait for human approval before proceeding',
-  message: '',
-  assignees: { actorIds: [] },
-  notification_methods: { in_app: true, email: true },
-  timeout: { enabled: true, duration: 24, unit: 'hours' },
-  require_login: true,
-  include_workflow_context: true,
-  test_behavior: 'always_approve',
-}
-
-/**
- * Validation function for human confirmation configuration
- */
-export const validateHumanConfirmationConfig = (
-  data: HumanConfirmationNodeData
-): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Validate title
-  if (!data.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Check assignees
-  const hasActorIds = (data.assignees?.actorIds?.length ?? 0) > 0
-  const hasVariable = !!data.assignees?.variable
-
-  if (!hasActorIds && !hasVariable) {
-    errors.push({ field: 'assignees', message: 'At least one assignee is required', type: 'error' })
-  }
-
-  // Check notification methods
-  if (!data.notification_methods?.in_app && !data.notification_methods?.email) {
-    errors.push({
-      field: 'notification_methods',
-      message: 'At least one notification method must be selected',
-      type: 'error',
-    })
-  }
-
-  // Check timeout (only if enabled)
-  if (data.timeout?.enabled !== false) {
-    // Default to true if not specified
-    if (!data.timeout?.duration) {
-      errors.push({
-        field: 'timeout.duration',
-        message: 'Timeout duration is required when timeout is enabled',
-        type: 'error',
-      })
-    } else if (typeof data.timeout.duration === 'number' && data.timeout.duration <= 0) {
-      errors.push({
-        field: 'timeout.duration',
-        message: 'Timeout duration must be greater than 0',
-        type: 'error',
-      })
-    }
-
-    if (!data.timeout?.unit) {
-      errors.push({
-        field: 'timeout.unit',
-        message: 'Timeout unit is required when timeout is enabled',
-        type: 'error',
-      })
-    }
-  }
-
-  // Warnings
-  if (
-    data.timeout?.enabled !== false &&
-    data.timeout &&
-    typeof data.timeout.duration === 'number'
-  ) {
-    const durationInMinutes =
-      data.timeout.unit === 'minutes'
-        ? data.timeout.duration
-        : data.timeout.unit === 'hours'
-          ? data.timeout.duration * 60
-          : data.timeout.duration * 1440
-
-    if (durationInMinutes > 10080) {
-      // More than 7 days
-      errors.push({
-        field: 'timeout.duration',
-        message: 'Very long timeout periods may affect workflow performance',
-        type: 'warning',
-      })
-    }
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
+// The data half (schema, defaults, validator, three-way branch rules) lives
+// in the node catalog (`@auxx/lib/workflow-engine/catalog/nodes/human`).
+// This file is the merge site: manifest + the web-only output resolver.
 
 /**
  * Output variables function for human confirmation node
  */
 export const getHumanConfirmationOutputVariables = (
-  data: HumanConfirmationNodeData,
+  _data: HumanConfirmationNodeData,
   nodeId: string
 ): any[] => {
   return [
     createUnifiedOutputVariable({
       nodeId,
-      path: 'approved_by', // Changed from 'name' to 'path'
+      path: 'approved_by',
       type: BaseType.STRING,
       description: 'User ID of the approver (empty if denied or timeout)',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'denied_by', // Changed from 'name' to 'path'
+      path: 'denied_by',
       type: BaseType.STRING,
       description: 'User ID of the denier (empty if approved or timeout)',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'response_time', // Changed from 'name' to 'path'
+      path: 'response_time',
       type: BaseType.NUMBER,
       description: 'Time taken to respond in seconds',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'outcome', // Changed from 'name' to 'path'
+      path: 'outcome',
       type: BaseType.STRING,
       description: 'The outcome: approved, denied, or timeout',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'response_message', // Changed from 'name' to 'path'
+      path: 'response_message',
       type: BaseType.STRING,
       description: 'Optional message from the reviewer',
     }),
@@ -193,17 +54,20 @@ export const getHumanConfirmationOutputVariables = (
 /**
  * Human confirmation node definition
  */
-export const humanConfirmationDefinition: NodeDefinition<HumanConfirmationNodeData> = {
-  id: NodeType.HUMAN_CONFIRMATION,
-  category: NodeCategory.CONDITION,
-  displayName: 'Human Review',
-  description: 'Pause workflow and wait for human approval',
-  icon: 'user-check',
-  color: '#f59e0b', // CONDITION category color
-  defaultData: humanConfirmationDefaultData,
-  schema: humanConfirmationNodeDataSchema,
-  validator: validateHumanConfirmationConfig,
-  canRunSingle: false,
-  extractVariables: () => [], // Human confirmation doesn't extract variables
-  outputVariables: getHumanConfirmationOutputVariables,
-}
+export const humanConfirmationDefinition: NodeDefinition<HumanConfirmationNodeData> =
+  defineFromManifest(
+    humanConfirmationManifest as unknown as NodeManifest<HumanConfirmationNodeData>,
+    { outputVariables: getHumanConfirmationOutputVariables }
+  )
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  humanConfirmationNodeDataSchema,
+  validateHumanConfirmationConfig,
+} from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Default configuration for new human confirmation nodes
+ */
+export const humanConfirmationDefaultData =
+  humanConfirmationManifest.defaultData() as Partial<HumanConfirmationNodeData>

--- a/apps/web/src/components/workflow/nodes/core/human/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/human/types.ts
@@ -1,78 +1,18 @@
 // apps/web/src/components/workflow/nodes/core/human/types.ts
 
-import type { TargetBranch, UnifiedVariable } from '~/components/workflow/types'
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { CatalogHumanConfirmationNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/human` — note the type id is
+// 'human-confirmation' while this folder is `core/human`).
 
 /**
  * Configuration data for the Human Confirmation node
  */
-export interface HumanConfirmationNodeData extends BaseNodeData {
-  // Basic configuration
-  /** Message displayed to reviewers when requesting confirmation */
-  message?: string
-
-  /** Assignees who can approve or deny the request */
-  assignees: {
-    /** ActorId format: ["user:abc", "group:xyz"] */
-    actorIds?: string[]
-    /** Dynamic assignee from workflow variable */
-    variable?: UnifiedVariable
-  }
-
-  // Notification settings
-  /** Methods to notify assignees about the confirmation request */
-  notification_methods: {
-    /**
-     * Ping assignees live (bell pulse + sound). Not "surface this in-app" — the
-     * Approvals tab and bell badge read `ApprovalRequest` directly, so turning
-     * this off hides nothing (plans/today/05-bell-and-feed-dedupe.md §2).
-     */
-    in_app: boolean
-    /** Send email notifications, if the recipient's own email preference allows. */
-    email: boolean
-  }
-
-  // Timeout settings
-  /** Configuration for when the request expires */
-  timeout: {
-    /** Whether timeout is enabled (defaults to true) */
-    enabled?: boolean
-    /** Duration before timeout (can be dynamic) */
-    duration: number | UnifiedVariable
-    /** Unit of time for the duration */
-    unit: 'minutes' | 'hours' | 'days'
-  }
-
-  /** Optional reminder configuration */
-  reminders?: {
-    /** Whether reminders are enabled */
-    enabled: boolean
-    /** When to send first reminder */
-    first_after: number
-    /** How often to repeat reminders */
-    repeat_every: number
-    /** Maximum number of reminders to send */
-    max_reminders: number
-    /** Unit of time for reminder intervals */
-    unit: 'minutes' | 'hours' | 'days'
-  }
-
-  /** Whether users must be logged in to respond */
-  require_login: boolean
-
-  // Test mode configuration
-  /** Behavior when running in test mode ('delayed' takes the timeout branch) */
-  test_behavior?: 'always_approve' | 'always_deny' | 'random' | 'delayed' | 'live'
-  /** Delay in seconds for 'delayed' test behavior */
-  test_delay?: number
-
-  // Additional metadata
-  /** Whether to include workflow context in the approval request */
-  include_workflow_context?: boolean
-
-  // Branch configuration
-  /** Target branches for human confirmation outcomes */
-  _targetBranches?: TargetBranch[]
+export interface HumanConfirmationNodeData extends CatalogHumanConfirmationNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/if-else/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/if-else/schema.ts
@@ -1,242 +1,59 @@
 // apps/web/src/components/workflow/nodes/core/if-else/schema.ts
 
-import { ALL_OPERATOR_KEYS } from '@auxx/lib/conditions/client'
-import { generateId } from '@auxx/utils/generateId'
-import { z } from 'zod'
-import {
-  BaseType,
-  NodeCategory,
-  type NodeDefinition,
-  NodeType,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
+import { ifElseManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
+import { BaseType, type NodeDefinition } from '~/components/workflow/types'
 import { createUnifiedOutputVariable } from '../../../utils/variable-conversion'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { IfElseNodeData } from './types'
 
-/**
- * Zod schema for if-else condition
- */
-const conditionSchema = z.object({
-  id: z.string(),
-  variableId: z.string(), // Use variableId for internal reference
-  comparison_operator: z.enum(ALL_OPERATOR_KEYS as [string, ...string[]]).optional(),
-  value: z
-    .union([z.string(), z.number(), z.boolean(), z.array(z.any()), z.record(z.string(), z.any())])
-    .optional(),
-})
-
-/**
- * Zod schema for if-else case
- */
-const caseSchema = z.object({
-  id: z.string(),
-  case_id: z.string(),
-  logical_operator: z.enum(['and', 'or']),
-  conditions: z.array(conditionSchema),
-})
-
-/**
- * Main schema for if-else configuration
- * @deprecated Use ifElseNodeDataSchema instead
- */
-export const ifElseSchema = z.object({
-  title: z.string().min(1),
-  description: z.string().optional(),
-  cases: z.array(caseSchema).min(1),
-  _targetBranches: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        type: z.enum(['default', 'fail']).default('default'),
-      })
-    )
-    .optional(),
-})
-
-/**
- * Zod schema for if-else node data (flattened structure)
- */
-export const ifElseNodeDataSchema = z.object({
-  // Base node properties
-  id: z.string(),
-  type: z.literal(NodeType.IF_ELSE),
-  selected: z.boolean(),
-
-  // Flattened config properties
-  title: z.string().min(1),
-  desc: z.string().optional(),
-  cases: z.array(caseSchema).min(1),
-  _targetBranches: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        type: z.enum(['default', 'fail']).default('default'),
-      })
-    )
-    .optional(),
-
-  // Other node data properties
-  isValid: z.boolean().optional(),
-  errors: z.array(z.string()).optional(),
-  disabled: z.boolean().optional(),
-  outputVariables: z.array(z.string()).optional(),
-})
-
-/**
- * Default data for new if-else nodes (flattened)
- */
-export const ifElseDefaultData: Partial<IfElseNodeData> = {
-  title: 'IF/ELSE',
-  desc: 'Branch based on conditions',
-  cases: [
-    {
-      id: generateId(),
-      case_id: 'true',
-      logical_operator: 'and',
-      conditions: [],
-    },
-  ],
-  _targetBranches: [
-    { id: 'true', name: 'IF', type: 'default' },
-    { id: 'false', name: 'ELSE', type: 'default' },
-  ],
-}
-
-/**
- * Validation function for if-else configuration
- */
-export const validateIfElseConfig = (data: IfElseNodeData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Support both old config format and new flattened format
-  const dataToValidate = 'config' in data ? (data as any).config : data
-
-  // Validate title
-  if (!dataToValidate.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Validate cases
-  if (!dataToValidate.cases || dataToValidate.cases.length === 0) {
-    errors.push({ field: 'cases', message: 'At least one case is required', type: 'error' })
-  }
-
-  // Validate each case
-  dataToValidate.cases?.forEach((caseItem: any, index: number) => {
-    if (!caseItem.case_id?.trim()) {
-      errors.push({
-        field: `cases.${index}.case_id`,
-        message: 'Case ID is required',
-        type: 'error',
-      })
-    }
-
-    if (caseItem.conditions.length === 0) {
-      errors.push({
-        field: `cases.${index}.conditions`,
-        message: 'At least one condition is required',
-        type: 'error',
-      })
-    }
-
-    // Validate conditions
-    caseItem.conditions.forEach((condition: any, condIndex: number) => {
-      if (!condition.variableId) {
-        errors.push({
-          field: `cases.${index}.conditions.${condIndex}.variable_selector`,
-          message: 'Variable selector is required',
-        })
-      }
-
-      if (!condition.comparison_operator) {
-        errors.push({
-          field: `cases.${index}.conditions.${condIndex}.comparison_operator`,
-          message: 'Comparison operator is required',
-        })
-      }
-    })
-  })
-
-  // Add warning for missing else branch description
-  if (!dataToValidate.desc?.trim()) {
-    errors.push({
-      field: 'desc',
-      message: 'Consider adding a description for better documentation',
-      type: 'warning',
-    })
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
-
-function extractIfElseVariableIds(data: IfElseNodeData): string[] {
-  const uniqueVariableIds = new Set<string>()
-
-  // Support both old config format and new flattened format
-  const dataToUse = 'config' in data ? (data as any).config : data
-
-  // Extract from all conditions in all cases
-  dataToUse.cases?.forEach((caseItem: any) => {
-    caseItem.conditions?.forEach((condition: any) => {
-      // Add variable ID from condition
-      if (condition.variableId) {
-        uniqueVariableIds.add(condition.variableId)
-      }
-      // Extract variable IDs from condition.value editor content
-      if (condition.value) {
-        extractVarIdsFromString(condition.value).forEach((id) => {
-          uniqueVariableIds.add(id)
-        })
-      }
-    })
-  })
-  return Array.from(uniqueVariableIds)
-}
-
-/**
- * Node definition for if-else
- */
-export const ifElseDefinition: NodeDefinition<IfElseNodeData> = {
-  id: NodeType.IF_ELSE,
-  category: NodeCategory.CONDITION,
-  displayName: 'IF/ELSE',
-  description: 'Branch workflow based on conditions',
-  icon: 'git-branch',
-  color: '#f59e0b', // CONDITION category color
-  defaultData: ifElseDefaultData,
-  schema: ifElseNodeDataSchema,
-  validator: validateIfElseConfig as any,
-  canRunSingle: true,
-  extractVariables: extractIfElseVariableIds as any,
-  outputVariables: getIfElseOutputVariables as any,
-}
+// The data half (condition/case types, schema, defaults, validator, variable
+// extraction, branch rules) lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/if-else`). This file is the merge
+// site: manifest + the web-only output resolver. The deprecated,
+// consumer-less `ifElseSchema` died in the move.
 
 /**
  * Define output variables for if-else node
  */
-function getIfElseOutputVariables(data: IfElseNodeData, nodeId: string): any[] {
+function getIfElseOutputVariables(_data: IfElseNodeData, nodeId: string): any[] {
   return [
     createUnifiedOutputVariable({
       nodeId,
-      path: 'matched_condition', // Changed from 'name' to 'path'
+      path: 'matched_condition',
       type: BaseType.STRING,
       description: 'Which condition was matched (case ID)',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'condition_index', // Changed from 'name' to 'path'
+      path: 'condition_index',
       type: BaseType.NUMBER,
       description: 'Index of the matched condition (0-based)',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'branch_taken', // Changed from 'name' to 'path'
+      path: 'branch_taken',
       type: BaseType.STRING,
       description: 'Which branch was taken (true/false)',
       enum: ['true', 'false'],
     }),
   ]
 }
+
+/**
+ * Node definition for if-else
+ */
+export const ifElseDefinition: NodeDefinition<IfElseNodeData> = defineFromManifest(
+  ifElseManifest as unknown as NodeManifest<IfElseNodeData>,
+  { outputVariables: getIfElseOutputVariables as any }
+)
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  ifElseNodeDataSchema,
+  validateIfElseConfig,
+} from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Default data for new if-else nodes (flattened)
+ */
+export const ifElseDefaultData = ifElseManifest.defaultData() as Partial<IfElseNodeData>

--- a/apps/web/src/components/workflow/nodes/core/if-else/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/if-else/types.ts
@@ -1,11 +1,23 @@
 // apps/web/src/components/workflow/nodes/core/if-else/types.ts
 
 import type { Operator } from '@auxx/lib/conditions/client'
+import type {
+  CatalogIfElseNodeData,
+  NodeCondition as CatalogNodeCondition,
+} from '@auxx/lib/workflow-engine/client'
 import type { Node as FlowNode } from '@xyflow/react'
 import type { TargetBranch } from '~/components/workflow/types'
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
 import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
 import type { TiptapJSON } from '~/components/workflow/ui/input-editor'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/if-else`). This file keeps the
+// web-only narrowings: `TiptapJSON` in condition values (lib types them as
+// `Record<string, any>`, which Tiptap docs satisfy structurally) and the
+// NodeType narrowing on the node data.
+export type { NodeCondition } from '@auxx/lib/workflow-engine/client'
 
 export type Node = FlowNode
 export type ValueSelector = string[]
@@ -20,10 +32,22 @@ export enum LogicalOperator {
 }
 
 // Extended condition interface for if-else nodes
-export interface IfElseCondition extends Omit<NodeCondition, 'value'> {
+export interface IfElseCondition extends Omit<CatalogNodeCondition, 'value' | 'varType'> {
   file_var?: any
   conditions?: IfElseCondition[]
   value?: string | number | boolean | string[] | TiptapJSON
+  /** Declared value type — drives which value editor is rendered */
+  varType?: BaseType
+}
+
+/**
+ * Case definition for if-else nodes
+ */
+export interface NodeCase {
+  id: string
+  case_id: string
+  logical_operator: 'and' | 'or'
+  conditions: IfElseCondition[]
 }
 
 // Re-export from store types for backward compatibility
@@ -32,11 +56,8 @@ export type IfElseCase = NodeCase
 /**
  * Node data for if-else nodes (flattened structure)
  */
-export interface IfElseNodeData extends BaseNodeData {
-  // Base fields
-  title: string
-  desc?: string
-  // If-else specific fields
+export interface IfElseNodeData extends CatalogIfElseNodeData {
+  type: NodeType
   cases: NodeCase[]
   _targetBranches?: TargetBranch[]
 }
@@ -52,36 +73,6 @@ export type IfElseNode = SpecificNode<'if-else', IfElseNodeData>
 export interface IfElseExecutionResult {
   outputs: { matched_case: string | null; branch: string }
   [key: string]: any
-}
-
-/**
- * Condition for if-else nodes
- * Uses Operator from lib for type safety
- */
-export interface NodeCondition {
-  id: string
-  /** Variable this condition reads. Empty until the user picks one. */
-  variableId?: string
-  comparison_operator?: Operator
-  value?: string | number | boolean | any[] | Record<string, any>
-  /** Whether the right-hand value is a literal rather than a variable reference */
-  isConstant?: boolean
-  /** Sub-key inside a structured variable (e.g. an address part) */
-  key?: string
-  /** Declared value type — drives which value editor is rendered */
-  varType?: BaseType
-  /** How this condition joins the previous one inside its case */
-  logical_operator?: 'and' | 'or'
-}
-
-/**
- * Case definition for if-else nodes
- */
-export interface NodeCase {
-  id: string
-  case_id: string
-  logical_operator: 'and' | 'or'
-  conditions: IfElseCondition[]
 }
 
 // Re-export for convenience

--- a/apps/web/src/components/workflow/nodes/core/loop/constants.ts
+++ b/apps/web/src/components/workflow/nodes/core/loop/constants.ts
@@ -1,11 +1,19 @@
 // apps/web/src/components/workflow/nodes/core/loop/constants.ts
 
-export const LOOP_CONSTANTS = {
-  DEFAULT_MAX_ITERATIONS: 100,
-  ABSOLUTE_MAX_ITERATIONS: 1000,
-  DEFAULT_ITERATOR_NAME: 'item',
-} as const
+// LOOP_CONSTANTS and LOOP_HANDLES moved to the node catalog with loop's data
+// half (node-catalog Phase 1 — `@auxx/lib/workflow-engine/catalog/nodes/loop`);
+// re-exported here so no web import churns.
+export { LOOP_CONSTANTS, LOOP_HANDLES } from '@auxx/lib/workflow-engine/client'
 
+/**
+ * Builder-only loop variable vocabulary.
+ *
+ * ⚠ Known drift (re-verification 2026-08-12): the ENGINE writes the bare
+ * `index` and node-scoped `<loopNodeId>.item`/`.index`/… keys — nothing in the
+ * engine writes these `loop.*` names (only the single-node-run hook seeds
+ * them). Deliberately NOT moved to the catalog until that drift is resolved;
+ * agent-facing guidance teaches node-scoped refs only.
+ */
 export const LOOP_VARIABLES = {
   INDEX: 'loop.index',
   COUNT: 'loop.count',
@@ -14,9 +22,4 @@ export const LOOP_VARIABLES = {
   IS_FIRST: 'loop.isFirst',
   IS_LAST: 'loop.isLast',
   RESULTS: 'loop.results',
-} as const
-
-export const LOOP_HANDLES = {
-  LOOP_START: 'loop-start', // Source handle that connects to first node in loop body
-  LOOP_BACK: 'loop-back', // Target handle where nodes inside loop connect to restart iteration
 } as const

--- a/apps/web/src/components/workflow/nodes/core/loop/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/loop/schema.ts
@@ -1,116 +1,15 @@
 // apps/web/src/components/workflow/nodes/core/loop/schema.ts
 
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { NodeType } from '~/components/workflow/types/node-types'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
+import { loopManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { LOOP_CONSTANTS } from './constants'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { LoopNodeData } from './types'
 
-/**
- * Zod schema for loop configuration
- */
-export const loopConfigSchema = z.object({
-  title: z.string().default('Loop'),
-  desc: z.string().optional(),
-  itemsSource: z.string().min(1, 'Items source is required'),
-  iteratorName: z.string().optional().default(LOOP_CONSTANTS.DEFAULT_ITERATOR_NAME), // @deprecated - always 'item' now
-  maxIterations: z
-    .number()
-    .min(1, 'Must have at least 1 iteration')
-    .max(
-      LOOP_CONSTANTS.ABSOLUTE_MAX_ITERATIONS,
-      `Cannot exceed ${LOOP_CONSTANTS.ABSOLUTE_MAX_ITERATIONS} iterations`
-    )
-    .default(LOOP_CONSTANTS.DEFAULT_MAX_ITERATIONS),
-  accumulateResults: z.boolean().default(true),
-})
-
-/**
- * Factory function to create default data (flattened structure)
- */
-export const createLoopDefaultData = (): Partial<LoopNodeData> => ({
-  title: 'Loop',
-  description: 'Iterate over each item in a list',
-  itemsSource: '',
-  // iteratorName is deprecated - always 'item' now
-  maxIterations: LOOP_CONSTANTS.DEFAULT_MAX_ITERATIONS,
-  accumulateResults: true,
-})
-
-/**
- * Default data for new loop nodes
- */
-export const loopDefaultData: Partial<LoopNodeData> = createLoopDefaultData()
-
-/**
- * Validation function for loop data
- */
-export function validateLoop(data: Partial<LoopNodeData>): ValidationResult {
-  try {
-    loopConfigSchema.parse(data)
-
-    const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-    // Additional validation
-    if (data.itemsSource && !data.itemsSource.trim()) {
-      errors.push({ field: 'itemsSource', message: 'Items source cannot be empty', type: 'error' })
-    }
-
-    // Add warning for high iteration counts
-    if (data.maxIterations && data.maxIterations > 1000) {
-      errors.push({
-        field: 'maxIterations',
-        message:
-          'High iteration count (>1000) may impact performance. Consider pagination or batch processing.',
-        type: 'warning',
-      })
-    }
-
-    // Iterator name validation removed - always 'item' now
-
-    if (errors.filter((e) => e.type === 'error').length > 0) {
-      return { isValid: false, errors }
-    }
-
-    return { isValid: true, errors }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return {
-        isValid: false,
-        errors: error.issues.map((e) => ({
-          field: e.path.join('.'),
-          message: e.message,
-          type: 'error' as const,
-        })),
-      }
-    }
-    return {
-      isValid: false,
-      errors: [{ field: 'general', message: 'Invalid configuration', type: 'error' }],
-    }
-  }
-}
-
-/**
- * Extract variables from loop data for single run
- * Returns string[] to match standard pattern used by other nodes
- */
-export function extractLoopVariables(data: Partial<LoopNodeData>): string[] {
-  const variableIds = new Set<string>()
-
-  // Extract from items source
-  if (data.itemsSource) {
-    extractVarIdsFromString(data.itemsSource).forEach((id) => variableIds.add(id))
-  }
-
-  return Array.from(variableIds)
-}
+// The data half (constants, schema, defaults, validator, variable extraction,
+// handle declarations) lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/loop`). This file is the merge
+// site: manifest + the web-only output resolver.
 
 /**
  * Define output variables for the loop node
@@ -122,13 +21,13 @@ export function getLoopOutputVariables(data: Partial<LoopNodeData>, nodeId: stri
   outputs.push(
     createUnifiedOutputVariable({
       nodeId,
-      path: 'totalIterations', // Changed from 'name' to 'path'
+      path: 'totalIterations',
       type: 'number' as any,
       description: 'Total number of iterations executed',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'completedIterations', // Changed from 'name' to 'path'
+      path: 'completedIterations',
       type: 'number' as any,
       description: 'Number of iterations completed',
     })
@@ -139,13 +38,13 @@ export function getLoopOutputVariables(data: Partial<LoopNodeData>, nodeId: stri
     outputs.push(
       createUnifiedOutputVariable({
         nodeId,
-        path: 'results', // Changed from 'name' to 'path'
+        path: 'results',
         type: 'array' as any,
         description: 'Accumulated results from all iterations',
       }),
       createUnifiedOutputVariable({
         nodeId,
-        path: 'lastResult', // Changed from 'name' to 'path'
+        path: 'lastResult',
         type: 'any' as any,
         description: 'Result from the last iteration',
       })
@@ -154,7 +53,7 @@ export function getLoopOutputVariables(data: Partial<LoopNodeData>, nodeId: stri
     outputs.push(
       createUnifiedOutputVariable({
         nodeId,
-        path: 'result', // Changed from 'name' to 'path'
+        path: 'result',
         type: 'any' as any,
         description: 'Result from the last iteration',
       })
@@ -167,17 +66,25 @@ export function getLoopOutputVariables(data: Partial<LoopNodeData>, nodeId: stri
 /**
  * Node definition for loop
  */
-export const loopDefinition: NodeDefinition<LoopNodeData> = {
-  id: NodeType.LOOP,
-  category: NodeCategory.FLOW_CONTROL,
-  displayName: 'Loop',
-  description: 'Iterate over each item in a list',
-  icon: 'repeat',
-  color: '#8B5CF6', // Purple
-  schema: loopConfigSchema,
-  defaultData: loopDefaultData,
-  canRunSingle: false, // Loops need context, can't run in isolation
-  validator: validateLoop,
-  extractVariables: extractLoopVariables,
-  outputVariables: getLoopOutputVariables,
-}
+export const loopDefinition: NodeDefinition<LoopNodeData> = defineFromManifest(
+  loopManifest as unknown as NodeManifest<LoopNodeData>,
+  { outputVariables: getLoopOutputVariables }
+)
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  extractLoopVariables,
+  loopConfigSchema,
+  validateLoop,
+} from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Factory function to create default data (flattened structure)
+ */
+export const createLoopDefaultData = (): Partial<LoopNodeData> =>
+  loopManifest.defaultData() as Partial<LoopNodeData>
+
+/**
+ * Default data for new loop nodes
+ */
+export const loopDefaultData: Partial<LoopNodeData> = createLoopDefaultData()

--- a/apps/web/src/components/workflow/nodes/core/loop/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/loop/types.ts
@@ -1,15 +1,17 @@
 // apps/web/src/components/workflow/nodes/core/loop/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { CatalogLoopNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/loop`).
 
 /**
  * Node data for loop nodes (flattened structure)
  */
-export interface LoopNodeData extends BaseNodeData {
-  itemsSource: string // variable path to array like "{{customers}}"
-  iteratorName?: string // @deprecated - always 'item' now, kept for backwards compatibility
-  maxIterations: number // safety limit
-  accumulateResults: boolean
+export interface LoopNodeData extends CatalogLoopNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
+++ b/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
@@ -107,6 +107,6 @@ describe('defineFromManifest', () => {
 
   it('resolves migrated types and stays undefined-safe for unmigrated ones', () => {
     expect(getManifest('wait')?.displayName).toBe('Wait')
-    expect(getManifest('loop')).toBeUndefined()
+    expect(getManifest('code')).toBeUndefined()
   })
 })

--- a/apps/web/src/components/workflow/types/core.ts
+++ b/apps/web/src/components/workflow/types/core.ts
@@ -28,8 +28,9 @@ export type VariableSelector = string[]
  */
 export type ComparisonOperator = Operator
 
-export type BranchType = 'default' | 'fail'
-export type TargetBranch = { id: string; name: string; type: BranchType }
+// Relocated to the lib node catalog (node-catalog Phase 1); re-exported so no
+// web import churns.
+export type { BranchType, TargetBranch } from '@auxx/lib/workflow-engine/client'
 
 export type EnvVarType = 'string' | 'number' | 'boolean' | 'array' | 'secret'
 export type EnvVar = {

--- a/apps/web/src/components/workflow/utils/branch-name-correct.ts
+++ b/apps/web/src/components/workflow/utils/branch-name-correct.ts
@@ -1,23 +1,6 @@
 // apps/web/src/components/workflow/utils/branch-name-correct.ts
 
-/**
- * Assigns display names to a node's outgoing branches.
- *
- * Two branches read as IF/ELSE; three or more read as CASE n/ELSE. The `false`
- * branch is always the ELSE. Generic over the branch shape so callers that carry
- * extra fields (e.g. `type`) keep them on the result.
- */
-export const branchNameCorrect = <T extends { id: string; name: string }>(branches: T[]): T[] => {
-  const branchLength = branches.length
-  if (branchLength < 2) throw new Error('if-else node branch number must than 2')
-
-  if (branchLength === 2) {
-    return branches.map((branch) => {
-      return { ...branch, name: branch.id === 'false' ? 'ELSE' : 'IF' }
-    })
-  }
-
-  return branches.map((branch, index) => {
-    return { ...branch, name: branch.id === 'false' ? 'ELSE' : `CASE ${index + 1}` }
-  })
-}
+// Moved to the node catalog with if-else's data half (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/if-else`); re-exported here so no
+// web import churns.
+export { branchNameCorrect } from '@auxx/lib/workflow-engine/client'

--- a/packages/lib/src/workflow-engine/catalog/node-base.ts
+++ b/packages/lib/src/workflow-engine/catalog/node-base.ts
@@ -14,6 +14,13 @@ import { NodeRunningStatus } from '../core/types'
  */
 
 /**
+ * Branch classification for a node's outgoing handles.
+ * Relocated from apps/web types/core.ts (which re-exports both).
+ */
+export type BranchType = 'default' | 'fail'
+export type TargetBranch = { id: string; name: string; type: BranchType }
+
+/**
  * Error handling strategy
  */
 export enum ErrorHandleType {

--- a/packages/lib/src/workflow-engine/catalog/nodes/human.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/human.ts
@@ -1,0 +1,254 @@
+// packages/lib/src/workflow-engine/catalog/nodes/human.ts
+
+import { z } from 'zod'
+import type { UnifiedVariable } from '../../types/unified-variable'
+import { type BaseNodeData, baseNodeDataSchema, type TargetBranch } from '../node-base'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
+
+/**
+ * Configuration data for the Human Confirmation node
+ */
+export interface HumanConfirmationNodeData extends BaseNodeData {
+  // Basic configuration
+  /** Message displayed to reviewers when requesting confirmation */
+  message?: string
+
+  /** Assignees who can approve or deny the request */
+  assignees: {
+    /** ActorId format: ["user:abc", "group:xyz"] */
+    actorIds?: string[]
+    /** Dynamic assignee from workflow variable */
+    variable?: UnifiedVariable
+  }
+
+  // Notification settings
+  /** Methods to notify assignees about the confirmation request */
+  notification_methods: {
+    /**
+     * Ping assignees live (bell pulse + sound). Not "surface this in-app" — the
+     * Approvals tab and bell badge read `ApprovalRequest` directly, so turning
+     * this off hides nothing (plans/today/05-bell-and-feed-dedupe.md §2).
+     */
+    in_app: boolean
+    /** Send email notifications, if the recipient's own email preference allows. */
+    email: boolean
+  }
+
+  // Timeout settings
+  /** Configuration for when the request expires */
+  timeout: {
+    /** Whether timeout is enabled (defaults to true) */
+    enabled?: boolean
+    /** Duration before timeout (can be dynamic) */
+    duration: number | UnifiedVariable
+    /** Unit of time for the duration */
+    unit: 'minutes' | 'hours' | 'days'
+  }
+
+  /** Optional reminder configuration */
+  reminders?: {
+    /** Whether reminders are enabled */
+    enabled: boolean
+    /** When to send first reminder */
+    first_after: number
+    /** How often to repeat reminders */
+    repeat_every: number
+    /** Maximum number of reminders to send */
+    max_reminders: number
+    /** Unit of time for reminder intervals */
+    unit: 'minutes' | 'hours' | 'days'
+  }
+
+  /** Whether users must be logged in to respond */
+  require_login: boolean
+
+  // Test mode configuration
+  /** Behavior when running in test mode ('delayed' takes the timeout branch) */
+  test_behavior?: 'always_approve' | 'always_deny' | 'random' | 'delayed' | 'live'
+  /** Delay in seconds for 'delayed' test behavior */
+  test_delay?: number
+
+  // Additional metadata
+  /** Whether to include workflow context in the approval request */
+  include_workflow_context?: boolean
+
+  // Branch configuration
+  /** Target branches for human confirmation outcomes */
+  _targetBranches?: TargetBranch[]
+}
+
+/**
+ * Zod schema for human confirmation node data
+ */
+export const humanConfirmationNodeDataSchema = baseNodeDataSchema.extend({
+  message: z.string().optional(),
+  // The assignee refinement is a COMPLETENESS rule and lives in
+  // `validateHumanConfirmationConfig` — the legacy schema-level .refine made
+  // the default data (empty actorIds, no variable) fail its own schema, the
+  // class the catalog defaults-parse test exists for.
+  assignees: z.object({
+    actorIds: z.array(z.string()).optional(),
+    variable: z.any().optional(), // UnifiedVariable
+  }),
+  notification_methods: z.object({ in_app: z.boolean(), email: z.boolean() }),
+  timeout: z.object({
+    enabled: z.boolean().optional(), // defaults to true
+    duration: z.union([z.number(), z.any()]), // number or UnifiedVariable
+    unit: z.enum(['minutes', 'hours', 'days']),
+  }),
+  reminders: z
+    .object({
+      enabled: z.boolean(),
+      first_after: z.number(),
+      repeat_every: z.number(),
+      max_reminders: z.number(),
+      unit: z.enum(['minutes', 'hours', 'days']),
+    })
+    .optional(),
+  require_login: z.boolean().default(true),
+  test_behavior: z.enum(['always_approve', 'always_deny', 'random', 'delayed', 'live']).optional(),
+  test_delay: z.number().optional(),
+  include_workflow_context: z.boolean().optional(),
+})
+
+/**
+ * Validation function for human confirmation configuration
+ */
+export const validateHumanConfirmationConfig = (
+  data: HumanConfirmationNodeData
+): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Validate title
+  if (!data.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Check assignees
+  const hasActorIds = (data.assignees?.actorIds?.length ?? 0) > 0
+  const hasVariable = !!data.assignees?.variable
+
+  if (!hasActorIds && !hasVariable) {
+    errors.push({ field: 'assignees', message: 'At least one assignee is required', type: 'error' })
+  }
+
+  // Check notification methods
+  if (!data.notification_methods?.in_app && !data.notification_methods?.email) {
+    errors.push({
+      field: 'notification_methods',
+      message: 'At least one notification method must be selected',
+      type: 'error',
+    })
+  }
+
+  // Check timeout (only if enabled)
+  if (data.timeout?.enabled !== false) {
+    // Default to true if not specified
+    if (!data.timeout?.duration) {
+      errors.push({
+        field: 'timeout.duration',
+        message: 'Timeout duration is required when timeout is enabled',
+        type: 'error',
+      })
+    } else if (typeof data.timeout.duration === 'number' && data.timeout.duration <= 0) {
+      errors.push({
+        field: 'timeout.duration',
+        message: 'Timeout duration must be greater than 0',
+        type: 'error',
+      })
+    }
+
+    if (!data.timeout?.unit) {
+      errors.push({
+        field: 'timeout.unit',
+        message: 'Timeout unit is required when timeout is enabled',
+        type: 'error',
+      })
+    }
+  }
+
+  // Warnings
+  if (
+    data.timeout?.enabled !== false &&
+    data.timeout &&
+    typeof data.timeout.duration === 'number'
+  ) {
+    const durationInMinutes =
+      data.timeout.unit === 'minutes'
+        ? data.timeout.duration
+        : data.timeout.unit === 'hours'
+          ? data.timeout.duration * 60
+          : data.timeout.duration * 1440
+
+    if (durationInMinutes > 10080) {
+      // More than 7 days
+      errors.push({
+        field: 'timeout.duration',
+        message: 'Very long timeout periods may affect workflow performance',
+        type: 'warning',
+      })
+    }
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/**
+ * Human confirmation node manifest.
+ * Note: the type id is 'human-confirmation'; the web folder is `core/human`.
+ */
+export const humanConfirmationManifest: NodeManifest<HumanConfirmationNodeData> = {
+  id: 'human-confirmation',
+  category: NodeCategory.CONDITION,
+  displayName: 'Human Review',
+  description: 'Pause workflow and wait for human approval',
+  icon: 'user-check',
+  color: '#f59e0b', // CONDITION category color
+  defaultData: () => ({
+    title: 'Human Review',
+    description: 'Wait for human approval before proceeding',
+    message: '',
+    assignees: { actorIds: [] },
+    notification_methods: { in_app: true, email: true },
+    timeout: { enabled: true, duration: 24, unit: 'hours' },
+    require_login: true,
+    include_workflow_context: true,
+    test_behavior: 'always_approve',
+  }),
+  configSchema: humanConfirmationNodeDataSchema as unknown as z.ZodType<HumanConfirmationNodeData>,
+  validate: validateHumanConfirmationConfig,
+  extractVariables: () => [], // Human confirmation doesn't extract variables
+  connection: {
+    canRunSingle: false,
+    /** Three-way outcome routing — not two-way. */
+    branches: (): NodeBranch[] => [
+      { id: 'approved', name: 'Approved', kind: 'default' },
+      { id: 'denied', name: 'Denied', kind: 'default' },
+      { id: 'timeout', name: 'Timeout', kind: 'default' },
+    ],
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Pauses the run for approval. `assignees.actorIds` uses ActorId format ' +
+      '("user:<id>", "group:<id>"). Wire all three branches: approved, denied, timeout. ' +
+      'Outputs: outcome, approved_by, denied_by, response_time, response_message.',
+    examples: [
+      {
+        description: 'Manager approval with a 4h timeout',
+        config: {
+          message: 'Approve refund for {{find-1.ticket.subject}}?',
+          assignees: { actorIds: ['group:managers'] },
+          notification_methods: { in_app: true, email: true },
+          timeout: { enabled: true, duration: 4, unit: 'hours' },
+          require_login: true,
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
@@ -1,0 +1,303 @@
+// packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
+
+import { generateId } from '@auxx/utils/generateId'
+import { z } from 'zod'
+import { ALL_OPERATOR_KEYS, type Operator } from '../../../conditions/client'
+import type { BaseNodeData, TargetBranch } from '../node-base'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
+import { extractVarIdsFromString } from '../variable-inference'
+
+/**
+ * Condition for if-else nodes.
+ * `value` admits any JSON shape — the builder's rich editor persists a Tiptap
+ * doc (an object) for variable-bearing values; apps/web narrows that member to
+ * its `TiptapJSON` type.
+ */
+export interface NodeCondition {
+  id: string
+  /** Variable this condition reads. Empty until the user picks one. */
+  variableId?: string
+  comparison_operator?: Operator
+  value?: string | number | boolean | any[] | Record<string, any>
+  /** Whether the right-hand value is a literal rather than a variable reference */
+  isConstant?: boolean
+  /** Sub-key inside a structured variable (e.g. an address part) */
+  key?: string
+  /** Declared value type — drives which value editor is rendered (BaseType) */
+  varType?: string
+  /** How this condition joins the previous one inside its case */
+  logical_operator?: 'and' | 'or'
+}
+
+// Extended condition interface for if-else nodes
+export interface IfElseCondition extends Omit<NodeCondition, 'value'> {
+  file_var?: any
+  conditions?: IfElseCondition[]
+  value?: string | number | boolean | string[] | Record<string, any>
+}
+
+/**
+ * Case definition for if-else nodes
+ */
+export interface NodeCase {
+  id: string
+  case_id: string
+  logical_operator: 'and' | 'or'
+  conditions: IfElseCondition[]
+}
+
+/**
+ * Node data for if-else nodes (flattened structure)
+ */
+export interface IfElseNodeData extends BaseNodeData {
+  cases: NodeCase[]
+  _targetBranches?: TargetBranch[]
+}
+
+/**
+ * Zod schema for if-else condition
+ */
+const conditionSchema = z.object({
+  id: z.string(),
+  variableId: z.string(), // Use variableId for internal reference
+  comparison_operator: z.enum(ALL_OPERATOR_KEYS as unknown as [string, ...string[]]).optional(),
+  value: z
+    .union([z.string(), z.number(), z.boolean(), z.array(z.any()), z.record(z.string(), z.any())])
+    .optional(),
+})
+
+/**
+ * Zod schema for if-else case
+ */
+const caseSchema = z.object({
+  id: z.string(),
+  case_id: z.string(),
+  logical_operator: z.enum(['and', 'or']),
+  conditions: z.array(conditionSchema),
+})
+
+/**
+ * Zod schema for if-else node data (flattened structure)
+ */
+export const ifElseNodeDataSchema = z.object({
+  // Base node properties
+  id: z.string(),
+  type: z.literal('if-else'),
+  // .default(false) aligns with baseNodeDataSchema — the node factory sets it
+  selected: z.boolean().default(false),
+
+  // Flattened config properties
+  title: z.string().min(1),
+  desc: z.string().optional(),
+  cases: z.array(caseSchema).min(1),
+  _targetBranches: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        type: z.enum(['default', 'fail']).default('default'),
+      })
+    )
+    .optional(),
+
+  // Other node data properties
+  isValid: z.boolean().optional(),
+  errors: z.array(z.string()).optional(),
+  disabled: z.boolean().optional(),
+  outputVariables: z.array(z.string()).optional(),
+})
+
+/**
+ * Assigns display names to a node's outgoing branches.
+ *
+ * Two branches read as IF/ELSE; three or more read as CASE n/ELSE. The `false`
+ * branch is always the ELSE. Generic over the branch shape so callers that carry
+ * extra fields (e.g. `type`) keep them on the result.
+ * (Relocated from apps/web utils/branch-name-correct.ts, which re-exports it.)
+ */
+export const branchNameCorrect = <T extends { id: string; name: string }>(branches: T[]): T[] => {
+  const branchLength = branches.length
+  if (branchLength < 2) throw new Error('if-else node branch number must than 2')
+
+  if (branchLength === 2) {
+    return branches.map((branch) => {
+      return { ...branch, name: branch.id === 'false' ? 'ELSE' : 'IF' }
+    })
+  }
+
+  return branches.map((branch, index) => {
+    return { ...branch, name: branch.id === 'false' ? 'ELSE' : `CASE ${index + 1}` }
+  })
+}
+
+/**
+ * Validation function for if-else configuration
+ */
+export const validateIfElseConfig = (data: IfElseNodeData): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Support both old config format and new flattened format
+  const dataToValidate = 'config' in data ? (data as any).config : data
+
+  // Validate title
+  if (!dataToValidate.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Validate cases
+  if (!dataToValidate.cases || dataToValidate.cases.length === 0) {
+    errors.push({ field: 'cases', message: 'At least one case is required', type: 'error' })
+  }
+
+  // Validate each case
+  dataToValidate.cases?.forEach((caseItem: any, index: number) => {
+    if (!caseItem.case_id?.trim()) {
+      errors.push({
+        field: `cases.${index}.case_id`,
+        message: 'Case ID is required',
+        type: 'error',
+      })
+    }
+
+    if (caseItem.conditions.length === 0) {
+      errors.push({
+        field: `cases.${index}.conditions`,
+        message: 'At least one condition is required',
+        type: 'error',
+      })
+    }
+
+    // Validate conditions
+    caseItem.conditions.forEach((condition: any, condIndex: number) => {
+      if (!condition.variableId) {
+        errors.push({
+          field: `cases.${index}.conditions.${condIndex}.variable_selector`,
+          message: 'Variable selector is required',
+        })
+      }
+
+      if (!condition.comparison_operator) {
+        errors.push({
+          field: `cases.${index}.conditions.${condIndex}.comparison_operator`,
+          message: 'Comparison operator is required',
+        })
+      }
+    })
+  })
+
+  // Add warning for missing else branch description
+  if (!dataToValidate.desc?.trim()) {
+    errors.push({
+      field: 'desc',
+      message: 'Consider adding a description for better documentation',
+      type: 'warning',
+    })
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+export function extractIfElseVariableIds(data: IfElseNodeData): string[] {
+  const uniqueVariableIds = new Set<string>()
+
+  // Support both old config format and new flattened format
+  const dataToUse = 'config' in data ? (data as any).config : data
+
+  // Extract from all conditions in all cases
+  dataToUse.cases?.forEach((caseItem: any) => {
+    caseItem.conditions?.forEach((condition: any) => {
+      // Add variable ID from condition
+      if (condition.variableId) {
+        uniqueVariableIds.add(condition.variableId)
+      }
+      // Extract variable IDs from condition.value editor content
+      if (condition.value) {
+        extractVarIdsFromString(condition.value).forEach((id) => {
+          uniqueVariableIds.add(id)
+        })
+      }
+    })
+  })
+  return Array.from(uniqueVariableIds)
+}
+
+/**
+ * If-else node manifest
+ */
+export const ifElseManifest: NodeManifest<IfElseNodeData> = {
+  id: 'if-else',
+  category: NodeCategory.CONDITION,
+  displayName: 'IF/ELSE',
+  description: 'Branch workflow based on conditions',
+  icon: 'git-branch',
+  color: '#f59e0b', // CONDITION category color
+  defaultData: () => ({
+    title: 'IF/ELSE',
+    desc: 'Branch based on conditions',
+    cases: [
+      {
+        id: generateId(),
+        case_id: 'true',
+        logical_operator: 'and',
+        conditions: [],
+      },
+    ],
+    _targetBranches: [
+      { id: 'true', name: 'IF', type: 'default' },
+      { id: 'false', name: 'ELSE', type: 'default' },
+    ],
+  }),
+  configSchema: ifElseNodeDataSchema as unknown as z.ZodType<IfElseNodeData>,
+  validate: validateIfElseConfig,
+  extractVariables: extractIfElseVariableIds,
+  connection: {
+    canRunSingle: true,
+    /**
+     * One branch per case (edge sourceHandle = the case's `case_id`) plus the
+     * reserved `false` ELSE branch. Mirrors the IF_ELSE arm of the canvas's
+     * `calculateTargetBranches` (workflow-initializer.ts), which stays the
+     * derived-state writer until the remaining branch-deriving types
+     * (text-classifier, http, crud) migrate and both converge here.
+     */
+    branches: (config): NodeBranch[] =>
+      branchNameCorrect([
+        ...(config.cases || []).map((c) => ({ id: c.case_id, name: '' })),
+        { id: 'false', name: '' },
+      ]).map((b) => ({ ...b, kind: 'default' as const })),
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Each entry in `cases` is one branch: `case_id` is the edge handle, conditions join via ' +
+      '`logical_operator`. Every condition reads a `variableId` (bare dotted path) with a ' +
+      '`comparison_operator` from the shared operator registry. The ELSE branch handle is ' +
+      "always 'false'. Wire edges by branch id.",
+    examples: [
+      {
+        description: 'Branch on a high-priority ticket',
+        config: {
+          cases: [
+            {
+              id: 'c1',
+              case_id: 'true',
+              logical_operator: 'and',
+              conditions: [
+                {
+                  id: 'cond1',
+                  variableId: 'trigger-1.ticket.priority',
+                  comparison_operator: 'is',
+                  value: 'high',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/loop.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/loop.ts
@@ -1,0 +1,161 @@
+// packages/lib/src/workflow-engine/catalog/nodes/loop.ts
+
+import { z } from 'zod'
+import type { BaseNodeData } from '../node-base'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
+import { extractVarIdsFromString } from '../variable-inference'
+
+export const LOOP_CONSTANTS = {
+  DEFAULT_MAX_ITERATIONS: 100,
+  ABSOLUTE_MAX_ITERATIONS: 1000,
+  DEFAULT_ITERATOR_NAME: 'item',
+} as const
+
+/**
+ * The loop node's structural handles. A loop is three edges, not one:
+ * `loop-start` (source) → first body node, last body node → `loop-back`
+ * (TARGET handle on the loop node), and `source` → whatever follows the loop.
+ * Body nodes additionally carry top-level `parentId` for containment — which
+ * is correctness-critical: the initializer regenerates `isLoopBackEdge` from
+ * it (and from the `loop-back` handle).
+ */
+export const LOOP_HANDLES = {
+  LOOP_START: 'loop-start', // Source handle that connects to first node in loop body
+  LOOP_BACK: 'loop-back', // Target handle where nodes inside loop connect to restart iteration
+} as const
+
+/**
+ * Node data for loop nodes (flattened structure)
+ */
+export interface LoopNodeData extends BaseNodeData {
+  itemsSource: string // variable path to array like "{{customers}}"
+  iteratorName?: string // @deprecated - always 'item' now, kept for backwards compatibility
+  maxIterations: number // safety limit
+  accumulateResults: boolean
+}
+
+/**
+ * Zod schema for loop configuration
+ */
+export const loopConfigSchema = z.object({
+  title: z.string().default('Loop'),
+  desc: z.string().optional(),
+  // Empty is a legitimate PERSISTED state — the canvas default has no items
+  // source until the user picks one. Completeness lives in `validateLoop`.
+  itemsSource: z.string().default(''),
+  iteratorName: z.string().optional().default(LOOP_CONSTANTS.DEFAULT_ITERATOR_NAME), // @deprecated - always 'item' now
+  maxIterations: z
+    .number()
+    .min(1, 'Must have at least 1 iteration')
+    .max(
+      LOOP_CONSTANTS.ABSOLUTE_MAX_ITERATIONS,
+      `Cannot exceed ${LOOP_CONSTANTS.ABSOLUTE_MAX_ITERATIONS} iterations`
+    )
+    .default(LOOP_CONSTANTS.DEFAULT_MAX_ITERATIONS),
+  accumulateResults: z.boolean().default(true),
+})
+
+/**
+ * Validation function for loop data
+ */
+export function validateLoop(data: Partial<LoopNodeData>): NodeValidationResult {
+  const parsed = loopConfigSchema.safeParse(data)
+  if (!parsed.success) {
+    return {
+      isValid: false,
+      errors: parsed.error.issues.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+        type: 'error' as const,
+      })),
+    }
+  }
+
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Completeness: an items source is required to actually run
+  if (!data.itemsSource || !data.itemsSource.trim()) {
+    errors.push({ field: 'itemsSource', message: 'Items source is required', type: 'error' })
+  }
+
+  // Add warning for high iteration counts
+  if (data.maxIterations && data.maxIterations > 1000) {
+    errors.push({
+      field: 'maxIterations',
+      message:
+        'High iteration count (>1000) may impact performance. Consider pagination or batch processing.',
+      type: 'warning',
+    })
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/**
+ * Extract variables from loop data for single run
+ * Returns string[] to match standard pattern used by other nodes
+ */
+export function extractLoopVariables(data: Partial<LoopNodeData>): string[] {
+  const variableIds = new Set<string>()
+
+  // Extract from items source
+  if (data.itemsSource) {
+    extractVarIdsFromString(data.itemsSource).forEach((id) => variableIds.add(id))
+  }
+
+  return Array.from(variableIds)
+}
+
+/**
+ * Loop node manifest
+ */
+export const loopManifest: NodeManifest<LoopNodeData> = {
+  id: 'loop',
+  category: NodeCategory.FLOW_CONTROL,
+  displayName: 'Loop',
+  description: 'Iterate over each item in a list',
+  icon: 'repeat',
+  color: '#8B5CF6', // Purple
+  defaultData: () => ({
+    title: 'Loop',
+    description: 'Iterate over each item in a list',
+    itemsSource: '',
+    // iteratorName is deprecated - always 'item' now
+    maxIterations: LOOP_CONSTANTS.DEFAULT_MAX_ITERATIONS,
+    accumulateResults: true,
+  }),
+  configSchema: loopConfigSchema as unknown as z.ZodType<LoopNodeData>,
+  validate: validateLoop,
+  extractVariables: extractLoopVariables,
+  connection: {
+    canRunSingle: false, // Loops need context, can't run in isolation
+    /**
+     * Source handles only — `loop-back` is a TARGET handle on the loop node
+     * and so not a branch here. Exactly one `loop-start` edge is required
+     * (the engine's validateLoopStructure throws otherwise).
+     */
+    branches: (): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      { id: LOOP_HANDLES.LOOP_START, name: 'Loop Start', kind: 'default' },
+    ],
+  },
+  agent: {
+    authorable: true,
+    usage:
+      "A loop is three edges: loop-start → first body node, last body node → the loop's " +
+      'loop-back TARGET handle, and source → whatever follows. Body nodes set top-level ' +
+      'parentId to the loop for containment. Reference the current item with node-scoped ' +
+      'refs only: {{<Loop Title>.item}} / .index / .count — never bare {{item}}.',
+    examples: [
+      {
+        description: 'Loop over found tickets',
+        config: { itemsSource: '{{find-1.tickets}}', maxIterations: 100, accumulateResults: true },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -35,7 +35,7 @@ export const NOT_YET_MIGRATED: readonly string[] = [
   'number-input',
   'file-upload',
   // Condition nodes
-  'if-else',
+  // 'if-else' — migrated (catalog/nodes/if-else.ts)
   // Action nodes
   'answer',
   'ai',
@@ -59,6 +59,6 @@ export const NOT_YET_MIGRATED: readonly string[] = [
   // Control nodes
   // 'end' — migrated (catalog/nodes/end.ts)
   // 'wait' — migrated (catalog/nodes/wait.ts)
-  'loop',
-  'human-confirmation',
+  // 'loop' — migrated (catalog/nodes/loop.ts)
+  // 'human-confirmation' — migrated (catalog/nodes/human.ts)
 ] as const

--- a/packages/lib/src/workflow-engine/catalog/registry.ts
+++ b/packages/lib/src/workflow-engine/catalog/registry.ts
@@ -3,6 +3,9 @@
 import { dateTimeManifest } from './nodes/date-time'
 import { endManifest } from './nodes/end'
 import { formatManifest } from './nodes/format'
+import { humanConfirmationManifest } from './nodes/human'
+import { ifElseManifest } from './nodes/if-else'
+import { loopManifest } from './nodes/loop'
 import { manualManifest } from './nodes/manual'
 import { noteManifest } from './nodes/note'
 import { scheduledTriggerManifest } from './nodes/scheduled'
@@ -25,6 +28,9 @@ const ALL_MANIFESTS: NodeManifest<any>[] = [
   dateTimeManifest,
   endManifest,
   formatManifest,
+  humanConfirmationManifest,
+  ifElseManifest,
+  loopManifest,
   manualManifest,
   noteManifest,
   scheduledTriggerManifest,

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -72,11 +72,13 @@ export * from './utils/terminal-nodes'
 
 export {
   type BaseNodeData as CatalogBaseNodeData,
+  type BranchType,
   baseNodeDataSchema,
   ErrorHandleType,
   type NodeConnectionMetadata,
   type NodeLoopContext,
   type NodeRuntimeState,
+  type TargetBranch,
   type WorkflowRetryConfig,
 } from './catalog/node-base'
 export {
@@ -104,6 +106,32 @@ export {
   formatNodeSchema,
   validateFormatNodeData,
 } from './catalog/nodes/format'
+export {
+  type HumanConfirmationNodeData as CatalogHumanConfirmationNodeData,
+  humanConfirmationManifest,
+  humanConfirmationNodeDataSchema,
+  validateHumanConfirmationConfig,
+} from './catalog/nodes/human'
+export {
+  branchNameCorrect,
+  extractIfElseVariableIds,
+  type IfElseCondition,
+  type IfElseNodeData as CatalogIfElseNodeData,
+  ifElseManifest,
+  ifElseNodeDataSchema,
+  type NodeCase,
+  type NodeCondition,
+  validateIfElseConfig,
+} from './catalog/nodes/if-else'
+export {
+  extractLoopVariables,
+  LOOP_CONSTANTS,
+  LOOP_HANDLES,
+  type LoopNodeData as CatalogLoopNodeData,
+  loopConfigSchema,
+  loopManifest,
+  validateLoop,
+} from './catalog/nodes/loop'
 export {
   type ManualNodeData as CatalogManualNodeData,
   manualManifest,

--- a/packages/lib/src/workflow-engine/nodes/flow-nodes/loop.ts
+++ b/packages/lib/src/workflow-engine/nodes/flow-nodes/loop.ts
@@ -20,15 +20,15 @@ import { BaseNodeProcessor } from '../base-node'
 const logger = createScopedLogger('loop-processor')
 
 /**
- * Loop node configuration - simplified to match frontend implementation
+ * Loop node configuration — the config subset of the catalog's `LoopNodeData`
+ * (node-catalog Phase 1; this file previously shadowed it).
  */
-interface LoopNodeConfig {
-  title: string
-  description?: string
-  itemsSource: string // Array variable path like "{{customers}}"
-  maxIterations: number // Safety limit (default: 100, max: 1000)
-  accumulateResults: boolean // Collect results from iterations (default: true)
-}
+import type { LoopNodeData } from '../../catalog/nodes/loop'
+
+type LoopNodeConfig = Pick<
+  LoopNodeData,
+  'title' | 'description' | 'itemsSource' | 'maxIterations' | 'accumulateResults'
+>
 
 /**
  * Processor for loop nodes that iterate over arrays (foreach loops)


### PR DESCRIPTION
## Summary

The branch-node batch — `if-else`, `loop`, `human-confirmation`. **11 of 38 types migrated**, zero diff on every React component. These are the first manifests with real `connection.branches()` implementations — the single declaration the parity suite's handle assertions and the future `connect_nodes` agent tool read from.

## Branch declarations

- **if-else**: one branch per case (`case_id` = edge handle) + the reserved `false` ELSE, named through `branchNameCorrect` (relocated into the manifest file; the canvas's `calculateTargetBranches` keeps its own derivation until `text-classifier`/`http`/`crud` migrate, then both converge on the manifest).
- **human-confirmation**: the three-way `approved`/`denied`/`timeout` routing, declared instead of implied by the node component.
- **loop**: `source` + `loop-start` only — `loop-back` is a TARGET handle, documented as such alongside the three-edge shape and `parentId` containment. The agent usage string teaches node-scoped item refs only (`{{Loop Title.item}}`), per the re-verification's loop-grammar decision.

## Also notable

- `TargetBranch`/`BranchType` relocate to `catalog/node-base` (web `types/core.ts` re-exports).
- The builder-only `LOOP_VARIABLES` (`loop.*`) vocabulary deliberately stays web-side with a drift warning — the engine never writes those keys.
- Engine sweep: `flow-nodes/loop.ts`'s `LoopNodeConfig` shadow becomes a `Pick` of the catalog data.
- **Defaults-parse discipline caught two more** (catches 4 and 5): `loop`'s `itemsSource: min(1)` and `human-confirmation`'s schema-level assignee `.refine` both rejected their own defaults. Both moved to the validators per the established shape-vs-completeness precedent.
- The deprecated, consumer-less `ifElseSchema` died in the move.

## Verification

- `apps/web` workflow suite: 90 passed (parity + catalog coverage).
- `packages/lib` flow/condition-node suites: 42 passed (incl. the nested-loop tests); tsc clean on touched files.
- Zero-diff on all three nodes' React components via `git diff --stat`.