### PR TITLE
feat(workflow): migrate the trigger nodes to the catalog and lift the trigger derivation

### DIFF
--- a/apps/web/src/components/workflow/hooks/use-workflow-save.ts
+++ b/apps/web/src/components/workflow/hooks/use-workflow-save.ts
@@ -1,10 +1,6 @@
 // apps/web/src/components/workflow/hooks/use-workflow-save.ts
 
-import {
-  RESOURCE_OPERATION_TO_TRIGGER_TYPE,
-  type ResourceTriggerOperation,
-  WorkflowTriggerType as TriggerType,
-} from '@auxx/lib/workflow-engine/client'
+import { deriveTriggerColumns } from '@auxx/lib/workflow-engine/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { debounce } from '@auxx/utils'
 import { useStoreApi } from '@xyflow/react'
@@ -144,39 +140,18 @@ export const useWorkflowSave = () => {
         return { ...edge, data: Object.keys(cleanData).length > 0 ? cleanData : undefined }
       })
 
-      // Detect trigger type from node definitions (registry-based)
-      let triggerType = workflow.triggerType
-      let entityDefinitionId: string | undefined
-
-      const triggerNode = cleanNodes.find((n) => {
-        const def = unifiedNodeRegistry.getDefinition(n.data.type as string)
-        return def?.triggerType !== undefined
+      // Detect trigger type from the graph. The derivation and its two
+      // load-bearing quirks (manual → FORM; resource-trigger only counts when
+      // both operation and entityDefinitionId are set) live in lib
+      // (`deriveTriggerColumns`, node-catalog §6b) so every writer computes
+      // the same columns. The registry-backed resolver covers what the
+      // catalog cannot see yet: not-yet-migrated triggers (webhook,
+      // webhook-endpoint) and dynamic app triggers.
+      const derived = deriveTriggerColumns(cleanNodes, {
+        resolveTriggerType: (nodeType) => unifiedNodeRegistry.getDefinition(nodeType)?.triggerType,
       })
-
-      if (triggerNode) {
-        const def = unifiedNodeRegistry.getDefinition(triggerNode.data.type as string)
-        if (def?.triggerType) {
-          triggerType = def.triggerType
-        }
-
-        // Resource triggers need special handling for entityDefinitionId
-        if (triggerNode.data.type === 'resource-trigger') {
-          const { operation, entityDefinitionId: nodeEntityDefId } = triggerNode.data
-          if (operation && nodeEntityDefId) {
-            const mappedTriggerType =
-              RESOURCE_OPERATION_TO_TRIGGER_TYPE[operation as ResourceTriggerOperation]
-            if (mappedTriggerType) {
-              triggerType = mappedTriggerType
-              entityDefinitionId = nodeEntityDefId
-            }
-          }
-        }
-
-        // Manual trigger maps to FORM
-        if (triggerNode.data.type === 'manual') {
-          triggerType = TriggerType.FORM
-        }
-      }
+      const triggerType = derived.triggerType ?? workflow.triggerType
+      const entityDefinitionId = derived.entityDefinitionId
 
       payload.graph = { nodes: cleanNodes, edges: cleanEdges, viewport: { x, y, zoom } }
       payload.triggerType = triggerType

--- a/apps/web/src/components/workflow/nodes/core/message-received/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/message-received/schema.ts
@@ -1,115 +1,19 @@
 // apps/web/src/components/workflow/nodes/core/message-received/schema.ts
 
-import { conditionGroupsSchema } from '@auxx/lib/conditions/client'
-import { WorkflowTriggerType } from '@auxx/lib/workflow-engine/client'
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  NodeType,
-  type ValidationResult,
-} from '~/components/workflow/types'
+import { messageReceivedManifest, type NodeManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
 import { BaseType, type UnifiedVariable } from '../../../types/variable-types'
 import {
   createNestedVariable,
   createUnifiedOutputVariable,
 } from '../../../utils/variable-conversion'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { MessageReceivedNodeData } from './types'
 
-/**
- * Zod schema for message-received configuration
- * @deprecated Use messageReceivedNodeDataSchema instead
- */
-export const messageReceivedSchema = z.object({
-  title: z.string().min(1),
-  description: z.string().optional(),
-})
-
-/**
- * Zod schema for message-received node data (flattened structure)
- */
-export const messageReceivedNodeDataSchema = z.object({
-  // Base node properties
-  id: z.string(),
-  type: z.literal(NodeType.MESSAGE_RECEIVED),
-  selected: z.boolean(),
-
-  // Flattened config properties
-  title: z.string().min(1),
-  desc: z.string().optional(),
-  description: z.string().optional(),
-  variables: z.array(z.any()).optional(),
-  channelIds: z.array(z.string()).optional(),
-  machineMail: z.enum(['exclude', 'include']).optional(),
-  conditions: conditionGroupsSchema.optional(),
-
-  // Other node data properties
-  isValid: z.boolean().optional(),
-  errors: z.array(z.string()).optional(),
-  disabled: z.boolean().optional(),
-  outputVariables: z.array(z.string()).optional(),
-})
-
-/**
- * Default data for new message-received nodes (flattened)
- */
-export const messageReceivedDefaultData: Partial<MessageReceivedNodeData> = {
-  title: 'Message Received',
-  desc: 'Triggered when a new message is received',
-  variables: [],
-}
-
-/**
- * Warning shown (on the node badge and inline in the panel) when a trigger has
- * no channel scope. Unscoped is a valid, supported state, publish never
- * forces a choice, but it must stay visible: the dispatcher fans this
- * workflow out to every channel in the org.
- */
-export const UNSCOPED_MESSAGE_TRIGGER_WARNING =
-  'Unscoped: runs on every channel in the org. Select channels or an inbox under "Run on" to limit it.'
-
-/**
- * Validation function for message-received configuration
- */
-export const validateMessageReceivedConfig = (data: MessageReceivedNodeData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  // Support both old config format and new flattened format
-  const dataToValidate = 'config' in data ? (data as any).config : data
-
-  // Validate title
-  if (!dataToValidate.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  // Unscoped trigger, allowed, but must be an unmissable warning (§4).
-  if (!dataToValidate.channelIds || dataToValidate.channelIds.length === 0) {
-    errors.push({
-      field: 'channelIds',
-      message: UNSCOPED_MESSAGE_TRIGGER_WARNING,
-      type: 'warning',
-    })
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
-
-/**
- * Node definition for message-received
- */
-export const messageReceivedDefinition: NodeDefinition<MessageReceivedNodeData> = {
-  id: NodeType.MESSAGE_RECEIVED,
-  category: NodeCategory.TRIGGER,
-  displayName: 'Message Received',
-  description: 'Triggers when a new message is received',
-  icon: 'mail',
-  color: '#10b981', // TRIGGER category color
-  defaultData: messageReceivedDefaultData,
-  schema: messageReceivedNodeDataSchema,
-  validator: validateMessageReceivedConfig as any,
-  triggerType: WorkflowTriggerType.MESSAGE_RECEIVED,
-  outputVariables: getMessageReceivedOutputVariables as any,
-}
+// The data half (data interface, zod schema, defaults, validator, the
+// unscoped-trigger warning) lives in the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/message-received`). This file is
+// the merge site: manifest + the web-only output resolver.
 
 /**
  * Define output variables for message-received node
@@ -249,3 +153,20 @@ function getMessageReceivedOutputVariables(
 
   return [messageVariable, threadRelation, messageRelation, ticketRelation]
 }
+
+/** Node definition for message-received */
+export const messageReceivedDefinition: NodeDefinition<MessageReceivedNodeData> =
+  defineFromManifest(messageReceivedManifest as unknown as NodeManifest<MessageReceivedNodeData>, {
+    outputVariables: getMessageReceivedOutputVariables as any,
+  })
+
+// Back-compat re-exports so no panel or consumer import churns:
+export {
+  messageReceivedNodeDataSchema,
+  UNSCOPED_MESSAGE_TRIGGER_WARNING,
+  validateMessageReceivedConfig,
+} from '@auxx/lib/workflow-engine/client'
+
+/** Default data for new message-received nodes (flattened) */
+export const messageReceivedDefaultData =
+  messageReceivedManifest.defaultData() as Partial<MessageReceivedNodeData>

--- a/apps/web/src/components/workflow/nodes/core/message-received/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/message-received/types.ts
@@ -1,40 +1,20 @@
 // apps/web/src/components/workflow/nodes/core/message-received/types.ts
 
-import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import type { CatalogMessageReceivedNodeData } from '@auxx/lib/workflow-engine/client'
 import type { ExecutionResult } from '~/components/workflow/types'
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/message-received`);
+// MessageReceivedNodeData narrows `type` to the web NodeType enum, same as
+// BaseNodeData does over its lib counterpart.
 
 /**
  * Node data for message-received nodes (flattened structure)
  */
-export interface MessageReceivedNodeData extends BaseNodeData {
-  desc?: string // Legacy field, prefer description
-  /**
-   * Channel scope, which channels' inbound mail can start this workflow.
-   * `undefined`/empty means **all channels** (the default, publish never
-   * forces a choice). Read by the `triggerMessageWorkflows` dispatcher off the
-   * published graph (`triggerNode.data.channelIds`), not by the runtime node
-   * itself. The "Inboxes" picker in the panel is UI sugar only: picking an
-   * inbox writes that inbox's channel ids in here.
-   */
-  channelIds?: string[]
-  /**
-   * Soft-tier machine-mail handling (out-of-office replies, mailing-list /
-   * notification mail). `'exclude'` (the default when absent) skips this
-   * workflow for soft machine mail; `'include'` opts it in. Read off the
-   * published graph by the `triggerMessageWorkflows` dispatcher. Hard-tier
-   * machine mail (bounces / delivery-failure NDRs) is always skipped
-   * regardless of this setting.
-   */
-  machineMail?: 'exclude' | 'include'
-  /**
-   * Content conditions, replaces the deleted "Message Filters" UI. Evaluated
-   * by the engine with the shared `evaluateConditionsWithDiagnostics` against
-   * message-resolvable fields (from/to/subject/body/hasAttachments).
-   * Deliberately excludes `channel`/`isInbound`, channel scoping lives only
-   * in `channelIds` above. Undefined/empty means "runs on every message".
-   */
-  conditions?: ConditionGroup[]
+export interface MessageReceivedNodeData extends CatalogMessageReceivedNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/resource-trigger/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/resource-trigger/schema.ts
@@ -1,154 +1,28 @@
 // apps/web/src/components/workflow/nodes/core/resource-trigger/schema.ts
 
-import { isKnownOperator, operatorRequiresValue } from '@auxx/lib/conditions/client'
-import { WorkflowTriggerType } from '@auxx/lib/workflow-engine/client'
-import { NodeCategory, type NodeDefinition } from '~/components/workflow/types'
+import { type NodeManifest, resourceTriggerManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
+import { defineFromManifest } from '../../define-from-manifest'
 import { getResourceTriggerOutputVariables } from './output-variables'
-import {
-  type ResourceTriggerData,
-  resourceTriggerNodeDataSchema,
-  type ValidationResult,
-} from './types'
+import type { ResourceTriggerData } from './types'
 
-/** Operations configuration */
-const RESOURCE_OPERATIONS: Record<string, { operation: string; label: string }> = {
-  created: { operation: 'created', label: 'Created' },
-  updated: { operation: 'updated', label: 'Updated' },
-  deleted: { operation: 'deleted', label: 'Deleted' },
-  manual: { operation: 'manual', label: 'Manual' },
-}
-
-/**
- * Get the appropriate icon for a resource/operation combination
- */
-function getResourceTriggerIcon(resourceType: string, operation: string): string {
-  const operationSuffixes: Record<string, string> = {
-    created: 'Plus',
-    updated: '',
-    deleted: 'Minus',
-    manual: 'Play',
-  }
-
-  if (operation === 'manual') return 'Play'
-  if (operation === 'updated') return 'Zap'
-
-  const suffix = operationSuffixes[operation] || ''
-  return suffix ? `Zap${suffix}` : 'Zap'
-}
-
-/**
- * Create default data for resource trigger
- */
-export function createResourceTriggerDefaultData(
-  resourceType: string = 'contact',
-  operation: string = 'created'
-): Partial<ResourceTriggerData> {
-  const operationConfig = RESOURCE_OPERATIONS[operation]
-
-  return {
-    title: `Record ${operationConfig?.label || operation}`,
-    desc: `Triggered when a record is ${operation}`,
-    description: `Triggered when a record is ${operation}`,
-    icon: getResourceTriggerIcon(resourceType, operation),
-    variables: [],
-    isValid: true,
-    errors: [],
-    disabled: false,
-    outputVariables: [],
-    resourceType,
-    operation: operation as 'created' | 'updated' | 'deleted' | 'manual',
-    // No filter = fire on every record. The engine reads this key.
-    filters: [],
-  }
-}
-
-/**
- * Validation function
- */
-export const validateResourceTriggerConfig = (data: ResourceTriggerData): ValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
-
-  if (!data.resourceType?.trim()) {
-    errors.push({ field: 'resourceType', message: 'Resource type is required', type: 'error' })
-  }
-
-  if (!data.operation) {
-    errors.push({ field: 'operation', message: 'Operation is required', type: 'error' })
-  }
-
-  if (!data.title?.trim()) {
-    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
-  }
-
-  if (data.title && data.title.length > 100) {
-    errors.push({
-      field: 'title',
-      message: 'Title is too long (max 100 characters)',
-      type: 'warning',
-    })
-  }
-
-  if (data.description && data.description.length > 500) {
-    errors.push({
-      field: 'description',
-      message: 'Description is too long (max 500 characters)',
-      type: 'warning',
-    })
-  }
-
-  // Trigger filters are a GATE — a condition that does not evaluate as written makes
-  // the engine refuse to fire the workflow at all (`resource-trigger-base.ts`). Reject
-  // it at save time so the author sees it here rather than as a workflow that stopped
-  // running for no visible reason.
-  for (const group of data.filters ?? []) {
-    for (const condition of group.conditions) {
-      if (condition.isConstant === false) {
-        errors.push({
-          field: 'filters',
-          message: 'Trigger filters cannot reference workflow variables',
-          type: 'error',
-        })
-      }
-      if (!isKnownOperator(condition.operator)) {
-        errors.push({
-          field: 'filters',
-          message: `Unknown filter operator: "${condition.operator}"`,
-          type: 'error',
-        })
-      } else if (operatorRequiresValue(condition.operator) && isBlank(condition.value)) {
-        errors.push({
-          field: 'filters',
-          message: `Filter on "${String(condition.fieldId)}" is missing a value`,
-          type: 'error',
-        })
-      }
-    }
-  }
-
-  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
-}
-
-/** A condition value the author has not filled in yet. */
-function isBlank(value: unknown): boolean {
-  if (value === undefined || value === null || value === '') return true
-  return Array.isArray(value) && value.length === 0
-}
+// The data half (data interface, zod schema, defaults, validator) lives in
+// the node catalog (`@auxx/lib/workflow-engine/catalog/nodes/resource-trigger`).
+// This file is the merge site: manifest + the web-only output resolver (which
+// reads the resource store context and moves server-side in Phase 2).
 
 /**
  * Unified resource trigger definition
  * Now supports both system resources and custom entities
  */
-export const resourceTriggerDefinition: NodeDefinition<ResourceTriggerData> = {
-  id: 'resource-trigger',
-  category: NodeCategory.TRIGGER,
-  displayName: 'Record',
-  description: 'Triggers when a record event occurs (create, update, delete, or manual)',
-  icon: 'zap',
-  color: '#10b981',
-  defaultData: createResourceTriggerDefaultData('contact', 'created'),
-  schema: resourceTriggerNodeDataSchema,
-  validator: validateResourceTriggerConfig,
-  triggerType: WorkflowTriggerType.RESOURCE_TRIGGER,
+export const resourceTriggerDefinition: NodeDefinition<ResourceTriggerData> = defineFromManifest(
+  resourceTriggerManifest as unknown as NodeManifest<ResourceTriggerData>,
   // Pattern: Accepts resource context from var store for dynamic variable generation
-  outputVariables: getResourceTriggerOutputVariables,
-}
+  { outputVariables: getResourceTriggerOutputVariables }
+)
+
+// Back-compat re-exports so no consumer import churns:
+export {
+  createResourceTriggerDefaultData,
+  validateResourceTriggerConfig,
+} from '@auxx/lib/workflow-engine/client'

--- a/apps/web/src/components/workflow/nodes/core/resource-trigger/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/resource-trigger/types.ts
@@ -1,81 +1,25 @@
 // apps/web/src/components/workflow/nodes/core/resource-trigger/types.ts
 
-import type { ConditionGroup } from '@auxx/lib/conditions/client'
-import { conditionGroupsSchema } from '@auxx/lib/conditions/client'
-import { z } from 'zod'
+import type { CatalogResourceTriggerData } from '@auxx/lib/workflow-engine/client'
 import type { ExecutionResult } from '~/components/workflow/types'
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
-import { NodeType } from '~/components/workflow/types/node-types'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
+
+// The data half moved to the node catalog (node-catalog Phase 1 —
+// `@auxx/lib/workflow-engine/catalog/nodes/resource-trigger`); re-exported
+// here so no web import churns. ResourceTriggerData narrows `type` to the web
+// NodeType enum and re-requires `entityDefinitionId` — the catalog admits the
+// pre-backfill draft state, but the panel backfills it on mount, so the web
+// view is always post-backfill.
+export { resourceTriggerNodeDataSchema } from '@auxx/lib/workflow-engine/client'
 
 /**
  * Node data for resource trigger nodes (flattened structure)
  */
-export interface ResourceTriggerData extends BaseNodeData {
-  // Base node properties (inherited from BaseNodeData)
-  id: string
+export interface ResourceTriggerData extends CatalogResourceTriggerData {
   type: NodeType.RESOURCE_TRIGGER
-  selected: boolean
-
-  // Resource trigger configuration
-  resourceType: string // Resource ID for display (e.g., 'contact', 'ticket', 'entity_vendors')
-  entityDefinitionId: string // Actual entity definition ID: 'contact', 'ticket', 'clq1abc123'
-  operation: 'created' | 'updated' | 'deleted' | 'manual'
-
-  // Node configuration (flattened structure like other nodes)
-  title: string
-  desc?: string
-  description?: string
-  variables?: any[]
-
-  /**
-   * Trigger filter — the gate that decides whether the workflow runs at all.
-   *
-   * Groups are AND'd; conditions inside a group combine by the group's
-   * `logicalOperator`. An empty/absent filter means "fire on every record".
-   *
-   * Read by `resource-trigger-base.ts`, which evaluates it with the shared
-   * `evaluateConditionsWithDiagnostics` and REFUSES to fire when any condition
-   * does not evaluate as written. Values are constants only — a trigger fires
-   * before any node has run, so there is no workflow variable to reference.
-   */
-  filters?: ConditionGroup[]
-
-  // Standard node data properties
-  isValid?: boolean
-  errors?: string[]
-  disabled?: boolean
-  outputVariables?: string[]
+  entityDefinitionId: string
 }
-
-/**
- * Zod schema for validation
- */
-export const resourceTriggerNodeDataSchema = z.object({
-  // Base node properties
-  id: z.string(),
-  type: z.literal(NodeType.RESOURCE_TRIGGER),
-  selected: z.boolean(),
-
-  // Resource trigger configuration
-  resourceType: z.string().min(1, 'Resource type is required'),
-  entityDefinitionId: z.string().min(1, 'Entity definition ID is required'),
-  operation: z.enum(['created', 'updated', 'deleted', 'manual']),
-
-  // Flattened config properties
-  title: z.string().min(1),
-  desc: z.string().optional(),
-  description: z.string().optional(),
-  variables: z.array(z.any()).optional(),
-
-  // Trigger filter — condition groups, AND'd at the top level
-  filters: conditionGroupsSchema.optional(),
-
-  // Standard properties
-  isValid: z.boolean().optional(),
-  errors: z.array(z.string()).optional(),
-  disabled: z.boolean().optional(),
-  outputVariables: z.array(z.string()).optional(),
-})
 
 /**
  * Full Resource Trigger node type for React Flow

--- a/packages/lib/src/workflow-engine/catalog/derive-trigger.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/derive-trigger.test.ts
@@ -1,0 +1,73 @@
+// packages/lib/src/workflow-engine/catalog/derive-trigger.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { WorkflowTriggerType } from '../core/types'
+import { deriveTriggerColumns } from './derive-trigger'
+
+/**
+ * The trigger-columns derivation moved from `use-workflow-save.ts` (browser)
+ * to lib — these pin the behavior it must preserve, in particular the two
+ * load-bearing quirks from `plans/kopilot/workflow/05-resource-model.md` §4.
+ */
+describe('deriveTriggerColumns', () => {
+  it('returns empty when the graph has no trigger node', () => {
+    const nodes = [{ data: { type: 'http' } }, { data: { type: 'if-else' } }]
+    expect(deriveTriggerColumns(nodes)).toEqual({})
+  })
+
+  it('maps a manual node to FORM, not MANUAL', () => {
+    const result = deriveTriggerColumns([{ data: { type: 'manual' } }])
+    expect(result.triggerType).toBe(WorkflowTriggerType.FORM)
+    expect(result.entityDefinitionId).toBeUndefined()
+  })
+
+  it('derives scheduled and message-received from the catalog', () => {
+    expect(deriveTriggerColumns([{ data: { type: 'scheduled' } }]).triggerType).toBe(
+      WorkflowTriggerType.SCHEDULED
+    )
+    expect(deriveTriggerColumns([{ data: { type: 'message-received' } }]).triggerType).toBe(
+      WorkflowTriggerType.MESSAGE_RECEIVED
+    )
+  })
+
+  it('maps a fully configured resource-trigger to the operation-specific type + entity id', () => {
+    const result = deriveTriggerColumns([
+      { data: { type: 'resource-trigger', operation: 'created', entityDefinitionId: 'ticket' } },
+    ])
+    expect(result.triggerType).toBe(WorkflowTriggerType.CREATED)
+    expect(result.entityDefinitionId).toBe('ticket')
+  })
+
+  it('leaves a half-configured resource-trigger at the generic type with no entity id', () => {
+    // Missing entityDefinitionId (the pre-panel-backfill draft state)
+    const noEntity = deriveTriggerColumns([
+      { data: { type: 'resource-trigger', operation: 'created' } },
+    ])
+    expect(noEntity.triggerType).toBe(WorkflowTriggerType.RESOURCE_TRIGGER)
+    expect(noEntity.entityDefinitionId).toBeUndefined()
+
+    // Missing operation
+    const noOperation = deriveTriggerColumns([
+      { data: { type: 'resource-trigger', entityDefinitionId: 'ticket' } },
+    ])
+    expect(noOperation.triggerType).toBe(WorkflowTriggerType.RESOURCE_TRIGGER)
+    expect(noOperation.entityDefinitionId).toBeUndefined()
+  })
+
+  it('uses the FIRST trigger node in graph order', () => {
+    const result = deriveTriggerColumns([
+      { data: { type: 'code' } },
+      { data: { type: 'scheduled' } },
+      { data: { type: 'manual' } },
+    ])
+    expect(result.triggerType).toBe(WorkflowTriggerType.SCHEDULED)
+  })
+
+  it('consults a caller-supplied resolver for types the catalog cannot see', () => {
+    const result = deriveTriggerColumns([{ data: { type: 'someapp:new-row' } }], {
+      resolveTriggerType: (nodeType) =>
+        nodeType === 'someapp:new-row' ? WorkflowTriggerType.APP_TRIGGER : undefined,
+    })
+    expect(result.triggerType).toBe(WorkflowTriggerType.APP_TRIGGER)
+  })
+})

--- a/packages/lib/src/workflow-engine/catalog/derive-trigger.ts
+++ b/packages/lib/src/workflow-engine/catalog/derive-trigger.ts
@@ -1,0 +1,88 @@
+// packages/lib/src/workflow-engine/catalog/derive-trigger.ts
+
+import {
+  RESOURCE_OPERATION_TO_TRIGGER_TYPE,
+  type ResourceTriggerOperation,
+  WorkflowTriggerType,
+} from '../core/types'
+import { getManifest } from './registry'
+
+/**
+ * The graph-node subset the derivation reads. React Flow nodes, engine nodes
+ * and agent-authored graphs all satisfy it structurally.
+ */
+export interface TriggerDerivationNode {
+  data?: {
+    type?: string
+    operation?: string
+    entityDefinitionId?: string
+    [key: string]: any
+  } | null
+}
+
+export interface DerivedTriggerColumns {
+  /** Undefined ⇒ no trigger node found — the caller keeps its previous value. */
+  triggerType?: WorkflowTriggerType
+  /** Set only by a fully configured resource-trigger. */
+  entityDefinitionId?: string
+}
+
+/**
+ * Derive `Workflow.triggerType` / `Workflow.entityDefinitionId` from a graph's
+ * nodes — THE one implementation of the derivation `use-workflow-save.ts` used
+ * to inline in the browser (plan §6b): the server takes these columns on
+ * trust with the posted graph, so every writer must derive them identically or
+ * a "switched" trigger keeps firing on the old one.
+ *
+ * Two load-bearing quirks, preserved verbatim (see `05-resource-model.md` §4):
+ *  - a `manual` node maps to `TriggerType.FORM`, not MANUAL;
+ *  - a `resource-trigger` sets the columns only when BOTH `operation` and
+ *    `entityDefinitionId` are present — a half-configured trigger leaves
+ *    `triggerType` at the generic RESOURCE_TRIGGER and no entity id.
+ *
+ * `resolveTriggerType` maps a node's `data.type` to its trigger type. The
+ * default consults the catalog, which covers every migrated trigger; apps/web
+ * passes its registry-backed resolver because the canvas can also hold
+ * not-yet-migrated triggers (webhook, webhook-endpoint) and dynamic app
+ * triggers (`appId:triggerId` → APP_TRIGGER / APP_POLLING_TRIGGER) the catalog
+ * cannot see yet.
+ */
+export function deriveTriggerColumns(
+  nodes: readonly TriggerDerivationNode[],
+  opts?: {
+    resolveTriggerType?: (nodeType: string) => WorkflowTriggerType | undefined
+  }
+): DerivedTriggerColumns {
+  const resolve =
+    opts?.resolveTriggerType ?? ((nodeType: string) => getManifest(nodeType)?.triggerType)
+
+  const triggerNode = nodes.find((n) => {
+    const nodeType = n.data?.type
+    return nodeType !== undefined && resolve(nodeType) !== undefined
+  })
+  if (!triggerNode?.data?.type) return {}
+
+  const nodeType = triggerNode.data.type
+  let triggerType = resolve(nodeType)
+  let entityDefinitionId: string | undefined
+
+  // Resource triggers need special handling for entityDefinitionId
+  if (nodeType === 'resource-trigger') {
+    const { operation, entityDefinitionId: nodeEntityDefId } = triggerNode.data
+    if (operation && nodeEntityDefId) {
+      const mappedTriggerType =
+        RESOURCE_OPERATION_TO_TRIGGER_TYPE[operation as ResourceTriggerOperation]
+      if (mappedTriggerType) {
+        triggerType = mappedTriggerType
+        entityDefinitionId = nodeEntityDefId
+      }
+    }
+  }
+
+  // Manual trigger maps to FORM
+  if (nodeType === 'manual') {
+    triggerType = WorkflowTriggerType.FORM
+  }
+
+  return { triggerType, entityDefinitionId }
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/message-received.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/message-received.ts
@@ -1,0 +1,166 @@
+// packages/lib/src/workflow-engine/catalog/nodes/message-received.ts
+
+import { z } from 'zod'
+import { type ConditionGroup, conditionGroupsSchema } from '../../../conditions/client'
+import { WorkflowTriggerType } from '../../core/types'
+import type { BaseNodeData } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+
+/**
+ * The message-received node's catalog manifest. Carries the #1555 scoping
+ * fields: `channelIds` (absent/empty = fires on EVERY channel in the org —
+ * allowed, but surfaced as `UNSCOPED_MESSAGE_TRIGGER_WARNING`), `conditions`
+ * (the shared ConditionGroup dialect, evaluated fail-closed), and
+ * `machineMail`. All three are read off the PUBLISHED graph by the
+ * `triggerMessageWorkflows` dispatcher, not by the runtime node. The
+ * deprecated duplicate `messageReceivedSchema` (zero consumers) was deleted.
+ */
+
+/**
+ * Node data for message-received nodes (flattened structure)
+ */
+export interface MessageReceivedNodeData extends BaseNodeData {
+  /**
+   * Channel scope, which channels' inbound mail can start this workflow.
+   * `undefined`/empty means **all channels** (the default, publish never
+   * forces a choice). Read by the `triggerMessageWorkflows` dispatcher off the
+   * published graph (`triggerNode.data.channelIds`), not by the runtime node
+   * itself. The "Inboxes" picker in the panel is UI sugar only: picking an
+   * inbox writes that inbox's channel ids in here.
+   */
+  channelIds?: string[]
+  /**
+   * Soft-tier machine-mail handling (out-of-office replies, mailing-list /
+   * notification mail). `'exclude'` (the default when absent) skips this
+   * workflow for soft machine mail; `'include'` opts it in. Read off the
+   * published graph by the `triggerMessageWorkflows` dispatcher. Hard-tier
+   * machine mail (bounces / delivery-failure NDRs) is always skipped
+   * regardless of this setting.
+   */
+  machineMail?: 'exclude' | 'include'
+  /**
+   * Content conditions, replaces the deleted "Message Filters" UI. Evaluated
+   * by the engine with the shared `evaluateConditionsWithDiagnostics` against
+   * message-resolvable fields (from/to/subject/body/hasAttachments).
+   * Deliberately excludes `channel`/`isInbound`, channel scoping lives only
+   * in `channelIds` above. Undefined/empty means "runs on every message".
+   */
+  conditions?: ConditionGroup[]
+}
+
+/**
+ * Zod schema for message-received node data (flattened structure)
+ */
+export const messageReceivedNodeDataSchema = z.object({
+  // Base node properties
+  id: z.string(),
+  type: z.literal('message-received'),
+  // .default(false) aligns with baseNodeDataSchema — the node factory sets it
+  selected: z.boolean().default(false),
+
+  // Flattened config properties
+  title: z.string().min(1),
+  desc: z.string().optional(),
+  description: z.string().optional(),
+  variables: z.array(z.any()).optional(),
+  channelIds: z.array(z.string()).optional(),
+  machineMail: z.enum(['exclude', 'include']).optional(),
+  conditions: conditionGroupsSchema.optional(),
+
+  // Other node data properties
+  isValid: z.boolean().optional(),
+  errors: z.array(z.string()).optional(),
+  disabled: z.boolean().optional(),
+  outputVariables: z.array(z.string()).optional(),
+})
+
+/**
+ * Warning shown (on the node badge and inline in the panel) when a trigger has
+ * no channel scope. Unscoped is a valid, supported state, publish never
+ * forces a choice, but it must stay visible: the dispatcher fans this
+ * workflow out to every channel in the org.
+ */
+export const UNSCOPED_MESSAGE_TRIGGER_WARNING =
+  'Unscoped: runs on every channel in the org. Select channels or an inbox under "Run on" to limit it.'
+
+/**
+ * Validation function for message-received configuration
+ */
+export const validateMessageReceivedConfig = (
+  data: MessageReceivedNodeData
+): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  // Support both old config format and new flattened format
+  const dataToValidate = 'config' in data ? (data as any).config : data
+
+  // Validate title
+  if (!dataToValidate.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  // Unscoped trigger, allowed, but must be an unmissable warning (§4).
+  if (!dataToValidate.channelIds || dataToValidate.channelIds.length === 0) {
+    errors.push({
+      field: 'channelIds',
+      message: UNSCOPED_MESSAGE_TRIGGER_WARNING,
+      type: 'warning',
+    })
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/**
+ * Message-received node manifest
+ */
+export const messageReceivedManifest: NodeManifest<MessageReceivedNodeData> = {
+  id: 'message-received',
+  category: NodeCategory.TRIGGER,
+  displayName: 'Message Received',
+  description: 'Triggers when a new message is received',
+  icon: 'mail',
+  color: '#10b981', // TRIGGER category color
+  triggerType: WorkflowTriggerType.MESSAGE_RECEIVED,
+  defaultData: () => ({
+    title: 'Message Received',
+    desc: 'Triggered when a new message is received',
+    variables: [],
+  }),
+  configSchema: messageReceivedNodeDataSchema as unknown as z.ZodType<MessageReceivedNodeData>,
+  validate: validateMessageReceivedConfig,
+  connection: {},
+  agent: {
+    authorable: true,
+    usage:
+      'ALWAYS scope with `channelIds` unless the user explicitly wants org-wide firing — absent or ' +
+      'empty means the workflow runs on EVERY channel in the org (the validator surfaces this as a ' +
+      'warning; relay it and push toward scoping). `conditions` filter on message content ' +
+      '(from/to/subject/body/hasAttachments, shared ConditionGroup dialect, fail-closed); channel ' +
+      "scoping lives ONLY in `channelIds`. `machineMail: 'include'` opts into soft machine mail " +
+      '(out-of-office, list mail); bounces are always skipped.',
+    examples: [
+      {
+        description: 'Fire on support-inbox mail that mentions a refund',
+        config: {
+          channelIds: ['channel_abc123'],
+          conditions: [
+            {
+              id: 'g1',
+              logicalOperator: 'AND',
+              conditions: [
+                {
+                  id: 'c1',
+                  fieldId: 'subject',
+                  operator: 'contains',
+                  value: 'refund',
+                  isConstant: true,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/resource-trigger.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/resource-trigger.ts
@@ -1,0 +1,248 @@
+// packages/lib/src/workflow-engine/catalog/nodes/resource-trigger.ts
+
+import { z } from 'zod'
+import {
+  type ConditionGroup,
+  conditionGroupsSchema,
+  isKnownOperator,
+  operatorRequiresValue,
+} from '../../../conditions/client'
+import { WorkflowTriggerType } from '../../core/types'
+import type { BaseNodeData } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+
+/**
+ * The resource-trigger node's catalog manifest.
+ *
+ * Drift fixed during the move (plan §6): `resourceTriggerNodeDataSchema`
+ * required `entityDefinitionId` (`.min(1)`) while
+ * `createResourceTriggerDefaultData()` never sets it — the defaults failed
+ * their own schema. Never bit in the builder because the panel backfills the
+ * id on mount, so it would have bitten exactly (and only) a server-side
+ * author. The schema now admits the pre-backfill draft state; the trigger
+ * columns derivation (`derive-trigger.ts`) already requires BOTH `operation`
+ * and `entityDefinitionId` before it sets anything.
+ */
+
+/**
+ * Node data for resource trigger nodes (flattened structure)
+ */
+export interface ResourceTriggerData extends BaseNodeData {
+  // Resource trigger configuration
+  resourceType: string // Resource ID for display (e.g., 'contact', 'ticket', 'entity_vendors')
+  /**
+   * Actual entity definition ID: 'contact', 'ticket', 'clq1abc123'.
+   * Absent on a freshly added node until the panel backfills it on mount —
+   * apps/web narrows this to required (its post-backfill view).
+   */
+  entityDefinitionId?: string
+  operation: 'created' | 'updated' | 'deleted' | 'manual'
+
+  variables?: any[]
+
+  /**
+   * Trigger filter — the gate that decides whether the workflow runs at all.
+   *
+   * Groups are AND'd; conditions inside a group combine by the group's
+   * `logicalOperator`. An empty/absent filter means "fire on every record".
+   *
+   * Read by `resource-trigger-base.ts`, which evaluates it with the shared
+   * `evaluateConditionsWithDiagnostics` and REFUSES to fire when any condition
+   * does not evaluate as written. Values are constants only — a trigger fires
+   * before any node has run, so there is no workflow variable to reference.
+   */
+  filters?: ConditionGroup[]
+}
+
+/**
+ * Zod schema for validation
+ */
+export const resourceTriggerNodeDataSchema = z.object({
+  // Base node properties
+  id: z.string(),
+  type: z.literal('resource-trigger'),
+  // .default(false) aligns with baseNodeDataSchema — the node factory sets it
+  selected: z.boolean().default(false),
+
+  // Resource trigger configuration
+  resourceType: z.string().min(1, 'Resource type is required'),
+  // Pre-backfill draft state is a node without this key — see the header note.
+  entityDefinitionId: z.string().optional(),
+  operation: z.enum(['created', 'updated', 'deleted', 'manual']),
+
+  // Flattened config properties
+  title: z.string().min(1),
+  desc: z.string().optional(),
+  description: z.string().optional(),
+  variables: z.array(z.any()).optional(),
+
+  // Trigger filter — condition groups, AND'd at the top level
+  filters: conditionGroupsSchema.optional(),
+
+  // Standard properties
+  isValid: z.boolean().optional(),
+  errors: z.array(z.string()).optional(),
+  disabled: z.boolean().optional(),
+  outputVariables: z.array(z.string()).optional(),
+})
+
+/** Operations configuration */
+const RESOURCE_OPERATIONS: Record<string, { operation: string; label: string }> = {
+  created: { operation: 'created', label: 'Created' },
+  updated: { operation: 'updated', label: 'Updated' },
+  deleted: { operation: 'deleted', label: 'Deleted' },
+  manual: { operation: 'manual', label: 'Manual' },
+}
+
+/**
+ * Get the appropriate icon for a resource/operation combination
+ */
+function getResourceTriggerIcon(_resourceType: string, operation: string): string {
+  const operationSuffixes: Record<string, string> = {
+    created: 'Plus',
+    updated: '',
+    deleted: 'Minus',
+    manual: 'Play',
+  }
+
+  if (operation === 'manual') return 'Play'
+  if (operation === 'updated') return 'Zap'
+
+  const suffix = operationSuffixes[operation] || ''
+  return suffix ? `Zap${suffix}` : 'Zap'
+}
+
+/**
+ * Create default data for resource trigger
+ */
+export function createResourceTriggerDefaultData(
+  resourceType: string = 'contact',
+  operation: string = 'created'
+): Partial<ResourceTriggerData> {
+  const operationConfig = RESOURCE_OPERATIONS[operation]
+
+  return {
+    title: `Record ${operationConfig?.label || operation}`,
+    desc: `Triggered when a record is ${operation}`,
+    description: `Triggered when a record is ${operation}`,
+    icon: getResourceTriggerIcon(resourceType, operation),
+    variables: [],
+    isValid: true,
+    errors: [],
+    disabled: false,
+    outputVariables: [],
+    resourceType,
+    operation: operation as 'created' | 'updated' | 'deleted' | 'manual',
+    // No filter = fire on every record. The engine reads this key.
+    filters: [],
+  }
+}
+
+/**
+ * Validation function
+ */
+export const validateResourceTriggerConfig = (data: ResourceTriggerData): NodeValidationResult => {
+  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+
+  if (!data.resourceType?.trim()) {
+    errors.push({ field: 'resourceType', message: 'Resource type is required', type: 'error' })
+  }
+
+  if (!data.operation) {
+    errors.push({ field: 'operation', message: 'Operation is required', type: 'error' })
+  }
+
+  if (!data.title?.trim()) {
+    errors.push({ field: 'title', message: 'Title is required', type: 'error' })
+  }
+
+  if (data.title && data.title.length > 100) {
+    errors.push({
+      field: 'title',
+      message: 'Title is too long (max 100 characters)',
+      type: 'warning',
+    })
+  }
+
+  if (data.description && data.description.length > 500) {
+    errors.push({
+      field: 'description',
+      message: 'Description is too long (max 500 characters)',
+      type: 'warning',
+    })
+  }
+
+  // Trigger filters are a GATE — a condition that does not evaluate as written makes
+  // the engine refuse to fire the workflow at all (`resource-trigger-base.ts`). Reject
+  // it at save time so the author sees it here rather than as a workflow that stopped
+  // running for no visible reason.
+  for (const group of data.filters ?? []) {
+    for (const condition of group.conditions) {
+      if (condition.isConstant === false) {
+        errors.push({
+          field: 'filters',
+          message: 'Trigger filters cannot reference workflow variables',
+          type: 'error',
+        })
+      }
+      if (!isKnownOperator(condition.operator)) {
+        errors.push({
+          field: 'filters',
+          message: `Unknown filter operator: "${condition.operator}"`,
+          type: 'error',
+        })
+      } else if (operatorRequiresValue(condition.operator) && isBlank(condition.value)) {
+        errors.push({
+          field: 'filters',
+          message: `Filter on "${String(condition.fieldId)}" is missing a value`,
+          type: 'error',
+        })
+      }
+    }
+  }
+
+  return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
+}
+
+/** A condition value the author has not filled in yet. */
+function isBlank(value: unknown): boolean {
+  if (value === undefined || value === null || value === '') return true
+  return Array.isArray(value) && value.length === 0
+}
+
+/**
+ * Resource trigger node manifest
+ */
+export const resourceTriggerManifest: NodeManifest<ResourceTriggerData> = {
+  id: 'resource-trigger',
+  category: NodeCategory.TRIGGER,
+  displayName: 'Record',
+  description: 'Triggers when a record event occurs (create, update, delete, or manual)',
+  icon: 'zap',
+  color: '#10b981',
+  triggerType: WorkflowTriggerType.RESOURCE_TRIGGER,
+  defaultData: () => createResourceTriggerDefaultData('contact', 'created'),
+  configSchema: resourceTriggerNodeDataSchema as unknown as z.ZodType<ResourceTriggerData>,
+  validate: validateResourceTriggerConfig,
+  connection: {},
+  agent: {
+    authorable: true,
+    usage:
+      '`resourceType`/`entityDefinitionId` name the record type (for custom entities the id is an ' +
+      'EntityDefinition CUID — resolve it, never guess) and `operation` picks the event. BOTH ' +
+      '`operation` and `entityDefinitionId` must be set or the workflow trigger columns are not ' +
+      "derived and the trigger will not fire. `filters` gate firing: groups AND'd, constants only " +
+      '(no {{…}} refs — nothing has run yet); empty means every record fires.',
+    examples: [
+      {
+        description: 'Fire when a ticket is created',
+        config: {
+          resourceType: 'ticket',
+          entityDefinitionId: 'ticket',
+          operation: 'created',
+          filters: [],
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -17,12 +17,12 @@
  */
 export const NOT_YET_MIGRATED: readonly string[] = [
   // Triggers
-  'message-received',
+  // 'message-received' — migrated (catalog/nodes/message-received.ts)
   'webhook',
   'webhook-endpoint',
   // 'scheduled' — migrated (catalog/nodes/scheduled.ts)
   // 'manual' — migrated (catalog/nodes/manual.ts)
-  'resource-trigger',
+  // 'resource-trigger' — migrated (catalog/nodes/resource-trigger.ts)
   // Legacy per-resource triggers (kept for backwards compatibility)
   'contact-created-trigger',
   'contact-updated-trigger',

--- a/packages/lib/src/workflow-engine/catalog/registry.ts
+++ b/packages/lib/src/workflow-engine/catalog/registry.ts
@@ -13,7 +13,9 @@ import { informationExtractorManifest } from './nodes/information-extractor'
 import { listManifest } from './nodes/list'
 import { loopManifest } from './nodes/loop'
 import { manualManifest } from './nodes/manual'
+import { messageReceivedManifest } from './nodes/message-received'
 import { noteManifest } from './nodes/note'
+import { resourceTriggerManifest } from './nodes/resource-trigger'
 import { scheduledTriggerManifest } from './nodes/scheduled'
 import { textClassifierManifest } from './nodes/text-classifier'
 import { varAssignManifest } from './nodes/var-assign'
@@ -45,7 +47,9 @@ const ALL_MANIFESTS: NodeManifest<any>[] = [
   listManifest,
   loopManifest,
   manualManifest,
+  messageReceivedManifest,
   noteManifest,
+  resourceTriggerManifest,
   scheduledTriggerManifest,
   textClassifierManifest,
   varAssignManifest,

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -70,6 +70,15 @@ export * from './utils/terminal-nodes'
 // NOTE: Operator definitions moved to @auxx/lib/conditions
 // Import OPERATOR_DEFINITIONS, Operator, etc. from '@auxx/lib/conditions' or '@auxx/lib/conditions/client'
 
+// ── Node catalog (Phase 1 of the node-catalog migration) ─────────────────────
+// The server-safe node contract: manifest types, the registry, the migration
+// tracker, and the pure variable-inference helpers split out of apps/web
+// utils/variable-utils.ts (the store-reading display helpers stayed there).
+export {
+  type DerivedTriggerColumns,
+  deriveTriggerColumns,
+  type TriggerDerivationNode,
+} from './catalog/derive-trigger'
 export {
   type BaseNodeData as CatalogBaseNodeData,
   type BranchType,
@@ -228,12 +237,26 @@ export {
   validateManualData,
 } from './catalog/nodes/manual'
 export {
+  type MessageReceivedNodeData as CatalogMessageReceivedNodeData,
+  messageReceivedManifest,
+  messageReceivedNodeDataSchema,
+  UNSCOPED_MESSAGE_TRIGGER_WARNING,
+  validateMessageReceivedConfig,
+} from './catalog/nodes/message-received'
+export {
   type NoteNodeData as CatalogNoteNodeData,
   type NoteTheme,
   noteManifest,
   noteNodeDataSchema,
   validateNoteConfig,
 } from './catalog/nodes/note'
+export {
+  createResourceTriggerDefaultData,
+  type ResourceTriggerData as CatalogResourceTriggerData,
+  resourceTriggerManifest,
+  resourceTriggerNodeDataSchema,
+  validateResourceTriggerConfig,
+} from './catalog/nodes/resource-trigger'
 export {
   extractScheduledTriggerVariables,
   type ScheduledTriggerNodeData as CatalogScheduledTriggerNodeData,
@@ -273,10 +296,6 @@ export {
   waitManifest,
   waitNodeDataSchema,
 } from './catalog/nodes/wait'
-// ── Node catalog (Phase 1 of the node-catalog migration) ─────────────────────
-// The server-safe node contract: manifest types, the registry, the migration
-// tracker, and the pure variable-inference helpers split out of apps/web
-// utils/variable-utils.ts (the store-reading display helpers stayed there).
 export { NOT_YET_MIGRATED } from './catalog/not-yet-migrated'
 export {
   getAuthorableManifests,

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/message-received.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/message-received.ts
@@ -6,43 +6,36 @@ import type { ThreadEntity } from '@auxx/database/types'
 import { toRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
 import { getCachedEntityDefId } from '../../../cache'
-import type { ConditionGroup } from '../../../conditions/types'
 import { evaluateMessageConditions } from '../../../message-trigger-conditions'
+import type { MessageReceivedNodeData } from '../../catalog/nodes/message-received'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, TEST_RECORD_ID, WorkflowNodeType } from '../../core/types'
 import { BaseNodeProcessor } from '../base-node'
 
 /**
- * Config (`node.data`) for the MESSAGE_RECEIVED trigger node.
+ * Config (`node.data`) for the MESSAGE_RECEIVED trigger node — the config
+ * subset of the catalog's `MessageReceivedNodeData` (node-catalog Phase 1;
+ * this file previously shadowed it). Deliberately WITHOUT `channelIds`: the
+ * `triggerMessageWorkflows` dispatcher reads channel scope off the published
+ * graph; the runtime processor never re-checks it.
+ *
+ * `conditions` are evaluated via `message-trigger-conditions/evaluate.ts`'s
+ * `evaluateMessageConditions`, which fails CLOSED (non-match) on any condition
+ * that doesn't evaluate as written. The legacy `filters` (single-valued
+ * domain/keyword matchers) and `message_filter` (dead builder toggle) keys are
+ * ignored if still present on an old graph — the runtime path that evaluated
+ * them was deleted outright (plan
+ * `2026-08-12-message-trigger-scoping-and-send-safety.md` §3).
+ *
+ * `machineMail` is likewise a dispatcher gate: `'exclude'` (default when
+ * absent) skips soft machine mail, hard-tier machine mail (bounces/NDRs) is
+ * always skipped regardless.
  */
-export interface MessageReceivedTriggerConfig {
-  /**
-   * Content conditions gating the trigger — the shared condition-group shape
-   * the condition builder writes (mail filters, record rules, if-else nodes).
-   * `undefined` or empty matches every message. Evaluated via
-   * `message-trigger-conditions/evaluate.ts`'s `evaluateMessageConditions`,
-   * which fails CLOSED (non-match) on any condition that doesn't evaluate as
-   * written — see that module for why.
-   *
-   * Replaces the legacy `filters` (single-valued domain/keyword matchers) and
-   * `message_filter` (dead builder toggle, never read) keys. Both are ignored
-   * if still present on an old graph — the runtime path that evaluated them
-   * has been deleted outright (plan
-   * `2026-08-12-message-trigger-scoping-and-send-safety.md` §3; no published
-   * message workflows existed to migrate).
-   */
-  conditions?: ConditionGroup[]
-  /**
-   * Soft-tier machine-mail handling (OOO auto-replies, list/notification mail).
-   * `'exclude'` (the default when absent) skips this workflow for soft machine
-   * mail; `'include'` opts it in. Hard-tier machine mail (bounces/NDRs) is always
-   * skipped at the dispatcher regardless of this setting. Read by
-   * `triggerMessageWorkflows` off the published graph — the runtime processor
-   * does not re-check it (the dispatcher is the gate).
-   */
-  machineMail?: 'exclude' | 'include'
-}
+export type MessageReceivedTriggerConfig = Pick<
+  MessageReceivedNodeData,
+  'conditions' | 'machineMail'
+>
 
 /** Output shape for the `message.attachments` node variable. */
 interface MessageAttachmentOutput {


### PR DESCRIPTION
Continues node-catalog Phase 1 (`plans/kopilot/workflow/01-node-catalog.md`, after #1570) — the trigger batch plus §6b. 20 wave-1 types are now migrated; the tracker holds only `crud`/`find` (which land with Phase 2's output-resolution work) and the deliberately-deferred types.

## resource-trigger — drift fixed during the move (D4, plan §6)

`resourceTriggerNodeDataSchema` required `entityDefinitionId` (`.min(1)`) while `createResourceTriggerDefaultData()` never sets it — the defaults failed their own schema. It never bit in the builder because the panel backfills the id on mount, so it would have bitten exactly (and only) a server-side author. The catalog schema now admits the pre-backfill draft state; apps/web narrows the field back to required (its post-backfill view), and the trigger-columns derivation already refuses to set anything without it. The filter-gate validation (fail-closed conditions, constants only) moved verbatim.

## message-received

Carries the #1555 scoping fields with their full doc trail: `channelIds` (absent/empty = fires on EVERY channel — allowed, surfaced as `UNSCOPED_MESSAGE_TRIGGER_WARNING`, which moved to the catalog with its panel re-export intact), fail-closed `conditions`, and `machineMail`. The agent docs instruct scoping and relaying the unscoped warning (index D11/§4). Deleted the deprecated duplicate `messageReceivedSchema` (zero consumers). The engine's `MessageReceivedTriggerConfig` shadow is now a `Pick` of the catalog type — deliberately without `channelIds`, which is a dispatcher gate read off the published graph.

## deriveTriggerColumns (plan §6b)

`use-workflow-save.ts` derived `Workflow.triggerType` / `Workflow.entityDefinitionId` inline in the browser; the server takes them on trust, so an agent writing only `graph` would leave them stale. The derivation now lives in `catalog/derive-trigger.ts` with both load-bearing quirks preserved verbatim (a `manual` node maps to FORM, not MANUAL; a `resource-trigger` sets the columns only when BOTH `operation` and `entityDefinitionId` are present — pinned by a new unit test).

It takes a pluggable `resolveTriggerType`, defaulting to the catalog. The web hook passes its registry-backed resolver because the canvas can still hold not-yet-migrated triggers (webhook, webhook-endpoint) and dynamic app triggers (`appId:triggerId` → APP_TRIGGER / APP_POLLING_TRIGGER) the catalog cannot see yet.

**Deliberately not absorbed here:** `workflow-service.ts`'s server-side trigger branches (the `webhook-endpoint` columns, explicit clear, `resolveActiveInstallationId`) — the re-verification note (`09-reverification-2026-08-12.md` §6) flags them for the same function, but that's a server save-path refactor that belongs with Phase 3's graph-edit writes, not this move.

## Verification

- Zero-diff panels: only `schema.ts` / `types.ts` changed under the two `core/<type>/` folders
- lib + web typecheck ratchets green (29/29, 1/1)
- New `derive-trigger.test.ts` pins the derivation behavior; full lib `workflow-engine` suite: 1020 passed (incl. existing message-received/trigger processor tests)
- Full `components/workflow` web sweep: 90 passed
- Biome error-level clean on all touched files