### PR TITLE
feat(apps): resolve unbound app nodes to the org default connection

### DIFF
--- a/apps/web/src/components/apps/hooks/use-app-connection-state.ts
+++ b/apps/web/src/components/apps/hooks/use-app-connection-state.ts
@@ -25,20 +25,30 @@ export interface AppConnectionInfo {
   requiresConnection: boolean
   /** Label of the resolved credential, when one resolved. */
   label: string | null
+  /**
+   * Id of the credential the run will actually use — the node's own
+   * `connectionId` when bound, otherwise the org's primary. Callers render this
+   * as the picker's implicit selection so an unbound node shows what it uses.
+   */
+  id: string | null
 }
 
-const LOADING: AppConnectionInfo = { state: 'loading', requiresConnection: false, label: null }
+const LOADING: AppConnectionInfo = {
+  state: 'loading',
+  requiresConnection: false,
+  label: null,
+  id: null,
+}
 
 /**
  * Resolve a node's connection state the same way the engine does at run time:
- * an explicit `connectionId` wins, otherwise any credential for the app (user-
- * or org-scoped) is a candidate — mirrors `resolveAppConnectionForRuntime`,
- * which falls back to whatever exists for the app when nothing is bound.
+ * an explicit `connectionId` wins, otherwise the org's *primary* credential for
+ * the app — `resolveAppConnectionForRuntime` bottoms out in `findCredential`,
+ * which orders by `isDefault` then newest and takes one row. Nothing here may
+ * accept a healthier credential than the one the run is going to get.
  *
- * Deliberately fails *open*: `listConnections` returns every user's credentials,
- * so a user-scoped app that somebody has connected reads as `ok` even though the
- * run's own user may not have connected. Only "nothing exists at all" is
- * reported as `missing`.
+ * Still fails open across users: `listConnections` returns every user's
+ * credentials, so a user-scoped app somebody else connected can win the pick.
  */
 export function deriveAppConnectionState({
   appId,
@@ -59,42 +69,33 @@ export function deriveAppConnectionState({
   )
 
   if (!requiresConnection) {
-    return { state: 'not_required', requiresConnection: false, label: null }
+    return { state: 'not_required', requiresConnection: false, label: null, id: null }
   }
 
-  // Explicit binding: that row is the only candidate. A bound id with no row is
-  // a deleted credential, which the engine cannot resolve either.
-  if (connectionId) {
-    const bound = appConnections.find((c) => c.id === connectionId)
-    if (!bound) return { state: 'missing', requiresConnection: true, label: null }
-    const label = bound.label ?? bound.appName ?? null
-    if (bound.connectionStatus === 'connected') {
-      return { state: 'ok', requiresConnection: true, label }
-    }
-    return {
-      state: bound.connectionStatus === 'expired' ? 'expired' : 'missing',
-      requiresConnection: true,
-      label,
-    }
-  }
+  // Bound: that row is the only candidate. A bound id with no row is a deleted
+  // credential, which the engine cannot resolve either. Unbound: the org's
+  // primary, newest as tiebreak — same order `findCredential` applies.
+  const picked = connectionId
+    ? appConnections.find((c) => c.id === connectionId)
+    : appConnections
+        .filter((c) => c.appId === appId)
+        .sort(
+          (a, b) =>
+            Number(b.isDefault) - Number(a.isDefault) ||
+            (b.connectedAt?.getTime() ?? 0) - (a.connectedAt?.getTime() ?? 0)
+        )[0]
 
-  // Unbound: any credential for the app can serve the run.
-  const candidates = appConnections.filter((c) => c.appId === appId)
-  if (candidates.length === 0) {
-    return { state: 'missing', requiresConnection: true, label: null }
-  }
-  const usable = candidates.find((c) => c.connectionStatus === 'connected')
-  if (usable) {
-    return {
-      state: 'ok',
-      requiresConnection: true,
-      label: usable.label ?? usable.appName ?? null,
-    }
-  }
+  if (!picked) return { state: 'missing', requiresConnection: true, label: null, id: null }
   return {
-    state: 'expired',
+    state:
+      picked.connectionStatus === 'connected'
+        ? 'ok'
+        : picked.connectionStatus === 'expired'
+          ? 'expired'
+          : 'missing',
     requiresConnection: true,
-    label: candidates[0]?.label ?? candidates[0]?.appName ?? null,
+    label: picked.label ?? picked.appName ?? null,
+    id: picked.id,
   }
 }
 

--- a/apps/web/src/components/apps/ui/app-account-picker.tsx
+++ b/apps/web/src/components/apps/ui/app-account-picker.tsx
@@ -23,6 +23,8 @@ interface AppAccountPickerProps {
   appId: string | null
   /** Currently-selected credId(s). String for single-select, array for multi-select. */
   value: string | string[] | undefined
+  /** True when `value` is the host's fallback default rather than a stored binding. */
+  valueIsDefault?: boolean
   /** Fires once per pick with the picked credId. Host decides single vs multi semantics. */
   onPick: (credId: string) => void
   /** Fires when the connect flow returns a new credential. */
@@ -53,6 +55,7 @@ interface AppAccountPickerProps {
 export function AppAccountPicker({
   appId,
   value,
+  valueIsDefault,
   onPick,
   onConnected,
   allowPersonal = true,
@@ -118,6 +121,7 @@ export function AppAccountPicker({
                   cred={c}
                   avatarUrl={avatarUrl}
                   selected={isSelected(c.id)}
+                  isDefault={!!valueIsDefault}
                   onSelect={() => onPick(c.id)}
                   onReconnect={reconnectHandler(c.id, 'user')}
                   onRemove={onRemove ? () => onRemove(c.id) : undefined}
@@ -134,6 +138,7 @@ export function AppAccountPicker({
                   cred={c}
                   avatarUrl={avatarUrl}
                   selected={isSelected(c.id)}
+                  isDefault={!!valueIsDefault}
                   onSelect={() => onPick(c.id)}
                   onReconnect={reconnectHandler(c.id, 'organization')}
                   onRemove={onRemove ? () => onRemove(c.id) : undefined}
@@ -185,6 +190,7 @@ function AccountRow({
   cred,
   avatarUrl,
   selected,
+  isDefault,
   onSelect,
   onReconnect,
   onRemove,
@@ -192,6 +198,8 @@ function AccountRow({
   cred: AppConnection
   avatarUrl: string | null
   selected: boolean
+  /** The row is checked because it is the host's default, not because it was picked. */
+  isDefault: boolean
   onSelect: () => void
   /** When set, the row shows a "Reconnect" action for expired/disconnected creds. */
   onReconnect?: () => void
@@ -216,6 +224,7 @@ function AccountRow({
       <span className='truncate'>{cred.label ?? cred.appName}</span>
       {needsReconnect && <TriangleAlert className='size-3.5 shrink-0 text-amber-600' />}
       <div className='ml-auto flex items-center gap-1.5'>
+        {selected && isDefault && <span className='text-xs text-muted-foreground'>Default</span>}
         {needsReconnect && onReconnect && (
           <Button
             type='button'

--- a/apps/web/src/components/apps/ui/app-account-popover.tsx
+++ b/apps/web/src/components/apps/ui/app-account-popover.tsx
@@ -14,6 +14,12 @@ interface AppAccountPopoverProps {
   appId: string | null
   /** Currently-selected credId(s). Renders as the trigger's value when single. */
   value: string | string[] | undefined
+  /**
+   * True when `value` is the workspace default the host falls back to rather
+   * than a binding the host stored. The row is still checked — it is the
+   * connection that will be used — but is labelled as the default.
+   */
+  valueIsDefault?: boolean
   /** Fires once per pick with the picked credId. Host decides single vs multi semantics. */
   onPick: (credId: string) => void
   /** Fires when the connect flow returns a new credential. */
@@ -55,6 +61,7 @@ interface AppAccountPopoverProps {
 export function AppAccountPopover({
   appId,
   value,
+  valueIsDefault,
   onPick,
   onConnected,
   onRemove,
@@ -103,6 +110,7 @@ export function AppAccountPopover({
           <AppAccountPicker
             appId={appId}
             value={value}
+            valueIsDefault={valueIsDefault}
             onPick={(credId) => {
               onPick(credId)
               setOpen(false)

--- a/apps/web/src/components/workflow/nodes/shared/base/base-panel.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/base/base-panel.tsx
@@ -42,6 +42,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import { useAppConnectionResolver } from '~/components/apps/hooks/use-app-connection-state'
 import { useBoundCredential } from '~/components/apps/hooks/use-bound-credential'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 import { AppAccountPopover } from '~/components/apps/ui/app-account-popover'
@@ -101,10 +102,10 @@ const KeyboardShortcut = ({ shortcut }: { shortcut: string }) => (
 )
 
 /**
- * Drawer-header icon for app nodes. Derives status from the node's *bound*
- * connection (the same source `AppSettingsTrigger` uses) so the header icon and
- * the trigger button never disagree — and so neither goes green off an unrelated
- * connection the node isn't actually bound to. See
+ * Drawer-header icon for app nodes. Both this and `AppSettingsTrigger` are
+ * handed the node's *effective* connection — its own binding, or the org primary
+ * the run would fall back to — so the header icon, the dot and the canvas
+ * warning always report the same credential. See
  * plans/kopilot/apps/agent-credentials.md §5.9.
  */
 function AppPanelIcon({
@@ -207,6 +208,13 @@ export const BasePanel = memo<BasePanelProps>(
     const { isReadOnly } = useReadOnly()
     const pathname = usePathname()
     const nodeType = data.type
+
+    // An unbound app node still runs against the org's primary connection, so
+    // report status and preselect the picker off that one — otherwise the panel
+    // reads "no connection" for a node that has one.
+    const resolveAppConnection = useAppConnectionResolver()
+    const effectiveConnectionId =
+      appContext?.connectionId ?? resolveAppConnection(appContext?.appId, undefined).id ?? undefined
 
     // Get all non-trigger definitions for node replacement
     const nonTriggerDefinitions = useNonTriggerDefinitions()
@@ -394,7 +402,7 @@ export const BasePanel = memo<BasePanelProps>(
           icon={
             appContext ? (
               <AppPanelIcon
-                connectionId={appContext.connectionId}
+                connectionId={effectiveConnectionId}
                 iconId={nodeIconName}
                 color={nodeColor}
               />
@@ -578,14 +586,21 @@ export const BasePanel = memo<BasePanelProps>(
                 <div className='ml-auto'>
                   <AppAccountPopover
                     appId={appContext.appId}
-                    value={appContext.connectionId}
+                    value={effectiveConnectionId}
+                    valueIsDefault={!appContext.connectionId}
                     onPick={(credId) => appContext.onConnectionChange?.(credId)}
                     onConnected={(credId) => appContext.onConnectionChange?.(credId)}
-                    onRemove={() => appContext.onConnectionChange?.(undefined)}
+                    // Only a pinned node has something to unpin — an unbound one
+                    // already follows the default, so "Remove" would be a no-op.
+                    onRemove={
+                      appContext.connectionId
+                        ? () => appContext.onConnectionChange?.(undefined)
+                        : undefined
+                    }
                     trigger={
                       <AppSettingsTrigger
                         appId={appContext.appId}
-                        connectionId={appContext.connectionId}
+                        connectionId={effectiveConnectionId}
                       />
                     }
                     appSettings={{

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -502,12 +502,6 @@
       "import": "./dist/field-values/client.mjs",
       "default": "./src/field-values/client.ts"
     },
-    "./field-values/converters": {
-      "types": "./src/field-values/converters/index.ts",
-      "source": "./src/field-values/converters/index.ts",
-      "import": "./dist/field-values/converters/index.mjs",
-      "default": "./src/field-values/converters/index.ts"
-    },
     "./files": {
       "types": "./src/files/index.ts",
       "source": "./src/files/index.ts",


### PR DESCRIPTION
> Note: this is work that was already in the working tree, not authored in this PR's session. Committed and opened on request. I read the full diff and verified it typechecks and lints, but I did not design or exercise the behaviour — worth a closer review than usual.

## What it does

An app node with no stored `connectionId` still runs against a credential: `resolveAppConnectionForRuntime` bottoms out in `findCredential`, which orders by `isDefault` then newest and takes one row.

`deriveAppConnectionState` did not mirror that. It accepted *any* connected credential for the app, so the panel could report a healthier connection than the run would actually get, and an unbound node read as "no connection" despite having one.

It now picks the same row the runtime would — the bound id when set, otherwise the org primary with newest as tiebreak — and returns that `id` so callers can render it. `BasePanel` derives one `effectiveConnectionId` and feeds the header icon, the settings trigger and the picker from it, so the icon, the dot and the canvas warning cannot disagree.

`AppAccountPicker` / `AppAccountPopover` gain `valueIsDefault`, which labels an implicitly-selected row as **Default** — the row is still checked, since it is the connection that will be used, but it reads as inherited rather than pinned. `Remove` is now only offered on a node that actually has a binding to unpin, where previously it was a no-op on unbound nodes.

The hook still fails open across users, and the comment says so: `listConnections` returns every user's credentials, so a user-scoped app someone else connected can win the pick.

## Second commit

`chore(lib): drop the unused field-values/converters export` is unrelated to the above and kept separate. It removes the `./field-values/converters` subpath from `packages/lib/package.json`. The only remaining importers are inside `packages/lib` itself using relative paths (`../../field-values/converters`), so nothing external resolves the subpath.

## Verification

- Biome clean on all 5 files.
- `tsc --noEmit` in `apps/web` reports 11 errors, none in these files — all pre-existing on `main` in `human/panel.tsx` (9), `kopilot/stream/route.ts` and `command-palette.tsx`. This branch adds none.
- No runtime verification: I did not exercise the picker, the default labelling, or an unbound node's resolution in the app.