### PR TITLE
fix(workflow): stop app blocks failing lambda envelope validation

### DIFF
--- a/apps/lambda/src/runtime-helpers/server-sdk.ts
+++ b/apps/lambda/src/runtime-helpers/server-sdk.ts
@@ -132,7 +132,7 @@ class ConflictError extends Error {
  *
  * @interface Connection
  * @property {string} id - Unique connection identifier
- * @property {('oauth2-code'|'secret')} type - Authentication type
+ * @property {('oauth2-code'|'client-credentials'|'secret'|'hosted-provision')} type - Authentication type
  * @property {string} value - The access token or secret value
  * @property {Object} [metadata] - Additional connection metadata
  * @property {string} [metadata.scope] - OAuth2 scopes granted
@@ -166,7 +166,7 @@ class ConflictError extends Error {
  */
 export interface Connection {
   id: string
-  type: 'oauth2-code' | 'secret'
+  type: 'oauth2-code' | 'client-credentials' | 'secret' | 'hosted-provision'
   value: string
   /** Connection variables (plain + decrypted secret-flagged), keyed by variable key. */
   fields?: Record<string, string>

--- a/apps/lambda/src/types.ts
+++ b/apps/lambda/src/types.ts
@@ -41,7 +41,7 @@ export interface ExecutionOptions {
  */
 export interface ConnectionData {
   id: string
-  type: 'oauth2-code' | 'secret'
+  type: 'oauth2-code' | 'client-credentials' | 'secret' | 'hosted-provision'
   value: string // Decrypted token/key/secret
   /** Merged connection-variable map (plain + decrypted secret-flagged), keyed by variable key. */
   fields?: Record<string, string>

--- a/apps/lambda/src/types/workflow.ts
+++ b/apps/lambda/src/types/workflow.ts
@@ -147,7 +147,7 @@ export interface WorkflowSDK {
  */
 export interface Connection {
   id: string
-  type: 'oauth2-code' | 'secret'
+  type: 'oauth2-code' | 'client-credentials' | 'secret' | 'hosted-provision'
   value: string
   metadata?: Record<string, any>
   expiresAt?: Date

--- a/apps/lambda/src/validator.ts
+++ b/apps/lambda/src/validator.ts
@@ -7,10 +7,19 @@
 
 import { z } from 'zod'
 
-/** Connection data schema */
+/**
+ * Connection data schema.
+ *
+ * `type` must stay in sync with `ConnectionType` in
+ * `packages/lib/src/connections/resolve-connection-for-runtime.ts` — that
+ * resolver is what fills this field. A type it emits but this enum omits
+ * rejects the whole invocation envelope with a bare "Validation failed",
+ * before the app bundle ever loads. Nothing branches on the value; it is
+ * descriptive only.
+ */
 const ConnectionDataSchema = z.object({
   id: z.string(),
-  type: z.enum(['oauth2-code', 'secret']),
+  type: z.enum(['oauth2-code', 'client-credentials', 'secret', 'hosted-provision']),
   value: z.string(),
   fields: z.record(z.string(), z.string()).optional(),
   metadata: z.record(z.string(), z.any()).optional(),

--- a/packages/lib/src/workflow-engine/nodes/app-workflow-block-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/app-workflow-block-processor.ts
@@ -233,10 +233,14 @@ export class AppWorkflowBlockProcessor extends BaseNodeProcessor {
       // Node outputs (entire objects per node)
       nodeOutputs: contextManager.getAllNodeVariables(),
 
-      // User and organization context
+      // User and organization context. `email` falls back to null, never '' —
+      // trigger-driven runs (message/resource/schedule) have no invoking user,
+      // and the lambda envelope types `context.userEmail` as
+      // `z.email().nullish()`, which accepts null but rejects the empty string.
+      // Coercing to '' rejects the whole event before the block ever loads.
       user: {
         id: context.userId || '',
-        email: (await contextManager.getVariable('sys.userEmail')) || '',
+        email: (await contextManager.getVariable('sys.userEmail')) || null,
         name: (await contextManager.getVariable('sys.userName')) || '',
       },
       organization: {
@@ -706,7 +710,28 @@ export class AppWorkflowBlockProcessor extends BaseNodeProcessor {
 
       if (lambdaResult.isErr()) {
         const error = lambdaResult.error
-        const lambdaError = Object.assign(new Error(`Lambda execution failed: ${error.message}`), {
+
+        // Envelope rejections (`VALIDATION_ERROR`) carry the offending fields in
+        // `details`; without them the message is a bare "Validation failed" and
+        // the lambda logs nothing on that branch. Same treatment as the code node.
+        let message = `Lambda execution failed: ${error.message}`
+        if (error.code === 'VALIDATION_ERROR' && error.details) {
+          const validationErrors = error.details
+            .map((err: any) => `  - ${err.field}: ${err.message}`)
+            .join('\n')
+          message += `\n\nValidation errors:\n${validationErrors}`
+        }
+
+        logger.error('Lambda invocation failed', {
+          appId,
+          blockId,
+          code: error.code,
+          message: error.message,
+          details: error.details,
+          statusCode: error.statusCode,
+        })
+
+        const lambdaError = Object.assign(new Error(message), {
           consoleLogs: error.consoleLogs,
         })
         throw lambdaError

--- a/packages/sdk/src/server/connections.ts
+++ b/packages/sdk/src/server/connections.ts
@@ -7,8 +7,15 @@ export interface Connection {
   /** Unique connection ID */
   id: string
 
-  /** Connection type (oauth2, api_key, secret) */
-  type: 'oauth2-code' | 'secret'
+  /**
+   * How the credential behind this connection was produced. Descriptive only —
+   * read `value`/`fields` to authenticate, not this.
+   * - `oauth2-code` — user-authorized OAuth2, auto-refreshed
+   * - `client-credentials` — server-minted bearer (no user, no browser)
+   * - `secret` — API key or multi-field secret
+   * - `hosted-provision` — platform-provisioned; no token semantics
+   */
+  type: 'oauth2-code' | 'client-credentials' | 'secret' | 'hosted-provision'
 
   /**
    * The credential value (access token, API key, or secret)


### PR DESCRIPTION
## What broke

Every trigger-driven workflow run that hits an app block fails with:

```
[app-workflow-block-processor]: Lambda execution failed
  { appId: "…", blockId: "shopify", error: "Lambda execution failed: Validation failed" }
```

Found while debugging the Shopify Demo org's `Shopify Order Lookup & Reply` workflow (run `qvkcomwtqo7rmhk6w11cngnp`). The Shopify connection is healthy and irrelevant — the block never ran.

## Root cause

`"Validation failed"` has one production source: `apps/lambda/src/index.ts:217`, the zod check on the **invocation envelope**, which runs before the app bundle is loaded. The lambda-server log for the failing run confirms it — `[Lambda:Auth] { decision: "accept" }` and then nothing, versus a successful run that logs `[BundleLoader]` → `[WorkflowBlockExecutor]` → `[ServerSDK] getOrganizationConnection`.

Message/resource/schedule-triggered runs have no invoking user, so `sys.userEmail` is undefined — visible in the worker log as `Variable not found: sys.userEmail`. `app-workflow-block-processor.ts:239` coerced that to `''`, which is passed through `prepareLambdaContext` into `context.userEmail`. The schema is `z.email().nullish()` (`validator.ts:25`) — `null` passes, `''` does not. Verified against the repo's zod 4.1.5: `''` → `invalid_format: "Invalid email address"`.

Manual runs from the builder were unaffected: `apps/web/src/app/api/workflows/[workflowId]/run/route.ts:227` forwards a real email. Every other headless call site already passes `null` explicitly (`polling-trigger-job.ts:236`, `webhooks.ts:380`, `tool-options.ts:97`). The app-block processor was the only one sending `''`.

## Changes

1. **The fix** — `email: … || null` instead of `|| ''`.

2. **The reason was unrecoverable from logs.** The reject branch in `index.ts` emits no log at all, and the processor rebuilt the error from `error.message` alone, dropping the `details` array that names the offending field. Now logged and appended to the message, the same way `action-nodes/code.ts:164-169` already does it.

3. **A second latent instance of the same failure.** `ConnectionDataSchema.type` accepted `'oauth2-code' | 'secret'`, but `resolveConnectionForRuntime` emits four types (`resolve-connection-for-runtime.ts:34`). A `client-credentials` or `hosted-provision` connection would have been rejected identically and just as silently. Widened here and in the four type declarations mirroring the same runtime shape. Safe: nothing in either repo branches on `connection.type` — apps read `value`/`fields`/`metadata`.

## Verification

- Replayed the real envelope: `userEmail: ''` → `[{field: 'userEmail', message: 'Invalid email address'}]`; `null` → OK; `client-credentials` → OK.
- `deno check` clean on all four `apps/lambda` files.
- `packages/lib` tsc: 29 errors, all pre-existing in `scripts/` and `vitest.integration.config.ts`; none in `src/`.
- `app-workflow-block-processor.test.ts` — 16/16 pass.
- Biome clean.

## Deploy

`worker` carries fixes 1 and 2 — fix 1 alone unblocks the workflow. `lambda-server` needs redeploying for fix 3. The `packages/sdk` change is a TS interface only, so the platform runtime bundle is unaffected.

## Not addressed

`fields: z.record(z.string(), z.string())` vs `mergeConnectionVariables` (`interpolate-connection.ts:68`), which spreads raw `metadata.connectionVariables` behind an unchecked `as Record<string, string>`. A non-string connection variable would fail the envelope the same silent way. Latent rather than live — the typed write paths all declare `Record<string, string>` — and the real fix belongs in `@auxx/services`.