### PR TITLE
feat(ai): gate training-permissive providers for google-connected orgs

### DIFF
--- a/packages/lib/src/ai/providers/__tests__/limited-use-gate.test.ts
+++ b/packages/lib/src/ai/providers/__tests__/limited-use-gate.test.ts
@@ -1,0 +1,137 @@
+// packages/lib/src/ai/providers/__tests__/limited-use-gate.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Google Workspace Limited Use gate — see `plans/google-limited-use-provider-gate.md`.
+ *
+ * The gate bars AI providers whose terms permit training on submitted data from any org
+ * with a connected Google account, because ticket bodies and calendar/spreadsheet content
+ * reaching a model are Workspace-derived data.
+ *
+ * The fail-closed cases below are the ones that matter most: when they regress, nothing
+ * visibly breaks — the gate just silently stops applying.
+ */
+
+const hasAccess = vi.fn()
+const cacheGet = vi.fn()
+
+vi.mock('../../../cache/singletons', () => ({
+  getOrgCache: () => ({ get: cacheGet }),
+}))
+
+vi.mock('../../../permissions/feature-permission-service', () => ({
+  FeaturePermissionService: class {
+    hasAccess = hasAccess
+  },
+}))
+
+const { assertProviderAllowed, isOrgLimitedUseGated } = await import('../config/limited-use')
+const { LIMITED_USE_SAFE_PROVIDERS, isProviderLimitedUseBlocked } = await import(
+  '../config/context'
+)
+
+const ORG = 'org_1'
+const googleChannel = [{ provider: 'google' }]
+const outlookOnly = [{ provider: 'outlook' }]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hasAccess.mockResolvedValue(false)
+  cacheGet.mockResolvedValue(googleChannel)
+})
+
+describe('isOrgLimitedUseGated', () => {
+  it('gates an org with a connected Google channel', async () => {
+    await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(true)
+  })
+
+  it('does not gate an org with no Google channel', async () => {
+    cacheGet.mockResolvedValue(outlookOnly)
+    await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(false)
+  })
+
+  it('does not gate an org with no channels at all', async () => {
+    cacheGet.mockResolvedValue([])
+    await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(false)
+  })
+
+  it('un-gates when unrestrictedAiProviders is explicitly granted', async () => {
+    hasAccess.mockResolvedValue(true)
+    await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(false)
+  })
+
+  // The `channels` cache provider filters soft-deleted rows, so a disconnected Google
+  // channel must not leave the org gated forever.
+  it('un-gates once the Google channel is disconnected', async () => {
+    cacheGet.mockResolvedValue([])
+    await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(false)
+  })
+
+  describe('fails closed', () => {
+    it('gates when the channels read throws', async () => {
+      cacheGet.mockRejectedValue(new Error('redis down'))
+      await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(true)
+    })
+
+    it('gates when the feature read throws', async () => {
+      hasAccess.mockRejectedValue(new Error('plan lookup failed'))
+      await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(true)
+    })
+
+    // A plan row predating this release has no `unrestrictedAiProviders` key at all.
+    // `hasAccess` reads a missing boolean gate as false, which must leave the org GATED.
+    it('gates when the feature key is absent from the plan', async () => {
+      hasAccess.mockResolvedValue(false)
+      await expect(isOrgLimitedUseGated(ORG)).resolves.toBe(true)
+    })
+  })
+})
+
+describe('assertProviderAllowed', () => {
+  it.each([...LIMITED_USE_SAFE_PROVIDERS])('allows %s on a gated org', async (provider) => {
+    await expect(assertProviderAllowed(provider, ORG)).resolves.toBeUndefined()
+  })
+
+  it.each([
+    'deepseek',
+    'qwen',
+    'kimi',
+    'zai',
+    'grok',
+  ])('blocks %s on a gated org', async (provider) => {
+    await expect(assertProviderAllowed(provider, ORG)).rejects.toMatchObject({
+      code: 'LIMITED_USE_BLOCKED',
+    })
+  })
+
+  it.each([
+    'deepseek',
+    'qwen',
+    'kimi',
+    'zai',
+    'grok',
+  ])('allows %s on an org with no Google channel', async (provider) => {
+    cacheGet.mockResolvedValue(outlookOnly)
+    await expect(assertProviderAllowed(provider, ORG)).resolves.toBeUndefined()
+  })
+
+  it('allows a blocked provider once unrestrictedAiProviders is granted', async () => {
+    hasAccess.mockResolvedValue(true)
+    await expect(assertProviderAllowed('deepseek', ORG)).resolves.toBeUndefined()
+  })
+})
+
+describe('isProviderLimitedUseBlocked', () => {
+  it('blocks nothing when the org is not gated', () => {
+    expect(isProviderLimitedUseBlocked('deepseek', false)).toBe(false)
+  })
+
+  it('blocks a non-allowlisted provider when gated', () => {
+    expect(isProviderLimitedUseBlocked('deepseek', true)).toBe(true)
+  })
+
+  it('never blocks an allowlisted provider', () => {
+    expect(isProviderLimitedUseBlocked('anthropic', true)).toBe(false)
+  })
+})

--- a/packages/lib/src/ai/providers/config/cache.ts
+++ b/packages/lib/src/ai/providers/config/cache.ts
@@ -12,7 +12,8 @@ import {
   type ProviderConfigurations,
 } from '../types'
 import { getSortedProviders } from '../utils'
-import type { AiProviderCtx } from './context'
+import { type AiProviderCtx, isProviderLimitedUseBlocked } from './context'
+import { isOrgLimitedUseGated } from './limited-use'
 import { resolveCredentials } from './runtime-credentials'
 
 const logger = createScopedLogger('ai-provider-config-cache')
@@ -23,11 +24,26 @@ const logger = createScopedLogger('ai-provider-config-cache')
  * except as a miss-fallback to the compute layer's `resolveCredentials`.
  */
 
-/** All provider configurations for the org, from the `aiProviderConfigs` cache key. */
+/**
+ * All provider configurations for the org, from the `aiProviderConfigs` cache key.
+ *
+ * Limited-Use-blocked providers are dropped HERE rather than in the compute layer, so the
+ * cached blob stays the full truth and the gate is evaluated against the org's current
+ * state on every read. That means connecting or disconnecting a Google channel, or toggling
+ * `unrestrictedAiProviders`, takes effect immediately — no `aiProviderConfigs` invalidation
+ * to get wrong, and no stale blob that fails open.
+ */
 export async function getProviderConfigs(ctx: AiProviderCtx): Promise<ProviderConfigurations> {
   try {
     const configurations = await getOrgCache().get(ctx.organizationId, 'aiProviderConfigs')
-    return { organizationId: ctx.organizationId, configurations }
+    const gated = await isOrgLimitedUseGated(ctx.organizationId)
+    if (!gated) return { organizationId: ctx.organizationId, configurations }
+
+    const allowed: typeof configurations = {}
+    for (const [provider, config] of Object.entries(configurations)) {
+      if (!isProviderLimitedUseBlocked(provider, gated)) allowed[provider] = config
+    }
+    return { organizationId: ctx.organizationId, configurations: allowed }
   } catch (error) {
     logger.error('Failed to get provider configurations', {
       organizationId: ctx.organizationId,
@@ -49,6 +65,16 @@ export async function getProviderConfig(
   const configurations = await getOrgCache().get(ctx.organizationId, 'aiProviderConfigs')
   const config = configurations[provider]
   if (!config) {
+    throw new ProviderConfigurationError(
+      `Provider '${provider}' not found in configurations`,
+      provider,
+      'PROVIDER_NOT_FOUND'
+    )
+  }
+  // A Limited-Use-blocked provider reads as absent rather than as a distinct error, so
+  // callers treat it exactly like an unconfigured provider. `createClient` is what
+  // produces the explicit LIMITED_USE_BLOCKED failure if something calls it anyway.
+  if (isProviderLimitedUseBlocked(provider, await isOrgLimitedUseGated(ctx.organizationId))) {
     throw new ProviderConfigurationError(
       `Provider '${provider}' not found in configurations`,
       provider,

--- a/packages/lib/src/ai/providers/config/context.ts
+++ b/packages/lib/src/ai/providers/config/context.ts
@@ -18,3 +18,25 @@ export type AiProviderCtx = {
  * Must match the providers seeded in organization-seeder.ts.
  */
 export const SYSTEM_ELIGIBLE_PROVIDERS = new Set(['anthropic', 'openai'])
+
+/**
+ * Providers whose standard API terms forbid training on submitted data.
+ *
+ * The Google Workspace API User Data and Developer Policy (Limited Use) bars transferring
+ * Workspace data — raw, aggregated, anonymized or derived — to third parties that use it to
+ * train generalized AI/ML models. An org with a connected Google account may therefore only
+ * reach providers on this list. See `plans/google-limited-use-provider-gate.md`.
+ *
+ * `google` belongs here only on the PAID Gemini tier; the free AI Studio tier trains on
+ * prompts. Re-check before adding a provider — this list is a compliance assertion.
+ */
+export const LIMITED_USE_SAFE_PROVIDERS = new Set(['openai', 'anthropic', 'google', 'groq'])
+
+/**
+ * Whether a provider is blocked for an org, given the org's already-resolved gate state.
+ * Pure — both the read layer and the client factory resolve `gated` their own way (see
+ * `limited-use.ts`) and share this decision so the two can never diverge.
+ */
+export function isProviderLimitedUseBlocked(providerId: string, gated: boolean): boolean {
+  return gated && !LIMITED_USE_SAFE_PROVIDERS.has(providerId)
+}

--- a/packages/lib/src/ai/providers/config/limited-use.ts
+++ b/packages/lib/src/ai/providers/config/limited-use.ts
@@ -1,0 +1,77 @@
+// packages/lib/src/ai/providers/config/limited-use.ts
+
+import { getOrgCache } from '../../../cache/singletons'
+import { createScopedLogger } from '../../../logger'
+import { FeaturePermissionService } from '../../../permissions/feature-permission-service'
+import { FeatureKey } from '../../../permissions/types'
+import { ProviderError } from '../base/types'
+import { isProviderLimitedUseBlocked } from './context'
+
+const logger = createScopedLogger('ai-limited-use-gate')
+
+/**
+ * Google Workspace Limited Use gate.
+ *
+ * An organization with a connected Google account may only use AI providers whose terms
+ * forbid training on submitted data (`LIMITED_USE_SAFE_PROVIDERS`), because ticket bodies,
+ * calendar entries and spreadsheet rows reaching a model are Workspace-derived data.
+ *
+ * This module deliberately imports neither `./cache` nor `../provider-registry`: `cache.ts`
+ * already imports `ProviderRegistry`, so a shared helper living in either would create an
+ * import cycle. Both enforcement layers import this one instead.
+ */
+
+/**
+ * Whether the Limited Use restriction currently applies to an org.
+ *
+ * Gated unless the org has no connected Google account, or an operator has explicitly set
+ * `unrestrictedAiProviders` on its plan. The `channels` cache provider already excludes
+ * soft-deleted rows, so a disconnected Google channel correctly un-gates the org.
+ *
+ * Fails CLOSED: any error resolving the org's state leaves the org gated. A compliance
+ * control that opens up when a cache read fails is worse than none.
+ */
+export async function isOrgLimitedUseGated(organizationId: string): Promise<boolean> {
+  try {
+    const channels = await getOrgCache().get(organizationId, 'channels')
+    if (!channels.some((channel) => channel.provider === 'google')) return false
+
+    // `hasAccess` is fail-closed for boolean gates (a missing key reads as false) and
+    // returns true on self-hosted, where the operator runs their own OAuth client and is
+    // their own data controller.
+    const unrestricted = await new FeaturePermissionService().hasAccess(
+      organizationId,
+      FeatureKey.unrestrictedAiProviders
+    )
+    return !unrestricted
+  } catch (error) {
+    logger.error('Failed to resolve Limited Use gate state; defaulting to gated', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return true
+  }
+}
+
+/**
+ * Throw if a provider may not be used by this org. The hard backstop — every provider
+ * client is constructed through `ProviderRegistry.createClient`, so a blocked provider
+ * cannot be reached via a stored model id, a pinned agent version, a workflow node or a
+ * scheduled job, regardless of what the UI shows.
+ */
+export async function assertProviderAllowed(
+  providerId: string,
+  organizationId: string
+): Promise<void> {
+  const gated = await isOrgLimitedUseGated(organizationId)
+  if (!isProviderLimitedUseBlocked(providerId, gated)) return
+
+  logger.warn('Blocked a Limited Use provider', { organizationId, provider: providerId })
+  throw new ProviderError(
+    `Provider '${providerId}' is unavailable for organizations with a connected Google account. ` +
+      'Its terms permit training on submitted data, which the Google Workspace Limited Use ' +
+      'requirements prohibit for Google user data.',
+    providerId,
+    'LIMITED_USE_BLOCKED'
+  )
+}

--- a/packages/lib/src/ai/providers/provider-registry.ts
+++ b/packages/lib/src/ai/providers/provider-registry.ts
@@ -4,6 +4,7 @@ import { createScopedLogger } from '../../logger'
 import { ANTHROPIC_CAPABILITIES, ANTHROPIC_MODELS } from './anthropic/anthropic-defaults'
 import type { ProviderClient, ProviderClientConstructor } from './base/provider-client'
 import { ProviderError } from './base/types'
+import { assertProviderAllowed } from './config/limited-use'
 import { DEEPSEEK_CAPABILITIES, DEEPSEEK_MODELS } from './deepseek/deepseek-defaults'
 import { GOOGLE_CAPABILITIES, GOOGLE_MODELS } from './google/google-defaults'
 import { GROK_CAPABILITIES, GROK_MODELS } from './grok/grok-defaults'
@@ -369,6 +370,12 @@ export class ProviderRegistry {
     cache?: any
   ): Promise<ProviderClient> {
     await ProviderRegistry.initialize()
+
+    // Google Workspace Limited Use gate. Enforced here because this is the single
+    // construction site for every provider client, so a blocked provider cannot be reached
+    // through a stored model id, a pinned agent version, a workflow node or a scheduled
+    // job — regardless of what any UI or cached config offers.
+    await assertProviderAllowed(providerId, organizationId)
 
     const registration = ProviderRegistry.providers[providerId]
 

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -49,6 +49,12 @@ export enum FeatureKey {
   dispatch = 'dispatch',
   sequences = 'sequences',
   granularPermissions = 'granularPermissions',
+  /**
+   * Google Workspace Limited Use compliance control, not a purchasable feature.
+   * `false` on every plan tier; set per-org only for orgs with no connected Google
+   * account. Absent MUST be read as `false` — see `plans/google-limited-use-provider-gate.md`.
+   */
+  unrestrictedAiProviders = 'unrestrictedAiProviders',
 
   // ── Static limits (count of things, not time-based) ──
   teammates = 'teammates',
@@ -215,6 +221,16 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     description:
       'Configure per-member capability grants beyond the built-in role defaults, plus inbox access levels, conversation sharing, and inbox manager delegation.',
     group: 'Security',
+  },
+  {
+    key: FeatureKey.unrestrictedAiProviders,
+    type: 'boolean',
+    label: 'Unrestricted AI Providers',
+    // Compliance control, not a plan feature. OFF everywhere by default; enabling it on an
+    // org with a connected Google account would breach the Limited Use requirements.
+    description:
+      'Allow AI providers whose terms permit training on submitted data. Off for every plan; enable only for organizations with no connected Google account.',
+    group: 'AI',
   },
 
   // ── Static limits ──

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -126,7 +126,21 @@ const STATIC_LIMITS = {
   },
 } as const
 
-/** Boolean gates (on/off) keyed by plan tier */
+/**
+ * Boolean gates (on/off) keyed by plan tier.
+ *
+ * `unrestrictedAiProviders` is not a plan feature and is deliberately `false` on every
+ * tier, including enterprise. It is a compliance control for the Google Workspace API
+ * User Data Policy (Limited Use), which bars transferring Workspace data to third parties
+ * that train on it. OFF means the org may only reach AI providers whose terms forbid
+ * training (see `LIMITED_USE_SAFE_PROVIDERS`); ON re-opens the full provider list and must
+ * only ever be set on an org with **no connected Google account**.
+ *
+ * It lives here so it can be flipped per-org without a deploy — not because it is
+ * purchasable. Do not promote it to a paid tier, and do not read it through a helper that
+ * treats a missing key as permitted: the read site inverts the usual default so that
+ * absent means restricted. See `plans/google-limited-use-provider-gate.md`.
+ */
 const BOOLEAN_GATES = {
   demo: {
     knowledgeBase: true,
@@ -158,6 +172,9 @@ const BOOLEAN_GATES = {
     // Demo carried `mailPermissions: true` before plan v3/03 §7.6 folded that key
     // into this one, so the demo org keeps demoing sharing (D9).
     granularPermissions: true,
+    // Google Workspace Limited Use gate. OFF on every tier by design — see the note
+    // above `BOOLEAN_GATES`. Flip per-org only for an org with no Google connection.
+    unrestrictedAiProviders: false,
   },
   free: {
     knowledgeBase: true,
@@ -182,6 +199,7 @@ const BOOLEAN_GATES = {
     dispatch: false,
     sequences: false,
     granularPermissions: false,
+    unrestrictedAiProviders: false,
   },
   starter: {
     knowledgeBase: true,
@@ -207,6 +225,7 @@ const BOOLEAN_GATES = {
     // On at a metered 3 (`sequencesLimit`) — the upgrade lever into Growth's 25.
     sequences: true,
     granularPermissions: false,
+    unrestrictedAiProviders: false,
   },
   growth: {
     knowledgeBase: true,
@@ -231,6 +250,7 @@ const BOOLEAN_GATES = {
     dispatch: true,
     sequences: true,
     granularPermissions: true,
+    unrestrictedAiProviders: false,
   },
   enterprise: {
     knowledgeBase: true,
@@ -255,6 +275,7 @@ const BOOLEAN_GATES = {
     dispatch: true,
     sequences: true,
     granularPermissions: true,
+    unrestrictedAiProviders: false,
   },
 } as const
 


### PR DESCRIPTION
## Why

Google Trust & Safety's 2026-08-13 verification response added a new requirement: under the Google Workspace API User Data and Developer Policy (Limited Use), Workspace data — raw, aggregated, anonymized or derived — must not be transferred to third parties that use it to train generalized AI/ML models.

Ticket bodies, calendar entries and spreadsheet rows reaching a model are Workspace-derived data. Today an org with a connected Gmail channel can point ticket drafting at DeepSeek, Qwen, Kimi, Z.ai or Grok, whose standard API terms permit training on submitted data.

## What

An org with a connected Google account may now only reach providers whose terms forbid training on submitted data: `openai`, `anthropic`, `google`, `groq`. The other five are blocked for those orgs, including through a customer-supplied API key.

Orgs with no Google connection are unaffected.

### Two layers

**Read-time filtering** — `getProviderConfigs` / `getProviderConfig` in `config/cache.ts`. Blocked providers never surface in model pickers.

Filtering at the cache *read* rather than in `assemble.ts` is deliberate: the cached `aiProviderConfigs` blob stays the full truth and the gate is evaluated against live state on every read. There is no stale blob that fails open and no `aiProviderConfigs` invalidation to get wrong. `assemble.ts` is a cache-compute path whose header forbids reading the cache anyway.

**Hard backstop** — `ProviderRegistry.createClient`, the single construction site for every provider client. A blocked provider cannot be reached via a stored model id, a pinned agent version, a workflow node or a scheduled job, regardless of what any UI offers. This is the layer that makes the answer to Google auditable: one function, one grep.

### Notes

- `config/limited-use.ts` holds the resolver rather than `context.ts` because `config/cache.ts` already imports `ProviderRegistry`; a shared helper in either would make the registry's import a cycle.
- The gate **fails closed** — any error reading the org's channels or plan features leaves it gated.
- The `channels` cache provider already filters soft-deleted rows, so disconnecting a Google channel correctly un-gates the org.
- `resolveUtilityModel` already stays within the primary's provider family, so no cross-provider escape exists.

## The override

`FeatureKey.unrestrictedAiProviders`, `false` on every plan tier including enterprise.

It uses the plan-feature transport so a single org can be flipped without a deploy, but it is a compliance control, not a purchasable feature. **Only enable it for an org with no connected Google account** — enabling it on a Google-connected org is the violation itself, not a workaround for it.

No migration: plan rows are updated manually. Until a row carries the key, `hasAccess` reads it as absent → `false` → the org stays gated, which is the safe direction.

## Testing

`src/ai/providers/__tests__/limited-use-gate.test.ts` — 26 tests. All 266 tests under `src/ai/providers` pass; lint and typecheck clean for the touched files.

The three that matter most are the fail-closed cases (channels read throws, feature read throws, feature key absent from the plan) — when those regress nothing visibly breaks, the gate just silently stops applying.

## Before this is fully live

- [ ] Run the audit query in `plans/google-limited-use-provider-gate.md` §4 against prod. If any org has both a Google channel and a pinned blocked-provider binding, the backstop will throw on their live agent runs. Expected zero, but confirm.
- [ ] Confirm the prod `GOOGLE_API_KEY` tier — the free Gemini/AI Studio tier trains on prompts, so if it is free-tier, `google` must come off the allowlist.
- [ ] Pull current terms citations for all five allowlisted providers before asserting anything to Google in writing.

Refs `plans/google-limited-use-provider-gate.md`, `plans/google-oauth-verification-round3-reply.md`.