### PR TITLE
feat(workflow): migrate ai, answer, information-extractor and text-classifier to the catalog

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/ai/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/ai/schema.ts
@@ -1,260 +1,15 @@
 // apps/web/src/components/workflow/nodes/core/ai/schema.ts
 
-import { collectVariableIds, isNonEmptyDoc, type TiptapDoc } from '@auxx/lib/tiptap'
-import { AI_NODE_CONSTANTS } from '@auxx/lib/workflow-engine/constants'
-import { z } from 'zod'
-import {
-  BaseType,
-  NodeCategory,
-  type NodeDefinition,
-  type UnifiedVariable,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { NodeType } from '~/components/workflow/types/node-types'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
+import { aiManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
+import { BaseType, type NodeDefinition, type UnifiedVariable } from '~/components/workflow/types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { containsVariableReference } from '~/components/workflow/utils/variable-utils'
-import { AiModelMode, type AiNodeData, PromptRole } from './types'
+import { defineFromManifest } from '../../define-from-manifest'
+import type { AiNodeData } from './types'
 
-const EMPTY_PROMPT_DOC: TiptapDoc = { type: 'doc', content: [{ type: 'paragraph' }] }
-
-/**
- * Zod schema for AI model completion parameters
- */
-const completionParamsSchema = z.object({
-  temperature: z
-    .number()
-    .min(AI_NODE_CONSTANTS.TEMPERATURE.min)
-    .max(AI_NODE_CONSTANTS.TEMPERATURE.max)
-    .default(AI_NODE_CONSTANTS.TEMPERATURE.default),
-  max_tokens: z
-    .number()
-    .min(AI_NODE_CONSTANTS.MAX_TOKENS.min)
-    .max(AI_NODE_CONSTANTS.MAX_TOKENS.max)
-    .optional(),
-  top_p: z.number().min(AI_NODE_CONSTANTS.TOP_P.min).max(AI_NODE_CONSTANTS.TOP_P.max).optional(),
-  frequency_penalty: z
-    .number()
-    .min(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.min)
-    .max(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.max)
-    .optional(),
-  presence_penalty: z
-    .number()
-    .min(AI_NODE_CONSTANTS.PRESENCE_PENALTY.min)
-    .max(AI_NODE_CONSTANTS.PRESENCE_PENALTY.max)
-    .optional(),
-})
-
-/**
- * Zod schema for AI model
- */
-const modelSchema = z.object({
-  useDefault: z.boolean().optional(),
-  provider: z.string(),
-  name: z.string(),
-  mode: z.enum(AiModelMode).default(AiModelMode.CHAT),
-  completion_params: completionParamsSchema,
-})
-
-/**
- * Zod schema for prompt template. Phase 4 storage shape: a Tiptap doc
- * (`{ type: 'doc', content: [...] }`) — see `PromptTemplate` in `./types.ts`.
- */
-const tiptapDocSchema = z
-  .object({
-    type: z.literal('doc'),
-    content: z.array(z.any()).optional(),
-  })
-  .passthrough()
-
-const promptTemplateSchema = z.object({ role: z.enum(PromptRole), json: tiptapDocSchema })
-
-/**
- * Zod schema for AI files
- */
-const filesSchema = z.object({
-  enabled: z.boolean().default(false),
-  input: z.string().default(''),
-  isConstant: z.boolean().default(false),
-})
-
-/**
- * Zod schema for structured output
- */
-const structuredOutputSchema = z.object({
-  enabled: z.boolean().default(false),
-  schema: z
-    .object({
-      type: z.literal('object'),
-      properties: z.record(z.string(), z.any()),
-      required: z.array(z.string()).optional(),
-      additionalProperties: z.boolean().optional(),
-    })
-    .optional(),
-})
-
-/**
- * Zod schema for a single toolset entry on the AI node. Mirrors the shared
- * `ToolsetEntry` from `@auxx/database` so the picker dialog and back-end
- * filter pipeline work without translation.
- */
-const toolsetEntrySchema = z.object({
-  slug: z.string(),
-  enabled: z.boolean(),
-  source: z.enum(['manual', 'mention', 'auto_default']),
-  config: z.record(z.string(), z.unknown()).default({}),
-  appInstallationId: z.string().nullable().optional(),
-})
-
-const appAccountsSchema = z.record(z.string(), z.object({ credId: z.string() }))
-
-/**
- * Main schema for AI node data
- */
-export const aiNodeDataSchema = z.object({
-  // Base fields
-  id: z.string(),
-  type: z.literal(NodeType.AI),
-  title: z.string().min(1),
-  desc: z.string().optional(),
-  // AI-specific fields
-  model: modelSchema,
-  prompt_template: z.array(promptTemplateSchema).min(1),
-  files: filesSchema,
-  structured_output: structuredOutputSchema,
-  // Flat tools shape (Phase 3)
-  toolsEnabled: z.boolean().optional(),
-  toolsets: z.array(toolsetEntrySchema).optional(),
-  appAccounts: appAccountsSchema.optional(),
-  approvalMode: z.literal('auto').optional(),
-  maxIterations: z.number().optional(),
-})
-
-/**
- * Main schema for AI configuration (deprecated)
- */
-export const aiSchema = z.object({
-  title: z.string().min(1),
-  desc: z.string().optional(),
-  model: modelSchema,
-  prompt_template: z.array(promptTemplateSchema).min(1),
-  files: filesSchema,
-  structured_output: structuredOutputSchema,
-  toolsEnabled: z.boolean().optional(),
-  toolsets: z.array(toolsetEntrySchema).optional(),
-  appAccounts: appAccountsSchema.optional(),
-  approvalMode: z.literal('auto').optional(),
-  maxIterations: z.number().optional(),
-})
-
-/**
- * Factory function to create a new AI default configuration
- * This ensures each node gets its own deep copy of the config
- */
-export const createAiDefaultData = (): Partial<AiNodeData> => ({
-  title: 'AI',
-  desc: 'AI-powered text generation',
-  model: {
-    useDefault: true,
-    provider: '',
-    name: '',
-    mode: AiModelMode.CHAT,
-    completion_params: { temperature: AI_NODE_CONSTANTS.TEMPERATURE.default },
-  },
-  prompt_template: [{ role: PromptRole.SYSTEM, json: EMPTY_PROMPT_DOC }],
-  files: { enabled: false, input: '', isConstant: false },
-  structured_output: { enabled: false },
-  toolsEnabled: false,
-  toolsets: [],
-})
-
-/**
- * Validation function for AI configuration
- */
-export const validateAiData = (data: Partial<AiNodeData>): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Validate title
-  if (!data.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Validate model — only require provider/name when NOT using default
-  if (!data.model?.useDefault) {
-    if (!data.model?.provider?.trim()) {
-      errors.push({ field: 'model.provider', message: 'Model provider is required', type: 'error' })
-    }
-
-    if (!data.model?.name?.trim()) {
-      errors.push({ field: 'model.name', message: 'Model name is required', type: 'error' })
-    }
-  }
-
-  // Validate temperature (an unset temperature falls back to the provider default)
-  const temperature = data.model?.completion_params?.temperature
-  if (temperature !== undefined) {
-    if (
-      temperature < AI_NODE_CONSTANTS.TEMPERATURE.min ||
-      temperature > AI_NODE_CONSTANTS.TEMPERATURE.max
-    ) {
-      errors.push({
-        field: 'model.completion_params.temperature',
-        message: `Temperature must be between ${AI_NODE_CONSTANTS.TEMPERATURE.min} and ${AI_NODE_CONSTANTS.TEMPERATURE.max}`,
-        type: 'error',
-      })
-    } else if (temperature > 0.8) {
-      // Add warning for high temperature
-      errors.push({
-        field: 'model.completion_params.temperature',
-        message: 'High temperature (>0.8) may produce more creative but less predictable results',
-        type: 'warning',
-      })
-    }
-  }
-
-  // Validate prompt template
-  if (!data.prompt_template || data.prompt_template.length === 0) {
-    errors.push({
-      field: 'prompt_template',
-      message: 'At least one prompt template is required',
-      type: 'error',
-    })
-  }
-
-  // Validate each prompt template
-  data.prompt_template?.forEach((template, index) => {
-    if (!template.role) {
-      errors.push({
-        field: `prompt_template.${index}.role`,
-        message: 'Prompt role is required',
-        type: 'error',
-      })
-    }
-
-    if (!template.json || !isNonEmptyDoc(template.json)) {
-      errors.push({
-        field: `prompt_template.${index}.json`,
-        message: 'Prompt text is required',
-        type: 'error',
-      })
-    }
-  })
-
-  // Validate structured output — enabling it without a schema only fails at
-  // run time otherwise ("Node validation failed"). Surface it in the builder.
-  if (data.structured_output?.enabled && !data.structured_output.schema) {
-    errors.push({
-      field: 'structured_output.schema',
-      message: 'Structured output is enabled but no schema is defined',
-      type: 'error',
-    })
-  }
-
-  // Check if there are any errors (not warnings)
-  const hasErrors = errors.filter((e) => e.type === 'error').length > 0
-
-  return { isValid: !hasErrors, errors }
-}
+// The data half (enums, model-config vocabulary, data interface, zod schema,
+// defaults, validator, variable extraction) lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/ai`). This file is the merge site:
+// manifest + the web-only output resolver.
 
 /**
  * Convert a JSON Schema fragment into a `UnifiedVariable`, recursively.
@@ -379,7 +134,7 @@ const getAiOutputVariables = (data: Partial<AiNodeData>, nodeId: string): Unifie
   outputs.push(
     createUnifiedOutputVariable({
       nodeId,
-      path: 'text', // Changed from 'name' to 'path'
+      path: 'text',
       type: BaseType.STRING,
       description: 'The AI-generated response text',
     })
@@ -405,47 +160,20 @@ const getAiOutputVariables = (data: Partial<AiNodeData>, nodeId: string): Unifie
   return outputs
 }
 
-/**
- * Extracts variable IDs from an AI node configuration
- */
-export function extractAIVariableIds(data: AiNodeData): string[] {
-  const uniqueVariableIds = new Set<string>()
+/** Node definition for AI */
+export const aiDefinition: NodeDefinition<AiNodeData> = defineFromManifest(
+  aiManifest as unknown as NodeManifest<AiNodeData>,
+  { outputVariables: getAiOutputVariables as any }
+)
 
-  // Extract from prompt templates — chip ids from the Tiptap doc.
-  data.prompt_template?.forEach((template) => {
-    const ids = collectVariableIds(template.json)
-    ids.forEach((id) => {
-      uniqueVariableIds.add(id)
-    })
-  })
+// Back-compat re-exports so no consumer import churns:
+export {
+  aiNodeDataSchema,
+  extractAIVariableIds,
+  validateAiData,
+} from '@auxx/lib/workflow-engine/client'
 
-  // Extract from file input (only in variable mode)
-  if (data.files?.input && !data.files.isConstant) {
-    if (containsVariableReference(data.files.input)) {
-      const ids = extractVarIdsFromString(data.files.input)
-      ids.forEach((id) => uniqueVariableIds.add(id))
-    } else {
-      uniqueVariableIds.add(data.files.input)
-    }
-  }
-
-  return Array.from(uniqueVariableIds)
-}
-/**
- * Node definition for AI
- */
-export const aiDefinition: NodeDefinition<AiNodeData> = {
-  id: NodeType.AI,
-  category: NodeCategory.TRANSFORM,
-  displayName: 'AI',
-  description: 'AI-powered text generation and processing',
-  icon: 'brain',
-  color: '#8B5CF6', // TRANSFORM category color
-  defaultData: createAiDefaultData(),
-  schema: aiSchema,
-  // validate: validateAiConfig,
-  validator: validateAiData,
-  canRunSingle: true,
-  extractVariables: (data: AiNodeData) => extractAIVariableIds(data),
-  outputVariables: getAiOutputVariables as any,
+/** Factory function to create a new AI default configuration */
+export function createAiDefaultData(): Partial<AiNodeData> {
+  return aiManifest.defaultData() as Partial<AiNodeData>
 }

--- a/apps/web/src/components/workflow/nodes/core/ai/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/ai/types.ts
@@ -1,91 +1,28 @@
 // apps/web/src/components/workflow/nodes/core/ai/types.ts
 
 import type { ToolsetEntry } from '@auxx/lib/agents/client'
-import type { TiptapDoc } from '@auxx/lib/tiptap'
+import type { CatalogAiNodeData } from '@auxx/lib/workflow-engine/client'
 import type { Node } from '@xyflow/react'
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types'
+import type { SpecificNode } from '~/components/workflow/types'
+import type { NodeType } from '~/components/workflow/types/node-types'
 
-/**
- * Prompt roles for AI conversation
- */
-export enum PromptRole {
-  SYSTEM = 'system',
-  USER = 'user',
-  ASSISTANT = 'assistant',
-}
-
-/**
- * AI model modes
- */
-export enum AiModelMode {
-  CHAT = 'chat',
-  COMPLETION = 'completion',
-}
-
-/**
- * AI model providers
- */
-export enum AiModelProvider {
-  OPENAI = 'openai',
-  ANTHROPIC = 'anthropic',
-  GOOGLE = 'google',
-  MISTRAL = 'mistral',
-}
-
-/**
- * AI model completion parameters
- */
-export interface AiCompletionParams {
-  temperature: number
-  max_tokens?: number
-  top_p?: number
-  frequency_penalty?: number
-  presence_penalty?: number
-}
-
-/**
- * AI model configuration
- */
-export interface AiModel {
-  useDefault?: boolean
-  provider: string
-  name: string
-  mode: AiModelMode
-  completion_params: AiCompletionParams
-}
-
-/**
- * Prompt template item. Storage shape after Phase 4: the prompt body is a
- * Tiptap doc (`{ type: 'doc', content: [...] }`) so `variable-node` and
- * `reference` chips round-trip without lossy text serialization.
- *
- * Phase 5 reads `.json` directly via `docToText({ variables, references })`.
- * The legacy `text: string` field is gone — no production users (see
- * `project_no_production_users.md`), hard cut.
- */
-export interface PromptTemplate {
-  role: PromptRole
-  json: TiptapDoc
-}
-
-/**
- * Files configuration for AI node
- */
-export interface AiFiles {
-  enabled: boolean
-  input: string // single file reference (variable ref or file:id constant)
-  isConstant: boolean // true = constant file picker, false = variable reference
-}
-
-export interface StructuredOutputConfig {
-  enabled: boolean
-  schema?: {
-    type: 'object'
-    properties: Record<string, any>
-    required?: string[]
-    additionalProperties?: boolean
-  }
-}
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/ai`, which is also the home of the
+// model-config vocabulary the other AI nodes share); re-exported here so no
+// web import churns. AiNodeData narrows `type` to the web NodeType enum, same
+// as BaseNodeData does over its lib counterpart.
+export type {
+  AiCompletionParams,
+  AiFiles,
+  AiModel,
+  PromptTemplate,
+  StructuredOutputConfig,
+} from '@auxx/lib/workflow-engine/client'
+export {
+  AiModelMode,
+  AiModelProvider,
+  PromptRole,
+} from '@auxx/lib/workflow-engine/client'
 
 /**
  * Re-export the shared ToolsetEntry shape for convenience. The flat AI-node
@@ -99,22 +36,8 @@ export type { ToolsetEntry }
  * Node data for AI nodes — flat tools shape (Phase 3). The legacy
  * `tools: AiToolsConfig` nested block is gone; see the Phase 3 plan.
  */
-export interface AiNodeData extends BaseNodeData {
-  model: AiModel
-  prompt_template: PromptTemplate[]
-  files: AiFiles
-  structured_output: StructuredOutputConfig
-
-  /** Master gate for the entire tool surface on this node. */
-  toolsEnabled?: boolean
-  /** Per-toolset enablement. Mirrors `Agent.toolsets`. */
-  toolsets?: ToolsetEntry[]
-  /** Per-app explicit credential pin. Mirrors `Agent.appAccounts`. */
-  appAccounts?: Record<string, { credId: string }>
-  /** Approval mode reserved for future use; v1 is always `auto`. */
-  approvalMode?: 'auto'
-  /** Default 10 for AI node; agent default is 30. */
-  maxIterations?: number
+export interface AiNodeData extends CatalogAiNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/answer/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/answer/schema.ts
@@ -1,119 +1,16 @@
 // apps/web/src/components/workflow/nodes/core/answer/schema.ts
 
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
-import { NodeType } from '~/components/workflow/types/node-types'
+import { answerManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
 import { BaseType } from '~/components/workflow/types/variable-types'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { AnswerNodeData } from './types'
 
-/**
- * Zod schema for answer node data (flattened structure)
- */
-export const answerNodeDataSchema = baseNodeDataSchema.extend({
-  title: z.string().min(1),
-  description: z.string().optional(),
-  messageType: z.enum(['new', 'reply', 'replyAll']).default('reply'),
-  integrationId: z.string().optional(),
-  recordId: z.string().optional(),
-  toIsAuto: z.boolean().optional(),
-  ccIsAuto: z.boolean().optional(),
-  bccIsAuto: z.boolean().optional(),
-  subjectIsAuto: z.boolean().optional(),
-  to: z.array(z.string()).optional(),
-  toModes: z.array(z.boolean()).optional(),
-  cc: z.array(z.string()).optional(),
-  ccModes: z.array(z.boolean()).optional(),
-  bcc: z.array(z.string()).optional(),
-  bccModes: z.array(z.boolean()).optional(),
-  text: z.string().min(1),
-  subject: z.string().optional(),
-  attachmentFiles: z.array(z.string()).optional(),
-  attachmentFilesModes: z.array(z.boolean()).optional(),
-  saveAsDraft: z.boolean().optional(),
-  test_behavior: z.enum(['default', 'live', 'dry_run', 'draft']).optional(),
-  fieldModes: z.record(z.string(), z.boolean()).optional(),
-})
-
-/**
- * Default configuration for new answer nodes
- */
-export const answerDefaultData: Partial<AnswerNodeData> = {
-  title: 'Send Message',
-  desc: 'Reply to customer',
-  messageType: 'reply',
-  text: '',
-  toIsAuto: true,
-  ccIsAuto: true,
-  bccIsAuto: true,
-  subjectIsAuto: true,
-  to: [],
-  toModes: [],
-  cc: [],
-  ccModes: [],
-  bcc: [],
-  bccModes: [],
-  subject: '',
-  attachmentFiles: [],
-  attachmentFilesModes: [],
-  saveAsDraft: false,
-  test_behavior: 'default',
-}
-
-/**
- * Validation function for answer configuration
- */
-export const validateAnswerConfig = (data: AnswerNodeData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Validate title
-  if (!data.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Validate text content
-  if (!data.text?.trim()) {
-    errors.push({ field: 'text', message: 'Message content is required', type: 'error' })
-  }
-
-  const isReply = data.messageType === 'reply' || data.messageType === 'replyAll'
-
-  if (data.messageType === 'new') {
-    // For new messages, integration is required
-    if (!data.integrationId) {
-      errors.push({
-        field: 'integrationId',
-        message: 'Integration is required for new messages',
-        type: 'error',
-      })
-    }
-    // To and Subject always required for new messages
-    if (!data.to || data.to.length === 0) {
-      errors.push({ field: 'to', message: 'At least one recipient is required', type: 'error' })
-    }
-  } else if (isReply) {
-    // recordId is always required for replies
-    if (!data.recordId) {
-      errors.push({
-        field: 'recordId',
-        message: 'Reply target is required',
-        type: 'error',
-      })
-    }
-    // To only required when not auto-resolved
-    if (data.toIsAuto === false && (!data.to || data.to.length === 0)) {
-      errors.push({ field: 'to', message: 'At least one recipient is required', type: 'error' })
-    }
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
+// The data half (data interface, zod schema, defaults, validator, variable
+// extraction) lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/answer`). This file is the merge
+// site: manifest + the web-only output resolver.
 
 /**
  * Define output variables for answer node
@@ -171,71 +68,18 @@ const getAnswerOutputVariables = (data: AnswerNodeData, nodeId: string): any[] =
   ]
 }
 
-export function extractAnswerVariables(data: AnswerNodeData): string[] {
-  const uniqueVariables = new Set<string>()
+/** Node definition for answer */
+export const answerDefinition: NodeDefinition<AnswerNodeData> = defineFromManifest(
+  answerManifest as unknown as NodeManifest<AnswerNodeData>,
+  { outputVariables: getAnswerOutputVariables as any }
+)
 
-  // Extract from text field (rich editor content)
-  if (data.text) {
-    extractVarIdsFromString(data.text).forEach((varId) => uniqueVariables.add(varId))
-  }
+// Back-compat re-exports so no consumer import churns:
+export {
+  answerNodeDataSchema,
+  extractAnswerVariables,
+  validateAnswerConfig,
+} from '@auxx/lib/workflow-engine/client'
 
-  // Extract from subject (only when not auto-resolved)
-  if (data.subject && data.subjectIsAuto === false) {
-    extractVarIdsFromString(data.subject).forEach((varId) => uniqueVariables.add(varId))
-  }
-
-  // Extract from email arrays (only when not auto-resolved)
-  if (data.toIsAuto === false && data.to && Array.isArray(data.to)) {
-    data.to.forEach((email) => {
-      extractVarIdsFromString(email).forEach((varId) => uniqueVariables.add(varId))
-    })
-  }
-  if (data.ccIsAuto === false && data.cc && Array.isArray(data.cc)) {
-    data.cc.forEach((email) => {
-      extractVarIdsFromString(email).forEach((varId) => uniqueVariables.add(varId))
-    })
-  }
-  if (data.bccIsAuto === false && data.bcc && Array.isArray(data.bcc)) {
-    data.bcc.forEach((email) => {
-      extractVarIdsFromString(email).forEach((varId) => uniqueVariables.add(varId))
-    })
-  }
-
-  // Extract from recordId for replies (PICKER mode stores raw variable ID, not {{...}} wrapped)
-  if (data.recordId) {
-    const extracted = extractVarIdsFromString(data.recordId)
-    if (extracted.length > 0) {
-      extracted.forEach((varId) => uniqueVariables.add(varId))
-    } else if (data.recordId.includes('.')) {
-      // Raw variable ID from PICKER mode (e.g. "nodeId.thread")
-      uniqueVariables.add(data.recordId)
-    }
-  }
-
-  // Extract from attachment files
-  if (data.attachmentFiles && Array.isArray(data.attachmentFiles)) {
-    data.attachmentFiles.forEach((file) => {
-      extractVarIdsFromString(file).forEach((varId) => uniqueVariables.add(varId))
-    })
-  }
-
-  return Array.from(uniqueVariables)
-}
-
-/**
- * Node definition for answer
- */
-export const answerDefinition: NodeDefinition<AnswerNodeData> = {
-  id: NodeType.ANSWER,
-  category: NodeCategory.ACTION,
-  displayName: 'Send Answer',
-  description: 'Send reply to customer email',
-  icon: 'send',
-  color: '#10b981', // ACTION category color
-  defaultData: answerDefaultData,
-  schema: answerNodeDataSchema,
-  validator: validateAnswerConfig,
-  canRunSingle: true,
-  extractVariables: extractAnswerVariables,
-  outputVariables: getAnswerOutputVariables as any,
-}
+/** Default configuration for new answer nodes */
+export const answerDefaultData = answerManifest.defaultData() as Partial<AnswerNodeData>

--- a/apps/web/src/components/workflow/nodes/core/answer/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/answer/types.ts
@@ -1,47 +1,19 @@
 // apps/web/src/components/workflow/nodes/core/answer/types.ts
 
-import type { BaseNodeData, ExecutionResult, SpecificNode } from '../../../types'
+import type { CatalogAnswerNodeData } from '@auxx/lib/workflow-engine/client'
+import type { ExecutionResult, SpecificNode } from '../../../types'
+import type { NodeType } from '../../../types/node-types'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/answer`); AnswerNodeData narrows
+// `type` to the web NodeType enum, same as BaseNodeData does over its lib
+// counterpart.
 
 /**
  * Node data for answer nodes with flattened structure
  */
-export interface AnswerNodeData extends BaseNodeData {
-  // 'new' = compose fresh email, 'reply' = reply to sender, 'replyAll' = reply to all
-  messageType: 'new' | 'reply' | 'replyAll'
-
-  integrationId?: string // Required for 'new', auto-derived for reply/replyAll
-  recordId?: string // Format: "entityDefinitionId:id" (e.g. "thread:abc123", "message:xyz789")
-  // Required for reply/replyAll. Replaces old resourceId + resourceType.
-
-  // Per-field auto-resolve toggles (reply/replyAll only, ignored for 'new')
-  // true (default): system auto-resolves from thread at execution time
-  // false: user provides the value explicitly
-  toIsAuto?: boolean
-  ccIsAuto?: boolean
-  bccIsAuto?: boolean
-  subjectIsAuto?: boolean
-
-  to?: string[]
-  toModes?: boolean[]
-  cc?: string[]
-  ccModes?: boolean[]
-  bcc?: string[]
-  bccModes?: boolean[]
-  text: string
-  subject?: string
-  /**
-   * Attachment picker rows — a constant row is a `file:<id>` reference, a
-   * variable row a `{{…}}` reference. `attachmentFilesModes` marks which is
-   * which, positionally. The engine resolves both to file ids and hands them to
-   * the send path as `attachmentIds`.
-   */
-  attachmentFiles?: string[]
-  attachmentFilesModes?: boolean[]
-  saveAsDraft?: boolean // When true, creates a draft instead of sending
-  // Per-node send behavior override: default = dry-run during test runs,
-  // live = always send, dry_run = never send, draft = save as thread draft
-  test_behavior?: 'default' | 'live' | 'dry_run' | 'draft'
-  fieldModes?: Record<string, boolean> // Track constant/variable mode per field
+export interface AnswerNodeData extends CatalogAnswerNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/information-extractor/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/information-extractor/schema.ts
@@ -1,233 +1,17 @@
 // apps/web/src/components/workflow/nodes/core/information-extractor/schema.ts
 
-import { AI_NODE_CONSTANTS } from '@auxx/lib/workflow-engine/constants'
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { NodeType } from '~/components/workflow/types/node-types'
+import { informationExtractorManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
 import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { schemaToUnifiedVariable } from '~/components/workflow/utils/schema-to-variable'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { InformationExtractorNodeData } from './types'
 
-/**
- * Zod schema for AI model completion parameters
- * Reused from AI node
- */
-export const completionParamsSchema = z.object({
-  temperature: z
-    .number()
-    .min(AI_NODE_CONSTANTS.TEMPERATURE.min)
-    .max(AI_NODE_CONSTANTS.TEMPERATURE.max)
-    .default(AI_NODE_CONSTANTS.TEMPERATURE.default),
-  max_tokens: z
-    .number()
-    .min(AI_NODE_CONSTANTS.MAX_TOKENS.min)
-    .max(AI_NODE_CONSTANTS.MAX_TOKENS.max)
-    .optional(),
-  top_p: z.number().min(AI_NODE_CONSTANTS.TOP_P.min).max(AI_NODE_CONSTANTS.TOP_P.max).optional(),
-  frequency_penalty: z
-    .number()
-    .min(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.min)
-    .max(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.max)
-    .optional(),
-  presence_penalty: z
-    .number()
-    .min(AI_NODE_CONSTANTS.PRESENCE_PENALTY.min)
-    .max(AI_NODE_CONSTANTS.PRESENCE_PENALTY.max)
-    .optional(),
-})
-
-/**
- * Zod schema for model configuration
- */
-const modelSchema = z.object({
-  useDefault: z.boolean().optional(),
-  provider: z.string(),
-  name: z.string(),
-  mode: z.enum(['chat', 'completion']).default('chat'),
-  completion_params: completionParamsSchema.optional(),
-})
-
-/**
- * Zod schema for vision configuration
- */
-const visionSchema = z.object({ enabled: z.boolean().default(false) })
-
-/**
- * Zod schema for instruction configuration
- */
-const instructionSchema = z.object({
-  enabled: z.boolean().default(false),
-  text: z.string().default(''), // Preprocessed text
-  // editorContent: z.string().optional(), // Tiptap JSON
-})
-
-/**
- * Zod schema for structured output configuration
- */
-const structuredOutputSchema = z.object({
-  enabled: z.boolean().default(false),
-  schema: z
-    .object({
-      type: z.literal('object'),
-      properties: z.record(z.string(), z.any()),
-      required: z.array(z.string()).optional(),
-      additionalProperties: z.boolean().optional(),
-    })
-    .optional(),
-})
-
-/**
- * Main schema for information extractor configuration
- */
-export const informationExtractorSchema = z.object({
-  title: z.string().default('Information Extractor'),
-  desc: z.string().optional(),
-  model: modelSchema,
-  text: z.string().default(''), // Preprocessed text
-  textEditorContent: z.string().optional(), // Tiptap JSON
-  structured_output: structuredOutputSchema,
-  vision: visionSchema,
-  instruction: instructionSchema,
-})
-
-/**
- * Factory function to create default data
- */
-export const createInformationExtractorDefaultData = (defaultModel?: {
-  provider: string
-  model: string
-  mode: 'chat' | 'completion'
-  completionParams: Record<string, any>
-}): Partial<InformationExtractorNodeData> => ({
-  title: 'Information Extractor',
-  desc: 'Extract structured information from text using AI',
-  model: defaultModel
-    ? {
-        provider: defaultModel.provider,
-        name: defaultModel.model,
-        mode: defaultModel.mode,
-        completion_params: {
-          temperature: 0.3, // Lower temperature for extraction - override default
-          ...defaultModel.completionParams,
-        },
-      }
-    : {
-        useDefault: true,
-        provider: '',
-        name: '',
-        mode: 'chat',
-        completion_params: { temperature: 0.3 },
-      },
-  text: '',
-  // textEditorContent: undefined,
-  structured_output: { enabled: false, schema: undefined },
-  vision: { enabled: false },
-  instruction: { enabled: false, text: '' },
-})
-
-/**
- * Validation function for information extractor data
- */
-export function validateInformationExtractor(data: InformationExtractorNodeData): ValidationResult {
-  try {
-    informationExtractorSchema.parse(data)
-
-    // Validate model — only require provider/name when NOT using default
-    if (!data.model.useDefault && (!data.model.provider || !data.model.name)) {
-      return {
-        isValid: false,
-        errors: [{ field: 'model', message: 'Please select an AI model', type: 'error' as const }],
-      }
-    }
-
-    if (!data.text.trim()) {
-      return {
-        isValid: false,
-        errors: [
-          {
-            field: 'text',
-            message: 'Please provide text to extract information from',
-            type: 'error' as const,
-          },
-        ],
-      }
-    }
-
-    if (data.structured_output.enabled && !data.structured_output.schema) {
-      return {
-        isValid: false,
-        errors: [
-          {
-            field: 'structured_output',
-            message: 'Please configure the extraction schema',
-            type: 'error' as const,
-          },
-        ],
-      }
-    }
-
-    // Validate schema field count if enabled
-    if (data.structured_output.enabled && data.structured_output.schema?.properties) {
-      const fieldCount = Object.keys(data.structured_output.schema.properties).length
-      if (fieldCount > AI_NODE_CONSTANTS.INFO_EXTRACTOR.MAX_FIELDS) {
-        return {
-          isValid: false,
-          errors: [
-            {
-              field: 'structured_output',
-              message: `Cannot exceed ${AI_NODE_CONSTANTS.INFO_EXTRACTOR.MAX_FIELDS} fields in the extraction schema`,
-              type: 'error' as const,
-            },
-          ],
-        }
-      }
-    }
-
-    return { isValid: true, errors: [] }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return {
-        isValid: false,
-        errors: error.issues.map((e) => ({
-          field: e.path.join('.'),
-          message: e.message,
-          type: 'error' as const,
-        })),
-      }
-    }
-    return {
-      isValid: false,
-      errors: [{ field: 'general', message: 'Invalid configuration', type: 'error' as const }],
-    }
-  }
-}
-
-/**
- * Extract variables from data for single run
- */
-export function extractInformationExtractorVariables(data: InformationExtractorNodeData): string[] {
-  const uniqueVariables = new Set<string>()
-
-  // Extract from main text
-  extractVarIdsFromString(data.text).forEach((varId) => {
-    uniqueVariables.add(varId)
-  })
-
-  // Extract from instruction if enabled
-  if (data.instruction.enabled) {
-    extractVarIdsFromString(data.instruction.text).forEach((varId) => {
-      uniqueVariables.add(varId)
-    })
-  }
-
-  return Array.from(uniqueVariables)
-}
+// The data half (config types, zod schemas, defaults, validator, variable
+// extraction) lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/information-extractor`). This file
+// is the merge site: manifest + the web-only output resolver.
 
 /**
  * Define output variables for information extractor node
@@ -265,20 +49,20 @@ const getInformationExtractorOutputVariables = (
   return outputs
 }
 
-/**
- * Node definition for information extractor
- */
-export const informationExtractorDefinition: NodeDefinition<InformationExtractorNodeData> = {
-  id: NodeType.INFORMATION_EXTRACTOR,
-  category: NodeCategory.TRANSFORM,
-  displayName: 'Information Extractor',
-  description: 'Extract structured information from text using AI with custom schemas',
-  icon: 'file-json', // More appropriate icon for extraction
-  color: '#8B5CF6', // TRANSFORM category color
-  schema: informationExtractorSchema,
-  defaultData: createInformationExtractorDefaultData(),
-  canRunSingle: true,
-  validator: validateInformationExtractor,
-  extractVariables: extractInformationExtractorVariables,
-  outputVariables: getInformationExtractorOutputVariables,
-}
+/** Node definition for information extractor */
+export const informationExtractorDefinition: NodeDefinition<InformationExtractorNodeData> =
+  defineFromManifest(
+    informationExtractorManifest as unknown as NodeManifest<InformationExtractorNodeData>,
+    { outputVariables: getInformationExtractorOutputVariables }
+  )
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  completionParamsSchema,
+  informationExtractorSchema,
+  validateInformationExtractor,
+} from '@auxx/lib/workflow-engine/client'
+
+/** Factory function to create default data */
+export const createInformationExtractorDefaultData = (): Partial<InformationExtractorNodeData> =>
+  informationExtractorManifest.defaultData() as Partial<InformationExtractorNodeData>

--- a/apps/web/src/components/workflow/nodes/core/information-extractor/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/information-extractor/types.ts
@@ -1,8 +1,23 @@
 // apps/web/src/components/workflow/nodes/core/information-extractor/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types'
+import type { CatalogInformationExtractorNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types'
+import type { NodeType } from '~/components/workflow/types/node-types'
 import type { SchemaRoot } from '~/components/workflow/ui/json-schema-types'
 import type { UnifiedVariable } from '../if-else'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/information-extractor`);
+// re-exported here so no web import churns. The node data narrows `type` to
+// the web NodeType enum and `structured_output.schema` to the schema editor's
+// `SchemaRoot` (the catalog keeps that member loose for exactly this reason).
+export type {
+  InformationExtractorInstruction,
+  InformationExtractorModel,
+  InformationExtractorVision,
+} from '@auxx/lib/workflow-engine/client'
+
+import type { InformationExtractorModel } from '@auxx/lib/workflow-engine/client'
 
 /**
  * Structured output configuration
@@ -13,48 +28,11 @@ export interface StructuredOutputConfig {
 }
 
 /**
- * Model configuration
- */
-export interface InformationExtractorModel {
-  useDefault?: boolean
-  provider: string
-  name: string
-  mode: 'chat' | 'completion'
-  completion_params?: {
-    temperature: number
-    max_tokens?: number
-    top_p?: number
-    frequency_penalty?: number
-    presence_penalty?: number
-  }
-}
-
-/**
- * Vision configuration
- */
-export interface InformationExtractorVision {
-  enabled: boolean
-}
-
-/**
- * Instruction configuration
- */
-export interface InformationExtractorInstruction {
-  enabled: boolean
-  text: string
-  // editorContent?: string
-}
-
-/**
  * Node data interface - flattened structure
  */
-export interface InformationExtractorNodeData extends BaseNodeData {
-  model: InformationExtractorModel
-  text: string // Preprocessed text with variables
-  // textEditorContent?: string // Tiptap JSON content
+export interface InformationExtractorNodeData extends CatalogInformationExtractorNodeData {
+  type: NodeType
   structured_output: StructuredOutputConfig
-  vision: InformationExtractorVision
-  instruction: InformationExtractorInstruction
 }
 
 /**
@@ -87,6 +65,5 @@ export interface InformationExtractorContextValue {
   updateInstruction: (enabled: boolean, text?: string) => void
 
   // Utilities
-  // preprocessPrompt: (editorContent: string) => { text: string; variables: string[] }
   getOutputVariables: () => UnifiedVariable[]
 }

--- a/apps/web/src/components/workflow/nodes/core/text-classifier/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/text-classifier/schema.ts
@@ -1,251 +1,16 @@
 // apps/web/src/components/workflow/nodes/core/text-classifier/schema.ts
 
-import { AI_NODE_CONSTANTS } from '@auxx/lib/workflow-engine/constants'
-import { z } from 'zod'
-import {
-  BaseType,
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { NodeType } from '~/components/workflow/types/node-types'
-import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
+import { type NodeManifest, textClassifierManifest } from '@auxx/lib/workflow-engine/client'
+import { BaseType, type NodeDefinition } from '~/components/workflow/types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { AiModelMode, type TextClassifierNodeData } from './types'
-import { generateCategoryId } from './utils'
+import { defineFromManifest } from '../../define-from-manifest'
+import type { TextClassifierNodeData } from './types'
 
-/**
- * Zod schema for AI model completion parameters
- */
-const completionParamsSchema = z.object({
-  temperature: z
-    .number()
-    .min(AI_NODE_CONSTANTS.TEMPERATURE.min)
-    .max(AI_NODE_CONSTANTS.TEMPERATURE.max)
-    .default(AI_NODE_CONSTANTS.TEMPERATURE.default),
-  max_tokens: z
-    .number()
-    .min(AI_NODE_CONSTANTS.MAX_TOKENS.min)
-    .max(AI_NODE_CONSTANTS.MAX_TOKENS.max)
-    .optional(),
-  top_p: z.number().min(AI_NODE_CONSTANTS.TOP_P.min).max(AI_NODE_CONSTANTS.TOP_P.max).optional(),
-  frequency_penalty: z
-    .number()
-    .min(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.min)
-    .max(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.max)
-    .optional(),
-  presence_penalty: z
-    .number()
-    .min(AI_NODE_CONSTANTS.PRESENCE_PENALTY.min)
-    .max(AI_NODE_CONSTANTS.PRESENCE_PENALTY.max)
-    .optional(),
-})
-
-/**
- * Zod schema for model configuration
- */
-const modelSchema = z.object({
-  useDefault: z.boolean().optional(),
-  provider: z.string(),
-  name: z.string(),
-  mode: z.enum(AiModelMode).default(AiModelMode.CHAT),
-  completion_params: completionParamsSchema.optional(),
-})
-
-/**
- * Zod schema for category
- */
-const categorySchema = z.object({
-  id: z.string(),
-  name: z.string().max(AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_NAME_MAX_LENGTH),
-  description: z
-    .string()
-    .max(AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_DESCRIPTION_MAX_LENGTH)
-    .optional(), // Preprocessed text
-  // editorContent: z.string().optional(), // Tiptap JSON
-  text: z.string().default(''), // Preprocessed text
-})
-
-/**
- * Zod schema for vision configuration
- */
-const visionSchema = z.object({ enabled: z.boolean().default(false) })
-
-/**
- * Zod schema for instruction configuration
- */
-const instructionSchema = z.object({
-  enabled: z.boolean().default(false),
-  text: z.string().default(''), // Preprocessed text
-  // editorContent: z.string().optional(), // Tiptap JSON
-})
-
-/**
- * Main schema for text classifier configuration
- */
-export const textClassifierSchema = z.object({
-  title: z.string().default('Text Classifier'),
-  desc: z.string().optional(),
-  model: modelSchema,
-  text: z.string().default(''), // Preprocessed text
-  // textEditorContent: z.string().optional(), // Tiptap JSON
-  categories: z.array(categorySchema).min(1),
-  vision: visionSchema,
-  instruction: instructionSchema,
-  outputMode: z.enum(['branches', 'variable']).default('branches'),
-})
-
-/**
- * Factory function to create a new text classifier default data
- * This ensures each node gets its own deep copy of the data
- */
-export const createTextClassifierDefaultData = (): Partial<TextClassifierNodeData> => ({
-  title: 'Text Classifier',
-  desc: 'Classify text into predefined categories',
-  model: {
-    useDefault: true,
-    provider: '',
-    name: '',
-    mode: AiModelMode.CHAT,
-    completion_params: { temperature: AI_NODE_CONSTANTS.TEMPERATURE.default },
-  },
-  text: '',
-  // textEditorContent: '',
-  categories: [
-    {
-      id: generateCategoryId(),
-      name: 'Category 1',
-      description: '',
-      text: '',
-      // editorContent: '',
-    },
-  ],
-  vision: { enabled: false },
-  instruction: { enabled: false, text: '' },
-  outputMode: 'branches' as const,
-})
-
-/**
- * Validation function for text classifier data
- */
-export const validateTextClassifierData = (data: TextClassifierNodeData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-  // Validate title
-  if (!data.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Validate model — only require provider/name when NOT using default
-  if (!data.model?.useDefault) {
-    if (!data.model?.provider?.trim()) {
-      errors.push({ field: 'model.provider', message: 'Model provider is required', type: 'error' })
-    }
-
-    if (!data.model?.name?.trim()) {
-      errors.push({ field: 'model.name', message: 'Model name is required', type: 'error' })
-    }
-  }
-
-  // Validate text to classify
-  if (!data.text?.trim()) {
-    errors.push({ field: 'text', message: 'Text to classify is required', type: 'error' })
-  }
-
-  // Validate categories
-  if (!data.categories || data.categories.length === 0) {
-    errors.push({
-      field: 'categories',
-      message: 'At least one category is required',
-      type: 'error',
-    })
-  } else if (data.categories.length < AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MIN_CATEGORIES) {
-    errors.push({
-      field: 'categories',
-      message: `At least ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MIN_CATEGORIES} categories are required`,
-      type: 'error',
-    })
-  } else if (data.categories.length > AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MAX_CATEGORIES) {
-    errors.push({
-      field: 'categories',
-      message: `Cannot exceed ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MAX_CATEGORIES} categories`,
-      type: 'error',
-    })
-  }
-
-  // Validate each category
-  data.categories?.forEach((category, index) => {
-    if (!category.name?.trim()) {
-      errors.push({
-        field: `categories.${index}.name`,
-        message: 'Category name is required',
-        type: 'error',
-      })
-    } else if (category.name.length > AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_NAME_MAX_LENGTH) {
-      errors.push({
-        field: `categories.${index}.name`,
-        message: `Category name cannot exceed ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_NAME_MAX_LENGTH} characters`,
-        type: 'error',
-      })
-    }
-
-    // Category description is required
-    if (!category.description?.trim()) {
-      errors.push({
-        field: `categories.${index}.description`,
-        message: 'Category description is recommended for better classification',
-        type: 'warning',
-      })
-    } else if (
-      category.description.length >
-      AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_DESCRIPTION_MAX_LENGTH
-    ) {
-      errors.push({
-        field: `categories.${index}.description`,
-        message: `Category description cannot exceed ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_DESCRIPTION_MAX_LENGTH} characters`,
-        type: 'error',
-      })
-    }
-  })
-
-  // Add warnings for optional fields
-  if (!data.desc?.trim()) {
-    errors.push({
-      field: 'desc',
-      message: 'Consider adding a description for better documentation',
-      type: 'warning',
-    })
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
-
-/**
- * Extract variables from text classifier data
- */
-const extractTextClassifierVariables = (data: TextClassifierNodeData): string[] => {
-  const uniqueVariables = new Set<string>()
-
-  // Extract from main text
-  extractVarIdsFromString(data.text).forEach((varId) => {
-    uniqueVariables.add(varId)
-  })
-
-  // Extract from category descriptions
-  data.categories?.forEach((category) => {
-    extractVarIdsFromString(category.text).forEach((varId) => {
-      uniqueVariables.add(varId)
-    })
-  })
-
-  // Extract from instructions if enabled
-  if (data.instruction?.enabled) {
-    extractVarIdsFromString(data.instruction.text).forEach((varId) => {
-      uniqueVariables.add(varId)
-    })
-  }
-
-  return Array.from(uniqueVariables)
-}
+// The data half (config types, zod schema, defaults, validator, variable
+// extraction — and the category-branch derivation as `connection.branches`)
+// lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/text-classifier`). This file is
+// the merge site: manifest + the web-only output resolver.
 
 /**
  * Define output variables for text classifier node
@@ -264,33 +29,34 @@ const getTextClassifierOutputVariables = (data: TextClassifierNodeData, nodeId: 
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'confidence', // Changed from 'name' to 'path'
+      path: 'confidence',
       type: BaseType.NUMBER,
       description: 'Confidence score of the classification (0-1)',
     }),
     createUnifiedOutputVariable({
       nodeId,
-      path: 'reasoning', // Changed from 'name' to 'path'
+      path: 'reasoning',
       type: BaseType.STRING,
       description: 'AI explanation for the classification',
     }),
   ]
 }
 
+/** Node definition for text classifier */
+export const textClassifierDefinition: NodeDefinition<TextClassifierNodeData> = defineFromManifest(
+  textClassifierManifest as unknown as NodeManifest<TextClassifierNodeData>,
+  { outputVariables: getTextClassifierOutputVariables as any }
+)
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  textClassifierSchema,
+  validateTextClassifierData,
+} from '@auxx/lib/workflow-engine/client'
+
 /**
- * Node definition for text classifier
+ * Factory function to create a new text classifier default data
+ * This ensures each node gets its own deep copy of the data
  */
-export const textClassifierDefinition: NodeDefinition<TextClassifierNodeData> = {
-  id: NodeType.TEXT_CLASSIFIER,
-  category: NodeCategory.CONDITION,
-  displayName: 'Text Classifier',
-  description: 'Classify text into predefined categories using AI',
-  icon: 'tags',
-  color: '#f59e0b', // CONDITION category color
-  defaultData: createTextClassifierDefaultData(),
-  schema: textClassifierSchema,
-  validator: validateTextClassifierData,
-  canRunSingle: true,
-  extractVariables: extractTextClassifierVariables,
-  outputVariables: getTextClassifierOutputVariables as any,
-}
+export const createTextClassifierDefaultData = (): Partial<TextClassifierNodeData> =>
+  textClassifierManifest.defaultData() as Partial<TextClassifierNodeData>

--- a/apps/web/src/components/workflow/nodes/core/text-classifier/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/text-classifier/types.ts
@@ -1,28 +1,23 @@
 // apps/web/src/components/workflow/nodes/core/text-classifier/types.ts
 
-import type { TargetBranch } from '~/components/workflow/types'
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { CatalogTextClassifierNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
 import { AiModelMode } from '../ai/types'
 
-export type TextClassifierOutputMode = 'branches' | 'variable'
-
-/**
- * Text Classifier node data interface - flattened structure
- */
-export interface TextClassifierNodeData extends BaseNodeData {
-  model: ModelConfig
-  text: string // Preprocessed text
-  categories: Category[]
-  vision: VisionConfig
-  instruction: InstructionConfig
-  outputMode?: TextClassifierOutputMode
-  _targetBranches?: TargetBranch[]
-}
-
-/**
- * Full Text Classifier node type for React Flow
- */
-export type TextClassifierNode = SpecificNode<'text-classifier', TextClassifierNodeData>
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/text-classifier`); re-exported
+// here under the historical local names so no web import churns.
+// TextClassifierNodeData narrows `type` to the web NodeType enum.
+export type {
+  ClassificationResult,
+  TextClassifierCategory as Category,
+  TextClassifierCompletionParams as CompletionParams,
+  TextClassifierInstructionConfig as InstructionConfig,
+  TextClassifierModelConfig as ModelConfig,
+  TextClassifierOutputMode,
+  TextClassifierVisionConfig as VisionConfig,
+} from '@auxx/lib/workflow-engine/client'
 
 /**
  * Model mode enum. Re-exported from the AI node rather than redeclared —
@@ -32,59 +27,13 @@ export type TextClassifierNode = SpecificNode<'text-classifier', TextClassifierN
 export { AiModelMode }
 
 /**
- * Model configuration interface
+ * Text Classifier node data interface - flattened structure
  */
-export interface ModelConfig {
-  useDefault?: boolean
-  provider: string
-  name: string
-  mode: AiModelMode
-  completion_params?: CompletionParams
+export interface TextClassifierNodeData extends CatalogTextClassifierNodeData {
+  type: NodeType
 }
 
 /**
- * Completion parameters interface
+ * Full Text Classifier node type for React Flow
  */
-export interface CompletionParams {
-  temperature?: number
-  max_tokens?: number
-  top_p?: number
-  frequency_penalty?: number
-  presence_penalty?: number
-}
-
-/**
- * Category interface for classification
- */
-export interface Category {
-  id: string
-  name: string
-  description?: string // Preprocessed text with {{variables}}
-  text: string
-  // editorContent?: string        // Tiptap JSON content
-}
-
-/**
- * Vision configuration interface
- */
-export interface VisionConfig {
-  enabled: boolean
-}
-
-/**
- * Instruction configuration interface
- */
-export interface InstructionConfig {
-  enabled: boolean
-  text: string // Preprocessed text
-  // editorContent?: string // Tiptap JSON content
-}
-
-/**
- * Classification result interface (for backend processing)
- */
-export interface ClassificationResult {
-  category: string
-  confidence: number
-  reasoning: string
-}
+export type TextClassifierNode = SpecificNode<'text-classifier', TextClassifierNodeData>

--- a/packages/lib/src/workflow-engine/catalog/nodes/ai.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/ai.ts
@@ -1,0 +1,433 @@
+// packages/lib/src/workflow-engine/catalog/nodes/ai.ts
+
+import { z } from 'zod'
+import type { ToolsetEntry } from '../../../agents/client'
+import { collectVariableIds, isNonEmptyDoc, type TiptapDoc } from '../../../tiptap'
+import { AI_NODE_CONSTANTS } from '../../constants'
+import type { BaseNodeData } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import { containsVariableReference, extractVarIdsFromString } from '../variable-inference'
+
+/**
+ * The ai node's catalog manifest — and the home of the model-config vocabulary
+ * (`PromptRole`, `AiModelMode`, `AiCompletionParams`, `completionParamsSchema`,
+ * `structuredOutputSchema`) that text-classifier and information-extractor
+ * share. `AiModelMode` in particular must exist ONCE: TS enums are nominal, so
+ * a second declaration with identical members is a different, incompatible
+ * type at every boundary the AI nodes share.
+ *
+ * The deprecated duplicate `aiSchema` (zero consumers; the old definition
+ * pointed at it while the flattened `aiNodeDataSchema` was the real shape) was
+ * deleted during the move.
+ */
+
+/**
+ * Prompt roles for AI conversation
+ */
+export enum PromptRole {
+  SYSTEM = 'system',
+  USER = 'user',
+  ASSISTANT = 'assistant',
+}
+
+/**
+ * AI model modes
+ */
+export enum AiModelMode {
+  CHAT = 'chat',
+  COMPLETION = 'completion',
+}
+
+/**
+ * AI model providers
+ */
+export enum AiModelProvider {
+  OPENAI = 'openai',
+  ANTHROPIC = 'anthropic',
+  GOOGLE = 'google',
+  MISTRAL = 'mistral',
+}
+
+/**
+ * AI model completion parameters
+ */
+export interface AiCompletionParams {
+  temperature: number
+  max_tokens?: number
+  top_p?: number
+  frequency_penalty?: number
+  presence_penalty?: number
+}
+
+/**
+ * AI model configuration
+ */
+export interface AiModel {
+  useDefault?: boolean
+  provider: string
+  name: string
+  mode: AiModelMode
+  completion_params: AiCompletionParams
+}
+
+/**
+ * Prompt template item. Storage shape after Phase 4: the prompt body is a
+ * Tiptap doc (`{ type: 'doc', content: [...] }`) so `variable-node` and
+ * `reference` chips round-trip without lossy text serialization.
+ *
+ * Phase 5 reads `.json` directly via `docToText({ variables, references })`.
+ * The legacy `text: string` field is gone — no production users (see
+ * `project_no_production_users.md`), hard cut.
+ */
+export interface PromptTemplate {
+  role: PromptRole
+  json: TiptapDoc
+}
+
+/**
+ * Files configuration for AI node
+ */
+export interface AiFiles {
+  enabled: boolean
+  input: string // single file reference (variable ref or file:id constant)
+  isConstant: boolean // true = constant file picker, false = variable reference
+}
+
+export interface StructuredOutputConfig {
+  enabled: boolean
+  schema?: {
+    type: 'object'
+    properties: Record<string, any>
+    required?: string[]
+    additionalProperties?: boolean
+  }
+}
+
+/**
+ * Node data for AI nodes — flat tools shape (Phase 3). The legacy
+ * `tools: AiToolsConfig` nested block is gone; see the Phase 3 plan.
+ * `toolsets` mirrors `Agent.toolsets` so the agent-framework picker dialog and
+ * the back-end `filterToolsByToolsets` pipeline work without translation.
+ */
+export interface AiNodeData extends BaseNodeData {
+  model: AiModel
+  prompt_template: PromptTemplate[]
+  files: AiFiles
+  structured_output: StructuredOutputConfig
+
+  /** Master gate for the entire tool surface on this node. */
+  toolsEnabled?: boolean
+  /** Per-toolset enablement. Mirrors `Agent.toolsets`. */
+  toolsets?: ToolsetEntry[]
+  /** Per-app explicit credential pin. Mirrors `Agent.appAccounts`. */
+  appAccounts?: Record<string, { credId: string }>
+  /** Approval mode reserved for future use; v1 is always `auto`. */
+  approvalMode?: 'auto'
+  /** Default 10 for AI node; agent default is 30. */
+  maxIterations?: number
+}
+
+export const EMPTY_PROMPT_DOC: TiptapDoc = { type: 'doc', content: [{ type: 'paragraph' }] }
+
+/**
+ * Zod schema for AI model completion parameters.
+ * Shared by text-classifier and information-extractor.
+ */
+export const completionParamsSchema = z.object({
+  temperature: z
+    .number()
+    .min(AI_NODE_CONSTANTS.TEMPERATURE.min)
+    .max(AI_NODE_CONSTANTS.TEMPERATURE.max)
+    .default(AI_NODE_CONSTANTS.TEMPERATURE.default),
+  max_tokens: z
+    .number()
+    .min(AI_NODE_CONSTANTS.MAX_TOKENS.min)
+    .max(AI_NODE_CONSTANTS.MAX_TOKENS.max)
+    .optional(),
+  top_p: z.number().min(AI_NODE_CONSTANTS.TOP_P.min).max(AI_NODE_CONSTANTS.TOP_P.max).optional(),
+  frequency_penalty: z
+    .number()
+    .min(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.min)
+    .max(AI_NODE_CONSTANTS.FREQUENCY_PENALTY.max)
+    .optional(),
+  presence_penalty: z
+    .number()
+    .min(AI_NODE_CONSTANTS.PRESENCE_PENALTY.min)
+    .max(AI_NODE_CONSTANTS.PRESENCE_PENALTY.max)
+    .optional(),
+})
+
+/**
+ * Zod schema for AI model
+ */
+const modelSchema = z.object({
+  useDefault: z.boolean().optional(),
+  provider: z.string(),
+  name: z.string(),
+  mode: z.enum(AiModelMode).default(AiModelMode.CHAT),
+  completion_params: completionParamsSchema,
+})
+
+/**
+ * Zod schema for prompt template. Phase 4 storage shape: a Tiptap doc
+ * (`{ type: 'doc', content: [...] }`) — see `PromptTemplate` above.
+ */
+const tiptapDocSchema = z
+  .object({
+    type: z.literal('doc'),
+    content: z.array(z.any()).optional(),
+  })
+  .passthrough()
+
+const promptTemplateSchema = z.object({ role: z.enum(PromptRole), json: tiptapDocSchema })
+
+/**
+ * Zod schema for AI files
+ */
+const filesSchema = z.object({
+  enabled: z.boolean().default(false),
+  input: z.string().default(''),
+  isConstant: z.boolean().default(false),
+})
+
+/**
+ * Zod schema for structured output.
+ * Shared by information-extractor.
+ */
+export const structuredOutputSchema = z.object({
+  enabled: z.boolean().default(false),
+  schema: z
+    .object({
+      type: z.literal('object'),
+      properties: z.record(z.string(), z.any()),
+      required: z.array(z.string()).optional(),
+      additionalProperties: z.boolean().optional(),
+    })
+    .optional(),
+})
+
+/**
+ * Zod schema for a single toolset entry on the AI node. Mirrors the shared
+ * `ToolsetEntry` from `@auxx/database` so the picker dialog and back-end
+ * filter pipeline work without translation.
+ */
+const toolsetEntrySchema = z.object({
+  slug: z.string(),
+  enabled: z.boolean(),
+  source: z.enum(['manual', 'mention', 'auto_default']),
+  config: z.record(z.string(), z.unknown()).default({}),
+  appInstallationId: z.string().nullable().optional(),
+})
+
+const appAccountsSchema = z.record(z.string(), z.object({ credId: z.string() }))
+
+/**
+ * Main schema for AI node data
+ */
+export const aiNodeDataSchema = z.object({
+  // Base fields
+  id: z.string(),
+  type: z.literal('ai'),
+  title: z.string().min(1),
+  desc: z.string().optional(),
+  // AI-specific fields
+  model: modelSchema,
+  prompt_template: z.array(promptTemplateSchema).min(1),
+  files: filesSchema,
+  structured_output: structuredOutputSchema,
+  // Flat tools shape (Phase 3)
+  toolsEnabled: z.boolean().optional(),
+  toolsets: z.array(toolsetEntrySchema).optional(),
+  appAccounts: appAccountsSchema.optional(),
+  approvalMode: z.literal('auto').optional(),
+  maxIterations: z.number().optional(),
+})
+
+/**
+ * Validation function for AI configuration
+ */
+export const validateAiData = (data: Partial<AiNodeData>): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Validate title
+  if (!data.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Validate model — only require provider/name when NOT using default
+  if (!data.model?.useDefault) {
+    if (!data.model?.provider?.trim()) {
+      errors.push({ field: 'model.provider', message: 'Model provider is required', type: 'error' })
+    }
+
+    if (!data.model?.name?.trim()) {
+      errors.push({ field: 'model.name', message: 'Model name is required', type: 'error' })
+    }
+  }
+
+  // Validate temperature (an unset temperature falls back to the provider default)
+  const temperature = data.model?.completion_params?.temperature
+  if (temperature !== undefined) {
+    if (
+      temperature < AI_NODE_CONSTANTS.TEMPERATURE.min ||
+      temperature > AI_NODE_CONSTANTS.TEMPERATURE.max
+    ) {
+      errors.push({
+        field: 'model.completion_params.temperature',
+        message: `Temperature must be between ${AI_NODE_CONSTANTS.TEMPERATURE.min} and ${AI_NODE_CONSTANTS.TEMPERATURE.max}`,
+        type: 'error',
+      })
+    } else if (temperature > 0.8) {
+      // Add warning for high temperature
+      errors.push({
+        field: 'model.completion_params.temperature',
+        message: 'High temperature (>0.8) may produce more creative but less predictable results',
+        type: 'warning',
+      })
+    }
+  }
+
+  // Validate prompt template
+  if (!data.prompt_template || data.prompt_template.length === 0) {
+    errors.push({
+      field: 'prompt_template',
+      message: 'At least one prompt template is required',
+      type: 'error',
+    })
+  }
+
+  // Validate each prompt template
+  data.prompt_template?.forEach((template, index) => {
+    if (!template.role) {
+      errors.push({
+        field: `prompt_template.${index}.role`,
+        message: 'Prompt role is required',
+        type: 'error',
+      })
+    }
+
+    if (!template.json || !isNonEmptyDoc(template.json)) {
+      errors.push({
+        field: `prompt_template.${index}.json`,
+        message: 'Prompt text is required',
+        type: 'error',
+      })
+    }
+  })
+
+  // Validate structured output — enabling it without a schema only fails at
+  // run time otherwise ("Node validation failed"). Surface it in the builder.
+  if (data.structured_output?.enabled && !data.structured_output.schema) {
+    errors.push({
+      field: 'structured_output.schema',
+      message: 'Structured output is enabled but no schema is defined',
+      type: 'error',
+    })
+  }
+
+  // Check if there are any errors (not warnings)
+  const hasErrors = errors.filter((e) => e.type === 'error').length > 0
+
+  return { isValid: !hasErrors, errors }
+}
+
+/**
+ * Extracts variable IDs from an AI node configuration
+ */
+export function extractAIVariableIds(data: AiNodeData): string[] {
+  const uniqueVariableIds = new Set<string>()
+
+  // Extract from prompt templates — chip ids from the Tiptap doc.
+  data.prompt_template?.forEach((template) => {
+    const ids = collectVariableIds(template.json)
+    ids.forEach((id) => {
+      uniqueVariableIds.add(id)
+    })
+  })
+
+  // Extract from file input (only in variable mode)
+  if (data.files?.input && !data.files.isConstant) {
+    if (containsVariableReference(data.files.input)) {
+      const ids = extractVarIdsFromString(data.files.input)
+      ids.forEach((id) => uniqueVariableIds.add(id))
+    } else {
+      uniqueVariableIds.add(data.files.input)
+    }
+  }
+
+  return Array.from(uniqueVariableIds)
+}
+
+/**
+ * AI node manifest
+ */
+export const aiManifest: NodeManifest<AiNodeData> = {
+  id: 'ai',
+  category: NodeCategory.TRANSFORM,
+  displayName: 'AI',
+  description: 'AI-powered text generation and processing',
+  icon: 'brain',
+  color: '#8B5CF6', // TRANSFORM category color
+  defaultData: () => ({
+    title: 'AI',
+    desc: 'AI-powered text generation',
+    model: {
+      useDefault: true,
+      provider: '',
+      name: '',
+      mode: AiModelMode.CHAT,
+      completion_params: { temperature: AI_NODE_CONSTANTS.TEMPERATURE.default },
+    },
+    prompt_template: [{ role: PromptRole.SYSTEM, json: EMPTY_PROMPT_DOC }],
+    files: { enabled: false, input: '', isConstant: false },
+    structured_output: { enabled: false },
+    toolsEnabled: false,
+    toolsets: [],
+  }),
+  configSchema: aiNodeDataSchema as unknown as z.ZodType<AiNodeData>,
+  validate: validateAiData,
+  extractVariables: extractAIVariableIds,
+  connection: {
+    canRunSingle: true,
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Each `prompt_template` entry is { role, json } where `json` is a Tiptap doc — the Phase 3 ' +
+      'normalizer converts plain text with {{…}} refs into that shape; do not author raw Tiptap. ' +
+      'Leave `model.useDefault: true` unless the user names a model. Enable `structured_output` ' +
+      'with a JSON schema to get typed outputs at `{{<node>.structured_output.<key>}}`; the plain ' +
+      'response is always at `{{<node>.text}}`.',
+    examples: [
+      {
+        description: 'Summarize an inbound message with the org default model',
+        config: {
+          model: {
+            useDefault: true,
+            provider: '',
+            name: '',
+            mode: 'chat',
+            completion_params: { temperature: 0.7 },
+          },
+          prompt_template: [
+            {
+              role: 'system',
+              json: {
+                type: 'doc',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      { type: 'text', text: 'Summarize the customer message in two sentences: ' },
+                      { type: 'variable-node', attrs: { variableId: 'trigger-1.message.body' } },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/answer.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/answer.ts
@@ -1,0 +1,244 @@
+// packages/lib/src/workflow-engine/catalog/nodes/answer.ts
+
+import { z } from 'zod'
+import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import { extractVarIdsFromString } from '../variable-inference'
+
+/**
+ * The answer node's catalog manifest — sends a new message or replies on a
+ * thread through a channel integration.
+ */
+
+/**
+ * Node data for answer nodes with flattened structure
+ */
+export interface AnswerNodeData extends BaseNodeData {
+  // 'new' = compose fresh email, 'reply' = reply to sender, 'replyAll' = reply to all
+  messageType: 'new' | 'reply' | 'replyAll'
+
+  integrationId?: string // Required for 'new', auto-derived for reply/replyAll
+  recordId?: string // Format: "entityDefinitionId:id" (e.g. "thread:abc123", "message:xyz789")
+  // Required for reply/replyAll. Replaces old resourceId + resourceType.
+
+  // Per-field auto-resolve toggles (reply/replyAll only, ignored for 'new')
+  // true (default): system auto-resolves from thread at execution time
+  // false: user provides the value explicitly
+  toIsAuto?: boolean
+  ccIsAuto?: boolean
+  bccIsAuto?: boolean
+  subjectIsAuto?: boolean
+
+  to?: string[]
+  toModes?: boolean[]
+  cc?: string[]
+  ccModes?: boolean[]
+  bcc?: string[]
+  bccModes?: boolean[]
+  text: string
+  subject?: string
+  /**
+   * Attachment picker rows — a constant row is a `file:<id>` reference, a
+   * variable row a `{{…}}` reference. `attachmentFilesModes` marks which is
+   * which, positionally. The engine resolves both to file ids and hands them to
+   * the send path as `attachmentIds`.
+   */
+  attachmentFiles?: string[]
+  attachmentFilesModes?: boolean[]
+  saveAsDraft?: boolean // When true, creates a draft instead of sending
+  // Per-node send behavior override: default = dry-run during test runs,
+  // live = always send, dry_run = never send, draft = save as thread draft
+  test_behavior?: 'default' | 'live' | 'dry_run' | 'draft'
+  fieldModes?: Record<string, boolean> // Track constant/variable mode per field
+}
+
+/**
+ * Zod schema for answer node data (flattened structure).
+ *
+ * `text` tolerates the empty string a fresh node persists — required-ness is
+ * the validator's "Message content is required" check, same as the list node's
+ * `inputList` (the defaults must parse their own schema).
+ */
+export const answerNodeDataSchema = baseNodeDataSchema.extend({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  messageType: z.enum(['new', 'reply', 'replyAll']).default('reply'),
+  integrationId: z.string().optional(),
+  recordId: z.string().optional(),
+  toIsAuto: z.boolean().optional(),
+  ccIsAuto: z.boolean().optional(),
+  bccIsAuto: z.boolean().optional(),
+  subjectIsAuto: z.boolean().optional(),
+  to: z.array(z.string()).optional(),
+  toModes: z.array(z.boolean()).optional(),
+  cc: z.array(z.string()).optional(),
+  ccModes: z.array(z.boolean()).optional(),
+  bcc: z.array(z.string()).optional(),
+  bccModes: z.array(z.boolean()).optional(),
+  text: z.string(),
+  subject: z.string().optional(),
+  attachmentFiles: z.array(z.string()).optional(),
+  attachmentFilesModes: z.array(z.boolean()).optional(),
+  saveAsDraft: z.boolean().optional(),
+  test_behavior: z.enum(['default', 'live', 'dry_run', 'draft']).optional(),
+  fieldModes: z.record(z.string(), z.boolean()).optional(),
+})
+
+/**
+ * Validation function for answer configuration
+ */
+export const validateAnswerConfig = (data: AnswerNodeData): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Validate title
+  if (!data.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Validate text content
+  if (!data.text?.trim()) {
+    errors.push({ field: 'text', message: 'Message content is required', type: 'error' })
+  }
+
+  const isReply = data.messageType === 'reply' || data.messageType === 'replyAll'
+
+  if (data.messageType === 'new') {
+    // For new messages, integration is required
+    if (!data.integrationId) {
+      errors.push({
+        field: 'integrationId',
+        message: 'Integration is required for new messages',
+        type: 'error',
+      })
+    }
+    // To and Subject always required for new messages
+    if (!data.to || data.to.length === 0) {
+      errors.push({ field: 'to', message: 'At least one recipient is required', type: 'error' })
+    }
+  } else if (isReply) {
+    // recordId is always required for replies
+    if (!data.recordId) {
+      errors.push({
+        field: 'recordId',
+        message: 'Reply target is required',
+        type: 'error',
+      })
+    }
+    // To only required when not auto-resolved
+    if (data.toIsAuto === false && (!data.to || data.to.length === 0)) {
+      errors.push({ field: 'to', message: 'At least one recipient is required', type: 'error' })
+    }
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/** Extract referenced variable IDs from answer node data */
+export function extractAnswerVariables(data: AnswerNodeData): string[] {
+  const uniqueVariables = new Set<string>()
+
+  // Extract from text field (rich editor content)
+  if (data.text) {
+    extractVarIdsFromString(data.text).forEach((varId) => uniqueVariables.add(varId))
+  }
+
+  // Extract from subject (only when not auto-resolved)
+  if (data.subject && data.subjectIsAuto === false) {
+    extractVarIdsFromString(data.subject).forEach((varId) => uniqueVariables.add(varId))
+  }
+
+  // Extract from email arrays (only when not auto-resolved)
+  if (data.toIsAuto === false && data.to && Array.isArray(data.to)) {
+    data.to.forEach((email) => {
+      extractVarIdsFromString(email).forEach((varId) => uniqueVariables.add(varId))
+    })
+  }
+  if (data.ccIsAuto === false && data.cc && Array.isArray(data.cc)) {
+    data.cc.forEach((email) => {
+      extractVarIdsFromString(email).forEach((varId) => uniqueVariables.add(varId))
+    })
+  }
+  if (data.bccIsAuto === false && data.bcc && Array.isArray(data.bcc)) {
+    data.bcc.forEach((email) => {
+      extractVarIdsFromString(email).forEach((varId) => uniqueVariables.add(varId))
+    })
+  }
+
+  // Extract from recordId for replies (PICKER mode stores raw variable ID, not {{...}} wrapped)
+  if (data.recordId) {
+    const extracted = extractVarIdsFromString(data.recordId)
+    if (extracted.length > 0) {
+      extracted.forEach((varId) => uniqueVariables.add(varId))
+    } else if (data.recordId.includes('.')) {
+      // Raw variable ID from PICKER mode (e.g. "nodeId.thread")
+      uniqueVariables.add(data.recordId)
+    }
+  }
+
+  // Extract from attachment files
+  if (data.attachmentFiles && Array.isArray(data.attachmentFiles)) {
+    data.attachmentFiles.forEach((file) => {
+      extractVarIdsFromString(file).forEach((varId) => uniqueVariables.add(varId))
+    })
+  }
+
+  return Array.from(uniqueVariables)
+}
+
+/**
+ * Answer node manifest
+ */
+export const answerManifest: NodeManifest<AnswerNodeData> = {
+  id: 'answer',
+  category: NodeCategory.ACTION,
+  displayName: 'Send Answer',
+  description: 'Send reply to customer email',
+  icon: 'send',
+  color: '#10b981', // ACTION category color
+  defaultData: () => ({
+    title: 'Send Message',
+    desc: 'Reply to customer',
+    messageType: 'reply',
+    text: '',
+    toIsAuto: true,
+    ccIsAuto: true,
+    bccIsAuto: true,
+    subjectIsAuto: true,
+    to: [],
+    toModes: [],
+    cc: [],
+    ccModes: [],
+    bcc: [],
+    bccModes: [],
+    subject: '',
+    attachmentFiles: [],
+    attachmentFilesModes: [],
+    saveAsDraft: false,
+    test_behavior: 'default',
+  }),
+  configSchema: answerNodeDataSchema as unknown as z.ZodType<AnswerNodeData>,
+  validate: validateAnswerConfig,
+  extractVariables: extractAnswerVariables,
+  connection: {
+    canRunSingle: true,
+  },
+  agent: {
+    authorable: true,
+    usage:
+      "`messageType: 'reply'` needs `recordId` (a thread/message ref, usually a bare variable path " +
+      "like `trigger-1.thread`); 'new' needs `integrationId` plus explicit `to`. Recipients/subject " +
+      'auto-resolve from the thread while the `*IsAuto` flags stay true — only set them false to ' +
+      'override. `text` is the message body and may contain {{…}} refs. `test_behavior` defaults to ' +
+      'dry-run during builder test runs.',
+    examples: [
+      {
+        description: 'Reply on the triggering thread with an AI draft',
+        config: {
+          messageType: 'reply',
+          recordId: 'trigger-1.thread',
+          text: '{{ai-1.text}}',
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/information-extractor.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/information-extractor.ts
@@ -1,0 +1,272 @@
+// packages/lib/src/workflow-engine/catalog/nodes/information-extractor.ts
+
+import { z } from 'zod'
+import { AI_NODE_CONSTANTS } from '../../constants'
+import type { BaseNodeData } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import { extractVarIdsFromString } from '../variable-inference'
+import { completionParamsSchema, structuredOutputSchema } from './ai'
+
+/**
+ * The information-extractor node's catalog manifest.
+ * `completionParamsSchema` / `structuredOutputSchema` are the ai node's —
+ * shared, not redeclared. The structured-output schema member is typed loosely
+ * (`type: string`) so apps/web can narrow it to its `SchemaRoot` (whose `type`
+ * is a string enum member, not the literal 'object') without a cast.
+ */
+
+/**
+ * Model configuration
+ */
+export interface InformationExtractorModel {
+  useDefault?: boolean
+  provider: string
+  name: string
+  mode: 'chat' | 'completion'
+  completion_params?: {
+    temperature: number
+    max_tokens?: number
+    top_p?: number
+    frequency_penalty?: number
+    presence_penalty?: number
+  }
+}
+
+/**
+ * Vision configuration
+ */
+export interface InformationExtractorVision {
+  enabled: boolean
+}
+
+/**
+ * Instruction configuration
+ */
+export interface InformationExtractorInstruction {
+  enabled: boolean
+  text: string
+}
+
+/**
+ * Node data interface - flattened structure
+ */
+export interface InformationExtractorNodeData extends BaseNodeData {
+  model: InformationExtractorModel
+  text: string // Preprocessed text with variables
+  structured_output: {
+    enabled: boolean
+    schema?: {
+      type: string // always 'object'; string so web's SchemaRoot narrows cleanly
+      properties: Record<string, any>
+      required?: string[]
+      additionalProperties?: boolean | Record<string, any>
+    }
+  }
+  vision: InformationExtractorVision
+  instruction: InformationExtractorInstruction
+}
+
+/**
+ * Zod schema for model configuration
+ */
+const modelSchema = z.object({
+  useDefault: z.boolean().optional(),
+  provider: z.string(),
+  name: z.string(),
+  mode: z.enum(['chat', 'completion']).default('chat'),
+  completion_params: completionParamsSchema.optional(),
+})
+
+/**
+ * Zod schema for vision configuration
+ */
+const visionSchema = z.object({ enabled: z.boolean().default(false) })
+
+/**
+ * Zod schema for instruction configuration
+ */
+const instructionSchema = z.object({
+  enabled: z.boolean().default(false),
+  text: z.string().default(''), // Preprocessed text
+})
+
+/**
+ * Main schema for information extractor configuration
+ */
+export const informationExtractorSchema = z.object({
+  title: z.string().default('Information Extractor'),
+  desc: z.string().optional(),
+  model: modelSchema,
+  text: z.string().default(''), // Preprocessed text
+  textEditorContent: z.string().optional(), // Tiptap JSON
+  structured_output: structuredOutputSchema,
+  vision: visionSchema,
+  instruction: instructionSchema,
+})
+
+/**
+ * Factory function to create default data
+ */
+export const createInformationExtractorDefaultData = (): Partial<InformationExtractorNodeData> => ({
+  title: 'Information Extractor',
+  desc: 'Extract structured information from text using AI',
+  model: {
+    useDefault: true,
+    provider: '',
+    name: '',
+    mode: 'chat',
+    completion_params: { temperature: 0.3 }, // Lower temperature for extraction
+  },
+  text: '',
+  structured_output: { enabled: false, schema: undefined },
+  vision: { enabled: false },
+  instruction: { enabled: false, text: '' },
+})
+
+/**
+ * Validation function for information extractor data
+ */
+export function validateInformationExtractor(
+  data: InformationExtractorNodeData
+): NodeValidationResult {
+  try {
+    informationExtractorSchema.parse(data)
+
+    // Validate model — only require provider/name when NOT using default
+    if (!data.model.useDefault && (!data.model.provider || !data.model.name)) {
+      return {
+        isValid: false,
+        errors: [{ field: 'model', message: 'Please select an AI model', type: 'error' as const }],
+      }
+    }
+
+    if (!data.text.trim()) {
+      return {
+        isValid: false,
+        errors: [
+          {
+            field: 'text',
+            message: 'Please provide text to extract information from',
+            type: 'error' as const,
+          },
+        ],
+      }
+    }
+
+    if (data.structured_output.enabled && !data.structured_output.schema) {
+      return {
+        isValid: false,
+        errors: [
+          {
+            field: 'structured_output',
+            message: 'Please configure the extraction schema',
+            type: 'error' as const,
+          },
+        ],
+      }
+    }
+
+    // Validate schema field count if enabled
+    if (data.structured_output.enabled && data.structured_output.schema?.properties) {
+      const fieldCount = Object.keys(data.structured_output.schema.properties).length
+      if (fieldCount > AI_NODE_CONSTANTS.INFO_EXTRACTOR.MAX_FIELDS) {
+        return {
+          isValid: false,
+          errors: [
+            {
+              field: 'structured_output',
+              message: `Cannot exceed ${AI_NODE_CONSTANTS.INFO_EXTRACTOR.MAX_FIELDS} fields in the extraction schema`,
+              type: 'error' as const,
+            },
+          ],
+        }
+      }
+    }
+
+    return { isValid: true, errors: [] }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        isValid: false,
+        errors: error.issues.map((e) => ({
+          field: e.path.join('.'),
+          message: e.message,
+          type: 'error' as const,
+        })),
+      }
+    }
+    return {
+      isValid: false,
+      errors: [{ field: 'general', message: 'Invalid configuration', type: 'error' as const }],
+    }
+  }
+}
+
+/**
+ * Extract variables from data for single run
+ */
+export function extractInformationExtractorVariables(data: InformationExtractorNodeData): string[] {
+  const uniqueVariables = new Set<string>()
+
+  // Extract from main text
+  extractVarIdsFromString(data.text).forEach((varId) => {
+    uniqueVariables.add(varId)
+  })
+
+  // Extract from instruction if enabled
+  if (data.instruction.enabled) {
+    extractVarIdsFromString(data.instruction.text).forEach((varId) => {
+      uniqueVariables.add(varId)
+    })
+  }
+
+  return Array.from(uniqueVariables)
+}
+
+/**
+ * Information extractor node manifest
+ */
+export const informationExtractorManifest: NodeManifest<InformationExtractorNodeData> = {
+  id: 'information-extractor',
+  category: NodeCategory.TRANSFORM,
+  displayName: 'Information Extractor',
+  description: 'Extract structured information from text using AI with custom schemas',
+  icon: 'file-json',
+  color: '#8B5CF6', // TRANSFORM category color
+  defaultData: createInformationExtractorDefaultData,
+  configSchema: informationExtractorSchema as unknown as z.ZodType<InformationExtractorNodeData>,
+  validate: validateInformationExtractor,
+  extractVariables: extractInformationExtractorVariables,
+  connection: {
+    canRunSingle: true,
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Define the fields to pull out as a JSON schema in `structured_output.schema` (enable it) — ' +
+      'each top-level key becomes `{{<node>.extracted_data.<key>}}`; the raw model answer is at ' +
+      '`{{<node>.raw_extraction}}`. `text` is the input and may contain {{…}} refs. Leave ' +
+      '`model.useDefault: true` unless the user names a model.',
+    examples: [
+      {
+        description: 'Pull an order number and sentiment out of a message',
+        config: {
+          model: { useDefault: true, provider: '', name: '', mode: 'chat' },
+          text: '{{trigger-1.message.body}}',
+          structured_output: {
+            enabled: true,
+            schema: {
+              type: 'object',
+              properties: {
+                orderNumber: { type: 'string', description: 'Order reference if mentioned' },
+                sentiment: { type: 'string', enum: ['positive', 'neutral', 'negative'] },
+              },
+            },
+          },
+          vision: { enabled: false },
+          instruction: { enabled: false, text: '' },
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
@@ -1,0 +1,357 @@
+// packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
+
+import { generateId } from '@auxx/utils/generateId'
+import { z } from 'zod'
+import { AI_NODE_CONSTANTS } from '../../constants'
+import type { BaseNodeData, TargetBranch } from '../node-base'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
+import { extractVarIdsFromString } from '../variable-inference'
+import { AiModelMode, completionParamsSchema } from './ai'
+
+/**
+ * The text-classifier node's catalog manifest. `AiModelMode` and
+ * `completionParamsSchema` come from the ai node's manifest — re-exported, not
+ * redeclared, because TS enums are nominal and the AI nodes share these at
+ * every boundary.
+ */
+
+export type TextClassifierOutputMode = 'branches' | 'variable'
+
+/**
+ * Model configuration interface
+ */
+export interface ModelConfig {
+  useDefault?: boolean
+  provider: string
+  name: string
+  mode: AiModelMode
+  completion_params?: CompletionParams
+}
+
+/**
+ * Completion parameters interface
+ */
+export interface CompletionParams {
+  temperature?: number
+  max_tokens?: number
+  top_p?: number
+  frequency_penalty?: number
+  presence_penalty?: number
+}
+
+/**
+ * Category interface for classification
+ */
+export interface Category {
+  id: string
+  name: string
+  description?: string // Preprocessed text with {{variables}}
+  text: string
+}
+
+/**
+ * Vision configuration interface
+ */
+export interface VisionConfig {
+  enabled: boolean
+}
+
+/**
+ * Instruction configuration interface
+ */
+export interface InstructionConfig {
+  enabled: boolean
+  text: string // Preprocessed text
+}
+
+/**
+ * Classification result interface (for backend processing)
+ */
+export interface ClassificationResult {
+  category: string
+  confidence: number
+  reasoning: string
+}
+
+/**
+ * Text Classifier node data interface - flattened structure
+ */
+export interface TextClassifierNodeData extends BaseNodeData {
+  model: ModelConfig
+  text: string // Preprocessed text
+  categories: Category[]
+  vision: VisionConfig
+  instruction: InstructionConfig
+  outputMode?: TextClassifierOutputMode
+  _targetBranches?: TargetBranch[]
+}
+
+/**
+ * Zod schema for model configuration
+ */
+const modelSchema = z.object({
+  useDefault: z.boolean().optional(),
+  provider: z.string(),
+  name: z.string(),
+  mode: z.enum(AiModelMode).default(AiModelMode.CHAT),
+  completion_params: completionParamsSchema.optional(),
+})
+
+/**
+ * Zod schema for category
+ */
+const categorySchema = z.object({
+  id: z.string(),
+  name: z.string().max(AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_NAME_MAX_LENGTH),
+  description: z
+    .string()
+    .max(AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_DESCRIPTION_MAX_LENGTH)
+    .optional(), // Preprocessed text
+  text: z.string().default(''), // Preprocessed text
+})
+
+/**
+ * Zod schema for vision configuration
+ */
+const visionSchema = z.object({ enabled: z.boolean().default(false) })
+
+/**
+ * Zod schema for instruction configuration
+ */
+const instructionSchema = z.object({
+  enabled: z.boolean().default(false),
+  text: z.string().default(''), // Preprocessed text
+})
+
+/**
+ * Main schema for text classifier configuration
+ */
+export const textClassifierSchema = z.object({
+  title: z.string().default('Text Classifier'),
+  desc: z.string().optional(),
+  model: modelSchema,
+  text: z.string().default(''), // Preprocessed text
+  categories: z.array(categorySchema).min(1),
+  vision: visionSchema,
+  instruction: instructionSchema,
+  outputMode: z.enum(['branches', 'variable']).default('branches'),
+})
+
+/**
+ * Validation function for text classifier data
+ */
+export const validateTextClassifierData = (data: TextClassifierNodeData): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+  // Validate title
+  if (!data.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Validate model — only require provider/name when NOT using default
+  if (!data.model?.useDefault) {
+    if (!data.model?.provider?.trim()) {
+      errors.push({ field: 'model.provider', message: 'Model provider is required', type: 'error' })
+    }
+
+    if (!data.model?.name?.trim()) {
+      errors.push({ field: 'model.name', message: 'Model name is required', type: 'error' })
+    }
+  }
+
+  // Validate text to classify
+  if (!data.text?.trim()) {
+    errors.push({ field: 'text', message: 'Text to classify is required', type: 'error' })
+  }
+
+  // Validate categories
+  if (!data.categories || data.categories.length === 0) {
+    errors.push({
+      field: 'categories',
+      message: 'At least one category is required',
+      type: 'error',
+    })
+  } else if (data.categories.length < AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MIN_CATEGORIES) {
+    errors.push({
+      field: 'categories',
+      message: `At least ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MIN_CATEGORIES} categories are required`,
+      type: 'error',
+    })
+  } else if (data.categories.length > AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MAX_CATEGORIES) {
+    errors.push({
+      field: 'categories',
+      message: `Cannot exceed ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.MAX_CATEGORIES} categories`,
+      type: 'error',
+    })
+  }
+
+  // Validate each category
+  data.categories?.forEach((category, index) => {
+    if (!category.name?.trim()) {
+      errors.push({
+        field: `categories.${index}.name`,
+        message: 'Category name is required',
+        type: 'error',
+      })
+    } else if (category.name.length > AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_NAME_MAX_LENGTH) {
+      errors.push({
+        field: `categories.${index}.name`,
+        message: `Category name cannot exceed ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_NAME_MAX_LENGTH} characters`,
+        type: 'error',
+      })
+    }
+
+    // Category description is required
+    if (!category.description?.trim()) {
+      errors.push({
+        field: `categories.${index}.description`,
+        message: 'Category description is recommended for better classification',
+        type: 'warning',
+      })
+    } else if (
+      category.description.length >
+      AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_DESCRIPTION_MAX_LENGTH
+    ) {
+      errors.push({
+        field: `categories.${index}.description`,
+        message: `Category description cannot exceed ${AI_NODE_CONSTANTS.TEXT_CLASSIFIER.CATEGORY_DESCRIPTION_MAX_LENGTH} characters`,
+        type: 'error',
+      })
+    }
+  })
+
+  // Add warnings for optional fields
+  if (!data.desc?.trim()) {
+    errors.push({
+      field: 'desc',
+      message: 'Consider adding a description for better documentation',
+      type: 'warning',
+    })
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/**
+ * Extract variables from text classifier data
+ */
+export const extractTextClassifierVariables = (data: TextClassifierNodeData): string[] => {
+  const uniqueVariables = new Set<string>()
+
+  // Extract from main text
+  extractVarIdsFromString(data.text).forEach((varId) => {
+    uniqueVariables.add(varId)
+  })
+
+  // Extract from category descriptions
+  data.categories?.forEach((category) => {
+    extractVarIdsFromString(category.text).forEach((varId) => {
+      uniqueVariables.add(varId)
+    })
+  })
+
+  // Extract from instructions if enabled
+  if (data.instruction?.enabled) {
+    extractVarIdsFromString(data.instruction.text).forEach((varId) => {
+      uniqueVariables.add(varId)
+    })
+  }
+
+  return Array.from(uniqueVariables)
+}
+
+/**
+ * Text classifier node manifest
+ */
+export const textClassifierManifest: NodeManifest<TextClassifierNodeData> = {
+  id: 'text-classifier',
+  category: NodeCategory.CONDITION,
+  displayName: 'Text Classifier',
+  description: 'Classify text into predefined categories using AI',
+  icon: 'tags',
+  color: '#f59e0b', // CONDITION category color
+  defaultData: () => ({
+    title: 'Text Classifier',
+    desc: 'Classify text into predefined categories',
+    model: {
+      useDefault: true,
+      provider: '',
+      name: '',
+      mode: AiModelMode.CHAT,
+      completion_params: { temperature: AI_NODE_CONSTANTS.TEMPERATURE.default },
+    },
+    text: '',
+    categories: [
+      {
+        id: generateId(),
+        name: 'Category 1',
+        description: '',
+        text: '',
+      },
+    ],
+    vision: { enabled: false },
+    instruction: { enabled: false, text: '' },
+    outputMode: 'branches' as const,
+  }),
+  configSchema: textClassifierSchema as unknown as z.ZodType<TextClassifierNodeData>,
+  validate: validateTextClassifierData,
+  extractVariables: extractTextClassifierVariables,
+  connection: {
+    canRunSingle: true,
+    /**
+     * Variable mode routes everything through 'source'; branches mode (the
+     * default) exposes one handle per category id plus the reserved
+     * 'unmatched'. Mirrors the TEXT_CLASSIFIER arm of the canvas's
+     * `calculateTargetBranches` (workflow-initializer.ts, which returns
+     * undefined — no handles — for a node with no categories), the last
+     * branch-deriving arm besides crud still living there.
+     */
+    branches: (config): NodeBranch[] => {
+      if (config.outputMode === 'variable') {
+        return [{ id: 'source', name: '', kind: 'default' }]
+      }
+      if (!config.categories?.length) return []
+      return [
+        ...config.categories.map((cat) => ({
+          id: cat.id,
+          name: cat.name,
+          kind: 'default' as const,
+        })),
+        { id: 'unmatched', name: 'Unmatched', kind: 'default' as const },
+      ]
+    },
+  },
+  agent: {
+    authorable: true,
+    usage:
+      "Each entry in `categories` becomes a wirable branch handle (edge sourceHandle = the category's " +
+      "`id`), plus the reserved 'unmatched' handle. Set `outputMode: 'variable'` to skip branching and " +
+      'read `{{<node>.category}}` instead. `text` is the input to classify and may contain {{…}} refs; ' +
+      'category `description` guides the model. Leave `model.useDefault: true` unless the user names a model.',
+    examples: [
+      {
+        description: 'Route tickets by intent',
+        config: {
+          model: { useDefault: true, provider: '', name: '', mode: 'chat' },
+          text: '{{trigger-1.message.body}}',
+          categories: [
+            { id: 'cat-refund', name: 'Refund', description: 'Asks for money back', text: '' },
+            {
+              id: 'cat-shipping',
+              name: 'Shipping',
+              description: 'Asks where an order is',
+              text: '',
+            },
+          ],
+          vision: { enabled: false },
+          instruction: { enabled: false, text: '' },
+          outputMode: 'branches',
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -37,8 +37,8 @@ export const NOT_YET_MIGRATED: readonly string[] = [
   // Condition nodes
   // 'if-else' — migrated (catalog/nodes/if-else.ts)
   // Action nodes
-  'answer',
-  'ai',
+  // 'answer' — migrated (catalog/nodes/answer.ts)
+  // 'ai' — migrated (catalog/nodes/ai.ts)
   'find',
   // 'http' — migrated (catalog/nodes/http.ts)
   'crud',
@@ -48,8 +48,8 @@ export const NOT_YET_MIGRATED: readonly string[] = [
   'knowledge-retrieval',
   // Transform nodes
   // 'code' — migrated (catalog/nodes/code.ts)
-  'text-classifier',
-  'information-extractor',
+  // 'text-classifier' — migrated (catalog/nodes/text-classifier.ts)
+  // 'information-extractor' — migrated (catalog/nodes/information-extractor.ts)
   // 'var-assign' — migrated (catalog/nodes/var-assign.ts)
   // 'date-time' — migrated (catalog/nodes/date-time.ts)
   // 'list' — migrated (catalog/nodes/list.ts)

--- a/packages/lib/src/workflow-engine/catalog/registry.ts
+++ b/packages/lib/src/workflow-engine/catalog/registry.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/workflow-engine/catalog/registry.ts
 
+import { aiManifest } from './nodes/ai'
+import { answerManifest } from './nodes/answer'
 import { codeManifest } from './nodes/code'
 import { dateTimeManifest } from './nodes/date-time'
 import { endManifest } from './nodes/end'
@@ -7,11 +9,13 @@ import { formatManifest } from './nodes/format'
 import { httpManifest } from './nodes/http'
 import { humanConfirmationManifest } from './nodes/human'
 import { ifElseManifest } from './nodes/if-else'
+import { informationExtractorManifest } from './nodes/information-extractor'
 import { listManifest } from './nodes/list'
 import { loopManifest } from './nodes/loop'
 import { manualManifest } from './nodes/manual'
 import { noteManifest } from './nodes/note'
 import { scheduledTriggerManifest } from './nodes/scheduled'
+import { textClassifierManifest } from './nodes/text-classifier'
 import { varAssignManifest } from './nodes/var-assign'
 import { waitManifest } from './nodes/wait'
 import type { NodeManifest } from './types'
@@ -28,6 +32,8 @@ import type { NodeManifest } from './types'
  * two-file change: add the manifest here, delete the list entry.
  */
 const ALL_MANIFESTS: NodeManifest<any>[] = [
+  aiManifest,
+  answerManifest,
   codeManifest,
   dateTimeManifest,
   endManifest,
@@ -35,11 +41,13 @@ const ALL_MANIFESTS: NodeManifest<any>[] = [
   httpManifest,
   humanConfirmationManifest,
   ifElseManifest,
+  informationExtractorManifest,
   listManifest,
   loopManifest,
   manualManifest,
   noteManifest,
   scheduledTriggerManifest,
+  textClassifierManifest,
   varAssignManifest,
   waitManifest,
 ]

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -82,6 +82,31 @@ export {
   type WorkflowRetryConfig,
 } from './catalog/node-base'
 export {
+  type AiCompletionParams,
+  type AiFiles,
+  type AiModel,
+  AiModelMode,
+  AiModelProvider,
+  type AiNodeData as CatalogAiNodeData,
+  aiManifest,
+  aiNodeDataSchema,
+  completionParamsSchema,
+  EMPTY_PROMPT_DOC,
+  extractAIVariableIds,
+  PromptRole,
+  type PromptTemplate,
+  type StructuredOutputConfig,
+  structuredOutputSchema,
+  validateAiData,
+} from './catalog/nodes/ai'
+export {
+  type AnswerNodeData as CatalogAnswerNodeData,
+  answerManifest,
+  answerNodeDataSchema,
+  extractAnswerVariables,
+  validateAnswerConfig,
+} from './catalog/nodes/answer'
+export {
   type CodeNodeData as CatalogCodeNodeData,
   type CodeNodeInput,
   type CodeNodeOutput,
@@ -157,6 +182,17 @@ export {
   validateIfElseConfig,
 } from './catalog/nodes/if-else'
 export {
+  createInformationExtractorDefaultData,
+  extractInformationExtractorVariables,
+  type InformationExtractorInstruction,
+  type InformationExtractorModel,
+  type InformationExtractorNodeData as CatalogInformationExtractorNodeData,
+  type InformationExtractorVision,
+  informationExtractorManifest,
+  informationExtractorSchema,
+  validateInformationExtractor,
+} from './catalog/nodes/information-extractor'
+export {
   CONFIG_KEY_BY_OPERATION,
   extractListVariables,
   type FilterConfig,
@@ -207,6 +243,20 @@ export {
   scheduledTriggerUIConfigSchema,
   validateScheduledTriggerData,
 } from './catalog/nodes/scheduled'
+export {
+  type Category as TextClassifierCategory,
+  type ClassificationResult,
+  type CompletionParams as TextClassifierCompletionParams,
+  extractTextClassifierVariables,
+  type InstructionConfig as TextClassifierInstructionConfig,
+  type ModelConfig as TextClassifierModelConfig,
+  type TextClassifierNodeData as CatalogTextClassifierNodeData,
+  type TextClassifierOutputMode,
+  textClassifierManifest,
+  textClassifierSchema,
+  type VisionConfig as TextClassifierVisionConfig,
+  validateTextClassifierData,
+} from './catalog/nodes/text-classifier'
 export {
   extractVarAssignVariables,
   type VarAssignNodeData as CatalogVarAssignNodeData,

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/ai-v2.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/ai-v2.ts
@@ -6,6 +6,7 @@ import { LLMClient } from '../../../ai/clients/base/llm-client'
 import type { Message, MultiModalContent } from '../../../ai/clients/base/types'
 import { buildInstructionReferenceResolver } from '../../../ai/kopilot/prompts/resolve-instruction-references'
 import { collectVariableIds, docToText } from '../../../tiptap'
+import type { AiNodeData } from '../../catalog/nodes/ai'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type {
   NodeExecutionResult,
@@ -54,42 +55,26 @@ export interface AiToolsetEntry {
 }
 
 /**
- * Flat AI-node data shape — see `plans/workflow/ai/phase-2-ai-processor-migration.md`.
- * No legacy `tools: AiToolsConfig` block; per `project_no_production_users.md`
- * we break the shape outright.
+ * Flat AI-node data shape — the config subset of the catalog's `AiNodeData`
+ * (node-catalog Phase 1; this file previously shadowed it). The engine keeps
+ * its tolerant/extended projections: `model` admits the provider-specific
+ * params `AiModelConfig` adds, `files` members are optional on old rows (plus
+ * the reserved maxFiles/maxTotalSize), `prompt_template` is ai-node-utils'
+ * literal-role shape, and `toolsets` is the narrowed `AiToolsetEntry`.
  */
-interface AiNodeConfig {
-  title?: string
-  desc?: string
+type AiNodeConfig = Pick<
+  AiNodeData,
+  'title' | 'desc' | 'toolsEnabled' | 'appAccounts' | 'approvalMode' | 'maxIterations'
+> & {
   model: AiModelConfig
   prompt_template: PromptTemplate[]
-  files?: {
-    enabled: boolean
-    input?: string
-    isConstant?: boolean
+  files?: Partial<AiNodeData['files']> & {
     maxFiles?: number
     maxTotalSize?: number
   }
-  structured_output?: {
-    enabled: boolean
-    schema?: {
-      type: 'object'
-      properties: Record<string, any>
-      required?: string[]
-      additionalProperties?: boolean
-    }
-  }
-
-  /** Master gate for the entire tool surface on this node. */
-  toolsEnabled?: boolean
+  structured_output?: AiNodeData['structured_output']
   /** Per-toolset enablement. */
   toolsets?: AiToolsetEntry[]
-  /** Per-app explicit credential pin. */
-  appAccounts?: Record<string, { credId: string }>
-  /** Approval mode reserved for future use; v1 is always `auto`. */
-  approvalMode?: 'auto'
-  /** Default 10 for AI node; agent default is 30. */
-  maxIterations?: number
 }
 
 /**

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../../messages/types/message-sending.types'
 import { ProviderRegistryService } from '../../../providers/provider-registry-service'
 import { executeResourceQuery } from '../../../resources/resource-fetcher'
+import type { AnswerNodeData as CatalogAnswerNodeData } from '../../catalog/nodes/answer'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type {
   NodeData,
@@ -25,43 +26,33 @@ import { NodeRunningStatus, TEST_RECORD_ID, WorkflowNodeType } from '../../core/
 import { BaseNodeProcessor } from '../base-node'
 
 /**
- * Configuration interface for Answer node
+ * Configuration for the Answer node — the config subset of the catalog's
+ * `AnswerNodeData` (node-catalog Phase 1; this file previously shadowed it),
+ * over the engine's `NodeData` base.
  */
-interface AnswerNodeData extends NodeData {
-  messageType: 'new' | 'reply' | 'replyAll'
-  integrationId?: string
-  recordId?: string // Format: "entityDefinitionId:id" (e.g. "thread:abc123")
-  toIsAuto?: boolean
-  ccIsAuto?: boolean
-  bccIsAuto?: boolean
-  subjectIsAuto?: boolean
-  to?: string[]
-  toModes?: boolean[]
-  cc?: string[]
-  ccModes?: boolean[]
-  bcc?: string[]
-  bccModes?: boolean[]
-  text: string
-  subject?: string
-  /**
-   * Attachment picker values, one per row, as the panel's `VarEditorArray`
-   * writes them: a constant row is a `file:<id>` reference (or a JSON array of
-   * them, when several files were picked into one row), a variable row is a
-   * `{{…}}` reference resolved at execution time. `attachmentFilesModes` marks
-   * which is which, positionally.
-   */
-  attachmentFiles?: string[]
-  attachmentFilesModes?: boolean[]
-  saveAsDraft?: boolean
-  /**
-   * Per-node send behavior override (mirrors the human-in-the-loop node's Test Mode).
-   * - 'default': send in production, dry-run in builder test runs
-   * - 'live': always really send, even in test runs
-   * - 'dry_run': never send, trace-only
-   * - 'draft': persist as a thread draft instead of sending
-   */
-  test_behavior?: 'default' | 'live' | 'dry_run' | 'draft'
-}
+type AnswerNodeData = NodeData &
+  Pick<
+    CatalogAnswerNodeData,
+    | 'messageType'
+    | 'integrationId'
+    | 'recordId'
+    | 'toIsAuto'
+    | 'ccIsAuto'
+    | 'bccIsAuto'
+    | 'subjectIsAuto'
+    | 'to'
+    | 'toModes'
+    | 'cc'
+    | 'ccModes'
+    | 'bcc'
+    | 'bccModes'
+    | 'text'
+    | 'subject'
+    | 'attachmentFiles'
+    | 'attachmentFilesModes'
+    | 'saveAsDraft'
+    | 'test_behavior'
+  >
 
 /**
  * Flatten one attachment row into bare file ids.

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/information-extractor.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/information-extractor.ts
@@ -19,42 +19,28 @@ import { extractModelConfig, resolveModelConfig } from '../utils/ai-node-utils'
 
 const logger = createScopedLogger('information-extractor-processor')
 
+import type {
+  InformationExtractorModel,
+  InformationExtractorNodeData,
+} from '../../catalog/nodes/information-extractor'
+
 /**
- * Information extractor configuration interface
+ * Information extractor configuration — the config subset of the catalog's
+ * `InformationExtractorNodeData` (node-catalog Phase 1; this file previously
+ * shadowed it). The engine stays tolerant of old rows: `mode` and every
+ * completion param are optional here, `vision`/`instruction` may be absent.
  */
-interface InformationExtractorConfig {
-  title?: string
-  desc?: string
-  model: {
-    useDefault?: boolean
-    provider: string
-    name: string
-    mode?: 'chat' | 'completion'
-    completion_params?: {
-      temperature?: number
-      max_tokens?: number
-      top_p?: number
-      frequency_penalty?: number
-      presence_penalty?: number
-    }
+type InformationExtractorConfig = Pick<
+  InformationExtractorNodeData,
+  'title' | 'desc' | 'text' | 'structured_output'
+> & {
+  model: Omit<InformationExtractorModel, 'mode' | 'completion_params'> & {
+    mode?: InformationExtractorModel['mode']
+    completion_params?: Partial<NonNullable<InformationExtractorModel['completion_params']>>
   }
-  text: string // Preprocessed text with {{variables}}
   textEditorContent?: string // Tiptap JSON content
-  structured_output: {
-    enabled: boolean
-    schema?: {
-      type: 'object'
-      properties: Record<string, any>
-      required?: string[]
-      additionalProperties?: boolean
-    }
-  }
-  vision?: { enabled: boolean }
-  instruction?: {
-    enabled: boolean
-    text: string // Preprocessed text
-    editorContent?: string // Tiptap JSON
-  }
+  vision?: InformationExtractorNodeData['vision']
+  instruction?: InformationExtractorNodeData['instruction'] & { editorContent?: string }
 }
 
 /**

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/text-classifier.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/text-classifier.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/workflow-engine/nodes/transform-nodes/text-classifier.ts
 
 import type { Message } from '../../../ai/clients/base/types'
+import type { TextClassifierNodeData } from '../../catalog/nodes/text-classifier'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
@@ -18,22 +19,19 @@ import {
 } from '../utils/ai-response-utils'
 
 /**
- * Text classifier configuration interface
+ * Text classifier configuration — the config subset of the catalog's
+ * `TextClassifierNodeData` (node-catalog Phase 1; this file previously
+ * shadowed it). `model` stays the engine's tolerant `BaseAiModelConfig`, and
+ * `vision`/`instruction` stay optional — old rows may lack them.
  */
-interface TextClassifierConfig {
-  title?: string
-  desc?: string
+type TextClassifierConfig = Pick<
+  TextClassifierNodeData,
+  'title' | 'desc' | 'text' | 'categories' | 'outputMode'
+> & {
   model: BaseAiModelConfig
-  text: string // Preprocessed text with {{variables}}
   textEditorContent?: string // Tiptap JSON content
-  categories: Category[]
-  vision?: { enabled: boolean }
-  instruction?: {
-    enabled: boolean
-    text: string // Preprocessed text
-    editorContent?: string // Tiptap JSON
-  }
-  outputMode?: 'branches' | 'variable'
+  vision?: TextClassifierNodeData['vision']
+  instruction?: TextClassifierNodeData['instruction'] & { editorContent?: string }
 }
 
 /**

--- a/packages/lib/src/workflow-engine/nodes/utils/ai-node-utils.ts
+++ b/packages/lib/src/workflow-engine/nodes/utils/ai-node-utils.ts
@@ -5,6 +5,7 @@ import type { AICallbacks } from '../../../ai/orchestrator/types'
 import { ModelType } from '../../../ai/providers/types'
 import { getCachedDefaultModel } from '../../../cache/org-cache-helpers'
 import { docToText, type TiptapDoc } from '../../../tiptap'
+import type { PromptRole } from '../../catalog/nodes/ai'
 import type { ExecutionContextManager } from '../../core/execution-context'
 
 /**
@@ -14,9 +15,12 @@ import type { ExecutionContextManager } from '../../core/execution-context'
  * full single-walk resolver — for now `buildMessagesFromTemplates` flattens
  * via `docToText(json)` which yields `{{varId}}` placeholders that the
  * existing `interpolateVariables` regex picks up (legacy-equivalent).
+ *
+ * The role vocabulary is the catalog's `PromptRole` (node-catalog Phase 1),
+ * projected to its literal values — the engine reads persisted strings.
  */
 export interface PromptTemplate {
-  role: 'system' | 'user' | 'assistant'
+  role: `${PromptRole}`
   json: TiptapDoc
 }
 


### PR DESCRIPTION
Continues node-catalog Phase 1 (`plans/kopilot/workflow/01-node-catalog.md`, after #1569) — the AI batch. 18 wave-1 types are now migrated; the tracker is down to `resource-trigger`, `message-received`, and `crud`/`find` (which land with Phase 2).

Each type follows the established pattern: manifest in `catalog/nodes/<type>.ts`, web `schema.ts` shrunk to a `defineFromManifest` merge site, `types.ts` narrows `type` to the web enum and re-exports, output resolvers stay web-side until Phase 2.

## The shared AI vocabulary now lives once

`catalog/nodes/ai.ts` is the home of `PromptRole`, `AiModelMode`, `AiModelProvider`, `completionParamsSchema`, and `structuredOutputSchema`, consumed by text-classifier and information-extractor. TS enums are nominal — text-classifier already re-exported `AiModelMode` from the ai node for exactly this reason, and the catalog keeps it a single declaration.

## Drift fixed during the move (D4)

- **ai:** deleted the deprecated duplicate `aiSchema` — notably, the old `NodeDefinition.schema` pointed at *it* (no `id`/`type` fields) while the real flattened `aiNodeDataSchema` sat unused. The manifest's `configSchema` is the flattened one.
- **answer:** same fix class as list's `inputList` in #1569 — the schema required `text` non-empty while a fresh node persists `''`, so the defaults failed their own schema. Required-ness moved into the validator with the identical field/message/severity.

## Branch derivation

`textClassifierManifest.connection.branches` mirrors the TEXT_CLASSIFIER arm of `calculateTargetBranches`: per-category handles (edge sourceHandle = category id) plus the reserved `unmatched`, or a single `source` handle in variable mode. `crud` is now the only branch-deriving arm left in the canvas initializer.

## Shadow interfaces deleted

- `ai-v2.ts`'s `AiNodeConfig`, `answer.ts`'s `AnswerNodeData`, `text-classifier.ts`'s `TextClassifierConfig`, and `information-extractor.ts`'s `InformationExtractorConfig` now derive from the catalog types via `Pick`, keeping the engine's documented tolerances explicit (optional `mode`/completion params on old rows, ai-v2's provider-specific params and narrowed `AiToolsetEntry`, the legacy `editorContent` keys).
- `ai-node-utils`' `PromptTemplate` role vocabulary is now a template-literal projection of the catalog's `PromptRole`.
- `information-extractor`'s catalog type keeps `structured_output.schema` loose (`type: string`) so apps/web narrows it to the schema editor's `SchemaRoot` (whose `type` is a string-enum member, not the literal `'object'`) without a cast.

## Verification

- Zero-diff panels: only `schema.ts` / `types.ts` changed under the four `core/<type>/` folders
- lib + web typecheck ratchets green (29/29, 1/1)
- Full `components/workflow` web sweep: 90 passed (including the ai schema contract test)
- lib `workflow-engine` suite: 1013 passed
- Biome error-level clean on all touched files